### PR TITLE
fix(test262): complete standalone Number and Boolean wrapper tail

### DIFF
--- a/plan/issues/4516-es5-standalone-small-bundles.md
+++ b/plan/issues/4516-es5-standalone-small-bundles.md
@@ -16,6 +16,9 @@ related: [2200, 2552, 3626]
 loc-budget-allow:
   - src/codegen/regexp-standalone.ts
   - src/codegen/expressions/calls.ts
+  # The standalone Boolean constructor delegates object truthiness to the
+  # shared primitive-tail leaf; this driver grows by its import only.
+  - src/codegen/expressions/new-builtin-globals.ts
 func-budget-allow:
   - src/codegen/regexp-standalone.ts::ensureDynamicStandaloneRegExpCompiler
   - src/codegen/regexp-dynamic-pattern.ts::ensureDynamicPatternTokenDecoder

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -3556,9 +3556,9 @@ export interface CodegenContext extends StandaloneCapabilityDemandState, BodyRou
    *  `scanModuleMemberDeletes`. Consulted ONLY by the standalone arm of
    *  the `hasOwnProperty`/`propertyIsEnumerable` routing gate in
    *  `compilePropertyIntrospection`: a receiver that saw `Object.defineProperty`
-   *  AND appears here can have its const-fold disagree with runtime state, so it
-   *  routes to the runtime helper. Empty for nearly every module. */
+   *  AND appears here can disagree with runtime state, so it routes to runtime. */
   memberDeleteReceiverNames?: ReadonlySet<string>;
+  deletedBuiltinPrototypeMembers?: ReadonlySet<string>;
   /** (#1472 Phase A) Set of dynamic-shape object/property host-import names
    *  already refused under `--target standalone`, used to deduplicate the
    *  compile-error so a single source construct emits at most one error per

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -25,7 +25,6 @@ import {
 import type { Instr, ValType } from "../../ir/types.js";
 import { compileArrayMethodCall, resolveArrayInfo } from "../array-methods.js";
 import { isWiredTypedArrayViewName } from "../array-object-proto.js";
-import { ensureWrapperProtoDynamicMember } from "../wrapper-proto-dynamic-demand.js"; // (#4619)
 import {
   emitStandalonePromiseFinally,
   emitStandalonePromiseThen,
@@ -139,7 +138,12 @@ import {
 import { sourceDefinesFunctionMember } from "../source-function-members.js";
 import { compileExternMethodCall } from "./extern.js";
 import { tryEmitValueOfFallback } from "./valueof-fallback.js";
-import { sourceOverridesMethodOnReceiver } from "./member-override-scan.js";
+import { sourceOverridesBuiltinPrototypeMember, sourceOverridesMethodOnReceiver } from "./member-override-scan.js";
+import {
+  tryCompileWrapperDynamicMethodCall,
+  tryCompileStandaloneBooleanToString,
+  tryCompileStandaloneNumberPrototypeTail,
+} from "./standalone-primitive-tail.js";
 import { compileInternalCallArgument } from "./internal-call-argument.js";
 import {
   directObjectMethodFuncIdx,
@@ -1179,61 +1183,14 @@ export function compileReceiverMethodCall(
     }
   }
 
-  // (#1397) Wrapper-object dynamic dispatch on reassigned methods.
-  //
-  // For wrapper-object receivers (`new String/Number/Boolean(...)`) where
-  // `.toString` or `.valueOf` has been reassigned somewhere in the source,
-  // skip every static fast-path and route through `__extern_method_call`
-  // so the runtime property lookup picks up the override. Required for
-  // spec compliance with transferred prototype methods (S15.7.4.2_A4_*,
-  // S15.7.4.4_A2_*, S15.6.4.2_A2_*, S15.6.4.3_A2_*):
-  //
-  //   var s1 = new String();
-  //   s1.toString = Number.prototype.toString;
-  //   s1.toString();   // spec: TypeError; we used to return s1 itself.
-  //
-  // Primitives keep the static fast-path — primitives can't have own
-  // properties, so `"abc".toString = …` is a no-op and the short-circuit
-  // is correct. Wrappers without any matching reassignment in the source
-  // also keep the static fast-path (no perf regression for the common
-  // case). The reassignment scan is conservative — any
-  // `<expr>.<method> = …` anywhere in the source disables the static
-  // path for wrappers; that's a narrower hit than Option B (always
-  // dynamic) and matches the architect's Option D feasibility study.
-  {
-    const wrapperMethodName = propAccess.name.text;
-    const isWrapperReceiver =
-      isStringWrapperType(receiverType) || isNumberWrapperType(receiverType) || isBooleanWrapperType(receiverType);
-    const wrapperDynamicCandidate =
-      isWrapperReceiver &&
-      (wrapperMethodName === "valueOf" || wrapperMethodName === "toString") &&
-      sourceHasMethodReassignment(ctx, propAccess.expression, wrapperMethodName);
-    if (wrapperDynamicCandidate) {
-      // (#4619 family D) Make the destination of this hand-off EXIST — and do
-      // it regardless of the argument count that gates the dispatch below, for
-      // the reason recorded in wrapper-proto-dynamic-demand.ts.
-      ensureWrapperProtoDynamicMember(
-        ctx,
-        isStringWrapperType(receiverType) ? "String" : isNumberWrapperType(receiverType) ? "Number" : "Boolean",
-        wrapperMethodName,
-      );
-    }
-    // (#4619) …and dispatch dynamically for an ARGUMENT-CARRYING call too, but
-    // only for the members the spec gives no parameters — §20.3.3.3 / §22.1.3.28
-    // `valueOf` and §20.3.3.2 / §22.1.3.27 `toString`, which ignore anything
-    // passed. `Number.prototype.toString` is excluded because its argument is
-    // the §21.1.3.6 RADIX and the standalone `__extern_method_call` path
-    // deliberately carries no args (`emitWrapperDynamicMethodCall`), so routing
-    // it here would silently drop the radix. Measured on base:
-    // `(new Boolean(-1)).valueOf(false)` (test262 `S15.6.4.3_A1_T2`) fell to the
-    // legacy arm that recompiles the WRAPPER as `i32` and answered `false`.
-    const memberIgnoresArguments =
-      wrapperMethodName === "valueOf" || (wrapperMethodName === "toString" && !isNumberWrapperType(receiverType));
-    if (wrapperDynamicCandidate && (expr.arguments.length === 0 || memberIgnoresArguments)) {
-      const dynResult = emitWrapperDynamicMethodCall(ctx, fctx, propAccess.expression, wrapperMethodName);
-      if (dynResult) return dynResult;
-    }
-  }
+  const dynamicWrapper = tryCompileWrapperDynamicMethodCall(ctx, fctx, propAccess, expr, receiverType, {
+    sourceOverridesMethodOnReceiver,
+    emitWrapperDynamicMethodCall,
+  });
+  if (dynamicWrapper !== undefined) return dynamicWrapper;
+
+  const booleanToString = tryCompileStandaloneBooleanToString(ctx, fctx, propAccess, expr, receiverType);
+  if (booleanToString !== undefined) return booleanToString;
 
   // Handle wrapper type method calls: new Number(x).valueOf(), etc.
   // Since wrapper constructors now return primitives, valueOf() is a no-op identity.
@@ -2311,6 +2268,12 @@ export function compileReceiverMethodCall(
 
   // Primitive method calls: number.toString(), number.toFixed()
   if (isNumberMethodReceiver(ctx, receiverType) && propAccess.name.text === "toString") {
+    const primitiveTail = tryCompileStandaloneNumberPrototypeTail(ctx, fctx, propAccess, expr, expectedType, {
+      sourceOverridesBuiltinPrototypeMember,
+      compileCallExpression,
+      emitWrapperDynamicMethodCall,
+    });
+    if (primitiveTail !== undefined) return primitiveTail;
     // RangeError: if radix argument is provided, must be integer 2-36
     // Also captures the validated, floored radix in `radixLocalIdx` so it can
     // be passed to the 2-arg `number_toString_radix` host import below (#1321).

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -142,6 +142,7 @@ import { sourceOverridesBuiltinPrototypeMember, sourceOverridesMethodOnReceiver 
 import {
   tryCompileWrapperDynamicMethodCall,
   tryCompileStandaloneBooleanToString,
+  tryCompileStandaloneDeletedStringToString,
   tryCompileStandaloneNumberPrototypeTail,
 } from "./standalone-primitive-tail.js";
 import { compileInternalCallArgument } from "./internal-call-argument.js";
@@ -1188,6 +1189,17 @@ export function compileReceiverMethodCall(
     emitWrapperDynamicMethodCall,
   });
   if (dynamicWrapper !== undefined) return dynamicWrapper;
+
+  const deletedStringToString = tryCompileStandaloneDeletedStringToString(
+    ctx,
+    fctx,
+    propAccess,
+    expr,
+    receiverType,
+    expectedType,
+    compileCallExpression,
+  );
+  if (deletedStringToString !== undefined) return deletedStringToString;
 
   const booleanToString = tryCompileStandaloneBooleanToString(ctx, fctx, propAccess, expr, receiverType);
   if (booleanToString !== undefined) return booleanToString;

--- a/src/codegen/expressions/member-override-scan.ts
+++ b/src/codegen/expressions/member-override-scan.ts
@@ -99,6 +99,80 @@ export function sourceHasMethodOverride(ctx: CodegenContext, anchor: ts.Node, me
 }
 
 /**
+ * True when this source mutates the exact ambient
+ * `<builtin>.prototype.<methodName>` property.  This is intentionally more
+ * precise than the historical whole-file reassignment scan: the Test262
+ * harness commonly assigns `Test262Error.prototype.toString`, which must not
+ * disable an unrelated Number/Boolean prototype fast path, while a direct
+ * `Number.prototype.toString = …` write must.
+ */
+const _builtinPrototypeOverrideCache = new WeakMap<ts.SourceFile, Map<string, boolean>>();
+export function sourceOverridesBuiltinPrototypeMember(
+  ctx: CodegenContext,
+  anchor: ts.Node,
+  builtinName: string,
+  methodName: string,
+): boolean {
+  const sf = anchor.getSourceFile();
+  if (!sf) return false;
+  const key = `${builtinName}.prototype.${methodName}`;
+  let perFile = _builtinPrototypeOverrideCache.get(sf);
+  if (perFile === undefined) {
+    perFile = new Map<string, boolean>();
+    _builtinPrototypeOverrideCache.set(sf, perFile);
+  }
+  const cached = perFile.get(key);
+  if (cached !== undefined) return cached;
+
+  const isAmbientBuiltin = (id: ts.Identifier): boolean => {
+    const declaration = ctx.oracle.valueDeclarationOf(id);
+    return declaration === undefined || declaration.getSourceFile().isDeclarationFile;
+  };
+  const isTarget = (node: ts.Expression): boolean =>
+    ts.isPropertyAccessExpression(node) &&
+    node.name.text === methodName &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "prototype" &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === builtinName &&
+    isAmbientBuiltin(node.expression.expression);
+
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) &&
+      isTarget(node.left)
+    ) {
+      found = true;
+      return;
+    }
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const callee = node.expression;
+      if (
+        callee.name.text === "defineProperty" &&
+        node.arguments.length >= 2 &&
+        ts.isIdentifier(callee.expression) &&
+        callee.expression.text === "Object" &&
+        isAmbientBuiltin(callee.expression) &&
+        isTarget(node.arguments[0]!) &&
+        ts.isStringLiteralLike(node.arguments[1]!) &&
+        node.arguments[1]!.text === methodName
+      ) {
+        found = true;
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+  visit(sf);
+  perFile.set(key, found);
+  return found;
+}
+
+/**
  * (#4482) The RECEIVER-PRECISE form of {@link sourceHasMethodOverride}: the
  * source installs `<methodName>` **on the same identifier** this call reads —
  * `d.valueOf = …` or `Object.defineProperty(d, "valueOf", …)` for a call

--- a/src/codegen/expressions/new-builtin-globals.ts
+++ b/src/codegen/expressions/new-builtin-globals.ts
@@ -53,6 +53,7 @@ import {
   isStringTypedArg,
   resolvesToAmbientGlobal,
 } from "./new-super.js";
+import { emitStandaloneBooleanConstructorValue } from "./standalone-primitive-tail.js";
 
 /** Sentinel: the `new` target is not one of the built-in global constructors. */
 export const NEW_GLOBAL_FALLTHROUGH = Symbol("new-builtin-global-fallthrough");
@@ -389,12 +390,12 @@ export function tryCompileBuiltinGlobalNew(
       }
 
       if (ctorName === "Boolean") {
-        // new Boolean(x) → create real JS Boolean wrapper object via __new_Boolean host import
-        // (typeof new Boolean(false) === "object", not "boolean")
-        if (args.length >= 1) {
-          // ToBoolean never throws on Symbol (a Symbol is truthy), but this path
-          // coerces the arg to f64 first, which would silently lose the Symbol.
-          // A Symbol arg should produce a truthy wrapper: box 1.0.
+        // new Boolean(x) → JS Boolean wrapper object via __new_Boolean (typeof is "object").
+        // Standalone uses shared ToBoolean so object and Symbol arguments remain truthy.
+        if (ctx.standalone) {
+          emitStandaloneBooleanConstructorValue(ctx, fctx, args);
+        } else if (args.length >= 1) {
+          // Host's f64 ABI preserves the existing Symbol-truthy special case.
           if (ctx.oracle.staticJsTypeOf(args[0]!) === "symbol") {
             const t = compileExpression(ctx, fctx, args[0]!);
             if (t !== null) fctx.body.push({ op: "drop" });

--- a/src/codegen/expressions/standalone-primitive-tail.ts
+++ b/src/codegen/expressions/standalone-primitive-tail.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4516) Small standalone-only tails for primitive-wrapper prototype methods.
+ *
+ * These paths live outside the receiver-method dispatcher so the large shared
+ * dispatch function does not grow for one ES5 compatibility bucket.  The
+ * callbacks in the Number helper keep this leaf independent of `calls.ts`,
+ * which owns the main call-expression dispatcher and imports the receiver
+ * dispatcher itself.
+ */
+import { ts } from "../../ts-api.js";
+import { isBooleanWrapperType, isNumberWrapperType, isStringWrapperType } from "../../checker/type-mapper.js";
+import type { ValType } from "../../ir/types.js";
+import { allocLocal } from "../context/locals.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { ensureObjectRuntime } from "../object-runtime.js";
+import { emitToBoolean, emitToString, runtimeToPrimitiveInstrs } from "../coercion-engine.js";
+import { coerceType, compileExpression } from "../shared.js";
+import type { InnerResult } from "../shared.js";
+import { ensureWrapperProtoDynamicMember } from "../wrapper-proto-dynamic-demand.js";
+
+function isBooleanPrototype(fctx: FunctionContext, expr: ts.Expression): boolean {
+  if (!ts.isPropertyAccessExpression(expr) || expr.name.text !== "prototype") return false;
+  const base = expr.expression;
+  if (!ts.isIdentifier(base) || base.text !== "Boolean") return false;
+  return !fctx.localMap.has("Boolean") && !(fctx.boxedCaptures?.has("Boolean") ?? false);
+}
+
+/** Emit the canonical ToBoolean path used by standalone `new Boolean(value)`. */
+export function emitStandaloneBooleanConstructorValue(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  args: readonly ts.Expression[],
+): void {
+  let argType: ValType | null;
+  if (args.length > 0) {
+    argType = compileExpression(ctx, fctx, args[0]!, { kind: "externref" });
+    if (argType === null) {
+      fctx.body.push({ op: "ref.null.extern" });
+      argType = { kind: "externref" };
+    } else if (argType.kind !== "externref") {
+      coerceType(ctx, fctx, argType, { kind: "externref" });
+      argType = { kind: "externref" };
+    }
+  } else {
+    fctx.body.push({ op: "ref.null.extern" });
+    argType = { kind: "externref" };
+  }
+  emitToBoolean(ctx, argType, fctx.body);
+  fctx.body.push({ op: "f64.convert_i32_s" });
+}
+
+export interface WrapperDynamicTailCallbacks {
+  sourceOverridesMethodOnReceiver: (receiver: ts.Expression, methodName: string, ctx?: CodegenContext) => boolean;
+  emitWrapperDynamicMethodCall: (
+    ctx: CodegenContext,
+    fctx: FunctionContext,
+    receiver: ts.Expression,
+    methodName: string,
+  ) => ValType | null;
+}
+
+/** Route an overridden wrapper method through its demanded runtime closure. */
+export function tryCompileWrapperDynamicMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  receiverType: ts.Type,
+  callbacks: WrapperDynamicTailCallbacks,
+): ValType | undefined {
+  const methodName = propAccess.name.text;
+  const brand = isStringWrapperType(receiverType)
+    ? "String"
+    : isNumberWrapperType(receiverType)
+      ? "Number"
+      : isBooleanWrapperType(receiverType)
+        ? "Boolean"
+        : undefined;
+  if (!brand || (methodName !== "valueOf" && methodName !== "toString")) return undefined;
+  if (!callbacks.sourceOverridesMethodOnReceiver(propAccess.expression, methodName, ctx)) return undefined;
+
+  ensureWrapperProtoDynamicMember(ctx, brand, methodName);
+  const memberIgnoresArguments = methodName === "valueOf" || (methodName === "toString" && brand !== "Number");
+  if (callExpr.arguments.length !== 0 && !memberIgnoresArguments) return undefined;
+  return callbacks.emitWrapperDynamicMethodCall(ctx, fctx, propAccess.expression, methodName) ?? undefined;
+}
+
+/**
+ * Compile `Boolean.prototype.toString()` and Boolean wrapper `toString()` in
+ * standalone mode.  The native prototype has the built-in false slot, while
+ * a wrapper's slot is recovered by the shared runtime primitive engine.
+ */
+export function tryCompileStandaloneBooleanToString(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  receiverType: ts.Type,
+): InnerResult | undefined {
+  if (!ctx.standalone || receiverType.getSymbol()?.name !== "Boolean" || propAccess.name.text !== "toString") {
+    return undefined;
+  }
+
+  ensureObjectRuntime(ctx);
+  const receiverLocal = allocLocal(fctx, `__bool_toString_recv_${fctx.locals.length}`, { kind: "externref" });
+  const recvType = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+  if (recvType === null) {
+    fctx.body.push({ op: "ref.null.extern" });
+  } else if (recvType.kind !== "externref") {
+    coerceType(ctx, fctx, recvType, { kind: "externref" });
+  }
+  fctx.body.push({ op: "local.set", index: receiverLocal });
+  for (const arg of callExpr.arguments) {
+    const argType = compileExpression(ctx, fctx, arg);
+    if (argType !== null) fctx.body.push({ op: "drop" });
+  }
+
+  if (isBooleanPrototype(fctx, propAccess.expression)) {
+    fctx.body.push({ op: "i32.const", value: 0 });
+    return emitToString(ctx, fctx, { kind: "i32" }, { kind: "boolean" }, "string");
+  }
+
+  const toPrimitive = runtimeToPrimitiveInstrs(ctx, "string");
+  const unboxBoolean = ctx.funcMap.get("__unbox_boolean");
+  if (toPrimitive !== null && unboxBoolean !== undefined) {
+    fctx.body.push({ op: "local.get", index: receiverLocal }, ...toPrimitive, { op: "call", funcIdx: unboxBoolean });
+    return emitToString(ctx, fctx, { kind: "i32" }, { kind: "boolean" }, "string");
+  }
+
+  fctx.body.push({ op: "local.get", index: receiverLocal });
+  return { kind: "externref" };
+}
+
+export interface NumberPrototypeTailCallbacks {
+  sourceOverridesBuiltinPrototypeMember: (
+    ctx: CodegenContext,
+    anchor: ts.Node,
+    builtinName: string,
+    methodName: string,
+  ) => boolean;
+  compileCallExpression: (
+    ctx: CodegenContext,
+    fctx: FunctionContext,
+    expr: ts.CallExpression,
+    expectedType?: ValType,
+  ) => InnerResult;
+  emitWrapperDynamicMethodCall: (
+    ctx: CodegenContext,
+    fctx: FunctionContext,
+    receiver: ts.Expression,
+    methodName: string,
+    callExpr?: ts.CallExpression,
+  ) => ValType | null;
+}
+
+/**
+ * Apply exact Number.prototype override/delete semantics before the numeric
+ * formatter.  The callbacks avoid importing the main call dispatcher here,
+ * which would create a cycle through `call-receiver-method.ts`.
+ */
+export function tryCompileStandaloneNumberPrototypeTail(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  expectedType: ValType | undefined,
+  callbacks: NumberPrototypeTailCallbacks,
+): InnerResult | undefined {
+  if (!ctx.standalone || propAccess.name.text !== "toString") return undefined;
+
+  if (
+    callbacks.sourceOverridesBuiltinPrototypeMember(ctx, callExpr, "Number", "toString") &&
+    callExpr.arguments.length === 0
+  ) {
+    const dynamic = callbacks.emitWrapperDynamicMethodCall(ctx, fctx, propAccess.expression, "toString", callExpr);
+    if (dynamic !== null) return dynamic;
+  }
+
+  if (!ctx.deletedBuiltinPrototypeMembers?.has("Number.prototype.toString")) return undefined;
+
+  const objectProto = ts.factory.createPropertyAccessExpression(
+    ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier("Object"), "prototype"),
+    "toString",
+  );
+  const borrowed = ts.factory.createPropertyAccessExpression(objectProto, "call");
+  const borrowedCall = ts.factory.createCallExpression(borrowed, undefined, [
+    propAccess.expression,
+    ...Array.from(callExpr.arguments),
+  ]);
+  ts.setTextRange(borrowedCall, callExpr);
+  (borrowedCall as { parent?: ts.Node }).parent = callExpr.parent;
+  return callbacks.compileCallExpression(ctx, fctx, borrowedCall, expectedType);
+}

--- a/src/codegen/expressions/standalone-primitive-tail.ts
+++ b/src/codegen/expressions/standalone-primitive-tail.ts
@@ -87,6 +87,48 @@ export function tryCompileWrapperDynamicMethodCall(
 }
 
 /**
+ * After deleting `String.prototype.toString`, wrapper instances inherit
+ * `Object.prototype.toString`. Re-emit that borrowed call before the native
+ * String-wrapper fast path can recover and stringify [[StringData]] directly.
+ */
+export function tryCompileStandaloneDeletedStringToString(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  receiverType: ts.Type,
+  expectedType: ValType | undefined,
+  compileCallExpression: (
+    ctx: CodegenContext,
+    fctx: FunctionContext,
+    expr: ts.CallExpression,
+    expectedType?: ValType,
+  ) => InnerResult,
+): InnerResult | undefined {
+  if (
+    !ctx.standalone ||
+    propAccess.name.text !== "toString" ||
+    !isStringWrapperType(receiverType) ||
+    !ctx.deletedBuiltinPrototypeMembers?.has("String.prototype.toString")
+  ) {
+    return undefined;
+  }
+
+  const objectProto = ts.factory.createPropertyAccessExpression(
+    ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier("Object"), "prototype"),
+    "toString",
+  );
+  const borrowed = ts.factory.createPropertyAccessExpression(objectProto, "call");
+  const borrowedCall = ts.factory.createCallExpression(borrowed, undefined, [
+    propAccess.expression,
+    ...Array.from(callExpr.arguments),
+  ]);
+  ts.setTextRange(borrowedCall, callExpr);
+  (borrowedCall as { parent?: ts.Node }).parent = callExpr.parent;
+  return compileCallExpression(ctx, fctx, borrowedCall, expectedType);
+}
+
+/**
  * Compile `Boolean.prototype.toString()` and Boolean wrapper `toString()` in
  * standalone mode.  The native prototype has the built-in false slot, while
  * a wrapper's slot is recovered by the shared runtime primitive engine.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4463,9 +4463,8 @@ export function generateModule(
   // (#4187) ONE walk answers both: the #2179 boolean above and the receiver
   // names the standalone hasOwnProperty const-fold gate needs (it only diverges
   // from runtime state for a receiver that is both defineProperty-widened and
-  // deleted from). Only standalone reads the names, and collecting them forfeits
-  // the boolean's short-circuit — worth +3,847 on the #3437 harness budget — so
-  // host mode asks for the boolean alone and keeps main's exact traversal.
+  // deleted from). Only standalone reads names; collecting forfeits the boolean
+  // short-circuit (+3,847 on #3437), so host mode keeps main's exact traversal.
   // (#4223) Demand gate for the primitive-wrapper `.constructor` carriers. Set
   // BEFORE anything can call `ensureObjectRuntime` (which is where the mint
   // hangs), and only for standalone — the gc/host lane keeps its genuine
@@ -4477,6 +4476,7 @@ export function generateModule(
   const memberDeletes = scanModuleMemberDeletes(ast.sourceFile, ctx.standalone === true);
   ctx.moduleUsesDelete = memberDeletes.any;
   ctx.memberDeleteReceiverNames = memberDeletes.receiverNames;
+  ctx.deletedBuiltinPrototypeMembers = memberDeletes.builtinPrototypeMembers;
   // (#2660 S1) Whole-program escape / dynamic-use classification of `new F()`
   // fnctor instances. INERT: the result is stored for the future S3
   // reconstruction lowering but is NOT yet consumed, so emitted Wasm is

--- a/src/codegen/object-proto-tostring.ts
+++ b/src/codegen/object-proto-tostring.ts
@@ -84,6 +84,7 @@ import { emitThrowTypeError } from "./expressions/helpers.js";
 import { resolveArrayInfo } from "./array-methods.js";
 import { isBooleanType, isNumberType, isStringType } from "../checker/type-mapper.js";
 import { TYPED_ARRAY_NAMES, resolveWasmType } from "./index.js";
+import { bindingIsSingleAssignment } from "./single-assignment-binding.js";
 
 /** §20.1.3.6 result string for a builtin tag. */
 const tagString = (tag: string): string => `[object ${tag}]`;
@@ -614,6 +615,67 @@ function nativeProtoTagOf(ctx: CodegenContext, argExpr: ts.PropertyAccessExpress
 }
 
 /**
+ * Resolve the one ES5 shape where `Object.getPrototypeOf` returns a builtin
+ * wrapper prototype through a local binding:
+ *
+ *     var numberProto = Object.getPrototypeOf(new Number(42));
+ *     Object.prototype.toString.call(numberProto);
+ *
+ * The ordinary static type of that binding is just `any`/`Object`, while the
+ * value is the intrinsic `Number.prototype` object and therefore carries the
+ * Number brand.  Keep this proof deliberately semantic and narrow: the oracle
+ * must identify both constructors as ambient bindings, and the alias must be
+ * a single-assignment variable.  A shadowed constructor or a later write
+ * declines to the existing path rather than baking a possibly stale tag.
+ */
+function numberPrototypeAliasTag(ctx: CodegenContext, argExpr: ts.Expression): string | undefined {
+  if (!ctx.standalone) return undefined;
+  if (!ts.isIdentifier(argExpr) || !bindingIsSingleAssignment(ctx, argExpr)) return undefined;
+  const initializer = ctx.oracle.variableInitializerOf(argExpr);
+  if (!initializer) return undefined;
+
+  let init: ts.Expression = initializer;
+  while (
+    ts.isParenthesizedExpression(init) ||
+    ts.isAsExpression(init) ||
+    ts.isNonNullExpression(init) ||
+    ts.isSatisfiesExpression(init) ||
+    ts.isTypeAssertionExpression(init)
+  ) {
+    init = init.expression;
+  }
+  if (
+    !ts.isCallExpression(init) ||
+    init.arguments.length !== 1 ||
+    !ts.isPropertyAccessExpression(init.expression) ||
+    init.expression.name.text !== "getPrototypeOf" ||
+    !ts.isIdentifier(init.expression.expression) ||
+    init.expression.expression.text !== "Object"
+  ) {
+    return undefined;
+  }
+  const objectDecl = ctx.oracle.valueDeclarationOf(init.expression.expression);
+  if (objectDecl !== undefined && !objectDecl.getSourceFile().isDeclarationFile) return undefined;
+
+  let target: ts.Expression = init.arguments[0]!;
+  while (
+    ts.isParenthesizedExpression(target) ||
+    ts.isAsExpression(target) ||
+    ts.isNonNullExpression(target) ||
+    ts.isSatisfiesExpression(target) ||
+    ts.isTypeAssertionExpression(target)
+  ) {
+    target = target.expression;
+  }
+  if (!ts.isNewExpression(target) || !ts.isIdentifier(target.expression) || target.expression.text !== "Number") {
+    return undefined;
+  }
+  const numberDecl = ctx.oracle.valueDeclarationOf(target.expression);
+  if (numberDecl !== undefined && !numberDecl.getSourceFile().isDeclarationFile) return undefined;
+  return "Number";
+}
+
+/**
  * (#2501) Resolve the §20.1.3.6 `Object.prototype.toString` builtin tag for a
  * statically-known receiver, returning the tag name (e.g. "Array", "Date") or
  * `undefined` when it can't be classified (caller falls back / refuses).
@@ -719,6 +781,14 @@ export function resolveObjectToStringTag(
     if (protoTag !== undefined) return protoTag;
     return deferOrStandalone("Object");
   }
+
+  // A `getPrototypeOf(new Number(...))` result is an intrinsic Number
+  // prototype even though the local binding's checker type is only Object/any.
+  // This must come after the direct `<Builtin>.prototype` case above and
+  // before the generic type-based fallback, which would otherwise emit
+  // `[object Object]` for this exact ES5 alias shape.
+  const numberAliasTag = numberPrototypeAliasTag(ctx, argExpr);
+  if (numberAliasTag !== undefined) return numberAliasTag;
 
   const t = ctx.checker.getTypeAtLocation(argExpr);
   const nn = ctx.checker.getNonNullableType(t);

--- a/src/codegen/source-scan-predicates.ts
+++ b/src/codegen/source-scan-predicates.ts
@@ -54,9 +54,10 @@ export function sourceContainsClass(sourceFile: ts.SourceFile): boolean {
 function scanMemberDeletes(
   sourceFile: ts.SourceFile,
   collectReceivers: boolean,
-): { any: boolean; receiverNames: Set<string> } {
+): { any: boolean; receiverNames: Set<string>; builtinPrototypeMembers: Set<string> } {
   let anyDelete = false;
   const receiverNames = new Set<string>();
+  const builtinPrototypeMembers = new Set<string>();
   function walk(node: ts.Node): void {
     // Short-circuit only when the names are not wanted — otherwise the walk
     // must run to completion to see every deleted-from receiver.
@@ -67,13 +68,23 @@ function scanMemberDeletes(
         anyDelete = true;
         const receiver = target.expression;
         if (collectReceivers && ts.isIdentifier(receiver)) receiverNames.add(receiver.text);
+        if (collectReceivers && ts.isPropertyAccessExpression(target) && ts.isPropertyAccessExpression(receiver)) {
+          const prototype = receiver;
+          if (
+            prototype.name.text === "prototype" &&
+            ts.isIdentifier(prototype.expression) &&
+            ts.isIdentifier(target.name)
+          ) {
+            builtinPrototypeMembers.add(`${prototype.expression.text}.prototype.${target.name.text}`);
+          }
+        }
         if (!collectReceivers) return;
       }
     }
     forEachChild(node, walk);
   }
   walk(sourceFile);
-  return { any: anyDelete, receiverNames };
+  return { any: anyDelete, receiverNames, builtinPrototypeMembers };
 }
 
 /**
@@ -125,7 +136,7 @@ function scanMemberDeletes(
 export function scanModuleMemberDeletes(
   sourceFile: ts.SourceFile,
   collectReceivers: boolean,
-): { any: boolean; receiverNames: Set<string> } {
+): { any: boolean; receiverNames: Set<string>; builtinPrototypeMembers: Set<string> } {
   return scanMemberDeletes(sourceFile, collectReceivers);
 }
 

--- a/tests/es5-standalone-primitive-tail.test.ts
+++ b/tests/es5-standalone-primitive-tail.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Standalone ES5 primitive-wrapper tail pins.
+ *
+ * These are the narrow source shapes behind the conformance rows fixed in the
+ * primitive/error/number/boolean/date census: deleting or replacing the
+ * Number prototype method, recovering Number.prototype through
+ * Object.getPrototypeOf, and applying Boolean ToBoolean to an object value.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runString(body: string): Promise<string> {
+  const source = `
+export function length(): number { return result().length; }
+export function codeUnit(index: number): number { return result().charCodeAt(index); }
+function result(): string {
+${body}
+}
+`;
+  const result = await compile(source, {
+    target: "standalone",
+    fileName: "es5-standalone-primitive-tail.test.ts",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.success ? "" : result.errors?.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  const exports = instance.exports as unknown as {
+    length(): number;
+    codeUnit(index: number): number;
+  };
+  let value = "";
+  for (let i = 0; i < exports.length(); i++) value += String.fromCharCode(exports.codeUnit(i));
+  return value;
+}
+
+describe("ES5 standalone primitive-wrapper tail", () => {
+  it("inherits Object.prototype.toString after deleting Number.prototype.toString", async () => {
+    await expect(runString("delete Number.prototype.toString; return Number.prototype.toString();")).resolves.toBe(
+      "[object Number]",
+    );
+    await expect(runString("delete Number.prototype.toString; return (new Number(42)).toString();")).resolves.toBe(
+      "[object Number]",
+    );
+  });
+
+  it("preserves an exact Number.prototype.toString override", async () => {
+    await expect(
+      runString("Number.prototype.toString = Object.prototype.toString; return Number.prototype.toString();"),
+    ).resolves.toBe("[object Number]");
+  });
+
+  it("tags an Object.getPrototypeOf(new Number(...)) alias as Number", async () => {
+    await expect(
+      runString(
+        "var numberProto = Object.getPrototypeOf(new Number(42)); return Object.prototype.toString.call(numberProto);",
+      ),
+    ).resolves.toBe("[object Number]");
+  });
+
+  it("keeps object and Symbol arguments truthy for new Boolean", async () => {
+    await expect(runString("return new Boolean(new Object()).toString();")).resolves.toBe("true");
+    await expect(runString("return new Boolean(Symbol()).toString();")).resolves.toBe("true");
+  });
+});

--- a/tests/es5-standalone-primitive-tail.test.ts
+++ b/tests/es5-standalone-primitive-tail.test.ts
@@ -50,6 +50,12 @@ describe("ES5 standalone primitive-wrapper tail", () => {
     ).resolves.toBe("[object Number]");
   });
 
+  it("inherits Object.prototype.toString after deleting String.prototype.toString", async () => {
+    await expect(runString('delete String.prototype.toString; return (new String("value")).toString();')).resolves.toBe(
+      "[object String]",
+    );
+  });
+
   it("tags an Object.getPrototypeOf(new Number(...)) alias as Number", async () => {
     await expect(
       runString(


### PR DESCRIPTION
## Summary

Complete the standalone ES5 Number and Boolean primitive-wrapper tail after JSON.parse PR #4865.

The branch now also handles the cross-PR String wrapper case: after deleting String.prototype.toString, a String wrapper inherits Object.prototype.toString and returns [object String]. This keeps composition with builtin prototype-constructor aliases in #4883 correct.

## Original focused bucket

Exact non-JSON bucket result: 14/17. Seven stale-fork baseline failures pass:

- built-ins/Number/15.7.4-1.js
- built-ins/Number/prototype/S15.7.3.1_A2_T1.js
- built-ins/Number/prototype/S15.7.4_A1.js
- built-ins/Number/prototype/S15.7.3.1_A2_T2.js
- built-ins/Number/S15.7.2.1_A4.js
- built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T1.js
- built-ins/Boolean/prototype/toString/S15.6.4.2_A1_T2.js

Fresh same-provider loopdive/js2 main already passed those seven rows, so they contribute zero new authoritative upstream passes. The new String deletion path is an aggregate compatibility fix for #4883.

## Residuals from the original 17-row census

- built-ins/Error/length.js: Error constructor length semantics
- built-ins/Error/prototype/constructor/S15.11.4.1_A1_T2.js: addressed by upstream PR #4883
- built-ins/Date/S15.9.2.1_A2.js: Date parse illegal cast

## Verification

- Focused primitive-tail regressions: 5/5, including the new String deletion pin
- Aggregate #4639 suite with #4883: 20/20
- #3175 controls: 8/8
- #4234 number-format controls: 22/22
- Exact original 17-file standalone census: 14/17
- Wrapper-prototype #4248 control: baseline-matched 5/6
- TS5 and TS7 typechecks, format, LOC/function budgets, coercion/oracle ratchets, dead-export, #3765 parity 18/18, and issue integrity pass

No verification bypasses were used.