### PR TITLE
fix(ci): one cancelled npm-compat row must not discard its whole lane

### DIFF
--- a/.github/workflows/npm-compat-promote.yml
+++ b/.github/workflows/npm-compat-promote.yml
@@ -111,7 +111,26 @@ jobs:
             done
           fi
 
+      # A lane whose rows were ALL cancelled or failed has nothing to say. The
+      # merge script would happily publish the last snapshot with a fresh
+      # `generatedAt`, i.e. a promotion PR whose only content is a newer
+      # timestamp over unchanged numbers. Stop instead — the caller no longer
+      # gates on the matrix result (one superseded row must not discard the
+      # lane), so this is where "nothing measured" is recognised.
+      - name: Stop if this lane produced no measurements
+        id: partials
+        shell: bash
+        run: |
+          set -euo pipefail
+          COUNT=$(find "$RUNNER_TEMP/npm-compat-partials" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+          echo "lane ${{ inputs.lane }}: ${COUNT} partial report(s)"
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::notice title=npm-compat-refresh::lane ${{ inputs.lane }} measured nothing this run; leaving the published artifact alone."
+          fi
+
       - name: Assemble the npm-compat artifacts
+        if: steps.partials.outputs.count != '0'
         run: node scripts/merge-npm-compat-partials.mjs "$RUNNER_TEMP/npm-compat-partials"
 
       # Refuse to publish an empty or truncated artifact. A generator that exits
@@ -122,6 +141,7 @@ jobs:
       # lint/syntax gate, and one apostrophe in a JS comment truncated it and
       # silently blocked ALL promotions for 6 hours on 2026-08-23 (#4604 S8).
       - name: Sanity-check the generated artifact
+        if: steps.partials.outputs.count != '0'
         run: node scripts/check-npm-compat-artifact.mjs
 
       # (2026-08-09, stakeholder) A DEFERRED run's measurement must never be
@@ -164,6 +184,7 @@ jobs:
       # Minted HERE, after matrix generation, because an installation
       # token expires in one hour.
       - name: Mint a GitHub App token for the promotion PR
+        if: steps.partials.outputs.count != '0'
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
@@ -182,6 +203,7 @@ jobs:
       # The current-head check gate below is deliberately fail-closed instead:
       # an unreadable check state must not knowingly cancel the CI it protects.
       - name: Check whether the promotion PR is already in the merge queue
+        if: steps.partials.outputs.count != '0'
         id: queue_state
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -273,7 +295,7 @@ jobs:
           esac
 
       - name: Publish the refreshed artifacts to the promotion branch
-        if: steps.queue_state.outputs.skip != '1'
+        if: steps.partials.outputs.count != '0' && steps.queue_state.outputs.skip != '1'
         id: promote
         env:
           MAIN_DEPLOY_KEY: ${{ secrets.MAIN_DEPLOY_KEY }}
@@ -481,4 +503,3 @@ jobs:
       # artifact. Dispatching from THIS run would in fact be wrong now: the
       # artifact is not on main yet when this job ends, so the deploy would
       # rebuild the stale page and #3958/#3977 would be back.
-

--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -256,9 +256,18 @@ jobs:
   # coordinator's branch-overlay + freshness stamps. A lane whose rows were
   # ALL superseded in their per-package queues reports `cancelled` and its
   # promotion is skipped — a newer run owns those measurements.
+  # Gate on `resolve` ONLY. Do NOT gate on the measure job's aggregate result:
+  # a matrix job reports `cancelled` when ANY row cancels, so one superseded
+  # package discarded every other package's completed measurement — the exact
+  # coupling this per-package split exists to remove. Observed 2026-08-23 in
+  # run 822: lit measured successfully in 29 minutes, react-dom's row was
+  # cancelled 17 minutes in, and `refresh-slow` skipped, throwing lit's result
+  # away. The coordinator already handles a partial lane (it carries unmeasured
+  # packages forward from the last snapshot, marked stale) and now stops
+  # cleanly when its lane produced no partials at all.
   refresh-fast:
     needs: [resolve, measure-fast]
-    if: always() && needs.resolve.result == 'success' && needs.measure-fast.result != 'cancelled' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
+    if: always() && needs.resolve.result == 'success' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     uses: ./.github/workflows/npm-compat-promote.yml
     with:
       source_sha: ${{ github.sha }}
@@ -268,7 +277,7 @@ jobs:
 
   refresh-slow:
     needs: [resolve, measure-slow]
-    if: always() && needs.resolve.result == 'success' && needs.measure-slow.result != 'cancelled' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
+    if: always() && needs.resolve.result == 'success' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     uses: ./.github/workflows/npm-compat-promote.yml
     with:
       source_sha: ${{ github.sha }}

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -237,9 +237,17 @@ describe("npm-compat refresh matrix wiring", () => {
     expect(refresh).not.toContain("id: typescript");
     expect(refresh).not.toContain("id: renderers");
 
-    // Two lanes, each promoting on its own cadence.
-    expect(refresh).toContain("needs.measure-fast.result != 'cancelled'");
-    expect(refresh).toContain("needs.measure-slow.result != 'cancelled'");
+    // Two lanes, each promoting on its own cadence — and NEITHER gated on the
+    // measure job's aggregate result. A matrix job reports `cancelled` when ANY
+    // row cancels, so gating on it made one superseded package discard every
+    // other package's completed work: run 822 (2026-08-23) threw away lit's
+    // successful 29-minute measurement because react-dom's row was cancelled
+    // 17 minutes in. The coordinator recognises "this lane measured nothing"
+    // itself, by counting partial reports.
+    expect(refresh).not.toContain("needs.measure-fast.result != 'cancelled'");
+    expect(refresh).not.toContain("needs.measure-slow.result != 'cancelled'");
+    expect(promote).toContain("Stop if this lane produced no measurements");
+    expect(promote).toContain("steps.partials.outputs.count != '0'");
     expect(refresh).toContain("uses: ./.github/workflows/npm-compat-promote.yml");
     expect(refresh).toContain("--partial-output");
     expect(refresh).toContain("if-no-files-found: warn");


### PR DESCRIPTION
## Description

The per-package split (#4796) removed the coupling between packages in the measure matrix but reintroduced it at the **lane gate**. Both promotion jobs were guarded on `needs.measure-<lane>.result != 'cancelled'`, and a matrix job reports `cancelled` when **any** row cancels — so one superseded package threw away every other package's completed measurement.

Observed in run 822, the first refresh after #4805 merged:

| job | result | window |
| --- | --- | --- |
| `Measure npm-compat (lit)` | success | 17:49:45 → 18:18:55 (29 min) |
| `Measure npm-compat (react-dom)` | cancelled | 17:48:31 → 18:05:17 |
| `refresh-slow` | **skipped** | 18:18:55 |

lit measured cleanly and uploaded its partial; the lane skipped anyway, so the published artifact still serves lit numbers from 2026-08-20. That is precisely the "a slow or failing package must not block another" property the split exists to provide — the fast lane got it, the lanes themselves did not.

**Fix:** both lanes gate on `resolve` only. "This lane measured nothing" is recognised where the evidence actually is — the coordinator counts its downloaded partial reports and stops before assembly when there are none, rather than publishing the previous snapshot under a fresh `generatedAt` (a promotion PR whose only content would be a newer timestamp over unchanged numbers).

The guard test added in #4805 caught this change, and now pins the corrected shape including the negative: neither lane may gate on the aggregate matrix result again.

## Not fixed here — needs a decision

**react-dom's row is being cancelled mid-flight by the next merge.** Run 822's row died at 18:05 (17 minutes in, seconds after run 823 was created); run 823 then cancelled entirely. Its row takes 3–4 h while merges land every ~20 min, so on a busy main react-dom may never complete a measurement regardless of this fix.

I have not established the mechanism — the per-package groups carry `cancel-in-progress: false`, which should queue rather than cancel — so I am reporting the observation rather than guessing at a cause. Any fix likely changes the merge-driven trigger for the long-pole packages specifically, which is a stakeholder call given "no cron is needed" was an explicit instruction.

Separately: promotion PR #4807 has been `CLEAN` and open since 17:22Z without being enqueued.

## Verification

`tests/npm-compat-partials.test.ts` + `tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts`: 27 passed. Both workflows parse. No `src/` changes; LOC and function budgets green.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ)_