### PR TITLE
fix(ci): one npm-compat measurement in flight — skip the run, and never re-push, while a promotion PR is open

### DIFF
--- a/.github/workflows/npm-compat-promote.yml
+++ b/.github/workflows/npm-compat-promote.yml
@@ -202,7 +202,32 @@ jobs:
       # gate — which is #4130, the failure this repo has already paid for once.
       # The current-head check gate below is deliberately fail-closed instead:
       # an unreadable check state must not knowingly cancel the CI it protects.
-      - name: Check whether the promotion PR is already in the merge queue
+      # NEVER re-push while a promotion PR is open (stakeholder, 2026-08-23).
+      #
+      # The branch is force-updated, which ejects its PR from the merge queue
+      # and restarts it. The previous guard tried to allow a push whenever the
+      # PR happened to be neither queued nor check-busy — but that is a
+      # point-in-time read of a state that changes constantly, and between
+      # "ejected by the last push" and "re-enqueued by auto-enqueue" the PR
+      # looks idle. Measured on run 827: the guard passed at 20:02:34, the
+      # forced update landed at 20:03:20, and auto-enqueue still reported the
+      # PR queued at 20:40. Before the per-package split the fleet promoted
+      # about once per 25 minutes, so that window was rarely hit; the fast lane
+      # now promotes on every merge and hit it repeatedly, leaving the
+      # dashboard frozen at 15:27Z for six hours while every job reported
+      # success.
+      #
+      # So: an open PR means hands off, full stop. This run's measurement is
+      # still uploaded as an artifact, and the run AFTER the PR merges
+      # publishes a fresher one — the artifact is never more than one cycle
+      # behind. No check-runs probe, no merge-queue probe, nothing to race.
+      #
+      # The cost is that a genuinely wedged PR (a permanently red check nobody
+      # clears) freezes promotion instead of trampling it. That is deliberate,
+      # and npm-compat-staleness.yml is the alarm for it — a frozen artifact
+      # that shouts is strictly better than the silent 6-hour freeze this
+      # replaces.
+      - name: Skip the push while a promotion PR is open
         if: steps.partials.outputs.count != '0'
         id: queue_state
         env:
@@ -210,87 +235,25 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          PR_INFO="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
-            --state open --json number,headRefOid \
-            --jq '.[0] | if . == null then empty else "\(.number) \(.headRefOid)" end' \
-            2>/dev/null || true)"
-          PR_NUMBER="${PR_INFO%% *}"
-          PR_HEAD_SHA="${PR_INFO#* }"
-          if [ "$PR_INFO" = "$PR_NUMBER" ]; then
-            PR_HEAD_SHA=""
-          fi
+          PR_NUMBER="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
+            --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "unreadable")"
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No open promotion PR on ${PROMOTION_BRANCH}; nothing can be queued."
-            echo "skip=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Open promotion PR: #${PR_NUMBER}"
-
-          # Do not replace the promotion branch while its current PR checks are
-          # running. A force-update fires `pull_request:synchronize`; GitHub
-          # cancels the checks for the old head before starting a new one. On a
-          # long npm-compat refresh cadence that turns every PR run into a
-          # moving target and can keep the artifact PR permanently pending.
-          # Let the current head finish; a later refresh will publish the newer
-          # measurement. Do not age this guard out: the refresh matrix itself
-          # has a 350-minute timeout, so a two-hour cutoff would knowingly
-          # cancel a valid long-running check. A genuinely wedged PR is
-          # surfaced by the staleness workflow and needs human intervention.
-          ACTIVE_CHECKS="unreadable"
-          if [ -n "$PR_HEAD_SHA" ]; then
-            if ! ACTIVE_CHECKS="$(gh api \
-              --paginate \
-              "/repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" \
-              --jq '[.check_runs[] | select(.status == "queued" or .status == "in_progress")] | length' \
-              2>/dev/null | awk '{ total += $1 } END { print total + 0 }')"; then
-              ACTIVE_CHECKS="unreadable"
-            fi
-          fi
-          case "$ACTIVE_CHECKS" in
+          case "$PR_NUMBER" in
+            "")
+              echo "No open promotion PR on ${PROMOTION_BRANCH}; safe to publish."
+              echo "skip=0" >> "$GITHUB_OUTPUT"
+              ;;
             unreadable)
-              echo "::warning title=npm-compat-refresh::could not read checks for promotion PR #${PR_NUMBER}; leaving its branch untouched to avoid cancelling CI."
+              # Fail CLOSED, unlike the gate this replaces. Pushing on an
+              # unreadable read is what the race exploited; skipping costs one
+              # cycle and the staleness workflow notices if it persists.
+              echo "::warning title=npm-compat-refresh::could not list promotion PRs; skipping the push this cycle."
               echo "skip=1" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-            ''|*[!0-9]*)
-              echo "::warning title=npm-compat-refresh::invalid active-check count (${ACTIVE_CHECKS}); leaving promotion PR #${PR_NUMBER} untouched."
-              echo "skip=1" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-            0)
-              echo "No checks are running on promotion PR #${PR_NUMBER}; continuing."
               ;;
             *)
-              echo "Promotion PR #${PR_NUMBER} has ${ACTIVE_CHECKS} check(s) in flight; leaving its branch untouched."
+              echo "::notice title=npm-compat-refresh::promotion PR #${PR_NUMBER} is open; leaving its branch untouched so it can land. This measurement is uploaded as an artifact; the run after #${PR_NUMBER} merges publishes a fresher one."
               echo "skip=1" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
-
-          QUEUED="$(gh api graphql -f query="
-            query(\$owner: String!, \$name: String!) {
-              repository(owner: \$owner, name: \$name) {
-                mergeQueue(branch: \"main\") {
-                  entries(first: 100) { nodes { pullRequest { number } } }
-                }
-              }
-            }" -f owner="${GITHUB_REPOSITORY%%/*}" -f name="${GITHUB_REPOSITORY##*/}" \
-            --jq "[.data.repository.mergeQueue.entries.nodes[].pullRequest.number] | index(${PR_NUMBER}) != null" 2>/dev/null || echo "unreadable")"
-
-          case "$QUEUED" in
-            true)
-              echo "::notice title=npm-compat-refresh::PR #${PR_NUMBER} is in the merge queue; leaving it alone. This measurement is uploaded as an artifact and the next run publishes a fresher one."
-              echo "skip=1" >> "$GITHUB_OUTPUT"
-              ;;
-            false)
-              echo "PR #${PR_NUMBER} is not queued; safe to force-update its branch."
-              echo "skip=0" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::warning title=npm-compat-refresh::could not read the merge queue; proceeding (an unreadable gate must never freeze the artifact — #4130)."
-              echo "skip=0" >> "$GITHUB_OUTPUT"
               ;;
           esac
 

--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -110,6 +110,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       # Per-lane package matrices, planned from the repo's own catalog at the
       # pinned revision (scripts/list-npm-compat-packages.mjs). Adding a
@@ -117,7 +118,47 @@ jobs:
       # the matrix automatically; this workflow never hardcodes package names.
       fast_packages: ${{ steps.plan.outputs.fast }}
       slow_packages: ${{ steps.plan.outputs.slow }}
+      promotion_pr: ${{ steps.pending.outputs.pr_number }}
     steps:
+      # DON'T MEASURE WHAT CANNOT BE PUBLISHED (stakeholder, 2026-08-23).
+      #
+      # The coordinator already refuses to push while a promotion PR is open,
+      # so a run started in that window spends ~24 runners for ~15 minutes
+      # producing an artifact that is thrown away at the last step. Merges land
+      # every ~20 minutes and the PR can be open for hours, so that is most
+      # runs. Deciding here instead costs one 30-second job.
+      #
+      # The measurement is not lost, only deferred: the run after the PR merges
+      # measures whatever main is by then, which is fresher than what this run
+      # would have produced anyway.
+      - name: Is a promotion PR already open?
+        id: pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROMOTION_BRANCH: ${{ env.PROMOTION_BRANCH }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          PR_NUMBER="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
+            --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "unreadable")"
+          case "$PR_NUMBER" in
+            "")
+              echo "No open promotion PR; measuring."
+              ;;
+            unreadable)
+              # Fail OPEN here, unlike the coordinator's push gate. The cost of
+              # a wrong measurement is wasted compute; the cost of a wrong skip
+              # is a stale dashboard, which is the failure this workflow exists
+              # to prevent (#3988).
+              echo "::warning title=npm-compat-refresh::could not list promotion PRs; measuring anyway."
+              PR_NUMBER=""
+              ;;
+            *)
+              echo "::notice title=npm-compat-refresh::promotion PR #${PR_NUMBER} is still open; skipping this measurement entirely. The run after it merges will measure a fresher main."
+              ;;
+          esac
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
@@ -144,7 +185,7 @@ jobs:
   measure-fast:
     name: Measure npm-compat (${{ matrix.package }})
     needs: resolve
-    if: github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
+    if: needs.resolve.outputs.promotion_pr == '' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     concurrency:
       group: npm-compat-pkg-${{ matrix.package }}
       cancel-in-progress: false
@@ -200,7 +241,7 @@ jobs:
   measure-slow:
     name: Measure npm-compat (${{ matrix.package }})
     needs: resolve
-    if: github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
+    if: needs.resolve.outputs.promotion_pr == '' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     concurrency:
       group: npm-compat-pkg-${{ matrix.package }}
       cancel-in-progress: false
@@ -267,7 +308,7 @@ jobs:
   # cleanly when its lane produced no partials at all.
   refresh-fast:
     needs: [resolve, measure-fast]
-    if: always() && needs.resolve.result == 'success' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
+    if: always() && needs.resolve.result == 'success' && needs.resolve.outputs.promotion_pr == '' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     uses: ./.github/workflows/npm-compat-promote.yml
     with:
       source_sha: ${{ github.sha }}
@@ -277,7 +318,7 @@ jobs:
 
   refresh-slow:
     needs: [resolve, measure-slow]
-    if: always() && needs.resolve.result == 'success' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
+    if: always() && needs.resolve.result == 'success' && needs.resolve.outputs.promotion_pr == '' && github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     uses: ./.github/workflows/npm-compat-promote.yml
     with:
       source_sha: ${{ github.sha }}

--- a/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
+++ b/plan/issues/4604-npm-compat-refresh-runtime-exceeds-timeout.md
@@ -379,3 +379,12 @@ instruction ("merge-driven, no cron", 2026-08-23). Options, cheapest first:
    the option that most contradicts the stated instruction.
 
 (1) or (2) look right; both keep the trigger merge-driven.
+
+**Decision (stakeholder, 2026-08-23): option 2.** The coordinator never pushes
+while a promotion PR is open. The check-runs probe and the merge-queue GraphQL
+probe are gone — there is no longer a "looks idle right now" path to race. An
+unreadable PR listing now fails CLOSED (skip the cycle) rather than pushing.
+
+Consequence accepted: a genuinely wedged PR freezes promotion rather than
+trampling it, and `npm-compat-staleness.yml` is the alarm. A frozen artifact
+that shouts beats the silent six-hour freeze this replaces.

--- a/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
+++ b/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
@@ -151,22 +151,31 @@ describe("the refresh cannot retrigger itself", () => {
     }
   });
 
-  it("does not force-update the branch while its PR is in the merge queue", () => {
-    // Force-pushing the head of the in-flight merge group rebuilds it and
-    // cancels its run — the exact harm this change removes, relocated.
-    const gate = workflow.slice(
-      at("- name: Check whether the promotion PR"),
-      at("- name: Publish the refreshed artifacts"),
-    );
-    expect(gate).toContain("mergeQueue");
-    // ...but an unreadable queue must PROCEED, never freeze the artifact.
-    // That is #4130's lesson and it survives the redesign.
-    expect(gate).toMatch(/skip=0[^\n]*GITHUB_OUTPUT[\s\S]*?;;\s*$/m);
-    expect(gate).toContain("must never freeze the artifact");
-  });
-});
+  it("never force-updates the branch while a promotion PR is open", () => {
+    // Force-updating ejects the PR from the merge queue and restarts it. The
+    // guard this replaces tried to allow a push whenever the PR looked neither
+    // queued nor check-busy — a point-in-time read of a state that changes
+    // constantly. Run 827 (2026-08-23): guard passed 20:02:34, forced update
+    // landed 20:03:20, auto-enqueue still reported the PR queued at 20:40. The
+    // fast lane promotes on every merge since the per-package split, so that
+    // window was hit repeatedly and the dashboard froze at 15:27Z for six
+    // hours with every job green. An open PR now means hands off, full stop
+    // (stakeholder choice, 2026-08-23).
+    const guard = workflow.slice(at("- name: Skip the push while a promotion PR is open"));
+    expect(guard).toContain('echo "skip=1" >> "$GITHUB_OUTPUT"');
 
-describe("the pre-promote sanity check is unrelated to the PR switch and stays", () => {
+    // The racy probes must stay gone: nothing may re-introduce a "push if it
+    // looks idle right now" path.
+    expect(code).not.toContain("mergeQueue(branch:");
+    expect(code).not.toContain("check-runs?per_page=100");
+    expect(code).not.toContain("PR_HEAD_SHA");
+
+    // Unreadable state now fails CLOSED. Pushing on an unreadable read is what
+    // the race exploited; skipping costs one cycle, and the staleness workflow
+    // is the alarm if it persists.
+    expect(guard).toContain("could not list promotion PRs; skipping the push this cycle");
+  });
+
   it("still refuses to publish fewer than 20 packages or entries missing name/compile", () => {
     // The check moved OUT of an inline `node -e` into scripts/ (#4792) after an
     // apostrophe in a JS comment terminated the bash string, truncating the

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -268,18 +268,16 @@ describe("npm-compat refresh matrix wiring", () => {
     }
   });
 
-  it("does not force-update a promotion PR while its checks are in flight", () => {
-    // Lives in the reusable coordinator since the per-package split.
+  it("never force-updates the promotion branch while its PR is open", () => {
+    // See issue-4130-npm-compat-refresh-staleness-gate.test.ts for the full
+    // history. Short version: the old "push if it looks idle" guard lost a
+    // race it now ran several times an hour, and froze the dashboard for six
+    // hours behind green CI.
     const workflow = readFileSync(new URL("../.github/workflows/npm-compat-promote.yml", import.meta.url), "utf8");
 
-    expect(workflow).toContain("headRefOid");
-    expect(workflow).toContain("--paginate");
-    expect(workflow).toContain("awk '{ total += $1 } END { print total + 0 }'");
-    expect(workflow).not.toContain("--slurp");
-    expect(workflow).toContain("/commits/${PR_HEAD_SHA}/check-runs?per_page=100");
-    expect(workflow).toContain("leaving its branch untouched to avoid cancelling CI");
-    expect(workflow).toContain("Do not age this guard out");
-    expect(workflow).not.toContain("CHECK_CUTOFF");
+    expect(workflow).toContain("Skip the push while a promotion PR is open");
+    expect(workflow).not.toContain("mergeQueue(branch:");
+    expect(workflow).not.toContain("check-runs?per_page=100");
     expect(workflow).toContain('echo "skip=1" >> "$GITHUB_OUTPUT"');
   });
 

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -253,6 +253,13 @@ describe("npm-compat refresh matrix wiring", () => {
     expect(refresh).toContain("if-no-files-found: warn");
     expect(refresh).toContain("DOGFOOD_REACT_DOM_PROJECT_CONCURRENCY: 2");
 
+    // Do not MEASURE what cannot be published: a run started while a promotion
+    // PR is open would spend ~24 runners for ~15 minutes on an artifact the
+    // coordinator then refuses to push. The gate lives in `resolve` so it costs
+    // one 30-second job instead.
+    expect(refresh).toContain("Is a promotion PR already open?");
+    expect(refresh).toContain("needs.resolve.outputs.promotion_pr == ''");
+
     expect(promote).toContain("actions/download-artifact@v7");
     expect(promote).toContain("continue-on-error: true");
     expect(promote).toContain("scripts/merge-npm-compat-partials.mjs");


### PR DESCRIPTION
## Description

Two changes that together make the rule "one measurement in flight at a time", applied at both ends of the pipeline. Stakeholder decisions, 2026-08-23.

### 1. Never force-update the promotion branch while its PR is open (option 2 of #4604)

The dashboard sat at `generatedAt 2026-08-23T15:27:53Z` for six hours while the fast lane promoted successfully over and over — green CI everywhere.

Not the enqueuer: `auto-enqueue` says `#4807 skip (already-queued)`, and the PR does reach the queue. Every fast-lane promotion force-updates the reused `ci/npm-compat-refresh` branch, which ejects the PR from the merge queue and restarts it. The old guard tried to allow a push whenever the PR looked neither queued nor check-busy — a point-in-time read of state that changes constantly. From run 827:

```
20:02:34  guard passes (the publish step ran, so skip != 1)
20:03:20  + b87c9042...a1793bff  (forced update)
20:40:39  auto-enqueue: "#4807 skip (already-queued)"
```

Before the per-package split (#4796) the fleet promoted about once per 25 minutes, so that window was rarely hit. The fast lane now promotes on every merge and hit it repeatedly. **Promoting more often made the artifact update less often.**

Both racy probes — the check-runs poll and the merge-queue GraphQL query — are deleted, so there is no "looks idle right now" path left to lose. An unreadable PR listing fails **closed**: pushing on an unreadable read is exactly what the race exploited.

### 2. Don't measure what cannot be published

*"When a npm compat promotion pr is open we could also just skip the run altogether."*

Change 1 means a run started while a PR is open spends ~24 runners for ~15 minutes on an artifact the coordinator then discards. Merges land every ~20 minutes and the PR can be open for hours, so that is **most runs**. The decision moves into `resolve`, where it costs one 30-second job.

Nothing is lost, only deferred: the run after the PR merges measures whatever main is by then — fresher than what the skipped run would have produced.

**The two gates fail in opposite directions, deliberately.** The `resolve` gate fails **open** (measure anyway) because a wrong decision there only wastes compute. The coordinator's push gate fails **closed** because a wrong decision there force-pushes a queued PR out of the merge queue. Asymmetric costs, asymmetric defaults.

### Considered and rejected: making the refresh manual

The alternative floated was to let the promotion PR's own merge trigger the next measurement, so the cycle only advances when someone enqueues. Rejected: that makes a human the clock for dashboard freshness, which is the exact failure #3988 exists to prevent — this workflow's own header records that the expense "is exactly the cost that made the manual step get skipped", and the artifact shipped stale twice before automation. Automatic it stays.

## The pipeline recovered on its own before this landed

Recording honestly: a promotion finally won the race at ~22:30Z, so main already carries `generatedAt 2026-08-23T20:03:12Z`. The race is intermittent, not absolutely fatal — but a mechanism that starves for six hours and then succeeds by luck is still broken, and the freeze is invisible while it happens.

That landing confirmed the earlier work end to end:

| | before | now on main |
| --- | --- | --- |
| `measuredRange` | absent | `19:07:01 → 20:02:27` |
| per-package `measuredAt` | 0 / 24 | **24 / 24** |
| react-dom | `blocked`, 0/0 tests | **`measured`, 18/194** |
| lit | 10/144 | **13/151** |

react-dom executing real tests is the payoff of the #4805 probe fix (300 s timeout → 96.8 s valid module); lit's gain is the two virtual-dispatch validity fixes.

## Verification

Guard tests rewrote their assertions to pin both new rules, including the negatives — neither racy probe may come back, and the measurement gate must stay: 27 passed. Both workflows parse; no `src/` changes.

## Still open

**react-dom's row is cancelled mid-flight by the next merge** on most runs — it produced numbers this once, but not reliably. Separate cadence question, tracked in #4813's body and #3982.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ