### PR TITLE
fix(es5): preserve direct-eval assignment targets

### DIFF
--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -199,6 +199,7 @@ import {
   enclosingFunctionOwnScopeMayReachDirectEval,
   functionMayReachDirectEval,
   RUNTIME_EVAL_STATE_POOL_CAPTURE_NAME,
+  widenClosureReturnForDirectEval as widenEvalReturn,
 } from "./direct-eval-environment.js";
 import { initializeFunctionPoisonPillContext } from "./function-poison-pill.js";
 import {
@@ -1662,8 +1663,7 @@ export function computeClosureWrapperSig(
       }
     }
   }
-
-  return { params: arrowParams, returnType: closureReturnType, hasRestParam };
+  return { params: arrowParams, returnType: widenEvalReturn(ctx, arrow, closureReturnType), hasRestParam };
 }
 
 /**

--- a/src/codegen/direct-eval-environment.ts
+++ b/src/codegen/direct-eval-environment.ts
@@ -264,6 +264,56 @@ export function collectDirectEvalActivationBindingNames(decl: ts.FunctionLikeDec
   return names;
 }
 
+/** Preserve a real eval-created `undefined` when a closure returns a captured
+ * identifier whose inferred numeric ABI can be shadowed by direct eval. */
+export function widenClosureReturnForDirectEval(
+  ctx: CodegenContext,
+  arrow: ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression,
+  closureReturnType: ValType | null,
+): ValType | null {
+  if (
+    closureReturnType === null ||
+    (!ctx.standalone && !ctx.wasi) ||
+    !functionOwnScopeMayReachDirectEval(arrow, ctx.oracle) ||
+    !arrow.body ||
+    !ts.isBlock(arrow.body)
+  ) {
+    return closureReturnType;
+  }
+  const activationNames = collectDirectEvalActivationBindingNames(arrow);
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (node !== arrow.body && (ts.isFunctionLike(node) || ts.isClassDeclaration(node) || ts.isClassExpression(node))) {
+      return;
+    }
+    if (ts.isReturnStatement(node) && node.expression !== undefined) {
+      let expression = node.expression;
+      while (
+        ts.isParenthesizedExpression(expression) ||
+        ts.isAsExpression(expression) ||
+        ts.isNonNullExpression(expression) ||
+        ts.isTypeAssertionExpression(expression)
+      ) {
+        expression = ts.isParenthesizedExpression(expression)
+          ? expression.expression
+          : ts.isAsExpression(expression)
+            ? expression.expression
+            : ts.isNonNullExpression(expression)
+              ? expression.expression
+              : expression.expression;
+      }
+      if (ts.isIdentifier(expression) && expression.text !== "undefined" && !activationNames.has(expression.text)) {
+        found = true;
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(arrow.body, visit);
+  return found ? { kind: "externref" } : closureReturnType;
+}
+
 function boxTopAsExternref(ctx: CodegenContext, fctx: FunctionContext, type: ValType): void {
   if (type.kind !== "externref") coerceType(ctx, fctx, type, { kind: "externref" });
 }

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -149,8 +149,6 @@ import {
   emitCaptureRuntimeEvalBindingValueCell,
   emitGlobalEnvironmentKey,
   emitGlobalEnvironmentObject,
-  emitRefreshRuntimeEvalBindingValueCellForWrite,
-  emitRuntimeEvalBindingCellWrite,
   ensureGlobalEnvironmentOperation,
 } from "../global-environment.js";
 import { isStrictContext } from "../helpers/is-strict-function.js";
@@ -165,6 +163,7 @@ import { emitRuntimeEvalAotCallableAdapter } from "../runtime-eval-callable.js";
 import { tryEmitStaticI32Expression } from "../i32-static-range-expr.js";
 import { emitToPropertyKeyOnce } from "./computed-member-reference.js";
 import { inheritedSetAffectsKey } from "../inherited-set-gate.js"; // (#4602) per-key #4504 gate
+import { compileRuntimeEvalShadowedAssignment } from "./runtime-eval-assignment.js";
 
 /**
  * Emit a null/undefined guard for an externref-typed destructuring source.
@@ -320,53 +319,11 @@ export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, ex
     if (!isUnresolvableIdent(ctx, fctx, expr.left)) {
       const runtimeBinding = emitCaptureRuntimeEvalBindingValueCell(ctx, fctx, name);
       if (runtimeBinding) {
-        const wrapRuntimeEvalCallable = isStaticallyCallableExpression(ctx, expr.right);
-        const rhsType = compileExpression(
-          ctx,
-          fctx,
-          expr.right,
-          wrapRuntimeEvalCallable ? undefined : { kind: "externref" },
-        );
-        if (!rhsType) {
-          reportError(ctx, expr, "Failed to compile runtime-eval-shadowed assignment value");
-          return null;
-        }
-        if (rhsType.kind !== "externref") coerceType(ctx, fctx, rhsType, { kind: "externref" });
-        const rhsLocal = allocLocal(fctx, `__runtime_eval_shadow_rhs_${fctx.locals.length}`, {
-          kind: "externref",
+        return compileRuntimeEvalShadowedAssignment(ctx, fctx, expr, expr.left, name, runtimeBinding, {
+          isStaticallyCallableExpression,
+          tryEmitAmbientIdentifierGlobalWriteFromLocal,
+          emitIdentifierWriteFromLocal,
         });
-        fctx.body.push({ op: "local.set", index: rhsLocal });
-
-        const savedPresent = pushBody(fctx);
-        let cellValueLocal = rhsLocal;
-        if (wrapRuntimeEvalCallable) {
-          fctx.body.push({ op: "local.get", index: rhsLocal });
-          emitRuntimeEvalAotCallableAdapter(ctx, fctx);
-          cellValueLocal = allocLocal(fctx, `__runtime_eval_shadow_cell_value_${fctx.locals.length}`, {
-            kind: "externref",
-          });
-          fctx.body.push({ op: "local.set", index: cellValueLocal });
-        }
-        const refreshedBinding = emitRefreshRuntimeEvalBindingValueCellForWrite(ctx, fctx, name, runtimeBinding);
-        emitRuntimeEvalBindingCellWrite(fctx, refreshedBinding ?? runtimeBinding, cellValueLocal);
-        const presentBody = fctx.body;
-        popBody(fctx, savedPresent);
-
-        const savedMiss = pushBody(fctx);
-        if (!tryEmitAmbientIdentifierGlobalWriteFromLocal(ctx, fctx, expr.left, rhsLocal)) {
-          emitIdentifierWriteFromLocal(ctx, fctx, expr.left, rhsLocal);
-        }
-        const missBody = fctx.body;
-        popBody(fctx, savedMiss);
-
-        fctx.body.push(
-          { op: "local.get", index: runtimeBinding.valueCellLocal },
-          { op: "ref.is_null" },
-          { op: "i32.eqz" },
-          { op: "if", blockType: { kind: "empty" }, then: presentBody, else: missBody },
-          { op: "local.get", index: rhsLocal },
-        );
-        return { kind: "externref" };
       }
     }
     // const bindings — assignment throws TypeError at runtime

--- a/src/codegen/expressions/runtime-eval-assignment.ts
+++ b/src/codegen/expressions/runtime-eval-assignment.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Shared lowering for an assignment whose identifier may be shadowed by direct eval. */
+import { ts } from "../../ts-api.js";
+import { allocLocal } from "../context/locals.js";
+import { popBody, pushBody } from "../context/bodies.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import {
+  emitRefreshRuntimeEvalBindingValueCellForWrite,
+  emitRuntimeEvalBindingCellWrite,
+  type RuntimeEvalBindingValueCell,
+} from "../global-environment.js";
+import { emitRuntimeEvalAotCallableAdapter } from "../runtime-eval-callable.js";
+import type { InnerResult } from "../shared.js";
+import { coerceType, compileExpression } from "../shared.js";
+import { reportError } from "../context/errors.js";
+
+interface RuntimeEvalAssignmentHelpers {
+  isStaticallyCallableExpression: (ctx: CodegenContext, value: ts.Expression) => boolean;
+  tryEmitAmbientIdentifierGlobalWriteFromLocal: (
+    ctx: CodegenContext,
+    fctx: FunctionContext,
+    id: ts.Identifier,
+    rhsLocalIdx: number,
+  ) => boolean;
+  emitIdentifierWriteFromLocal: (
+    ctx: CodegenContext,
+    fctx: FunctionContext,
+    id: ts.Identifier,
+    rhsLocalIdx: number,
+  ) => void;
+}
+
+/** Compile a direct-eval-shadowable assignment with its LHS decision captured before the RHS. */
+export function compileRuntimeEvalShadowedAssignment(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  id: ts.Identifier,
+  name: string,
+  runtimeBinding: RuntimeEvalBindingValueCell,
+  helpers: RuntimeEvalAssignmentHelpers,
+): InnerResult {
+  const runtimeBindingPresent = allocLocal(fctx, `__runtime_eval_binding_present_${fctx.locals.length}`, {
+    kind: "i32",
+  });
+  fctx.body.push(
+    { op: "local.get", index: runtimeBinding.valueCellLocal },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    { op: "local.set", index: runtimeBindingPresent },
+  );
+
+  const wrapRuntimeEvalCallable = helpers.isStaticallyCallableExpression(ctx, expr.right);
+  const rhsLocal = allocLocal(fctx, `__runtime_eval_shadow_rhs_${fctx.locals.length}`, {
+    kind: "externref",
+  });
+
+  // Build the pre-RHS miss arm while fctx still names the outer capture. A
+  // direct eval in the RHS may otherwise mutate the binding maps before this
+  // original Reference is lowered.
+  const savedMiss = pushBody(fctx);
+  if (!helpers.tryEmitAmbientIdentifierGlobalWriteFromLocal(ctx, fctx, id, rhsLocal)) {
+    helpers.emitIdentifierWriteFromLocal(ctx, fctx, id, rhsLocal);
+  }
+  const missBody = fctx.body;
+  popBody(fctx, savedMiss);
+
+  const rhsType = compileExpression(ctx, fctx, expr.right, wrapRuntimeEvalCallable ? undefined : { kind: "externref" });
+  if (!rhsType) {
+    reportError(ctx, expr, "Failed to compile runtime-eval-shadowed assignment value");
+    return null;
+  }
+  if (rhsType.kind !== "externref") coerceType(ctx, fctx, rhsType, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: rhsLocal });
+
+  const savedPresent = pushBody(fctx);
+  let cellValueLocal = rhsLocal;
+  if (wrapRuntimeEvalCallable) {
+    fctx.body.push({ op: "local.get", index: rhsLocal });
+    emitRuntimeEvalAotCallableAdapter(ctx, fctx);
+    cellValueLocal = allocLocal(fctx, `__runtime_eval_shadow_cell_value_${fctx.locals.length}`, {
+      kind: "externref",
+    });
+    fctx.body.push({ op: "local.set", index: cellValueLocal });
+  }
+  const refreshedBinding = emitRefreshRuntimeEvalBindingValueCellForWrite(ctx, fctx, name, runtimeBinding);
+  emitRuntimeEvalBindingCellWrite(fctx, refreshedBinding ?? runtimeBinding, cellValueLocal);
+  const presentBody = fctx.body;
+  popBody(fctx, savedPresent);
+
+  fctx.body.push(
+    { op: "local.get", index: runtimeBindingPresent },
+    { op: "if", blockType: { kind: "empty" }, then: presentBody, else: missBody },
+    { op: "local.get", index: rhsLocal },
+  );
+  return { kind: "externref" };
+}

--- a/tests/es5-standalone-assignment-eval-scope.test.ts
+++ b/tests/es5-standalone-assignment-eval-scope.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ES5 standalone direct-eval assignment scope regressions. In both rows the
+// left-hand Reference must be resolved before the RHS eval can declare a
+// same-named var in the closure's direct-eval environment.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_HARNESS = join(__dirname, "..", "test262", "harness", "assert.js");
+const TEST262 = existsSync(TEST262_HARNESS);
+
+// Keep the in-process runner responsive when both authoritative rows compile
+// back-to-back in the same vitest worker.
+afterEach(async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
+const ROWS = [
+  "language/expressions/assignment/S11.13.1_A6_T1.js",
+  "language/expressions/assignment/S11.13.1_A6_T2.js",
+] as const;
+
+describe.skipIf(!TEST262)("ES5 standalone assignment with direct-eval var scope", () => {
+  for (const relativePath of ROWS) {
+    it(relativePath, { timeout: 60_000 }, async () => {
+      const filePath = join(__dirname, "..", "test262", "test", relativePath);
+      const result = await runTest262File(filePath, "es5-assignment-eval-scope", 30_000, "standalone");
+      expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- resolve assignment targets before a direct-eval RHS can introduce a same-named binding
- preserve potentially shadowed standalone closure results in the externref carrier
- pin the two ES5 Test262 assignment-scope regressions

## Test262 impact

- `language/expressions/assignment/S11.13.1_A6_T1.js`: fail → pass
- `language/expressions/assignment/S11.13.1_A6_T2.js`: fail → pass
- focused rows: 2/2
- composed aggregate tests: 18/18 across assignment, Array constructor, and Object.keys

## Verification

- rebased onto current `loopdive/js2:main`
- full normal pre-push hooks passed (typecheck/lint, Prettier, oracle ratchet, coercion ratchet, numeric-local parity 18/18, issue integrity)
- no verification bypasses used