### PR TITLE
fix(function): expose hasInstance descriptor standalone

### DIFF
--- a/plan/issues/4739-es2015-function-hasinstance-descriptor.md
+++ b/plan/issues/4739-es2015-function-hasinstance-descriptor.md
@@ -1,0 +1,84 @@
+---
+id: 4739
+title: "ES2015 standalone Function.prototype @@hasInstance descriptor"
+status: done
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 2015
+language_feature: function-prototype, symbol-hasInstance, descriptors
+goal: standalone-gap
+assignee: ttraenkler/es6_next_residual_wave19
+related: [4676, 2175, 4265]
+origin: "Current ES2015 residual snapshot and exact host/standalone verification on upstream/main 3809cc76e3."
+loc-budget-allow:
+  - src/codegen/property-access.ts
+  - src/codegen/native-proto-own-props.ts
+---
+
+# #4739 — standalone `Function.prototype[Symbol.hasInstance]` descriptor
+
+## Scope
+
+Own the smallest current ES2015 residual candidate:
+`test/built-ins/Function/prototype/Symbol.hasInstance/prop-desc.js`.
+The host lane passes on current upstream/main, while standalone currently
+reports `typeof Function.prototype[Symbol.hasInstance] === "undefined"`.
+The test then verifies the non-writable, non-enumerable, non-configurable
+descriptor. Related `@@hasInstance` value/dispatch rows are controls and are
+not part of this issue unless the narrow fix requires them.
+
+## Plan
+
+1. Reproduce the exact host and standalone result on current upstream/main,
+   using the interpreter refusal provider only for this non-eval test.
+2. Trace the direct symbol read and descriptor lookup, then add the narrowest
+   standalone lowering that exposes the existing native method singleton and
+   exact descriptor without widening generic symbol/property behavior.
+3. Add a focused issue test plus sibling value and descriptor controls.
+4. Run the exact test262 row, focused controls, TypeScript 5/7 checks, scoped
+   lint/format, and repository hooks. Record all commands and results here.
+
+## Baseline (upstream/main `3809cc76e3`, 2026-08-25)
+
+The baseline JSONL snapshot is `/private/tmp/js2-es6-functionproto-wave3/.test262-cache/test262-standalone-current.jsonl`,
+timestamped `25.8.2026, 04:31:12`. The selected ES2015 row is current in the
+snapshot and is not in the excluded #4680–#4738/open-PR scopes.
+
+| lane | result | observation |
+| --- | --- | --- |
+| host | pass | `runTest262File` completes with wasm SHA `5c089a71ca7a` |
+| standalone | fail | `Test262Error` at L13: expected `typeof Function.prototype[Symbol.hasInstance]` to be `"function"`, got `"undefined"`; wasm SHA `bf988f8f318b` |
+| standalone controls | pass | `value-positive.js`, `value-negative.js`, `value-non-obj.js`, and `this-val-bound-target.js` |
+
+The standalone run used `JS2WASM_EVAL_ENGINE=interpreter` with the refusal-only
+provider, which is permitted for this non-eval diagnostic and keeps the
+compiler/runtime result deterministic.
+
+## Test Results
+
+All runs below used the isolated worktree at upstream/main `3809cc76e3`.
+
+| check | result |
+| --- | --- |
+| exact host `prop-desc.js` | pass |
+| exact standalone `prop-desc.js` (`JS2WASM_EVAL_ENGINE=interpreter`, refusal-only provider) | pass |
+| standalone controls: `value-positive.js`, `value-negative.js`, `value-non-obj.js`, `this-val-bound-target.js` | pass, pass, pass, pass |
+| focused `tests/issue-4739-function-hasinstance-descriptor.test.ts` | 2/2 pass |
+| existing `tests/issue-4676-function-prototype-hasinstance.test.ts` controls | 3/3 pass |
+| TypeScript 5 `node node_modules/typescript/lib/tsc.js --noEmit` | pass |
+| TypeScript 7 `node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json` | pass |
+| Biome scoped lint | pass |
+| Prettier scoped check | pass |
+
+The nearby `this-val-not-callable.js` control remains a pre-existing
+`Function.prototype.call` standalone refusal and is outside this descriptor
+slice. Production changes are 180 net lines across the two allowed codegen
+files, within the 180-line budget; the issue test and this record are separate.

--- a/src/codegen/native-proto-own-props.ts
+++ b/src/codegen/native-proto-own-props.ts
@@ -69,7 +69,13 @@
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
-import { seededNativeProtoDataMembersByBrand } from "./native-proto.js";
+import {
+  ensureStandaloneNativeMethodClosure,
+  getBuiltinBrand,
+  seededNativeProtoDataMembersByBrand,
+} from "./native-proto.js";
+import { ensureFunctionNativeProtoGlue } from "./array-object-proto.js";
+import { pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
 import { addFuncType } from "./registry/types.js";
 
@@ -85,6 +91,105 @@ const STR_DATA = 2;
 const COMMA = 0x2c;
 
 export const NATIVE_PROTO_HASOWN_FN = "__nproto_hasown";
+
+function registerNativeProtoHasInstanceGopd(
+  ctx: CodegenContext,
+  protoTypeIdx: number,
+  functionBrand: number | undefined,
+  symbolType: number | undefined,
+): void {
+  const createDescriptorIdx = ctx.funcMap.get("__create_descriptor");
+  if (createDescriptorIdx === undefined || symbolType === undefined || functionBrand === undefined) return;
+  const brand = ensureFunctionNativeProtoGlue(ctx);
+  const closure =
+    brand === undefined
+      ? null
+      : ensureStandaloneNativeMethodClosure(ctx, brand, "@@hasInstance", "method", { refusalBodyFallback: true });
+  if (!closure) return;
+
+  const gopdTypeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  const gopdFuncIdx = mintDefinedFunc(ctx);
+  const gopdBody: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: 2 },
+    { op: "ref.test", typeIdx: protoTypeIdx },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+    { op: "local.get", index: 2 },
+    { op: "ref.cast", typeIdx: protoTypeIdx },
+    { op: "struct.get", typeIdx: protoTypeIdx, fieldIdx: NP_BRAND },
+    { op: "i32.const", value: functionBrand },
+    { op: "i32.ne" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+    { op: "local.get", index: 1 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: symbolType },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+    { op: "local.get", index: 1 },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: symbolType },
+    { op: "struct.get", typeIdx: symbolType, fieldIdx: 0 },
+    { op: "i32.const", value: 2 },
+    { op: "i32.ne" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+    ...pushBuiltinFnSingletonValueInstrs(ctx, closure),
+    { op: "extern.convert_any" },
+    { op: "i32.const", value: 0 },
+    { op: "call", funcIdx: createDescriptorIdx },
+  ];
+  pushDefinedFunc(ctx, gopdFuncIdx, {
+    name: "__nproto_gopd",
+    typeIdx: gopdTypeIdx,
+    locals: [{ name: "any", type: { kind: "anyref" } }],
+    body: gopdBody,
+    exported: false,
+  });
+  ctx.funcMap.set("__nproto_gopd", gopdFuncIdx);
+}
+
+function nativeProtoHasInstanceOwnArm(
+  protoTypeIdx: number,
+  functionBrand: number | undefined,
+  symbolType: number | undefined,
+  anyLocal: number,
+): Instr[] {
+  if (functionBrand === undefined || symbolType === undefined) return [];
+  return [
+    { op: "local.get", index: 1 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: symbolType },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 1 },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: symbolType },
+        { op: "struct.get", typeIdx: symbolType, fieldIdx: 0 },
+        { op: "i32.const", value: 2 },
+        { op: "i32.eq" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: anyLocal },
+            { op: "ref.cast", typeIdx: protoTypeIdx },
+            { op: "struct.get", typeIdx: protoTypeIdx, fieldIdx: NP_BRAND },
+            { op: "i32.const", value: functionBrand },
+            { op: "i32.eq" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
 
 /**
  * Register `__nproto_hasown(obj externref, key externref) -> i32`: 1 when `key`
@@ -109,6 +214,8 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
   const seededDataMembers = seededNativeProtoDataMembersByBrand(ctx);
   const protoOwnRecvIdx = ctx.funcMap.get("__protoidx_own_recv");
   const objectHasOwnIdx = ctx.funcMap.get("__object_hasOwn");
+  const functionBrand = getBuiltinBrand(ctx, "Function");
+  const symbolType = ctx.symbolTypeIdx >= 0 ? ctx.symbolTypeIdx : undefined;
 
   // params: 0 obj, 1 key
   const L_ANY = 2;
@@ -159,7 +266,9 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
     { op: "ref.cast", typeIdx: protoTypeIdx },
     { op: "struct.get", typeIdx: protoTypeIdx, fieldIdx: NP_IS_CLASS },
     { op: "if", blockType: { kind: "empty" }, then: returnZero },
-    // A non-string key (symbol, boxed number) names no member of a prototype.
+    // Symbol.hasInstance is an own Function.prototype method.
+    ...nativeProtoHasInstanceOwnArm(protoTypeIdx, functionBrand, symbolType, L_ANY),
+    // A non-string key (other symbols, boxed number) names no member of a prototype.
     { op: "local.get", index: 1 },
     { op: "any.convert_extern" },
     { op: "ref.test", typeIdx: anyStr },
@@ -352,6 +461,8 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
     body,
     exported: false,
   });
+
+  registerNativeProtoHasInstanceGopd(ctx, protoTypeIdx, functionBrand, symbolType);
   return funcIdx;
 }
 
@@ -384,6 +495,23 @@ export function unshiftNativeProtoHasOwnArms(ctx: CodegenContext): void {
           { op: "i32.const", value: name === "__propertyIsEnumerable" ? 0 : 1 },
           { op: "return" },
         ],
+      },
+    );
+  }
+  const gopdFn = ctx.mod.functions.find((candidate) => candidate.name === "__getOwnPropertyDescriptor");
+  const gopdIdx = ctx.funcMap.get("__nproto_gopd");
+  if (gopdFn && gopdIdx !== undefined) {
+    gopdFn.body.unshift(
+      { op: "local.get", index: 0 },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: gopdIdx },
+      { op: "local.tee", index: 6 },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 6 }, { op: "return" }],
       },
     );
   }

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -232,6 +232,66 @@ export {
   tryEnsureNativeProtoBrand,
 } from "./builtin-value-read.js";
 
+const PROTOTYPE_MUTATION_CACHE = new WeakMap<ts.SourceFile, ReadonlySet<string>>();
+const isAssignmentOperator = (kind: ts.SyntaxKind): boolean =>
+  kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+
+function prototypeMutationNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
+  const cached = PROTOTYPE_MUTATION_CACHE.get(sourceFile);
+  if (cached !== undefined) return cached;
+  const names = new Set<string>();
+  const isPrototypeAccess = (expr: ts.Expression): boolean => {
+    const inner = skipTransparentExpressions(expr);
+    return (
+      (ts.isPropertyAccessExpression(inner) && inner.name.text === "prototype") ||
+      (ts.isElementAccessExpression(inner) &&
+        ts.isStringLiteral(inner.argumentExpression) &&
+        inner.argumentExpression.text === "prototype")
+    );
+  };
+  const prototypeBaseName = (expr: ts.Expression): string | undefined => {
+    const inner = skipTransparentExpressions(expr);
+    const prototype = isPrototypeAccess(inner)
+      ? inner
+      : (ts.isPropertyAccessExpression(inner) || ts.isElementAccessExpression(inner)) &&
+          isPrototypeAccess(inner.expression)
+        ? inner.expression
+        : undefined;
+    const base =
+      prototype && (ts.isPropertyAccessExpression(prototype) || ts.isElementAccessExpression(prototype))
+        ? prototype.expression
+        : undefined;
+    return base && ts.isIdentifier(base) ? base.text : undefined;
+  };
+  const visit = (node: ts.Node): void => {
+    if (ts.isBinaryExpression(node) && isAssignmentOperator(node.operatorToken.kind) && prototypeBaseName(node.left)) {
+      names.add(prototypeBaseName(node.left)!);
+    } else if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      prototypeBaseName(node.operand)
+    ) {
+      names.add(prototypeBaseName(node.operand)!);
+    } else if (ts.isDeleteExpression(node) && prototypeBaseName(node.expression)) {
+      names.add(prototypeBaseName(node.expression)!);
+    }
+    if (ts.isCallExpression(node) && node.arguments.length > 0 && ts.isPropertyAccessExpression(node.expression)) {
+      const callee = node.expression;
+      if (
+        ts.isIdentifier(callee.expression) &&
+        (callee.expression.text === "Object" || callee.expression.text === "Reflect") &&
+        (callee.name.text === "defineProperty" || callee.name.text === "defineProperties") &&
+        prototypeBaseName(node.arguments[0]!)
+      ) {
+        names.add(prototypeBaseName(node.arguments[0]!)!);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  PROTOTYPE_MUTATION_CACHE.set(sourceFile, names);
+  return names;
+}
+
 /**
  * Standalone computed-read arm for the inherited Function @@hasInstance
  * method. The generic symbol-key path has no `$NativeProto` symbol-cell
@@ -262,18 +322,10 @@ function tryCompileStandaloneFunctionHasInstanceRead(
     return undefined;
   }
 
-  // An own `prototype` write/getter is observable by OrdinaryHasInstance and
-  // must remain on the existing generic path until the native closure edge can
-  // model that own property. The conservative source gate covers both direct
-  // assignments and Object.defineProperty/defineProperties forms while keeping
-  // the common ordinary-function path native.
-  const sourceText = expr.getSourceFile().text;
-  if (
-    sourceText.includes("prototype") &&
-    (sourceText.includes("defineProperty") || /\.prototype\s*=/.test(sourceText))
-  ) {
-    return undefined;
-  }
+  // Syntax-aware guard: Test262 helper defineProperty text must not mask an
+  // untouched Function.prototype intrinsic read.
+  const mutationName = directFunctionProto ? "Function" : ts.isIdentifier(receiver) ? receiver.text : undefined;
+  if (mutationName !== undefined && prototypeMutationNames(expr.getSourceFile()).has(mutationName)) return undefined;
 
   // `__closure_proto_of` is filled from the compile-time fnctor/prototype
   // registry. A method-only read does not otherwise touch `F.prototype`, so

--- a/tests/issue-4739-function-hasinstance-descriptor.test.ts
+++ b/tests/issue-4739-function-hasinstance-descriptor.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #4739 — standalone Function.prototype @@hasInstance value and descriptor.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(body: string): Promise<number> {
+  const result = await compile(`export function test(): number { ${body} }`, {
+    allowJs: true,
+    fileName: "issue-4739-function-hasinstance-descriptor.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#4739 standalone Function.prototype @@hasInstance descriptor", () => {
+  it("exposes the native method and its exact non-writable descriptor", async () => {
+    await expect(
+      runStandalone(`
+        const descriptor = Object.getOwnPropertyDescriptor(Function.prototype, Symbol.hasInstance);
+        return typeof Function.prototype[Symbol.hasInstance] === "function" &&
+          descriptor !== undefined &&
+          descriptor.value === Function.prototype[Symbol.hasInstance] &&
+          descriptor.writable === false &&
+          descriptor.enumerable === false &&
+          descriptor.configurable === false ? 1 : 0;
+      `),
+    ).resolves.toBe(1);
+  });
+
+  it("ignores unrelated prototype setup in the source when resolving the intrinsic", async () => {
+    await expect(
+      runStandalone(`
+        function HarnessError() {}
+        HarnessError.prototype.toString = function () { return "error"; };
+        const descriptor = Object.getOwnPropertyDescriptor(Function.prototype, Symbol.hasInstance);
+        return typeof Function.prototype[Symbol.hasInstance] === "function" &&
+          descriptor !== undefined && descriptor.writable === false ? 1 : 0;
+      `),
+    ).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `Function.prototype[Symbol.hasInstance]` as an own standalone native method
- return its exact non-writable, non-enumerable, non-configurable descriptor
- use syntax-aware prototype mutation detection and add tracked #4739 evidence

## Validation
- exact host and standalone Test262 `prop-desc.js`: pass
- sibling standalone controls: 4/4 pass
- focused #4739 + existing #4676 tests: 5/5 pass after latest upstream merge
- TS5, TS7, lint, format, budgets, commit and pre-push hooks pass

Issue: `plan/issues/4739-es2015-function-hasinstance-descriptor.md`