### PR TITLE
fix(npm-compat): build the perf artifact from the whole corpus, not only freshly-measured rows

### DIFF
--- a/scripts/lib/npm-compat-partials.mjs
+++ b/scripts/lib/npm-compat-partials.mjs
@@ -165,7 +165,23 @@ export function mergeNpmCompatPartials(
     },
     packages: sortedPackages,
   };
-  const perfRows = npmPerfRows(freshPackages);
+  // The perf ARTIFACT is built from the WHOLE corpus, not only what this run
+  // re-measured. A carried-forward row keeps its own last measurement in
+  // `packages[]` and the card still renders it, stamped with its real
+  // `measuredAt` — so dropping it from the perf chart makes the chart disagree
+  // with the cards beside it. Since the per-package split that stopped being a
+  // cosmetic inconsistency and became a hard stop: a promotion routinely
+  // carries ONE fresh package (react-dom's lane runs on its own 3-4h cadence
+  // and promotes alone), and on 2026-08-24T02:31Z it did exactly that with all
+  // three of react-dom's lanes at `compile-error`. Fresh-only rows made
+  // `npm-compat-perf.json` come out `[]`, which
+  // `check-npm-compat-promotion.mjs` rejects — "must contain performance
+  // measurements" — failing `quality` and stranding the promotion PR.
+  //
+  // The HISTORY point stays fresh-only, deliberately: it is a time series, and
+  // appending a carried-forward measurement under this run's `generatedAt`
+  // would claim a measurement happened now that did not.
+  const perfRows = npmPerfRows(sortedPackages);
   const perfHistory = mergeNpmPerfHistory(
     existingHistory,
     freshPackages.length > 0

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -102,10 +102,62 @@ describe("npm-compat partial aggregation", () => {
       reason: "measurement worker did not produce a partial report",
       lastMeasuredAt: "2026-08-21T00:00:00.000Z",
     });
-    expect(result.perfRows.map((entry) => entry.name)).toEqual(["acorn · JS host · runtime dynamic"]);
+    // The perf ARTIFACT keeps the carried-forward row: react's card still shows
+    // its last measurement, so the chart beside it must too.
+    expect(result.perfRows.map((entry) => entry.name)).toEqual([
+      "acorn · JS host · runtime dynamic",
+      "react · JS host · runtime dynamic",
+    ]);
+    // The HISTORY point does not — a stale measurement must not be recorded as
+    // having happened in this run.
     expect(result.perfHistory.runs.at(-1)?.packages).toEqual({
       acorn: { jsHost: { dynamic: 2 }, standalone: {} },
     });
+  });
+
+  it("still produces perf rows when the only fresh package failed to compile", () => {
+    // The live failure (2026-08-24T02:31Z). react-dom's lane promotes on its
+    // own 3-4h cadence, so a promotion legitimately carries ONE fresh package;
+    // that run's three react-dom lanes were all `compile-error`. With perf rows
+    // built from fresh packages only, `npm-compat-perf.json` came out `[]` and
+    // `check-npm-compat-promotion.mjs` failed the `quality` gate with
+    // "must contain performance measurements", stranding the promotion PR with
+    // 23 packages' worth of perfectly good carried-forward measurements on it.
+    const previous = partial(["acorn", "react"], "old");
+    previous.packages = previous.packages.map((entry) => ({
+      ...entry,
+      perf: { lanes: { jsHost: { status: "measured", ratio: 1.5, wasmUs: 10, nodeUs: 15 } } },
+    })) as typeof previous.packages;
+
+    const fresh = partial(["react-dom"]);
+    (fresh.packages[0] as any).perf = {
+      lanes: {
+        jsHost: { status: "compile-error" },
+        standalone: { status: "compile-error" },
+        standaloneDynamic: { status: "compile-error" },
+      },
+    };
+
+    const result = mergeNpmCompatPartials([fresh], {
+      expectedNames: ["acorn", "react", "react-dom"],
+      sourceRevision: "source",
+      existingPackages: previous.packages,
+      existingSummaryMeta: previous.summaryMeta,
+      existingGeneratedAt: "2026-08-21T00:00:00.000Z",
+      allowStaleFallback: true,
+      generatedAt: "2026-08-24T02:31:23.145Z",
+    });
+
+    expect(result.summary.refresh.freshCount).toBe(1);
+    // Both carried-forward rows survive into the perf artifact — the exact
+    // thing that was `[]` before. Order follows the report's popularity sort.
+    expect(result.perfRows.map((entry) => entry.name)).toEqual([
+      "react · JS host · runtime dynamic",
+      "acorn · JS host · runtime dynamic",
+    ]);
+    // The history point carries no packages: the one package measured this run
+    // produced no timing. Stale rows are not backdated into it.
+    expect(result.perfHistory.runs.at(-1)?.packages).toEqual({});
   });
 
   it("keeps a stale row's OWN measurement time instead of creeping it forward each refresh", () => {


### PR DESCRIPTION
## What

`mergeNpmCompatPartials` now builds `npm-compat-perf.json` from every package in the merged report instead of only the ones the current run re-measured. The history point is unchanged — still fresh-only.

## Why

The npm-compat promotion PR (#4817) fails the `quality` gate. `check-npm-compat-promotion.mjs` rejects it:

```
Error: benchmarks/results/npm-compat-perf.json must contain performance measurements
    at validateNpmCompatPromotion (scripts/check-npm-compat-promotion.mjs:84:11)
```

The artifact really is `[]`. Perf rows came from `freshPackages`, and since the per-package split a promotion routinely carries exactly **one** fresh package — react-dom's lane runs on its own 3-4h cadence and promotes alone. The 02:31Z promotion did that, and all three of react-dom's lanes were `compile-error`, so zero rows came out. Twenty-three carried-forward packages sat in the same report with perfectly good measurements, and the promotion was rejected anyway (`freshCount: 1, totalCount: 24`).

Building the rows from the whole corpus is what the rest of the report already does: a carried-forward row keeps its own last measurement in `packages[]` and its card renders it stamped with the real `measuredAt`. Dropping that same row from the chart sitting next to the card was inconsistent before the split; after it, it empties the artifact.

The **history** point deliberately stays fresh-only. It is a time series, and backdating a carried-forward measurement under this run's `generatedAt` would claim a measurement happened now that did not.

This is the last link in the chain that has kept the dashboard frozen at `generatedAt 2026-08-23T20:03:12`: the trust gate ([#4826](https://github.com/loopdive/js2/pull/4826), [#4831](https://github.com/loopdive/js2/pull/4831)) stopped the promotion PR from being enqueued at all; with that fixed it reached the gate and failed on this.

## Verification

Replayed the real 02:31Z promotion — react-dom as the sole fresh partial over main's committed snapshot:

| | perf rows | validator |
|---|---|---|
| before | 0 | fails "must contain performance measurements" |
| after | 13 | passes, 0 invalid timing entries |

## Tests

`tests/npm-compat-partials.test.ts`: a new case reproduces the live shape (sole fresh package with all lanes `compile-error` + carried-forward rows that do have timings) and pins non-empty perf rows; the existing carry-forward case is updated to assert the split explicitly — the carried-forward row appears in the perf artifact but **not** in the history point. 13/13 pass.

Related: [#3982](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3982-npm-compat-react-dom-compile-timeout), [#4130](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4130-npm-compat-refresh-staleness-gate)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ)_