### PR TITLE
fix(ci): prevent npm-compat cancellation churn

### DIFF
--- a/.github/workflows/auto-refresh-prs.yml
+++ b/.github/workflows/auto-refresh-prs.yml
@@ -36,6 +36,9 @@ name: Auto-refresh BEHIND PR branches with main
 #   - skip PRs whose current head is already ALL-GREEN and quiescent — those are
 #     enqueue-eligible RIGHT NOW (#4094 behind-eligible); a refresh would only
 #     knock them back to pending and reopen the livelock window.
+#   - skip the bot-owned `ci/npm-compat-refresh` promotion branch — its
+#     coordinator has its own freshness and check-state guards; a generic
+#     rebase emits `pull_request:synchronize` and cancels its artifact checks.
 #
 # TRIGGER: cron only (every 20 min) + manual dispatch — NOT push:main. A per-merge
 # push trigger races the SERIAL merge queue's merge_group formation (the churn
@@ -111,10 +114,11 @@ jobs:
           # in-flight/green-head classification below can query this head's
           # check runs without a second PR lookup.
           mapfile -t BEHIND < <(gh pr list --state open --limit 200 \
-            --json number,mergeStateStatus,isDraft,labels,headRefOid \
+            --json number,mergeStateStatus,isDraft,labels,headRefName,headRefOid \
             --jq '.[]
                     | select(.mergeStateStatus == "BEHIND")
                     | select(.isDraft == false)
+                    | select(.headRefName != "ci/npm-compat-refresh")
                     | select([.labels[].name]
                         | any(. == "hold" or . == "do-not-merge" or . == "do not merge" or . == "wip" or . == "blocked")
                         | not)

--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -69,10 +69,10 @@ on:
   # Backstop for a quiet main (no pushes ⇒ no push-triggered refresh).
   #
   # It is NOT a backstop against starvation by a busy main, which is what the
-  # original comment here claimed. Scheduled and manual runs share the branch
-  # group below and serialize. Push runs are keyed by their immutable commit
-  # instead, so a busy main cannot replace an older pending measurement before
-  # it gets a runner.
+  # original comment here claimed. Push runs are keyed by their immutable
+  # commit, while scheduled and manual runs are keyed by their own run IDs, so
+  # a busy main cannot replace an older pending measurement before it gets a
+  # runner.
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
@@ -88,14 +88,14 @@ env:
 
 concurrency:
   # GitHub keeps only one pending run per concurrency group. A ref-only key
-  # therefore cancelled older pending push runs even with
-  # `cancel-in-progress: false` (the active run survived, but its predecessor
-  # never got a runner). Key pushes by SHA so every main commit has an
-  # independent measurement. Schedule and workflow_dispatch still share the
-  # branch ref and remain serialized.
-  group: npm-compat-refresh-${{ github.event_name == 'push' && github.sha || github.ref }}
-  # Never kill an active measurement. Promotion is freshness-checked and uses
-  # a lease-protected force push, so independent SHA lanes can safely race.
+  # therefore cancelled older pending push runs even with `cancel-in-progress: false`
+  # (the active run survived, but its predecessor never got a runner). Pushes
+  # are keyed by their immutable SHA; scheduled and manual runs also get a
+  # unique run-id suffix so a delayed measurement is never discarded while it
+  # waits for a runner. Promotion is freshness-checked and uses a
+  # lease-protected force push, so independent lanes can safely race.
+  group: npm-compat-refresh-${{ github.event_name == 'push' && github.sha || format('{0}-{1}', github.ref, github.run_id) }}
+  # Never kill an active measurement.
   cancel-in-progress: false
 
 jobs:
@@ -337,15 +337,16 @@ jobs:
           # new one. On a long npm-compat refresh cadence that turns every PR
           # run into a moving target and can keep the artifact PR permanently
           # pending. Let the current head finish; a later refresh will publish
-          # the newer measurement. Keep the bound finite so one wedged check
-          # cannot suppress updates forever (the staleness workflow is the
-          # product-level backstop).
-          CHECK_CUTOFF="$(date -u -d '-2 hours' +%Y-%m-%dT%H:%M:%SZ)"
+          # the newer measurement. Do not age this guard out: the refresh
+          # matrix itself has a 350-minute timeout, so a two-hour cutoff would
+          # knowingly cancel a valid long-running check. A genuinely wedged PR
+          # is surfaced by the staleness workflow and needs human intervention.
           ACTIVE_CHECKS="unreadable"
           if [ -n "$PR_HEAD_SHA" ]; then
             ACTIVE_CHECKS="$(gh api \
+              --paginate --slurp \
               "/repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" \
-              --jq "[.check_runs[] | select((.status == \"queued\" or .status == \"in_progress\") and ((.started_at // .created_at // \"1970-01-01T00:00:00Z\") > \"${CHECK_CUTOFF}\"))] | length" \
+              --jq '[.[].check_runs[] | select(.status == "queued" or .status == "in_progress")] | length' \
               2>/dev/null || echo "unreadable")"
           fi
           case "$ACTIVE_CHECKS" in
@@ -360,10 +361,10 @@ jobs:
               exit 0
               ;;
             0)
-              echo "No recent checks are running on promotion PR #${PR_NUMBER}; continuing."
+              echo "No checks are running on promotion PR #${PR_NUMBER}; continuing."
               ;;
             *)
-              echo "Promotion PR #${PR_NUMBER} has ${ACTIVE_CHECKS} recent check(s) in flight; leaving its branch untouched."
+              echo "Promotion PR #${PR_NUMBER} has ${ACTIVE_CHECKS} check(s) in flight; leaving its branch untouched."
               echo "skip=1" >> "$GITHUB_OUTPUT"
               exit 0
               ;;

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -230,3 +230,5 @@ guard out, and fails closed when the check API is unreadable. The generic
 behind-PR sweep excludes `ci/npm-compat-refresh` entirely. This makes the npm
 coordinator the only updater of its promotion branch and prevents both direct
 and indirect `pull_request:synchronize` cancellation churn.
+
+Implementation: [PR #4776](https://github.com/loopdive/js2/pull/4776).

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -214,3 +214,19 @@ than knowingly cancel CI; the generated measurement is retained as an
 artifact and the next scheduled/push run retries.
 
 Implementation: [PR #4774](https://github.com/loopdive/js2wasm/pull/4774).
+
+## 2026-08-22 follow-up — cancellation protections need to cover every updater
+
+The merged check guard still had two holes. First, a two-hour cutoff could
+reset a legitimate long-running promotion check even though the refresh matrix
+allows 350 minutes. Second, scheduled and manual refreshes shared one
+concurrency group, so GitHub could discard an older pending run even with
+`cancel-in-progress: false`. The generic `auto-refresh-prs` cron could also
+rebase the bot-owned promotion branch independently of the npm coordinator.
+
+The workflow now uses per-SHA keys for pushes and per-run keys for scheduled or
+manual refreshes, paginates every check-run page without aging the active-check
+guard out, and fails closed when the check API is unreadable. The generic
+behind-PR sweep excludes `ci/npm-compat-refresh` entirely. This makes the npm
+coordinator the only updater of its promotion branch and prevents both direct
+and indirect `pull_request:synchronize` cancellation churn.

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -66,7 +66,7 @@ describe("npm-compat refresh matrix wiring", () => {
 
     expect(workflow).toContain("fail-fast: false");
     expect(workflow).toContain(
-      "group: npm-compat-refresh-${{ github.event_name == 'push' && github.sha || github.ref }}",
+      "group: npm-compat-refresh-${{ github.event_name == 'push' && github.sha || format('{0}-{1}', github.ref, github.run_id) }}",
     );
     expect(workflow).toMatch(/concurrency:[\s\S]*?cancel-in-progress: false/);
     expect(workflow).toContain("needs: measure");
@@ -80,9 +80,18 @@ describe("npm-compat refresh matrix wiring", () => {
     const workflow = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf8");
 
     expect(workflow).toContain("headRefOid");
+    expect(workflow).toContain("--paginate --slurp");
     expect(workflow).toContain("/commits/${PR_HEAD_SHA}/check-runs?per_page=100");
     expect(workflow).toContain("leaving its branch untouched to avoid cancelling CI");
-    expect(workflow).toContain("CHECK_CUTOFF");
+    expect(workflow).toContain("Do not age this guard out");
+    expect(workflow).not.toContain("CHECK_CUTOFF");
     expect(workflow).toContain('echo "skip=1" >> "$GITHUB_OUTPUT"');
+  });
+
+  it("keeps the generic behind-PR sweep away from the npm promotion branch", () => {
+    const autoRefresh = readFileSync(new URL("../.github/workflows/auto-refresh-prs.yml", import.meta.url), "utf8");
+
+    expect(autoRefresh).toContain("headRefName");
+    expect(autoRefresh).toContain('select(.headRefName != "ci/npm-compat-refresh")');
   });
 });


### PR DESCRIPTION
## Summary

- use independent concurrency keys for push, scheduled, and manual npm-compat
  refreshes so GitHub cannot discard an older pending measurement;
- inspect every check-run page for the reusable promotion PR and leave its
  branch untouched while any check is queued or running;
- fail closed when the check API is unavailable, rather than knowingly
  cancelling the CI that protects publication;
- exclude `ci/npm-compat-refresh` from the generic behind-PR refresh sweep,
  which could otherwise emit an out-of-band `pull_request:synchronize` event;
- document the remaining cancellation paths in [#4604](https://github.com/loopdive/js2/issues/4604).

## Verification

- `pnpm vitest run tests/npm-compat-partials.test.ts --reporter=dot`
- `pnpm exec prettier --check .github/workflows/npm-compat-refresh.yml .github/workflows/auto-refresh-prs.yml tests/npm-compat-partials.test.ts plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md`
- `node scripts/check-issue-ids.mjs --check`
- `git diff --check`

The targeted workflow contract tests pass (6 tests). This PR changes only
refresh scheduling and promotion safety; it does not alter benchmark results.
