### PR TITLE
fix(closures): keep recursive mutable captures type-correct

### DIFF
--- a/plan/issues/4525-moment-closure-capture-i32-ref-validation.md
+++ b/plan/issues/4525-moment-closure-capture-i32-ref-validation.md
@@ -54,6 +54,22 @@ should first check whether the #4384 branch already fixes the capture typing
 name-remapped capture sources", "captures written after a declaration use a
 live cell").
 
+## Fix checkpoint (2026-08-24)
+
+The validation failure was caused by the generic recursive-function-value
+materializer introduced by the ReactDOM closure work. While an outer closure
+was emitting its capture list, materializing an earlier sibling could promote
+the later mutable binding into a ref-cell and update `localMap`. The capture
+descriptor still held the old raw `i32` slot, so `pushCaptureCell` read that slot
+even though the closure field now required the live cell reference.
+
+`pushCaptureCell` now resolves the mapped slot only when its declared type is
+the expected ref-cell type, preserving the descriptor slot for ordinary and
+stale-map cases. A focused regression test compiles the pinned Moment entry
+module and validates the resulting Wasm. The six selected upstream modules now
+all emit and validate (6/6); the runtime slice remains 4/10 because six tests
+still hit the separate null-cell/runtime-body issue tracked by #4384.
+
 ## Reproduction
 
 ```bash
@@ -97,7 +113,9 @@ node --import tsx tests/dogfood/moment-upstream-suite.mjs --json
 
 ## Acceptance criteria
 
-- [ ] All six generated Moment modules validate on main.
-- [ ] The reduced closure-capture shape is a committed regression test.
-- [ ] Moment upstream slice pass count recorded in this file (Node 10/10 must
+- [x] All six generated Moment modules validate on main.
+- [ ] The reduced closure-capture shape is a committed regression test. The
+      pinned entry-module validation test is in place; a smaller source-only
+      fixture can follow if the package compile cost becomes a concern.
+- [x] Moment upstream slice pass count recorded in this file (Node 10/10 must
       hold; Wasm count depends on #4384's unmerged resolver fix).

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -1145,7 +1145,20 @@ function findUnboxedCaptureLocal(
  */
 function pushCaptureCell(ctx: CodegenContext, fctx: FunctionContext, cap: ArrowClosureCapture): void {
   const boxed = fctx.boxedCaptures?.get(cap.name);
-  const boxedLocalIdx = cap.localIdx;
+  // A recursive sibling can materialize this binding while an outer closure's
+  // construction is still walking its capture list. That promotion updates
+  // `boxedCaptures` and `localMap`, but the capture descriptor's `localIdx`
+  // was computed before the promotion and still names the raw value slot.
+  // Prefer the live mapped cell only when its type agrees with the box; keep
+  // the descriptor slot for ordinary captures and stale-map cases.
+  const mappedLocalIdx = fctx.localMap.get(cap.name);
+  const mappedType = mappedLocalIdx === undefined ? undefined : getLocalType(fctx, mappedLocalIdx);
+  const mappedIsCell =
+    boxed !== undefined &&
+    mappedType !== undefined &&
+    (mappedType.kind === "ref" || mappedType.kind === "ref_null") &&
+    mappedType.typeIdx === boxed.refCellTypeIdx;
+  const boxedLocalIdx = mappedIsCell ? mappedLocalIdx! : cap.localIdx;
   const boxedType = getLocalType(fctx, boxedLocalIdx);
   const valueType = boxed?.valType;
   const rawLocalIdx = valueType ? findUnboxedCaptureLocal(fctx, cap.name, boxedLocalIdx, valueType) : undefined;

--- a/tests/issue-4525-moment-closure-validation.test.ts
+++ b/tests/issue-4525-moment-closure-validation.test.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compileProject } from "../src/index.js";
+import { setupNpmCompatCatalogPackage } from "./dogfood/npm-compat-catalog.mjs";
+
+describe("#4525 Moment closure capture validation", () => {
+  it("keeps the pinned Moment entry module valid after recursive capture materialization", async () => {
+    const packageSetup = setupNpmCompatCatalogPackage("moment");
+    const result = await compileProject(packageSetup.entryModulePath, {
+      allowJs: true,
+      skipSemanticDiagnostics: true,
+      target: "gc",
+      platform: "web",
+      experimentalIR: true,
+      emitWat: false,
+      deferTopLevelInit: true,
+    });
+
+    expect(result.success, result.errors?.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  }, 120_000);
+});


### PR DESCRIPTION
Follow-up to merged PR #4817 and the Moment closure validation defect documented in [#4525](https://github.com/loopdive/js2/blob/main/plan/issues/4525-moment-closure-capture-i32-ref-validation.md).

Recursive sibling-function materialization can box a later mutable capture while an outer closure is emitting its capture list. The descriptor then points at the old raw i32 slot even though the closure field requires the ref-cell. Capture emission now uses the live mapped slot only when its type matches the expected cell, preserving the existing fallback for ordinary/stale maps.

Also adds a pinned Moment entry-module validation regression test and records the measured 6/6 validation result; the remaining 4/10 runtime result is a separate follow-up.

Tests:
- pnpm exec vitest run tests/issue-4525-moment-closure-validation.test.ts
- pnpm exec vitest run tests/issue-4384-moment-js-runtime-body.test.ts tests/issue-2029-emit-index-families.test.ts tests/issue-4134-transitive-nested-captures.test.ts tests/issue-3278.test.ts
- pnpm run typecheck
- pnpm exec prettier --check src/codegen/closures/arrow-phases.ts tests/issue-4525-moment-closure-validation.test.ts