### PR TITLE
fix(annexb): restore B.3.3 block function hoisting

### DIFF
--- a/plan/issues/2552-annexb-phase2-rework-tdz-var-hotpath-regression.md
+++ b/plan/issues/2552-annexb-phase2-rework-tdz-var-hotpath-regression.md
@@ -1,7 +1,8 @@
 ---
 id: 2552
 title: "Annex B B.3.3 Phase 2 rework — TDZ-var outer-binding allocation perturbs hot-path codegen (-1180 test262 regression)"
-status: ready
+status: done
+completed: 2026-08-25
 sprint: current
 created: 2026-06-19
 priority: high
@@ -14,10 +15,24 @@ goal: es5
 parent: 2200
 related: [2200, 1764]
 loc-budget-allow:
+  - src/codegen/closure-exports.ts
   - src/codegen/context/types.ts
+  - src/codegen/expressions/assignment.ts
   - src/codegen/expressions/call-identifier.ts
   - src/codegen/expressions/call-tail-dispatch.ts
+  - src/codegen/expressions/call-receiver-method.ts
+  - src/codegen/expressions/calls-closures.ts
   - src/codegen/expressions/eval-inline.ts
+  - src/codegen/expressions/identifiers.ts
+  - src/codegen/statements.ts
+  - src/codegen/statements/nested-declarations.ts
+  - src/codegen/typeof-delete.ts
+func-budget-allow:
+  - src/codegen/closure-exports.ts::emitClosureCallExportN
+  - src/codegen/closure-exports.ts::emitClosureMethodCallExportN
+  - src/codegen/expressions/call-identifier.ts::compileIdentifierCall
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
+  - src/codegen/expressions/identifiers.ts::compileIdentifierCore
 origin: "2026-06-19 — #2200 Phase 2 (PR #1769) failed the full test262-regression gate -1180; parked Phase-1-only. This is the rework follow-up."
 ---
 

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -562,6 +562,7 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
       vecTypeIdx: number;
       arrTypeIdx: number;
       elemType: ValType;
+      emptyStruct?: boolean;
     };
   }[] = [];
   const restEntries: (typeof entries)[number][] = [];
@@ -601,6 +602,23 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
             selfTypeIdx,
             closureArity: hostArity,
             rest: { matchTypeIdx: typeIdx, vecTypeIdx, arrTypeIdx, elemType: arrDef.element },
+          });
+          continue;
+        }
+        const vecDef = mod.types[vecTypeIdx];
+        if (vecDef?.kind === "struct" && vecDef.fields.length === 0) {
+          restEntries.push({
+            funcTypeIdx: info.funcTypeIdx,
+            returnType: info.returnType,
+            selfTypeIdx,
+            closureArity: hostArity,
+            rest: {
+              matchTypeIdx: typeIdx,
+              vecTypeIdx,
+              arrTypeIdx: -1,
+              elemType: { kind: "externref" },
+              emptyStruct: true,
+            },
           });
           continue;
         }
@@ -707,7 +725,9 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
         funcTypeDef?.kind === "func" && funcTypeDef.params.length >= i + 2 ? funcTypeDef.params[i + 1] : undefined;
       argInstrs.push(...buildArgConversion(i + 1, paramType));
     }
-    if (entry.rest) {
+    if (entry.rest?.emptyStruct) {
+      argInstrs.push({ op: "struct.new", typeIdx: entry.rest.vecTypeIdx });
+    } else if (entry.rest) {
       const restCount = arity - entry.closureArity;
       argInstrs.push({ op: "i32.const", value: restCount });
       for (let i = entry.closureArity; i < arity; i++) {
@@ -754,10 +774,22 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
       setupInstrs.push({ op: "global.set", index: extrasArgvGlobalIdx });
     }
 
+    // Most closure trampolines receive their closure self as parameter 0.
+    // The synthetic `arguments` function used for an Annex-B declaration that
+    // collides with the enclosing function's implicit arguments binding is a
+    // genuine zero-parameter function, however: it has no self parameter at
+    // all.  Supplying the wrapper self to that `call_ref` leaves one extra
+    // value on the stack and makes the generated dispatcher invalid.
+    const directZeroParam = funcTypeDef?.kind === "func" && funcTypeDef.params.length === 0;
+    const selfArgInstrs: Instr[] = directZeroParam
+      ? []
+      : [
+          { op: "local.get", index: anyLocal },
+          { op: "ref.cast", typeIdx: entry.selfTypeIdx },
+        ];
     const callBody: Instr[] = [
       ...setupInstrs,
-      { op: "local.get", index: anyLocal },
-      { op: "ref.cast", typeIdx: entry.selfTypeIdx },
+      ...selfArgInstrs,
       ...argInstrs,
       { op: "local.get", index: funcLocal },
       { op: "ref.cast", typeIdx: entry.funcTypeIdx },
@@ -1046,6 +1078,7 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
       vecTypeIdx: number;
       arrTypeIdx: number;
       elemType: ValType;
+      emptyStruct?: boolean;
     };
   }[] = [];
   const restEntries: (typeof entries)[number][] = [];
@@ -1081,6 +1114,23 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
             selfTypeIdx,
             closureArity: hostArity,
             rest: { matchTypeIdx: typeIdx, vecTypeIdx, arrTypeIdx, elemType: arrDef.element },
+          });
+          continue;
+        }
+        const vecDef = mod.types[vecTypeIdx];
+        if (vecDef?.kind === "struct" && vecDef.fields.length === 0) {
+          restEntries.push({
+            funcTypeIdx: info.funcTypeIdx,
+            returnType: info.returnType,
+            selfTypeIdx,
+            closureArity: hostArity,
+            rest: {
+              matchTypeIdx: typeIdx,
+              vecTypeIdx,
+              arrTypeIdx: -1,
+              elemType: { kind: "externref" },
+              emptyStruct: true,
+            },
           });
           continue;
         }
@@ -1212,7 +1262,9 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
         funcTypeDef?.kind === "func" && funcTypeDef.params.length >= i + 2 ? funcTypeDef.params[i + 1] : undefined;
       argInstrs.push(...buildArgConversion(i + 2, i, paramType));
     }
-    if (entry.rest) {
+    if (entry.rest?.emptyStruct) {
+      argInstrs.push({ op: "struct.new", typeIdx: entry.rest.vecTypeIdx });
+    } else if (entry.rest) {
       const restCount = arity - entry.closureArity;
       argInstrs.push({ op: "i32.const", value: restCount });
       for (let i = entry.closureArity; i < arity; i++) {

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -239,8 +239,17 @@ function emitAnnexBOuterBindingWriteFlag(fctx: FunctionContext, name: string): v
   if (!fctx.annexBOuterBindings?.has(name)) return;
   const flagLocal = fctx.tdzFlagLocals?.get(name);
   if (flagLocal === undefined) return;
-  fctx.body.push({ op: "i32.const", value: 1 });
-  fctx.body.push({ op: "local.set", index: flagLocal });
+  const boxed = fctx.boxedTdzFlags?.get(name);
+  if (boxed) {
+    // Captured Annex-B outer bindings share their flag through an i32 ref
+    // cell; the `tdzFlagLocals` entry is the box local in this case.
+    fctx.body.push({ op: "local.get", index: boxed.localIdx });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "struct.set", typeIdx: boxed.refCellTypeIdx, fieldIdx: 0 });
+  } else {
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "local.set", index: flagLocal });
+  }
 }
 
 export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): InnerResult {

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -75,6 +75,7 @@ import {
   pushParamSentinel,
 } from "../type-coercion.js";
 import { compileAnnexBEscapeCall } from "../annexb-escape-call.js"; // (#3064 / #4556)
+import { annexBDeclaringRange } from "../annexb-cancel.js";
 import { URI_DECODE_MASK, URI_ENCODE_MASK } from "../uri-encoding-native.js";
 import { ensureWasiWriteFileStringsHelper } from "../wasi.js";
 import { wasiAllocStringData } from "./builtins.js";
@@ -1337,7 +1338,7 @@ export function compileIdentifierCall(
       isOutOfScopeNestedBinding = !visible;
     }
 
-    const isLocallyShadowed = localBindingShadowsCapturingFunction(ctx, fctx, expr.expression);
+    const locallyShadowsFunction = localBindingShadowsCapturingFunction(ctx, fctx, expr.expression);
 
     // (#4133/#4134) `ctx.closureMap` is a THIRD bare-name namespace and it is
     // consulted BEFORE `funcMap`. A visible nested declaration lexically
@@ -1352,6 +1353,18 @@ export function compileIdentifierCall(
     // sibling reached another module's `const equal = function equal(...)` and
     // the enclosing function silently returned 0.
     const nestedBindingVisible = nestedOwnerDecl !== undefined && !isOutOfScopeNestedBinding;
+    // Annex B block functions shadow a same-named parameter/local only while
+    // evaluating their declaring block.  In particular, a function declaration
+    // named `arguments` must win over the enclosing function's implicit
+    // arguments object for `arguments()` inside that block; property reads such
+    // as `arguments.toString()` remain on the ordinary local path.
+    const annexBBlockFunctionCall =
+      nestedBindingVisible &&
+      nestedOwnerDecl !== undefined &&
+      annexBDeclaringRange(nestedOwnerDecl) !== null &&
+      expr.getStart() >= annexBDeclaringRange(nestedOwnerDecl)!.getStart() &&
+      expr.end <= annexBDeclaringRange(nestedOwnerDecl)!.end;
+    const isLocallyShadowed = locallyShadowsFunction && !annexBBlockFunctionCall;
     const hasVisibleClosureStorage =
       fctx.localMap.has(funcName) || ctx.moduleGlobals.has(funcName) || ctx.capturedGlobals.has(funcName);
     // `closureMap` is keyed by a bare identifier across the complete linked

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -125,6 +125,7 @@ import { ensureTaMapFilterHelper } from "../ta-hof-map-filter.js";
 import { ensureUint8ToBase64, ensureUint8ToHex } from "../uint8-codec.js";
 import { tryCompileTemporalMethodCall } from "../temporal-native.js";
 import { ensureTextEncodingHelpers } from "../text-encoding-native.js";
+import { isArgumentsObjectIdentifier } from "../arguments-object-mop.js";
 import { defaultValueInstrs, emitGuardedRefCast, pushDefaultValue } from "../type-coercion.js";
 import { compileDateMethodCall } from "./builtins.js";
 // (#4479 slice 2) Annex B §B.2.2 legacy accessor methods on an ordinary receiver.
@@ -2279,6 +2280,25 @@ export function compileReceiverMethodCall(
   // Do not specialize it as a Wasm vec from the method spelling alone: the
   // generic object-runtime call preserves the admitted raw JS receiver and
   // reaches the boundary-object adapter only on its non-native fallback.
+  // Standalone/WASI represent the implicit `arguments` object as a packed vec,
+  // so the array-method dispatcher must not claim its inherited toString.
+  // §10.6 exposes the ordinary-object tag instead. Keep this before the array
+  // arm and binding-aware so an explicit local/parameter named `arguments`
+  // remains on the ordinary property path.
+  if (
+    (ctx.standalone || ctx.wasi) &&
+    propAccess.name.text === "toString" &&
+    expr.arguments.length === 0 &&
+    ts.isIdentifier(propAccess.expression) &&
+    isArgumentsObjectIdentifier(ctx, fctx, propAccess.expression) &&
+    !sourceOverridesMethodOnReceiver(propAccess.expression, "toString", ctx)
+  ) {
+    const tag = "[object Arguments]";
+    addStringConstantGlobal(ctx, tag);
+    fctx.body.push(...stringConstantExternrefInstrs(ctx, tag));
+    return { kind: "externref" };
+  }
+
   if (
     !(
       ctx.targetProfile.semanticProviders === "native-first" &&

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -441,6 +441,17 @@ function compileRestClosureArguments(
     pushDefaultValue(fctx, restType, ctx);
     return { fixedParamCount, restExternLocals: [] };
   }
+  // TypeScript represents an unused `...rest` parameter as an empty tuple
+  // struct rather than the ordinary `(length, data)` vec.  It is still a
+  // non-null lifted formal, so padding it with `pushDefaultValue(ref)` emits
+  // `ref.null; ref.as_non_null` and traps before the callee can materialize its
+  // `arguments` object.  Construct the canonical empty tuple instead; the
+  // arguments-object builder treats the parameter as a normal boxed formal.
+  const restDef = ctx.mod.types[restType.typeIdx];
+  if (restDef?.kind === "struct" && restDef.fields.length === 0) {
+    fctx.body.push({ op: "struct.new", typeIdx: restType.typeIdx });
+    return { fixedParamCount, restExternLocals: [] };
+  }
   const vecInfo = getVecInfo(ctx, restType.typeIdx);
   if (vecInfo === null) {
     pushDefaultValue(fctx, restType, ctx);

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -744,7 +744,14 @@ function compileIdentifierCore(
   if (cancelRanges && cancelRanges.length > 0) {
     const pos = id.getStart();
     const insideDeclaringBlock = cancelRanges.some((r) => pos >= r.start && pos < r.end);
-    if (!insideDeclaringBlock) return emitAnnexBUnboundReferenceError(ctx, fctx, name);
+    // A cancelled block declaration named `arguments` does not erase the
+    // enclosing function's implicit arguments binding.  Keep that binding
+    // available outside the declaring block; calls inside the block are
+    // resolved separately by the Annex-B call-site path.
+    const preservesImplicitArguments = name === "arguments" && fctx.localMap.has(name);
+    if (!insideDeclaringBlock && !preservesImplicitArguments) {
+      return emitAnnexBUnboundReferenceError(ctx, fctx, name);
+    }
   }
 
   // (#3980, Annex B B.3.3) The `fctx.annexBCancelled` map above is per-
@@ -759,10 +766,11 @@ function compileIdentifierCore(
   // short-circuiting on the (near-universally) empty site list, so non-Annex-B
   // modules are byte-identical.
   const annexBSites = collectAnnexBCancelSites(id.getSourceFile());
-  if (annexBSites.length > 0 && annexBReadIsUnbound(annexBSites, id)) {
+  const preservesImplicitArguments = name === "arguments" && fctx.localMap.has(name);
+  if (annexBSites.length > 0 && !preservesImplicitArguments && annexBReadIsUnbound(annexBSites, id)) {
     return emitAnnexBUnboundReferenceError(ctx, fctx, name);
   }
-  if (annexBReadEscapesFunctionScope(id)) {
+  if (!preservesImplicitArguments && annexBReadEscapesFunctionScope(id)) {
     return emitAnnexBUnboundReferenceError(ctx, fctx, name);
   }
 
@@ -786,11 +794,28 @@ function compileIdentifierCore(
       emitUndefined(ctx, fctx);
       const undefLocal = allocLocal(fctx, `__annexb_undef_${fctx.locals.length}`, { kind: "externref" });
       fctx.body.push({ op: "local.set", index: undefLocal });
-      fctx.body.push({ op: "local.get", index: flagLocal });
+      const boxed = fctx.boxedTdzFlags?.get(name);
+      if (boxed) {
+        // Captured Annex-B outer bindings share their TDZ state through an
+        // i32 ref cell.  The `tdzFlagLocals` entry then names the box local,
+        // not an i32 local, so dereference it before using it as a condition.
+        fctx.body.push({ op: "local.get", index: boxed.localIdx });
+        fctx.body.push({ op: "struct.get", typeIdx: boxed.refCellTypeIdx, fieldIdx: 0 });
+      } else {
+        fctx.body.push({ op: "local.get", index: flagLocal });
+      }
       fctx.body.push({
         op: "if",
         blockType: { kind: "val", type: { kind: "externref" } },
-        then: [{ op: "local.get", index: outerLocal }],
+        then: (() => {
+          const valueBox = fctx.boxedCaptures?.get(name);
+          return valueBox
+            ? [
+                { op: "local.get", index: outerLocal },
+                { op: "struct.get", typeIdx: valueBox.refCellTypeIdx, fieldIdx: 0 },
+              ]
+            : [{ op: "local.get", index: outerLocal }];
+        })(),
         else: [{ op: "local.get", index: undefLocal }],
       });
       return { kind: "externref" };

--- a/src/codegen/statements.ts
+++ b/src/codegen/statements.ts
@@ -22,7 +22,7 @@ import {
   hasInterveningLexicalBinder,
 } from "./annexb-cancel.js";
 import { tryCompileAnnexBModuleBlockFnEvaluation } from "./annexb-global-live-binding.js";
-import { emitCachedFuncClosureAccess } from "./closures.js";
+import { emitCachedFuncClosureAccess, emitFuncRefAsClosure } from "./closures.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocLocal, getLocalType } from "./context/locals.js";
 import { attachSourcePos, getSourcePos } from "./context/source-pos.js";
@@ -32,6 +32,7 @@ import { restoreBlockScopedShadows, saveBlockScopedShadows } from "./statements/
 import { resetCompletionValueForStatement, sinkExpressionStatementValue } from "./statements/eval-completion-value.js";
 import { compileWithStatement } from "./with-scope.js";
 import { expressionRunsUserCode } from "./module-init-collection.js"; // (#4433) bare `typeof f();`
+import { noJsHost } from "./js-errors.js";
 
 // Sub-module imports — statement-family functions
 import {
@@ -56,6 +57,7 @@ import {
   compileNestedFunctionDeclaration,
 } from "./statements/nested-declarations.js";
 import { compileVariableStatement } from "./statements/variables.js";
+import { emitLocalTdzInit } from "./statements/tdz.js";
 import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
 import { coerceType } from "./type-coercion.js";
 import { compileClassExpression } from "./expressions/new-super.js";
@@ -229,13 +231,68 @@ function tryCompileAnnexBExistingDirectFunctionUpdate(
     }
   }
   if (innerIdx !== undefined) {
-    const closureType = emitCachedFuncClosureAccess(ctx, fctx, funcName, innerIdx);
+    const closureType = emitAnnexBFunctionClosure(ctx, fctx, stmt, funcName, innerIdx);
     if (closureType) {
       if (closureType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
       fctx.body.push({ op: "local.set", index: bindingLocal });
     }
   }
   return true;
+}
+
+/**
+ * Ordinary function declarations carry the nominal constructible marker in
+ * standalone/WASI closure values. Annex-B evaluation sites used to omit this
+ * flag while identifier reads supplied it, so both sites shared one cache
+ * global but disagreed about its struct type; the first site to initialize the
+ * cache then made the other site's ref.cast trap. Keep all declaration-value
+ * paths on the same wrapper family.
+ */
+function isOrdinaryFunctionDeclaration(ctx: CodegenContext, stmt: ts.FunctionDeclaration): boolean {
+  return (
+    (noJsHost(ctx) || ctx.targetProfile.semanticProviders === "native-first") &&
+    stmt.asteriskToken === undefined &&
+    !(stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false)
+  );
+}
+
+/**
+ * Annex-B function values may carry TDZ/capture cells when the declaration's
+ * body mutates its own binding. The cached singleton helper models the full
+ * function signature as user parameters and therefore cannot represent those
+ * hidden capture parameters; use the per-activation closure path for such
+ * declarations and retain the singleton for capture-free functions.
+ */
+function emitAnnexBFunctionClosure(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmt: ts.FunctionDeclaration,
+  funcName: string,
+  funcIdx: number,
+): ReturnType<typeof emitCachedFuncClosureAccess> {
+  const constructible = isOrdinaryFunctionDeclaration(ctx, stmt);
+  const captures = ctx.nestedFuncCaptures.get(funcName);
+  const closureType =
+    captures && captures.length > 0
+      ? emitFuncRefAsClosure(ctx, fctx, funcName, funcIdx, constructible)
+      : emitCachedFuncClosureAccess(ctx, fctx, funcName, funcIdx, constructible);
+  const boxed = fctx.boxedCaptures?.get(funcName);
+  if (!closureType || !boxed || boxed.valType.kind !== "externref") return closureType;
+
+  // A function body that assigns to its own Annex-B name captures the mutable
+  // outer binding through a ref cell.  The closure must publish itself into
+  // that cell after construction; otherwise its first `f` read observes the
+  // null value captured while the box was being allocated.
+  if (closureType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
+  const closureLocal = allocLocal(fctx, `__annexb_closure_${funcName}_${fctx.locals.length}`, {
+    kind: "externref",
+  });
+  fctx.body.push({ op: "local.tee", index: closureLocal });
+  fctx.body.push({ op: "local.get", index: fctx.localMap.get(funcName)! });
+  fctx.body.push({ op: "local.get", index: closureLocal });
+  fctx.body.push({ op: "struct.set", typeIdx: boxed.refCellTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "local.get", index: closureLocal });
+  return { kind: "externref" };
 }
 
 /**
@@ -487,15 +544,14 @@ function compileStatementInner(ctx: CodegenContext, fctx: FunctionContext, stmt:
       }
       const fnIdx = ctx.funcMap.get(funcName);
       if (outerLocal !== undefined && flagLocal !== undefined && fnIdx !== undefined) {
-        const closureType = emitCachedFuncClosureAccess(ctx, fctx, funcName, fnIdx);
+        const closureType = emitAnnexBFunctionClosure(ctx, fctx, stmt, funcName, fnIdx);
         if (closureType) {
           // Closure value is on the stack; widen to externref for the outer local.
           if (closureType.kind !== "externref") {
             fctx.body.push({ op: "extern.convert_any" });
           }
           fctx.body.push({ op: "local.set", index: outerLocal });
-          fctx.body.push({ op: "i32.const", value: 1 });
-          fctx.body.push({ op: "local.set", index: flagLocal });
+          emitLocalTdzInit(fctx, funcName);
         }
       }
       // The function body itself was already compiled during the hoist pre-pass;
@@ -543,7 +599,7 @@ function compileStatementInner(ctx: CodegenContext, fctx: FunctionContext, stmt:
       // through to today's wrong-but-valid behaviour instead.
       if (varLocal === undefined || fnIdx === undefined) return;
       if (getLocalType(fctx, varLocal)?.kind !== "externref") return;
-      const closureType = emitCachedFuncClosureAccess(ctx, fctx, funcName, fnIdx);
+      const closureType = emitAnnexBFunctionClosure(ctx, fctx, stmt, funcName, fnIdx);
       if (!closureType) return;
       if (closureType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
       fctx.body.push({ op: "local.set", index: varLocal });

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -1792,45 +1792,6 @@ function isAnnexBValueReference(id: ts.Identifier): boolean {
 }
 
 /**
- * (#2552) Is the block-fn `name` REASSIGNED (an assignment write target) anywhere
- * inside its declaring `block`? — e.g. `{ function f() { f = 123; } }`. When it
- * is, the block-local function binding and the outer var binding hold *distinct*
- * values (per §B.3.3: the outer binding captures the function value at block
- * entry and is independent of a later in-block reassignment of the block-local
- * `f`). The flag-gated single-slot outer-binding machinery cannot model that
- * split (it shares one `localMap` slot for both), so such a shape is excluded
- * from the outer-binding allocation and reverts to the pre-Phase-2 path — which
- * already passes the `*-block-scoping` test262 files. Only assignment WRITES
- * count (not reads); the scan stays within the declaring block (nested function
- * scopes are skipped — they have their own bindings).
- */
-function annexBNameReassignedInRange(name: string, declaringRange: ts.Node): boolean {
-  let reassigned = false;
-  const visit = (node: ts.Node): void => {
-    if (reassigned) return;
-    // Descend through the WHOLE block subtree, INCLUDING the block-fn's own body:
-    // the canonical mutable-binding shape is `{ function f() { f = 123; } }`, where
-    // the reassignment lives inside `f`'s body and still mutates the binding (the
-    // block-local `f` and the outer var binding then diverge). A same-named decl in
-    // a *deeper* nested scope would shadow, but conflating it here only makes the
-    // gate MORE conservative (skip the outer binding → pre-Phase-2 path), never
-    // less correct, so we accept the slight over-approximation for soundness.
-    if (
-      ts.isBinaryExpression(node) &&
-      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      ts.isIdentifier(node.left) &&
-      node.left.text === name
-    ) {
-      reassigned = true;
-      return;
-    }
-    ts.forEachChild(node, visit);
-  };
-  ts.forEachChild(declaringRange, visit);
-  return reassigned;
-}
-
-/**
  * (#2552) Does the enclosing Annex-B scope (the nearest function body / global
  * holding `block`) already declare a function-scoped `var name` or direct
  * `function name`? Per Annex B B.3.3 step 2 ("If instantiatedVarNames does not

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -1919,7 +1919,10 @@ function annexBBlockNestedEligible(fnDecl: ts.FunctionDeclaration): ts.Node | nu
   const scope = enclosingVarScope(fnDecl);
   if (scope && hasInterveningLexicalBinder(fnDecl.parent, name, scope)) return null;
   if (!annexBNameObservedOutsideRange(name, declaringRange)) return null; // (#2552) not observed → no binding
-  if (annexBNameReassignedInRange(name, declaringRange)) return null; // (#2552) mutable split → pre-Phase-2 path
+  // The block function's own lexical binding may be reassigned by its body;
+  // that does not mutate the Annex-B outer var binding. Keep the declaration
+  // on the TDZ/closure path so the outer value remains callable after the
+  // block's function activation changes its self binding.
   if (annexBSameNameVarOrFunctionInScope(name, declaringRange)) return null; // (#2552) existing F → use it
   return declaringRange;
 }

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -1336,7 +1336,15 @@ function emitAnnexBTypeofFlagBranch(ctx: CodegenContext, fctx: FunctionContext, 
   compileStringLiteral(ctx, fctx, "undefined");
   const undefStrLocal = allocLocal(fctx, `__typeof_undef_${fctx.locals.length}`, strType);
   fctx.body.push({ op: "local.set", index: undefStrLocal });
-  fctx.body.push({ op: "local.get", index: flagLocal });
+  const boxed = fctx.boxedTdzFlags?.get(name);
+  if (boxed) {
+    // Captured Annex-B outer bindings keep the flag in a shared ref cell;
+    // `tdzFlagLocals` points at that cell rather than an i32 local.
+    fctx.body.push({ op: "local.get", index: boxed.localIdx });
+    fctx.body.push({ op: "struct.get", typeIdx: boxed.refCellTypeIdx, fieldIdx: 0 });
+  } else {
+    fctx.body.push({ op: "local.get", index: flagLocal });
+  }
   fctx.body.push({
     op: "if",
     blockType: { kind: "val", type: strType },

--- a/tests/issue-2552-annexb-b33.test.ts
+++ b/tests/issue-2552-annexb-b33.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, {
+    target: "standalone",
+    nativeStrings: true,
+    allowJs: true,
+    fileName: "issue-2552-annexb-b33.js",
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#2552 Annex B b33 residuals", () => {
+  it("keeps the Annex-B outer closure callable after a block-local self write", async () => {
+    await expect(
+      runStandalone(`
+        export function test() {
+          let varBinding;
+          { function f() { f = 7; return 1; } varBinding = f; f(); }
+          return varBinding();
+        }
+      `),
+    ).resolves.toBe(1);
+  });
+
+  it("preserves the implicit arguments object around a skipped Annex-B declaration", async () => {
+    await expect(
+      runStandalone(`
+        export function test() {
+          return (function(..._) {
+            let score = arguments.toString() === "[object Arguments]" ? 1 : 0;
+            { function arguments() {} }
+            score += arguments.toString() === "[object Arguments]" ? 1 : 0;
+            return score;
+          }());
+        }
+      `),
+    ).resolves.toBe(2);
+  });
+
+  it("resolves a block function named arguments only inside its declaring block", async () => {
+    await expect(
+      runStandalone(`
+        export function test() {
+          let score = 0;
+          (function() {
+            {
+              if (arguments() === undefined) score++;
+              function arguments() {}
+              if (arguments() === undefined) score++;
+            }
+          }());
+          return score;
+        }
+      `),
+    ).resolves.toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- restore Annex B B.3.3 block-level function hoisting across declaration and closure lowering
- cover switch/default and nested declaration residual cases
- preserve strict and provider-dependent behavior

## Verification

- exact executable bucket: 3/7 -> 7/7; the eighth file remains QuickJS-provider-unmeasured
- focused Vitest: 3/3
- zero exact-bucket regressions
- full normal pre-push hook with pnpm 10.30.2: passed
- no `--no-verify` used

Co-authored-by: Codex <codex@openai.com>