### PR TITLE
feat(jest): expose pinned isError dependency

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -1115,3 +1115,21 @@ runtime failures in the optional-property/error paths and are not reclassified
 as dependency infrastructure.
 
 Implementation remains on [PR #4767 — bridge WebAssembly callbacks in prompt tests](https://github.com/loopdive/js2wasm/pull/4767).
+
+## 2026-08-22 Jest `jest-util.isError` package seam checkpoint
+
+The original `jest-core/src/lib/__tests__/serializeToJSON.test.ts` unit is now
+selected unchanged. Its upstream implementation imports `isError` through the
+published `jest-util` package name; the adapter now verifies the pinned
+`jest-util@30.4.1` `isError.ts` bytes and exposes that real source alongside the
+existing `formatTime`, `convertDescriptorToString`, and `tryRealpath` exports.
+This fixes a genuine package-resolution gap in both the Node oracle and the
+compiled Wasm project. No test result is synthesized and the upstream test
+body is untouched.
+
+The exact unchanged run now covers **353 callbacks across 33 selected files**.
+Node admits **351/353** (the two existing diff-sequence snapshot-oracle
+failures remain), all 33 modules compile and 32 validate, and Wasm scores
+**247/351** with zero runtime failures. The unavailable-infrastructure
+remainder is **2,935 registrations** from 208 deferred files. Both newly
+admitted `serializeToJSON` callbacks pass in Node and Wasm.

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -1133,3 +1133,5 @@ failures remain), all 33 modules compile and 32 validate, and Wasm scores
 **247/351** with zero runtime failures. The unavailable-infrastructure
 remainder is **2,935 registrations** from 208 deferred files. Both newly
 admitted `serializeToJSON` callbacks pass in Node and Wasm.
+
+Implementation: [PR #4772 — expose the pinned `jest-util.isError` dependency](https://github.com/loopdive/js2wasm/pull/4772).

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -37,6 +37,7 @@
     "packages/jest-watcher/src/lib/__tests__/scroll.test.ts",
     "packages/jest-haste-map/src/__tests__/get_mock_name.test.js",
     "packages/jest-core/src/__tests__/FailedTestsCache.test.js",
+    "packages/jest-core/src/lib/__tests__/serializeToJSON.test.ts",
     "packages/jest-watcher/src/lib/__tests__/prompt.test.ts",
     "packages/jest-environment-node/src/__tests__/globals_cleanup_3.test.ts",
     "packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts"
@@ -52,7 +53,10 @@
     },
     "jest-util": {
       "version": "30.4.1",
-      "sourceSha256": "ef7320f8e85b76a67a65ec29e9c55e724b7a25de5b2aad75c3ed1c82a53cc7d4"
+      "sourceSha256": "ef7320f8e85b76a67a65ec29e9c55e724b7a25de5b2aad75c3ed1c82a53cc7d4",
+      "files": {
+        "isError.ts": "119ebfd40f2f3552bff9e699149832c8fce37acc45e2b30e2f47e72b872e2e3d"
+      }
     },
     "graceful-fs": {
       "version": "4.2.11",

--- a/tests/dogfood/setup-jest-upstream-suite.mjs
+++ b/tests/dogfood/setup-jest-upstream-suite.mjs
@@ -20,6 +20,9 @@ const JEST_GET_TYPE_PIN = {
 const JEST_UTIL_PIN = {
   version: "30.4.1",
   sourceSha256: "ef7320f8e85b76a67a65ec29e9c55e724b7a25de5b2aad75c3ed1c82a53cc7d4",
+  files: {
+    "isError.ts": "119ebfd40f2f3552bff9e699149832c8fce37acc45e2b30e2f47e72b872e2e3d",
+  },
 };
 
 const GRACEFUL_FS_PIN = {
@@ -460,6 +463,10 @@ export function setupJestUpstreamSuite(options = {}) {
   // ESM package adapter; its implementation remains the upstream source.
   const utilPin = suite.pin.dependencies?.["jest-util"] ?? JEST_UTIL_PIN;
   const util = resolveJestUtilFormatTimeSource(suite, utilPin);
+  resolveJestSource(suite, "jest-util", "isError.ts", {
+    version: utilPin.version,
+    files: utilPin.files ?? JEST_UTIL_PIN.files,
+  });
   const utilRoot = join(suite.root, "node_modules/jest-util");
   mkdirSync(utilRoot, { recursive: true });
   writeFileSync(
@@ -481,6 +488,7 @@ export function setupJestUpstreamSuite(options = {}) {
     join(utilRoot, "index.ts"),
     'export { default as formatTime } from "../../packages/jest-util/src/formatTime.ts";\n' +
       'export { default as convertDescriptorToString } from "../../packages/jest-util/src/convertDescriptorToString.ts";\n' +
+      'export { isError } from "../../packages/jest-util/src/isError.ts";\n' +
       'export { default as tryRealpath } from "../../packages/jest-util/src/tryRealpath.ts";\n',
   );
 


### PR DESCRIPTION
## Summary

- expose the verified Jest 30.4.1 `isError.ts` implementation through the existing `jest-util` package-resolution adapter
- admit the original `jest-core/src/lib/__tests__/serializeToJSON.test.ts` unchanged
- record the measured Jest upstream-suite checkpoint in [the markdown issue](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md)

## Verification

- original upstream callbacks: 353 registered, 351/353 native oracle pass
- Wasm: 247/351 scored callbacks pass, 0 runtime failures
- compile: 33/33 modules succeed, 32/33 validate
- unavailable infrastructure: 2,935 registrations from 208 deferred files
- `pnpm exec vitest run tests/dogfood/jest-upstream-suite.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot`
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:issue-ids`
- Prettier check on changed files

This is a ready PR; no test result is synthesized and no upstream test body is modified.