### PR TITLE
fix(codegen): scope the decl-aware generator lookup to same-name aliases

### DIFF
--- a/plan/issues/3505-host-compilemulti-harness-callable-init.md
+++ b/plan/issues/3505-host-compilemulti-harness-callable-init.md
@@ -179,3 +179,16 @@ same change-set that carries this note:
 Verified 2026-08-21: the exact FYI record passes gc AND standalone through
 `runTest`, the vitest suite is 3/3, equivalence 8/8 shards no new regressions.
 
+## 2026-08-22 hotfix — decl-aware lookup scoped to same-name aliases
+
+PR #4740 merged with an over-broad `nativeGeneratorInfoForDecl`: it scanned
+EVERY registry entry by decl, so a declaration registered under several names
+(class method under its classMemberFuncKey plus a second key from another emit
+site) answered with the other name's state machine — 617 class gen-method
+standalone tests flipped pass→compile_error ('unresolved call target') in the
+merge_group, breaching the #2097 standalone floor. The follow-up PR scopes the
+scan to the requested name's bare key and its ' shadowedN' aliases. The
+`loc-budget-allow` / `func-budget-allow` entries above cover the +8 LOC this
+adds to generators-native.ts. Verified: the 5 named + 20 random of the 617
+flipped tests pass standalone again; equivalence spot-shards clean.
+

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -2762,10 +2762,18 @@ export function nativeGeneratorInfoForDecl(
 ): NativeGeneratorInfo | undefined {
   const byName = ctx.nativeGenerators.get(name);
   if (byName && byName.decl === decl) return byName;
-  for (const info of ctx.nativeGenerators.values()) {
-    if (info.decl === decl) return info;
+  // Scan ONLY this name's shadow aliases — never other names' entries: one
+  // declaration may legitimately register under several names (e.g. a class
+  // method under its classMemberFuncKey and again under a different key from
+  // another emit site), and answering with a different-name info here would
+  // hand the caller a state machine whose funcMap/resume wiring belongs to
+  // the other name (measured: 617 class gen-method standalone tests broke on
+  // exactly that in the first cut of this fix).
+  for (let shadowIdx = 0; ; shadowIdx++) {
+    const alias = ctx.nativeGenerators.get(`${name} shadowed${shadowIdx}`);
+    if (!alias) return undefined;
+    if (alias.decl === decl) return alias;
   }
-  return undefined;
 }
 
 function ensureRegisteredNativeGenerator(ctx: CodegenContext, name: string): NativeGeneratorInfo | null {


### PR DESCRIPTION
## Description

**Urgent follow-up to #4740**, which merged at its pre-fix head: main currently carries a 617-test standalone regression that breaches the #2097 standalone pass-count floor, so **every merge_group run parks until this lands**.

The #4740 merge_group park was diagnosed correctly but the fix commit raced the merge: `nativeGeneratorInfoForDecl` scanned *every* registry entry by declaration, so a declaration legitimately registered under several names (a class method under its `classMemberFuncKey`, then again under a different key from another emit site) answered with the other name's state machine — wiring that belongs to that name — producing `absoluteFuncIndex: unresolved call target (funcIdx=undefined)` in 617 class gen-method standalone tests.

This PR scopes the scan to the requested name's bare key and its `' shadowedN'` aliases; a different-name registration mints its own info exactly as before #3505.

**Verified** against the failed merge_group's own merged-report artifact: the 5 named + 20 randomly sampled of the 617 flipped tests pass standalone again; the instn-uniq-env-rec repros from #4740 still pass; #3505/generators/W6 suites green (34 tests); equivalence spot-shards clean.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uew3UBKiqutbucBdwA8pCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uew3UBKiqutbucBdwA8pCi)_