### PR TITLE
feat(ir): module-level declared-type tables for the verifier

### DIFF
--- a/plan/issues/4605-ir-module-declared-type-table.md
+++ b/plan/issues/4605-ir-module-declared-type-table.md
@@ -1,7 +1,8 @@
 ---
 id: 4605
 title: "IR module-level declared-type table: give the verifier a signature/global source of truth for call/global.* rules"
-status: ready
+status: done
+completed: 2026-08-21
 sprint: current
 created: 2026-08-21
 priority: medium
@@ -14,6 +15,12 @@ language_feature: compiler-internals
 goal: backend-agnostic-ir
 parent: 3518
 related: [4603, 4523, 3030, 3520]
+loc-budget-allow:
+  - src/ir/verify.ts
+  - src/ir/nodes.ts
+  - src/ir/integration.ts
+func-budget-allow:
+  - src/ir/integration.ts::compileIrPathFunctions
 origin: "#4603 finding 1 (PR #4704): call/global.* type rules could only be intra-function coherence checks because no declared-signature record exists in the verifier's scope"
 # id 4605 reserved via claim-issue.mjs --allocate --allow-unscanned on
 # 2026-08-21 (gh CLI offline in this container; pr_scan=degraded). MCP
@@ -55,18 +62,115 @@ natural place the table's serialized form lands.
 
 ## Acceptance criteria
 
-- [ ] A decision, recorded here, on the table's home (ProgramAbiMap
+- [x] A decision, recorded here, on the table's home (ProgramAbiMap
       projection vs IrModule-owned declarations), with the #3030
       serialization consequence stated.
-- [ ] `IrModule` (or the chosen carrier) exposes declared signatures for
+- [x] `IrModule` (or the chosen carrier) exposes declared signatures for
       functions and declared IrTypes for globals reachable by
       `verifyIrFunction` (likely via an optional context parameter so
       existing single-function callers stay valid).
-- [ ] The #4603 coherence rules for `call`/`global.*` upgrade to
+- [x] The #4603 coherence rules for `call`/`global.*` upgrade to
       declared-type rules when the table is present, keeping the
       conservative skip when it is absent; positive + negative fixtures per
       the #4070 method, and the mutation proof that removing a rule fails
       loudly.
-- [ ] No behavior change for valid IR; `check:ir-fallbacks` post-claim
+- [x] No behavior change for valid IR; `check:ir-fallbacks` post-claim
       buckets and `check:ir-only` (both lanes) unchanged; the full corpus
       shows zero new demotions attributable to the upgraded rules.
+
+## Implementation Plan (Fable, 2026-08-21)
+
+**Decision (AC 1): option B — `IrModule`-owned declared tables, not a `ProgramAbiMap` projection.** Rationale: (1) the verifier stays standalone — coupling verify to the prepared pipeline would invert the dependency the `check:ir-layering` ratchet exists to shrink; (2) `ProgramAbiMap` (#3520 R1) is actively edited by another lane — consuming it now creates conflicts with every in-flight prepared-pipeline transaction; (3) #3030 wants a self-describing serializable module, which means declarations belong ON the module. Serialization consequence (record in the issue): the tables become part of the module's serialized form under #3030's C2 schema-namespace thread; preparation later cross-checks `ProgramAbiMap` against them (one more sync point, accepted deliberately).
+
+Verified anchors (current main, commit c3988b6d5):
+
+- `IrModule` at `src/ir/nodes.ts:2408` — `{ readonly functions: readonly IrFunction[] }` only.
+- `verifyIrFunction(func, domain = defaultTagDomain())` at `src/ir/verify.ts:341`.
+- `bindingKey` (stable structural key for `IrGlobalRef`/`IrFuncRef` bindings) at `src/ir/verify.ts:~1557`.
+- The #4603 coherence rules live in `checkSymbolicRefCoherence` at `src/ir/verify.ts:~2106`, with state in `RoadmapRuleCtx` (`callSignatures`, `globalKinds` maps, `:~1788-1818`). Its doc comment (`:2096`) states the exact gap this issue closes.
+- `verifySymbolicReferences` (`:222`) owns malformed-ref errors; keep that separation.
+
+Mechanism:
+
+1. **Types** (nodes.ts, next to `IrModule`): `IrDeclaredSignature = { readonly params: readonly IrType[]; readonly result: IrType | null }` (null = void). Extend `IrModule` with OPTIONAL fields `declaredSignatures?: ReadonlyMap<string, IrDeclaredSignature>` and `declaredGlobals?: ReadonlyMap<string, IrType>`, keyed by the same structural binding key `bindingKey` computes. Optional fields keep every existing `IrModule` construction site valid — zero-churn.
+2. **Key sharing**: `bindingKey` is currently verify-internal. Export it from verify.ts (or move it to nodes.ts if that reads cleaner) so producer and consumer use ONE key function. Do not duplicate the logic.
+3. **Verifier context**: add an optional third parameter to `verifyIrFunction(func, domain, declarations?: IrModuleDeclarations)` where `IrModuleDeclarations` is a pick of the two tables. Existing callers unchanged. Thread it into `RoadmapRuleCtx`.
+4. **Rule upgrade** in `checkSymbolicRefCoherence`: when the table has an entry for the binding key, check the reference against the DECLARATION (call: arity vs `params.length`, resultType kind vs declared result kind; global.get resultType / global.set value kind vs declared global's ValType kind) — this catches the "ONE mistaken call site, coherent with itself" shape the coherence rule cannot. When the table lacks the key, keep the existing first-seen coherence behavior unchanged (conservative skip). Same carrier-kind-level comparison and unknown-skips as every #4603 rule (a verify error DEMOTES to legacy, so rules fire only on provable contradictions).
+5. **Producer wiring — minimal-diff, stop-rule guarded**: `src/ir/integration.ts` assembles `IrModule`. Populate the tables ONLY where the assembly site already has the signature/global type in hand (the per-function results it accumulates). **Stop-rule: if wiring requires >30 changed lines in integration.ts or restructuring code that #3520/#3521 (prepared-pipeline lanes) are editing, do NOT force it** — land the tables + verifier upgrade + fixtures with a test-side producer, keep the issue `in-progress`, and record production wiring as the follow-up gated on #3520. Honest partial over forced complete.
+6. **Tests** (`tests/issue-4605-declared-type-table.test.ts`), per the #4070 method: positive fixtures (valid IR verifies clean with tables present), negative fixtures (one mistaken-but-self-coherent call site caught ONLY with the table present — this is the load-bearing case; wrong arity, wrong result kind, wrong global carrier for both get and set), absent-table conservatism (same IR, no tables, no errors), and the mutation proof: deliberately disable the declaration check in a scratch build and show the negative fixture goes silent (record the counterfactual in the issue file, restore).
+
+Bar (AC 4): no behavior change for valid IR; ts7 `pnpm run typecheck`; IR test files green (`ir-*.test.ts`, `issue-4523-*`, `issue-4603-*`); `pnpm run check:ir-fallbacks` and `pnpm run check:ir-only` unchanged; `pnpm run check:linear-ir` still OK compiled=8. If integration.ts wiring lands, run the full corpus check and record zero new demotions. Respect LOC/func budgets — if the diff exceeds a budget gate, grant it in THIS issue's frontmatter (`loc-budget-allow:` list), NEVER edit `scripts/*-baseline.json`.
+
+## Outcome (2026-08-21)
+
+All six steps landed, **including production wiring** (step 5 — the stop-rule did not trigger).
+
+### What shipped
+
+| Step | Where | Note |
+| --- | --- | --- |
+| 1 Types | `src/ir/nodes.ts` — `IrDeclaredSignature`, `IrModuleDeclarations`, `IrModule extends IrModuleDeclarations` | Optional fields; every existing `IrModule` literal still compiles untouched. |
+| 2 Key sharing | `src/ir/declared-types.ts` — `irBindingKey` | The one implementation now lives here; `verify.ts` keeps a `const bindingKey = irBindingKey` alias so its existing call sites are unchanged. |
+| 3 Verifier context | `verifyIrFunction(func, domain?, declarations?)`, threaded to `RoadmapRuleCtx.declarations` | Third parameter, so every existing call site is unchanged. |
+| 4 Rule upgrade | `checkSymbolicRefCoherence` in `src/ir/verify.ts`; rules in `declared-types.ts` (`declaredCallProblems`, `declaredGlobalProblem`) | Declaration present ⇒ declaration rule and return; absent ⇒ #4603 coherence, unchanged. |
+| 5 Producer wiring | `src/ir/integration.ts`, **13 changed lines** (11 +, 2 −) | Two module-level verify sites: post-inline (`irModuleDeclarations(modOut)`) and post-mono/TU (`irModuleDeclarations(modAfterTU)`). |
+| 6 Tests | `tests/issue-4605-declared-type-table.test.ts` — 19 tests | Positive, negative, absent-table conservatism, producer derivation, end-to-end. |
+
+**Deviation from the plan, deliberate:** the plan put the types and the key in `nodes.ts`/`verify.ts`. Both are god-files under the `check:loc-budget` ratchet, so the substance went into a new subsystem module `src/ir/declared-types.ts` instead — which is what that gate asks for. Two smaller consequences fall out of it: the type declarations still had to sit in `nodes.ts` (placed below every instruction-kind declaration, so `scripts/ir-kind-neutrality-baseline.json` line numbers do not shift), and `declared-types.ts` imports only *types* from `nodes.ts`, so the edge has no back edge.
+
+### Step-5 stop-rule decision: PROCEED
+
+The rule was ">30 changed lines in integration.ts, or restructuring code the #3520/#3521 lanes are editing". Measured: **13 changed lines**, all additive, none inside a structure those lanes touch (two `const` bindings and two extra call arguments at existing `verifyIrFunction` sites). Well under the threshold, so the wiring landed rather than being deferred.
+
+### The measurement that changed the design
+
+Wiring the producer in ON THE FIRST CUT demoted **3 previously-IR-compiled functions** — `website/playground/examples/js/async.ts`, bucket `async-function` 0 → 3 (reproduced twice, A/B against the base copy of `integration.ts`). Instrumented, the verify error was:
+
+```
+call fetchUser resultType externref contradicts the module-declared result f64
+```
+
+This is a **false positive, not a caught bug**. An `async function fetchUser(id: number): Promise<number>` lowers to an `IrFunction` whose `resultTypes` is the UNWRAPPED `f64` (#1373b unwraps `Promise<T>` for the awaiting caller), while a call site that does *not* await legitimately receives the Promise object as `externref`. Both carriers are correct for the same callee, so no single declared result carrier exists. Generators divide the same way (the lowerer picks `externref` for the Generator object regardless of the annotation `resultTypes` records).
+
+The fix is `declarableResultType` in `declared-types.ts`: `funcKind === "async" | "generator"` declares `result: null`, which skips the result comparison. **Arity is still declared and still checked for both.** After the guard the bucket returns to 0 — identical to the base run.
+
+This is the concrete argument for wiring the producer rather than shipping the mechanism with a test-side producer only: the async/Promise split is invisible in hand-built fixtures and would otherwise have shipped as a latent conformance loss the first time someone wired it.
+
+### Mutation proof (AC 3)
+
+Counterfactual run, `declared-types.ts` scratch-mutated so `declaredCallProblems` returns `[]` and `declaredGlobalProblem` returns `null` (the declaration checks disabled, everything else intact), then restored:
+
+| | Result |
+| --- | --- |
+| Rules enabled | 19 passed / 19 |
+| Rules disabled | **5 failed** / 14 passed |
+
+The five that went silent are exactly the declaration-only negatives — lone-call wrong arity, lone-call wrong result carrier, lone `global.get` wrong carrier, lone `global.set` wrong carrier, and the end-to-end sibling-unit arity contradiction. Every positive, every conservative-skip, and every #4603 coherence test stayed green under the mutation, which is the other half of the proof: the mutation removes only the new rule.
+
+### Gate results (all on the final tree)
+
+| Gate | Result |
+| --- | --- |
+| `pnpm run typecheck` (ts7) | clean |
+| `pnpm run format:check` | clean |
+| `pnpm run check:ir-fallbacks` | OK — no unintended/post-claim/module-level increases; deferred buckets identical to base (`string-builder-candidate` 2, `async-function` 0) |
+| `pnpm run check:ir-only` | READY — 38 units, 38 IR bodies, 0 unsupported, 0 invariants, 0 legacy bodies |
+| `pnpm run check:linear-ir` | OK — compiled=8 (baseline 8) |
+| `pnpm run check:ir-dialect` | OK |
+| `pnpm run check:ir-kind-neutrality` | OK (baseline: one `declaredAt` line number shifted by the integration.ts insertions; committed) |
+| `pnpm run check:jstag-seam` | OK — no growth |
+| `pnpm run check:ir-layering` | OK — 83 import lines (baseline 83) |
+| `tests/issue-4605-declared-type-table.test.ts` | 19/19 |
+| `tests/issue-4603-*`, `issue-4523-*`, `tests/ir/**`, `issue-3520-*`, `ir-scaffold` | 269/270 |
+
+The single failure is `tests/ir-scaffold.test.ts` "selection picks the expected functions" (`withVar`), and it is **pre-existing on `origin/main`** — verified by an A/B run with the base copies of `verify.ts`/`nodes.ts`/`integration.ts` restored and `declared-types.ts` removed, where it fails identically. Not attributable to this change and not fixed here.
+
+### Budget allowances granted in this issue's frontmatter
+
+`src/ir/verify.ts` (+31), `src/ir/nodes.ts` (+25), `src/ir/integration.ts` (+9), and `compileIrPathFunctions` (+8) exceed their ratchets. The bulk of the new code (~150 lines) is in the new `declared-types.ts`, which is not god-file growth; what remains in the three is the threading and the type declarations, which cannot live anywhere else. `scripts/loc-budget-baseline.json` and `scripts/func-budget-baseline.json` were NOT touched.
+
+### Follow-ups this deliberately does not do
+
+- **`declaredGlobals` has no production producer.** The mechanism, the rules, and the fixtures are all in place, but nothing in `integration.ts` records a declared IrType per global — no such record exists to read yet. So in production the `global.*` rules still fall back to #4603 coherence; only `call` is upgraded end to end. Populating it belongs with whichever slice first materialises global declarations (#3520 R1's globals table is the natural source).
+- **Serialization (#3030 C2).** The tables are on the module but not yet in the serialized schema; that is the C2 thread's to add, per the AC-1 decision recorded above.
+- **Preparation cross-check.** The accepted cost of option B is that `ProgramAbiMap` and these tables must agree. Nothing checks that today.

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -270,7 +270,7 @@
       "where": "dialect",
       "declaredAt": "src/ir/dialect/js.ts:687",
       "why": "This is `%String.prototype%[@@iterator]` inlined as a statement form. The per-iteration element is a CODE POINT rendered as a one-element string — the intent field resolves to `__str_charAt_cp`, deliberately not the code-unit `string.char_at` next door. Its general sibling `forof.iter` is already in the dialect, so keeping the string specialization in core splits one protocol across the boundary.",
-      "evidence": ["src/ir/dialect/js.ts:696", "src/ir/integration.ts:4963"]
+      "evidence": ["src/ir/dialect/js.ts:696", "src/ir/integration.ts:4972"]
     },
     "forof.vec": {
       "verdict": "neutral",

--- a/src/ir/declared-types.ts
+++ b/src/ir/declared-types.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4605 — module-level DECLARED-TYPE tables for the IR verifier.
+//
+// The IR resolves globals and callables lazily through symbolic refs, so until
+// this module existed the verifier had no record anywhere in scope of "the
+// signature this callable declares" or "the IrType this global declares":
+// `IrFuncRef`/`IrGlobalRef` carry a debug name plus a structural binding, and
+// `IrModule` held only `functions`. #4603's `call` / `global.get` /
+// `global.set` rules therefore had to settle for intra-function COHERENCE —
+// two references to one binding must agree with each other — which catches the
+// defect class but not its most common shape: ONE mistaken reference that is
+// perfectly coherent with itself.
+//
+// The design decision recorded in #4605: the tables live ON the module
+// (`IrModule extends IrModuleDeclarations`) rather than being projected out of
+// `ProgramAbiMap` (#3520 R1). That keeps `verifyIrFunction` standalone — it
+// does not learn about the prepared pipeline — and matches #3030's
+// self-describing serializable module, at the cost of one more record for
+// preparation to cross-check against.
+//
+// Everything here is CONSERVATIVE by construction: a binding with no
+// declaration is skipped, not flagged. A verify error demotes the function to
+// the legacy compiler, so a rule that guesses costs conformance.
+
+import type { IrDeclaredSignature, IrFunction, IrModuleDeclarations, IrType } from "./nodes.js";
+import type { ValType } from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * A stable structural key for an `IrGlobalRef` / `IrFuncRef` binding (#4603,
+ * generalized here by #4605).
+ *
+ * This is the SHARED vocabulary between producer and verifier — the tables
+ * above are keyed by exactly this string — so there must be one key function,
+ * never two. `name` is explicitly a debug label and never the identity, so the
+ * key is built from the binding discriminant alone.
+ */
+export function irBindingKey(binding: unknown): string | null {
+  if (!isRecord(binding)) return null;
+  const kind = binding.kind;
+  if (typeof kind !== "string") return null;
+  const id = binding.bindingId ?? binding.unitId ?? binding.symbol;
+  if (typeof id === "string") return `${kind}:${id}`;
+  if (kind === "import" && typeof binding.module === "string" && typeof binding.field === "string") {
+    return `import:${binding.module}:${binding.field}`;
+  }
+  return null;
+}
+
+/**
+ * The result type a function DECLARES to its callers, or `null` when no single
+ * carrier is declarable.
+ *
+ * `async` and `generator` bodies are the `null` case, and this is a measured
+ * constraint rather than caution (#4605): `async function fetchUser(): Promise<number>`
+ * lowers to an `IrFunction` whose `resultTypes` is the UNWRAPPED `f64` (#1373b
+ * unwraps `Promise<T>` for the awaiting caller), while a call site that does
+ * not await legitimately receives the Promise object as `externref`. Both
+ * carriers are correct for the same callee, so a declared-result rule over
+ * them reports contradictions that are not contradictions — it demoted three
+ * functions in `website/playground/examples/js/async.ts` before this guard.
+ * Generators divide the same way: the lowerer picks `externref` for the
+ * Generator object regardless of the source-level annotation `resultTypes`
+ * records. Arity is unaffected and still checked for both.
+ */
+function declarableResultType(fn: IrFunction): IrType | null {
+  if (fn.funcKind === "async" || fn.funcKind === "generator") return null;
+  return fn.resultTypes.length > 0 ? fn.resultTypes[0]! : null;
+}
+
+/**
+ * Derive the declared-signature table a module implies for its own functions,
+ * merged with whatever declarations the module already carries.
+ *
+ * Every `IrFunction` in the module IS the declaration for its own unit
+ * binding — `params` and `resultTypes` are the signature the lowerer will
+ * emit — so the common case needs no new bookkeeping at the producer. Explicit
+ * tables already on the module WIN over the derived entries: a producer that
+ * knows better (an import's declared ABI, say) states it, and this helper never
+ * overwrites it.
+ *
+ * Globals are pass-through — nothing in `functions` declares a global's type.
+ */
+export function irModuleDeclarations(
+  module: { readonly functions: readonly IrFunction[] } & IrModuleDeclarations,
+): IrModuleDeclarations {
+  const declaredSignatures = new Map<string, IrDeclaredSignature>();
+  for (const fn of module.functions) {
+    const key = irBindingKey({ kind: "unit", unitId: fn.unitId });
+    // A duplicate unit id would make "the" declaration ambiguous; first wins,
+    // and `integration.ts`'s module-level identity checks own the real
+    // complaint about it.
+    if (key === null || declaredSignatures.has(key)) continue;
+    declaredSignatures.set(key, {
+      params: fn.params.map((p) => p.type),
+      result: declarableResultType(fn),
+    });
+  }
+  for (const [key, signature] of module.declaredSignatures ?? []) declaredSignatures.set(key, signature);
+  return { declaredSignatures, declaredGlobals: module.declaredGlobals };
+}
+
+/**
+ * Contradictions between ONE `call` site and the module-declared signature for
+ * its target, at the same carrier-kind granularity as every other #4603 rule.
+ *
+ * `resultKind` / `declaredResultKind` are `null` when the carrier is unknown or
+ * not a `val` (a declared-void callable, a `dynamic` result); either being null
+ * skips the result comparison. Returns an empty array when the call is
+ * consistent with the declaration.
+ */
+export function declaredCallProblems(
+  targetName: string,
+  argCount: number,
+  resultKind: ValType["kind"] | null,
+  declared: IrDeclaredSignature,
+  declaredResultKind: ValType["kind"] | null,
+): string[] {
+  const problems: string[] = [];
+  if (argCount !== declared.params.length) {
+    problems.push(
+      `call ${targetName} passes ${argCount} argument(s) but the module declares ${declared.params.length} parameter(s)`,
+    );
+  }
+  if (resultKind !== null && declaredResultKind !== null && resultKind !== declaredResultKind) {
+    problems.push(
+      `call ${targetName} resultType ${resultKind} contradicts the module-declared result ${declaredResultKind}`,
+    );
+  }
+  return problems;
+}
+
+/**
+ * The contradiction, if any, between the carrier ONE `global.get`/`global.set`
+ * commits to and the module-declared carrier for that global. `null` when the
+ * declared carrier is unknown or the two agree.
+ */
+export function declaredGlobalProblem(
+  instrKind: "global.get" | "global.set",
+  targetName: string,
+  observed: ValType["kind"],
+  declaredKind: ValType["kind"] | null,
+): string | null {
+  if (declaredKind === null || declaredKind === observed) return null;
+  return `${instrKind} ${targetName} carrier ${observed} contradicts the module-declared ${declaredKind}`;
+}

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -296,6 +296,7 @@ import {
   type IrSelection,
 } from "./select.js";
 import { verifyIrFunction } from "./verify.js";
+import { irModuleDeclarations } from "./declared-types.js";
 import { prepareIrRuntimeManifest, type PreparedIrRuntimeManifest } from "./intrinsic-support.js";
 import { attachIrExternSupport } from "./extern-support.js";
 import { attachIrGeneratorSupport, collectAttachedGeneratorProviders } from "./generator-support.js";
@@ -2186,6 +2187,11 @@ export function compileIrPathFunctions(
   }
 
   // 2c. Re-run hygiene on functions the inline pass actually rewrote; verify.
+  // (#4605) The module IS in scope here, so the verifier gets its declared
+  // signatures — a call site whose arity or result carrier contradicts the
+  // callee's own declaration is caught even when it is the only reference to
+  // that callee in its function.
+  const declsAfterInline = irModuleDeclarations(modOut);
   const afterInline: BuiltFn[] = [];
   for (let i = 0; i < afterHygiene.length; i++) {
     const before = afterHygiene[i]!;
@@ -2200,7 +2206,7 @@ export function compileIrPathFunctions(
       }
       const changed = after !== before.fn;
       const final = changed ? runHygienePasses(after, allocRegistry) : after;
-      const verifyErrors = verifyIrFunction(final);
+      const verifyErrors = verifyIrFunction(final, undefined, declsAfterInline);
       if (verifyErrors.length > 0) {
         throw new IrInvariantError(
           "verifier-failure",
@@ -2467,6 +2473,9 @@ export function compileIrPathFunctions(
   // (usually a no-op but cheap).
   // -------------------------------------------------------------------------
   const readyForLower: BuiltFn[] = [];
+  // (#4605) Same declared-signature check as after inlining, re-derived after
+  // monomorphization: clones are new units with their own declarations.
+  const declsAfterTU = irModuleDeclarations(modAfterTU);
 
   for (const fn of modAfterTU.functions) {
     const before = afterInlineByUnitId.get(fn.unitId);
@@ -2491,7 +2500,7 @@ export function compileIrPathFunctions(
           ? batchStringConcat(hygienic, allocRegistry, 8)
           : hygienic;
       const final = batched === hygienic ? hygienic : runHygienePasses(batched, allocRegistry);
-      const verifyErrors = verifyIrFunction(final);
+      const verifyErrors = verifyIrFunction(final, undefined, declsAfterTU);
       if (verifyErrors.length > 0) {
         throw new IrInvariantError(
           "verifier-failure",

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -2402,10 +2402,35 @@ export interface IrFunction extends IrFunctionIdentity {
 // `integration.ts` accumulates the per-function results into an `IrModule`
 // container between the build phase and the lower phase.
 //
-// The container holds only functions for now. Globals/types/imports remain
-// resolved lazily via the symbolic-ref mechanism.
+// The container holds functions plus the OPTIONAL declared-type tables #4605
+// added. Globals/types/imports are still *resolved* lazily via the symbolic-ref
+// mechanism at lowering; the tables are a declaration record, not a resolver.
+// The rules that read them, and the key function they are keyed by, live in
+// `declared-types.ts` — only the shapes are here, so that module's import edge
+// into `nodes.ts` has no back edge.
 
-export interface IrModule {
+/**
+ * (#4605) The declared shape of one callable, as the module DECLARES it —
+ * independent of any particular call site. `result === null` means "no single
+ * declarable result carrier" (void, or a call-site-dependent one such as an
+ * async body's Promise-vs-awaited split — see `declarableResultType`).
+ */
+export interface IrDeclaredSignature {
+  readonly params: readonly IrType[];
+  readonly result: IrType | null;
+}
+
+/**
+ * (#4605) Module-level declaration tables, keyed by `irBindingKey`. Both are
+ * OPTIONAL and both may be partial: a missing entry means "no declaration in
+ * scope", which consumers must treat as a conservative skip.
+ */
+export interface IrModuleDeclarations {
+  readonly declaredSignatures?: ReadonlyMap<string, IrDeclaredSignature>;
+  readonly declaredGlobals?: ReadonlyMap<string, IrType>;
+}
+
+export interface IrModule extends IrModuleDeclarations {
   readonly functions: readonly IrFunction[];
 }
 

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -20,8 +20,12 @@
 // On failure, returns a list of `IrVerifyError`s rather than throwing, so
 // callers can decide whether to bail or fall back to the legacy path.
 
-import type { IrBlock, IrFunction, IrInstr, IrLabelId, IrType, IrValueId } from "./nodes.js";
+import type { IrBlock, IrFunction, IrInstr, IrLabelId, IrModuleDeclarations, IrType, IrValueId } from "./nodes.js";
 import { asVal, forEachInstrDeep, forEachNestedBuffer, irTypeEquals } from "./nodes.js";
+// #4605 — the module-level declared-type tables and the rules that read them.
+// `verifyIrFunction` stays standalone: the tables arrive as an optional
+// parameter, and their absence is always a conservative skip.
+import { declaredCallProblems, declaredGlobalProblem, irBindingKey } from "./declared-types.js";
 import type { ValType } from "./types.js";
 // #2949 slice 1 / #3954 phase 1 — the dynamic-operand rules (payload-kind
 // consistency of unbox/tag.test) are DOMAIN questions, not ECMAScript ones:
@@ -337,8 +341,21 @@ function verifySymbolicReferences(func: IrFunction, errors: IrVerifyError[]): vo
  * to the producer axis's default domain, so callers that do not care are
  * unchanged; a non-JS producer passes its own and the verifier stops answering
  * from ECMAScript.
+ *
+ * `declarations` (#4605) is the OPTIONAL module-level declared-type table —
+ * `IrModule.declaredSignatures` / `.declaredGlobals`, keyed by
+ * {@link irBindingKey}. When a binding has an entry, the `call` / `global.get`
+ * / `global.set` rules check each reference against the DECLARATION, which
+ * catches the shape intra-function coherence structurally cannot: ONE mistaken
+ * reference that is perfectly coherent with itself. When it is absent — the
+ * default, and every existing caller — the #4603 coherence behaviour is
+ * unchanged. Use {@link irModuleDeclarations} to derive it from an `IrModule`.
  */
-export function verifyIrFunction(func: IrFunction, domain: TagDomain = defaultTagDomain()): IrVerifyError[] {
+export function verifyIrFunction(
+  func: IrFunction,
+  domain: TagDomain = defaultTagDomain(),
+  declarations?: IrModuleDeclarations,
+): IrVerifyError[] {
   const errors: IrVerifyError[] = [];
   const defs = new Set<IrValueId>();
 
@@ -428,7 +445,7 @@ export function verifyIrFunction(func: IrFunction, domain: TagDomain = defaultTa
   }
 
   // #1924 — per-instruction operand / result / slot type rules.
-  verifyInstrTypeRules(func, typeOf, errors);
+  verifyInstrTypeRules(func, typeOf, errors, declarations);
 
   // #1798 — defense-in-depth: every `return` terminator's value types must be
   // Wasm-assignment-compatible with the function's declared `resultTypes`.
@@ -1554,28 +1571,12 @@ function constResultKind(v: import("./nodes.js").IrConst): ValType["kind"] | nul
 }
 
 /**
- * (#4603) A stable structural key for an `IrGlobalRef` / `IrFuncRef` binding.
- *
- * The IR resolves globals and callables LAZILY through symbolic refs — neither
- * `IrModule` nor `IrFunction` carries a declared-type table (see `IrModule`,
- * which holds only `functions`). So the verifier cannot compare a `global.get`
- * against "the global's declared IrType": no such record is in scope. What IS
- * in scope is every OTHER reference to the same binding in the same function,
- * which must agree — that intra-function coherence rule is what `global.get` /
- * `global.set` get here. `name` is explicitly a debug label and never the
- * identity, so the key is built from the binding discriminant alone.
+ * (#4603) The verifier's local alias for the shared structural binding key.
+ * `declared-types.ts` owns the one implementation (#4605) — the module-level
+ * declaration tables are keyed by exactly this string, so producer and
+ * verifier must never grow a second key function.
  */
-function bindingKey(binding: unknown): string | null {
-  if (!isRecord(binding)) return null;
-  const kind = binding.kind;
-  if (typeof kind !== "string") return null;
-  const id = binding.bindingId ?? binding.unitId ?? binding.symbol;
-  if (typeof id === "string") return `${kind}:${id}`;
-  if (kind === "import" && typeof binding.module === "string" && typeof binding.field === "string") {
-    return `import:${binding.module}:${binding.field}`;
-  }
-  return null;
-}
+const bindingKey = irBindingKey;
 
 /**
  * Per-kind type-rule coverage status (#4523). `"checked"` means `checkInstr`
@@ -1798,6 +1799,13 @@ interface RoadmapRuleCtx {
   readonly numSlots: number;
   readonly callSignatures: Map<string, { arity: number; resultKind: ValType["kind"] | null }>;
   readonly globalKinds: Map<string, { kind: ValType["kind"]; via: "global.get" | "global.set" }>;
+  /**
+   * (#4605) The module's declared-type tables, when the caller supplied them.
+   * A binding WITH an entry is checked against the declaration; a binding
+   * without one falls back to #4603 coherence. Never a source of errors on its
+   * own — absence is always a conservative skip.
+   */
+  readonly declarations: IrModuleDeclarations | undefined;
 }
 
 /** Kinds whose rule is a fixed or self-declared carrier on the instr itself. */
@@ -2093,21 +2101,32 @@ function checkForOfSlots(
 }
 
 /**
- * #4603 — coherence, NOT declaration-matching, for the three symbolic-ref
- * kinds.
+ * #4603 coherence, upgraded by #4605 to declaration-matching wherever the
+ * module supplies a declaration for the binding.
  *
- * The IR resolves globals and callables lazily through symbolic refs, and
- * neither `IrModule` (which holds only `functions`) nor `IrFunction` carries a
- * declared-type table — so "must match the global's declared IrType" has
- * nothing in scope to match against. What IS in scope is every other reference
- * to the same binding in the same function: those must agree, and a
- * disagreement is a producer bug.
+ * The IR resolves globals and callables lazily through symbolic refs. When no
+ * declared-type table is in scope — the default for every single-function
+ * caller — the only derivable rule is that every reference to one binding
+ * inside one function must agree with the others, and a disagreement is a
+ * producer bug. That misses the most common defect shape: ONE mistaken
+ * reference, perfectly coherent with itself. `IrModule.declaredSignatures` /
+ * `.declaredGlobals` (#4605) close exactly that gap; a binding they do not
+ * mention keeps the coherence behaviour unchanged.
  */
 function checkSymbolicRefCoherence(instr: RoadmapSymbolicInstr, blockId: number, ctx: RoadmapRuleCtx): void {
   const key = bindingKey(instr.target.binding);
   if (key === null) return; // malformed ref — `verifySymbolicReferences` owns it
   if (instr.kind === "call") {
     const resultKind = instr.resultType ? (asVal(instr.resultType)?.kind ?? null) : null;
+    const signature = ctx.declarations?.declaredSignatures?.get(key);
+    if (signature !== undefined) {
+      const want = signature.result ? (asVal(signature.result)?.kind ?? null) : null;
+      const args = instr.args.length;
+      for (const p of declaredCallProblems(instr.target.name, args, resultKind, signature, want)) {
+        roadmapError(ctx, blockId, p);
+      }
+      return;
+    }
     const seen = ctx.callSignatures.get(key);
     if (seen === undefined) {
       ctx.callSignatures.set(key, { arity: instr.args.length, resultKind });
@@ -2136,6 +2155,12 @@ function checkSymbolicRefCoherence(instr: RoadmapSymbolicInstr, blockId: number,
         : null
       : valKindOf(ctx.typeOf, instr.value);
   if (observed === null) return;
+  const declaredType = ctx.declarations?.declaredGlobals?.get(key);
+  if (declaredType !== undefined) {
+    const problem = declaredGlobalProblem(instr.kind, instr.target.name, observed, asVal(declaredType)?.kind ?? null);
+    if (problem !== null) roadmapError(ctx, blockId, problem);
+    return;
+  }
   const seen = ctx.globalKinds.get(key);
   if (seen === undefined) {
     ctx.globalKinds.set(key, { kind: observed, via: instr.kind });
@@ -2150,7 +2175,12 @@ function checkSymbolicRefCoherence(instr: RoadmapSymbolicInstr, blockId: number,
   }
 }
 
-function verifyInstrTypeRules(func: IrFunction, typeOf: ReadonlyMap<IrValueId, IrType>, errors: IrVerifyError[]): void {
+function verifyInstrTypeRules(
+  func: IrFunction,
+  typeOf: ReadonlyMap<IrValueId, IrType>,
+  errors: IrVerifyError[],
+  declarations?: IrModuleDeclarations,
+): void {
   const numSlots = func.slots?.length ?? 0;
 
   // #2949 R4 — a dynamic-typed value may only feed box/unbox/tag.test, moves
@@ -2175,6 +2205,7 @@ function verifyInstrTypeRules(func: IrFunction, typeOf: ReadonlyMap<IrValueId, I
     numSlots,
     callSignatures: new Map(),
     globalKinds: new Map(),
+    declarations,
   };
 
   const checkInstr = (instr: IrInstr, blockId: number): void => {

--- a/tests/issue-4605-declared-type-table.test.ts
+++ b/tests/issue-4605-declared-type-table.test.ts
@@ -1,0 +1,335 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4605 — module-level declared-type tables for the IR verifier.
+ *
+ * #4603 could only give `call` / `global.get` / `global.set` an intra-function
+ * COHERENCE rule (two references to one binding must agree with each other),
+ * because no declared-signature record existed anywhere the verifier could
+ * reach. That catches the defect class but misses its most common shape: ONE
+ * mistaken reference, perfectly coherent with itself. The load-bearing tests
+ * below are exactly that shape — a single call site or a single `global.get`,
+ * which the coherence rule cannot possibly flag and the declaration rule does.
+ *
+ * Method (#4070): every rule gets both halves, plus the third half this issue
+ * needs — ABSENCE. The same negative fixture verified WITHOUT the tables must
+ * be silent, because a table that is not there must never be read as
+ * "undeclared, therefore wrong": absence is a conservative skip, and a verify
+ * error demotes the function to the legacy compiler.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  asBlockId,
+  asValueId,
+  irVal,
+  verifyIrFunction,
+  type IrBlock,
+  type IrFunction,
+  type IrInstr,
+  type IrType,
+  type IrValueId,
+} from "../src/ir/index.js";
+import {
+  irBindingKey,
+  irModuleDeclarations,
+  type IrDeclaredSignature,
+  type IrModuleDeclarations,
+} from "../src/ir/declared-types.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const irIdentities = createTestIrFunctionIdentityFactory("issue-4605");
+
+const I32 = irVal({ kind: "i32" });
+const F64 = irVal({ kind: "f64" });
+const EXTERNREF = irVal({ kind: "externref" });
+
+function constF64(id: number, value = 1): IrInstr {
+  return { kind: "const", value: { kind: "f64", value }, result: asValueId(id), resultType: F64 };
+}
+function constI32(id: number, value = 1): IrInstr {
+  return { kind: "const", value: { kind: "i32", value }, result: asValueId(id), resultType: I32 };
+}
+
+function block(id: number, instrs: IrInstr[]): IrBlock {
+  return {
+    id: asBlockId(id),
+    blockArgs: [],
+    blockArgTypes: [],
+    instrs,
+    terminator: { kind: "return", values: [] as IrValueId[] },
+  };
+}
+
+function voidFn(name: string, instrs: IrInstr[]): IrFunction {
+  return {
+    ...irIdentities.next(name),
+    params: [],
+    resultTypes: [],
+    blocks: [block(0, instrs)],
+    exported: false,
+    valueCount: 64,
+  };
+}
+
+/** Messages only — the assertions are about which rule fired, not order. */
+function verify(func: IrFunction, declarations?: IrModuleDeclarations): string[] {
+  return verifyIrFunction(func, undefined, declarations).map((e) => e.message);
+}
+
+const runtimeFunc = (name: string) =>
+  ({ kind: "func", name, binding: { kind: "runtime", symbol: name } }) as IrInstr extends {
+    kind: "call";
+    target: infer T;
+  }
+    ? T
+    : never;
+
+const supportGlobal = (name: string, bindingId: string) =>
+  ({ kind: "global", name, binding: { kind: "support", bindingId } }) as IrInstr extends {
+    kind: "global.get";
+    target: infer T;
+  }
+    ? T
+    : never;
+
+const call = (id: number | null, target: string, args: number[], resultType: IrType | null): IrInstr =>
+  ({
+    kind: "call",
+    target: runtimeFunc(target),
+    args: args.map(asValueId),
+    result: id === null ? null : asValueId(id),
+    resultType,
+  }) as IrInstr;
+
+const globalGet = (id: number, name: string, bindingId: string, resultType: IrType): IrInstr => ({
+  kind: "global.get",
+  target: supportGlobal(name, `ir-binding:v1:global:${bindingId}`),
+  result: asValueId(id),
+  resultType,
+});
+
+const globalSet = (name: string, bindingId: string, value: number): IrInstr => ({
+  kind: "global.set",
+  target: supportGlobal(name, `ir-binding:v1:global:${bindingId}`),
+  value: asValueId(value),
+  result: null,
+  resultType: null,
+});
+
+/** Declarations for one runtime callable, keyed the way the verifier keys it. */
+function signatures(entries: readonly (readonly [string, IrDeclaredSignature])[]): IrModuleDeclarations {
+  return {
+    declaredSignatures: new Map(
+      entries.map(([symbol, signature]) => [irBindingKey({ kind: "runtime", symbol })!, signature]),
+    ),
+  };
+}
+
+/** Declarations for one support global, keyed the way the verifier keys it. */
+function globals(entries: readonly (readonly [string, IrType])[]): IrModuleDeclarations {
+  return {
+    declaredGlobals: new Map(
+      entries.map(([bindingId, type]) => [
+        irBindingKey({ kind: "support", bindingId: `ir-binding:v1:global:${bindingId}` })!,
+        type,
+      ]),
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The key is the shared vocabulary
+// ---------------------------------------------------------------------------
+
+describe("#4605 irBindingKey — one key function for producer and verifier", () => {
+  it("keys each binding discriminant by its structural id, never by the debug name", () => {
+    expect(irBindingKey({ kind: "runtime", symbol: "__helper" })).toBe("runtime:__helper");
+    expect(irBindingKey({ kind: "unit", unitId: "u1" })).toBe("unit:u1");
+    expect(irBindingKey({ kind: "support", bindingId: "b1" })).toBe("support:b1");
+    expect(irBindingKey({ kind: "import", module: "env", field: "log" })).toBe("import:env:log");
+  });
+
+  it("returns null for a malformed binding, which is the verifier's skip signal", () => {
+    expect(irBindingKey(null)).toBeNull();
+    expect(irBindingKey({ noKind: true })).toBeNull();
+    expect(irBindingKey({ kind: "runtime" })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// call — the gap #4603 recorded and this issue closes
+// ---------------------------------------------------------------------------
+
+describe("#4605 call — one mistaken call site, coherent with itself", () => {
+  const declared = signatures([["__h", { params: [F64], result: F64 }]]);
+
+  it("accepts a lone call that matches the declaration", () => {
+    expect(verify(voidFn("callOk", [constF64(1), call(2, "__h", [1], F64)]), declared)).toEqual([]);
+  });
+
+  it("rejects a lone call whose arity contradicts the declaration", () => {
+    expect(verify(voidFn("callBadArity", [call(2, "__h", [], F64)]), declared)).toContain(
+      "call __h passes 0 argument(s) but the module declares 1 parameter(s)",
+    );
+  });
+
+  it("rejects a lone call whose result carrier contradicts the declaration", () => {
+    expect(verify(voidFn("callBadResult", [constF64(1), call(2, "__h", [1], I32)]), declared)).toContain(
+      "call __h resultType i32 contradicts the module-declared result f64",
+    );
+  });
+
+  it("is silent on the SAME fixtures without the table — this is the whole gap", () => {
+    // Neither of the two negatives above has a second reference to `__h`, so
+    // #4603's coherence rule has nothing to compare against and reports
+    // nothing. That is the defect shape #4605 exists to catch.
+    expect(verify(voidFn("callBadArityNoDecl", [call(2, "__h", [], F64)]))).toEqual([]);
+    expect(verify(voidFn("callBadResultNoDecl", [constF64(1), call(2, "__h", [1], I32)]))).toEqual([]);
+  });
+
+  it("skips a binding the table does not mention, and still applies coherence to it", () => {
+    // `__other` is undeclared: no declaration error, but the #4603 coherence
+    // rule is untouched and still catches the intra-function disagreement.
+    const fn = voidFn("mixed", [constF64(1), call(2, "__other", [1], F64), call(3, "__other", [], F64)]);
+    expect(verify(fn, declared)).toEqual(["call __other arity 0 disagrees with 1 used elsewhere in this function"]);
+  });
+
+  it("skips the result comparison when either carrier is undeclared or non-val", () => {
+    const voidCallee = signatures([["__v", { params: [], result: null }]]);
+    expect(verify(voidFn("voidCallee", [call(1, "__v", [], EXTERNREF)]), voidCallee)).toEqual([]);
+    expect(verify(voidFn("noResultType", [call(null, "__v", [], null)]), voidCallee)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// global.get / global.set
+// ---------------------------------------------------------------------------
+
+describe("#4605 global.get / global.set — matched against the declared IrType", () => {
+  const declared = globals([["b1", F64]]);
+
+  it("accepts a lone get and a lone set on the declared carrier", () => {
+    expect(verify(voidFn("globalOk", [globalGet(1, "g", "b1", F64)]), declared)).toEqual([]);
+    expect(verify(voidFn("globalSetOk", [constF64(1), globalSet("g", "b1", 1)]), declared)).toEqual([]);
+  });
+
+  it("rejects a lone get whose carrier contradicts the declaration", () => {
+    expect(verify(voidFn("globalBadGet", [globalGet(1, "g", "b1", I32)]), declared)).toContain(
+      "global.get g carrier i32 contradicts the module-declared f64",
+    );
+  });
+
+  it("rejects a lone set whose value carrier contradicts the declaration", () => {
+    expect(verify(voidFn("globalBadSet", [constI32(1), globalSet("g", "b1", 1)]), declared)).toContain(
+      "global.set g carrier i32 contradicts the module-declared f64",
+    );
+  });
+
+  it("is silent on the SAME fixtures without the table", () => {
+    expect(verify(voidFn("globalBadGetNoDecl", [globalGet(1, "g", "b1", I32)]))).toEqual([]);
+    expect(verify(voidFn("globalBadSetNoDecl", [constI32(1), globalSet("g", "b1", 1)]))).toEqual([]);
+  });
+
+  it("leaves an undeclared global to the #4603 coherence rule", () => {
+    const fn = voidFn("otherGlobal", [globalGet(1, "h", "b2", F64), constI32(2), globalSet("h", "b2", 2)]);
+    expect(verify(fn, declared)).toEqual([
+      "global.set h carrier i32 disagrees with f64 used by global.get elsewhere in this function",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// irModuleDeclarations — the producer side
+// ---------------------------------------------------------------------------
+
+describe("#4605 irModuleDeclarations — every function declares its own unit binding", () => {
+  const sigFn = (name: string, params: IrType[], resultTypes: IrType[], extra?: Partial<IrFunction>): IrFunction => ({
+    ...irIdentities.next(name),
+    params: params.map((type, i) => ({ value: asValueId(i), type, name: `p${i}` })),
+    resultTypes,
+    blocks: [block(0, [])],
+    exported: false,
+    valueCount: 64,
+    ...extra,
+  });
+
+  it("derives params and the first result type, keyed by the unit binding", () => {
+    const fn = sigFn("add", [F64, F64], [F64]);
+    const declarations = irModuleDeclarations({ functions: [fn] });
+    const entry = declarations.declaredSignatures?.get(irBindingKey({ kind: "unit", unitId: fn.unitId })!);
+    expect(entry).toEqual({ params: [F64, F64], result: F64 });
+  });
+
+  it("declares a void function's result as null", () => {
+    const fn = sigFn("sideEffect", [I32], []);
+    const declarations = irModuleDeclarations({ functions: [fn] });
+    expect(declarations.declaredSignatures?.get(irBindingKey({ kind: "unit", unitId: fn.unitId })!)).toEqual({
+      params: [I32],
+      result: null,
+    });
+  });
+
+  it("declares NO result for async and generator bodies, but still declares arity", () => {
+    // Measured constraint, not caution: an async callee's `resultTypes` is the
+    // AWAITED carrier (Promise<T> unwrapped), while a non-awaiting call site
+    // legitimately receives the Promise as externref. Both are correct for the
+    // same callee, so no single result carrier is declarable. Wiring this in
+    // without the guard demoted three functions in
+    // `website/playground/examples/js/async.ts`.
+    for (const funcKind of ["async", "generator"] as const) {
+      const fn = sigFn(`${funcKind}Body`, [F64], [F64], { funcKind });
+      const entry = irModuleDeclarations({ functions: [fn] }).declaredSignatures?.get(
+        irBindingKey({ kind: "unit", unitId: fn.unitId })!,
+      );
+      expect(entry, funcKind).toEqual({ params: [F64], result: null });
+    }
+  });
+
+  it("lets an explicit table on the module win over the derived entry", () => {
+    const fn = sigFn("overridden", [F64], [F64]);
+    const key = irBindingKey({ kind: "unit", unitId: fn.unitId })!;
+    const explicit: IrDeclaredSignature = { params: [I32, I32], result: I32 };
+    const declarations = irModuleDeclarations({
+      functions: [fn],
+      declaredSignatures: new Map([[key, explicit]]),
+    });
+    expect(declarations.declaredSignatures?.get(key)).toEqual(explicit);
+  });
+
+  it("passes declaredGlobals through untouched — no function declares a global", () => {
+    const table = globals([["b1", F64]]).declaredGlobals!;
+    expect(irModuleDeclarations({ functions: [], declaredGlobals: table }).declaredGlobals).toBe(table);
+    expect(irModuleDeclarations({ functions: [] }).declaredGlobals).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End to end: a module's own functions catch a bad call to one of them
+// ---------------------------------------------------------------------------
+
+describe("#4605 end to end — a call to a sibling unit is checked against that unit", () => {
+  it("flags an arity contradiction against the callee's own declaration", () => {
+    const callee: IrFunction = {
+      ...irIdentities.next("callee"),
+      params: [{ value: asValueId(0), type: F64, name: "x" }],
+      resultTypes: [F64],
+      blocks: [block(0, [])],
+      exported: false,
+      valueCount: 8,
+    };
+    const unitCall = (args: number[]): IrInstr =>
+      ({
+        kind: "call",
+        target: { kind: "func", name: "callee", binding: { kind: "unit", unitId: callee.unitId } },
+        args: args.map(asValueId),
+        result: asValueId(9),
+        resultType: F64,
+      }) as IrInstr;
+    const caller = voidFn("caller", [constF64(1), unitCall([1, 1])]);
+    const declarations = irModuleDeclarations({ functions: [callee, caller] });
+
+    expect(verify(caller, declarations)).toContain(
+      "call callee passes 2 argument(s) but the module declares 1 parameter(s)",
+    );
+    expect(verify(caller)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes [#4605](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4605-ir-module-declared-type-table).

## Problem

The IR verifier had no record in scope of "the signature this callable declares" or "the IrType this global declares" — `IrFuncRef`/`IrGlobalRef` resolve lazily through symbolic refs, and `IrModule` held only `functions`. So [#4603](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4603-checkinstr-roadmap-rules)'s `call` / `global.get` / `global.set` rules had to settle for intra-function **coherence** (two references to one binding must agree with each other), which catches the defect class but misses its most common shape: **ONE mistaken reference, perfectly coherent with itself**.

## Decision (AC 1)

Option B — declared tables live **on `IrModule`**, not projected out of `ProgramAbiMap`. That keeps `verifyIrFunction` standalone (no dependency on the prepared pipeline, which the `check:ir-layering` ratchet exists to shrink), avoids conflicting with the in-flight [#3520](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3520-program-abi-map) lane, and matches [#3030](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3030-serializable-ir-interchange)'s self-describing serializable module. Accepted cost: the tables become part of the serialized form under #3030's C2 thread, and preparation gains one more record to cross-check.

## What changed

| | |
| --- | --- |
| `src/ir/declared-types.ts` (new) | The shared structural binding key, the tables derived from a module, and the rules that read them. |
| `src/ir/nodes.ts` | `IrDeclaredSignature`, `IrModuleDeclarations`; `IrModule extends IrModuleDeclarations`. Optional fields — every existing construction site compiles untouched. |
| `src/ir/verify.ts` | `verifyIrFunction(func, domain?, declarations?)` — third parameter, so every existing caller is unchanged. Declaration present ⇒ declaration rule; absent ⇒ #4603 coherence, unchanged. |
| `src/ir/integration.ts` | Producer wired at the two module-level verify sites (post-inline, post-mono/TU). **13 changed lines**, under the issue's 30-line stop-rule. |
| `tests/issue-4605-declared-type-table.test.ts` | 19 tests. |

The substance went into a new subsystem module rather than the two god-files, which is what `check:loc-budget` asks for. `declared-types.ts` imports only *types* from `nodes.ts`, so the edge has no back edge.

## The measurement that changed the design

Wiring the producer in on the first cut demoted **3 previously-IR-compiled functions** (`website/playground/examples/js/async.ts`):

```
call fetchUser resultType externref contradicts the module-declared result f64
```

A **false positive**, not a caught bug: an `async function fetchUser(): Promise<number>` lowers to an `IrFunction` whose `resultTypes` is the *unwrapped* `f64`, while a call site that does not await legitimately receives the Promise as `externref`. Both are correct for the same callee. `async` and `generator` bodies therefore declare no result carrier — **arity is still declared and still checked**. After the guard, `check:ir-fallbacks` is identical to the base run.

This is the argument for wiring the producer rather than shipping with a test-side one: the split is invisible in hand-built fixtures and would otherwise have shipped as a latent conformance loss.

## Verification

| Gate | Result |
| --- | --- |
| `typecheck` (ts7), `format:check` | clean |
| `check:ir-fallbacks` | OK — buckets identical to base (`async-function` 0) |
| `check:ir-only` | READY — 38 units, 38 IR bodies, 0 unsupported |
| `check:linear-ir` | OK — compiled=8 (baseline 8) |
| `check:ir-dialect`, `check:ir-kind-neutrality`, `check:jstag-seam`, `check:ir-layering` | OK |
| New tests | 19/19 |
| `issue-4603-*`, `issue-4523-*`, `tests/ir/**`, `issue-3520-*`, `ir-scaffold` | 269/270 |

**Mutation proof:** with the declaration checks disabled in a scratch build, exactly the 5 declaration-only negatives go silent (19 → 5 failed / 14 passed); every positive, conservative-skip and #4603 coherence test stays green.

The one failing test (`ir-scaffold` selection / `withVar`) is **pre-existing on `origin/main`** — verified by an A/B run with the base files restored, where it fails identically.

## Notes for review

- Budget allowances for `verify.ts` (+31), `nodes.ts` (+25), `integration.ts` (+9) and `compileIrPathFunctions` (+8) are granted in the issue's frontmatter. No `scripts/*-budget-baseline.json` was touched.
- `scripts/ir-kind-neutrality-baseline.json` moves by **one** `declaredAt` line number, shifted by the integration.ts insertions. The nodes.ts declarations were deliberately placed below every instruction-kind declaration so that file's line numbers do not shift.
- **`declaredGlobals` has no production producer yet** — nothing in `integration.ts` records a declared IrType per global, because no such record exists to read. The mechanism, rules and fixtures are in place; in production only `call` is upgraded end to end, and `global.*` still falls back to coherence.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_