### PR TITLE
fix(native-messaging): keep node fs shim MVP-compatible

### DIFF
--- a/scripts/build-node-fs-shim.mjs
+++ b/scripts/build-node-fs-shim.mjs
@@ -74,7 +74,10 @@ export const NODE_FS_SHIM_WAT = `(module
 /** Assemble the shim WAT to a validated wasm binary (Uint8Array). */
 export function buildNodeFsShim() {
   const m = binaryen.parseText(NODE_FS_SHIM_WAT);
-  m.setFeatures(binaryen.Features.All);
+  // This shim only uses MVP instructions. Binaryen 132's `Features.All` also
+  // enables CompactImports, causing `emitBinary()` to produce a module that
+  // stock Wasmtime 46 rejects unless that experimental proposal is enabled.
+  m.setFeatures(binaryen.Features.MVP);
   if (!m.validate()) {
     m.dispose();
     throw new Error("node-fs shim: binaryen validation failed");


### PR DESCRIPTION
## Summary

- restrict the MVP-only node:fs provider to Binaryen Features.MVP
- prevent Binaryen 132 from encoding the shim with experimental CompactImports
- restore compatibility with the repository-pinned Wasmtime 46 runtime

## Verification

- Binaryen 132 emits the compatible 210-byte shim
- Wasmtime 46.0.1 accepts the shim and round-trips the exact 17-byte Native Messaging frame
- tests/issue-2631-node-fs-fd-shim.test.ts: 6/6
- full pre-push validation passed

This fixes the broken-main smoke failure currently blocking the open IR PRs.