### PR TITLE
ci(npm-compat-refresh): move the artifact sanity check out of inline node -e into scripts/

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -255,38 +255,12 @@ jobs:
       # Refuse to publish an empty or truncated artifact. A generator that exits
       # 0 having written nothing useful would otherwise blank the dashboard, and
       # the page has no other source of truth to fall back on.
+      # The check itself lives in scripts/check-npm-compat-artifact.mjs, NOT
+      # inline: an inline single-quoted `node -e` script is invisible to every
+      # lint/syntax gate, and one apostrophe in a JS comment truncated it and
+      # silently blocked ALL promotions for 6 hours on 2026-08-23 (#4604 S8).
       - name: Sanity-check the generated artifact
-        run: |
-          set -euo pipefail
-          node -e '
-            const fs = require("fs");
-            const path = "benchmarks/results/npm-compat.json";
-            const report = JSON.parse(fs.readFileSync(path, "utf8"));
-            const packages = report.packages ?? report;
-            if (!Array.isArray(packages) || packages.length < 20) {
-              throw new Error(`${path} has ${packages?.length ?? "no"} packages; refusing to publish`);
-            }
-            if (!packages.every((entry) => entry.name && entry.compile)) {
-              throw new Error(`${path} has entries missing name/compile; refusing to publish`);
-            }
-            const byName = new Map(packages.map(entry => [entry.name, entry]));
-            const suitePins = JSON.parse(fs.readFileSync("tests/dogfood/npm-compat-upstream-sources.json", "utf8"));
-            for (const pin of suitePins.filter(entry => entry.suiteScript)) {
-              const entry = byName.get(pin.name);
-              // A failed worker is carried forward from the last committed
-              // snapshot. Its old test numbers are useful context, but they
-              // must not block publication or masquerade as data from this run.
-              if (entry?.refresh?.status === "stale") continue;
-              const tests = entry?.tests;
-              if (!tests || typeof tests.passed !== "number" || typeof tests.total !== "number") {
-                throw new Error(`${pin.name} has ${pin.suiteScript} but its unit-test result is absent from ${path}`);
-              }
-              if (tests.status === "not-integrated") {
-                throw new Error(`${pin.name} still reports adapter pending despite ${pin.suiteScript}`);
-              }
-            }
-            console.log(`ok: ${packages.length} packages`);
-          '
+        run: node scripts/check-npm-compat-artifact.mjs
 
       # (2026-08-09, stakeholder) A DEFERRED run's measurement must never be
       # LOST. On 2026-08-09 two successful runs — including the one measuring

--- a/scripts/check-npm-compat-artifact.mjs
+++ b/scripts/check-npm-compat-artifact.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Sanity-check the assembled npm-compat artifact before promotion.
+//
+// This logic used to live INLINE in npm-compat-refresh.yml as a single-quoted
+// `node -e '…'` block. A JS comment containing an apostrophe ("this run's
+// data", added 2026-08-23 in dae19f63) terminated the bash string, so node
+// received a truncated program and every coordinator run from 04:53Z to the
+// 10:17Z reword failed at this step with `SyntaxError: Unexpected end of
+// input` — promotion skipped every time and the npm-compat page served a
+// three-day-old artifact. No gate saw it: the workflow is not a required
+// check, and an inline script is invisible to biome/prettier/node --check.
+// Living here, the script is covered by the repo's normal lint surface and
+// the quoting class is structurally gone. (#4604 S8 follow-up)
+//
+// Exit 0 = safe to publish. Exit 1 = refuse (the reason is the thrown error).
+
+import { readFileSync } from "node:fs";
+
+const path = process.argv[2] ?? "benchmarks/results/npm-compat.json";
+const pinsPath = process.argv[3] ?? "tests/dogfood/npm-compat-upstream-sources.json";
+
+const report = JSON.parse(readFileSync(path, "utf8"));
+const packages = report.packages ?? report;
+if (!Array.isArray(packages) || packages.length < 20) {
+  throw new Error(`${path} has ${packages?.length ?? "no"} packages; refusing to publish`);
+}
+if (!packages.every((entry) => entry.name && entry.compile)) {
+  throw new Error(`${path} has entries missing name/compile; refusing to publish`);
+}
+
+const byName = new Map(packages.map((entry) => [entry.name, entry]));
+const suitePins = JSON.parse(readFileSync(pinsPath, "utf8"));
+for (const pin of suitePins.filter((entry) => entry.suiteScript)) {
+  const entry = byName.get(pin.name);
+  // A failed worker is carried forward from the last committed snapshot. Its
+  // old test numbers are useful context, but they must not block publication
+  // or masquerade as data from this run.
+  if (entry?.refresh?.status === "stale") continue;
+  const tests = entry?.tests;
+  if (!tests || typeof tests.passed !== "number" || typeof tests.total !== "number") {
+    throw new Error(`${pin.name} has ${pin.suiteScript} but its unit-test result is absent from ${path}`);
+  }
+  if (tests.status === "not-integrated") {
+    throw new Error(`${pin.name} still reports adapter pending despite ${pin.suiteScript}`);
+  }
+}
+
+console.log(`ok: ${packages.length} packages`);


### PR DESCRIPTION
## Description

Removes the failure **class** behind the 3-day-stale npm-compat page ([#4604](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4604-react-dom-upstream-suite-hang) S8 follow-up).

The coordinator's artifact sanity check lived in the workflow as a single-quoted `node -e '…'` block — invisible to biome/prettier/`node --check`. One apostrophe in a JS comment ("this run's data", `dae19f63`) terminated the bash string, node received a truncated program, and every coordinator run from 04:53Z to the 10:17Z reword (`343c906f`) failed at the sanity step with `SyntaxError: Unexpected end of input` — all promotion steps skipped each time, with no red gate anywhere (the workflow isn't a required check and the measure rows kept succeeding).

`343c906f` removed the apostrophe; this PR removes the class: the identical logic (≥20 packages, name/compile presence, suite-pin unit-test presence with the stale-carry-forward exemption) now lives in `scripts/check-npm-compat-artifact.mjs`, covered by the repo's normal lint/syntax surface, with artifact + pins paths as optional argv for local runs. The workflow step becomes a one-liner.

Verified: passes against the committed artifact (`ok: 24 packages`), refuses a truncated one, `node --check` + biome green, workflow YAML parses.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ)_