### PR TITLE
test(annexb): cover escape and unescape globals

### DIFF
--- a/tests/issue-4516-escape-unescape.test.ts
+++ b/tests/issue-4516-escape-unescape.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4516 — standalone ES5 Annex B `escape` / `unescape`.
+ *
+ * These probes stay in allowJs top-level code so the arguments exercise the
+ * same dynamic path as the assembled Test262 harness. The global-object probe
+ * pins the callable own properties and ES5 descriptor flags required by both
+ * `prop-desc.js` rows.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-4516-escape-unescape.js",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports.map((entry) => `${entry.module}::${entry.name}`)).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { probe: () => number }).probe();
+}
+
+describe("#4516 — standalone Annex B escape/unescape", () => {
+  it("ToString-coerces undefined and omitted arguments", async () => {
+    const result = await runStandalone(`
+      var checks =
+        escape(undefined) === "undefined" &&
+        escape() === "undefined" &&
+        unescape(undefined) === "undefined" &&
+        unescape() === "undefined" &&
+        escape(null) === "null" &&
+        unescape(null) === "null";
+      export function probe() { return checks ? 1 : 0; }
+    `);
+    expect(result).toBe(1);
+  });
+
+  it("seeds callable own properties with ES5 descriptors", async () => {
+    const result = await runStandalone(`
+      export function probe() {
+        var e = Object.getOwnPropertyDescriptor(globalThis, "escape");
+        var u = Object.getOwnPropertyDescriptor(globalThis, "unescape");
+        return typeof globalThis.escape === "function" &&
+          typeof globalThis.unescape === "function" &&
+          e.writable === true && e.enumerable === false && e.configurable === true &&
+          u.writable === true && u.enumerable === false && u.configurable === true ? 1 : 0;
+      }
+    `);
+    expect(result).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- add focused current-main coverage for Annex B `escape` and `unescape`
- pin omitted/undefined/null ToString coercion
- pin callable global own properties and ES5 descriptor flags

The original implementation checkpoint was based on an older main and became redundant after equivalent behavior landed in the ES5 checkpoint. This branch was replayed as a clean current-main regression-test PR.

## Verification

- focused Vitest: 2/2
- scoped current-main Test262: 3 pass plus one compile-timeout retry in 4 files; no semantic assertion failure
- full normal pre-push hook with pnpm 10.30.2: passed
- no `--no-verify` used

Co-authored-by: Codex <codex@openai.com>