### PR TITLE
fix(standalone): reify ES5 function descriptor properties

### DIFF
--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -2765,7 +2765,7 @@ export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionCo
   fctx.body = savedBody;
   ctx.liveBodies.delete(savedBody);
   ctx.liveBodies.add(namespaceSeeds);
-  const functionSeeds = standaloneGlobalFunctionSeedInstrs(ctx, objLocal);
+  const functionSeeds = standaloneGlobalFunctionSeedInstrs(ctx, fctx, objLocal);
   const newObjectIdx = ctx.funcMap.get("__new_plain_object");
   const defineValueIdx = ctx.funcMap.get("__defineProperty_value");
   const boxNumberIdx = ctx.funcMap.get("__box_number");

--- a/src/codegen/builtin-proto-constructor.ts
+++ b/src/codegen/builtin-proto-constructor.ts
@@ -66,6 +66,7 @@ import {
   isSupportedBuiltinNamespace,
 } from "./builtin-static-globals.js";
 import { emitStandaloneFunctionIntrinsicValue } from "./function-intrinsic-carrier.js";
+import { withSpeculativeCompile } from "./context/speculative.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { coerceType, ensureLateImport, flushLateImportShifts } from "./shared.js";
 
@@ -136,29 +137,26 @@ export function tryEmitBuiltinProtoConstructorDescriptor(
 ): boolean {
   if (builtinName === undefined || member !== "constructor") return false;
   if (!hasBuiltinProtoConstructorCarrier(builtinName)) return false;
-  const bodyMark = fctx.body.length;
+  return withSpeculativeCompile(ctx, fctx, () => {
+    // The provider-backed `%Function%` emitter can register the runtime-eval
+    // import while producing the descriptor value. Emit the value first, then
+    // resolve the descriptor helper and flush shifts so its call index is live.
+    // The other carriers are self-contained, but keeping the ordering uniform
+    // avoids a future carrier reintroducing the same stale-index hazard.
+    const valueType = emitBuiltinProtoConstructorValue(ctx, fctx, builtinName);
+    if (valueType === null) return { commit: false, value: false };
+    if (valueType.kind !== "externref") coerceType(ctx, fctx, valueType, { kind: "externref" });
 
-  // The provider-backed `%Function%` emitter can register the runtime-eval
-  // import while producing the descriptor value. Emit the value first, then
-  // resolve the descriptor helper and flush shifts so its call index is live.
-  // The other carriers are self-contained, but keeping the ordering uniform
-  // avoids a future carrier reintroducing the same stale-index hazard.
-  const valueType = emitBuiltinProtoConstructorValue(ctx, fctx, builtinName);
-  if (valueType === null) return false;
-  if (valueType.kind !== "externref") coerceType(ctx, fctx, valueType, { kind: "externref" });
-
-  const createIdx = ensureLateImport(
-    ctx,
-    "__create_descriptor",
-    [{ kind: "externref" }, { kind: "i32" }],
-    [{ kind: "externref" }],
-  );
-  flushLateImportShifts(ctx, fctx);
-  if (createIdx === undefined) {
-    fctx.body.length = bodyMark;
-    return false;
-  }
-  fctx.body.push({ op: "i32.const", value: CONSTRUCTOR_FLAGS });
-  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__create_descriptor") ?? createIdx });
-  return true;
+    const createIdx = ensureLateImport(
+      ctx,
+      "__create_descriptor",
+      [{ kind: "externref" }, { kind: "i32" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    if (createIdx === undefined) return { commit: false, value: false };
+    fctx.body.push({ op: "i32.const", value: CONSTRUCTOR_FLAGS });
+    fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__create_descriptor") ?? createIdx });
+    return { commit: true, value: true };
+  });
 }

--- a/src/codegen/builtin-proto-constructor.ts
+++ b/src/codegen/builtin-proto-constructor.ts
@@ -41,21 +41,22 @@
  * | `__builtin_ctor_<N>` (#3006)       | Set, Map, Weak*, RegExp, FinalizationRegistry, …    |
  * | `__builtin_<N>` namespace (#2907)  | Object, Array, Math, JSON, Reflect, Error family    |
  *
- * A builtin with NEITHER carrier (`Date`, `String`, `Number`, `Boolean`,
- * `Function`) declines and keeps today's `undefined`. Minting a carrier for
- * those means changing what the BARE identifier reads — a strictly wider blast
- * radius than this arm — so it is deliberately left to a follow-up that can
- * measure the bare-value change on its own. `Function` in particular must stay
- * out: its bare value is the realm-owned `%Function%` intrinsic in runtime-eval
- * builds (`emitStandaloneIntrinsicFunctionValue`), not a plain carrier.
+ * A builtin with NEITHER carrier (`Date`, `String`, `Number`, `Boolean`)
+ * declines and keeps today's `undefined`. `Function` is the one exception:
+ * its constructor value already has a single shared emitter
+ * (`emitStandaloneFunctionIntrinsicValue`) because the bare value is the
+ * realm-owned `%Function%` intrinsic in runtime-eval builds. Reusing that
+ * emitter here makes the prototype's own data property agree with both the
+ * `Function.prototype.constructor` read and the bare `Function` value without
+ * minting a second, non-callable carrier.
  *
  * ## Safety envelope
  *
  * Standalone only (`ctx.standalone` is checked by both callers); host/gc keep
  * their genuine `Object_get_constructor` read. Every shape this module answers
- * read `undefined` on main, so nothing that previously produced a value can
- * change. `tryEmit*` returns `false` having pushed NOTHING when it declines, so
- * a decline can never leave partial instructions in `fctx.body`.
+ * was previously `undefined` on main, so nothing that previously produced a
+ * value can change. `tryEmit*` keeps the no-partial-instructions contract when
+ * it declines.
  */
 import type { ValType } from "../ir/types.js";
 import {
@@ -64,6 +65,7 @@ import {
   isBuiltinConstructorIdentityName,
   isSupportedBuiltinNamespace,
 } from "./builtin-static-globals.js";
+import { emitStandaloneFunctionIntrinsicValue } from "./function-intrinsic-carrier.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { coerceType, ensureLateImport, flushLateImportShifts } from "./shared.js";
 
@@ -80,7 +82,11 @@ const CONSTRUCTOR_FLAGS = 0x05;
  * pushing operands and keep the "declines push nothing" contract.
  */
 export function hasBuiltinProtoConstructorCarrier(builtinName: string): boolean {
-  return isBuiltinConstructorIdentityName(builtinName) || isSupportedBuiltinNamespace(builtinName);
+  return (
+    builtinName === "Function" ||
+    isBuiltinConstructorIdentityName(builtinName) ||
+    isSupportedBuiltinNamespace(builtinName)
+  );
 }
 
 /**
@@ -95,6 +101,9 @@ export function emitBuiltinProtoConstructorValue(
   fctx: FunctionContext,
   builtinName: string,
 ): ValType | null {
+  if (builtinName === "Function") {
+    return emitStandaloneFunctionIntrinsicValue(ctx, fctx) ?? null;
+  }
   if (isBuiltinConstructorIdentityName(builtinName)) {
     return emitBuiltinConstructorIdentity(ctx, fctx, builtinName);
   }
@@ -127,6 +136,17 @@ export function tryEmitBuiltinProtoConstructorDescriptor(
 ): boolean {
   if (builtinName === undefined || member !== "constructor") return false;
   if (!hasBuiltinProtoConstructorCarrier(builtinName)) return false;
+  const bodyMark = fctx.body.length;
+
+  // The provider-backed `%Function%` emitter can register the runtime-eval
+  // import while producing the descriptor value. Emit the value first, then
+  // resolve the descriptor helper and flush shifts so its call index is live.
+  // The other carriers are self-contained, but keeping the ordering uniform
+  // avoids a future carrier reintroducing the same stale-index hazard.
+  const valueType = emitBuiltinProtoConstructorValue(ctx, fctx, builtinName);
+  if (valueType === null) return false;
+  if (valueType.kind !== "externref") coerceType(ctx, fctx, valueType, { kind: "externref" });
+
   const createIdx = ensureLateImport(
     ctx,
     "__create_descriptor",
@@ -134,12 +154,11 @@ export function tryEmitBuiltinProtoConstructorDescriptor(
     [{ kind: "externref" }],
   );
   flushLateImportShifts(ctx, fctx);
-  if (createIdx === undefined) return false;
-
-  const valueType = emitBuiltinProtoConstructorValue(ctx, fctx, builtinName);
-  if (valueType === null) return false;
-  if (valueType.kind !== "externref") coerceType(ctx, fctx, valueType, { kind: "externref" });
+  if (createIdx === undefined) {
+    fctx.body.length = bodyMark;
+    return false;
+  }
   fctx.body.push({ op: "i32.const", value: CONSTRUCTOR_FLAGS });
-  fctx.body.push({ op: "call", funcIdx: createIdx });
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__create_descriptor") ?? createIdx });
   return true;
 }

--- a/src/codegen/standalone-global-functions.ts
+++ b/src/codegen/standalone-global-functions.ts
@@ -21,6 +21,7 @@ import { addStringConstantGlobal, addUnionImports } from "./registry/imports.js"
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitNativeEscape, emitNativeUnescape } from "./escape-native.js"; // (#4556) Annex B §B.2.1/§B.2.2
 import { emitNativeUriDecode, emitNativeUriEncode, URI_DECODE_MASK, URI_ENCODE_MASK } from "./uri-encoding-native.js";
+import { emitStandaloneIntrinsicEvalValue } from "./expressions/eval-inline.js";
 
 export const STANDALONE_ES5_GLOBAL_FUNCTION_NAMES = [
   "parseInt",
@@ -268,8 +269,18 @@ export function tryEmitStandaloneGlobalFunctionIdentifier(
   return emitStandaloneGlobalFunctionValue(ctx, fctx, name);
 }
 
+function moduleNeedsStandaloneEvalGlobalSeed(ctx: CodegenContext): boolean {
+  return (
+    ctx.standalone && (ctx.runtimeEvalBoundaryPlan?.sites.some((site) => site.kind === "global-eval-property") ?? false)
+  );
+}
+
 /** Build the one-time seeds for the native realm object in `objectLocal`. */
-export function standaloneGlobalFunctionSeedInstrs(ctx: CodegenContext, objectLocal: number): Instr[] | null {
+export function standaloneGlobalFunctionSeedInstrs(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  objectLocal: number,
+): Instr[] | null {
   if (!ctx.standalone && !ctx.wasi) return [];
 
   // Settle every possible late import before capturing any function index in
@@ -284,9 +295,42 @@ export function standaloneGlobalFunctionSeedInstrs(ctx: CodegenContext, objectLo
     closures.set(name, closure);
   }
 
-  const defineIdx = ctx.funcMap.get("__defineProperty_value");
-  if (defineIdx === undefined) return null;
+  // `%eval%` is not one of the native ES5 call helpers above: its first-class
+  // value is the identity-stable indirect-eval wrapper from the runtime-eval
+  // seam. Seed that same wrapper on the realm object so `this.eval` and
+  // `Object.getOwnPropertyDescriptor(this, "eval")` observe the existing bare
+  // `eval` value rather than an absent property. Keep the detached body live
+  // while the wrapper can register its provider import and shift indices.
   const body: Instr[] = [];
+  if (moduleNeedsStandaloneEvalGlobalSeed(ctx)) {
+    ctx.liveBodies.add(body);
+    const savedBody = fctx.body;
+    fctx.body = body;
+    addStringConstantGlobal(ctx, "eval");
+    body.push({ op: "local.get", index: objectLocal }, ...stringConstantExternrefInstrs(ctx, "eval"));
+    let evalType: ValType | undefined;
+    try {
+      evalType = emitStandaloneIntrinsicEvalValue(ctx, fctx);
+    } finally {
+      fctx.body = savedBody;
+    }
+    if (evalType === undefined) {
+      ctx.liveBodies.delete(body);
+      return null;
+    }
+    if (evalType.kind !== "externref") body.push({ op: "extern.convert_any" });
+  }
+
+  const defineIdx = ctx.funcMap.get("__defineProperty_value");
+  if (defineIdx === undefined) {
+    ctx.liveBodies.delete(body);
+    return null;
+  }
+
+  if (moduleNeedsStandaloneEvalGlobalSeed(ctx)) {
+    // Host flag bits: writable=1, enumerable=2, configurable=4.
+    body.push({ op: "f64.const", value: 0x05 }, { op: "call", funcIdx: defineIdx }, { op: "drop" });
+  }
 
   for (const name of STANDALONE_ES5_GLOBAL_FUNCTION_NAMES) {
     const closure = closures.get(name)!;
@@ -297,5 +341,6 @@ export function standaloneGlobalFunctionSeedInstrs(ctx: CodegenContext, objectLo
     // Host flag bits: writable=1, enumerable=2, configurable=4.
     body.push({ op: "f64.const", value: 0x05 }, { op: "call", funcIdx: defineIdx }, { op: "drop" });
   }
+  ctx.liveBodies.delete(body);
   return body;
 }

--- a/src/ir/runtime-eval-boundary-plan.ts
+++ b/src/ir/runtime-eval-boundary-plan.ts
@@ -12,6 +12,7 @@ export type IrRuntimeEvalSiteKind =
   | "indirect-eval"
   | "function-constructor"
   | "intrinsic-value"
+  | "global-eval-property"
   | "provider-definition";
 
 export interface IrRuntimeEvalSite {
@@ -152,6 +153,22 @@ function isDirectCalleeIntrinsicValue(identifier: ts.Identifier): boolean {
   return false;
 }
 
+/**
+ * A small syntactic gate for the realm object's first-class `eval` property.
+ * The global binding is commonly reached as `globalThis.eval`, `this.eval`, or
+ * Node's `global.eval`; the latter also covers the ES5 Test262 row's
+ * `var global = this` alias. A property on an arbitrary object is deliberately
+ * excluded so the global-object seed does not pull the runtime-eval provider
+ * into unrelated `obj.eval` programs.
+ */
+function isLikelyGlobalObjectReceiver(expression: ts.Expression): boolean {
+  const unwrapped = unwrapExpression(expression);
+  return (
+    unwrapped.kind === ts.SyntaxKind.ThisKeyword ||
+    (ts.isIdentifier(unwrapped) && (unwrapped.text === "globalThis" || unwrapped.text === "global"))
+  );
+}
+
 /** Build the single immutable runtime-eval routing authority for a program. */
 export function buildIrRuntimeEvalBoundaryPlan(
   sourceFiles: readonly ts.SourceFile[],
@@ -218,6 +235,29 @@ export function buildIrRuntimeEvalBoundaryPlan(
             else if (source !== undefined) unknownDynamicSource = true;
           }
         }
+      }
+
+      // `eval` is normally accounted for by the identifier walk below, but a
+      // realm-object read (`global.eval` / `globalThis.eval`) has the property
+      // name in AST member position and therefore intentionally does not count
+      // as an `intrinsic-value` site. It still needs the provider-backed,
+      // identity-stable wrapper when the compiler seeds the native global
+      // object, so record this narrow demand separately.
+      const elementKey = ts.isElementAccessExpression(node) ? unwrapExpression(node.argumentExpression) : undefined;
+      if (
+        ts.isPropertyAccessExpression(node) &&
+        node.name.text === "eval" &&
+        isLikelyGlobalObjectReceiver(node.expression)
+      ) {
+        addSite(sourceFile, id, node, "global-eval-property", "required");
+      } else if (
+        ts.isElementAccessExpression(node) &&
+        elementKey !== undefined &&
+        ts.isStringLiteralLike(elementKey) &&
+        elementKey.text === "eval" &&
+        isLikelyGlobalObjectReceiver(node.expression)
+      ) {
+        addSite(sourceFile, id, node, "global-eval-property", "required");
       }
 
       if (

--- a/tests/es5-standalone-getownpropertydescriptor.test.ts
+++ b/tests/es5-standalone-getownpropertydescriptor.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ES5 standalone own-descriptor pins for the two remaining built-in function
+// properties: Function.prototype.constructor and the realm's eval binding.
+// The Test262 rows assert the descriptor shape; the direct probe below adds
+// non-vacuous identity/type witnesses so a null≡null implementation cannot
+// silently satisfy the equality assertions.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { instantiateTest262Module } from "../scripts/test262-import-object.mjs";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_ROOT = join(__dirname, "..", "test262");
+const TEST262 = existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+
+const TARGET_ROWS = [
+  "built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-34.js",
+  "built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-4.js",
+] as const;
+
+describe("ES5 standalone getOwnPropertyDescriptor function properties", () => {
+  it("keeps the eval provider demand-gated", async () => {
+    const result = await compile(`export function plainGlobal(): boolean { return globalThis !== null; }`, {
+      allowJs: true,
+      fileName: "es5-standalone-gopd-demand.ts",
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+    });
+    expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+    const imports = WebAssembly.Module.imports(new WebAssembly.Module(result.binary));
+    expect(imports.some((entry) => entry.module === "js2wasm:runtime-eval")).toBe(false);
+  });
+
+  it("keeps both descriptor values real and identity-stable", async () => {
+    const result = await compile(
+      `
+const functionDesc: any = Object.getOwnPropertyDescriptor(Function.prototype, "constructor");
+const evalDesc: any = Object.getOwnPropertyDescriptor(globalThis, "eval");
+export function functionLive(): boolean {
+  return functionDesc !== null && typeof functionDesc.value === "function" &&
+    functionDesc.value === Function.prototype.constructor && functionDesc.value === Function &&
+    functionDesc.writable === true && functionDesc.enumerable === false && functionDesc.configurable === true;
+}
+export function evalLive(): boolean {
+  return evalDesc !== null && typeof evalDesc.value === "function" &&
+    evalDesc.value === globalThis.eval && evalDesc.value === eval &&
+    evalDesc.writable === true && evalDesc.enumerable === false && evalDesc.configurable === true;
+}
+`,
+      {
+        allowJs: true,
+        fileName: "es5-standalone-getownpropertydescriptor.ts",
+        skipSemanticDiagnostics: true,
+        target: "standalone",
+      },
+    );
+    expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+    const instance = await instantiateTest262Module(
+      result.binary,
+      {},
+      {
+        target: "standalone",
+        providerLabel: "es5-standalone-gopd",
+      },
+    );
+    const exports = instance.exports as { functionLive(): number; evalLive(): number };
+    expect({ functionLive: exports.functionLive(), evalLive: exports.evalLive() }).toEqual({
+      functionLive: 1,
+      evalLive: 1,
+    });
+  });
+});
+
+describe.skipIf(!TEST262)("authoritative Test262 rows", () => {
+  for (const rel of TARGET_ROWS) {
+    it(`${rel} passes on standalone`, { timeout: 60_000 }, async () => {
+      const result = await runTest262File(join(TEST262_ROOT, "test", rel), "es5-standalone-gopd", 30_000, "standalone");
+      expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- share the realm-owned Function intrinsic with Function.prototype.constructor descriptors
- seed the demand-gated eval wrapper on the native global object with ES5 attributes
- preserve provider demand gating for programs that do not observe global eval

## Test262 delta

Exact upstream baseline nonpasses flipped: 2/2

- built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-34.js
- built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-4.js

Focused tests also prove descriptor flags, live callable identity, and provider-demand behavior.

## Verification

- exact Test262 rows and nearby controls
- existing Function identity coverage
- TypeScript, Biome, Prettier
- LOC and function budgets
- full normal pre-push hooks: typecheck, lint, format, oracle ratchet, coercion ratchet, issue #3765 18/18, issue integrity

No hooks were bypassed.