### PR TITLE
fix(#4604): create the styled-components generated dir before its first write — unblocks the matrix refresh

### DIFF
--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -94,6 +94,19 @@ same stale artifact.
   future timestamp — is STALE. Read-only by design: it alerts, recovery stays
   with the refresh workflow. Verified against the live episode: at
   implementation time it reports `STALE — artifact is 33.2h old`.
+- **S4 (this PR): first matrix flight findings (run 770, id 32549785178).**
+  Five groups finished in 3–11 min — the split works. Two blockers surfaced:
+  (a) the `tools` group CRASHED at 33 min: `styled-components-upstream-suite.mjs`
+  wrote `.styled-components-upstream-suite-generated/styled-components-version.ts`
+  without creating the directory (ENOENT). The suite landed 2026-08-21 (#4726)
+  and no serial CI run ever reached it, so the first focused `--only` worker was
+  its first-ever execution. Fixed here with the eslint-suite `mkdirSync` idiom —
+  without this, EVERY run's tools group fails and the coordinator (correctly)
+  refuses to publish, so the dashboard can never heal.
+  (b) the `renderers` group (react-dom, jsdom, redux) ran >3h and was still
+  going at 06:57Z — react-dom's upstream suite dominates; group re-balancing /
+  bounding is follow-up for the roster owners (context: #4751 isolated the
+  ReactDOM server/Fizz batches the day before).
 
 ## Fix directions (pick during implementation)
 

--- a/tests/dogfood/styled-components-upstream-suite.mjs
+++ b/tests/dogfood/styled-components-upstream-suite.mjs
@@ -1,6 +1,6 @@
 // styled-components 6.4.4 original synchronous utility-unit slice.
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -61,6 +61,11 @@ export async function runHarness({ quiet = false } = {}) {
   const suite = setupStyledComponentsUpstreamSuite();
   const runs = [];
   const versionFixturePath = join(GENERATED_ROOT, "styled-components-version.ts");
+  // First write into GENERATED_ROOT — a focused `--only` run (the #4604 matrix
+  // worker) starts from a clean checkout where nothing else has created it
+  // (mirrors eslint-upstream-suite.mjs). The serial path never reached this
+  // line in CI before the matrix split, which is how the gap shipped.
+  mkdirSync(GENERATED_ROOT, { recursive: true });
   writeFileSync(versionFixturePath, `globalThis.__VERSION__ = ${JSON.stringify(suite.pin.version)};\nexport {};\n`);
 
   log(`[dogfood] styled-components@${suite.pin.version} upstream ${suite.pin.tag} (${suite.pin.commit.slice(0, 12)})`);


### PR DESCRIPTION
## Description

First-flight finding from run 770 (the first full matrix refresh, id 32549785178): five groups finished in 3–11 minutes — the #4745 split works — but the **tools group crashed with ENOENT** at 33 min: `styled-components-upstream-suite.mjs` writes `.styled-components-upstream-suite-generated/styled-components-version.ts` before anything creates that directory. The suite landed 2026-08-21 (#4726) and no serial CI run ever survived long enough to reach it, so the focused `--only` matrix worker was its first-ever execution.

This is the critical unblock for the dashboard: without it **every** run's tools group fails, the coordinator (correctly) refuses to publish an incomplete package set, and the committed artifact can never heal. One-line fix using the same `mkdirSync(GENERATED_ROOT, { recursive: true })` idiom as `eslint-upstream-suite.mjs`; audited the other 40 dogfood suites — every other write is already paired with its mkdir.

Also records the run-770 findings on [#4604](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4604-npm-compat-refresh-runtime-exceeds-timeout), including the second observation for the roster owners: the `renderers` group (react-dom, jsdom, redux) ran >3h and was still going at 06:57Z — react-dom dominates and likely needs re-balancing or bounding (context: #4751).

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8)_