### PR TITLE
docs(#4609): record the third measurement and name the right CI job

### DIFF
--- a/plan/issues/4609-equivalence-baseline-stale-entries.md
+++ b/plan/issues/4609-equivalence-baseline-stale-entries.md
@@ -56,24 +56,27 @@ A stale known-failure entry is a masked regression channel: if one of these
 
 ### The measurement, and which `main` it belongs to
 
-Measured **twice**, because `main` moved mid-work:
+Measured **three times**, because `main` kept moving:
 
-| run | base | why |
+| run | where | base |
 | --- | --- | --- |
-| first | `03bd58c04` (`Merge pull request #4733`) | the commit this branch was cut from |
-| **final** | **`961cea04a`** | after PR #4736 landed — this is the base the branch actually carries |
+| 1 | local, 8 shards | `03bd58c04` — the commit this branch was cut from |
+| 2 | local, 8 shards | `961cea04a` — after PR #4736 landed |
+| 3 | **CI**, `equivalence-shard` ×8 | branch head `a11fc84d9` = branch + `main` @ `3d1de92f0` (auto-refresh merge) |
 
-Both runs: eight shards, one at a time
+Runs 1 and 2: eight shards, one at a time
 (`SHARD=i/8 node scripts/equivalence-gate.mjs`, single-fork,
 `VITEST_FORK_MAX_OLD_SPACE_SIZE=4096`) — the same per-shard invocation
 `ci.yml`'s `equivalence-shard` matrix uses, never the unsharded run (it OOMs a
-16 GB box). Per-shard partials merged and diffed against the baseline.
+16 GB box). Per-shard partials merged and diffed against the baseline. Run 3 is
+that matrix itself.
 
-**The two runs are identical**: same 1,685 tests, same 1,661 passing, same 24
-failing — set membership, not just counts. So the numbers below hold for the
-final base, and PR #4736 moved nothing in this suite. CI's own eight
-`equivalence-shard` jobs on the PR head (base `961cea04a`) are green against
-the tightened baseline, which is a third, independent confirmation.
+**All three agree exactly** — 1,685 tests, 1,661 passing, 24 failing, per
+shard: 5 / 4 / 3 / 0 / 2 / 7 / 0 / 3. Runs 1 and 2 match by set membership,
+not just by count; run 3 matches shard-for-shard and reports **no** "baseline
+failure(s) now PASS" line in any shard, i.e. the tightened list still has zero
+slack three bases later. So PR #4736 moved nothing in this suite, and neither
+did the PRs between `961cea04a` and `3d1de92f0`.
 
 The figures:
 
@@ -206,9 +209,10 @@ scores a supplied set).
 ## Acceptance criteria
 
 - [x] Measured stale set recorded here — 12, listed above, measured at
-      `03bd58c04` and re-measured identically at the final base `961cea04a`.
+      `03bd58c04` and re-measured identically at `961cea04a` and (via CI) at
+      the branch head carrying `main` @ `3d1de92f0`.
 - [x] Baseline tightened by exactly that set (36 → 24); equivalence gate
-      green on both merged runs and on CI's 8 shards at the final base.
+      green on both local merged runs and on CI's 8 shards.
 - [x] Mutation proof recorded: `typeof`'s symbol arm broken → the gate names
       a removed entry as a REGRESSION and exits 1; the same input exited 0
       before the tightening.

--- a/tests/issue-4609-equivalence-baseline-ratchet.test.ts
+++ b/tests/issue-4609-equivalence-baseline-ratchet.test.ts
@@ -59,8 +59,8 @@ function knownFailures(): string[] {
 
 /**
  * Run the real gate over a synthetic merged shard report in which exactly one
- * test id failed. No vitest, no compile — this is the same set comparison CI's
- * "merge shard reports" job performs, against the same committed baseline.
+ * test id failed. No vitest, no compile — the same set comparison each CI
+ * `equivalence-shard` job performs, against the same committed baseline.
  */
 function gateVerdictFor(failingId: string): { status: number; output: string } {
   const dir = mkdtempSync(join(tmpdir(), "equiv-4609-"));


### PR DESCRIPTION
Two documentation refinements to
[#4609](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4609-equivalence-baseline-stale-entries)
that were still local when PR #4738 merged. No behaviour change — the baseline
itself is untouched here.

**1. The merged issue file's "final base" line was already stale when it
landed.** It named `961cea04a`, but `auto-refresh-prs` had merged `main` @
`3d1de92f0` into the branch, and CI ran the equivalence matrix *there*. That
run is the strongest evidence in the whole issue and it was not recorded, so
the issue now names three bases instead of two:

| run | where | base |
| --- | --- | --- |
| 1 | local, 8 shards | `03bd58c04` |
| 2 | local, 8 shards | `961cea04a` (post-#4736) |
| 3 | **CI**, `equivalence-shard` ×8 | `a11fc84d9` = branch + `main` @ `3d1de92f0` |

All three agree — 1,685 tests, 1,661 passing, 24 failing; per shard
5 / 4 / 3 / 0 / 2 / 7 / 0 / 3 — and **no** shard prints a "baseline failure(s)
now PASS" line, so the tightened 24-entry list still has zero slack three bases
later. Naming a base the branch had already moved off is exactly the
inherited-figure defect this issue exists to remove, so it is fixed rather than
left.

**2. One wrong job name in the ratchet test's comment.** `merge shard reports`
is the **test262** job; the set comparison `gateVerdictFor` mirrors is the one
each `equivalence-shard` job performs. Comment only.

`tests/issue-4609-equivalence-baseline-ratchet.test.ts` still passes 4/4 in
1.1 s on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_