### PR TITLE
test(npm-compat): expand Stylelint utility unit coverage

### DIFF
--- a/plan/issues/4536-stylelint-webpack-residual-illegal-casts.md
+++ b/plan/issues/4536-stylelint-webpack-residual-illegal-casts.md
@@ -90,3 +90,14 @@ remaining four scored failures are unchanged compiler/runtime residuals:
 `arrayEqual` still traps with an illegal cast, `ruleMessages` loses arguments
 through its returned message closure, and both `vendor` callbacks return null.
 The other 1,550 registrations remain explicitly deferred infrastructure.
+
+## Latest adapter checkpoint (2026-08-21, utility expansion)
+
+The adapter now selects **30** original synchronous utility files and registers
+**108/108** callbacks natively. All 30 modules compile and validate in the
+Wasm lane. Wasm passes **104/108** callbacks with no runtime-only failures; the
+same four compiler residuals remain (`arrayEqual`, the parameterized
+`ruleMessages` closure, and two `vendor` cases). The remaining **251 files / 1,466
+registrations** stay explicitly deferred as unavailable infrastructure rather
+than being silently omitted. The added files are local utility/reference
+modules; no test body or input was rewritten.

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -198,14 +198,14 @@ describe("small npm package upstream suites", () => {
     const report = await run("stylelint");
     expect(report.extraction).toMatchObject({
       filesSeen: 281,
-      filesSelected: 16,
-      filesDeferred: 265,
-      testsRegistered: 24,
-      nativePassed: 24,
+      filesSelected: 30,
+      filesDeferred: 251,
+      testsRegistered: 108,
+      nativePassed: 108,
       nativeFailed: 0,
     });
-    expect(report.compile).toMatchObject({ modules: 16, succeeded: 16, validated: 16 });
-    expect(report.results.scored).toBe(24);
+    expect(report.compile).toMatchObject({ modules: 30, succeeded: 30, validated: 30 });
+    expect(report.results).toMatchObject({ scored: 108, passed: 104, failed: 4, runtimeFailed: 0 });
   });
 
   const threeHeavy = process.env.DOGFOOD_THREE_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/stylelint-upstream-suite-pin.json
+++ b/tests/dogfood/stylelint-upstream-suite-pin.json
@@ -11,12 +11,26 @@
     "lib/utils/__tests__/arrayEqual.test.mjs",
     "lib/utils/__tests__/appendRuleName.test.mjs",
     "lib/utils/__tests__/containsString.test.mjs",
+    "lib/utils/__tests__/getSchemeFromUrl.test.mjs",
+    "lib/utils/__tests__/hasEmptyLine.test.mjs",
+    "lib/utils/__tests__/hasInterpolation.test.mjs",
     "lib/utils/__tests__/isCounterIncrementCustomIdentValue.test.mjs",
     "lib/utils/__tests__/isCounterResetCustomIdentValue.test.mjs",
+    "lib/utils/__tests__/isCustomMediaQuery.test.mjs",
     "lib/utils/__tests__/isCustomFunction.test.mjs",
+    "lib/utils/__tests__/isCustomProperty.test.mjs",
+    "lib/utils/__tests__/isCustomSelector.test.mjs",
+    "lib/utils/__tests__/isKeyframeSelector.test.mjs",
     "lib/utils/__tests__/isNonNegativeInteger.test.mjs",
     "lib/utils/__tests__/isOnlyWhitespace.test.mjs",
+    "lib/utils/__tests__/isNumbery.test.mjs",
+    "lib/utils/__tests__/isScssVariable.test.mjs",
     "lib/utils/__tests__/isSingleLineString.test.mjs",
+    "lib/utils/__tests__/isStandardSyntaxHexColor.test.mjs",
+    "lib/utils/__tests__/isStandardSyntaxKeyframesName.test.mjs",
+    "lib/utils/__tests__/isStandardSyntaxProperty.test.mjs",
+    "lib/utils/__tests__/isStandardSyntaxSelector.test.mjs",
+    "lib/utils/__tests__/isStandardSyntaxValue.test.mjs",
     "lib/utils/__tests__/isValidHex.test.mjs",
     "lib/utils/__tests__/isValidIdentifier.test.mjs",
     "lib/utils/__tests__/isVariable.test.mjs",
@@ -25,5 +39,5 @@
     "lib/utils/__tests__/ruleMessages.test.mjs",
     "lib/utils/__tests__/vendor.test.mjs"
   ],
-  "_note": "The complete lib/**/__tests__ inventory is verified. This adapter selects sixteen synchronous utility modules with local implementation imports and no filesystem, PostCSS, snapshot, plugin, or async runner requirements. Original callback bodies and inputs are unchanged; all other files remain explicit deferred inventory."
+  "_note": "The complete lib/**/__tests__ inventory is verified. This adapter selects thirty synchronous utility modules with local implementation imports and no filesystem, PostCSS, snapshot, plugin, or async runner requirements. Original callback bodies and inputs are unchanged; all other files remain explicit deferred inventory."
 }


### PR DESCRIPTION
## Summary

- expand the pinned Stylelint upstream adapter from 16 to 30 original synchronous utility modules
- keep all upstream callback bodies and inputs unchanged; only resolve their local relative imports
- record the measured deferred inventory and residual failures in the [Stylelint infrastructure issue](https://github.com/loopdive/js2/blob/main/plan/issues/4536-stylelint-webpack-residual-illegal-casts.md)

## Measurements

- 30/30 modules compile and validate
- 108/108 callbacks pass in native Node
- 104/108 callbacks pass in Wasm; the four existing residuals remain explicit (`arrayEqual`, parameterized `ruleMessages`, and two `vendor` cases)
- 251 test files and 1,466 registrations remain explicitly deferred as unavailable infrastructure

The expanded test only asserts the pinned denominator and these measured residuals. It does not turn deferred tests or failed Wasm callbacks into passes.

## Checks

- `DOGFOOD_STYLELINT_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts`
- `pnpm exec prettier --check ...`
- `pnpm run typecheck`
- pre-push typecheck/lint, formatting, oracle/coercion ratchets, numeric-local parity, and issue integrity
