### PR TITLE
fix(#4604): raise npm-compat refresh timeout 180 → 350 min — immediate-unblock slice

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -112,7 +112,19 @@ jobs:
     # is kept as a second, cheaper line against any OTHER bot push to main.
     if: github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
-    timeout-minutes: 180
+    # (#4604) 180 was outgrown by the upstream-suite roster: on 2026-08-21 four
+    # consecutive runs (700/705/714/721) died un-published — run 721's generate
+    # step was killed at exactly 180:00 with the promotion steps never reached,
+    # and the artifact stayed stale >24h while the acorn/clsx recovery
+    # (#4578/#4586/#4602) was already on main. 350 sits just under the 6h
+    # GitHub-hosted hard cap and nearly doubles the budget; the STRUCTURAL
+    # bound (per-package matrix or per-package time budgets, plus a staleness
+    # alert) is #4604's remaining scope — this raise is its immediate-unblock
+    # slice, not the fix. The sibling rule to #3988's "never cancel-in-progress
+    # a job longer than its trigger interval" applies: never let this job's
+    # runtime outgrow its own timeout, because a timeout kill and a
+    # supersession cancel produce the same stale artifact.
+    timeout-minutes: 350
     environment: baseline-promote
     permissions:
       # The branch push uses MAIN_DEPLOY_KEY (SSH) and the PR is opened with a

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -1,9 +1,10 @@
 ---
 id: 4604
 title: "npm-compat refresh runtime exceeds its 180-min timeout — dashboard stale since 2026-08-20 18:45Z"
-status: ready
+status: in-progress
 created: 2026-08-21
 updated: 2026-08-21
+assignee: loopdive/claude
 priority: critical
 feasibility: medium
 reasoning_effort: medium
@@ -61,9 +62,17 @@ hazard on the OTHER bound: **never let the job's runtime outgrow its own
 `timeout-minutes`** — a timeout kill and a supersession cancel produce the
 same stale artifact.
 
+## Status
+
+- **S1 landed (this PR): `timeout-minutes` 180 → 350.** Run 721's job record
+  settled the diagnosis: its generate step was killed at exactly 180:00
+  (16:09:17 → 19:09:01Z), promotion steps never reached — a pure timeout, the
+  fourth in a row (700/705/714/721). 350 sits just under the 6h GitHub-hosted
+  hard cap. The structural bound and the staleness alert below remain OPEN.
+
 ## Fix directions (pick during implementation)
 
-- **Immediate unblock:** raise `timeout-minutes` (e.g. 300–360) so one run can
+- **Immediate unblock (S1, done):** raise `timeout-minutes` so one run can
   actually land and publish the recovery. Cheap, reversible, buys time.
 - **Structural:** the generation is a serial walk over ever-growing upstream
   suites. Options, roughly in order of leverage:


### PR DESCRIPTION
## Description

The immediate-unblock slice of [#4604](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4604-npm-compat-refresh-runtime-exceeds-timeout): `timeout-minutes` 180 → 350 on the `refresh` job of `npm-compat-refresh.yml`.

Diagnosis is now settled from run 721's job record: its "Regenerate the npm-compat artifacts" step was killed at **exactly 180:00** (16:09:17 → 19:09:01Z) with the sanity-check and promotion steps never reached — a pure `timeout-minutes` kill, the **fourth consecutive un-published marathon** (runs 700/705/714/721). The dashboard has served the pre-fix acorn/clsx collapse for >24h while the actual recovery (#4578/#4586/#4602) has long been on main.

350 sits just under the 6h GitHub-hosted hard cap and roughly doubles the budget. This is deliberately NOT the fix — the workflow comment records the #3988-sibling rule (never let the job's runtime outgrow its own timeout) and #4604 keeps the structural scope open: per-package matrix or per-package time budgets, and a staleness alert on the committed artifact's `generatedAt`.

Also flips #4604 to `in-progress` with an S1-landed status note.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8)_