### PR TITLE
fix(for-of): probe iterator for empty assignment patterns

### DIFF
--- a/plan/issues/4714-es2015-forof-empty-array-pattern.md
+++ b/plan/issues/4714-es2015-forof-empty-array-pattern.md
@@ -1,0 +1,103 @@
+---
+id: 4714
+title: "ES2015 for-of empty array assignment pattern requires GetIterator"
+status: in-review
+created: 2026-08-25
+updated: 2026-08-25
+assignee: codex/4714-es6-forof-empty-array-pattern
+priority: medium
+horizon: s
+feasibility: medium
+task_type: conformance
+area: codegen, destructuring, for-of
+es_edition: es6
+related: [4690, 4693, 4702, 4710]
+loc-budget: 180
+loc-budget-allow:
+  - src/codegen/statements/for-of-destructuring.ts
+---
+
+# #4714 — empty array assignment pattern in for-of
+
+## Scope and live baseline
+
+The exact rows were run through the authoritative `runTest262File` seam from
+upstream/main `598cb2f226dc1c60376a5d19f858b2db99f91b06` (2026-08-25). Both
+the default host/GC lane and `target: "standalone"` were measured. The target
+rows are the two named files; the directly related controls cover iterable
+arrays/strings and the sibling non-iterable primitive/null values.
+
+| file | host/GC baseline | standalone baseline | signature |
+| --- | --- | --- | --- |
+| `array-empty-val-num.js` | fail | fail | expected TypeError, no exception |
+| `array-empty-val-undef.js` | fail | fail | expected TypeError, no exception |
+| `array-empty-val-array.js` | pass | pass | empty array value completes one iteration |
+| `array-empty-val-string.js` | pass | pass | string value completes one iteration |
+| `array-empty-val-null.js` | fail | fail | expected TypeError, no exception |
+| `array-empty-val-bool.js` | fail | fail | expected TypeError, no exception |
+| `array-empty-val-symbol.js` | fail | fail | expected TypeError, no exception |
+
+The two target failures are genuine behavior failures, not compile errors or
+runner skips. Current lowering treats an empty assignment pattern as no work:
+the externref path skips `__array_from_iter_n`, and the primitive path returns
+without emitting the required non-iterable TypeError. This incorrectly avoids
+`GetIterator` even though an empty `ArrayAssignmentPattern` still performs it.
+
+## Implementation plan
+
+1. In `src/codegen/statements/for-of-destructuring.ts`, route empty
+   assignment-array patterns through the existing `__iterator` primitive,
+   dropping its iterator record without reading an element. This performs the
+   required `GetIterator` step on both host and standalone/WASI lanes while
+   leaving the existing bounded materializer for non-empty patterns intact.
+2. For statically primitive element types, emit the existing TypeError helper
+   instead of silently returning. Keep binding allocation behavior and all
+   non-empty paths unchanged.
+3. Add exact seven-row host and standalone pins in a focused issue test. The
+   two target rows must become pass; iterable controls must remain pass; the
+   sibling non-iterable controls must become pass.
+4. Re-run the focused seam, compiler/type checks, and adjacent empty-pattern
+   controls after merging latest upstream/main. Keep changed compiler source
+   below 180 lines.
+
+## Non-goals and exclusions
+
+This issue does not implement assignment-target writes (#4693), temporal-dead-
+zone behavior (#4710), fresh per-iteration bindings (#4702), async/for-await,
+collection iterators, or broad `IteratorClose` repair. The zero-step iterator
+probe is used only to expose the iterator acquisition required by this empty
+pattern; it does not broaden iterator destructuring ownership.
+
+## Acceptance
+
+- Both named rows pass in host/GC and standalone through the exact
+  `runTest262File` seam.
+- `array-empty-val-array.js` and `array-empty-val-string.js` remain passing in
+  both lanes, and null/bool/symbol sibling controls pass by observing the
+  expected TypeError.
+- No unrelated source files are changed; compiler source growth is at most
+  180 lines.
+- Focused tests, typecheck/format checks, and the final upstream-main merge
+  validation pass.
+
+## Test Results
+
+Baseline recorded above before source edits. After the fix, all eight focused
+rows passed in both lanes through `runTest262File` (16/16): the two named
+regressions, array/string iterable controls, null/bool/Symbol non-iterable
+controls, and `array-empty-iter-get-err.js`. The focused Vitest file
+`tests/issue-4714.test.ts` reproduced the same 16/16 result.
+
+Additional checks:
+
+- TypeScript 7: `node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json` — pass.
+- TypeScript 5: `node node_modules/typescript/lib/tsc.js --noEmit` — pass.
+- Prettier check on the changed source/test files — pass.
+- `git diff --check` — pass.
+- Fetched and merged `upstream/main` at `598cb2f226dc1c60376a5d19f858b2db99f91b06`
+  (`git merge upstream/main --no-edit` reported already up to date), then
+  reran the focused Vitest pins — pass.
+
+The compiler change is confined to `src/codegen/statements/for-of-destructuring.ts`
+and is 19 net source LOC (26 additions, 7 deletions), below the 180-line
+budget.

--- a/src/codegen/statements/for-of-destructuring.ts
+++ b/src/codegen/statements/for-of-destructuring.ts
@@ -114,6 +114,26 @@ function emitGlobalSyncWritebackByName(
   emitGlobalSyncWriteback(ctx, fctx, targetLocal, ctx.moduleGlobals.get(targetName));
 }
 
+/** Enforce GetIterator for an empty ArrayAssignmentPattern (#4714). */
+function emitEmptyForOfArrayPatternRequirement(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  elemLocal: number,
+  elemType: ValType,
+): void {
+  if (elemType.kind !== "externref") {
+    emitThrowTypeError(ctx, fctx, "value is not iterable");
+    return;
+  }
+  const iteratorIdx = ensureLateImport(ctx, "__iterator", [{ kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (iteratorIdx !== undefined) {
+    fctx.body.push({ op: "local.get", index: elemLocal });
+    fctx.body.push({ op: "call", funcIdx: iteratorIdx });
+    fctx.body.push({ op: "drop" });
+  }
+}
+
 export function compileForOfDestructuring(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1100,14 +1120,13 @@ export function compileForOfAssignDestructuring(
   } else if (ts.isArrayLiteralExpression(expr)) {
     // for ([x, y] of arr) — elem is a vec struct or tuple struct, extract by index
     if (elemType.kind !== "ref" && elemType.kind !== "ref_null") {
-      // Externref elements: use __extern_get to extract indexed properties
+      if (expr.elements.length === 0) {
+        emitEmptyForOfArrayPatternRequirement(ctx, fctx, elemLocal, elemType);
+        return;
+      }
       if (elemType.kind === "externref") {
-        // Per ECMA-262 §13.15.5.2 / §8.4.2 GetIterator(null/undefined) throws
-        // TypeError. Required for nested patterns like `for ([[x]] of [[null]])`
-        // (#1225). Skip for empty `[] of …` patterns to match existing behavior.
-        if (expr.elements.length > 0) {
-          emitExternrefDestructureGuard(ctx, fctx, elemLocal);
-        }
+        // Guard null/undefined before the nested externref readers (#1225).
+        emitExternrefDestructureGuard(ctx, fctx, elemLocal);
         compileForOfAssignDestructuringExternref(ctx, fctx, expr, elemLocal, stmt);
       }
       return;

--- a/tests/issue-4714.test.ts
+++ b/tests/issue-4714.test.ts
@@ -1,0 +1,37 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+// #4714 — an empty ArrayAssignmentPattern in a for-of head still performs
+// GetIterator(value), even though it does not consume an element. Keep the
+// two exact regressions beside all value-shape controls, plus the direct
+// custom-iterator GetIterator abrupt-completion control. IteratorClose rows
+// remain outside this issue's scope.
+const TEST262 = join(process.cwd(), "test262");
+const maybe = existsSync(TEST262) ? describe : describe.skip;
+
+const rows = [
+  "language/statements/for-of/dstr/array-empty-val-num.js",
+  "language/statements/for-of/dstr/array-empty-val-undef.js",
+  "language/statements/for-of/dstr/array-empty-val-array.js",
+  "language/statements/for-of/dstr/array-empty-val-string.js",
+  "language/statements/for-of/dstr/array-empty-val-null.js",
+  "language/statements/for-of/dstr/array-empty-val-bool.js",
+  "language/statements/for-of/dstr/array-empty-val-symbol.js",
+  "language/statements/for-of/dstr/array-empty-iter-get-err.js",
+] as const;
+
+maybe("#4714 for-of empty array assignment pattern", () => {
+  for (const lane of [
+    { name: "host/GC", target: undefined },
+    { name: "standalone", target: "standalone" as const },
+  ]) {
+    for (const rel of rows) {
+      it(`${rel} passes in ${lane.name}`, async () => {
+        const result = await runTest262File(join(TEST262, "test", rel), "issue-4714", 120_000, lane.target);
+        expect(result.status, result.error ?? result.reason ?? "").toBe("pass");
+      }, 180_000);
+    }
+  }
+});


### PR DESCRIPTION
Empty ArrayAssignmentPatterns still perform GetIterator before the loop body. Emit the existing iterator probe for externref values and a catchable TypeError for statically primitive values, covering host and standalone lowering without changing non-empty destructuring paths.

Add exact Test262 host/standalone pins and record the live baseline and validation results for issue #4714.

Co-authored-by: Codex <codex@openai.com>
