### PR TITLE
test(jest): support original registration APIs

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -871,3 +871,30 @@ files**: Node admits **240/240**, all 15 modules compile and validate, and Wasm
 scores **114/240**. The remaining **3,046 registrations** from 226 verified
 files remain explicitly reported as unavailable infrastructure; other Wasm
 failures remain compatibility findings rather than unavailable setup.
+
+## 2026-08-22 Jest registration-API checkpoint
+
+Three original `jest-jasmine2` units are now selected unchanged:
+`itTestError.test.ts`, `todoError.test.ts`, and `hooksError.test.ts`. The shared
+adapter now validates Jest test names and callbacks, implements the `it.todo` /
+`test.todo` argument contract, validates all four lifecycle hooks, and lowers
+Jest's curried `*.each(cases)(name, body)` registration shape to an equivalent
+direct registration call for Wasm. The hook-error unit's dynamic global hook
+lookup is routed through the same named hook functions; its assertion body and
+inputs remain upstream source.
+
+The exact run now covers **283 callbacks across 18 selected files**: Node admits
+**281/283**, all 18 modules compile and validate, and Wasm scores **195/281**.
+The remaining **3,005 registrations** from 223 verified files remain explicitly
+reported as unavailable infrastructure; Wasm failures are compatibility findings,
+not silently skipped tests.
+
+## 2026-08-22 Jest current-main rebase checkpoint
+
+After rebasing the registration-API slice over the landed package-resolution
+and queue-runner work, the exact inventory includes those two earlier files as
+well. It now covers **306 callbacks across 20 selected files**: Node admits
+**304/306**, all 20 modules compile and 19 validate (the queue-runner Wasm
+binary remains the known compiler validation finding), and Wasm scores
+**206/304**. The remaining **2,982 registrations** from 221 verified files are
+still explicitly reported as unavailable infrastructure.

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -815,6 +815,7 @@ compiler, validation, or runtime mismatches in the upstream suites remain
 scored as compatibility failures.
 
 Implementation: [PR #4756](https://github.com/loopdive/js2/pull/4756).
+
 ## 2026-08-22 Jest internal-package resolution checkpoint
 
 The Jest adapter now materializes the verified `@jest/get-type@30.1.0`
@@ -859,3 +860,14 @@ covers **260 callbacks across 15 selected files**: Node admits **258/258**, all
 queue-runner Wasm module remains a compiler validation finding, while the
 remaining **3,028 registrations** from 226 verified files remain explicitly
 reported as unavailable infrastructure.
+## 2026-08-22 Jest collection-matcher checkpoint
+
+The original `jest-jasmine2/src/__tests__/iterators.test.ts` and
+`itToTestAlias.test.ts` units are now selected without changing their source.
+The shared Jest matcher now distinguishes arrays from array-like objects and
+implements recursive Set/Map equality, matching the collection semantics those
+tests exercise. The exact run covers **242 callbacks across 15 selected
+files**: Node admits **240/240**, all 15 modules compile and validate, and Wasm
+scores **114/240**. The remaining **3,046 registrations** from 226 verified
+files remain explicitly reported as unavailable infrastructure; other Wasm
+failures remain compatibility findings rather than unavailable setup.

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -24,7 +24,10 @@
     "packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts",
     "packages/jest-jasmine2/src/__tests__/queueRunner.test.ts",
     "packages/jest-jasmine2/src/__tests__/iterators.test.ts",
-    "packages/jest-jasmine2/src/__tests__/itToTestAlias.test.ts"
+    "packages/jest-jasmine2/src/__tests__/itToTestAlias.test.ts",
+    "packages/jest-jasmine2/src/__tests__/itTestError.test.ts",
+    "packages/jest-jasmine2/src/__tests__/todoError.test.ts",
+    "packages/jest-jasmine2/src/__tests__/hooksError.test.ts"
   ],
   "dependencies": {
     "detect-newline": {

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -22,7 +22,9 @@
     "packages/jest-config/src/__tests__/stringToBytes.test.ts",
     "packages/jest-jasmine2/src/__tests__/pTimeout.test.ts",
     "packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts",
-    "packages/jest-jasmine2/src/__tests__/queueRunner.test.ts"
+    "packages/jest-jasmine2/src/__tests__/queueRunner.test.ts",
+    "packages/jest-jasmine2/src/__tests__/iterators.test.ts",
+    "packages/jest-jasmine2/src/__tests__/itToTestAlias.test.ts"
   ],
   "dependencies": {
     "detect-newline": {

--- a/tests/dogfood/jest-upstream-suite.mjs
+++ b/tests/dogfood/jest-upstream-suite.mjs
@@ -24,6 +24,81 @@ function moduleSpecifier(fromDirectory, target) {
   return value;
 }
 
+function matchingParenthesis(source, openIndex) {
+  let depth = 0;
+  let quote = "";
+  let lineComment = false;
+  let blockComment = false;
+  for (let index = openIndex; index < source.length; index++) {
+    const character = source[index];
+    const next = source[index + 1];
+    if (lineComment) {
+      if (character === "\n" || character === "\r") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (character === "*" && next === "/") {
+        blockComment = false;
+        index++;
+      }
+      continue;
+    }
+    if (quote) {
+      if (character === "\\") index++;
+      else if (character === quote) quote = "";
+      continue;
+    }
+    if (character === "/" && next === "/") {
+      lineComment = true;
+      index++;
+      continue;
+    }
+    if (character === "/" && next === "*") {
+      blockComment = true;
+      index++;
+      continue;
+    }
+    if (character === "'" || character === '"' || character === "`") {
+      quote = character;
+      continue;
+    }
+    if (character === "(") depth++;
+    else if (character === ")") {
+      depth--;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function rewriteCurriedEachCalls(source) {
+  let output = "";
+  let cursor = 0;
+  const callPattern = /\b(describe|it|test)\.each\s*\(/g;
+  while (true) {
+    const match = callPattern.exec(source);
+    if (!match) break;
+    const firstOpen = callPattern.lastIndex - 1;
+    const firstClose = matchingParenthesis(source, firstOpen);
+    if (firstClose < 0) break;
+    let secondOpen = firstClose + 1;
+    while (/\s/.test(source[secondOpen] ?? "")) secondOpen++;
+    if (source[secondOpen] !== "(") {
+      callPattern.lastIndex = firstClose + 1;
+      continue;
+    }
+    const secondClose = matchingParenthesis(source, secondOpen);
+    if (secondClose < 0) break;
+    output += source.slice(cursor, match.index);
+    const helper = match[1] === "describe" ? "__upstreamDescribeEachDirect" : "__upstreamEachDirect";
+    const secondArguments = rewriteCurriedEachCalls(source.slice(secondOpen + 1, secondClose));
+    output += `${helper}(${source.slice(firstOpen + 1, firstClose)}, ${secondArguments})`;
+    cursor = secondClose + 1;
+    callPattern.lastIndex = cursor;
+  }
+  return output + source.slice(cursor);
+}
+
 function resolveJestImport(filePath, specifier) {
   const base = resolve(dirname(filePath), specifier);
   const candidates = [
@@ -117,7 +192,15 @@ function transformJestTest(source, filePath, generatedPath, { normalizeCjs = fal
     },
   );
   for (const { pattern, replacement } of namespaceReplacements) transformed = transformed.replace(pattern, replacement);
-  return transformed;
+  // Preserve the original registration callbacks but lower Jest's curried
+  // `*.each(cases)(name, body)` surface to a direct shim call. This avoids
+  // requiring the Wasm lane to materialize a temporary callable with a
+  // package-owned function property.
+  transformed = rewriteCurriedEachCalls(transformed);
+  // The original hook-error unit indexes the global object with a dynamic
+  // name. Resolve that standard Jest API through the same local hook wrappers
+  // so the Wasm lane does not depend on dynamic host-object property lookup.
+  return transformed.replace(/\bglobalThis\[fn\]\(el\)/g, "__upstreamCallNamedHook(fn, el)");
 }
 
 export async function runHarness({ quiet = false } = {}) {

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -282,15 +282,15 @@ describe("small npm package upstream suites", () => {
     const report = await run("jest");
     expect(report.extraction).toMatchObject({
       filesSeen: 241,
-      filesSelected: 15,
-      filesDeferred: 226,
-      testsRegistered: 260,
-      nativePassed: 258,
+      filesSelected: 17,
+      filesDeferred: 224,
+      testsRegistered: 265,
+      nativePassed: 263,
       nativeFailed: 2,
     });
-    expect(report.extraction.unavailableInfra).toBe(3028);
-    expect(report.compile).toMatchObject({ modules: 15, succeeded: 15, validated: 14 });
-    expect(report.results).toMatchObject({ scored: 258, passed: 120, failed: 138, runtimeFailed: 0 });
+    expect(report.extraction.unavailableInfra).toBe(3023);
+    expect(report.compile).toMatchObject({ modules: 17, succeeded: 17, validated: 16 });
+    expect(report.results).toMatchObject({ scored: 263, passed: 120, failed: 143, runtimeFailed: 0 });
   });
 
   const uuidHeavy = process.env.DOGFOOD_UUID_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -282,15 +282,15 @@ describe("small npm package upstream suites", () => {
     const report = await run("jest");
     expect(report.extraction).toMatchObject({
       filesSeen: 241,
-      filesSelected: 17,
-      filesDeferred: 224,
-      testsRegistered: 265,
-      nativePassed: 263,
+      filesSelected: 20,
+      filesDeferred: 221,
+      testsRegistered: 306,
+      nativePassed: 304,
       nativeFailed: 2,
     });
-    expect(report.extraction.unavailableInfra).toBe(3023);
-    expect(report.compile).toMatchObject({ modules: 17, succeeded: 17, validated: 16 });
-    expect(report.results).toMatchObject({ scored: 263, passed: 120, failed: 143, runtimeFailed: 0 });
+    expect(report.extraction.unavailableInfra).toBe(2982);
+    expect(report.compile).toMatchObject({ modules: 20, succeeded: 20, validated: 19 });
+    expect(report.results).toMatchObject({ scored: 304, passed: 206, failed: 98, runtimeFailed: 0 });
   });
 
   const uuidHeavy = process.env.DOGFOOD_UUID_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -51,6 +51,39 @@ function __upstreamSame(a, b) {
   if (typeof a !== "object") return false;
   if (a instanceof Date || b instanceof Date) return a instanceof Date && b instanceof Date && +a === +b;
   if (a instanceof RegExp || b instanceof RegExp) return a instanceof RegExp && b instanceof RegExp && String(a) === String(b);
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (aIsArray || bIsArray) {
+    if (!aIsArray || !bIsArray || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (!__upstreamSame(a[i], b[i])) return false;
+    return true;
+  }
+  const aIsSet = a instanceof Set;
+  const bIsSet = b instanceof Set;
+  if (aIsSet || bIsSet) {
+    if (!aIsSet || !bIsSet || a.size !== b.size) return false;
+    const unmatched = Array.from(b);
+    for (const value of a) {
+      const index = unmatched.findIndex((candidate) => __upstreamSame(value, candidate));
+      if (index < 0) return false;
+      unmatched.splice(index, 1);
+    }
+    return true;
+  }
+  const aIsMap = a instanceof Map;
+  const bIsMap = b instanceof Map;
+  if (aIsMap || bIsMap) {
+    if (!aIsMap || !bIsMap || a.size !== b.size) return false;
+    const unmatched = Array.from(b);
+    for (const [key, value] of a) {
+      const index = unmatched.findIndex(
+        (candidate) => __upstreamSame(key, candidate[0]) && __upstreamSame(value, candidate[1]),
+      );
+      if (index < 0) return false;
+      unmatched.splice(index, 1);
+    }
+    return true;
+  }
   if (typeof a.length === "number" || typeof b.length === "number") {
     if (typeof a.length !== "number" || typeof b.length !== "number" || a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) if (!__upstreamSame(a[i], b[i])) return false;

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -449,9 +449,6 @@ function describe(_name, body) {
   __upstreamBeforeAll.length = beforeAllCount;
   __upstreamAfterAll.length = afterAllCount;
 }
-function beforeEach(body) { __upstreamBeforeEach.push(body); }
-function beforeAll(body) { __upstreamBeforeAll.push(body); }
-function afterAll(body) { __upstreamAfterAll.push(body); }
 function __upstreamRegister(name, body) {
   const hooks = __upstreamBeforeEach.slice();
   const afterHooks = __upstreamAfterEach.slice();
@@ -487,16 +484,58 @@ function __upstreamRegister(name, body) {
     },
   });
 }
-function it(name, body) { __upstreamRegister(name, body); }
-function test(name, body) { __upstreamRegister(name, body); }
+function __upstreamRegisterTest(name, body) {
+  const validName = typeof name === "string" || typeof name === "number" || (typeof name === "function" && name.name);
+  if (!validName) {
+    const renderedName = typeof name === "function" && !name.name ? "() => {}" : String(name);
+    throw new Error("Invalid first argument, " + renderedName + ". It must be a named class, named function, number, or string.");
+  }
+  if (typeof body === "undefined") {
+    throw new Error(
+      "Missing second argument. It must be a callback function. Perhaps you want to use " +
+        String.fromCharCode(96) +
+        "test.todo" +
+        String.fromCharCode(96) +
+        " for a test placeholder.",
+    );
+  }
+  if (typeof body !== "function") {
+    throw new Error("Invalid second argument, " + String(body) + ". It must be a callback function.");
+  }
+  __upstreamRegister(name, body);
+}
+function it(name, body) { __upstreamRegisterTest(name, body); }
+function test(name, body) { __upstreamRegisterTest(name, body); }
 function __upstreamSkip() {}
+function __upstreamTodo(description) {
+  if (arguments.length !== 1 || typeof description !== "string") {
+    throw new Error("Todo must be called with only a description.");
+  }
+}
 it.skip = __upstreamSkip;
-it.todo = __upstreamSkip;
+it.todo = __upstreamTodo;
 test.skip = __upstreamSkip;
-test.todo = __upstreamSkip;
+test.todo = __upstreamTodo;
 describe.skip = __upstreamSkip;
 describe.todo = __upstreamSkip;
-function afterEach(body) { __upstreamAfterEach.push(body); }
+function __upstreamRegisterHook(body) {
+  if (typeof body !== "function") throw new Error("Invalid first argument. It must be a callback function.");
+}
+function afterEach(body) { __upstreamRegisterHook(body); __upstreamAfterEach.push(body); }
+function beforeEach(body) { __upstreamRegisterHook(body); __upstreamBeforeEach.push(body); }
+function beforeAll(body) { __upstreamRegisterHook(body); __upstreamBeforeAll.push(body); }
+function afterAll(body) { __upstreamRegisterHook(body); __upstreamAfterAll.push(body); }
+Object.defineProperty(globalThis, "beforeEach", { configurable: true, writable: true, value: function(body) { __upstreamRegisterHook(body); __upstreamBeforeEach.push(body); } });
+Object.defineProperty(globalThis, "beforeAll", { configurable: true, writable: true, value: function(body) { __upstreamRegisterHook(body); __upstreamBeforeAll.push(body); } });
+Object.defineProperty(globalThis, "afterEach", { configurable: true, writable: true, value: function(body) { __upstreamRegisterHook(body); __upstreamAfterEach.push(body); } });
+Object.defineProperty(globalThis, "afterAll", { configurable: true, writable: true, value: function(body) { __upstreamRegisterHook(body); __upstreamAfterAll.push(body); } });
+function __upstreamCallNamedHook(name, body) {
+  if (name === "beforeEach") return beforeEach(body);
+  if (name === "beforeAll") return beforeAll(body);
+  if (name === "afterEach") return afterEach(body);
+  if (name === "afterAll") return afterAll(body);
+  throw new Error("Unknown hook: " + String(name));
+}
 function __upstreamTableRows(strings, values) {
   const markers = [];
   let source = "";
@@ -532,7 +571,10 @@ function __upstreamEach(cases) {
   const tableRows = Array.isArray(cases) && cases.raw && values.length > 0 ? __upstreamTableRows(cases, values) : null;
   return function(name, body) {
     const sourceCases = tableRows || cases;
-    const expandRows = sourceCases.length > 0 && sourceCases.every(function(value) { return Array.isArray(value); });
+    let expandRows = sourceCases.length > 0;
+    for (let caseIndex = 0; caseIndex < sourceCases.length; caseIndex++) {
+      if (!Array.isArray(sourceCases[caseIndex])) { expandRows = false; break; }
+    }
     for (let index = 0; index < sourceCases.length; index++) {
       const sourceRow = sourceCases[index];
       const row = expandRows ? sourceRow : [sourceRow];
@@ -552,24 +594,59 @@ function __upstreamEach(cases) {
     }
   };
 }
+function __upstreamEachDirect(cases, name, body) {
+  let expandRows = cases.length > 0;
+  for (let caseIndex = 0; caseIndex < cases.length; caseIndex++) {
+    if (!Array.isArray(cases[caseIndex])) { expandRows = false; break; }
+  }
+  for (let index = 0; index < cases.length; index++) {
+    const sourceRow = cases[index];
+    const row = expandRows ? sourceRow : [sourceRow];
+    const displayName = String(name).replace(/%s/g, function() { return String(row[0]); });
+    it(displayName, function() {
+      if (row.length === 0) return body();
+      if (row.length === 1) return body(row[0]);
+      if (row.length === 2) return body(row[0], row[1]);
+      if (row.length === 3) return body(row[0], row[1], row[2]);
+      return body(row[0], row[1], row[2], row[3]);
+    });
+  }
+}
+function __upstreamDescribeEachDirect(cases, name, body) {
+  let expandRows = cases.length > 0;
+  for (let caseIndex = 0; caseIndex < cases.length; caseIndex++) {
+    if (!Array.isArray(cases[caseIndex])) { expandRows = false; break; }
+  }
+  for (let index = 0; index < cases.length; index++) {
+    const sourceRow = cases[index];
+    const row = expandRows ? sourceRow : [sourceRow];
+    if (row.length === 0) body();
+    else if (row.length === 1) body(row[0]);
+    else if (row.length === 2) body(row[0], row[1]);
+    else if (row.length === 3) body(row[0], row[1], row[2]);
+    else body(row[0], row[1], row[2], row[3]);
+  }
+}
 it.each = __upstreamEach;
 test.each = __upstreamEach;
-describe.each = function(cases) {
-  return function(name, body) {
-    const expandRows = cases.length > 0 && cases.every(function(value) { return Array.isArray(value); });
+function __upstreamDescribeEach(cases) {
+  return (name, body) => {
+    let expandRows = cases.length > 0;
+    for (let caseIndex = 0; caseIndex < cases.length; caseIndex++) {
+      if (!Array.isArray(cases[caseIndex])) { expandRows = false; break; }
+    }
     for (let index = 0; index < cases.length; index++) {
       const row = expandRows ? cases[index] : [cases[index]];
       const displayName = String(name).replace(/%s/g, function() { return String(row[0]); });
-      describe(displayName, function() {
-        if (row.length === 0) return body();
-        if (row.length === 1) return body(row[0]);
-        if (row.length === 2) return body(row[0], row[1]);
-        if (row.length === 3) return body(row[0], row[1], row[2]);
-        return body(row[0], row[1], row[2], row[3]);
-      });
+      if (row.length === 0) body();
+      else if (row.length === 1) body(row[0]);
+      else if (row.length === 2) body(row[0], row[1]);
+      else if (row.length === 3) body(row[0], row[1], row[2]);
+      else body(row[0], row[1], row[2], row[3]);
     }
   };
-};
+}
+describe.each = __upstreamDescribeEach;
 // Vitest's expectTypeOf is erased by TypeScript and only performs compile-time
 // checks. Keep the original calls executable without turning type assertions
 // into fake runtime coverage in either the Node or Wasm lane.

--- a/tests/dogfood/upstream-suite-runner.test.ts
+++ b/tests/dogfood/upstream-suite-runner.test.ts
@@ -104,6 +104,45 @@ ${UPSTREAM_TEST_EXPORTS}`;
     }
   }, 90_000);
 
+  it("matches Jest deep equality for arrays, sets, maps, and array-like iterables", async () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
+    const generatedPath = join(root, "suite.ts");
+    const source = `${UPSTREAM_TEST_SHIM}
+test("collection equality", () => {
+  const iterable = { 0: "a", 1: "b", length: 2, [Symbol.iterator]: Array.prototype[Symbol.iterator] };
+  expect(iterable).toEqual({ 0: "a", 1: "b", length: 2, [Symbol.iterator]: Array.prototype[Symbol.iterator] });
+  expect(iterable).not.toEqual(["a", "b"]);
+  expect(new Set([1, 2])).toEqual(new Set([2, 1]));
+  expect(new Set([1, 2])).not.toEqual(new Set([1, 3]));
+  expect(new Map([["a", 1]])).toEqual(new Map([["a", 1]]));
+  expect(new Map([["a", 1]])).not.toEqual(new Map([["a", 2]]));
+});
+${UPSTREAM_TEST_EXPORTS}`;
+
+    try {
+      const previousNodeOptions = process.env.NODE_OPTIONS;
+      process.env.NODE_OPTIONS = [previousNodeOptions, "--import=tsx"].filter(Boolean).join(" ");
+      let result;
+      try {
+        result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 60_000 });
+      } finally {
+        // biome-ignore lint/performance/noDelete: `process.env.X = undefined` sets the string "undefined" instead of unsetting the var
+        if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+        else process.env.NODE_OPTIONS = previousNodeOptions;
+      }
+      expect(result.native.statuses).toEqual([true]);
+      expect(result.native.errors).toEqual([""]);
+      expect(result.compile?.success).toBe(true);
+      expect(result.compile?.validates).toBe(true);
+      // The upstream inventory records any Wasm collection mismatch as a
+      // compatibility result; this regression protects the shared matcher and
+      // native oracle without turning that compiler/runtime finding into an
+      // infrastructure gate.
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 90_000);
+
   it("supports suite lifecycle hooks and the spy helpers used by upstream Web API tests", async () => {
     const root = mkdtempSync(join(tmpdir(), "js2-upstream-runner-"));
     const generatedPath = join(root, "suite.ts");


### PR DESCRIPTION
## Summary

- select the original Jest `iterators.test.ts` and `itToTestAlias.test.ts` units without changing their upstream source
- extend the shared upstream matcher with Jest-compatible array, array-like, Set, and Map equality
- select the original `itTestError.test.ts`, `todoError.test.ts`, and `hooksError.test.ts` units
- enforce Jest's test, todo, and lifecycle-hook registration contracts in the shared adapter
- lower curried `*.each(cases)(name, body)` and dynamic named-hook lookup to Wasm-safe direct shims while keeping the callback bodies upstream
- preserve compiler/runtime compatibility findings as measurements rather than misclassifying them as unavailable infrastructure

## Measured result

The verified Jest 30.4.2 inventory now covers **306 callbacks across 20
selected files**. The Node oracle admits **304/306** callbacks, all 20 modules
compile and 19 validate, and the Wasm lane scores **206/304**. The queue-runner
module remains the known invalid-Wasm compiler finding. The remaining
**2,982 registrations** from 221 verified files remain explicitly reported as
unavailable infrastructure; the 98 Wasm failures are compatibility findings,
not silently skipped tests.

## Validation

- `DOGFOOD_JEST_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts --testNamePattern="Jest's selected original utility units"`
- `pnpm exec vitest run tests/dogfood/upstream-suite-runner.test.ts --testNamePattern="deep equality"`
- `pnpm run typecheck`
- `pnpm exec prettier --check` on changed files
- `node scripts/check-issue-ids.mjs`
- `git diff --check`

Handoff: [Jest upstream-suite issue](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).
