### PR TITLE
fix(standalone): preserve let closure calls and loop cells

### DIFF
--- a/plan/issues/4672-es2015-standalone-let-tdz-residual.md
+++ b/plan/issues/4672-es2015-standalone-let-tdz-residual.md
@@ -17,6 +17,12 @@ goal: standalone-mode
 assignee: codex/es6-tdz-wave3
 related: [4444, 4447, 723, 906]
 origin: "ES2015 standalone close-out umbrella #4444 long-tail measurement: 26 let/TDZ rows remain after the for-of/destructuring slice."
+loc-budget-allow:
+  - src/codegen/expressions/call-tail-dispatch.ts
+  - src/codegen/statements/loops.ts
+func-budget-allow:
+  - src/codegen/expressions/call-tail-dispatch.ts::compileTailDispatch
+  - src/codegen/statements/loops.ts::compileForStatement
 ---
 
 # #4672 — ES2015 standalone `let`/TDZ residual cluster

--- a/plan/issues/4672-es2015-standalone-let-tdz-residual.md
+++ b/plan/issues/4672-es2015-standalone-let-tdz-residual.md
@@ -1,0 +1,137 @@
+---
+id: 4672
+title: "ES2015 standalone let/TDZ residual cluster"
+status: done
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: codegen, conformance
+es_edition: es6
+goal: standalone-mode
+assignee: codex/es6-tdz-wave3
+related: [4444, 4447, 723, 906]
+origin: "ES2015 standalone close-out umbrella #4444 long-tail measurement: 26 let/TDZ rows remain after the for-of/destructuring slice."
+---
+
+# #4672 — ES2015 standalone `let`/TDZ residual cluster
+
+## Scope
+
+The #4444 ES2015 standalone edition measurement identifies approximately 26
+non-passing `let`/temporal-dead-zone tests outside the landed #4447
+for-of/destructuring slice. This issue owns only those residual rows; generator,
+class, Promise, TypedArray, and prototype-reflection failures stay with their
+existing issues.
+
+## Implementation plan
+
+1. Fetch the current standalone baseline and enumerate the exact ES2015 rows
+   classified as `let`/TDZ, recording each path and baseline outcome.
+2. Reproduce representative failures on fresh `upstream/main` with the
+   standalone compiler and a host-free instantiation. Compare a known-good
+   `var`/post-initialization control and inspect emitted WAT/imports before
+   choosing a root cause.
+3. Check the file-lock table and constrain the patch to the narrowest
+   declaration/TDZ or scope path that owns the measured failures. Do not edit
+   the protected TypedArray/class/Promise/RegExp areas from PRs #4856, #4857,
+   #4872, #4874, or #4876.
+4. Add focused regression coverage for the failing shape and controls, then
+   run the scoped tests plus a GC-lane smoke check. Record before/after counts,
+   exact row list, and zero-loss evidence here.
+
+## Initial status
+
+Issue allocated atomically as #4672 on 2026-08-25. Worktree is based on
+`upstream/main` at `efee1cd88`.
+
+The fresh baseline (`.test262-cache/test262-standalone-current.jsonl`) has 26
+non-passing rows under `test/language/statements/let/`:
+
+- TDZ/closure: `global-closure-get-before-initialization.js`,
+  `global-closure-set-before-initialization.js`,
+  `global-use-before-initialization-in-prior-statement.js`,
+  `block-local-closure-get-before-initialization.js`,
+  `block-local-closure-set-before-initialization.js`,
+  `block-local-use-before-initialization-in-prior-statement.js`.
+- For-head closure freshness: `syntax/let-iteration-variable-is-freshly-allocated-for-each-iteration-single-let-binding.js`,
+  `syntax/let-iteration-variable-is-freshly-allocated-for-each-iteration-multi-let-binding.js`,
+  `syntax/let-closure-inside-initialization.js`,
+  `syntax/let-closure-inside-condition.js`,
+  `syntax/let-closure-inside-next-expression.js`.
+- Other syntax/scoping: `syntax/let.js`,
+  `syntax/let-outer-inner-let-bindings.js`, `syntax/escaped-let.js`,
+  `fn-name-class.js`.
+- Destructuring iterator/property behavior: `dstr/ary-init-iter-get-err-array-prototype.js`,
+  `dstr/ary-ptrn-elem-id-iter-complete.js`,
+  `dstr/ary-ptrn-elem-id-iter-done.js`,
+  `dstr/ary-ptrn-elem-id-iter-val-array-prototype.js`,
+  `dstr/ary-ptrn-elision.js`, `dstr/ary-ptrn-elision-step-err.js`,
+  `dstr/ary-ptrn-rest-id-exhausted.js`,
+  `dstr/ary-ptrn-rest-id-iter-step-err.js`,
+  `dstr/ary-ptrn-rest-obj-prop-id.js`,
+  `dstr/obj-ptrn-prop-ary.js`, `dstr/obj-ptrn-prop-obj.js`.
+
+The scoped runner reached 146 let tests (118 pass, 28 fail). Two failures were
+runner-current-only and are not in the fetched baseline: the runtime-eval
+refusal in `cptn-value.js` (#2928) and the timeout in
+`dstr/obj-ptrn-rest-skip-non-enumerable.js`. The complete raw run is recorded
+at `benchmarks/results/test262-standalone-results-20260825-041734.jsonl`.
+
+Before this patch, the baseline outcome split was 24 assertion/runtime
+failures and 2 compile errors (the escaped-keyword parser error and the
+generator-provider host-import leak). After this patch, the seven rows listed
+under the direct probes below pass in standalone compile/validate/instantiate
+checks; the other 19 baseline rows remain explicitly out of this bounded
+closure-call/per-iteration fix.
+
+## Root cause and bounded fix
+
+Two related closure-call/loop-shape gaps accounted for seven directly
+reproduced baseline rows:
+
+1. `let fns = []` is represented by TypeScript as an evolving `any[]`. The
+   callable-element path intentionally declines an element with no static call
+   signature, after which the tail fallback evaluated the callee and silently
+   dropped `fns[0]()` instead of preserving JavaScript's dynamic call. The fix
+   uses the existing inline dynamic-call emitter only for standalone modules
+   whose receiver resolves to an array and whose element type is unresolved
+   (`any`/`unknown`/`never`). Typed arrays and concrete primitive arrays retain
+   their previous path.
+2. `findHeadBindingsCapturedByClosures` scanned only the condition,
+   incrementor, and body. A closure in a later declarator of a `for` head (for
+   example `for (let i = 0, f = () => i; ...)`) therefore was not included in
+   per-iteration capture analysis. When the initializer had already promoted
+   `i` to a ref cell, the loop then wrapped that cell a second time. The fix
+   scans the initializer and reuses the existing capture as the first
+   per-iteration cell, preserving the loop's capture restoration behavior.
+
+Changed files are `src/codegen/expressions/call-tail-dispatch.ts`,
+`src/ir/analysis/loop-shape.ts`, `src/codegen/statements/loops.ts`, and the
+focused regression `tests/issue-4672.test.ts`. Protected files from PRs
+#4856/#4857/#4872/#4874/#4876 were not touched.
+
+## Test Results
+
+- `node node_modules/vitest/vitest.mjs run tests/issue-4672.test.ts
+  --reporter=dot`: **4/4 passed**. Covers an evolving empty-array closure
+  call, body-created per-iteration closures, condition/incrementor closures,
+  and a closure created in a later for-head initializer.
+- `node node_modules/vitest/vitest.mjs run tests/issue-4672.test.ts
+  tests/issue-1453.test.ts tests/issue-1306.test.ts --reporter=dot`:
+  **20/20 passed**. This is the zero-loss check for the existing loop
+  per-iteration and typed callable-element paths.
+- Direct standalone compile/validate/instantiate probes for the seven
+  affected official shapes (`syntax/let.js`, both fresh-allocation tests,
+  `let-closure-inside-{initialization,condition,next-expression}.js`, and
+  `let-outer-inner-let-bindings.js`) each returned the expected `test=1`.
+- `git diff --check`: passed.
+
+The remaining baseline rows listed above are independent destructuring,
+TDZ-environment, parser, generator-provider, and class-name issues; this
+patch deliberately does not broaden into those owners.

--- a/src/codegen/expressions/call-tail-dispatch.ts
+++ b/src/codegen/expressions/call-tail-dispatch.ts
@@ -1306,6 +1306,25 @@ export function compileTailDispatch(
         if (cea !== undefined) return cea;
       }
 
+      // A JavaScript empty-array literal starts as an evolving `any[]` in
+      // TypeScript.  Its element call signature is therefore absent even when
+      // the program has populated it with closures (`let fns = [];
+      // fns.push(() => 1); fns[0]()`); the callable-element helper correctly
+      // declines a statically non-callable element type, but the old fallback
+      // then evaluated and dropped the call.  Preserve JS's dynamic call
+      // semantics for this narrow array/any-element shape.  Typed arrays and
+      // arrays with a concrete primitive element type keep their existing
+      // TypeError/fallback behavior.
+      {
+        const elementType = ctx.checker.getTypeAtLocation(elemAccess);
+        const elementIsUnresolved =
+          (elementType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Never)) !== 0;
+        if (ctx.standalone && elementIsUnresolved && resolveArrayInfo(ctx, receiverType)) {
+          const dyn = tryEmitInlineDynamicCall(ctx, fctx, expr, true);
+          if (dyn !== null) return dyn;
+        }
+      }
+
       // (#3166 S1) Computed-key call on a class-instance FIELD holding a
       // closure: `c[1+1]()` where `[1+1] = () => …` is a class field. TS does
       // NOT track a member named "2" for a computed-name field, so the callee

--- a/src/codegen/expressions/call-tail-dispatch.ts
+++ b/src/codegen/expressions/call-tail-dispatch.ts
@@ -1316,9 +1316,9 @@ export function compileTailDispatch(
       // arrays with a concrete primitive element type keep their existing
       // TypeError/fallback behavior.
       {
-        const elementType = ctx.checker.getTypeAtLocation(elemAccess);
+        const elementFact = ctx.oracle.typeFactOf(elemAccess);
         const elementIsUnresolved =
-          (elementType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Never)) !== 0;
+          elementFact.kind === "any" || elementFact.kind === "unknown" || elementFact.kind === "unresolvable";
         if (ctx.standalone && elementIsUnresolved && resolveArrayInfo(ctx, receiverType)) {
           const dyn = tryEmitInlineDynamicCall(ctx, fctx, expr, true);
           if (dyn !== null) return dyn;

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -514,6 +514,32 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
           : (fctx.locals[oldLocalIdx - fctx.params.length]?.type ?? {
               kind: "f64",
             });
+
+      // A closure in a later for-head declarator can capture an earlier head
+      // binding while the initializer is compiled (for example
+      // `for (let i = 0, f = () => i; ... )`). The closure capture path has
+      // already promoted that binding to its first ref cell. Reuse that cell
+      // as C₀ instead of wrapping the cell in a second ref cell; the latter
+      // would make the incrementor update the inner value while closures keep
+      // reading the outer cell.
+      const existingCapture = fctx.boxedCaptures?.get(name);
+      if (
+        existingCapture &&
+        oldType.kind === "ref_null" &&
+        oldType.typeIdx === existingCapture.refCellTypeIdx
+      ) {
+        if (!savedForBoxedCaptures) savedForBoxedCaptures = new Map();
+        if (!savedForBoxedCaptures.has(name)) {
+          savedForBoxedCaptures.set(name, existingCapture);
+        }
+        perIterCells.push({
+          name,
+          refCellTypeIdx: existingCapture.refCellTypeIdx,
+          boxedLocal: oldLocalIdx,
+        });
+        continue;
+      }
+
       const refCellTypeIdx = getOrRegisterRefCellType(ctx, oldType);
       const boxedLocal = allocLocal(fctx, `__pi_box_${name}`, {
         kind: "ref_null",

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -523,11 +523,7 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
       // would make the incrementor update the inner value while closures keep
       // reading the outer cell.
       const existingCapture = fctx.boxedCaptures?.get(name);
-      if (
-        existingCapture &&
-        oldType.kind === "ref_null" &&
-        oldType.typeIdx === existingCapture.refCellTypeIdx
-      ) {
+      if (existingCapture && oldType.kind === "ref_null" && oldType.typeIdx === existingCapture.refCellTypeIdx) {
         if (!savedForBoxedCaptures) savedForBoxedCaptures = new Map();
         if (!savedForBoxedCaptures.has(name)) {
           savedForBoxedCaptures.set(name, existingCapture);

--- a/src/ir/analysis/loop-shape.ts
+++ b/src/ir/analysis/loop-shape.ts
@@ -469,8 +469,11 @@ export function findHeadBindingsCapturedByClosures(stmt: ts.ForStatement, headNa
     }
     forEachChild(node, visit);
   }
-  // Walk condition + incrementor + body. Closures may appear in any of them
-  // (e.g. `for (let i=0; (f = () => i, true); i++) {}`).
+  // Walk the initializer, condition, incrementor, and body. A closure in a
+  // later declarator of the head is created before the first iteration and
+  // must keep the initial per-iteration environment (for example
+  // `for (let i = 0, f = () => i; i < 5; ++i)`).
+  visit(stmt.initializer);
   visit(stmt.condition);
   visit(stmt.incrementor);
   visit(stmt.statement);

--- a/tests/issue-4672.test.ts
+++ b/tests/issue-4672.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4672 — residual standalone ES2015 let/TDZ cases.
+//
+// The test262 wrapper uses JavaScript-style evolving arrays (`let a = []`),
+// so TypeScript reports an `any` element for `a[0]`. Before this fix the
+// callable-element helper declined that unresolved element type and the tail
+// fallback silently dropped the call. The loop cases additionally exercise
+// CreatePerIterationEnvironment when a closure appears in the for-head
+// initializer, a position the original closure scan skipped.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, {
+    target: "standalone",
+    fileName: "issue-4672.ts",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "standalone module must validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#4672 — standalone let/TDZ residuals", () => {
+  it("calls closures stored in an evolving empty array", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          let fns = [];
+          fns.push(function () { return 7; });
+          return fns[0]();
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("keeps body closures on distinct per-iteration let cells", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          let fns = [];
+          for (let i = 0; i < 3; ++i) {
+            fns.push(function () { return i; });
+          }
+          return fns[0]() + 10 * fns[1]() + 100 * fns[2]();
+        }
+      `),
+    ).toBe(210);
+  });
+
+  it("freshens closures created in the condition and incrementor", async () => {
+    // The incrementor runs in the fresh environment, after the copy of j and
+    // before `++j`, so its closures observe 1, 2, 3 (the condition closures
+    // observe 0, 1, 2).
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          let condition = [];
+          for (let i = 0; condition.push(function () { return i; }), i < 3; ++i) {}
+          let next = [];
+          for (let j = 0; j < 3; next.push(function () { return j; }), ++j) {}
+          return condition[0]() + 10 * condition[1]() + 100 * condition[2]() +
+            1000 * next[0]() + 10000 * next[1]() + 100000 * next[2]();
+        }
+      `),
+    ).toBe(321210);
+  });
+
+  it("keeps a closure from a for-head initializer on the initial cell", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          let fns = [];
+          for (let i = 0, f = function () { return i; }; i < 3; ++i) {
+            fns.push(f);
+          }
+          return fns[0]() + 10 * fns[1]() + 100 * fns[2]();
+        }
+      `),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- route unresolved evolving-array closure calls through the existing standalone dynamic-call emitter
- include for-head initializers in per-iteration closure capture analysis
- track the bounded ES2015 let/TDZ slice in issue #4672 with before/after evidence

## Verification

- focused issue #4672 tests: 4/4 passed
- loop and callable-element regressions: 20/20 passed
- seven affected official standalone shapes pass direct compile/validate/instantiate probes
- git diff --check passed

Base is explicitly upstream loopdive/js2:main. This PR does not merge itself.