### PR TITLE
perf(#4602): per-key gate for the #4504 inherited-set machinery — acorn standalone-dynamic back to baseline

### DIFF
--- a/plan/issues/4602-acorn-standalone-dynamic-residual-perf.md
+++ b/plan/issues/4602-acorn-standalone-dynamic-residual-perf.md
@@ -1,0 +1,127 @@
+---
+id: 4602
+title: "Acorn standalone-dynamic residual ~1.9x vs pre-#4658 baseline: dynamic-set machinery"
+status: ready
+created: 2026-08-21
+updated: 2026-08-21
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: codegen, standalone, npm-compat
+language_feature: property assignment
+goal: performance
+sprint: current
+horizon: m
+related: [4578, 4586, 4504, 2175, 4556]
+origin: "Same-machine A/B while verifying the published acorn/clsx npm-compat collapse: after the #4578 and #4586 fixes, clsx is fully recovered but acorn standalone-dynamic sits at ~52% of its pre-#4658 throughput."
+files:
+  - src/codegen/object-runtime.ts
+  - src/codegen/closed-struct-extern-set.ts
+  - src/codegen/native-proto-instance-method-read.ts
+---
+
+# #4602 — acorn standalone-dynamic residual ~1.9x: dynamic-set machinery
+
+## Problem
+
+The published acorn/clsx standalone-dynamic collapse (dashboard run
+`0d87f216`, 2026-08-20) had two stacked causes, both since fixed on main:
+
+1. `536a3c0` strict-`arguments` poison accessors (~120–1,400x hot-path
+   collapse) — fixed by #4578 / PR #4669.
+2. Standardized `try_table` EH aborting Binaryen O4 `Flatten`, shipping
+   UNOPTIMIZED binaries — fixed by #4586 / PR #4677 + #4678.
+
+clsx standalone-dynamic is fully recovered. **Acorn is not**: it sits at
+roughly **52% of its pre-#4658 throughput**, stable across repeated runs,
+and the loss is concentrated in the dynamic property-set machinery.
+
+## Measurements (all same machine, same command, 2026-08-21)
+
+`node --import tsx scripts/generate-npm-compat-report.mjs --only acorn
+--perf-only --lane standalone-dynamic`, ratio = js/wasm (higher is better).
+Rows marked `+skip` had `--skip-pass=flatten` grafted into `optimize.ts` so
+the O4 abort (pre-#4677 revisions) cannot mask the codegen signal — the same
+graft measured **0.140** at the baseline revision, i.e. skipping Flatten
+itself costs nothing.
+
+| revision | state | acorn sa-dyn |
+| --- | --- | --- |
+| `6049c004` (pre-#4658 baseline) | full O4 | 0.1451 / 0.1373 |
+| `6049c004` +skip | flatten skipped | 0.1402 |
+| `1d0fc43` (mid-#4658) +skip | pre-unmask | 0.1333 |
+| `dc188a3` (= `1d0fc43` + `6d18505`) +skip | first bad | 0.0010 |
+| `7b2a1f94` (post-#4665) +skip | before #4669 | 0.0010 |
+| `f6ebb57` (first rev with #4677) | O4 retry | 0.0806 |
+| `bc588f2` (HEAD 2026-08-21) | current | 0.0752 / 0.0757 |
+
+Notes on the bisect: `git bisect` over `6049c004..0d87f216` (probe = the
+`+skip` measurement, threshold 0.11) lands on `dc188a3`, whose only content
+vs the good parent is `6d18505` (#4556: `arrayIndexConstantKey` restricted
+to literal keys). `6d18505` is a CORRECTNESS fix — before it, `nums[i]`
+folded to `nums[0]`, wrong-but-fast — so it did not *cause* the slow path,
+it **unmasked** a slow dynamic path introduced earlier in the branch. #4578
+(PR #4669) then recovered most of it (0.0010 → 0.0806). This issue is about
+what is still left.
+
+clsx same-machine for contrast: baseline 0.1387, HEAD 0.1313 — recovered.
+
+## Profile evidence (HEAD, optimized O4 binary, `--preserve-debug-names --profile-runtime wasm`)
+
+Top self-time, excluding the `node:inspector` frame (`post`, profiler
+overhead):
+
+| function | share of total |
+| --- | --- |
+| `__str_equals` | 13.2% |
+| `__extern_set` | 8.5% |
+| `__extern_get` | 1.5% |
+| `__extern_strict_eq` | 1.2% |
+| `__protoidx_brand_off` | 0.7% |
+
+Dynamic-property machinery is ~35% of wasm self-time, spread across many
+call sites (dozens of distinct profile nodes for `__extern_set` /
+`__str_equals`). Eliminating it entirely would be worth ~1.5x, i.e. most of
+the observed 1.9x gap.
+
+## Candidate causes, with what is already measured
+
+1. **`__extern_set` inherited-descriptor chain walk (#4504 / PR #4665)** —
+   prime suspect, unquantified. Every dynamic [[Set]] now performs the
+   nearest-descriptor walk across the receiver chain and native companions;
+   acorn's parser mutates `this.pos` / `node.*` in its innermost loops. A/B
+   of the walk alone is still missing (reverting #4665 at HEAD conflicts;
+   needs a targeted fast-path prototype instead).
+2. **`ec33d32` (#2175) seeded-companion routing on builtin-proto method
+   reads** — measured: reverting it at HEAD moves 0.0757 → 0.0869, ~+15%.
+   Every seeded data-method read goes through `__protoidx_get_r` instead of
+   the singleton shortcut, even though prototype mutation is rare.
+3. Other #4658 residue on the paths `6d18505` unmasked (dynamic element
+   reads with non-literal keys).
+
+## Fix directions
+
+- **Fast path for the common [[Set]]:** a cheap monomorphic guard before
+  the chain walk — e.g. a module-global (or per-prototype) "an inherited
+  accessor/read-only data descriptor exists somewhere" flag, set by
+  `__defineProperty_accessor` / companion mutation, checked once per
+  `__extern_set`. Clean receivers skip the walk entirely; conformance is
+  preserved because the flag is raised before any observable mutation.
+- **Dirty-flag gate for `ec33d32`:** same shape — route seeded-member reads
+  through `__protoidx_get_r` only after a builtin prototype data method has
+  actually been assigned/deleted (a per-brand or global i32), otherwise
+  return the pre-minted singleton as before.
+- Reduce `__str_equals` ladder cost on hot keys (first-char/length guard is
+  presumably already there — verify; consider key interning for extern-set
+  paths).
+
+## Acceptance criteria
+
+- [ ] acorn standalone-dynamic within noise of 0.14 same-machine (or its
+      pre-#4658 band 0.10–0.15 on the dashboard) at O4.
+- [ ] clsx standalone-dynamic does not regress (≥ 0.13 same-machine).
+- [ ] #4504 conformance pinned tests stay green (inherited setter/read-only
+      data descriptor honored after the fast path).
+- [ ] #2175 pinned tests stay green (builtin-proto method mutation,
+      deletion, inheritance still observed after the dirty-flag gate).

--- a/plan/issues/4602-acorn-standalone-dynamic-residual-perf.md
+++ b/plan/issues/4602-acorn-standalone-dynamic-residual-perf.md
@@ -52,6 +52,7 @@ itself costs nothing.
 | `6049c004` +skip | flatten skipped | 0.1402 |
 | `1d0fc43` (mid-#4658) +skip | pre-unmask | 0.1333 |
 | `dc188a3` (= `1d0fc43` + `6d18505`) +skip | first bad | 0.0010 |
+| `0d87f216` (#4658 merge, dashboard rev) +skip | end of window | 0.0007 |
 | `7b2a1f94` (post-#4665) +skip | before #4669 | 0.0010 |
 | `f6ebb57` (first rev with #4677) | O4 retry | 0.0806 |
 | `bc588f2` (HEAD 2026-08-21) | current | 0.0752 / 0.0757 |

--- a/plan/issues/4602-acorn-standalone-dynamic-residual-perf.md
+++ b/plan/issues/4602-acorn-standalone-dynamic-residual-perf.md
@@ -1,9 +1,11 @@
 ---
 id: 4602
 title: "Acorn standalone-dynamic residual ~1.9x vs pre-#4658 baseline: dynamic-set machinery"
-status: ready
+status: done
 created: 2026-08-21
 updated: 2026-08-21
+completed: 2026-08-21
+assignee: loopdive/claude
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -16,9 +18,26 @@ horizon: m
 related: [4578, 4586, 4504, 2175, 4556]
 origin: "Same-machine A/B while verifying the published acorn/clsx npm-compat collapse: after the #4578 and #4586 fixes, clsx is fully recovered but acorn standalone-dynamic sits at ~52% of its pre-#4658 throughput."
 files:
+  - src/codegen/array-holes.ts
+  - src/codegen/inherited-set-gate.ts
+  - src/codegen/member-set-dispatch.ts
+  - src/codegen/fnctor-typed-reads.ts
+  - tests/issue-4602-inherited-set-per-key-gate.test.ts
+loc-budget-allow:
+  # One import line per consumer file of the new per-key gate (the gate logic
+  # itself lives in the new src/codegen/inherited-set-gate.ts); types.ts gains
+  # the documented `inheritedSetDirtyKeys` context field.
+  - src/codegen/context/types.ts
+  - src/codegen/expressions/assignment.ts
+  - src/codegen/object-ops.ts
   - src/codegen/object-runtime.ts
-  - src/codegen/closed-struct-extern-set.ts
-  - src/codegen/native-proto-instance-method-read.ts
+  - src/codegen/proto-index-store.ts
+  - src/codegen/typed-this.ts
+func-budget-allow:
+  # A two-line comment on the per-key gate swap inside the existing dispatcher
+  # and the one-line context-field init; no new logic in either function.
+  - src/codegen/member-set-dispatch.ts::fillMemberSetDispatch
+  - src/codegen/context/create-context.ts::createCodegenContext
 ---
 
 # #4602 — acorn standalone-dynamic residual ~1.9x: dynamic-set machinery
@@ -101,7 +120,44 @@ the observed 1.9x gap.
 3. Other #4658 residue on the paths `6d18505` unmasked (dynamic element
    reads with non-literal keys).
 
-## Fix directions
+## Fix (landed with this issue)
+
+The isolation A/B settled the attribution: forcing `inheritedSetDescriptorDirty`
+off at HEAD measured **0.1297** — the whole residual is the #4504 machinery's
+**module-wide activation**, not the chain walk's own cost on genuinely dirty
+keys. Acorn trips the flag through the standard buble/rollup ES5 accessor
+shape (`var prototypeAccessors = {…}; prototypeAccessors.inFunction.get = fn;
+Object.defineProperties(Parser.prototype, prototypeAccessors)`), and the
+module-wide boolean then demoted every presence-tracked member write (and
+absent-slot read) in the 226KB bundle — dominated by `node.start = …` FIRST
+writes during Node construction, which all fell to `__extern_set`'s string
+ladder + descriptor decision.
+
+Landed change — **per-key precision, no semantics change**:
+
+- `ctx.inheritedSetDirtyKeys` (new): the scan (`array-holes.ts`) collects the
+  statically-known trigger key names — accessor declaration names, literal
+  `defineProperty`/`defineProperties`/`create`/`__defineGetter__` keys — and
+  reserves the module-wide flag for triggers whose key set is unknowable
+  (freeze, captured define builtins, computed names, dynamic code).
+- Identifier Properties bags (the buble shape) resolve through a dedicated
+  conservative walk (`resolveBagIdentifierKeys`): declaration-literal keys ∪
+  direct `bag.k = …` writes; ANY other occurrence of the identifier (aliasing,
+  argument passing) is an escape → module-wide flag.
+- Consumers with a static property name gate via `inheritedSetAffectsKey`
+  (member-set/get dispatch, fnctor typed read/write, typed-this, assignment,
+  member-set-f64): a clean key emits byte-identical pre-#4504 code. Key-dynamic
+  machinery (`__extern_set` runtime, proxy, tombstones, vec overlays,
+  proto-index store) activates on `inheritedSetAnyDirty`, so a dynamic set of a
+  dirty key still reaches the shared decision (`src/codegen/inherited-set-gate.ts`).
+
+Measured after (same machine, same command): **acorn standalone-dynamic
+0.1381** (pre-#4658 baseline band 0.137–0.145, was 0.075), **clsx 0.1414**
+(was 0.131, no regression). The remaining candidates below (ec33d32
+seeded-companion routing) turned out not to be needed for the acorn target and
+are left as-is.
+
+## Fix directions (original analysis)
 
 - **Fast path for the common [[Set]]:** a cheap monomorphic guard before
   the chain walk — e.g. a module-global (or per-prototype) "an inherited
@@ -119,10 +175,19 @@ the observed 1.9x gap.
 
 ## Acceptance criteria
 
-- [ ] acorn standalone-dynamic within noise of 0.14 same-machine (or its
-      pre-#4658 band 0.10–0.15 on the dashboard) at O4.
-- [ ] clsx standalone-dynamic does not regress (≥ 0.13 same-machine).
-- [ ] #4504 conformance pinned tests stay green (inherited setter/read-only
+- [x] acorn standalone-dynamic within noise of 0.14 same-machine (or its
+      pre-#4658 band 0.10–0.15 on the dashboard) at O4 — measured 0.1381.
+- [x] clsx standalone-dynamic does not regress (≥ 0.13 same-machine) —
+      measured 0.1414.
+- [x] #4504 conformance pinned tests stay green (inherited setter/read-only
       data descriptor honored after the fast path).
-- [ ] #2175 pinned tests stay green (builtin-proto method mutation,
-      deletion, inheritance still observed after the dirty-flag gate).
+- [x] #2175 pinned tests stay green (untouched — the seeded-companion gate
+      turned out not to be needed for the acorn target).
+- [x] New pinned suite `issue-4602-inherited-set-per-key-gate.test.ts`:
+      poisoned keys observe their descriptors through every collection route
+      (literal key, buble identifier bag, alias escape) while clean-key writes
+      stay correct. Two shapes are pre-existing gaps verified IDENTICAL on
+      main `26a1801` and deliberately not pinned: a bag grown from `{}` by
+      direct writes (module does not instantiate standalone), and
+      frozen-prototype inherited-write refusal (never implemented); the gc
+      lane does not honor ctor-prototype accessors at all (also pre-existing).

--- a/src/codegen/array-holes.ts
+++ b/src/codegen/array-holes.ts
@@ -58,6 +58,7 @@ import { planHoleyArrayCarrier } from "./holey-array-plan.js"; // (#4222) isolat
  * lazy flag would desync reads against stores.
  */
 export function scanForArrayHoles(ctx: CodegenContext, root: ts.Node): void {
+  const pendingBagIdents = new Set<string>();
   const visit = (node: ts.Node): void => {
     if (
       ctx.usesArrayHoles &&
@@ -92,8 +93,23 @@ export function scanForArrayHoles(ctx: CodegenContext, root: ts.Node): void {
     if (!ctx.vecAccessorDescriptorDirty && isNonDataDescriptorDefine(node)) {
       ctx.vecAccessorDescriptorDirty = true;
     }
-    if (!ctx.inheritedSetDescriptorDirty && isInheritedSetDescriptorUse(node)) {
-      ctx.inheritedSetDescriptorDirty = true;
+    if (!ctx.inheritedSetDescriptorDirty) {
+      // (#4602) Statically-named triggers poison only their own keys; a
+      // trigger whose key cannot be named sets the module-wide flag, which
+      // supersedes the key set (consumers check the flag first). Identifier
+      // bags queue for the dedicated post-visit resolution walk.
+      const poisoned = inheritedSetDescriptorUseKeys(node);
+      if (poisoned === "all") {
+        if (process.env.JS2WASM_DEBUG_4602) {
+          console.error(
+            `[4602] ALL-trigger kind=${ts.SyntaxKind[node.kind]} text=${node.getText().slice(0, 120).replace(/\n/g, " ")}`,
+          );
+        }
+        ctx.inheritedSetDescriptorDirty = true;
+      } else if (poisoned !== null) {
+        if (Array.isArray(poisoned)) for (const key of poisoned) ctx.inheritedSetDirtyKeys.add(key);
+        else pendingBagIdents.add((poisoned as { bagIdentifier: string }).bagIdentifier);
+      }
     }
     if (!ctx.vecIndexDeleteDirty && isIndexDelete(node)) {
       ctx.vecIndexDeleteDirty = true;
@@ -120,6 +136,19 @@ export function scanForArrayHoles(ctx: CodegenContext, root: ts.Node): void {
     forEachChild(node, visit);
   };
   visit(root);
+  for (const name of pendingBagIdents) {
+    if (ctx.inheritedSetDescriptorDirty) break;
+    const resolved = resolveBagIdentifierKeys(root, name);
+    if (resolved === "all") {
+      if (process.env.JS2WASM_DEBUG_4602) console.error(`[4602] bag identifier "${name}" escapes — all-keys`);
+      ctx.inheritedSetDescriptorDirty = true;
+    } else for (const key of resolved) ctx.inheritedSetDirtyKeys.add(key);
+  }
+  if (process.env.JS2WASM_DEBUG_4602) {
+    console.error(
+      `[4602] allDirty=${ctx.inheritedSetDescriptorDirty} dynamicCode=${ctx.dynamicCodeDirty} keys=${JSON.stringify([...ctx.inheritedSetDirtyKeys])}`,
+    );
+  }
   planHoleyArrayCarrier(ctx, root);
 }
 
@@ -288,47 +317,242 @@ function isProvablyWritableDataDescriptorBag(node: ts.Expression | undefined): b
  * Accessor declarations are included because class/object-literal accessors
  * install prototype descriptors without passing through an Object builtin.
  */
-function isInheritedSetDescriptorUse(node: ts.Node): boolean {
-  if (ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) return true;
+function inheritedSetDescriptorUseKeys(
+  node: ts.Node,
+): "all" | readonly string[] | { readonly bagIdentifier: string } | null {
+  if (ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) {
+    return accessorDeclarationKeys(node.name);
+  }
   // Stored Object builtins are lowered by the same builtin capture path as
   // direct calls (`const dp = Object.defineProperty; dp(proto, ...)`). This
   // pre-scan intentionally has no binding/flow state, so recognize the value
   // reference itself as the conservative gate; a harmless uncalled capture
-  // only enables the already-reserved standalone resolver.
+  // only enables the already-reserved standalone resolver. Its future key is
+  // unknowable here, so it is an all-keys trigger.
   if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "Object") {
     const method = node.name.text;
     const isDirectCallee = ts.isCallExpression(node.parent) && node.parent.expression === node;
-    if (method === "freeze") return true;
+    if (method === "freeze") return "all";
     // Preserve the direct-call precision below: a literal
     // `{ value: 1, writable: true }` does not need the resolver. Only a
     // stored/captured define builtin loses that proof.
-    if (!isDirectCallee && (method === "defineProperty" || method === "defineProperties")) return true;
+    if (!isDirectCallee && (method === "defineProperty" || method === "defineProperties")) return "all";
   }
-  if (!ts.isCallExpression(node)) return false;
+  if (!ts.isCallExpression(node)) return null;
   const callee = node.expression;
-  if (!ts.isPropertyAccessExpression(callee)) return false;
+  if (!ts.isPropertyAccessExpression(callee)) return null;
   const method = callee.name.text;
   // Annex B's legacy mutators install an accessor directly on their receiver.
   // Do not try to prove that receiver is a prototype in this early syntactic
   // scan: an unnecessary resolver is safe; a missed setter is not.
-  if (method === "__defineGetter__" || method === "__defineSetter__") return true;
-  if (!ts.isIdentifier(callee.expression)) return false;
+  if (method === "__defineGetter__" || method === "__defineSetter__") {
+    const key = literalPropertyKeyOf(node.arguments[0]);
+    return key === undefined ? "all" : [key];
+  }
+  if (!ts.isIdentifier(callee.expression)) return null;
   const ns = callee.expression.text;
   // `Object.freeze(proto)` turns every existing data descriptor non-writable,
-  // including one later reached through an inherited write.  This is a
-  // per-module conservative gate; proving the receiver is a prototype is not
-  // worth risking a false negative here.
-  if (ns === "Object" && method === "freeze") return true;
+  // including one later reached through an inherited write, and the frozen
+  // object's key set is unknowable here.  Per-module conservative gate.
+  if (ns === "Object" && method === "freeze") return "all";
   if (method === "defineProperty" && (ns === "Object" || ns === "Reflect")) {
-    return !isProvablyWritableDataDescriptorLiteral(node.arguments[2]);
+    if (isProvablyWritableDataDescriptorLiteral(node.arguments[2])) return null;
+    const key = literalPropertyKeyOf(node.arguments[1]);
+    return key === undefined ? "all" : [key];
   }
   if (method === "defineProperties" && ns === "Object") {
-    return !isProvablyWritableDataDescriptorBag(node.arguments[1]);
+    return descriptorBagPoisonedKeysOrIdent(node.arguments[1]);
   }
   if (method === "create" && ns === "Object") {
-    return node.arguments.length >= 2 && !isProvablyWritableDataDescriptorBag(node.arguments[1]);
+    if (node.arguments.length < 2) return null;
+    return descriptorBagPoisonedKeysOrIdent(node.arguments[1]);
   }
-  return false;
+  return null;
+}
+
+/**
+ * A Properties bag that is a plain identifier — the standard buble/rollup ES5
+ * accessor pattern (`var protoAccessors = {...}; …;
+ * Object.defineProperties(C.prototype, protoAccessors)`) — is deferred to
+ * `resolveBagIdentifierKeys`, which resolves the identifier's key set with a
+ * dedicated conservative walk after the main scan.
+ */
+function descriptorBagPoisonedKeysOrIdent(
+  node: ts.Expression | undefined,
+): "all" | readonly string[] | { readonly bagIdentifier: string } {
+  if (node) {
+    const inner = unwrapExpr(node);
+    if (ts.isIdentifier(inner)) return { bagIdentifier: inner.text };
+  }
+  return descriptorBagPoisonedKeys(node);
+}
+
+/** A statically-known ToPropertyKey for a literal key argument, else undefined. */
+function literalPropertyKeyOf(node: ts.Expression | undefined): string | undefined {
+  if (!node) return undefined;
+  const inner = unwrapExpr(node);
+  if (ts.isStringLiteral(inner)) return inner.text;
+  // Canonical numeric-string form, matching ToPropertyKey (`1e0` → "1").
+  if (ts.isNumericLiteral(inner)) return String(Number(inner.text));
+  return undefined;
+}
+
+/** Keys an accessor DECLARATION installs, or "all" for a computed name. */
+function accessorDeclarationKeys(name: ts.PropertyName): "all" | readonly string[] {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return [name.text];
+  if (ts.isNumericLiteral(name)) return [String(Number(name.text))];
+  // A private accessor (`get #x`) never answers a public string-keyed [[Set]].
+  if (ts.isPrivateIdentifier(name)) return [];
+  return "all"; // computed name — key unknowable in this binding-free scan
+}
+
+/**
+ * (#4602) Resolve the possible key set of an identifier used as a Properties
+ * bag. Binding-free and name-based, so it is deliberately a whitelist of SAFE
+ * occurrences; anything unrecognized is an escape and answers "all":
+ *
+ *  - a declaration `var N = {…literal…}` contributes the literal's
+ *    non-provably-writable keys (`descriptorBagPoisonedKeys`);
+ *  - an assignment `N = {…literal…}` contributes the same; a non-literal RHS
+ *    is "all";
+ *  - a DIRECT property write `N.k = …` (any assignment operator — `||=` can
+ *    create the key) poisons `k`; a computed key it cannot read is "all";
+ *  - a property/element READ with base `N` is safe (`N.k.get = fn` mutates
+ *    `N.k`'s object, which cannot grow `N`'s own key set);
+ *  - the bag-argument position of `Object.defineProperties` /
+ *    `Object.create` is safe (that is the consumer being analyzed);
+ *  - `delete N.k` only shrinks the set — safe.
+ *
+ * Name-based matching conflates same-named bindings across scopes; the union
+ * over all of them is a superset of any one binding's keys, which is the
+ * sound direction. This resolves the ubiquitous buble/rollup ES5 accessor
+ * shape (acorn ships nine of them) without a real flow analysis.
+ */
+function resolveBagIdentifierKeys(root: ts.Node, name: string): "all" | ReadonlySet<string> {
+  let all = false;
+  const keys = new Set<string>();
+  const merge = (r: "all" | readonly string[]): void => {
+    if (r === "all") all = true;
+    else for (const k of r) keys.add(k);
+  };
+  /** Climb transparent wrappers so `(N as any)` is judged by ITS parent. */
+  const effectiveParent = (node: ts.Node): { wrapper: ts.Node; parent: ts.Node | undefined } => {
+    let wrapper: ts.Node = node;
+    let parent = node.parent as ts.Node | undefined;
+    while (
+      parent &&
+      (ts.isParenthesizedExpression(parent) ||
+        ts.isAsExpression(parent) ||
+        ts.isNonNullExpression(parent) ||
+        ts.isSatisfiesExpression?.(parent))
+    ) {
+      wrapper = parent;
+      parent = parent.parent;
+    }
+    return { wrapper, parent };
+  };
+  const visit = (node: ts.Node): void => {
+    if (all) return;
+    if (ts.isIdentifier(node) && node.text === name) {
+      const { wrapper, parent } = effectiveParent(node);
+      if (!parent) {
+        all = true;
+        return;
+      }
+      // NAME positions — not value uses of the binding.
+      if (ts.isPropertyAccessExpression(parent) && parent.name === node) return;
+      if (
+        (ts.isPropertyAssignment(parent) ||
+          ts.isMethodDeclaration(parent) ||
+          ts.isGetAccessorDeclaration(parent) ||
+          ts.isSetAccessorDeclaration(parent) ||
+          ts.isPropertySignature(parent) ||
+          ts.isEnumMember(parent)) &&
+        parent.name === node
+      ) {
+        return;
+      }
+      // Declaration site: literal init contributes keys; other init escapes.
+      if (ts.isVariableDeclaration(parent) && parent.name === node) {
+        if (parent.initializer === undefined) return; // writes are matched below
+        const init = unwrapExpr(parent.initializer);
+        if (ts.isObjectLiteralExpression(init)) merge(descriptorBagPoisonedKeys(init as ts.Expression));
+        else all = true;
+        return;
+      }
+      // Whole-binding assignment `N = …`.
+      if (
+        ts.isBinaryExpression(parent) &&
+        parent.left === wrapper &&
+        parent.operatorToken.kind === ts.SyntaxKind.EqualsToken
+      ) {
+        const rhs = unwrapExpr(parent.right);
+        if (ts.isObjectLiteralExpression(rhs)) merge(descriptorBagPoisonedKeys(rhs as ts.Expression));
+        else all = true;
+        return;
+      }
+      // Property-access base.
+      if (
+        (ts.isPropertyAccessExpression(parent) || ts.isElementAccessExpression(parent)) &&
+        parent.expression === wrapper
+      ) {
+        const { wrapper: access, parent: gp } = effectiveParent(parent);
+        // A DIRECT write `N.k ⟶= …` (any assignment operator) can create `k`.
+        if (
+          gp &&
+          ts.isBinaryExpression(gp) &&
+          gp.left === access &&
+          gp.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+          gp.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+        ) {
+          const key = ts.isPropertyAccessExpression(parent)
+            ? ts.isIdentifier(parent.name)
+              ? parent.name.text
+              : undefined
+            : literalPropertyKeyOf(parent.argumentExpression);
+          if (key === undefined) all = true;
+          else keys.add(key);
+        }
+        return; // a read base cannot grow N's own key set
+      }
+      // The sanctioned bag-argument position of defineProperties/create.
+      if (ts.isCallExpression(parent) && parent.arguments[1] === wrapper) {
+        const callee = parent.expression;
+        if (
+          ts.isPropertyAccessExpression(callee) &&
+          ts.isIdentifier(callee.expression) &&
+          callee.expression.text === "Object" &&
+          (callee.name.text === "defineProperties" || callee.name.text === "create")
+        ) {
+          return;
+        }
+      }
+      all = true; // every other occurrence is an escape
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  visit(root);
+  return all ? "all" : keys;
+}
+
+/**
+ * The statically-named keys of a Properties bag whose descriptors are NOT
+ * provably writable data, or "all" when the bag (or any entry's key) cannot
+ * be resolved statically.
+ */
+function descriptorBagPoisonedKeys(node: ts.Expression | undefined): "all" | readonly string[] {
+  if (!node || !ts.isObjectLiteralExpression(node)) return "all";
+  const keys: string[] = [];
+  for (const prop of node.properties) {
+    if (!ts.isPropertyAssignment(prop)) return "all";
+    if (isProvablyWritableDataDescriptorLiteral(prop.initializer)) continue;
+    const name = prop.name;
+    if (ts.isIdentifier(name) || ts.isStringLiteral(name)) keys.push(name.text);
+    else if (ts.isNumericLiteral(name)) keys.push(String(Number(name.text)));
+    else return "all";
+  }
+  return keys;
 }
 
 /**

--- a/src/codegen/array-holes.ts
+++ b/src/codegen/array-holes.ts
@@ -303,15 +303,6 @@ function isProvablyWritableDataDescriptorLiteral(node: ts.Expression | undefined
   return writableTrue;
 }
 
-/** Every descriptor in a Properties bag must be provably writable data. */
-function isProvablyWritableDataDescriptorBag(node: ts.Expression | undefined): boolean {
-  if (!node || !ts.isObjectLiteralExpression(node)) return false;
-  for (const prop of node.properties) {
-    if (!ts.isPropertyAssignment(prop) || !isProvablyWritableDataDescriptorLiteral(prop.initializer)) return false;
-  }
-  return true;
-}
-
 /**
  * (#4504) Detect descriptors that can change an inherited [[Set]] outcome.
  * Accessor declarations are included because class/object-literal accessors

--- a/src/codegen/closed-struct-extern-set.ts
+++ b/src/codegen/closed-struct-extern-set.ts
@@ -52,6 +52,7 @@
  * (`__is_class_instance_carrier` screens them), and the lookup answers null
  * there, so the clear is a cheap no-op outside class instances.
  */
+import { inheritedSetAnyDirty } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import type { FieldDef, Instr, ValType, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { isSyntheticStructName } from "./emit-helpers.js";
@@ -163,7 +164,7 @@ export function fillClosedStructExternSetArms(ctx: CodegenContext): void {
   // active, because only then would recursive __extern_set re-enter the new
   // descriptor decision.
   const resurrectIdx =
-    ctx.standalone && ctx.inheritedSetDescriptorDirty ? ctx.funcMap.get(INSTANCE_FIELD_RESURRECT) : undefined;
+    ctx.standalone && inheritedSetAnyDirty(ctx) ? ctx.funcMap.get(INSTANCE_FIELD_RESURRECT) : undefined;
   const externSetIdx = ctx.funcMap.get("__extern_set");
   const setResultGlobalIdx = ctx.externSetResultGlobalIdx;
   const setDecideIdx = ctx.funcMap.get("__extern_set_decide");
@@ -234,7 +235,7 @@ export function fillClosedStructExternSetArms(ctx: CodegenContext): void {
   // index churn here.
   const presenceDecisionAvailable =
     ctx.standalone &&
-    ctx.inheritedSetDescriptorDirty &&
+    inheritedSetAnyDirty(ctx) &&
     setResultGlobalIdx !== undefined &&
     setDecideIdx !== undefined &&
     setOwnIdx !== undefined &&

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -147,6 +147,7 @@ export function createCodegenContext(
     protoMemberDirty: false, // (#2175 V2-S3b-1) scanForArrayHoles: branded builtin .prototype reaches the dynamic reader as a VALUE
     vecAccessorDescriptorDirty: false, // (#4159) scanForArrayHoles: a non-data descriptor may exist somewhere
     inheritedSetDescriptorDirty: false, // (#4504) scanForArrayHoles: a descriptor may affect inherited [[Set]]
+    inheritedSetDirtyKeys: new Set<string>(), // (#4602) scanForArrayHoles: statically-named keys such a descriptor could use
     vecIndexDeleteDirty: false, // (#4222) scanForArrayHoles: a `delete arr[i]` may tombstone an index
     vecOwnKeysDirty: false, // (#4230 L1) scanForArrayHoles: a descriptor define / own-name read is present
     dynamicCodeDirty: false, // (#4159/#4160) scanForArrayHoles: eval/Function present ⇒ both flags above forced

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1617,6 +1617,23 @@ export interface CodegenContext extends StandaloneCapabilityDemandState, BodyRou
    */
   inheritedSetDescriptorDirty: boolean;
   /**
+   * (#4602) Property KEYS a #4504-relevant descriptor could be installed
+   * under, when every trigger in the module names its key statically (an
+   * accessor declaration's literal name, a `defineProperty` call with a
+   * literal key and non-provably-writable descriptor, a literal
+   * `defineProperties`/`create` bag entry, a literal `__defineGetter__`/
+   * `__defineSetter__` key).  A trigger whose key cannot be resolved
+   * statically (freeze, a captured define builtin, a computed name, dynamic
+   * code) sets `inheritedSetDescriptorDirty` instead, which supersedes this
+   * set.  Consumers with a static property name gate per key via
+   * `inheritedSetAffectsKey`; key-dynamic runtime machinery activates on
+   * `inheritedSetAnyDirty`.  A clean key compiles byte-identical to a
+   * flag-clear module — that is the whole point: one accessor declaration in
+   * a 226KB bundle must not demote every unrelated member write (measured
+   * ~1.7x on acorn standalone, #4602).
+   */
+  inheritedSetDirtyKeys: Set<string>;
+  /**
    * (#4222) The module contains a `delete <elementAccess>`, so some array index
    * may be semantically ABSENT while its dense backing slot still holds a
    * value. `__delete_property`'s vec arm (#4010) records that as a

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -152,6 +152,7 @@ import { tryCompileStrictFunctionPoisonAssignment } from "../function-poison-pil
 import { emitRuntimeEvalAotCallableAdapter } from "../runtime-eval-callable.js";
 import { tryEmitStaticI32Expression } from "../i32-static-range-expr.js";
 import { emitToPropertyKeyOnce } from "./computed-member-reference.js";
+import { inheritedSetAffectsKey } from "../inherited-set-gate.js"; // (#4602) per-key #4504 gate
 
 /**
  * Emit a null/undefined guard for an externref-typed destructuring source.
@@ -4289,7 +4290,7 @@ function compilePropertyAssignment(
   // This runs before either receiver or RHS is emitted, preserving evaluation
   // order and leaving the direct physical fast path for a present slot in the
   // dispatcher/runtime itself.
-  if (ctx.standalone && ctx.inheritedSetDescriptorDirty && presenceSlot !== undefined) {
+  if (ctx.standalone && inheritedSetAffectsKey(ctx, fieldName) && presenceSlot !== undefined) {
     return compilePropertyAssignmentExternSet(ctx, fctx, target, value, fieldName);
   }
 

--- a/src/codegen/fnctor-typed-reads.ts
+++ b/src/codegen/fnctor-typed-reads.ts
@@ -86,6 +86,7 @@ import { undefinedExternInstrs } from "./any-helpers.js";
 // module can reach the expression/coercion engines without a cycle back through
 // property-access.ts / index.ts.
 import { coerceType, compileExpression } from "./shared.js";
+import { inheritedSetAffectsKey } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 
 /**
  * Names with dedicated lowerings (array length, proto walk, constructor
@@ -330,7 +331,7 @@ export function tryEmitFnctorTypedFieldGet(
   // When inherited descriptors are observable, preserve the dynamic getter so
   // it can continue into the fnctor prototype instead of returning the slot's
   // local `undefined`.
-  if (ctx.standalone && ctx.inheritedSetDescriptorDirty && f.presenceSlot !== undefined) {
+  if (ctx.standalone && inheritedSetAffectsKey(ctx, propName) && f.presenceSlot !== undefined) {
     note(fnctorTypedReadStats.declines, `get:inherited-presence:${f.structName}.${propName}`);
     return undefined;
   }
@@ -401,7 +402,7 @@ export function tryEmitFnctorTypedFieldSet(
   // write shortcut materialize an absent slot ahead of an inherited setter or
   // non-writable descriptor; its caller falls through to the already-reserved
   // member dispatcher, whose absent branch delegates once to `__extern_set`.
-  if (ctx.standalone && ctx.inheritedSetDescriptorDirty && f.presenceSlot !== undefined) {
+  if (ctx.standalone && inheritedSetAffectsKey(ctx, propName) && f.presenceSlot !== undefined) {
     note(fnctorTypedReadStats.declines, `set:inherited-presence:${f.structName}.${propName}`);
     return undefined;
   }

--- a/src/codegen/inherited-set-gate.ts
+++ b/src/codegen/inherited-set-gate.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4602) Per-key gate for the #4504 inherited-[[Set]] descriptor machinery.
+//
+// #4504's pre-scan used one module-wide boolean: ANY accessor declaration or
+// suspicious `defineProperty` anywhere demoted EVERY presence-tracked member
+// write (and absent-slot read) in the module to the generic runtime, whose
+// closed-struct arm resolves the key by a string-equality ladder and runs the
+// nearest-descriptor chain walk. On acorn's 226KB bundle — nine getter-only
+// prototype accessors, millions of unrelated `node.start = …` first writes —
+// that cost ~1.7x end-to-end (#4602 measurements).
+//
+// The repair is precision, not a semantics change. A [[Set]] of key `p` can
+// only be affected by a descriptor FOR `p`; if no construct in the module can
+// install a suspicious descriptor named `p`, the pre-#4504 direct write IS the
+// nearest-descriptor outcome. The scan (array-holes.ts) therefore collects the
+// statically-known trigger key names into `ctx.inheritedSetDirtyKeys` and
+// reserves the module-wide `ctx.inheritedSetDescriptorDirty` for triggers
+// whose key cannot be named (freeze, captured define builtins, computed
+// names, dynamic code).
+//
+// Consumers split two ways:
+//  - a compile site with a STATIC property name gates on
+//    `inheritedSetAffectsKey` — a clean key emits byte-identical pre-#4504
+//    code, a dirty key keeps the full #4504 path;
+//  - key-DYNAMIC machinery (the `__extern_set` runtime, proxies, tombstones,
+//    vec overlays) activates on `inheritedSetAnyDirty`, so a dynamic set of a
+//    dirty key still reaches the shared decision.
+
+import type { CodegenContext } from "./context/types.js";
+
+/**
+ * Does any #4504-relevant descriptor trigger exist in this module at all?
+ * Key-dynamic machinery (runtime [[Set]] decision, result channel, proxy and
+ * tombstone routing) must be reserved and active exactly when this holds.
+ */
+export function inheritedSetAnyDirty(ctx: CodegenContext): boolean {
+  return ctx.inheritedSetDescriptorDirty || ctx.inheritedSetDirtyKeys.size > 0;
+}
+
+/**
+ * Can a #4504-relevant descriptor exist under this specific property key?
+ * Compile sites with a static property name use this; `false` licenses the
+ * pre-#4504 direct physical path for that key.
+ */
+export function inheritedSetAffectsKey(ctx: CodegenContext, key: string): boolean {
+  return ctx.inheritedSetDescriptorDirty || ctx.inheritedSetDirtyKeys.has(key);
+}

--- a/src/codegen/instance-tombstones.ts
+++ b/src/codegen/instance-tombstones.ts
@@ -96,6 +96,7 @@
  * answer (`0`), so a skipped fill degrades to exactly today's behaviour instead
  * of trapping.
  */
+import { inheritedSetAnyDirty } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
@@ -251,7 +252,7 @@ export function fillInstanceTombstones(ctx: CodegenContext): void {
   // active.  The marker belongs to the hidden bag's OWN table; a prototype
   // setter on Object.prototype must neither observe delete nor replace it.
   const externSetOwnIdx = ctx.funcMap.get("__extern_set_own");
-  const inheritedSetRuntimeActive = ctx.standalone && ctx.inheritedSetDescriptorDirty && externSetOwnIdx !== undefined;
+  const inheritedSetRuntimeActive = ctx.standalone && inheritedSetAnyDirty(ctx) && externSetOwnIdx !== undefined;
   if (lookupIdx === undefined || ensureIdx === undefined || externGetIdx === undefined || externSetIdx === undefined) {
     return;
   }

--- a/src/codegen/member-get-dispatch.ts
+++ b/src/codegen/member-get-dispatch.ts
@@ -64,6 +64,7 @@ import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js
 import { canonicalUndefinedExternInstrs, undefinedExternInstrs } from "./any-helpers.js";
 import { presenceTestInstrs } from "./fnctor-presence-bits.js"; // (#3780) packed own-presence flags
 import { coldFieldReadArm, findColdStructsForField } from "./fnctor-cold-tail.js"; // (#3927) hot/cold fnctor split
+import { inheritedSetAffectsKey } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import {
   findFnctorLayoutStructsForField,
   findFnctorResidStructsForField,
@@ -585,7 +586,7 @@ export function fillMemberGetDispatch(ctx: CodegenContext): void {
     // is cloned because this fill can splice a presence miss into multiple
     // independently-remapped instruction trees.
     const presenceMiss = (): Instr[] =>
-      ctx.standalone && ctx.inheritedSetDescriptorDirty
+      ctx.standalone && inheritedSetAffectsKey(ctx, propName)
         ? (structuredClone(fallback) as Instr[])
         : (undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }]);
 
@@ -938,7 +939,7 @@ export function fillTypedMemberGetF64Dispatch(ctx: CodegenContext): void {
           ]
         : [{ op: "f64.const", value: NaN }];
     const presenceMiss = (): Instr[] =>
-      ctx.standalone && ctx.inheritedSetDescriptorDirty
+      ctx.standalone && inheritedSetAffectsKey(ctx, propName)
         ? (structuredClone(fallback) as Instr[])
         : [{ op: "f64.const", value: NaN }];
 

--- a/src/codegen/member-set-dispatch.ts
+++ b/src/codegen/member-set-dispatch.ts
@@ -46,6 +46,7 @@ import { buildVecFromExternMaterializer, coercionInstrs, getVecInfo } from "./ty
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 import { presenceSetInstrs, presenceTestInstrs } from "./fnctor-presence-bits.js"; // (#3780) packed own-presence flags
 import { coldFieldWriteArm, coldTailAllocatorName, findColdStructsForField } from "./fnctor-cold-tail.js"; // (#3927)
+import { inheritedSetAffectsKey } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import {
   findFnctorLayoutStructsForField,
   findFnctorResidStructsForField,
@@ -203,7 +204,9 @@ export function fillMemberSetDispatch(ctx: CodegenContext): void {
     // each arm embeds its `next` chain exactly once (#1302).
     const layoutLocs = findFnctorLayoutStructsForField(ctx, propName).filter((loc) => loc.mutable);
     const residLocs = findFnctorResidStructsForField(ctx, propName);
-    const inheritedFlowDecisionActive = ctx.standalone && ctx.inheritedSetDescriptorDirty;
+    // (#4602) Per-key: only a key a suspicious descriptor could actually use
+    // demotes this property's writes; a clean key keeps the pre-#4504 path.
+    const inheritedFlowDecisionActive = ctx.standalone && inheritedSetAffectsKey(ctx, propName);
     const buildResidArmChain = (idx: number): Instr[] => {
       if (idx >= residLocs.length) return buildFallback();
       const loc = residLocs[idx]!;
@@ -381,7 +384,7 @@ export function fillMemberSetDispatch(ctx: CodegenContext): void {
       // slot on MISS/ALLOW.  A present slot remains a physical own field and
       // writes directly, ahead of every prototype descriptor.
       const presenceAwareSetFieldInstrs: Instr[] =
-        ctx.standalone && ctx.inheritedSetDescriptorDirty && cand.presenceSlot !== undefined
+        inheritedFlowDecisionActive && cand.presenceSlot !== undefined
           ? [
               { op: "local.get", index: 2 },
               { op: "ref.cast", typeIdx: cand.structTypeIdx },

--- a/src/codegen/member-set-f64.ts
+++ b/src/codegen/member-set-f64.ts
@@ -50,6 +50,7 @@ import { addFuncType } from "./registry/types.js";
 import { addUnionImportsViaRegistry, flushLateImportShifts } from "./shared.js";
 import { allocLocal } from "./context/locals.js";
 import { coercionInstrs } from "./type-coercion.js";
+import { inheritedSetAffectsKey } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 
 /** Flag gate. Default ON; `=0` ⇒ nothing below runs ⇒ byte-identical output. */
 export function setMemberF64Enabled(): boolean {
@@ -233,7 +234,7 @@ export function fillTypedMemberSetF64Dispatch(ctx: CodegenContext): void {
       ];
       const direct: Instr[] = !canStoreDirect
         ? buildDelegate()
-        : ctx.standalone && ctx.inheritedSetDescriptorDirty && cand.presenceSlot !== undefined
+        : ctx.standalone && inheritedSetAffectsKey(ctx, propName) && cand.presenceSlot !== undefined
           ? [
               { op: "local.get", index: 2 },
               { op: "ref.cast", typeIdx: cand.structTypeIdx },

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -5,6 +5,7 @@
  *
  * Extracted from expressions.ts (#688 step 6).
  */
+import { inheritedSetAnyDirty } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import { ts } from "../ts-api.js";
 import { isVoidType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType, WasmFunction } from "../ir/types.js";
@@ -1383,7 +1384,7 @@ export function compileObjectDefineProperty(
   // genuine instance-side accessors retain the compiled fast path below.
   const prototypeDescriptorTarget =
     ctx.standalone &&
-    ctx.inheritedSetDescriptorDirty &&
+    inheritedSetAnyDirty(ctx) &&
     (() => {
       const unwrapped = unwrapTransparentExpression(objArg);
       return ts.isPropertyAccessExpression(unwrapped) && unwrapped.name.text === "prototype";

--- a/src/codegen/object-runtime-proxy.ts
+++ b/src/codegen/object-runtime-proxy.ts
@@ -9,6 +9,7 @@
  * back (still called from `ensureObjectRuntime`). Byte-identity IDENTICAL across
  * gc/standalone/wasi is the acceptance gate (`scripts/prove-emit-identity.mjs`).
  */
+import { inheritedSetAnyDirty } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import type { ObjectRuntimeTypes } from "./object-runtime.js";
@@ -1372,8 +1373,7 @@ export function ensureProxyRuntime(
   const setBody = findBody("__extern_set");
   if (setBody) {
     const setResultGlobalIdx = ctx.externSetResultGlobalIdx;
-    const inheritedSetRuntimeActive =
-      ctx.standalone && ctx.inheritedSetDescriptorDirty && setResultGlobalIdx !== undefined;
+    const inheritedSetRuntimeActive = ctx.standalone && inheritedSetAnyDirty(ctx) && setResultGlobalIdx !== undefined;
     const isTruthyIdx = ctx.funcMap.get("__is_truthy");
     const resultAwareGuard = inheritedSetRuntimeActive && isTruthyIdx !== undefined;
     const callSetDispatch = (): Instr[] => [

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -55,6 +55,7 @@
  * runtime — it emits `struct.get`/`struct.set` directly and never calls
  * `ensureLateImport` for these names.
  */
+import { inheritedSetAnyDirty } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import type { FieldDef, Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { BFN_ID_FIELD_IDX, BFN_STATE_FIELD_IDX } from "./builtin-fn-meta.js"; // (#4241) header-derived
@@ -2787,7 +2788,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   // only at individual callers) prevents descriptor-bearing host/native-first
   // builds from gaining a private result global whose index could be shifted by
   // later imports.
-  const inheritedSetRuntimeActive = ctx.standalone && ctx.inheritedSetDescriptorDirty;
+  const inheritedSetRuntimeActive = ctx.standalone && inheritedSetAnyDirty(ctx);
   const SET_RESULT_UNADMITTED = 0;
   const SET_RESULT_SUCCESS = 1;
   const SET_RESULT_REFUSED = 2;
@@ -8458,7 +8459,7 @@ export function fillClosedStructEnumerationArms(ctx: CodegenContext): void {
  */
 export function fillClosedStructExternGetArms(ctx: CodegenContext): void {
   if (!ctx.standalone || ctx.anyStrTypeIdx < 0) return;
-  const inheritedSetGetMissActive = ctx.inheritedSetDescriptorDirty;
+  const inheritedSetGetMissActive = inheritedSetAnyDirty(ctx);
   const fn = ctx.mod.functions.find((candidate) => candidate.name === "__extern_get");
   const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
   const equalsIdx = ctx.nativeStrHelpers.get("__str_equals");
@@ -9651,7 +9652,7 @@ export function fillExternSetVecArms(ctx: CodegenContext): void {
   const setResultGlobalIdx = ctx.externSetResultGlobalIdx;
   const setDecideIdx = ctx.funcMap.get("__extern_set_decide");
   const descriptorDecisionAvailable =
-    ctx.standalone && ctx.inheritedSetDescriptorDirty && setResultGlobalIdx !== undefined && setDecideIdx !== undefined;
+    ctx.standalone && inheritedSetAnyDirty(ctx) && setResultGlobalIdx !== undefined && setDecideIdx !== undefined;
   const RESULT_SUCCESS = 1;
   const RESULT_REFUSED = 2;
   const publishSuccess = (): Instr[] =>

--- a/src/codegen/proto-index-store.ts
+++ b/src/codegen/proto-index-store.ts
@@ -99,6 +99,7 @@
  *    resolves the subclass brand then Object — the middle hop is a measured
  *    follow-up if it ever surfaces.
  */
+import { inheritedSetAnyDirty } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import type { Instr, ValType, WasmFunction } from "../ir/types.js";
 import { undefinedExternInstrs } from "./any-helpers.js";
 import type { CodegenContext } from "./context/types.js";
@@ -249,7 +250,7 @@ export function reserveProtoIndexStore(ctx: CodegenContext): void {
   // native-prototype companions.  It never creates a companion while deciding.
   // This helper is deliberately absent from descriptor-free modules so the
   // existing proto-store function space remains byte-identical.
-  if (ctx.inheritedSetDescriptorDirty) {
+  if (inheritedSetAnyDirty(ctx)) {
     reserve(PROTOIDX_SET_R, [ext, ext, ext], [i32], zero);
   }
   // (#2175 P2) `recv -> recv'` for the OWN-property views: a `$NativeProto`
@@ -552,7 +553,7 @@ export function fillProtoIndexStore(ctx: CodegenContext): void {
   fillNormKeyBody(ctx, deps);
   fillHasKBody(ctx, deps);
   fillGetKBody(ctx, deps);
-  if (ctx.inheritedSetDescriptorDirty) fillSetRBody(ctx, deps);
+  if (inheritedSetAnyDirty(ctx)) fillSetRBody(ctx, deps);
   fillHasFBody(ctx, deps);
   fillGetFBody(ctx, deps);
   fillBrandOffBody(ctx);

--- a/src/codegen/typed-this.ts
+++ b/src/codegen/typed-this.ts
@@ -96,6 +96,7 @@ import { stringConstantExternrefInstrs } from "./native-strings.js";
 // reach the expression/coercion engines without a cycle back through
 // expressions.ts / index.ts.
 import { VOID_RESULT, coerceType, compileExpression, flushLateImportShifts, valTypesMatch } from "./shared.js";
+import { inheritedSetAffectsKey } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 
 /**
  * Property names whose reads/writes have dedicated lowerings (array length,
@@ -1444,7 +1445,7 @@ export function tryEmitProvenReceiverFieldGet(
   // A clear flow-presence bit is a logical own-property miss. In an active
   // inherited-descriptor module, route it to the dynamic getter so a fnctor
   // prototype can supply the value rather than inlining `undefined`.
-  if (ctx.standalone && ctx.inheritedSetDescriptorDirty && presenceSlot !== undefined) {
+  if (ctx.standalone && inheritedSetAffectsKey(ctx, propName) && presenceSlot !== undefined) {
     noteProvenReceiver(`inherited-presence:${cls}.${propName}`);
     return undefined;
   }

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -74,6 +74,7 @@
  * `ctx.standalone` (see buildObjectDescriptorHelpers) and the fill gates on
  * the reserve flag — host output is byte-identical.
  */
+import { inheritedSetAnyDirty } from "./inherited-set-gate.js"; // (#4602) per-key #4504 gate
 import type { Instr, ValType, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
@@ -700,7 +701,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
   // an inherited descriptor. Keep the historical gOPD/hasOwn tree untouched
   // otherwise; the existing `$Hole` carrier is still used by the write path
   // below when this gate is armed.
-  const inheritedSetHolePresenceActive = ctx.inheritedSetDescriptorDirty && ctx.usesArrayHoles;
+  const inheritedSetHolePresenceActive = inheritedSetAnyDirty(ctx) && ctx.usesArrayHoles;
 
   const findFn = (name: string) => ctx.mod.functions.find((f) => f.name === name);
   const missExtern = (): Instr[] => undefinedExternInstrs(ctx)?.map((i) => ({ ...i })) ?? [{ op: "ref.null.extern" }];
@@ -1999,10 +2000,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
       const setResultGlobalIdx = ctx.externSetResultGlobalIdx;
       const setDecideIdx = ctx.funcMap.get("__extern_set_decide");
       const descriptorDecisionAvailable =
-        ctx.standalone &&
-        ctx.inheritedSetDescriptorDirty &&
-        setResultGlobalIdx !== undefined &&
-        setDecideIdx !== undefined;
+        ctx.standalone && inheritedSetAnyDirty(ctx) && setResultGlobalIdx !== undefined && setDecideIdx !== undefined;
       const holeAwarePresence =
         descriptorDecisionAvailable && ctx.usesArrayHoles && carriers.some((carrier) => carrier.kind === "externref");
       const base = 3 + fn.locals.length;

--- a/tests/issue-4602-inherited-set-per-key-gate.test.ts
+++ b/tests/issue-4602-inherited-set-per-key-gate.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4602) The #4504 inherited-[[Set]] machinery is gated PER KEY: a suspicious
+// descriptor trigger whose key is statically known poisons only that key, so
+// unrelated member writes keep the pre-#4504 direct physical path. This suite
+// pins the SEMANTIC side of that gate — every poisoned key must still observe
+// its descriptor, through each collection route the scan implements:
+//
+//   1. a literal `defineProperty` key,
+//   2. the buble/rollup ES5 identifier-bag shape
+//      (`var acc = {…}; acc.k.get = fn; Object.defineProperties(proto, acc)`),
+//   3. an ALIAS escape of the bag (forces the module-wide flag, so a key the
+//      per-key walk never saw is still honored).
+//
+// Clean-key behavior is pinned alongside each case: the point of #4602 is that
+// those writes compile to the pre-#4504 path, and they must stay correct.
+// (The perf claim itself is measured in the issue file, not asserted here —
+// acorn standalone-dynamic 0.075 → 0.138 same-machine, back to its pre-#4658
+// band.)
+//
+// STANDALONE lane only, deliberately: the #4504 machinery this gates is
+// standalone-only (`ctx.standalone && …`), and the js-host lane does not honor
+// function-constructor prototype accessors at all — verified IDENTICAL on main
+// (2026-08-21, `.tmp` probe: every gc-lane case below already fails on
+// `26a1801` without this change). Two more shapes are pre-existing standalone
+// gaps, also verified main-identical, and are NOT pinned here: a bag GROWN by
+// direct writes (`const bag: any = {}; bag.k = {…}` — the module does not
+// instantiate), and a frozen prototype refusing an inherited write (freeze
+// support predates #4504 and never refused). The scan still classifies both
+// conservatively (key-add / all-dirty).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" as const });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#4602 — per-key inherited-set gate (standalone)", () => {
+  it("a literal defineProperty setter key is honored while a clean key writes directly", async () => {
+    expect(
+      await run(
+        `function C(this: any) {}
+         Object.defineProperty(C.prototype, "poisoned", {
+           set: function (this: any, v: number) {
+             this.log = v * 2;
+           },
+           configurable: true,
+         });
+         export function test(): number {
+           const c: any = new (C as any)();
+           c.clean = 7; // clean key — pre-#4504 direct path
+           c.poisoned = 21; // must reach the inherited setter
+           return c.log === 42 && c.clean === 7 && c.poisoned === undefined ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("the buble identifier-bag getter is honored and hot writes on other keys stay correct", async () => {
+    expect(
+      await run(
+        `function Parser(this: any) {
+           this.pos = 0;
+         }
+         const prototypeAccessors: any = { doubled: { configurable: true } };
+         prototypeAccessors.doubled.get = function (this: any) {
+           return this.pos * 2;
+         };
+         Object.defineProperties(Parser.prototype, prototypeAccessors);
+         export function test(): number {
+           const p: any = new (Parser as any)();
+           let sum = 0;
+           for (let i = 0; i < 100; i++) {
+             p.pos = i; // clean key — the acorn hot shape
+             sum += p.doubled; // poisoned key — must run the getter
+           }
+           return sum === 9900 ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("an aliased bag escapes per-key tracking and its late key is still honored", async () => {
+    expect(
+      await run(
+        `function C(this: any) {}
+         const bag: any = { known: { configurable: true, get: function () { return 1; } } };
+         const alias: any = bag; // escape — the scan must fall back to all-keys
+         alias.late = {
+           set: function (this: any, v: number) {
+             this.seen = v * 3;
+           },
+           configurable: true,
+         };
+         Object.defineProperties(C.prototype, bag);
+         export function test(): number {
+           const c: any = new (C as any)();
+           c.late = 14;
+           return c.seen === 42 && c.known === 1 ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes the residual ~1.9× acorn standalone-dynamic regression left after the #4658 collapse was repaired ([#4602](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4602-acorn-standalone-dynamic-residual-perf), filed and root-caused in this PR).

## Root cause

#4504's pre-scan used one module-wide boolean: ANY accessor declaration or suspicious `defineProperty` anywhere demoted EVERY presence-tracked member write (and absent-slot read) in the module to the generic `__extern_set` runtime — string-ladder key resolution plus the nearest-descriptor chain walk. Acorn's bundle trips it through the standard buble/rollup ES5 accessor shape (`var prototypeAccessors = {…}; …; Object.defineProperties(Parser.prototype, prototypeAccessors)` — nine getter-only scope-flag accessors), and its hot path is millions of unrelated `node.start = …` first writes. Isolation A/B: forcing the flag off at HEAD measured 0.130 vs 0.075 with it on — the whole residual.

## Change

Per-key precision, no semantics change:

- The scan collects statically-named trigger keys into `ctx.inheritedSetDirtyKeys`; only triggers whose keys are unknowable (freeze, captured define builtins, computed names, dynamic code) set the module-wide flag.
- Identifier Properties bags (the buble shape) resolve through a dedicated conservative walk: declaration-literal keys ∪ direct `bag.k = …` writes; any other occurrence of the identifier escapes to the module-wide flag.
- Compile sites with a static property name gate via `inheritedSetAffectsKey` and emit byte-identical pre-#4504 code for clean keys. Key-dynamic machinery (`__extern_set` runtime, proxies, tombstones, vec overlays, proto-index store) activates on `inheritedSetAnyDirty`, so a dynamic set of a dirty key still reaches the shared four-state decision.

## Measurements (same machine, `--perf-only --lane standalone-dynamic`)

| | pre-#4658 baseline `6049c004` | before this PR (HEAD) | after |
|---|---|---|---|
| acorn | 0.137–0.145 | 0.075 | **0.138** |
| clsx | 0.139 | 0.131 | **0.141** |

## Validation

- New pinned suite `tests/issue-4602-inherited-set-per-key-gate.test.ts`: poisoned keys observe their descriptors through every collection route (literal key, buble identifier bag, alias escape) while clean-key writes stay correct. Two shapes verified as pre-existing gaps identical on main `26a1801` are documented, not pinned.
- `issue-4504-inherited-set`, `issue-4556-array-index-key-mutable-binding`, `issue-2175-p2-own-view-companion`, `issue-4578-strict-arguments-perf` suites green.
- typecheck (ts7), lint, format, LOC/function budget gates green (allowances granted in the issue frontmatter for the one-line import additions).

The PR also carries the #4602 issue file with the full regression forensics (bisect of the #4658 window, boundary measurements, profile data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8