### PR TITLE
refactor(abi): #3520 C34 — source-qualified owners for per-field host accessors

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -2,15 +2,15 @@
 id: 3520
 title: "IR-only R1: source-qualified unit identity and whole-program ABI map"
 status: in-progress
-assignee: ttraenkler/codex-r1
-claimed_by: codex-r1
+assignee: ttraenkler/fable-lead
+claimed_by: fable-lead
 claimed_at: 2026-07-21T20:23:19Z
-branch: codex/3520-c29-function-value-abi
-pr: 3799
+branch: claude/issue-3520-r1-completion
+pr: 4722
 last_merged_pr: 3798
 sprint: current
 created: 2026-07-21
-updated: 2026-07-30
+updated: 2026-08-21
 priority: critical
 horizon: l
 complexity: L
@@ -103,6 +103,7 @@ files:
   - src/codegen/closure-exports.ts
   - src/codegen/data-struct-host-bridge.ts
   - src/codegen/struct-field-exports.ts
+  - src/codegen/struct-field-accessor-abi.ts
   - src/codegen/program-abi-signatures.ts
   - src/codegen/program-abi-session.ts
   - src/codegen/program-abi-type-planning.ts
@@ -169,6 +170,7 @@ files:
   - tests/issue-3520-class-method-alias-abi.test.ts
   - tests/issue-3520-closure-host-bridge-abi.test.ts
   - tests/issue-3520-data-struct-host-bridge-abi.test.ts
+  - tests/issue-3520-struct-field-accessor-abi.test.ts
   - tests/issue-3520-module-init-callable-abi.test.ts
   - tests/issue-3520-source-callable-abi.test.ts
   - tests/issue-3520-type-class-abi.test.ts
@@ -1021,27 +1023,81 @@ Commit 3.3 and Commit 4 before R1 can close.
 
 ## Resume checkpoint
 
-- **Branch:** `symphony/3520-r1-planning-identity`
-- **Draft PR:** `#3496`
-- **Resume from:** the branch tip containing Stage 9 / Commit 3.2. The pushed
-  worktree is expected to be clean; no stash or local-only patch is required.
-- **First task:** replace the remaining source-function `byName` tables in
-  `src/ir/passes/inline-small.ts` and `src/ir/passes/monomorphize.ts` with
-  `IrUnitId`/callable-binding maps. Recursion detection, rewrite sites, clone
-  plans, and pass-output reconciliation must all use the same structural key.
-- **Then:** migrate integration verifier/error/pass bookkeeping to IDs, thread
-  support/import bindings through the backend ABI tables, and replace the
-  temporary exact-unit/support-to-legacy-label slot join with `ProgramAbiMap`
-  resolution. Only after those steps should R1 acceptance be reevaluated.
+**Superseded 2026-08-21.** The checkpoint below is the current one. The
+2026-07-21 checkpoint it replaced named a first-task chain
+(`inline-small` / `monomorphize` `byName` tables) that later merged slices
+already completed; it is preserved for history in the Commit 3.3 section.
+
+- **Branch:** `claude/issue-3520-r1-completion` (from `origin/main`
+  `540064dfb`). Prior lane branches `symphony/3520-*` and `codex/3520-c10..c33`
+  are all merged; `codex/3520-branded-instance-api` is a superseded
+  intermediate — `setInstance` is already on main. Do not adopt it.
+- **Resume from:** the branch tip. The worktree is clean; no stash or
+  local-only patch is required.
+- **Completed and verified on main (2026-08-21 re-measurement, not inherited):**
+  - `src/ir/passes/inline-small.ts` and `src/ir/passes/monomorphize.ts` are
+    fully `IrUnitId`-keyed. No `byName` table for source functions survives in
+    either; recursion sets, call-site counts, clone plans, provenance, and edit
+    tables all key on `unitId` / callable binding.
+  - Integration verifier/error/pass bookkeeping is ID-keyed
+    (`src/ir/integration-identity.ts`, `src/ir/integration.ts`). The residual
+    `legacyMatchName` uses are the deliberate validated one-to-one projection,
+    not independent name re-joins.
+  - Support/import bindings reach the backend ABI tables; a compilation-owned
+    `ProgramAbiSession` publishes one program map per module.
+- **Remaining, in order:**
+  1. **Retire the positional `retained-module-function` fallback.** This is the
+     concrete residue of "replace the temporary support-to-legacy-label slot
+     join with `ProgramAbiMap` resolution". Its derived ordinal IS the final
+     function index (`src/codegen/program-abi-callable-planning.ts`
+     `planRetained`), so identity moves whenever an unrelated import or
+     function is added or removed. C30–C34 each moved one family off it.
+     Measured on the five `SINGLE_HOST_ENTRIES` at `540064dfb`: **40** generic
+     rows; after C34, **15**. The 15 that remain, by family:
+     - `__sget_*`/`__sset_*`/`__shas_*`/`__sbool_*` — **done in C34**;
+     - `__\0js2_call_fn_method_argc_0..5` (6 rows) — the higher-arity method
+       dispatchers C31 explicitly deferred;
+     - `__async_resume_*` (2) and `__cb_0..3` (4) — async resume/callback
+       machinery;
+     - `__vec_from_extern_4` (1);
+     - `__math_reduce_trig` and `Math_atan` (2) — math support helpers.
+  2. Route the remaining direct `funcMap` / `structMap` / module-array /
+     display-name scans in concrete WasmGC, linear, and compatibility-slot
+     resolution through `LegacyAbiAdapter` (Commit 4 body).
+  3. Represent exports as explicit Program ABI aliases rather than emitting
+     them directly from legacy codegen.
+  4. Notify the production session from allocator replacement, dead-type
+     elimination, and compaction.
 - **Do not touch:** `benchmarks/results/test262-run.log` or
   `scripts/equivalence-baseline.json`. No local Test262 run is required for
   this checkpoint.
-- **Known unrelated control:** two #2956 L3 string/charCode fixtures remain
-  pre-existing failures; binding-affected linear cases and the 29-case
-  cross-backend suite pass.
-- **Not rerun after Stage 9:** the full equivalence gate and fallback/readiness
-  ratchets. Run them before declaring R1 complete; do not infer completion from
-  the focused matrices below.
+- **Known-base controls, re-measured 2026-08-21 (do NOT inherit the old
+  values):**
+  - The issue's own control command
+    (`tests/issue-1983-funcmap-collision.test.ts` + `tests/ir/inline-small.test.ts`)
+    is now **22/22 GREEN** on `540064dfb`. The "not expected green" note under
+    *Required completion evidence* is stale: the #1983 type-index and
+    inline-small harness failures it describes have been fixed on main.
+  - **17 of this issue's own 60 `tests/issue-3520-*.test.ts` files are RED on
+    current main**, 22 failing tests, and the failing file/test sets are
+    byte-identical on `540064dfb` and on this branch. They are main-side drift,
+    not regressions. The bulk are the C30–C33 five-entry census assertions
+    carrying 2026-07-30 denominators (166 defined functions / 45 generic / 24
+    vec / 26 closure / 1 date / 5 data) against a main that now measures 139
+    defined functions and emits **zero** vec/closure/date/data host-bridge rows
+    for those entries. Four are semantic drift:
+    `issue-3520-module-binding-class-identity` (a planning invariant no longer
+    raised), `issue-3520-lowering-plan-identity` (a capability violation now
+    thrown ahead of the expected stale-owner error),
+    `issue-3520-context-integration`, and
+    `issue-3520-integration-population-identity`. **Re-baselining these is
+    prerequisite work for any R1 acceptance claim** — the acceptance criteria
+    cannot be evaluated against a suite that does not run green.
+- **Vitest heap note:** the *Required completion evidence* command uses
+  `--poolOptions.forks.singleFork=true`, which puts all six files in one fork.
+  The repo pins forks to a 512 MB old space (`vitest.config.ts`), so the
+  command OOMs in that mode regardless of the change under test. Run it with
+  `VITEST_FORK_MAX_OLD_SPACE_SIZE=4096`.
 
 ### 2026-07-25 resume state
 
@@ -2823,6 +2879,86 @@ C33 closes exact retained ownership for these two data-struct host helpers, not
 R1. Per-field accessors and other support callable families remain on their
 existing ownership paths.
 
+### 2026-08-21 per-field host accessor ownership continuation (C34)
+
+The C34 continuation on `claude/issue-3520-r1-completion` moves the per-field
+host accessor family — the population C33 named as the next one — behind one
+canonical entry-source-owned role.
+
+- `__sget_<field>`, `__sset_<field>`, `__shas_<field>`, and `__sbool_<field>`
+  publish `struct-field-accessor` support bindings at callable role ordinal
+  **14**. Identity is `(entry source, "struct-field-accessor", ordinal)` with
+  `ordinal = fieldPosition * 4 + kind`, where `kind` is
+  `get:0 / set:1 / has:2 / bool:3` and `fieldPosition` is the field name's index
+  in the module's canonically **sorted** accessor field-name list. The
+  four-wide stride reserves one slot per kind per field, so no two fields can
+  overlap.
+- Two properties follow from deriving the ordinal that way, and both are
+  asserted rather than argued. The ordinal does not depend on the order the
+  emitters visited fields — reversing the input to
+  `structFieldAccessorFieldOrder` yields the identical order. And it does not
+  depend on the function's index: adding three unrelated exported functions
+  ahead of the accessors moves every final index while leaving all seven
+  accessor binding IDs unchanged. Under the generic
+  `retained-module-function` fallback the derived ordinal **is** the final
+  index, so that same shift used to rewrite the identity.
+- The display name stays a diagnostic label. `irSupportFuncRef` excludes it
+  from the binding key, proven directly: the same role and ordinal with a
+  deliberately unrelated label produce the identical `IrBindingId`, while a
+  different ordinal produces a different one. A same-spelled source function
+  therefore cannot occupy the role.
+- Recording is deliberately split from planning. `emitStructFieldGetters` and
+  `emitStructFieldSetters` wrap their bodies in a non-fatal `try`/`catch`, so a
+  `ProgramAbiInvariantError` raised inside them would be swallowed and the
+  compile would return a successful module whose accessor family had no owner —
+  the same failure mode C30 closed for the vec bridges. `recordStructFieldAccessor`
+  cannot throw; `observeStructFieldAccessorAbi` runs from
+  `eliminateDeadLayoutAndPlanProgramAbi`, after DCE has settled the layout and
+  before the generic sweep, so an eliminated accessor is simply absent instead
+  of claiming a slot that is gone.
+
+**Census, measured in fresh processes on both sides** (`readFileSync(entry) ->
+analyzeSource(source, entry) -> generateModule(ast, { experimentalIR: true,
+trackIrOutcomes: true })` over `SINGLE_HOST_ENTRIES`), base `origin/main`
+`540064dfb` versus this branch:
+
+| Measure                                  | base `540064dfb` | C34     |
+| ---------------------------------------- | ---------------- | ------- |
+| defined functions                        | 139              | 139     |
+| generic `retained-module-function` rows  | 40               | **15**  |
+| `struct-field-accessor` rows             | 0                | **25**  |
+| terminal / emitted / unsupported / invariant | 37 / 32 / 5 / 0 | 37 / 32 / 5 / 0 |
+
+The 25 rows are **moved, not created**: defined-function count and every
+routing figure are unchanged. The 25 are the `async.ts` state-slot accessors
+(13 `__sget_*` + 12 `__sset_*`), which were 62.5 % of the remaining generic
+bucket.
+
+**Byte identity.** All five entries were emitted through `emitBinary` in both
+tracked and untracked lanes on the base copies and on this branch; all twenty
+sha256 digests match, so this landing changes ownership only. `check:ir-only
+--policy=hybrid` and `check:ir-fallbacks --verbose` produce **byte-identical
+output** on base and branch (READY, 38 terminal / 38 emitted / 0 unsupported /
+0 invariants per lane; no unintended, post-claim, or module-level increase).
+
+**Validation.** The focused C34 suite passes **7/7**. The issue's expected-green
+gate command passes **66/66** (with `VITEST_FORK_MAX_OLD_SPACE_SIZE=4096`; see
+the resume checkpoint's heap note), cross-backend differential **29/29**, and
+the known-base control matrix **22/22** on both base and branch. Strict
+TypeScript, full Biome lint, Prettier, LOC budget, function budget,
+oracle ratchet (`+0 / +0`), and dead-export (**19 known / 0 new**) all pass.
+The full 62-file `issue-3520-*` + backend-contract + `#1899` matrix reports the
+**identical 17 failing files / 22 failing tests on base and on branch** — see
+the resume checkpoint for why those are main-side drift and why re-baselining
+them gates R1 acceptance. The equivalence gate reports no new regressions on
+either side; the 12 baseline failures that now pass are pre-existing main-side
+drift and the baseline is deliberately left unchanged in this ownership-only
+slice.
+
+C34 closes exact retained ownership for the per-field host accessor family, not
+R1. The 15 remaining generic rows, the direct `funcMap`/`structMap`/module-array
+scans, and export aliasing are enumerated in the resume checkpoint.
+
 ### R1a validation evidence
 
 - Representative inventory denominator: **1 source / 2 classes / 12 allUnits /
@@ -2994,6 +3130,19 @@ and inline-small harness/expectation failures remain. Completion requires the
 exact test/failure set and diagnostics to match the pre-branch control, with no
 new failure. Do not combine it with the expected-green command or report the
 combined exit status as a green gate.
+
+**Correction, measured 2026-08-21 at `origin/main` `540064dfb`: this control is
+now GREEN at 22/22.** The #1983 type-index and inline-small harness failures it
+describes have since been fixed on main. The rule above still stands as
+written — match the pre-branch control exactly — but the expected control state
+is now "green on both sides", and a red control run today is a real finding, not
+the documented known base.
+
+**Heap note:** the expected-green command pins
+`--poolOptions.forks.singleFork=true`, which loads all six files into one fork.
+`vitest.config.ts` pins forks to a 512 MB old space, so the command OOMs in
+that mode independently of the change under test. Prefix it with
+`VITEST_FORK_MAX_OLD_SPACE_SIZE=4096`.
 
 The PR report must include the source/unit/class/binding denominators, a
 collision matrix, deterministic-order proof, old-vs-new telemetry diff, and

--- a/src/codegen/program-abi-finalization.ts
+++ b/src/codegen/program-abi-finalization.ts
@@ -3,6 +3,7 @@
 import type { CodegenContext } from "./context/types.js";
 import { eliminateDeadImports } from "./dead-elimination.js";
 import { planProgramAbiCallableImports } from "./program-abi-import-planning.js";
+import { observeStructFieldAccessorAbi } from "./struct-field-accessor-abi.js";
 
 /**
  * Settle allocator layout, then publish every retained Program ABI population.
@@ -12,10 +13,16 @@ import { planProgramAbiCallableImports } from "./program-abi-import-planning.js"
  * retained class bodies/helpers recover their exact source/class owners before
  * generic callable population; total callable/global owners then exist before
  * exports alias them; type cells publish last from the same compacted layout.
+ *
+ * (#3520 C34) The per-field host accessor family is observed here, after DCE
+ * has settled the layout and before the generic `retained-module-function`
+ * fallback runs — so an accessor the module no longer contains is simply absent
+ * rather than claiming a slot that is gone.
  */
 export function eliminateDeadLayoutAndPlanProgramAbi(ctx: CodegenContext): void {
   eliminateDeadImports(ctx.mod, ctx);
   planProgramAbiCallableImports(ctx);
+  observeStructFieldAccessorAbi(ctx);
   ctx.programAbiCallableProviders?.planRetained();
   ctx.programAbiClassCallables?.planRetained();
   ctx.programAbiModuleInitCallables?.planRetained();

--- a/src/codegen/program-abi-planning.ts
+++ b/src/codegen/program-abi-planning.ts
@@ -37,6 +37,11 @@ export const PROGRAM_ABI_CALLABLE_ROLE = Object.freeze({
   // the guard that keeps it that way.
   callableProvider: 12,
   classConstructorNew: 13,
+  // (#3520 C34) Per-field host accessors (`__sget_*` / `__sset_*` / `__shas_*` /
+  // `__sbool_*`). See struct-field-accessor-abi.ts for the derived-ordinal
+  // encoding; the family was previously the largest population left on the
+  // positional `retainedModuleFunction` fallback.
+  structFieldAccessor: 14,
 } as const);
 
 /**

--- a/src/codegen/struct-field-accessor-abi.ts
+++ b/src/codegen/struct-field-accessor-abi.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// struct-field-accessor-abi.ts — #3520 C34.
+//
+// The per-field host accessor family (`__sget_<f>`, `__sset_<f>`, `__shas_<f>`,
+// `__sbool_<f>`) was the last large population of defined functions with no
+// semantic Program ABI owner. Without an owner each accessor fell through to the
+// generic `retained-module-function` role, whose derived ordinal is the
+// function's FINAL INDEX — a value that moves whenever any unrelated import or
+// function is added or eliminated. That is a positional label, not an identity,
+// and it is exactly what R1 exists to remove.
+//
+// This module gives the family one canonical entry-source-owned role. Identity
+// is `(entry source, "struct-field-accessor", ordinal)` where the ordinal is
+// derived from the accessor KIND plus the field name's position in the
+// module's canonically SORTED accessor field-name list. Two consequences follow
+// and are both covered by tests:
+//
+//   * the ordinal does not depend on emission order, so reversing the order in
+//     which the emitters visit fields cannot change an identity; and
+//   * the ordinal does not depend on the function's index, so a late import or
+//     a dead-slot compaction cannot move it.
+//
+// The display name (`__sget_value`) stays a label. It never participates in the
+// binding key, so a user function spelled the same way cannot occupy the role.
+
+import type { WasmFunction } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncHandleOf } from "./func-space.js";
+import { PROGRAM_ABI_CALLABLE_ROLE } from "./program-abi-planning.js";
+import type { ProgramAbiEntrySourceSupportObservation } from "./program-abi-callable-planning.js";
+
+export const STRUCT_FIELD_ACCESSOR_ROLE = "struct-field-accessor";
+
+/**
+ * Accessor kinds in one closed table.
+ *
+ * The value is the low component of the derived ordinal, so it must stay stable
+ * and must never exceed {@link STRUCT_FIELD_ACCESSOR_KIND_STRIDE}.
+ */
+export const STRUCT_FIELD_ACCESSOR_KIND = Object.freeze({
+  get: 0,
+  set: 1,
+  has: 2,
+  bool: 3,
+} as const);
+
+export type StructFieldAccessorKind = keyof typeof STRUCT_FIELD_ACCESSOR_KIND;
+
+/** Ordinal stride reserved per field name. Must exceed every kind value. */
+export const STRUCT_FIELD_ACCESSOR_KIND_STRIDE = 4;
+
+interface RecordedStructFieldAccessor {
+  readonly kind: StructFieldAccessorKind;
+  readonly fieldName: string;
+  readonly func: WasmFunction;
+}
+
+const recordedStructFieldAccessors = new WeakMap<CodegenContext, RecordedStructFieldAccessor[]>();
+const observedStructFieldAccessorContexts = new WeakSet<CodegenContext>();
+
+/**
+ * Record one emitted accessor by its EXACT allocator object.
+ *
+ * Recording is deliberately separate from planning: the getter and setter
+ * emitters are wrapped in a non-fatal `try`/`catch`, so a Program ABI invariant
+ * raised inside them would be swallowed and the compile would silently return a
+ * module whose accessor family had no owner. Recording cannot throw; the
+ * observation pass that can runs outside those guards.
+ */
+export function recordStructFieldAccessor(
+  ctx: CodegenContext,
+  kind: StructFieldAccessorKind,
+  fieldName: string,
+  func: WasmFunction,
+): void {
+  if (fieldName.length === 0) return;
+  let recorded = recordedStructFieldAccessors.get(ctx);
+  if (!recorded) {
+    recorded = [];
+    recordedStructFieldAccessors.set(ctx, recorded);
+  }
+  recorded.push({ kind, fieldName, func });
+}
+
+/**
+ * Canonical field-name order for the accessor family.
+ *
+ * Sorted by UTF-16 code unit, which is total over the recorded names and
+ * independent of the order the emitters happened to visit them in.
+ */
+export function structFieldAccessorFieldOrder(fieldNames: Iterable<string>): readonly string[] {
+  return [...new Set(fieldNames)].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
+/** Derived ordinal for one accessor within the canonical field order. */
+export function structFieldAccessorDerivedOrdinal(
+  fieldOrder: readonly string[],
+  kind: StructFieldAccessorKind,
+  fieldName: string,
+): number | undefined {
+  const position = fieldOrder.indexOf(fieldName);
+  if (position < 0) return undefined;
+  return position * STRUCT_FIELD_ACCESSOR_KIND_STRIDE + STRUCT_FIELD_ACCESSOR_KIND[kind];
+}
+
+/**
+ * Hand the recorded family to the retained-callable registry as one batch.
+ *
+ * Runs after dead-import/function elimination has settled the final layout, so
+ * an accessor the module no longer contains is simply absent rather than
+ * claimed as an owner of a slot that is gone. Duplicate (kind, field) records
+ * for the same exact function are collapsed; a duplicate carrying a DIFFERENT
+ * function object is left to the registry's contradictory-ownership invariant.
+ */
+export function observeStructFieldAccessorAbi(ctx: CodegenContext): void {
+  if (observedStructFieldAccessorContexts.has(ctx)) return;
+  const registry = ctx.programAbiCallables;
+  if (!registry) return;
+  const recorded = recordedStructFieldAccessors.get(ctx);
+  if (!recorded || recorded.length === 0) return;
+  observedStructFieldAccessorContexts.add(ctx);
+
+  const live = recorded.filter((entry) => definedFuncHandleOf(ctx, entry.func) !== undefined);
+  if (live.length === 0) return;
+
+  const fieldOrder = structFieldAccessorFieldOrder(live.map((entry) => entry.fieldName));
+  const observations: ProgramAbiEntrySourceSupportObservation[] = [];
+  const claimed = new Map<number, WasmFunction>();
+  for (const entry of live) {
+    const derivedOrdinal = structFieldAccessorDerivedOrdinal(fieldOrder, entry.kind, entry.fieldName);
+    if (derivedOrdinal === undefined) continue;
+    // An identical re-record of the same exact object is inert. A SECOND object
+    // claiming one (kind, field) slot is a real ownership contradiction, so it
+    // is forwarded and the registry's duplicate-slot invariant rejects it.
+    if (claimed.get(derivedOrdinal) === entry.func) continue;
+    claimed.set(derivedOrdinal, entry.func);
+    const funcIdx = definedFuncHandleOf(ctx, entry.func);
+    if (funcIdx === undefined) continue;
+    observations.push({
+      role: STRUCT_FIELD_ACCESSOR_ROLE,
+      roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.structFieldAccessor,
+      derivedOrdinal,
+      displayName: entry.func.name,
+      funcIdx,
+    });
+  }
+  if (observations.length === 0) return;
+  registry.observeEntrySourceSupports(observations);
+}

--- a/src/codegen/struct-field-exports.ts
+++ b/src/codegen/struct-field-exports.ts
@@ -19,6 +19,7 @@ import { presenceSlotOf, presenceTestInstrs } from "./fnctor-presence-bits.js";
 import { UNDEF_F64_BITS } from "./value-tags.js";
 import { DATA_STRUCT_HOST_BRIDGE_ORDINAL, publishDataStructHostBridge } from "./data-struct-host-bridge.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+import { recordStructFieldAccessor } from "./struct-field-accessor-abi.js"; // (#3520 C34) structural ownership
 
 /**
  * Emit exported getter/setter helper functions so the JS runtime can read
@@ -103,13 +104,15 @@ export function emitStructFieldPresenceGetters(ctx: CodegenContext): void {
 
     const funcName = `__shas_${fieldName}`;
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({
+    const presenceFunc = {
       name: funcName,
       typeIdx,
       locals: [{ name: "__any", type: { kind: "anyref" } }],
       body: [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "local.set", index: 1 }, ...dispatch],
       exported: true,
-    } as WasmFunction);
+    } as WasmFunction;
+    ctx.mod.functions.push(presenceFunc);
+    recordStructFieldAccessor(ctx, "has", fieldName, presenceFunc);
     ctx.mod.exports.push({ name: funcName, desc: { kind: "func", index: funcIdx } });
   }
 }
@@ -127,13 +130,15 @@ export function emitStructFieldBooleanMarkers(ctx: CodegenContext): void {
   for (const fieldName of [...ctx.booleanPropertyNames].sort()) {
     const funcName = `__sbool_${fieldName}`;
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({
+    const markerFunc = {
       name: funcName,
       typeIdx,
       locals: [],
       body: [{ op: "i32.const", value: 1 }],
       exported: true,
-    } as WasmFunction);
+    } as WasmFunction;
+    ctx.mod.functions.push(markerFunc);
+    recordStructFieldAccessor(ctx, "bool", fieldName, markerFunc);
     ctx.mod.exports.push({ name: funcName, desc: { kind: "func", index: funcIdx } });
   }
 }
@@ -316,13 +321,15 @@ function _emitStructFieldGettersInner(ctx: CodegenContext): void {
     const locals: { name: string; type: ValType }[] = [{ name: "__any", type: { kind: "anyref" } }];
     if (useSentinel) locals.push({ name: "__sent_f64", type: { kind: "f64" } });
 
-    mod.functions.push({
+    const getterFunc = {
       name: funcName,
       typeIdx: getterTypeIdx,
       locals,
       body: funcBody,
       exported: true,
-    } as WasmFunction);
+    } as WasmFunction;
+    mod.functions.push(getterFunc);
+    recordStructFieldAccessor(ctx, "get", fieldName, getterFunc);
 
     mod.exports.push({
       name: funcName,
@@ -540,7 +547,7 @@ function _emitStructFieldSettersInner(ctx: CodegenContext): void {
       unboxSymbolIdx,
     );
 
-    mod.functions.push({
+    const setterFunc = {
       name: funcName,
       typeIdx: setterTypeIdx,
       locals: [
@@ -549,7 +556,9 @@ function _emitStructFieldSettersInner(ctx: CodegenContext): void {
       ],
       body: funcBody,
       exported: true,
-    } as WasmFunction);
+    } as WasmFunction;
+    mod.functions.push(setterFunc);
+    recordStructFieldAccessor(ctx, "set", fieldName, setterFunc);
 
     mod.exports.push({
       name: funcName,

--- a/tests/issue-3520-struct-field-accessor-abi.test.ts
+++ b/tests/issue-3520-struct-field-accessor-abi.test.ts
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SINGLE_HOST_ENTRIES } from "../scripts/check-ir-only.js";
+import { analyzeSource } from "../src/checker/index.js";
+import { generateModule } from "../src/codegen/index.js";
+import {
+  programAbiCallableRoleOrdinalsAreDistinct,
+  PROGRAM_ABI_CALLABLE_ROLE,
+} from "../src/codegen/program-abi-planning.js";
+import {
+  STRUCT_FIELD_ACCESSOR_ROLE,
+  STRUCT_FIELD_ACCESSOR_KIND,
+  STRUCT_FIELD_ACCESSOR_KIND_STRIDE,
+  structFieldAccessorDerivedOrdinal,
+  structFieldAccessorFieldOrder,
+  type StructFieldAccessorKind,
+} from "../src/codegen/struct-field-accessor-abi.js";
+import { irSupportFuncRef } from "../src/ir/callable-bindings.js";
+import { buildIrUnitInventory, createIrBindingId } from "../src/ir/identity.js";
+import { emitBinary } from "../src/emit/binary.js";
+
+// Register the expression/statement delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+const RETAINED_MODULE_FUNCTION_ROLE = "retained-module-function";
+
+const POINT_SOURCE = `
+class Point {
+  x: number;
+  y: number;
+  visible: boolean;
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+    this.visible = true;
+  }
+}
+export function make(a: number, b: number): Point {
+  return new Point(a, b);
+}
+export function shift(p: Point): number {
+  p.x = p.x + 1;
+  return p.x;
+}
+`;
+
+/** Same struct shape, but three extra source functions ahead of the accessors. */
+const POINT_SOURCE_WITH_EXTRA_FUNCTIONS = `${POINT_SOURCE}
+export function extraOne(v: number): number {
+  return v + 1;
+}
+export function extraTwo(v: number): number {
+  return v + 2;
+}
+export function extraThree(v: number): number {
+  return v + 3;
+}
+`;
+
+interface AbiEntryView {
+  readonly id: string;
+  readonly displayName?: string;
+  readonly intent?: { readonly kind?: string };
+}
+
+function hardErrors(result: ReturnType<typeof generateModule>) {
+  return result.errors.filter((error) => error.severity !== "warning");
+}
+
+function compileFixture(source: string, fileName: string, trackIrOutcomes = true) {
+  const ast = analyzeSource(source, fileName);
+  const result = generateModule(ast, { experimentalIR: true, trackIrOutcomes });
+  expect(
+    hardErrors(result),
+    hardErrors(result)
+      .map((error) => error.message)
+      .join("\n"),
+  ).toEqual([]);
+  return result;
+}
+
+function abiEntries(result: ReturnType<typeof generateModule>): readonly AbiEntryView[] {
+  const publication = (result as unknown as { programAbi?: { abi: { entries(): readonly AbiEntryView[] } } })
+    .programAbi;
+  expect(publication, "compilation published no Program ABI").toBeDefined();
+  return publication!.abi.entries();
+}
+
+function entrySourceId(source: string, fileName: string): string {
+  const ast = analyzeSource(source, fileName);
+  return buildIrUnitInventory([ast.sourceFile], {
+    entrySource: ast.sourceFile,
+    checker: ast.checker,
+  }).sources.find((candidate) => candidate.kind === "entry")!.id;
+}
+
+function accessorBindingId(sourceId: string, kind: StructFieldAccessorKind, fieldOrderPosition: number): string {
+  return createIrBindingId({
+    ownerId: sourceId as never,
+    domain: "support",
+    role: STRUCT_FIELD_ACCESSOR_ROLE,
+    ordinal: fieldOrderPosition * STRUCT_FIELD_ACCESSOR_KIND_STRIDE + STRUCT_FIELD_ACCESSOR_KIND[kind],
+  });
+}
+
+/**
+ * Callable rows only. An export alias carries the same `displayName` as the
+ * callable it aliases, so an unfiltered name match sees two rows per accessor.
+ */
+function callableRowsForRole(entries: readonly AbiEntryView[], role: string): readonly AbiEntryView[] {
+  return entries.filter((entry) => entry.intent?.kind === "callable" && String(entry.id).includes(`:${role}:`));
+}
+
+describe("#3520 C34 per-field host accessor Program ABI ownership", () => {
+  it("gives every emitted per-field accessor an exact entry-source structural owner", () => {
+    const result = compileFixture(POINT_SOURCE, "issue-3520-struct-field-accessor.ts");
+    const entries = abiEntries(result);
+    const sourceId = entrySourceId(POINT_SOURCE, "issue-3520-struct-field-accessor.ts");
+
+    // Canonical sorted field order for this fixture: visible(0), x(1), y(2).
+    const expected = new Map<string, string>([
+      ["__sget_visible", accessorBindingId(sourceId, "get", 0)],
+      ["__sset_visible", accessorBindingId(sourceId, "set", 0)],
+      ["__sbool_visible", accessorBindingId(sourceId, "bool", 0)],
+      ["__sget_x", accessorBindingId(sourceId, "get", 1)],
+      ["__sset_x", accessorBindingId(sourceId, "set", 1)],
+      ["__sget_y", accessorBindingId(sourceId, "get", 2)],
+      ["__sset_y", accessorBindingId(sourceId, "set", 2)],
+    ]);
+
+    const emittedAccessors = result.module.functions
+      .map((func) => func.name)
+      .filter((name) => /^__(sget|sset|shas|sbool)_/.test(name));
+    expect(new Set(emittedAccessors)).toEqual(new Set(expected.keys()));
+
+    for (const [displayName, bindingId] of expected) {
+      const owners = entries.filter((entry) => entry.intent?.kind === "callable" && entry.displayName === displayName);
+      expect(
+        owners.map((entry) => entry.id),
+        `callable owners for ${displayName}`,
+      ).toEqual([bindingId]);
+    }
+
+    // The whole family left the positional fallback: no accessor is generic.
+    const genericAccessorRows = callableRowsForRole(entries, RETAINED_MODULE_FUNCTION_ROLE).filter((entry) =>
+      /^__(sget|sset|shas|sbool)_/.test(entry.displayName ?? ""),
+    );
+    expect(genericAccessorRows).toEqual([]);
+  });
+
+  it("derives the ordinal from canonical field order, never from emission order", () => {
+    const forward = structFieldAccessorFieldOrder(["y", "x", "visible"]);
+    const reversed = structFieldAccessorFieldOrder(["visible", "x", "y"].reverse());
+    expect(forward).toEqual(["visible", "x", "y"]);
+    expect(reversed).toEqual(forward);
+
+    // Kinds occupy distinct low components inside one field's reserved stride.
+    expect(structFieldAccessorDerivedOrdinal(forward, "get", "visible")).toBe(0);
+    expect(structFieldAccessorDerivedOrdinal(forward, "set", "visible")).toBe(1);
+    expect(structFieldAccessorDerivedOrdinal(forward, "has", "visible")).toBe(2);
+    expect(structFieldAccessorDerivedOrdinal(forward, "bool", "visible")).toBe(3);
+    expect(structFieldAccessorDerivedOrdinal(forward, "get", "x")).toBe(4);
+    expect(structFieldAccessorDerivedOrdinal(forward, "get", "y")).toBe(8);
+    expect(structFieldAccessorDerivedOrdinal(forward, "get", "absent")).toBeUndefined();
+
+    // Every kind fits inside the reserved stride, so no two fields overlap.
+    for (const kind of Object.values(STRUCT_FIELD_ACCESSOR_KIND)) {
+      expect(kind).toBeLessThan(STRUCT_FIELD_ACCESSOR_KIND_STRIDE);
+    }
+  });
+
+  it("keeps accessor identity fixed while unrelated growth moves every final index", () => {
+    const base = compileFixture(POINT_SOURCE, "issue-3520-struct-field-accessor-stability.ts");
+    const grown = compileFixture(POINT_SOURCE_WITH_EXTRA_FUNCTIONS, "issue-3520-struct-field-accessor-stability.ts");
+
+    const accessorIds = (result: ReturnType<typeof generateModule>) =>
+      callableRowsForRole(abiEntries(result), STRUCT_FIELD_ACCESSOR_ROLE)
+        .map((entry) => entry.id)
+        .sort();
+
+    expect(accessorIds(base)).toHaveLength(7);
+    // Same struct shape ⇒ identical accessor identities, even though the module
+    // now contains three more source functions ahead of them.
+    expect(accessorIds(grown)).toEqual(accessorIds(base));
+
+    // Control: the positions really did move. Under the old positional
+    // `retained-module-function` fallback the derived ordinal IS the final
+    // index, so this shift is exactly what used to rewrite the identity.
+    const finalIndexOf = (result: ReturnType<typeof generateModule>, name: string) =>
+      result.module.functions.findIndex((func) => func.name === name);
+    expect(grown.module.functions.length).toBeGreaterThan(base.module.functions.length);
+    expect(finalIndexOf(grown, "__sget_x")).not.toBe(finalIndexOf(base, "__sget_x"));
+  });
+
+  it("keys the binding by role and ordinal only — the display label is not part of it", () => {
+    const sourceId = entrySourceId(POINT_SOURCE, "issue-3520-struct-field-accessor-label.ts");
+    const labelled = irSupportFuncRef(sourceId as never, STRUCT_FIELD_ACCESSOR_ROLE, "__sget_x", 4);
+    const differentLabel = irSupportFuncRef(sourceId as never, STRUCT_FIELD_ACCESSOR_ROLE, "totally-unrelated", 4);
+    expect(labelled.binding.kind).toBe("support");
+    expect(differentLabel.binding.kind).toBe("support");
+    if (labelled.binding.kind !== "support" || differentLabel.binding.kind !== "support") return;
+    expect(differentLabel.binding.bindingId).toBe(labelled.binding.bindingId);
+
+    // A different ordinal is a different binding — the ordinal really is the key.
+    const otherOrdinal = irSupportFuncRef(sourceId as never, STRUCT_FIELD_ACCESSOR_ROLE, "__sget_x", 5);
+    if (otherOrdinal.binding.kind !== "support") return;
+    expect(otherOrdinal.binding.bindingId).not.toBe(labelled.binding.bindingId);
+  });
+
+  it("reserves a distinct callable role ordinal", () => {
+    expect(programAbiCallableRoleOrdinalsAreDistinct()).toBe(true);
+    expect(PROGRAM_ABI_CALLABLE_ROLE.structFieldAccessor).toBe(14);
+  });
+
+  it("keeps tracked and untracked binaries byte-identical", () => {
+    const untracked = compileFixture(POINT_SOURCE, "issue-3520-struct-field-accessor-bytes.ts", false);
+    const tracked = compileFixture(POINT_SOURCE, "issue-3520-struct-field-accessor-bytes.ts", true);
+    expect(Buffer.from(emitBinary(tracked.module))).toEqual(Buffer.from(emitBinary(untracked.module)));
+  });
+
+  it("moves the per-field accessor rows off generic ownership across the five host entries", () => {
+    let definedFunctions = 0;
+    let genericRows = 0;
+    let accessorRows = 0;
+    let terminalUnits = 0;
+    let emitted = 0;
+    let unsupported = 0;
+    let invariants = 0;
+
+    for (const entry of SINGLE_HOST_ENTRIES) {
+      const source = readFileSync(resolve(entry), "utf8");
+      const ast = analyzeSource(source, entry);
+      const result = generateModule(ast, { experimentalIR: true, trackIrOutcomes: true });
+      expect(
+        hardErrors(result),
+        `${entry}\n${hardErrors(result)
+          .map((error) => error.message)
+          .join("\n")}`,
+      ).toEqual([]);
+      definedFunctions += result.module.functions.length;
+      const entries = abiEntries(result);
+      genericRows += entries.filter((candidate) => candidate.id.includes(RETAINED_MODULE_FUNCTION_ROLE)).length;
+      accessorRows += entries.filter((candidate) => candidate.id.includes(STRUCT_FIELD_ACCESSOR_ROLE)).length;
+      for (const outcome of result.irOutcomes ?? []) {
+        terminalUnits++;
+        if (outcome.kind === "emitted") emitted++;
+        if (outcome.kind === "unsupported") unsupported++;
+        if (outcome.kind === "invariant") invariants++;
+      }
+    }
+
+    // Measured on this branch and on its exact base (origin/main 540064dfb):
+    // the base census is 139 defined functions / 40 generic rows / 0 accessor
+    // rows. The 25 accessor rows are moved, not created — routing is untouched.
+    expect({ definedFunctions, genericRows, accessorRows }).toEqual({
+      definedFunctions: 139,
+      genericRows: 15,
+      accessorRows: 25,
+    });
+    expect({ terminalUnits, emitted, unsupported, invariants }).toEqual({
+      terminalUnits: 37,
+      emitted: 32,
+      unsupported: 5,
+      invariants: 0,
+    });
+  });
+});


### PR DESCRIPTION
Continues [#3520](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3520-ir-r1-source-qualified-identity-program-abi) (IR-only R1). This is the C34 slice plus a re-measured resume checkpoint; **it does not close R1** and the issue stays `in-progress`.

> **Note for the reviewer:** this PR was opened as a **draft** and was un-drafted and enqueued by automation, not by me. Commit `ef2a89e2d` on my worktree — a factual correction to the issue file plus the cross-target byte-identity result — could not be pushed because the branch is queue-locked. It is described under "Correction" below and will be pushed as soon as the branch is writable. The **code diff is unaffected**; the pending commit touches only `plan/issues/3520-…md`.

## What this changes

The per-field host accessor family — `__sget_<f>`, `__sset_<f>`, `__shas_<f>`, `__sbool_<f>` — was the largest population of defined functions with no semantic Program ABI owner. Each fell through to the generic `retained-module-function` role, whose derived ordinal **is the function's final index** (`program-abi-callable-planning.ts` `planRetained`). That value moves whenever any unrelated import or function is added or eliminated, so it is a positional label rather than an identity — exactly the class of assumption R1 exists to remove.

The family now has one canonical entry-source-owned role at callable role ordinal 14. Identity is `(entry source, "struct-field-accessor", ordinal)` with `ordinal = fieldPosition * 4 + kind`, where `kind` is `get:0 / set:1 / has:2 / bool:3` and `fieldPosition` is the field name's index in the module's canonically **sorted** accessor field-name list.

Recording is deliberately split from planning. `emitStructFieldGetters` / `emitStructFieldSetters` wrap their bodies in a non-fatal `try`/`catch`, so an ABI invariant raised inside them would be swallowed and the compile would return a successful module whose accessor family had no owner — the same failure mode C30 closed for the vec bridges. `recordStructFieldAccessor` cannot throw; `observeStructFieldAccessorAbi` runs from `eliminateDeadLayoutAndPlanProgramAbi`, after DCE has settled the layout and before the generic sweep, so an eliminated accessor is simply absent instead of claiming a slot that is gone.

## Denominators

Measured in fresh processes on both sides (`readFileSync(entry)` → `analyzeSource` → `generateModule({experimentalIR: true, trackIrOutcomes: true})` over the five `SINGLE_HOST_ENTRIES`), base `origin/main` `540064dfb` versus this branch:

| Measure | base `540064dfb` | this branch |
| --- | --- | --- |
| defined functions | 139 | 139 |
| generic `retained-module-function` rows | 40 | **15** |
| `struct-field-accessor` rows | 0 | **25** |
| `vec-host-bridge` rows | 24 | 24 |
| `closure-host-bridge` rows | 14 | 14 |
| `date-civil-support` rows | 1 | 1 |
| `data-struct-host-bridge` rows | 3 | 3 |
| terminal / emitted / unsupported / invariant | 37 / 32 / 5 / 0 | 37 / 32 / 5 / 0 |

The 25 rows are **moved, not created** — defined-function count, every other structural family, and every routing figure are unchanged. They are the `async.ts` state-slot accessors (13 `__sget_*` + 12 `__sset_*`), 62.5 % of the remaining generic bucket.

## Collision matrix / determinism / byte identity

- **Label is not a key.** The same role + ordinal with a deliberately unrelated display label produces the identical `IrBindingId`; a different ordinal produces a different one. A same-spelled source function cannot occupy the role.
- **Kind separation.** `get`/`set`/`has`/`bool` on one field name occupy four distinct reserved ordinals inside that field's stride, so instance-vs-static-style aliasing is structurally impossible here.
- **Order-independent.** Reversing the input to `structFieldAccessorFieldOrder` yields the identical canonical order.
- **Index-independent.** Adding three unrelated exported functions ahead of the accessors moves every final index while leaving all seven accessor binding IDs unchanged. Under the positional fallback that same shift rewrote the identity — that contrast is the test's control.
- **Byte identity, all three targets.** All five entries emitted through `emitBinary` across `gc`, `standalone` and `wasi`, in both tracked and untracked lanes, on the base copies and on this branch: **all 30 sha256 digests match**, zero compile failures on either side.

## Old-vs-new telemetry diff

`check:ir-only --policy=hybrid` and `check:ir-fallbacks --verbose` produce **byte-identical output** on base and branch (`diff` exit 0): READY, 38 terminal / 38 emitted / 0 unsupported / 0 invariants per lane; no unintended, post-claim, or module-level increase.

## Gates

Expected-green set, all run with `VITEST_FORK_MAX_OLD_SPACE_SIZE=4096` (see note below):

| Gate | Result |
| --- | --- |
| the issue's six-file vitest command | 66/66 |
| `check:ir-only -- --policy=hybrid` | READY (identical to base) |
| `check:ir-fallbacks -- --verbose` | pass (identical to base) |
| `typecheck` / `lint` / `format:check` | pass |
| `cross-backend-diff` | 29/29 |
| new `tests/issue-3520-struct-field-accessor-abi.test.ts` | 7/7 |
| `check:loc-budget` / `check:func-budget` | pass (growth granted by the issue frontmatter) |
| `check:oracle-ratchet` | +0 / +0 |
| `check:dead-exports` | 19 known / 0 new |

Known-base control matrix, run separately on branch **and** on its exact base — reported separately, never combined with the expected-green set: **22/22 on both**.

## Correction (pending commit `ef2a89e2d`)

An earlier revision of this body and of the issue file claimed main emits "zero vec/closure/date/data host-bridge rows" for these entries. **That was wrong**, and for an instructive reason: the probe behind it captured the owner prefix out of the binding id instead of the role component, so every structural family read as absent. Re-measured with an exact `:role:` match, the C30–C33 families are all still published — see the denominators table above. The census tests are red because four of six figures moved (defined functions 166→139, generic 45→40, closure 26→14, data 5→3), not because the ownership work stopped applying. Vec (24) and date (1) still match exactly.

## Two findings a reviewer should act on

1. **The issue's own control note is stale.** It says the control command is "not expected green" while the #1983 type-index and inline-small harness failures remain. Both were fixed on main; the control is now green on both sides. A red control run today is a real finding, not the documented known base. Corrected in the issue file.
2. **17 of this issue's own 60 `tests/issue-3520-*.test.ts` files are RED on current main** (22 failing tests). The failing file and test sets are **identical on `540064dfb` and on this branch**, so they are main-side drift, not regressions from this change. Most are the C30–C33 five-entry census assertions carrying 2026-07-30 denominators; four are semantic drift (`module-binding-class-identity`, `lowering-plan-identity`, `context-integration`, `integration-population-identity`). Re-baselining them is prerequisite work for any R1 acceptance claim — the acceptance criteria cannot be evaluated against a suite that does not run green. **Do not simply overwrite the numbers**: the closure `26 → 14` and data `5 → 3` moves need a cause before they are re-asserted, or the anti-vacuity value of those tests is thrown away.

Also recorded: the issue's expected-green command pins `--poolOptions.forks.singleFork=true` while `vitest.config.ts` pins forks to a 512 MB old space, so that command OOMs in that mode regardless of the change under test.

A six-file struct/host accessor regression sweep (`issue-1320-sget-host-box`, `anon-struct`, `issue-1821-delete-struct-fastpath`, `issue-2582-numeric-key-struct-read`, `arraybuffer-dataview`, `issue-2194-objlit-method-host-leak`) reports the identical 10 failing tests on base and branch — a pre-existing `string_constants` harness-wiring drift, not accessor behavior.

## Not done

R1 acceptance remains open. The updated `## Resume checkpoint` in the issue file enumerates what is left with measured sizes: the 15 remaining generic rows by family (6 higher-arity method dispatchers, 2 async resume, 4 callbacks, 1 vec-from-extern, 2 math helpers), the direct `funcMap`/`structMap`/module-array/display-name scans still to route through `LegacyAbiAdapter`, export aliasing, and session notification from allocator replacement / dead-type elimination / compaction.

No local Test262 run was performed. `benchmarks/results/test262-run.log` and `scripts/equivalence-baseline.json` are unchanged — the 12 equivalence baseline failures that now pass are pre-existing main-side drift and are deliberately not ratcheted in this ownership-only slice.