### PR TITLE
fix(reflect): tombstone host closed-struct deletions

### DIFF
--- a/plan/issues/4745-es2015-reflect-deleteproperty-host-tombstone.md
+++ b/plan/issues/4745-es2015-reflect-deleteproperty-host-tombstone.md
@@ -1,10 +1,11 @@
 ---
 id: 4745
 title: "ES2015 Reflect.deleteProperty host closed-struct tombstone"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-26
 updated: 2026-08-26
+completed: 2026-08-26
 priority: high
 horizon: s
 feasibility: medium
@@ -17,6 +18,7 @@ goal: test262-conformance
 source_loc_cap: 180
 loc-budget-allow:
   - src/runtime.ts
+  - src/runtime/wasm-struct-host-semantics.ts
   - src/codegen/source-scan-predicates.ts
   - src/codegen/index.ts
   - src/codegen/context/types.ts

--- a/plan/issues/4745-es2015-reflect-deleteproperty-host-tombstone.md
+++ b/plan/issues/4745-es2015-reflect-deleteproperty-host-tombstone.md
@@ -1,0 +1,128 @@
+---
+id: 4745
+title: "ES2015 Reflect.deleteProperty host closed-struct tombstone"
+status: in-progress
+sprint: current
+created: 2026-08-26
+updated: 2026-08-26
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: runtime, codegen, conformance
+es_edition: es6
+language_feature: Reflect.deleteProperty
+goal: test262-conformance
+source_loc_cap: 180
+loc-budget-allow:
+  - src/runtime.ts
+  - src/codegen/source-scan-predicates.ts
+  - src/codegen/index.ts
+  - src/codegen/context/types.ts
+  - src/codegen/object-ops.ts
+func-budget-allow:
+  - src/runtime.ts::_wrapForHost
+  - src/codegen/source-scan-predicates.ts::scanMemberDeletes
+  - src/codegen/index.ts::generateModule
+  - src/codegen/object-ops.ts::compilePropertyIntrospection
+related: [4129, 2046, 4742, 4744]
+origin: "ES2015 residual census on upstream/main 8ddcd9b2b; distinct from the active Date.parse (#4742) and Array iterator (#4744) slices."
+---
+
+# #4745 — host `Reflect.deleteProperty` closed-struct tombstone
+
+## Scope
+
+This issue owns the host/WasmGC residual in the two ES2015 rows below. A
+compiled object literal is a fixed-shape WasmGC struct. Host
+`Reflect.deleteProperty` wraps that struct in `_wrapForHost`, but the proxy's
+delete trap previously removed only sidecar entries. The fixed field therefore
+remained visible to the compiled `hasOwnProperty` shape fold.
+
+The standalone non-`$Object` `Reflect.deleteProperty` refusal is already tracked
+by #4129/#2046 and is deliberately not changed here.
+
+## Exact rows and baseline
+
+Measured on `upstream/main` `9efc8e766` (the source-equivalent scheduled
+baseline-sync successor of `8ddcd9b2b`) with the authoritative assembled
+`runTest262File` runner and the pinned Test262 checkout:
+
+```text
+test/built-ins/Reflect/deleteProperty/delete-properties.js
+  host: fail — Expected SameValue(«true», «false») at o.hasOwnProperty('prop')
+  standalone: fail — TypeError: Reflect.deleteProperty called on non-object
+
+test/built-ins/Reflect/deleteProperty/return-boolean.js
+  host: fail — Expected SameValue(«true», «false») at Reflect.deleteProperty(o, 'p1')
+  standalone: pass
+```
+
+The host failures are one family: the call is routed through the host proxy,
+while the subsequent closed-struct own-property call is compile-time folded.
+The standalone failure is an excluded, pre-existing ownership boundary.
+
+Adjacent host controls were passing on the baseline and remain controls:
+
+```text
+delete-symbol-properties.js: pass
+target-is-not-object-throws.js: pass
+target-is-symbol-throws.js: pass
+```
+
+## Bounded implementation plan
+
+1. Make `_wrapForHost`'s WasmGC delete trap mirror `__delete_property`: honor
+   frozen/sealed and non-configurable descriptor state, remove sidecar and
+   accessor metadata, and record a `_wasmStructDeletedKeys` tombstone. During
+   module initialization the export view may not yet expose the struct shape;
+   an unresolved delete is recorded so the later host own-property query sees
+   the operation.
+2. Extend the existing cheap source pre-scan to recognize
+   `Reflect.deleteProperty(receiver, key)`. For host modules containing that
+   spelling, route `receiver.hasOwnProperty(key)` through the host predicate
+   instead of folding from the immutable struct shape. Existing delete-free
+   modules retain the no-scan/no-runtime-call path; standalone behavior keeps
+   its current native lowering.
+3. Add exact Test262 pins plus symbol/target-validation and standalone controls.
+   Do not widen standalone Reflect support or touch the active #4742/#4744
+   implementation files.
+
+## Acceptance
+
+- Both exact host rows pass, including the frozen false-return assertion.
+- Adjacent host controls and the standalone boolean-return control remain green.
+- The standalone non-`$Object` row remains attributed to #4129/#2046.
+- Production source delta remains ≤180 changed lines.
+- TS5, TS7, lint, format, focused tests, issue checks, budgets, hooks, and
+  post-upstream-merge validation pass.
+
+## Test Results
+
+Baseline on upstream/main `9efc8e766`:
+
+```text
+host exact rows: 0/2 pass
+standalone controls: delete-properties fail (owned by #4129/#2046), return-boolean pass
+adjacent host controls: 3/3 pass
+```
+
+Implementation on merged upstream `9efc8e766`:
+
+```text
+host exact rows: 2/2 pass
+adjacent host controls: 3/3 pass
+standalone return-boolean control: pass
+focused Vitest/Test262 suite: 6/6 pass
+TypeScript 5 check: pass
+TypeScript 7 check: pass
+Prettier check: pass
+LOC budget: pass, net +60 production LOC (≤180 cap)
+function budget: pass
+issue-ID and issue/spec checks: pass (repository warnings are pre-existing)
+```
+
+Biome lint reports eight pre-existing diagnostics in unrelated lines of the
+large `src/runtime.ts` file; the new `tests/issue-4745.test.ts` is lint-clean,
+and no diagnostic overlaps the changed ranges.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -3538,9 +3538,10 @@ export interface CodegenContext extends StandaloneCapabilityDemandState, BodyRou
    *  runs it after `setExports` (symmetric with the standalone `_start` model).
    *  Default false. WASI is unaffected. */
   deferTopLevelInit: boolean;
-  /** (#2179) True when the module body contains any `delete` of a property or
-   *  element access (e.g. `delete o.a` / `delete o[k]`). Pre-scanned once at
-   *  module setup. When true, `any`/`unknown`-typed property READS in JS-host
+  /** (#2179/#4745) True when the module body contains any `delete` of a
+   *  property or element access (e.g. `delete o.a` / `delete o[k]`) or
+   *  `Reflect.deleteProperty(o, k)`. Pre-scanned once at module setup. When
+   *  true, `any`/`unknown`-typed property READS in JS-host
    *  mode are routed through the tombstone-aware `__extern_get` host helper
    *  instead of the inline `ref.test`+`struct.get` fast-path — the fast-path
    *  reads the live WasmGC field and bypasses the runtime delete tombstone, so
@@ -3565,13 +3566,13 @@ export interface CodegenContext extends StandaloneCapabilityDemandState, BodyRou
    *  module reading `.constructor` anywhere, including ones only ever asking
    *  about a primitive wrapper (#4034's unconditional-pull-in hazard). */
   plainCtorCarrierDemanded?: boolean;
-  /** (#4187) Identifier names appearing as the receiver of a member delete
-   *  (`delete r.k` / `delete r[e]`), pre-scanned by
-   *  `scanModuleMemberDeletes`. Consulted ONLY by the standalone arm of
-   *  the `hasOwnProperty`/`propertyIsEnumerable` routing gate in
-   *  `compilePropertyIntrospection`: a receiver that saw `Object.defineProperty`
-   *  AND appears here can have its const-fold disagree with runtime state, so it
-   *  routes to the runtime helper. Empty for nearly every module. */
+  /** (#4187/#4745) Identifier names appearing as the receiver of a member
+   *  delete (`delete r.k` / `delete r[e]`) or Reflect.deleteProperty(r, …),
+   *  pre-scanned by `scanModuleMemberDeletes`. Consulted by the
+   *  `hasOwnProperty`/`propertyIsEnumerable` routing gate in
+   *  `compilePropertyIntrospection`: a receiver that may have been deleted from
+   *  can have its const-fold disagree with runtime state, so it routes to the
+   *  runtime helper. Empty for nearly every module. */
   memberDeleteReceiverNames?: ReadonlySet<string>;
   /** (#1472 Phase A) Set of dynamic-shape object/property host-import names
    *  already refused under `--target standalone`, used to deduplicate the

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4465,16 +4465,18 @@ export function generateModule(
       ctx.topLevelFunctionNames.add(stmt.name.text);
     }
   }
-  // (#2179) Pre-scan for `delete <member>` so `any`-receiver property reads can
+  // (#2179/#4745) Pre-scan for `delete <member>` and Reflect.deleteProperty so
+  // `any`-receiver property reads can
   // be routed through the tombstone-aware `__extern_get` host helper instead of
   // the inline struct.get fast-path (which reads the live field and ignores the
   // runtime delete tombstone). Delete-free modules keep byte-identical output.
   // (#4187) ONE walk answers both: the #2179 boolean above and the receiver
-  // names the standalone hasOwnProperty const-fold gate needs (it only diverges
+  // names the hasOwnProperty const-fold gate needs (it only diverges
   // from runtime state for a receiver that is both defineProperty-widened and
-  // deleted from). Only standalone reads the names, and collecting them forfeits
-  // the boolean's short-circuit — worth +3,847 on the #3437 harness budget — so
-  // host mode asks for the boolean alone and keeps main's exact traversal.
+  // deleted from). Host modules containing Reflect.deleteProperty also collect
+  // receiver names so closed-struct hasOwnProperty folds consult the host
+  // tombstone sidecar. Other host modules still ask for the boolean alone and
+  // keep main's exact traversal.
   // (#4223) Demand gate for the primitive-wrapper `.constructor` carriers. Set
   // BEFORE anything can call `ensureObjectRuntime` (which is where the mint
   // hangs), and only for standalone — the gc/host lane keeps its genuine
@@ -4483,7 +4485,9 @@ export function generateModule(
   // (#4232) Narrower gate for the ordinary-object arm alone — see
   // `moduleMentionsObjectIdentifier` for why it cannot ride the flag above.
   ctx.plainCtorCarrierDemanded = ctx.wrapperCtorCarrierDemanded && moduleMentionsObjectIdentifier(ast.sourceFile);
-  const memberDeletes = scanModuleMemberDeletes(ast.sourceFile, ctx.standalone === true);
+  const collectMemberDeleteReceivers =
+    ctx.standalone === true || ast.sourceFile.text.includes("Reflect.deleteProperty");
+  const memberDeletes = scanModuleMemberDeletes(ast.sourceFile, collectMemberDeleteReceivers);
   ctx.moduleUsesDelete = memberDeletes.any;
   ctx.memberDeleteReceiverNames = memberDeletes.receiverNames;
   // (#2660 S1) Whole-program escape / dynamic-use classification of `new F()`

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -4940,6 +4940,13 @@ export function compilePropertyIntrospection(
       // from the same mechanism. See `scanModuleMemberDeletes`.
       const standaloneDeleteObserved =
         ctx.standalone && recvVarName !== undefined && (ctx.memberDeleteReceiverNames?.has(recvVarName) ?? false);
+      // (#4745) Host Reflect.deleteProperty mutates the runtime sidecar, while
+      // a closed-struct hasOwnProperty call would otherwise fold from its
+      // immutable shape. Route that receiver through the host predicate even
+      // when no Object.defineProperty widening is present.
+      const hostReflectDeleteObserved =
+        !ctx.standalone && recvVarName !== undefined && (ctx.memberDeleteReceiverNames?.has(recvVarName) ?? false);
+      if (hostReflectDeleteObserved) needsRuntime = true;
       if (!needsRuntime && (!ctx.standalone || standaloneDeleteObserved)) {
         for (const k of ctx.definePropertyReceiverKeys) {
           if (k.startsWith(prefix)) {

--- a/src/codegen/source-scan-predicates.ts
+++ b/src/codegen/source-scan-predicates.ts
@@ -38,14 +38,14 @@ export function sourceContainsClass(sourceFile: ts.SourceFile): boolean {
  * short-circuit unconditionally cost **+3,847** on the #3437 harness
  * compile-work budget (111,568 → 115,415), which meters shared-helper
  * `forEachChild` invocations over a fixture whose prelude is prepended to all
- * ~43k test262 files. Since `memberDeleteReceiverNames` is read only by the
- * STANDALONE arm of the `hasOwnProperty` routing gate, host-mode callers pass
- * `false` and keep main's exact traversal — the budget fixture compiles in host
- * mode and returns to 111,568.
+ * ~43k test262 files. Host-mode callers still pass `false` unless the source
+ * contains the narrow `Reflect.deleteProperty` spelling (#4745), preserving
+ * the baseline traversal for the common case.
  *
- * @returns `any` — a `delete o.a` / `delete o[k]` occurs somewhere (a no-op
- *   `delete x` of a bare identifier does NOT count: it leaves no tombstone for
- *   the inline `struct.get` read fast-path to miss).
+ * @returns `any` — a `delete o.a` / `delete o[k]` or
+ *   `Reflect.deleteProperty(o, k)` occurs somewhere (a no-op `delete x` of a
+ *   bare identifier does NOT count: it leaves no tombstone for the inline
+ *   `struct.get` read fast-path to miss).
  * @returns `receiverNames` — see {@link scanModuleMemberDeletes}; empty
  *   when `collectReceivers` is false. A strict subset of what sets `any`:
  *   `delete a.b.c` and `delete f().x` have no identifier receiver, so they set
@@ -70,6 +70,23 @@ function scanMemberDeletes(
         if (!collectReceivers) return;
       }
     }
+    // Reflect.deleteProperty(target, key) has the same observable tombstone
+    // effect as the delete operator, but its target is the first call
+    // argument rather than a member-expression receiver. Keep it in this
+    // pre-scan so host hasOwnProperty reads do not fold past a Reflect delete.
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "deleteProperty" &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === "Reflect" &&
+      node.arguments.length >= 2
+    ) {
+      anyDelete = true;
+      const receiver = node.arguments[0];
+      if (collectReceivers && ts.isIdentifier(receiver)) receiverNames.add(receiver.text);
+      if (!collectReceivers) return;
+    }
     forEachChild(node, walk);
   }
   walk(sourceFile);
@@ -78,32 +95,33 @@ function scanMemberDeletes(
 
 /**
  * Both member-delete answers from ONE walk — the module-setup entry point.
- * Pass `collectReceivers: false` outside `--target standalone`; nothing reads
- * the names there and the boolean-only walk short-circuits (see
+ * Pass `collectReceivers: false` outside `--target standalone` unless the
+ * source contains `Reflect.deleteProperty`; the host gate needs those target
+ * names, while the common boolean-only walk still short-circuits (see
  * {@link scanMemberDeletes} for the measured cost).
  *
  * ---
  *
- * (#2179) `any` is true when the source contains a `delete` operating on a
- * property or element access (`delete o.a` / `delete o[k]`). `delete x` of a
- * bare identifier and `delete <other expr>` (no-op deletes) do NOT count — only
- * member deletes can leave a runtime tombstone that the inline `struct.get`
- * read fast-path would bypass. Gates the tombstone-aware read routing so
- * delete-free modules emit byte-identical wasm.
+ * (#2179/#4745) `any` is true when the source contains a `delete` operating on
+ * a property or element access (`delete o.a` / `delete o[k]`) or a
+ * `Reflect.deleteProperty(o, k)` call. `delete x` of a bare identifier and
+ * `delete <other expr>` (no-op deletes) do NOT count — only operations that can
+ * leave a runtime tombstone need the tombstone-aware read routing. Delete-free
+ * modules emit byte-identical wasm.
  *
  * ---
  *
- * (#4187) `receiverNames` holds identifier names used as the RECEIVER of a
- * member delete anywhere in the program — `delete r.k` / `delete r[e]` yields
- * `r`.
+ * (#4187/#4745) `receiverNames` holds identifier names used as the RECEIVER of
+ * a member delete anywhere in the program — `delete r.k` / `delete r[e]` yields
+ * `r`; `Reflect.deleteProperty(r, k)` yields the first argument `r`.
  *
- * Consumed by `compilePropertyIntrospection` to decide whether a STANDALONE
- * `r.hasOwnProperty(k)` / `r.propertyIsEnumerable(k)` on a receiver that also
- * saw an `Object.defineProperty` may keep its compile-time constant fold. The
- * fold answers from the (defineProperty-widened) struct SHAPE, which no runtime
- * `delete` can retract, so it and the runtime state diverge for exactly the
- * receivers that appear here — and only for those. Receivers never deleted from
- * keep folding, so the overwhelming majority of modules stay byte-identical.
+ * Consumed by `compilePropertyIntrospection` to decide whether an
+ * `r.hasOwnProperty(k)` / `r.propertyIsEnumerable(k)` on a receiver that may
+ * have been deleted from can keep its compile-time constant fold. The fold
+ * answers from the struct SHAPE, which no runtime delete retracts, so it and
+ * runtime state diverge for exactly the receivers that appear here — and only
+ * for those. Receivers never deleted from keep folding, so the overwhelming
+ * majority of modules stay byte-identical.
  *
  * Why a whole-program PRE-SCAN and not record-as-you-compile: in the canonical
  * repro the first read (`obj.hasOwnProperty("property")`, expected `true`)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7531,11 +7531,41 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
           }
         }
       }
-      // Always report success — Array.prototype.pop etc. call
-      // `delete O[len-1]` on sparse arrayLikes where the index may not be
-      // present in the sidecar. Returning false here throws a Proxy
-      // invariant TypeError. Sidecar delete is best-effort.
+      // (#4745) Reflect.deleteProperty reaches this proxy before the generated
+      // exports are available when the call runs in module initialization.
+      // Keep the same own-property and integrity checks as __delete_property;
+      // otherwise deleting a fixed struct field only removes a sidecar entry
+      // (if one exists), and the field reappears through its struct shape.
+      const normalizedKey = typeof key === "symbol" ? key : String(key);
+      const hasOwn = _wasmStructHasOwn(obj, normalizedKey, liveExports);
+      const descs = _wasmPropDescs.get(obj);
+      const flags = descs?.get(normalizedKey);
+      if (
+        ((hasOwn || liveExports === undefined) && (_wasmFrozenObjs.has(obj) || _wasmSealedObjs.has(obj))) ||
+        (flags !== undefined && !(flags & _SC_CONFIGURABLE))
+      ) {
+        return false;
+      }
+      // Always report success for an absent key — Array.prototype.pop etc.
+      // call `delete O[len-1]` on sparse arrayLikes where the index may not be
+      // present in the sidecar. Returning false here throws a Proxy invariant
+      // TypeError. Sidecar delete is best-effort.
       _sidecarDelete(obj, key);
+      if (descs) descs.delete(normalizedKey);
+      if (typeof key === "symbol") {
+        _wasmStructAccessors.get(obj)?.delete(key);
+      }
+      // A module-init call cannot discover the fixed struct shape until
+      // setExports wires the getters. Treat that unresolved delete as an own
+      // deletion; with exports available, only tombstone a confirmed own key.
+      if (hasOwn || liveExports === undefined) {
+        let tomb = _wasmStructDeletedKeys.get(obj);
+        if (!tomb) {
+          tomb = new Set<string | symbol>();
+          _wasmStructDeletedKeys.set(obj, tomb);
+        }
+        tomb.add(normalizedKey);
+      }
       // #1364b — if `obj` is a registered class prototype or class object and
       // `key` is a method/static name from its allowlist, mark it deleted so
       // subsequent `Object.getOwnPropertyDescriptor(obj, key)` returns

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7531,41 +7531,17 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
           }
         }
       }
-      // (#4745) Reflect.deleteProperty reaches this proxy before the generated
-      // exports are available when the call runs in module initialization.
-      // Keep the same own-property and integrity checks as __delete_property;
-      // otherwise deleting a fixed struct field only removes a sidecar entry
-      // (if one exists), and the field reappears through its struct shape.
-      const normalizedKey = typeof key === "symbol" ? key : String(key);
-      const hasOwn = _wasmStructHasOwn(obj, normalizedKey, liveExports);
-      const descs = _wasmPropDescs.get(obj);
-      const flags = descs?.get(normalizedKey);
       if (
-        ((hasOwn || liveExports === undefined) && (_wasmFrozenObjs.has(obj) || _wasmSealedObjs.has(obj))) ||
-        (flags !== undefined && !(flags & _SC_CONFIGURABLE))
-      ) {
+        !wsh.deleteStructProperty(obj, key, liveExports, {
+          hasOwn: _wasmStructHasOwn,
+          sidecarDelete: _sidecarDelete,
+          propDescs: _wasmPropDescs,
+          accessors: _wasmStructAccessors,
+          deletedKeys: _wasmStructDeletedKeys,
+          integrity: [_wasmFrozenObjs, _wasmSealedObjs],
+        })
+      )
         return false;
-      }
-      // Always report success for an absent key — Array.prototype.pop etc.
-      // call `delete O[len-1]` on sparse arrayLikes where the index may not be
-      // present in the sidecar. Returning false here throws a Proxy invariant
-      // TypeError. Sidecar delete is best-effort.
-      _sidecarDelete(obj, key);
-      if (descs) descs.delete(normalizedKey);
-      if (typeof key === "symbol") {
-        _wasmStructAccessors.get(obj)?.delete(key);
-      }
-      // A module-init call cannot discover the fixed struct shape until
-      // setExports wires the getters. Treat that unresolved delete as an own
-      // deletion; with exports available, only tombstone a confirmed own key.
-      if (hasOwn || liveExports === undefined) {
-        let tomb = _wasmStructDeletedKeys.get(obj);
-        if (!tomb) {
-          tomb = new Set<string | symbol>();
-          _wasmStructDeletedKeys.set(obj, tomb);
-        }
-        tomb.add(normalizedKey);
-      }
       // #1364b — if `obj` is a registered class prototype or class object and
       // `key` is a method/static name from its allowlist, mark it deleted so
       // subsequent `Object.getOwnPropertyDescriptor(obj, key)` returns

--- a/src/runtime/wasm-struct-host-semantics.ts
+++ b/src/runtime/wasm-struct-host-semantics.ts
@@ -3,6 +3,7 @@
 
 export const NO_GENERATED_FIELD = Symbol("no-generated-field");
 export const PRIMITIVE_STRING_UNDEFINED = Symbol("primitive-string-undefined");
+const CONFIGURABLE_FLAG = 4;
 const PRIMITIVE_STRING_INTRINSICS: Readonly<Record<string, Function | undefined>> = Object.freeze({
   charAt: String.prototype.charAt,
   charCodeAt: String.prototype.charCodeAt,
@@ -55,6 +56,46 @@ export function readField(
 
 export function ordinaryFields(fields: readonly string[] | null): boolean {
   return fields !== null && !fields.includes("__tag");
+}
+
+interface StructDeleteState {
+  hasOwn: (obj: object, key: PropertyKey, exports: Record<string, Function> | undefined) => boolean;
+  sidecarDelete: (obj: object, key: PropertyKey) => boolean;
+  propDescs: WeakMap<object, Map<PropertyKey, number>>;
+  accessors: WeakMap<object, Map<PropertyKey, { get?: Function; set?: Function }>>;
+  deletedKeys: WeakMap<object, Set<PropertyKey>>;
+  integrity: readonly [WeakSet<object>, WeakSet<object>];
+}
+
+/** Apply host-proxy deletion semantics to a fixed-shape WasmGC struct. */
+export function deleteStructProperty(
+  obj: object,
+  key: PropertyKey,
+  exports: Record<string, Function> | undefined,
+  state: StructDeleteState,
+): boolean {
+  const normalizedKey = typeof key === "symbol" ? key : String(key);
+  const hasOwn = state.hasOwn(obj, normalizedKey, exports);
+  const descs = state.propDescs.get(obj);
+  const flags = descs?.get(normalizedKey);
+  if (
+    ((hasOwn || exports === undefined) && state.integrity.some((objects) => objects.has(obj))) ||
+    (flags !== undefined && !(flags & CONFIGURABLE_FLAG))
+  ) {
+    return false;
+  }
+  state.sidecarDelete(obj, key);
+  descs?.delete(normalizedKey);
+  if (typeof key === "symbol") state.accessors.get(obj)?.delete(key);
+  if (hasOwn || exports === undefined) {
+    let tombstones = state.deletedKeys.get(obj);
+    if (!tombstones) {
+      tombstones = new Set<PropertyKey>();
+      state.deletedKeys.set(obj, tombstones);
+    }
+    tombstones.add(normalizedKey);
+  }
+  return true;
 }
 
 export function unboxSymbol(cache: Map<number, symbol>, value: unknown): number {

--- a/tests/issue-4745.test.ts
+++ b/tests/issue-4745.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4745 — host Reflect.deleteProperty must retract a closed-struct field from
+// the runtime own-property view, including when the call happens during the
+// Test262 module-initialization path before the callback exports are wired.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262 = join("test262", "test");
+const HAVE_TEST262 = existsSync(join(TEST262, "built-ins", "Reflect", "deleteProperty", "delete-properties.js"));
+
+const run = (relative: string, target?: "standalone") =>
+  runTest262File(join(TEST262, relative), "issue-4745", 30_000, target);
+
+describe.skipIf(!HAVE_TEST262)("#4745 — Reflect.deleteProperty struct tombstones", () => {
+  it.each([
+    "built-ins/Reflect/deleteProperty/delete-properties.js",
+    "built-ins/Reflect/deleteProperty/return-boolean.js",
+  ])("host exact row passes: %s", async (relative) => {
+    const result = await run(relative);
+    expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+  });
+
+  it.each([
+    "built-ins/Reflect/deleteProperty/delete-symbol-properties.js",
+    "built-ins/Reflect/deleteProperty/target-is-not-object-throws.js",
+    "built-ins/Reflect/deleteProperty/target-is-symbol-throws.js",
+  ])("host control remains passing: %s", async (relative) => {
+    const result = await run(relative);
+    expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+  });
+
+  it("keeps the standalone boolean-return control passing", async () => {
+    const result = await run("built-ins/Reflect/deleteProperty/return-boolean.js", "standalone");
+    expect(`${result.status}: ${result.error ?? ""}`).toBe("pass: ");
+  });
+});


### PR DESCRIPTION
## Summary
- record host-side WasmGC struct deletions in the runtime tombstone set
- honor integrity descriptors in the host proxy delete trap
- route affected closed-struct `hasOwnProperty` checks through the host predicate
- track the implementation and evidence in `plan/issues/4745-es2015-reflect-deleteproperty-host-tombstone.md`

## Validation
- exact owned host Test262 rows: 2/2 pass (baseline 0/2)
- adjacent host controls 3/3 and standalone boolean-return control pass
- focused suite 6/6
- TS5/TS7, lint, format, LOC/function/oracle/coercion/issue gates pass

The remaining standalone non-`$Object` row is intentionally owned by #4129/#2046.