### PR TITLE
fix(ci): stop npm-compat promotion check cancellation

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -299,11 +299,13 @@ jobs:
       # group rebuilds that group and cancels its run — the same harm this whole
       # change removes, just relocated. So look before pushing.
       #
-      # FAIL-SAFE DIRECTION IS "PUSH ANYWAY". If the queue cannot be read we
-      # proceed: the harm of a wrong push is bounded (with
+      # The merge-queue gate remains fail-open: if the queue cannot be read we
+      # proceed, because the harm of a wrong push is bounded (with
       # `max_entries_to_build=1` the cancelled group contains only this PR), and
       # the harm of a wrong skip is the artifact freezing behind an unreadable
       # gate — which is #4130, the failure this repo has already paid for once.
+      # The current-head check gate below is deliberately fail-closed instead:
+      # an unreadable check state must not knowingly cancel the CI it protects.
       - name: Check whether the promotion PR is already in the merge queue
         id: queue_state
         env:
@@ -311,8 +313,15 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          PR_NUMBER="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
-            --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          PR_INFO="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
+            --state open --json number,headRefOid \
+            --jq '.[0] | if . == null then empty else "\(.number) \(.headRefOid)" end' \
+            2>/dev/null || true)"
+          PR_NUMBER="${PR_INFO%% *}"
+          PR_HEAD_SHA="${PR_INFO#* }"
+          if [ "$PR_INFO" = "$PR_NUMBER" ]; then
+            PR_HEAD_SHA=""
+          fi
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
           if [ -z "$PR_NUMBER" ]; then
@@ -321,6 +330,44 @@ jobs:
             exit 0
           fi
           echo "Open promotion PR: #${PR_NUMBER}"
+
+          # Do not replace the promotion branch while its current PR checks are
+          # running. A force-update fires `pull_request:synchronize`; GitHub
+          # cancels the checks for the old head before starting checks for the
+          # new one. On a long npm-compat refresh cadence that turns every PR
+          # run into a moving target and can keep the artifact PR permanently
+          # pending. Let the current head finish; a later refresh will publish
+          # the newer measurement. Keep the bound finite so one wedged check
+          # cannot suppress updates forever (the staleness workflow is the
+          # product-level backstop).
+          CHECK_CUTOFF="$(date -u -d '-2 hours' +%Y-%m-%dT%H:%M:%SZ)"
+          ACTIVE_CHECKS="unreadable"
+          if [ -n "$PR_HEAD_SHA" ]; then
+            ACTIVE_CHECKS="$(gh api \
+              "/repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" \
+              --jq "[.check_runs[] | select((.status == \"queued\" or .status == \"in_progress\") and ((.started_at // .created_at // \"1970-01-01T00:00:00Z\") > \"${CHECK_CUTOFF}\"))] | length" \
+              2>/dev/null || echo "unreadable")"
+          fi
+          case "$ACTIVE_CHECKS" in
+            unreadable)
+              echo "::warning title=npm-compat-refresh::could not read checks for promotion PR #${PR_NUMBER}; leaving its branch untouched to avoid cancelling CI."
+              echo "skip=1" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            ''|*[!0-9]*)
+              echo "::warning title=npm-compat-refresh::invalid active-check count (${ACTIVE_CHECKS}); leaving promotion PR #${PR_NUMBER} untouched."
+              echo "skip=1" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            0)
+              echo "No recent checks are running on promotion PR #${PR_NUMBER}; continuing."
+              ;;
+            *)
+              echo "Promotion PR #${PR_NUMBER} has ${ACTIVE_CHECKS} recent check(s) in flight; leaving its branch untouched."
+              echo "skip=1" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
 
           QUEUED="$(gh api graphql -f query="
             query(\$owner: String!, \$name: String!) {

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -193,3 +193,24 @@ upload their partial artifacts instead of being cancelled as collateral.
 Implementation: [PR #4767](https://github.com/loopdive/js2wasm/pull/4767) (the
 Jest infrastructure change and npm-compat reliability follow-up share the
 same branch checkpoint).
+
+## 2026-08-22 follow-up — promotion checks were being cancelled by refreshes
+
+The SHA-keyed measurement groups stopped newer pushes from cancelling pending
+refresh runs, but a second race remained at promotion. When the reusable
+`ci/npm-compat-refresh` branch already had an open PR, the coordinator checked
+only whether that PR was in the merge queue. If its current `CI` checks were
+still queued or running, the coordinator force-updated the branch anyway. The
+resulting `pull_request:synchronize` event cancelled the checks for the old
+head and started a new set, so frequent refreshes could keep the promotion PR
+permanently pending.
+
+The workflow now reads check-runs for the promotion PR's current head and
+leaves the branch untouched while any recent check is queued or in progress.
+The guard has a two-hour bound so a wedged check cannot suppress publication
+forever; the staleness workflow remains the product-level alert. If the check
+API is unreadable, the safe action is also to leave the branch untouched rather
+than knowingly cancel CI; the generated measurement is retained as an
+artifact and the next scheduled/push run retries.
+
+Implementation: [PR #4774](https://github.com/loopdive/js2wasm/pull/4774).

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -75,4 +75,14 @@ describe("npm-compat refresh matrix wiring", () => {
     expect(workflow).toContain("scripts/merge-npm-compat-partials.mjs");
     expect(workflow).toContain("id: typescript");
   });
+
+  it("does not force-update a promotion PR while its checks are in flight", () => {
+    const workflow = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf8");
+
+    expect(workflow).toContain("headRefOid");
+    expect(workflow).toContain("/commits/${PR_HEAD_SHA}/check-runs?per_page=100");
+    expect(workflow).toContain("leaving its branch untouched to avoid cancelling CI");
+    expect(workflow).toContain("CHECK_CUTOFF");
+    expect(workflow).toContain('echo "skip=1" >> "$GITHUB_OUTPUT"');
+  });
 });


### PR DESCRIPTION
## Summary

- stop the npm-compat refresh coordinator from force-updating its reusable promotion branch while that PR's current checks are queued or running
- query the current promotion head's recent check-runs and leave the branch untouched when CI is in flight, preventing `pull_request:synchronize` cancellation churn
- add a workflow-shape regression test and document the cancellation race in [plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md](https://github.com/loopdive/js2wasm/blob/main/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md)

## Verification

- `pnpm exec prettier --check .github/workflows/npm-compat-refresh.yml tests/npm-compat-partials.test.ts plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md`
- `pnpm exec vitest run tests/npm-compat-partials.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot`
- `node scripts/check-issue-ids.mjs --check`
- `git diff --check`

The check guard has a two-hour freshness bound so a wedged check cannot block publication forever; generated measurements remain uploaded and the staleness workflow remains the product-level backstop.
