### PR TITLE
feat(dogfood): run Hono Node-host upstream units

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -616,3 +616,14 @@ remaining 211 Wasm failures and six module-init runtime failures are compiler
 or runtime semantics; they are now scored rather than hidden as unavailable
 infrastructure. The full 120-file inventory and 2,058 deferred registrations
 remain explicit in the report.
+
+The same generic runner now exposes `it.skip`/`test.skip`, `todo`, and skipped
+suite registration semantics. This admits Hono's original Node-facing
+`utils/buffer.test.ts` and `utils/crypto.test.ts` without changing their
+callbacks. The compile worker also forwards the host's standard Web
+constructors when a suite explicitly selects the Node platform. The expanded
+18-file selection registers **311/311 native callbacks**, compiles 18 modules
+(17 validate), and scores **90/311 Wasm passes**; the two intentionally skipped
+upstream callbacks remain outside the denominator. The unresolved TextEncoder
+and crypto behavior is reported as Wasm compatibility failure, not relabeled as
+unavailable infrastructure. Deferred inventory is now 2,044 registrations.

--- a/tests/dogfood/hono-upstream-suite-pin.json
+++ b/tests/dogfood/hono-upstream-suite-pin.json
@@ -19,11 +19,13 @@
     "src/utils/cookie.test.ts",
     "src/utils/encode.test.ts",
     "src/utils/concurrent.test.ts",
+    "src/utils/buffer.test.ts",
+    "src/utils/crypto.test.ts",
     "src/utils/filepath.test.ts",
     "src/utils/html.test.ts",
     "src/utils/ipaddr.test.ts",
     "src/utils/mime.test.ts",
     "src/utils/url.test.ts"
   ],
-  "_note": "The published Hono tarball contains dist but omits its Vitest sources. The complete 120-file src/**/*.test.{ts,tsx} inventory is verified by path hash at the matching immutable tag. The adapter executes sixteen self-contained HTTP, routing, middleware, and utility files against the published dist bytes; files requiring external test packages, platform adapters, DOM, sockets, or network mocks remain explicitly deferred rather than silently absent. registrationSites is a measured count of test()/it() call sites, not a claim about test.each expansion."
+  "_note": "The published Hono tarball contains dist but omits its Vitest sources. The complete 120-file src/**/*.test.{ts,tsx} inventory is verified by path hash at the matching immutable tag. The adapter executes eighteen self-contained HTTP, routing, middleware, utility, and Node-crypto files against the published dist bytes; files requiring external test packages, platform adapters, DOM, sockets, or network mocks remain explicitly deferred rather than silently absent. registrationSites is a measured count of test()/it() call sites, not a claim about test.each expansion."
 }

--- a/tests/dogfood/hono-upstream-suite.mjs
+++ b/tests/dogfood/hono-upstream-suite.mjs
@@ -69,7 +69,15 @@ export async function runHarness({ quiet = false } = {}) {
       generatedPath,
     );
     const source = `${UPSTREAM_TEST_SHIM}\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
-    const result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 240_000 });
+    const result = await compileAndRunUpstreamModule({
+      generatedPath,
+      source,
+      timeoutMs: 240_000,
+      // Hono's buffer/crypto originals intentionally import the Node crypto
+      // builtin. Keep that dependency at the host boundary for those files;
+      // the other selected web-facing units remain on the hermetic web lane.
+      workerEnv: /(?:^|\/)utils\/(?:buffer|crypto)\.test\.ts$/.test(file) ? { DOGFOOD_PLATFORM: "node" } : undefined,
+    });
     runs.push({ file, result });
     log(
       `[dogfood] ${file}: ${result.native.statuses.filter(Boolean).length}/${result.native.count} native; ` +

--- a/tests/dogfood/hono-upstream-suite.test.ts
+++ b/tests/dogfood/hono-upstream-suite.test.ts
@@ -26,6 +26,8 @@ describe("hono v4.12.16 upstream suite", () => {
       "src/utils/cookie.test.ts",
       "src/utils/encode.test.ts",
       "src/utils/concurrent.test.ts",
+      "src/utils/buffer.test.ts",
+      "src/utils/crypto.test.ts",
       "src/utils/filepath.test.ts",
       "src/utils/html.test.ts",
       "src/utils/ipaddr.test.ts",
@@ -42,13 +44,13 @@ describe("hono v4.12.16 upstream suite", () => {
     const report = JSON.parse(out);
     expect(report.upstreamSuite.commit).toBe(pin.commit);
     expect(report.extraction.filesSeen).toBe(120);
-    expect(report.extraction.filesSelected).toBe(16);
-    expect(report.extraction.testsRegistered).toBe(297);
-    expect(report.extraction.nativePassed).toBe(297);
+    expect(report.extraction.filesSelected).toBe(18);
+    expect(report.extraction.testsRegistered).toBe(311);
+    expect(report.extraction.nativePassed).toBe(311);
     expect(report.extraction.nativeFailed).toBe(0);
-    expect(report.extraction.unavailableInfra).toBe(2058);
-    expect(report.compile).toMatchObject({ modules: 16, succeeded: 16, validated: 15 });
-    expect(report.results).toMatchObject({ scored: 297, passed: 86, runtimeFailed: 6 });
+    expect(report.extraction.unavailableInfra).toBe(2044);
+    expect(report.compile).toMatchObject({ modules: 18, succeeded: 18, validated: 17 });
+    expect(report.results).toMatchObject({ scored: 311, passed: 90, runtimeFailed: 6 });
     expect(report.results.passed + report.results.failed + report.results.runtimeFailed).toBe(report.results.scored);
   });
 });

--- a/tests/dogfood/upstream-suite-compile-worker.mjs
+++ b/tests/dogfood/upstream-suite-compile-worker.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 
 import { compile, compileProject } from "../../src/index.ts";
 import { buildCompiledImports, wrapExports } from "../../src/runtime.ts";
+import { getWebHostConstructors } from "../../src/runtime/web-host-constructors.ts";
 
 const generatedPath = process.argv[2];
 const mode = process.argv[3] ?? "project";
@@ -56,6 +57,11 @@ async function loadNodeHostDependencies() {
       // Optional builtins remain subject to the compiler's normal diagnostic.
     }
   }
+  // Node exposes the WHATWG encoding/stream constructors globally, but the
+  // compiled adapter resolves extern classes from the explicit dependency
+  // map. Forward the same host constructors so upstream Node tests can use
+  // TextEncoder/TextDecoder and related Web APIs without a package shim.
+  Object.assign(dependencies, getWebHostConstructors());
   return dependencies;
 }
 

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -255,6 +255,13 @@ function __upstreamRegister(name, body) {
 }
 function it(name, body) { __upstreamRegister(name, body); }
 function test(name, body) { __upstreamRegister(name, body); }
+function __upstreamSkip() {}
+it.skip = __upstreamSkip;
+it.todo = __upstreamSkip;
+test.skip = __upstreamSkip;
+test.todo = __upstreamSkip;
+describe.skip = __upstreamSkip;
+describe.todo = __upstreamSkip;
 function afterEach(body) { __upstreamAfterEach.push(body); }
 function __upstreamTableRows(strings, values) {
   const markers = [];

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -194,6 +194,41 @@ ${UPSTREAM_TEST_EXPORTS}`;
     }
   }, 90_000);
 
+  it("keeps upstream skip and todo registrations out of the runnable denominator", async () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
+    const generatedPath = join(root, "suite.ts");
+    const source = `${UPSTREAM_TEST_SHIM}
+describe.skip("skipped group", () => {
+  test("never registers", () => { throw new Error("must not run"); });
+});
+it.skip("skipped test", () => { throw new Error("must not run"); });
+test.todo("future test");
+QUnit.test("runnable test", function () { expect(1).toBe(1); });
+${UPSTREAM_TEST_EXPORTS}`;
+
+    try {
+      const previousNodeOptions = process.env.NODE_OPTIONS;
+      process.env.NODE_OPTIONS = [previousNodeOptions, "--import=tsx"].filter(Boolean).join(" ");
+      let result;
+      try {
+        result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 60_000 });
+      } finally {
+        // biome-ignore lint/performance/noDelete: `process.env.X = undefined` sets the string "undefined" instead of unsetting the var
+        if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+        else process.env.NODE_OPTIONS = previousNodeOptions;
+      }
+      expect(result.native.count).toBe(1);
+      expect(result.native.names).toEqual(["runnable test"]);
+      expect(result.native.statuses).toEqual([true]);
+      expect(result.compile.success).toBe(true);
+      expect(result.compile.validates).toBe(true);
+      expect(result.wasm?.count).toBe(1);
+      expect(result.wasm?.statuses).toEqual([true]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 90_000);
+
   it("forwards a package-selected Node platform to the isolated compiler worker", async () => {
     const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
     const generatedPath = join(root, "suite.ts");


### PR DESCRIPTION
## Summary

- teach the shared upstream runner to model `it.skip`, `test.skip`, `todo`, and skipped suites without registering them as runnable tests
- run Hono's original `utils/buffer.test.ts` and `utils/crypto.test.ts` on the explicit Node host lane, keeping `crypto` at the host boundary
- forward the host's standard Web constructors to Node-platform compiled upstream modules
- update the pinned Hono selection, heavy regression oracle, and [the catalog handoff](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md)

No upstream callback or input is rewritten.

## Measurement

The expanded 18-file Hono selection registers **311/311 native callbacks**, compiles 18 modules (17 validate), and scores **90/311 Wasm passes**, up from 86/297. Two upstream `it.skip` callbacks remain intentionally outside the denominator. Remaining TextEncoder/crypto mismatches are reported as Wasm compatibility failures, not unavailable infrastructure.

## Verification

- `pnpm exec vitest run tests/dogfood/hono-upstream-suite.test.ts tests/dogfood/upstream-suite-runner.test.ts --reporter=dot`
- `pnpm run typecheck`
- `pnpm exec prettier --check` on all changed files
- targeted Biome lint
- `pnpm run check:issue-ids`
- `node --import tsx tests/dogfood/hono-upstream-suite.mjs --json`
