### PR TITLE
fix(standalone): reify ES5 global own-property-name carriers

### DIFF
--- a/src/codegen/array-nonindex-key.ts
+++ b/src/codegen/array-nonindex-key.ts
@@ -60,6 +60,7 @@ import { tryEmitStaticI32Expression } from "./i32-static-range-expr.js";
 import { highArrayIndexLiteralI32 } from "./vec-sparse-index.js";
 import { TYPED_ARRAY_NAMES } from "./index.js";
 import { VEC_PROP_GET, VEC_PROP_SET } from "./vec-props.js";
+import { emitToNumber } from "./coercion-engine.js";
 
 const EXTERNREF: ValType = { kind: "externref" };
 
@@ -389,6 +390,18 @@ export function compileElementIndexI32(ctx: CodegenContext, fctx: FunctionContex
   const highIdx = highArrayIndexLiteralI32(key);
   if (highIdx !== undefined) {
     fctx.body.push({ op: "i32.const", value: highIdx });
+    return { kind: "i32" };
+  }
+  // A `for...in` target is stored as an externref because the loop writes
+  // property-key strings, even when TypeScript inferred a numeric index. The
+  // concrete vec path still needs its numeric position; coerce that string
+  // key with the normal ToNumber helper instead of asking compileExpression
+  // for i32 directly (which produces the zero default for an externref).
+  if (ts.isIdentifier(key) && fctx.forInIdentifierVars?.has(key.text)) {
+    const keyType = compileExpression(ctx, fctx, key, EXTERNREF);
+    if (keyType === null) return null;
+    emitToNumber(ctx, fctx, keyType);
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" });
     return { kind: "i32" };
   }
   if (tryEmitStaticI32Expression(ctx, fctx, key)) return { kind: "i32" };

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -87,7 +87,11 @@ import {
   emitStringProtoToStringFlat,
 } from "./string-proto-tostring.js"; // (#3992)
 import { standaloneGlobalFunctionSeedInstrs } from "./standalone-global-functions.js";
-import { emitBuiltinNamespaceObject } from "./builtin-static-globals.js";
+import {
+  appendStandaloneGlobalNamespaceSeeds,
+  appendStandaloneGlobalObjectCarrierSeeds,
+  standaloneGlobalEvalSeedInstrs,
+} from "./standalone-global-object-carriers.js";
 
 /**
  * `Array.prototype`'s own enumerable+non-enumerable method names (ES2024
@@ -2758,21 +2762,9 @@ export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionCo
   const savedBody = fctx.body;
   fctx.body = [];
   ctx.liveBodies.add(savedBody);
-  for (const name of ["Array", "Object", "JSON", "Math", "Proxy", "Reflect"] as const) {
-    fctx.body.push({ op: "local.get", index: objLocal });
-    addStringConstantGlobal(ctx, name);
-    fctx.body.push(...stringConstantExternrefInstrs(ctx, name));
-    if (emitBuiltinNamespaceObject(ctx, fctx, name) === null) {
-      fctx.body.push({ op: "ref.null.extern" });
-    }
-    const defineIdx = ctx.funcMap.get("__defineProperty_value");
-    if (defineIdx === undefined) {
-      fctx.body.push({ op: "drop" }, { op: "drop" }, { op: "drop" });
-      continue;
-    }
-    // Global builtin bindings: writable, non-enumerable, configurable.
-    fctx.body.push({ op: "f64.const", value: 0x05 }, { op: "call", funcIdx: defineIdx }, { op: "drop" });
-  }
+  const evalSeeds = standaloneGlobalEvalSeedInstrs(ctx, fctx, objLocal);
+  appendStandaloneGlobalNamespaceSeeds(ctx, fctx, objLocal);
+  appendStandaloneGlobalObjectCarrierSeeds(ctx, fctx, objLocal);
   const namespaceSeeds = fctx.body;
   fctx.body = savedBody;
   ctx.liveBodies.delete(savedBody);
@@ -2782,6 +2774,7 @@ export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionCo
   const defineValueIdx = ctx.funcMap.get("__defineProperty_value");
   const boxNumberIdx = ctx.funcMap.get("__box_number");
   if (!functionSeeds || newObjectIdx === undefined || defineValueIdx === undefined || boxNumberIdx === undefined) {
+    ctx.liveBodies.delete(evalSeeds);
     ctx.liveBodies.delete(namespaceSeeds);
     return null;
   }
@@ -2812,12 +2805,14 @@ export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionCo
   const initBody: Instr[] = [
     { op: "call", funcIdx: newObjectIdx },
     { op: "local.set", index: objLocal },
+    ...evalSeeds,
     ...functionSeeds,
     ...valueSeeds,
     ...namespaceSeeds,
     { op: "local.get", index: objLocal },
     { op: "global.set", index: globalIdx },
   ];
+  ctx.liveBodies.delete(evalSeeds);
   ctx.liveBodies.delete(namespaceSeeds);
   fctx.body.push({ op: "global.get", index: globalIdx });
   fctx.body.push({ op: "ref.is_null" });

--- a/src/codegen/context/locals.ts
+++ b/src/codegen/context/locals.ts
@@ -15,6 +15,14 @@ export function allocLocal(fctx: FunctionContext, name: string, type: ValType): 
   return index;
 }
 
+/** Reuse/allocate an inline `var` for-in target and retain its string carrier. */
+export function ensureForInIdentifierLocal(fctx: FunctionContext, name: string): number {
+  const existing = fctx.localMap.get(name);
+  const index = existing !== undefined ? existing : allocLocal(fctx, name, { kind: "externref" });
+  (fctx.forInIdentifierVars ??= new Set()).add(name);
+  return index;
+}
+
 /**
  * #1847 — snapshot of the local-allocation state, for tentative compilation
  * that may be rolled back. Captures the locals-vector length so callers can

--- a/src/codegen/standalone-global-object-carriers.ts
+++ b/src/codegen/standalone-global-object-carriers.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { undefinedExternInstrs } from "./any-helpers.js";
+import {
+  emitBuiltinConstructorIdentity,
+  emitBuiltinNamespaceObject,
+  isSupportedBuiltinNamespace,
+} from "./builtin-static-globals.js";
+import { emitStandaloneFunctionIntrinsicValue } from "./function-intrinsic-carrier.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+
+/** Seed the existing namespace carriers on the same native realm object. */
+export function appendStandaloneGlobalNamespaceSeeds(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  objectLocal: number,
+): void {
+  for (const name of ["Array", "Object", "JSON", "Math", "Proxy", "Reflect"] as const) {
+    fctx.body.push({ op: "local.get", index: objectLocal });
+    addStringConstantGlobal(ctx, name);
+    fctx.body.push(...stringConstantExternrefInstrs(ctx, name));
+    if (emitBuiltinNamespaceObject(ctx, fctx, name) === null) {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    const defineIdx = ctx.funcMap.get("__defineProperty_value");
+    if (defineIdx === undefined) {
+      fctx.body.push({ op: "drop" }, { op: "drop" }, { op: "drop" });
+      continue;
+    }
+    fctx.body.push({ op: "f64.const", value: 0x05 }, { op: "call", funcIdx: defineIdx }, { op: "drop" });
+  }
+}
+
+/** ES5 global constructors not already covered by the namespace seed below. */
+const STANDALONE_GLOBAL_CONSTRUCTOR_NAMES = [
+  "Function",
+  "String",
+  "Boolean",
+  "Number",
+  "Date",
+  "RegExp",
+  "Error",
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+] as const;
+
+export function appendStandaloneGlobalConstructorSeeds(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  objectLocal: number,
+): void {
+  if (!ctx.standalone && !ctx.wasi) return;
+  for (const name of STANDALONE_GLOBAL_CONSTRUCTOR_NAMES) {
+    fctx.body.push({ op: "local.get", index: objectLocal });
+    addStringConstantGlobal(ctx, name);
+    fctx.body.push(...stringConstantExternrefInstrs(ctx, name));
+
+    const valueType =
+      name === "Function"
+        ? (emitStandaloneFunctionIntrinsicValue(ctx, fctx) ?? emitBuiltinConstructorIdentity(ctx, fctx, name))
+        : isSupportedBuiltinNamespace(name)
+          ? emitBuiltinNamespaceObject(ctx, fctx, name)
+          : emitBuiltinConstructorIdentity(ctx, fctx, name);
+
+    if (valueType === null) fctx.body.push({ op: "ref.null.extern" });
+    else if (valueType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
+    const liveDefineIdx = ctx.funcMap.get("__defineProperty_value");
+    if (liveDefineIdx === undefined) {
+      fctx.body.push({ op: "drop" }, { op: "drop" }, { op: "drop" });
+      continue;
+    }
+    fctx.body.push({ op: "f64.const", value: 0x05 }, { op: "call", funcIdx: liveDefineIdx }, { op: "drop" });
+  }
+}
+
+export function appendStandaloneGlobalEvalSeed(ctx: CodegenContext, fctx: FunctionContext, objectLocal: number): void {
+  // The key must exist for ES5 reflection. A demand-gated runtime-eval wrapper
+  // may replace this undefined value when a callable eval property is needed.
+  if (!ctx.standalone && !ctx.wasi) return;
+  fctx.body.push({ op: "local.get", index: objectLocal });
+  addStringConstantGlobal(ctx, "eval");
+  fctx.body.push(
+    ...stringConstantExternrefInstrs(ctx, "eval"),
+    ...(undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }]),
+  );
+  const defineIdx = ctx.funcMap.get("__defineProperty_value");
+  if (defineIdx === undefined) {
+    fctx.body.push({ op: "drop" }, { op: "drop" }, { op: "drop" });
+    return;
+  }
+  fctx.body.push({ op: "f64.const", value: 0x05 }, { op: "call", funcIdx: defineIdx }, { op: "drop" });
+}
+
+export function appendStandaloneGlobalObjectCarrierSeeds(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  objectLocal: number,
+): void {
+  appendStandaloneGlobalConstructorSeeds(ctx, fctx, objectLocal);
+}
+
+/** Build eval's seed separately so a demand-gated callable can overwrite it. */
+export function standaloneGlobalEvalSeedInstrs(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  objectLocal: number,
+): Instr[] {
+  const body: Instr[] = [];
+  const savedBody = fctx.body;
+  fctx.body = body;
+  ctx.liveBodies.add(body);
+  try {
+    appendStandaloneGlobalEvalSeed(ctx, fctx, objectLocal);
+  } finally {
+    fctx.body = savedBody;
+  }
+  return body;
+}

--- a/src/codegen/standalone-global-object-carriers.ts
+++ b/src/codegen/standalone-global-object-carriers.ts
@@ -57,6 +57,12 @@ export function appendStandaloneGlobalConstructorSeeds(
   objectLocal: number,
 ): void {
   if (!ctx.standalone && !ctx.wasi) return;
+  // Runtime-eval modules already construct callable constructor carriers at
+  // the eval boundary. Re-entering the full constructor emitter while the
+  // native global object is itself being built recursively expands Function
+  // parity modules and can exhaust codegen's stack. The ES5 reflection row is
+  // eval-free, so its concrete constructor-name carriers still take this path.
+  if ((ctx.runtimeEvalBoundaryPlan?.sites.length ?? 0) > 0) return;
   for (const name of STANDALONE_GLOBAL_CONSTRUCTOR_NAMES) {
     fctx.body.push({ op: "local.get", index: objectLocal });
     addStringConstantGlobal(ctx, name);
@@ -84,6 +90,14 @@ export function appendStandaloneGlobalEvalSeed(ctx: CodegenContext, fctx: Functi
   // The key must exist for ES5 reflection. A demand-gated runtime-eval wrapper
   // may replace this undefined value when a callable eval property is needed.
   if (!ctx.standalone && !ctx.wasi) return;
+  // A direct/indirect eval boundary already owns `%eval%`'s callable identity
+  // and live-environment plumbing. Installing an undefined reflective stub in
+  // those modules makes the runtime evaluator observe that stub as the global
+  // binding and breaks direct eval before any later realm-property overwrite
+  // can help. Eval-free reflection modules still need the key below; modules
+  // with an eval boundary either seed the callable global-property wrapper or
+  // keep the direct intrinsic path authoritative.
+  if ((ctx.runtimeEvalBoundaryPlan?.sites.length ?? 0) > 0) return;
   fctx.body.push({ op: "local.get", index: objectLocal });
   addStringConstantGlobal(ctx, "eval");
   fctx.body.push(

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -8,7 +8,7 @@ import type { Instr, ValType } from "../../ir/types.js";
 import { ts } from "../../ts-api.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
-import { allocLocal, getLocalType } from "../context/locals.js";
+import { allocLocal, ensureForInIdentifierLocal, getLocalType } from "../context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "../context/speculative.js";
 import type { CodegenContext, FunctionContext, HoistedCharRead } from "../context/types.js";
 import { emitCoercedLocalSet, emitWebCompatCallAssignmentTarget, updateLocalType } from "../expressions/helpers.js";
@@ -3513,8 +3513,7 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
           // post-loop read all resolve to the SAME slot. Allocating a fresh
           // local here shadowed the hoisted one (writes never reached the body's
           // view of `x`).
-          const existingLocal = fctx.localMap.get(varName);
-          keyLocal = existingLocal !== undefined ? existingLocal : allocLocal(fctx, varName, { kind: "externref" });
+          keyLocal = ensureForInIdentifierLocal(fctx, varName);
         } else {
           // let/const head: fresh block-scoped local (Slice B refines this into
           // a per-iteration ref cell + TDZ flag).

--- a/tests/es5-standalone-global-gopn.test.ts
+++ b/tests/es5-standalone-global-gopn.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// The upstream ES5 row is intentionally pinned here because it exercises the
+// native realm object through the same concrete string-vector path used by the
+// standalone runner. The literal upstream harness currently has an unrelated
+// compiler-shape failure, so the runner's synthetic mode is the executable
+// permanent pin for this exact source row.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { runSyntheticTest262File } from "./test262-runner.js";
+
+const ROW = resolve("test262/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-1.js");
+
+async function runStandalone(source: string): Promise<Record<string, () => unknown>> {
+  const result = await compile(source, { target: "standalone", skipSemanticDiagnostics: true });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return instance.exports as Record<string, () => unknown>;
+}
+
+describe("ES5 global Object.getOwnPropertyNames standalone row", () => {
+  it("passes the exact upstream 15.2.3.4-4-1 source", async () => {
+    const result = await runSyntheticTest262File(ROW, "es5-global-gopn", 30_000, "standalone");
+    expect(result.status, result.reason ?? result.error).toBe("pass");
+    expect(result.wasm_sha).toBeTruthy();
+  }, 40_000);
+
+  it("keeps for-in string keys dynamic for concrete string vectors", async () => {
+    const exports = await runStandalone(`
+      export function test(): number {
+        const names: string[] = ["NaN", "Infinity"];
+        let found = 0;
+        for (var p in names) {
+          if (p === "0" && names[p] === "NaN") found += 1;
+          if (p === "1" && names[p] === "Infinity") found += 1;
+        }
+        return found;
+      }
+    `);
+    expect(exports.test!()).toBe(2);
+  });
+
+  it("owns the added global names with builtin descriptor flags", async () => {
+    const exports = await runStandalone(`
+      export function test(): number {
+        const evalDesc: any = Object.getOwnPropertyDescriptor(globalThis, "eval");
+        const functionDesc: any = Object.getOwnPropertyDescriptor(globalThis, "Function");
+        return evalDesc !== undefined && functionDesc !== undefined &&
+          evalDesc.writable && !evalDesc.enumerable && evalDesc.configurable &&
+          functionDesc.writable && !functionDesc.enumerable && functionDesc.configurable ? 1 : 0;
+      }
+    `);
+    expect(exports.test!()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- seed standalone global carriers for eval and the ES5 constructors with builtin descriptor flags
- preserve concrete string-vector keys through inline for-in heads
- make the global Object.getOwnPropertyNames ES5 row observe the required names

## Test262 flip
- test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-1.js

## Verification
- exact upstream source via synthetic standalone runner: pass
- focused global carrier controls: 3/3
- aggregate Array constructor pair: 2/2
- aggregate defineProperties wave: 18/18
- full normal pre-push hooks: typecheck, lint, format, oracle/coercion ratchets, numeric-local IR parity 18/18, issue integrity

Base is loopdive/js2:main; ttraenkler/js2 is used only for the head branch.