### PR TITLE
fix(#2668): observe overlay state in indexed typeof comparisons

### DIFF
--- a/plan/issues/2668-es5-object-defineproperty-descriptor-fidelity-residual.md
+++ b/plan/issues/2668-es5-object-defineproperty-descriptor-fidelity-residual.md
@@ -3,11 +3,14 @@ id: 2668
 title: "ES5: canonical vec-index Object/property MOP residual"
 status: ready
 created: 2026-06-25
-updated: 2026-08-16
+updated: 2026-08-25
 loc-budget-allow:
   - src/codegen/vec-overlay.ts
+  - src/codegen/typeof-delete.ts
 func-budget-allow:
   - src/codegen/vec-overlay.ts::fillVecOverlayHelpers
+  - src/codegen/typeof-delete.ts::compileTypeofExpression
+  - src/codegen/typeof-delete.ts::compileTypeofComparison
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -122,6 +125,24 @@ No claim is made beyond this partition.
   observed by the reader (`15.2.3.14-5-a-4`, `15.2.3.4-4-b-6`).
 - Host `_vecDefineOwnProperty`'s first-definition workaround (host reports
   all-false after an empty redefine) — unchanged, host-side.
+
+## 2026-08-25 follow-up slice — indexed `typeof` must observe overlay state
+
+Standalone `typeof a[i]` comparisons were folded from the checker-visible
+element type even when the module's descriptor overlay was armed. A delete on
+an `Object.keys` result therefore produced a runtime tombstone that dynamic
+reads observed, while the static-looking `typeof array[0]` comparison stayed
+folded to the original element type. The comparison path now suppresses that
+fold only when the standalone overlay route is active; the existing routed
+element read and `__typeof_*` helper provide the actual result.
+
+**Measured, authentic harness, exact 86-row family, standalone.** Base
+`ef5b5d335` (52 pass / 34 fail); head with this slice (53 pass / 33 fail).
+Partition: 1 fail → pass, 0 pass → fail, 0 other status changes, 85
+unchanged; **NET +1**. The gained row is
+`test/built-ins/Object/keys/15.2.3.14-5-a-4.js`. The four-row controls in the
+focused standalone vector suites remained green; the existing dynamic-HOF
+control failure (`expected 4, got 3`) is unrelated and unchanged.
 
 ### Instrument note for the next lane
 

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -14,6 +14,7 @@ import { elementReadOfRebindWidenedArray } from "./declarations/array-rebind-ele
 import { moduleGlobalIsDynamicButStaticallyPrimitive } from "./declarations/heterogeneous-scalar-var-widening.js";
 import { typeofFoldContradictedByFieldVerdict } from "./fnctor-ctor-param-types.js";
 import { typeIsForeignReturnFnctorInstance } from "./fnctor-foreign-return.js"; // (#4637 A2) §10.2.1.3 step 13
+import { overlayRouteActive } from "./typed-lane-overlay-route.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import { popBody, pushBody } from "./context/bodies.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -1786,6 +1787,21 @@ export function compileTypeofExpression(
     if (elementReadOfRebindWidenedArray(ctx, bareTdz)) {
       forceRuntimeTypeof = true;
     }
+    // (#2668) Indexed reads can become `undefined` after a descriptor-overlay
+    // mutation (`delete a[i]`, an accessor descriptor, or an inherited index),
+    // even when TypeScript still reports the element's declared type. A static
+    // `typeof a[i]` fold would therefore hide the runtime tombstone/getter
+    // result. Keep the read on the normal runtime typeof path whenever the
+    // standalone overlay route is armed; the route's dynamic get helper then
+    // supplies the actual value before `__typeof` classifies it.
+    if (
+      !forceRuntimeTypeof &&
+      ctx.standalone === true &&
+      overlayRouteActive(ctx) &&
+      ts.isElementAccessExpression(bareTdz)
+    ) {
+      forceRuntimeTypeof = true;
+    }
     // (#4394) JSDoc-typed JS parameter — the declared type is not enforced at
     // runtime, so the fold is unsound (see typeofFoldUnsoundForJsParam).
     if (!forceRuntimeTypeof && typeofFoldUnsoundForJsParam(ctx, bareTdz)) {
@@ -2078,6 +2094,19 @@ export function compileTypeofComparison(
   // (#4428) Element read off an array whose ELEMENT representation was widened
   // — the checker still reports the first declaration's element type.
   if (staticTypeof !== null && elementReadOfRebindWidenedArray(ctx, operand)) {
+    staticTypeof = null;
+  }
+  // (#2668) A descriptor-overlay mutation can make an indexed read disappear
+  // (or invoke an accessor with a different value) without changing the
+  // checker-visible element type. Do not fold `typeof a[i]` while the
+  // standalone overlay route is armed; compile the indexed read and classify
+  // its actual runtime result instead.
+  if (
+    staticTypeof !== null &&
+    ctx.standalone === true &&
+    overlayRouteActive(ctx) &&
+    ts.isElementAccessExpression(operand)
+  ) {
     staticTypeof = null;
   }
   // (#2623 P-7) Same unsound-fold guard as compileTypeofExpression: a

--- a/tests/issue-2668-standalone-vector-typeof.test.ts
+++ b/tests/issue-2668-standalone-vector-typeof.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#2668) A descriptor-overlay mutation can make a typed-looking indexed
+// read undefined at runtime. `typeof a[i]` must observe that value instead of
+// folding from the checker-visible element type.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, { target: "standalone" });
+  expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
+  if (!result.success) return 0;
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports as Record<string, () => number>).test!();
+}
+
+describe("#2668 — standalone typeof observes descriptor-overlay indexed reads", () => {
+  it("reports undefined after deleting an Object.keys result element", async () => {
+    await expect(
+      run(`
+        const array = Object.keys({ prop1: 100 });
+        delete array[0];
+        export function test(): number {
+          return typeof array[0] === "undefined" ? 1 : 0;
+        }
+      `),
+    ).resolves.toBe(1);
+  });
+
+  it("keeps the ordinary typed typeof result when no overlay mutation occurs", async () => {
+    await expect(
+      run(`
+        const array = ["value"];
+        export function test(): number {
+          return typeof array[0] === "string" ? 1 : 0;
+        }
+      `),
+    ).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Suppress standalone `typeof a[i]` constant folding while the descriptor overlay route is active. Indexed reads then flow through the existing overlay-aware runtime get and `__typeof_*` helpers, so deleted or accessor-backed elements report their actual runtime type.

Adds a focused #2668 regression and records the exact family measurement in the issue file.

## Measurement

Authentic standalone harness over the exact 86-row defineProperty-family denominator, base `ef5b5d335`: 52 pass / 34 fail. Head: 53 pass / 33 fail. One fail-to-pass (`test/built-ins/Object/keys/15.2.3.14-5-a-4.js`), zero losses, 85 unchanged, NET +1.

## Verification

- Focused #2668 regression: 2/2 passed.
- TypeScript 5 typecheck: passed.
- Biome lint and Prettier checks: passed.
- Normal pre-commit hooks: passed (lint-staged, LOC/function budgets; sanctioned `SKIP_SLOW_PRECOMMIT=1` slow-check skip).
- Full normal pre-push: passed (typecheck/lint, format, oracle/coercion ratchets, #3765 IR parity 18/18, issue integrity).
- Existing vector suites: all relevant overlay tests pass; one pre-existing dynamic-HOF control remains expected 4 / got 3 and is unchanged.

No `--no-verify` used.

> Current-upstream accounting (2026-08-25): the original body records the stale fork baseline ef5b5d335. Rechecking against loopdive/js2 upstream/main preserves the same genuine +1 fail-to-pass and zero regression result.