### PR TITLE
test(jest): expand original unit coverage

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -917,3 +917,22 @@ scores **215/313** (98 compatibility failures, zero runtime failures). The
 remaining **2,973 registrations** from 220 verified files are explicitly
 reported as unavailable infrastructure. The nine new parse-shard callbacks
 pass in both lanes; no test body or expected input was rewritten.
+
+## 2026-08-22 Jest global-process and concurrent-registration checkpoint
+
+Two additional original release-tag units are now selected without changing
+their callback bodies: `jest-core/src/__tests__/globals.test.ts` and
+`jest-jasmine2/src/__tests__/concurrent.test.ts`. The generic Jest extractor
+also recognizes the original `test.concurrent.each(...)` registration form and
+routes it through the same per-callback runner; the compatibility lane scores
+results serially because it compares behavior, not Jest's worker scheduling.
+
+The exact run now covers **319 callbacks across 23 selected files**. Node
+admits **317/319**, all 23 modules compile and 22 validate, and Wasm scores
+**218/317**. All three concurrent callbacks pass in Wasm. The globals callback
+runs in both lanes but fails its original `[object process]` assertion because
+the current Wasm host exposes the process binding as a null-shaped value; this
+is retained as a compatibility failure rather than relabeled as unavailable
+infrastructure. The queue-runner module remains the sole invalid Wasm module.
+The remaining **2,969 registrations** from 218 verified files remain explicit
+unavailable infrastructure.

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -936,3 +936,14 @@ is retained as a compatibility failure rather than relabeled as unavailable
 infrastructure. The queue-runner module remains the sole invalid Wasm module.
 The remaining **2,969 registrations** from 218 verified files remain explicit
 unavailable infrastructure.
+
+The same checkpoint also admits the original
+`jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js` utility unit.
+Its single callback passes in both lanes. The exact inventory is now **320
+callbacks across 24 selected files**: Node admits **318/320**, 24 modules
+compile and 23 validate, and Wasm scores **219/318**. The unavailable
+infrastructure remainder is **2,968 registrations** from 217 verified files.
+An exploratory `jest-config/src/__tests__/Defaults.test.ts` was not admitted:
+its original package graph requires the unmaterialized pinned `deepmerge`
+dependency, so the Node oracle could not register the callback. That remains a
+concrete dependency-resolution follow-up rather than a Wasm result.

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -30,7 +30,8 @@
     "packages/jest-jasmine2/src/__tests__/hooksError.test.ts",
     "packages/jest-config/src/__tests__/parseShardPair.test.ts",
     "packages/jest-core/src/__tests__/globals.test.ts",
-    "packages/jest-jasmine2/src/__tests__/concurrent.test.ts"
+    "packages/jest-jasmine2/src/__tests__/concurrent.test.ts",
+    "packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js"
   ],
   "dependencies": {
     "detect-newline": {

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -28,7 +28,9 @@
     "packages/jest-jasmine2/src/__tests__/itTestError.test.ts",
     "packages/jest-jasmine2/src/__tests__/todoError.test.ts",
     "packages/jest-jasmine2/src/__tests__/hooksError.test.ts",
-    "packages/jest-config/src/__tests__/parseShardPair.test.ts"
+    "packages/jest-config/src/__tests__/parseShardPair.test.ts",
+    "packages/jest-core/src/__tests__/globals.test.ts",
+    "packages/jest-jasmine2/src/__tests__/concurrent.test.ts"
   ],
   "dependencies": {
     "detect-newline": {

--- a/tests/dogfood/jest-upstream-suite.mjs
+++ b/tests/dogfood/jest-upstream-suite.mjs
@@ -74,7 +74,7 @@ function matchingParenthesis(source, openIndex) {
 function rewriteCurriedEachCalls(source) {
   let output = "";
   let cursor = 0;
-  const callPattern = /\b(describe|it|test)\.each\s*\(/g;
+  const callPattern = /\b(describe|it|test)(?:\.concurrent)?\.each\s*\(/g;
   while (true) {
     const match = callPattern.exec(source);
     if (!match) break;

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -282,15 +282,15 @@ describe("small npm package upstream suites", () => {
     const report = await run("jest");
     expect(report.extraction).toMatchObject({
       filesSeen: 241,
-      filesSelected: 21,
-      filesDeferred: 220,
-      testsRegistered: 315,
-      nativePassed: 313,
+      filesSelected: 23,
+      filesDeferred: 218,
+      testsRegistered: 319,
+      nativePassed: 317,
       nativeFailed: 2,
     });
-    expect(report.extraction.unavailableInfra).toBe(2973);
-    expect(report.compile).toMatchObject({ modules: 21, succeeded: 21, validated: 20 });
-    expect(report.results).toMatchObject({ scored: 313, passed: 215, failed: 98, runtimeFailed: 0 });
+    expect(report.extraction.unavailableInfra).toBe(2969);
+    expect(report.compile).toMatchObject({ modules: 23, succeeded: 23, validated: 22 });
+    expect(report.results).toMatchObject({ scored: 317, passed: 218, failed: 99, runtimeFailed: 0 });
   });
 
   const uuidHeavy = process.env.DOGFOOD_UUID_UPSTREAM_SUITE === "1" ? it : it.skip;

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -282,15 +282,15 @@ describe("small npm package upstream suites", () => {
     const report = await run("jest");
     expect(report.extraction).toMatchObject({
       filesSeen: 241,
-      filesSelected: 23,
-      filesDeferred: 218,
-      testsRegistered: 319,
-      nativePassed: 317,
+      filesSelected: 24,
+      filesDeferred: 217,
+      testsRegistered: 320,
+      nativePassed: 318,
       nativeFailed: 2,
     });
-    expect(report.extraction.unavailableInfra).toBe(2969);
-    expect(report.compile).toMatchObject({ modules: 23, succeeded: 23, validated: 22 });
-    expect(report.results).toMatchObject({ scored: 317, passed: 218, failed: 99, runtimeFailed: 0 });
+    expect(report.extraction.unavailableInfra).toBe(2968);
+    expect(report.compile).toMatchObject({ modules: 24, succeeded: 24, validated: 23 });
+    expect(report.results).toMatchObject({ scored: 318, passed: 219, failed: 99, runtimeFailed: 0 });
   });
 
   const uuidHeavy = process.env.DOGFOOD_UUID_UPSTREAM_SUITE === "1" ? it : it.skip;


### PR DESCRIPTION
## Summary

- Admit the original Jest `jest-core` globals unit and `jest-jasmine2` concurrent unit.
- Recognize `test.concurrent.each(...)` while preserving the original callback bodies and inputs.
- Keep the Wasm process-object mismatch and the queue-runner validation defect visible as compatibility findings.
- Update the shared Jest checkpoint and unavailable-infrastructure denominator in [#3995](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).

## Measured checkpoint

- 23 selected files / 319 registered callbacks.
- Node admits 317/319.
- 23 modules compile; 22 validate.
- Wasm scores 218/317; all three concurrent callbacks pass.
- 2,969 callbacks remain explicitly unavailable infrastructure.

The globals test runs in both lanes but currently fails its original process-object assertion in Wasm. The known queue-runner `call_ref` validation failure remains in the denominator; neither is relabeled as unavailable infrastructure.

## Validation

- `DOGFOOD_JEST_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts --testNamePattern="Jest's selected original utility units" --pool=forks --poolOptions.forks.singleFork=true`
- `pnpm run typecheck`
- `pnpm exec prettier --check ...`
- `node scripts/check-issue-ids.mjs`
- `git diff --check`
