### PR TITLE
fix(codegen): preserve standalone in prototype semantics

### DIFF
--- a/plan/issues/4515-es5-standalone-language-misc-mechanisms.md
+++ b/plan/issues/4515-es5-standalone-language-misc-mechanisms.md
@@ -29,7 +29,13 @@ loc-budget-allow:
   # register's whole lifecycle and rationale live in the new leaf module
   # src/codegen/statements/eval-completion-value.ts, and eval-inline.ts SHRANK.
   - src/codegen/context/types.ts
+  # A carrier-bag miss on a fnctor must continue through the constructor's
+  # prototype object before the builtin-prototype fallback.
+  - src/codegen/object-runtime.ts
 func-budget-allow:
+  # Extend the existing `__extern_has` builder with the same fnctor prototype
+  # walk already used by value reads.
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
   # 2026-08-23 wave-5, §14.15.3 step 5 (a NORMALLY-completing `finally`
   # contributes no completion value). +2 LINES, both calls: the snapshot local's
   # lifecycle, the abrupt-exit argument and the clone-safety argument all live in

--- a/src/codegen/binary-ops-in.ts
+++ b/src/codegen/binary-ops-in.ts
@@ -35,7 +35,11 @@ import { overlayRouteActive } from "./typed-lane-overlay-route.js"; // (#4222) o
 // a carrier bag the receiver's field list cannot see — route the folded `false`.
 import { carrierBagKeyNeedsRuntime } from "./builtin-instance-key-presence.js";
 // (#4491 T4) %Object.prototype%'s own names are `in` every ordinary object.
-import { inReceiverIsObjectShaped, objectPrototypeInheritsInName } from "./object-proto-name-in.js";
+import {
+  hasExplicitNullObjectPrototype,
+  inReceiverIsObjectShaped,
+  objectPrototypeInheritsInName,
+} from "./object-proto-name-in.js";
 
 /**
  * (#3714) `emitThrowTypeError` pushes directly onto `fctx.body`; to nest its
@@ -62,6 +66,12 @@ function publicPhysicalFieldNames(rightType: ts.Type, fields: FieldDef[]): strin
   return fields
     .map((field) => field.name)
     .filter((name): name is string => name !== undefined && publicPropertyNames.has(name));
+}
+
+/** Return true for an approved standalone fnctor instance struct. */
+function isFnctorInstanceWasm(ctx: CodegenContext, wasmType: ValType): boolean {
+  if (wasmType.kind !== "ref" && wasmType.kind !== "ref_null") return false;
+  return ctx.typeIdxToStructName.get(wasmType.typeIdx)?.startsWith("__fnctor_") ?? false;
 }
 
 /**
@@ -407,7 +417,9 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
     // `__extern_has` already answers correctly — stays byte-identical.
     // See `object-proto-name-in.ts`.
     const inheritsFromObjectPrototype =
-      ctx.standalone && objectPrototypeInheritsInName(staticKey, inReceiverIsObjectShaped(rightWasm.kind));
+      ctx.standalone &&
+      !hasExplicitNullObjectPrototype(ctx, expr.right) &&
+      objectPrototypeInheritsInName(staticKey, inReceiverIsObjectShaped(rightWasm.kind));
     const has = inheritsFromObjectPrototype || (!growableReceiver && (hasInStruct || tsTypeHasProperty));
     // (#1444) When RHS is externref/anyref AND static analysis came up empty
     // (no struct field, no TS-typed prop), the answer is NOT reliably false
@@ -422,6 +434,7 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
     // overlay and the #3537 bag, so routing makes `in` agree with the read — and
     // only a folded `false` is routed, so no affirmative answer moves.
     const vecNamedKeyRoute = !has && carrierBagKeyNeedsRuntime(ctx, rightWasm, staticKey, 0);
+    const fnctorProtoRoute = !has && ctx.standalone && isFnctorInstanceWasm(ctx, rightWasm);
     // (#4515 wave-5) The SECOND half of the #4484 D guard above. That one
     // stopped a reassigned binding's stale static type from producing a wrong
     // THROW; the same staleness also produces a wrong ANSWER here, because
@@ -445,7 +458,11 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
     const reassignedReceiverRoute = rhsIsReassignedBinding && rightWasm.kind !== "ref" && rightWasm.kind !== "ref_null";
     if (
       !has &&
-      (rightWasm.kind === "externref" || rightWasm.kind === "anyref" || vecNamedKeyRoute || reassignedReceiverRoute)
+      (rightWasm.kind === "externref" ||
+        rightWasm.kind === "anyref" ||
+        vecNamedKeyRoute ||
+        reassignedReceiverRoute ||
+        fnctorProtoRoute)
     ) {
       const hasIdx = ensureLateImport(
         ctx,

--- a/src/codegen/object-proto-name-in.ts
+++ b/src/codegen/object-proto-name-in.ts
@@ -1,4 +1,6 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
 /**
  * (#4491 wave-5 T4) `"valueOf" in {}` answered **false**.
  *
@@ -96,4 +98,50 @@ export function objectPrototypeInheritsInName(staticKey: string | null, receiver
  */
 export function inReceiverIsObjectShaped(kind: string): boolean {
   return kind === "externref" || kind === "anyref" || kind === "ref" || kind === "ref_null";
+}
+
+/** Prove the source expression explicitly creates a null-prototype object. */
+export function hasExplicitNullObjectPrototype(
+  ctx: CodegenContext,
+  expr: ts.Expression,
+  seen = new Set<ts.Node>(),
+): boolean {
+  let current = expr;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  if (seen.has(current)) return false;
+  seen.add(current);
+
+  if (ts.isObjectLiteralExpression(current)) {
+    return current.properties.some(
+      (member) =>
+        ts.isPropertyAssignment(member) &&
+        (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name)) &&
+        member.name.text === "__proto__" &&
+        member.initializer.kind === ts.SyntaxKind.NullKeyword,
+    );
+  }
+
+  if (
+    ts.isCallExpression(current) &&
+    ts.isPropertyAccessExpression(current.expression) &&
+    ts.isIdentifier(current.expression.expression) &&
+    current.expression.expression.text === "Object" &&
+    current.expression.name.text === "create"
+  ) {
+    return current.arguments[0]?.kind === ts.SyntaxKind.NullKeyword;
+  }
+
+  if (ts.isIdentifier(current)) {
+    const initializer = ctx.oracle.variableInitializerOf(current);
+    if (initializer && initializer !== current) return hasExplicitNullObjectPrototype(ctx, initializer, seen);
+  }
+  return false;
 }

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -4360,6 +4360,64 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
                 },
               ] satisfies Instr[])
             : []),
+          // A carrier-bag miss is not the end of an approved fnctor's chain:
+          // walk its per-fnctor prototype `$Object` before consulting the
+          // builtin-prototype companion fallback. This mirrors the
+          // `__extern_get` arm above and makes dynamic `key in new F()` agree
+          // with the inherited value read.
+          ...(fnctorProtoStartIdx === undefined
+            ? []
+            : ([
+                { op: "local.get", index: 0 },
+                { op: "call", funcIdx: fnctorProtoStartIdx },
+                { op: "local.tee", index: 4 + (boundaryObjectHasIdx !== undefined ? 1 : 0) },
+                { op: "ref.is_null" },
+                { op: "i32.eqz" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    {
+                      op: "local.get",
+                      index: 4 + (boundaryObjectHasIdx !== undefined ? 1 : 0),
+                    },
+                    { op: "any.convert_extern" },
+                    { op: "ref.cast", typeIdx: objectTypeIdx },
+                    { op: "local.set", index: 2 },
+                    {
+                      op: "block",
+                      blockType: { kind: "empty" },
+                      body: [
+                        {
+                          op: "loop",
+                          blockType: { kind: "empty" },
+                          body: [
+                            { op: "local.get", index: 2 },
+                            { op: "ref.is_null" },
+                            { op: "br_if", depth: 1 },
+                            { op: "local.get", index: 2 },
+                            { op: "ref.as_non_null" },
+                            { op: "local.get", index: 1 },
+                            { op: "call", funcIdx: objFindIdx },
+                            { op: "ref.is_null" },
+                            { op: "i32.eqz" },
+                            {
+                              op: "if",
+                              blockType: { kind: "empty" },
+                              then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                            },
+                            { op: "local.get", index: 2 },
+                            { op: "ref.as_non_null" },
+                            { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 0 },
+                            { op: "local.set", index: 2 },
+                            { op: "br", depth: 0 },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ] satisfies Instr[])),
           // …then the inherited proto-companion consult (or the legacy 0).
           ...(protoIndexRecvHasMissInstrs(ctx, 0, 1) ?? [{ op: "i32.const", value: 0 } satisfies Instr]),
           { op: "return" },
@@ -4419,6 +4477,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         { name: "o", type: objRefNull },
         { name: "any", type: { kind: "anyref" } },
         ...(boundaryObjectHasIdx !== undefined ? [{ name: "boundaryHas", type: { kind: "i32" } as ValType }] : []),
+        ...(fnctorProtoStartIdx === undefined ? [] : [{ name: "fnctorProto", type: { kind: "externref" } as ValType }]),
       ],
       body,
     );

--- a/tests/issue-4515-in-prototype-chain.test.ts
+++ b/tests/issue-4515-in-prototype-chain.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4515 — standalone `in` membership over the Object/fnctor prototype chain.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface StandaloneOutcome {
+  result: number;
+  imports: string[];
+}
+
+async function runStandalone(sourceBody: string): Promise<StandaloneOutcome> {
+  const compiled = await compile(`${sourceBody}\nexport function test(): number { return result as number; }\n`, {
+    allowJs: true,
+    fileName: "issue-4515-in-prototype-chain.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+    inferModuleStrictArguments: false,
+  });
+  expect(compiled.success, compiled.errors.map((error) => error.message).join("; ")).toBe(true);
+  const imports = (compiled.imports ?? []).map((entry: unknown) =>
+    typeof entry === "string" ? entry : `${(entry as { module: string }).module}::${(entry as { name: string }).name}`,
+  );
+  const { instance } = await WebAssembly.instantiate(compiled.binary, {});
+  (instance.exports as Record<string, unknown> & { __module_init?: () => void }).__module_init?.();
+  return {
+    result: (instance.exports as Record<string, () => number>).test(),
+    imports,
+  };
+}
+
+describe("#4515 — standalone `in` prototype-chain fixes", () => {
+  it("sees Object.prototype.valueOf on an ordinary open object", async () => {
+    const outcome = await runStandalone(`var result = 0;\nvar object = {};\nresult = "valueOf" in object ? 1 : 0;`);
+    expect(outcome.result).toBe(1);
+    expect(outcome.imports).toEqual([]);
+  });
+
+  it("does not invent Object.prototype on Object.create(null)", async () => {
+    const outcome = await runStandalone(
+      `var result = 0;\nvar object = Object.create(null);\nresult = "valueOf" in object ? 1 : 0;`,
+    );
+    expect(outcome.result).toBe(0);
+    expect(outcome.imports).toEqual([]);
+  });
+
+  it("walks a user fnctor's per-constructor prototype object", async () => {
+    const outcome = await runStandalone(
+      `var result = 0;\n` +
+        `var proto = { phylum: "avis" };\n` +
+        `function Robin() { this.name = "robin"; }\n` +
+        `Robin.prototype = proto;\n` +
+        `var robin = new Robin();\n` +
+        `result = (("phylum" in robin) ? 10 : 0) + (robin.hasOwnProperty("phylum") ? 1 : 0);`,
+    );
+    expect(outcome.result).toBe(10);
+    expect(outcome.imports).toEqual([]);
+  });
+
+  it("preserves an object-valued constructor alias in evaluation order", async () => {
+    const outcome = await runStandalone(
+      `var result = 0;\nvar NUMBER = 0;\nresult = (NUMBER = Number, "MAX_VALUE") in NUMBER ? 1 : 0;`,
+    );
+    expect(outcome.result).toBe(1);
+    expect(outcome.imports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve prototype-chain membership for standalone `in`
- route fnctor instances through the same prototype walk as value reads
- keep assignment-updated receivers and null-prototype objects distinct

## Verification
- exact bucket: 9/15 -> 12/15
- focused tests: 4/4
- TypeScript 7 typecheck passes
- normal pre-push typecheck, lint, formatting, oracle, coercion, IR parity, budget, and issue-integrity gates pass

> Current-upstream accounting (2026-08-25): after rebasing against loopdive/js2 upstream/main, one of the three originally targeted rows remains a genuine fail-to-pass; the other two had landed independently upstream. Count this PR as +1 against the current upstream baseline.