### PR TITLE
fix(#4556): honor Array overrides for inline String arrays

### DIFF
--- a/src/codegen/builtin-proto-member-override.ts
+++ b/src/codegen/builtin-proto-member-override.ts
@@ -49,10 +49,14 @@
  * byte-identically — `protoNamedDirty` is a pre-scan flag, so the arm is not
  * merely dead, it is never built.
  *
- * IDENTIFIER RECEIVERS ONLY. The else arm re-dispatches the whole call so the
- * builtin lowering runs verbatim, which compiles the receiver a second time;
- * that is only sound when evaluating it has no side effects. Same restriction,
- * for the same reason, as the dyn-view two-arm.
+ * IDENTIFIER RECEIVERS are the general case. The else arm re-dispatches the
+ * whole call so the builtin lowering runs verbatim, which compiles the
+ * receiver a second time; that is only sound when evaluating it has no side
+ * effects. The one non-identifier exception is the zero-argument `new Array`
+ * expression synthesized for `String(new Array)`: constructing a fresh empty
+ * Array has no user-observable evaluation effect, and the native join branch
+ * must still see the same inline receiver shape. Same restriction, for the
+ * same reason, as the dyn-view two-arm.
  */
 import { ts } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
@@ -82,6 +86,26 @@ import {
 /** `skipTransparentExpressions` takes an Expression; narrow before calling. */
 function isExpressionNode(n: ts.Node): n is ts.Expression {
   return typeof (n as ts.Expression).kind === "number" && "getSourceFile" in n;
+}
+
+/**
+ * The override two-arm re-compiles the call in its builtin branch. Keep the
+ * non-identifier exception deliberately exact: `String(new Array)` lowers to
+ * an inline synthetic `toString()` call, and a zero-argument native Array
+ * construction is the only inline receiver needed by that ES5 row that can be
+ * evaluated twice without running user code. Calls with constructor arguments,
+ * array literals, and arbitrary expressions stay on the single-evaluation
+ * path until they have a receiver-local lowering of their own.
+ */
+function isSideEffectFreeInlineArrayReceiver(receiverExpr: ts.Expression, ctorName: string): boolean {
+  if (ctorName !== "Array") return false;
+  const n = skipTransparentExpressions(receiverExpr);
+  return (
+    ts.isNewExpression(n) &&
+    ts.isIdentifier(skipTransparentExpressions(n.expression)) &&
+    (skipTransparentExpressions(n.expression) as ts.Identifier).text === "Array" &&
+    (n.arguments?.length ?? 0) === 0
+  );
 }
 
 export function sourceOverridesBuiltinPrototypeMember(anchor: ts.Node, ctorName: string, memberName: string): boolean {
@@ -226,7 +250,8 @@ function emitProtoOverrideApply(
  *
  * Returns the branch's ValType, or `undefined` to leave the caller on its
  * ordinary single path — which is what happens for every module that does not
- * override, for a non-identifier receiver, and whenever an arm declines.
+ * override, for a receiver whose evaluation is not safe to repeat, and
+ * whenever an arm declines.
  */
 export function tryEmitProtoOverrideTwoArm(
   ctx: CodegenContext,
@@ -246,7 +271,7 @@ export function tryEmitProtoOverrideTwoArm(
   // unwrap, which is what keeps the else arm's re-compile of the receiver
   // side-effect-free.
   const receiverExpr = skipTransparentExpressions(propAccess.expression);
-  if (!ts.isIdentifier(receiverExpr)) return undefined;
+  if (!ts.isIdentifier(receiverExpr) && !isSideEffectFreeInlineArrayReceiver(receiverExpr, ctorName)) return undefined;
   if (callExpr.arguments.some((a) => ts.isSpreadElement(a))) return undefined;
   if (!sourceOverridesBuiltinPrototypeMember(callExpr, ctorName, memberName)) return undefined;
 

--- a/tests/issue-4556-builtin-proto-member-override.test.ts
+++ b/tests/issue-4556-builtin-proto-member-override.test.ts
@@ -30,9 +30,11 @@
 // receiver picks up the override today) and ignores it for one that has an arm
 // (`toString` does not). Fixing that is the consult-order inversion inside the
 // dynamic reader, a strictly larger change than this call-site branch.
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
 
 // STANDALONE ONLY. The two-arm is gated on `ctx.standalone` — in host mode the
 // override already works through the JS engine's own prototype chain, and the
@@ -65,6 +67,28 @@ describe.each(LANES)("#4556 — Array.prototype member override (%s)", (lane) =>
         lane,
       ),
     ).toBe(1);
+  });
+
+  it("String(new Array) uses an overridden Array.prototype.toString", async () => {
+    expect(
+      await run(
+        `(Array.prototype as any).toString = function (): any { return "__ARRAY__"; };
+         export function test(): number {
+           return String(new Array) === "__ARRAY__" ? 1 : 0;
+         }`,
+        lane,
+      ),
+    ).toBe(1);
+  });
+
+  it("the assembled Test262 row S15.5.1.1_A1_T8 passes in standalone", async () => {
+    const result = await runTest262File(
+      resolve("test262/test/built-ins/String/S15.5.1.1_A1_T8.js"),
+      "built-ins/String",
+      120_000,
+      "standalone",
+    );
+    expect(result.status, result.error ?? result.reason).toBe("pass");
   });
 
   it("an overridden join is used, and receives the arguments", async () => {


### PR DESCRIPTION
## Summary\n\n- Allow the standalone builtin-prototype override arm to handle the zero-argument `new Array` receiver synthesized by `String(new Array)`.\n- Keep side-effecting inline expressions on the existing single-evaluation path.\n- Add focused #4556 controls plus the assembled Test262 pin for `built-ins/String/S15.5.1.1_A1_T8.js`.\n\n## Evidence\n\n- Upstream baseline `9bed3802f`: the focused standalone Test262 row was `fail` (controls: must-pass `pass`, must-fail `fail`).\n- Rebasing onto current upstream `c4c831aa1` produced `abef934d6`; the row is `pass` and the #4556 focused suite is 6/6.\n- TypeScript 7 and TypeScript 5 typechecks pass.\n- Normal pre-commit and pre-push hooks pass, including lint, format, budget, oracle/coercion ratchets, numeric-local parity, and issue integrity.\n\nAll validation ran without `--no-verify`.