### PR TITLE
fix(ci): remove apostrophe that truncates the npm-compat sanity-check script (#4604 S8)

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -275,7 +275,7 @@ jobs:
               const entry = byName.get(pin.name);
               // A failed worker is carried forward from the last committed
               // snapshot. Its old test numbers are useful context, but they
-              // must not block publication or masquerade as this run's data.
+              // must not block publication or masquerade as data from this run.
               if (entry?.refresh?.status === "stale") continue;
               const tests = entry?.tests;
               if (!tests || typeof tests.passed !== "number" || typeof tests.total !== "number") {

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -173,6 +173,25 @@ same stale artifact.
   `expectedLateJsdomHostError` flag) into the report's `nativeHostErrors`
   instead of re-throwing — one stray callback now costs one report entry,
   never the whole measurement.
+- **S8: after S5–S7, every measure group succeeds — the coordinator itself
+  was broken.** Run 801 (id 32619275535, S7 merge commit) and run 805 (id
+  32624575420, a later commit) both show all 9 matrix groups green
+  (react-dom completing in 3h48m and 3h10m respectively, no timeout, no
+  crash), but the `refresh` coordinator job's "Sanity-check the generated
+  artifact" step fails on both: `[eval]:18 ... Expected '}', got '<eof>'`
+  from `node -e`. Root cause: `#4779` ("keep npm-compat refresh publishing
+  partial results") added a comment inside that step's inline
+  `node -e '...'` script — `// must not block publication or masquerade as
+  this run's data.` — whose apostrophe terminates the bash single-quoted
+  string wrapping the whole script. Everything after it, including the
+  rest of the validation logic and the closing quote, falls outside the
+  quoted argument node receives, so `node -e` gets a truncated script and
+  throws a `SyntaxError` before ever reading the artifact. Unrelated to
+  react-dom or timing — a plain bash-quoting bug that blocked every run
+  from publishing regardless of how clean the measurements were. Fixed by
+  rewording the comment to avoid the apostrophe; verified by extracting the
+  exact script bash constructs (`bash -n`) and running it against synthetic
+  data.
 
 ## Fix directions (pick during implementation)
 


### PR DESCRIPTION
## Problem

Every npm-compat refresh run since #4779 landed has failed at the coordinator's "Sanity-check the generated artifact" step, even though all 9 measure matrix groups succeed. Run 801 (id 32619275535, measuring the #4604 S7 merge commit) and run 805 (id 32624575420, measuring a later commit) both show the identical failure:

```
[eval]:18
    // must not block publication or masquerade as this runs

Expected '}', got '<eof>'
SyntaxError: Unexpected end of input
```

## Root cause

`#4779` ("keep npm-compat refresh publishing partial results") added a comment inside the sanity-check step's inline `node -e '...'` script:

```js
// must not block publication or masquerade as this run's data.
```

The apostrophe in `run's` terminates the bash single-quoted string that wraps the entire node script. Everything after it — the remaining ~15 lines of validation logic and the closing quote — is no longer part of the quoted argument bash passes to `node -e`; it gets word-split and dropped or misattached, and node receives a truncated script that fails to parse. This has nothing to do with react-dom or the #4604 S5–S7 timing fixes — it's a plain bash-quoting bug that blocks the coordinator from ever reaching the publish step, regardless of how clean the upstream measurements are.

## Fix

Reworded the comment to avoid the apostrophe (`"...masquerade as data from this run."`). Also swept the rest of the step and the file's other two `node -e '...'` inline scripts for any other embedded `'` characters — none found.

[#4604](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4604-npm-compat-refresh-runtime-exceeds-timeout) updated with the S8 forensics.

## Validation

- Extracted the exact script bash constructs from the step's `run: |` block (stripping YAML indentation) and ran `bash -n` against it — syntactically valid.
- Ran the extracted script against a synthetic `npm-compat.json` (22 packages, `tests: {passed,total}` present) and an empty upstream-sources pin list — printed `ok: 22 packages` and exited 0, confirming the node script itself is correct once bash stops truncating it.
- Prettier clean; loc/func-budget, oracle-ratchet, dead-export gate all clean (pre-commit hooks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8)_