### PR TITLE
fix(array): brand standalone arguments carriers

### DIFF
--- a/src/codegen/arguments-carrier-brand.ts
+++ b/src/codegen/arguments-carrier-brand.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Shared state/IR helpers for the standalone nominal arguments carrier.
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+
+type ArgumentsCarrierContext = CodegenContext & { argumentsVecTypeIdx?: number };
+
+/** Return the nominal arguments carrier, or -1 before it is materialized. */
+export function getArgumentsVecTypeIdx(ctx: CodegenContext): number {
+  return (ctx as ArgumentsCarrierContext).argumentsVecTypeIdx ?? -1;
+}
+
+/** Exclude the nominal arguments subtype before testing ordinary vec carriers. */
+export function excludeArgumentsArrayCarrier(ctx: CodegenContext, anyLocal: number, chain: Instr[]): Instr[] {
+  const typeIdx = getArgumentsVecTypeIdx(ctx);
+  if (typeIdx < 0) return chain;
+  return [
+    { op: "local.get", index: anyLocal },
+    { op: "ref.test", typeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "i32.const", value: 0 }],
+      else: chain,
+    },
+  ];
+}

--- a/src/codegen/arguments-vector-tail.ts
+++ b/src/codegen/arguments-vector-tail.ts
@@ -4,6 +4,7 @@
 // declaration driver so the god-file remains within its LOC budget.
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { getArgumentsVecTypeIdx } from "./arguments-carrier-brand.js";
 import { allocLocal } from "./context/locals.js";
 
 interface ArgumentsVecTailOptions {
@@ -101,7 +102,9 @@ export function emitArgumentsVecTail(
         { op: "local.get", index: argcLocal },
         { op: "local.get", index: extrasLocal },
         { op: "ref.as_non_null" },
-        { op: "struct.get", typeIdx: vti, fieldIdx: 1 },
+        // `extrasLocal` is the canonical protocol vec even when `vti` is the
+        // nominal arguments subtype being constructed.
+        { op: "struct.get", typeIdx: ctx.extrasArgvVecTypeIdx, fieldIdx: 1 },
         { op: "i32.const", value: 0 },
         { op: "local.get", index: extrasLenLocal },
         { op: "array.copy", dstTypeIdx: ati, srcTypeIdx: ati },
@@ -114,6 +117,15 @@ export function emitArgumentsVecTail(
   );
 
   if (numArgs !== 0) {
+    fctx.body.push(...buildArgsBody);
+    return;
+  }
+
+  // The extras global is the canonical parent vec. A nominal arguments child
+  // cannot alias that value into its more-specific local, so always build the
+  // child for zero-formal arguments objects as well. This preserves the brand
+  // that IsArray must reject while retaining the same indexed contents.
+  if (vti === getArgumentsVecTypeIdx(ctx)) {
     fctx.body.push(...buildArgsBody);
     return;
   }

--- a/src/codegen/array-carrier-brand.ts
+++ b/src/codegen/array-carrier-brand.ts
@@ -16,6 +16,7 @@
  */
 import type { ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { getArgumentsVecTypeIdx } from "./arguments-carrier-brand.js";
 import { NON_ARRAY_BYTE_VEC_ELEM_KINDS } from "./object-runtime.js";
 
 /** True when `t` is a reference to a struct that is a real Array carrier. */
@@ -23,6 +24,9 @@ export function isArrayCarrierValType(ctx: CodegenContext, t: ValType): boolean 
   if (t.kind !== "ref" && t.kind !== "ref_null") return false;
   const typeIdx = (t as { typeIdx: number }).typeIdx;
   if (typeIdx < 0) return false;
+  // `arguments` uses a vec-compatible nominal subtype so indexed/length
+  // lowering remains shared, but §7.2.2 IsArray must reject that brand.
+  if (typeIdx === getArgumentsVecTypeIdx(ctx)) return false;
   if (ctx.objectRuntimeTypes && typeIdx === ctx.objectRuntimeTypes.objVecTypeIdx) return true;
   const typeDef = ctx.mod.types[typeIdx];
   if (!typeDef || typeDef.kind !== "struct") return false;

--- a/src/codegen/array-holes.ts
+++ b/src/codegen/array-holes.ts
@@ -40,6 +40,7 @@
 import { ts, forEachChild } from "../ts-api.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import type { Instr, StructTypeDef } from "../ir/types.js";
+export { excludeArgumentsArrayCarrier } from "./arguments-carrier-brand.js";
 import { allocTempLocal } from "./context/locals.js";
 import { emitUndefined } from "./expressions/late-imports.js";
 import { isBrandedBuiltinName } from "./builtin-brands.js"; // (#4176) named proto-write pre-scan

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -2377,8 +2377,7 @@ export function compileLiftedClosureBody(
       flushLateImportShiftsShared(ctx, liftedFctx);
     }
 
-    const elemType: ValType = { kind: "externref" };
-    const vti = getOrRegisterVecType(ctx, "externref", elemType);
+    const vti = getOrRegisterVecType(ctx, "arguments");
     const ati = getArrTypeIdxFromVec(ctx, vti);
     const vecRef: ValType = { kind: "ref", typeIdx: vti };
     const argsLocal = allocLocal(liftedFctx, "arguments", vecRef);

--- a/src/codegen/fnctor-ctor-arguments.ts
+++ b/src/codegen/fnctor-ctor-arguments.ts
@@ -116,7 +116,7 @@ export function emitFnctorCtorArgumentsObject(
     flushLateImportShifts(ctx, ctorFctx);
   }
 
-  const vecTypeIdx = getOrRegisterVecType(ctx, "externref", EXTERNREF);
+  const vecTypeIdx = getOrRegisterVecType(ctx, "arguments");
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
 
   const argsLocal = allocLocal(ctorFctx, "arguments", { kind: "ref", typeIdx: vecTypeIdx });

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -661,8 +661,7 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
       flushLateImportShifts(ctx, fctx);
     }
 
-    const elemType: ValType = { kind: "externref" };
-    const vecTypeIdx = getOrRegisterVecType(ctx, "externref", elemType);
+    const vecTypeIdx = getOrRegisterVecType(ctx, "arguments");
     const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
     const vecRef: ValType = { kind: "ref", typeIdx: vecTypeIdx };
 

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -145,7 +145,7 @@ import {
   reserveProtoIndexStore,
 } from "./proto-index-store.js";
 import { reserveArrayToPrimitiveString } from "./array-to-primitive.js";
-import { holeTestInstrs } from "./array-holes.js";
+import { excludeArgumentsArrayCarrier, holeTestInstrs } from "./array-holes.js";
 import { UNDEF_F64_BITS } from "./value-tags.js";
 import { f64HolesActive, f64HoleTestInstrs } from "./vec-f64-hole-presence.js"; // (#4491 T11)
 // (#2106 S1) function-level-only cycle with any-helpers.ts (which imports
@@ -7464,7 +7464,7 @@ export function fillExternIsArray(ctx: CodegenContext): void {
       },
     ];
   }
-  body.push(...chain);
+  body.push(...excludeArgumentsArrayCarrier(ctx, anyLocal, chain));
 
   fn.locals = [{ name: "any", type: { kind: "anyref" } }];
   fn.body = body;

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -7,6 +7,7 @@
  */
 import type { ArrayTypeDef, FieldDef, FuncTypeDef, StructTypeDef, ValType } from "../../ir/types.js";
 import type { CodegenContext } from "../context/types.js";
+import { getArgumentsVecTypeIdx } from "../arguments-carrier-brand.js";
 import { closureBagField } from "../closures/funcref-wrapper-types.js"; // (#4241)
 
 /**
@@ -194,6 +195,7 @@ export function withSuppressedVecUsage<T>(ctx: CodegenContext, fn: () => T): T {
  * The vec struct has {length: i32, data: (ref $__arr_<elemKind>)}.
  */
 export function getOrRegisterVecType(ctx: CodegenContext, elemKind: string, elemTypeOverride?: ValType): number {
+  if (elemKind === "arguments") return getOrRegisterArgumentsVecType(ctx);
   // (#2083) Any request for a vec type — whether it allocates a new struct or
   // reuses a pre-registered one (`externref`/`f64`, baked into every context for
   // type-index stability) — means the module genuinely materialises an array
@@ -281,6 +283,49 @@ export function getOrRegisterHoleyArrayType(ctx: CodegenContext): number {
     ],
   });
   ctx.holeyArrayTypeIdx = idx;
+  ctx.structMap.set(name, idx);
+  ctx.typeIdxToStructName.set(idx, name);
+  ctx.structFields.set(name, [
+    { name: "length", type: { kind: "i32" as const }, mutable: true },
+    { name: "data", type: { kind: "ref" as const, typeIdx: arrTypeIdx }, mutable: true },
+  ]);
+  return idx;
+}
+
+/**
+ * Register the nominal standalone `arguments` carrier.
+ *
+ * `arguments` is array-like but §15.4.3.2 must reject it from IsArray. A
+ * dedicated subtype preserves the canonical externref-vec prefix, so all
+ * existing vec length/index/property machinery continues to accept it, while
+ * the standalone IsArray finalizer can exclude this exact type. The subtype
+ * repeats the two vec fields for the same field layout convention used by the
+ * sparse-array carrier above.
+ */
+export function getOrRegisterArgumentsVecType(ctx: CodegenContext): number {
+  // Host-backed arguments objects already have a real JS Object identity and
+  // prototype registration. Keep their established canonical vec ABI; the
+  // nominal brand is only needed in the host-free lanes where IsArray is
+  // answered by the module-local carrier predicate.
+  if (!ctx.standalone && !ctx.wasi) return getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+  if (getArgumentsVecTypeIdx(ctx) >= 0) return getArgumentsVecTypeIdx(ctx);
+
+  const parentVecTypeIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, parentVecTypeIdx);
+  if (arrTypeIdx < 0) throw new Error("arguments carrier requires the canonical externref vec layout");
+
+  const idx = ctx.mod.types.length;
+  const name = "__arguments_vec_externref";
+  ctx.mod.types.push({
+    kind: "struct",
+    name,
+    superTypeIdx: parentVecTypeIdx,
+    fields: [
+      { name: "length", type: { kind: "i32" }, mutable: true },
+      { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx }, mutable: true },
+    ],
+  });
+  (ctx as CodegenContext & { argumentsVecTypeIdx?: number }).argumentsVecTypeIdx = idx;
   ctx.structMap.set(name, idx);
   ctx.typeIdxToStructName.set(idx, name);
   ctx.structFields.set(name, [

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -3174,9 +3174,10 @@ export function emitArgumentsVecBody(
     flushLateImportShifts(ctx, fctx);
   }
 
-  const { globalIdx: extrasGlobalIdx } = ensureExtrasArgvGlobal(ctx);
+  const { globalIdx: extrasGlobalIdx, vecTypeIdx: extrasVecTypeIdx } = ensureExtrasArgvGlobal(ctx);
   const argcGlobalIdx = ensureArgcGlobal(ctx);
-  const extrasVecType: ValType = { kind: "ref_null", typeIdx: vti };
+  // Keep extras at the canonical parent type; materialize the branded child below.
+  const extrasVecType: ValType = { kind: "ref_null", typeIdx: extrasVecTypeIdx };
   const extrasLocal = allocLocal(fctx, "__extras_argv_local", extrasVecType);
   const extrasLenLocal = allocLocal(fctx, "__extras_len", { kind: "i32" });
   const totalLenLocal = allocLocal(fctx, "__args_total_len", { kind: "i32" });
@@ -3212,7 +3213,7 @@ export function emitArgumentsVecBody(
   // don't see stale data.
   fctx.body.push({ op: "global.get", index: extrasGlobalIdx });
   fctx.body.push({ op: "local.set", index: extrasLocal });
-  fctx.body.push({ op: "ref.null", typeIdx: vti });
+  fctx.body.push({ op: "ref.null", typeIdx: extrasVecTypeIdx });
   fctx.body.push({ op: "global.set", index: extrasGlobalIdx });
 
   // extrasLen = extrasLocal != null ? extrasLocal.length : 0
@@ -3225,7 +3226,7 @@ export function emitArgumentsVecBody(
     else: [
       { op: "local.get", index: extrasLocal },
       { op: "ref.as_non_null" },
-      { op: "struct.get", typeIdx: vti, fieldIdx: 0 },
+      { op: "struct.get", typeIdx: extrasVecTypeIdx, fieldIdx: 0 },
     ],
   });
   fctx.body.push({ op: "local.set", index: extrasLenLocal });
@@ -3287,8 +3288,7 @@ export function emitArgumentsObject(
   unmapped = false,
 ): void {
   const numArgs = paramTypes.length;
-  const elemType: ValType = { kind: "externref" };
-  const vti = getOrRegisterVecType(ctx, "externref", elemType);
+  const vti = getOrRegisterVecType(ctx, "arguments");
   const ati = getArrTypeIdxFromVec(ctx, vti);
   const vecRef: ValType = { kind: "ref", typeIdx: vti };
   const argsLocal = allocLocal(fctx, "arguments", vecRef);

--- a/tests/es5-array-isarray-arguments.test.ts
+++ b/tests/es5-array-isarray-arguments.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ES5 §15.4.3.2 — an arguments object is array-like, but IsArray must reject
+// it. The standalone lowering keeps arguments on a nominal vec subtype so the
+// ordinary vec indexed/length machinery remains shared without conflating the
+// two brands.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, {
+    target: "standalone",
+    fileName: "es5-array-isarray-arguments.ts",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("ES5 Array.isArray(arguments) in standalone", () => {
+  it("rejects arguments while preserving its indexed and length values", async () => {
+    await expect(
+      run(`
+        let observed = 0;
+        (function probe(a: number, b: number): void {
+          observed = (Array.isArray(arguments) ? 100 : 0) + arguments.length * 10 + arguments[1];
+        })(3, 7);
+        export function test(): number { return observed; }
+      `),
+    ).resolves.toBe(27);
+  });
+
+  it("keeps the brand on a zero-formal arguments object", async () => {
+    await expect(
+      run(`
+        let observed = 0;
+        (function probe(): void {
+          observed = Array.isArray(arguments) ? 1 : 0;
+        })(1, 2, 3);
+        export function test(): number { return observed; }
+      `),
+    ).resolves.toBe(0);
+  });
+
+  it("continues to identify ordinary arrays", async () => {
+    await expect(
+      run(`
+        const values = [1, 2, 3];
+        export function test(): number { return Array.isArray(values) ? 1 : 0; }
+      `),
+    ).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary\n\n- Give standalone/WASI arguments carriers a nominal vec-compatible subtype.\n- Reject that subtype in Array.isArray while preserving indexed, length, and extras behavior.\n- Add focused standalone coverage for ordinary, non-empty, and zero-formal arguments objects.\n\n## Verification\n\n- Registered worktree: /private/tmp/js2-es5-array-prototype\n- Branch: codex/es5-array-prototype\n- Commit: 6b35f26136981821cc78d11369a8df4e4fcda8d7\n- Original local origin/main exact 60-row array-prototype census: 35/60 pass (24 runtime failures plus 1 compile error).\n- Same-base result: 36/60 pass, one fail-to-pass, zero losses or other status changes. The gained row is test/built-ins/Array/isArray/15.4.3.2-1-13.js.\n- After rebasing onto current upstream main efee1cd88, the census is 43/60; seven additional rows are unrelated upstream fixes, while the exact mechanism flip remains the one row above.\n- Focused Vitest: 3/3. Exact Array.isArray controls: 4/4. Existing arguments-object controls: 2/2. Prettier, Biome, LOC/function budgets, oracle/coercion ratchets, typecheck/lint, numeric-local parity, and issue-integrity pre-push gates all passed.\n- No verification hooks were bypassed.\n\nThe host-backed lane remains canonical and unchanged; the nominal subtype is limited to standalone/WASI carriers.\n