### PR TITLE
fix(ci): ✓ widen IR-dialect gate R1 to all of src/ (#4552 D1/C1)

### DIFF
--- a/plan/issues/4552-fable-review-js-dialect-split.md
+++ b/plan/issues/4552-fable-review-js-dialect-split.md
@@ -415,3 +415,5 @@ evidence quotes); nothing to unblock, nothing to fold.
    dialect fails the gate instead of passing silently.
 2. **C2 (schema Q1):** open the `instrKind` namespace in
    `docs/ir/ir-module.schema.json` + version bump, under #3030.
+
+**C1 done in PR #4708** (2026-08-21) — R1 now walks all of `src/` with resolution-based matching; `tests/issue-4552-ir-dialect-gate-scope.test.ts` proves the gate fails on the demonstrated `src/codegen/peephole.ts` import (5 of its 8 tests fail against the pre-fix script). C2 remains open.

--- a/scripts/check-ir-dialect.mjs
+++ b/scripts/check-ir-dialect.mjs
@@ -11,11 +11,25 @@
 //
 // Two rules, both narrow on purpose:
 //
-//   R1  The dialect may be imported from exactly ONE place in the core:
+//   R1  The dialect may be imported from exactly ONE place in the REPO:
 //       `src/ir/nodes.ts`, which assembles the `IrInstr` union and re-exports
 //       the dialect's names so existing importers are unaffected. Any other
-//       core file reaching into `dialect/` means the boundary has stopped
-//       meaning anything.
+//       file reaching into `dialect/` means the boundary has stopped meaning
+//       anything.
+//
+//       R1 scans **all of `src/`**, not just `src/ir/` (#4552 finding D1). The
+//       first cut walked `src/ir/` only, which made the rule enforceable inside
+//       the IR tree and merely true-by-luck outside it: adding
+//       `import type { IrInstrAwait } from "../ir/dialect/js.js"` to
+//       `src/codegen/peephole.ts` passed the gate with exit 0. `nodes.ts` is
+//       documented as the only legitimate importer repo-wide, so the walk has
+//       to match that claim — a boundary a consumer can step around is not a
+//       boundary. This also settles #4552 §1's "should the gate assert the
+//       converse?" question: core files legitimately *reference* dialect kinds
+//       (verifiers and lowerers dispatch over the whole union — that is the
+//       union edge working as designed); the enforceable converse is exactly
+//       "no import path to the dialect except `nodes.ts`", which is R1 at full
+//       scope.
 //
 //   R2  Every name the dialect declares must be re-exported by `nodes.ts`.
 //       The split is a declaration move, not an API change: 54 files import
@@ -31,7 +45,12 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
-const IR_DIR = "src/ir";
+// `--src <dir>` repoints every path at a synthetic tree, which is what
+// `tests/issue-4552-ir-dialect-gate-scope.test.ts` uses to prove the gate
+// FAILS on an out-of-IR import without planting one in the real `src/`.
+const srcArg = process.argv.indexOf("--src");
+const SRC_DIR = srcArg === -1 ? "src" : process.argv[srcArg + 1];
+const IR_DIR = path.join(SRC_DIR, "ir");
 const DIALECT_DIR = path.join(IR_DIR, "dialect");
 const UNION_HOST = path.join(IR_DIR, "nodes.ts");
 
@@ -49,13 +68,27 @@ function walk(dir) {
 const failures = [];
 
 // ── R1: only nodes.ts may import the dialect ──────────────────────────────
-const importsDialect = /from\s+"[^"]*\bdialect\/[^"]*"/;
-for (const file of walk(IR_DIR)) {
+// Matching is RESOLUTION-based, not a `dialect/` substring test: a relative
+// specifier is resolved against the importing file's directory and flagged only
+// if it lands inside `src/ir/dialect/`. At repo scope a substring test would
+// also flag any unrelated future `…/dialect/…` path, and the point of widening
+// the walk is to catch real edges to THIS dialect, not to claim the word.
+const importFrom = /from\s+"([^"]*)"/;
+
+/** Does this import specifier, seen in `file`, reach into the JS dialect? */
+function reachesDialect(specifier, file) {
+  if (!specifier.startsWith(".")) return false; // no aliases resolve here today
+  const resolved = path.resolve(path.dirname(file), specifier);
+  return resolved.startsWith(path.resolve(DIALECT_DIR) + path.sep);
+}
+
+for (const file of walk(SRC_DIR)) {
   if (file.startsWith(DIALECT_DIR + path.sep) || file === DIALECT_DIR) continue;
   if (path.normalize(file) === path.normalize(UNION_HOST)) continue;
   const text = readFileSync(file, "utf8");
   for (const [i, line] of text.split("\n").entries()) {
-    if (importsDialect.test(line)) {
+    const m = importFrom.exec(line);
+    if (m && reachesDialect(m[1], file)) {
       failures.push(
         `${file}:${i + 1}: imports the JS dialect. Only ${UNION_HOST} may — it is the ` +
           "single core->dialect edge (the IrInstr union + re-exports). Import from " +
@@ -74,8 +107,11 @@ const dialectFiles = (() => {
   }
 })();
 
-if (dialectFiles.length === 0) {
-  console.log("IR dialect gate: no src/ir/dialect/ yet — nothing to check.");
+// `failures.length === 0` is part of the condition so a "no dialect yet" tree
+// cannot swallow an R1 hit: specifier resolution does not require the target to
+// exist, so an import of a deleted dialect is still a reportable violation.
+if (dialectFiles.length === 0 && failures.length === 0) {
+  console.log(`IR dialect gate: no ${DIALECT_DIR}/ yet — nothing to check.`);
   process.exit(0);
 }
 
@@ -87,7 +123,7 @@ for (const file of dialectFiles) {
   }
 }
 
-const hostText = readFileSync(UNION_HOST, "utf8");
+const hostText = dialectFiles.length > 0 ? readFileSync(UNION_HOST, "utf8") : "";
 const reExported = new Set();
 for (const block of hostText.matchAll(/export type \{([^}]*)\} from "\.\/dialect\/[^"]*"/g)) {
   for (const name of block[1].split(",")) {
@@ -115,5 +151,5 @@ if (failures.length > 0) {
 
 console.log(
   `IR dialect gate: OK — ${declared.size} dialect declaration(s) re-exported by ${UNION_HOST}; ` +
-    "no other core file imports the dialect.",
+    `no other file under ${SRC_DIR}/ imports the dialect.`,
 );

--- a/tests/issue-4552-ir-dialect-gate-scope.test.ts
+++ b/tests/issue-4552-ir-dialect-gate-scope.test.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4552 finding D1 / change C1 — the IR-dialect gate's R1 scope.
+ *
+ * `scripts/check-ir-dialect.mjs` claims `src/ir/nodes.ts` is the only file that
+ * may import `src/ir/dialect/js.ts`. Its first cut walked `src/ir/` only, so the
+ * claim was enforced inside the IR tree and merely true-by-luck outside it: the
+ * Fable-lane review demonstrated live that adding
+ * `import type { IrInstrAwait } from "../ir/dialect/js.js"` to
+ * `src/codegen/peephole.ts` left the gate at exit 0.
+ *
+ * A gate that passes on the violation it exists to catch is worse than no gate,
+ * because it is *reported* as coverage. So the load-bearing case here is the
+ * NEGATIVE one — "out-of-IR import ⇒ exit 1" — and it is written against a
+ * synthetic tree (via the script's `--src`) rather than by planting an import in
+ * the real `src/`, which would be a compile error and could not be left behind.
+ *
+ * The synthetic tree also pins the two scope decisions that are easy to get
+ * wrong and impossible to notice: `src/ir/nodes.ts` is the allow-set repo-wide
+ * (not merely IR-wide), and matching is resolution-based, so an unrelated
+ * directory that happens to be named `dialect/` is NOT gated.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "check-ir-dialect.mjs");
+
+interface RunResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/** Run the gate, capturing exit status instead of throwing on failure. */
+function runGate(args: string[] = []): RunResult {
+  try {
+    const stdout = execFileSync("node", [SCRIPT, ...args], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+/** The one dialect declaration the synthetic trees share. */
+const DIALECT_JS = "export interface IrInstrAwait {\n  readonly kind: 'await';\n}\n";
+
+/** `nodes.ts` in its compliant shape: the single importer, re-exporting the name. */
+const COMPLIANT_NODES =
+  'import type { IrInstrAwait } from "./dialect/js.js";\n' +
+  'export type { IrInstrAwait } from "./dialect/js.js";\n' +
+  "export type IrInstr = IrInstrAwait;\n";
+
+describe("#4552 D1 — check-ir-dialect R1 scans all of src/, not just src/ir/", () => {
+  let dir: string;
+  let src: string;
+
+  /** Write the synthetic `src/` tree, replacing any previous one. */
+  function writeTree(files: Record<string, string>): void {
+    rmSync(src, { recursive: true, force: true });
+    for (const [rel, body] of Object.entries(files)) {
+      const full = join(src, rel);
+      mkdirSync(dirname(full), { recursive: true });
+      writeFileSync(full, body);
+    }
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ir-dialect-gate-scope-"));
+    src = join(dir, "src");
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("passes on a compliant tree — only nodes.ts imports the dialect", () => {
+    writeTree({
+      "ir/dialect/js.ts": DIALECT_JS,
+      "ir/nodes.ts": COMPLIANT_NODES,
+      "ir/verify.ts": 'import type { IrInstr } from "./nodes.js";\nexport type V = IrInstr;\n',
+      "codegen/peephole.ts": 'import type { IrInstr } from "../ir/nodes.js";\nexport type P = IrInstr;\n',
+    });
+
+    const res = runGate(["--src", src]);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("IR dialect gate: OK");
+  });
+
+  // THE regression test for D1. Before the scope widening this exited 0.
+  it("FAILS when a file OUTSIDE src/ir/ imports the dialect (the demonstrated miss)", () => {
+    writeTree({
+      "ir/dialect/js.ts": DIALECT_JS,
+      "ir/nodes.ts": COMPLIANT_NODES,
+      "codegen/peephole.ts":
+        'import type { IrInstrAwait } from "../ir/dialect/js.js";\nexport type P = IrInstrAwait;\n',
+    });
+
+    const res = runGate(["--src", src]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("IR dialect gate: FAILED");
+    expect(res.stderr).toContain("codegen/peephole.ts:1");
+    expect(res.stderr).toContain("imports the JS dialect");
+  });
+
+  it("still FAILS on the in-IR case R1 always covered (widening did not lose it)", () => {
+    writeTree({
+      "ir/dialect/js.ts": DIALECT_JS,
+      "ir/nodes.ts": COMPLIANT_NODES,
+      "ir/verify.ts": 'import type { IrInstrAwait } from "./dialect/js.js";\nexport type V = IrInstrAwait;\n',
+    });
+
+    const res = runGate(["--src", src]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("ir/verify.ts:1");
+  });
+
+  it("reaches arbitrarily deep out-of-IR files, not just src/*/ leaves", () => {
+    writeTree({
+      "ir/dialect/js.ts": DIALECT_JS,
+      "ir/nodes.ts": COMPLIANT_NODES,
+      "codegen-linear/lower/deep/emit.ts":
+        'import type { IrInstrAwait } from "../../../ir/dialect/js.js";\nexport type E = IrInstrAwait;\n',
+    });
+
+    const res = runGate(["--src", src]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("deep/emit.ts:1");
+  });
+
+  it("keeps nodes.ts as the allow-set — it is exempt repo-wide, not IR-wide", () => {
+    // Same import, in the one file permitted to hold it. If the widening had
+    // dropped the exemption, the compliant tree above would fail too.
+    writeTree({ "ir/dialect/js.ts": DIALECT_JS, "ir/nodes.ts": COMPLIANT_NODES });
+
+    const res = runGate(["--src", src]);
+    expect(res.status).toBe(0);
+  });
+
+  it("does NOT gate an unrelated directory named dialect/ — matching is resolution-based", () => {
+    // A substring test on `dialect/` would flag this. Widening the walk to the
+    // whole compiler tree is what makes that distinction start to matter.
+    writeTree({
+      "ir/dialect/js.ts": DIALECT_JS,
+      "ir/nodes.ts": COMPLIANT_NODES,
+      "wit/dialect/vocab.ts": "export const VOCAB = 1;\n",
+      "wit/generator.ts": 'import { VOCAB } from "./dialect/vocab.js";\nexport const G = VOCAB;\n',
+    });
+
+    const res = runGate(["--src", src]);
+    expect(res.status).toBe(0);
+  });
+
+  it("still enforces R2 — a dialect name nodes.ts does not re-export", () => {
+    writeTree({
+      "ir/dialect/js.ts": `${DIALECT_JS}export interface IrInstrYield {\n  readonly kind: 'yield';\n}\n`,
+      "ir/nodes.ts": COMPLIANT_NODES,
+    });
+
+    const res = runGate(["--src", src]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("does not re-export `IrInstrYield`");
+  });
+});
+
+describe("#4552 D1 — the real repo", () => {
+  it("is clean under the WIDENED scope, and says so", () => {
+    // Pre-fix this passed while only src/ir/ was walked; the repo-wide claim was
+    // unverified. Now the OK line is a statement about all of src/.
+    const res = runGate();
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("IR dialect gate: OK");
+    expect(res.stdout).toContain("no other file under src/ imports the dialect");
+  });
+});


### PR DESCRIPTION
## Description

Fixes finding **D1** / accepted change **C1** from the Fable-lane review of [#4552](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4552-fable-review-js-dialect-split), merged in PR #4702.

### The defect, reproduced

`scripts/check-ir-dialect.mjs` documents `src/ir/nodes.ts` as the **only** file repo-wide that may import `src/ir/dialect/js.ts`, but R1's walk was scoped to `src/ir/` (`walk(IR_DIR)`, line 53). Reproduced on current `main` before changing anything — adding the reviewer's exact probe to `src/codegen/peephole.ts`:

```ts
import type { IrInstrAwait } from "../ir/dialect/js.js";
```

```
IR dialect gate: OK — 26 dialect declaration(s) re-exported by src/ir/nodes.ts; no other core file imports the dialect.
exit=0
```

So the boundary was enforced inside the IR tree and merely true-by-luck outside it (a repo-wide grep confirms zero real violations today — the risk was future, not present).

### The fix

- **R1 walks all of `src/`**, with the allow-set the script's own rules imply: `src/ir/nodes.ts` exempt repo-wide, `src/ir/dialect/` itself skipped.
- **Resolution-based matching** replaces the `dialect/` substring regex: a relative specifier is resolved against the importing file's directory and flagged only if it lands inside `src/ir/dialect/`. At repo scope the substring form would flag any unrelated future `…/dialect/…` path — the point of widening is to catch real edges to *this* dialect, not to claim the word.
- The **"no dialect yet" early exit no longer swallows accumulated R1 failures** — specifier resolution does not require the target to exist, so an import of a deleted dialect stays reportable.
- **`--src <dir>`** repoints every path at a synthetic tree, so the negative test can run without planting an import in the real `src/`.

This also settles §1's *"should the gate assert the converse?"* question, as the review's judgement call 3 anticipated: core files legitimately **reference** dialect kinds (verifiers and lowerers dispatch over the whole union — the union edge working as designed), so the enforceable converse is exactly "no import path to the dialect except `nodes.ts`", which is R1 at full scope.

### Test evidence

New `tests/issue-4552-ir-dialect-gate-scope.test.ts` — 8 tests, tmp-tree pattern borrowed from `tests/issue-3113-ir-layering-gate.test.ts`. The load-bearing case is the negative one (out-of-IR import ⇒ exit 1); it also pins the deep-path case, the `nodes.ts` exemption, the unrelated-`dialect/` non-match, and that R2 still fires.

**Non-vacuity checked by mutation**: against the pre-fix script from `origin/main`, **5 of 8 fail**, including the demonstrated D1 case. Against the fixed script, 8/8 pass.

On the reviewer's exact probe the gate now says:

```
IR dialect gate: FAILED

  src/codegen/peephole.ts:2: imports the JS dialect. Only src/ir/nodes.ts may — it is the
  single core->dialect edge (the IrInstr union + re-exports). Import from "nodes.js" instead,
  which re-exports every dialect name.

1 violation(s).
exit=1
```

(The probe was reverted; the committed tree is clean and the gate is green on it.)

### Verification

| Check | Result |
| --- | --- |
| `check:ir-dialect` on clean tree | OK — "no other file under `src/` imports the dialect" |
| `check:ir-dialect` on synthetic violation | exits 1, names `src/codegen/peephole.ts:2` |
| `npm run typecheck` | clean |
| `check:ir-fallbacks` | OK, unaffected |
| `check:ir-layering` | OK — 92 lines / 19 files (baseline 92), unaffected |
| `check:loc-budget` / `check:func-budget` | OK |
| `lint` / `prettier --check` | clean (exit 0) |

Scope is deliberately limited to C1. **C2** (schema Q1 — opening the `instrKind` namespace, under #3030) is untouched and remains open.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_