### PR TITLE
feat(ir): cut Fibonacci pair over to Prepared IR

### DIFF
--- a/plan/issues/4589-multi-source-scalar-leaf-cutover.md
+++ b/plan/issues/4589-multi-source-scalar-leaf-cutover.md
@@ -1,0 +1,106 @@
+---
+id: 4589
+title: "Cut one exact multi-source scalar leaf over to Prepared IR"
+status: done
+created: 2026-08-21
+updated: 2026-08-21
+completed: 2026-08-21
+priority: critical
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: compiler, codegen, ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+sprint: current
+parent: 3525
+depends_on: [2138, 3520, 4579, 4583, 4588]
+related: [3090, 3518, 3520, 3525, 3792, 4579, 4583, 4588]
+assignee: ttraenkler/codex
+files:
+  - src/codegen/index.ts
+  - src/codegen/multi-prepared-scalar-leaf.ts
+  - tests/issue-2138-multi-module-ir-overlay.test.ts
+  - tests/issue-4589-multi-prepared-scalar-leaf.test.ts
+  - plan/issues/4589-multi-source-scalar-leaf-cutover.md
+---
+
+# #4589 — cut one exact multi-source scalar leaf over to Prepared IR
+
+## Problem
+
+The bounded #2138 multi-source overlay already patches `entryPure` through IR,
+but only after the direct compiler has emitted its body. That leaves two
+physical AST-codegen entries (`compileFunctionBody` and `compileStatement`) for
+a source-local scalar singleton whose exact source UnitId and Program ABI
+callable are already available before the body loop.
+
+Multi-source declaration collection, import aliasing, module-init ordering, and
+callback reservation are graph-wide. The cutover therefore cannot reuse the
+single-source early route blindly or prepare the same owner again in the late
+overlay.
+
+## Scope
+
+- Prepare at most one graph-wide eligible, named, top-level numeric scalar
+  `FunctionDeclaration`, and only when it belongs to the standalone entry
+  source.
+- Require the exact UnitId terminal/claim, fully annotated f64 Program ABI,
+  source callable allocation, singleton local call component, collision-free
+  flat registry, and one-entry Prepared skip projection with a nonempty
+  `preparedComponentId`.
+- Exclude cross-file/import/module-storage/callable/closure/class/support,
+  CommonJS, collision, fast, WASI, IR-first-disabled, and late-provider edges
+  before requesting a direct-body skip.
+- Carry candidate-source plans, the Prepared report/completed set, and the
+  correlated skipped UnitId into the ordinary late overlay. Complete and
+  consume that report exactly once.
+- Keep the route default-on with
+  `JS2WASM_MULTI_PREPARED_SCALAR_LEAF_CUTOVER=0` as the bounded one-release
+  control. `JS2WASM_IR_FIRST=0` and `disableIrFirst` retain their wider opt-out
+  contracts.
+
+## Non-goals
+
+- Multi-source module-init preparation or generic multi-owner inversion.
+- Cross-file call-component, class, closure, derived-support, CJS, fast, or
+  WASI ownership.
+- Removing `compileDeclarations`, changing `ModuleInitMode`, or treating one
+  scalar leaf as evidence that direct codegen is globally deletable.
+
+## Acceptance criteria
+
+- [x] Default standalone compilation bypasses poisoned direct emission for the
+      exact `entryPure` leaf; the route switch restores the two direct entries.
+- [x] Kill-switch on/off binary, WAT, and runtime behavior are exact.
+- [x] The canonical #2138 standalone audit moves from 14 to 12 total physical
+      rows and from 12 to 10 non-`compileDeclarations` roots; the exact multiset
+      difference is only `entryPure`'s function-body and statement rows.
+- [x] Exact UnitId-attributed rows move from 11 to 9. The dependency discovery
+      `compileModuleInitBody` row is intentionally source-attributed without a
+      UnitId, so it is not misreported as a twelfth UnitId row.
+- [x] `compileMulti` and `compileProject` both exercise a real two-source
+      type-only dependency graph, with one `entryPure` IR emission and no
+      direct `entryPure` row.
+- [x] Graph ambiguity and representative callable/support predicates withdraw
+      before skip; post-certification Program ABI drift fails closed.
+- [x] Default GC, fast, WASI, and IR-first-disabled controls retain direct
+      ownership.
+
+## Measured checkpoint
+
+The canonical #2138 standalone artifact remains byte-identical with the route
+enabled and disabled: binary SHA-256
+`6facf9cc597fc8b9b3070723139d5d91d88dfaf11868644e15d6eb606eb96bef`
+and WAT SHA-256
+`ebb3d4b26b057ac3798e423678c46f425da34c3b0a466cd7b7c2bc70f2fb5c74`.
+Both modes report `irCompiledFuncs: ["entryPure"]` and leave
+`irFirstSkipped` undefined. Every physical row other than the two
+`entryPure` entries is unchanged.
+
+## Completion evidence
+
+- `tests/issue-4589-multi-prepared-scalar-leaf.test.ts`: 15/15 passed.
+- `tests/issue-2138-multi-module-ir-overlay.test.ts`: 6/6 passed.
+- `pnpm run typecheck`: passed.
+- LOC and function budget gates: passed without allowances.

--- a/plan/issues/4590-bench-loop-function-value-prepared-cutover.md
+++ b/plan/issues/4590-bench-loop-function-value-prepared-cutover.md
@@ -1,0 +1,139 @@
+---
+id: 4590
+title: "Cut the exact bench_loop function-value leaf over to Prepared IR"
+status: done
+created: 2026-08-21
+updated: 2026-08-21
+completed: 2026-08-21
+priority: critical
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: compiler, codegen, ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+sprint: current
+parent: 3525
+depends_on: [2138, 3520, 4589]
+related: [3090, 3518, 3520, 3525, 3792, 4583, 4589, 4591]
+assignee: ttraenkler/codex
+files:
+  - src/codegen/index.ts
+  - src/codegen/multi-prepared-function-value-import-target.ts
+  - src/codegen/multi-prepared-scalar-leaf.ts
+  - tests/issue-4590-bench-loop-prepared-cutover.test.ts
+  - plan/issues/4590-bench-loop-function-value-prepared-cutover.md
+---
+
+# #4590 — cut the exact bench_loop function-value leaf over to Prepared IR
+
+## Problem
+
+The real `website/playground/examples/benchmarks/loop.ts` graph already lowers
+`bench_loop` through IR, but it previously emitted the direct AST body first.
+That left both `compileFunctionBody` and `compileStatement` on the physical
+route. Unlike #4589's scalar leaf, `bench_loop` is also read as a function value
+by legacy `main` and passed to the imported `addBenchCard` helper. Prepared IR
+therefore cannot skip its body until the exact target callable, trampoline, and
+closure-cache global exist and are owned by Program ABI.
+
+## Scope
+
+- Recognize only one graph-wide, no-parameter numeric reduction function with
+  the exact eight-way `| 0` loop shape used by the real benchmark.
+- Require a singleton direct-call component and exactly one non-call function
+  value reference in a distinct legacy owner.
+- Require that reference to be one argument of a direct named import call. Join
+  the exact `ImportSpecifier` to one canonical relative source record, require
+  one direct exported bodyful target before oracle certification, and reject
+  merged or ambiguous declaration populations.
+- Preallocate the exact `bench_loop` source callable plus one
+  `__fn_tramp_bench_loop_cached` / `__fn_closure_bench_loop` support pair before
+  Prepared sealing. Carry their allocator objects, handles, binding IDs, and
+  locators through the late overlay and re-prove them after legacy owners run.
+  At that same seam, re-prove the candidate declaration, value-reference
+  parent/oracle identity, enclosing legacy-owner declaration/UnitId, and
+  imported callee target/UnitId from the frozen receipt.
+- Carry the one Prepared report and skipped UnitId through the existing #4589
+  late completion seam exactly once. The #4589 syntactic scalar predicate and
+  late-provider exclusion set remain unchanged.
+- Keep the route default-on with
+  `JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER=0` as the true pre-#4590 artifact
+  rollback.
+
+## Non-goals
+
+- Generic callable-value routing, imported-call planning in the standalone
+  host-disabled lane, or name-based `bench_loop` authorization.
+- The Fibonacci pair. `bench_fib` and `fib` form a two-terminal recursive
+  component and require a later atomic cutover (#4591).
+- Cross-source callable components, stored or repeated function values,
+  module initialization, classes, derived units, CommonJS, fast, WASI, or
+  default host/GC ownership.
+- Hiding allocation-order changes by preallocating support when the public
+  kill switch is disabled. The switch intentionally remains the old baseline.
+
+## Acceptance criteria
+
+- [x] The default route survives a poisoned direct `bench_loop` body; the
+      dedicated kill switch restores the poison and both physical entries.
+- [x] The exact audit moves from 16 to 14 total legacy rows and from 14 to 12
+      non-`compileDeclarations` rows. Only `bench_loop`'s
+      `compileFunctionBody` and `compileStatement` rows disappear.
+- [x] The target disposition is `terminal-ir`, with
+      `legacyBodyEmitted: false`, `irBodyEmitted: true`, and one nonempty
+      Prepared component ID.
+- [x] Raw `bench_loop` instructions are exact against the old control. Both the
+      target and inlined trampoline retain eight reduction accumulators and the
+      125,000-trip unrolled loop.
+- [x] Raw and optimized DTS, import descriptors/helper, Wasm imports/exports,
+      and string pool are exact. Raw and optimized runtime both return
+      `1783293664`.
+- [x] Optimized target and trampoline bodies are exact against the old control;
+      the preserve-names optimized artifact does not grow.
+- [x] Program ABI retains the same source/trampoline/cache binding contracts
+      and one exact object per role in both lanes. Each lane certifies its own
+      final slots; this is not a claim of cross-lane support-slot parity.
+- [x] Unsupported sealing withdraws before skip. Altered loop/import/value
+      flow, extra direct callers, support-name collisions, and module-init
+      shapes stay direct-owned. Post-certification support tampering is an
+      Invariant.
+- [x] Renaming every declaration/use of `bench_loop` preserves the Prepared
+      route and still bypasses a poisoned renamed direct body; no source name
+      allowlist participates in eligibility.
+- [x] Default GC, fast, WASI, IR-first-disabled, and IR-disabled controls stay
+      direct-owned. The adjacent #4589 and #2138 suites remain green.
+
+## Measured checkpoint
+
+The public kill-switch control is byte-identical to parent `f78fa8c34a0567`:
+115,072 raw bytes, SHA-256
+`7792f5445cf8ab65885fbb63922638f513903eff4b5924866940e517fdf1735d`,
+with both legacy rows present. The Prepared artifact is 115,037 bytes, SHA-256
+`b7d9f0147aa483851029c99173791107f3515812e16aa3d42bcc36269b6408a8`.
+The intentional 35-byte reduction comes from allocating the required support
+pair before Prepared sealing: the trampoline moves from raw type 66 / late
+inliner prefix 226 to type 61 / early prefix 22. Normalizing those allocator
+labels leaves the raw trampoline body exact; `bench_loop` itself is text-exact.
+
+With `optimize: true` and preserved names, both lanes are 50,363 bytes. Binaryen
+prints text-exact optimized bodies for `bench_loop` and its trampoline, and
+both return `1783293664`. Whole-module hashes are deliberately not claimed:
+the required preallocation changes internal type/function order while leaving
+the target bodies and external contract exact.
+
+Program ABI binding-contract parity is exact. The source callable remains
+function slot 76 in both lanes with signature `[] -> f64`. The Prepared lane's
+preallocated trampoline/cache resolve to function/global slots 78/10; the true
+old control resolves the same binding roles to 252/129. Each final slot points
+to the single expected allocator object, the trampoline signature agrees with
+its published callable intent, and the cache is one mutable `externref` global.
+
+## Completion evidence
+
+- `tests/issue-4590-bench-loop-prepared-cutover.test.ts`: 21/21 passed.
+- `tests/issue-4589-multi-prepared-scalar-leaf.test.ts`: 15/15 passed.
+- `tests/issue-2138-multi-module-ir-overlay.test.ts`: 6/6 passed (with the
+  Vitest fork heap raised above its default 512 MB ceiling).
+- Typecheck, Prettier, LOC/function/oracle/fallback/format/diff gates: passed
+  without allowances.

--- a/plan/issues/4591-fib-pair-prepared-cutover.md
+++ b/plan/issues/4591-fib-pair-prepared-cutover.md
@@ -1,9 +1,10 @@
 ---
 id: 4591
 title: "Cut the exact Fibonacci call component over to Prepared IR"
-status: in_progress
+status: done
 created: 2026-08-21
 updated: 2026-08-21
+completed: 2026-08-21
 priority: critical
 feasibility: medium
 reasoning_effort: high
@@ -17,6 +18,10 @@ depends_on: [2138, 3520, 4590]
 related: [3090, 3214, 3518, 3520, 3525, 3792, 4589, 4590]
 assignee: ttraenkler/codex
 files:
+  - src/codegen/index.ts
+  - src/codegen/multi-prepared-fibonacci-pair.ts
+  - src/codegen/multi-prepared-function-value-import-target.ts
+  - src/codegen/multi-prepared-scalar-leaf.ts
   - tests/issue-4591-fib-pair-prepared-cutover.test.ts
   - plan/issues/4591-fib-pair-prepared-cutover.md
 ---
@@ -55,34 +60,68 @@ before either direct body is skipped.
 
 ## Acceptance criteria
 
-- [ ] Dual direct-body poison is red on the old route and green only when both
+- [x] Dual direct-body poison is red on the old route and green only when both
       `fib` and `bench_fib` are skipped atomically.
-- [ ] The real audit moves from 18 to 14 total physical rows and from 16 to 12
+- [x] The real audit moves from 18 to 14 total physical rows and from 16 to 12
       non-`compileDeclarations` rows; only the two body/statement pairs vanish.
-- [ ] Both terminals are `terminal-ir`, share one nonempty Prepared component
+- [x] Both terminals are `terminal-ir`, share one nonempty Prepared component
       ID, and report IR emitted with no legacy body.
-- [ ] Raw and optimized `fib`, `bench_fib`, and outer trampoline bodies retain
+- [x] Raw and optimized `fib`, `bench_fib`, and outer trampoline bodies retain
       exact old-control behavior; DTS/import/export/string-pool surfaces agree.
-- [ ] Raw and optimized runtime returns `832040`, and the optimized artifact
+- [x] Raw and optimized runtime returns `832040`, and the optimized artifact
       does not grow.
-- [ ] Program ABI proves the exact source callable objects for both terminals
+- [x] Program ABI proves the exact source callable objects for both terminals
       and exactly one outer trampoline/cache support pair in both lanes.
-- [ ] The public kill switch reproduces the measured pre-#4591 artifact.
-- [ ] Shape, edge, value-flow, collision, reassignment, module-init, mode, seal,
+- [x] The public kill switch reproduces the measured pre-#4591 artifact.
+- [x] Shape, edge, value-flow, collision, reassignment, module-init, mode, seal,
       and post-certification tamper negatives all fail closed before skip.
 
 ## Measured checkpoint
 
-The pre-#4591 control is 114,844 raw bytes with SHA-256
+The kill-switch control is the exact pre-#4591 artifact: 114,844 raw bytes
+with SHA-256
 `1d9d913d021eded3d9f9e9349bd3dbe095836e9daec4f8fa53e7c27ae3c6a4e3`;
 its WAT SHA-256 is
 `2575b086c93e14277b2cf43c837f7d944cb61e093d11c17034175d07afa23825`
 and DTS SHA-256 is
 `874ff64e8642ca4d5d1060091ab7d78a9ab0eda374e483e5c028115ad71c2022`.
-With optimization and preserved names, the old control is 48,521 bytes with
-SHA-256
+The Prepared raw artifact is 114,795 bytes with binary SHA-256
+`f8fd3ebf0c9eb748d12e64780932b65b859077f2a13cd62ea984c23f90698189`,
+WAT SHA-256
+`b5c9798b6dbecadb2d89433b7686ea4302e841720e4c41bdc3cac7b1e348a7be`,
+and the same DTS hash. Early support allocation accounts for the 49-byte
+reduction and the deliberate whole-module hash difference. The `fib` and
+`bench_fib` raw bodies are text-exact. The outer trampoline is text-exact after
+normalizing only its allocator-chosen type number and inliner prefix; its
+instructions are unchanged.
+
+With default name-stripped optimization, both lanes are 48,521 bytes. The old
+control SHA-256 is
 `4e8f66606a18497ad7c11d4a65e14dd120b69caa825bf7a3c6e1738fbc4d2837`.
-It returns `832040`. Program ABI resolves `fib`/`bench_fib` to function slots
-76/77, the late `bench_fib` trampoline to function slot 253, and its mutable
-externref cache to global slot 129. Candidate allocator slots and artifact
-measurements will be recorded after the implementation is testable.
+The Prepared SHA-256 is
+`69e58bd6a56438e857d02707f3dce704b7650a5d0bc3cf34f9df511609444f88`.
+With debug names preserved, both lanes are 50,123 bytes. The Prepared SHA-256
+is `3a3b4e233a1354467aea227eb75c2a6271239cca8007c6e6fed744de9e481ab4`;
+the control SHA-256 is
+`6493d10768439d3826384a4bf2b20e298bdbaea61b876b8ec1aba14083d3131f`.
+Binaryen prints text-exact `fib`, `bench_fib`, and outer-trampoline bodies.
+Both raw and optimized lanes return `832040`; `fib(10)` independently returns
+`55`.
+
+Program ABI resolves `fib`/`bench_fib` to function slots 76/77 in both lanes.
+The Prepared lane resolves the preallocated `bench_fib` trampoline/cache to
+function/global slots 79/10; the exact old control resolves the same binding
+roles to 253/129. Each final slot points to the one expected allocator object,
+and only `bench_fib` owns a trampoline/cache pair. The source and support
+callable signatures agree with their published intents; the cache is one
+mutable `externref` global.
+
+## Completion evidence
+
+- `tests/issue-4591-fib-pair-prepared-cutover.test.ts`: 27/27 passed with a
+  512 MiB V8 heap cap and one Vitest worker.
+- The added recursive-member non-call reference leaves both exact function
+  bodies intact, withdraws the entire component before skip, and reproduces
+  both direct-body poisons.
+- `tests/issue-4590-bench-loop-prepared-cutover.test.ts`: 21/21 passed.
+- `tests/issue-4589-multi-prepared-scalar-leaf.test.ts`: 15/15 passed.

--- a/plan/issues/4591-fib-pair-prepared-cutover.md
+++ b/plan/issues/4591-fib-pair-prepared-cutover.md
@@ -1,0 +1,88 @@
+---
+id: 4591
+title: "Cut the exact Fibonacci call component over to Prepared IR"
+status: in_progress
+created: 2026-08-21
+updated: 2026-08-21
+priority: critical
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: compiler, codegen, ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+sprint: current
+parent: 3525
+depends_on: [2138, 3520, 4590]
+related: [3090, 3214, 3518, 3520, 3525, 3792, 4589, 4590]
+assignee: ttraenkler/codex
+files:
+  - tests/issue-4591-fib-pair-prepared-cutover.test.ts
+  - plan/issues/4591-fib-pair-prepared-cutover.md
+---
+
+# #4591 — cut the exact Fibonacci call component over to Prepared IR
+
+## Problem
+
+The real `website/playground/examples/benchmarks/fib.ts` graph already lowers
+`fib` and `bench_fib` through IR, but both direct AST bodies are emitted first.
+The pair is one recursive direct-call component: `fib` self-recurses and
+`bench_fib` calls it. In addition, legacy `main` passes `bench_fib` as a
+function value to imported `addBenchCard`, so an atomic Prepared cutover must
+certify both source callables and the outer target's trampoline/cache support
+before either direct body is skipped.
+
+## Scope
+
+- Recognize only the exact two-member Fibonacci component in the standalone
+  entry source, using checker and Program ABI identity rather than names.
+- Prepare both terminals as one component and skip both only after the exact
+  source callables plus `bench_fib` function-value support are certified.
+- Re-prove the component, call/value edges, allocator objects, bindings, and
+  locators after every remaining legacy owner has run.
+- Keep the route default-on with
+  `JS2WASM_MULTI_PREPARED_FIB_PAIR_CUTOVER=0` as the exact pre-#4591 rollback.
+
+## Non-goals
+
+- Generic recursive-component routing, arbitrary Fibonacci-like syntax, or
+  name-based authorization.
+- Cross-source components, stored/repeated function values, module-init
+  ownership, classes, derived units, CommonJS, fast, WASI, or default host/GC.
+- Widening #4590's singleton reduction route or removing late-provider
+  exclusions without an exact replacement proof.
+
+## Acceptance criteria
+
+- [ ] Dual direct-body poison is red on the old route and green only when both
+      `fib` and `bench_fib` are skipped atomically.
+- [ ] The real audit moves from 18 to 14 total physical rows and from 16 to 12
+      non-`compileDeclarations` rows; only the two body/statement pairs vanish.
+- [ ] Both terminals are `terminal-ir`, share one nonempty Prepared component
+      ID, and report IR emitted with no legacy body.
+- [ ] Raw and optimized `fib`, `bench_fib`, and outer trampoline bodies retain
+      exact old-control behavior; DTS/import/export/string-pool surfaces agree.
+- [ ] Raw and optimized runtime returns `832040`, and the optimized artifact
+      does not grow.
+- [ ] Program ABI proves the exact source callable objects for both terminals
+      and exactly one outer trampoline/cache support pair in both lanes.
+- [ ] The public kill switch reproduces the measured pre-#4591 artifact.
+- [ ] Shape, edge, value-flow, collision, reassignment, module-init, mode, seal,
+      and post-certification tamper negatives all fail closed before skip.
+
+## Measured checkpoint
+
+The pre-#4591 control is 114,844 raw bytes with SHA-256
+`1d9d913d021eded3d9f9e9349bd3dbe095836e9daec4f8fa53e7c27ae3c6a4e3`;
+its WAT SHA-256 is
+`2575b086c93e14277b2cf43c837f7d944cb61e093d11c17034175d07afa23825`
+and DTS SHA-256 is
+`874ff64e8642ca4d5d1060091ab7d78a9ab0eda374e483e5c028115ad71c2022`.
+With optimization and preserved names, the old control is 48,521 bytes with
+SHA-256
+`4e8f66606a18497ad7c11d4a65e14dd120b69caa825bf7a3c6e1738fbc4d2837`.
+It returns `832040`. Program ABI resolves `fib`/`bench_fib` to function slots
+76/77, the late `bench_fib` trampoline to function slot 253, and its mutable
+externref cache to global slot 129. Candidate allocator slots and artifact
+measurements will be recorded after the implementation is testable.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -199,12 +199,15 @@ import {
   buildMultiIrGraphSafety,
   collectMultiIrFunctionNameCollisions,
   compileMultiPreparedScalarLeafDeclarations,
-  planEarlyMultiPreparedFunctionValueLeafRoute,
   planEarlyMultiPreparedScalarLeafRoute,
   type EarlyMultiPreparedScalarLeafState,
   type MultiPreparedFunctionValueSupportReceipt,
   type MultiPreparedScalarLeafGraphSafety,
 } from "./multi-prepared-scalar-leaf.js";
+import {
+  assertMultiPreparedFibonacciPairRouteCurrent,
+  planEarlyMultiPreparedFunctionValueRoutes,
+} from "./multi-prepared-fibonacci-pair.js";
 import * as irTimerShim from "./ir-timer-shim-planning.js";
 import { buildLeakedHostImportError, scanForLeakedHostImports } from "./host-import-allowlist.js";
 import {
@@ -3519,11 +3522,11 @@ function multiIrFunctionValueLeafHasForeignLateProvider(
   sourceFile: ts.SourceFile,
   plan: IrOverlayPlan,
   unitId: IrUnitId,
+  functionValueTarget: boolean,
 ): boolean {
   const valueTargets = collectPreparedTopLevelFunctionValueTargetUnitIds(ctx, sourceFile, plan.identityPlan);
   return (
-    valueTargets.size !== 1 ||
-    !valueTargets.has(unitId) ||
+    (functionValueTarget ? valueTargets.size !== 1 || !valueTargets.has(unitId) : valueTargets.has(unitId)) ||
     collectDirectCallerActivationTargetUnitIds(ctx, sourceFile, plan.identityPlan).has(unitId) ||
     [...plan.importedCalls.values()].some((candidate) => candidate.ownerUnitId === unitId) ||
     [...plan.topLevelFunctionValues.values()].some((candidate) => candidate.ownerUnitId === unitId) ||
@@ -3563,17 +3566,18 @@ function planEarlyMultiIrOverlay(
     lateProviderOwnerUnitIds: (plan, sourceFile) => collectMultiIrLateProviderOwnerUnitIds(ctx, sourceFile, plan),
     projectLoweringPlans: (plan, selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
   });
-  const functionValueStates = planEarlyMultiPreparedFunctionValueLeafRoute({
+  const functionValueStates = planEarlyMultiPreparedFunctionValueRoutes({
     active,
-    cutoverEnabled: !explicitlyDisabledEnv(process.env.JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER),
+    leafCutoverEnabled: !explicitlyDisabledEnv(process.env.JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER),
+    fibonacciPairCutoverEnabled: !explicitlyDisabledEnv(process.env.JS2WASM_MULTI_PREPARED_FIB_PAIR_CUTOVER),
     ctx,
     sourceFiles: multiAst.sourceFiles,
     entryFile: multiAst.entryFile,
     safety: () => buildMultiIrGraphSafety(ctx, multiAst.sourceFiles, multiAst.checker),
     planSource: (sourceFile) => planMultiIrOverlaySource(ctx, multiAst, sourceFile, identityContext, undefined),
     safeSelection: (plan, sourceFile, safety) => makeMultiIrSafeSelection(ctx, plan, sourceFile, safety),
-    hasForeignLateProvider: (plan, sourceFile, unitId) =>
-      multiIrFunctionValueLeafHasForeignLateProvider(ctx, sourceFile, plan, unitId),
+    hasForeignLateProvider: (plan, sourceFile, unitId, functionValueTarget) =>
+      multiIrFunctionValueLeafHasForeignLateProvider(ctx, sourceFile, plan, unitId, functionValueTarget),
     prepareFunctionValueSupport: (plan, sourceFile, unitId, legacyName) =>
       prepareTopLevelFunctionValueTargetSupport(ctx, sourceFile, plan, new Set([legacyName])).get(unitId),
     projectLoweringPlans: (plan, selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
@@ -3631,7 +3635,9 @@ function compileMultiIrOverlaySource(
     ),
   );
   const { overrideMap, classShapes } = plan;
-  if (early?.route?.routeKind === "function-value") {
+  if (early?.route?.routeKind === "fibonacci-pair") {
+    assertMultiPreparedFibonacciPairRouteCurrent({ ctx, route: early.route, finalSelection: safeSelection, safety });
+  } else if (early?.route?.routeKind === "function-value") {
     assertMultiPreparedFunctionValueLeafRouteCurrent({
       ctx,
       route: early.route,

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -194,12 +194,15 @@ import {
   type PreparedIrModuleInitBody,
 } from "./ir-prepared-free-functions.js";
 import {
+  assertMultiPreparedFunctionValueLeafRouteCurrent,
   assertMultiPreparedScalarLeafRouteCurrent,
   buildMultiIrGraphSafety,
   collectMultiIrFunctionNameCollisions,
   compileMultiPreparedScalarLeafDeclarations,
+  planEarlyMultiPreparedFunctionValueLeafRoute,
   planEarlyMultiPreparedScalarLeafRoute,
   type EarlyMultiPreparedScalarLeafState,
+  type MultiPreparedFunctionValueSupportReceipt,
   type MultiPreparedScalarLeafGraphSafety,
 } from "./multi-prepared-scalar-leaf.js";
 import * as irTimerShim from "./ir-timer-shim-planning.js";
@@ -2234,7 +2237,8 @@ function prepareTopLevelFunctionValueTargetSupport(
   sourceFile: ts.SourceFile,
   plan: IrOverlayPlan,
   selectedLegacyNames: ReadonlySet<string>,
-): void {
+): ReadonlyMap<IrUnitId, MultiPreparedFunctionValueSupportReceipt> {
+  const receipts = new Map<IrUnitId, MultiPreparedFunctionValueSupportReceipt>();
   const selectedUnitIds = new Set(
     [...selectedLegacyNames].map((legacyName) =>
       irOverlayIdentity.requireIrOverlayFunctionUnitId(plan.identityPlan, legacyName),
@@ -2275,7 +2279,33 @@ function prepareTopLevelFunctionValueTargetSupport(
         `prepared function-value target ${unitId} could not freeze its singleton Program ABI`,
       );
     }
+    if (
+      functionValuePlan.trampoline.binding.kind !== "support" ||
+      functionValuePlan.cacheGlobal.binding.kind !== "support"
+    ) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `prepared function-value target ${unitId} lost its exact support binding identities`,
+      );
+    }
+    receipts.set(
+      unitId,
+      Object.freeze({
+        targetFunction: ctx.programAbiSourceCallables!.functionForUnit(unitId)!,
+        targetHandle: funcIdx,
+        trampolineFunction: trampoline,
+        trampolineHandle: singleton.trampolineFuncIdx,
+        trampolineRef: functionValuePlan.trampoline,
+        trampolineBindingId: functionValuePlan.trampoline.binding.bindingId,
+        cacheGlobal: cache,
+        cacheGlobalHandle: singleton.cacheGlobalIdx,
+        cacheGlobalRef: functionValuePlan.cacheGlobal,
+        cacheGlobalBindingId: functionValuePlan.cacheGlobal.binding.bindingId,
+      }),
+    );
   }
+  return receipts;
 }
 
 function recordWholeSourceFailure(
@@ -3484,6 +3514,28 @@ function collectMultiIrLateProviderOwnerUnitIds(
   ]);
 }
 
+function multiIrFunctionValueLeafHasForeignLateProvider(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  plan: IrOverlayPlan,
+  unitId: IrUnitId,
+): boolean {
+  const valueTargets = collectPreparedTopLevelFunctionValueTargetUnitIds(ctx, sourceFile, plan.identityPlan);
+  return (
+    valueTargets.size !== 1 ||
+    !valueTargets.has(unitId) ||
+    collectDirectCallerActivationTargetUnitIds(ctx, sourceFile, plan.identityPlan).has(unitId) ||
+    [...plan.importedCalls.values()].some((candidate) => candidate.ownerUnitId === unitId) ||
+    [...plan.topLevelFunctionValues.values()].some((candidate) => candidate.ownerUnitId === unitId) ||
+    [...plan.hostVoidCallbacks.values()].some((candidate) => candidate.ownerUnitId === unitId) ||
+    [...plan.hostDateSnapshots.values()].some((candidate) => candidate.ownerUnitId === unitId) ||
+    [...plan.hostDateGetters.values()].some((candidate) => candidate.ownerUnitId === unitId) ||
+    [...plan.promiseDelays.constructions.values()].some((candidate) => candidate.ownerUnitId === unitId) ||
+    plan.suspendingAsyncUnitIds.has(unitId) ||
+    irTimerShim.inspectIrCompilerTimerShimRouting(plan).ownerUnitIds.has(unitId)
+  );
+}
+
 function planEarlyMultiIrOverlay(
   ctx: CodegenContext,
   multiAst: MultiTypedAST,
@@ -3499,7 +3551,7 @@ function planEarlyMultiIrOverlay(
     !ctx.fast &&
     multiAst.sourceFiles.length > 1;
   if (!active) return new Map();
-  return planEarlyMultiPreparedScalarLeafRoute({
+  const scalarStates = planEarlyMultiPreparedScalarLeafRoute({
     active,
     cutoverEnabled: !explicitlyDisabledEnv(process.env.JS2WASM_MULTI_PREPARED_SCALAR_LEAF_CUTOVER),
     ctx,
@@ -3511,6 +3563,32 @@ function planEarlyMultiIrOverlay(
     lateProviderOwnerUnitIds: (plan, sourceFile) => collectMultiIrLateProviderOwnerUnitIds(ctx, sourceFile, plan),
     projectLoweringPlans: (plan, selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
   });
+  const functionValueStates = planEarlyMultiPreparedFunctionValueLeafRoute({
+    active,
+    cutoverEnabled: !explicitlyDisabledEnv(process.env.JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER),
+    ctx,
+    sourceFiles: multiAst.sourceFiles,
+    entryFile: multiAst.entryFile,
+    safety: () => buildMultiIrGraphSafety(ctx, multiAst.sourceFiles, multiAst.checker),
+    planSource: (sourceFile) => planMultiIrOverlaySource(ctx, multiAst, sourceFile, identityContext, undefined),
+    safeSelection: (plan, sourceFile, safety) => makeMultiIrSafeSelection(ctx, plan, sourceFile, safety),
+    hasForeignLateProvider: (plan, sourceFile, unitId) =>
+      multiIrFunctionValueLeafHasForeignLateProvider(ctx, sourceFile, plan, unitId),
+    prepareFunctionValueSupport: (plan, sourceFile, unitId, legacyName) =>
+      prepareTopLevelFunctionValueTargetSupport(ctx, sourceFile, plan, new Set([legacyName])).get(unitId),
+    projectLoweringPlans: (plan, selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
+  });
+  for (const [sourceFile, state] of functionValueStates) {
+    if (scalarStates.has(sourceFile)) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `multi-source early routes both claimed ${sourceFile.fileName}`,
+      );
+    }
+    scalarStates.set(sourceFile, state);
+  }
+  return scalarStates;
 }
 
 function compileMultiIrOverlaySource(
@@ -3553,7 +3631,14 @@ function compileMultiIrOverlaySource(
     ),
   );
   const { overrideMap, classShapes } = plan;
-  if (early?.route) {
+  if (early?.route?.routeKind === "function-value") {
+    assertMultiPreparedFunctionValueLeafRouteCurrent({
+      ctx,
+      route: early.route,
+      finalSelection: safeSelection,
+      safety,
+    });
+  } else if (early?.route) {
     assertMultiPreparedScalarLeafRouteCurrent({ ctx, route: early.route, finalSelection: safeSelection, safety });
   }
   const report = completePreparedIrIntegration({

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -193,6 +193,15 @@ import {
   type PreparedIrFreeFunctionBodies,
   type PreparedIrModuleInitBody,
 } from "./ir-prepared-free-functions.js";
+import {
+  assertMultiPreparedScalarLeafRouteCurrent,
+  buildMultiIrGraphSafety,
+  collectMultiIrFunctionNameCollisions,
+  compileMultiPreparedScalarLeafDeclarations,
+  planEarlyMultiPreparedScalarLeafRoute,
+  type EarlyMultiPreparedScalarLeafState,
+  type MultiPreparedScalarLeafGraphSafety,
+} from "./multi-prepared-scalar-leaf.js";
 import * as irTimerShim from "./ir-timer-shim-planning.js";
 import { buildLeakedHostImportError, scanForLeakedHostImports } from "./host-import-allowlist.js";
 import {
@@ -3134,172 +3143,6 @@ function consumeIrOverlayReport(
   }
 }
 
-/** Flat function names shared by two or more source files are not safe IR keys. */
-function collectMultiIrFunctionNameCollisions(sourceFiles: readonly ts.SourceFile[]): ReadonlySet<string> {
-  const owner = new Map<string, ts.SourceFile>();
-  const collisions = new Set<string>();
-  for (const sourceFile of sourceFiles) {
-    const namesInFile = new Set<string>();
-    for (const stmt of sourceFile.statements) {
-      if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body && !hasDeclareModifier(stmt)) {
-        namesInFile.add(stmt.name.text);
-      }
-    }
-    for (const name of namesInFile) {
-      const previous = owner.get(name);
-      if (previous && previous !== sourceFile) collisions.add(name);
-      else owner.set(name, sourceFile);
-    }
-  }
-  return collisions;
-}
-
-/** Import locals that can overwrite an unrelated flat `ctx.funcMap` key. */
-function collectMultiImportAliasNames(sourceFiles: readonly ts.SourceFile[]): ReadonlySet<string> {
-  const names = new Set<string>();
-  for (const sourceFile of sourceFiles) {
-    for (const stmt of sourceFile.statements) {
-      if (ts.isImportDeclaration(stmt)) {
-        const clause = stmt.importClause;
-        if (!clause) continue;
-        if (clause.name) names.add(clause.name.text);
-        if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
-          names.add(clause.namedBindings.name.text);
-        } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
-          for (const element of clause.namedBindings.elements) {
-            const target = (element.propertyName ?? element.name).text;
-            if (element.name.text !== target) names.add(element.name.text);
-          }
-        }
-      } else if (ts.isImportEqualsDeclaration(stmt)) {
-        names.add(stmt.name.text);
-      }
-    }
-  }
-  return names;
-}
-
-/** Resolve cross-file import aliases back to their declared function names. */
-function collectMultiImportedFunctionNames(
-  sourceFiles: readonly ts.SourceFile[],
-  checker: ts.TypeChecker,
-): ReadonlySet<string> {
-  const names = new Set<string>();
-  const addFunctionDeclarations = (symbol: ts.Symbol | undefined): void => {
-    if (!symbol) return;
-    const target = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
-    for (const declaration of target.declarations ?? []) {
-      if (ts.isFunctionDeclaration(declaration) && declaration.name) names.add(declaration.name.text);
-    }
-    if (target.flags & ts.SymbolFlags.Module) {
-      for (const exported of checker.getExportsOfModule(target)) {
-        const value = exported.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exported) : exported;
-        for (const declaration of value.declarations ?? []) {
-          if (ts.isFunctionDeclaration(declaration) && declaration.name) names.add(declaration.name.text);
-        }
-      }
-    }
-  };
-  const addTarget = (local: ts.Identifier, syntacticTarget?: string): void => {
-    addFunctionDeclarations(checker.getSymbolAtLocation(local));
-    if (syntacticTarget) names.add(syntacticTarget);
-  };
-
-  for (const sourceFile of sourceFiles) {
-    for (const stmt of sourceFile.statements) {
-      if (!ts.isImportDeclaration(stmt)) continue;
-      const clause = stmt.importClause;
-      if (!clause) continue;
-      if (clause.name) addTarget(clause.name);
-      if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
-        addTarget(clause.namedBindings.name);
-      } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
-        for (const element of clause.namedBindings.elements) {
-          addTarget(element.name, (element.propertyName ?? element.name).text);
-        }
-      }
-    }
-    for (const stmt of sourceFile.statements) {
-      if (ts.isImportEqualsDeclaration(stmt)) addTarget(stmt.name);
-    }
-  }
-  return names;
-}
-
-/**
- * Top-level function declarations referenced from a different source file.
- *
- * Import syntax covers ordinary ESM edges, but `compileMulti` also accepts
- * global-script roots. A module can call a function declared by one of those
- * roots without an `ImportDeclaration`; TypeScript still resolves the
- * identifier to the other file's declaration. Treat that checker-resolved
- * edge exactly like an imported target so a legacy caller never observes an
- * IR-only callable ABI (the M0 overlay has no cross-file call closure yet).
- */
-function collectMultiCrossFileFunctionNames(
-  sourceFiles: readonly ts.SourceFile[],
-  checker: ts.TypeChecker,
-): ReadonlySet<string> {
-  // Preserve the deliberately conservative namespace/default/re-export import
-  // handling above, then add all symbol-resolved cross-file references.
-  const names = new Set(collectMultiImportedFunctionNames(sourceFiles, checker));
-  // External modules can only cross source-file boundaries through the import
-  // surface already collected above. Pay the full checker walk only when a
-  // global-script root makes import-free cross-file references possible.
-  if (!sourceFiles.some((sourceFile) => !ts.isExternalModule(sourceFile))) return names;
-  const sourceSet = new Set(sourceFiles);
-  const allFunctionNames = new Set<string>();
-  for (const sourceFile of sourceFiles) {
-    for (const stmt of sourceFile.statements) {
-      if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body) allFunctionNames.add(stmt.name.text);
-    }
-  }
-  const markUnknownTargetConservatively = (): void => {
-    for (const name of allFunctionNames) names.add(name);
-  };
-
-  const addResolvedTarget = (symbol: ts.Symbol | undefined, referenceFile: ts.SourceFile): void => {
-    if (!symbol) return;
-    let target = symbol;
-    if (target.flags & ts.SymbolFlags.Alias) {
-      try {
-        target = checker.getAliasedSymbol(target);
-      } catch {
-        markUnknownTargetConservatively();
-        return;
-      }
-    }
-    for (const declaration of target.declarations ?? []) {
-      if (
-        ts.isFunctionDeclaration(declaration) &&
-        declaration.name &&
-        declaration.body &&
-        sourceSet.has(declaration.getSourceFile()) &&
-        declaration.getSourceFile() !== referenceFile
-      ) {
-        names.add(declaration.name.text);
-      }
-    }
-  };
-
-  for (const sourceFile of sourceFiles) {
-    const visit = (node: ts.Node): void => {
-      if (ts.isIdentifier(node)) {
-        try {
-          addResolvedTarget(checker.getSymbolAtLocation(node), sourceFile);
-        } catch {
-          // Safety scan uncertainty must only reduce M0 coverage. In host mode
-          // this blocks callable boundaries; standalone/WASI block every name.
-          markUnknownTargetConservatively();
-        }
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(sourceFile);
-  }
-  return names;
-}
-
 function functionBodyHasUnsupportedImportUse(fn: ts.FunctionDeclaration, plan: IrOverlayPlan): boolean {
   if (!fn.body || !plan.importedFunctionResolver) return false;
   let found = false;
@@ -3384,13 +3227,7 @@ function functionHasCallableBoundary(ctx: CodegenContext, declaration: ts.Functi
  * no IR body can resolve or patch the wrong module's slot. Class members and
  * the shared `__module_init` stay legacy-owned in M0.
  */
-interface MultiIrGraphSafety {
-  readonly collisions: ReadonlySet<string>;
-  readonly crossFileFunctionNames: ReadonlySet<string>;
-  readonly importAliasNames: ReadonlySet<string>;
-  readonly occupiedFunctionKeys: readonly string[];
-  readonly occupiedFunctionNameCounts: ReadonlyMap<string, number>;
-}
+type MultiIrGraphSafety = MultiPreparedScalarLeafGraphSafety;
 
 function multiIrTargetHasExactRegistryEntry(
   ctx: CodegenContext,
@@ -3609,14 +3446,13 @@ function prepareMultiIrImportedLowering(
   };
 }
 
-function compileMultiIrOverlaySource(
+function planMultiIrOverlaySource(
   ctx: CodegenContext,
   multiAst: MultiTypedAST,
   sourceFile: ts.SourceFile,
   identityContext: IrPlanningIdentityContext,
-  safety: MultiIrGraphSafety,
   hostImportedFunctions: irOverlayIdentity.IrIdentityImportedFunctionResolver | undefined,
-): void {
+): IrOverlayPlan {
   const sourceAst: TypedAST = {
     sourceFile,
     checker: multiAst.checker,
@@ -3624,10 +3460,70 @@ function compileMultiIrOverlaySource(
     diagnostics: multiAst.diagnostics,
     syntacticDiagnostics: multiAst.syntacticDiagnostics,
   };
-  const plan = planIrOverlay(ctx, sourceAst, identityContext, {
+  return planIrOverlay(ctx, sourceAst, identityContext, {
     resolveModuleBindings: false,
     ...(hostImportedFunctions ? { importedFunctions: hostImportedFunctions } : {}),
   });
+}
+
+function collectMultiIrLateProviderOwnerUnitIds(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  plan: IrOverlayPlan,
+): ReadonlySet<IrUnitId> {
+  return new Set([
+    ...[...plan.importedCalls.values()].map((candidate) => candidate.ownerUnitId),
+    ...[...plan.topLevelFunctionValues.values()].map((candidate) => candidate.ownerUnitId),
+    ...[...plan.hostVoidCallbacks.values()].map((candidate) => candidate.ownerUnitId),
+    ...[...plan.hostDateSnapshots.values()].map((candidate) => candidate.ownerUnitId),
+    ...[...plan.hostDateGetters.values()].map((candidate) => candidate.ownerUnitId),
+    ...[...plan.promiseDelays.constructions.values()].map((candidate) => candidate.ownerUnitId),
+    ...plan.suspendingAsyncUnitIds,
+    ...irTimerShim.inspectIrCompilerTimerShimRouting(plan).ownerUnitIds,
+    ...collectPreparedTopLevelFunctionValueTargetUnitIds(ctx, sourceFile, plan.identityPlan),
+  ]);
+}
+
+function planEarlyMultiIrOverlay(
+  ctx: CodegenContext,
+  multiAst: MultiTypedAST,
+  identityContext: IrPlanningIdentityContext,
+  options: CodegenOptions | undefined,
+): Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<IrOverlayPlan>> {
+  const active =
+    !!options?.experimentalIR &&
+    !options.disableIrFirst &&
+    !explicitlyDisabledEnv(process.env.JS2WASM_IR_FIRST) &&
+    ctx.standalone &&
+    !ctx.wasi &&
+    !ctx.fast &&
+    multiAst.sourceFiles.length > 1;
+  if (!active) return new Map();
+  return planEarlyMultiPreparedScalarLeafRoute({
+    active,
+    cutoverEnabled: !explicitlyDisabledEnv(process.env.JS2WASM_MULTI_PREPARED_SCALAR_LEAF_CUTOVER),
+    ctx,
+    sourceFiles: multiAst.sourceFiles,
+    entryFile: multiAst.entryFile,
+    safety: () => buildMultiIrGraphSafety(ctx, multiAst.sourceFiles, multiAst.checker),
+    planSource: (sourceFile) => planMultiIrOverlaySource(ctx, multiAst, sourceFile, identityContext, undefined),
+    safeSelection: (plan, sourceFile, safety) => makeMultiIrSafeSelection(ctx, plan, sourceFile, safety),
+    lateProviderOwnerUnitIds: (plan, sourceFile) => collectMultiIrLateProviderOwnerUnitIds(ctx, sourceFile, plan),
+    projectLoweringPlans: (plan, selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
+  });
+}
+
+function compileMultiIrOverlaySource(
+  ctx: CodegenContext,
+  multiAst: MultiTypedAST,
+  sourceFile: ts.SourceFile,
+  identityContext: IrPlanningIdentityContext,
+  safety: MultiIrGraphSafety,
+  hostImportedFunctions: irOverlayIdentity.IrIdentityImportedFunctionResolver | undefined,
+  early?: EarlyMultiPreparedScalarLeafState<IrOverlayPlan>,
+): void {
+  const plan =
+    early?.plan ?? planMultiIrOverlaySource(ctx, multiAst, sourceFile, identityContext, hostImportedFunctions);
   let safeSelection = makeMultiIrSafeSelection(ctx, plan, sourceFile, safety);
   safeSelection = prepareMultiIrImportedLowering(ctx, sourceFile, plan, safeSelection);
   safeSelection = synchronizeIrSafeFunctionSelection(plan, safeSelection);
@@ -3657,9 +3553,20 @@ function compileMultiIrOverlaySource(
     ),
   );
   const { overrideMap, classShapes } = plan;
-  const loweringPlans = irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, safeSelection);
-  const report = compileIrPathFunctions(ctx, sourceFile, safeSelection, overrideMap, classShapes, loweringPlans);
-  consumeIrOverlayReport(ctx, report, plan, safeSelection, sourceFile);
+  if (early?.route) {
+    assertMultiPreparedScalarLeafRouteCurrent({ ctx, route: early.route, finalSelection: safeSelection, safety });
+  }
+  const report = completePreparedIrIntegration({
+    ctx,
+    sourceFile,
+    selection: safeSelection,
+    overrideMap,
+    classShapes,
+    ...(early?.route ? { preparedReport: early.route.preparedReport } : {}),
+    ...(early?.route ? { preparedLegacyNames: early.route.preparedFreeFunctions.completedBodies } : {}),
+    projectLoweringPlans: (selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
+  });
+  consumeIrOverlayReport(ctx, report, plan, safeSelection, sourceFile, early?.skippedFunctionUnitIds);
 }
 
 function recordSourceGlobalEnvironment(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
@@ -8120,6 +8027,9 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
 
     standaloneCalendar.reserveDirectCallbacks(irPlanningIdentityContext);
 
+    // (#4589) Prepare one exact standalone scalar leaf before direct bodies.
+    const earlyMultiIr = planEarlyMultiIrOverlay(ctx, multiAst, irPlanningIdentityContext!, options);
+
     // Phase 3: Compile all function bodies.
     //
     // (#3782) compileDeclarations recompiles the one accumulated module
@@ -8165,7 +8075,9 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
         for (const [name, idx] of ownFuncIdxBySource.get(sf) ?? []) {
           ctx.funcMap.set(name, idx);
         }
-        profilePhase(sf.fileName, () => compileDeclarations(ctx, sf, undefined, undefined, undefined, moduleInitMode));
+        profilePhase(sf.fileName, () =>
+          compileMultiPreparedScalarLeafDeclarations(ctx, sf, earlyMultiIr.get(sf), moduleInitMode),
+        );
       }
     });
 
@@ -8176,13 +8088,12 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
     frameStage(ctx, "finalizeMethodTrampolines");
     profileCount("functions-after-bodies", ctx.mod.functions.length);
 
-    // (#2138 M0) Compile-twice IR overlay for multi-module top-level functions.
-    // Every legacy body in every source file is already present, and method
-    // trampolines are final, before planning starts. Imported calls remain an
-    // external selector boundary in M0 (no module-binding resolver); class
-    // members, module init, and IR-first body skipping are deliberately out of
-    // scope. In particular, never patch the one shared `__module_init` once per
-    // source file.
+    // (#2138 M0) Late IR overlay for multi-module top-level functions. Ordinary
+    // owners have direct bodies and finalized trampolines here; #4589's one
+    // exact standalone scalar singleton instead carries its Prepared body and
+    // correlated skip into this report. Imported calls remain an external
+    // selector boundary. Class members and module init stay direct-owned; never
+    // patch the shared `__module_init` once per source file.
     // Fast-mode legacy declarations use i32 for `number`, while the current IR
     // overlay uses f64. A multi-file target can be reached by a legacy caller,
     // so replacing only that target would change its live Wasm ABI. Keep the
@@ -8193,17 +8104,7 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
         ctx.standalone || ctx.wasi || ctx.strictNoHostImports
           ? undefined
           : irOverlayIdentity.makeIrOverlayImportedResolver(multiAst.checker, irPlanningIdentityContext!);
-      const occupiedFunctionNameCounts = new Map<string, number>();
-      for (const fn of ctx.mod.functions) {
-        occupiedFunctionNameCounts.set(fn.name, (occupiedFunctionNameCounts.get(fn.name) ?? 0) + 1);
-      }
-      const safety: MultiIrGraphSafety = {
-        collisions: collectMultiIrFunctionNameCollisions(multiAst.sourceFiles),
-        crossFileFunctionNames: collectMultiCrossFileFunctionNames(multiAst.sourceFiles, multiAst.checker),
-        importAliasNames: collectMultiImportAliasNames(multiAst.sourceFiles),
-        occupiedFunctionKeys: [...ctx.funcMap.keys()],
-        occupiedFunctionNameCounts,
-      };
+      const safety = buildMultiIrGraphSafety(ctx, multiAst.sourceFiles, multiAst.checker);
       profilePhase("ir-overlay", () => {
         for (const sourceFile of multiAst.sourceFiles) {
           profilePhase(sourceFile.fileName, () =>
@@ -8214,6 +8115,7 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
               irPlanningIdentityContext!,
               safety,
               hostImportedFunctions,
+              earlyMultiIr.get(sourceFile),
             ),
           );
         }

--- a/src/codegen/multi-prepared-fibonacci-pair.ts
+++ b/src/codegen/multi-prepared-fibonacci-pair.ts
@@ -1,0 +1,828 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrUnitId } from "../ir/identity.js";
+import type { IrIntegrationLoweringPlans } from "../ir/ast-lowering-plans.js";
+import { asVal } from "../ir/nodes.js";
+import { IrInvariantError } from "../ir/outcomes.js";
+import type { IrSelection } from "../ir/select.js";
+import type { Instr, WasmFunction } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+import { collectLocalCallEdgesByIdentity } from "./ir-first-gate.js";
+import type { IrOverlayIdentityPlan } from "./ir-overlay-identity.js";
+import { prepareIrBodies, type PreparedIrFreeFunctionBodies } from "./ir-prepared-free-functions.js";
+import {
+  exactOracleValueDeclaration,
+  multiPreparedFunctionValueUseIsCurrent,
+  resolveMultiPreparedFunctionValueImportTarget,
+} from "./multi-prepared-function-value-import-target.js";
+import {
+  collectMultiPreparedScalarLeafCandidates,
+  exactAllocatedNumericCallable,
+  functionValueSupportIsCurrent,
+  hasExactNumericDeclarationSignature,
+  identifierResolvesExactly,
+  planEarlyMultiPreparedFunctionValueLeafRoute,
+  sourceContainsCommonJsExport,
+  type EarlyMultiPreparedScalarLeafState,
+  type MultiPreparedFunctionValueCandidateEvidence,
+  type MultiPreparedFunctionValueLeafRoute,
+  type MultiPreparedFunctionValuePlan,
+  type MultiPreparedFunctionValueSupportReceipt,
+  type MultiPreparedScalarLeafGraphSafety,
+  type MultiPreparedScalarLeafReceipt,
+} from "./multi-prepared-scalar-leaf.js";
+
+interface ExactFibonacciPairSyntax {
+  readonly sourceFile: ts.SourceFile;
+  readonly recursiveDeclaration: ts.FunctionDeclaration;
+  readonly wrapperDeclaration: ts.FunctionDeclaration;
+  readonly wrapperCall: ts.CallExpression;
+}
+
+interface MultiPreparedFibonacciPairCandidateEvidence extends MultiPreparedFunctionValueCandidateEvidence {
+  readonly recursiveDeclaration: ts.FunctionDeclaration;
+  readonly recursiveUnitId: IrUnitId;
+  readonly recursiveName: string;
+  readonly wrapperDeclaration: ts.FunctionDeclaration;
+  readonly wrapperCall: ts.CallExpression;
+}
+
+interface PreparedFunctionSlotReceipt {
+  readonly declaration: ts.FunctionDeclaration;
+  readonly unitId: IrUnitId;
+  readonly legacyName: string;
+  readonly receipt: MultiPreparedScalarLeafReceipt;
+  readonly allocatedFunction: WasmFunction;
+  readonly preparedBody: WasmFunction["body"];
+  readonly preparedInstructions: readonly Instr[];
+}
+
+export type MultiPreparedFibonacciPairRoute = Omit<MultiPreparedFunctionValueLeafRoute, "routeKind"> & {
+  readonly routeKind: "fibonacci-pair";
+  readonly recursiveDeclaration: ts.FunctionDeclaration;
+  readonly recursiveUnitId: IrUnitId;
+  readonly recursiveName: string;
+  readonly recursiveReceipt: MultiPreparedScalarLeafReceipt;
+  readonly recursiveAllocatedFunction: WasmFunction;
+  readonly recursivePreparedBody: WasmFunction["body"];
+  readonly recursivePreparedInstructions: readonly Instr[];
+  readonly wrapperCall: ts.CallExpression;
+  readonly preparedComponentId: string;
+  readonly identityPlan: MultiPreparedFunctionValuePlan["identityPlan"];
+};
+
+function invariant(stage: "resolve" | "patch", detail: string): never {
+  throw new IrInvariantError("selection-preparation-mismatch", stage, detail);
+}
+
+function rejectRequired(detail: string): undefined {
+  if (process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_FIB_PAIR === "1") {
+    invariant("resolve", `required multi-source Fibonacci pair rejected: ${detail}`);
+  }
+  return undefined;
+}
+
+function numericLiteralIs(expression: ts.Expression | undefined, text: string): expression is ts.NumericLiteral {
+  return expression !== undefined && ts.isNumericLiteral(expression) && expression.text === text;
+}
+
+function exactRecursiveArgument(
+  ctx: CodegenContext,
+  expression: ts.Expression,
+  parameter: ts.ParameterDeclaration,
+  decrement: string,
+): boolean {
+  return (
+    ts.isBinaryExpression(expression) &&
+    expression.operatorToken.kind === ts.SyntaxKind.MinusToken &&
+    ts.isIdentifier(expression.left) &&
+    identifierResolvesExactly(ctx, expression.left, parameter) &&
+    numericLiteralIs(expression.right, decrement)
+  );
+}
+
+function exactRecursiveCall(
+  ctx: CodegenContext,
+  expression: ts.Expression,
+  declaration: ts.FunctionDeclaration,
+  parameter: ts.ParameterDeclaration,
+  decrement: string,
+): expression is ts.CallExpression {
+  return (
+    ts.isCallExpression(expression) &&
+    expression.questionDotToken === undefined &&
+    (expression.typeArguments?.length ?? 0) === 0 &&
+    ts.isIdentifier(expression.expression) &&
+    identifierResolvesExactly(ctx, expression.expression, declaration) &&
+    expression.arguments.length === 1 &&
+    exactRecursiveArgument(ctx, expression.arguments[0]!, parameter, decrement)
+  );
+}
+
+function isExactFibonacciRecurrence(ctx: CodegenContext, declaration: ts.FunctionDeclaration): boolean {
+  if (!hasExactNumericDeclarationSignature(declaration) || declaration.parameters.length !== 1 || !declaration.body) {
+    return false;
+  }
+  const parameter = declaration.parameters[0]!;
+  if (!ts.isIdentifier(parameter.name)) return false;
+  const [baseCase, recursiveReturn] = declaration.body.statements;
+  if (
+    declaration.body.statements.length !== 2 ||
+    !baseCase ||
+    !ts.isIfStatement(baseCase) ||
+    baseCase.elseStatement !== undefined ||
+    !ts.isBinaryExpression(baseCase.expression) ||
+    baseCase.expression.operatorToken.kind !== ts.SyntaxKind.LessThanEqualsToken ||
+    !ts.isIdentifier(baseCase.expression.left) ||
+    !identifierResolvesExactly(ctx, baseCase.expression.left, parameter) ||
+    !numericLiteralIs(baseCase.expression.right, "1") ||
+    !ts.isReturnStatement(baseCase.thenStatement) ||
+    !baseCase.thenStatement.expression ||
+    !ts.isIdentifier(baseCase.thenStatement.expression) ||
+    !identifierResolvesExactly(ctx, baseCase.thenStatement.expression, parameter) ||
+    !recursiveReturn ||
+    !ts.isReturnStatement(recursiveReturn) ||
+    !recursiveReturn.expression ||
+    !ts.isBinaryExpression(recursiveReturn.expression) ||
+    recursiveReturn.expression.operatorToken.kind !== ts.SyntaxKind.PlusToken
+  ) {
+    return false;
+  }
+  return (
+    exactRecursiveCall(ctx, recursiveReturn.expression.left, declaration, parameter, "1") &&
+    exactRecursiveCall(ctx, recursiveReturn.expression.right, declaration, parameter, "2")
+  );
+}
+
+function exactFibonacciWrapperCall(
+  ctx: CodegenContext,
+  declaration: ts.FunctionDeclaration,
+  recursiveDeclaration: ts.FunctionDeclaration,
+): ts.CallExpression | undefined {
+  if (
+    !hasExactNumericDeclarationSignature(declaration) ||
+    declaration.parameters.length !== 0 ||
+    !declaration.body ||
+    declaration.body.statements.length !== 1
+  ) {
+    return undefined;
+  }
+  const statement = declaration.body.statements[0];
+  const call = statement && ts.isReturnStatement(statement) ? statement.expression : undefined;
+  if (
+    !call ||
+    !ts.isCallExpression(call) ||
+    call.questionDotToken !== undefined ||
+    (call.typeArguments?.length ?? 0) !== 0 ||
+    !ts.isIdentifier(call.expression) ||
+    !identifierResolvesExactly(ctx, call.expression, recursiveDeclaration) ||
+    call.arguments.length !== 1 ||
+    !numericLiteralIs(call.arguments[0], "30")
+  ) {
+    return undefined;
+  }
+  return call;
+}
+
+function collectExactFibonacciPairSyntax(
+  ctx: CodegenContext,
+  sourceFiles: readonly ts.SourceFile[],
+): { readonly recurrences: readonly ts.FunctionDeclaration[]; readonly pairs: readonly ExactFibonacciPairSyntax[] } {
+  if (sourceFiles.some(sourceContainsCommonJsExport)) return { recurrences: [], pairs: [] };
+  const recurrences = sourceFiles.flatMap((sourceFile) =>
+    sourceFile.statements.filter(
+      (statement): statement is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(statement) && isExactFibonacciRecurrence(ctx, statement),
+    ),
+  );
+  const pairs: ExactFibonacciPairSyntax[] = [];
+  for (const recursiveDeclaration of recurrences) {
+    const sourceFile = recursiveDeclaration.getSourceFile();
+    for (const statement of sourceFile.statements) {
+      if (!ts.isFunctionDeclaration(statement) || statement === recursiveDeclaration) continue;
+      const wrapperCall = exactFibonacciWrapperCall(ctx, statement, recursiveDeclaration);
+      if (wrapperCall) {
+        pairs.push({ sourceFile, recursiveDeclaration, wrapperDeclaration: statement, wrapperCall });
+      }
+    }
+  }
+  return { recurrences, pairs };
+}
+
+function setIsExactly<T>(actual: ReadonlySet<T> | undefined, expected: readonly T[]): boolean {
+  return actual !== undefined && actual.size === expected.length && expected.every((value) => actual.has(value));
+}
+
+function exactFibonacciCallTopology(
+  sourceFile: ts.SourceFile,
+  identityPlan: IrOverlayIdentityPlan,
+  recursiveUnitId: IrUnitId,
+  wrapperUnitId: IrUnitId,
+): boolean {
+  const edges = collectLocalCallEdgesByIdentity(sourceFile, identityPlan.identityContext);
+  const pairIds = new Set([recursiveUnitId, wrapperUnitId]);
+  if (
+    !setIsExactly(edges.callees.get(recursiveUnitId), [recursiveUnitId]) ||
+    !setIsExactly(edges.callees.get(wrapperUnitId), [recursiveUnitId]) ||
+    edges.calleesFromUnownedCallers.has(recursiveUnitId) ||
+    edges.calleesFromUnownedCallers.has(wrapperUnitId) ||
+    (edges.constructionCallees.get(recursiveUnitId)?.size ?? 0) !== 0 ||
+    (edges.constructionCallees.get(wrapperUnitId)?.size ?? 0) !== 0 ||
+    (edges.moduleBindingStorageTerminals.get(recursiveUnitId)?.size ?? 0) !== 0 ||
+    (edges.moduleBindingStorageTerminals.get(wrapperUnitId)?.size ?? 0) !== 0
+  ) {
+    return false;
+  }
+  for (const [callerUnitId, callees] of edges.callees) {
+    if (pairIds.has(callerUnitId)) continue;
+    if ([...callees].some((calleeUnitId) => pairIds.has(calleeUnitId))) return false;
+  }
+  return true;
+}
+
+function exactFunctionReferences(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  declaration: ts.FunctionDeclaration,
+): readonly ts.Identifier[] {
+  const references: ts.Identifier[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isIdentifier(node) && node !== declaration.name && identifierResolvesExactly(ctx, node, declaration)) {
+      references.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return references;
+}
+
+function functionHasNoSupport(ctx: CodegenContext, legacyName: string): boolean {
+  const trampolineName = `__fn_tramp_${legacyName}_cached`;
+  const cacheName = `__fn_closure_${legacyName}`;
+  return (
+    !ctx.funcMap.has(trampolineName) &&
+    !ctx.funcClosureGlobals.has(legacyName) &&
+    !ctx.mod.functions.some((func) => func.name === trampolineName) &&
+    !ctx.mod.globals.some((global) => global.name === cacheName)
+  );
+}
+
+function exactFunctionIdentity(
+  ctx: CodegenContext,
+  declaration: ts.FunctionDeclaration,
+  plan: MultiPreparedFunctionValuePlan,
+  safeSelection: IrSelection,
+  safety: MultiPreparedScalarLeafGraphSafety,
+  parameterCount: number,
+): { readonly unitId: IrUnitId; readonly legacyName: string } | undefined {
+  const legacyName = declaration.name?.text;
+  const unitId = plan.identityPlan.identityContext.unitIdByDeclaration.get(declaration);
+  const terminal = unitId ? plan.identityPlan.identityContext.terminalByUnitId.get(unitId) : undefined;
+  const claim = unitId ? plan.functionClaimsByUnitId.get(unitId) : undefined;
+  const override = unitId ? plan.overrideMapByUnitId.get(unitId) : undefined;
+  if (
+    !legacyName ||
+    !declaration.name ||
+    exactOracleValueDeclaration(ctx.oracle, declaration.name) !== declaration ||
+    !unitId ||
+    !terminal ||
+    terminal !== plan.identityPlan.identityContext.unitByUnitId.get(unitId) ||
+    terminal.kind !== "top-level-function" ||
+    terminal.observedKind !== "function" ||
+    terminal.terminalOwnerId !== unitId ||
+    plan.identityPlan.identityContext.declarationByUnitId.get(unitId) !== declaration ||
+    claim?.declaration !== declaration ||
+    claim.legacyName !== legacyName ||
+    !safeSelection.funcs.has(legacyName) ||
+    !plan.identityPlan.safeFunctionUnitIds.has(unitId) ||
+    !override ||
+    override.params.length !== parameterCount ||
+    !override.params.every((type) => asVal(type)?.kind === "f64") ||
+    override.returnType === null ||
+    asVal(override.returnType)?.kind !== "f64" ||
+    safety.collisions.has(legacyName) ||
+    safety.crossFileFunctionNames.has(legacyName) ||
+    safety.importAliasNames.has(legacyName) ||
+    safety.occupiedFunctionNameCounts.get(legacyName) !== 1 ||
+    safety.occupiedFunctionKeys.some((key) => key.startsWith(`${legacyName}$`)) ||
+    ctx.liveFuncBindingGlobals?.has(legacyName) === true ||
+    !exactAllocatedNumericCallable(ctx, unitId, legacyName, parameterCount, true)
+  ) {
+    return undefined;
+  }
+  return { unitId, legacyName };
+}
+
+function resolveExactFibonacciPair<Plan extends MultiPreparedFunctionValuePlan>(input: {
+  readonly ctx: CodegenContext;
+  readonly syntax: ExactFibonacciPairSyntax;
+  readonly plan: Plan;
+  readonly safeSelection: IrSelection;
+  readonly safety: MultiPreparedScalarLeafGraphSafety;
+  readonly hasForeignLateProvider: (recursiveUnitId: IrUnitId, wrapperUnitId: IrUnitId) => boolean;
+}): MultiPreparedFibonacciPairCandidateEvidence | undefined {
+  const { ctx, plan, safeSelection, safety, syntax } = input;
+  const { recursiveDeclaration, sourceFile, wrapperCall, wrapperDeclaration } = syntax;
+  if (!ctx.standalone || ctx.fast || ctx.wasi) return rejectRequired("target lane");
+  if (recursiveDeclaration.parent !== sourceFile || wrapperDeclaration.parent !== sourceFile) {
+    return rejectRequired("source children");
+  }
+  if (safeSelection.moduleInit !== undefined || (plan.selection.moduleInit?.stmtCount ?? 0) !== 0) {
+    return rejectRequired("module init");
+  }
+  if (plan.classShapes.size !== 0 || plan.classShapesById.size !== 0) return rejectRequired("class shapes");
+  const recursive = exactFunctionIdentity(ctx, recursiveDeclaration, plan, safeSelection, safety, 1);
+  const wrapper = exactFunctionIdentity(ctx, wrapperDeclaration, plan, safeSelection, safety, 0);
+  if (!recursive || !wrapper || recursive.unitId === wrapper.unitId) return rejectRequired("function identities");
+  if (!exactFibonacciCallTopology(sourceFile, plan.identityPlan, recursive.unitId, wrapper.unitId)) {
+    return rejectRequired("call topology");
+  }
+  if (input.hasForeignLateProvider(recursive.unitId, wrapper.unitId)) return rejectRequired("late provider");
+  if (!ctx.programAbiSession) return rejectRequired("Program ABI session");
+  if (
+    [...ctx.programAbiSession.derivedUnitRecords()].some(
+      (record) => record.terminalOwnerId === recursive.unitId || record.terminalOwnerId === wrapper.unitId,
+    )
+  ) {
+    return rejectRequired("derived unit");
+  }
+  const recursiveReferences = exactFunctionReferences(ctx, sourceFile, recursiveDeclaration);
+  if (
+    recursiveReferences.length !== 3 ||
+    recursiveReferences.some(
+      (identifier) => !ts.isCallExpression(identifier.parent) || identifier.parent.expression !== identifier,
+    ) ||
+    !recursiveReferences.some((identifier) => identifier.parent === wrapperCall)
+  ) {
+    return rejectRequired("recursive references");
+  }
+  const wrapperReferences = exactFunctionReferences(ctx, sourceFile, wrapperDeclaration).filter(
+    (identifier) => !(ts.isCallExpression(identifier.parent) && identifier.parent.expression === identifier),
+  );
+  const valueIdentifier = wrapperReferences.length === 1 ? wrapperReferences[0] : undefined;
+  const importedCall = valueIdentifier?.parent;
+  if (
+    !valueIdentifier ||
+    !importedCall ||
+    !ts.isCallExpression(importedCall) ||
+    importedCall.arguments.filter((argument) => argument === valueIdentifier).length !== 1
+  ) {
+    return rejectRequired(`wrapper value reference count ${wrapperReferences.length}`);
+  }
+  let owner: ts.Node | undefined = importedCall.parent;
+  while (owner && owner !== sourceFile && !ts.isFunctionLike(owner)) owner = owner.parent;
+  if (!owner || !ts.isFunctionDeclaration(owner) || owner.parent !== sourceFile || !owner.name || !owner.body) {
+    return rejectRequired("legacy owner");
+  }
+  const legacyOwnerUnitId = plan.identityPlan.identityContext.unitIdByDeclaration.get(owner);
+  const ownerTerminal = legacyOwnerUnitId
+    ? plan.identityPlan.identityContext.terminalByUnitId.get(legacyOwnerUnitId)
+    : undefined;
+  const importedTarget = ts.isIdentifier(importedCall.expression)
+    ? resolveMultiPreparedFunctionValueImportTarget({
+        oracle: ctx.oracle,
+        sourceFile,
+        callee: importedCall.expression,
+        identityContext: plan.identityPlan.identityContext,
+      })
+    : undefined;
+  const importedTargetUnitId = importedTarget
+    ? plan.identityPlan.identityContext.unitIdByDeclaration.get(importedTarget)
+    : undefined;
+  if (
+    !legacyOwnerUnitId ||
+    legacyOwnerUnitId === recursive.unitId ||
+    legacyOwnerUnitId === wrapper.unitId ||
+    ownerTerminal?.observedKind !== "function" ||
+    ownerTerminal.terminalOwnerId !== legacyOwnerUnitId ||
+    plan.identityPlan.identityContext.declarationByUnitId.get(legacyOwnerUnitId) !== owner ||
+    safeSelection.funcs.has(owner.name.text) ||
+    !importedTarget ||
+    !importedTargetUnitId ||
+    plan.identityPlan.identityContext.declarationByUnitId.get(importedTargetUnitId) !== importedTarget ||
+    importedTarget.getSourceFile() === sourceFile ||
+    !functionHasNoSupport(ctx, recursive.legacyName) ||
+    !functionHasNoSupport(ctx, wrapper.legacyName)
+  ) {
+    return rejectRequired("function-value edge/support");
+  }
+  return {
+    legacyName: wrapper.legacyName,
+    unitId: wrapper.unitId,
+    valueIdentifier,
+    legacyOwnerUnitId,
+    legacyOwnerName: owner.name.text,
+    importedCall,
+    importedTargetUnitId,
+    recursiveDeclaration,
+    recursiveUnitId: recursive.unitId,
+    recursiveName: recursive.legacyName,
+    wrapperDeclaration,
+    wrapperCall,
+  };
+}
+
+function exactPairWithdrawal(
+  report: MultiPreparedFunctionValueLeafRoute["preparedReport"],
+  prepared: PreparedIrFreeFunctionBodies,
+  candidate: MultiPreparedFibonacciPairCandidateEvidence,
+): boolean {
+  const evidence = report.terminalEvidence ?? [];
+  const empty =
+    prepared.skipBodies.size === 0 &&
+    prepared.preserveBodies.size === 0 &&
+    prepared.completedBodies.size === 0 &&
+    prepared.requestedSkipProjection.entries.length === 0 &&
+    report.compiled.length === 0 &&
+    (report.compiledArtifactEvidence?.length ?? 0) === 0 &&
+    (report.syntheticCompiledArtifacts?.length ?? 0) === 0;
+  if (!empty) return false;
+  if (report.errors.length === 0 && evidence.length === 0) return true;
+  const expected = new Map<IrUnitId, string>([
+    [candidate.recursiveUnitId, candidate.recursiveName],
+    [candidate.unitId, candidate.legacyName],
+  ]);
+  return (
+    report.errors.length === 2 &&
+    evidence.length === 2 &&
+    setIsExactly(new Set(evidence.map((entry) => entry.unitId)), [...expected.keys()]) &&
+    evidence.every(
+      (entry) =>
+        entry.kind === "failed" &&
+        expected.get(entry.unitId) === entry.legacyName &&
+        entry.error.outcome.kind === "unsupported" &&
+        report.errors.includes(entry.error),
+    )
+  );
+}
+
+function preparedSlotReceipt(
+  ctx: CodegenContext,
+  declaration: ts.FunctionDeclaration,
+  unitId: IrUnitId,
+  legacyName: string,
+  parameterCount: number,
+  componentId: string,
+): PreparedFunctionSlotReceipt {
+  const allocated = exactAllocatedNumericCallable(ctx, unitId, legacyName, parameterCount, false);
+  if (!allocated || allocated.func.body.length === 0) {
+    invariant("patch", `multi-source Fibonacci pair ${unitId} lost its prepared source slot`);
+  }
+  return {
+    declaration,
+    unitId,
+    legacyName,
+    receipt: { kind: "prepared", unitId, legacyName, preparedComponentId: componentId },
+    allocatedFunction: allocated.func,
+    preparedBody: allocated.func.body,
+    preparedInstructions: Object.freeze([...allocated.func.body]),
+  };
+}
+
+function tryPrepareExactFibonacciPair<Plan extends MultiPreparedFunctionValuePlan>(input: {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly plan: Plan;
+  readonly candidate: MultiPreparedFibonacciPairCandidateEvidence;
+  readonly support: MultiPreparedFunctionValueSupportReceipt;
+  readonly projectLoweringPlans: (selection: IrSelection) => IrIntegrationLoweringPlans;
+}): MultiPreparedFibonacciPairRoute | undefined {
+  const { candidate, ctx, plan, sourceFile, support } = input;
+  if (
+    !functionValueSupportIsCurrent(ctx, candidate, support, true) ||
+    !functionHasNoSupport(ctx, candidate.recursiveName)
+  ) {
+    invariant("resolve", `multi-source Fibonacci pair ${candidate.unitId} lost its preallocated support receipt`);
+  }
+  const preparedSelection: IrSelection = {
+    funcs: new Set([candidate.recursiveName, candidate.legacyName]),
+    classMembers: new Set(),
+    classMemberUnitIds: new Set(),
+    moduleInit: undefined,
+  };
+  const prepared = prepareIrBodies({
+    ctx,
+    sourceFile,
+    selection: preparedSelection,
+    identityPlan: plan.identityPlan,
+    functionClaimsByUnitId: plan.functionClaimsByUnitId,
+    overrideMap: plan.overrideMap,
+    classShapes: plan.classShapes,
+    classShapesById: plan.classShapesById,
+    projectLoweringPlans: input.projectLoweringPlans,
+  });
+  if (prepared.classMembers || prepared.moduleInit || prepared.implicitConstructorUnitIds.size !== 0) {
+    invariant("patch", `multi-source Fibonacci pair ${candidate.unitId} produced a foreign Prepared family`);
+  }
+  if (prepared.freeFunctions.skipBodies.size === 0) {
+    if (
+      exactPairWithdrawal(prepared.report, prepared.freeFunctions, candidate) &&
+      functionValueSupportIsCurrent(ctx, candidate, support, true) &&
+      functionHasNoSupport(ctx, candidate.recursiveName)
+    ) {
+      return undefined;
+    }
+    invariant("patch", `multi-source Fibonacci pair ${candidate.unitId} did not withdraw both bodies before skip`);
+  }
+  const expectedByUnitId = new Map<IrUnitId, string>([
+    [candidate.recursiveUnitId, candidate.recursiveName],
+    [candidate.unitId, candidate.legacyName],
+  ]);
+  const expectedNames = [...expectedByUnitId.values()];
+  const evidence = prepared.report.terminalEvidence ?? [];
+  const artifacts = prepared.report.compiledArtifactEvidence ?? [];
+  const componentIds = new Set(
+    evidence.flatMap((entry) =>
+      entry.kind === "patched" && entry.preparedComponentId ? [entry.preparedComponentId] : [],
+    ),
+  );
+  const componentId = componentIds.size === 1 ? [...componentIds][0] : undefined;
+  const exact =
+    componentId !== undefined &&
+    prepared.report.errors.length === 0 &&
+    evidence.length === 2 &&
+    setIsExactly(new Set(evidence.map((entry) => entry.unitId)), [...expectedByUnitId.keys()]) &&
+    evidence.every(
+      (entry) =>
+        entry.kind === "patched" &&
+        expectedByUnitId.get(entry.unitId) === entry.legacyName &&
+        entry.preparedComponentId === componentId,
+    ) &&
+    artifacts.length === 2 &&
+    setIsExactly(new Set(artifacts.map((artifact) => artifact.artifactUnitId)), [...expectedByUnitId.keys()]) &&
+    artifacts.every(
+      (artifact) =>
+        expectedByUnitId.get(artifact.artifactUnitId) === artifact.name &&
+        artifact.terminalOwnerUnitId === artifact.artifactUnitId &&
+        artifact.preparedComponentId === componentId,
+    ) &&
+    prepared.report.compiled.length === 2 &&
+    setIsExactly(new Set(prepared.report.compiled), expectedNames) &&
+    prepared.report.terminalCompiledOwners?.length === 2 &&
+    setIsExactly(new Set(prepared.report.terminalCompiledOwners), expectedNames) &&
+    setIsExactly(prepared.freeFunctions.skipBodies, expectedNames) &&
+    setIsExactly(prepared.freeFunctions.preserveBodies, expectedNames) &&
+    setIsExactly(prepared.freeFunctions.completedBodies, expectedNames) &&
+    prepared.freeFunctions.requestedSkipProjection.entries.length === 2 &&
+    setIsExactly(new Set(prepared.freeFunctions.requestedSkipProjection.entries.map((entry) => entry.unitId)), [
+      ...expectedByUnitId.keys(),
+    ]) &&
+    prepared.freeFunctions.requestedSkipProjection.entries.every(
+      (entry) => expectedByUnitId.get(entry.unitId) === entry.legacyName,
+    ) &&
+    (prepared.report.syntheticCompiledArtifacts?.length ?? 0) === 0;
+  if (!exact || !componentId) {
+    invariant("patch", `multi-source Fibonacci pair ${candidate.unitId} produced a non-atomic Prepared receipt`);
+  }
+  const recursiveSlot = preparedSlotReceipt(
+    ctx,
+    candidate.recursiveDeclaration,
+    candidate.recursiveUnitId,
+    candidate.recursiveName,
+    1,
+    componentId,
+  );
+  const wrapperSlot = preparedSlotReceipt(
+    ctx,
+    plan.identityPlan.identityContext.declarationByUnitId.get(candidate.unitId) === candidate.wrapperDeclaration
+      ? candidate.wrapperDeclaration
+      : invariant("patch", `multi-source Fibonacci pair ${candidate.unitId} lost its wrapper source`),
+    candidate.unitId,
+    candidate.legacyName,
+    0,
+    componentId,
+  );
+  if (
+    !functionValueSupportIsCurrent(ctx, candidate, support, false) ||
+    !functionHasNoSupport(ctx, candidate.recursiveName)
+  ) {
+    invariant("patch", `multi-source Fibonacci pair ${candidate.unitId} drifted during Prepared certification`);
+  }
+  return Object.freeze({
+    routeKind: "fibonacci-pair",
+    sourceFile,
+    declaration: wrapperSlot.declaration,
+    unitId: wrapperSlot.unitId,
+    legacyName: wrapperSlot.legacyName,
+    preparedSelection,
+    preparedReport: prepared.report,
+    preparedFreeFunctions: prepared.freeFunctions,
+    receipt: wrapperSlot.receipt,
+    allocatedFunction: wrapperSlot.allocatedFunction,
+    preparedBody: wrapperSlot.preparedBody,
+    preparedInstructions: wrapperSlot.preparedInstructions,
+    valueIdentifier: candidate.valueIdentifier,
+    legacyOwnerUnitId: candidate.legacyOwnerUnitId,
+    legacyOwnerName: candidate.legacyOwnerName,
+    importedCall: candidate.importedCall,
+    importedTargetUnitId: candidate.importedTargetUnitId,
+    support,
+    recursiveDeclaration: recursiveSlot.declaration,
+    recursiveUnitId: recursiveSlot.unitId,
+    recursiveName: recursiveSlot.legacyName,
+    recursiveReceipt: recursiveSlot.receipt,
+    recursiveAllocatedFunction: recursiveSlot.allocatedFunction,
+    recursivePreparedBody: recursiveSlot.preparedBody,
+    recursivePreparedInstructions: recursiveSlot.preparedInstructions,
+    wrapperCall: candidate.wrapperCall,
+    preparedComponentId: componentId,
+    identityPlan: plan.identityPlan,
+  });
+}
+
+function allocatedSlotIsCurrent(
+  ctx: CodegenContext,
+  slot: PreparedFunctionSlotReceipt,
+  parameterCount: number,
+): boolean {
+  const allocated = exactAllocatedNumericCallable(ctx, slot.unitId, slot.legacyName, parameterCount, false);
+  return (
+    allocated !== undefined &&
+    allocated.func === slot.allocatedFunction &&
+    allocated.func.body === slot.preparedBody &&
+    allocated.func.body.length === slot.preparedInstructions.length &&
+    allocated.func.body.every((instruction, index) => instruction === slot.preparedInstructions[index]) &&
+    allocated.func.body.length > 0
+  );
+}
+
+export function assertMultiPreparedFibonacciPairRouteCurrent(input: {
+  readonly ctx: CodegenContext;
+  readonly route: MultiPreparedFibonacciPairRoute;
+  readonly finalSelection: IrSelection;
+  readonly safety: MultiPreparedScalarLeafGraphSafety;
+}): void {
+  const { ctx, finalSelection, route, safety } = input;
+  const tamper = process.env.JS2WASM_TEST_TAMPER_MULTI_PREPARED_FIB_PAIR;
+  if (tamper && tamper !== "0" && tamper !== "false") {
+    route.support.trampolineFunction.name = `${route.support.trampolineFunction.name}$tampered`;
+  }
+  const recursiveSlot: PreparedFunctionSlotReceipt = {
+    declaration: route.recursiveDeclaration,
+    unitId: route.recursiveUnitId,
+    legacyName: route.recursiveName,
+    receipt: route.recursiveReceipt,
+    allocatedFunction: route.recursiveAllocatedFunction,
+    preparedBody: route.recursivePreparedBody,
+    preparedInstructions: route.recursivePreparedInstructions,
+  };
+  const wrapperSlot: PreparedFunctionSlotReceipt = {
+    declaration: route.declaration,
+    unitId: route.unitId,
+    legacyName: route.legacyName,
+    receipt: route.receipt,
+    allocatedFunction: route.allocatedFunction,
+    preparedBody: route.preparedBody,
+    preparedInstructions: route.preparedInstructions,
+  };
+  const currentSyntax =
+    isExactFibonacciRecurrence(ctx, route.recursiveDeclaration) &&
+    exactFibonacciWrapperCall(ctx, route.declaration, route.recursiveDeclaration) === route.wrapperCall;
+  const candidate: MultiPreparedFibonacciPairCandidateEvidence = {
+    legacyName: route.legacyName,
+    unitId: route.unitId,
+    valueIdentifier: route.valueIdentifier,
+    legacyOwnerUnitId: route.legacyOwnerUnitId,
+    legacyOwnerName: route.legacyOwnerName,
+    importedCall: route.importedCall,
+    importedTargetUnitId: route.importedTargetUnitId,
+    recursiveDeclaration: route.recursiveDeclaration,
+    recursiveUnitId: route.recursiveUnitId,
+    recursiveName: route.recursiveName,
+    wrapperDeclaration: route.declaration,
+    wrapperCall: route.wrapperCall,
+  };
+  const names = [route.recursiveName, route.legacyName];
+  const safetyCurrent = names.every(
+    (name) =>
+      !safety.collisions.has(name) &&
+      !safety.crossFileFunctionNames.has(name) &&
+      !safety.importAliasNames.has(name) &&
+      safety.occupiedFunctionNameCounts.get(name) === 1 &&
+      !safety.occupiedFunctionKeys.some((key) => key.startsWith(`${name}$`)) &&
+      ctx.liveFuncBindingGlobals?.has(name) !== true,
+  );
+  if (
+    route.identityPlan.identityContext !== ctx.irPlanningIdentityContext ||
+    !currentSyntax ||
+    !exactFibonacciCallTopology(route.sourceFile, route.identityPlan, route.recursiveUnitId, route.unitId) ||
+    !finalSelection.funcs.has(route.recursiveName) ||
+    !finalSelection.funcs.has(route.legacyName) ||
+    finalSelection.funcs.has(route.legacyOwnerName) ||
+    !safetyCurrent ||
+    route.recursiveReceipt.kind !== "prepared" ||
+    route.receipt.kind !== "prepared" ||
+    route.recursiveReceipt.preparedComponentId !== route.preparedComponentId ||
+    route.receipt.preparedComponentId !== route.preparedComponentId ||
+    !allocatedSlotIsCurrent(ctx, recursiveSlot, 1) ||
+    !allocatedSlotIsCurrent(ctx, wrapperSlot, 0) ||
+    !multiPreparedFunctionValueUseIsCurrent(ctx.oracle, ctx.irPlanningIdentityContext, route) ||
+    !functionValueSupportIsCurrent(ctx, candidate, route.support, false) ||
+    !functionHasNoSupport(ctx, route.recursiveName)
+  ) {
+    invariant(
+      "patch",
+      `multi-source Fibonacci pair ${route.recursiveUnitId}/${route.unitId} drifted after direct-body certification`,
+    );
+  }
+}
+
+export function planEarlyMultiPreparedFunctionValueRoutes<Plan extends MultiPreparedFunctionValuePlan>(input: {
+  readonly active: boolean;
+  readonly leafCutoverEnabled: boolean;
+  readonly fibonacciPairCutoverEnabled: boolean;
+  readonly ctx: CodegenContext;
+  readonly sourceFiles: readonly ts.SourceFile[];
+  readonly entryFile: ts.SourceFile;
+  readonly safety: () => MultiPreparedScalarLeafGraphSafety;
+  readonly planSource: (sourceFile: ts.SourceFile) => Plan;
+  readonly safeSelection: (
+    plan: Plan,
+    sourceFile: ts.SourceFile,
+    safety: MultiPreparedScalarLeafGraphSafety,
+  ) => IrSelection;
+  readonly hasForeignLateProvider: (
+    plan: Plan,
+    sourceFile: ts.SourceFile,
+    unitId: IrUnitId,
+    functionValueTarget: boolean,
+  ) => boolean;
+  readonly prepareFunctionValueSupport: (
+    plan: Plan,
+    sourceFile: ts.SourceFile,
+    unitId: IrUnitId,
+    legacyName: string,
+  ) => MultiPreparedFunctionValueSupportReceipt | undefined;
+  readonly projectLoweringPlans: (plan: Plan, selection: IrSelection) => IrIntegrationLoweringPlans;
+}): Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<Plan>> {
+  const leafStates = planEarlyMultiPreparedFunctionValueLeafRoute({
+    active: input.active,
+    cutoverEnabled: input.leafCutoverEnabled,
+    ctx: input.ctx,
+    sourceFiles: input.sourceFiles,
+    entryFile: input.entryFile,
+    safety: input.safety,
+    planSource: input.planSource,
+    safeSelection: input.safeSelection,
+    hasForeignLateProvider: (plan, sourceFile, unitId) => input.hasForeignLateProvider(plan, sourceFile, unitId, true),
+    prepareFunctionValueSupport: input.prepareFunctionValueSupport,
+    projectLoweringPlans: input.projectLoweringPlans,
+  });
+  if (leafStates.size !== 0) return leafStates;
+  const states = new Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<Plan>>();
+  if (!input.active || collectMultiPreparedScalarLeafCandidates(input.sourceFiles).length !== 0) {
+    if (process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_FIB_PAIR === "1") {
+      invariant("resolve", "required multi-source Fibonacci pair failed its active/competing-route gate");
+    }
+    return states;
+  }
+  const syntax = collectExactFibonacciPairSyntax(input.ctx, input.sourceFiles);
+  if (syntax.recurrences.length !== 1 || syntax.pairs.length !== 1) {
+    if (process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_FIB_PAIR === "1") {
+      invariant(
+        "resolve",
+        `required multi-source Fibonacci pair found ${syntax.recurrences.length} recurrences/${syntax.pairs.length} wrappers`,
+      );
+    }
+    return states;
+  }
+  const exactSyntax = syntax.pairs[0]!;
+  if (exactSyntax.sourceFile !== input.entryFile) return states;
+  const safety = input.safety();
+  const plan = input.planSource(exactSyntax.sourceFile);
+  const safeSelection = input.safeSelection(plan, exactSyntax.sourceFile, safety);
+  const candidate = resolveExactFibonacciPair({
+    ctx: input.ctx,
+    syntax: exactSyntax,
+    plan,
+    safeSelection,
+    safety,
+    hasForeignLateProvider: (recursiveUnitId, wrapperUnitId) =>
+      input.hasForeignLateProvider(plan, exactSyntax.sourceFile, recursiveUnitId, false) ||
+      input.hasForeignLateProvider(plan, exactSyntax.sourceFile, wrapperUnitId, true),
+  });
+  if (!candidate) return states;
+  const state: EarlyMultiPreparedScalarLeafState<Plan> = { plan, skippedFunctionUnitIds: new Set() };
+  states.set(exactSyntax.sourceFile, state);
+  if (!input.fibonacciPairCutoverEnabled) return states;
+  const support = input.prepareFunctionValueSupport(
+    plan,
+    exactSyntax.sourceFile,
+    candidate.unitId,
+    candidate.legacyName,
+  );
+  if (!support || !functionValueSupportIsCurrent(input.ctx, candidate, support, true)) {
+    invariant("resolve", `multi-source Fibonacci pair ${candidate.unitId} could not preallocate exact support`);
+  }
+  const route = tryPrepareExactFibonacciPair({
+    ctx: input.ctx,
+    sourceFile: exactSyntax.sourceFile,
+    plan,
+    candidate,
+    support,
+    projectLoweringPlans: (selection) => input.projectLoweringPlans(plan, selection),
+  });
+  if (route) states.set(exactSyntax.sourceFile, { plan, route, skippedFunctionUnitIds: new Set() });
+  return states;
+}

--- a/src/codegen/multi-prepared-function-value-import-target.ts
+++ b/src/codegen/multi-prepared-function-value-import-target.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { TypeOracle } from "../checker/oracle.js";
+import type { IrPlanningIdentityContext } from "../ir/planning-identity.js";
+import { ts } from "../ts-api.js";
+import { hasDeclareModifier, hasExportModifier } from "./ast-modifiers.js";
+
+function exactRelativeModuleSourceKey(importerSourceKey: string, specifier: string): string | undefined {
+  if (!specifier.startsWith("./") && !specifier.startsWith("../")) return undefined;
+  const parts = importerSourceKey.split("/").slice(0, -1);
+  for (const part of specifier.replace(/\\/g, "/").split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (parts.length === 0) return undefined;
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+  return parts.join("/");
+}
+
+/** Resolve one exact direct named import through the canonical source inventory. */
+export function resolveMultiPreparedFunctionValueImportTarget(input: {
+  readonly oracle: Pick<TypeOracle, "declarationsOf" | "valueDeclarationOf">;
+  readonly sourceFile: ts.SourceFile;
+  readonly callee: ts.Identifier;
+  readonly identityContext: IrPlanningIdentityContext;
+}): ts.FunctionDeclaration | undefined {
+  const { callee, identityContext, oracle, sourceFile } = input;
+  const localImport = oracle.valueDeclarationOf(callee);
+  const localDeclarations = oracle.declarationsOf(callee);
+  if (
+    !localImport ||
+    !ts.isImportSpecifier(localImport) ||
+    localImport.isTypeOnly ||
+    localImport.name.text !== callee.text ||
+    localDeclarations.length !== 1 ||
+    localDeclarations[0] !== localImport
+  ) {
+    return undefined;
+  }
+  const namedImports = localImport.parent;
+  const importClause = namedImports.parent;
+  const importDeclaration = importClause.parent;
+  if (
+    !ts.isNamedImports(namedImports) ||
+    !ts.isImportClause(importClause) ||
+    importClause.isTypeOnly ||
+    importClause.namedBindings !== namedImports ||
+    !ts.isImportDeclaration(importDeclaration) ||
+    importDeclaration.parent !== sourceFile ||
+    importDeclaration.importClause !== importClause ||
+    !ts.isStringLiteral(importDeclaration.moduleSpecifier)
+  ) {
+    return undefined;
+  }
+  const importerSourceId = identityContext.sourceIdBySourceFile.get(sourceFile);
+  const importerRecord = identityContext.inventory.sources.find((record) => record.id === importerSourceId);
+  if (
+    !importerSourceId ||
+    !importerRecord ||
+    identityContext.sourceFileBySourceId.get(importerSourceId) !== sourceFile
+  ) {
+    return undefined;
+  }
+  const targetSourceKey = exactRelativeModuleSourceKey(
+    importerRecord.sourceKey,
+    importDeclaration.moduleSpecifier.text,
+  );
+  const targetRecords = targetSourceKey
+    ? identityContext.inventory.sources.filter((record) => record.sourceKey === targetSourceKey)
+    : [];
+  const targetRecord = targetRecords.length === 1 ? targetRecords[0] : undefined;
+  const targetSourceFile = targetRecord ? identityContext.sourceFileBySourceId.get(targetRecord.id) : undefined;
+  if (!targetRecord || !targetSourceFile || targetSourceFile === sourceFile || targetSourceFile.isDeclarationFile) {
+    return undefined;
+  }
+  const importedName = (localImport.propertyName ?? localImport.name).text;
+  const syntacticTargets = targetSourceFile.statements.filter(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) &&
+      !!statement.name &&
+      statement.name.text === importedName &&
+      !!statement.body &&
+      hasExportModifier(statement) &&
+      !hasDeclareModifier(statement),
+  );
+  if (syntacticTargets.length !== 1) return undefined;
+  const target = syntacticTargets[0]!;
+  return target.name && oracle.valueDeclarationOf(target.name) === target ? target : undefined;
+}

--- a/src/codegen/multi-prepared-function-value-import-target.ts
+++ b/src/codegen/multi-prepared-function-value-import-target.ts
@@ -6,6 +6,18 @@ import type { IrPlanningIdentityContext } from "../ir/planning-identity.js";
 import { ts } from "../ts-api.js";
 import { hasDeclareModifier, hasExportModifier } from "./ast-modifiers.js";
 
+/** Require one oracle value declaration and the same singleton declaration population. */
+export function exactOracleValueDeclaration(
+  oracle: Pick<TypeOracle, "declarationsOf" | "valueDeclarationOf">,
+  identifier: ts.Identifier,
+): ts.Declaration | undefined {
+  const valueDeclaration = oracle.valueDeclarationOf(identifier);
+  const declarations = oracle.declarationsOf(identifier);
+  return valueDeclaration && declarations.length === 1 && declarations[0] === valueDeclaration
+    ? valueDeclaration
+    : undefined;
+}
+
 function exactRelativeModuleSourceKey(importerSourceKey: string, specifier: string): string | undefined {
   if (!specifier.startsWith("./") && !specifier.startsWith("../")) return undefined;
   const parts = importerSourceKey.split("/").slice(0, -1);
@@ -29,15 +41,12 @@ export function resolveMultiPreparedFunctionValueImportTarget(input: {
   readonly identityContext: IrPlanningIdentityContext;
 }): ts.FunctionDeclaration | undefined {
   const { callee, identityContext, oracle, sourceFile } = input;
-  const localImport = oracle.valueDeclarationOf(callee);
-  const localDeclarations = oracle.declarationsOf(callee);
+  const localImport = exactOracleValueDeclaration(oracle, callee);
   if (
     !localImport ||
     !ts.isImportSpecifier(localImport) ||
     localImport.isTypeOnly ||
-    localImport.name.text !== callee.text ||
-    localDeclarations.length !== 1 ||
-    localDeclarations[0] !== localImport
+    localImport.name.text !== callee.text
   ) {
     return undefined;
   }

--- a/src/codegen/multi-prepared-function-value-import-target.ts
+++ b/src/codegen/multi-prepared-function-value-import-target.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { TypeOracle } from "../checker/oracle.js";
+import type { IrUnitId } from "../ir/identity.js";
 import type { IrPlanningIdentityContext } from "../ir/planning-identity.js";
 import { ts } from "../ts-api.js";
 import { hasDeclareModifier, hasExportModifier } from "./ast-modifiers.js";
@@ -89,4 +90,64 @@ export function resolveMultiPreparedFunctionValueImportTarget(input: {
   if (syntacticTargets.length !== 1) return undefined;
   const target = syntacticTargets[0]!;
   return target.name && oracle.valueDeclarationOf(target.name) === target ? target : undefined;
+}
+
+interface MultiPreparedFunctionValueUseReceipt {
+  readonly sourceFile: ts.SourceFile;
+  readonly declaration: ts.FunctionDeclaration;
+  readonly unitId: IrUnitId;
+  readonly legacyName: string;
+  readonly valueIdentifier: ts.Identifier;
+  readonly legacyOwnerUnitId: IrUnitId;
+  readonly legacyOwnerName: string;
+  readonly importedCall: ts.CallExpression;
+  readonly importedTargetUnitId: IrUnitId;
+}
+
+/** Re-prove the frozen imported function-value edge at the late body seam. */
+export function multiPreparedFunctionValueUseIsCurrent(
+  oracle: Pick<TypeOracle, "declarationsOf" | "valueDeclarationOf">,
+  identityContext: IrPlanningIdentityContext | undefined,
+  receipt: MultiPreparedFunctionValueUseReceipt,
+): boolean {
+  const { declaration, importedCall, sourceFile, valueIdentifier } = receipt;
+  if (
+    !identityContext ||
+    declaration.parent !== sourceFile ||
+    declaration.name?.text !== receipt.legacyName ||
+    identityContext.unitIdByDeclaration.get(declaration) !== receipt.unitId ||
+    identityContext.declarationByUnitId.get(receipt.unitId) !== declaration ||
+    valueIdentifier.parent !== importedCall ||
+    valueIdentifier.getSourceFile() !== sourceFile ||
+    oracle.valueDeclarationOf(valueIdentifier) !== declaration ||
+    importedCall.arguments.filter((argument) => argument === valueIdentifier).length !== 1 ||
+    !ts.isIdentifier(importedCall.expression)
+  ) {
+    return false;
+  }
+
+  let owner: ts.Node | undefined = importedCall.parent;
+  while (owner && owner !== sourceFile && !ts.isFunctionLike(owner)) owner = owner.parent;
+  if (
+    !owner ||
+    !ts.isFunctionDeclaration(owner) ||
+    owner.parent !== sourceFile ||
+    owner.name?.text !== receipt.legacyOwnerName ||
+    identityContext.unitIdByDeclaration.get(owner) !== receipt.legacyOwnerUnitId ||
+    identityContext.declarationByUnitId.get(receipt.legacyOwnerUnitId) !== owner
+  ) {
+    return false;
+  }
+
+  const importedTarget = resolveMultiPreparedFunctionValueImportTarget({
+    oracle,
+    sourceFile,
+    callee: importedCall.expression,
+    identityContext,
+  });
+  return (
+    importedTarget !== undefined &&
+    identityContext.unitIdByDeclaration.get(importedTarget) === receipt.importedTargetUnitId &&
+    identityContext.declarationByUnitId.get(receipt.importedTargetUnitId) === importedTarget
+  );
 }

--- a/src/codegen/multi-prepared-scalar-leaf.ts
+++ b/src/codegen/multi-prepared-scalar-leaf.ts
@@ -1,0 +1,830 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrClassId, IrUnitId } from "../ir/identity.js";
+import type { IrIntegrationLoweringPlans } from "../ir/ast-lowering-plans.js";
+import type { IrIntegrationReport, IrTypeOverrideMap } from "../ir/integration.js";
+import { asVal, type IrClassShape, type IrType } from "../ir/nodes.js";
+import { IrInvariantError } from "../ir/outcomes.js";
+import type { IrSelection } from "../ir/select.js";
+import type { Instr, WasmFunction } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+import { hasDeclareModifier } from "./ast-modifiers.js";
+import { compileDeclarations } from "./audited-declarations.js";
+import type { ModuleInitMode } from "./declarations.js";
+import { definedFuncAt } from "./func-space.js";
+import { collectLocalCallEdgesByIdentity } from "./ir-first-gate.js";
+import type { IrOverlayIdentityPlan } from "./ir-overlay-identity.js";
+import { prepareIrBodies, type PreparedIrFreeFunctionBodies } from "./ir-prepared-free-functions.js";
+import { correlateIrSkippedFunctionNames, type IrExactFunctionClaim } from "./ir-overlay-safety.js";
+
+export interface MultiPreparedScalarLeafGraphSafety {
+  readonly collisions: ReadonlySet<string>;
+  readonly crossFileFunctionNames: ReadonlySet<string>;
+  readonly importAliasNames: ReadonlySet<string>;
+  readonly occupiedFunctionKeys: readonly string[];
+  readonly occupiedFunctionNameCounts: ReadonlyMap<string, number>;
+}
+
+/** Flat function names shared by two or more source files are not safe IR keys. */
+export function collectMultiIrFunctionNameCollisions(sourceFiles: readonly ts.SourceFile[]): ReadonlySet<string> {
+  const owner = new Map<string, ts.SourceFile>();
+  const collisions = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    const namesInFile = new Set<string>();
+    for (const statement of sourceFile.statements) {
+      if (ts.isFunctionDeclaration(statement) && statement.name && statement.body && !hasDeclareModifier(statement)) {
+        namesInFile.add(statement.name.text);
+      }
+    }
+    for (const name of namesInFile) {
+      const previous = owner.get(name);
+      if (previous && previous !== sourceFile) collisions.add(name);
+      else owner.set(name, sourceFile);
+    }
+  }
+  return collisions;
+}
+
+function collectMultiImportAliasNames(sourceFiles: readonly ts.SourceFile[]): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    for (const statement of sourceFile.statements) {
+      if (ts.isImportDeclaration(statement)) {
+        const clause = statement.importClause;
+        if (!clause) continue;
+        if (clause.name) names.add(clause.name.text);
+        if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+          names.add(clause.namedBindings.name.text);
+        } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+          for (const element of clause.namedBindings.elements) {
+            const target = (element.propertyName ?? element.name).text;
+            if (element.name.text !== target) names.add(element.name.text);
+          }
+        }
+      } else if (ts.isImportEqualsDeclaration(statement)) {
+        names.add(statement.name.text);
+      }
+    }
+  }
+  return names;
+}
+
+function collectMultiImportedFunctionNames(
+  sourceFiles: readonly ts.SourceFile[],
+  checker: ts.TypeChecker,
+): ReadonlySet<string> {
+  const names = new Set<string>();
+  const allFunctionNames = new Set(
+    sourceFiles.flatMap((sourceFile) =>
+      sourceFile.statements.flatMap((statement) =>
+        ts.isFunctionDeclaration(statement) && statement.name && statement.body ? [statement.name.text] : [],
+      ),
+    ),
+  );
+  const addFunctionDeclarations = (symbol: ts.Symbol | undefined): boolean => {
+    if (!symbol) return false;
+    let target = symbol;
+    try {
+      if (target.flags & ts.SymbolFlags.Alias) target = checker.getAliasedSymbol(target);
+    } catch {
+      return false;
+    }
+    let found = false;
+    for (const declaration of target.declarations ?? []) {
+      if (ts.isFunctionDeclaration(declaration) && declaration.name) {
+        names.add(declaration.name.text);
+        found = true;
+      }
+    }
+    if (target.flags & ts.SymbolFlags.Module) {
+      for (const exported of checker.getExportsOfModule(target)) {
+        let value = exported;
+        try {
+          if (value.flags & ts.SymbolFlags.Alias) value = checker.getAliasedSymbol(value);
+        } catch {
+          for (const name of allFunctionNames) names.add(name);
+          return true;
+        }
+        for (const declaration of value.declarations ?? []) {
+          if (ts.isFunctionDeclaration(declaration) && declaration.name) {
+            names.add(declaration.name.text);
+            found = true;
+          }
+        }
+      }
+    }
+    return found;
+  };
+  const addTarget = (local: ts.Identifier, syntacticTarget?: string, conservativeAll = false): void => {
+    const found = addFunctionDeclarations(checker.getSymbolAtLocation(local));
+    if (syntacticTarget) names.add(syntacticTarget);
+    if (!found && conservativeAll) for (const name of allFunctionNames) names.add(name);
+  };
+
+  for (const sourceFile of sourceFiles) {
+    for (const statement of sourceFile.statements) {
+      if (!ts.isImportDeclaration(statement)) continue;
+      const clause = statement.importClause;
+      if (!clause) continue;
+      if (clause.name) addTarget(clause.name, undefined, true);
+      if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+        addTarget(clause.namedBindings.name, undefined, true);
+      } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+        for (const element of clause.namedBindings.elements) {
+          addTarget(element.name, (element.propertyName ?? element.name).text);
+        }
+      }
+    }
+    for (const statement of sourceFile.statements) {
+      if (ts.isImportEqualsDeclaration(statement)) addTarget(statement.name, undefined, true);
+      if (!ts.isExportDeclaration(statement) || statement.isTypeOnly || !statement.moduleSpecifier) continue;
+      if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) {
+          if (element.isTypeOnly) continue;
+          const target = element.propertyName ?? element.name;
+          if (!addFunctionDeclarations(checker.getSymbolAtLocation(target))) names.add(target.text);
+        }
+      } else if (!addFunctionDeclarations(checker.getSymbolAtLocation(statement.moduleSpecifier))) {
+        for (const name of allFunctionNames) names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+function collectMultiCrossFileFunctionNames(
+  sourceFiles: readonly ts.SourceFile[],
+  checker: ts.TypeChecker,
+): ReadonlySet<string> {
+  const names = new Set(collectMultiImportedFunctionNames(sourceFiles, checker));
+  if (!sourceFiles.some((sourceFile) => !ts.isExternalModule(sourceFile))) return names;
+  const sourceSet = new Set(sourceFiles);
+  const allFunctionNames = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    for (const statement of sourceFile.statements) {
+      if (ts.isFunctionDeclaration(statement) && statement.name && statement.body) {
+        allFunctionNames.add(statement.name.text);
+      }
+    }
+  }
+  const markUnknownTargetConservatively = (): void => {
+    for (const name of allFunctionNames) names.add(name);
+  };
+  const addResolvedTarget = (symbol: ts.Symbol | undefined, referenceFile: ts.SourceFile): void => {
+    if (!symbol) return;
+    let target = symbol;
+    if (target.flags & ts.SymbolFlags.Alias) {
+      try {
+        target = checker.getAliasedSymbol(target);
+      } catch {
+        markUnknownTargetConservatively();
+        return;
+      }
+    }
+    for (const declaration of target.declarations ?? []) {
+      if (
+        ts.isFunctionDeclaration(declaration) &&
+        declaration.name &&
+        declaration.body &&
+        sourceSet.has(declaration.getSourceFile()) &&
+        declaration.getSourceFile() !== referenceFile
+      ) {
+        names.add(declaration.name.text);
+      }
+    }
+  };
+  for (const sourceFile of sourceFiles) {
+    const visit = (node: ts.Node): void => {
+      if (ts.isIdentifier(node)) {
+        try {
+          addResolvedTarget(checker.getSymbolAtLocation(node), sourceFile);
+        } catch {
+          markUnknownTargetConservatively();
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+  return names;
+}
+
+export function buildMultiIrGraphSafety(
+  ctx: CodegenContext,
+  sourceFiles: readonly ts.SourceFile[],
+  checker: ts.TypeChecker,
+): MultiPreparedScalarLeafGraphSafety {
+  const occupiedFunctionNameCounts = new Map<string, number>();
+  for (const fn of ctx.mod.functions) {
+    occupiedFunctionNameCounts.set(fn.name, (occupiedFunctionNameCounts.get(fn.name) ?? 0) + 1);
+  }
+  return {
+    collisions: collectMultiIrFunctionNameCollisions(sourceFiles),
+    crossFileFunctionNames: collectMultiCrossFileFunctionNames(sourceFiles, checker),
+    importAliasNames: collectMultiImportAliasNames(sourceFiles),
+    occupiedFunctionKeys: [...ctx.funcMap.keys()],
+    occupiedFunctionNameCounts,
+  };
+}
+
+export interface MultiPreparedScalarLeafPlan {
+  readonly identityPlan: IrOverlayIdentityPlan;
+  readonly functionClaimsByUnitId: ReadonlyMap<IrUnitId, IrExactFunctionClaim>;
+  readonly overrideMapByUnitId: ReadonlyMap<
+    IrUnitId,
+    { readonly params: readonly IrType[]; readonly returnType: IrType | null }
+  >;
+  readonly overrideMap: IrTypeOverrideMap;
+  readonly classShapes: ReadonlyMap<string, IrClassShape>;
+  readonly classShapesById: ReadonlyMap<IrClassId, IrClassShape>;
+}
+
+export type MultiPreparedScalarLeafReceipt =
+  | {
+      readonly kind: "prepared";
+      readonly unitId: IrUnitId;
+      readonly legacyName: string;
+      readonly preparedComponentId: string;
+    }
+  | {
+      readonly kind: "invariant";
+      readonly unitId: IrUnitId;
+      readonly legacyName: string;
+    };
+
+export interface MultiPreparedScalarLeafRoute {
+  readonly sourceFile: ts.SourceFile;
+  readonly declaration: ts.FunctionDeclaration;
+  readonly unitId: IrUnitId;
+  readonly legacyName: string;
+  readonly preparedSelection: IrSelection;
+  readonly preparedReport: IrIntegrationReport;
+  readonly preparedFreeFunctions: PreparedIrFreeFunctionBodies;
+  readonly receipt: MultiPreparedScalarLeafReceipt;
+  readonly allocatedFunction: WasmFunction;
+  readonly preparedBody: WasmFunction["body"];
+  readonly preparedInstructions: readonly Instr[];
+}
+
+function invariant(stage: "resolve" | "patch", detail: string): never {
+  throw new IrInvariantError("selection-preparation-mismatch", stage, detail);
+}
+
+function isCommonJsAssignmentTarget(expression: ts.Expression): boolean {
+  let current = expression;
+  while (ts.isParenthesizedExpression(current)) current = current.expression;
+  if (ts.isIdentifier(current)) return current.text === "exports";
+  if (!ts.isPropertyAccessExpression(current) && !ts.isElementAccessExpression(current)) return false;
+  const receiver = current.expression;
+  if (ts.isIdentifier(receiver) && (receiver.text === "exports" || receiver.text === "module")) return true;
+  return isCommonJsAssignmentTarget(receiver);
+}
+
+function sourceContainsCommonJsExport(sourceFile: ts.SourceFile): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isIdentifier(node) && (node.text === "exports" || node.text === "module" || node.text === "require")) {
+      found = true;
+      return;
+    }
+    if (ts.isExportAssignment(node) && node.isExportEquals) {
+      found = true;
+      return;
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      isCommonJsAssignmentTarget(node.left)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+function hasExactNumericDeclarationSignature(declaration: ts.FunctionDeclaration): boolean {
+  return (
+    declaration.name !== undefined &&
+    declaration.body !== undefined &&
+    declaration.asteriskToken === undefined &&
+    (declaration.typeParameters?.length ?? 0) === 0 &&
+    !declaration.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) &&
+    declaration.type?.kind === ts.SyntaxKind.NumberKeyword &&
+    declaration.parameters.every(
+      (parameter) =>
+        ts.isIdentifier(parameter.name) &&
+        parameter.type?.kind === ts.SyntaxKind.NumberKeyword &&
+        parameter.questionToken === undefined &&
+        parameter.dotDotDotToken === undefined &&
+        parameter.initializer === undefined,
+    )
+  );
+}
+
+/**
+ * A syntax-only preflight used to decide whether moving multi-source IR
+ * planning before the direct body loop is even relevant. It deliberately
+ * accepts only one entry-source numeric leaf and has no mutation surface.
+ */
+function isSyntacticScalarLeaf(declaration: ts.FunctionDeclaration): boolean {
+  if (!hasExactNumericDeclarationSignature(declaration) || !declaration.body) return false;
+  const localNames = new Set(declaration.parameters.map((parameter) => (parameter.name as ts.Identifier).text));
+  let valid = true;
+
+  const collectLocals = (node: ts.Node): void => {
+    if (!valid) return;
+    if (node !== declaration.body && ts.isFunctionLike(node)) {
+      valid = false;
+      return;
+    }
+    if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+      valid = false;
+      return;
+    }
+    if (ts.isVariableDeclaration(node)) {
+      if (!ts.isIdentifier(node.name)) {
+        valid = false;
+        return;
+      }
+      localNames.add(node.name.text);
+    }
+    ts.forEachChild(node, collectLocals);
+  };
+  collectLocals(declaration.body);
+  if (!valid) return false;
+
+  const visit = (node: ts.Node): void => {
+    if (!valid) return;
+    if (
+      (ts.isBinaryExpression(node) &&
+        ![
+          ts.SyntaxKind.PlusToken,
+          ts.SyntaxKind.MinusToken,
+          ts.SyntaxKind.AsteriskToken,
+          ts.SyntaxKind.SlashToken,
+        ].includes(node.operatorToken.kind)) ||
+      (ts.isPrefixUnaryExpression(node) &&
+        node.operator !== ts.SyntaxKind.PlusToken &&
+        node.operator !== ts.SyntaxKind.MinusToken) ||
+      ts.isPostfixUnaryExpression(node)
+    ) {
+      valid = false;
+      return;
+    }
+    if (
+      (node !== declaration.body && ts.isFunctionLike(node)) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node) ||
+      ts.isCallExpression(node) ||
+      ts.isNewExpression(node) ||
+      ts.isPropertyAccessExpression(node) ||
+      ts.isElementAccessExpression(node) ||
+      ts.isObjectLiteralExpression(node) ||
+      ts.isArrayLiteralExpression(node) ||
+      ts.isThrowStatement(node) ||
+      ts.isTryStatement(node) ||
+      ts.isForInStatement(node) ||
+      ts.isForOfStatement(node) ||
+      ts.isWithStatement(node) ||
+      ts.isSpreadElement(node) ||
+      ts.isSpreadAssignment(node) ||
+      node.kind === ts.SyntaxKind.ThisKeyword ||
+      node.kind === ts.SyntaxKind.SuperKeyword ||
+      node.kind === ts.SyntaxKind.AwaitExpression ||
+      node.kind === ts.SyntaxKind.YieldExpression
+    ) {
+      valid = false;
+      return;
+    }
+    if (ts.isIdentifier(node) && !localNames.has(node.text)) {
+      valid = false;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(declaration.body);
+  return valid;
+}
+
+/** Collect syntax candidates without choosing an arbitrary graph member. */
+export function collectMultiPreparedScalarLeafCandidates(
+  sourceFiles: readonly ts.SourceFile[],
+): readonly ts.FunctionDeclaration[] {
+  if (sourceFiles.some(sourceContainsCommonJsExport)) return [];
+  return sourceFiles.flatMap((sourceFile) =>
+    sourceFile.statements.filter(
+      (statement): statement is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(statement) && isSyntacticScalarLeaf(statement),
+    ),
+  );
+}
+
+function exactAllocatedNumericCallable(
+  ctx: CodegenContext,
+  unitId: IrUnitId,
+  legacyName: string,
+  parameterCount: number,
+  requireEmptyBody: boolean,
+) {
+  const registry = ctx.programAbiSourceCallables;
+  const handle = registry?.handleForUnit(unitId);
+  const func = registry?.functionForUnit(unitId);
+  const signature = func === undefined ? undefined : ctx.mod.types[func.typeIdx];
+  if (
+    handle === undefined ||
+    func === undefined ||
+    definedFuncAt(ctx, handle) !== func ||
+    ctx.funcMap.get(legacyName) !== handle ||
+    func.name !== legacyName ||
+    (requireEmptyBody && func.body.length !== 0) ||
+    signature?.kind !== "func" ||
+    signature.params.length !== parameterCount ||
+    !signature.params.every((type) => type.kind === "f64") ||
+    signature.results.length !== 1 ||
+    signature.results[0]?.kind !== "f64"
+  ) {
+    return undefined;
+  }
+  return { handle, func, signature };
+}
+
+function isExactSingletonComponent(
+  sourceFile: ts.SourceFile,
+  unitId: IrUnitId,
+  identityPlan: IrOverlayIdentityPlan,
+): boolean {
+  const edges = collectLocalCallEdgesByIdentity(sourceFile, identityPlan.identityContext);
+  if ((edges.callees.get(unitId)?.size ?? 0) > 0 || edges.calleesFromUnownedCallers.has(unitId)) return false;
+  for (const [callerUnitId, callees] of edges.callees) {
+    if (callerUnitId !== unitId && callees.has(unitId)) return false;
+  }
+  return true;
+}
+
+function exactWithdrawal(
+  preparedReport: IrIntegrationReport,
+  prepared: PreparedIrFreeFunctionBodies,
+  unitId: IrUnitId,
+  legacyName: string,
+): boolean {
+  const terminalEvidence = preparedReport.terminalEvidence ?? [];
+  const evidence = terminalEvidence[0];
+  const emptyRoute =
+    prepared.skipBodies.size === 0 &&
+    prepared.preserveBodies.size === 0 &&
+    prepared.completedBodies.size === 0 &&
+    prepared.requestedSkipProjection.entries.length === 0 &&
+    preparedReport.compiled.length === 0 &&
+    (preparedReport.compiledArtifactEvidence?.length ?? 0) === 0 &&
+    (preparedReport.syntheticCompiledArtifacts?.length ?? 0) === 0;
+  return (
+    emptyRoute &&
+    ((preparedReport.errors.length === 0 && terminalEvidence.length === 0) ||
+      (preparedReport.errors.length === 1 &&
+        terminalEvidence.length === 1 &&
+        evidence?.kind === "failed" &&
+        evidence.unitId === unitId &&
+        evidence.legacyName === legacyName &&
+        evidence.error === preparedReport.errors[0] &&
+        evidence.error.outcome.kind === "unsupported"))
+  );
+}
+
+interface MultiPreparedScalarLeafCandidateInput {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly declaration: ts.FunctionDeclaration;
+  readonly plan: MultiPreparedScalarLeafPlan;
+  readonly safeSelection: IrSelection;
+  readonly safety: MultiPreparedScalarLeafGraphSafety;
+  readonly lateProviderOwnerUnitIds: ReadonlySet<IrUnitId>;
+}
+
+interface MultiPreparedScalarLeafCandidateEvidence {
+  readonly legacyName: string;
+  readonly unitId: IrUnitId;
+}
+
+function resolveExactCandidate(
+  input: MultiPreparedScalarLeafCandidateInput,
+): MultiPreparedScalarLeafCandidateEvidence | undefined {
+  const { ctx, declaration, plan, safeSelection, safety, sourceFile } = input;
+  if (
+    !ctx.standalone ||
+    ctx.fast ||
+    ctx.wasi ||
+    declaration.parent !== sourceFile ||
+    !declaration.name ||
+    !declaration.body
+  ) {
+    return undefined;
+  }
+  const legacyName = declaration.name.text;
+  const unitId = plan.identityPlan.identityContext.unitIdByDeclaration.get(declaration);
+  const terminal = unitId ? plan.identityPlan.identityContext.terminalByUnitId.get(unitId) : undefined;
+  const claim = unitId ? plan.functionClaimsByUnitId.get(unitId) : undefined;
+  const override = unitId ? plan.overrideMapByUnitId.get(unitId) : undefined;
+  if (
+    unitId === undefined ||
+    terminal === undefined ||
+    terminal !== plan.identityPlan.identityContext.unitByUnitId.get(unitId) ||
+    terminal.kind !== "top-level-function" ||
+    terminal.observedKind !== "function" ||
+    terminal.terminalOwnerId !== unitId ||
+    plan.identityPlan.identityContext.declarationByUnitId.get(unitId) !== declaration ||
+    claim?.declaration !== declaration ||
+    claim.legacyName !== legacyName ||
+    !safeSelection.funcs.has(legacyName) ||
+    !plan.identityPlan.safeFunctionUnitIds.has(unitId) ||
+    !override ||
+    override.params.length !== declaration.parameters.length ||
+    !override.params.every((type) => asVal(type)?.kind === "f64") ||
+    override.returnType === null ||
+    asVal(override.returnType)?.kind !== "f64" ||
+    safety.collisions.has(legacyName) ||
+    safety.crossFileFunctionNames.has(legacyName) ||
+    safety.importAliasNames.has(legacyName) ||
+    safety.occupiedFunctionNameCounts.get(legacyName) !== 1 ||
+    safety.occupiedFunctionKeys.some((key) => key.startsWith(`${legacyName}$`)) ||
+    ctx.liveFuncBindingGlobals?.has(legacyName) === true ||
+    input.lateProviderOwnerUnitIds.has(unitId) ||
+    plan.classShapes.size !== 0 ||
+    plan.classShapesById.size !== 0 ||
+    !isExactSingletonComponent(sourceFile, unitId, plan.identityPlan) ||
+    exactAllocatedNumericCallable(ctx, unitId, legacyName, declaration.parameters.length, true) === undefined
+  ) {
+    return undefined;
+  }
+  return { legacyName, unitId };
+}
+
+/** Read-only eligibility proof used before enforcing graph-wide uniqueness. */
+export function isMultiPreparedScalarLeafCandidateEligible(input: MultiPreparedScalarLeafCandidateInput): boolean {
+  return resolveExactCandidate(input) !== undefined;
+}
+
+/**
+ * Prepare one exact entry-source scalar leaf before multi-source direct body
+ * emission. All ordinary ineligibility is decided before requesting a skip;
+ * once exact Prepared evidence exists, any drift is an invariant.
+ */
+export function tryPrepareMultiSourceScalarLeaf(
+  input: MultiPreparedScalarLeafCandidateInput & {
+    readonly projectLoweringPlans: (selection: IrSelection) => IrIntegrationLoweringPlans;
+  },
+): MultiPreparedScalarLeafRoute | undefined {
+  const { ctx, declaration, plan, sourceFile } = input;
+  const candidate = resolveExactCandidate(input);
+  if (!candidate) return undefined;
+  const { legacyName, unitId } = candidate;
+
+  const preparedSelection: IrSelection = {
+    funcs: new Set([legacyName]),
+    classMembers: new Set(),
+    classMemberUnitIds: new Set(),
+    moduleInit: undefined,
+  };
+  const prepared = prepareIrBodies({
+    ctx,
+    sourceFile,
+    selection: preparedSelection,
+    identityPlan: plan.identityPlan,
+    functionClaimsByUnitId: plan.functionClaimsByUnitId,
+    overrideMap: plan.overrideMap,
+    classShapes: plan.classShapes,
+    classShapesById: plan.classShapesById,
+    projectLoweringPlans: input.projectLoweringPlans,
+  });
+  if (prepared.classMembers || prepared.moduleInit || prepared.implicitConstructorUnitIds.size !== 0) {
+    invariant("patch", `multi-source scalar leaf ${unitId} produced a foreign Prepared routing family`);
+  }
+  if (prepared.freeFunctions.skipBodies.size === 0) {
+    if (
+      exactWithdrawal(prepared.report, prepared.freeFunctions, unitId, legacyName) &&
+      exactAllocatedNumericCallable(ctx, unitId, legacyName, declaration.parameters.length, true)
+    ) {
+      return undefined;
+    }
+    invariant("patch", `multi-source scalar leaf ${unitId} did not withdraw atomically before its skip`);
+  }
+
+  const requested = prepared.freeFunctions.requestedSkipProjection.entries;
+  const terminalEvidence = prepared.report.terminalEvidence ?? [];
+  const artifactEvidence = prepared.report.compiledArtifactEvidence ?? [];
+  const evidence = terminalEvidence[0];
+  const artifact = artifactEvidence[0];
+  const exactSets =
+    requested.length === 1 &&
+    requested[0]?.unitId === unitId &&
+    requested[0]?.legacyName === legacyName &&
+    prepared.freeFunctions.skipBodies.size === 1 &&
+    prepared.freeFunctions.skipBodies.has(legacyName) &&
+    prepared.freeFunctions.completedBodies.size === 1 &&
+    prepared.freeFunctions.completedBodies.has(legacyName) &&
+    (prepared.report.syntheticCompiledArtifacts?.length ?? 0) === 0;
+  if (!exactSets || terminalEvidence.length !== 1) {
+    invariant("patch", `multi-source scalar leaf ${unitId} produced a non-exact Prepared route receipt`);
+  }
+
+  let receipt: MultiPreparedScalarLeafReceipt;
+  if (evidence?.kind === "patched") {
+    if (
+      evidence.unitId !== unitId ||
+      evidence.legacyName !== legacyName ||
+      evidence.preparedComponentId === undefined ||
+      prepared.report.errors.length !== 0 ||
+      prepared.report.compiled.length !== 1 ||
+      prepared.report.compiled[0] !== legacyName ||
+      prepared.report.terminalCompiledOwners?.length !== 1 ||
+      prepared.report.terminalCompiledOwners[0] !== legacyName ||
+      artifactEvidence.length !== 1 ||
+      artifact?.artifactUnitId !== unitId ||
+      artifact?.terminalOwnerUnitId !== unitId ||
+      artifact?.name !== legacyName ||
+      artifact?.preparedComponentId !== evidence.preparedComponentId ||
+      prepared.freeFunctions.preserveBodies.size !== 1 ||
+      !prepared.freeFunctions.preserveBodies.has(legacyName)
+    ) {
+      invariant("patch", `multi-source scalar leaf ${unitId} lost its exact Prepared Program ABI receipt`);
+    }
+    receipt = {
+      kind: "prepared",
+      unitId,
+      legacyName,
+      preparedComponentId: evidence.preparedComponentId,
+    };
+  } else {
+    if (
+      evidence?.kind !== "failed" ||
+      evidence.unitId !== unitId ||
+      evidence.legacyName !== legacyName ||
+      evidence.error.outcome.kind !== "invariant" ||
+      artifactEvidence.length !== 0 ||
+      prepared.freeFunctions.preserveBodies.size !== 0
+    ) {
+      invariant("patch", `multi-source scalar leaf ${unitId} failed without an exact invariant receipt`);
+    }
+    receipt = { kind: "invariant", unitId, legacyName };
+  }
+
+  const allocated = exactAllocatedNumericCallable(ctx, unitId, legacyName, declaration.parameters.length, false);
+  if (!allocated || (receipt.kind === "prepared" && allocated.func.body.length === 0)) {
+    invariant("patch", `multi-source scalar leaf ${unitId} drifted after Prepared certification`);
+  }
+
+  return Object.freeze({
+    sourceFile,
+    declaration,
+    unitId,
+    legacyName,
+    preparedSelection,
+    preparedReport: prepared.report,
+    preparedFreeFunctions: prepared.freeFunctions,
+    receipt,
+    allocatedFunction: allocated.func,
+    preparedBody: allocated.func.body,
+    preparedInstructions: Object.freeze([...allocated.func.body]),
+  });
+}
+
+export interface EarlyMultiPreparedScalarLeafState<Plan extends MultiPreparedScalarLeafPlan> {
+  readonly plan: Plan;
+  readonly route?: MultiPreparedScalarLeafRoute;
+  skippedFunctionUnitIds: ReadonlySet<IrUnitId>;
+}
+
+export function compileMultiPreparedScalarLeafDeclarations<Plan extends MultiPreparedScalarLeafPlan>(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  state: EarlyMultiPreparedScalarLeafState<Plan> | undefined,
+  moduleInitMode: ModuleInitMode,
+): void {
+  const skippedNames = compileDeclarations(
+    ctx,
+    sourceFile,
+    state?.route?.preparedFreeFunctions.skipBodies,
+    state?.route?.preparedFreeFunctions.preserveBodies,
+    undefined,
+    moduleInitMode,
+  );
+  if (state?.route) {
+    state.skippedFunctionUnitIds = correlateIrSkippedFunctionNames(
+      state.route.preparedFreeFunctions.requestedSkipProjection,
+      skippedNames ?? [],
+    ).unitIds;
+  }
+}
+
+/**
+ * Plan every candidate-bearing source at the shared pre-body seam, prove that
+ * exactly one graph candidate survives, and prepare only when it belongs to
+ * the entry source. Kill-switch controls carry the same plans without a route.
+ */
+export function planEarlyMultiPreparedScalarLeafRoute<Plan extends MultiPreparedScalarLeafPlan>(input: {
+  readonly active: boolean;
+  readonly cutoverEnabled: boolean;
+  readonly ctx: CodegenContext;
+  readonly sourceFiles: readonly ts.SourceFile[];
+  readonly entryFile: ts.SourceFile;
+  readonly safety: () => MultiPreparedScalarLeafGraphSafety;
+  readonly planSource: (sourceFile: ts.SourceFile) => Plan;
+  readonly safeSelection: (
+    plan: Plan,
+    sourceFile: ts.SourceFile,
+    safety: MultiPreparedScalarLeafGraphSafety,
+  ) => IrSelection;
+  readonly lateProviderOwnerUnitIds: (plan: Plan, sourceFile: ts.SourceFile) => ReadonlySet<IrUnitId>;
+  readonly projectLoweringPlans: (plan: Plan, selection: IrSelection) => IrIntegrationLoweringPlans;
+}): Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<Plan>> {
+  const states = new Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<Plan>>();
+  if (!input.active) return states;
+  const candidates = collectMultiPreparedScalarLeafCandidates(input.sourceFiles);
+  if (candidates.length === 0) return states;
+  const safety = input.safety();
+  const eligible: Array<{
+    declaration: ts.FunctionDeclaration;
+    sourceFile: ts.SourceFile;
+    plan: Plan;
+    safeSelection: IrSelection;
+    lateProviderOwnerUnitIds: ReadonlySet<IrUnitId>;
+  }> = [];
+  for (const declaration of candidates) {
+    const sourceFile = declaration.getSourceFile();
+    let state = states.get(sourceFile);
+    if (!state) {
+      state = { plan: input.planSource(sourceFile), skippedFunctionUnitIds: new Set() };
+      states.set(sourceFile, state);
+    }
+    const safeSelection = input.safeSelection(state.plan, sourceFile, safety);
+    const lateProviderOwnerUnitIds = input.lateProviderOwnerUnitIds(state.plan, sourceFile);
+    if (
+      isMultiPreparedScalarLeafCandidateEligible({
+        ctx: input.ctx,
+        sourceFile,
+        declaration,
+        plan: state.plan,
+        safeSelection,
+        safety,
+        lateProviderOwnerUnitIds,
+      })
+    ) {
+      eligible.push({ declaration, sourceFile, plan: state.plan, safeSelection, lateProviderOwnerUnitIds });
+    }
+  }
+  const exact = eligible.length === 1 ? eligible[0] : undefined;
+  if (!input.cutoverEnabled || exact?.sourceFile !== input.entryFile) return states;
+  const route = tryPrepareMultiSourceScalarLeaf({
+    ctx: input.ctx,
+    sourceFile: exact.sourceFile,
+    declaration: exact.declaration,
+    plan: exact.plan,
+    safeSelection: exact.safeSelection,
+    safety,
+    lateProviderOwnerUnitIds: exact.lateProviderOwnerUnitIds,
+    projectLoweringPlans: (selection) => input.projectLoweringPlans(exact.plan, selection),
+  });
+  if (route) states.set(exact.sourceFile, { plan: exact.plan, route, skippedFunctionUnitIds: new Set() });
+  return states;
+}
+
+/** Re-prove the exact leaf after all other direct bodies have run. */
+export function assertMultiPreparedScalarLeafRouteCurrent(input: {
+  readonly ctx: CodegenContext;
+  readonly route: MultiPreparedScalarLeafRoute;
+  readonly finalSelection: IrSelection;
+  readonly safety: MultiPreparedScalarLeafGraphSafety;
+}): void {
+  const { ctx, finalSelection, route, safety } = input;
+  if (process.env.JS2WASM_TEST_TAMPER_MULTI_PREPARED_SCALAR_LEAF?.split(",").includes(route.legacyName)) {
+    route.allocatedFunction.name = `${route.legacyName}$tampered`;
+  }
+  const allocated = exactAllocatedNumericCallable(
+    ctx,
+    route.unitId,
+    route.legacyName,
+    route.declaration.parameters.length,
+    false,
+  );
+  if (
+    !finalSelection.funcs.has(route.legacyName) ||
+    safety.collisions.has(route.legacyName) ||
+    safety.crossFileFunctionNames.has(route.legacyName) ||
+    safety.importAliasNames.has(route.legacyName) ||
+    safety.occupiedFunctionNameCounts.get(route.legacyName) !== 1 ||
+    safety.occupiedFunctionKeys.some((key) => key.startsWith(`${route.legacyName}$`)) ||
+    ctx.liveFuncBindingGlobals?.has(route.legacyName) === true ||
+    !allocated ||
+    allocated.func !== route.allocatedFunction ||
+    allocated.func.body !== route.preparedBody ||
+    allocated.func.body.length !== route.preparedInstructions.length ||
+    allocated.func.body.some((instruction, index) => instruction !== route.preparedInstructions[index]) ||
+    (route.receipt.kind === "prepared" && allocated.func.body.length === 0)
+  ) {
+    invariant("patch", `multi-source scalar leaf ${route.unitId} drifted after direct-body certification`);
+  }
+}

--- a/src/codegen/multi-prepared-scalar-leaf.ts
+++ b/src/codegen/multi-prepared-scalar-leaf.ts
@@ -303,7 +303,10 @@ export interface MultiPreparedFunctionValueLeafRoute extends MultiPreparedLeafRo
   readonly support: MultiPreparedFunctionValueSupportReceipt;
 }
 
-export type MultiPreparedEarlyLeafRoute = MultiPreparedScalarLeafRoute | MultiPreparedFunctionValueLeafRoute;
+export type MultiPreparedEarlyLeafRoute =
+  | MultiPreparedScalarLeafRoute
+  | MultiPreparedFunctionValueLeafRoute
+  | import("./multi-prepared-fibonacci-pair.js").MultiPreparedFibonacciPairRoute;
 
 function invariant(stage: "resolve" | "patch", detail: string): never {
   throw new IrInvariantError("selection-preparation-mismatch", stage, detail);
@@ -319,7 +322,7 @@ function isCommonJsAssignmentTarget(expression: ts.Expression): boolean {
   return isCommonJsAssignmentTarget(receiver);
 }
 
-function sourceContainsCommonJsExport(sourceFile: ts.SourceFile): boolean {
+export function sourceContainsCommonJsExport(sourceFile: ts.SourceFile): boolean {
   let found = false;
   const visit = (node: ts.Node): void => {
     if (found) return;
@@ -345,7 +348,7 @@ function sourceContainsCommonJsExport(sourceFile: ts.SourceFile): boolean {
   return found;
 }
 
-function hasExactNumericDeclarationSignature(declaration: ts.FunctionDeclaration): boolean {
+export function hasExactNumericDeclarationSignature(declaration: ts.FunctionDeclaration): boolean {
   return (
     declaration.name !== undefined &&
     declaration.body !== undefined &&
@@ -472,7 +475,7 @@ function unwrapParentheses(expression: ts.Expression): ts.Expression {
   return current;
 }
 
-function identifierResolvesExactly(
+export function identifierResolvesExactly(
   ctx: CodegenContext,
   identifier: ts.Identifier,
   declaration: ts.Declaration,
@@ -579,7 +582,7 @@ function collectMultiPreparedReductionLeafCandidates(
   );
 }
 
-function exactAllocatedNumericCallable(
+export function exactAllocatedNumericCallable(
   ctx: CodegenContext,
   unitId: IrUnitId,
   legacyName: string,
@@ -679,7 +682,7 @@ interface MultiPreparedFunctionValueCandidateInput<Plan extends MultiPreparedFun
   readonly hasForeignLateProvider: (unitId: IrUnitId) => boolean;
 }
 
-interface MultiPreparedFunctionValueCandidateEvidence extends MultiPreparedScalarLeafCandidateEvidence {
+export interface MultiPreparedFunctionValueCandidateEvidence extends MultiPreparedScalarLeafCandidateEvidence {
   readonly valueIdentifier: ts.Identifier;
   readonly legacyOwnerUnitId: IrUnitId;
   readonly legacyOwnerName: string;
@@ -879,7 +882,7 @@ function resolveExactFunctionValueCandidate<Plan extends MultiPreparedFunctionVa
   };
 }
 
-function functionValueSupportIsCurrent(
+export function functionValueSupportIsCurrent(
   ctx: CodegenContext,
   candidate: MultiPreparedFunctionValueCandidateEvidence,
   support: MultiPreparedFunctionValueSupportReceipt,
@@ -1333,11 +1336,7 @@ export function planEarlyMultiPreparedScalarLeafRoute<Plan extends MultiPrepared
   return states;
 }
 
-/**
- * Prepare the one structural reduction leaf whose value crosses an imported
- * source-call boundary. This route is intentionally separate from #4589: its
- * one allowed late-provider edge is proved and preallocated explicitly.
- */
+/** Prepare the exact reduction leaf whose value crosses an imported source-call boundary. */
 export function planEarlyMultiPreparedFunctionValueLeafRoute<Plan extends MultiPreparedFunctionValuePlan>(input: {
   readonly active: boolean;
   readonly cutoverEnabled: boolean;

--- a/src/codegen/multi-prepared-scalar-leaf.ts
+++ b/src/codegen/multi-prepared-scalar-leaf.ts
@@ -20,7 +20,10 @@ import { collectLocalCallEdgesByIdentity } from "./ir-first-gate.js";
 import type { IrOverlayIdentityPlan } from "./ir-overlay-identity.js";
 import { prepareIrBodies, type PreparedIrFreeFunctionBodies } from "./ir-prepared-free-functions.js";
 import { correlateIrSkippedFunctionNames, type IrExactFunctionClaim } from "./ir-overlay-safety.js";
-import { resolveMultiPreparedFunctionValueImportTarget } from "./multi-prepared-function-value-import-target.js";
+import {
+  multiPreparedFunctionValueUseIsCurrent,
+  resolveMultiPreparedFunctionValueImportTarget,
+} from "./multi-prepared-function-value-import-target.js";
 import { localGlobalIdx } from "./registry/imports.js";
 
 export interface MultiPreparedScalarLeafGraphSafety {
@@ -1486,6 +1489,7 @@ export function assertMultiPreparedFunctionValueLeafRouteCurrent(input: {
     allocated.func.body.length !== route.preparedInstructions.length ||
     allocated.func.body.some((instruction, index) => instruction !== route.preparedInstructions[index]) ||
     (route.receipt.kind === "prepared" && allocated.func.body.length === 0) ||
+    !multiPreparedFunctionValueUseIsCurrent(ctx.oracle, ctx.irPlanningIdentityContext, route) ||
     !functionValueSupportIsCurrent(ctx, candidate, route.support, false)
   ) {
     invariant("patch", `multi-source function-value leaf ${route.unitId} drifted after direct-body certification`);

--- a/src/codegen/multi-prepared-scalar-leaf.ts
+++ b/src/codegen/multi-prepared-scalar-leaf.ts
@@ -1,12 +1,15 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import type { IrClassId, IrUnitId } from "../ir/identity.js";
+import { irGlobalBindingKey } from "../ir/abi-bindings.js";
+import { irCallableBindingKey } from "../ir/callable-bindings.js";
+import { absoluteFuncIndex } from "../emit/resolve-layout.js";
+import type { IrBindingId, IrClassId, IrUnitId } from "../ir/identity.js";
 import type { IrIntegrationLoweringPlans } from "../ir/ast-lowering-plans.js";
 import type { IrIntegrationReport, IrTypeOverrideMap } from "../ir/integration.js";
-import { asVal, type IrClassShape, type IrType } from "../ir/nodes.js";
+import { asVal, type IrClassShape, type IrFuncRef, type IrGlobalRef, type IrType } from "../ir/nodes.js";
 import { IrInvariantError } from "../ir/outcomes.js";
 import type { IrSelection } from "../ir/select.js";
-import type { Instr, WasmFunction } from "../ir/types.js";
+import type { FuncHandle, GlobalDef, Instr, WasmFunction } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import type { CodegenContext } from "./context/types.js";
 import { hasDeclareModifier } from "./ast-modifiers.js";
@@ -17,6 +20,8 @@ import { collectLocalCallEdgesByIdentity } from "./ir-first-gate.js";
 import type { IrOverlayIdentityPlan } from "./ir-overlay-identity.js";
 import { prepareIrBodies, type PreparedIrFreeFunctionBodies } from "./ir-prepared-free-functions.js";
 import { correlateIrSkippedFunctionNames, type IrExactFunctionClaim } from "./ir-overlay-safety.js";
+import { resolveMultiPreparedFunctionValueImportTarget } from "./multi-prepared-function-value-import-target.js";
+import { localGlobalIdx } from "./registry/imports.js";
 
 export interface MultiPreparedScalarLeafGraphSafety {
   readonly collisions: ReadonlySet<string>;
@@ -253,7 +258,7 @@ export type MultiPreparedScalarLeafReceipt =
       readonly legacyName: string;
     };
 
-export interface MultiPreparedScalarLeafRoute {
+interface MultiPreparedLeafRouteBase {
   readonly sourceFile: ts.SourceFile;
   readonly declaration: ts.FunctionDeclaration;
   readonly unitId: IrUnitId;
@@ -266,6 +271,36 @@ export interface MultiPreparedScalarLeafRoute {
   readonly preparedBody: WasmFunction["body"];
   readonly preparedInstructions: readonly Instr[];
 }
+
+export interface MultiPreparedScalarLeafRoute extends MultiPreparedLeafRouteBase {
+  readonly routeKind: "scalar";
+}
+
+/** Exact allocator objects frozen before a legacy owner reads a prepared function value. */
+export interface MultiPreparedFunctionValueSupportReceipt {
+  readonly targetFunction: WasmFunction;
+  readonly targetHandle: FuncHandle;
+  readonly trampolineFunction: WasmFunction;
+  readonly trampolineHandle: FuncHandle;
+  readonly trampolineRef: IrFuncRef;
+  readonly trampolineBindingId: IrBindingId;
+  readonly cacheGlobal: GlobalDef;
+  readonly cacheGlobalHandle: number;
+  readonly cacheGlobalRef: IrGlobalRef;
+  readonly cacheGlobalBindingId: IrBindingId;
+}
+
+export interface MultiPreparedFunctionValueLeafRoute extends MultiPreparedLeafRouteBase {
+  readonly routeKind: "function-value";
+  readonly valueIdentifier: ts.Identifier;
+  readonly legacyOwnerUnitId: IrUnitId;
+  readonly legacyOwnerName: string;
+  readonly importedCall: ts.CallExpression;
+  readonly importedTargetUnitId: IrUnitId;
+  readonly support: MultiPreparedFunctionValueSupportReceipt;
+}
+
+export type MultiPreparedEarlyLeafRoute = MultiPreparedScalarLeafRoute | MultiPreparedFunctionValueLeafRoute;
 
 function invariant(stage: "resolve" | "patch", detail: string): never {
   throw new IrInvariantError("selection-preparation-mismatch", stage, detail);
@@ -424,6 +459,123 @@ export function collectMultiPreparedScalarLeafCandidates(
   );
 }
 
+function numericLiteralIs(node: ts.Expression | undefined, text: string): node is ts.NumericLiteral {
+  return node !== undefined && ts.isNumericLiteral(node) && node.text === text;
+}
+
+function unwrapParentheses(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (ts.isParenthesizedExpression(current)) current = current.expression;
+  return current;
+}
+
+function identifierResolvesExactly(
+  ctx: CodegenContext,
+  identifier: ts.Identifier,
+  declaration: ts.Declaration,
+): boolean {
+  return ctx.oracle.valueDeclarationOf(identifier) === declaration;
+}
+
+/** Exact source-identity-proven i32 reduction; deliberately disjoint from #4589. */
+function isExactPreparedReductionLeaf(ctx: CodegenContext, declaration: ts.FunctionDeclaration): boolean {
+  if (!hasExactNumericDeclarationSignature(declaration) || declaration.parameters.length !== 0 || !declaration.body) {
+    return false;
+  }
+  const [seedStatement, loopStatement, returnStatement] = declaration.body.statements;
+  if (
+    declaration.body.statements.length !== 3 ||
+    !seedStatement ||
+    !ts.isVariableStatement(seedStatement) ||
+    (seedStatement.declarationList.flags & ts.NodeFlags.Let) === 0 ||
+    seedStatement.declarationList.declarations.length !== 1 ||
+    !loopStatement ||
+    !ts.isForStatement(loopStatement) ||
+    !returnStatement ||
+    !ts.isReturnStatement(returnStatement)
+  ) {
+    return false;
+  }
+  const seed = seedStatement.declarationList.declarations[0];
+  if (!seed || !ts.isIdentifier(seed.name) || seed.type !== undefined || !numericLiteralIs(seed.initializer, "0")) {
+    return false;
+  }
+  const initializer = loopStatement.initializer;
+  if (
+    !initializer ||
+    !ts.isVariableDeclarationList(initializer) ||
+    (initializer.flags & ts.NodeFlags.Let) === 0 ||
+    initializer.declarations.length !== 1
+  ) {
+    return false;
+  }
+  const counter = initializer.declarations[0];
+  if (
+    !counter ||
+    !ts.isIdentifier(counter.name) ||
+    counter.type !== undefined ||
+    !numericLiteralIs(counter.initializer, "0")
+  ) {
+    return false;
+  }
+  const condition = loopStatement.condition;
+  const incrementor = loopStatement.incrementor;
+  const body = loopStatement.statement;
+  if (
+    !condition ||
+    !ts.isBinaryExpression(condition) ||
+    condition.operatorToken.kind !== ts.SyntaxKind.LessThanToken ||
+    !ts.isIdentifier(condition.left) ||
+    !identifierResolvesExactly(ctx, condition.left, counter) ||
+    !numericLiteralIs(condition.right, "1000000") ||
+    !incrementor ||
+    !ts.isPostfixUnaryExpression(incrementor) ||
+    incrementor.operator !== ts.SyntaxKind.PlusPlusToken ||
+    !ts.isIdentifier(incrementor.operand) ||
+    !identifierResolvesExactly(ctx, incrementor.operand, counter) ||
+    !ts.isExpressionStatement(body) ||
+    !ts.isBinaryExpression(body.expression) ||
+    body.expression.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+    !ts.isIdentifier(body.expression.left) ||
+    !identifierResolvesExactly(ctx, body.expression.left, seed)
+  ) {
+    return false;
+  }
+  const wrapped = unwrapParentheses(body.expression.right);
+  if (
+    !ts.isBinaryExpression(wrapped) ||
+    wrapped.operatorToken.kind !== ts.SyntaxKind.BarToken ||
+    !numericLiteralIs(wrapped.right, "0")
+  ) {
+    return false;
+  }
+  const sum = unwrapParentheses(wrapped.left);
+  return (
+    ts.isBinaryExpression(sum) &&
+    sum.operatorToken.kind === ts.SyntaxKind.PlusToken &&
+    ts.isIdentifier(sum.left) &&
+    identifierResolvesExactly(ctx, sum.left, seed) &&
+    ts.isIdentifier(sum.right) &&
+    identifierResolvesExactly(ctx, sum.right, counter) &&
+    returnStatement.expression !== undefined &&
+    ts.isIdentifier(returnStatement.expression) &&
+    identifierResolvesExactly(ctx, returnStatement.expression, seed)
+  );
+}
+
+function collectMultiPreparedReductionLeafCandidates(
+  ctx: CodegenContext,
+  sourceFiles: readonly ts.SourceFile[],
+): readonly ts.FunctionDeclaration[] {
+  if (sourceFiles.some(sourceContainsCommonJsExport)) return [];
+  return sourceFiles.flatMap((sourceFile) =>
+    sourceFile.statements.filter(
+      (statement): statement is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(statement) && isExactPreparedReductionLeaf(ctx, statement),
+    ),
+  );
+}
+
 function exactAllocatedNumericCallable(
   ctx: CodegenContext,
   unitId: IrUnitId,
@@ -510,6 +662,28 @@ interface MultiPreparedScalarLeafCandidateEvidence {
   readonly unitId: IrUnitId;
 }
 
+export interface MultiPreparedFunctionValuePlan extends MultiPreparedScalarLeafPlan {
+  readonly selection: IrSelection;
+}
+
+interface MultiPreparedFunctionValueCandidateInput<Plan extends MultiPreparedFunctionValuePlan> {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly declaration: ts.FunctionDeclaration;
+  readonly plan: Plan;
+  readonly safeSelection: IrSelection;
+  readonly safety: MultiPreparedScalarLeafGraphSafety;
+  readonly hasForeignLateProvider: (unitId: IrUnitId) => boolean;
+}
+
+interface MultiPreparedFunctionValueCandidateEvidence extends MultiPreparedScalarLeafCandidateEvidence {
+  readonly valueIdentifier: ts.Identifier;
+  readonly legacyOwnerUnitId: IrUnitId;
+  readonly legacyOwnerName: string;
+  readonly importedCall: ts.CallExpression;
+  readonly importedTargetUnitId: IrUnitId;
+}
+
 function resolveExactCandidate(
   input: MultiPreparedScalarLeafCandidateInput,
 ): MultiPreparedScalarLeafCandidateEvidence | undefined {
@@ -566,6 +740,235 @@ function resolveExactCandidate(
 /** Read-only eligibility proof used before enforcing graph-wide uniqueness. */
 export function isMultiPreparedScalarLeafCandidateEligible(input: MultiPreparedScalarLeafCandidateInput): boolean {
   return resolveExactCandidate(input) !== undefined;
+}
+
+function resolveExactFunctionValueCandidate<Plan extends MultiPreparedFunctionValuePlan>(
+  input: MultiPreparedFunctionValueCandidateInput<Plan>,
+): MultiPreparedFunctionValueCandidateEvidence | undefined {
+  const { ctx, declaration, plan, safeSelection, safety, sourceFile } = input;
+  const reject = (detail: string): undefined => {
+    if (process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_BENCH_LOOP === "1") {
+      invariant("resolve", `required multi-source function-value candidate rejected: ${detail}`);
+    }
+    return undefined;
+  };
+  if (!ctx.standalone) return reject("not standalone");
+  if (ctx.fast) return reject("fast");
+  if (ctx.wasi) return reject("WASI");
+  if (declaration.parent !== sourceFile) return reject("not a source child");
+  if (!declaration.name || !declaration.body) return reject("missing name/body");
+  if (!isExactPreparedReductionLeaf(ctx, declaration)) return reject("reduction shape drift");
+  const legacyName = declaration.name.text;
+  const unitId = plan.identityPlan.identityContext.unitIdByDeclaration.get(declaration);
+  const terminal = unitId ? plan.identityPlan.identityContext.terminalByUnitId.get(unitId) : undefined;
+  const claim = unitId ? plan.functionClaimsByUnitId.get(unitId) : undefined;
+  const override = unitId ? plan.overrideMapByUnitId.get(unitId) : undefined;
+  const allocated = unitId ? exactAllocatedNumericCallable(ctx, unitId, legacyName, 0, true) : undefined;
+  if (unitId === undefined) return reject("missing UnitId");
+  if (terminal === undefined) return reject("missing terminal");
+  if (terminal !== plan.identityPlan.identityContext.unitByUnitId.get(unitId)) return reject("unit/terminal mismatch");
+  if (terminal.kind !== "top-level-function" || terminal.observedKind !== "function") return reject("terminal kind");
+  if (terminal.terminalOwnerId !== unitId) return reject("terminal owner");
+  if (plan.identityPlan.identityContext.declarationByUnitId.get(unitId) !== declaration) return reject("declaration");
+  if (claim?.declaration !== declaration || claim.legacyName !== legacyName) return reject("claim");
+  if (!safeSelection.funcs.has(legacyName)) return reject("safe selection");
+  if (safeSelection.moduleInit !== undefined || (plan.selection.moduleInit?.stmtCount ?? 0) !== 0) {
+    return reject("module init");
+  }
+  if (!plan.identityPlan.safeFunctionUnitIds.has(unitId)) return reject("safe UnitId");
+  if (!override || override.params.length !== 0 || override.returnType === null) return reject("override arity");
+  if (asVal(override.returnType)?.kind !== "f64") return reject("override result");
+  if (safety.collisions.has(legacyName)) return reject("name collision");
+  if (safety.crossFileFunctionNames.has(legacyName)) return reject("cross-file name");
+  if (safety.importAliasNames.has(legacyName)) return reject("import alias");
+  if (safety.occupiedFunctionNameCounts.get(legacyName) !== 1) return reject("occupied name count");
+  if (safety.occupiedFunctionKeys.some((key) => key.startsWith(`${legacyName}$`))) return reject("occupied suffix");
+  if (ctx.liveFuncBindingGlobals?.has(legacyName) === true) return reject("live function binding");
+  if (plan.classShapes.size !== 0 || plan.classShapesById.size !== 0) return reject("class shape");
+  if (!isExactSingletonComponent(sourceFile, unitId, plan.identityPlan)) return reject("direct-call component");
+  if (allocated === undefined) return reject("source callable");
+  if (input.hasForeignLateProvider(unitId)) return reject("foreign late provider");
+  if (!ctx.programAbiSession) return reject("Program ABI session");
+  if ([...ctx.programAbiSession.derivedUnitRecords()].some((record) => record.terminalOwnerId === unitId)) {
+    return reject("derived unit");
+  }
+
+  const valueReferences: ts.Identifier[] = [];
+  const collectReferences = (node: ts.Node): void => {
+    if (
+      ts.isIdentifier(node) &&
+      node !== declaration.name &&
+      identifierResolvesExactly(ctx, node, declaration) &&
+      !(ts.isCallExpression(node.parent) && node.parent.expression === node)
+    ) {
+      valueReferences.push(node);
+    }
+    ts.forEachChild(node, collectReferences);
+  };
+  collectReferences(sourceFile);
+  const identifier = valueReferences.length === 1 ? valueReferences[0] : undefined;
+  const call = identifier?.parent;
+  if (
+    !identifier ||
+    !call ||
+    !ts.isCallExpression(call) ||
+    call.arguments.filter((arg) => arg === identifier).length !== 1
+  ) {
+    return reject(`function-value reference count ${valueReferences.length}`);
+  }
+  let ownerNode: ts.Node | undefined = call.parent;
+  while (ownerNode && ownerNode !== sourceFile && !ts.isFunctionLike(ownerNode)) ownerNode = ownerNode.parent;
+  if (
+    !ownerNode ||
+    !ts.isFunctionDeclaration(ownerNode) ||
+    ownerNode.parent !== sourceFile ||
+    !ownerNode.name ||
+    !ownerNode.body
+  ) {
+    return reject("legacy owner");
+  }
+  const legacyOwnerUnitId = plan.identityPlan.identityContext.unitIdByDeclaration.get(ownerNode);
+  const ownerTerminal = legacyOwnerUnitId
+    ? plan.identityPlan.identityContext.terminalByUnitId.get(legacyOwnerUnitId)
+    : undefined;
+  const callee = call.expression;
+  const importedTarget = ts.isIdentifier(callee)
+    ? resolveMultiPreparedFunctionValueImportTarget({
+        oracle: ctx.oracle,
+        sourceFile,
+        callee,
+        identityContext: plan.identityPlan.identityContext,
+      })
+    : undefined;
+  const importedTargetUnitId = importedTarget
+    ? plan.identityPlan.identityContext.unitIdByDeclaration.get(importedTarget)
+    : undefined;
+  const expectedTrampolineName = `__fn_tramp_${legacyName}_cached`;
+  const expectedCacheName = `__fn_closure_${legacyName}`;
+  if (legacyOwnerUnitId === undefined || legacyOwnerUnitId === unitId) return reject("owner UnitId");
+  if (
+    ownerTerminal?.observedKind !== "function" ||
+    ownerTerminal.terminalOwnerId !== legacyOwnerUnitId ||
+    plan.identityPlan.identityContext.declarationByUnitId.get(legacyOwnerUnitId) !== ownerNode
+  ) {
+    return reject("owner identity");
+  }
+  if (safeSelection.funcs.has(ownerNode.name.text)) return reject("owner not legacy");
+  if (!importedTarget) return reject("imported target declaration");
+  if (importedTargetUnitId === undefined) return reject("imported target UnitId");
+  if (plan.identityPlan.identityContext.declarationByUnitId.get(importedTargetUnitId) !== importedTarget) {
+    return reject("imported target identity");
+  }
+  if (importedTarget.getSourceFile() === sourceFile) return reject("same-source import target");
+  if (ctx.funcMap.has(expectedTrampolineName)) return reject("trampoline name occupied");
+  if (ctx.funcClosureGlobals.has(legacyName)) return reject("cache registry occupied");
+  if (ctx.mod.functions.some((func) => func.name === expectedTrampolineName))
+    return reject("trampoline object occupied");
+  if (ctx.mod.globals.some((global) => global.name === expectedCacheName)) return reject("cache object occupied");
+  return {
+    legacyName,
+    unitId,
+    valueIdentifier: identifier,
+    legacyOwnerUnitId,
+    legacyOwnerName: ownerNode.name.text,
+    importedCall: call,
+    importedTargetUnitId,
+  };
+}
+
+function functionValueSupportIsCurrent(
+  ctx: CodegenContext,
+  candidate: MultiPreparedFunctionValueCandidateEvidence,
+  support: MultiPreparedFunctionValueSupportReceipt,
+  requireEmptyTargetBody: boolean,
+): boolean {
+  const exactTarget = exactAllocatedNumericCallable(
+    ctx,
+    candidate.unitId,
+    candidate.legacyName,
+    0,
+    requireEmptyTargetBody,
+  );
+  const session = ctx.programAbiSession;
+  const expectedTrampolineName = `__fn_tramp_${candidate.legacyName}_cached`;
+  const expectedCacheName = `__fn_closure_${candidate.legacyName}`;
+  const reject = (detail: string): false => {
+    if (process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_BENCH_LOOP === "1") {
+      invariant("resolve", `required multi-source function-value support rejected: ${detail}`);
+    }
+    return false;
+  };
+  if (!exactTarget) return reject("target callable");
+  if (!session) return reject("Program ABI session");
+  if (support.targetFunction !== exactTarget.func || support.targetHandle !== exactTarget.handle) {
+    return reject("target allocator");
+  }
+  if (definedFuncAt(ctx, support.trampolineHandle) !== support.trampolineFunction)
+    return reject("trampoline allocator");
+  if (ctx.mod.globals[localGlobalIdx(ctx, support.cacheGlobalHandle)] !== support.cacheGlobal) {
+    return reject("cache allocator");
+  }
+  if (ctx.funcMap.get(expectedTrampolineName) !== support.trampolineHandle) return reject("trampoline registry");
+  if (ctx.funcClosureGlobals.get(candidate.legacyName) !== support.cacheGlobalHandle) return reject("cache registry");
+  if (
+    support.trampolineFunction.name !== expectedTrampolineName ||
+    support.trampolineRef.name !== expectedTrampolineName
+  ) {
+    return reject("trampoline name");
+  }
+  if (support.cacheGlobal.name !== expectedCacheName || support.cacheGlobalRef.name !== expectedCacheName) {
+    return reject("cache name");
+  }
+  if (
+    support.trampolineRef.binding.kind !== "support" ||
+    support.trampolineBindingId !== support.trampolineRef.binding.bindingId
+  ) {
+    return reject("trampoline binding");
+  }
+  if (
+    support.cacheGlobalRef.binding.kind !== "support" ||
+    support.cacheGlobalBindingId !== support.cacheGlobalRef.binding.bindingId
+  ) {
+    return reject("cache binding");
+  }
+  if (
+    support.trampolineFunction.body.length !== 1 ||
+    support.trampolineFunction.body[0]?.op !== "call" ||
+    support.trampolineFunction.body[0].funcIdx !== support.targetHandle
+  ) {
+    return reject("trampoline body");
+  }
+  if (
+    support.cacheGlobal.type.kind !== "externref" ||
+    !support.cacheGlobal.mutable ||
+    support.cacheGlobal.init.length !== 1 ||
+    support.cacheGlobal.init[0]?.op !== "ref.null.extern"
+  ) {
+    return reject("cache shape");
+  }
+  if (!session.hasPlan(support.trampolineBindingId)) return reject("trampoline plan");
+  if (!session.hasLocator(support.trampolineBindingId, support.trampolineFunction)) return reject("trampoline locator");
+  if (!session.hasPlan(support.cacheGlobalBindingId)) return reject("cache plan");
+  if (!session.hasLocator(support.cacheGlobalBindingId, support.cacheGlobal)) return reject("cache locator");
+  const trampolineCurrentIndex = session.resolveCurrentIndex(
+    support.trampolineBindingId,
+    "function",
+    irCallableBindingKey(support.trampolineRef.binding),
+  );
+  const resolvedTrampolineHandle = absoluteFuncIndex(ctx.mod, support.trampolineHandle);
+  if (trampolineCurrentIndex !== resolvedTrampolineHandle) {
+    return reject(`trampoline current index ${trampolineCurrentIndex} !== ${resolvedTrampolineHandle}`);
+  }
+  if (
+    session.resolveCurrentIndex(
+      support.cacheGlobalBindingId,
+      "global",
+      irGlobalBindingKey(support.cacheGlobalRef.binding),
+    ) !== support.cacheGlobalHandle
+  ) {
+    return reject("cache current index");
+  }
+  return true;
 }
 
 /**
@@ -678,6 +1081,7 @@ export function tryPrepareMultiSourceScalarLeaf(
   }
 
   return Object.freeze({
+    routeKind: "scalar",
     sourceFile,
     declaration,
     unitId,
@@ -692,9 +1096,143 @@ export function tryPrepareMultiSourceScalarLeaf(
   });
 }
 
+function tryPrepareMultiSourceFunctionValueLeaf<Plan extends MultiPreparedFunctionValuePlan>(input: {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly declaration: ts.FunctionDeclaration;
+  readonly plan: Plan;
+  readonly candidate: MultiPreparedFunctionValueCandidateEvidence;
+  readonly support: MultiPreparedFunctionValueSupportReceipt;
+  readonly projectLoweringPlans: (selection: IrSelection) => IrIntegrationLoweringPlans;
+}): MultiPreparedFunctionValueLeafRoute | undefined {
+  const { candidate, ctx, declaration, plan, sourceFile, support } = input;
+  const { legacyName, unitId } = candidate;
+  if (!functionValueSupportIsCurrent(ctx, candidate, support, true)) {
+    invariant("resolve", `multi-source function-value leaf ${unitId} lost its preallocated singleton receipt`);
+  }
+
+  const preparedSelection: IrSelection = {
+    funcs: new Set([legacyName]),
+    classMembers: new Set(),
+    classMemberUnitIds: new Set(),
+    moduleInit: undefined,
+  };
+  const prepared = prepareIrBodies({
+    ctx,
+    sourceFile,
+    selection: preparedSelection,
+    identityPlan: plan.identityPlan,
+    functionClaimsByUnitId: plan.functionClaimsByUnitId,
+    overrideMap: plan.overrideMap,
+    classShapes: plan.classShapes,
+    classShapesById: plan.classShapesById,
+    projectLoweringPlans: input.projectLoweringPlans,
+  });
+  if (prepared.classMembers || prepared.moduleInit || prepared.implicitConstructorUnitIds.size !== 0) {
+    invariant("patch", `multi-source function-value leaf ${unitId} produced a foreign Prepared routing family`);
+  }
+  if (prepared.freeFunctions.skipBodies.size === 0) {
+    if (
+      exactWithdrawal(prepared.report, prepared.freeFunctions, unitId, legacyName) &&
+      functionValueSupportIsCurrent(ctx, candidate, support, true)
+    ) {
+      return undefined;
+    }
+    invariant("patch", `multi-source function-value leaf ${unitId} did not withdraw atomically before its skip`);
+  }
+
+  const requested = prepared.freeFunctions.requestedSkipProjection.entries;
+  const terminalEvidence = prepared.report.terminalEvidence ?? [];
+  const artifactEvidence = prepared.report.compiledArtifactEvidence ?? [];
+  const evidence = terminalEvidence[0];
+  const artifact = artifactEvidence[0];
+  const exactSets =
+    requested.length === 1 &&
+    requested[0]?.unitId === unitId &&
+    requested[0]?.legacyName === legacyName &&
+    prepared.freeFunctions.skipBodies.size === 1 &&
+    prepared.freeFunctions.skipBodies.has(legacyName) &&
+    prepared.freeFunctions.completedBodies.size === 1 &&
+    prepared.freeFunctions.completedBodies.has(legacyName) &&
+    (prepared.report.syntheticCompiledArtifacts?.length ?? 0) === 0;
+  if (!exactSets || terminalEvidence.length !== 1) {
+    invariant("patch", `multi-source function-value leaf ${unitId} produced a non-exact Prepared route receipt`);
+  }
+
+  let receipt: MultiPreparedScalarLeafReceipt;
+  if (evidence?.kind === "patched") {
+    if (
+      evidence.unitId !== unitId ||
+      evidence.legacyName !== legacyName ||
+      evidence.preparedComponentId === undefined ||
+      prepared.report.errors.length !== 0 ||
+      prepared.report.compiled.length !== 1 ||
+      prepared.report.compiled[0] !== legacyName ||
+      prepared.report.terminalCompiledOwners?.length !== 1 ||
+      prepared.report.terminalCompiledOwners[0] !== legacyName ||
+      artifactEvidence.length !== 1 ||
+      artifact?.artifactUnitId !== unitId ||
+      artifact?.terminalOwnerUnitId !== unitId ||
+      artifact?.name !== legacyName ||
+      artifact?.preparedComponentId !== evidence.preparedComponentId ||
+      prepared.freeFunctions.preserveBodies.size !== 1 ||
+      !prepared.freeFunctions.preserveBodies.has(legacyName)
+    ) {
+      invariant("patch", `multi-source function-value leaf ${unitId} lost its exact Prepared Program ABI receipt`);
+    }
+    receipt = {
+      kind: "prepared",
+      unitId,
+      legacyName,
+      preparedComponentId: evidence.preparedComponentId,
+    };
+  } else {
+    if (
+      evidence?.kind !== "failed" ||
+      evidence.unitId !== unitId ||
+      evidence.legacyName !== legacyName ||
+      evidence.error.outcome.kind !== "invariant" ||
+      artifactEvidence.length !== 0 ||
+      prepared.freeFunctions.preserveBodies.size !== 0
+    ) {
+      invariant("patch", `multi-source function-value leaf ${unitId} failed without an exact invariant receipt`);
+    }
+    receipt = { kind: "invariant", unitId, legacyName };
+  }
+
+  if (!functionValueSupportIsCurrent(ctx, candidate, support, false)) {
+    invariant("patch", `multi-source function-value leaf ${unitId} drifted after Prepared certification`);
+  }
+  const allocated = exactAllocatedNumericCallable(ctx, unitId, legacyName, 0, false);
+  if (!allocated || (receipt.kind === "prepared" && allocated.func.body.length === 0)) {
+    invariant("patch", `multi-source function-value leaf ${unitId} lost its prepared target body`);
+  }
+
+  return Object.freeze({
+    routeKind: "function-value",
+    sourceFile,
+    declaration,
+    unitId,
+    legacyName,
+    preparedSelection,
+    preparedReport: prepared.report,
+    preparedFreeFunctions: prepared.freeFunctions,
+    receipt,
+    allocatedFunction: allocated.func,
+    preparedBody: allocated.func.body,
+    preparedInstructions: Object.freeze([...allocated.func.body]),
+    valueIdentifier: candidate.valueIdentifier,
+    legacyOwnerUnitId: candidate.legacyOwnerUnitId,
+    legacyOwnerName: candidate.legacyOwnerName,
+    importedCall: candidate.importedCall,
+    importedTargetUnitId: candidate.importedTargetUnitId,
+    support,
+  });
+}
+
 export interface EarlyMultiPreparedScalarLeafState<Plan extends MultiPreparedScalarLeafPlan> {
   readonly plan: Plan;
-  readonly route?: MultiPreparedScalarLeafRoute;
+  readonly route?: MultiPreparedEarlyLeafRoute;
   skippedFunctionUnitIds: ReadonlySet<IrUnitId>;
 }
 
@@ -792,6 +1330,89 @@ export function planEarlyMultiPreparedScalarLeafRoute<Plan extends MultiPrepared
   return states;
 }
 
+/**
+ * Prepare the one structural reduction leaf whose value crosses an imported
+ * source-call boundary. This route is intentionally separate from #4589: its
+ * one allowed late-provider edge is proved and preallocated explicitly.
+ */
+export function planEarlyMultiPreparedFunctionValueLeafRoute<Plan extends MultiPreparedFunctionValuePlan>(input: {
+  readonly active: boolean;
+  readonly cutoverEnabled: boolean;
+  readonly ctx: CodegenContext;
+  readonly sourceFiles: readonly ts.SourceFile[];
+  readonly entryFile: ts.SourceFile;
+  readonly safety: () => MultiPreparedScalarLeafGraphSafety;
+  readonly planSource: (sourceFile: ts.SourceFile) => Plan;
+  readonly safeSelection: (
+    plan: Plan,
+    sourceFile: ts.SourceFile,
+    safety: MultiPreparedScalarLeafGraphSafety,
+  ) => IrSelection;
+  readonly hasForeignLateProvider: (plan: Plan, sourceFile: ts.SourceFile, unitId: IrUnitId) => boolean;
+  readonly prepareFunctionValueSupport: (
+    plan: Plan,
+    sourceFile: ts.SourceFile,
+    unitId: IrUnitId,
+    legacyName: string,
+  ) => MultiPreparedFunctionValueSupportReceipt | undefined;
+  readonly projectLoweringPlans: (plan: Plan, selection: IrSelection) => IrIntegrationLoweringPlans;
+}): Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<Plan>> {
+  const states = new Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<Plan>>();
+  if (!input.active || collectMultiPreparedScalarLeafCandidates(input.sourceFiles).length !== 0) {
+    if (process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_BENCH_LOOP === "1") {
+      invariant("resolve", "required multi-source function-value route failed its active/scalar-exclusion gate");
+    }
+    return states;
+  }
+  const candidates = collectMultiPreparedReductionLeafCandidates(input.ctx, input.sourceFiles);
+  if (candidates.length !== 1) {
+    if (process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_BENCH_LOOP === "1") {
+      invariant("resolve", `required multi-source function-value route found ${candidates.length} reduction leaves`);
+    }
+    return states;
+  }
+  const declaration = candidates[0]!;
+  const sourceFile = declaration.getSourceFile();
+  if (sourceFile !== input.entryFile) return states;
+  const safety = input.safety();
+  const plan = input.planSource(sourceFile);
+  const safeSelection = input.safeSelection(plan, sourceFile, safety);
+  const candidate = resolveExactFunctionValueCandidate({
+    ctx: input.ctx,
+    sourceFile,
+    declaration,
+    plan,
+    safeSelection,
+    safety,
+    hasForeignLateProvider: (unitId) => input.hasForeignLateProvider(plan, sourceFile, unitId),
+  });
+  if (!candidate) {
+    if (process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_BENCH_LOOP === "1") {
+      invariant("resolve", "required multi-source function-value route failed exact candidate certification");
+    }
+    return states;
+  }
+  const state: EarlyMultiPreparedScalarLeafState<Plan> = { plan, skippedFunctionUnitIds: new Set() };
+  states.set(sourceFile, state);
+  if (!input.cutoverEnabled) return states;
+
+  const support = input.prepareFunctionValueSupport(plan, sourceFile, candidate.unitId, candidate.legacyName);
+  if (!support || !functionValueSupportIsCurrent(input.ctx, candidate, support, true)) {
+    invariant("resolve", `multi-source function-value leaf ${candidate.unitId} could not preallocate exact support`);
+  }
+  const route = tryPrepareMultiSourceFunctionValueLeaf({
+    ctx: input.ctx,
+    sourceFile,
+    declaration,
+    plan,
+    candidate,
+    support,
+    projectLoweringPlans: (selection) => input.projectLoweringPlans(plan, selection),
+  });
+  if (route) states.set(sourceFile, { plan, route, skippedFunctionUnitIds: new Set() });
+  return states;
+}
+
 /** Re-prove the exact leaf after all other direct bodies have run. */
 export function assertMultiPreparedScalarLeafRouteCurrent(input: {
   readonly ctx: CodegenContext;
@@ -826,5 +1447,47 @@ export function assertMultiPreparedScalarLeafRouteCurrent(input: {
     (route.receipt.kind === "prepared" && allocated.func.body.length === 0)
   ) {
     invariant("patch", `multi-source scalar leaf ${route.unitId} drifted after direct-body certification`);
+  }
+}
+
+/** Re-prove the prepared target and its exact singleton pair after direct owners ran. */
+export function assertMultiPreparedFunctionValueLeafRouteCurrent(input: {
+  readonly ctx: CodegenContext;
+  readonly route: MultiPreparedFunctionValueLeafRoute;
+  readonly finalSelection: IrSelection;
+  readonly safety: MultiPreparedScalarLeafGraphSafety;
+}): void {
+  const { ctx, finalSelection, route, safety } = input;
+  if (process.env.JS2WASM_TEST_TAMPER_MULTI_PREPARED_FUNCTION_VALUE_LEAF?.split(",").includes(route.legacyName)) {
+    route.support.trampolineFunction.name = `${route.support.trampolineFunction.name}$tampered`;
+  }
+  const candidate: MultiPreparedFunctionValueCandidateEvidence = {
+    legacyName: route.legacyName,
+    unitId: route.unitId,
+    valueIdentifier: route.valueIdentifier,
+    legacyOwnerUnitId: route.legacyOwnerUnitId,
+    legacyOwnerName: route.legacyOwnerName,
+    importedCall: route.importedCall,
+    importedTargetUnitId: route.importedTargetUnitId,
+  };
+  const allocated = exactAllocatedNumericCallable(ctx, route.unitId, route.legacyName, 0, false);
+  if (
+    !finalSelection.funcs.has(route.legacyName) ||
+    finalSelection.funcs.has(route.legacyOwnerName) ||
+    safety.collisions.has(route.legacyName) ||
+    safety.crossFileFunctionNames.has(route.legacyName) ||
+    safety.importAliasNames.has(route.legacyName) ||
+    safety.occupiedFunctionNameCounts.get(route.legacyName) !== 1 ||
+    safety.occupiedFunctionKeys.some((key) => key.startsWith(`${route.legacyName}$`)) ||
+    ctx.liveFuncBindingGlobals?.has(route.legacyName) === true ||
+    !allocated ||
+    allocated.func !== route.allocatedFunction ||
+    allocated.func.body !== route.preparedBody ||
+    allocated.func.body.length !== route.preparedInstructions.length ||
+    allocated.func.body.some((instruction, index) => instruction !== route.preparedInstructions[index]) ||
+    (route.receipt.kind === "prepared" && allocated.func.body.length === 0) ||
+    !functionValueSupportIsCurrent(ctx, candidate, route.support, false)
+  ) {
+    invariant("patch", `multi-source function-value leaf ${route.unitId} drifted after direct-body certification`);
   }
 }

--- a/tests/issue-2138-multi-module-ir-overlay.test.ts
+++ b/tests/issue-2138-multi-module-ir-overlay.test.ts
@@ -3,13 +3,14 @@
 // #2138 M0 — bounded multi-module IR overlay. Multi-source WasmGC compiles
 // legacy bodies first, then lets IR replace only unambiguous top-level function
 // slots. #3214 A+B1 additionally admits checker-certified host imported direct
-// calls (including exact bare top-level callbacks). Class members, module init,
-// and IR-first body skipping remain legacy-owned.
+// calls (including exact bare top-level callbacks). Class members and module
+// init remain legacy-owned; #4589 admits one exact standalone scalar leaf.
 
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { compileFiles, compileMulti, compileProject, type CompileResult } from "../src/index.js";
 import { instantiateWithRuntime } from "./equivalence/helpers.js";
@@ -51,6 +52,14 @@ function expectSuccess(result: CompileResult, label: string): void {
     `${label} failed:\n${result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")}`,
   ).toBe(true);
 }
+
+function digest(value: Uint8Array | string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 async function instantiate(result: CompileResult): Promise<Record<string, (...args: number[]) => number>> {
   const instance = await instantiateWithRuntime(result);
@@ -138,8 +147,19 @@ describe("#2138 M0 — multi-module top-level IR overlay", () => {
     const result = await compileMulti(MULTI_FILES, "./entry.ts", {
       experimentalIR: true,
       target: "standalone",
+      trackIrOutcomes: true,
+      emitWat: true,
     });
     expectSuccess(result, "standalone multi compile");
+
+    vi.stubEnv("JS2WASM_MULTI_PREPARED_SCALAR_LEAF_CUTOVER", "0");
+    const direct = await compileMulti(MULTI_FILES, "./entry.ts", {
+      experimentalIR: true,
+      target: "standalone",
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(direct, "standalone kill-switch control");
 
     const compiled = new Set(result.irCompiledFuncs ?? []);
     expect(compiled.has("depPure"), "legacy imported caller is outside the dependency call graph").toBe(false);
@@ -148,9 +168,67 @@ describe("#2138 M0 — multi-module top-level IR overlay", () => {
     expect(compiled.has("initHelper")).toBe(false);
     expect(compiled.has("<module-init>")).toBe(false);
     expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs).toEqual(["entryPure"]);
+    expect(direct.irCompiledFuncs).toEqual(["entryPure"]);
+    expect(result.irFirstSkipped).toBeUndefined();
+    expect(direct.irFirstSkipped).toBeUndefined();
+    expect(digest(result.binary)).toBe("6facf9cc597fc8b9b3070723139d5d91d88dfaf11868644e15d6eb606eb96bef");
+    expect(digest(direct.binary)).toBe(digest(result.binary));
+    expect(digest(result.wat)).toBe("ebb3d4b26b057ac3798e423678c46f425da34c3b0a466cd7b7c2bc70f2fb5c74");
+    expect(digest(direct.wat)).toBe(digest(result.wat));
+
+    const preparedRows = result.irBodyRouteAudit?.legacyEntries ?? [];
+    const directRows = direct.irBodyRouteAudit?.legacyEntries ?? [];
+    expect([directRows.length, preparedRows.length]).toEqual([14, 12]);
+    expect([
+      directRows.filter((row) => row.entryPoint !== "compileDeclarations").length,
+      preparedRows.filter((row) => row.entryPoint !== "compileDeclarations").length,
+    ]).toEqual([12, 10]);
+    expect([
+      directRows.filter((row) => row.unitId !== undefined).length,
+      preparedRows.filter((row) => row.unitId !== undefined).length,
+    ]).toEqual([11, 9]);
+    expect(
+      directRows
+        .filter((row) => row.bodyName === "entryPure")
+        .map((row) => row.entryPoint)
+        .sort(),
+    ).toEqual(["compileFunctionBody", "compileStatement"]);
+    expect(preparedRows.filter((row) => row.bodyName === "entryPure")).toEqual([]);
+    const rowKey = (row: (typeof directRows)[number]): string =>
+      JSON.stringify({
+        target: row.target,
+        entryPoint: row.entryPoint,
+        bodyName: row.bodyName,
+        file: row.file,
+        line: row.line,
+        column: row.column,
+        sourceId: row.sourceId,
+        unitId: row.unitId,
+        classId: row.classId,
+        unitKind: row.unitKind,
+        terminalOwnerId: row.terminalOwnerId,
+        count: row.count,
+      });
+    expect(preparedRows.map(rowKey).sort()).toEqual(
+      directRows
+        .filter((row) => row.bodyName !== "entryPure")
+        .map(rowKey)
+        .sort(),
+    );
+    const discoverModuleInit = directRows.find((row) => row.bodyName === "__module_init" && row.unitId === undefined);
+    expect(discoverModuleInit).toMatchObject({ entryPoint: "compileModuleInitBody" });
+    expect(discoverModuleInit?.sourceId).toBeDefined();
 
     const exports = await instantiate(result);
-    expect([exports.entryPure!(5), exports.callRenamed!(5), exports.readInit!()]).toEqual([9, 15, 42]);
+    const directExports = await instantiate(direct);
+    const observed = (compiledExports: typeof exports) => [
+      compiledExports.entryPure!(5),
+      compiledExports.callRenamed!(5),
+      compiledExports.readInit!(),
+    ];
+    expect(observed(exports)).toEqual([9, 15, 42]);
+    expect(observed(exports)).toEqual(observed(directExports));
   });
 
   it("closes checker-resolved global-script caller ABI edges without import syntax", async () => {

--- a/tests/issue-4589-multi-prepared-scalar-leaf.test.ts
+++ b/tests/issue-4589-multi-prepared-scalar-leaf.test.ts
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { compileMulti, compileProject, type CompileResult } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+const CUTOVER = "JS2WASM_MULTI_PREPARED_SCALAR_LEAF_CUTOVER";
+const DIRECT_POISON = "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY";
+const SEAL_FAILURE = "JS2WASM_TEST_INJECT_IR_PREPARED_SEAL_FAILURE";
+const TAMPER = "JS2WASM_TEST_TAMPER_MULTI_PREPARED_SCALAR_LEAF";
+
+const TYPE_ONLY_FILES = {
+  "./dep.ts": `export interface Marker { readonly tag: "marker"; }`,
+  "./entry.ts": `
+    import type { Marker } from "./dep";
+    type KeepDependencyInProgram = Marker;
+    export function entryPure(x: number): number {
+      return x + 4;
+    }
+  `,
+} as const;
+
+function expectSuccess(result: CompileResult, label: string): void {
+  expect(
+    result.success,
+    `${label} failed:\n${result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")}`,
+  ).toBe(true);
+}
+
+function digest(value: Uint8Array | string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function entryPureLegacyRows(result: CompileResult) {
+  return (
+    result.irBodyRouteAudit?.legacyEntries.filter(
+      (entry) => entry.unitId !== undefined && entry.bodyName === "entryPure",
+    ) ?? []
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("#4589 multi-source Prepared scalar-leaf cutover", () => {
+  it("is default-on, bypasses the poisoned direct body, and restores it with the kill switch", async () => {
+    vi.stubEnv(DIRECT_POISON, "entryPure");
+    const prepared = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      trackIrOutcomes: true,
+      target: "standalone",
+    });
+    expectSuccess(prepared, "default-on Prepared compile");
+    expect(prepared.irCompiledFuncs?.filter((name) => name === "entryPure")).toEqual(["entryPure"]);
+    expect(entryPureLegacyRows(prepared)).toEqual([]);
+    const outcome = prepared.irOutcomes?.find((candidate) => candidate.displayName === "entryPure");
+    expect(outcome).toMatchObject({ irBodyEmitted: true, legacyBodyEmitted: false });
+    expect(prepared.irBodyRouteAudit?.dispositions.find((row) => row.unitId === outcome?.unitId)?.disposition).toBe(
+      "terminal-ir",
+    );
+
+    vi.stubEnv(CUTOVER, "0");
+    const direct = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      target: "standalone",
+    });
+    expect(direct.success).toBe(false);
+    expect(direct.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: entryPure",
+    );
+    expect(entryPureLegacyRows(direct).map((entry) => entry.entryPoint)).toContain("compileFunctionBody");
+  });
+
+  it("keeps kill-switch WAT, binary, and runtime behavior exact", async () => {
+    const prepared = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      experimentalIR: true,
+      target: "standalone",
+      emitWat: true,
+    });
+    vi.stubEnv(CUTOVER, "0");
+    const direct = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      experimentalIR: true,
+      target: "standalone",
+      emitWat: true,
+    });
+    expectSuccess(prepared, "Prepared compile");
+    expectSuccess(direct, "direct control compile");
+
+    expect(digest(prepared.binary)).toBe(digest(direct.binary));
+    expect(digest(prepared.wat)).toBe(digest(direct.wat));
+    const preparedInstance = await instantiateWithRuntime(prepared);
+    const directInstance = await instantiateWithRuntime(direct);
+    const preparedEntry = preparedInstance.exports.entryPure as (value: number) => number;
+    const directEntry = directInstance.exports.entryPure as (value: number) => number;
+    expect(preparedEntry(5)).toBe(9);
+    expect(preparedEntry(5)).toBe(directEntry(5));
+  });
+
+  it("reaches the non-vacuous type-only graph through compileMulti and compileProject", async () => {
+    const multi = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      target: "standalone",
+    });
+    expectSuccess(multi, "compileMulti");
+    expect(multi.irBodyRouteAudit?.sourceCount).toBe(2);
+    expect(entryPureLegacyRows(multi)).toEqual([]);
+
+    const dir = mkdtempSync(join(tmpdir(), "js2wasm-4589-"));
+    const depPath = join(dir, "dep.ts");
+    const entryPath = join(dir, "entry.ts");
+    writeFileSync(depPath, TYPE_ONLY_FILES["./dep.ts"]);
+    writeFileSync(entryPath, TYPE_ONLY_FILES["./entry.ts"]);
+    try {
+      const project = await compileProject(entryPath, {
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        target: "standalone",
+      });
+      expectSuccess(project, "compileProject");
+      expect(project.irBodyRouteAudit?.sourceCount).toBe(2);
+      expect(entryPureLegacyRows(project)).toEqual([]);
+      expect(project.irCompiledFuncs?.filter((name) => name === "entryPure")).toEqual(["entryPure"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves the default GC multi-source lane on the direct body route", async () => {
+    vi.stubEnv(DIRECT_POISON, "entryPure");
+    const result = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: entryPure",
+    );
+    expect(entryPureLegacyRows(result).map((entry) => entry.entryPoint)).toContain("compileFunctionBody");
+  });
+
+  it("fails closed when the allocated callable drifts after Prepared certification", async () => {
+    vi.stubEnv(TAMPER, "entryPure");
+    const result = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      target: "standalone",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain("drifted after direct-body certification");
+  });
+
+  it.each([
+    {
+      label: "ambiguous graph candidates",
+      entry: `
+        export function entryPure(x: number): number { return x + 4; }
+        export function otherPure(x: number): number { return x - 4; }
+      `,
+    },
+    {
+      label: "runtime function-value support",
+      entry: `
+        export function entryPure(x: number): number { return x + 4; }
+        export function expose(): (x: number) => number { return entryPure; }
+      `,
+    },
+    {
+      label: "derived remainder support",
+      entry: `export function entryPure(x: number): number { return x % 2; }`,
+    },
+    {
+      label: "class-bearing source",
+      entry: `
+        export class Box {}
+        export function entryPure(x: number): number { return x + 4; }
+      `,
+    },
+    {
+      label: "CommonJS export surface",
+      entry: `
+        declare const module: { exports: unknown };
+        function entryPure(x: number): number { return x + 4; }
+        module.exports = entryPure;
+      `,
+    },
+  ])("withdraws before skip for $label", async ({ entry }) => {
+    vi.stubEnv(DIRECT_POISON, "entryPure");
+    const result = await compileMulti({ ...TYPE_ONLY_FILES, "./entry.ts": entry }, "./entry.ts", {
+      target: "standalone",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: entryPure",
+    );
+    expect(entryPureLegacyRows(result).map((entry) => entry.entryPoint)).toContain("compileFunctionBody");
+  });
+
+  it("withdraws when another source re-exports the candidate", async () => {
+    vi.stubEnv(DIRECT_POISON, "entryPure");
+    const result = await compileMulti(
+      {
+        ...TYPE_ONLY_FILES,
+        "./bridge.ts": `export { entryPure } from "./entry";`,
+      },
+      "./entry.ts",
+      { target: "standalone", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: entryPure",
+    );
+    expect(entryPureLegacyRows(result).map((entry) => entry.entryPoint)).toContain("compileFunctionBody");
+  });
+
+  it.each([
+    ["fast", { target: "standalone" as const, fast: true }],
+    ["WASI", { target: "wasi" as const }],
+    ["IR-first-disabled", { target: "standalone" as const, disableIrFirst: true }],
+  ])("keeps the %s target lane direct-owned", async (_label, targetOptions) => {
+    vi.stubEnv(DIRECT_POISON, "entryPure");
+    const result = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      ...targetOptions,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: entryPure",
+    );
+  });
+
+  it("withdraws an exact Unsupported preparation before requesting the skip", async () => {
+    vi.stubEnv(SEAL_FAILURE, "1");
+    vi.stubEnv(DIRECT_POISON, "entryPure");
+    const result = await compileMulti(TYPE_ONLY_FILES, "./entry.ts", {
+      target: "standalone",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expect(result.success).toBe(false);
+    const errors = result.errors.map((error) => error.message).join("\n");
+    expect(errors).toContain("injected direct function-body poison: entryPure");
+    expect(errors).not.toContain("did not withdraw atomically before its skip");
+    expect(entryPureLegacyRows(result).map((entry) => entry.entryPoint)).toContain("compileFunctionBody");
+  });
+});

--- a/tests/issue-4590-bench-loop-prepared-cutover.test.ts
+++ b/tests/issue-4590-bench-loop-prepared-cutover.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { compileProject, type CompileResult } from "../src/index.js";
+
+const ENTRY = resolve(import.meta.dirname, "../website/playground/examples/benchmarks/loop.ts");
+const CUTOVER = "JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER";
+const DIRECT_POISON = "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY";
+
+function expectSuccess(result: CompileResult, label: string): void {
+  expect(
+    result.success,
+    `${label} failed:\n${result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")}`,
+  ).toBe(true);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("#4590 exact bench_loop Prepared cutover", () => {
+  it("bypasses the real compileProject direct body and restores it with the dedicated kill switch", async () => {
+    vi.stubEnv(DIRECT_POISON, "bench_loop");
+    const prepared = await compileProject(ENTRY, {
+      experimentalIR: true,
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    expectSuccess(prepared, "default-on Prepared compile");
+    expect(prepared.irBodyRouteAudit?.legacyEntries.filter((row) => row.bodyName === "bench_loop")).toEqual([]);
+    expect(prepared.irOutcomes?.find((outcome) => outcome.displayName === "bench_loop")).toMatchObject({
+      irBodyEmitted: true,
+      legacyBodyEmitted: false,
+    });
+
+    vi.stubEnv(CUTOVER, "0");
+    const direct = await compileProject(ENTRY, {
+      experimentalIR: true,
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    expect(direct.success).toBe(false);
+    expect(direct.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: bench_loop",
+    );
+  });
+});

--- a/tests/issue-4590-bench-loop-prepared-cutover.test.ts
+++ b/tests/issue-4590-bench-loop-prepared-cutover.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { analyzeMultiSource } from "../src/checker/index.js";
 import { generateMultiModule, type GeneratedCodegenModule } from "../src/codegen/index.js";
 import { canonicalProgramAbiCallableTypeContract } from "../src/codegen/program-abi-signatures.js";
-import { compileProject, type CompileOptions, type CompileResult } from "../src/index.js";
+import { compileMulti, compileProject, type CompileOptions, type CompileResult } from "../src/index.js";
 import { irSupportGlobalRef } from "../src/ir/abi-bindings.js";
 import { irSupportFuncRef, irUnitCallableBindingId } from "../src/ir/callable-bindings.js";
 import { instantiateWithRuntime } from "./equivalence/helpers.js";
@@ -23,6 +23,8 @@ const HELPERS_SOURCE = readFileSync(HELPERS, "utf8");
 const CUTOVER = "JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER";
 const DIRECT_POISON = "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY";
 const REQUIRE_ROUTE = "JS2WASM_TEST_REQUIRE_MULTI_PREPARED_BENCH_LOOP";
+const SEAL_FAILURE = "JS2WASM_TEST_INJECT_IR_PREPARED_SEAL_FAILURE";
+const TAMPER = "JS2WASM_TEST_TAMPER_MULTI_PREPARED_FUNCTION_VALUE_LEAF";
 const TRAMPOLINE = "__fn_tramp_bench_loop_cached";
 const CACHE = "__fn_closure_bench_loop";
 const EXPECTED_RUNTIME = 1_783_293_664;
@@ -83,6 +85,26 @@ async function benchRuntime(result: CompileResult): Promise<number> {
   return (instance.exports.bench_loop as () => number)();
 }
 
+function expectDirectPoison(result: CompileResult): void {
+  expect(result.success).toBe(false);
+  expect(result.errors.map((error) => error.message).join("\n")).toContain(
+    "injected direct function-body poison: bench_loop",
+  );
+  expect(
+    result.irBodyRouteAudit?.legacyEntries.filter((row) => row.bodyName === "bench_loop").map((row) => row.entryPoint),
+  ).toContain("compileFunctionBody");
+}
+
+async function compileMutatedLoop(source: string): Promise<CompileResult> {
+  vi.stubEnv(CUTOVER, "1");
+  vi.stubEnv(DIRECT_POISON, "bench_loop");
+  return compileMulti({ "helpers.ts": HELPERS_SOURCE, "loop.ts": source }, "loop.ts", {
+    experimentalIR: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+  });
+}
+
 function generatedBench(cutover: boolean): GeneratedCodegenModule {
   vi.stubEnv(CUTOVER, cutover ? "1" : "0");
   vi.stubEnv(REQUIRE_ROUTE, "1");
@@ -100,6 +122,7 @@ afterEach(() => {
 
 describe("#4590 exact bench_loop Prepared cutover", () => {
   it("bypasses the real compileProject direct body and restores it with the dedicated kill switch", async () => {
+    vi.stubEnv(REQUIRE_ROUTE, "1");
     vi.stubEnv(DIRECT_POISON, "bench_loop");
     const prepared = await compileProject(ENTRY, {
       experimentalIR: true,
@@ -293,5 +316,100 @@ describe("#4590 exact bench_loop Prepared cutover", () => {
         trampolineSignature,
       );
     }
+  });
+
+  it("fails closed when the preallocated singleton pair drifts after Prepared certification", async () => {
+    vi.stubEnv(TAMPER, "bench_loop");
+    const result = await compileBench(true);
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain("drifted after direct-body certification");
+    expect(result.irBodyRouteAudit?.legacyEntries.filter((row) => row.bodyName === "bench_loop")).toEqual([]);
+  });
+
+  it("withdraws an exact Unsupported preparation before requesting the direct-body skip", async () => {
+    vi.stubEnv(SEAL_FAILURE, "1");
+    vi.stubEnv(DIRECT_POISON, "bench_loop");
+    const result = await compileBench(true);
+    expectDirectPoison(result);
+    expect(result.errors.map((error) => error.message).join("\n")).not.toContain(
+      "did not withdraw atomically before its skip",
+    );
+  });
+
+  it("routes the same exact reduction after every function-value use is renamed", async () => {
+    const renamed = "renamed_reduction";
+    const source = LOOP_SOURCE.replaceAll("bench_loop", renamed);
+    vi.stubEnv(CUTOVER, "1");
+    vi.stubEnv(REQUIRE_ROUTE, "1");
+    vi.stubEnv(DIRECT_POISON, renamed);
+    const result = await compileMulti({ "helpers.ts": HELPERS_SOURCE, "loop.ts": source }, "loop.ts", {
+      experimentalIR: true,
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result, "renamed Prepared reduction");
+    expect(result.irBodyRouteAudit?.legacyEntries.filter((row) => row.bodyName === renamed)).toEqual([]);
+    expect(result.irOutcomes?.find((outcome) => outcome.displayName === renamed)).toMatchObject({
+      irBodyEmitted: true,
+      legacyBodyEmitted: false,
+    });
+  });
+
+  it.each([
+    {
+      label: "altered reduction literal",
+      source: LOOP_SOURCE.replace("i < 1000000", "i < 999999"),
+    },
+    {
+      label: "extensionless imported source",
+      source: LOOP_SOURCE.replace('from "./helpers.ts"', 'from "./helpers"'),
+    },
+    {
+      label: "shadowed imported callee",
+      source: LOOP_SOURCE.replace(
+        "export function main(): void {",
+        "export function main(): void {\n  function addBenchCard(..._args: unknown[]): void {}",
+      ),
+    },
+    {
+      label: "stored function value",
+      source: LOOP_SOURCE.replace(
+        '  addBenchCard(wrap, "Loop: 1M Int32 sum", "Tight i32 loop with explicit | 0 wrap, no allocations", bench_loop);',
+        '  const stored = bench_loop;\n  addBenchCard(wrap, "Loop: 1M Int32 sum", "Tight i32 loop with explicit | 0 wrap, no allocations", stored);',
+      ),
+    },
+    {
+      label: "multiple function-value references",
+      source: LOOP_SOURCE.replace("  host.appendChild(wrap);", "  void bench_loop;\n  host.appendChild(wrap);"),
+    },
+    {
+      label: "additional direct caller",
+      source: LOOP_SOURCE.replace("  host.appendChild(wrap);", "  bench_loop();\n  host.appendChild(wrap);"),
+    },
+    {
+      label: "synthetic trampoline collision",
+      source: `${LOOP_SOURCE}\nfunction ${TRAMPOLINE}(value: string): string { return value; }\n`,
+    },
+    {
+      label: "nonliteral reduction bound",
+      source: `const LOOP_LIMIT = 1000000;\n${LOOP_SOURCE.replace("i < 1000000", "i < LOOP_LIMIT")}`,
+    },
+    {
+      label: "exact reduction with module initialization",
+      source: `let moduleMarker = 1;\n${LOOP_SOURCE}`,
+    },
+  ])("withdraws before skip for $label", async ({ source }) => {
+    expectDirectPoison(await compileMutatedLoop(source));
+  });
+
+  it.each([
+    ["default GC", { target: "gc" as const }],
+    ["fast standalone", { target: "standalone" as const, fast: true }],
+    ["WASI", { target: "wasi" as const }],
+    ["IR-first disabled", { target: "standalone" as const, disableIrFirst: true }],
+    ["IR disabled", { target: "standalone" as const, experimentalIR: false }],
+  ])("keeps the %s lane direct-owned", async (_label, options) => {
+    vi.stubEnv(DIRECT_POISON, "bench_loop");
+    expectDirectPoison(await compileBench(true, options));
   });
 });

--- a/tests/issue-4590-bench-loop-prepared-cutover.test.ts
+++ b/tests/issue-4590-bench-loop-prepared-cutover.test.ts
@@ -1,19 +1,97 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import binaryen from "binaryen";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { compileProject, type CompileResult } from "../src/index.js";
+import { analyzeMultiSource } from "../src/checker/index.js";
+import { generateMultiModule, type GeneratedCodegenModule } from "../src/codegen/index.js";
+import { canonicalProgramAbiCallableTypeContract } from "../src/codegen/program-abi-signatures.js";
+import { compileProject, type CompileOptions, type CompileResult } from "../src/index.js";
+import { irSupportGlobalRef } from "../src/ir/abi-bindings.js";
+import { irSupportFuncRef, irUnitCallableBindingId } from "../src/ir/callable-bindings.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+// Register the low-level codegen delegates used by generateMultiModule.
+import "../src/codegen/expressions.js";
 
 const ENTRY = resolve(import.meta.dirname, "../website/playground/examples/benchmarks/loop.ts");
+const HELPERS = resolve(import.meta.dirname, "../website/playground/examples/benchmarks/helpers.ts");
+const LOOP_SOURCE = readFileSync(ENTRY, "utf8");
+const HELPERS_SOURCE = readFileSync(HELPERS, "utf8");
 const CUTOVER = "JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER";
 const DIRECT_POISON = "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY";
+const REQUIRE_ROUTE = "JS2WASM_TEST_REQUIRE_MULTI_PREPARED_BENCH_LOOP";
+const TRAMPOLINE = "__fn_tramp_bench_loop_cached";
+const CACHE = "__fn_closure_bench_loop";
+const EXPECTED_RUNTIME = 1_783_293_664;
 
 function expectSuccess(result: CompileResult, label: string): void {
   expect(
     result.success,
     `${label} failed:\n${result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")}`,
   ).toBe(true);
+}
+
+async function compileBench(cutover: boolean, options: CompileOptions = {}): Promise<CompileResult> {
+  vi.stubEnv(CUTOVER, cutover ? "1" : "0");
+  return compileProject(ENTRY, {
+    experimentalIR: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+    emitWat: true,
+    ...options,
+  });
+}
+
+function wasmSurface(binary: Uint8Array) {
+  const module = new WebAssembly.Module(binary);
+  return {
+    imports: WebAssembly.Module.imports(module),
+    exports: WebAssembly.Module.exports(module),
+  };
+}
+
+function watFunction(wat: string, name: string): string {
+  const sameLine = wat.indexOf(`(func $${name} `);
+  const start = sameLine >= 0 ? sameLine : wat.indexOf(`(func $${name}\n`);
+  if (start < 0) throw new Error(`missing WAT function ${name}`);
+  let depth = 0;
+  for (let index = start; index < wat.length; index++) {
+    if (wat[index] === "(") depth++;
+    else if (wat[index] === ")" && --depth === 0) return wat.slice(start, index + 1);
+  }
+  throw new Error(`unterminated WAT function ${name}`);
+}
+
+function binaryenWat(binary: Uint8Array): string {
+  const module = binaryen.readBinary(binary);
+  try {
+    return module.emitText();
+  } finally {
+    module.dispose();
+  }
+}
+
+function normalizedRawTrampoline(body: string): string {
+  return body.replace(/\(type \d+\)/, "(type #)").replace(/\$__inl\d+_/g, "$__inl#_");
+}
+
+async function benchRuntime(result: CompileResult): Promise<number> {
+  const instance = await instantiateWithRuntime(result);
+  return (instance.exports.bench_loop as () => number)();
+}
+
+function generatedBench(cutover: boolean): GeneratedCodegenModule {
+  vi.stubEnv(CUTOVER, cutover ? "1" : "0");
+  vi.stubEnv(REQUIRE_ROUTE, "1");
+  const ast = analyzeMultiSource({ "helpers.ts": HELPERS_SOURCE, "loop.ts": LOOP_SOURCE }, "loop.ts");
+  return generateMultiModule(ast, {
+    experimentalIR: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+  });
 }
 
 afterEach(() => {
@@ -45,5 +123,175 @@ describe("#4590 exact bench_loop Prepared cutover", () => {
     expect(direct.errors.map((error) => error.message).join("\n")).toContain(
       "injected direct function-body poison: bench_loop",
     );
+  });
+
+  it("removes exactly the two bench_loop direct rows while preserving its raw body and external surface", async () => {
+    const prepared = await compileBench(true, {
+      emitWatOnlyFunctions: ["bench_loop", TRAMPOLINE],
+    });
+    const direct = await compileBench(false, {
+      emitWatOnlyFunctions: ["bench_loop", TRAMPOLINE],
+    });
+    expectSuccess(prepared, "Prepared raw compile");
+    expectSuccess(direct, "direct raw control");
+
+    const preparedRows = prepared.irBodyRouteAudit?.legacyEntries ?? [];
+    const directRows = direct.irBodyRouteAudit?.legacyEntries ?? [];
+    expect(preparedRows).toHaveLength(14);
+    expect(directRows).toHaveLength(16);
+    expect(preparedRows.filter((row) => row.entryPoint !== "compileDeclarations")).toHaveLength(12);
+    expect(directRows.filter((row) => row.entryPoint !== "compileDeclarations")).toHaveLength(14);
+    expect(preparedRows.filter((row) => row.bodyName === "bench_loop")).toEqual([]);
+    expect(directRows.filter((row) => row.bodyName !== "bench_loop")).toEqual(preparedRows);
+    expect(directRows.filter((row) => row.bodyName === "bench_loop").map((row) => row.entryPoint)).toEqual([
+      "compileFunctionBody",
+      "compileStatement",
+    ]);
+    const outcome = prepared.irOutcomes?.find((candidate) => candidate.displayName === "bench_loop");
+    expect(outcome).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irBodyRouteAudit?.dispositions.find((row) => row.unitId === outcome?.unitId)?.disposition).toBe(
+      "terminal-ir",
+    );
+
+    const preparedBody = watFunction(prepared.wat, "bench_loop");
+    const directBody = watFunction(direct.wat, "bench_loop");
+    const preparedTrampoline = watFunction(prepared.wat, TRAMPOLINE);
+    const directTrampoline = watFunction(direct.wat, TRAMPOLINE);
+    expect(preparedBody).toBe(directBody);
+    expect(normalizedRawTrampoline(preparedTrampoline)).toBe(normalizedRawTrampoline(directTrampoline));
+    expect(preparedBody.match(/\$slot___ru_acc[0-7]/g)).toHaveLength(8);
+    expect(preparedTrampoline.match(/\$__inl\d+_\$slot___ru_acc[0-7]/g)).toHaveLength(8);
+    expect(preparedBody).toContain("i32.const 125000");
+    expect(preparedTrampoline).toContain("i32.const 125000");
+
+    // Early support allocation is the one intentional raw artifact delta.
+    expect(prepared.binary.byteLength).toBe(direct.binary.byteLength - 35);
+    expect(prepared.dts).toBe(direct.dts);
+    expect(prepared.importsHelper).toBe(direct.importsHelper);
+    expect(prepared.imports).toEqual(direct.imports);
+    expect(prepared.stringPool).toEqual(direct.stringPool);
+    expect(wasmSurface(prepared.binary)).toEqual(wasmSurface(direct.binary));
+    await expect(benchRuntime(prepared)).resolves.toBe(EXPECTED_RUNTIME);
+    await expect(benchRuntime(direct)).resolves.toBe(EXPECTED_RUNTIME);
+  });
+
+  it("keeps optimized bench_loop and trampoline bodies exact without size or runtime growth", async () => {
+    const prepared = await compileBench(true, { optimize: true, preserveDebugNames: true });
+    const direct = await compileBench(false, { optimize: true, preserveDebugNames: true });
+    expectSuccess(prepared, "Prepared optimized compile");
+    expectSuccess(direct, "direct optimized control");
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    expect(prepared.binary.byteLength).toBe(50_363);
+    expect(direct.binary.byteLength).toBe(50_363);
+
+    const preparedWat = binaryenWat(prepared.binary);
+    const directWat = binaryenWat(direct.binary);
+    const preparedBody = watFunction(preparedWat, "bench_loop");
+    const directBody = watFunction(directWat, "bench_loop");
+    const preparedTrampoline = watFunction(preparedWat, TRAMPOLINE);
+    const directTrampoline = watFunction(directWat, TRAMPOLINE);
+    expect(preparedBody).toBe(directBody);
+    expect(preparedTrampoline).toBe(directTrampoline);
+    expect(preparedBody).toContain("(i32.const 125000)");
+    expect(preparedTrampoline).toContain("(i32.const 125000)");
+
+    expect(prepared.dts).toBe(direct.dts);
+    expect(prepared.importsHelper).toBe(direct.importsHelper);
+    expect(prepared.imports).toEqual(direct.imports);
+    expect(prepared.stringPool).toEqual(direct.stringPool);
+    expect(wasmSurface(prepared.binary)).toEqual(wasmSurface(direct.binary));
+    await expect(benchRuntime(prepared)).resolves.toBe(EXPECTED_RUNTIME);
+    await expect(benchRuntime(direct)).resolves.toBe(EXPECTED_RUNTIME);
+  });
+
+  it("preserves support binding contracts with lane-exact singleton slots and objects", () => {
+    const prepared = generatedBench(true);
+    const direct = generatedBench(false);
+    for (const [label, result] of [
+      ["Prepared", prepared],
+      ["direct", direct],
+    ] as const) {
+      const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+      expect(hardErrors, `${label}: ${hardErrors.map((error) => error.message).join("\n")}`).toEqual([]);
+      expect(result.programAbi).toBeDefined();
+    }
+    const preparedOutcome = prepared.irOutcomes?.find((candidate) => candidate.displayName === "bench_loop");
+    const directOutcome = direct.irOutcomes?.find((candidate) => candidate.displayName === "bench_loop");
+    expect(preparedOutcome?.unitId).toBe(directOutcome?.unitId);
+    if (!preparedOutcome?.unitId) throw new Error("missing exact bench_loop UnitId");
+
+    const sourceId = irUnitCallableBindingId(preparedOutcome.unitId);
+    const trampolineId = irSupportFuncRef(preparedOutcome.unitId, "function-value-trampoline", TRAMPOLINE).binding
+      .bindingId;
+    const cacheId = irSupportGlobalRef(preparedOutcome.unitId, "function-value-cache", CACHE).binding.bindingId;
+    const ids = [sourceId, trampolineId, cacheId] as const;
+    const slotExpectations = [
+      { result: prepared, source: 76, trampoline: 78, cache: 10 },
+      { result: direct, source: 76, trampoline: 252, cache: 129 },
+    ] as const;
+
+    for (const { result, source, trampoline, cache } of slotExpectations) {
+      const publication = result.programAbi!;
+      expect(publication.abi.entries().filter((entry) => ids.includes(entry.id))).toHaveLength(3);
+      expect(publication.abi.get(sourceId)).toMatchObject({
+        id: sourceId,
+        displayName: "bench_loop",
+        slotPolicy: "required",
+        slotSpace: "function",
+        intent: { kind: "callable", origin: "source", unitId: preparedOutcome.unitId },
+      });
+      expect(publication.abi.get(trampolineId)).toMatchObject({
+        id: trampolineId,
+        displayName: TRAMPOLINE,
+        slotPolicy: "required",
+        slotSpace: "function",
+        intent: { kind: "callable", origin: "support", unitId: preparedOutcome.unitId },
+      });
+      expect(publication.abi.get(cacheId)).toMatchObject({
+        id: cacheId,
+        displayName: CACHE,
+        slotPolicy: "required",
+        slotSpace: "global",
+        intent: { kind: "global", origin: "support", mutable: true, valueType: '{"kind":"externref"}' },
+      });
+      expect(publication.abi.resolveFinalIndex(sourceId)).toEqual({ space: "function", index: source });
+      expect(publication.abi.resolveFinalIndex(trampolineId)).toEqual({ space: "function", index: trampoline });
+      expect(publication.abi.resolveFinalIndex(cacheId)).toEqual({ space: "global", index: cache });
+
+      const functionImports = result.module.imports.filter((entry) => entry.desc.kind === "func").length;
+      const globalImports = result.module.imports.filter((entry) => entry.desc.kind === "global").length;
+      const sourceObject = result.module.functions[source - functionImports];
+      const trampolineObject = result.module.functions[trampoline - functionImports];
+      const cacheObject = result.module.globals[cache - globalImports];
+      expect(result.module.functions.filter((func) => func.name === "bench_loop")).toEqual([sourceObject]);
+      expect(result.module.functions.filter((func) => func.name === TRAMPOLINE)).toEqual([trampolineObject]);
+      expect(result.module.globals.filter((global) => global.name === CACHE)).toEqual([cacheObject]);
+      expect(sourceObject?.name).toBe("bench_loop");
+      expect(trampolineObject?.name).toBe(TRAMPOLINE);
+      expect(cacheObject).toMatchObject({ name: CACHE, mutable: true, type: { kind: "externref" } });
+
+      if (!sourceObject || !trampolineObject) throw new Error("missing exact function object at Program ABI slot");
+      const sourceEntry = publication.abi.get(sourceId);
+      const trampolineEntry = publication.abi.get(trampolineId);
+      const sourceSignature = canonicalProgramAbiCallableTypeContract(result.module.types[sourceObject.typeIdx]!);
+      const trampolineSignature = canonicalProgramAbiCallableTypeContract(
+        result.module.types[trampolineObject.typeIdx]!,
+      );
+      expect(sourceSignature).toEqual({ params: [], results: ['{"kind":"f64"}'] });
+      expect(sourceEntry?.intent.kind === "callable" ? sourceEntry.intent.signature : undefined).toEqual(
+        sourceSignature,
+      );
+      expect(trampolineSignature.results).toEqual(['{"kind":"f64"}']);
+      expect(trampolineSignature.params).toHaveLength(1);
+      expect(trampolineSignature.params[0]).toMatch(/^\{"kind":"ref(?:_null)?",/);
+      expect(trampolineEntry?.intent.kind === "callable" ? trampolineEntry.intent.signature : undefined).toEqual(
+        trampolineSignature,
+      );
+    }
   });
 });

--- a/tests/issue-4591-fib-pair-prepared-cutover.test.ts
+++ b/tests/issue-4591-fib-pair-prepared-cutover.test.ts
@@ -496,6 +496,10 @@ describe("#4591 exact Fibonacci pair Prepared cutover", () => {
       source: replaceOnce(FIB_SOURCE, "  host.appendChild(wrap);", "  void bench_fib;\n  host.appendChild(wrap);"),
     },
     {
+      label: "recursive member function-value reference",
+      source: replaceOnce(FIB_SOURCE, "  host.appendChild(wrap);", "  void fib;\n  host.appendChild(wrap);"),
+    },
+    {
       label: "outer function reassignment",
       source: replaceOnce(
         FIB_SOURCE,

--- a/tests/issue-4591-fib-pair-prepared-cutover.test.ts
+++ b/tests/issue-4591-fib-pair-prepared-cutover.test.ts
@@ -1,0 +1,528 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import binaryen from "binaryen";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { analyzeMultiSource } from "../src/checker/index.js";
+import { generateMultiModule, type GeneratedCodegenModule } from "../src/codegen/index.js";
+import { canonicalProgramAbiCallableTypeContract } from "../src/codegen/program-abi-signatures.js";
+import { compileMulti, compileProject, type CompileOptions, type CompileResult } from "../src/index.js";
+import { irSupportGlobalRef } from "../src/ir/abi-bindings.js";
+import { irSupportFuncRef, irUnitCallableBindingId } from "../src/ir/callable-bindings.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+// Register the low-level codegen delegates used by generateMultiModule.
+import "../src/codegen/expressions.js";
+
+const ENTRY = resolve(import.meta.dirname, "../website/playground/examples/benchmarks/fib.ts");
+const HELPERS = resolve(import.meta.dirname, "../website/playground/examples/benchmarks/helpers.ts");
+const FIB_SOURCE = readFileSync(ENTRY, "utf8");
+const HELPERS_SOURCE = readFileSync(HELPERS, "utf8");
+const CUTOVER = "JS2WASM_MULTI_PREPARED_FIB_PAIR_CUTOVER";
+const DIRECT_POISON = "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY";
+const REQUIRE_ROUTE = "JS2WASM_TEST_REQUIRE_MULTI_PREPARED_FIB_PAIR";
+const SEAL_FAILURE = "JS2WASM_TEST_INJECT_IR_PREPARED_SEAL_FAILURE";
+const TAMPER = "JS2WASM_TEST_TAMPER_MULTI_PREPARED_FIB_PAIR";
+const TARGETS = ["fib", "bench_fib"] as const;
+const TRAMPOLINE = "__fn_tramp_bench_fib_cached";
+const CACHE = "__fn_closure_bench_fib";
+const EXPECTED_RUNTIME = 832_040;
+const OLD_RAW_BYTES = 114_844;
+const OLD_RAW_SHA256 = "1d9d913d021eded3d9f9e9349bd3dbe095836e9daec4f8fa53e7c27ae3c6a4e3";
+const OLD_WAT_SHA256 = "2575b086c93e14277b2cf43c837f7d944cb61e093d11c17034175d07afa23825";
+const OLD_DTS_SHA256 = "874ff64e8642ca4d5d1060091ab7d78a9ab0eda374e483e5c028115ad71c2022";
+const OLD_OPTIMIZED_BYTES = 48_521;
+const OLD_OPTIMIZED_SHA256 = "4e8f66606a18497ad7c11d4a65e14dd120b69caa825bf7a3c6e1738fbc4d2837";
+
+function expectSuccess(result: CompileResult, label: string): void {
+  expect(
+    result.success,
+    `${label} failed:\n${result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")}`,
+  ).toBe(true);
+}
+
+function targetLegacyRows(result: CompileResult) {
+  return (
+    result.irBodyRouteAudit?.legacyEntries.filter((row) =>
+      TARGETS.includes(row.bodyName as (typeof TARGETS)[number]),
+    ) ?? []
+  );
+}
+
+function digest(value: Uint8Array | string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function compileFib(cutover: boolean, options: CompileOptions = {}): Promise<CompileResult> {
+  vi.stubEnv(CUTOVER, cutover ? "1" : "0");
+  return compileProject(ENTRY, {
+    experimentalIR: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+    emitWat: true,
+    ...options,
+  });
+}
+
+function wasmSurface(binary: Uint8Array) {
+  const module = new WebAssembly.Module(binary);
+  return {
+    imports: WebAssembly.Module.imports(module),
+    exports: WebAssembly.Module.exports(module),
+  };
+}
+
+function watFunction(wat: string, name: string): string {
+  const sameLine = wat.indexOf(`(func $${name} `);
+  const start = sameLine >= 0 ? sameLine : wat.indexOf(`(func $${name}\n`);
+  if (start < 0) throw new Error(`missing WAT function ${name}`);
+  let depth = 0;
+  for (let index = start; index < wat.length; index++) {
+    if (wat[index] === "(") depth++;
+    else if (wat[index] === ")" && --depth === 0) return wat.slice(start, index + 1);
+  }
+  throw new Error(`unterminated WAT function ${name}`);
+}
+
+function binaryenWat(binary: Uint8Array): string {
+  const module = binaryen.readBinary(binary);
+  try {
+    return module.emitText();
+  } finally {
+    module.dispose();
+  }
+}
+
+function normalizedRawTrampoline(body: string): string {
+  return body.replace(/\(type \d+\)/, "(type #)").replace(/\$__inl\d+_/g, "$__inl#_");
+}
+
+function expectSurfaceParity(prepared: CompileResult, direct: CompileResult): void {
+  expect(prepared.dts).toBe(direct.dts);
+  expect(prepared.importsHelper).toBe(direct.importsHelper);
+  expect(prepared.imports).toEqual(direct.imports);
+  expect(prepared.stringPool).toEqual(direct.stringPool);
+  expect(wasmSurface(prepared.binary)).toEqual(wasmSurface(direct.binary));
+}
+
+async function fibonacciRuntime(result: CompileResult): Promise<readonly [number, number]> {
+  const instance = await instantiateWithRuntime(result);
+  const fib = instance.exports.fib as (value: number) => number;
+  const benchFib = instance.exports.bench_fib as () => number;
+  return [fib(10), benchFib()];
+}
+
+function expectDirectPoison(result: CompileResult): void {
+  expect(result.success).toBe(false);
+  const errors = result.errors.map((error) => error.message).join("\n");
+  for (const name of TARGETS) expect(errors).toContain(`injected direct function-body poison: ${name}`);
+  expect(
+    targetLegacyRows(result)
+      .map((row) => [row.bodyName, row.entryPoint])
+      .sort(),
+  ).toEqual(TARGETS.map((name) => [name, "compileFunctionBody"]).sort());
+}
+
+function replaceOnce(source: string, search: string, replacement: string): string {
+  if (!source.includes(search)) throw new Error(`missing mutation anchor: ${search}`);
+  return source.replace(search, replacement);
+}
+
+async function compileMutatedFib(source: string): Promise<CompileResult> {
+  vi.stubEnv(CUTOVER, "1");
+  vi.stubEnv(DIRECT_POISON, TARGETS.join(","));
+  return compileMulti({ "helpers.ts": HELPERS_SOURCE, "fib.ts": source }, "fib.ts", {
+    experimentalIR: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+  });
+}
+
+function generatedFib(cutover: boolean): GeneratedCodegenModule {
+  vi.stubEnv(CUTOVER, cutover ? "1" : "0");
+  vi.stubEnv(REQUIRE_ROUTE, "1");
+  const ast = analyzeMultiSource({ "helpers.ts": HELPERS_SOURCE, "fib.ts": FIB_SOURCE }, "fib.ts");
+  return generateMultiModule(ast, {
+    experimentalIR: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("#4591 exact Fibonacci pair Prepared cutover", () => {
+  it("atomically bypasses both real compileProject direct bodies and restores both with the kill switch", async () => {
+    vi.stubEnv(REQUIRE_ROUTE, "1");
+    vi.stubEnv(DIRECT_POISON, TARGETS.join(","));
+    const prepared = await compileProject(ENTRY, {
+      experimentalIR: true,
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    expectSuccess(prepared, "default-on Prepared Fibonacci pair");
+    expect(targetLegacyRows(prepared)).toEqual([]);
+    const outcomes = TARGETS.map((name) => prepared.irOutcomes?.find((outcome) => outcome.displayName === name));
+    expect(outcomes).toEqual([
+      expect.objectContaining({ irBodyEmitted: true, legacyBodyEmitted: false }),
+      expect.objectContaining({ irBodyEmitted: true, legacyBodyEmitted: false }),
+    ]);
+    expect(outcomes[0]?.preparedComponentId).toMatch(/^prepared-component:/);
+    expect(outcomes[1]?.preparedComponentId).toBe(outcomes[0]?.preparedComponentId);
+
+    vi.stubEnv(CUTOVER, "0");
+    const direct = await compileProject(ENTRY, {
+      experimentalIR: true,
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    expect(direct.success).toBe(false);
+    const errors = direct.errors.map((error) => error.message).join("\n");
+    expect(errors).toContain("injected direct function-body poison: fib");
+    expect(errors).toContain("injected direct function-body poison: bench_fib");
+    expect(
+      targetLegacyRows(direct)
+        .map((row) => [row.bodyName, row.entryPoint])
+        .sort(),
+    ).toEqual(TARGETS.map((name) => [name, "compileFunctionBody"]).sort());
+  });
+
+  it("removes exactly four direct rows as one Prepared component while preserving raw bodies and surface", async () => {
+    const prepared = await compileFib(true);
+    const direct = await compileFib(false);
+    expectSuccess(prepared, "Prepared raw Fibonacci compile");
+    expectSuccess(direct, "direct raw Fibonacci control");
+
+    const preparedRows = prepared.irBodyRouteAudit?.legacyEntries ?? [];
+    const directRows = direct.irBodyRouteAudit?.legacyEntries ?? [];
+    expect(preparedRows).toHaveLength(14);
+    expect(directRows).toHaveLength(18);
+    expect(preparedRows.filter((row) => row.entryPoint !== "compileDeclarations")).toHaveLength(12);
+    expect(directRows.filter((row) => row.entryPoint !== "compileDeclarations")).toHaveLength(16);
+    expect(targetLegacyRows(prepared)).toEqual([]);
+    expect(directRows.filter((row) => !TARGETS.includes(row.bodyName as (typeof TARGETS)[number]))).toEqual(
+      preparedRows,
+    );
+    expect(
+      targetLegacyRows(direct)
+        .map((row) => [row.bodyName, row.entryPoint])
+        .sort(),
+    ).toEqual(
+      [
+        ["fib", "compileFunctionBody"],
+        ["fib", "compileStatement"],
+        ["bench_fib", "compileFunctionBody"],
+        ["bench_fib", "compileStatement"],
+      ].sort(),
+    );
+
+    const outcomes = TARGETS.map((name) => prepared.irOutcomes?.find((outcome) => outcome.displayName === name));
+    for (const outcome of outcomes) {
+      expect(outcome).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irBodyRouteAudit?.dispositions.find((row) => row.unitId === outcome?.unitId)?.disposition).toBe(
+        "terminal-ir",
+      );
+    }
+    expect(outcomes[1]?.preparedComponentId).toBe(outcomes[0]?.preparedComponentId);
+
+    for (const name of [...TARGETS, TRAMPOLINE]) {
+      const preparedBody = watFunction(prepared.wat, name);
+      const directBody = watFunction(direct.wat, name);
+      if (name === TRAMPOLINE) expect(normalizedRawTrampoline(preparedBody)).toBe(normalizedRawTrampoline(directBody));
+      else expect(preparedBody).toBe(directBody);
+    }
+    expect(watFunction(prepared.wat, "fib").match(/\bcall 76\b/g)).toHaveLength(2);
+    expect(watFunction(prepared.wat, "bench_fib")).toContain("call 76");
+    expect(watFunction(prepared.wat, TRAMPOLINE)).toContain("call 76");
+
+    expect(direct.binary.byteLength).toBe(OLD_RAW_BYTES);
+    expect(digest(direct.binary)).toBe(OLD_RAW_SHA256);
+    expect(digest(direct.wat)).toBe(OLD_WAT_SHA256);
+    expect(digest(direct.dts)).toBe(OLD_DTS_SHA256);
+    expectSurfaceParity(prepared, direct);
+    await expect(fibonacciRuntime(prepared)).resolves.toEqual([55, EXPECTED_RUNTIME]);
+    await expect(fibonacciRuntime(direct)).resolves.toEqual([55, EXPECTED_RUNTIME]);
+  });
+
+  it("keeps optimized target and trampoline bodies exact without artifact growth", async () => {
+    const prepared = await compileFib(true, { optimize: true });
+    const direct = await compileFib(false, { optimize: true });
+    expectSuccess(prepared, "Prepared optimized Fibonacci compile");
+    expectSuccess(direct, "direct optimized Fibonacci control");
+    expect(direct.binary.byteLength).toBe(OLD_OPTIMIZED_BYTES);
+    expect(digest(direct.binary)).toBe(OLD_OPTIMIZED_SHA256);
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    expectSurfaceParity(prepared, direct);
+    await expect(fibonacciRuntime(prepared)).resolves.toEqual([55, EXPECTED_RUNTIME]);
+    await expect(fibonacciRuntime(direct)).resolves.toEqual([55, EXPECTED_RUNTIME]);
+
+    const preparedNamed = await compileFib(true, { optimize: true, preserveDebugNames: true });
+    const directNamed = await compileFib(false, { optimize: true, preserveDebugNames: true });
+    expectSuccess(preparedNamed, "Prepared preserve-names optimized Fibonacci compile");
+    expectSuccess(directNamed, "direct preserve-names optimized Fibonacci control");
+    expect(preparedNamed.binary.byteLength).toBe(50_123);
+    expect(directNamed.binary.byteLength).toBe(50_123);
+    const preparedWat = binaryenWat(preparedNamed.binary);
+    const directWat = binaryenWat(directNamed.binary);
+    for (const name of [...TARGETS, TRAMPOLINE]) {
+      expect(watFunction(preparedWat, name)).toBe(watFunction(directWat, name));
+    }
+    expectSurfaceParity(preparedNamed, directNamed);
+  });
+
+  it("preserves exact source and outer support binding objects in both allocation lanes", () => {
+    const prepared = generatedFib(true);
+    const direct = generatedFib(false);
+    for (const [label, result] of [
+      ["Prepared", prepared],
+      ["direct", direct],
+    ] as const) {
+      const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+      expect(hardErrors, `${label}: ${hardErrors.map((error) => error.message).join("\n")}`).toEqual([]);
+      expect(result.programAbi).toBeDefined();
+    }
+
+    const preparedOutcomes = new Map(
+      TARGETS.map((name) => [name, prepared.irOutcomes?.find((outcome) => outcome.displayName === name)] as const),
+    );
+    const directOutcomes = new Map(
+      TARGETS.map((name) => [name, direct.irOutcomes?.find((outcome) => outcome.displayName === name)] as const),
+    );
+    const fibUnitId = preparedOutcomes.get("fib")?.unitId;
+    const benchUnitId = preparedOutcomes.get("bench_fib")?.unitId;
+    expect(fibUnitId).toBe(directOutcomes.get("fib")?.unitId);
+    expect(benchUnitId).toBe(directOutcomes.get("bench_fib")?.unitId);
+    if (!fibUnitId || !benchUnitId) throw new Error("missing exact Fibonacci pair UnitIds");
+
+    const fibSourceId = irUnitCallableBindingId(fibUnitId);
+    const benchSourceId = irUnitCallableBindingId(benchUnitId);
+    const trampolineId = irSupportFuncRef(benchUnitId, "function-value-trampoline", TRAMPOLINE).binding.bindingId;
+    const cacheId = irSupportGlobalRef(benchUnitId, "function-value-cache", CACHE).binding.bindingId;
+    const ids = [fibSourceId, benchSourceId, trampolineId, cacheId] as const;
+    const slotExpectations = [
+      { result: prepared, fib: 76, bench: 77, trampoline: undefined, cache: undefined },
+      { result: direct, fib: 76, bench: 77, trampoline: 253, cache: 129 },
+    ] as const;
+
+    for (const { result, fib, bench, trampoline, cache } of slotExpectations) {
+      const publication = result.programAbi!;
+      expect(publication.abi.entries().filter((entry) => ids.includes(entry.id))).toHaveLength(4);
+      expect(publication.abi.get(fibSourceId)).toMatchObject({
+        id: fibSourceId,
+        displayName: "fib",
+        slotPolicy: "required",
+        slotSpace: "function",
+        intent: { kind: "callable", origin: "source", unitId: fibUnitId },
+      });
+      expect(publication.abi.get(benchSourceId)).toMatchObject({
+        id: benchSourceId,
+        displayName: "bench_fib",
+        slotPolicy: "required",
+        slotSpace: "function",
+        intent: { kind: "callable", origin: "source", unitId: benchUnitId },
+      });
+      expect(publication.abi.get(trampolineId)).toMatchObject({
+        id: trampolineId,
+        displayName: TRAMPOLINE,
+        slotPolicy: "required",
+        slotSpace: "function",
+        intent: { kind: "callable", origin: "support", unitId: benchUnitId },
+      });
+      expect(publication.abi.get(cacheId)).toMatchObject({
+        id: cacheId,
+        displayName: CACHE,
+        slotPolicy: "required",
+        slotSpace: "global",
+        intent: { kind: "global", origin: "support", mutable: true, valueType: '{"kind":"externref"}' },
+      });
+      expect(publication.abi.resolveFinalIndex(fibSourceId)).toEqual({ space: "function", index: fib });
+      expect(publication.abi.resolveFinalIndex(benchSourceId)).toEqual({ space: "function", index: bench });
+      const resolvedTrampoline = publication.abi.resolveFinalIndex(trampolineId);
+      const resolvedCache = publication.abi.resolveFinalIndex(cacheId);
+      if (trampoline === undefined || cache === undefined) {
+        expect(resolvedTrampoline).toMatchObject({ space: "function", index: expect.any(Number) });
+        expect(resolvedCache).toMatchObject({ space: "global", index: expect.any(Number) });
+      } else {
+        expect(resolvedTrampoline).toEqual({ space: "function", index: trampoline });
+        expect(resolvedCache).toEqual({ space: "global", index: cache });
+      }
+
+      const functionImports = result.module.imports.filter((entry) => entry.desc.kind === "func").length;
+      const globalImports = result.module.imports.filter((entry) => entry.desc.kind === "global").length;
+      const fibObject = result.module.functions[fib - functionImports];
+      const benchObject = result.module.functions[bench - functionImports];
+      const trampolineObject = result.module.functions[resolvedTrampoline!.index - functionImports];
+      const cacheObject = result.module.globals[resolvedCache!.index - globalImports];
+      expect(result.module.functions.filter((func) => func.name === "fib")).toEqual([fibObject]);
+      expect(result.module.functions.filter((func) => func.name === "bench_fib")).toEqual([benchObject]);
+      expect(result.module.functions.filter((func) => func.name === TRAMPOLINE)).toEqual([trampolineObject]);
+      expect(result.module.globals.filter((global) => global.name === CACHE)).toEqual([cacheObject]);
+      expect(result.module.functions.some((func) => func.name === "__fn_tramp_fib_cached")).toBe(false);
+      expect(result.module.globals.some((global) => global.name === "__fn_closure_fib")).toBe(false);
+      expect(cacheObject).toMatchObject({ name: CACHE, mutable: true, type: { kind: "externref" } });
+
+      if (!fibObject || !benchObject || !trampolineObject) throw new Error("missing Program ABI callable object");
+      const fibSignature = canonicalProgramAbiCallableTypeContract(result.module.types[fibObject.typeIdx]!);
+      const benchSignature = canonicalProgramAbiCallableTypeContract(result.module.types[benchObject.typeIdx]!);
+      const trampolineSignature = canonicalProgramAbiCallableTypeContract(
+        result.module.types[trampolineObject.typeIdx]!,
+      );
+      expect(fibSignature).toEqual({ params: ['{"kind":"f64"}'], results: ['{"kind":"f64"}'] });
+      expect(benchSignature).toEqual({ params: [], results: ['{"kind":"f64"}'] });
+      expect(trampolineSignature.results).toEqual(['{"kind":"f64"}']);
+      expect(trampolineSignature.params).toHaveLength(1);
+      expect(trampolineSignature.params[0]).toMatch(/^\{"kind":"ref(?:_null)?",/);
+      expect(publication.abi.get(fibSourceId)?.intent).toMatchObject({ signature: fibSignature });
+      expect(publication.abi.get(benchSourceId)?.intent).toMatchObject({ signature: benchSignature });
+      expect(publication.abi.get(trampolineId)?.intent).toMatchObject({ signature: trampolineSignature });
+    }
+  });
+
+  it("withdraws the whole component when Prepared sealing is Unsupported", async () => {
+    vi.stubEnv(SEAL_FAILURE, "1");
+    vi.stubEnv(DIRECT_POISON, TARGETS.join(","));
+    const result = await compileFib(true);
+    expectDirectPoison(result);
+    expect(result.errors.map((error) => error.message).join("\n")).not.toContain(
+      "did not withdraw atomically before its skip",
+    );
+  });
+
+  it("fails closed when the certified pair or its support drifts before the late overlay", async () => {
+    vi.stubEnv(TAMPER, "1");
+    const result = await compileFib(true);
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain("drifted after direct-body certification");
+    expect(targetLegacyRows(result)).toEqual([]);
+  });
+
+  it("routes the same exact component after both source declarations and uses are renamed", async () => {
+    const source = FIB_SOURCE.replaceAll("bench_fib", "renamed_bench").replaceAll("fib", "renamed_fib");
+    vi.stubEnv(CUTOVER, "1");
+    vi.stubEnv(REQUIRE_ROUTE, "1");
+    vi.stubEnv(DIRECT_POISON, "renamed_fib,renamed_bench");
+    const result = await compileMulti({ "helpers.ts": HELPERS_SOURCE, "fib.ts": source }, "fib.ts", {
+      experimentalIR: true,
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result, "renamed Prepared Fibonacci component");
+    for (const name of ["renamed_fib", "renamed_bench"]) {
+      expect(result.irBodyRouteAudit?.legacyEntries.filter((row) => row.bodyName === name)).toEqual([]);
+      expect(result.irOutcomes?.find((outcome) => outcome.displayName === name)).toMatchObject({
+        irBodyEmitted: true,
+        legacyBodyEmitted: false,
+      });
+    }
+  });
+
+  it.each([
+    {
+      label: "missing recursive self-edge",
+      source: replaceOnce(FIB_SOURCE, "return fib(n - 1) + fib(n - 2);", "return n - 1;"),
+    },
+    {
+      label: "altered recurrence",
+      source: replaceOnce(FIB_SOURCE, "return fib(n - 1) + fib(n - 2);", "return fib(n - 1) - fib(n - 2);"),
+    },
+    {
+      label: "altered benchmark literal",
+      source: replaceOnce(FIB_SOURCE, "return fib(30);", "return fib(29);"),
+    },
+    {
+      label: "extra component member",
+      source: replaceOnce(
+        FIB_SOURCE,
+        "export function main(): void {",
+        "export function wrapper(): number { return bench_fib(); }\n\nexport function main(): void {",
+      ),
+    },
+    {
+      label: "extra legacy caller",
+      source: replaceOnce(FIB_SOURCE, "  const host = document.body;", "  void fib(2);\n  const host = document.body;"),
+    },
+    {
+      label: "extra component callee",
+      source: replaceOnce(
+        FIB_SOURCE,
+        "export function bench_fib(): number {\n  return fib(30);\n}",
+        "function adjust(n: number): number { return n; }\n\nexport function bench_fib(): number {\n  return fib(30) + adjust(0);\n}",
+      ),
+    },
+    {
+      label: "shadowed recursive target",
+      source: replaceOnce(
+        FIB_SOURCE,
+        "export function bench_fib(): number {\n  return fib(30);\n}",
+        "export function bench_fib(): number {\n  const fib = (n: number): number => n;\n  return fib(30);\n}",
+      ),
+    },
+    {
+      label: "ambiguous recursive declaration",
+      source: replaceOnce(
+        FIB_SOURCE,
+        "export function fib(n: number): number {",
+        "export function fib(n: number): number;\nexport function fib(n: number): number {",
+      ),
+    },
+    {
+      label: "one ineligible component member",
+      source: replaceOnce(
+        FIB_SOURCE,
+        "export function bench_fib(): number {",
+        "export function bench_fib(): number {\n  void 0;",
+      ),
+    },
+    {
+      label: "stored outer function value",
+      source: replaceOnce(
+        FIB_SOURCE,
+        '  addBenchCard(wrap, "fib(30)", "Recursive — pure i32/f64 math, no host calls", bench_fib);',
+        '  const stored = bench_fib;\n  addBenchCard(wrap, "fib(30)", "Recursive — pure i32/f64 math, no host calls", stored);',
+      ),
+    },
+    {
+      label: "extra outer function-value reference",
+      source: replaceOnce(FIB_SOURCE, "  host.appendChild(wrap);", "  void bench_fib;\n  host.appendChild(wrap);"),
+    },
+    {
+      label: "outer function reassignment",
+      source: replaceOnce(
+        FIB_SOURCE,
+        "  const host = document.body;",
+        "  if (false) bench_fib = (): number => 0;\n  const host = document.body;",
+      ),
+    },
+    {
+      label: "support-name collision",
+      source: `${FIB_SOURCE}\nfunction ${TRAMPOLINE}(value: string): string { return value; }\n`,
+    },
+    {
+      label: "module initialization",
+      source: `let moduleMarker = 1;\n${FIB_SOURCE}`,
+    },
+  ])("withdraws the whole component before skip for $label", async ({ source }) => {
+    expectDirectPoison(await compileMutatedFib(source));
+  });
+
+  it.each([
+    ["default GC", { target: "gc" as const }],
+    ["fast standalone", { target: "standalone" as const, fast: true }],
+    ["WASI", { target: "wasi" as const }],
+    ["IR-first disabled", { target: "standalone" as const, disableIrFirst: true }],
+    ["IR disabled", { target: "standalone" as const, experimentalIR: false }],
+  ])("keeps the %s lane direct-owned", async (_label, options) => {
+    vi.stubEnv(DIRECT_POISON, TARGETS.join(","));
+    expectDirectPoison(await compileFib(true, options));
+  });
+});


### PR DESCRIPTION
Completed #4591 implementation, stacked on #4681 / #4590.

This cuts the exact recursive fib + bench_fib component over atomically before multi-source direct bodies. It freezes only the wrapper function-value trampoline/cache support, requires both terminal receipts to share one Prepared component, and withdraws both or neither.

Final evidence:
- focused #4591: 27/27 under a 512 MiB heap cap
- dual direct-body poison bypass; kill switch restores both direct poisons
- recursive-member non-call value reference withdraws the whole component before skip
- exact route reduction: 18 to 14 total and 16 to 12 non-declaration rows
- source slots fib=76 and bench_fib=77 remain stable
- candidate raw 114,795 bytes versus exact control 114,844; documented support-allocation delta only
- default optimized size unchanged at 48,521 bytes; preserve-names both 50,123 bytes
- exact target/trampoline bodies, runtime 832040, external surface/DTS/import/string-pool parity
- Program ABI binding/object checks with lane-exact support slots
- bounded shape, edge, value-flow, collision, reassignment, module-init, mode, seal, and tamper negatives
- adjacent #4590 21/21 and #4589 15/15
- TypeScript, LOC/function/oracle/format/diff/issues gates green

Independent review approved the implementation and final evidence. Keep this PR draft until #4680 and #4681 land, then sync it to current main and verify the child-only diff before marking ready.

Process note: this environment could not unlock the passphrase-protected SSH signing key, so the two Codex-authored commits are correctly attributed but unsigned; no replacement key or history rewrite was attempted.