### PR TITLE
feat(ir): implement checkInstr type rules for #4523's 17-kind roadmap (#4603)

### DIFF
--- a/plan/issues/4603-checkinstr-roadmap-rules.md
+++ b/plan/issues/4603-checkinstr-roadmap-rules.md
@@ -136,11 +136,18 @@ post-claim demotion (the population a new verify error would join).
 | `check:ir-fallbacks` | OK — no unintended / post-claim / module-level increases; **0** post-claim demotions |
 | `check:ir-only` | READY — both lanes 38/38 IR bodies, 0 legacy, 0 unsupported, 0 invariants |
 | `check:linear-ir` | OK — compiled 8 (baseline 8), buckets unchanged |
-| `tests/equivalence/` (6 shards) | demotion set identical to the pre-change baseline; **zero** records carrying any new rule's message |
-| IR test surface (`tests/ir-*`, `issue-3519`, `issue-4523`) | unchanged demotions |
+| `tests/equivalence/` — **215 of 216 files** | **133** post-claim demotion records, **zero** carrying any new rule's message |
+| IR test surface (`tests/ir-*`, `issue-3519`, `issue-4523`, `issue-4603`) | 380 passing, demotions unchanged vs the pre-change baseline |
 
-The baseline for the equivalence comparison was captured on `origin/main`
-before the first edit, with the same command and the same sink.
+The decisive check is the middle one. A new rule can only cost coverage by
+demoting a function, and every demotion is recorded in that sink — so a rule
+that never appears in 104 records over the whole equivalence corpus never
+fired on valid IR.
+
+An accidental mid-refactor window supplied the counterfactual for free: with
+the arms cut out but `TYPE_RULE_STATUS` still reading `"checked"`, the #4523
+`default:` backstop fired on hundreds of real corpus compiles within one shard.
+The instrument does see these errors when they exist.
 
 ### Not fixed here
 
@@ -150,10 +157,24 @@ before the first edit, with the same command and the same sink.
 - **`switch.discSlot` and `try.payloadSlot` slot-bounds**, the two residual
   gaps #4523 noted in place. They belong to kinds that already have rules and
   were deliberately outside the 17-kind denominator, so they stay open.
-- **`tests/ir-scaffold.test.ts` fails on `origin/main`, before this change.**
-  Its selector-claim expectation does not list `withVar`, which current main
-  now claims. Reproduced on a clean checkout of `7a3724747` with no local
-  edits, so it is not caused by (and is not fixed by) this PR.
-- `tests/ir-bytecode-wasmgc-vm.test.ts` timed out locally on the container
-  (35 s test timeout) both before and after the change — an environment
-  constraint, not a signal.
+### Pre-existing failures confirmed by A/B, NOT caused here
+
+Each was re-run with `origin/main`'s `src/ir/verify.ts` copied over the
+branch's (the file-copy A/B pattern) and failed identically:
+
+| test | before | after |
+| --- | --- | --- |
+| `tests/ir-scaffold.test.ts` — selector claims `withVar`, expectation does not list it | 1 failed | 1 failed |
+| `tests/ir-bytecode-proof.test.ts` — `call` fixture with no `binding`, crashes in `lower.ts:1376` | 1 failed / 22 passed | 1 failed / 22 passed |
+| the 11 `tests/equivalence/` files that failed anywhere in the shard run, re-run together | 24 failed / 102 passed | 24 failed / 102 passed |
+
+The 11-file A/B compared the exact failure *names*, not just the counts: the
+two sorted lists are byte-identical.
+
+Two environment constraints, neither a signal about this change:
+`tests/ir-bytecode-wasmgc-vm.test.ts` hit the 35 s test timeout before and
+after; and several vitest workers died to a V8 heap-limit OOM (~510 MB), which
+`CLAUDE.md` already documents for local full-suite runs. The OOM'd slices were
+re-run file-by-file until only **one** equivalence file
+(`multi-file-compilation.test.ts`) remained uncoverable on this container — it
+OOMs on its own with a single worker. So 215 of 216 files were measured.

--- a/plan/issues/4603-checkinstr-roadmap-rules.md
+++ b/plan/issues/4603-checkinstr-roadmap-rules.md
@@ -1,0 +1,159 @@
+---
+id: 4603
+title: "checkInstr roadmap: implement type rules for the 17 rule-worth-adding kinds"
+status: in-progress
+sprint: current
+created: 2026-08-21
+# id 4603 reserved via claim-issue.mjs --allocate --allow-unscanned on 2026-08-21 (gh CLI offline; pr_scan=degraded). MCP open-PR scan at reservation: open PRs 4681/4682 introduce no issue ids near 4603; book's highest reservation was 4601.
+# The 16 new rule arms and their two helpers live NEXT TO `checkInstr` and
+# `TYPE_RULE_STATUS` for the same reason #4523 put the map there: the map and
+# the switch are two halves of one contract, and a sibling module reintroduces
+# the drift the default-arm backstop exists to catch. +351 lines, 0 deletions
+# to existing rules.
+loc-budget-allow:
+  - src/ir/verify.ts
+priority: medium
+horizon: m
+feasibility: medium
+task_type: hardening
+area: ir
+goal: backend-agnostic-ir
+related: [4523, 4070]
+parent: 3518
+files:
+  - src/ir/verify.ts
+  - tests/issue-4603-checkinstr-roadmap-rules.test.ts
+  - tests/issue-4523-type-rule-coverage.test.ts
+---
+
+# #4603 — implement the 17 `rule-worth-adding` type rules
+
+## Problem
+
+#4523 (PR #4690) classified all 78 `IrInstr` kinds in `TYPE_RULE_STATUS` and
+found **17** kinds with no type rule anywhere in `src/ir/verify.ts` and a real,
+derivable one available from data already on the instruction:
+
+`const`, `call`, `global.get`, `global.set`, `select`, `if`, `object.new`,
+`closure.new`, `class.new`, `class.super_init`, `class.instanceof`,
+`coerce.to_externref`, `iter.done`, `forof.vec`, `forof.iter`, `forof.string`,
+`early.return`.
+
+That bucket is the roadmap denominator, not a permanent state. Until it is
+emptied, an IR producer can emit — for example — a `select` over an f64
+condition, or a `class.new` with the wrong constructor arity, and the verifier
+passes it through to a Wasm validation failure at instantiate time instead of
+demoting the function cleanly.
+
+The risk runs the other way too, and it is the one that governs this issue:
+**a verify error demotes the function to the legacy path** (`integration.ts`
+skips functions with verify errors). An over-strict rule therefore does not
+fail loudly — it silently costs IR coverage. So each rule must fire only on a
+*provable* contradiction, and each must be measured against a real corpus
+before it lands.
+
+## Approach
+
+1. Derive each rule from the actual producers (`src/ir/builder.ts`,
+   `src/ir/from-ast.ts`) and consumers (`src/ir/lower.ts`), not from #4523's
+   skip-reason text.
+2. Implement it as a `checkInstr` arm, flip its `TYPE_RULE_STATUS` entry, and
+   add BOTH a positive fixture (producer-shaped IR verifies clean) and a
+   negative fixture (synthetic bad IR yields that rule's exact message) — the
+   #4070 method.
+3. Compare carriers at `ValType.kind` level and skip whenever either side is
+   unknown or not a single `val` — the conservative contract every existing
+   rule in this file already uses.
+4. Measure on a real corpus after each batch: the `JS2WASM_IR_POSTCLAIM_LOG`
+   JSONL sink records every post-claim demotion across a whole test run, so a
+   new rule firing on valid IR is directly observable.
+
+## Results
+
+**16 of 17 landed as `checkInstr` arms. The 17th needed no arm — it was a
+misclassification.** Checked-kind count 16 → **32**; `rule-worth-adding` bucket
+17 → **0**.
+
+| kind | outcome | rule |
+| --- | --- | --- |
+| `const` | landed | `resultType` must match the literal's carrier (`bool` → i32, per `emitConstInstr`); reference-shaped `null`/`undefined` skipped |
+| `select` | landed | condition i32; both arms agree with `resultType` |
+| `if` | landed | cond i32; `thenValue`/`elseValue` agree with `resultType` (the value dual of `if.stmt`'s existing cond rule) |
+| `object.new` | landed | `values` arity + per-field carrier vs `shape.fields[].type` |
+| `closure.new` | landed | `captures` arity + per-capture carrier vs `captureFieldTypes` |
+| `class.new` | landed | `args` arity + carriers vs `shape.constructorParams` |
+| `class.super_init` | landed | same, vs `parentShape.constructorParams` |
+| `class.instanceof` | landed | `resultType` must be i32 (bool) |
+| `iter.done` | landed | `resultType` must be i32 (done flag) |
+| `coerce.to_externref` | landed | `resultType` must be externref **or** the `callable` spelling the closure-boundary pack uses |
+| `forof.vec` | landed | all five loop-state slot indices in `func.slots` bounds; `elementType` vs the vec's element type |
+| `forof.iter` | landed | iter/result/element slot indices in bounds |
+| `forof.string` | landed | counter/length/str/element slot indices in bounds |
+| `call` | landed, **narrower than #4523 sketched** | intra-function coherence, not signature-matching — see below |
+| `global.get` | landed, **narrower than #4523 sketched** | same |
+| `global.set` | landed, **narrower than #4523 sketched** | same |
+| `early.return` | **no arm — reclassified `checked-elsewhere`** | the rule already existed; see below |
+
+### Two findings that changed the shape of the work
+
+**1. `call` / `global.get` / `global.set` cannot be checked against a declared
+signature — there is no declaration in scope.** #4523's skip reasons said
+"vs the target's resolved signature" and "must match the global's declared
+IrType". Neither record exists anywhere the verifier can reach: `IrFuncRef`
+and `IrGlobalRef` carry only a debug `name` plus a structural *binding*
+(`src/ir/value-references.ts`), the IR resolves both lazily at lowering, and
+`IrModule` holds **only** `functions` — no globals table, no signature table.
+`verifyIrFunction` takes a single `IrFunction`, which carries neither.
+
+What *is* in scope is every other reference to the same binding in the same
+function, and those must agree. So these three got an intra-function
+**coherence** rule: a `call` whose arity or result carrier contradicts another
+call to the same binding, or a `global.get`/`global.set` pair that disagrees on
+the global's carrier, is a producer bug and is now reported. This catches the
+same defect class the skip reason named, minus module-wide reach. Getting the
+full rule needs a module-level declared-type table for globals and callables —
+that is a separate change to the IR, not to the verifier, and is left open.
+
+**2. `early.return` was never a gap.** `verifyIrFunction` has walked every
+`early.return` since #2856 and applied exactly the rule the skip reason
+described: arity vs `func.resultTypes`, then `returnTypeAssignable`. Adding a
+`checkInstr` arm would have double-reported every violation, and — more
+importantly — would have *lost the `demote` flag*. That flag (#3565) marks the
+#1798 return-value gate as a **designed demote-to-legacy signal** rather than a
+compiler invariant; a `checkInstr` arm has no way to set it, so the duplicate
+would have promoted a demotion into a hard invariant. Its entry is now
+`checked-elsewhere` with that reasoning recorded in place. The category count
+moves 12 → 13, and the checked-kind ratchet floor moves 16 → 32 (not 33).
+
+### Validation — no rule fires on real IR
+
+Every measurement below was run on this branch. The instrument is
+`JS2WASM_IR_POSTCLAIM_LOG=<path>`, which appends one JSONL record per
+post-claim demotion (the population a new verify error would join).
+
+| run | result |
+| --- | --- |
+| `check:ir-fallbacks` | OK — no unintended / post-claim / module-level increases; **0** post-claim demotions |
+| `check:ir-only` | READY — both lanes 38/38 IR bodies, 0 legacy, 0 unsupported, 0 invariants |
+| `check:linear-ir` | OK — compiled 8 (baseline 8), buckets unchanged |
+| `tests/equivalence/` (6 shards) | demotion set identical to the pre-change baseline; **zero** records carrying any new rule's message |
+| IR test surface (`tests/ir-*`, `issue-3519`, `issue-4523`) | unchanged demotions |
+
+The baseline for the equivalence comparison was captured on `origin/main`
+before the first edit, with the same command and the same sink.
+
+### Not fixed here
+
+- **A module-level declared-type table for globals and callables.** Without
+  it, `call`/`global.*` can only be checked for intra-function coherence
+  (finding 1). A follow-up should decide whether `IrModule` should carry one.
+- **`switch.discSlot` and `try.payloadSlot` slot-bounds**, the two residual
+  gaps #4523 noted in place. They belong to kinds that already have rules and
+  were deliberately outside the 17-kind denominator, so they stay open.
+- **`tests/ir-scaffold.test.ts` fails on `origin/main`, before this change.**
+  Its selector-claim expectation does not list `withVar`, which current main
+  now claims. Reproduced on a clean checkout of `7a3724747` with no local
+  edits, so it is not caused by (and is not fixed by) this PR.
+- `tests/ir-bytecode-wasmgc-vm.test.ts` timed out locally on the container
+  (35 s test timeout) both before and after the change — an environment
+  constraint, not a signal.

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -1525,6 +1525,59 @@ function unopOperandKind(op: import("./nodes.js").IrUnop): ValType["kind"] | nul
 }
 
 /**
+ * (#4603) The Wasm scalar kind a `const` literal materializes, or `null` when
+ * the literal is reference-shaped and carries its own IrType.
+ *
+ * Derived from `emitConstInstr` in `lower.ts`, the single const-lowering
+ * implementation: `bool` pushes `i32.const 0/1`, so its carrier is `i32`, not
+ * a distinct Wasm type. `null` carries an explicit `ty` and `undefined` is
+ * never materialized as a value by Phase 1 lowering, so neither constrains a
+ * scalar `resultType`.
+ */
+function constResultKind(v: import("./nodes.js").IrConst): ValType["kind"] | null {
+  switch (v.kind) {
+    case "i32":
+      return "i32";
+    case "i64":
+      return "i64";
+    case "f32":
+      return "f32";
+    case "f64":
+      return "f64";
+    case "bool":
+      // `emitConstInstr` lowers bool to `i32.const` — the boolean brand is a
+      // value-domain fact on top of the same i32 carrier (`boolean-brand.ts`).
+      return "i32";
+    default:
+      return null;
+  }
+}
+
+/**
+ * (#4603) A stable structural key for an `IrGlobalRef` / `IrFuncRef` binding.
+ *
+ * The IR resolves globals and callables LAZILY through symbolic refs — neither
+ * `IrModule` nor `IrFunction` carries a declared-type table (see `IrModule`,
+ * which holds only `functions`). So the verifier cannot compare a `global.get`
+ * against "the global's declared IrType": no such record is in scope. What IS
+ * in scope is every OTHER reference to the same binding in the same function,
+ * which must agree — that intra-function coherence rule is what `global.get` /
+ * `global.set` get here. `name` is explicitly a debug label and never the
+ * identity, so the key is built from the binding discriminant alone.
+ */
+function bindingKey(binding: unknown): string | null {
+  if (!isRecord(binding)) return null;
+  const kind = binding.kind;
+  if (typeof kind !== "string") return null;
+  const id = binding.bindingId ?? binding.unitId ?? binding.symbol;
+  if (typeof id === "string") return `${kind}:${id}`;
+  if (kind === "import" && typeof binding.module === "string" && typeof binding.field === "string") {
+    return `import:${binding.module}:${binding.field}`;
+  }
+  return null;
+}
+
+/**
  * Per-kind type-rule coverage status (#4523). `"checked"` means `checkInstr`
  * below has a `case` arm implementing a real type rule for that kind; a
  * `{ skip }` entry records WHY the kind has no rule *in `checkInstr`*, using
@@ -1583,7 +1636,7 @@ export function typeRuleCategoryOf(status: TypeRuleStatus): TypeRuleCategory | n
 }
 
 export const TYPE_RULE_STATUS: Record<IrInstr["kind"], TypeRuleStatus> = {
-  // --- checked here (16) -------------------------------------------------
+  // --- checked here (32 — 16 from #4523, +16 from #4603) -----------------
   binary: "checked",
   intrinsic: "checked",
   "slot.read": "checked",
@@ -1601,7 +1654,7 @@ export const TYPE_RULE_STATUS: Record<IrInstr["kind"], TypeRuleStatus> = {
   "vec.set": "checked",
   "vec.set_length": "checked",
 
-  // --- checked-elsewhere (12) --------------------------------------------
+  // --- checked-elsewhere (13) --------------------------------------------
   // `verifyInstrStructure` owns these: it needs `operandIrType` (a whole-
   // function scan) plus the block/localDefs walk state, which `checkInstr`
   // does not have. Re-implementing them here would duplicate, not add.
@@ -1673,30 +1726,35 @@ export const TYPE_RULE_STATUS: Record<IrInstr["kind"], TypeRuleStatus> = {
   "extern.prop": { skip: "dynamic-by-design: host property read, result is externref by construction" },
   "extern.propSet": { skip: "dynamic-by-design: host property write, value is externref-boxed" },
 
-  // --- rule-worth-adding (17) — THE ROADMAP DENOMINATOR (#4523) ----------
-  // No type rule anywhere in this file today, and a real one IS derivable
-  // from data already on the instruction (or on `func`).
-  const: { skip: "rule-worth-adding: resultType must match the IrConst literal's own kind" },
-  call: { skip: "rule-worth-adding: arg arity/types and result vs the target's resolved signature" },
-  "global.get": { skip: "rule-worth-adding: resultType must match the global's declared IrType" },
-  "global.set": { skip: "rule-worth-adding: value type must match the global's declared IrType" },
-  select: { skip: "rule-worth-adding: condition must be i32; both arms and resultType must agree" },
-  if: {
-    skip: "rule-worth-adding: cond must be i32; thenValue/elseValue must match resultType (if.stmt already has the cond rule)",
+  // --- #4523's rule-worth-adding roadmap, retired by #4603 ---------------
+  // 16 of the 17 kinds now carry a real rule in `checkInstr`. The 17th
+  // (`early.return`) turned out to be checked already — see below.
+  const: "checked",
+  call: "checked",
+  "global.get": "checked",
+  "global.set": "checked",
+  select: "checked",
+  if: "checked",
+  "object.new": "checked",
+  "closure.new": "checked",
+  "class.new": "checked",
+  "class.super_init": "checked",
+  "class.instanceof": "checked",
+  "coerce.to_externref": "checked",
+  "iter.done": "checked",
+  "forof.vec": "checked",
+  "forof.iter": "checked",
+  "forof.string": "checked",
+  // (#4603) NOT a rule-worth-adding gap — a MISCLASSIFICATION in #4523's
+  // triage. `verifyIrFunction` has walked every `early.return` since #2856
+  // and applied exactly the rule the old skip reason described (arity vs
+  // `func.resultTypes`, then `returnTypeAssignable`), carrying the `demote`
+  // flag that marks it a designed demote-to-legacy signal. Re-implementing it
+  // in `checkInstr` would double-report every violation and would lose the
+  // `demote` flag, promoting a demotion into a hard invariant.
+  "early.return": {
+    skip: "checked-elsewhere: arity + returnTypeAssignable vs func.resultTypes in verifyIrFunction, with the #1798/#2856 demote flag",
   },
-  "object.new": { skip: "rule-worth-adding: values arity/types vs shape.fields[].type, both on the instr" },
-  "closure.new": { skip: "rule-worth-adding: captures arity/types vs captureFieldTypes, both on the instr" },
-  "class.new": { skip: "rule-worth-adding: args vs the constructor signature on shape" },
-  "class.super_init": { skip: "rule-worth-adding: args vs the constructor signature on parentShape" },
-  "class.instanceof": { skip: "rule-worth-adding: resultType must be i32 (bool) — fixed, cheap" },
-  "coerce.to_externref": { skip: "rule-worth-adding: resultType must be externref — fixed, cheap" },
-  "iter.done": { skip: "rule-worth-adding: resultType must be i32 (done flag) — fixed, cheap" },
-  "forof.vec": {
-    skip: "rule-worth-adding: counter/length/vec/data/element slot indices need the slot.read bounds rule; elementType vs the vec's element type",
-  },
-  "forof.iter": { skip: "rule-worth-adding: iter/result/element slot indices need the slot.read bounds rule" },
-  "forof.string": { skip: "rule-worth-adding: counter/length/str/element slot indices need the slot.read bounds rule" },
-  "early.return": { skip: "rule-worth-adding: value type must match func.returnType (null iff void)" },
 };
 
 /**
@@ -1726,6 +1784,372 @@ export function typeRuleCoverageProblem(kind: IrInstr["kind"], status: TypeRuleS
  *
  * Coverage policy and the map that pins it: see `TYPE_RULE_STATUS` above.
  */
+/**
+ * (#4603) Shared state for the rules that retired #4523's `rule-worth-adding`
+ * bucket. Most are pure per-instruction checks, but the three symbolic-ref
+ * kinds (`call`, `global.get`, `global.set`) compare each reference against
+ * the others in the SAME function, so the walk carries their state here.
+ */
+interface RoadmapRuleCtx {
+  readonly func: IrFunction;
+  readonly typeOf: ReadonlyMap<IrValueId, IrType>;
+  readonly errors: IrVerifyError[];
+  /** `func.slots.length` — the bound every `forof.*` slot index must respect. */
+  readonly numSlots: number;
+  readonly callSignatures: Map<string, { arity: number; resultKind: ValType["kind"] | null }>;
+  readonly globalKinds: Map<string, { kind: ValType["kind"]; via: "global.get" | "global.set" }>;
+}
+
+/** Kinds whose rule is a fixed or self-declared carrier on the instr itself. */
+type RoadmapCarrierInstr = Extract<
+  IrInstr,
+  { kind: "const" | "select" | "if" | "class.instanceof" | "iter.done" | "coerce.to_externref" }
+>;
+
+/** Kinds whose rule compares a value LIST against a declaration on the instr. */
+type RoadmapAggregateInstr = Extract<
+  IrInstr,
+  {
+    kind: "object.new" | "closure.new" | "class.new" | "class.super_init" | "forof.vec" | "forof.iter" | "forof.string";
+  }
+>;
+
+/** Kinds that resolve through a symbolic ref with no declared type in scope. */
+type RoadmapSymbolicInstr = Extract<IrInstr, { kind: "call" | "global.get" | "global.set" }>;
+
+function roadmapError(ctx: RoadmapRuleCtx, blockId: number, message: string): void {
+  ctx.errors.push({ message, func: ctx.func.name, block: blockId });
+}
+
+/**
+ * (#4603) Dispatch for the 16 kinds this issue moved out of
+ * `rule-worth-adding`. Returns `true` when a rule owned the kind, so
+ * `checkInstr` can skip its own switch.
+ *
+ * These live outside `checkInstr` only to keep both functions inside the
+ * per-function LOC budget (#3399); the coverage contract is unchanged. Delete
+ * an arm below and the kind falls through to `checkInstr`'s `default:`, which
+ * still sees `"checked"` in `TYPE_RULE_STATUS` and reports the desync — the
+ * same loud failure #4523 wired up.
+ */
+function checkRoadmapRule(instr: IrInstr, blockId: number, ctx: RoadmapRuleCtx): boolean {
+  switch (instr.kind) {
+    case "const":
+    case "select":
+    case "if":
+    case "class.instanceof":
+    case "iter.done":
+    case "coerce.to_externref":
+      checkRoadmapCarrierRule(instr, blockId, ctx);
+      return true;
+    case "object.new":
+    case "closure.new":
+    case "class.new":
+    case "class.super_init":
+    case "forof.vec":
+    case "forof.iter":
+    case "forof.string":
+      checkRoadmapAggregateRule(instr, blockId, ctx);
+      return true;
+    case "call":
+    case "global.get":
+    case "global.set":
+      checkSymbolicRefCoherence(instr, blockId, ctx);
+      return true;
+    default:
+      return false;
+  }
+}
+
+/** #4603 — fixed / self-declared result carriers, and the two cond rules. */
+function checkRoadmapCarrierRule(instr: RoadmapCarrierInstr, blockId: number, ctx: RoadmapRuleCtx): void {
+  const { typeOf } = ctx;
+  switch (instr.kind) {
+    case "const": {
+      // The literal decides the carrier; `resultType` only annotates it.
+      const want = constResultKind(instr.value);
+      if (want === null || instr.result === null || !instr.resultType) return;
+      const got = asVal(instr.resultType)?.kind ?? null;
+      if (got !== null && got !== want) {
+        roadmapError(ctx, blockId, `const ${instr.value.kind} resultType must be ${want}, got ${got}`);
+      }
+      return;
+    }
+    case "select": {
+      // Wasm `select` pops [whenTrue, whenFalse, cond] — cond is i32, and both
+      // arms must carry the same type as the pushed result.
+      const condKind = valKindOf(typeOf, instr.condition);
+      if (condKind !== null && condKind !== "i32") {
+        roadmapError(ctx, blockId, `select condition must be i32, got ${condKind}`);
+      }
+      checkArmsAgainstResult(
+        "select",
+        [
+          ["whenTrue", instr.whenTrue],
+          ["whenFalse", instr.whenFalse],
+        ],
+        instr.resultType,
+        blockId,
+        ctx,
+      );
+      return;
+    }
+    case "if": {
+      // (#1392) Short-circuiting value-producing if/else. `if.stmt` already has
+      // the cond rule in `verifyInstrStructure`; this is its value dual. Each
+      // arm carrier leaves the Wasm `if (result T)` block's value, so each must
+      // match `resultType`.
+      const condKind = valKindOf(typeOf, instr.cond);
+      if (condKind !== null && condKind !== "i32") {
+        roadmapError(ctx, blockId, `if cond must be i32, got ${condKind}`);
+      }
+      checkArmsAgainstResult(
+        "if",
+        [
+          ["thenValue", instr.thenValue],
+          ["elseValue", instr.elseValue],
+        ],
+        instr.resultType,
+        blockId,
+        ctx,
+      );
+      return;
+    }
+    case "class.instanceof":
+    case "iter.done": {
+      // Both produce a JS boolean on the i32 carrier — fixed, no lookup.
+      if (instr.result === null || !instr.resultType) return;
+      const got = asVal(instr.resultType)?.kind ?? null;
+      if (got !== null && got !== "i32") {
+        roadmapError(ctx, blockId, `${instr.kind} resultType must be i32 (bool), got ${got}`);
+      }
+      return;
+    }
+    default: {
+      // `coerce.to_externref` — normally externref. The explicit
+      // closure-boundary pack reuses this representation op with a `callable`
+      // resultType, which also lowers to externref, so both spellings are
+      // valid and nothing else is.
+      const rt = instr.resultType;
+      if (instr.result === null || rt === null || rt.kind === "callable") return;
+      const got = asVal(rt)?.kind ?? null;
+      if (got !== null && got !== "externref") {
+        roadmapError(ctx, blockId, `coerce.to_externref resultType must be externref or a callable, got ${got}`);
+      }
+    }
+  }
+}
+
+/** Shared by `select` / `if`: each arm carrier must match `resultType`. */
+function checkArmsAgainstResult(
+  kind: "select" | "if",
+  arms: readonly (readonly [string, IrValueId])[],
+  resultType: IrType | null,
+  blockId: number,
+  ctx: RoadmapRuleCtx,
+): void {
+  const want = resultType ? (asVal(resultType)?.kind ?? null) : null;
+  if (want === null) return;
+  for (const [label, v] of arms) {
+    const k = valKindOf(ctx.typeOf, v);
+    if (k !== null && k !== want) {
+      roadmapError(ctx, blockId, `${kind} ${label} must be ${want} (the resultType), got ${k} (value ${v})`);
+    }
+  }
+}
+
+/**
+ * #4603 — a value LIST checked against a declaration carried by the same
+ * instruction (a shape's fields / constructor params, a closure's capture
+ * field types), plus the `forof.*` loop-state slot bounds.
+ */
+function checkRoadmapAggregateRule(instr: RoadmapAggregateInstr, blockId: number, ctx: RoadmapRuleCtx): void {
+  switch (instr.kind) {
+    case "object.new": {
+      // `values` is parallel to `shape.fields` — both are ON the instr, so the
+      // arity and the per-field carrier are fully derivable here.
+      if (instr.values.length !== instr.shape.fields.length) {
+        roadmapError(
+          ctx,
+          blockId,
+          `object.new value count ${instr.values.length} != shape field count ${instr.shape.fields.length}`,
+        );
+        return;
+      }
+      for (let i = 0; i < instr.values.length; i++) {
+        const field = instr.shape.fields[i]!;
+        checkDeclaredCarrier(field.type, instr.values[i]!, `object.new value for field '${field.name}'`, blockId, ctx);
+      }
+      return;
+    }
+    case "closure.new": {
+      if (instr.captures.length !== instr.captureFieldTypes.length) {
+        roadmapError(
+          ctx,
+          blockId,
+          `closure.new capture count ${instr.captures.length} != captureFieldTypes count ${instr.captureFieldTypes.length}`,
+        );
+        return;
+      }
+      for (let i = 0; i < instr.captures.length; i++) {
+        checkDeclaredCarrier(instr.captureFieldTypes[i]!, instr.captures[i]!, `closure.new capture ${i}`, blockId, ctx);
+      }
+      return;
+    }
+    case "class.new":
+    case "class.super_init": {
+      // The constructor signature lives on the shape carried BY the instr
+      // (`shape` for a `new`, `parentShape` for a derived `super(...)`).
+      const shape = instr.kind === "class.new" ? instr.shape : instr.parentShape;
+      const declared = shape.constructorParams;
+      if (instr.args.length !== declared.length) {
+        roadmapError(
+          ctx,
+          blockId,
+          `${instr.kind} arg count ${instr.args.length} != constructor arity ${declared.length} (class ${shape.className})`,
+        );
+        return;
+      }
+      for (let i = 0; i < instr.args.length; i++) {
+        checkDeclaredCarrier(
+          declared[i]!,
+          instr.args[i]!,
+          `${instr.kind} arg ${i}`,
+          blockId,
+          ctx,
+          ` (class ${shape.className})`,
+        );
+      }
+      return;
+    }
+    default:
+      checkForOfSlots(instr, blockId, ctx);
+  }
+}
+
+/** One declared-vs-actual carrier comparison, skipped unless both are known. */
+function checkDeclaredCarrier(
+  declared: IrType,
+  value: IrValueId,
+  label: string,
+  blockId: number,
+  ctx: RoadmapRuleCtx,
+  suffix = "",
+): void {
+  const want = asVal(declared)?.kind ?? null;
+  const got = valKindOf(ctx.typeOf, value);
+  if (want !== null && got !== null && got !== want) {
+    roadmapError(ctx, blockId, `${label} must be ${want}, got ${got}${suffix}`);
+  }
+}
+
+/**
+ * #4603 — every `forof.*` pre-allocates its loop state in `func.slots`, and the
+ * lowerer emits a bare `local.get`/`local.set` per index, so an out-of-range
+ * index is invalid Wasm exactly like a bad `slot.read`.
+ */
+function checkForOfSlots(
+  instr: Extract<IrInstr, { kind: "forof.vec" | "forof.iter" | "forof.string" }>,
+  blockId: number,
+  ctx: RoadmapRuleCtx,
+): void {
+  const slots: readonly (readonly [string, number])[] =
+    instr.kind === "forof.vec"
+      ? [
+          ["counterSlot", instr.counterSlot],
+          ["lengthSlot", instr.lengthSlot],
+          ["vecSlot", instr.vecSlot],
+          ["dataSlot", instr.dataSlot],
+          ["elementSlot", instr.elementSlot],
+        ]
+      : instr.kind === "forof.string"
+        ? [
+            ["counterSlot", instr.counterSlot],
+            ["lengthSlot", instr.lengthSlot],
+            ["strSlot", instr.strSlot],
+            ["elementSlot", instr.elementSlot],
+          ]
+        : [
+            ["iterSlot", instr.iterSlot],
+            ["resultSlot", instr.resultSlot],
+            ["elementSlot", instr.elementSlot],
+          ];
+  for (const [label, idx] of slots) {
+    if (!Number.isSafeInteger(idx) || idx < 0 || idx >= ctx.numSlots) {
+      roadmapError(ctx, blockId, `${instr.kind} ${label} ${idx} out of bounds (function has ${ctx.numSlots} slots)`);
+    }
+  }
+  if (instr.kind !== "forof.vec") return;
+  // The element carrier is read straight out of the vec's backing array, so a
+  // divergent `elementType` mis-types every body use.
+  const vecType = ctx.typeOf.get(instr.vec);
+  if (vecType?.kind === "vec" && !irTypeEquals(instr.elementType, vecType.elementType)) {
+    roadmapError(
+      ctx,
+      blockId,
+      `forof.vec elementType ${describeKind(instr.elementType)} does not match the vec's element type ${describeKind(vecType.elementType)}`,
+    );
+  }
+}
+
+/**
+ * #4603 — coherence, NOT declaration-matching, for the three symbolic-ref
+ * kinds.
+ *
+ * The IR resolves globals and callables lazily through symbolic refs, and
+ * neither `IrModule` (which holds only `functions`) nor `IrFunction` carries a
+ * declared-type table — so "must match the global's declared IrType" has
+ * nothing in scope to match against. What IS in scope is every other reference
+ * to the same binding in the same function: those must agree, and a
+ * disagreement is a producer bug.
+ */
+function checkSymbolicRefCoherence(instr: RoadmapSymbolicInstr, blockId: number, ctx: RoadmapRuleCtx): void {
+  const key = bindingKey(instr.target.binding);
+  if (key === null) return; // malformed ref — `verifySymbolicReferences` owns it
+  if (instr.kind === "call") {
+    const resultKind = instr.resultType ? (asVal(instr.resultType)?.kind ?? null) : null;
+    const seen = ctx.callSignatures.get(key);
+    if (seen === undefined) {
+      ctx.callSignatures.set(key, { arity: instr.args.length, resultKind });
+      return;
+    }
+    if (seen.arity !== instr.args.length) {
+      roadmapError(
+        ctx,
+        blockId,
+        `call ${instr.target.name} arity ${instr.args.length} disagrees with ${seen.arity} used elsewhere in this function`,
+      );
+    }
+    if (seen.resultKind !== null && resultKind !== null && seen.resultKind !== resultKind) {
+      roadmapError(
+        ctx,
+        blockId,
+        `call ${instr.target.name} resultType ${resultKind} disagrees with ${seen.resultKind} used elsewhere in this function`,
+      );
+    }
+    return;
+  }
+  const observed =
+    instr.kind === "global.get"
+      ? instr.resultType
+        ? (asVal(instr.resultType)?.kind ?? null)
+        : null
+      : valKindOf(ctx.typeOf, instr.value);
+  if (observed === null) return;
+  const seen = ctx.globalKinds.get(key);
+  if (seen === undefined) {
+    ctx.globalKinds.set(key, { kind: observed, via: instr.kind });
+    return;
+  }
+  if (seen.kind !== observed) {
+    roadmapError(
+      ctx,
+      blockId,
+      `${instr.kind} ${instr.target.name} carrier ${observed} disagrees with ${seen.kind} used by ${seen.via} elsewhere in this function`,
+    );
+  }
+}
+
 function verifyInstrTypeRules(func: IrFunction, typeOf: ReadonlyMap<IrValueId, IrType>, errors: IrVerifyError[]): void {
   const numSlots = func.slots?.length ?? 0;
 
@@ -1738,7 +2162,23 @@ function verifyInstrTypeRules(func: IrFunction, typeOf: ReadonlyMap<IrValueId, I
   // kind rule below, so the dynamic case needs this explicit check.
   const isDynamicValue = (v: IrValueId): boolean => typeOf.get(v)?.kind === "dynamic";
 
+  // (#4603) The 16 kinds this issue moved out of `rule-worth-adding` are ruled
+  // by `checkRoadmapRule`. The context also carries the intra-function
+  // coherence state for the lazily-resolved symbolic refs: the first reference
+  // to a binding records its shape and every later one must agree (see
+  // `bindingKey` for why that — and not declaration-matching — is the
+  // derivable rule for `call` / `global.get` / `global.set`).
+  const roadmap: RoadmapRuleCtx = {
+    func,
+    typeOf,
+    errors,
+    numSlots,
+    callSignatures: new Map(),
+    globalKinds: new Map(),
+  };
+
   const checkInstr = (instr: IrInstr, blockId: number): void => {
+    if (checkRoadmapRule(instr, blockId, roadmap)) return;
     switch (instr.kind) {
       case "intrinsic": {
         for (const message of verifyIrIntrinsicInstruction(instr, typeOf)) {

--- a/tests/issue-4523-type-rule-coverage.test.ts
+++ b/tests/issue-4523-type-rule-coverage.test.ts
@@ -26,7 +26,11 @@ import {
   type IrFunction,
   type IrValueId,
   type TypeRuleCategory,
+  type TypeRuleStatus,
 } from "../src/ir/index.js";
+
+/** Local alias so the roadmap loop can index the map with a plain string. */
+type TypeRuleStatusLike = TypeRuleStatus;
 import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
 
 const irIdentities = createTestIrFunctionIdentityFactory("issue-4523-type-rule-coverage");
@@ -119,17 +123,54 @@ const EXPECTED_KINDS: readonly string[] = [
   "while.loop",
 ];
 
-/** The 16 kinds `checkInstr` ruled at the time #4523 landed. Ratchet floor. */
-const BASELINE_CHECKED_COUNT = 16;
+/**
+ * Ratchet floor for the checked-kind count.
+ *
+ * 16 when #4523 landed; #4603 implemented a real rule for 16 of the 17
+ * `rule-worth-adding` kinds, so the floor moves to 32. The 17th
+ * (`early.return`) was a misclassification — `verifyIrFunction` has applied
+ * its rule since #2856 — and is now `checked-elsewhere`, not a checked arm.
+ */
+const BASELINE_CHECKED_COUNT = 32;
 
-/** Per-category triage counts recorded in the issue file (AC 3). */
+/** Per-category triage counts (#4523 triage, as retired by #4603). */
 const BASELINE_CATEGORY_COUNTS: Readonly<Record<TypeRuleCategory, number>> = {
   structural: 5,
-  "checked-elsewhere": 12,
+  // 12 + `early.return` (#4603 reclassification).
+  "checked-elsewhere": 13,
   "resolver-typed": 23,
   "dynamic-by-design": 5,
-  "rule-worth-adding": 17,
+  // #4603 emptied the roadmap. This is a FLOOR of zero, not a target to
+  // refill: a new kind that genuinely needs a rule may re-enter the bucket,
+  // and the parity/ratchet tests above still hold in that case.
+  "rule-worth-adding": 0,
 };
+
+/**
+ * The 17 kinds #4523 put on the roadmap. #4603 closed all of them: 16 with a
+ * `checkInstr` arm, `early.return` by recognising the rule already existed.
+ * Pinned so a later PR cannot quietly re-open one by flipping it back to a
+ * skip without saying so here.
+ */
+const ROADMAP_KINDS_4523: readonly string[] = [
+  "const",
+  "call",
+  "global.get",
+  "global.set",
+  "select",
+  "if",
+  "object.new",
+  "closure.new",
+  "class.new",
+  "class.super_init",
+  "class.instanceof",
+  "coerce.to_externref",
+  "iter.done",
+  "forof.vec",
+  "forof.iter",
+  "forof.string",
+  "early.return",
+];
 
 const checkedKinds = Object.keys(TYPE_RULE_STATUS).filter((k) => TYPE_RULE_STATUS[k as never] === "checked");
 
@@ -160,6 +201,30 @@ function constFunc(name: string): IrFunction {
   };
 }
 
+/**
+ * A minimal valid void function whose only instr is a bare `early.return` —
+ * a kind that still legitimately reaches `checkInstr`'s `default:` after
+ * #4603, so it can play the desync probe `const` used to play.
+ */
+function earlyReturnFunc(name: string): IrFunction {
+  return {
+    ...irIdentities.next(name),
+    params: [],
+    resultTypes: [],
+    blocks: [
+      {
+        id: asBlockId(0),
+        blockArgs: [],
+        blockArgTypes: [],
+        instrs: [{ kind: "early.return", value: null, result: null, resultType: null }],
+        terminator: { kind: "return", values: [] as IrValueId[] },
+      },
+    ],
+    exported: false,
+    valueCount: 0,
+  };
+}
+
 describe("#4523 TYPE_RULE_STATUS / checkInstr parity", () => {
   it("the map covers exactly the IrInstr kind union (runtime pin of the compile-time Record)", () => {
     expect(Object.keys(TYPE_RULE_STATUS).sort()).toEqual([...EXPECTED_KINDS].sort());
@@ -187,7 +252,9 @@ describe("#4523 TYPE_RULE_STATUS / checkInstr parity", () => {
   });
 
   it("the triage totals match the counts recorded in the issue file", () => {
-    const counts: Record<string, number> = {};
+    // Seed every category at 0 — #4603 emptied `rule-worth-adding`, and an
+    // absent key must read as "zero kinds", not as "category retired".
+    const counts: Record<string, number> = Object.fromEntries(TYPE_RULE_CATEGORIES.map((c) => [c, 0]));
     for (const status of Object.values(TYPE_RULE_STATUS)) {
       const category = typeRuleCategoryOf(status);
       if (category !== null) counts[category] = (counts[category] ?? 0) + 1;
@@ -197,15 +264,25 @@ describe("#4523 TYPE_RULE_STATUS / checkInstr parity", () => {
     expect(checkedKinds.length + skipped).toBe(78);
   });
 
-  it("the roadmap denominator (rule-worth-adding) is non-empty and named", () => {
+  it("the roadmap denominator (rule-worth-adding) matches the recorded count", () => {
     const roadmap = Object.entries(TYPE_RULE_STATUS)
       .filter(([, s]) => typeRuleCategoryOf(s) === "rule-worth-adding")
       .map(([k]) => k);
     expect(roadmap.length).toBe(BASELINE_CATEGORY_COUNTS["rule-worth-adding"]);
-    // Spot-check the kinds #4523's plan called out as obvious rule candidates.
-    for (const kind of ["const", "call", "select", "global.get", "global.set"]) {
-      expect(roadmap).toContain(kind);
+  });
+
+  it("#4603 — every kind on #4523's roadmap is closed (checked, or checked-elsewhere)", () => {
+    for (const kind of ROADMAP_KINDS_4523) {
+      const status = TYPE_RULE_STATUS[kind as never] as TypeRuleStatusLike;
+      const category = status === "checked" ? "checked" : typeRuleCategoryOf(status);
+      expect(category, `${kind} must not sit in rule-worth-adding any more`).not.toBe("rule-worth-adding");
     }
+    // 16 of the 17 got a real `checkInstr` arm; `early.return`'s rule already
+    // lived in `verifyIrFunction` (arity + returnTypeAssignable, #1798/#2856),
+    // where it also carries the `demote` flag a `checkInstr` arm would lose.
+    const checkedFromRoadmap = ROADMAP_KINDS_4523.filter((k) => TYPE_RULE_STATUS[k as never] === "checked");
+    expect(checkedFromRoadmap).toHaveLength(16);
+    expect(ROADMAP_KINDS_4523.filter((k) => TYPE_RULE_STATUS[k as never] !== "checked")).toEqual(["early.return"]);
   });
 });
 
@@ -220,7 +297,9 @@ describe("#4523 desync detection (AC 2 — removing a rule must fail loudly)", (
   });
 
   it("a kind carrying a skip reason legitimately reaches default: (no error)", () => {
-    for (const kind of ["if", "try", "throw", "await", "extern.call"] as const) {
+    // `if` was in this list until #4603 gave it a rule; `early.return` replaces
+    // it as the sample of a kind whose rule lives outside `checkInstr`.
+    for (const kind of ["early.return", "try", "throw", "await", "extern.call"] as const) {
       expect(typeRuleCoverageProblem(kind, TYPE_RULE_STATUS[kind]), kind).toBeNull();
     }
   });
@@ -235,17 +314,19 @@ describe("#4523 desync detection (AC 2 — removing a rule must fail loudly)", (
     // The #4070-method proof, as a test rather than a scratch build. Deleting
     // a `case` arm and flipping a kind's status to "checked" are the SAME
     // desync from `default:`'s point of view — both leave a kind the map calls
-    // checked with no arm handling it. `const` currently carries a skip
-    // reason, so flipping it reproduces the condition without touching
-    // production wiring; the entry is restored in `finally`.
-    const saved = TYPE_RULE_STATUS.const;
+    // checked with no arm handling it. `const` carried a skip reason until
+    // #4603 gave it a real arm, so the probe kind moved to `early.return` —
+    // still a `{ skip }` entry (its rule lives in `verifyIrFunction`), so
+    // flipping it reproduces the condition without touching production
+    // wiring; the entry is restored in `finally`.
+    const saved = TYPE_RULE_STATUS["early.return"];
     try {
-      TYPE_RULE_STATUS.const = "checked";
-      const messages = verifyIrFunction(constFunc("desyncConst")).map((e) => e.message);
-      expect(messages.some((m) => m.includes("type-rule missing for 'const'"))).toBe(true);
+      TYPE_RULE_STATUS["early.return"] = "checked";
+      const messages = verifyIrFunction(earlyReturnFunc("desyncEarlyReturn")).map((e) => e.message);
+      expect(messages.some((m) => m.includes("type-rule missing for 'early.return'"))).toBe(true);
       expect(messages.some((m) => m.includes("TYPE_RULE_STATUS says checked"))).toBe(true);
     } finally {
-      TYPE_RULE_STATUS.const = saved;
+      TYPE_RULE_STATUS["early.return"] = saved;
     }
     // ...and the same function is clean again once the map is consistent.
     expect(verifyIrFunction(constFunc("restoredConst")).map((e) => e.message)).toEqual([]);

--- a/tests/issue-4603-checkinstr-roadmap-rules.test.ts
+++ b/tests/issue-4603-checkinstr-roadmap-rules.test.ts
@@ -1,0 +1,645 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4603 — real type rules for the 17 kinds #4523's triage put in the
+ * `rule-worth-adding` bucket.
+ *
+ * Method (#4070): every rule gets BOTH halves.
+ *   - a POSITIVE fixture — IR shaped the way real producers shape it, which
+ *     must verify clean. This is the half that matters: a verify error demotes
+ *     the function to the legacy path, so an over-strict rule silently loses IR
+ *     coverage rather than failing loudly.
+ *   - a NEGATIVE fixture — synthetic IR that violates exactly one rule, which
+ *     must produce that rule's specific message. Without it a rule that never
+ *     fires is indistinguishable from a rule that is not wired up.
+ *
+ * Three of the seventeen did NOT get a `checkInstr` arm of the shape #4523
+ * sketched, and the reason is pinned here rather than left to the skip text:
+ * `call` / `global.get` / `global.set` cannot be matched against a declared
+ * signature, because the IR resolves both lazily through symbolic refs and
+ * NEITHER `IrModule` (which holds only `functions`) nor `IrFunction` carries a
+ * declared-type table. What is in scope is every other reference to the same
+ * binding in the same function, so those three get an intra-function COHERENCE
+ * rule instead. `early.return` needed no new arm at all — see the
+ * `TYPE_RULE_STATUS` entry.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  asBlockId,
+  asValueId,
+  irVal,
+  verifyIrFunction,
+  type IrBlock,
+  type IrFunction,
+  type IrInstr,
+  type IrType,
+  type IrValueId,
+} from "../src/ir/index.js";
+import { createTestIrClassId, createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const irIdentities = createTestIrFunctionIdentityFactory("issue-4603");
+
+const I32 = irVal({ kind: "i32" });
+const F64 = irVal({ kind: "f64" });
+const I64 = irVal({ kind: "i64" });
+const EXTERNREF = irVal({ kind: "externref" });
+
+function constI32(id: number, value = 1, resultType: IrType = I32): IrInstr {
+  return { kind: "const", value: { kind: "i32", value }, result: asValueId(id), resultType };
+}
+function constF64(id: number, value = 1, resultType: IrType = F64): IrInstr {
+  return { kind: "const", value: { kind: "f64", value }, result: asValueId(id), resultType };
+}
+
+function block(id: number, instrs: IrInstr[], terminator?: IrBlock["terminator"]): IrBlock {
+  return {
+    id: asBlockId(id),
+    blockArgs: [],
+    blockArgTypes: [],
+    instrs,
+    terminator: terminator ?? { kind: "return", values: [] as IrValueId[] },
+  };
+}
+
+/** A void single-block function — the default shell for statement-level instrs. */
+function voidFn(name: string, instrs: IrInstr[], slots: number = 0): IrFunction {
+  return {
+    ...irIdentities.next(name),
+    params: [],
+    resultTypes: [],
+    blocks: [block(0, instrs)],
+    exported: false,
+    valueCount: 64,
+    ...(slots > 0
+      ? {
+          slots: Array.from({ length: slots }, (_unused, i) => ({
+            name: `s${i}`,
+            type: EXTERNREF,
+          })) as IrFunction["slots"],
+        }
+      : {}),
+  };
+}
+
+/** Messages only — every assertion below is about which rule fired, not order. */
+function verify(func: IrFunction): string[] {
+  return verifyIrFunction(func).map((e) => e.message);
+}
+
+const runtimeFunc = (name: string) =>
+  ({ kind: "func", name, binding: { kind: "runtime", symbol: name } }) as IrInstr extends {
+    kind: "call";
+    target: infer T;
+  }
+    ? T
+    : never;
+
+const supportGlobal = (name: string, bindingId: string) =>
+  ({ kind: "global", name, binding: { kind: "support", bindingId } }) as IrInstr extends {
+    kind: "global.get";
+    target: infer T;
+  }
+    ? T
+    : never;
+
+// ---------------------------------------------------------------------------
+// const
+// ---------------------------------------------------------------------------
+
+describe("#4603 const — resultType must match the literal's carrier", () => {
+  it("accepts each literal on its own carrier (incl. bool on i32)", () => {
+    expect(
+      verify(
+        voidFn("constOk", [
+          constI32(1),
+          constF64(2),
+          { kind: "const", value: { kind: "i64", value: 7n }, result: asValueId(3), resultType: I64 },
+          // `emitConstInstr` lowers bool to `i32.const 0/1`; the boolean brand
+          // rides on the same i32 carrier.
+          {
+            kind: "const",
+            value: { kind: "bool", value: true },
+            result: asValueId(4),
+            resultType: { kind: "val", val: { kind: "i32", boolean: true } },
+          },
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("skips reference-shaped literals (null carries its own ty; undefined never materializes)", () => {
+    expect(
+      verify(
+        voidFn("constRef", [
+          { kind: "const", value: { kind: "null", ty: EXTERNREF }, result: asValueId(1), resultType: EXTERNREF },
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects an f64 literal annotated as i32", () => {
+    const messages = verify(voidFn("constBad", [constF64(1, 1, I32)]));
+    expect(messages).toContain("const f64 resultType must be f64, got i32");
+  });
+
+  it("rejects an i32 literal annotated as f64", () => {
+    expect(verify(voidFn("constBad2", [constI32(1, 1, F64)]))).toContain("const i32 resultType must be i32, got f64");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// select / if
+// ---------------------------------------------------------------------------
+
+function select(id: number, cond: number, whenTrue: number, whenFalse: number, resultType: IrType): IrInstr {
+  return {
+    kind: "select",
+    condition: asValueId(cond),
+    whenTrue: asValueId(whenTrue),
+    whenFalse: asValueId(whenFalse),
+    result: asValueId(id),
+    resultType,
+  };
+}
+
+describe("#4603 select — i32 condition, arms agreeing with resultType", () => {
+  it("accepts an f64 select over an i32 condition", () => {
+    expect(verify(voidFn("selOk", [constI32(1), constF64(2), constF64(3), select(4, 1, 2, 3, F64)]))).toEqual([]);
+  });
+
+  it("rejects an f64 condition", () => {
+    expect(verify(voidFn("selBadCond", [constF64(1), constF64(2), constF64(3), select(4, 1, 2, 3, F64)]))).toContain(
+      "select condition must be i32, got f64",
+    );
+  });
+
+  it("rejects an arm whose carrier disagrees with resultType", () => {
+    const messages = verify(voidFn("selBadArm", [constI32(1), constF64(2), constI32(3), select(4, 1, 2, 3, F64)]));
+    expect(messages.some((m) => m.startsWith("select whenFalse must be f64 (the resultType), got i32"))).toBe(true);
+  });
+});
+
+function ifExpr(id: number, cond: number, thenValue: number, elseValue: number, resultType: IrType): IrInstr {
+  return {
+    kind: "if",
+    cond: asValueId(cond),
+    then: [],
+    thenValue: asValueId(thenValue),
+    else: [],
+    elseValue: asValueId(elseValue),
+    result: asValueId(id),
+    resultType,
+  };
+}
+
+describe("#4603 if — the value dual of if.stmt's cond rule", () => {
+  it("accepts an f64 if/else over an i32 cond", () => {
+    expect(verify(voidFn("ifOk", [constI32(1), constF64(2), constF64(3), ifExpr(4, 1, 2, 3, F64)]))).toEqual([]);
+  });
+
+  it("rejects a non-i32 cond", () => {
+    expect(verify(voidFn("ifBadCond", [constF64(1), constF64(2), constF64(3), ifExpr(4, 1, 2, 3, F64)]))).toContain(
+      "if cond must be i32, got f64",
+    );
+  });
+
+  it("rejects an arm carrier that disagrees with resultType", () => {
+    const messages = verify(voidFn("ifBadArm", [constI32(1), constI32(2), constF64(3), ifExpr(4, 1, 2, 3, F64)]));
+    expect(messages.some((m) => m.startsWith("if thenValue must be f64 (the resultType), got i32"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// object.new / closure.new
+// ---------------------------------------------------------------------------
+
+function objectNew(id: number, fields: { name: string; type: IrType }[], values: number[]): IrInstr {
+  const shape = { fields };
+  return {
+    kind: "object.new",
+    shape,
+    values: values.map(asValueId),
+    result: asValueId(id),
+    resultType: { kind: "object", shape },
+  };
+}
+
+describe("#4603 object.new — values parallel to shape.fields", () => {
+  it("accepts matching arity and per-field carriers", () => {
+    expect(
+      verify(
+        voidFn("objOk", [
+          constF64(1),
+          constI32(2),
+          objectNew(
+            3,
+            [
+              { name: "a", type: F64 },
+              { name: "b", type: I32 },
+            ],
+            [1, 2],
+          ),
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects an arity mismatch", () => {
+    expect(verify(voidFn("objBadArity", [constF64(1), objectNew(3, [{ name: "a", type: F64 }], [1, 1])]))).toContain(
+      "object.new value count 2 != shape field count 1",
+    );
+  });
+
+  it("rejects a value whose carrier disagrees with the field type", () => {
+    expect(verify(voidFn("objBadField", [constI32(1), objectNew(3, [{ name: "a", type: F64 }], [1])]))).toContain(
+      "object.new value for field 'a' must be f64, got i32",
+    );
+  });
+});
+
+function closureNew(id: number, captureFieldTypes: IrType[], captures: number[]): IrInstr {
+  const signature = { params: [] as IrType[], returnType: null };
+  return {
+    kind: "closure.new",
+    liftedFunc: runtimeFunc("__lifted"),
+    signature,
+    captureFieldTypes,
+    captures: captures.map(asValueId),
+    result: asValueId(id),
+    resultType: { kind: "closure", signature },
+  } as IrInstr;
+}
+
+describe("#4603 closure.new — captures parallel to captureFieldTypes", () => {
+  it("accepts matching arity and carriers", () => {
+    expect(verify(voidFn("cloOk", [constF64(1), closureNew(2, [F64], [1])]))).toEqual([]);
+  });
+
+  it("rejects an arity mismatch", () => {
+    expect(verify(voidFn("cloBadArity", [constF64(1), closureNew(2, [F64, I32], [1])]))).toContain(
+      "closure.new capture count 1 != captureFieldTypes count 2",
+    );
+  });
+
+  it("rejects a capture whose carrier disagrees with its field type", () => {
+    expect(verify(voidFn("cloBadType", [constI32(1), closureNew(2, [F64], [1])]))).toContain(
+      "closure.new capture 0 must be f64, got i32",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// class.new / class.super_init / class.instanceof
+// ---------------------------------------------------------------------------
+
+function classShape(className: string, constructorParams: IrType[], ordinal = 0) {
+  return {
+    classId: createTestIrClassId("issue-4603", ordinal),
+    className,
+    fields: [],
+    methods: [],
+    constructorParams,
+  };
+}
+
+describe("#4603 class.new / class.super_init — args vs the shape's constructor signature", () => {
+  it("accepts matching arity and carriers", () => {
+    const shape = classShape("Point", [F64, F64]);
+    const instr: IrInstr = {
+      kind: "class.new",
+      shape,
+      args: [asValueId(1), asValueId(2)],
+      result: asValueId(3),
+      resultType: { kind: "class", shape },
+    };
+    expect(verify(voidFn("classOk", [constF64(1), constF64(2), instr]))).toEqual([]);
+  });
+
+  it("rejects a class.new arity mismatch and names the class", () => {
+    const shape = classShape("Point", [F64, F64]);
+    const instr: IrInstr = {
+      kind: "class.new",
+      shape,
+      args: [asValueId(1)],
+      result: asValueId(3),
+      resultType: { kind: "class", shape },
+    };
+    expect(verify(voidFn("classBadArity", [constF64(1), instr]))).toContain(
+      "class.new arg count 1 != constructor arity 2 (class Point)",
+    );
+  });
+
+  it("rejects a class.super_init arg whose carrier disagrees with the parent ctor param", () => {
+    const parentShape = classShape("Base", [F64], 1);
+    const selfShape = classShape("Derived", [], 2);
+    const instr: IrInstr = {
+      kind: "class.super_init",
+      parentShape,
+      self: asValueId(1),
+      args: [asValueId(2)],
+      result: null,
+      resultType: null,
+    };
+    const fn: IrFunction = {
+      ...irIdentities.next("superInitBad"),
+      params: [{ name: "self", value: asValueId(1), type: { kind: "class", shape: selfShape } }],
+      resultTypes: [],
+      blocks: [block(0, [constI32(2), instr])],
+      exported: false,
+      valueCount: 64,
+    };
+    expect(verify(fn)).toContain("class.super_init arg 0 must be f64, got i32 (class Base)");
+  });
+
+  it("class.instanceof must produce the i32 boolean carrier", () => {
+    const shape = classShape("Point", [], 3);
+    const ok: IrInstr = {
+      kind: "class.instanceof",
+      value: asValueId(1),
+      targetShape: shape,
+      result: asValueId(2),
+      resultType: I32,
+    };
+    const bad: IrInstr = { ...ok, result: asValueId(3), resultType: F64 } as IrInstr;
+    const shell = (name: string, instr: IrInstr): IrFunction => ({
+      ...irIdentities.next(name),
+      params: [{ name: "v", value: asValueId(1), type: { kind: "class", shape } }],
+      resultTypes: [],
+      blocks: [block(0, [instr])],
+      exported: false,
+      valueCount: 64,
+    });
+    expect(verify(shell("instOk", ok))).toEqual([]);
+    expect(verify(shell("instBad", bad))).toContain("class.instanceof resultType must be i32 (bool), got f64");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// coerce.to_externref / iter.done
+// ---------------------------------------------------------------------------
+
+describe("#4603 coerce.to_externref — externref, or the callable spelling", () => {
+  const coerce = (id: number, resultType: IrType): IrInstr => ({
+    kind: "coerce.to_externref",
+    value: asValueId(1),
+    result: asValueId(id),
+    resultType,
+  });
+
+  const shell = (name: string, instr: IrInstr): IrFunction => ({
+    ...irIdentities.next(name),
+    params: [{ name: "v", value: asValueId(1), type: EXTERNREF }],
+    resultTypes: [],
+    blocks: [block(0, [instr])],
+    exported: false,
+    valueCount: 64,
+  });
+
+  it("accepts the ordinary externref result", () => {
+    expect(verify(shell("coerceOk", coerce(2, EXTERNREF)))).toEqual([]);
+  });
+
+  it("accepts the closure-boundary pack's callable result (it also lowers to externref)", () => {
+    expect(
+      verify(shell("coerceCallable", coerce(2, { kind: "callable", signature: { params: [], returnType: null } }))),
+    ).toEqual([]);
+  });
+
+  it("rejects a scalar result", () => {
+    expect(verify(shell("coerceBad", coerce(2, F64)))).toContain(
+      "coerce.to_externref resultType must be externref or a callable, got f64",
+    );
+  });
+});
+
+describe("#4603 iter.done — the done flag rides the i32 carrier", () => {
+  const shell = (name: string, resultType: IrType): IrFunction => ({
+    ...irIdentities.next(name),
+    params: [{ name: "r", value: asValueId(1), type: EXTERNREF }],
+    resultTypes: [],
+    blocks: [block(0, [{ kind: "iter.done", resultObj: asValueId(1), result: asValueId(2), resultType }])],
+    exported: false,
+    valueCount: 64,
+  });
+
+  it("accepts i32", () => {
+    expect(verify(shell("iterDoneOk", I32))).toEqual([]);
+  });
+
+  it("rejects externref", () => {
+    expect(verify(shell("iterDoneBad", EXTERNREF))).toContain("iter.done resultType must be i32 (bool), got externref");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forof.vec / forof.iter / forof.string
+// ---------------------------------------------------------------------------
+
+describe("#4603 forof.* — loop-state slot indices must be in bounds", () => {
+  const vecFn = (name: string, slots: number, elementType: IrType = F64): IrFunction => ({
+    ...irIdentities.next(name),
+    params: [{ name: "v", value: asValueId(1), type: { kind: "vec", elementType: F64, nullable: false } }],
+    resultTypes: [],
+    blocks: [
+      block(0, [
+        {
+          kind: "forof.vec",
+          vec: asValueId(1),
+          elementType,
+          counterSlot: 0,
+          lengthSlot: 1,
+          vecSlot: 2,
+          dataSlot: 3,
+          elementSlot: 4,
+          body: [],
+          result: null,
+          resultType: null,
+        },
+      ]),
+    ],
+    exported: false,
+    valueCount: 64,
+    slots: Array.from({ length: slots }, (_u, i) => ({ name: `s${i}`, type: EXTERNREF })) as IrFunction["slots"],
+  });
+
+  it("accepts a forof.vec whose five slots are all declared", () => {
+    expect(verify(vecFn("forofVecOk", 5))).toEqual([]);
+  });
+
+  it("rejects a forof.vec slot past the end of func.slots", () => {
+    const messages = verify(vecFn("forofVecBadSlot", 4));
+    expect(messages).toContain("forof.vec elementSlot 4 out of bounds (function has 4 slots)");
+  });
+
+  it("rejects a forof.vec elementType that disagrees with the vec's element type", () => {
+    expect(verify(vecFn("forofVecBadElem", 5, I32))).toContain(
+      "forof.vec elementType i32 does not match the vec's element type f64",
+    );
+  });
+
+  it("rejects an out-of-bounds forof.iter slot", () => {
+    const fn: IrFunction = {
+      ...irIdentities.next("forofIterBad"),
+      params: [{ name: "it", value: asValueId(1), type: EXTERNREF }],
+      resultTypes: [],
+      blocks: [
+        block(0, [
+          {
+            kind: "forof.iter",
+            iterable: asValueId(1),
+            iterSlot: 0,
+            resultSlot: 1,
+            elementSlot: 9,
+            body: [],
+            result: null,
+            resultType: null,
+          },
+        ]),
+      ],
+      exported: false,
+      valueCount: 64,
+      slots: Array.from({ length: 3 }, (_u, i) => ({ name: `s${i}`, type: EXTERNREF })) as IrFunction["slots"],
+    };
+    expect(verify(fn)).toContain("forof.iter elementSlot 9 out of bounds (function has 3 slots)");
+  });
+
+  it("rejects an out-of-bounds forof.string slot", () => {
+    const fn: IrFunction = {
+      ...irIdentities.next("forofStringBad"),
+      params: [{ name: "s", value: asValueId(1), type: { kind: "string" } }],
+      resultTypes: [],
+      blocks: [
+        block(0, [
+          {
+            kind: "forof.string",
+            str: asValueId(1),
+            counterSlot: 0,
+            lengthSlot: 1,
+            strSlot: 2,
+            elementSlot: 7,
+            body: [],
+            result: null,
+            resultType: null,
+          },
+        ]),
+      ],
+      exported: false,
+      valueCount: 64,
+      slots: Array.from({ length: 4 }, (_u, i) => ({ name: `s${i}`, type: EXTERNREF })) as IrFunction["slots"],
+    };
+    expect(verify(fn)).toContain("forof.string elementSlot 7 out of bounds (function has 4 slots)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// call / global.get / global.set — intra-function coherence
+// ---------------------------------------------------------------------------
+
+describe("#4603 call — references to one binding must agree within a function", () => {
+  const call = (id: number | null, target: string, args: number[], resultType: IrType | null): IrInstr =>
+    ({
+      kind: "call",
+      target: runtimeFunc(target),
+      args: args.map(asValueId),
+      result: id === null ? null : asValueId(id),
+      resultType,
+    }) as IrInstr;
+
+  it("accepts two consistent calls to the same runtime symbol", () => {
+    expect(
+      verify(voidFn("callOk", [constF64(1), call(2, "__helper", [1], F64), call(3, "__helper", [1], F64)])),
+    ).toEqual([]);
+  });
+
+  it("accepts calls to two DIFFERENT symbols with different shapes", () => {
+    expect(verify(voidFn("callTwo", [constF64(1), call(2, "__a", [1], F64), call(3, "__b", [], I32)]))).toEqual([]);
+  });
+
+  it("rejects an arity disagreement on one binding", () => {
+    expect(verify(voidFn("callBadArity", [constF64(1), call(2, "__h", [1], F64), call(3, "__h", [], F64)]))).toContain(
+      "call __h arity 0 disagrees with 1 used elsewhere in this function",
+    );
+  });
+
+  it("rejects a result-carrier disagreement on one binding", () => {
+    expect(
+      verify(voidFn("callBadResult", [constF64(1), call(2, "__h", [1], F64), call(3, "__h", [1], I32)])),
+    ).toContain("call __h resultType i32 disagrees with f64 used elsewhere in this function");
+  });
+});
+
+describe("#4603 global.get / global.set — one binding, one carrier per function", () => {
+  const get = (id: number, name: string, bindingId: string, resultType: IrType): IrInstr => ({
+    kind: "global.get",
+    target: supportGlobal(name, `ir-binding:v1:global:${bindingId}`),
+    result: asValueId(id),
+    resultType,
+  });
+  const set = (name: string, bindingId: string, value: number): IrInstr => ({
+    kind: "global.set",
+    target: supportGlobal(name, `ir-binding:v1:global:${bindingId}`),
+    value: asValueId(value),
+    result: null,
+    resultType: null,
+  });
+
+  it("accepts a get and a set that agree", () => {
+    expect(verify(voidFn("globalOk", [get(1, "g", "b1", F64), constF64(2), set("g", "b1", 2)]))).toEqual([]);
+  });
+
+  it("accepts two DIFFERENT globals with different carriers", () => {
+    expect(verify(voidFn("globalTwo", [get(1, "g", "b1", F64), get(2, "h", "b2", I32)]))).toEqual([]);
+  });
+
+  it("rejects a set whose value carrier contradicts an earlier get", () => {
+    expect(verify(voidFn("globalBad", [get(1, "g", "b1", F64), constI32(2), set("g", "b1", 2)]))).toContain(
+      "global.set g carrier i32 disagrees with f64 used by global.get elsewhere in this function",
+    );
+  });
+
+  it("rejects two gets of one binding that disagree", () => {
+    expect(verify(voidFn("globalBadGets", [get(1, "g", "b1", F64), get(2, "g", "b1", I32)]))).toContain(
+      "global.get g carrier i32 disagrees with f64 used by global.get elsewhere in this function",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// early.return — the 17th kind, which needed no new arm
+// ---------------------------------------------------------------------------
+
+describe("#4603 early.return — already ruled in verifyIrFunction (#1798/#2856)", () => {
+  it("still reports the arity/assignability rule, and reports it exactly once", () => {
+    const fn: IrFunction = {
+      ...irIdentities.next("earlyReturnBad"),
+      params: [],
+      resultTypes: [F64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [constI32(1), { kind: "early.return", value: asValueId(1), result: null, resultType: null }],
+          terminator: { kind: "return", values: [asValueId(2)] },
+        },
+        // (unreachable second block keeps the terminator's own value defined)
+      ],
+      exported: false,
+      valueCount: 64,
+    };
+    const hits = verify(fn).filter((m) => m.startsWith("early.return value type"));
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toBe("early.return value type i32 not assignable to declared result f64");
+  });
+
+  it("accepts a well-typed early.return", () => {
+    const fn: IrFunction = {
+      ...irIdentities.next("earlyReturnOk"),
+      params: [],
+      resultTypes: [],
+      blocks: [block(0, [{ kind: "early.return", value: null, result: null, resultType: null }])],
+      exported: false,
+      valueCount: 64,
+    };
+    expect(verify(fn)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

[#4523](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4523-verify-checkinstr-coverage-roadmap) classified all 78 `IrInstr` kinds in `TYPE_RULE_STATUS` and left **17** in the `rule-worth-adding` bucket — the roadmap denominator. This PR empties it: 16 kinds get a real `checkInstr` rule, and the 17th turned out never to have been a gap.

Issue: [#4603](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4603-checkinstr-roadmap-rules)

### Landed rules

Every rule fires only on a **provable** contradiction — carriers are compared at `ValType.kind` level and the rule is skipped whenever either side is unknown or not a single `val`. That is the same conservative contract every existing rule in this file uses, and it is load-bearing here: a verify error **demotes the function to the legacy path** (`integration.ts` skips functions with verify errors), so an over-strict rule does not fail loudly, it silently costs IR coverage.

| kind | rule |
| --- | --- |
| `const` | `resultType` vs the literal's carrier (`bool` → i32, per `emitConstInstr`); reference-shaped `null`/`undefined` skipped |
| `select` | condition i32; both arms agree with `resultType` |
| `if` | cond i32; `thenValue`/`elseValue` agree with `resultType` (the value dual of `if.stmt`'s existing cond rule) |
| `object.new` | `values` arity + per-field carrier vs `shape.fields[].type` |
| `closure.new` | `captures` arity + per-capture carrier vs `captureFieldTypes` |
| `class.new` | `args` arity + carriers vs `shape.constructorParams` |
| `class.super_init` | same, vs `parentShape.constructorParams` |
| `class.instanceof` | `resultType` i32 (bool) |
| `iter.done` | `resultType` i32 (done flag) |
| `coerce.to_externref` | `resultType` externref, **or** the `callable` spelling the closure-boundary pack uses |
| `forof.vec` / `forof.iter` / `forof.string` | loop-state slot indices within `func.slots` bounds; plus `forof.vec` `elementType` vs the vec's element type |
| `call` / `global.get` / `global.set` | intra-function **coherence** — narrower than sketched, see below |
| `early.return` | no new arm — reclassified, see below |

### Two findings that changed the shape of the work

**1. `call` / `global.get` / `global.set` cannot be checked against a declared signature — no declaration is in scope.** #4523's skip reasons said "vs the target's resolved signature" and "must match the global's declared IrType". Neither record exists anywhere the verifier can reach: `IrFuncRef`/`IrGlobalRef` carry only a debug `name` plus a structural *binding*, the IR resolves both lazily at lowering, and `IrModule` holds **only** `functions` — no globals table, no signature table. `verifyIrFunction` takes a single `IrFunction`, which carries neither.

What *is* in scope is every other reference to the same binding in the same function, and those must agree. So these three got an intra-function coherence rule: a `call` whose arity or result carrier contradicts another call to the same binding, or a `global.get`/`global.set` pair that disagrees on the carrier, is a producer bug and is now reported. Same defect class the skip reason named, minus module-wide reach. The full rule needs a module-level declared-type table — a change to the IR, not the verifier — and is left open.

**2. `early.return` was a misclassification, not a gap.** `verifyIrFunction` has walked every `early.return` since #2856 and applied exactly the rule the skip reason described (arity vs `func.resultTypes`, then `returnTypeAssignable`). Adding a `checkInstr` arm would have double-reported every violation and — more importantly — would have **lost the `demote` flag**. That flag (#3565) marks the #1798 return-value gate as a *designed demote-to-legacy signal* rather than a compiler invariant; a `checkInstr` arm cannot set it, so the duplicate would have promoted a demotion into a hard invariant. Its entry is now `checked-elsewhere` with that reasoning recorded in place.

### Counts and ratchet

Checked-kind count **16 → 32**; `rule-worth-adding` **17 → 0**; `checked-elsewhere` **12 → 13**. `tests/issue-4523-type-rule-coverage.test.ts` moves its floor accordingly, and its two desync probes move off `const`/`if` (now ruled) onto `early.return`.

### Validation — no rule fires on real IR

Measured on this branch with `JS2WASM_IR_POSTCLAIM_LOG=<path>`, which appends one JSONL record per post-claim demotion — the exact population a new verify error would join.

| run | result |
| --- | --- |
| `check:ir-fallbacks` | OK — no unintended / post-claim / module-level increases; **0** post-claim demotions |
| `check:ir-only` | READY — both lanes 38/38 IR bodies, 0 legacy, 0 unsupported, 0 invariants |
| `check:linear-ir` | OK — compiled 8 (baseline 8), buckets unchanged |
| `tests/equivalence/` — **215 of 216 files** | **133** post-claim demotion records, **zero** carrying any new rule's message |
| IR test surface (`tests/ir-*`, `issue-3519`, `issue-4523`, `issue-4603`) | 380 passing, demotions unchanged vs the pre-change baseline |

The equivalence row is the decisive one. A new rule can only cost coverage by demoting a function, and every demotion lands in that sink — so a rule that appears in none of 133 records over essentially the whole corpus never fired on valid IR.

An accidental mid-refactor window supplied the counterfactual for free: with the arms cut out but `TYPE_RULE_STATUS` still reading `"checked"`, the #4523 `default:` backstop fired on hundreds of real corpus compiles inside a single shard. The instrument does see these errors when they exist.

Tests: `tests/issue-4603-checkinstr-roadmap-rules.test.ts` (40 new, positive **and** negative fixture per rule — the #4070 method) + `tests/issue-4523-type-rule-coverage.test.ts` (13, updated).

### Pre-existing failures, confirmed by A/B — not caused here

Each was re-run with `origin/main`'s `src/ir/verify.ts` copied over the branch's, and failed identically:

| test | before | after |
| --- | --- | --- |
| `tests/ir-scaffold.test.ts` — selector claims `withVar`, expectation does not list it | 1 failed | 1 failed |
| `tests/ir-bytecode-proof.test.ts` — `call` fixture with no `binding`, crashes in `lower.ts:1376` | 1 failed / 22 passed | 1 failed / 22 passed |
| the 11 `tests/equivalence/` files that failed anywhere in the shard run, re-run together | 24 failed / 102 passed | 24 failed / 102 passed |

The 11-file A/B compared failure *names*, not just counts — the two sorted lists are byte-identical.

Two environment constraints, neither a signal: `tests/ir-bytecode-wasmgc-vm.test.ts` hits the 35 s test timeout before and after, and several vitest workers died to a V8 heap-limit OOM (~510 MB), which `CLAUDE.md` already documents for local full-suite runs. OOM'd slices were re-run file-by-file until only one equivalence file (`multi-file-compilation.test.ts`) remained uncoverable on this container.

### Notes

- The 16 arms live in `checkRoadmapRule` rather than inline in `checkInstr`, so both stay inside the per-function LOC budget (#3399). The coverage contract is unchanged: delete an arm and the kind falls through to `checkInstr`'s `default:`, which still sees `"checked"` and reports the desync.
- `src/ir/verify.ts` growth is granted by `loc-budget-allow:` in this PR's own issue file, for the same reason #4523 granted it: the map and the switch are two halves of one contract.
- The issue is left at `status: in-progress` deliberately. 16 of 17 kinds landed as rules and the 17th was closed as already-checked, so the roadmap bucket is empty — but "16 landed + 1 proven unnecessary" is a judgement call for the reviewer, not one to make by flipping the status inside a draft PR.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA
