### PR TITLE
test(npm-compat): expand Lodash upstream unit coverage

### DIFF
--- a/plan/issues/4585-npm-compat-refresh-resilience.md
+++ b/plan/issues/4585-npm-compat-refresh-resilience.md
@@ -220,3 +220,12 @@ The existing selected adapters also run successfully for jsdom (6/6),
 styled-components (6/6), and the selected webpack slice (13/16). Stylelint is
 8/9 and Redux is 13/82; their remaining failures are scored runtime/compiler
 semantics, not missing test registration or acquisition infrastructure.
+
+## Unit-infrastructure continuation 4
+
+The Lodash adapter now selects 18 original QUnit modules instead of seven,
+covering arithmetic, comparison, and string helpers. The expanded lane runs
+26/26 callbacks natively for both packages; Wasm passes 26/26 for `lodash` and
+22/26 for `lodash-es` (the four failures are null string-method results).
+The other 1,727 registrations remain explicitly deferred as unavailable
+infrastructure, and no upstream callback or input is rewritten.

--- a/tests/dogfood/lodash-upstream-suite-pin.json
+++ b/tests/dogfood/lodash-upstream-suite-pin.json
@@ -10,12 +10,23 @@
   "testSourceSha256": "dff4bb034bc54534e9d73ba352accee0a2a49e657f984b25d4c391b2db36e294",
   "selectedModules": [
     "lodash.add",
+    "lodash.capitalize",
     "lodash.divide",
+    "lodash.eq",
+    "lodash.gt",
+    "lodash.gte",
+    "lodash.lowerCase",
+    "lodash.lowerFirst",
+    "lodash.lt",
+    "lodash.lte",
     "lodash.multiply",
     "lodash.replace",
+    "lodash.startCase",
     "lodash.subtract",
     "lodash.toLower",
-    "lodash.toUpper"
+    "lodash.toUpper",
+    "lodash.upperCase",
+    "lodash.upperFirst"
   ],
-  "_note": "Lodash keeps 1,753 QUnit registration sites in one 27,234-line test/test.js file. The immutable commit and source digest pin that entire original suite. The adapter copies complete upstream QUnit.module slices for seven self-contained arithmetic/string modules and runs their unchanged callbacks against the matching published modular method files; the remaining modules stay reported as deferred."
+  "_note": "Lodash keeps 1,753 QUnit registration sites in one 27,234-line test/test.js file. The immutable commit and source digest pin that entire original suite. The adapter copies complete upstream QUnit.module slices for eighteen self-contained arithmetic, comparison, and string modules and runs their unchanged callbacks against the matching published modular method files; the remaining modules stay reported as deferred."
 }

--- a/tests/dogfood/lodash-upstream-suite.test.ts
+++ b/tests/dogfood/lodash-upstream-suite.test.ts
@@ -14,7 +14,7 @@ describe("lodash 4.18.1 upstream suite", () => {
     expect(pin.commit).toBe("cb0b9b9212521c08e3eafe7c8cb0af1b42b6649e");
     expect(pin.testFileCount).toBe(1);
     expect(pin.registrationSites).toBe(1753);
-    expect(pin.selectedModules).toHaveLength(7);
+    expect(pin.selectedModules).toHaveLength(18);
   });
 
   const heavy = process.env.DOGFOOD_LODASH_UPSTREAM_SUITE === "1" ? it : it.skip;
@@ -24,8 +24,8 @@ describe("lodash 4.18.1 upstream suite", () => {
     });
     const report = JSON.parse(out);
     expect(report.upstreamSuite.commit).toBe(pin.commit);
-    expect(report.extraction.testsRegistered).toBe(11);
-    expect(report.extraction.nativePassed).toBe(11);
+    expect(report.extraction.testsRegistered).toBe(26);
+    expect(report.extraction.nativePassed).toBe(26);
     expect(report.results.passed + report.results.failed + report.results.runtimeFailed).toBe(report.results.scored);
   });
 
@@ -37,8 +37,8 @@ describe("lodash 4.18.1 upstream suite", () => {
     const report = JSON.parse(out);
     expect(report.package).toBe("lodash-es@4.18.1");
     expect(report.upstreamSuite.commit).toBe(pin.commit);
-    expect(report.extraction.testsRegistered).toBe(11);
-    expect(report.extraction.nativePassed).toBe(11);
+    expect(report.extraction.testsRegistered).toBe(26);
+    expect(report.extraction.nativePassed).toBe(26);
     expect(report.results.passed + report.results.failed + report.results.runtimeFailed).toBe(report.results.scored);
   });
 });


### PR DESCRIPTION
## Summary

- expand the pinned Lodash QUnit adapter from seven to 18 original modules
- run the same selected callbacks against both `lodash@4.18.1` and `lodash-es@4.18.1`
- record exact native/Wasm denominators and deferred registrations in the [npm compatibility handoff](https://github.com/loopdive/js2/blob/main/plan/issues/4585-npm-compat-refresh-resilience.md)

## Measurements

- both packages: 26/26 callbacks pass in native Node; one compiled module validates
- `lodash`: 26/26 callbacks pass in Wasm
- `lodash-es`: 22/26 callbacks pass in Wasm; four callbacks return null from the string-method family
- 1,727 of the 1,753 pinned registrations remain explicitly deferred as unavailable infrastructure

The QUnit module bodies and inputs are copied unchanged. No cached result or package-specific expected answer is used.

## Checks

- `DOGFOOD_LODASH_UPSTREAM_SUITE=1 DOGFOOD_LODASH_ES_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/lodash-upstream-suite.test.ts`
- `pnpm exec prettier --check ...`
- `pnpm run typecheck`
- pre-push typecheck/lint, formatting, oracle/coercion ratchets, numeric-local parity, and issue integrity
