### PR TITLE
fix(#4634): drop the realm shim's Object forward — restores dynamic-import import-meta pass

### DIFF
--- a/plan/issues/4634-realm-shim-nonshadowing-error-ctors.md
+++ b/plan/issues/4634-realm-shim-nonshadowing-error-ctors.md
@@ -12,6 +12,26 @@ task_type: bug
 area: testing
 goal: test262-conformance
 lane: B
+trap-growth-allow:
+  count: 16
+  reason: "#4634 realm shim: createRealm().global is now a narrowed forwarding object instead of the real globalThis, so 16 cross-realm tests that were ALREADY failing (all baseline fail) reach their failure differently — property reads/calls on the realm object (e.g. other.eval(...) via the any-channel call path) answer null and null-deref instead of failing an assertion. Failure-flavour reclassification only; no baseline-pass test traps. The underlying any-channel call gap is compiler territory tracked by the standalone realm work, not widened here."
+  tests:
+    - test/built-ins/AsyncFunction/proto-from-ctor-realm.js
+    - test/built-ins/AsyncGeneratorFunction/proto-from-ctor-realm-prototype.js
+    - test/built-ins/AsyncGeneratorFunction/proto-from-ctor-realm.js
+    - test/built-ins/Function/internals/Call/class-ctor-realm.js
+    - test/built-ins/Function/internals/Construct/derived-return-val-realm.js
+    - test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js
+    - test/built-ins/GeneratorFunction/proto-from-ctor-realm-prototype.js
+    - test/built-ins/GeneratorFunction/proto-from-ctor-realm.js
+    - test/built-ins/Proxy/apply/arguments-realm.js
+    - test/built-ins/Proxy/construct/arguments-realm.js
+    - test/language/eval-code/indirect/realm.js
+    - test/language/expressions/async-generator/eval-body-proto-realm.js
+    - test/language/expressions/generators/eval-body-proto-realm.js
+    - test/language/expressions/tagged-template/cache-realm.js
+    - test/language/types/reference/get-value-prop-base-primitive-realm.js
+    - test/language/types/reference/put-value-prop-base-primitive-realm.js
 files:
   - tests/test262-runner.ts
 ---

--- a/scripts/test262-fyi-runtime.js
+++ b/scripts/test262-fyi-runtime.js
@@ -40,7 +40,16 @@ var $262 = {
       Function: globalThis.Function,
       Iterator: globalThis.Iterator,
       Math: globalThis.Math,
-      Object: globalThis.Object,
+      // NO `Object: globalThis.Object` forward — measured 2026-08-23 (PR
+      // #4794 merge_group park): ANY compiled read of `globalThis.Object` /
+      // `globalThis["Object"]` in this prelude (which compiles into EVERY
+      // test) changes how js-host dynamic `import()` rejections construct
+      // their error — `error.constructor` degrades TypeError → Error,
+      // regressing test/language/expressions/dynamic-import/
+      // assignment-expression/import-meta.js from pass. Isolated by shim
+      // bisection: dropping ONLY this entry restores the pass; every other
+      // forward is inert. Re-add only together with a compiler-side fix and
+      // that test in the validation list.
       Proxy: globalThis.Proxy,
       Symbol: globalThis.Symbol,
       eval: globalThis.eval,


### PR DESCRIPTION
## Description

PR #4794's merge_group run surfaced a pass→fail regression that is now baselined on main: `test/language/expressions/dynamic-import/assignment-expression/import-meta.js`. Shim bisection isolated the cause to a single entry in the new `createRealm()` forwarding global — `Object: globalThis.Object`. Any compiled read of `globalThis.Object` (member or element access) in the `$262` prelude, which compiles into every test, degrades the js-host dynamic `import()` rejection error from `TypeError` to `Error`. Every other forward is inert (A/B measured per entry).

This drops only that entry, with an explanatory comment, and restores the pass. The compiler-side root cause (why a `globalThis.Object` read perturbs the import() rejection path) is left documented in [#4634](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4634-realm-shim-nonshadowing-error-ctors), which also carries a named `trap-growth-allow` declaration for the 16 baseline-fail cross-realm tests whose failure changed flavour to null_deref under the narrowed realm global (inert now that those are baselined; kept as documentation and as protection if a baseline refresh races this PR).

**Verified**: `import-meta.js` js-host fail→pass; full standalone harness category 112/116 (unchanged); full js-host harness category 102/116 (unchanged); the 8 baseline-pass createRealm standalone tests 8/8.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uew3UBKiqutbucBdwA8pCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uew3UBKiqutbucBdwA8pCi)_