### PR TITLE
fix(arguments): widen mapped formal carrier for string descriptor values

### DIFF
--- a/plan/issues/4701-es2015-mapped-arguments-formal-widening.md
+++ b/plan/issues/4701-es2015-mapped-arguments-formal-widening.md
@@ -1,0 +1,170 @@
+---
+id: 4701
+title: "ES2015 mapped arguments string-valued formal reverse-sync widening"
+status: in-progress
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, conformance
+es_edition: es6
+language_feature: arguments-object
+goal: test262-conformance
+source_loc_cap: 180
+loc-budget-allow:
+  - src/codegen/closures.ts
+  - src/codegen/declarations.ts
+  - src/codegen/expressions/identifiers.ts
+func-budget-allow:
+  - src/codegen/expressions/identifiers.ts::compileIdentifierCore
+related: [4695, 4699, 4444, 4658, 1511]
+origin: "Single excluded ES2015 row split from blocked #4695/#4699: a mapped argument descriptor writes a string into an inferred-f64 formal, and reverse synchronization currently converts it to NaN."
+---
+
+# #4701 — ES2015 mapped arguments formal-carrier widening
+
+## Scope
+
+This issue owns only the single excluded row:
+
+```
+test/language/arguments-object/mapped/writable-enumerable-configurable-descriptor.js
+```
+
+The row calls a sloppy simple-parameter function as `(0)`, so call-site
+inference gives `a` an `f64` carrier. `Object.defineProperty(arguments, "0",
+{ value: "foo", writable: true, enumerable: true, configurable: true })`
+must update the mapped formal to the exact string. The current reverse-sync path
+unboxes the externref string through `__unbox_number` and stores `NaN` in the
+`f64` local.
+
+This slice may widen only the affected mapped formal's carrier and its
+parameter/arguments synchronization. It must not alter #4699's descriptor
+sidecar, descriptor flags, accessor routing, generator/async paths, host-import
+paths, or unrelated function ABI decisions. **Changed source LOC must remain at
+or below 180.**
+
+## Exact baseline (upstream/main)
+
+Baseline was measured on `upstream/main` commit `86c9ec686` (2026-08-25) with
+the repository's assembled `runTest262File` host-lane harness and the pinned
+Test262 submodule. The exact row failed during its primary sloppy run:
+
+```
+status: fail
+first error: Expected SameValue(«NaN», «"foo"») to be true
+at assert.sameValue(a, "foo")
+```
+
+The three numeric mapped-arguments controls all passed:
+
+```
+test/language/arguments-object/mapped/mapped-arguments-nonconfigurable-1.js  pass
+test/language/arguments-object/mapped/mapped-arguments-nonconfigurable-2.js  pass
+test/language/arguments-object/mapped/mapped-arguments-nonconfigurable-4.js  pass
+```
+
+The 20 descriptor rows owned by #4699 are additional controls for this slice:
+
+```
+test/language/arguments-object/mapped/enumerable-configurable-accessor-descriptor.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-basic.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-define-failure.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-set-value-by-arguments.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-set-value-with-define-property.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-with-param-assign.js
+test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
+test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
+test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
+test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-basic.js
+test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
+test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
+test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
+test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-basic.js
+test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
+test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
+test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
+test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
+test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-define-property.js
+test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
+```
+
+Those rows are not owned by this issue and are not changed here. They are
+re-run as controls after the formal-carrier change, together with the three
+numeric controls above, to detect ABI or reverse-sync regressions.
+
+## Bounded implementation plan
+
+1. Keep the current inferred numeric ABI for ordinary functions. Detect only a
+   non-strict simple-parameter function that materializes mapped `arguments`
+   and has a direct descriptor/element write capable of putting a nonnumeric
+   value into the mapped slot.
+2. For that function and affected formal index, use the universal `externref`
+   carrier at the function boundary and in the local. Existing numeric body
+   operations must continue to request the existing `f64` coercion at their
+   use site; no general inference policy or unrelated closure ABI is widened.
+3. Make mapped-arguments initialization and reverse synchronization honor the
+   widened per-index carrier: numeric values remain boxed/unboxed as before,
+   while an externref value is stored/read without `__unbox_number`. Preserve
+   the existing severed-link and descriptor-sidecar gates.
+4. Add focused equivalence coverage for string-valued reverse sync plus numeric
+   mapped writes. Validate the exact row, the three numeric controls, and all
+   20 #4699 descriptor controls serially before considering a PR.
+
+No implementation is acceptable if the exact row does not pass, any control
+regresses, the change crosses #4699 descriptor-sidecar ownership, or the source
+diff exceeds 180 changed source LOC. If the safe affected-index analysis cannot
+be implemented within this boundary, leave this issue blocked and open no PR.
+
+## Acceptance
+
+- The exact `writable-enumerable-configurable-descriptor.js` row passes.
+- All three named numeric mapped-arguments controls remain passing.
+- All 20 #4699 descriptor rows remain passing when run against the same
+  descriptor implementation; no descriptor-sidecar code is changed here.
+- Other ordinary numeric mapped arguments continue using their existing
+  `f64`/`i32` carriers and reverse-sync behavior.
+- No generator, async, host-import, or unrelated closure ABI behavior changes.
+- Changed source LOC is ≤180; focused tests and issue results are recorded.
+- Scoped compiler/typecheck/equivalence checks pass on the final merged branch.
+
+## Test Results
+
+Baseline only (upstream/main `86c9ec686`):
+
+```
+1/1 exact row fail (NaN vs "foo")
+3/3 numeric mapped-arguments controls pass
+20 #4699 descriptor rows: control set; no implementation change in this slice
+```
+
+Implementation results on the same upstream base:
+
+```
+exact writable-enumerable-configurable-descriptor.js: pass
+numeric mapped-arguments controls: 3/3 pass
+focused Vitest/Test262 suite: 4/4 pass
+TypeScript 7 typecheck: pass
+Prettier check: pass
+Oracle ratchet: pass
+changed source LOC: 154 (≤180 cap)
+```
+
+The 20 non-owned #4699 descriptor controls remain 12/20 on both upstream and
+the current descriptor-sidecar worktree. This formal-carrier slice leaves that
+baseline unchanged and does not modify any #4699-owned file; the full 20-row
+acceptance check remains a parent-lane integration gate after the descriptor
+implementation is repaired/landed.
+
+Combined integration validation was then run in disposable branch
+`tmp/4701-with-4699`, merging the head of upstream PR #4924
+(`codex/4699-es2015-mapped-arguments-descriptor-flags`) without carrying that
+merge into this PR. The documented/default host `runTest262File` lane passed
+the full matrix: 1 exact row + 20 #4699 descriptor controls + 3 numeric
+controls = **24/24 pass**. The PR therefore depends on upstream #4924 for the
+non-owned descriptor implementation; this branch contributes only formal
+carrier widening and its exact/numeric regression tests.

--- a/plan/issues/4701-es2015-mapped-arguments-formal-widening.md
+++ b/plan/issues/4701-es2015-mapped-arguments-formal-widening.md
@@ -1,0 +1,161 @@
+---
+id: 4701
+title: "ES2015 mapped arguments string-valued formal reverse-sync widening"
+status: in-progress
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, conformance
+es_edition: es6
+language_feature: arguments-object
+goal: test262-conformance
+source_loc_cap: 180
+loc-budget-allow:
+  - src/codegen/closures.ts
+  - src/codegen/declarations.ts
+  - src/codegen/expressions/identifiers.ts
+func-budget-allow:
+  - src/codegen/expressions/identifiers.ts::compileIdentifierCore
+related: [4695, 4699, 4444, 4658, 1511]
+origin: "Single excluded ES2015 row split from blocked #4695/#4699: a mapped argument descriptor writes a string into an inferred-f64 formal, and reverse synchronization currently converts it to NaN."
+---
+
+# #4701 — ES2015 mapped arguments formal-carrier widening
+
+## Scope
+
+This issue owns only the single excluded row:
+
+```
+test/language/arguments-object/mapped/writable-enumerable-configurable-descriptor.js
+```
+
+The row calls a sloppy simple-parameter function as `(0)`, so call-site
+inference gives `a` an `f64` carrier. `Object.defineProperty(arguments, "0",
+{ value: "foo", writable: true, enumerable: true, configurable: true })`
+must update the mapped formal to the exact string. The current reverse-sync path
+unboxes the externref string through `__unbox_number` and stores `NaN` in the
+`f64` local.
+
+This slice may widen only the affected mapped formal's carrier and its
+parameter/arguments synchronization. It must not alter #4699's descriptor
+sidecar, descriptor flags, accessor routing, generator/async paths, host-import
+paths, or unrelated function ABI decisions. **Changed source LOC must remain at
+or below 180.**
+
+## Exact baseline (upstream/main)
+
+Baseline was measured on `upstream/main` commit `86c9ec686` (2026-08-25) with
+the repository's assembled `runTest262File` host-lane harness and the pinned
+Test262 submodule. The exact row failed during its primary sloppy run:
+
+```
+status: fail
+first error: Expected SameValue(«NaN», «"foo"») to be true
+at assert.sameValue(a, "foo")
+```
+
+The three numeric mapped-arguments controls all passed:
+
+```
+test/language/arguments-object/mapped/mapped-arguments-nonconfigurable-1.js  pass
+test/language/arguments-object/mapped/mapped-arguments-nonconfigurable-2.js  pass
+test/language/arguments-object/mapped/mapped-arguments-nonconfigurable-4.js  pass
+```
+
+The 20 descriptor rows owned by #4699 are additional controls for this slice:
+
+```
+test/language/arguments-object/mapped/enumerable-configurable-accessor-descriptor.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-basic.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-define-failure.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-set-value-by-arguments.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-set-value-with-define-property.js
+test/language/arguments-object/mapped/nonconfigurable-descriptors-with-param-assign.js
+test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
+test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
+test/language/arguments-object/mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
+test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-basic.js
+test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
+test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
+test/language/arguments-object/mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
+test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-basic.js
+test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
+test/language/arguments-object/mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
+test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
+test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
+test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-define-property.js
+test/language/arguments-object/mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
+```
+
+Those rows are not owned by this issue and are not changed here. They are
+re-run as controls after the formal-carrier change, together with the three
+numeric controls above, to detect ABI or reverse-sync regressions.
+
+## Bounded implementation plan
+
+1. Keep the current inferred numeric ABI for ordinary functions. Detect only a
+   non-strict simple-parameter function that materializes mapped `arguments`
+   and has a direct descriptor/element write capable of putting a nonnumeric
+   value into the mapped slot.
+2. For that function and affected formal index, use the universal `externref`
+   carrier at the function boundary and in the local. Existing numeric body
+   operations must continue to request the existing `f64` coercion at their
+   use site; no general inference policy or unrelated closure ABI is widened.
+3. Make mapped-arguments initialization and reverse synchronization honor the
+   widened per-index carrier: numeric values remain boxed/unboxed as before,
+   while an externref value is stored/read without `__unbox_number`. Preserve
+   the existing severed-link and descriptor-sidecar gates.
+4. Add focused equivalence coverage for string-valued reverse sync plus numeric
+   mapped writes. Validate the exact row, the three numeric controls, and all
+   20 #4699 descriptor controls serially before considering a PR.
+
+No implementation is acceptable if the exact row does not pass, any control
+regresses, the change crosses #4699 descriptor-sidecar ownership, or the source
+diff exceeds 180 changed source LOC. If the safe affected-index analysis cannot
+be implemented within this boundary, leave this issue blocked and open no PR.
+
+## Acceptance
+
+- The exact `writable-enumerable-configurable-descriptor.js` row passes.
+- All three named numeric mapped-arguments controls remain passing.
+- All 20 #4699 descriptor rows remain passing when run against the same
+  descriptor implementation; no descriptor-sidecar code is changed here.
+- Other ordinary numeric mapped arguments continue using their existing
+  `f64`/`i32` carriers and reverse-sync behavior.
+- No generator, async, host-import, or unrelated closure ABI behavior changes.
+- Changed source LOC is ≤180; focused tests and issue results are recorded.
+- Scoped compiler/typecheck/equivalence checks pass on the final merged branch.
+
+## Test Results
+
+Baseline only (upstream/main `86c9ec686`):
+
+```
+1/1 exact row fail (NaN vs "foo")
+3/3 numeric mapped-arguments controls pass
+20 #4699 descriptor rows: control set; no implementation change in this slice
+```
+
+Implementation results on the same upstream base:
+
+```
+exact writable-enumerable-configurable-descriptor.js: pass
+numeric mapped-arguments controls: 3/3 pass
+focused Vitest/Test262 suite: 4/4 pass
+TypeScript 7 typecheck: pass
+Prettier check: pass
+Oracle ratchet: pass
+changed source LOC: 154 (≤180 cap)
+```
+
+The 20 non-owned #4699 descriptor controls remain 12/20 on both upstream and
+the current descriptor-sidecar worktree. This formal-carrier slice leaves that
+baseline unchanged and does not modify any #4699-owned file; the full 20-row
+acceptance check remains a parent-lane integration gate after the descriptor
+implementation is repaired/landed.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -161,6 +161,7 @@ import { needsImplicitArgumentsObject } from "./helpers/body-uses-arguments.js";
 import { bodyReferencesOwnThis, findOwnThisReference } from "./helpers/body-references-own-this.js";
 // (#4491) §10.2.11 step 22.a — the mapped-vs-unmapped `arguments` split.
 import { isSimpleParameterList, isStrictFunction } from "./helpers/is-strict-function.js";
+import { mappedFormalNeedsExternref } from "./mapped-arguments-formal-widening.js";
 export { emitFuncRefAsClosure, materializeHoistedFunctionValueBinding };
 
 function emitClosureDefaultReturnValue(
@@ -1558,7 +1559,9 @@ export function computeClosureWrapperSig(
 
   // 1. Parameter types. (#3359) A TS `this` param is type-level only — exclude it.
   const arrowParams: ValType[] = [];
-  for (const p of runtimeParameters(arrow)) {
+  const runtimeParams = runtimeParameters(arrow);
+  for (let runtimeIndex = 0; runtimeIndex < runtimeParams.length; runtimeIndex++) {
+    const p = runtimeParams[runtimeIndex]!;
     const paramType = ctx.checker.getTypeAtLocation(p);
     let wasmType =
       !ts.isFunctionDeclaration(arrow) && setAccessorParamIsDynamic(arrow)
@@ -1619,6 +1622,16 @@ export function computeClosureWrapperSig(
       ctx.widenTupleCallbackParams === true &&
       (wasmType.kind === "ref" || wasmType.kind === "ref_null") &&
       isTupleType(paramType)
+    ) {
+      wasmType = { kind: "externref" };
+    }
+    // #4701: preserve a nonnumeric value written back through a mapped
+    // arguments slot, but leave ordinary numeric closure ABIs untouched.
+    if (
+      p.type === undefined &&
+      ts.getJSDocType(p) === undefined &&
+      (wasmType.kind === "f64" || wasmType.kind === "i32") &&
+      mappedFormalNeedsExternref(ctx, arrow, runtimeIndex)
     ) {
       wasmType = { kind: "externref" };
     }

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -57,6 +57,7 @@ import type { CodegenContext, FunctionContext, OptionalParamInfo } from "./conte
 import { compileFunctionBody, dumpFrameBreach, registerInlinableFunction } from "./audited-function-body.js";
 import { _hasRuntimeComputedKey, objectLiteralForcesHostPath } from "./literals.js"; // (#3024/#4638) module-global externref routing in lockstep with the literal's own host-path gate
 import { needsImplicitArgumentsObject } from "./helpers/body-uses-arguments.js";
+import { mappedFormalNeedsExternref } from "./mapped-arguments-formal-widening.js";
 import {
   addArrayIteratorImports,
   addForInImports,
@@ -920,6 +921,18 @@ function lowerParamType(
     runtimeEvalParamStructName !== undefined &&
     ctx.structFields.has(runtimeEvalParamStructName) &&
     !ctx.classTagMap.has(runtimeEvalParamStructName)
+  ) {
+    wasmType = { kind: "externref" };
+  }
+  // #4701: an inferred numeric formal in a mapped-arguments function can be
+  // written through Object.defineProperty/arguments[i] with a nonnumeric JS
+  // value. Keep ordinary numeric ABIs unchanged; widen only this measured
+  // direct-write shape so reverse sync can preserve the exact externref value.
+  if (
+    !param.type &&
+    ts.getJSDocType(param) === undefined &&
+    (wasmType.kind === "f64" || wasmType.kind === "i32") &&
+    mappedFormalNeedsExternref(ctx, stmt, index)
   ) {
     wasmType = { kind: "externref" };
   }

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -886,12 +886,24 @@ function compileIdentifierCore(
     // runtime `undefined` to NaN before `=== undefined` / any-param uses can
     // observe it. Return the raw externref; numeric consumers coerce at
     // their own use site (ToNumber(undefined) = NaN matches JS).
+    // #4701: a widened mapped-arguments formal is intentionally a dynamic
+    // carrier. Its checker type can remain numeric because the original
+    // call-site argument was numeric, but reverse sync may later write any JS
+    // value (for example, a string descriptor value) into the formal. Preserve
+    // the carrier on a bare read; numeric consumers coerce it at their use site.
+    const mappedExternrefParam = (() => {
+      const info = fctx.mappedArgsInfo;
+      if (!info || localIdx < info.paramOffset) return false;
+      const paramIndex = localIdx - info.paramOffset;
+      return paramIndex < info.paramCount && info.paramTypes[paramIndex]?.kind === "externref";
+    })();
     if (
       declaredType.kind === "externref" &&
       !fctx.captureExternrefNames?.has(name) &&
       !fctx.undefWidenedLocals?.has(name) &&
       !fctx.forInIdentifierVars?.has(name) &&
-      !fctx.mixedAssignmentCarrierVars?.has(name)
+      !fctx.mixedAssignmentCarrierVars?.has(name) &&
+      !mappedExternrefParam
     ) {
       const narrowedType = ctx.checker.getTypeAtLocation(id);
       const narrowed = narrowTypeToUnbox(ctx, fctx, narrowedType);

--- a/src/codegen/mapped-arguments-formal-widening.ts
+++ b/src/codegen/mapped-arguments-formal-widening.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+import { needsImplicitArgumentsObject } from "./helpers/body-uses-arguments.js";
+import { isSimpleParameterList, isStrictFunction } from "./helpers/is-strict-function.js";
+
+function staticArgumentIndex(expr: ts.Expression): number | undefined {
+  if (!ts.isNumericLiteral(expr) && !ts.isStringLiteral(expr)) return undefined;
+  const index = Number(expr.text);
+  return Number.isInteger(index) && index >= 0 && String(index) === expr.text ? index : undefined;
+}
+
+function isObjectDefineProperty(expr: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(expr) &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "Object" &&
+    expr.name.text === "defineProperty"
+  );
+}
+
+function isNumericValue(ctx: CodegenContext, expr: ts.Expression): boolean {
+  return ctx.oracle.staticJsTypeOf(expr) === "number";
+}
+
+/**
+ * Whether a mapped formal can receive a value outside its inferred numeric
+ * carrier through the function's own arguments object. This intentionally
+ * recognizes only direct, statically indexed writes: widening an entire
+ * closure ABI for an aliased or dynamic object would make the repair much
+ * broader than the measured descriptor row.
+ */
+export function mappedFormalNeedsExternref(
+  ctx: CodegenContext,
+  fn: ts.FunctionLikeDeclaration,
+  index: number,
+): boolean {
+  // Arrow functions inherit `arguments` and therefore cannot own a mapped
+  // arguments object for this formal. Closure inference visits arrows too, so
+  // reject them before the shared `needsImplicitArgumentsObject` predicate.
+  if (ts.isArrowFunction(fn)) return false;
+  const gate = fn.body === undefined;
+  const needs = needsImplicitArgumentsObject(fn, ctx.inferModuleStrictArguments);
+  const simple = isSimpleParameterList(fn.parameters);
+  const strict = isStrictFunction(fn, ctx.inferModuleStrictArguments);
+  if (gate || !needs || !simple || strict) {
+    return false;
+  }
+
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    // Nested ordinary functions (including methods/accessors) own their own
+    // `arguments`; nested arrows inherit this function's binding and remain
+    // part of the direct-write scan.
+    if (ts.isFunctionLike(node) && !ts.isArrowFunction(node)) return;
+
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      const left = node.left;
+      if (
+        ts.isElementAccessExpression(left) &&
+        ts.isIdentifier(left.expression) &&
+        left.expression.text === "arguments" &&
+        staticArgumentIndex(left.argumentExpression) === index &&
+        !isNumericValue(ctx, node.right)
+      ) {
+        found = true;
+        return;
+      }
+    }
+
+    if (ts.isCallExpression(node) && isObjectDefineProperty(node.expression) && node.arguments.length >= 3) {
+      const receiver = node.arguments[0];
+      const key = staticArgumentIndex(node.arguments[1]!);
+      if (ts.isIdentifier(receiver) && receiver.text === "arguments" && key === index) {
+        const descriptor = node.arguments[2]!;
+        if (!ts.isObjectLiteralExpression(descriptor)) {
+          found = true;
+          return;
+        }
+        let hasValue = false;
+        for (const property of descriptor.properties) {
+          if (ts.isSpreadAssignment(property)) {
+            found = true;
+            return;
+          }
+          const name = property.name;
+          const propertyName =
+            name && (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name))
+              ? name.text
+              : undefined;
+          if (propertyName !== "value") continue;
+          if (ts.isPropertyAssignment(property)) {
+            hasValue = true;
+            if (!isNumericValue(ctx, property.initializer)) {
+              found = true;
+              return;
+            }
+          } else if (ts.isShorthandPropertyAssignment(property)) {
+            hasValue = true;
+            if (!isNumericValue(ctx, property.name)) {
+              found = true;
+              return;
+            }
+          }
+        }
+        if (hasValue) return;
+      }
+    }
+
+    node.forEachChild(visit);
+  };
+  visit(fn.body);
+  return found;
+}

--- a/tests/issue-4701.test.ts
+++ b/tests/issue-4701.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4701 — an inferred numeric formal must retain a string written through its
+// own mapped arguments object. The three numeric rows are controls for the
+// existing f64 reverse-sync path; descriptor-sidecar rows remain #4699-owned.
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262 = resolve(process.cwd(), "test262");
+const ROOT = join(TEST262, "test", "language", "arguments-object", "mapped");
+const cases = [
+  "writable-enumerable-configurable-descriptor.js",
+  "mapped-arguments-nonconfigurable-1.js",
+  "mapped-arguments-nonconfigurable-2.js",
+  "mapped-arguments-nonconfigurable-4.js",
+];
+
+const maybe = existsSync(TEST262) ? describe : describe.skip;
+
+maybe("#4701 mapped-arguments formal carrier", () => {
+  for (const name of cases) {
+    it(name, async () => {
+      const result = await runTest262File(join(ROOT, name), "language/arguments-object/mapped", 30_000, "standalone");
+      expect(result.status, result.error ?? result.reason ?? "").toBe("pass");
+    });
+  }
+});


### PR DESCRIPTION
Depends on #4924.

Widen only mapped simple formals whose arguments-object descriptor path can write a nonnumeric value. The exact row plus three numeric controls pass locally; a disposable integration branch combining #4924 passes the full 24/24 matrix.

Refs #4701.