### PR TITLE
feat(ir): nested classes with static methods compile once — the sealing-order transaction

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -4,7 +4,9 @@ title: "IR-only R3: compile-once classes, members, and closures"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-15
+updated: 2026-08-21
+assignee: ttraenkler/fable-lead
+branch: claude/ir-3522-static-nested-family
 priority: critical
 horizon: xl
 complexity: XL
@@ -92,6 +94,7 @@ loc-budget-allow:
   - src/ir/prepared-component-dependencies.ts
   - src/ir/select.ts
 func-budget-allow:
+  - src/ir/select.ts::isPhase1Expr
   - src/codegen/class-bodies.ts::collectClassDeclaration
   - src/codegen/declarations.ts::compileDeclarations
   - src/codegen/function-body.ts::compileFunctionBody
@@ -2865,3 +2868,184 @@ STATIC members on nested classes (the sealing-order transaction above), field
 initializers carrying call edges (the attribution transaction above), computed
 member names, nested heritage, and then top-level class expressions with their
 module-global binding ABI.
+
+### Slice record — nested class STATIC METHODS, the sealing-order transaction (2026-08-22)
+
+The boundary the previous slice deferred and named next. Measured on
+`origin/main` `34e102dc8` before any change and again after, through the
+production `compile` seam with `experimentalIR: true, trackIrOutcomes: true`.
+Every row is identical on `gc` and `standalone`, and every `run=` value was
+cross-checked against the same program in node.
+
+| Fixture                                        | Before        | After         | run |
+| ---------------------------------------------- | ------------- | ------------- | --- |
+| nested class reached ONLY via a static, no `new` | legacy=1 ir=0 | legacy=0 ir=2 | 42  |
+| two statics, no `new`                          | legacy=1 ir=0 | legacy=0 ir=3 | 42  |
+| static calling a sibling static                | legacy=1 ir=0 | legacy=0 ir=3 | 42  |
+| static + instance method                       | legacy=1 ir=0 | legacy=0 ir=3 | 42  |
+| static + initialized field + instance method   | legacy=1 ir=0 | legacy=0 ir=4 | 42  |
+| static + explicit constructor                  | legacy=1 ir=0 | legacy=0 ir=4 | 42  |
+| multi-parameter static                         | legacy=1 ir=0 | legacy=0 ir=2 | 42  |
+| string-returning static                        | legacy=1 ir=0 | legacy=0 ir=2 | 42  |
+
+The gain is the whole enclosing function plus every member: before the slice the
+owner read `body-shape-rejected@select` and the members were never inventoried.
+The identical static-method shape on a TOP-LEVEL class already compiled once
+(`legacy=0 ir=4`), so no lowering, ABI, value representation or import surface
+was added — the capability was already proven.
+
+**The recorded terminal diagnostic reproduces exactly, and only for ONE shape.**
+Relaxing the member-shape gate alone gives, for a class reached ONLY through its
+static side:
+
+```
+run  kind=invariant  code=unexpected-internal-throw  stage=lower
+ABI draft ir-binding:v1:callable:…class-implicit-constructor…:body:…
+  would mutate sealed prepared scope
+  prepared-component:…class-static-method:…+…root:top-level-function:…
+```
+
+Bisected by shape one at a time, the invariant fires **iff** no `new` appears
+anywhere in the transaction: `static-only, no new` · `two statics, no new` ·
+`static calling a static` all throw, while the same class WITH a `new Box()`
+somewhere, or beside any instance method, field or explicit constructor, is
+clean. The stack names the site: `emitInstrTree → resolveClass →
+ClassRegistry.resolve → initRef → bindUnitCallableSlot →
+planProgramAbiUnitCallable`. `ClassRegistry.resolve` binds the source-owned
+`_init` callable for **every** class shape the lowering materializes, not only
+for constructed ones, and `prepareImplicitConstructorSupports` — which plans that
+binding up front — scanned for `new <Identifier>` only. With no `new`, nothing
+planned it, so `initRef` planned it lazily during lowering, after the static
+component had sealed.
+
+**The transaction is an ORDERING one; nothing about the seal moves.** Three
+source edits:
+
+1. `isBoundedPreparedNestedOrdinaryClass` (`src/ir/class-accessor-safety.ts`)
+   rejected every static member. It now admits a static METHOD under exactly the
+   member shape instance methods already carry — undecorated, identifier-named,
+   body-bearing, non-abstract, non-async, non-generator, fixed-arity. A static
+   method's definition evaluation is a method's: a body-bearing callable
+   installed on the constructor object, with nothing running in the containing
+   frame. Static FIELDS and static ACCESSORS stay rejected (below).
+2. `prepareImplicitConstructorSupports` (`src/codegen/ir-plain-implicit-constructors.ts`)
+   now reaches a bounded nested class through a STATIC MEMBER ACCESS on its
+   identifier, exactly as it already does for `new <Identifier>`, so the support
+   pair is planned in the same pre-seal planning phase as the static member.
+   The reaching walk moved into `collectPreparedImplicitConstructorClasses` (the
+   function budget caps the caller at 300 LOC). The static admission is
+   restricted to classes that actually carry a static member, so every
+   pre-existing static-free shape keeps the exact `new`-only population.
+3. `isPhase1Expr` (`src/ir/select.ts`) — the correctness fix this slice forced,
+   below.
+
+**A prepared class binding is not a first-class IR value (the correctness fix).**
+Admitting statics made a static-side ALIAS reachable, and it leaked. Measured
+before the fix, `class Box { static k() {…} } const Alias = Box; return
+Alias.k();` claimed and EMITTED `Box_k` while `run` fell back, and recorded the
+post-claim BUILD error `ir/from-ast: identifier "Box" is not in scope in run` —
+split ownership, which R3 exists to prevent. The equivalent instance-member
+program was already withdrawn correctly, by the `constructor-resolution-unsupported`
+arm on `new Alias()`; the static side has no such arm. The class-declaration and
+`const C = class {…}` arms add the binding NAME to the selector scope purely so
+the dedicated `new C(...)`, `C.staticMember` and `x instanceof C` arms can
+consume it — those resolve the binding themselves and never reach the generic
+identifier accept, so anything that DOES reach it is a bare value use. That
+accept now rejects a name in `currentPreparedClassBindingNames`, withdrawing the
+owner at selection so the class withdraws with it. A/B'd against unmodified
+`origin/main` on seven class-binding shapes — nested `instanceof` on a
+declaration, top-level `instanceof`, top-level class-as-value, nested
+`new`-only declaration, nested `new`-only class expression, nested
+class-expression `instanceof`, and static-beside-`new` — all byte-identical
+before and after; only the two aliasing shapes move, and both move from a leak
+to a clean demotion.
+
+Exact static-member boundary, measured one shape at a time:
+
+| Static member shape                       | Verdict                                   |
+| ----------------------------------------- | ----------------------------------------- |
+| static method, any arity, number/string   | claims                                    |
+| static reached from a sibling static body | claims                                    |
+| static beside field / method / ctor       | claims                                    |
+| static FIELD                              | direct (`body-shape-rejected`)            |
+| static ACCESSOR                           | direct (`body-shape-rejected`)            |
+| computed static name                      | direct (`body-shape-rejected`)            |
+| `async` / generator static                | direct (`body-shape-rejected`)            |
+| heritage                                  | direct (the explicit #4448/#4575 guard)   |
+| static capturing the enclosing frame      | direct (`class-member-unsupported`)       |
+| static-ONLY class EXPRESSION              | direct (`body-shape-rejected`) — residual |
+| class binding used as a VALUE             | owner AND class withdrawn together        |
+
+A static FIELD stays out because its initializer runs at class-definition time
+IN the containing frame, which is exactly the inertness the predicate asserts —
+a different ordered contract. A static ACCESSOR stays out because its descriptor
+is not on the ordinary descriptor-by-name-and-kind path this family resolves.
+
+**Residual, measured not assumed: the static-ONLY class EXPRESSION.** A nested
+class expression whose binding is consumed by a `new` is already admitted, and
+one carrying a static BESIDE an instance member is admitted by this slice
+(`const Box = class { static base() {…} get() { return Box.base() + 2; } }`
+compiles once). What stays out is the static-ONLY expression: its `const`
+binding is proven safe only for CONSTRUCTION uses
+(`boundedClassExpressionBindingHasOnlyStaticConstructionUses`), which a static
+member access is not, so the binding never reaches the projected local-class set
+and the owner rejects at `body-shape-rejected` — its base behaviour, a clean
+demotion, not a failure. Widening that binding proof is a separate transaction
+from the sealing order and is left to the class-expression boundary.
+
+Coverage is `tests/issue-3522-nested-class-static.test.ts`, **33/33** on `gc`
+and `standalone`: direct class/function body poison on every expected body,
+exact terminal outcomes, one shared prepared component across owner + statics
+whose id is asserted to NAME the `class-static-method` scope (the scope whose
+seal the draft used to arrive after), Wasm validation, runtime results
+cross-checked against node, dual-run legacy↔IR equality on six fixtures, and a
+static-call evaluation-ORDER chain checked against the DIRECT path rather than a
+hard-coded constant. The WAT proof uses a parameterised fixture so the static
+call cannot constant-fold: the prepared owner, the static and the instance
+method carry no `externref`, boxing, `call_ref`, `call_indirect`, `ref.test` or
+`__call_m_*` traffic; `run` reaches the static as a direct `return_call`; the
+STATIC callable declares no receiver slot while the instance method beside it
+declares `(param (ref null …))`; and `run` contains no `struct.new` — a class
+reached only through its static side allocates nothing, so the ordering fix
+plans the `_init` binding without forcing a construction. Eleven negative
+boundaries are verified rather than assumed (the table above plus a
+name-shadowing direct↔IR parity check and a positive control proving the direct
+class-body emitter is still reached).
+
+One pin in the implicit-constructor suite moved: "keeps a nested class with a
+static member direct" pinned a static METHOD, which this slice admits. It now
+pins the static ACCESSOR, the boundary that remains.
+
+**A pre-existing defect found while A/B-ing, neither introduced nor hidden
+here:** `const Box = class { get() { return 42; } }; const b = new Box(); return
+b instanceof Box ? b.get() : 0;` returns **0**, not 42 — identically on this
+branch and on unmodified `origin/main`, on the direct path. Nested
+class-expression `instanceof` evaluates false. Not this slice's territory;
+recorded so it is not rediscovered as a regression.
+
+Gates: focused class-family suites (nested implicit-constructor, accessor,
+field, class-expression ownership, nested-class ownership, static class-method)
+plus the new suite **114/114**; `check:ir-fallbacks --verbose` OK — no
+unintended, post-claim or module-level increases (only the two unchanged
+deferred string-builder candidates); `check:ir-only` **READY** on both lanes —
+single-host and standalone each **38/38 terminal units, 38 IR-emitted, 0 legacy
+bodies, 0 unsupported, 0 invariants**, byte-identical to the same run on
+unmodified base; `check:ir-only --policy=hybrid` **READY**;
+`gen:ir-adoption --check` byte-clean with no row refresh needed; typecheck
+**543 errors on base and 543 on this branch** (all pre-existing `@types/node`
+noise under symlinked `node_modules`) — no new errors; lint and `format:check`
+green on every changed file.
+
+Budget grants for this change-set are in this file's frontmatter, not in any
+`scripts/*-baseline.json`: `src/ir/select.ts` was already granted under
+`loc-budget-allow`, and `src/ir/select.ts::isPhase1Expr` is added under
+`func-budget-allow` (+13 LOC for the value-use guard). The reaching-set
+extraction kept `prepareImplicitConstructorSupports` under its own 300-LOC cap
+without a grant.
+
+Remaining nested class-family boundaries, in the order their surfaces grow:
+field initializers carrying call edges (the attribution transaction recorded in
+the previous slice), static-ONLY class expressions (the binding-proof residual
+above), computed member names, static fields with their class-definition-time
+ordered contract, nested heritage, and then top-level class expressions with
+their module-global binding ABI.

--- a/src/codegen/ir-plain-implicit-constructors.ts
+++ b/src/codegen/ir-plain-implicit-constructors.ts
@@ -83,6 +83,65 @@ function sameValType(left: ValType, right: ValType): boolean {
  * as an exact parent-init chain. Initialized instance fields and host-backed
  * construction remain direct until their complete contracts are represented.
  */
+/**
+ * Every class an owner unit's own body materializes, and whose implicit
+ * constructor this pass may therefore prepare.
+ *
+ * Two reaching forms, both resolved through the oracle and both restricted to
+ * the owner's OWN body (the walk stops at any nested executable or class, whose
+ * units carry their own entry in `ownerUnitIds`):
+ *
+ *   - `new <Identifier>(...)`, the construction form; and
+ *   - (#3522) a STATIC MEMBER ACCESS `<Identifier>.member` on a class that
+ *     carries a static member. A class reached only through its static side is
+ *     materialized by the lowering exactly like a constructed one:
+ *     `ClassRegistry.resolve` binds the source-owned `_init` callable for every
+ *     class shape it resolves, not only for the ones a `new` reaches. With no
+ *     `new` anywhere in the transaction that binding was planned lazily DURING
+ *     lowering, after the static component had sealed — the measured
+ *     "ABI draft …class-implicit-constructor…:body would mutate sealed prepared
+ *     scope …class-static-method…" invariant. Reaching the class here plans its
+ *     support pair in the SAME planning phase as its static member, before the
+ *     seal; nothing about the seal itself moves.
+ *
+ * The static form is restricted to classes that actually carry a static member,
+ * so every pre-existing static-free shape keeps the exact `new`-only population.
+ */
+function collectPreparedImplicitConstructorClasses(input: {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly ownerUnitIds: ReadonlySet<IrUnitId>;
+  readonly identityPlan: IrOverlayIdentityPlan;
+}): Set<ImplicitConstructorClass> {
+  const referencedClassDeclarations = new Set<ImplicitConstructorClass>();
+  const admit = (expression: ts.Identifier, requireStaticMember: boolean): void => {
+    for (const declaration of input.ctx.oracle.declarationsOf(expression)) {
+      const owner = implicitConstructorClassForDeclaration(declaration);
+      if (
+        owner &&
+        (!requireStaticMember || owner.members.some(hasStaticModifier)) &&
+        isAdmissibleImplicitConstructorClass(owner, input.sourceFile)
+      ) {
+        referencedClassDeclarations.add(owner);
+      }
+    }
+  };
+  for (const ownerUnitId of input.ownerUnitIds) {
+    const root = input.identityPlan.identityContext.declarationByUnitId.get(ownerUnitId);
+    if (!root) continue;
+    const visit = (node: ts.Node): void => {
+      if (node !== root && (ts.isFunctionLike(node) || ts.isClassDeclaration(node) || ts.isClassExpression(node))) {
+        return;
+      }
+      if (ts.isNewExpression(node) && ts.isIdentifier(node.expression)) admit(node.expression, false);
+      if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression)) admit(node.expression, true);
+      ts.forEachChild(node, visit);
+    };
+    visit(root);
+  }
+  return referencedClassDeclarations;
+}
+
 export function prepareImplicitConstructorSupports(input: {
   readonly ctx: CodegenContext;
   readonly sourceFile: ts.SourceFile;
@@ -91,26 +150,7 @@ export function prepareImplicitConstructorSupports(input: {
   readonly classShapes: ReadonlyMap<string, IrClassShape>;
   readonly classShapesById: ReadonlyMap<IrClassId, IrClassShape>;
 }): ReadonlySet<IrUnitId> {
-  const referencedClassDeclarations = new Set<ImplicitConstructorClass>();
-  for (const ownerUnitId of input.ownerUnitIds) {
-    const root = input.identityPlan.identityContext.declarationByUnitId.get(ownerUnitId);
-    if (!root) continue;
-    const visit = (node: ts.Node): void => {
-      if (node !== root && (ts.isFunctionLike(node) || ts.isClassDeclaration(node) || ts.isClassExpression(node))) {
-        return;
-      }
-      if (ts.isNewExpression(node) && ts.isIdentifier(node.expression)) {
-        for (const declaration of input.ctx.oracle.declarationsOf(node.expression)) {
-          const owner = implicitConstructorClassForDeclaration(declaration);
-          if (owner && isAdmissibleImplicitConstructorClass(owner, input.sourceFile)) {
-            referencedClassDeclarations.add(owner);
-          }
-        }
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(root);
-  }
+  const referencedClassDeclarations = collectPreparedImplicitConstructorClasses(input);
 
   // A synthesized derived constructor forwards to its exact parent `_init`.
   // Pull every local ancestor into the support-preparation population so a

--- a/src/ir/class-accessor-safety.ts
+++ b/src/ir/class-accessor-safety.ts
@@ -162,6 +162,17 @@ function hasFixedPreparedParameters(parameters: readonly ts.ParameterDeclaration
  * contract and stay rejected above: their initializer runs at class-definition
  * time IN the containing frame, which is exactly the inertness this predicate
  * asserts.
+ *
+ * #3522 — STATIC METHODS are ordinary members of this family. A static
+ * method's definition evaluation is a method's: a body-bearing callable
+ * installed on the constructor object, with nothing running in the containing
+ * frame. The lowering and the callable ABI are proven at top level (a
+ * top-level class with a static method compiles once today). Admitting them
+ * here required ORDERING, not lowering: a class reached only through its
+ * static side is still fully materialized by `ClassRegistry.resolve`, which
+ * binds the source-owned `_init` callable for every class shape it resolves —
+ * see `prepareImplicitConstructorSupports`, which now pulls such a class into
+ * the pre-seal support population.
  */
 export function isBoundedPreparedNestedOrdinaryClass(declaration: ts.ClassDeclaration | ts.ClassExpression): boolean {
   if (declaration.heritageClauses?.length || hasDecorators(declaration) || declaration.members.length === 0) {
@@ -182,7 +193,14 @@ export function isBoundedPreparedNestedOrdinaryClass(declaration: ts.ClassDeclar
       }
       continue;
     }
-    if (isStatic) return false;
+    // (#3522) STATIC METHODS are inert in the containing frame exactly as
+    // instance methods are: ClassDefinitionEvaluation installs a body-bearing
+    // callable on the constructor object and runs none of it. Static FIELDS
+    // and static ACCESSORS stay rejected — a static field's initializer runs
+    // at class-definition time IN the containing frame (the inertness this
+    // predicate asserts), and a static accessor's descriptor is not part of
+    // the ordinary descriptor-by-name-and-kind path this family resolves.
+    if (isStatic && !ts.isMethodDeclaration(member)) return false;
     if (ts.isConstructorDeclaration(member)) {
       if (!member.body) continue; // Type-only overload signature.
       constructorCount++;

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -8185,7 +8185,23 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     if (isUnrepresentableModuleBinding(expr)) {
       return shapeNo("expr-module-storage-unrepresentable", expr);
     }
-    if (scope.has(expr.text)) return true;
+    if (scope.has(expr.text)) {
+      // (#3522) A prepared nested class binding is a CONSTRUCTOR IDENTITY, not
+      // a first-class IR value. The class-declaration and `const C = class {…}`
+      // arms add the name to `scope` so the dedicated `new C(...)`,
+      // `C.staticMember` and `x instanceof C` arms can consume it — those arms
+      // resolve the binding themselves and never reach this generic identifier
+      // accept. Anything that DOES reach here is a bare value use
+      // (`const Alias = C;`, `return C;`, passing `C` as an argument), which
+      // `ir/from-ast` cannot represent: it reports
+      // "identifier \"C\" is not in scope" as a POST-CLAIM build error, after
+      // the class members have already been claimed and emitted — the exact
+      // split-ownership state R3 exists to prevent. Reject the owner here, at
+      // selection, so the whole class withdraws with it.
+      return currentPreparedClassBindingNames.has(expr.text)
+        ? shapeNo("expr-prepared-class-binding-value", expr)
+        : true;
+    }
     if (
       currentHostGlobalResolver !== null &&
       !localClasses.has(expr.text) &&

--- a/tests/issue-3522-nested-class-static.test.ts
+++ b/tests/issue-3522-nested-class-static.test.ts
@@ -1,0 +1,626 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#3522) Nested classes carrying STATIC METHODS compile once.
+//
+// Measured on `origin/main` 34e102dc8 before this slice, through the production
+// `compile` seam (`experimentalIR: true, trackIrOutcomes: true`): every shape
+// below withdrew its WHOLE enclosing function — `body-shape-rejected` on the
+// owner, `legacy=1 ir=0` — while the identical static-method shape on a
+// TOP-LEVEL class already compiled once (`legacy=0 ir=4`).
+//
+// Relaxing the member-shape gate alone reproduces the terminal diagnostic the
+// previous slice recorded, and ONLY for a class reached exclusively through its
+// static side (no `new` anywhere in the transaction):
+//
+//   run  kind=invariant  code=unexpected-internal-throw  stage=lower
+//   "ABI draft …class-implicit-constructor…:body would mutate sealed prepared
+//    scope prepared-component:…class-static-method…+…top-level-function…"
+//
+// `ClassRegistry.resolve` binds the source-owned `_init` callable for EVERY
+// class shape the lowering materializes, not only for the ones a `new` reaches.
+// With no `new`, nothing planned that binding up front, so it was planned
+// lazily during lowering — after the static component sealed. The transaction
+// is an ORDERING one: the implicit-constructor reaching set now also reaches a
+// bounded nested class through a STATIC MEMBER ACCESS on its identifier, so the
+// support pair is planned in the same pre-seal phase as the static member.
+//
+// Every expected value was cross-checked against the same program in node.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const TARGETS = ["gc", "standalone"] as const;
+
+function outcome(result: CompileResult, name: string): IrObservedOutcome {
+  const observed = (result.irOutcomes ?? []).filter((candidate) => candidate.displayName.startsWith(name));
+  expect(observed, `terminal outcome count for ${name}`).toHaveLength(1);
+  return observed[0]!;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setExports?.(exports);
+  return exports;
+}
+
+/**
+ * Compile with the direct class/function body emitters poisoned, so a hidden
+ * direct compile followed by an IR patch cannot satisfy a positive assertion.
+ */
+async function compilePoisoned(
+  source: string,
+  fileName: string,
+  target: (typeof TARGETS)[number],
+  classBodies: readonly string[],
+  functionBodies: readonly string[],
+): Promise<CompileResult> {
+  const previousClass = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+  const previousFunction = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+  try {
+    process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = classBodies.join(",");
+    process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = functionBodies.join(",");
+    return await compile(source, {
+      fileName,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+      target,
+    });
+  } finally {
+    if (previousClass === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+    else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClass;
+    if (previousFunction === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+    else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunction;
+  }
+}
+
+function expectCompiledOnce(result: CompileResult, names: readonly string[]): void {
+  for (const name of names) {
+    expect(outcome(result, name), `${name} must be prepared IR`).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+  }
+  expect(result.irPostClaimErrors ?? []).toEqual([]);
+}
+
+function expectDirect(result: CompileResult, names: readonly string[]): void {
+  for (const name of names) {
+    expect(outcome(result, name), `${name} must remain direct`).toMatchObject({
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+  }
+  expect(result.irPostClaimErrors ?? []).toEqual([]);
+}
+
+// node: 42. THE fixture that reproduces the sealing-order invariant — a class
+// reached only through its static side, with no `new` anywhere.
+const STATIC_ONLY = `
+export function run(): number {
+  class Box {
+    make(): number { return 0; }
+    static base(): number { return 42; }
+  }
+  return Box.base();
+}
+`;
+
+// node: 40 + 2 === 42
+const TWO_STATICS = `
+export function run(): number {
+  class Box {
+    static a(): number { return 40; }
+    static b(): number { return 2; }
+  }
+  return Box.a() + Box.b();
+}
+`;
+
+// node: 40 + 2 === 42 — a static reached from inside ANOTHER static body, so
+// the reaching walk must find it from a class-member owner unit, not only from
+// the enclosing function.
+const STATIC_CALLS_STATIC = `
+export function run(): number {
+  class Box {
+    static a(): number { return Box.b() + 2; }
+    static b(): number { return 40; }
+  }
+  return Box.a();
+}
+`;
+
+// node: 40 + 2 === 42
+const STATIC_PLUS_INSTANCE = `
+export function run(): number {
+  class Box {
+    static base(): number { return 40; }
+    get(): number { return Box.base() + 2; }
+  }
+  return new Box().get();
+}
+`;
+
+// node: 40 + 2 === 42 — statics beside an initialized field and an implicit
+// constructor, the family the previous slice admitted.
+const STATIC_FIELD_METHOD = `
+export function run(): number {
+  class Box {
+    p: number = 40;
+    static base(): number { return 2; }
+    get(): number { return this.p + Box.base(); }
+  }
+  return new Box().get();
+}
+`;
+
+// node: 2 + 40 === 42
+const STATIC_EXPLICIT_CTOR = `
+export function run(seed: number): number {
+  class Box {
+    p: number;
+    constructor(v: number) { this.p = v; }
+    static base(): number { return 40; }
+    get(): number { return this.p + Box.base(); }
+  }
+  return new Box(seed).get();
+}
+`;
+
+describe("#3522 nested class static-member ownership", () => {
+  it.each(TARGETS)("prepares a STATIC-ONLY reached class once in the %s lane", async (target) => {
+    const prepared = await compilePoisoned(
+      STATIC_ONLY,
+      `nested-static-only-${target}.ts`,
+      target,
+      ["Box_base", "Box_make"],
+      ["run"],
+    );
+
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(prepared.binary)).toBe(true);
+    // This is the sealing-order case: before the transaction it was
+    // `unexpected-internal-throw@lower`, not merely a demotion.
+    expectCompiledOnce(prepared, ["run", "Box_base@", "Box_make@"]);
+    expect((await instantiate(prepared)).run!()).toBe(42);
+  });
+
+  it.each(TARGETS)("prepares TWO static methods once in the %s lane", async (target) => {
+    const prepared = await compilePoisoned(
+      TWO_STATICS,
+      `nested-static-two-${target}.ts`,
+      target,
+      ["Box_a", "Box_b"],
+      ["run"],
+    );
+
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(prepared.binary)).toBe(true);
+    expectCompiledOnce(prepared, ["run", "Box_a@", "Box_b@"]);
+    expect((await instantiate(prepared)).run!()).toBe(42);
+  });
+
+  it.each(TARGETS)("prepares a static reached from another STATIC BODY in the %s lane", async (target) => {
+    const prepared = await compilePoisoned(
+      STATIC_CALLS_STATIC,
+      `nested-static-chain-${target}.ts`,
+      target,
+      ["Box_a", "Box_b"],
+      ["run"],
+    );
+
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(prepared.binary)).toBe(true);
+    expectCompiledOnce(prepared, ["run", "Box_a@", "Box_b@"]);
+    expect((await instantiate(prepared)).run!()).toBe(42);
+  });
+
+  it.each(TARGETS)("prepares a static beside an INSTANCE method in the %s lane", async (target) => {
+    const prepared = await compilePoisoned(
+      STATIC_PLUS_INSTANCE,
+      `nested-static-instance-${target}.ts`,
+      target,
+      ["Box_base", "Box_get"],
+      ["run"],
+    );
+
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(prepared.binary)).toBe(true);
+    expectCompiledOnce(prepared, ["run", "Box_base@", "Box_get@"]);
+    expect((await instantiate(prepared)).run!()).toBe(42);
+  });
+
+  it.each(TARGETS)("prepares a static beside an INITIALIZED FIELD in the %s lane", async (target) => {
+    const prepared = await compilePoisoned(
+      STATIC_FIELD_METHOD,
+      `nested-static-field-${target}.ts`,
+      target,
+      ["Box_base", "Box_get", "Box_new"],
+      ["run"],
+    );
+
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(prepared.binary)).toBe(true);
+    // The gain is the whole owner plus every member INCLUDING the promoted
+    // implicit-constructor terminal the previous slice introduced.
+    expectCompiledOnce(prepared, ["run", "Box_base@", "Box_get@", "Box_new@"]);
+    expect((await instantiate(prepared)).run!()).toBe(42);
+  });
+
+  it.each(TARGETS)("prepares a static beside an EXPLICIT constructor in the %s lane", async (target) => {
+    const prepared = await compilePoisoned(
+      STATIC_EXPLICIT_CTOR,
+      `nested-static-explicit-${target}.ts`,
+      target,
+      ["Box_base", "Box_get", "Box_new"],
+      ["run"],
+    );
+
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(prepared.binary)).toBe(true);
+    expectCompiledOnce(prepared, ["run", "Box_base@", "Box_get@", "Box_new@"]);
+    expect((await instantiate(prepared)).run!(2)).toBe(42);
+  });
+
+  it.each(TARGETS)("prepares a MULTI-PARAMETER static in the %s lane", async (target) => {
+    // node: 40 + 2 === 42. Arity is carried by the callable ABI, not by a
+    // receiver: a static takes no `this` slot.
+    const source = `
+    export function run(): number {
+      class Box { static add(a: number, b: number): number { return a + b; } }
+      return Box.add(40, 2);
+    }
+    `;
+    const prepared = await compilePoisoned(source, `nested-static-arity-${target}.ts`, target, ["Box_add"], ["run"]);
+
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(prepared.binary)).toBe(true);
+    expectCompiledOnce(prepared, ["run", "Box_add@"]);
+    expect((await instantiate(prepared)).run!()).toBe(42);
+  });
+
+  it.each(TARGETS)("prepares a STRING-returning static in the %s lane", async (target) => {
+    // node: "abc".length + 39 === 42. Proves the static callable is not
+    // restricted to scalar returns — a reference-bearing result reaches the
+    // same prepared route.
+    const source = `
+    export function run(): number {
+      class Box { static label(): string { return "abc"; } }
+      return Box.label().length + 39;
+    }
+    `;
+    const prepared = await compilePoisoned(source, `nested-static-string-${target}.ts`, target, ["Box_label"], ["run"]);
+
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(prepared.binary)).toBe(true);
+    expectCompiledOnce(prepared, ["run", "Box_label@"]);
+    expect((await instantiate(prepared)).run!()).toBe(42);
+  });
+
+  it.each(TARGETS)("shares one prepared component across owner and statics in the %s lane", async (target) => {
+    const prepared = await compilePoisoned(
+      STATIC_PLUS_INSTANCE,
+      `nested-static-component-${target}.ts`,
+      target,
+      ["Box_base", "Box_get"],
+      ["run"],
+    );
+    const observed = [outcome(prepared, "run"), outcome(prepared, "Box_base@"), outcome(prepared, "Box_get@")];
+    const componentIds = new Set(observed.map((candidate) => candidate.preparedComponentId));
+    expect(componentIds.size).toBe(1);
+    expect([...componentIds][0]).toMatch(/^prepared-component:/);
+    // The component id must name the static-method unit — that is the scope
+    // whose seal the implicit-constructor draft used to arrive after.
+    expect([...componentIds][0]).toContain("class-static-method");
+  });
+
+  it.each(TARGETS)("keeps the prepared static owner free of dynamic dispatch in the %s lane", async (target) => {
+    // Parameterised so the static call cannot constant-fold away — the shape
+    // under test is the CALL, not a folded literal.
+    const source = `
+    export function run(seed: number): number {
+      class Box {
+        make(): number { return 0; }
+        static base(v: number): number { return v + 40; }
+      }
+      return Box.base(seed);
+    }
+    `;
+    const prepared = await compilePoisoned(
+      source,
+      `nested-static-shape-${target}.ts`,
+      target,
+      ["Box_base", "Box_make", "Box_new"],
+      ["run"],
+    );
+    expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(prepared)).run!(2)).toBe(42);
+
+    const body = (name: string): string => {
+      const start = prepared.wat.indexOf(`  (func $${name}`);
+      expect(start, `missing $${name}`).toBeGreaterThanOrEqual(0);
+      const next = prepared.wat.indexOf("\n  (func $", start + 1);
+      return prepared.wat.slice(start, next < 0 ? prepared.wat.length : next);
+    };
+    // No ambient `this`, no generic member ladder, no boxing, no indirect
+    // dispatch anywhere in the owner or its statics.
+    for (const name of ["run", "Box_base", "Box_make"]) {
+      expect(body(name)).not.toMatch(
+        /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.test|__call_m_/,
+      );
+    }
+    // The static reach is a DIRECT call, and the STATIC callable carries no
+    // receiver slot — the instance method beside it does. That contrast is the
+    // ABI proof: `$Box_base` resolves through a shared func type with no
+    // leading reference parameter, `$Box_make` declares `(param (ref null …))`.
+    expect(body("run")).toMatch(/\b(return_call|call)\b/);
+    expect(body("Box_base").split("\n")[0]).not.toMatch(/\(param \(ref/);
+    expect(body("Box_make").split("\n")[0]).toMatch(/\(param \(ref/);
+    // A class reached only through its static side allocates nothing: the
+    // ordering fix plans the `_init` support binding, it does not force a
+    // construction into the owner.
+    expect(body("run")).not.toMatch(/struct\.new/);
+  });
+
+  it("produces identical results on the legacy and IR paths", async () => {
+    const cases: readonly (readonly [string, number, number | undefined])[] = [
+      [STATIC_ONLY, 42, undefined],
+      [TWO_STATICS, 42, undefined],
+      [STATIC_CALLS_STATIC, 42, undefined],
+      [STATIC_PLUS_INSTANCE, 42, undefined],
+      [STATIC_FIELD_METHOD, 42, undefined],
+      [STATIC_EXPLICIT_CTOR, 42, 2],
+    ];
+    for (const [source, expected, argument] of cases) {
+      const direct = await compile(source, { fileName: "static-dual-direct.ts", experimentalIR: false });
+      const prepared = await compile(source, { fileName: "static-dual-ir.ts", experimentalIR: true });
+      expect(direct.success && prepared.success).toBe(true);
+      const directRun = (await instantiate(direct)).run!(argument);
+      const preparedRun = (await instantiate(prepared)).run!(argument);
+      expect(directRun).toBe(expected);
+      expect(preparedRun).toBe(directRun);
+    }
+  });
+
+  it("preserves static-call evaluation ORDER against the direct path", async () => {
+    // node: a() * b() === 10 * 4 === 40; the log records 1 then 2, so
+    // 40 + 1*100 + 2 === 142. Any reordering or elision of the two static calls
+    // gives a different answer — and the DIRECT path is the oracle here, not a
+    // hard-coded constant.
+    const source = `
+    export function run(): number {
+      const log: number[] = [];
+      class Box {
+        static a(): number { log.push(1); return 10; }
+        static b(): number { log.push(2); return 4; }
+      }
+      const v = Box.a() * Box.b();
+      return v + log[0] * 100 + log[1];
+    }
+    `;
+    const direct = await compile(source, { fileName: "static-order-direct.ts", experimentalIR: false });
+    const prepared = await compile(source, {
+      fileName: "static-order-ir.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expect(direct.success && prepared.success).toBe(true);
+    const directRun = (await instantiate(direct)).run!();
+    expect(directRun).toBe(142);
+    expect((await instantiate(prepared)).run!()).toBe(directRun);
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+  });
+});
+
+describe("#3522 nested class static-member negative boundaries", () => {
+  it("keeps a class with a STATIC FIELD direct", async () => {
+    // A static field initializer runs at class-definition time IN the
+    // containing frame — exactly the inertness the bounded predicate asserts.
+    // It is a different ordered contract and stays out of this family.
+    const result = await compile(
+      `
+      export function run(): number {
+        class Box { static k: number = 40; static base(): number { return 2; } }
+        return Box.k + Box.base();
+      }
+      `,
+      { fileName: "nested-static-field.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run"]);
+  });
+
+  it("keeps a class with a STATIC ACCESSOR direct", async () => {
+    // A static accessor's descriptor is not on the ordinary
+    // descriptor-by-name-and-kind path this family resolves.
+    const result = await compile(
+      `
+      export function run(): number {
+        class Box { static get base(): number { return 42; } }
+        return Box.base;
+      }
+      `,
+      { fileName: "nested-static-accessor.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run"]);
+  });
+
+  it("keeps a static with a COMPUTED name direct", async () => {
+    const result = await compile(
+      `
+      export function run(): number {
+        class Box { static ["k"](): number { return 42; } }
+        return Box["k"]();
+      }
+      `,
+      { fileName: "nested-static-computed.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run"]);
+  });
+
+  it("keeps an ASYNC static direct", async () => {
+    const result = await compile(
+      `
+      export function run(): number {
+        class Box { static async k(): Promise<number> { return 42; } get(): number { return 42; } }
+        return new Box().get();
+      }
+      `,
+      { fileName: "nested-static-async.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run"]);
+  });
+
+  it("keeps a GENERATOR static direct", async () => {
+    const result = await compile(
+      `
+      export function run(): number {
+        class Box { static *k(): Generator<number> { yield 42; } get(): number { return 42; } }
+        return new Box().get();
+      }
+      `,
+      { fileName: "nested-static-generator.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run"]);
+  });
+
+  it("keeps a static class with HERITAGE direct (no shadow-identity widening, #4448/#4575)", async () => {
+    const result = await compile(
+      `
+      export function run(): number {
+        class Base { static b(): number { return 40; } }
+        class Box extends Base { static k(): number { return 2; } }
+        return Box.k() + Base.b();
+      }
+      `,
+      { fileName: "nested-static-heritage.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run"]);
+  });
+
+  it("keeps a static that CAPTURES the enclosing frame direct", async () => {
+    const result = await compile(
+      `
+      export function run(): number {
+        const seed = 40;
+        class Box { static k(): number { return seed + 2; } }
+        return Box.k();
+      }
+      `,
+      { fileName: "nested-static-capture.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run"]);
+  });
+
+  it("keeps a STATIC-ONLY class EXPRESSION direct (the residual of this slice)", async () => {
+    // Measured boundary, not an assumption. A nested class EXPRESSION whose
+    // binding is consumed by a `new` is already admitted (the accessor and
+    // field slices own that), and one carrying a static BESIDE an instance
+    // member is admitted here. What stays out is the static-ONLY expression:
+    // its `const` binding is proven safe only for construction uses
+    // (`boundedClassExpressionBindingHasOnlyStaticConstructionUses`), which a
+    // static member access is not, so the binding never reaches the projected
+    // local-class set and the owner rejects at `body-shape-rejected`. Widening
+    // that proof is a separate transaction from the sealing order.
+    const result = await compile(
+      `
+      export function run(): number {
+        const Box = class { static make(): number { return 42; } };
+        return Box.make();
+      }
+      `,
+      { fileName: "nested-static-expression.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run"]);
+  });
+
+  it("withdraws BOTH owner and class when the class binding is used as a VALUE", async () => {
+    // The correctness fix that came with this slice. Admitting statics made a
+    // static-side ALIAS reachable, and `ir/from-ast` cannot represent a class
+    // binding as a first-class value: measured before the fix, `Box_k` claimed
+    // and emitted while `run` fell back, with the post-claim BUILD error
+    // 'identifier "Box" is not in scope in run' — split ownership. The
+    // equivalent instance-member program was already withdrawn correctly by the
+    // `new Alias()` arm; the static side had no such arm.
+    const result = await compile(
+      `
+      export function run(): number {
+        class Box { static k(): number { return 42; } }
+        const Alias = Box;
+        return Alias.k();
+      }
+      `,
+      { fileName: "nested-static-alias.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    expectDirect(result, ["run", "Box_k@"]);
+  });
+
+  it("does not change name-shadowed static-class behaviour versus the direct path", async () => {
+    // An inner `Box` with a static shadowing an outer `Box` with a static. The
+    // DIRECT path is the oracle, not node — this pins that the slice neither
+    // introduces nor hides any pre-existing name-resolution difference, and
+    // that no post-claim error appears.
+    const source = `
+    class Box { static k(): number { return 1; } }
+    export function run(): number {
+      class Box { static k(): number { return 41; } }
+      return Box.k() + outer();
+    }
+    function outer(): number { return Box.k(); }
+    `;
+    const result = await compile(source, {
+      fileName: "nested-static-shadow.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const direct = await compile(source, { fileName: "nested-static-shadow-direct.ts", experimentalIR: false });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe((await instantiate(direct)).run!());
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("still reaches the direct class-body emitter for an unadmitted static class", async () => {
+    // Positive control for the poison seam itself: without it every
+    // admitted-family assertion above could pass vacuously.
+    const previous = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Box_base";
+      const result = await compile(
+        `
+        export function run(): number {
+          class Box { static k: number = 40; static base(): number { return 2; } }
+          return Box.k + Box.base();
+        }
+        `,
+        { fileName: "nested-static-poison-control.ts", experimentalIR: true, trackIrOutcomes: true },
+      );
+      expect(result.success).toBe(false);
+      expect(result.errors.map((error) => error.message).join("\n")).toContain("injected direct class-body poison");
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previous;
+    }
+  });
+});

--- a/tests/issue-3522-nested-implicit-constructor.test.ts
+++ b/tests/issue-3522-nested-implicit-constructor.test.ts
@@ -272,11 +272,16 @@ describe("#3522 nested implicit-constructor negative boundaries", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("keeps a nested class with a static member direct", async () => {
+  // (#3522) A static METHOD is no longer a boundary — the static-member slice
+  // admits it, and `tests/issue-3522-nested-class-static.test.ts` owns that
+  // positive family. The boundary MOVED to the static ACCESSOR: its descriptor
+  // is not on the ordinary descriptor-by-name-and-kind path this family
+  // resolves, so it must still withdraw the whole owner.
+  it("keeps a nested class with a static ACCESSOR direct", async () => {
     const result = await compile(
       `
       export function run(): number {
-        class Box { get(): number { return 42; } static k(): number { return 1; } }
+        class Box { get(): number { return 42; } static get k(): number { return 1; } }
         return new Box().get();
       }
       `,


### PR DESCRIPTION
Advances [#3522](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3522-ir-r3-classes-closures-compile-once) — the next nested class-family boundary its own history named: **STATIC members on nested classes**, the sealing-order transaction.

## What moved

A nested class carrying a static method used to withdraw its **whole enclosing function** (`body-shape-rejected@select`, `legacy=1 ir=0`). It now compiles once through the prepared pipeline. Measured on `origin/main` `34e102dc8` before and after, through the production `compile` seam with `experimentalIR: true, trackIrOutcomes: true`; identical on `gc` and `standalone`; every `run=` cross-checked against node.

| Fixture | Before | After | run |
| --- | --- | --- | --- |
| reached ONLY via a static, no `new` | legacy=1 ir=0 | legacy=0 ir=2 | 42 |
| two statics, no `new` | legacy=1 ir=0 | legacy=0 ir=3 | 42 |
| static calling a sibling static | legacy=1 ir=0 | legacy=0 ir=3 | 42 |
| static + instance method | legacy=1 ir=0 | legacy=0 ir=3 | 42 |
| static + initialized field + method | legacy=1 ir=0 | legacy=0 ir=4 | 42 |
| static + explicit constructor | legacy=1 ir=0 | legacy=0 ir=4 | 42 |
| multi-parameter static | legacy=1 ir=0 | legacy=0 ir=2 | 42 |
| string-returning static | legacy=1 ir=0 | legacy=0 ir=2 | 42 |

The identical shape on a **top-level** class already compiled once, so no lowering, ABI, value representation or import surface was added.

## The reproduced diagnostic, and what it actually was

Relaxing the member-shape gate alone reproduces the terminal outcome the previous slice recorded — and **only** for a class reached exclusively through its static side:

```
run  kind=invariant  code=unexpected-internal-throw  stage=lower
ABI draft ir-binding:v1:callable:…class-implicit-constructor…:body:…
  would mutate sealed prepared scope
  prepared-component:…class-static-method:…+…root:top-level-function:…
```

Bisected one shape at a time, it fires **iff no `new` appears anywhere in the transaction**. The stack names the site: `emitInstrTree → resolveClass → ClassRegistry.resolve → initRef → bindUnitCallableSlot → planProgramAbiUnitCallable`. `ClassRegistry.resolve` binds the source-owned `_init` callable for **every** class shape the lowering materializes, not only for constructed ones — while `prepareImplicitConstructorSupports`, which plans that binding up front, scanned for `new <Identifier>` only. With no `new`, nothing planned it, so it was planned lazily *during lowering*, after the static component had sealed.

## The transaction

Ordering, not lowering. Nothing about the seal moves and no sealed scope is mutated.

1. **`src/ir/class-accessor-safety.ts`** — `isBoundedPreparedNestedOrdinaryClass` admits a static METHOD under exactly the member shape instance methods already carry. A static method's definition evaluation is a method's: a body-bearing callable installed on the constructor object, nothing running in the containing frame.
2. **`src/codegen/ir-plain-implicit-constructors.ts`** — the implicit-constructor reaching set now also reaches a bounded nested class through a **static member access** on its identifier, so the support pair is planned in the same pre-seal phase as the static member. Restricted to classes that actually carry a static member, so every pre-existing static-free shape keeps the exact `new`-only population. The walk moved into `collectPreparedImplicitConstructorClasses` to stay under the caller's 300-LOC function budget.
3. **`src/ir/select.ts`** — the correctness fix this slice forced (below).

## Correctness fix: a prepared class binding is not a first-class IR value

Admitting statics made a static-side **alias** reachable, and it leaked. Measured before the fix, `class Box { static k() {…} } const Alias = Box; return Alias.k();` claimed and **emitted** `Box_k` while `run` fell back, recording the post-claim build error `ir/from-ast: identifier "Box" is not in scope in run` — split ownership, which R3 exists to prevent. The equivalent instance-member program was already withdrawn correctly by the `new Alias()` arm; the static side had no such arm.

The class-declaration and `const C = class {…}` arms add the binding NAME to the selector scope purely so the dedicated `new C(...)`, `C.staticMember` and `x instanceof C` arms can consume it — those resolve the binding themselves and never reach the generic identifier accept. Anything that does reach it is a bare value use, so that accept now rejects it and the owner withdraws at selection, taking the class with it.

A/B'd against unmodified `origin/main` on seven class-binding shapes (nested `instanceof` on a declaration, top-level `instanceof`, top-level class-as-value, nested `new`-only declaration, nested `new`-only class expression, nested class-expression `instanceof`, static-beside-`new`): all byte-identical. Only the two aliasing shapes move — from a leak to a clean demotion.

## Boundaries — verified, not assumed

| Shape | Verdict |
| --- | --- |
| static method, any arity, number/string | claims |
| static reached from a sibling static body | claims |
| static beside field / method / ctor | claims |
| static FIELD | direct (`body-shape-rejected`) |
| static ACCESSOR | direct (`body-shape-rejected`) |
| computed static name | direct (`body-shape-rejected`) |
| `async` / generator static | direct (`body-shape-rejected`) |
| heritage | direct — the explicit heritage guard; no shadow-identity inheritance surface moves |
| static capturing the enclosing frame | direct (`class-member-unsupported`) |
| static-ONLY class EXPRESSION | direct — **the residual**, see below |
| class binding used as a VALUE | owner AND class withdrawn together |

A static field's initializer runs at class-definition time **in the containing frame** — exactly the inertness the predicate asserts, a different ordered contract. A static accessor's descriptor is not on the ordinary descriptor-by-name-and-kind path this family resolves.

**Residual, measured:** a nested class expression carrying a static *beside an instance member* is admitted; the static-**only** expression is not. Its `const` binding is proven safe only for construction uses (`boundedClassExpressionBindingHasOnlyStaticConstructionUses`), which a static member access is not, so it never reaches the projected local-class set and the owner keeps its base `body-shape-rejected`. A clean demotion, not a failure. Widening that binding proof is a separate transaction from the sealing order.

## Evidence

`tests/issue-3522-nested-class-static.test.ts` — **33/33** on `gc` and `standalone`: direct class/function body poison on every expected body, exact terminal outcomes, one shared prepared component whose id is asserted to **name the `class-static-method` scope** (the scope whose seal the draft used to arrive after), Wasm validation, node cross-checks, dual-run legacy↔IR equality on six fixtures, and a static-call evaluation-ORDER chain checked against the DIRECT path rather than a constant.

WAT proof on a parameterised fixture so the call cannot constant-fold: owner, static and instance method carry no `externref`, boxing, `call_ref`, `call_indirect`, `ref.test` or `__call_m_*` traffic; `run` reaches the static as a direct `return_call`; the static callable declares **no receiver slot** while the instance method beside it declares `(param (ref null …))`; and `run` contains no `struct.new` — a class reached only through its static side allocates nothing.

One pin moved: *"keeps a nested class with a static member direct"* pinned a static METHOD, which this slice admits. It now pins the static ACCESSOR, the boundary that remains.

## Gates

- Focused class-family suites (nested implicit-constructor, accessor, field, class-expression ownership, nested-class ownership, static class-method) plus the new suite: **114/114**
- `check:ir-fallbacks --verbose`: OK — no unintended, post-claim or module-level increases
- `check:ir-only` and `--policy=hybrid`: **READY**, both lanes **38/38 terminal units, 38 IR-emitted, 0 legacy bodies, 0 unsupported, 0 invariants** — byte-identical to the same run on unmodified base
- `gen:ir-adoption --check`: byte-clean, no row refresh needed
- Typecheck: **543 errors on base, 543 on this branch** (all pre-existing `@types/node` noise under symlinked `node_modules`) — no new errors
- Lint + `format:check`: green on every changed file
- Equivalence: CI's own 8 `equivalence-shard` jobs are the authoritative full-suite check on this PR. Locally, shards 1–2 (383 tests) ran clean against the full baseline — *"no new equivalence regressions"* on each — before the local run was stopped as redundant with CI (the box was oversubscribed by a concurrent run in another lane).

Budget grants live in the issue file's frontmatter, never in `scripts/*-baseline.json`: `src/ir/select.ts` was already granted under `loc-budget-allow`; `src/ir/select.ts::isPhase1Expr` is added under `func-budget-allow`. Both gates report the same **+16 LOC** for the value-use guard (`src/ir/select.ts` `10040 → 10056`; `isPhase1Expr` `1072 → 1088`). The reaching-set extraction kept `prepareImplicitConstructorSupports` under its own 300-LOC cap without a grant.

## Pre-existing defect recorded, not hidden

`const Box = class { get() { return 42; } }; const b = new Box(); return b instanceof Box ? b.get() : 0;` returns **0**, not 42 — identically on this branch and on unmodified `origin/main`, on the direct path. Nested class-expression `instanceof` evaluates false. Outside this slice's territory; recorded so it is not rediscovered as a regression.

## Remaining boundaries

Field initializers carrying call edges (the attribution transaction), static-ONLY class expressions (the binding-proof residual above), computed member names, static fields with their class-definition-time ordered contract, nested heritage, then top-level class expressions with their module-global binding ABI.
