### PR TITLE
fix(arguments): preserve deduped object method dispatch

### DIFF
--- a/plan/issues/4697-es2015-method-arguments-trailing-comma.md
+++ b/plan/issues/4697-es2015-method-arguments-trailing-comma.md
@@ -1,0 +1,96 @@
+---
+id: 4697
+title: "ES2015 object-literal method arguments with trailing-comma calls"
+status: done
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+priority: medium
+es_edition: es2015
+language_feature: arguments-object
+task_type: bug
+area: codegen
+related: [4695, 2704, 2725]
+loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/expressions/call-receiver-method.ts
+  - src/codegen/literals.ts
+func-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
+  - src/codegen/literals.ts::compileObjectLiteralForStruct
+  - src/codegen/context/create-context.ts::createCodegenContext
+---
+
+# #4697 — ES2015 method arguments and trailing-comma calls
+
+## Scope
+
+This bounded slice owns exactly these five current-main Test262 rows:
+
+- `test/language/arguments-object/meth-args-trailing-comma-undefined.js`
+- `test/language/arguments-object/meth-args-trailing-comma-null.js`
+- `test/language/arguments-object/meth-args-trailing-comma-single-args.js`
+- `test/language/arguments-object/meth-args-trailing-comma-multiple.js`
+- `test/language/arguments-object/meth-args-trailing-comma-spread-operator.js`
+
+Generator, async, class, private-method, host-import, and mapped descriptor
+rows remain out of scope. The mapped descriptor work in #4695 is not part of
+this change.
+
+## Current baseline (upstream/main `028eb69ae`)
+
+The exact five rows all compile and fail at runtime (`0/5` pass). Each method's
+assertions do not contribute the expected `callCount`; the final assertion
+reports `Expected SameValue(«0», «1»)`. The failures reproduce through the
+authoritative `runTest262File` original-harness path, including its strict
+rerun. Controls already pass: class-method null, class-expression-method null,
+function-declaration null, and function-expression null trailing-comma rows.
+
+## Root-cause implementation plan
+
+Trace the object-literal `MethodDeclaration` lowering in
+`src/codegen/literals.ts` and the receiver-method dispatch in
+`src/codegen/expressions/call-receiver-method.ts` /
+`src/codegen/expressions/object-method-rest-abi.ts`. The baseline WAT shows the
+method body forked to a per-literal function because harness and test literals
+share a deduplicated struct shape, while the direct `obj.method(...)` arm
+re-looked up the shared, empty placeholder in `funcMap`. Record each method
+declaration's actual function handle, recover a single-assignment `var` object
+initializer for the direct-call proof, and preserve the selected handle through
+the existing argument-count/extras setup and late re-lookup. Preserve
+left-to-right evaluation, receiver binding, spread expansion, and the existing
+class/function paths.
+
+Add a focused regression test only if an existing equivalence test cannot assert
+the five shapes; do not alter Test262 sources. Keep all compiler-source changes
+under **180 changed source LOC**.
+
+## Controls
+
+- Plain object-method call without a trailing comma, with and without an
+  `arguments` read, to ensure the fix is not comma-only dead-code.
+- Existing class-method, class-expression-method, function-declaration, and
+  function-expression trailing-comma rows above (all baseline pass).
+- The five exact rows in both normal and strict original-harness variants.
+- A spread control without a trailing comma and a non-method direct call to
+  guard spread expansion and generic closure dispatch.
+
+## Acceptance
+
+- All five exact rows pass through `runTest262File` on host/gc, including the
+  strict rerun where applicable.
+- Controls remain passing with no new compile errors, traps, or wrong values.
+- No source edits touch generator/async/class/private-method/host-import or
+  mapped-descriptor paths.
+- `git diff --stat` reports no more than 180 changed source LOC; focused
+  TypeScript/equivalence checks and the normal pre-push checks pass.
+
+## Test Results
+
+- Baseline on upstream/main: exact rows `0/5` pass; controls `4/4` pass.
+- After fix: exact rows `5/5` pass through `runTest262File` (host/gc original
+  harness, including strict reruns); controls remain `4/4` pass.
+- Source diff: 32 changed lines across five compiler files, under the 180-line
+  cap.
+- `tsc --noEmit`: pass; TypeScript 7 `tsc --noEmit -p tsconfig.ts7.json`: pass.
+- Prettier check on changed files: pass.

--- a/plan/issues/4697-es2015-method-arguments-trailing-comma.md
+++ b/plan/issues/4697-es2015-method-arguments-trailing-comma.md
@@ -27,11 +27,11 @@ func-budget-allow:
 
 This bounded slice owns exactly these five current-main Test262 rows:
 
-- `test/language/arguments-object/meth-args-trailing-comma-undefined.js`
-- `test/language/arguments-object/meth-args-trailing-comma-null.js`
-- `test/language/arguments-object/meth-args-trailing-comma-single-args.js`
-- `test/language/arguments-object/meth-args-trailing-comma-multiple.js`
-- `test/language/arguments-object/meth-args-trailing-comma-spread-operator.js`
+- `test262/test/language/arguments-object/meth-args-trailing-comma-undefined.js`
+- `test262/test/language/arguments-object/meth-args-trailing-comma-null.js`
+- `test262/test/language/arguments-object/meth-args-trailing-comma-single-args.js`
+- `test262/test/language/arguments-object/meth-args-trailing-comma-multiple.js`
+- `test262/test/language/arguments-object/meth-args-trailing-comma-spread-operator.js`
 
 Generator, async, class, private-method, host-import, and mapped descriptor
 rows remain out of scope. The mapped descriptor work in #4695 is not part of

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -188,6 +188,7 @@ export function createCodegenContext(
     genericResolved: new Map(),
     funcRestParams: new Map(),
     funcUsesArguments: new Set(),
+    objectLiteralMethodFuncIdx: new Map(),
     extrasArgvGlobalIdx: -1,
     extrasArgvVecTypeIdx: -1,
     argcGlobalIdx: -1,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2384,6 +2384,13 @@ export interface CodegenContext extends StandaloneCapabilityDemandState, BodyRou
    */
   funcUsesArguments: Set<string>;
   /**
+   * Object-literal method declaration → the function handle containing that
+   * literal's body. Struct-shape deduplication can fork a method body while
+   * leaving the name-keyed placeholder shared; direct calls must select the
+   * declaration's own handle instead of that empty placeholder.
+   */
+  objectLiteralMethodFuncIdx: Map<ts.MethodDeclaration, number>;
+  /**
    * Module global index for the runtime extras argv vec (#1053).
    * Lazily registered on first use; -1 if not yet created.
    * Type: (mut (ref null $vec_externref))

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -2012,7 +2012,13 @@ export function compileReceiverMethodCall(
         const callablePropResult = compileCallablePropertyCall(ctx, fctx, expr, propAccess, structTypeName);
         if (callablePropResult !== undefined) return callablePropResult;
       }
-      if ((funcIdx = directObjectMethodFuncIdx(ctx, expr, funcIdx)) !== undefined) {
+      // Keep a per-literal method handle selected by directObjectMethodFuncIdx
+      // through the late re-lookup below. A deduped sibling may leave the
+      // name-keyed placeholder pointing at a different (empty) body.
+      const nameMethodFuncIdx = funcIdx;
+      const directMethodFuncIdx = directObjectMethodFuncIdx(ctx, expr, funcIdx);
+      const hasLiteralMethodOverride = directMethodFuncIdx !== undefined && directMethodFuncIdx !== nameMethodFuncIdx;
+      if ((funcIdx = directMethodFuncIdx) !== undefined) {
         // Push self (the receiver) as first argument, with type hint from method's first param
         const structMethodPTypes = getFuncParamTypes(ctx, funcIdx);
         const recvType = compileExpression(ctx, fctx, propAccess.expression, structMethodPTypes?.[0]);
@@ -2076,7 +2082,7 @@ export function compileReceiverMethodCall(
           }
           // Set __argc before the call so the callee knows the actual arg count
           maybeSetArgcForKnownCall(ctx, fctx, fullName, expr.arguments.length, smMethodParamCount);
-          const finalStructMethodIdx = ctx.funcMap.get(fullName) ?? funcIdx;
+          const finalStructMethodIdx = hasLiteralMethodOverride ? funcIdx : (ctx.funcMap.get(fullName) ?? funcIdx);
           fctx.body.push({ op: "call", funcIdx: finalStructMethodIdx });
           const elseInstrs = fctx.body;
           fctx.body = savedBody;
@@ -2141,7 +2147,7 @@ export function compileReceiverMethodCall(
         // Set __argc before the call so the callee knows the actual arg count
         maybeSetArgcForKnownCall(ctx, fctx, fullName, expr.arguments.length, nnMethodParamCount);
         // Re-lookup funcIdx: argument compilation may trigger addUnionImports
-        const finalStructMethodIdx = ctx.funcMap.get(fullName) ?? funcIdx;
+        const finalStructMethodIdx = hasLiteralMethodOverride ? funcIdx : (ctx.funcMap.get(fullName) ?? funcIdx);
         fctx.body.push({ op: "call", funcIdx: finalStructMethodIdx });
 
         const sig = ctx.checker.getResolvedSignature(expr);

--- a/src/codegen/expressions/object-method-rest-abi.ts
+++ b/src/codegen/expressions/object-method-rest-abi.ts
@@ -5,6 +5,7 @@ import type { ValType } from "../../ir/types.js";
 import type { CodegenContext, FunctionContext, RestParamInfo } from "../context/types.js";
 import { getArrTypeIdxFromVec } from "../registry/types.js";
 import { skipTransparentExpressions } from "../shared.js";
+import { bindingIsSingleAssignment } from "../single-assignment-binding.js";
 import { pushDefaultValue } from "../type-coercion.js";
 import { compileInternalCallArgument } from "./internal-call-argument.js";
 
@@ -16,7 +17,12 @@ function objectLiteralMethodDeclaration(
   if (!ts.isPropertyAccessExpression(callee)) return undefined;
   let receiver = skipTransparentExpressions(callee.expression);
   if (ts.isIdentifier(receiver)) {
-    const initializer = ctx.oracle.constInitializerOf(receiver);
+    // `var` object bindings are the dominant test262 form. The declaration
+    // body is still a closed struct, so use its initializer when available;
+    // callers already fall back to the generic path when this proof fails.
+    const initializer =
+      ctx.oracle.constInitializerOf(receiver) ??
+      (bindingIsSingleAssignment(ctx, receiver) ? ctx.oracle.variableInitializerOf(receiver) : undefined);
     if (initializer) receiver = skipTransparentExpressions(initializer);
   }
   if (!ts.isObjectLiteralExpression(receiver)) return undefined;
@@ -41,6 +47,8 @@ export function directObjectMethodFuncIdx(
 ): number | undefined {
   if (funcIdx === undefined) return undefined;
   const declaration = objectLiteralMethodDeclaration(ctx, expr);
+  const literalFuncIdx = declaration ? ctx.objectLiteralMethodFuncIdx.get(declaration) : undefined;
+  if (literalFuncIdx !== undefined) funcIdx = literalFuncIdx;
   const hasRestBinding = declaration?.parameters.some(
     (parameter) =>
       parameter.dotDotDotToken !== undefined &&

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3660,6 +3660,12 @@ export function compileObjectLiteralForStruct(
         };
         pushDefinedFunc(ctx, methodFuncIdx, methodFunc);
       }
+      // Struct-shape deduplication may have forked this method into a
+      // per-literal function. Keep the declaration identity alongside the
+      // body handle so a direct call through a variable initialized by this
+      // literal does not fall back to the shared (possibly empty) placeholder.
+      const actualMethodFuncIdx = existingFunc !== undefined ? existingFuncIdx! : ctx.funcMap.get(fullName)!;
+      ctx.objectLiteralMethodFuncIdx.set(prop, actualMethodFuncIdx);
 
       // Promote captured locals to globals so the method body can access them.
       // (#3040) ALSO scan the parameter-default initializers — an object-literal


### PR DESCRIPTION
Record the concrete function handle for each object-literal method so direct calls through single-assignment var bindings keep their per-literal body after struct-shape deduplication. Preserve that handle through argument setup and late funcMap re-lookups, fixing arguments-object trailing-comma calls without changing class or function dispatch.

Co-authored-by: Codex <codex@openai.com>
