### PR TITLE
fix(standalone): add trimLeft and trimRight aliases

### DIFF
--- a/plan/issues/4677-es6-trim-left-right-aliases-standalone.md
+++ b/plan/issues/4677-es6-trim-left-right-aliases-standalone.md
@@ -1,0 +1,100 @@
+---
+id: 4677
+title: "ES6 standalone: String.prototype.trimLeft/trimRight aliases"
+status: in-progress
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+assignee: codex/es6-trim-alias-wave3
+priority: medium
+horizon: s
+feasibility: medium
+task_type: feature
+area: codegen, conformance
+es_edition: es6
+goal: standalone-mode
+related: [4444, 4445, 3217, 4485]
+files:
+  - src/checker/inhouse-globals.ts
+  - src/codegen/array-object-proto.ts
+  - src/codegen/char-at-transfer.ts
+  - src/codegen/declarations/import-collector.ts
+  - src/codegen/expressions/calls.ts
+  - src/codegen/index.ts
+  - src/codegen/numeric-property-analysis.ts
+  - src/codegen/string-ops.ts
+  - src/codegen/string-proto-tostring.ts
+  - tests/issue-4677.test.ts
+loc-budget-allow:
+  - src/checker/inhouse-globals.ts
+  - src/codegen/array-object-proto.ts
+  - src/codegen/char-at-transfer.ts
+  - src/codegen/declarations/import-collector.ts
+  - src/codegen/expressions/calls.ts
+  - src/codegen/index.ts
+  - src/codegen/numeric-property-analysis.ts
+  - src/codegen/string-ops.ts
+  - src/codegen/string-proto-tostring.ts
+func-budget-allow:
+  - src/codegen/array-object-proto.ts::makeGlue
+  - src/codegen/array-object-proto.ts::emitStringProtoMemberBody
+  - src/codegen/string-ops.ts::compileNativeStringMethodCall
+---
+
+# #4677 — ES6 standalone `trimLeft`/`trimRight` aliases
+
+## Problem
+
+The Annex B aliases `String.prototype.trimLeft` and `trimRight` are absent
+from the standalone String prototype member table. Direct calls therefore reach
+the native-string path with no helper, while prototype value reads are
+`undefined`. The aliases must also be the exact initial function objects of
+`trimStart` and `trimEnd`, respectively, not merely equivalent wrappers.
+
+This is the documented follow-up from #4444/#4445. The focused upstream
+Test262 cohort is eight files:
+
+`annexB/built-ins/String/prototype/{trimLeft,trimRight}/{length,name,prop-desc,reference-*}.js`.
+
+## Scoped baseline (upstream/main `d5b14033d`, 2026-08-25)
+
+- Focused Test262 run through `runTest262File(..., "standalone")`: **0/8
+  pass, 8/8 fail**. The four `length.js`/`name.js` files fail while reading
+  the absent member, the two `prop-desc.js` files report the missing own
+  property, and both `reference-*` files compare `undefined` to the canonical
+  method.
+- Direct standalone smoke (`("  x  ").trimLeft/trimRight()`): compile and
+  Wasm validation succeed with zero imports, but each invocation traps on a
+  null native helper; the alias identity probe returns `0` and the two alias
+  lengths read as `0`.
+
+All counts use the eight-file denominator above; no broader ES6 bucket claim is
+made from this scoped baseline.
+
+## Implementation plan
+
+1. Add both Annex B names to the first-class String method registries and
+   arity/type analyses, so direct calls and prototype own-property reads use
+   the existing native trim machinery.
+2. Map `trimLeft` to `__str_trimStart` and `trimRight` to `__str_trimEnd` in
+   both direct and reflective call paths. Add them to the borrowed-method
+   transfer set where the existing reflective closure ABI requires explicit
+   membership.
+3. Use the native-prototype `memberAliasOf` hook (#4485) to canonicalize the
+   two aliases to `trimStart`/`trimEnd`; keep the alias names in the member CSV
+   so own-property and descriptor checks remain observable.
+4. Add focused equivalence tests for direct behavior, prototype descriptor
+   metadata, and exact alias identity in standalone mode.
+
+## Budgets and ratchets
+
+- Keep this as a table/dispatch-only fix: no new runtime imports, helper
+  families, or prototype representation. Any new source should be limited to
+  the existing files listed in `loc-budget-allow`.
+- Acceptance ratchet: focused Test262 must improve from **0/8** to **8/8**;
+  all existing trim/trimStart/trimEnd controls must remain passing, and the
+  standalone import manifest must stay empty.
+- Before/after evidence must report the same eight-file denominator and an
+  explicit pass→fail loss count; no zero-loss claim may be extrapolated from a
+  different runner or baseline artifact.
+

--- a/plan/issues/4677-es6-trim-left-right-aliases-standalone.md
+++ b/plan/issues/4677-es6-trim-left-right-aliases-standalone.md
@@ -1,10 +1,11 @@
 ---
 id: 4677
 title: "ES6 standalone: String.prototype.trimLeft/trimRight aliases"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-25
 updated: 2026-08-25
+completed: 2026-08-25
 assignee: codex/es6-trim-alias-wave3
 priority: medium
 horizon: s
@@ -17,27 +18,39 @@ related: [4444, 4445, 3217, 4485]
 files:
   - src/checker/inhouse-globals.ts
   - src/codegen/array-object-proto.ts
+  - src/codegen/builtin-value-read.ts
   - src/codegen/char-at-transfer.ts
   - src/codegen/declarations/import-collector.ts
   - src/codegen/expressions/calls.ts
+  - src/codegen/extern-declarations.ts
   - src/codegen/index.ts
   - src/codegen/numeric-property-analysis.ts
   - src/codegen/string-ops.ts
   - src/codegen/string-proto-tostring.ts
+  - src/ir/analysis/encoding.ts
+  - src/runtime/wasm-struct-host-semantics.ts
   - tests/issue-4677.test.ts
 loc-budget-allow:
   - src/checker/inhouse-globals.ts
   - src/codegen/array-object-proto.ts
+  - src/codegen/builtin-value-read.ts
   - src/codegen/char-at-transfer.ts
   - src/codegen/declarations/import-collector.ts
   - src/codegen/expressions/calls.ts
+  - src/codegen/extern-declarations.ts
   - src/codegen/index.ts
   - src/codegen/numeric-property-analysis.ts
   - src/codegen/string-ops.ts
   - src/codegen/string-proto-tostring.ts
+  - src/ir/analysis/encoding.ts
+  - src/runtime/wasm-struct-host-semantics.ts
 func-budget-allow:
   - src/codegen/array-object-proto.ts::makeGlue
   - src/codegen/array-object-proto.ts::emitStringProtoMemberBody
+  - src/codegen/builtin-value-read.ts::tryCompileStandaloneBuiltinProtoMemberMeta
+  - src/codegen/declarations/import-collector.ts::finalizeUnifiedCollector
+  - src/codegen/expressions/calls.ts::compileCallExpression
+  - src/codegen/extern-declarations.ts::registerBuiltinExternClasses
   - src/codegen/string-ops.ts::compileNativeStringMethodCall
 ---
 
@@ -98,3 +111,26 @@ made from this scoped baseline.
   explicit pass→fail loss count; no zero-loss claim may be extrapolated from a
   different runner or baseline artifact.
 
+## Implementation Summary
+
+- Registered `trimLeft` and `trimRight` in the standalone String method,
+  transfer, type, encoding, and host-semantics tables.
+- Routed direct and borrowed calls to the existing `__str_trimStart` and
+  `__str_trimEnd` helpers without adding imports.
+- Kept both alias names as own prototype entries while using the native-proto
+  identity hook to share the canonical closure and metadata. Direct `.name`
+  folds now emit `trimStart`/`trimEnd` for the aliases.
+- Added six standalone equivalence tests in `tests/issue-4677.test.ts`.
+
+## Test Results
+
+- Focused Test262 cohort: **8/8 pass, 0/8 fail** after the fix (same eight-file
+  denominator as the baseline; measured pass delta **+8**, fail delta **-8**).
+- `tests/issue-4677.test.ts`: **6/6 pass** with Vitest, one worker.
+- Existing trim controls `tests/issue-3217.test.ts` and
+  `tests/issue-3256.test.ts`: **19/19 pass** (standalone and WASI lanes).
+- TypeScript 7 check: `node node_modules/typescript7/lib/tsc.js --noEmit -p
+  tsconfig.ts7.json` — pass.
+- LOC and function budget gates — pass.
+- Direct standalone smoke: both calls, borrowed `.call`, exact identity,
+  canonical names, zero arity, valid Wasm, and zero imports — pass.

--- a/src/checker/inhouse-globals.ts
+++ b/src/checker/inhouse-globals.ts
@@ -286,6 +286,8 @@ export const STRING_METHOD_RETURNS: ReadonlyMap<string, TypeFact> = new Map<stri
   ["toString", STRING],
   ["trim", STRING],
   ["trimEnd", STRING],
+  ["trimLeft", STRING],
+  ["trimRight", STRING],
   ["trimStart", STRING],
   ["valueOf", STRING],
 ]);

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -269,6 +269,8 @@ const STRING_PROTO_METHODS = [
   "toWellFormed",
   "trim",
   "trimEnd",
+  "trimLeft",
+  "trimRight",
   "trimStart",
   "valueOf",
 ] as const;
@@ -548,6 +550,8 @@ const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = Object.assign(
     toLocaleUpperCase: 0,
     trim: 0,
     trimEnd: 0,
+    trimLeft: 0,
+    trimRight: 0,
     trimStart: 0,
     isWellFormed: 0,
     toWellFormed: 0,
@@ -1757,10 +1761,18 @@ function makeGlue(
     memberParamSlots: (member) => (name === "String" ? (STRING_PROTO_METHOD_PARAM_SLOTS[member] ?? 0) : 0),
     // (#4485) §B.2.4.3 — `Date.prototype.toGMTString` IS `Date.prototype.
     // toUTCString` (one function object, asserted by test262 annexB
-    // .../toGMTString/value.js). Alias the closure identity, not the member
-    // set: `toGMTString` stays in `DATE_PROTO_METHODS` so it is still an own
-    // property for hasOwnProperty/gOPD. No other family has an identity alias.
-    memberAliasOf: (member) => (name === "Date" && member === "toGMTString" ? "toUTCString" : undefined),
+    // .../toGMTString/value.js). The Annex B String aliases have the same
+    // identity rule: trimLeft→trimStart and trimRight→trimEnd. Alias the
+    // closure identity, not the member set: each spelling stays in its own
+    // proto CSV entry for hasOwnProperty/gOPD.
+    memberAliasOf: (member) =>
+      name === "Date" && member === "toGMTString"
+        ? "toUTCString"
+        : name === "String" && member === "trimLeft"
+          ? "trimStart"
+          : name === "String" && member === "trimRight"
+            ? "trimEnd"
+            : undefined,
     // (#2193 PR-B) Array.prototype.slice is now a real native closure body;
     // (#2875 slice 1) String.prototype.{charAt,at} likewise. Other Array/String
     // members + all Object members still degrade to a catchable TypeError.

--- a/src/codegen/builtin-value-read.ts
+++ b/src/codegen/builtin-value-read.ts
@@ -763,7 +763,10 @@ function tryCompileStandaloneBuiltinProtoMemberMeta(
   }
   // `.name` — the member's own name (getters are spelled "get <member>" per
   // §10.2.9, but the test gate reads method names; emit the bare member name).
-  return compileStringLiteral(ctx, fctx, member) ?? undefined;
+  // Annex B's trimLeft/trimRight entries are identity aliases, so their
+  // function object's name is the canonical trimStart/trimEnd spelling.
+  const canonicalMember = glue.memberAliasOf?.(member) ?? member;
+  return compileStringLiteral(ctx, fctx, canonicalMember) ?? undefined;
 }
 
 function tryCompileStandaloneBuiltinProtoMemberRead(

--- a/src/codegen/char-at-transfer.ts
+++ b/src/codegen/char-at-transfer.ts
@@ -247,6 +247,8 @@ const TRANSFERRED_STRING_PROTO_MEMBERS = [
   "trim",
   "trimStart",
   "trimEnd",
+  "trimLeft",
+  "trimRight",
   "indexOf",
   "lastIndexOf",
   "charCodeAt",

--- a/src/codegen/declarations/import-collector.ts
+++ b/src/codegen/declarations/import-collector.ts
@@ -1645,6 +1645,8 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
       "trim",
       "trimStart",
       "trimEnd",
+      "trimLeft",
+      "trimRight",
       "repeat",
       "padStart",
       "padEnd",

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7950,6 +7950,8 @@ function compileCallExpression(
               "trim",
               "trimStart",
               "trimEnd",
+              "trimLeft",
+              "trimRight",
               "concat",
               "repeat",
               "padStart",

--- a/src/codegen/extern-declarations.ts
+++ b/src/codegen/extern-declarations.ts
@@ -480,6 +480,10 @@ export function registerBuiltinExternClasses(ctx: CodegenContext): void {
     methods.set("toUpperCase", methodEntry([], { kind: "externref" }));
     methods.set("toLowerCase", methodEntry([], { kind: "externref" }));
     methods.set("trim", methodEntry([], { kind: "externref" }));
+    methods.set("trimStart", methodEntry([], { kind: "externref" }));
+    methods.set("trimEnd", methodEntry([], { kind: "externref" }));
+    methods.set("trimLeft", methodEntry([], { kind: "externref" }));
+    methods.set("trimRight", methodEntry([], { kind: "externref" }));
 
     // String.length is f64-typed in JS engine semantics (Number, not
     // i32). Read-only — `(str).length = N` is a no-op in JS, but we

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -9473,6 +9473,8 @@ export const STRING_METHODS: Record<string, { params: ValType[]; result: ValType
   trim: { params: [], result: { kind: "externref" } },
   trimStart: { params: [], result: { kind: "externref" } },
   trimEnd: { params: [], result: { kind: "externref" } },
+  trimLeft: { params: [], result: { kind: "externref" } },
+  trimRight: { params: [], result: { kind: "externref" } },
   charAt: { params: [{ kind: "f64" }], result: { kind: "externref" } },
   slice: {
     params: [{ kind: "f64" }, { kind: "f64" }],

--- a/src/codegen/numeric-property-analysis.ts
+++ b/src/codegen/numeric-property-analysis.ts
@@ -256,6 +256,8 @@ const STRING_STRING_METHODS: ReadonlySet<string> = new Set([
   "trim",
   "trimStart",
   "trimEnd",
+  "trimLeft",
+  "trimRight",
   "charAt",
   "concat",
   "repeat",

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -3049,11 +3049,20 @@ export function compileNativeStringMethodCall(
     return { kind: "i32" };
   }
 
-  // trim, trimStart, trimEnd: native helpers
-  if (method === "trim" || method === "trimStart" || method === "trimEnd") {
+  // trim, trimStart/trimLeft, trimEnd/trimRight: native helpers. Annex B's
+  // aliases intentionally share the canonical helper, just as their
+  // String.prototype function values share identity in the proto glue.
+  if (
+    method === "trim" ||
+    method === "trimStart" ||
+    method === "trimEnd" ||
+    method === "trimLeft" ||
+    method === "trimRight"
+  ) {
     emitReceiver();
     emitFlatten();
-    const helperName = `__str_${method}`;
+    const helperName =
+      method === "trimLeft" ? "__str_trimStart" : method === "trimRight" ? "__str_trimEnd" : `__str_${method}`;
     const funcIdx = ctx.nativeStrHelpers.get(helperName)!;
     fctx.body.push({ op: "call", funcIdx });
     return nativeStringType(ctx);

--- a/src/codegen/string-proto-tostring.ts
+++ b/src/codegen/string-proto-tostring.ts
@@ -33,6 +33,8 @@ export const NO_ARG_STRING_MEMBER_HELPER: Readonly<Record<string, string>> = {
   trim: "__str_trim",
   trimStart: "__str_trimStart",
   trimEnd: "__str_trimEnd",
+  trimLeft: "__str_trimStart",
+  trimRight: "__str_trimEnd",
   toLowerCase: "__str_toLowerCase",
   toUpperCase: "__str_toUpperCase",
   toLocaleLowerCase: "__str_toLowerCase",

--- a/src/ir/analysis/encoding.ts
+++ b/src/ir/analysis/encoding.ts
@@ -192,6 +192,8 @@ const ENCODING_PRESERVING_METHODS: ReadonlySet<string> = new Set([
   "trim",
   "trimStart",
   "trimEnd",
+  "trimLeft",
+  "trimRight",
   "normalize",
   "padStart",
   "padEnd",

--- a/src/runtime/wasm-struct-host-semantics.ts
+++ b/src/runtime/wasm-struct-host-semantics.ts
@@ -25,6 +25,8 @@ const PRIMITIVE_STRING_INTRINSICS: Readonly<Record<string, Function | undefined>
   toString: String.prototype.toString,
   trim: String.prototype.trim,
   trimEnd: String.prototype.trimEnd,
+  trimLeft: String.prototype.trimLeft,
+  trimRight: String.prototype.trimRight,
   trimStart: String.prototype.trimStart,
   valueOf: String.prototype.valueOf,
 });

--- a/tests/issue-4677.test.ts
+++ b/tests/issue-4677.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4677) Annex B String.prototype.trimLeft/trimRight in standalone mode.
+// The aliases must use the native trim helpers and resolve to the exact
+// canonical trimStart/trimEnd function objects.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(body: string): Promise<number> {
+  const result = await compile(`export function test(): number { ${body} }`, {
+    allowJs: true,
+    fileName: "issue-4677.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  if (!result.success) {
+    throw new Error(result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n"));
+  }
+  expect(Object.keys(result.imports)).toEqual([]);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#4677 — standalone trimLeft/trimRight aliases", () => {
+  it("trims leading whitespace through trimLeft", async () => {
+    await expect(runStandalone(`return " \\t x \\n".trimLeft() === "x \\n" ? 1 : 0;`)).resolves.toBe(1);
+  });
+
+  it("trims trailing whitespace through trimRight", async () => {
+    await expect(runStandalone(`return " \\t x \\n".trimRight() === " \\t x" ? 1 : 0;`)).resolves.toBe(1);
+  });
+
+  it("uses the canonical trimStart function object for trimLeft", async () => {
+    await expect(
+      runStandalone(`return String.prototype.trimLeft === String.prototype.trimStart ? 1 : 0;`),
+    ).resolves.toBe(1);
+  });
+
+  it("uses the canonical trimEnd function object for trimRight", async () => {
+    await expect(
+      runStandalone(`return String.prototype.trimRight === String.prototype.trimEnd ? 1 : 0;`),
+    ).resolves.toBe(1);
+  });
+
+  it("reports canonical names and zero arity for both aliases", async () => {
+    await expect(
+      runStandalone(
+        `return String.prototype.trimLeft.name === "trimStart" && String.prototype.trimRight.name === "trimEnd" && String.prototype.trimLeft.length === 0 && String.prototype.trimRight.length === 0 ? 1 : 0;`,
+      ),
+    ).resolves.toBe(1);
+  });
+
+  it("supports borrowed alias calls without host imports", async () => {
+    await expect(
+      runStandalone(
+        `return String.prototype.trimLeft.call("  x  ") === "x  " && String.prototype.trimRight.call("  x  ") === "  x" ? 1 : 0;`,
+      ),
+    ).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- track the documented #4445/#4444 trim alias follow-up in issue #4677
- expose trimLeft/trimRight through the first-class String prototype registries
- reuse trimStart/trimEnd native helpers and preserve exact alias function identity

## Verification

- focused Test262: 0/8 to 8/8
- trim regression controls: 25/25 passed
- TypeScript 7 and LOC/function budgets passed
- full pre-push type/lint, format, oracle/coercion ratchets, 18/18 numeric parity, and issue integrity passed

Base is explicitly upstream loopdive/js2:main. This PR does not merge itself.