### PR TITLE
fix(regexp): compile dynamic nested capture groups

### DIFF
--- a/plan/issues/4665-regexp-dynamic-pattern-runtime-grammar.md
+++ b/plan/issues/4665-regexp-dynamic-pattern-runtime-grammar.md
@@ -16,6 +16,15 @@ language_feature: regexp
 goal: standalone-gap
 related: [4654, 682, 4492]
 origin: "split out of #4654 part C. The #4654 issue ASKED whether the refusal was narrow for these specific patterns; the lane MEASURED that it is not, and the table below is that measurement."
+# The dynamic compiler owns the runtime RegExp representation and all four
+# token walks. This bounded group-envelope step must update those walks and the
+# SAVE-slot constructor in place; moving it would duplicate the grammar/plumbing
+# boundary and risk the same count/emission drift this issue is fixing.
+loc-budget-allow:
+  - src/codegen/regexp-standalone.ts
+func-budget-allow:
+  - src/codegen/regexp-standalone.ts::ensureDynamicStandaloneRegExpCompiler
+  - src/codegen/regexp-dynamic-pattern.ts::ensureDynamicPatternTokenDecoder
 ---
 
 ## Problem

--- a/src/codegen/regexp-dynamic-pattern.ts
+++ b/src/codegen/regexp-dynamic-pattern.ts
@@ -44,9 +44,9 @@ import {
   RE_FLAG_Y,
 } from "./regex/bytecode.js";
 
-/** Token kinds, packed into bits 0..2 of the decoder's result. */
+/** Token kinds, packed into bits 0..3 of the decoder's result. */
 export const TOKEN_UNSUPPORTED = 0;
-/** A single literal code unit; the unit is in bits 8..23. */
+/** A single literal code unit; the unit is in bits 9..24. */
 export const TOKEN_LITERAL = 1;
 /** `.` — compiles to `ReOp.ANY`. */
 export const TOKEN_ANY = 2;
@@ -58,28 +58,32 @@ export const TOKEN_STAR = 4;
 export const TOKEN_PLUS = 5;
 /** `?` — greedy zero-or-one quantifier (Annex B `\\c` fallback only). */
 export const TOKEN_OPT = 6;
+/** `(` or `(?:` — a group opener; value 1 denotes non-capturing `(?:`. */
+export const TOKEN_GROUP_OPEN = 7;
+/** `)` — a group closer. */
+export const TOKEN_GROUP_CLOSE = 8;
 
 /**
  * The decoder packs its answer into one i32 so the callers need no
  * multi-value plumbing:
  *
- *   bits 0..2   kind      (TOKEN_*)
- *   bits 3..7   len       source code units consumed (always >= 1)
- *   bits 8..23  value     literal code unit, for TOKEN_LITERAL
+ *   bits 0..3   kind      (TOKEN_*)
+ *   bits 4..8   len       source code units consumed (always >= 1)
+ *   bits 9..24  value     literal code unit, for TOKEN_LITERAL
  */
-export const TOKEN_KIND_MASK = 0x7;
-export const TOKEN_LEN_SHIFT = 3;
+export const TOKEN_KIND_MASK = 0xf;
+export const TOKEN_LEN_SHIFT = 4;
 export const TOKEN_LEN_MASK = 0x1f;
-export const TOKEN_VALUE_SHIFT = 8;
+export const TOKEN_VALUE_SHIFT = 9;
 
 const DYN_TOKEN_HELPER = "__regex_dyn_token";
 
-/** `kind | len << 3 | value << 8`, as a constant-folded i32 where possible. */
+/** `kind | len << 4 | value << 9`, as a constant-folded i32 where possible. */
 function packConst(kind: number, len: number, value: number): Instr[] {
   return [{ op: "i32.const", value: kind | (len << TOKEN_LEN_SHIFT) | (value << TOKEN_VALUE_SHIFT) }];
 }
 
-/** `kind | len << 3 | (<value instrs>) << 8` for a runtime-computed unit. */
+/** `kind | len << 4 | (<value instrs>) << 9` for a runtime-computed unit. */
 function packDynamic(kind: number, len: number, value: Instr[]): Instr[] {
   return [
     ...value,
@@ -129,13 +133,18 @@ const inRange = (local: number, lo: number, hi: number): Instr[] => [
  * | `\` + non-alnum   | LITERAL(that unit)           | 2   |
  * | `\\c` + `*+?`       | STAR/PLUS/OPT quantifier      | 1   |
  * | `\\c` + `{}`        | LITERAL(that unit)            | 1   |
+ * | `(`                 | GROUP_OPEN (capturing)        | 1   |
+ * | `(?:`               | GROUP_OPEN (non-capturing)    | 3   |
+ * | `)`                 | GROUP_CLOSE                   | 1   |
  * | ordinary unit     | LITERAL(unit)                | 1   |
  * | anything else     | UNSUPPORTED                  | 1   |
  *
  * Deliberately UNSUPPORTED (each would need engine features this runtime
  * grammar does not have, and guessing would risk a wrong match):
  * `\d \D \s \S \w \W \b \B \k \p \P`, octal / back-references (`\1`),
- * every other `\`+alphanumeric, and the metacharacters `^ $ * + ? ( ) [ ] { }`.
+ * every other `\`+alphanumeric, and the metacharacters `^ $ * + ? [ ] { }`.
+ * Plain and non-capturing group envelopes are tokenised explicitly; the
+ * runtime compiler validates their nesting before emitting SAVE records.
  *
  * `\c` not followed by an ASCII letter decodes as a **literal backslash of
  * width 1**, so the trailing `c` is re-scanned as its own literal token. That
@@ -410,15 +419,27 @@ export function ensureDynamicPatternTokenDecoder(ctx: CodegenContext, strDataRef
         eqConst(C, 0x2e),
         packConst(TOKEN_ANY, 1, 0),
         cond(
-          eqConst(C, 0x2a),
-          annexBControlFallbackQuantifier(TOKEN_STAR),
+          eqConst(C, 0x28),
           cond(
-            eqConst(C, 0x2b),
-            annexBControlFallbackQuantifier(TOKEN_PLUS),
+            eqConst(D, 0x3f),
+            cond(eqConst(E, 0x3a), packConst(TOKEN_GROUP_OPEN, 3, 1), UNSUPPORTED),
+            packConst(TOKEN_GROUP_OPEN, 1, 0),
+          ),
+          cond(
+            eqConst(C, 0x29),
+            packConst(TOKEN_GROUP_CLOSE, 1, 0),
             cond(
-              eqConst(C, 0x3f),
-              annexBControlFallbackQuantifier(TOKEN_OPT),
-              cond(eqConst(C, 0x5c), backslash, annexBControlFallbackLiteral),
+              eqConst(C, 0x2a),
+              annexBControlFallbackQuantifier(TOKEN_STAR),
+              cond(
+                eqConst(C, 0x2b),
+                annexBControlFallbackQuantifier(TOKEN_PLUS),
+                cond(
+                  eqConst(C, 0x3f),
+                  annexBControlFallbackQuantifier(TOKEN_OPT),
+                  cond(eqConst(C, 0x5c), backslash, annexBControlFallbackLiteral),
+                ),
+              ),
             ),
           ),
         ),

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -93,6 +93,8 @@ import {
   ensureDynamicPatternTokenDecoder,
   makeDynamicPatternAccessors,
   TOKEN_ANY,
+  TOKEN_GROUP_CLOSE,
+  TOKEN_GROUP_OPEN,
   TOKEN_OPT,
   TOKEN_PIPE,
   TOKEN_PLUS,
@@ -1106,6 +1108,16 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
   const NEXT = 32;
   // Start pc of the current quantified atom's loop.
   const QSTART = 33;
+  // Group bookkeeping for the bounded dynamic capture-envelope grammar. A
+  // capture group gets two SAVE records; a non-capturing group only changes
+  // the nesting stack. Groups are deliberately refused when mixed with `|`
+  // so the existing alternative counter cannot be fed a mismatched stack.
+  const GROUP_DEPTH = 34;
+  const GROUP_CAPS = 35;
+  const GROUP_STACK = 36;
+  const GROUP_ID = 37;
+  const GROUP_SEEN = 38;
+  const GROUP_TOTAL = 39;
   const readFlatUnit = (dataLocal: number, offLocal: number, indexLocal: number): Instr[] => [
     { op: "local.get", index: dataLocal },
     { op: "local.get", index: offLocal },
@@ -1120,6 +1132,19 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
     { op: "i32.const", value: index },
     { op: "i32.add" },
     { op: "array.get_u", typeIdx: ctx.nativeStrDataTypeIdx },
+  ];
+
+  const groupStackGet = (index: number): Instr[] => [
+    { op: "local.get", index: GROUP_STACK },
+    { op: "local.get", index },
+    { op: "array.get", typeIdx: i32ArrIdx },
+  ];
+
+  const groupStackSet = (value: Instr[]): Instr[] => [
+    { op: "local.get", index: GROUP_STACK },
+    { op: "local.get", index: GROUP_DEPTH },
+    ...value,
+    { op: "array.set", typeIdx: i32ArrIdx },
   ];
 
   // #4065 — the single shared tokeniser. All FOUR walks over the pattern (count
@@ -1186,6 +1211,9 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
     { op: "local.get", index: PFLAT },
     { op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 0 },
     { op: "local.set", index: PLEN },
+    { op: "local.get", index: PLEN },
+    { op: "array.new_default", typeIdx: i32ArrIdx },
+    { op: "local.set", index: GROUP_STACK },
     { op: "local.get", index: FLAGS },
     { op: "call", funcIdx: flattenIdx },
     { op: "local.tee", index: FFLAT },
@@ -1336,6 +1364,12 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
     { op: "local.set", index: PLAIN },
     { op: "i32.const", value: 0 },
     { op: "local.set", index: CAN_QUANTIFY },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: GROUP_DEPTH },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: GROUP_CAPS },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: GROUP_SEEN },
     { op: "local.get", index: START },
     { op: "local.set", index: I },
     {
@@ -1370,96 +1404,124 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                 { op: "local.set", index: PLAIN },
               ],
             },
-            ...tk.kindIs(TOKEN_PIPE),
+            ...tk.kindIs(TOKEN_GROUP_OPEN),
             {
               op: "if",
               blockType: { kind: "empty" },
               then: [
-                { op: "local.get", index: ANCHORED },
+                { op: "i32.const", value: 1 },
+                { op: "local.set", index: GROUP_SEEN },
+                { op: "local.get", index: PIPES },
+                { op: "i32.eqz" },
                 {
                   op: "if",
                   blockType: { kind: "empty" },
-                  then: [
-                    { op: "local.get", index: PIPES },
-                    { op: "i32.const", value: 1 },
-                    { op: "i32.add" },
-                    { op: "local.set", index: PIPES },
-                  ],
+                  then: [],
                   else: [
                     { op: "i32.const", value: 0 },
                     { op: "local.set", index: SIMPLE },
                   ],
                 },
+                { op: "i32.const", value: 0 },
+                { op: "local.set", index: PLAIN },
+                ...tk.value(),
+                { op: "i32.eqz" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    ...groupStackSet([{ op: "local.get", index: GROUP_CAPS }]),
+                    { op: "local.get", index: GROUP_CAPS },
+                    { op: "i32.const", value: 1 },
+                    { op: "i32.add" },
+                    { op: "local.set", index: GROUP_CAPS },
+                    { op: "local.get", index: CHARS },
+                    { op: "i32.const", value: 2 },
+                    { op: "i32.add" },
+                    { op: "local.set", index: CHARS },
+                  ],
+                  else: [...groupStackSet([{ op: "i32.const", value: -1 }])],
+                },
+                { op: "local.get", index: GROUP_DEPTH },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: GROUP_DEPTH },
               ],
               else: [
-                ...tk.kindIs(TOKEN_UNSUPPORTED),
+                ...tk.kindIs(TOKEN_GROUP_CLOSE),
                 {
                   op: "if",
                   blockType: { kind: "empty" },
                   then: [
                     { op: "i32.const", value: 0 },
-                    { op: "local.set", index: SIMPLE },
-                    { op: "i32.const", value: 0 },
-                    { op: "local.set", index: CAN_QUANTIFY },
-                  ],
-                  else: [
-                    // `*`, `+`, and `?` are operators rather than program
-                    // records. They add the records needed to wrap the
-                    // immediately preceding atom; a leading/repeated
-                    // quantifier remains a loud unsupported pattern.
-                    ...tk.kindIs(TOKEN_STAR),
+                    { op: "local.set", index: PLAIN },
+                    { op: "local.get", index: GROUP_DEPTH },
+                    { op: "i32.eqz" },
                     {
                       op: "if",
                       blockType: { kind: "empty" },
                       then: [
-                        { op: "local.get", index: CAN_QUANTIFY },
+                        { op: "i32.const", value: 0 },
+                        { op: "local.set", index: SIMPLE },
+                      ],
+                      else: [
+                        { op: "local.get", index: GROUP_DEPTH },
+                        { op: "i32.const", value: 1 },
+                        { op: "i32.sub" },
+                        { op: "local.set", index: GROUP_DEPTH },
+                      ],
+                    },
+                  ],
+                  else: [
+                    ...tk.kindIs(TOKEN_PIPE),
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: [
+                        { op: "local.get", index: GROUP_SEEN },
                         {
                           op: "if",
                           blockType: { kind: "empty" },
                           then: [
-                            { op: "local.get", index: CHARS },
-                            { op: "i32.const", value: 2 },
-                            { op: "i32.add" },
-                            { op: "local.set", index: CHARS },
-                          ],
-                          else: [
                             { op: "i32.const", value: 0 },
                             { op: "local.set", index: SIMPLE },
                           ],
-                        },
-                        { op: "i32.const", value: 0 },
-                        { op: "local.set", index: PLAIN },
-                        { op: "i32.const", value: 0 },
-                        { op: "local.set", index: CAN_QUANTIFY },
-                      ],
-                      else: [
-                        ...tk.kindIs(TOKEN_PLUS),
-                        {
-                          op: "if",
-                          blockType: { kind: "empty" },
-                          then: [
-                            { op: "local.get", index: CAN_QUANTIFY },
+                          else: [
+                            { op: "local.get", index: ANCHORED },
                             {
                               op: "if",
                               blockType: { kind: "empty" },
                               then: [
-                                { op: "local.get", index: CHARS },
+                                { op: "local.get", index: PIPES },
                                 { op: "i32.const", value: 1 },
                                 { op: "i32.add" },
-                                { op: "local.set", index: CHARS },
+                                { op: "local.set", index: PIPES },
                               ],
                               else: [
                                 { op: "i32.const", value: 0 },
                                 { op: "local.set", index: SIMPLE },
                               ],
                             },
+                          ],
+                        },
+                      ],
+                      else: [
+                        ...tk.kindIs(TOKEN_UNSUPPORTED),
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [
                             { op: "i32.const", value: 0 },
-                            { op: "local.set", index: PLAIN },
+                            { op: "local.set", index: SIMPLE },
                             { op: "i32.const", value: 0 },
                             { op: "local.set", index: CAN_QUANTIFY },
                           ],
                           else: [
-                            ...tk.kindIs(TOKEN_OPT),
+                            // `*`, `+`, and `?` are operators rather than program
+                            // records. They add the records needed to wrap the
+                            // immediately preceding atom; a leading/repeated
+                            // quantifier remains a loud unsupported pattern.
+                            ...tk.kindIs(TOKEN_STAR),
                             {
                               op: "if",
                               blockType: { kind: "empty" },
@@ -1470,7 +1532,7 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                                   blockType: { kind: "empty" },
                                   then: [
                                     { op: "local.get", index: CHARS },
-                                    { op: "i32.const", value: 1 },
+                                    { op: "i32.const", value: 2 },
                                     { op: "i32.add" },
                                     { op: "local.set", index: CHARS },
                                   ],
@@ -1485,14 +1547,70 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                                 { op: "local.set", index: CAN_QUANTIFY },
                               ],
                               else: [
-                                // A literal or `.` is an atom that a later
-                                // quantifier may decorate.
-                                { op: "local.get", index: CHARS },
-                                { op: "i32.const", value: 1 },
-                                { op: "i32.add" },
-                                { op: "local.set", index: CHARS },
-                                { op: "i32.const", value: 1 },
-                                { op: "local.set", index: CAN_QUANTIFY },
+                                ...tk.kindIs(TOKEN_PLUS),
+                                {
+                                  op: "if",
+                                  blockType: { kind: "empty" },
+                                  then: [
+                                    { op: "local.get", index: CAN_QUANTIFY },
+                                    {
+                                      op: "if",
+                                      blockType: { kind: "empty" },
+                                      then: [
+                                        { op: "local.get", index: CHARS },
+                                        { op: "i32.const", value: 1 },
+                                        { op: "i32.add" },
+                                        { op: "local.set", index: CHARS },
+                                      ],
+                                      else: [
+                                        { op: "i32.const", value: 0 },
+                                        { op: "local.set", index: SIMPLE },
+                                      ],
+                                    },
+                                    { op: "i32.const", value: 0 },
+                                    { op: "local.set", index: PLAIN },
+                                    { op: "i32.const", value: 0 },
+                                    { op: "local.set", index: CAN_QUANTIFY },
+                                  ],
+                                  else: [
+                                    ...tk.kindIs(TOKEN_OPT),
+                                    {
+                                      op: "if",
+                                      blockType: { kind: "empty" },
+                                      then: [
+                                        { op: "local.get", index: CAN_QUANTIFY },
+                                        {
+                                          op: "if",
+                                          blockType: { kind: "empty" },
+                                          then: [
+                                            { op: "local.get", index: CHARS },
+                                            { op: "i32.const", value: 1 },
+                                            { op: "i32.add" },
+                                            { op: "local.set", index: CHARS },
+                                          ],
+                                          else: [
+                                            { op: "i32.const", value: 0 },
+                                            { op: "local.set", index: SIMPLE },
+                                          ],
+                                        },
+                                        { op: "i32.const", value: 0 },
+                                        { op: "local.set", index: PLAIN },
+                                        { op: "i32.const", value: 0 },
+                                        { op: "local.set", index: CAN_QUANTIFY },
+                                      ],
+                                      else: [
+                                        // A literal or `.` is an atom that a later
+                                        // quantifier may decorate.
+                                        { op: "local.get", index: CHARS },
+                                        { op: "i32.const", value: 1 },
+                                        { op: "i32.add" },
+                                        { op: "local.set", index: CHARS },
+                                        { op: "i32.const", value: 1 },
+                                        { op: "local.set", index: CAN_QUANTIFY },
+                                      ],
+                                    },
+                                  ],
+                                },
                               ],
                             },
                           ],
@@ -1509,6 +1627,19 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
         },
       ],
     },
+    { op: "local.get", index: GROUP_DEPTH },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [],
+      else: [
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: SIMPLE },
+      ],
+    },
+    { op: "local.get", index: GROUP_CAPS },
+    { op: "local.set", index: GROUP_TOTAL },
     // SAVE0 + chars + (SPLIT,JMP per pipe) + optional BOL/EOL + SAVE1 + MATCH.
     { op: "local.get", index: CHARS },
     { op: "local.get", index: PIPES },
@@ -1626,6 +1757,10 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
         { op: "local.set", index: PROG },
         { op: "i32.const", value: 0 },
         { op: "local.set", index: PC },
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: GROUP_DEPTH },
+        { op: "i32.const", value: 1 },
+        { op: "local.set", index: GROUP_CAPS },
         ...emitRecord([{ op: "i32.const", value: ReOp.SAVE }], [{ op: "i32.const", value: 0 }]),
         { op: "local.get", index: ANCHORED },
         {
@@ -1774,62 +1909,85 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                         // exactly `CHARS` records and stays inside the
                         // `NINSTR * 3` program array.
                         ...readToken(K),
-                        // Quantifiers are operators: wrap the immediately
-                        // preceding atom instead of emitting a standalone
-                        // record. The decoder scopes these tokens to the
-                        // Annex B `\\c` fallback, so ordinary unsupported
-                        // quantifier patterns still take the refusal path.
-                        { op: "local.get", index: K },
-                        ...tk.len(),
-                        { op: "i32.add" },
-                        { op: "local.set", index: NEXT },
-                        ...readToken(NEXT),
-                        ...tk.kindIs(TOKEN_STAR),
+                        ...tk.kindIs(TOKEN_GROUP_OPEN),
                         {
                           op: "if",
                           blockType: { kind: "empty" },
                           then: [
-                            { op: "local.get", index: PC },
-                            { op: "local.set", index: QSTART },
-                            ...emitRecord(
-                              [{ op: "i32.const", value: ReOp.SPLIT }],
-                              [{ op: "local.get", index: PC }, { op: "i32.const", value: 1 }, { op: "i32.add" }],
-                              [{ op: "local.get", index: PC }, { op: "i32.const", value: 3 }, { op: "i32.add" }],
-                            ),
-                            ...readToken(K),
                             ...tk.value(),
-                            { op: "local.set", index: CH },
-                            ...emitRecord(tk.recordOp(), dynamicCharOperand),
-                            ...emitRecord([{ op: "i32.const", value: ReOp.JMP }], [{ op: "local.get", index: QSTART }]),
-                            ...readToken(NEXT),
-                            ...advanceByToken(NEXT),
-                            { op: "local.get", index: NEXT },
-                            { op: "local.set", index: K },
-                          ],
-                          else: [
-                            ...tk.kindIs(TOKEN_PLUS),
+                            { op: "i32.eqz" },
                             {
                               op: "if",
                               blockType: { kind: "empty" },
                               then: [
-                                { op: "local.get", index: PC },
-                                { op: "local.set", index: QSTART },
-                                ...readToken(K),
-                                ...tk.value(),
-                                { op: "local.set", index: CH },
-                                ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                                ...groupStackSet([{ op: "local.get", index: GROUP_CAPS }]),
                                 ...emitRecord(
-                                  [{ op: "i32.const", value: ReOp.SPLIT }],
-                                  [{ op: "local.get", index: QSTART }],
-                                  [{ op: "local.get", index: PC }, { op: "i32.const", value: 1 }, { op: "i32.add" }],
+                                  [{ op: "i32.const", value: ReOp.SAVE }],
+                                  [
+                                    { op: "i32.const", value: 2 },
+                                    { op: "local.get", index: GROUP_CAPS },
+                                    { op: "i32.mul" },
+                                  ],
                                 ),
-                                ...readToken(NEXT),
-                                ...advanceByToken(NEXT),
-                                { op: "local.get", index: NEXT },
-                                { op: "local.set", index: K },
+                                { op: "local.get", index: GROUP_CAPS },
+                                { op: "i32.const", value: 1 },
+                                { op: "i32.add" },
+                                { op: "local.set", index: GROUP_CAPS },
+                              ],
+                              else: [...groupStackSet([{ op: "i32.const", value: -1 }])],
+                            },
+                            { op: "local.get", index: GROUP_DEPTH },
+                            { op: "i32.const", value: 1 },
+                            { op: "i32.add" },
+                            { op: "local.set", index: GROUP_DEPTH },
+                            ...advanceByToken(K),
+                          ],
+                          else: [
+                            ...tk.kindIs(TOKEN_GROUP_CLOSE),
+                            {
+                              op: "if",
+                              blockType: { kind: "empty" },
+                              then: [
+                                { op: "local.get", index: GROUP_DEPTH },
+                                { op: "i32.const", value: 1 },
+                                { op: "i32.sub" },
+                                { op: "local.set", index: GROUP_DEPTH },
+                                ...groupStackGet(GROUP_DEPTH),
+                                { op: "local.set", index: GROUP_ID },
+                                { op: "local.get", index: GROUP_ID },
+                                { op: "i32.const", value: 0 },
+                                { op: "i32.ge_s" },
+                                {
+                                  op: "if",
+                                  blockType: { kind: "empty" },
+                                  then: [
+                                    ...emitRecord(
+                                      [{ op: "i32.const", value: ReOp.SAVE }],
+                                      [
+                                        { op: "i32.const", value: 2 },
+                                        { op: "local.get", index: GROUP_ID },
+                                        { op: "i32.mul" },
+                                        { op: "i32.const", value: 1 },
+                                        { op: "i32.add" },
+                                      ],
+                                    ),
+                                  ],
+                                  else: [],
+                                },
+                                ...advanceByToken(K),
                               ],
                               else: [
-                                ...tk.kindIs(TOKEN_OPT),
+                                // Quantifiers are operators: wrap the immediately
+                                // preceding atom instead of emitting a standalone
+                                // record. The decoder scopes these tokens to the
+                                // Annex B `\\c` fallback, so ordinary unsupported
+                                // quantifier patterns still take the refusal path.
+                                { op: "local.get", index: K },
+                                ...tk.len(),
+                                { op: "i32.add" },
+                                { op: "local.set", index: NEXT },
+                                ...readToken(NEXT),
+                                ...tk.kindIs(TOKEN_STAR),
                                 {
                                   op: "if",
                                   blockType: { kind: "empty" },
@@ -1845,7 +2003,7 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                                       ],
                                       [
                                         { op: "local.get", index: PC },
-                                        { op: "i32.const", value: 2 },
+                                        { op: "i32.const", value: 3 },
                                         { op: "i32.add" },
                                       ],
                                     ),
@@ -1853,17 +2011,81 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
                                     ...tk.value(),
                                     { op: "local.set", index: CH },
                                     ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                                    ...emitRecord(
+                                      [{ op: "i32.const", value: ReOp.JMP }],
+                                      [{ op: "local.get", index: QSTART }],
+                                    ),
                                     ...readToken(NEXT),
                                     ...advanceByToken(NEXT),
                                     { op: "local.get", index: NEXT },
                                     { op: "local.set", index: K },
                                   ],
                                   else: [
-                                    ...readToken(K),
-                                    ...tk.value(),
-                                    { op: "local.set", index: CH },
-                                    ...emitRecord(tk.recordOp(), dynamicCharOperand),
-                                    ...advanceByToken(K),
+                                    ...tk.kindIs(TOKEN_PLUS),
+                                    {
+                                      op: "if",
+                                      blockType: { kind: "empty" },
+                                      then: [
+                                        { op: "local.get", index: PC },
+                                        { op: "local.set", index: QSTART },
+                                        ...readToken(K),
+                                        ...tk.value(),
+                                        { op: "local.set", index: CH },
+                                        ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                                        ...emitRecord(
+                                          [{ op: "i32.const", value: ReOp.SPLIT }],
+                                          [{ op: "local.get", index: QSTART }],
+                                          [
+                                            { op: "local.get", index: PC },
+                                            { op: "i32.const", value: 1 },
+                                            { op: "i32.add" },
+                                          ],
+                                        ),
+                                        ...readToken(NEXT),
+                                        ...advanceByToken(NEXT),
+                                        { op: "local.get", index: NEXT },
+                                        { op: "local.set", index: K },
+                                      ],
+                                      else: [
+                                        ...tk.kindIs(TOKEN_OPT),
+                                        {
+                                          op: "if",
+                                          blockType: { kind: "empty" },
+                                          then: [
+                                            { op: "local.get", index: PC },
+                                            { op: "local.set", index: QSTART },
+                                            ...emitRecord(
+                                              [{ op: "i32.const", value: ReOp.SPLIT }],
+                                              [
+                                                { op: "local.get", index: PC },
+                                                { op: "i32.const", value: 1 },
+                                                { op: "i32.add" },
+                                              ],
+                                              [
+                                                { op: "local.get", index: PC },
+                                                { op: "i32.const", value: 2 },
+                                                { op: "i32.add" },
+                                              ],
+                                            ),
+                                            ...readToken(K),
+                                            ...tk.value(),
+                                            { op: "local.set", index: CH },
+                                            ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                                            ...readToken(NEXT),
+                                            ...advanceByToken(NEXT),
+                                            { op: "local.get", index: NEXT },
+                                            { op: "local.set", index: K },
+                                          ],
+                                          else: [
+                                            ...readToken(K),
+                                            ...tk.value(),
+                                            { op: "local.set", index: CH },
+                                            ...emitRecord(tk.recordOp(), dynamicCharOperand),
+                                            ...advanceByToken(K),
+                                          ],
+                                        },
+                                      ],
+                                    },
                                   ],
                                 },
                               ],
@@ -1993,7 +2215,9 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
     },
     ...buildIndexedAnchoredLiteralAltProgram(i32ArrIdx, ctx.nativeStrDataTypeIdx),
     { op: "local.get", index: FBITS },
+    { op: "local.get", index: GROUP_TOTAL },
     { op: "i32.const", value: 1 },
+    { op: "i32.add" },
     { op: "local.get", index: PROG },
     { op: "i32.const", value: 0 },
     { op: "array.new_default", typeIdx: i32ArrIdx },
@@ -2046,6 +2270,12 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
       { name: "canQuantify", type: { kind: "i32" } },
       { name: "next", type: { kind: "i32" } },
       { name: "qstart", type: { kind: "i32" } },
+      { name: "groupDepth", type: { kind: "i32" } },
+      { name: "groupCaps", type: { kind: "i32" } },
+      { name: "groupStack", type: i32ArrRef },
+      { name: "groupId", type: { kind: "i32" } },
+      { name: "groupSeen", type: { kind: "i32" } },
+      { name: "groupTotal", type: { kind: "i32" } },
     ],
     body,
     exported: false,

--- a/tests/issue-4065.test.ts
+++ b/tests/issue-4065.test.ts
@@ -174,7 +174,7 @@ describe("#4065 constructs outside the runtime grammar stay LOUD refusals", () =
     ["class escape \\w", "\\w", "q"],
     ["assertion \\b", "\\b", "q"],
     ["back-reference", "(a)\\1", "aa"],
-    ["capture group", "(a)b", "ab"],
+    ["group alternation", "(a|b)", "a"],
     ["character class", "[abc]", "b"],
     ["quantifier", "a*b", "aab"],
     ["\\x with bad hex digits", "\\xZZ", "xZZ"],

--- a/tests/issue-4665-regexp-dynamic-groups.test.ts
+++ b/tests/issue-4665-regexp-dynamic-groups.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4665 — the bounded standalone dynamic-RegExp grammar accepts balanced plain
+// and non-capturing group envelopes. Keep the pattern runtime-built here: a
+// literal or compile-time-folded concatenation would exercise the static
+// regexp compiler instead of the dynamic token decoder.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, { target: "standalone" });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#4665 standalone dynamic RegExp group envelopes", () => {
+  it("captures all 200 nested plain groups", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          var pattern = "";
+          var i = 0;
+          for (i = 0; i < 200; i++) pattern += "(";
+          pattern += "hello";
+          for (i = 0; i < 200; i++) pattern += ")";
+          var match: any = new RegExp(pattern).exec("hello");
+          return match !== null && match.length === 201 && match[0] === "hello" && match[200] === "hello" ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("keeps 200 nested non-capturing groups out of the capture array", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          var pattern = "";
+          var i = 0;
+          for (i = 0; i < 200; i++) pattern += "(?:";
+          pattern += "hello";
+          for (i = 0; i < 200; i++) pattern += ")";
+          var match: any = new RegExp(pattern).exec("hello");
+          return match !== null && match.length === 1 && match[0] === "hello" ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Extend the standalone dynamic RegExp compiler with balanced capturing/non-capturing group tokens, SAVE-slot emission, and runtime `nGroups` tracking. Grouped alternation and malformed groups continue to fail closed.

## Test262 impact

Exact +3 fail-to-pass, zero regressions:

- `built-ins/RegExp/S15.10.2.8_A3_T15.js`
- `built-ins/RegExp/S15.10.2.8_A3_T16.js`
- `annexB/built-ins/RegExp/RegExp-control-escape-russian-letter.js`

## Verification

- Target Test262 rows: 3/3.
- Focused RegExp controls: 38/38.
- Typecheck, formatting, diff, LOC/function budgets passed.
- Full normal pre-push passed without bypasses: typecheck/lint, format, oracle/coercion ratchets, #3765 18/18, issue integrity.

Commit: `bfe41e8a9`.