### PR TITLE
fix(promise): validate custom capabilities for empty combinators

### DIFF
--- a/plan/issues/4682-standalone-promise-custom-constructor-capability.md
+++ b/plan/issues/4682-standalone-promise-custom-constructor-capability.md
@@ -1,0 +1,66 @@
+---
+title: "standalone: Promise combinator custom-constructor capability executor"
+status: done
+priority: P1
+assignee: codex/es6-promise-capability-wave4
+issue: 4682
+completed: 2026-08-25
+loc-budget-allow:
+  - src/codegen/promise-combinators.ts
+  - src/codegen/expressions/call-namespace-static.ts
+func-budget-allow:
+  - src/codegen/expressions/call-namespace-static.ts::compileNamespaceStaticCall
+---
+
+# Scope
+
+Bounded ES2015 standalone Promise follow-up after #4872: reproduce and fix one
+custom-constructor/NewPromiseCapability failure in the Promise combinator
+surface. The `.call(Promise, iterable)` routing landed in #4872 is excluded,
+as are async/generator drive failures and the broader inbound callback/value
+marshalling lane tracked by #2623.
+
+## Cohort / plan
+
+Bounded cohort: `test262/test/built-ins/Promise/all/capability-executor-not-callable.js`
+(six synchronous subcases). Each subcase passes an ordinary compiled function
+as the `.call` receiver with an empty iterable; the constructor either omits
+the capability executor call or supplies at least one non-callable slot. The
+homologous `allSettled`/`race`/`any` files and
+`capability-executor-called-twice.js` remain explicit follow-up residuals.
+The `.call(Promise, iterable)` route, non-empty custom iterables, and
+class/subclass receivers remain out of scope. Keep the implementation to one
+constructor/capability protocol arm and preserve the gc/host lane.
+
+Plan:
+
+1. Capture a fresh upstream-main baseline for the bounded six-subcase row and
+   identify the first failing operation.
+2. Implement the narrowest host-free standalone fix that addresses that
+   operation without changing generic custom constructors or async drive.
+3. Add focused equivalence coverage for the six subcases plus before/after
+   zero-loss and required typecheck/format gates.
+
+## Test Results
+
+Baseline (fresh upstream/main `56afab8c3`, wasm SHA `af476666ab72`):
+`Promise/all/capability-executor-not-callable.js` failed with
+`TypeError: Promise resolve or reject function is not callable`.
+
+After (#4682 branch, wasm SHA `53efe413775a`): the same exact Test262 row
+passes (authoritative standalone runner evidence).
+
+Focused checks:
+
+- `tests/issue-4682.test.ts`: 3/3 passed; all six capability-executor
+  subcases return the expected post-constructor checkpoint (`71`) with zero
+  imports, and both non-empty standalone and gc/host fallback controls retain
+  `env.Promise_all`.
+- `prettier --check` on all changed TS files: passed.
+- Biome lint on all changed TS files: passed.
+- TypeScript 7 project typecheck: passed.
+- TypeScript 5 changed-file filter: no diagnostics in changed files.
+
+Explicit residual: `capability-executor-called-twice.js` remains outside this
+bounded row and is not claimed by #4682; the homologous allSettled/race/any
+rows and non-empty custom-constructor protocol remain follow-up work.

--- a/src/codegen/expressions/call-namespace-static.ts
+++ b/src/codegen/expressions/call-namespace-static.ts
@@ -30,7 +30,7 @@ import {
   isStandalonePromiseActive,
 } from "../async-scheduler.js";
 import { classMemberFuncKey } from "../class-member-keys.js";
-import { compileArrowAsClosure } from "../closures.js";
+import { compileArrowAsClosure, getClosureFuncSelfTypeIdx } from "../closures.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import { rollbackSpeculative, snapshotSpeculative } from "../context/speculative.js";
@@ -66,6 +66,7 @@ import { emitDefinePropertyDescRuntime, emitNonObjectArgGuard } from "../object-
 import { ensureObjectRuntime, ensureObjVecBuilders } from "../object-runtime.js";
 import {
   emitStandalonePromiseCombinator,
+  emitStandalonePromiseCustomCapabilityCheck,
   emitStandalonePromiseCombinatorRuntime,
   isNativeCombinatorMethod,
   resolveExternrefVecArg,
@@ -1980,6 +1981,63 @@ export function compileNamespaceStaticCall(
     // the earlier direct-call site (`Promise.resolve(v)` /
     // `Promise.reject(r)` without `.call`) and does not apply here.
     const methodName = propAccess.expression.name.text;
+
+    // (#4682) Bounded NewPromiseCapability arm: an ordinary compiled
+    // constructor plus an empty array.  The existing native aggregate path
+    // intentionally models the intrinsic Promise only; custom receivers
+    // otherwise fall through to `Promise_METHOD`, which is unsatisfiable in a
+    // standalone module.  Keep this admission narrow while the full
+    // per-element `C.resolve`/species protocol remains in its own follow-up:
+    // the selected capability-executor cohort observes only construction,
+    // executor capture, and post-construction callable validation.
+    if (
+      isStandalonePromiseActive(ctx) &&
+      expr.arguments.length === 2 &&
+      ts.isIdentifier(expr.arguments[0]) &&
+      expr.arguments[0].text !== "Promise" &&
+      ts.isArrayLiteralExpression(expr.arguments[1]) &&
+      expr.arguments[1].elements.length === 0
+    ) {
+      const ctorDecl = ctx.oracle.valueDeclarationOf(expr.arguments[0]);
+      const isOrdinaryCtorDecl =
+        ctorDecl !== undefined &&
+        ts.isFunctionDeclaration(ctorDecl) &&
+        ctorDecl.asteriskToken === undefined &&
+        !(ctorDecl.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false);
+      if (isOrdinaryCtorDecl) {
+        const snap = snapshotSpeculative(ctx, fctx);
+        // Preserve the nominal closure ref here.  Asking for externref would
+        // erase the wrapper type before the capability probe can recover the
+        // constructor's lifted signature from closureInfoByTypeIdx.
+        const ctorType = compileExpression(ctx, fctx, expr.arguments[0]!);
+        const ctorInfo =
+          ctorType && (ctorType.kind === "ref" || ctorType.kind === "ref_null")
+            ? ctx.closureInfoByTypeIdx.get(ctorType.typeIdx)
+            : ctx.closureMap.get(expr.arguments[0].text);
+        const supportsCapabilityCtor =
+          ctorInfo !== undefined && ctorInfo.paramTypes.length === 1 && ctorInfo.paramTypes[0]?.kind === "externref";
+        const ctorSelfTypeIdx =
+          ctorInfo && (getClosureFuncSelfTypeIdx(ctx, ctorInfo.funcTypeIdx) ?? ctorInfo.structTypeIdx);
+        if (
+          ctorType &&
+          ctorInfo &&
+          supportsCapabilityCtor &&
+          ctorSelfTypeIdx !== undefined &&
+          (ctorType.kind === "ref" || ctorType.kind === "ref_null" || ctorType.kind === "externref")
+        ) {
+          const ctorLocal = allocLocal(fctx, `__promise_custom_ctor_${fctx.locals.length}`, {
+            kind: "ref_null",
+            typeIdx: ctorSelfTypeIdx,
+          });
+          coerceType(ctx, fctx, ctorType, { kind: "ref_null", typeIdx: ctorSelfTypeIdx });
+          fctx.body.push({ op: "local.set", index: ctorLocal });
+          if (emitStandalonePromiseCustomCapabilityCheck(ctx, fctx, ctorLocal, ctorInfo, ctorSelfTypeIdx)) {
+            return emitStandalonePromiseCombinator(ctx, fctx, methodName, []);
+          }
+        }
+        rollbackSpeculative(ctx, fctx, snap);
+      }
+    }
 
     // (#2867 wave-2 / #3390 slice 2) `Promise.METHOD.call(Promise, iter)` is
     // semantically the direct global-Promise form.  Keep it on the native

--- a/src/codegen/promise-combinators.ts
+++ b/src/codegen/promise-combinators.ts
@@ -50,7 +50,7 @@
 // (#2867 string-combinator slice): `__combinator_to_vec` now has a native
 // code-point string arm (see `buildToVecStringArm`).
 
-import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import type { Instr, LocalDef, ValType } from "../ir/types.js";
 import {
   addFuncType,
@@ -60,6 +60,19 @@ import {
 } from "./registry/types.js";
 import { allocLocal } from "./context/locals.js";
 import { definedFuncAt, mintDefinedFunc, nativeStrHelperHandle, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable mint/push
+import {
+  CLOSURE_CAPTURE_FIELD_BASE,
+  closureArityField,
+  closureBagField,
+  closureBagInitInstr,
+  getClosureFuncSelfTypeIdx,
+  getFuncRefWrapperRootTypeIdx,
+  getOrCreateFuncRefWrapperTypes,
+} from "./closures/funcref-wrapper-types.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { ensureExnTag } from "./registry/imports.js";
+import { emitGuardedFuncRefCast } from "./type-coercion.js";
+import { emitNullCheckThrow } from "./property-access.js";
 // (#3137) allSettled/any additions: status objects live on the object runtime
 // ($Object via __new_plain_object/__extern_set), the AggregateError is a native
 // $Error_struct (tag from builtin-tags), and the "status"/"fulfilled"/… keys are
@@ -76,6 +89,7 @@ import {
   PROMISE_STATE_FULFILLED,
   PROMISE_STATE_PENDING,
   PROMISE_STATE_REJECTED,
+  isStandalonePromiseActive,
 } from "./async-scheduler.js";
 
 const EXTERNREF: ValType = { kind: "externref" };
@@ -87,6 +101,233 @@ export type NativeCombinator = "all" | "race" | "allSettled" | "any";
 
 export function isNativeCombinatorMethod(method: string): method is NativeCombinator {
   return method === "all" || method === "race" || method === "allSettled" || method === "any";
+}
+
+/**
+ * (#4682) The small NewPromiseCapability substrate used by the bounded
+ * custom-constructor arm.  This is deliberately separate from the aggregate
+ * state below: the first slice only admits an empty array, where the only
+ * observable combinator work is constructing C and validating the executor's
+ * captured resolve/reject pair.
+ */
+interface CustomCapabilityRuntime {
+  stateTypeIdx: number;
+  executorTypeIdx: number;
+  executorFuncIdx: number;
+}
+
+type CtxWithCustomCapability = CodegenContext & { __promiseCustomCapability?: CustomCapabilityRuntime };
+
+function customCapabilityTypeError(ctx: CodegenContext): Instr[] {
+  // NewPromiseCapability's executor protocol throws a TypeError before the
+  // combinator touches an empty iterable when either captured slot is not
+  // callable.  Reuse the in-module standalone Error constructor and native
+  // exception tag so this arm never introduces an env import.
+  emitWasiErrorConstructor(ctx, "TypeError", 1);
+  const ctorIdx = ctx.funcMap.get("__new_TypeError");
+  if (ctorIdx === undefined) return [{ op: "unreachable" }];
+  return [{ op: "ref.null.extern" }, { op: "call", funcIdx: ctorIdx }, { op: "throw", tagIdx: ensureExnTag(ctx) }];
+}
+
+/** Register the two-argument capability executor and its mutable slots once. */
+function ensureCustomCapabilityRuntime(ctx: CodegenContext): CustomCapabilityRuntime | null {
+  const cached = (ctx as CtxWithCustomCapability).__promiseCustomCapability;
+  if (cached) return cached;
+
+  const wrapper = getOrCreateFuncRefWrapperTypes(ctx, [EXTERNREF, EXTERNREF], []);
+  if (!wrapper) return null;
+
+  // The capability record stores the two values supplied by C's constructor.
+  // `undefined` is represented by a null externref on this native path. The
+  // selected Test262 cohort intentionally uses undefined for the first call;
+  // a later slice can add a presence bit for explicit null.
+  const stateTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "$__promise_custom_capability",
+    fields: [
+      { name: "$resolve", type: EXTERNREF, mutable: true },
+      { name: "$reject", type: EXTERNREF, mutable: true },
+    ],
+  });
+  ctx.structMap.set("$__promise_custom_capability", stateTypeIdx);
+  ctx.typeIdxToStructName.set(stateTypeIdx, "$__promise_custom_capability");
+  ctx.structFields.set("$__promise_custom_capability", [
+    { name: "$resolve", type: EXTERNREF, mutable: true },
+    { name: "$reject", type: EXTERNREF, mutable: true },
+  ]);
+
+  // This subtype is a normal `(externref, externref) -> void` closure with one
+  // capture: the mutable capability record. Its inherited header makes it
+  // callable by the ordinary `executor(...)` lowering in a compiled C body.
+  const executorTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "$__promise_custom_capability_executor",
+    fields: [
+      { name: "func", type: { kind: "funcref" }, mutable: false },
+      closureArityField(),
+      closureBagField(),
+      { name: "$capability", type: { kind: "ref", typeIdx: stateTypeIdx }, mutable: false },
+    ],
+    superTypeIdx: wrapper.structTypeIdx,
+  });
+  ctx.structMap.set("$__promise_custom_capability_executor", executorTypeIdx);
+  ctx.typeIdxToStructName.set(executorTypeIdx, "$__promise_custom_capability_executor");
+  ctx.structFields.set("$__promise_custom_capability_executor", [
+    { name: "func", type: { kind: "funcref" }, mutable: false },
+    closureArityField(),
+    closureBagField(),
+    { name: "$capability", type: { kind: "ref", typeIdx: stateTypeIdx }, mutable: false },
+  ]);
+
+  emitWasiErrorConstructor(ctx, "TypeError", 1);
+  const typeErrorIdx = ctx.funcMap.get("__new_TypeError");
+  const exnTag = ensureExnTag(ctx);
+  const executorFuncIdx = mintDefinedFunc(ctx);
+  const stateLocal = 3;
+  const body: Instr[] = [
+    // state = self.$capability
+    { op: "local.get", index: 0 },
+    { op: "ref.cast", typeIdx: executorTypeIdx },
+    { op: "struct.get", typeIdx: executorTypeIdx, fieldIdx: CLOSURE_CAPTURE_FIELD_BASE },
+    { op: "local.set", index: stateLocal },
+    // A second call is only an error once a non-undefined slot was stored.
+    { op: "local.get", index: stateLocal },
+    { op: "struct.get", typeIdx: stateTypeIdx, fieldIdx: 0 },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    { op: "local.get", index: stateLocal },
+    { op: "struct.get", typeIdx: stateTypeIdx, fieldIdx: 1 },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then:
+        typeErrorIdx === undefined
+          ? [{ op: "unreachable" }]
+          : [{ op: "ref.null.extern" }, { op: "call", funcIdx: typeErrorIdx }, { op: "throw", tagIdx: exnTag }],
+    },
+    // Capture resolve and reject even when either is undefined. This mirrors
+    // GetCapabilitiesExecutor's sentinel semantics for the selected cohort.
+    { op: "local.get", index: stateLocal },
+    { op: "local.get", index: 1 },
+    { op: "struct.set", typeIdx: stateTypeIdx, fieldIdx: 0 },
+    { op: "local.get", index: stateLocal },
+    { op: "local.get", index: 2 },
+    { op: "struct.set", typeIdx: stateTypeIdx, fieldIdx: 1 },
+  ];
+  const funcTypeIdx = wrapper.liftedFuncTypeIdx;
+  pushDefinedFunc(ctx, executorFuncIdx, {
+    name: "__promise_custom_capability_executor",
+    typeIdx: funcTypeIdx,
+    locals: [{ name: "$capability", type: { kind: "ref", typeIdx: stateTypeIdx } }],
+    body,
+    exported: false,
+  });
+  ctx.funcMap.set("__promise_custom_capability_executor", executorFuncIdx);
+
+  const result: CustomCapabilityRuntime = {
+    stateTypeIdx,
+    executorTypeIdx,
+    executorFuncIdx,
+  };
+  (ctx as CtxWithCustomCapability).__promiseCustomCapability = result;
+  return result;
+}
+
+/**
+ * (#4682) Invoke an ordinary compiled constructor with a native capability
+ * executor and validate the captured slots. This is intentionally limited to
+ * an empty iterable; callers use the established native combinator emitter for
+ * the resulting aggregate once this protocol completes.
+ */
+export function emitStandalonePromiseCustomCapabilityCheck(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  constructorLocal: number,
+  constructorInfo: ClosureInfo,
+  constructorSelfTypeIdx: number,
+): boolean {
+  if (!isStandalonePromiseActive(ctx)) return false;
+  const runtime = ensureCustomCapabilityRuntime(ctx);
+  const wrapperRoot = getFuncRefWrapperRootTypeIdx(ctx);
+  if (!runtime || wrapperRoot === undefined) return false;
+
+  const stateLocal = allocLocal(fctx, `__promise_capability_state_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: runtime.stateTypeIdx,
+  });
+  fctx.body.push(
+    { op: "ref.null.extern" },
+    { op: "ref.null.extern" },
+    { op: "struct.new", typeIdx: runtime.stateTypeIdx },
+    { op: "local.set", index: stateLocal },
+  );
+  const executorLocal = allocLocal(fctx, `__promise_capability_executor_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: runtime.executorTypeIdx,
+  });
+  fctx.body.push(
+    { op: "ref.func", funcIdx: runtime.executorFuncIdx },
+    { op: "i32.const", value: 2 },
+    closureBagInitInstr(),
+    { op: "local.get", index: stateLocal },
+    { op: "struct.new", typeIdx: runtime.executorTypeIdx },
+    { op: "local.set", index: executorLocal },
+  );
+
+  // C's lifted closure ABI always carries its self struct first. The
+  // capability executor itself is passed as the first user parameter; any
+  // extra formals get their ordinary default values.
+  fctx.body.push({ op: "local.get", index: constructorLocal });
+  for (let i = 0; i < constructorInfo.paramTypes.length; i++) {
+    const p = constructorInfo.paramTypes[i]!;
+    if (i === 0) {
+      fctx.body.push({ op: "local.get", index: executorLocal }, { op: "extern.convert_any" });
+    } else {
+      // This arm is admitted only for the one-parameter constructors in the
+      // Test262 capability cohort. Keep a defensive default for malformed
+      // declarations instead of emitting an invalid stack shape.
+      if (p.kind === "externref") fctx.body.push({ op: "ref.null.extern" });
+      else if (p.kind === "f64") fctx.body.push({ op: "f64.const", value: 0 });
+      else if (p.kind === "i32") fctx.body.push({ op: "i32.const", value: 0 });
+      else fctx.body.push({ op: "ref.null", typeIdx: (p as { typeIdx: number }).typeIdx });
+    }
+  }
+  const constructorSelf = getClosureFuncSelfTypeIdx(ctx, constructorInfo.funcTypeIdx) ?? constructorSelfTypeIdx;
+  fctx.body.push(
+    { op: "local.get", index: constructorLocal },
+    { op: "struct.get", typeIdx: constructorSelf, fieldIdx: 0 },
+  );
+  emitGuardedFuncRefCast(fctx, constructorInfo.funcTypeIdx);
+  emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: constructorInfo.funcTypeIdx });
+  fctx.body.push({ op: "call_ref", typeIdx: constructorInfo.funcTypeIdx });
+  if (constructorInfo.returnType !== null) fctx.body.push({ op: "drop" });
+
+  // NewPromiseCapability validates both captured values after C returns.
+  const resolveCallable = [
+    { op: "local.get", index: stateLocal } as Instr,
+    { op: "struct.get", typeIdx: runtime.stateTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.test", typeIdx: wrapperRoot } as Instr,
+  ];
+  const rejectCallable = [
+    { op: "local.get", index: stateLocal } as Instr,
+    { op: "struct.get", typeIdx: runtime.stateTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.test", typeIdx: wrapperRoot } as Instr,
+  ];
+  fctx.body.push(...resolveCallable, ...rejectCallable, { op: "i32.and" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [],
+    else: customCapabilityTypeError(ctx),
+  });
+  return true;
 }
 
 interface CombinatorRuntime {

--- a/tests/issue-4682.test.ts
+++ b/tests/issue-4682.test.ts
@@ -1,0 +1,89 @@
+// #4682 — the standalone NewPromiseCapability executor must reject an
+// ordinary custom constructor whose captured resolve/reject pair is not
+// callable, before the empty Promise.all iterable path asks for `resolve`.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Exports {
+  test: () => number;
+}
+
+async function runStandalone(source: string): Promise<{ imports: string[]; value: number }> {
+  const result = await compile(source, { fileName: "issue-4682.ts", target: "standalone" });
+  expect(result.success, result.success ? "" : JSON.stringify(result.errors?.slice(0, 3))).toBe(true);
+  const imports = (result.imports ?? []).map((item) => `${item.module}.${item.name}`);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return { imports, value: (instance.exports as unknown as Exports).test() };
+}
+
+describe("#4682 standalone Promise.all custom capability executor", () => {
+  it("passes the six capability-executor-not-callable subcases", async () => {
+    const source = `
+      let checkPoint = 0;
+      function fn1(executor: any) {
+        checkPoint += 1;
+      }
+      function fn2(executor: any) {
+        checkPoint += 1;
+        executor();
+        checkPoint += 1;
+      }
+      function fn3(executor: any) {
+        checkPoint += 1;
+        executor(undefined, undefined);
+        checkPoint += 1;
+      }
+      function fn4(executor: any) {
+        checkPoint += 1;
+        executor(undefined, function () {});
+        checkPoint += 1;
+      }
+      function fn5(executor: any) {
+        checkPoint += 1;
+        executor(function () {}, undefined);
+        checkPoint += 1;
+      }
+      function fn6(executor: any) {
+        checkPoint += 1;
+        executor(123, "invalid value");
+        checkPoint += 1;
+      }
+      export function test(): number {
+        try { Promise.all.call(fn1, []); } catch (e) { checkPoint += 10; }
+        try { Promise.all.call(fn2, []); } catch (e) { checkPoint += 10; }
+        try { Promise.all.call(fn3, []); } catch (e) { checkPoint += 10; }
+        try { Promise.all.call(fn4, []); } catch (e) { checkPoint += 10; }
+        try { Promise.all.call(fn5, []); } catch (e) { checkPoint += 10; }
+        try { Promise.all.call(fn6, []); } catch (e) { checkPoint += 10; }
+        return checkPoint;
+      }
+    `;
+    const result = await runStandalone(source);
+    expect(result.imports).toEqual([]);
+    // fn1 contributes 1; every other constructor contributes 1 + 1 before
+    // NewPromiseCapability validates the captured pair and throws (+10).
+    expect(result.value).toBe(71);
+  });
+
+  it("keeps the non-empty custom-constructor fallback unchanged", async () => {
+    const result = await compile(
+      `function C(executor: any) { executor(function () {}, function () {}); }
+       C.resolve = function (value: any) { return value; };
+       export function test(): number { Promise.all.call(C, [1]); return 1; }`,
+      { fileName: "issue-4682-control.ts", target: "standalone" },
+    );
+    expect(result.success, result.success ? "" : JSON.stringify(result.errors?.slice(0, 3))).toBe(true);
+    expect((result.imports ?? []).map((item) => `${item.module}.${item.name}`)).toContain("env.Promise_all");
+  });
+
+  it("keeps the gc/host custom-constructor path unchanged", async () => {
+    const result = await compile(
+      `function C(executor: any) { executor(function () {}, function () {}); }
+       export function test(): number { Promise.all.call(C, []); return 1; }`,
+      { fileName: "issue-4682-host-control.ts" },
+    );
+    expect(result.success, result.success ? "" : JSON.stringify(result.errors?.slice(0, 3))).toBe(true);
+    expect((result.imports ?? []).map((item) => `${item.module}.${item.name}`)).toContain("env.Promise_all");
+  });
+});


### PR DESCRIPTION
## Summary
- model the bounded NewPromiseCapability executor protocol for ordinary custom constructors used by empty standalone Promise combinators
- validate captured resolve/reject callability without introducing host imports
- preserve non-empty standalone and gc/host fallback behavior
- track the implementation and evidence in `plan/issues/4682-standalone-promise-custom-constructor-capability.md`

## Verification
- authoritative `Promise/all/capability-executor-not-callable.js`: fail (`af476666ab72`) -> pass (`53efe413775a`)
- `pnpm exec vitest run tests/issue-4682.test.ts`: 3/3 passed
- TypeScript 7 project typecheck passed; TypeScript 5 changed-file filter clean
- Prettier, Biome, oracle ratchet, coercion ratchet, numeric-local IR parity, and issue integrity passed

## Residuals
`capability-executor-called-twice.js`, homologous allSettled/race/any rows, non-empty custom-constructor protocol, and class/subclass receivers remain explicit follow-up work.