### PR TITLE
fix(reflect): validate setPrototypeOf Symbol and undefined arguments (#4722)

### DIFF
--- a/plan/issues/4722-es2015-reflect-setprototypeof-validation.md
+++ b/plan/issues/4722-es2015-reflect-setprototypeof-validation.md
@@ -1,0 +1,109 @@
+---
+id: 4722
+title: "ES2015 standalone Reflect.setPrototypeOf validates Symbol targets and non-nullish primitive prototypes"
+status: done
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: codegen
+es_edition: 2015
+language_feature: reflect-setprototypeof-validation
+goal: standalone-mode
+assignee: codex/4722-es2015-reflect-setprototypeof-validation
+related: [2046, 2175]
+loc-budget-allow:
+  - src/codegen/object-ops.ts
+  - src/codegen/expressions/call-namespace-static.ts
+---
+
+# #4722 — Reflect.setPrototypeOf validation
+
+## Scope
+
+Own the one standalone validation cluster represented by:
+
+- `test/built-ins/Reflect/setPrototypeOf/target-is-symbol-throws.js`
+- `test/built-ins/Reflect/setPrototypeOf/proto-is-not-object-and-not-null-throws.js`
+- `test/built-ins/Reflect/setPrototypeOf/proto-is-symbol-throws.js`
+
+The successful primitive-target row and the successful object/null row are
+controls. The standalone failures in `return-true-if-new-prototype-is-set.js`,
+`return-false-if-target-and-proto-are-the-same.js`, and
+`return-false-if-target-is-not-extensible.js` are excluded: they exercise the
+native boolean/failure-channel semantics, not argument validation.
+
+## Live baseline (upstream/main `778e4ae0f`, 2026-08-25)
+
+Measured with the repository's assembled-harness probe, including structural
+must-pass and must-fail controls. The host lane is the default `runTest262File`
+target; standalone uses `--target standalone`.
+
+| Test262 row | Host | Standalone |
+|---|---:|---:|
+| `target-is-symbol-throws.js` | pass | **fail** — expected TypeError, none thrown |
+| `proto-is-not-object-and-not-null-throws.js` | pass | **fail** — expected TypeError, none thrown |
+| `proto-is-symbol-throws.js` | pass | **fail** — expected TypeError, none thrown |
+| `target-is-not-object-throws.js` (primitive target control) | pass | pass |
+| `return-true-if-proto-is-current.js` (object/null control) | pass | pass |
+
+The broader eight-row probe was host `7 pass / 1 fail` and standalone
+`2 pass / 6 fail`; the four excluded failures all reported the existing
+`Reflect.setPrototypeOf` native result/failure-channel gap. Both lanes' probes
+observed the required positive and negative harness controls before reporting
+rows.
+
+## Root cause
+
+The shared `emitNonObjectArgGuard` in `src/codegen/object-ops.ts` recognizes
+undefined/null/boolean/number/string/bigint flags but omits TypeScript's
+`ESSymbolLike` flag. A statically typed `Symbol(1)` target or prototype is
+therefore lowered through the standalone native helper, which silently declines
+non-`$Object` values instead of throwing. Separately, the
+`Reflect.setPrototypeOf` call-site treats `undefined` as a legal nullish
+prototype; §28.1.14 permits only `null`, so the first assertion in
+`proto-is-not-object-and-not-null-throws.js` also falls through without a throw.
+
+## Implementation plan
+
+1. Extend the shared non-object guard with `ESSymbolLike`, preserving the
+   existing side-effect evaluation and TypeError path for Object/Reflect users.
+2. Make the Reflect.setPrototypeOf prototype exception explicit for `null`
+   only; let the shared guard reject undefined, void, and all other primitive
+   types. Do not change `__object_setPrototypeOf` or its separate boolean
+   failure-channel residual.
+3. Add focused host and standalone regression tests for Symbol target,
+   Symbol prototype, undefined/number prototypes, plus object/null and ordinary
+   primitive-target controls. Re-run the exact assembled-harness cohort and
+   verify no excluded native-semantics row changes.
+
+## Test Results
+
+All commands used the pinned `pnpm 10.30.2` binary and the isolated worktree.
+
+- Focused regressions: `pnpm exec vitest run tests/issue-4722.test.ts
+  --reporter verbose` → **6/6 passed** (three host and three standalone cases).
+- Exact assembled-harness validation cohort plus controls, using
+  `scripts/harness-flip-probe.ts` with structural must-pass/must-fail controls:
+  **host 5/5 pass**, **standalone 5/5 pass** for the three validation rows and
+  two controls.
+- Full eight-row guard: host remained **7 pass / 1 fail**; standalone moved
+  from **2 pass / 6 fail** to **5 pass / 3 fail**. Exactly the three selected
+  validation rows flipped `fail → pass`; the four excluded native
+  boolean/failure-channel rows were unchanged.
+- TypeScript 5: `pnpm run typecheck:ts5` → exit 0.
+- TypeScript 7: `pnpm run typecheck` → exit 0.
+- Lint: `pnpm run lint` → exit 0 (Biome reports the repository's existing
+  diagnostic-summary warning, with no command failure).
+- Format: `pnpm run format:check` → exit 0.
+- Pre-push hook with the pinned PATH → typecheck/lint, format, oracle ratchet,
+  coercion-site ratchet, numeric-local parity (18/18), conformance sync, and
+  issue-integrity checks passed.
+
+Baseline artifacts remain under `.tmp/` and are untracked by design:
+`.tmp/4722-host-baseline.jsonl` and `.tmp/4722-standalone-baseline.jsonl`.

--- a/src/codegen/expressions/call-namespace-static.ts
+++ b/src/codegen/expressions/call-namespace-static.ts
@@ -1111,8 +1111,8 @@ export function compileNamespaceStaticCall(
         //   step 2: proto not Object and not null → throw a TypeError. Reuse
         //     the same static guard on the proto arg, but `null` is a LEGAL
         //     proto here (unlike target), so only reject a statically-
-        //     primitive NON-null proto. A `null`/`undefined`/object proto
-        //     passes; a number/string/boolean proto literal throws.
+        //     primitive NON-null proto. A `null`/object proto passes;
+        //     undefined, number/string/boolean, and Symbol proto literals throw.
         //   step 4: return the boolean [[SetPrototypeOf]] result. The native
         //     has no failure channel (a refused set — non-extensible target or
         //     a cycle — silently no-ops and still returns obj), so we drop obj
@@ -1129,14 +1129,10 @@ export function compileNamespaceStaticCall(
           fctx.body.push({ op: "i32.const", value: 0 }); // unreachable after throw
           return { kind: "i32" };
         }
-        // §28.1.14 step 2: a statically-primitive proto that is NOT null/
-        // undefined is illegal. `null`/`undefined` set the prototype to null
-        // (legal), so let them through to the native (which maps a non-$Object
-        // proto to a null $proto).
-        const protoIsNullish =
-          protoArg.kind === ts.SyntaxKind.NullKeyword ||
-          (ts.isIdentifier(protoArg) && protoArg.text === "undefined") ||
-          protoArg.kind === ts.SyntaxKind.UndefinedKeyword;
+        // §28.1.14 step 2: a statically-primitive proto that is not null is
+        // illegal. Only `null` is a legal primitive prototype; undefined and
+        // void expressions must take the shared TypeError guard below.
+        const protoIsNullish = protoArg.kind === ts.SyntaxKind.NullKeyword;
         if (!protoIsNullish && emitNonObjectArgGuard(ctx, fctx, protoArg, "Reflect.setPrototypeOf")) {
           fctx.body.push({ op: "i32.const", value: 0 }); // unreachable after throw
           return { kind: "i32" };

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -536,7 +536,8 @@ function maybeEmitVecLengthGrowth(
 /**
  * Check if the first argument to Object.defineProperty / defineProperties
  * is statically known to be a non-object type (undefined, null, boolean,
- * number, string).  If so, emit `throw TypeError` and return true.
+ * number, string, bigint, or Symbol).  If so, emit `throw TypeError` and
+ * return true.
  *
  * Per ES spec (19.1.2.4 step 1): "If Type(O) is not Object, throw a TypeError."
  */
@@ -557,7 +558,8 @@ export function emitNonObjectArgGuard(
     ts.TypeFlags.BooleanLike |
     ts.TypeFlags.NumberLike |
     ts.TypeFlags.StringLike |
-    ts.TypeFlags.BigIntLike;
+    ts.TypeFlags.BigIntLike |
+    ts.TypeFlags.ESSymbolLike;
 
   if (flags & NON_OBJECT_FLAGS) {
     // Compile the argument for side effects (it might have side effects)

--- a/tests/issue-4722.test.ts
+++ b/tests/issue-4722.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4722 — Reflect.setPrototypeOf must reject every non-object, non-null
+// prototype and every non-object target in both the host and standalone lanes.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+type Lane = "host" | "standalone";
+
+async function run(source: string, lane: Lane): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-4722.ts",
+    skipSemanticDiagnostics: true,
+    ...(lane === "standalone" ? { target: "standalone" as const } : {}),
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), `${lane} module failed validation`).toBe(true);
+
+  if (lane === "standalone") {
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    return (instance.exports as { test: () => number }).test();
+  }
+
+  const imports = result.importObject!;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { __setInstance?: (value: WebAssembly.Instance) => void }).__setInstance?.(instance);
+  return (instance.exports as { test: () => number }).test();
+}
+
+const SYMBOL_VALIDATION = `
+  export function test(): number {
+    let caught = 0;
+    try { Reflect.setPrototypeOf(Symbol(1), {}); } catch (error) { caught++; }
+    const symbolProto = Symbol("proto");
+    try { Reflect.setPrototypeOf({}, symbolProto); } catch (error) { caught++; }
+    return caught === 2 ? 1 : 0;
+  }
+`;
+
+const PRIMITIVE_PROTO_VALIDATION = `
+  export function test(): number {
+    const target: any = {};
+    let caught = 0;
+    try { Reflect.setPrototypeOf(target, undefined); } catch (error) { caught++; }
+    try { Reflect.setPrototypeOf(target, 42); } catch (error) { caught++; }
+    const nullResult = Reflect.setPrototypeOf(target, null);
+    return caught === 2 && nullResult === true ? 1 : 0;
+  }
+`;
+
+const PRIMITIVE_TARGET_CONTROL = `
+  export function test(): number {
+    try { Reflect.setPrototypeOf(1, {}); return 0; }
+    catch (error) { return 1; }
+  }
+`;
+
+describe("#4722 — Reflect.setPrototypeOf validation", () => {
+  for (const lane of ["host", "standalone"] as const) {
+    it(`${lane}: Symbol target and prototype throw TypeError`, async () => {
+      await expect(run(SYMBOL_VALIDATION, lane)).resolves.toBe(1);
+    });
+
+    it(`${lane}: undefined and primitive prototypes throw, null remains legal`, async () => {
+      await expect(run(PRIMITIVE_PROTO_VALIDATION, lane)).resolves.toBe(1);
+    });
+
+    it(`${lane}: ordinary primitive target remains a TypeError`, async () => {
+      await expect(run(PRIMITIVE_TARGET_CONTROL, lane)).resolves.toBe(1);
+    });
+  }
+});


### PR DESCRIPTION
Route statically typed Symbol values through the shared non-object TypeError guard and allow only null as a primitive Reflect.setPrototypeOf prototype. Add host and standalone regressions plus live baseline and validation evidence.

Co-authored-by: Codex <codex@openai.com>
