### PR TITLE
fix(function): throw for aliased non-callable instances

### DIFF
--- a/src/codegen/expressions/calls-guards.ts
+++ b/src/codegen/expressions/calls-guards.ts
@@ -18,6 +18,7 @@ import { noJsHost } from "../js-errors.js";
 import { pushDefaultValue } from "../type-coercion.js";
 import { compileStandaloneRegExpConstructor, isGlobalRegExpIdentifier } from "../regexp-standalone.js";
 import { foreignReturnFunctionNames } from "../fnctor-foreign-return.js"; // (#4637 A2) §10.2.1.3 step 13
+import { isFreshOrdinaryObjectExpression } from "../native-ordinary-instanceof.js";
 
 /**
  * (#4221) Unwrap the transparent wrappers that sit between a call expression
@@ -223,6 +224,7 @@ export function isEvolvingAnyBinding(ctx: CodegenContext, callee: ts.Expression)
     // static fact here or it is nowhere.
     if (!isConst && nullishBindingIsRetargeted(callee)) return true;
   }
+  if (isFreshlyConstructedAlias(ctx, callee)) return false;
   return !NEVER_CALLABLE_FACT_KINDS.has(initFact.kind) && !isFreshlyConstructedNonCallable(ctx, init, initFact.kind);
 }
 
@@ -354,12 +356,33 @@ export function isFreshlyConstructedNonCallable(ctx: CodegenContext, callee: ts.
     // only here), unlike a checker-typed `{}` binding.
     return factKind === "builtin" || factKind === "class" || factKind === "object";
   }
+  // A single-assignment alias preserves the non-callability of a freshly
+  // constructed ordinary object. The checker reports untyped JavaScript
+  // aliases as `any`, so the direct-`new` arm above cannot see them and the
+  // call used to fall through to the silent undefined result. The helper
+  // requires a syntactic object / `new` initializer and a no-value-returning
+  // user constructor, and declines on any binding write; a later assignment
+  // may therefore replace the object with a callable value.
+  if (isFreshlyConstructedAlias(ctx, callee)) return true;
   // A nominal instance type (`new Number(1)` bound to a variable, an `Error`,
   // `IArguments`, a user class instance) carries no [[Call]] — `factOfType`
   // classifies anything with a call/construct signature as `function` before
   // it can reach `builtin`/`class`. `object` (the structural `{}` fact) is
   // deliberately NOT accepted off the `new` path.
   return factKind === "builtin" || factKind === "class";
+}
+
+/**
+ * True for a single-assignment binding whose initializer is a `new` expression
+ * producing an ordinary object. Keep this alias arm narrower than
+ * `isFreshOrdinaryObjectExpression`: object-literal aliases are a separate
+ * call-dispatch question, while this residual is specifically the untyped
+ * `var instance = new Ctor()` form.
+ */
+function isFreshlyConstructedAlias(ctx: CodegenContext, expr: ts.Expression): boolean {
+  if (!ts.isIdentifier(expr)) return false;
+  const initializer = ctx.oracle.variableInitializerOf(expr);
+  return initializer !== undefined && ts.isNewExpression(initializer) && isFreshOrdinaryObjectExpression(ctx, expr);
 }
 
 /**

--- a/src/codegen/native-ordinary-instanceof.ts
+++ b/src/codegen/native-ordinary-instanceof.ts
@@ -295,7 +295,7 @@ function isProvablyNonCallableObjectType(ctx: CodegenContext, expr: ts.Expressio
  * Either one unproven ⇒ decline, because the consequence of a false positive is
  * a spurious TypeError (a wrong answer), not a missed conversion.
  */
-function isFreshOrdinaryObjectExpression(ctx: CodegenContext, expr: ts.Expression): boolean {
+export function isFreshOrdinaryObjectExpression(ctx: CodegenContext, expr: ts.Expression): boolean {
   if (ts.isObjectLiteralExpression(expr)) return true;
   let source: ts.Expression = expr;
   if (ts.isIdentifier(expr)) {

--- a/tests/issue-4653.test.ts
+++ b/tests/issue-4653.test.ts
@@ -366,17 +366,13 @@ describe("#4653 residuals — measured standalone", () => {
 
   // ROW S13.2.2_A8_T3 — root corrected TWICE; see the issue file for both
   // superseded versions and why each was wrong. Final measured rule: inside
-  // eval'd / minted code, an UPDATE expression (`++`/`--`) throws
-  // ReferenceError for any name whose binding lives in a FUNCTION variable
-  // environment (the enclosing function's locals or parameters, a Function
-  // mint's own parameters, or an eval-local `var` when the eval runs inside a
-  // function); it works for names bound in the MODULE/global environment.
-  // Reads and compound assignment work in every case. The axis is WHERE THE
-  // NAME IS BOUND — not the surrounding syntax, and not whether an enclosing
-  // function exists. Filed as #4662; owner is the runtime-eval lane.
+  // eval'd / minted code, UPDATE expressions must resolve bindings in every
+  // supported environment. #4662 landed independently while this branch was
+  // being rebased, so these former expected-failure pins are now positive
+  // controls for that upstream behavior.
   //
   // This is the row's own shape: `++` on a Function-mint parameter.
-  it.fails("(#4662) `++` on a Function-mint PARAMETER resolves", async () => {
+  it("(#4662) `++` on a Function-mint PARAMETER resolves", async () => {
     expect(
       await runScript(`
         function host() { return new Function("p", "p++; return p;")(1); }
@@ -389,7 +385,7 @@ describe("#4653 residuals — measured standalone", () => {
   // top level throws too, because a Function parameter is always bound in a
   // function environment. This pin is what falsifies the enclosing-function
   // reading, so it must stay separate from the one above.
-  it.fails("(#4662) `++` on a mint parameter resolves at MODULE TOP LEVEL too", async () => {
+  it("(#4662) `++` on a mint parameter resolves at MODULE TOP LEVEL too", async () => {
     expect(
       await runScript(`
         var mint = new Function("p", "p++; return p;");
@@ -402,7 +398,7 @@ describe("#4653 residuals — measured standalone", () => {
   // root missed: the name is a local of the ENCLOSING function — neither
   // eval-local nor module-level. No loop, so this also rules out the
   // "loop-test position" reading on its own.
-  it.fails("(#4662) `++` on an ENCLOSING-FUNCTION local resolves inside eval", async () => {
+  it("(#4662) `++` on an ENCLOSING-FUNCTION local resolves inside eval", async () => {
     expect(
       await runScript(`
         function host() { var d = 0; eval("d++;"); return d; }
@@ -412,7 +408,7 @@ describe("#4653 residuals — measured standalone", () => {
   });
 
   // Same environment, eval-local spelling.
-  it.fails("(#4662) `++` on an eval-LOCAL var resolves inside a function", async () => {
+  it("(#4662) `++` on an eval-LOCAL var resolves inside a function", async () => {
     expect(
       await runScript(`
         function host() { return eval("var i = 0; i++; i"); }
@@ -421,11 +417,8 @@ describe("#4653 residuals — measured standalone", () => {
     ).toBe(null);
   });
 
-  // POSITIVE CONTROLS. These must PASS, and they are what make the four
-  // `it.fails` above a claim about `++`-on-a-function-env-binding rather than
-  // about eval scope in general. A fix that widens the wrong thing would repair
-  // these — which they already do — while leaving the four above failing; a fix
-  // that flips these instead of those is fixing the wrong thing.
+  // Additional positive controls distinguish update-expression resolution from
+  // ordinary reads and assignments through the same environments.
   it("binds a Function parameter for a plain read and for `p = p + 1`", async () => {
     expect(
       await runScript(`

--- a/tests/issue-4653.test.ts
+++ b/tests/issue-4653.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 //
 // (#4653) `language/statements/function` residual — the three families this
-// issue closed, plus `it.fails` pins on the nine it did not, each with the
-// measured root that owns it.
+// issue originally closed, plus executable pins for the remaining measured
+// roots. The call-dispatch residual is repaired by the focused alias arm below.
 //
 // Scoped sweep, standalone lane, over `language/statements/function` +
 // `language/statements/{return,try}` (668 files), run by the same driver on
@@ -233,7 +233,7 @@ describe("#4653 D — a var initialized from a REDECLARED function gets a neutra
 // with the root measured on this branch. They are `it.fails` so the suite
 // records the current answer and flips loudly when the owning lane lands.
 
-describe("#4653 residuals — measured, not fixed here", () => {
+describe("#4653 residuals — measured standalone", () => {
   // ROWS S13.2.2_A18_T1 / _T2. `arguments.callee` is synthesized by a
   // compile-time property-access arm; it is NOT an own property of the runtime
   // vec that backs the arguments object, so the dynamic `with` HasBinding gate
@@ -335,11 +335,10 @@ describe("#4653 residuals — measured, not fixed here", () => {
   });
 
   // ROW S13.2.2_A2. Calling a NON-callable instance must throw TypeError
-  // (§7.3.14 Call step 1). Measured: `rose()` does not throw at all — it
-  // evaluates to undefined — so the test's own `throw new Test262Error(...)`
-  // runs inside the try and is caught as the "exception", which is why the row
-  // reports `[object Object]` rather than a missing throw.
-  it.fails("(#4653 residual, call-dispatch) calling a non-callable throws TypeError", async () => {
+  // (§7.3.14 Call step 1). The single-assignment `new FACTORY()` alias used
+  // to fall through to undefined; the call-dispatch arm now proves that its
+  // constructor returns an ordinary, non-callable object.
+  it("(#4653 call-dispatch) calling a non-callable instance throws TypeError", async () => {
     expect(
       await runScript(`
         function PROTO() {}
@@ -350,6 +349,17 @@ describe("#4653 residuals — measured, not fixed here", () => {
         var kind = "no-throw";
         try { rose(); } catch (e) { kind = (e instanceof TypeError) ? "TypeError" : "other:" + String(e); }
         if (kind !== "TypeError") throw new Error("threw " + kind);
+      `),
+    ).toBe(null);
+  });
+
+  it("keeps a reassigned instance alias callable", async () => {
+    expect(
+      await runScript(`
+        function FACTORY() {}
+        var rose = new FACTORY();
+        rose = function () { return "callable"; };
+        if (rose() !== "callable") throw new Error("rose() was not callable");
       `),
     ).toBe(null);
   });


### PR DESCRIPTION
## Summary

Resolve single-assignment aliases initialized from ordinary-object constructors through the existing fresh-object proof before call dispatch. Calling that proven non-callable value now throws TypeError, while evolving/reassigned aliases stay on the runtime path.

## Test262 impact

- Genuine current-upstream fail-to-pass: `language/statements/function/S13.2.2_A2.js`.
- Exact delta: +1 pass, zero regressions.
- Added a callable-reassignment control so the proof does not overreach.

## Verification

- `tests/issue-4653.test.ts`: 24/24.
- Four #4662 expected-failure pins were promoted after that independent fix landed upstream during rebase.
- Normal pre-commit and full pre-push hooks passed without bypasses: typecheck/lint, format, LOC/function budgets, oracle/coercion ratchets, #3765 18/18, issue integrity.

Commits: `8a3639ef9`, `8aae281df`.