### PR TITLE
feat(dogfood): restore upstream environment stubs

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -643,3 +643,20 @@ expanded 19-file selection registers **316/316 native callbacks** (up from
 The five new callbacks still expose existing Hono route/object compiler
 failures; only the former `vi.stubGlobal is not a function` harness failure was
 removed. Deferred inventory is now 2,039 registrations.
+
+## 2026-08-21 Vitest environment-stub checkpoint
+
+The shared upstream shim now gives `vi.stubEnv` and `vi.unstubAllEnvs` real
+Vitest-style save/restore behavior. Each environment write records the prior
+own-property state and restores or deletes it in reverse order. A runner
+regression covers the contract without depending on a host-only process
+global.
+
+Hono's original `src/helper/dev/index.test.ts` is now admitted because its
+`NO_COLOR` setup/teardown no longer leaves the process environment mutated.
+The unchanged selection registers **324/324 native callbacks** (up from
+316/316), compiles all 20 modules (18 validate), and leaves the Wasm score at
+**90/324** while the two invalid modules remain compiler findings. Deferred
+inventory is now **2,031** registrations. The native oracle was run with
+`NO_COLOR` unset so the upstream color expectations are not contaminated by
+the local shell environment.

--- a/tests/dogfood/hono-upstream-suite-pin.json
+++ b/tests/dogfood/hono-upstream-suite-pin.json
@@ -12,6 +12,7 @@
     "src/request.test.ts",
     "src/helper/accepts/accepts.test.ts",
     "src/helper/testing/index.test.ts",
+    "src/helper/dev/index.test.ts",
     "src/middleware/powered-by/index.test.ts",
     "src/middleware/trailing-slash/index.test.ts",
     "src/utils/accept.test.ts",
@@ -28,5 +29,5 @@
     "src/utils/mime.test.ts",
     "src/utils/url.test.ts"
   ],
-  "_note": "The published Hono tarball contains dist but omits its Vitest sources. The complete 120-file src/**/*.test.{ts,tsx} inventory is verified by path hash at the matching immutable tag. The adapter executes eighteen self-contained HTTP, routing, middleware, utility, and Node-crypto files against the published dist bytes; files requiring external test packages, platform adapters, DOM, sockets, or network mocks remain explicitly deferred rather than silently absent. registrationSites is a measured count of test()/it() call sites, not a claim about test.each expansion."
+  "_note": "The published Hono tarball contains dist but omits its Vitest sources. The complete 120-file src/**/*.test.{ts,tsx} inventory is verified by path hash at the matching immutable tag. The adapter executes twenty self-contained HTTP, routing, middleware, utility, and Node-crypto files against the published dist bytes; files requiring external test packages, platform adapters, DOM, sockets, or network mocks remain explicitly deferred rather than silently absent. registrationSites is a measured count of test()/it() call sites, not a claim about test.each expansion."
 }

--- a/tests/dogfood/hono-upstream-suite.test.ts
+++ b/tests/dogfood/hono-upstream-suite.test.ts
@@ -19,6 +19,7 @@ describe("hono v4.12.16 upstream suite", () => {
       "src/request.test.ts",
       "src/helper/accepts/accepts.test.ts",
       "src/helper/testing/index.test.ts",
+      "src/helper/dev/index.test.ts",
       "src/middleware/powered-by/index.test.ts",
       "src/middleware/trailing-slash/index.test.ts",
       "src/utils/accept.test.ts",
@@ -45,13 +46,13 @@ describe("hono v4.12.16 upstream suite", () => {
     const report = JSON.parse(out);
     expect(report.upstreamSuite.commit).toBe(pin.commit);
     expect(report.extraction.filesSeen).toBe(120);
-    expect(report.extraction.filesSelected).toBe(19);
-    expect(report.extraction.testsRegistered).toBe(316);
-    expect(report.extraction.nativePassed).toBe(316);
+    expect(report.extraction.filesSelected).toBe(20);
+    expect(report.extraction.testsRegistered).toBe(324);
+    expect(report.extraction.nativePassed).toBe(324);
     expect(report.extraction.nativeFailed).toBe(0);
-    expect(report.extraction.unavailableInfra).toBe(2039);
-    expect(report.compile).toMatchObject({ modules: 19, succeeded: 19, validated: 18 });
-    expect(report.results).toMatchObject({ scored: 316, passed: 90, runtimeFailed: 6 });
+    expect(report.extraction.unavailableInfra).toBe(2031);
+    expect(report.compile).toMatchObject({ modules: 20, succeeded: 20, validated: 18 });
+    expect(report.results).toMatchObject({ scored: 324, passed: 90, runtimeFailed: 6 });
     expect(report.results.passed + report.results.failed + report.results.runtimeFailed).toBe(report.results.scored);
   });
 });

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -164,6 +164,7 @@ function __upstreamExpect(actual) {
 }
 const expect = __upstreamExpect;
 const __upstreamGlobalStubs = [];
+const __upstreamEnvStubs = [];
 const vi = {
   fn(implementation) {
     function spy() {
@@ -200,9 +201,21 @@ const vi = {
     __upstreamGlobalStubs.length = 0;
   },
   stubEnv(key, value) {
-    if (globalThis.process && globalThis.process.env) globalThis.process.env[key] = String(value);
+    if (globalThis.process && globalThis.process.env) {
+      const env = globalThis.process.env;
+      const name = String(key);
+      __upstreamEnvStubs.push({ env, name, hadOwn: Object.prototype.hasOwnProperty.call(env, name), previous: env[name] });
+      env[name] = String(value);
+    }
   },
-  unstubAllEnvs() {},
+  unstubAllEnvs() {
+    for (let index = __upstreamEnvStubs.length - 1; index >= 0; index--) {
+      const stub = __upstreamEnvStubs[index];
+      if (stub.hadOwn) stub.env[stub.name] = stub.previous;
+      else delete stub.env[stub.name];
+    }
+    __upstreamEnvStubs.length = 0;
+  },
 };
 // A number of Jest-owned packages publish their original tests with the Jest
 // global even when the selected unit only needs spies. Keep this small facade

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -264,6 +264,46 @@ ${UPSTREAM_TEST_EXPORTS}`;
     }
   }, 90_000);
 
+  it("restores Vitest environment stubs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
+    const generatedPath = join(root, "suite.ts");
+    const source = `${UPSTREAM_TEST_SHIM}
+QUnit.test("restores environment stubs when a process environment is available", function () {
+  const processValue = globalThis.process;
+  expect(typeof vi.stubEnv).toBe("function");
+  expect(typeof vi.unstubAllEnvs).toBe("function");
+  if (processValue && processValue.env) {
+    const key = "__JS2_UPSTREAM_RUNNER_ENV_STUB";
+    const before = processValue.env[key];
+    vi.stubEnv(key, "stubbed");
+    expect(processValue.env[key]).toBe("stubbed");
+    vi.unstubAllEnvs();
+    expect(processValue.env[key]).toBe(before);
+  }
+});
+${UPSTREAM_TEST_EXPORTS}`;
+
+    try {
+      const previousNodeOptions = process.env.NODE_OPTIONS;
+      process.env.NODE_OPTIONS = [previousNodeOptions, "--import=tsx"].filter(Boolean).join(" ");
+      let result;
+      try {
+        result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 60_000 });
+      } finally {
+        // biome-ignore lint/performance/noDelete: `process.env.X = undefined` sets the string "undefined" instead of unsetting the var
+        if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+        else process.env.NODE_OPTIONS = previousNodeOptions;
+      }
+      expect(result.native.statuses).toEqual([true]);
+      expect(result.native.errors).toEqual([""]);
+      expect(result.compile?.success).toBe(true);
+      expect(result.compile?.validates).toBe(true);
+      expect(result.wasm?.statuses).toEqual([true]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 90_000);
+
   it("forwards a package-selected Node platform to the isolated compiler worker", async () => {
     const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
     const generatedPath = join(root, "suite.ts");


### PR DESCRIPTION
## Summary

- implement Vitest-style `vi.stubEnv`/`vi.unstubAllEnvs` save-and-restore semantics in the shared upstream runner
- admit Hono’s original `src/helper/dev/index.test.ts`, which uses `NO_COLOR` setup/teardown
- add a cross-backend runner regression and update the reproducible catalog handoff

## Measurement

- Hono selection: 20 files, 324/324 native registrations and passes, 2,031 deferred registrations
- Wasm lane: 20 modules compiled, 18 validated; 324 callbacks scored, 90 passed, 6 module-init runtime failures
- eight callbacks moved out of unavailable infrastructure; the two invalid modules remain compiler validation findings
- native oracle was run with `NO_COLOR` unset so the upstream color assertions are not contaminated by the local shell

## Verification

- full Hono upstream Vitest lane: 2 passed
- shared runner Vitest lane: 11 passed
- `pnpm run typecheck`
- targeted Biome lint, Prettier, issue-ID, and whitespace checks

This branch includes the already-open global-stub checkpoint so the follow-up remains coherent if that PR is still running.