### PR TITLE
refactor(ir): share counted string append proof

### DIFF
--- a/src/codegen/statements/counted-string-append.ts
+++ b/src/codegen/statements/counted-string-append.ts
@@ -1,241 +1,48 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
-/**
- * (#1004) Counted-append string-loop aggregation.
- *
- * Recognizes the adversarial repeated-concat idiom
- *
- *     let s = <string>;
- *     for (let i = A; i < B; i++) s = s + FRAGMENT;   // or  s += FRAGMENT
- *
- * and lowers the whole loop to a SINGLE string operation
- *
- *     s = s + FRAGMENT.repeat(N)          where N = max(0, B - A)
- *
- * turning O(N) per-iteration concat operations (each of which crosses the
- * `wasm:js-string` host boundary or calls `__str_concat`) into one
- * `String.prototype.repeat` call plus one concat.
- *
- * The transform is applied ONLY when it is provably identical to running the
- * loop, under a deliberately tight guard:
- *
- *  - the loop counter `i` is `let`/`const`-declared in the for-head
- *    (block-scoped, so it cannot be observed after the loop) and initialized to
- *    a compile-time integer `A`;
- *  - the condition is `i < B` or `i <= B` where `B` is a compile-time integer
- *    (literal or `const`), so the iteration count `N` is a known finite
- *    non-negative integer (no `Infinity` / non-integer-bound hazards);
- *  - the incrementor is `i++`, `++i`, or `i += 1` (unit positive step);
- *  - the body is EXACTLY one statement `s = s + FRAGMENT` or `s += FRAGMENT`
- *    where `s` is a plain string-typed identifier (not `i`);
- *  - FRAGMENT is a side-effect-free, loop-invariant string value — a string
- *    literal or a string-typed identifier other than `s`/`i`. (Because the body
- *    is only the append, no other variable is mutated in the loop, so such an
- *    identifier is invariant; forbidding calls / member access rules out
- *    getters and other observable effects.)
- *
- * Under those constraints there are no intermediate observations of `s` and
- * FRAGMENT is evaluated with the same (side-effect-free) result each iteration,
- * so `s + FRAGMENT.repeat(N)` yields the byte-identical final string.
- */
+/** (#1004 / #3518 Transaction A) Counted-append string-loop aggregation. */
 import { ts } from "../../ts-api.js";
-import type { TypeOracle } from "../../checker/oracle.js";
+import { countedStringAppendPlanIsCurrent, planCountedStringAppend } from "../../ir/analysis/counted-string-append.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { compileStatement } from "../shared.js";
 
-/** Unwrap parentheses/`as`/non-null wrappers around an expression. */
-function unwrap(expr: ts.Expression): ts.Expression {
-  let cur: ts.Expression = expr;
-  while (
-    ts.isParenthesizedExpression(cur) ||
-    ts.isAsExpression(cur) ||
-    ts.isNonNullExpression(cur) ||
-    ts.isTypeAssertionExpression(cur)
-  ) {
-    cur = (cur as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression | ts.TypeAssertion).expression;
-  }
-  return cur;
-}
-
 /**
- * Resolve a compile-time INTEGER constant: numeric literals, `const`
- * identifiers initialized to one, and unary `+`/`-` of those. Returns undefined
- * for anything non-integer or not statically known. Const resolution goes
- * through the oracle's `constInitializerOf` (which excludes `let`/`var`), so no
- * raw checker query is needed.
- */
-function constIntValue(oracle: TypeOracle, expr: ts.Expression): number | undefined {
-  const e = unwrap(expr);
-  if (ts.isNumericLiteral(e)) {
-    const n = Number(e.text);
-    return Number.isInteger(n) ? n : undefined;
-  }
-  if (ts.isPrefixUnaryExpression(e)) {
-    if (e.operator === ts.SyntaxKind.MinusToken || e.operator === ts.SyntaxKind.PlusToken) {
-      const v = constIntValue(oracle, e.operand);
-      if (v === undefined) return undefined;
-      return e.operator === ts.SyntaxKind.MinusToken ? -v : v;
-    }
-    return undefined;
-  }
-  if (ts.isIdentifier(e)) {
-    const init = oracle.constInitializerOf(e);
-    if (init) return constIntValue(oracle, init);
-  }
-  return undefined;
-}
-
-/** True when `expr` is exactly the identifier named `name`. */
-function isIdentNamed(expr: ts.Expression, name: string): boolean {
-  const e = unwrap(expr);
-  return ts.isIdentifier(e) && e.text === name;
-}
-
-/**
- * A safe, loop-invariant, side-effect-free STRING fragment: a string literal /
- * no-substitution template, or a string-typed identifier that is neither the
- * accumulator `s` nor the counter `i`. Calls, member access (possible getters),
- * template substitutions, etc. are rejected.
- */
-function isSafeStringFragment(
-  oracle: TypeOracle,
-  expr: ts.Expression,
-  accumName: string,
-  counterName: string,
-): boolean {
-  const e = unwrap(expr);
-  if (ts.isStringLiteral(e) || ts.isNoSubstitutionTemplateLiteral(e)) return true;
-  if (ts.isIdentifier(e)) {
-    if (e.text === accumName || e.text === counterName) return false;
-    return oracle.staticJsTypeOf(e) === "string";
-  }
-  return false;
-}
-
-/**
- * Extract the accumulator identifier and the appended fragment from a single
- * body statement of the form `s = s + FRAGMENT` or `s += FRAGMENT`.
- * Returns the REAL (typed) `s` read node and the REAL fragment node so the
- * synthesized replacement re-uses checker-resolvable nodes.
- */
-function matchAppendBody(stmt: ts.Statement): { accum: ts.Identifier; fragment: ts.Expression } | undefined {
-  let exprStmt: ts.Statement = stmt;
-  if (ts.isBlock(stmt)) {
-    if (stmt.statements.length !== 1) return undefined;
-    exprStmt = stmt.statements[0]!;
-  }
-  if (!ts.isExpressionStatement(exprStmt)) return undefined;
-  const expr = exprStmt.expression;
-  if (!ts.isBinaryExpression(expr)) return undefined;
-
-  // `s += FRAGMENT`
-  if (expr.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken) {
-    const lhs = unwrap(expr.left);
-    if (!ts.isIdentifier(lhs)) return undefined;
-    return { accum: lhs, fragment: expr.right };
-  }
-
-  // `s = s + FRAGMENT`
-  if (expr.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-    const target = unwrap(expr.left);
-    if (!ts.isIdentifier(target)) return undefined;
-    const rhs = unwrap(expr.right);
-    if (!ts.isBinaryExpression(rhs) || rhs.operatorToken.kind !== ts.SyntaxKind.PlusToken) return undefined;
-    // Append shape only: `s = s + FRAGMENT` (accumulator on the LEFT of `+`).
-    if (!isIdentNamed(rhs.left, target.text)) return undefined;
-    const accumRead = unwrap(rhs.left);
-    if (!ts.isIdentifier(accumRead)) return undefined;
-    return { accum: accumRead, fragment: rhs.right };
-  }
-
-  return undefined;
-}
-
-/** Match `i++`, `++i`, or `i += 1` (unit positive step on `name`). */
-function isUnitIncrement(oracle: TypeOracle, incr: ts.Expression | undefined, name: string): boolean {
-  if (!incr) return false;
-  const e = unwrap(incr);
-  if (ts.isPostfixUnaryExpression(e) || ts.isPrefixUnaryExpression(e)) {
-    return e.operator === ts.SyntaxKind.PlusPlusToken && isIdentNamed(e.operand, name);
-  }
-  if (ts.isBinaryExpression(e) && e.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken) {
-    return isIdentNamed(e.left, name) && constIntValue(oracle, e.right) === 1;
-  }
-  return false;
-}
-
-/**
- * If `stmt` matches the counted string-append idiom, emit the aggregated
- * `s = s + FRAGMENT.repeat(N)` lowering and return true. Otherwise return false
- * (the caller compiles the loop normally).
+ * If `stmt` has the shared checker-backed counted-append proof, emit one
+ * `fragment.repeat(N)` plus one concat. The recognizer intentionally lives in
+ * `src/ir/analysis`: this handler only consumes and revalidates its plan.
  */
 export function tryCompileCountedStringAppend(
   ctx: CodegenContext,
   fctx: FunctionContext,
   stmt: ts.ForStatement,
 ): boolean {
-  const oracle = ctx.oracle;
-  const { initializer, condition, incrementor, statement } = stmt;
-  if (!initializer || !condition || !incrementor) return false;
-
-  // init: `let i = A` (single block-scoped integer counter)
-  if (!ts.isVariableDeclarationList(initializer)) return false;
-  if ((initializer.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0) return false;
-  if (initializer.declarations.length !== 1) return false;
-  const decl = initializer.declarations[0]!;
-  if (!ts.isIdentifier(decl.name) || !decl.initializer) return false;
-  const counterName = decl.name.text;
-  const start = constIntValue(oracle, decl.initializer);
-  if (start === undefined) return false;
-
-  // cond: `i < B` or `i <= B` with compile-time integer B
-  if (!ts.isBinaryExpression(condition)) return false;
-  const condOp = condition.operatorToken.kind;
-  if (condOp !== ts.SyntaxKind.LessThanToken && condOp !== ts.SyntaxKind.LessThanEqualsToken) return false;
-  if (!isIdentNamed(condition.left, counterName)) return false;
-  const bound = constIntValue(oracle, condition.right);
-  if (bound === undefined) return false;
-
-  // incrementor: unit positive step
-  if (!isUnitIncrement(oracle, incrementor, counterName)) return false;
-
-  // body: `s = s + FRAGMENT` / `s += FRAGMENT`
-  const matched = matchAppendBody(statement);
-  if (!matched) return false;
-  const { accum, fragment } = matched;
-  if (accum.text === counterName) return false;
-  if (oracle.staticJsTypeOf(accum) !== "string") return false;
-  if (!isSafeStringFragment(oracle, fragment, accum.text, counterName)) return false;
-
-  // Iteration count N = number of times the body runs.
-  const rawCount = condOp === ts.SyntaxKind.LessThanToken ? bound - start : bound - start + 1;
-  const count = rawCount > 0 ? rawCount : 0;
+  const plan = planCountedStringAppend(ctx, stmt);
+  if (!plan || !countedStringAppendPlanIsCurrent(ctx, plan)) return false;
 
   // N === 0 → loop never runs; the accumulator keeps its value (emit nothing).
-  if (count === 0) return true;
+  if (plan.tripCount === 0) return true;
 
-  // N === 1 → a single append; let the normal loop path handle it (no repeat
-  // machinery needed, avoids a needless `.repeat(1)`).
-  if (count === 1) return false;
+  // N === 1 stays on the ordinary loop path; no repeat machinery is useful.
+  if (plan.tripCount === 1) return false;
 
-  // Synthesize `accum += fragment.repeat(N)` re-using the REAL, checker-typed
-  // `accum` (string) and `fragment` nodes so type resolution and string-concat
-  // routing behave exactly as for hand-written source.
-  const countLit = ts.factory.createNumericLiteral(String(count));
-  const repeatProp = ts.factory.createPropertyAccessExpression(fragment, "repeat");
-  ts.setTextRange(repeatProp, fragment);
-  (repeatProp as unknown as { parent: ts.Node }).parent = stmt;
-  const repeatCall = ts.factory.createCallExpression(repeatProp, undefined, [countLit]);
+  // Synthesize only after the identity proof has been revalidated. Re-use the
+  // real checker-typed accumulator/fragment nodes; analysis never manufactures
+  // AST or compilation identities.
+  const countLiteral = ts.factory.createNumericLiteral(String(plan.tripCount));
+  const repeatProperty = ts.factory.createPropertyAccessExpression(plan.fragmentExpression, "repeat");
+  ts.setTextRange(repeatProperty, plan.fragmentExpression);
+  (repeatProperty as unknown as { parent: ts.Node }).parent = stmt;
+  const repeatCall = ts.factory.createCallExpression(repeatProperty, undefined, [countLiteral]);
   ts.setTextRange(repeatCall, stmt);
   (repeatCall as unknown as { parent: ts.Node }).parent = stmt;
-  (countLit as unknown as { parent: ts.Node }).parent = repeatCall;
+  (countLiteral as unknown as { parent: ts.Node }).parent = repeatCall;
 
-  const assign = ts.factory.createBinaryExpression(accum, ts.SyntaxKind.PlusEqualsToken, repeatCall);
-  ts.setTextRange(assign, stmt);
-  (assign as unknown as { parent: ts.Node }).parent = stmt;
-  const exprStmt = ts.factory.createExpressionStatement(assign);
-  ts.setTextRange(exprStmt, stmt);
-  (exprStmt as unknown as { parent: ts.Node }).parent = stmt.parent;
+  const assignment = ts.factory.createBinaryExpression(plan.accumulatorRead, ts.SyntaxKind.PlusEqualsToken, repeatCall);
+  ts.setTextRange(assignment, stmt);
+  (assignment as unknown as { parent: ts.Node }).parent = stmt;
+  const expressionStatement = ts.factory.createExpressionStatement(assignment);
+  ts.setTextRange(expressionStatement, stmt);
+  (expressionStatement as unknown as { parent: ts.Node }).parent = stmt.parent;
 
-  compileStatement(ctx, fctx, exprStmt);
+  compileStatement(ctx, fctx, expressionStatement);
   return true;
 }

--- a/src/ir/analysis/counted-string-append.ts
+++ b/src/ir/analysis/counted-string-append.ts
@@ -1,0 +1,732 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3518 Transaction A / #1004) Shared proof for counted string appends.
+ *
+ * The syntax reader is shared by the legacy selector gate and the direct
+ * lowering. The selector deliberately keeps its old, checker-free and eager
+ * deferral contract; only the direct lowering asks for the stronger
+ * declaration/symbol/lifetime proof below.
+ */
+import type { TypeOracle } from "../../checker/oracle.js";
+import { forEachChild, ts } from "../../ts-api.js";
+
+export type IrCountedStringComparison = "lt" | "lte";
+export type IrCountedStringIncrement = "postfix" | "prefix" | "plus-equals";
+
+export interface IrCountedStringAppendPlan {
+  readonly sourceFile: ts.SourceFile;
+  readonly loop: ts.ForStatement;
+  readonly appendStatement: ts.ExpressionStatement;
+  readonly appendExpression: ts.BinaryExpression;
+  readonly accumulatorDeclaration: ts.VariableDeclaration;
+  readonly accumulatorSymbol: ts.Symbol;
+  readonly accumulatorWrite: ts.Identifier;
+  readonly accumulatorRead: ts.Identifier;
+  readonly accumulatorType: "string";
+  readonly counterDeclaration: ts.VariableDeclaration;
+  readonly counterSymbol: ts.Symbol;
+  readonly counterConditionRead: ts.Identifier;
+  readonly counterIncrementWrite: ts.Identifier;
+  readonly startExpression: ts.Expression;
+  readonly startConstDeclarations: readonly ts.VariableDeclaration[];
+  readonly start: number;
+  readonly boundExpression: ts.Expression;
+  readonly boundConstDeclarations: readonly ts.VariableDeclaration[];
+  readonly bound: number;
+  readonly comparison: IrCountedStringComparison;
+  readonly increment: IrCountedStringIncrement;
+  readonly fragmentExpression: ts.Expression;
+  readonly fragmentDeclaration?: ts.VariableDeclaration;
+  readonly fragmentSymbol?: ts.Symbol;
+  readonly fragmentConstDeclarations: readonly ts.VariableDeclaration[];
+  readonly fragmentType: "string";
+  readonly tripCount: number;
+}
+
+interface CountedStringAppendSyntax {
+  readonly loop: ts.ForStatement;
+  readonly counterDeclarationList: ts.VariableDeclarationList;
+  readonly counterDeclaration: ts.VariableDeclaration;
+  readonly counterName: ts.Identifier;
+  readonly startExpression: ts.Expression;
+  readonly condition: ts.BinaryExpression;
+  readonly counterConditionRead: ts.Identifier;
+  readonly boundExpression: ts.Expression;
+  readonly comparison: IrCountedStringComparison;
+  readonly incrementExpression: ts.Expression;
+  readonly counterIncrementWrite: ts.Identifier;
+  readonly increment: IrCountedStringIncrement;
+  readonly appendStatement: ts.ExpressionStatement;
+  readonly appendExpression: ts.BinaryExpression;
+  readonly accumulatorWrite: ts.Identifier;
+  readonly accumulatorRead: ts.Identifier;
+  readonly fragmentExpression: ts.Expression;
+}
+
+interface ProofContext {
+  readonly checker: ts.TypeChecker;
+  readonly oracle: TypeOracle;
+}
+
+interface ResolvedInt {
+  readonly value: number;
+  readonly declarations: readonly ts.VariableDeclaration[];
+}
+
+interface ResolvedStringFragment {
+  readonly expression: ts.Expression;
+  readonly declaration?: ts.VariableDeclaration;
+  readonly symbol?: ts.Symbol;
+  readonly declarations: readonly ts.VariableDeclaration[];
+}
+
+const ASSIGNMENT_OPERATORS = new Set<ts.SyntaxKind>([
+  ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.MinusEqualsToken,
+  ts.SyntaxKind.AsteriskEqualsToken,
+  ts.SyntaxKind.SlashEqualsToken,
+  ts.SyntaxKind.PercentEqualsToken,
+  ts.SyntaxKind.AsteriskAsteriskEqualsToken,
+  ts.SyntaxKind.LessThanLessThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.AmpersandEqualsToken,
+  ts.SyntaxKind.BarEqualsToken,
+  ts.SyntaxKind.CaretEqualsToken,
+  ts.SyntaxKind.QuestionQuestionEqualsToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
+]);
+
+function unwrapExpression(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function identifierExpression(expression: ts.Expression): ts.Identifier | null {
+  const current = unwrapExpression(expression);
+  return ts.isIdentifier(current) ? current : null;
+}
+
+function oneBodyStatement(statement: ts.Statement): ts.Statement | null {
+  if (!ts.isBlock(statement)) return statement;
+  return statement.statements.length === 1 ? statement.statements[0]! : null;
+}
+
+/** One syntax reader for both the checker-free routing gate and full proof. */
+function readCountedStringAppendSyntax(loop: ts.ForStatement): CountedStringAppendSyntax | null {
+  const initializer = loop.initializer;
+  const condition = loop.condition;
+  const incrementor = loop.incrementor;
+  if (
+    !initializer ||
+    !ts.isVariableDeclarationList(initializer) ||
+    initializer.declarations.length !== 1 ||
+    !condition ||
+    !ts.isBinaryExpression(condition) ||
+    !incrementor
+  ) {
+    return null;
+  }
+
+  const counterDeclaration = initializer.declarations[0]!;
+  if (!ts.isIdentifier(counterDeclaration.name) || !counterDeclaration.initializer) return null;
+  const counterName = counterDeclaration.name;
+
+  const conditionRead = identifierExpression(condition.left);
+  const comparison =
+    condition.operatorToken.kind === ts.SyntaxKind.LessThanToken
+      ? "lt"
+      : condition.operatorToken.kind === ts.SyntaxKind.LessThanEqualsToken
+        ? "lte"
+        : null;
+  if (!conditionRead || conditionRead.text !== counterName.text || comparison === null) return null;
+
+  const incrementExpression = unwrapExpression(incrementor);
+  let counterIncrementWrite: ts.Identifier | null = null;
+  let increment: IrCountedStringIncrement | null = null;
+  if (ts.isPostfixUnaryExpression(incrementExpression)) {
+    const operand = identifierExpression(incrementExpression.operand);
+    if (incrementExpression.operator === ts.SyntaxKind.PlusPlusToken && operand?.text === counterName.text) {
+      counterIncrementWrite = operand;
+      increment = "postfix";
+    }
+  } else if (ts.isPrefixUnaryExpression(incrementExpression)) {
+    const operand = identifierExpression(incrementExpression.operand);
+    if (incrementExpression.operator === ts.SyntaxKind.PlusPlusToken && operand?.text === counterName.text) {
+      counterIncrementWrite = operand;
+      increment = "prefix";
+    }
+  } else if (
+    ts.isBinaryExpression(incrementExpression) &&
+    incrementExpression.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken
+  ) {
+    const target = identifierExpression(incrementExpression.left);
+    const step = unwrapExpression(incrementExpression.right);
+    if (target?.text === counterName.text && ts.isNumericLiteral(step) && Number(step.text) === 1) {
+      counterIncrementWrite = target;
+      increment = "plus-equals";
+    }
+  }
+  if (!counterIncrementWrite || increment === null) return null;
+
+  const onlyStatement = oneBodyStatement(loop.statement);
+  if (!onlyStatement || !ts.isExpressionStatement(onlyStatement) || !ts.isBinaryExpression(onlyStatement.expression)) {
+    return null;
+  }
+  const appendExpression = onlyStatement.expression;
+  let accumulatorWrite: ts.Identifier | null = null;
+  let accumulatorRead: ts.Identifier | null = null;
+  let fragmentExpression: ts.Expression | null = null;
+  if (appendExpression.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken) {
+    const target = identifierExpression(appendExpression.left);
+    if (target) {
+      accumulatorWrite = target;
+      accumulatorRead = target;
+      fragmentExpression = appendExpression.right;
+    }
+  } else if (appendExpression.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+    const target = identifierExpression(appendExpression.left);
+    const right = unwrapExpression(appendExpression.right);
+    if (target && ts.isBinaryExpression(right) && right.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+      const read = identifierExpression(right.left);
+      if (read?.text === target.text) {
+        accumulatorWrite = target;
+        accumulatorRead = read;
+        fragmentExpression = right.right;
+      }
+    }
+  }
+  if (!accumulatorWrite || !accumulatorRead || !fragmentExpression) return null;
+
+  return {
+    loop,
+    counterDeclarationList: initializer,
+    counterDeclaration,
+    counterName,
+    startExpression: counterDeclaration.initializer,
+    condition,
+    counterConditionRead: conditionRead,
+    boundExpression: condition.right,
+    comparison,
+    incrementExpression,
+    counterIncrementWrite,
+    increment,
+    appendStatement: onlyStatement,
+    appendExpression,
+    accumulatorWrite,
+    accumulatorRead,
+    fragmentExpression,
+  };
+}
+
+function sourceFileOf(node: ts.Node): ts.SourceFile {
+  return node.getSourceFile();
+}
+
+function runtimeOwner(node: ts.Node): ts.SignatureDeclaration | ts.SourceFile | null {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (ts.isFunctionLike(current)) return current;
+    if (ts.isSourceFile(current)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function statementContainer(node: ts.Node): ts.Block | ts.SourceFile | ts.ModuleBlock | null {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (ts.isBlock(current) || ts.isSourceFile(current) || ts.isModuleBlock(current)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function directStatementChild(
+  container: ts.Block | ts.SourceFile | ts.ModuleBlock,
+  node: ts.Node,
+): ts.Statement | null {
+  let current: ts.Node = node;
+  while (current.parent && current.parent !== container) current = current.parent;
+  return current.parent === container && ts.isStatement(current) ? current : null;
+}
+
+/** The declaration's initialized value must exist before `use` executes. */
+function declarationDominatesUse(declaration: ts.VariableDeclaration, use: ts.Node): boolean {
+  const declarationContainer = statementContainer(declaration);
+  if (!declarationContainer) return false;
+  const declarationStatement = directStatementChild(declarationContainer, declaration);
+  const useStatement = directStatementChild(declarationContainer, use);
+  if (!declarationStatement || !useStatement) return false;
+  const declarationIndex = declarationContainer.statements.indexOf(declarationStatement);
+  const useIndex = declarationContainer.statements.indexOf(useStatement);
+  return declarationIndex >= 0 && useIndex >= 0 && declarationIndex < useIndex;
+}
+
+function exactVariableDeclaration(
+  checker: ts.TypeChecker,
+  identifier: ts.Identifier,
+  kind: ts.NodeFlags.Let | ts.NodeFlags.Const,
+): { declaration: ts.VariableDeclaration; symbol: ts.Symbol } | null {
+  const symbol = checker.getSymbolAtLocation(identifier);
+  const declaration = symbol?.valueDeclaration;
+  if (
+    !symbol ||
+    !declaration ||
+    !ts.isVariableDeclaration(declaration) ||
+    !ts.isIdentifier(declaration.name) ||
+    !ts.isVariableDeclarationList(declaration.parent) ||
+    declaration.parent.declarations.length !== 1 ||
+    (declaration.parent.flags & kind) === 0 ||
+    symbol.declarations?.length !== 1 ||
+    checker.getSymbolAtLocation(declaration.name) !== symbol
+  ) {
+    return null;
+  }
+  return { declaration, symbol };
+}
+
+function resolveSafeInteger(
+  context: ProofContext,
+  expression: ts.Expression,
+  loop: ts.ForStatement,
+  use: ts.Node,
+  active: ReadonlySet<ts.Symbol> = new Set(),
+): ResolvedInt | null {
+  const current = unwrapExpression(expression);
+  if (ts.isNumericLiteral(current)) {
+    const value = Number(current.text.replace(/_/g, ""));
+    return Number.isSafeInteger(value) ? { value, declarations: [] } : null;
+  }
+  if (
+    ts.isPrefixUnaryExpression(current) &&
+    (current.operator === ts.SyntaxKind.PlusToken || current.operator === ts.SyntaxKind.MinusToken)
+  ) {
+    const inner = resolveSafeInteger(context, current.operand, loop, use, active);
+    if (!inner) return null;
+    const value = current.operator === ts.SyntaxKind.MinusToken ? -inner.value : inner.value;
+    return Number.isSafeInteger(value) ? { value, declarations: inner.declarations } : null;
+  }
+  if (!ts.isIdentifier(current)) return null;
+
+  const exact = exactVariableDeclaration(context.checker, current, ts.NodeFlags.Const);
+  if (!exact || !exact.declaration.initializer || active.has(exact.symbol)) return null;
+  if (
+    sourceFileOf(exact.declaration) !== sourceFileOf(loop) ||
+    runtimeOwner(exact.declaration) !== runtimeOwner(loop)
+  ) {
+    return null;
+  }
+  if (!declarationDominatesUse(exact.declaration, use)) return null;
+
+  const nextActive = new Set(active);
+  nextActive.add(exact.symbol);
+  const resolved = resolveSafeInteger(
+    context,
+    exact.declaration.initializer,
+    loop,
+    exact.declaration.initializer,
+    nextActive,
+  );
+  if (!resolved) return null;
+  return { value: resolved.value, declarations: [exact.declaration, ...resolved.declarations] };
+}
+
+function resolveStringFragment(
+  context: ProofContext,
+  expression: ts.Expression,
+  loop: ts.ForStatement,
+  counterSymbol: ts.Symbol,
+  accumulatorSymbol: ts.Symbol,
+  use: ts.Node,
+  active: ReadonlySet<ts.Symbol> = new Set(),
+): ResolvedStringFragment | null {
+  const current = unwrapExpression(expression);
+  if (ts.isStringLiteral(current) || ts.isNoSubstitutionTemplateLiteral(current)) {
+    return { expression, declarations: [] };
+  }
+  if (!ts.isIdentifier(current) || context.oracle.staticJsTypeOf(current) !== "string") return null;
+  const exact = exactVariableDeclaration(context.checker, current, ts.NodeFlags.Const);
+  if (
+    !exact ||
+    exact.symbol === counterSymbol ||
+    exact.symbol === accumulatorSymbol ||
+    !exact.declaration.initializer ||
+    active.has(exact.symbol) ||
+    sourceFileOf(exact.declaration) !== sourceFileOf(loop) ||
+    runtimeOwner(exact.declaration) !== runtimeOwner(loop) ||
+    !declarationDominatesUse(exact.declaration, use)
+  ) {
+    return null;
+  }
+  const nextActive = new Set(active);
+  nextActive.add(exact.symbol);
+  const initializer = resolveStringFragment(
+    context,
+    exact.declaration.initializer,
+    loop,
+    counterSymbol,
+    accumulatorSymbol,
+    exact.declaration.initializer,
+    nextActive,
+  );
+  if (!initializer) return null;
+  return {
+    expression,
+    declaration: exact.declaration,
+    symbol: exact.symbol,
+    declarations: [exact.declaration, ...initializer.declarations],
+  };
+}
+
+function isWriteOccurrence(identifier: ts.Identifier): boolean {
+  const parent = identifier.parent;
+  if (!parent) return true;
+  if (ts.isPostfixUnaryExpression(parent)) return true;
+  if (
+    ts.isPrefixUnaryExpression(parent) &&
+    (parent.operator === ts.SyntaxKind.PlusPlusToken || parent.operator === ts.SyntaxKind.MinusMinusToken)
+  ) {
+    return true;
+  }
+  if (ts.isDeleteExpression(parent)) return true;
+  return (
+    ts.isBinaryExpression(parent) && parent.left === identifier && ASSIGNMENT_OPERATORS.has(parent.operatorToken.kind)
+  );
+}
+
+function isDescendantOf(node: ts.Node, ancestor: ts.Node): boolean {
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    if (current === ancestor) return true;
+  }
+  return false;
+}
+
+function symbolUsesAreSafe(
+  checker: ts.TypeChecker,
+  owner: ts.SignatureDeclaration | ts.SourceFile,
+  loop: ts.ForStatement,
+  symbol: ts.Symbol,
+  declarationName: ts.Identifier,
+  allowedLoopUses: ReadonlySet<ts.Identifier>,
+  allowedWrites: ReadonlySet<ts.Identifier>,
+): boolean {
+  const root: ts.Node = ts.isSourceFile(owner) ? owner : "body" in owner && owner.body ? owner.body : owner;
+  let safe = true;
+  const visit = (node: ts.Node, nestedFunction: boolean): void => {
+    if (!safe) return;
+    const entersNestedFunction = node !== owner && ts.isFunctionLike(node);
+    const nested = nestedFunction || entersNestedFunction;
+    if (ts.isIdentifier(node) && checker.getSymbolAtLocation(node) === symbol) {
+      if (node === declarationName) return;
+      if (nested) {
+        safe = false;
+        return;
+      }
+      const inLoop = isDescendantOf(node, loop);
+      if (inLoop && !allowedLoopUses.has(node)) {
+        safe = false;
+        return;
+      }
+      if (isWriteOccurrence(node) && !allowedWrites.has(node)) {
+        safe = false;
+        return;
+      }
+    }
+    forEachChild(node, (child) => visit(child, nested));
+  };
+  visit(root, false);
+  return safe;
+}
+
+function constDeclarationsStayReadOnly(
+  checker: ts.TypeChecker,
+  owner: ts.SignatureDeclaration | ts.SourceFile,
+  declarations: readonly ts.VariableDeclaration[],
+): boolean {
+  const root: ts.Node = ts.isSourceFile(owner) ? owner : "body" in owner && owner.body ? owner.body : owner;
+  for (const declaration of declarations) {
+    if (!ts.isIdentifier(declaration.name)) return false;
+    const symbol = checker.getSymbolAtLocation(declaration.name);
+    if (!symbol) return false;
+    let readOnly = true;
+    const visit = (node: ts.Node): void => {
+      if (!readOnly) return;
+      if (
+        ts.isIdentifier(node) &&
+        node !== declaration.name &&
+        checker.getSymbolAtLocation(node) === symbol &&
+        isWriteOccurrence(node)
+      ) {
+        readOnly = false;
+        return;
+      }
+      forEachChild(node, visit);
+    };
+    visit(root);
+    if (!readOnly) return false;
+  }
+  return true;
+}
+
+function checkedTripCount(start: number, bound: number, comparison: IrCountedStringComparison): number | null {
+  const raw = BigInt(bound) - BigInt(start) + (comparison === "lte" ? 1n : 0n);
+  if (raw <= 0n) return 0;
+  if (raw > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+  return Number(raw);
+}
+
+export function planCountedStringAppend(
+  context: ProofContext,
+  loop: ts.ForStatement,
+): IrCountedStringAppendPlan | null {
+  const syntax = readCountedStringAppendSyntax(loop);
+  if (!syntax || (syntax.counterDeclarationList.flags & ts.NodeFlags.Let) === 0) return null;
+
+  const counter = exactVariableDeclaration(context.checker, syntax.counterName, ts.NodeFlags.Let);
+  if (!counter || counter.declaration !== syntax.counterDeclaration) return null;
+  if (
+    context.checker.getSymbolAtLocation(syntax.counterConditionRead) !== counter.symbol ||
+    context.checker.getSymbolAtLocation(syntax.counterIncrementWrite) !== counter.symbol
+  ) {
+    return null;
+  }
+
+  const accumulator = exactVariableDeclaration(context.checker, syntax.accumulatorRead, ts.NodeFlags.Let);
+  const owner = runtimeOwner(loop);
+  if (
+    !owner ||
+    !accumulator ||
+    !accumulator.declaration.initializer ||
+    context.checker.getSymbolAtLocation(syntax.accumulatorWrite) !== accumulator.symbol ||
+    accumulator.symbol === counter.symbol ||
+    sourceFileOf(accumulator.declaration) !== sourceFileOf(loop) ||
+    runtimeOwner(accumulator.declaration) !== owner ||
+    !declarationDominatesUse(accumulator.declaration, loop) ||
+    context.oracle.staticJsTypeOf(syntax.accumulatorRead) !== "string"
+  ) {
+    return null;
+  }
+
+  const start = resolveSafeInteger(context, syntax.startExpression, loop, syntax.startExpression);
+  const bound = resolveSafeInteger(context, syntax.boundExpression, loop, loop);
+  if (!start || !bound) return null;
+  if (
+    !constDeclarationsStayReadOnly(context.checker, owner, start.declarations) ||
+    !constDeclarationsStayReadOnly(context.checker, owner, bound.declarations)
+  ) {
+    return null;
+  }
+  const tripCount = checkedTripCount(start.value, bound.value, syntax.comparison);
+  if (tripCount === null) return null;
+
+  const fragment = resolveStringFragment(
+    context,
+    syntax.fragmentExpression,
+    loop,
+    counter.symbol,
+    accumulator.symbol,
+    loop,
+  );
+  if (!fragment) return null;
+
+  const counterUses = new Set<ts.Identifier>([syntax.counterConditionRead, syntax.counterIncrementWrite]);
+  if (
+    !symbolUsesAreSafe(
+      context.checker,
+      owner,
+      loop,
+      counter.symbol,
+      syntax.counterName,
+      counterUses,
+      new Set([syntax.counterIncrementWrite]),
+    )
+  ) {
+    return null;
+  }
+
+  const fragmentIdentifier = identifierExpression(syntax.fragmentExpression);
+  for (const declaration of fragment.declarations) {
+    if (!ts.isIdentifier(declaration.name)) return null;
+    const symbol = context.checker.getSymbolAtLocation(declaration.name);
+    if (!symbol) return null;
+    const loopUses =
+      symbol === fragment.symbol && fragmentIdentifier
+        ? new Set<ts.Identifier>([fragmentIdentifier])
+        : new Set<ts.Identifier>();
+    if (
+      !symbolUsesAreSafe(context.checker, owner, loop, symbol, declaration.name, loopUses, new Set<ts.Identifier>())
+    ) {
+      return null;
+    }
+  }
+  const accumulatorUses = new Set<ts.Identifier>([syntax.accumulatorWrite, syntax.accumulatorRead]);
+  if (
+    !symbolUsesAreSafe(
+      context.checker,
+      owner,
+      loop,
+      accumulator.symbol,
+      accumulator.declaration.name as ts.Identifier,
+      accumulatorUses,
+      new Set([syntax.accumulatorWrite]),
+    )
+  ) {
+    return null;
+  }
+
+  return Object.freeze({
+    sourceFile: sourceFileOf(loop),
+    loop,
+    appendStatement: syntax.appendStatement,
+    appendExpression: syntax.appendExpression,
+    accumulatorDeclaration: accumulator.declaration,
+    accumulatorSymbol: accumulator.symbol,
+    accumulatorWrite: syntax.accumulatorWrite,
+    accumulatorRead: syntax.accumulatorRead,
+    accumulatorType: "string",
+    counterDeclaration: counter.declaration,
+    counterSymbol: counter.symbol,
+    counterConditionRead: syntax.counterConditionRead,
+    counterIncrementWrite: syntax.counterIncrementWrite,
+    startExpression: syntax.startExpression,
+    startConstDeclarations: Object.freeze([...start.declarations]),
+    start: start.value,
+    boundExpression: syntax.boundExpression,
+    boundConstDeclarations: Object.freeze([...bound.declarations]),
+    bound: bound.value,
+    comparison: syntax.comparison,
+    increment: syntax.increment,
+    fragmentExpression: fragment.expression,
+    fragmentDeclaration: fragment.declaration,
+    fragmentSymbol: fragment.symbol,
+    fragmentConstDeclarations: Object.freeze([...fragment.declarations]),
+    fragmentType: "string",
+    tripCount,
+  });
+}
+
+/** Re-run and compare every identity-bearing field immediately before use. */
+export function countedStringAppendPlanIsCurrent(context: ProofContext, plan: IrCountedStringAppendPlan): boolean {
+  const current = planCountedStringAppend(context, plan.loop);
+  const sameDeclarations = (
+    left: readonly ts.VariableDeclaration[],
+    right: readonly ts.VariableDeclaration[],
+  ): boolean => left.length === right.length && left.every((declaration, index) => declaration === right[index]);
+  return (
+    current !== null &&
+    current.sourceFile === plan.sourceFile &&
+    current.loop === plan.loop &&
+    current.appendStatement === plan.appendStatement &&
+    current.appendExpression === plan.appendExpression &&
+    current.accumulatorDeclaration === plan.accumulatorDeclaration &&
+    current.accumulatorSymbol === plan.accumulatorSymbol &&
+    current.accumulatorWrite === plan.accumulatorWrite &&
+    current.accumulatorRead === plan.accumulatorRead &&
+    current.counterDeclaration === plan.counterDeclaration &&
+    current.counterSymbol === plan.counterSymbol &&
+    current.counterConditionRead === plan.counterConditionRead &&
+    current.counterIncrementWrite === plan.counterIncrementWrite &&
+    current.startExpression === plan.startExpression &&
+    sameDeclarations(current.startConstDeclarations, plan.startConstDeclarations) &&
+    current.start === plan.start &&
+    current.boundExpression === plan.boundExpression &&
+    sameDeclarations(current.boundConstDeclarations, plan.boundConstDeclarations) &&
+    current.bound === plan.bound &&
+    current.comparison === plan.comparison &&
+    current.increment === plan.increment &&
+    current.fragmentExpression === plan.fragmentExpression &&
+    current.fragmentDeclaration === plan.fragmentDeclaration &&
+    current.fragmentSymbol === plan.fragmentSymbol &&
+    sameDeclarations(current.fragmentConstDeclarations, plan.fragmentConstDeclarations) &&
+    current.tripCount === plan.tripCount
+  );
+}
+
+/**
+ * Preserve the pre-#3518 unconditional selector deferral byte-for-shape. This
+ * intentionally asks only for the old adjacent literal seed/loop syntax; it
+ * does not claim that the direct transform's checker proof succeeds.
+ */
+export function containsCountedStringAppendCandidate(root: ts.Node): boolean {
+  let found = false;
+  const matches = (seedStatement: ts.Statement, loopStatement: ts.Statement): boolean => {
+    if (!ts.isVariableStatement(seedStatement) || seedStatement.declarationList.declarations.length !== 1) {
+      return false;
+    }
+    const seed = seedStatement.declarationList.declarations[0]!;
+    if (
+      !ts.isIdentifier(seed.name) ||
+      !seed.initializer ||
+      !(ts.isStringLiteral(seed.initializer) || ts.isNoSubstitutionTemplateLiteral(seed.initializer)) ||
+      !ts.isForStatement(loopStatement)
+    ) {
+      return false;
+    }
+    const syntax = readCountedStringAppendSyntax(loopStatement);
+    if (!syntax) return false;
+    const directIncrement = loopStatement.incrementor!;
+    const oldIncrementShape =
+      ((ts.isPrefixUnaryExpression(directIncrement) || ts.isPostfixUnaryExpression(directIncrement)) &&
+        ts.isIdentifier(directIncrement.operand)) ||
+      (ts.isBinaryExpression(directIncrement) &&
+        ts.isIdentifier(directIncrement.left) &&
+        ts.isNumericLiteral(directIncrement.right));
+    let oldAppendShape = false;
+    if (
+      syntax.appendExpression.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken &&
+      ts.isIdentifier(syntax.appendExpression.left)
+    ) {
+      oldAppendShape = true;
+    } else if (
+      syntax.appendExpression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(syntax.appendExpression.left)
+    ) {
+      let right = syntax.appendExpression.right;
+      while (ts.isParenthesizedExpression(right)) right = right.expression;
+      oldAppendShape =
+        ts.isBinaryExpression(right) &&
+        right.operatorToken.kind === ts.SyntaxKind.PlusToken &&
+        ts.isIdentifier(right.left) &&
+        right.left.text === syntax.appendExpression.left.text;
+    }
+    return (
+      ts.isNumericLiteral(syntax.startExpression) &&
+      ts.isIdentifier(syntax.condition.left) &&
+      ts.isNumericLiteral(syntax.boundExpression) &&
+      oldIncrementShape &&
+      oldAppendShape &&
+      syntax.accumulatorWrite.text === seed.name.text &&
+      syntax.accumulatorWrite.text !== syntax.counterName.text &&
+      (ts.isStringLiteral(syntax.fragmentExpression) || ts.isNoSubstitutionTemplateLiteral(syntax.fragmentExpression))
+    );
+  };
+
+  const walk = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isBlock(node) || ts.isSourceFile(node) || ts.isModuleBlock(node)) {
+      for (let index = 0; index + 1 < node.statements.length; index++) {
+        if (matches(node.statements[index]!, node.statements[index + 1]!)) {
+          found = true;
+          return;
+        }
+      }
+    }
+    forEachChild(node, (child) => {
+      if (found || ts.isFunctionLike(child)) return;
+      walk(child);
+    });
+  };
+  walk(root);
+  return found;
+}

--- a/src/ir/string-builder-shape.ts
+++ b/src/ir/string-builder-shape.ts
@@ -29,6 +29,7 @@
  *     just leaves an existing regression unfixed for that shape.
  */
 import { forEachChild, ts } from "../ts-api.js";
+import { containsCountedStringAppendCandidate } from "./analysis/counted-string-append.js";
 
 function isFunctionScopeBoundary(node: ts.Node): boolean {
   return (
@@ -109,133 +110,8 @@ function loopBodyOnlyAppends(loopBody: ts.Node, name: string): boolean {
 export function stringBuilderForcedLegacy(body: ts.Node): boolean {
   return (
     (process.env.JS2WASM_IR_STRING_BUILDER === "0" && containsStringBuilderLoopShape(body)) ||
-    containsCountedLiteralStringAppend(body)
+    containsCountedStringAppendCandidate(body)
   );
-}
-
-/**
- * Detect the constant-count, literal-fragment append loop handled by legacy
- * codegen's #1004 aggregation:
- *
- *   let s = <string literal>;
- *   for (let i = A; i < B; i++) s = s + <string literal>;
- *
- * IR currently emits every iteration as a wasm:js-string `concat` call. The
- * legacy path proves this narrow shape and replaces it with one `repeat(N)`
- * plus one concat, so the selector should preserve that production
- * optimization until IR owns an equivalent transform.
- */
-function containsCountedLiteralStringAppend(root: ts.Node): boolean {
-  let found = false;
-
-  const unwrap = (expr: ts.Expression): ts.Expression => {
-    let current = expr;
-    while (ts.isParenthesizedExpression(current)) current = current.expression;
-    return current;
-  };
-
-  const appendTarget = (stmt: ts.Statement): { accum: string; fragment: ts.Expression } | null => {
-    const only = ts.isBlock(stmt) && stmt.statements.length === 1 ? stmt.statements[0]! : stmt;
-    if (!ts.isExpressionStatement(only) || !ts.isBinaryExpression(only.expression)) return null;
-    const expr = only.expression;
-    if (expr.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken && ts.isIdentifier(expr.left)) {
-      return { accum: expr.left.text, fragment: expr.right };
-    }
-    if (expr.operatorToken.kind !== ts.SyntaxKind.EqualsToken || !ts.isIdentifier(expr.left)) return null;
-    const rhs = unwrap(expr.right);
-    if (
-      !ts.isBinaryExpression(rhs) ||
-      rhs.operatorToken.kind !== ts.SyntaxKind.PlusToken ||
-      !ts.isIdentifier(rhs.left) ||
-      rhs.left.text !== expr.left.text
-    ) {
-      return null;
-    }
-    return { accum: expr.left.text, fragment: rhs.right };
-  };
-
-  const isUnitIncrement = (expr: ts.Expression | undefined, counter: string): boolean => {
-    if (!expr) return false;
-    if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
-      return (
-        expr.operator === ts.SyntaxKind.PlusPlusToken && ts.isIdentifier(expr.operand) && expr.operand.text === counter
-      );
-    }
-    return (
-      ts.isBinaryExpression(expr) &&
-      expr.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken &&
-      ts.isIdentifier(expr.left) &&
-      expr.left.text === counter &&
-      ts.isNumericLiteral(expr.right) &&
-      Number(expr.right.text) === 1
-    );
-  };
-
-  const matches = (seedStmt: ts.Statement, loopStmt: ts.Statement): boolean => {
-    if (!ts.isVariableStatement(seedStmt) || seedStmt.declarationList.declarations.length !== 1) return false;
-    const seed = seedStmt.declarationList.declarations[0]!;
-    if (
-      !ts.isIdentifier(seed.name) ||
-      !seed.initializer ||
-      !(ts.isStringLiteral(seed.initializer) || ts.isNoSubstitutionTemplateLiteral(seed.initializer))
-    ) {
-      return false;
-    }
-    if (
-      !ts.isForStatement(loopStmt) ||
-      !loopStmt.initializer ||
-      !ts.isVariableDeclarationList(loopStmt.initializer) ||
-      loopStmt.initializer.declarations.length !== 1 ||
-      !loopStmt.condition
-    ) {
-      return false;
-    }
-    const counterDecl = loopStmt.initializer.declarations[0]!;
-    if (
-      !ts.isIdentifier(counterDecl.name) ||
-      !counterDecl.initializer ||
-      !ts.isNumericLiteral(counterDecl.initializer)
-    ) {
-      return false;
-    }
-    const counter = counterDecl.name.text;
-    if (
-      !ts.isBinaryExpression(loopStmt.condition) ||
-      (loopStmt.condition.operatorToken.kind !== ts.SyntaxKind.LessThanToken &&
-        loopStmt.condition.operatorToken.kind !== ts.SyntaxKind.LessThanEqualsToken) ||
-      !ts.isIdentifier(loopStmt.condition.left) ||
-      loopStmt.condition.left.text !== counter ||
-      !ts.isNumericLiteral(loopStmt.condition.right) ||
-      !isUnitIncrement(loopStmt.incrementor, counter)
-    ) {
-      return false;
-    }
-    const append = appendTarget(loopStmt.statement);
-    return (
-      append !== null &&
-      append.accum === seed.name.text &&
-      append.accum !== counter &&
-      (ts.isStringLiteral(append.fragment) || ts.isNoSubstitutionTemplateLiteral(append.fragment))
-    );
-  };
-
-  const walk = (node: ts.Node): void => {
-    if (found) return;
-    if (ts.isBlock(node) || ts.isSourceFile(node) || ts.isModuleBlock(node)) {
-      for (let i = 0; i + 1 < node.statements.length; i++) {
-        if (matches(node.statements[i]!, node.statements[i + 1]!)) {
-          found = true;
-          return;
-        }
-      }
-    }
-    forEachChild(node, (child) => {
-      if (found || isFunctionScopeBoundary(child)) return;
-      walk(child);
-    });
-  };
-  walk(root);
-  return found;
 }
 
 export function containsStringBuilderLoopShape(root: ts.Node): boolean {

--- a/tests/issue-1004-counted-string-proof.test.ts
+++ b/tests/issue-1004-counted-string-proof.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// (#3518 Transaction A / #1004) Non-vacuous tests for the shared counted
+// string-append proof. Runtime semantics remain covered by issue-1004.test.ts.
+import { describe, expect, it } from "vitest";
+import { analyzeSource } from "../src/checker/index.js";
+import { TsCheckerOracle } from "../src/checker/oracle.js";
+import {
+  containsCountedStringAppendCandidate,
+  countedStringAppendPlanIsCurrent,
+  planCountedStringAppend,
+} from "../src/ir/analysis/counted-string-append.js";
+import { ts } from "../src/ts-api.js";
+
+function firstFor(sourceFile: ts.SourceFile): ts.ForStatement {
+  let result: ts.ForStatement | undefined;
+  const visit = (node: ts.Node): void => {
+    if (result) return;
+    if (ts.isForStatement(node)) {
+      result = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!result) throw new Error("fixture has no for statement");
+  return result;
+}
+
+function proofFor(source: string) {
+  const { sourceFile, checker } = analyzeSource(source, "issue-1004-proof.ts");
+  const context = { checker, oracle: new TsCheckerOracle(checker) };
+  const plan = planCountedStringAppend(context, firstFor(sourceFile));
+  return { context, plan, sourceFile };
+}
+
+describe("#3518 Transaction A shared counted string proof", () => {
+  it("records exact symbols, declarations, constants, and checked trip count", () => {
+    const { context, plan } = proofFor(`
+      export function test(): string {
+        const START = 1;
+        const END = 4;
+        const PIECE0 = "xy";
+        const PIECE = PIECE0;
+        let value = "seed";
+        for (let index = START; index <= END; ++index) value += PIECE;
+        return value;
+      }
+    `);
+    expect(plan).not.toBeNull();
+    expect(plan?.start).toBe(1);
+    expect(plan?.bound).toBe(4);
+    expect(plan?.tripCount).toBe(4);
+    expect(plan?.comparison).toBe("lte");
+    expect(plan?.increment).toBe("prefix");
+    expect(plan?.startConstDeclarations).toHaveLength(1);
+    expect(plan?.boundConstDeclarations).toHaveLength(1);
+    expect(plan?.fragmentConstDeclarations).toHaveLength(2);
+    expect(plan && countedStringAppendPlanIsCurrent(context, plan)).toBe(true);
+  });
+
+  it.each([
+    ["const counter", 'const frag = "x"; let s = ""; for (const i = 0; i < 3; i++) s += frag;'],
+    ["const accumulator", 'const frag = "x"; const s = ""; for (let i = 0; i < 3; i++) s += frag;'],
+    ["mutable fragment", 'let frag = "x"; let s = ""; for (let i = 0; i < 3; i++) s += frag;'],
+    ["second accumulator write", 'const frag = "x"; let s = ""; s += "seed"; for (let i = 0; i < 3; i++) s += frag;'],
+    [
+      "captured accumulator",
+      'const frag = "x"; let s = ""; const read = () => s; for (let i = 0; i < 3; i++) s += frag;',
+    ],
+  ])("rejects %s", (_label, body) => {
+    const { plan } = proofFor(`
+      export function test(): string {
+        ${body}
+        return s;
+      }
+    `);
+    expect(plan).toBeNull();
+  });
+
+  it.each([
+    ["forward/TDZ bound", 'let s = ""; for (let i = 0; i < END; i++) s += "x"; const END = 3;'],
+    ["forward/TDZ fragment", 'const FRAG = NEXT; const NEXT = "x"; let s = ""; for (let i = 0; i < 3; i++) s += FRAG;'],
+    ["written checker constant", 'const END = 3; END = 4; let s = ""; for (let i = 0; i < END; i++) s += "x";'],
+    ["const cycle", 'const A = B; const B = A; let s = ""; for (let i = A; i < 3; i++) s += "x";'],
+    ["unsafe trip count", 'let s = ""; for (let i = -9007199254740991; i <= 9007199254740991; i++) s += "x";'],
+  ])("rejects %s", (_label, body) => {
+    expect(
+      proofFor(`
+        // @ts-nocheck
+        export function test(): string {
+          ${body}
+          return s;
+        }
+      `).plan,
+    ).toBeNull();
+  });
+
+  it("rejects a captured cross-owner bound", () => {
+    expect(
+      proofFor(`
+        const END = 3;
+        export function test(): string {
+          let s = "";
+          for (let i = 0; i < END; i++) s += "x";
+          return s;
+        }
+      `).plan,
+    ).toBeNull();
+  });
+
+  it("keeps the existing checker-free unconditional selector candidate", () => {
+    const { sourceFile } = proofFor(`
+      export function test(): string {
+        const s = "";
+        for (const i = 0; i < 3; i++) s += "x";
+        return s;
+      }
+    `);
+    const declaration = sourceFile.statements.find(ts.isFunctionDeclaration);
+    expect(declaration?.body && containsCountedStringAppendCandidate(declaration.body)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- extract the #1004 counted-string recognizer into an immutable checker-backed IR analysis plan
- share the checker-free legacy deferral syntax reader while keeping routing behavior unchanged
- revalidate declaration, symbol, dominance, capture, constant, and trip-count evidence before direct lowering
- add focused fail-closed proof mutations

This is the behavior-neutral Transaction A checkpoint for #3518. It does not claim the Prepared cutover; the typed string.repeat foundation and from-ast consumption remain follow-up transactions.

## Validation

- combined #1004 suites: 31/31
- TypeScript typecheck
- explicit LOC regrowth ratchet: PASS (net +415, allowed by #3518)
- function budget and oracle ratchet
- normal pre-commit hooks, including changed-root 13/13
- normal pre-push hooks: typecheck, lint, format, oracle/coercion ratchets, #3765 18/18, issue integrity

Refs #3518