### PR TITLE
feat(jest): provide CommonJS path globals

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -1135,3 +1135,19 @@ remainder is **2,935 registrations** from 208 deferred files. Both newly
 admitted `serializeToJSON` callbacks pass in Node and Wasm.
 
 Implementation: [PR #4772 — expose the pinned `jest-util.isError` dependency](https://github.com/loopdive/js2wasm/pull/4772).
+
+## 2026-08-22 Jest CommonJS path-global checkpoint
+
+The original `jest-haste-map/src/lib/__tests__/fast_path.test.js` unit is now
+selected unchanged. Its CommonJS-compatible test body uses Node's
+`__dirname`; the generated ESM harness now supplies per-file `__dirname` and
+`__filename` bindings, matching the standard Node module surface without
+hard-coding a package result. All five callbacks pass in both lanes.
+
+The exact unchanged run now covers **358 callbacks across 34 selected files**.
+Node admits **356/358** (the two existing diff-sequence snapshot-oracle
+failures remain), all 34 modules compile and 33 validate, and Wasm scores
+**252/356** with zero runtime failures. The unavailable-infrastructure
+remainder is **2,930 registrations** from 207 deferred files.
+
+Implementation remains on [PR #4772](https://github.com/loopdive/js2wasm/pull/4772).

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -1150,4 +1150,4 @@ failures remain), all 34 modules compile and 33 validate, and Wasm scores
 **252/356** with zero runtime failures. The unavailable-infrastructure
 remainder is **2,930 registrations** from 207 deferred files.
 
-Implementation remains on [PR #4772](https://github.com/loopdive/js2wasm/pull/4772).
+Implementation: [PR #4773 — provide CommonJS path globals](https://github.com/loopdive/js2wasm/pull/4773).

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -38,6 +38,7 @@
     "packages/jest-haste-map/src/__tests__/get_mock_name.test.js",
     "packages/jest-core/src/__tests__/FailedTestsCache.test.js",
     "packages/jest-core/src/lib/__tests__/serializeToJSON.test.ts",
+    "packages/jest-haste-map/src/lib/__tests__/fast_path.test.js",
     "packages/jest-watcher/src/lib/__tests__/prompt.test.ts",
     "packages/jest-environment-node/src/__tests__/globals_cleanup_3.test.ts",
     "packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts"

--- a/tests/dogfood/jest-upstream-suite.mjs
+++ b/tests/dogfood/jest-upstream-suite.mjs
@@ -245,6 +245,9 @@ export async function runHarness({ quiet = false } = {}) {
     const original = readFileSync(filePath, "utf-8");
     const transformed = transformJestTest(original, filePath, generatedPath);
     const nativeTransformed = transformJestTest(original, filePath, generatedPath, { normalizeCjs: true });
+    const nodeModuleBindings = /\b__dirname\b|\b__filename\b/.test(original)
+      ? `const __dirname = ${JSON.stringify(dirname(filePath))};\nconst __filename = ${JSON.stringify(filePath)};`
+      : "";
     const snapshotEntries = readSnapshotEntries(filePath);
     const snapshotSetup = snapshotEntries.length
       ? `__upstreamInstallSnapshotMatcher(${JSON.stringify(snapshotEntries)});`
@@ -254,8 +257,8 @@ export async function runHarness({ quiet = false } = {}) {
           moduleSpecifier(dirname(generatedPath), join(suite.root, "node_modules/pretty-format/index.ts")),
         )};`
       : "";
-    const source = `${snapshotFormatterImport}\n${UPSTREAM_TEST_SHIM}\n${snapshotSetup}\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
-    const nativeSource = `${snapshotFormatterImport}\n${UPSTREAM_TEST_SHIM}\n${snapshotSetup}\n${nativeTransformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const source = `${nodeModuleBindings}\n${snapshotFormatterImport}\n${UPSTREAM_TEST_SHIM}\n${snapshotSetup}\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const nativeSource = `${nodeModuleBindings}\n${snapshotFormatterImport}\n${UPSTREAM_TEST_SHIM}\n${snapshotSetup}\n${nativeTransformed}\n${UPSTREAM_TEST_EXPORTS}`;
     const result = await compileAndRunUpstreamModule({
       generatedPath,
       source,


### PR DESCRIPTION
## Summary

- expose per-file `__dirname` and `__filename` bindings in the generated Jest upstream ESM harness
- admit the original `jest-haste-map/src/lib/__tests__/fast_path.test.js` unchanged
- preserve the measured checkpoint in [the markdown issue](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md)

## Verification

- original upstream callbacks: 358 registered, 356/358 native oracle pass
- Wasm: 252/356 scored callbacks pass, 0 runtime failures
- compile: 34/34 modules succeed, 33/34 validate
- unavailable infrastructure: 2,930 registrations from 207 deferred files
- `pnpm exec vitest run tests/dogfood/jest-upstream-suite.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot`
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:issue-ids`
- Prettier check on changed files

This is a ready follow-up to the merged Jest dependency seam; no test result is synthesized and no upstream test body is modified.
