### PR TITLE
fix(ci): keep npm-compat refresh publishing partial results

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -168,12 +168,20 @@ jobs:
             --only "${{ matrix.packages }}" \
             --partial-output "$RUNNER_TEMP/npm-compat-${{ matrix.id }}.json"
 
+      - name: Discard incomplete package-group report
+        if: failure()
+        run: rm -f "$RUNNER_TEMP/npm-compat-${{ matrix.id }}.json"
+
       - name: Upload package-group report
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: npm-compat-partial-${{ matrix.id }}
           path: ${{ runner.temp }}/npm-compat-${{ matrix.id }}.json
-          if-no-files-found: error
+          # A failed worker has no fresh report. The coordinator fills that
+          # package group from the last committed snapshot and marks it stale,
+          # so one flaky upstream suite cannot freeze every other package.
+          if-no-files-found: warn
           retention-days: 14
 
   refresh:
@@ -181,7 +189,11 @@ jobs:
     # The `paths-ignore` filter above is what actually breaks the trigger loop
     # now (this job's own landing changes only artifact paths). The actor guard
     # is kept as a second, cheaper line against any OTHER bot push to main.
-    if: github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
+    # Matrix failures are data-quality signals, not a reason to discard the
+    # successful groups. The merge step carries missing groups forward from
+    # the committed snapshot and marks them stale. A cancelled matrix cannot
+    # be trusted because it may have no artifacts at all.
+    if: always() && needs.measure.result != 'cancelled' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
     # The coordinator only assembles reports and promotes them. The expensive
     # package work runs in the matrix above, so this retains the 350-minute
@@ -219,6 +231,10 @@ jobs:
 
       - name: Download package-group reports
         uses: actions/download-artifact@v7
+        # If every worker failed, there are no partial artifacts. The merge
+        # script can still publish the last complete snapshot, so do not make
+        # an empty download abort the coordinator.
+        continue-on-error: true
         with:
           pattern: npm-compat-partial-*
           path: ${{ runner.temp }}/npm-compat-partials
@@ -247,7 +263,12 @@ jobs:
             const byName = new Map(packages.map(entry => [entry.name, entry]));
             const suitePins = JSON.parse(fs.readFileSync("tests/dogfood/npm-compat-upstream-sources.json", "utf8"));
             for (const pin of suitePins.filter(entry => entry.suiteScript)) {
-              const tests = byName.get(pin.name)?.tests;
+              const entry = byName.get(pin.name);
+              // A failed worker is carried forward from the last committed
+              // snapshot. Its old test numbers are useful context, but they
+              // must not block publication or masquerade as this run's data.
+              if (entry?.refresh?.status === "stale") continue;
+              const tests = entry?.tests;
               if (!tests || typeof tests.passed !== "number" || typeof tests.total !== "number") {
                 throw new Error(`${pin.name} has ${pin.suiteScript} but its unit-test result is absent from ${path}`);
               }

--- a/scripts/lib/npm-compat-partials.mjs
+++ b/scripts/lib/npm-compat-partials.mjs
@@ -27,11 +27,22 @@ export function mergeNpmCompatPartials(
     generatedAt = new Date().toISOString(),
     sourceRevision = null,
     existingHistory = { schemaVersion: 1, runs: [] },
+    existingPackages = [],
+    existingSummaryMeta = null,
+    existingGeneratedAt = null,
+    staleReason = "measurement worker did not produce a partial report",
+    allowStaleFallback = false,
     expectedNames = NPM_COMPAT_EXPECTED_PACKAGE_NAMES,
   } = {},
 ) {
-  if (!Array.isArray(partials) || partials.length === 0) {
-    throw new Error("npm-compat aggregation requires at least one partial report");
+  if (!Array.isArray(partials)) {
+    throw new Error("npm-compat aggregation requires an array of partial reports");
+  }
+  if (
+    partials.length === 0 &&
+    (!allowStaleFallback || !Array.isArray(existingPackages) || existingPackages.length === 0)
+  ) {
+    throw new Error("npm-compat aggregation requires at least one partial report or an existing snapshot");
   }
 
   const packages = [];
@@ -51,6 +62,41 @@ export function mergeNpmCompatPartials(
   }
 
   const expected = new Set(expectedNames);
+  const existingByName = new Map(
+    (Array.isArray(existingPackages) ? existingPackages : [])
+      .filter((packageRow) => packageRow?.name)
+      .map((packageRow) => [packageRow.name, packageRow]),
+  );
+  const stalePackages = [];
+  for (const name of allowStaleFallback ? [...expected].filter((candidate) => !seen.has(candidate)) : []) {
+    const previous = existingByName.get(name);
+    const packageRow = previous
+      ? {
+          ...previous,
+          refresh: {
+            status: "stale",
+            reason: staleReason,
+            ...(existingGeneratedAt ? { lastMeasuredAt: existingGeneratedAt } : {}),
+          },
+        }
+      : {
+          name,
+          version: null,
+          issue: null,
+          entryFile: null,
+          shape: null,
+          compile: { success: false, error: staleReason },
+          validation: { validates: false, firstError: staleReason },
+          tests: { kind: "upstream-suite", status: "refresh-failed", reason: staleReason },
+          correctness: { status: "unverified", reason: staleReason },
+          perf: null,
+          knownBugs: [],
+          refresh: { status: "stale", reason: staleReason },
+        };
+    packages.push(packageRow);
+    seen.add(name);
+    stalePackages.push(name);
+  }
   const missing = [...expected].filter((name) => !seen.has(name));
   const unexpected = [...seen].filter((name) => !expected.has(name));
   if (missing.length > 0 || unexpected.length > 0) {
@@ -67,25 +113,35 @@ export function mergeNpmCompatPartials(
     );
   }
 
-  const firstMeta = partials.find((partial) => partial.summaryMeta)?.summaryMeta ?? {};
+  const firstMeta = partials.find((partial) => partial.summaryMeta)?.summaryMeta ?? existingSummaryMeta ?? {};
   const sortedPackages = sortPackages(packages);
+  const freshPackages = sortedPackages.filter((packageRow) => packageRow.refresh?.status !== "stale");
   const summary = {
     generatedAt,
     correctness: correctnessRollup(sortedPackages),
     note: firstMeta.note ?? "Only packages with a committed, reproducible tests/dogfood harness are listed.",
     popularity: firstMeta.popularity ?? null,
     performanceMethodology: firstMeta.performanceMethodology ?? null,
+    refresh: {
+      status: stalePackages.length > 0 ? "partial" : "complete",
+      stalePackages: [...stalePackages].sort(),
+    },
     packages: sortedPackages,
   };
-  const perfRows = npmPerfRows(sortedPackages);
-  const perfHistory = mergeNpmPerfHistory(existingHistory, [
-    npmPerfHistoryPoint(
-      sortedPackages,
-      generatedAt,
-      sourceRevision,
-      firstMeta.performanceMethodology?.optimizationLevels,
-    ),
-  ]);
+  const perfRows = npmPerfRows(freshPackages);
+  const perfHistory = mergeNpmPerfHistory(
+    existingHistory,
+    freshPackages.length > 0
+      ? [
+          npmPerfHistoryPoint(
+            freshPackages,
+            generatedAt,
+            sourceRevision,
+            firstMeta.performanceMethodology?.optimizationLevels,
+          ),
+        ]
+      : [],
+  );
 
   return { summary, perfRows, perfHistory };
 }

--- a/scripts/merge-npm-compat-partials.mjs
+++ b/scripts/merge-npm-compat-partials.mjs
@@ -15,14 +15,16 @@ const partialDirectory = process.argv[2];
 if (!partialDirectory) throw new Error("usage: merge-npm-compat-partials.mjs <partial-directory>");
 
 const partialRoot = resolve(partialDirectory);
+mkdirSync(partialRoot, { recursive: true });
 const partialPaths = readdirSync(partialRoot)
   .filter((name) => name.endsWith(".json"))
   .sort()
   .map((name) => join(partialRoot, name));
-if (partialPaths.length === 0) throw new Error(`no npm-compat partial reports found in ${partialRoot}`);
 
 const partials = partialPaths.map((path) => JSON.parse(readFileSync(path, "utf8")));
 const sourceRevision = execFileSync("git", ["rev-parse", "HEAD"], { cwd: ROOT, encoding: "utf8" }).trim();
+const summaryPath = resolve(ROOT, "benchmarks", "results", "npm-compat.json");
+const existingSummary = existsSync(summaryPath) ? JSON.parse(readFileSync(summaryPath, "utf8")) : null;
 const historyPath = resolve(ROOT, "benchmarks", "results", "npm-compat-history.json");
 const existingHistory = existsSync(historyPath)
   ? JSON.parse(readFileSync(historyPath, "utf8"))
@@ -31,6 +33,16 @@ const existingHistory = existsSync(historyPath)
 const { summary, perfRows, perfHistory } = mergeNpmCompatPartials(partials, {
   sourceRevision,
   existingHistory,
+  existingPackages: existingSummary?.packages ?? [],
+  existingSummaryMeta: existingSummary
+    ? {
+        note: existingSummary.note,
+        popularity: existingSummary.popularity,
+        performanceMethodology: existingSummary.performanceMethodology,
+      }
+    : null,
+  existingGeneratedAt: existingSummary?.generatedAt ?? null,
+  allowStaleFallback: true,
 });
 
 const outputs = [

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -58,10 +58,69 @@ describe("npm-compat partial aggregation", () => {
       }),
     ).toThrow(/source revision mismatch/);
   });
+
+  it("carries a failed worker forward without recording stale perf as a new run", () => {
+    const previous = {
+      ...partial(["react"], "old"),
+      packages: [
+        {
+          ...partial(["react"], "old").packages[0],
+          perf: {
+            lanes: {
+              jsHost: { status: "measured", ratio: 0.5 },
+            },
+          },
+        },
+      ],
+    };
+    const fresh = partial(["acorn"]);
+    (fresh.packages[0] as any).perf = {
+      lanes: {
+        jsHost: { status: "measured", ratio: 2 },
+      },
+    };
+    const result = mergeNpmCompatPartials([fresh], {
+      expectedNames: ["acorn", "react"],
+      sourceRevision: "source",
+      existingPackages: previous.packages,
+      existingSummaryMeta: previous.summaryMeta,
+      existingGeneratedAt: "2026-08-21T00:00:00.000Z",
+      allowStaleFallback: true,
+      generatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(result.summary.refresh).toEqual({ status: "partial", stalePackages: ["react"] });
+    expect(result.summary.packages.find((entry) => entry.name === "react")?.refresh).toEqual({
+      status: "stale",
+      reason: "measurement worker did not produce a partial report",
+      lastMeasuredAt: "2026-08-21T00:00:00.000Z",
+    });
+    expect(result.perfRows.map((entry) => entry.name)).toEqual(["acorn · JS host · runtime dynamic"]);
+    expect(result.perfHistory.runs.at(-1)?.packages).toEqual({
+      acorn: { jsHost: { dynamic: 2 }, standalone: {} },
+    });
+  });
+
+  it("can publish the prior complete snapshot when every worker fails", () => {
+    const previous = partial(["acorn", "react"], "old");
+    const result = mergeNpmCompatPartials([], {
+      expectedNames: ["acorn", "react"],
+      sourceRevision: "source",
+      existingPackages: previous.packages,
+      existingSummaryMeta: previous.summaryMeta,
+      existingGeneratedAt: "2026-08-21T00:00:00.000Z",
+      allowStaleFallback: true,
+      generatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(result.summary.packages).toHaveLength(2);
+    expect(result.summary.refresh.stalePackages).toEqual(["acorn", "react"]);
+    expect(result.perfHistory.runs).toHaveLength(0);
+  });
 });
 
 describe("npm-compat refresh matrix wiring", () => {
-  it("measures independent groups and assembles only after every group succeeds", () => {
+  it("measures independent groups and publishes successful groups after a worker failure", () => {
     const workflow = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf8");
 
     expect(workflow).toContain("github.repository == 'loopdive/js2'");
@@ -71,8 +130,11 @@ describe("npm-compat refresh matrix wiring", () => {
     );
     expect(workflow).toMatch(/concurrency:[\s\S]*?cancel-in-progress: false/);
     expect(workflow).toContain("needs: measure");
+    expect(workflow).toContain("always() && needs.measure.result != 'cancelled'");
     expect(workflow).toContain("--partial-output");
     expect(workflow).toContain("actions/download-artifact@v7");
+    expect(workflow).toContain("continue-on-error: true");
+    expect(workflow).toContain("if-no-files-found: warn");
     expect(workflow).toContain("scripts/merge-npm-compat-partials.mjs");
     expect(workflow).toContain("id: typescript");
     expect(workflow).toContain("id: react-dom");

--- a/website/components/npm-compat-chart.js
+++ b/website/components/npm-compat-chart.js
@@ -135,6 +135,10 @@ class NpmCompatChart extends HTMLElement {
   }
 
   _currentSpeedSnapshot(pkg) {
+    // A failed matrix worker carries the last committed package row forward
+    // so other packages can still publish. Do not append that old measurement
+    // as if it were a point from the current refresh.
+    if (pkg?.refresh?.status === "stale") return null;
     const perf = pkg.perf;
     if (!perf) return null;
     const lanes = perf.lanes ?? { jsHost: perf };
@@ -391,6 +395,18 @@ class NpmCompatChart extends HTMLElement {
         )
       : "";
 
+    const refreshNotice =
+      pkg.refresh?.status === "stale"
+        ? this._row(
+            "refresh",
+            `<span class="muted">not measured in this run${
+              pkg.refresh.lastMeasuredAt
+                ? `; last measured ${this._esc(this._fmtDate(pkg.refresh.lastMeasuredAt))}`
+                : ""
+            }</span>`,
+          )
+        : "";
+
     // Tests — the "own test suite" vs "differential ops" distinction is
     // load-bearing, so it is the row's own label, never blurred into one number.
     let tests;
@@ -576,7 +592,7 @@ class NpmCompatChart extends HTMLElement {
             ? `<span class="badge" title="The published entry module only re-exports other packages, so these badges describe the barrel — see the tests row for the real implementation.">entry is a barrel</span>`
             : ""
         }</div>
-        <div class="rows">${correctness}${tests}${serverTests}${fizzTests}${nodeFizzTests}${edgeFizzTests}${perf}${bugs}</div>
+        <div class="rows">${refreshNotice}${correctness}${tests}${serverTests}${fizzTests}${nodeFizzTests}${edgeFizzTests}${perf}${bugs}</div>
         <div class="card-links">
           <a class="playground-link" href="${playgroundUrl}"
             title="Open ${this._esc(pkg.name)} test files in the playground">Open tests in playground&nbsp;↗</a>


### PR DESCRIPTION
## Summary

The npm-compat refresh coordinator was skipped whenever one package matrix job failed. React-dom's upstream assertion failure therefore prevented every successful package measurement from reaching the dashboard, leaving npm-compat data unchanged for days.

This change:

- runs the coordinator after a matrix failure (but not cancellation);
- uploads only complete worker reports;
- carries missing groups forward from the last committed snapshot and marks those package rows stale;
- excludes stale rows from new performance-history points;
- shows the stale status on the package card;
- allows the sanity check to publish a mixed fresh/stale snapshot.

## Verification

- `pnpm exec vitest run tests/npm-compat-partials.test.ts tests/npm-compat-history-retention.test.ts` (16 tests passed)
- `pnpm run typecheck`
- `pnpm exec prettier --check` on all changed files
- `git diff --check`

The existing #4728 CI failure was also fixed separately by refreshing its host-import baseline; its fresh run 32617282774 is green.
