### PR TITLE
fix(eval): preserve inlined IIFE var shadowing

### DIFF
--- a/plan/issues/4713-es2015-forof-head-var-scope.md
+++ b/plan/issues/4713-es2015-forof-head-var-scope.md
@@ -4,7 +4,7 @@ title: "ES2015 for-of head scope without a variable environment"
 status: done
 sprint: current
 created: 2026-08-25
-updated: 2026-08-25
+updated: 2026-08-26
 completed: 2026-08-25
 priority: high
 horizon: m
@@ -18,6 +18,7 @@ goal: es6
 related: [4706]
 loc-budget-max: 180
 loc-budget-allow:
+  - src/codegen/expressions/eval-inline.ts
   - src/codegen/index.ts
 ---
 
@@ -172,3 +173,19 @@ biome lint src/codegen/index.ts tests/issue-4713.test.ts \
   --diagnostic-level=error: pass
 prettier --check tests/issue-4713.test.ts: pass
 ```
+
+## Follow-up: module-init IIFE shadowing
+
+The original module-global reuse test was attached to every `var` hoist that
+shared the `__module_init` function context. Top-level IIFEs are inlined into
+that same Wasm function, so an IIFE-local `var x` that collided with a script
+global incorrectly reused the global instead of creating the function-local
+binding required by FunctionDeclarationInstantiation.
+
+The follow-up makes global reuse an explicit hoist mode selected only by the
+folded-eval entry point. Ordinary function and inline-IIFE hoists retain their
+existing local-shadow behavior even when their Wasm context is the module
+initializer. The exact original row plus
+`language/expressions/call/scope-var-close.js` and
+`language/statements/variable/S12.2_A3.js` pass 3/3 through the assembled
+Test262 harness on `6eb910d3f`.

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -1218,7 +1218,7 @@ export function tryStaticEvalInline(
   const isolateIndirectBindings = !directEval && hasScriptScopeAnnexBFunction(sf);
   if (!directEval) {
     try {
-      return compileInlinedEvalStatements(ctx, fctx, stmts, isolateIndirectBindings);
+      return compileInlinedEvalStatements(ctx, fctx, stmts, isolateIndirectBindings, fctx.name === "__module_init");
     } finally {
       restoreFoldedEvalLexicalScope(fctx, lexicalScope);
     }
@@ -1229,7 +1229,7 @@ export function tryStaticEvalInline(
   fctx.directEvalSloppyThisFallback =
     savedDirectEvalThisFallback === true || !isStrictContext(expr, ctx.inferModuleStrictArguments);
   try {
-    const result = compileInlinedEvalStatements(ctx, fctx, stmts, false);
+    const result = compileInlinedEvalStatements(ctx, fctx, stmts, false, fctx.name === "__module_init");
     if (result === undefined) {
       // Late bail to the provider: undo BOTH scope mutations before the caller
       // recompiles the call, or the provider path sees phantom caller bindings.
@@ -1299,6 +1299,7 @@ function compileInlinedEvalStatements(
   fctx: FunctionContext,
   stmts: ts.NodeArray<ts.Statement>,
   isolateBindings: boolean,
+  reuseExistingModuleGlobals: boolean,
 ): InnerResult | undefined {
   const savedBindingState = isolateBindings
     ? {
@@ -1330,7 +1331,7 @@ function compileInlinedEvalStatements(
     // Hoist var / function declarations before compiling any statements.
     // `let`/`const` enter the block scope in source order.
     try {
-      hoistVarDeclarations(ctx, fctx, stmts);
+      hoistVarDeclarations(ctx, fctx, stmts, reuseExistingModuleGlobals);
       hoistLetConstWithTdz(ctx, fctx, stmts);
       hoistFunctionDeclarations(ctx, fctx, stmts);
     } catch {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -10977,9 +10977,10 @@ export function hoistVarDeclarations(
   ctx: CodegenContext,
   fctx: FunctionContext,
   stmts: ts.NodeArray<ts.Statement> | ts.Statement[],
+  reuseExistingModuleGlobals = false,
 ): void {
   for (const stmt of stmts) {
-    walkStmtForVars(ctx, fctx, stmt);
+    walkStmtForVars(ctx, fctx, stmt, reuseExistingModuleGlobals);
   }
 }
 
@@ -11113,7 +11114,12 @@ function varBindingIsForInIdentifierTarget(ctx: CodegenContext, decl: ts.Variabl
 }
 
 /** Hoist a single variable declaration (handles both simple identifiers and binding patterns). */
-function hoistVarDecl(ctx: CodegenContext, fctx: FunctionContext, decl: ts.VariableDeclaration): void {
+function hoistVarDecl(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  decl: ts.VariableDeclaration,
+  reuseExistingModuleGlobals: boolean,
+): void {
   if (ts.isIdentifier(decl.name)) {
     const name = decl.name.text;
     // A folded Script-level eval executes in the module initializer's
@@ -11122,7 +11128,7 @@ function hoistVarDecl(ctx: CodegenContext, fctx: FunctionContext, decl: ts.Varia
     // declaration lowering emits the live global store. This matters when the
     // eval is in a loop head: ForIn/OfHeadEvaluation creates no environment
     // when the head names are not referenced by the receiver expression.
-    if (fctx.name === "__module_init" && ctx.moduleGlobals.has(name)) return;
+    if (reuseExistingModuleGlobals && fctx.name === "__module_init" && ctx.moduleGlobals.has(name)) return;
     if (fctx.localMap.has(name)) return;
     // #1690b: do NOT skip allocation when the name collides with a module
     // global. This hoister only runs for nested function bodies; per JS var
@@ -11297,27 +11303,32 @@ function hoistVarDecl(ctx: CodegenContext, fctx: FunctionContext, decl: ts.Varia
   }
 }
 
-function walkStmtForVars(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.Statement): void {
+function walkStmtForVars(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmt: ts.Statement,
+  reuseExistingModuleGlobals: boolean,
+): void {
   if (ts.isVariableStatement(stmt)) {
     const list = stmt.declarationList;
     // Only hoist `var` (not let/const/using/await-using). #1177
     if (list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing)) return;
     for (const decl of list.declarations) {
-      hoistVarDecl(ctx, fctx, decl);
+      hoistVarDecl(ctx, fctx, decl, reuseExistingModuleGlobals);
     }
     return;
   }
   if (ts.isBlock(stmt)) {
-    for (const s of stmt.statements) walkStmtForVars(ctx, fctx, s);
+    for (const s of stmt.statements) walkStmtForVars(ctx, fctx, s, reuseExistingModuleGlobals);
     return;
   }
   if (ts.isIfStatement(stmt)) {
-    walkStmtForVars(ctx, fctx, stmt.thenStatement);
-    if (stmt.elseStatement) walkStmtForVars(ctx, fctx, stmt.elseStatement);
+    walkStmtForVars(ctx, fctx, stmt.thenStatement, reuseExistingModuleGlobals);
+    if (stmt.elseStatement) walkStmtForVars(ctx, fctx, stmt.elseStatement, reuseExistingModuleGlobals);
     return;
   }
   if (ts.isWhileStatement(stmt) || ts.isDoStatement(stmt)) {
-    walkStmtForVars(ctx, fctx, stmt.statement);
+    walkStmtForVars(ctx, fctx, stmt.statement, reuseExistingModuleGlobals);
     return;
   }
   if (ts.isForStatement(stmt)) {
@@ -11325,11 +11336,11 @@ function walkStmtForVars(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.St
       const list = stmt.initializer;
       if (!(list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const))) {
         for (const decl of list.declarations) {
-          hoistVarDecl(ctx, fctx, decl);
+          hoistVarDecl(ctx, fctx, decl, reuseExistingModuleGlobals);
         }
       }
     }
-    walkStmtForVars(ctx, fctx, stmt.statement);
+    walkStmtForVars(ctx, fctx, stmt.statement, reuseExistingModuleGlobals);
     return;
   }
   if (ts.isForInStatement(stmt) || ts.isForOfStatement(stmt)) {
@@ -11338,30 +11349,30 @@ function walkStmtForVars(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.St
       const list = stmt.initializer;
       if (!(list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const))) {
         for (const decl of list.declarations) {
-          hoistVarDecl(ctx, fctx, decl);
+          hoistVarDecl(ctx, fctx, decl, reuseExistingModuleGlobals);
         }
       }
     }
-    walkStmtForVars(ctx, fctx, stmt.statement);
+    walkStmtForVars(ctx, fctx, stmt.statement, reuseExistingModuleGlobals);
     return;
   }
   if (ts.isLabeledStatement(stmt)) {
-    walkStmtForVars(ctx, fctx, stmt.statement);
+    walkStmtForVars(ctx, fctx, stmt.statement, reuseExistingModuleGlobals);
     return;
   }
   if (ts.isTryStatement(stmt)) {
-    for (const s of stmt.tryBlock.statements) walkStmtForVars(ctx, fctx, s);
+    for (const s of stmt.tryBlock.statements) walkStmtForVars(ctx, fctx, s, reuseExistingModuleGlobals);
     if (stmt.catchClause) {
-      for (const s of stmt.catchClause.block.statements) walkStmtForVars(ctx, fctx, s);
+      for (const s of stmt.catchClause.block.statements) walkStmtForVars(ctx, fctx, s, reuseExistingModuleGlobals);
     }
     if (stmt.finallyBlock) {
-      for (const s of stmt.finallyBlock.statements) walkStmtForVars(ctx, fctx, s);
+      for (const s of stmt.finallyBlock.statements) walkStmtForVars(ctx, fctx, s, reuseExistingModuleGlobals);
     }
     return;
   }
   if (ts.isSwitchStatement(stmt)) {
     for (const clause of stmt.caseBlock.clauses) {
-      for (const s of clause.statements) walkStmtForVars(ctx, fctx, s);
+      for (const s of clause.statements) walkStmtForVars(ctx, fctx, s, reuseExistingModuleGlobals);
     }
   }
 }

--- a/tests/issue-4713.test.ts
+++ b/tests/issue-4713.test.ts
@@ -35,4 +35,11 @@ describe("#4713 — for-of head var scope without a variable environment", () =>
       expect(result.status, `${file}: ${JSON.stringify(result)}`).toBe("pass");
     }
   });
+
+  it("keeps inlined-IIFE vars local when their names collide with globals", async () => {
+    for (const file of ["language/expressions/call/scope-var-close.js", "language/statements/variable/S12.2_A3.js"]) {
+      const result = await runTest262File(join(TEST262, file), "issue-4713-iife-var-shadow", 30_000);
+      expect(result.status, `${file}: ${JSON.stringify(result)}`).toBe("pass");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- make module-global reuse an explicit folded-eval hoist mode
- keep top-level inlined-IIFE `var` declarations function-local when names collide with script globals
- add the two Test262 regressions exposed after #4935 landed

## Validation

- `tests/issue-4713.test.ts`: 4/4 tests passed
- assembled Test262 harness: original #4713 row plus both scope regressions passed 3/3
- pre-commit format/lint/LOC/function gates passed
- full pre-push typecheck, lint, format, oracle, coercion, numeric-local parity, and issue-integrity gates passed

Follow-up to #4935.