### PR TITLE
test(npm-compat): unblock Lodash CommonJS upstream units

### DIFF
--- a/tests/dogfood/lodash-upstream-suite.mjs
+++ b/tests/dogfood/lodash-upstream-suite.mjs
@@ -8,7 +8,7 @@ import { setupNpmCompatCatalogPackage } from "./npm-compat-catalog.mjs";
 import { setupLodashUpstreamSuite } from "./setup-lodash-upstream-suite.mjs";
 import {
   UPSTREAM_TEST_EXPORTS,
-  UPSTREAM_TEST_SHIM,
+  UPSTREAM_TEST_SHIM_NODE,
   cliUpstreamHarness,
   compileAndRunUpstreamModule,
   summarizeUpstreamRuns,
@@ -50,13 +50,22 @@ export async function runHarness({ quiet = false, packageName = "lodash" } = {})
   const source = [
     ...methodImports,
     `const _ = { ${methodNames.join(", ")} };`,
-    UPSTREAM_TEST_SHIM,
+    UPSTREAM_TEST_SHIM_NODE,
     ...slices,
     UPSTREAM_TEST_EXPORTS,
   ].join("\n");
 
   log(`[dogfood] ${packageName}@${packageSetup.version} upstream ${suite.pin.tag} (${suite.pin.commit.slice(0, 12)})`);
-  const result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 300_000 });
+  // Lodash's modular published files are CommonJS and resolve their internal
+  // helpers through `require`. Compile this adapter with the Node platform so
+  // that host-facing CommonJS bindings are installed instead of the browser
+  // platform's null placeholder. The test source and callbacks remain exact.
+  const result = await compileAndRunUpstreamModule({
+    generatedPath,
+    source,
+    timeoutMs: 300_000,
+    workerEnv: { DOGFOOD_PLATFORM: "node" },
+  });
   const runs = [{ file: basename(suite.sourcePath), result }];
   const report = summarizeUpstreamRuns({
     name: `${packageName}@${packageSetup.version}`,

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -361,6 +361,13 @@ const QUnit = {
 };
 `;
 
+// CommonJS package graphs can execute imported modules before the generated
+// entry module initializes a top-level `var global` alias. The Node platform
+// already provides the binding through codegen, so Node-oriented adapters must
+// omit this browser compatibility declaration rather than observing it as
+// undefined during module initialization.
+export const UPSTREAM_TEST_SHIM_NODE = UPSTREAM_TEST_SHIM.replace("var global = globalThis;\n", "");
+
 export const UPSTREAM_TEST_EXPORTS = String.raw`
 export function upstreamTestCount(): number { return __upstreamTests.length; }
 export function upstreamTestNames(): string[] {

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -7,11 +7,17 @@ import { describe, expect, it } from "vitest";
 import {
   UPSTREAM_TEST_EXPORTS,
   UPSTREAM_TEST_SHIM,
+  UPSTREAM_TEST_SHIM_NODE,
   compileAndRunUpstreamModule,
   summarizeUpstreamRuns,
 } from "./upstream-suite-runner.mjs";
 
 describe("upstream suite runner", () => {
+  it("provides a Node shim without a late-initialized global alias", () => {
+    expect(UPSTREAM_TEST_SHIM).toContain("var global = globalThis;");
+    expect(UPSTREAM_TEST_SHIM_NODE).not.toContain("var global = globalThis;");
+  });
+
   it("awaits async callbacks without classifying them as unavailable infrastructure", async () => {
     const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
     const generatedPath = join(root, "suite.ts");


### PR DESCRIPTION
## Summary

- expose a reusable Node-oriented upstream test shim without the late-initialized browser `global` alias
- compile Lodash and lodash-es's modular CommonJS graphs with the Node platform
- keep the original selected QUnit callbacks and native oracle unchanged
- add a runner regression test for the Node shim contract

## Why

Imported Lodash CommonJS helpers execute before the generated entry module initializes the shared `var global = globalThis` shim alias. Its `_root` probe therefore observed an uninitialized alias and fell back to the unavailable `Function` constructor in Wasm. The Node platform already lowers bare `global` correctly, so the Node shim omits only that alias.

## Results

Before this change, both adapters reached native 11/11 but failed all 11 Wasm callbacks at module initialization. After this change:

- lodash: 11/11 admitted original callbacks pass in Wasm; native 11/11
- lodash-es: 11/11 admitted original callbacks pass in Wasm; native 11/11
- each report keeps 1,742 unselected upstream registrations explicitly classified as deferred/unavailable infrastructure

## Validation

- `pnpm exec vitest run tests/dogfood/upstream-suite-runner.test.ts`
- `DOGFOOD_LODASH_UPSTREAM_SUITE=1 DOGFOOD_LODASH_ES_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/lodash-upstream-suite.test.ts`
- `pnpm run typecheck`
- Prettier, Biome, LOC/function/oracle budgets, and pre-push checks

Related tracking: [#4585](https://github.com/loopdive/js2wasm/blob/main/plan/issues/4585-npm-compat-refresh-resilience.md)
