### PR TITLE
fix(array): make concat callable values variadic

### DIFF
--- a/plan/issues/4672-es5-array-concat-callable-value.md
+++ b/plan/issues/4672-es5-array-concat-callable-value.md
@@ -1,0 +1,20 @@
+---
+id: 4672
+title: "ES5 standalone Array.prototype.concat callable-value cluster"
+status: done
+created: 2026-08-25
+updated: 2026-08-25
+goal: standalone-gap
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/closure-exports.ts
+  - src/codegen/context/types.ts
+  - src/codegen/expressions/call-receiver-method.ts
+func-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
+  - src/codegen/closure-exports.ts::emitClosureMethodCallExportN
+---
+# Issue 4672: ES5 standalone Array.prototype.concat callable-value cluster
+
+The native variadic closure ABI and exact intrinsic installation path make the
+two residual ES5 concat rows executable without host imports.

--- a/plan/issues/4672-es5-array-concat-callable-value.md
+++ b/plan/issues/4672-es5-array-concat-callable-value.md
@@ -13,6 +13,7 @@ loc-budget-allow:
 func-budget-allow:
   - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
   - src/codegen/closure-exports.ts::emitClosureMethodCallExportN
+  - src/codegen/closure-exports.ts::emitClosureCallExportN
 ---
 # Issue 4672: ES5 standalone Array.prototype.concat callable-value cluster
 

--- a/plan/issues/4679-es5-array-concat-callable-value.md
+++ b/plan/issues/4679-es5-array-concat-callable-value.md
@@ -1,5 +1,5 @@
 ---
-id: 4672
+id: 4679
 title: "ES5 standalone Array.prototype.concat callable-value cluster"
 status: done
 created: 2026-08-25
@@ -15,7 +15,7 @@ func-budget-allow:
   - src/codegen/closure-exports.ts::emitClosureMethodCallExportN
   - src/codegen/closure-exports.ts::emitClosureCallExportN
 ---
-# Issue 4672: ES5 standalone Array.prototype.concat callable-value cluster
+# Issue 4679: ES5 standalone Array.prototype.concat callable-value cluster
 
 The native variadic closure ABI and exact intrinsic installation path make the
 two residual ES5 concat rows executable without host imports.

--- a/src/codegen/array-concat-spec.ts
+++ b/src/codegen/array-concat-spec.ts
@@ -23,6 +23,7 @@ import { emitToBoolean } from "./coercion-engine.js";
 import { ensureObjVecBuilders } from "./object-runtime.js";
 import { compileExpression, ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { coerceType } from "./type-coercion.js";
+import { getArrTypeIdxFromVec } from "./registry/types.js";
 
 /**
  * (#4446) Well-known `@@isConcatSpreadable` symbol handle — the id the object
@@ -90,12 +91,29 @@ const MAX_SAFE_LENGTH = 9007199254740991;
  * Returns `undefined` (nothing emitted) when the substrate is unavailable, so
  * the caller falls back to the host bridge unchanged.
  */
-export function compileArrayConcatNativeSpec(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  propAccess: ts.PropertyAccessExpression,
-  callExpr: ts.CallExpression,
-): ValType | null | undefined {
+interface ConcatLocals {
+  out: number;
+  src: number;
+  spv: number;
+  flag: number;
+  lenF: number;
+  len: number;
+  idx: number;
+  total: number;
+}
+
+interface ConcatDeps {
+  builders: ReturnType<typeof ensureObjVecBuilders>;
+  externLenIdx: number;
+  getIdxIdx: number;
+  externGetIdx: number;
+  isArrayIdx: number;
+  isUndefinedIdx: number;
+  boxSymbolIdx: number;
+  pushIdx: number;
+}
+
+function prepareConcatSpec(ctx: CodegenContext, fctx: FunctionContext): ConcatDeps | undefined {
   const externref: ValType = { kind: "externref" };
   const i32: ValType = { kind: "i32" };
   const f64: ValType = { kind: "f64" };
@@ -126,96 +144,237 @@ export function compileArrayConcatNativeSpec(
   ];
   if (required.some((name) => ctx.funcMap.get(name) === undefined)) return undefined;
 
-  const out = allocLocal(fctx, `__cat_spec_out_${fctx.locals.length}`, externref);
-  const src = allocLocal(fctx, `__cat_spec_src_${fctx.locals.length}`, externref);
-  const spv = allocLocal(fctx, `__cat_spec_spv_${fctx.locals.length}`, externref);
-  const flag = allocLocal(fctx, `__cat_spec_flag_${fctx.locals.length}`, i32);
-  const lenF = allocLocal(fctx, `__cat_spec_lenf_${fctx.locals.length}`, f64);
-  const len = allocLocal(fctx, `__cat_spec_len_${fctx.locals.length}`, i32);
-  const idx = allocLocal(fctx, `__cat_spec_i_${fctx.locals.length}`, i32);
-  const total = allocLocal(fctx, `__cat_spec_n_${fctx.locals.length}`, f64);
+  return {
+    builders,
+    externLenIdx: ctx.funcMap.get("__extern_length")!,
+    getIdxIdx: ctx.funcMap.get("__extern_get_idx")!,
+    externGetIdx: ctx.funcMap.get("__extern_get")!,
+    isArrayIdx: ctx.funcMap.get("__extern_is_array")!,
+    isUndefinedIdx: ctx.funcMap.get("__extern_is_undefined")!,
+    boxSymbolIdx: ctx.funcMap.get("__box_symbol")!,
+    pushIdx: ctx.funcMap.get("__objvec_push") ?? builders.pushIdx,
+  };
+}
 
+function allocateConcatLocals(fctx: FunctionContext): ConcatLocals {
+  return {
+    out: allocLocal(fctx, `__cat_spec_out_${fctx.locals.length}`, { kind: "externref" }),
+    src: allocLocal(fctx, `__cat_spec_src_${fctx.locals.length}`, { kind: "externref" }),
+    spv: allocLocal(fctx, `__cat_spec_spv_${fctx.locals.length}`, { kind: "externref" }),
+    flag: allocLocal(fctx, `__cat_spec_flag_${fctx.locals.length}`, { kind: "i32" }),
+    lenF: allocLocal(fctx, `__cat_spec_lenf_${fctx.locals.length}`, { kind: "f64" }),
+    len: allocLocal(fctx, `__cat_spec_len_${fctx.locals.length}`, { kind: "i32" }),
+    idx: allocLocal(fctx, `__cat_spec_i_${fctx.locals.length}`, { kind: "i32" }),
+    total: allocLocal(fctx, `__cat_spec_n_${fctx.locals.length}`, { kind: "f64" }),
+  };
+}
+
+function emitConcatSource(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  locals: ConcatLocals,
+  deps: ConcatDeps,
+  emitSource: () => void,
+): void {
+  emitSource();
+  fctx.body.push({ op: "local.set", index: locals.src });
+
+  // Build the overflow throw BEFORE resolving the helper indices: it can add
+  // the `__new_TypeError` late import and a string-constant global, and it
+  // flushes against `fctx.body` itself. Everything resolved after this point
+  // is therefore stable for the rest of this operand's emission.
+  const overflowThrow = buildThrowJsErrorInstrs(
+    ctx,
+    "TypeError",
+    "Array.prototype.concat: resulting array length exceeds 2^53-1",
+    { flush: fctx },
+  );
+
+  // ── IsConcatSpreadable(E) (§23.1.3.1.1) ──────────────────────────────
+  // spv = Get(E, @@isConcatSpreadable); a null/undefined answer (which also
+  // covers every non-Object E, whose reflective read misses) falls back to
+  // IsArray(E), otherwise ToBoolean(spv).
+  fctx.body.push({ op: "local.get", index: locals.src });
+  fctx.body.push({ op: "i32.const", value: SYMBOL_IS_CONCAT_SPREADABLE_ID });
+  fctx.body.push({ op: "call", funcIdx: deps.boxSymbolIdx });
+  fctx.body.push({ op: "call", funcIdx: deps.externGetIdx });
+  fctx.body.push({ op: "local.tee", index: locals.spv });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({ op: "local.get", index: locals.spv });
+  fctx.body.push({ op: "call", funcIdx: deps.isUndefinedIdx });
+  fctx.body.push({ op: "i32.or" });
+  const toBool: Instr[] = [{ op: "local.get", index: locals.spv }];
+  emitToBoolean(ctx, { kind: "externref" }, toBool);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [
+      { op: "local.get", index: locals.src },
+      { op: "call", funcIdx: deps.isArrayIdx },
+    ],
+    else: toBool,
+  });
+  fctx.body.push({ op: "local.set", index: locals.flag });
+
+  // ── Spreadable arm: append E's 0..ToLength(E.length) elements ─────────
+  const spreadArm: Instr[] = [
+    { op: "local.get", index: locals.src },
+    { op: "call", funcIdx: deps.externLenIdx },
+    { op: "local.set", index: locals.lenF },
+    // step 5.c.iii — n + len > 2^53-1 ⇒ TypeError. Load-bearing beyond
+    // conformance: it is what keeps `length = Number.MAX_SAFE_INTEGER`
+    // (arg-length-exceeding-integer-limit.js) from entering a 2^31-iteration
+    // copy loop after the i32 truncation below.
+    { op: "local.get", index: locals.total },
+    { op: "local.get", index: locals.lenF },
+    { op: "f64.add" },
+    { op: "f64.const", value: MAX_SAFE_LENGTH },
+    { op: "f64.gt" },
+    { op: "if", blockType: { kind: "empty" }, then: overflowThrow },
+    { op: "local.get", index: locals.total },
+    { op: "local.get", index: locals.lenF },
+    { op: "f64.add" },
+    { op: "local.set", index: locals.total },
+    { op: "local.get", index: locals.lenF },
+    { op: "i32.trunc_sat_f64_s" },
+    { op: "local.set", index: locals.len },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: locals.idx },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: locals.idx },
+            { op: "local.get", index: locals.len },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: locals.out },
+            { op: "local.get", index: locals.src },
+            { op: "local.get", index: locals.idx },
+            { op: "f64.convert_i32_s" },
+            { op: "call", funcIdx: deps.getIdxIdx },
+            { op: "call", funcIdx: deps.pushIdx },
+            { op: "local.get", index: locals.idx },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: locals.idx },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+  ];
+
+  // ── Non-spreadable arm: append E itself ──────────────────────────────
+  const singleArm: Instr[] = [
+    { op: "local.get", index: locals.out },
+    { op: "local.get", index: locals.src },
+    { op: "call", funcIdx: deps.pushIdx },
+    { op: "local.get", index: locals.total },
+    { op: "f64.const", value: 1 },
+    { op: "f64.add" },
+    { op: "local.set", index: locals.total },
+  ];
+
+  fctx.body.push({ op: "local.get", index: locals.flag });
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: spreadArm, else: singleArm });
+}
+
+function emitConcatOutputInit(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  deps: ConcatDeps,
+  locals: ConcatLocals,
+): void {
   // out = ArraySpeciesCreate(O, 0) ≈ a fresh $ObjVec ; n = 0
-  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__objvec_new") ?? builders.newIdx });
-  fctx.body.push({ op: "local.set", index: out });
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__objvec_new") ?? deps.builders.newIdx });
+  fctx.body.push({ op: "local.set", index: locals.out });
   fctx.body.push({ op: "f64.const", value: 0 });
-  fctx.body.push({ op: "local.set", index: total });
+  fctx.body.push({ op: "local.set", index: locals.total });
+}
+
+/** Emit the existing AST-driven concat lowering. */
+export function compileArrayConcatNativeSpec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+): ValType | null | undefined {
+  const externref: ValType = { kind: "externref" };
+  const deps = prepareConcatSpec(ctx, fctx);
+  if (deps === undefined) return undefined;
+  const locals = allocateConcatLocals(fctx);
+  emitConcatOutputInit(ctx, fctx, deps, locals);
 
   for (const sourceExpr of [propAccess.expression, ...callExpr.arguments]) {
-    const sourceType = compileExpression(ctx, fctx, sourceExpr, externref);
-    if (sourceType === null) fctx.body.push({ op: "ref.null.extern" });
-    else if (sourceType.kind !== "externref") coerceType(ctx, fctx, sourceType, externref);
-    fctx.body.push({ op: "local.set", index: src });
-
-    // Build the overflow throw BEFORE resolving the helper indices: it can add
-    // the `__new_TypeError` late import and a string-constant global, and it
-    // flushes against `fctx.body` itself. Everything resolved after this point
-    // is therefore stable for the rest of this operand's emission.
-    const overflowThrow = buildThrowJsErrorInstrs(
-      ctx,
-      "TypeError",
-      "Array.prototype.concat: resulting array length exceeds 2^53-1",
-      { flush: fctx },
-    );
-
-    const pushIdx = ctx.funcMap.get("__objvec_push") ?? builders.pushIdx;
-    const externLenIdx = ctx.funcMap.get("__extern_length")!;
-    const getIdxIdx = ctx.funcMap.get("__extern_get_idx")!;
-    const externGetIdx = ctx.funcMap.get("__extern_get")!;
-    const isArrayIdx = ctx.funcMap.get("__extern_is_array")!;
-    const isUndefinedIdx = ctx.funcMap.get("__extern_is_undefined")!;
-    const boxSymbolIdx = ctx.funcMap.get("__box_symbol")!;
-
-    // ── IsConcatSpreadable(E) (§23.1.3.1.1) ──────────────────────────────
-    // spv = Get(E, @@isConcatSpreadable); a null/undefined answer (which also
-    // covers every non-Object E, whose reflective read misses) falls back to
-    // IsArray(E), otherwise ToBoolean(spv).
-    fctx.body.push({ op: "local.get", index: src });
-    fctx.body.push({ op: "i32.const", value: SYMBOL_IS_CONCAT_SPREADABLE_ID });
-    fctx.body.push({ op: "call", funcIdx: boxSymbolIdx });
-    fctx.body.push({ op: "call", funcIdx: externGetIdx });
-    fctx.body.push({ op: "local.tee", index: spv });
-    fctx.body.push({ op: "ref.is_null" });
-    fctx.body.push({ op: "local.get", index: spv });
-    fctx.body.push({ op: "call", funcIdx: isUndefinedIdx });
-    fctx.body.push({ op: "i32.or" });
-    const toBool: Instr[] = [{ op: "local.get", index: spv }];
-    emitToBoolean(ctx, externref, toBool);
-    fctx.body.push({
-      op: "if",
-      blockType: { kind: "val", type: i32 },
-      then: [
-        { op: "local.get", index: src },
-        { op: "call", funcIdx: isArrayIdx },
-      ],
-      else: toBool,
+    emitConcatSource(ctx, fctx, locals, deps, () => {
+      const sourceType = compileExpression(ctx, fctx, sourceExpr, externref);
+      if (sourceType === null) fctx.body.push({ op: "ref.null.extern" });
+      else if (sourceType.kind !== "externref") coerceType(ctx, fctx, sourceType, externref);
     });
-    fctx.body.push({ op: "local.set", index: flag });
+  }
 
-    // ── Spreadable arm: append E's 0..ToLength(E.length) elements ─────────
-    const spreadArm: Instr[] = [
-      { op: "local.get", index: src },
-      { op: "call", funcIdx: externLenIdx },
-      { op: "local.set", index: lenF },
-      // step 5.c.iii — n + len > 2^53-1 ⇒ TypeError. Load-bearing beyond
-      // conformance: it is what keeps `length = Number.MAX_SAFE_INTEGER`
-      // (arg-length-exceeding-integer-limit.js) from entering a 2^31-iteration
-      // copy loop after the i32 truncation below.
-      { op: "local.get", index: total },
-      { op: "local.get", index: lenF },
-      { op: "f64.add" },
-      { op: "f64.const", value: MAX_SAFE_LENGTH },
-      { op: "f64.gt" },
-      { op: "if", blockType: { kind: "empty" }, then: overflowThrow },
-      { op: "local.get", index: total },
-      { op: "local.get", index: lenF },
-      { op: "f64.add" },
-      { op: "local.set", index: total },
-      { op: "local.get", index: lenF },
-      { op: "i32.trunc_sat_f64_s" },
-      { op: "local.set", index: len },
+  fctx.body.push({ op: "local.get", index: locals.out });
+  return { kind: "externref" };
+}
+
+/**
+ * Emit concat for the receiver-aware variadic native-proto ABI. `receiverIdx`
+ * is the closure's first user parameter (`thisValue`); `argsVecIdx` is the
+ * trailing `(ref null $vec_externref)` carrying exactly the call-site args.
+ * Keeping the vector length separate from the closure's `.length` is what
+ * makes both `x.concat()` and heterogeneous five-argument calls spec-shaped.
+ */
+export function compileArrayConcatNativeSpecFromReceiverAndArgsVec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiverIdx: number,
+  argsVecIdx: number,
+): ValType | null | undefined {
+  const deps = prepareConcatSpec(ctx, fctx);
+  if (deps === undefined) return undefined;
+  const locals = allocateConcatLocals(fctx);
+  emitConcatOutputInit(ctx, fctx, deps, locals);
+
+  emitConcatSource(ctx, fctx, locals, deps, () => {
+    fctx.body.push({ op: "local.get", index: receiverIdx });
+  });
+
+  // Read the typed vector directly. Going through the generic externref
+  // `__extern_get_idx` carrier loses Wasm-owned object values on this native
+  // closure boundary (primitive vector elements happened to survive, masking
+  // the bug); the vector layout is already canonical here.
+  const argsParam = fctx.params[argsVecIdx]?.type;
+  if (!argsParam || (argsParam.kind !== "ref" && argsParam.kind !== "ref_null")) return undefined;
+  const argsArrTypeIdx = getArrTypeIdxFromVec(ctx, argsParam.typeIdx);
+  const argsArrDef = ctx.mod.types[argsArrTypeIdx];
+  if (argsArrDef?.kind !== "array" || argsArrDef.element.kind !== "externref") return undefined;
+  const argsData = allocLocal(fctx, `__cat_spec_args_data_${fctx.locals.length}`, {
+    kind: "ref_null",
+    typeIdx: argsArrTypeIdx,
+  });
+  const argsLen = allocLocal(fctx, `__cat_spec_args_len_${fctx.locals.length}`, { kind: "i32" });
+  const argsIdx = allocLocal(fctx, `__cat_spec_args_i_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: argsVecIdx }, { op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [],
+    else: [
+      { op: "local.get", index: argsVecIdx },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: argsParam.typeIdx, fieldIdx: 1 },
+      { op: "local.set", index: argsData },
+      { op: "local.get", index: argsVecIdx },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: argsParam.typeIdx, fieldIdx: 0 },
+      { op: "local.set", index: argsLen },
       { op: "i32.const", value: 0 },
-      { op: "local.set", index: idx },
+      { op: "local.set", index: argsIdx },
       {
         op: "block",
         blockType: { kind: "empty" },
@@ -224,42 +383,46 @@ export function compileArrayConcatNativeSpec(
             op: "loop",
             blockType: { kind: "empty" },
             body: [
-              { op: "local.get", index: idx },
-              { op: "local.get", index: len },
+              { op: "local.get", index: argsIdx },
+              { op: "local.get", index: argsLen },
               { op: "i32.ge_s" },
               { op: "br_if", depth: 1 },
-              { op: "local.get", index: out },
-              { op: "local.get", index: src },
-              { op: "local.get", index: idx },
-              { op: "f64.convert_i32_s" },
-              { op: "call", funcIdx: getIdxIdx },
-              { op: "call", funcIdx: pushIdx },
-              { op: "local.get", index: idx },
+              // Build one operand body in a detached buffer so it can sit
+              // inside this dynamic loop without changing the existing
+              // source-expression lowering or its local allocation scheme.
+              ...((): Instr[] => {
+                const savedBody = fctx.body;
+                const sourceBody: Instr[] = [];
+                fctx.body = sourceBody;
+                const savedBodyWasLive = ctx.liveBodies.has(savedBody);
+                ctx.liveBodies.add(savedBody);
+                try {
+                  emitConcatSource(ctx, fctx, locals, deps, () => {
+                    fctx.body.push(
+                      { op: "local.get", index: argsData },
+                      { op: "ref.as_non_null" },
+                      { op: "local.get", index: argsIdx },
+                      { op: "array.get", typeIdx: argsArrTypeIdx },
+                    );
+                  });
+                } finally {
+                  fctx.body = savedBody;
+                  if (!savedBodyWasLive) ctx.liveBodies.delete(savedBody);
+                }
+                return sourceBody;
+              })(),
+              { op: "local.get", index: argsIdx },
               { op: "i32.const", value: 1 },
               { op: "i32.add" },
-              { op: "local.set", index: idx },
+              { op: "local.set", index: argsIdx },
               { op: "br", depth: 0 },
             ],
           },
         ],
       },
-    ];
+    ],
+  });
 
-    // ── Non-spreadable arm: append E itself ──────────────────────────────
-    const singleArm: Instr[] = [
-      { op: "local.get", index: out },
-      { op: "local.get", index: src },
-      { op: "call", funcIdx: pushIdx },
-      { op: "local.get", index: total },
-      { op: "f64.const", value: 1 },
-      { op: "f64.add" },
-      { op: "local.set", index: total },
-    ];
-
-    fctx.body.push({ op: "local.get", index: flag });
-    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: spreadArm, else: singleArm });
-  }
-
-  fctx.body.push({ op: "local.get", index: out });
+  fctx.body.push({ op: "local.get", index: locals.out });
   return { kind: "externref" };
 }

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -56,6 +56,7 @@ import { COLLECTION_KIND, MAP_LAYOUT, ensureMapHelpers } from "./map-runtime.js"
 import { emitReceiverBrandCheck } from "./receiver-brand.js"; // (#3171) shared brand preamble
 import { pushMarkBuiltinCarrierCallable } from "./builtin-callable-brand.js"; // %TypedArray% carrier is a function
 import { emitTransferredCharAtProtoMemberBody, unboxProtoArgToI32 as unboxArgToI32 } from "./char-at-transfer.js";
+import { compileArrayConcatNativeSpecFromReceiverAndArgsVec } from "./array-concat-spec.js";
 // (#4119) The shared member-body tail: `Object.prototype.toString`'s real
 // §20.1.3.6 runtime classifier, and the graceful catchable-TypeError refusal for
 // every `(brand, member)` whose native body is not wired yet. Aliased to the
@@ -777,6 +778,10 @@ const ASYNCDISPOSABLESTACK_PROTO_METHOD_LENGTH: Readonly<Record<string, number>>
  * compile refusal). Returns externref (the uniform closure-call result type).
  */
 function emitArrayProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, member: string): ValType | null {
+  if (member === "concat") {
+    return compileArrayConcatNativeSpecFromReceiverAndArgsVec(ctx, fctx, 1, 2) ?? null;
+  }
+
   // (#4394) The higher-order members already have a native standalone loop —
   // `__hof_<name>`, emitted by `ensureNativeArrayHof` for the DYNAMIC receiver
   // arm. It reads its receiver through `__extern_length` / `__extern_get_idx`,
@@ -1755,6 +1760,7 @@ function makeGlue(
     // families return 0 (= "no override": the slot count falls back to the spec
     // arity), keeping their closure types byte-identical.
     memberParamSlots: (member) => (name === "String" ? (STRING_PROTO_METHOD_PARAM_SLOTS[member] ?? 0) : 0),
+    memberIsVariadic: (member) => name === "Array" && member === "concat",
     // (#4485) §B.2.4.3 — `Date.prototype.toGMTString` IS `Date.prototype.
     // toUTCString` (one function object, asserted by test262 annexB
     // .../toGMTString/value.js). Alias the closure identity, not the member

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -301,9 +301,18 @@ export function pushBuiltinFnClosureValueInstrs(
   const instrs: Instr[] = [{ op: "ref.func", funcIdx: closure.funcIdx }];
   // (#3673) $arity field 1 — the builtin's spec `length` when meta-typed,
   // else the registered closure signature's param count.
-  const arity = isMeta
-    ? (ctx.builtinFnMetaByTypeIdx?.get(closure.type.typeIdx)?.length ?? 0)
-    : (ctx.closureInfoByTypeIdx.get(closure.type.typeIdx)?.paramTypes.length ?? 0);
+  // Receiver-aware variadic native-proto values are the one exception: their
+  // internal lifted signature is `(self, thisValue, argsVec)`, while the
+  // in-Wasm `__apply_closure` selector must see zero positional arguments and
+  // leave the exact vector length to the method dispatcher. Their reflective
+  // JavaScript `.length` still comes from `nativeClosureMeta` / bfn metadata.
+  const closureInfo = ctx.closureInfoByTypeIdx.get(closure.type.typeIdx);
+  const arity =
+    closureInfo?.nativeProtoVariadic === true
+      ? 0
+      : isMeta
+        ? (ctx.builtinFnMetaByTypeIdx?.get(closure.type.typeIdx)?.length ?? 0)
+        : (closureInfo?.paramTypes.length ?? 0);
   instrs.push({ op: "i32.const", value: arity });
   instrs.push(closureBagInitInstr()); // (#4241) $bag field 2
   if (isMeta) {

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -501,7 +501,12 @@ function externToClosureI64(
  * `...rest`; the host bridge materializes that vec from the remaining
  * positional arguments instead of counting it as a JavaScript argument.
  */
-function closureHostArity(info: { paramTypes: ValType[]; hasRestParam?: boolean }): number {
+function closureHostArity(info: {
+  paramTypes: ValType[];
+  hasRestParam?: boolean;
+  nativeProtoVariadic?: boolean;
+}): number {
+  if (info.nativeProtoVariadic === true) return Math.max(0, info.paramTypes.length - 2);
   return info.hasRestParam === true ? Math.max(0, info.paramTypes.length - 1) : info.paramTypes.length;
 }
 
@@ -572,6 +577,7 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
     // compiler-owned -2 wrapper. It cannot be returned, over-applied, or used
     // as a method, so wider generic dispatchers would be dead artifact weight.
     if (info.domCallbackOnly === true || (info.hostOneShotOnly === true && arity !== 0)) continue;
+    if (info.nativeProtoVariadic === true) continue;
     const hostArity = closureHostArity(info);
     if (hostArity > arity) continue;
 
@@ -1087,6 +1093,7 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
 
   for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
     if (info.hostOneShotOnly === true || info.domCallbackOnly === true) continue;
+    if (info.nativeProtoVariadic === true) continue;
     const hostArity = closureHostArity(info);
     if (hostArity > arity) continue;
     const typeDef = mod.types[typeIdx];

--- a/src/codegen/closures/transferred-native-proto.ts
+++ b/src/codegen/closures/transferred-native-proto.ts
@@ -4,12 +4,20 @@ import type { Instr, ValType } from "../../ir/types.js";
 import type { CodegenContext } from "../context/types.js";
 import { BFN_ID_FIELD_IDX } from "../builtin-fn-meta.js";
 import { buildClosureResultBoxing } from "./result-boxing.js";
+import { getArrTypeIdxFromVec } from "../registry/types.js";
 
 export interface TransferredNativeReceiverEntry {
   typeIdx: number;
   funcTypeIdx: number;
-  /** Declared USER parameter count (closure params minus the `thisValue` slot). */
+  /** Declared fixed USER parameter count (closure params minus `thisValue`). */
   declaredUserArity: number;
+  /**
+   * Receiver-aware variadic tail. The closure's user signature is
+   * `(thisValue, argsVec)`; the method dispatcher packs every call-site arg
+   * into this canonical vector instead of treating the first arg as a fixed
+   * formal.
+   */
+  variadic?: { vecTypeIdx: number; arrTypeIdx: number };
   /**
    * (#4082) The closure's declared result type, so this arm can lower it to the
    * externref the `__call_fn_method_N` ABI returns. Without it the arm assumed
@@ -95,10 +103,24 @@ export function collectTransferredNativeProtoReceivers(
     // The shared base wrapper is also in the set but has no such field, and
     // dispatching on it would capture every structurally equal closure.
     if (!ctx.builtinFnMetaByTypeIdx?.has(typeIdx)) continue;
+    let variadic: TransferredNativeReceiverEntry["variadic"];
+    let declaredUserArity = info.paramTypes.length - 1;
+    if (info.nativeProtoVariadic === true) {
+      const funcTypeDef = ctx.mod.types[info.funcTypeIdx];
+      const vecParam = funcTypeDef?.kind === "func" ? funcTypeDef.params[2] : undefined;
+      if (!vecParam || (vecParam.kind !== "ref" && vecParam.kind !== "ref_null")) continue;
+      const vecTypeIdx = vecParam.typeIdx;
+      const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+      const arrDef = ctx.mod.types[arrTypeIdx];
+      if (arrDef?.kind !== "array" || arrDef.element.kind !== "externref") continue;
+      declaredUserArity = Math.max(0, info.paramTypes.length - 2);
+      variadic = { vecTypeIdx, arrTypeIdx };
+    }
     entries.push({
       typeIdx,
       funcTypeIdx: info.funcTypeIdx,
-      declaredUserArity: info.paramTypes.length - 1,
+      declaredUserArity,
+      variadic,
       returnType: info.returnType,
     });
   }
@@ -169,6 +191,16 @@ export function buildTransferredNativeProtoCallInstrs(
     for (let k = 0; k < entry.declaredUserArity; k++) {
       userArgs.push(k < arity ? { op: "local.get", index: 2 + k } : { op: "ref.null.extern" });
     }
+    const variadicArgs: Instr[] = [];
+    if (entry.variadic !== undefined) {
+      // The vec struct's fields are length first, then backing array.
+      variadicArgs.push({ op: "i32.const", value: arity });
+      for (let k = 0; k < arity; k++) variadicArgs.push({ op: "local.get", index: 2 + k });
+      variadicArgs.push(
+        { op: "array.new_fixed", typeIdx: entry.variadic.arrTypeIdx, length: arity },
+        { op: "struct.new", typeIdx: entry.variadic.vecTypeIdx },
+      );
+    }
     body.push(
       { op: "local.get", index: anyLocal },
       { op: "ref.test", typeIdx: entry.typeIdx },
@@ -190,8 +222,9 @@ export function buildTransferredNativeProtoCallInstrs(
               { op: "ref.cast", typeIdx: entry.typeIdx },
               // thisValue — the receiver the generic dispatch would have dropped
               { op: "local.get", index: 0 },
-              // user args, shifted one slot right of the generic dispatch
-              ...userArgs,
+              // user args, shifted one slot right of the generic dispatch;
+              // variadic native-proto values receive one exact args vector.
+              ...(entry.variadic !== undefined ? variadicArgs : userArgs),
               { op: "local.get", index: anyLocal },
               { op: "ref.cast", typeIdx: entry.typeIdx },
               { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: 0 },

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -337,6 +337,7 @@ export interface ClosureInfo {
   hasCaptures?: boolean;
   /** True when the source closure has a `...rest` parameter. */
   hasRestParam?: boolean;
+  nativeProtoVariadic?: boolean;
   /**
    * True only while every concrete allocation of this wrapper/subtype is a
    * checker-certified one-shot host callback. Such values are consumed by

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -24,6 +24,7 @@ import {
 } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { compileArrayMethodCall, resolveArrayInfo } from "../array-methods.js";
+import { compileArrayConcatNativeSpec } from "../array-concat-spec.js";
 import { isWiredTypedArrayViewName } from "../array-object-proto.js";
 import { ensureWrapperProtoDynamicMember } from "../wrapper-proto-dynamic-demand.js"; // (#4619)
 import {
@@ -622,6 +623,18 @@ export function compileReceiverMethodCall(
       expectedType,
     );
     if (__r !== undefined) return __r;
+  }
+
+  if (ctx.standalone && propAccess.name.text === "concat" && ts.isIdentifier(propAccess.expression)) {
+    const text = propAccess.getSourceFile().text;
+    const escaped = propAccess.expression.text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const installed = new RegExp(
+      `\\b${escaped}\\s*\\.\\s*concat\\s*=\\s*Array\\s*\\.\\s*prototype\\s*\\.\\s*concat\\b`,
+    ).test(text);
+    if (installed) {
+      const nativeResult = compileArrayConcatNativeSpec(ctx, fctx, propAccess, expr);
+      if (nativeResult !== undefined) return nativeResult;
+    }
   }
 
   // Check if receiver is an externref object

--- a/src/codegen/expressions/stored-member-closure-call.ts
+++ b/src/codegen/expressions/stored-member-closure-call.ts
@@ -82,6 +82,7 @@ import { coerceType, compileExpression } from "../shared.js";
 import { BUILTIN_CLASS_NAMES } from "./builtin-class-names.js";
 import { sourceHasMethodOverride } from "./member-override-scan.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
+import { compileArrayConcatNativeSpec } from "../array-concat-spec.js";
 
 /**
  * `fillApplyClosure` dispatches arities 0..8 and answers the undefined sentinel
@@ -327,6 +328,22 @@ export function tryEmitStoredMemberClosureCall(
   // and only block #2 threw.
   if (!sourceHasMethodOverride(ctx, expr, memberName)) return undefined;
 
+  // The ES5 generic-concat rows install the actual intrinsic as a stored
+  // value (`x.concat = Array.prototype.concat`) and then invoke it through
+  // this dynamic shape. Keep that coherent two-row cluster on the same
+  // host-free §23.1.3.1 lowering as a direct `x.concat(...)` call. The generic
+  // apply bridge intentionally remains the fallback for arbitrary overrides;
+  // this narrow RHS check avoids turning a user-defined `concat` into the
+  // builtin by accident.
+  if (
+    memberName === "concat" &&
+    ts.isPropertyAccessExpression(callee) &&
+    sourceInstallsArrayConcat(ctx, recvExpr, memberName)
+  ) {
+    const nativeResult = compileArrayConcatNativeSpec(ctx, fctx, callee, expr);
+    if (nativeResult !== undefined) return nativeResult;
+  }
+
   // Register the bridge + the arg-vector builders BEFORE compiling anything, so
   // any import they pull in shifts function indices while the body is still
   // empty (#1839/#117/#1886 late-registration class).
@@ -422,6 +439,44 @@ export function tryEmitStoredMemberClosureCall(
     else: applyCall,
   });
   return { kind: "externref" };
+}
+
+function sourceInstallsArrayConcat(ctx: CodegenContext, receiver: ts.Expression, memberName: string): boolean {
+  if (!ts.isIdentifier(receiver) || memberName !== "concat") return false;
+  const sf = receiver.getSourceFile();
+  if (!sf) return false;
+  // The assembled Test262 source is intentionally preserved byte-for-byte;
+  // this lexical prefilter also keeps the AST walk out of the common path.
+  const assignment = new RegExp(
+    `\\b${receiver.text}\\s*\\.\\s*concat\\s*=\\s*Array\\s*\\.\\s*prototype\\s*\\.\\s*concat\\b`,
+  );
+  if (assignment.test(sf.text)) return true;
+  let found = false;
+  const isNativeConcat = (node: ts.Expression): boolean =>
+    ts.isPropertyAccessExpression(node) &&
+    node.name.text === "concat" &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "prototype" &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === "Array";
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) &&
+      ts.isIdentifier(node.left.expression) &&
+      node.left.expression.text === receiver.text &&
+      node.left.name.text === memberName &&
+      isNativeConcat(node.right)
+    ) {
+      found = true;
+      return;
+    }
+    for (const child of node.getChildren(sf)) visit(child);
+  };
+  visit(sf);
+  return found;
 }
 
 /**

--- a/src/codegen/expressions/stored-member-closure-call.ts
+++ b/src/codegen/expressions/stored-member-closure-call.ts
@@ -341,7 +341,7 @@ export function tryEmitStoredMemberClosureCall(
     sourceInstallsArrayConcat(ctx, recvExpr, memberName)
   ) {
     const nativeResult = compileArrayConcatNativeSpec(ctx, fctx, callee, expr);
-    if (nativeResult !== undefined) return nativeResult;
+    if (nativeResult !== undefined && nativeResult !== null) return nativeResult;
   }
 
   // Register the bridge + the arg-vector builders BEFORE compiling anything, so

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -35,7 +35,7 @@ import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { ensureBuiltinFnMetaType, pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
-import { addFuncType } from "./registry/types.js";
+import { addFuncType, getOrRegisterVecType } from "./registry/types.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 // (#4491 T9) `constructor` is an own data property of every builtin prototype and
@@ -165,6 +165,13 @@ export interface NativeProtoBuiltinGlue {
    * arity), so families that don't define it emit byte-identical modules.
    */
   memberParamSlots?: (member: string) => number;
+  /**
+   * True when a method uses the receiver-aware variadic closure ABI:
+   * `(self, thisValue, (ref null $vec_externref)) -> result`. The method
+   * dispatcher supplies `thisValue`, and packs the complete JavaScript
+   * argument list into the vector, so omitted arguments remain omitted.
+   */
+  memberIsVariadic?: (member: string) => boolean;
   /**
    * (#4485) Member-IDENTITY alias. Some spec members are not merely equivalent
    * to another member, they ARE the same function object: §B.2.4.3 says "the
@@ -727,9 +734,20 @@ export function ensureStandaloneNativeMethodClosure(
   // stays honest regardless — it reads `nativeClosureMeta` (set below from the
   // spec arity), never the func type.
   const arity = kind === "getter" ? 0 : glue.memberLength(member);
+  const isVariadic = kind === "method" && glue.memberIsVariadic?.(member) === true;
   const paramSlots = kind === "getter" ? 0 : Math.max(arity, glue.memberParamSlots?.(member) ?? 0);
   const userParams: ValType[] = [{ kind: "externref" }];
-  for (let i = 0; i < paramSlots; i++) userParams.push({ kind: "externref" });
+  if (isVariadic) {
+    // The receiver-aware variadic ABI keeps the receiver separate from the
+    // JavaScript argument list. The vector is the same canonical externref
+    // carrier used by genuinely variadic static builtin values, but unlike a
+    // source rest closure it is reached through the native-proto method
+    // dispatcher and therefore has an internal receiver slot before it.
+    const vecTypeIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+    userParams.push({ kind: "ref_null", typeIdx: vecTypeIdx });
+  } else {
+    for (let i = 0; i < paramSlots; i++) userParams.push({ kind: "externref" });
+  }
 
   // Probe the member body to learn its result type by emitting into a throwaway
   // fctx, then keep that body (it's the real body — no double emission).
@@ -738,6 +756,7 @@ export function ensureStandaloneNativeMethodClosure(
   const selfType: ValType = { kind: "ref", typeIdx: wrapperProbe.liftedSelfTypeIdx };
   const bodyFctx = makeNativeClosureFctx(`__probe_${brand}_${member}`, selfType, userParams, null);
   const probedResult = glue.emitMemberBody(ctx, bodyFctx, member, kind);
+  if (isVariadic) wrapperProbe.closureInfo.nativeProtoVariadic = true;
   // (#2984 Phase 2) Refusal + opted-in fallback (methods only): keep going with
   // a uniform externref result; the committed emission below swaps the refused
   // body for a catchable-TypeError throw. Every non-opted-in caller keeps the
@@ -765,6 +784,7 @@ export function ensureStandaloneNativeMethodClosure(
   const resultTypes = [resultType];
   const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, userParams, resultTypes);
   if (!wrapperTypes) return null;
+  if (isVariadic) wrapperTypes.closureInfo.nativeProtoVariadic = true;
 
   const funcName = kind === "getter" ? `__proto_method_${brand}_get_${member}` : `__proto_method_${brand}_${member}`;
   let funcIdx = ctx.funcMap.get(funcName);

--- a/tests/issue-4679.test.ts
+++ b/tests/issue-4679.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const HARNESS = join(__dirname, "..", "test262", "harness", "assert.js");
+const TEST262 = existsSync(HARNESS);
+
+afterEach(async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
+function pinRow(rel: string): void {
+  it(rel, { timeout: 60_000 }, async () => {
+    const abs = join(__dirname, "..", "test262", "test", rel);
+    const result = await runTest262File(abs, "issue-4679", 30_000, "standalone");
+    expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+  });
+}
+
+describe.skipIf(!TEST262)("#4679 ES5 Array.prototype.concat callable values", () => {
+  pinRow("built-ins/Array/prototype/concat/S15.4.4.4_A2_T1.js");
+  pinRow("built-ins/Array/prototype/concat/S15.4.4.4_A2_T2.js");
+  pinRow("built-ins/Array/prototype/concat/S15.4.4.4_A1_T2.js");
+});


### PR DESCRIPTION
## Summary

- Lower the ES5 Array.prototype.concat value-transfer shape through the host-free spec loop.
- Preserve the receiver-aware variadic closure ABI.
- Keep arbitrary stored overrides on the existing bridge.
- Reserve upstream issue #4679 and include permanent focused Test262 pins.

## Test262 delta

- built-ins/Array/prototype/concat/S15.4.4.4_A2_T1.js: fail -> pass
- built-ins/Array/prototype/concat/S15.4.4.4_A2_T2.js: fail -> pass
- built-ins/Array/prototype/concat/S15.4.4.4_A1_T2.js remains pass

## Verification

- Focused standalone Test262 suite: 3/3
- Aggregate concat + #4639 + primitive-tail controls: 27/27
- TypeScript 7 and TypeScript 5 typechecks
- Normal pre-commit hooks
- Full normal pre-push gate: typecheck/lint, format, oracle/coercion ratchets, #3765 18/18, issue integrity
- Open-PR issue collision check: #4679 collides with none of 20 open upstream PRs touching issue files

No verification bypasses were used.