### PR TITLE
fix(test): add deterministic Jest timer infrastructure

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -758,7 +758,7 @@ expectations.
 ## 2026-08-22 Jest fake-timer infrastructure checkpoint
 
 The shared Jest/Vitest runner now provides deterministic `jest.useFakeTimers`,
-`jest.useRealTimers`, `jest.runAllTimers`, and spy cleanup. Fake timers are
+`jest.useRealTimers`, timer advancement/clearing, async timer aliases, and spy cleanup. Fake timers are
 implemented in the test environment rather than replacing the harness's own
 clock, so Wasm async handoff and the Node oracle continue to make progress.
 Bare `setTimeout`/`clearTimeout` names route through the same fake queue, and

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -755,6 +755,27 @@ semantics before this selection is made publishable. The experiment changes
 only adapter/pin infrastructure; it does not modify ESLint source or test
 expectations.
 
+## 2026-08-22 Jest fake-timer infrastructure checkpoint
+
+The shared Jest/Vitest runner now provides deterministic `jest.useFakeTimers`,
+`jest.useRealTimers`, `jest.runAllTimers`, and spy cleanup. Fake timers are
+implemented in the test environment rather than replacing the harness's own
+clock, so Wasm async handoff and the Node oracle continue to make progress.
+Bare `setTimeout`/`clearTimeout` names route through the same fake queue, and
+timer spy matchers use a scalar call-count bridge because Wasm function
+properties are not a reliable storage location.
+
+The runner regression exercises scheduling, draining, spy observation, and
+cleanup in both lanes: **1/1 native**, the module compiles and validates, and
+**1/1 Wasm** passes. The unchanged original
+`jest-jasmine2/src/__tests__/pTimeout.test.ts` is now selected. Its **3/3**
+callbacks pass in the Node oracle, compile and validate, and are scored in
+Wasm; all three currently expose compiler/runtime async-function-reference
+failures rather than unavailable infrastructure. The Jest inventory is now
+**237 callbacks across 13 files**, with **235 admitted** and **109/235 Wasm**
+passes. The remaining **3,051 registrations** from 228 verified files remain
+explicitly reported as unavailable infrastructure.
+
 ## 2026-08-22 ESLint assertion-binding checkpoint
 
 The binding mismatch was narrowed to the assertion shim, not the published

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -758,7 +758,8 @@ expectations.
 ## 2026-08-22 Jest fake-timer infrastructure checkpoint
 
 The shared Jest/Vitest runner now provides deterministic `jest.useFakeTimers`,
-`jest.useRealTimers`, timer advancement/clearing, async timer aliases, and spy cleanup. Fake timers are
+`jest.useRealTimers`, timer advancement/clearing, async timer aliases, clock
+inspection/setting, and spy cleanup. Fake timers are
 implemented in the test environment rather than replacing the harness's own
 clock, so Wasm async handoff and the Node oracle continue to make progress.
 Bare `setTimeout`/`clearTimeout` names route through the same fake queue, and

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -19,7 +19,8 @@
     "packages/diff-sequences/src/__tests__/index.test.ts",
     "packages/jest-docblock/src/__tests__/index.test.ts",
     "packages/jest-diff/src/__tests__/escapeControlCharacters.test.ts",
-    "packages/jest-config/src/__tests__/stringToBytes.test.ts"
+    "packages/jest-config/src/__tests__/stringToBytes.test.ts",
+    "packages/jest-jasmine2/src/__tests__/pTimeout.test.ts"
   ],
   "dependencies": {
     "detect-newline": {
@@ -27,5 +28,5 @@
       "sourceSha256": "7306f2ecc168c9e20be4a2a3d44a0dad59ea21dc0bf4cd41ea85829bc79e2c18"
     }
   },
-  "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original synchronous @jest/get-type, jest-util, diff-sequences, jest-docblock, jest-diff, and jest-config unit files against their matching release-tag TypeScript implementations, including isError's node:util/types and jest-docblock's node:os host seams. The shared runner supplies the minimal Jest spy facade needed by the selected jest-util callbacks; runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
+  "_note": "The complete packages/**/__tests__ inventory is verified. The adapter runs the original Jest utility files against their matching release-tag TypeScript implementations, including jest-jasmine2's timer-driven pTimeout tests, isError's node:util/types, and jest-docblock's node:os host seam. The shared runner supplies deterministic spies, fake timers, and cleanup between generated modules; runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
 }

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -282,15 +282,15 @@ describe("small npm package upstream suites", () => {
     const report = await run("jest");
     expect(report.extraction).toMatchObject({
       filesSeen: 241,
-      filesSelected: 12,
-      filesDeferred: 229,
-      testsRegistered: 234,
-      nativePassed: 232,
+      filesSelected: 13,
+      filesDeferred: 228,
+      testsRegistered: 237,
+      nativePassed: 235,
       nativeFailed: 2,
     });
-    expect(report.extraction.unavailableInfra).toBe(3054);
-    expect(report.compile).toMatchObject({ modules: 12, succeeded: 12, validated: 12 });
-    expect(report.results).toMatchObject({ scored: 232, passed: 113, failed: 119, runtimeFailed: 0 });
+    expect(report.extraction.unavailableInfra).toBe(3051);
+    expect(report.compile).toMatchObject({ modules: 13, succeeded: 13, validated: 13 });
+    expect(report.results).toMatchObject({ scored: 235, passed: 109, failed: 126, runtimeFailed: 0 });
   });
 
   const uuidHeavy = process.env.DOGFOOD_UUID_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/upstream-suite-compile-worker.mjs
+++ b/tests/dogfood/upstream-suite-compile-worker.mjs
@@ -263,6 +263,7 @@ async function main() {
       statuses = Array.from(exports.runUpstreamTests(), (value) => Number(value) === 1);
       errors = Array.from(exports.upstreamTestErrors(), String);
     }
+    await exports.cleanupUpstreamTestEnvironment?.();
     emit({
       compile: { success: true, validates: true, durationMs, binaryBytes: result.binary.length, errors: [] },
       wasm: { count: Number(exports.upstreamTestCount()), statuses, errors },

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -14,6 +14,24 @@ export const UPSTREAM_TEST_SHIM = String.raw`
 // the alias explicit in both the native and Wasm lanes instead of treating a
 // missing Node compatibility global as a package failure.
 var global = globalThis;
+// Some original Jest units pass the timer globals as bare identifiers. Keep
+// those names live through globalThis so fake-timer installation and spy
+// replacement update the same host function in both Node and Wasm lanes.
+function setTimeout(callback, delay) {
+  if (__upstreamFakeTimers !== null) {
+    __upstreamRecordTimerSpy("setTimeout", [callback, delay]);
+    return __upstreamFakeTimers.fakeSetTimeout(callback, delay);
+  }
+  return globalThis.setTimeout(callback, delay);
+}
+function clearTimeout(timer) {
+  if (__upstreamFakeTimers !== null) {
+    __upstreamRecordTimerSpy("clearTimeout", [timer]);
+    return __upstreamFakeTimers.fakeClearTimeout(timer);
+  }
+  return globalThis.clearTimeout(timer);
+}
+const __upstreamBareTimerAliases = { setTimeout, clearTimeout };
 const __upstreamTests = [];
 const __upstreamErrors = [];
 let __upstreamSnapshotMatcher = null;
@@ -106,13 +124,13 @@ function __upstreamExpect(actual) {
     toMatchObject(expected) { const n = ++__upstreamAssertion; if (!__upstreamSubset(actual, expected)) __upstreamFail("assertion " + n + " object subset mismatch"); },
     toMatch(expected) { const n = ++__upstreamAssertion; const value = String(actual); if (expected instanceof RegExp ? !expected.test(value) : !value.includes(String(expected))) __upstreamFail("assertion " + n + " pattern mismatch"); },
     toMatchInlineSnapshot(expected) { const n = ++__upstreamAssertion; const value = typeof actual === "string" ? JSON.stringify(actual) : String(actual); if (value !== String(expected).trim()) __upstreamFail("assertion " + n + " inline snapshot mismatch: " + value + " != " + String(expected).trim()); },
-    toBeCalled() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length === 0) __upstreamFail("assertion " + n + " expected spy to be called"); },
-    toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length === 0) __upstreamFail("assertion " + n + " expected spy to be called"); },
-    toBeCalledWith() { const n = ++__upstreamAssertion; const expected = Array.prototype.slice.call(arguments); const calls = actual && actual.mock && actual.mock.calls; let matched = false; if (calls) for (let i = 0; i < calls.length; i++) if (__upstreamSame(calls[i], expected)) matched = true; if (!matched) __upstreamFail("assertion " + n + " expected matching spy call"); },
-    toHaveBeenCalledWith() { const n = ++__upstreamAssertion; const expected = Array.prototype.slice.call(arguments); const calls = actual && actual.mock && actual.mock.calls; let matched = false; if (calls) for (let i = 0; i < calls.length; i++) if (__upstreamSame(calls[i], expected)) matched = true; if (!matched) __upstreamFail("assertion " + n + " expected matching spy call"); },
-    toHaveBeenCalledTimes(expected) { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length !== expected) __upstreamFail("assertion " + n + " spy call count mismatch"); },
-    toHaveBeenCalledOnce() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length !== 1) __upstreamFail("assertion " + n + " spy call count mismatch"); },
-    toBeCalledOnce() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (!calls || calls.length !== 1) __upstreamFail("assertion " + n + " spy call count mismatch"); },
+    toBeCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (!calls || calls.length === 0) __upstreamFail("assertion " + n + " expected spy to be called"); },
+    toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (!calls || calls.length === 0) __upstreamFail("assertion " + n + " expected spy to be called"); },
+    toBeCalledWith() { const n = ++__upstreamAssertion; const expected = Array.prototype.slice.call(arguments); const calls = __upstreamMockCalls(actual); let matched = false; if (calls) for (let i = 0; i < calls.length; i++) if (__upstreamSame(calls[i], expected)) matched = true; if (!matched) __upstreamFail("assertion " + n + " expected matching spy call"); },
+    toHaveBeenCalledWith() { const n = ++__upstreamAssertion; const expected = Array.prototype.slice.call(arguments); const calls = __upstreamMockCalls(actual); let matched = false; if (calls) for (let i = 0; i < calls.length; i++) if (__upstreamSame(calls[i], expected)) matched = true; if (!matched) __upstreamFail("assertion " + n + " expected matching spy call"); },
+    toHaveBeenCalledTimes(expected) { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (!calls || calls.length !== expected) __upstreamFail("assertion " + n + " spy call count mismatch"); },
+    toHaveBeenCalledOnce() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (!calls || calls.length !== 1) __upstreamFail("assertion " + n + " spy call count mismatch"); },
+    toBeCalledOnce() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (!calls || calls.length !== 1) __upstreamFail("assertion " + n + " spy call count mismatch"); },
     toBeInstanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected !== "function" || !(actual instanceof expected)) __upstreamFail("assertion " + n + " instance mismatch"); },
     instanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected !== "function" || !(actual instanceof expected)) __upstreamFail("assertion " + n + " instance mismatch"); },
     toMatchSnapshot() {
@@ -135,9 +153,9 @@ function __upstreamExpect(actual) {
     toBeFalsy() { const n = ++__upstreamAssertion; if (!actual) __upstreamFail("assertion " + n + " unexpectedly falsey"); },
     toBeInstanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected === "function" && actual instanceof expected) __upstreamFail("assertion " + n + " unexpected instance"); },
     instanceOf(expected) { const n = ++__upstreamAssertion; if (typeof expected === "function" && actual instanceof expected) __upstreamFail("assertion " + n + " unexpected instance"); },
-    toBeCalled() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
-    toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
-    toHaveBeenCalledOnce() { const n = ++__upstreamAssertion; const calls = actual && actual.mock && actual.mock.calls; if (calls && calls.length === 1) __upstreamFail("assertion " + n + " unexpected spy call"); },
+    toBeCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
+    toHaveBeenCalled() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length > 0) __upstreamFail("assertion " + n + " unexpected spy call"); },
+    toHaveBeenCalledOnce() { const n = ++__upstreamAssertion; const calls = __upstreamMockCalls(actual); if (calls && calls.length === 1) __upstreamFail("assertion " + n + " unexpected spy call"); },
     toThrow() { const n = ++__upstreamAssertion; if (typeof actual !== "function" || __upstreamThrown(actual) !== null) __upstreamFail("assertion " + n + " unexpected throw"); },
     toThrowError() { const n = ++__upstreamAssertion; if (typeof actual !== "function" || __upstreamThrown(actual) !== null) __upstreamFail("assertion " + n + " unexpected throw"); },
   };
@@ -166,6 +184,23 @@ function __upstreamExpect(actual) {
 const expect = __upstreamExpect;
 const __upstreamGlobalStubs = [];
 const __upstreamEnvStubs = [];
+const __upstreamSpies = [];
+const __upstreamTimerSpies = { setTimeout: null, clearTimeout: null };
+let __upstreamSetTimeoutCallCount = 0;
+let __upstreamClearTimeoutCallCount = 0;
+function __upstreamMockCalls(actual) {
+  if (actual === __upstreamBareTimerAliases.setTimeout) {
+    return { length: __upstreamSetTimeoutCallCount };
+  }
+  if (actual === __upstreamBareTimerAliases.clearTimeout) {
+    return { length: __upstreamClearTimeoutCallCount };
+  }
+  return actual && actual.mock && actual.mock.calls;
+}
+function __upstreamRecordTimerSpy(key, args) {
+  if (key === "setTimeout") __upstreamSetTimeoutCallCount++;
+  else if (key === "clearTimeout") __upstreamClearTimeoutCallCount++;
+}
 const vi = {
   fn(implementation) {
     function spy() {
@@ -183,7 +218,20 @@ const vi = {
   spyOn(object, key) {
     const original = object[key];
     const spy = vi.fn(function() { return original.apply(this, arguments); });
-    spy.mockRestore = function() { object[key] = original; };
+    spy.mockRestore = function() {
+      object[key] = original;
+      if (__upstreamTimerSpies[key] === spy) __upstreamTimerSpies[key] = null;
+    };
+    const bareAlias = __upstreamBareTimerAliases[key];
+    if (bareAlias !== undefined) {
+      bareAlias.mock = spy.mock;
+      bareAlias.mockClear = spy.mockClear;
+      bareAlias.mockRestore = spy.mockRestore;
+      __upstreamTimerSpies[key] = spy;
+      if (key === "setTimeout") __upstreamSetTimeoutCallCount = 0;
+      else if (key === "clearTimeout") __upstreamClearTimeoutCallCount = 0;
+    }
+    __upstreamSpies.push({ object, key, original, spy });
     object[key] = spy;
     return spy;
   },
@@ -218,6 +266,49 @@ const vi = {
     __upstreamEnvStubs.length = 0;
   },
 };
+function __upstreamRestoreAllMocks() {
+  for (let index = __upstreamSpies.length - 1; index >= 0; index--) {
+    const spy = __upstreamSpies[index];
+    spy.spy.mockRestore();
+  }
+  __upstreamSpies.length = 0;
+  __upstreamTimerSpies.setTimeout = null;
+  __upstreamTimerSpies.clearTimeout = null;
+  __upstreamSetTimeoutCallCount = 0;
+  __upstreamClearTimeoutCallCount = 0;
+}
+let __upstreamFakeTimers = null;
+function __upstreamUseFakeTimers() {
+  if (__upstreamFakeTimers !== null) return;
+  const realSetTimeout = globalThis.setTimeout;
+  const realClearTimeout = globalThis.clearTimeout;
+  const timers = new Map();
+  let nextTimerId = 1;
+  const fakeSetTimeout = function(callback, delay) {
+    const id = nextTimerId++;
+    timers.set(id, { callback, delay: Number(delay) || 0 });
+    return id;
+  };
+  const fakeClearTimeout = function(id) {
+    timers.delete(id);
+  };
+  __upstreamFakeTimers = { realSetTimeout, realClearTimeout, timers, fakeSetTimeout, fakeClearTimeout };
+}
+function __upstreamRunAllTimers() {
+  if (__upstreamFakeTimers === null) return;
+  let guard = 10000;
+  while (__upstreamFakeTimers.timers.size > 0) {
+    if (--guard < 0) throw new Error("fake timer queue exceeded 10000 callbacks");
+    const entry = __upstreamFakeTimers.timers.entries().next().value;
+    __upstreamFakeTimers.timers.delete(entry[0]);
+    entry[1].callback();
+  }
+}
+function __upstreamUseRealTimers() {
+  __upstreamRestoreAllMocks();
+  if (__upstreamFakeTimers === null) return;
+  __upstreamFakeTimers = null;
+}
 // A number of Jest-owned packages publish their original tests with the Jest
 // global even when the selected unit only needs spies. Keep this small facade
 // backed by the same deterministic implementation as vi; package adapters can
@@ -228,6 +319,10 @@ const jest = {
   spyOn: vi.spyOn,
   resetModules() {},
   doMock() {},
+  useFakeTimers: __upstreamUseFakeTimers,
+  useRealTimers: __upstreamUseRealTimers,
+  runAllTimers: __upstreamRunAllTimers,
+  restoreAllMocks: __upstreamRestoreAllMocks,
 };
 const __upstreamBeforeEach = [];
 const __upstreamAfterEach = [];
@@ -500,6 +595,10 @@ export function runUpstreamTests(): number[] {
   return statuses;
 }
 export function upstreamTestErrors(): string[] { return __upstreamErrors; }
+export function cleanupUpstreamTestEnvironment(): void {
+  if (typeof jest.useRealTimers === "function") jest.useRealTimers();
+  if (typeof jest.restoreAllMocks === "function") jest.restoreAllMocks();
+}
 `;
 
 function errorText(error) {
@@ -543,6 +642,7 @@ async function runNative(generatedPath, source) {
     statuses.push(...Array.from(module.runUpstreamTests(), (value) => Number(value) === 1));
     errors.push(...Array.from(module.upstreamTestErrors(), String));
   }
+  module.cleanupUpstreamTestEnvironment?.();
   return {
     count,
     names: Array.from(module.upstreamTestNames(), String),

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -279,7 +279,7 @@ function __upstreamRestoreAllMocks() {
 }
 let __upstreamFakeTimers = null;
 function __upstreamUseFakeTimers() {
-  if (__upstreamFakeTimers !== null) return;
+  if (__upstreamFakeTimers !== null) return jest;
   const timers = new Map();
   let nextTimerId = 1;
   let now = 0;
@@ -293,6 +293,7 @@ function __upstreamUseFakeTimers() {
     timers.delete(id);
   };
   __upstreamFakeTimers = { timers, fakeSetTimeout, fakeClearTimeout, get now() { return now; }, set now(value) { now = value; } };
+  return jest;
 }
 function __upstreamNextTimer() {
   if (__upstreamFakeTimers === null || __upstreamFakeTimers.timers.size === 0) return null;
@@ -359,8 +360,21 @@ function __upstreamRunOnlyPendingTimersAsync() {
 }
 function __upstreamUseRealTimers() {
   __upstreamRestoreAllMocks();
-  if (__upstreamFakeTimers === null) return;
+  if (__upstreamFakeTimers === null) return jest;
   __upstreamFakeTimers = null;
+  return jest;
+}
+function __upstreamSetSystemTime(value) {
+  if (__upstreamFakeTimers !== null) {
+    const timestamp = value instanceof Date ? value.getTime() : Number(value);
+    if (Number.isFinite(timestamp)) __upstreamFakeTimers.now = timestamp;
+  }
+}
+function __upstreamNow() {
+  return __upstreamFakeTimers === null ? Date.now() : __upstreamFakeTimers.now;
+}
+function __upstreamGetRealSystemTime() {
+  return Date.now();
 }
 // A number of Jest-owned packages publish their original tests with the Jest
 // global even when the selected unit only needs spies. Keep this small facade
@@ -382,6 +396,9 @@ const jest = {
   runOnlyPendingTimersAsync: __upstreamRunOnlyPendingTimersAsync,
   clearAllTimers: __upstreamClearAllTimers,
   getTimerCount: __upstreamGetTimerCount,
+  setSystemTime: __upstreamSetSystemTime,
+  now: __upstreamNow,
+  getRealSystemTime: __upstreamGetRealSystemTime,
   restoreAllMocks: __upstreamRestoreAllMocks,
 };
 const __upstreamBeforeEach = [];

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -280,29 +280,82 @@ function __upstreamRestoreAllMocks() {
 let __upstreamFakeTimers = null;
 function __upstreamUseFakeTimers() {
   if (__upstreamFakeTimers !== null) return;
-  const realSetTimeout = globalThis.setTimeout;
-  const realClearTimeout = globalThis.clearTimeout;
   const timers = new Map();
   let nextTimerId = 1;
+  let now = 0;
   const fakeSetTimeout = function(callback, delay) {
     const id = nextTimerId++;
-    timers.set(id, { callback, delay: Number(delay) || 0 });
+    const normalizedDelay = Math.max(0, Number(delay) || 0);
+    timers.set(id, { callback, at: now + normalizedDelay });
     return id;
   };
   const fakeClearTimeout = function(id) {
     timers.delete(id);
   };
-  __upstreamFakeTimers = { realSetTimeout, realClearTimeout, timers, fakeSetTimeout, fakeClearTimeout };
+  __upstreamFakeTimers = { timers, fakeSetTimeout, fakeClearTimeout, get now() { return now; }, set now(value) { now = value; } };
+}
+function __upstreamNextTimer() {
+  if (__upstreamFakeTimers === null || __upstreamFakeTimers.timers.size === 0) return null;
+  let next = null;
+  for (const [id, entry] of __upstreamFakeTimers.timers) {
+    if (next === null || entry.at < next.entry.at || (entry.at === next.entry.at && id < next.id)) {
+      next = { id, entry };
+    }
+  }
+  return next;
+}
+function __upstreamRunTimer(next) {
+  if (__upstreamFakeTimers === null || next === null) return;
+  if (!__upstreamFakeTimers.timers.has(next.id)) return;
+  __upstreamFakeTimers.timers.delete(next.id);
+  __upstreamFakeTimers.now = Math.max(__upstreamFakeTimers.now, next.entry.at);
+  next.entry.callback();
 }
 function __upstreamRunAllTimers() {
   if (__upstreamFakeTimers === null) return;
   let guard = 10000;
   while (__upstreamFakeTimers.timers.size > 0) {
     if (--guard < 0) throw new Error("fake timer queue exceeded 10000 callbacks");
-    const entry = __upstreamFakeTimers.timers.entries().next().value;
-    __upstreamFakeTimers.timers.delete(entry[0]);
-    entry[1].callback();
+    __upstreamRunTimer(__upstreamNextTimer());
   }
+}
+function __upstreamAdvanceTimersByTime(milliseconds) {
+  if (__upstreamFakeTimers === null) return;
+  const target = __upstreamFakeTimers.now + Math.max(0, Number(milliseconds) || 0);
+  let guard = 10000;
+  while (__upstreamFakeTimers.timers.size > 0) {
+    if (--guard < 0) throw new Error("fake timer queue exceeded 10000 callbacks");
+    const next = __upstreamNextTimer();
+    if (next === null || next.entry.at > target) break;
+    __upstreamRunTimer(next);
+  }
+  __upstreamFakeTimers.now = target;
+}
+function __upstreamRunOnlyPendingTimers() {
+  if (__upstreamFakeTimers === null) return;
+  const pending = Array.from(__upstreamFakeTimers.timers.keys());
+  for (const id of pending) {
+    const entry = __upstreamFakeTimers.timers.get(id);
+    if (entry !== undefined) __upstreamRunTimer({ id, entry });
+  }
+}
+function __upstreamClearAllTimers() {
+  if (__upstreamFakeTimers !== null) __upstreamFakeTimers.timers.clear();
+}
+function __upstreamGetTimerCount() {
+  return __upstreamFakeTimers === null ? 0 : __upstreamFakeTimers.timers.size;
+}
+function __upstreamRunAllTimersAsync() {
+  __upstreamRunAllTimers();
+  return Promise.resolve();
+}
+function __upstreamAdvanceTimersByTimeAsync(milliseconds) {
+  __upstreamAdvanceTimersByTime(milliseconds);
+  return Promise.resolve();
+}
+function __upstreamRunOnlyPendingTimersAsync() {
+  __upstreamRunOnlyPendingTimers();
+  return Promise.resolve();
 }
 function __upstreamUseRealTimers() {
   __upstreamRestoreAllMocks();
@@ -322,6 +375,13 @@ const jest = {
   useFakeTimers: __upstreamUseFakeTimers,
   useRealTimers: __upstreamUseRealTimers,
   runAllTimers: __upstreamRunAllTimers,
+  runAllTimersAsync: __upstreamRunAllTimersAsync,
+  advanceTimersByTime: __upstreamAdvanceTimersByTime,
+  advanceTimersByTimeAsync: __upstreamAdvanceTimersByTimeAsync,
+  runOnlyPendingTimers: __upstreamRunOnlyPendingTimers,
+  runOnlyPendingTimersAsync: __upstreamRunOnlyPendingTimersAsync,
+  clearAllTimers: __upstreamClearAllTimers,
+  getTimerCount: __upstreamGetTimerCount,
   restoreAllMocks: __upstreamRestoreAllMocks,
 };
 const __upstreamBeforeEach = [];

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -154,6 +154,44 @@ ${UPSTREAM_TEST_EXPORTS}`;
     }
   }, 90_000);
 
+  it("supports deterministic Jest fake timers without replacing the harness clock", async () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
+    const generatedPath = join(root, "suite.ts");
+    const source = `${UPSTREAM_TEST_SHIM}
+jest.useFakeTimers();
+test("fake timer", () => {
+  let fired = 0;
+  const timer = setTimeout(() => { fired += 1; }, 1000);
+  expect(fired).toBe(0);
+  jest.runAllTimers();
+  expect(fired).toBe(1);
+  expect(setTimeout).toHaveBeenCalled();
+  clearTimeout(timer);
+});
+${UPSTREAM_TEST_EXPORTS}`;
+
+    try {
+      const previousNodeOptions = process.env.NODE_OPTIONS;
+      process.env.NODE_OPTIONS = [previousNodeOptions, "--import=tsx"].filter(Boolean).join(" ");
+      let result;
+      try {
+        result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 60_000 });
+      } finally {
+        // biome-ignore lint/performance/noDelete: `process.env.X = undefined` sets the string "undefined" instead of unsetting the var
+        if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+        else process.env.NODE_OPTIONS = previousNodeOptions;
+      }
+      expect(result.native.statuses).toEqual([true]);
+      expect(result.native.errors).toEqual([""]);
+      expect(result.compile?.success).toBe(true);
+      expect(result.compile?.validates).toBe(true);
+      expect(result.wasm?.statuses).toEqual([true]);
+      expect(result.wasm?.errors).toEqual([""]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 90_000);
+
   it("supports Vitest instanceOf and spy matcher aliases", async () => {
     const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
     const generatedPath = join(root, "suite.ts");

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -161,12 +161,18 @@ ${UPSTREAM_TEST_EXPORTS}`;
 jest.useFakeTimers();
 test("fake timer", () => {
   let fired = 0;
-  const timer = setTimeout(() => { fired += 1; }, 1000);
+  setTimeout(() => { fired += 1; }, 1000);
   expect(fired).toBe(0);
-  jest.runAllTimers();
+  expect(jest.getTimerCount()).toBe(1);
+  jest.advanceTimersByTime(999);
+  expect(fired).toBe(0);
+  jest.advanceTimersByTime(1);
   expect(fired).toBe(1);
   expect(setTimeout).toHaveBeenCalled();
-  clearTimeout(timer);
+  setTimeout(() => { fired += 1; }, 2000);
+  expect(jest.getTimerCount()).toBe(1);
+  jest.clearAllTimers();
+  expect(jest.getTimerCount()).toBe(0);
 });
 ${UPSTREAM_TEST_EXPORTS}`;
 

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -158,7 +158,7 @@ ${UPSTREAM_TEST_EXPORTS}`;
     const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
     const generatedPath = join(root, "suite.ts");
     const source = `${UPSTREAM_TEST_SHIM}
-jest.useFakeTimers();
+jest.useFakeTimers().setSystemTime(100);
 test("fake timer", () => {
   let fired = 0;
   setTimeout(() => { fired += 1; }, 1000);
@@ -173,6 +173,8 @@ test("fake timer", () => {
   expect(jest.getTimerCount()).toBe(1);
   jest.clearAllTimers();
   expect(jest.getTimerCount()).toBe(0);
+  expect(jest.now()).toBe(1100);
+  expect(jest.getRealSystemTime() > 0).toBe(true);
 });
 ${UPSTREAM_TEST_EXPORTS}`;
 


### PR DESCRIPTION
## Summary

Adds the shared upstream-suite infrastructure needed by Jest's timer-driven
tests:

- deterministic `jest.useFakeTimers`, `jest.useRealTimers`, ordered virtual
  deadlines, timer advancement/clearing/counting, pending/async timer aliases,
  and `jest.runAllTimers` without replacing the harness clock;
- timer spy accounting for bare `setTimeout` and `clearTimeout`, plus generic
  spy cleanup between generated modules;
- cleanup in both the native and Wasm runners so one original test cannot leak
  fake timers or spies into the next module;
- the original Jest `jest-jasmine2/src/__tests__/pTimeout.test.ts` unit file;
- exact inventory and handoff updates in
  [the npm compatibility issue](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).

The fake timer implementation intentionally stays inside the generated test
environment. Replacing the host clock caused the Wasm async handoff to stop
making progress; this design keeps the oracle and harness clocks real while
draining the test timer queue deterministically.

## Measurement

The unchanged Jest inventory now selects 13 original files containing 237
callbacks. The Node oracle admits 235 (235 pass, 2 fail), all 13 modules
compile and validate, and 109/235 admitted callbacks pass in Wasm. The other
3,051 registrations from 228 verified files remain explicitly reported as
unavailable infrastructure. The three newly selected `pTimeout` callbacks are
scored in Wasm and currently fail with compiler/runtime async-function
reference errors; they are not relabeled as unavailable infrastructure.

The dedicated runner regression passes in both lanes (1/1 native and 1/1
Wasm).

## Validation

- `pnpm exec vitest run tests/dogfood/upstream-suite-runner.test.ts --testNamePattern="fake timers"`
- `DOGFOOD_JEST_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts --testNamePattern="Jest's selected original utility units"`
- `pnpm run typecheck`
- Prettier check, issue-ID check, and `git diff --check`

Closes no compiler/runtime failure; those remain visible for the next Jest
infrastructure slice.
