### PR TITLE
fix(codegen): eliminate Acorn arguments-brand regression

### DIFF
--- a/src/codegen/arguments-length-brand.ts
+++ b/src/codegen/arguments-length-brand.ts
@@ -1,97 +1,56 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * (#4658) The `arguments`-object BRAND that lets `__vec_gopd` tell §10.4.4's
- * `length` from §10.4.2's, for `--target standalone`.
+ * (#4658) Standalone `arguments` identity and configurable-length state.
  *
- * ## The defect
- * `arguments` is backed by the same opaque `$Vec` an array literal uses, so
- * `Object.getOwnPropertyDescriptor(arguments, "length")` is answered by
- * `__vec_gopd`'s ARRAY-length synthesis: `{value: <live length>, writable:
- * <companion bit>, enumerable: false, configurable: **false**}`. That is exactly
- * right for `[1, 2]` — an Array's `length` is `configurable: false` (§10.4.2.1)
- * — and wrong for an arguments object, whose `length` is a plain data property
- * `{writable: true, enumerable: false, configurable: true}` in BOTH
- * CreateMappedArgumentsObject (§10.4.4 step 7) and CreateUnmappedArgumentsObject
- * (step 4). Measured on the base sources, standalone:
- *
- * ```js
- * var argObj = (function () { return arguments })();
- * Object.getOwnPropertyDescriptor(argObj, "length")
- * // {value: 0, writable: true, enumerable: false, configurable: false}
- * ```
- *
- * `language/arguments-object/10.6-6-2` and `10.6-7-1` fail on exactly that bit
- * ("length descriptor should be configurable").
- *
- * ## Why a runtime brand, and why this one
- * `arguments-object-mop.ts` records the constraint that shaped #4622: *"Fixing
- * `__vec_gopd` is not available: it is shared with real arrays and there is no
- * runtime brand to split them on."* The syntactic escape hatch it used instead
- * cannot serve here — both failing tests hand the object to `verifyProperty`, a
- * harness FUNCTION, so the receiver at the gOPD site is a dynamic value with no
- * syntactic connection to any `arguments` binding. The brand is the missing
- * runtime fact, minted once at construction.
- *
- * It lives on the #3251 overlay COMPANION's `$Object.flags` (field 4), the same
- * internal-slot channel `OBJ_FLAG_RAWJSON` (#3176) and `OBJ_FLAG_CALLABLE` /
- * `OBJ_FLAG_CONSTRUCTOR` (#4120) already use; `0x40` was reserved as free in
- * `object-runtime.ts`'s flag table. It is an INTERNAL SLOT, not an own property:
- * nothing enumerates it, `Object.keys` cannot see it, and every existing reader
- * of that field masks only its own bits, so an unbranded module is unaffected
- * and a branded one changes exactly one descriptor bit.
- *
- * ## Why the companion, not the #3537 bag
- * `__vec_gopd`'s length arm ALREADY loads the companion (`__vec_overlay_lookup`
- * into its local 3) to read the `writable` bit off a companion `length` entry.
- * Reading the brand from the same non-null-checked local costs one `struct.get`
- * and no new lookup; hanging it on the bag would add a second table probe to a
- * path that is on every `gOPD(arr, "length")`.
- *
- * ## Table growth — why marking is not a new cost
- * `__vec_overlay_ensure` APPENDS to a linearly scanned pair table, so branding
- * every arguments object on every call would grow it unboundedly (the hazard
- * `ensureOverlayCore` documents for per-exec RegExp match results). It does not,
- * because the call site is gated on the SAME `shouldRegisterArgumentsWithHost`
- * proof #4578 uses to elide work for an unobservable arguments object — and
- * whenever that proof says "observable", `arguments-callee.ts` has already put a
- * companion on this vec via `__defineProperty_value(args, "callee", …)` (or the
- * strict poison accessor). The mark therefore hits an existing pair, or shares
- * the one entry the callee seed was going to append anyway. A function whose
- * `arguments` never escapes gets no mark, no companion, and no table entry.
- *
- * ## Reserve-then-fill
- * The mark is emitted from a function BODY (`emitArgumentsVecBody`), long before
- * the overlay core exists — the core is minted at FINALIZE. So the native is
- * reserved as a typed no-op stub at the construction site (the
- * `reserveVecOverlayPrime` pattern, append-only mint, no funcIdx shift) and
- * filled from `fillVecOverlayHelpers` once `__vec_overlay_ensure` and `$Object`
- * are resolvable. A module that never reaches the fill keeps the no-op body, so
- * host/gc output is byte-identical.
+ * Arguments used to be branded by appending every observable arguments object
+ * to the global vec-overlay table. That table is strongly held and linearly
+ * scanned; Acorn's hot parser calls therefore changed a ~75 ms parse into a
+ * progressively slower multi-second parse. The brand is now the concrete
+ * `$__arguments_vec` WasmGC subtype. Its third field stores the rare
+ * delete/revive state for the configurable own `length` property. Brand checks
+ * are O(1) `ref.test`s and ordinary calls retain no global references.
  */
 import type { Instr, ValType } from "../ir/types.js";
-import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { CodegenContext } from "./context/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
 import { addFuncType } from "./registry/types.js";
 
 const EXT: ValType = { kind: "externref" };
 const I32: ValType = { kind: "i32" };
+const ARGUMENTS_VEC_STRUCT = "__arguments_vec";
+const LENGTH_ABSENT_FIELD = 2;
 
 /**
- * `$Object.flags` bit 6 — "this `$Object` is the overlay companion of an
- * `arguments` exotic object". `0x40` is the first free bit in
- * `object-runtime.ts`'s table (0x01/0x02/0x04 integrity, 0x08 rawJSON,
- * 0x10/0x20 callable/ctor).
+ * A distinct subtype makes the arguments brand an O(1) WasmGC `ref.test`.
+ * Field 2 records the only mutable exotic state required by #4658: whether
+ * the configurable own `length` property has been deleted.
  */
-export const OBJ_FLAG_ARGUMENTS = 0x40;
+export function getOrRegisterArgumentsVecType(ctx: CodegenContext, baseVecTypeIdx: number, arrTypeIdx: number): number {
+  const existing = ctx.structMap.get(ARGUMENTS_VEC_STRUCT);
+  if (existing !== undefined) return existing;
+  const base = ctx.mod.types[baseVecTypeIdx];
+  if (base && base.kind === "struct") base.final = false;
+  const fields = [
+    { name: "length", type: { kind: "i32" } as ValType, mutable: true },
+    { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx } as ValType, mutable: true },
+    { name: "lengthAbsent", type: { kind: "i32" } as ValType, mutable: true },
+  ];
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind: "struct", name: ARGUMENTS_VEC_STRUCT, superTypeIdx: baseVecTypeIdx, fields });
+  ctx.structMap.set(ARGUMENTS_VEC_STRUCT, typeIdx);
+  ctx.typeIdxToStructName.set(typeIdx, ARGUMENTS_VEC_STRUCT);
+  ctx.structFields.set(ARGUMENTS_VEC_STRUCT, fields);
+  return typeIdx;
+}
 
 /**
- * `$Object.flags` bit 7 — "this branded arguments object's `length` has been
- * DELETED". §10.4.4 makes `length` `configurable: true`, so `delete
+ * The subtype's `lengthAbsent` field records that this arguments object's
+ * `length` has been DELETED. §10.4.4 makes `length` configurable, so `delete
  * args.length` must succeed AND the property must then be gone; the vec has no
  * per-key storage for `length` (`__vec_prop_set` refuses the key outright,
  * because the real vec length must never be shadowed by the bag), so the
- * deletion is recorded as a tombstone BIT rather than as a bag entry.
+ * deletion is recorded as subtype-local state rather than as a bag entry.
  *
  * Why the tombstone is required and not cosmetic: test262's
  * `propertyHelper.verifyProperty` does not read `configurable` off the
@@ -101,9 +60,6 @@ export const OBJ_FLAG_ARGUMENTS = 0x40;
  * "length descriptor should be configurable" even once gOPD answers `true`
  * (measured — that is exactly what the brand alone produced).
  */
-export const OBJ_FLAG_ARGS_LENGTH_ABSENT = 0x80;
-
-const MARK_NAME = "__args_brand_mark";
 const ABSENT_NAME = "__args_len_absent";
 const DELETE_NAME = "__args_len_delete";
 const REVIVE_NAME = "__args_len_revive";
@@ -126,13 +82,12 @@ const REVIVE_NAME = "__args_len_revive";
 const IS_BRANDED_NAME = "__args_is_branded";
 
 /**
- * Reserve `__args_brand_mark(externref vec) -> ()` as a no-op stub. Idempotent;
- * returns the funcIdx, or `undefined` outside standalone (where the host's
- * `__register_arguments` owns §10.4.4 and the overlay is never built).
+ * Reserve the arguments-query helpers before finalize. Idempotent; returns the
+ * first funcIdx, or `undefined` outside standalone where the host owns the MOP.
  */
 export function reserveArgumentsLengthBrand(ctx: CodegenContext): number | undefined {
   if (!ctx.standalone) return undefined;
-  const existing = ctx.funcMap.get(MARK_NAME);
+  const existing = ctx.funcMap.get(ABSENT_NAME);
   if (existing !== undefined) return existing;
   const reserve = (name: string, params: ValType[], results: ValType[], placeholder: Instr[]): number => {
     const typeIdx = addFuncType(ctx, params, results, `$${name}_type`);
@@ -141,14 +96,12 @@ export function reserveArgumentsLengthBrand(ctx: CodegenContext): number | undef
     ctx.funcMap.set(name, funcIdx);
     return funcIdx;
   };
-  // Placeholders are the "no arguments object was ever branded" answers, so a
-  // module whose overlay core is never built keeps today's behaviour exactly.
-  const markIdx = reserve(MARK_NAME, [EXT], [], []);
-  reserve(ABSENT_NAME, [EXT], [I32], [{ op: "i32.const", value: 0 }]);
+  // Placeholders are safe negative answers until finalize fills the bodies.
+  const absentIdx = reserve(ABSENT_NAME, [EXT], [I32], [{ op: "i32.const", value: 0 }]);
   reserve(DELETE_NAME, [EXT, EXT], [I32], [{ op: "i32.const", value: 0 }]);
   reserve(REVIVE_NAME, [EXT], [], []);
   reserve(IS_BRANDED_NAME, [EXT], [I32], [{ op: "i32.const", value: 0 }]);
-  return markIdx;
+  return absentIdx;
 }
 
 /**
@@ -256,37 +209,15 @@ export function buildArgumentsLengthReviveCall(ctx: CodegenContext, objParam = 0
   ];
 }
 
-/**
- * Emit `__args_brand_mark(<vec in argsLocalIdx>)` at an arguments-vec
- * construction site. No-op when the native could not be reserved.
- */
-export function emitArgumentsLengthBrandMark(ctx: CodegenContext, fctx: FunctionContext, argsLocalIdx: number): void {
-  const markIdx = reserveArgumentsLengthBrand(ctx);
-  if (markIdx === undefined) return;
-  fctx.body.push({ op: "local.get", index: argsLocalIdx });
-  fctx.body.push({ op: "extern.convert_any" });
-  fctx.body.push({ op: "call", funcIdx: markIdx });
-}
-
-/**
- * FINALIZE fill: `comp = __vec_overlay_ensure(any(vec)); comp.flags |= 0x40`.
- *
- * The companion lands in a `(ref null $Object)` local and BOTH the `struct.set`
- * receiver and the `struct.get` are read back from it. Reading the receiver
- * through a non-externref local is load-bearing: `fixups.ts`'s backward stack
- * walk for `struct.set` receivers splices a repair `any.convert_extern +
- * ref.cast_null` when the deepest producer is an externref `local.get`, and on
- * an already-correct sequence that repair makes the module fail validation (the
- * hazard `builtin-callable-brand.ts` documents at its own flag OR).
- */
+/** Fill the reserved helpers with subtype tests and field accesses. */
 export function fillArgumentsLengthBrand(
   ctx: CodegenContext,
-  objectTypeIdx: number,
-  overlayEnsureIdx: number,
-  overlayLookupIdx: number,
+  _objectTypeIdx: number,
+  _overlayEnsureIdx: number,
+  _overlayLookupIdx: number,
 ): void {
-  const markIdx = ctx.funcMap.get(MARK_NAME);
-  if (markIdx === undefined) return;
+  const argumentsTypeIdx = ctx.structMap.get(ARGUMENTS_VEC_STRUCT);
+  if (argumentsTypeIdx === undefined) return;
   const setFn = (name: string, locals: { name: string; type: ValType }[], body: Instr[]): void => {
     const idx = ctx.funcMap.get(name);
     if (idx === undefined) return;
@@ -295,116 +226,73 @@ export function fillArgumentsLengthBrand(
     fn.locals = locals;
     fn.body = body;
   };
-  /**
-   * A FACTORY, never a shared array — and this one bit, measured.
-   *
-   * Assigning ONE `{name, type}` array (and therefore one `ValType` object) to
-   * all four `fn.locals` makes the finalize type-remap walk rewrite that single
-   * object's `typeIdx` once PER FUNCTION, while the `struct.get`/`struct.set`
-   * immediates (built fresh below) are remapped once each. The two drift apart:
-   * `10.6-6-2` compiled to `(local $comp (ref null 153))` beside `struct.get
-   * 159 4` and V8 rejected the module with *"struct.get[0] expected type (ref
-   * null 159), found ref.as_non_null of type (ref 153)"* — attributed to
-   * `testcase`, because the stub had been INLINED there. Same rule as
-   * `reference_shared_instr_object_dce_double_remap`, one level out: it governs
-   * local TYPE objects too, not only `Instr`s.
-   */
-  const comp = (): { name: string; type: ValType }[] => [
-    { name: "comp", type: { kind: "ref_null", typeIdx: objectTypeIdx } },
-  ];
-  /** `comp = __vec_overlay_lookup(any(param0))`; then `if (comp == null) <miss>`. */
-  const loadCompanion = (compLocal: number, miss: Instr[]): Instr[] => [
-    { op: "local.get", index: 0 },
+  const isArguments = (param = 0): Instr[] => [
+    { op: "local.get", index: param },
     { op: "any.convert_extern" },
-    { op: "call", funcIdx: overlayLookupIdx },
-    { op: "local.tee", index: compLocal },
-    { op: "ref.is_null" },
-    { op: "if", blockType: { kind: "empty" }, then: miss },
+    { op: "ref.test", typeIdx: argumentsTypeIdx },
   ];
-  /** `comp.flags = (comp.flags & ~clear) | set` for a NON-NULL companion local. */
-  const updateFlags = (compLocal: number, set: number, clear: number): Instr[] => [
-    { op: "local.get", index: compLocal },
-    { op: "ref.as_non_null" },
-    { op: "local.get", index: compLocal },
-    { op: "ref.as_non_null" },
-    { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
-    { op: "i32.const", value: ~clear },
-    { op: "i32.and" },
-    { op: "i32.const", value: set },
-    { op: "i32.or" },
-    { op: "struct.set", typeIdx: objectTypeIdx, fieldIdx: 4 },
-  ];
-  /** `(comp.flags & mask) != 0` for a NON-NULL companion local. */
-  const testFlag = (compLocal: number, mask: number): Instr[] => [
-    { op: "local.get", index: compLocal },
-    { op: "ref.as_non_null" },
-    { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
-    { op: "i32.const", value: mask },
-    { op: "i32.and" },
-    { op: "i32.const", value: 0 },
-    { op: "i32.ne" },
+  const castArguments = (param = 0): Instr[] => [
+    { op: "local.get", index: param },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: argumentsTypeIdx },
   ];
 
-  // ── __args_brand_mark(vec) ───────────────────────────────────────────────
-  // ENSURE, not lookup: this is the one site that creates the companion.
-  //
-  // The companion lands in a `(ref null $Object)` local and BOTH the
-  // `struct.set` receiver and the `struct.get` are read back from it. Reading
-  // the receiver through a non-externref local is load-bearing: `fixups.ts`'s
-  // backward stack walk for `struct.set` receivers splices a repair
-  // `any.convert_extern + ref.cast_null` when the deepest producer is an
-  // externref `local.get`, and on an already-correct sequence that repair makes
-  // the module fail validation (the hazard `builtin-callable-brand.ts`
-  // documents at its own flag OR).
-  setFn(MARK_NAME, comp(), [
-    { op: "local.get", index: 0 },
-    { op: "any.convert_extern" },
-    { op: "call", funcIdx: overlayEnsureIdx },
-    { op: "local.set", index: 1 },
-    ...updateFlags(1, OBJ_FLAG_ARGUMENTS, 0),
-  ]);
-
-  // ── __args_len_absent(vec) -> i32 ────────────────────────────────────────
-  // A pure query: LOOKUP, never ensure (the `carrier-bag-hasown.ts` rule — a
-  // query must not hand a later consumer a companion the receiver never had).
-  setFn(ABSENT_NAME, comp(), [
-    ...loadCompanion(1, [{ op: "i32.const", value: 0 }, { op: "return" }]),
-    ...testFlag(1, OBJ_FLAG_ARGS_LENGTH_ABSENT),
-  ]);
+  setFn(
+    ABSENT_NAME,
+    [],
+    [
+      ...isArguments(),
+      {
+        op: "if",
+        blockType: { kind: "val", type: I32 },
+        then: [...castArguments(), { op: "struct.get", typeIdx: argumentsTypeIdx, fieldIdx: LENGTH_ABSENT_FIELD }],
+        else: [{ op: "i32.const", value: 0 }],
+      },
+    ],
+  );
 
   // ── __args_len_delete(vec, key) -> i32 (1 = handled) ─────────────────────
   const keyIsLength = buildKeyIsLengthInstrs(ctx, 1);
   setFn(
     DELETE_NAME,
-    comp(),
+    [],
     keyIsLength === null
       ? [{ op: "i32.const", value: 0 }]
       : [
           ...keyIsLength,
           { op: "i32.eqz" },
           { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
-          ...loadCompanion(2, [{ op: "i32.const", value: 0 }, { op: "return" }]),
-          ...testFlag(2, OBJ_FLAG_ARGUMENTS),
+          ...isArguments(),
           { op: "i32.eqz" },
           { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
-          ...updateFlags(2, OBJ_FLAG_ARGS_LENGTH_ABSENT, 0),
+          ...castArguments(),
+          { op: "i32.const", value: 1 },
+          { op: "struct.set", typeIdx: argumentsTypeIdx, fieldIdx: LENGTH_ABSENT_FIELD },
           { op: "i32.const", value: 1 },
         ],
   );
 
   // ── __args_len_revive(vec) ───────────────────────────────────────────────
-  setFn(REVIVE_NAME, comp(), [
-    ...loadCompanion(1, [{ op: "return" }]),
-    ...updateFlags(1, 0, OBJ_FLAG_ARGS_LENGTH_ABSENT),
-  ]);
+  setFn(
+    REVIVE_NAME,
+    [],
+    [
+      ...isArguments(),
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          ...castArguments(),
+          { op: "i32.const", value: 0 },
+          { op: "struct.set", typeIdx: argumentsTypeIdx, fieldIdx: LENGTH_ABSENT_FIELD },
+        ],
+      },
+    ],
+  );
 
   // ── __args_is_branded(vec) -> i32 ────────────────────────────────────────
-  // (#4491 wave-7) The same pure-query shape as ABSENT_NAME — LOOKUP, never
-  // ensure — reading the brand bit itself rather than the length tombstone.
-  setFn(IS_BRANDED_NAME, comp(), [
-    ...loadCompanion(1, [{ op: "i32.const", value: 0 }, { op: "return" }]),
-    ...testFlag(1, OBJ_FLAG_ARGUMENTS),
-  ]);
+  // (#4491 wave-7) Pure type-identity query; no overlay lookup or allocation.
+  setFn(IS_BRANDED_NAME, [], isArguments());
 }
 
 /**
@@ -436,29 +324,12 @@ function buildKeyIsLengthInstrs(ctx: CodegenContext, keyLocal: number): Instr[] 
   ];
 }
 
-/**
- * `i32` on the stack: is the `(ref null $Object)` companion in `compLocal`
- * branded as an arguments object? `0` for a null companion (an ordinary array
- * that has never been reflected on), which keeps §10.4.2's `configurable:
- * false` as the default answer.
- */
-export function buildArgumentsBrandBit(compLocal: number, objectTypeIdx: number): Instr[] {
+/** `i32` on the stack: is `objParam` an arguments-vec subtype? */
+export function buildArgumentsBrandBit(objParam: number, argumentsTypeIdx: number | undefined): Instr[] {
+  if (argumentsTypeIdx === undefined) return [{ op: "i32.const", value: 0 }];
   return [
-    { op: "local.get", index: compLocal },
-    { op: "ref.is_null" },
-    {
-      op: "if",
-      blockType: { kind: "val", type: { kind: "i32" } },
-      then: [{ op: "i32.const", value: 0 }],
-      else: [
-        { op: "local.get", index: compLocal },
-        { op: "ref.as_non_null" },
-        { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
-        { op: "i32.const", value: OBJ_FLAG_ARGUMENTS },
-        { op: "i32.and" },
-        { op: "i32.const", value: 0 },
-        { op: "i32.ne" },
-      ],
-    },
+    { op: "local.get", index: objParam },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: argumentsTypeIdx },
   ];
 }

--- a/src/codegen/arguments-vector-tail.ts
+++ b/src/codegen/arguments-vector-tail.ts
@@ -11,6 +11,8 @@ interface ArgumentsVecTailOptions {
   readonly paramOffset: number;
   readonly numArgs: number;
   readonly vecTypeIdx: number;
+  /** Concrete subtype used for the arguments object itself. */
+  readonly argumentsVecTypeIdx?: number;
   readonly arrTypeIdx: number;
   readonly argsLocalIdx: number;
   readonly arrTmpIdx: number;
@@ -38,6 +40,7 @@ export function emitArgumentsVecTail(
     paramOffset,
     numArgs,
     vecTypeIdx: vti,
+    argumentsVecTypeIdx = vti,
     arrTypeIdx: ati,
     argsLocalIdx: argsLocal,
     arrTmpIdx: arrTmp,
@@ -109,11 +112,13 @@ export function emitArgumentsVecTail(
     },
     { op: "local.get", index: totalLenLocal },
     { op: "local.get", index: arrTmp },
-    { op: "struct.new", typeIdx: vti },
+    ...(argumentsVecTypeIdx === vti ? [] : ([{ op: "i32.const", value: 0 }] satisfies Instr[])),
+    { op: "struct.new", typeIdx: argumentsVecTypeIdx },
     { op: "local.set", index: argsLocal },
   );
 
-  if (numArgs !== 0) {
+  // An ordinary extras vec cannot be reused as the branded arguments subtype.
+  if (numArgs !== 0 || argumentsVecTypeIdx !== vti) {
     fctx.body.push(...buildArgsBody);
     return;
   }

--- a/src/codegen/object-proto-tostring.ts
+++ b/src/codegen/object-proto-tostring.ts
@@ -313,8 +313,8 @@ export function emitObjectProtoToStringClassifier(
         // (#4491 wave-7) …but a `$Vec` is not necessarily an Array: an
         // `arguments` exotic shares the carrier (#4667), and §20.1.3.6 step 12
         // gives it `[object Arguments]`. #4658 already mints a runtime brand for
-        // exactly this object (`OBJ_FLAG_ARGUMENTS` on the overlay companion),
-        // so the split is one query, not a new representation.
+        // exactly this object (`$__arguments_vec` type identity), so the split
+        // is one O(1) query.
         //
         // Order is the whole point: the Arguments test runs FIRST and the Array
         // answer is the else. An UNBRANDED arguments object (one #4658's

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -24,7 +24,7 @@ import {
   prepareHoistedFunctionBindings,
   skipUnobservedHoistedCapture,
 } from "../function-declaration-observation.js";
-import { emitArgumentsLengthBrandMark } from "../arguments-length-brand.js"; // (#4658) §10.4.4 `length` brand
+import { getOrRegisterArgumentsVecType, reserveArgumentsLengthBrand } from "../arguments-length-brand.js";
 import { recordLiftedCaptureSlots } from "../closures/capture-source-slot.js";
 import { collectOwnerBindingsWrittenAfterDeclaration } from "../closures/declaration-write-analysis.js";
 import { popBody, pushBody } from "../context/bodies.js";
@@ -3162,6 +3162,8 @@ export function emitArgumentsVecBody(
 ): void {
   const numArgs = paramTypes.length;
   const { vecTypeIdx: vti, arrTypeIdx: ati, argsLocalIdx: argsLocal, arrTmpIdx: arrTmp } = locals;
+  const argumentsVecTypeIdx = registerWithHost && ctx.standalone ? getOrRegisterArgumentsVecType(ctx, vti, ati) : vti;
+  if (argumentsVecTypeIdx !== vti) reserveArgumentsLengthBrand(ctx);
   // (#2743 a) Register this arguments vec with the host so its `[[Prototype]]`
   // resolves to %Object.prototype% and `.constructor`/`hasOwnProperty` behave
   // like an ordinary Object (§10.4.4). This is a NEW host import; adding it
@@ -3241,6 +3243,7 @@ export function emitArgumentsVecBody(
     paramOffset,
     numArgs,
     vecTypeIdx: vti,
+    argumentsVecTypeIdx,
     arrTypeIdx: ati,
     argsLocalIdx: argsLocal,
     arrTmpIdx: arrTmp,
@@ -3260,15 +3263,8 @@ export function emitArgumentsVecBody(
     fctx.body.push({ op: "call", funcIdx: registerArgsIdx });
   }
 
-  // (#4658) The standalone twin of that registration: brand the vec so
-  // `__vec_gopd` answers §10.4.4's `length` descriptor (`configurable: true`)
-  // instead of §10.4.2's Array one. Gated on the SAME `registerWithHost`
-  // observability proof (#4578) — an arguments object that provably never
-  // escapes its function cannot have its descriptor queried, and marking it
-  // would append a pair to the overlay's linearly scanned table on every call.
-  if (registerWithHost && ctx.standalone) {
-    emitArgumentsLengthBrandMark(ctx, fctx, argsLocal);
-  }
+  // Standalone arguments identity is carried by the concrete WasmGC subtype
+  // constructed above; no global overlay-table registration is required.
 }
 
 /**

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -1997,15 +1997,14 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               // (#4658) `configurable` is `false` for an Array (§10.4.2.1) and
               // `true` for an `arguments` exotic object (§10.4.4 steps 4/7),
               // which shares this representation. The #4658 brand on the
-              // companion's `$Object.flags` is the only runtime fact that
-              // separates them; local 3 already holds that companion (loaded
-              // above for the `writable` bit), so this costs one `struct.get`
-              // and no second lookup. Null companion ⇒ 0 ⇒ the Array answer.
+              // `$__arguments_vec` type identity is the runtime fact that
+              // separates them; unlike the old companion brand, this is an
+              // O(1) ref.test and does not retain each arguments object.
               // (#4658) `false` for an Array (§10.4.2.1), `true` for an
               // `arguments` object (§10.4.4) — ANDed with §7.3.14 integrity, so
               // a sealed/frozen arguments object stays non-configurable.
               ...setKey("configurable", [
-                ...buildArgumentsBrandBit(3, objectTypeIdx),
+                ...buildArgumentsBrandBit(0, ctx.structMap.get("__arguments_vec")),
                 ...integrityBit(OBJ_FLAG_SEALED | OBJ_FLAG_FROZEN),
                 { op: "i32.eqz" },
                 { op: "i32.and" },

--- a/tests/issue-4658.test.ts
+++ b/tests/issue-4658.test.ts
@@ -16,9 +16,8 @@
 //
 //  2. **`arguments` had no runtime brand,** so `__vec_gopd` answered its
 //     `length` with §10.4.2's Array rules (`configurable: false`) instead of
-//     §10.4.4's (`configurable: true`). Fixed by `OBJ_FLAG_ARGUMENTS` on the
-//     #3251 overlay companion, plus an `OBJ_FLAG_ARGS_LENGTH_ABSENT` tombstone
-//     so a successful `delete args.length` is actually observable.
+//     §10.4.4's (`configurable: true`). Fixed by a dedicated WasmGC arguments
+//     vec subtype whose mutable third field records the deleted-length state.
 //
 // ## Every pin EXECUTES the operation it guards
 // The descriptor pins call `Object.getOwnPropertyDescriptor` and assert the
@@ -127,6 +126,19 @@ describe("#4658 root 1 — a vec define must not inherit its own value", () => {
 });
 
 describe("#4658 root 2 — §10.4.4 length descriptor on an arguments object", () => {
+  it("brands arguments by WasmGC type, never by per-call overlay registration", async () => {
+    const r = await compile(
+      `function f() { return Object.getOwnPropertyDescriptor(arguments, "length").configurable; }
+       export function test() { var n = 0; for (var i = 0; i < 100; i++) if (f(i)) n++; return n; }`,
+      { fileName: "test.js", allowJs: true, skipSemanticDiagnostics: true, target: "standalone" },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.wat).toContain("__arguments_vec");
+    expect(r.wat).not.toContain("__args_brand_mark");
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { test: () => number }).test()).toBe(100);
+  });
+
   it("gOPD(arguments, 'length') reports writable+configurable, non-enumerable", async () => {
     // 1 writable | 4 configurable = 5; value 0 (no args passed) contributes 0.
     expect(


### PR DESCRIPTION
## Summary

- represent standalone arguments objects with a dedicated WasmGC subtype
- store deleted-length state directly on the arguments vector
- replace per-call vec-overlay registration and linear brand lookup with O(1) type tests
- preserve arguments descriptors, delete/revival, and Object.prototype.toString behavior

## Root cause

Commit d2cd86e16 (#4658) branded every observable arguments object through the strongly held, linearly scanned vec-overlay table. Acorn creates arguments objects on hot parser paths, so the table grew on every parse and later parses became progressively slower.

## Performance

Exact npm-compat O4 runtime-dynamic benchmark:

- current page: 0.000734x
- overlay-reset workaround: 0.02015x
- this PR: 0.12003x (~8.3x slower than Node)
- historical pre-regression range: 0.101x–0.129x

This PR's median was 82.6 ms Wasm versus 10.2 ms Node, checksum 422. Samples remain flat rather than growing into multi-second parses.

## Validation

- TypeScript 7 typecheck
- 41/41 focused #4658 and #4491 tests
- new structural regression test verifies arguments use the WasmGC subtype and no __args_brand_mark helper exists
- pre-push typecheck, lint, Prettier, oracle/coercion ratchets, numeric-local parity, and issue integrity
- O4 standalone-dynamic Acorn benchmark, 9 measured rounds

Related to #3780.