### PR TITLE
fix(es5): construct Function call/apply results

### DIFF
--- a/src/codegen/expressions/new-non-constructable-value.ts
+++ b/src/codegen/expressions/new-non-constructable-value.ts
@@ -33,15 +33,101 @@
 //     it, so it never reaches this file.
 import { ts } from "../../ts-api.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { allocLocal } from "../context/locals.js";
 import type { ValType } from "../../ir/types.js";
-import { compileExpression } from "../shared.js";
-import { emitThrowTypeError } from "./helpers.js";
+import { coerceType, compileExpression } from "../shared.js";
+import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
+import { emitThrowTypeError, noJsHost } from "./helpers.js";
 import {
   NEVER_CALLABLE_FACT_KINDS,
   isEvolvingAnyBinding,
   isFreshlyConstructedNonCallable,
   unwrapCallee,
 } from "./calls-guards.js";
+
+/**
+ * Host-lane `[[Construct]]` for a constructor expression evaluated at runtime.
+ * In particular, `new (Function(...).call())` and `new (Function(...).apply())`
+ * first evaluate the reflective call and then construct the function it
+ * returns. The old unknown-constructor fallback skipped that call expression
+ * and left a null externref in its place.
+ *
+ * Spread arguments deliberately decline here: their runtime arity needs the
+ * dynamic argv machinery used by the identifier-based path in new-super.ts.
+ * Fixed arguments are evaluated once, in ordinary `new` order, and passed
+ * through the existing host bridge so IsConstructor and Reflect.construct keep
+ * their standard semantics.
+ */
+export function tryEmitHostConstructExpression(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.NewExpression,
+): boolean {
+  let calleeExpr: ts.Expression = expr.expression;
+  while (
+    ts.isParenthesizedExpression(calleeExpr) ||
+    ts.isAsExpression(calleeExpr) ||
+    ts.isNonNullExpression(calleeExpr) ||
+    ts.isTypeAssertionExpression(calleeExpr)
+  ) {
+    calleeExpr = ts.isParenthesizedExpression(calleeExpr)
+      ? calleeExpr.expression
+      : ts.isAsExpression(calleeExpr)
+        ? calleeExpr.expression
+        : ts.isNonNullExpression(calleeExpr)
+          ? calleeExpr.expression
+          : (calleeExpr as ts.TypeAssertion).expression;
+  }
+  const args = expr.arguments ?? [];
+  if (!ts.isCallExpression(calleeExpr) || noJsHost(ctx) || args.some((arg) => ts.isSpreadElement(arg))) return false;
+
+  // Evaluate the constructor expression before any `new` arguments, as
+  // required by EvaluateNew. The expression may itself be a dynamic
+  // Function/call/apply chain and therefore may register late imports.
+  const calleeTy = compileExpression(ctx, fctx, calleeExpr, { kind: "externref" });
+  if (calleeTy && calleeTy.kind !== "externref") {
+    coerceType(ctx, fctx, calleeTy, { kind: "externref" });
+  } else if (calleeTy === null) {
+    fctx.body.push({ op: "ref.null.extern" });
+  }
+  const calleeLocal = allocLocal(fctx, `__newexpr_callee_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: calleeLocal });
+
+  // Register the bridge as one batch after the callee has been compiled. The
+  // terminal flush keeps call indices above nested-expression imports stable
+  // (#608/#794).
+  const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+  const arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
+  const ccIdx = ensureLateImport(
+    ctx,
+    "__construct_closure",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  const finalArrNew = ctx.funcMap.get("__js_array_new") ?? arrNewIdx;
+  const finalArrPush = ctx.funcMap.get("__js_array_push") ?? arrPushIdx;
+  const finalCc = ctx.funcMap.get("__construct_closure") ?? ccIdx;
+  if (finalArrNew === undefined || finalArrPush === undefined || finalCc === undefined) return false;
+
+  fctx.body.push({ op: "call", funcIdx: finalArrNew });
+  const argvLocal = allocLocal(fctx, `__newexpr_argv_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: argvLocal });
+  for (const arg of args) {
+    fctx.body.push({ op: "local.get", index: argvLocal });
+    const argTy = compileExpression(ctx, fctx, arg, { kind: "externref" });
+    if (argTy && argTy.kind !== "externref") {
+      coerceType(ctx, fctx, argTy, { kind: "externref" });
+    } else if (argTy === null) {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    fctx.body.push({ op: "call", funcIdx: finalArrPush });
+  }
+  fctx.body.push({ op: "local.get", index: calleeLocal });
+  fctx.body.push({ op: "local.get", index: argvLocal });
+  fctx.body.push({ op: "call", funcIdx: finalCc });
+  return true;
+}
 
 /**
  * (#4246) `new <provably-not-a-constructor>` → TypeError.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -21,7 +21,7 @@ import {
   resolvesToAmbientGlobal,
   resolvesToNonConstructableValue,
 } from "./non-constructable.js"; // (#4017)
-import { tryNonConstructableNewTarget } from "./new-non-constructable-value.js"; // (#4246)
+import * as newConstructors from "./new-non-constructable-value.js"; // (#4246)
 import { getOrRegisterTaCtorType } from "../registry/types.js"; // (#4626) runtime $__ta_ctor gate in the ordinary-[[Construct]] arm
 import { tryNewBuiltinStaticAlias } from "./new-builtin-static-alias.js"; // (#4491 wave-5 T6)
 import { reportError } from "../context/errors.js";
@@ -3829,7 +3829,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   // before the class-expression / unknown-constructor paths that would
   // otherwise swallow the construction and answer `undefined`.
   {
-    const nonCtorValue = tryNonConstructableNewTarget(ctx, fctx, expr);
+    const nonCtorValue = newConstructors.tryNonConstructableNewTarget(ctx, fctx, expr);
     if (nonCtorValue !== undefined) return nonCtorValue;
   }
 
@@ -3935,7 +3935,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       return emitStaticNotAConstructorThrow(ctx, fctx, []);
     }
   }
-
+  if (newConstructors.tryEmitHostConstructExpression(ctx, fctx, expr)) return { kind: "externref" };
   // (#1519 sub-issue B) Built-in non-constructor namespaces — `Math`, `JSON`,
   // `Reflect`, `Atomics` — have neither call nor construct signatures. Per
   // ECMA-262 §7.2.10 IsConstructor, `new`-on a value lacking `[[Construct]]`

--- a/tests/es5-function-call-apply-null.test.ts
+++ b/tests/es5-function-call-apply-null.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ES5 Function.prototype.call/apply constructor-expression pins.
+//
+// The A8_T6/A7_T6 rows evaluate `.apply()` / `.call()` first and then use the
+// returned function as the `new` target. The adjacent A8_T3..T5/A7_T3..T5 rows
+// are receiver controls: they construct the reflective `.apply` / `.call`
+// method itself and must keep throwing TypeError. Running the upstream files
+// through the authoritative runner keeps these pins tied to their real harness
+// and assertions instead of duplicating a weakened approximation here.
+
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { runTest262File } from "./test262-runner.js";
+
+const ROWS = [
+  // Positive constructor-expression rows owned by this fix.
+  "built-ins/Function/prototype/apply/S15.3.4.3_A8_T6.js",
+  "built-ins/Function/prototype/call/S15.3.4.4_A7_T6.js",
+  // Neighboring receiver controls: constructing the reflective method itself
+  // remains a TypeError and must not be captured by the dynamic-call arm.
+  "built-ins/Function/prototype/apply/S15.3.4.3_A8_T3.js",
+  "built-ins/Function/prototype/apply/S15.3.4.3_A8_T4.js",
+  "built-ins/Function/prototype/apply/S15.3.4.3_A8_T5.js",
+  "built-ins/Function/prototype/call/S15.3.4.4_A7_T3.js",
+  "built-ins/Function/prototype/call/S15.3.4.4_A7_T4.js",
+  "built-ins/Function/prototype/call/S15.3.4.4_A7_T5.js",
+] as const;
+
+describe("ES5 Function.call/apply constructor-expression semantics", () => {
+  it.each(ROWS)("passes the exact Test262 row %s", async (relativePath) => {
+    const result = await runTest262File(resolve("test262/test", relativePath), "es5-function-call-apply-null");
+    expect(result.status, result.error ?? result.reason ?? "Test262 row did not pass").toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- evaluate Function.prototype.call/apply constructor expressions before Construct
- route their returned function values through the existing construct bridge
- preserve TypeError behavior for constructing call/apply methods themselves

## Test262 delta

Exact upstream baseline nonpasses flipped: 2/2

- built-ins/Function/prototype/apply/S15.3.4.3_A8_T6.js
- built-ins/Function/prototype/call/S15.3.4.4_A7_T6.js

Focused filter: 8/8, including six neighboring receiver controls.

## Verification

- TS5 and TS7
- structural, LOC, and function gates
- Prettier and Biome
- full normal pre-push hooks: typecheck, lint, format, oracle ratchet, coercion ratchet, issue #3765 18/18, issue integrity

No hooks were bypassed.