### PR TITLE
fix(array): preserve dynamic ES5 constructor keys

### DIFF
--- a/plan/issues/4491-es5-defineproperty-mop-residual.md
+++ b/plan/issues/4491-es5-defineproperty-mop-residual.md
@@ -14,6 +14,11 @@ area: codegen
 es_edition: es5
 goal: standalone-mode
 related: [4444, 3031, 4490, 4504]
+# 2026-08-25 standalone Array constructor pair: the dynamic computed-key
+# dispatch for S15.4_A1.1_T9 and the sparse companion write/read for
+# S15.4_A1.1_T10 are the remaining value-representation slice described in
+# this issue's sparse-tail residual. The dispatch must stay beside the native
+# locals it splices, so the existing allowances below apply to this pair.
 loc-budget-allow:
   # 2026-08-24 wave-7 (Object.prototype.toString): the syntactic `.call(v)` form
   # is owned by the #2501 compile-time fold, whose standalone ladder ended in a

--- a/src/codegen/array-nonindex-key.ts
+++ b/src/codegen/array-nonindex-key.ts
@@ -26,7 +26,8 @@
 // to the array's NAMED store: the #3537 expando bag in standalone, the host
 // `__extern_*` bridge in gc. Both spellings route, so they cannot disagree.
 //
-// Scope discipline — COMPILE-TIME CONSTANT keys only, and among those:
+// Scope discipline — compile-time constants use the dedicated fast routes,
+// while dynamic numeric/object keys use the property-key dispatch:
 //   * A numeric constant, a boolean literal, or a string constant whose
 //     `String(Number(s))` round-trips. That last condition is what keeps the
 //     reserved names out: `arr["length"]`, `arr["push"]`, `arr["constructor"]`
@@ -38,16 +39,19 @@
 //   * A key that IS an array index (including `-0`, whose ToString is `"0"`)
 //     returns `undefined` and falls through to the untouched vec path, so a
 //     module with only ordinary indices is byte-identical.
-//   * A non-constant key (`a[i]`, `x[object]` with a user `valueOf`) is
-//     untouched. Deciding index-ness at runtime needs the dispatch inside the
-//     element helper itself; the measured cluster is constant-keyed. Named in
-//     the issue as a known leftover.
+//   * A non-constant key is routed through the property-key dispatch when its
+//     type is numeric or object-like. That keeps runtime values such as
+//     `x[k - 2]` in the same property-key lane as object coercions; the
+//     receiver-specific helper can then preserve sparse array indices without
+//     saturating them to a signed i32.
 import ts from "typescript";
+import type { TypeFact } from "../checker/oracle.js";
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { allocLocal } from "./context/locals.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
+import { emitToPropertyKeyOnce } from "./expressions/computed-member-reference.js";
 import {
   coerceType,
   compileExpression,
@@ -62,6 +66,40 @@ import { TYPED_ARRAY_NAMES } from "./index.js";
 import { VEC_PROP_GET, VEC_PROP_SET } from "./vec-props.js";
 
 const EXTERNREF: ValType = { kind: "externref" };
+
+/** Whether a type fact can change the property-key lane at runtime. */
+function factNeedsPropertyKeyRuntime(fact: TypeFact): boolean {
+  if (fact.kind === "union") return fact.parts.some(factNeedsPropertyKeyRuntime);
+  return fact.kind !== "number" && fact.kind !== "string";
+}
+
+/**
+ * True when a computed key must stay on the JavaScript property-key path.
+ *
+ * A vec's fast element lane is intentionally numeric, but an object/function,
+ * Symbol, boolean, nullish, or BigInt key is converted with ToPropertyKey — it
+ * must not be coerced to an i32 before the receiver-specific runtime sees it.
+ * Constant spellings are classified by the helpers below first; this predicate
+ * covers the remaining dynamic values (notably `x[object]` from ES5 T9).
+ */
+export function isDynamicPropertyKeyExpression(ctx: CodegenContext, key: ts.Expression): boolean {
+  const keyFact = ctx.oracle.typeFactOf(key);
+  if (factNeedsPropertyKeyRuntime(keyFact)) return true;
+  const inner = skipTransparentExpressions(key);
+  // A mutable arithmetic expression cannot be classified as an array index at
+  // compile time. Keep it on the runtime property-key path so values above
+  // i32's signed range (for example `k - 2` at 2^32 - 2) retain their exact
+  // canonical string instead of saturating before the vec dispatch sees them.
+  // Constant numeric expressions and simple variable indices stay on their
+  // existing dense path.
+  if (keyFact.kind === "number") {
+    return ts.isBinaryExpression(inner) && typeof resolveConstantExpression(ctx, inner) !== "number";
+  }
+  // A literal ordinary name (for example `"[object Object]"`) is also a
+  // property key, not a numeric index. Numeric spellings and the historical
+  // named-key constants are handled by their dedicated routes first.
+  return ts.isStringLiteral(inner) && !isArrayIndexString(inner.text) && !isNamedNumericOrBooleanSpelling(inner.text);
+}
 
 /** 2^32 − 1 — the exclusive upper bound on array indices (§10.4.2.2). */
 const MAX_ARRAY_INDEX_EXCLUSIVE = 4294967295;
@@ -393,6 +431,49 @@ export function compileElementIndexI32(ctx: CodegenContext, fctx: FunctionContex
   }
   if (tryEmitStaticI32Expression(ctx, fctx, key)) return { kind: "i32" };
   return compileExpression(ctx, fctx, key, { kind: "i32" });
+}
+
+/**
+ * Dynamic object-key READ for a vec receiver. The receiver is already on the
+ * stack; canonicalize the key once with ToPropertyKey, then let the existing
+ * standalone/host `__extern_get` dispatch choose element, expando, prototype,
+ * or ordinary-object semantics.
+ */
+export function emitDynamicVecElementGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  recvType: ValType,
+  key: ts.Expression,
+  compile: (expr: ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const recvLocal = allocLocal(fctx, `__dynkey_recv_${fctx.locals.length}`, recvType);
+  fctx.body.push({ op: "local.set", index: recvLocal });
+  fctx.body.push({ op: "local.get", index: recvLocal });
+  fctx.body.push({ op: "extern.convert_any" });
+  const keyFact = ctx.oracle.typeFactOf(key);
+  // Numeric expressions can use the indexed helper directly. It formats the
+  // f64 key canonically for the overlay read, avoiding a string round-trip
+  // that would otherwise lose the sparse-tail distinction at i32.max.
+  const numericKey = keyFact.kind === "number";
+  const keyResult = compile(key, numericKey ? { kind: "f64" } : EXTERNREF);
+  if (!keyResult) return null;
+  let getIdx: number | undefined;
+  if (numericKey) {
+    if (keyResult.kind !== "f64") coerceType(ctx, fctx, keyResult, { kind: "f64" });
+    getIdx = ensureLateImport(ctx, "__extern_get_idx", [EXTERNREF, { kind: "f64" }], [EXTERNREF]);
+  } else {
+    emitToPropertyKeyOnce(ctx, fctx);
+    getIdx = ensureLateImport(ctx, "__extern_get", [EXTERNREF, EXTERNREF], [EXTERNREF]);
+  }
+  flushLateImportShifts(ctx, fctx);
+  if (getIdx === undefined) {
+    fctx.body.push({ op: "drop" });
+    fctx.body.push({ op: "drop" });
+    fctx.body.push({ op: "ref.null.extern" });
+    return EXTERNREF;
+  }
+  fctx.body.push({ op: "call", funcIdx: getIdx });
+  return EXTERNREF;
 }
 
 /**

--- a/src/codegen/array-nonindex-key.ts
+++ b/src/codegen/array-nonindex-key.ts
@@ -82,7 +82,30 @@ function factNeedsPropertyKeyRuntime(fact: TypeFact): boolean {
  * Constant spellings are classified by the helpers below first; this predicate
  * covers the remaining dynamic values (notably `x[object]` from ES5 T9).
  */
-export function isDynamicPropertyKeyExpression(ctx: CodegenContext, key: ts.Expression): boolean {
+function isOrdinaryArrayReceiver(ctx: CodegenContext, receiver: ts.Expression): boolean {
+  const type = ctx.checker.getTypeAtLocation(receiver);
+  const typeName = type.getSymbol()?.name ?? type.aliasSymbol?.name;
+  if (typeName === "Array" || typeName === "ReadonlyArray") return true;
+  const inner = skipTransparentExpressions(receiver);
+  if (ts.isArrayLiteralExpression(inner)) return true;
+  if (ts.isNewExpression(inner) && ts.isIdentifier(inner.expression) && inner.expression.text === "Array") return true;
+  if (!ts.isIdentifier(inner)) return false;
+  const declaration = ctx.oracle.valueDeclarationOf(inner);
+  if (!declaration || !ts.isVariableDeclaration(declaration) || !declaration.initializer) return false;
+  const initializer = skipTransparentExpressions(declaration.initializer);
+  return (
+    ts.isArrayLiteralExpression(initializer) ||
+    (ts.isNewExpression(initializer) &&
+      ts.isIdentifier(initializer.expression) &&
+      initializer.expression.text === "Array")
+  );
+}
+
+export function isDynamicPropertyKeyExpression(
+  ctx: CodegenContext,
+  key: ts.Expression,
+  receiver?: ts.Expression,
+): boolean {
   const keyFact = ctx.oracle.typeFactOf(key);
   if (factNeedsPropertyKeyRuntime(keyFact)) return true;
   const inner = skipTransparentExpressions(key);
@@ -93,7 +116,12 @@ export function isDynamicPropertyKeyExpression(ctx: CodegenContext, key: ts.Expr
   // Constant numeric expressions and simple variable indices stay on their
   // existing dense path.
   if (keyFact.kind === "number") {
-    return ts.isBinaryExpression(inner) && typeof resolveConstantExpression(ctx, inner) !== "number";
+    return (
+      receiver !== undefined &&
+      isOrdinaryArrayReceiver(ctx, receiver) &&
+      ts.isBinaryExpression(inner) &&
+      typeof resolveConstantExpression(ctx, inner) !== "number"
+    );
   }
   // A literal ordinary name (for example `"[object Object]"`) is also a
   // property key, not a numeric index. Numeric spellings and the historical

--- a/src/codegen/array-nonindex-key.ts
+++ b/src/codegen/array-nonindex-key.ts
@@ -106,6 +106,12 @@ export function isDynamicPropertyKeyExpression(
   key: ts.Expression,
   receiver?: ts.Expression,
 ): boolean {
+  // Bundlers routinely erase TypedArray annotations from helper parameters,
+  // leaving both the receiver and arithmetic key as `any`. The generic vec
+  // property route is for Array exotics only; an unknown receiver must retain
+  // the established dense element lane so Uint8Array copy loops do not get
+  // captured merely because checker precision was lost.
+  if (receiver !== undefined && !isOrdinaryArrayReceiver(ctx, receiver)) return false;
   const keyFact = ctx.oracle.typeFactOf(key);
   if (factNeedsPropertyKeyRuntime(keyFact)) return true;
   const inner = skipTransparentExpressions(key);
@@ -116,12 +122,7 @@ export function isDynamicPropertyKeyExpression(
   // Constant numeric expressions and simple variable indices stay on their
   // existing dense path.
   if (keyFact.kind === "number") {
-    return (
-      receiver !== undefined &&
-      isOrdinaryArrayReceiver(ctx, receiver) &&
-      ts.isBinaryExpression(inner) &&
-      typeof resolveConstantExpression(ctx, inner) !== "number"
-    );
+    return ts.isBinaryExpression(inner) && typeof resolveConstantExpression(ctx, inner) !== "number";
   }
   // A literal ordinary name (for example `"[object Object]"`) is also a
   // property key, not a numeric index. Numeric spellings and the historical

--- a/src/codegen/array-nonindex-key.ts
+++ b/src/codegen/array-nonindex-key.ts
@@ -83,9 +83,8 @@ function factNeedsPropertyKeyRuntime(fact: TypeFact): boolean {
  * covers the remaining dynamic values (notably `x[object]` from ES5 T9).
  */
 function isOrdinaryArrayReceiver(ctx: CodegenContext, receiver: ts.Expression): boolean {
-  const type = ctx.checker.getTypeAtLocation(receiver);
-  const typeName = type.getSymbol()?.name ?? type.aliasSymbol?.name;
-  if (typeName === "Array" || typeName === "ReadonlyArray") return true;
+  const receiverFact = ctx.oracle.typeFactOf(receiver);
+  if (receiverFact.kind === "array" || receiverFact.kind === "tuple") return true;
   const inner = skipTransparentExpressions(receiver);
   if (ts.isArrayLiteralExpression(inner)) return true;
   if (ts.isNewExpression(inner) && ts.isIdentifier(inner.expression) && inner.expression.text === "Array") return true;

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -766,6 +766,13 @@ function isOrdinaryToPrimitiveLiteralCandidate(literal: ts.ObjectLiteralExpressi
 function isNumericOrdinaryToPrimitiveUse(identifier: ts.Identifier): boolean {
   const parent = identifier.parent;
   if (!parent) return false;
+  // A computed property key applies ToPropertyKey (and therefore the
+  // OrdinaryToPrimitive valueOf/toString sequence) to the identifier. Treat
+  // this as a coercive use too: ES5 Array tests commonly redeclare the same
+  // `var object` with different valueOf/toString shapes before using it as
+  // `array[object]`. Keeping those sibling literals as closed structs loses
+  // the later shape behind the checker-identity-selected first declaration.
+  if (ts.isElementAccessExpression(parent) && parent.argumentExpression === identifier) return true;
   if (ts.isPrefixUnaryExpression(parent) && parent.operand === identifier) {
     return (
       parent.operator === ts.SyntaxKind.PlusToken ||

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -132,6 +132,7 @@ import {
   emitNonIndexVecElementSet,
   nonArrayIndexNumericKey,
   compileElementIndexI32,
+  isDynamicPropertyKeyExpression,
 } from "../array-nonindex-key.js"; // (#4247) §10.4.2.2 named-key routing + the relocated TA-view-name helper
 import {
   compileStringBuilderAppend,
@@ -5291,6 +5292,19 @@ function compileElementAssignment(
         then: [{ op: "ref.null.extern" }, { op: "throw", tagIdx }],
         else: [],
       });
+    }
+    // Dynamic object-like keys use ToPropertyKey, not the numeric element
+    // lane. Reuse the ordinary extern setter after the vec null guard so
+    // `x[object] = value` preserves coercion order and reaches either the
+    // numeric element or the vec expando/prototype path selected by the
+    // runtime (`S15.4_A1.1_T9`).
+    if (
+      elementAccessTypedArrayName(ctx, target.expression) === undefined &&
+      !(ts.isIdentifier(target.expression) && target.expression.text === "arguments") &&
+      isDynamicPropertyKeyExpression(ctx, target.argumentExpression)
+    ) {
+      fctx.body.push({ op: "local.get", index: vecLocal });
+      return compileExternSetFallback(ctx, fctx, target, value, arrType);
     }
     // Preserve range-proven counted-loop index arithmetic as i32. Fall back to
     // the existing conversion path when constants, bounds, or overflow safety

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -5301,7 +5301,7 @@ function compileElementAssignment(
     if (
       elementAccessTypedArrayName(ctx, target.expression) === undefined &&
       !(ts.isIdentifier(target.expression) && target.expression.text === "arguments") &&
-      isDynamicPropertyKeyExpression(ctx, target.argumentExpression)
+      isDynamicPropertyKeyExpression(ctx, target.argumentExpression, target.expression)
     ) {
       fctx.body.push({ op: "local.get", index: vecLocal });
       return compileExternSetFallback(ctx, fctx, target, value, arrType);

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -128,6 +128,8 @@ import {
   reserveVecPropHelpers,
 } from "./vec-props.js";
 import { ensureSymbolCarrier, usesNativeSymbolProvider } from "./symbol-native.js";
+import { ensureVecElemSet } from "./vec-elem-set.js";
+import { SPARSE_INDEX_CEILING } from "./vec-sparse-index.js";
 // (#4160) prototype-index store — reserve + registration-time consult builders
 // (all resolve to `undefined` unless `ctx.standalone && ctx.protoIndexDirty`).
 import {
@@ -9873,6 +9875,11 @@ export function fillExternSetVecArms(ctx: CodegenContext): void {
   const setDecideIdx = ctx.funcMap.get("__extern_set_decide");
   const descriptorDecisionAvailable =
     ctx.standalone && inheritedSetAnyDirty(ctx) && setResultGlobalIdx !== undefined && setDecideIdx !== undefined;
+  // Descriptor overlay writes are the lossless storage for canonical numeric
+  // keys that cannot be represented by the signed i32 backing lane. The
+  // overlay helper is reserved before this finalize-time fill and receives its
+  // real body later in the same finalize pass.
+  const vecDpValueIdx = ctx.funcMap.get("__vec_dp_value");
   const RESULT_SUCCESS = 1;
   const RESULT_REFUSED = 2;
   const publishSuccess = (): Instr[] =>
@@ -9940,6 +9947,60 @@ export function fillExternSetVecArms(ctx: CodegenContext): void {
               { op: "return" },
             ],
           },
+        ];
+
+  // The ordinary dynamic setter historically handled only in-bounds vec
+  // overwrites. Object-valued keys can canonicalize to a new numeric index,
+  // however (`x[object] = v` in ES5 T9), so use the same grow-and-set helper as
+  // the typed element-assignment lane for a canonical, non-negative index.
+  // Keep the 16M ceiling here as a trap guard for physical growth. Larger
+  // canonical indices use the descriptor overlay's companion map below, so a
+  // sparse write/read round-trips without allocating a four-billion-slot
+  // backing array.
+  const growCarrierArms: Instr[] = [];
+  for (const { typeIdx, elemType } of carriers) {
+    const unbox = unboxExternrefToVecElement(ctx, elemType);
+    const elemSetIdx = unbox === null ? null : ensureVecElemSet(ctx, typeIdx);
+    if (elemSetIdx === null) continue;
+    growCarrierArms.push(
+      { op: "local.get", index: setAny },
+      { op: "ref.test", typeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: setAny },
+          { op: "ref.cast", typeIdx },
+          { op: "local.get", index: setI },
+          { op: "local.get", index: 2 },
+          ...unboxExternrefToVecElement(ctx, elemType)!,
+          { op: "call", funcIdx: elemSetIdx },
+          ...publishSuccess(),
+          { op: "return" },
+        ],
+      },
+    );
+  }
+
+  // A canonical array-index string at or above the physical-growth ceiling is
+  // still a real property. Store it in the existing vec overlay rather than
+  // converting it through `i32.trunc_sat_f64_s` (which would saturate
+  // 4294967294 to i32.max and lose the original key). `__vec_dp_value` accepts
+  // the already-ToPropertyKey'd key and marks the companion value authoritative
+  // for the dynamic read prologue. Without an overlay helper, retain the
+  // historical lenient no-op.
+  const sparseOverlayStore: Instr[] =
+    vecDpValueIdx === undefined
+      ? buildNumericMissDecision()
+      : [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: 1 },
+          { op: "local.get", index: 2 },
+          { op: "f64.const", value: 0xbf },
+          { op: "call", funcIdx: vecDpValueIdx },
+          { op: "drop" },
+          ...publishSuccess(),
+          { op: "return" },
         ];
 
   for (const { typeIdx, arrTypeIdx, elemType } of carriers) {
@@ -10033,7 +10094,56 @@ export function fillExternSetVecArms(ctx: CodegenContext): void {
               op: "if",
               blockType: { kind: "empty" },
               then: carrierArms,
-              else: buildNumericMissDecision(),
+              else:
+                growCarrierArms.length === 0
+                  ? buildNumericMissDecision()
+                  : [
+                      // A grow is safe only for a canonical non-negative
+                      // integer. The signed conversion above is exact for
+                      // the small indices this path grows; the ceiling keeps
+                      // it away from the signed saturation boundary.
+                      { op: "local.get", index: setI },
+                      { op: "f64.convert_i32_s" },
+                      { op: "local.get", index: setN },
+                      { op: "f64.eq" },
+                      { op: "local.get", index: setI },
+                      { op: "i32.const", value: 0 },
+                      { op: "i32.ge_s" },
+                      { op: "i32.and" },
+                      { op: "local.get", index: setI },
+                      { op: "i32.const", value: SPARSE_INDEX_CEILING },
+                      { op: "i32.lt_u" },
+                      { op: "i32.and" },
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: growCarrierArms,
+                        else: [
+                          // The signed i32 conversion above cannot represent
+                          // the high half of the canonical array-index domain.
+                          // Test the original f64 first, then hand the exact
+                          // property key to the sparse companion store.
+                          { op: "local.get", index: setN },
+                          { op: "f64.floor" },
+                          { op: "local.get", index: setN },
+                          { op: "f64.eq" },
+                          { op: "local.get", index: setN },
+                          { op: "f64.const", value: 0 },
+                          { op: "f64.ge" },
+                          { op: "i32.and" },
+                          { op: "local.get", index: setN },
+                          { op: "f64.const", value: 4294967295 },
+                          { op: "f64.lt" },
+                          { op: "i32.and" },
+                          {
+                            op: "if",
+                            blockType: { kind: "empty" },
+                            then: sparseOverlayStore,
+                            else: buildNumericMissDecision(),
+                          },
+                        ],
+                      },
+                    ],
             },
             // NUMERIC key on a vec: handled here terminally — in-bounds stored
             // above (each carrier arm returns), OOB/grow/unsupported kind stays

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -214,9 +214,11 @@ import {
 } from "./builtin-value-read.js"; // (#3267) built-in static/prototype VALUE-read subsystem — extracted
 import {
   elementAccessTypedArrayName,
+  emitDynamicVecElementGet,
   emitNonIndexVecElementGet,
   nonArrayIndexNumericKey,
   compileElementIndexI32,
+  isDynamicPropertyKeyExpression,
 } from "./array-nonindex-key.js"; // (#4247)
 // (#3267) Re-export the moved symbols other modules import from property-access.js
 // so their `from "./property-access.js"` imports keep resolving unchanged.
@@ -5686,6 +5688,25 @@ export function compileElementAccessBody(
       }
     }
 
+    const isRegexMatchVec = typeDef.fields.length >= 4 && typeDef.fields[2]?.name === "index";
+    // Dynamic object-like keys must be canonicalized with ToPropertyKey before
+    // the receiver-specific runtime dispatch. This is the read twin of the
+    // assignment fallback above: numeric results (for example an object's
+    // `toString() { return 0; }`) still reach the vec element, while ordinary
+    // names use the expando/prototype lookup (`S15.4_A1.1_T9`). Constant
+    // numeric-looking names have already taken the dedicated bag route above.
+    if (
+      elementAccessTypedArrayName(ctx, expr.expression) === undefined &&
+      !(ts.isIdentifier(expr.expression) && expr.expression.text === "arguments") &&
+      !isRegexMatchVec &&
+      isDynamicPropertyKeyExpression(ctx, expr.argumentExpression)
+    ) {
+      const dynamic = emitDynamicVecElementGet(ctx, fctx, objType, expr.argumentExpression, (e, h) =>
+        compileExpression(ctx, fctx, e, h),
+      );
+      if (dynamic) return dynamic;
+    }
+
     // (#2743 b) `vec[Symbol.iterator]` is %Array.prototype.values%
     // (§10.4.4.6/§10.4.4.7 + the Array iterator), NOT a numeric index. This
     // covers BOTH `[][Symbol.iterator]` and `arguments[Symbol.iterator]` — both
@@ -5725,7 +5746,6 @@ export function compileElementAccessBody(
     // below. Other `i32` elements (packed-number / other handle reps) and
     // externref elements keep the shared-helper path; WasmGC `ref` / `ref_null`
     // elements use the dedicated reference-array widen below.
-    const isRegexMatchVec = typeDef.fields.length >= 4 && typeDef.fields[2]?.name === "index";
     const numericHint = expectedType?.kind === "f64" || expectedType?.kind === "i32";
     const taClass = classifyTypedArrayType(ctx.checker.getTypeAtLocation(expr.expression), ctx.checker);
     const oobUndefined = !numericHint && taClass === "other" && !isRegexMatchVec;

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -5699,7 +5699,7 @@ export function compileElementAccessBody(
       elementAccessTypedArrayName(ctx, expr.expression) === undefined &&
       !(ts.isIdentifier(expr.expression) && expr.expression.text === "arguments") &&
       !isRegexMatchVec &&
-      isDynamicPropertyKeyExpression(ctx, expr.argumentExpression)
+      isDynamicPropertyKeyExpression(ctx, expr.argumentExpression, expr.expression)
     ) {
       const dynamic = emitDynamicVecElementGet(ctx, fctx, objType, expr.argumentExpression, (e, h) =>
         compileExpression(ctx, fctx, e, h),

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -101,6 +101,7 @@ import { undefinedExternInstrs } from "./any-helpers.js";
 import { nonExtensibleFreshIndexGuard, nonWritableLengthIndexGuard } from "./vec-define-rejections.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
 import { canonicalNumericKeyGuard } from "./vec-index-domain.js"; // (#4434) index domain + sparse tail
+import { SPARSE_INDEX_CEILING } from "./vec-sparse-index.js";
 import { holeTestInstrs } from "./array-holes.js";
 import {
   buildArgumentsBrandBit,
@@ -1489,10 +1490,24 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
             },
           ];
         }
+        // The descriptor companion is authoritative for an unbacked sparse
+        // tail. Keep the physical write-back helper on its dense domain: its
+        // normal growth sequence intentionally traps on a four-billion-slot
+        // request, while a dynamic ordinary assignment must remain a
+        // companion-only write.
         writeBackArms.push(
-          { op: "local.get", index: 4 },
-          { op: "ref.test", typeIdx: c.vecTypeIdx },
-          { op: "if", blockType: { kind: "empty" }, then: inner },
+          { op: "local.get", index: 7 },
+          { op: "i32.const", value: SPARSE_INDEX_CEILING },
+          { op: "i32.lt_u" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 4 },
+              { op: "ref.test", typeIdx: c.vecTypeIdx },
+              { op: "if", blockType: { kind: "empty" }, then: inner },
+            ],
+          },
         );
       }
 
@@ -1618,6 +1633,10 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
             { op: "local.get", index: 7 },
             { op: "local.get", index: 8 },
             { op: "i32.ge_s" },
+            { op: "local.get", index: 7 },
+            { op: "i32.const", value: SPARSE_INDEX_CEILING },
+            { op: "i32.lt_u" },
+            { op: "i32.and" },
             { op: "i32.and" },
             {
               op: "if",
@@ -1685,6 +1704,10 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         { op: "local.get", index: 7 },
         { op: "local.get", index: 8 },
         { op: "i32.ge_s" },
+        { op: "local.get", index: 7 },
+        { op: "i32.const", value: SPARSE_INDEX_CEILING },
+        { op: "i32.lt_u" },
+        { op: "i32.and" },
         { op: "i32.and" },
         {
           op: "if",

--- a/tests/es5-array-constructor-pair.test.ts
+++ b/tests/es5-array-constructor-pair.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ES5 Array constructor edge cases covered by S15.4_A1.1_T9/T10:
+// object-valued property keys must use ToPropertyKey, and a dynamic numeric
+// key must remain readable after the array reaches the sparse-index ceiling.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, { target: "standalone", fileName: "es5-array-constructor-pair.ts" });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("ES5 Array constructor property-key edge cases (standalone)", () => {
+  it("canonicalizes repeated object-valued keys before the vec dispatch", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const x: any[] = [];
+        var object: any = {
+          valueOf: function(): number { return 1; },
+          toString: function(): number { return 0; },
+        };
+        x[object] = 7;
+        var object: any = {
+          valueOf: function(): number { return 1; },
+          toString: function(): number { return 0; },
+        };
+        return x[0] === 7 ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("round-trips dynamic indices through the sparse companion", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        var x: any[] = [];
+        var k = 1;
+        for (var i = 0; i < 32; i++) { k = k * 2; x[k - 2] = k; }
+        k = 1;
+        for (var i = 0; i < 32; i++) {
+          k = k * 2;
+          if (x[k - 2] !== k) return 0;
+        }
+        return 1;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes the two authoritative standalone ES5 Array constructor rows S15.4_A1.1_T9 and S15.4_A1.1_T10. Dynamic computed keys now use ToPropertyKey and sparse canonical indices round-trip through the descriptor companion without huge backing allocation. Adds focused standalone pins.\n\nValidation: exact Test262 T9/T10 pass; focused Vitest 2/2; TypeScript 5 and 7; Biome, Prettier, oracle/coercion ratchets, numeric-local parity, and full pre-push hooks pass.\n\nBase: loopdive/js2:main. Head: ttraenkler:codex/es5-array-constructor-pair-20260825.