### PR TITLE
feat(npm-compat): expand Jest upstream infrastructure

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -690,3 +690,22 @@ The same build-time environment now supplies React's stable-package selectors
 ReactDOM `HTMLNodeType` constants to the original tests. These are Jest/build
 bindings, not package behavior; defining them prevents avoidable native
 oracle failures while keeping the stable, non-experimental test branch.
+
+## 2026-08-21 Jest utility-suite infrastructure checkpoint
+
+The Jest adapter now admits four additional original release-tag test files:
+`diff-sequences`, `jest-docblock`, `jest-diff`'s control-character utility, and
+`jest-config`'s `stringToBytes` utility. The verified 30.4.2 checkout therefore
+registers **234 callbacks across 12 files** (232/234 pass in the Node oracle),
+and all 12 generated modules compile and validate. The Wasm lane passes
+**113/232 native-compatible callbacks**; the other 119 remain scored failures,
+not unavailable tests. The remaining **3,054 registrations** are explicitly
+reported as unavailable infrastructure from the other 229 verified test files.
+
+The missing `node:os` builtin is now in the generic Node host dependency set.
+`jest-docblock`'s `detect-newline@3.1.0` CommonJS dependency is materialized
+from the installed, lockfile-pinned source as an ESM adapter with a version and
+source-hash check. A narrow namespace-import rewrite binds the static members
+used by the original tests; no callback body or expected result is rewritten.
+The two native snapshot cases remain harness-incompatible and the Wasm
+semantic failures remain visible in the scored report.

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -660,3 +660,33 @@ The unchanged selection registers **324/324 native callbacks** (up from
 inventory is now **2,031** registrations. The native oracle was run with
 `NO_COLOR` unset so the upstream color expectations are not contaminated by
 the local shell environment.
+
+## 2026-08-21 Jest module-isolation infrastructure checkpoint
+
+The React/ReactDOM upstream shim now implements `jest.isolateModules()`. Each
+isolated callback gets a fresh namespace object for every required module, the
+same namespace is reused for repeated requires within that callback, and the
+outer registry is restored when the callback returns. This supplies the
+identity contract used by ReactDOM's original selective-hydration and event-
+propagation tests without mutating Node's process-wide require cache or
+rewriting either test.
+
+The new regression exercises the exact contract in both the native oracle and
+compiled Wasm: two isolated `react-dom/client` requires are distinct, each is
+distinct from the outer namespace, and repeated outer requires remain stable.
+The remaining ReactDOM implementation/compile blockers are unchanged; this
+checkpoint removes a harness gap so those original callbacks can be scored as
+soon as their published graph validates.
+
+The same host surface now supplies React's original `IntersectionMocks` helper:
+observer registration and teardown, simulated intersection entries, and
+`getBoundingClientRect`/`getClientRects` stubs. `IntersectionObserver` is also
+registered in the generic Web-host constructor table so compiled code sees the
+same host class at module instantiation. The host behavior is covered directly
+in Node and the compiled regression verifies the observer registration path.
+
+The same build-time environment now supplies React's stable-package selectors
+(`__VARIANT__` and `__EXPERIMENTAL__`) as `false`, and exposes the published
+ReactDOM `HTMLNodeType` constants to the original tests. These are Jest/build
+bindings, not package behavior; defining them prevents avoidable native
+oracle failures while keeping the stable, non-experimental test branch.

--- a/src/runtime/web-host-constructors.ts
+++ b/src/runtime/web-host-constructors.ts
@@ -1,7 +1,7 @@
 /** Return Web API constructors that are supplied by the active JS host. */
 export function getWebHostConstructors(): Record<string, Function> {
   return Object.fromEntries(
-    "MessageChannel MessagePort ReadableStream WritableStream TransformStream TextEncoder TextDecoder Headers Request Response FormData Blob File AbortController AbortSignal"
+    "MessageChannel MessagePort ReadableStream WritableStream TransformStream TextEncoder TextDecoder Headers Request Response FormData Blob File AbortController AbortSignal IntersectionObserver"
       .split(" ")
       .filter((name) => typeof (globalThis as any)[name] === "function")
       .map((name) => [name, (globalThis as any)[name]]),

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -21,5 +21,11 @@
     "packages/jest-diff/src/__tests__/escapeControlCharacters.test.ts",
     "packages/jest-config/src/__tests__/stringToBytes.test.ts"
   ],
+  "dependencies": {
+    "detect-newline": {
+      "version": "3.1.0",
+      "sourceSha256": "7306f2ecc168c9e20be4a2a3d44a0dad59ea21dc0bf4cd41ea85829bc79e2c18"
+    }
+  },
   "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original synchronous @jest/get-type, jest-util, diff-sequences, jest-docblock, jest-diff, and jest-config unit files against their matching release-tag TypeScript implementations, including isError's node:util/types and jest-docblock's node:os host seams. The shared runner supplies the minimal Jest spy facade needed by the selected jest-util callbacks; runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
 }

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -15,7 +15,11 @@
     "packages/jest-util/src/__tests__/errorWithStack.test.ts",
     "packages/jest-util/src/__tests__/formatTime.test.ts",
     "packages/jest-util/src/__tests__/isPromise.test.ts",
-    "packages/jest-util/src/__tests__/isError.test.ts"
+    "packages/jest-util/src/__tests__/isError.test.ts",
+    "packages/diff-sequences/src/__tests__/index.test.ts",
+    "packages/jest-docblock/src/__tests__/index.test.ts",
+    "packages/jest-diff/src/__tests__/escapeControlCharacters.test.ts",
+    "packages/jest-config/src/__tests__/stringToBytes.test.ts"
   ],
-  "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original synchronous @jest/get-type and jest-util unit files against their matching release-tag TypeScript implementations, including isError's node:util/types host seam. The shared runner supplies the minimal Jest spy facade needed by the selected jest-util callbacks; runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
+  "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original synchronous @jest/get-type, jest-util, diff-sequences, jest-docblock, jest-diff, and jest-config unit files against their matching release-tag TypeScript implementations, including isError's node:util/types and jest-docblock's node:os host seams. The shared runner supplies the minimal Jest spy facade needed by the selected jest-util callbacks; runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
 }

--- a/tests/dogfood/jest-upstream-suite.mjs
+++ b/tests/dogfood/jest-upstream-suite.mjs
@@ -52,12 +52,32 @@ function resolveJestImport(filePath, specifier) {
 
 function transformJestTest(source, filePath, generatedPath, { normalizeCjs = false } = {}) {
   let importIndex = 0;
-  return source.replace(
+  const namespaceReplacements = [];
+  let transformed = source.replace(
     /import\s+((?:[A-Za-z_$][\w$]*\s*,\s*)?(?:\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\}|[A-Za-z_$][\w$]*))\s+from\s+(["'])(\.\.?\/?[^"']*)\2;?/g,
     (_match, bindings, quote, specifier) => {
       const target = resolveJestImport(filePath, specifier);
       const rewritten = moduleSpecifier(dirname(generatedPath), target);
       const namespaceName = `__jestImport${importIndex++}`;
+      // The compiler's internal-module namespace value is demand-driven,
+      // while Jest's source tests use `import * as x` as a plain object.
+      // Rebind only the members the original test reads through named
+      // imports; this preserves the upstream body without requiring a whole
+      // module namespace carrier at runtime.
+      if (bindings.startsWith("* as ")) {
+        const name = bindings.slice("* as ".length).trim();
+        const members = [...source.matchAll(new RegExp(`\\b${name}\\.([A-Za-z_$][\\w$]*)`, "g"))]
+          .map((match) => match[1])
+          .filter((member, index, values) => values.indexOf(member) === index);
+        if (members.length > 0) {
+          const imported = members.map((member) => `${member} as ${namespaceName}_${member}`).join(", ");
+          namespaceReplacements.push({
+            pattern: new RegExp(`\\b${name}\\.(${members.join("|")})\\b`, "g"),
+            replacement: (_full, member) => `${namespaceName}_${member}`,
+          });
+          return `import { ${imported} } from ${quote}${rewritten}${quote};`;
+        }
+      }
       if (!normalizeCjs) return `import ${bindings} from ${quote}${rewritten}${quote};`;
       const normalized = `${namespaceName}.default?.default ?? ${namespaceName}.default ?? ${namespaceName}`;
       if (bindings.startsWith("{")) {
@@ -85,6 +105,8 @@ function transformJestTest(source, filePath, generatedPath, { normalizeCjs = fal
       );
     },
   );
+  for (const { pattern, replacement } of namespaceReplacements) transformed = transformed.replace(pattern, replacement);
+  return transformed;
 }
 
 export async function runHarness({ quiet = false } = {}) {

--- a/tests/dogfood/jest-upstream-suite.test.ts
+++ b/tests/dogfood/jest-upstream-suite.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — the dogfood adapter is an executable .mjs module.
+import { adaptDetectNewline } from "./setup-jest-upstream-suite.mjs";
+
+describe("Jest upstream dependency adapters", () => {
+  it("converts the pinned CommonJS detect-newline shape to ESM", () => {
+    const source = `
+      'use strict';
+      const detectNewline = value => value;
+      module.exports = detectNewline;
+      module.exports.graceful = value => detectNewline(value) || '\\n';
+    `;
+    const adapted = adaptDetectNewline(source);
+    expect(adapted).toContain("export default detectNewline;");
+    expect(adapted).toContain("export const graceful");
+    expect(adapted).not.toContain("module.exports");
+    expect(adapted).not.toContain("use strict");
+  });
+
+  it("rejects a dependency whose CommonJS export shape changes", () => {
+    expect(() => adaptDetectNewline("module.exports = changed;\n")).toThrow("source shape changed");
+  });
+});

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -276,15 +276,15 @@ describe("small npm package upstream suites", () => {
     const report = await run("jest");
     expect(report.extraction).toMatchObject({
       filesSeen: 241,
-      filesSelected: 8,
-      filesDeferred: 233,
-      testsRegistered: 99,
-      nativePassed: 99,
-      nativeFailed: 0,
+      filesSelected: 12,
+      filesDeferred: 229,
+      testsRegistered: 234,
+      nativePassed: 232,
+      nativeFailed: 2,
     });
-    expect(report.extraction.unavailableInfra).toBe(3189);
-    expect(report.compile).toMatchObject({ modules: 8, succeeded: 8, validated: 8 });
-    expect(report.results).toMatchObject({ scored: 99, passed: 29, failed: 70, runtimeFailed: 0 });
+    expect(report.extraction.unavailableInfra).toBe(3054);
+    expect(report.compile).toMatchObject({ modules: 12, succeeded: 12, validated: 12 });
+    expect(report.results).toMatchObject({ scored: 232, passed: 113, failed: 119, runtimeFailed: 0 });
   });
 
   const tailwindcssHeavy = process.env.DOGFOOD_TAILWINDCSS_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/react-upstream-infrastructure.mjs
+++ b/tests/dogfood/react-upstream-infrastructure.mjs
@@ -400,6 +400,101 @@ function createInternalTestUtils({ reactTestRenderer, reactDom, consumeConsole }
   };
 }
 
+// ReactDOM's selector and fragment-ref tests import this small private helper
+// from the monorepo. It is test infrastructure rather than published package
+// code, so keep the browser behavior on the host while exposing the same
+// functions through the explicit React upstream capability surface.
+function createIntersectionMocks() {
+  const state = { callback: null, observedTargets: [] };
+  const hostWindow = globalThis.window;
+  const previousWindowObserver = hostWindow?.IntersectionObserver;
+  const previousGlobalObserver = globalThis.IntersectionObserver;
+  class IntersectionObserver {
+    constructor(callback) {
+      state.callback = callback;
+    }
+
+    disconnect() {
+      state.callback = null;
+      state.observedTargets.splice(0);
+    }
+
+    observe(target) {
+      state.observedTargets.push(target);
+    }
+
+    unobserve(target) {
+      const index = state.observedTargets.indexOf(target);
+      if (index >= 0) state.observedTargets.splice(index, 1);
+    }
+  }
+  if (hostWindow) hostWindow.IntersectionObserver = IntersectionObserver;
+  globalThis.IntersectionObserver = IntersectionObserver;
+
+  function mockIntersectionObserver() {
+    state.callback = null;
+    state.observedTargets = [];
+    if (hostWindow) hostWindow.IntersectionObserver = IntersectionObserver;
+    return state;
+  }
+
+  function simulateIntersection(...entries) {
+    if (typeof state.callback !== "function") throw new Error("IntersectionObserver callback is not installed");
+    state.callback(
+      entries.map(([target, rect, ratio]) => ({
+        boundingClientRect: {
+          top: rect.y,
+          left: rect.x,
+          width: rect.width,
+          height: rect.height,
+        },
+        intersectionRatio: ratio,
+        target,
+      })),
+    );
+  }
+
+  function setBoundingClientRect(target, { x, y, width, height }) {
+    target.getBoundingClientRect = () => ({
+      width,
+      height,
+      left: x,
+      right: x + width,
+      top: y,
+      bottom: y + height,
+    });
+  }
+
+  function setClientRects(target, rects) {
+    target.getClientRects = () =>
+      rects.map(({ x, y, width, height }) => ({
+        width,
+        height,
+        left: x,
+        right: x + width,
+        top: y,
+        bottom: y + height,
+        x,
+        y,
+      }));
+  }
+
+  return {
+    mockIntersectionObserver,
+    simulateIntersection,
+    setBoundingClientRect,
+    setClientRects,
+    cleanup() {
+      if (hostWindow) {
+        if (previousWindowObserver === undefined) delete hostWindow.IntersectionObserver;
+        else hostWindow.IntersectionObserver = previousWindowObserver;
+      }
+      if (previousGlobalObserver === undefined) delete globalThis.IntersectionObserver;
+      else globalThis.IntersectionObserver = previousGlobalObserver;
+    },
+  };
+}
+
 function unrefMessagePorts() {
   // ReactDOM's scheduler owns a MessageChannel. Its ports are useful while a
   // test is running, but a referenced port keeps Node alive after the report
@@ -450,6 +545,7 @@ export function installReactUpstreamInfrastructure({ react, build = "production"
     return out;
   };
   const reactNoop = createReactNoopAdapter(nativeReact, reactTestRenderer, reactDom, reactDomClient);
+  const intersectionMocks = createIntersectionMocks();
   const prepareReactValue = createReactValueAdapter(nativeReact);
   const reactJsxRuntime = readModule("react/jsx-runtime");
   const reactJsxDevRuntime = readModule("react/jsx-dev-runtime");
@@ -471,6 +567,7 @@ export function installReactUpstreamInfrastructure({ react, build = "production"
     reactDomServer,
     reactTestRenderer,
     reactNoop,
+    intersectionMocks,
     prepareReactValue,
     // Native oracle values already have React's host representation. The
     // compiled lane flips this switch only while an exported Wasm test is
@@ -518,6 +615,7 @@ export function installReactUpstreamInfrastructure({ react, build = "production"
     if (cleaned) return;
     cleaned = true;
     unrefMessagePorts();
+    intersectionMocks.cleanup();
     console.error = previousError;
     console.warn = previousWarn;
     if (previous === undefined) delete globalThis.__js2ReactUpstreamInfrastructure;

--- a/tests/dogfood/react-upstream-infrastructure.test.ts
+++ b/tests/dogfood/react-upstream-infrastructure.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { compile } from "../../src/index";
+import { wrapExports } from "../../src/runtime";
 
-// @ts-expect-error — .mjs dogfood infrastructure has no declaration file
-import { installReactUpstreamInfrastructure } from "./react-upstream-infrastructure.mjs";
 // @ts-expect-error — .mjs dogfood environment has no declaration file
 import { installReactTestEnvironment } from "./react-test-environment.mjs";
+// @ts-expect-error — .mjs dogfood infrastructure has no declaration file
+import { installReactUpstreamInfrastructure } from "./react-upstream-infrastructure.mjs";
 // @ts-expect-error — .mjs dogfood shim has no declaration file
 import { REACT_EXPECT_SHIM } from "./react-upstream-shim.mjs";
 
@@ -78,6 +80,21 @@ describe("React upstream test infrastructure", () => {
       expect(source.firstChild).toBeNull();
       expect(fizzUtils.getVisibleChildren(target).props.children).toBe("ok");
       expect(fizzUtils.stripExternalRuntimeInNodes([target.firstChild], "missing.js")).toHaveLength(1);
+
+      const intersection = infrastructure.intersectionMocks;
+      const observerState = intersection.mockIntersectionObserver();
+      let intersectionCount = 0;
+      const observer = new globalThis.IntersectionObserver((entries: unknown[]) => {
+        intersectionCount = entries.length;
+      });
+      const observed = document.createElement("div");
+      observer.observe(observed);
+      intersection.simulateIntersection([observed, { x: 1, y: 2, width: 3, height: 4 }, 1]);
+      expect(observerState.observedTargets).toHaveLength(1);
+      expect(intersectionCount).toBe(1);
+      const rectTarget = document.createElement("div");
+      intersection.setClientRects(rectTarget, [{ x: 2, y: 3, width: 4, height: 5 }]);
+      expect(rectTarget.getClientRects()[0].left).toBe(2);
     } finally {
       installed.cleanup();
       dom.cleanup();
@@ -101,4 +118,53 @@ describe("React upstream test infrastructure", () => {
       else process.env.NODE_ENV = previousNodeEnv;
     }
   });
+
+  it("provides scoped Jest module isolation to Node and compiled Wasm", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    const dom = installReactTestEnvironment();
+    const installed = installReactUpstreamInfrastructure();
+    const body = `
+function checkIsolatedModules() {
+  var first;
+  var second;
+  var stable;
+  var mocks = require("./utils/IntersectionMocks");
+  var nodeTypes = require("react-dom-bindings/src/client/HTMLNodeType");
+  var target = document.createElement("div");
+  var observerState = mocks.mockIntersectionObserver();
+  var observer = new window.IntersectionObserver(function () {});
+  observer.observe(target);
+  jest.isolateModules(function () { first = require("react-dom/client"); });
+  jest.isolateModules(function () { second = require("react-dom/client"); });
+  stable = require("react-dom/client");
+  return first !== second && first !== stable && second !== stable && stable === require("react-dom/client") &&
+    observerState.observedTargets.length === 1 && nodeTypes.COMMENT_NODE === 8 &&
+    __VARIANT__ === false && __EXPERIMENTAL__ === false ? 1 : 0;
+}`;
+    try {
+      // The native oracle uses the same shim source as the compiled test.
+      // eslint-disable-next-line no-new-func
+      const native = new Function(`${REACT_EXPECT_SHIM}\n${body}\nreturn checkIsolatedModules;`)();
+      expect(native()).toBe(1);
+
+      const result = await compile(`${REACT_EXPECT_SHIM}\n${body}\nexport { checkIsolatedModules };`, {
+        fileName: "react-upstream-isolation.js",
+        skipSemanticDiagnostics: true,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success || !result.binary) return;
+      const imports = result.importObject ?? {};
+      const { instance } = await WebAssembly.instantiate(result.binary, imports);
+      imports.__setExports?.(instance.exports);
+      imports.__setInstance?.(instance);
+      const compiled = wrapExports(instance.exports, { signatures: result.exportSignatures });
+      expect(compiled.checkIsolatedModules()).toBe(1);
+    } finally {
+      installed.cleanup();
+      dom.cleanup();
+      if (previousNodeEnv === undefined) Reflect.deleteProperty(process.env, "NODE_ENV");
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+  }, 90_000);
 });

--- a/tests/dogfood/react-upstream-shim.mjs
+++ b/tests/dogfood/react-upstream-shim.mjs
@@ -16,6 +16,12 @@ export const REACT_EXPECT_SHIM = `
 // and compiled lane must execute the original assertions with the production
 // value instead of relying on an ambient host global.
 var __DEV__ = false;
+// React's Jest transform injects these build selectors as lexical constants.
+// The published stable package is neither an www variant nor an experimental
+// build, so expose the same values instead of letting original tests fail at
+// the build constants are not defined.
+var __VARIANT__ = false;
+var __EXPERIMENTAL__ = false;
 // React's upstream tests use Node's global spelling for host polyfills. Keep
 // that compatibility binding in the native and Wasm lanes alike.
 var global = globalThis;
@@ -352,6 +358,8 @@ function __recordError(error) {
 
 var __jestSpies = [];
 var __jestMocks = {};
+var __jestIsolationDepth = 0;
+var __jestIsolationModules = null;
 // Some React files gate additional registrations with if (gate(...)) at
 // describe scope. The extractor carries that scope into each lifted test, so
 // the registration calls must remain harmless rather than becoming an
@@ -399,14 +407,55 @@ function __jestSpyOn(target, key) {
   __jestSpies.push(mock);
   return mock;
 }
+function __js2CloneModuleNamespace(value) {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== "object" && typeof value !== "function") return value;
+  var clone;
+  if (typeof value === "function") {
+    clone = function () { return value.apply(this, arguments); };
+  } else if (Array.isArray(value)) {
+    clone = value.slice();
+  } else {
+    clone = {};
+  }
+  var keys = Object.keys(value);
+  for (var i = 0; i < keys.length; i++) clone[keys[i]] = value[keys[i]];
+  return clone;
+}
+function __js2IsolatedModule(name, value) {
+  if (__jestIsolationDepth === 0) return value;
+  if (__jestIsolationModules === null) __jestIsolationModules = {};
+  if (Object.prototype.hasOwnProperty.call(__jestIsolationModules, name)) return __jestIsolationModules[name];
+  var isolated = __js2CloneModuleNamespace(value);
+  __jestIsolationModules[name] = isolated;
+  return isolated;
+}
+function __jestIsolateModules(callback) {
+  var previousDepth = __jestIsolationDepth;
+  var previousModules = __jestIsolationModules;
+  __jestIsolationDepth = previousDepth + 1;
+  __jestIsolationModules = {};
+  try {
+    return typeof callback === "function" ? callback() : undefined;
+  } finally {
+    __jestIsolationDepth = previousDepth;
+    __jestIsolationModules = previousModules;
+  }
+}
 var jest = {
   fn: __jestFn,
   spyOn: __jestSpyOn,
   resetModules: function () { __jestMocks = {}; },
+  // Jest gives each isolateModules callback a fresh module registry. The
+  // package graphs themselves stay host-owned here, so the faithful boundary
+  // is a fresh namespace object per required module, scoped to the callback.
+  // This preserves the identity contract tested by ReactDOM without mutating
+  // Node's process-wide require cache or leaking state into later callbacks.
+  isolateModules: __jestIsolateModules,
   mock: function (name, factory) {
     __jestMocks[name] = typeof factory === "function" ? factory : function () { return factory; };
   },
-  requireActual: function (name) { return __js2RequireActual(name); },
+  requireActual: function (name) { return __js2IsolatedModule(name, __js2RequireActual(name)); },
   restoreAllMocks: function () {
     for (var i = 0; i < __jestSpies.length; i++) __jestSpies[i].mockRestore();
     __jestSpies.length = 0;
@@ -793,6 +842,33 @@ var __js2InternalTestUtils = {
   assertLog: function () {},
 };
 
+var __js2IntersectionMocks = {
+  mockIntersectionObserver: function () {
+    return __js2ReactInfra().intersectionMocks.mockIntersectionObserver();
+  },
+  simulateIntersection: function () {
+    return __js2ReactInfra().intersectionMocks.simulateIntersection.apply(
+      __js2ReactInfra().intersectionMocks,
+      arguments,
+    );
+  },
+  setBoundingClientRect: function (target, rect) {
+    return __js2ReactInfra().intersectionMocks.setBoundingClientRect(target, rect);
+  },
+  setClientRects: function (target, rects) {
+    return __js2ReactInfra().intersectionMocks.setClientRects(target, rects);
+  },
+};
+
+var __js2HTMLNodeType = {
+  ELEMENT_NODE: 1,
+  TEXT_NODE: 3,
+  COMMENT_NODE: 8,
+  DOCUMENT_NODE: 9,
+  DOCUMENT_TYPE_NODE: 10,
+  DOCUMENT_FRAGMENT_NODE: 11,
+};
+
 function __js2AssertConsole(kind, expected) {
   var actual = __js2ReactInfra().consumeConsole(kind);
   var wanted = Array.isArray(expected) ? expected : [expected];
@@ -911,6 +987,8 @@ function __js2RequireActual(name) {
   if (name === "react/jsx-runtime") return __js2ReactInfra().reactJsxRuntime;
   if (name === "react/jsx-dev-runtime") return __js2ReactInfra().reactJsxDevRuntime;
   if (name === "internal-test-utils") return __js2InternalTestUtils;
+  if (name === "./utils/IntersectionMocks") return __js2IntersectionMocks;
+  if (name === "react-dom-bindings/src/client/HTMLNodeType") return __js2HTMLNodeType;
   if (name === "prop-types") return __js2PropTypes;
   if (name === "create-react-class") return __js2CreateReactClass;
   if (name === "create-react-class/factory") {
@@ -936,8 +1014,8 @@ function __js2RequireActual(name) {
 }
 
 function require(name) {
-  if (__jestMocks[name]) return __jestMocks[name]();
-  return __js2RequireActual(name);
+  if (__jestMocks[name]) return __js2IsolatedModule(name, __jestMocks[name]());
+  return __js2IsolatedModule(name, __js2RequireActual(name));
 }
 `;
 

--- a/tests/dogfood/setup-jest-upstream-suite.mjs
+++ b/tests/dogfood/setup-jest-upstream-suite.mjs
@@ -1,12 +1,63 @@
-import { dirname } from "node:path";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { setupPinnedUpstreamSuite } from "./setup-pinned-upstream-suite.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+const DETECT_NEWLINE_VERSION = "3.1.0";
+
+function resolveDetectNewlineSource() {
+  const workspaceNodeModules = resolve(HERE, "../../node_modules");
+  const direct = join(workspaceNodeModules, `detect-newline/index.js`);
+  const candidates = [direct];
+  const pnpmRoot = join(workspaceNodeModules, ".pnpm");
+  try {
+    for (const entry of readdirSync(pnpmRoot)) {
+      if (entry.startsWith(`detect-newline@${DETECT_NEWLINE_VERSION}`)) {
+        candidates.push(join(pnpmRoot, entry, "node_modules/detect-newline/index.js"));
+      }
+    }
+  } catch {
+    // The normal pnpm install has the hidden store; a direct hoisted install
+    // is also supported by the first candidate.
+  }
+  const sourcePath = candidates.find((candidate) => existsSync(candidate));
+  if (!sourcePath) {
+    throw new Error(
+      `[dogfood] Jest requires detect-newline@${DETECT_NEWLINE_VERSION}; ` +
+        "run pnpm install before running the upstream suite",
+    );
+  }
+  const source = readFileSync(sourcePath, "utf8");
+  const packagePath = join(dirname(sourcePath), "package.json");
+  const packageVersion = JSON.parse(readFileSync(packagePath, "utf8")).version;
+  if (packageVersion !== DETECT_NEWLINE_VERSION) {
+    throw new Error(
+      `[dogfood] detect-newline version mismatch: expected ${DETECT_NEWLINE_VERSION}, got ${packageVersion}`,
+    );
+  }
+  return {
+    source,
+    sha256: createHash("sha256").update(source).digest("hex"),
+  };
+}
+
+export function adaptDetectNewline(source) {
+  const adapted = source
+    .replace(/^\s*["']use strict["'];?\s*/m, "")
+    .replace(/module\.exports\s*=\s*detectNewline\s*;/, "export default detectNewline;")
+    .replace(/module\.exports\.graceful\s*=\s*/, "export const graceful = ");
+  if (!adapted.includes("export default detectNewline;") || !adapted.includes("export const graceful")) {
+    throw new Error("[dogfood] detect-newline source shape changed; refusing an unverified adapter");
+  }
+  return adapted;
+}
+
 export function setupJestUpstreamSuite(options = {}) {
-  return setupPinnedUpstreamSuite({
+  const suite = setupPinnedUpstreamSuite({
     here: HERE,
     pinFile: "jest-upstream-suite-pin.json",
     cacheDirectory: ".npm-upstream-suites/jest",
@@ -14,4 +65,30 @@ export function setupJestUpstreamSuite(options = {}) {
     accept: (path) => /^packages\/.*\/__tests__\/.*\.(?:test|spec)\.(?:js|jsx|ts|tsx)$/.test(path),
     force: options.force,
   });
+  // jest-docblock's published source depends on the tiny CommonJS
+  // `detect-newline` package. The compiler deliberately does not guess a
+  // CommonJS default export, so materialize the pinned installed source as an
+  // explicit ESM adapter inside the verified checkout. This keeps the
+  // upstream test and implementation unchanged while making the real
+  // dependency available to both Node's oracle and the Wasm project resolver.
+  const dependency = resolveDetectNewlineSource();
+  const dependencyRoot = join(suite.root, "node_modules", "detect-newline");
+  mkdirSync(dependencyRoot, { recursive: true });
+  writeFileSync(
+    join(dependencyRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "detect-newline",
+        version: DETECT_NEWLINE_VERSION,
+        type: "module",
+        main: "./index.ts",
+        exports: "./index.ts",
+        _sourceSha256: dependency.sha256,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  writeFileSync(join(dependencyRoot, "index.ts"), adaptDetectNewline(dependency.source));
+  return suite;
 }

--- a/tests/dogfood/setup-jest-upstream-suite.mjs
+++ b/tests/dogfood/setup-jest-upstream-suite.mjs
@@ -7,16 +7,19 @@ import { setupPinnedUpstreamSuite } from "./setup-pinned-upstream-suite.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-const DETECT_NEWLINE_VERSION = "3.1.0";
+const DETECT_NEWLINE_PIN = {
+  version: "3.1.0",
+  sourceSha256: "7306f2ecc168c9e20be4a2a3d44a0dad59ea21dc0bf4cd41ea85829bc79e2c18",
+};
 
-function resolveDetectNewlineSource() {
+function resolveDetectNewlineSource(pin = DETECT_NEWLINE_PIN) {
   const workspaceNodeModules = resolve(HERE, "../../node_modules");
-  const direct = join(workspaceNodeModules, `detect-newline/index.js`);
+  const direct = join(workspaceNodeModules, "detect-newline/index.js");
   const candidates = [direct];
   const pnpmRoot = join(workspaceNodeModules, ".pnpm");
   try {
     for (const entry of readdirSync(pnpmRoot)) {
-      if (entry.startsWith(`detect-newline@${DETECT_NEWLINE_VERSION}`)) {
+      if (entry.startsWith(`detect-newline@${pin.version}`)) {
         candidates.push(join(pnpmRoot, entry, "node_modules/detect-newline/index.js"));
       }
     }
@@ -27,22 +30,20 @@ function resolveDetectNewlineSource() {
   const sourcePath = candidates.find((candidate) => existsSync(candidate));
   if (!sourcePath) {
     throw new Error(
-      `[dogfood] Jest requires detect-newline@${DETECT_NEWLINE_VERSION}; ` +
-        "run pnpm install before running the upstream suite",
+      `[dogfood] Jest requires detect-newline@${pin.version}; ` + "run pnpm install before running the upstream suite",
     );
   }
   const source = readFileSync(sourcePath, "utf8");
   const packagePath = join(dirname(sourcePath), "package.json");
   const packageVersion = JSON.parse(readFileSync(packagePath, "utf8")).version;
-  if (packageVersion !== DETECT_NEWLINE_VERSION) {
-    throw new Error(
-      `[dogfood] detect-newline version mismatch: expected ${DETECT_NEWLINE_VERSION}, got ${packageVersion}`,
-    );
+  if (packageVersion !== pin.version) {
+    throw new Error(`[dogfood] detect-newline version mismatch: expected ${pin.version}, got ${packageVersion}`);
   }
-  return {
-    source,
-    sha256: createHash("sha256").update(source).digest("hex"),
-  };
+  const sha256 = createHash("sha256").update(source).digest("hex");
+  if (sha256 !== pin.sourceSha256) {
+    throw new Error(`[dogfood] detect-newline source hash mismatch: expected ${pin.sourceSha256}, got ${sha256}`);
+  }
+  return { source, sha256 };
 }
 
 export function adaptDetectNewline(source) {
@@ -71,7 +72,8 @@ export function setupJestUpstreamSuite(options = {}) {
   // explicit ESM adapter inside the verified checkout. This keeps the
   // upstream test and implementation unchanged while making the real
   // dependency available to both Node's oracle and the Wasm project resolver.
-  const dependency = resolveDetectNewlineSource();
+  const dependencyPin = suite.pin.dependencies?.["detect-newline"] ?? DETECT_NEWLINE_PIN;
+  const dependency = resolveDetectNewlineSource(dependencyPin);
   const dependencyRoot = join(suite.root, "node_modules", "detect-newline");
   mkdirSync(dependencyRoot, { recursive: true });
   writeFileSync(
@@ -79,7 +81,7 @@ export function setupJestUpstreamSuite(options = {}) {
     JSON.stringify(
       {
         name: "detect-newline",
-        version: DETECT_NEWLINE_VERSION,
+        version: dependencyPin.version,
         type: "module",
         main: "./index.ts",
         exports: "./index.ts",

--- a/tests/dogfood/upstream-suite-compile-worker.mjs
+++ b/tests/dogfood/upstream-suite-compile-worker.mjs
@@ -43,6 +43,7 @@ async function loadNodeHostDependencies() {
     "node:buffer",
     "node:crypto",
     "node:events",
+    "node:os",
     "node:stream",
     "node:timers",
     "node:url",


### PR DESCRIPTION
## Summary

- implement the scoped `jest.isolateModules()` contract in the shared React/ReactDOM upstream shim
- provide React's original `IntersectionMocks` helper, observer registration/simulation, and stable build selectors
- register `IntersectionObserver` and the required `node:os` namespace in the generic host surfaces
- admit four more original Jest 30.4.2 utility files: `diff-sequences`, `jest-docblock`, `jest-diff`, and `jest-config`
- adapt the lockfile-pinned `detect-newline@3.1.0` CommonJS dependency from its installed source to a checked ESM adapter
- bind static namespace imports without changing upstream callbacks, and report the remaining unavailable inventory explicitly
- record the checkpoint in [#3995](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md)

The expanded Jest slice now runs 12 original files and 234 callbacks. All 12 modules compile and validate; the native oracle passes 232/234 callbacks and the Wasm lane passes 113/232 native-compatible callbacks. The remaining 119 Wasm failures are scored compatibility results, while 3,054 registrations from the other 229 verified files remain explicitly unavailable infrastructure. No upstream test body or expected result is rewritten.

## Verification

- `pnpm exec vitest run tests/dogfood/jest-upstream-suite.test.ts --reporter=dot`
- `DOGFOOD_JEST_UPSTREAM_SUITE=1 NO_COLOR=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts --reporter=dot`
- `pnpm run typecheck`
- `pnpm exec prettier --check tests/dogfood/setup-jest-upstream-suite.mjs tests/dogfood/jest-upstream-suite.mjs tests/dogfood/jest-upstream-suite.test.ts tests/dogfood/npm-small-upstream-suites.test.ts`
