### PR TITLE
fix(regexp): preserve aliased constructor identity in standalone

### DIFF
--- a/plan/issues/4233-standalone-regexp-es5-cluster.md
+++ b/plan/issues/4233-standalone-regexp-es5-cluster.md
@@ -24,6 +24,8 @@ oracle-ratchet-allow:
   - src/codegen/regexp-standalone.ts
 # loc-budget (wave-3 PR aggregate vs main): static-pattern tracing, exec arity/shape and ctor-identity arms live in the regexp subsystem module itself
 loc-budget-allow:
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/property-access.ts
   - src/codegen/regexp-standalone.ts
 ---
 

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -70,11 +70,7 @@ import { MAX_NATIVE_CONSTRUCT_ARITY, reserveNativeConstructDriver } from "../nat
 import { emitBoundConstructOnNull } from "../construct-bound.js"; // (#4196) §10.4.1.2
 import { emitRuntimeEvalConstructOnNull } from "../runtime-eval-construct.js"; // (#4438) §10.2.2
 import { emitNativeNumberFormat } from "../number-format-native.js";
-import {
-  compileStandaloneRegExpConstructor,
-  isGlobalRegExpIdentifier,
-  isGlobalRegExpType,
-} from "../regexp-standalone.js";
+import { compileStandaloneRegExpConstructor, isGlobalRegExpConstructorExpression } from "../regexp-standalone.js";
 import { emitStandaloneTest262Error, emitWasiErrorConstructor, isWasiErrorName } from "../registry/error-types.js";
 import type { InnerResult } from "../shared.js";
 import {
@@ -3638,6 +3634,16 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   // constructor path. The paren-only form previously fell through to a null
   // placeholder without evaluating the constructor body at all.
   const unwrappedLiteralCtor = unwrapNewTarget(expr.expression);
+  // #682 — standalone mode supports a reduced native RegExp subset for static
+  // literal patterns. Keep this before the non-constructable guards so the
+  // ambient `Function` type of `RegExp.prototype.constructor` cannot reject
+  // the direct prototype spelling before identity-aware lowering sees it.
+  if (
+    ctx.targetProfile.semanticProviders === "native-first" &&
+    isGlobalRegExpConstructorExpression(ctx, unwrappedLiteralCtor)
+  ) {
+    return compileStandaloneRegExpConstructor(ctx, fctx, expr.arguments ?? [], expr);
+  }
   if (ts.isFunctionExpression(unwrappedLiteralCtor)) {
     return compileNewFunctionExpression(ctx, fctx, expr, unwrappedLiteralCtor);
   }
@@ -4176,16 +4182,6 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       className = owner.name;
       thisFnctorSym = owner.sym;
     }
-  }
-
-  // #682 — standalone mode supports a reduced native RegExp subset for static
-  // literal patterns. Unsupported constructor forms still produce explicit
-  // #1474-compatible compile errors instead of JS-host imports.
-  if (
-    ctx.targetProfile.semanticProviders === "native-first" &&
-    (isGlobalRegExpType(type) || (ts.isIdentifier(expr.expression) && isGlobalRegExpIdentifier(ctx, expr.expression)))
-  ) {
-    return compileStandaloneRegExpConstructor(ctx, fctx, expr.arguments ?? [], expr);
   }
 
   // #1679 — `new this(...)` inside a static method: the callee is `this`, which

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -3440,6 +3440,15 @@ export function compilePropertyAccess(
   const objType = ctx.checker.getTypeAtLocation(expr.expression);
   const propName = ts.isPrivateIdentifier(expr.name) ? "__priv_" + expr.name.text.slice(1) : expr.name.text;
 
+  // A JavaScript binding initialized from `new RegExp(...)` is commonly
+  // widened to `any`, so its `.constructor` read cannot reach the later
+  // statically-typed builtin dispatch. Let the native RegExp identity arm run
+  // before generic any/object routing; it declines for every other receiver.
+  if (ctx.standalone && propName === "constructor") {
+    const regexpCtor = tryCompileStandaloneRegExpPropertyRead(ctx, fctx, expr);
+    if (regexpCtor !== undefined) return regexpCtor;
+  }
+
   // ES5 §15.3.5.4 poison properties.
   //
   // Strict function objects have throwing `caller` and `arguments` accessors.

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -85,6 +85,7 @@ import { tryCompileCoercedStringMatch, tryCompileCoercedStringSearch } from "./s
 import { isPlainToStringReplacement } from "./string-proto-replace.js";
 import { tryCompileStandaloneRegExpFunctionReplace } from "./regex-replace-fn.js";
 import { nativeStringRepr } from "./builtin-scaffold.js";
+import { emitBuiltinConstructorIdentity } from "./builtin-static-globals.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { addFuncType } from "./registry/types.js";
 import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "../ir/regexp-runtime-contract.js";
@@ -242,11 +243,11 @@ function isStaticStandaloneRegExpCreation(ctx: CodegenContext, expr: ts.Expressi
   if (unwrapped.kind === ts.SyntaxKind.RegularExpressionLiteral) return true;
   if (ts.isNewExpression(unwrapped)) {
     const callee = stripStaticWrapper(unwrapped.expression);
-    return ts.isIdentifier(callee) && isGlobalRegExpIdentifier(ctx, callee);
+    return isGlobalRegExpConstructorExpression(ctx, callee);
   }
   if (ts.isCallExpression(unwrapped) && !unwrapped.questionDotToken) {
     const callee = stripStaticWrapper(unwrapped.expression);
-    return ts.isIdentifier(callee) && isGlobalRegExpIdentifier(ctx, callee);
+    return isGlobalRegExpConstructorExpression(ctx, callee);
   }
   return false;
 }
@@ -460,6 +461,64 @@ export function isGlobalRegExpIdentifier(ctx: CodegenContext, ident: ts.Identifi
   if (ident.text !== "RegExp") return false;
   const sym = ctx.checker.getSymbolAtLocation(ident);
   return isDeclarationFileOnlySymbol(sym);
+}
+
+/**
+ * Whether an expression is the ambient RegExp constructor value.
+ *
+ * TypeScript gives `RegExp.prototype.constructor` the broad `Function` type
+ * (and therefore gives a variable initialized from it no construct signature)
+ * even though the ES5 value is the callable/constructable RegExp intrinsic.
+ * The standalone `new` dispatcher must retain that identity when the
+ * constructor is read through the prototype or a const/var alias; otherwise
+ * the generic externref constructor path sees a plain carrier object and
+ * reports "RegExp is not a constructor" at runtime.
+ *
+ * This is intentionally a syntax-and-binding proof, not a broad name check:
+ * shadowed `RegExp` bindings do not satisfy `isGlobalRegExpIdentifier`, and an
+ * alias is only followed through a variable declaration initializer. Writes or
+ * cycles decline and keep the ordinary dynamic path.
+ */
+export function isGlobalRegExpConstructorExpression(ctx: CodegenContext, expr: ts.Expression): boolean {
+  const seen = new Set<ts.Symbol>();
+
+  const isPrototypeExpression = (candidate: ts.Expression): boolean => {
+    const unwrapped = stripStaticWrapper(candidate);
+    if (!ts.isPropertyAccessExpression(unwrapped) || unwrapped.name.text !== "prototype") return false;
+    const base = stripStaticWrapper(unwrapped.expression);
+    return ts.isIdentifier(base) && isGlobalRegExpIdentifier(ctx, base);
+  };
+
+  const visit = (candidate: ts.Expression): boolean => {
+    const unwrapped = stripStaticWrapper(candidate);
+    if (ts.isIdentifier(unwrapped)) {
+      if (isGlobalRegExpIdentifier(ctx, unwrapped)) return true;
+      const symbol = ctx.checker.getSymbolAtLocation(unwrapped);
+      if (!symbol || seen.has(symbol)) return false;
+      seen.add(symbol);
+      const declarations = symbol.getDeclarations() ?? [];
+      if (declarations.length === 0) return false;
+      let foundVariable = false;
+      for (const declaration of declarations) {
+        if (!ts.isVariableDeclaration(declaration) || declaration.initializer === undefined) return false;
+        // A mutable alias remains claimable only when the whole binding is
+        // never assigned after its declaration. `const` naturally passes;
+        // `var`/`let` are checked because JavaScript's checker still reports
+        // their initializer as the useful identity even after a rebind.
+        if (bindingHasWrites(ctx, declaration, symbol)) return false;
+        foundVariable = true;
+        if (!visit(declaration.initializer)) return false;
+      }
+      return foundVariable;
+    }
+
+    if (ts.isPropertyAccessExpression(unwrapped) && unwrapped.name.text === "constructor") {
+      return isPrototypeExpression(unwrapped.expression);
+    }
+    return false;
+  };
+
+  return visit(expr);
 }
 
 function isDeclarationFileOnlySymbol(sym: ts.Symbol | undefined): boolean {
@@ -4240,6 +4299,22 @@ export function tryCompileStandaloneRegExpPropertyRead(
 ): ValType | null | undefined {
   if (!usesNativeRegExpProvider(ctx) || ts.isPrivateIdentifier(expr.name)) return undefined;
   const propName = expr.name.text;
+  // `var re = new RegExp(); re.constructor` is still a RegExp constructor
+  // read when JavaScript checking widens `re` to `any`. The ordinary
+  // reflection set below deliberately only covers fields physically stored on
+  // the native carrier, so keep this identity arm separate. It is guarded by
+  // the same whole-file proof used by RegExp(R)'s identity lowering: an
+  // explicit `.constructor`/descriptor/prototype override must stay on the
+  // dynamic object path rather than being silently replaced with the builtin.
+  if (
+    propName === "constructor" &&
+    regExpIdentityBrandIsProvable(expr.expression) &&
+    isKnownBackendCreatedRegExpReceiver(ctx, expr.expression)
+  ) {
+    const loaded = loadStandaloneRegExpStruct(ctx, fctx, expr.expression);
+    if (loaded === null) return null;
+    return emitBuiltinConstructorIdentity(ctx, fctx, "RegExp");
+  }
   if (!STANDALONE_REGEXP_REFLECTION_PROPS.has(propName)) return undefined;
   const objType = ctx.checker.getTypeAtLocation(expr.expression);
   const nonNull = objType.getNonNullableType?.() ?? objType;

--- a/tests/issue-4233-regexp-constructor-alias.test.ts
+++ b/tests/issue-4233-regexp-constructor-alias.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4233 follow-up — the ambient RegExp constructor must remain constructable
+// when it is obtained through RegExp.prototype.constructor. TypeScript reports
+// that property as the broad `Function` type, so the standalone new dispatcher
+// must use the binding/prototype identity rather than the checker signature.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(body: string): Promise<number> {
+  const source = `export function test(): number { ${body} }`;
+  const result = await compile(source, {
+    target: "standalone",
+    fileName: "regexp-constructor-alias.ts",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#4233 RegExp.prototype.constructor aliases", () => {
+  it("constructs through a direct prototype constructor alias", async () => {
+    const result = await runStandalone(`
+      var factory = RegExp.prototype.constructor;
+      var instance = new factory;
+      return instance.constructor === RegExp ? 1 : 0;
+    `);
+    expect(result).toBe(1);
+  });
+
+  it("constructs when the prototype constructor is used directly", async () => {
+    const result = await runStandalone(`
+      var instance = new RegExp.prototype.constructor;
+      return instance.constructor === RegExp ? 1 : 0;
+    `);
+    expect(result).toBe(1);
+  });
+
+  it("follows a second variable alias without treating it as a plain object", async () => {
+    const result = await runStandalone(`
+      var factory = RegExp.prototype.constructor;
+      var alias = factory;
+      var instance = new alias;
+      return instance.constructor === RegExp ? 1 : 0;
+    `);
+    expect(result).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Follow up #4233 for the ES5 standalone RegExp constructor identity residual. TypeScript types `RegExp.prototype.constructor` as broad `Function`, so the standalone `new` dispatcher rejected the direct prototype form and aliases were treated as generic externref values.

This change:
- recognizes the ambient RegExp constructor through `RegExp.prototype.constructor` and immutable variable aliases before non-constructable guards;
- restores `.constructor === RegExp` for backend-created RegExp values widened to `any`;
- preserves shadowed/reassigned aliases by declining the identity proof;
- adds direct, one-hop, and multi-hop focused standalone tests.

## Verification

- `tests/issue-4233-regexp-constructor-alias.test.ts`: 3/3 passed
- `tests/issue-1914.test.ts tests/issue-4089-regexp-ctor-tostring.test.ts tests/issue-3724-standalone-regexp-tostring-arg.test.ts`: 27/27 passed
- `built-ins/RegExp/prototype/S15.10.6.1_A1_T2.js`: before fail (`RegExp is not a constructor`), after pass
- full normal pre-push gates passed: typecheck/lint, format, oracle/coercion ratchets, numeric-local parity, issue integrity

The remaining census rows (dynamic group/class patterns, borrowed `Object.prototype.toString`, static `RegExp.indicator`/`Math.NaN`, object `lastIndex.valueOf`, and QuickJS-provider rows) are separate root causes.