### PR TITLE
fix(eval): reject construction of global eval

### DIFF
--- a/plan/issues/4737-es2015-eval-not-constructor.md
+++ b/plan/issues/4737-es2015-eval-not-constructor.md
@@ -1,0 +1,97 @@
+---
+id: 4737
+title: "eval is not a constructor in standalone output"
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+status: done
+priority: high
+depends_on: []
+es_edition: es2015
+language_feature: eval
+task_type: bug
+files:
+  - src/codegen/closures/ordinary-fn-constructibility.ts
+  - src/codegen/expressions/identifiers.ts
+  - src/codegen/expressions/new-super.ts
+  - scripts/test262-sandbox-globals.mjs
+  - tests/issue-4737.test.ts
+loc-budget-allow:
+  - src/codegen/expressions/identifiers.ts
+  - src/codegen/expressions/new-super.ts
+func-budget-allow:
+  - src/codegen/expressions/identifiers.ts::compileIdentifierCore
+---
+
+# `eval` is not a constructor in standalone output
+
+## Scope
+
+Fix the exact Test262 case `test/built-ins/eval/not-a-constructor.js`.
+The confirmed host baseline fails at upstream commit `627013f0f`.
+
+The case checks both `isConstructor(eval) === false` and that `new eval('')`
+throws `TypeError`. Its source does not execute dynamic eval: the `eval` value
+is only inspected by `Reflect.construct`, and the `new` expression must reject
+it before invocation. Standalone validation may therefore use the repository's
+interpreter-refusal provider; QuickJS is not required for this case.
+
+Include Function/constructor controls so the fix does not make genuine
+constructors non-constructable.
+
+## Acceptance
+
+- The focused Test262 case passes in the host lane and standalone/refusal lane.
+- `Function` and an ordinary user constructor remain constructable.
+- Production change stays within 180 net lines and is limited to the `new`
+  non-constructor classification path.
+
+## Implementation Plan
+
+1. Reproduce the exact Test262 file on the confirmed host baseline
+   `627013f0f`, using an absolute path so the compiler can resolve the source
+   file. Record the host failure and the standalone failure with the
+   repository's interpreter-refusal provider.
+2. Materialize an unshadowed host `eval` read from the realm global object,
+   classify the synthetic standalone indirect-eval adapter as callable but
+   non-constructible, and include `eval` in the static global
+   non-constructor `new` guard.
+3. Add the missing `eval` name to the Test262 sandbox globals and exercise the
+   exact case plus Function/ordinary-function/arrow controls.
+
+The exact source only probes `eval` through `isConstructor` and
+`Reflect.construct`; it does not execute dynamic code. Therefore the
+standalone run uses the repository refusal provider and does not require
+QuickJS.
+
+## Test Results
+
+### Provider and baseline evidence
+
+- Built the repository refusal provider with
+  `node --import tsx scripts/build-runtime-eval-provider.mjs --refusal-only`.
+  Cache key: `53838e1372b11156`; artifact:
+  `.test262-cache/runtime-eval-refusal-53838e1372b11156.wasm` (138827 bytes,
+  canary verified).
+- At upstream `627013f0f`, exact host run failed with
+  `Test262Error: isConstructor invoked with a non-function value` (Wasm SHA
+  `db1bd6eeadfe`).
+- At the same baseline, exact standalone/refusal run failed with
+  `Test262Error: isConstructor(eval) must return false` (Wasm SHA
+  `42760785cff0`). The default QuickJS lane was unavailable because its
+  `libquickjs.wasm` artifact was not present; QuickJS is not needed for this
+  no-dynamic-eval case.
+
+### Fixed revision
+
+- Exact host Test262 case: `pass` (Wasm SHA `39900f71c380`; total 3747.6 ms).
+- Exact standalone Test262 case with refusal provider: `pass` (Wasm SHA
+  `73de890f8587`; total 6953.34 ms). The provider announced refusal key
+  `53838e1372b11156` and no dynamic eval was executed.
+- Focused controls: standalone `eval` is non-constructible, an ordinary
+  function expression remains constructible, an arrow remains
+  non-constructible; host `%Function%` remains constructible.
+- Focused Vitest: 3/3 pass under the interpreter-refusal provider.
+- TypeScript 5 and TypeScript 7 checks, ESLint, Prettier, issue validation,
+  LOC budget, and function budget: pass. The narrowly scoped budget grants
+  cover the `eval` classification branches recorded above.

--- a/scripts/test262-sandbox-globals.mjs
+++ b/scripts/test262-sandbox-globals.mjs
@@ -29,6 +29,7 @@ export const SANDBOX_GLOBAL_NAMES = Object.freeze([
   "Array",
   "Object",
   "Function",
+  "eval",
   "String",
   "Number",
   "Boolean",

--- a/src/codegen/closures/ordinary-fn-constructibility.ts
+++ b/src/codegen/closures/ordinary-fn-constructibility.ts
@@ -74,6 +74,11 @@ export function normalizeOrdinaryFunctionConstructibility(
   funcName: string,
   constructible: boolean,
 ): boolean {
+  // The synthetic indirect-eval adapter is callable but deliberately has no
+  // [[Construct]]. It is FunctionDeclaration-shaped only so the existing
+  // closure hoister can compile its body; do not expose that implementation
+  // detail through Reflect.construct(eval) in standalone output.
+  if (funcName === "__js2wasm_intrinsic_indirect_eval") return false;
   if (constructible) return true;
   // (#4661) Lane-INDEPENDENT (was gated to `noJsHost || native-first`). The
   // js-host lane needs the same nominal constructible subtype so

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -1231,6 +1231,33 @@ function compileIdentifierCore(
       if (valueType !== undefined) return valueType;
     }
   }
+  // Host/gc: a first-class read of the unshadowed global `%eval%` must expose
+  // the realm's actual function object. Direct calls are lowered separately;
+  // this is the value path used by Reflect.construct and aliases.
+  if (!ctx.standalone && !ctx.wasi && name === "eval") {
+    const declaration = ctx.oracle.valueDeclarationOf(id);
+    const isGlobalIntrinsic = declaration === undefined || declaration.getSourceFile().isDeclarationFile;
+    if (isGlobalIntrinsic) {
+      const gtFuncIdx = ensureLateImport(ctx, "__get_globalThis", [], [{ kind: "externref" }]);
+      const getIdx = ensureLateImport(
+        ctx,
+        "__extern_get",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "externref" }],
+      );
+      flushLateImportShifts(ctx, fctx);
+      if (gtFuncIdx !== undefined && getIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: gtFuncIdx });
+        addStringConstantGlobal(ctx, name);
+        const strGlobalIdx = ctx.stringGlobalMap.get(name);
+        fctx.body.push(
+          strGlobalIdx !== undefined ? { op: "global.get", index: strGlobalIdx } : { op: "ref.null.extern" },
+        );
+        fctx.body.push({ op: "call", funcIdx: getIdx });
+        return { kind: "externref" };
+      }
+    }
+  }
   // `%Function%` is a genuine realm-owned callable in runtime-eval builds.
   // Direct `Function(...)` / `new Function(...)` syntax is intercepted before
   // identifier lowering; this branch preserves first-class aliases and the

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -561,8 +561,8 @@ function resolvesToDynamicAnyCtorValue(ctx: CodegenContext, calleeExpr: ts.Expre
  * `isFinite`). Each is an ordinary built-in function object that does **not**
  * implement `[[Construct]]`, so `new <fn>()` must throw a `TypeError`
  * (§13.3.5.1 EvaluateNew step 5: `IsConstructor(constructor) === false`).
- * `eval` is intentionally omitted — it is filtered out of test262 and handled
- * elsewhere.
+ * `eval` is included because it is an ordinary built-in function without
+ * [[Construct]], just like the other global callables in this set.
  */
 const GLOBAL_NON_CONSTRUCTOR_FUNCTIONS = new Set([
   "decodeURI",
@@ -573,6 +573,7 @@ const GLOBAL_NON_CONSTRUCTOR_FUNCTIONS = new Set([
   "parseFloat",
   "isNaN",
   "isFinite",
+  "eval",
 ]);
 
 /**

--- a/tests/issue-4737.test.ts
+++ b/tests/issue-4737.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #4737 — the global eval value is callable but not constructable.
+//
+// The exact Test262 case is intentionally run on both lanes. Its source only
+// probes the value through IsConstructor/Reflect.construct; it never executes
+// dynamic eval, so standalone uses the repository's interpreter-refusal
+// provider rather than requiring QuickJS.
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import {
+  RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS,
+  buildRuntimeEvalRefusalProviderSource,
+  computeCompilerBundleHash,
+  defaultRuntimeEvalProviderCacheDir,
+  readCachedRuntimeEvalProvider,
+  runtimeEvalProviderCacheKey,
+  runtimeEvalRefusalCachePath,
+  writeCachedRuntimeEvalProvider,
+} from "../scripts/runtime-eval-provider.mjs";
+import { instantiateTest262Module, resetTest262RuntimeEvalProviderForTest } from "../scripts/test262-import-object.mjs";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_CASE = resolve("test262/test/built-ins/eval/not-a-constructor.js");
+let previousEvalEngine: string | undefined;
+
+async function ensureRefusalProviderCached(): Promise<void> {
+  const source = buildRuntimeEvalRefusalProviderSource();
+  const key = runtimeEvalProviderCacheKey(source, computeCompilerBundleHash());
+  const cacheDir = defaultRuntimeEvalProviderCacheDir();
+  if (readCachedRuntimeEvalProvider(cacheDir, key, runtimeEvalRefusalCachePath)) return;
+  const result = await compile(source, RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS);
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  writeCachedRuntimeEvalProvider(cacheDir, key, result.binary!, runtimeEvalRefusalCachePath);
+  resetTest262RuntimeEvalProviderForTest();
+}
+
+async function runStandalone(source: string): Promise<number> {
+  await ensureRefusalProviderCached();
+  const result = await compile(source, {
+    target: "standalone",
+    fileName: "issue-4737-controls.ts",
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const instance = await instantiateTest262Module(result.binary!, imports, {
+    target: "standalone",
+    providerLabel: "#4737",
+  });
+  return (instance.exports as Record<string, () => number>).test();
+}
+
+async function runHost(source: string): Promise<number> {
+  const result = await compile(source, { fileName: "issue-4737-host-controls.ts" });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const instance = await instantiateTest262Module(result.binary!, imports);
+  return (instance.exports as Record<string, () => number>).test();
+}
+
+beforeAll(async () => {
+  previousEvalEngine = process.env.JS2WASM_EVAL_ENGINE;
+  process.env.JS2WASM_EVAL_ENGINE = "interpreter";
+  await ensureRefusalProviderCached();
+}, 600_000);
+
+afterAll(() => {
+  if (previousEvalEngine === undefined) Reflect.deleteProperty(process.env, "JS2WASM_EVAL_ENGINE");
+  else process.env.JS2WASM_EVAL_ENGINE = previousEvalEngine;
+  resetTest262RuntimeEvalProviderForTest();
+});
+
+describe("#4737 eval is not a constructor", () => {
+  it("passes the exact Test262 case on the host lane", async () => {
+    expect(existsSync(TEST262_CASE)).toBe(true);
+    const result = await runTest262File(TEST262_CASE, "issue-4737-host", 60_000);
+    expect(result?.status).toBe("pass");
+  }, 120_000);
+
+  it("passes the exact Test262 case standalone with the refusal provider", async () => {
+    expect(existsSync(TEST262_CASE)).toBe(true);
+    const result = await runTest262File(TEST262_CASE, "issue-4737-standalone", 60_000, "standalone");
+    expect(result?.status).toBe("pass");
+  }, 120_000);
+
+  it("keeps Function and ordinary constructor controls constructable", async () => {
+    const standaloneValue = await runStandalone(`
+      function isConstructor(f: any): boolean {
+        try { Reflect.construct(function () {}, [], f); } catch (e) { return false; }
+        return true;
+      }
+      const ordinaryFunction: any = function () {};
+      export function test(): number {
+        const arrow: any = () => 1;
+        return isConstructor(eval) === false &&
+          isConstructor(ordinaryFunction) === true &&
+          isConstructor(arrow) === false ? 1 : 0;
+      }
+    `);
+    expect(standaloneValue).toBe(1);
+
+    const hostFunctionValue = await runHost(`
+      function isConstructor(f: any): boolean {
+        try { Reflect.construct(function () {}, [], f); } catch (e) { return false; }
+        return true;
+      }
+      export function test(): number {
+        return isConstructor(Function) === true ? 1 : 0;
+      }
+    `);
+    expect(hostFunctionValue).toBe(1);
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary
- classify the unshadowed global `eval` adapter as callable but non-constructible
- reject `new eval(...)` before invocation in host and standalone output
- add tracked #4737 plan/evidence and exact Test262 coverage with constructor controls

## Validation
- exact host and standalone/refusal Test262 case pass
- focused Vitest: 3/3
- TS5, TS7, lint, format, budgets, issue checks, commit and pre-push hooks pass

Issue: `plan/issues/4737-es2015-eval-not-constructor.md`