### PR TITLE
docs(#4601): the `analysis/` pair is NOT a leaf — record the failed leaf-proof instead of banking a shuffle

### DIFF
--- a/plan/issues/3113-ir-codegen-layering-shared-vocab.md
+++ b/plan/issues/3113-ir-codegen-layering-shared-vocab.md
@@ -240,6 +240,19 @@ Notes on the three judgement calls:
   ("If a candidate is not a dependency-free leaf, do not move it"). It is the
   obvious first candidate for a follow-up that moves the `analysis/` pair
   together.
+
+  > **Correction (2026-08-21).** Row 3's "own deps" cell records
+  > `remainder-fast-path`'s deps but **not `static-numeric-range`'s**, and that
+  > omission makes the follow-up it recommends unreachable:
+  > `static-numeric-range.ts:4` imports `../statements/loop-analysis.js` —
+  > row **6** of this very table, classified `(b) bridge, left`. So the *pair*
+  > is not a leaf either, and no relocation-only move set clears the edge. The
+  > dep predates this PR (added by `8e77e6740`, 2026-08-09, an ancestor of it);
+  > it is a measurement gap, not drift. Moving the pair anyway scores 92 → 90
+  > but trips the ratchet's own `NEW file with codegen imports` FAIL and leaves
+  > the IR's transitive reach into codegen unchanged. Full measurement and the
+  > two routes that would actually work: `4601-ir-integration-bridge-containment.md`,
+  > "Progress log".
 - **#6 `loop-analysis`** is pure AST analysis (`from-ast.ts` already documents
   it as "no codegen state") and reads like vocabulary, but it imports
   `codegen/closures.js` and `statements/tdz.js`, so it is not a leaf either.

--- a/plan/issues/4601-ir-integration-bridge-containment.md
+++ b/plan/issues/4601-ir-integration-bridge-containment.md
@@ -72,3 +72,77 @@ pipeline transaction. Unblocks when #3520 and #3521 reach `done`.
       behavior-affecting refactors carry their own differential evidence.
 - [ ] ts7 typecheck, `check:ir-fallbacks`, `check:ir-only`, equivalence gate
       all green.
+
+## Progress log
+
+### 2026-08-21 — `analysis/` pair move ATTEMPTED, NOT LANDED (leaf-proof fails)
+
+The follow-up PR #4689 teed up — "move the `remainder-fast-path` /
+`static-numeric-range` pair below the IR together" — **does not hold on current
+main**. Nothing moved; the baseline stays at **92**.
+
+**Why.** #4689's S2 table (row 3) recorded `remainder-fast-path`'s own deps
+(`ts-api` + `codegen/analysis/static-numeric-range.js`) but never recorded
+`static-numeric-range`'s. Measured on `7a3724747`:
+
+```
+codegen/analysis/remainder-fast-path.ts  →  ts-api, ./static-numeric-range.js
+codegen/analysis/static-numeric-range.ts →  ts-api, checker/oracle.js,
+                                            ../statements/loop-analysis.js   ← not a leaf
+```
+
+That third edge is **not** drift since #4689 measured — it was added by
+`8e77e6740` ("perf(array): accelerate hot indexOf scans", 2026-08-09), twelve
+days *before* #4689 merged and an ancestor of it. So the pair was already
+non-leaf when it was classified as the "obvious first candidate"; the table
+simply did not carry the second module's deps.
+
+`loop-analysis.js` is #4689's own row 6 — classified **(b) bridge, left** —
+because it imports `codegen/closures.js` (3,984 LOC, 54 imports, `CodegenContext`
+throughout) and `codegen/statements/tdz.js`. The chain does not terminate in a
+leaf, so no relocation-only move set exists that clears the edge.
+
+**Measured effect of doing it anyway** (move performed, measured, reverted):
+
+| | files | import lines |
+| - | - | - |
+| main @ `7a3724747` | 19 | 92 |
+| pair moved to `src/ir/analysis/` | 19 | **90** |
+
+`from-ast.ts` 5→4, `fmod-selection.ts` 2→1, `ir/remainder-fast-path.ts` 1→0,
+**new** `ir/analysis/static-numeric-range.ts` 0→1. Ten consumer import lines
+rewritten (3 IR-side, 7 codegen-side). Typecheck / emit-identity were not run:
+the gate itself rejects the result first —
+
+```
+ir-layering ratchet: FAIL — src/ir/ must not grow its dependency on src/codegen/.
+  - NEW file with codegen imports: ir/analysis/static-numeric-range.ts (1 import line)
+```
+
+**Why the −2 was not banked.** The scalar improves; the invariant does not. The
+IR's transitive reach into codegen is **unchanged** — `from-ast.ts:62` and
+`ir/analysis/i32-slots.ts:67` already import the same `loop-analysis.js`, so
+relocating a third importer inside `src/ir/` moves the edge rather than removing
+it, and leaves a module that still blocks legacy-path deletion while looking as
+though it does not. Silencing a `NEW file with codegen imports` FAIL with
+`--update` is exactly the signal the ratchet exists to raise.
+
+**What would actually unblock it.** `staticIntegerRange` needs one pure-AST
+predicate, `loopBodyMutatesIndexOrArray` (a whole-line call at
+`static-numeric-range.ts:136`). Two routes, both beyond pure relocation and so
+deliberately not taken here:
+
+1. **Extract the pure-AST subset of `loop-analysis.ts` below the IR.** Its two
+   deps are `collectReferencedIdentifiers` (pure AST walk, `closures.ts:375`)
+   and `collectPatternBindingNames` (`tdz.ts`); a leaf closure exists only if
+   both are lifted out of their `CodegenContext`-typed homes. This also clears
+   `from-ast.ts:62` and `i32-slots.ts:67` — worth ~4 lines, not 2.
+2. **Inject the predicate** as a member of the existing
+   `StaticIntegerRangeContext` interface. Cheaper, but changes the module's
+   public contract at all 8 call sites and needs its own differential evidence.
+
+Route 1 is the one consistent with #3113's "move vocabulary BELOW the IR".
+
+Issue stays `blocked`: the bridge (#3520/#3521) is the blocker for the main
+scope, and this near-leaf branch turns out to need its own decomposition step
+rather than a relocation.


### PR DESCRIPTION
## Description

Docs-only. **No module moved; the `check:ir-layering` baseline stays at 92.**

This was dispatched as the follow-up PR [#4689](https://github.com/loopdive/js2/pull/4689) explicitly teed up — move the near-leaf `analysis` pair (`remainder-fast-path` + `static-numeric-range`) below the IR and bank the ratchet decrease. The mandated first step was to re-verify the pair is genuinely leaf w.r.t. the ir↔codegen boundary on current main. **It is not**, so this PR records the classification rather than performing the move.

### Why the pair is not a leaf

Measured on `7a3724747`:

```
codegen/analysis/remainder-fast-path.ts  →  ts-api, ./static-numeric-range.js
codegen/analysis/static-numeric-range.ts →  ts-api, checker/oracle.js,
                                            ../statements/loop-analysis.js   ← not a leaf
```

`loop-analysis.js` is [#4689](https://github.com/loopdive/js2/pull/4689)'s own S2 table **row 6**, classified `(b) bridge, left`, because it imports `codegen/closures.ts` (3,984 LOC, 54 imports, `CodegenContext` throughout) and `codegen/statements/tdz.ts`. The chain never terminates in a leaf, so **no relocation-only move set clears the edge**.

This is a measurement gap, not drift: `8e77e6740` ("perf(array): accelerate hot indexOf scans", 2026-08-09) added the dep twelve days *before* [#4689](https://github.com/loopdive/js2/pull/4689) merged and is an ancestor of it. Row 3's "own deps" cell recorded `remainder-fast-path`'s deps but never `static-numeric-range`'s, which is what made the follow-up look reachable.

### Measured effect of doing it anyway (performed, measured, reverted)

| | files | import lines |
| - | - | - |
| main @ `7a3724747` | 19 | 92 |
| pair moved to `src/ir/analysis/` | 19 | **90** |

`from-ast.ts` 5→4 · `fmod-selection.ts` 2→1 · `ir/remainder-fast-path.ts` 1→0 · **new** `ir/analysis/static-numeric-range.ts` 0→1. Ten consumer import lines rewritten (3 IR-side, 7 codegen-side).

Typecheck and `prove-emit-identity` were not run — the gate rejects the result first:

```
ir-layering ratchet: FAIL — src/ir/ must not grow its dependency on src/codegen/.
  - NEW file with codegen imports: ir/analysis/static-numeric-range.ts (1 import line)
```

### Why the −2 was not banked

The scalar improves; the invariant does not. The IR's transitive reach into codegen is **unchanged** — `from-ast.ts:62` and `ir/analysis/i32-slots.ts:67` already import the same `loop-analysis.js`, so relocating a third importer *inside* `src/ir/` moves the edge rather than removing it, and leaves a module that still blocks legacy-front-end deletion while looking as though it does not. Silencing a `NEW file with codegen imports` FAIL with `--update` is precisely the signal the ratchet exists to raise.

### What would actually unblock it

`staticIntegerRange` needs exactly one pure-AST predicate, `loopBodyMutatesIndexOrArray` (a single call at `static-numeric-range.ts:136`). Two routes, both beyond pure relocation and so deliberately not taken here:

1. **Extract `loop-analysis.ts`'s pure-AST subset below the IR.** Its deps are `collectReferencedIdentifiers` (pure AST walk, `closures.ts:375`) and `collectPatternBindingNames` (`tdz.ts`); a leaf closure exists only if both are lifted out of their `CodegenContext`-typed homes. This also clears `from-ast.ts:62` and `i32-slots.ts:67` — worth ~4 lines, not 2. Consistent with [#3113](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3113-ir-codegen-layering-shared-vocab)'s "move vocabulary BELOW the IR".
2. **Inject the predicate** into the existing `StaticIntegerRangeContext` interface. Cheaper, but changes the module's public contract at all 8 call sites and needs its own differential evidence.

### Changes

- `plan/issues/4601-ir-integration-bridge-containment.md` — `## Progress log` entry with the full measurement and the two routes. Status stays `blocked`: the bridge ([#3520](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3520-ir-r1-source-qualified-identity-program-abi), [#3521](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3521-ir-r2-prepared-program-free-function-compile-once)) remains the blocker for the main scope, and this near-leaf branch turns out to need its own decomposition step.
- `plan/issues/3113-ir-codegen-layering-shared-vocab.md` — correction note on S2 table row 3, so the next reader is not sent down the same path.

`ir/integration.ts` is untouched, as required.

Related: [#4601](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4601-ir-integration-bridge-containment), [#3113](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3113-ir-codegen-layering-shared-vocab)

### Validation

- `check:ir-layering` — OK, 92 lines / 19 files, baseline 92 (unchanged)
- `check:loc-budget` / `check:func-budget` — OK, 0 changed `src/` files, net +0 LOC
- Docs-only: no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` files touched

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA
