### PR TITLE
fix(collections): expose native instance prototypes

### DIFF
--- a/plan/issues/4740-weakset-native-instance-prototype.md
+++ b/plan/issues/4740-weakset-native-instance-prototype.md
@@ -1,0 +1,81 @@
+---
+id: 4740
+title: "standalone: native WeakSet instances report WeakSet.prototype"
+status: done
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: conformance
+area: codegen
+language_feature: builtins, reflection
+goal: standalone-mode
+---
+
+## Problem
+
+In `--target standalone`, `Object.getPrototypeOf(new WeakSet(...))` returns
+`null`, although the collection's language-level prototype is
+`WeakSet.prototype`. The same failure affects the sibling native collection
+backing type (`Map`, `Set`, and `WeakMap`) because all four lower to `$Map`.
+
+## Evidence
+
+On upstream/main `3809cc76e3ece099b77ec67ea5927c6950c09033`, this direct probe
+returns `1` in the host lane and `0` in standalone:
+
+```js
+export function test() {
+  return Object.getPrototypeOf(new WeakSet([])) === WeakSet.prototype ? 1 : 0;
+}
+```
+
+The exact Test262 files
+`built-ins/WeakSet/empty-iterable.js` and `built-ins/WeakSet/no-iterable.js`
+also fail standalone with `Expected SameValue(«null», «[object Object]»)`.
+The host runner's upstream harness assembly currently reports a separate
+`sameValue is not a function` harness error for these files, so the direct
+host/standalone probe is the host comparison. The corresponding standalone
+failures are compiler behavior, not a harness-only result.
+
+Nearby open work is non-overlapping: Map/Set `forEach` thisArg handling is
+tracked separately (#4725), and WeakSet `undefined-newtarget` is a different
+constructor error path (#4732).
+
+## Root cause
+
+Standalone construction creates a `$Map`-backed WasmGC struct. The generic
+`__getPrototypeOf` fallback can only inspect `$Object`/fnctor links and thus
+sees the opaque struct's host prototype as `null`. The compiler already emits
+an identity-stable `$NativeProto` object for each collection's direct
+`<Builtin>.prototype` value read, so the missing step is the statically typed
+native-collection receiver arm in `Object.getPrototypeOf`.
+
+## Implementation plan
+
+1. In the standalone `Object.getPrototypeOf` dispatch, recognize checker types
+   whose symbols are `Map`, `Set`, `WeakMap`, or `WeakSet`.
+2. Evaluate and drop the receiver (preserving side effects), then reuse the
+   existing native-prototype glue and lazy singleton for that collection.
+3. Keep dynamic/`any` receivers and host mode on their existing fallback path.
+4. Add focused controls for all four collections and ordinary object behavior;
+   run the two exact WeakSet Test262 files in host and standalone where the
+   harness permits, plus TypeScript/lint/format/budget checks.
+
+## Test Results
+
+- Focused Vitest controls: 3 passed (standalone and host all-four collection
+  prototype mask `15`, plus ordinary object identity).
+- Direct host/standalone probe after the fix: both return `1`; standalone emits
+  no imports.
+- Exact standalone Test262: `WeakSet/empty-iterable.js` pass;
+  `WeakSet/no-iterable.js` pass. The legacy synthetic host runner also passes
+  both exact files. `WeakSet/properties-of-the-weakset-prototype-object.js`
+  remains a separate prototype-of-prototype residual and is intentionally not
+  included in this fix.
+- TS5 and TS7 typechecks pass; targeted Biome lint and Prettier checks pass;
+  LOC/function budgets pass with 24 net production LOC and no allowance.

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -120,7 +120,7 @@ import { buildThrowJsErrorInstrs, emitThrowTypeError, noJsHost } from "./helpers
 import { mayStaticallyExpandCreateDescriptor, staticDescriptorTypeError } from "../descriptor-shape.js";
 import { emitUndefined, ensureGetUndefined, ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { resolveStructName } from "./misc.js";
-import { tryCompileEs5GetPrototypeOfEarly, tryCompileEs5GetPrototypeOfValue } from "./object-get-prototype-of.js";
+import * as objectGetPrototypeOf from "./object-get-prototype-of.js";
 import { tryCompileFnctorInstanceGetPrototypeOf } from "../fnctor-instance-prototype.js";
 import {
   BUILTIN_CLASS_NAMES,
@@ -1907,7 +1907,7 @@ export function compileBuiltinStaticCall(
     isGlobalBuiltinIdentifier(ctx, fctx, propAccess.expression) &&
     propAccess.name.text === "getPrototypeOf"
   ) {
-    const es5Early = tryCompileEs5GetPrototypeOfEarly(ctx, fctx, expr);
+    const es5Early = objectGetPrototypeOf.tryCompileEs5GetPrototypeOfEarly(ctx, fctx, expr);
     if (es5Early) return es5Early;
     const arg0 = expr.arguments[0]!;
 
@@ -2037,7 +2037,7 @@ export function compileBuiltinStaticCall(
 
     const argTsType = ctx.checker.getTypeAtLocation(arg0);
 
-    const es5Value = tryCompileEs5GetPrototypeOfValue(ctx, fctx, expr);
+    const es5Value = objectGetPrototypeOf.tryCompileEs5GetPrototypeOfValue(ctx, fctx, expr);
     if (es5Value) return es5Value;
 
     // (#3013) `Object.getPrototypeOf(<array iterator>)` → the shared native
@@ -2088,7 +2088,7 @@ export function compileBuiltinStaticCall(
     }
 
     const className = resolveStructName(ctx, argTsType);
-
+    if (objectGetPrototypeOf.tryNativeCollectionGpo(ctx, fctx, arg0, argTsType)) return { kind: "externref" };
     // For known class instances, return the class prototype singleton
     if (className && ctx.classSet.has(className)) {
       // (#802 Slice C) Marked-hierarchy receiver (standalone): the instance's

--- a/src/codegen/expressions/object-get-prototype-of.ts
+++ b/src/codegen/expressions/object-get-prototype-of.ts
@@ -7,9 +7,13 @@ import { ts } from "../../ts-api.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression } from "../shared.js";
+import { emitLazyNativeProtoGet } from "../native-proto.js";
+import { tryEnsureNativeProtoBrand } from "../property-access.js";
 import { isGlobalBuiltinIdentifier } from "./calls.js";
 import { emitThrowTypeError } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
+
+const NATIVE_COLLECTION_NAMES = new Set(["Map", "Set", "WeakMap", "WeakSet"]);
 
 const ES5_FUNCTION_PROTOTYPE_CTORS = new Set([
   "Object",
@@ -54,6 +58,26 @@ function isTopLevelThis(expr: ts.Expression): boolean {
   if (expr.kind !== ts.SyntaxKind.ThisKeyword) return false;
   for (let parent = expr.parent; parent; parent = parent.parent) {
     if (ts.isFunctionLike(parent)) return false;
+  }
+  return true;
+}
+
+/** Emit the identity-stable standalone prototype for a native collection. */
+export function tryNativeCollectionGpo(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+  argTsType: ts.Type,
+): boolean {
+  if (!ctx.standalone && !ctx.wasi) return false;
+  const collectionName = argTsType.getSymbol()?.name;
+  if (collectionName === undefined || !NATIVE_COLLECTION_NAMES.has(collectionName)) return false;
+
+  const argType = compileExpression(ctx, fctx, arg);
+  if (argType) fctx.body.push({ op: "drop" });
+  const brand = tryEnsureNativeProtoBrand(ctx, collectionName);
+  if (brand === undefined || !emitLazyNativeProtoGet(ctx, fctx, brand)) {
+    fctx.body.push({ op: "ref.null.extern" });
   }
   return true;
 }

--- a/tests/issue-4740-weakset-native-instance-prototype.test.ts
+++ b/tests/issue-4740-weakset-native-instance-prototype.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #4740 — standalone native collection instances must expose their intrinsic
+// collection prototype through Object.getPrototypeOf.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const COLLECTION_PROTOTYPES = `
+  const map = Object.getPrototypeOf(new Map([])) === Map.prototype;
+  const set = Object.getPrototypeOf(new Set([])) === Set.prototype;
+  const weakMap = Object.getPrototypeOf(new WeakMap([])) === WeakMap.prototype;
+  const weakSet = Object.getPrototypeOf(new WeakSet([])) === WeakSet.prototype;
+  return (map ? 1 : 0) + (set ? 2 : 0) + (weakMap ? 4 : 0) + (weakSet ? 8 : 0);
+`;
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, { fileName: "issue-4740.ts", target: "standalone" });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  expect(result.imports ?? []).toHaveLength(0);
+  expect(WebAssembly.validate(result.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+async function runHost(source: string): Promise<number> {
+  const result = await compile(source, { fileName: "issue-4740.ts" });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  const importResult = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, importResult as WebAssembly.Imports);
+  (importResult as typeof importResult & { setInstance?: (value: WebAssembly.Instance) => void }).setInstance?.(
+    instance,
+  );
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#4740 native collection instance prototypes", () => {
+  it("returns each collection prototype in standalone", async () => {
+    expect(await runStandalone(`export function test(): number {${COLLECTION_PROTOTYPES}}`)).toBe(15);
+  });
+
+  it("preserves host collection prototype behavior", async () => {
+    expect(await runHost(`export function test(): number {${COLLECTION_PROTOTYPES}}`)).toBe(15);
+  });
+
+  it("does not change ordinary object prototype identity", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        return Object.getPrototypeOf({}) === Object.prototype ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- return intrinsic prototypes for standalone Map, Set, WeakMap, and WeakSet instances
- preserve receiver side effects while reusing identity-stable native prototype singletons
- add tracked #4740 plan/evidence and host/standalone controls

## Validation
- exact WeakSet standalone Test262 rows: 2/2 pass
- focused host/standalone controls: 3/3 pass after latest upstream merge
- TS5, TS7, lint, format, budgets, commit and pre-push hooks pass
- production change: 24 net LOC

Issue: `plan/issues/4740-weakset-native-instance-prototype.md`