### PR TITLE
fix(annexb): preserve existing var function updates

### DIFF
--- a/src/codegen/analysis/mixed-assignment-carrier.ts
+++ b/src/codegen/analysis/mixed-assignment-carrier.ts
@@ -29,6 +29,16 @@ function containingScope(decl: ts.VariableDeclaration): ts.Node {
   return decl.getSourceFile();
 }
 
+/**
+ * True when Annex B will write a block-level function object into this
+ * existing `var` binding while evaluating the enclosing var scope. That write
+ * is implicit in the AST, so the binding must remain boxed even when usage
+ * inference proves all visible uses numeric.
+ */
+export function bindingHasAnnexBExistingVarUpdate(decl: ts.VariableDeclaration): boolean {
+  return ts.isIdentifier(decl.name) && annexBExistingVarUpdateNames(containingScope(decl)).has(decl.name.text);
+}
+
 function carrierDomain(tag: JsTag): string {
   // Boolean and symbol both use i32 physically, but their boxing semantics are
   // distinct, so crossing between them still requires a dynamic carrier.
@@ -151,7 +161,7 @@ export function bindingHasMixedAssignmentCarrier(ctx: CodegenContext, decl: ts.V
   // evaluated. No `F = …` BinaryExpression exists for the walk below to see, so
   // without this the slot keeps the initializer's narrow representation
   // (`var f = 123` → f64) and the write-back is unrepresentable.
-  if (initialDomain !== "function" && annexBExistingVarUpdateNames(scope).has(decl.name.text)) return true;
+  if (initialDomain !== "function" && bindingHasAnnexBExistingVarUpdate(decl)) return true;
   let mixed = false;
 
   // (#4122) `"mixed"` is the oracle's answer for UNRESOLVABLE, not for "proven

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -44,6 +44,7 @@ import { compileStringBuilderInit } from "../string-builder.js";
 import { tryEmitLinearU8New } from "../linear-uint8-codegen.js";
 import { tryCompileWithScopedVarDeclaration } from "../with-var-decl.js";
 import {
+  bindingHasAnnexBExistingVarUpdate,
   bindingHasMixedAssignmentCarrier,
   numericProofOverridesMixedCarrier,
 } from "../analysis/mixed-assignment-carrier.js";
@@ -678,12 +679,11 @@ function isPropertyDescriptorResultExpression(expr: ts.Expression | undefined): 
  * `any`/`unknown`-typed local binding is ToNumber-invariant — otherwise `null`,
  * leaving the caller's boxed-carrier resolution in place. Gated by
  * `ctx.useUsageInfer`. This is the SINGLE codegen entry point for the inference,
- * shared by all local-slot minting sites (var hoister, let/const pre-hoister,
- * `localTypeForDeclaration`) so every site agrees on the slot type.
+ * shared by all local-slot minting sites so every site agrees on the slot type.
  */
 export function usageInferredLocalType(ctx: CodegenContext, decl: ts.VariableDeclaration | undefined): ValType | null {
   if (!decl || !ctx.useUsageInfer) return null;
-  if (!ts.isIdentifier(decl.name)) return null;
+  if (!ts.isIdentifier(decl.name) || bindingHasAnnexBExistingVarUpdate(decl)) return null;
   return ctx.usageInference.scalarForDecl(decl) === "number" ? { kind: "f64" } : null;
 }
 

--- a/tests/issue-4131-standalone-existing-var-update.test.ts
+++ b/tests/issue-4131-standalone-existing-var-update.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4131 — Annex B B.3.3.1 step 3.f must update an existing `var` binding with
+// the function object produced by a sloppy block-level function declaration.
+// These are the five `if` statement forms covered by the ES5 generated
+// `*-func-existing-var-update.js` rows. Keep the numeric initializer after the
+// observation: numeric usage admission must not re-narrow the hidden function
+// assignment to an f64 carrier.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const cases = [
+  {
+    name: "if-decl-else-decl-a",
+    statement: "if (true) function f() { return 17; } else function _f() {}",
+  },
+  {
+    name: "if-decl-else-decl-b",
+    statement: "if (false) function _f() {} else function f() { return 17; }",
+  },
+  {
+    name: "if-decl-else-stmt",
+    statement: "if (true) function f() { return 17; } else ;",
+  },
+  {
+    name: "if-decl-no-else",
+    statement: "if (true) function f() { return 17; }",
+  },
+  {
+    name: "if-stmt-else-decl",
+    statement: "if (false) ; else function f() { return 17; }",
+  },
+] as const;
+
+async function runStandalone(statement: string): Promise<number> {
+  const source = `
+    export function test() {
+      var after;
+      (function() {
+        ${statement}
+        after = f;
+        var f = 123;
+      }());
+      return typeof after === "function" && after() === 17 ? 1 : 0;
+    }
+  `;
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "/issue-4131-standalone-existing-var-update.js",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#4131 Annex B existing-var updates in standalone if forms", () => {
+  for (const { name, statement } of cases) {
+    it(`${name} writes the function object into the existing var`, async () => {
+      await expect(runStandalone(statement)).resolves.toBe(1);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- keep Annex B existing-var bindings boxed when B.3.3.1 writes a function object into them
- prevent numeric usage admission from re-narrowing that hidden cross-domain assignment to f64
- add permanent standalone coverage for all five generated if-statement forms

## Test262 delta

Exact clean-upstream baseline nonpasses flipped: 5/5

- annexB/language/function-code/if-decl-else-decl-a-func-existing-var-update.js
- annexB/language/function-code/if-decl-else-decl-b-func-existing-var-update.js
- annexB/language/function-code/if-decl-else-stmt-func-existing-var-update.js
- annexB/language/function-code/if-decl-no-else-func-existing-var-update.js
- annexB/language/function-code/if-stmt-else-decl-func-existing-var-update.js

Fresh baseline: 0/5 with null dereferences. Post-fix standalone: 5/5. Host controls: 5/5. Focused permanent suites: 9/9.

## Verification

- TS5 and TS7
- pre-commit hooks, LOC/function budgets
- oracle ratchet and IR fallback gate
- full normal pre-push hooks: typecheck, lint, format, oracle ratchet, coercion ratchet, issue #3765 18/18, issue integrity

No hooks were bypassed.