### PR TITLE
docs(3522): correct the recorded budget delta to the measured +16

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -3039,7 +3039,8 @@ green on every changed file.
 Budget grants for this change-set are in this file's frontmatter, not in any
 `scripts/*-baseline.json`: `src/ir/select.ts` was already granted under
 `loc-budget-allow`, and `src/ir/select.ts::isPhase1Expr` is added under
-`func-budget-allow` (+13 LOC for the value-use guard). The reaching-set
+`func-budget-allow`. Both report the same **+16 LOC** for the value-use guard
+(`10040 → 10056`; `isPhase1Expr` `1072 → 1088`). The reaching-set
 extraction kept `prepareImplicitConstructorSupports` under its own 300-LOC cap
 without a grant.
 


### PR DESCRIPTION
## Description

Recovers the 3-line correction stranded when the merge queue locked PR #4739's branch: the [#3522](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3522-ir-r3-classes-closures-compile-once) slice record quoted **+13 LOC** for the value-use guard's budget grant; the measured figure from `check:loc-budget`/`check:func-budget` on the committed tree is **+16** (`src/ir/select.ts` 10040→10056; `isPhase1Expr` 1072→1088). PR #4739's body already carried the corrected figure; this aligns the issue file.

Docs-only, one issue file.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_