### PR TITLE
feat(ir): box concrete arguments at dynamic call parameters

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -1,10 +1,10 @@
 ---
 id: 2949
 title: "IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-07-02
-updated: 2026-07-29
+updated: 2026-08-21
 priority: high
 horizon: xl
 feasibility: hard
@@ -24,7 +24,8 @@ loc-budget-allow:
   - src/codegen/any-helpers.ts
 func-budget-allow:
   - src/codegen/index.ts::planIrOverlay
-branch: codex/2949-acorn-module-var-scalars
+  - src/ir/select.ts::dynamicUsesAreMoveOnly
+branch: claude/issue-2949-next-family
 ---
 
 # #2949 — the IR's type system is Wasm types, not JS types
@@ -2086,3 +2087,106 @@ Validation for this slice:
 - focused recursive-boolean and prior #2949 claim-flip suites pass;
 - mixed-value logical fallback is pinned;
 - typecheck and the standard IR gates pass.
+
+## Implementation Notes — concrete arguments at dynamic call parameters (2026-08-21)
+
+### The driver, re-established from source
+
+The prior slices' "#3796 driver" was a script on a lane that no longer exists,
+so it was rebuilt from the artifact it names: the npm-compat report generator's
+`--only acorn --lane standalone-dynamic` perf lane in its DEFAULT (inline,
+non-linked) form. That is the pinned acorn@8.16.0 dist bundle concatenated with
+the runtime-dynamic benchmark driver and compiled as ONE standalone source unit
+with `optimize: 4`, `deferTopLevelInit`, and `trackIrOutcomes` on. It embeds the
+whole 230 KB source as a chunked string array — the 32,768-element
+`array.new_fixed` the earlier notes describe — which is why it is a
+compile/outcome probe rather than a runtime fixture.
+
+Replayed on `fd679233f` (the recursive-boolean slice, 2026-07-30) it reports
+**20 emitted**, matching that slice's recorded figure exactly, so the
+reconstruction is the same measurement. Its denominator counts 42 terminal
+function units where the notes said 43; the recorded body-shape count was
+likewise 14 against 13 here. Treat the earlier denominator as off by one unit,
+not the emitted counts.
+
+### Census, re-measured (driver, standalone)
+
+| | `fd679233f` (2026-07-30) | `fec977606` (main, 2026-08-21) | this slice |
+| --- | --- | --- | --- |
+| emitted | 20/42 | 27/42 | **31/42** |
+| post-claim withdrawals | 0 | 1 | 1 (unchanged) |
+| `body-shape-rejected` | 13 | 8 | 8 |
+| `param-type-not-resolvable` | 4 | 2 | **0** |
+| `call-graph-closure` | 1 | 2 | **0** |
+| `regexp-constructor-unsupported` | 2 | 0 | 0 |
+| `logical-value-unsupported` | 1 | 1 | 1 |
+| `constructor-resolution-unsupported` | 1 | 1 | 1 |
+| `abi-signature-parity` | 0 | 1 | 1 |
+
+Two things moved under main without this slice. Seven functions gained a claim
+(`parse`, `parseExpressionAt`, `codePointToString`, `hasProp`,
+`isPrivateNameConflicted`, `isRegularExpressionModifier`, `stringToNumber`), and
+the RegExp-constructor bucket emptied — `isIdentifierStart` / `isIdentifierChar`
+moved off it and onto the dyn-use scan. **A post-claim withdrawal also appeared:
+`tokenizer` withdraws on `abi-signature-parity` (IR=182, legacy=151).** It is
+present on main before this branch and is unchanged by it; it is not this
+slice's to fix, but the "zero withdrawals" bar is no longer met by main itself.
+
+### Grouping of the residual body-shape rejections
+
+Measured with `JS2WASM_IR_SHAPE_DIAG=1`; each rejects on its own arm, so there
+is no longer a body-shape *family*, only singletons:
+
+| function | arm | shape |
+| --- | --- | --- |
+| `kw` | `objectlit-empty` | `var options = {}` then dynamic property writes |
+| `getOptions` | `objectlit-empty` | same, plus `for…in` over a module object |
+| `getLineInfo` | `tail-unhandled:ForStatement` | `for (;;)` with two init bindings + `new` |
+| `pushComment` | `closure-return-type` | returns a function expression |
+| `finishNodeAt` | `nontail-if-cond:PropertyAccess` | `this.options.…` guards + member writes |
+| `buildUnicodeData` | `expr-binary-op-=` | assignment-expression value into a module object |
+| `stringToBigInt` | `expr-ident-not-in-scope` | `BigInt` |
+| `__npmCompatStandaloneBenchmark` | (driver) | the harness loop itself |
+
+The two `objectlit-empty` entries share an arm but not a fix: both need the
+open-object substrate, which is a different issue's territory.
+
+### The family this slice lands
+
+`isIdentifierStart` / `isIdentifierChar`, plus `isRegExpIdentifierStart` /
+`isRegExpIdentifierPart`, which were held back only by the call-graph closure
+over them — four functions, one root cause.
+
+The root cause is NOT the RegExp constant, `String.fromCharCode`, or the
+optional-boolean parameter; each of those was measured claimable in isolation.
+It is the dyn-use move-only scan. That scan runs over the WHOLE body of any
+function owning a dynamic binding, and it checked every argument of every direct
+call against the callee's resolved parameter kind. `isIdentifierStart` owns a
+dynamic `astral` (some Acorn call sites omit the second argument, so the
+projection reports `dynamic` rather than `bool`), which is what puts it under
+the scan at all — and it was then rejected for `isInAstralSet(code, …)`, whose
+own `code` parameter resolves `dynamic` while the caller's is projected f64. The
+argument that sank the claim has nothing to do with the dynamic binding.
+
+The direct-call lowering already crosses that boundary: it boxes a concrete
+argument at a dynamic parameter through the canonical tag-aware boxer
+(`boxConcreteToDynamic`). Only the scan was missing the symmetric arm to the
+unbox arm right above it. It now admits exactly the operand family that boxer
+accepts — proven number, string, definite boolean, and conditionals over those —
+so the claim can never withdraw on a missing box, and everything else still
+declines before the claim rather than after it. A `null` argument at the same
+position stays a pre-claim `param-type-not-resolvable`, pinned by the test.
+
+One selector arm, no lowering change, no touched file outside `src/ir/select.ts`.
+
+Validation for this slice:
+
+- exact driver: **27/42 → 31/42** emitted, adding `isIdentifierStart`,
+  `isIdentifierChar`, `isRegExpIdentifierStart`, `isRegExpIdentifierPart`;
+  no function lost a claim; the withdrawal set is byte-identical to main's;
+- focused suite (`tests/issue-2949-concrete-arg-dynamic-param.test.ts`): claims
+  the family on gc AND standalone, checks the predicates' runtime values across
+  the boxed boundary, and pins the unboxable-operand refusal;
+- prior #2949 slice suites, equivalence matrix (8 shards), typecheck, lint,
+  fallback / adoption / oracle / LOC / function-budget / ir-only / linear-IR
+  gates.

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -2673,6 +2673,24 @@ function dynamicUsesAreMoveOnly(
         if (!scanExpr(a, true)) return false;
         continue;
       }
+      // #2949 — the SYMMETRIC counterpart of the unbox arm above: a CONCRETE
+      // argument reaching a dynamic callee parameter crosses the same carrier
+      // boundary as a concrete equality operand, and the direct-call lowering
+      // already boxes it there through the canonical tag-aware boxer.
+      //
+      // Without this arm the scan demanded a dynamic-shaped operand at every
+      // dynamic parameter position, so a caller that merely HAS a dynamic
+      // binding of its own (which is what makes this scan run at all) was
+      // rejected for an argument that has nothing to do with that binding —
+      // e.g. Acorn's `isIdentifierStart(code, astral)` passing its proven-f64
+      // `code` to `isInAstralSet(code, set)`, whose own `code` is dynamic.
+      //
+      // Admission is exactly the operand family `boxConcreteToDynamic`
+      // accepts, so the claim can never withdraw on a missing box.
+      if (!argumentIsDynamic && expectedKind === "dynamic" && concreteDynamicAssignmentOperandIsBuildable(unwrap(a))) {
+        if (!scanExpr(a, false)) return false;
+        continue;
+      }
       if (!scanExpr(a, expectedKind === "dynamic")) return false;
     }
     return true;

--- a/tests/issue-2949-concrete-arg-dynamic-param.test.ts
+++ b/tests/issue-2949-concrete-arg-dynamic-param.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 — a CONCRETE argument at a dynamic callee-parameter position.
+//
+// The dyn-use move-only scan runs over the WHOLE body of any function that owns
+// a dynamic binding, and it checked every argument of every direct call against
+// the callee's parameter kind. A concrete argument reaching a dynamic parameter
+// was rejected outright, so a function was demoted for an argument that has
+// nothing to do with the dynamic binding that put it under the scan.
+//
+// The direct-call lowering already crosses that boundary with the canonical
+// tag-aware boxer, so the scan now admits exactly the operand family that boxer
+// accepts, and declines the rest BEFORE the claim rather than withdrawing after
+// it.
+//
+// The fixture is Acorn's exact shape: `isIdentifierStart(code, astral)` has a
+// projected-f64 `code` and a dynamic `astral` (some call sites omit the second
+// argument), and passes its concrete `code` to a helper whose own parameter is
+// dynamic. The two RegExp identifier predicates were held back only by the
+// call-graph closure over that helper.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const IDENTIFIER_FAMILY = `
+function isSpecialCode(value) {
+  if (value === 36) { return true }
+  if (value === 95) { return true }
+  return false
+}
+
+function isIdentifierStart(code, astral) {
+  if (code < 65) { return isSpecialCode(code) }
+  if (code < 91) { return true }
+  if (code < 97) { return isSpecialCode(code) }
+  if (code < 123) { return true }
+  if (astral === false) { return false }
+  return isSpecialCode(code)
+}
+
+function isRegExpIdentifierStart(ch) {
+  return isIdentifierStart(ch, true) || ch === 0x24 || ch === 0x5F
+}
+
+// A closure call site that omits the second argument. This is what keeps
+// \`astral\` dynamic rather than boolean — Acorn reaches the same state through
+// its prototype-method call sites.
+var scanner = function (code) {
+  return isIdentifierStart(code) ? 1 : 0;
+};
+
+export function runScanner(code: number): number {
+  return scanner(code);
+}
+
+export function classifySpecial(value: any): number {
+  return isSpecialCode(value) ? 1 : 0;
+}
+
+export function classify(code: number): number {
+  let flags = 0;
+  if (isIdentifierStart(code, true)) flags += 1;
+  if (isIdentifierStart(code, false)) flags += 2;
+  if (isRegExpIdentifierStart(code)) flags += 4;
+  return flags;
+}
+`;
+
+const FAMILY = ["isSpecialCode", "isIdentifierStart", "isRegExpIdentifierStart", "classify"];
+
+async function compileFixture(source: string, target: "gc" | "standalone", fileName: string) {
+  const result = await compile(source, {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    fileName,
+    target,
+    trackIrOutcomes: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  return result;
+}
+
+describe("#2949 concrete argument at a dynamic callee parameter", () => {
+  it.each(["gc", "standalone"] as const)("claims the whole identifier family on the %s target", async (target) => {
+    const result = await compileFixture(IDENTIFIER_FAMILY, target, "issue-2949-concrete-arg-dynamic-param.ts");
+
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toEqual(expect.arrayContaining(FAMILY));
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps the identifier predicates value-correct across the boxed argument boundary", async () => {
+    const result = await compileFixture(IDENTIFIER_FAMILY, "gc", "issue-2949-concrete-arg-runtime.ts");
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+    const classify = instance.exports.classify as (code: number) => number;
+
+    // '$' and '_' are identifier starts through the boxed helper, with and
+    // without the astral flag, and both satisfy the RegExp predicate.
+    expect(classify(0x24)).toBe(1 + 2 + 4);
+    expect(classify(0x5f)).toBe(1 + 2 + 4);
+    // 'a' takes the plain `code < 123` arm.
+    expect(classify(0x61)).toBe(1 + 2 + 4);
+    // '5' and '-' reach the helper and are refused by it.
+    expect(classify(0x35)).toBe(0);
+    expect(classify(0x2d)).toBe(0);
+  });
+
+  it("declines an argument the canonical boxer cannot tag before the claim, not after it", async () => {
+    // `null` has no sound carrier tag in this slice. The function must stay on
+    // the legacy path with its pre-claim rejection intact — never claim and
+    // then withdraw.
+    const result = await compileFixture(
+      IDENTIFIER_FAMILY.replace("  return isSpecialCode(code)\n}", "  return isSpecialCode(null)\n}"),
+      "gc",
+      "issue-2949-unboxable-arg.ts",
+    );
+
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irOutcomes?.find((outcome) => outcome.displayName === "isIdentifierStart")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      code: "param-type-not-resolvable",
+      irBodyEmitted: false,
+      legacyBodyEmitted: true,
+    });
+  });
+});


### PR DESCRIPTION
One selector arm for [#2949](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2949-ir-dynamic-value-representation). No lowering change, no file touched outside `src/ir/select.ts`.

## What was blocked

The dyn-use move-only scan runs over the **whole body** of any function that owns a dynamic binding, and it checked every argument of every direct call against the callee's resolved parameter kind. A **concrete** argument reaching a **dynamic** parameter was rejected outright — so a function was demoted for an argument that has nothing to do with the dynamic binding that put it under the scan.

Acorn's exact shape:

```js
function isInAstralSet(code, set) { … }              // `code` resolves dynamic

function isIdentifierStart(code, astral) {            // `code` projected f64,
  …                                                   // `astral` dynamic — some
  if (astral === false) { return false }              // call sites omit it
  return isInAstralSet(code, astralIdentifierStartCodes)   // ← rejected here
}
```

The direct-call lowering already crosses that boundary with the canonical tag-aware boxer (`boxConcreteToDynamic`); only the scan was missing the symmetric arm to the unbox arm directly above it. It now admits exactly the operand family that boxer accepts — proven number, string, definite boolean, and conditionals over those — so a claim can never withdraw on a missing box, and everything else still declines *before* the claim rather than after it.

## Measurement

The prior slices' driver lived on a lane that no longer exists, so it was rebuilt from the artifact it names: the npm-compat generator's `--only acorn --lane standalone-dynamic` perf lane in its default inline form. Replayed on `fd679233f` it reports **20/42 emitted**, matching that slice's recorded figure exactly, so the reconstruction is the same measurement.

| | `fd679233f` (2026-07-30) | `main` (`fec977606`) | this PR |
| --- | --- | --- | --- |
| emitted | 20/42 | 27/42 | **31/42** |
| post-claim withdrawals | 0 | 1 | 1 (unchanged) |
| `param-type-not-resolvable` | 4 | 2 | **0** |
| `call-graph-closure` | 1 | 2 | **0** |
| `body-shape-rejected` | 13 | 8 | 8 |

Four functions gained a claim — `isIdentifierStart`, `isIdentifierChar`, `isRegExpIdentifierStart`, `isRegExpIdentifierPart` — and none lost one.

## Pre-existing on main, not introduced here

Each verified by a file-copy A/B with `src/ir/select.ts` reverted to main:

- `tokenizer` withdraws on `abi-signature-parity` (IR=182, legacy=151) — byte-identical before and after this branch. The "zero post-claim withdrawals" bar is no longer met by main itself.
- 5 assertions across `issue-2949-slice3b-any-dynamic` and `issue-2949-slice2-dynamic-producers` fail with identical messages on main. They are stale bucket expectations (e.g. `call-resolution-unsupported` where the test still expects `param-type-not-resolvable`).
- The **linked** lane: the same driver compiled as a multi-source project emits **1 of 43**, with 21 selector-*accepted* units dropped at final-context preparation (`late-preparation-unsupported`). Every claim flip this issue has measured on the inline lane is invisible there. That is `reconcileIrOverlayOutcomes` bookkeeping — #3520 territory, unchanged by this slice. Recorded in the issue file.

## Validation

- exact driver: 27/42 → 31/42, withdrawal set unchanged
- new focused suite: claims the family on **gc and standalone**, checks the predicates' runtime values across the boxed boundary, and pins the unboxable-operand (`null`) refusal as a *pre-claim* rejection
- **equivalence matrix: 8/8 shards, `rc=0`, no new regressions** (7 baseline failures now pass, all in unrelated areas — Symbol, `Math.pow`, i32 peephole, `+` coercion; the baseline ratchet is a post-merge concern and is deliberately not committed here)
- `typecheck`, `format:check`, biome lint
- `check:ir-fallbacks --verbose` (no unintended / post-claim / module-level increases), `check:ir-only` (READY, both lanes 38/38), `check:linear-ir` (compiled=8 = baseline), `check:oracle-ratchet` (+0), `check:ir-layering`, `check:ir-dialect`, `check:ir-adoption`, `check:jstag-seam`
- `check:harness-compile-budget`: 131142 both with and without this change — zero added compile work
- LOC + function budgets granted in the issue frontmatter, not in any `scripts/*-baseline.json`

The issue stays `in-progress` — this is one slice of an umbrella.
