### PR TITLE
fix(ci): parallelize ReactDOM project compilation

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -153,6 +153,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Measure package group
+        env:
+          # ReactDOM's project lane has many independent compile batches. Keep
+          # two compiler workers active so the long pole finishes before the
+          # job ceiling without exhausting the runner's memory.
+          DOGFOOD_REACT_DOM_PROJECT_CONCURRENCY: "2"
         run: |
           set -euo pipefail
           pnpm run generate:npm-compat -- \

--- a/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
@@ -672,9 +672,15 @@ serially. That made the worker deadline effective per batch but left the
 overall ReactDOM refresh vulnerable to the 350-minute GitHub Actions ceiling.
 The lane now uses a bounded two-worker compile pool (configurable with
 `DOGFOOD_REACT_DOM_PROJECT_CONCURRENCY`) and consumes the native oracle in the
-original source order. Each batch still has its own isolated compiler deadline
-and remains visible in the report; only independent compilation is concurrent.
-The npm-compat workflow pins the pool to two workers to limit runner memory
+original source order. Compilation is pipelined with that oracle: while the
+shared host consumes one completed batch, the workers continue compiling later
+batches. Each batch still has its own isolated compiler deadline and remains
+visible in the report; only independent compilation is concurrent. The
+npm-compat workflow pins the pool to two workers to limit runner memory
 pressure. This addresses the remaining refresh-timeout path without reducing
 the upstream denominator or relabeling compiler failures as unavailable host
 infrastructure.
+
+The bounded pool and its fallback-to-two behavior have focused unit coverage;
+the 50-test probe observed both client batches dispatched to the two-worker
+pool, and the upstream suite harness tests remain green.

--- a/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
@@ -684,3 +684,6 @@ infrastructure.
 The bounded pool and its fallback-to-two behavior have focused unit coverage;
 the 50-test probe observed both client batches dispatched to the two-worker
 pool, and the upstream suite harness tests remain green.
+
+Implementation: [PR #4771](https://github.com/loopdive/js2/pull/4771), stacked
+on the compiler boundary work in [PR #4769](https://github.com/loopdive/js2/pull/4769).

--- a/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
@@ -664,3 +664,17 @@ object receivers, but proven numeric and native-string carriers remain
 specialized. The complete real-wasmtime matrix (1/64/128/256 MiB across
 node_process, deno, wasi_p1, and node_fs) now passes. This is a compiler ABI
 fix, not a skipped or unavailable test.
+
+## Bounded project compilation checkpoint (2026-08-22)
+
+The client project lane was still compiling its 110 independent test batches
+serially. That made the worker deadline effective per batch but left the
+overall ReactDOM refresh vulnerable to the 350-minute GitHub Actions ceiling.
+The lane now uses a bounded two-worker compile pool (configurable with
+`DOGFOOD_REACT_DOM_PROJECT_CONCURRENCY`) and consumes the native oracle in the
+original source order. Each batch still has its own isolated compiler deadline
+and remains visible in the report; only independent compilation is concurrent.
+The npm-compat workflow pins the pool to two workers to limit runner memory
+pressure. This addresses the remaining refresh-timeout path without reducing
+the upstream denominator or relabeling compiler failures as unavailable host
+infrastructure.

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -226,3 +226,6 @@ time without dropping tests or converting compiler failures into
 `unavailableInfra`. Compilation is pipelined with the source-ordered native
 oracle, so the workers continue compiling later batches while the shared host
 consumes the next completed batch.
+
+Implementation: [PR #4771](https://github.com/loopdive/js2/pull/4771), stacked
+on the renderer/compiler baseline in [PR #4769](https://github.com/loopdive/js2/pull/4769).

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -223,4 +223,6 @@ batches with two isolated workers and runs the shared native oracle in stable
 source order. The workflow pins the pool to two workers to keep memory bounded;
 each batch retains its own timeout and report entry. This reduces wall-clock
 time without dropping tests or converting compiler failures into
-`unavailableInfra`.
+`unavailableInfra`. Compilation is pipelined with the source-ordered native
+oracle, so the workers continue compiling later batches while the shared host
+consumes the next completed batch.

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -212,3 +212,15 @@ cancellations. Keep this run as the acceptance probe: if ReactDOM itself
 reaches 350 minutes, the next slice must bound or subdivide the ReactDOM suite
 and publish an explicit `unavailableInfra` result rather than letting the
 workflow be killed without a partial report.
+
+## 2026-08-22 ReactDOM compile-pool follow-up
+
+The ReactDOM cell is now independently protected from the old renderer-group
+timeout, but its client project still contains 110 compile batches. They were
+being compiled one after another, so a valid but slow corpus could still reach
+the cell's 350-minute ceiling. The project lane now compiles those independent
+batches with two isolated workers and runs the shared native oracle in stable
+source order. The workflow pins the pool to two workers to keep memory bounded;
+each batch retains its own timeout and report entry. This reduces wall-clock
+time without dropping tests or converting compiler failures into
+`unavailableInfra`.

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -562,6 +562,19 @@ export function partitionProjectTests(tests, maxChars = 800_000) {
   return batches;
 }
 
+// Project batches are independent compile jobs, but the native oracle must
+// remain serial: it shares the installed React/jsdom globals and the host
+// error boundary. Keep the compile pool deliberately small because each
+// worker loads the published ReactDOM graph and TypeScript compiler. Two
+// workers cut the long pole without turning a runner's memory pressure into a
+// second source of cancelled refreshes; CI can raise this for a larger host.
+export function projectCompileConcurrency(batchCount, configured = process.env.DOGFOOD_REACT_DOM_PROJECT_CONCURRENCY) {
+  if (batchCount <= 0) return 0;
+  const requested = Number(configured ?? 2);
+  if (!Number.isFinite(requested) || requested < 1) return Math.min(2, batchCount);
+  return Math.max(1, Math.min(Math.floor(requested), batchCount));
+}
+
 function buildNativeRunners(implementation, tests, options = {}) {
   const { server = false } = options;
   const init = server ? "__reactDomServerEnsureInit()" : "__reactDomEnsureInit()";
@@ -1011,48 +1024,70 @@ async function runProjectHarness({
   let totalBytes = 0;
 
   try {
-    for (let batchIndex = 0; batchIndex < projectBatches.length; batchIndex++) {
-      const { file, tests: batchTests } = projectBatches[batchIndex];
-      const files = buildProjectFiles({ reactSource, sharedSource, clientSource, tests: batchTests });
-      const generatedRoot = join(PROJECT_ROOT, `batch-${batchIndex}`);
-      const started = performance.now();
-      let isolated;
-      try {
-        isolated = await compileProjectInWorker({
-          generatedRoot,
-          entryFile: "entry.ts",
-          files,
-          timeoutMs,
-          workerEnv: {
-            DOGFOOD_INSTALL_JSDOM: "1",
-            DOGFOOD_NAMED_TEST_EXPORTS: "1",
-            DOGFOOD_REACT_DOM_ACT: "1",
-          },
-        });
-      } catch (error) {
-        isolated = {
-          compile: {
-            success: false,
-            validates: false,
-            durationMs: Math.round(performance.now() - started),
-            binaryBytes: 0,
-            errors: [{ message: error instanceof Error ? error.message : String(error) }],
-          },
-          wasm: null,
+    const compiledBatches = Array(projectBatches.length);
+    const workerCount = projectCompileConcurrency(projectBatches.length);
+    log(`[dogfood]   client project: ${projectBatches.length} batches, ${workerCount} compile workers`);
+    let nextBatchIndex = 0;
+    const compileBatch = async () => {
+      while (true) {
+        const batchIndex = nextBatchIndex++;
+        if (batchIndex >= projectBatches.length) return;
+        const { file, tests: batchTests } = projectBatches[batchIndex];
+        const files = buildProjectFiles({ reactSource, sharedSource, clientSource, tests: batchTests });
+        const generatedRoot = join(PROJECT_ROOT, `batch-${batchIndex}`);
+        const started = performance.now();
+        let isolated;
+        try {
+          isolated = await compileProjectInWorker({
+            generatedRoot,
+            entryFile: "entry.ts",
+            files,
+            timeoutMs,
+            workerEnv: {
+              DOGFOOD_INSTALL_JSDOM: "1",
+              DOGFOOD_NAMED_TEST_EXPORTS: "1",
+              DOGFOOD_REACT_DOM_ACT: "1",
+            },
+          });
+        } catch (error) {
+          isolated = {
+            compile: {
+              success: false,
+              validates: false,
+              durationMs: Math.round(performance.now() - started),
+              binaryBytes: 0,
+              errors: [{ message: error instanceof Error ? error.message : String(error) }],
+            },
+            wasm: null,
+          };
+        }
+        const compile = isolated?.compile ?? {
+          success: false,
+          validates: false,
+          durationMs: Math.round(performance.now() - started),
+          binaryBytes: 0,
+          errors: [{ message: "compile worker returned no result" }],
         };
+        const wasm = isolated?.wasm ?? null;
+        const compileError =
+          compile.errors?.[0]?.message ??
+          compile.validationError ??
+          (compile.timedOut ? `compile timeout after ${timeoutMs}ms` : compile.success ? null : "no binary emitted");
+        compiledBatches[batchIndex] = { file, batchTests, compile, wasm, compileError };
+        log(
+          `[dogfood]   client project ${file.replace(/^.*\//, "")}: ${batchTests.length} tests, ` +
+            `${compile.validates === true ? "valid" : `INVALID — ${String(compileError).slice(0, 70)}`}`,
+        );
       }
-      const compile = isolated?.compile ?? {
-        success: false,
-        validates: false,
-        durationMs: Math.round(performance.now() - started),
-        binaryBytes: 0,
-        errors: [{ message: "compile worker returned no result" }],
-      };
-      const wasm = isolated?.wasm ?? null;
-      const compileError =
-        compile.errors?.[0]?.message ??
-        compile.validationError ??
-        (compile.timedOut ? `compile timeout after ${timeoutMs}ms` : compile.success ? null : "no binary emitted");
+    };
+    await Promise.all(Array.from({ length: workerCount }, () => compileBatch()));
+
+    // The compiled Wasm results are independent, but the native oracle uses a
+    // shared jsdom/React host. Consume batches in source order so scheduler
+    // callbacks and late host errors remain deterministic.
+    for (const batch of compiledBatches) {
+      if (!batch) continue;
+      const { file, batchTests, compile, wasm, compileError } = batch;
       const validates = compile.validates === true;
       totalCompileMs += compile.durationMs ?? 0;
       totalBytes += compile.binaryBytes ?? 0;
@@ -1083,10 +1118,6 @@ async function runProjectHarness({
         validates,
         firstError: compileError,
       });
-      log(
-        `[dogfood]   client project ${file.replace(/^.*\//, "")}: ${batchTests.length} tests, ` +
-          `${validates ? "valid" : `INVALID — ${String(compileError).slice(0, 70)}`}`,
-      );
     }
   } finally {
     // A scheduler callback can outlive the final test body. Keep the host error

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -1024,7 +1024,13 @@ async function runProjectHarness({
   let totalBytes = 0;
 
   try {
-    const compiledBatches = Array(projectBatches.length);
+    const batchReady = Array.from({ length: projectBatches.length }, () => {
+      let resolve;
+      const promise = new Promise((done) => {
+        resolve = done;
+      });
+      return { promise, resolve };
+    });
     const workerCount = projectCompileConcurrency(projectBatches.length);
     log(`[dogfood]   client project: ${projectBatches.length} batches, ${workerCount} compile workers`);
     let nextBatchIndex = 0;
@@ -1033,11 +1039,11 @@ async function runProjectHarness({
         const batchIndex = nextBatchIndex++;
         if (batchIndex >= projectBatches.length) return;
         const { file, tests: batchTests } = projectBatches[batchIndex];
-        const files = buildProjectFiles({ reactSource, sharedSource, clientSource, tests: batchTests });
         const generatedRoot = join(PROJECT_ROOT, `batch-${batchIndex}`);
         const started = performance.now();
         let isolated;
         try {
+          const files = buildProjectFiles({ reactSource, sharedSource, clientSource, tests: batchTests });
           isolated = await compileProjectInWorker({
             generatedRoot,
             entryFile: "entry.ts",
@@ -1073,51 +1079,57 @@ async function runProjectHarness({
           compile.errors?.[0]?.message ??
           compile.validationError ??
           (compile.timedOut ? `compile timeout after ${timeoutMs}ms` : compile.success ? null : "no binary emitted");
-        compiledBatches[batchIndex] = { file, batchTests, compile, wasm, compileError };
+        const batch = { file, batchTests, compile, wasm, compileError };
+        batchReady[batchIndex].resolve(batch);
         log(
           `[dogfood]   client project ${file.replace(/^.*\//, "")}: ${batchTests.length} tests, ` +
             `${compile.validates === true ? "valid" : `INVALID — ${String(compileError).slice(0, 70)}`}`,
         );
       }
     };
-    await Promise.all(Array.from({ length: workerCount }, () => compileBatch()));
+    const compileWorkers = Promise.all(Array.from({ length: workerCount }, () => compileBatch()));
 
-    // The compiled Wasm results are independent, but the native oracle uses a
-    // shared jsdom/React host. Consume batches in source order so scheduler
-    // callbacks and late host errors remain deterministic.
-    for (const batch of compiledBatches) {
-      if (!batch) continue;
-      const { file, batchTests, compile, wasm, compileError } = batch;
-      const validates = compile.validates === true;
-      totalCompileMs += compile.durationMs ?? 0;
-      totalBytes += compile.binaryBytes ?? 0;
+    // Compilation and the native oracle are pipelined: later independent
+    // batches keep compiling while the shared host consumes the next batch.
+    // The oracle itself remains strictly source-ordered, so scheduler
+    // callbacks and late host errors stay deterministic.
+    try {
+      for (const { promise } of batchReady) {
+        const { file, batchTests, compile, wasm, compileError } = await promise;
+        const validates = compile.validates === true;
+        totalCompileMs += compile.durationMs ?? 0;
+        totalBytes += compile.binaryBytes ?? 0;
 
-      nativeContextFile = file;
-      const nativeResults = new Map((await runNative(implementation, batchTests)).map((entry) => [entry.id, entry]));
-      const statuses = wasm?.statuses ?? [];
-      const wasmErrors = wasm?.errors ?? [];
-      for (let index = 0; index < batchTests.length; index++) {
-        const test = batchTests[index];
-        const native = nativeResults.get(test.id) ?? {};
-        runResults.set(test.id, {
-          native,
+        nativeContextFile = file;
+        const nativeResults = new Map((await runNative(implementation, batchTests)).map((entry) => [entry.id, entry]));
+        const statuses = wasm?.statuses ?? [];
+        const wasmErrors = wasm?.errors ?? [];
+        for (let index = 0; index < batchTests.length; index++) {
+          const test = batchTests[index];
+          const native = nativeResults.get(test.id) ?? {};
+          runResults.set(test.id, {
+            native,
+            validates,
+            compileError,
+            wasmFatal: wasm?.fatal ?? null,
+            wasmStatus: statuses[index] === true,
+            wasmError: wasmErrors[index] ?? "",
+          });
+        }
+        batchReports.push({
+          file,
+          tests: batchTests.length,
+          compileMs: compile.durationMs ?? 0,
+          binaryBytes: compile.binaryBytes ?? 0,
+          imports: compile.imports ?? [],
+          compileSuccess: compile.success === true,
           validates,
-          compileError,
-          wasmFatal: wasm?.fatal ?? null,
-          wasmStatus: statuses[index] === true,
-          wasmError: wasmErrors[index] ?? "",
+          firstError: compileError,
         });
       }
-      batchReports.push({
-        file,
-        tests: batchTests.length,
-        compileMs: compile.durationMs ?? 0,
-        binaryBytes: compile.binaryBytes ?? 0,
-        imports: compile.imports ?? [],
-        compileSuccess: compile.success === true,
-        validates,
-        firstError: compileError,
-      });
+    } finally {
+      // Do not leave compiler workers behind if the shared native oracle throws.
+      await compileWorkers;
     }
   } finally {
     // A scheduler callback can outlive the final test body. Keep the host error

--- a/tests/dogfood/react-dom-upstream-suite.test.ts
+++ b/tests/dogfood/react-dom-upstream-suite.test.ts
@@ -16,6 +16,7 @@ import {
   isExpectedLateJsdomHostError,
   partitionProjectTests,
   partitionReactDomTestsForBuild,
+  projectCompileConcurrency,
 } from "./react-dom-upstream-suite.mjs";
 // @ts-expect-error — .mjs dogfood extractor has no declaration file
 import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
@@ -146,6 +147,13 @@ describe("react-dom upstream suite", () => {
       ["b.js", ["b.js-0"]],
     ]);
     expect(batches.flatMap(({ tests }) => tests).map(({ id }) => id)).toEqual(input.map(({ id }) => id));
+  });
+
+  it("keeps the project compile pool bounded and deterministic", () => {
+    expect(projectCompileConcurrency(0, "4")).toBe(0);
+    expect(projectCompileConcurrency(3, "1")).toBe(1);
+    expect(projectCompileConcurrency(3, "4")).toBe(3);
+    expect(projectCompileConcurrency(3, "not-a-number")).toBe(2);
   });
 
   it("keeps server and Fizz batches in isolated project modules", () => {

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -76,6 +76,7 @@ describe("npm-compat refresh matrix wiring", () => {
     expect(workflow).toContain("id: typescript");
     expect(workflow).toContain("id: react-dom");
     expect(workflow).toContain("packages: react-dom");
+    expect(workflow).toContain('DOGFOOD_REACT_DOM_PROJECT_CONCURRENCY: "2"');
     expect(workflow).not.toContain("id: renderers");
   });
 });


### PR DESCRIPTION
Stacked on PR #4769.

The ReactDOM client lane had 110 independent compile batches but awaited them serially, leaving the isolated npm-compat cell vulnerable to its 350-minute ceiling. This change compiles batches with a bounded two-worker pool, then runs the shared native oracle in deterministic source order. Per-batch compiler deadlines, results, and denominators are unchanged. The workflow pins two workers to bound runner memory.

Validation:
- ReactDOM compile-pool probe: two batches dispatched to two workers
- ReactDOM reassigned-ref boundary tests: 8/8
- npm-compat workflow tests: 4/4
- typecheck, Prettier, and IR fallback gate: pass

Handoff/ownership: plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md and plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md.