### PR TITLE
fix(ci): never force-update the npm-compat promotion branch while its PR is open

### DIFF
--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -333,3 +333,49 @@ branch and emit the same cancelling `synchronize` event outside the npm
 coordinator.
 
 Implementation: [PR #4776](https://github.com/loopdive/js2/pull/4776).
+
+## The promotion PR never lands: the queue guard loses a race it now runs constantly (2026-08-23)
+
+**Symptom.** `benchmarks/results/npm-compat.json` on main sat at
+`generatedAt 2026-08-23T15:27:53Z` for 6+ hours while the fast lane promoted
+successfully over and over. The dashboard was frozen with green CI everywhere.
+
+**Not the enqueuer.** `auto-enqueue` is healthy and explicitly reports
+`#4807 skip (already-queued)`; the queue held 5 entries with another PR
+`AWAITING_CHECKS` at the head. The promotion PR reaches the queue fine.
+
+**What actually happens.** Every fast-lane promotion force-updates the reused
+`ci/npm-compat-refresh` branch, which ejects the PR from the merge queue and
+restarts it. The coordinator has a guard against exactly this — it skips the
+push when the PR has checks in flight or appears in the queue — but the guard
+is a POINT-IN-TIME read, and there is a window between "ejected" and
+"re-enqueued" in which the PR is neither queued nor check-busy. Measured on
+run 827:
+
+```
+20:02:34  refresh-fast starts; queue guard passes (the publish step ran, so skip != 1)
+20:03:20  + b87c9042...a1793bff HEAD -> ci/npm-compat-refresh (forced update)
+20:40:39  auto-enqueue: "#4807 skip (already-queued)"
+```
+
+**Why it started now.** Before the per-package split (#4796) the whole fleet
+promoted roughly once per ~25 minutes, and only after every package finished.
+The fast lane now promotes on EVERY merge — ~12 minutes after each one — so
+the race window is entered several times an hour instead of occasionally, and
+the PR never survives long enough to reach the front of a 5-deep queue. This is
+a consequence of the split, not a pre-existing bug.
+
+**Not fixed here — it needs a call on cadence**, and cadence is a stakeholder
+instruction ("merge-driven, no cron", 2026-08-23). Options, cheapest first:
+
+1. **Only push when the numbers actually changed.** Perf timings differ every
+   run, so every run currently publishes something. Comparing the artifact
+   modulo perf noise would collapse most promotions to no-ops, and the PR would
+   sit still long enough to merge. Does not touch the trigger.
+2. **Do not re-push while an open promotion PR exists.** Let the current one
+   land; the next run's measurement is picked up by the run after it. The
+   artifact is then never more than one cycle behind.
+3. **Rate-limit promotions** (at most one push per hour). Closest to a cron and
+   the option that most contradicts the stated instruction.
+
+(1) or (2) look right; both keep the trigger merge-driven.


### PR DESCRIPTION
## Description

Implements **option 2** of the three recorded on #4604 (stakeholder choice).

**The problem.** The dashboard sat at `generatedAt 2026-08-23T15:27:53Z` for six hours while the fast lane promoted successfully over and over — green CI everywhere.

It is not the enqueuer: `auto-enqueue` says `#4807 skip (already-queued)`, and the PR does reach the queue. What happens is that every fast-lane promotion force-updates the reused `ci/npm-compat-refresh` branch, which ejects the PR from the merge queue and restarts it. The old guard tried to allow a push whenever the PR looked neither queued nor check-busy — a point-in-time read of state that changes constantly. From run 827:

```
20:02:34  guard passes (the publish step ran, so skip != 1)
20:03:20  + b87c9042...a1793bff  (forced update)
20:40:39  auto-enqueue: "#4807 skip (already-queued)"
```

Before the per-package split (#4796) the fleet promoted about once per 25 minutes, so that window was rarely hit. The fast lane now promotes on every merge and hit it repeatedly, so the PR never survived long enough to reach the front of a 5-deep queue. **Promoting more often made the artifact update less often.**

**The fix.** An open promotion PR means hands off, full stop. Both racy probes — the check-runs poll and the merge-queue GraphQL query — are deleted, so there is no "looks idle right now" path left to lose. This run's measurement is still uploaded as an artifact, and the run after the PR merges publishes a fresher one, so the artifact is never more than one cycle behind.

An unreadable PR listing now fails **closed** rather than pushing. Pushing on an unreadable read is exactly what the race exploited; skipping costs one cycle.

**Accepted cost:** a genuinely wedged PR now freezes promotion instead of trampling it. `npm-compat-staleness.yml` is the alarm for that, and a frozen artifact that shouts beats the silent six-hour freeze this replaces.

## Verification

Both guard tests rewrote their assertions to pin the new rule, including the negatives (neither probe may come back): 27 passed. Workflow parses; no `src/` changes.

## Still open

**react-dom's row is cancelled mid-flight by the next merge** on every run, so it has produced no measurement all day — a separate cadence question, tracked in #4813's body and #3982.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ