### PR TITLE
fix(test): resolve Jest workspace utility dependencies

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -848,3 +848,14 @@ finding (`call_ref` received one argument but requires two), not unavailable
 package infrastructure; its six callbacks remain in the denominator and are
 reported as compiler-blocked. The remaining **3,031 registrations** from 227
 verified files remain explicitly reported as unavailable infrastructure.
+
+## 2026-08-22 Jest merged-timer integration checkpoint
+
+After rebasing this package-resolution and queue-runner work onto the landed
+fake-timer infrastructure, the selected inventory includes both the original
+`pTimeout.test.ts` timer unit and `queueRunner.test.ts`. The exact run now
+covers **260 callbacks across 15 selected files**: Node admits **258/258**, all
+15 modules compile, 14 validate, and Wasm scores **120/258**. The one invalid
+queue-runner Wasm module remains a compiler validation finding, while the
+remaining **3,028 registrations** from 226 verified files remain explicitly
+reported as unavailable infrastructure.

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -815,3 +815,19 @@ compiler, validation, or runtime mismatches in the upstream suites remain
 scored as compatibility failures.
 
 Implementation: [PR #4756](https://github.com/loopdive/js2/pull/4756).
+## 2026-08-22 Jest internal-package resolution checkpoint
+
+The Jest adapter now materializes the verified `@jest/get-type@30.1.0`
+workspace package in the pinned checkout's `node_modules`. The package metadata
+and source hash are checked against the release-tag source before the test
+starts; the implementation bytes are unchanged. This closes the real package
+name-resolution seam used by `jest-matcher-utils/src/Replaceable.ts` instead of
+rewriting that import to a relative path.
+
+The unchanged `Replaceable.test.ts` is now selected alongside the existing Jest
+utility slice. The verified 30.4.2 inventory registers **251 callbacks across
+13 files**: **249/249** admitted callbacks pass in the Node oracle, all 13
+modules compile and validate, and Wasm scores **124/249**. The two original
+snapshot callbacks remain harness-incompatible and the 125 Wasm failures are
+scored compatibility findings. The remaining **3,037 registrations** from 228
+verified files remain explicitly reported as unavailable infrastructure.

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -831,3 +831,20 @@ modules compile and validate, and Wasm scores **124/249**. The two original
 snapshot callbacks remain harness-incompatible and the 125 Wasm failures are
 scored compatibility findings. The remaining **3,037 registrations** from 228
 verified files remain explicitly reported as unavailable infrastructure.
+
+## 2026-08-22 Jest queue-runner package seam checkpoint
+
+The original `jest-jasmine2/src/__tests__/queueRunner.test.ts` file is now
+selected. Its `jest-util` package-name import is materialized as a
+hash-verified ESM adapter exposing the release-tag `formatTime` implementation;
+the six upstream callback bodies and timeout inputs are unchanged. The shared
+Jest transform also strips type-only named imports from the native CommonJS
+normalization path, so the Node oracle registers all six callbacks.
+
+The exact run now covers **257 callbacks across 14 selected files**: Node
+admits **255/255**, all 14 modules compile, 13 validate, and Wasm scores
+**124/255**. The queue-runner module's invalid Wasm is a compiler validation
+finding (`call_ref` received one argument but requires two), not unavailable
+package infrastructure; its six callbacks remain in the denominator and are
+reported as compiler-blocked. The remaining **3,031 registrations** from 227
+verified files remain explicitly reported as unavailable infrastructure.

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -21,7 +21,8 @@
     "packages/jest-diff/src/__tests__/escapeControlCharacters.test.ts",
     "packages/jest-config/src/__tests__/stringToBytes.test.ts",
     "packages/jest-jasmine2/src/__tests__/pTimeout.test.ts",
-    "packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts"
+    "packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts",
+    "packages/jest-jasmine2/src/__tests__/queueRunner.test.ts"
   ],
   "dependencies": {
     "detect-newline": {
@@ -31,7 +32,11 @@
     "@jest/get-type": {
       "version": "30.1.0",
       "sourceSha256": "568e74bbefa9a86accea3c9289cfb93568cd4354bc822650a0e203b03bca341d"
+    },
+    "jest-util": {
+      "version": "30.4.1",
+      "sourceSha256": "ef7320f8e85b76a67a65ec29e9c55e724b7a25de5b2aad75c3ed1c82a53cc7d4"
     }
   },
-  "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original Jest utility files against their matching release-tag TypeScript implementations, including jest-jasmine2's timer-driven pTimeout tests and jest-matcher-utils' Replaceable object/array/Map paths. Verified package-name seams cover @jest/get-type, detect-newline, node:util/types, and node:os; the shared runner supplies deterministic spies, fake timers, and cleanup between generated modules. Runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
+  "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original Jest utility files against their matching release-tag TypeScript implementations, including jest-jasmine2's timer-driven pTimeout and queueRunner tests and jest-matcher-utils' Replaceable object/array/Map paths. Verified package-name seams cover @jest/get-type, jest-util's formatTime, detect-newline, node:util/types, and node:os; the shared runner supplies deterministic spies, fake timers, and cleanup between generated modules. Runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
 }

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -20,13 +20,18 @@
     "packages/jest-docblock/src/__tests__/index.test.ts",
     "packages/jest-diff/src/__tests__/escapeControlCharacters.test.ts",
     "packages/jest-config/src/__tests__/stringToBytes.test.ts",
-    "packages/jest-jasmine2/src/__tests__/pTimeout.test.ts"
+    "packages/jest-jasmine2/src/__tests__/pTimeout.test.ts",
+    "packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts"
   ],
   "dependencies": {
     "detect-newline": {
       "version": "3.1.0",
       "sourceSha256": "7306f2ecc168c9e20be4a2a3d44a0dad59ea21dc0bf4cd41ea85829bc79e2c18"
+    },
+    "@jest/get-type": {
+      "version": "30.1.0",
+      "sourceSha256": "568e74bbefa9a86accea3c9289cfb93568cd4354bc822650a0e203b03bca341d"
     }
   },
-  "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original Jest utility files against their matching release-tag TypeScript implementations, including jest-jasmine2's timer-driven pTimeout tests, isError's node:util/types, and jest-docblock's node:os host seam. The shared runner supplies deterministic spies, fake timers, and cleanup between generated modules; runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
+  "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original Jest utility files against their matching release-tag TypeScript implementations, including jest-jasmine2's timer-driven pTimeout tests and jest-matcher-utils' Replaceable object/array/Map paths. Verified package-name seams cover @jest/get-type, detect-newline, node:util/types, and node:os; the shared runner supplies deterministic spies, fake timers, and cleanup between generated modules. Runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
 }

--- a/tests/dogfood/jest-upstream-suite.mjs
+++ b/tests/dogfood/jest-upstream-suite.mjs
@@ -1,4 +1,4 @@
-// Jest 30.4.2 original @jest/get-type and @jest/util unit slice.
+// Jest 30.4.2 original utility unit slice.
 
 import { readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";

--- a/tests/dogfood/jest-upstream-suite.mjs
+++ b/tests/dogfood/jest-upstream-suite.mjs
@@ -80,9 +80,20 @@ function transformJestTest(source, filePath, generatedPath, { normalizeCjs = fal
       }
       if (!normalizeCjs) return `import ${bindings} from ${quote}${rewritten}${quote};`;
       const normalized = `${namespaceName}.default?.default ?? ${namespaceName}.default ?? ${namespaceName}`;
+      const runtimeNamed = (named) => {
+        if (!named.startsWith("{")) return named;
+        const members = named
+          .slice(1, -1)
+          .split(",")
+          .map((member) => member.trim())
+          .filter((member) => member && !member.startsWith("type "));
+        return members.length > 0 ? `{ ${members.join(", ")} }` : "";
+      };
       if (bindings.startsWith("{")) {
+        const named = runtimeNamed(bindings);
         return (
-          `import * as ${namespaceName} from ${quote}${rewritten}${quote};\n` + `const ${bindings} = ${normalized};`
+          `import * as ${namespaceName} from ${quote}${rewritten}${quote};` +
+          (named ? `\nconst ${named} = ${normalized};` : "")
         );
       }
       if (bindings.startsWith("* as ")) {
@@ -92,11 +103,11 @@ function transformJestTest(source, filePath, generatedPath, { normalizeCjs = fal
       const comma = bindings.indexOf(",");
       if (comma >= 0) {
         const defaultName = bindings.slice(0, comma).trim();
-        const named = bindings.slice(comma + 1).trim();
+        const named = runtimeNamed(bindings.slice(comma + 1).trim());
         return (
           `import * as ${namespaceName} from ${quote}${rewritten}${quote};\n` +
-          `const ${defaultName} = ${normalized};\n` +
-          `const ${named} = ${normalized};`
+          `const ${defaultName} = ${normalized};` +
+          (named ? `\nconst ${named} = ${normalized};` : "")
         );
       }
       return (

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -284,13 +284,13 @@ describe("small npm package upstream suites", () => {
       filesSeen: 241,
       filesSelected: 14,
       filesDeferred: 227,
-      testsRegistered: 254,
-      nativePassed: 252,
+      testsRegistered: 260,
+      nativePassed: 258,
       nativeFailed: 2,
     });
-    expect(report.extraction.unavailableInfra).toBe(3034);
-    expect(report.compile).toMatchObject({ modules: 14, succeeded: 14, validated: 14 });
-    expect(report.results).toMatchObject({ scored: 252, passed: 120, failed: 132, runtimeFailed: 0 });
+    expect(report.extraction.unavailableInfra).toBe(3028);
+    expect(report.compile).toMatchObject({ modules: 15, succeeded: 15, validated: 14 });
+    expect(report.results).toMatchObject({ scored: 258, passed: 120, failed: 138, runtimeFailed: 0 });
   });
 
   const uuidHeavy = process.env.DOGFOOD_UUID_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -282,15 +282,15 @@ describe("small npm package upstream suites", () => {
     const report = await run("jest");
     expect(report.extraction).toMatchObject({
       filesSeen: 241,
-      filesSelected: 13,
-      filesDeferred: 228,
-      testsRegistered: 237,
-      nativePassed: 235,
+      filesSelected: 14,
+      filesDeferred: 227,
+      testsRegistered: 254,
+      nativePassed: 252,
       nativeFailed: 2,
     });
-    expect(report.extraction.unavailableInfra).toBe(3051);
-    expect(report.compile).toMatchObject({ modules: 13, succeeded: 13, validated: 13 });
-    expect(report.results).toMatchObject({ scored: 235, passed: 109, failed: 126, runtimeFailed: 0 });
+    expect(report.extraction.unavailableInfra).toBe(3034);
+    expect(report.compile).toMatchObject({ modules: 14, succeeded: 14, validated: 14 });
+    expect(report.results).toMatchObject({ scored: 252, passed: 120, failed: 132, runtimeFailed: 0 });
   });
 
   const uuidHeavy = process.env.DOGFOOD_UUID_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -282,8 +282,8 @@ describe("small npm package upstream suites", () => {
     const report = await run("jest");
     expect(report.extraction).toMatchObject({
       filesSeen: 241,
-      filesSelected: 14,
-      filesDeferred: 227,
+      filesSelected: 15,
+      filesDeferred: 226,
       testsRegistered: 260,
       nativePassed: 258,
       nativeFailed: 2,

--- a/tests/dogfood/setup-jest-upstream-suite.mjs
+++ b/tests/dogfood/setup-jest-upstream-suite.mjs
@@ -17,6 +17,11 @@ const JEST_GET_TYPE_PIN = {
   sourceSha256: "568e74bbefa9a86accea3c9289cfb93568cd4354bc822650a0e203b03bca341d",
 };
 
+const JEST_UTIL_PIN = {
+  version: "30.4.1",
+  sourceSha256: "ef7320f8e85b76a67a65ec29e9c55e724b7a25de5b2aad75c3ed1c82a53cc7d4",
+};
+
 function resolveDetectNewlineSource(pin = DETECT_NEWLINE_PIN) {
   const workspaceNodeModules = resolve(HERE, "../../node_modules");
   const direct = join(workspaceNodeModules, "detect-newline/index.js");
@@ -76,6 +81,24 @@ function resolveJestGetTypeSource(suite, pin = JEST_GET_TYPE_PIN) {
   const sha256 = createHash("sha256").update(source).digest("hex");
   if (sha256 !== pin.sourceSha256) {
     throw new Error(`[dogfood] @jest/get-type source hash mismatch: expected ${pin.sourceSha256}, got ${sha256}`);
+  }
+  return { source, sha256 };
+}
+
+function resolveJestUtilFormatTimeSource(suite, pin = JEST_UTIL_PIN) {
+  const sourcePath = join(suite.root, "packages/jest-util/src/formatTime.ts");
+  if (!existsSync(sourcePath)) {
+    throw new Error(`[dogfood] Jest requires jest-util@${pin.version}; source is missing`);
+  }
+  const source = readFileSync(sourcePath, "utf8");
+  const packagePath = join(suite.root, "packages/jest-util/package.json");
+  const packageVersion = JSON.parse(readFileSync(packagePath, "utf8")).version;
+  if (packageVersion !== pin.version) {
+    throw new Error(`[dogfood] jest-util version mismatch: expected ${pin.version}, got ${packageVersion}`);
+  }
+  const sha256 = createHash("sha256").update(source).digest("hex");
+  if (sha256 !== pin.sourceSha256) {
+    throw new Error(`[dogfood] jest-util formatTime source hash mismatch: expected ${pin.sourceSha256}, got ${sha256}`);
   }
   return { source, sha256 };
 }
@@ -141,5 +164,32 @@ export function setupJestUpstreamSuite(options = {}) {
     ) + "\n",
   );
   writeFileSync(join(getTypeRoot, "index.ts"), getType.source);
+
+  // jest-jasmine2's queueRunner imports formatTime through the published
+  // package name. Materialize only that exact release-tag utility in a tiny
+  // ESM package adapter; its implementation remains the upstream source.
+  const utilPin = suite.pin.dependencies?.["jest-util"] ?? JEST_UTIL_PIN;
+  const util = resolveJestUtilFormatTimeSource(suite, utilPin);
+  const utilRoot = join(suite.root, "node_modules/jest-util");
+  mkdirSync(utilRoot, { recursive: true });
+  writeFileSync(
+    join(utilRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "jest-util",
+        version: utilPin.version,
+        type: "module",
+        main: "./index.ts",
+        exports: "./index.ts",
+        _sourceSha256: util.sha256,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  writeFileSync(
+    join(utilRoot, "index.ts"),
+    'export { default as formatTime } from "../../packages/jest-util/src/formatTime.ts";\n',
+  );
   return suite;
 }

--- a/tests/dogfood/setup-jest-upstream-suite.mjs
+++ b/tests/dogfood/setup-jest-upstream-suite.mjs
@@ -12,6 +12,11 @@ const DETECT_NEWLINE_PIN = {
   sourceSha256: "7306f2ecc168c9e20be4a2a3d44a0dad59ea21dc0bf4cd41ea85829bc79e2c18",
 };
 
+const JEST_GET_TYPE_PIN = {
+  version: "30.1.0",
+  sourceSha256: "568e74bbefa9a86accea3c9289cfb93568cd4354bc822650a0e203b03bca341d",
+};
+
 function resolveDetectNewlineSource(pin = DETECT_NEWLINE_PIN) {
   const workspaceNodeModules = resolve(HERE, "../../node_modules");
   const direct = join(workspaceNodeModules, "detect-newline/index.js");
@@ -57,6 +62,24 @@ export function adaptDetectNewline(source) {
   return adapted;
 }
 
+function resolveJestGetTypeSource(suite, pin = JEST_GET_TYPE_PIN) {
+  const sourcePath = join(suite.root, "packages/jest-get-type/src/index.ts");
+  if (!existsSync(sourcePath)) {
+    throw new Error(`[dogfood] Jest requires @jest/get-type@${pin.version}; source is missing`);
+  }
+  const source = readFileSync(sourcePath, "utf8");
+  const packagePath = join(suite.root, "packages/jest-get-type/package.json");
+  const packageVersion = JSON.parse(readFileSync(packagePath, "utf8")).version;
+  if (packageVersion !== pin.version) {
+    throw new Error(`[dogfood] @jest/get-type version mismatch: expected ${pin.version}, got ${packageVersion}`);
+  }
+  const sha256 = createHash("sha256").update(source).digest("hex");
+  if (sha256 !== pin.sourceSha256) {
+    throw new Error(`[dogfood] @jest/get-type source hash mismatch: expected ${pin.sourceSha256}, got ${sha256}`);
+  }
+  return { source, sha256 };
+}
+
 export function setupJestUpstreamSuite(options = {}) {
   const suite = setupPinnedUpstreamSuite({
     here: HERE,
@@ -92,5 +115,31 @@ export function setupJestUpstreamSuite(options = {}) {
     ) + "\n",
   );
   writeFileSync(join(dependencyRoot, "index.ts"), adaptDetectNewline(dependency.source));
+
+  // The selected jest-matcher-utils unit imports @jest/get-type by its
+  // published package name. A source checkout has the workspace package but
+  // no installed workspace links, so materialize a verified ESM package root
+  // in the checkout's node_modules. The implementation bytes remain the
+  // pinned upstream source; only the package-resolution seam is supplied.
+  const getTypePin = suite.pin.dependencies?.["@jest/get-type"] ?? JEST_GET_TYPE_PIN;
+  const getType = resolveJestGetTypeSource(suite, getTypePin);
+  const getTypeRoot = join(suite.root, "node_modules/@jest/get-type");
+  mkdirSync(getTypeRoot, { recursive: true });
+  writeFileSync(
+    join(getTypeRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "@jest/get-type",
+        version: getTypePin.version,
+        type: "module",
+        main: "./index.ts",
+        exports: "./index.ts",
+        _sourceSha256: getType.sha256,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  writeFileSync(join(getTypeRoot, "index.ts"), getType.source);
   return suite;
 }


### PR DESCRIPTION
## Summary

- materialize the hash-pinned `@jest/get-type` and `jest-util` source seams under the verified Jest checkout so original package-name imports resolve in both lanes
- select the unchanged upstream `Replaceable.test.ts` and `queueRunner.test.ts` units alongside the landed timer-driven `pTimeout.test.ts` coverage
- strip only type-only named imports in the native CommonJS normalization path; keep unavailable registrations and compiler/runtime findings explicit in the report and handoff

## Measured result

After rebasing onto the landed fake-timer infrastructure, the Jest 30.4.2
inventory selects **15 of 241 verified test files** and registers **260
callbacks**. The Node oracle admits and passes **258/258** callbacks; two
snapshot callbacks remain harness-incompatible. All 15 modules compile and 14
validate. Wasm scores **120/258 admitted callbacks**. The queue-runner module's
invalid Wasm is reported as a compiler validation finding (`call_ref` received
one argument but requires two), not unavailable infrastructure. The other
**3,028 registrations** remain explicitly reported as unavailable
infrastructure.

The exact handoff is recorded in the [npm compatibility issue](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).

## Validation

- `DOGFOOD_JEST_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts --testNamePattern="Jest's selected original utility units"`
- `pnpm run typecheck`
- `pnpm exec prettier --check` on changed files
- `node scripts/check-issue-ids.mjs`
- `git diff --check`

No upstream callback body or expected result was rewritten.
