### PR TITLE
fix(ci): resolve the PR author login from GraphQL so App authors match the trust allowlist

### DIFF
--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -745,14 +745,30 @@ function freshPrForEnqueue(number) {
 // to the BASE repo, loopdive/js2wasm). A number missing from the map (e.g. >100 open
 // PRs, or a transient GraphQL hiccup) is treated as untrusted by the caller —
 // fail closed, never enqueue a PR whose association we could not confirm.
+//
+// It also returns the author LOGIN, from this same query, and that is
+// deliberate (#4826 follow-up). `gh pr list --json author` does carry an
+// `author` object, and the login taken from it is what the login allowlist was
+// matched against until 2026-08-24 — but for a GitHub **App** author it does
+// not yield the app slug the allowlist names, so the promotion PR opened by
+// `js2-merge-queue-bot` was skipped `untrusted-author:CONTRIBUTOR` even after
+// BOTH spellings (`js2-merge-queue-bot` and `js2-merge-queue-bot[bot]`) were
+// allowlisted. The GraphQL `author { login }` selection resolves a Bot actor's
+// login unambiguously, so the gate no longer depends on which spelling a
+// particular gh version emits. This narrows nothing and widens nothing: the
+// same single app is trusted, it is simply identified from a source that
+// actually names it. The observed login is logged on every untrusted skip so a
+// future mismatch is visible in the run log instead of being inferred.
 function authorAssociations() {
   const r = graphql(
-    `{ repository(owner:"${OWNER}",name:"${NAME}"){ pullRequests(first:100,states:OPEN){ nodes { number authorAssociation } } } }`,
+    `{ repository(owner:"${OWNER}",name:"${NAME}"){ pullRequests(first:100,states:OPEN){ nodes { number authorAssociation author { login } } } } }`,
   );
   const nodes = r?.data?.repository?.pullRequests?.nodes || [];
   const byNumber = new Map();
   for (const n of nodes) {
-    if (n?.number != null) byNumber.set(n.number, n.authorAssociation || "NONE");
+    if (n?.number != null) {
+      byNumber.set(n.number, { assoc: n.authorAssociation || "NONE", login: n.author?.login || "" });
+    }
   }
   return byNumber;
 }
@@ -936,8 +952,8 @@ export function blockedDiagnosis(pr, authorAssoc) {
   // Do not label a stranger's PR: an external PR is *supposed* to require a
   // deliberate human enqueue (#2549), so "needs manual enqueue" is not news.
   const trust = isTrustedAuthor({
-    assoc: authorAssoc.get(pr.number) || "UNKNOWN",
-    authorLogin: pr.author?.login,
+    assoc: authorAssoc.get(pr.number)?.assoc || "UNKNOWN",
+    authorLogin: authorAssoc.get(pr.number)?.login || pr.author?.login,
     headRepoOwner: pr.headRepositoryOwner?.login,
   });
   if (!trust.trusted) return { suspected: false, reason: "", annotated: state };
@@ -1311,14 +1327,22 @@ function runSweep() {
     // ALWAYS needs a deliberate human enqueue. "Approve CI" ≠ "approve merge." A
     // PR missing from the association map (assoc unknown) and not on the
     // login/fork allowlist is untrusted. See isTrustedAuthor() for the decision.
-    const assoc = authorAssoc.get(pr.number) || "UNKNOWN";
+    const authorInfo = authorAssoc.get(pr.number);
+    const assoc = authorInfo?.assoc || "UNKNOWN";
+    // Prefer the GraphQL login (resolves App/Bot actors); fall back to whatever
+    // `gh pr list --json author` gave us if the GraphQL page missed this PR.
+    const authorLogin = authorInfo?.login || pr.author?.login || "";
     const trust = isTrustedAuthor({
       assoc,
-      authorLogin: pr.author?.login,
+      authorLogin,
       headRepoOwner: pr.headRepositoryOwner?.login,
     });
     if (!trust.trusted) {
-      skipped.push([pr.number, trust.reason]);
+      // Log the login we actually saw. Without it, a skip only says WHICH
+      // association was rejected, so an allowlist that names the right actor
+      // under the wrong spelling looks identical to a genuinely untrusted
+      // stranger — which is how the promotion PR stalled unnoticed.
+      skipped.push([pr.number, `${trust.reason} (login=${authorLogin || "(none)"})`]);
       continue;
     }
     const checks = visibleCheckState(pr.number);

--- a/tests/issue-2550-trust-gate-fork-allowlist.test.ts
+++ b/tests/issue-2550-trust-gate-fork-allowlist.test.ts
@@ -101,4 +101,31 @@ describe("the promotion bot is allowlisted in BOTH login spellings", () => {
       expect(r.reason).toBe("untrusted-author:CONTRIBUTOR");
     }
   });
+
+  // --- the login has to come from a source that names an App author ---
+  //
+  // Allowlisting both spellings (above) was necessary but not sufficient: the
+  // sweep matched against the login from `gh pr list --json author`, which for
+  // a GitHub App author does not yield the app slug, so the promotion PR kept
+  // being skipped `untrusted-author:CONTRIBUTOR` with a correct allowlist in
+  // place. The login is now read from the same GraphQL page that already
+  // returns authorAssociation, where a Bot actor's login resolves.
+
+  it("selects the author login in the association GraphQL query", () => {
+    const script = readFileSync(new URL("../scripts/enqueue-green-prs.mjs", import.meta.url), "utf8");
+    const query = script.slice(script.indexOf("function authorAssociations()"));
+    expect(query).toContain("number authorAssociation author { login }");
+  });
+
+  it("carries both association and login per PR, and logs the login it saw on a skip", () => {
+    const script = readFileSync(new URL("../scripts/enqueue-green-prs.mjs", import.meta.url), "utf8");
+    // The map value is a record, not a bare association string — a caller that
+    // reads it as a string would silently compare "[object Object]".
+    expect(script).toContain(
+      'byNumber.set(n.number, { assoc: n.authorAssociation || "NONE", login: n.author?.login || "" })',
+    );
+    // A skip must name the login, otherwise a spelling mismatch is
+    // indistinguishable in the log from a genuinely untrusted stranger.
+    expect(script).toContain('`${trust.reason} (login=${authorLogin || "(none)"})`');
+  });
 });


### PR DESCRIPTION
## What

`scripts/enqueue-green-prs.mjs` now reads the PR author login from the same GraphQL page that already returns `authorAssociation`, instead of from `gh pr list --json author`. Every untrusted skip also logs the login it saw.

## Why

The npm-compat promotion PR (#4817, head `ci/npm-compat-refresh`) was **still** skipped `untrusted-author:CONTRIBUTOR` after the previous fix put both login spellings of the promotion app into `TRUSTED_AUTHOR_LOGINS`. Auto-enqueue run [32681573559](https://github.com/loopdive/js2/actions/runs/32681573559) shows the allowlist live in the job env:

```
TRUSTED_AUTHOR_LOGINS: ttraenkler,js2-merge-queue-bot,js2-merge-queue-bot[bot]
  - #4817 skip (untrusted-author:CONTRIBUTOR)
```

So the allowlist was never the thing that failed to match. The sweep matched against the login from `gh pr list --json author`, which for a GitHub **App** author does not yield the app slug the allowlist names — no spelling of the allowlist entry could have matched. GraphQL's `author { login }` resolves a Bot actor's login, so the gate no longer depends on which spelling a given `gh` version emits. The `--json author` value stays as a fallback for a PR the GraphQL page misses.

This **narrows nothing and widens nothing**: the same single app is trusted, it is simply identified from a source that actually names it. The association gate, the fork allowlist, and the fail-closed default are untouched.

The skip log gains the observed login because without it a correct allowlist under an unmatched spelling is indistinguishable from a genuinely untrusted stranger — which is why this took two attempts to locate rather than being read off the first run.

## Effect

The promotion PR reaches the merge queue, so `benchmarks/results/npm-compat.json` advances past `generatedAt 2026-08-23T20:03:12` — it has been frozen there since the split, with every measurement lane running and its output never promoted.

## Tests

`tests/issue-2550-trust-gate-fork-allowlist.test.ts` (+2, already in the required guard suite): the GraphQL query selects `author { login }`; the per-PR map carries `{assoc, login}` rather than a bare string; the skip line names the login. 17/17 pass.

Related: [#4130](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4130-npm-compat-refresh-staleness-gate), [#3982](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3982-npm-compat-react-dom-compile-timeout)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ)_