### PR TITLE
fix(symbol): preserve undefined descriptions standalone

### DIFF
--- a/plan/issues/4741-symbol-description-undefined.md
+++ b/plan/issues/4741-symbol-description-undefined.md
@@ -1,0 +1,112 @@
+---
+id: 4741
+title: "ES2015 standalone Symbol.prototype.description returns null for an absent description"
+status: in-progress
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: codegen, conformance
+es_edition: es6
+language_feature: Symbol.prototype.description
+goal: standalone-mode
+source_loc_cap: 180
+loc-budget-allow:
+  - src/codegen/type-coercion.ts
+  - tests/issue-4741.test.ts
+func-budget-allow:
+  - src/codegen/type-coercion.ts::coerceType
+related: [2163, 4739, 4740]
+---
+
+# #4741 — standalone `Symbol.prototype.description` absent value
+
+## Problem
+
+The native standalone Symbol implementation stores descriptions in a nullable
+native-string slot. An absent description (`Symbol()` or
+`Symbol(undefined)`) and an out-of-range/unset slot are represented by a null
+native-string reference internally, but the public
+`Symbol.prototype.description` getter must return JavaScript `undefined`. At
+the `ref_null $AnyString` → `externref` boundary, the generic coercion
+currently emits `extern.convert_any` directly, which exposes the sentinel as
+JavaScript `null`.
+
+This is separate from the active Function descriptor work in #4739/#4740: it
+is a native-string-to-externref boundary conversion, and does not change
+function descriptor dispatch or Symbol storage.
+
+## Exact baseline (upstream/main `3809cc76e`, 2026-08-25)
+
+The repository's original Test262 runner was used with the pinned Test262
+checkout and the exact absolute test path. The host lane passes, while the
+standalone lane fails with `SameValue(null, undefined)`:
+
+```
+test/built-ins/Symbol/prototype/description/get.js
+  host:       pass
+  standalone: fail — The value of empty.description is `undefined`;
+                 Expected SameValue(«null», «undefined») to be true (line 16)
+```
+
+Standalone direct smoke also reproduces the mismatch for `Symbol()` while the
+non-empty control `Symbol("x").description === "x"` remains correct. Nearby
+candidate controls were checked before selection: Number.isFinite and
+Reflect.get abrupt-result rows pass in both lanes, and the failure is therefore
+scoped to this Symbol description conversion.
+
+## Bounded implementation plan
+
+1. In the generic `ref`/`ref_null` → `externref` coercion, recognize only a
+   nullable native-string value. Preserve the non-null native string through
+   `extern.convert_any`; map the null native-string sentinel to the canonical
+   standalone/native-strings `undefined` externref.
+2. Leave non-null native strings, ordinary GC references, host-only nullable
+   references, and Symbol description storage unchanged.
+3. Add a focused regression covering the exact Test262 getter plus direct
+   empty, `undefined`, and non-empty Symbol descriptions in standalone mode;
+   rerun a host-lane control to ensure the boundary remains valid there.
+
+## Acceptance and regression controls
+
+- The exact getter row changes from 0/1 standalone pass to 1/1, with host
+  behavior remaining 1/1.
+- `Symbol().description` and `Symbol(undefined).description` are strictly
+  `undefined`; `Symbol("").description` and `Symbol("x").description` remain
+  exact strings.
+- Standalone compilation remains host-free (zero imports for the direct
+  smoke), and the source diff stays within the 180 production-LOC cap.
+- TypeScript 5/7, focused tests, lint/format, issue checks, and LOC/function
+  budget checks pass before handoff.
+
+## Implementation Summary
+
+The `coerceType` native-string boundary now tees a nullable `$AnyString`,
+checks its null sentinel, and emits `canonicalUndefinedExternInstrs(ctx)` for
+the null arm. Non-null native strings still use `extern.convert_any`; no
+Symbol storage, property dispatch, or host import path changed.
+
+## Test Results
+
+- Exact Test262 getter: **host 1/1 pass, standalone 1/1 pass** (the baseline
+  was host 1/1 and standalone 0/1).
+- Focused Test262 controls: **6/6 pass** across host and standalone for
+  `description-symboldescriptivestring.js` and
+  `keyFor/arg-symbol-registry-miss.js`.
+- `tests/issue-4741.test.ts`: **3/3 pass** (exact host/standalone rows plus
+  zero-import direct smoke).
+- Existing `tests/issue-2163-registry-standalone.test.ts` and
+  `tests/issue-2163-tostring-standalone.test.ts`: **19/19 pass**. The older
+  `tests/issue-2163.test.ts` remains **13/14**, with its empty-string nested
+  ternary failure reproduced on the unpatched upstream base before this
+  change; it is not a regression from #4741.
+- TypeScript 5 and TypeScript 7 checks: pass.
+- Biome lint and Prettier format check: pass.
+- LOC budget: **+17 production LOC**, explicitly allowed here and below the
+  180-LOC cap. Function budget: **+17** in `coerceType`, explicitly allowed.
+- Issue/ID/spec-coverage/done-status/IR-retirement checks: pass (the issue
+  scripts retain their existing warnings for unrelated ready issues).

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -2702,6 +2702,23 @@ export function coerceType(
   //   breaking `typeof obj === "object"`, downstream `obj + n`, `obj != 0`, and
   //   any host method that runs its own ToPrimitive on the wasmGC arg.
   if ((from.kind === "ref" || from.kind === "ref_null") && to.kind === "externref") {
+    // (#4741) A missing native-string description is represented internally by
+    // a null `$AnyString` reference, but its public value is `undefined`, not
+    // JavaScript `null`. Keep the nullable native string on the stack long
+    // enough to distinguish that sentinel before crossing into externref.
+    if (ctx.nativeStrings && from.kind === "ref_null" && ctx.anyStrTypeIdx >= 0 && from.typeIdx === ctx.anyStrTypeIdx) {
+      const nativeString = allocTempLocal(fctx, from);
+      fctx.body.push({ op: "local.tee", index: nativeString });
+      fctx.body.push({ op: "ref.is_null" });
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: canonicalUndefinedExternInstrs(ctx),
+        else: [{ op: "local.get", index: nativeString }, { op: "extern.convert_any" }],
+      });
+      releaseTempLocal(fctx, nativeString);
+      return;
+    }
     const typeIdx = (from as { typeIdx: number }).typeIdx;
     const name = ctx.typeIdxToStructName.get(typeIdx);
     if (name !== undefined && toPrimitiveHint !== undefined) {

--- a/tests/issue-4741.test.ts
+++ b/tests/issue-4741.test.ts
@@ -1,0 +1,48 @@
+// #4741 — a null native-string description slot is semantic `undefined`.
+// The exact upstream getter row exercises the original Test262 harness, while
+// the direct smoke keeps the null and non-null values on the public boundary.
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const DESCRIPTION_GETTER = "built-ins/Symbol/prototype/description/get.js";
+
+describe("#4741 — standalone Symbol.prototype.description", () => {
+  it("passes the exact ES2015 getter row in standalone mode", async () => {
+    const result = await runTest262File(
+      join("test262/test", DESCRIPTION_GETTER),
+      "built-ins/Symbol/prototype/description",
+      30_000,
+      "standalone",
+    );
+    expect(result.status, `${result.file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+  });
+
+  it("keeps the exact getter row passing in the host lane", async () => {
+    const result = await runTest262File(
+      join("test262/test", DESCRIPTION_GETTER),
+      "built-ins/Symbol/prototype/description",
+      30_000,
+    );
+    expect(result.status, `${result.file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+  });
+
+  it("maps absent descriptions to undefined without changing strings", async () => {
+    const result = await compile(
+      `export function test(): number {
+        const absent = Symbol().description;
+        const explicitUndefined = Symbol(undefined).description;
+        const empty = Symbol("").description;
+        const present = Symbol("x").description;
+        return absent === undefined && explicitUndefined === undefined && empty === "" && present === "x" ? 1 : 0;
+      }`,
+      { fileName: "issue-4741.ts", target: "standalone" },
+    );
+    expect(result.success, result.success ? "" : result.errors?.map((e) => e.message).join("; ")).toBe(true);
+    const imports = WebAssembly.Module.imports(await WebAssembly.compile(result.binary));
+    expect(imports, "standalone Symbol descriptions stay host-free").toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports as { test(): number }).test()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- map nullable native-string description sentinels to canonical JavaScript `undefined`
- preserve non-null Symbol descriptions on the existing conversion path
- add tracked #4741 exact Test262 and zero-import standalone controls

## Validation
- exact Symbol description getter: host and standalone pass
- focused issue tests: 3/3 pass after latest upstream merge
- sibling Symbol controls: 19/19 pass
- TS5, TS7, lint, format, budgets, issue checks, commit and pre-push hooks pass
- production change: 17 net LOC

Issue: `plan/issues/4741-symbol-description-undefined.md`