### PR TITLE
perf(deps): upgrade Binaryen to 132

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "binaryen": "^125.0.0",
+    "binaryen": "^132.0.0",
     "bun": ">=1.3.14",
     "deno": ">=2.8.1"
   },
@@ -325,7 +325,7 @@
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22",
     "axios": "^1.16.1",
-    "binaryen": "^125.0.0",
+    "binaryen": "^132.0.0",
     "bun": "1.3.14",
     "create-react-class": "15.7.0",
     "deno": "2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^1.16.1
         version: 1.16.1
       binaryen:
-        specifier: ^125.0.0
-        version: 125.0.0
+        specifier: ^132.0.0
+        version: 132.0.0
       bun:
         specifier: 1.3.14
         version: 1.3.14
@@ -2196,8 +2196,8 @@ packages:
     resolution: {integrity: sha512-/hls/a309aZCc0itqP6uhoR+5DsKSlJVfB8Opd2BY9Ndghs84IScTunlyidyF4r2Xe3lQttnfBNIDjaNpj6mTw==}
     hasBin: true
 
-  binaryen@125.0.0:
-    resolution: {integrity: sha512-X7CUM9ZnwL/Ow++JH5AJKiemc82J7JyeryuPvXQdXBLcL/rqrC5KMUB1mHiORSolietH9sotvaOZlr6HSwPAlw==}
+  binaryen@132.0.0:
+    resolution: {integrity: sha512-4Usg7yEvwO3FMso3Oov6qkOOHSod1IEv+boKkh77kTljM+eNBouqCTbqWswGzbG+vDNO/b/v2C4gfEh1WgB9Lg==}
     hasBin: true
 
   bl@1.2.3:
@@ -6335,7 +6335,7 @@ snapshots:
 
   binaryen@123.0.0: {}
 
-  binaryen@125.0.0: {}
+  binaryen@132.0.0: {}
 
   bl@1.2.3:
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade the Binaryen peer and development dependency from 125 to 132
- regenerate the pnpm lockfile
- restore stable Acorn standalone-dynamic performance under the standardized-EH reduced O4 pipeline

## Performance

The published Binaryen 125 benchmark has a 10.99 s median and 0.00059× Node throughput, with Wasm samples growing from 2.86 s to 23.93 s across repetitions.

With Binaryen 132, the same benchmark has a 43.78 ms median and 0.1358× Node throughput, with samples remaining flat at 43.55–47.19 ms. The checksum remains 422, and the reduced pipeline still omits the unsupported Flatten pass.

## Verification

- Acorn standalone-dynamic benchmark with Binaryen 132
- 38/38 focused wasm-opt, inline-hints, and benchmark-lifecycle tests
- TypeScript typecheck
- Biome lint
- Prettier format check
- frozen-lockfile install
