### PR TITLE
feat(dogfood): run more Hono upstream units

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -627,3 +627,19 @@ constructors when a suite explicitly selects the Node platform. The expanded
 upstream callbacks remain outside the denominator. The unresolved TextEncoder
 and crypto behavior is reported as Wasm compatibility failure, not relabeled as
 unavailable infrastructure. Deferred inventory is now 2,044 registrations.
+
+## 2026-08-21 Vitest global-stub infrastructure checkpoint
+
+The shared upstream shim now implements Vitest's generic `vi.stubGlobal` and
+`vi.unstubAllGlobals` contract. Each stub records whether the global was an
+own property and restores or deletes it in reverse order, so upstream tests can
+temporarily install browser/platform globals without leaking state into later
+callbacks. The runner regression test exercises the complete install/restore
+cycle in both Node and Wasm.
+
+Hono's unchanged `src/helper/testing/index.test.ts` is now admitted. The
+expanded 19-file selection registers **316/316 native callbacks** (up from
+311/311), compiles 19 modules (18 validate), and records **90/316 Wasm passes**.
+The five new callbacks still expose existing Hono route/object compiler
+failures; only the former `vi.stubGlobal is not a function` harness failure was
+removed. Deferred inventory is now 2,039 registrations.

--- a/tests/dogfood/hono-upstream-suite-pin.json
+++ b/tests/dogfood/hono-upstream-suite-pin.json
@@ -11,6 +11,7 @@
     "src/http-exception.test.ts",
     "src/request.test.ts",
     "src/helper/accepts/accepts.test.ts",
+    "src/helper/testing/index.test.ts",
     "src/middleware/powered-by/index.test.ts",
     "src/middleware/trailing-slash/index.test.ts",
     "src/utils/accept.test.ts",

--- a/tests/dogfood/hono-upstream-suite.test.ts
+++ b/tests/dogfood/hono-upstream-suite.test.ts
@@ -18,6 +18,7 @@ describe("hono v4.12.16 upstream suite", () => {
       "src/http-exception.test.ts",
       "src/request.test.ts",
       "src/helper/accepts/accepts.test.ts",
+      "src/helper/testing/index.test.ts",
       "src/middleware/powered-by/index.test.ts",
       "src/middleware/trailing-slash/index.test.ts",
       "src/utils/accept.test.ts",
@@ -44,13 +45,13 @@ describe("hono v4.12.16 upstream suite", () => {
     const report = JSON.parse(out);
     expect(report.upstreamSuite.commit).toBe(pin.commit);
     expect(report.extraction.filesSeen).toBe(120);
-    expect(report.extraction.filesSelected).toBe(18);
-    expect(report.extraction.testsRegistered).toBe(311);
-    expect(report.extraction.nativePassed).toBe(311);
+    expect(report.extraction.filesSelected).toBe(19);
+    expect(report.extraction.testsRegistered).toBe(316);
+    expect(report.extraction.nativePassed).toBe(316);
     expect(report.extraction.nativeFailed).toBe(0);
-    expect(report.extraction.unavailableInfra).toBe(2044);
-    expect(report.compile).toMatchObject({ modules: 18, succeeded: 18, validated: 17 });
-    expect(report.results).toMatchObject({ scored: 311, passed: 90, runtimeFailed: 6 });
+    expect(report.extraction.unavailableInfra).toBe(2039);
+    expect(report.compile).toMatchObject({ modules: 19, succeeded: 19, validated: 18 });
+    expect(report.results).toMatchObject({ scored: 316, passed: 90, runtimeFailed: 6 });
     expect(report.results.passed + report.results.failed + report.results.runtimeFailed).toBe(report.results.scored);
   });
 });

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -163,6 +163,7 @@ function __upstreamExpect(actual) {
   return positive;
 }
 const expect = __upstreamExpect;
+const __upstreamGlobalStubs = [];
 const vi = {
   fn(implementation) {
     function spy() {
@@ -183,6 +184,20 @@ const vi = {
     spy.mockRestore = function() { object[key] = original; };
     object[key] = spy;
     return spy;
+  },
+  stubGlobal(key, value) {
+    const name = String(key);
+    const hadOwn = Object.prototype.hasOwnProperty.call(globalThis, name);
+    __upstreamGlobalStubs.push({ name, hadOwn, previous: globalThis[name] });
+    globalThis[name] = value;
+  },
+  unstubAllGlobals() {
+    for (let index = __upstreamGlobalStubs.length - 1; index >= 0; index--) {
+      const stub = __upstreamGlobalStubs[index];
+      if (stub.hadOwn) globalThis[stub.name] = stub.previous;
+      else delete globalThis[stub.name];
+    }
+    __upstreamGlobalStubs.length = 0;
   },
   stubEnv(key, value) {
     if (globalThis.process && globalThis.process.env) globalThis.process.env[key] = String(value);

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -229,6 +229,41 @@ ${UPSTREAM_TEST_EXPORTS}`;
     }
   }, 90_000);
 
+  it("supports Vitest global stubs and restores globals", async () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
+    const generatedPath = join(root, "suite.ts");
+    const source = `${UPSTREAM_TEST_SHIM}
+QUnit.test("global stub", function () {
+  const key = "__js2_upstream_runner_global_stub";
+  expect(typeof vi.stubGlobal).toBe("function");
+  vi.stubGlobal(key, 42);
+  expect(globalThis[key]).toBe(42);
+  vi.unstubAllGlobals();
+  expect(globalThis[key]).toBeUndefined();
+});
+${UPSTREAM_TEST_EXPORTS}`;
+
+    try {
+      const previousNodeOptions = process.env.NODE_OPTIONS;
+      process.env.NODE_OPTIONS = [previousNodeOptions, "--import=tsx"].filter(Boolean).join(" ");
+      let result;
+      try {
+        result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 60_000 });
+      } finally {
+        // biome-ignore lint/performance/noDelete: `process.env.X = undefined` sets the string "undefined" instead of unsetting the var
+        if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+        else process.env.NODE_OPTIONS = previousNodeOptions;
+      }
+      expect(result.native.statuses).toEqual([true]);
+      expect(result.native.errors).toEqual([""]);
+      expect(result.compile?.success).toBe(true);
+      expect(result.compile?.validates).toBe(true);
+      expect(result.wasm?.statuses).toEqual([true]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 90_000);
+
   it("forwards a package-selected Node platform to the isolated compiler worker", async () => {
     const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
     const generatedPath = join(root, "suite.ts");


### PR DESCRIPTION
## Summary

- add generic Vitest `vi.stubGlobal` and `vi.unstubAllGlobals` support to the shared upstream runner, including reverse-order restoration and deletion of newly-created globals
- run Hono’s original `src/helper/testing/index.test.ts` unit alongside the existing Hono upstream selection
- retain the skip/todo registration and Node-host constructor infrastructure from the queued Hono expansion
- update the measured oracle and the catalog handoff

## Measurement

- Hono selection: 19 files, 316 native registrations and 316 native passes, 2,039 deferred registrations
- Wasm lane: 19 modules, 18 validated; 316 scored, 90 passed, 6 runtime failures
- the former native harness failure (`vi.stubGlobal is not a function`) is gone; remaining Hono failures are compiler/runtime compatibility findings

## Verification

- focused Vitest: 11 passed, 1 skipped
- `pnpm run typecheck`
- targeted Biome lint
- Prettier check
- issue-ID and whitespace checks

This is based on `main` because the related Hono PR is already in the merge queue and cannot be updated.