### PR TITLE
docs(#4605): file the IR module-level declared-type table issue

### DIFF
--- a/plan/issues/4121-generic-carrier-unboxing.md
+++ b/plan/issues/4121-generic-carrier-unboxing.md
@@ -737,6 +737,61 @@ slice's, the baseline was NOT refreshed here, and it wants its own issue.
 - **AC 6 — achieved.** Full-capture equivalence run + kill-switch A/B; see the
   PR body for the run output.
 
+## Implementation Plan — slice 2: interprocedural definition/use proofs (Fable, 2026-08-21)
+
+Slice 1 (PR #4695) made the admission gate see `parseCookie`'s `index`; both
+existing proofs then declined it. This slice closes the two measured decline
+arms, reusing machinery that already exists rather than adding a fifth pass.
+
+**Verified anchors (2026-08-21):**
+`inferBindingAwareNumericReturnTypes` (`src/codegen/declarations/param-return-inference.ts:1142`)
+already computes a grounded least-fixpoint `Map<string, ValType>` of
+proven-numeric RETURN carriers (the #4121 2026-08-09 "residual return-carrier
+checkpoint", kill switch `JS2WASM_NUMERIC_RETURNS`, wired at
+`src/codegen/index.ts:4651`/`:7886`, consumed at `declarations.ts:588`).
+Route 2 (definition-site, #3765) does NOT consult it: a definition that is a
+direct call (`i = endIndex(str, index, len)`) contributes no numeric
+evidence when the callee's own params are unresolvable — exactly slice 1's
+measured decline.
+
+**Step 1 — route-2 call-definition arm.** In the route-2 definition prover
+(`numeric-property-analysis.ts`), a definition whose value is a direct call
+to a binding present in `ctx.bindingAwareNumericReturnTypes` with an f64 (or
+i32-boolean-branded — but see the boolean trap below) carrier is proven
+numeric. Groundedness is inherited: the return map is itself a grounded
+least fixpoint that declines ungrounded recursion, so this cannot launder a
+cycle. Kill switch: fold under `JS2WASM_NUMERIC_RETURNS` (the fact source)
+plus the slice-1 admission switch; no new env var.
+
+**Step 2 — route-1 argument-use arm.** Route 1 (use-site, #684) bails when
+the local is passed as an ARGUMENT (`endIndex(str, index, len)`,
+`str.slice(index)`). Two sub-cases, in order of safety:
+(a) the callee's corresponding param is itself proven-numeric via the
+callsite-param inference (#2803's `inferBindingAware…` param twin in
+`param-return-inference.ts`) — then an f64 argument is representation-exact,
+no boxing needed; (b) otherwise the use is ToNumber-neutral only if a box is
+emitted at the call frontier — which the "box only at the frontier" rule
+already sanctions. Implement (a); for (b) only count the use as
+non-blocking when the existing frontier-boxing path provably fires (measure
+first; if the plumbing is absent, record it and leave (b) declined).
+
+**Step 3 — prove.** (i) The reduced case
+`var i = s.indexOf(";"); i = i + 1;` (table row 4 — the case slice 1 left
+red) emits an f64 slot with zero box/unbox in the loop; pin as a WAT test
+next to slice 1's. (ii) `parseCookie`'s `index` specifically: report
+claimed→proven with the box-site census delta by carrier (the 13 local-carrier
+sites are the target). (iii) Full-capture equivalence A/B by test id across
+the kill switch — the "What must still decline" list is unchanged and
+load-bearing; booleans stay OUT of the step-1 arm (an i32-branded return
+assigned into a numeric local is exactly the `${b}` → `1` trap — decline
+mixed boolean/number, as the return-map's own prover already does).
+(iv) The pinned cookie runtime-dynamic A/B per the 2026-08-09 methodology,
+switch-off control, checksum equality; report honestly including a null
+result.
+
+**Out of scope:** the IR lattice pass (still blocked on coverage — the
+pre-flight table in slice 1 stands), new carrier kinds, peephole.
+
 ## Relationship to adjacent work
 
 - **#4118 / PR #4062** specializes named hot paths (`indexOf`, `find`, counted

--- a/plan/issues/4605-ir-module-declared-type-table.md
+++ b/plan/issues/4605-ir-module-declared-type-table.md
@@ -1,0 +1,72 @@
+---
+id: 4605
+title: "IR module-level declared-type table: give the verifier a signature/global source of truth for call/global.* rules"
+status: ready
+sprint: current
+created: 2026-08-21
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: hardening
+area: ir
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+parent: 3518
+related: [4603, 4523, 3030, 3520]
+origin: "#4603 finding 1 (PR #4704): call/global.* type rules could only be intra-function coherence checks because no declared-signature record exists in the verifier's scope"
+# id 4605 reserved via claim-issue.mjs --allocate --allow-unscanned on
+# 2026-08-21 (gh CLI offline in this container; pr_scan=degraded). MCP
+# open-PR scan at reservation: open PRs 4703/4707 introduce no issue file
+# with an id near 4605; the assignment book's prior reservation was #4603.
+# Note: "#4605" also appears in old prose as a PULL REQUEST number (ids and
+# PR numbers share one sequence); no plan/issues/4605-*.md exists on main.
+---
+
+# #4605 — module-level declared-type table for the IR verifier
+
+## Problem (from #4603's measured finding)
+
+PR #4704 set out to give `call`, `global.get`, and `global.set` the type
+rules #4523's triage sketched ("vs the target's resolved signature", "must
+match the global's declared IrType") and found the records **do not exist**
+anywhere the verifier can reach: `IrFuncRef`/`IrGlobalRef` carry only a debug
+name plus a structural binding, both resolve lazily at lowering, and
+`IrModule` holds *only* `functions` — no globals table, no signature table.
+`verifyIrFunction` takes a single `IrFunction`, which carries neither.
+
+The landed fallback is intra-function coherence (two references to one
+binding must agree with each other), which catches the defect class but not
+its most common shape: ONE mistaken call site, coherent with itself.
+
+## Why this belongs on the #3518 spine
+
+`ProgramAbiMap` (#3520 R1) is building exactly this vocabulary on the
+codegen side — source-qualified identity with planned signatures, globals,
+imports, and types. The verifier needing a declared-type table and the
+prepared pipeline needing a whole-program ABI are the same fact stated
+twice. The design question this issue owns: does the verifier consume a
+projection of `ProgramAbiMap` (one source of truth, but couples verify to
+preparation), or does `IrModule` grow its own declared tables that
+preparation then cross-checks (verifier stays standalone, one more thing to
+keep in sync)? #3030 (serializable interchange) wants the second shape —
+a self-describing module — and its C2 thread (schema namespace) is the
+natural place the table's serialized form lands.
+
+## Acceptance criteria
+
+- [ ] A decision, recorded here, on the table's home (ProgramAbiMap
+      projection vs IrModule-owned declarations), with the #3030
+      serialization consequence stated.
+- [ ] `IrModule` (or the chosen carrier) exposes declared signatures for
+      functions and declared IrTypes for globals reachable by
+      `verifyIrFunction` (likely via an optional context parameter so
+      existing single-function callers stay valid).
+- [ ] The #4603 coherence rules for `call`/`global.*` upgrade to
+      declared-type rules when the table is present, keeping the
+      conservative skip when it is absent; positive + negative fixtures per
+      the #4070 method, and the mutation proof that removing a rule fails
+      loudly.
+- [ ] No behavior change for valid IR; `check:ir-fallbacks` post-claim
+      buckets and `check:ir-only` (both lanes) unchanged; the full corpus
+      shows zero new demotions attributable to the upgraded rules.

--- a/plan/issues/4605-ir-module-declared-type-table.md
+++ b/plan/issues/4605-ir-module-declared-type-table.md
@@ -20,7 +20,7 @@ origin: "#4603 finding 1 (PR #4704): call/global.* type rules could only be intr
 # open-PR scan at reservation: open PRs 4703/4707 introduce no issue file
 # with an id near 4605; the assignment book's prior reservation was #4603.
 # Note: "#4605" also appears in old prose as a PULL REQUEST number (ids and
-# PR numbers share one sequence); no plan/issues/4605-*.md exists on main.
+# PR numbers share one sequence); no issue FILE with id 4605 exists on main.
 ---
 
 # #4605 — module-level declared-type table for the IR verifier


### PR DESCRIPTION
## Description

Docs-only: files [#4605](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4605-ir-module-declared-type-table) — the structural follow-up to PR #4704's finding 1. The #4603 work measured that `call`/`global.get`/`global.set` verifier rules cannot exceed intra-function coherence because no declared-signature or global-type record exists in the verifier's scope (`IrModule` holds only `functions`; refs resolve lazily at lowering). The issue owns the missing table, the design decision on its home (a `ProgramAbiMap` projection per [#3520](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3520-ir-r1-source-qualified-identity-program-abi) R1 vs `IrModule`-owned declarations per [#3030](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3030-ir-interchange-contract)'s self-describing-module shape), and the subsequent rule upgrade with the #4070 mutation-proof method.

Not appended to the open PR #4707 because that PR ceased to be docs-only (it now carries a workflow timeout fix).

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_