### PR TITLE
npm-compat: per-package freshness, two virtual-dispatch validity fixes, and react-dom unblocked

### DIFF
--- a/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
@@ -805,5 +805,26 @@ Two independent directions, either of which unblocks the card:
    the same statements at top level. That is worth knowing regardless of
    react-dom — every CJS package in the corpus is compiled through a wrapper.
 
-Not yet attempted: neither of these is implemented. The measurement is
-reproducible with `.tmp/rd-wrap.mjs` (top-level vs wrapped, same bytes).
+**Direction 1 is now implemented.** `compileImplementationOnly` builds the
+project files (`buildProjectFiles(…, { tests: [] })`) and goes through
+`compileProjectInWorker`, the same path the per-batch lane uses.
+
+Measured end to end on the pinned sources (react 17 KB, shared 6.6 KB, client
+536 KB):
+
+| probe shape                                    | result                                   |
+| ---------------------------------------------- | ---------------------------------------- |
+| `buildImplementationSource` (4 function wrappers) | 300 s TIMEOUT, no module, card `blocked` |
+| `buildProjectFiles` (real modules)              | **96.8 s, success, `validates: true`, 2.25 MB** |
+
+So the implementation is not "too big to compile" and never was — it compiles
+and validates in under two minutes once it is not wrapped. The card's
+`tests.status: "blocked"` / 0-of-1,261 line was an artifact of the probe's
+shape, not a statement about react-dom.
+
+Direction 2 (why a function body costs 2.4× and emits 30% more than the same
+statements at top level) is still open, and still worth doing: every CJS
+package in the corpus is compiled through a wrapper somewhere.
+
+The wrapping measurement is reproducible with `.tmp/rd-wrap.mjs` (top-level vs
+wrapped, same bytes); the probe comparison with `.tmp/rd-probe-time.mjs`.

--- a/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
@@ -828,3 +828,46 @@ package in the corpus is compiled through a wrapper somewhere.
 
 The wrapping measurement is reproducible with `.tmp/rd-wrap.mjs` (top-level vs
 wrapped, same bytes); the probe comparison with `.tmp/rd-probe-time.mjs`.
+
+## Lever 2: the project lane recompiles the implementation once PER BATCH (2026-08-23)
+
+SPECIFIED, NOT IMPLEMENTED. Recording the measurement and the design so the
+next attempt starts from evidence rather than from the same guess.
+
+`partitionProjectTests` partitions BY UPSTREAM FILE first and only then splits
+anything oversized (`maxChars = 800_000`). There are 115 test files, so there
+are at least 115 batches, and the 800 KB cap is almost never the binding
+constraint. Every batch compiles the whole project — `react.ts`, `scheduler.ts`,
+`shared.ts` and the 525 KB `client.ts` — plus its own entry.
+
+Measured cost of a batch carrying ZERO tests: **102 s** (success, validates,
+2.25 MB). That is the floor each batch pays before a single test body is
+compiled. At 115 batches over the pinned 2-worker pool that is roughly
+**98 minutes of pure implementation recompilation**, which is most of the row's
+3-4 hour wall clock.
+
+The clean fix is separate compilation: compile the implementation once and link
+each file's test module against it. The compiler has no module-linking story
+today, so that is a large piece of work, not a harness tweak.
+
+The cheap approximation is to **pack by size instead of by file**: fill each
+batch to `maxChars` across several upstream files rather than starting a new
+batch per file. Ten files per batch turns ~115 batches into ~12 and should cut
+the row by roughly the same factor, since the per-batch cost is dominated by a
+constant.
+
+Two things that fix does NOT get for free, and which is why it is not landed
+here:
+
+1. **Lifecycle isolation.** The current partition keeps each file's Jest-style
+   `beforeEach`/`afterEach` together deliberately. Co-locating several files in
+   one module has to keep each file's lifecycle scoped to its own tests or
+   results silently change.
+2. **Blast radius.** One invalid function currently poisons one file's binary.
+   At ten files per batch it poisons ten. The halving-retry recovers, but the
+   retry is exactly the cost being optimised away, so a batch that fails
+   validation could end up slower than today.
+
+Neither can be judged from a unit test: it needs a full react-dom row (3-4 h)
+before and after, comparing wall clock AND the admitted/passed denominators.
+Do not land it on a green harness test alone.

--- a/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
@@ -767,3 +767,43 @@ pool, and the upstream suite harness tests remain green.
 
 Implementation: [PR #4771](https://github.com/loopdive/js2/pull/4771), stacked
 on the compiler boundary work in [PR #4769](https://github.com/loopdive/js2/pull/4769).
+
+## Where the 300s implementation-compile timeout actually goes (2026-08-23)
+
+`compileImplementationOnly` times out at 300s and the card reports
+`tests.status: "blocked"` with 0 of 1,261 admitted tests executed in Wasm. The
+obvious reading — "a 536 KB module is simply too big" — is wrong, and the
+measurement says so:
+
+| what                                                   | compile | emitted   |
+| ------------------------------------------------------ | ------- | --------- |
+| `react-dom-client.production.js`, TOP LEVEL             | 35.4 s  | 1.36 MB   |
+| the SAME bytes wrapped in `function __mod() { … }`      | 84.4 s  | 1.77 MB   |
+
+**2.4× the time and 30% more code for identical source, purely from being
+inside a function body.** That is the multiplier, not a pathological pass: the
+top-level compile of the whole published file finishes in half a minute.
+
+It matters here because `buildImplementationSource` wraps FOUR modules that way
+— `__reactModule`, `__schedulerModule`, `__reactDomSharedModule`,
+`__reactDomClientModule` — to emulate CJS scoping. The client module alone is
+84 s under that shape; with the other three plus `wireRequires` the assembly
+reaches the 300 s ceiling.
+
+Scaling for reference (top level, production build): 214 KB → 10.5 s,
+536 KB → 35.4 s. Mildly superlinear, nothing like the wrapping penalty.
+
+Two independent directions, either of which unblocks the card:
+
+1. **Harness.** Stop emulating CJS with a function wrapper for the
+   implementation-only compile. The harness ALREADY has the better shape —
+   `buildProjectFiles` emits real `react.ts` / `shared.ts` / `scheduler.ts` /
+   `client.ts` modules for the per-batch test lane. Routing
+   `compileImplementationOnly` through `compileProject` the same way should
+   drop it to roughly the top-level cost.
+2. **Compiler.** Find why a function body costs 2.4× and emits 30% more than
+   the same statements at top level. That is worth knowing regardless of
+   react-dom — every CJS package in the corpus is compiled through a wrapper.
+
+Not yet attempted: neither of these is implemented. The measurement is
+reproducible with `.tmp/rd-wrap.mjs` (top-level vs wrapped, same bytes).

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -2273,7 +2273,22 @@ async function buildPackageEntry({
   };
 }
 
-const packages = [];
+// Every row records WHEN ITS OWN measurement finished, not when the run
+// ended. Packages are measured in independent CI rows now (one per package,
+// see npm-compat-refresh.yml), so a single run-level timestamp would describe
+// a moment that applies to no package in particular — and on the dashboard it
+// read as "everything here was measured at 15:27" while react-dom's numbers
+// were three days old. `measuredAt` is the per-package truth the page renders;
+// the summary's `generatedAt` stays what it always was (when this artifact was
+// assembled) and is still what the promotion freshness compare comes down to.
+class MeasuredPackageList extends Array {
+  push(...rows) {
+    const measuredAt = new Date().toISOString();
+    return super.push(...rows.map((row) => (row?.measuredAt ? row : { ...row, measuredAt })));
+  }
+}
+
+const packages = new MeasuredPackageList();
 
 if (perfOnly) {
   const name = [...selectedPackages][0];
@@ -3029,8 +3044,19 @@ packages.sort(
     (right.weeklyDownloads ?? Number.NEGATIVE_INFINITY) - (left.weeklyDownloads ?? Number.NEGATIVE_INFINITY) ||
     left.name.localeCompare(right.name),
 );
+const measuredAtStamps = packages.map((packageRow) => packageRow.measuredAt).filter(Boolean);
 const summary = {
   generatedAt: new Date().toISOString(),
+  // The spread of per-package measurement times (see MeasuredPackageList).
+  // The dashboard headline is built from this rather than `generatedAt`, so a
+  // corpus whose oldest and newest numbers are days apart says so.
+  measuredRange:
+    measuredAtStamps.length > 0
+      ? {
+          oldest: measuredAtStamps.reduce((left, right) => (left < right ? left : right)),
+          newest: measuredAtStamps.reduce((left, right) => (left > right ? left : right)),
+        }
+      : null,
   // (#4127) How much of the corpus carries correctness evidence at all. The
   // `unverified` list is named, not just counted, so the size of the blind spot
   // is legible rather than implied.

--- a/scripts/lib/npm-compat-partials.mjs
+++ b/scripts/lib/npm-compat-partials.mjs
@@ -70,13 +70,32 @@ export function mergeNpmCompatPartials(
   const stalePackages = [];
   for (const name of allowStaleFallback ? [...expected].filter((candidate) => !seen.has(candidate)) : []) {
     const previous = existingByName.get(name);
+    // A carried-forward row keeps ITS OWN measurement time. Deriving it from
+    // the previous SNAPSHOT's `generatedAt` (what this did until 2026-08-23)
+    // makes the reported date creep forward one refresh at a time: a package
+    // stale across five promotions would claim it was measured at the fifth,
+    // having actually run before the first. With the fast lane promoting every
+    // ~12 minutes and react-dom's row taking 3-4 hours, that drift is the
+    // normal case, not an edge one.
+    //
+    // For rows written before `measuredAt` existed, migrate from the truth the
+    // old shape DID carry: a row already marked stale records its real date in
+    // `refresh.lastMeasuredAt`. Reaching past that to `existingGeneratedAt`
+    // would commit the creep once, permanently — against the live 2026-08-23
+    // artifact it restamped react-dom from its true 08-20 18:44 to the 15:27
+    // snapshot, and no later run could recover the real date. The snapshot
+    // time is right only for a row that has never been stale, which is exactly
+    // the case where neither of the first two is present.
+    const previouslyMeasuredAt =
+      previous?.measuredAt ?? previous?.refresh?.lastMeasuredAt ?? existingGeneratedAt ?? null;
     const packageRow = previous
       ? {
           ...previous,
+          ...(previouslyMeasuredAt ? { measuredAt: previouslyMeasuredAt } : {}),
           refresh: {
             status: "stale",
             reason: staleReason,
-            ...(existingGeneratedAt ? { lastMeasuredAt: existingGeneratedAt } : {}),
+            ...(previouslyMeasuredAt ? { lastMeasuredAt: previouslyMeasuredAt } : {}),
           },
         }
       : {
@@ -114,10 +133,26 @@ export function mergeNpmCompatPartials(
   }
 
   const firstMeta = partials.find((partial) => partial.summaryMeta)?.summaryMeta ?? existingSummaryMeta ?? {};
-  const sortedPackages = sortPackages(packages);
+  // A fresh row written by a generator that predates per-package stamping gets
+  // this assembly's time: it really was measured in this run.
+  const sortedPackages = sortPackages(packages).map((packageRow) =>
+    packageRow.measuredAt ? packageRow : { ...packageRow, measuredAt: generatedAt },
+  );
   const freshPackages = sortedPackages.filter((packageRow) => packageRow.refresh?.status !== "stale");
+  const measuredAtStamps = sortedPackages.map((packageRow) => packageRow.measuredAt).filter(Boolean);
   const summary = {
     generatedAt,
+    // The SPREAD of measurement times across the corpus. The page headline is
+    // built from this, not from `generatedAt`: with per-package rows the two
+    // ends can be days apart, and one timestamp over a mixed-age corpus
+    // presents the oldest numbers as if they were current.
+    measuredRange:
+      measuredAtStamps.length > 0
+        ? {
+            oldest: measuredAtStamps.reduce((left, right) => (left < right ? left : right)),
+            newest: measuredAtStamps.reduce((left, right) => (left > right ? left : right)),
+          }
+        : null,
     correctness: correctnessRollup(sortedPackages),
     note: firstMeta.note ?? "Only packages with a committed, reproducible tests/dogfood harness are listed.",
     popularity: firstMeta.popularity ?? null,
@@ -125,6 +160,8 @@ export function mergeNpmCompatPartials(
     refresh: {
       status: stalePackages.length > 0 ? "partial" : "complete",
       stalePackages: [...stalePackages].sort(),
+      freshCount: freshPackages.length,
+      totalCount: sortedPackages.length,
     },
     packages: sortedPackages,
   };

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -98,6 +98,11 @@ import {
 import { emitMaterializedArgumentsVector, prepareCompiledApplyBridge } from "./apply-arguments-vector.js";
 import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "../context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "../context/speculative.js";
+import { emitVirtualMethodDispatchByTag } from "./virtual-dispatch.js";
+
+// (#1299) Lives in its own subsystem module since 2026-08-23; re-exported here
+// because call sites import it from `calls.ts`.
+export { emitVirtualMethodDispatchByTag };
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
 import {
   addFuncType,
@@ -4322,151 +4327,6 @@ export function tryEmitInlineDynamicCall(
 
   fctx.body.push(...dispatch);
   return { kind: "externref" };
-}
-
-/**
- * (#1299) Emit a tag-based virtual method dispatch for a base-typed
- * receiver where multiple subclasses provide overriding implementations.
- * Mirrors the `instanceof` codegen: load the receiver's `__tag` field
- * (i32, set in each subclass's constructor) and compare against each
- * candidate's known `classTag` value, calling the matching subclass's
- * method body. Receiver and arguments are evaluated once and saved to
- * temp locals so each branch can reference them.
- *
- * Returns the call's IR result type, or undefined if dispatch could not
- * be emitted (caller falls back to the existing static path).
- */
-export function emitVirtualMethodDispatchByTag(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  expr: ts.CallExpression,
-  propAccess: ts.PropertyAccessExpression,
-  candidates: { className: string; funcIdx: number; classTag: number }[],
-  baseClassName: string,
-): InnerResult | undefined {
-  // Resolve the base struct typeIdx for `struct.get __tag` (field 0).
-  const baseStructIdx = ctx.structMap.get(baseClassName);
-  if (baseStructIdx === undefined) return undefined;
-
-  // Validate first candidate's signature (used as the schema for arg
-  // type hints and return-type lookup; all overrides share the same
-  // user-visible signature).
-  const firstCand = candidates[0]!;
-  const firstParamTypes = getFuncParamTypes(ctx, firstCand.funcIdx);
-  if (!firstParamTypes || firstParamTypes.length === 0) return undefined;
-
-  // Compile the receiver expression — produces a ref-typed value.
-  const recvType = compileExpression(ctx, fctx, propAccess.expression);
-  if (!recvType || (recvType.kind !== "ref" && recvType.kind !== "ref_null")) return undefined;
-
-  const recvLocalType: ValType = { kind: "ref_null", typeIdx: (recvType as { typeIdx: number }).typeIdx };
-  const recvLocal = allocTempLocal(fctx, recvLocalType);
-  fctx.body.push({ op: "local.set", index: recvLocal });
-
-  // Evaluate args and save each to a temp local. Pad missing args with
-  // default values so call sites can omit trailing arguments.
-  const argLocals: { idx: number; type: ValType }[] = [];
-  const userParamCount = firstParamTypes.length - 1; // exclude self
-  const argCount = Math.min(expr.arguments.length, userParamCount);
-  for (let i = 0; i < argCount; i++) {
-    const expectedArgType = firstParamTypes[i + 1];
-    const aType = compileExpression(ctx, fctx, expr.arguments[i]!, expectedArgType);
-    if (!aType) return undefined;
-    const local = allocTempLocal(fctx, aType);
-    fctx.body.push({ op: "local.set", index: local });
-    argLocals.push({ idx: local, type: aType });
-  }
-  for (let i = expr.arguments.length + 1; i < firstParamTypes.length; i++) {
-    const paramType = firstParamTypes[i]!;
-    pushDefaultValue(fctx, paramType, ctx);
-    const local = allocTempLocal(fctx, paramType);
-    fctx.body.push({ op: "local.set", index: local });
-    argLocals.push({ idx: local, type: paramType });
-  }
-
-  // Determine return type from the first candidate's signature.
-  const sig = ctx.checker.getResolvedSignature(expr);
-  let resultType: ValType | typeof VOID_RESULT = VOID_RESULT;
-  if (sig) {
-    const retType = ctx.checker.getReturnTypeOfSignature(sig);
-    const fullName0 = `${firstCand.className}_${propAccess.name.text}`;
-    if (!isEffectivelyVoidReturn(ctx, retType, fullName0)) {
-      const wasmRet = getWasmFuncReturnType(ctx, firstCand.funcIdx);
-      resultType = wasmRet ?? resolveWasmType(ctx, retType);
-    }
-  }
-  if (resultType !== VOID_RESULT && wasmFuncReturnsVoid(ctx, firstCand.funcIdx)) {
-    resultType = VOID_RESULT;
-  }
-
-  const resultIsRef = resultType !== VOID_RESULT && (resultType.kind === "ref" || resultType.kind === "ref_null");
-
-  // (#2564) Each nested `if` in the tag cascade below MUST get its own
-  // `blockType` object — never a single shared one. `dead-elimination`'s
-  // `remapTypeIdxInBody` remaps a `ref`/`ref_null` block-type via `remapVT`,
-  // and its double-remap guard (`seen` WeakSet, #1302) keys on the *instruction*
-  // object, not on the `blockType.type` sub-object. The cascade builds one
-  // distinct `if` instruction per candidate; if they all alias the SAME
-  // `blockType.type` ValType, the second nested `if`'s visit chain-remaps the
-  // already-remapped index a second time (observed: 20→16 on the first `if`,
-  // then 16→13 on the second — the compaction map shifts each survivor down, so
-  // 13 is the fn-wrapper type), while the callee func's result type — remapped
-  // exactly once in the type table — lands on 16. The mismatch surfaces as
-  // `type error in fallthru[0] (expected (ref null 13), got (ref null 16))`.
-  // A fresh `{ ...resultType }` per `if` keeps each block-type remapped once.
-  const freshBlockType = (): { kind: "val"; type: ValType } | { kind: "empty" } =>
-    resultType === VOID_RESULT
-      ? { kind: "empty" }
-      : { kind: "val", type: resultIsRef ? { ...(resultType as ValType) } : (resultType as ValType) };
-
-  // Build the call body for one candidate. We need to ref.cast the
-  // receiver to the candidate's struct type before calling, so the
-  // function-type signature matches.
-  function callBody(cand: { className: string; funcIdx: number; classTag: number }): Instr[] {
-    const candParams = getFuncParamTypes(ctx, cand.funcIdx);
-    if (!candParams || candParams.length === 0) return [];
-    const selfType = candParams[0]!;
-    if (selfType.kind !== "ref" && selfType.kind !== "ref_null") return [];
-    const selfTypeIdx = (selfType as { typeIdx: number }).typeIdx;
-    const body: Instr[] = [];
-    body.push({ op: "local.get", index: recvLocal });
-    // ref.cast_null preserves nullability if the receiver might be null;
-    // ref.cast (non-null) traps on null. Use ref.cast_null since the
-    // receiver could be null at the static type level.
-    body.push({ op: "ref.cast_null", typeIdx: selfTypeIdx });
-    for (const a of argLocals) {
-      body.push({ op: "local.get", index: a.idx });
-    }
-    const finalIdx = ctx.funcMap.get(`${cand.className}_${propAccess.name.text}`) ?? cand.funcIdx;
-    body.push({ op: "call", funcIdx: finalIdx });
-    return body;
-  }
-
-  // Build the cascade: load __tag, compare to each candidate's classTag.
-  // Outermost: candidates[0]; deepest else: unreachable.
-  let elseInstrs: Instr[] = [{ op: "unreachable" }];
-  for (let i = candidates.length - 1; i >= 0; i--) {
-    const cand = candidates[i]!;
-    const branch: Instr[] = [
-      { op: "local.get", index: recvLocal },
-      { op: "struct.get", typeIdx: baseStructIdx, fieldIdx: 0 },
-      { op: "i32.const", value: cand.classTag },
-      { op: "i32.eq" },
-      {
-        op: "if",
-        blockType: freshBlockType(),
-        then: callBody(cand),
-        else: elseInstrs,
-      },
-    ];
-    elseInstrs = branch;
-  }
-  for (const instr of elseInstrs) fctx.body.push(instr);
-
-  for (const a of argLocals) releaseTempLocal(fctx, a.idx);
-  releaseTempLocal(fctx, recvLocal);
-
-  return resultType;
 }
 
 /**

--- a/src/codegen/expressions/virtual-dispatch.ts
+++ b/src/codegen/expressions/virtual-dispatch.ts
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#1299) Tag-based virtual method dispatch.
+ *
+ * Extracted from `calls.ts` (a god file under the #3102 LOC budget) so this
+ * emitter can carry the explanation its two 2026-08-23 stack-discipline fixes
+ * need. Behaviour is unchanged by the move; `calls.ts` re-exports the entry
+ * point so existing call sites are untouched.
+ */
+import { ts } from "../../ts-api.js";
+
+import type { Instr, ValType } from "../../ir/types.js";
+import { allocTempLocal, releaseTempLocal } from "../context/locals.js";
+import { rollbackSpeculative, snapshotSpeculative } from "../context/speculative.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import type { InnerResult } from "../shared.js";
+import { compileExpression, VOID_RESULT } from "../shared.js";
+import { pushDefaultValue } from "../type-coercion.js";
+import { resolveWasmType } from "../index.js";
+import { getFuncParamTypes, getWasmFuncReturnType, isEffectivelyVoidReturn, wasmFuncReturnsVoid } from "./helpers.js";
+
+/**
+ * (#1299) Emit a tag-based virtual method dispatch for a base-typed
+ * receiver where multiple subclasses provide overriding implementations.
+ * Mirrors the `instanceof` codegen: load the receiver's `__tag` field
+ * (i32, set in each subclass's constructor) and compare against each
+ * candidate's known `classTag` value, calling the matching subclass's
+ * method body. Receiver and arguments are evaluated once and saved to
+ * temp locals so each branch can reference them.
+ *
+ * Returns the call's IR result type, or undefined if dispatch could not
+ * be emitted (caller falls back to the existing static path).
+ */
+export function emitVirtualMethodDispatchByTag(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+  candidates: { className: string; funcIdx: number; classTag: number }[],
+  baseClassName: string,
+): InnerResult | undefined {
+  // Resolve the base struct typeIdx for `struct.get __tag` (field 0).
+  const baseStructIdx = ctx.structMap.get(baseClassName);
+  if (baseStructIdx === undefined) return undefined;
+
+  // Validate first candidate's signature (used as the schema for arg
+  // type hints and return-type lookup; all overrides share the same
+  // user-visible signature).
+  const firstCand = candidates[0]!;
+  const firstParamTypes = getFuncParamTypes(ctx, firstCand.funcIdx);
+  if (!firstParamTypes || firstParamTypes.length === 0) return undefined;
+
+  // EVERY bail-out from here on must be transactional. This function emits
+  // into `fctx.body` as it probes, and returning `undefined` tells the caller
+  // "I emitted nothing, use the static path" — so an un-rewound partial
+  // emission is left stranded on the operand stack while the fallback compiles
+  // the same receiver and arguments again.
+  //
+  // That is not hypothetical: it is why lit's implementation module failed to
+  // validate (`type error in fallthru[0] (expected i32, got externref)`).
+  // `class extends HTMLElement` makes the receiver EXTERNREF, so the
+  // ref/ref_null check below rejects it — after the receiver push had already
+  // landed. The static path then re-pushed the receiver, the call consumed
+  // only its own two operands, and one externref survived to the end of the
+  // enclosing `&&` arm, whose block type was i32. Every lit test file inherits
+  // that invalid module, which is what drives the halving-retry cascade in the
+  // upstream-suite runner.
+  const snap = snapshotSpeculative(ctx, fctx);
+
+  // Compile the receiver expression — produces a ref-typed value.
+  const recvType = compileExpression(ctx, fctx, propAccess.expression);
+  if (!recvType || (recvType.kind !== "ref" && recvType.kind !== "ref_null")) {
+    rollbackSpeculative(ctx, fctx, snap);
+    return undefined;
+  }
+
+  const recvLocalType: ValType = { kind: "ref_null", typeIdx: (recvType as { typeIdx: number }).typeIdx };
+  const recvLocal = allocTempLocal(fctx, recvLocalType);
+  fctx.body.push({ op: "local.set", index: recvLocal });
+
+  // Evaluate args and save each to a temp local. Pad missing args with
+  // default values so call sites can omit trailing arguments.
+  const argLocals: { idx: number; type: ValType }[] = [];
+  const userParamCount = firstParamTypes.length - 1; // exclude self
+  const argCount = Math.min(expr.arguments.length, userParamCount);
+  for (let i = 0; i < argCount; i++) {
+    const expectedArgType = firstParamTypes[i + 1];
+    const aType = compileExpression(ctx, fctx, expr.arguments[i]!, expectedArgType);
+    if (!aType) {
+      rollbackSpeculative(ctx, fctx, snap);
+      return undefined;
+    }
+    const local = allocTempLocal(fctx, aType);
+    fctx.body.push({ op: "local.set", index: local });
+    argLocals.push({ idx: local, type: aType });
+  }
+  for (let i = expr.arguments.length + 1; i < firstParamTypes.length; i++) {
+    const paramType = firstParamTypes[i]!;
+    pushDefaultValue(fctx, paramType, ctx);
+    const local = allocTempLocal(fctx, paramType);
+    fctx.body.push({ op: "local.set", index: local });
+    argLocals.push({ idx: local, type: paramType });
+  }
+
+  // Determine return type from the first candidate's signature.
+  const sig = ctx.checker.getResolvedSignature(expr);
+  let resultType: ValType | typeof VOID_RESULT = VOID_RESULT;
+  if (sig) {
+    const retType = ctx.checker.getReturnTypeOfSignature(sig);
+    const fullName0 = `${firstCand.className}_${propAccess.name.text}`;
+    if (!isEffectivelyVoidReturn(ctx, retType, fullName0)) {
+      const wasmRet = getWasmFuncReturnType(ctx, firstCand.funcIdx);
+      resultType = wasmRet ?? resolveWasmType(ctx, retType);
+    }
+  }
+  if (resultType !== VOID_RESULT && wasmFuncReturnsVoid(ctx, firstCand.funcIdx)) {
+    resultType = VOID_RESULT;
+  }
+
+  const resultIsRef = resultType !== VOID_RESULT && (resultType.kind === "ref" || resultType.kind === "ref_null");
+
+  // (#2564) Each nested `if` in the tag cascade below MUST get its own
+  // `blockType` object — never a single shared one. `dead-elimination`'s
+  // `remapTypeIdxInBody` remaps a `ref`/`ref_null` block-type via `remapVT`,
+  // and its double-remap guard (`seen` WeakSet, #1302) keys on the *instruction*
+  // object, not on the `blockType.type` sub-object. The cascade builds one
+  // distinct `if` instruction per candidate; if they all alias the SAME
+  // `blockType.type` ValType, the second nested `if`'s visit chain-remaps the
+  // already-remapped index a second time (observed: 20→16 on the first `if`,
+  // then 16→13 on the second — the compaction map shifts each survivor down, so
+  // 13 is the fn-wrapper type), while the callee func's result type — remapped
+  // exactly once in the type table — lands on 16. The mismatch surfaces as
+  // `type error in fallthru[0] (expected (ref null 13), got (ref null 16))`.
+  // A fresh `{ ...resultType }` per `if` keeps each block-type remapped once.
+  const freshBlockType = (): { kind: "val"; type: ValType } | { kind: "empty" } =>
+    resultType === VOID_RESULT
+      ? { kind: "empty" }
+      : { kind: "val", type: resultIsRef ? { ...(resultType as ValType) } : (resultType as ValType) };
+
+  // Build the call body for one candidate. We need to ref.cast the
+  // receiver to the candidate's struct type before calling, so the
+  // function-type signature matches.
+  function callBody(cand: { className: string; funcIdx: number; classTag: number }): Instr[] {
+    const candParams = getFuncParamTypes(ctx, cand.funcIdx);
+    if (!candParams || candParams.length === 0) return [];
+    const selfType = candParams[0]!;
+    if (selfType.kind !== "ref" && selfType.kind !== "ref_null") return [];
+    const selfTypeIdx = (selfType as { typeIdx: number }).typeIdx;
+    const body: Instr[] = [];
+    body.push({ op: "local.get", index: recvLocal });
+    // ref.cast_null preserves nullability if the receiver might be null;
+    // ref.cast (non-null) traps on null. Use ref.cast_null since the
+    // receiver could be null at the static type level.
+    body.push({ op: "ref.cast_null", typeIdx: selfTypeIdx });
+    for (const a of argLocals) {
+      body.push({ op: "local.get", index: a.idx });
+    }
+    const finalIdx = ctx.funcMap.get(`${cand.className}_${propAccess.name.text}`) ?? cand.funcIdx;
+    body.push({ op: "call", funcIdx: finalIdx });
+    return body;
+  }
+
+  // Load `__tag` through the RECEIVER's own struct type, not the base's.
+  //
+  // These class structs are NOT declared in a Wasm subtype relation with each
+  // other (`$__anonClass_0` is emitted as a bare `(sub (struct …))`, not
+  // `(sub $y …)`), so `struct.get $base` over a local typed `(ref null
+  // $__anonClass_0)` is a validation error, not a widening. It fires whenever
+  // this method is compiled as a synthesised per-subclass COPY: the copy's
+  // `this` is the copy's struct while `baseClassName` still names the original,
+  // which is how lit's `y_get_updateComplete` failed with `struct.get[0]
+  // expected type (ref null 54), found local.tee of type (ref null 44)`.
+  //
+  // Field 0 is `__tag` in every class struct this path can see — the same
+  // assumption the base-typed read already made — so reading it through the
+  // receiver's own type is well-typed and loads the identical field. Only do
+  // that for a type we can confirm IS a class struct; anything else bails out,
+  // now safely, because the snapshot above rewinds what we emitted.
+  const recvTypeIdx = (recvType as { typeIdx: number }).typeIdx;
+  let tagStructIdx = baseStructIdx;
+  if (recvTypeIdx !== baseStructIdx) {
+    let recvIsClassStruct = false;
+    for (const idx of ctx.structMap.values()) {
+      if (idx === recvTypeIdx) {
+        recvIsClassStruct = true;
+        break;
+      }
+    }
+    if (!recvIsClassStruct) {
+      rollbackSpeculative(ctx, fctx, snap);
+      return undefined;
+    }
+    tagStructIdx = recvTypeIdx;
+  }
+
+  // Build the cascade: load __tag, compare to each candidate's classTag.
+  // Outermost: candidates[0]; deepest else: unreachable.
+  let elseInstrs: Instr[] = [{ op: "unreachable" }];
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const cand = candidates[i]!;
+    const branch: Instr[] = [
+      { op: "local.get", index: recvLocal },
+      { op: "struct.get", typeIdx: tagStructIdx, fieldIdx: 0 },
+      { op: "i32.const", value: cand.classTag },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: freshBlockType(),
+        then: callBody(cand),
+        else: elseInstrs,
+      },
+    ];
+    elseInstrs = branch;
+  }
+  for (const instr of elseInstrs) fctx.body.push(instr);
+
+  for (const a of argLocals) releaseTempLocal(fctx, a.idx);
+  releaseTempLocal(fctx, recvLocal);
+
+  return resultType;
+}

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -38,11 +38,10 @@ import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
 import { installReactTestEnvironment } from "./react-test-environment.mjs";
 import { installReactUpstreamInfrastructure } from "./react-upstream-infrastructure.mjs";
 import { REACT_EXPECT_SHIM, LAST_ERROR_EXPORT, buildTestFunction, withTimeout } from "./react-upstream-shim.mjs";
-import { compileProjectInWorker, compileSourceInWorker } from "./upstream-suite-runner.mjs";
+import { compileProjectInWorker } from "./upstream-suite-runner.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPORT_PATH = join(HERE, "report", "react-dom-upstream-suite.json");
-const GENERATED_ROOT = join(HERE, ".react-dom-upstream-suite-impl");
 const PROJECT_ROOT = join(HERE, ".react-dom-upstream-suite-project");
 let nativeContextFile = "<setup>";
 let nativeContextTest = "<setup>";
@@ -473,7 +472,10 @@ function buildProjectModuleSource({ exportName, moduleName, imports, bindings = 
 // Concatenating the 560 KB client graph into every test batch both repeats
 // compilation work and makes a single compiler watchdog unable to distinguish
 // a slow implementation from a pathological test body.
-function buildProjectFiles({ reactSource, sharedSource, clientSource, tests }) {
+// Exported like its sibling `buildServerProjectFiles`: the implementation
+// probe's cost is a property of this shape, so it has to be measurable
+// without running the 3-4 hour suite.
+export function buildProjectFiles({ reactSource, sharedSource, clientSource, tests }) {
   const entry = [
     'import { __reactExports } from "./react.ts";',
     'import { __sharedExports } from "./shared.ts";',
@@ -1064,13 +1066,27 @@ async function runServerHarness({
 // Compiles the implementation ALONE — no test code. If this cannot produce a
 // valid module then every batch containing it is invalid too, and subdividing
 // per test only burns wall clock while hiding the actual finding.
-async function compileImplementationOnly(implementation) {
-  const source = `${implementation}\nexport function __probe() {\n  return 1;\n}`;
+//
+// Uses the PROJECT shape (real `react.ts` / `scheduler.ts` / `shared.ts` /
+// `client.ts` modules), not `buildImplementationSource`'s CJS-emulating
+// `function __reactDomClientModule() { … }` wrapper. Measured 2026-08-23 on the
+// 536 KB published client source: 35.4 s compiling at top level versus 84.4 s
+// wrapped in a function body, emitting 1.36 MB versus 1.77 MB — 2.4× the time
+// and 30% more code for identical source. `buildImplementationSource` wraps
+// four modules that way, which is what drove this probe into its 300 s ceiling
+// and left the card reporting `blocked` with 0 of 1,261 admitted tests run.
+//
+// The per-batch lane already knew: `buildProjectModuleSource` keeps each export
+// carrier top-level with the comment "so the large React production bodies do
+// not become nested function expressions". This probe is now the same shape,
+// with an empty test list, so it measures what the batches actually compile.
+async function compileImplementationOnly({ reactSource, sharedSource, clientSource }) {
   const configuredTimeout = Number(process.env.DOGFOOD_REACT_DOM_COMPILE_TIMEOUT_MS ?? 300_000);
   const timeoutMs = Number.isFinite(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : 300_000;
-  const result = await compileSourceInWorker({
-    generatedPath: join(GENERATED_ROOT, "generated-implementation.ts"),
-    source,
+  const result = await compileProjectInWorker({
+    generatedRoot: join(PROJECT_ROOT, "implementation-probe"),
+    entryFile: "entry.ts",
+    files: buildProjectFiles({ reactSource, sharedSource, clientSource, tests: [] }),
     timeoutMs,
     workerEnv: { DOGFOOD_INSTALL_JSDOM: "1" },
   });
@@ -1629,7 +1645,7 @@ export async function runHarness({ quiet = false } = {}) {
   }
 
   // --- 3. DOES THE IMPLEMENTATION COMPILE AT ALL? --------------------------
-  const baseline = await compileImplementationOnly(implementation);
+  const baseline = await compileImplementationOnly({ reactSource, sharedSource, clientSource });
   log(
     `[dogfood] react-dom implementation alone (${Math.round(implementation.length / 1024)} KB): ` +
       (baseline.validates ? `valid in ${baseline.compileMs}ms` : `INVALID — ${String(baseline.error).slice(0, 100)}`),

--- a/tests/guard-suite.json
+++ b/tests/guard-suite.json
@@ -1,15 +1,15 @@
 {
   "$comment": [
-    "#3552 — REQUIRED per-PR guard suite, run by the `quality` job (ci.yml)",
+    "#3552 \u2014 REQUIRED per-PR guard suite, run by the `quality` job (ci.yml)",
     "on every pull_request, merge_group, and push via",
     "`node scripts/run-guard-suite.mjs` (`pnpm run test:guard` locally).",
     "",
-    "Why this exists: untouched root test files do NOT run at PR time — the",
+    "Why this exists: untouched root test files do NOT run at PR time \u2014 the",
     "#3008 two-layer design runs only PR-touched tests/*.test.ts per PR and",
     "defers the full ~2,100-file suite (~9 CPU-hours) to the post-merge",
     "issue-tests.yml detector, which detects but does not ENFORCE. #3503",
     "proved the gap on 2026-07-23: it regressed tests/issue-3471.test.ts",
-    "without touching it — green PR, red main (#3551). This manifest brings",
+    "without touching it \u2014 green PR, red main (#3551). This manifest brings",
     "a SMALL curated set of invariant-guard tests into the required check.",
     "",
     "Entry criteria (all must hold):",
@@ -18,7 +18,14 @@
     "  2. It completes in <60s locally and needs NO test262 submodule or",
     "     other prepared harness inputs (plain `vitest run <file>` works on",
     "     a bare checkout + pnpm install).",
-    "  3. It is green on current main — a red entry blocks EVERY PR.",
+    "  3. It is green on current main \u2014 a red entry blocks EVERY PR.",
+    "",
+    "Second proof, 2026-08-23: #4792 and #4796 each silently reddened the",
+    "npm-compat workflow guards on main by editing the workflow/scripts they",
+    "pin WITHOUT touching the test files, so `test:changed-root` never ran",
+    "them. Nine tests were red on main for hours behind green PRs. Guards",
+    "that pin a FILE OTHER than themselves are exactly the shape this suite",
+    "is for: the edit that breaks them never selects them.",
     "Keep the suite cheap: total budget ~2 minutes. If it outgrows that,",
     "split the slowest entries back to post-merge and say why here."
   ],
@@ -26,47 +33,47 @@
     {
       "path": "tests/issue-3471.test.ts",
       "guards": "polymorphic (any-typed) params must not be narrowed to f64 by body-usage inference; the test262 propertyHelper isSameValue shape",
-      "broken_by": "#3503 (silently, untouched — the motivating regression)"
+      "broken_by": "#3503 (silently, untouched \u2014 the motivating regression)"
     },
     {
       "path": "tests/issue-3536.test.ts",
-      "guards": "standalone declared-fn object-literal arguments cross the call boundary intact (the counterpart invariant #3503 fixed — keeps the 3471/3536 tension resolved BOTH ways)",
+      "guards": "standalone declared-fn object-literal arguments cross the call boundary intact (the counterpart invariant #3503 fixed \u2014 keeps the 3471/3536 tension resolved BOTH ways)",
       "broken_by": "pre-#3503 main (standalone lane)"
     },
     {
       "path": "tests/issue-3551.test.ts",
-      "guards": "IR ABI-parity withdrawal cascades to committed IR callers — no partial commit of a calleeTypes cluster",
+      "guards": "IR ABI-parity withdrawal cascades to committed IR callers \u2014 no partial commit of a calleeTypes cluster",
       "broken_by": "#3503 partial-commit semantics"
     },
     {
       "path": "tests/issue-2906-gap3-tryfinally.test.ts",
       "guards": "wasi async try/finally runs on every completion path AND the module stays JS-host-free (no env.* imports; wasi_snapshot_preview1 system imports allowed per #2968)",
-      "broken_by": "#2968/PR #2533 (2026-07-04) invalidated the bare-{} instantiation silently — red 19 days, found+reconciled by #3558"
+      "broken_by": "#2968/PR #2533 (2026-07-04) invalidated the bare-{} instantiation silently \u2014 red 19 days, found+reconciled by #3558"
     },
     {
       "path": "tests/issue-2980-carrier-fallback.test.ts",
       "guards": "standalone Promise carrier lane split: all-drivable async-gen modules import-free (native $Promise), non-drivable ones host-consistent (legacy __gen_* buffer, no mixing)",
-      "broken_by": "#3132 PR-2/PR #3013 (2026-07-13) superseded the blanket #2980 fallback silently — red 10 days, found+reconciled by #3558"
+      "broken_by": "#3132 PR-2/PR #3013 (2026-07-13) superseded the blanket #2980 fallback silently \u2014 red 10 days, found+reconciled by #3558"
     },
     {
       "path": "tests/issue-2961.test.ts",
-      "guards": "standalone host-import leak scan (warning severity): a non-allowlisted leak (user extern class → env::Widget_*) WARNS + still emits (floor-neutral); an allowlisted import (Math_random) is silent; console.log is host-free (native strings+console); the wasi strict path stays a hard error",
-      "broken_by": "native strings + native console retired the __str_from_mem string bridge, so the old console.log leak example went host-free and the 4 console.log assertions silently rotted — a #3558-class invisible stale guard; refreshed to the durable extern-class example + folded into the required gate by #3561"
+      "guards": "standalone host-import leak scan (warning severity): a non-allowlisted leak (user extern class \u2192 env::Widget_*) WARNS + still emits (floor-neutral); an allowlisted import (Math_random) is silent; console.log is host-free (native strings+console); the wasi strict path stays a hard error",
+      "broken_by": "native strings + native console retired the __str_from_mem string bridge, so the old console.log leak example went host-free and the 4 console.log assertions silently rotted \u2014 a #3558-class invisible stale guard; refreshed to the durable extern-class example + folded into the required gate by #3561"
     },
     {
       "path": "tests/issue-680.test.ts",
       "guards": "a basic standalone generator (function* g(){yield 1;yield 2;return 3}) + a caller doing g.next() compiles host-free (native __GenState state machine, no __gen_* imports) and runs (1235); default-target generators are native too",
-      "broken_by": "#3341/#3519 (PR #3249, 2026-07-17) promoted the generator IR path's host-only unknown-function-ref AND the caller's untyped '.next() not in slice 4' throw to HARD compile errors — broke basic standalone generators for 7 days, invisible outside required checks (#3008); found+fixed by #680"
+      "broken_by": "#3341/#3519 (PR #3249, 2026-07-17) promoted the generator IR path's host-only unknown-function-ref AND the caller's untyped '.next() not in slice 4' throw to HARD compile errors \u2014 broke basic standalone generators for 7 days, invisible outside required checks (#3008); found+fixed by #680"
     },
     {
       "path": "tests/issue-2047.test.ts",
-      "guards": "standalone Array.isArray discriminates byte carriers per §7.2.2: ArrayBuffer/DataView/Uint8Array → false, real number[]/boolean[]/string[] → true; value-read agrees with direct call across carrier kinds",
-      "broken_by": "the $__vec_base common-supertype WasmGC refactor silently defeated #2047's leaf-exclusion — collectStandaloneArrayCarrierTypeIdxs matched the abstract $__vec_base via its __vec_* name prefix, so ref.test against it subsumed the byte-vec subtypes → Array.isArray(ArrayBuffer/Uint8Array)===true (regression >2026-07-04, another weeks-old invisible one outside required checks #3008); found+fixed by #3562"
+      "guards": "standalone Array.isArray discriminates byte carriers per \u00a77.2.2: ArrayBuffer/DataView/Uint8Array \u2192 false, real number[]/boolean[]/string[] \u2192 true; value-read agrees with direct call across carrier kinds",
+      "broken_by": "the $__vec_base common-supertype WasmGC refactor silently defeated #2047's leaf-exclusion \u2014 collectStandaloneArrayCarrierTypeIdxs matched the abstract $__vec_base via its __vec_* name prefix, so ref.test against it subsumed the byte-vec subtypes \u2192 Array.isArray(ArrayBuffer/Uint8Array)===true (regression >2026-07-04, another weeks-old invisible one outside required checks #3008); found+fixed by #3562"
     },
     {
       "path": "tests/issue-4524-closed-struct-data-define.test.ts",
-      "guards": "standalone: an out-of-shape DATA descriptor define on a closed-struct object literal lands as a real own property (readable, `in`, hasOwnProperty, Object.keys) — and an Object.prototype.<m>.call(o, …) elsewhere in the module does NOT revert the receiver to a closed struct; plus the narrowness side, that an in-shape define and an unrelated literal keep the struct path",
-      "broken_by": "two silent-wrong-answer defects that hid each other: (1) an out-of-shape data define had nowhere to write on a closed struct and was DROPPED with no diagnostic, while the accessor-define and dynamic-write siblings were already covered; (2) the consumer-safety guard read the borrowed idiom `Object.prototype.hasOwnProperty.call(o, …)` as a concrete-struct consumer and UN-POISONED the receiver — action at a distance, a read changing an object's representation — which silently disabled (1) in every harness-linked compile, making the first fix measure as zero. Found+fixed by #4524 (2026-08-16)"
+      "guards": "standalone: an out-of-shape DATA descriptor define on a closed-struct object literal lands as a real own property (readable, `in`, hasOwnProperty, Object.keys) \u2014 and an Object.prototype.<m>.call(o, \u2026) elsewhere in the module does NOT revert the receiver to a closed struct; plus the narrowness side, that an in-shape define and an unrelated literal keep the struct path",
+      "broken_by": "two silent-wrong-answer defects that hid each other: (1) an out-of-shape data define had nowhere to write on a closed struct and was DROPPED with no diagnostic, while the accessor-define and dynamic-write siblings were already covered; (2) the consumer-safety guard read the borrowed idiom `Object.prototype.hasOwnProperty.call(o, \u2026)` as a concrete-struct consumer and UN-POISONED the receiver \u2014 action at a distance, a read changing an object's representation \u2014 which silently disabled (1) in every harness-linked compile, making the first fix measure as zero. Found+fixed by #4524 (2026-08-16)"
     },
     {
       "path": "tests/issue-1539-standalone-regex-replace.test.ts",
@@ -75,28 +82,43 @@
     },
     {
       "path": "tests/issue-3565.test.ts",
-      "guards": "four DESIGNED demote-to-legacy sites compile (fall back to legacy) instead of hard-erroring — TypedArray element STORE (lowerElementStore), slice-12 element ACCESS on an extern receiver (lowerElementAccess), the verify.ts #1798 return-value gate, and compound-assign with a non-f64 RHS (the issue-2079 generator for-of `s += v` shape, runs =3) — AND a GENERIC invariant (block-id/type desync, injected build throw) STILL hard-fails (no masking of real invalid-Wasm)",
-      "broken_by": "#3341/#3519 (PR #3249, 2026-07-17) made outcome.kind==='invariant' a hard compile error, silently promoting these 4 documented 'clean throw → legacy' demotes; #680 exempted only the generator+method-call cases, leaving these 4 hard for ~7 days (invisible outside required checks, #3008); found+fixed by #3565"
+      "guards": "four DESIGNED demote-to-legacy sites compile (fall back to legacy) instead of hard-erroring \u2014 TypedArray element STORE (lowerElementStore), slice-12 element ACCESS on an extern receiver (lowerElementAccess), the verify.ts #1798 return-value gate, and compound-assign with a non-f64 RHS (the issue-2079 generator for-of `s += v` shape, runs =3) \u2014 AND a GENERIC invariant (block-id/type desync, injected build throw) STILL hard-fails (no masking of real invalid-Wasm)",
+      "broken_by": "#3341/#3519 (PR #3249, 2026-07-17) made outcome.kind==='invariant' a hard compile error, silently promoting these 4 documented 'clean throw \u2192 legacy' demotes; #680 exempted only the generator+method-call cases, leaving these 4 hard for ~7 days (invisible outside required checks, #3008); found+fixed by #3565"
     },
     {
       "path": "tests/issue-3164.test.ts",
-      "guards": "standalone generator FUNCTION EXPRESSIONS go native and stay host-free (zero env imports): dstr-harness IIFE laziness, .next() body-runs-once, for-of / destructuring over an any-held native generator, §27.5 first-next() suspension, and the #1344 host-mix arm (a real HOST generator does NOT take the TypeError arm)",
-      "broken_by": "#3032 W6 (PR #3356, 1fbb1810, 2026-07-19) silently broke 3 of these — a module-scope generator fn-expr is lifted once per compileModuleInitBody pass with a DIFFERENT state-struct type, while .next()'s inline ref.test dispatch is frozen between the passes on pass 1's dead type. Green at the parent 8bc6e1c3, red on main for 5 days, invisible because #3356 touched neither suite and the #3008 per-PR gate only runs PR-TOUCHED root tests. Root-caused + skipped-with-pointer as #3591; the remaining 10 cases guard the rest"
+      "guards": "standalone generator FUNCTION EXPRESSIONS go native and stay host-free (zero env imports): dstr-harness IIFE laziness, .next() body-runs-once, for-of / destructuring over an any-held native generator, \u00a727.5 first-next() suspension, and the #1344 host-mix arm (a real HOST generator does NOT take the TypeError arm)",
+      "broken_by": "#3032 W6 (PR #3356, 1fbb1810, 2026-07-19) silently broke 3 of these \u2014 a module-scope generator fn-expr is lifted once per compileModuleInitBody pass with a DIFFERENT state-struct type, while .next()'s inline ref.test dispatch is frozen between the passes on pass 1's dead type. Green at the parent 8bc6e1c3, red on main for 5 days, invisible because #3356 touched neither suite and the #3008 per-PR gate only runs PR-TOUCHED root tests. Root-caused + skipped-with-pointer as #3591; the remaining 10 cases guard the rest"
     },
     {
       "path": "tests/issue-3386.test.ts",
-      "guards": "standalone sync-generator PATTERN PARAMS are host-free and spec-correct: array/object patterns incl. renamed+defaulted elements, elisions, nested sub-patterns, whole-param defaults, two pattern params, and the §27.5 call-time-vs-first-next() split (destructure + throwing defaults fire at CALL, body at first .next())",
+      "guards": "standalone sync-generator PATTERN PARAMS are host-free and spec-correct: array/object patterns incl. renamed+defaulted elements, elisions, nested sub-patterns, whole-param defaults, two pattern params, and the \u00a727.5 call-time-vs-first-next() split (destructure + throwing defaults fire at CALL, body at first .next())",
       "broken_by": "#3032 W6 (PR #3356, 1fbb1810, 2026-07-19) silently broke the fn-expr case via the same stale pass-1 state-struct type as tests/issue-3164.test.ts (#3591); green at parent 8bc6e1c3. The other 16 cases pin the call-time/lazy split that #3386 established"
     },
     {
       "path": "tests/issue-3597-auto-park-step-aware.test.ts",
-      "guards": "the auto-park bot's infra-vs-verdict step classification: an infra-only merge_group failure (artifact download) must NOT park, a verdict-step failure MUST park, and anything unclassifiable parks conservatively — plus the unchanged #2547 cancellation invariant (0 failed jobs never parks) and the REAL workflow step names (a rename surfaces here). 48 cases, 5ms",
-      "broken_by": "criterion 1 applies via the SCRIPT-vs-TEST gap: editing scripts/auto-park-merge-group-failure.mjs alone does NOT trigger the #3008 per-PR gate (that gate runs changed tests/*.test.ts files, not tests RELATED to changed scripts), so without this entry the classification is unguarded against exactly the silent drift this manifest exists for. The incident it encodes: on 2026-07-24 the bot emitted THREE parks, two with textually identical comments for opposite causes — #3566 (artifact download 403'd, verdict never ran, merged cleanly once unparked), #3563 (verdict ran, real uncatchable-trap regression), #3581 (duplicate issue id). Held PRs are SKIPPED by auto-enqueue, so a wrong park STRANDS the PR. The classification is only safe in one direction: widening INFRA_STEP_PATTERNS makes the bot park LESS, which is how a real regression reaches main (#3597)"
+      "guards": "the auto-park bot's infra-vs-verdict step classification: an infra-only merge_group failure (artifact download) must NOT park, a verdict-step failure MUST park, and anything unclassifiable parks conservatively \u2014 plus the unchanged #2547 cancellation invariant (0 failed jobs never parks) and the REAL workflow step names (a rename surfaces here). 48 cases, 5ms",
+      "broken_by": "criterion 1 applies via the SCRIPT-vs-TEST gap: editing scripts/auto-park-merge-group-failure.mjs alone does NOT trigger the #3008 per-PR gate (that gate runs changed tests/*.test.ts files, not tests RELATED to changed scripts), so without this entry the classification is unguarded against exactly the silent drift this manifest exists for. The incident it encodes: on 2026-07-24 the bot emitted THREE parks, two with textually identical comments for opposite causes \u2014 #3566 (artifact download 403'd, verdict never ran, merged cleanly once unparked), #3563 (verdict ran, real uncatchable-trap regression), #3581 (duplicate issue id). Held PRs are SKIPPED by auto-enqueue, so a wrong park STRANDS the PR. The classification is only safe in one direction: widening INFRA_STEP_PATTERNS makes the bot park LESS, which is how a real regression reaches main (#3597)"
     },
     {
       "path": "tests/issue-3613-vacuity-machinery.test.ts",
       "guards": "the anti-vacuity machinery itself: the vacuous-verifier guard (a checker answering for 0 of N non-empty inputs is a BROKEN checker, not a clean result), its wiring into diff-test262's trap-frame verifier, the vacuity detector's probe shape (CONDITIONAL throw, harness-guarded, marker-tagged) + eligibility exclusions + seeded sampling, AND the ratchet-at-zero on identifier-gate-defeating `new (X as any)(...)` callees in our OWN tests. Hermetic, no test262 inputs; ~22s, almost all of it the repo-wide AST scan for the last one",
       "broken_by": "criterion 1 applies via the SCRIPT-vs-TEST gap AND the class's own history: the #3601 park's `trapInnermostFrame` silently answered for 0 of 65 CI trap rows (grammar drift) and reported it as '0 verified unmasked pre-existing traps', while a throw-probe audit on a pre-#3592 base reported a spurious '43/43 vacuous' from a probe that had been compiled away. Both are silent zeros from a checker that stopped working; editing scripts/diff-test262.ts or scripts/detect-vacuity.ts alone does not trigger the #3008 per-PR gate, so without this entry the guard against them is itself unguarded (#3613)"
+    },
+    {
+      "path": "tests/npm-compat-partials.test.ts",
+      "guards": "npm-compat refresh pipeline wiring: per-package concurrency groups, catalog-planned matrices, two promotion lanes, and stale carry-forward that keeps each package's OWN measurement time",
+      "broken_by": "#4796 (silently, untouched \u2014 the per-package split moved the coordinator into npm-compat-promote.yml and left these guards reading the wrong file)"
+    },
+    {
+      "path": "tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts",
+      "guards": "npm-compat promotion never pushes to main: PR-only promotion, no [skip ci], non-GITHUB_TOKEN actor, sanity check before push",
+      "broken_by": "#4792 and #4796 (silently, untouched \u2014 the sanity check moved to scripts/ and the coordinator to a second workflow file)"
+    },
+    {
+      "path": "tests/npm-compat-page-freshness.test.ts",
+      "guards": "the dashboard header describes the measurement SPREAD and every card carries its own measuredAt \u2014 never one timestamp over an out-of-sync corpus",
+      "broken_by": "#4796 (the per-package split made a single header timestamp wrong; react-dom showed 3-day-old numbers under a current one)"
     }
   ]
 }

--- a/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
+++ b/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
@@ -32,7 +32,17 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
-const workflow = readFileSync(resolve(ROOT, ".github/workflows/npm-compat-refresh.yml"), "utf8");
+
+// The refresh PIPELINE is two files since the per-package split (2026-08-23):
+// npm-compat-refresh.yml plans and measures, npm-compat-promote.yml assembles
+// and promotes. Every guard below is about the pipeline's behaviour, not about
+// which file a step happens to live in, so read both. Order matters for the
+// `at()` comparisons and promotion runs after measurement, so concatenate in
+// pipeline order — that keeps "sanity check precedes push" meaningful.
+const workflow = [
+  readFileSync(resolve(ROOT, ".github/workflows/npm-compat-refresh.yml"), "utf8"),
+  readFileSync(resolve(ROOT, ".github/workflows/npm-compat-promote.yml"), "utf8"),
+].join("\n");
 
 const at = (needle: string): number => workflow.indexOf(needle);
 
@@ -158,13 +168,22 @@ describe("the refresh cannot retrigger itself", () => {
 
 describe("the pre-promote sanity check is unrelated to the PR switch and stays", () => {
   it("still refuses to publish fewer than 20 packages or entries missing name/compile", () => {
-    const check = workflow.slice(
+    // The check moved OUT of an inline `node -e` into scripts/ (#4792) after an
+    // apostrophe in a JS comment terminated the bash string, truncating the
+    // program so every promotion failed for six hours with nothing on fire.
+    // Assert on the step wiring here and the thresholds in the script itself —
+    // asserting the thresholds against the YAML is exactly what stopped being
+    // possible, and is why this test went red on main unnoticed.
+    const step = workflow.slice(
       at("- name: Sanity-check the generated artifact"),
       at("- name: Upload generated artifacts"),
     );
-    expect(check).toContain("packages.length < 20");
-    expect(check).toContain("entry.name && entry.compile");
-    expect(check).toContain("refusing to publish");
+    expect(step).toContain("scripts/check-npm-compat-artifact.mjs");
+
+    const script = readFileSync(resolve(ROOT, "scripts/check-npm-compat-artifact.mjs"), "utf8");
+    expect(script).toContain("packages.length < 20");
+    expect(script).toContain("entry.name && entry.compile");
+    expect(script).toContain("refusing to publish");
   });
 
   it("runs BEFORE anything is pushed", () => {
@@ -208,7 +227,10 @@ describe("the promotion PR must survive auto-enqueue's author-trust gate", () =>
     const withAllowlist = execFileSync("node", ["--input-type=module", "-e", probe], {
       cwd: ROOT,
       encoding: "utf8",
-      env: { ...process.env, TRUSTED_AUTHOR_LOGINS: "ttraenkler,some-app[bot]" },
+      env: {
+        ...process.env,
+        TRUSTED_AUTHOR_LOGINS: "ttraenkler,some-app[bot]",
+      },
     });
     expect(JSON.parse(withAllowlist).trusted).toBe(true);
 

--- a/tests/npm-compat-page-freshness.test.ts
+++ b/tests/npm-compat-page-freshness.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * The dashboard must not present ONE measurement time over a corpus whose
+ * packages were measured at different moments.
+ *
+ * WHY: until 2026-08-23 every package was measured in one run, so the
+ * artifact's `generatedAt` really was when every number on the page was taken,
+ * and the header rendered it directly. The per-package split (#4796) ended
+ * that: packages now measure in independent CI rows, the fast 22 promote about
+ * 12 minutes after a merge, and react-dom (3-4 h) and lit (~40 min) promote on
+ * their own cadence. On the day of the split the page said "measured
+ * 2026-08-23 15:27 UTC" above react-dom figures from 2026-08-20 — a 3-day skew
+ * presented as a single moment.
+ *
+ * These assertions pin the two halves of the fix: the header describes the
+ * SPREAD and names who is behind, and every card carries its own timestamp so
+ * freshness reads as a per-package property rather than an exception.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+const component = readFileSync(resolve(ROOT, "website/components/npm-compat-chart.js"), "utf8");
+
+/**
+ * Exercise the real `_measuredSummary` without a DOM: pull the method off the
+ * component source and call it with the escaping/formatting helpers it needs.
+ * A raw-text pin would pass on a header that renders the right words in the
+ * wrong order; this runs the actual string the reader sees.
+ */
+function measuredSummary(data: unknown): string {
+  const body = component.slice(
+    component.indexOf("  _measuredSummary(data) {"),
+    component.indexOf("  // ratio = nodeUs / wasmUs"),
+  );
+  expect(body).not.toBe("");
+  const host = {
+    _fmtDate(iso: string) {
+      if (!iso) return "";
+      const d = new Date(iso);
+      return Number.isNaN(d.valueOf()) ? "" : `${d.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+    },
+  };
+  // eslint-disable-next-line no-new-func
+  const holder = new Function(`return ({ ${body} });`)();
+  return holder._measuredSummary.call(host, data);
+}
+
+describe("npm-compat page header describes the measurement SPREAD", () => {
+  it("shows a single timestamp when every package was measured in the same run", () => {
+    const text = measuredSummary({
+      generatedAt: "2026-08-23T15:27:53.000Z",
+      measuredRange: {
+        oldest: "2026-08-23T15:20:00.000Z",
+        newest: "2026-08-23T15:27:53.000Z",
+      },
+      refresh: {
+        status: "complete",
+        stalePackages: [],
+        freshCount: 24,
+        totalCount: 24,
+      },
+    });
+
+    expect(text).toBe("2026-08-23 15:27 UTC");
+  });
+
+  it("names the packages left behind and how old they are", () => {
+    const text = measuredSummary({
+      generatedAt: "2026-08-23T15:27:53.000Z",
+      measuredRange: {
+        oldest: "2026-08-20T18:44:18.000Z",
+        newest: "2026-08-23T15:27:53.000Z",
+      },
+      refresh: {
+        status: "partial",
+        stalePackages: ["lit", "react-dom"],
+        freshCount: 22,
+        totalCount: 24,
+      },
+    });
+
+    expect(text).toContain("2026-08-23 15:27 UTC");
+    expect(text).toContain("22 of 24 packages");
+    expect(text).toContain("lit, react-dom");
+    expect(text).toContain("2026-08-20 18:44 UTC");
+  });
+
+  it("falls back to generatedAt for an artifact written before measuredRange existed", () => {
+    const text = measuredSummary({ generatedAt: "2026-08-20T18:44:18.000Z" });
+    expect(text).toBe("2026-08-20 18:44 UTC");
+  });
+
+  it("never renders the bare assembly time when packages are out of sync", () => {
+    // The specific regression: `textContent = this._fmtDate(data.generatedAt)`.
+    expect(component).not.toContain("measuredDate.textContent = this._fmtDate(data.generatedAt)");
+    expect(component).toContain("this._measuredSummary(data)");
+  });
+});
+
+describe("every npm-compat card carries its own measurement time", () => {
+  it("renders a measured row from the package's own stamp, not only for stale rows", () => {
+    const card = component.slice(component.indexOf("const measuredAt = pkg.measuredAt"));
+    expect(card).toContain("pkg.measuredAt ?? pkg.refresh?.lastMeasuredAt");
+    // The stale case still says so, but it is no longer the ONLY case that
+    // gets a date.
+    expect(card).toContain("not re-measured in this run");
+    expect(card).toMatch(/this\._row\(\s*"measured"/);
+  });
+});

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
 
 import { mergeNpmCompatPartials } from "../scripts/lib/npm-compat-partials.mjs";
 
@@ -9,7 +9,9 @@ function partial(names: string[], sourceRevision = "source", downloadBase = 0) {
     summaryMeta: {
       note: "test",
       popularity: { metric: "weekly npm downloads" },
-      performanceMethodology: { optimizationLevels: { "js-host": 4, standalone: 4 } },
+      performanceMethodology: {
+        optimizationLevels: { "js-host": 4, standalone: 4 },
+      },
     },
     packages: names.map((name, index) => ({
       name,
@@ -89,7 +91,12 @@ describe("npm-compat partial aggregation", () => {
       generatedAt: "2026-08-22T00:00:00.000Z",
     });
 
-    expect(result.summary.refresh).toEqual({ status: "partial", stalePackages: ["react"] });
+    expect(result.summary.refresh).toEqual({
+      status: "partial",
+      stalePackages: ["react"],
+      freshCount: 1,
+      totalCount: 2,
+    });
     expect(result.summary.packages.find((entry) => entry.name === "react")?.refresh).toEqual({
       status: "stale",
       reason: "measurement worker did not produce a partial report",
@@ -99,6 +106,90 @@ describe("npm-compat partial aggregation", () => {
     expect(result.perfHistory.runs.at(-1)?.packages).toEqual({
       acorn: { jsHost: { dynamic: 2 }, standalone: {} },
     });
+  });
+
+  it("keeps a stale row's OWN measurement time instead of creeping it forward each refresh", () => {
+    // The regression this pins: `lastMeasuredAt` used to be taken from the
+    // previous SNAPSHOT's generatedAt, so a package that stayed stale across
+    // several promotions reported the most recent one as its measurement date.
+    // With the fast lane promoting every ~12 min and react-dom's row running
+    // 3-4 h, that is the ordinary case.
+    const measuredLongAgo = {
+      ...partial(["react"], "old").packages[0],
+      measuredAt: "2026-08-20T18:44:00.000Z",
+    };
+    let existingPackages: any[] = [measuredLongAgo];
+    let existingGeneratedAt = "2026-08-21T00:00:00.000Z";
+
+    // Three consecutive fast-lane promotions, react-dom stale through all.
+    for (const generatedAt of ["2026-08-22T00:00:00.000Z", "2026-08-22T12:00:00.000Z", "2026-08-23T00:00:00.000Z"]) {
+      const result: any = mergeNpmCompatPartials([partial(["acorn"])], {
+        expectedNames: ["acorn", "react"],
+        sourceRevision: "source",
+        existingPackages,
+        existingGeneratedAt,
+        allowStaleFallback: true,
+        generatedAt,
+      });
+      existingPackages = result.summary.packages;
+      existingGeneratedAt = result.summary.generatedAt;
+    }
+
+    const react = existingPackages.find((entry) => entry.name === "react");
+    expect(react.measuredAt).toBe("2026-08-20T18:44:00.000Z");
+    expect(react.refresh.lastMeasuredAt).toBe("2026-08-20T18:44:00.000Z");
+  });
+
+  it("migrates a pre-measuredAt stale row from refresh.lastMeasuredAt, not the snapshot time", () => {
+    // The live 2026-08-23 artifact: react-dom already stale, its real date only
+    // in refresh.lastMeasuredAt because per-package stamping did not exist yet.
+    // Falling back to existingGeneratedAt here commits the creep ONCE and
+    // permanently — the real date is then unrecoverable by any later run.
+    const legacyStale = {
+      ...partial(["react"], "old").packages[0],
+      refresh: {
+        status: "stale",
+        reason: "worker failed",
+        lastMeasuredAt: "2026-08-20T18:44:18.260Z",
+      },
+    };
+    const result: any = mergeNpmCompatPartials([partial(["acorn"])], {
+      expectedNames: ["acorn", "react"],
+      sourceRevision: "source",
+      existingPackages: [legacyStale],
+      existingGeneratedAt: "2026-08-23T15:27:53.137Z",
+      allowStaleFallback: true,
+      generatedAt: "2026-08-23T17:00:00.000Z",
+    });
+
+    const react = result.summary.packages.find((entry: any) => entry.name === "react");
+    expect(react.measuredAt).toBe("2026-08-20T18:44:18.260Z");
+    expect(react.refresh.lastMeasuredAt).toBe("2026-08-20T18:44:18.260Z");
+  });
+
+  it("stamps fresh rows and reports the measured range across a mixed-age corpus", () => {
+    const stale = {
+      ...partial(["react"], "old").packages[0],
+      measuredAt: "2026-08-20T18:44:00.000Z",
+    };
+    const result: any = mergeNpmCompatPartials([partial(["acorn"])], {
+      expectedNames: ["acorn", "react"],
+      sourceRevision: "source",
+      existingPackages: [stale],
+      allowStaleFallback: true,
+      generatedAt: "2026-08-23T15:27:00.000Z",
+    });
+
+    // A fresh row with no stamp of its own was measured in this run.
+    expect(result.summary.packages.find((entry: any) => entry.name === "acorn").measuredAt).toBe(
+      "2026-08-23T15:27:00.000Z",
+    );
+    expect(result.summary.measuredRange).toEqual({
+      oldest: "2026-08-20T18:44:00.000Z",
+      newest: "2026-08-23T15:27:00.000Z",
+    });
+    expect(result.summary.refresh.freshCount).toBe(1);
+    expect(result.summary.refresh.totalCount).toBe(2);
   });
 
   it("can publish the prior complete snapshot when every worker fails", () => {
@@ -120,27 +211,43 @@ describe("npm-compat partial aggregation", () => {
 });
 
 describe("npm-compat refresh matrix wiring", () => {
-  it("measures independent groups and publishes successful groups after a worker failure", () => {
-    const workflow = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf8");
+  it("measures every package independently and publishes a lane after a worker failure", () => {
+    // The per-package split (2026-08-23) moved the coordinator into its own
+    // reusable workflow and replaced the hardcoded package GROUPS with
+    // catalog-planned matrices, so these guards read both files. The
+    // group-era assertions this replaces (`id: typescript`, `packages:
+    // react-dom`, one `needs: measure`) described a shape that no longer
+    // exists — they broke the moment the split landed.
+    const refresh = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf8");
+    const promote = readFileSync(new URL("../.github/workflows/npm-compat-promote.yml", import.meta.url), "utf8");
 
-    expect(workflow).toContain("github.repository == 'loopdive/js2'");
-    expect(workflow).toContain("fail-fast: false");
-    expect(workflow).toContain(
-      "group: npm-compat-refresh-${{ github.event_name == 'push' && github.sha || format('{0}-{1}', github.ref, github.run_id) }}",
-    );
-    expect(workflow).toMatch(/concurrency:[\s\S]*?cancel-in-progress: false/);
-    expect(workflow).toContain("needs: measure");
-    expect(workflow).toContain("always() && needs.measure.result != 'cancelled'");
-    expect(workflow).toContain("--partial-output");
-    expect(workflow).toContain("actions/download-artifact@v7");
-    expect(workflow).toContain("continue-on-error: true");
-    expect(workflow).toContain("if-no-files-found: warn");
-    expect(workflow).toContain("scripts/merge-npm-compat-partials.mjs");
-    expect(workflow).toContain("id: typescript");
-    expect(workflow).toContain("id: react-dom");
-    expect(workflow).toContain("packages: react-dom");
-    expect(workflow).toContain('DOGFOOD_REACT_DOM_PROJECT_CONCURRENCY: "2"');
-    expect(workflow).not.toContain("id: renderers");
+    expect(refresh).toContain("github.repository == 'loopdive/js2'");
+    expect(refresh).toContain("fail-fast: false");
+
+    // Per-PACKAGE serialization: each row coalesces on its own queue, so a
+    // slow or failing package never delays another package's measurement.
+    expect(refresh).toContain("group: npm-compat-pkg-${{ matrix.package }}");
+    expect(refresh).toMatch(/concurrency:[\s\S]*?cancel-in-progress: false/);
+
+    // Matrices are planned from the catalog at run time — adding a package
+    // must never require a YAML edit.
+    expect(refresh).toContain("scripts/list-npm-compat-packages.mjs");
+    expect(refresh).toContain("fromJSON(needs.resolve.outputs.fast_packages)");
+    expect(refresh).toContain("fromJSON(needs.resolve.outputs.slow_packages)");
+    expect(refresh).not.toContain("id: typescript");
+    expect(refresh).not.toContain("id: renderers");
+
+    // Two lanes, each promoting on its own cadence.
+    expect(refresh).toContain("needs.measure-fast.result != 'cancelled'");
+    expect(refresh).toContain("needs.measure-slow.result != 'cancelled'");
+    expect(refresh).toContain("uses: ./.github/workflows/npm-compat-promote.yml");
+    expect(refresh).toContain("--partial-output");
+    expect(refresh).toContain("if-no-files-found: warn");
+    expect(refresh).toContain("DOGFOOD_REACT_DOM_PROJECT_CONCURRENCY: 2");
+
+    expect(promote).toContain("actions/download-artifact@v7");
+    expect(promote).toContain("continue-on-error: true");
+    expect(promote).toContain("scripts/merge-npm-compat-partials.mjs");
   });
 
   it("keeps the renamed repository guards active for refresh promotion", () => {
@@ -154,7 +261,8 @@ describe("npm-compat refresh matrix wiring", () => {
   });
 
   it("does not force-update a promotion PR while its checks are in flight", () => {
-    const workflow = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf8");
+    // Lives in the reusable coordinator since the per-package split.
+    const workflow = readFileSync(new URL("../.github/workflows/npm-compat-promote.yml", import.meta.url), "utf8");
 
     expect(workflow).toContain("headRefOid");
     expect(workflow).toContain("--paginate");

--- a/tests/virtual-dispatch-stack-discipline.test.ts
+++ b/tests/virtual-dispatch-stack-discipline.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * `emitVirtualMethodDispatchByTag` must emit NOTHING when it bails out, and
+ * must load `__tag` through a struct type the receiver actually has.
+ *
+ * WHY: these two defects are why lit's implementation module failed
+ * `WebAssembly.compile`, and an invalid implementation is expensive far beyond
+ * the one package — the upstream-suite runner halves and retries a unit that
+ * fails validation (depth <= 6, i.e. up to 64 full-bundle recompiles for one
+ * test file), which is a large part of lit's ~28-minute measurement row.
+ *
+ * 1. PARTIAL EMISSION ON BAIL-OUT. The function compiled the receiver into
+ *    `fctx.body` and only then checked that the receiver was ref-typed.
+ *    Returning `undefined` means "I emitted nothing, use the static path", so
+ *    for an EXTERNREF receiver — which is what `class extends HTMLElement`
+ *    produces — the receiver push stayed on the stack, the static path pushed
+ *    it again, and one externref outlived the call. Inside `t && this.k(1)`
+ *    the surviving value became the value of an arm whose block type is i32:
+ *    `type error in fallthru[0] (expected i32, got externref)`.
+ *
+ * 2. TAG LOAD THROUGH THE WRONG STRUCT. The cascade read `struct.get $base` from
+ *    a local typed with the receiver's own struct. These class structs are not
+ *    declared in a Wasm subtype relation (`$__anonClass_0` is a bare
+ *    `(sub (struct …))`), so that is a validation error rather than a widening.
+ *    It fires when the method is compiled as a synthesised per-subclass copy,
+ *    where `this` is the copy's struct but `baseClassName` still names the
+ *    original: lit's `y_get_updateComplete` failed with `struct.get[0] expected
+ *    type (ref null 54), found local.tee of type (ref null 44)`.
+ *
+ * Both need a SUBCLASS to exist — that is what puts the call on the virtual
+ * dispatch path at all — so every case here declares one.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function compileAndValidate(source: string): Promise<{ compiled: boolean; validationError: string | null }> {
+  const result = await compile(source, { fileName: "t.js", skipSemanticDiagnostics: true });
+  if (!result.success || !result.binary?.length) {
+    return { compiled: false, validationError: result.errors?.[0]?.message ?? "no binary emitted" };
+  }
+  try {
+    await WebAssembly.compile(result.binary);
+    return { compiled: true, validationError: null };
+  } catch (error) {
+    return { compiled: true, validationError: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+describe("virtual method dispatch keeps the operand stack balanced", () => {
+  it("emits a valid module for an externref receiver in a short-circuit arm", async () => {
+    // The reduced lit shape: `extends HTMLElement` makes the receiver
+    // externref, so the dispatch path bails — and must leave no trace.
+    const { validationError } = await compileAndValidate(`
+      var y = class extends HTMLElement {
+        m() { let t = false; t && this.k(1); }
+        k(a) {}
+      };
+      var i = class extends y {};
+      export {};
+    `);
+    expect(validationError).toBeNull();
+  });
+
+  it("emits a valid module for the same shape with ?: and ||", async () => {
+    for (const arm of ["t ? this.k(1) : 0", "t || this.k(1)"]) {
+      const { validationError } = await compileAndValidate(`
+        var y = class extends HTMLElement {
+          m() { let t = false; ${arm}; }
+          k(a) {}
+        };
+        var i = class extends y {};
+        export {};
+      `);
+      expect(validationError, `arm: ${arm}`).toBeNull();
+    }
+  });
+
+  it("emits a valid module when the receiver IS a class struct (the tag-load path)", async () => {
+    // No HTMLElement: the receiver is ref-typed, dispatch is really taken, and
+    // the `__tag` read must use a struct type the receiver has.
+    const { validationError } = await compileAndValidate(`
+      var y = class {
+        m() { let t = false; t && this.k(1); }
+        k(a) {}
+      };
+      var i = class extends y {};
+      export {};
+    `);
+    expect(validationError).toBeNull();
+  });
+
+  it("emits a valid module for a two-deep subclass chain", async () => {
+    const { validationError } = await compileAndValidate(`
+      var y = class {
+        m() { let t = false; t && this.k(1); }
+        k(a) {}
+      };
+      var i = class extends y {};
+      var j = class extends i {};
+      export {};
+    `);
+    expect(validationError).toBeNull();
+  });
+
+  it("still dispatches to the overriding implementation at runtime", async () => {
+    // A balanced stack is necessary, not sufficient: the cascade must still
+    // pick the subclass body. Compiling to a valid module and running it is
+    // what distinguishes "we fixed the types" from "we broke dispatch".
+    const result = await compile(
+      `
+      class Base {
+        constructor() { this.seen = 0; }
+        tag() { return 1; }
+        run() { let t = true; return t && this.tag(); }
+      }
+      class Derived extends Base {
+        tag() { return 2; }
+      }
+      export function baseTag() { return new Base().run(); }
+      export function derivedTag() { return new Derived().run(); }
+    `,
+      { fileName: "t.js", skipSemanticDiagnostics: true },
+    );
+    expect(result.success).toBe(true);
+
+    const imports = result.importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(result.binary!, imports);
+    (imports as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+    const exports = instance.exports as { baseTag(): number; derivedTag(): number };
+
+    expect(exports.baseTag()).toBe(1);
+    expect(exports.derivedTag()).toBe(2);
+  });
+});

--- a/website/components/npm-compat-chart.js
+++ b/website/components/npm-compat-chart.js
@@ -91,6 +91,30 @@ class NpmCompatChart extends HTMLElement {
     return `${d.toISOString().slice(0, 16).replace("T", " ")} UTC`;
   }
 
+  // The headline. NOT `generatedAt` — that is when the artifact was assembled,
+  // which since the per-package split (2026-08-23) is a moment that describes
+  // no package in particular. Packages are measured in independent CI rows, so
+  // the fast 22 can be minutes old while react-dom and lit, whose rows take
+  // 3-4 h and ~40 min, are hours or days behind. Rendering one timestamp over
+  // that spread presented the oldest numbers as current: on the day of the
+  // split the page said "measured 15:27 UTC" above react-dom figures from
+  // three days earlier. So say the range, and name who is behind.
+  _measuredSummary(data) {
+    const range = data?.measuredRange;
+    const newest = range?.newest ?? data?.generatedAt;
+    if (!newest) return "—";
+    const head = this._fmtDate(newest) || "—";
+    const stale = data?.refresh?.stalePackages ?? [];
+    const fresh = data?.refresh?.freshCount;
+    const total = data?.refresh?.totalCount ?? data?.packages?.length;
+    if (stale.length === 0) return head;
+
+    const counted = fresh != null && total != null ? ` · ${fresh} of ${total} packages` : "";
+    const oldest = range?.oldest && range.oldest !== newest ? this._fmtDate(range.oldest) : "";
+    const behind = `${stale.join(", ")} last measured ${oldest || "earlier"}`;
+    return `${head}${counted} · ${behind}`;
+  }
+
   // ratio = nodeUs / wasmUs. >1 => wasm faster. <1 => node faster.
   _perfLabel(ratio) {
     if (ratio == null) return { text: "—", cls: "" };
@@ -395,16 +419,22 @@ class NpmCompatChart extends HTMLElement {
         )
       : "";
 
-    const refreshNotice =
-      pkg.refresh?.status === "stale"
-        ? this._row(
-            "refresh",
-            `<span class="muted">not measured in this run${
-              pkg.refresh.lastMeasuredAt
-                ? `; last measured ${this._esc(this._fmtDate(pkg.refresh.lastMeasuredAt))}`
-                : ""
-            }</span>`,
-          )
+    // EVERY card carries its own measurement time, not only the stale ones.
+    // Showing a date exclusively on stale cards frames freshness as an
+    // exception; with packages measured in independent rows it is a per-package
+    // property, and "when was THIS number taken" is a question the reader has
+    // for react-dom and acorn alike.
+    const measuredAt = pkg.measuredAt ?? pkg.refresh?.lastMeasuredAt ?? null;
+    const isStale = pkg.refresh?.status === "stale";
+    const refreshNotice = measuredAt
+      ? this._row(
+          "measured",
+          isStale
+            ? `<span class="muted">${this._esc(this._fmtDate(measuredAt))} — not re-measured in this run</span>`
+            : `<span class="muted">${this._esc(this._fmtDate(measuredAt))}</span>`,
+        )
+      : isStale
+        ? this._row("measured", `<span class="muted">not re-measured in this run</span>`)
         : "";
 
     // Tests — the "own test suite" vs "differential ops" distinction is
@@ -605,7 +635,7 @@ class NpmCompatChart extends HTMLElement {
   _render(data, history) {
     this._data = data;
     const measuredDate = document.getElementById("npm-compat-measured");
-    if (measuredDate) measuredDate.textContent = this._fmtDate(data.generatedAt) || "—";
+    if (measuredDate) measuredDate.textContent = this._measuredSummary(data);
     const pkgs = [...(data.packages ?? [])].sort(
       (left, right) =>
         (right.weeklyDownloads ?? Number.NEGATIVE_INFINITY) - (left.weeklyDownloads ?? Number.NEGATIVE_INFINITY) ||


### PR DESCRIPTION
## Description

Four pieces. Two are dashboard/measurement correctness, two are compiler and harness fixes that come straight out of "why are react-dom and lit so slow".

### 1. The dashboard stops presenting one timestamp over an out-of-sync corpus

The per-package split (#4796) ended the invariant the header relied on. Packages used to be measured in one run, so `generatedAt` really was when every number was taken. Now the fast 22 promote ~12 min after a merge while react-dom (3–4 h) and lit (~40 min) promote on their own cadence — on the day of the split the page read **"measured 2026-08-23 15:27 UTC" above react-dom figures from 2026-08-20**.

- Every package row carries its own `measuredAt` (a `MeasuredPackageList` stamps on push, so all ~15 push sites get it without touching any).
- The header states the **spread** and names who is behind: `15:27 UTC · 22 of 24 packages · lit, react-dom last measured 2026-08-20 18:44 UTC`. `generatedAt` stays in the artifact for the promotion freshness compare and the history chart.
- Every card shows its own `measured` row, not only stale ones.

Two defects found by running this against the **live artifact** rather than fixtures:

- `lastMeasuredAt` **crept** — it came from the previous *snapshot's* `generatedAt`, so a package stale across N promotions reported the Nth as its measurement date. At a 12-minute cadence against a 3–4 h row that is the normal case.
- The migration for pre-`measuredAt` rows must read `refresh.lastMeasuredAt` before falling back to the snapshot time, or it commits that creep once and permanently.

Also repairs **9 guard tests that #4792 and #4796 silently reddened on main** by moving the sanity check into `scripts/` and the coordinator into `npm-compat-promote.yml` without touching the tests that pin them. `test:changed-root` only runs PR-touched test files, so the edit that broke them never selected them. All three files join `tests/guard-suite.json`, which exists for exactly this shape. Suite still green in 109 s.

### 2. Two Wasm-validity bugs in tag-based virtual dispatch

Both made lit's implementation module fail `WebAssembly.compile`, and an invalid implementation is expensive well beyond lit: the runner halves and retries any unit that fails validation (depth ≤ 6, up to 64 full-bundle recompiles for one file).

1. **Partial emission on bail-out.** `emitVirtualMethodDispatchByTag` compiled the receiver into `fctx.body` and only then checked it was ref-typed. Returning `undefined` means "I emitted nothing" — so for an **externref** receiver (`class extends HTMLElement`) the push stayed on the stack, the static path pushed it again, and one externref outlived the call: `type error in fallthru[0] (expected i32, got externref)`. Both post-emission bail-outs now roll back through the existing speculative snapshot.
2. **Tag load through the wrong struct.** The cascade read `struct.get $base` from a local typed with the receiver's own struct. These class structs are not in a Wasm subtype relation (`$__anonClass_0` is a bare `(sub (struct …))`), so that is a validation error. It fires for synthesised per-subclass copies, where `this` is the copy's struct while `baseClassName` names the original.

**Measured:** `lit-html`, `@lit/reactive-element` and `lit-element` each compiled INVALID before and each VALIDATES now. The three-package bundle still fails on a third, unrelated defect (`__anon_42_set`) that appears only with `lit/decorators.js` — not addressed here.

Emitter moves to `src/codegen/expressions/virtual-dispatch.ts` (`calls.ts` is a god file with 3 lines of LOC headroom and the gate's advice is to add to the subsystem module). `calls.ts` re-exports it; the move is verbatim apart from the two fixes.

### 3. react-dom unblocked — the 300 s timeout was the probe's shape, not the module's size

`compileImplementationOnly` hit its ceiling, so the card reported `blocked` with **0 of 1,261** admitted tests executed in Wasm.

Measured on the 536 KB client source: **35.4 s at top level vs 84.4 s wrapped in `function __mod() { … }`**, emitting 1.36 MB vs 1.77 MB — 2.4× the time and 30% more code for identical bytes. `buildImplementationSource` wraps four modules that way to emulate CJS scoping.

The per-batch lane already avoids this — `buildProjectModuleSource` keeps each carrier top-level "so the large React production bodies do not become nested function expressions". The probe now uses that same shape with an empty test list:

| probe shape | result |
| --- | --- |
| `buildImplementationSource` (4 wrappers) | 300 s TIMEOUT, no module, card `blocked` |
| `buildProjectFiles` (real modules) | **96.8 s, success, `validates: true`, 2.25 MB** |

### 4. Recorded, not implemented

- **Why a function body costs 2.4× and emits 30% more** than the same statements at top level. Every CJS package in the corpus pays this somewhere.
- **Lever 2 — the project lane recompiles the implementation per batch.** A zero-test batch costs 102 s; `partitionProjectTests` partitions by file, so 115 files means ≥115 batches ≈ 98 minutes of pure recompilation over the 2-worker pool. Both the clean fix (compile once, link — blocked on the compiler having no module-linking story) and the cheap one (pack by size, ~115 → ~12) are written up on #3982 with the two things the cheap fix does not get free: per-file Jest lifecycle isolation, and a 10× blast radius for the halving-retry it is meant to avoid. Judging it needs a full row before and after; a green harness test is not evidence, so it is deliberately not attempted here.

## Verification

- Dispatch regression tests fail **4/5 without** the compiler change. The fifth instantiates the module and asserts the cascade still selects the overriding implementation, so a stack fix that broke dispatch would not pass.
- Required guard suite 225 passed · class/inheritance suites 63 · class-related equivalence files 153 · react-dom harness 12 passed/1 skipped · typecheck, LOC and function budgets green.
- Header behaviour calls the real `_measuredSummary` rather than pinning text; creep and migration are pinned against the live artifact's shape.

## Known issue, not from this PR

`tests/equivalence/optional-direct-closure-call.test.ts` fails **with and without** these changes — pre-existing red on main, verified by stashing the compiler diff.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ