### PR TITLE
test(npm-compat): expand Stylelint upstream utility coverage

### DIFF
--- a/plan/issues/4536-stylelint-webpack-residual-illegal-casts.md
+++ b/plan/issues/4536-stylelint-webpack-residual-illegal-casts.md
@@ -4,7 +4,7 @@ title: "stylelint arrayEqual + webpack groupBy/formatSize residuals: illegal cas
 status: ready
 sprint: current
 created: 2026-08-16
-updated: 2026-08-16
+updated: 2026-08-21
 priority: low
 horizon: s
 feasibility: medium
@@ -79,3 +79,14 @@ node --import tsx tests/dogfood/webpack-upstream-suite.mjs --json
 - [ ] stylelint pinned suite 9/9.
 - [ ] webpack pinned suite 16/16.
 - [ ] Each fix carried by a general reduction, no package-specific casing.
+
+## Latest adapter checkpoint (2026-08-21)
+
+The Stylelint adapter now selects 16 original pure utility files instead of
+five, increasing the admitted corpus from 9 to 24 callbacks without adding a
+PostCSS, filesystem, plugin, or async test shim. All 16 modules compile and
+validate; 20/24 callbacks pass in Wasm and all 24 pass in native Node. The
+remaining four scored failures are unchanged compiler/runtime residuals:
+`arrayEqual` still traps with an illegal cast, `ruleMessages` loses arguments
+through its returned message closure, and both `vendor` callbacks return null.
+The other 1,550 registrations remain explicitly deferred infrastructure.

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -198,14 +198,14 @@ describe("small npm package upstream suites", () => {
     const report = await run("stylelint");
     expect(report.extraction).toMatchObject({
       filesSeen: 281,
-      filesSelected: 5,
-      filesDeferred: 276,
-      testsRegistered: 9,
-      nativePassed: 9,
+      filesSelected: 16,
+      filesDeferred: 265,
+      testsRegistered: 24,
+      nativePassed: 24,
       nativeFailed: 0,
     });
-    expect(report.compile).toMatchObject({ modules: 5, succeeded: 5, validated: 5 });
-    expect(report.results.scored).toBe(9);
+    expect(report.compile).toMatchObject({ modules: 16, succeeded: 16, validated: 16 });
+    expect(report.results.scored).toBe(24);
   });
 
   const threeHeavy = process.env.DOGFOOD_THREE_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/stylelint-upstream-suite-pin.json
+++ b/tests/dogfood/stylelint-upstream-suite-pin.json
@@ -9,10 +9,21 @@
   "registrationSites": 1574,
   "selectedFiles": [
     "lib/utils/__tests__/arrayEqual.test.mjs",
+    "lib/utils/__tests__/appendRuleName.test.mjs",
     "lib/utils/__tests__/containsString.test.mjs",
+    "lib/utils/__tests__/isCounterIncrementCustomIdentValue.test.mjs",
+    "lib/utils/__tests__/isCounterResetCustomIdentValue.test.mjs",
+    "lib/utils/__tests__/isCustomFunction.test.mjs",
     "lib/utils/__tests__/isNonNegativeInteger.test.mjs",
     "lib/utils/__tests__/isOnlyWhitespace.test.mjs",
-    "lib/utils/__tests__/pluralize.test.mjs"
+    "lib/utils/__tests__/isSingleLineString.test.mjs",
+    "lib/utils/__tests__/isValidHex.test.mjs",
+    "lib/utils/__tests__/isValidIdentifier.test.mjs",
+    "lib/utils/__tests__/isVariable.test.mjs",
+    "lib/utils/__tests__/normalizeCombinator.test.mjs",
+    "lib/utils/__tests__/pluralize.test.mjs",
+    "lib/utils/__tests__/ruleMessages.test.mjs",
+    "lib/utils/__tests__/vendor.test.mjs"
   ],
-  "_note": "The complete lib/**/__tests__ inventory is verified. This first adapter selects five synchronous utility modules with local implementation imports and no filesystem, PostCSS, snapshot, plugin, or async runner requirements. Original callback bodies and inputs are unchanged; all other files remain explicit deferred inventory."
+  "_note": "The complete lib/**/__tests__ inventory is verified. This adapter selects sixteen synchronous utility modules with local implementation imports and no filesystem, PostCSS, snapshot, plugin, or async runner requirements. Original callback bodies and inputs are unchanged; all other files remain explicit deferred inventory."
 }


### PR DESCRIPTION
## Summary

- expand Stylelint from 5 to 16 original pure utility test files
- increase the admitted callback denominator from 9 to 24 without changing callback bodies
- keep the remaining 1,550 upstream registrations explicitly deferred
- record the measured residuals in [#4536](https://github.com/loopdive/js2wasm/blob/main/plan/issues/4536-stylelint-webpack-residual-illegal-casts.md)

## Results

All 16 modules compile and validate. Native Node passes 24/24; Wasm passes 20/24. The four failures are scored runtime/compiler results: one `arrayEqual` illegal cast, one `ruleMessages` closure-argument mismatch, and two `vendor` null returns.

## Validation

- `DOGFOOD_STYLELINT_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts`
- `pnpm run typecheck`
- Prettier, Biome, LOC/function/oracle/coercion/numeric-local, and pre-push gates