### PR TITLE
codex/4700 es2015 forof head tdz only

### DIFF
--- a/plan/issues/4700-es2015-forof-head-tdz-only.md
+++ b/plan/issues/4700-es2015-forof-head-tdz-only.md
@@ -12,7 +12,6 @@ language_feature: for-of-lexical-head-tdz
 task_type: bug
 feasibility: medium
 goal: test262-conformance
-depends_on: [4698]
 loc-budget-allow:
   - src/codegen/statements/loops.ts
 func-budget-allow:

--- a/plan/issues/4700-es2015-forof-head-tdz-only.md
+++ b/plan/issues/4700-es2015-forof-head-tdz-only.md
@@ -1,0 +1,87 @@
+---
+id: 4700
+title: "ES2015 for-of lexical head TDZ (bounded identifier heads)"
+status: done
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+sprint: current
+priority: high
+es_edition: ES2015
+language_feature: for-of-lexical-head-tdz
+task_type: bug
+feasibility: medium
+goal: test262-conformance
+depends_on: [4698]
+loc-budget-allow:
+  - src/codegen/statements/loops.ts
+func-budget-allow:
+  - src/codegen/statements/loops.ts::compileForOfArray
+---
+# #4700 — ES2015 for-of lexical head TDZ (bounded identifier heads)
+
+## Scope
+
+Reconstruct only the bounded synchronous, non-destructuring `for (let/const x
+of iterable)` head-TDZ behavior split from blocked #4698. The receiver must be
+evaluated while the lexical head binding is uninitialized, so a receiver read
+of that name throws `ReferenceError`.
+
+This issue explicitly excludes the fresh-binding rows (their distinct
+externref array/function failure is not part of the TDZ mechanism),
+`using`/`await using`, async/for-await, destructuring, IteratorClose, and
+Map/Set collection paths.
+
+## Candidate evidence from #4698
+
+The #4698 candidate was measured against the pinned test262 checkout and
+reported the bounded result: both TDZ rows passed (2/2), and the five controls
+below remained green (5/5). The two fresh-binding rows still failed with the
+same pre-existing `TypeError: undefined is not a function` at L16 in a clean
+upstream/main worktree, establishing a separate externref array/function
+problem. #4700 therefore carries only the two TDZ rows and the five controls.
+
+## Exact artifact rows
+
+| Row | Expected behavior |
+| --- | --- |
+| `test/language/statements/for-of/head-const-bound-names-fordecl-tdz.js` | The `[x]` receiver is evaluated with `const x` in its TDZ and throws `ReferenceError`. |
+| `test/language/statements/for-of/head-let-bound-names-fordecl-tdz.js` | The `[x]` receiver is evaluated with `let x` in its TDZ and throws `ReferenceError`. |
+
+## Controls
+
+- `head-const-bound-names-in-stmt.js`
+- `head-let-bound-names-in-stmt.js`
+- `head-const-init.js`
+- `head-let-init.js`
+- `scope-body-lex-boundary.js`
+
+## Plan
+
+1. Keep the change in the synchronous array/vec for-of lowering only.
+2. For a simple `let`/`const` identifier head, save outer binding metadata,
+   install a temporary TDZ state while compiling the receiver, then remove
+   that temporary head environment before loop iteration code is emitted.
+3. Preserve existing non-lexical, destructuring, iterator, async, collection,
+   and fresh-binding paths. Do not add ref-cell/per-iteration machinery here.
+4. Restore all outer binding maps after the loop and add focused regression
+   coverage only if needed by the existing test262 runner.
+
+## Acceptance
+
+- The exact two TDZ rows pass in the host lane.
+- All five listed controls remain green.
+- The excluded fresh-binding rows are not used as acceptance evidence.
+- No source change exceeds 180 changed source LOC, and excluded feature paths
+  remain untouched.
+- Scoped checks and normal pre-push checks pass.
+
+## Test Results
+
+Baseline on `upstream/main` `353b88b94`: the exact TDZ rows failed 2/2 because
+the receiver read produced no `ReferenceError`; all five controls passed 5/5.
+The candidate's focused `runTest262File` host-lane run (including the runner's
+strict rerun where applicable) passes the exact two TDZ rows 2/2 and all five
+controls 5/5. The implementation changes 88 source lines in
+`src/codegen/statements/loops.ts`; fresh-binding rows were intentionally not
+used as acceptance evidence.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -1599,6 +1599,42 @@ function compileForOfArrayFromLocal(
   compileForOfArray(ctx, fctx, stmt, undefined, { vecLocal, vecType });
 }
 
+/** #4700 — outer descriptors shadowed by a simple lexical for-of head. */
+interface ForOfHeadSaved {
+  name: string;
+  localMap: number | undefined;
+  tdz: number | undefined;
+  boxed: { refCellTypeIdx: number; valType: ValType } | undefined;
+  boxedTdz: { localIdx: number; refCellTypeIdx: number } | undefined;
+  isConst: boolean;
+}
+
+/** Restore the binding descriptors that surround a bounded lexical for-of. */
+function restoreForOfHead(fctx: FunctionContext, saved: ForOfHeadSaved): void {
+  fctx.localMap.delete(saved.name);
+  fctx.tdzFlagLocals?.delete(saved.name);
+  fctx.boxedCaptures?.delete(saved.name);
+  fctx.boxedTdzFlags?.delete(saved.name);
+  fctx.constBindings?.delete(saved.name);
+  if (saved.localMap !== undefined) fctx.localMap.set(saved.name, saved.localMap);
+  if (saved.tdz !== undefined) {
+    if (!fctx.tdzFlagLocals) fctx.tdzFlagLocals = new Map();
+    fctx.tdzFlagLocals.set(saved.name, saved.tdz);
+  }
+  if (saved.boxed !== undefined) {
+    if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
+    fctx.boxedCaptures.set(saved.name, saved.boxed);
+  }
+  if (saved.boxedTdz !== undefined) {
+    if (!fctx.boxedTdzFlags) fctx.boxedTdzFlags = new Map();
+    fctx.boxedTdzFlags.set(saved.name, saved.boxedTdz);
+  }
+  if (saved.isConst) {
+    if (!fctx.constBindings) fctx.constBindings = new Set();
+    fctx.constBindings.add(saved.name);
+  }
+}
+
 // (#2769) Does this for-of need the in-bounds undefined/hole sentinel preserved
 // through the OUTER array-literal construction? True ONLY when the subject is a
 // *direct array literal* AND the for-of binding pattern has an element default
@@ -1624,6 +1660,47 @@ function compileForOfArray(
   // #1919 — snapshot so a non-array receiver rolls back body + locals + imports
   // before reporting. With `preVec` no compile happens, so rollback is a no-op.
   const snap = snapshotSpeculative(ctx, fctx);
+  // #4700 — a simple lexical ForDeclaration shadows the outer binding while
+  // the receiver is evaluated. Keep this reconstruction limited to the direct
+  // array/vec path; destructuring, collection materialization, and iterator
+  // paths remain outside the bounded TDZ slice.
+  const headDecl =
+    !preVec &&
+    !iterableOverride &&
+    ts.isVariableDeclarationList(stmt.initializer) &&
+    stmt.initializer.declarations.length === 1
+      ? stmt.initializer.declarations[0]!
+      : undefined;
+  const isLexicalIdentifierHead =
+    headDecl !== undefined &&
+    ts.isIdentifier(headDecl.name) &&
+    !!(stmt.initializer.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const));
+  const headName = isLexicalIdentifierHead ? (headDecl!.name as ts.Identifier).text : undefined;
+  const savedHead: ForOfHeadSaved | undefined =
+    headName === undefined
+      ? undefined
+      : {
+          name: headName,
+          localMap: fctx.localMap.get(headName),
+          tdz: fctx.tdzFlagLocals?.get(headName),
+          boxed: fctx.boxedCaptures?.get(headName),
+          boxedTdz: fctx.boxedTdzFlags?.get(headName),
+          isConst: fctx.constBindings?.has(headName) ?? false,
+        };
+  if (headName !== undefined) {
+    // The value slot only keeps identifier lowering well-typed; every receiver
+    // read checks the zero-initialized flag before that value can matter.
+    const headValueLocal = allocLocal(fctx, `__forof_hbind_${headName}_${fctx.locals.length}`, {
+      kind: "externref",
+    });
+    const headTdzLocal = allocLocal(fctx, `__forof_hflag_${headName}_${fctx.locals.length}`, { kind: "i32" });
+    fctx.localMap.set(headName, headValueLocal);
+    if (!fctx.tdzFlagLocals) fctx.tdzFlagLocals = new Map();
+    fctx.tdzFlagLocals.set(headName, headTdzLocal);
+    fctx.boxedCaptures?.delete(headName);
+    fctx.boxedTdzFlags?.delete(headName);
+    fctx.constBindings?.delete(headName);
+  }
   // (#2769) Preserve in-bounds undefined/hole identity through the OUTER
   // array-literal construction for the spec'd for-of-dstr template family. The
   // flag is scoped tightly to the subject compile (set→compile→restore) so it
@@ -1636,6 +1713,7 @@ function compileForOfArray(
   const vecType = preVec ? preVec.vecType : compileExpression(ctx, fctx, iterableOverride ?? stmt.expression);
   if (preserveUndefElem) (ctx as any)._forOfPreserveUndefElem = prevPreserveUndefElem;
   if (!vecType || (vecType.kind !== "ref" && vecType.kind !== "ref_null")) {
+    if (savedHead) restoreForOfHead(fctx, savedHead);
     rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array expression");
     return;
@@ -1645,6 +1723,7 @@ function compileForOfArray(
   const vecTypeIdx = vecType.typeIdx;
   const vecDef = ctx.mod.types[vecTypeIdx];
   if (!vecDef || vecDef.kind !== "struct") {
+    if (savedHead) restoreForOfHead(fctx, savedHead);
     rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array type");
     return;
@@ -1653,10 +1732,16 @@ function compileForOfArray(
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   const arrDef = ctx.mod.types[arrTypeIdx];
   if (!arrDef || arrDef.kind !== "array") {
+    if (savedHead) restoreForOfHead(fctx, savedHead);
     rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array type");
     return;
   }
+  // HeadEvaluation step 4: the receiver TDZ environment ends before the
+  // loop's per-iteration binding is installed. The emitted receiver reads
+  // retain the temporary locals/flag; only the compiler's active descriptors
+  // are restored here.
+  if (savedHead) restoreForOfHead(fctx, savedHead);
   const elemType = arrDef.element;
   // (#2934 1b) Packed i8/i16 typed-array elements (Uint8Array/Int8Array/
   // Int16Array/… standalone, #2593) are STORAGE-only types: a local declared
@@ -1932,6 +2017,9 @@ function compileForOfArray(
       });
     }
   }
+  // #4700 — lexical head bindings end with the loop and must not leak into
+  // later code in the surrounding function.
+  if (savedHead) restoreForOfHead(fctx, savedHead);
 }
 
 /**

--- a/tests/issue-4700.test.ts
+++ b/tests/issue-4700.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4700 — bounded synchronous for-of lexical-head TDZ.
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const TDZ_ROWS = [
+  "language/statements/for-of/head-const-bound-names-fordecl-tdz.js",
+  "language/statements/for-of/head-let-bound-names-fordecl-tdz.js",
+] as const;
+
+const CONTROLS = [
+  "language/statements/for-of/head-const-bound-names-in-stmt.js",
+  "language/statements/for-of/head-let-bound-names-in-stmt.js",
+  "language/statements/for-of/head-const-init.js",
+  "language/statements/for-of/head-let-init.js",
+  "language/statements/for-of/scope-body-lex-boundary.js",
+] as const;
+
+async function run(file: string) {
+  return runTest262File(join("test262/test", file), "for-of", 60_000);
+}
+
+describe("#4700 — bounded for-of lexical-head TDZ", () => {
+  it.each(TDZ_ROWS)("passes the exact TDZ row %s", async (file) => {
+    const result = await run(file);
+    expect(result.status, `${file}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
+  });
+
+  it.each(CONTROLS)("keeps the control row %s green", async (file) => {
+    const result = await run(file);
+    expect(result.status, `${file}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
+  });
+});


### PR DESCRIPTION
- **fix(for-of): preserve lexical head TDZ during receiver evaluation**
- **docs(issue-4700): remove unavailable dependency metadata**
