### PR TITLE
fix(4754): restore module Proxy escape typing

### DIFF
--- a/plan/issues/4754-module-global-proxy-escape-gate.md
+++ b/plan/issues/4754-module-global-proxy-escape-gate.md
@@ -1,0 +1,313 @@
+---
+id: 4754
+title: "module-global Proxy externref widening bypasses the binding escape gate"
+status: in-progress
+sprint: current
+created: 2026-08-26
+updated: 2026-08-26
+priority: critical
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, conformance
+es_edition: 2015
+language_feature: proxy, array-methods, module-globals
+goal: test262-zero-regressions
+related: [4707, 2615, 3189, 3335]
+origin: "PR #4931 merge-group run 32903525074 and post-merge Test262 promotion: illegal_cast 19 -> 21"
+files:
+  - src/codegen/analysis/proxy-binding-escape.ts
+  - src/codegen/declarations.ts
+  - src/codegen/statements/variables.ts
+  - tests/issue-4754-module-global-proxy-escape.test.ts
+  - plan/issues/4754-module-global-proxy-escape-gate.md
+---
+
+# #4754 — module-global Proxy widening bypasses the escape gate
+
+## Incident and exact attribution
+
+Merged PR #4931, "ES2015 for-of iterator-as-proxy dispatch", fixed the exact
+`language/statements/for-of/iterator-as-proxy.js` target but also changed every
+module-global `new Proxy(...)` and `Proxy.revocable(...)` binding to an
+`externref` slot. The PR's own
+[merge-group Test262 run 32903525074](https://github.com/loopdive/js2/actions/runs/32903525074)
+measured the uncatchable `illegal_cast` category growing from **19 to 21**. That failed
+result existed before merge; a later speculative group inherited the same rows
+and the stale baseline eventually let the change reach `main` as merge commit
+`8da62deddc17ac9a60d67d4ca2b0684ba5c02ff2`.
+
+Adjacent-commit attribution is exact:
+
+- before: `9efc8e766b5fd5e52ae9ac1719692fb232b886bc`;
+- causal PR head: `03783ae5d3510b9c1905be0bb3e9743c09896eb9`;
+- causal merge: `8da62deddc17ac9a60d67d4ca2b0684ba5c02ff2`;
+- current planning base: `6eb910d3f47ec7c0c4c21792f873a74c7a1b3d6f`.
+
+The oracle version and error classification did not change. The two rows are
+therefore compiler behavior, not a scoring or baseline-policy reclassification:
+
+| Test262 row | before #4931 | after #4931 | interpretation |
+| --- | --- | --- | --- |
+| `built-ins/Array/prototype/concat/is-concat-spreadable-proxy.js` | host `fail`: expected length 0, got 1; standalone **`pass`** | host and standalone `illegal_cast` at `__module_init` | real supported-lane regression plus a worse host failure mode |
+| `built-ins/Array/prototype/splice/create-species-undef-invalid-len.js` | host `runtime_error`: cannot convert Symbol to number; standalone `assertion_fail`: expected RangeError | host `illegal_cast` in `__cb_1 ← __closure_51 ← __call_fn_method_3`; standalone `illegal_cast` in `__closure_70 ← __closure_63 ← __call_fn_method_3 ← __apply_closure` | newly exposed uncatchable trap; not a new conformance pass target |
+
+The failed gate job is **97990564492**. Its immutable evidence is retained in
+the `test262-merged-report` artifact **9584870517**, grouped commit artifact
+**9584871298**, and `test262-regressions-report` artifact **9584891604**. The
+last artifact explicitly records `illegal_cast 19 → 21` and both paths above.
+
+Do not grant, document, or promote an `illegal_cast +2` allowance. The
+standalone concat row was passing immediately before the causal change, and the
+splice row's old failure is still safer than an uncatchable Wasm cast.
+
+## Root cause
+
+The local-binding Proxy path already contains the necessary representation
+boundary. `src/codegen/statements/variables.ts::proxyResultEscapesToCall`
+keeps a Proxy target structurally typed when its binding escapes as a call/new
+argument or as the `this` argument of `.call`/`.apply`. This preserves the
+existing generic-method and host-array consumers, which cannot safely consume
+the bare `externref` Proxy carrier.
+
+PR #4931 added a parallel unconditional arm in
+`src/codegen/declarations.ts::moduleInitForcesExternref`. It recognizes the
+Proxy initializer but never asks whether the module binding escapes. Both
+failing Test262 bindings do:
+
+- concat passes the Proxy through concat/species inputs; and
+- splice supplies the Proxy as argument zero of an
+  `Array.prototype.splice.call(...)` generic dispatch.
+
+The unconditional module-global widening then makes
+`moduleGlobalWasmType` publish an `externref` global. The consumer routes still
+trust checker-derived Array shapes:
+
+- `compileArrayConcat` enters the typed `$Vec` path and casts the externref
+  global to its checker-selected vec type; and
+- `compileArrayPrototypeCall` recognizes the borrowed externref receiver, but
+  the splice arm still invokes typed `compileArraySplice` and performs the same
+  impossible cast.
+
+The repair belongs at the producer-side representation decision. Hardening
+every static Array consumer or implementing a new generic standalone Proxy
+splice runtime would be a much larger feature and would not restore the shared
+local/module policy that already exists.
+
+## Implementation plan
+
+### P1. Extract one binding-identity-aware escape analysis
+
+Move the reusable logic out of `statements/variables.ts` into the narrow,
+dependency-light module
+`src/codegen/analysis/proxy-binding-escape.ts`. Export a predicate shaped around
+the exact declaration and codegen oracle, not a display name:
+
+- the candidate declaration must have a simple identifier binding;
+- every identifier reference must satisfy
+  `ctx.oracle.valueDeclarationOf(reference) === declaration`;
+- scan only the declaration's enclosing function or SourceFile;
+- do not descend into an unrelated nested executable unless that executable
+  actually captures the same binding; and
+- unwrap only transparent expression wrappers already recognized by the local
+  slot analysis.
+
+Return true only when that exact binding is used:
+
+- as a by-value argument to a call or `new` expression; or
+- as argument zero of a `.call`/`.apply` generic-method dispatch.
+
+Member reads/calls on the Proxy itself (`p.x`, `p[k]`, `p.method()`, `delete
+p.x`, `k in p`) remain non-escaping. A same-spelled shadow in a nested function
+must never classify the outer binding. Preserve every existing #2615 control's
+classification by making `statements/variables.ts` consume the shared predicate
+before deleting its private name-based copy; the intended observable refinement
+is only that a same-spelled shadow no longer creates a false escape.
+
+### P2. Gate only the module-global Proxy arm
+
+In `src/codegen/declarations.ts::moduleInitForcesExternref`, preserve the exact
+`new Proxy` / `Proxy.revocable` initializer recognition added for #4707, but
+return true only when the exact module binding does **not** escape according to
+P1. All non-Proxy arms in `moduleInitForcesExternref` remain unchanged.
+
+Put only this new conjunction behind the default-on, one-variable kill switch
+`JS2WASM_PROXY_MODULE_ESCAPE_GATE`; unset means enabled and the exact token `0`
+restores #4931's unconditional module-Proxy widening. Read the switch once per
+compile/collector invocation, not once per identifier visit. It exists for
+same-tree attribution and emergency rollback, not as a second policy mode; no
+other Proxy, Array, iterator, or module-global behavior may consult it.
+
+This gives the two representations their existing bounded roles:
+
+- a local-only/member-only module Proxy stays `externref`, preserving dynamic
+  Proxy MOP reads; and
+- a Proxy handed to a generic or statically typed consumer retains the
+  checker-derived structural slot, avoiding an impossible externref-to-vec
+  cast.
+
+Do not change `array-methods.ts`, `array-prototype-borrow.ts`, Proxy runtime
+semantics, iterator dispatch, the Test262 oracle, or any baseline/tolerance in
+this checkpoint. If the shared analysis cannot distinguish one of the exact
+bindings, it must conservatively report escape and decline the widening.
+
+This checkpoint proves direct binding flow only. It does not claim alias flow
+such as `const q = p; consume(q)`, nor a declaration initialized from
+`Proxy.revocable(...).proxy`; both remain separate representation-analysis
+families. Transparent wrappers around the same identifier are not aliases and
+remain in scope. Do not silently treat an out-of-scope alias as positive proof
+for either representation.
+
+### P3. Pin the boundary and its non-vacuity
+
+Add `tests/issue-4754-module-global-proxy-escape.test.ts` with structural and
+runtime controls for both `new Proxy` and `Proxy.revocable`:
+
+1. module-global Proxy passed as an ordinary call argument retains a non-
+   externref global slot;
+2. module-global Proxy passed as `.call`/`.apply` argument zero retains that
+   structural slot;
+3. module-global Proxy passed through transparent parentheses, `as`, type
+   assertion, non-null, and `satisfies` wrappers is still the same escaping
+   binding;
+4. module-global Proxy passed to `new Consumer(p)` is an escaping by-value
+   argument just like `consume(p)`;
+5. member-only module-global Proxy remains externref and its get trap is
+   observable;
+6. same-spelled nested shadow references do not classify the outer binding;
+7. a genuine closure capture and escape of the outer binding does classify it;
+8. function-local controls from `tests/issue-2615.test.ts` remain exact; and
+9. the #4707 returned `proxiedIterator` shape remains externref and the exact
+   iterator-as-Proxy Test262 row remains passing in both lanes.
+
+Make the tests mutation-sensitive: deleting the new module escape gate must
+restore both illegal casts; changing binding identity to text equality must
+fail the shadow control; removing the call/new or transparent-wrapper arms must
+fail their exact controls; inverting the predicate must fail the member-only
+Proxy and #4707 controls.
+
+Run a same-tree kill-switch A/B before accepting the implementation. With the
+switch unset, all P3 controls and the restored Test262 classifications below
+must hold. With `JS2WASM_PROXY_MODULE_ESCAPE_GATE=0`, the two selected rows must
+reproduce #4931's `illegal_cast` cells while iterator-as-Proxy remains green.
+This is the causal proof that the narrow gate, rather than unrelated drift,
+removes the regression.
+
+### P4. Reproduce and clear the queue regression
+
+Run the exact two Test262 rows through the same authoritative runner in both
+host and standalone lanes, first on the causal state and then on the repair.
+Acceptance is classification-specific:
+
+- concat standalone returns from `illegal_cast` to **pass**;
+- concat host returns exactly to its pre-#4931 assertion failure (expected
+  length 0, observed 1), not another error class;
+- splice host returns exactly to its pre-#4931 runtime error (`Cannot convert a
+  Symbol value to a number`);
+- splice standalone returns exactly to its pre-#4931 assertion failure
+  (expected RangeError, no exception); and
+- iterator-as-Proxy stays **pass/pass**.
+
+Also retain #4707's two published known-good controls, each in both lanes:
+
+- `language/statements/for-of/generic-iterable.js`; and
+- `language/statements/for-of/head-expr-obj-iterator-method.js`.
+
+Then run the smallest complete Proxy-to-Array/generic-call population that
+contains the two selected rows plus #2615's documented proxy-array,
+copyWithin, `getPrototypeOf`, `getOwnPropertySymbols`, and
+`Object.prototype.toString` escape controls. Report the exact denominator and
+per-lane transitions. A larger pass count does not offset any new wrong answer,
+trap, compile error, or timeout.
+
+## Landing and verification gates
+
+### Implementation checkpoint (2026-08-26)
+
+The bounded repair is implemented locally on
+`codex/4754-proxy-module-global-escape` atop `6eb910d3f47e`, pending independent
+review, signed commit hooks, push hooks, and the PR's own merge-group Test262
+run. The change extracts one shared binding-identity-aware direct-flow
+predicate, makes both function-local and module-global Proxy slot decisions
+consume it, and snapshots the default-on module gate once per declaration
+collector. The exact token `JS2WASM_PROXY_MODULE_ESCAPE_GATE=0` restores the
+#4931 module-global widening arm; no Array, iterator, runtime, oracle, or
+Test262 baseline file changes.
+
+Current source growth is a measured net **+58 LOC**. Both LOC and function
+ratchets pass without an allowance. Focused #4754 coverage is **10/10**, and
+TypeScript 7, TypeScript 5, Prettier, scoped Biome, oracle-use, and verdict
+ratchets pass. The final-byte same-tree Test262 matrix produced the required
+classifications:
+
+- gate on: concat host returns to its prior length assertion and standalone
+  passes; splice host returns to its prior Symbol-to-number runtime error and
+  standalone returns to its prior missing-RangeError assertion;
+- gate on: iterator-as-Proxy, generic-iterable, and head-expression iterator
+  controls remain pass/pass; and
+- gate `=0`: both affected rows return to illegal-cast/illegal-cast while the
+  iterator-as-Proxy target remains pass/pass with identical output hashes.
+
+The existing #2615 suite is **6/8** in the current local Node environment: its
+two set/delete runtime cases stop at Node's `WebAssembly objects are opaque`
+host limitation. An exact detached-base replay at `6eb910d3f47e` reproduces
+the same error classes, messages, frames, line numbers, and Wasm module IDs.
+The two compiled binaries are byte-identical between base and this branch:
+the set case is 2,791 bytes with SHA-256
+`89c427bf3e091a0af4882a0d294e77eabd484b96c1046fe86a6584669e0301d6`, and
+the delete case is 1,244 bytes with SHA-256
+`e9d5cbeb83588507320edd19ec660dc0b14e0fb1ab9d4cd5e8822ecc07f7ba15`.
+The exact representation branches affected by this refactor pass, and the new
+focused suite separately pins the local member-only versus escaping split.
+These two pre-existing host-runtime failures are not suppressed or counted as
+acceptance evidence. Final acceptance remains blocked until the unskipped
+hooks, independent audit, and authoritative PR queue run all pass.
+
+This is one bounded regression-repair PR based on fresh `main`. It may land
+independently of the IR migration, but it is queue-critical because the stale
+19-count trap baseline prevents unrelated PRs from promoting while `main`
+contains 21 rows. Do not promote a 21-row baseline before this repair lands.
+
+Before commit and again after merging current `main`, run:
+
+- the focused #4754 and existing #2615 suites;
+- the exact four Test262 executions for the two affected rows, plus all six
+  #4707 executions (target and two controls in both lanes), **10 total**;
+- TypeScript 7 and TypeScript 5 checks;
+- scoped Prettier/Biome and the relevant representation/oracle checks;
+- `pnpm run check:loc-budget` immediately before the signed commit; and
+- the complete unskipped pre-commit and pre-push hooks.
+
+Measure source and function growth before adding any issue-scoped allowance;
+never raise a global LOC/function or Test262 baseline speculatively. Every
+heavy command and commit/push boundary requires a fresh finite, non-negative
+one-minute load strictly below **logical cores - 2**.
+
+## Acceptance
+
+- The exact causal source hunk is narrowed; no array consumer or Test262 policy
+  is weakened to hide it.
+- `illegal_cast` returns from 21 to at most 19 with the two named rows absent
+  from every uncatchable-trap category.
+- The four selected row/lane cells exactly match their pre-#4931
+  classifications; concat standalone is restored to pass.
+- The #4707 iterator-as-Proxy target and its two published iterator controls
+  remain pass in host and standalone.
+- The default-on kill-switch A/B is non-vacuous: `=0` restores the exact two
+  illegal casts, while unset removes them with no unrelated transition.
+- Local and module Proxy decisions use one binding-identity-aware escape
+  predicate, including shadow/capture mutations.
+- No unrelated Proxy, Array, iterator, or module-global row regresses.
+- The PR receives independent read-only review and is shepherded through its
+  own merge-group Test262 run; a failed required run is never treated as
+  acceptance evidence.
+
+## Process follow-up
+
+The code repair does not explain why a PR whose own required merge-group
+Test262 workflow failed was nevertheless merged. Queue recovery must retain
+run 32903525074 and the later speculative-group ancestry as evidence. If the
+existing merge-queue hardening backlog does not already cover this exact
+failure mode, file a separate CI issue; do not expand this compiler checkpoint
+into workflow surgery.

--- a/src/codegen/analysis/proxy-binding-escape.ts
+++ b/src/codegen/analysis/proxy-binding-escape.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { forEachChild, ts } from "../../ts-api.js";
+import type { CodegenContext } from "../context/types.js";
+
+/** The two direct initializer shapes whose result carrier is Proxy-owned. */
+export function isDirectProxyConstruction(expression: ts.Expression): boolean {
+  if (ts.isNewExpression(expression)) {
+    return ts.isIdentifier(expression.expression) && expression.expression.text === "Proxy";
+  }
+  return (
+    ts.isCallExpression(expression) &&
+    ts.isPropertyAccessExpression(expression.expression) &&
+    expression.expression.name.text === "revocable" &&
+    ts.isIdentifier(expression.expression.expression) &&
+    expression.expression.expression.text === "Proxy"
+  );
+}
+
+function enclosingExecutableOrSource(node: ts.Node): ts.Node | undefined {
+  let current: ts.Node | undefined = node.parent;
+  while (current !== undefined) {
+    if (ts.isFunctionLike(current) || ts.isSourceFile(current)) return current;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function isTransparentWrapperOf(parent: ts.Node, child: ts.Expression): parent is ts.Expression {
+  return (
+    (ts.isParenthesizedExpression(parent) ||
+      ts.isAsExpression(parent) ||
+      ts.isTypeAssertionExpression(parent) ||
+      ts.isNonNullExpression(parent) ||
+      ts.isSatisfiesExpression(parent)) &&
+    parent.expression === child
+  );
+}
+
+function outermostTransparentExpression(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (current.parent !== undefined && isTransparentWrapperOf(current.parent, current)) {
+    current = current.parent;
+  }
+  return current;
+}
+
+function expressionIsEscapingArgument(expression: ts.Expression): boolean {
+  const outer = outermostTransparentExpression(expression);
+  const parent = outer.parent;
+  if ((!ts.isCallExpression(parent) && !ts.isNewExpression(parent)) || parent.arguments === undefined) return false;
+
+  // This includes argument zero of `.call` / `.apply`, the generic-method
+  // receiver that motivated #2615. A member receiver (`p.method()`) is not in
+  // the argument list and therefore remains non-escaping.
+  return parent.arguments.some((argument) => argument === outer);
+}
+
+function nestedExecutableMayReferenceBinding(
+  ctx: CodegenContext,
+  executable: ts.SignatureDeclaration,
+  declaration: ts.VariableDeclaration,
+  bindingName: string,
+): boolean {
+  let mayReference = false;
+  const visit = (node: ts.Node): void => {
+    if (mayReference) return;
+    if (ts.isIdentifier(node) && node.text === bindingName) {
+      const resolved = ctx.oracle.valueDeclarationOf(node);
+      // An unresolved same-spelled reference cannot prove non-escape. Descend
+      // and let the main classifier fail closed if it is in argument position.
+      if (resolved === declaration || resolved === undefined) {
+        mayReference = true;
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(executable, visit);
+  return mayReference;
+}
+
+/**
+ * Whether one exact Proxy result binding escapes into a call/new argument.
+ *
+ * The check deliberately proves declaration identity through the shared type
+ * oracle instead of comparing display names. Transparent TypeScript wrappers
+ * preserve the same binding. Assignment aliases and
+ * `Proxy.revocable(...).proxy` declarations are outside this direct-flow
+ * predicate; callers decide which initializer families are eligible.
+ *
+ * Unsupported binding patterns and unresolved same-spelled argument uses are
+ * conservative escapes: when identity cannot be proved, storage widening must
+ * decline rather than risk an externref-to-struct cast at a typed consumer.
+ */
+export function proxyBindingEscapesToCall(ctx: CodegenContext, declaration: ts.VariableDeclaration): boolean {
+  if (!ts.isIdentifier(declaration.name)) return true;
+  const scope = enclosingExecutableOrSource(declaration);
+  if (scope === undefined) return true;
+
+  const bindingName = declaration.name.text;
+  let escapes = false;
+  const visit = (node: ts.Node): void => {
+    if (escapes) return;
+
+    if (
+      node !== scope &&
+      ts.isFunctionLike(node) &&
+      !nestedExecutableMayReferenceBinding(ctx, node, declaration, bindingName)
+    ) {
+      return;
+    }
+
+    if (ts.isIdentifier(node) && node.text === bindingName && expressionIsEscapingArgument(node)) {
+      const resolved = ctx.oracle.valueDeclarationOf(node);
+      if (resolved === declaration || resolved === undefined) {
+        escapes = true;
+        return;
+      }
+    }
+
+    forEachChild(node, visit);
+  };
+  visit(scope);
+  return escapes;
+}

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -138,6 +138,7 @@ import { variableSlotHoldsReconstructedFnctorInstance } from "./fnctor-instance-
 import { callTargetIsRedeclaredFunction } from "./duplicate-function-declaration.js"; // (#4653)
 import { emitRuntimeEvalAotCallableAdapter } from "./runtime-eval-callable.js";
 import { numericReturnsFlagEnabled } from "../derivation-flags.js";
+import { isDirectProxyConstruction, proxyBindingEscapesToCall } from "./analysis/proxy-binding-escape.js";
 
 // ── Extracted subsystems (#3268) — re-exported for external consumers ─────
 export {
@@ -1492,6 +1493,10 @@ function isTopLevelFunctionPropertyReceiver(ctx: CodegenContext, receiver: ts.Ex
 }
 
 export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFile, isEntryFile = true): void {
+  // (#4754) Snapshot once for this declaration collector. The exact token `0`
+  // restores #4931's unconditional module-Proxy widening for same-tree A/B.
+  const proxyModuleEscapeGateEnabled = process.env.JS2WASM_PROXY_MODULE_ESCAPE_GATE !== "0";
+
   // First: collect enum declarations (so enum values are available)
   collectEnumDeclarations(ctx, sourceFile);
 
@@ -2272,20 +2277,14 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
   function moduleInitForcesExternref(decl: ts.VariableDeclaration): boolean {
     if (!decl.initializer) return false;
     if (ctx.ordinaryToPrimitiveObjectDeclarations.has(decl)) return true;
-    // (#4707) `new Proxy` returns an externref carrier even though TypeScript
-    // gives it the target's structural type. Keep the module global dynamic so
-    // a proxy is not cast back to that target struct and nulled on assignment.
-    if (
-      (ts.isNewExpression(decl.initializer) &&
-        ts.isIdentifier(decl.initializer.expression) &&
-        decl.initializer.expression.text === "Proxy") ||
-      (ts.isCallExpression(decl.initializer) &&
-        ts.isPropertyAccessExpression(decl.initializer.expression) &&
-        decl.initializer.expression.name.text === "revocable" &&
-        ts.isIdentifier(decl.initializer.expression.expression) &&
-        decl.initializer.expression.expression.text === "Proxy")
-    ) {
-      return true;
+    // (#4707/#4754) `new Proxy` returns an externref carrier even though
+    // TypeScript gives it the target's structural type. Keep a member-only
+    // module binding dynamic, but preserve the structural slot when that exact
+    // binding is handed to a typed/generic consumer: widening it would make the
+    // consumer cast a host Proxy externref back to the target struct and trap.
+    // The default-on gate is the sole attribution seam; `=0` restores #4931.
+    if (isDirectProxyConstruction(decl.initializer)) {
+      return !proxyModuleEscapeGateEnabled || !proxyBindingEscapesToCall(ctx, decl);
     }
     // (#3365) Script top-level `this` is the host global object. The checker
     // describes it as the enormous structural `typeof globalThis` type, but

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -53,6 +53,7 @@ import {
   numericProofOverridesMixedCarrier,
 } from "../analysis/mixed-assignment-carrier.js";
 import { declarationReadsStructuralObjectFromRealmGlobal } from "../analysis/realm-global-structural-carrier.js";
+import { isDirectProxyConstruction, proxyBindingEscapesToCall } from "../analysis/proxy-binding-escape.js";
 import { staticConstStringValues } from "../analysis/static-string-values.js";
 import { staticIntegerRange } from "../../ir/analysis/static-numeric-range.js";
 import { tryEmitStaticI32Expression } from "../i32-static-range-expr.js";
@@ -775,7 +776,7 @@ export function resolveSpillLocalValType(ctx: CodegenContext, decl: ts.VariableD
       if (objectLiteralForcesHostPath(ctx, init)) return { kind: "externref" };
       if (objectLiteralSpreadTakesHostPath(ctx, init)) return { kind: "externref" };
     }
-    if (isProxyConstruction(init)) return { kind: "externref" };
+    if (isDirectProxyConstruction(init)) return { kind: "externref" };
     // Representations the var-decl path computes from a decl/receiver-driven
     // inference that diverges from resolveWasmType — defer to the host path.
     if (inferStandaloneRegExpMatchArrayType(ctx, init) !== null) return null;
@@ -1091,19 +1092,6 @@ function isPromiseHostCall(_ctx: CodegenContext, expr: ts.Expression): boolean {
  * `isBindCarrierCall` / `isPromiseHostCall` slot-type overrides. Mode-agnostic:
  * both host and standalone emit a Proxy externref, so both need the override.
  */
-function isProxyConstruction(expr: ts.Expression): boolean {
-  if (ts.isNewExpression(expr)) {
-    return ts.isIdentifier(expr.expression) && expr.expression.text === "Proxy";
-  }
-  return (
-    ts.isCallExpression(expr) &&
-    ts.isPropertyAccessExpression(expr.expression) &&
-    expr.expression.name.text === "revocable" &&
-    ts.isIdentifier(expr.expression.expression) &&
-    expr.expression.expression.text === "Proxy"
-  );
-}
-
 /**
  * Does this binding become the target of a native Proxy in its lexical scope?
  * A Proxy can mutate that target through a trap or an absent-trap forward, so
@@ -1157,60 +1145,6 @@ function bindingIsProxyTarget(ctx: CodegenContext, decl: ts.VariableDeclaration)
   };
   visit(scope);
   return found;
-}
-
-/**
- * (#2615 narrowing) Does the Proxy-bound variable `name` ever ESCAPE into a
- * call/new as a by-value argument, or get used as a generic-method receiver
- * (`Array.prototype.X.call(p, …)` / `Object.getPrototypeOf(p)` /
- * `Object.prototype.toString.call(p)`) anywhere in the enclosing function?
- *
- * Why this matters: forcing the slot to `externref` (so member READS route
- * through `__extern_get` — the read-trap fix) breaks the regression cases where
- * the Proxy is handed to a host generic-method / global. For a struct-typed
- * slot those host paths received a wasm struct they could introspect (IsArray,
- * getPrototypeOf, the Array.prototype.* spec walk); the bare externref Proxy
- * goes through a different host path that loses Array-ness / prototype identity
- * (regressed `Object/prototype/toString/proxy-array`, `copyWithin/*-proxy-*`,
- * `getOwnPropertySymbols/proxy-invariant-*`, `getPrototypeOf/*-target-is-proxy`).
- *
- * So: only flip the slot to externref when the Proxy stays LOCAL and is used
- * purely in member position (`p.x` / `p[k]` / `delete p.x` / `k in p`). If it
- * escapes into a call argument, keep the struct typing — the keystone read-trap
- * fix still lands for the common direct-read case, and the escaping-into-host
- * paths keep working. A receiver of `p.method()` (member-then-call) is NOT an
- * escape; only `p` appearing as a CALL/NEW ARGUMENT (incl. `.call`/`.apply`
- * first arg) counts.
- */
-function proxyResultEscapesToCall(decl: ts.VariableDeclaration, name: string): boolean {
-  const fn = findEnclosingFunctionOrSource(decl);
-  if (!fn) return false;
-  let escapes = false;
-  const visit = (node: ts.Node): void => {
-    if (escapes) return;
-    if (ts.isIdentifier(node) && node.text === name) {
-      const p = node.parent;
-      // `f(…, p, …)` or `new C(…, p, …)` — p is a by-value argument.
-      if ((ts.isCallExpression(p) || ts.isNewExpression(p)) && p.arguments?.some((a) => a === node)) {
-        escapes = true;
-        return;
-      }
-      // `<receiver>.call(p, …)` / `<receiver>.apply(p, …)` — p is the `this`
-      // arg of a generic-method dispatch (Array.prototype.X.call(p), etc.).
-      if (
-        ts.isCallExpression(p) &&
-        ts.isPropertyAccessExpression(p.expression) &&
-        (p.expression.name.text === "call" || p.expression.name.text === "apply") &&
-        p.arguments?.[0] === node
-      ) {
-        escapes = true;
-        return;
-      }
-    }
-    node.forEachChild(visit);
-  };
-  visit(fn);
-  return escapes;
 }
 
 function findEnclosingFunctionOrSource(node: ts.Node): ts.Node | undefined {
@@ -1798,9 +1732,9 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
     // Array.prototype.* spec walk) still work on a wasm-struct receiver.
     const initIsProxy =
       decl.initializer !== undefined &&
-      isProxyConstruction(decl.initializer) &&
+      isDirectProxyConstruction(decl.initializer) &&
       ts.isIdentifier(decl.name) &&
-      !proxyResultEscapesToCall(decl, decl.name.text);
+      !proxyBindingEscapesToCall(ctx, decl);
     const isProxyTargetBinding = bindingIsProxyTarget(ctx, decl);
     if (isProxyTargetBinding) ctx.externrefAccessorVars.add(name);
     const initIsPropertyDescriptorResult = isPropertyDescriptorResultExpression(decl.initializer);

--- a/tests/issue-4754-module-global-proxy-escape.test.ts
+++ b/tests/issue-4754-module-global-proxy-escape.test.ts
@@ -1,0 +1,230 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { afterEach, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const GATE = "JS2WASM_PROXY_MODULE_ESCAPE_GATE";
+const originalGate = process.env[GATE];
+
+afterEach(() => {
+  if (originalGate === undefined) Reflect.deleteProperty(process.env, GATE);
+  else process.env[GATE] = originalGate;
+});
+
+async function compileProxySource(source: string, gate: "default" | "one" | "off" = "default") {
+  if (gate === "off") process.env[GATE] = "0";
+  else if (gate === "one") process.env[GATE] = "1";
+  else Reflect.deleteProperty(process.env, GATE);
+  const result = await compile(source, { fileName: "issue-4754.ts", emitWat: true });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  return result;
+}
+
+function moduleGlobal(wat: string | undefined, name: string): string {
+  const line = wat?.split("\n").find((candidate) => candidate.includes(`(global $__mod_${name} `));
+  expect(line, `missing $__mod_${name} in WAT`).toBeDefined();
+  return line!;
+}
+
+function expectStructuralModuleGlobal(wat: string | undefined, name: string): void {
+  const line = moduleGlobal(wat, name);
+  expect(line).toMatch(/\(mut \(ref null \d+\)\)/);
+  expect(line).not.toContain("externref");
+}
+
+function expectExternrefModuleGlobal(wat: string | undefined, name: string): void {
+  expect(moduleGlobal(wat, name)).toContain("(mut externref)");
+}
+
+async function instantiate(result: Awaited<ReturnType<typeof compile>>): Promise<WebAssembly.Exports> {
+  const imports = result.importObject ?? buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { __setExports?: (exports: object) => void }).__setExports?.(instance.exports);
+  return instance.exports;
+}
+
+describe("#4754 module-global Proxy escape gate", () => {
+  it("keeps an escaping new Proxy structural while the revocable result object stays dynamic", async () => {
+    const result = await compileProxySource(`
+      function consume(value: any): number { return value ? 1 : 0; }
+      const target = { x: 1 };
+      const direct = new Proxy(target, {});
+      const revocable = Proxy.revocable(target, {});
+      consume(direct);
+      consume(revocable);
+      export function test(): number { return 1; }
+    `);
+
+    expectStructuralModuleGlobal(result.wat, "direct");
+    // `Proxy.revocable` returns a result record that contains a callable
+    // `revoke` field. Its checker-derived representation is already externref;
+    // declining the #4931 Proxy arm must not invent a closed struct for it.
+    expectExternrefModuleGlobal(result.wat, "revocable");
+  });
+
+  it("treats .call/.apply argument zero and constructor arguments as direct escapes", async () => {
+    const result = await compileProxySource(`
+      class Consumer { constructor(value: any) { void value; } }
+      const a = new Proxy([1], {});
+      const b = new Proxy([2], {});
+      const c = new Proxy({ x: 3 }, {});
+      Array.prototype.push.call(a, 2);
+      Array.prototype.push.apply(b, [3]);
+      new Consumer(c);
+      export function test(): number { return 1; }
+    `);
+
+    expectStructuralModuleGlobal(result.wat, "a");
+    expectStructuralModuleGlobal(result.wat, "b");
+    expectStructuralModuleGlobal(result.wat, "c");
+  });
+
+  it("unwraps every transparent TypeScript expression around an escaping binding", async () => {
+    const result = await compileProxySource(`
+      function consume(value: any): number { return value ? 1 : 0; }
+      const target = { x: 1 };
+      const paren = new Proxy(target, {});
+      const asExpr = new Proxy(target, {});
+      const asserted = new Proxy(target, {});
+      const nonNull = new Proxy(target, {});
+      const satisfiesExpr = new Proxy(target, {});
+      consume((paren));
+      consume(asExpr as any);
+      consume(<any>asserted);
+      consume(nonNull!);
+      consume(satisfiesExpr satisfies { x: number });
+      export function test(): number { return 1; }
+    `);
+
+    for (const name of ["paren", "asExpr", "asserted", "nonNull", "satisfiesExpr"]) {
+      expectStructuralModuleGlobal(result.wat, name);
+    }
+  });
+
+  it("uses binding identity: a shadow is inert but a genuine captured escape is structural", async () => {
+    const shadow = await compileProxySource(`
+      function consume(value: any): number { return value ? 1 : 0; }
+      const p = new Proxy({ x: 1 }, { get: function () { return 7; } });
+      function nested(): void {
+        const p = new Proxy({ x: 2 }, {});
+        consume(p);
+      }
+      nested();
+      export function test(): number { return p.x; }
+    `);
+    expectExternrefModuleGlobal(shadow.wat, "p");
+
+    const capture = await compileProxySource(`
+      function consume(value: any): number { return value ? 1 : 0; }
+      const p = new Proxy({ x: 1 }, {});
+      function nested(): void { consume(p); }
+      nested();
+      export function test(): number { return 1; }
+    `);
+    expectStructuralModuleGlobal(capture.wat, "p");
+  });
+
+  it("keeps member-only Proxy carriers externref and observes their get traps", async () => {
+    const direct = await compileProxySource(`
+      const p = new Proxy({ x: 1 }, { get: function () { return 7; } });
+      export function test(): number { return p.x; }
+    `);
+    expectExternrefModuleGlobal(direct.wat, "p");
+    expect(((await instantiate(direct)).test as () => number)()).toBe(7);
+
+    const revocable = await compileProxySource(`
+      const holder = Proxy.revocable({ x: 1 }, { get: function () { return 9; } });
+      export function test(): number { return holder.proxy.x; }
+    `);
+    expectExternrefModuleGlobal(revocable.wat, "holder");
+    expect(((await instantiate(revocable)).test as () => number)()).toBe(9);
+  });
+
+  it("does not widen the out-of-scope Proxy.revocable(...).proxy declaration", async () => {
+    const result = await compileProxySource(`
+      function consume(value: any): number { return value ? 1 : 0; }
+      const p = Proxy.revocable({ x: 1 }, {}).proxy;
+      consume(p);
+      export function test(): number { return 1; }
+    `);
+
+    expectStructuralModuleGlobal(result.wat, "p");
+  });
+
+  it("does not promote assignment aliases into direct binding-flow evidence", async () => {
+    const result = await compileProxySource(`
+      function consume(value: any): number { return value ? 1 : 0; }
+      const p = new Proxy({ x: 1 }, { get: function () { return 7; } });
+      const alias = p;
+      consume(alias);
+      export function test(): number { return p.x; }
+    `);
+
+    expectExternrefModuleGlobal(result.wat, "p");
+  });
+
+  it("only exact =0 restores #4931 unconditional widening", async () => {
+    const source = `
+      function consume(value: any): number { return value ? 1 : 0; }
+      const p = new Proxy({ x: 1 }, {});
+      consume(p);
+      export function test(): number { return 1; }
+    `;
+    const gated = await compileProxySource(source);
+    const explicitOne = await compileProxySource(source, "one");
+    const legacy = await compileProxySource(source, "off");
+
+    expectStructuralModuleGlobal(gated.wat, "p");
+    expectStructuralModuleGlobal(explicitOne.wat, "p");
+    expectExternrefModuleGlobal(legacy.wat, "p");
+  });
+
+  it("preserves #4707's member-only proxiedIterator externref carrier and behavior", async () => {
+    const result = await compileProxySource(`
+      const iterable: any = {};
+      let nextResult = { value: 23, done: false };
+      const lastResult = { value: 0, done: true };
+      const iterator = {
+        next: function() {
+          const result = nextResult;
+          nextResult = lastResult;
+          return result;
+        },
+      };
+      const proxiedIterator = new Proxy(iterator, {
+        get: function(target: any, name: any) { return target[name]; },
+      });
+      iterable[Symbol.iterator] = function() { return proxiedIterator; };
+
+      export function test(): number {
+        let total = 0;
+        for (const value of iterable) total += value;
+        return total;
+      }
+    `);
+
+    expectExternrefModuleGlobal(result.wat, "proxiedIterator");
+    expect(((await instantiate(result)).test as () => number)()).toBe(23);
+  });
+
+  it("preserves the function-local #2615 member-only and escaping slot split", async () => {
+    const result = await compileProxySource(`
+      function consume(value: any): number { return value ? 1 : 0; }
+      export function memberOnly(): number {
+        const p = new Proxy({ x: 1 }, { get: function () { return 7; } });
+        return p.x;
+      }
+      export function escaping(): number {
+        const p = new Proxy({ x: 1 }, {});
+        return consume((p as any)!);
+      }
+    `);
+    const memberOnly = result.wat.split("\n").find((line) => /\(local \$p\s/.test(line));
+    expect(memberOnly).toContain("externref");
+
+    const escapingBody = result.wat.slice(result.wat.indexOf("(func $escaping"));
+    const escaping = escapingBody.split("\n").find((line) => /\(local \$p\s/.test(line));
+    expect(escaping).toBeDefined();
+    expect(escaping).not.toContain("externref");
+  });
+});


### PR DESCRIPTION
## Summary

- extract the existing Proxy escape decision into one binding-identity-aware shared analysis
- keep escaping module Proxy bindings structurally typed while member-only carriers remain externref
- add a default-on module-only gate where exact JS2WASM_PROXY_MODULE_ESCAPE_GATE=0 restores the #4931 behavior
- add the grounded issue plan and mutation-sensitive wrapper, shadow, capture, kill-switch, local, and #4707 controls

Issue: [#4754 — module-global Proxy widening bypasses the escape gate](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4754-module-global-proxy-escape-gate)

## Evidence

- focused #4754 suite: 10/10 passed
- exact gate-on Test262 matrix: concat returns to prior host assertion plus standalone pass; splice returns to prior host runtime error plus standalone assertion; all six #4707 cells pass
- exact gate-off attribution: both affected rows return to illegal-cast/illegal-cast while iterator-as-Proxy remains pass/pass
- TypeScript 7 and TypeScript 5 checks passed
- Prettier, Biome, oracle, coercion, LOC, function, verdict, and issue-integrity ratchets passed
- source growth is net +58 LOC with no allowance
- both unrelated #2615 Node failures reproduce on exact base with byte-identical Wasm binaries
- pre-commit hooks passed, including changed-root 10/10; pre-push hooks passed, including numeric-local IR parity 18/18
- signed commit independently audited and verified

## Scope

No Array consumer, iterator implementation, runtime, Test262 oracle, tolerance, or trap baseline changes. Final acceptance remains pending this PRs own merge-group Test262 run.

## CLA

- [x] I have read and agree to the CLA