### PR TITLE
fix(npm-compat): bound upstream React test watchdogs

### DIFF
--- a/plan/issues/4585-npm-compat-refresh-resilience.md
+++ b/plan/issues/4585-npm-compat-refresh-resilience.md
@@ -23,6 +23,7 @@ files:
   - src/codegen/extern-declarations.ts
   - tests/dogfood/react-dom-upstream-suite.mjs
   - tests/dogfood/react-dom-upstream-suite.test.ts
+  - tests/dogfood/react-upstream-suite.mjs
   - tests/issue-3781-npm-perf-lanes.test.ts
   - tests/issue-4585-npm-compat-refresh-resilience.test.ts
   - plan/issues/4585-npm-compat-refresh-resilience.md
@@ -56,6 +57,10 @@ artifacts:
   modules while rejecting every unrelated optimizer warning.
 - Regenerate and publish the complete npm compatibility aggregate only after
   every package finishes and the fixed Acorn/clsx measurements are present.
+- Bound the React and React DOM per-test watchdogs at two seconds by default so
+  admitted upstream tests that need unavailable async infrastructure remain
+  visible in the report without consuming the aggregate refresh's entire job
+  budget.
 
 ## Acceptance criteria
 
@@ -70,6 +75,9 @@ artifacts:
       record the omitted `Flatten` pass and no raw fallback is measured.
 - [ ] A fresh aggregate refresh completes and the live page serves a post-#4578
       timestamp and corrected Acorn/clsx measurements.
+- [ ] The full aggregate refresh reaches publication without timing out in the
+      React upstream suites; all admitted tests remain represented with an
+      explicit pass, fail, trap, or infrastructure outcome.
 
 Pre-[#4586](./4586-o4-try-table-flatten-fallback.md) checkpoint: the exact standalone-dynamic clsx 2.1.1 lane at O3 measured
 0.149035 µs/op versus Node's 0.023225 µs/op (ratio 0.155833), with checksum
@@ -97,3 +105,15 @@ O3 artifact; the stale public ratio is 0.000838.
 - Focused parse/standalone tests pass `16/16`; ReactDOM infrastructure passes
   `5/5` with its heavy suite deliberately skipped. Typecheck, formatting, lint,
   LOC/function/oracle/dead-export, IR-fallback, and issue gates pass.
+
+## Refresh-timeout checkpoint
+
+The first post-O4 full refresh reached the React package at 04:54 UTC and was
+cancelled at the 180-minute workflow limit before the next package. The log
+showed no compiler error: React's 272 admitted upstream tests were being run
+with the historical ten-second per-test watchdog, so tests waiting on missing
+Jest/DOM infrastructure serialized into hours. A local complete React run with
+the watchdog set to 2 seconds finished in 56 seconds and retained the same
+`102/179` scored result (`272/273` upstream tests represented). This change
+keeps the original corpus and records each timeout; it only prevents a missing
+async dependency from starving publication.

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -44,6 +44,11 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const REPORT_PATH = join(HERE, "report", "react-dom-upstream-suite.json");
 const GENERATED_ROOT = join(HERE, ".react-dom-upstream-suite-impl");
 const PROJECT_ROOT = join(HERE, ".react-dom-upstream-suite-project");
+// Keep the complete upstream corpus observable without allowing a missing
+// browser/test dependency to consume the refresh job's entire wall-clock
+// budget. A timeout is reported on the individual test; it never removes the
+// test from extraction or the denominator silently.
+const DEFAULT_REACT_DOM_TEST_TIMEOUT_MS = 2_000;
 
 let nativeContextFile = "<setup>";
 let nativeContextTest = "<setup>";
@@ -552,7 +557,7 @@ async function runServerHarness({
     serverSource: isFizz ? "" : (serverSource ?? ""),
     fizzSource,
   });
-  const testTimeoutMs = Number(process.env.DOGFOOD_REACT_DOM_TEST_TIMEOUT_MS ?? 10_000);
+  const testTimeoutMs = Number(process.env.DOGFOOD_REACT_DOM_TEST_TIMEOUT_MS ?? DEFAULT_REACT_DOM_TEST_TIMEOUT_MS);
   const configuredCompileTimeout = Number(process.env.DOGFOOD_REACT_DOM_COMPILE_TIMEOUT_MS ?? 300_000);
   const compileTimeoutMs =
     Number.isFinite(configuredCompileTimeout) && configuredCompileTimeout > 0 ? configuredCompileTimeout : 300_000;

--- a/tests/dogfood/react-upstream-suite.mjs
+++ b/tests/dogfood/react-upstream-suite.mjs
@@ -46,6 +46,13 @@ import { REACT_EXPECT_SHIM, LAST_ERROR_EXPORT, buildTestFunction } from "./react
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPORT_PATH = join(HERE, "report", "react-upstream-suite.json");
+// React's lifted suite intentionally admits tests that need infrastructure the
+// harness cannot provide. Those tests still run against the native oracle and
+// the compiled lane, but a missing async dependency must not hold the complete
+// npm-compat refresh for ten seconds per test. The timeout is a watchdog, not
+// a test selection filter: timed-out tests remain in the report as failures or
+// harness-incompatible results.
+const DEFAULT_REACT_TEST_TIMEOUT_MS = 2_000;
 
 // `var exports = {}` makes the published CommonJS implementation an internal
 // module value. Every byte of the implementation after that one binding is
@@ -180,7 +187,7 @@ function quarantineFromErrors(moduleSource, tests, errors) {
 export async function runHarness({
   quiet = false,
   filter = process.env.DOGFOOD_REACT_FILTER || "",
-  testTimeoutMs = Number(process.env.DOGFOOD_REACT_TEST_TIMEOUT_MS || 10_000),
+  testTimeoutMs = Number(process.env.DOGFOOD_REACT_TEST_TIMEOUT_MS || DEFAULT_REACT_TEST_TIMEOUT_MS),
   compileTimeoutMs = Number(process.env.DOGFOOD_REACT_COMPILE_TIMEOUT_MS || 30_000),
 } = {}) {
   const log = quiet ? () => {} : (...values) => console.log(...values);


### PR DESCRIPTION
## Summary

- bound React and React DOM upstream per-test watchdogs to two seconds by default
- keep every admitted upstream test represented; timeouts remain explicit outcomes rather than silent skips
- unblock the full O4 npm-compat refresh from spending the job budget in the React suite

## Evidence

- React upstream suite: 272/273 upstream tests represented, 102/179 scored, completed in about 54 seconds with the new default
- React and React DOM harness tests: 11 passed, 2 intentionally skipped
- typecheck, lint, Prettier, issue-integrity, and diff checks pass
- the first post-O4 refresh was cancelled at the 180-minute limit immediately after entering React; no compiler error was reported

## Publication

After this PR merges, the queued main refresh will run with the O4 benchmark policy and the bounded watchdog, then publish through the existing npm-compat promotion PR. No partial artifact is included here.

Tracks [Restore npm compatibility refresh publication](https://github.com/loopdive/js2wasm/blob/codex/npm-compat-react-watchdog/plan/issues/4585-npm-compat-refresh-resilience.md).
