### PR TITLE
fix(object): preserve sparse array keys during index growth

### DIFF
--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -208,6 +208,7 @@ import {
 import { ensureWrapperConstructorCarriers, wrapperConstructorArmInstrs } from "./wrapper-constructor-carrier.js"; // (#4223) runtime `<wrapper>.constructor`
 import { overlayRouteActive } from "./typed-lane-overlay-route.js"; // (#4222) overlay-aware index presence
 import { backedBoundsGuard, canonicalIndexDigitStep } from "./vec-index-domain.js"; // (#4434) index domain + sparse tail
+import { buildVecIndexKeyPush, reserveVecIndexEnumerable } from "./vec-index-enumerable.js"; // (#4491) overlay-aware key flags
 import { fillHostArrayCarrierPredicate } from "./host-array-carrier.js"; // (#4649) js-host late-bound carrier test
 import {
   buildOwnToPrimitiveOverridePresent,
@@ -9555,24 +9556,22 @@ export function fillDynamicForinVecArms(ctx: CodegenContext): void {
   // `keys` listed `0,1,2,3`. All three now consult `__extern_has_idx`, which
   // `fillF64HoleHasIdxArms` teaches about the absence marker.
   const gateKeysOnPresence = (overlayRouteActive(ctx) || f64HolesActive(ctx)) && externHasIdxIdx !== undefined;
+  // __vec_index_enumerable was originally reserved only for a for-in site,
+  // leaving Object.keys with no way to exclude a non-enumerable array-index
+  // descriptor. Own-key enumeration has the same overlay source, so reserve
+  // the helper here when the module's own-key demand gate is active.
+  reserveVecIndexEnumerable(ctx);
   /** `__objvec_push(out, ToString(i))`, presence-gated under the overlay route. */
-  const pushKeyI = (outLocal: number, iLocal: number): Instr[] => {
-    const push: Instr[] = [
-      { op: "local.get", index: outLocal },
-      { op: "local.get", index: iLocal },
-      { op: "f64.convert_i32_s" },
-      { op: "call", funcIdx: numToStringIdx as number },
-      { op: "call", funcIdx: objVecPushIdx as number },
-    ];
-    if (!gateKeysOnPresence) return push;
-    return [
-      { op: "local.get", index: 0 },
-      { op: "local.get", index: iLocal },
-      { op: "f64.convert_i32_s" },
-      { op: "call", funcIdx: externHasIdxIdx as number },
-      { op: "if", blockType: { kind: "empty" }, then: push },
-    ];
-  };
+  const pushKeyI = (outLocal: number, iLocal: number): Instr[] =>
+    buildVecIndexKeyPush(ctx, {
+      objLocal: 0,
+      outLocal,
+      indexLocal: iLocal,
+      numToStringIdx: numToStringIdx as number,
+      objVecPushIdx: objVecPushIdx as number,
+      externHasIdxIdx,
+      gatePresence: gateKeysOnPresence,
+    });
   for (const keysFn of [findFn("__object_keys_forin"), findFn("__object_keys")]) {
     if (!(keysFn && numToStringIdx !== undefined && objVecNewIdx !== undefined && objVecPushIdx !== undefined))
       continue;

--- a/src/codegen/vec-elem-set.ts
+++ b/src/codegen/vec-elem-set.ts
@@ -27,6 +27,8 @@ import type { CodegenContext } from "./context/types.js";
 import { addFuncType, getOrRegisterHoleyArrayType, getOrRegisterVecType, isHoleyArrayType } from "./registry/types.js";
 import { ensureExnTag } from "./registry/imports.js";
 import { holeSentinelInstrs } from "./array-holes.js";
+import { f64HolesActive } from "./vec-f64-hole-presence.js";
+import { HOLE_F64_BITS } from "./value-tags.js";
 
 /** Reserved name prefix; the suffix is the vec STRUCT typeIdx. */
 export const VEC_ELEM_SET_PREFIX = "__vec_elem_set_";
@@ -167,6 +169,18 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
   if (elem.kind === "i8" || elem.kind === "i16") return null;
 
   const holeyCarrier = isHoleyArrayType(ctx, vecTypeIdx) && elem.kind === "externref";
+  // Standalone f64 vectors use the same absence marker as sparse literals.
+  // Without this, an indexed write past capacity grows the backing array with
+  // f64 zeroes, materializing every intervening index as an own property.
+  // Mark the carrier here as well as in literal lowering: a module can first
+  // encounter a sparse indexed write before it emits a f64 literal marker.
+  const f64HoleCarrier = ctx.standalone && elem.kind === "f64" && f64HolesActive(ctx);
+  if (f64HoleCarrier) ctx.f64HoleMarkerEmitted = true;
+  const gapFillInit: Instr[] = holeyCarrier
+    ? holeSentinelInstrs(ctx)
+    : f64HoleCarrier
+      ? [{ op: "i64.const", value: HOLE_F64_BITS }, { op: "f64.reinterpret_i64" }]
+      : [];
   // (#4430) The branded sparse carrier is a FINAL subtype of the ordinary
   // externref vec, and BOTH fields this helper touches (`length`, `data`) are
   // declared on that parent. The IR path types the receiving binding from the
@@ -257,10 +271,12 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
             { op: "local.set", index: NCAP },
           ],
         },
-        // Only the branded sparse carrier fills new capacity with `$Hole`.
-        ...(holeyCarrier ? holeSentinelInstrs(ctx) : []),
+        // Branded externref sparse carriers and standalone f64 sparse carriers
+        // fill new capacity with their respective absence markers. Dense
+        // carriers retain the ordinary zero/null default.
+        ...gapFillInit,
         { op: "local.get", index: NCAP },
-        ...(holeyCarrier
+        ...(holeyCarrier || f64HoleCarrier
           ? ([{ op: "array.new", typeIdx: arrTypeIdx }] satisfies Instr[])
           : ([{ op: "array.new_default", typeIdx: arrTypeIdx }] satisfies Instr[])),
         { op: "local.set", index: NDATA },
@@ -281,10 +297,11 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
         { op: "local.set", index: DATA },
       ],
     },
-    ...(holeyCarrier
+    ...(holeyCarrier || f64HoleCarrier
       ? ([
           // A write beyond logical length can land in already-allocated spare
-          // capacity. Preserve absence in the full [oldLength, idx) gap.
+          // capacity. Preserve absence in the full [oldLength, idx) gap for
+          // both branded externref and standalone f64 sparse carriers.
           { op: "local.get", index: VEC },
           { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 0 },
           { op: "local.set", index: OLEN },
@@ -297,7 +314,7 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
             then: [
               { op: "local.get", index: DATA },
               { op: "local.get", index: OLEN },
-              ...holeSentinelInstrs(ctx),
+              ...gapFillInit,
               { op: "local.get", index: IDX },
               { op: "local.get", index: OLEN },
               { op: "i32.sub" },
@@ -339,7 +356,7 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
       { name: "$ncap", type: { kind: "i32" } },
       { name: "$ndata", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
       { name: "$ocap", type: { kind: "i32" } },
-      ...(holeyCarrier ? [{ name: "$oldlen", type: { kind: "i32" } as ValType }] : []),
+      ...(holeyCarrier || f64HoleCarrier ? [{ name: "$oldlen", type: { kind: "i32" } as ValType }] : []),
     ],
     body,
     exported: false,

--- a/src/codegen/vec-index-enumerable.ts
+++ b/src/codegen/vec-index-enumerable.ts
@@ -44,14 +44,13 @@
  * time, and the real body is installed from `fillObjVecReflectionHelpers`. A
  * skipped fill degrades to exactly the previous behaviour, never a trap.
  *
- * ## Deliberately NOT widened here
+ * ## Object.keys integration
  *
- * `Object.keys` / `getOwnPropertyNames` over a vec have the same gap (measured:
- * `Object.keys(a)` still answers `["0"]` for the array above) but reach it
- * through `__vec_overlay_push_keys` and the `__object_keys` vec arm — different
- * wiring, no test in this bucket asserting it, and widening both at once would
- * make one regression indistinguishable from the other. Recorded so the next
- * reader does not have to re-derive it.
+ * `fillDynamicForinVecArms` now reserves and calls this same helper for the
+ * `__object_keys` vec arm when the own-key demand gate is active. Keeping the
+ * check at that arm, rather than folding descriptor flags into the generic
+ * index loop, preserves the no-descriptor fast path and keeps `for…in` and
+ * `Object.keys` on one overlay-aware answer.
  */
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
@@ -71,6 +70,51 @@ const FLAG_ENUMERABLE = 0x02;
 const EXT: ValType = { kind: "externref" };
 const I32: ValType = { kind: "i32" };
 
+/**
+ * Build one vec index push for the standalone Object.keys/for-in arm.
+ * Presence remains the first gate; when a descriptor-aware module has the
+ * enumerable helper, its overlay predicate wraps that same push.
+ */
+export function buildVecIndexKeyPush(
+  ctx: CodegenContext,
+  args: {
+    objLocal: number;
+    outLocal: number;
+    indexLocal: number;
+    numToStringIdx: number;
+    objVecPushIdx: number;
+    externHasIdxIdx?: number;
+    gatePresence: boolean;
+  },
+): Instr[] {
+  const push: Instr[] = [
+    { op: "local.get", index: args.outLocal },
+    { op: "local.get", index: args.indexLocal },
+    { op: "f64.convert_i32_s" },
+    { op: "call", funcIdx: args.numToStringIdx },
+    { op: "call", funcIdx: args.objVecPushIdx },
+  ];
+  const gatedPush: Instr[] =
+    args.gatePresence && args.externHasIdxIdx !== undefined
+      ? [
+          { op: "local.get", index: args.objLocal },
+          { op: "local.get", index: args.indexLocal },
+          { op: "f64.convert_i32_s" },
+          { op: "call", funcIdx: args.externHasIdxIdx },
+          { op: "if", blockType: { kind: "empty" }, then: push },
+        ]
+      : push;
+  const enumerableIdx = ctx.funcMap.get(VEC_INDEX_ENUMERABLE);
+  if (enumerableIdx === undefined) return gatedPush;
+  return [
+    { op: "local.get", index: args.objLocal },
+    { op: "local.get", index: args.indexLocal },
+    { op: "f64.convert_i32_s" },
+    { op: "call", funcIdx: args.numToStringIdx },
+    { op: "call", funcIdx: enumerableIdx },
+    { op: "if", blockType: { kind: "empty" }, then: gatedPush },
+  ];
+}
 /**
  * Reserve the native so a for-in site can bake `call <idx>` before
  * `__vec_overlay_lookup` exists. Append-only mint (defined funcs live after the

--- a/tests/issue-4491-wave4.test.ts
+++ b/tests/issue-4491-wave4.test.ts
@@ -354,10 +354,10 @@ describe("#4491 wave-4 — measured residuals", () => {
     ).toBe(1);
   });
 
-  // Defining a far index grows the backing with a NON-hole default, so
-  // `Object.keys` enumerates the whole filled range.
+  // Defining a far index must preserve the intervening slots as holes rather
+  // than growing the f64 backing with a non-hole default.
   // (`keys/15.2.3.14-5-13`.)
-  it.fails("a far-index define leaves the intervening slots as holes", async () => {
+  it("a far-index define leaves the intervening slots as holes", async () => {
     expect(
       await runStandalone(`
         export function main() {


### PR DESCRIPTION
Fixes the ES5 standalone `Object.keys` far-index residual by preserving intervening numeric slots as holes during vector growth and consulting the overlay enumerable predicate during index enumeration.

Exact Test262 delta:
- `built-ins/Object/keys/15.2.3.14-5-13.js`: fail (`arr.length === 9999`) → pass

The originally paired `Object/getOwnPropertyNames/15.2.3.4-4-1.js` remains nonpassing because it requires global-object property carriers, an independent mechanism intentionally excluded from this PR.

Verification:
- Exact official scoped runner: 1/1 pass
- `tests/issue-4491-wave4.test.ts`: 14/14 pass
- TypeScript 7 typecheck
- Full normal pre-push hooks: typecheck/lint, Prettier, oracle/coercion ratchets, #3765 18/18, issue integrity

No verification hooks were bypassed.