### PR TITLE
fix(dogfood): expand the opted-in Node host dependency surface

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -791,3 +791,5 @@ adapter descriptors (the fs call's numeric coercion used to emit two identical
 visible to strict manifest validation. This is host setup coverage only; any
 compiler, validation, or runtime mismatches in the upstream suites remain
 scored as compatibility failures.
+
+Implementation: [PR #4756](https://github.com/loopdive/js2/pull/4756).

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -774,3 +774,20 @@ with per-file failure summaries retained in the generated report. The adapter
 is still draft-only until those gaps are either fixed or explicitly scoped in
 follow-up issue slices; they are compatibility findings, not unavailable
 infrastructure.
+
+## 2026-08-22 generic Node host dependency checkpoint
+
+The isolated upstream-suite worker previously forwarded only ten Node builtin
+namespaces. The verified Hono and jsdom source inventories also import
+`node:fs`, `node:fs/promises`, `node:http`, `node:https`, `node:child_process`,
+`node:dns`, `node:vm`, `node:worker_threads`, and related platform modules.
+The host dependency surface is now expanded explicitly for opt-in
+`DOGFOOD_NODE_HOST_DEPS=1` runs, without changing the default web lane or
+standalone compilation. A regression fixture imports `node:fs`, reads its own
+generated source through the real host binding, and instantiates successfully
+through the worker. The same compiler path now removes only exact duplicate
+adapter descriptors (the fs call's numeric coercion used to emit two identical
+`__box_number` entries); descriptors that differ in arity or intent remain
+visible to strict manifest validation. This is host setup coverage only; any
+compiler, validation, or runtime mismatches in the upstream suites remain
+scored as compatibility failures.

--- a/src/compiler/import-manifest.ts
+++ b/src/compiler/import-manifest.ts
@@ -319,6 +319,14 @@ function classifyImport(name: string, mod: WasmModule): ImportIntent {
 
 function buildImportManifest(mod: WasmModule): ImportDescriptor[] {
   const manifest: ImportDescriptor[] = [];
+  // Codegen can request the same adapter helper from more than one lowering
+  // path (for example, a Node fs call plus the surrounding numeric coercion
+  // both need `__box_number`). Wasm accepts repeated physical imports, but the
+  // JavaScript adapter manifest is keyed by module/name/kind and must contain
+  // one descriptor for each exact helper. Collapse only byte-for-byte-equal
+  // descriptors here; entries that share a name but differ in arity or intent
+  // remain visible so manifest validation can reject the ambiguous ABI.
+  const seenExact = new Set<string>();
   for (const imp of mod.imports) {
     if (imp.module !== "env") continue;
     // (#4150) Carry the declared parameter count for func imports so the host
@@ -328,13 +336,17 @@ function buildImportManifest(mod: WasmModule): ImportDescriptor[] {
       const t = mod.types[imp.desc.typeIdx];
       if (t && t.kind === "func") paramCount = t.params.length;
     }
-    manifest.push({
+    const descriptor: ImportDescriptor = {
       module: "env",
       name: imp.name,
       kind: imp.desc.kind === "func" ? "func" : "global",
       intent: classifyImport(imp.name, mod),
       paramCount,
-    });
+    };
+    const key = JSON.stringify(descriptor);
+    if (seenExact.has(key)) continue;
+    seenExact.add(key);
+    manifest.push(descriptor);
   }
   return manifest;
 }

--- a/tests/dogfood/upstream-suite-compile-worker.mjs
+++ b/tests/dogfood/upstream-suite-compile-worker.mjs
@@ -40,14 +40,33 @@ async function loadNodeHostDependencies() {
   for (const moduleName of [
     "node:async_hooks",
     "node:assert",
+    "node:assert/strict",
     "node:buffer",
+    "node:child_process",
     "node:crypto",
+    "node:dns",
     "node:events",
+    "node:fs",
+    "node:fs/promises",
+    "node:http",
+    "node:https",
+    "node:module",
+    "node:net",
     "node:os",
+    "node:perf_hooks",
+    "node:process",
+    "node:querystring",
+    "node:readline",
     "node:stream",
+    "node:string_decoder",
     "node:timers",
+    "node:timers/promises",
+    "node:tls",
     "node:url",
     "node:util",
+    "node:vm",
+    "node:worker_threads",
+    "node:zlib",
   ]) {
     try {
       const namespace = require(moduleName);
@@ -92,6 +111,12 @@ async function main() {
       skipSemanticDiagnostics: true,
       target: "gc",
       platform,
+      // A package opts into the Node host lane explicitly when it imports
+      // path-based `node:fs` APIs. Keep the default web lane hermetic, but do
+      // enable the compiler's real-fs capability gate for that same opt-in;
+      // otherwise the worker resolves the namespace and still emits a null
+      // provider for `readFileSync`/`existsSync`.
+      allowFs: platform === "node" || process.env.DOGFOOD_NODE_HOST_DEPS === "1",
       experimentalIR: process.env.DOGFOOD_REACT_DOM_LEGACY !== "1",
       // The upstream compatibility lane only needs the binary. WAT is a
       // diagnostic artifact and can become quadratic for large generated
@@ -112,6 +137,7 @@ async function main() {
             experimentalIR: process.env.DOGFOOD_REACT_DOM_LEGACY !== "1",
             sourceMap: true,
             platform,
+            allowFs: platform === "node" || process.env.DOGFOOD_NODE_HOST_DEPS === "1",
             deferTopLevelInit: true,
           })
         : await compileProject(generatedPath, projectOptions);

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -409,6 +409,45 @@ export function runUpstreamTest() { return storage ? 1 : 0; }
     }
   }, 90_000);
 
+  it("supplies filesystem and secondary Node namespaces to opted-in suites", async () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
+    const generatedPath = join(root, "suite.ts");
+    const source = `
+import { readFileSync } from "node:fs";
+import * as os from "node:os";
+export function upstreamTestCount() { return 1; }
+export function upstreamTestNames() { return ["fs call"] as any; }
+export function upstreamTestErrors() { return [""] as any; }
+export function runUpstreamTest() {
+  return readFileSync(${JSON.stringify(generatedPath)}, "utf8").length > 0 && os !== undefined ? 1 : 0;
+}
+`;
+
+    try {
+      const previousNodeOptions = process.env.NODE_OPTIONS;
+      process.env.NODE_OPTIONS = [previousNodeOptions, "--import=tsx"].filter(Boolean).join(" ");
+      let result;
+      try {
+        result = await compileAndRunUpstreamModule({
+          generatedPath,
+          source,
+          timeoutMs: 60_000,
+          workerEnv: { DOGFOOD_NODE_HOST_DEPS: "1" },
+        });
+      } finally {
+        // biome-ignore lint/performance/noDelete: `process.env.X = undefined` sets the string "undefined" instead of unsetting the var
+        if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+        else process.env.NODE_OPTIONS = previousNodeOptions;
+      }
+      expect(result.native.statuses).toEqual([true]);
+      expect(result.compile?.success).toBe(true);
+      expect(result.compile?.validates).toBe(true);
+      expect(result.wasm?.statuses).toEqual([true]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 90_000);
+
   it("reports deferred upstream registrations as unavailable infrastructure", () => {
     const report = summarizeUpstreamRuns({
       name: "fixture",


### PR DESCRIPTION
## Summary

- forward the Node builtin namespaces imported by the pinned Hono and jsdom source inventories in the isolated upstream-suite worker
- enable `allowFs` only when a suite explicitly opts into the Node host lane
- deduplicate exact compiler-generated adapter descriptors so filesystem calls do not publish an invalid manifest with repeated `__box_number` imports
- keep strict validation for forged or ABI-ambiguous duplicate descriptors
- add a worker regression that imports `node:fs` and a secondary Node namespace, reads the generated suite through the real host binding, and runs the callback in Wasm

This is host setup coverage, not a compatibility score change: compiler, validation, and runtime mismatches in the upstream suites remain scored as failures.

Tracked in [#3995](https://github.com/loopdive/js2/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).

## Validation

- `pnpm exec vitest run tests/dogfood/upstream-suite-runner.test.ts` (13 passed)
- `pnpm exec vitest run tests/issue-1491.test.ts tests/issue-4585-npm-compat-refresh-resilience.test.ts tests/dogfood/upstream-suite-runner.test.ts` (20 passed)
- `pnpm run typecheck`
- `pnpm exec prettier --check ...`
- `node scripts/check-issue-ids.mjs`
