### PR TITLE
ES5-standalone #4653: for-in's shadow set fired user setters, late-assigned fnctor split brain, redeclared-function module slot

### DIFF
--- a/plan/issues/4653-es5-function-declaration-semantics.md
+++ b/plan/issues/4653-es5-function-declaration-semantics.md
@@ -1,7 +1,8 @@
 ---
 id: 4653
 title: "ES5 standalone: language/statements/function residual — 12 rows across arguments.callee identity, named-function-expression scope, property-vs-declaration shadowing, and a null-pointer in __module_init"
-status: in-progress
+status: done
+completed: 2026-08-23
 sprint: current
 created: 2026-08-23
 updated: 2026-08-23
@@ -26,6 +27,14 @@ func-budget-allow:
 ---
 
 # #4653 — `language/statements/function` residual (12 rows)
+
+> **Outcome: 3 of the 12 rows fixed, 9 documented as residuals with measured
+> roots and owners.** `status: done` records that the issue's acceptance bar —
+> triage, before/after sweep, per-file flips, zero regressions, pins, residual
+> attribution — is met; it does NOT mean all twelve rows pass. The nine open
+> rows and their roots are in `## Residuals`, and the twelve rows turned out to
+> be **eleven distinct roots**, so they do not belong under one issue. Anyone
+> picking one up should start from that section, not from the row table.
 
 ## Affected rows (sweep-verified on campaign HEAD, 2026-08-23)
 
@@ -212,20 +221,39 @@ All numbers below come from runs executed on this branch, by the same driver
 adapter rebuilt locally before the first measurement.
 
 **Scoped sweep**, `language/statements/function` + `language/statements/return` +
-`language/statements/try`, 668 files, both arms:
+`language/statements/try`, 668 files, both arms, 2 shards, 20 s per-row timeout:
 
 | arm | pass | fail | compile_error |
 | --- | --- | --- | --- |
 | base (`c42bdbe3e`) | 611 | 56 | 1 |
-| this branch | (see `## Sweep result` below) | | |
+| this branch, as swept | 604 | 53 | 11 |
+| this branch, **corrected** | **614** | **53** | **1** |
 
-**Per-file flips (fail → pass), 3:**
+**Per-file flips (fail → pass), 3 — each re-verified SERIALLY on both arms:**
 
-- `language/statements/function/13.2-17-1.js`
-- `language/statements/function/S13.2.2_A4_T2.js`
-- `language/statements/function/S13_A6_T1.js`
+| row | base | this branch |
+| --- | --- | --- |
+| `language/statements/function/13.2-17-1.js` | fail | **pass** |
+| `language/statements/function/S13.2.2_A4_T2.js` | fail | **pass** |
+| `language/statements/function/S13_A6_T1.js` | fail | **pass** |
 
-**Zero regressions** (per-file diff of the two sweeps).
+**Zero regressions.** The raw after-sweep showed ten `pass → compile_error`
+rows — `13.0-{7,8,12,13,14,15,16,17}-s`, `13.0_4-17gs`, `13.1-2-s` — every one
+of them `compilation timeout` at 24–54 s with the box at load 17–21 (five lanes
+sweeping). **A timeout is a measurement failure, not a status**, and
+`runTest262File`'s `timeoutMs` is post-hoc: it cannot interrupt a slow compile,
+only report after the fact. All ten were re-run SERIALLY at a 120 s timeout on
+BOTH arms and **pass on both**, which is what the corrected row above records.
+The three real flips were re-run in the same serial pass and hold in both
+directions. The one remaining `compile_error`
+(`param-dflt-yield-non-strict.js`) is present on base too and is unchanged.
+
+Two earlier measurements were discarded rather than reported: a first pass at
+the 12 rows where the missing local quickjs adapter made two rows read as
+"provider not built" and one as a compile timeout (the brief's stale-bundle
+trap), and a first after-sweep that I aborted because I had file-copy-reverted
+the source mid-run for a pin sensitivity check — a sweep whose base moved under
+it is not a measurement.
 
 **Pins** — `tests/issue-4653.test.ts`, 17 tests, `npm test -- tests/issue-4653.test.ts`:
 
@@ -288,14 +316,20 @@ Nine rows remain, each with a measured root and an owner. None is a guess.
   Measured identically for `new Function("arg","return ++arg;")`,
   `Function("arg", …)` and `Function.call(null, "arg", …)`, so the root is the
   MINT, not the receiver or the `.call` transfer. Runtime-eval lane.
-- **M `fun.prototype` own-ness** (`13.2-18-1`) — **#4491's**, with evidence: with
-  an accessor installed on `Function.prototype.prototype`, `fun.prototype` reads
-  as `undefined` and `hasOwnProperty(fun, "prototype")` is false for a function
-  EXPRESSION, so `verifyProperty`'s `assert(__hasOwnProperty(obj, name))` cannot
-  hold and `fun.prototype.toString()` throws first. Its sibling `13.2-17-1` did
-  NOT root in the MOP — every descriptor on `fun.prototype.constructor` is
-  already correct (`writable: true, enumerable: false, configurable: true`, own,
-  data) — which is why only one of the pair moved here.
+- **M `fun.prototype` own-ness** (`13.2-18-1`) — **owner #4491**, with evidence: a
+  function EXPRESSION has no own `prototype` property under the live descriptor
+  MOP. With an accessor installed on `Function.prototype.prototype`,
+  `fun.prototype` therefore reads as `undefined` and
+  `hasOwnProperty(fun, "prototype")` is false, so `verifyProperty`'s
+  `assert(__hasOwnProperty(obj, name))` cannot hold and `fun.prototype.toString()`
+  throws first (base error: "Cannot destructure 'null' or 'undefined'").
+  **This is DISTINCT from its sibling `13.2-17-1`**, whose
+  `fun.prototype.constructor` descriptors are already fully correct on base
+  (`writable: true, enumerable: false, configurable: true`, own, data) — that row
+  rooted in the for-in shadow write and is fixed here. The pair looked like one
+  family and is two. Routed to the issue file rather than to a live lane: the
+  dev-4491 lane completed and stood down (its slice is in PR #4808), so the next
+  lane on #4491 picks this row up from here.
 
 One residual is NOT one of the twelve, found while measuring F and worth
 recording: `a instanceof A` still answers false for a late-assigned fnctor even
@@ -309,6 +343,17 @@ accessor on `Object.prototype` and `o` has no own `zzz` (measured: the setter
 never ran). That is #4504's territory, stated here only because the same
 `__extern_set_decide` path carries both.
 
-## Sweep result
+## Cross-lane note
 
-_(filled in below once the after-sweep completes — see `## Test Results`)_
+`language/statements/try` is in this sweep's scope and **dev-4515 has landed
+§13 completion-value changes that move three rows in it**
+(`try/cptn-finally-{wo-catch,skip-catch,from-catch}.js`) on branch
+`issue-4515-wave5`. Those are eval-only and touch no file this change-set
+touches (`statements/eval-completion-value.ts`, `statements.ts`,
+`statements/exceptions.ts`, `expressions/eval-*.ts`, `helpers/*`,
+`binary-ops-in.ts` vs this lane's `object-runtime-enumeration.ts`,
+`fnctor-escape-gate.ts`, `declarations.ts` + two new modules), so there is no
+file conflict. Per the brief's third-arm rule, the numbers above are for THIS
+branch only and say nothing about dev-4515's effect: those three rows are `fail`
+on both of my arms, exactly as they should be, because neither arm contains
+their change. The combined tree needs its own run.

--- a/plan/issues/4653-es5-function-declaration-semantics.md
+++ b/plan/issues/4653-es5-function-declaration-semantics.md
@@ -255,14 +255,17 @@ trap), and a first after-sweep that I aborted because I had file-copy-reverted
 the source mid-run for a pin sensitivity check — a sweep whose base moved under
 it is not a measurement.
 
-**Pins** — `tests/issue-4653.test.ts`, 17 tests, `npm test -- tests/issue-4653.test.ts`:
+**Pins** — `tests/issue-4653.test.ts`, 20 tests, `npm test -- tests/issue-4653.test.ts`:
 
-- on this branch: **17 passed**;
+- on this branch: **20 passed**;
 - on base, by file-copy revert of exactly the three modified files: **3 failed,
-  14 passed** — and the three failures are precisely the three positive pins
-  that guard E, F and D. Every negative control and every `it.fails` residual
-  pin answers identically on both arms, which is what makes the three failures
-  attributable to this change-set rather than to the revert.
+  14 passed** (of the 17 pins that existed at the time of that A/B — three
+  runtime-eval pins were added afterwards, see residual **R**, and they are
+  `it.fails`/positive controls that this change-set does not touch) — and the
+  three failures are precisely the three positive pins that guard E, F and D.
+  Every negative control and every `it.fails` residual pin answers identically
+  on both arms, which is what makes the three failures attributable to this
+  change-set rather than to the revert.
 
 The second E pin (a two-level own name yielded once) and the non-enumerable
 shadow pin pass on BOTH arms: they guard the half of the shadow write that the
@@ -311,11 +314,48 @@ Nine rows remain, each with a measured root and an owner. None is a guess.
   evaluates to `undefined`. That is why the row reports `[object Object]`: the
   test's own `throw new Test262Error(…)` then runs inside the `try` and is caught
   as "the exception". The spec answer is a TypeError from §7.3.14 Call step 1.
-- **R `Function(p, body)`** (`S13.2.2_A8_T3`) — the minted function does not bind
-  its declared parameters: `++arg` throws `ReferenceError: arg is not defined`.
-  Measured identically for `new Function("arg","return ++arg;")`,
-  `Function("arg", …)` and `Function.call(null, "arg", …)`, so the root is the
-  MINT, not the receiver or the `.call` transfer. Runtime-eval lane.
+- **R `Function(p, body)`** (`S13.2.2_A8_T3`) — **CORRECTED 2026-08-23 after
+  dev-4515 flagged an adjacent eval finding; the first write-up of this row was
+  an inference restated as a measurement and it was WRONG.** It is *not* "the
+  minted function does not bind its declared parameters" — `new Function("p",
+  "return p;")(7)` answers **7**, so the parameter is bound. The measured rule is:
+
+  > An **update expression (`++`/`--`)** applied to a name that is **LOCAL to the
+  > eval'd / `Function`-minted code** — an eval-local `var`, or a `Function`
+  > parameter — throws `ReferenceError: <name> is not defined`, but **only when
+  > the eval/mint sits inside an enclosing FUNCTION**. At module top level the
+  > same code works. Compound assignment (`x = x + 1`) works everywhere, a plain
+  > read works everywhere, and `++` on an **outer** binding works everywhere.
+
+  Discriminator table, all standalone, this branch (`.tmp/probes/ev{1,2,3,4}.js`):
+
+  | shape | inside a function | at module top level |
+  | --- | --- | --- |
+  | `eval("n + 1")`, outer read | ✓ 1 | ✓ |
+  | `eval("if (a<3) { a=7; }")`, outer in IF test | ✓ 7 | — |
+  | `eval("while (d<3) { d++; }")`, OUTER + `++` | ✓ 3 | ✓ 3 |
+  | `eval("var i=0; i++; i")`, local + `++`, no loop | **THROW** `i` | ✓ 1 |
+  | `eval("var j=0; j=j+1; j")`, local + `=` | ✓ 1 | ✓ |
+  | `eval("var k=0; while(k<1){k=k+1;} k")`, local + `=` | ✓ 1 | ✓ 1 |
+  | `eval("var m=0; while(m<1){m++;} m")`, local + `++` | **THROW** `m` | ✓ 1 |
+  | `eval("var q=0; for(q=0;q<3;q++){} q")`, local + `++` | **THROW** `q` | — |
+  | `new Function("p","return p;")(7)` | ✓ 7 | — |
+  | `new Function("p","return p+1;")(1)` | ✓ 2 | — |
+  | `new Function("p","p=p+1; return p;")(1)` | ✓ 2 | — |
+  | `new Function("p","p++; return p;")(1)` | **THROW** `p` | — |
+  | `new Function("","var z=0; z++; return z;")()` | **THROW** `z` | — |
+
+  So `for` vs `while` is irrelevant, the loop is irrelevant (the no-loop case
+  throws), and outer-vs-local is **inverted** from the first reading: OUTER
+  works, LOCAL throws. `S13.2.2_A8_T3` matches exactly — `Function.call(this,
+  "arg", "return ++arg;")` is `++` on a mint-local parameter inside the enclosing
+  `var __func = function(arg1, arg2){…}`. Owner: the runtime-eval lane.
+
+  **Not reproduced:** dev-4515 reports `var n = 0; eval("while(n<3){ n++; }")`
+  throwing on the merged campaign tip (`8794ab2c9` + their commit). On MY base
+  (`c42bdbe3e` + this branch) that exact shape **passes in both contexts** — it
+  is the OUTER-binding row above. Per the brief's third-arm rule I can only say
+  it does not reproduce here; whether their tip differs is theirs to measure.
 - **M `fun.prototype` own-ness** (`13.2-18-1`) — **owner #4491**, with evidence: a
   function EXPRESSION has no own `prototype` property under the live descriptor
   MOP. With an accessor installed on `Function.prototype.prototype`,

--- a/plan/issues/4653-es5-function-declaration-semantics.md
+++ b/plan/issues/4653-es5-function-declaration-semantics.md
@@ -1,7 +1,7 @@
 ---
 id: 4653
 title: "ES5 standalone: language/statements/function residual — 12 rows across arguments.callee identity, named-function-expression scope, property-vs-declaration shadowing, and a null-pointer in __module_init"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-08-23
 updated: 2026-08-23
@@ -14,8 +14,15 @@ area: codegen
 es_edition: 5
 language_feature: functions
 goal: standalone-gap
-related: [4515, 4641, 4643]
+related: [4491, 4504, 4515, 4641, 4643]
 origin: "wave-5 lead sweep (2026-08-23) on campaign HEAD c9990a7d2+, fresh compiler bundle + eval adapter. All 12 rows re-verified failing; no existing issue covers this directory."
+assignee: dev-4653
+loc-budget-allow:
+  - src/codegen/declarations.ts
+  - src/codegen/object-runtime-enumeration.ts
+func-budget-allow:
+  - src/codegen/declarations.ts::collectDeclarations
+  - src/codegen/object-runtime-enumeration.ts::buildObjectEnumerationHelpers
 ---
 
 # #4653 — `language/statements/function` residual (12 rows)
@@ -76,3 +83,232 @@ pinning every fixed shape (executing it, not asserting about it), verified
 failing on base by revert; `it.fails` pins for measured residuals with
 owners. `## Root cause` (per cluster) / `## Fix` / `## Test Results` /
 `## Residuals` in this file.
+
+---
+
+## Triage — the 12 rows are ELEVEN roots, not four
+
+Re-verified live on the branch base (campaign HEAD `c42bdbe3e`) with a freshly
+rebuilt `scripts/compiler-bundle.mjs` + quickjs adapter (the brief's stale-bundle
+trap: on the first pass, two rows reported "quickjs provider is not built" and
+one reported a compile timeout — both artifacts of the missing local adapter, not
+of the compiler). All 12 confirmed failing after the rebuild.
+
+Every root below was isolated with a reduced probe, not inferred from the row's
+error text. Three of the issue file's four premises did not survive measurement:
+`S13_A2_T2` is not a named-function-expression scope bug, `13.2-17-1`'s
+descriptors are all correct, and `S13.2.2_A19_T8`'s closure capture works in
+isolation.
+
+| cluster | rows | measured root | status |
+| --- | --- | --- | --- |
+| **E** for-in shadow set | `13.2-17-1` | `__object_keys_forin`'s private `seen` table is written with `__extern_set`, which probes the implicit `Object.prototype` companion and fires a user setter | **FIXED** |
+| **F** late-assigned fnctor | `S13.2.2_A4_T2` | `var F; F = function(){}` is invisible to both fnctor recognisers, so `F.prototype` and `new F()` disagree | **FIXED** |
+| **D** redeclared function slot | `S13_A6_T1` | the module global is typed from the FIRST `function f(){}`'s signature while the emitted body is the LAST one's | **FIXED** |
+| **W1** `with (arguments)` | `S13.2.2_A18_T1`, `_T2` | `arguments.callee` is a compile-time property-access arm, not an own property of the backing vec, so the dynamic `with` HasBinding gate misses it | residual — vec representation |
+| **W2** re-declared `with` target | `S13.2.2_A19_T8` | two `with` blocks over one re-declared `var` share a target proof keyed off the FIRST initializer's key set | residual |
+| **W3** `with` + var-hoisted fn | `S13.2.2_A17_T3` | null-pointer trap in `__module_init` | residual |
+| **V** omitted reference-typed arg | `S13_A15_T3` | an omitted argument for a `(ref null T)` parameter is `ref.null T`, i.e. JS `null`, not `undefined` | residual — value-rep |
+| **P** binary `+` | `S13_A2_T2` | `number + <dynamic>` folded to an f64 add | residual |
+| **C** non-callable call | `S13.2.2_A2` | calling a non-callable object does not throw at all | residual |
+| **R** `Function(p, body)` | `S13.2.2_A8_T3` | the minted function does not bind its declared parameters | residual — runtime-eval |
+| **M** `fun.prototype` own-ness | `13.2-18-1` | a function EXPRESSION has no own `prototype` under the live descriptor MOP | residual — **#4491** |
+
+## Root cause
+
+### E — the for-in shadow set was written through the full `[[Set]]`
+
+`__object_keys_forin` (`src/codegen/object-runtime-enumeration.ts`) walks the
+prototype chain and, at each level, marks EVERY own key — enumerable or not —
+into a private `seen` table, so a closer own property shadows an inherited
+same-named key. `seen` is `__new_plain_object()`: a `$Object` with a **null
+`$proto`**, which is exactly how an ordinary object literal is represented in
+this runtime. `__extern_set` therefore treats it as one — it exhausts the
+explicit `$proto` chain (immediately, there is none) and then probes the
+**implicit** `Object.prototype` companion via `__extern_set_decide`'s
+`protoIndexSetDecisionInstrs` tail.
+
+Once a test installs an accessor on `Object.prototype` — which the entire
+`propertyHelper.js` / `verifyProperty` family does — the mark
+`seen[key] = key` **invokes that user setter**, passing the enumerated key as
+its argument, and records nothing. Two observable defects from one write:
+
+1. a bare `for (x in o)` fires a setter it must not touch;
+2. the shadow set stays empty, so a name owned at two chain levels is yielded
+   twice.
+
+Measured on base: `13.2-17-1` fails `assert.sameValue(data, "data")` with actual
+`"constructor"`. A step-by-step replay of `verifyProperty`'s phases showed `data`
+flipping at the `for (var x in obj)` enumerability probe (`d0=data` →
+`d1=constructor`), not at any assignment the test performs.
+
+### F — `var F; … F = function(){}` was invisible to both fnctor recognisers
+
+`fnctorDeclFromSymbol` and `resolveFnctorSymbol` both keyed on a
+`VariableDeclaration`'s own initializer. The Sputnik ES5 corpus overwhelmingly
+writes the separated form (`var __CUBE, __FACTORY, __device;` then
+`__FACTORY = function(){}`), and TypeScript records no function declaration for
+that symbol: `getDeclarations()` answers `[VariableDeclaration, Identifier]`,
+the Identifier being the `F` of a later expando write, never the assignment's
+right-hand function.
+
+The result was not a missed optimisation but the **split brain**
+`resolveUserFnctorName`'s own gate comment names. The escape gate held no ctor
+declaration for the name, so `resolveUserFnctorName` reached its
+`neverConstructed` arm and minted `__fnctor_proto_F`; `F.prototype = {…}` and
+`F.prototype.p` read and wrote that global consistently; and `new F()` could not
+route to the fnctor lowering at all. Measured on base:
+
+```
+var A; A = function(){}; A.prototype = {shape:"cube", printShape:…};
+var a = new A();
+A.prototype.shape         // "cube"   <- the write landed
+Object.getPrototypeOf(a)  // null     <- the instance never saw it
+a instanceof A            // false
+```
+
+with `var A = function(){}` correct in the same program on the same run.
+
+### D — a var initialized from a REDECLARED function got a numeric slot
+
+ES §14.1.23 hoists every `function f(){…}` declaration and lets the LAST win, so
+a duplicated name is one binding holding the second body; every call, including
+one written above the second declaration, answers the second body's value.
+TypeScript resolves `f()` through the FIRST declaration's signature.
+
+The compiler already emits the last body correctly — on base the emitted
+function is `(func $__func (result (ref null 6)))` returning the `'A'` constant.
+Only the receiving slot was wrong: `moduleGlobalWasmType` typed
+`var __1 = __func()` from the checker's `number`, giving `(mut f64)`, and the
+string result coerced to `NaN` on BOTH reads.
+
+## Fix
+
+| file | change |
+| --- | --- |
+| `src/codegen/object-runtime-enumeration.ts` | the `seen` mark uses `__extern_set_own` (same data-write tail, no descriptor or prototype consult), falling back to `__extern_set` where the own-only helper is not registered — which is exactly the configuration in which `__extern_set` cannot walk a chain anyway |
+| `src/codegen/fnctor-ctor-decl.ts` (new) | `lateAssignedFunctionExpression` + the relocated `fnctorDeclFromSymbol`, so the escape gate and the resolver share ONE admission rule |
+| `src/codegen/fnctor-escape-gate.ts` | both recognisers consult it; net −16 LOC (the relocation is larger than the addition) |
+| `src/codegen/duplicate-function-declaration.ts` (new) | `callTargetIsRedeclaredFunction`, via `ctx.oracle.declarationsOf` |
+| `src/codegen/declarations.ts` | `moduleGlobalWasmType` widens a call-initialized global to `externref` when the callee has ≥2 body-bearing declarations — the sibling of the existing purely-void-call arm |
+
+**Why F's admission is narrow.** A wrong claim there is a miscompile; a decline
+only forfeits today's behaviour. Admitted: a non-exported `var` with no
+initializer, declared at the top level of its source file (a module-local `var`
+cannot be written from another file, so one file is the whole write set),
+written exactly once, by a top-level `F = <FunctionExpression>` statement. A
+second write, a compound assignment, an update expression or a for-in/of binding
+all decline. Identity is proved with `checker.getSymbolAtLocation`, never
+spelling, so an inner scope that shadows the name cannot forge a write.
+
+**Why D's admission is narrow.** Only two or more **body-bearing** declarations
+qualify, so an ordinary TS overload set — where only the implementation has a
+body — is untouched, as is every singly-declared function.
+
+## Test Results
+
+All numbers below come from runs executed on this branch, by the same driver
+(`runTest262File(…, "standalone")`), with the compiler bundle and quickjs
+adapter rebuilt locally before the first measurement.
+
+**Scoped sweep**, `language/statements/function` + `language/statements/return` +
+`language/statements/try`, 668 files, both arms:
+
+| arm | pass | fail | compile_error |
+| --- | --- | --- | --- |
+| base (`c42bdbe3e`) | 611 | 56 | 1 |
+| this branch | (see `## Sweep result` below) | | |
+
+**Per-file flips (fail → pass), 3:**
+
+- `language/statements/function/13.2-17-1.js`
+- `language/statements/function/S13.2.2_A4_T2.js`
+- `language/statements/function/S13_A6_T1.js`
+
+**Zero regressions** (per-file diff of the two sweeps).
+
+**Pins** — `tests/issue-4653.test.ts`, 17 tests, `npm test -- tests/issue-4653.test.ts`:
+
+- on this branch: **17 passed**;
+- on base, by file-copy revert of exactly the three modified files: **3 failed,
+  14 passed** — and the three failures are precisely the three positive pins
+  that guard E, F and D. Every negative control and every `it.fails` residual
+  pin answers identically on both arms, which is what makes the three failures
+  attributable to this change-set rather than to the revert.
+
+The second E pin (a two-level own name yielded once) and the non-enumerable
+shadow pin pass on BOTH arms: they guard the half of the shadow write that the
+own-only switch must not break, not a behaviour this change flips.
+
+## Residuals
+
+Nine rows remain, each with a measured root and an owner. None is a guess.
+
+- **W1 `with (arguments)`** (`S13.2.2_A18_T1`, `_T2`) — `arguments.callee` is
+  synthesized by a compile-time property-access arm; it is not an own property of
+  the runtime vec that backs the arguments object, so the dynamic `with`
+  HasBinding gate (`__extern_has`) misses it and `callee = 1` writes the OUTER
+  binding. Measured discriminator: inside the same `with (arguments)`,
+  `return length` answers 3 for a 3-argument call (the vec DOES own `length`)
+  while `return callee` answers the outer variable. A real fix needs `callee` to
+  become a writable own property of the arguments object — the row also asserts
+  `result.callee === 1` afterwards, so a read-only special case would flip
+  CHECK#1 and still fail CHECK#3. That is vec-representation work
+  (`src/codegen/vec-overlay*.ts`), owned by another lane; **not** attempted here.
+- **W2 re-declared `with` target** (`S13.2.2_A19_T8`) — narrowed to: two `with`
+  blocks over the SAME re-declared `var obj`, where the second literal owns a key
+  the first does not. The same program with two DISTINCT target variables is
+  correct, and a single `with` block with a `var`-declared closure inside is
+  correct; only the re-declared target fails. The static target proof is keyed
+  off the first initializer's key set.
+- **W3 `with` + var-hoisted function expression** (`S13.2.2_A17_T3`) — a
+  `var f = function(){}` declared inside a `with` body whose target owns the same
+  name traps with `dereferencing a null pointer in __module_init`. Reproduced in a
+  reduced probe. Trap-first: this is an invalid access, not a wrong answer, and I
+  did not attempt a fix I could not verify end-to-end within this lane.
+- **V omitted reference-typed argument** (`S13_A15_T3`) — the row's
+  `arguments`-named parameter is INCIDENTAL. Measured: `function pass(q){return q}`
+  called with zero arguments answers `undefined` when that is the only call site,
+  and answers **`null`** (`typeof "object"`, `v === null` true) as soon as one
+  other call site passes a string, because the parameter's wasm type becomes a
+  nullable reference and the padding is `ref.null <typeidx>`. Value-representation
+  territory (#4641's lane); the fix is to widen the parameter, not to patch the
+  pad.
+- **P binary `+`** (`S13_A2_T2`) — also not what the issue file predicted. The
+  named-function-expression scope check (CHECK#2) PASSES; `arguments[1]` on its
+  own IS the string `"1"` and `typeof arguments[1]` IS `"string"`. Only
+  `arg + arguments[1]` folded to an f64 add because the left operand is provably
+  numeric and the right one is dynamic.
+- **C non-callable call** (`S13.2.2_A2`) — `rose()` does not throw at all; it
+  evaluates to `undefined`. That is why the row reports `[object Object]`: the
+  test's own `throw new Test262Error(…)` then runs inside the `try` and is caught
+  as "the exception". The spec answer is a TypeError from §7.3.14 Call step 1.
+- **R `Function(p, body)`** (`S13.2.2_A8_T3`) — the minted function does not bind
+  its declared parameters: `++arg` throws `ReferenceError: arg is not defined`.
+  Measured identically for `new Function("arg","return ++arg;")`,
+  `Function("arg", …)` and `Function.call(null, "arg", …)`, so the root is the
+  MINT, not the receiver or the `.call` transfer. Runtime-eval lane.
+- **M `fun.prototype` own-ness** (`13.2-18-1`) — **#4491's**, with evidence: with
+  an accessor installed on `Function.prototype.prototype`, `fun.prototype` reads
+  as `undefined` and `hasOwnProperty(fun, "prototype")` is false for a function
+  EXPRESSION, so `verifyProperty`'s `assert(__hasOwnProperty(obj, name))` cannot
+  hold and `fun.prototype.toString()` throws first. Its sibling `13.2-17-1` did
+  NOT root in the MOP — every descriptor on `fun.prototype.constructor` is
+  already correct (`writable: true, enumerable: false, configurable: true`, own,
+  data) — which is why only one of the pair moved here.
+
+One residual is NOT one of the twelve, found while measuring F and worth
+recording: `a instanceof A` still answers false for a late-assigned fnctor even
+now that `Object.getPrototypeOf(a)` is right. `native-user-instanceof.ts` reaches
+the same `emitFnctorProtoGet` but a different arm decides first. Pinned
+`it.fails`.
+
+Also observed while measuring E, outside this issue's rows: an inherited
+accessor's SETTER is not invoked by an ordinary `o.zzz = 42` when `zzz` is an
+accessor on `Object.prototype` and `o` has no own `zzz` (measured: the setter
+never ran). That is #4504's territory, stated here only because the same
+`__extern_set_decide` path carries both.
+
+## Sweep result
+
+_(filled in below once the after-sweep completes — see `## Test Results`)_

--- a/plan/issues/4658-arguments-object-length-callee-descriptors.md
+++ b/plan/issues/4658-arguments-object-length-callee-descriptors.md
@@ -1,0 +1,87 @@
+---
+id: 4658
+title: "ES5 standalone: arguments-object `length`/`callee` own-property descriptors — a NUMBER write to arguments.length sticks but a STRING write does not; gOPD reports wrong writable/configurable; typeof argObj.callee answers \"number\""
+status: ready
+sprint: current
+created: 2026-08-23
+updated: 2026-08-23
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: arguments-object
+goal: standalone-gap
+related: [4491, 4515, 4032]
+origin: "Narrowed by dev-4515 against dev-4491's MERGED wave-4 tree (2026-08-23), then handed to dev-4491, which DECLINED it as a distinct slice with its own risk surface rather than fold it into an unrelated parity fix. Filed by the lead so it has an owner. Both lanes' measurements are recorded below; neither is working it."
+---
+
+# #4658 — arguments-object `length` / `callee` descriptors
+
+## Why this is its own issue, not #4491's element-freeze work
+
+dev-4515 re-verified these four rows against dev-4491's **merged** wave-4 fix
+(`Object.freeze` now visible to array/arguments ELEMENTS) and the residue is
+**not** element freeze — it is the `length` and `callee` **own-property
+descriptors** on the arguments object. dev-4491 declined to fold it in with the
+reason worth preserving: folding a distinct slice into an unrelated fix "would
+make both unmeasurable". Take it as its own before/after.
+
+## Affected rows
+
+```
+language/arguments-object/10.6-13-a-1.js   typeof argObj.callee → "number", want "function"
+language/arguments-object/10.6-6-2.js      length descriptor should be configurable
+language/arguments-object/10.6-7-1.js      length descriptor should be configurable
+language/arguments-object/S10.6_A5_T4.js   arguments object don't exists
+```
+
+## Measured symptoms (dev-4515, on the merged wave-4 tree)
+
+1. **A NUMBER write to `arguments.length` sticks; a STRING write does not.**
+   dev-4491 identifies this as the same **kind-incompatible-carrier** defect as
+   its own `15.2.3.7-6-a-183` residual — a cross-type write to a slot whose
+   carrier was resolved for the other kind.
+2. `Object.getOwnPropertyDescriptor(argObj, "length")` reports the wrong
+   `writable` / `configurable`.
+3. `typeof argObj.callee` answers `"number"`.
+
+## Lead's note on likely shared root (from dev-4491)
+
+The `length` half **likely shares a root with dev-4491's
+`heterogeneousWidenedModuleGlobalType` residual** — whoever takes this may get
+two fixes for one investigation. Verify that before assuming it; it is a
+pointer, not a measurement.
+
+## Implementation Plan
+
+1. Brief: `plan/method/es5-standalone-agent-brief.md` — BINDING, read fully
+   before the first edit. Especially: methodology 1–7, the **contention trap**
+   (re-run every apparent flip AND apparent regression SERIALLY before it goes
+   in a report — a `compile_error: compilation timeout` is a measurement
+   failure, not a status), the **pool-suite false green** (`skipped` is not
+   `passed`; read counts, never exit codes), the stale `compiler-bundle.mjs`
+   trap, the `test262/` symlink-farm + **GITLINK hazard**.
+2. Re-verify all four rows live on current campaign HEAD first — dev-4491's
+   wave-4 fixes are merged and may have moved them since the narrowing.
+3. Start with symptom 1 (the cross-type write): it is the one with a named
+   sibling defect (`-6-a-183`) and a named candidate shared root
+   (`heterogeneousWidenedModuleGlobalType`). Establish whether the carrier is
+   resolved per-slot or per-kind before designing the fix.
+4. `callee` answering `"number"` smells like the same slot-carrier confusion
+   one level out — measure whether it shares root 1 before treating it
+   separately.
+5. Absent-not-wrong: if a descriptor cannot be answered faithfully, decline the
+   fold rather than answer wrongly.
+
+## Acceptance
+
+Scoped standalone sweep over `language/arguments-object` before AND after from
+your own runs, with apparent flips/regressions re-verified serially; per-file
+flip list; **zero regressions**. `tests/issue-4658.test.ts` pinning each fixed
+shape — the pin must EXECUTE the write and read it back, and the descriptor
+pins must call `gOPD` and assert the specific attributes — verified failing on
+base by file-copy revert; `it.fails` pins for measured residuals with owners.
+Record `## Root cause` / `## Fix` / `## Test Results` / `## Residuals` here.

--- a/plan/issues/4662-eval-local-update-expression-referenceerror.md
+++ b/plan/issues/4662-eval-local-update-expression-referenceerror.md
@@ -1,0 +1,108 @@
+---
+id: 4662
+title: "runtime-eval: `++`/`--` on a name LOCAL to eval'd or Function-minted code throws ReferenceError — but only when the eval/mint sits inside an enclosing function; plain reads and `x = x + 1` are fine"
+status: ready
+sprint: current
+created: 2026-08-23
+updated: 2026-08-23
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: runtime-eval
+es_edition: 5
+language_feature: eval
+goal: standalone-gap
+related: [4653, 4515, 4642, 4647]
+origin: "dev-4515 flagged an eval-scope symptom; dev-4653 ran the discriminator neither lane had and falsified BOTH narrowings, including its own prior write-up. Filed by the lead — neither lane owns runtime-eval substrate and neither started on it."
+---
+
+# #4662 — update expression on an eval-local name throws ReferenceError
+
+## Measured rule (dev-4653, standalone lane, reduced probes)
+
+An update expression (`++` / `--`) on a name **local to the eval'd or minted
+code** — an eval-local `var`, or a `Function` parameter — throws
+`ReferenceError: <name> is not defined`, **and only when the eval/mint sits
+inside an enclosing function.** Module top level is fine.
+
+```js
+new Function("p", "return p;")(7)             // -> 7   the parameter IS bound
+new Function("p", "p = p + 1; return p;")(1)  // -> 2   compound assignment fine
+new Function("p", "p++; return p;")(1)        // -> THROW `p is not defined`
+eval("var i = 0; i++; i")   inside a function // -> THROW `i`  (no loop involved)
+eval("var i = 0; i++; i")   at top level      // -> 1
+```
+
+## Three intuitions this kills — read before hypothesising
+
+1. **`for` vs `while` is irrelevant.** `for (q = 0; q < 3; q++)` throws too.
+2. **The loop is irrelevant.** The bare `eval("var i = 0; i++; i")` throws with
+   no loop anywhere.
+3. **Outer-vs-local is INVERTED from the first reading.** `++` on an **outer**
+   binding works; `++` on a **local** one throws. The originally-reported repro
+   (`var n = 0; eval("while (n<3) { n++; }")`) is the *outer* case and does
+   **not** reproduce on dev-4653's base.
+4. **The enclosing-function context is the confound.** A top-level survey cannot
+   see this defect at all, which is why it first looked like a loop-test rule.
+
+## Provenance and its limits (third-arm rule)
+
+- The rule above is dev-4653's measurement on base `c42bdbe3e` + its own commits,
+  **standalone lane only**.
+- dev-4515 was on `8794ab2c9` + its own commit. Neither lane can speak for the
+  other's tree, so "does not reproduce" is recorded as *does not reproduce
+  here*, not as a claim about the other arm. Re-establish the rule on current
+  campaign HEAD before building on it.
+- Probes: `.tmp/probes/ev{1,2,3,4}.js` in dev-4653's worktree; the full
+  discriminator table is in `plan/issues/4653-es5-function-declaration-semantics.md`
+  under residual **R**.
+
+## A correction this issue exists because of
+
+dev-4653's first write-up recorded residual R as *"the minted function does not
+bind its declared parameters"* — an inference restated as a measurement, and
+**false**: the read-only case answers `7`. The refuting probe cost one run. The
+brief names this as the campaign's most-repeated documented defect; it is worth
+re-reading before the first hypothesis here hardens into a claim.
+
+## Known conformance rows
+
+`language/statements/function/S13.2.2_A8_T3.js`
+(`Function.call(this, "arg", "return ++arg;")` inside a function expression) is
+this root. `language/expressions/assignment/S11.13.1_A6_T{1,2}` are **plausibly**
+the same and must be verified, not assumed.
+
+## Implementation Plan
+
+1. Brief: `plan/method/es5-standalone-agent-brief.md` — BINDING, read fully.
+   Load-bearing here: methodology 1–7, the **contention trap** (a
+   `compilation timeout` is a measurement failure, not a status — re-run every
+   apparent flip and regression serially), the **pool-suite false green**
+   (`skipped` is not `passed`; read counts, never exit codes), the stale
+   `compiler-bundle.mjs` trap (rebuild bundle + adapter on BOTH arms — this is
+   eval territory), the `test262/` symlink-farm + **GITLINK hazard**.
+2. Re-establish the discriminator table on current campaign HEAD first, in
+   both tiers (quickjs and `JS2WASM_EVAL_ENGINE=interpreter`). The
+   enclosing-function axis is the one to keep in every probe — dropping it hides
+   the defect entirely.
+3. Then find why an update expression resolves its operand differently from a
+   read or a compound assignment in minted code. The asymmetry is the lead:
+   `p` reads fine and `p = p + 1` writes fine, so the binding exists — it is the
+   update expression's own reference resolution that misses it.
+4. Absent-not-wrong: if some shape cannot be resolved faithfully, decline rather
+   than answer wrongly.
+
+## Acceptance
+
+Scoped standalone sweep over `language/expressions/assignment`,
+`language/statements/function` and the eval-dependent `built-ins/Function` rows
+before AND after from your own runs, apparent flips/regressions serially
+re-verified; per-file flip list; **zero regressions**.
+`tests/issue-4662.test.ts` pinning each fixed shape in BOTH tiers, every pin
+EXECUTING the update expression — and carrying **positive controls** the way
+dev-4653's corrected pins do (parameter binding; outer-`++` in a loop), so the
+suite claims "`++` on a local" rather than "eval scope is broken" and a fix that
+widens the wrong thing cannot read as green. Verified failing on base by revert.
+Record `## Root cause` / `## Fix` / `## Test Results` / `## Residuals` here.

--- a/plan/method/es5-standalone-agent-brief.md
+++ b/plan/method/es5-standalone-agent-brief.md
@@ -84,6 +84,40 @@ from `src/index.js`; `emitWat:true` to read WAT. All probes live in `.tmp/`.
    - The merge check confirms the run says **N passed** — never that it
      exited 0 (`describe.skipIf` gates can skip an entire suite green).
 
+8. **A residual is a CLAIM, and `it.fails` protects it from ever being
+   tested (2026-08-23, dev-4653 self-correction).** This is the cheapest
+   place in the method for a wrong statement to survive indefinitely, and
+   it was found the only way it can be — by accident, when a sibling
+   lane's message forced a re-open of a row already written up, swept
+   green, pinned, and committed.
+
+   The failure shape: a lane attributes a residual to a root it inferred
+   rather than probed, then pins it `it.fails`. The pin **passes**,
+   because the row does fail — just not for the stated reason. The sweep
+   is green, the suite is green, and the wrong root is now documented as
+   a measurement for the next lane to build on. Nothing in the workflow
+   ever re-examines it. Measured instance: "the minted function does not
+   bind its declared parameters" survived a full lane and its pins, while
+   `new Function("p","return p;")(7)` answers `7` — one probe, never run,
+   and the attribution was backwards (the defect is `++` on a
+   mint-LOCAL name, only inside an enclosing function; see #4662).
+
+   Rules that fall out:
+   - **Probe the NEGATIVE case before attributing a residual.** State the
+     one observation that would refute your root, run it, and record the
+     result. An attribution you did not try to falsify is a hypothesis,
+     so label it one — `suspected root`, not `root`.
+   - **Every `it.fails` pin carries POSITIVE CONTROLS that must pass**,
+     chosen so the suite claims the specific root rather than the general
+     area. dev-4653's corrected pins are the worked example: two
+     `it.fails` on "`++` on a mint-local name" plus controls asserting
+     that parameter binding works and that outer-`++` works. Without the
+     controls, a future fix that widens the wrong thing repairs the pin
+     and reads as green.
+   - Residual attributions are what the NEXT lane starts from, so a wrong
+     one costs more than a missing one. "Root unknown, here is what I
+     ruled out" is a better handover than a confident wrong root.
+
 ## Environment trap: fresh worktrees have NO .test262-cache (#4484 finding)
 
 A fresh agent worktree lacks `.test262-cache/`, so eval-dependent rows fail

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -132,6 +132,7 @@ import { inferStandaloneRegExpMatchGlobalType } from "./regexp-standalone.js";
 import { prepareModuleTdzGlobals, registerModuleGlobal } from "./module-global-registration.js";
 import { annexBModuleGlobalSeedsFromTopLevel } from "./annexb-global-live-binding.js";
 import { variableSlotHoldsReconstructedFnctorInstance } from "./fnctor-instance-object-slot.js";
+import { callTargetIsRedeclaredFunction } from "./duplicate-function-declaration.js"; // (#4653)
 import { emitRuntimeEvalAotCallableAdapter } from "./runtime-eval-callable.js";
 import { numericReturnsFlagEnabled } from "../derivation-flags.js";
 
@@ -2390,6 +2391,11 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
         if ((callType.flags & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0) {
           return { kind: "externref" };
         }
+        // (#4653) …and the DUPLICATE-DECLARATION twin of the same defect: the
+        // checker answers the FIRST `function f(){…}`'s signature while the
+        // emitted body is the LAST one's, so no query on this call site reports
+        // what the slot will actually receive. See duplicate-function-declaration.ts.
+        if (callTargetIsRedeclaredFunction(ctx, init)) return { kind: "externref" };
       }
     }
     // #1914 — `var m = re.exec(s)` under standalone gets the precise

--- a/src/codegen/duplicate-function-declaration.ts
+++ b/src/codegen/duplicate-function-declaration.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4653) A name declared by MORE THAN ONE body-bearing `function` declaration.
+ *
+ * ES §14.1.23 FunctionDeclarationInstantiation hoists every declaration and lets
+ * the LAST one win, so `function f(){return 1} … function f(){return 'A'}` is
+ * one binding holding the second body — and every call, including calls written
+ * ABOVE the second declaration, answers `'A'`. TypeScript disagrees: it resolves
+ * `f()` through the FIRST declaration's signature. The compiler emits the last
+ * body (correctly), so the two views split, and the split lands wherever a slot
+ * is typed from the checker's answer instead of the emitted one:
+ *
+ *     function __func(){return 1};
+ *     var __1 = __func();            // slot typed `number` -> (mut f64)
+ *     function __func(){return 'A'};
+ *     var __A = __func();            // same
+ *     __1                            // NaN  (the string coerced into f64)
+ *
+ * measured on this branch's base, where `__func` itself compiles to
+ * `(func $__func (result (ref null 6)))` returning the `'A'` constant — i.e. the
+ * function is right and only the receiving slot is wrong.
+ *
+ * The remedy is representation-neutral storage, not a better guess at the type:
+ * the live body's result is whatever the LAST declaration returns, which no
+ * checker query on the call site reports. Widening is confined to this
+ * already-pathological shape, so a name with a single declaration (including
+ * ordinary TS overloads, where only the implementation carries a body) is
+ * untouched.
+ */
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+
+/** Unwrap parenthesized / `as` / `!` wrappers. */
+function unwrap(expr: ts.Expression): ts.Expression {
+  let cur = expr;
+  while (ts.isParenthesizedExpression(cur) || ts.isAsExpression(cur) || ts.isNonNullExpression(cur)) {
+    cur = cur.expression;
+  }
+  return cur;
+}
+
+/**
+ * True when `expr` is a direct call `f(…)` whose callee resolves to a name with
+ * two or more body-bearing `function` declarations — i.e. the checker's result
+ * type for the call is NOT the type the emitted body produces.
+ */
+export function callTargetIsRedeclaredFunction(ctx: CodegenContext, expr: ts.Expression): boolean {
+  const call = unwrap(expr);
+  if (!ts.isCallExpression(call)) return false;
+  const callee = unwrap(call.expression);
+  if (!ts.isIdentifier(callee)) return false;
+  let bodies = 0;
+  for (const decl of ctx.oracle.declarationsOf(callee)) {
+    if (decl.getSourceFile().isDeclarationFile) continue;
+    if (ts.isFunctionDeclaration(decl) && decl.body) bodies++;
+    if (bodies > 1) return true;
+  }
+  return false;
+}

--- a/src/codegen/fnctor-ctor-decl.ts
+++ b/src/codegen/fnctor-ctor-decl.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Resolving a fnctor SYMBOL to the declaration that supplies its constructor
+ * body. `fnctor-escape-gate.ts` owns the escape/approval analysis; this module
+ * owns only the "which node is F's body?" question, so both of that file's
+ * recognisers (`fnctorDeclFromSymbol` here, `resolveFnctorSymbol` there) can
+ * share one admission rule.
+ *
+ * ## (#4653) The `var F; … F = function(){…};` spelling
+ *
+ * `var F = function(){}` is recognised by both recognisers off the
+ * VariableDeclaration's own initializer. The Sputnik ES5 corpus overwhelmingly
+ * writes the *separated* form instead (`var __CUBE, __FACTORY, __device;` then
+ * `__FACTORY = function(){}`), and TypeScript records NO function declaration
+ * for that symbol — `getDeclarations()` answers `[VariableDeclaration,
+ * Identifier]`, the Identifier being the `F` of a later expando write, never the
+ * assignment's right-hand function.
+ *
+ * The consequence was not a missed optimisation but the SPLIT BRAIN
+ * `resolveUserFnctorName`'s gate comment names. That resolver reaches its
+ * `neverConstructed` arm (the escape gate holds no ctor declaration for the
+ * name, so "is it constructed?" answers no), mints `__fnctor_proto_F`, and
+ * `F.prototype = {…}` / `F.prototype.p` read and write it consistently — while
+ * `new F()` cannot route to the fnctor lowering at all and hands back an
+ * instance whose [[Prototype]] is null. Measured on this branch's base:
+ *
+ *   var A; A = function(){}; A.prototype = {shape:"cube", printShape:…};
+ *   var a = new A();
+ *   A.prototype.shape        // "cube"   ← the write landed
+ *   Object.getPrototypeOf(a) // null     ← the instance never saw it
+ *
+ * with the `var A = function(){}` spelling of the very same program correct on
+ * the same run. Teaching BOTH recognisers this one shape is what keeps them in
+ * lockstep; teaching only one would move the split rather than close it.
+ *
+ * Admission is deliberately narrow, because a wrong claim here is a miscompile
+ * while a decline only forfeits today's behaviour:
+ *   - the binding is a non-exported `var` with NO initializer, declared at the
+ *     top level of its source file (a module-local `var` cannot be written from
+ *     another file, so one file is the whole write set);
+ *   - it is WRITTEN exactly once in that file, by a top-level
+ *     `F = <FunctionExpression>` expression statement. A second write, a
+ *     compound assignment, an update expression, or a for-in/of binding all
+ *     decline — those are the shapes that could put a different value in the
+ *     slot and re-open the split from the other side.
+ */
+import { ts } from "../ts-api.js";
+
+/** Per-`ts.Symbol` memo; entries die with the program the symbols came from. */
+const cache = new WeakMap<ts.Symbol, ts.FunctionExpression | null>();
+
+/** Whether this identifier occurrence WRITES its binding. */
+function isWritePosition(ident: ts.Identifier): boolean {
+  const parent = ident.parent;
+  if (ts.isBinaryExpression(parent) && parent.left === ident) {
+    return (
+      parent.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      parent.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+    );
+  }
+  if ((ts.isPrefixUnaryExpression(parent) || ts.isPostfixUnaryExpression(parent)) && parent.operand === ident) {
+    return parent.operator === ts.SyntaxKind.PlusPlusToken || parent.operator === ts.SyntaxKind.MinusMinusToken;
+  }
+  if ((ts.isForInStatement(parent) || ts.isForOfStatement(parent)) && parent.initializer === ident) return true;
+  return false;
+}
+
+/** The single top-level `var` declaration behind `sym`, or `undefined`. */
+function soleUninitializedTopLevelVar(sym: ts.Symbol): ts.VariableDeclaration | undefined {
+  let found: ts.VariableDeclaration | undefined;
+  for (const decl of sym.getDeclarations() ?? []) {
+    if (!ts.isVariableDeclaration(decl)) continue;
+    if (decl.initializer !== undefined || !ts.isIdentifier(decl.name)) return undefined;
+    const list = decl.parent;
+    if (!ts.isVariableDeclarationList(list) || (list.flags & ts.NodeFlags.BlockScoped) !== 0) return undefined;
+    const stmt = list.parent;
+    if (!ts.isVariableStatement(stmt) || stmt.parent.kind !== ts.SyntaxKind.SourceFile) return undefined;
+    if (stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) return undefined;
+    if (found) return undefined; // two `var F;` declarations — not worth proving
+    found = decl;
+  }
+  return found;
+}
+
+/**
+ * The `FunctionExpression` a once-assigned `var F;` binding holds, or
+ * `undefined` when the shape is not provable. See the module header.
+ */
+export function lateAssignedFunctionExpression(
+  checker: ts.TypeChecker,
+  sym: ts.Symbol,
+): ts.FunctionExpression | undefined {
+  const cached = cache.get(sym);
+  if (cached !== undefined) return cached ?? undefined;
+
+  const decide = (): ts.FunctionExpression | undefined => {
+    const varDecl = soleUninitializedTopLevelVar(sym);
+    if (!varDecl) return undefined;
+
+    let found: ts.FunctionExpression | undefined;
+    let writes = 0;
+    const visit = (node: ts.Node): void => {
+      if (writes > 1) return;
+      if (ts.isIdentifier(node) && node.text === sym.name && isWritePosition(node)) {
+        // Spelling alone does not prove identity — an inner scope may shadow
+        // the name — so the symbol must match before the write is counted.
+        if (checker.getSymbolAtLocation(node) === sym) {
+          writes++;
+          const parent = node.parent;
+          const assignment =
+            ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken
+              ? parent
+              : undefined;
+          // Top-level `F = function(){…};` only: a write nested in a branch or
+          // in a function body is not proof that the slot holds this value when
+          // the module's `new F()` sites run.
+          if (
+            assignment &&
+            ts.isExpressionStatement(assignment.parent) &&
+            assignment.parent.parent.kind === ts.SyntaxKind.SourceFile
+          ) {
+            let rhs: ts.Expression = assignment.right;
+            while (ts.isParenthesizedExpression(rhs)) rhs = rhs.expression;
+            if (ts.isFunctionExpression(rhs) && rhs.body) found = rhs;
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(varDecl.getSourceFile());
+    return writes === 1 ? found : undefined;
+  };
+
+  const result = decide();
+  cache.set(sym, result ?? null);
+  return result;
+}
+
+/**
+ * Resolve a fnctor symbol to the function-like declaration that supplies its
+ * constructor body — a top-level `function F(){…}`, a `var F = function(){…}`, a
+ * once-assigned `var F; F = function(){…}` (#4653, above), or a bare
+ * `FunctionExpression`. Returns `undefined` for anything else (arrow, class —
+ * those never reach here via `resolveFnctorSymbol`).
+ *
+ * `checker` is optional only so a caller without one keeps the pre-#4653
+ * answers; every caller in `fnctor-escape-gate.ts` supplies it.
+ */
+export function fnctorDeclFromSymbol(
+  sym: ts.Symbol,
+  checker?: ts.TypeChecker,
+): ts.FunctionDeclaration | ts.FunctionExpression | undefined {
+  for (const decl of sym.getDeclarations() ?? []) {
+    if (ts.isFunctionDeclaration(decl) && decl.body) return decl;
+    if (ts.isFunctionExpression(decl) && decl.body) return decl;
+    if (ts.isVariableDeclaration(decl) && decl.initializer) {
+      let init: ts.Expression = decl.initializer;
+      while (ts.isParenthesizedExpression(init)) init = init.expression;
+      if (ts.isFunctionExpression(init) && init.body) return init;
+    }
+  }
+  return checker ? lateAssignedFunctionExpression(checker, sym) : undefined;
+}

--- a/src/codegen/fnctor-escape-gate.ts
+++ b/src/codegen/fnctor-escape-gate.ts
@@ -53,6 +53,7 @@ import { fnctorBodyMayReturnForeignObject, foreignReturnFunctionNames } from "./
 import { applyFnctorLayoutSplit, fnctorLayoutEmitEnabled } from "./fnctor-layout-emit.js"; // (#3927) per-type layout EMISSION
 import { recordFnctorFieldProvenance } from "./fnctor-field-provenance.js";
 import { fnctorFieldNumericWriteViolation, inferFnctorFieldTypeFromCtorParam } from "./fnctor-ctor-param-types.js";
+import { fnctorDeclFromSymbol, lateAssignedFunctionExpression } from "./fnctor-ctor-decl.js"; // (#4653)
 import { resolveWasmType } from "./index.js";
 
 /** Classification of a `new F()` fnctor allocation site. */
@@ -262,25 +263,6 @@ function emptyResult(compilePath: FnctorCompilePath, sourceFileCount: number): F
   };
 }
 
-/**
- * Resolve a fnctor symbol to the function-like declaration that supplies its
- * constructor body — a top-level `function F(){…}`, a `var F = function(){…}`, or
- * a bare `FunctionExpression`. Returns `undefined` for anything else (arrow, class
- * — those never reach here via `resolveFnctorSymbol`).
- */
-function fnctorDeclFromSymbol(sym: ts.Symbol): ts.FunctionDeclaration | ts.FunctionExpression | undefined {
-  for (const decl of sym.getDeclarations() ?? []) {
-    if (ts.isFunctionDeclaration(decl) && decl.body) return decl;
-    if (ts.isFunctionExpression(decl) && decl.body) return decl;
-    if (ts.isVariableDeclaration(decl) && decl.initializer) {
-      let init: ts.Expression = decl.initializer;
-      while (ts.isParenthesizedExpression(init)) init = init.expression;
-      if (ts.isFunctionExpression(init) && init.body) return init;
-    }
-  }
-  return undefined;
-}
-
 /** Max callee-chain depth the single-return struct inference will follow. */
 const RETURN_INFER_MAX_DEPTH = 6;
 
@@ -316,7 +298,9 @@ export function resolveFnctorSymbol(checker: ts.TypeChecker, calleeExpr: ts.Expr
       if (ts.isArrowFunction(init)) return undefined; // arrows are not constructors
     }
   }
-  return undefined;
+  // (#4653) `var F; … F = function(){…};` — the SAME recogniser
+  // `fnctorDeclFromSymbol` uses, so gate and resolver keep one population.
+  return lateAssignedFunctionExpression(checker, sym) ? sym : undefined;
 }
 
 /**
@@ -1628,7 +1612,7 @@ export function analyzeFnctorEscapeGate(
   // costs only the optimization and is COUNTED, so the decline is visible.
   const declFilesByName = new Map<string, Set<ts.SourceFile>>();
   for (const { ctorSym } of newSites) {
-    const decl = fnctorDeclFromSymbol(ctorSym);
+    const decl = fnctorDeclFromSymbol(ctorSym, checker);
     if (!decl) continue;
     const seen = declFilesByName.get(ctorSym.name);
     if (seen) seen.add(decl.getSourceFile());
@@ -1640,7 +1624,7 @@ export function analyzeFnctorEscapeGate(
       refuse(ctorSym.name, "multi-module-name-collision");
       continue;
     }
-    const decl = fnctorDeclFromSymbol(ctorSym);
+    const decl = fnctorDeclFromSymbol(ctorSym, checker);
     if (decl) ctorDeclByName.set(ctorSym.name, decl);
   }
 

--- a/src/codegen/object-runtime-enumeration.ts
+++ b/src/codegen/object-runtime-enumeration.ts
@@ -372,10 +372,27 @@ export function buildObjectEnumerationHelpers(ctx: CodegenContext, s: ObjectEnum
   //   2. ALL own keys (`__obj_ordered_all`, incl. non-enumerable): add each to
   //      `seen` so it shadows the same name at lower (proto) levels.
   // The `seen` set is a fresh empty `$Object` (null $proto) used purely as a
-  // membership table via `__object_hasOwn`/`__extern_set` — this reuses the exact
-  // key hashing + equality the property map uses, so there is no native-string
-  // representation mismatch. The own-only test remains correct even after the
-  // Object.prototype companion has gained properties of its own.
+  // membership table via `__object_hasOwn`/`__extern_set_own` — this reuses the
+  // exact key hashing + equality the property map uses, so there is no
+  // native-string representation mismatch. The own-only test remains correct
+  // even after the Object.prototype companion has gained properties of its own.
+  //
+  // (#4653) The membership WRITE must be own-only. A null-`$proto` `$Object` is
+  // exactly how an ordinary object literal is represented in this runtime, so
+  // `__extern_set` treats `seen` as one and — after the explicit chain runs out
+  // — probes the IMPLICIT `Object.prototype` companion (`__extern_set_decide`'s
+  // `protoIndexSetDecisionInstrs` tail). Once a test installs an accessor on
+  // `Object.prototype` (the `propertyHelper.js` / `verifyProperty` family does
+  // this constantly), `seen[key] = key` INVOKES that user setter with the
+  // enumerated key as its argument and the shadow entry is never recorded. Two
+  // observable defects fall out: the setter fires from a bare `for (x in o)`
+  // (`language/statements/function/13.2-17-1` fails on `data === "data"` — the
+  // setter received the string `"constructor"`), and the shadow set stays empty
+  // so a name owned at two chain levels is yielded twice. `__extern_set_own` is
+  // the same data-write tail without any descriptor/proto consult; it exists
+  // only when the #4504 inherited-set runtime is active, which is also the only
+  // configuration in which `__extern_set` can walk a chain at all, so the
+  // fallback below is exact.
   //
   // params: 0=obj(externref)
   // locals: 1=any(anyref) 2=cur(ref null $Object) 3=arr(ref null $PropMap)
@@ -384,7 +401,11 @@ export function buildObjectEnumerationHelpers(ctx: CodegenContext, s: ObjectEnum
   {
     const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
     const objectHasOwnIdx = ctx.funcMap.get("__object_hasOwn")!;
-    const externSetIdx = ctx.funcMap.get("__extern_set")!;
+    // (#4653) Prefer the own-only data write; see the note above.
+    const externSetOwnIdx = ctx.funcMap.get("__extern_set_own");
+    const seenSetIdx = externSetOwnIdx ?? ctx.funcMap.get("__extern_set")!;
+    /** `__extern_set_own` answers an i32 result code the shadow set ignores. */
+    const seenSetTail: Instr[] = externSetOwnIdx === undefined ? [] : [{ op: "drop" }];
     const body: Instr[] = [
       // vec = __objvec_new() ; seen = __new_plain_object()
       { op: "call", funcIdx: objVecNewIdx },
@@ -514,7 +535,7 @@ export function buildObjectEnumerationHelpers(ctx: CodegenContext, s: ObjectEnum
                       { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 },
                       { op: "extern.convert_any" },
                       { op: "local.set", index: 9 },
-                      // if !__object_hasOwn(seen, keyExt) → __extern_set(seen, keyExt, keyExt)
+                      // if !__object_hasOwn(seen, keyExt) → set_own(seen, keyExt, keyExt)
                       { op: "local.get", index: 8 },
                       { op: "local.get", index: 9 },
                       { op: "call", funcIdx: objectHasOwnIdx },
@@ -526,7 +547,8 @@ export function buildObjectEnumerationHelpers(ctx: CodegenContext, s: ObjectEnum
                           { op: "local.get", index: 8 },
                           { op: "local.get", index: 9 },
                           { op: "local.get", index: 9 },
-                          { op: "call", funcIdx: externSetIdx },
+                          { op: "call", funcIdx: seenSetIdx },
+                          ...seenSetTail,
                         ],
                       },
                       { op: "local.get", index: 5 },

--- a/tests/issue-4653.test.ts
+++ b/tests/issue-4653.test.ts
@@ -354,16 +354,59 @@ describe("#4653 residuals — measured, not fixed here", () => {
     ).toBe(null);
   });
 
-  // ROW S13.2.2_A8_T3. A `Function(params…, body)` product does not bind its
-  // declared parameters: `++arg` throws ReferenceError. Measured identically for
-  // `new Function("arg","return ++arg;")`, `Function(...)` and
-  // `Function.call(null, ...)`, so the root is the mint, not the receiver.
-  // Owner: the runtime-eval lane.
-  it.fails("(#4653 residual, runtime-eval) `Function(p, body)` binds its parameter", async () => {
+  // ROW S13.2.2_A8_T3. CORRECTED: the parameter IS bound —
+  // `new Function("p","return p;")(7)` answers 7, and `p = p + 1` works. What
+  // throws is an UPDATE expression (`++`/`--`) on a name LOCAL to the eval'd /
+  // minted code (an eval-local `var`, or a Function parameter), and only when
+  // the mint sits inside an enclosing FUNCTION; at module top level the same
+  // code works, and `++` on an OUTER binding works everywhere. Full
+  // discriminator table in the issue file. Owner: the runtime-eval lane.
+  it.fails("(#4653 residual, runtime-eval) `++` on a mint-LOCAL name resolves", async () => {
     expect(
       await runScript(`
-        var g = new Function("arg", "return ++arg;");
-        if (g(1) !== 2) throw new Error("g(1) === " + String(g(1)));
+        function host() { return new Function("p", "p++; return p;")(1); }
+        if (host() !== 2) throw new Error("host() === " + String(host()));
+      `),
+    ).toBe(null);
+  });
+
+  // Same root, eval spelling — an eval-LOCAL `var` incremented inside an
+  // enclosing function. No loop is involved, which is what rules out the
+  // "loop-test position" reading.
+  it.fails("(#4653 residual, runtime-eval) `++` on an eval-LOCAL var resolves", async () => {
+    expect(
+      await runScript(`
+        function host() { return eval("var i = 0; i++; i"); }
+        if (host() !== 1) throw new Error("host() === " + String(host()));
+      `),
+    ).toBe(null);
+  });
+
+  // POSITIVE CONTROLS for the corrected root — these must PASS, and they are
+  // what makes the two `it.fails` above a claim about `++`-on-a-local rather
+  // than about eval scope in general. If a future fix "repairs" these by
+  // widening something, the pair above should flip, not these.
+  it("binds a Function parameter for a plain read and for `p = p + 1`", async () => {
+    expect(
+      await runScript(`
+        function host() {
+          if (new Function("p", "return p;")(7) !== 7) throw new Error("plain read");
+          if (new Function("p", "return p + 1;")(1) !== 2) throw new Error("read + add");
+          if (new Function("p", "p = p + 1; return p;")(1) !== 2) throw new Error("compound assign");
+          if (new Function("x", "y", "return y;")(1, 2) !== 2) throw new Error("two params");
+          return 1;
+        }
+        if (host() !== 1) throw new Error("host() === " + String(host()));
+      `),
+    ).toBe(null);
+  });
+
+  it("increments an OUTER binding from inside an eval, in a loop test", async () => {
+    expect(
+      await runScript(`
+        var d = 0;
+        function host() { eval("while (d < 3) { d++; }"); return d; }
+        if (host() !== 3) throw new Error("d === " + String(host()));
       `),
     ).toBe(null);
   });

--- a/tests/issue-4653.test.ts
+++ b/tests/issue-4653.test.ts
@@ -8,12 +8,19 @@
 // `language/statements/{return,try}` (668 files), run by the same driver on
 // both arms (`runTest262File(…, "standalone")`):
 //
-//   | state                | pass | fail | compile_error |
-//   | -------------------- | ---- | ---- | ------------- |
-//   | base (c42bdbe3e)     | 611  |  56  |       1       |
-//   | this branch          | 614  |  53  |       1       |
+//   | state                    | pass | fail | compile_error |
+//   | ------------------------ | ---- | ---- | ------------- |
+//   | base (c42bdbe3e)         | 611  |  56  |       1       |
+//   | this branch, as swept    | 604  |  53  |      11       |
+//   | this branch, CORRECTED   | 614  |  53  |       1       |
 //
-// +3 flips, zero regressions (per-file diff, see the issue file).
+// +3 flips, zero regressions. The correction is not a rounding: the raw
+// after-sweep reported ten `pass -> compile_error` rows, every one of them a
+// `compilation timeout` at 24-54 s with the box at load 17-21 (five lanes
+// sweeping). A timeout is a measurement failure, not a status, and
+// `runTest262File`'s timeout is post-hoc — it cannot interrupt a slow compile.
+// All ten were re-run SERIALLY at 120 s on BOTH arms and pass on both; the
+// three flips were re-run in the same pass and hold in both directions.
 //
 // Every pin here compiles a SCRIPT and runs its `__module_init`, not a wrapped
 // `export function test()`. That is load-bearing for two of the three families:

--- a/tests/issue-4653.test.ts
+++ b/tests/issue-4653.test.ts
@@ -1,0 +1,398 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4653) `language/statements/function` residual — the three families this
+// issue closed, plus `it.fails` pins on the nine it did not, each with the
+// measured root that owns it.
+//
+// Scoped sweep, standalone lane, over `language/statements/function` +
+// `language/statements/{return,try}` (668 files), run by the same driver on
+// both arms (`runTest262File(…, "standalone")`):
+//
+//   | state                | pass | fail | compile_error |
+//   | -------------------- | ---- | ---- | ------------- |
+//   | base (c42bdbe3e)     | 611  |  56  |       1       |
+//   | this branch          | 614  |  53  |       1       |
+//
+// +3 flips, zero regressions (per-file diff, see the issue file).
+//
+// Every pin here compiles a SCRIPT and runs its `__module_init`, not a wrapped
+// `export function test()`. That is load-bearing for two of the three families:
+// the fnctor recogniser admits only a TOP-LEVEL `var F; F = function(){}`, and
+// the redeclared-function slot is a MODULE global. A pin wrapped in a function
+// would compile a different program from the one the defect lives in.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { instantiateTest262Module } from "../scripts/test262-import-object.mjs";
+import { extractWasmExceptionMessage } from "./test262-runner.js";
+
+/**
+ * Compile `source` as a standalone SCRIPT and run its top-level initializer.
+ * Resolves to `null` when it completed, or the thrown message. The scripts below
+ * `throw` on a wrong answer, so the pin's assertion is `null`.
+ */
+async function runScript(source: string): Promise<string | null> {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-4653.js",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+  });
+  expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  let instance: WebAssembly.Instance;
+  try {
+    instance = await instantiateTest262Module(
+      result.binary,
+      {},
+      {
+        target: "standalone",
+        providerLabel: "#4653",
+      },
+    );
+  } catch (err) {
+    return `instantiate: ${err instanceof Error ? err.message : String(err)}`;
+  }
+  const moduleInit = (instance.exports as Record<string, unknown>).__module_init;
+  if (typeof moduleInit !== "function") return "no __module_init export";
+  try {
+    moduleInit();
+  } catch (err) {
+    const decoded = extractWasmExceptionMessage(err, instance);
+    return decoded || (err instanceof Error ? err.message : String(err));
+  }
+  return null;
+}
+
+/** A runtime-carried counter, so no arm below can be constant-folded away. */
+const LOOP_CARRIED = `var __n = 0; for (var __i = 0; __i < 3; __i++) { __n += __i; } /* __n === 3 */`;
+
+describe("#4653 E — the for-in shadow set is written OWN-ONLY", () => {
+  // `__object_keys_forin` marks every own key into a private `seen` table. That
+  // table is a null-$proto `$Object` — the same representation as an ordinary
+  // object literal — so `__extern_set` ran out of explicit links and probed the
+  // IMPLICIT Object.prototype companion. Measured on base: `data` became the
+  // string "constructor", i.e. a bare `for (x in o)` invoked a user setter with
+  // the enumerated key. Flipped `13.2-17-1`.
+  it("does not invoke an Object.prototype setter while enumerating", async () => {
+    expect(
+      await runScript(`
+        ${LOOP_CARRIED}
+        var data = "data";
+        Object.defineProperty(Object.prototype, "constructor", {
+          get: function () { return 100 + __n; },
+          set: function (v) { data = v; },
+          configurable: true
+        });
+        var fun = function () {};
+        var visited = 0;
+        for (var k in fun.prototype) { visited++; }
+        if (data !== "data") {
+          throw new Error("for-in invoked the inherited setter: data=" + String(data));
+        }
+      `),
+    ).toBe(null);
+  });
+
+  // The OTHER half of the same write. A refused mark leaves `seen` empty, so a
+  // name owned at two chain levels is yielded twice. This half needs no
+  // accessor at all — it is the shadow table's whole job.
+  it("still yields a two-level own name exactly once", async () => {
+    expect(
+      await runScript(`
+        ${LOOP_CARRIED}
+        var proto = { a: 1, b: 2 };
+        var child = Object.create(proto);
+        child.a = __n;
+        var aCount = 0, total = 0;
+        for (var k in child) { total++; if (k === "a") aCount++; }
+        if (aCount !== 1) throw new Error("shadowed key yielded " + aCount + " times");
+        if (total !== 2) throw new Error("expected 2 keys, saw " + total);
+      `),
+    ).toBe(null);
+  });
+
+  // NEGATIVE CONTROL: the mark must still HAPPEN. Switching to an own-only
+  // write must not turn into skipping the write, which would regress the pin
+  // above; this one checks the non-enumerable case that only the mark covers —
+  // a non-enumerable own property shadows an enumerable inherited one.
+  it("lets a NON-enumerable own property shadow an inherited enumerable one", async () => {
+    expect(
+      await runScript(`
+        ${LOOP_CARRIED}
+        var proto = { hidden: 1 };
+        var child = Object.create(proto);
+        Object.defineProperty(child, "hidden", { value: __n, enumerable: false, configurable: true });
+        var seen = 0;
+        for (var k in child) { if (k === "hidden") seen++; }
+        if (seen !== 0) throw new Error("non-enumerable own key did not shadow; seen=" + seen);
+      `),
+    ).toBe(null);
+  });
+});
+
+describe("#4653 F — `var F; … F = function(){}` is a fnctor declaration", () => {
+  // Base: the escape gate saw no ctor for the name, minted `__fnctor_proto_F`
+  // for the `.prototype` reads/writes, and `new F()` could not route to the
+  // fnctor lowering — `Object.getPrototypeOf(new A())` was null while
+  // `A.prototype.shape` was "cube". Flipped `S13.2.2_A4_T2`.
+  it("links `new F()` to the object assigned to F.prototype", async () => {
+    expect(
+      await runScript(`
+        ${LOOP_CARRIED}
+        var CUBE, FACTORY, device;
+        CUBE = "cube" + __n;
+        FACTORY = function () {};
+        FACTORY.prototype = { shape: CUBE, printShape: function () { return this.shape; } };
+        device = new FACTORY();
+        if (device.printShape === undefined) throw new Error("printShape is undefined");
+        if (device.printShape() !== CUBE) throw new Error("printShape() === " + device.printShape());
+        if (Object.getPrototypeOf(device) !== FACTORY.prototype) throw new Error("[[Prototype]] is not F.prototype");
+      `),
+    ).toBe(null);
+  });
+
+  // NEGATIVE CONTROL 1: the spelling that already worked must be unchanged.
+  it("leaves `var F = function(){}` alone", async () => {
+    expect(
+      await runScript(`
+        ${LOOP_CARRIED}
+        var B = function () {};
+        B.prototype = { shape: "cube" + __n, printShape: function () { return this.shape; } };
+        var b = new B();
+        if (b.printShape() !== "cube3") throw new Error("printShape() === " + b.printShape());
+      `),
+    ).toBe(null);
+  });
+
+  // NEGATIVE CONTROL 2: TWO assignments must DECLINE. The admission rule's whole
+  // point is that a second write could put a different value in the slot, so the
+  // recogniser must not claim this shape — and, declining, must not miscompile
+  // it either: the live constructor is still the last one assigned.
+  it("declines a twice-assigned binding without breaking it", async () => {
+    expect(
+      await runScript(`
+        ${LOOP_CARRIED}
+        var C;
+        C = function () { this.tag = "first"; };
+        C = function () { this.tag = "second" + __n; };
+        var c = new C();
+        if (c.tag !== "second3") throw new Error("tag === " + String(c.tag));
+      `),
+    ).toBe(null);
+  });
+});
+
+describe("#4653 D — a var initialized from a REDECLARED function gets a neutral slot", () => {
+  // ES §14.1.23: the LAST `function f(){}` wins for every call, including one
+  // written above it. TypeScript resolves `f()` through the FIRST signature, so
+  // the module global was typed `(mut f64)` and the emitted string result
+  // coerced to NaN — on BOTH reads. Flipped `S13_A6_T1`.
+  it("stores the LAST declaration's result, not the first signature's type", async () => {
+    expect(
+      await runScript(`
+        ${LOOP_CARRIED}
+        function dup() { return 1; }
+        var storedFn = dup;
+        var first = dup();
+        function dup() { return "A" + __n; }
+        var second = dup();
+        if (storedFn !== dup) throw new Error("the two declarations are not one binding");
+        if (first !== second) throw new Error("first=" + String(first) + " second=" + String(second));
+        if (second !== "A3") throw new Error("second === " + String(second));
+      `),
+    ).toBe(null);
+  });
+
+  // NEGATIVE CONTROL: a SINGLE declaration must keep its numeric slot — the
+  // widening is keyed on two or more BODY-bearing declarations, so an ordinary
+  // numeric helper (and a TS overload set, where only the implementation has a
+  // body) is untouched.
+  it("leaves a singly-declared numeric helper on its numeric slot", async () => {
+    expect(
+      await runScript(`
+        ${LOOP_CARRIED}
+        function once() { return 2 + __n; }
+        var n = once();
+        if (n + 1 !== 6) throw new Error("n + 1 === " + (n + 1));
+        if (typeof n !== "number") throw new Error("typeof n === " + typeof n);
+      `),
+    ).toBe(null);
+  });
+});
+
+// ───────────────────────── measured residuals ─────────────────────────
+//
+// Each of these reproduces one of the nine #4653 rows this change did NOT fix,
+// with the root measured on this branch. They are `it.fails` so the suite
+// records the current answer and flips loudly when the owning lane lands.
+
+describe("#4653 residuals — measured, not fixed here", () => {
+  // ROWS S13.2.2_A18_T1 / _T2. `arguments.callee` is synthesized by a
+  // compile-time property-access arm; it is NOT an own property of the runtime
+  // vec that backs the arguments object, so the dynamic `with` HasBinding gate
+  // (`__extern_has`) misses it and `callee = 1` writes the OUTER binding.
+  // Measured: `with (arguments) { return length }` answers correctly (the vec
+  // DOES own `length`), `{ return callee }` does not. Fixing it needs `callee`
+  // to become a real, writable own property of the arguments object — vec
+  // representation work, another lane's territory.
+  it.fails("(#4653 residual, vec-overlay) `with (arguments)` resolves `callee`", async () => {
+    expect(
+      await runScript(`
+        var callee = 0;
+        var obj = { callee: "a" };
+        var result = (function () {
+          with (arguments) { callee = 1; }
+          return arguments;
+        })(obj);
+        if (callee !== 0) throw new Error("outer callee === " + callee);
+        if (result.callee !== 1) throw new Error("arguments.callee === " + String(result.callee));
+      `),
+    ).toBe(null);
+  });
+
+  // ROW S13.2.2_A19_T8. Two `with` blocks over a RE-DECLARED `var obj` share one
+  // static target proof, keyed off the FIRST initializer's key set, so a name
+  // only the second literal owns falls through to the outer lexical binding.
+  // Measured: identical program with two DISTINCT target variables is correct.
+  it.fails("(#4653 residual, with-scope) a re-declared `with` target re-proves its key set", async () => {
+    expect(
+      await runScript(`
+        var a = 1, b = "a";
+        var obj = { a: 2 };
+        with (obj) { var f = function () { return a; }; }
+        var first = f();
+        var obj = { a: 3, b: "b" };
+        with (obj) { var f = function () { return b; }; }
+        if (first !== 2) throw new Error("first === " + String(first));
+        if (f() !== "b") throw new Error("second === " + String(f()));
+      `),
+    ).toBe(null);
+  });
+
+  // ROW S13.2.2_A17_T3. A `var f = function(){}` declared INSIDE a `with` body,
+  // where the target owns the same name, traps: "dereferencing a null pointer
+  // in __module_init". The #4264 hoisted-var widening gives the slot an
+  // externref, but the closure that the with-routed write installs is never
+  // reachable from the outer read.
+  it.fails("(#4653 residual, with-scope) `with(o) { var f = function(){} }` does not trap", async () => {
+    expect(
+      await runScript(`
+        p1 = "alert";
+        this.obj = { p1: 1, getRight: function () { return "right"; } };
+        var getRight = function () { return "napravo"; };
+        var out = (function () {
+          with (obj) {
+            p1 = "w1";
+            var getRight = function () { return false; };
+            return p1;
+          }
+        })();
+        if (p1 !== "alert") throw new Error("global p1 === " + String(p1));
+        if (getRight() !== "napravo") throw new Error("outer getRight() === " + String(getRight()));
+        if (out !== "w1") throw new Error("out === " + String(out));
+      `),
+    ).toBe(null);
+  });
+
+  // ROW S13_A15_T3. An OMITTED argument for a parameter whose wasm type is a
+  // nullable reference is materialized as `ref.null <typeidx>`, which surfaces
+  // in JS as `null`, not `undefined`. Measured: with a single zero-arg call site
+  // the answer is correct; adding ONE call site that passes a string makes the
+  // parameter a string ref and the omitted argument becomes `null`
+  // (`typeof === "object"`, `v === null` true). The test's `arguments`-named
+  // parameter is incidental — a plainly-named parameter behaves identically.
+  it.fails("(#4653 residual, value-rep) an omitted reference-typed argument is `undefined`", async () => {
+    expect(
+      await runScript(`
+        function pass(q) { return q; }
+        var missing = pass();
+        var given = pass("X");
+        if (given !== "X") throw new Error("given === " + String(given));
+        if (missing !== undefined) throw new Error("missing === " + String(missing) + " (null? " + (missing === null) + ")");
+        if (typeof missing !== "undefined") throw new Error("typeof missing === " + typeof missing);
+      `),
+    ).toBe(null);
+  });
+
+  // ROW S13_A2_T2. `arg + arguments[1]` compiled to a numeric add. Measured:
+  // `arguments[1]` on its own IS the string "1" and `typeof arguments[1]` IS
+  // "string"; only the `+` folded to f64 because its LEFT operand is provably
+  // numeric and the right one is dynamic.
+  it.fails("(#4653 residual, binary-+) `number + <dynamic string>` concatenates", async () => {
+    expect(
+      await runScript(`
+        var x = (function (arg) { return arg + arguments[1]; })(1, "1");
+        if (x !== "11") throw new Error("x === " + String(x));
+      `),
+    ).toBe(null);
+  });
+
+  // ROW S13.2.2_A2. Calling a NON-callable instance must throw TypeError
+  // (§7.3.14 Call step 1). Measured: `rose()` does not throw at all — it
+  // evaluates to undefined — so the test's own `throw new Test262Error(...)`
+  // runs inside the try and is caught as the "exception", which is why the row
+  // reports `[object Object]` rather than a missing throw.
+  it.fails("(#4653 residual, call-dispatch) calling a non-callable throws TypeError", async () => {
+    expect(
+      await runScript(`
+        function PROTO() {}
+        PROTO.type = "flower";
+        function FACTORY() {}
+        FACTORY.prototype = PROTO;
+        var rose = new FACTORY();
+        var kind = "no-throw";
+        try { rose(); } catch (e) { kind = (e instanceof TypeError) ? "TypeError" : "other:" + String(e); }
+        if (kind !== "TypeError") throw new Error("threw " + kind);
+      `),
+    ).toBe(null);
+  });
+
+  // ROW S13.2.2_A8_T3. A `Function(params…, body)` product does not bind its
+  // declared parameters: `++arg` throws ReferenceError. Measured identically for
+  // `new Function("arg","return ++arg;")`, `Function(...)` and
+  // `Function.call(null, ...)`, so the root is the mint, not the receiver.
+  // Owner: the runtime-eval lane.
+  it.fails("(#4653 residual, runtime-eval) `Function(p, body)` binds its parameter", async () => {
+    expect(
+      await runScript(`
+        var g = new Function("arg", "return ++arg;");
+        if (g(1) !== 2) throw new Error("g(1) === " + String(g(1)));
+      `),
+    ).toBe(null);
+  });
+
+  // ROW 13.2-18-1. Root is NOT this issue's: a function EXPRESSION has no OWN
+  // `prototype` property once the descriptor MOP runtime is live, so with an
+  // accessor installed on `Function.prototype.prototype` the read walks the
+  // chain and answers `undefined` (base error: "Cannot destructure 'null' or
+  // 'undefined'" at `fun.prototype.toString()`). Owner: #4491.
+  it.fails("(#4491) `fun.prototype` is an own property, not an inherited accessor", async () => {
+    expect(
+      await runScript(`
+        Object.defineProperty(Function.prototype, "prototype", {
+          get: function () { return 100; },
+          set: function (v) { },
+          configurable: true
+        });
+        var fun = function () {};
+        if (fun.prototype === 100) throw new Error("fun.prototype came from the inherited getter");
+        if (String(fun.prototype) !== "[object Object]") throw new Error("fun.prototype === " + String(fun.prototype));
+        if (!Object.prototype.hasOwnProperty.call(fun, "prototype")) throw new Error("prototype is not an own property");
+      `),
+    ).toBe(null);
+  });
+
+  // Adjacent to F, and NOT closed by it: `new F()` now links the assigned
+  // prototype, but `instanceof` still answers false for the same binding.
+  it.fails("(#4653 residual) `instanceof` follows a late-assigned fnctor's prototype", async () => {
+    expect(
+      await runScript(`
+        var A;
+        A = function () {};
+        A.prototype = { shape: "cube" };
+        var a = new A();
+        if (!(a instanceof A)) throw new Error("a instanceof A === false");
+      `),
+    ).toBe(null);
+  });
+});


### PR DESCRIPTION
## Description

Wave-5 lane on [#4653](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4653-es5-function-declaration-semantics) (`language/statements/function`, 12 rows).

**3 rows fixed, 0 regressions, and the other 9 attributed to measured roots.** The headline is the triage: the 12 rows turned out to be **eleven distinct roots**, and **three of the issue file's four premises did not survive measurement** — `S13_A2_T2` is not a named-function-expression scope bug (that check passes; the `+` folded to an f64 add), `13.2-17-1`'s `fun.prototype.constructor` descriptors are already fully correct on base, and `S13.2.2_A19_T8`'s closure capture works in isolation (it needs a *re-declared* `with` target to fail). Every root was isolated with a reduced probe rather than inferred from the row's error text.

### Fixed

**E — `for (x in o)` fired a user setter it must never touch.** `__object_keys_forin` marks every own key into a private `seen` table so a closer own property shadows an inherited same-named key. `seen` is `__new_plain_object()` — a `$Object` with a **null `$proto`**, which is exactly how an ordinary object literal is represented — so `__extern_set` treats it as one: it exhausts the (empty) explicit chain and then probes the **implicit `Object.prototype` companion**. Once a test installs an accessor there — which the entire `propertyHelper.js` / `verifyProperty` family does — the mark `seen[key] = key` **invokes that user setter with the enumerated key** and records nothing.

Two observable defects from one write: a bare `for-in` calls a setter, and the shadow set stays empty so a name owned at two chain levels is yielded twice. Fixed with `__extern_set_own` (same data-write tail, no descriptor/proto consult), falling back to `__extern_set` only where the own-only helper is absent — which is exactly where `__extern_set` could not walk a chain anyway.

**F — `var F; F = function(){}` was invisible to both fnctor recognisers.** Both keyed on a `VariableDeclaration`'s own initializer, but the Sputnik ES5 corpus overwhelmingly writes the separated form, and TypeScript records no function declaration for that symbol. The result was the **split brain** `resolveUserFnctorName`'s own gate comment names:

```js
var A; A = function(){}; A.prototype = {shape:"cube"};
var a = new A();
A.prototype.shape         // "cube"  <- the write landed
Object.getPrototypeOf(a)  // null    <- the instance never saw it
a instanceof A            // false
```

with `var A = function(){}` correct in the same program on the same run. Fixed by one narrow admission rule shared by both recognisers, extracted to `src/codegen/fnctor-ctor-decl.ts`.

**D — a redeclared function's module slot was typed from the wrong declaration.** The global is typed from the FIRST `function f(){}`'s signature while the emitted body is the LAST one's — `(func $__func (result (ref null 6)))` against a `(mut f64)` slot, yielding NaN. New `src/codegen/duplicate-function-declaration.ts` plus one arm in `moduleGlobalWasmType`, sibling of the existing void-call arm.

### Numbers (lane's own runs, same driver both arms)

668-file scoped sweep over `language/statements/function` + `{return,try}`:

| arm | pass | fail | compile_error |
|---|---|---|---|
| base `c42bdbe3e` | 611 | 56 | 1 |
| branch, **corrected** | **614** | **53** | **1** |

**Flips: 3**, each re-run serially on both arms. **Regressions: 0.**

The ten apparent `pass → compile_error` rows in the raw diff (`13.0-{7,8,12,13,14,15,16,17}-s`, `13.0_4-17gs`, `13.1-2-s`) were all `compilation timeout` at 24–54 s under load 17–21; re-run serially at 120 s they pass on **both** arms. This is the contention trap now recorded in the brief — a timeout is a measurement failure, not a status.

### Pins

`tests/issue-4653.test.ts` → **17 passed** on branch; **3 failed / 14 passed** on base by file-copy revert, the three failures being exactly the three positive pins. The pins compile a *script* and run `__module_init` rather than a wrapped `export function test()`, because two of the three families only exist at module top level — a function-wrapped pin would compile a different program.

Verified again by the lead on the merged tree (serially, after a first run showed one sibling pin timing out under load): `issue-4653` + `issue-4491-wave4` + `issue-4643` → **41 passed**, and `issue-4643` alone → **11 passed**.

### Residuals (9, each with a measured root and owner)

`with (arguments)` resolving `callee` (vec representation — `return length` works, `return callee` does not) · re-declared `with` target's key set · `with` + var-hoisted function trap · an omitted reference-typed argument answering `null` not `undefined` (value-rep; the `arguments`-named parameter in `S13_A15_T3` is incidental — a plainly-named parameter behaves identically) · `number + <dynamic>` folding to f64 · calling a non-callable not throwing at all · `Function(p, body)` not binding its declared parameter (same for `new Function`, `Function(…)` and `Function.call` — the root is the mint, runtime-eval) · `13.2-18-1` → **#4491**, root distinct from its sibling: a function *expression* has no own `prototype` under the live descriptor MOP.

One further defect found while measuring F, not among the twelve: `instanceof` still answers false for a late-assigned fnctor even now that `getPrototypeOf` is right.

### Also in this PR

[#4658](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4658-arguments-object-length-callee-descriptors) — a new issue filed for the arguments-object `length`/`callee` descriptor slice, narrowed by one lane and explicitly declined by another as a distinct slice with its own risk surface ("folding a distinct slice into an unrelated fix would make both unmeasurable"). Filed so it has an owner rather than falling through the gap between two lanes that each correctly said "not mine".

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_