### PR TITLE
fix(ci): parallelize npm-compat refresh

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -51,7 +51,7 @@ on:
     #
     # That matters because the measurement includes perf timings, which differ
     # on every run — so every run publishes something. Without this filter each
-    # landing would trigger the next refresh, forever: a 24-minute runner and a
+    # landing would trigger the next refresh, forever: a long-lived runner and a
     # merge-queue entry every ~25 minutes, in perpetuity.
     #
     # `paths-ignore` is evaluated against the union of files changed by the
@@ -89,7 +89,8 @@ env:
 
 concurrency:
   group: npm-compat-refresh-${{ github.ref }}
-  # MUST be false. This job takes ~24 min; main merges more often than that. With
+  # MUST be false. The refresh remains long-lived; main can merge more often
+  # than it runs. With
   # `cancel-in-progress: true` every run was killed mid-flight by the next push —
   # 6 of the first 7 runs were `cancelled` and the artifact never moved off its
   # first snapshot. The original reasoning ("a cancelled run is always superseded
@@ -106,24 +107,76 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # The package runners are independent. Running them as a matrix changes the
+  # wall clock from the sum of every upstream suite to the slowest group, so a
+  # busy main can finish a refresh before the next queued run supersedes it.
+  # `fail-fast: false` is intentional: one flaky package must not cancel the
+  # other measurements or leave the coordinator without their artifacts.
+  measure:
+    name: Measure npm-compat (${{ matrix.id }})
+    if: github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: core
+            packages: acorn,marked,clsx,cookie
+          - id: frontend
+            packages: eslint,prettier,react
+          - id: renderers
+            packages: react-dom,jsdom,redux
+          - id: libraries
+            packages: hono,lodash,lodash-es,axios,uuid,moment
+          - id: tools
+            packages: webpack,jest,styled-components,stylelint,three,lit
+          - id: tailwind
+            packages: tailwindcss
+          - id: typescript
+            packages: typescript
+    runs-on: ubuntu-24.04
+    timeout-minutes: 350
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Measure package group
+        run: |
+          set -euo pipefail
+          pnpm run generate:npm-compat -- \
+            --only "${{ matrix.packages }}" \
+            --partial-output "$RUNNER_TEMP/npm-compat-${{ matrix.id }}.json"
+
+      - name: Upload package-group report
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-compat-partial-${{ matrix.id }}
+          path: ${{ runner.temp }}/npm-compat-${{ matrix.id }}.json
+          if-no-files-found: error
+          retention-days: 14
+
   refresh:
+    needs: measure
     # The `paths-ignore` filter above is what actually breaks the trigger loop
     # now (this job's own landing changes only artifact paths). The actor guard
     # is kept as a second, cheaper line against any OTHER bot push to main.
     if: github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
-    # (#4604) 180 was outgrown by the upstream-suite roster: on 2026-08-21 four
-    # consecutive runs (700/705/714/721) died un-published — run 721's generate
-    # step was killed at exactly 180:00 with the promotion steps never reached,
-    # and the artifact stayed stale >24h while the acorn/clsx recovery
-    # (#4578/#4586/#4602) was already on main. 350 sits just under the 6h
-    # GitHub-hosted hard cap and nearly doubles the budget; the STRUCTURAL
-    # bound (per-package matrix or per-package time budgets, plus a staleness
-    # alert) is #4604's remaining scope — this raise is its immediate-unblock
-    # slice, not the fix. The sibling rule to #3988's "never cancel-in-progress
-    # a job longer than its trigger interval" applies: never let this job's
-    # runtime outgrow its own timeout, because a timeout kill and a
-    # supersession cancel produce the same stale artifact.
+    # The coordinator only assembles reports and promotes them. The expensive
+    # package work runs in the matrix above, so this retains the 350-minute
+    # ceiling as a final safety bound without making one serial job the
+    # availability bottleneck (#4604).
     timeout-minutes: 350
     environment: baseline-promote
     permissions:
@@ -139,10 +192,9 @@ jobs:
         shell: bash
         run: echo "source_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
-      # Single job, unlike benchmark-refresh's measure/promote split. That split
-      # exists because it also runs on PRs, where untrusted code must never
-      # reach write credentials. This workflow never runs on a PR, so everything
-      # it executes is already main's own trusted code.
+      # This job only assembles trusted worker output and performs promotion.
+      # The workers already checked out the same immutable source revision and
+      # do not receive write credentials.
       - uses: actions/checkout@v5
         with:
           ref: ${{ steps.refs.outputs.source_sha }}
@@ -155,20 +207,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # (#4130) The "capture the COMMITTED artifact's age before regenerating"
-      # step that used to sit here is GONE. It existed for exactly one consumer:
-      # the `--stale-after-hours` floor in the merge-queue gate, which asked
-      # "how old is the artifact main is currently serving" and could only be
-      # answered before this job overwrote the file. There is no gate and no
-      # floor on this path any more, so there is nothing to feed. The freshness
-      # invariant that DOES survive — never overwrite a newer artifact with an
-      # older measurement — is enforced in the publish step below by comparing
-      # `generatedAt` values, which is a different question.
-      - name: Regenerate the npm-compat artifacts
-        # No `--only`: a focused run never writes, because a partial file would
-        # drop the other packages. Refreshing anything means regenerating all of
-        # it (#3988).
-        run: pnpm run generate:npm-compat
+      - name: Download package-group reports
+        uses: actions/download-artifact@v7
+        with:
+          pattern: npm-compat-partial-*
+          path: ${{ runner.temp }}/npm-compat-partials
+          merge-multiple: true
+
+      - name: Assemble the npm-compat artifacts
+        run: node scripts/merge-npm-compat-partials.mjs "$RUNNER_TEMP/npm-compat-partials"
 
       # Refuse to publish an empty or truncated artifact. A generator that exits
       # 0 having written nothing useful would otherwise blank the dashboard, and
@@ -238,7 +285,7 @@ jobs:
       # adopting the app instead), so a `secrets.AUTO_ENQUEUE_TOKEN || ...`
       # fallback would silently select the broken path.
       #
-      # Minted HERE, after the ~24-minute generation, because an installation
+      # Minted HERE, after matrix generation, because an installation
       # token expires in one hour.
       - name: Mint a GitHub App token for the promotion PR
         id: app-token
@@ -329,7 +376,7 @@ jobs:
           git fetch deploykey "$PROMOTION_BRANCH" || true
 
           # Do NOT gate on "did main advance". It always advances — the job runs
-          # ~24 min and main merges faster than that — so the sha-equality guard
+          # matrix generation and main merges faster than that — so the sha-equality guard
           # this replaces deferred EVERY completed run to "a newer run", while
           # `cancel-in-progress` was killing those newer runs. The two composed
           # into a livelock: the artifact sat on its first snapshot for 9 hours
@@ -370,7 +417,7 @@ jobs:
 
           # Stash the generated artifacts OUTSIDE the work tree, then replay them
           # onto whatever main is now. The commit cannot be built on SOURCE_SHA:
-          # main has advanced during the ~24 min measurement, so the PR would
+          # main has advanced during matrix measurement, so the PR would
           # open behind main and immediately need a refresh. This is the step
           # that actually makes a long-running measurement publishable.
           STAGE="$(mktemp -d)"
@@ -391,7 +438,7 @@ jobs:
 
           # The perf-history artifact ACCUMULATES; the other two are snapshots.
           # Ours was derived from main as of SOURCE_SHA, so a run published
-          # during the ~24-minute measurement — still pending in the open
+          # during matrix measurement — still pending in the open
           # promotion PR, or already landed on main — is missing from it, and a
           # force-push of the branch would delete it. Union before committing so
           # this branch is only ever additive. Idempotent by measurement
@@ -422,7 +469,7 @@ jobs:
           # and neither hook can do its job. The sibling `benchmark-refresh` is
           # immune only structurally — its promote job is separate and never
           # runs `pnpm install`, so no hook is installed. This workflow is
-          # deliberately a SINGLE job and has to opt out explicitly. Running
+          # deliberately a single coordinator job and has to opt out explicitly. Running
           # either check over generated JSON artifacts would be meaningless.
           #
           # NO `[skip ci]`. The PR now NEEDS its checks to run to become CLEAN;

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -82,6 +82,7 @@ same stale artifact.
   sum of all upstream suites. `cancel-in-progress` remains `false`: pending
   runs may still be coalesced by GitHub, but the active run is no longer a
   multi-hour serial bottleneck that repeatedly times out before publishing.
+  The implementation is in [#4745](https://github.com/loopdive/js2wasm/pull/4745).
 
 ## Fix directions (pick during implementation)
 

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -3,7 +3,7 @@ id: 4604
 title: "npm-compat refresh runtime exceeds its 180-min timeout — dashboard stale since 2026-08-20 18:45Z"
 status: in-progress
 created: 2026-08-21
-updated: 2026-08-21
+updated: 2026-08-22
 assignee: loopdive/claude
 priority: critical
 feasibility: medium
@@ -17,6 +17,10 @@ related: [3988, 4585, 4586, 4602]
 origin: "Check-in while verifying the acorn/clsx recovery (#4602): 39 consecutive npm-compat-refresh runs (683-721) have failed to publish; the last successful run is 682 (2026-08-20 18:45Z), which is exactly the snapshot still showing the pre-fix collapse on the website."
 files:
   - .github/workflows/npm-compat-refresh.yml
+  - scripts/generate-npm-compat-report.mjs
+  - scripts/lib/npm-compat-partials.mjs
+  - scripts/merge-npm-compat-partials.mjs
+  - tests/npm-compat-partials.test.ts
 ---
 
 # #4604 — npm-compat refresh runtime exceeds its timeout; dashboard stale >22h
@@ -64,11 +68,20 @@ same stale artifact.
 
 ## Status
 
-- **S1 landed (this PR): `timeout-minutes` 180 → 350.** Run 721's job record
+- **S1 landed previously: `timeout-minutes` 180 → 350.** Run 721's job record
   settled the diagnosis: its generate step was killed at exactly 180:00
   (16:09:17 → 19:09:01Z), promotion steps never reached — a pure timeout, the
   fourth in a row (700/705/714/721). 350 sits just under the 6h GitHub-hosted
   hard cap. The structural bound and the staleness alert below remain OPEN.
+- **S2 implemented in the follow-up workflow PR:** the serial package walk is
+  split into seven `fail-fast: false` matrix groups. Each worker writes a focused
+  report; a read-only coordinator validates the complete package set, merges
+  the rows/history, and only then enters the existing promotion path. A
+  package failure therefore cannot cancel sibling measurements, and the
+  active refresh wall clock is bounded by the slowest group rather than the
+  sum of all upstream suites. `cancel-in-progress` remains `false`: pending
+  runs may still be coalesced by GitHub, but the active run is no longer a
+  multi-hour serial bottleneck that repeatedly times out before publishing.
 
 ## Fix directions (pick during implementation)
 
@@ -90,12 +103,12 @@ same stale artifact.
 
 ## Acceptance criteria
 
-- [ ] One `npm-compat-refresh` run completes end-to-end and its promotion PR
+- [ ] One matrix-based `npm-compat-refresh` run completes end-to-end and its promotion PR
       merges; the committed `npm-compat-perf.json` shows acorn and clsx
       standalone-dynamic recovered (acorn back in its ~0.10–0.15 band per
       #4602, clsx ~0.12–0.2).
-- [ ] The workflow's runtime has headroom against its timeout again (either a
-      raised timeout with measured margin, or a bounded/parallelized
-      generation).
+- [ ] The workflow's matrix runtime has headroom against its timeout; each
+      package group emits a partial report and the coordinator refuses to
+      publish if any expected package is missing or duplicated.
 - [ ] Staleness of the committed artifact is observable (guard or alert),
       not only discoverable by manual audit.

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -201,6 +201,10 @@ if (unknownPackages.length > 0 || selectedPackages.size === 0) {
   );
 }
 const focusedRun = selectedPackages.size !== PACKAGE_NAMES.length;
+const partialOutputPath = optionValue("--partial-output");
+if (partialOutputPath && !focusedRun) {
+  throw new Error("--partial-output requires a focused run via --only");
+}
 const writeArtifacts = !cliArgs.includes("--no-write") && !focusedRun;
 const inspectWatFunctions = optionValue("--inspect-wat")
   ?.split(",")
@@ -3049,6 +3053,33 @@ const summary = {
   packages,
 };
 
+// Focused matrix workers do not write aggregate artifacts: a partial report
+// must never replace the complete dashboard with one package group. They do
+// write a self-contained fragment for the coordinator job, which combines all
+// groups after the slow work has finished.
+if (partialOutputPath) {
+  mkdirSync(dirname(resolve(ROOT, partialOutputPath)), { recursive: true });
+  writeFileSync(
+    resolve(ROOT, partialOutputPath),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        generatedAt: summary.generatedAt,
+        sourceRevision: currentRevision(),
+        summaryMeta: {
+          note: summary.note,
+          popularity: summary.popularity,
+          performanceMethodology: summary.performanceMethodology,
+        },
+        packages,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  console.log(`[npm-compat] wrote partial report ${resolve(ROOT, partialOutputPath)}`);
+}
+
 function assertMeasuredOptimizationReceipts(packageRows) {
   for (const packageRow of packageRows) {
     for (const [laneName, lane] of Object.entries(packageRow.perf?.lanes ?? {})) {
@@ -3099,6 +3130,8 @@ if (writeArtifacts) {
   copyFileSync(HISTORY_RESULTS_PATH, HISTORY_PUBLIC_PATH);
   console.log(`[npm-compat] wrote ${HISTORY_RESULTS_PATH}`);
   console.log(`[npm-compat] wrote ${HISTORY_PUBLIC_PATH}`);
+} else if (partialOutputPath) {
+  console.log("[npm-compat] skipped aggregate artifact writes (partial report is ready for the coordinator)");
 } else {
   console.log("[npm-compat] skipped aggregate artifact writes");
   console.log(JSON.stringify({ ...summary, perfRows, perfHistory }, null, 2));

--- a/scripts/lib/npm-compat-partials.mjs
+++ b/scripts/lib/npm-compat-partials.mjs
@@ -1,0 +1,91 @@
+import { correctnessRollup } from "./npm-compat-correctness.mjs";
+import { mergeNpmPerfHistory, npmPerfHistoryPoint, npmPerfRows } from "./npm-compat-perf.mjs";
+import { NPM_COMPAT_CATALOG_NAMES } from "../../tests/dogfood/npm-compat-catalog.mjs";
+
+const CORE_PACKAGE_NAMES = ["acorn", "marked", "clsx", "cookie", "eslint", "prettier", "react"];
+
+export const NPM_COMPAT_EXPECTED_PACKAGE_NAMES = Object.freeze(
+  [...new Set([...CORE_PACKAGE_NAMES, ...NPM_COMPAT_CATALOG_NAMES])].sort(),
+);
+
+function sortPackages(packages) {
+  return [...packages].sort(
+    (left, right) =>
+      (right.weeklyDownloads ?? Number.NEGATIVE_INFINITY) - (left.weeklyDownloads ?? Number.NEGATIVE_INFINITY) ||
+      left.name.localeCompare(right.name),
+  );
+}
+
+/**
+ * Combine focused npm-compat worker reports into the same aggregate shape the
+ * serial generator writes. Keeping this pure makes the matrix merge easy to
+ * test without running a package compiler or upstream unit suite.
+ */
+export function mergeNpmCompatPartials(
+  partials,
+  {
+    generatedAt = new Date().toISOString(),
+    sourceRevision = null,
+    existingHistory = { schemaVersion: 1, runs: [] },
+    expectedNames = NPM_COMPAT_EXPECTED_PACKAGE_NAMES,
+  } = {},
+) {
+  if (!Array.isArray(partials) || partials.length === 0) {
+    throw new Error("npm-compat aggregation requires at least one partial report");
+  }
+
+  const packages = [];
+  const seen = new Set();
+  for (const partial of partials) {
+    if (!partial || !Array.isArray(partial.packages) || partial.packages.length === 0) {
+      throw new Error("npm-compat partial report has no package rows");
+    }
+    for (const packageRow of partial.packages) {
+      if (!packageRow?.name) throw new Error("npm-compat partial report contains a nameless package row");
+      if (seen.has(packageRow.name)) {
+        throw new Error(`npm-compat partial reports duplicate package ${packageRow.name}`);
+      }
+      seen.add(packageRow.name);
+      packages.push(packageRow);
+    }
+  }
+
+  const expected = new Set(expectedNames);
+  const missing = [...expected].filter((name) => !seen.has(name));
+  const unexpected = [...seen].filter((name) => !expected.has(name));
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      `npm-compat partial package set mismatch; missing: ${missing.join(", ") || "(none)"}; ` +
+        `unexpected: ${unexpected.join(", ") || "(none)"}`,
+    );
+  }
+
+  const revisions = new Set(partials.map((partial) => partial.sourceRevision).filter(Boolean));
+  if (sourceRevision && [...revisions].some((revision) => revision !== sourceRevision)) {
+    throw new Error(
+      `npm-compat partial source revision mismatch; expected ${sourceRevision}, received ${[...revisions].join(", ")}`,
+    );
+  }
+
+  const firstMeta = partials.find((partial) => partial.summaryMeta)?.summaryMeta ?? {};
+  const sortedPackages = sortPackages(packages);
+  const summary = {
+    generatedAt,
+    correctness: correctnessRollup(sortedPackages),
+    note: firstMeta.note ?? "Only packages with a committed, reproducible tests/dogfood harness are listed.",
+    popularity: firstMeta.popularity ?? null,
+    performanceMethodology: firstMeta.performanceMethodology ?? null,
+    packages: sortedPackages,
+  };
+  const perfRows = npmPerfRows(sortedPackages);
+  const perfHistory = mergeNpmPerfHistory(existingHistory, [
+    npmPerfHistoryPoint(
+      sortedPackages,
+      generatedAt,
+      sourceRevision,
+      firstMeta.performanceMethodology?.optimizationLevels,
+    ),
+  ]);
+
+  return { summary, perfRows, perfHistory };
+}

--- a/scripts/merge-npm-compat-partials.mjs
+++ b/scripts/merge-npm-compat-partials.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+// Assemble the focused reports produced by npm-compat-refresh's matrix
+// workers. The worker reports are deliberately not dashboard artifacts: only
+// this coordinator writes the complete snapshots and the public twins.
+
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { mergeNpmCompatPartials } from "./lib/npm-compat-partials.mjs";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const partialDirectory = process.argv[2];
+if (!partialDirectory) throw new Error("usage: merge-npm-compat-partials.mjs <partial-directory>");
+
+const partialRoot = resolve(partialDirectory);
+const partialPaths = readdirSync(partialRoot)
+  .filter((name) => name.endsWith(".json"))
+  .sort()
+  .map((name) => join(partialRoot, name));
+if (partialPaths.length === 0) throw new Error(`no npm-compat partial reports found in ${partialRoot}`);
+
+const partials = partialPaths.map((path) => JSON.parse(readFileSync(path, "utf8")));
+const sourceRevision = execFileSync("git", ["rev-parse", "HEAD"], { cwd: ROOT, encoding: "utf8" }).trim();
+const historyPath = resolve(ROOT, "benchmarks", "results", "npm-compat-history.json");
+const existingHistory = existsSync(historyPath)
+  ? JSON.parse(readFileSync(historyPath, "utf8"))
+  : { schemaVersion: 1, runs: [] };
+
+const { summary, perfRows, perfHistory } = mergeNpmCompatPartials(partials, {
+  sourceRevision,
+  existingHistory,
+});
+
+const outputs = [
+  ["benchmarks/results/npm-compat.json", JSON.stringify(summary, null, 2) + "\n"],
+  ["benchmarks/results/npm-compat-perf.json", JSON.stringify(perfRows, null, 2) + "\n"],
+  ["benchmarks/results/npm-compat-history.json", JSON.stringify(perfHistory, null, 2) + "\n"],
+];
+for (const [relativePath, contents] of outputs) {
+  const outputPath = resolve(ROOT, relativePath);
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, contents);
+  const publicPath = resolve(ROOT, "website/public", relativePath);
+  mkdirSync(dirname(publicPath), { recursive: true });
+  copyFileSync(outputPath, publicPath);
+  console.log(`[npm-compat] wrote ${outputPath}`);
+  console.log(`[npm-compat] wrote ${publicPath}`);
+}
+
+console.log(
+  `[npm-compat] assembled ${summary.packages.length} packages from ${partialPaths.length} worker reports at ${sourceRevision}`,
+);

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+import { mergeNpmCompatPartials } from "../scripts/lib/npm-compat-partials.mjs";
+
+function partial(names: string[], sourceRevision = "source", downloadBase = 0) {
+  return {
+    sourceRevision,
+    summaryMeta: {
+      note: "test",
+      popularity: { metric: "weekly npm downloads" },
+      performanceMethodology: { optimizationLevels: { "js-host": 4, standalone: 4 } },
+    },
+    packages: names.map((name, index) => ({
+      name,
+      weeklyDownloads: downloadBase + index + 1,
+      compile: { success: true },
+      validation: { validates: true },
+      tests: { status: "measured", passed: 1, total: 1 },
+    })),
+  };
+}
+
+describe("npm-compat partial aggregation", () => {
+  it("combines focused workers and keeps the popularity ordering", () => {
+    const result = mergeNpmCompatPartials([partial(["acorn"]), partial(["react"], "source", 10)], {
+      expectedNames: ["acorn", "react"],
+      sourceRevision: "source",
+      generatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(result.summary.packages.map((entry) => entry.name)).toEqual(["react", "acorn"]);
+    expect(result.summary.generatedAt).toBe("2026-08-22T00:00:00.000Z");
+    expect(result.perfHistory.runs).toHaveLength(1);
+  });
+
+  it("rejects duplicate or missing package rows instead of publishing a partial dashboard", () => {
+    expect(() =>
+      mergeNpmCompatPartials([partial(["acorn"]), partial(["acorn"])], {
+        expectedNames: ["acorn"],
+        sourceRevision: "source",
+      }),
+    ).toThrow(/duplicate package acorn/);
+
+    expect(() =>
+      mergeNpmCompatPartials([partial(["acorn"])], {
+        expectedNames: ["acorn", "react"],
+        sourceRevision: "source",
+      }),
+    ).toThrow(/missing: react/);
+  });
+
+  it("rejects a worker that measured a different immutable source revision", () => {
+    expect(() =>
+      mergeNpmCompatPartials([partial(["acorn"], "old")], {
+        expectedNames: ["acorn"],
+        sourceRevision: "source",
+      }),
+    ).toThrow(/source revision mismatch/);
+  });
+});
+
+describe("npm-compat refresh matrix wiring", () => {
+  it("measures independent groups and assembles only after every group succeeds", () => {
+    const workflow = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf8");
+
+    expect(workflow).toContain("fail-fast: false");
+    expect(workflow).toContain("needs: measure");
+    expect(workflow).toContain("--partial-output");
+    expect(workflow).toContain("actions/download-artifact@v7");
+    expect(workflow).toContain("scripts/merge-npm-compat-partials.mjs");
+    expect(workflow).toContain("id: typescript");
+  });
+});


### PR DESCRIPTION
## Summary

- split npm-compat measurement into seven independent `fail-fast: false` matrix groups
- emit focused worker reports and assemble the complete dashboard artifact in a coordinator job
- reject missing, duplicate, or mixed-source package reports before promotion
- keep `cancel-in-progress: false` so an active measurement is never killed by a newer push
- update the handoff in [#4604](https://github.com/loopdive/js2wasm/blob/main/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md)

This addresses the long serial run that was timing out before it could publish. GitHub may still coalesce obsolete pending runs, but the active run now measures groups in parallel and can reach promotion.

## Validation

- focused partial aggregation and workflow tests
- npm-compat history/promotion contract tests
- `pnpm run typecheck`
- Prettier and YAML validation
- focused real `clsx` worker generation produced a valid partial report without writing aggregate artifacts