### PR TITLE
fix(npm-compat): per-test watchdog for the react-dom upstream suite — unhang the renderers group (#4604 S5)

### DIFF
--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -107,6 +107,30 @@ same stale artifact.
   going at 06:57Z — react-dom's upstream suite dominates; group re-balancing /
   bounding is follow-up for the roster owners (context: #4751 isolated the
   ReactDOM server/Fizz batches the day before).
+- **S5: the renderers group was not slow — it was HUNG, and this PR fixes the
+  hang class.** Run 778 (id 32559024885, job 96997622379) settled it: the
+  renderers worker printed exactly one line
+  (`[npm-compat] react-dom — package entry + react-dom's own upstream unit
+  tests...` at 07:14:03Z) and then NOTHING until the 350-min timeout kill at
+  13:03:44Z, leaving orphaned node/sh/esbuild processes. Every parallel
+  per-SHA run died identically, so the coordinator never gets a renderers
+  partial and the dashboard cannot heal. Root cause: the React suite added a
+  per-test watchdog in #4683 (`withTimeout`, 2s default,
+  `DOGFOOD_REACT_TEST_TIMEOUT_MS`) around both its native-oracle and
+  compiled-test awaits — but `react-dom-upstream-suite.mjs`, which reuses the
+  React suite's extractor and shim, **never inherited the watchdog**. Its
+  `runNative` awaited each test unbounded, so one upstream test whose native
+  run never settles (a Fizz stream await, an `act` whose scheduler work never
+  drains — the node/edge Fizz lanes are recent) parks the generator forever
+  with zero output. Fixed by moving `withTimeout` into the shared
+  `react-upstream-shim.mjs` and wrapping react-dom's native and legacy
+  compiled awaits (`DOGFOOD_REACT_DOM_TEST_TIMEOUT_MS`, default 2s; the
+  project-lane Wasm side was already bounded by the compile-worker kill).
+  Additionally the generator now arms an unref'd 10s forced-exit after its
+  final artifact writes: a timed-out test can leak live scheduler timer
+  chains (`setTimeout(run, 0)` reschedules while render work remains) that
+  would otherwise keep a FINISHED run's process — and its CI step — alive
+  indefinitely.
 
 ## Fix directions (pick during implementation)
 

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -3136,3 +3136,12 @@ if (writeArtifacts) {
   console.log("[npm-compat] skipped aggregate artifact writes");
   console.log(JSON.stringify({ ...summary, perfRows, perfHistory }, null, 2));
 }
+
+// (#4604) Every report is written at this point, but a timed-out upstream test
+// can leave live host timer chains behind (React's scheduler shim reschedules
+// `setTimeout(run, 0)` while render work remains), and those keep the event
+// loop — and therefore the CI step — alive indefinitely after the run is
+// complete. Unref'd so a clean drain still exits naturally and immediately;
+// the forced exit only fires when leaked handles would otherwise hang a
+// finished run. All artifact writes above are synchronous.
+setTimeout(() => process.exit(process.exitCode ?? 0), 10_000).unref();

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -37,7 +37,7 @@ import { setupReactDomImplementation, setupReactDomUpstreamSuite } from "./setup
 import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
 import { installReactTestEnvironment } from "./react-test-environment.mjs";
 import { installReactUpstreamInfrastructure } from "./react-upstream-infrastructure.mjs";
-import { REACT_EXPECT_SHIM, LAST_ERROR_EXPORT, buildTestFunction } from "./react-upstream-shim.mjs";
+import { REACT_EXPECT_SHIM, LAST_ERROR_EXPORT, buildTestFunction, withTimeout } from "./react-upstream-shim.mjs";
 import { compileProjectInWorker, compileSourceInWorker } from "./upstream-suite-runner.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -46,6 +46,19 @@ const GENERATED_ROOT = join(HERE, ".react-dom-upstream-suite-impl");
 const PROJECT_ROOT = join(HERE, ".react-dom-upstream-suite-project");
 let nativeContextFile = "<setup>";
 let nativeContextTest = "<setup>";
+
+// (#4604) Per-test watchdog, same contract as the React suite's
+// DOGFOOD_REACT_TEST_TIMEOUT_MS (#4683). The react-dom harness inherited the
+// React suite's extractor and shim but not its watchdog, so one upstream test
+// whose native run never settles (a Fizz stream await, an act whose scheduler
+// work never drains) hung the entire npm-compat generator with zero output —
+// refresh run 778's renderers group printed one marker line and was killed
+// 5h49m later. Read at call time so tests can override per-case.
+const DEFAULT_REACT_DOM_TEST_TIMEOUT_MS = 2_000;
+function testTimeoutMs() {
+  const configured = Number(process.env.DOGFOOD_REACT_DOM_TEST_TIMEOUT_MS ?? 0);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_REACT_DOM_TEST_TIMEOUT_MS;
+}
 
 export function isExpectedLateJsdomHostError(error) {
   return error?.name === "NotFoundError" && error?.message === "The node to be removed is not a child of this node.";
@@ -616,7 +629,7 @@ async function runNative(implementation, tests, options = {}) {
       let value;
       let error = null;
       try {
-        value = await runners.tests[test.id]();
+        value = await withTimeout(runners.tests[test.id](), testTimeoutMs(), `native ${test.fullName}`);
       } catch (thrown) {
         error = thrown instanceof Error ? thrown.message : String(thrown);
       }
@@ -1677,7 +1690,7 @@ export async function runHarness({ quiet = false } = {}) {
     }
     let value;
     try {
-      value = await compiled[test.id]();
+      value = await withTimeout(compiled[test.id](), testTimeoutMs(), `compiled ${test.fullName}`);
     } catch (error) {
       entry.status = "trapped";
       const stack = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/tests/dogfood/react-upstream-shim.mjs
+++ b/tests/dogfood/react-upstream-shim.mjs
@@ -1057,3 +1057,22 @@ ${test.body}
 
 /** Reads back the message recorded by the most recent failing test. */
 export const LAST_ERROR_EXPORT = `export function __react_last_error() { return __lastError; }`;
+
+/**
+ * Watchdog for one awaited test execution, shared by the React-family suites.
+ *
+ * An upstream body can await a promise the harness can never settle (a Fizz
+ * stream that never completes, an `act` whose scheduler work never drains).
+ * Without this bound a single such test parks the whole npm-compat generator
+ * forever — the process prints nothing and never exits, which is
+ * indistinguishable from a crashed runner from CI's point of view. The
+ * timeout is a watchdog, not a selection filter: a timed-out test stays in
+ * the report as a failure or harness-incompatible result.
+ */
+export function withTimeout(value, timeoutMs, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs} ms`)), timeoutMs);
+  });
+  return Promise.race([Promise.resolve(value), timeout]).finally(() => clearTimeout(timer));
+}

--- a/tests/dogfood/react-upstream-suite.mjs
+++ b/tests/dogfood/react-upstream-suite.mjs
@@ -42,7 +42,7 @@ import { setupReactUpstreamSuite } from "./setup-react-upstream-suite.mjs";
 import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
 import { installReactTestEnvironment } from "./react-test-environment.mjs";
 import { installReactUpstreamInfrastructure } from "./react-upstream-infrastructure.mjs";
-import { REACT_EXPECT_SHIM, LAST_ERROR_EXPORT, buildTestFunction } from "./react-upstream-shim.mjs";
+import { REACT_EXPECT_SHIM, LAST_ERROR_EXPORT, buildTestFunction, withTimeout } from "./react-upstream-shim.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPORT_PATH = join(HERE, "report", "react-upstream-suite.json");
@@ -80,14 +80,6 @@ function buildNativeRunners(tests) {
   ].join("\n");
   // eslint-disable-next-line no-new-func
   return new Function("__REACT__", "require", source);
-}
-
-function withTimeout(value, timeoutMs, label) {
-  let timer;
-  const timeout = new Promise((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs} ms`)), timeoutMs);
-  });
-  return Promise.race([Promise.resolve(value), timeout]).finally(() => clearTimeout(timer));
 }
 
 async function runNative(tests, nativeReact, timeoutMs, infrastructure) {


### PR DESCRIPTION
## Problem

The npm-compat `renderers` matrix group (react-dom, jsdom, redux) hangs in every refresh run. Run 778 (id 32559024885, job 96997622379) is the smoking gun: the worker printed exactly one line — `[npm-compat] react-dom — package entry + react-dom's own upstream unit tests...` at 07:14:03Z — then **nothing** for 5h49m until the 350-min timeout kill, leaving orphaned node/sh/esbuild processes. Every parallel per-SHA run died identically. The coordinator (correctly) refuses to publish without the renderers partial, so the dashboard is stuck serving the 2026-08-20T18:44Z snapshot — the one still showing the already-fixed acorn/clsx regression ([#4602](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4602-inherited-set-per-key-gate)).

## Root cause

The React suite gained a per-test watchdog in #4683: `withTimeout` (2s default, `DOGFOOD_REACT_TEST_TIMEOUT_MS`) around both its native-oracle and compiled-test awaits. `react-dom-upstream-suite.mjs` — deliberately built on the React suite's extractor and shim — **never inherited that watchdog**. Its `runNative` awaited each upstream test unbounded, so a single test whose native run never settles (a Fizz stream await, an `act` whose scheduler work never drains — the node/edge Fizz lanes are recent additions) parks the entire generator forever with zero output.

## Fix

- Move `withTimeout` into the shared `react-upstream-shim.mjs`; the React suite imports it instead of keeping a private copy.
- Wrap react-dom's native-oracle and legacy compiled-lane awaits in it (`DOGFOOD_REACT_DOM_TEST_TIMEOUT_MS`, default 2s, same contract as React's). The project-lane Wasm side was already bounded by the compile-worker hard kill. A timed-out test stays in the report as a failure/harness-incompatible result — a watchdog, not a selection filter.
- Arm an unref'd 10s forced-exit in `generate-npm-compat-report.mjs` after the final artifact writes: a timed-out test can leak live scheduler timer chains (the shim's `setTimeout(run, 0)` reschedules while render work remains) that would otherwise keep a **finished** run's process — and its CI step — alive indefinitely. A clean drain still exits naturally and immediately; all artifact writes above the guard are synchronous.
- [#4604](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4604-npm-compat-refresh-runtime-exceeds-timeout) updated with the S5 forensics.

## Validation

- Probe: `withTimeout` rejects a never-settling promise at the deadline (~300ms for a 300ms bound) and passes fast settles through unchanged.
- `tests/dogfood/react-dom-upstream-suite.test.ts` — 7 passed, 2 skipped (unchanged).
- `tests/dogfood/react-upstream-suite.test.ts` — 6 passed, 1 skipped (unchanged).
- Prettier and the dead-export gate clean on all edited files.
- Limited end-to-end react-dom harness smoke (2 client + 1 per server lane) reached extraction normally (1,923/2,003 admitted) with the watchdog wired.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8)_