### PR TITLE
fix(ci): a failing npm-compat promotion PR must not hold the dashboard

### DIFF
--- a/.github/workflows/npm-compat-promote.yml
+++ b/.github/workflows/npm-compat-promote.yml
@@ -235,8 +235,22 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          PR_NUMBER="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
-            --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "unreadable")"
+          # Same rule as the refresh workflow's measurement gate: a promotion
+          # PR that is FAILING a check does not hold the branch. Leaving it
+          # untouched protects a PR that can still land; a PR that cannot land
+          # is instead held together with the dashboard behind it, because the
+          # regenerated artifact is the only thing that can make it mergeable.
+          # Both gates have to agree — a measurement allowed through upstream
+          # and then refused here would deadlock just the same.
+          PR_JSON="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
+            --state open --json number,statusCheckRollup 2>/dev/null || echo "unreadable")"
+          if [ "$PR_JSON" = "unreadable" ]; then
+            PR_NUMBER="unreadable"
+          else
+            PR_NUMBER="$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty')"
+            PR_FAILING="$(printf '%s' "$PR_JSON" | jq -r \
+              '[.[0].statusCheckRollup[]? | select((.conclusion // "") == "FAILURE")] | length')"
+          fi
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
           case "$PR_NUMBER" in
@@ -252,8 +266,13 @@ jobs:
               echo "skip=1" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "::notice title=npm-compat-refresh::promotion PR #${PR_NUMBER} is open; leaving its branch untouched so it can land. This measurement is uploaded as an artifact; the run after #${PR_NUMBER} merges publishes a fresher one."
-              echo "skip=1" >> "$GITHUB_OUTPUT"
+              if [ "${PR_FAILING:-0}" -gt 0 ]; then
+                echo "::warning title=npm-compat-refresh::promotion PR #${PR_NUMBER} has ${PR_FAILING} failing check(s) and cannot land as-is; publishing over its branch so the fresh artifact can heal it."
+                echo "skip=0" >> "$GITHUB_OUTPUT"
+              else
+                echo "::notice title=npm-compat-refresh::promotion PR #${PR_NUMBER} is open; leaving its branch untouched so it can land. This measurement is uploaded as an artifact; the run after #${PR_NUMBER} merges publishes a fresher one."
+                echo "skip=1" >> "$GITHUB_OUTPUT"
+              fi
               ;;
           esac
 

--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -139,8 +139,29 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          PR_NUMBER="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
-            --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "unreadable")"
+          # A FAILING promotion PR does not count as "open" for this gate. It
+          # will never merge on its own, and both this gate and the
+          # coordinator's push gate leave its branch untouched while it is
+          # open — so a promotion that fails a required check DEADLOCKS the
+          # dashboard: PR open -> measurement skipped -> branch never
+          # regenerated -> PR never fixes itself. That is not a hypothetical;
+          # #4817 sat un-mergeable on a `quality` failure while its head went
+          # unchanged for hours and every refresh run skipped, and the fix that
+          # would have healed it (landed on main) could not reach it.
+          #
+          # Skipping is only ever worth it for a promotion that can still land.
+          # Nothing is protected by leaving a dead PR alone: it is not in the
+          # merge queue, so force-updating it cannot eject anything, and the
+          # regenerated artifact is the only thing that can make it mergeable.
+          PR_JSON="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
+            --state open --json number,statusCheckRollup 2>/dev/null || echo "unreadable")"
+          if [ "$PR_JSON" = "unreadable" ]; then
+            PR_NUMBER="unreadable"
+          else
+            PR_NUMBER="$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty')"
+            PR_FAILING="$(printf '%s' "$PR_JSON" | jq -r \
+              '[.[0].statusCheckRollup[]? | select((.conclusion // "") == "FAILURE")] | length')"
+          fi
           case "$PR_NUMBER" in
             "")
               echo "No open promotion PR; measuring."
@@ -154,7 +175,12 @@ jobs:
               PR_NUMBER=""
               ;;
             *)
-              echo "::notice title=npm-compat-refresh::promotion PR #${PR_NUMBER} is still open; skipping this measurement entirely. The run after it merges will measure a fresher main."
+              if [ "${PR_FAILING:-0}" -gt 0 ]; then
+                echo "::warning title=npm-compat-refresh::promotion PR #${PR_NUMBER} is open but has ${PR_FAILING} failing check(s); it cannot land as-is, so measuring and regenerating its branch instead of waiting for it."
+                PR_NUMBER=""
+              else
+                echo "::notice title=npm-compat-refresh::promotion PR #${PR_NUMBER} is still open; skipping this measurement entirely. The run after it merges will measure a fresher main."
+              fi
               ;;
           esac
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
+++ b/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
@@ -25,8 +25,9 @@
  * lands on somebody else's PR.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
@@ -39,10 +40,9 @@ const ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
 // which file a step happens to live in, so read both. Order matters for the
 // `at()` comparisons and promotion runs after measurement, so concatenate in
 // pipeline order — that keeps "sanity check precedes push" meaningful.
-const workflow = [
-  readFileSync(resolve(ROOT, ".github/workflows/npm-compat-refresh.yml"), "utf8"),
-  readFileSync(resolve(ROOT, ".github/workflows/npm-compat-promote.yml"), "utf8"),
-].join("\n");
+const refresh = readFileSync(resolve(ROOT, ".github/workflows/npm-compat-refresh.yml"), "utf8");
+const promote = readFileSync(resolve(ROOT, ".github/workflows/npm-compat-promote.yml"), "utf8");
+const workflow = [refresh, promote].join("\n");
 
 const at = (needle: string): number => workflow.indexOf(needle);
 
@@ -249,5 +249,121 @@ describe("the promotion PR must survive auto-enqueue's author-trust gate", () =>
       env: { ...process.env, TRUSTED_AUTHOR_LOGINS: "ttraenkler" },
     });
     expect(JSON.parse(withoutAllowlist).trusted).toBe(false);
+  });
+});
+
+describe("a promotion PR that cannot land must not hold the dashboard", () => {
+  // THE DEADLOCK. Two gates skip while a promotion PR is open: the refresh
+  // workflow skips the measurement, and the coordinator skips the push. Both
+  // exist so an in-flight promotion is never force-updated out from under
+  // itself. But a promotion that FAILS a required check never merges, and the
+  // artifact that would fix it is exactly what both gates are refusing to
+  // produce — so the PR cannot heal, and the dashboard freezes behind it.
+  //
+  // Observed 2026-08-24: #4817 failed `quality` on an empty
+  // npm-compat-perf.json at 02:32Z. The fix landed on main at 04:32Z and could
+  // not reach the branch; #4817's head did not move for hours while every
+  // refresh run skipped, and npm-compat.json stayed at 2026-08-23T20:03:12.
+  //
+  // These run the real gate scripts against a stubbed `gh`, because the bug is
+  // in what the shell DECIDES, not in which words the file contains.
+
+  /** Pull one step's `run:` body out of a workflow, by step name. */
+  function stepScript(workflow: string, stepName: string): string {
+    const start = workflow.indexOf(`- name: ${stepName}`);
+    expect(start).toBeGreaterThan(-1);
+    const runAt = workflow.indexOf("\n        run: |\n", start);
+    expect(runAt).toBeGreaterThan(-1);
+    const body = workflow.slice(runAt + "\n        run: |\n".length);
+    const lines: string[] = [];
+    for (const line of body.split("\n")) {
+      if (line.trim() !== "" && !line.startsWith("          ")) break;
+      lines.push(line.slice(10));
+    }
+    return lines.join("\n");
+  }
+
+  /**
+   * Run a gate script with `gh pr list` stubbed to return `prJson`, and give
+   * back the step's GITHUB_OUTPUT.
+   */
+  function runGate(script: string, prJson: string): Record<string, string> {
+    const dir = mkdtempSync(join(tmpdir(), "npm-compat-gate-"));
+    try {
+      const bin = join(dir, "bin");
+      mkdirSync(bin);
+      writeFileSync(join(bin, "gh"), `#!/bin/sh\ncat <<'JSON'\n${prJson}\nJSON\n`, { mode: 0o755 });
+      const outFile = join(dir, "out");
+      writeFileSync(outFile, "");
+      execFileSync("bash", ["-c", script], {
+        cwd: dir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          GITHUB_OUTPUT: outFile,
+          GITHUB_REPOSITORY: "loopdive/js2",
+          PROMOTION_BRANCH: "ci/npm-compat-refresh",
+        },
+      });
+      return Object.fromEntries(
+        readFileSync(outFile, "utf8")
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => {
+            const eq = line.indexOf("=");
+            return [line.slice(0, eq), line.slice(eq + 1)];
+          }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  const NO_PR = "[]";
+  const HEALTHY_PR = JSON.stringify([
+    { number: 4817, statusCheckRollup: [{ conclusion: "SUCCESS" }, { conclusion: "SKIPPED" }] },
+  ]);
+  // The real shape of #4817 at 02:32Z: `quality` and `changes` both FAILURE.
+  const FAILING_PR = JSON.stringify([
+    {
+      number: 4817,
+      statusCheckRollup: [{ conclusion: "SUCCESS" }, { conclusion: "FAILURE" }, { conclusion: "FAILURE" }],
+    },
+  ]);
+
+  describe("the refresh workflow's measurement gate", () => {
+    const script = () => stepScript(refresh, "Is a promotion PR already open?");
+
+    it("measures when no promotion PR is open", () => {
+      expect(runGate(script(), NO_PR).pr_number).toBe("");
+    });
+
+    it("still skips for a promotion PR that can land", () => {
+      expect(runGate(script(), HEALTHY_PR).pr_number).toBe("4817");
+    });
+
+    it("measures anyway when the open PR is failing a check", () => {
+      // An empty pr_number is what un-gates the measure-* jobs.
+      expect(runGate(script(), FAILING_PR).pr_number).toBe("");
+    });
+  });
+
+  describe("the coordinator's push gate", () => {
+    const script = () => stepScript(promote, "Skip the push while a promotion PR is open");
+
+    it("publishes when no promotion PR is open", () => {
+      expect(runGate(script(), NO_PR).skip).toBe("0");
+    });
+
+    it("still holds off for a promotion PR that can land", () => {
+      expect(runGate(script(), HEALTHY_PR).skip).toBe("1");
+    });
+
+    it("publishes over a failing PR's branch so the fresh artifact can heal it", () => {
+      // Both gates must agree. A measurement let through upstream and then
+      // refused here would deadlock exactly the same way.
+      expect(runGate(script(), FAILING_PR).skip).toBe("0");
+    });
   });
 });


### PR DESCRIPTION
## The deadlock

Two gates skip while a promotion PR is open on `ci/npm-compat-refresh`:

| gate | while a promotion PR is open |
|---|---|
| `npm-compat-refresh.yml` → `resolve` | skips the whole measurement |
| `npm-compat-promote.yml` → push step | skips the push |

Both exist so an in-flight promotion is never force-updated out from under itself — that was the deliberate cadence choice. But together they deadlock on a promotion that **fails a check**: it never merges, and the regenerated artifact that would fix it is exactly what both gates refuse to produce.

## Observed, not hypothetical

- 02:32Z — #4817 fails `quality`: `npm-compat-perf.json must contain performance measurements`. The artifact is `[]`.
- 04:32Z — the fix for that emptiness (#4833) merges to main.
- It cannot reach the branch. #4817's head is still `0db1207e` from 02:32Z, every refresh run since has skipped, and `npm-compat.json` is still at `generatedAt 2026-08-23T20:03:12`.

The PR cannot heal itself, and the dashboard is frozen behind it.

## The change

Both gates now read "open" as **open and not failing**. Skipping is only ever worth it for a promotion that can still land: a PR failing a required check is not in the merge queue, so force-updating it cannot eject anything, and the fresh artifact is the only thing that can make it mergeable.

This preserves the original intent rather than reversing it — a healthy promotion PR is still left completely untouched. Both gates have to agree, since a measurement let through upstream and then refused at the push would deadlock the same way.

## Tests

`tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts` (+6, already in the required guard suite) extracts each gate's real `run:` body and executes it against a stubbed `gh`, because the bug is in what the shell **decides**, not in which words the file contains:

| stubbed PR state | measurement gate | push gate |
|---|---|---|
| none open | runs | publishes |
| open, all checks pass | skips (unchanged) | holds off (unchanged) |
| open, 2 × `FAILURE` (the real #4817 shape) | runs | publishes over it |

The two decisive cases fail against the previous gates. 21/21 pass.

Related: [#4130](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4130-npm-compat-refresh-staleness-gate), [#3982](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3982-npm-compat-react-dom-compile-timeout)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ)_