### PR TITLE
fix(array): preserve constructor element carriers

### DIFF
--- a/src/codegen/declarations/array-rebind-element-widening.ts
+++ b/src/codegen/declarations/array-rebind-element-widening.ts
@@ -60,6 +60,9 @@ const analysisCache = new WeakMap<CodegenContext, Map<ts.SourceFile, ReadonlySet
 /** The domain a single whole-array write stores into the binding. */
 type WriteDomain = "object" | "primitive";
 
+/** `typeof null` is "object", but it is not an object-element carrier. */
+type WriteTag = JsTag | "nullish";
+
 /** Tags whose values are references with observable identity. */
 const OBJECT_TAGS: ReadonlySet<JsTag> = new Set<JsTag>(["object", "function"]);
 
@@ -147,18 +150,25 @@ function isModuleScoped(node: ts.Node): boolean {
  * not a syntactically classifiable array construction.
  *
  * `undefined` means "an array with no statically known elements" (`[]`, or the
- * `new Array(len)` length form): carries no element evidence, and — unlike
- * `null` — does not abandon the binding.
+ * `new Array(len)` length form): carries no element evidence, and — unlike an
+ * unclassifiable `null` result — does not abandon the binding.
  */
-function writtenElementTags(ctx: CodegenContext, expr: ts.Expression): readonly JsTag[] | undefined | null {
+function writtenElementTags(ctx: CodegenContext, expr: ts.Expression): readonly WriteTag[] | undefined | null {
   if (ts.isArrayLiteralExpression(expr)) {
     if (expr.elements.length === 0) return undefined;
-    const tags: JsTag[] = [];
+    const tags: WriteTag[] = [];
     for (const element of expr.elements) {
       if (ts.isSpreadElement(element) || ts.isOmittedExpression(element)) return null;
-      const tag = ctx.oracle.staticJsTypeOf(element);
-      if (tag === "mixed") return null;
-      tags.push(tag);
+      // Keep null separate from ordinary objects: null can share the
+      // externref element carrier, but it cannot be represented by a closed
+      // object struct (and `typeof null` otherwise hides this distinction).
+      if (element.kind === ts.SyntaxKind.NullKeyword) {
+        tags.push("nullish");
+      } else {
+        const tag = ctx.oracle.staticJsTypeOf(element);
+        if (tag === "mixed") return null;
+        tags.push(tag);
+      }
     }
     return tags;
   }
@@ -167,12 +177,16 @@ function writtenElementTags(ctx: CodegenContext, expr: ts.Expression): readonly 
     if (!ts.isIdentifier(callee) || callee.text !== "Array") return null;
     const args = expr.arguments;
     if (args === undefined || args.length === 0) return undefined;
-    const tags: JsTag[] = [];
+    const tags: WriteTag[] = [];
     for (const argument of args) {
       if (ts.isSpreadElement(argument)) return null;
-      const tag = ctx.oracle.staticJsTypeOf(argument);
-      if (tag === "mixed") return null;
-      tags.push(tag);
+      if (argument.kind === ts.SyntaxKind.NullKeyword) {
+        tags.push("nullish");
+      } else {
+        const tag = ctx.oracle.staticJsTypeOf(argument);
+        if (tag === "mixed") return null;
+        tags.push(tag);
+      }
     }
     // §23.1.1.1 step 5 / ES5 §15.4.2.2: a SINGLE Number argument is a LENGTH,
     // so the array has no statically known elements. Every other single
@@ -184,9 +198,17 @@ function writtenElementTags(ctx: CodegenContext, expr: ts.Expression): readonly 
 }
 
 /** The domain of one write, or `undefined` when it carries no element evidence. */
-function writeDomain(tags: readonly JsTag[] | undefined): WriteDomain | undefined {
+function writeDomain(tags: readonly WriteTag[] | undefined): WriteDomain | undefined {
   if (tags === undefined || tags.length === 0) return undefined;
-  const objectElements = tags.filter((tag) => OBJECT_TAGS.has(tag)).length;
+  const objectElements = tags.filter((tag) => tag !== "nullish" && OBJECT_TAGS.has(tag)).length;
+  const nullishElements = tags.filter((tag) => tag === "nullish").length;
+  // A null-containing write needs the universal element carrier even when all
+  // its other values are primitive. Treat that representation as object-domain
+  // evidence so a preceding numeric/boolean/string write widens the rebinding.
+  if (nullishElements > 0) {
+    const nonNullElements = tags.length - nullishElements;
+    if (objectElements === 0 || objectElements === nonNullElements) return "object";
+  }
   if (objectElements === tags.length) return "object";
   if (objectElements === 0) return "primitive";
   // Mixed within a single write — the array-literal element-typing lane's job.

--- a/src/codegen/expressions/array-constructor-carrier.ts
+++ b/src/codegen/expressions/array-constructor-carrier.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Shared carrier decisions for the `Array(...)` and `new Array(...)` paths.
+ * Keeping these small emitters out of their dispatchers preserves the
+ * god-file/per-function budgets while both constructor spellings stay aligned.
+ */
+import type { ValType } from "../../ir/types.js";
+import { ts } from "../../ts-api.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { allocLocal } from "../context/locals.js";
+import { getArrTypeIdxFromVec, getOrRegisterVecType } from "../registry/types.js";
+import { compileExpression } from "../shared.js";
+
+/** Dense Array constructors must keep an explicit null in a reference carrier. */
+export function widenDenseArrayElementType(args: readonly ts.Expression[], elemWasm: ValType): ValType {
+  if (args.length > 1 && elemWasm.kind !== "externref" && args.some((arg) => arg.kind === ts.SyntaxKind.NullKeyword)) {
+    return { kind: "externref" };
+  }
+  return elemWasm;
+}
+
+/** Emit the one-element constructor form without narrowing a known ref to null. */
+export function compileOneElementArray(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+  elemWasm: ValType,
+  vecTypeIdx: number,
+): ValType {
+  const typedReferenceElement = elemWasm.kind === "ref" || elemWasm.kind === "ref_null";
+  const oneVecIdx = typedReferenceElement
+    ? vecTypeIdx
+    : elemWasm.kind === "externref"
+      ? vecTypeIdx
+      : getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+  const oneArrIdx = getArrTypeIdxFromVec(ctx, oneVecIdx);
+  compileExpression(ctx, fctx, arg, typedReferenceElement ? elemWasm : { kind: "externref" });
+  fctx.body.push({ op: "array.new_fixed", typeIdx: oneArrIdx, length: 1 });
+  const oneData = allocLocal(fctx, `__arr_data_${fctx.locals.length}`, { kind: "ref", typeIdx: oneArrIdx });
+  fctx.body.push({ op: "local.set", index: oneData });
+  fctx.body.push({ op: "i32.const", value: 1 });
+  fctx.body.push({ op: "local.get", index: oneData });
+  fctx.body.push({ op: "struct.new", typeIdx: oneVecIdx });
+  return { kind: "ref_null", typeIdx: oneVecIdx };
+}

--- a/src/codegen/expressions/new-indexed.ts
+++ b/src/codegen/expressions/new-indexed.ts
@@ -21,6 +21,7 @@ import { ensureHoleyArrayNew } from "../vec-elem-set.js";
 import { sparseArrayNewSplitInstrs } from "../vec-sparse-index.js";
 import { compileExpression } from "../shared.js";
 import { buildThrowJsErrorInstrs } from "./helpers.js";
+import { compileOneElementArray, widenDenseArrayElementType } from "./array-constructor-carrier.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { inferArrayElementType } from "./new-super.js";
 
@@ -590,6 +591,13 @@ export function tryCompileIndexedBuiltinNew(
 
     const args = expr.arguments ?? [];
 
+    const widenedElemWasm = widenDenseArrayElementType(args, elemWasm);
+    if (widenedElemWasm.kind !== elemWasm.kind) {
+      elemWasm = widenedElemWasm;
+      vecTypeIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+      arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+    }
+
     if (args.length === 0) {
       // new Array() → empty array with default backing capacity
       // JS arrays are dynamically resizable; wasm arrays are fixed-size.
@@ -613,23 +621,7 @@ export function tryCompileIndexedBuiltinNew(
       // args keep the historical length behavior.
       const argTag = ctx.oracle.staticJsTypeOf(args[0]!);
       if (argTag !== "number" && argTag !== "mixed") {
-        let oneVecIdx = vecTypeIdx;
-        let oneArrIdx = arrTypeIdx;
-        if (elemWasm.kind !== "externref") {
-          oneVecIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
-          oneArrIdx = getArrTypeIdxFromVec(ctx, oneVecIdx);
-        }
-        compileExpression(ctx, fctx, args[0]!, { kind: "externref" });
-        fctx.body.push({ op: "array.new_fixed", typeIdx: oneArrIdx, length: 1 });
-        const oneData = allocLocal(fctx, `__arr_data_${fctx.locals.length}`, {
-          kind: "ref",
-          typeIdx: oneArrIdx,
-        });
-        fctx.body.push({ op: "local.set", index: oneData });
-        fctx.body.push({ op: "i32.const", value: 1 });
-        fctx.body.push({ op: "local.get", index: oneData });
-        fctx.body.push({ op: "struct.new", typeIdx: oneVecIdx });
-        return { kind: "ref_null", typeIdx: oneVecIdx };
+        return compileOneElementArray(ctx, fctx, args[0]!, elemWasm, vecTypeIdx);
       }
       // new Array(n) → array with capacity n, length 0
       // For test262 patterns like `var a = new Array(16); a[0] = x;`

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -92,6 +92,7 @@ import {
 } from "./shared.js";
 import { buildVecFromExternref, getVecInfo, pushDefaultValue } from "./type-coercion.js";
 import { emitDrainCustomIterableToVec, isCustomIterable } from "./custom-iterable.js";
+import { compileOneElementArray, widenDenseArrayElementType } from "./expressions/array-constructor-carrier.js";
 import {
   S5C_STRUCT_ACCESSOR_CLOSURE,
   buildAccessorClosure,
@@ -5685,6 +5686,9 @@ export function compileArrayConstructorCall(
     elemWasm = { kind: "f64" };
   }
 
+  const widenedElemWasm = widenDenseArrayElementType(args, elemWasm);
+  if (widenedElemWasm.kind !== elemWasm.kind) elemWasm = widenedElemWasm;
+
   const elemKind =
     elemWasm.kind === "ref" || elemWasm.kind === "ref_null"
       ? `ref_${(elemWasm as { typeIdx: number }).typeIdx}`
@@ -5713,17 +5717,7 @@ export function compileArrayConstructorCall(
     // number) take this path; `mixed` (any-typed) keeps length behavior.
     const argTag = ctx.oracle.staticJsTypeOf(args[0]!);
     if (argTag !== "number" && argTag !== "mixed" && !ts.isSpreadElement(args[0]!)) {
-      const oneVecIdx =
-        elemWasm.kind === "externref" ? vecTypeIdx : getOrRegisterVecType(ctx, "externref", { kind: "externref" });
-      const oneArrIdx = getArrTypeIdxFromVec(ctx, oneVecIdx);
-      compileExpression(ctx, fctx, args[0]!, { kind: "externref" });
-      fctx.body.push({ op: "array.new_fixed", typeIdx: oneArrIdx, length: 1 });
-      const oneData = allocLocal(fctx, `__arr_data_${fctx.locals.length}`, { kind: "ref", typeIdx: oneArrIdx });
-      fctx.body.push({ op: "local.set", index: oneData });
-      fctx.body.push({ op: "i32.const", value: 1 });
-      fctx.body.push({ op: "local.get", index: oneData });
-      fctx.body.push({ op: "struct.new", typeIdx: oneVecIdx });
-      return { kind: "ref_null", typeIdx: oneVecIdx };
+      return compileOneElementArray(ctx, fctx, args[0]!, elemWasm, vecTypeIdx);
     }
     // Array(n) → sparse array of length n with default values.
     // #2000 — §23.1.1.1 step 4.b: when the single argument is a Number it is a

--- a/tests/issue-4655.test.ts
+++ b/tests/issue-4655.test.ts
@@ -203,6 +203,17 @@ describe("#4655 — the element step of Array.prototype.toLocaleString", () => {
   );
 });
 
+describe("#4655 — Array constructor carriers used by Array.prototype.toString", () => {
+  pinRow(
+    "built-ins/Array/prototype/toString/S15.4.4.2_A1_T2.js",
+    "a null element survives rebinding after an earlier numeric constructor",
+  );
+  pinRow(
+    "built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js",
+    "a one-element object constructor preserves OrdinaryToPrimitive and its TypeError",
+  );
+});
+
 describe("#4655 — measured residuals, each with the control that pins its root", () => {
   // ── R1. an overridden PRIMITIVE prototype method is never consulted ──────
   // The array lowering renders booleans/numbers natively, so the first guess is
@@ -277,15 +288,17 @@ describe("#4655 — measured residuals, each with the control that pins its root
   // control below is the refutation: the SAME expression standing alone renders
   // ",1,,3" and answers `x[2] === null` TRUE. The defect is carrier SELECTION
   // for a reassigned variable whose wasm type was fixed by an earlier numeric
-  // array — #3580's union-collapse at the local/var slot. test262
-  // `toString/S15.4.4.2_A1_T2.js`.
-  failSource(
+  // array — #3580's union-collapse at the local/var slot. The constructor now
+  // widens null-containing dense writes and the rebind analysis widens the slot
+  // when that representation differs. test262
+  // `toString/S15.4.4.2_A1_T2.js` is now pinned as a passing corpus row.
+  pinSource(
     "R3-nullish-into-a-reused-numeric-carrier",
     `${LOOP_CARRIED}
      var x = new Array(0, 1, 2, __n);
      x = Array(undefined, 1, null, __n);
      assert.sameValue(x.toString(), ",1,,3", "reused carrier: " + x.toString());`,
-    "a null element assigned into a var already typed number[] renders 0 (#3580, not a missing NULL payload)",
+    "a null element assigned into a var already typed number[] keeps its nullish representation (#3580)",
   );
   // POSITIVE CONTROL for R3 — the discriminator. It PASSES, which is what makes
   // R3 a statement about the variable rather than about `null` elements.
@@ -499,7 +512,7 @@ describe("#4655 — measured residuals, each with the control that pins its root
   // precisely the mistake this comment records. Unfoldability is not at risk:
   // answering `x.toString()` at compile time would mean running the user's
   // `valueOf`/`toString` closures.
-  failSource(
+  pinSource(
     "R8-new-Array-element-loses-the-toprimitive-throw",
     `${LOOP_CARRIED}
      var both = { valueOf: function () { return {}; }, toString: function () { return {}; } };
@@ -509,7 +522,7 @@ describe("#4655 — measured residuals, each with the control that pins its root
      catch (e) { threw = e instanceof TypeError ? "TypeError" : "other:" + e; }
      assert.sameValue(threw, "TypeError", "new Array(elem): " + threw);
      assert.sameValue(__n, 3, "loop-carried");`,
-    "an element passed to new Array() renders '' where the spec throws a TypeError",
+    "an element passed to new Array() preserves its object carrier so the spec TypeError is observed",
   );
   // POSITIVE CONTROLS for R8 — the two cells that WORK. Without them the pin
   // above reads as "array element ToPrimitive is broken", which is the claim


### PR DESCRIPTION
## Summary

- preserve explicit-null element carriers for dense `Array` and `new Array` constructors
- retain known reference elements in typed one-element carriers so `Array.prototype.toString` follows `OrdinaryToPrimitive` and preserves `TypeError` propagation
- promote the exact ES5 Test262 rows and non-vacuous #4655 controls to permanent passing pins

## Validation

- exact standalone Test262 rows: 2/2 passing (baseline: 0/2)
- neighboring `Array.prototype.toString` controls: 5/5 passing
- `tests/issue-4655.test.ts`: 31/31
- `tests/issue-4428.test.ts`: 12/12
- TypeScript 5 and TypeScript 7 typechecks pass
- IR, structural, and standalone cutover gates pass

## CLA

- [x] I have read and agree to the CLA