### PR TITLE
test(npm-compat): wire UUID upstream suite into package gate

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -709,3 +709,14 @@ source-hash check. A narrow namespace-import rewrite binds the static members
 used by the original tests; no callback body or expected result is rewritten.
 The two native snapshot cases remain harness-incompatible and the Wasm
 semantic failures remain visible in the scored report.
+
+## 2026-08-21 UUID common-suite CI checkpoint
+
+UUID's existing pinned v14.0.1 runner is now part of the shared
+`npm-small-upstream-suites.test.ts` package gate. The gate verifies the complete
+official ten-file inventory and, when `DOGFOOD_UUID_UPSTREAM_SUITE=1`, runs all
+**75/75 original callbacks** in both lanes: the Node oracle passes 75, all ten
+modules compile and validate, and Wasm scores **10 passed / 65 failed**. The
+failures remain visible compatibility findings (WebCrypto typed-array
+crossing, missing global `crypto`, UUID parsing/exception semantics, and the
+v3/v5 hash path); none are relabeled as unavailable infrastructure.

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -110,6 +110,12 @@ describe("small npm package upstream suites", () => {
       testFileCount: 256,
       registrationSites: 1761,
     });
+    expect(pin("uuid")).toMatchObject({
+      tag: "v14.0.1",
+      commit: "70177807e9229dfacde2038dc1e722f1828f358a",
+      testFiles: expect.any(Array),
+    });
+    expect(pin("uuid").testFiles).toHaveLength(10);
   });
 
   const clsxHeavy = process.env.DOGFOOD_CLSX_UPSTREAM_SUITE === "1" ? it : it.skip;
@@ -285,6 +291,19 @@ describe("small npm package upstream suites", () => {
     expect(report.extraction.unavailableInfra).toBe(3054);
     expect(report.compile).toMatchObject({ modules: 12, succeeded: 12, validated: 12 });
     expect(report.results).toMatchObject({ scored: 232, passed: 113, failed: 119, runtimeFailed: 0 });
+  });
+
+  const uuidHeavy = process.env.DOGFOOD_UUID_UPSTREAM_SUITE === "1" ? it : it.skip;
+  uuidHeavy("runs UUID's complete original runtime callback inventory", { timeout: 600_000 }, async () => {
+    const report = await run("uuid");
+    expect(report.extraction).toMatchObject({
+      upstreamTestsSeen: 75,
+      admitted: 75,
+      rejected: 0,
+    });
+    expect(report.results).toMatchObject({ nativePassed: 75, scored: 75, passed: 10, failed: 65 });
+    expect(report.compile).toMatchObject({ success: true, validates: true });
+    expect(report.compile.files).toHaveLength(10);
   });
 
   const tailwindcssHeavy = process.env.DOGFOOD_TAILWINDCSS_UPSTREAM_SUITE === "1" ? it : it.skip;


### PR DESCRIPTION
## Summary

- wire UUID v14.0.1's existing pinned ten-file upstream harness into the shared `npm-small-upstream-suites.test.ts` gate
- assert the complete 75-callback inventory and compile/validation coverage
- preserve the measured Wasm result (10 passed / 65 failed) as scored compatibility data; crypto, typed-array, parser, exception, and hash failures are not mislabeled as unavailable infrastructure
- record the checkpoint in the [upstream-suite compatibility plan](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md)

## Verification

- `pnpm exec prettier --check tests/dogfood/npm-small-upstream-suites.test.ts plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md`
- `DOGFOOD_UUID_UPSTREAM_SUITE=1 NO_COLOR=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts --reporter=dot`

The full upstream suite runs all 75 original callbacks in Node and Wasm; no test body or expected result is rewritten.
