### PR TITLE
feat(3518): cut over standalone bench_array to Prepared IR

### DIFF
--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -20,6 +20,10 @@ lane: ir-retirement
 model: gpt-5.6-sol
 related: [1373b, 2855, 2950, 3090, 3142, 3143, 3341, 3517, 3529, 3520, 3521, 3522, 3523, 3525, 3526, 3527, 3528, 3678, 3681, 4382, 4576, 4577]
 origin: "2026-07-21 explicit user directive: enable IR-only by default and retire the old direct codegen path"
+oracle-ratchet-allow:
+  - src/codegen/multi-prepared-array-leaf.ts
+loc-budget-allow:
+  - src/codegen/index.ts
 ---
 # #3518 — IR-only default and direct front-end retirement
 

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -3,7 +3,7 @@ id: 3518
 title: "IR-only default and direct front-end retirement"
 status: in-progress
 created: 2026-07-21
-updated: 2026-08-20
+updated: 2026-08-24
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -664,3 +664,181 @@ must restore exactly the current two target direct rows. Runtime instantiation,
 raw/optimized WAT A/B, vector/bounds/call/allocation parity, and callback ABI
 publication remain acceptance evidence for the implementation; this audit does
 not claim those route-specific checks have passed.
+
+### Implementation checkpoint: array leaf route after the first failed attempt (2026-08-24)
+
+This is a design-only checkpoint. No compiler source, runtime artifact, or
+heavy test result is accepted by this entry. The first implementation attempt
+did not produce a safe array route: adding the route to the existing scalar
+union is not enough, because the scalar recogniser rejects array syntax and the
+function-value recogniser is deliberately limited to the earlier reduction
+fixture. The next implementation must land as one independently reviewable
+array transaction; it must not widen either generic recogniser or copy a second
+array lowerer.
+
+#### Exact candidate proof
+
+Add `src/codegen/multi-prepared-array-leaf.ts`. Its exported candidate
+collector/resolver should be named and shaped like the existing scalar leaf:
+`collectMultiPreparedArrayLeafCandidates`,
+`isMultiPreparedArrayLeafCandidateEligible`,
+`tryPrepareMultiSourceArrayLeaf`,
+`planEarlyMultiPreparedArrayLeafRoute`, and
+`assertMultiPreparedArrayLeafRouteCurrent`. The route is eligible only when
+all of these facts hold before any direct body is requested:
+
+1. The shared planner is active only for `experimentalIR`, non-`disableIrFirst`,
+   standalone WasmGC, non-fast, non-WASI, and a graph with more than one source;
+   the candidate declaration is in the entry source and the array cutover
+   switch is enabled. The resolver must use the exact `IrUnitId`, source record,
+   declaration, terminal owner, claim, override, and `ProgramAbiSession`
+   joins, not the spelling `bench_array`.
+2. There is exactly one exported, bodyful, top-level, non-async,
+   non-generator, non-generic, zero-parameter function with an explicit
+   `number` return. Its five statements are exactly the benchmark shape from
+   `website/playground/examples/benchmarks/array.ts:3-9`: one `const` binding
+   with an explicit `number[]` annotation and empty literal; one counted loop
+   beginning at numeric literal zero, with a strictly increasing update and a
+   single `arr.push(i)` statement; one zero-initialised numeric accumulator; one
+   counted `i < arr.length` loop with one `total = total + arr[i]` assignment;
+   and a return of that same accumulator. Require the checker symbol for every
+   array, counter, accumulator, `length`, `push`, and indexed access to match
+   the candidate declarations. The push bound must be a safe integer literal
+   (the real fixture is `10000`); do not admit an arbitrary expression merely
+   because it currently lowers.
+3. The proof must call the shared canonical helpers rather than duplicate their
+   semantics: `canonicalCountedPushPlanForLiteral` and
+   `canonicalCountedPushPlanForCall` in
+   `src/ir/array-element-lowering.ts:226-264`, the empty-array inference and
+   `number[]` annotation contract in `array-element-lowering.ts:292-324`, and
+   the existing counted-loop/index proof in `src/ir/from-ast.ts:9278-9328`.
+   Require the canonical push plan’s single-argument, non-spread, same-symbol
+   receiver and pure non-aliasing value proof. Reject aliases, a `let` array,
+   reassignment, additional writes/methods, a dynamic or negative bound,
+   non-increasing updates, `<=`/`>=` bounds, index mutation, nested functions,
+   an escaping array, an extra array literal, or any second eligible function.
+4. The candidate’s local call/value graph is a singleton. The only runtime
+   value observation of the candidate is the one identifier passed once as the
+   fourth argument of an exact named imported call in the legacy `main` owner.
+   Resolve that import through
+   `resolveMultiPreparedFunctionValueImportTarget` in
+   `src/codegen/multi-prepared-function-value-import-target.ts:36-102` and
+   require the imported declaration to be the unique exported `addBenchCard`
+   helper from the exact `helpers.ts` source record. The caller is a distinct
+   top-level terminal with its own UnitId and remains direct-owned. Reject an
+   alias, re-export, repeated/stored/returned value, same-source target,
+   wrong-arity callback, callback type/ABI drift, an extra direct caller, or a
+   callback whose owner/source identity changes.
+5. The target must have the exact prepared `[] -> f64` override, one occupied
+   callable with the matching source UnitId, no collision/suffix/import-alias/
+   live-function binding, no class shape, no module-init/storage terminal,
+   no derived owner, no cross-file target, and no late provider. A candidate
+   that cannot be fully proven returns ordinary ineligibility before skip;
+   drift after certification is an `IrInvariantError`, never a silent direct
+   fallback after a skip was requested.
+
+#### Route and receipt API
+
+Reuse the common prepared body state from
+`src/codegen/multi-prepared-scalar-leaf.ts:239-304` (export the route base if
+needed) and add `MultiPreparedArrayLeafRoute` with `routeKind: "array"`.
+`MultiPreparedArrayLeafPlan` may extend the scalar plan’s identity, claims,
+overrides, and class-shape maps, but its receipt must retain an immutable shape
+record: target UnitId/name/declaration, the exact array declaration, push and
+reduction loop nodes, counter/accumulator declarations, source IDs, and the
+canonical callback/value-edge evidence. This lets the late assertion prove
+AST identity and symbol joins rather than trusting a name or a stale report.
+
+The planner should mirror
+`planEarlyMultiPreparedScalarLeafRoute` at
+`multi-prepared-scalar-leaf.ts:1273-1337`: build one plan per candidate source,
+compute the ordinary graph safety/selection, require exactly one eligible
+entry-source candidate, and call `prepareIrBodies` with only the target
+function. Reject any class-member, module-init, implicit-constructor, derived,
+or second free-function result. Require the same exact skip/preserve/completed
+body sets, terminal evidence, artifact evidence, nonempty prepared component,
+and `[] -> f64` allocated callable checked by
+`tryPrepareMultiSourceScalarLeaf` at `multi-prepared-scalar-leaf.ts:986-1104`.
+Do not make a second array-specific IR builder: the prepared body must be the
+existing `from-ast` result.
+
+The array route must receive a callback
+`prepareFunctionValueSupport(plan, sourceFile, unitId, legacyName)` from the
+shared planner and call the existing private
+`prepareTopLevelFunctionValueTargetSupport` in `src/codegen/index.ts:2265-2345`.
+Store the returned `MultiPreparedFunctionValueSupportReceipt` unchanged and
+revalidate it with `functionValueSupportIsCurrent` after the remaining legacy
+owners run. This freezes the candidate callable plus exactly one trampoline,
+cache global, support binding, locator, and Program ABI role before the direct
+caller can materialise `bench_array`; it does not prepare or duplicate the
+`addBenchCard` helper. The callback’s owner UnitId, imported target UnitId,
+source key, call AST node, and distinct owner must be rechecked at the late
+seam.
+
+Wire the map in `src/codegen/index.ts:3570-3623` with
+`JS2WASM_MULTI_PREPARED_ARRAY_CUTOVER` and an explicit route-overlap assertion.
+The array route must be considered before the generic function-value route and
+must never silently share a source state with scalar, Fibonacci, or bench-loop
+routes. Reuse `compileMultiPreparedScalarLeafDeclarations` at
+`index.ts:8718-8720`; in the late overlay at `index.ts:3665-3688`, dispatch an
+array-specific current-route assertion before `completePreparedIrIntegration`.
+The final assertion must check final selection, target/support allocator
+identity, immutable prepared instruction sequence, exact report receipt, and
+the unchanged callback/value edge. Any failed post-certification check is an
+Invariant.
+
+#### Existing IR shape that must remain load-bearing
+
+The implementation must preserve the already measured lowerings, not replace
+them with a fused hand-written body. `lowerArrayLiteral` uses the empty
+`number[]` hint and canonical counted-push capacity at
+`src/ir/from-ast.ts:4464-4533`; `tryLowerVecPush` emits the one-element vector
+store and length increment at `src/ir/array-element-lowering.ts:368-448`;
+`lowerPropertyAccess`/element access uses the counted-loop proof and only emits
+unchecked `vec.get` for a proven `0 <= i < arr.length` at
+`src/ir/from-ast.ts:5467-5476,5693-5781`; and `lowerForStatement` carries the
+proof into the loop body at `from-ast.ts:9605-9640`. The route is correct only
+when the resulting prepared body retains the i32 vector carrier, in-bounds
+read, vector allocation/store/get, and f64 return conversion observed in the
+baseline. If any of those facts cannot be certified, withdraw before skip.
+
+#### Kill switch and focused test contract
+
+Use `JS2WASM_MULTI_PREPARED_ARRAY_CUTOVER=0` as the exact pre-cutover control.
+Add `tests/issue-3518-bench-array-prepared-cutover.test.ts`, following the
+15/21-case structure of the existing #4589/#4590 route suites:
+
+- default-on direct-body poison must compile with no target
+  `compileFunctionBody`/`compileStatement` rows and report one `terminal-ir`
+  target with `legacyBodyEmitted: false`, `irBodyEmitted: true`, and a prepared
+  component; the kill switch must reproduce exactly the two target direct rows
+  and fail the same poison;
+- raw direct/Prepared audit rows must differ only by those two target rows;
+  target raw WAT must retain the vector allocation, counted push/store, proven
+  bounds/indexed get, i32 carrier, and `() -> f64` body shape; source callable,
+  trampoline/cache, import/export, and callback Program ABI contracts must be
+  exact and singleton;
+- raw and optimized Prepared/direct A/B must instantiate and return
+  `49_995_000`, preserve DTS/import helper/import/string-pool/public surfaces,
+  retain callback publication, and show no optimized size or call/allocation
+  regression. Runtime and WAT evidence are required for implementation
+  acceptance; this design checkpoint makes no such claim;
+- mutation cases must cover renamed-but-equivalent declarations (positive),
+  extra candidate/extra caller, alias/re-export/stored value, `let`/reassigned
+  array, non-empty or escaping array, push arity/spread/dynamic value, bound or
+  index/update changes, `<=`/`>=`, additional array method, callback source or
+  ABI tamper, support-name/allocator tamper, post-certification route tamper,
+  class/module-init/cross-file component, and fast/WASI/IR-first-disabled
+  controls. Every negative must retain the two direct rows or fail with a typed
+  pre-emission Unsupported/Invariant; none may skip first and discover drift
+  later;
+- preserve the existing #4589, #4590, #4591, #2138, standalone-floor, and
+  direct-caller suites. Add a required-route env for the positive fixture and
+  a dedicated `JS2WASM_TEST_TAMPER_MULTI_PREPARED_ARRAY_LEAF` hook so the
+  late fail-closed assertion is exercised without weakening production gates.
+
+The implementation PR must update this checkpoint with measured denominators,
+artifact hashes, raw/optimized A/B results, focused-test counts, and signed
+source/bundle/issue locks. Until those records exist, `bench_array` remains a
+direct multi-source overlay and the parent issue’s bounded 38/38 census must
+not be presented as compile-once evidence.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -205,6 +205,10 @@ import {
   type MultiPreparedScalarLeafGraphSafety,
 } from "./multi-prepared-scalar-leaf.js";
 import {
+  assertMultiPreparedArrayLeafRouteCurrent,
+  planEarlyMultiPreparedArrayLeafRoute,
+} from "./multi-prepared-array-leaf.js";
+import {
   assertMultiPreparedFibonacciPairRouteCurrent,
   planEarlyMultiPreparedFunctionValueRoutes,
 } from "./multi-prepared-fibonacci-pair.js";
@@ -3594,6 +3598,30 @@ function planEarlyMultiIrOverlay(
     lateProviderOwnerUnitIds: (plan, sourceFile) => collectMultiIrLateProviderOwnerUnitIds(ctx, sourceFile, plan),
     projectLoweringPlans: (plan, selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
   });
+  const arrayStates = planEarlyMultiPreparedArrayLeafRoute({
+    active,
+    cutoverEnabled: !explicitlyDisabledEnv(process.env.JS2WASM_MULTI_PREPARED_ARRAY_CUTOVER),
+    ctx,
+    sourceFiles: multiAst.sourceFiles,
+    entryFile: multiAst.entryFile,
+    safety: () => buildMultiIrGraphSafety(ctx, multiAst.sourceFiles, multiAst.checker),
+    planSource: (sourceFile) => planMultiIrOverlaySource(ctx, multiAst, sourceFile, identityContext, undefined),
+    safeSelection: (plan, sourceFile, safety) => makeMultiIrSafeSelection(ctx, plan, sourceFile, safety),
+    lateProviderOwnerUnitIds: (plan, sourceFile) => collectMultiIrLateProviderOwnerUnitIds(ctx, sourceFile, plan),
+    prepareFunctionValueSupport: (plan, sourceFile, unitId, legacyName) =>
+      prepareTopLevelFunctionValueTargetSupport(ctx, sourceFile, plan, new Set([legacyName])).get(unitId),
+    projectLoweringPlans: (plan, selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
+  });
+  for (const [sourceFile, state] of arrayStates) {
+    if (scalarStates.has(sourceFile)) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `multi-source early routes both claimed ${sourceFile.fileName}`,
+      );
+    }
+    scalarStates.set(sourceFile, state);
+  }
   const functionValueStates = planEarlyMultiPreparedFunctionValueRoutes({
     active,
     leafCutoverEnabled: !explicitlyDisabledEnv(process.env.JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER),
@@ -3663,7 +3691,9 @@ function compileMultiIrOverlaySource(
     ),
   );
   const { overrideMap, classShapes } = plan;
-  if (early?.route?.routeKind === "fibonacci-pair") {
+  if (early?.route?.routeKind === "array") {
+    assertMultiPreparedArrayLeafRouteCurrent({ ctx, route: early.route, finalSelection: safeSelection, safety });
+  } else if (early?.route?.routeKind === "fibonacci-pair") {
     assertMultiPreparedFibonacciPairRouteCurrent({ ctx, route: early.route, finalSelection: safeSelection, safety });
   } else if (early?.route?.routeKind === "function-value") {
     assertMultiPreparedFunctionValueLeafRouteCurrent({

--- a/src/codegen/multi-prepared-array-leaf.ts
+++ b/src/codegen/multi-prepared-array-leaf.ts
@@ -1,0 +1,697 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * Narrow multi-source Prepared route for the standalone numeric array leaf.
+ *
+ * This module intentionally owns only the array proof.  Array lowering itself
+ * remains in the shared IR frontend (`array-element-lowering.ts` and
+ * `from-ast.ts`); this route merely certifies that the already-existing
+ * prepared body is the exact body that can be withdrawn from the legacy pass.
+ */
+
+import type { IrUnitId } from "../ir/identity.js";
+import type { IrIntegrationReport } from "../ir/integration.js";
+import type { IrIntegrationLoweringPlans } from "../ir/ast-lowering-plans.js";
+import { asVal } from "../ir/nodes.js";
+import { IrInvariantError } from "../ir/outcomes.js";
+import type { IrSelection } from "../ir/select.js";
+import type { Instr } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import { hasExportModifier } from "./ast-modifiers.js";
+import type { CodegenContext } from "./context/types.js";
+import { canonicalCountedPushPlanForCall, canonicalCountedPushPlanForLiteral } from "../ir/array-element-lowering.js";
+import {
+  exactAllocatedNumericCallable,
+  functionValueSupportIsCurrent,
+  hasExactNumericDeclarationSignature,
+  identifierResolvesExactly,
+  type EarlyMultiPreparedScalarLeafState,
+  type MultiPreparedFunctionValueCandidateEvidence,
+  type MultiPreparedFunctionValueSupportReceipt,
+  type MultiPreparedLeafRouteBase,
+  type MultiPreparedScalarLeafGraphSafety,
+  type MultiPreparedScalarLeafPlan,
+  type MultiPreparedScalarLeafReceipt,
+} from "./multi-prepared-scalar-leaf.js";
+import {
+  multiPreparedFunctionValueUseIsCurrent,
+  resolveMultiPreparedFunctionValueImportTarget,
+} from "./multi-prepared-function-value-import-target.js";
+import { prepareIrBodies, type PreparedIrFreeFunctionBodies } from "./ir-prepared-free-functions.js";
+import type { IrOverlayIdentityPlan } from "./ir-overlay-identity.js";
+import { collectLocalCallEdgesByIdentity } from "./ir-first-gate.js";
+
+export interface MultiPreparedArrayLeafShape {
+  readonly arrayDeclaration: ts.VariableDeclaration;
+  readonly fillLoop: ts.ForStatement;
+  readonly pushCall: ts.CallExpression;
+  readonly fillCounter: ts.VariableDeclaration;
+  readonly totalDeclaration: ts.VariableDeclaration;
+  readonly reduceLoop: ts.ForStatement;
+  readonly reduceCounter: ts.VariableDeclaration;
+  readonly reduceAssignment: ts.BinaryExpression;
+  readonly indexedAccess: ts.ElementAccessExpression;
+}
+
+export interface MultiPreparedArrayLeafCallback extends MultiPreparedFunctionValueCandidateEvidence {}
+
+export interface MultiPreparedArrayLeafRoute extends MultiPreparedLeafRouteBase {
+  readonly routeKind: "array";
+  readonly shape: MultiPreparedArrayLeafShape;
+  readonly callback?: MultiPreparedArrayLeafCallback;
+  readonly support?: MultiPreparedFunctionValueSupportReceipt;
+}
+
+interface ArrayCandidateEvidence {
+  readonly unitId: IrUnitId;
+  readonly legacyName: string;
+  readonly shape: MultiPreparedArrayLeafShape;
+  readonly callback?: MultiPreparedArrayLeafCallback;
+}
+
+interface ArrayCandidateInput<Plan extends MultiPreparedScalarLeafPlan> {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly declaration: ts.FunctionDeclaration;
+  readonly plan: Plan;
+  readonly safeSelection: IrSelection;
+  readonly safety: MultiPreparedScalarLeafGraphSafety;
+  readonly lateProviderOwnerUnitIds: ReadonlySet<IrUnitId>;
+}
+
+function numericLiteralIs(expression: ts.Expression | undefined, text: string): expression is ts.NumericLiteral {
+  return !!expression && ts.isNumericLiteral(expression) && expression.text === text;
+}
+
+function isIdentifierOf(
+  ctx: CodegenContext,
+  node: ts.Node | undefined,
+  declaration: ts.Declaration,
+): node is ts.Identifier {
+  return !!node && ts.isIdentifier(node) && identifierResolvesExactly(ctx, node, declaration);
+}
+
+function oneStatementBody(statement: ts.Statement): ts.Statement | undefined {
+  if (ts.isBlock(statement)) return statement.statements.length === 1 ? statement.statements[0] : undefined;
+  return statement;
+}
+
+function exactArrayShape(
+  ctx: CodegenContext,
+  declaration: ts.FunctionDeclaration,
+): MultiPreparedArrayLeafShape | undefined {
+  if (!declaration.body || declaration.body.statements.length !== 5) return undefined;
+  const [arrayStatement, fillStatement, totalStatement, reduceStatement, returnStatement] = declaration.body.statements;
+  if (
+    !arrayStatement ||
+    !ts.isVariableStatement(arrayStatement) ||
+    arrayStatement.declarationList.flags !== ts.NodeFlags.Const ||
+    arrayStatement.declarationList.declarations.length !== 1
+  ) {
+    return undefined;
+  }
+  const arrayDeclaration = arrayStatement.declarationList.declarations[0]!;
+  if (
+    !ts.isIdentifier(arrayDeclaration.name) ||
+    !arrayDeclaration.type ||
+    !ts.isArrayTypeNode(arrayDeclaration.type) ||
+    arrayDeclaration.type.elementType.kind !== ts.SyntaxKind.NumberKeyword ||
+    !arrayDeclaration.initializer ||
+    !ts.isArrayLiteralExpression(arrayDeclaration.initializer) ||
+    arrayDeclaration.initializer.elements.length !== 0
+  ) {
+    return undefined;
+  }
+  const fillLoop = fillStatement && ts.isForStatement(fillStatement) ? fillStatement : undefined;
+  if (!fillLoop) return undefined;
+  const fillInit = fillLoop.initializer;
+  if (
+    !fillInit ||
+    !ts.isVariableDeclarationList(fillInit) ||
+    fillInit.flags !== ts.NodeFlags.Let ||
+    fillInit.declarations.length !== 1
+  ) {
+    return undefined;
+  }
+  const fillCounter = fillInit.declarations[0]!;
+  if (!ts.isIdentifier(fillCounter.name) || !numericLiteralIs(fillCounter.initializer, "0")) return undefined;
+  if (
+    !fillLoop.condition ||
+    !ts.isBinaryExpression(fillLoop.condition) ||
+    fillLoop.condition.operatorToken.kind !== ts.SyntaxKind.LessThanToken ||
+    !isIdentifierOf(ctx, fillLoop.condition.left, fillCounter) ||
+    !ts.isNumericLiteral(fillLoop.condition.right) ||
+    !Number.isSafeInteger(Number(fillLoop.condition.right.text)) ||
+    Number(fillLoop.condition.right.text) <= 0
+  ) {
+    return undefined;
+  }
+  if (
+    !fillLoop.incrementor ||
+    !ts.isPostfixUnaryExpression(fillLoop.incrementor) ||
+    fillLoop.incrementor.operator !== ts.SyntaxKind.PlusPlusToken ||
+    !isIdentifierOf(ctx, fillLoop.incrementor.operand, fillCounter)
+  ) {
+    return undefined;
+  }
+  const pushStatement = oneStatementBody(fillLoop.statement);
+  const pushCall = pushStatement && ts.isExpressionStatement(pushStatement) ? pushStatement.expression : undefined;
+  if (
+    !pushCall ||
+    !ts.isCallExpression(pushCall) ||
+    pushCall.arguments.length !== 1 ||
+    ts.isSpreadElement(pushCall.arguments[0]!) ||
+    !ts.isPropertyAccessExpression(pushCall.expression) ||
+    pushCall.expression.name.text !== "push" ||
+    !isIdentifierOf(ctx, pushCall.expression.expression, arrayDeclaration) ||
+    !isIdentifierOf(ctx, pushCall.arguments[0], fillCounter)
+  ) {
+    return undefined;
+  }
+  const pushPlan = canonicalCountedPushPlanForLiteral(arrayDeclaration.initializer, ctx.checker);
+  if (!pushPlan || pushPlan.pushCall !== pushCall || pushPlan.capacity !== Number(fillLoop.condition.right.text)) {
+    return undefined;
+  }
+
+  if (
+    !totalStatement ||
+    !ts.isVariableStatement(totalStatement) ||
+    totalStatement.declarationList.flags !== ts.NodeFlags.Let ||
+    totalStatement.declarationList.declarations.length !== 1
+  ) {
+    return undefined;
+  }
+  const totalDeclaration = totalStatement.declarationList.declarations[0]!;
+  if (!ts.isIdentifier(totalDeclaration.name) || !numericLiteralIs(totalDeclaration.initializer, "0")) return undefined;
+
+  const reduceLoop = reduceStatement && ts.isForStatement(reduceStatement) ? reduceStatement : undefined;
+  if (!reduceLoop) return undefined;
+  const reduceInit = reduceLoop.initializer;
+  if (
+    !reduceInit ||
+    !ts.isVariableDeclarationList(reduceInit) ||
+    reduceInit.flags !== ts.NodeFlags.Let ||
+    reduceInit.declarations.length !== 1
+  ) {
+    return undefined;
+  }
+  const reduceCounter = reduceInit.declarations[0]!;
+  if (!ts.isIdentifier(reduceCounter.name) || !numericLiteralIs(reduceCounter.initializer, "0")) return undefined;
+  if (
+    !reduceLoop.condition ||
+    !ts.isBinaryExpression(reduceLoop.condition) ||
+    reduceLoop.condition.operatorToken.kind !== ts.SyntaxKind.LessThanToken ||
+    !isIdentifierOf(ctx, reduceLoop.condition.left, reduceCounter) ||
+    !ts.isPropertyAccessExpression(reduceLoop.condition.right) ||
+    reduceLoop.condition.right.name.text !== "length" ||
+    !isIdentifierOf(ctx, reduceLoop.condition.right.expression, arrayDeclaration)
+  ) {
+    return undefined;
+  }
+  if (
+    !reduceLoop.incrementor ||
+    !ts.isPostfixUnaryExpression(reduceLoop.incrementor) ||
+    reduceLoop.incrementor.operator !== ts.SyntaxKind.PlusPlusToken ||
+    !isIdentifierOf(ctx, reduceLoop.incrementor.operand, reduceCounter)
+  ) {
+    return undefined;
+  }
+  const reduceStatementBody = oneStatementBody(reduceLoop.statement);
+  const reduceExpression =
+    reduceStatementBody && ts.isExpressionStatement(reduceStatementBody) ? reduceStatementBody.expression : undefined;
+  const reduceAssignment = reduceExpression && ts.isBinaryExpression(reduceExpression) ? reduceExpression : undefined;
+  if (
+    !reduceAssignment ||
+    reduceAssignment.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+    !isIdentifierOf(ctx, reduceAssignment.left, totalDeclaration) ||
+    !ts.isBinaryExpression(reduceAssignment.right) ||
+    reduceAssignment.right.operatorToken.kind !== ts.SyntaxKind.PlusToken ||
+    !isIdentifierOf(ctx, reduceAssignment.right.left, totalDeclaration) ||
+    !ts.isElementAccessExpression(reduceAssignment.right.right) ||
+    !isIdentifierOf(ctx, reduceAssignment.right.right.expression, arrayDeclaration) ||
+    reduceAssignment.right.right.argumentExpression === undefined ||
+    !isIdentifierOf(ctx, reduceAssignment.right.right.argumentExpression, reduceCounter)
+  ) {
+    return undefined;
+  }
+  const indexedAccess = reduceAssignment.right.right;
+  const reducePlan = canonicalCountedPushPlanForCall(pushCall, ctx.checker);
+  if (!reducePlan || reducePlan.pushCall !== pushCall) {
+    // The helper is intentionally called on the push site above; this branch
+    // documents that the count proof is shared, while reduction uses length.
+    return undefined;
+  }
+  if (
+    !returnStatement ||
+    !ts.isReturnStatement(returnStatement) ||
+    !isIdentifierOf(ctx, returnStatement.expression, totalDeclaration)
+  ) {
+    return undefined;
+  }
+  return {
+    arrayDeclaration,
+    fillLoop,
+    pushCall,
+    fillCounter,
+    totalDeclaration,
+    reduceLoop,
+    reduceCounter,
+    reduceAssignment,
+    indexedAccess,
+  };
+}
+
+function exactLocalSingleton(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  unitId: IrUnitId,
+  plan: IrOverlayIdentityPlan,
+): boolean {
+  const edges = collectLocalCallEdgesByIdentity(sourceFile, plan.identityContext);
+  if ((edges.callees.get(unitId)?.size ?? 0) !== 0 || edges.calleesFromUnownedCallers.has(unitId)) return false;
+  return ![...edges.callees].some(([caller, callees]) => caller !== unitId && callees.has(unitId));
+}
+
+function collectCallback(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  declaration: ts.FunctionDeclaration,
+  identityPlan: IrOverlayIdentityPlan,
+): MultiPreparedArrayLeafCallback | undefined {
+  const refs: ts.Identifier[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isIdentifier(node) &&
+      node !== declaration.name &&
+      identifierResolvesExactly(ctx, node, declaration) &&
+      !(ts.isCallExpression(node.parent) && node.parent.expression === node)
+    ) {
+      refs.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (refs.length === 0) return undefined;
+  if (refs.length !== 1) return undefined;
+  const valueIdentifier = refs[0]!;
+  const importedCall = valueIdentifier.parent;
+  if (
+    !ts.isCallExpression(importedCall) ||
+    importedCall.arguments.filter((arg) => arg === valueIdentifier).length !== 1
+  ) {
+    return undefined;
+  }
+  let owner: ts.Node | undefined = importedCall.parent;
+  while (owner && owner !== sourceFile && !ts.isFunctionLike(owner)) owner = owner.parent;
+  if (!owner || !ts.isFunctionDeclaration(owner) || owner.parent !== sourceFile || !owner.name) return undefined;
+  const legacyOwnerUnitId = identityPlan.identityContext.unitIdByDeclaration.get(owner);
+  const unitId = identityPlan.identityContext.unitIdByDeclaration.get(declaration);
+  const importedTarget = ts.isIdentifier(importedCall.expression)
+    ? resolveMultiPreparedFunctionValueImportTarget({
+        oracle: ctx.oracle,
+        sourceFile,
+        callee: importedCall.expression,
+        identityContext: identityPlan.identityContext,
+      })
+    : undefined;
+  const importedTargetUnitId = importedTarget
+    ? identityPlan.identityContext.unitIdByDeclaration.get(importedTarget)
+    : undefined;
+  const ownerTerminal = legacyOwnerUnitId
+    ? identityPlan.identityContext.terminalByUnitId.get(legacyOwnerUnitId)
+    : undefined;
+  if (
+    !unitId ||
+    !legacyOwnerUnitId ||
+    legacyOwnerUnitId === unitId ||
+    !ownerTerminal ||
+    ownerTerminal.terminalOwnerId !== legacyOwnerUnitId ||
+    ownerTerminal.observedKind !== "function" ||
+    !importedTarget ||
+    importedTarget.name?.text !== "addBenchCard" ||
+    !importedTargetUnitId
+  ) {
+    return undefined;
+  }
+  return {
+    legacyName: declaration.name!.text,
+    unitId,
+    valueIdentifier,
+    legacyOwnerUnitId,
+    legacyOwnerName: owner.name.text,
+    importedCall,
+    importedTargetUnitId,
+  };
+}
+
+export function collectMultiPreparedArrayLeafCandidates(
+  ctx: CodegenContext,
+  sourceFiles: readonly ts.SourceFile[],
+): readonly ts.FunctionDeclaration[] {
+  return sourceFiles.flatMap((sourceFile) =>
+    sourceFile.statements.filter(
+      (statement): statement is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(statement) &&
+        hasExportModifier(statement) &&
+        hasExactNumericDeclarationSignature(statement) &&
+        statement.parameters.length === 0 &&
+        exactArrayShape(ctx, statement) !== undefined,
+    ),
+  );
+}
+
+function resolveArrayCandidate<Plan extends MultiPreparedScalarLeafPlan>(
+  input: ArrayCandidateInput<Plan>,
+): ArrayCandidateEvidence | undefined {
+  const { ctx, declaration, lateProviderOwnerUnitIds, plan, safeSelection, safety, sourceFile } = input;
+  if (
+    !ctx.standalone ||
+    ctx.fast ||
+    ctx.wasi ||
+    declaration.parent !== sourceFile ||
+    !declaration.name ||
+    !declaration.body
+  ) {
+    return undefined;
+  }
+  const shape = exactArrayShape(ctx, declaration);
+  if (!shape) return undefined;
+  const legacyName = declaration.name.text;
+  const unitId = plan.identityPlan.identityContext.unitIdByDeclaration.get(declaration);
+  const terminal = unitId ? plan.identityPlan.identityContext.terminalByUnitId.get(unitId) : undefined;
+  const claim = unitId ? plan.functionClaimsByUnitId.get(unitId) : undefined;
+  const override = unitId ? plan.overrideMapByUnitId.get(unitId) : undefined;
+  const callback = collectCallback(ctx, sourceFile, declaration, plan.identityPlan);
+  const foreignLateProvider = unitId !== undefined && lateProviderOwnerUnitIds.has(unitId) && !callback;
+  if (
+    !unitId ||
+    !terminal ||
+    terminal.kind !== "top-level-function" ||
+    terminal.observedKind !== "function" ||
+    terminal.terminalOwnerId !== unitId ||
+    plan.identityPlan.identityContext.declarationByUnitId.get(unitId) !== declaration ||
+    claim?.declaration !== declaration ||
+    claim.legacyName !== legacyName ||
+    !safeSelection.funcs.has(legacyName) ||
+    !plan.identityPlan.safeFunctionUnitIds.has(unitId) ||
+    !override ||
+    override.params.length !== 0 ||
+    override.returnType === null ||
+    asVal(override.returnType)?.kind !== "f64" ||
+    safety.collisions.has(legacyName) ||
+    safety.crossFileFunctionNames.has(legacyName) ||
+    safety.importAliasNames.has(legacyName) ||
+    safety.occupiedFunctionNameCounts.get(legacyName) !== 1 ||
+    safety.occupiedFunctionKeys.some((key) => key.startsWith(`${legacyName}$`)) ||
+    ctx.liveFuncBindingGlobals?.has(legacyName) === true ||
+    foreignLateProvider ||
+    plan.classShapes.size !== 0 ||
+    plan.classShapesById.size !== 0 ||
+    !exactLocalSingleton(ctx, sourceFile, unitId, plan.identityPlan) ||
+    exactAllocatedNumericCallable(ctx, unitId, legacyName, 0, true) === undefined
+  ) {
+    return undefined;
+  }
+  // A non-empty reference set which is not the exact imported callback is not
+  // safe to prepare. `undefined` is ambiguous, so distinguish it by counting
+  // the references again only for this narrow candidate.
+  if (callback === undefined) {
+    let references = 0;
+    const visit = (node: ts.Node): void => {
+      if (ts.isIdentifier(node) && node !== declaration.name && identifierResolvesExactly(ctx, node, declaration))
+        references++;
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    if (references !== 0) return undefined;
+  }
+  return { unitId, legacyName, shape, ...(callback ? { callback } : {}) };
+}
+
+function exactWithdrawal(
+  preparedReport: IrIntegrationReport,
+  prepared: PreparedIrFreeFunctionBodies,
+  unitId: IrUnitId,
+  legacyName: string,
+): boolean {
+  const evidence = (preparedReport.terminalEvidence ?? [])[0];
+  return (
+    prepared.skipBodies.size === 0 &&
+    prepared.preserveBodies.size === 0 &&
+    prepared.completedBodies.size === 0 &&
+    prepared.requestedSkipProjection.entries.length === 0 &&
+    preparedReport.compiled.length === 0 &&
+    (preparedReport.compiledArtifactEvidence?.length ?? 0) === 0 &&
+    (preparedReport.syntheticCompiledArtifacts?.length ?? 0) === 0 &&
+    ((preparedReport.errors.length === 0 && (preparedReport.terminalEvidence?.length ?? 0) === 0) ||
+      (preparedReport.errors.length === 1 &&
+        preparedReport.terminalEvidence?.length === 1 &&
+        evidence?.kind === "failed" &&
+        evidence.unitId === unitId &&
+        evidence.legacyName === legacyName &&
+        evidence.error === preparedReport.errors[0] &&
+        evidence.error.outcome.kind === "unsupported"))
+  );
+}
+
+export function tryPrepareMultiSourceArrayLeaf<Plan extends MultiPreparedScalarLeafPlan>(input: {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly declaration: ts.FunctionDeclaration;
+  readonly plan: Plan;
+  readonly candidate: ArrayCandidateEvidence;
+  readonly projectLoweringPlans: (selection: IrSelection) => IrIntegrationLoweringPlans;
+  readonly prepareFunctionValueSupport?: (
+    unitId: IrUnitId,
+    legacyName: string,
+  ) => MultiPreparedFunctionValueSupportReceipt | undefined;
+}): MultiPreparedArrayLeafRoute | undefined {
+  const { candidate, ctx, declaration, plan, projectLoweringPlans, sourceFile } = input;
+  const support = candidate.callback
+    ? input.prepareFunctionValueSupport?.(candidate.unitId, candidate.legacyName)
+    : undefined;
+  if (candidate.callback && (!support || !functionValueSupportIsCurrent(ctx, candidate.callback, support, true)))
+    return undefined;
+  const preparedSelection: IrSelection = {
+    funcs: new Set([candidate.legacyName]),
+    classMembers: new Set(),
+    classMemberUnitIds: new Set(),
+    moduleInit: undefined,
+  };
+  const prepared = prepareIrBodies({
+    ctx,
+    sourceFile,
+    selection: preparedSelection,
+    identityPlan: plan.identityPlan,
+    functionClaimsByUnitId: plan.functionClaimsByUnitId,
+    overrideMap: plan.overrideMap,
+    classShapes: plan.classShapes,
+    classShapesById: plan.classShapesById,
+    projectLoweringPlans,
+  });
+  if (prepared.classMembers || prepared.moduleInit || prepared.implicitConstructorUnitIds.size !== 0) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `array leaf ${candidate.unitId} produced foreign routing`,
+    );
+  }
+  if (prepared.freeFunctions.skipBodies.size === 0) {
+    if (exactWithdrawal(prepared.report, prepared.freeFunctions, candidate.unitId, candidate.legacyName))
+      return undefined;
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `array leaf ${candidate.unitId} did not withdraw`,
+    );
+  }
+  const requested = prepared.freeFunctions.requestedSkipProjection.entries;
+  const evidence = (prepared.report.terminalEvidence ?? [])[0];
+  const artifact = (prepared.report.compiledArtifactEvidence ?? [])[0];
+  if (
+    requested.length !== 1 ||
+    requested[0]?.unitId !== candidate.unitId ||
+    requested[0]?.legacyName !== candidate.legacyName ||
+    prepared.freeFunctions.skipBodies.size !== 1 ||
+    !prepared.freeFunctions.skipBodies.has(candidate.legacyName) ||
+    prepared.freeFunctions.completedBodies.size !== 1 ||
+    !prepared.freeFunctions.completedBodies.has(candidate.legacyName) ||
+    (prepared.report.terminalEvidence?.length ?? 0) !== 1 ||
+    evidence?.kind !== "patched" ||
+    evidence.unitId !== candidate.unitId ||
+    evidence.legacyName !== candidate.legacyName ||
+    evidence.preparedComponentId === undefined ||
+    prepared.report.errors.length !== 0 ||
+    prepared.report.compiled.length !== 1 ||
+    prepared.report.compiled[0] !== candidate.legacyName ||
+    (prepared.report.compiledArtifactEvidence?.length ?? 0) !== 1 ||
+    artifact?.artifactUnitId !== candidate.unitId ||
+    artifact?.terminalOwnerUnitId !== candidate.unitId ||
+    artifact?.name !== candidate.legacyName ||
+    artifact?.preparedComponentId !== evidence.preparedComponentId ||
+    prepared.freeFunctions.preserveBodies.size !== 1 ||
+    !prepared.freeFunctions.preserveBodies.has(candidate.legacyName)
+  ) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `array leaf ${candidate.unitId} produced non-exact receipt`,
+    );
+  }
+  const allocated = exactAllocatedNumericCallable(ctx, candidate.unitId, candidate.legacyName, 0, false);
+  if (!allocated || allocated.func.body.length === 0) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `array leaf ${candidate.unitId} lost prepared body`,
+    );
+  }
+  return Object.freeze({
+    routeKind: "array",
+    sourceFile,
+    declaration,
+    unitId: candidate.unitId,
+    legacyName: candidate.legacyName,
+    preparedSelection,
+    preparedReport: prepared.report,
+    preparedFreeFunctions: prepared.freeFunctions,
+    receipt: {
+      kind: "prepared",
+      unitId: candidate.unitId,
+      legacyName: candidate.legacyName,
+      preparedComponentId: evidence.preparedComponentId,
+    } satisfies MultiPreparedScalarLeafReceipt,
+    allocatedFunction: allocated.func,
+    preparedBody: allocated.func.body,
+    preparedInstructions: Object.freeze([...allocated.func.body]) as readonly Instr[],
+    shape: candidate.shape,
+    ...(candidate.callback ? { callback: candidate.callback } : {}),
+    ...(support ? { support } : {}),
+  });
+}
+
+export function planEarlyMultiPreparedArrayLeafRoute<Plan extends MultiPreparedScalarLeafPlan>(input: {
+  readonly active: boolean;
+  readonly cutoverEnabled: boolean;
+  readonly ctx: CodegenContext;
+  readonly sourceFiles: readonly ts.SourceFile[];
+  readonly entryFile: ts.SourceFile;
+  readonly safety: () => MultiPreparedScalarLeafGraphSafety;
+  readonly planSource: (sourceFile: ts.SourceFile) => Plan;
+  readonly safeSelection: (
+    plan: Plan,
+    sourceFile: ts.SourceFile,
+    safety: MultiPreparedScalarLeafGraphSafety,
+  ) => IrSelection;
+  readonly lateProviderOwnerUnitIds: (plan: Plan, sourceFile: ts.SourceFile) => ReadonlySet<IrUnitId>;
+  readonly prepareFunctionValueSupport?: (
+    plan: Plan,
+    sourceFile: ts.SourceFile,
+    unitId: IrUnitId,
+    legacyName: string,
+  ) => MultiPreparedFunctionValueSupportReceipt | undefined;
+  readonly projectLoweringPlans: (plan: Plan, selection: IrSelection) => IrIntegrationLoweringPlans;
+}): Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<Plan>> {
+  const states = new Map<ts.SourceFile, EarlyMultiPreparedScalarLeafState<Plan>>();
+  if (!input.active) return states;
+  const candidates = collectMultiPreparedArrayLeafCandidates(input.ctx, input.sourceFiles);
+  if (candidates.length === 0) return states;
+  const safety = input.safety();
+  const eligible: Array<{
+    declaration: ts.FunctionDeclaration;
+    sourceFile: ts.SourceFile;
+    plan: Plan;
+    candidate: ArrayCandidateEvidence;
+  }> = [];
+  for (const declaration of candidates) {
+    const sourceFile = declaration.getSourceFile();
+    const state = states.get(sourceFile) ?? { plan: input.planSource(sourceFile), skippedFunctionUnitIds: new Set() };
+    states.set(sourceFile, state);
+    const candidate = resolveArrayCandidate({
+      ctx: input.ctx,
+      sourceFile,
+      declaration,
+      plan: state.plan,
+      safeSelection: input.safeSelection(state.plan, sourceFile, safety),
+      safety,
+      lateProviderOwnerUnitIds: input.lateProviderOwnerUnitIds(state.plan, sourceFile),
+    });
+    if (!candidate && process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_ARRAY_LEAF === "1") {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `required multi-source array leaf candidate rejected: ${declaration.name?.text ?? "<unnamed>"}`,
+      );
+    }
+    if (candidate) eligible.push({ declaration, sourceFile, plan: state.plan, candidate });
+  }
+  const exact = eligible.length === 1 ? eligible[0] : undefined;
+  if (!input.cutoverEnabled || !exact || exact.sourceFile !== input.entryFile) return states;
+  const route = tryPrepareMultiSourceArrayLeaf({
+    ctx: input.ctx,
+    sourceFile: exact.sourceFile,
+    declaration: exact.declaration,
+    plan: exact.plan,
+    candidate: exact.candidate,
+    prepareFunctionValueSupport: exact.candidate.callback
+      ? (unitId, legacyName) => input.prepareFunctionValueSupport?.(exact.plan, exact.sourceFile, unitId, legacyName)
+      : undefined,
+    projectLoweringPlans: (selection) => input.projectLoweringPlans(exact.plan, selection),
+  });
+  if (!route && process.env.JS2WASM_TEST_REQUIRE_MULTI_PREPARED_ARRAY_LEAF === "1") {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `required multi-source array leaf route did not prepare ${exact.candidate.legacyName}`,
+    );
+  }
+  if (route) states.set(exact.sourceFile, { plan: exact.plan, route, skippedFunctionUnitIds: new Set() });
+  return states;
+}
+
+export function assertMultiPreparedArrayLeafRouteCurrent(input: {
+  readonly ctx: CodegenContext;
+  readonly route: MultiPreparedArrayLeafRoute;
+  readonly finalSelection: IrSelection;
+  readonly safety: MultiPreparedScalarLeafGraphSafety;
+}): void {
+  const { ctx, route, finalSelection, safety } = input;
+  if (process.env.JS2WASM_TEST_TAMPER_MULTI_PREPARED_ARRAY_LEAF?.split(",").includes(route.legacyName)) {
+    route.allocatedFunction.name = `${route.legacyName}$tampered`;
+  }
+  const allocated = exactAllocatedNumericCallable(ctx, route.unitId, route.legacyName, 0, false);
+  const shape = exactArrayShape(ctx, route.declaration);
+  if (
+    !finalSelection.funcs.has(route.legacyName) ||
+    safety.collisions.has(route.legacyName) ||
+    safety.crossFileFunctionNames.has(route.legacyName) ||
+    safety.importAliasNames.has(route.legacyName) ||
+    !allocated ||
+    allocated.func !== route.allocatedFunction ||
+    allocated.func.body !== route.preparedBody ||
+    allocated.func.body.length !== route.preparedInstructions.length ||
+    allocated.func.body.some((instruction, index) => instruction !== route.preparedInstructions[index]) ||
+    route.receipt.kind !== "prepared" ||
+    !route.receipt.preparedComponentId ||
+    !shape ||
+    shape.arrayDeclaration !== route.shape.arrayDeclaration ||
+    shape.fillLoop !== route.shape.fillLoop ||
+    shape.pushCall !== route.shape.pushCall ||
+    shape.reduceLoop !== route.shape.reduceLoop ||
+    shape.reduceAssignment !== route.shape.reduceAssignment ||
+    (route.callback !== undefined &&
+      (!route.support ||
+        !functionValueSupportIsCurrent(ctx, route.callback, route.support, false) ||
+        !multiPreparedFunctionValueUseIsCurrent(ctx.oracle, ctx.irPlanningIdentityContext, {
+          sourceFile: route.sourceFile,
+          declaration: route.declaration,
+          ...route.callback,
+        })))
+  ) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `array leaf ${route.unitId} drifted after certification`,
+    );
+  }
+}

--- a/src/codegen/multi-prepared-scalar-leaf.ts
+++ b/src/codegen/multi-prepared-scalar-leaf.ts
@@ -261,7 +261,8 @@ export type MultiPreparedScalarLeafReceipt =
       readonly legacyName: string;
     };
 
-interface MultiPreparedLeafRouteBase {
+/** Common immutable prepared-body receipt shared by the narrow multi-source routes. */
+export interface MultiPreparedLeafRouteBase {
   readonly sourceFile: ts.SourceFile;
   readonly declaration: ts.FunctionDeclaration;
   readonly unitId: IrUnitId;
@@ -306,6 +307,7 @@ export interface MultiPreparedFunctionValueLeafRoute extends MultiPreparedLeafRo
 export type MultiPreparedEarlyLeafRoute =
   | MultiPreparedScalarLeafRoute
   | MultiPreparedFunctionValueLeafRoute
+  | import("./multi-prepared-array-leaf.js").MultiPreparedArrayLeafRoute
   | import("./multi-prepared-fibonacci-pair.js").MultiPreparedFibonacciPairRoute;
 
 function invariant(stage: "resolve" | "patch", detail: string): never {

--- a/tests/issue-3518-bench-array-prepared-cutover.test.ts
+++ b/tests/issue-3518-bench-array-prepared-cutover.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { compileMulti, compileProject, type CompileOptions, type CompileResult } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+const ENTRY = resolve(import.meta.dirname, "../website/playground/examples/benchmarks/array.ts");
+const HELPERS = resolve(import.meta.dirname, "../website/playground/examples/benchmarks/helpers.ts");
+const ARRAY_SOURCE = readFileSync(ENTRY, "utf8");
+const HELPERS_SOURCE = readFileSync(HELPERS, "utf8");
+
+const CUTOVER = "JS2WASM_MULTI_PREPARED_ARRAY_CUTOVER";
+const DIRECT_POISON = "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY";
+const REQUIRE_ROUTE = "JS2WASM_TEST_REQUIRE_MULTI_PREPARED_ARRAY_LEAF";
+const TAMPER = "JS2WASM_TEST_TAMPER_MULTI_PREPARED_ARRAY_LEAF";
+const EXPECTED_RUNTIME = 49_995_000;
+
+function expectSuccess(result: CompileResult, label: string): void {
+  expect(
+    result.success,
+    `${label} failed:\n${result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")}`,
+  ).toBe(true);
+}
+
+async function compileArray(cutover: boolean | undefined, options: CompileOptions = {}): Promise<CompileResult> {
+  if (cutover !== undefined) vi.stubEnv(CUTOVER, cutover ? "1" : "0");
+  return compileProject(ENTRY, {
+    experimentalIR: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+    emitWat: true,
+    ...options,
+  });
+}
+
+function wasmSurface(binary: Uint8Array) {
+  const module = new WebAssembly.Module(binary);
+  return {
+    imports: WebAssembly.Module.imports(module),
+    exports: WebAssembly.Module.exports(module),
+  };
+}
+
+function targetLegacyRows(result: CompileResult) {
+  return result.irBodyRouteAudit?.legacyEntries.filter((row) => row.bodyName === "bench_array") ?? [];
+}
+
+function targetOutcome(result: CompileResult) {
+  return result.irOutcomes?.find((outcome) => outcome.displayName === "bench_array");
+}
+
+function expectDirectPoison(result: CompileResult): void {
+  expect(result.success).toBe(false);
+  expect(result.errors.map((error) => error.message).join("\n")).toContain(
+    "injected direct function-body poison: bench_array",
+  );
+  expect(targetLegacyRows(result).map((row) => row.entryPoint)).toContain("compileFunctionBody");
+}
+
+async function arrayRuntime(result: CompileResult): Promise<number> {
+  const instance = await instantiateWithRuntime(result);
+  return (instance.exports.bench_array as () => number)();
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("#3518 prepared bench_array cutover", () => {
+  it("is default-on, bypasses the poisoned direct body, and restores it with the kill switch", async () => {
+    vi.stubEnv(REQUIRE_ROUTE, "1");
+    vi.stubEnv(DIRECT_POISON, "bench_array");
+    const prepared = await compileArray(undefined);
+    expectSuccess(prepared, "default-on Prepared array compile");
+    expect(targetLegacyRows(prepared)).toEqual([]);
+    const outcome = targetOutcome(prepared);
+    expect(outcome).toMatchObject({
+      kind: "emitted",
+      irBodyEmitted: true,
+      legacyBodyEmitted: false,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irBodyRouteAudit?.dispositions.find((row) => row.unitId === outcome?.unitId)?.disposition).toBe(
+      "terminal-ir",
+    );
+
+    vi.stubEnv(CUTOVER, "0");
+    const direct = await compileArray(false);
+    expectDirectPoison(direct);
+    expect(targetLegacyRows(direct).map((row) => row.entryPoint)).toEqual(["compileFunctionBody"]);
+  });
+
+  it("preserves the external surface and runtime value across the Prepared/direct lanes", async () => {
+    const prepared = await compileArray(true);
+    const direct = await compileArray(false);
+    expectSuccess(prepared, "Prepared array compile");
+    expectSuccess(direct, "direct array control");
+
+    expect(targetLegacyRows(prepared)).toEqual([]);
+    expect(
+      targetLegacyRows(direct)
+        .map((row) => row.entryPoint)
+        .sort(),
+    ).toEqual(["compileFunctionBody", "compileStatement"]);
+    expect(targetOutcome(prepared)).toMatchObject({
+      irBodyEmitted: true,
+      legacyBodyEmitted: false,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(targetOutcome(direct)).toMatchObject({
+      irBodyEmitted: true,
+      legacyBodyEmitted: true,
+    });
+    expect(targetOutcome(prepared)?.unitId).toBe(targetOutcome(direct)?.unitId);
+    expect(direct.irBodyRouteAudit?.legacyEntries.filter((row) => row.bodyName !== "bench_array")).toEqual(
+      prepared.irBodyRouteAudit?.legacyEntries,
+    );
+
+    expect(prepared.dts).toBe(direct.dts);
+    expect(prepared.importsHelper).toBe(direct.importsHelper);
+    expect(prepared.imports).toEqual(direct.imports);
+    expect(prepared.stringPool).toEqual(direct.stringPool);
+    expect(wasmSurface(prepared.binary)).toEqual(wasmSurface(direct.binary));
+    await expect(arrayRuntime(prepared)).resolves.toBe(EXPECTED_RUNTIME);
+    await expect(arrayRuntime(direct)).resolves.toBe(EXPECTED_RUNTIME);
+  });
+
+  it("fails closed when the certified Prepared body drifts", async () => {
+    vi.stubEnv(REQUIRE_ROUTE, "1");
+    vi.stubEnv(TAMPER, "bench_array");
+    const result = await compileArray(true);
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain("drifted after certification");
+    expect(targetLegacyRows(result)).toEqual([]);
+  });
+
+  it("keeps an exact-shape mutation on the direct path", async () => {
+    vi.stubEnv(CUTOVER, "1");
+    vi.stubEnv(DIRECT_POISON, "bench_array");
+    const mutated = ARRAY_SOURCE.replace("i < 10000", "i <= 10000");
+    expect(mutated).not.toBe(ARRAY_SOURCE);
+    const result = await compileMulti({ "helpers.ts": HELPERS_SOURCE, "array.ts": mutated }, "array.ts", {
+      experimentalIR: true,
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    expectDirectPoison(result);
+  });
+
+  it("keeps the array leaf direct-owned outside the standalone Prepared lane", async () => {
+    vi.stubEnv(DIRECT_POISON, "bench_array");
+    expectDirectPoison(await compileArray(true, { fast: true }));
+  });
+});


### PR DESCRIPTION
## Summary

Implements the next bounded slice of **IR-only default and direct front-end retirement** (issue 3518, "IR-only default and direct front-end retirement"):

- Adds a checker/ABI-proven multi-source Prepared route for the standalone `bench_array` numeric array leaf.
- Preserves the existing counted fill, vector/array element, bounds, and reduction lowering, plus the imported `addBenchCard` callback support receipt.
- Keeps the direct route behind `JS2WASM_MULTI_PREPARED_ARRAY_CUTOVER=0`.
- Adds poison, kill-switch, tamper, exact-shape mutation, runtime parity, and external-surface tests.

## Verification

- `pnpm run typecheck` PASS
- Prettier, Biome, IR-layering, oracle-ratchet, LOC/function budgets PASS
- `tests/issue-3518-bench-array-prepared-cutover.test.ts`: 5/5 PASS under the strict load gate (10 cores, limit 8, launch load 4.375)
- Signed commit: `ddae721796a2c7bca75049c668c27355bd56e003`

The frozen composite and unrelated worktrees are untouched.

Issue: **3518 — IR-only default and direct front-end retirement**.
