### PR TITLE
fix(regexp): support Annex B dynamic escape cases

### DIFF
--- a/plan/issues/4516-es5-standalone-small-bundles.md
+++ b/plan/issues/4516-es5-standalone-small-bundles.md
@@ -47,3 +47,27 @@ File lists per bucket are in the analysis doc.
   semantics (fix compiler) or the runner's harness wrapping (file a separate
   runner issue; do not bury a runner defect in a compiler fix).
 - annexB-b33: verify #2200/#2552 claim state on the ledger before touching.
+
+## annexB-regexp — 3
+
+The baseline census recorded 0/3 passing files: the invalid `\\c` fallback
+case refused with `Unsupported dynamic regular expression pattern`, while the
+leading/trailing BMP escape cases observed `pattern.source === undefined`.
+
+The standalone RegExp path now keeps the `\\c` Annex B fallback literal, adds
+the small `*+?` quantifier records needed by the invalid-control-letter cases,
+and routes the exact `eval("/" + pattern + "/")` peephole through the native
+standalone RegExp carrier. The focused standalone tests cover both changes and
+keep ordinary dynamic quantifiers as refusals.
+
+### Test Results
+
+- Standalone runner with `JS2WASM_EVAL_ENGINE=interpreter`: 3/3 pass
+  (`RegExp-control-escape-russian-letter.js`, `RegExp-leading-escape-BMP.js`,
+  `RegExp-trailing-escape-BMP.js`). This is the local refusal/interpreter
+  diagnostic tier, not the QuickJS CI tier.
+- The default QuickJS run passes the control-letter file but cannot execute the
+  two eval files locally because the pinned QuickJS artifact is absent; building
+  it is blocked here by missing `clang-18`/`cmake`.
+- `tests/issue-4516-regexp.test.ts` plus `tests/issue-4065.test.ts`: 36/36.
+- TypeScript 7 typecheck and targeted Prettier check: pass.

--- a/plan/issues/4516-es5-standalone-small-bundles.md
+++ b/plan/issues/4516-es5-standalone-small-bundles.md
@@ -16,6 +16,9 @@ related: [2200, 2552, 3626]
 loc-budget-allow:
   - src/codegen/regexp-standalone.ts
   - src/codegen/expressions/calls.ts
+func-budget-allow:
+  - src/codegen/regexp-standalone.ts::ensureDynamicStandaloneRegExpCompiler
+  - src/codegen/regexp-dynamic-pattern.ts::ensureDynamicPatternTokenDecoder
 ---
 
 # ES5 standalone small bundles — ~39 rows across 6 mechanical buckets

--- a/plan/issues/4516-es5-standalone-small-bundles.md
+++ b/plan/issues/4516-es5-standalone-small-bundles.md
@@ -13,6 +13,9 @@ area: codegen, runtime
 es_edition: 5
 goal: es5
 related: [2200, 2552, 3626]
+loc-budget-allow:
+  - src/codegen/regexp-standalone.ts
+  - src/codegen/expressions/calls.ts
 ---
 
 # ES5 standalone small bundles — ~39 rows across 6 mechanical buckets

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3409,7 +3409,7 @@ function classifyEvalCallExpression(expr: ts.CallExpression, checker: ts.TypeChe
  * Wasm-instantiate pipeline (~50ms). 65,536 × 50ms = an hour of wall-clock,
  * so the test always hits the 30s pool ceiling. By detecting the literal-
  * fence shape `"/" + X + "/"` we can route directly to the RegExp
- * constructor host call — same observable semantics for any code that
+ * constructor path — same observable semantics for any code that
  * inspects `.source` / `.flags` / matching behavior, but ~one
  * host-call's worth of work instead of two.
  *
@@ -3422,10 +3422,6 @@ function tryEvalAsRegExpPeephole(
   fctx: FunctionContext,
   expr: ts.CallExpression,
 ): InnerResult | undefined {
-  // #1474 — this peephole desugars `eval("/" + X + "/")` to a RegExp_new
-  // host call. RegExp has no Wasm-native engine yet, so refuse to register
-  // the host import in --target standalone (eval itself is also host-only).
-  if (ctx.standalone) return undefined;
   if (expr.arguments.length !== 1) return undefined;
 
   // Strip parens around the argument.
@@ -3447,6 +3443,16 @@ function tryEvalAsRegExpPeephole(
   if (inner.left.text !== "/") return undefined;
 
   const xExpr = inner.right;
+
+  // The standalone lane has a Wasm-native RegExp carrier now. Route the exact
+  // literal-fence shape through the native constructor instead of the
+  // runtime-eval provider, whose foreign RegExp object cannot be reflected
+  // through the standalone carrier (`pattern.source` became undefined in the
+  // ES5 BMP escape tests). This preserves the peephole's one-evaluation
+  // property while keeping the module host-free.
+  if (ctx.standalone) {
+    return compileStandaloneRegExpConstructor(ctx, fctx, [xExpr], expr) ?? undefined;
+  }
 
   // Register `RegExp_new(pattern, flags) -> externref` on demand. The 7 target
   // tests (regexp/S7.8.5_*, comments/S7.4_A6, AnnexB/RegExp/RegExp-*-escape-BMP)

--- a/src/codegen/regexp-dynamic-pattern.ts
+++ b/src/codegen/regexp-dynamic-pattern.ts
@@ -52,6 +52,12 @@ export const TOKEN_LITERAL = 1;
 export const TOKEN_ANY = 2;
 /** `|` — alternation separator. */
 export const TOKEN_PIPE = 3;
+/** `*` — greedy zero-or-more quantifier (Annex B `\\c` fallback only). */
+export const TOKEN_STAR = 4;
+/** `+` — greedy one-or-more quantifier (Annex B `\\c` fallback only). */
+export const TOKEN_PLUS = 5;
+/** `?` — greedy zero-or-one quantifier (Annex B `\\c` fallback only). */
+export const TOKEN_OPT = 6;
 
 /**
  * The decoder packs its answer into one i32 so the callers need no
@@ -121,6 +127,8 @@ const inRange = (local: number, lo: number, hi: number): Instr[] => [
  * | `\c` + other      | LITERAL(`\`)  (Annex B)      | 1   |
  * | `\f\n\r\t\v`      | LITERAL(control)             | 2   |
  * | `\` + non-alnum   | LITERAL(that unit)           | 2   |
+ * | `\\c` + `*+?`       | STAR/PLUS/OPT quantifier      | 1   |
+ * | `\\c` + `{}`        | LITERAL(that unit)            | 1   |
  * | ordinary unit     | LITERAL(unit)                | 1   |
  * | anything else     | UNSUPPORTED                  | 1   |
  *
@@ -179,6 +187,29 @@ export function ensureDynamicPatternTokenDecoder(ctx: CodegenContext, strDataRef
         { op: "local.get", index: I },
         { op: "i32.add" },
         { op: "i32.const", value: delta },
+        { op: "i32.add" },
+        { op: "array.get_u", typeIdx: dataTypeIdx },
+      ],
+      else: [{ op: "i32.const", value: -1 }],
+    },
+  ];
+
+  /** Read a preceding source unit, or -1 before the pattern start. */
+  const readBehind = (delta: number): Instr[] => [
+    { op: "local.get", index: I },
+    { op: "i32.const", value: delta },
+    { op: "i32.add" },
+    { op: "i32.const", value: 0 },
+    { op: "i32.ge_s" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [
+        { op: "local.get", index: PDATA },
+        { op: "local.get", index: POFF },
+        { op: "local.get", index: I },
+        { op: "i32.const", value: delta },
+        { op: "i32.add" },
         { op: "i32.add" },
         { op: "array.get_u", typeIdx: dataTypeIdx },
       ],
@@ -327,6 +358,29 @@ export function ensureDynamicPatternTokenDecoder(ctx: CodegenContext, strDataRef
     return out;
   })();
 
+  // Annex B's `\\c` fallback consumes only the backslash. The following `c`
+  // is an ordinary atom, so `\\c*`, `\\c+`, and `\\c?` quantify that `c`;
+  // unmatched braces remain literal identity escapes. Keep this context local
+  // to the fallback so ordinary dynamic `a*b` remains a loud refusal.
+  const annexBControlFallbackMeta: Instr[] = [
+    ...readBehind(-1),
+    { op: "i32.const", value: 0x63 },
+    { op: "i32.eq" },
+    ...readBehind(-2),
+    { op: "i32.const", value: 0x5c },
+    { op: "i32.eq" },
+    { op: "i32.and" },
+  ];
+
+  const annexBControlFallbackLiteral = cond(
+    annexBControlFallbackMeta,
+    packDynamic(TOKEN_LITERAL, 1, [{ op: "local.get", index: C }]),
+    cond(isMeta, UNSUPPORTED, packDynamic(TOKEN_LITERAL, 1, [{ op: "local.get", index: C }])),
+  );
+
+  const annexBControlFallbackQuantifier = (kind: number): Instr[] =>
+    cond(annexBControlFallbackMeta, packConst(kind, 1, 0), annexBControlFallbackLiteral);
+
   const body: Instr[] = [
     ...readAhead(0),
     { op: "local.set", index: C },
@@ -356,9 +410,17 @@ export function ensureDynamicPatternTokenDecoder(ctx: CodegenContext, strDataRef
         eqConst(C, 0x2e),
         packConst(TOKEN_ANY, 1, 0),
         cond(
-          eqConst(C, 0x5c),
-          backslash,
-          cond(isMeta, UNSUPPORTED, packDynamic(TOKEN_LITERAL, 1, [{ op: "local.get", index: C }])),
+          eqConst(C, 0x2a),
+          annexBControlFallbackQuantifier(TOKEN_STAR),
+          cond(
+            eqConst(C, 0x2b),
+            annexBControlFallbackQuantifier(TOKEN_PLUS),
+            cond(
+              eqConst(C, 0x3f),
+              annexBControlFallbackQuantifier(TOKEN_OPT),
+              cond(eqConst(C, 0x5c), backslash, annexBControlFallbackLiteral),
+            ),
+          ),
         ),
       ),
     ),

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -93,7 +93,10 @@ import {
   ensureDynamicPatternTokenDecoder,
   makeDynamicPatternAccessors,
   TOKEN_ANY,
+  TOKEN_OPT,
   TOKEN_PIPE,
+  TOKEN_PLUS,
+  TOKEN_STAR,
   TOKEN_UNSUPPORTED,
 } from "./regexp-dynamic-pattern.js";
 
@@ -1096,6 +1099,13 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
   // verbatim as its match payload. `.` (ANY) and any multi-unit escape make
   // source text != matched text, which that path has no way to express.
   const PLAIN = 30;
+  // #4516 — Annex B `\\c` fallback quantifiers are only valid immediately
+  // after an atom. Keep malformed/ordinary dynamic quantifiers loud.
+  const CAN_QUANTIFY = 31;
+  // Emission lookahead for a quantifier following the current atom.
+  const NEXT = 32;
+  // Start pc of the current quantified atom's loop.
+  const QSTART = 33;
   const readFlatUnit = (dataLocal: number, offLocal: number, indexLocal: number): Instr[] => [
     { op: "local.get", index: dataLocal },
     { op: "local.get", index: offLocal },
@@ -1324,6 +1334,8 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
     { op: "local.set", index: CHARS },
     { op: "i32.const", value: 1 },
     { op: "local.set", index: PLAIN },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: CAN_QUANTIFY },
     { op: "local.get", index: START },
     { op: "local.set", index: I },
     {
@@ -1387,12 +1399,106 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                   then: [
                     { op: "i32.const", value: 0 },
                     { op: "local.set", index: SIMPLE },
+                    { op: "i32.const", value: 0 },
+                    { op: "local.set", index: CAN_QUANTIFY },
                   ],
                   else: [
-                    { op: "local.get", index: CHARS },
-                    { op: "i32.const", value: 1 },
-                    { op: "i32.add" },
-                    { op: "local.set", index: CHARS },
+                    // `*`, `+`, and `?` are operators rather than program
+                    // records. They add the records needed to wrap the
+                    // immediately preceding atom; a leading/repeated
+                    // quantifier remains a loud unsupported pattern.
+                    ...tk.kindIs(TOKEN_STAR),
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: [
+                        { op: "local.get", index: CAN_QUANTIFY },
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [
+                            { op: "local.get", index: CHARS },
+                            { op: "i32.const", value: 2 },
+                            { op: "i32.add" },
+                            { op: "local.set", index: CHARS },
+                          ],
+                          else: [
+                            { op: "i32.const", value: 0 },
+                            { op: "local.set", index: SIMPLE },
+                          ],
+                        },
+                        { op: "i32.const", value: 0 },
+                        { op: "local.set", index: PLAIN },
+                        { op: "i32.const", value: 0 },
+                        { op: "local.set", index: CAN_QUANTIFY },
+                      ],
+                      else: [
+                        ...tk.kindIs(TOKEN_PLUS),
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [
+                            { op: "local.get", index: CAN_QUANTIFY },
+                            {
+                              op: "if",
+                              blockType: { kind: "empty" },
+                              then: [
+                                { op: "local.get", index: CHARS },
+                                { op: "i32.const", value: 1 },
+                                { op: "i32.add" },
+                                { op: "local.set", index: CHARS },
+                              ],
+                              else: [
+                                { op: "i32.const", value: 0 },
+                                { op: "local.set", index: SIMPLE },
+                              ],
+                            },
+                            { op: "i32.const", value: 0 },
+                            { op: "local.set", index: PLAIN },
+                            { op: "i32.const", value: 0 },
+                            { op: "local.set", index: CAN_QUANTIFY },
+                          ],
+                          else: [
+                            ...tk.kindIs(TOKEN_OPT),
+                            {
+                              op: "if",
+                              blockType: { kind: "empty" },
+                              then: [
+                                { op: "local.get", index: CAN_QUANTIFY },
+                                {
+                                  op: "if",
+                                  blockType: { kind: "empty" },
+                                  then: [
+                                    { op: "local.get", index: CHARS },
+                                    { op: "i32.const", value: 1 },
+                                    { op: "i32.add" },
+                                    { op: "local.set", index: CHARS },
+                                  ],
+                                  else: [
+                                    { op: "i32.const", value: 0 },
+                                    { op: "local.set", index: SIMPLE },
+                                  ],
+                                },
+                                { op: "i32.const", value: 0 },
+                                { op: "local.set", index: PLAIN },
+                                { op: "i32.const", value: 0 },
+                                { op: "local.set", index: CAN_QUANTIFY },
+                              ],
+                              else: [
+                                // A literal or `.` is an atom that a later
+                                // quantifier may decorate.
+                                { op: "local.get", index: CHARS },
+                                { op: "i32.const", value: 1 },
+                                { op: "i32.add" },
+                                { op: "local.set", index: CHARS },
+                                { op: "i32.const", value: 1 },
+                                { op: "local.set", index: CAN_QUANTIFY },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
                   ],
                 },
               ],
@@ -1571,10 +1677,52 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                         ...readToken(J),
                         ...tk.kindIs(TOKEN_PIPE),
                         { op: "br_if", depth: 1 },
-                        { op: "local.get", index: ALTN },
-                        { op: "i32.const", value: 1 },
-                        { op: "i32.add" },
-                        { op: "local.set", index: ALTN },
+                        // Quantifiers contribute only their loop scaffolding:
+                        // `*` is SPLIT+atom+JMP (+2 records), while `+`/`?`
+                        // each add one. Other tokens contribute one record.
+                        ...tk.kindIs(TOKEN_STAR),
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [
+                            { op: "local.get", index: ALTN },
+                            { op: "i32.const", value: 2 },
+                            { op: "i32.add" },
+                            { op: "local.set", index: ALTN },
+                          ],
+                          else: [
+                            ...tk.kindIs(TOKEN_PLUS),
+                            {
+                              op: "if",
+                              blockType: { kind: "empty" },
+                              then: [
+                                { op: "local.get", index: ALTN },
+                                { op: "i32.const", value: 1 },
+                                { op: "i32.add" },
+                                { op: "local.set", index: ALTN },
+                              ],
+                              else: [
+                                ...tk.kindIs(TOKEN_OPT),
+                                {
+                                  op: "if",
+                                  blockType: { kind: "empty" },
+                                  then: [
+                                    { op: "local.get", index: ALTN },
+                                    { op: "i32.const", value: 1 },
+                                    { op: "i32.add" },
+                                    { op: "local.set", index: ALTN },
+                                  ],
+                                  else: [
+                                    { op: "local.get", index: ALTN },
+                                    { op: "i32.const", value: 1 },
+                                    { op: "i32.add" },
+                                    { op: "local.set", index: ALTN },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
                         ...advanceByToken(J),
                         { op: "br", depth: 0 },
                       ],
@@ -1626,10 +1774,102 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                         // exactly `CHARS` records and stays inside the
                         // `NINSTR * 3` program array.
                         ...readToken(K),
-                        ...tk.value(),
-                        { op: "local.set", index: CH },
-                        ...emitRecord(tk.recordOp(), dynamicCharOperand),
-                        ...advanceByToken(K),
+                        // Quantifiers are operators: wrap the immediately
+                        // preceding atom instead of emitting a standalone
+                        // record. The decoder scopes these tokens to the
+                        // Annex B `\\c` fallback, so ordinary unsupported
+                        // quantifier patterns still take the refusal path.
+                        { op: "local.get", index: K },
+                        ...tk.len(),
+                        { op: "i32.add" },
+                        { op: "local.set", index: NEXT },
+                        ...readToken(NEXT),
+                        ...tk.kindIs(TOKEN_STAR),
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [
+                            { op: "local.get", index: PC },
+                            { op: "local.set", index: QSTART },
+                            ...emitRecord(
+                              [{ op: "i32.const", value: ReOp.SPLIT }],
+                              [{ op: "local.get", index: PC }, { op: "i32.const", value: 1 }, { op: "i32.add" }],
+                              [{ op: "local.get", index: PC }, { op: "i32.const", value: 3 }, { op: "i32.add" }],
+                            ),
+                            ...readToken(K),
+                            ...tk.value(),
+                            { op: "local.set", index: CH },
+                            ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                            ...emitRecord([{ op: "i32.const", value: ReOp.JMP }], [{ op: "local.get", index: QSTART }]),
+                            ...readToken(NEXT),
+                            ...advanceByToken(NEXT),
+                            { op: "local.get", index: NEXT },
+                            { op: "local.set", index: K },
+                          ],
+                          else: [
+                            ...tk.kindIs(TOKEN_PLUS),
+                            {
+                              op: "if",
+                              blockType: { kind: "empty" },
+                              then: [
+                                { op: "local.get", index: PC },
+                                { op: "local.set", index: QSTART },
+                                ...readToken(K),
+                                ...tk.value(),
+                                { op: "local.set", index: CH },
+                                ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                                ...emitRecord(
+                                  [{ op: "i32.const", value: ReOp.SPLIT }],
+                                  [{ op: "local.get", index: QSTART }],
+                                  [{ op: "local.get", index: PC }, { op: "i32.const", value: 1 }, { op: "i32.add" }],
+                                ),
+                                ...readToken(NEXT),
+                                ...advanceByToken(NEXT),
+                                { op: "local.get", index: NEXT },
+                                { op: "local.set", index: K },
+                              ],
+                              else: [
+                                ...tk.kindIs(TOKEN_OPT),
+                                {
+                                  op: "if",
+                                  blockType: { kind: "empty" },
+                                  then: [
+                                    { op: "local.get", index: PC },
+                                    { op: "local.set", index: QSTART },
+                                    ...emitRecord(
+                                      [{ op: "i32.const", value: ReOp.SPLIT }],
+                                      [
+                                        { op: "local.get", index: PC },
+                                        { op: "i32.const", value: 1 },
+                                        { op: "i32.add" },
+                                      ],
+                                      [
+                                        { op: "local.get", index: PC },
+                                        { op: "i32.const", value: 2 },
+                                        { op: "i32.add" },
+                                      ],
+                                    ),
+                                    ...readToken(K),
+                                    ...tk.value(),
+                                    { op: "local.set", index: CH },
+                                    ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                                    ...readToken(NEXT),
+                                    ...advanceByToken(NEXT),
+                                    { op: "local.get", index: NEXT },
+                                    { op: "local.set", index: K },
+                                  ],
+                                  else: [
+                                    ...readToken(K),
+                                    ...tk.value(),
+                                    { op: "local.set", index: CH },
+                                    ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                                    ...advanceByToken(K),
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
                         { op: "br", depth: 0 },
                       ],
                     },
@@ -1803,6 +2043,9 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
       { name: "tok", type: { kind: "i32" } },
       { name: "altn", type: { kind: "i32" } },
       { name: "plain", type: { kind: "i32" } },
+      { name: "canQuantify", type: { kind: "i32" } },
+      { name: "next", type: { kind: "i32" } },
+      { name: "qstart", type: { kind: "i32" } },
     ],
     body,
     exported: false,

--- a/tests/issue-4516-regexp.test.ts
+++ b/tests/issue-4516-regexp.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(source: string): Promise<WebAssembly.Instance> {
+  const result = await compile(source, {
+    target: "standalone",
+    fileName: "issue-4516-regexp.ts",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const module = new WebAssembly.Module(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  return (await WebAssembly.instantiate(result.binary, {})).instance;
+}
+
+it("matches Annex B \\c fallbacks with quantifiers and literal braces", async () => {
+  const source = `
+function pattern(suffix: any): any { return "\\\\c" + suffix; }
+function flags(): any { return ""; }
+function unsupported(): any { return "a*b"; }
+export function test(): number {
+  let score = 0;
+  try {
+    score += new RegExp(pattern("*"), flags()).exec("\\\\c") !== null ? 1 : 0;
+    score += new RegExp(pattern("+"), flags()).exec("\\\\c") !== null ? 2 : 0;
+    score += new RegExp(pattern("?"), flags()).exec("\\\\") !== null ? 4 : 0;
+    score += new RegExp(pattern("{"), flags()).exec("\\\\c{") !== null ? 8 : 0;
+    score += new RegExp(pattern("}"), flags()).exec("\\\\c}") !== null ? 16 : 0;
+  } catch {
+    return -1;
+  }
+  try {
+    new RegExp(unsupported(), flags()).exec("aab");
+    return score + 100;
+  } catch {
+    return score;
+  }
+}
+`;
+  const instance = await compileStandalone(source);
+  expect((instance.exports as { test: () => number }).test()).toBe(31);
+});
+
+it("keeps eval-created escaped BMP sources on the native standalone carrier", async () => {
+  const source = `
+export function test(): number {
+  const leading = "\\\\" + String.fromCharCode(0);
+  const trailing = "a\\\\" + String.fromCharCode(0);
+  const leadingPattern: any = eval("/" + leading + "/");
+  const trailingPattern: any = eval("/" + trailing + "/");
+  return leadingPattern.source === leading && trailingPattern.source === trailing ? 1 : 0;
+}
+`;
+  const instance = await compileStandalone(source);
+  expect((instance.exports as { test: () => number }).test()).toBe(1);
+});


### PR DESCRIPTION
## Summary
- support Annex B dynamic control and BMP escape patterns in standalone RegExp
- keep malformed dynamic escapes aligned with the legacy grammar

## Verification
- exact bucket: 0/3 -> 3/3 in the interpreter/refusal tier
- focused and existing RegExp tests: 36/36
- TypeScript 7 typecheck and formatting checks pass