### PR TITLE
fix(#4690): assign for-of rest to member targets

### DIFF
--- a/plan/issues/4690-es2015-forof-destructuring-residual.md
+++ b/plan/issues/4690-es2015-forof-destructuring-residual.md
@@ -1,0 +1,106 @@
+---
+id: 4690
+title: "ES2015 standalone for-of destructuring: assign array rest to property references"
+status: done
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+assignee: codex/4690-es2015-forof-destructuring-wave6
+priority: medium
+horizon: s
+feasibility: medium
+task_type: conformance
+area: codegen, destructuring, for-of
+es_edition: es6
+goal: standalone-mode
+related: [4447, 2602, 2869]
+loc-budget-allow:
+  - src/codegen/statements/for-of-destructuring.ts
+---
+
+# #4690 — for-of assignment-rest property references
+
+## Scope and measured baseline
+
+The supplied standalone snapshot is
+`/private/tmp/js2-es6-functionproto-wave3/.test262-cache/test262-standalone-current.jsonl`
+(timestamp `25.8.2026, 04:31:12`–`04:36:35`, oracle version 13; snapshot file
+mtime 2026-08-25 05:27:06).  The bounded slice is exactly four non-passing
+official `language/statements/for-of/dstr` rows:
+
+| file | snapshot status/signature |
+| --- | --- |
+| `array-rest-put-prop-ref.js` | `fail / assertion_fail` — expected rest length/value, observed `0` |
+| `array-rest-put-prop-ref-no-get.js` | `fail / assertion_fail` — expected setter result, observed `0` |
+| `array-rest-put-prop-ref-user-err.js` | `fail / assertion_fail` — expected setter `Test262Error`, no throw |
+| `array-rest-put-prop-ref-user-err-iter-close-skip.js` | `fail / assertion_fail` — expected setter `Test262Error`, no throw |
+
+Count: **4 rows, 4 fail, 0 compile errors, 0 passes** in this slice.  The
+current `upstream/main` used for implementation is `eba07b0e8` (2026-08-25).
+Faithful `runTest262File(file, "issue-4690", 120000, "standalone")` probes on
+that tip reproduce all four failures:
+
+- `array-rest-put-prop-ref.js`: `Expected SameValue(«0», «3») ... x.y.length`
+- `array-rest-put-prop-ref-no-get.js`: `Expected SameValue(«0», «3») ... setValue.length`
+- `array-rest-put-prop-ref-user-err.js`: expected a `Test262Error`, no exception
+- `array-rest-put-prop-ref-user-err-iter-close-skip.js`: expected a `Test262Error`, no exception
+
+The known-good control `array-rest-after-element.js` is a baseline pass on the
+same snapshot and current tip; it exercises the already-supported identifier
+rest target and guards against changing the ordinary rest slice.
+
+## Root cause hypothesis
+
+`src/codegen/statements/for-of-destructuring.ts` contains the assignment-rest
+helpers `emitForOfRestAssignment` (externref/iterator and tuple paths) and
+`emitVecRestAssignment` (WasmGC vec path).  The helpers had no member-target
+PutValue path, so a property/element target such as `...x.y` was dropped after
+the source slice was available (or returned before building the vec slice).
+While adding that path, the native vec helper also exposed a second local-stack
+bug: it built a fresh vec but did not store it into the temporary that
+`emitAssignToTarget` reads, so the member write received null.  As a result the
+required §13.15.5.5 PutValue never retained the rest or invoked a setter.  The
+`no-get` case confirms the target must be evaluated without reading its current
+value, and the final row requires a setter abrupt completion to propagate
+without IteratorClose.
+
+## Implementation plan
+
+1. Extend the externref/tuple rest helper to materialize the slice into a temp
+   and route property/element targets through the existing `emitAssignToTarget`
+   PutValue dispatcher.  Keep identifier and nested-pattern paths byte-stable.
+2. Extend the native vec rest helper to materialize the fresh vec into a temp
+   and route property/element targets through the same dispatcher.  Preserve
+   native slice construction and typed vec identity for identifier targets.
+3. Add strict four-row pins plus the passing identifier-rest control to
+   `tests/issue-4690.test.ts`.  Require all five to be `pass` in standalone.
+4. Re-run focused controls and normal compiler/pre-push gates after merging the
+   latest upstream main.
+
+## Risks and non-goals
+
+- This slice covers only array assignment-rest targets that are a direct
+  property/element reference.  It does not broaden nested rest patterns,
+  defaults on property targets, iterator-close semantics, object-rest targets,
+  or binding-form rest.
+- `emitAssignToTarget` is the existing member PutValue path; no new getter or
+  property-read should be emitted.  A setter throw must remain the active
+  abrupt completion and must not be swallowed.
+- Keep source growth below 150 LOC and avoid rewriting shared destructuring.
+
+## Acceptance
+
+- The four named rows and `array-rest-after-element.js` pass via the exact
+  standalone `runTest262File` seam.
+- No baseline-pass control in the focused slice regresses, and the compiler
+  typecheck, formatting, focused tests, and normal pre-push checks pass.
+- The implementation remains within the intended files:
+  `src/codegen/statements/for-of-destructuring.ts`,
+  `tests/issue-4690.test.ts`, and this issue record.
+
+## Test Results
+
+- `pnpm exec vitest run tests/issue-4690.test.ts --maxWorkers=1 --minWorkers=1`
+  — **5 passed** (four exact standalone pins plus the identifier-rest control).
+- Exact `runTest262File(file, "issue-4690", 120000, "standalone")` rows: **4
+  before → 4 pass after**; control: **pass before → pass after**.

--- a/src/codegen/statements/for-of-destructuring.ts
+++ b/src/codegen/statements/for-of-destructuring.ts
@@ -1572,11 +1572,11 @@ export function compileForOfAssignDestructuring(
  * (a JS array host-side / native array standalone); we then PutValue it to the
  * rest target.
  *
- * Only IDENTIFIER rest targets are handled (local OR pre-declared module global
- * — the shape every test262 array-rest case + #2602 uses). A rest target that is
- * a property/element access (`[...obj.x]`) is rare and left as a no-op (matching
- * the pre-#2602 drop — no regression). Returns `true` when the spread element was
- * consumed (the caller should `continue`), `false` to fall through.
+ * Identifier targets use the existing local/global path. Property/element
+ * targets are materialized into a temporary and routed through the existing
+ * PutValue dispatcher (`emitAssignToTarget`) so setters run without reading the
+ * property first. Returns `true` when the spread element was consumed (the
+ * caller should `continue`), `false` to fall through.
  */
 function emitForOfRestAssignment(
   ctx: CodegenContext,
@@ -1616,11 +1616,12 @@ function emitForOfRestAssignment(
     return true;
   }
 
+  const isMemberTarget = ts.isPropertyAccessExpression(restTarget) || ts.isElementAccessExpression(restTarget);
   // Pop the source externref the caller pushed — we only need it when the target
   // resolves; for an unhandled target shape, drop it to keep the stack balanced.
-  if (!ts.isIdentifier(restTarget)) {
-    // Unhandled rest target (property/element access). Drop the source externref
-    // the caller pushed so the value stack stays balanced, then bail.
+  if (!ts.isIdentifier(restTarget) && !isMemberTarget) {
+    // Unhandled rest target. Drop the source externref the caller pushed so the
+    // value stack stays balanced, then bail.
     fctx.body.push({ op: "drop" });
     return true;
   }
@@ -1637,6 +1638,18 @@ function emitForOfRestAssignment(
   if (sliceIdx === undefined) {
     // Could not register the slice helper — drop the source to keep balance.
     fctx.body.push({ op: "drop" });
+    return true;
+  }
+
+  if (isMemberTarget) {
+    // §13.15.5.5 evaluates the target reference only for PutValue; do not read
+    // `obj.prop` before invoking its setter (the `no-get` Test262 case relies on
+    // this). The source is already on the stack from the caller.
+    const restLocal = allocLocal(fctx, `__forof_restmem_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "f64.const", value: restStartIndex });
+    fctx.body.push({ op: "call", funcIdx: sliceIdx });
+    fctx.body.push({ op: "local.set", index: restLocal });
+    emitAssignToTarget(ctx, fctx, restTarget, restLocal, { kind: "externref" });
     return true;
   }
 
@@ -1686,9 +1699,9 @@ function emitForOfRestAssignment(
  * fresh vec of the SAME struct type as the source. This mirrors the binding-form
  * vec rest (loops.ts ~1488) so behaviour is byte-identical between
  * `const [a,...r]=…` and `[a,...r]=…`. The fresh vec is PutValue'd to the rest
- * target (identifier local OR pre-declared module global). Only identifier
- * targets are handled (the test262 array-rest shape + #2602); a property/element
- * rest target is left unwritten (matching the pre-#2602 drop — no regression).
+ * target (identifier local OR pre-declared module global). Property and element
+ * targets are assigned through the existing PutValue dispatcher after the fresh
+ * vec is materialized.
  */
 function emitVecRestAssignment(
   ctx: CodegenContext,
@@ -1709,21 +1722,26 @@ function emitVecRestAssignment(
   // A nested pattern rest target (`for ([...[x]] of …)`): build the rest vec
   // into a temp, then recurse into the nested assignment pattern with the fresh
   // rest vec as the element (mirror of the binding-form rest recursion,
-  // loops.ts ~1551). Identifier targets store directly; property/element rest
-  // targets are not handled (matching the pre-#2602 drop — no regression).
+  // loops.ts ~1551). Identifier targets store directly; member targets are
+  // assigned after materialization through the existing PutValue dispatcher.
   const isNestedPattern = ts.isArrayLiteralExpression(restTarget) || ts.isObjectLiteralExpression(restTarget);
+  const isMemberTarget = ts.isPropertyAccessExpression(restTarget) || ts.isElementAccessExpression(restTarget);
   let targetLocal: number | undefined;
   let restSyncGlobalIdx: number | undefined;
   if (isNestedPattern) {
     targetLocal = allocLocal(fctx, `__forof_rest_${fctx.locals.length}`, restVecType);
   } else {
-    if (!ts.isIdentifier(restTarget)) return; // property/element rest target — not handled (no regression)
-    targetLocal = fctx.localMap.get(restTarget.text);
-    if (targetLocal === undefined) {
-      const globalIdx = ctx.moduleGlobals.get(restTarget.text);
-      if (globalIdx === undefined) return; // unresolvable identifier — nothing to write
-      targetLocal = allocLocal(fctx, restTarget.text, restVecType);
-      restSyncGlobalIdx = globalIdx;
+    if (isMemberTarget) {
+      targetLocal = allocLocal(fctx, `__forof_restmem_${fctx.locals.length}`, restVecType);
+    } else {
+      if (!ts.isIdentifier(restTarget)) return;
+      targetLocal = fctx.localMap.get(restTarget.text);
+      if (targetLocal === undefined) {
+        const globalIdx = ctx.moduleGlobals.get(restTarget.text);
+        if (globalIdx === undefined) return; // unresolvable identifier — nothing to write
+        targetLocal = allocLocal(fctx, restTarget.text, restVecType);
+        restSyncGlobalIdx = globalIdx;
+      }
     }
   }
 
@@ -1781,6 +1799,15 @@ function emitVecRestAssignment(
       outerArrTypeIdx,
       stmt,
     );
+    return;
+  }
+
+  if (isMemberTarget) {
+    // Materialize the fresh vector in the temporary before PutValue reads it.
+    // Without this store, emitAssignToTarget observes the local's null default
+    // even though the vector is still on the value stack.
+    fctx.body.push({ op: "local.set", index: targetLocal });
+    emitAssignToTarget(ctx, fctx, restTarget, targetLocal, restVecType);
     return;
   }
 

--- a/tests/issue-4690.test.ts
+++ b/tests/issue-4690.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4690 pins the four standalone for-of assignment-rest cases whose rest target
+// is a property reference. The exact upstream files exercise PutValue, setter
+// invocation, and the no-get/abrupt-completion ordering that reduced probes
+// tend to miss. The identifier-rest control protects the existing #2602 path.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const T262 = join(__dirname, "..", "test262");
+const HAVE_T262 = existsSync(join(T262, "harness", "assert.js"));
+const abs = (rel: string) => join(T262, "test", rel);
+
+describe.skipIf(!HAVE_T262)("#4690 standalone for-of assignment-rest property targets", () => {
+  const files = [
+    "language/statements/for-of/dstr/array-rest-put-prop-ref.js",
+    "language/statements/for-of/dstr/array-rest-put-prop-ref-no-get.js",
+    "language/statements/for-of/dstr/array-rest-put-prop-ref-user-err.js",
+    "language/statements/for-of/dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js",
+    // Baseline-pass control: identifier rest must remain byte/semantically stable.
+    "language/statements/for-of/dstr/array-rest-after-element.js",
+  ];
+
+  for (const rel of files) {
+    it(`${rel} passes in standalone`, { timeout: 120_000 }, async () => {
+      const result = await runTest262File(abs(rel), "issue-4690", 120_000, "standalone");
+      expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+    });
+  }
+});


### PR DESCRIPTION
## Summary\n\n- route for-of assignment-rest property and element targets through the existing PutValue dispatcher\n- store freshly built native vec rests before member assignment so setters receive the rest value\n- add exact standalone Test262 pins for four #4690 rows plus the identifier-rest control\n\n## Verification\n\n- exact standalone pins: 5/5 passed (4 target rows + 1 baseline control)\n- typecheck, lint, format:check, oracle/coercion ratchets, numeric-local parity, issue integrity, and pre-push hooks passed\n- merged upstream/main at e64fd0e926f5989fe72765850873f32d074cd7b3\n\nCloses #4690