### PR TITLE
fix(ci): prevent npm-compat refresh cancellation

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -69,11 +69,10 @@ on:
   # Backstop for a quiet main (no pushes ⇒ no push-triggered refresh).
   #
   # It is NOT a backstop against starvation by a busy main, which is what the
-  # original comment here claimed. A cron run lands in the same concurrency
-  # group as every push run, so under `cancel-in-progress: true` it was
-  # cancelled just like the rest — the "guaranteed upper bound on staleness" was
-  # never guaranteed by anything. That is now handled where it belongs, by not
-  # cancelling in-progress runs at all.
+  # original comment here claimed. Scheduled and manual runs share the branch
+  # group below and serialize. Push runs are keyed by their immutable commit
+  # instead, so a busy main cannot replace an older pending measurement before
+  # it gets a runner.
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
@@ -88,28 +87,21 @@ env:
   PROMOTION_BRANCH: ci/npm-compat-refresh
 
 concurrency:
-  group: npm-compat-refresh-${{ github.ref }}
-  # MUST be false. The refresh remains long-lived; main can merge more often
-  # than it runs. With
-  # `cancel-in-progress: true` every run was killed mid-flight by the next push —
-  # 6 of the first 7 runs were `cancelled` and the artifact never moved off its
-  # first snapshot. The original reasoning ("a cancelled run is always superseded
-  # by one publishing a strictly fresher artifact") only holds when the job is
-  # SHORTER than the merge interval; here the superseding run is cancelled too,
-  # forever. The 6h cron was supposed to backstop that and cannot: it lands in
-  # this same concurrency group and is cancelled by the next push like anything
-  # else.
-  #
-  # `false` is not "let runs pile up": GitHub keeps at most ONE pending run per
-  # group and cancels older pending ones, so this is bounded at one running plus
-  # one queued — finish the current measurement, coalesce everything that arrived
-  # while it ran.
+  # GitHub keeps only one pending run per concurrency group. A ref-only key
+  # therefore cancelled older pending push runs even with
+  # `cancel-in-progress: false` (the active run survived, but its predecessor
+  # never got a runner). Key pushes by SHA so every main commit has an
+  # independent measurement. Schedule and workflow_dispatch still share the
+  # branch ref and remain serialized.
+  group: npm-compat-refresh-${{ github.event_name == 'push' && github.sha || github.ref }}
+  # Never kill an active measurement. Promotion is freshness-checked and uses
+  # a lease-protected force push, so independent SHA lanes can safely race.
   cancel-in-progress: false
 
 jobs:
   # The package runners are independent. Running them as a matrix changes the
   # wall clock from the sum of every upstream suite to the slowest group, so a
-  # busy main can finish a refresh before the next queued run supersedes it.
+  # busy main can finish a refresh without a newer push cancelling its lane.
   # `fail-fast: false` is intentional: one flaky package must not cancel the
   # other measurements or leave the coordinator without their artifacts.
   measure:
@@ -479,14 +471,18 @@ jobs:
           # see the note at the end of this job).
           git commit -q --no-verify -m "chore(ci): refresh npm-compat artifacts"
 
-          # `--force` on purpose, and no replay loop. This is a bot-owned branch
-          # that nothing else authors; the five-attempt replay existed only
-          # because pushing to `main` races every other merge. Whatever is on
-          # the branch is a SUPERSEDED measurement (or an `auto-refresh-prs`
-          # merge of main into it), and the commit we just built is main's tip
-          # plus the newest artifacts — so overwriting is always the right
-          # answer and can never lose work.
-          git push --no-verify --force deploykey "HEAD:refs/heads/${PROMOTION_BRANCH}"
+          # Pushes for different main SHAs now run in independent workflow
+          # groups, so two coordinators can reach this point together. Keep
+          # the bot-owned branch race-safe: a lease failure means another run
+          # won the update between our fetch and push. Its freshness check will
+          # publish the newer measurement, so this older run can finish cleanly
+          # without overwriting it.
+          LEASE_SHA="$(git rev-parse "refs/remotes/deploykey/${PROMOTION_BRANCH}" 2>/dev/null || printf '%040d' 0)"
+          if ! git push --no-verify --force-with-lease="refs/heads/${PROMOTION_BRANCH}:${LEASE_SHA}" \
+            deploykey "HEAD:refs/heads/${PROMOTION_BRANCH}"; then
+            echo "A concurrent refresh already updated ${PROMOTION_BRANCH}; leaving its newer artifact in place."
+            exit 0
+          fi
           echo "Pushed npm-compat artifacts measured at ${SOURCE_SHA} to ${PROMOTION_BRANCH}."
           echo "published=1" >> "$GITHUB_OUTPUT"
 

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -124,7 +124,8 @@ cancels an older pending run when another push arrives. The run history after
 the refresh for `3f8b6e6` was cancelled when the next main push queued
 `2860d72d`, even though the workflow declared `cancel-in-progress: false`.
 
-The follow-up change keys push-triggered refreshes by `github.sha`. Every main commit therefore gets a
+The follow-up in [#4755](https://github.com/loopdive/js2/pull/4755) keys
+push-triggered refreshes by `github.sha`. Every main commit therefore gets a
 runner instead of being silently replaced while pending; scheduled and manual
 runs continue to serialize on the branch ref. The promotion push uses
 `--force-with-lease` so concurrent SHA lanes cannot overwrite a newer

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -113,3 +113,19 @@ same stale artifact.
       publish if any expected package is missing or duplicated.
 - [ ] Staleness of the committed artifact is observable (guard or alert),
       not only discoverable by manual audit.
+
+## 2026-08-22 follow-up — pending refreshes were still being cancelled
+
+The matrix split fixed the active-run timeout, but it did not eliminate the
+other GitHub Actions concurrency rule: `cancel-in-progress: false` protects the
+currently running job only. GitHub retains one pending run per group and
+cancels an older pending run when another push arrives. The run history after
+[#4745](https://github.com/loopdive/js2wasm/pull/4745) still shows this shape:
+the refresh for `3f8b6e6` was cancelled when the next main push queued
+`2860d72d`, even though the workflow declared `cancel-in-progress: false`.
+
+The follow-up change keys push-triggered refreshes by `github.sha`. Every main commit therefore gets a
+runner instead of being silently replaced while pending; scheduled and manual
+runs continue to serialize on the branch ref. The promotion push uses
+`--force-with-lease` so concurrent SHA lanes cannot overwrite a newer
+promotion branch update. The workflow-shape test now pins both invariants.

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -65,6 +65,10 @@ describe("npm-compat refresh matrix wiring", () => {
     const workflow = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf8");
 
     expect(workflow).toContain("fail-fast: false");
+    expect(workflow).toContain(
+      "group: npm-compat-refresh-${{ github.event_name == 'push' && github.sha || github.ref }}",
+    );
+    expect(workflow).toMatch(/concurrency:[\s\S]*?cancel-in-progress: false/);
     expect(workflow).toContain("needs: measure");
     expect(workflow).toContain("--partial-output");
     expect(workflow).toContain("actions/download-artifact@v7");


### PR DESCRIPTION
## Summary

- Key push-triggered npm-compat refreshes by the immutable `github.sha`, so a newer main push cannot cancel an older pending measurement.
- Keep scheduled and manual runs serialized, while active refreshes remain non-cancellable.
- Protect the reused promotion branch with `--force-with-lease`; a concurrent winner exits the older lane cleanly instead of overwriting newer artifacts.
- Add a workflow-shape regression test and record the observed cancellation behavior.

Tracking: [#4604](https://github.com/loopdive/js2/blob/main/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md)

## Validation

- `pnpm exec prettier --check .github/workflows/npm-compat-refresh.yml tests/npm-compat-partials.test.ts plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md`
- `pnpm exec vitest run tests/npm-compat-partials.test.ts`
- `pnpm run typecheck`
- Ruby YAML parse of `.github/workflows/npm-compat-refresh.yml`