### PR TITLE
fix(test262): keep realm callbacks on host path

### DIFF
--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -378,6 +378,16 @@ const CLOSURE_SAFE_AMBIENT_GLOBALS = new Set([
   "AggregateError",
 ]);
 
+// These names are supplied by the Test262 realm/harness rather than being
+// ordinary compiler intrinsics.  A callback that captures one must remain on
+// the host callback path: inlining it into the ref-element lane would carry
+// compiler-owned Temporal values into the harness (or vice versa), making
+// methods such as `Duration.prototype.round` disappear.  The explicit deny
+// list is deliberately small; it keeps the generic host fallback for realm
+// objects while retaining the host-free fast path for callbacks that only use
+// normal JS builtins.
+const CLOSURE_UNSAFE_HOST_AMBIENTS = new Set(["Temporal", "TemporalHelpers", "Intl", "$262"]);
+
 /**
  * (#4616) May this ref-element HOF call take the closure lane in the gc HOST
  * profile? Only when the inline callback's body resolves every identifier to a
@@ -399,6 +409,10 @@ function hofRefElemClosureLaneSafe(ctx: CodegenContext, callExpr: ts.CallExpress
       const parent = node.parent;
       if (ts.isPropertyAccessExpression(parent) && parent.name === node) return;
       if ((ts.isPropertyAssignment(parent) || ts.isMethodDeclaration(parent)) && parent.name === node) return;
+      if (CLOSURE_UNSAFE_HOST_AMBIENTS.has(node.text)) {
+        safe = false;
+        return;
+      }
       if (CLOSURE_SAFE_AMBIENT_GLOBALS.has(node.text)) return;
       const decl = ctx.oracle.valueDeclarationOf(node);
       if (decl === undefined || decl.getSourceFile().isDeclarationFile) safe = false;

--- a/src/codegen/statements.ts
+++ b/src/codegen/statements.ts
@@ -576,12 +576,13 @@ function compileStatementInner(ctx: CodegenContext, fctx: FunctionContext, stmt:
     // scope resolve to THIS declaration, not the first same-named one.
     const scopedSynthetic = ctx.anonClassExprNames.get(stmt);
     compileNestedClassDeclaration(ctx, fctx, stmt, scopedSynthetic);
-    // Bind uniformly — the FIRST same-named declaration keeps its collection
-    // name but must also read through a scoped local, or its scope behaves
-    // differently from its duplicates'.
-    const scopedName =
-      scopedSynthetic ??
-      (stmt.name !== undefined && ctx.classObjectGlobals?.has(stmt.name.text) ? stmt.name.text : undefined);
+    // Only synthetic nested duplicates need a local singleton binding.  The
+    // ordinary class-declaration path intentionally keeps its historical
+    // module/class binding: eagerly materialising every class object here
+    // changes module-init ordering and can hand the host a half-initialised
+    // prototype (the Test262 class-elements cluster exposed this as
+    // "Cannot convert undefined or null to object").
+    const scopedName = scopedSynthetic;
     if (scopedName !== undefined && stmt.name !== undefined) {
       const bindName = stmt.name.text;
       // Bind the SINGLETON class object (registered with the #4618 host


### PR DESCRIPTION
Follow-up to #4728.

The #4728 merge-group runs reproduced 480 changed-Wasm regressions, concentrated in 205 class-elements module-init failures and 273 Temporal/realm failures. This draft targets those clusters without changing the regression gate:

- keep Temporal, TemporalHelpers, Intl, and $262 callbacks on the host callback path instead of the ref-element closure lane;
- restrict class-object local singleton binding to synthetic nested duplicates so ordinary class declarations retain their established module-initialisation order.

Focused issue tests, typecheck, Prettier, function-budget, and issue checks pass locally. Full merge-group Test262 validation is intentionally pending. Keep #4728 on hold until this dependent change is validated.