### PR TITLE
fix(#4626): harness detachArrayBuffer-host + issues #4629–#4635 with implementation plans

### DIFF
--- a/plan/issues/4626-standalone-harness-selftest-gaps.md
+++ b/plan/issues/4626-standalone-harness-selftest-gaps.md
@@ -96,7 +96,7 @@ alias form `var TA = Int8Array; new TA([5])` misreads the array argument as a
 length (`.length` 5) — a different (builtin-alias) arm; the harness shape is
 the param form, which is fixed.
 
-## Remaining standalone failures (11) — root causes surveyed
+## Remaining standalone failures (10) — root causes surveyed
 
 | Test(s) | Gap |
 | --- | --- |
@@ -106,5 +106,5 @@ the param form, which is fixed.
 | deepEqual-primitives-bigint | BigInt standalone (`env::__new_BigInt` host-import refusal) |
 | assert-throws-same-realm, (throwsAsync-same-realm) | needs a realm shim with distinct error-ctor identities (see revert note above — must not shadow builtin names) plus `.constructor` identity |
 | wellKnownIntrinsicObjects | `%Array%` intrinsic identity (`Object.is(Array, intrinsic)`) |
-| detachArrayBuffer-host | `err.constructor` on a Test262Error thrown by a BARE `throw new Test262Error(...)` inside an object-literal method loses fnctor identity (resolves to a generic closure; `throw (new …)` and `throw <var>` both work — the escape-gate/lowering divergence is syntactic) |
+| detachArrayBuffer-host | FIXED (third slice): the runtime shim's `var $262` collided with the test's own `var $262` override (no last-assignment-wins for duplicate top-level vars); `assembleVariant` now renames the shim part's `$262` occurrences when the body declares one. Fixes BOTH lanes. |
 | testTypedArray-conversions | FIXED (second slice, above) |

--- a/plan/issues/4626-standalone-harness-selftest-gaps.md
+++ b/plan/issues/4626-standalone-harness-selftest-gaps.md
@@ -91,20 +91,19 @@ untouched (its own 17 failures unchanged, none new).
   callee routes through `emitTaDynCtorConstructFromLocals`; every other value
   keeps the ordinary-construct driver byte-for-byte.
 
-Residual found while reducing (NOT one of the 16, deferred): the DECLARED
-alias form `var TA = Int8Array; new TA([5])` misreads the array argument as a
-length (`.length` 5) — a different (builtin-alias) arm; the harness shape is
-the param form, which is fixed.
+Residual found while reducing (NOT one of the 16): the DECLARED alias form
+`var TA = Int8Array; new TA([5])` misreads the array argument as a length
+(`.length` 5) — filed as **#4635**.
 
 ## Remaining standalone failures (10) — root causes surveyed
 
 | Test(s) | Gap |
 | --- | --- |
-| asyncHelpers-* (5) | asyncTest/thenable semantics through harness closures (one null-deref trap in an async resume) |
-| deepEqual-mapset | Set/Map member dispatch through `any` (`.size`, `Symbol.iterator`, `.next()` all missing → trap/false) |
-| compare-array-symbol | symbol[] elements are raw i32 ids in `$__arr_i32`; `map.call(arr, String)` renders the id number |
-| deepEqual-primitives-bigint | BigInt standalone (`env::__new_BigInt` host-import refusal) |
-| assert-throws-same-realm, (throwsAsync-same-realm) | needs a realm shim with distinct error-ctor identities (see revert note above — must not shadow builtin names) plus `.constructor` identity |
-| wellKnownIntrinsicObjects | `%Array%` intrinsic identity (`Object.is(Array, intrinsic)`) |
+| asyncHelpers-* (5) | → **#4630** (asyncTest/thenable semantics; one null-deref trap) |
+| deepEqual-mapset | → **#4629** (Set/Map member dispatch through `any`: `.size`, `Symbol.iterator`, `.next()` all missing) |
+| compare-array-symbol | → **#4632** (symbol[] elements are raw i32 ids; `String` renders the id number) |
+| deepEqual-primitives-bigint | → **#4631** (standalone BigInt carrier) |
+| assert-throws-same-realm, (throwsAsync-same-realm) | → **#4634** (non-shadowing realm-shim error ctors) + #4630 for the async trap |
+| wellKnownIntrinsicObjects | → **#4633** (intrinsic identity across the runtime-eval boundary) |
 | detachArrayBuffer-host | FIXED (third slice): the runtime shim's `var $262` collided with the test's own `var $262` override (no last-assignment-wins for duplicate top-level vars); `assembleVariant` now renames the shim part's `$262` occurrences when the body declares one. Fixes BOTH lanes. |
 | testTypedArray-conversions | FIXED (second slice, above) |

--- a/plan/issues/4629-standalone-setmap-any-dispatch.md
+++ b/plan/issues/4629-standalone-setmap-any-dispatch.md
@@ -1,0 +1,90 @@
+---
+id: 4629
+title: "Standalone: Set/Map members miss through the any channel (.size, Symbol.iterator, iterator protocol)"
+status: ready
+sprint: Backlog
+created: 2026-08-23
+updated: 2026-08-23
+priority: medium
+horizon: l
+feasibility: medium
+task_type: bug
+area: codegen
+goal: test262-conformance
+lane: B
+files:
+  - src/codegen/map-runtime.ts
+  - src/codegen/object-runtime.ts
+  - src/codegen/property-access-dispatch.ts
+---
+
+# #4629 — Standalone: Set/Map members miss through the `any` channel
+
+## Problem
+
+`test/harness/deepEqual-mapset.js` fails standalone on its FIRST assertion,
+`assert.deepEqual(new Set(), new Set())`. Measured probe (2026-08-23, this
+exact shape):
+
+```js
+function probe(v) { ... }
+probe(new Set([1]));
+// hasIt=false  size=undefined  isSet=true  next.done=null
+```
+
+On an `any`-typed receiver holding a Set:
+
+- `v[Symbol.iterator]` reads `undefined` (so `typeof v[Symbol.iterator] ===
+  "function"` — deepEqual's `isIterableEquatable` — answers false),
+- `v.size` reads `undefined`,
+- `v instanceof Set` DOES work (the brand test is wired).
+
+deepEqual's `compareIteratorEquality` additionally needs the returned
+iterator to answer `.next()` → `{done, value}` and optional `.return`.
+
+## Why
+
+The standalone Set/Map runtime carrier (see `map-runtime.ts`) has typed
+fast paths for statically-typed receivers, but the reflective
+`__extern_get` ladder (object-runtime.ts) has no arm for the Set/Map
+carrier structs: a symbol-keyed read (`[Symbol.iterator]`) and the `size`
+member both fall through to the open-object walk and miss to null.
+
+## Implementation Plan
+
+1. **Identify the carrier structs**: find the `$Set`/`$Map` (or
+   equivalently named) struct type indices in `map-runtime.ts`; confirm how
+   a statically-typed `set.size` / `for (x of set)` lowers today (there is
+   a working typed path — reuse its helpers).
+2. **`__extern_get` arms (finalize-spliced, same discipline as
+   `fillTaDynViewMopArms`)**:
+   - receiver `ref.test $Set/$Map` + string key `"size"` → i32 count →
+     `__box_number`.
+   - same receivers + SYMBOL key equal to the well-known
+     `Symbol.iterator` id → return a closure that mints the native
+     iterator (see step 3). Well-known symbol ids are already modeled
+     (see `builtin-value-read.ts` "well-known-symbol ids").
+3. **Iterator object**: mint a small `$__setmap_iter` struct
+   `{recv, idx}` plus a `next` native returning a two-field result object
+   (`done` bool, `value` externref) through the existing `$Object`
+   builder, mirroring how the existing typed `for-of` over Set/Map yields
+   elements. `.return` may be absent (deepEqual guards with `if
+   (b.return)`).
+4. **Method-call twin**: `__extern_method_call` must dispatch
+   `it.next()` on the iterator struct — add the arm next to the existing
+   `$__ta_dyn_view` method arms (`call-receiver-method.ts` /
+   `fillFnctorPrototypeDispatchArms` pattern).
+5. **Acceptance**: `harness/deepEqual-mapset.js` passes standalone via
+   `runTest262File(..., "standalone")`; probe above answers
+   `hasIt=true size=1 next.done=false`; no regression in a 30-test
+   standalone sample over `built-ins/Set/**` + `built-ins/Map/**`
+   baseline-pass tests; js-host lane byte-identical (all arms
+   noJsHost-gated).
+
+## Order-preservation constraints
+
+- All new natives are DEFINED functions minted at reserve time and filled
+  at finalize (#1719 reserve-then-fill); no late host imports mid-emission
+  (#608/#794).
+- Splice arms in FRONT of the generic `$Object` walk, after the vec fills
+  (last-fill-wins ordering documented in `ta-dyn-mop.ts`).

--- a/plan/issues/4630-standalone-asynchelpers-thenables.md
+++ b/plan/issues/4630-standalone-asynchelpers-thenables.md
@@ -1,0 +1,74 @@
+---
+id: 4630
+title: "Standalone: asyncHelpers harness self-tests — thenable coercion through asyncTest closures"
+status: ready
+sprint: Backlog
+created: 2026-08-23
+updated: 2026-08-23
+priority: medium
+horizon: l
+feasibility: hard
+task_type: bug
+area: codegen
+goal: test262-conformance
+lane: B
+files:
+  - src/codegen/async-frame.ts
+  - src/codegen/expressions/calls-closures.ts
+---
+
+# #4630 — Standalone asyncHelpers self-tests (4 tests + 1 trap)
+
+## Problem
+
+Five `test/harness/asyncHelpers-*` self-tests fail standalone (measured
+2026-08-23 via `runTest262File(..., "standalone")`):
+
+| Test | Symptom |
+| --- | --- |
+| asyncTest-return-not-thenable | `[false×6]` vs `[true×6]` — none of the six non-thenable return values produced the expected synchronous Test262Error rejection path |
+| asyncTest-returns-undefined | `Test262:AsyncTestFailure:Test262Error: [object Object]` |
+| asyncTest-then-rejects | same |
+| asyncTest-then-resolves | same |
+| throwsAsync-same-realm | `RuntimeError: dereferencing a null pointer in __closure_111 (via asyncTest ← __fn_tramp…)` — a hard trap, distinct from the four soft failures (also depends on #4634's realm shim) |
+
+## What the harness needs
+
+`asyncTest(testFunc)` (harness/asyncHelpers.js):
+
+1. calls `testFunc()` and inspects the RESULT for thenable-ness
+   (`res && typeof res.then === "function"`) — a duck-typed `.then` read on
+   an `any` value that may be a compiled closure result, a native Promise
+   carrier, a plain `$Object` with a `then` member, or a primitive;
+2. chains `.then(onFulfilled, onRejected)` with harness closures and
+   routes the outcome to `$DONE`;
+3. `assert.throwsAsync` builds its OWN promise around the thenable and
+   compares constructor identities on rejection values.
+
+The `[object Object]` rendering in three of the failures means the
+rejection VALUE reached `$DONE`, but it stringifies as a plain object —
+the Test262Error's message is not recovered — so either the wrong value is
+propagated or `String(err)`/`err.message` on it misses.
+
+## Implementation Plan
+
+1. **Reproduce small**: reduce each failure in `.tmp/` probes:
+   (a) `typeof x.then === "function"` for x = compiled async fn result,
+   plain object with `then`, number; (b) `.then(f, r)` on a native promise
+   held in `any`; (c) `String(thrownTest262Error)` through the async
+   rejection path. Identify which of the three legs breaks per test.
+2. **Fix the `.then` duck-typing leg** first (likely shared with #4629's
+   any-member-read mechanics): the native Promise carrier must answer a
+   callable `then` through `__extern_get`.
+3. **Fix rejection-value fidelity**: the async frame's rejection plumbing
+   (async-frame.ts) must hand the ORIGINAL thrown value to the `onRejected`
+   closure, not a re-boxed generic object; verify `err.message` and
+   `err.constructor` survive (constructor identity additionally needs the
+   fnctor proto machinery, cf. #4626 third-slice notes).
+4. **Trap in throwsAsync-same-realm**: chase the null deref in
+   `__closure_111` separately — reproduce with the full-harness assembly,
+   bisect includes; do NOT fold into the soft fixes.
+5. **Acceptance**: the four soft tests pass standalone;
+   the trap test at minimum stops trapping (its pass additionally requires
+   #4634); 20-test standalone sample over `built-ins/Promise/**`
+   baseline-pass tests shows 0 regressions.

--- a/plan/issues/4631-standalone-bigint-carrier.md
+++ b/plan/issues/4631-standalone-bigint-carrier.md
@@ -1,0 +1,55 @@
+---
+id: 4631
+title: "Standalone: BigInt literal/value support (env::__new_BigInt host-import refusal)"
+status: ready
+sprint: Backlog
+created: 2026-08-23
+updated: 2026-08-23
+priority: low
+horizon: xl
+feasibility: hard
+task_type: feature
+area: codegen
+goal: test262-conformance
+lane: B
+files:
+  - src/codegen/literals.ts
+  - src/codegen/type-coercion.ts
+---
+
+# #4631 — Standalone BigInt carrier
+
+## Problem
+
+`test/harness/deepEqual-primitives-bigint.js` (and every standalone test
+touching a BigInt value) fails at module level: BigInt construction lowers
+to the `env::__new_BigInt` host import, which the standalone lane refuses
+(#2961 leaked-import gate). There is no Wasm-native BigInt representation.
+
+## Scope note
+
+This is a FEATURE slice, not a bug: dual-mode rule (CLAUDE.md
+"Architecture Principles") requires a Wasm-native implementation before
+the host import can remain as a fast path. i64-branded values exist for
+`type i64` annotations (`from.bigint` arm in type-coercion.ts boxes via
+`__box_bigint`), but arbitrary-precision semantics, mixed comparisons and
+`typeof x === "bigint"` are unimplemented standalone.
+
+## Implementation Plan (phased)
+
+1. **Phase 0 — inventory**: count standalone test262 failures whose error
+   signature names BigInt (baseline jsonl grep) to size the payoff before
+   committing; record the number here.
+2. **Phase 1 — i64-backed small-BigInt carrier**: a `$BigInt` struct
+   wrapping i64 for values that fit; literals (`123n`) mint it;
+   `typeof` arm answers "bigint" (mirror the #4626 `$Symbol` typeof-arm
+   splice in typeof-natives-finalize.ts); `===`/`==`/relational arms
+   compare by value; ToString via existing i64 formatting.
+   Out-of-range literals → honest CompileError (better than silent wrap).
+3. **Phase 2 — deepEqual/harness needs**: `Object.is`, `assert.sameValue`,
+   deepEqual classification (`typeof value === "bigint"`) — all fall out
+   of the typeof arm + comparison arms.
+4. **Phase 3 (deferred)** — arbitrary precision (limb array), BigInt64Array
+   element type, `BigInt(string)`.
+5. **Acceptance for phase 1-2**: `harness/deepEqual-primitives-bigint.js`
+   passes standalone; no js-host byte change; standalone floor unaffected.

--- a/plan/issues/4632-standalone-symbol-array-elements.md
+++ b/plan/issues/4632-standalone-symbol-array-elements.md
@@ -1,0 +1,61 @@
+---
+id: 4632
+title: "Standalone: symbol[] elements are raw i32 ids — compareArray renders the id number"
+status: ready
+sprint: Backlog
+created: 2026-08-23
+updated: 2026-08-23
+priority: medium
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen
+goal: test262-conformance
+lane: B
+files:
+  - src/codegen/literals.ts
+  - src/codegen/array-methods.ts
+  - src/codegen/symbol-native.ts
+---
+
+# #4632 — Standalone symbol[] element representation
+
+## Problem
+
+`test/harness/compare-array-symbol.js` fails standalone: an array of
+symbols (`[Symbol("a")]`) lowers its elements into a numeric vec
+(`$__arr_i32`-family), losing the symbol brand per element. The harness's
+`compareArray.format` does `map.call(arr, String)`, which renders the raw
+id NUMBER (e.g. `"1"`) instead of `"Symbol(a)"`, and element equality
+against another symbol value compares id-as-number vs boxed carrier.
+
+Related fixed context: #4626 slice 1 branded the SCALAR `Symbol()` result
+(`{kind:"i32", symbol:true}`, native-symbol lanes only) so any-channel
+coercions box via `__box_symbol`. The ARRAY path does not consult that
+brand when choosing the element vec type.
+
+## Implementation Plan
+
+1. **Element-type inference**: in the array-literal lowering
+   (literals.ts), when the inferred element ValType carries
+   `symbol: true` (or the checker type is `symbol`), do NOT select the
+   numeric vec; select the externref/anyref vec and store the interned
+   `$Symbol` carriers (`__box_symbol(id)`) as elements. This keeps every
+   existing reflective consumer (String(), sameValue, typeof, key use)
+   correct with no new arms, at the cost of boxing on store.
+2. **Read path**: element reads then flow as externref carriers —
+   `typeof arr[0]` already answers "symbol" via the #4626 typeof arm;
+   `o[arr[0]]` symbol-keying already works via the defineProperty /
+   `__key_equals` id-compare.
+3. **Check the micro-shape residual from #4626's survey**: param-type
+   inference turning `t(Symbol())` params into f64 — the same brand-loss
+   family; verify whether step 1's inference hook also covers the
+   param-inference site (declarations/param-return-inference.ts), and if
+   not, note it as a follow-up rather than widening this slice.
+4. **Acceptance**: `harness/compare-array-symbol.js` passes standalone;
+   `String(Symbol("a"))` renders `Symbol(a)` from an array element; a
+   15-test standalone sample over `built-ins/Symbol/**` baseline-pass
+   tests shows 0 regressions; js-host lane byte-identical (gate on
+   `usesNativeSymbolProvider`, mirroring the #4626 brand gate — the
+   js-host brand leak was exactly the 2026-08-23 merge_group park, do not
+   repeat it).

--- a/plan/issues/4633-standalone-intrinsic-identity-runtime-eval.md
+++ b/plan/issues/4633-standalone-intrinsic-identity-runtime-eval.md
@@ -1,0 +1,55 @@
+---
+id: 4633
+title: "Standalone: %Array% intrinsic identity across the runtime-eval boundary (wellKnownIntrinsicObjects)"
+status: ready
+sprint: Backlog
+created: 2026-08-23
+updated: 2026-08-23
+priority: low
+horizon: l
+feasibility: hard
+task_type: bug
+area: codegen
+goal: test262-conformance
+lane: B
+files:
+  - src/codegen/runtime-eval-boundary.ts
+  - src/codegen/builtin-value-read.ts
+---
+
+# #4633 — Intrinsic identity across the runtime-eval boundary
+
+## Problem
+
+`test/harness/wellKnownIntrinsicObjects.js` fails standalone at
+`assert(Object.is(Array, intrinsicArray))`. The harness populates each
+intrinsic with `new Function("return " + source)()` — i.e. the value comes
+back from the RUNTIME-EVAL engine (quickjs tier, #4242) — and compares it
+with `Object.is` against the compiled module's own `Array` value read.
+
+Two representations meet: the compiled lane's native builtin-ctor value
+(a `$NativeProto`/singleton carrier from builtin-value-read.ts) and
+whatever the eval boundary returns for `Array`. They are not the same
+reference, so `Object.is` answers false.
+
+## Implementation Plan
+
+1. **Measure first**: instrument what `new Function("return Array")()`
+   returns standalone (carrier kind, null?) and what the bare `Array`
+   value read returns in the same module. Record both here before design.
+2. **Design decision** (pick after step 1):
+   - (a) **Boundary canonicalization**: when the runtime-eval boundary
+     hands back a value that names a global builtin (the eval engine can
+     tag "this is the global `Array`"), substitute the compiled lane's own
+     singleton for it, so identity holds by construction; or
+   - (b) **Identity map in Object.is/===**: teach the sameValue native an
+     arm equating the eval-side proxy for a builtin with the native
+     singleton — narrower but leaks into every comparison site.
+   Prefer (a): single chokepoint, no comparison-site sprawl.
+3. **Scope guard**: only globals reachable by bare name need this
+   (`Array`, `Object`, …); accessor-path intrinsics
+   (`Object.getPrototypeOf([][Symbol.iterator]())`) are follow-ups — the
+   harness self-test only asserts `%Array%` plus two throwing cases, which
+   already throw correctly.
+4. **Acceptance**: `harness/wellKnownIntrinsicObjects.js` passes
+   standalone; runtime-eval canary suite unchanged; no js-host byte change.

--- a/plan/issues/4634-realm-shim-nonshadowing-error-ctors.md
+++ b/plan/issues/4634-realm-shim-nonshadowing-error-ctors.md
@@ -1,0 +1,82 @@
+---
+id: 4634
+title: "Runner realm shim: distinct per-realm error constructors WITHOUT builtin-shadowing names (same-realm harness tests)"
+status: ready
+sprint: Backlog
+created: 2026-08-23
+updated: 2026-08-23
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: testing
+goal: test262-conformance
+lane: B
+files:
+  - tests/test262-runner.ts
+---
+
+# #4634 — Non-shadowing realm-shim error constructors
+
+## Problem
+
+`test/harness/assert-throws-same-realm.js` and
+`asyncHelpers-throwsAsync-same-realm.js` fail standalone (the latter also
+traps — see #4630 step 4). They need `$262.createRealm()` to expose error
+constructors with DISTINCT function identity, so
+`assert.throws(TypeError, () => { throw new realm.TypeError(); })`
+REJECTS the foreign instance.
+
+## The trap already hit once — do not repeat it
+
+The first attempt (PR #4782's parked commit c3a45f95b) wrote the shim as
+NAMED function expressions:
+
+```ts
+realm.TypeError = function TypeError(msg: any) { ... };
+```
+
+The `$262` stub is COMPILED SOURCE prepended to every `needs262` test
+module, and the compiler's fnctor machinery is NAME-keyed
+(`funcConstructorMap`, `classSet`, brand registries) — so a preamble
+function literally named `TypeError` shadowed the builtin in EVERY such
+module: 367 js-host regressions with wasm-hash change, 216 "invalid Wasm
+binary", `e instanceof TypeError` false across Temporal buckets. Full
+post-mortem in `plan/issues/4626-standalone-harness-selftest-gaps.md`
+(first-slice item 4).
+
+## Implementation Plan
+
+1. In the runner's `$262.createRealm()` shim (tests/test262-runner.ts,
+   the `let $262 = {` template around L2301), add per-realm ctors via a
+   factory so NO builtin name appears as a function name anywhere in the
+   compiled preamble:
+
+   ```ts
+   const mkRealmCtor = function (n: any): any {
+     const f: any = function (msg: any) { (this as any).message = msg; };
+     return f;
+   };
+   realm.Error = mkRealmCtor("Error");
+   realm.TypeError = mkRealmCtor("TypeError");
+   // + RangeError, SyntaxError, ReferenceError, EvalError, URIError
+   ```
+
+   The same-realm tests assert IDENTITY (`err.constructor !==
+   TypeError`), not `.name`, so the anonymous inner function suffices; if
+   a test turns out to read `.name`, install it as a data property, never
+   via the function's own name.
+2. **Regression gate BEFORE pushing** (the exact check the first attempt
+   lacked): compile one `needs262` js-host test (e.g.
+   `built-ins/JSON/stringify/value-string-escape-ascii.js`) on the branch
+   and on main via `runTest262File` and compare `wasm_sha` — they must be
+   EQUAL for any module that does not call `createRealm` beyond what main
+   does. Also re-run the 8 baseline-pass `createRealm` standalone tests.
+3. `assert.throws`'s rejection path also needs `err.constructor` identity
+   on the foreign instance — verify against #4626's third-slice
+   `.constructor` findings (a module-level typed use of the fnctor
+   registers the identity machinery; the shim's factory closure may need
+   the same nudge; measure, don't assume).
+4. **Acceptance**: both same-realm harness tests pass standalone (the
+   async one also needs #4630's trap fixed); wasm_sha equality per step 2;
+   js-host harness category unchanged.

--- a/plan/issues/4635-standalone-ta-alias-array-arg-as-length.md
+++ b/plan/issues/4635-standalone-ta-alias-array-arg-as-length.md
@@ -1,0 +1,63 @@
+---
+id: 4635
+title: "Standalone: declared-alias TypedArray ctor misreads an array argument as a length (var TA = Int8Array; new TA([5]))"
+status: ready
+sprint: Backlog
+created: 2026-08-23
+updated: 2026-08-23
+priority: low
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+goal: test262-conformance
+lane: B
+files:
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/expressions/new-builtin-globals.ts
+---
+
+# #4635 — Declared-alias TA ctor: array arg treated as length
+
+## Problem
+
+Measured 2026-08-23 (standalone, `runTest262File` probe):
+
+```js
+var TA = Int8Array;
+var sample = new TA([5]);
+sample.length; // 5  — WRONG (spec: 1)
+sample[0];     // undefined — WRONG (spec: 5)
+```
+
+The checker types `TA` as `Int8ArrayConstructor` (declared alias), so the
+DYNAMIC any-ctor paths (fixed for the param shape in #4626's second slice)
+never fire; some static builtin-alias arm claims the `new` and compiles
+the COUNT constructor, ToNumber-ing the array (`[5]` → "5" → 5).
+The direct spelling `new Int8Array([5])` is correct; the ANY-typed param
+shape is correct since #4626 slice 2. Only the statically-aliased binding
+misroutes.
+
+Not currently blocking any test262 harness self-test (the harness uses
+the param shape) — filed from the #4626 reduction so the residual is not
+lost.
+
+## Implementation Plan
+
+1. **Locate the claiming arm**: instrument `compileNewExpression`
+   (new-super.ts) for `new TA([5])` with the alias-typed binding — the
+   #4626 debugging showed candidates: `tryNewBuiltinStaticAlias`
+   (new-builtin-static-alias.ts, #4491 T6) and the
+   `NEW_GLOBAL_FALLTHROUGH` route (new-builtin-globals.ts). Confirm which
+   one wins before editing (repeat of the mark-trace method; the method is
+   cheap, wrong guesses are not).
+2. **Fix inside that arm**: it already resolves the concrete view kind
+   from the alias's static type; give it the same argument-shape dispatch
+   the direct `new Int8Array(...)` path has (count vs array-copy vs
+   buffer vs view-copy) instead of unconditionally ToNumber-ing arg0.
+   Reuse the direct path's helpers — do not re-implement the copy loops.
+3. **Acceptance**: the probe answers `length 1, sample[0] === 5`; the
+   direct and param spellings stay green
+   (`harness/testTypedArray-conversions.js` standalone), and a 15-test
+   standalone sample over `built-ins/TypedArray*/**` baseline-pass tests
+   shows 0 regressions; js-host lane untouched.

--- a/tests/test262-original-harness.ts
+++ b/tests/test262-original-harness.ts
@@ -201,9 +201,27 @@ function assembleVariant(
   // helper declarations (e.g. `isPrimitive` in both testTypedArray.js + assert.js)
   // that a JS engine tolerates last-wins. Rename all-but-last in place (line-count
   // preserving) so bodyLineOffset below stays exact.
-  const prefix = dedupeTopLevelFunctionDeclarations(
+  let prefix = dedupeTopLevelFunctionDeclarations(
     (strict ? '"use strict";\n' : "") + assemblePrefixIncludes(meta, async),
   );
+  // (#4626) A test that DECLARES its own top-level `$262` (harness
+  // detachArrayBuffer-host-detachArrayBuffer.js: `var $262 = {
+  // detachArrayBuffer() { throw ... } }`) collides with the runtime shim's
+  // `var $262 = {...}` — the compiler does not give the duplicate var
+  // last-assignment-wins semantics, so the test's override never took effect
+  // (its detach shim silently no-op'd; the read even nulled). Rename the SHIM
+  // part's `$262` occurrences (same byte length, line-count preserving, so
+  // bodyLineOffset stays exact); harness includes and the test body then bind
+  // the single remaining `$262` — the test's own, matching a real host where
+  // the test shadows the host object.
+  if (/\b(?:var|let|const)\s+\$262\b/.test(source)) {
+    const shim = cachedSource(RUNTIME_PATH);
+    const idx = prefix.indexOf(shim);
+    if (idx >= 0) {
+      const renamed = shim.replace(/\$262\b/g, () => "$26_");
+      prefix = prefix.slice(0, idx) + renamed + prefix.slice(idx + shim.length);
+    }
+  }
   return {
     source: prefix + source,
     bodyLineOffset: lineCount(prefix),


### PR DESCRIPTION
## Description

Follow-up slice of [#4626](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4626-standalone-harness-selftest-gaps) (after PR #4782 merged):

- **`tests/test262-original-harness.ts`** — fixes `harness/detachArrayBuffer-host-detachArrayBuffer.js` in **both lanes**: the runtime shim's `var $262 = {…}` collided with the one test262 file that declares its own `$262` override (the compiler gives duplicate top-level vars no last-assignment-wins semantics, so the test's detach-throws shim silently no-op'd). When the body declares `$262`, `assembleVariant` renames the shim part's occurrences in place — same byte length, line counts preserved, so `bodyLineOffset` stays exact. Exactly one test262 file declares its own `$262` (verified by repo-wide grep), so the blast radius is that one test.
- **Seven new issue files with implementation plans** for the remaining standalone `harness/` self-test gaps, ids allocated via `claim-issue.mjs`: [#4629](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4629-standalone-setmap-any-dispatch) Set/Map any-channel dispatch, [#4630](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4630-standalone-asynchelpers-thenables) asyncHelpers thenables, [#4631](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4631-standalone-bigint-carrier) standalone BigInt carrier, [#4632](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4632-standalone-symbol-array-elements) symbol[] element representation, [#4633](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4633-standalone-intrinsic-identity-runtime-eval) runtime-eval intrinsic identity, [#4634](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4634-realm-shim-nonshadowing-error-ctors) non-shadowing realm-shim error ctors, [#4635](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4635-standalone-ta-alias-array-arg-as-length) TA-alias array-arg-as-length residual. [#4626](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4626-standalone-harness-selftest-gaps)'s survey table now links to them.

**Verified**: `detachArrayBuffer-host-detachArrayBuffer.js` passes standalone AND js-host via `runTest262File`; the change is runner-only (no `src/` diff beyond the issue docs) and fires only when a test body declares `$262`.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uew3UBKiqutbucBdwA8pCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uew3UBKiqutbucBdwA8pCi)_