### PR TITLE
fix(for-of): preserve assignment-head writes

### DIFF
--- a/plan/issues/4712-es2015-forof-lhs-cover.md
+++ b/plan/issues/4712-es2015-forof-lhs-cover.md
@@ -1,0 +1,117 @@
+---
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+status: done
+priority: high
+depends_on: []
+es_edition: es2015
+language_feature: for-of-assignment-head-cover
+task_type: bug
+files:
+  - src/codegen/statements/loops.ts
+  - tests/issue-4712.test.ts
+loc-budget-allow:
+  - src/codegen/statements/loops.ts
+func-budget-allow:
+  - src/codegen/statements/loops.ts::compileForOfArray
+  - src/codegen/statements/loops.ts::compileForOfDirectIterator
+  - src/codegen/statements/loops.ts::compileForOfIterator
+---
+
+# Issue 4712 — ES2015 `for-of` assignment-head CoverParenthesizedExpression
+
+## Scope
+
+Close the synchronous ES2015 `for-of` assignment-head rows whose left side is
+an assignment expression covered by `CoverParenthesizedExpressionAndArrowParameterList`:
+
+- `test/language/statements/for-of/head-lhs-cover.js`
+- `test/language/statements/for-of/head-lhs-async-parens.js`
+
+This slice is limited to synchronous assignment heads and their direct
+head-expression controls. It excludes destructuring, lexical TDZ/fresh
+bindings, async iteration, Set/Map, and IteratorClose behavior.
+
+## Live current-main baseline (before source edits)
+
+Baseline was run from `upstream/main` at `cd1677bcef59de3d7882125bf8fdce9ff82e714c`
+with the initialized Test262 submodule at `b363f29d3c43c626dc852744ad64a0b48a003693`.
+The authoritative `runTest262File` runner was invoked directly with absolute
+paths for each file; the result below is therefore a fresh compile/run, not a
+committed dashboard artifact.
+
+| path | baseline status | exact signature |
+| --- | --- | --- |
+| `for-of/head-lhs-cover.js` | `fail` | `Test262Error: Expected SameValue(«undefined», «23») to be true; assignment never updates `x` |
+| `for-of/head-lhs-async-parens.js` | `fail` | `Test262Error: Expected SameValue(«undefined», «7») to be true; assignment never updates `async` |
+
+The same assignment-write defect is reproduced by the directly related
+positive controls `head-lhs-member.js` (`x.y` remains `undefined`) and
+`head-lhs-async-dot.js` (`async.x` remains `0`). `head-lhs-async-escaped.js`
+currently has the separate compile-time signature `'async' is not allowed as a
+left-hand side identifier in for-of` and is excluded from this bounded slice.
+Adjacent controls that already pass and must stay green are
+`head-expr-no-expr.js`, `head-decl-no-expr.js`, `head-lhs-async-invalid.js`,
+`head-lhs-cover-non-asnmt-trgt.js`, `head-lhs-invalid-asnmt-ptrn-ary.js`,
+`head-lhs-invalid-asnmt-ptrn-obj.js`, `head-lhs-non-asnmt-trgt.js`,
+`head-lhs-let.js`, `head-expr-obj-iterator-method.js`, and
+`head-expr-primitive-iterator-method.js`. `head-expr-to-obj.js` remains an
+unrelated runtime assertion failure (the expected TypeError is not rendered as
+an object) and is not admitted as a control.
+
+The compiler accepts minimal equivalents outside the literal Test262 harness
+(`var x; for ((x) of [23]) {}` and `let async; for ((async) of [7]);`), so the
+failure is not a parser-wide inability to parse these heads. The current
+failure is a missing assignment-target write in the for-of lowering path used
+by the complete test body/harness.
+
+## Root-cause hypothesis and bounded plan
+
+1. Reproduce the missing-write result with the literal harness and inspect the
+   AST/lowering route for a parenthesized assignment head.
+2. Normalize only the CoverParenthesizedExpression wrapper at the synchronous
+   `for-of` assignment target boundary, retaining member/identifier semantics
+   and existing invalid-target early errors.
+3. Route the unwrapped assignment target through the existing array and generic
+   iterator write paths; do not broaden this change to destructuring, lexical
+   heads, async iteration, collection specialization, or close handling.
+4. Add focused regression coverage for the two exact rows and the listed
+   positive/negative controls, then compile and run 3–5 representative Test262
+   files plus scoped equivalence tests.
+
+Maximum changed source LOC: 180 (tests and this planning artifact are outside
+That source LOC budget).
+
+## Acceptance
+
+- Both exact rows pass the authoritative Test262 runner in the synchronous host
+  lane, with no `undefined.kind` compile error.
+- Positive controls `head-lhs-member.js` and `head-lhs-async-dot.js` pass.
+- The adjacent parse/early-error controls listed above remain passing.
+- No destructuring, lexical TDZ/fresh-binding, async iteration, Set/Map, or
+  IteratorClose behavior changes are introduced.
+- Scoped TypeScript/build checks and the focused tests pass from a branch
+  rebased only by merging the latest upstream main (no force push or rebase).
+
+## Test Results
+
+Implementation is confined to `src/codegen/statements/loops.ts`: the lowering
+now unwraps only parenthesized assignment heads, reuses the existing local for
+an unwrapped identifier, and sends member/element targets through
+`emitAssignToTarget`. Destructuring and existing declaration paths remain
+unchanged. Focused coverage is in `tests/issue-4712.test.ts`.
+
+From the implementation branch, after the live baseline above:
+
+```text
+node_modules/.bin/vitest run tests/issue-4712.test.ts --reporter=verbose
+14 passed (2 exact rows, 2 member-write controls, 10 adjacent controls)
+```
+
+The direct authoritative `runTest262File` invocation produced the same 14/14
+passing results. `git diff --check` is clean and the changed compiler source
+is 65 lines, below the 180-line budget. A repository-wide `tsc --noEmit`
+attempt remains blocked by the existing worktree dependency/type-resolution
+environment (many unrelated missing Node globals); it does not affect the
+focused compile/run checks or their 14/14 result.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -12,6 +12,7 @@ import { allocLocal, getLocalType } from "../context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "../context/speculative.js";
 import type { CodegenContext, FunctionContext, HoistedCharRead } from "../context/types.js";
 import { emitCoercedLocalSet, emitWebCompatCallAssignmentTarget, updateLocalType } from "../expressions/helpers.js";
+import { emitAssignToTarget } from "../expressions/assignment.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "../expressions/late-imports.js";
 import { nativeGeneratorInfoForForOfSubject, tryCompileNativeGeneratorForOf } from "../generators-native.js";
 import {
@@ -85,6 +86,33 @@ import { tryCompileCountedStringAppend } from "./counted-string-append.js";
 import { emitHoleToUndefined } from "../array-holes.js"; // (#2001 S1)
 import { emitF64HoleToUndef, f64HolesActive } from "../vec-f64-hole-presence.js"; // (#4491 T11)
 import { definedFuncAt, nativeStrHelperHandle } from "../func-space.js"; // (#1916 S2) positional-read chokepoint
+
+/** Strip the transparent parentheses used by CoverParenthesizedExpression in a
+ * for-of assignment head. The declaration/destructuring paths intentionally
+ * stay outside this helper; this is only the assignment-target dispatch. */
+function unwrapForOfAssignmentTarget(target: ts.Expression): ts.Expression {
+  let unwrapped = target;
+  while (ts.isParenthesizedExpression(unwrapped)) unwrapped = unwrapped.expression;
+  return unwrapped;
+}
+
+/** Write one already-evaluated for-of value to a member/call assignment head.
+ * Identifier targets reuse the selected loop local, while call targets retain
+ * Annex-B's evaluate-then-ReferenceError behavior. */
+function emitForOfAssignmentTarget(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.Expression,
+  valueLocal: number,
+  valueType: ValType,
+): void {
+  const unwrapped = unwrapForOfAssignmentTarget(target);
+  if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
+    emitAssignToTarget(ctx, fctx, unwrapped, valueLocal, valueType);
+    return;
+  }
+  emitWebCompatCallAssignmentTarget(ctx, fctx, target);
+}
 
 /**
  * Compile a loop body, saving/restoring block-scoped shadows (#817) so that
@@ -1414,6 +1442,9 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
   const elemType = strType;
 
   // Declare the loop variable
+  const assignmentTarget = ts.isVariableDeclarationList(stmt.initializer)
+    ? undefined
+    : unwrapForOfAssignmentTarget(stmt.initializer);
   let elemLocal: number;
   if (ts.isVariableDeclarationList(stmt.initializer)) {
     const decl = stmt.initializer.declarations[0]!;
@@ -1424,9 +1455,9 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
       if (!fctx.constBindings) fctx.constBindings = new Set();
       fctx.constBindings.add(decl.name.text);
     }
-  } else if (ts.isIdentifier(stmt.initializer)) {
+  } else if (assignmentTarget && ts.isIdentifier(assignmentTarget)) {
     // Expression form: for (x of str) — x is already declared
-    const varName = stmt.initializer.text;
+    const varName = assignmentTarget.text;
     elemLocal = fctx.localMap.get(varName) ?? allocLocal(fctx, varName, elemType);
   } else {
     elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, elemType);
@@ -1504,7 +1535,7 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
   fctx.body.push({ op: "call", funcIdx: substringIdx });
   fctx.body.push({ op: "local.set", index: elemLocal });
   if (!ts.isVariableDeclarationList(stmt.initializer)) {
-    emitWebCompatCallAssignmentTarget(ctx, fctx, stmt.initializer);
+    emitForOfAssignmentTarget(ctx, fctx, stmt.initializer, elemLocal, elemType);
   }
 
   // Compile body — save/restore block-scoped shadows for let/const (#817).
@@ -1675,6 +1706,10 @@ function compileForOfArray(
     elemType.kind === "f64" ? { kind: "f64" as const, undefSentinel: true as const } : unpackedElemType(elemType);
   const elemReadOp = elemGetOp(elemType, typedArraySearchSignedness(ctx, iterableOverride ?? stmt.expression));
 
+  const assignmentTarget = ts.isVariableDeclarationList(stmt.initializer)
+    ? undefined
+    : unwrapForOfAssignmentTarget(stmt.initializer);
+
   // Save vec ref to temp local. With `preVec` the vec is already in `vecLocal`.
   const vecLocal = preVec ? preVec.vecLocal : allocLocal(fctx, `__forof_vec_${fctx.locals.length}`, vecType);
   if (!preVec) {
@@ -1751,9 +1786,9 @@ function compileForOfArray(
     // These assign to already-declared variables
     assignDestructExpr = stmt.initializer;
     elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, readElemType);
-  } else if (ts.isIdentifier(stmt.initializer)) {
+  } else if (assignmentTarget && ts.isIdentifier(assignmentTarget)) {
     // Expression form: for (x of arr) — x is already declared
-    const varName = stmt.initializer.text;
+    const varName = assignmentTarget.text;
     elemLocal = fctx.localMap.get(varName) ?? allocLocal(fctx, varName, readElemType);
   } else {
     elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, readElemType);
@@ -1843,7 +1878,7 @@ function compileForOfArray(
   }
   emitCoercedLocalSet(ctx, fctx, elemLocal, readElemType);
   if (!ts.isVariableDeclarationList(stmt.initializer)) {
-    emitWebCompatCallAssignmentTarget(ctx, fctx, stmt.initializer);
+    emitForOfAssignmentTarget(ctx, fctx, stmt.initializer, elemLocal, readElemType);
   }
 
   // If destructuring pattern (binding form), destructure from the element
@@ -2357,6 +2392,9 @@ function compileForOfDirectIterator(
 
   // Declare the loop variable
   const elemType: ValType = valueFieldType;
+  const assignmentTarget = ts.isVariableDeclarationList(stmt.initializer)
+    ? undefined
+    : unwrapForOfAssignmentTarget(stmt.initializer);
   let elemLocal: number;
   let destructPatternIter: ts.ObjectBindingPattern | ts.ArrayBindingPattern | null = null;
   let assignDestructExprIter: ts.ObjectLiteralExpression | ts.ArrayLiteralExpression | null = null;
@@ -2383,8 +2421,8 @@ function compileForOfDirectIterator(
   } else if (ts.isObjectLiteralExpression(stmt.initializer) || ts.isArrayLiteralExpression(stmt.initializer)) {
     assignDestructExprIter = stmt.initializer;
     elemLocal = allocLocal(fctx, `__forit_elem_${fctx.locals.length}`, elemType);
-  } else if (ts.isIdentifier(stmt.initializer)) {
-    const varName = stmt.initializer.text;
+  } else if (assignmentTarget && ts.isIdentifier(assignmentTarget)) {
+    const varName = assignmentTarget.text;
     elemLocal = fctx.localMap.get(varName) ?? allocLocal(fctx, varName, elemType);
   } else {
     elemLocal = allocLocal(fctx, `__forit_elem_${fctx.locals.length}`, elemType);
@@ -2507,7 +2545,7 @@ function compileForOfDirectIterator(
   }
   fctx.body.push({ op: "local.set", index: elemLocal });
   if (!ts.isVariableDeclarationList(stmt.initializer)) {
-    emitWebCompatCallAssignmentTarget(ctx, fctx, stmt.initializer);
+    emitForOfAssignmentTarget(ctx, fctx, stmt.initializer, elemLocal, valueFieldType);
   }
 
   // If destructuring, handle it
@@ -2809,6 +2847,9 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
 
   // Declare the loop variable (element type is externref for iterator protocol)
   const elemType: ValType = { kind: "externref" };
+  const assignmentTarget = ts.isVariableDeclarationList(stmt.initializer)
+    ? undefined
+    : unwrapForOfAssignmentTarget(stmt.initializer);
   let elemLocal: number;
   let destructPatternIter: ts.ObjectBindingPattern | ts.ArrayBindingPattern | null = null;
   let assignDestructExprIter: ts.ObjectLiteralExpression | ts.ArrayLiteralExpression | null = null;
@@ -2836,9 +2877,9 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
     // Expression form with destructuring: for ({a, b} of arr) or for ([x, y] of arr)
     assignDestructExprIter = stmt.initializer;
     elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, elemType);
-  } else if (ts.isIdentifier(stmt.initializer)) {
+  } else if (assignmentTarget && ts.isIdentifier(assignmentTarget)) {
     // Expression form: for (x of arr) — x is already declared
-    const varName = stmt.initializer.text;
+    const varName = assignmentTarget.text;
     elemLocal = fctx.localMap.get(varName) ?? allocLocal(fctx, varName, elemType);
   } else {
     elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, elemType);
@@ -2961,7 +3002,7 @@ function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: 
   fctx.body.push({ op: "local.get", index: resultLocal });
   fctx.body.push({ op: "local.set", index: elemLocal });
   if (!ts.isVariableDeclarationList(stmt.initializer)) {
-    emitWebCompatCallAssignmentTarget(ctx, fctx, stmt.initializer);
+    emitForOfAssignmentTarget(ctx, fctx, stmt.initializer, elemLocal, elemType);
   }
 
   // If destructuring pattern, destructure from the element

--- a/tests/issue-4712.test.ts
+++ b/tests/issue-4712.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4712 — synchronous for-of assignment-head CoverParenthesizedExpression.
+// Keep the exact Test262 rows here: a source-only probe would not exercise the
+// same assignment-head lowering or the literal harness assertion.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_ROOT = join(__dirname, "..", "test262");
+const FOR_OF_ROOT = join(TEST262_ROOT, "test", "language", "statements", "for-of");
+const TEST262 = existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+
+const rows = ["head-lhs-cover.js", "head-lhs-async-parens.js", "head-lhs-member.js", "head-lhs-async-dot.js"] as const;
+
+const controls = [
+  "head-expr-no-expr.js",
+  "head-decl-no-expr.js",
+  "head-lhs-async-invalid.js",
+  "head-lhs-cover-non-asnmt-trgt.js",
+  "head-lhs-invalid-asnmt-ptrn-ary.js",
+  "head-lhs-invalid-asnmt-ptrn-obj.js",
+  "head-lhs-non-asnmt-trgt.js",
+  "head-lhs-let.js",
+  "head-expr-obj-iterator-method.js",
+  "head-expr-primitive-iterator-method.js",
+] as const;
+
+afterEach(async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
+async function runRow(file: string) {
+  return runTest262File(join(FOR_OF_ROOT, file), "issue-4712", 30_000);
+}
+
+describe.skipIf(!TEST262)("#4712 — synchronous for-of assignment-head cover", () => {
+  for (const file of rows) {
+    it(`${file} passes`, { timeout: 60_000 }, async () => {
+      const result = await runRow(file);
+      expect(result.status, result.error ?? "").toBe("pass");
+    });
+  }
+
+  for (const file of controls) {
+    it(`${file} remains passing`, { timeout: 60_000 }, async () => {
+      const result = await runRow(file);
+      expect(result.status, result.error ?? "").toBe("pass");
+    });
+  }
+});


### PR DESCRIPTION
Unwrap CoverParenthesizedExpression around synchronous for-of assignment heads and route member targets through the existing assignment emitter. Reuse the declared local for parenthesized identifiers while preserving existing invalid-target behavior.

Add exact Test262 regressions and adjacent controls for issue #4712, with the live baseline and acceptance record in the issue plan.

Co-authored-by: Codex <codex@openai.com>
