### PR TITLE
test(npm-compat): expand Prettier upstream unit infrastructure

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -1173,3 +1173,29 @@ Hono failures are scored compiler/runtime compatibility findings, not missing
 Web-global infrastructure.
 
 Implementation: [PR #4752](https://github.com/loopdive/js2/pull/4752).
+
+## 2026-08-22 Prettier utility-suite infrastructure checkpoint
+
+The Prettier adapter now selects 16 of the 20 verified `tests/unit/*.js`
+files, up from the original three-file smoke slice. The unchanged upstream
+callbacks register **151 tests**; the Node oracle reproduces **151/151** after
+the shared runner's negative `toThrow` fix. The shared runner now implements
+negative `toThrow`/`toThrowError` matching, so a negative assertion only fails
+when the thrown error also matches its requested message or constructor.
+
+The adapter supplies source-compatible, ignored checkout dependencies for the
+small pure helpers Prettier imports (`trim-newlines`, `escape-string-regexp`,
+`emoji-regex`, `get-east-asian-width`, `url-or-path`, and `n-readlines`). It
+also supports inline snapshots and the `toBeGreaterThan` matcher used by the
+selected utility tests. No upstream callback or expected input was changed.
+
+The expanded lane compiles 16/16 modules and validates 10/16. It scores
+**48/151** in Wasm; the remaining results are compiler/runtime findings,
+including the existing async-await-in-try refusal tracked in
+[3587](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3587-host-declined-async-shapes-swallow-rejections.md),
+document-carrier validation failures. The four deferred files
+(`builtin-plugins.js`, `html-elements.js`, `syntax-transform.js`, and
+`visitor-keys.js`) remain explicit, with 11 direct static registration sites
+reported as unavailable infrastructure rather than silently disappearing. The
+pinned inventory counts direct `it`/`test` call sites; table-driven
+registrations are expanded separately by the runner.

--- a/tests/dogfood/prettier-upstream-suite-pin.json
+++ b/tests/dogfood/prettier-upstream-suite-pin.json
@@ -7,6 +7,24 @@
   "testFileCount": 20,
   "testFilePathSha256": "79e27ef592b9fafc4369a6971417326b66b9d484d906d03087c2f849c6363f6b",
   "registrationSites": 48,
-  "selectedFiles": ["tests/unit/ast-path.js", "tests/unit/errors.js", "tests/unit/make-string.js"],
-  "_note": "The complete tests/unit/*.js inventory is verified. This first adapter selects the three synchronous, self-contained files whose imports stay within Prettier's implementation. Async plugin loading, snapshots, node:path/url, external development dependencies, and larger document/parser graphs remain explicitly deferred. Test callback bodies and inputs are unchanged."
+  "selectedRegistrationSites": 37,
+  "selectedFiles": [
+    "tests/unit/ast-path.js",
+    "tests/unit/doc-builders.js",
+    "tests/unit/doc-printer.js",
+    "tests/unit/editorconfig-to-prettier.js",
+    "tests/unit/errors.js",
+    "tests/unit/get-descendants.js",
+    "tests/unit/get-parser-plugin-by-parser-name.js",
+    "tests/unit/get-printer-plugin-by-ast-format.js",
+    "tests/unit/is-empty-doc.js",
+    "tests/unit/make-string.js",
+    "tests/unit/massage-ast.js",
+    "tests/unit/print-doc-to-string.js",
+    "tests/unit/resolve-parser.js",
+    "tests/unit/strip-trailing-hardline.js",
+    "tests/unit/traverse-doc.js",
+    "tests/unit/whitespace-utilities.js"
+  ],
+  "_note": "The complete tests/unit/*.js inventory is verified. This adapter executes the synchronous, self-contained utility/document/config files whose imports stay within Prettier's implementation, while preserving original callbacks and inputs. Async plugin loading, snapshots, node:path/url, external development dependencies, visitor-key parser graphs, and larger parser graphs remain explicitly deferred."
 }

--- a/tests/dogfood/prettier-upstream-suite.mjs
+++ b/tests/dogfood/prettier-upstream-suite.mjs
@@ -1,6 +1,6 @@
 // Prettier 3.8.1 original synchronous unit slice against its pinned source.
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -31,6 +31,53 @@ function transformPrettierTest(source, filePath, generatedPath) {
   });
 }
 
+function readPrettierSnapshots(snapshotPath) {
+  const source = readFileSync(snapshotPath, "utf-8");
+  const values = {};
+  const pattern = /exports\[`([^`]*)`\] = `\n([\s\S]*?)\n`;/g;
+  for (const match of source.matchAll(pattern)) {
+    const key = match[1].replace(/ \d+$/, "");
+    values[key] = match[2];
+  }
+  return values;
+}
+
+function buildPrettierSnapshotShim(snapshotPath) {
+  const snapshots = JSON.stringify(readPrettierSnapshots(snapshotPath));
+  return String.raw`
+const __prettierSnapshotValues = ${snapshots};
+function __prettierSnapshotSerialize(value, depth) {
+  if (value === null) return "null";
+  const kind = typeof value;
+  if (kind === "string") return '"' + value + '"';
+  if (kind === "number" || kind === "boolean" || kind === "undefined") return String(value);
+  if (kind !== "object") return String(value);
+  const indent = "  ".repeat(depth);
+  const childIndent = "  ".repeat(depth + 1);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    let output = "[\n";
+    for (let index = 0; index < value.length; index++) {
+      output += childIndent + __prettierSnapshotSerialize(value[index], depth + 1) + ",\n";
+    }
+    return output + indent + "]";
+  }
+  const keys = Object.keys(value).sort();
+  if (keys.length === 0) return "{}";
+  let output = "{\n";
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index];
+    output += childIndent + '"' + key + '": ' + __prettierSnapshotSerialize(value[key], depth + 1) + ",\n";
+  }
+  return output + indent + "}";
+}
+__upstreamSnapshotMatcher = function (value) {
+  const expected = __prettierSnapshotValues["visitor keys " + __upstreamCurrentTestName];
+  return expected !== undefined && __prettierSnapshotSerialize(value, 0) === expected;
+};
+`;
+}
+
 export async function runHarness({ quiet = false } = {}) {
   const log = quiet ? () => {} : (...values) => console.log(...values);
   const suite = setupPrettierUpstreamSuite();
@@ -41,7 +88,9 @@ export async function runHarness({ quiet = false } = {}) {
     const file = suite.relativePath(filePath);
     const generatedPath = join(GENERATED_ROOT, file.replace(/\.js$/, ".ts"));
     const transformed = transformPrettierTest(readFileSync(filePath, "utf-8"), filePath, generatedPath);
-    const source = `${UPSTREAM_TEST_SHIM}\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const snapshotPath = join(suite.root, "tests", "unit", "__snapshots__", `${filePath.split("/").at(-1)}.snap`);
+    const snapshotShim = existsSync(snapshotPath) ? buildPrettierSnapshotShim(snapshotPath) : "";
+    const source = `${UPSTREAM_TEST_SHIM}\n${snapshotShim}\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
     const result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 240_000 });
     runs.push({ file, result });
     log(

--- a/tests/dogfood/setup-prettier-upstream-suite.mjs
+++ b/tests/dogfood/setup-prettier-upstream-suite.mjs
@@ -1,12 +1,59 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 
 import { setupPinnedUpstreamSuite } from "./setup-pinned-upstream-suite.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+// The source checkout intentionally contains Prettier's development-time
+// imports, while this adapter does not install the upstream development tree.
+// Install source-compatible host modules into the ignored checkout so the
+// original utility tests can resolve the same imports without changing their
+// bodies or adding package dependencies to the compiler repository.
+function installSourceDependency(root, name, source) {
+  const directory = `${root}/node_modules/${name}`;
+  if (existsSync(`${directory}/package.json`)) return;
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(`${directory}/package.json`, '{"type":"module","exports":"./index.js"}\n');
+  writeFileSync(`${directory}/index.js`, `${source}\n`);
+}
+
+function installPrettierSourceDependencies(root) {
+  installSourceDependency(
+    root,
+    "trim-newlines",
+    `export function trimNewlinesEnd(value) { return String(value).replace(/(?:\\r\\n|\\n|\\r)+$/, ""); }`,
+  );
+  installSourceDependency(
+    root,
+    "escape-string-regexp",
+    `export default function escapeStringRegexp(value) { return String(value).replace(/[|\\\\{}()[\\]^$+*?.-]/g, "\\\\$&"); }`,
+  );
+  installSourceDependency(
+    root,
+    "emoji-regex",
+    `export default function emojiRegex() { return /[\\u{1f000}-\\u{1faff}]/gu; }`,
+  );
+  installSourceDependency(
+    root,
+    "get-east-asian-width",
+    `const isWideCodePoint = (codePoint) => (codePoint >= 0x1100 && codePoint <= 0x115f) || (codePoint >= 0x2e80 && codePoint <= 0xa4cf) || (codePoint >= 0xac00 && codePoint <= 0xd7a3) || (codePoint >= 0xf900 && codePoint <= 0xfaff) || (codePoint >= 0xfe10 && codePoint <= 0xfe6f) || (codePoint >= 0xff00 && codePoint <= 0xff60) || (codePoint >= 0xffe0 && codePoint <= 0xffe6) || (codePoint >= 0x1f300 && codePoint <= 0x1faff); export function _isFullWidth(codePoint) { return isWideCodePoint(codePoint); } export function _isWide(codePoint) { return isWideCodePoint(codePoint); }`,
+  );
+  installSourceDependency(
+    root,
+    "url-or-path",
+    `import { fileURLToPath } from "node:url"; export function toPath(value) { return value instanceof URL ? fileURLToPath(value) : String(value); } export function isUrl(value) { return value instanceof URL || (typeof value === "string" && /^[a-z][a-z\\d+.-]*:/i.test(value)); } export function isUrlString(value) { return typeof value === "string" && /^[a-z][a-z\\d+.-]*:/i.test(value); }`,
+  );
+  installSourceDependency(
+    root,
+    "n-readlines",
+    `import { readFileSync } from "node:fs"; export default class Readlines { constructor(file) { this.lines = readFileSync(file, "utf8").split(/\\r?\\n/); this.index = 0; } next() { return this.index < this.lines.length ? Buffer.from(this.lines[this.index++]) : false; } close() {} }`,
+  );
+}
+
 export function setupPrettierUpstreamSuite(options = {}) {
-  return setupPinnedUpstreamSuite({
+  const suite = setupPinnedUpstreamSuite({
     here: HERE,
     pinFile: "prettier-upstream-suite-pin.json",
     cacheDirectory: ".npm-upstream-suites/prettier",
@@ -14,4 +61,6 @@ export function setupPrettierUpstreamSuite(options = {}) {
     accept: (path) => /^tests\/unit\/[^/]+\.js$/.test(path),
     force: options.force,
   });
+  installPrettierSourceDependencies(suite.root);
+  return suite;
 }

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -183,6 +183,24 @@ function __upstreamAsyncResolve(actual, matcher, expected, hasExpected, label) {
     },
   );
 }
+function __upstreamNormalizeInlineSnapshot(value) {
+  return String(value)
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .replace(/,\n([}\]])/g, "\n$1");
+}
+function __upstreamInlineSnapshotValue(value) {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === undefined) return "undefined";
+  try {
+    const serialized = JSON.stringify(value, null, 2);
+    return serialized === undefined ? String(value) : serialized;
+  } catch {
+    return String(value);
+  }
+}
 function __upstreamExpect(actual) {
   const positive = {
     toBe(expected) { const n = ++__upstreamAssertion; if (!Object.is(actual, expected)) __upstreamFail("assertion " + n + " toBe: " + __upstreamValue(actual) + " != " + __upstreamValue(expected)); },
@@ -198,7 +216,8 @@ function __upstreamExpect(actual) {
     toHaveProperty(expected) { const n = ++__upstreamAssertion; if (actual == null || !(expected in Object(actual))) __upstreamFail("assertion " + n + " missing property " + String(expected)); },
     toMatchObject(expected) { const n = ++__upstreamAssertion; if (!__upstreamSubset(actual, expected)) __upstreamFail("assertion " + n + " object subset mismatch"); },
     toMatch(expected) { const n = ++__upstreamAssertion; const value = String(actual); if (expected instanceof RegExp ? !expected.test(value) : !value.includes(String(expected))) __upstreamFail("assertion " + n + " pattern mismatch"); },
-    toMatchInlineSnapshot(expected) { const n = ++__upstreamAssertion; const value = typeof actual === "string" ? JSON.stringify(actual) : String(actual); if (value !== String(expected).trim()) __upstreamFail("assertion " + n + " inline snapshot mismatch: " + value + " != " + String(expected).trim()); },
+    toMatchInlineSnapshot(expected) { const n = ++__upstreamAssertion; const value = __upstreamNormalizeInlineSnapshot(__upstreamInlineSnapshotValue(actual)); const snapshot = __upstreamNormalizeInlineSnapshot(expected); if (value !== snapshot) __upstreamFail("assertion " + n + " inline snapshot mismatch: " + value + " != " + snapshot); },
+    toBeGreaterThan(expected) { const n = ++__upstreamAssertion; if (!(actual > expected)) __upstreamFail("assertion " + n + " expected greater value"); },
     toBeCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (!calls || calls.length === 0) __upstreamFail("assertion " + n + " expected spy to be called"); },
     toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (!calls || calls.length === 0) __upstreamFail("assertion " + n + " expected spy to be called"); },
     toBeCalledWith() { const n = ++__upstreamAssertion; const expected = Array.prototype.slice.call(arguments); const calls = __upstreamMockCalls(actual); let matched = false; if (calls) for (let i = 0; i < calls.length; i++) if (__upstreamSame(calls[i], expected)) matched = true; if (!matched) __upstreamFail("assertion " + n + " expected matching spy call"); },
@@ -229,13 +248,17 @@ function __upstreamExpect(actual) {
     toBeNull() { const n = ++__upstreamAssertion; if (actual === null) __upstreamFail("assertion " + n + " unexpectedly null"); },
     toBeTruthy() { const n = ++__upstreamAssertion; if (actual) __upstreamFail("assertion " + n + " unexpectedly truthy"); },
     toBeFalsy() { const n = ++__upstreamAssertion; if (!actual) __upstreamFail("assertion " + n + " unexpectedly falsey"); },
+    toMatchInlineSnapshot(expected) { const n = ++__upstreamAssertion; const value = __upstreamNormalizeInlineSnapshot(__upstreamInlineSnapshotValue(actual)); const snapshot = __upstreamNormalizeInlineSnapshot(expected); if (value === snapshot) __upstreamFail("assertion " + n + " unexpectedly matched inline snapshot"); },
     toBeInstanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected === "function" && actual instanceof expected) __upstreamFail("assertion " + n + " unexpected instance"); },
     instanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected === "function" && actual instanceof expected) __upstreamFail("assertion " + n + " unexpected instance"); },
     toBeCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
     toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
     toHaveBeenCalledOnce() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length === 1) __upstreamFail("assertion " + n + " unexpected spy call"); },
-    toThrow() { const n = ++__upstreamAssertion; if (typeof actual !== "function" || __upstreamThrown(actual) !== null) __upstreamFail("assertion " + n + " unexpected throw"); },
-    toThrowError() { const n = ++__upstreamAssertion; if (typeof actual !== "function" || __upstreamThrown(actual) !== null) __upstreamFail("assertion " + n + " unexpected throw"); },
+    toBeCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
+    toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
+    toHaveBeenCalledOnce() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length === 1) __upstreamFail("assertion " + n + " unexpected spy call"); },
+    toThrow(expected) { const n = ++__upstreamAssertion; const error = typeof actual === "function" ? __upstreamThrown(actual) : new Error("not callable"); if (error !== null && (expected === undefined || __upstreamThrownMatches(error, expected))) __upstreamFail("assertion " + n + " unexpected throw"); },
+    toThrowError(expected) { const n = ++__upstreamAssertion; const error = typeof actual === "function" ? __upstreamThrown(actual) : new Error("not callable"); if (error !== null && (expected === undefined || __upstreamThrownMatches(error, expected))) __upstreamFail("assertion " + n + " unexpected throw"); },
   };
   // Vitest/Jest promise assertions are part of the upstream test contract,
   // not optional syntax. Attach rejection handlers immediately so a rejected
@@ -1084,6 +1107,7 @@ export function summarizeUpstreamRuns({ name, pin, testFiles, selectedFiles, run
       testFiles: testFiles.length,
       testFilePaths: testFiles,
       registrationSites: pin.registrationSites,
+      selectedRegistrationSites: pin.selectedRegistrationSites ?? null,
       selectedFiles,
     },
     extraction: {
@@ -1142,7 +1166,16 @@ export function summarizeUpstreamRuns({ name, pin, testFiles, selectedFiles, run
   }
   const registrationSites = Number(pin.registrationSites);
   if (Number.isFinite(registrationSites)) {
-    report.extraction.deferredRegistrations = Math.max(0, registrationSites - report.extraction.testsRegistered);
+    // `testsRegistered` may include expanded `test.each`/`it.each` cases and
+    // therefore cannot be compared directly with the static call-site count.
+    // An adapter can provide the number of static sites it selected so the
+    // report keeps deferred host infrastructure visible without inventing a
+    // negative or zero deferred count after table expansion.
+    const selectedRegistrationSites = Number(pin.selectedRegistrationSites);
+    const registeredForInventory = Number.isFinite(selectedRegistrationSites)
+      ? selectedRegistrationSites
+      : report.extraction.testsRegistered;
+    report.extraction.deferredRegistrations = Math.max(0, registrationSites - registeredForInventory);
     report.extraction.unavailableInfra = report.extraction.deferredRegistrations;
   }
   report.compile.details = runs.map((run) => ({

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -254,6 +254,8 @@ QUnit.test("matcher aliases", function () {
   expect(called).toHaveBeenCalledWith("value");
   expect("plain").not.instanceOf(ErrorCtor);
   expect("plain").not.toBeInstanceOf(ErrorCtor);
+  expect(() => { throw new Error("different message"); }).not.toThrow("expected message");
+  expect(() => {}).not.toThrow("expected message");
 });
 ${UPSTREAM_TEST_EXPORTS}`;
 
@@ -536,7 +538,13 @@ export function runUpstreamTest() {
   it("reports deferred upstream registrations as unavailable infrastructure", () => {
     const report = summarizeUpstreamRuns({
       name: "fixture",
-      pin: { repo: "https://example.test/fixture", tag: "v1", commit: "abc", registrationSites: 5 },
+      pin: {
+        repo: "https://example.test/fixture",
+        tag: "v1",
+        commit: "abc",
+        registrationSites: 5,
+        selectedRegistrationSites: 2,
+      },
       testFiles: ["a.test.ts", "b.test.ts"],
       selectedFiles: ["a.test.ts"],
       runs: [


### PR DESCRIPTION
## Summary

- Expand the pinned Prettier upstream adapter from 3 to 16 original `tests/unit/*.js` files.
- Add deterministic ignored source shims for Prettier's small utility dependencies and the missing `isUrlString` export.
- Add inline-snapshot and `toBeGreaterThan` support to the shared upstream runner.
- Fix negative `toThrow`/`toThrowError` so message and constructor arguments are respected.
- Preserve unavailable infrastructure when `test.each` expands beyond static registration-site counts.
- Record the measured checkpoint in [3995](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).

## Measurement

Against the pinned Prettier 3.8.1 source revision:

- 151/151 original callbacks pass in the native oracle.
- 16/16 selected modules compile; 10/16 validate; 48/151 native-compatible callbacks pass in Wasm.
- 11 direct registration sites remain explicitly unavailable across four deferred files.
- The remaining Wasm failures are compiler/runtime findings, not hidden host setup failures.

## Verification

- `pnpm run typecheck`
- `pnpm exec vitest run tests/dogfood/upstream-suite-runner.test.ts`
- `pnpm exec prettier --check` on all changed files
- `node scripts/check-issue-ids.mjs --check`
- `node --import tsx tests/dogfood/prettier-upstream-suite.mjs --json`
