### PR TITLE
fix(standalone): capture ambient receivers in arrows

### DIFF
--- a/plan/issues/4673-arrow-function-lexical-this-standalone.md
+++ b/plan/issues/4673-arrow-function-lexical-this-standalone.md
@@ -1,0 +1,116 @@
+---
+id: 4673
+title: "standalone: arrow-function lexical this capture residual"
+status: done
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+assignee: codex/es6-arrow-wave3
+priority: high
+horizon: s
+feasibility: medium
+task_type: conformance
+area: codegen, conformance
+es_edition: es6
+goal: standalone-mode
+related: [4444, 4447, 368, 2797]
+loc-budget-allow:
+  - src/codegen/closures/arrow-phases.ts
+  - src/codegen/closures.ts
+  - src/codegen/context/types.ts
+  - src/codegen/helpers/body-references-own-this.ts
+func-budget-allow:
+  - src/codegen/closures/arrow-phases.ts::planClosureCaptures
+  - src/codegen/closures.ts::compileArrowAsClosure
+  - src/codegen/helpers/body-references-own-this.ts::findOwnThisReference
+---
+
+# #4673 — arrow-function lexical `this` capture residual
+
+## Problem
+
+The ES2015 standalone arrow-function cluster was re-measured against a fresh
+`test262-standalone-current.jsonl` (48,735 entries, SHA-256
+`9bbc9cd8ab6afe460088443ecd3181b00ba1908edf90b765c6dbd8bf89aa3b5c`,
+2026-08-25). Of 343 files under
+`language/expressions/arrow-function`, 308 pass, 32 fail at runtime, and 3
+have compile errors. The failures are heterogeneous; this issue owns the
+bounded lexical-receiver slice only.
+
+The clearest failures are:
+
+- `lexical-this.js`: an arrow created by a constructor reads a null receiver;
+- `arrow/binding-tests-1.js` and `arrow/binding-tests-2.js`: arrows returned
+  from a function's dynamic lexical scope are expected to retain that scope's
+  receiver (the standalone harness currently stops earlier at the independent
+  runtime-eval refusal);
+- `lexical-super-property.js` and
+  `lexical-super-property-from-within-constructor.js`: an arrow's inherited
+  `this` path produces `0` instead of `1`/`2`;
+- `lexical-new.target*.js`: lexical `new.target` is a separate global-carrier
+  problem and remains deferred here;
+- `lexical-super-call-from-within-constructor.js`: a lexical `super()` call
+  needs constructor completion machinery and remains deferred here.
+
+The current closure planner scans free identifiers but does not add the
+synthetic `this` binding. Consequently `compileThisKeyword` cannot find the
+enclosing function's receiver in a lifted arrow body and falls back to the
+`__current_this`/unbound path. In ordinary function frames, the receiver is
+represented by that ambient global rather than a `localMap` slot, so the
+capture path must materialize a private receiver local at arrow construction;
+it must not install `this` into the ordinary function's local map, because a
+preceding direct `this` read would otherwise observe an uninitialized local.
+Non-arrow closures must retain their own receiver behavior.
+
+## Implementation Plan
+
+1. Add a scope-aware lexical-`this` check for arrow bodies and include
+   `"this"` in the existing immutable capture plan when the enclosing frame
+   already has a receiver local.
+2. For ordinary frames whose receiver is supplied through `__current_this`,
+   materialize that value into a private local at each arrow construction and
+   resolve the synthetic capture through that local. Keep it separate from
+   the normal `this` binding so direct reads before closure creation remain
+   unchanged.
+3. Add focused unit regressions for an ordinary function returning an arrow,
+   constructor-created arrows, a class-method arrow, and an ordinary function
+   expression control. Re-run the exact lexical Test262 cohort and compare
+   the scoped baseline for zero-loss evidence. Do not absorb
+   destructuring/default-parameter, generator-host-import, `with`,
+   direct-eval, prototype-reflection, or lexical `new.target`/`super()`
+   residuals; those require their owning issues or a follow-up slice.
+
+## Baseline Evidence
+
+Full authoritative filter: 343 total, 308 pass, 32 runtime failures, 3
+compile errors. The complete residual list is retained in the run output; the
+representative lexical rows above are the acceptance cohort. The existing
+scoped runner uses the interpreter fallback in this worktree because the
+QuickJS artifact is unavailable.
+
+## Test Results
+
+- Before (authoritative baseline, 2026-08-25): the scoped arrow-function
+  filter was 343 total / 308 pass / 32 runtime failures / 3 compile errors.
+  The focused ambient-receiver probe returned `0`; the three controls were
+  green (1 failure, 3 passes in the eventual four-test regression file).
+- After: the four focused Vitest cases pass (4/4). The ambient-receiver
+  probe is now `1` (0 → 1); constructor, class-method, and ordinary-function
+  controls remain green (3/3).
+- Real assembled standalone Test262 cohort after the fix: 4 files yielded
+  1 pass (`cannot-override-this-with-thisArg.js`) and 3 unchanged failures.
+  `lexical-this.js` still fails in the dynamic member-call/harness path, and
+  the two `binding-tests-*` rows stop at the independent #2928 runtime-eval
+  refusal. This slice does not claim those residuals are fixed.
+- Zero-loss evidence: the assembled positive control and negative control
+  both retained their expected verdicts; scoped Biome lint passed for all
+  modified source and test files; the ordinary-function receiver control
+  stayed green before and after.
+
+## Scope Notes
+
+The issue is intentionally narrow. The remaining arrow failures include
+destructuring/iterator close/default-initializer cases overlapping #4447,
+generator carrier imports owned by #2864/#3178, dynamic `with`/eval paths,
+prototype reflection, and independent `new.target`/`super()` carrier work.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -158,6 +158,7 @@ export { isVecOrArrayRefType, isHostCallbackArgument, isDeferredCallbackArgument
 import { emitFuncRefAsClosure, materializeHoistedFunctionValueBinding } from "./closures/funcref-as-closure.js";
 import { emitUndefined } from "./expressions/late-imports.js";
 import { needsImplicitArgumentsObject } from "./helpers/body-uses-arguments.js";
+import { bodyReferencesOwnThis, findOwnThisReference } from "./helpers/body-references-own-this.js";
 // (#4491) §10.2.11 step 22.a — the mapped-vs-unmapped `arguments` split.
 import { isSimpleParameterList, isStrictFunction } from "./helpers/is-strict-function.js";
 export { emitFuncRefAsClosure, materializeHoistedFunctionValueBinding };
@@ -2969,6 +2970,22 @@ export function compileArrowAsClosure(
   //    TDZ-flag boxing) and the self-recursive binding — see planClosureCaptures.
   const reachesDirectEval = functionMayReachDirectEval(arrow, ctx.oracle);
   const additionalCaptureNames = planAdditionalWithEnvironmentCaptureNames(fctx, reachesDirectEval);
+  // Ordinary function frames do not bind `this` in localMap: their receiver
+  // is resolved through __current_this at each source read.  An arrow must
+  // snapshot that value at creation, however. Keep the snapshot in a private
+  // local instead of installing it as the frame's ordinary `this` binding;
+  // direct reads before this arrow is created must retain their old lowering.
+  if (
+    ts.isArrowFunction(arrow) &&
+    !fctx.localMap.has("this") &&
+    (bodyReferencesOwnThis(body) || genBodyReferencesSuper(body))
+  ) {
+    const thisLocal = fctx.lexicalThisCaptureLocal ?? allocLocal(fctx, "__arrow_lexical_this", { kind: "externref" });
+    fctx.lexicalThisCaptureLocal = thisLocal;
+    const thisNode = findOwnThisReference(body) ?? ts.factory.createThis();
+    compileExpression(ctx, fctx, thisNode, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: thisLocal });
+  }
   const { captures, selfBindingName } = planClosureCaptures(ctx, fctx, arrow, body, additionalCaptureNames);
   captureOwningDirectEvalState(ctx, fctx, arrow, reachesDirectEval, captures);
 

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -37,6 +37,7 @@ import { closureObservesBindingValue, collectTransitiveCaptureNames } from "../f
 import { emitBoundsCheckedArrayGet, valTypesMatch } from "../shared.js";
 import { spliceNullGuarded } from "./param-emit-helpers.js";
 import { materializeHoistedFunctionValueBinding } from "./funcref-as-closure.js";
+import { bodyReferencesOwnThis } from "../helpers/body-references-own-this.js";
 // (#4437) per-declaration `name` / §15.1.5 `length` carrier
 import { ensureFnMetaSubtype, fnMetaSlot, registerFnMetaFamily } from "../function-instance-meta.js";
 // (#4440) object-literal accessors / methods — §10.2.9 comes from the property key
@@ -50,6 +51,7 @@ import {
   collectParamDefaultReferences,
   collectReferencedIdentifiers,
   collectWrittenIdentifiers,
+  genBodyReferencesSuper,
   isOwnParamName,
   runtimeParameters,
 } from "../closures.js";
@@ -408,6 +410,21 @@ export function planClosureCaptures(
   // shadow set, so the param's own binding names stay excluded.
   collectClosureParameterReferences(arrow, referencedNames, ownLocals);
 
+  // Arrow functions do not introduce a `this` binding.  `this` is not an
+  // identifier, so the free-variable scan above intentionally cannot see it;
+  // without an explicit capture, the lifted body falls through to
+  // `__current_this` (or the unbound value) instead of retaining the receiver
+  // from its enclosing constructor/method.  Keep ordinary function
+  // expressions on their existing own-`this` path, and only add the synthetic
+  // capture when the enclosing frame actually has a receiver local.
+  if (
+    ts.isArrowFunction(arrow) &&
+    fctx.localMap.has("this") &&
+    (bodyReferencesOwnThis(body) || genBodyReferencesSuper(body))
+  ) {
+    referencedNames.add("this");
+  }
+
   // (#3040) Parameter DEFAULT initializers can reference enclosing-scope names
   // that appear NOWHERE in the body — e.g. `f = async function*([x] = iter)`
   // where `iter` is an outer local used ONLY in the default. The body-only scan
@@ -575,6 +592,9 @@ export function planClosureCaptures(
   }[] = [];
   for (const name of referencedNames) {
     let localIdx = fctx.localMap.get(name);
+    // The ordinary-function lexical-this path materializes a private local
+    // without changing the frame's normal `this` binding (see closures.ts).
+    if (localIdx === undefined && name === "this") localIdx = fctx.lexicalThisCaptureLocal;
     let tdzFlagIdxFromScan: number | undefined;
     if (localIdx === undefined) {
       // (#3121) A localMap miss can ALSO mean the name was PROMOTED to a

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -856,6 +856,13 @@ export interface FunctionContext {
    * test262 failures in `function-code/10.4.3-1-*` and `Array/prototype/*`).
    */
   readsCurrentThis?: boolean;
+  /**
+   * Receiver local used only while constructing a lexical arrow capture in a
+   * frame whose own `this` is represented by `__current_this` rather than a
+   * normal `localMap` binding.  It is deliberately separate from the `this`
+   * binding so reads that occur before the first arrow remain unchanged.
+   */
+  lexicalThisCaptureLocal?: number;
   /** While lowering a compile-time direct-eval Script, an otherwise absent
    * receiver in a sloppy caller denotes the realm global object. This is
    * scoped to the foreign eval AST so ordinary strict/direct-call `this`

--- a/src/codegen/helpers/body-references-own-this.ts
+++ b/src/codegen/helpers/body-references-own-this.ts
@@ -8,6 +8,35 @@ import { ts } from "../../ts-api.js";
 const cache = new WeakMap<ts.Node, boolean>();
 
 /**
+ * Return one `this` node belonging to the scanned lexical function body.
+ * Nested arrows inherit `this`, while ordinary function-like/class nodes
+ * rebind it and therefore are not traversed.  The node is used when codegen
+ * must materialize a lexical receiver so source-sensitive sloppy-IIFE rules
+ * see the original AST position rather than a detached synthetic node.
+ */
+export function findOwnThisReference(node: ts.Node): ts.Expression | undefined {
+  const stack: ts.Node[] = [node];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.kind === ts.SyntaxKind.ThisKeyword) return current as ts.Expression;
+    if (
+      ts.isFunctionDeclaration(current) ||
+      ts.isFunctionExpression(current) ||
+      ts.isMethodDeclaration(current) ||
+      ts.isGetAccessorDeclaration(current) ||
+      ts.isSetAccessorDeclaration(current) ||
+      ts.isConstructorDeclaration(current) ||
+      ts.isClassDeclaration(current) ||
+      ts.isClassExpression(current)
+    ) {
+      continue;
+    }
+    current.forEachChild((child) => stack.push(child));
+  }
+  return undefined;
+}
+
+/**
  * #2152 — Check whether a node tree references `this` in its OWN function scope.
  *
  * A non-arrow `function` / method / accessor / constructor / class rebinds

--- a/tests/issue-4673-arrow-lexical-this.test.ts
+++ b/tests/issue-4673-arrow-lexical-this.test.ts
@@ -1,0 +1,96 @@
+// #4673 — standalone arrow closures must retain the receiver from their
+// enclosing function.  `this` is not an identifier, so the ordinary free-name
+// capture scan cannot discover this lexical dependency.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const OPTIONS = {
+  allowJs: true,
+  deferTopLevelInit: true,
+  fileName: "issue-4673.ts",
+  hostBridge: "always",
+  skipSemanticDiagnostics: true,
+  target: "standalone",
+} as const;
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, OPTIONS as never);
+  expect(
+    result.success,
+    result.success ? "" : result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n"),
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#4673 — standalone arrow lexical this capture", () => {
+  it("captures the ambient receiver of an ordinary function", async () => {
+    expect(
+      await runStandalone(`
+        function makeArrow() {
+          return () => this;
+        }
+        export function test(): number {
+          const receiver = {};
+          const arrow = makeArrow.call(receiver);
+          return arrow() === receiver ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("keeps a constructor receiver across direct, call, and apply invocation", async () => {
+    expect(
+      await runStandalone(`
+        function F() {
+          this.arrow = () => this;
+        }
+        export function test(): number {
+          const f = new F();
+          const other = {};
+          return (f.arrow() === f ? 1 : 0) +
+            (f.arrow.call(other) === f ? 2 : 0) +
+            (f.arrow.apply(other) === f ? 4 : 0);
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("keeps a class-method receiver after the arrow is returned", async () => {
+    expect(
+      await runStandalone(`
+        class Box {
+          value: number;
+          constructor() { this.value = 23; }
+          makeArrow() {
+            const callback = () => this;
+            return callback;
+          }
+        }
+        export function test(): number {
+          const box = new Box();
+          const callback = box.makeArrow();
+          const other = { value: 99 };
+          return (callback() === box ? 1 : 0) +
+            (callback.call(other) === box ? 2 : 0) +
+            (callback().value === 23 ? 4 : 0);
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("leaves ordinary function expressions with their own receiver", async () => {
+    expect(
+      await runStandalone(`
+        function F() {
+          this.method = function () { return this; };
+        }
+        export function test(): number {
+          const f = new F();
+          const other = {};
+          return f.method.call(other) === other ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- track the bounded ES2015 lexical-this arrow residual in issue #4673
- include ambient receiver bindings in standalone lifted-arrow capture planning
- preserve ordinary-function receiver behavior while fixing constructor/class-method arrows

## Verification

- focused #4673 tests: 4/4 passed
- TypeScript 7 typecheck passed
- Biome lint and LOC/function budgets passed
- full pre-push type/lint, format, oracle/coercion ratchets, 18/18 numeric parity, and issue integrity passed
- representative Test262 cohort records one fixed pass and three unrelated residuals

Base is explicitly upstream loopdive/js2:main. This PR does not merge itself.