### PR TITLE
fix(array): close ES5 standalone filter residuals

### DIFF
--- a/plan/issues/4638-array-element-descriptor-substrate.md
+++ b/plan/issues/4638-array-element-descriptor-substrate.md
@@ -46,6 +46,10 @@ loc-budget-allow:
   #   below the new arm), so the arm is inlined there exactly as the spread arm is.
   - src/codegen/index.ts
   - src/codegen/declarations.ts
+  # The filter result-carrier and open-object guards are the corresponding
+  # residual substrate decisions in the standalone ES5 filter lane.
+  - src/codegen/statements/variables.ts
+  - src/codegen/declarations/object-shape-widening.ts
 func-budget-allow:
   # `compileObjectDefineProperty` +29: the mapped-arguments §10.4.4.2 block gains
   #   the `applyAttributeState` closure and the flag-word computation. Both are
@@ -60,6 +64,7 @@ func-budget-allow:
   #   `moduleInitForcesExternref`, a nested function whose entire job is to list
   #   the reasons a module global must be externref. The list is the function.
   - src/codegen/declarations.ts::collectDeclarations
+  - src/codegen/statements/variables.ts::compileVariableStatement
 ---
 
 # #4638 — array element/descriptor substrate

--- a/src/codegen/array-filter-spec-access.ts
+++ b/src/codegen/array-filter-spec-access.ts
@@ -36,6 +36,7 @@
  *   agree on accessor indices.
  */
 
+import { ts } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { allocLocal } from "./context/locals.js";
@@ -49,6 +50,21 @@ export interface FilterLoopView {
   logicalLenTmp: number;
   iTmp: number;
   getOp: "array.get_u" | "array.get_s" | "array.get";
+}
+
+/**
+ * Whether a filter result can carry a non-number through a typed numeric
+ * receiver and therefore must stay on the dynamic externref carrier at its
+ * binding site. The output widening in `compileArrayFilter` and the slot type
+ * chosen by declarations/variables must agree; otherwise a `number[]` slot
+ * coerces an inherited accessor's string to NaN before the next read.
+ */
+export function filterResultNeedsDynamicCarrier(ctx: CodegenContext, initializer: ts.Expression | undefined): boolean {
+  if (!ctx.standalone || !ctx.protoIndexDirty || !initializer || !ts.isCallExpression(initializer)) return false;
+  if (!ts.isPropertyAccessExpression(initializer.expression) || initializer.expression.name.text !== "filter")
+    return false;
+  const resultFact = ctx.oracle.typeFactOf(initializer);
+  return resultFact.kind === "array" && resultFact.element.kind === "number";
 }
 
 /**
@@ -80,6 +96,14 @@ export interface OverlayFilterAccess {
   hasIdx: Instr[];
   /** `[] → []`: stores the fresh `Get(O, ToString(i))` into the element local. */
   loadElem: Instr[];
+  /**
+   * When a numeric typed lane is widened for an inherited accessor, preserve
+   * the raw JS value as an externref alongside the numeric callback value.
+   * `filter` must store the former in its result: `Get` can produce a string
+   * (or any other non-number) even though the callback's statically typed
+   * parameter is a number.
+   */
+  rawElemLocal?: number;
 }
 
 /**
@@ -98,6 +122,7 @@ export function overlayFilterAccess(
   loop: FilterLoopView,
   elemType: ValType,
   elemLocal: number,
+  rawElemLocal?: number,
 ): OverlayFilterAccess | null {
   if (!overlayRouteActive(ctx)) return null;
   if (elemType.kind !== "f64" && elemType.kind !== "externref") return null;
@@ -140,9 +165,11 @@ export function overlayFilterAccess(
     loadElem: [
       ...idxArg,
       { op: "call", funcIdx: getIdxFn },
+      ...(rawElemLocal === undefined ? [] : ([{ op: "local.tee", index: rawElemLocal }] satisfies Instr[])),
       ...(elemType.kind === "f64" ? ([{ op: "call", funcIdx: unboxFn }] satisfies Instr[]) : []),
       { op: "local.set", index: elemLocal },
     ],
+    ...(rawElemLocal === undefined ? {} : { rawElemLocal }),
   };
 }
 

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -28,6 +28,7 @@ import {
   typedArrayPackedSignedness,
 } from "./index.js";
 import { getClosureFuncSelfTypeIdx, getOrCreateFuncRefWrapperTypes } from "./closures/funcref-wrapper-types.js";
+import { getFuncSignature } from "./closures/funcref-wrapper-types.js";
 import { addStringConstantGlobal, localGlobalIdx } from "./registry/imports.js";
 import { reserveVecMethodHelper } from "./vec-access-exports.js"; // (#4531) extern-receiver push/pop dual-lane
 import { buildThrowJsErrorInstrs, emitThrowTypeError, noJsHost } from "./js-errors.js";
@@ -103,6 +104,7 @@ const {
   isLocalizedJoin,
 } = tls;
 import { emitFuncRefAsClosure } from "./closures/funcref-as-closure.js";
+import { emitRuntimeEvalCarrierUnwrapAny } from "./runtime-eval-callable.js";
 
 // (#3264) Array.prototype-borrow subsystem extracted to array-prototype-borrow.ts;
 // re-export the two public entries so existing importers keep resolving.
@@ -5511,20 +5513,29 @@ function resolveDynamicCallbackClosure(
   // mirrors `compileArrowAsClosure`'s `computeClosureWrapperSig` lowering so the
   // key MATCHES the arrow value-site's — they share the wrapper struct + func
   // type, which is exactly what makes the runtime `ref.cast` + `call_ref` valid.
+  const loweredSig =
+    ts.isIdentifier(cbArg) && ctx.funcMap.get(cbArg.text) !== undefined
+      ? getFuncSignature(ctx, ctx.funcMap.get(cbArg.text)!)
+      : undefined;
   const cbType = ctx.checker.getTypeAtLocation(cbArg);
   const sigs = cbType.getCallSignatures();
-  if (sigs.length !== 1) return undefined;
-  const sig = sigs[0]!;
-  const paramValTypes: ValType[] = [];
-  for (const p of sig.parameters) {
-    const loc = p.valueDeclaration ?? p.declarations?.[0] ?? cbArg;
-    paramValTypes.push(resolveWasmType(ctx, ctx.checker.getTypeOfSymbolAtLocation(p, loc)));
-  }
-  const retTsType = ctx.checker.getReturnTypeOfSignature(sig);
-  const results: ValType[] =
-    isVoidType(retTsType) || (retTsType.flags & ts.TypeFlags.Never) !== 0
-      ? []
-      : [resolveWasmTypeForClosureReturn(ctx, retTsType)];
+  if (loweredSig === undefined && sigs.length !== 1) return undefined;
+  const paramValTypes: ValType[] = loweredSig
+    ? loweredSig.params.map((param) => ({ ...param }))
+    : sigs[0]!.parameters.map((p) =>
+        resolveWasmType(
+          ctx,
+          ctx.checker.getTypeOfSymbolAtLocation(p, p.valueDeclaration ?? p.declarations?.[0] ?? cbArg),
+        ),
+      );
+  const results: ValType[] = loweredSig
+    ? loweredSig.results.map((result) => ({ ...result }))
+    : (() => {
+        const retTsType = ctx.checker.getReturnTypeOfSignature(sigs[0]!);
+        return isVoidType(retTsType) || (retTsType.flags & ts.TypeFlags.Never) !== 0
+          ? []
+          : [resolveWasmTypeForClosureReturn(ctx, retTsType)];
+      })();
   const wrapper = getOrCreateFuncRefWrapperTypes(ctx, paramValTypes, results);
   if (!wrapper) return undefined;
   const selfStructTypeIdx = getClosureFuncSelfTypeIdx(ctx, wrapper.liftedFuncTypeIdx) ?? wrapper.structTypeIdx;
@@ -5593,6 +5604,7 @@ function setupArrayCallback(
       // `call_ref` self argument, whose param type is `(ref root)` — non-null,
       // matching the arrow branch's `(ref …)` `closureTmp`.
       fctx.body.push({ op: "any.convert_extern" });
+      emitRuntimeEvalCarrierUnwrapAny(ctx, fctx);
       emitGuardedRefCast(fctx, dyn.selfStructTypeIdx);
       fctx.body.push({ op: "ref.as_non_null" });
       closureTmp = allocLocal(fctx, `__arr_${tag}_dyncb_${fctx.locals.length}`, {
@@ -6330,7 +6342,6 @@ function compileArrayFilter(
   const setup = setupArrayCallback(ctx, fctx, callExpr, "filter", "flt", undefined, 1);
   if (!setup) return null;
 
-  const resData = allocLocal(fctx, `__arr_flt_rd_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const resLen = allocLocal(fctx, `__arr_flt_rl_${fctx.locals.length}`, { kind: "i32" });
   const elemTmp = allocLocal(fctx, `__arr_flt_el_${fctx.locals.length}`, elemType);
 
@@ -6339,10 +6350,23 @@ function compileArrayFilter(
   // §15.4.4.20 step 3: `len` is captured ONCE — see array-filter-spec-access.ts
   // for why the overlay route walks the LOGICAL length and the dense route the
   // #3215 backing-clamped one. Result capacity = one push per visited index.
-  const overlay = overlayFilterAccess(ctx, fctx, loop, elemType, elemTmp);
+  const rawOverlayElemLocal =
+    elemType.kind === "f64" && ctx.protoIndexDirty
+      ? allocLocal(fctx, `__arr_flt_raw_${fctx.locals.length}`, { kind: "externref" })
+      : undefined;
+  const overlay = overlayFilterAccess(ctx, fctx, loop, elemType, elemTmp, rawOverlayElemLocal);
+  const resultVecTypeIdx =
+    overlay?.rawElemLocal === undefined ? vecTypeIdx : getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+  const resultArrTypeIdx =
+    overlay?.rawElemLocal === undefined ? arrTypeIdx : getArrTypeIdxFromVec(ctx, resultVecTypeIdx);
+  const resultElemLocal = overlay?.rawElemLocal ?? elemTmp;
+  const resData = allocLocal(fctx, `__arr_flt_rd_${fctx.locals.length}`, {
+    kind: "ref_null",
+    typeIdx: resultArrTypeIdx,
+  });
   const boundTmp = overlay ? loop.logicalLenTmp : loop.lenTmp;
   fctx.body.push({ op: "local.get", index: boundTmp });
-  fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "array.new_default", typeIdx: resultArrTypeIdx });
   fctx.body.push({ op: "local.set", index: resData });
 
   fctx.body.push({ op: "i32.const", value: 0 });
@@ -6375,8 +6399,8 @@ function compileArrayFilter(
       then: [
         { op: "local.get", index: resData },
         { op: "local.get", index: resLen },
-        { op: "local.get", index: elemTmp },
-        { op: "array.set", typeIdx: arrTypeIdx },
+        { op: "local.get", index: resultElemLocal },
+        { op: "array.set", typeIdx: resultArrTypeIdx },
         { op: "local.get", index: resLen },
         { op: "i32.const", value: 1 },
         { op: "i32.add" },
@@ -6392,8 +6416,8 @@ function compileArrayFilter(
   fctx.body.push({ op: "local.get", index: resLen });
   fctx.body.push({ op: "local.get", index: resData });
   fctx.body.push({ op: "ref.as_non_null" });
-  fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx });
-  return { kind: "ref_null", typeIdx: vecTypeIdx };
+  fctx.body.push({ op: "struct.new", typeIdx: resultVecTypeIdx });
+  return { kind: "ref_null", typeIdx: resultVecTypeIdx };
 }
 
 /**

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -51,6 +51,7 @@ import {
 import { nativeTypeFromTypeNode, nativeTypeOfDeclaration } from "./native-type-annotations.js";
 import { widenMixedUndefinedReturn } from "./mixed-return-widening.js"; // (#4641) `T | undefined` return slots
 import { concatCallYieldsDynamicCarrier } from "./array-concat-carrier.js"; // (#4655) concat result-slot carrier
+import { filterResultNeedsDynamicCarrier } from "./array-filter-spec-access.js";
 import { addFunctionOwnLocals } from "../ir/analysis/binding-info.js"; // (#2103) memoized own-locals oracle
 import { dedupeDiagnosticsFrom, reportError } from "./context/errors.js";
 import type { CodegenContext, FunctionContext, OptionalParamInfo } from "./context/types.js";
@@ -2359,6 +2360,14 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
    * let/const pass so both scopes register the same type.
    */
   function moduleGlobalWasmType(decl: ts.VariableDeclaration, varType: ts.Type): ValType {
+    // (#ES5 filter residual) A typed numeric filter can observe an inherited
+    // accessor whose Get result is not numeric.  The filter lowering keeps the
+    // callback's f64 ABI but widens its result vec to externref so that value
+    // survives the module-global store.  Keep the receiving binding on the
+    // same dynamic carrier; otherwise the checker-inferred number[] slot
+    // immediately coerces the heterogeneous result back to f64 ("prototype"
+    // becomes NaN) before the next read.
+    if (filterResultNeedsDynamicCarrier(ctx, decl.initializer)) return { kind: "externref" };
     // (#4222 ES5 residual) The bounded sized-Array carrier is a nominal
     // subtype of the ordinary externref vec.  Module globals need the same
     // concrete slot as function-local bindings; otherwise the initializer can

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -2233,6 +2233,15 @@ export function applyShapeInference(ctx: CodegenContext, checker: ts.TypeChecker
     const globalIdx = ctx.moduleGlobals.get(varName);
     if (globalIdx === undefined) continue;
 
+    // Standalone accessor/MOP analysis deliberately keeps these receivers on
+    // the identity-bearing open-object carrier.  Shape inference runs after
+    // that analysis and used to overwrite the decision for a plain `{}` whose
+    // accessor body happened to write a numeric key (for example the
+    // self-writing `length` getter in Array.prototype.filter's generic
+    // receiver tests).  A vec has Array-exotic `length` semantics, so applying
+    // the shape here makes the accessor define throw before filter runs.
+    if (ctx.objectHashConsumerVars.has(varName) || ctx.growableObjectLiteralVars.has(varName)) continue;
+
     // Determine element type for the vec struct from the shape's numeric value type
     let elemType: ValType;
     let elemKey: string;

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -15,6 +15,7 @@ import { needsTdzFlag, resolveWasmType, varBindingNeedsExternrefForUndefined } f
 import { nativeTypeOfDeclaration } from "../native-type-annotations.js";
 import { widenedVarKeyFromDecl } from "../widened-var-key.js";
 import { concatCallYieldsDynamicCarrier } from "../array-concat-carrier.js"; // (#4655) concat result-slot carrier
+import { filterResultNeedsDynamicCarrier } from "../array-filter-spec-access.js";
 import { emitShapeInferredVecInit } from "../shape-vec-literal-seed.js"; // (#4491) module-global array-carrier seed
 import {
   arrayLiteralEscapeWidensToExternref,
@@ -1854,6 +1855,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       arrayLiteralEscapeWidensToExternref(ctx, decl.initializer)
         ? { kind: "ref_null", typeIdx: getOrRegisterVecType(ctx, "externref", { kind: "externref" }) }
         : undefined;
+    const filterResultDynamicCarrier = filterResultNeedsDynamicCarrier(ctx, decl.initializer);
     const wasmTypeBase: ValType =
       // (#3123) A widened fnctor-subclass binding (pre-hoist recorded it in
       // `fnctorWidenedLocals` — reassigned with a foreign/host value) must
@@ -1885,40 +1887,42 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
                           ? { kind: "ref_null" as const, typeIdx: getOrRegisterVecType(ctx, "i32", { kind: "i32" }) }
                           : widenedTypeIdx !== undefined
                             ? { kind: "ref_null" as const, typeIdx: widenedTypeIdx }
-                            : (escapeWidenedVecType ??
-                              taViewType ??
-                              subarraySubviewType ??
-                              inferredVecType ??
-                              standaloneRegExpMatchArrayType ??
-                              // (#4655) `var arr = x.concat(y, z)` — the concat
-                              // lowering yields a dynamic `$ObjVec` externref
-                              // for these shapes while the checker types the
-                              // binding `number[]` from the lib signature; the
-                              // vec-typed slot ToNumber'd every non-numeric
-                              // element to NaN. Same predicate the lowering's
-                              // dispatcher asks (array-concat-carrier.ts), so
-                              // slot and value cannot disagree.
-                              (concatCallYieldsDynamicCarrier(ctx, decl.initializer)
-                                ? { kind: "externref" as const }
-                                : decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)
+                            : filterResultDynamicCarrier
+                              ? { kind: "externref" as const }
+                              : (escapeWidenedVecType ??
+                                taViewType ??
+                                subarraySubviewType ??
+                                inferredVecType ??
+                                standaloneRegExpMatchArrayType ??
+                                // (#4655) `var arr = x.concat(y, z)` — the concat
+                                // lowering yields a dynamic `$ObjVec` externref
+                                // for these shapes while the checker types the
+                                // binding `number[]` from the lib signature; the
+                                // vec-typed slot ToNumber'd every non-numeric
+                                // element to NaN. Same predicate the lowering's
+                                // dispatcher asks (array-concat-carrier.ts), so
+                                // slot and value cannot disagree.
+                                (concatCallYieldsDynamicCarrier(ctx, decl.initializer)
                                   ? { kind: "externref" as const }
-                                  : decl.initializer && isPromiseHostCall(ctx, decl.initializer)
+                                  : decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)
                                     ? { kind: "externref" as const }
-                                    : // (#2615/#4397) Proxy and revocable-handle results are
-                                      // externref carriers in both provider profiles. A
-                                      // checker-derived struct slot would cast them to null
-                                      // before their MOP/result fields can be observed.
-                                      initIsProxy
+                                    : decl.initializer && isPromiseHostCall(ctx, decl.initializer)
                                       ? { kind: "externref" as const }
-                                      : // (#1337/#4397) In a JS environment, both the
-                                        // compatibility exotic and native `$__bound_fn`
-                                        // are externref carriers, never the target struct.
-                                        decl.initializer &&
-                                          !ctx.standalone &&
-                                          !noJsHost(ctx) &&
-                                          isBindCarrierCall(decl.initializer)
+                                      : // (#2615/#4397) Proxy and revocable-handle results are
+                                        // externref carriers in both provider profiles. A
+                                        // checker-derived struct slot would cast them to null
+                                        // before their MOP/result fields can be observed.
+                                        initIsProxy
                                         ? { kind: "externref" as const }
-                                        : localTypeForDeclaration(ctx, varType, decl)));
+                                        : // (#1337/#4397) In a JS environment, both the
+                                          // compatibility exotic and native `$__bound_fn`
+                                          // are externref carriers, never the target struct.
+                                          decl.initializer &&
+                                            !ctx.standalone &&
+                                            !noJsHost(ctx) &&
+                                            isBindCarrierCall(decl.initializer)
+                                          ? { kind: "externref" as const }
+                                          : localTypeForDeclaration(ctx, varType, decl)));
     // (#2660 S3b) A provably-monomorphic `new F(...)` binding of an approved
     // fnctor gets the reserved struct slot instead of externref. Same (cached)
     // verdict as the var hoister / let-const pre-hoister, so a reused
@@ -2104,6 +2108,12 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
         // is the same "undefined" sentinel a hoisted externref would carry
         // before its first assignment).
         if (initIsAccessorLiteral && existingIsRef && wasmType.kind === "externref") {
+          localSlot.type = wasmType;
+        } else if (filterResultDynamicCarrier && existingIsRef && wasmType.kind === "externref") {
+          // A typed numeric filter can widen its result when an inherited
+          // accessor returns a non-number. Its pre-hoisted number[] slot is
+          // safe to narrow to externref because the hoister emits no value
+          // initialization before this declaration.
           localSlot.type = wasmType;
         } else if (initIsProxy && existingIsRef && wasmType.kind === "externref") {
           // (#2615) A `const p = new Proxy(...)` was pre-hoisted as the target's

--- a/tests/es5-standalone-array-filter.test.ts
+++ b/tests/es5-standalone-array-filter.test.ts
@@ -27,9 +27,12 @@
 // The presence gate is unconditional (both lanes); the overlay-aware element
 // read is gated on the #4159 `vecAccessorDescriptorDirty` pre-scan flag, so a
 // module that never installs a non-data descriptor keeps the dense kernel.
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { join } from "node:path";
 import { compile } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
+import { resetTest262RuntimeEvalProviderForTest } from "../scripts/test262-import-object.mjs";
+import { runTest262File } from "./test262-runner.js";
 
 async function run(src: string, target: "standalone" | "gc"): Promise<unknown> {
   const opts = target === "standalone" ? { target: "standalone" as const } : {};
@@ -46,6 +49,37 @@ async function bothLanes(src: string, expected: unknown): Promise<void> {
   expect(await run(src, "standalone"), "standalone").toStrictEqual(expected);
   expect(await run(src, "gc"), "gc").toStrictEqual(expected);
 }
+
+const FILTER_TEST262_ROOT = join(process.cwd(), "test262", "test", "built-ins", "Array", "prototype", "filter");
+const EXACT_ES5_FILTER_ROWS = ["15.4.4.20-5-7.js", "15.4.4.20-9-b-2.js", "15.4.4.20-9-b-15.js"] as const;
+
+describe("§15.4.4.20 exact ES5 standalone residual rows", () => {
+  const previousEvalEngine = process.env.JS2WASM_EVAL_ENGINE;
+  beforeAll(() => {
+    // The exact 5-7 row reaches eval as a callback thisArg. Pin this small
+    // ratchet to the refusal/interpreter provider so a developer checkout
+    // without the optional QuickJS artifact cannot turn it into a link error.
+    process.env.JS2WASM_EVAL_ENGINE = "interpreter";
+    resetTest262RuntimeEvalProviderForTest();
+  });
+  afterAll(() => {
+    if (previousEvalEngine === undefined) Reflect.deleteProperty(process.env, "JS2WASM_EVAL_ENGINE");
+    else process.env.JS2WASM_EVAL_ENGINE = previousEvalEngine;
+    resetTest262RuntimeEvalProviderForTest();
+  });
+
+  for (const file of EXACT_ES5_FILTER_ROWS) {
+    it(`passes the literal Test262 row ${file}`, async () => {
+      const result = await runTest262File(
+        join(FILTER_TEST262_ROOT, file),
+        "built-ins/Array/prototype/filter",
+        120_000,
+        "standalone",
+      );
+      expect(result.status, result.error ?? file).toBe("pass");
+    }, 180_000);
+  }
+});
 
 describe("§15.4.4.20 filter — HasProperty is re-evaluated per index", () => {
   it("skips indices a callback removed by shrinking .length (test262 15.4.4.20-9-4)", async () => {

--- a/tests/issue-4638.test.ts
+++ b/tests/issue-4638.test.ts
@@ -20,6 +20,7 @@
 // message, so a combined script would report "something threw" and nothing more.
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
+import { instantiateTest262Module, resetTest262RuntimeEvalProviderForTest } from "../scripts/test262-import-object.mjs";
 
 const OPTS = {
   fileName: "test.js",
@@ -35,6 +36,28 @@ async function runScript(src: string): Promise<void> {
   expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
   const { instance } = await WebAssembly.instantiate(r.binary, {});
   (instance.exports as { __module_init?: () => void }).__module_init?.();
+}
+
+/** Same script probe, with the refusal provider attached for eval-value rows. */
+async function runRuntimeEvalScript(src: string): Promise<void> {
+  const previousEvalEngine = process.env.JS2WASM_EVAL_ENGINE;
+  process.env.JS2WASM_EVAL_ENGINE = "interpreter";
+  resetTest262RuntimeEvalProviderForTest();
+  try {
+    const r = await compile(src, OPTS);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+    const instance = await instantiateTest262Module(
+      r.binary,
+      {},
+      { target: "standalone", providerLabel: "issue-4638" },
+    );
+    (instance.exports as { __module_init?: () => void }).__module_init?.();
+  } finally {
+    if (previousEvalEngine === undefined) Reflect.deleteProperty(process.env, "JS2WASM_EVAL_ENGINE");
+    else process.env.JS2WASM_EVAL_ENGINE = previousEvalEngine;
+    resetTest262RuntimeEvalProviderForTest();
+  }
 }
 
 /** Compile a module and return its exported `test()` result. */
@@ -238,7 +261,7 @@ describe("#4638 measured residuals", () => {
   // `$__vec_externref` an ordinary array uses. See the issue's Residuals section
   // for the `$__holey_array` subtype sketch and why it is not taken here.
   // test262: built-ins/Array/isArray/15.4.3.2-1-13.js
-  it.fails("answers false for Array.isArray(arguments)", async () => {
+  it("answers false for Array.isArray(arguments)", async () => {
     await runScript(`
       var arg;
       (function fun() { arg = arguments; }(1, 2, 3));
@@ -247,7 +270,7 @@ describe("#4638 measured residuals", () => {
   });
 
   // test262: language/arguments-object/10.6-6-2.js
-  it.fails("reports arguments.length as configurable", async () => {
+  it("reports arguments.length as configurable", async () => {
     await runScript(`
       (function () {
         var d = Object.getOwnPropertyDescriptor(arguments, "length");
@@ -256,12 +279,12 @@ describe("#4638 measured residuals", () => {
     `);
   });
 
-  // `eval` reachable as a VALUE in the module turns on the runtime-eval boundary
-  // and the filter callback dispatch null-derefs. `parseInt` in the same position
-  // is fine. Owner: the runtime-eval boundary lane (#4442 / eval-inline.ts).
+  // `eval` reachable as a VALUE in the module turns on the runtime-eval boundary.
+  // The filter callback now unwraps that boundary's AOT carrier before its
+  // in-module call_ref dispatch (runtime-eval boundary lane #4442).
   // test262: built-ins/Array/prototype/filter/15.4.4.20-5-7.js
-  it.fails("passes eval as a filter thisArg", async () => {
-    await runScript(`
+  it("passes eval as a filter thisArg", async () => {
+    await runRuntimeEvalScript(`
       function cb(val, idx, obj) { return true; }
       var out = [11].filter(cb, eval);
       if (out[0] !== 11) { throw new Error("out[0]"); }


### PR DESCRIPTION
## Summary

- preserve inherited accessor values through numeric filter result lanes
- keep open-object descriptor receivers out of array-shape inference
- unwrap runtime-eval callback carriers before standalone call_ref dispatch
- add exact Test262 pins and refresh measured #4638 expectations

## Test262 delta

Exact clean-upstream baseline nonpasses flipped: 3/3

- built-ins/Array/prototype/filter/15.4.4.20-5-7.js
- built-ins/Array/prototype/filter/15.4.4.20-9-b-2.js
- built-ins/Array/prototype/filter/15.4.4.20-9-b-15.js

Focused suites: 27/27. Full filter category: 203/242 with 39 known residuals; b-14 and b-16 remain owned by PR #4895.

## Verification

- TS5 and TS7
- lint and formatting
- oracle, LOC/function, IR, stack, fallback, coercion, and structural gates
- full normal pre-push hooks: typecheck, lint, format, oracle ratchet, coercion ratchet, issue #3765 18/18, issue integrity

The godfile profiler still reports pre-existing upstream baseline regressions, with no newly affected function. No hooks were bypassed.