### PR TITLE
fix(es6): restore StringIteratorPrototype toStringTag

### DIFF
--- a/plan/issues/4747-es2015-string-iterator-tag.md
+++ b/plan/issues/4747-es2015-string-iterator-tag.md
@@ -1,0 +1,138 @@
+---
+id: 4747
+title: "ES2015 StringIteratorPrototype Symbol.toStringTag"
+status: done
+sprint: current
+created: 2026-08-26
+updated: 2026-08-26
+completed: 2026-08-26
+assignee: "codex/4747-es2015-string-iterator-tag"
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: codegen
+es_edition: es2015
+language_feature: string-iterator-prototype
+goal: host-and-standalone
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/expressions/call-builtin-static.ts
+  - src/codegen/object-proto-tostring.ts
+func-budget-allow:
+  - src/codegen/array-object-proto.ts::emitIteratorPrototypeSingleton
+  - src/codegen/expressions/call-builtin-static.ts::compileBuiltinStaticCall
+files:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/expressions/call-builtin-static.ts
+  - src/codegen/object-proto-tostring.ts
+  - tests/test262-restore-builtins.ts
+  - tests/issue-4747.test.ts
+---
+
+# #4747 — ES2015 StringIteratorPrototype Symbol.toStringTag
+
+## Scope and baseline
+
+The authoritative source baseline is upstream/main at 9efc8e766 (2026-08-26).
+The exact Test262 row is:
+
+- test/built-ins/StringIteratorPrototype/Symbol.toStringTag.js
+
+The row is not covered by the open namespace @@toStringTag PR (#4966) or the
+open ArrayIteratorPrototype PR (#4968); those changes do not touch this exact
+StringIteratorPrototype row. The existing upstream PR #4747 is merged ABI work
+and is unrelated.
+
+Fresh runTest262File evidence on the clean upstream worktree:
+
+| lane | result |
+| --- | --- |
+| host | **fail** in the strict rerun: actual "Iterator", expected "String Iterator" |
+| standalone | **fail**: TypeError: Cannot access property on null or undefined at the tag read |
+
+The test obtains the iterator through Object.getPrototypeOf(''[Symbol.iterator]())
+and then checks the own Symbol.toStringTag value and descriptor. Host mode
+reaches a generic compiler-owned iterator prototype in the strict harness path
+after `verifyProperty` destructively deletes the configurable native tag; the
+in-process runner did not snapshot `%StringIteratorPrototype%` even though the
+sharded worker does. The host-free path has no reified StringIterator prototype
+value. A direct host compile probe confirms that the ordinary native string
+iterator itself has the correct host tag; the host lane therefore needs runner
+realm restoration parity while the standalone lane needs the compiler-owned
+intrinsic routing fix.
+
+## Implementation plan
+
+1. Recognize checker-proven StringIterator values at the standalone
+   Object.getPrototypeOf seam and route them to the existing identity-stable
+   iterator-prototype singleton, using the "String" kind. Preserve evaluation
+   side effects before returning the singleton.
+2. Seed the StringIterator singleton's own Symbol.toStringTag data property
+   with value "String Iterator" and descriptor flags
+   { writable: false, enumerable: false, configurable: true }, sharing the
+   existing intrinsic singleton materialization used by adjacent iterator kinds.
+3. Extend the standalone Object.prototype.toString classifier only for the
+   checker-proven StringIterator carrier, leaving host mode on its dynamic
+   path and preserving ordinary arrays/iterators.
+4. Snapshot `%StringIteratorPrototype%` in the in-process Test262 host-realm
+   restore list so `verifyProperty`'s configurable-property probe cannot leak
+   into the strict rerun; this mirrors the already-correct sharded worker.
+5. Add the exact host and standalone Test262 row plus positive/negative
+   identity and descriptor controls.
+
+## Risks and non-goals
+
+- Do not alter String iteration order, code-point handling, or next(); those
+  semantics are covered by existing string iteration tests.
+- Do not classify arbitrary iterator-like objects as StringIterator values.
+- Keep host behavior observable and ensure the existing host lane remains a
+  must-pass control after the standalone routing change.
+
+## Acceptance criteria
+
+- The exact Test262 row passes in both host and standalone lanes.
+- The StringIterator singleton has the exact value and descriptor flags above.
+- Existing array, map, set, generator, and string iteration focused tests stay
+  green; no unrelated iterator kind aliases to the String tag.
+- TypeScript, lint, format, issue, and scoped regression gates pass.
+
+## Test Results
+
+- `tests/issue-4747.test.ts`: **4/4 passed** — exact host row, exact
+  standalone row, standalone identity/descriptor/tag control, and host
+  native/restoration control.
+- Adjacent `StringIteratorPrototype/ancestry.js`: **pass in host and
+  standalone**. The separate standalone `next/*` rows still expose the
+  existing string-iterator `next` limitation (`called value is not a
+  function` / `value is not iterable`) and are outside this tag/prototype
+  slice.
+- TypeScript 7 and TypeScript 5.9 `--noEmit`: **pass**.
+- Prettier check, Biome lint, issue-ID, LOC-budget, and function-budget gates:
+  **pass**.
+
+## Implementation Summary
+
+- **What was done:** Standalone checker-proven `StringIterator` values now
+  resolve through an identity-stable `%StringIteratorPrototype%` singleton;
+  its own `Symbol.toStringTag` is seeded as the exact non-writable,
+  non-enumerable, configurable data property. The standalone
+  `Object.prototype.toString` classifier recognizes only this proven carrier.
+  The in-process Test262 realm snapshot now includes the native
+  `%StringIteratorPrototype%`, and restoration reapplies descriptor flags when
+  a destructive configurable-property probe recreated a property with default
+  attributes.
+- **What worked:** Reusing the existing iterator singleton seam preserved
+  argument evaluation and identity without changing string iteration. Mirroring
+  the worker's host snapshot fixed the strict-rerun leak while keeping host
+  classification dynamic.
+- **What did not work:** The baseline host failure initially looked like a
+  compiler tag mismatch; a direct native probe and the worker snapshot showed
+  it was also an in-process restore gap. The implementation keeps those causes
+  separate.
+- **Files changed:**
+  `src/codegen/array-object-proto.ts`,
+  `src/codegen/expressions/call-builtin-static.ts`,
+  `src/codegen/object-proto-tostring.ts`,
+  `tests/test262-restore-builtins.ts`, and `tests/issue-4747.test.ts`.

--- a/plan/log/issues-log.md
+++ b/plan/log/issues-log.md
@@ -537,6 +537,7 @@ sprint: 0
 | 3519 | 2026-07-21 | IR R0 typed outcomes and honest gate: hybrid 5/5, 37 terminal, 31 IR, 6 Unsupported, 0 Invariants, 37 legacy | Sprint 74 |
 | 3652 | 2026-07-26 | Compact Unicode RegExp code-point classes recover the four remaining step-limited property rows without relaxing the ReDoS budget (462/469 current generated rows pass) | Current |
 | 3924 | 2026-08-09 | Sound opt-in linear call-arena reset reclaims primitive-only exported calls while aggregate boundaries and heap-backed globals fall back to monotonic allocation | Current |
+| 4747 | 2026-08-26 | ES2015 StringIteratorPrototype now has the exact Symbol.toStringTag value and descriptor in standalone, with host Test262 realm restoration parity | Current |
 
 > **IR retirement checkpoint:** #3518 remains in progress; #3520 is ready as
 > the next R1 slice. R2–R8 remain blocked on the dependency spine.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -2878,8 +2878,17 @@ export function emitIteratorPrototypeSingleton(
   kind: NativeIteratorPrototypeKind,
 ): ValType | null {
   ensureObjectRuntime(ctx);
+  // StringIteratorPrototype has an own configurable Symbol.toStringTag per
+  // ES2015 §21.1.5.3. Materialize that descriptor on the standalone singleton
+  // so both direct reads and Object.prototype.toString observe the intrinsic
+  // tag. Register the late symbol import before capturing any function index;
+  // adding it shifts existing body indices.
+  const boxSymbolIdx =
+    kind === "String" ? ensureLateImport(ctx, "__box_symbol", [{ kind: "i32" }], [{ kind: "externref" }]) : undefined;
+  if (kind === "String") flushLateImportShifts(ctx, fctx);
   const newObjectIdx = ctx.funcMap.get("__new_plain_object");
   if (newObjectIdx === undefined) return null;
+  const defineValueIdx = kind === "String" ? ctx.funcMap.get("__defineProperty_value") : undefined;
 
   const globalName = `__native_${kind.toLowerCase()}_iterator_prototype`;
   let globalIdx = ctx.builtinObjectGlobals.get(globalName);
@@ -2894,10 +2903,34 @@ export function emitIteratorPrototypeSingleton(
     ctx.builtinObjectGlobals.set(globalName, globalIdx);
   }
 
-  const initBody: Instr[] = [
-    { op: "call", funcIdx: newObjectIdx },
-    { op: "global.set", index: globalIdx },
-  ];
+  const objLocal =
+    kind === "String"
+      ? allocLocal(fctx, `__${kind.toLowerCase()}_iter_proto_${fctx.locals.length}`, { kind: "externref" })
+      : undefined;
+  const initBody: Instr[] =
+    objLocal === undefined
+      ? [
+          { op: "call", funcIdx: newObjectIdx },
+          { op: "global.set", index: globalIdx },
+        ]
+      : [
+          { op: "call", funcIdx: newObjectIdx },
+          { op: "local.set", index: objLocal },
+        ];
+  if (kind === "String" && boxSymbolIdx !== undefined && defineValueIdx !== undefined) {
+    initBody.push(
+      { op: "local.get", index: objLocal! },
+      { op: "i32.const", value: 4 }, // Symbol.toStringTag
+      { op: "call", funcIdx: boxSymbolIdx },
+    );
+    addStringConstantGlobal(ctx, "String Iterator");
+    initBody.push(...stringConstantExternrefInstrs(ctx, "String Iterator"));
+    // writable:false, enumerable:false, configurable:true.
+    initBody.push({ op: "f64.const", value: 0x04 }, { op: "call", funcIdx: defineValueIdx }, { op: "drop" });
+  }
+  if (objLocal !== undefined) {
+    initBody.push({ op: "local.get", index: objLocal }, { op: "global.set", index: globalIdx });
+  }
   fctx.body.push({ op: "global.get", index: globalIdx });
   fctx.body.push({ op: "ref.is_null" });
   fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: initBody, else: [] });

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -20,6 +20,7 @@ import { numberIsPredicateOps } from "../number-is-predicate-ops.js";
 import { sameValueNumberOps } from "../same-value-number-ops.js";
 import {
   emitArrayIteratorPrototypeSingleton,
+  emitIteratorPrototypeSingleton,
   emitFunctionPrototypeObjectSingleton,
   emitGeneratorFunctionPrototypeSingleton,
   emitGeneratorPrototypeSingleton,
@@ -2055,6 +2056,21 @@ export function compileBuiltinStaticCall(
       const argType = compileExpression(ctx, fctx, arg0);
       if (argType) fctx.body.push({ op: "drop" });
       const protoType = emitArrayIteratorPrototypeSingleton(ctx, fctx);
+      if (protoType) return protoType;
+      // Runtime unavailable: preserve the historical null return.
+      fctx.body.push({ op: "ref.null.extern" });
+      return { kind: "externref" };
+    }
+
+    // (#4747) `Object.getPrototypeOf(<string iterator>)` → the shared native
+    // `%StringIteratorPrototype%` singleton (standalone/WASI). String iterator
+    // carriers do not model [[Prototype]], so the generic fallback returns
+    // null; route only checker-proven `StringIterator` values and preserve the
+    // argument's evaluation side effects before returning the singleton.
+    if ((ctx.standalone || ctx.wasi) && argTsType.getSymbol()?.name === "StringIterator") {
+      const argType = compileExpression(ctx, fctx, arg0);
+      if (argType) fctx.body.push({ op: "drop" });
+      const protoType = emitIteratorPrototypeSingleton(ctx, fctx, "String");
       if (protoType) return protoType;
       // Runtime unavailable: preserve the historical null return.
       fctx.body.push({ op: "ref.null.extern" });

--- a/src/codegen/object-proto-tostring.ts
+++ b/src/codegen/object-proto-tostring.ts
@@ -743,6 +743,13 @@ export function resolveObjectToStringTag(
   if (symName === "ArrayBuffer") return "ArrayBuffer";
   if (symName === "SharedArrayBuffer") return "SharedArrayBuffer";
 
+  // (#4747) String iterator carriers are opaque native records in standalone,
+  // so their intrinsic prototype tag cannot be discovered through the generic
+  // externref classifier. The checker-proven type is narrow enough to avoid
+  // reclassifying arbitrary iterator-like objects; host mode keeps the dynamic
+  // native path through deferOrStandalone().
+  if (symName === "StringIterator") return deferOrStandalone("String Iterator");
+
   // Array (real `__vec_`/`__arr_` arrays, via the established resolver) — the
   // host sees an opaque GC vec and mis-tags it [object Object].
   if (resolveArrayInfo(ctx, nn)) return "Array";

--- a/tests/issue-4747.test.ts
+++ b/tests/issue-4747.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+const EXACT_ROW = "built-ins/StringIteratorPrototype/Symbol.toStringTag.js";
+
+async function run(source: string, standalone: boolean): Promise<unknown> {
+  const result = await compile(source, {
+    fileName: "issue-4747-string-iterator.ts",
+    ...(standalone ? { target: "standalone" as const, nativeStrings: true } : {}),
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  return (instance.exports as Record<string, () => unknown>).test!();
+}
+
+const CONTROL_SOURCE = `
+  export function test(): number {
+    const first: any = Object.getPrototypeOf("ab"[Symbol.iterator]());
+    const second: any = Object.getPrototypeOf("xy"[Symbol.iterator]());
+    const arrayProto: any = Object.getPrototypeOf([][Symbol.iterator]());
+    const desc: any = Object.getOwnPropertyDescriptor(first, Symbol.toStringTag);
+    if (first !== second || first === arrayProto) return 1;
+    if (first[Symbol.toStringTag] !== "String Iterator") return 2;
+    if (
+      desc === undefined ||
+      desc.value !== "String Iterator" ||
+      desc.writable !== false ||
+      desc.enumerable !== false ||
+      desc.configurable !== true
+    ) return 3;
+    if (Object.prototype.toString.call("z"[Symbol.iterator]()) !== "[object String Iterator]") return 4;
+    return 0;
+  }
+`;
+
+describe("#4747 StringIteratorPrototype Symbol.toStringTag", () => {
+  it("passes the exact Test262 row in the host lane", { timeout: 180_000 }, async () => {
+    const result = await runTest262File(resolve("test262/test", EXACT_ROW), "issue-4747-host", 120_000);
+    expect(result.status, result.error ?? result.reason).toBe("pass");
+
+    // The exact row's configurable-property probe must not leak into the
+    // strict rerun or subsequent in-process tests.
+    const desc = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(""[Symbol.iterator]()), Symbol.toStringTag);
+    expect(desc).toEqual({
+      value: "String Iterator",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
+  it("passes the exact Test262 row in standalone", { timeout: 180_000 }, async () => {
+    const result = await runTest262File(
+      resolve("test262/test", EXACT_ROW),
+      "issue-4747-standalone",
+      120_000,
+      "standalone",
+    );
+    expect(result.status, result.error ?? result.reason).toBe("pass");
+  });
+
+  it("keeps StringIteratorPrototype identity, descriptor, and tag distinct from arrays", async () => {
+    await expect(run(CONTROL_SOURCE, true)).resolves.toBe(0);
+  });
+
+  it("preserves the host's native StringIteratorPrototype control", async () => {
+    await expect(run(CONTROL_SOURCE, false)).resolves.toBe(0);
+  });
+});

--- a/tests/test262-restore-builtins.ts
+++ b/tests/test262-restore-builtins.ts
@@ -44,6 +44,10 @@ const PROTOS: ReadonlyArray<[string, object]> = [
   ["Object.prototype", Object.prototype],
   ["Array.prototype", Array.prototype],
   ["String.prototype", String.prototype],
+  // (#4747) verifyProperty() destructively probes configurable
+  // StringIteratorPrototype[@@toStringTag]; restore it before the strict
+  // rerun in this in-process realm, matching scripts/test262-worker.mjs.
+  ["%StringIteratorPrototype%", Object.getPrototypeOf(""[Symbol.iterator]())],
   ["Number.prototype", Number.prototype],
   ["Boolean.prototype", Boolean.prototype],
   ["Function.prototype", Function.prototype],
@@ -114,6 +118,23 @@ function snapshotProto(name: string, proto: object): ProtoSnapshot {
     if ("value" in d) values.set(key, d.value);
   }
   return { name, proto, ownKeys, ownSymbols, values, descs };
+}
+
+function sameDataDescriptor(
+  actual: PropertyDescriptor | undefined,
+  expected: PropertyDescriptor | undefined,
+  value: unknown,
+): boolean {
+  // A configurable verifyProperty() probe can delete a data property and a
+  // plain assignment recreates it with writable/enumerable defaults. Matching
+  // the value alone would therefore preserve the wrong descriptor flags.
+  if (!actual || !("value" in actual) || actual.value !== value) return false;
+  if (!expected) return true;
+  return (
+    actual.writable === expected.writable &&
+    actual.enumerable === expected.enumerable &&
+    actual.configurable === expected.configurable
+  );
 }
 
 // Snapshot at MODULE LOAD — import this module before any test executes.
@@ -229,24 +250,24 @@ export function restoreHostBuiltins(): boolean {
     // re-application as the fallback (#1160 defineProperty-poisoned shapes).
     for (const [key, orig] of values) {
       const cur = Object.getOwnPropertyDescriptor(proto, key);
-      if (cur && "value" in cur && cur.value === orig) continue;
+      const originalDesc = descs.get(key);
+      if (sameDataDescriptor(cur, originalDesc, orig)) continue;
       try {
         (proto as Record<string | symbol, unknown>)[key] = orig;
       } catch {
         /* fall through */
       }
       const after = Object.getOwnPropertyDescriptor(proto, key);
-      if (!after || !("value" in after) || after.value !== orig) {
-        const d = descs.get(key);
-        if (d) {
+      if (!sameDataDescriptor(after, originalDesc, orig)) {
+        if (originalDesc) {
           try {
-            Object.defineProperty(proto, key, d);
+            Object.defineProperty(proto, key, originalDesc);
           } catch {
             /* residual check below */
           }
         }
         const final = Object.getOwnPropertyDescriptor(proto, key);
-        if (!final || ("value" in final && final.value !== orig)) clean = false;
+        if (!sameDataDescriptor(final, originalDesc, orig)) clean = false;
       }
     }
   }


### PR DESCRIPTION
## Summary
- route checker-proven StringIterator values to the identity-stable native iterator prototype singleton
- seed the exact `String Iterator` `Symbol.toStringTag` value and descriptor
- preserve host restoration and standalone `Object.prototype.toString` classification
- track the plan and evidence in `plan/issues/4747-es2015-string-iterator-tag.md`

## Validation
- exact ES2015 Test262 row passes in host and standalone
- focused controls 4/4
- TS5/TS7, lint, formatting, LOC/function budgets, and post-upstream-merge validation pass