### PR TITLE
fix(property-access): reject standalone undefined receivers

### DIFF
--- a/plan/issues/4206-with-statement-es5-standalone-residue.md
+++ b/plan/issues/4206-with-statement-es5-standalone-residue.md
@@ -4,7 +4,7 @@ title: "`with` statement, ES5 standalone: 73-row residue reduced to 51; first IR
 status: suspended
 sprint: current
 created: 2026-08-07
-updated: 2026-08-22
+updated: 2026-08-25
 priority: high
 horizon: xl
 feasibility: hard
@@ -58,6 +58,13 @@ loc-budget-allow:
   # of dispatch into a new module would hide the arm from the two identical
   # arms it must stay in step with.
   - src/codegen/statements/nested-declarations.ts
+  # 2026-08-25 deferred A5_T4/A5_T5 follow-up: the two rows now reach the
+  # open-representation member-access boundary, where standalone's distinct
+  # undefined singleton must be rejected as a nullish receiver. The shared
+  # guard wiring stays in these capped dispatchers; the native-string fallback
+  # check itself lives in the new src/codegen/string-element-read.ts leaf.
+  - src/codegen/property-access.ts
+  - src/codegen/property-access-dispatch.ts
 func-budget-allow:
   # Four-line statement-dispatch hook; all selection logic is in the dedicated
   # isPhase1WithStatement helper and ir/with-environment subsystem.
@@ -82,6 +89,13 @@ func-budget-allow:
   # hoisting it elsewhere would bypass that guard.
   - src/codegen/declarations/object-shape-widening.ts::collectGrowableObjectLiterals
   - src/codegen/declarations/object-shape-widening.ts::scanStatements#2
+  # 2026-08-25 deferred A5_T4/A5_T5 follow-up: the two small guard call-sites
+  # must stay beside their existing receiver compilation and late-import flush
+  # so the captured function indices remain valid. The reusable undefined
+  # predicate is in late-imports.ts; moving these lines into a helper would
+  # obscure the ordering invariant they enforce.
+  - src/codegen/property-access-dispatch.ts::finalizeStructAndDynamicMemberGet
+  - src/codegen/property-access.ts::compileElementAccess
 ---
 
 # #4206 — the `with` statement residue, correctly sized
@@ -947,6 +961,24 @@ typeof o.p1;       // "object"; must be "undefined"
 A member read off a deleted/absent property of an open `$Object` neither throws
 nor types as `undefined`. That is its own head — property-access on the open
 representation — and should not be filed against `with`.
+
+### 2026-08-25 follow-up — the deferred pair now passes
+
+The two rows are now fixed by the property-access head; this issue remains
+`suspended` because the broader `with` residue is not complete. Standalone's
+`__extern_get` can return a non-null `$undefined` singleton, so checking only
+`ref.is_null` lets `myObj.p1.a` and `myObj.p1[2]` continue into a second lookup.
+Dynamic member and element receivers now also call the native
+`__extern_is_undefined` predicate and throw the catchable TypeError required by
+RequireObjectCoercible. Identifier receivers retain the prior path so a
+shadowed `undefined` binding is not misclassified.
+
+Focused controls: #4206 dynamic-with plus the ES5 standalone-with and #4484
+shadowing suites are 59/59. The local authentic 44-row census moved from
+28/16 (14 provider-unavailable rows plus the two semantic failures) to 30/14;
+the canonical published baseline had A5_T4 already passing and A5_T5 as the
+single semantic flip. The remaining 14 local failures are provider-unavailable
+QuickJS rows, not regressions from this change.
 
 ### `language/statements/function` — 25 rows re-verified, clustered, none taken
 

--- a/plan/issues/4206-with-statement-es5-standalone-residue.md
+++ b/plan/issues/4206-with-statement-es5-standalone-residue.md
@@ -980,6 +980,11 @@ the canonical published baseline had A5_T4 already passing and A5_T5 as the
 single semantic flip. The remaining 14 local failures are provider-unavailable
 QuickJS rows, not regressions from this change.
 
+The merge-queue host sweep exposed 11 regressions when the standalone
+undefined predicate was also installed in JS-host mode. The predicate is now
+strictly standalone/WASI-gated. All 11 reported host Test262 paths pass again,
+while the two intended dynamic-with receiver checks remain 2/2 green.
+
 ### `language/statements/function` — 25 rows re-verified, clustered, none taken
 
 All 25 reproduce on this head. Clustering (so the next lane does not re-derive

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -4139,7 +4139,10 @@ export function finalizeStructAndDynamicMemberGet(
           }
         }
         const receiverExpr = skipTransparentExpressions(expr.expression);
-        const isUndefinedIdx = ts.isIdentifier(receiverExpr) ? undefined : ensureExternIsUndefinedImport(ctx);
+        const isUndefinedIdx =
+          (ctx.standalone || ctx.wasi) && !ts.isIdentifier(receiverExpr)
+            ? ensureExternIsUndefinedImport(ctx)
+            : undefined;
         flushLateImportShifts(ctx, fctx);
         // Null check: throw TypeError for property access on null/undefined.
         // (#4157) Skipped when the receiver is PROVABLY non-null.

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -49,7 +49,7 @@ import {
   reserveMemberGetDispatch,
 } from "./member-get-dispatch.js";
 import { coercionInstrs, defaultValueInstrs } from "./type-coercion.js";
-import { patchStructNewForAddedField } from "./expressions/late-imports.js";
+import { ensureExternIsUndefinedImport, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { reserveAccessorGetDriver } from "./accessor-driver.js";
 import { S5C_STRUCT_ACCESSOR_CLOSURE } from "./struct-accessor-closure.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
@@ -3551,6 +3551,7 @@ function emitExternGetReceiverGuard(
   expr: ts.PropertyAccessExpression,
   objExprType: ValType | null,
   objTmp: number,
+  isUndefinedIdx?: number,
 ): void {
   const numeric = objExprType?.kind === "f64" || objExprType?.kind === "i32";
   emitReceiverNullGuard(
@@ -3570,6 +3571,14 @@ function emitExternGetReceiverGuard(
     // local (allocated by the caller), which is the shape this builder wants.
     () => (receiverIsUndefinedIdentifier(expr.expression) ? undefined : nullishExternTestInstrs(ctx, objTmp)),
   );
+  // `__extern_get` can return a non-null undefined singleton in standalone.
+  // A subsequent member read must reject that value just like a null
+  // externref; the legacy `ref.is_null` check alone is insufficient.
+  if (isUndefinedIdx !== undefined && objExprType?.kind === "externref") {
+    fctx.body.push({ op: "local.get", index: objTmp });
+    fctx.body.push({ op: "call", funcIdx: isUndefinedIdx });
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: typeErrorThrowInstrs(ctx, expr), else: [] });
+  }
 }
 
 export function finalizeStructAndDynamicMemberGet(
@@ -4095,6 +4104,7 @@ export function finalizeStructAndDynamicMemberGet(
       );
       let unboxIdx = ensureScalarUnbox(ctx, fctx, accessWasm);
       if (getIdx !== undefined) {
+        flushLateImportShifts(ctx, fctx);
         const objExprType = compileExpression(ctx, fctx, expr.expression);
         // (#4155 Phase 2) The receiver's compiled ValType is already a
         // `$__fnctor_<Name>` struct ref and `propName` is one of its plain data
@@ -4128,10 +4138,13 @@ export function finalizeStructAndDynamicMemberGet(
             fctx.body.push({ op: "call", funcIdx: boxIdx });
           }
         }
+        const receiverExpr = skipTransparentExpressions(expr.expression);
+        const isUndefinedIdx = ts.isIdentifier(receiverExpr) ? undefined : ensureExternIsUndefinedImport(ctx);
+        flushLateImportShifts(ctx, fctx);
         // Null check: throw TypeError for property access on null/undefined.
         // (#4157) Skipped when the receiver is PROVABLY non-null.
         const objTmp = allocLocal(fctx, `__nullchk_${fctx.locals.length}`, { kind: "externref" });
-        emitExternGetReceiverGuard(ctx, fctx, expr, objExprType, objTmp);
+        emitExternGetReceiverGuard(ctx, fctx, expr, objExprType, objTmp, isUndefinedIdx);
         // An interface / object-type receiver is only a structural contract.
         // When its runtime value is externref, let the canonical dynamic
         // provider discriminate exact closed shapes by their `$shape` stamps.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -3253,7 +3253,8 @@ function tryOpenObjectDynamicGet(
   // the predicate AFTER compiling the receiver, because that compilation may
   // register imports which must be settled before the guard captures its idx.
   const baseExpr = skipTransparentExpressions(expr.expression);
-  const isUndefinedIdx = ts.isIdentifier(baseExpr) ? undefined : ensureExternIsUndefinedImport(ctx);
+  const isUndefinedIdx =
+    (ctx.standalone || ctx.wasi) && !ts.isIdentifier(baseExpr) ? ensureExternIsUndefinedImport(ctx) : undefined;
   flushLateImportShifts(ctx, fctx);
   // §13.3 member access on null/undefined throws TypeError (keep parity with
   // the default read path's null guard).
@@ -3336,7 +3337,7 @@ function tryKnownFnctorDynamicObjectCarrierGet(
   } else if (recvType.kind !== "externref") {
     coerceType(ctx, fctx, recvType, { kind: "externref" });
   }
-  const isUndefinedIdx = ensureExternIsUndefinedImport(ctx);
+  const isUndefinedIdx = ctx.standalone || ctx.wasi ? ensureExternIsUndefinedImport(ctx) : undefined;
   flushLateImportShifts(ctx, fctx);
   const recvTmp = allocTempLocal(fctx, { kind: "externref" });
   emitExternRecvNullGuard(ctx, fctx, recvTmp, recvType, carrierRead, expr, "carrier-get:recv", isUndefinedIdx);
@@ -4778,7 +4779,8 @@ export function compileElementAccess(
   if (objType.kind === "externref") {
     if (!isProvablyNonNull(expr.expression, ctx.checker)) {
       const receiverExpr = skipTransparentExpressions(expr.expression);
-      const isUndefinedIdx = ts.isIdentifier(receiverExpr) ? undefined : ensureExternIsUndefinedImport(ctx);
+      const isUndefinedIdx =
+        (ctx.standalone || ctx.wasi) && !ts.isIdentifier(receiverExpr) ? ensureExternIsUndefinedImport(ctx) : undefined;
       flushLateImportShifts(ctx, fctx);
       emitNullCheckThrow(ctx, fctx, objType, expr, undefined, isUndefinedIdx);
     }

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1194,6 +1194,7 @@ export function emitNullCheckThrow(
   refType: ValType,
   node?: ts.Node,
   proof?: ReceiverProofHint,
+  isUndefinedIdx?: number,
 ): void {
   const backupLocal: number | undefined = (fctx as any).__lastGuardedCastBackup;
   if (receiverProofHolds(ctx, fctx, proof, (e) => isProvablyNonNull(e, ctx.checker))) return;
@@ -1247,6 +1248,16 @@ export function emitNullCheckThrow(
       then: typeErrorThrowInstrs(ctx, node),
       else: [],
     });
+  }
+
+  // Under the standalone undefined-singleton regime, a dynamic member read
+  // can leave a non-null externref carrying JavaScript `undefined`.  Element
+  // access has the same RequireObjectCoercible obligation as dot access, so
+  // test that carrier in addition to the structural null check.
+  if (isUndefinedIdx !== undefined && refType.kind === "externref") {
+    fctx.body.push({ op: "local.get", index: tmp });
+    fctx.body.push({ op: "call", funcIdx: isUndefinedIdx });
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: typeErrorThrowInstrs(ctx, node), else: [] });
   }
 
   fctx.body.push({ op: "local.get", index: tmp });
@@ -3237,10 +3248,17 @@ function tryOpenObjectDynamicGet(
   } else if (recvType.kind !== "externref") {
     coerceType(ctx, fctx, recvType, { kind: "externref" });
   }
+  // A dynamic member read can itself produce JavaScript `undefined` without
+  // using the null externref (standalone's tag-1 singleton regime). Reserve
+  // the predicate AFTER compiling the receiver, because that compilation may
+  // register imports which must be settled before the guard captures its idx.
+  const baseExpr = skipTransparentExpressions(expr.expression);
+  const isUndefinedIdx = ts.isIdentifier(baseExpr) ? undefined : ensureExternIsUndefinedImport(ctx);
+  flushLateImportShifts(ctx, fctx);
   // §13.3 member access on null/undefined throws TypeError (keep parity with
   // the default read path's null guard).
   const recvTmp = allocTempLocal(fctx, { kind: "externref" });
-  emitExternRecvNullGuard(ctx, fctx, recvTmp, recvType, expr.expression, expr, "growable-get:recv");
+  emitExternRecvNullGuard(ctx, fctx, recvTmp, recvType, expr.expression, expr, "growable-get:recv", isUndefinedIdx);
   fctx.body.push({ op: "local.get", index: recvTmp });
   releaseTempLocal(fctx, recvTmp);
   fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
@@ -3318,8 +3336,10 @@ function tryKnownFnctorDynamicObjectCarrierGet(
   } else if (recvType.kind !== "externref") {
     coerceType(ctx, fctx, recvType, { kind: "externref" });
   }
+  const isUndefinedIdx = ensureExternIsUndefinedImport(ctx);
+  flushLateImportShifts(ctx, fctx);
   const recvTmp = allocTempLocal(fctx, { kind: "externref" });
-  emitExternRecvNullGuard(ctx, fctx, recvTmp, recvType, carrierRead, expr, "carrier-get:recv");
+  emitExternRecvNullGuard(ctx, fctx, recvTmp, recvType, carrierRead, expr, "carrier-get:recv", isUndefinedIdx);
   fctx.body.push({ op: "local.get", index: recvTmp });
   releaseTempLocal(fctx, recvTmp);
   fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
@@ -3340,6 +3360,7 @@ function emitExternRecvNullGuard(
   recvExpr: ts.Expression,
   throwNode: ts.Node,
   site: string,
+  isUndefinedIdx?: number,
 ): void {
   emitReceiverNullGuard(
     ctx,
@@ -3352,6 +3373,14 @@ function emitExternRecvNullGuard(
     // and both hold the receiver in an externref local.
     () => (receiverIsUndefinedIdentifier(recvExpr) ? undefined : nullishExternTestInstrs(ctx, recvTmp)),
   );
+  // `ref.is_null` catches the legacy null/undefined carrier, but standalone
+  // now preserves a distinct undefined singleton.  A chained dynamic read
+  // such as `o.missing.x` must reject that value before the second lookup.
+  if (isUndefinedIdx !== undefined && recvType?.kind === "externref") {
+    fctx.body.push({ op: "local.get", index: recvTmp });
+    fctx.body.push({ op: "call", funcIdx: isUndefinedIdx });
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: typeErrorThrowInstrs(ctx, throwNode), else: [] });
+  }
 }
 
 /**
@@ -4748,7 +4777,10 @@ export function compileElementAccess(
   // Null-guard for externref: null[x] and undefined[x] throw TypeError (#775)
   if (objType.kind === "externref") {
     if (!isProvablyNonNull(expr.expression, ctx.checker)) {
-      emitNullCheckThrow(ctx, fctx, objType, expr);
+      const receiverExpr = skipTransparentExpressions(expr.expression);
+      const isUndefinedIdx = ts.isIdentifier(receiverExpr) ? undefined : ensureExternIsUndefinedImport(ctx);
+      flushLateImportShifts(ctx, fctx);
+      emitNullCheckThrow(ctx, fctx, objType, expr, undefined, isUndefinedIdx);
     }
   }
 

--- a/src/codegen/string-element-read.ts
+++ b/src/codegen/string-element-read.ts
@@ -73,7 +73,8 @@ export function emitGuardedNativeStringElementGet(
   // it must enforce RequireObjectCoercible on the captured receiver before
   // either string probing or the dynamic index read.
   const receiverExpr = skipTransparentExpressions(recvExpr);
-  const isUndefinedIdx = ts.isIdentifier(receiverExpr) ? undefined : ensureExternIsUndefinedImport(ctx);
+  const isUndefinedIdx =
+    (ctx.standalone || ctx.wasi) && !ts.isIdentifier(receiverExpr) ? ensureExternIsUndefinedImport(ctx) : undefined;
   flushLateImportShifts(ctx, fctx);
   fctx.body.push({ op: "local.set", index: recvLocal });
   const receiverTypeError = (): Instr[] =>

--- a/src/codegen/string-element-read.ts
+++ b/src/codegen/string-element-read.ts
@@ -16,7 +16,9 @@ import { undefinedExternInstrs } from "./any-helpers.js";
 import { redundantFlattenCall } from "./lazy-str-flatten.js"; // (#4157)
 import { ensureNativeStringHelpers } from "./native-strings.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
-import { compileExpression, ensureLateImport, flushLateImportShifts } from "./shared.js";
+import { buildThrowJsErrorInstrs } from "./js-errors.js";
+import { compileExpression, ensureLateImport, flushLateImportShifts, skipTransparentExpressions } from "./shared.js";
+import { ensureExternIsUndefinedImport } from "./expressions/late-imports.js";
 
 /**
  * (#3973) Emit a runtime-guarded native-string ELEMENT read (`recv[idx]`) for a
@@ -66,7 +68,26 @@ export function emitGuardedNativeStringElementGet(
   // Receiver ONCE → externref local.
   const recvLocal = allocLocal(fctx, `__strix_recv_${fctx.locals.length}`, { kind: "externref" });
   compileExpression(ctx, fctx, recvExpr, { kind: "externref" });
+  // `__extern_get` represents a missing property with standalone's distinct
+  // undefined singleton.  This helper owns the fallback arm for `any[i]`, so
+  // it must enforce RequireObjectCoercible on the captured receiver before
+  // either string probing or the dynamic index read.
+  const receiverExpr = skipTransparentExpressions(recvExpr);
+  const isUndefinedIdx = ts.isIdentifier(receiverExpr) ? undefined : ensureExternIsUndefinedImport(ctx);
+  flushLateImportShifts(ctx, fctx);
   fctx.body.push({ op: "local.set", index: recvLocal });
+  const receiverTypeError = (): Instr[] =>
+    buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot access property on null or undefined", {
+      forceInModuleCtor: true,
+    });
+  fctx.body.push({ op: "local.get", index: recvLocal });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: receiverTypeError(), else: [] });
+  if (isUndefinedIdx !== undefined) {
+    fctx.body.push({ op: "local.get", index: recvLocal });
+    fctx.body.push({ op: "call", funcIdx: isUndefinedIdx });
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: receiverTypeError(), else: [] });
+  }
 
   // Index ONCE → f64 local (shared by the string arm and the fallback call).
   const idxF64 = allocLocal(fctx, `__strix_idx_${fctx.locals.length}`, { kind: "f64" });

--- a/tests/issue-4206-standalone-dynamic-with.test.ts
+++ b/tests/issue-4206-standalone-dynamic-with.test.ts
@@ -76,6 +76,32 @@ describe("#4206 standalone Tier-2 dynamic `with`", () => {
     ).toBe(1);
   });
 
+  it("throws when a deleted with member is used as a property receiver", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          var myObj: any = { p1: { a: "hello" } };
+          with (myObj) { delete p1; }
+          try { myObj.p1.a; return 0; }
+          catch (e) { return e instanceof TypeError ? 1 : 2; }
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("throws when a deleted with member is used for element access", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          var myObj: any = { p1: [1, 2, 3] };
+          with (myObj) { delete p1; }
+          try { myObj.p1[2]; return 0; }
+          catch (e) { return e instanceof TypeError ? 1 : 2; }
+        }
+      `),
+    ).toBe(1);
+  });
+
   it("still reads own fields through the with scope", async () => {
     expect(
       await runStandalone(`


### PR DESCRIPTION
## Summary

Treat the standalone undefined singleton as nullish at dynamic member and element access boundaries. Deleted open-object properties now satisfy RequireObjectCoercible and throw a catchable TypeError, while identifier receivers retain their existing shadowing behavior.

## Test262 impact

- Authentic local 44-row census: 28 pass / 16 nonpass -> 30 pass / 14 nonpass.
- Fresh published loopdive/js2 same-provider accounting: one genuine fail-to-pass (`S12.10_A5_T5`); `A5_T4` already passed there. Count this PR as +1 authoritative current-upstream pass.
- Remaining 14 local nonpasses are provider-unavailable QuickJS rows, not regressions.

## Verification

- Focused dynamic-with and receiver tests: 59/59.
- Changed-root: 8/8.
- Typecheck, lint, format, LOC/function budgets, oracle/coercion ratchets, dead-export and issue integrity all pass.
- Full normal pre-push completed without bypasses, including #3765 parity 18/18.

Commit: `10c2d55e0`.