### PR TITLE
fix(#4689): support direct string yield-star delegation

### DIFF
--- a/plan/issues/4689-es2015-generator-yield-residual.md
+++ b/plan/issues/4689-es2015-generator-yield-residual.md
@@ -1,0 +1,180 @@
+---
+id: 4689
+title: "ES2015 standalone generator-yield residual"
+status: in-progress
+created: 2026-08-25
+updated: 2026-08-25
+priority: high
+depends_on: []
+es_edition: es2015
+language_feature: generators-yield
+task_type: bug
+files:
+  - src/codegen/generators-native.ts
+  - src/codegen/generators-native-consumer.ts
+  - tests/issue-4689.test.ts
+loc-budget-allow:
+  - src/codegen/generators-native.ts
+func-budget-allow:
+  - src/codegen/generators-native.ts::compileState
+---
+
+# #4689 — ES2015 standalone generator-yield residual
+
+## Scope and baseline record
+
+The authoritative artifact is
+`/private/tmp/js2-es6-functionproto-wave3/.test262-cache/test262-standalone-current.jsonl`
+(oracle version 13, honest lane, generated 2026-08-25). Filtering to the ES2015
+`test/language/expressions/yield/` directory gives **52 non-pass rows**:
+
+- **49 `compile_error/other`** rows, all refusing with the native-generator
+  lowering diagnostic `#680` (complex/non-numeric yield shape).
+- **3 `fail/assertion_fail`** rows: `rhs-yield.js`, `star-string.js`, and
+  `rhs-unresolvable.js`.
+
+Exact 52-row list (status is the artifact status):
+
+### 49 compile refusals (`#680`)
+
+1. `test/language/expressions/yield/star-iterable.js`
+2. `test/language/expressions/yield/star-rhs-iter-thrw-thrw-call-non-obj.js`
+3. `test/language/expressions/yield/rhs-regexp.js`
+4. `test/language/expressions/yield/star-rhs-iter-rtrn-res-value-final.js`
+5. `test/language/expressions/yield/from-with.js`
+6. `test/language/expressions/yield/star-rhs-iter-thrw-violation-no-rtrn.js`
+7. `test/language/expressions/yield/star-rhs-iter-rtrn-rtrn-invoke.js`
+8. `test/language/expressions/yield/star-rhs-iter-thrw-res-value-final.js`
+9. `test/language/expressions/yield/star-rhs-iter-nrml-res-done-no-value.js`
+10. `test/language/expressions/yield/star-rhs-iter-rtrn-no-rtrn.js`
+11. `test/language/expressions/yield/star-rhs-iter-nrml-next-call-err.js`
+12. `test/language/expressions/yield/in-rltn-expr.js`
+13. `test/language/expressions/yield/star-rhs-iter-rtrn-rtrn-get-err.js`
+14. `test/language/expressions/yield/star-return-is-null.js`
+15. `test/language/expressions/yield/star-rhs-iter-rtrn-rtrn-call-non-obj.js`
+16. `test/language/expressions/yield/star-rhs-iter-thrw-violation-rtrn-invoke.js`
+17. `test/language/expressions/yield/star-rhs-iter-nrml-next-invoke.js`
+18. `test/language/expressions/yield/star-rhs-iter-nrml-res-value-final.js`
+19. `test/language/expressions/yield/star-rhs-iter-rtrn-res-value-err.js`
+20. `test/language/expressions/yield/formal-parameters-after-reassignment-non-strict.js`
+21. `test/language/expressions/yield/star-rhs-iter-thrw-thrw-invoke.js`
+22. `test/language/expressions/yield/star-rhs-iter-thrw-violation-rtrn-call-err.js`
+23. `test/language/expressions/yield/star-rhs-iter-get-get-err.js`
+24. `test/language/expressions/yield/star-rhs-iter-rtrn-res-done-no-value.js`
+25. `test/language/expressions/yield/star-rhs-iter-nrml-res-value-err.js`
+26. `test/language/expressions/yield/rhs-omitted.js`
+27. `test/language/expressions/yield/rhs-template-middle.js`
+28. `test/language/expressions/yield/star-rhs-iter-nrml-res-done-err.js`
+29. `test/language/expressions/yield/arguments-object-attributes.js`
+30. `test/language/expressions/yield/iter-value-unspecified.js`
+31. `test/language/expressions/yield/star-rhs-iter-nrml-next-get-err.js`
+32. `test/language/expressions/yield/star-rhs-iter-nrml-next-call-non-obj.js`
+33. `test/language/expressions/yield/star-rhs-iter-thrw-violation-rtrn-get-err.js`
+34. `test/language/expressions/yield/star-rhs-unresolvable.js`
+35. `test/language/expressions/yield/star-rhs-iter-get-call-err.js`
+36. `test/language/expressions/yield/star-rhs-iter-rtrn-res-done-err.js`
+37. `test/language/expressions/yield/star-in-rltn-expr.js`
+38. `test/language/expressions/yield/star-rhs-iter-thrw-violation-rtrn-call-non-obj.js`
+39. `test/language/expressions/yield/formal-parameters-after-reassignment-strict.js`
+40. `test/language/expressions/yield/star-throw-is-null.js`
+41. `test/language/expressions/yield/iter-value-specified.js`
+42. `test/language/expressions/yield/rhs-primitive.js`
+43. `test/language/expressions/yield/star-rhs-iter-thrw-thrw-call-err.js`
+44. `test/language/expressions/yield/star-rhs-iter-thrw-res-done-no-value.js`
+45. `test/language/expressions/yield/star-rhs-iter-rtrn-rtrn-call-err.js`
+46. `test/language/expressions/yield/star-rhs-iter-thrw-thrw-get-err.js`
+47. `test/language/expressions/yield/star-rhs-iter-thrw-res-done-err.js`
+48. `test/language/expressions/yield/star-rhs-iter-get-call-non-obj.js`
+49. `test/language/expressions/yield/star-rhs-iter-thrw-res-value-err.js`
+
+### 3 runtime failures
+
+| Artifact status | File | Observed error |
+| --- | --- | --- |
+| `fail/assertion_fail` | `test/language/expressions/yield/rhs-yield.js` | First result `value`: actual `undefined`, expected `1` |
+| `fail/assertion_fail` | `test/language/expressions/yield/star-string.js` | First result `value`: actual `NaN`, expected `"a"` |
+| `fail/assertion_fail` | `test/language/expressions/yield/rhs-unresolvable.js` | `typeof err` actual `"undefined"`, expected `"object"` |
+
+## Selected bounded cohort
+
+This issue selects the single direct-string delegation row
+`test/language/expressions/yield/star-string.js` (1 row) as the first coherent
+slice. It exercises the existing native `yield*` delegation machinery with the
+already-implemented native string character-vector runtime. The other 51 rows
+remain explicitly out of scope: nested-yield evaluation, unresolvable-reference
+throw timing, arbitrary custom-iterator completion/abrupt protocol, and the
+remaining #680 shape refusals each require separate mechanisms.
+
+Measured baseline on the artifact: `star-string.js` is a runtime failure with
+`result.value === NaN` on the first `next()`, not a compile refusal. The current
+plan only admits numeric-vector and generic iterable delegation; it does not
+classify a string operand as a native delegation source, and the generic arm's
+externref-to-f64 conversion would be wrong for string characters even if the
+source were admitted. After the carrier fix, the exact pin exposed the same
+string result struct's terminal null ref being surfaced as JS `null` instead of
+the required `undefined`; that is part of this row's result-value contract.
+
+## Root-cause hypothesis
+
+`buildNativeGeneratorPlan` (`src/codegen/generators-native.ts`) derives an f64
+result carrier for a generator containing only `yield* 'abc'`. The delegation
+classifier does not recognize the native string type, while the native iterator
+runtime already has `__str_to_char_vec` support. Consequently the generated
+state machine does not carry string elements as native strings; the yielded
+character is converted through the numeric path and appears as `NaN`. Once the
+string carrier is admitted, `buildOpenResultValueReadExtern` in
+`generators-native-consumer.ts` must also map its nullable terminal ref through
+the canonical undefined producer; `extern.convert_any(null)` otherwise exposes
+JS `null` for the final `.value` read.
+
+## Implementation plan
+
+1. Add a narrow native-string `yield*` classification using the existing
+   `__str_to_char_vec` geometry; keep arbitrary strings/objects and custom
+   iterator protocol on the existing refusal path.
+2. Carry the string element/result type through the existing delegation state
+   without changing numeric or boxed-any generator carriers.
+3. Canonicalize nullable native-string result refs as `undefined` on dynamic
+   `.value` reads while preserving non-null yielded characters.
+4. Add an exact `runTest262File(..., "standalone")` pin for `star-string.js` and
+   baseline-pass controls from the same yield directory. Include a zero-host-
+   import check for the admitted native string path via the standalone runner.
+
+## Risks and non-goals
+
+- Do not admit `yield*` over arbitrary objects, `any`, or custom iterators in
+  this slice; those remain in the 49-row #680 cohort.
+- Do not alter nested-yield evaluation (`rhs-yield.js`) or unresolvable reference
+  handling (`rhs-unresolvable.js`).
+- Preserve the existing f64 numeric and externref generic delegation paths.
+- Keep source changes below ~150 lines and confined to the generator native
+  lowering/consumer plus its focused regression test.
+
+## Acceptance criteria
+
+- `star-string.js` passes through `runTest262File(file, "issue-4689", ..., "standalone")`.
+- At least one baseline-pass yield control remains passing through the same
+  runner, and no host imports are emitted for the admitted string delegation.
+- The other two runtime failures and all 49 compile refusals remain honest and
+  are not pinned as passes by this issue.
+- Typecheck, focused tests, and normal prepush checks pass.
+
+## Intended files
+
+- `src/codegen/generators-native.ts`
+- `src/codegen/generators-native-consumer.ts`
+- `tests/issue-4689.test.ts`
+
+## Test Results
+
+- Baseline artifact (2026-08-25, oracle 13): `star-string.js` was
+  `fail/assertion_fail`, first delegated value `NaN` instead of `"a"`;
+  the final value path was not reached correctly either.
+- Focused issue suite after the fix: **4/4 passed** — exact `star-string.js`,
+  baseline-pass `star-array.js` and `rhs-iter.js`, and a direct compile/runtime
+  control asserting zero WebAssembly imports and a character count of 3.
+- Existing generator controls: **23/23 passed** across
+  `issue-2171-string-yields.test.ts` and `issue-2173-yieldstar-array.test.ts`.
+- Source changes are 21 lines in the native planner and 21 lines in the native
+  result consumer; no arbitrary/custom iterator or other residual row is
+  admitted.

--- a/plan/issues/4689-es2015-generator-yield-residual.md
+++ b/plan/issues/4689-es2015-generator-yield-residual.md
@@ -1,7 +1,8 @@
 ---
 id: 4689
 title: "ES2015 standalone generator-yield residual"
-status: in-progress
+status: done
+completed: 2026-08-25
 created: 2026-08-25
 updated: 2026-08-25
 priority: high

--- a/src/codegen/generators-native-consumer.ts
+++ b/src/codegen/generators-native-consumer.ts
@@ -846,9 +846,24 @@ function buildOpenResultValueReadExtern(
       return [...read, ...toF64, ...sentinelAwareF64BoxInstrs(f64Scratch, boxNumberIdx, undefInstrs)];
     }
     // ref/ref_null elem (native string / struct): wrap to externref. A null
-    // ref (the done default) converts to the null externref = canonical
-    // undefined.
-    return [...read, { op: "extern.convert_any" }];
+    // ref (the done default) must use the lane's canonical undefined value;
+    // `extern.convert_any(null)` is the JS value `null`, not `undefined`.
+    const refType = e.elemValType as { kind: "ref" | "ref_null"; typeIdx: number };
+    const refLocal = allocLocal(fctx, `__gen_ref_value_${fctx.locals.length}`, {
+      kind: "ref_null",
+      typeIdx: refType.typeIdx,
+    });
+    return [
+      ...read,
+      { op: "local.tee", index: refLocal },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: externVT },
+        then: [...undefInstrs],
+        else: [{ op: "local.get", index: refLocal }, { op: "extern.convert_any" }],
+      },
+    ];
   };
 
   // (#3505) No-match tail: under a JS host, a LEGACY (eager-buffer) generator's

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -363,7 +363,7 @@ function isStringYieldExpression(ctx: CodegenContext, expr: ts.Expression | unde
  * the body (not descending into nested functions).
  *
  *  - all-numeric (or zero-yield) → `{kind:"f64"}` (the historical fast path);
- *  - all-string → the native `$AnyString` ref (#2171);
+ *  - all-string (including a direct `yield*` string) → the native `$AnyString` ref (#2171);
  *  - anything else (object yields, or a MIX of numeric/string/object) →
  *    `{kind:"externref"}`, the universal boxed-`any` carrier (#2864 F1). Every
  *    JS value coerces to externref host-free in standalone/WASI (numbers via the
@@ -383,8 +383,14 @@ function generatorElemValType(ctx: CodegenContext, decl: GeneratorDecl): ValType
     if (isFunctionLikeScope(node)) {
       return; // a yield here belongs to an inner generator
     }
-    if (ts.isYieldExpression(node) && !node.asteriskToken) {
-      if (isNumericExpression(ctx, node.expression)) sawNumeric = true;
+    if (ts.isYieldExpression(node)) {
+      // A direct `yield* "abc"` is lowered by the generic iterable cursor,
+      // whose values are native strings in the standalone iterator runtime.
+      // Include that operand in the carrier decision; otherwise the generator
+      // defaults to f64 and each delegated character becomes NaN.
+      if (node.asteriskToken) {
+        if (isStringYieldExpression(ctx, node.expression)) sawString = true;
+      } else if (isNumericExpression(ctx, node.expression)) sawNumeric = true;
       else if (isStringYieldExpression(ctx, node.expression)) sawString = true;
       else sawOther = true;
     }
@@ -900,12 +906,12 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
         // (#2173 slice-2b) Not a native-gen call nor a numeric vec — try a
         // GENERIC iterable (`yield* arr.values()`, `yield* customIterable`).
         // Driven by the standalone-native `__iterator`/`__iterator_next` runtime
-        // (#2038) → zero host imports. Same STRING-outer bail as the other arms:
-        // the iterator value rides externref and re-yields through the OUTER
+        // (#2038) → zero host imports. The iterator value rides externref and re-yields through the OUTER
         // result struct's `value` field; an f64 outer unboxes it and a boxed-any
-        // outer passes it through, but a concrete-ref (string) outer has no
-        // repair seam — bail to the host path (the clean #680 refusal).
-        if (!elemIsString && isGenericIterableDelegate(ctx, subject)) {
+        // outer passes it through. A direct string operand is the one concrete
+        // ref case supported here: the iterator runtime returns native-string
+        // refs, and the emitter casts the externref back to that ref below.
+        if ((!elemIsString || isStringYieldExpression(ctx, subject)) && isGenericIterableDelegate(ctx, subject)) {
           // (#2864 R1) `const x = yield* it` — the delegation completion value
           // (§27.5.3.7) is the iterator's done-result `value`; for the common
           // array/`.values()` shape that is `undefined`. The done-arm delivers
@@ -3620,8 +3626,8 @@ function compileState(
         }
 
         // Re-yielded value: unbox the externref `value` to the OUTER element type
-        // (f64 outer → native `__unbox_number` via coerceType; boxed-any outer →
-        // pass through). String outers bailed in `emitYield`.
+        // (f64 outer → native `__unbox_number`; string outer → guarded native
+        // string ref cast; boxed-any outer → pass through).
         const valueInstrs: Instr[] = [];
         {
           const savedC = fctx.body;
@@ -3629,6 +3635,8 @@ function compileState(
           fctx.body.push({ op: "local.get", index: valueLocal });
           if (info.elemValType.kind === "f64") {
             coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" }, "number");
+          } else if (info.elemValType.kind === "ref" || info.elemValType.kind === "ref_null") {
+            coerceType(ctx, fctx, { kind: "externref" }, info.elemValType);
           }
           fctx.body = savedC;
         }

--- a/tests/issue-4689.test.ts
+++ b/tests/issue-4689.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4689 — the direct-string `yield*` residual in ES2015 standalone.
+ *
+ * The exact Test262 row exercises each delegated character and the terminal
+ * `{ value: undefined, done: true }` result. The two green rows are controls
+ * for the existing numeric-vec and generic-iterable delegation paths.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_ROOT = join(__dirname, "..", "test262");
+const HAS_TEST262 = existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+
+afterEach(async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
+function pinRow(rel: string, note: string): void {
+  it(`${rel} — ${note}`, { timeout: 60_000 }, async () => {
+    const file = join(TEST262_ROOT, "test", rel);
+    const result = await runTest262File(file, "issue-4689", 30_000, "standalone");
+    expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+  });
+}
+
+describe.skipIf(!HAS_TEST262)("#4689 — standalone generator yield* pins", () => {
+  pinRow(
+    "language/expressions/yield/star-string.js",
+    "direct string delegation preserves each character and the terminal result",
+  );
+
+  // Baseline-pass controls: these exercise the numeric vec and generic
+  // iterable delegation arms that the string-specific gate must preserve.
+  pinRow("language/expressions/yield/star-array.js", "numeric vec delegation remains green");
+  pinRow("language/expressions/yield/rhs-iter.js", "non-delegating iterable-valued yield remains green");
+});
+
+describe("#4689 — native string delegation module shape", () => {
+  it("keeps direct string delegation host-free and preserves characters", async () => {
+    const result = await compile(
+      `function* g(): Generator<string> { yield* "abc"; }
+export function test(): number { let n = 0; for (const value of g()) n += value.length; return n; }`,
+      { fileName: "test.ts", target: "standalone" },
+    );
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    const module = await WebAssembly.compile(result.binary);
+    expect(WebAssembly.Module.imports(module), "direct string delegation must be host-free").toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Classify direct `yield* "abc"` as a native-string generator carrier and cast delegated iterator values back to native strings.
- Map nullable terminal string result refs to canonical `undefined` on dynamic `.value` reads.
- Add exact standalone Test262 pins for `star-string.js`, numeric/generic controls, and a zero-host-import module-shape control.

## Evidence

The authoritative artifact `/private/tmp/js2-es6-functionproto-wave3/.test262-cache/test262-standalone-current.jsonl` had 52 non-pass ES2015 yield rows (49 compile refusals, 3 assertion failures). The selected `star-string.js` row was `fail/assertion_fail` with first value `NaN` instead of `"a"`; after the fix it passes, including the final `value === undefined` assertion.

Tests after merging upstream/main at `d91d297d3`:

- `pnpm exec vitest run tests/issue-4689.test.ts tests/issue-2171-string-yields.test.ts tests/issue-2173-yieldstar-array.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot` — 23/23 passed.
- `pnpm run typecheck` — passed.
- Normal `.husky/pre-push` — passed, including lint, format, ratchets, IR parity (18/18), and issue integrity.

Commits: `4f89a9606` (implementation/tests), `8c27f4272` (issue status done).

No merge requested; please review and merge upstream.