### PR TITLE
fix(#4727): reject standalone Promise self-resolution

### DIFF
--- a/plan/issues/4727-es2015-promise-resolve-self.md
+++ b/plan/issues/4727-es2015-promise-resolve-self.md
@@ -1,0 +1,130 @@
+---
+id: 4727
+title: "ES2015 standalone Promise.resolve custom-constructor self-resolution"
+status: done
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen, promises
+es_edition: es2015
+language_feature: promise-resolve
+goal: spec-completeness
+related: [4682]
+source_cap: 180
+loc-budget-allow:
+  - src/codegen/expressions/call-namespace-static.ts
+  - src/codegen/promise-combinators.ts
+  - tests/issue-4727.test.ts
+func-budget-allow:
+  - src/codegen/expressions/call-namespace-static.ts::compileNamespaceStaticCall
+---
+
+# #4727 — Promise.resolve custom-constructor self-resolution
+
+## Scope
+
+This issue owns the bounded standalone `Promise.resolve.call(C, value)` path
+when `C` is an ordinary compiled constructor and its capability resolver is
+used to resolve the constructed promise.  The exact residual is
+`built-ins/Promise/resolve/resolve-self.js`; focused identity, non-thenable,
+thenable, and native self-resolution controls cover the same Promise.resolve
+admission and resolver protocol.  It does not widen into the general custom
+constructor/subclass Promise capability family, poisoned constructors, or the
+separate direct `Promise.resolve(promiseWithCustomThen)` value path.
+
+## Live baseline
+
+The authoritative JSONL snapshots were refreshed with `--force` on 2026-08-25
+from `upstream/main` `21d7d893d` (oracle version 13):
+
+| Test262 row | Host baseline | Standalone baseline |
+| --- | --- | --- |
+| `built-ins/Promise/resolve/resolve-self.js` | pass | fail — `TypeError: Promise.resolve is not yet implemented in --target standalone` |
+| `built-ins/Promise/resolve/ctx-ctor.js` | pass | fail — same not-implemented error |
+| `built-ins/Promise/resolve/resolve-from-promise-capability.js` | pass | fail — same not-implemented error |
+| `built-ins/Promise/resolve/resolve-thenable.js` | fail — promise settles with the wrong value | pass |
+| `built-ins/Promise/resolve/resolve-prms-cstm-then.js` | pass | fail — expected the provided promise/value identity |
+| `built-ins/Promise/resolve/capability-executor-called-twice.js` | pass | fail — same not-implemented error |
+
+Fresh `runTest262File` probes in this worktree reproduce the table in the
+normal assembled host and standalone harnesses.  The positive standalone
+`resolve-thenable.js` control demonstrates that the native direct resolve
+lowering already assimilates an ordinary thenable; the host thenable failure
+and the standalone custom-`then` failure are separate pre-existing defects.
+
+## Root cause
+
+Direct standalone `Promise.resolve(value)` is lowered in
+`src/codegen/expressions/call-namespace-static.ts` through
+`emitStandalonePromiseResolve`.  A first-class read of `Promise.resolve`,
+however, is created by `ensureStandaloneBuiltinStaticMethodClosure` in
+`src/codegen/builtin-value-read.ts`, whose static-method metadata has no
+Promise.resolve entry and therefore emits the generic “not yet implemented”
+closure.  Reflective `Promise.resolve.call(C, value)` consequently never
+enters the native PromiseResolve/`NewPromiseCapability(C)` protocol.  The
+existing standalone custom-capability runtime in `promise-combinators.ts`
+already validates the resolve/reject functions for empty combinators, but it
+does not retain the constructed promise or invoke the captured resolver with
+the requested value.  That missing admission and resolver hand-off is the
+shared root cause of the bounded custom-constructor rows.
+
+## Implementation plan
+
+1. Add a narrow standalone `Promise.resolve.call(C, value)` admission before
+   the generic reflective call path.  Preserve left-to-right evaluation and
+   the ordinary intrinsic `Promise.resolve` direct path.
+2. Reuse the existing custom-capability executor machinery to construct `C`,
+   retain its returned promise, validate callable resolve/reject captures, and
+   invoke the captured resolve through the native standalone promise-resolve
+   routine.  Self-resolution must therefore reject with `TypeError`, while
+   identity and thenable controls retain their specified behavior.
+3. Add focused regression coverage and rerun the exact official rows and
+   controls in both host and standalone modes.  Keep compiler source changes
+   within the 180-line cap and leave unrelated Promise capability/subclass
+   residuals unchanged.
+4. Run the required TS5/TS7, typecheck, lint, format, focused test, and
+   prepush checks before merging the latest `upstream/main` into the branch.
+
+## Test Results
+
+Focused regression (`tests/issue-4727.test.ts`): 2/2 passed.  The standalone
+self-resolution case preserves constructor-result identity and observes the
+required asynchronous TypeError rejection; the ordinary-value and thenable
+case checks both resolver inputs.
+
+Exact `runTest262File` probes after the fix, with the host lane and standalone
+lane run separately, report:
+
+| Test262 row | Host | Standalone |
+| --- | --- | --- |
+| `resolve-self.js` | pass | pass |
+| `resolve-non-thenable.js` | pass | pass |
+| `resolve-thenable.js` | fail — existing wrong fulfillment value | pass |
+| `S25.4.4.5_A2.1_T1.js` | pass | pass |
+| `S25.4.4.5_A2.3_T1.js` | pass | pass |
+
+The pre-existing `resolve-from-promise-capability.js` residual remains host
+pass / standalone fail (`callCount` is observed as `1` before the custom
+constructor returns).  It exercises the broader direct promise-capability
+constructor path and is recorded as evidence, not expanded into this bounded
+change.
+
+Quality gates: TS5 typecheck pass; TS7/typecheck pass; Biome lint pass;
+Prettier format check pass; LOC/function budgets, oracle ratchet, and
+coercion-site ratchet pass. Production source growth is +174 net lines, below
+the 180-line cap. The publication push runs the repository pre-push hook.
+
+## Acceptance / non-goals
+
+- `resolve-self.js` passes in standalone and remains passing in host mode.
+- The selected identity/non-thenable/thenable controls pass in standalone;
+  existing host/direct controls do not regress.
+- No broad Promise combinator, subclass, or resolver-element-function rewrite.
+- Source delta remains ≤180 lines, with issue evidence and test results kept in
+  this file.

--- a/src/codegen/expressions/call-namespace-static.ts
+++ b/src/codegen/expressions/call-namespace-static.ts
@@ -67,6 +67,7 @@ import { ensureObjectRuntime, ensureObjVecBuilders } from "../object-runtime.js"
 import {
   emitStandalonePromiseCombinator,
   emitStandalonePromiseCustomCapabilityCheck,
+  emitStandalonePromiseCustomResolve,
   emitStandalonePromiseCombinatorRuntime,
   isNativeCombinatorMethod,
   resolveExternrefVecArg,
@@ -1964,6 +1965,81 @@ export function compileNamespaceStaticCall(
   // The current call expression looks like `(Promise.METHOD).call(thisArg, iter)`,
   // i.e. propAccess.name.text === "call" and propAccess.expression is a
   // PropertyAccess `Promise.METHOD`.
+  if (
+    propAccess.name.text === "call" &&
+    ts.isPropertyAccessExpression(propAccess.expression) &&
+    ts.isIdentifier(propAccess.expression.expression) &&
+    propAccess.expression.expression.text === "Promise" &&
+    propAccess.expression.name.text === "resolve" &&
+    isStandalonePromiseActive(ctx) &&
+    expr.arguments.length === 2
+  ) {
+    const ctorArg = unwrapReflectConstructExpr(expr.arguments[0]!);
+    const ctorDecl = ts.isIdentifier(ctorArg) ? ctx.oracle.valueDeclarationOf(ctorArg) : ctorArg;
+    const ctorInit = ctorDecl && ts.isVariableDeclaration(ctorDecl) ? ctorDecl.initializer : undefined;
+    const ctorExpr = ctorInit ? unwrapReflectConstructExpr(ctorInit) : ctorDecl;
+    const isOrdinaryCtorDecl =
+      (ctorExpr !== undefined && ts.isFunctionExpression(ctorExpr) && ctorExpr.asteriskToken === undefined) ||
+      (ctorDecl !== undefined &&
+        ts.isFunctionDeclaration(ctorDecl) &&
+        ctorDecl.asteriskToken === undefined &&
+        !(ctorDecl.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false));
+    if (isOrdinaryCtorDecl) {
+      const snap = snapshotSpeculative(ctx, fctx);
+      ensurePromiseSettleFunctions(ctx);
+      ensureObjectRuntime(ctx);
+      const ctorType = compileExpression(ctx, fctx, expr.arguments[0]!);
+      const ctorInfo =
+        ctorType && (ctorType.kind === "ref" || ctorType.kind === "ref_null")
+          ? ctx.closureInfoByTypeIdx.get(ctorType.typeIdx)
+          : ts.isIdentifier(ctorArg)
+            ? ctx.closureMap.get(ctorArg.text)
+            : undefined;
+      const supportsCapabilityCtor =
+        ctorInfo !== undefined &&
+        ctorInfo.paramTypes.length === 1 &&
+        ctorInfo.paramTypes[0]?.kind === "externref" &&
+        (ctorInfo.returnType === null ||
+          ctorInfo.returnType.kind === "externref" ||
+          ctorInfo.returnType.kind === "ref" ||
+          ctorInfo.returnType.kind === "ref_null");
+      const ctorSelfTypeIdx =
+        ctorInfo && (getClosureFuncSelfTypeIdx(ctx, ctorInfo.funcTypeIdx) ?? ctorInfo.structTypeIdx);
+      if (
+        ctorType &&
+        ctorInfo &&
+        supportsCapabilityCtor &&
+        ctorSelfTypeIdx !== undefined &&
+        (ctorType.kind === "ref" || ctorType.kind === "ref_null" || ctorType.kind === "externref")
+      ) {
+        const ctorLocal = allocLocal(fctx, `__promise_custom_ctor_${fctx.locals.length}`, {
+          kind: "ref_null",
+          typeIdx: ctorSelfTypeIdx,
+        });
+        coerceType(ctx, fctx, ctorType, { kind: "ref_null", typeIdx: ctorSelfTypeIdx });
+        fctx.body.push({ op: "local.set", index: ctorLocal });
+        const valueInstrs: Instr[] = [];
+        ctx.liveBodies.add(valueInstrs);
+        const savedBody = fctx.body;
+        fctx.body = valueInstrs;
+        try {
+          const valueType = compileExpression(ctx, fctx, expr.arguments[1]!, { kind: "externref" });
+          if (valueType === null) fctx.body.push({ op: "ref.null.extern" });
+          else if (valueType.kind !== "externref") coerceType(ctx, fctx, valueType, { kind: "externref" });
+        } finally {
+          fctx.body = savedBody;
+        }
+        try {
+          if (emitStandalonePromiseCustomResolve(ctx, fctx, ctorLocal, ctorInfo, ctorSelfTypeIdx, valueInstrs)) {
+            return { kind: "externref" };
+          }
+        } finally {
+          ctx.liveBodies.delete(valueInstrs);
+        }
+      }
+      rollbackSpeculative(ctx, fctx, snap);
+    }
+  }
   if (
     propAccess.name.text === "call" &&
     ts.isPropertyAccessExpression(propAccess.expression) &&

--- a/src/codegen/promise-combinators.ts
+++ b/src/codegen/promise-combinators.ts
@@ -79,7 +79,7 @@ import { emitNullCheckThrow } from "./property-access.js";
 // interned native-string constants. All lazily pulled ONLY when a module
 // actually compiles a native allSettled/any (see ensureSettledAnyCombinators) so
 // all/race-only modules stay byte-identical.
-import { ensureObjectRuntime } from "./object-runtime.js";
+import { ensureObjVecBuilders, ensureObjectRuntime, reserveApplyClosure } from "./object-runtime.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { ensureNativeStringHelpers, stringConstantExternrefInstrs } from "./native-strings.js";
 import { BUILTIN_TYPE_TAGS } from "./builtin-tags.js";
@@ -252,6 +252,14 @@ export function emitStandalonePromiseCustomCapabilityCheck(
   constructorSelfTypeIdx: number,
 ): boolean {
   if (!isStandalonePromiseActive(ctx)) return false;
+  if (
+    constructorInfo.returnType !== null &&
+    constructorInfo.returnType.kind !== "externref" &&
+    constructorInfo.returnType.kind !== "ref" &&
+    constructorInfo.returnType.kind !== "ref_null"
+  ) {
+    return false;
+  }
   const runtime = ensureCustomCapabilityRuntime(ctx);
   const wrapperRoot = getFuncRefWrapperRootTypeIdx(ctx);
   if (!runtime || wrapperRoot === undefined) return false;
@@ -321,12 +329,102 @@ export function emitStandalonePromiseCustomCapabilityCheck(
     { op: "ref.test", typeIdx: wrapperRoot } as Instr,
   ];
   fctx.body.push(...resolveCallable, ...rejectCallable, { op: "i32.and" });
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: [], else: customCapabilityTypeError(ctx) });
+  return true;
+}
+
+/** (#4727) Invoke C with a native capability, then call its resolve slot. */
+export function emitStandalonePromiseCustomResolve(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  constructorLocal: number,
+  constructorInfo: ClosureInfo,
+  constructorSelfTypeIdx: number,
+  valueInstrs: Instr[],
+): boolean {
+  if (!isStandalonePromiseActive(ctx)) return false;
+  const runtime = ensureCustomCapabilityRuntime(ctx);
+  const wrapperRoot = getFuncRefWrapperRootTypeIdx(ctx);
+  const vec = ensureObjVecBuilders(ctx);
+  const applyIdx = reserveApplyClosure(ctx);
+  if (!runtime || wrapperRoot === undefined || vec.newIdx === undefined || vec.pushIdx === undefined) return false;
+  const resultLocal = allocLocal(fctx, `__promise_resolve_result_${fctx.locals.length}`, { kind: "externref" });
+  const valueLocal = allocLocal(fctx, `__promise_resolve_value_${fctx.locals.length}`, { kind: "externref" });
+  const argsLocal = allocLocal(fctx, `__promise_resolve_args_${fctx.locals.length}`, { kind: "externref" });
+  const stateLocal = allocLocal(fctx, `__promise_capability_state_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: runtime.stateTypeIdx,
+  });
+  const executorLocal = allocLocal(fctx, `__promise_capability_executor_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: runtime.executorTypeIdx,
+  });
+  fctx.body.push(...valueInstrs, { op: "local.set", index: valueLocal });
+  fctx.body.push(
+    { op: "ref.null.extern" },
+    { op: "ref.null.extern" },
+    { op: "struct.new", typeIdx: runtime.stateTypeIdx },
+    { op: "local.set", index: stateLocal },
+    { op: "ref.func", funcIdx: runtime.executorFuncIdx },
+    { op: "i32.const", value: 2 },
+    closureBagInitInstr(),
+    { op: "local.get", index: stateLocal },
+    { op: "struct.new", typeIdx: runtime.executorTypeIdx },
+    { op: "local.set", index: executorLocal },
+  );
+  fctx.body.push({ op: "local.get", index: constructorLocal });
+  for (let i = 0; i < constructorInfo.paramTypes.length; i++) {
+    const p = constructorInfo.paramTypes[i]!;
+    if (i === 0) fctx.body.push({ op: "local.get", index: executorLocal }, { op: "extern.convert_any" });
+    else if (p.kind === "externref") fctx.body.push({ op: "ref.null.extern" });
+    else if (p.kind === "f64") fctx.body.push({ op: "f64.const", value: 0 });
+    else if (p.kind === "i32") fctx.body.push({ op: "i32.const", value: 0 });
+    else fctx.body.push({ op: "ref.null", typeIdx: (p as { typeIdx: number }).typeIdx });
+  }
+  const constructorSelf = getClosureFuncSelfTypeIdx(ctx, constructorInfo.funcTypeIdx) ?? constructorSelfTypeIdx;
+  fctx.body.push(
+    { op: "local.get", index: constructorLocal },
+    { op: "struct.get", typeIdx: constructorSelf, fieldIdx: 0 },
+  );
+  emitGuardedFuncRefCast(fctx, constructorInfo.funcTypeIdx);
+  emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: constructorInfo.funcTypeIdx });
+  fctx.body.push({ op: "call_ref", typeIdx: constructorInfo.funcTypeIdx });
+  if (constructorInfo.returnType === null) fctx.body.push({ op: "ref.null.extern" });
+  else if (constructorInfo.returnType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
+  fctx.body.push({ op: "local.set", index: resultLocal });
+  const resolveCallable = [
+    { op: "local.get", index: stateLocal } as Instr,
+    { op: "struct.get", typeIdx: runtime.stateTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.test", typeIdx: wrapperRoot } as Instr,
+  ];
+  const rejectCallable = [
+    { op: "local.get", index: stateLocal } as Instr,
+    { op: "struct.get", typeIdx: runtime.stateTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.test", typeIdx: wrapperRoot } as Instr,
+  ];
+  fctx.body.push(...resolveCallable, ...rejectCallable, { op: "i32.and" });
   fctx.body.push({
     op: "if",
     blockType: { kind: "empty" },
     then: [],
     else: customCapabilityTypeError(ctx),
   });
+  fctx.body.push(
+    { op: "call", funcIdx: vec.newIdx },
+    { op: "local.set", index: argsLocal },
+    { op: "local.get", index: argsLocal },
+    { op: "local.get", index: valueLocal },
+    { op: "call", funcIdx: vec.pushIdx },
+    { op: "local.get", index: stateLocal },
+    { op: "struct.get", typeIdx: runtime.stateTypeIdx, fieldIdx: 0 },
+    { op: "ref.null.extern" },
+    { op: "local.get", index: argsLocal },
+    { op: "call", funcIdx: applyIdx },
+    { op: "drop" },
+    { op: "local.get", index: resultLocal },
+  );
   return true;
 }
 

--- a/tests/issue-4727.test.ts
+++ b/tests/issue-4727.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+type Exports = Record<string, (() => number) | undefined>;
+
+async function runStandalone(source: string): Promise<Exports> {
+  const result = await compile(source, { fileName: "issue-4727.ts", target: "standalone" });
+  expect(result.success, result.success ? "" : JSON.stringify(result.errors?.slice(0, 3))).toBe(true);
+  expect(result.imports ?? []).toEqual([]);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return instance.exports as unknown as Exports;
+}
+
+describe("#4727 standalone Promise.resolve.call custom constructors", () => {
+  it("rejects a custom constructor's promise on self-resolution", async () => {
+    const ex = await runStandalone(`
+      let resolve: any, reject: any;
+      let promise: any = new Promise(function(r: any, j: any) { resolve = r; reject = j; });
+      let state = 0;
+      let C = function(executor: any) { executor(resolve, reject); return promise; };
+      export function test(): number {
+        const result: any = Promise.resolve.call(C, promise);
+        result.then(function() { state = 1; }, function(value: any) { state = value ? 2 : 3; });
+        return result === promise ? 1 : 0;
+      }
+      export function stateValue(): number { return state; }
+    `);
+
+    expect(ex.test?.()).toBe(1);
+    ex.__drain_microtasks?.();
+    expect(ex.stateValue?.()).toBe(2);
+  });
+
+  it("passes ordinary values and thenables to the captured resolver", async () => {
+    const ex = await runStandalone(`
+      let ordinary: any, seenThenable: any;
+      let resolve1: any, reject1: any;
+      let promise1: any = new Promise(function(r: any, j: any) { resolve1 = r; reject1 = j; });
+      let C1 = function(executor: any) { executor(resolve1, reject1); return promise1; };
+      let resolve2: any, reject2: any;
+      let promise2: any = new Promise(function(r: any, j: any) { resolve2 = r; reject2 = j; });
+      let C2 = function(executor: any) { executor(resolve2, reject2); return promise2; };
+      let thenable = { then: function(r: any) { r(7); } };
+      export function test(): number {
+        Promise.resolve.call(C1, 3).then(function(value: any) { ordinary = value; });
+        Promise.resolve.call(C2, thenable).then(function(value: any) { seenThenable = value; }, function() { seenThenable = -1; });
+        return 1;
+      }
+      export function ordinaryValue(): number { return ordinary; }
+      export function thenableValue(): number { return seenThenable; }
+    `);
+
+    expect(ex.test?.()).toBe(1);
+    ex.__drain_microtasks?.();
+    expect(ex.ordinaryValue?.()).toBe(3);
+    expect(ex.thenableValue?.()).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- admit standalone `Promise.resolve.call(C, value)` for ordinary compiled constructors
- reuse the custom capability resolver so resolving a promise with itself rejects with `TypeError`
- preserve ordinary-value and thenable resolver behavior with focused coverage

## Validation
- exact `built-ins/Promise/resolve/resolve-self.js`: host pass, standalone pass
- selected non-thenable/thenable/identity controls: standalone pass; documented pre-existing host/control residuals remain scoped out
- focused `tests/issue-4727.test.ts`: 2/2
- TS5/TS7, lint, format, LOC/function/oracle/coercion gates, commit hooks and pre-push hook: pass
- production source delta: +174 net lines (cap 180)

Tracked by `plan/issues/4727-es2015-promise-resolve-self.md`.

No PR merge is performed by this task.