### PR TITLE
fix(#4732): reject WeakSet calls without new

### DIFF
--- a/plan/issues/4732-es2015-weakset-undefined-newtarget.md
+++ b/plan/issues/4732-es2015-weakset-undefined-newtarget.md
@@ -1,0 +1,86 @@
+---
+id: 4732
+title: "ES2015 WeakSet rejects calls without new"
+created: 2026-08-25
+updated: 2026-08-25
+status: done
+priority: medium
+depends_on: []
+es_edition: es2015
+language_feature: WeakSet constructor NewTarget validation
+task_type: bug
+completed: 2026-08-25
+loc-budget-allow:
+  - src/codegen/expressions/new-builtin-globals.ts
+  - src/codegen/expressions/calls.ts
+func-budget-allow:
+  - src/codegen/expressions/calls.ts::compileCallExpression
+files:
+  - src/codegen/expressions/new-builtin-globals.ts
+  - src/codegen/expressions/calls.ts
+  - tests/issue-4732.test.ts
+---
+
+# #4732 — ES2015 `WeakSet` undefined-`NewTarget` / call-without-`new`
+
+## Scope
+
+Close the remaining ES2015 Test262 residual in
+`test/built-ins/WeakSet/undefined-newtarget.js`. The test has two independent
+call-without-`new` cases: `WeakSet()` and `WeakSet([])`. Both must throw a
+`TypeError`, while constructor controls (`new WeakSet()` and
+`new WeakSet([])`) must continue to construct successfully. WeakMap and Set
+controls are included to guard the shared builtin-constructor dispatch.
+
+The exact pinned upstream Test262 file is present at:
+`test262/test/built-ins/WeakSet/undefined-newtarget.js` (ES2015 source; its
+frontmatter cites §23.4.1.1 step 1, “If NewTarget is undefined, throw a
+TypeError exception”).
+
+## Baseline (upstream/main)
+
+Measured from upstream/main commit `21d7d893d` on 2026-08-25 before source
+changes with `TEST262_PATH_FILTER=test/built-ins/WeakSet/undefined-newtarget.js`
+and one focused shard:
+
+| Lane | Result | Error signature | Host imports |
+| --- | --- | --- | --- |
+| host (`TEST262_TARGET=gc`) | 0/1 pass, 1/1 fail | `other: Expected a TypeError to be thrown but no exception was thrown at all` | 44 dynamic/runtime imports (expected host lane) |
+| standalone (`TEST262_TARGET=standalone`, interpreter refusal provider) | 0/1 pass, 1/1 fail | `assertion_fail: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all` | no import-leak row; execution reached the assertion |
+
+The standalone QuickJS provider was not used because this environment cannot
+resolve its GitHub build dependency; the interpreter refusal provider is
+appropriate for this test because it does not exercise dynamic evaluation.
+The committed report names this file in the Map/Set/Weak collections residual,
+but that aggregate is not a per-file verdict.
+
+## Plan
+
+1. Reproduce the exact Test262 file on both host and standalone targets and
+   record its per-file verdict/error text.
+2. Trace the WeakSet identifier-call and `new WeakSet(...)` lowering on current
+   main, comparing minimal WeakMap/Set constructor and call controls.
+3. Add the narrowest constructor-call guard/fix, preserving native iterable
+   construction and host imports where required.
+4. Add focused equivalence tests with positive and negative controls, then run
+   the exact focused host/standalone lanes plus TS5/TS7/typecheck/lint/format/
+   hooks checks.
+
+## Test Results
+
+Measured against the pinned upstream baseline above after the narrow guard:
+
+| Check | Result |
+| --- | --- |
+| Focused Vitest (`tests/issue-4732.test.ts`) | 6/6 passed across host and standalone lanes |
+| Test262 host (`TEST262_TARGET=gc`, run `20260825-212209`) | 1/1 passed; expected host dynamic imports remained (44 imports) |
+| Test262 standalone (`TEST262_TARGET=standalone`, interpreter refusal provider, run `20260825-212814`) | 1/1 passed; no host-import leak |
+| Standalone QuickJS provider | Not run: this environment cannot resolve its GitHub build dependency; the interpreter refusal provider is sufficient for this non-eval test |
+| Prettier format check | Passed |
+| Biome lint (`--diagnostic-level=error`) | Passed (existing non-error diagnostics suppressed by the configured diagnostic limit) |
+| TypeScript 5 and 7 | Passed |
+| LOC/function budgets, oracle ratchet, coercion-site ratchet | Passed with the change-scoped grants above |
+
+The source delta is 42 added lines and one import-format adjustment. The guard
+only intercepts an ambient bare `WeakSet` call; constructor forms and shadowed
+bindings retain their existing lowering.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -345,7 +345,11 @@ import {
 import { ensureAnyHelpers, undefinedExternInstrs } from "../any-helpers.js";
 import { emitSymbolToString, ensureSymbolRegistry } from "../symbol-native.js";
 import { resolveStructName } from "./misc.js";
-import { tryCompileDateCallWithoutNew, tryCompileErrorCtorCallWithoutNew } from "./new-builtin-globals.js";
+import {
+  tryCompileDateCallWithoutNew,
+  tryCompileErrorCtorCallWithoutNew,
+  tryCompileWeakSetCallWithoutNew,
+} from "./new-builtin-globals.js";
 import { compileSuperElementMethodCall, compileSuperMethodCall } from "./new-super.js";
 import { compileIdentifierCall } from "./call-identifier.js";
 import { compileBuiltinStaticCall, tryCompileFromCharCodeFamilyReflective } from "./call-builtin-static.js";
@@ -6499,6 +6503,12 @@ function compileCallExpression(
   // `Date.parse(...)` illegal-cast TRAPPED.
   {
     const r = tryCompileDateCallWithoutNew(ctx, fctx, expr);
+    if (r !== undefined) return r;
+  }
+
+  // (#4732) `WeakSet(...)` has no [[Call]] — §23.4.1.1 step 1 requires `new`.
+  {
+    const r = tryCompileWeakSetCallWithoutNew(ctx, fctx, expr);
     if (r !== undefined) return r;
   }
 

--- a/src/codegen/expressions/new-builtin-globals.ts
+++ b/src/codegen/expressions/new-builtin-globals.ts
@@ -1546,6 +1546,37 @@ export function tryCompileErrorCtorCallWithoutNew(
   return result === NEW_GLOBAL_FALLTHROUGH ? undefined : result;
 }
 
+/**
+ * (#4732) `WeakSet(...)` is not callable — §23.4.1.1 step 1 requires a
+ * TypeError when `NewTarget` is undefined. The generic identifier-call path
+ * used to answer with the undefined sentinel instead, so both `WeakSet()` and
+ * `WeakSet([])` silently succeeded. Evaluate arguments first (including their
+ * side effects), then emit the same real TypeError instance used by the other
+ * call-without-`new` guards.
+ *
+ * The ambient-global and class checks are important: a user binding named
+ * `WeakSet` must retain ordinary call semantics, just like the Error and Date
+ * guards above.
+ */
+export function tryCompileWeakSetCallWithoutNew(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | undefined {
+  if (expr.questionDotToken) return undefined;
+  const callee = expr.expression;
+  if (!ts.isIdentifier(callee) || callee.text !== "WeakSet") return undefined;
+  if (ctx.classSet.has("WeakSet")) return undefined;
+  if (!resolvesToAmbientGlobal(ctx, callee)) return undefined;
+
+  for (const arg of expr.arguments ?? []) {
+    const argResult = compileExpression(ctx, fctx, arg);
+    if (argResult) fctx.body.push({ op: "drop" });
+  }
+  emitThrowTypeError(ctx, fctx, "Constructor WeakSet requires 'new'");
+  return { kind: "externref" };
+}
+
 /** `__date_format_string` mode selector for §21.4.4.41 `toString`. */
 const DATE_FORMAT_MODE_TO_STRING = 2;
 

--- a/tests/issue-4732.test.ts
+++ b/tests/issue-4732.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * #4732 — §23.4.1.1 step 1: WeakSet has no [[Call]] method. Calling the
+ * ambient constructor without `new` must throw a TypeError on both the JS-host
+ * and standalone lanes, while the native constructor path and adjacent
+ * WeakMap/Set constructors remain usable.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildImports, compile, instantiateWasm } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+type Lane = "host" | "standalone";
+
+async function run(source: string, lane: Lane): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-4732.ts",
+    skipSemanticDiagnostics: true,
+    ...(lane === "standalone" ? { target: "standalone" as const } : {}),
+  });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown"}`);
+  }
+
+  if (lane === "standalone") {
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    return (instance.exports as { test: () => number }).test();
+  }
+
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, imports.env, imports.string_constants);
+  imports.setInstance?.(instance);
+  return (instance.exports as { test: () => number }).test();
+}
+
+function lanes(): Lane[] {
+  return ["host", "standalone"];
+}
+
+describe("#4732 — WeakSet requires new", () => {
+  for (const lane of lanes()) {
+    describe(lane, () => {
+      it("throws TypeError for both no-argument and iterable calls", async () => {
+        await expect(
+          run(
+            `export function test(): number {
+              let sideEffect = 0;
+              let noArg = 0;
+              let iterableArg = 0;
+              try { WeakSet(); } catch (e) { noArg = e instanceof TypeError ? 1 : -1; }
+              try { WeakSet([sideEffect = 1]); } catch (e) {
+                iterableArg = e instanceof TypeError ? 1 : -1;
+              }
+              return noArg + iterableArg * 2 + sideEffect * 4;
+            }`,
+            lane,
+          ),
+        ).resolves.toBe(7);
+      });
+
+      it("keeps native constructor controls working", async () => {
+        await expect(
+          run(
+            `export function test(): number {
+              const ws = new WeakSet([]);
+              const wm = new WeakMap([]);
+              const set = new Set([]);
+              return ws !== undefined && wm !== undefined && set !== undefined ? 1 : 0;
+            }`,
+            lane,
+          ),
+        ).resolves.toBe(1);
+      });
+    });
+  }
+});
+
+describe("#4732 — constructor import shape", () => {
+  it("keeps standalone WeakSet/WeakMap/Set construction host-free", async () => {
+    const result = await compile(
+      `export function test(): number {
+        const key: object = {};
+        return new WeakSet([key]).has(key) && new WeakMap([[key, 1]]).get(key) === 1 && new Set([1]).has(1) ? 1 : 0;
+      }`,
+      { fileName: "issue-4732-structure.ts", target: "standalone", skipSemanticDiagnostics: true },
+    );
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    if (!result.success) return;
+    const imports = result.imports.map((entry) => entry.name);
+    expect(imports.filter((name) => /^(WeakSet|WeakMap|Set)_/.test(name))).toEqual([]);
+  });
+
+  it("retains host constructor imports for the host lane", async () => {
+    const result = await compile(
+      `export function test(): number {
+        const key: object = {};
+        return new WeakSet([key]).has(key) && new WeakMap([[key, 1]]).get(key) === 1 && new Set([1]).has(1) ? 1 : 0;
+      }`,
+      { fileName: "issue-4732-host-structure.ts", skipSemanticDiagnostics: true },
+    );
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    if (!result.success) return;
+    const imports = result.imports.map((entry) => entry.name);
+    expect(imports).toEqual(expect.arrayContaining(["WeakSet_new", "WeakMap_new", "Set_new"]));
+  });
+});


### PR DESCRIPTION
## Summary
- reject ambient `WeakSet()` calls when NewTarget is undefined in host and standalone lowering
- preserve `new WeakSet(...)`, WeakMap/Set controls, and shadowed user bindings
- keep the change focused to the constructor-call dispatch

## Validation
- exact `built-ins/WeakSet/undefined-newtarget.js`: host 1/1, standalone 1/1 (baseline 0/1 in each lane)
- focused `tests/issue-4732.test.ts`: 6/6
- TS5/TS7, lint, format, LOC/function/oracle/coercion gates, commit hooks and pre-push hook: pass
- production source delta: +41 net lines

Tracked by `plan/issues/4732-es2015-weakset-undefined-newtarget.md`.

No PR merge is performed by this task.