### PR TITLE
fix(#4731): preserve Set iterator method semantics

### DIFF
--- a/plan/issues/4731-es2015-set-iterator-not-constructor.md
+++ b/plan/issues/4731-es2015-set-iterator-not-constructor.md
@@ -1,0 +1,113 @@
+---
+id: 4731
+title: "ES2015 standalone Set iterator methods and non-constructor semantics"
+status: in-progress
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+assignee: codex/4731-es2015-set-iterator-not-constructor
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: es2015
+language_feature: set-iterators
+goal: standalone-mode
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/builtin-value-read.ts
+  - src/codegen/property-access.ts
+func-budget-allow:
+  - src/codegen/property-access.ts::compileElementAccess
+files:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/builtin-value-read.ts
+  - src/codegen/property-access.ts
+  - tests/issue-4731.test.ts
+---
+
+# #4731 — ES2015 standalone Set iterator methods and non-constructor semantics
+
+## Scope and baseline
+
+The authoritative source baseline is `upstream/main` at
+`21d7d893dfd316caa8349c6e2b23bcf61cc6e6b5` (2026-08-25). The repository's
+host artifact records the three Set iterator non-constructor rows as passing:
+
+- `test/built-ins/Set/prototype/Symbol.iterator/not-a-constructor.js`
+- `test/built-ins/Set/prototype/entries/not-a-constructor.js`
+- `test/built-ins/Set/prototype/values/not-a-constructor.js`
+
+That aggregate is insufficient for this standalone-only residual, so the exact
+rows and nearby controls were rerun with `runTest262File` from this commit.
+The measured matrix is:
+
+| lane | Set Symbol.iterator | Set entries | Set values | Set keys identity | Map Symbol.iterator control | Map keys/values/entries controls |
+| --- | --- | --- | --- | --- | --- | --- |
+| host | pass | pass | pass | pass | pass | 3/3 pass |
+| standalone | fail: `isConstructor invoked with a non-function value` | pass | pass | fail: `Set.prototype.keys` is not `Set.prototype.values` | fail: same non-function control | 3/3 pass |
+
+The Set non-constructor cohort is therefore **2/3 standalone rows passing,
+with only `Symbol.iterator` failing**. The adjacent `entries`/`values` rows
+are must-pass controls, as are the Map method controls. `Set/prototype/keys/keys.js`
+is the minimal identity control: the standalone Set `keys` property is not
+aliased to the `values` function even though both methods produce Set values.
+The Map `Symbol.iterator` failure is deliberately retained as a shared-path
+control and is not silently counted as a Set-only fix.
+
+## Implementation plan
+
+1. Confirmed the standalone failure is a computed native-prototype value read:
+   `Set.prototype[Symbol.iterator]` (and the matching Map control) fell through
+   to `__extern_get` with a symbol key, which has no standalone `$NativeProto`
+   symbol-key arm. The `isConstructor` assertion consequently received null,
+   rather than a callable native-method closure.
+2. Added one exact static-shape lowering in the built-in value-read subsystem:
+   Set resolves the computed iterator to the identity-stable `values` closure;
+   Map resolves it to `entries`. The existing Set `entries`/`values` and Map
+   method paths remain untouched.
+3. Confirmed the Set identity control was an independent registration seam and
+   fixed it narrowly with the collection glue alias `keys` → `values`; both
+   spellings remain in the own-member CSV for reflection.
+4. Added focused tests that run all eight exact Test262 rows in both host and
+   standalone lanes (16 assertions total), retaining the Set non-constructor,
+   Set identity, and nearby Map controls.
+
+## Risks and non-goals
+
+- Do not change the generic `isConstructor` contract or unrelated Map
+  iterator methods without a demonstrated regression.
+- Do not treat a host pass as evidence that the standalone native collection
+  path is correct; the two lanes exercise different built-in carriers.
+- Keep production source changes at or below 180 lines.
+
+## Acceptance criteria
+
+- The exact Set `Symbol.iterator/not-a-constructor.js` row passes in
+  standalone, while the Set `entries` and `values` controls remain passing.
+- `Set/prototype/keys/keys.js` passes if and only if the confirmed shared
+  method-registration seam is part of this fix; otherwise the issue records
+  the independent residual explicitly.
+- Host and Map controls remain passing, with no silent harness/provider error.
+- Focused tests, TypeScript 5/7 checks, lint, format, and repository hooks pass.
+
+## Test Results
+
+- Baseline exact run on upstream `21d7d893d`: host **8/8 pass**; standalone
+  **5/8 pass, 3 fail**. The three standalone failures were Set
+  `Symbol.iterator/not-a-constructor.js`, Map
+  `Symbol.iterator/not-a-constructor.js` (shared control), and Set
+  `keys/keys.js` (identity control). Set `entries` and `values` exact rows
+  passed in both lanes.
+- Post-fix exact run on the same baseline plus this change: host **8/8 pass**;
+  standalone **8/8 pass**. Focused Vitest lane test
+  `tests/issue-4731.test.ts`: **16/16 pass** (8 host + 8 standalone).
+- TypeScript 5 (`typescript/lib/tsc.js --noEmit`) and TypeScript 7
+  (`typescript@7.0.2/lib/tsc.js --noEmit -p tsconfig.ts7.json`) both pass.
+  Scoped Biome lint, Prettier format check, `git diff --check`, and the
+  direct lint-staged hook pass. The wrapper's first attempt lacked `npx` in
+  the runtime image; invoking the checked-in lint-staged binary produced the
+  same staged-file checks. LOC/function budget hooks pass with the measured
+  allowances above.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -1730,6 +1730,9 @@ function makeCollectionGlue(brand: number, name: "Map" | "Set", members: readonl
     memberCsv: [...members, "size"].join(","),
     memberKind: (member) => (member === "size" ? "getter" : "method"),
     memberLength: (member) => (member === "size" ? 0 : (PROTO_METHOD_LENGTH[member] ?? 1)),
+    // ES2015 §23.2.3: Set.prototype.keys and .values are the same function
+    // object (and Set.prototype[@@iterator] aliases that object as well).
+    memberAliasOf: (member) => (name === "Set" && member === "keys" ? "values" : undefined),
     emitMemberBody: (c, fctx, member) =>
       member === "size"
         ? emitCollectionSizeGetterBody(c, fctx, name)

--- a/src/codegen/builtin-value-read.ts
+++ b/src/codegen/builtin-value-read.ts
@@ -849,6 +849,59 @@ function tryCompileStandaloneBuiltinProtoMemberRead(
 }
 
 /**
+ * (#4731) `<Map|Set>.prototype[Symbol.iterator]` is an alias for the
+ * prototype's `entries`/`values` method.  The ordinary computed-property path
+ * materializes the `$NativeProto` object and asks `__extern_get` for a dynamic
+ * symbol key; standalone has no symbol-key arm there, so it returned null.
+ * Resolve this exact static shape through the same identity-stable method
+ * closure used by the dot form.  Keeping this in the value-read subsystem also
+ * makes the Set and nearby Map controls share one spec-derived path.
+ */
+function tryCompileStandaloneBuiltinProtoIteratorRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.ElementAccessExpression,
+): ValType | undefined {
+  if (!ctx.standalone) return undefined;
+
+  const key = skipTransparentExpressions(expr.argumentExpression);
+  if (
+    !ts.isPropertyAccessExpression(key) ||
+    !ts.isIdentifier(key.expression) ||
+    key.expression.text !== "Symbol" ||
+    key.name.text !== "iterator" ||
+    getWellKnownSymbolId(key.name.text) === undefined
+  ) {
+    return undefined;
+  }
+
+  const receiver = skipTransparentExpressions(expr.expression);
+  if (!ts.isPropertyAccessExpression(receiver) || receiver.name.text !== "prototype") return undefined;
+  if (!ts.isIdentifier(receiver.expression)) return undefined;
+
+  const builtinName = receiver.expression.text;
+  if (builtinName !== "Map" && builtinName !== "Set") return undefined;
+  if (
+    fctx.localMap.has(builtinName) ||
+    (fctx.boxedCaptures?.has(builtinName) ?? false) ||
+    fctx.localMap.has("Symbol") ||
+    (fctx.boxedCaptures?.has("Symbol") ?? false)
+  ) {
+    return undefined;
+  }
+
+  const brand = tryEnsureNativeProtoBrand(ctx, builtinName);
+  if (brand === undefined) return undefined;
+  const member = builtinName === "Set" ? "values" : "entries";
+  const resolved = resolveStandaloneProtoMemberValueClosure(ctx, brand, builtinName, member);
+  if (!resolved || resolved.kind !== "method") return undefined;
+
+  fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, resolved.closure));
+  fctx.body.push({ op: "extern.convert_any" });
+  return { kind: "externref" };
+}
+
+/**
  * The result ValType of a builtin static that returns a JS **boolean**
  * (`Array.isArray`, `Object.is`, `Object.hasOwn`, `Reflect.has`, `Reflect.set`,
  * `Number.isNaN` & friends).
@@ -1580,4 +1633,5 @@ export {
   reportUnsupportedStandaloneBuiltinValueRead,
   tryCompileStandaloneBuiltinProtoMemberMeta,
   tryCompileStandaloneBuiltinProtoMemberRead,
+  tryCompileStandaloneBuiltinProtoIteratorRead,
 };

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -208,6 +208,7 @@ import {
   TYPED_ARRAY_BYTES_PER_ELEMENT,
   tryCompileStandaloneBuiltinProtoMemberMeta,
   tryCompileStandaloneBuiltinProtoMemberRead,
+  tryCompileStandaloneBuiltinProtoIteratorRead,
   tryEmitBuiltinNamespaceConstantValue,
   tryEnsureNativeProtoBrand,
   typedArrayViewSignedness,
@@ -4531,6 +4532,12 @@ export function compileElementAccess(
 
   const functionHasInstanceRead = tryCompileStandaloneFunctionHasInstanceRead(ctx, fctx, expr);
   if (functionHasInstanceRead !== undefined) return functionHasInstanceRead;
+
+  // (#4731) Resolve the static Set/Map prototype iterator alias before the
+  // generic computed read materializes a `$NativeProto` and asks `__extern_get`
+  // for a symbol key (which has no standalone symbol-key arm).
+  const builtinProtoIteratorRead = tryCompileStandaloneBuiltinProtoIteratorRead(ctx, fctx, expr);
+  if (builtinProtoIteratorRead !== undefined) return builtinProtoIteratorRead;
 
   // #1886 Slice B: linear-backed Uint8Array read `buf[i]` → i32.load8_u(ptr+i).
   // Only fires when `buf` is a registered linear-safe buffer in this function;

--- a/tests/issue-4731.test.ts
+++ b/tests/issue-4731.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolve } from "node:path";
+import { runTest262File } from "./test262-runner.js";
+
+const CASES = [
+  // Exact Set iterator-method/non-constructor targets.
+  ["Set", "prototype/Symbol.iterator/not-a-constructor.js"],
+  ["Set", "prototype/entries/not-a-constructor.js"],
+  ["Set", "prototype/values/not-a-constructor.js"],
+  // Nearby Map iterator controls exercise the shared prototype-symbol path.
+  ["Map", "prototype/Symbol.iterator/not-a-constructor.js"],
+  ["Map", "prototype/keys/not-a-constructor.js"],
+  ["Map", "prototype/values/not-a-constructor.js"],
+  ["Map", "prototype/entries/not-a-constructor.js"],
+  // Set's separate ES2015 identity control (`keys === values`).
+  ["Set", "prototype/keys/keys.js"],
+] as const;
+
+const TEST262_ROOT = resolve(import.meta.dirname ?? ".", "..", "test262", "test");
+
+describe("#4731 Set/Map iterator prototype value reads", () => {
+  for (const lane of ["host", "standalone"] as const) {
+    describe(lane, () => {
+      for (const [builtin, relativePath] of CASES) {
+        it(`${builtin}/${relativePath}`, async () => {
+          const testPath = `built-ins/${builtin}/${relativePath}`;
+          const result = await runTest262File(
+            resolve(TEST262_ROOT, testPath),
+            `${builtin}/${relativePath.split("/")[0]}`,
+            120000,
+            lane === "standalone" ? "standalone" : undefined,
+          );
+          expect(result.status, result.error ?? testPath).toBe("pass");
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- lower standalone `Set.prototype[Symbol.iterator]` to the identity-stable `values` closure
- preserve the `Set.prototype.keys === Set.prototype.values` alias while retaining reflective member names
- cover the shared computed native-prototype read with adjacent Map controls

## Validation
- exact Test262 matrix: host 8/8, standalone 8/8 (baseline standalone 5/8)
- focused `tests/issue-4731.test.ts`: 16/16
- TypeScript 5 and 7, lint, format, LOC/function/oracle/coercion gates, and pre-push hook: pass
- production source delta: +64 lines

Tracked by `plan/issues/4731-es2015-set-iterator-not-constructor.md`.

No PR merge is performed by this task.