### PR TITLE
fix(array): preserve accessor-backed values through filter

### DIFF
--- a/src/codegen/array-filter-length-set.ts
+++ b/src/codegen/array-filter-length-set.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Standalone ArraySetLength routing for typed `Array.prototype.filter` inputs.
+ *
+ * A descriptor-aware array keeps its indexed attributes in the vec overlay.
+ * Static `.length` assignment must therefore use the same native
+ * `__vec_dp_value` path as `Object.defineProperty`, including its
+ * non-configurable-index stop and strict/sloppy TypeError behavior.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { BUILTIN_TYPE_TAGS } from "./builtin-tags.js";
+import { ensureExnTag } from "./registry/imports.js";
+import { getOrRegisterErrorStructType } from "./registry/error-types.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { buildTargetTaggedTry } from "../ir/try-table.js";
+import { allocLocal } from "./context/locals.js";
+import { isStrictContext } from "./helpers/is-strict-function.js";
+import type { ts } from "../ts-api.js";
+
+/**
+ * Build the descriptor-overlay `.length` store, or return `null` when the
+ * module cannot use the overlay route. The caller owns the receiver null guard
+ * because prototype-shaped receivers must retain their existing no-op path.
+ */
+export function buildOverlayArrayLengthSet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  vecTmp: number,
+  newLenTmp: number,
+  strictTarget: ts.Node,
+): Instr[] | null {
+  if (!ctx.standalone || !ctx.vecAccessorDescriptorDirty) return null;
+  const dpValueIdx = ctx.funcMap.get("__vec_dp_value");
+  const boxNumberIdx = ctx.funcMap.get("__box_number");
+  if (dpValueIdx === undefined || boxNumberIdx === undefined) return null;
+
+  const call: Instr[] = [
+    { op: "local.get", index: vecTmp },
+    { op: "extern.convert_any" },
+    ...stringConstantExternrefInstrs(ctx, "length"),
+    { op: "local.get", index: newLenTmp },
+    { op: "f64.convert_i32_u" },
+    { op: "call", funcIdx: boxNumberIdx },
+    { op: "f64.const", value: 1 << 7 }, // HOST_HAS_VALUE
+    { op: "call", funcIdx: dpValueIdx },
+    { op: "drop" },
+  ];
+
+  const errorLocal = allocLocal(fctx, `__arr_len_set_err_${fctx.locals.length}`, { kind: "externref" });
+  const exnTag = ensureExnTag(ctx);
+  const rethrow: Instr[] = [
+    { op: "local.get", index: errorLocal },
+    { op: "throw", tagIdx: exnTag },
+  ];
+  const handler: Instr[] = [{ op: "local.set", index: errorLocal }];
+  const strict = isStrictContext(strictTarget, ctx.inferModuleStrictArguments);
+  if (strict) {
+    handler.push(...rethrow);
+  } else {
+    const errorTypeIdx = getOrRegisterErrorStructType(ctx);
+    handler.push(
+      { op: "local.get", index: errorLocal },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: errorTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: errorLocal },
+          { op: "any.convert_extern" },
+          { op: "ref.cast", typeIdx: errorTypeIdx },
+          { op: "struct.get", typeIdx: errorTypeIdx, fieldIdx: 0 },
+          { op: "i32.const", value: BUILTIN_TYPE_TAGS.TypeError },
+          { op: "i32.eq" },
+          { op: "if", blockType: { kind: "empty" }, then: [], else: rethrow },
+        ],
+        else: rethrow,
+      },
+    );
+  }
+  return [buildTargetTaggedTry(ctx, { kind: "empty" }, call, [{ tagIdx: exnTag, body: handler }])];
+}

--- a/src/codegen/array-filter-spec-access.ts
+++ b/src/codegen/array-filter-spec-access.ts
@@ -39,8 +39,9 @@
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { allocLocal } from "./context/locals.js";
-import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+import { ensureLateImport, flushLateImportShifts, isAnyValue } from "./shared.js";
 import { overlayRouteActive } from "./typed-lane-overlay-route.js";
+import { ensureAnyFromExternHelper } from "./any-helpers.js";
 
 /** The subset of the HOF loop locals these builders need. */
 export interface FilterLoopView {
@@ -100,13 +101,14 @@ export function overlayFilterAccess(
   elemLocal: number,
 ): OverlayFilterAccess | null {
   if (!overlayRouteActive(ctx)) return null;
-  if (elemType.kind !== "f64" && elemType.kind !== "externref") return null;
+  const anyValueElem = isAnyValue(elemType, ctx);
+  if (elemType.kind !== "f64" && elemType.kind !== "externref" && !anyValueElem) return null;
   // (#2001) A module with array-literal elisions keeps the `$Hole` dense route:
   // `__extern_has_idx`'s vec arm answers on `i < length` alone, so it would
   // report a `$Hole` slot as PRESENT and leak the sentinel through
   // `__extern_get_idx`. Holes and accessor descriptors together are rare; the
   // dense route is the conservative answer for that intersection.
-  if (ctx.usesArrayHoles && elemType.kind === "externref") return null;
+  if (ctx.usesArrayHoles && (elemType.kind === "externref" || anyValueElem)) return null;
 
   const hasIdxFn = ensureLateImport(
     ctx,
@@ -122,8 +124,17 @@ export function overlayFilterAccess(
   );
   const unboxFn =
     elemType.kind === "f64" ? ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]) : 0;
+  let anyFromExternFn: number | undefined;
+  if (anyValueElem) {
+    // The vec carrier itself stores boxed AnyValue structs. The externref
+    // chokepoint unwraps those back to the canonical box (and classifies
+    // accessor results such as primitive numbers) rather than wrapping the
+    // carrier externref as a new tag-5 value.
+    anyFromExternFn = ensureAnyFromExternHelper(ctx);
+  }
   flushLateImportShifts(ctx, fctx);
   if (hasIdxFn === undefined || getIdxFn === undefined || unboxFn === undefined) return null;
+  if (anyValueElem && anyFromExternFn === undefined) return null;
 
   const recvLocal = allocLocal(fctx, `__arr_flt_ovr_${fctx.locals.length}`, { kind: "externref" });
   fctx.body.push({ op: "local.get", index: loop.vecTmp });
@@ -141,6 +152,7 @@ export function overlayFilterAccess(
       ...idxArg,
       { op: "call", funcIdx: getIdxFn },
       ...(elemType.kind === "f64" ? ([{ op: "call", funcIdx: unboxFn }] satisfies Instr[]) : []),
+      ...(anyValueElem ? ([{ op: "call", funcIdx: anyFromExternFn! }] satisfies Instr[]) : []),
       { op: "local.set", index: elemLocal },
     ],
   };

--- a/src/codegen/array-holes.ts
+++ b/src/codegen/array-holes.ts
@@ -44,6 +44,7 @@ import { allocTempLocal } from "./context/locals.js";
 import { emitUndefined } from "./expressions/late-imports.js";
 import { isBrandedBuiltinName } from "./builtin-brands.js"; // (#4176) named proto-write pre-scan
 import { planHoleyArrayCarrier } from "./holey-array-plan.js"; // (#4222) isolated sparse-carrier proof
+import { recordDescriptorArrayReceiver } from "./declarations/descriptor-array-carrier.js"; // (#4670)
 
 /**
  * Cheap AST pre-scan: set `ctx.usesArrayHoles` when the program contains any
@@ -101,6 +102,10 @@ export function scanForArrayHoles(ctx: CodegenContext, root: ts.Node): void {
     }
     if (!ctx.vecAccessorDescriptorDirty && isNonDataDescriptorDefine(node)) {
       ctx.vecAccessorDescriptorDirty = true;
+    }
+    const descriptorArrayReceiver = indexedDescriptorArrayReceiver(node);
+    if (descriptorArrayReceiver !== undefined) {
+      recordDescriptorArrayReceiver(ctx, descriptorArrayReceiver);
     }
     if (!ctx.inheritedSetDescriptorDirty) {
       // (#4602) Statically-named triggers poison only their own keys; a
@@ -285,6 +290,27 @@ function isNonDataDescriptorDefine(node: ts.Node): boolean {
     return node.arguments.length >= 2 && !isDataOnlyDescriptorBag(node.arguments[1]);
   }
   return false;
+}
+
+/**
+ * (#4670) Return a direct identifier receiver for a non-data descriptor on a
+ * canonical array-index key. This is intentionally narrower than the module
+ * dirty flag: only these writes need an identity-preserving array carrier.
+ */
+function indexedDescriptorArrayReceiver(node: ts.Node): string | undefined {
+  if (!isNonDataDescriptorDefine(node) || !ts.isCallExpression(node)) return undefined;
+  const callee = node.expression;
+  if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== "defineProperty") return undefined;
+  const key = literalPropertyKeyOf(node.arguments[1]);
+  if (!isCanonicalArrayIndexKey(key)) return undefined;
+  const receiver = unwrapExpr(node.arguments[0]);
+  return ts.isIdentifier(receiver) ? receiver.text : undefined;
+}
+
+function isCanonicalArrayIndexKey(key: string | undefined): boolean {
+  if (key === undefined) return false;
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < 0xffffffff && String(index) === key;
 }
 
 /**

--- a/src/codegen/declarations/array-rebind-element-widening.ts
+++ b/src/codegen/declarations/array-rebind-element-widening.ts
@@ -53,6 +53,7 @@ import type { ValType } from "../../ir/types.js";
 import { ts } from "../../ts-api.js";
 import type { CodegenContext } from "../context/types.js";
 import { getOrRegisterVecType } from "../registry/types.js";
+import { descriptorArrayCarrierType } from "./descriptor-array-carrier.js";
 
 /** Per-(context, file) memo — `moduleGlobalWasmType` asks once per declaration. */
 const analysisCache = new WeakMap<CodegenContext, Map<ts.SourceFile, ReadonlySet<string>>>();
@@ -73,6 +74,8 @@ export function rebindWidenedArrayVecType(
   decl: ts.VariableDeclaration,
 ): ValType | undefined {
   if (!ts.isIdentifier(decl.name)) return undefined;
+  const descriptorCarrier = descriptorArrayCarrierType(ctx, decl);
+  if (descriptorCarrier !== undefined) return descriptorCarrier;
   if (!widenedVarsOf(ctx, sourceFile).has(decl.name.text)) return undefined;
   return { kind: "ref_null", typeIdx: getOrRegisterVecType(ctx, "externref", { kind: "externref" }) };
 }

--- a/src/codegen/declarations/descriptor-array-carrier.ts
+++ b/src/codegen/declarations/descriptor-array-carrier.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4670) Keep arrays with indexed accessor descriptors on the identity-safe
+ * externref vec carrier. A typed f64/AnyValue slot cannot preserve a getter's
+ * heterogeneous result through Array.prototype.filter.
+ */
+import type { ValType } from "../../ir/types.js";
+import { ts } from "../../ts-api.js";
+import type { CodegenContext } from "../context/types.js";
+import { getOrRegisterVecType } from "../registry/types.js";
+
+const descriptorArrayReceivers = new WeakMap<CodegenContext, Set<string>>();
+
+export function recordDescriptorArrayReceiver(ctx: CodegenContext, name: string): void {
+  let names = descriptorArrayReceivers.get(ctx);
+  if (names === undefined) {
+    names = new Set();
+    descriptorArrayReceivers.set(ctx, names);
+  }
+  names.add(name);
+}
+
+export function descriptorArrayCarrierType(ctx: CodegenContext, decl: ts.VariableDeclaration): ValType | undefined {
+  if (!ctx.standalone || !ctx.vecAccessorDescriptorDirty || !ts.isIdentifier(decl.name)) return undefined;
+  const receivers = descriptorArrayReceivers.get(ctx);
+  if (receivers === undefined) return undefined;
+  const name = decl.name.text;
+  if (receivers.has(name) && isArrayLiteralInitializer(decl.initializer)) {
+    return externrefVecType(ctx);
+  }
+  const receiver = filterReceiverIdentifier(decl.initializer);
+  return receiver !== undefined && receivers.has(receiver) ? externrefVecType(ctx) : undefined;
+}
+
+function externrefVecType(ctx: CodegenContext): ValType {
+  return { kind: "ref_null", typeIdx: getOrRegisterVecType(ctx, "externref", { kind: "externref" }) };
+}
+
+function isArrayLiteralInitializer(initializer: ts.Expression | undefined): boolean {
+  let current = initializer;
+  while (current && ts.isParenthesizedExpression(current)) current = current.expression;
+  return current !== undefined && ts.isArrayLiteralExpression(current);
+}
+
+function filterReceiverIdentifier(initializer: ts.Expression | undefined): string | undefined {
+  let current = initializer;
+  while (current && ts.isParenthesizedExpression(current)) current = current.expression;
+  if (!current || !ts.isCallExpression(current)) return undefined;
+  const callee = current.expression;
+  if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== "filter") return undefined;
+  let receiver: ts.Node = callee.expression;
+  while (ts.isParenthesizedExpression(receiver)) receiver = receiver.expression;
+  return ts.isIdentifier(receiver) ? receiver.text : undefined;
+}

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -127,6 +127,7 @@ import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { emitNativeGlobalThisObject } from "../array-object-proto.js"; // (#4630)
 import { resolveEffectiveStructName } from "../property-access.js";
 import { emitOverlayRoutedElementSet, overlayRouteActive } from "../typed-lane-overlay-route.js"; // (#4159 S5)
+import { buildOverlayArrayLengthSet } from "../array-filter-length-set.js";
 import {
   elementAccessTypedArrayName,
   emitNonIndexVecElementSet,
@@ -4238,15 +4239,14 @@ function compilePropertyAssignment(
         { op: "local.get", index: newLenTmp },
         { op: "struct.set", typeIdx: vecBaseIdx, fieldIdx: 0 },
       ];
+      const selectedStore = buildOverlayArrayLengthSet(ctx, fctx, vecTmp, newLenTmp, target) ?? lengthStore;
       if (receiverProvenVec) {
-        // Byte-identical to pre-#4638 for a statically proven vec receiver.
-        for (const instr of lengthStore) fctx.body.push(instr);
+        for (const instr of selectedStore) fctx.body.push(instr);
       } else {
         // The guarded cast above parks `null` when the receiver was not a vec;
-        // `struct.set` on null is the same uncatchable trap, so skip the store.
         fctx.body.push({ op: "local.get", index: vecTmp });
         fctx.body.push({ op: "ref.is_null" });
-        fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: [], else: lengthStore });
+        fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: [], else: selectedStore });
       }
       // Assignment result — UNSIGNED widening (#4491, see array-length-define.ts).
       fctx.body.push({ op: "local.get", index: newLenTmp });

--- a/src/codegen/vec-overlay-carriers.ts
+++ b/src/codegen/vec-overlay-carriers.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** The concrete JS-array element carriers served by the descriptor overlay. */
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { getArrTypeIdxFromVec } from "./registry/types.js";
+
+export interface OverlayCarrier {
+  vecTypeIdx: number;
+  arrTypeIdx: number;
+  elemType: ValType;
+  kind: "f64" | "externref" | "any" | "anystr";
+}
+
+export function allowedCarriers(ctx: CodegenContext): OverlayCarrier[] {
+  const seen = new Set<number>();
+  const out: OverlayCarrier[] = [];
+  const addCarrier = (vecTypeIdx: number): void => {
+    if (seen.has(vecTypeIdx)) return;
+    seen.add(vecTypeIdx);
+    const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+    if (arrTypeIdx < 0) return;
+    const arrDef = ctx.mod.types[arrTypeIdx];
+    if (!arrDef || arrDef.kind !== "array") return;
+    const elemType = arrDef.element as ValType;
+    if (elemType.kind === "f64") {
+      out.push({ vecTypeIdx, arrTypeIdx, elemType, kind: "f64" });
+    } else if (elemType.kind === "externref") {
+      out.push({ vecTypeIdx, arrTypeIdx, elemType, kind: "externref" });
+    } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
+      const ti = (elemType as { typeIdx: number }).typeIdx;
+      if (ti === ctx.anyValueTypeIdx) {
+        out.push({ vecTypeIdx, arrTypeIdx, elemType, kind: "any" });
+      } else if (ti >= 0 && (ti === ctx.anyStrTypeIdx || ti === ctx.nativeStrTypeIdx)) {
+        out.push({ vecTypeIdx, arrTypeIdx, elemType, kind: "anystr" });
+      }
+    }
+  };
+  for (const vecTypeIdx of ctx.vecTypeMap.values()) addCarrier(vecTypeIdx);
+  const objVec = ctx.objectRuntimeTypes;
+  if (objVec) addCarrier(objVec.objVecTypeIdx);
+  const regexpMatchVecTypeIdx = ctx.structMap.get("__regexp_match_vec");
+  if (regexpMatchVecTypeIdx !== undefined) addCarrier(regexpMatchVecTypeIdx);
+  out.sort((a, b) => a.vecTypeIdx - b.vecTypeIdx);
+  return out;
+}
+
+export function carrierDefaultInstrs(
+  ctx: CodegenContext,
+  carrier: OverlayCarrier,
+  externAsUndefined: boolean,
+  missExtern: () => Instr[],
+): Instr[] {
+  if (carrier.kind === "f64") return [{ op: "f64.const", value: 0 }];
+  if (carrier.kind === "externref") return externAsUndefined ? missExtern() : [{ op: "ref.null.extern" }];
+  return carrier.kind === "any"
+    ? [{ op: "ref.null", typeIdx: ctx.anyValueTypeIdx }]
+    : [{ op: "ref.null", typeIdx: -15 }];
+}
+
+export function carrierRefWriteBack(
+  carrier: OverlayCarrier,
+  castVecAndIdx: Instr[],
+  wrote: Instr[],
+  elemSetIdx: number,
+  anyStrTypeIdx: number,
+): Instr[] {
+  if (carrier.kind === "any") return [];
+  if (carrier.kind !== "anystr") return [];
+  return [
+    { op: "local.get", index: 12 },
+    { op: "ref.test", typeIdx: anyStrTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...castVecAndIdx,
+        { op: "local.get", index: 12 },
+        { op: "ref.cast", typeIdx: anyStrTypeIdx },
+        { op: "call", funcIdx: elemSetIdx },
+        ...wrote,
+      ],
+    },
+  ];
+}

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -78,7 +78,7 @@ import { inheritedSetAnyDirty } from "./inherited-set-gate.js"; // (#4602) per-k
 import type { Instr, ValType, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
-import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecBaseType } from "./registry/types.js";
+import { addFuncType, getOrRegisterVecBaseType } from "./registry/types.js";
 import { ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { reserveAccessorGetDriver } from "./accessor-driver.js";
@@ -107,6 +107,12 @@ import {
   buildArgumentsLengthDeletedBail,
   fillArgumentsLengthBrand,
 } from "./arguments-length-brand.js"; // (#4658)
+import {
+  allowedCarriers,
+  carrierDefaultInstrs,
+  carrierRefWriteBack,
+  type OverlayCarrier,
+} from "./vec-overlay-carriers.js";
 
 /**
  * `$PropEntry.$flags` bit claimed by the overlay (see the flag table in
@@ -215,58 +221,6 @@ export function reserveVecOverlayHelpers(ctx: CodegenContext): VecOverlayReserve
   // driver — reserve it now (idempotent) so its funcIdx is stable.
   reserveAccessorGetDriver(ctx);
   return { dpValueIdx, dpAccessorIdx, gopdIdx };
-}
-
-/** JS-array element carriers the overlay serves (TypedArray storage + subviews
- *  keep the legacy no-op — integer-indexed-exotic semantics are out of scope). */
-interface OverlayCarrier {
-  vecTypeIdx: number;
-  arrTypeIdx: number;
-  elemType: ValType;
-  kind: "f64" | "externref" | "anystr";
-}
-
-function allowedCarriers(ctx: CodegenContext): OverlayCarrier[] {
-  const seen = new Set<number>();
-  const out: OverlayCarrier[] = [];
-  const addCarrier = (vecTypeIdx: number): void => {
-    if (seen.has(vecTypeIdx)) return;
-    seen.add(vecTypeIdx);
-    const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
-    if (arrTypeIdx < 0) return;
-    const arrDef = ctx.mod.types[arrTypeIdx];
-    if (!arrDef || arrDef.kind !== "array") return;
-    const elemType = arrDef.element as ValType;
-    if (elemType.kind === "f64") {
-      out.push({ vecTypeIdx, arrTypeIdx, elemType, kind: "f64" });
-    } else if (elemType.kind === "externref") {
-      out.push({ vecTypeIdx, arrTypeIdx, elemType, kind: "externref" });
-    } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
-      const ti = (elemType as { typeIdx: number }).typeIdx;
-      if (ti >= 0 && (ti === ctx.anyStrTypeIdx || ti === ctx.nativeStrTypeIdx)) {
-        out.push({ vecTypeIdx, arrTypeIdx, elemType, kind: "anystr" });
-      }
-    }
-  };
-  for (const vecTypeIdx of ctx.vecTypeMap.values()) {
-    addCarrier(vecTypeIdx);
-  }
-  // `$ObjVec` is the growable externref-array carrier used by Object
-  // enumeration and RegExp `d`-flag indices. It deliberately lives outside
-  // `vecTypeMap`, but is still a genuine Array and therefore participates in
-  // the same dense-index and named-property descriptor overlay.
-  const objVec = ctx.objectRuntimeTypes;
-  if (objVec) addCarrier(objVec.objVecTypeIdx);
-  // RegExp exec results are an extended native-string vec subtype rather than
-  // a direct `vecTypeMap` entry. Include that exact exotic so its spec own
-  // properties (`index`, `input`, `groups`, `indices`) can be materialised in
-  // the overlay without broadening the carrier whitelist to arbitrary structs.
-  const regexpMatchVecTypeIdx = ctx.structMap.get("__regexp_match_vec");
-  if (regexpMatchVecTypeIdx !== undefined) {
-    addCarrier(regexpMatchVecTypeIdx);
-  }
-  out.sort((a, b) => a.vecTypeIdx - b.vecTypeIdx);
-  return out;
 }
 
 /** Overlay-core state minted by the fill (types, global, lookup/ensure). */
@@ -939,19 +893,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
     for (const c of carriers) {
       const elemSetIdx = ensureVecElemSet(ctx, c.vecTypeIdx);
       if (elemSetIdx === null) continue;
-      const defaultVal: Instr[] =
-        c.kind === "f64"
-          ? [{ op: "f64.const", value: 0 }]
-          : c.kind === "externref"
-            ? // (#4491) A DATA define with no [[Value]] gives the property
-              // `undefined` (CompletePropertyDescriptor), not the carrier's
-              // null hole — `arr[0]` must read `undefined`. Opt-in, so the
-              // accessor arm (whose slot is dead, the getter answers) and the
-              // ArraySetLength growth keep the null default.
-              externAsUndefined
-              ? missExtern()
-              : [{ op: "ref.null.extern" }]
-            : [{ op: "ref.null", typeIdx: NONE_HEAP }];
+      const defaultVal = carrierDefaultInstrs(ctx, c, externAsUndefined, missExtern);
       arms.push(
         { op: "local.get", index: anyLocal },
         { op: "ref.test", typeIdx: c.vecTypeIdx },
@@ -1472,22 +1414,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
           }
           inner = arms;
         } else {
-          // anystr carrier: value must be an $AnyString.
-          inner = [
-            { op: "local.get", index: 12 },
-            { op: "ref.test", typeIdx: anyStrTypeIdx },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [
-                ...castVecAndIdx,
-                { op: "local.get", index: 12 },
-                { op: "ref.cast", typeIdx: anyStrTypeIdx },
-                { op: "call", funcIdx: elemSetIdx },
-                ...wrote,
-              ],
-            },
-          ];
+          inner = carrierRefWriteBack(c, castVecAndIdx, wrote, elemSetIdx, anyStrTypeIdx);
         }
         writeBackArms.push(
           { op: "local.get", index: 4 },

--- a/tests/es5-standalone-array-filter.test.ts
+++ b/tests/es5-standalone-array-filter.test.ts
@@ -101,6 +101,49 @@ describe("§15.4.4.20 filter — HasProperty is re-evaluated per index", () => {
 });
 
 describe("§15.4.4.20 filter — accessor indices installed by defineProperty", () => {
+  it("keeps the captured result length after an accessor shrinks a heterogeneous array", async () => {
+    // The accessor fires while filter is visiting index 0. The captured len is
+    // four, but ArraySetLength leaves indices 0..2 present, so only three
+    // values may be copied into the result.
+    expect(
+      await run(
+        `const arr = [0, 1, 2, "last"];
+        Object.defineProperty(arr, "0", { get: function (): number { arr.length = 3; return 0; }, configurable: true });
+        export function test(): number {
+          return arr.filter(function (): boolean { return true; }).length;
+        }`,
+        "standalone",
+      ),
+    ).toBe(3);
+  });
+
+  it("does not truncate a non-configurable accessor during filter", async () => {
+    // The getter at index 1 requests a shrink to two, but index 2 is
+    // non-configurable. ArraySetLength must stop at three and filter must keep
+    // the captured index 2 in its result.
+    expect(
+      await run(
+        `const arr = [0, 1, 2];
+        Object.defineProperty(arr, "2", { get: function (): string { return "unconfigurable"; }, configurable: false });
+        Object.defineProperty(arr, "1", {
+          get: function (): number {
+            // The test source is an ES module, so catch strict-mode's
+            // TypeError here; the noStrict Test262 variant suppresses it.
+            try {
+              arr.length = 2;
+            } catch (_) {}
+            return 1;
+          },
+          configurable: true,
+        });
+        export function test(): number {
+          return arr.filter(function (): boolean { return true; }).length;
+        }`,
+        "standalone",
+      ),
+    ).toBe(3);
+  });
+
   it("invokes an own accessor over an existing element (standalone overlay route)", async () => {
     expect(
       await run(

--- a/tests/es5-standalone-array-filter.test.ts
+++ b/tests/es5-standalone-array-filter.test.ts
@@ -28,8 +28,13 @@
 // read is gated on the #4159 `vecAccessorDescriptorDirty` pre-scan flag, so a
 // module that never installs a non-data descriptor keeps the dense kernel.
 import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { compile } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262 = existsSync(join(__dirname, "..", "test262", "harness", "assert.js"));
 
 async function run(src: string, target: "standalone" | "gc"): Promise<unknown> {
   const opts = target === "standalone" ? { target: "standalone" as const } : {};
@@ -198,4 +203,18 @@ describe("§15.4.4.20 filter — accessor indices installed by defineProperty", 
       ),
     ).toBe(22);
   });
+});
+
+describe("§15.4.4.20 filter — exact ES5 descriptor rows", () => {
+  for (const file of ["15.4.4.20-9-b-14.js", "15.4.4.20-9-b-16.js"] as const) {
+    it.skipIf(!TEST262)(`${file} passes in full through the Test262 runner`, { timeout: 60_000 }, async () => {
+      const result = await runTest262File(
+        join(__dirname, "..", "test262", "test", "built-ins/Array/prototype/filter", file),
+        "array-filter-exact-rows",
+        30_000,
+        "standalone",
+      );
+      expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Preserve ES5 Array.prototype.filter behavior when indexed properties are accessor-backed and the source length changes during iteration. Keep descriptor-backed receivers and filter results on the externref vec carrier so getter values retain identity while length snapshots remain spec-correct.

## Test262 impact

Fresh-upstream baseline fail -> branch pass for two exact ES5 rows:

- built-ins/Array/prototype/filter/15.4.4.20-9-b-14.js
- built-ins/Array/prototype/filter/15.4.4.20-9-b-16.js

## Verification

- Exact rows: 2/2 pass
- Permanent filter suite: 11/11
- TypeScript 5 and 7 typechecks pass
- Normal pre-commit and full pre-push hooks pass, including lint/format, budgets, oracle/coercion ratchets, #3765 parity 18/18, and issue integrity
- No verification bypasses

Commits: 37c3fe6e4, a08738ab7.