### PR TITLE
fix(#4640): preserve native Error constructor properties

### DIFF
--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -275,19 +275,6 @@ export function tryDynamicReceiverRuntimeDispatchReads(
   return PA_FALLTHROUGH;
 }
 
-// (#4640 residual) Native Error instances use the same namespace carrier as
-// their bare constructor value, including the length/name/prototype seed.
-function isBuiltinConstructorCarrierName(name: string): boolean {
-  return isBuiltinConstructorIdentityName(name) || isWasiErrorName(name);
-}
-
-function emitBuiltinConstructorCarrier(ctx: CodegenContext, fctx: FunctionContext, builtinName: string): ValType {
-  if (isBuiltinConstructorIdentityName(builtinName)) {
-    return emitBuiltinConstructorIdentity(ctx, fctx, builtinName);
-  }
-  return emitBuiltinNamespaceObject(ctx, fctx, builtinName)!;
-}
-
 export function tryConstructorPrototypeIdentity(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -486,7 +473,7 @@ export function tryConstructorPrototypeIdentity(
     const builtinName = objType.getSymbol()?.name;
     if (
       builtinName !== undefined &&
-      isBuiltinConstructorCarrierName(builtinName) &&
+      (isBuiltinConstructorIdentityName(builtinName) || isWasiErrorName(builtinName)) &&
       isExternalDeclaredClass(objType, ctx.checker)
     ) {
       // Evaluate the receiver for spec side effects before returning its identity.
@@ -494,7 +481,9 @@ export function tryConstructorPrototypeIdentity(
       if (objResult) {
         fctx.body.push({ op: "drop" });
       }
-      return emitBuiltinConstructorCarrier(ctx, fctx, builtinName);
+      return isBuiltinConstructorIdentityName(builtinName)
+        ? emitBuiltinConstructorIdentity(ctx, fctx, builtinName)
+        : emitBuiltinNamespaceObject(ctx, fctx, builtinName)!;
     }
   }
 

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -275,6 +275,19 @@ export function tryDynamicReceiverRuntimeDispatchReads(
   return PA_FALLTHROUGH;
 }
 
+// (#4640 residual) Native Error instances use the same namespace carrier as
+// their bare constructor value, including the length/name/prototype seed.
+function isBuiltinConstructorCarrierName(name: string): boolean {
+  return isBuiltinConstructorIdentityName(name) || isWasiErrorName(name);
+}
+
+function emitBuiltinConstructorCarrier(ctx: CodegenContext, fctx: FunctionContext, builtinName: string): ValType {
+  if (isBuiltinConstructorIdentityName(builtinName)) {
+    return emitBuiltinConstructorIdentity(ctx, fctx, builtinName);
+  }
+  return emitBuiltinNamespaceObject(ctx, fctx, builtinName)!;
+}
+
 export function tryConstructorPrototypeIdentity(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -473,17 +486,15 @@ export function tryConstructorPrototypeIdentity(
     const builtinName = objType.getSymbol()?.name;
     if (
       builtinName !== undefined &&
-      isBuiltinConstructorIdentityName(builtinName) &&
+      isBuiltinConstructorCarrierName(builtinName) &&
       isExternalDeclaredClass(objType, ctx.checker)
     ) {
-      // Evaluate the receiver for its side effects (spec: the object expression is
-      // evaluated), then discard it — the constructor identity does not depend on
-      // the receiver instance.
+      // Evaluate the receiver for spec side effects before returning its identity.
       const objResult = compileExpression(ctx, fctx, expr.expression);
       if (objResult) {
         fctx.body.push({ op: "drop" });
       }
-      return emitBuiltinConstructorIdentity(ctx, fctx, builtinName);
+      return emitBuiltinConstructorCarrier(ctx, fctx, builtinName);
     }
   }
 

--- a/tests/es5-standalone-error-date-residual.test.ts
+++ b/tests/es5-standalone-error-date-residual.test.ts
@@ -26,9 +26,5 @@ function pinRow(relativePath: string, note: string): void {
 
 describe.skipIf(!TEST262)("ES5 standalone Error/Date residuals", () => {
   pinRow("built-ins/Error/length.js", "Error constructor length is one");
-  pinRow(
-    "built-ins/Error/prototype/constructor/S15.11.4.1_A1_T2.js",
-    "Error.prototype.constructor remains constructable",
-  );
   pinRow("built-ins/Date/S15.9.2.1_A2.js", "Date() returns a parseable current-date string");
 });

--- a/tests/es5-standalone-error-date-residual.test.ts
+++ b/tests/es5-standalone-error-date-residual.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Focused standalone ES5 pins for the remaining Error/Date smalls. These rows
+// run through the same original Test262 harness as the authoritative lane, so
+// they preserve the module-init and builtin-carrier shape of the census.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const HARNESS = join(__dirname, "..", "test262", "harness", "assert.js");
+const TEST262 = existsSync(HARNESS);
+
+afterEach(async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
+function pinRow(relativePath: string, note: string): void {
+  it(`${relativePath} — ${note}`, { timeout: 60_000 }, async () => {
+    const filePath = join(__dirname, "..", "test262", "test", relativePath);
+    const result = await runTest262File(filePath, "es5-error-date-residual", 30_000, "standalone");
+    expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+  });
+}
+
+describe.skipIf(!TEST262)("ES5 standalone Error/Date residuals", () => {
+  pinRow("built-ins/Error/length.js", "Error constructor length is one");
+  pinRow(
+    "built-ins/Error/prototype/constructor/S15.11.4.1_A1_T2.js",
+    "Error.prototype.constructor remains constructable",
+  );
+  pinRow("built-ins/Date/S15.9.2.1_A2.js", "Date() returns a parseable current-date string");
+});


### PR DESCRIPTION
## Summary

Route statically known native Error instances through the shared callable namespace carrier so err.constructor exposes the standard length, name, prototype, and identity properties. Keep the driver at zero net LOC growth.

## Test262 delta

- built-ins/Error/length.js: fail with NaN vs 1 -> pass
- built-ins/Date/S15.9.2.1_A2.js remains pass as a clean-upstream control
- built-ins/Error/prototype/constructor/S15.11.4.1_A1_T2.js remains owned by upstream PR #4883 and passes in the aggregate composition

## Verification

- clean-upstream focused pins: 2/2, non-vacuous
- aggregate Error/Date plus #4639 composition: 25/25
- TypeScript 7 and TypeScript 5
- LOC and function budgets: zero unallowed growth
- normal pre-commit and full pre-push gates: typecheck/lint, format, oracle/coercion ratchets, #3765 18/18, issue integrity

The branch diff is exactly two files. No verification bypasses were used.