### PR TITLE
docs(issues): file #4644, #4645, #4646 from the #4628 Temporal spike

### DIFF
--- a/plan/issues/4644-call-thunk-arity-shortfall-invalid-wasm.md
+++ b/plan/issues/4644-call-thunk-arity-shortfall-invalid-wasm.md
@@ -1,0 +1,93 @@
+---
+id: 4644
+title: "Compiler-emitted call thunks push one operand fewer than the callee's declared arity → invalid Wasm"
+status: ready
+sprint: current
+created: 2026-08-23
+updated: 2026-08-23
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen, calls
+language_feature: calls, varargs, toString
+goal: correctness
+related: [4628, 4627, 4645]
+---
+
+# #4644 — Call thunks push one operand fewer than the callee's declared arity
+
+## Problem
+
+A compiler-emitted call thunk sets up **N−1** operands for a callee declared
+with **N** parameters. The module compiles cleanly — `compile()` reports zero
+errors — and then `WebAssembly.compile()` rejects the binary.
+
+Found by the #4628 spike while compiling `@js-temporal/polyfill@0.5.1`: **5 of
+14 slices** emitted a binary the validator refuses. All five are the same
+family.
+
+| Count | Validator message | Callee |
+| --- | --- | --- |
+| 3 | `not enough arguments on the stack for local.set (need 1, got 0)` | `__class_call_formatToParts_vararg`, `__call_toString` ×2 |
+| 2 | `not enough arguments on the stack for call (need N, got N−1)` | `__call_toString` (need 2, got 1); `IslamicBaseHelper_estimateIsoDate` (need 5, got 4) |
+
+**Not Temporal-specific.** The polyfill is just the corpus that surfaced it.
+
+**Not the same bug as #4627**, despite sharing the validate gate. #4627 was a
+*type* mismatch on a `global.set` (f64 carrier, i32 value); this is an *arity*
+shortfall on a call. Fixing one does not fix the other — #4627's fix
+(`569d78f7`) is already on `main` and these still reproduce.
+
+## Why this matters beyond the polyfill
+
+`IslamicBaseHelper_estimateIsoDate` is an **ordinary user function**, not a
+synthesized thunk. The `__call_*` / `__class_call_*` naming on the other four
+suggests a thunk-synthesis bug, but that fifth sample says the shortfall
+reaches plain calls too — so the blast radius is wider than the names imply.
+Establish which of the two it actually is before scoping a fix.
+
+This class of defect is also **silent by construction**: `compile()` returns
+success, so nothing upstream of `WebAssembly.compile()` notices. Any corpus
+that is compiled but never instantiated will report it as a clean pass.
+
+## Reproduce
+
+```bash
+DOGFOOD_TEMPORAL_POLYFILL=1 node node_modules/vitest/dist/cli.js run \
+  tests/dogfood/temporal-polyfill.test.ts
+```
+
+The harness (`tests/dogfood/temporal-polyfill-harness.mjs`, landed by #4628 /
+PR #4789) pins `@js-temporal/polyfill@0.5.1` + `jsbi@4.3.0`, links them, and
+compiles in slices. The five failing slices are reported individually with the
+validator's message and the offending function name.
+
+## Investigation entry points
+
+- `__call_toString` accounts for three of the five — start there; a
+  `toString` thunk is synthesized in a small number of places and the
+  divergence should be visible by inspection.
+- `__class_call_formatToParts_vararg` is the **vararg** thunk path, and the
+  vararg spread is a plausible place to lose exactly one operand (the
+  count/array pair, or a receiver).
+- `local.set (need 1, got 0)` vs `call (need N, got N−1)` may be the same
+  producer failing at two different consumption points, or two bugs. Decide
+  which before fixing — three of one and two of the other is not obviously one
+  root cause.
+
+## Acceptance criteria
+
+1. All 14 slices of the polyfill harness pass `WebAssembly.validate()`.
+2. A regression test under `tests/` for each distinct root cause found (one if
+   the two message shapes share a producer, two if they don't).
+3. No net regression on the test262 baseline.
+4. If any of the five turns out to need a separate fix that is out of scope,
+   file it and say so — do not leave a slice silently failing.
+
+## Notes
+
+Blocks the Option A path in #4628 (compiling the polyfill as the runtime
+`Temporal` implementation). #4628's decision was "keep Option A, but the CE
+count is not the binding constraint — these two compiler bugs are."

--- a/plan/issues/4645-superlinear-compile-time-large-modules.md
+++ b/plan/issues/4645-superlinear-compile-time-large-modules.md
@@ -1,0 +1,109 @@
+---
+id: 4645
+title: "Compile time goes superlinear past ~100 KB — 157 KB module does not terminate in 45 min"
+status: ready
+sprint: current
+created: 2026-08-23
+updated: 2026-08-23
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen, performance
+goal: dogfood
+related: [4628, 4644]
+---
+
+# #4645 — Compile time goes superlinear past ~100 KB
+
+## Problem
+
+Compiling a single large module stops terminating. Measured on the linked
+`@js-temporal/polyfill@0.5.1` + `jsbi@4.3.0` bundle during the #4628 spike, on
+prefixes cut at top-level statement boundaries (every prefix compiles with
+**zero** errors — this is purely a time curve, not a correctness cliff):
+
+| Input size | Compile time |
+| --- | --- |
+| 39 KB | 9.1 s |
+| 49 KB | 8.4 s |
+| 60 KB | 10.1 s |
+| 69 KB | 11.7 s |
+| 83 KB | 18.2 s |
+| 106 KB | 52.6 s |
+| ~138 KB | **killed at 38 min** |
+| 157 KB | **killed at 45 min** |
+
+The same 342 top-level statements, compiled as 14 separate slices, sum to
+**~24 s**. So the work itself is cheap; something is superlinear in
+whole-module size.
+
+## Where the time goes
+
+`JS2WASM_COMPILE_PROFILE=stream` on the 157 KB run:
+
+- `module-init-pass1` — 3.50 s
+- `module-init-pass2` — 1.77 s
+- heap ~297 MB at that point
+- then **no phase marker closes for the remaining ~44 minutes**
+- steady 100 % of one core, RSS flat at ~600 MB
+
+Flat RSS with pinned CPU rules out a memory blowup or GC thrash — it is
+CPU-bound in per-function codegen, after module-init. The profiler's markers
+are too coarse past module-init to narrow it further, which is itself worth
+fixing: **the profile cannot currently attribute 98 % of a pathological
+compile.**
+
+## Suggested approach
+
+1. **Get attribution first.** Add per-function (or at least per-phase) markers
+   to the post-module-init codegen path in `src/compile-profile.ts` so the
+   44-minute window resolves into something. Without this, any fix is guessed.
+   A cheaper interim: attach a sampling profiler (`node --cpu-prof`) to the
+   106 KB case — 52.6 s is long enough to sample and short enough to finish.
+2. **Suspect anything keyed by a whole-module collection** that is rescanned
+   per function — a linear scan inside a per-function loop is the classic
+   shape for "fine in slices, quadratic whole". The slice-vs-whole gap
+   (~24 s vs ≥45 min for identical statements) points hard at cross-function
+   state rather than at any single function's complexity.
+3. **Set a regression floor** once fixed, so this cannot silently return.
+
+## Why this matters
+
+- **Blocks Option A in #4628** — compiling `@js-temporal/polyfill` as the
+  runtime `Temporal` implementation requires compiling the whole bundle, which
+  currently does not finish.
+- **Blocks dogfooding generally.** 157 KB is not a large JavaScript module by
+  modern standards. The `tests/dogfood/` catalog compiles real npm packages,
+  and the UMD lane of the polyfill (242 KB) was not even attempted because it
+  is further past the cliff.
+- Per `tests/dogfood/README.md`, a compile timeout is an unverified workload,
+  never a pass — so this converts silently into missing coverage rather than
+  into a visible failure.
+
+## Reproduce
+
+```bash
+DOGFOOD_TEMPORAL_POLYFILL=1 node node_modules/vitest/dist/cli.js run \
+  tests/dogfood/temporal-polyfill.test.ts
+```
+
+Harness from #4628 / PR #4789. It compiles both whole-bundle and sliced lanes;
+the whole-bundle lane is the one that hangs. Prefix cutting at statement
+boundaries is how the curve above was produced — reuse it to bisect the cliff.
+
+## Acceptance criteria
+
+1. The 157 KB linked bundle compiles to completion, with the time recorded.
+2. The scaling curve above is re-measured and is no longer superlinear — state
+   the new numbers against the old ones.
+3. Whatever the root cause, the profiler can attribute it: a repeat of this
+   investigation should not start with "no phase closes for 44 minutes".
+4. A guard so the cliff cannot silently return.
+
+## Notes
+
+Do not treat "it finished in 40 minutes instead of 45" as fixed. The target is
+the shape of the curve, not one data point — the sliced ~24 s is the evidence
+that near-linear is achievable.

--- a/plan/issues/4646-structmap-class-name-keying-shared-body.md
+++ b/plan/issues/4646-structmap-class-name-keying-shared-body.md
@@ -83,8 +83,42 @@ working.
    the wrong constructor, so tests depending on them may flip in either
    direction. Investigate any flip rather than assuming it is noise.
 
+## Measured test262 impact — 45 files, all currently dead
+
+Measured 2026-08-23 against a `tc39/test262` sparse checkout at tip-of-main
+(53,872 test files) joined to `test262-current.jsonl`.
+
+**No test calls any of the five helpers directly.** They are reached only
+through two public entry points:
+
+| Entry point | Fans out to | Test files |
+| --- | --- | --- |
+| `TemporalHelpers.checkSubclassingIgnored` | `checkSubclassConstructorUndefined`, `checkSubclassConstructorNotCalled`, `checkSubclassSpeciesNull`, `checkSubclassSpeciesUndefined` | 35 |
+| `TemporalHelpers.checkSubclassingIgnoredStatic` | `checkThisValueNotCalled` | 10 |
+| **union** | | **45** |
+
+All 45 are `*/subclassing-ignored.js` under `test/built-ins/Temporal/**`. All 45
+are present in the baseline, and **all 45 currently report `compile_error`**
+with the invalid-Wasm signature from #4627 — none of them reaches its test body
+today.
+
+So the blast radius is bounded at 45 tests, and **the flip risk is one-way**:
+nothing here can regress from `pass`, because nothing here passes. Once #4627's
+fix (`569d78f7`) propagates into the baseline these 45 become the population
+where this defect is first observable — five helpers sharing one compiled class
+body is exactly what `subclassing-ignored.js` tests are written to detect, so
+expect some of them to fail on substance rather than pass outright.
+
+Two caveats on the measurement:
+
+- Taken against **tip-of-main** test262 while the project pins a revision. The
+  helper call graph is stable, but re-confirm the file count against the pinned
+  submodule before quoting 45 as a target.
+- Taken against a **pre-#4627** baseline, which is why all 45 read as
+  `compile_error`. Re-measure after that fix lands to get the real starting
+  point.
+
 ## Notes
 
-The test262 impact is not estimated. Five harness helpers are affected and they
-are used across the Temporal suite, but how many tests observe the difference
-is unmeasured — do not quote a number that has not been measured.
+Do not quote a pass-count target for this issue. 45 is the number of tests that
+can *observe* the defect, not the number that will pass once it is fixed.

--- a/plan/issues/4646-structmap-class-name-keying-shared-body.md
+++ b/plan/issues/4646-structmap-class-name-keying-shared-body.md
@@ -1,0 +1,90 @@
+---
+id: 4646
+title: "structMap keyed by class NAME — same-named classes in different functions share one compiled body (silent wrong behaviour)"
+status: ready
+sprint: current
+created: 2026-08-23
+updated: 2026-08-23
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen, classes
+language_feature: classes, closures
+goal: correctness
+related: [4627, 4616, 4618]
+---
+
+# #4646 — `structMap` keyed by class NAME, so same-named classes share one body
+
+## Problem
+
+Two class declarations with the **same name** in **different functions** are
+distinct classes with distinct bodies. The compiler keys `ctx.structMap` by
+class name, so the second declaration reuses the first one's compiled body.
+Every call to the second class runs the first class's code.
+
+This produces **no invalid Wasm and no compile error**. It is a silent
+wrong-behaviour bug, which is why nothing has caught it.
+
+## Concrete instance
+
+`test262`'s `harness/temporalHelpers.js` declares `class MySubclass` in **five**
+separate helper functions:
+
+- `checkSubclassConstructorUndefined`
+- `checkSubclassConstructorNotCalled`
+- `checkSubclassSpeciesNull`
+- `checkSubclassSpeciesUndefined`
+- `checkThisValueNotCalled`
+
+All five share the first one's compiled class body. So
+`checkThisValueNotCalled`'s subclass constructor — which the source writes as
+`called = true` — actually executes the **first** helper's constructor, which
+does `++called`. The helper's own assertion (`assert.sameValue(called, false)`)
+is therefore checking a value produced by code it never wrote.
+
+## Relationship to #4627 — same key, different map
+
+`569d78f7` (#4616/#4618) fixed exactly this keying mistake in
+**`classMemberCaptureGlobals`**, re-keying it from class name to the `ts.Node`
+declaration. That healed the *capture-global* cross-wiring, which was
+producing invalid Wasm (`global.set expected f64, found i32` — #4627).
+
+**`structMap` was not re-keyed and still uses the class name.** So the same
+collapse persists one layer down, minus the crash that made the first one
+visible. Found while instrumenting #4627; deliberately left out of scope there
+because it is an independent defect with a different failure mode.
+
+## Suggested approach
+
+Mirror `569d78f7`'s fix: key `ctx.structMap` (and audit any sibling map keyed
+the same way) by the declaration node rather than the name. Check for other
+name-keyed class state at the same time — this is now the second instance of
+the pattern, so a sweep is likely cheaper than a third round-trip.
+
+Watch for the synthetic-name path: class **expressions** are collected under a
+synthetic name (see `src/codegen/statements/nested-declarations.ts`, the
+`structMap.has(syntheticName)` branch), so the keying change has to keep that
+working.
+
+## Acceptance criteria
+
+1. Two same-named classes declared in different functions compile to distinct
+   bodies, and each behaves per its own source.
+2. A regression test under `tests/` in the shape that actually occurs: two
+   functions, each declaring `class MySubclass`, with **different** constructor
+   bodies, asserting each runs its own.
+3. A sweep for other class-name-keyed compiler state, with findings recorded
+   even if nothing else turns up.
+4. No net regression on the test262 baseline. Note that this may *change*
+   results in `test/built-ins/Temporal/**` — those five helpers currently run
+   the wrong constructor, so tests depending on them may flip in either
+   direction. Investigate any flip rather than assuming it is noise.
+
+## Notes
+
+The test262 impact is not estimated. Five harness helpers are affected and they
+are used across the Temporal suite, but how many tests observe the difference
+is unmeasured — do not quote a number that has not been measured.


### PR DESCRIPTION
Docs-only. Three issue files, no `src/` change.

All three are **generic compiler defects** surfaced while compiling `@js-temporal/polyfill` for the [#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-runtime-object-spike) spike — not Temporal work. The first two are what actually block the Option A path that spike recommends; its CE count was **0**, so the compile gate was never the constraint.

## [#4644](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4644-call-thunk-arity-shortfall-invalid-wasm) — call thunks push one operand short

5 of 14 polyfill slices emit a binary `WebAssembly.compile()` rejects while `compile()` reports zero errors.

| Count | Validator message | Callee |
| --- | --- | --- |
| 3 | `not enough arguments on the stack for local.set (need 1, got 0)` | `__class_call_formatToParts_vararg`, `__call_toString` ×2 |
| 2 | `not enough arguments on the stack for call (need N, got N−1)` | `__call_toString` (need 2, got 1); `IslamicBaseHelper_estimateIsoDate` (need 5, got 4) |

The `__call_*` naming suggests a thunk-synthesis bug, but `IslamicBaseHelper_estimateIsoDate` is an ordinary user function — so the blast radius is wider than the names imply. Distinct from [#4627](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4627-temporal-harness-global-set-i32-f64): that was a *type* mismatch on `global.set`, this is an *arity* shortfall on a call, and `569d78f7` does not fix it.

## [#4645](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4645-superlinear-compile-time-large-modules) — compile time superlinear past ~100 KB

| Input | Time |
| --- | --- |
| 106 KB | 52.6 s |
| ~138 KB | killed at 38 min |
| 157 KB | killed at 45 min |

The same 342 statements compiled as 14 slices sum to **~24 s**. Profile: `module-init` closes in ~5 s, then no phase marker closes for the remaining ~44 min at a steady 100 % of one core with RSS flat at 600 MB — CPU-bound in per-function codegen, and unattributable with the current markers. The slice-vs-whole gap points at cross-function state rather than any one function's complexity.

157 KB is not a large module; this blocks dogfooding generally, not just the polyfill.

## [#4646](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4646-structmap-class-name-keying-shared-body) — `structMap` keyed by class name

`569d78f7` re-keyed `classMemberCaptureGlobals` from class name to declaration node, healing the invalid-Wasm symptom behind [#4627](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4627-temporal-harness-global-set-i32-f64). **`structMap` kept the name key**, so the same collapse persists one layer down — minus the crash that made the first one visible.

`temporalHelpers.js` declares `class MySubclass` in five separate helpers; they share one compiled body, so `checkThisValueNotCalled`'s constructor actually runs the first helper's `++called` rather than its own `called = true`. Produces no invalid Wasm and no compile error.

### Blast radius measured — 45 files, all currently dead

No test calls the five helpers directly; they are reached through two entry points:

| Entry point | Fans out to | Files |
| --- | --- | --- |
| `checkSubclassingIgnored` | the four `checkSubclass*` helpers | 35 |
| `checkSubclassingIgnoredStatic` | `checkThisValueNotCalled` | 10 |
| **union** | | **45** |

All 45 are `*/subclassing-ignored.js` under `built-ins/Temporal/**`, all present in the baseline, and **all 45 currently report `compile_error`** with the #4627 signature. The flip risk is one-way — nothing here can regress from `pass`, because nothing here passes.

Measured against a tip-of-main `tc39/test262` checkout (53,872 test files) while the project pins a revision, and against a pre-#4627 baseline. Both caveats are recorded in the issue; 45 is the number of tests that can *observe* the defect, not a pass-count target.

## Note on this branch

Force-updated onto current `main`. It previously carried the [#4627](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4627-temporal-harness-global-set-i32-f64) and [#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-runtime-object-spike) issue files, which now reach `main` through #4788 and #4789 in richer form (444 vs 331 and 490 vs 292 lines). Keeping them here would have collided with both PRs on the same files and gained nothing.