### PR TITLE
fix(dogfood): support upstream matcher aliases

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -3,7 +3,7 @@ id: 3995
 title: "npm-compat: pin and adapt original upstream test suites for catalog packages"
 status: ready
 created: 2026-07-30
-updated: 2026-08-20
+updated: 2026-08-21
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -598,3 +598,21 @@ The long landing-four-lane CI probe in this work was changed to await its
 child process instead of blocking Vitest's worker heartbeat; the focused core
 probe passes locally. Keep this CI plumbing in PR #4660 and treat the Lit
 compiler gaps in #3977/#3978/#3979/#3980 as the next independent work item.
+
+## 2026-08-21 shared matcher infrastructure checkpoint
+
+The shared upstream assertion shim now implements Vitest's `instanceOf` and
+`toBeInstanceOf` aliases in both positive and negated form, plus the positive
+`toBeCalled` and `toHaveBeenCalled` spy aliases. These are generic runner
+features, covered by `upstream-suite-runner.test.ts`; they are not Hono-specific
+rewrites. Before this change Hono's `utils/body.test.ts` was incorrectly
+classified as harness-incompatible because the native oracle could not call
+`expect(value).not.instanceOf(...)`.
+
+Rerunning the unchanged 16-file Hono selection after the shim fix produced
+**297/297 native callbacks** (previously 296/297 with one harness error), all
+16 modules compiled, 15 validated, and **86/297 Wasm callbacks passed**. The
+remaining 211 Wasm failures and six module-init runtime failures are compiler
+or runtime semantics; they are now scored rather than hidden as unavailable
+infrastructure. The full 120-file inventory and 2,058 deferred registrations
+remain explicit in the report.

--- a/tests/dogfood/hono-upstream-suite.test.ts
+++ b/tests/dogfood/hono-upstream-suite.test.ts
@@ -44,11 +44,11 @@ describe("hono v4.12.16 upstream suite", () => {
     expect(report.extraction.filesSeen).toBe(120);
     expect(report.extraction.filesSelected).toBe(16);
     expect(report.extraction.testsRegistered).toBe(297);
-    expect(report.extraction.nativePassed).toBe(296);
-    expect(report.extraction.nativeFailed).toBe(1);
+    expect(report.extraction.nativePassed).toBe(297);
+    expect(report.extraction.nativeFailed).toBe(0);
     expect(report.extraction.unavailableInfra).toBe(2058);
     expect(report.compile).toMatchObject({ modules: 16, succeeded: 16, validated: 15 });
-    expect(report.results).toMatchObject({ scored: 296, passed: 86, runtimeFailed: 6 });
+    expect(report.results).toMatchObject({ scored: 297, passed: 86, runtimeFailed: 6 });
     expect(report.results.passed + report.results.failed + report.results.runtimeFailed).toBe(report.results.scored);
   });
 });

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -105,12 +105,15 @@ function __upstreamExpect(actual) {
     toHaveProperty(expected) { const n = ++__upstreamAssertion; if (actual == null || !(expected in Object(actual))) __upstreamFail("assertion " + n + " missing property " + String(expected)); },
     toMatchObject(expected) { const n = ++__upstreamAssertion; if (!__upstreamSubset(actual, expected)) __upstreamFail("assertion " + n + " object subset mismatch"); },
     toMatch(expected) { const n = ++__upstreamAssertion; const value = String(actual); if (expected instanceof RegExp ? !expected.test(value) : !value.includes(String(expected))) __upstreamFail("assertion " + n + " pattern mismatch"); },
+    toBeCalled() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length === 0) __upstreamFail("assertion " + n + " expected spy to be called"); },
+    toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length === 0) __upstreamFail("assertion " + n + " expected spy to be called"); },
     toBeCalledWith() { const n = ++__upstreamAssertion; const expected = Array.prototype.slice.call(arguments); const calls = actual && actual.mock && actual.mock.calls; let matched = false; if (calls) for (let i = 0; i < calls.length; i++) if (__upstreamSame(calls[i], expected)) matched = true; if (!matched) __upstreamFail("assertion " + n + " expected matching spy call"); },
     toHaveBeenCalledWith() { const n = ++__upstreamAssertion; const expected = Array.prototype.slice.call(arguments); const calls = actual && actual.mock && actual.mock.calls; let matched = false; if (calls) for (let i = 0; i < calls.length; i++) if (__upstreamSame(calls[i], expected)) matched = true; if (!matched) __upstreamFail("assertion " + n + " expected matching spy call"); },
     toHaveBeenCalledTimes(expected) { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length !== expected) __upstreamFail("assertion " + n + " spy call count mismatch"); },
     toHaveBeenCalledOnce() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length !== 1) __upstreamFail("assertion " + n + " spy call count mismatch"); },
     toBeCalledOnce() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length !== 1) __upstreamFail("assertion " + n + " spy call count mismatch"); },
     toBeInstanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected !== "function" || !(actual instanceof expected)) __upstreamFail("assertion " + n + " instance mismatch"); },
+    instanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected !== "function" || !(actual instanceof expected)) __upstreamFail("assertion " + n + " instance mismatch"); },
     toMatchSnapshot() {
       if (typeof __upstreamSnapshotMatcher !== "function") {
         __upstreamFail("snapshot assertion requires a package-specific snapshot adapter");
@@ -129,6 +132,8 @@ function __upstreamExpect(actual) {
     toBeNull() { const n = ++__upstreamAssertion; if (actual === null) __upstreamFail("assertion " + n + " unexpectedly null"); },
     toBeTruthy() { const n = ++__upstreamAssertion; if (actual) __upstreamFail("assertion " + n + " unexpectedly truthy"); },
     toBeFalsy() { const n = ++__upstreamAssertion; if (!actual) __upstreamFail("assertion " + n + " unexpectedly falsey"); },
+    toBeInstanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected === "function" && actual instanceof expected) __upstreamFail("assertion " + n + " unexpected instance"); },
+    instanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected === "function" && actual instanceof expected) __upstreamFail("assertion " + n + " unexpected instance"); },
     toBeCalled() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
     toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
     toHaveBeenCalledOnce() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (calls && calls.length === 1) __upstreamFail("assertion " + n + " unexpected spy call"); },

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -154,6 +154,46 @@ ${UPSTREAM_TEST_EXPORTS}`;
     }
   }, 90_000);
 
+  it("supports Vitest instanceOf and spy matcher aliases", async () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
+    const generatedPath = join(root, "suite.ts");
+    const source = `${UPSTREAM_TEST_SHIM}
+const ErrorCtor = Error;
+const called = { mock: { calls: [["value"]] } };
+QUnit.test("matcher aliases", function () {
+  expect(new Error("ok")).instanceOf(ErrorCtor);
+  expect(new Error("ok")).toBeInstanceOf(ErrorCtor);
+  expect(called).toBeCalled();
+  expect(called).toHaveBeenCalled();
+  expect(called).toBeCalledWith("value");
+  expect(called).toHaveBeenCalledWith("value");
+  expect("plain").not.instanceOf(ErrorCtor);
+  expect("plain").not.toBeInstanceOf(ErrorCtor);
+});
+${UPSTREAM_TEST_EXPORTS}`;
+
+    try {
+      const previousNodeOptions = process.env.NODE_OPTIONS;
+      process.env.NODE_OPTIONS = [previousNodeOptions, "--import=tsx"].filter(Boolean).join(" ");
+      let result;
+      try {
+        result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 60_000 });
+      } finally {
+        // biome-ignore lint/performance/noDelete: `process.env.X = undefined` sets the string "undefined" instead of unsetting the var
+        if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+        else process.env.NODE_OPTIONS = previousNodeOptions;
+      }
+      expect(result.native.statuses).toEqual([true]);
+      expect(result.native.errors).toEqual([""]);
+      expect(result.compile.success).toBe(true);
+      expect(result.compile.validates).toBe(true);
+      expect(result.wasm?.statuses).toEqual([true]);
+      expect(result.wasm?.errors).toEqual([""]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 90_000);
+
   it("forwards a package-selected Node platform to the isolated compiler worker", async () => {
     const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
     const generatedPath = join(root, "suite.ts");


### PR DESCRIPTION
## Summary

- add the shared Vitest `instanceOf`/`toBeInstanceOf` aliases in positive and negated assertions
- add positive `toBeCalled`/`toHaveBeenCalled` spy aliases
- cover the aliases in the upstream runner regression suite
- record the measured Hono infrastructure checkpoint in [the catalog issue](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md)

This is generic upstream-test infrastructure; no Hono callback or input is rewritten.

## Measurement

The unchanged 16-file Hono selection now runs **297/297 native callbacks** (the previous `utils/body.test.ts` harness-incompatible case is admitted), with 16 modules compiled, 15 validated, and **86/297 Wasm callbacks passing**. The remaining Wasm failures are scored compiler/runtime compatibility findings, not hidden infrastructure failures.

## Verification

- `pnpm exec vitest run tests/dogfood/upstream-suite-runner.test.ts --reporter=dot`
- `pnpm run typecheck`
- `pnpm exec prettier --check tests/dogfood/upstream-suite-runner.mjs tests/dogfood/upstream-suite-runner.test.ts plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md`
- `pnpm exec biome lint tests/dogfood/upstream-suite-runner.test.ts --diagnostic-level=error`
- `node --import tsx tests/dogfood/hono-upstream-suite.mjs --json`
