### PR TITLE
fix(namespaces): seed ES6 toStringTag properties

### DIFF
--- a/plan/issues/4743-es2015-namespace-symbol-tostringtag.md
+++ b/plan/issues/4743-es2015-namespace-symbol-tostringtag.md
@@ -1,0 +1,80 @@
+---
+id: 4743
+title: "ES2015 standalone Math and Reflect Symbol.toStringTag descriptors"
+status: done
+sprint: current
+created: 2026-08-25
+updated: 2026-08-25
+completed: 2026-08-25
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: conformance
+area: codegen
+es_edition: es6
+language_feature: Symbol.toStringTag
+goal: standalone-mode
+source_loc_cap: 180
+loc-budget-allow:
+  - src/codegen/builtin-static-globals.ts
+func-budget-allow:
+  - src/codegen/builtin-static-globals.ts::pushBuiltinNamespaceObject
+related: [2907, 4740, 4741]
+---
+
+# #4743 — standalone namespace `Symbol.toStringTag` descriptors
+
+## Problem
+
+The standalone compiler materializes `Math`, `JSON`, and `Reflect` as native
+namespace carriers. `JSON` seeds its own non-enumerable `Symbol.toStringTag`
+property, but the analogous `Math` and `Reflect` properties are omitted. A
+computed read therefore returns `undefined`, and `propertyHelper.js` reports
+that the symbol is not an own property. This is separate from #4741's native
+string null conversion and #4740's collection prototype mapping.
+
+## Exact baseline
+
+The fresh standalone baseline JSONL fetched on 2026-08-25 (oracle version 13)
+records both exact ES2015 rows as standalone failures while the host lane passes:
+
+```
+test/built-ins/Math/Symbol.toStringTag.js
+  host: pass
+  standalone: fail — Expected SameValue(«undefined», «"Math"») to be true
+
+test/built-ins/Reflect/Symbol.toStringTag.js
+  host: pass
+  standalone: fail — Symbol() should be an own property
+```
+
+The corresponding `JSON/Symbol.toStringTag.js` row is already pass in both
+lanes, proving that the existing JSON namespace seed is the intended substrate.
+
+## Bounded implementation plan
+
+1. Extend the existing standalone namespace-carrier initialization to seed the
+   `Math` and `Reflect` `Symbol.toStringTag` data properties with their exact
+   string values.
+2. Preserve the spec descriptor flags (`writable: false`, `enumerable: false`,
+   `configurable: true`) and the existing identity-stable well-known-symbol
+   key path. Leave JSON, host mode, and unrelated namespace properties alone.
+3. Add focused host/standalone controls for both exact Test262 files, a direct
+   value check, and an ordinary namespace control to prove no host import leak.
+
+## Acceptance
+
+- Both exact rows change from standalone 0/1 to 1/1 while host remains 1/1.
+- `Math[Symbol.toStringTag] === "Math"` and
+  `Reflect[Symbol.toStringTag] === "Reflect"`; descriptors match Test262.
+- Standalone direct probes instantiate with zero host imports.
+- Production source remains below the 180-LOC cap; TS5/TS7, focused tests,
+  lint/format, issue checks, and LOC/function budgets pass.
+
+## Test Results
+
+- Exact Test262 rows: Math and Reflect both pass in host and standalone (4/4).
+- Focused zero-import namespace control: pass; focused Vitest total 5/5.
+- TypeScript 5/7, Biome, Prettier, LOC/function budgets, and issue checks: pass.
+- Production change: 24 net LOC in the issue-approved namespace carrier.

--- a/src/codegen/builtin-static-globals.ts
+++ b/src/codegen/builtin-static-globals.ts
@@ -428,6 +428,29 @@ function pushJsonNamespaceOwnPropSeed(ctx: CodegenContext, fctx: FunctionContext
   fctx.body.push({ op: "drop" });
 }
 
+/** Seed the ES2015 namespace tags omitted by the generic Math/Reflect carrier. */
+function pushMathReflectNamespaceTagSeed(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  builtinName: string,
+  objLocal: number,
+): void {
+  if ((!ctx.standalone && !ctx.wasi) || (builtinName !== "Math" && builtinName !== "Reflect")) return;
+  const defineIdx = ctx.funcMap.get("__defineProperty_value");
+  if (defineIdx === undefined) return;
+  const boxSymbolIdx = ensureLateImport(ctx, "__box_symbol", [{ kind: "i32" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (boxSymbolIdx === undefined) return;
+  fctx.body.push({ op: "local.get", index: objLocal });
+  fctx.body.push({ op: "i32.const", value: 4 }); // Symbol.toStringTag
+  fctx.body.push({ op: "call", funcIdx: boxSymbolIdx });
+  addStringConstantGlobal(ctx, builtinName);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, builtinName));
+  fctx.body.push({ op: "f64.const", value: 0x04 });
+  fctx.body.push({ op: "call", funcIdx: defineIdx });
+  fctx.body.push({ op: "drop" });
+}
+
 export function emitBuiltinNamespaceObject(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -495,6 +518,7 @@ export function emitBuiltinNamespaceObject(
     if (builtinName === "JSON") {
       pushJsonNamespaceOwnPropSeed(ctx, fctx, objLocal);
     }
+    pushMathReflectNamespaceTagSeed(ctx, fctx, builtinName, objLocal);
     // (#2984 ctor-carrier own props) The Error-family / `Array` / `Object`
     // carriers are CONSTRUCTOR objects, so they also own `length`/`name`/
     // `prototype`. No-op for the true namespaces (`Math`/`JSON`/`Reflect`),

--- a/tests/issue-4743.test.ts
+++ b/tests/issue-4743.test.ts
@@ -1,0 +1,42 @@
+// #4743 — standalone namespace carriers must expose ES2015 Symbol.toStringTag.
+// The exact Test262 rows validate value and descriptor semantics; the direct
+// smoke proves the new carrier seeds stay host-free.
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const NAMESPACE_TAG_ROWS = ["built-ins/Math/Symbol.toStringTag.js", "built-ins/Reflect/Symbol.toStringTag.js"] as const;
+
+describe("#4743 — standalone Math and Reflect Symbol.toStringTag", () => {
+  for (const row of NAMESPACE_TAG_ROWS) {
+    it(`passes the exact ${row} row in standalone mode`, async () => {
+      const result = await runTest262File(
+        join("test262/test", row),
+        row.slice(0, row.lastIndexOf("/")),
+        30_000,
+        "standalone",
+      );
+      expect(result.status, `${result.file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    });
+
+    it(`keeps the exact ${row} row passing in the host lane`, async () => {
+      const result = await runTest262File(join("test262/test", row), row.slice(0, row.lastIndexOf("/")), 30_000);
+      expect(result.status, `${result.file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    });
+  }
+
+  it("returns both namespace tags without standalone host imports", async () => {
+    const result = await compile(
+      `export function test(): number {
+        return Math[Symbol.toStringTag] === "Math" && Reflect[Symbol.toStringTag] === "Reflect" ? 1 : 0;
+      }`,
+      { fileName: "issue-4743.ts", target: "standalone" },
+    );
+    expect(result.success, result.success ? "" : result.errors?.map((e) => e.message).join("; ")).toBe(true);
+    const imports = WebAssembly.Module.imports(await WebAssembly.compile(result.binary));
+    expect(imports, "namespace tag reads stay host-free").toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports as { test(): number }).test()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- seed standalone Math and Reflect namespace carriers with exact `Symbol.toStringTag` values
- preserve ES6 descriptor flags and the existing identity-stable well-known-symbol path
- add tracked #4743 plan/evidence and exact host/standalone coverage

## Validation
- exact Math and Reflect Test262 rows: host + standalone 4/4 pass
- focused zero-import namespace control: pass; total 5/5 after latest upstream merge
- TS5, TS7, lint, format, budgets, issue checks, commit and pre-push hooks pass
- production change: 24 net LOC

Issue: `plan/issues/4743-es2015-namespace-symbol-tostringtag.md`