### PR TITLE
fix(es5): preserve forEach array-like coercion

### DIFF
--- a/plan/issues/3169-standalone-array-hof-arraylike-receivers.md
+++ b/plan/issues/3169-standalone-array-hof-arraylike-receivers.md
@@ -5,7 +5,7 @@ status: done
 completed: 2026-07-12
 assignee: ttraenkler/dev-array-hof
 created: 2026-07-12
-updated: 2026-07-13
+updated: 2026-08-25
 priority: high
 feasibility: hard
 task_type: bug
@@ -31,6 +31,10 @@ loc-budget-allow:
   - src/codegen/context/types.ts
   - src/codegen/index.ts
   - src/codegen/array-methods.ts
+  # 2026-08-25 ES5 forEach tail: a constructor instance stored in an object
+  # literal's `length` field must cross the dynamic prototype/ToPrimitive
+  # boundary. The escape classifier owns that representation decision.
+  - src/codegen/fnctor-escape-gate.ts
 # (#2108) The added coercion sites INVOKE the sealed engine helpers, not
 # hand-rolled vocabulary: `__str_to_number` applies §7.1.20 ToLength →
 # §7.1.4 ToNumber to a STRING-ref `length` field (`length: "2"`, the -3-*

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -307,6 +307,17 @@ function emitCallbackTypeCheck(
   }
   // Known non-callable literal → compile arg for side effects, then throw
   const cbArg = callExpr.arguments[0]!;
+  // ArgumentListEvaluation reads the callback before Array.prototype.forEach
+  // (or its siblings) can perform IsCallable. A genuinely unresolvable bare
+  // identifier therefore throws ReferenceError, and must not fall through to
+  // the generic `__call_*` callback bridge after identifier lowering has
+  // already emitted that throw. Besides choosing the wrong error, that stale
+  // bridge introduces an unsatisfiable host import in standalone output.
+  // Runtime-eval globals remain dynamic and keep the ordinary callback path.
+  if (ts.isIdentifier(cbArg) && ctx.oracle.isUnresolvableIdentifier(cbArg) && !ctx.runtimeEvalGlobalFunctionBindings) {
+    compileExpression(ctx, fctx, cbArg);
+    return true;
+  }
   if (isKnownNonCallable(ctx, cbArg)) {
     const cbType = compileExpression(ctx, fctx, cbArg);
     if (cbType) fctx.body.push({ op: "drop" });

--- a/src/codegen/fnctor-escape-gate.ts
+++ b/src/codegen/fnctor-escape-gate.ts
@@ -537,6 +537,16 @@ function classifyUse(
   // the externref `$Object` runtime — a user call's object-literal argument is
   // untouched.
   if (ts.isPropertyAssignment(parent) && parent.initializer === useNode) {
+    // `{ length: new F() }` feeds the value to LengthOfArrayLike/ToLength once
+    // the containing object is consumed by a borrowed Array method. The field
+    // boundary erases the direct constructor expression, so keeping `F` on its
+    // closed struct would make the later runtime ToPrimitive walk unable to see
+    // methods installed on `F.prototype`. Treat this canonical ES5 array-like
+    // slot as the same dynamic escape as `table.length = inst` above. Clause B
+    // still wins for constructors with typed own-field consumers.
+    const propertyName = ts.isIdentifier(parent.name) || ts.isStringLiteral(parent.name) ? parent.name.text : undefined;
+    if (standalone === true && propertyName === "length") return "dynamic";
+
     const lit = parent.parent;
     if (ts.isObjectLiteralExpression(lit) && ts.isCallExpression(lit.parent) && lit.parent.arguments.includes(lit)) {
       const outerCallee = lit.parent.expression;

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -10300,10 +10300,10 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
       const isObjectRefLength =
         (cand.lengthFieldType.kind === "ref" || cand.lengthFieldType.kind === "ref_null") &&
         !isStringRefType(cand.lengthFieldType);
-      const objectRefRead: Instr[] =
+      const primitiveNumberRead = (convertAny: boolean): Instr[] =>
         toPrimIdx !== undefined && typeofStringIdx !== undefined && unboxNumIdx !== undefined
           ? [
-              { op: "extern.convert_any" },
+              ...(convertAny ? ([{ op: "extern.convert_any" }] satisfies Instr[]) : []),
               { op: "ref.null.extern" }, // hint: number/default
               { op: "call", funcIdx: toPrimIdx },
               { op: "local.tee", index: L_PRIM },
@@ -10328,19 +10328,19 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
               },
             ]
           : [{ op: "drop" }, { op: "f64.const", value: 0 }];
+      const objectRefRead = primitiveNumberRead(true);
+      const externRefRead = primitiveNumberRead(false);
       const readAsF64: Instr[] =
         cand.lengthFieldType.kind === "i32"
           ? [{ op: "f64.convert_i32_s" }]
           : cand.lengthFieldType.kind === "externref"
-            ? unboxNumIdx !== undefined
-              ? [{ op: "call", funcIdx: unboxNumIdx }]
-              : [{ op: "drop" }, { op: "f64.const", value: 0 }]
+            ? externRefRead
             : isStringRefType(cand.lengthFieldType) && strToNumIdx !== undefined
               ? [{ op: "extern.convert_any" }, { op: "call", funcIdx: strToNumIdx }]
               : isObjectRefLength
                 ? objectRefRead
                 : [];
-      if (isObjectRefLength && !lenPrimLocalAdded && primExtPos < 0) {
+      if ((isObjectRefLength || cand.lengthFieldType.kind === "externref") && !lenPrimLocalAdded && primExtPos < 0) {
         // Scratch externref local for the ToPrimitive result — appended once,
         // and only when the registration did not already provide it (#4556).
         lenFn.locals.push({ name: "primExt", type: { kind: "externref" } });

--- a/tests/es5-array-foreach-pair.test.ts
+++ b/tests/es5-array-foreach-pair.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ES5 Array.prototype.forEach generic-call edge cases covered by
+// 15.4.4.18-3-23 and 15.4.4.18-4-2.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, {
+    target: "standalone",
+    fileName: "es5-array-foreach-pair.js",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports, "standalone output leaked host imports").toEqual([]);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("ES5 Array.prototype.forEach generic-call edge cases (standalone)", () => {
+  it("reduces the same constructor instance through its assigned prototype", async () => {
+    expect(
+      await runStandalone(`export function test() {
+        var valueOfAccessed = false;
+        var proto = { valueOf: function() { valueOfAccessed = true; return 2; } };
+        var Con = function() {};
+        Con.prototype = proto;
+        var child = new Con();
+        var direct = child.valueOf();
+        var coerced = Number(child);
+        return direct * 100 + coerced * 10 + (valueOfAccessed ? 1 : 0);
+      }`),
+    ).toBe(221);
+  });
+
+  it("reduces the constructor instance after an object-field round trip", async () => {
+    expect(
+      await runStandalone(`export function test() {
+        var valueOfAccessed = false;
+        var proto = { valueOf: function() { valueOfAccessed = true; return 2; } };
+        var Con = function() {};
+        Con.prototype = proto;
+        var child = new Con();
+        var holder = { length: child };
+        var coerced = Number(holder.length);
+        return coerced * 10 + (valueOfAccessed ? 1 : 0);
+      }`),
+    ).toBe(21);
+  });
+
+  it("coerces an object-valued length through its inherited valueOf first", async () => {
+    expect(
+      await runStandalone(`export function test() {
+        var testResult = false;
+        var valueOfAccessed = false;
+        var toStringAccessed = false;
+        function callbackfn(val, idx, obj) { testResult = val > 10; }
+        var proto = { valueOf: function() { valueOfAccessed = true; return 2; } };
+        var Con = function() {};
+        Con.prototype = proto;
+        var child = new Con();
+        child.toString = function() { toStringAccessed = true; return "1"; };
+        var obj = { 1: 11, 2: 9, length: child };
+        Array.prototype.forEach.call(obj, callbackfn);
+        return (testResult ? 1 : 0) + (valueOfAccessed ? 2 : 0) + (toStringAccessed ? 4 : 0);
+      }`),
+    ).toBe(3);
+  });
+
+  it("throws ReferenceError for an unresolved callback before invoking forEach", async () => {
+    expect(
+      await runStandalone(`export function test() {
+        var arr = new Array(10);
+        try { arr.forEach(foo); }
+        catch (error) { return error instanceof ReferenceError ? 1 : 0; }
+        return 0;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- keep constructor instances dynamic when stored in object-valued length fields
- apply ToPrimitive/ToNumber to externref array-like lengths
- terminate unresolved callback identifiers after their ReferenceError path instead of emitting an impossible standalone callback import

## Test262 flips
- test/built-ins/Array/prototype/forEach/15.4.4.18-3-23.js
- test/built-ins/Array/prototype/forEach/15.4.4.18-4-2.js

## Verification
- exact official rows: 2/2
- focused regressions and borrowed-array controls: 19/19
- clean-upstream comparison confirmed the issue-3200/2773 neighbor failures are pre-existing
- typecheck, format, LOC/function, oracle/coercion gates pass
- full normal pre-push hooks pass, including numeric-local IR parity 18/18 and issue integrity

Base is loopdive/js2:main; ttraenkler/js2 is used only for the head branch.