### PR TITLE
fix(es5): preserve defineProperties array residuals

### DIFF
--- a/src/codegen/array-nonindex-key.ts
+++ b/src/codegen/array-nonindex-key.ts
@@ -230,6 +230,7 @@ export function nonArrayIndexNumericKey(
   ctx: CodegenContext,
   fctx: FunctionContext,
   key: ts.Expression,
+  allowHighArrayIndex = false,
 ): string | undefined {
   // `skipTransparentExpressions` unwraps parens AND the type-only wrappers
   // (`x as any`, `<any>x`, `!`), which carry no runtime meaning — the key
@@ -281,14 +282,18 @@ export function nonArrayIndexNumericKey(
 
   const n = resolveNumericKey(ctx, fctx, key);
   if (n !== undefined) {
-    if (isArrayIndexNumber(n)) return undefined;
+    if (isArrayIndexNumber(n)) return allowHighArrayIndex && n > 0x7fffffff ? String(n) : undefined;
     // `String(n)` IS ECMAScript `ToString(Number)` for every finite and
     // non-finite double, including `"1e+21"` and `"-Infinity"`.
     return String(n);
   }
 
   const s = resolveStringKey(ctx, fctx, key);
-  if (s === undefined || isArrayIndexString(s) || !isNamedNumericOrBooleanSpelling(s)) return undefined;
+  if (s === undefined || !isNamedNumericOrBooleanSpelling(s)) return undefined;
+  if (isArrayIndexString(s)) {
+    const n = Number(s);
+    return allowHighArrayIndex && n > 0x7fffffff ? s : undefined;
+  }
   return s;
 }
 

--- a/src/codegen/declarations/array-rebind-element-widening.ts
+++ b/src/codegen/declarations/array-rebind-element-widening.ts
@@ -48,7 +48,7 @@
  * WITHIN one write (`[obj, true]`) is the array-literal element-typing lane's
  * job and is not touched here.
  */
-import type { JsTag } from "../../checker/oracle.js";
+import { jsTagOfFact, type JsTag } from "../../checker/oracle.js";
 import type { ValType } from "../../ir/types.js";
 import { ts } from "../../ts-api.js";
 import type { CodegenContext } from "../context/types.js";
@@ -73,8 +73,130 @@ export function rebindWidenedArrayVecType(
   decl: ts.VariableDeclaration,
 ): ValType | undefined {
   if (!ts.isIdentifier(decl.name)) return undefined;
+  const descriptorType = descriptorValueWidenedArrayVecType(ctx, sourceFile, decl);
+  if (descriptorType !== undefined) return descriptorType;
   if (!widenedVarsOf(ctx, sourceFile).has(decl.name.text)) return undefined;
   return { kind: "ref_null", typeIdx: getOrRegisterVecType(ctx, "externref", { kind: "externref" }) };
+}
+
+/**
+ * (#4491) A standalone data descriptor can write a value whose JS tag cannot
+ * live in the array's inferred primitive element carrier. The descriptor
+ * overlay correctly keeps that value in its companion, but a typed element
+ * read would otherwise bypass the companion and return the stale primitive
+ * slot. Widen the binding's element carrier before its initializer is built so
+ * the ordinary vec read/write path remains authoritative.
+ *
+ * This is deliberately limited to statically known indexed data descriptors:
+ * unknown descriptors and non-index expandos retain their existing lowering,
+ * while a dynamic value remains the overlay's responsibility. The standalone
+ * lane is the only one with this WasmGC vec/companion split; host arrays do not
+ * need a representation change here.
+ */
+export function descriptorValueWidenedArrayVecType(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  decl: ts.VariableDeclaration,
+): ValType | undefined {
+  if (!ctx.standalone || !ts.isIdentifier(decl.name)) return undefined;
+  const elementTag = jsTagOfFact(ctx.oracle.elementFactOf(decl));
+  if (elementTag === undefined || !["number", "string", "boolean", "bigint"].includes(elementTag)) {
+    return undefined;
+  }
+
+  let widened = false;
+  const indexedKey = (node: ts.Node): boolean => {
+    const key = ts.isStringLiteral(node) || ts.isNumericLiteral(node) ? node.text : undefined;
+    if (key === undefined || !/^(0|[1-9][0-9]*)$/.test(key)) return false;
+    const numeric = Number(key);
+    return Number.isInteger(numeric) && numeric >= 0 && numeric < 0xffffffff;
+  };
+  const descriptorValue = (node: ts.Expression): ts.Expression | undefined => {
+    let desc = node;
+    while (
+      ts.isParenthesizedExpression(desc) ||
+      ts.isAsExpression(desc) ||
+      ts.isTypeAssertionExpression(desc) ||
+      ts.isNonNullExpression(desc) ||
+      ts.isSatisfiesExpression(desc)
+    ) {
+      desc = desc.expression;
+    }
+    if (!ts.isObjectLiteralExpression(desc)) return undefined;
+    let value: ts.Expression | undefined;
+    for (const property of desc.properties) {
+      if (ts.isPropertyAssignment(property) || ts.isShorthandPropertyAssignment(property)) {
+        const name = property.name;
+        if ((ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === "value") {
+          value = ts.isPropertyAssignment(property) ? property.initializer : property.name;
+        }
+      }
+      if (
+        (ts.isPropertyAssignment(property) || ts.isMethodDeclaration(property)) &&
+        (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) &&
+        (property.name.text === "get" || property.name.text === "set")
+      ) {
+        return undefined;
+      }
+    }
+    return value;
+  };
+  const incompatible = (value: ts.Expression): boolean => {
+    const valueTag = ctx.oracle.staticJsTypeOf(value);
+    return valueTag !== "mixed" && valueTag !== elementTag;
+  };
+  const visit = (node: ts.Node): void => {
+    if (widened || !ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) {
+      ts.forEachChild(node, visit);
+      return;
+    }
+    const callee = node.expression;
+    if (
+      !ts.isIdentifier(callee.expression) ||
+      callee.expression.text !== "Object" ||
+      !ts.isIdentifier(callee.name) ||
+      (callee.name.text !== "defineProperty" && callee.name.text !== "defineProperties")
+    ) {
+      ts.forEachChild(node, visit);
+      return;
+    }
+    const receiver = node.arguments[0];
+    if (!receiver || !ts.isIdentifier(receiver) || ctx.oracle.variableDeclarationOf(receiver) !== decl) {
+      ts.forEachChild(node, visit);
+      return;
+    }
+    if (callee.name.text === "defineProperty" && node.arguments.length >= 3) {
+      const key = node.arguments[1]!;
+      const value = descriptorValue(node.arguments[2]!);
+      if (indexedKey(key) && value !== undefined && incompatible(value)) widened = true;
+    } else if (callee.name.text === "defineProperties" && node.arguments.length >= 2) {
+      let descriptors = node.arguments[1]!;
+      while (
+        ts.isParenthesizedExpression(descriptors) ||
+        ts.isAsExpression(descriptors) ||
+        ts.isTypeAssertionExpression(descriptors) ||
+        ts.isNonNullExpression(descriptors) ||
+        ts.isSatisfiesExpression(descriptors)
+      ) {
+        descriptors = descriptors.expression;
+      }
+      if (ts.isObjectLiteralExpression(descriptors)) {
+        for (const property of descriptors.properties) {
+          if (!ts.isPropertyAssignment(property)) continue;
+          const value = descriptorValue(property.initializer);
+          if (indexedKey(property.name) && value !== undefined && incompatible(value)) {
+            widened = true;
+            break;
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return widened
+    ? { kind: "ref_null", typeIdx: getOrRegisterVecType(ctx, "externref", { kind: "externref" }) }
+    : undefined;
 }
 
 /**

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -5679,7 +5679,7 @@ export function compileElementAccessBody(
       elementAccessTypedArrayName(ctx, expr.expression) === undefined &&
       !(ts.isIdentifier(expr.expression) && expr.expression.text === "arguments")
     ) {
-      const namedKey = nonArrayIndexNumericKey(ctx, fctx, expr.argumentExpression);
+      const namedKey = nonArrayIndexNumericKey(ctx, fctx, expr.argumentExpression, true);
       if (namedKey !== undefined) {
         const named = emitNonIndexVecElementGet(ctx, fctx, namedKey);
         if (named) return named;

--- a/src/codegen/vec-overlay-high-index.ts
+++ b/src/codegen/vec-overlay-high-index.ts
@@ -63,9 +63,15 @@ export function growHighArrayIndexLength(
   keyNumLocal: number,
   highArrayIndexLocal: number,
   vecBaseIdx: number,
+  descriptorFlagsLocal: number,
+  ordinarySetFlags: number,
 ): Instr[] {
   return [
     { op: "local.get", index: highArrayIndexLocal },
+    { op: "local.get", index: descriptorFlagsLocal },
+    { op: "f64.const", value: ordinarySetFlags },
+    { op: "f64.ne" },
+    { op: "i32.and" },
     {
       op: "if",
       blockType: { kind: "empty" },

--- a/src/codegen/vec-overlay-high-index.ts
+++ b/src/codegen/vec-overlay-high-index.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Standalone descriptor-overlay helpers for the upper half of the ES array-index
+// domain. The object runtime keeps a signed i32 index for property ordering, but
+// an array descriptor still needs to retain both its numeric-key reachability and
+// its uint32 logical length.
+
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { canonicalNumericKeyGuard } from "./vec-index-domain.js";
+
+/**
+ * Mark a canonical numeric string as reachable through the indexed read lane.
+ * When requested, also retain the legal high-index fact that the signed object
+ * index parser cannot represent.
+ */
+export function markNumericLikeNamedKey(
+  ctx: CodegenContext,
+  keyLocal: number,
+  scratchF64: number,
+  numericFlagGlobalIdx: number,
+  numToStringIdx: number,
+  strFlattenIdx: number,
+  strEqualsIdx: number,
+  anyStrTypeIdx: number,
+  highArrayIndexLocal?: number,
+): Instr[] {
+  const strToNumberIdx = ctx.funcMap.get("__str_to_number");
+  if (strToNumberIdx === undefined) return [];
+  const mark: Instr[] = [
+    { op: "i32.const", value: 1 },
+    { op: "global.set", index: numericFlagGlobalIdx },
+  ];
+  if (highArrayIndexLocal !== undefined) {
+    mark.push(
+      { op: "local.get", index: scratchF64 },
+      { op: "f64.const", value: 2147483647 },
+      { op: "f64.gt" },
+      { op: "local.get", index: scratchF64 },
+      { op: "f64.const", value: 4294967295 },
+      { op: "f64.lt" },
+      { op: "i32.and" },
+      { op: "local.set", index: highArrayIndexLocal },
+    );
+  }
+  return canonicalNumericKeyGuard(
+    keyLocal,
+    scratchF64,
+    {
+      strToNumber: strToNumberIdx,
+      numberToString: numToStringIdx,
+      strFlatten: strFlattenIdx,
+      strEquals: strEqualsIdx,
+      anyStrTypeIdx,
+    },
+    mark,
+  );
+}
+
+/** Update a vec's uint32 logical length after a high-index descriptor define. */
+export function growHighArrayIndexLength(
+  vecLocal: number,
+  keyNumLocal: number,
+  highArrayIndexLocal: number,
+  vecBaseIdx: number,
+): Instr[] {
+  return [
+    { op: "local.get", index: highArrayIndexLocal },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: vecLocal },
+        { op: "ref.cast", typeIdx: vecBaseIdx },
+        { op: "local.get", index: keyNumLocal },
+        { op: "f64.const", value: 1 },
+        { op: "f64.add" },
+        { op: "i32.trunc_sat_f64_u" },
+        { op: "struct.set", typeIdx: vecBaseIdx, fieldIdx: 0 },
+      ],
+    },
+  ];
+}

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -100,7 +100,7 @@ import {
 import { undefinedExternInstrs } from "./any-helpers.js";
 import { nonExtensibleFreshIndexGuard, nonWritableLengthIndexGuard } from "./vec-define-rejections.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
-import { canonicalNumericKeyGuard } from "./vec-index-domain.js"; // (#4434) index domain + sparse tail
+import { growHighArrayIndexLength, markNumericLikeNamedKey } from "./vec-overlay-high-index.js";
 import { holeTestInstrs } from "./array-holes.js";
 import {
   buildArgumentsBrandBit,
@@ -780,38 +780,6 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
     { op: "i32.eqz" },
     { op: "if", blockType: { kind: "empty" }, then: inner },
   ];
-
-  /**
-   * (#4434) Mark the module as carrying an indexed-lane-reachable companion
-   * entry when the key is a canonical numeric STRING that is not an array
-   * index (`"4294967295"`, `"4294967296"`, `"1e21"`).
-   *
-   * The `__extern_get_idx` prologue is gated on this flag, and the define path
-   * set it only for keys with an index `>= 0` — but `arr[4294967295]` reaches
-   * that same prologue as an f64 whose `number_toString` is the stored key. So
-   * the flag has to follow reachability, not index-ness; see
-   * `canonicalNumericKeyGuard`'s doc comment. Returns `[]` (no-op) when
-   * `__str_to_number` is unavailable, leaving today's behaviour.
-   */
-  const markNumericLikeNamedKey = (keyLocal: number, scratchF64: number): Instr[] => {
-    const strToNumberIdx = ctx.funcMap.get("__str_to_number");
-    if (strToNumberIdx === undefined) return [];
-    return canonicalNumericKeyGuard(
-      keyLocal,
-      scratchF64,
-      {
-        strToNumber: strToNumberIdx,
-        numberToString: numToStringIdx,
-        strFlatten: strFlattenIdx,
-        strEquals: strEqualsIdx,
-        anyStrTypeIdx,
-      },
-      [
-        { op: "i32.const", value: 1 },
-        { op: "global.set", index: core.numericFlagGlobalIdx },
-      ],
-    );
-  };
 
   /** `idxLocal = __obj_index_of_key(cast key)` — canonical array index or -1. */
   const parseIndex = (keyLocal: number, idxLocal: number): Instr[] => [
@@ -1569,7 +1537,17 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         {
           op: "if",
           blockType: { kind: "empty" },
-          then: markNumericLikeNamedKey(1, 20),
+          then: markNumericLikeNamedKey(
+            ctx,
+            1,
+            20,
+            core.numericFlagGlobalIdx,
+            numToStringIdx,
+            strFlattenIdx,
+            strEqualsIdx,
+            anyStrTypeIdx,
+            13,
+          ),
         },
         // (#4010 S1′) Named-key twin of the index seed above — see `vec-bag-seed.ts`.
         // Deliberately NOT applied on the accessor path: converting a data
@@ -1582,6 +1560,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         { op: "local.get", index: 3 },
         { op: "call", funcIdx: dpValueIdx },
         { op: "drop" },
+        ...growHighArrayIndexLength(4, 20, 13, vecBaseIdx),
         // Write-back for index-keyed DATA defines carrying a [[Value]].
         { op: "local.get", index: 3 },
         { op: "i32.trunc_f64_s" },
@@ -1797,7 +1776,16 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         {
           op: "if",
           blockType: { kind: "empty" },
-          then: markNumericLikeNamedKey(1, 13),
+          then: markNumericLikeNamedKey(
+            ctx,
+            1,
+            13,
+            core.numericFlagGlobalIdx,
+            numToStringIdx,
+            strFlattenIdx,
+            strEqualsIdx,
+            anyStrTypeIdx,
+          ),
         },
         // Delegate the accessor define (validation + merge live in the native).
         { op: "local.get", index: 7 },

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -1560,7 +1560,13 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         { op: "local.get", index: 3 },
         { op: "call", funcIdx: dpValueIdx },
         { op: "drop" },
-        ...growHighArrayIndexLength(4, 20, 13, vecBaseIdx),
+        // Ordinary sparse assignment already uses the companion store/read
+        // lane. Growing its logical length to u32::MAX makes the legacy vec
+        // read guard swallow lower dynamic indices before that companion can
+        // answer. Descriptor defines still need §10.4.2.2 length growth; the
+        // all-true ordinary-set flags distinguish the existing assignment
+        // call sites from the descriptor API's partial descriptor here.
+        ...growHighArrayIndexLength(4, 20, 13, vecBaseIdx, 3, SEED_FLAGS),
         // Write-back for index-keyed DATA defines carrying a [[Value]].
         { op: "local.get", index: 3 },
         { op: "i32.trunc_f64_s" },

--- a/tests/issue-4491-wave4.test.ts
+++ b/tests/issue-4491-wave4.test.ts
@@ -30,7 +30,10 @@
  * a later lane's fix flips a red test to green rather than landing unnoticed.
  */
 import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
 
 async function runStandalone(source: string): Promise<unknown> {
   const result = await compile(source, {
@@ -315,11 +318,12 @@ describe("#4491 wave-4 — measured residuals", () => {
     ).toBe(1);
   });
 
-  // #4497. `MAX_CANONICAL_INDEX` is 2^31-1 because `__obj_index_of_key`'s
-  // result doubles as a SIGNED sort key, so an index in [2^31, 2^32-2] is
-  // treated as an ordinary string key and never bumps `length`.
+  // #4497. `__obj_index_of_key` still uses a signed sort key, so the upper
+  // half of the legal u32 index domain stays out of the i32 element lane. The
+  // descriptor sidecar retains the value and the logical length is updated
+  // without allocating an unbackable backing array.
   // (`defineProperty/15.2.3.6-4-183`, `defineProperties/15.2.3.7-6-a-179`.)
-  it.fails("an array index at 2^32-2 bumps length to 2^32-1", async () => {
+  it("an array index at 2^32-2 bumps length to 2^32-1", async () => {
     expect(
       await runStandalone(`
         export function main() {
@@ -332,23 +336,42 @@ describe("#4491 wave-4 — measured residuals", () => {
   });
 
   // A data-only descriptor whose VALUE is kind-incompatible with the array's
-  // carrier (a string into a `__vec_f64`) cannot be written back into the
-  // element, so it lands in the companion with FLAG_COMPANION_VALUE — but
-  // `isNonDataDescriptorDefine` calls `{value: "abc"}` data-only, so the module
-  // is not descriptor-dirty and the typed read never consults the companion.
-  // Fixing it in the PRE-SCAN would route every element access in any module
-  // containing `Object.defineProperty(x, k, {value: <non-numeric>})` through
-  // the dynamic lane; the narrow fix is to widen the array's own CARRIER
-  // (`heterogeneousWidenedModuleGlobalType`, #4428) for that binding.
+  // carrier (a string into a `__vec_f64`) must remain authoritative on the
+  // typed read path. The narrow fix widens only the affected binding's element
+  // carrier; compatible numeric descriptors retain the dense representation.
   // (`defineProperties/15.2.3.7-6-a-183`.)
-  it.fails("a string value defined on a numeric array is read back", async () => {
+  it("a string value defined on a numeric array is read back", async () => {
+    expect(
+      await runStandalone(`
+        var arr = [1, 2, 3];
+        Object.defineProperty(arr, "length", { writable: false });
+        Object.defineProperties(arr, { "1": { value: "abc" } });
+        export function main() {
+          return (arr[0] === 1 && arr[1] === "abc" && arr[2] === 3) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("keeps a non-index numeric-looking property out of length", async () => {
+    expect(
+      await runStandalone(`
+        export function main() {
+          var arr = [];
+          Object.defineProperties(arr, { "4294967295": { value: 100 } });
+          return (arr.length === 0 && arr[4294967295] === 100) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("keeps compatible data descriptors on the dense numeric carrier", async () => {
     expect(
       await runStandalone(`
         export function main() {
           var arr = [1, 2, 3];
-          Object.defineProperty(arr, "length", { writable: false });
-          Object.defineProperties(arr, { "1": { value: "abc" } });
-          return (arr[0] === 1 && arr[1] === "abc" && arr[2] === 3) ? 1 : 0;
+          Object.defineProperties(arr, { "1": { value: 42 } });
+          return (arr.length === 3 && arr[0] === 1 && arr[1] === 42 && arr[2] === 3) ? 1 : 0;
         }
       `),
     ).toBe(1);
@@ -429,4 +452,24 @@ describe("#4491 wave-4 — measured residuals", () => {
       `),
     ).toBe(1);
   });
+});
+
+const TEST262_HARNESS = join(__dirname, "..", "test262", "harness", "assert.js");
+const TEST262 = existsSync(TEST262_HARNESS);
+
+describe.skipIf(!TEST262)("#4491 wave-4 — exact defineProperties residuals", () => {
+  for (const rel of [
+    "built-ins/Object/defineProperties/15.2.3.7-6-a-179.js",
+    "built-ins/Object/defineProperties/15.2.3.7-6-a-183.js",
+  ]) {
+    it(`${rel} passes on the standalone lane`, { timeout: 60_000 }, async () => {
+      const result = await runTest262File(
+        join(__dirname, "..", "test262", "test", rel),
+        "issue-4491-wave4",
+        30_000,
+        "standalone",
+      );
+      expect(`${result.status}: ${result.reason ?? ""}`).toBe("pass: ");
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- preserve descriptor values for high array-index keys without allocating a four-billion-slot backing array
- widen descriptor-array carriers for non-writable length/value combinations
- keep ordinary sparse assignment reads stable while descriptor definitions update logical array length

## Test262 flips
- test/built-ins/Object/defineProperties/15.2.3.7-6-a-179.js
- test/built-ins/Object/defineProperties/15.2.3.7-6-a-183.js

## Verification
- focused issue-4491 wave 4: 18/18
- official high-index controls: 5/5, including Array assignment/length and Object.defineProperty
- aggregate Array constructor pair: 2/2
- full normal pre-push hooks: typecheck, lint, format, oracle/coercion ratchets, numeric-local IR parity 18/18, issue integrity

Base is loopdive/js2:main; ttraenkler/js2 is used only for the head branch.