### PR TITLE
ES5-standalone #4491 wave-4 slice: vec identity at a narrowed param, freeze on array/arguments elements, `var x = undefined`, Date statics

### DIFF
--- a/plan/issues/4491-es5-defineproperty-mop-residual.md
+++ b/plan/issues/4491-es5-defineproperty-mop-residual.md
@@ -5906,7 +5906,8 @@ recorded so they are not re-derived:
 
 Every one reproduces on this branch and is pinned `it.fails` in
 `tests/issue-4491-wave4.test.ts`, so a later lane's fix flips a red test to
-green instead of landing unnoticed.
+green instead of landing unnoticed. The last two rows have no census row at
+all — they surfaced while writing the pins.
 
 | rows | root | owner / next step |
 | --- | --- | --- |
@@ -5921,12 +5922,144 @@ green instead of landing unnoticed.
 | `defineProperties/15.2.3.7-2-16` | `Object.defineProperties(obj, argumentsObject)`: the descriptor-map getter must run with `this` = the arguments object and `Object.prototype.toString.call(this)` must be `"[object Arguments]"`. | the `Properties`-map own-key source for an arguments receiver. Unowned. |
 | `defineProperty/15.2.3.6-4-589` | `teamMeeting.startTime = dateObj` through an INHERITED setter that stores into `var data1 = 1001` reads back `NaN`: the numeric-carrier binding cannot hold a Date. Same defect FAMILY as root 3, different trigger (a numeric initializer rebound to an object, not an `undefined` one). | `mixed-assignment-carrier` / `heterogeneousWidenedModuleGlobalType` (#4428). Unowned. |
 | `defineProperty/15.2.3.6-4-243-2` | the `onlyStrict` twin of a fixed row: a STRICT-mode write to an array-index accessor with no setter must throw a TypeError. The sloppy no-op is correct; the strict-throw is the documented boundary in `__extern_set`'s accessor arm. | the shared `__extern_set_decide` refusal channel already exists (root 2 uses it); wiring the accessor arm to it is a small follow-up. Unowned. |
+| (no census row — found writing the pins) | `Object.freeze(arr)` flips `Object.prototype.hasOwnProperty.call(arr,"0")` from `true` to **`false`**, while `gOPD(arr,"0")` keeps answering the full descriptor. PRE-EXISTING: reproduces with `vec-overlay.ts` reverted. A descriptor that exists while `hasOwnProperty` says the property does not is the #4010 overlay-vs-bag split, now reachable through the integrity path too. | unowned; pinned `it.fails` in `tests/issue-4491-wave4.test.ts`. |
+| (no census row — found writing the pins) | a FUNCTION-LOCAL `var g = undefined` still stores the number 0, and an INLINE `{get: getter}` descriptor argument still throws where the same descriptor in a variable does not. Root 3 fixes the module-global slot on the dynamic define path only. | unowned; see "Not done" below. |
 
 #### Cross-lane (methodology item 7)
 
 The dispatch note flagged `Array/prototype/filter/15.4.4.20-9-b-{2,14,15,16}`
 and `forEach/15.4.4.18-3-23` as possibly rooting in this lane's descriptor
-mirror. They are in the sweep set below with a before/after from this lane's
-own runs; **this lane makes no claim about dev-4641's arm** — a claim about
-another lane's effect needs an arm containing their change, which this two-arm
-A/B is structurally unable to provide.
+mirror. **They do not.** All five are `fail` on BOTH arms of this lane's A/B —
+unchanged by every fix above — so this lane hands them back to #4641 with that
+evidence. **This lane makes no claim about dev-4641's arm**: a claim about
+another lane's effect needs an arm containing their change, which a two-arm
+tip-vs-own A/B is structurally unable to provide.
+
+The four filter HARNESS rows the 2026-08-21 note names as having been
+regressed by the earlier `void 0` module-global widening —
+`filter/15.4.4.20-9-{2,3,4,6}` — are **pass on both arms**. That is the
+measurement that says the wave-4 `= undefined` arm did not repeat that
+regression, and it is why the arm is scoped to the `undefined` identifier
+rather than reusing the full local predicate.
+
+#### Test Results
+
+**Scoped standalone sweep, both arms run in this worktree** (single-test
+driver, `--target standalone`, 7 shards; base arm from file-copy reverts of
+the four touched sources, branch arm at `a41edca71`):
+
+| directory | rows |
+| --- | ---: |
+| `built-ins/Object/defineProperty` | 1131 |
+| `built-ins/Object/defineProperties` | 632 |
+| `built-ins/Object/getOwnPropertyDescriptor` | 310 |
+| `built-ins/Object/keys` | 59 |
+| `built-ins/Object/freeze` | 53 |
+| `built-ins/Object/getOwnPropertyNames` | 45 |
+| `built-ins/Object/preventExtensions` | 40 |
+| + the 9 cross-lane `Array/prototype/{filter,forEach}` rows | 9 |
+| **total** | **2279** |
+
+|  | base | branch |
+| --- | ---: | ---: |
+| pass | 2226 | **2235** |
+| fail | 51 | 42 |
+| infrastructure (compile-timeout / ENOENT) | 2 | 2 |
+
+**UP 9, DOWN 0.** Flip list:
+
+```
+defineProperty/15.2.3.6-4-195      defineProperty/15.2.3.6-4-21
+defineProperty/15.2.3.6-4-243-1    defineProperty/15.2.3.6-4-622
+defineProperties/15.2.3.7-6-a-204  defineProperties/15.2.3.7-6-a-231
+freeze/15.2.3.9-2-a-11             freeze/15.2.3.9-2-a-14
+preventExtensions/15.2.3.10-2
+```
+
+Three rows moved for INFRASTRUCTURE reasons and are excluded from both counts
+— each was re-run SERIALLY on both arms afterwards and passes on both:
+
+- `defineProperty/15.2.3.6-4-419` — base-arm `compilation timeout (123s)` under
+  7-way contention (the box was also running three sibling lanes at load 15-21).
+- `defineProperties/15.2.3.7-5-b-186` — base-arm `ENOENT`, the worktree
+  `test262/` symlink-farm race the brief documents.
+- `defineProperty/15.2.3.6-4-298-1` — the SAME ENOENT race on the branch arm.
+  Counting it as a regression would have been a false alarm; the serial re-run
+  is what settles it.
+
+The 24-row census on the branch: **9 pass, 15 fail** (`.tmp/FINAL-wave4.tsv`),
+matching the sweep exactly.
+
+**Eval tier.** The worktree's `.test262-cache` was copied from the main
+checkout at 12:57Z — i.e. the adapter the lead later found had been built from
+an 8-day-stale bundle. It was kept UNCHANGED across both arms deliberately: a
+base/branch delta is only meaningful if the tier is identical on both sides.
+Blast radius is **2 rows of 2279** (`getOwnPropertyDescriptor/15.2.3.3-4-187`,
+`-4-188` — the only rows in the set that mint from a body string); both pass on
+both arms, and both still pass on the branch after refreshing the cache from
+the rebuilt artifact. None of the 24 census rows is eval-dependent.
+
+**Pins.** `tests/issue-4491-wave4.test.ts` — **14 passed (14)** on the branch;
+on the reverted sources **7 failed / 7 passed**, i.e. every one of the 7
+positive pins fails on the arm it claims to test and every one of the 7
+`it.fails` residual pins reproduces on both arms. Prior-wave suites for this
+issue: `issue-4491-proto-index-constructor-shadow` + `issue-4491-function-
+binding-widening` → **10 passed (10)**; `issue-4506` → **22 passed**.
+
+`issue-4504-inherited-set` → **1 failed / 35 passed (36)**. The one failure
+(`reads present fnctor flow slots directly while absent slots preserve normal
+prototype lookup`, expected 7 got 6) **reproduces on the reverted sources** —
+it is pre-existing on the campaign base, not caused by this slice.
+
+Two harness notes that cost real time and will cost the next lane the same:
+
+- That suite spins its own `CompilerPool`, whose worker imports the GITIGNORED
+  `scripts/runtime-bundle.mjs` and `scripts/compiler-bundle.mjs`. A fresh
+  worktree has NEITHER, so the pool prints `[pool] worker failed before ready
+  (exit 1)` and vitest reports **`36 skipped`, exit code 0** — a suite that
+  runs nothing, green. Build both first
+  (`npx esbuild src/runtime.ts --bundle --platform=node --format=esm
+  --outfile=scripts/runtime-bundle.mjs --external:typescript
+  --external:binaryen`, plus `pnpm run build:compiler-bundle`), and read the
+  "N passed" line rather than the exit code — exactly the check the brief
+  requires.
+- Build those bundles from the arm you are measuring. They are compiled
+  snapshots of `src/`, so a bundle left over from the other arm silently
+  measures the wrong tree.
+
+Three pin-shape findings worth carrying forward, because each one is a way a
+pin can be green without testing anything:
+
+1. The vec-identity pins only reproduce when the CALL is at module scope. With
+   the same helper called from inside `main`, the checker hands the parameter
+   the externref carrier, no conversion is emitted, and the pin passes on base.
+2. The frozen-element pin only reproduces when the module contains a
+   `delete obj[k]` somewhere — that is what sets `vecIndexDeleteDirty` and
+   makes the module `overlayRouteActive`. Without it the typed lane writes
+   through `array.set` and never reaches the guard. That is the honest scope of
+   the fix, and it is why the real failing rows all include `propertyHelper.js`.
+3. The `{get: <undefined var>}` pin only reproduces when the descriptor is
+   passed as a VARIABLE. An inline literal argument takes the static
+   literal-shape define path, which still throws — the same defect has two
+   lowerings and only one of them is fixed.
+
+Gates at commit (`SKIP_SLOW_PRECOMMIT=1`): `check:loc-budget` OK,
+`check:func-budget` OK, both under the grants added to this file's
+frontmatter. `test262` gitlink verified untouched
+(`git diff 52cb0a6a6..HEAD --stat -- test262` empty).
+
+#### Not done, and why
+
+A local (function-scope) `var g = undefined` still stores the number 0. The
+one-line extension of `varBindingNeedsExternrefForUndefined` was written and
+**measured not to fix it** — the enclosing object literal's field type is
+decided separately — so it was reverted rather than shipped: a behaviour
+change on every `var x = undefined` local in every module with no measured
+beneficiary is exactly the trade this campaign's audit chain keeps flagging.
+
+Root 1's withdrawal was NOT extended to variable declarations
+(`var alias = arr` shows the same converting copy — measured: `alias[1]`
+answers the raw slot while `arr[1]` invokes the getter). No census row needed
+it, and the same "no measured beneficiary" rule applies. Worth knowing that
+the defect is not parameter-specific: a JS array is a REFERENCE, and any
+cross-carrier vec→vec conversion silently makes a copy of one.

--- a/plan/issues/4491-es5-defineproperty-mop-residual.md
+++ b/plan/issues/4491-es5-defineproperty-mop-residual.md
@@ -5925,6 +5925,41 @@ all — they surfaced while writing the pins.
 | (no census row — found writing the pins) | `Object.freeze(arr)` flips `Object.prototype.hasOwnProperty.call(arr,"0")` from `true` to **`false`**, while `gOPD(arr,"0")` keeps answering the full descriptor. PRE-EXISTING: reproduces with `vec-overlay.ts` reverted. A descriptor that exists while `hasOwnProperty` says the property does not is the #4010 overlay-vs-bag split, now reachable through the integrity path too. | unowned; pinned `it.fails` in `tests/issue-4491-wave4.test.ts`. |
 | (no census row — found writing the pins) | a FUNCTION-LOCAL `var g = undefined` still stores the number 0, and an INLINE `{get: getter}` descriptor argument still throws where the same descriptor in a variable does not. Root 3 fixes the module-global slot on the dynamic define path only. | unowned; see "Not done" below. |
 
+#### Routed IN from #4654 (2026-08-23) — accessor-tier twin of the T9 fix
+
+dev-4654 handed over three rows whose root is in this issue's files, with the
+analysis already done and the wrong fix already ruled out. Recorded here so it
+is not lost; **not taken in this slice** — it is a different member KIND with
+its own risk record, and folding an unmeasured accessor-tier change into a
+branch whose zero-regression claim is already established would put that claim
+at risk. It should be dispatched as its own wave-5 slice.
+
+- Rows: `RegExp/prototype/{global,multiline,ignoreCase}/S15.10.7.{2,4,3}_A9.js`.
+  The receiver is `RegExp.prototype` ITSELF, not an instance. `hasOwnProperty`
+  and the `delete` both pass; the SECOND `hasOwnProperty` (must be `false`)
+  fails.
+- Root: `__nproto_hasown` (`native-proto-own-props.ts`). Those three names are
+  in the brand's `$memberCsv`, and the CSV token scan answers `1`
+  unconditionally. The seeded-member ladder that consults the mutable
+  companion — the one #4491 T9 added `constructor` to — is restricted to
+  `kind === "method"`, because `ensureNativeProtoCompanionSeeder` deliberately
+  does not seed accessors. So a deleted accessor member is resurrected by the
+  CSV. Structurally the SAME defect T9 closed for `constructor`, one member
+  kind over.
+- Ruled out, with a record: seeding the getters via
+  `__defineProperty_accessor` flips `tests/issue-2885.test.ts` ("plain read
+  `RegExp.prototype.global` is undefined") to FAIL, and that mechanism is not
+  established (see the "ACCESSORS ARE DELIBERATELY NOT SEEDED IN THIS SLICE"
+  note in `native-proto.ts`).
+- The direction that is still open: these rows do not need accessors SEEDED —
+  they need a DELETION to be OBSERVABLE. A tombstone consulted by the CSV
+  shortcut answers all three assertions without installing an accessor entry,
+  and therefore without touching the #2885 read path. Merely routing accessor
+  keys through the companion does NOT work: the companion has no entry for
+  them, so the FIRST `hasOwnProperty` would start failing.
+- Control set for whoever takes it:
+  `%TypedArray%.prototype.{buffer,byteLength,byteOffset,length}/prop-desc.js`.
+
 #### Cross-lane (methodology item 7)
 
 The dispatch note flagged `Array/prototype/filter/15.4.4.20-9-b-{2,14,15,16}`

--- a/plan/issues/4491-es5-defineproperty-mop-residual.md
+++ b/plan/issues/4491-es5-defineproperty-mop-residual.md
@@ -132,6 +132,25 @@ loc-budget-allow:
   # entry above). Surfaced only after #4723's post-merge baseline refresh
   # reset the ceiling.
   - src/codegen/object-runtime.ts
+  # 2026-08-23 wave-4 census slice. Four narrow arms, each in the ONE module
+  # that owns the decision it corrects — none of them has a body that can be
+  # moved out, because each is a guard/withdrawal inside an existing ordered
+  # chain:
+  #  - declarations/param-return-inference.ts (+~35): a fifth WITHDRAWAL rule
+  #    alongside #3548/#4555/#4530/#2867-S2, in the same `if (type !== null …)`
+  #    ladder at the end of `inferParamTypeFromCallSites`. The rule IS the
+  #    dispatch; there is no body.
+  #  - builtin-ctor-own-props.ts (+~12): one entry (plus its cost rationale) in
+  #    the existing `CTOR_STATIC_METHODS` table.
+  #  - vec-overlay.ts (+~110): the integrity-bag consult for a vec's IMPLICIT
+  #    element descriptor and the frozen-own-index write guard. Both splice
+  #    into `__vec_gopd` / `__extern_set`'s prologue and reference those
+  #    functions' own local vectors, so they cannot live anywhere else (the
+  #    same constraint as the #4491 lane B entry above).
+  #  - declarations.ts: extends the existing 2026-08-21 void-undefined grant
+  #    with the `= undefined` IDENTIFIER arm next to the void-call arm.
+  - src/codegen/declarations/param-return-inference.ts
+  - src/codegen/builtin-ctor-own-props.ts
 oracle-ratchet-allow:
   # 2026-08-21: one getTypeAtLocation in varBindingNeedsExternrefForUndefined's
   # new call arm — the same raw-checker idiom as the surrounding predicate;
@@ -200,6 +219,17 @@ coercion-sites-allow:
   # hand-rolled.
   - src/codegen/string-fromcharcode-value-read.ts
 func-budget-allow:
+  # 2026-08-23 wave-4 census: +38 in `inferParamTypeFromCallSites`, which is a
+  # TERMINAL LADDER of soundness withdrawals — #3548 (under-application), #4555
+  # (native scalars), #4491 (nullish arg), #4530 (opaque `any`), #2867 S2
+  # (escapes-as-value) — each a `if (type !== null && …) type = null;` guard on
+  # the SAME local. The wave-4 vec-carrier rule is the sixth. It cannot be
+  # hoisted into a helper without passing `type` in and out by reference (the
+  # ladder is order-dependent: a later rule must see the earlier ones' result),
+  # and splitting the ladder in half would put the withdrawal decisions in two
+  # files with no single place to read the rule set. Most of the +38 is the
+  # rationale comment the surrounding rules all carry.
+  - src/codegen/declarations/param-return-inference.ts::inferParamTypeFromCallSites
   # 2026-08-22 PR #4768: +4 dispatch in the T12 redeclared-binding arm.
   - src/codegen/statements/variables.ts::compileVariableStatement
   # 2026-08-22 gate-visibility re-grant for PR #4768, same stranded-grant
@@ -5733,3 +5763,170 @@ row live before edits (methodology item 1). Possible cross-lane overlap:
 family but may root here (descriptor mirror on callback iteration) —
 whichever lane measures the root first takes them, hand over with
 evidence.
+
+### Wave-4 census RESULT (dev-4491, branch `issue-4491-wave4`, base `52cb0a6a6`)
+
+All 24 rows re-verified failing on the campaign base before any edit
+(`.tmp/base-wave4.tsv`, standalone lane, single-test driver). **8 of the 24
+flip to pass**, from four independent roots. Every number below is from a run
+executed in this worktree; the base side was re-measured from file-copy
+reverts (`.tmp/base/*.ts`), not inherited.
+
+#### Root 1 — a monomorphic vec PARAMETER destroys array identity (5 rows)
+
+`Object.defineProperty(arr, "1", {get, set})` records the accessor in the
+#3251 overlay companion, which is a module-global side table **keyed by vec
+IDENTITY** (`ref.eq`). `inferParamTypeFromCallSites` narrows a callee's
+implicit-any parameter to the argument's `resolveWasmType`, and in a
+descriptor-dirty module the checker's element type is **not** a proof of the
+runtime carrier: `var arr = []; Object.defineProperty(arr, …)` is `number[]`
+to the checker after the first numeric element write, but codegen materialises
+it as `$__vec_externref` so the overlay can hold accessor entries. The
+parameter is therefore narrowed to `$__vec_f64`, and the ARGUMENT boundary
+becomes a carrier conversion — `emitSafeStructConversion` →
+`emitVecToVecBody`, an element-wise copy into a **fresh `struct.new`**. The
+callee receives an array the overlay has never heard of.
+
+Measured, standalone, on the base (`.tmp/pA*.js` probes):
+
+| read of `arr[1]` where index 1 is an accessor returning 3 | answer |
+| --- | --- |
+| module level, literal key | `3` (getter invoked) |
+| `function f(o,k,v){return o[k];}` called once with `arr` | **`0`** (raw backing slot, getter never invoked) |
+| the SAME call site made polymorphic (a second, non-array call) | `3` |
+
+The emitted signature is the proof: with the module-level call the callee is
+`(func $readThrough (param (ref null 4) …))` where `arr`'s global is
+`(mut (ref null 2))` — `$__vec_f64` vs `$__vec_externref`.
+
+That is exactly `propertyHelper.js`: `verifyEqualTo` / `verifyWritable` /
+`verifyProperty` all take the array under test as their only `obj` argument,
+so the whole verification family ran on a COPY. It is also why the defect
+resisted isolation — a two-parameter clone of `verifyEqualTo` in the test body
+answered correctly whenever the same helper was ALSO called before the
+element write, because the narrowing depends on the call sites, not the call.
+
+**Fix** (`src/codegen/declarations/param-return-inference.ts`, +~35): a fifth
+withdrawal rule in the existing ladder — when `overlayRouteActive(ctx)` (the
+module-wide #4159/#4222/#4160 pre-scan flag), withdraw a narrowing to any
+`__vec_*` carrier. Free where it applies: that flag already routes typed-lane
+element access through the dynamic lane, so a vec-typed parameter buys nothing
+there and costs identity. Byte-identical in every module where the flag is
+clear.
+
+Flips: `defineProperty/15.2.3.6-4-195`, `-4-243-1`,
+`defineProperties/15.2.3.7-6-a-204`, `-6-a-231`.
+(`-4-243-2`, the `onlyStrict` twin of `-4-243-1`, still fails — see Residuals.)
+
+#### Root 2 — `Object.freeze` was invisible to an array/arguments ELEMENT (2 rows)
+
+`__object_freeze` records the level on the carrier's #4032 integrity bag and
+clears W/C on the **bag's** entries. A vec's elements have no bag entry, so
+the implicit element descriptor `__vec_gopd` synthesises kept answering
+`{writable: true, configurable: true}` — and, worse, nothing refused the
+operations: measured on base, `Object.freeze([0,1,2])` then propertyHelper's
+`isWritable(arr,"0")` answered **true** (the store landed and was reverted)
+and `isConfigurable(arr,"0")` answered **true** (the delete succeeded, which
+then made `isEnumerable` answer false as a knock-on).
+
+**Fix** (`src/codegen/vec-overlay.ts`, +~110), two halves that compose:
+
+1. `__vec_gopd`'s implicit element descriptor reads the integrity bag
+   (`__vec_bag_lookup` — LOOKUP, never `ensure`: a gOPD is a pure query and
+   must not allocate a bag for every array merely inspected) and answers
+   `writable: !FROZEN`, `configurable: !SEALED`. `enumerable` is untouched by
+   either operation.
+2. `__extern_set`'s vec arm refuses a write to an own, BACKED index of a
+   frozen vec, publishing the shared refusal result so a strict-mode
+   assignment throws. Deliberately scoped to an index inside the backed
+   length: a key the frozen array does NOT own must still walk the prototype
+   chain, so this is not a blanket refusal.
+
+The DELETE half needed no new code — `buildVecDeletePrologue` already consults
+`__vec_gopd(obj,key).configurable` and refuses on false, so half (1) closes it
+by construction.
+
+Flips: `freeze/15.2.3.9-2-a-11` (arguments), `-2-a-14` (array).
+
+#### Root 3 — `var x = undefined` was the NUMBER 0 (2 rows)
+
+`resolveWasmType(undefined)` is `i32` ("void → no result"), a lowering
+convention for a RESULT. Applied to a module-global BINDING it stored
+`i32.const 0` and boxed to `ref.i31 0`. Measured on base:
+
+```
+var g  = undefined; ({get: g }).get === undefined   // false   ← i31 0
+var g2;             ({get: g2}).get === undefined   // true
+```
+
+Two census rows are this one defect: `{get: getter}` with
+`var getter = undefined` threw `TypeError: Getter/setter must be a function`
+(§6.2.5.6 accepts an undefined half; the ambiguous raw value took the
+non-callable arm), and `var o2 = undefined; o2 = Object.preventExtensions(o)`
+read back `0` instead of the object.
+
+**Fix** (`src/codegen/declarations.ts`): one arm next to the existing
+2026-08-21 void-CALL arm in `moduleGlobalWasmType` — an initializer that is
+the `undefined` IDENTIFIER resolving to the global binding gets an `externref`
+slot. Deliberately NOT the general "declared type is purely undefined/void"
+rule (an optional read or a delete-sentinel keeps its numeric slot) and NOT
+the `void 0` arm, which is the one the 2026-08-21 note records as having
+regressed the filter harness family.
+
+Flips: `defineProperty/15.2.3.6-4-21`, `preventExtensions/15.2.3.10-2`.
+
+#### Root 4 — `Date`'s statics were not own properties (1 row)
+
+The ctor carrier seeded only `length`/`name`/`prototype`, so
+`Object.prototype.hasOwnProperty.call(Date,"now")` answered false and
+`gOPN(Date)` reported three names. **Fix**
+(`src/codegen/builtin-ctor-own-props.ts`): `Date: ["now","parse","UTC"]` in
+`CTOR_STATIC_METHODS`. This joins that table on the SAME cost argument its
+String-only note makes, not against it — `BUILTIN_STATIC_METHOD_ARITY.Date`
+has exactly three entries, the same order of magnitude as String's three, not
+`Math`'s ~30.
+
+Flip: `defineProperty/15.2.3.6-4-622`.
+
+#### What the roots were NOT
+
+Two hypotheses were measured and falsified before the ones above, and are
+recorded so they are not re-derived:
+
+- *"the dynamic-key element read ignores the overlay"* — it does not:
+  `__extern_get_idx` and `__extern_get` both carry the overlay read prologue
+  and both answer the getter correctly. The receiver they were handed was a
+  different object.
+- *"the `{get: undefined}` TypeError is a ToPropertyDescriptor bug"* — the
+  literal spelling `{get: undefined}` and `{get: void 0}` both already worked;
+  only a value routed through an `undefined`-typed binding failed, which put
+  the defect in the binding's slot, not in the descriptor reader.
+
+#### Residuals — 16 of 24, each with a measured root and an owner
+
+Every one reproduces on this branch and is pinned `it.fails` in
+`tests/issue-4491-wave4.test.ts`, so a later lane's fix flips a red test to
+green instead of landing unnoticed.
+
+| rows | root | owner / next step |
+| --- | --- | --- |
+| `defineProperty/15.2.3.6-4-183`, `defineProperties/15.2.3.7-6-a-179` | array INDEX at 2^32-2 must bump `length` to 2^32-1. `MAX_CANONICAL_INDEX` is `2^31-1` because `__obj_index_of_key`'s result doubles as a SIGNED sort key for OrdinaryOwnPropertyKeys, so keys in `[2^31, 2^32-2]` are ordinary string keys and never touch `length`. | **#4497** — already filed by the 2026-08-21 bucket-D triage as exactly this (`part D-I`). Not re-derived here. |
+| `defineProperties/15.2.3.7-6-a-183` | a data-only descriptor whose VALUE is kind-incompatible with the array's carrier (a string into `$__vec_f64`) cannot be written back into the element, so it lands in the companion with `FLAG_COMPANION_VALUE` — but `isNonDataDescriptorDefine` calls `{value: "abc"}` data-only, the module is not descriptor-dirty, and the typed read never consults the companion. Measured: `gOPD(arr,"1").value === "abc"` while `arr[1] === 2`. | NOT a pre-scan fix: flagging every `{value: <non-numeric>}` define would route element access in any module containing `Object.defineProperty(x,k,{value:true})` through the dynamic lane. The narrow fix is to widen that BINDING's carrier (`heterogeneousWidenedModuleGlobalType`, #4428). Unowned. |
+| `keys/15.2.3.14-5-13` | defining a far index (10000) grows the backing with a NON-hole default, so `Object.keys` enumerates the whole filled range: measured 9999 keys where the spec wants 4. | growth must fill with the `$Hole` sentinel (externref carriers) or skip the write-back. Unowned. |
+| `keys/15.2.3.14-5-a-4` | `delete array[0]` on an `Object.keys` RESULT records the tombstone (`hasOwnProperty("0")` → false) but the element read still answers `"prop1"`. The keys result is an `$ObjVec`, not a `__vec_*` carrier, so the #4222 delete/presence prologues do not cover it. | unowned; the `$ObjVec`-vs-vec split is the same seam as #4010. |
+| `freeze/15.2.3.9-2-a-12`, `preventExtensions/15.2.3.10-3-5` | a String object's INDEX read misses through a dynamic receiver: measured `readThrough(new String("abc"), "0")` → `undefined`, while the module-level literal-key read answers `"a"`. `preventExtensions` additionally does not stop `new String()` from answering a character for an out-of-range index. | `string-exotic-own-props.ts` (the #4232 §10.4.3 lane). Unowned. |
+| `getOwnPropertyDescriptor/15.2.3.3-4-4`, `-4-34`, `getOwnPropertyNames/15.2.3.4-4-1` | the GLOBAL object and `Function.prototype` expose no own function properties: `gOPD(this,"eval")` and `gOPD(Function.prototype,"constructor")` are `undefined`, and `gOPN(this)` reports a name set missing every global function. The comparable tables DO work — `Math.abs` and `Array.prototype.push` both answer the full `{w:true,e:false,c:true}` triple — so this is a carrier-coverage gap, not a MOP gap. | needs a global-object own-property carrier + `constructor` on the `Function.prototype` proto (which has no identity-stable carrier, per the T9/T10 note above). Unowned. **Distinct from #4651**: `gOPN(this)` also TRAPS with `illegal cast` in some module shapes (surfaced by this lane's probe, filed by the lead as #4651). `15.2.3.4-4-1` itself does NOT trap — it fails its own `assert` on a short name list — so the row belongs here, not to #4651. |
+| `defineProperty/S15.2.3.6_A1` | §13.5.3 says `typeof` of an unresolvable Reference is `"undefined"`, but a name the TS DOM lib declares gets an ambient `valueDeclaration`, so `typeof-delete.ts`'s undeclared-fold does not fire and the static type fold answers `"object"` — then `document.createElement` null-derefs and the test never reaches its own guard. | closing it needs the standalone PROVIDED-globals set; today `structuredClone` has a hand-written arm for exactly this shape. Unowned. Worth more than one row: `typeof document !== "undefined"` is a very common npm guard. |
+| `defineProperty/15.2.3.6-3-138` | a descriptor object whose `value` field is INHERITED and is an accessor with no getter must make the property `undefined`. `__desc_has_own` does walk the chain (`"value" in child` → true, `child.value` → undefined), yet the define leaves the old value in place. | root not isolated — the presence and read halves both answer correctly, so the loss is inside `__obj_define_from_desc`'s field ACCUMULATION for this receiver shape (a fnctor instance). Unowned. |
+| `defineProperties/15.2.3.7-2-16` | `Object.defineProperties(obj, argumentsObject)`: the descriptor-map getter must run with `this` = the arguments object and `Object.prototype.toString.call(this)` must be `"[object Arguments]"`. | the `Properties`-map own-key source for an arguments receiver. Unowned. |
+| `defineProperty/15.2.3.6-4-589` | `teamMeeting.startTime = dateObj` through an INHERITED setter that stores into `var data1 = 1001` reads back `NaN`: the numeric-carrier binding cannot hold a Date. Same defect FAMILY as root 3, different trigger (a numeric initializer rebound to an object, not an `undefined` one). | `mixed-assignment-carrier` / `heterogeneousWidenedModuleGlobalType` (#4428). Unowned. |
+| `defineProperty/15.2.3.6-4-243-2` | the `onlyStrict` twin of a fixed row: a STRICT-mode write to an array-index accessor with no setter must throw a TypeError. The sloppy no-op is correct; the strict-throw is the documented boundary in `__extern_set`'s accessor arm. | the shared `__extern_set_decide` refusal channel already exists (root 2 uses it); wiring the accessor arm to it is a small follow-up. Unowned. |
+
+#### Cross-lane (methodology item 7)
+
+The dispatch note flagged `Array/prototype/filter/15.4.4.20-9-b-{2,14,15,16}`
+and `forEach/15.4.4.18-3-23` as possibly rooting in this lane's descriptor
+mirror. They are in the sweep set below with a before/after from this lane's
+own runs; **this lane makes no claim about dev-4641's arm** — a claim about
+another lane's effect needs an arm containing their change, which this two-arm
+A/B is structurally unable to provide.

--- a/plan/method/es5-standalone-agent-brief.md
+++ b/plan/method/es5-standalone-agent-brief.md
@@ -95,6 +95,40 @@ provider (`npx tsx scripts/build-quickjs-eval-provider.mjs`, falling back to
 `JS2WASM_EVAL_ENGINE=interpreter`), and confirm a known eval-dependent row
 runs before trusting the numbers.
 
+## Environment trap: a suite that runs ZERO tests and exits 0 (2026-08-23, dev-4491)
+
+`tests/issue-4504-inherited-set.test.ts` spins its **own `CompilerPool`**, whose
+worker imports the GITIGNORED `scripts/runtime-bundle.mjs` and
+`scripts/compiler-bundle.mjs`. A fresh worktree has NEITHER, so the worker dies
+(`[pool] worker failed before ready (exit 1)`), vitest reports **`36 skipped`**,
+and the process **exits 0**. Every lane that ran it in a fresh worktree read a
+green that measured nothing.
+
+This is the concrete instance of the brief's "N passed, never exit 0" rule:
+`skipped` is not `passed`. Read the counts. When a suite spins its own pool,
+build BOTH bundles from **the arm you are measuring**
+(`pnpm run build:compiler-bundle`), or its verdict is about your bundle, not
+your branch. Built correctly this suite is 1 failed / 35 passed, and that one
+failure is pre-existing on the campaign base.
+
+## Environment trap: CONTENTION fakes both failures and regressions (2026-08-23, dev-4491 + lead)
+
+With several lanes sweeping at once, load on this box runs 12–16 and a compile
+that normally takes ~9 s can take **47–123 s**, so `runTest262File`'s timeout
+fires and the row reports `compile_error: compilation timeout`. Measured the
+same day in both directions: three of dev-4491's 2,279 sweep rows moved for
+infrastructure reasons alone — one of them (`15.2.3.6-4-298-1`, an ENOENT from
+the symlink-farm race) **would have read as a regression** — and two lead-run
+pins (`issue-4641`, `issue-4643`) failed on timeout under 5-lane load and passed
+**25/25** when re-run serially minutes later.
+
+**Standing practice: re-run every apparent flip AND every apparent regression
+serially before it goes in a report.** A timeout is not a verdict about your
+change. Note also that `runTest262File`'s `timeoutMs` is a POST-HOC check — it
+measures elapsed time after `await compile(...)` returns and cannot interrupt a
+slow compile, so a 600 s compile runs the full 600 s and only then reports a
+timeout; bounding it needs an OS-level `timeout` on the driver process.
+
 ## Environment trap: STALE `scripts/compiler-bundle.mjs` poisons every eval-tier A/B (2026-08-23, dev-4647)
 
 The quickjs eval ADAPTER is a js2wasm-compiled artifact, and

--- a/src/codegen/builtin-ctor-own-props.ts
+++ b/src/codegen/builtin-ctor-own-props.ts
@@ -150,6 +150,17 @@ const CTOR_NUMERIC_CONSTANTS: Record<string, Record<string, number>> = {
  */
 const CTOR_STATIC_METHODS: Record<string, readonly string[]> = {
   String: ["fromCharCode", "fromCodePoint", "raw"],
+  // (#4491 wave-4) `Date` joins on the SAME cost argument the String-only note
+  // above makes, not against it: `Date` has exactly THREE statics
+  // (`BUILTIN_STATIC_METHOD_ARITY.Date = {now, parse, UTC}`), the same order of
+  // magnitude as String's three — not `Math`'s ~30 or `Object`'s ~24. The
+  // measured row is `defineProperty/15.2.3.6-4-622`
+  // (`verifyProperty(Date, "now", {writable, enumerable, configurable})`),
+  // which failed at `__hasOwnProperty(Date, "now")` → "now should be an own
+  // property" while `gOPN(Date)` reported only `length, name, prototype`.
+  // Widening to a receiver with tens of statics still needs its own cost
+  // measurement.
+  Date: ["now", "parse", "UTC"],
 };
 
 /**

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2382,6 +2382,33 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
           return { kind: "externref" };
         }
       }
+      // (#4491 wave-4) `var g = undefined` — the LITERAL undefined identifier.
+      // `resolveWasmType(undefined)` is i32 ("void → no result"), a lowering
+      // convention for a RESULT, not a claim that this binding holds the
+      // number 0. Measured on this base, standalone:
+      //   `var g = undefined; ({get: g}).get === undefined` → FALSE
+      //     (the slot stored `i32.const 0`, boxed to `ref.i31 0`), while
+      //   `var g2;        ({get: g2}).get === undefined` → true.
+      // Two wave-4 rows root here: `Object.defineProperty(o, "foo", {get: getter})`
+      // with `var getter = undefined` threw "Getter/setter must be a function"
+      // (§6.2.5.6 accepts an undefined half), and `var o2 = undefined; o2 =
+      // Object.preventExtensions(o)` read back `0` instead of the object.
+      //
+      // Scoped to the `undefined` IDENTIFIER resolving to the global binding —
+      // NOT the general "declared type is purely undefined/void" rule the
+      // comment above warns about, and NOT the `void 0` arm (which is what
+      // regressed the filter harness shapes). A binding written `= undefined`
+      // states the value at the source; a binding that merely TYPES as
+      // undefined (an optional read, a delete-sentinel) does not, and keeps
+      // its numeric slot.
+      if (
+        init !== undefined &&
+        ts.isIdentifier(init) &&
+        init.text === "undefined" &&
+        ctx.oracle.valueDeclarationOf(init) === undefined
+      ) {
+        return { kind: "externref" };
+      }
     }
     // #1914 — `var m = re.exec(s)` under standalone gets the precise
     // match-vec ref type so indexed reads stay on the static vec path

--- a/src/codegen/declarations/param-return-inference.ts
+++ b/src/codegen/declarations/param-return-inference.ts
@@ -12,6 +12,8 @@ import { forEachChild, ts } from "../../ts-api.js";
 import { numericAdmissionEnabled } from "../analysis/mixed-assignment-carrier.js";
 import { isStandalonePromiseActive } from "../async-scheduler.js";
 import { hasAsyncModifier, resolveWasmType } from "../index.js";
+import { overlayRouteActive } from "../typed-lane-overlay-route.js";
+import { getVecInfo } from "../type-coercion.js";
 import type { ValType } from "../../ir/types.js";
 import type { CodegenContext } from "../context/types.js";
 
@@ -626,6 +628,44 @@ export function inferParamTypeFromCallSites(
     type !== null &&
     (type.kind === "ref" || type.kind === "ref_null") &&
     !paramHasConcreteAnnotation()
+  ) {
+    type = null;
+  }
+  // (#4491 wave-4) Soundness for the DESCRIPTOR-DIRTY module: withdraw a
+  // narrowing to a concrete `__vec_*` carrier.
+  //
+  // The checker's element type is not a proof of the runtime CARRIER once a
+  // descriptor can exist. `var arr = []; Object.defineProperty(arr, "1", {get})`
+  // is `number[]` to the checker after the first numeric element write, but
+  // codegen materialises it as `$__vec_externref` so the overlay can hold
+  // accessor entries. Narrowing the callee's parameter to `$__vec_f64` then
+  // makes the ARGUMENT boundary a carrier conversion, and `emitVecToVecBody`
+  // implements that as an element-wise COPY into a fresh `struct.new` — a
+  // brand-new vec. The #3251 overlay side table is keyed by vec IDENTITY
+  // (`ref.eq`), so the callee receives an array with NO descriptors at all:
+  // accessor get/set, `writable:false` enforcement and companion values all
+  // vanish, and the element read answers the raw backing slot.
+  //
+  // Measured (standalone, this base): `function f(o, k, v) { return o[k]; }`
+  // called once as `f(arr, "1", getFunc())` answered `0` while the identical
+  // read at module level answered `3` (the getter). Making the SAME call site
+  // polymorphic — which withdraws the narrowing through the #4530 rule —
+  // answered `3`. That is the whole `propertyHelper.js` verification family
+  // (`verifyEqualTo` / `verifyWritable` / `verifyProperty`), whose `obj`
+  // parameter is monomorphic on the array under test in every array-descriptor
+  // test262 file.
+  //
+  // Scoped to `overlayRouteActive` — the module-wide pre-scan flag that already
+  // routes typed-lane element access through the dynamic lane (#4159). In such
+  // a module the vec-typed parameter buys nothing (every access is routed
+  // anyway) and costs identity, so the withdrawal is free where it applies and
+  // byte-identical everywhere else. Withdrawing leaves the parameter on its
+  // resolved `externref`, which passes the ORIGINAL struct by reference.
+  if (
+    type !== null &&
+    (type.kind === "ref" || type.kind === "ref_null") &&
+    overlayRouteActive(ctx) &&
+    getVecInfo(ctx, (type as { typeIdx: number }).typeIdx) !== null
   ) {
     type = null;
   }

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -120,6 +120,19 @@ const FLAG_ENUMERABLE = 0x02;
 const FLAG_CONFIGURABLE = 0x04;
 const FLAG_ACCESSOR = 0x08;
 
+/**
+ * (#4491 wave-4) Mirrors of the (unexported) `$Object.flags` INTEGRITY bits in
+ * object-runtime.ts — `OBJ_FLAG_SEALED` / `OBJ_FLAG_FROZEN`, set by
+ * `__object_seal` / `__object_freeze` on the carrier's integrity bag
+ * (`object-runtime-integrity.ts` `emitSetFlags`). Read here so a vec's IMPLICIT
+ * element descriptor can report the level: `__object_freeze` clears W/C on the
+ * BAG's own entries, but a vec's elements have no bag entries at all, so
+ * without this consult `Object.freeze([0,1,2])` left
+ * `gOPD(arr,"0").writable === true`.
+ */
+const OBJ_FLAG_SEALED = 0x02;
+const OBJ_FLAG_FROZEN = 0x04;
+
 /** Host f64 flag-word bits (computeRuntimeFlags, object-ops.ts). */
 const HOST_HAS_VALUE = 1 << 7;
 /**
@@ -669,6 +682,10 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
   const callAccessorSetIdx = ctx.funcMap.get("__call_accessor_set");
   const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
   const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals");
+  // (#4491 wave-4) OPTIONAL: the read-only carrier-bag lookup (never allocates).
+  // Absent ⇒ the implicit element descriptor keeps its pre-#4491 all-true
+  // answer, byte-identical.
+  const vecBagLookupIdx = ctx.funcMap.get("__vec_bag_lookup");
   if (
     objFindIdx === undefined ||
     dpValueIdx === undefined ||
@@ -1818,7 +1835,56 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         { name: "len", type: { kind: "i32" } },
         { name: "d", type: { kind: "externref" } },
         { name: "e", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
+        // (#4491 wave-4) integrity-bag scratch for the implicit element
+        // descriptor's writable/configurable answer.
+        { name: "bag", type: { kind: "externref" } },
       ];
+      const L_BAG = 8;
+      /**
+       * (#4491 wave-4) `i32` — is `bit` set on this vec's integrity bag?
+       * A FACTORY (never a shared `Instr[]`): the result is spliced into two
+       * arms of the same body, and aliasing one array into both makes the
+       * finalize walks remap it twice (`reference_shared_instr_object_dce_
+       * double_remap`, the same rule `decodeIntegrityFlag` documents).
+       *
+       * `__vec_bag_lookup` READS — it must never be `__vec_bag_ensure` here: a
+       * gOPD on an element is a pure query and must not allocate a bag for
+       * every array that is merely inspected.
+       */
+      const integrityBit = (bit: number): Instr[] =>
+        vecBagLookupIdx === undefined
+          ? [{ op: "i32.const", value: 0 }]
+          : [
+              { op: "local.get", index: 0 },
+              { op: "call", funcIdx: vecBagLookupIdx },
+              { op: "local.tee", index: L_BAG },
+              { op: "ref.is_null" },
+              {
+                op: "if",
+                blockType: { kind: "val", type: { kind: "i32" } },
+                then: [{ op: "i32.const", value: 0 }],
+                else: [
+                  { op: "local.get", index: L_BAG },
+                  { op: "any.convert_extern" },
+                  { op: "ref.test", typeIdx: objectTypeIdx },
+                  {
+                    op: "if",
+                    blockType: { kind: "val", type: { kind: "i32" } },
+                    then: [
+                      { op: "local.get", index: L_BAG },
+                      { op: "any.convert_extern" },
+                      { op: "ref.cast", typeIdx: objectTypeIdx },
+                      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
+                      { op: "i32.const", value: bit },
+                      { op: "i32.and" },
+                      { op: "i32.const", value: 0 },
+                      { op: "i32.ne" },
+                    ],
+                    else: [{ op: "i32.const", value: 0 }],
+                  },
+                ],
+              },
+            ];
       const bailMiss = (): Instr[] => [...missExtern(), { op: "return" }];
       // A backed externref `$Hole` is storage, not an implicit array-element
       // descriptor. `__vec_gopd` feeds both getOwnPropertyDescriptor and the
@@ -2003,8 +2069,16 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               { op: "f64.convert_i32_s" },
               { op: "call", funcIdx: externGetIdxIdx },
             ]),
+            // (#4491 wave-4) §7.3.14 SetIntegrityLevel applied to an ARRAY
+            // element. `Object.freeze(arr)` / `Object.seal(arr)` record the
+            // level on the carrier's integrity bag; the elements themselves
+            // have no bag entry, so the implicit descriptor must read the
+            // level here or `Object.freeze([0,1,2])` keeps answering
+            // `{writable: true, configurable: true}` for index 0.
+            // `enumerable` is untouched by either operation.
             ...setKey("writable", [
-              { op: "i32.const", value: 1 },
+              ...integrityBit(OBJ_FLAG_FROZEN),
+              { op: "i32.eqz" },
               { op: "call", funcIdx: boxBoolIdx },
             ]),
             ...setKey("enumerable", [
@@ -2012,7 +2086,8 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               { op: "call", funcIdx: boxBoolIdx },
             ]),
             ...setKey("configurable", [
-              { op: "i32.const", value: 1 },
+              ...integrityBit(OBJ_FLAG_SEALED),
+              { op: "i32.eqz" },
               { op: "call", funcIdx: boxBoolIdx },
             ]),
             { op: "local.get", index: 6 },
@@ -2064,6 +2139,99 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
             ] as const)
           : []),
       );
+      // (#4491 wave-4) Two extra scratch slots for the frozen-element guard,
+      // allocated AFTER the conditional block above so their indices are read
+      // off the final local list rather than assumed.
+      const setBagLocal = 3 + fn.locals.length;
+      const setFrozenLenLocal = setBagLocal + 1;
+      fn.locals.push(
+        { name: "__ov_set_bag", type: { kind: "externref" } },
+        { name: "__ov_set_frozen_len", type: { kind: "i32" } },
+      );
+      /**
+       * (#4491 wave-4) §10.1.9.2 OrdinarySetWithOwnDescriptor step 2.b —
+       * a write to an own, BACKED element of a FROZEN array is rejected.
+       *
+       * `Object.freeze` records the level on the carrier's integrity bag
+       * (#4032) and clears W/C on the BAG's entries; a vec's elements have no
+       * bag entry, so nothing refused `arr[0] = x` on a frozen array. Measured
+       * on this base: `Object.freeze([0,1,2])` then propertyHelper's
+       * `isWritable(arr, "0")` answered **true** (the store landed and was
+       * reverted), which is what `freeze/15.2.3.9-2-a-{11,14}` report as
+       * "0 descriptor should not be writable".
+       *
+       * Scoped to an index INSIDE the backed length — i.e. an own element.
+       * A key the frozen array does NOT own must still walk the prototype
+       * chain (an inherited setter is legitimately reachable), so the guard
+       * deliberately does not blanket-refuse every write to a frozen vec.
+       * `vecBagLookupIdx` absent ⇒ `[]`, byte-identical.
+       */
+      const frozenOwnIndexGuard = (): Instr[] => {
+        if (vecBagLookupIdx === undefined) return [];
+        const frozenBit: Instr[] = [
+          { op: "local.get", index: 0 },
+          { op: "call", funcIdx: vecBagLookupIdx },
+          { op: "local.tee", index: setBagLocal },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [{ op: "i32.const", value: 0 }],
+            else: [
+              { op: "local.get", index: setBagLocal },
+              { op: "any.convert_extern" },
+              { op: "ref.test", typeIdx: objectTypeIdx },
+              {
+                op: "if",
+                blockType: { kind: "val", type: { kind: "i32" } },
+                then: [
+                  { op: "local.get", index: setBagLocal },
+                  { op: "any.convert_extern" },
+                  { op: "ref.cast", typeIdx: objectTypeIdx },
+                  { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
+                  { op: "i32.const", value: OBJ_FLAG_FROZEN },
+                  { op: "i32.and" },
+                  { op: "i32.const", value: 0 },
+                  { op: "i32.ne" },
+                ],
+                else: [{ op: "i32.const", value: 0 }],
+              },
+            ],
+          },
+        ];
+        return [
+          ...frozenBit,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              ...vecBackedLen(anyLocal, setFrozenLenLocal),
+              { op: "local.get", index: indexLocal },
+              { op: "i32.const", value: 0 },
+              { op: "i32.ge_s" },
+              { op: "local.get", index: indexLocal },
+              { op: "local.get", index: setFrozenLenLocal },
+              { op: "i32.lt_s" },
+              { op: "i32.and" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                // Refusal, not silence: the shared result global is how a
+                // STRICT-mode assignment learns to throw (#4504). Absent ⇒
+                // plain sloppy no-op, today's behaviour for the strict case.
+                then:
+                  setResultGlobalIdx === undefined
+                    ? [{ op: "return" }]
+                    : [
+                        { op: "i32.const", value: 2 },
+                        { op: "global.set", index: setResultGlobalIdx },
+                        { op: "return" },
+                      ],
+              },
+            ],
+          },
+        ];
+      };
       const publishSuccess = (): Instr[] =>
         !descriptorDecisionAvailable
           ? []
@@ -2266,6 +2434,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               blockType: { kind: "empty" },
               then: [
                 ...parseIndex(keyLocal, indexLocal),
+                ...frozenOwnIndexGuard(),
                 { op: "local.get", index: indexLocal },
                 { op: "i32.const", value: 0 },
                 { op: "i32.ge_s" },

--- a/tests/issue-4491-wave4.test.ts
+++ b/tests/issue-4491-wave4.test.ts
@@ -104,9 +104,29 @@ describe("#4491 wave-4 — vec identity at a monomorphic parameter", () => {
 });
 
 describe("#4491 wave-4 — Object.freeze reaches array/arguments ELEMENTS", () => {
-  // Executes both destructive operations propertyHelper performs: the write
-  // (isWritable) and the delete (isConfigurable). Measured on the campaign
-  // base: the write LANDED and the delete SUCCEEDED, so this returned 0.
+  // Executes both destructive operations `propertyHelper.js` performs — the
+  // write (`isWritable`) and the delete (`isConfigurable`) — plus the
+  // descriptor read. Measured on the campaign base: the write LANDED, the
+  // delete SUCCEEDED, and the descriptor said `{writable: true,
+  // configurable: true}`, so this returned 0.
+  //
+  // The module is an ES module and therefore STRICT, so both refusals are
+  // `TypeError`s rather than silent no-ops — the pin asserts BOTH throws AND
+  // that the element survives unchanged, which is the stricter of the two spec
+  // outcomes and exercises the refusal channel the fix publishes into.
+  //
+  // `drop` is load-bearing beyond its own assertion: the `delete obj[name]` in
+  // it is what sets `vecIndexDeleteDirty`, and without a dirty flag the module
+  // is not `overlayRouteActive` at all — the typed lane writes straight through
+  // `array.set` and never reaches the guard. That is exactly why the real
+  // failing rows include `propertyHelper.js` (which contains that delete), and
+  // it is the honest scope of this fix: an array frozen in a module with NO
+  // descriptor/delete/proto-index trigger anywhere still accepts the write.
+  //
+  // Presence is deliberately NOT asserted here: `Object.freeze(arr)` makes
+  // `Object.prototype.hasOwnProperty.call(arr, "0")` answer FALSE, and that is
+  // PRE-EXISTING — measured on the reverted `vec-overlay.ts` as well, where the
+  // element also had no protection at all. It is pinned separately below.
   it("a frozen array element is neither writable nor deletable", async () => {
     expect(
       await runStandalone(`
@@ -117,12 +137,14 @@ describe("#4491 wave-4 — Object.freeze reaches array/arguments ELEMENTS", () =
           Object.freeze(arr);
           var k = "";
           for (var i = 0; i < 1; i++) k = String(i);
-          poke(arr, k, 42);
+          var wThrew = 0;
+          try { poke(arr, k, 42); } catch (e) { wThrew = 1; }
           var afterWrite = arr[0];
-          drop(arr, k);
-          var stillThere = Object.prototype.hasOwnProperty.call(arr, "0");
+          var dThrew = 0;
+          try { drop(arr, k); } catch (e) { dThrew = 1; }
+          var afterDelete = arr[0];
           var d = Object.getOwnPropertyDescriptor(arr, "0");
-          return (afterWrite === 7 && stillThere === true &&
+          return (wThrew === 1 && dThrew === 1 && afterWrite === 7 && afterDelete === 7 &&
                   d.writable === false && d.configurable === false &&
                   d.enumerable === true && d.value === 7) ? 1 : 0;
         }
@@ -141,9 +163,10 @@ describe("#4491 wave-4 — Object.freeze reaches array/arguments ELEMENTS", () =
           Object.freeze(argObj);
           var k = "";
           for (var i = 0; i < 1; i++) k = String(i);
-          poke(argObj, k, 99);
+          var threw = 0;
+          try { poke(argObj, k, 99); } catch (e) { threw = 1; }
           var d = Object.getOwnPropertyDescriptor(argObj, "0");
-          return (argObj[0] === 1 && d.writable === false &&
+          return (threw === 1 && argObj[0] === 1 && d.writable === false &&
                   d.configurable === false && d.value === 1) ? 1 : 0;
         }
       `),
@@ -156,21 +179,37 @@ describe("#4491 wave-4 — `var x = undefined` holds undefined, not 0", () => {
   // non-undefined value is a TypeError. The define is executed and the
   // surviving SETTER is then invoked, so the pin fails if the second define
   // either throws or discards the first one's setter.
+  //
+  // Two spellings are load-bearing, both taken from `15.2.3.6-4-21` itself:
+  //
+  //  - the bindings are MODULE-SCOPE. A FUNCTION-LOCAL `var g = undefined`
+  //    still fails — measured, and NOT fixed here: widening the local slot
+  //    alone does not close it (the enclosing literal's field type is decided
+  //    separately), so shipping that half would have been a behaviour change
+  //    on every `var x = undefined` local with no measured beneficiary. Listed
+  //    under Residuals in the issue file.
+  //  - the descriptor is passed as a VARIABLE (`desc`), not as an inline
+  //    literal. An inline `{get: getter}` argument takes the static
+  //    literal-shape define path, which still throws; the variable form is the
+  //    dynamic `__obj_define_from_desc` path the test uses and the one the
+  //    slot fix reaches. Same defect, two lowerings — worth knowing before
+  //    writing the follow-up.
   it("accepts `{get: <var holding undefined>}` and keeps the existing setter", async () => {
     expect(
       await runStandalone(`
         var wrote = 0;
+        var o = {};
+        var setter = function (x) { wrote = x; };
+        var getter = undefined;
+        var desc = { get: getter };
+        var threw = 0;
+        Object.defineProperty(o, "foo", { set: setter });
+        try {
+          Object.defineProperty(o, "foo", desc);
+        } catch (e) {
+          threw = 1;
+        }
         export function main() {
-          var o = {};
-          var setter = function (x) { wrote = x; };
-          Object.defineProperty(o, "foo", { set: setter });
-          var getter = undefined;
-          var threw = 0;
-          try {
-            Object.defineProperty(o, "foo", { get: getter });
-          } catch (e) {
-            threw = 1;
-          }
           o.foo = 5;
           var d = Object.getOwnPropertyDescriptor(o, "foo");
           return (threw === 0 && wrote === 5 && d.set === setter &&
@@ -212,14 +251,17 @@ describe("#4491 wave-4 — Date's statics are own properties", () => {
   // (`Object.prototype.hasOwnProperty.call`, the exact spelling
   // `propertyHelper.js` uses and the one that answered `false`), the own-key
   // LIST (`gOPN(Date)` reported only `length, name, prototype`), and the
-  // descriptor — and the descriptor's value is CALLED, because a seeded
-  // descriptor whose value is not a working function would be worse than no
-  // descriptor at all.
+  // descriptor — and the descriptor's value must be a callable that is
+  // IDENTITY-STABLE across two reads, because a seeded descriptor that minted
+  // a fresh closure per query would answer `true` to every shape assertion and
+  // still be wrong for any consumer that compares functions.
   //
-  // The receiver is passed as a VALUE only through `hasOwn`'s parameter and a
-  // literal-key gOPD: a syntactic `Date.now` in a value position (`d.value ===
-  // Date.now`) compiles to `__get_builtin`, which standalone rejects, and a
-  // compile error is not the failure this pin exists to catch.
+  // Two things it deliberately does NOT do. `d.value === Date.now`: a
+  // syntactic `Date.now` in a value position compiles to `__get_builtin`,
+  // which standalone rejects — a compile error is not the failure this pin
+  // exists to catch. And `d.value()`: `Date.now` needs the host clock, so
+  // CALLING it traps under this harness's `hostBridge` default and would make
+  // the pin an environment test rather than a descriptor test.
   it("Date.now is an own, writable, non-enumerable, configurable data property", async () => {
     expect(
       await runStandalone(`
@@ -230,8 +272,9 @@ describe("#4491 wave-4 — Date's statics are own properties", () => {
           var found = false;
           for (var i = 0; i < names.length; i++) { if (names[i] === "now") { found = true; } }
           var d = Object.getOwnPropertyDescriptor(Date, "now");
-          var t = d.value();
-          return (present === true && found === true && typeof t === "number" &&
+          var d2 = Object.getOwnPropertyDescriptor(Date, "now");
+          return (present === true && found === true &&
+                  typeof d.value === "function" && d.value === d2.value &&
                   d.writable === true && d.enumerable === false &&
                   d.configurable === true) ? 1 : 0;
         }
@@ -246,6 +289,32 @@ describe("#4491 wave-4 — Date's statics are own properties", () => {
  * carries the full analysis.
  */
 describe("#4491 wave-4 — measured residuals", () => {
+  // Found while writing the frozen-element pin above, and PRE-EXISTING (it
+  // reproduces with `vec-overlay.ts` reverted): `Object.freeze(arr)` flips
+  // `Object.prototype.hasOwnProperty.call(arr, "0")` from true to FALSE, while
+  // `Object.getOwnPropertyDescriptor(arr, "0")` keeps answering the full
+  // descriptor. A descriptor that exists while `hasOwnProperty` says the
+  // property does not is the #4010 overlay-vs-bag split, now reachable through
+  // the integrity path too.
+  it.fails("Object.freeze does not hide an array element from hasOwnProperty", async () => {
+    expect(
+      await runStandalone(`
+        function drop(obj, name) { return delete obj[name]; }
+        export function main() {
+          var sink = [1, 2];
+          var kk = "";
+          for (var j = 0; j < 1; j++) kk = String(j);
+          drop(sink, kk);
+          var arr = [7, 8, 9];
+          var before = Object.prototype.hasOwnProperty.call(arr, "0");
+          Object.freeze(arr);
+          var after = Object.prototype.hasOwnProperty.call(arr, "0");
+          return (before === true && after === true) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
   // #4497. `MAX_CANONICAL_INDEX` is 2^31-1 because `__obj_index_of_key`'s
   // result doubles as a SIGNED sort key, so an index in [2^31, 2^32-2] is
   // treated as an ordinary string key and never bumps `length`.

--- a/tests/issue-4491-wave4.test.ts
+++ b/tests/issue-4491-wave4.test.ts
@@ -1,0 +1,363 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4491 wave-4 — the descriptor-MOP residual slice (standalone lane).
+ *
+ * Four independent roots, each pinned by EXECUTING the operation it guards
+ * (define, then write / delete / enumerate / call, and read the result back) —
+ * never by asserting a descriptor shape. A pin that asserts a shape is not a
+ * pin that exercises the shape.
+ *
+ * 1. **Identity destroyed at a monomorphic vec parameter.** In a
+ *    descriptor-dirty module, narrowing a callee's parameter to a concrete
+ *    `__vec_<k>` carrier turns the ARGUMENT boundary into a converting COPY
+ *    (`emitVecToVecBody` → a fresh `struct.new`). The #3251 overlay side table
+ *    is keyed by vec IDENTITY, so the callee received an array with no
+ *    descriptors: accessor get/set and `writable:false` all vanished. This is
+ *    the whole `propertyHelper.js` verification family, whose `obj` parameter
+ *    is monomorphic on the array under test.
+ * 2. **`Object.freeze` was invisible to an array/arguments ELEMENT.** The level
+ *    is recorded on the carrier's integrity bag and clears W/C on the BAG's
+ *    entries; a vec's elements have no bag entry, so the implicit element
+ *    descriptor kept answering `{writable: true, configurable: true}` and the
+ *    element stayed writable and deletable.
+ * 3. **`var g = undefined` was the NUMBER 0.** `resolveWasmType(undefined)` is
+ *    i32 — a lowering convention for a void RESULT, not a claim about a
+ *    binding's value — so the slot stored `i32.const 0` and boxed to `i31 0`.
+ * 4. **`Date`'s statics were not own properties.** The ctor carrier seeded only
+ *    `length`/`name`/`prototype`.
+ *
+ * The `it.fails` block at the end pins measured RESIDUALS with their owners, so
+ * a later lane's fix flips a red test to green rather than landing unnoticed.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, {
+    target: "standalone",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  expect(WebAssembly.validate(result.binary!), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary!, {});
+  return (instance.exports as { main: () => unknown }).main();
+}
+
+describe("#4491 wave-4 — vec identity at a monomorphic parameter", () => {
+  // The propertyHelper shape, reduced: a THREE-parameter helper called ONCE
+  // with the array under test, so call-site inference narrows `obj` to that
+  // array's carrier. The key is loop-carried, not a syntactic literal, so no
+  // compile-time fold can answer the read; the getter is counted so a pin that
+  // "passed" without ever invoking it would still fail.
+  //
+  // Measured on the campaign base: `0` (the raw backing slot) with the getter
+  // never called. Reverting the withdrawal in
+  // `declarations/param-return-inference.ts` reproduces it.
+  it("reads an array-index ACCESSOR through a narrowed parameter", async () => {
+    expect(
+      await runStandalone(`
+        var calls = 0;
+        var arr = [];
+        function getFunc() { calls = calls + 1; return 3; }
+        function readThrough(obj, name, unused) { return obj[name]; }
+        Object.defineProperty(arr, "1", { get: getFunc, configurable: true });
+        arr[1] = 4;
+        var K = "";
+        for (var i = 0; i < 1; i++) K = String(i + 1);
+        var V = readThrough(arr, K, getFunc());
+        export function main() {
+          return (V === 3 && calls === 2) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // The write half: a SETTER installed on an array index must run when the
+  // element is assigned through the narrowed parameter, and its side effect
+  // must be observable on the ORIGINAL array — which a copy could not deliver.
+  it("runs an array-index SETTER through a narrowed parameter", async () => {
+    expect(
+      await runStandalone(`
+        var seen = 0;
+        var arr = [];
+        function writeThrough(obj, name, value) { obj[name] = value; }
+        Object.defineProperties(arr, {
+          "0": {
+            set: function (v) { seen = v; },
+            get: function () { return seen; },
+            enumerable: true
+          }
+        });
+        arr[0] = 7;
+        var K = "";
+        for (var i = 0; i < 1; i++) K = String(i);
+        writeThrough(arr, K, 101);
+        export function main() {
+          return (seen === 101 && arr[0] === 101) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});
+
+describe("#4491 wave-4 — Object.freeze reaches array/arguments ELEMENTS", () => {
+  // Executes both destructive operations propertyHelper performs: the write
+  // (isWritable) and the delete (isConfigurable). Measured on the campaign
+  // base: the write LANDED and the delete SUCCEEDED, so this returned 0.
+  it("a frozen array element is neither writable nor deletable", async () => {
+    expect(
+      await runStandalone(`
+        function poke(obj, name, value) { obj[name] = value; }
+        function drop(obj, name) { return delete obj[name]; }
+        export function main() {
+          var arr = [7, 8, 9];
+          Object.freeze(arr);
+          var k = "";
+          for (var i = 0; i < 1; i++) k = String(i);
+          poke(arr, k, 42);
+          var afterWrite = arr[0];
+          drop(arr, k);
+          var stillThere = Object.prototype.hasOwnProperty.call(arr, "0");
+          var d = Object.getOwnPropertyDescriptor(arr, "0");
+          return (afterWrite === 7 && stillThere === true &&
+                  d.writable === false && d.configurable === false &&
+                  d.enumerable === true && d.value === 7) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // The mapped-arguments carrier takes the same path. Kept separate because it
+  // is a different carrier brand, and only the array half was predicted.
+  it("a frozen arguments-object index is neither writable nor deletable", async () => {
+    expect(
+      await runStandalone(`
+        function poke(obj, name, value) { obj[name] = value; }
+        export function main() {
+          var argObj = (function () { return arguments; }(1, 2, 3));
+          Object.freeze(argObj);
+          var k = "";
+          for (var i = 0; i < 1; i++) k = String(i);
+          poke(argObj, k, 99);
+          var d = Object.getOwnPropertyDescriptor(argObj, "0");
+          return (argObj[0] === 1 && d.writable === false &&
+                  d.configurable === false && d.value === 1) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});
+
+describe("#4491 wave-4 — `var x = undefined` holds undefined, not 0", () => {
+  // §6.2.5.6 accepts an UNDEFINED accessor half; only a non-callable
+  // non-undefined value is a TypeError. The define is executed and the
+  // surviving SETTER is then invoked, so the pin fails if the second define
+  // either throws or discards the first one's setter.
+  it("accepts `{get: <var holding undefined>}` and keeps the existing setter", async () => {
+    expect(
+      await runStandalone(`
+        var wrote = 0;
+        export function main() {
+          var o = {};
+          var setter = function (x) { wrote = x; };
+          Object.defineProperty(o, "foo", { set: setter });
+          var getter = undefined;
+          var threw = 0;
+          try {
+            Object.defineProperty(o, "foo", { get: getter });
+          } catch (e) {
+            threw = 1;
+          }
+          o.foo = 5;
+          var d = Object.getOwnPropertyDescriptor(o, "foo");
+          return (threw === 0 && wrote === 5 && d.set === setter &&
+                  d.get === undefined && d.configurable === false) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // The same slot defect on an ordinary binding: `Object.preventExtensions`
+  // RETURNS its argument, and the i32 slot turned the object into `0`. The
+  // returned reference is then used (a define on it must be refused) so the
+  // pin cannot pass on identity alone.
+  it("an `undefined`-initialized var can hold an object afterwards", async () => {
+    expect(
+      await runStandalone(`
+        var o = {};
+        var o2 = undefined;
+        export function main() {
+          o2 = Object.preventExtensions(o);
+          var same = (o2 === o);
+          var ext = Object.isExtensible(o2);
+          var threw = 0;
+          try {
+            Object.defineProperty(o2, "fresh", { value: 1 });
+          } catch (e) {
+            threw = 1;
+          }
+          return (same === true && ext === false && threw === 1 &&
+                  Object.prototype.hasOwnProperty.call(o, "fresh") === false) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});
+
+describe("#4491 wave-4 — Date's statics are own properties", () => {
+  // Three independent observers of the same carrier — RUNTIME presence
+  // (`Object.prototype.hasOwnProperty.call`, the exact spelling
+  // `propertyHelper.js` uses and the one that answered `false`), the own-key
+  // LIST (`gOPN(Date)` reported only `length, name, prototype`), and the
+  // descriptor — and the descriptor's value is CALLED, because a seeded
+  // descriptor whose value is not a working function would be worse than no
+  // descriptor at all.
+  //
+  // The receiver is passed as a VALUE only through `hasOwn`'s parameter and a
+  // literal-key gOPD: a syntactic `Date.now` in a value position (`d.value ===
+  // Date.now`) compiles to `__get_builtin`, which standalone rejects, and a
+  // compile error is not the failure this pin exists to catch.
+  it("Date.now is an own, writable, non-enumerable, configurable data property", async () => {
+    expect(
+      await runStandalone(`
+        function hasOwn(o, k) { return Object.prototype.hasOwnProperty.call(o, k); }
+        export function main() {
+          var present = hasOwn(Date, "now");
+          var names = Object.getOwnPropertyNames(Date);
+          var found = false;
+          for (var i = 0; i < names.length; i++) { if (names[i] === "now") { found = true; } }
+          var d = Object.getOwnPropertyDescriptor(Date, "now");
+          var t = d.value();
+          return (present === true && found === true && typeof t === "number" &&
+                  d.writable === true && d.enumerable === false &&
+                  d.configurable === true) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});
+
+/**
+ * Measured residuals — each reproduces on this branch. Owners in the comments;
+ * the wave-4 census section of `plan/issues/4491-es5-defineproperty-mop-residual.md`
+ * carries the full analysis.
+ */
+describe("#4491 wave-4 — measured residuals", () => {
+  // #4497. `MAX_CANONICAL_INDEX` is 2^31-1 because `__obj_index_of_key`'s
+  // result doubles as a SIGNED sort key, so an index in [2^31, 2^32-2] is
+  // treated as an ordinary string key and never bumps `length`.
+  // (`defineProperty/15.2.3.6-4-183`, `defineProperties/15.2.3.7-6-a-179`.)
+  it.fails("an array index at 2^32-2 bumps length to 2^32-1", async () => {
+    expect(
+      await runStandalone(`
+        export function main() {
+          var arr = [];
+          Object.defineProperty(arr, 4294967294, { value: 100 });
+          return (arr.length === 4294967295 && arr[4294967294] === 100) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // A data-only descriptor whose VALUE is kind-incompatible with the array's
+  // carrier (a string into a `__vec_f64`) cannot be written back into the
+  // element, so it lands in the companion with FLAG_COMPANION_VALUE — but
+  // `isNonDataDescriptorDefine` calls `{value: "abc"}` data-only, so the module
+  // is not descriptor-dirty and the typed read never consults the companion.
+  // Fixing it in the PRE-SCAN would route every element access in any module
+  // containing `Object.defineProperty(x, k, {value: <non-numeric>})` through
+  // the dynamic lane; the narrow fix is to widen the array's own CARRIER
+  // (`heterogeneousWidenedModuleGlobalType`, #4428) for that binding.
+  // (`defineProperties/15.2.3.7-6-a-183`.)
+  it.fails("a string value defined on a numeric array is read back", async () => {
+    expect(
+      await runStandalone(`
+        export function main() {
+          var arr = [1, 2, 3];
+          Object.defineProperty(arr, "length", { writable: false });
+          Object.defineProperties(arr, { "1": { value: "abc" } });
+          return (arr[0] === 1 && arr[1] === "abc" && arr[2] === 3) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // Defining a far index grows the backing with a NON-hole default, so
+  // `Object.keys` enumerates the whole filled range.
+  // (`keys/15.2.3.14-5-13`.)
+  it.fails("a far-index define leaves the intervening slots as holes", async () => {
+    expect(
+      await runStandalone(`
+        export function main() {
+          var obj = [1, , 3, , 5];
+          Object.defineProperty(obj, 5, { value: 7, enumerable: false, configurable: true });
+          Object.defineProperty(obj, 10000, { value: "X", enumerable: true, configurable: true });
+          var arr = Object.keys(obj);
+          return (arr.length === 4 && arr[3] === "10000") ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // A String object's index is answered by the String-exotic own-property arm
+  // only for a receiver the compiler resolved statically; through a dynamic
+  // receiver the read misses. (`freeze/15.2.3.9-2-a-12`,
+  // `preventExtensions/15.2.3.10-3-5`.)
+  it.fails("a String object's index reads through a dynamic receiver", async () => {
+    expect(
+      await runStandalone(`
+        function readThrough(obj, name) { return obj[name]; }
+        export function main() {
+          var s = new String("abc");
+          var k = "";
+          for (var i = 0; i < 1; i++) k = String(i);
+          var empty = new String();
+          return (readThrough(s, k) === "a" &&
+                  typeof readThrough(empty, k) === "undefined") ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // §13.5.3: `typeof` of an unresolvable Reference is "undefined". A name the
+  // TS DOM lib declares gets an ambient `valueDeclaration`, so the
+  // undeclared-fold in `typeof-delete.ts` does not fire and the static type
+  // fold answers "object" — then `document.createElement` null-derefs. Closing
+  // it needs the standalone PROVIDED-globals set, which no single table holds
+  // today (`structuredClone` has a hand-written arm for exactly this).
+  // (`defineProperty/S15.2.3.6_A1`.)
+  it.fails('typeof a host-only global is "undefined" in standalone', async () => {
+    expect(
+      await runStandalone(`
+        export function main() {
+          return (typeof document === "undefined") ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // §6.2.5.6 reads descriptor fields with HasProperty, and `__desc_has_own`
+  // does walk the chain — but the define still leaves the old value in place
+  // when the inherited field is an accessor with no getter.
+  // (`defineProperty/15.2.3.6-3-138`.)
+  it.fails("an INHERITED accessor `value` field is honored by ToPropertyDescriptor", async () => {
+    expect(
+      await runStandalone(`
+        export function main() {
+          var obj = { property: 120 };
+          var proto = {};
+          Object.defineProperty(proto, "value", { set: function () {} });
+          var ConstructFun = function () {};
+          ConstructFun.prototype = proto;
+          var child = new ConstructFun();
+          Object.defineProperty(obj, "property", child);
+          return (Object.prototype.hasOwnProperty.call(obj, "property") &&
+                  typeof obj.property === "undefined") ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

The fourth wave-4 lane, split out of [#4806](https://github.com/loopdive/js2/pull/4806) because its zero-regression proof was still running when that PR went out.

**9 of the 24 census rows flip; 0 regressions across a 2,279-row two-arm sweep** (base 2,226 pass → branch 2,235). Both arms run in the lane's own worktree, the base side from file-copy reverts of the four touched sources.

### Four measured roots

**1. A monomorphic vec PARAMETER destroys array identity (5 rows).** In a descriptor-dirty module, `inferParamTypeFromCallSites` narrows a callee's parameter to `$__vec_f64` while the array is materialised `$__vec_externref`, so the *argument boundary* becomes `emitSafeStructConversion` → `emitVecToVecBody` — an element-wise COPY into a fresh `struct.new`. The #3251 overlay side table is keyed by vec **identity** (`ref.eq`), so the callee receives an array with no descriptors at all: accessors, `writable:false` enforcement and companion values all vanish, and an element read answers the raw backing slot.

Measured: a helper called once as `f(arr, "1", getFunc())` answered `0` (raw slot, getter never invoked) where the identical module-level read answered `3`; making the same call site polymorphic answered `3`. That is the entire `propertyHelper.js` verification family (`verifyEqualTo` / `verifyWritable` / `verifyProperty`), whose `obj` parameter is monomorphic on the array under test in every array-descriptor test262 file.

Fixed as a sixth withdrawal rule in the existing ladder, gated on `overlayRouteActive` — in such a module the vec-typed parameter buys nothing (every access is already routed through the dynamic lane) and costs identity, so the withdrawal is free where it applies and byte-identical everywhere else.

**2. `Object.freeze` was invisible to array/arguments ELEMENTS (2 rows).** The integrity level is recorded on the carrier's bag and clears W/C on the *bag's* entries; a vec's elements have no bag entry. Measured on base: `isWritable` answered true (the store landed) and `isConfigurable` answered true (the delete succeeded). `__vec_gopd` now reads the #4032 integrity bag and `__extern_set` refuses a write to an own backed index; the delete half fell out for free.

**3. `var x = undefined` was the NUMBER 0 at module scope (2 rows).** `resolveWasmType(undefined)` is i32, so the module-global slot stored `i32.const 0` and boxed to `i31 0` — `{get: getter}` threw "Getter/setter must be a function" and `o2 = Object.preventExtensions(o)` read back `0`.

**4. `Date`'s statics were not own properties (1 row).**

### Merge resolution

`param-return-inference.ts` conflicted with main's #4630 catch-var rule — both append an independent withdrawal to the same ladder. Both kept, sequentially: each rule only ever nulls the type, so ordering cannot change the outcome. Typecheck clean; both lanes' pins verified on the merged tree.

## Two measurement traps found by this lane (now standing brief sections)

**A green suite that ran nothing.** `tests/issue-4504-inherited-set.test.ts` spins its own `CompilerPool`, whose worker imports the gitignored `scripts/runtime-bundle.mjs` and `scripts/compiler-bundle.mjs`. A fresh worktree has neither, so it prints `[pool] worker failed before ready (exit 1)`, vitest reports **`36 skipped`**, and the process **exits 0**. Any lane that ran it in a fresh worktree read a green that measured zero tests. Built from branch sources it is 1 failed / 35 passed, and that one failure reproduces on the reverted sources — pre-existing.

**Contention fakes both failures and regressions.** Three of the 2,279 sweep rows moved for infrastructure reasons alone — one of them (`15.2.3.6-4-298-1`, an ENOENT from the `test262/` symlink-farm race) **would have read as a regression**. All three pass on both arms when re-run serially. The lead hit the same thing independently: two pins failed on 47–50 s compile timeouts under 5-lane load and passed **25/25** serially. Re-running every apparent flip *and* every apparent regression serially is now standing practice; note `runTest262File`'s `timeoutMs` is post-hoc and cannot interrupt a slow compile.

## Cross-lane

`filter/15.4.4.20-9-b-{2,14,15,16}` and `forEach/15.4.4.18-3-23` are `fail` on **both** arms, unchanged by every fix — they do not root in the descriptor mirror. Handed back with that evidence and no claim about the other lane's arm. Separately, the four filter harness rows that the 2026-08-21 `void 0` note records as previously regressed are **pass on both arms** — the wave-4 `= undefined` arm did not repeat that regression.

## Pins

`tests/issue-4491-wave4.test.ts` → **14 passed (14)** on branch; **7 failed / 7 passed** on the reverted sources, so every positive pin fails on the arm it tests. `issue-4491-proto-index-constructor-shadow` + `issue-4491-function-binding-widening` → 10 passed. `issue-4506` → 22 passed.

New pre-existing defect pinned `it.fails`: `Object.freeze(arr)` flips `Object.prototype.hasOwnProperty.call(arr,"0")` to **false** while `gOPD` still returns the full descriptor (reproduces with `vec-overlay.ts` reverted) — the #4010 overlay-vs-bag disagreement.

## Residuals

15 of 24, each with a measured root and owner in the issue file. `-4-183`/`-6-a-179` stay with #4497; `15.2.3.4-4-1` stays with [#4491](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4491-es5-defineproperty-mop-residual) (it does not trap, so not [#4651](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4651-gopn-global-this-illegal-cast-trap)). Issue status left `ready` — it is a living issue.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_