### PR TITLE
feat(ci): IR→codegen layering ratchet + move two shared-vocabulary leaves below the IR (#3113 S1+S2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,15 @@ jobs:
         if: steps.npm_compat.outputs.only != 'true'
         run: pnpm run check:jstag-seam
 
+      - name: IR->codegen layering ratchet (#3113)
+        if: steps.npm_compat.outputs.only != 'true'
+        # The intended layering is emit <- ir <- codegen. It regrew ~4x (25 ->
+        # 96 import lines) in the six weeks after #3113 slice 1 because nothing
+        # enforced it. Ratchet, not emptiness check: containing the 7k-LOC
+        # ir/integration.ts bridge (#3113 S3) is blocked on #3520/#3521, so the
+        # reachable invariant is "no growth, ratchet toward zero".
+        run: pnpm run check:ir-layering
+
       - name: IR fallback gate (#1376)
         if: steps.npm_compat.outputs.only != 'true'
         run: pnpm run check:ir-fallbacks

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "check:ir-dialect": "node scripts/check-ir-dialect.mjs",
     "check:ir-kind-neutrality": "node scripts/check-ir-kind-neutrality.mjs",
     "check:jstag-seam": "node scripts/check-jstag-seam.mjs",
+    "check:ir-layering": "node scripts/check-ir-layering.mjs",
     "check:ir-fallbacks": "npx tsx scripts/check-ir-fallbacks.ts",
     "check:host-import-policy": "node --import tsx scripts/check-host-import-policy.ts",
     "check:ir-only": "npx tsx scripts/check-ir-only.ts",

--- a/plan/issues/3113-ir-codegen-layering-shared-vocab.md
+++ b/plan/issues/3113-ir-codegen-layering-shared-vocab.md
@@ -123,3 +123,60 @@ byte-identical via `scripts/prove-emit-identity.mjs check` — all 56
 transitively pulling ~17 codegen modules (move the bridge to the codegen side /
 behind a narrow interface). That is a larger, design-sensitive change and is
 left open under this issue.
+
+## Implementation Plan (Fable, 2026-08-21)
+
+**Re-measured on `bc588f2f3` + the #4558/#4521 branch:** the inversion has
+kept regrowing since slice 1 — now **20 files under `src/ir/` import from
+`../codegen`, ~100 import lines** (was 6 files / 25 lines when this issue was
+filed), and `ir/integration.ts` is **7,335 LOC** (was 2,610). Top offenders:
+`integration.ts` 42 lines, `from-ast.ts` 7, `number-to-string-provider.ts` 6,
+`prepared-vector-support.ts` / `prepared-closure-support.ts` /
+`backend/linear-integration.ts` 5 each. Consequences for sequencing:
+
+- The original step 2 (move `integration.ts` to the codegen side) is now MORE
+  disruptive and collides with the in-flight R1–R4 branches (#3520–#3523),
+  which edit that file heavily. **Do not do it in this dispatch.**
+- The guard (original step 4) is the urgent part — the boundary regrew 4×
+  since this issue was FILED because nothing enforces it. AC 1's "grep empty"
+  is not reachable today; the guard must be a **ratchet**, not an emptiness
+  check.
+
+**S1 — the layering ratchet (this dispatch, Opus):**
+
+1. `scripts/check-ir-layering.mjs`: walk `src/ir/**/*.ts`, count import lines
+   whose specifier resolves into `src/codegen/` (match `from "../codegen` and
+   `from "../../codegen`; ignore type-only? NO — count `import type` too, the
+   boundary is about the dependency graph). Output per-file counts.
+2. Baseline `scripts/ir-layering-baseline.json` seeded at the measured
+   current truth (per-file map + total). Gate semantics cloned from
+   `scripts/check-linear-ir.ts`: any per-file increase OR any NEW file with
+   codegen imports fails; decreases pass with a hint to `--update`;
+   `--update` refreshes.
+3. Wire as `"check:ir-layering"` in package.json and add to the `quality` CI
+   job exactly where `check:ir-fallbacks` is invoked (find it in
+   `.github/workflows/` and mirror the invocation).
+4. Prove the gate fires: a unit test (`tests/issue-3113-ir-layering-gate.test.ts`)
+   that runs the script against a synthetic tree (tmp dir with a violating
+   file) and asserts failure, plus asserts the committed baseline matches the
+   script's live measurement (so the baseline cannot drift silently).
+
+**S2 — `from-ast.ts` import review (same dispatch, only if S1 lands clean):**
+classify each of its 7 codegen imports as (a) shared vocabulary → move the
+module (or the needed part) below IR like js-tag was, or (b) a bridge call →
+leave, listed in the baseline. Move ONLY category (a), one import per commit,
+each proven byte-identical via `node scripts/prove-emit-identity.mjs check`
+(all 56 emits IDENTICAL) + ts7 typecheck. If a candidate is not a
+dependency-free leaf, do not move it — record why in this file instead.
+
+**S3 — deferred, do NOT attempt now:** the `integration.ts` bridge move.
+Blocked on #3520/#3521 landing (active edits). The ratchet from S1 protects
+the boundary meanwhile.
+
+**Validation bar for the PR:** `check:ir-layering` green + fires on synthetic
+violation; `prove-emit-identity` IDENTICAL if any file moved; ts7 typecheck;
+`check:ir-fallbacks` / `check:ir-only` / `check:linear-ir` unchanged; LOC
+budget (new script file is fine; touching `src/codegen/index.ts` needs care).
+
+**Amended AC (supersedes AC 1–2 above):** the enforced state is "committed
+baseline, no growth, ratchet-to-zero direction"; AC 3 unchanged.

--- a/plan/issues/3113-ir-codegen-layering-shared-vocab.md
+++ b/plan/issues/3113-ir-codegen-layering-shared-vocab.md
@@ -1,10 +1,11 @@
 ---
 id: 3113
 title: "Fix IR->codegen reverse layering: move shared vocabulary (js-tag) below IR; contain the bridge to ir/integration.ts"
-status: ready
+status: done
 sprint: current
 created: 2026-07-09
-updated: 2026-07-17
+updated: 2026-08-21
+completed: 2026-08-21
 priority: medium
 horizon: m
 feasibility: medium
@@ -180,3 +181,105 @@ budget (new script file is fine; touching `src/codegen/index.ts` needs care).
 
 **Amended AC (supersedes AC 1–2 above):** the enforced state is "committed
 baseline, no growth, ratchet-to-zero direction"; AC 3 unchanged.
+
+## Outcome — S1 + S2 shipped 2026-08-21
+
+Both slices landed as planned. **S3 (the `integration.ts` bridge move) remains
+deferred** — see "Follow-up still owed" below.
+
+### S1 — the layering ratchet (shipped)
+
+`scripts/check-ir-layering.mjs` + `scripts/ir-layering-baseline.json`, wired as
+`check:ir-layering` in package.json and into the `quality` CI job immediately
+before `check:ir-fallbacks`. Gate semantics cloned from `check-linear-ir.ts`:
+per-file increase **or** a NEW file with codegen imports fails; decreases pass
+with a hint to bank via `--update`.
+
+`tests/issue-3113-ir-layering-gate.test.ts` (8 tests) proves the gate fires on
+a synthetic tree (growth, new file, `import type`), does **not** fire on
+`codegen-linear`, and that the committed baseline equals live measurement so it
+cannot drift silently.
+
+**Measured seed: 96 import lines / 20 files — not the 100 / 20 the plan above
+records.** The plan's figure came from a `from "../codegen` prefix grep, which
+also matches `../../codegen-linear/…`. `src/codegen-linear/` is a sibling
+*backend*, not the WasmGC codegen layer this issue is about, so those 4 lines
+are not part of the inversion. The script therefore **resolves** specifiers
+instead of prefix-matching, and reports the codegen-linear count as a separate
+informational line so the exclusion is visible rather than silent. Four of the
+five lines attributed to `ir/backend/linear-integration.ts` were this artifact;
+its real debt is 1 line.
+
+`import type` **is** counted: the boundary is about the dependency graph, and a
+type-only edge still constrains what may move. Dynamic `import("…")` and
+`export … from "…"` are counted for the same reason (and to close the obvious
+bypasses); neither occurs in `src/ir/` today.
+
+### S2 — `from-ast.ts` codegen-import classification
+
+Criterion for category (a), per the plan and the slice-1 precedent: the module
+must be a **dependency-free leaf** with respect to the ir↔codegen boundary — no
+codegen imports, no `CodegenContext`, no codegen state.
+
+| # | codegen import                       | LOC   | own deps                                       | class                  | action     |
+| - | ------------------------------------ | ----- | ---------------------------------------------- | ---------------------- | ---------- |
+| 1 | `regexp-runtime-contract.js`         | 9     | **none**                                       | (a) shared vocabulary  | **MOVED**  |
+| 2 | `async-static.js`                    | 160   | `src/ts-api.js` only                           | (a) shared vocabulary  | **MOVED**  |
+| 3 | `analysis/remainder-fast-path.js`    | 109   | `ts-api` + `codegen/analysis/static-numeric-range.js` | (b) near-leaf   | left       |
+| 4 | `ir-native-map.js`                   | 138   | 5 codegen (CodegenContext, func-space, …)      | (b) bridge             | left       |
+| 5 | `dyn-ops.js`                         | 589   | 11 codegen (CodegenContext, func-space, regex/…) | (b) bridge           | left       |
+| 6 | `statements/loop-analysis.js`        | 654   | `codegen/closures.js`, `statements/tdz.js`     | (b) bridge             | left       |
+| 7 | `statements/control-flow.js`         | 1,789 | ~15 codegen (CodegenContext, coercion-engine, …) | (b) bridge           | left       |
+
+Notes on the three judgement calls:
+
+- **#3 `remainder-fast-path` is the near miss.** It touches no codegen state —
+  `ts-api` plus one sibling, `analysis/static-numeric-range.js`. But it is not
+  dependency-free: moving it alone re-creates the upward import from its new
+  home, and moving both is a 2-module change the plan explicitly scopes out
+  ("If a candidate is not a dependency-free leaf, do not move it"). It is the
+  obvious first candidate for a follow-up that moves the `analysis/` pair
+  together.
+- **#6 `loop-analysis`** is pure AST analysis (`from-ast.ts` already documents
+  it as "no codegen state") and reads like vocabulary, but it imports
+  `codegen/closures.js` and `statements/tdz.js`, so it is not a leaf either.
+- **#5 and #7** are the real bridge calls: both take `CodegenContext` and emit.
+  They belong behind the bridge, which is S3's problem, not S2's.
+
+`select.ts`'s single codegen import was `async-static.js` (the same leaf as
+#2), so moving it cleared that file entirely — 20 files → 19.
+
+### Result
+
+| | files | import lines |
+| - | - | - |
+| seeded baseline | 20 | 96 |
+| after `regexp-runtime-contract` | 20 | 94 |
+| after `async-static` | **19** | **92** |
+
+Both moves are pure relocation, proven byte-identical with
+`node scripts/prove-emit-identity.mjs check` → **IDENTICAL, all 60
+(file,target) emits** (the corpus is 60 now, not the 56 the plan cites), ts7
+typecheck clean, `check:ir-fallbacks` / `check:ir-only` / `check:ir-dialect` /
+`check:jstag-seam` / `check:dead-exports` / `check:host-import-policy` all
+green, LOC + func budgets OK.
+
+**Pre-existing failures confirmed NOT caused by this work** (each reproduced on
+unmodified `origin/main` @ `ba151267f` in a scratch worktree):
+
+- `tests/issue-2175-regexp-proto-readers.test.ts` — 3 failing tests.
+- `pnpm run check:linear-ir` — FAIL, identical three lines (`compiled 8 → 6`,
+  `illegal:instr-vec.set_length 0 → 2`, `select:string-builder-candidate
+  0 → 2`). It is a **local dev tool, not wired into any workflow**. Its
+  baseline was deliberately **not** refreshed here: banking another lane's
+  regression into an unrelated PR would hide it. Worth its own issue.
+
+### Follow-up still owed
+
+**S3 — containing `ir/integration.ts` (7,335 LOC, 42 of the remaining 92 import
+lines) — was deliberately not attempted**, per the plan: it collides with the
+in-flight #3520–#3523 branches that edit that file heavily. That is Problem 2 in
+this issue's original statement and it is still open; the ratchet now stops the
+boundary regrowing while it waits. This issue is closed against its **amended**
+AC (ratchet in place, no growth, direction set); S3 needs a fresh issue once
+#3520/#3521 land.

--- a/scripts/check-ir-layering.mjs
+++ b/scripts/check-ir-layering.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3113 S1 — the IR→codegen LAYERING RATCHET.
+//
+// WHY THIS GATE EXISTS. The intended layering is `emit` <- `ir` <- `codegen`:
+// codegen consumes the IR, and the IR consumes nothing above it. Reality has
+// been drifting the other way for months, and nothing measured it:
+//
+//     issue filed (2026-07-09)      6 files /  25 import lines
+//     after slice 1  (2026-07-17)   (js-tag moved below IR)
+//     re-measured    (2026-08-21)  20 files /  96 import lines
+//
+// A ~4x regrowth in six weeks, entirely invisible, because the boundary was a
+// convention rather than a check. The IR is supposed to become the primary
+// front-end (#2855); a front-end that imports the legacy path's internals can
+// never let that path be deleted.
+//
+// WHY A RATCHET AND NOT AN EMPTINESS CHECK. The issue's original acceptance
+// criterion was `grep -rn 'from "../codegen' src/ir/` -> empty. That is not
+// reachable today: `ir/integration.ts` alone is 7,000+ LOC of IR->codegen
+// bridge and its containment (#3113 S3) is blocked on the in-flight #3520/#3521
+// branches. So this gate enforces the reachable invariant instead — "no
+// growth, ratchet toward zero" — which is what actually stops the regrowth
+// while the structural fix waits its turn.
+//
+// WHAT IS COUNTED, per file under `src/ir/`:
+//   Every import/export STATEMENT whose module specifier resolves to a path
+//   under `src/codegen/`. That includes:
+//     - `import { x } from "../codegen/y.js"`
+//     - `import type { X } from "../codegen/y.js"`   <- type-only counts too:
+//       the boundary is about the dependency GRAPH, and a type import is a
+//       real edge in it (it constrains what may move, and tsc follows it).
+//     - `export { x } from "../codegen/y.js"` (re-export pass-throughs)
+//     - `await import("../codegen/y.js")` (dynamic — otherwise a trivial bypass)
+//   Specifiers are RESOLVED, not prefix-matched. That distinction is
+//   load-bearing: `src/codegen-linear/` is a SIBLING directory, so the obvious
+//   `from "../codegen` grep matches `../../codegen-linear/context.js` too and
+//   over-counts. (It over-counted by 4 lines when this gate was written — the
+//   whole of `ir/backend/linear-integration.ts`'s apparent debt but one.)
+//
+// WHAT IS NOT COUNTED:
+//   - `src/codegen-linear/**` — a sibling BACKEND, not the WasmGC codegen
+//     layer this issue is about. Its count is reported as an informational
+//     line so the omission is visible rather than silent, but it does not gate.
+//   - Whole-line comments (`//`, `*`, `/*`).
+//
+// GATE SEMANTICS (cloned from `scripts/check-linear-ir.ts`):
+//   - any per-file count INCREASE                       -> FAIL
+//   - any NEW file acquiring codegen imports            -> FAIL
+//   - decreases / removed files                         -> PASS, with a hint
+//     to bank them via `--update`
+//
+// Usage:
+//   node scripts/check-ir-layering.mjs              # gate against baseline
+//   node scripts/check-ir-layering.mjs --update     # refresh/seed the baseline
+//   node scripts/check-ir-layering.mjs --json       # machine-readable
+//   node scripts/check-ir-layering.mjs --verbose    # per-import-line detail
+//   node scripts/check-ir-layering.mjs --src <dir> --baseline <file>
+//                                                   # scan an alternate tree
+//                                                   # (used by the unit test)
+
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ── argv ──────────────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+function flagValue(name) {
+  const i = argv.indexOf(name);
+  return i !== -1 && i + 1 < argv.length ? argv[i + 1] : undefined;
+}
+const update = argv.includes("--update");
+const json = argv.includes("--json");
+const verbose = argv.includes("--verbose");
+
+// Under `--json`, stdout carries the machine-readable payload and NOTHING
+// else — the human verdict goes to stderr so a caller can pipe stdout into a
+// parser without stripping a trailing summary line first.
+const say = (msg) => (json ? console.error(msg) : console.log(msg));
+
+const SRC_DIR = resolve(REPO_ROOT, flagValue("--src") ?? "src");
+const BASELINE_PATH = resolve(REPO_ROOT, flagValue("--baseline") ?? "scripts/ir-layering-baseline.json");
+
+const IR_DIR = join(SRC_DIR, "ir");
+const CODEGEN_DIR = join(SRC_DIR, "codegen");
+
+/** Every `.ts` file under `dir`, recursively, excluding declaration files. */
+function walk(dir) {
+  const out = [];
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir).sort()) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (full.endsWith(".ts") && !full.endsWith(".d.ts")) out.push(full);
+  }
+  return out;
+}
+
+/** True when `p` is the directory `dir` itself or anything beneath it. */
+function isUnder(p, dir) {
+  return p === dir || p.startsWith(dir + sep);
+}
+
+/**
+ * Module specifiers referenced by one source line.
+ *
+ * Static `import`/`export ... from "x"`, bare `import "x"`, and dynamic
+ * `import("x")` all produce a dependency edge, so all three are collected.
+ */
+function specifiersOnLine(line) {
+  const trimmed = line.trim();
+  // Whole-line comments only. A partial trailing comment cannot introduce a
+  // `from "..."` that wasn't already an import, so this is sufficient and it
+  // never mangles a string literal the way full comment-stripping can.
+  if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return [];
+
+  const out = [];
+  for (const re of [
+    /(?:^|[\s})])from\s+"([^"]+)"/g, // import/export ... from "x"
+    /^\s*import\s+"([^"]+)"/g, //       bare side-effect import
+    /\bimport\(\s*"([^"]+)"/g, //       dynamic import("x")
+  ]) {
+    for (const m of line.matchAll(re)) out.push(m[1]);
+  }
+  return out;
+}
+
+// ── measure ───────────────────────────────────────────────────────────────
+/** @type {Record<string, number>} */
+const files = {};
+/** @type {{file: string, line: number, specifier: string}[]} */
+const hits = [];
+let linearHits = 0;
+
+for (const file of walk(IR_DIR)) {
+  const rel = relative(SRC_DIR, file).split(sep).join("/");
+  const text = readFileSync(file, "utf8");
+  for (const [i, line] of text.split("\n").entries()) {
+    for (const spec of specifiersOnLine(line)) {
+      if (!spec.startsWith(".")) continue; // bare package specifier
+      const resolved = resolve(dirname(file), spec);
+      if (isUnder(resolved, CODEGEN_DIR)) {
+        files[rel] = (files[rel] ?? 0) + 1;
+        hits.push({ file: rel, line: i + 1, specifier: spec });
+      } else if (isUnder(resolved, `${CODEGEN_DIR}-linear`)) {
+        linearHits += 1;
+      }
+    }
+  }
+}
+
+const total = Object.values(files).reduce((a, b) => a + b, 0);
+const current = {
+  total,
+  files: Object.fromEntries(Object.entries(files).sort(([a], [b]) => a.localeCompare(b))),
+};
+
+if (json) console.log(JSON.stringify({ current, hits }, null, 2));
+if (verbose) {
+  for (const h of hits) say(`  ${h.file}:${h.line}  ${h.specifier}`);
+}
+
+// ── seed / update ─────────────────────────────────────────────────────────
+if (update || !existsSync(BASELINE_PATH)) {
+  writeFileSync(BASELINE_PATH, `${JSON.stringify({ generated: new Date().toISOString(), ...current }, null, 2)}\n`);
+  say(
+    `ir-layering ratchet: baseline ${update ? "updated" : "seeded"} — ` +
+      `${total} import lines across ${Object.keys(files).length} files under src/ir/`,
+  );
+  process.exit(0);
+}
+
+// ── gate ──────────────────────────────────────────────────────────────────
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+const baseFiles = baseline.files ?? {};
+const failures = [];
+
+for (const [file, count] of Object.entries(current.files)) {
+  const base = baseFiles[file];
+  if (base === undefined) {
+    failures.push(`NEW file with codegen imports: ${file} (${count} import line${count === 1 ? "" : "s"})`);
+  } else if (count > base) {
+    failures.push(`${file}: codegen imports INCREASED ${base} → ${count}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("ir-layering ratchet: FAIL — src/ir/ must not grow its dependency on src/codegen/.");
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    "\nThe intended layering is emit <- ir <- codegen: the IR consumes nothing above it.\n" +
+      "Fix by moving the needed vocabulary BELOW the IR (as #3113 slice 1 did for js-tag.ts),\n" +
+      "or by routing the call through the bridge (src/ir/integration.ts) instead of a new edge.\n" +
+      "If the growth is genuinely intended, run `pnpm run check:ir-layering -- --update`\n" +
+      "and commit the refreshed baseline so the increase is visible in review.",
+  );
+  process.exit(1);
+}
+
+const removed = Object.keys(baseFiles).filter((f) => current.files[f] === undefined);
+const decreased = Object.entries(current.files).filter(([f, c]) => c < (baseFiles[f] ?? 0));
+const improved = removed.length > 0 || decreased.length > 0;
+
+say(
+  `ir-layering ratchet: OK — ${total} import lines across ${Object.keys(current.files).length} files ` +
+    `(baseline ${baseline.total})` +
+    (improved ? " [improved — run with --update to bank it]" : "") +
+    (linearHits > 0 ? `\n  note: ${linearHits} src/codegen-linear/ import lines are NOT gated (sibling backend)` : ""),
+);

--- a/scripts/ir-layering-baseline.json
+++ b/scripts/ir-layering-baseline.json
@@ -1,0 +1,26 @@
+{
+  "generated": "2026-08-21T10:48:42.598Z",
+  "total": 96,
+  "files": {
+    "ir/analysis/i32-slots.ts": 2,
+    "ir/backend/linear-integration.ts": 1,
+    "ir/calendar-selection-support.ts": 1,
+    "ir/char-read-loop.ts": 1,
+    "ir/closure-struct-registry.ts": 3,
+    "ir/compiler-timer-shim-preparation.ts": 4,
+    "ir/dynamic-number-lowering.ts": 3,
+    "ir/fixed-literal-loop-proof.ts": 1,
+    "ir/fmod-selection.ts": 2,
+    "ir/from-ast.ts": 7,
+    "ir/i32-pure-bitwise.ts": 2,
+    "ir/integration.ts": 42,
+    "ir/math-runtime-providers.ts": 3,
+    "ir/number-to-string-provider.ts": 6,
+    "ir/prepared-callable-resolution.ts": 3,
+    "ir/prepared-closure-support.ts": 5,
+    "ir/prepared-component-sealing.ts": 3,
+    "ir/prepared-vector-support.ts": 5,
+    "ir/remainder-fast-path.ts": 1,
+    "ir/select.ts": 1
+  }
+}

--- a/scripts/ir-layering-baseline.json
+++ b/scripts/ir-layering-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-21T11:00:59.142Z",
-  "total": 94,
+  "generated": "2026-08-21T11:05:00.893Z",
+  "total": 92,
   "files": {
     "ir/analysis/i32-slots.ts": 2,
     "ir/backend/linear-integration.ts": 1,
@@ -11,7 +11,7 @@
     "ir/dynamic-number-lowering.ts": 3,
     "ir/fixed-literal-loop-proof.ts": 1,
     "ir/fmod-selection.ts": 2,
-    "ir/from-ast.ts": 6,
+    "ir/from-ast.ts": 5,
     "ir/i32-pure-bitwise.ts": 2,
     "ir/integration.ts": 41,
     "ir/math-runtime-providers.ts": 3,
@@ -20,7 +20,6 @@
     "ir/prepared-closure-support.ts": 5,
     "ir/prepared-component-sealing.ts": 3,
     "ir/prepared-vector-support.ts": 5,
-    "ir/remainder-fast-path.ts": 1,
-    "ir/select.ts": 1
+    "ir/remainder-fast-path.ts": 1
   }
 }

--- a/scripts/ir-layering-baseline.json
+++ b/scripts/ir-layering-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-21T10:48:42.598Z",
-  "total": 96,
+  "generated": "2026-08-21T11:00:59.142Z",
+  "total": 94,
   "files": {
     "ir/analysis/i32-slots.ts": 2,
     "ir/backend/linear-integration.ts": 1,
@@ -11,9 +11,9 @@
     "ir/dynamic-number-lowering.ts": 3,
     "ir/fixed-literal-loop-proof.ts": 1,
     "ir/fmod-selection.ts": 2,
-    "ir/from-ast.ts": 7,
+    "ir/from-ast.ts": 6,
     "ir/i32-pure-bitwise.ts": 2,
-    "ir/integration.ts": 42,
+    "ir/integration.ts": 41,
     "ir/math-runtime-providers.ts": 3,
     "ir/number-to-string-provider.ts": 6,
     "ir/prepared-callable-resolution.ts": 3,

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -3,7 +3,7 @@
 // Shared async/await CPS analysis and state-machine contracts (#1042/#1373b).
 
 import type { TypeOracle } from "../checker/oracle.js";
-import { awaitIsStaticallyResolved, staticPromiseResolveSettledExpr } from "./async-static.js";
+import { awaitIsStaticallyResolved, staticPromiseResolveSettledExpr } from "../ir/async-static.js";
 import { isPromiseType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { forEachChild, ts } from "../ts-api.js";
@@ -159,7 +159,7 @@ export function analyzeAsyncBody(_ctx: CodegenContext, fn: ts.FunctionLikeDeclar
 // moved to the leaf module `async-static.ts` so the IR front-end can import
 // them without an import cycle (this file imports codegen/index.ts, which
 // imports ir/select.ts). Re-exported here for existing callers.
-export { awaitIsStaticallyResolved, staticPromiseResolveSettledExpr } from "./async-static.js";
+export { awaitIsStaticallyResolved, staticPromiseResolveSettledExpr } from "../ir/async-static.js";
 
 /** Promise static combinators whose call result is already a real Promise. */
 const PROMISE_COMBINATOR_NAMES = new Set(["all", "race", "any", "allSettled"]);

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -37,7 +37,7 @@ import type { Instr, ValType, WasmFunction } from "../ir/types.js";
  */
 import { forEachChild, ts } from "../ts-api.js";
 import type { AsyncCfgPlan, AsyncCfgState, AsyncCpsPlan, AsyncResumePoint } from "./async-cps.js";
-import { awaitIsStaticallyResolved } from "./async-static.js"; // (#3723) settled-local flow test
+import { awaitIsStaticallyResolved } from "../ir/async-static.js"; // (#3723) settled-local flow test
 import {
   ASYNC_CPS_ENABLED,
   FORAWAIT_ITER_SPILL,
@@ -728,7 +728,7 @@ function bindingLiveAcrossLaterAwait(name: string, k: number, plan: AsyncCpsPlan
  * resumes with `v` unchanged. So an await whose operand type carries no `then`
  * is a pass-through no matter what the syntax looks like.
  *
- * This exists because {@link import("./async-static.js").awaitIsStaticallyResolved}
+ * This exists because {@link import("../ir/async-static.js").awaitIsStaticallyResolved}
  * cannot answer it. That helper is deliberately a checker-free LEAF module (it
  * imports only `ts-api`, so the IR front-end can consume it without closing the
  * #3324 import cycle), which means it recognises literals and

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -126,7 +126,7 @@ import {
   prepareIrAsyncSelectionOptions,
   registerIrAsyncPromiseDelayResolver,
 } from "./async-ir-planning.js";
-import { unwrapPromiseTypeNode } from "./async-static.js"; // (#1373b C-1)
+import { unwrapPromiseTypeNode } from "../ir/async-static.js"; // (#1373b C-1)
 import { createCodegenContext } from "./context/create-context.js";
 import { ProgramAbiSession, type PublishedProgramAbi } from "./program-abi-session.js";
 import { stripHostBridgeExports } from "./host-bridge-exports.js";

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -87,7 +87,7 @@ import { tryCompileStandaloneRegExpFunctionReplace } from "./regex-replace-fn.js
 import { nativeStringRepr } from "./builtin-scaffold.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { addFuncType } from "./registry/types.js";
-import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "./regexp-runtime-contract.js";
+import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "../ir/regexp-runtime-contract.js";
 import { emitTestCapsAcquire, emitTestCapsRelease } from "./regex-scratch-pool.js";
 import {
   ensureDynamicPatternTokenDecoder,

--- a/src/ir/async-static.ts
+++ b/src/ir/async-static.ts
@@ -5,6 +5,14 @@
 // ir/select.ts — so `ir/* → async-cps` would close a module-init cycle (the
 // #3324 hazard class). async-cps.ts re-exports these for its existing callers;
 // behaviour is byte-identical to the pre-extraction definitions.
+//
+// (#3113 S2) The extraction landed this in `src/codegen/`, which left the two
+// primary consumers — both under `src/ir/` — importing UPWARD across the layer
+// boundary. It now lives below the IR, where the leaf argument above always
+// pointed: these are predicates over `ts` syntax nodes with no codegen state,
+// no CodegenContext, and no codegen imports. The three codegen consumers
+// (index.ts, async-frame.ts, async-cps.ts) import down-stack instead, which is
+// the intended direction (emit <- ir <- codegen).
 
 import { ts } from "../ts-api.js";
 

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -49,7 +49,7 @@ import {
   IR_DYN_METHOD_CALL_1_FN,
   IR_DYN_STRING_REPLACE_FN,
 } from "../codegen/dyn-ops.js";
-import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "../codegen/regexp-runtime-contract.js";
+import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "./regexp-runtime-contract.js";
 import { IR_NATIVE_MAP_GET_NUM_FN, IR_NATIVE_MAP_NEW_FN, IR_NATIVE_MAP_SET_NUM_FN } from "../codegen/ir-native-map.js"; // (#4461) native $Map adapter ABI
 // (#1373b C-1) Leaf-module async helpers (no codegen/index cycle).
 import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codegen/async-static.js";

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -52,7 +52,7 @@ import {
 import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "./regexp-runtime-contract.js";
 import { IR_NATIVE_MAP_GET_NUM_FN, IR_NATIVE_MAP_NEW_FN, IR_NATIVE_MAP_SET_NUM_FN } from "../codegen/ir-native-map.js"; // (#4461) native $Map adapter ABI
 // (#1373b C-1) Leaf-module async helpers (no codegen/index cycle).
-import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codegen/async-static.js";
+import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "./async-static.js";
 import { boundedPreparedNestedOrdinaryClassBindingName } from "./class-accessor-safety.js";
 import { remainderFastPathPlan } from "../codegen/analysis/remainder-fast-path.js";
 import { evaluateConstantCondition } from "../codegen/statements/control-flow.js";

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -117,7 +117,7 @@ import {
   type NativeStringLiteralMaterialization,
   type StringEncoding,
 } from "../codegen/native-string-literals.js";
-import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "../codegen/regexp-runtime-contract.js";
+import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "./regexp-runtime-contract.js";
 import { ensureStandaloneRegExpCarrierTestHelper } from "../codegen/regexp-standalone.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../codegen/registry/imports.js";
 import { emitWasiErrorConstructor } from "../codegen/registry/error-types.js";

--- a/src/ir/regexp-runtime-contract.ts
+++ b/src/ir/regexp-runtime-contract.ts
@@ -5,5 +5,11 @@
  *
  * This is a defined Wasm helper, never a host import. Its receiver-first ABI
  * preserves the `$NativeRegExp` brand check before any user-method dispatch.
+ *
+ * (#3113 S2) Lives BELOW the IR, not in `src/codegen/`, for the same reason
+ * `js-tag.ts` moved in slice 1: it is shared *vocabulary* — a dependency-free
+ * name that both the IR front-end and the legacy codegen must agree on — so
+ * homing it in codegen forced `src/ir/` to import upward. It has no imports of
+ * its own, so the move is pure relocation.
  */
 export const STANDALONE_REGEXP_CARRIER_TEST_HELPER = "__regexp_test_carrier";

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -73,7 +73,7 @@ import { objectLiteralDataPropertyName } from "./property-key-fold.js";
 import { selectWithEnvironmentClosures } from "./with-environment.js";
 // (#1373b C-1) Pure-syntactic async helpers from the LEAF module (safe for
 // ir/* — async-static.ts imports only ts-api, so no codegen/index cycle).
-import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codegen/async-static.js";
+import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "./async-static.js";
 import { closureSignatureEquals, type IrClassShape, type IrClosureSignature, type IrType } from "./nodes.js";
 import type { IrImportedFunctionResolver, IrResolvedFunctionTarget } from "./imported-functions.js";
 import type { IrHostDateSnapshotResolver } from "./host-date.js";

--- a/tests/issue-3113-ir-layering-gate.test.ts
+++ b/tests/issue-3113-ir-layering-gate.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3113 S1 — tests for the IR→codegen layering ratchet
+ * (`scripts/check-ir-layering.mjs`).
+ *
+ * A ratchet is only worth its CI minute if it actually FIRES. This suite
+ * proves both halves of that:
+ *
+ *   1. Against a synthetic tree (a tmp `src/ir` + `src/codegen` pair), the
+ *      script fails when a file grows a codegen import, fails when a NEW file
+ *      acquires one, and passes when the tree matches its baseline.
+ *   2. Against the REAL repo, the committed baseline equals the script's live
+ *      measurement — so `scripts/ir-layering-baseline.json` cannot drift out
+ *      of sync with `src/` without a test noticing.
+ *
+ * The synthetic tree also pins the two counting decisions that are easy to get
+ * wrong and impossible to notice: `import type` COUNTS (it is a real edge in
+ * the dependency graph), and `src/codegen-linear/` does NOT (it is a sibling
+ * backend, and a naive `from "../codegen` grep over-counts it).
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "check-ir-layering.mjs");
+const COMMITTED_BASELINE = join(REPO_ROOT, "scripts", "ir-layering-baseline.json");
+
+interface RunResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/** Run the gate, capturing exit status instead of throwing on failure. */
+function runGate(args: string[]): RunResult {
+  try {
+    const stdout = execFileSync("node", [SCRIPT, ...args], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+describe("#3113 — IR→codegen layering ratchet", () => {
+  describe("synthetic tree", () => {
+    let dir: string;
+    let src: string;
+    let baseline: string;
+
+    /** Overwrite the synthetic `src/ir/*.ts` files, replacing any previous set. */
+    function writeIr(files: Record<string, string>): void {
+      rmSync(join(src, "ir"), { recursive: true, force: true });
+      mkdirSync(join(src, "ir"), { recursive: true });
+      for (const [name, body] of Object.entries(files)) {
+        writeFileSync(join(src, "ir", name), body);
+      }
+    }
+
+    beforeAll(() => {
+      dir = mkdtempSync(join(tmpdir(), "ir-layering-gate-"));
+      src = join(dir, "src");
+      // The codegen + codegen-linear leaves the synthetic IR files import from.
+      mkdirSync(join(src, "codegen"), { recursive: true });
+      mkdirSync(join(src, "codegen-linear"), { recursive: true });
+      writeFileSync(join(src, "codegen", "vocab.ts"), "export const VOCAB = 1;\n");
+      writeFileSync(join(src, "codegen", "other.ts"), "export const OTHER = 2;\n");
+      writeFileSync(join(src, "codegen-linear", "layout.ts"), "export const LAYOUT = 3;\n");
+      baseline = join(dir, "baseline.json");
+    });
+
+    afterAll(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("seeds a baseline from the tree it is pointed at", () => {
+      writeIr({
+        "a.ts": 'import { VOCAB } from "../codegen/vocab.js";\nexport const a = VOCAB;\n',
+        "b.ts": "export const b = 1;\n",
+      });
+
+      const seeded = runGate(["--src", src, "--baseline", baseline]);
+      expect(seeded.status).toBe(0);
+      expect(seeded.stdout).toContain("baseline seeded");
+
+      const parsed = JSON.parse(readFileSync(baseline, "utf-8")) as {
+        total: number;
+        files: Record<string, number>;
+      };
+      expect(parsed.total).toBe(1);
+      expect(parsed.files).toEqual({ "ir/a.ts": 1 });
+    });
+
+    it("passes when the tree is unchanged", () => {
+      const res = runGate(["--src", src, "--baseline", baseline]);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain("ir-layering ratchet: OK");
+    });
+
+    it("FAILS when an existing file grows a codegen import", () => {
+      writeIr({
+        "a.ts":
+          'import { VOCAB } from "../codegen/vocab.js";\n' +
+          'import { OTHER } from "../codegen/other.js";\n' +
+          "export const a = VOCAB + OTHER;\n",
+        "b.ts": "export const b = 1;\n",
+      });
+
+      const res = runGate(["--src", src, "--baseline", baseline]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain("ir-layering ratchet: FAIL");
+      expect(res.stderr).toContain("ir/a.ts: codegen imports INCREASED 1 → 2");
+    });
+
+    it("FAILS when a NEW file acquires a codegen import", () => {
+      writeIr({
+        "a.ts": 'import { VOCAB } from "../codegen/vocab.js";\nexport const a = VOCAB;\n',
+        "b.ts": 'import { OTHER } from "../codegen/other.js";\nexport const b = OTHER;\n',
+      });
+
+      const res = runGate(["--src", src, "--baseline", baseline]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain("NEW file with codegen imports: ir/b.ts");
+    });
+
+    it("counts `import type` — a type-only edge is still an edge in the graph", () => {
+      writeIr({
+        "a.ts":
+          'import { VOCAB } from "../codegen/vocab.js";\n' +
+          'import type { Other } from "../codegen/other.js";\n' +
+          "export const a: Other = VOCAB;\n",
+        "b.ts": "export const b = 1;\n",
+      });
+
+      const res = runGate(["--src", src, "--baseline", baseline]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toContain("ir/a.ts: codegen imports INCREASED 1 → 2");
+    });
+
+    it("does NOT count src/codegen-linear/ — a sibling backend, not the codegen layer", () => {
+      writeIr({
+        "a.ts":
+          'import { VOCAB } from "../codegen/vocab.js";\n' +
+          'import { LAYOUT } from "../codegen-linear/layout.js";\n' +
+          "export const a = VOCAB + LAYOUT;\n",
+        "b.ts": "export const b = 1;\n",
+      });
+
+      // A naive `from "../codegen` prefix match would count the second import
+      // and fail here. Resolution-based matching keeps it at 1.
+      const res = runGate(["--src", src, "--baseline", baseline]);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain("codegen-linear/ import lines are NOT gated");
+    });
+
+    it("passes on a DECREASE and says the improvement can be banked", () => {
+      writeIr({ "a.ts": "export const a = 1;\n", "b.ts": "export const b = 1;\n" });
+
+      const res = runGate(["--src", src, "--baseline", baseline]);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain("[improved — run with --update to bank it]");
+    });
+  });
+
+  describe("committed baseline", () => {
+    it("matches the live measurement of src/ir/ (no silent drift)", () => {
+      const res = runGate(["--json"]);
+      expect(res.status).toBe(0);
+
+      const live = (JSON.parse(res.stdout) as { current: { total: number; files: Record<string, number> } }).current;
+      const committed = JSON.parse(readFileSync(COMMITTED_BASELINE, "utf-8")) as {
+        total: number;
+        files: Record<string, number>;
+      };
+
+      expect(live.files).toEqual(committed.files);
+      expect(live.total).toBe(committed.total);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Implements S1 and S2 of [#3113](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3113-ir-codegen-layering-shared-vocab). S3 (containing `ir/integration.ts`) is **deliberately not attempted** — the plan defers it as colliding with the in-flight #3520–#3523 branches.

### The problem

The intended layering is `emit` ← `ir` ← `codegen`: codegen consumes the IR, the IR consumes nothing above it. Nothing enforced that, and it regrew ~4× since the issue was filed — 25 import lines then, **96 now across 20 files** under `src/ir/`. Invisible the whole time, because the boundary was a convention rather than a check.

### S1 — the ratchet

`scripts/check-ir-layering.mjs` + committed `scripts/ir-layering-baseline.json`, wired as `check:ir-layering` and added to the `quality` CI job next to `check:ir-fallbacks`. Semantics cloned from `check-linear-ir.ts`: a per-file increase **or** a new file acquiring codegen imports fails; decreases pass with a hint to bank them via `--update`.

A **ratchet, not** the issue's original `grep → empty` criterion: emptiness is not reachable while `ir/integration.ts` (7.3k LOC, 42 of the import lines) awaits S3. "No growth, ratchet toward zero" is the invariant that is both reachable and sufficient to stop the regrowth.

`tests/issue-3113-ir-layering-gate.test.ts` (8 tests) proves the gate actually fires — growth, new file, and `import type`, against a synthetic tmp tree — and asserts the committed baseline equals live measurement, so it cannot drift silently.

**Two corrections to the plan's figures, found while implementing:**

- The seed is **96** import lines, not 100. The plan's number came from a `from "../codegen` prefix grep, which also matches `../../codegen-linear/…`. `src/codegen-linear/` is a sibling *backend*, not the layer this issue is about. The script **resolves** specifiers instead, and reports the codegen-linear count on a separate informational line so the exclusion is visible rather than silent. 4 of the 5 lines attributed to `ir/backend/linear-integration.ts` were this artifact; its real debt is 1.
- The emit-identity corpus is **60** `(file,target)` pairs now, not 56.

`import type` **is** counted: the boundary is about the dependency graph, and a type-only edge still constrains what may move.

### S2 — `from-ast.ts` import classification

Category (a) requires a **dependency-free leaf** w.r.t. the ir↔codegen boundary — no codegen imports, no `CodegenContext`, no codegen state.

| # | codegen import | LOC | own deps | class | action |
| - | -------------- | --- | -------- | ----- | ------ |
| 1 | `regexp-runtime-contract.js` | 9 | **none** | (a) vocabulary | **MOVED** |
| 2 | `async-static.js` | 160 | `src/ts-api.js` only | (a) vocabulary | **MOVED** |
| 3 | `analysis/remainder-fast-path.js` | 109 | `ts-api` + `analysis/static-numeric-range.js` | (b) near-leaf | left |
| 4 | `ir-native-map.js` | 138 | 5 codegen | (b) bridge | left |
| 5 | `dyn-ops.js` | 589 | 11 codegen | (b) bridge | left |
| 6 | `statements/loop-analysis.js` | 654 | `closures.js`, `statements/tdz.js` | (b) bridge | left |
| 7 | `statements/control-flow.js` | 1,789 | ~15 codegen | (b) bridge | left |

**#3 is the near miss** — it touches no codegen state, but one sibling import means moving it alone just re-creates the upward edge. Moving the `analysis/` pair together is the obvious follow-up. Both moved modules' own headers already described them as shared/leaf: `regexp-runtime-contract` says "shared by legacy codegen and IR", and `async-static` says it was extracted as a leaf "so the IR front-end can consume them" — the extraction simply left it on the wrong side.

Moving `async-static` also cleared `src/ir/select.ts` of codegen imports entirely.

| | files | import lines |
| - | ----- | ------------ |
| seeded | 20 | 96 |
| after move 1 | 20 | 94 |
| after move 2 | **19** | **92** |

### Validation

Both moves are pure relocation, one per commit:

- `prove-emit-identity check` → **IDENTICAL, all 60 (file,target) emits**, after each move
- ts7 typecheck, lint, format clean
- `check:ir-fallbacks`, `check:ir-only --policy=hybrid`, `check:ir-dialect`, `check:jstag-seam`, `check:ir-kind-neutrality`, `check:dead-exports`, `check:host-import-policy` all green
- LOC + func budgets OK (net +14, all doc comments; the `src/codegen/index.ts` and `src/ir/select.ts` edits are path rewrites, +0)
- `tests/async-await.test.ts`, `tests/es5-standalone-regexp.test.ts` pass

**Two pre-existing failures, each reproduced on unmodified `origin/main` @ `ba151267f` in a scratch worktree — not caused by this PR:**

- `tests/issue-2175-regexp-proto-readers.test.ts` — 3 failing tests.
- `pnpm run check:linear-ir` — FAIL with identical output (`compiled 8 → 6`, `illegal:instr-vec.set_length 0 → 2`, `select:string-builder-candidate 0 → 2`). It is a local dev tool, **not wired into any workflow**. Its baseline was deliberately **not** refreshed here — banking another lane's regression into an unrelated PR would hide it. Worth its own issue.

### Still owed

S3 — containing `ir/integration.ts` (42 of the remaining 92 lines) — needs a fresh issue once #3520/#3521 land. The issue is marked `done` against its **amended** acceptance criteria (ratchet committed, no growth, direction set), not the original "grep empty", which S3 owns.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_