### PR TITLE
fix(npm-compat): stop subdividing timed-out react-dom compile batches (#4604 S6)

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -153,6 +153,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Measure package group
+        env:
+          # (#4604) Keep react-dom's per-batch [dogfood] progress lines in the
+          # job log. Two full runs were lost to a silent single-line log where
+          # a 350-min timeout and a hang were indistinguishable.
+          NPM_COMPAT_SUITE_LOGS: "1"
         run: |
           set -euo pipefail
           pnpm run generate:npm-compat -- \

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -131,6 +131,27 @@ same stale artifact.
   chains (`setTimeout(run, 0)` reschedules while render work remains) that
   would otherwise keep a FINISHED run's process — and its CI step — alive
   indefinitely.
+- **S6: the remaining budget-eater is subdivision-on-timeout, not a hang.**
+  Run 785 (id 32576730177) measured the S5 watchdog merge itself and its
+  react-dom group STILL died at exactly 350:00 (job 97040048748,
+  13:46:49 → 19:36:27Z) with the same single-line log. Two facts resolve the
+  contradiction: (a) the log is single-line **by design** — the generator ran
+  the suite with `quiet: true`, so batch progress was invisible and a bounded
+  slow run is indistinguishable from a hang; (b) a local smoke showed a
+  1-test browser-Fizz batch consuming the full 300s compile-worker timeout,
+  and `runServerHarness`'s `compileGroup` subdivided on ANY invalid result —
+  timeouts included — up to depth 6. Since every sub-batch repeats the same
+  multi-megabyte renderer graph, halving a timed-out batch re-pays the full
+  timeout per half: the ~60-test browser-Fizz file alone can burn up to
+  2^7−1 ≈ 127 attempts × 300s ≈ 10.6h of perfectly bounded compiles — more
+  than the entire 350-min job. Fix in this slice: (1) `compileGroup` no
+  longer subdivides when the worker timed out — one timeout is the verdict
+  for the whole group, its tests recorded as blocked with the timeout as
+  reason; (2) the refresh workflow sets `NPM_COMPAT_SUITE_LOGS=1` and the
+  generator honors it by running react-dom's suite non-quiet, so the next
+  timeout names the lane and batch it went to. All other groups were green
+  in run 785 (jsdom 4 min, redux 2 min, tools 46 min), so react-dom is the
+  sole remaining publisher-blocker.
 
 ## Fix directions (pick during implementation)
 

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -2754,7 +2754,15 @@ if (!perfOnly && selectedPackages.has("react-dom")) {
   console.log("[npm-compat] react-dom — package entry + react-dom's own upstream unit tests...");
   const reactDomEntry = NPM_COMPAT_CATALOG.find((entry) => entry.name === "react-dom");
   const reactDomReport = await runNpmCompatCatalogHarness("react-dom", { quiet: true });
-  const reactDomSuite = await runConfiguredUpstreamSuite("react-dom", { quiet: true });
+  // (#4604) react-dom is the roster's largest suite by an order of magnitude
+  // and has twice burned a whole CI run with `quiet: true` hiding all
+  // progress — a 350-min timeout and a genuine hang produce the same
+  // single-line log. NPM_COMPAT_SUITE_LOGS=1 (set by npm-compat-refresh.yml)
+  // keeps its per-batch [dogfood] lines so the job log shows which lane and
+  // batch the clock went to.
+  const reactDomSuite = await runConfiguredUpstreamSuite("react-dom", {
+    quiet: process.env.NPM_COMPAT_SUITE_LOGS !== "1",
+  });
   const reactDomImplementationReport = {
     ...reactDomReport,
     // The package-entry probe only compiles the small environment selector.

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -780,7 +780,16 @@ async function runServerHarness({
       result.validationError ??
       (result.timedOut ? `compile timeout after ${compileTimeoutMs}ms` : validates ? null : "no binary emitted");
 
-    if (!validates && groupTests.length > 1 && depth < 6) {
+    // (#4604) Subdivide only on a genuine invalid result, never on a worker
+    // TIMEOUT. Each batch's compile cost is dominated by the multi-megabyte
+    // renderer graph that every sub-batch repeats, so halving a timed-out
+    // batch re-pays the full timeout per half: a 60-test Fizz file whose graph
+    // cannot compile inside the deadline would burn up to 2^7-1 attempts ×
+    // 300s ≈ 10.6h of bounded compiles — alone exceeding the refresh job's
+    // 350-min budget (run 785, job 97040048748, killed at exactly 350:00 with
+    // the graphs still compiling). One timeout is the verdict for the whole
+    // group; its tests are recorded as blocked with the timeout as reason.
+    if (!validates && !result.timedOut && groupTests.length > 1 && depth < 6) {
       const middle = Math.ceil(groupTests.length / 2);
       await compileGroup(file, groupTests.slice(0, middle), depth + 1);
       await compileGroup(file, groupTests.slice(middle), depth + 1);


### PR DESCRIPTION
## Problem

Refresh run 785 (id 32576730177) measured the S5 watchdog merge (#4770) and its react-dom group **still** died at exactly 350:00 (job 97040048748, 13:46:49 → 19:36:27Z) with the same single-line log. Two facts resolve the contradiction:

- The single-line log is **by design** — the generator ran the suite with `quiet: true`, so a bounded slow run and a hang are indistinguishable in CI.
- A local smoke showed a 1-test browser-Fizz batch consuming the full 300s compile-worker timeout, and `runServerHarness`'s `compileGroup` subdivided on **any** invalid result — timeouts included — up to depth 6. Every sub-batch repeats the same multi-megabyte renderer graph, so halving a timed-out batch re-pays the full timeout per half: the ~60-test browser-Fizz file alone can burn up to 2^7−1 ≈ 127 attempts × 300s ≈ **10.6h of perfectly bounded compiles** — more than the whole job's budget.

All 8 other matrix groups were green in run 785 (jsdom 4 min, redux 2 min, tools 46 min), so react-dom is the sole remaining publisher-blocker keeping the dashboard on the stale 2026-08-20 snapshot.

## Fix

- `runServerHarness.compileGroup` no longer subdivides when the compile worker **timed out** — one timeout is the verdict for the whole group; its tests are recorded as blocked with the timeout as reason. Subdivision still runs for genuine validation failures, where isolating a pathological test body helps.
- `npm-compat-refresh.yml` sets `NPM_COMPAT_SUITE_LOGS=1` and the generator honors it by running react-dom's upstream suite non-quiet, so the next slow run's job log names the lane and batch the clock went to instead of a single silent line.
- [#4604](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4604-npm-compat-refresh-runtime-exceeds-timeout) updated with the S6 forensics.

## Validation

- Prettier and biome clean; loc/func/oracle budget gates OK (pre-commit hooks).
- `tests/dogfood/react-dom-upstream-suite.test.ts` — 8 passed, 1 skipped (unchanged).
- `tests/npm-compat-partials.test.ts` — 6 passed (unchanged).
- Timeout-path run (`DOGFOOD_REACT_DOM_COMPILE_TIMEOUT_MS=30000`, 2 browser-Fizz tests): the 2-test batch was recorded as ONE timed-out batch — `browser Fizz ReactDOMFizzServerBrowser-test.js: 2 tests, INVALID — compile timeout after 30000ms` — with no subdivision into child attempts, every lane completed, and the process exited 0. Pre-fix, the same run would have recursed into additional per-test compile attempts.