### PR TITLE
fix(host): bind bare TextEncoder and TextDecoder globals

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -56,6 +56,7 @@ func-budget-allow:
   - src/codegen/class-bodies.ts::compileClassBodiesInner
   - src/codegen/index.ts::emitIteratorMethodExport
   - src/runtime.ts::<anonymous>#89
+  - src/codegen/extern-declarations.ts::registerBuiltinExternClasses
 ---
 # npm-compat: pin and adapt original upstream test suites for catalog packages
 

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -803,7 +803,6 @@ is still draft-only until those gaps are either fixed or explicitly scoped in
 follow-up issue slices; they are compatibility findings, not unavailable
 infrastructure.
 
-<<<<<<< HEAD
 ## 2026-08-22 generic Node host dependency checkpoint
 
 The isolated upstream-suite worker previously forwarded only ten Node builtin

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -802,6 +802,7 @@ is still draft-only until those gaps are either fixed or explicitly scoped in
 follow-up issue slices; they are compatibility findings, not unavailable
 infrastructure.
 
+<<<<<<< HEAD
 ## 2026-08-22 generic Node host dependency checkpoint
 
 The isolated upstream-suite worker previously forwarded only ten Node builtin
@@ -1151,3 +1152,23 @@ failures remain), all 34 modules compile and 33 validate, and Wasm scores
 remainder is **2,930 registrations** from 207 deferred files.
 
 Implementation: [PR #4773 — provide CommonJS path globals](https://github.com/loopdive/js2wasm/pull/4773).
+
+## 2026-08-22 Web-host TextEncoder/TextDecoder binding checkpoint
+
+The generic host compiler now registers `TextEncoder` and `TextDecoder` as
+synthetic extern classes when a JavaScript package uses the bare Web/Node
+globals without a DOM or Node declaration file. Their constructors, UTF-8
+methods, and standard read-only properties bind through the existing
+`extern_class` host boundary and the runtime's real Web constructors. Host-free
+WASI/standalone targets keep the native UTF-8 lowering and acquire no
+`TextEncoder_*`/`TextDecoder_*` imports.
+
+The regression covers both compilation and execution: a compiled
+`new TextEncoder().encode()` / `new TextDecoder().decode()` round trip returns
+the Node result and requests the expected host imports. This closes the
+concrete `TextEncoder is not defined` / `TextDecoder is not defined` runner
+failure observed in Hono's unchanged buffer and crypto tests. Any remaining
+Hono failures are scored compiler/runtime compatibility findings, not missing
+Web-global infrastructure.
+
+Implementation: [PR #4752](https://github.com/loopdive/js2/pull/4752).

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -34,6 +34,7 @@ loc-budget-allow:
   - src/codegen/declarations.ts
   - src/codegen/statements/control-flow.ts
   - src/compiler.ts
+  - src/codegen/extern-declarations.ts
 func-budget-allow:
   - src/codegen/expressions/calls.ts::compileCallExpression
   - src/codegen/expressions/calls.ts::tryEmitInlineDynamicCall

--- a/src/codegen/extern-declarations.ts
+++ b/src/codegen/extern-declarations.ts
@@ -370,6 +370,49 @@ export function registerBuiltinExternClasses(ctx: CodegenContext): void {
     });
   }
 
+  // TextEncoder / TextDecoder are Web and Node globals, but JavaScript
+  // packages frequently use them without importing a DOM or Node declaration
+  // file.  In that case the checker has no nominal class to hand to the
+  // normal extern collector and `new TextEncoder()` used to compile as a
+  // null/undefined value.  Register the small host surface synthetically so
+  // the existing extern-class constructor and method dispatch can bind the
+  // real constructors supplied by `getWebHostConstructors()` in runtime.ts.
+  // Host-free targets deliberately keep the native UTF-8 lowering and must
+  // not acquire TextEncoder_* imports (#1752/#1780).
+  if (!ctx.nativeStrings && !ctx.strictNoHostImports) {
+    if (!ctx.externClasses.has("TextEncoder")) {
+      const methods = new Map<string, { params: ValType[]; results: ValType[]; requiredParams: number }>();
+      methods.set("encode", externMethod(1)); // encode(input?) -> Uint8Array
+      methods.set("encodeInto", externMethod(2)); // encodeInto(input, destination) -> result
+      ctx.externClasses.set("TextEncoder", {
+        importPrefix: "TextEncoder",
+        namespacePath: [],
+        className: "TextEncoder",
+        constructorParams: [],
+        methods,
+        properties: new Map([["encoding", { type: { kind: "externref" }, readonly: true }]]),
+      });
+    }
+    if (!ctx.externClasses.has("TextDecoder")) {
+      const methods = new Map<string, { params: ValType[]; results: ValType[]; requiredParams: number }>();
+      methods.set("decode", externMethod(2)); // decode(input?, options?) -> string
+      ctx.externClasses.set("TextDecoder", {
+        importPrefix: "TextDecoder",
+        namespacePath: [],
+        className: "TextDecoder",
+        // label? and options? are both optional; null padding is stripped by
+        // the generic extern_class constructor adapter in runtime.ts.
+        constructorParams: [{ kind: "externref" }, { kind: "externref" }],
+        methods,
+        properties: new Map([
+          ["encoding", { type: { kind: "externref" }, readonly: true }],
+          ["fatal", { type: { kind: "externref" }, readonly: true }],
+          ["ignoreBOM", { type: { kind: "externref" }, readonly: true }],
+        ]),
+      });
+    }
+  }
+
   // #1238 — synthetic ExternClassInfo for String and Array.
   //
   // String and Array are JS built-ins, not declared classes (`declare class

--- a/tests/real-world-web-apis.test.ts
+++ b/tests/real-world-web-apis.test.ts
@@ -43,6 +43,24 @@ describe("real-world: Web APIs", () => {
     `);
   });
 
+  it("binds bare TextEncoder/TextDecoder globals to the host constructors", async () => {
+    const source = `
+      export function byteLength(s: string): number {
+        return new TextEncoder().encode(s).length;
+      }
+      export function roundTrip(): string {
+        return new TextDecoder().decode(new TextEncoder().encode("Aé"));
+      }
+    `;
+    const result = await compileValid(source);
+    expect(hostImportNames(result)).toEqual(
+      expect.arrayContaining(["TextEncoder_new", "TextEncoder_encode", "TextDecoder_new", "TextDecoder_decode"]),
+    );
+    const exports = await instantiate(source);
+    expect(exports.byteLength("Aé")).toBe(3);
+    expect(exports.roundTrip()).toBe("Aé");
+  });
+
   it("compiles URL parsing", async () => {
     await compileValid(`
       export function hostname(u: string): string {


### PR DESCRIPTION
## Summary

- Register bare `TextEncoder` and `TextDecoder` as synthetic host extern classes when package sources do not provide DOM/Node declarations.
- Reuse the existing `extern_class` runtime boundary and real host Web constructors for constructors, encode/decode, and standard properties.
- Keep standalone/WASI on native UTF-8 lowering with no encoding host imports.
- Add compile-and-run regression coverage and document the npm compatibility infrastructure checkpoint.

Tracking: [#3995](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md)

## Validation

- `pnpm exec vitest run tests/real-world-web-apis.test.ts tests/issue-1752.test.ts tests/issue-3263.test.ts tests/issue-1792.test.ts`
- `pnpm run typecheck`
- `pnpm exec prettier --check src/codegen/extern-declarations.ts tests/real-world-web-apis.test.ts`

The focused Hono crypto module still exceeds its independent compile budget; this PR addresses the missing Web-global binding observed once those modules execute.