### PR TITLE
fix(npm-compat): align ReactDOM native oracle host

### DIFF
--- a/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
@@ -4,7 +4,7 @@ title: "Run react-dom's own unit tests against compiled react-dom"
 status: in-progress
 sprint: current
 created: 2026-08-01
-updated: 2026-08-21
+updated: 2026-08-22
 priority: high
 horizon: m
 feasibility: medium
@@ -538,6 +538,25 @@ are production warning expectations, renderer semantics, and compiled
 component/function closures that still arrive as opaque host objects. ReactDOM
 compiled correctness therefore remains a separate follow-up, while this
 checkpoint makes the cross-package infrastructure explicit and measurable.
+
+## ReactDOM native-oracle singleton checkpoint (2026-08-22)
+
+The ReactDOM harness previously built its native oracle with the full compiled
+implementation source initialized, while `internal-test-utils` and the native
+package imports came from a separate host React/ReactDOM instance. That split
+made `createRoot` tests appear harness-incompatible (`container.firstChild`
+was empty) before the Wasm result could be compared. The native runner now
+keeps the compiled carriers uninitialized and routes React, ReactDOM,
+ReactDOM/client, server renderers, test-renderer, and noop renderer imports to
+the exact pinned host infrastructure. ReactDOM `act` can also prefer the
+host `flushSync` boundary, and the compile worker receives the same setting.
+
+A one-test-per-lane probe now scores the client and all server/Fizz lanes with
+zero native-oracle infrastructure failures. The remaining failures are real
+compiled-lane findings (for example the client `stateNode` carrier error and
+Fizz null dereferences), not an oracle mismatch. The full 1,923-test admitted
+corpus remains bounded by the existing project batches and is not claimed
+green.
 
 ## Permanent test reference
 

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -268,11 +268,9 @@ function buildServerImplementationSource({ reactSource, sharedSource, serverSour
   ].join("\n");
 }
 
-function reactDomTestSetup(prelude, testSource = prelude, { server = false, fizz = false } = {}) {
-  const lines = [
-    `${server ? "__reactDomServerEnsureInit" : "__reactDomEnsureInit"}();`,
-    `document.body.textContent = "";`,
-  ];
+function reactDomTestSetup(prelude, testSource = prelude, { server = false, fizz = false, nativeHost = false } = {}) {
+  const lines = [`document.body.textContent = "";`];
+  if (!nativeHost) lines.unshift(`${server ? "__reactDomServerEnsureInit" : "__reactDomEnsureInit"}();`);
   const binds = (name, expression) => {
     const declaration = new RegExp(`\\b(let|var|const)\\s+${name}\\b`).exec(prelude);
     if (declaration && declaration[1] !== "const") {
@@ -486,6 +484,7 @@ function buildNativeRunners(implementation, tests, options = {}) {
   const init = server ? "__reactDomServerEnsureInit()" : "__reactDomEnsureInit()";
   const source = [
     implementation,
+    options.nativeHost ? "var __js2NativeHost = true;" : "",
     REACT_EXPECT_SHIM,
     ...tests.map((test) => buildTestFunction(withReactDomSetup(test, options), { exported: false })),
     `return { init: function () { ${init}; }, __lastError: function () { return __lastError; }, tests: { ${tests
@@ -496,11 +495,51 @@ function buildNativeRunners(implementation, tests, options = {}) {
   return new Function("require", source);
 }
 
+// The native oracle must use the same pinned React object and the same
+// cross-package renderer instances as the host infrastructure. Passing
+// createRequire() directly gives react-dom a second React singleton, so
+// createRoot/act tests either render nothing or fail before their assertions.
+// Keep these dependencies explicit: they are the native counterpart of the
+// compiled lane's __js2RequireActual() facades, not a test-result shortcut.
+export function createNativeRequire() {
+  const nativeRequire = createRequire(import.meta.url);
+  const infrastructure = globalThis.__js2ReactUpstreamInfrastructure;
+  return (name) => {
+    if (name === "react") return infrastructure?.react ?? nativeRequire(name);
+    if (name === "react-dom") return infrastructure?.reactDom ?? nativeRequire(name);
+    if (name === "react-dom/client") return infrastructure?.reactDomClient ?? nativeRequire(name);
+    if (name === "react-dom/server") return infrastructure?.reactDomServer ?? nativeRequire(name);
+    if (name === "react-test-renderer") return infrastructure?.reactTestRenderer ?? nativeRequire(name);
+    if (name === "react-noop-renderer") {
+      if (!infrastructure?.reactNoop) throw new Error("ReactDOM upstream noop renderer infrastructure is unavailable");
+      return infrastructure.reactNoop;
+    }
+    if (name === "react-native-renderer") {
+      if (!infrastructure?.reactNativeRenderer)
+        throw new Error("ReactDOM upstream native renderer infrastructure is unavailable");
+      return infrastructure.reactNativeRenderer;
+    }
+    if (name === "internal-test-utils") {
+      if (!infrastructure?.internalTestUtils)
+        throw new Error("ReactDOM upstream internal test utilities are unavailable");
+      return infrastructure.internalTestUtils;
+    }
+    if (name === "react/jsx-runtime") return infrastructure?.reactJsxRuntime ?? nativeRequire(name);
+    if (name === "react/jsx-dev-runtime") return infrastructure?.reactJsxDevRuntime ?? nativeRequire(name);
+    if (name === "react-dom/test-utils") {
+      if (!infrastructure?.internalTestUtils)
+        throw new Error("ReactDOM upstream test-utils infrastructure is unavailable");
+      return { act: infrastructure.internalTestUtils.act };
+    }
+    return nativeRequire(name);
+  };
+}
+
 async function runNative(implementation, tests, options = {}) {
   try {
-    const nativeRequire = createRequire(import.meta.url);
-    const runners = buildNativeRunners(implementation, tests, options)(nativeRequire);
-    runners.init();
+    const nativeOptions = { ...options, nativeHost: true };
+    const runners = buildNativeRunners(implementation, tests, nativeOptions)(createNativeRequire());
+    if (!nativeOptions.nativeHost) runners.init();
     const out = [];
     for (const test of tests) {
       nativeContextTest = test.id;
@@ -912,7 +951,11 @@ async function runProjectHarness({
           entryFile: "entry.ts",
           files,
           timeoutMs,
-          workerEnv: { DOGFOOD_INSTALL_JSDOM: "1", DOGFOOD_NAMED_TEST_EXPORTS: "1" },
+          workerEnv: {
+            DOGFOOD_INSTALL_JSDOM: "1",
+            DOGFOOD_NAMED_TEST_EXPORTS: "1",
+            DOGFOOD_REACT_DOM_ACT: "1",
+          },
         });
       } catch (error) {
         isolated = {
@@ -1106,7 +1149,11 @@ export async function runHarness({ quiet = false } = {}) {
   const reactSource = readFileSync(reactModulePath, "utf-8");
   const implementationPin = setupReactDomImplementation({ build });
   const localRequire = createRequire(import.meta.url);
-  const hostInfrastructure = installReactUpstreamInfrastructure({ react: localRequire(reactModulePath), build });
+  const hostInfrastructure = installReactUpstreamInfrastructure({
+    react: localRequire(reactModulePath),
+    build,
+    preferReactDomAct: true,
+  });
   const installedReactDom = localRequire("react-dom/package.json");
   if (installedReactDom.version !== implementationPin.version) {
     throw new Error(

--- a/tests/dogfood/react-dom-upstream-suite.test.ts
+++ b/tests/dogfood/react-dom-upstream-suite.test.ts
@@ -11,6 +11,7 @@ import { loadReactDomUpstreamSuitePin, setupReactDomImplementation } from "./set
 import { loadReactUpstreamSuitePin } from "./setup-react-upstream-suite.mjs";
 // @ts-expect-error — .mjs dogfood harness has no declaration file
 import {
+  createNativeRequire,
   isExpectedLateJsdomHostError,
   partitionProjectTests,
   partitionReactDomTestsForBuild,
@@ -105,6 +106,27 @@ describe("react-dom upstream suite", () => {
     expect(implementation.nodeFizzServerPath).toMatch(/react-dom-server\.node\.development\.js$/);
     expect(implementation.edgeFizzServerPath).toMatch(/react-dom-server\.edge\.development\.js$/);
     expect(implementation.moduleNames.fizzServer).toBe("package/cjs/react-dom-server.browser.development.js");
+  });
+
+  it("uses the pinned cross-package singletons in the native oracle", () => {
+    const previous = globalThis.__js2ReactUpstreamInfrastructure;
+    const react = { version: "pinned-react" };
+    const reactDom = { version: "pinned-react-dom" };
+    const reactDomClient = { createRoot: () => null };
+    const internalTestUtils = { act: () => Promise.resolve() };
+    const infrastructure = { react, reactDom, reactDomClient, internalTestUtils };
+    globalThis.__js2ReactUpstreamInfrastructure = infrastructure;
+    try {
+      const nativeRequire = createNativeRequire();
+      expect(nativeRequire("react")).toBe(react);
+      expect(nativeRequire("react-dom")).toBe(reactDom);
+      expect(nativeRequire("react-dom/client")).toBe(reactDomClient);
+      expect(nativeRequire("internal-test-utils")).toBe(internalTestUtils);
+      expect(nativeRequire("react-dom/test-utils")).toEqual({ act: internalTestUtils.act });
+    } finally {
+      if (previous === undefined) delete globalThis.__js2ReactUpstreamInfrastructure;
+      else globalThis.__js2ReactUpstreamInfrastructure = previous;
+    }
   });
 
   it("partitions project entries without dropping tests or mixing files", () => {

--- a/tests/dogfood/react-dom-upstream-suite.test.ts
+++ b/tests/dogfood/react-dom-upstream-suite.test.ts
@@ -124,7 +124,7 @@ describe("react-dom upstream suite", () => {
       expect(nativeRequire("internal-test-utils")).toBe(internalTestUtils);
       expect(nativeRequire("react-dom/test-utils")).toEqual({ act: internalTestUtils.act });
     } finally {
-      if (previous === undefined) delete globalThis.__js2ReactUpstreamInfrastructure;
+      if (previous === undefined) Reflect.deleteProperty(globalThis, "__js2ReactUpstreamInfrastructure");
       else globalThis.__js2ReactUpstreamInfrastructure = previous;
     }
   });

--- a/tests/dogfood/react-upstream-infrastructure.mjs
+++ b/tests/dogfood/react-upstream-infrastructure.mjs
@@ -348,9 +348,9 @@ function createReactNoopAdapter(react, reactTestRenderer, reactDom, reactDomClie
   };
 }
 
-function createInternalTestUtils({ reactTestRenderer, reactDom, consumeConsole }) {
+function createInternalTestUtils({ reactTestRenderer, reactDom, consumeConsole, preferReactDomAct = false }) {
   const act = (callback) => {
-    if (typeof reactTestRenderer?.act === "function") return reactTestRenderer.act(callback);
+    if (!preferReactDomAct && typeof reactTestRenderer?.act === "function") return reactTestRenderer.act(callback);
     // The production test-renderer intentionally has no `act` export. The
     // upstream tests still use the shared internal helper for ReactDOM roots,
     // so use ReactDOM's synchronous commit boundary instead of merely calling
@@ -515,7 +515,7 @@ function unrefMessagePorts() {
  * generated test source can use them in the native oracle and through the
  * Wasm host boundary.
  */
-export function installReactUpstreamInfrastructure({ react, build = "production" } = {}) {
+export function installReactUpstreamInfrastructure({ react, build = "production", preferReactDomAct = false } = {}) {
   const nativeReact = react ?? readReactForBuild(build);
   const { reactDom, reactDomClient, reactDomServer, reactTestRenderer } = loadCrossPackageReactModules(nativeReact, {
     build,
@@ -580,7 +580,7 @@ export function installReactUpstreamInfrastructure({ react, build = "production"
     propTypes,
     createReactClass,
     createReactClassFactory: createReactClassFactoryModule,
-    internalTestUtils: createInternalTestUtils({ reactTestRenderer, reactDom, consumeConsole }),
+    internalTestUtils: createInternalTestUtils({ reactTestRenderer, reactDom, consumeConsole, preferReactDomAct }),
     webStreams,
     patchMessageChannel() {},
     // Node Fizz's upstream tests construct `stream.PassThrough` through a

--- a/tests/dogfood/react-upstream-infrastructure.test.ts
+++ b/tests/dogfood/react-upstream-infrastructure.test.ts
@@ -119,6 +119,28 @@ describe("React upstream test infrastructure", () => {
     }
   });
 
+  it("can use ReactDOM's flushSync boundary for ReactDOM unit tests", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    const dom = installReactTestEnvironment();
+    const installed = installReactUpstreamInfrastructure({ preferReactDomAct: true });
+    try {
+      const { infrastructure } = installed;
+      const container = document.createElement("div");
+      const root = infrastructure.reactDomClient.createRoot(container);
+      await infrastructure.internalTestUtils.act(() => {
+        root.render(infrastructure.react.createElement("div", null, "ok"));
+      });
+      expect(container.firstChild?.textContent).toBe("ok");
+      root.unmount();
+    } finally {
+      installed.cleanup();
+      dom.cleanup();
+      if (previousNodeEnv === undefined) Reflect.deleteProperty(process.env, "NODE_ENV");
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
   it("provides scoped Jest module isolation to Node and compiled Wasm", async () => {
     const previousNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "production";

--- a/tests/dogfood/react-upstream-shim.mjs
+++ b/tests/dogfood/react-upstream-shim.mjs
@@ -935,6 +935,9 @@ function __js2RequireActual(name) {
   if (name === "react") return typeof __REACT__ === "undefined" ? __js2ReactInfra().react : __REACT__;
   if (name === "react-dom" || name === "react-dom/client") {
     __js2CheckReactVersion("react-dom");
+    if (typeof __js2NativeHost !== "undefined" && __js2NativeHost) {
+      return name === "react-dom" ? __js2ReactInfra().reactDom : __js2ReactInfra().reactDomClient;
+    }
     // When the harness has compiled ReactDOM's published graphs, keep the
     // package import inside that graph. The host facades remain the fallback
     // for the standalone React suite, where no compiled ReactDOM carrier is
@@ -959,6 +962,7 @@ function __js2RequireActual(name) {
     name === "react-dom/static.edge"
   ) {
     __js2CheckReactVersion("react-dom");
+    if (typeof __js2NativeHost !== "undefined" && __js2NativeHost) return __js2ReactInfra().reactDomServer;
     // Each Fizz lane compiles exactly one published server graph (browser,
     // node, or edge). Route every server/static entrypoint to that graph while
     // the lane is active; the graph's own test file determines which API is
@@ -979,8 +983,14 @@ function __js2RequireActual(name) {
       throw new Error("React upstream native renderer infrastructure is unavailable");
     return nativeRenderer;
   }
-  if (name === "react-test-renderer") return __js2ReactTestRenderer;
-  if (name === "react-noop-renderer") return __js2ReactNoop;
+  if (name === "react-test-renderer")
+    return typeof __js2NativeHost !== "undefined" && __js2NativeHost
+      ? __js2ReactInfra().reactTestRenderer
+      : __js2ReactTestRenderer;
+  if (name === "react-noop-renderer")
+    return typeof __js2NativeHost !== "undefined" && __js2NativeHost
+      ? __js2ReactInfra().reactNoop
+      : __js2ReactNoop;
   // These entries are internal React-monorepo test dependencies rather than
   // published package graphs. Keep their host carriers explicit so an
   // upstream test reaches its assertion instead of failing at module lookup.

--- a/tests/dogfood/upstream-suite-compile-worker.mjs
+++ b/tests/dogfood/upstream-suite-compile-worker.mjs
@@ -80,7 +80,10 @@ async function main() {
     installReactTestEnvironment();
     const { createRequire } = await import("node:module");
     const workerRequire = createRequire(import.meta.url);
-    installReactUpstreamInfrastructure({ react: workerRequire("react") });
+    installReactUpstreamInfrastructure({
+      react: workerRequire("react"),
+      preferReactDomAct: process.env.DOGFOOD_REACT_DOM_ACT === "1",
+    });
   }
   let result;
   try {


### PR DESCRIPTION
## Summary

- Route the ReactDOM native oracle through the pinned host React/ReactDOM singletons instead of initializing compiled carriers.
- Prefer the host ReactDOM `flushSync` act boundary for the parent oracle and compile-worker infrastructure.
- Record the measured checkpoint in [issue 3982](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md).

The bounded one-test-per-lane probe now reports `nativePassed: true`, `harnessIncompatible: 0`, and `0 need infrastructure` for client, legacy server, browser Fizz, Node Fizz, and edge Fizz. The selected compiled tests still expose real runtime/compiler failures; this PR does not claim the full ReactDOM corpus is green.

## Validation

- `pnpm exec vitest run tests/dogfood/react-upstream-infrastructure.test.ts tests/dogfood/react-dom-upstream-suite.test.ts`
- `pnpm run typecheck`
- `pnpm exec prettier --check` on all modified files
- `node scripts/check-issue-ids.mjs --check`
- bounded ReactDOM upstream suite probe with all five lane limits set to 1
