### PR TITLE
fix(#4711): propagate dynamic Set for-of bindings

### DIFF
--- a/plan/issues/4711-es2015-forof-set-dynamic-binding.md
+++ b/plan/issues/4711-es2015-forof-set-dynamic-binding.md
@@ -16,7 +16,7 @@ language_feature: for-of, Set, mutable-binding
 goal: spec-completeness
 assignee: codex/4711-es2015-forof-set-dynamic-binding
 loc-budget-max-source: 180
-related: [4704, 4708, 4702]
+related: [4704, 4708, 4702, 4930]
 ---
 
 # ES2015 `for-of` Set dynamic and mutable binding values
@@ -112,4 +112,8 @@ controls (`array.js`, `array-contract.js`, `array-expand.js`,
 line cap; no iterator/storage code changed. A temporary validation worktree
 stacked #4708 commit `cd1bf056a` on this commit; all five Set rows then passed
 in both host and standalone lanes. The #4708 commit and its files are not part
-of this PR.
+of this PR. After merging upstream main as `1e47a46d8`, the exact Set matrix
+remained unchanged: both owned rows passed in both lanes, both standalone
+native-mutation controls retained their expected #4708 failures, and all other
+controls passed. Full standalone control closure depends on #4930 (the #4708
+live native Set iteration PR).

--- a/plan/issues/4711-es2015-forof-set-dynamic-binding.md
+++ b/plan/issues/4711-es2015-forof-set-dynamic-binding.md
@@ -1,0 +1,115 @@
+---
+id: 4711
+title: "ES2015 for-of Set dynamic and mutable binding values"
+status: in-review
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: codegen, runtime, conformance
+es_edition: es2015
+language_feature: for-of, Set, mutable-binding
+goal: spec-completeness
+assignee: codex/4711-es2015-forof-set-dynamic-binding
+loc-budget-max-source: 180
+related: [4704, 4708, 4702]
+---
+
+# ES2015 `for-of` Set dynamic and mutable binding values
+
+## Exact scope
+
+This issue owns only the dynamic-`any`/mutable-binding defects in:
+
+- `test/language/statements/for-of/set.js`
+- `test/language/statements/for-of/set-contract-expand.js`
+
+The change must keep the loop variable's current value observable through the
+dynamic assertion/call path after each iteration. It must not implement eager
+snapshot replacement or live native Set iteration (#4708), Set `entries`
+(#4680), Map iteration, destructuring, async iteration, IteratorClose, or the
+generic fresh-binding feature (#4702).
+
+## Exact per-lane baseline from #4704
+
+The #4704 fresh measurement used upstream `main` commit `34b083771` and the
+pinned test262 submodule `b363f29d3c`; current upstream `main` (`cd1677bce`)
+reproduces the headline `set.js` host failure. Results from that record are:
+
+| Row | Host lane | Standalone lane |
+| --- | --- | --- |
+| `set.js` | **fail** — `Expected SameValue(«null», «false»)` | **fail** — `Expected SameValue(«null», «false»)` |
+| `set-contract.js` (control) | **pass** | **fail** — `Expected SameValue(«1», «0»)` |
+| `set-expand.js` (control) | **pass** | **fail** — `Expected SameValue(«1», «2»)` |
+| `set-contract-expand.js` | **fail** — `Expected SameValue(«1», «0»)` | **pass** |
+| `set-expand-contract.js` (control) | **pass** | **pass** |
+
+The `set.js` and host `set-contract-expand.js` failures occur after Set values
+have been yielded: their dynamic assertion closure reads stale mutable state
+(`null`/`0`) rather than the current loop value. The standalone pass for
+`set-contract-expand.js` is the eager-snapshot behavior documented by #4704,
+not evidence that dynamic binding is correct. The two standalone control
+failures belong to #4708 and remain negative-scope checks here.
+
+## Focused plan
+
+1. Re-run the two owned rows and the four Set controls in fresh host and
+   standalone processes on current main. The Set cursor and loop-body value
+   are already correct; the failing dynamic assertion path exposes a stale
+   primitive module slot instead of the current iteration value.
+2. Trace mutable binding identity through the existing heterogeneous-module
+   analysis. A direct assignment such as `third = fourth` was not widening
+   `third` when `fourth` was the binding that later received `null`, `undefined`,
+   or an object, even though that value flows through the assignment edge.
+3. Extend only that analysis with a bounded module-binding dependency graph:
+   unwrap identifier RHS expressions, record same-source module binding edges,
+   and propagate widening from seeded heterogeneous bindings to their mutable
+   consumers. Keep the existing declaration-identity and `with` fallback
+   behavior; do not alter Set iterator storage, cursor, or dispatch code.
+4. Add focused issue tests for the owned rows and host controls, then rerun the
+   exact matrix, array/string controls, both TypeScript lanes, formatting, and
+   diff/LOC review. The #4708 live-iterator implementation remains separate;
+   its standalone mutation controls are retained as dependency baselines.
+
+## Acceptance
+
+- `set.js` passes in both host and standalone lanes on the current-main
+  iterator path.
+- `set-contract-expand.js` passes in both lanes on this branch and remains
+  green when the #4708 live-iterator source is stacked; its standalone pass is
+  not used to claim the separate native Set mutation behavior.
+- `set-contract.js`, `set-expand.js`, and `set-expand-contract.js` preserve
+  their recorded outcomes; array/string `for-of` controls remain passing.
+- No changes to native Set cursor/storage, Map, Set `entries`, destructuring,
+  async, IteratorClose, or generic fresh-binding behavior.
+- Changed compiler/runtime source is at most 180 lines and the PR contains no
+  unrelated worktree changes.
+
+## Test Results
+
+Baseline above is from #4704's fresh current-main run on test262 `b363f29d3c`.
+After the binding-analysis fix, the exact Set matrix on current branch
+`cd1677bce` is:
+
+| Row | Host lane | Standalone lane |
+| --- | --- | --- |
+| `set.js` (owned) | pass | pass |
+| `set-contract.js` (#4708 control) | pass | fail — `Expected SameValue(«1», «0»)` |
+| `set-expand.js` (#4708 control) | pass | fail — `Expected SameValue(«1», «2»)` |
+| `set-contract-expand.js` (owned) | pass | pass |
+| `set-expand-contract.js` (control) | pass | pass |
+
+The focused `tests/issue-4711.test.ts` suite passes all 7 assertions: both
+owned rows in both lanes plus the three host controls. Array and string
+controls (`array.js`, `array-contract.js`, `array-expand.js`,
+`array-contract-expand.js`, `array-expand-contract.js`, `string-bmp.js`, and
+`string-astral.js`) pass in both lanes. TypeScript 5 and TypeScript 7
+`--noEmit` checks pass. The compiler source diff is 47 lines, below the 180
+line cap; no iterator/storage code changed. A temporary validation worktree
+stacked #4708 commit `cd1bf056a` on this commit; all five Set rows then passed
+in both host and standalone lanes. The #4708 commit and its files are not part
+of this PR.

--- a/src/ir/heterogeneous-module-bindings.ts
+++ b/src/ir/heterogeneous-module-bindings.ts
@@ -115,6 +115,7 @@ export function collectHeterogeneouslyAssignedModuleVarNames(
   if (cached) return cached;
 
   const widened = new Set<string>();
+  const propagationEdges = new Map<string, string[]>();
   const moduleVarsByName = sourceFile.text.includes("with")
     ? collectModuleScopedVarsByName(sourceFile)
     : new Map<string, ts.VariableDeclaration>();
@@ -142,6 +143,19 @@ export function collectHeterogeneouslyAssignedModuleVarNames(
     return tag;
   };
 
+  const unwrapIdentifier = (expression: ts.Expression): ts.Identifier | undefined => {
+    let current = expression;
+    while (
+      ts.isParenthesizedExpression(current) ||
+      ts.isAsExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isNonNullExpression(current)
+    ) {
+      current = current.expression;
+    }
+    return ts.isIdentifier(current) ? current : undefined;
+  };
+
   const visit = (node: ts.Node): void => {
     if (
       ts.isBinaryExpression(node) &&
@@ -152,7 +166,23 @@ export function collectHeterogeneouslyAssignedModuleVarNames(
       const declaration = oracle.variableDeclarationOf(node.left);
       if (declaration !== undefined && declaration.getSourceFile() === sourceFile) {
         const declTag = initializerTagOf(declaration);
-        if (declTag !== "none" && assignmentWidens(oracle, declTag, node.right)) widened.add(node.left.text);
+        if (declTag !== "none") {
+          if (assignmentWidens(oracle, declTag, node.right)) widened.add(node.left.text);
+          const rhs = unwrapIdentifier(node.right);
+          if (rhs !== undefined) {
+            const rhsDeclaration = oracle.variableDeclarationOf(rhs);
+            if (
+              rhsDeclaration !== undefined &&
+              ts.isIdentifier(rhsDeclaration.name) &&
+              rhsDeclaration.getSourceFile() === sourceFile &&
+              isModuleScoped(rhsDeclaration)
+            ) {
+              const targets = propagationEdges.get(rhsDeclaration.name.text) ?? [];
+              targets.push(node.left.text);
+              propagationEdges.set(rhsDeclaration.name.text, targets);
+            }
+          }
+        }
       } else if (declaration === undefined && moduleVarsByName.size > 0 && isInsideWithBody(node.left)) {
         // `with` can dynamically resolve the target to the object environment,
         // so only an unresolved identifier may use this deliberately name-keyed
@@ -165,6 +195,21 @@ export function collectHeterogeneouslyAssignedModuleVarNames(
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);
+
+  // A specialized binding can also receive values through another mutable
+  // binding. Resolve that small dependency graph to keep dynamic assignments
+  // in the same externref carrier (`var a = false; var b = a; a = null;
+  // b = a`). The direct pass above seeds the graph; propagation is bounded by
+  // the number of module bindings and does not inspect unrelated locals.
+  const pending = [...widened];
+  for (let index = 0; index < pending.length; index++) {
+    const sourceName = pending[index]!;
+    for (const target of propagationEdges.get(sourceName) ?? []) {
+      if (widened.has(target)) continue;
+      widened.add(target);
+      pending.push(target);
+    }
+  }
   bySource.set(sourceFile, widened);
   return widened;
 }

--- a/tests/issue-4711.test.ts
+++ b/tests/issue-4711.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4711 owns the dynamic-any/mutable-binding half of the Set for-of wave. The
+// native Set cursor/storage rows remain #4708 controls and are intentionally
+// not asserted here.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_ROOT = join(__dirname, "..", "test262");
+const HAS_TEST262 = existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+const FOR_OF_ROOT = join(TEST262_ROOT, "test", "language", "statements", "for-of");
+
+afterEach(async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
+async function runRow(file: string, target?: "standalone") {
+  return runTest262File(join(FOR_OF_ROOT, file), "issue-4711", 30_000, target);
+}
+
+describe.skipIf(!HAS_TEST262)("#4711 — Set for-of dynamic bindings", () => {
+  for (const target of [undefined, "standalone"] as const) {
+    it(`${target ?? "host"}: set.js preserves mutable any values`, { timeout: 60_000 }, async () => {
+      const result = await runRow("set.js", target);
+      expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+    });
+
+    it(`${target ?? "host"}: set-contract-expand.js preserves rebinding`, { timeout: 60_000 }, async () => {
+      const result = await runRow("set-contract-expand.js", target);
+      expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+    });
+  }
+
+  // Host controls remain green. Standalone Set mutation controls belong to
+  // #4708 and stay outside this PR's acceptance surface.
+  for (const file of ["set-contract.js", "set-expand.js", "set-expand-contract.js"]) {
+    it(`host control: ${file}`, { timeout: 60_000 }, async () => {
+      const result = await runRow(file);
+      expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Propagate heterogeneous module-slot widening across same-source mutable binding assignment edges so Set for-of dynamic assertions observe current values.
- Add focused #4711 Test262 coverage and preserve the exact #4704 host/standalone control matrix.
- No Set iterator storage/cursor, Map, entries, destructuring, async, IteratorClose, or generic fresh-binding changes.

## Validation

- Focused Vitest: 7/7 passed.
- Exact Set matrix: both owned rows pass in host and standalone; expected standalone #4708 controls remain the only two failures.
- Array and string controls pass in both lanes.
- TypeScript 5/7 checks pass; pre-push typecheck, lint, format, ratchets, issue integrity, and #3765 parity pass.
- Temporary #4708 stack validation (`cd1bf056a`) passes all five Set rows in both lanes.

Depends on #4930 (the live native Set iteration implementation for #4708 controls). Its source is intentionally not included here.