### PR TITLE
fix(ci): allowlist the promotion bot in both login spellings — the real reason the dashboard froze

### DIFF
--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -134,5 +134,14 @@ jobs:
           # delta is narrow: the only thing that can make this app author a PR
           # is a workflow already on `main`, and the app already holds enqueue
           # authority — an external contributor cannot reach either.
-          TRUSTED_AUTHOR_LOGINS: ttraenkler,${{ steps.app-token.outputs.app-slug }}[bot]
+          # BOTH spellings of the app's login, deliberately. `gh pr list --json
+          # author` resolves through GraphQL, where a GitHub App's `Bot.login`
+          # is the BARE slug; REST reports the same account as `<slug>[bot]`.
+          # The allowlist was written in the REST form, so the comparison against
+          # the GraphQL form never matched and the promotion PR was rejected
+          # `untrusted-author:CONTRIBUTOR` — measured 2026-08-24 00:32 on #4817,
+          # which had been CLEAN and unenqueued for three hours while the
+          # npm-compat dashboard stayed frozen. Naming both forms grants no new
+          # trust: it is the same app, spelled the way each API returns it.
+          TRUSTED_AUTHOR_LOGINS: ttraenkler,${{ steps.app-token.outputs.app-slug }},${{ steps.app-token.outputs.app-slug }}[bot]
         run: node scripts/enqueue-green-prs.mjs

--- a/tests/issue-2550-trust-gate-fork-allowlist.test.ts
+++ b/tests/issue-2550-trust-gate-fork-allowlist.test.ts
@@ -10,6 +10,8 @@
 // These tests pin the trust decision (`isTrustedAuthor`) directly — they make
 // no `gh` calls (the live sweep is guarded behind an import.meta.url check).
 
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 import { isTrustedAuthor } from "../scripts/enqueue-green-prs.mjs";
 
@@ -64,5 +66,39 @@ describe("#2550 author-trust gate fork allowlist", () => {
     // Set membership is exact — guard against accidental substring trust.
     const r = isTrustedAuthor({ assoc: "NONE", authorLogin: "not-ttraenkler-evil", headRepoOwner: "evil-fork" });
     expect(r.trusted).toBe(false);
+  });
+});
+
+describe("the promotion bot is allowlisted in BOTH login spellings", () => {
+  // `gh pr list --json author` resolves through GraphQL, where a GitHub App's
+  // `Bot.login` is the BARE slug; REST reports the same account as
+  // `<slug>[bot]`. auto-enqueue.yml wrote the allowlist in the REST form only,
+  // so the comparison against the GraphQL form never matched: PR #4817 sat
+  // CLEAN and unenqueued for three hours on 2026-08-24 with
+  // `untrusted-author:CONTRIBUTOR` in the log, while the npm-compat dashboard
+  // stayed frozen. The workflow now names both forms.
+  const workflow = readFileSync(new URL("../.github/workflows/auto-enqueue.yml", import.meta.url), "utf8");
+
+  it("passes the app slug to the allowlist with and without the [bot] suffix", () => {
+    const line = workflow.split("\n").find((l) => l.includes("TRUSTED_AUTHOR_LOGINS:"));
+    expect(line).toBeDefined();
+    expect(line).toContain("${{ steps.app-token.outputs.app-slug }},");
+    expect(line).toContain("${{ steps.app-token.outputs.app-slug }}[bot]");
+  });
+
+  it("trusts an allowlisted login regardless of which spelling the API returned", () => {
+    // The decision function itself is spelling-agnostic: it just matches the
+    // configured set. Both entries are what makes either API form work.
+    for (const login of ["promo-bot", "promo-bot[bot]"]) {
+      const r = isTrustedAuthor({
+        assoc: "CONTRIBUTOR",
+        authorLogin: login,
+        headRepoOwner: "loopdive",
+      });
+      // With the default allowlist neither is trusted; this pins that the
+      // gate still FAILS CLOSED for a login nobody configured.
+      expect(r.trusted).toBe(false);
+      expect(r.reason).toBe("untrusted-author:CONTRIBUTOR");
+    }
   });
 });


### PR DESCRIPTION
## Description

The npm-compat dashboard has been frozen because **auto-enqueue rejects the promotion PR outright**, not because of the force-push race I fixed in #4822.

auto-enqueue's own log, 2026-08-24 00:32:

```
- #4817 skip (untrusted-author:CONTRIBUTOR)
```

PR #4817 had been `CLEAN`, non-draft and unlabelled for three hours. The enqueuer never took it → it never merged → the coordinator (correctly, post-#4822) kept refusing to push → nothing was ever published.

**Root cause.** `gh pr list --json author` resolves through GraphQL, where a GitHub App's `Bot.login` is the **bare slug**. REST reports the same account as `<slug>[bot]` — which is the form `auto-enqueue.yml` passed in `TRUSTED_AUTHOR_LOGINS`. So in `isTrustedAuthor()`:

- association gate: `CONTRIBUTOR` → not trusted (correct, that's the #2549 design)
- login allowlist: `js2-merge-queue-bot` vs configured `js2-merge-queue-bot[bot]` → **no match**
- fork-owner allowlist: head repo owner is `loopdive`, allowlist is `ttraenkler` → no match (legitimate)

→ fail closed, every cycle, forever.

**Fix.** Pass both spellings. This grants **no new trust**: it is the same app the allowlist already intended to trust, named the way each API returns it. The gate still fails closed for any unconfigured login — pinned by the second new test.

## Correcting the record

I want this legible for whoever reads the earlier PRs in sequence. #4822's force-push race was real and measured (run 827: guard passed 20:02:34, forced update 20:03:20), and worth fixing on its own. But it was **not the whole story**, and I presented it as though it were. With the enqueuer rejecting the PR outright, no amount of push discipline could have made the artifact land. My very first guess in this investigation — a trust gate rejecting the bot — was right, and I retracted it too readily when I saw a different PR logged as `already-queued`; that PR had reached the queue by another route, which made the trust gate invisible in that one sample.

## Verification

`tests/issue-2550-trust-gate-fork-allowlist.test.ts`: 15 passed, including two new cases — the workflow must pass both spellings, and the decision function must still reject an unconfigured login with `untrusted-author:CONTRIBUTOR`.

## Expected effect

Once this merges, #4817 (or its successor) should be enqueued on the next sweep and land, publishing the pending measurement. The `resolve` gate from #4822 then lets the next merge measure again — one measurement in flight, as designed.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ)_