### PR TITLE
fix(promises): seed standalone Promise constructor properties

### DIFF
--- a/plan/issues/4746-es2015-promise-property-order.md
+++ b/plan/issues/4746-es2015-promise-property-order.md
@@ -1,0 +1,115 @@
+---
+id: 4746
+title: "ES2015 Promise constructor property order"
+status: done
+sprint: current
+created: 2026-08-26
+updated: 2026-08-26
+completed: 2026-08-26
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: promises, builtins, conformance
+es_edition: es2015
+language_feature: Promise-constructor
+goal: test262-conformance
+source_loc_cap: 120
+related: [2671, 2739]
+---
+
+# #4746 — ES2015 Promise constructor property order
+
+## Scope
+
+This issue owns the exact ES2015 Test262 row
+`test/built-ins/Promise/property-order.js`. The row checks that the Promise
+constructor's own `length` property precedes its own `name` property in
+`Object.getOwnPropertyNames(Promise)`. The fix must preserve the existing
+Promise constructor behavior and the property order of unrelated built-ins.
+
+The initial baseline and emitted-Wasm inspection will establish whether the
+failure is in the standalone Promise constructor's static property
+registration, the generic own-property ordering path, or the test harness.
+The implementation will be wired at the narrowest confirmed site. Host and
+standalone Promise behavior are both in scope; unrelated Promise instance,
+combinator, subclass, and asynchronous scheduling residuals are excluded.
+
+## Baseline
+
+Measured on upstream/main commit `9efc8e766` with fresh Node processes for
+each row. The exact target passes in host but fails in standalone with the
+Test262 assertion. A direct numeric probe showed the host Promise has
+`length` at index 0 and `name` at index 1, while standalone Promise has no
+own properties at all (`Object.getOwnPropertyNames(Promise).length === 0`).
+The host controls all pass. Standalone Object property order passes; the
+standalone Function control reaches a pre-existing illegal-cast failure, and
+the standalone Promise resolve/reject-function controls fail their own
+`length`/`name` assertions. The standalone measurements used the local
+interpreter refusal provider because the QuickJS artifact is not available in
+this environment; the target itself is independent of dynamic evaluation.
+
+| Test262 row | Host | Standalone |
+| --- | --- | --- |
+| `built-ins/Promise/property-order.js` (exact target) | pass | **fail** — `Promise` carrier has zero own properties |
+| `built-ins/Function/property-order.js` (control) | pass | fail — pre-existing illegal cast in `__module_init` |
+| `built-ins/Object/property-order.js` (control) | pass | pass |
+| `built-ins/Promise/resolve-function-property-order.js` (control) | pass | fail — callback function property order |
+| `built-ins/Promise/reject-function-property-order.js` (control) | pass | fail — callback function property order |
+
+## Bounded implementation plan
+
+1. Reproduce the exact row on the upstream/main worktree in both lanes and
+   confirm the issue is not already fixed or silently skipped. Capture the
+   expected native order and the compiler's returned order/error.
+2. Trace the Promise constructor creation and own-property enumeration path.
+   The current standalone constructor identity set omits `Promise`, so its
+   bare value falls through without the existing constructor carrier and
+   `pushBuiltinCtorOwnPropSeed` cannot install `length`/`name`/`prototype`.
+3. Add `Promise` to the existing standalone constructor-identity set. Reuse
+   the established carrier seeding path, which installs the spec's
+   non-enumerable `length`, `name`, and native-prototype properties in order;
+   do not broaden generic object enumeration or callback-function metadata.
+   Add an explicit regression test under `tests/issue-4746.test.ts` that drives
+   the exact row through host and standalone execution, plus the Object
+   property-order control and a direct carrier probe.
+4. Rerun the exact row, controls, and focused regression test in fresh
+   processes. Check the changed-file format/lint/type gates and source/function
+   budgets, then merge the latest upstream/main without rebasing and rerun the
+   focused checks.
+
+## Acceptance
+
+- `built-ins/Promise/property-order.js` passes in host and standalone lanes.
+- The Promise constructor still exposes the same own properties and values,
+  with `length` immediately before `name`.
+- The selected Function/Object property-order controls remain unchanged.
+- The patch stays within the stated source budget and does not alter generic
+  property enumeration, Promise instance settlement, combinators, or subclass
+  behavior.
+
+## Test Results
+
+Baseline (upstream/main `9efc8e766`):
+
+```
+exact Promise/property-order: host pass; standalone fail (Promise had zero own properties)
+Function/property-order control: host pass; standalone pre-existing illegal cast
+Object/property-order control: host pass; standalone pass
+Promise resolve/reject-function-property-order controls: host pass; standalone fail (callback metadata residual)
+```
+
+Post-fix (after fast-forward merge of upstream/main `ed7ecba7c`):
+
+```
+direct Promise constructor index probe (length index * 100 + name index): host 1; standalone 1
+exact Promise/property-order: host pass; standalone pass
+Object/property-order control: host pass; standalone pass
+focused tests/issue-4746.test.ts: 4/4 pass
+```
+
+The standalone checks use the local interpreter refusal provider because the
+QuickJS artifact is unavailable in this environment; this row does not invoke
+dynamic evaluation. The Promise resolve/reject callback metadata residual is
+intentionally outside this constructor-carrier slice.

--- a/src/codegen/builtin-static-globals.ts
+++ b/src/codegen/builtin-static-globals.ts
@@ -82,6 +82,10 @@ export function isSupportedBuiltinNamespace(name: string): boolean {
  * untouched.
  */
 export const BUILTIN_CONSTRUCTOR_IDENTITY_NAMES: ReadonlySet<string> = new Set([
+  // (#4746) Promise's standalone bare value uses the same reified constructor
+  // carrier as the other native constructors, so runtime own-property
+  // reflection sees its spec `length`, `name`, and `prototype` properties.
+  "Promise",
   "Set",
   "Map",
   "WeakMap",

--- a/tests/issue-4746.test.ts
+++ b/tests/issue-4746.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4746 — standalone Promise constructor own-property order.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262 = join(__dirname, "..", "test262");
+const HAVE_TEST262 = existsSync(join(TEST262, "harness", "assert.js"));
+
+const abs = (relative: string) => join(TEST262, "test", relative);
+
+async function run(relative: string, target?: "standalone") {
+  return runTest262File(abs(relative), "issue-4746", 60_000, target);
+}
+
+describe.skipIf(!HAVE_TEST262)("#4746 — Promise constructor property order", () => {
+  it("passes the exact row in the host lane", async () => {
+    const result = await run("built-ins/Promise/property-order.js");
+    expect(result.status, result.error ?? result.reason).toBe("pass");
+  });
+
+  it("passes the exact row in the standalone lane", async () => {
+    const result = await run("built-ins/Promise/property-order.js", "standalone");
+    expect(result.status, result.error ?? result.reason).toBe("pass");
+  });
+
+  // Object's constructor carrier exercises the same own-key reflection path
+  // without depending on Promise's native async state or callback closures.
+  it.each([undefined, "standalone"] as const)("keeps Object constructor order in %s", async (target) => {
+    const result = await run("built-ins/Object/property-order.js", target ?? undefined);
+    expect(result.status, result.error ?? result.reason).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary
- add `Promise` to standalone native constructor identity seeding
- restore the ES2015 constructor own-property ordering (`length` before `name`)
- track diagnosis, plan, and evidence in `plan/issues/4746-es2015-promise-property-order.md`

## Validation
- exact Promise property-order Test262 row in host and standalone
- Object constructor property-order controls in both lanes
- focused suite 4/4 after the final upstream merge
- Prettier, Biome, LOC/function budgets, native-first import policy, and issue checks pass