### PR TITLE
feat(#4604): staleness guard — scheduled assert that the committed npm-compat artifact is fresh

### DIFF
--- a/.github/workflows/npm-compat-staleness.yml
+++ b/.github/workflows/npm-compat-staleness.yml
@@ -1,0 +1,47 @@
+name: npm-compat staleness guard
+
+# (#4604 S3) The 2026-08-20/21 episode: every npm-compat refresh run died
+# before promotion for >24h, the committed artifact silently kept serving an
+# already-fixed regression, and the only detector was a manual audit. A run
+# that never publishes fails no gate — cancelled and superseded runs do not
+# even notify. This guard asserts the PRODUCT ("the committed artifact is
+# recent"), not any run's own success: it goes red when
+# `benchmarks/results/npm-compat.json` is older than the threshold, which is
+# unreachable while the refresh pipeline works (per-push runs + 6h cron +
+# ~1-2h promotion latency; threshold rationale in
+# scripts/lib/npm-compat-freshness.mjs).
+#
+# Read-only by design: it alerts, it never republishes — recovery belongs to
+# the refresh workflow, and an auto-"fix" here would just hide the next
+# pipeline failure behind fresher-looking data.
+on:
+  schedule:
+    # Every 6h, offset from :00 so it never races the refresh cron's own
+    # window start (project convention: spread crons off the hour).
+    - cron: "23 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    if: github.repository == 'loopdive/js2'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      # Full checkout is unnecessary — only the committed artifact and the
+      # checker script are read.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+          sparse-checkout: |
+            benchmarks/results/npm-compat.json
+            scripts/check-npm-compat-freshness.mjs
+            scripts/lib/npm-compat-freshness.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Assert the committed npm-compat artifact is fresh
+        run: node scripts/check-npm-compat-freshness.mjs

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -83,6 +83,17 @@ same stale artifact.
   runs may still be coalesced by GitHub, but the active run is no longer a
   multi-hour serial bottleneck that repeatedly times out before publishing.
   The implementation is in [#4745](https://github.com/loopdive/js2wasm/pull/4745).
+- **S3 (this PR): the staleness guard.** A scheduled workflow
+  (`npm-compat-staleness.yml`, 6h cron) asserts the PRODUCT — the committed
+  `npm-compat.json` is younger than 12h — instead of any run's own success,
+  which is the gap that let this episode run >24h undetected (a run that never
+  publishes fails no gate; cancelled/superseded runs don't notify). Verdict
+  logic is pure and time-injected (`scripts/lib/npm-compat-freshness.mjs`,
+  pinned by `tests/npm-compat-freshness.test.ts`): anything short of a
+  parseable recent `generatedAt` — missing file, malformed JSON, absent or
+  future timestamp — is STALE. Read-only by design: it alerts, recovery stays
+  with the refresh workflow. Verified against the live episode: at
+  implementation time it reports `STALE — artifact is 33.2h old`.
 
 ## Fix directions (pick during implementation)
 
@@ -111,8 +122,8 @@ same stale artifact.
 - [ ] The workflow's matrix runtime has headroom against its timeout; each
       package group emits a partial report and the coordinator refuses to
       publish if any expected package is missing or duplicated.
-- [ ] Staleness of the committed artifact is observable (guard or alert),
-      not only discoverable by manual audit.
+- [x] Staleness of the committed artifact is observable (guard or alert),
+      not only discoverable by manual audit — `npm-compat-staleness.yml` (S3).
 
 ## 2026-08-22 follow-up — pending refreshes were still being cancelled
 

--- a/scripts/check-npm-compat-freshness.mjs
+++ b/scripts/check-npm-compat-freshness.mjs
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4604 S3) CLI for the npm-compat staleness guard. Reads the COMMITTED
+// artifact and exits non-zero when it is stale, so the scheduled workflow's
+// red run — not a manual audit — is what surfaces the next silent-staleness
+// episode. Last output line is always a verdict (project convention: the
+// verdict survives a bad pipe).
+//
+//   node scripts/check-npm-compat-freshness.mjs
+//   node scripts/check-npm-compat-freshness.mjs --artifact <path> --max-age-hours 12
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { DEFAULT_MAX_AGE_HOURS, judgeNpmCompatFreshness } from "./lib/npm-compat-freshness.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function optionValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const artifactPath = resolve(ROOT, optionValue("--artifact") ?? "benchmarks/results/npm-compat.json");
+const maxAgeHours = Number(optionValue("--max-age-hours") ?? DEFAULT_MAX_AGE_HOURS);
+if (!Number.isFinite(maxAgeHours) || maxAgeHours <= 0) {
+  console.error("check-npm-compat-freshness: FAILED — --max-age-hours expects a positive number (exit 2)");
+  process.exit(2);
+}
+
+let rawJson;
+try {
+  rawJson = readFileSync(artifactPath, "utf-8");
+} catch {
+  rawJson = undefined;
+}
+
+const verdict = judgeNpmCompatFreshness(rawJson, { nowMs: Date.now(), maxAgeHours });
+console.error(`artifact: ${artifactPath}`);
+if (verdict.fresh) {
+  console.error(`check-npm-compat-freshness: OK — ${verdict.reason} (exit 0)`);
+  process.exit(0);
+}
+console.error(
+  "The dashboard is serving stale data. The refresh pipeline is not publishing —",
+  "check the newest npm-compat-refresh runs and the ci/npm-compat-refresh promotion PR.",
+  "History and playbook: plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md",
+);
+console.error(`check-npm-compat-freshness: STALE — ${verdict.reason} (exit 1)`);
+process.exit(1);

--- a/scripts/lib/npm-compat-freshness.mjs
+++ b/scripts/lib/npm-compat-freshness.mjs
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4604 S3) Staleness verdict for the committed npm-compat artifact.
+//
+// The 2026-08-20/21 episode ran >24h before anyone noticed: every refresh run
+// died before promotion, the committed artifact silently kept serving a
+// regression that was already fixed on main, and the only detector was a
+// manual audit. Nothing in CI asserted "the dashboard's data is recent" —
+// every gate was about a run's own success, and a run that never publishes
+// fails those gates invisibly (cancelled/superseded runs don't even alert).
+//
+// This module is the pure verdict; the scheduled workflow
+// (.github/workflows/npm-compat-staleness.yml) turns a STALE verdict into a
+// red run. Kept pure and time-injected so the boundary cases are testable.
+
+/** Default alarm threshold. The refresh runs per push plus a 6h cron, and a
+ * healthy promotion adds ~1–2h of merge-queue latency, so a quiet weekend
+ * legitimately reaches ~8h. 12h is unreachable while the pipeline works —
+ * exactly the #4604 episode's signature. */
+export const DEFAULT_MAX_AGE_HOURS = 12;
+
+/**
+ * Judge the committed artifact's freshness.
+ *
+ * @param {string|undefined} rawJson  file contents, or undefined if unreadable
+ * @param {{ nowMs: number, maxAgeHours?: number }} opts
+ * @returns {{ fresh: boolean, reason: string, ageHours?: number }}
+ *
+ * An unreadable/malformed artifact or missing `generatedAt` is STALE, not an
+ * error state: the guard's one job is "is the dashboard provably recent", and
+ * anything short of a parseable recent timestamp is the alarm condition.
+ */
+export function judgeNpmCompatFreshness(rawJson, { nowMs, maxAgeHours = DEFAULT_MAX_AGE_HOURS }) {
+  if (typeof rawJson !== "string" || rawJson.length === 0) {
+    return { fresh: false, reason: "artifact missing or unreadable" };
+  }
+  let generatedAt;
+  try {
+    generatedAt = JSON.parse(rawJson)?.generatedAt;
+  } catch {
+    return { fresh: false, reason: "artifact is not valid JSON" };
+  }
+  const generatedMs = Date.parse(generatedAt ?? "");
+  if (Number.isNaN(generatedMs)) {
+    return { fresh: false, reason: `generatedAt missing or unparseable (${JSON.stringify(generatedAt)})` };
+  }
+  const ageHours = (nowMs - generatedMs) / 3_600_000;
+  // A future timestamp is a clock or generator bug, not freshness — flag it.
+  if (ageHours < -1) {
+    return { fresh: false, reason: `generatedAt is ${(-ageHours).toFixed(1)}h in the future`, ageHours };
+  }
+  if (ageHours > maxAgeHours) {
+    return {
+      fresh: false,
+      reason: `artifact is ${ageHours.toFixed(1)}h old (threshold ${maxAgeHours}h)`,
+      ageHours,
+    };
+  }
+  return { fresh: true, reason: `artifact is ${ageHours.toFixed(1)}h old (threshold ${maxAgeHours}h)`, ageHours };
+}

--- a/tests/npm-compat-freshness.test.ts
+++ b/tests/npm-compat-freshness.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4604 S3) The staleness guard's verdict logic. The workflow that runs it is
+// only as good as this boundary: everything short of a parseable RECENT
+// `generatedAt` must be STALE — the 2026-08-20/21 episode's whole failure mode
+// was an alarm condition that nothing classified as one.
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_MAX_AGE_HOURS, judgeNpmCompatFreshness } from "../scripts/lib/npm-compat-freshness.mjs";
+
+const NOW = Date.parse("2026-08-22T12:00:00.000Z");
+const artifact = (generatedAt: unknown) => JSON.stringify({ generatedAt, packages: [] });
+const hoursAgo = (h: number) => new Date(NOW - h * 3_600_000).toISOString();
+
+describe("npm-compat staleness guard (#4604 S3)", () => {
+  it("accepts an artifact younger than the threshold", () => {
+    const v = judgeNpmCompatFreshness(artifact(hoursAgo(3)), { nowMs: NOW });
+    expect(v.fresh).toBe(true);
+    expect(v.ageHours).toBeCloseTo(3, 5);
+  });
+
+  it("rejects an artifact older than the threshold, reporting its age", () => {
+    const v = judgeNpmCompatFreshness(artifact(hoursAgo(30)), { nowMs: NOW });
+    expect(v.fresh).toBe(false);
+    expect(v.reason).toContain("30.0h old");
+    expect(v.reason).toContain(`${DEFAULT_MAX_AGE_HOURS}h`);
+  });
+
+  it("honors a custom threshold in both directions", () => {
+    expect(judgeNpmCompatFreshness(artifact(hoursAgo(3)), { nowMs: NOW, maxAgeHours: 2 }).fresh).toBe(false);
+    expect(judgeNpmCompatFreshness(artifact(hoursAgo(20)), { nowMs: NOW, maxAgeHours: 24 }).fresh).toBe(true);
+  });
+
+  // The guard's one job is "provably recent" — every unprovable state is the
+  // alarm condition, never an error path that skips the alarm.
+  it("treats a missing or unreadable artifact as stale", () => {
+    expect(judgeNpmCompatFreshness(undefined, { nowMs: NOW }).fresh).toBe(false);
+    expect(judgeNpmCompatFreshness("", { nowMs: NOW }).fresh).toBe(false);
+  });
+
+  it("treats malformed JSON as stale", () => {
+    expect(judgeNpmCompatFreshness("{not json", { nowMs: NOW }).fresh).toBe(false);
+  });
+
+  it("treats a missing or unparseable generatedAt as stale", () => {
+    expect(judgeNpmCompatFreshness(JSON.stringify({ packages: [] }), { nowMs: NOW }).fresh).toBe(false);
+    expect(judgeNpmCompatFreshness(artifact("yesterday-ish"), { nowMs: NOW }).fresh).toBe(false);
+  });
+
+  it("flags a generatedAt in the future as a bug, not freshness", () => {
+    const v = judgeNpmCompatFreshness(artifact(hoursAgo(-8)), { nowMs: NOW });
+    expect(v.fresh).toBe(false);
+    expect(v.reason).toContain("future");
+  });
+});


### PR DESCRIPTION
## Description

The last open slice (S3) of [#4604](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4604-npm-compat-refresh-runtime-exceeds-timeout), completing the trio after the S1 timeout raise (#4714) and the team's S2 matrix split + supersession fixes (#4745/#4755).

**Gap it closes:** the 2026-08-20/21 staleness episode ran >24h undetected because every existing gate judges a *run's own success* — a refresh that never publishes fails no gate, and cancelled/superseded runs don't notify. This guard asserts the **product** instead: a scheduled workflow (`npm-compat-staleness.yml`, 6h cron + dispatch, read-only, 10-min timeout, sparse checkout) goes red when the committed `benchmarks/results/npm-compat.json` is older than 12h — unreachable while the pipeline works (per-push runs + 6h cron + ~1–2h promotion latency).

- Verdict logic is pure and time-injected (`scripts/lib/npm-compat-freshness.mjs`), pinned by `tests/npm-compat-freshness.test.ts` (7 cases): anything short of a parseable recent `generatedAt` — missing file, malformed JSON, absent or future timestamp — is STALE, never an error path that skips the alarm.
- CLI (`scripts/check-npm-compat-freshness.mjs`) follows the last-line-verdict convention.
- Deliberately alert-only: recovery belongs to the refresh workflow; an auto-fix here would hide the next pipeline failure behind fresher-looking data.
- Verified against the live episode: at implementation time it reports `STALE — artifact is 33.2h old (threshold 12h)`.

Ticks #4604's third acceptance box; the first two close when the in-flight matrix run's promotion lands (run 770's groups are completing in 3–9 min each).

Validation: new test suite green, typecheck/lint/format green, LOC/func-budget and dead-export gates green, workflow YAML parse-checked.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8)_