### PR TITLE
feat(program-abi): describe prepared callable plans (#4260)

### DIFF
--- a/src/codegen/program-abi-import-planning.ts
+++ b/src/codegen/program-abi-import-planning.ts
@@ -14,7 +14,7 @@ import {
   programAbiCallableSignaturesEqual,
   type ProgramAbiCallableTypeContract,
 } from "./program-abi-signatures.js";
-import type { ProgramAbiDraft, ProgramAbiSlotLocator } from "./program-abi-session.js";
+import type { ProgramAbiDraft, ProgramAbiSession, ProgramAbiSlotLocator } from "./program-abi-session.js";
 
 /** Source-anchored global roles not owned by source declaration planning. */
 const PROGRAM_ABI_IMPORT_GLOBAL_ROLE = Object.freeze({
@@ -238,6 +238,7 @@ interface PreparedCallableImportDenominatorEntry {
 
 interface PreparedCallableImportSessionSnapshot {
   readonly draft: ProgramAbiDraft | undefined;
+  readonly structuralOrderOwner: IrBindingId | undefined;
   readonly structuralReferenceBindingIds: readonly IrBindingId[];
   readonly locatorOwner: IrBindingId | undefined;
   readonly hasExactLocator: boolean;
@@ -312,6 +313,26 @@ function callableImportEntriesEqual(left: ProgramAbiCallableImport, right: Progr
     left.capabilityId === right.capabilityId &&
     left.providerId === right.providerId
   );
+}
+
+function draftStructuralOrderOwner(session: ProgramAbiSession, draft: ProgramAbiDraft): IrBindingId | undefined {
+  const sourceOrder = session.inventory.sources.find(({ id }) => id === draft.structuralOrder.sourceId)?.order;
+  if (sourceOrder === undefined) {
+    throw new ProgramAbiInvariantError(
+      "unknown-draft-source",
+      `ABI draft ${draft.id} references source ${draft.structuralOrder.sourceId} outside this inventory`,
+    );
+  }
+  const order = draft.structuralOrder;
+  const key = [
+    sourceOrder,
+    order.declarationOrdinal,
+    order.domainOrdinal,
+    order.roleOrdinal,
+    order.derivedOrdinal,
+  ].join(":");
+  const state = session as unknown as { readonly draftOrderOwners: ReadonlyMap<string, IrBindingId> };
+  return state.draftOrderOwners.get(key);
 }
 
 /**
@@ -488,6 +509,7 @@ export class ProgramAbiCallableImportRegistry {
         actual.planned.bindingId !== expected.bindingId ||
         actual.planned.ordinal !== expected.ordinal ||
         !callableDraftsEqual(actual.session.draft, expected.draft) ||
+        actual.session.structuralOrderOwner !== expected.bindingId ||
         !exactBindingIdsEqual(actual.session.structuralReferenceBindingIds, [expected.bindingId]) ||
         actual.session.locatorOwner !== expected.bindingId ||
         !actual.session.hasExactLocator
@@ -608,6 +630,7 @@ export class ProgramAbiCallableImportRegistry {
     }
     const session = Object.freeze({
       draft: this.session.getDraft(bindingId),
+      structuralOrderOwner: draftStructuralOrderOwner(this.session, draft),
       structuralReferenceBindingIds: Object.freeze([
         ...this.session.bindingIdsForStructuralReference(denominatorEntry.entry.key),
       ]),
@@ -617,6 +640,7 @@ export class ProgramAbiCallableImportRegistry {
     const expectedIds = planned ? Object.freeze([bindingId]) : Object.freeze([]);
     if (
       !callableDraftsEqual(session.draft, planned ? draft : undefined) ||
+      session.structuralOrderOwner !== (planned ? bindingId : undefined) ||
       !exactBindingIdsEqual(session.structuralReferenceBindingIds, expectedIds) ||
       session.locatorOwner !== (planned ? bindingId : undefined) ||
       session.hasExactLocator !== (planned !== undefined)
@@ -670,6 +694,7 @@ export class ProgramAbiCallableImportRegistry {
       !callableTypeContractsEqual(expected.typeContract, actual.typeContract) ||
       !callableDraftsEqual(expected.draft, actual.draft) ||
       !callableDraftsEqual(expected.session.draft, actual.session.draft) ||
+      expected.session.structuralOrderOwner !== actual.session.structuralOrderOwner ||
       !exactBindingIdsEqual(
         expected.session.structuralReferenceBindingIds,
         actual.session.structuralReferenceBindingIds,

--- a/src/codegen/program-abi-import-planning.ts
+++ b/src/codegen/program-abi-import-planning.ts
@@ -7,10 +7,14 @@ import { ProgramAbiInvariantError } from "../ir/program-abi.js";
 import type { IrGlobalRef } from "../ir/nodes.js";
 import type { FuncTypeDef, Import, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { programAbiIntentsEqual } from "./program-abi-intent-equality.js";
 import {
   canonicalProgramAbiCallableTypeContract,
   cloneProgramAbiCallableTypeContract,
+  programAbiCallableSignaturesEqual,
+  type ProgramAbiCallableTypeContract,
 } from "./program-abi-signatures.js";
+import type { ProgramAbiDraft, ProgramAbiSlotLocator } from "./program-abi-session.js";
 
 /** Source-anchored global roles not owned by source declaration planning. */
 const PROGRAM_ABI_IMPORT_GLOBAL_ROLE = Object.freeze({
@@ -225,6 +229,91 @@ interface PlannedCallableImport {
   readonly ordinal: number;
 }
 
+interface PreparedCallableImportDenominatorEntry {
+  readonly entry: ProgramAbiCallableImport;
+  readonly descriptor: Import["desc"];
+  readonly signature: FuncTypeDef;
+  readonly typeContract: ProgramAbiCallableTypeContract;
+}
+
+interface PreparedCallableImportSessionSnapshot {
+  readonly draft: ProgramAbiDraft | undefined;
+  readonly structuralReferenceBindingIds: readonly IrBindingId[];
+  readonly locatorOwner: IrBindingId | undefined;
+  readonly hasExactLocator: boolean;
+}
+
+interface PreparedCallableImportEntry extends PreparedCallableImportDenominatorEntry {
+  readonly ordinal: number;
+  readonly bindingId: IrBindingId;
+  readonly draft: ProgramAbiDraft;
+  readonly locator: Extract<ProgramAbiSlotLocator, { readonly kind: "import-function" }>;
+  readonly planned: PlannedCallableImport | undefined;
+  readonly session: PreparedCallableImportSessionSnapshot;
+}
+
+interface PreparedCallableImportDescriptorPayload {
+  readonly registry: ProgramAbiCallableImportRegistry;
+  readonly sealedEntries: readonly ProgramAbiCallableImport[] | undefined;
+  readonly denominator: readonly PreparedCallableImportDenominatorEntry[];
+  readonly selected: readonly PreparedCallableImportEntry[];
+}
+
+/** Opaque registry-authenticated token; its payload never crosses this module. */
+interface PreparedCallableImportDescriptor {
+  readonly kind: "prepared-callable-import-descriptor";
+}
+
+const preparedCallableImportDescriptors = new WeakMap<
+  PreparedCallableImportDescriptor,
+  PreparedCallableImportDescriptorPayload
+>();
+
+function callableTypeContractsEqual(
+  left: ProgramAbiCallableTypeContract,
+  right: ProgramAbiCallableTypeContract,
+): boolean {
+  return programAbiCallableSignaturesEqual(
+    canonicalProgramAbiCallableTypeContract(left),
+    canonicalProgramAbiCallableTypeContract(right),
+  );
+}
+
+function callableDraftsEqual(left: ProgramAbiDraft | undefined, right: ProgramAbiDraft | undefined): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  const leftAlias = left as ProgramAbiDraft & { readonly aliasOf?: IrBindingId; readonly slotSpace?: string };
+  const rightAlias = right as ProgramAbiDraft & { readonly aliasOf?: IrBindingId; readonly slotSpace?: string };
+  return (
+    left.id === right.id &&
+    left.displayName === right.displayName &&
+    left.structuralReferenceKey === right.structuralReferenceKey &&
+    left.slotPolicy === right.slotPolicy &&
+    leftAlias.slotSpace === rightAlias.slotSpace &&
+    leftAlias.aliasOf === rightAlias.aliasOf &&
+    left.structuralOrder.sourceId === right.structuralOrder.sourceId &&
+    left.structuralOrder.declarationOrdinal === right.structuralOrder.declarationOrdinal &&
+    left.structuralOrder.domainOrdinal === right.structuralOrder.domainOrdinal &&
+    left.structuralOrder.roleOrdinal === right.structuralOrder.roleOrdinal &&
+    left.structuralOrder.derivedOrdinal === right.structuralOrder.derivedOrdinal &&
+    programAbiIntentsEqual(left.intent, right.intent)
+  );
+}
+
+function exactBindingIdsEqual(left: readonly IrBindingId[], right: readonly IrBindingId[]): boolean {
+  return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
+function callableImportEntriesEqual(left: ProgramAbiCallableImport, right: ProgramAbiCallableImport): boolean {
+  return (
+    left.baseKey === right.baseKey &&
+    left.key === right.key &&
+    left.value === right.value &&
+    left.signature === right.signature &&
+    left.capabilityId === right.capabilityId &&
+    left.providerId === right.providerId
+  );
+}
+
 /**
  * Compilation-wide callable-import planner with a selective pre-DCE seal.
  *
@@ -251,23 +340,82 @@ export class ProgramAbiCallableImportRegistry {
     return new ImmutableProgramAbiImportCatalog(entries.map(({ key, value }) => Object.freeze([key, value] as const)));
   }
 
-  planPrepared(values: ReadonlySet<Import>): void {
-    if (values.size === 0) return;
+  describePrepared(values: ReadonlySet<Import>): PreparedCallableImportDescriptor {
     if (this.plannedValue) {
       throw new ProgramAbiInvariantError(
         "planning-sealed",
-        "cannot prepare callable imports after retained import planning",
+        "cannot describe prepared callable imports after retained import planning",
       );
     }
-    const entries = this.sealEntries();
-    const byImport = new Map(entries.map((entry, ordinal) => [entry.value, { entry, ordinal }] as const));
-    for (const value of values) {
-      const selected = byImport.get(value);
-      if (!selected) {
-        throw callableImportError("prepared callable import is outside the sealed pre-DCE import population");
-      }
-      this.planEntry(selected.entry, selected.ordinal);
+    const sealedEntries = this.sealedEntries;
+    const denominator = this.describeDenominator(sealedEntries ?? collectProgramAbiCallableImports(this.ctx));
+    const current = collectProgramAbiCallableImports(this.ctx);
+    const selected = Object.freeze([...values].map((value) => this.describeSelectedEntry(value, denominator, current)));
+    const descriptor = Object.freeze({ kind: "prepared-callable-import-descriptor" as const });
+    preparedCallableImportDescriptors.set(
+      descriptor,
+      Object.freeze({
+        registry: this,
+        sealedEntries,
+        denominator,
+        selected,
+      }),
+    );
+    return descriptor;
+  }
+
+  assertPreparedDescriptorCurrent(descriptor: PreparedCallableImportDescriptor): void {
+    const payload = this.requirePreparedDescriptor(descriptor);
+    if (this.plannedValue) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        "prepared callable-import descriptor crossed retained import planning",
+      );
     }
+    if (payload.sealedEntries === undefined) {
+      if (this.sealedEntries !== undefined) {
+        throw callableImportError("prepared callable-import descriptor crossed a denominator seal");
+      }
+    } else if (this.sealedEntries !== payload.sealedEntries) {
+      throw callableImportError("prepared callable-import descriptor no longer owns the exact sealed denominator");
+    }
+
+    const denominator = this.describeDenominator(payload.sealedEntries ?? collectProgramAbiCallableImports(this.ctx));
+    this.assertSameDenominator(payload.denominator, denominator);
+    const current = collectProgramAbiCallableImports(this.ctx);
+    for (const expected of payload.selected) {
+      const actual = this.describeSelectedEntry(expected.entry.value, denominator, current);
+      this.assertSameSelectedEntry(expected, actual);
+    }
+  }
+
+  preparedDescriptorBindingId(descriptor: PreparedCallableImportDescriptor, value: Import): IrBindingId | undefined {
+    const payload = this.requirePreparedDescriptor(descriptor);
+    const selected = payload.selected.find((entry) => entry.entry.value === value);
+    if (!selected) {
+      this.assertPreparedDescriptorCurrent(descriptor);
+      return undefined;
+    }
+    const planned = this.plannedByImport.get(value);
+    if (planned?.bindingId === selected.bindingId) {
+      this.assertPreparedDescriptorPublished(payload);
+    } else {
+      this.assertPreparedDescriptorCurrent(descriptor);
+    }
+    return selected.bindingId;
+  }
+
+  publishPreparedDescriptor(descriptor: PreparedCallableImportDescriptor): void {
+    this.assertPreparedDescriptorCurrent(descriptor);
+    const payload = this.requirePreparedDescriptor(descriptor);
+    if (payload.selected.length === 0) return;
+    this.sealedEntries ??= Object.freeze(payload.denominator.map(({ entry }) => entry));
+    for (const entry of payload.selected) this.planPreparedEntry(entry);
+  }
+
+  planPrepared(values: ReadonlySet<Import>): void {
+    if (values.size === 0) return;
+    this.publishPreparedDescriptor(this.describePrepared(values));
   }
 
   planRetained(): ReadonlyMap<string, IrBindingId> {
@@ -308,18 +456,243 @@ export class ProgramAbiCallableImportRegistry {
     return this.plannedValue;
   }
 
-  private sealEntries(): readonly ProgramAbiCallableImport[] {
-    if (this.sealedEntries) return this.sealedEntries;
-    const entries = collectProgramAbiCallableImports(this.ctx);
-    const exactImports = new Set<Import>();
-    for (const entry of entries) {
-      if (exactImports.has(entry.value)) {
-        throw callableImportError(`callable import ${entry.key} reuses one allocator object in multiple slots`);
-      }
-      exactImports.add(entry.value);
+  private requirePreparedDescriptor(
+    descriptor: PreparedCallableImportDescriptor,
+  ): PreparedCallableImportDescriptorPayload {
+    const payload = preparedCallableImportDescriptors.get(descriptor);
+    if (!payload || payload.registry !== this) {
+      throw callableImportError("prepared callable-import descriptor is forged or belongs to another registry");
     }
-    this.sealedEntries = entries;
-    return entries;
+    return payload;
+  }
+
+  private assertPreparedDescriptorPublished(payload: PreparedCallableImportDescriptorPayload): void {
+    if (this.plannedValue || !this.sealedEntries) {
+      throw callableImportError("prepared callable-import descriptor is neither fresh nor exactly published");
+    }
+    const denominator = this.describeDenominator(this.sealedEntries);
+    this.assertSameDenominator(payload.denominator, denominator);
+    const current = collectProgramAbiCallableImports(this.ctx);
+    for (const expected of payload.selected) {
+      const actual = this.describeSelectedEntry(expected.entry.value, denominator, current);
+      if (
+        !callableImportEntriesEqual(actual.entry, expected.entry) ||
+        actual.ordinal !== expected.ordinal ||
+        actual.bindingId !== expected.bindingId ||
+        actual.descriptor !== expected.descriptor ||
+        actual.signature !== expected.signature ||
+        actual.locator.value !== expected.locator.value ||
+        !callableTypeContractsEqual(actual.typeContract, expected.typeContract) ||
+        !callableDraftsEqual(actual.draft, expected.draft) ||
+        actual.planned?.key !== expected.entry.key ||
+        actual.planned.bindingId !== expected.bindingId ||
+        actual.planned.ordinal !== expected.ordinal ||
+        !callableDraftsEqual(actual.session.draft, expected.draft) ||
+        !exactBindingIdsEqual(actual.session.structuralReferenceBindingIds, [expected.bindingId]) ||
+        actual.session.locatorOwner !== expected.bindingId ||
+        !actual.session.hasExactLocator
+      ) {
+        throw callableImportError(`published callable import ${expected.entry.key} no longer matches its descriptor`);
+      }
+    }
+  }
+
+  private describeDenominator(
+    entries: readonly ProgramAbiCallableImport[],
+  ): readonly PreparedCallableImportDenominatorEntry[] {
+    const entrySourceId = canonicalEntrySource(this.ctx);
+    const exactImports = new Set<Import>();
+    const exactKeys = new Set<string>();
+    const exactBindingIds = new Set<IrBindingId>();
+    return Object.freeze(
+      entries.map((entry, ordinal) => {
+        if (exactImports.has(entry.value)) {
+          throw callableImportError(`callable import ${entry.key} reuses one allocator object in multiple slots`);
+        }
+        if (exactKeys.has(entry.key)) {
+          throw callableImportError(`callable import denominator repeats structural key ${entry.key}`);
+        }
+        exactImports.add(entry.value);
+        exactKeys.add(entry.key);
+        const signature = callableImportSignature(this.ctx, entry.value);
+        if (signature !== entry.signature) {
+          throw callableImportError(`callable import ${entry.key} changed its exact function type object`);
+        }
+        const bindingId = createIrBindingId({
+          ownerId: entrySourceId,
+          domain: "callable",
+          role: PROGRAM_ABI_IMPORT_CALLABLE_BINDING_ROLE,
+          ordinal,
+        });
+        if (exactBindingIds.has(bindingId)) {
+          throw callableImportError(`callable import ${entry.key} collides on projected binding ${bindingId}`);
+        }
+        exactBindingIds.add(bindingId);
+        return Object.freeze({
+          entry,
+          descriptor: entry.value.desc,
+          signature,
+          typeContract: cloneProgramAbiCallableTypeContract(signature),
+        });
+      }),
+    );
+  }
+
+  private describeSelectedEntry(
+    value: Import,
+    denominator: readonly PreparedCallableImportDenominatorEntry[],
+    current: readonly ProgramAbiCallableImport[],
+  ): PreparedCallableImportEntry {
+    const ordinal = denominator.findIndex((entry) => entry.entry.value === value);
+    if (ordinal < 0) {
+      throw callableImportError("prepared callable import is outside the sealed pre-DCE import population");
+    }
+    const currentEntries = current.filter((entry) => entry.value === value);
+    if (currentEntries.length !== 1) {
+      throw callableImportError(
+        `prepared callable import ${denominator[ordinal]!.entry.key} must appear exactly once in the current population`,
+      );
+    }
+    const denominatorEntry = denominator[ordinal]!;
+    const currentEntry = currentEntries[0]!;
+    if (
+      currentEntry.key !== denominatorEntry.entry.key ||
+      currentEntry.baseKey !== denominatorEntry.entry.baseKey ||
+      currentEntry.signature !== denominatorEntry.signature ||
+      currentEntry.value.desc !== denominatorEntry.descriptor ||
+      currentEntry.capabilityId !== denominatorEntry.entry.capabilityId ||
+      currentEntry.providerId !== denominatorEntry.entry.providerId ||
+      !callableTypeContractsEqual(
+        denominatorEntry.typeContract,
+        cloneProgramAbiCallableTypeContract(currentEntry.signature),
+      )
+    ) {
+      throw callableImportError(`prepared callable import ${denominatorEntry.entry.key} changed structural identity`);
+    }
+
+    const entrySourceId = canonicalEntrySource(this.ctx);
+    const bindingId = createIrBindingId({
+      ownerId: entrySourceId,
+      domain: "callable",
+      role: PROGRAM_ABI_IMPORT_CALLABLE_BINDING_ROLE,
+      ordinal,
+    });
+    const draft = Object.freeze({
+      id: bindingId,
+      structuralOrder: Object.freeze({
+        ...this.session.structuralOrder.forSource(entrySourceId, {
+          domain: "callable",
+          roleOrdinal: PROGRAM_ABI_IMPORT_CALLABLE_ROLE.importedFunction,
+          derivedOrdinal: ordinal,
+        }),
+      }),
+      structuralReferenceKey: denominatorEntry.entry.key,
+      displayName: value.name,
+      slotPolicy: "required" as const,
+      slotSpace: "function" as const,
+      intent: Object.freeze({
+        kind: "callable" as const,
+        origin: "import" as const,
+        signature: canonicalProgramAbiCallableTypeContract(denominatorEntry.typeContract),
+        ...(denominatorEntry.entry.capabilityId
+          ? {
+              capabilityId: denominatorEntry.entry.capabilityId,
+              providerId: denominatorEntry.entry.providerId,
+            }
+          : {}),
+      }),
+    }) satisfies ProgramAbiDraft;
+    const planned = this.plannedByImport.get(value);
+    if (planned && (planned.key !== denominatorEntry.entry.key || planned.ordinal !== ordinal)) {
+      throw callableImportError(`callable import ${denominatorEntry.entry.key} changed its sealed structural identity`);
+    }
+    const session = Object.freeze({
+      draft: this.session.getDraft(bindingId),
+      structuralReferenceBindingIds: Object.freeze([
+        ...this.session.bindingIdsForStructuralReference(denominatorEntry.entry.key),
+      ]),
+      locatorOwner: this.session.locatorBindingId(value),
+      hasExactLocator: this.session.hasLocator(bindingId, value),
+    });
+    const expectedIds = planned ? Object.freeze([bindingId]) : Object.freeze([]);
+    if (
+      !callableDraftsEqual(session.draft, planned ? draft : undefined) ||
+      !exactBindingIdsEqual(session.structuralReferenceBindingIds, expectedIds) ||
+      session.locatorOwner !== (planned ? bindingId : undefined) ||
+      session.hasExactLocator !== (planned !== undefined)
+    ) {
+      throw callableImportError(
+        `prepared callable import ${denominatorEntry.entry.key} disagrees with current session ownership`,
+      );
+    }
+    return Object.freeze({
+      ...denominatorEntry,
+      ordinal,
+      bindingId,
+      draft,
+      locator: Object.freeze({ kind: "import-function" as const, value }),
+      planned,
+      session,
+    });
+  }
+
+  private assertSameDenominator(
+    expected: readonly PreparedCallableImportDenominatorEntry[],
+    actual: readonly PreparedCallableImportDenominatorEntry[],
+  ): void {
+    if (
+      expected.length !== actual.length ||
+      expected.some((entry, index) => {
+        const current = actual[index]!;
+        return (
+          !callableImportEntriesEqual(entry.entry, current.entry) ||
+          entry.descriptor !== current.descriptor ||
+          entry.signature !== current.signature ||
+          entry.entry.capabilityId !== current.entry.capabilityId ||
+          entry.entry.providerId !== current.entry.providerId ||
+          !callableTypeContractsEqual(entry.typeContract, current.typeContract)
+        );
+      })
+    ) {
+      throw callableImportError("prepared callable-import descriptor denominator is stale");
+    }
+  }
+
+  private assertSameSelectedEntry(expected: PreparedCallableImportEntry, actual: PreparedCallableImportEntry): void {
+    if (
+      !callableImportEntriesEqual(expected.entry, actual.entry) ||
+      expected.ordinal !== actual.ordinal ||
+      expected.bindingId !== actual.bindingId ||
+      expected.descriptor !== actual.descriptor ||
+      expected.signature !== actual.signature ||
+      expected.planned !== actual.planned ||
+      expected.locator.value !== actual.locator.value ||
+      !callableTypeContractsEqual(expected.typeContract, actual.typeContract) ||
+      !callableDraftsEqual(expected.draft, actual.draft) ||
+      !callableDraftsEqual(expected.session.draft, actual.session.draft) ||
+      !exactBindingIdsEqual(
+        expected.session.structuralReferenceBindingIds,
+        actual.session.structuralReferenceBindingIds,
+      ) ||
+      expected.session.locatorOwner !== actual.session.locatorOwner ||
+      expected.session.hasExactLocator !== actual.session.hasExactLocator
+    ) {
+      throw callableImportError(`prepared callable import ${expected.entry.key} descriptor is stale`);
+    }
+  }
+
+  private planPreparedEntry(entry: PreparedCallableImportEntry): IrBindingId {
+    const existing = this.plannedByImport.get(entry.entry.value);
+    if (existing) return existing.bindingId;
+    this.session.ensurePlan(entry.draft);
+    this.session.registerCallableTypeContract(entry.bindingId, entry.typeContract);
+    this.session.registerStructuralReference(entry.bindingId, entry.entry.key);
+    this.session.attachLocator(entry.bindingId, entry.locator);
+    this.plannedByImport.set(
+      entry.entry.value,
+      Object.freeze({ key: entry.entry.key, bindingId: entry.bindingId, ordinal: entry.ordinal }),
+    );
+    return entry.bindingId;
   }
 
   private planEntry(entry: ProgramAbiCallableImport, ordinal: number): IrBindingId {

--- a/src/codegen/program-abi-provider-planning.ts
+++ b/src/codegen/program-abi-provider-planning.ts
@@ -45,6 +45,7 @@ interface PreparedCallableProviderDenominatorEntry {
 
 interface PreparedCallableProviderSessionSnapshot {
   readonly draft: ProgramAbiDraft | undefined;
+  readonly structuralOrderOwner: IrBindingId | undefined;
   readonly structuralReferenceBindingIds: readonly IrBindingId[];
   readonly locatorOwner: IrBindingId | undefined;
   readonly hasExactLocator: boolean;
@@ -195,6 +196,26 @@ function exactBindingIdsEqual(left: readonly IrBindingId[], right: readonly IrBi
 
 function exactStringsEqual(left: readonly string[], right: readonly string[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function draftStructuralOrderOwner(session: ProgramAbiSession, draft: ProgramAbiDraft): IrBindingId | undefined {
+  const sourceOrder = session.inventory.sources.find(({ id }) => id === draft.structuralOrder.sourceId)?.order;
+  if (sourceOrder === undefined) {
+    throw new ProgramAbiInvariantError(
+      "unknown-draft-source",
+      `ABI draft ${draft.id} references source ${draft.structuralOrder.sourceId} outside this inventory`,
+    );
+  }
+  const order = draft.structuralOrder;
+  const key = [
+    sourceOrder,
+    order.declarationOrdinal,
+    order.domainOrdinal,
+    order.roleOrdinal,
+    order.derivedOrdinal,
+  ].join(":");
+  const state = session as unknown as { readonly draftOrderOwners: ReadonlyMap<string, IrBindingId> };
+  return state.draftOrderOwners.get(key);
 }
 
 /**
@@ -695,6 +716,7 @@ export class ProgramAbiCallableProviderRegistry {
         }
         const session = Object.freeze({
           draft: this.session.getDraft(bindingId),
+          structuralOrderOwner: draftStructuralOrderOwner(this.session, draft),
           structuralReferenceBindingIds: Object.freeze([
             ...this.session.bindingIdsForStructuralReference(entry.provider.structuralReferenceKey),
           ]),
@@ -708,6 +730,7 @@ export class ProgramAbiCallableProviderRegistry {
             : session.locatorOwner === (owner.kind === "batch-provider" ? undefined : owner.id);
         if (
           !callableDraftsEqual(session.draft, planned ? draft : undefined) ||
+          session.structuralOrderOwner !== (planned ? bindingId : undefined) ||
           !exactBindingIdsEqual(session.structuralReferenceBindingIds, expectedIds) ||
           !ownerCurrent ||
           session.hasExactLocator !== (planned !== undefined && ownsLocator)
@@ -776,6 +799,7 @@ export class ProgramAbiCallableProviderRegistry {
       !callableTypeContractsEqual(expected.typeContract, actual.typeContract) ||
       !callableDraftsEqual(expected.draft, actual.draft) ||
       !callableDraftsEqual(expected.session.draft, actual.session.draft) ||
+      expected.session.structuralOrderOwner !== actual.session.structuralOrderOwner ||
       !exactBindingIdsEqual(
         expected.session.structuralReferenceBindingIds,
         actual.session.structuralReferenceBindingIds,

--- a/src/codegen/program-abi-provider-planning.ts
+++ b/src/codegen/program-abi-provider-planning.ts
@@ -6,12 +6,16 @@ import { ProgramAbiInvariantError } from "../ir/program-abi.js";
 import type { IrFuncRef } from "../ir/nodes.js";
 import type { FuncTypeDef, Import, WasmFunction, WasmModule } from "../ir/types.js";
 import { definedFuncAt, definedFuncHandleOf, isImportFuncIdx } from "./func-space.js";
+import { programAbiIntentsEqual } from "./program-abi-intent-equality.js";
+import type { ProgramAbiCallableImportRegistry } from "./program-abi-import-planning.js";
 import { PROGRAM_ABI_CALLABLE_ROLE } from "./program-abi-planning.js";
 import type { CodegenContext } from "./context/types.js";
-import type { ProgramAbiSession, ProgramAbiSlotLocator } from "./program-abi-session.js";
+import type { ProgramAbiDraft, ProgramAbiSession, ProgramAbiSlotLocator } from "./program-abi-session.js";
 import {
   canonicalProgramAbiCallableTypeContract,
   cloneProgramAbiCallableTypeContract,
+  programAbiCallableSignaturesEqual,
+  type ProgramAbiCallableTypeContract,
 } from "./program-abi-signatures.js";
 
 // (#4033) Sourced from the shared role table, NOT a local literal. This was
@@ -28,6 +32,55 @@ interface ObservedProvider {
   readonly structuralReferenceKey: string;
   readonly locator: ProviderLocator;
 }
+
+type PreparedCallableImportDescriptor = ReturnType<ProgramAbiCallableImportRegistry["describePrepared"]>;
+
+interface PreparedCallableProviderDenominatorEntry {
+  readonly provider: ObservedProvider;
+  readonly ordinal: number;
+  readonly typeIndex: number;
+  readonly signature: FuncTypeDef;
+  readonly typeContract: ProgramAbiCallableTypeContract;
+}
+
+interface PreparedCallableProviderSessionSnapshot {
+  readonly draft: ProgramAbiDraft | undefined;
+  readonly structuralReferenceBindingIds: readonly IrBindingId[];
+  readonly locatorOwner: IrBindingId | undefined;
+  readonly hasExactLocator: boolean;
+}
+
+type PreparedCallableProviderOwnerKind = "committed" | "batch-provider" | "provisional-import";
+
+interface PreparedCallableProviderEntry extends PreparedCallableProviderDenominatorEntry {
+  readonly bindingId: IrBindingId;
+  readonly draft: ProgramAbiDraft;
+  readonly canonicalOwner: IrBindingId;
+  readonly ownerKind: PreparedCallableProviderOwnerKind;
+  readonly ownsLocator: boolean;
+  readonly planned: IrBindingId | undefined;
+  readonly session: PreparedCallableProviderSessionSnapshot;
+}
+
+interface PreparedCallableProviderDescriptorPayload {
+  readonly registry: ProgramAbiCallableProviderRegistry;
+  readonly observationOrder: readonly string[] | undefined;
+  readonly appendedOrder: readonly string[];
+  readonly denominator: readonly PreparedCallableProviderDenominatorEntry[];
+  readonly selected: readonly PreparedCallableProviderEntry[];
+  readonly returnKeys: readonly string[];
+  readonly importDescriptor: PreparedCallableImportDescriptor | undefined;
+}
+
+/** Opaque registry-authenticated token; its payload never crosses this module. */
+interface PreparedCallableProviderDescriptor {
+  readonly kind: "prepared-callable-provider-descriptor";
+}
+
+const preparedCallableProviderDescriptors = new WeakMap<
+  PreparedCallableProviderDescriptor,
+  PreparedCallableProviderDescriptorPayload
+>();
 
 function providerError(message: string): ProgramAbiInvariantError {
   return new ProgramAbiInvariantError("callable-provider-mismatch", message);
@@ -94,6 +147,54 @@ function canonicalEntrySource(session: ProgramAbiSession): IrSourceId {
 
 function sameLocator(left: ProviderLocator, right: ProviderLocator): boolean {
   return left.kind === right.kind && left.value === right.value;
+}
+
+function callableTypeIndex(locator: ProviderLocator): number {
+  if (locator.kind === "import-function") {
+    if (locator.value.desc.kind !== "func") {
+      throw providerError("import-function provider locator no longer carries a function descriptor");
+    }
+    return locator.value.desc.typeIdx;
+  }
+  return locator.value.typeIdx;
+}
+
+function callableTypeContractsEqual(
+  left: ProgramAbiCallableTypeContract,
+  right: ProgramAbiCallableTypeContract,
+): boolean {
+  return programAbiCallableSignaturesEqual(
+    canonicalProgramAbiCallableTypeContract(left),
+    canonicalProgramAbiCallableTypeContract(right),
+  );
+}
+
+function callableDraftsEqual(left: ProgramAbiDraft | undefined, right: ProgramAbiDraft | undefined): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  const leftAlias = left as ProgramAbiDraft & { readonly aliasOf?: IrBindingId; readonly slotSpace?: string };
+  const rightAlias = right as ProgramAbiDraft & { readonly aliasOf?: IrBindingId; readonly slotSpace?: string };
+  return (
+    left.id === right.id &&
+    left.displayName === right.displayName &&
+    left.structuralReferenceKey === right.structuralReferenceKey &&
+    left.slotPolicy === right.slotPolicy &&
+    leftAlias.slotSpace === rightAlias.slotSpace &&
+    leftAlias.aliasOf === rightAlias.aliasOf &&
+    left.structuralOrder.sourceId === right.structuralOrder.sourceId &&
+    left.structuralOrder.declarationOrdinal === right.structuralOrder.declarationOrdinal &&
+    left.structuralOrder.domainOrdinal === right.structuralOrder.domainOrdinal &&
+    left.structuralOrder.roleOrdinal === right.structuralOrder.roleOrdinal &&
+    left.structuralOrder.derivedOrdinal === right.structuralOrder.derivedOrdinal &&
+    programAbiIntentsEqual(left.intent, right.intent)
+  );
+}
+
+function exactBindingIdsEqual(left: readonly IrBindingId[], right: readonly IrBindingId[]): boolean {
+  return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
+function exactStringsEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 /**
@@ -232,6 +333,140 @@ export class ProgramAbiCallableProviderRegistry {
     return imports;
   }
 
+  describePrepared(
+    structuralReferenceKeys: ReadonlySet<string>,
+    exactImportDescriptor?: PreparedCallableImportDescriptor,
+  ): PreparedCallableProviderDescriptor {
+    if (this.plannedValue) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        "cannot describe prepared callable providers after retained provider planning",
+      );
+    }
+    const importRegistry = this.ctx.programAbiCallableImports;
+    if (exactImportDescriptor) {
+      if (!importRegistry) {
+        throw providerError("prepared callable-provider import descriptor has no registry in this context");
+      }
+      importRegistry.assertPreparedDescriptorCurrent(exactImportDescriptor);
+    }
+    const observationOrder = this.observationOrder;
+    const appendedOrder = Object.freeze([...this.appendedOrder]);
+    const denominator = this.describeDenominator(this.currentDescriptionOrder());
+    const requestedKeys = Object.freeze([...structuralReferenceKeys]);
+    const requestedProviders = requestedKeys.map((key) => {
+      const provider = this.observed.get(key);
+      if (!provider) {
+        throw providerError(`prepared callable provider ${key} was not observed before discovery sealed`);
+      }
+      return provider;
+    });
+    const returnKeys = [...requestedKeys];
+    const selectedKeys = new Set(returnKeys);
+    for (const candidate of this.observed.values()) {
+      if (
+        requestedProviders.some((requested) => sameLocator(requested.locator, candidate.locator)) &&
+        !selectedKeys.has(candidate.structuralReferenceKey)
+      ) {
+        selectedKeys.add(candidate.structuralReferenceKey);
+        returnKeys.push(candidate.structuralReferenceKey);
+      }
+    }
+    const selected = this.describeSelectedEntries(
+      denominator.filter(({ provider }) => selectedKeys.has(provider.structuralReferenceKey)),
+      exactImportDescriptor,
+    );
+    const descriptor = Object.freeze({ kind: "prepared-callable-provider-descriptor" as const });
+    preparedCallableProviderDescriptors.set(
+      descriptor,
+      Object.freeze({
+        registry: this,
+        observationOrder,
+        appendedOrder,
+        denominator,
+        selected,
+        returnKeys: Object.freeze(returnKeys),
+        importDescriptor: exactImportDescriptor,
+      }),
+    );
+    return descriptor;
+  }
+
+  assertPreparedDescriptorCurrent(descriptor: PreparedCallableProviderDescriptor): void {
+    const payload = this.requirePreparedDescriptor(descriptor);
+    if (this.plannedValue) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        "prepared callable-provider descriptor crossed retained provider planning",
+      );
+    }
+    if (payload.observationOrder === undefined) {
+      if (this.observationOrder !== undefined) {
+        throw providerError("prepared callable-provider descriptor crossed an observation-order seal");
+      }
+    } else if (this.observationOrder !== payload.observationOrder) {
+      throw providerError("prepared callable-provider descriptor lost its exact sealed prefix");
+    }
+    if (!exactStringsEqual(payload.appendedOrder, this.appendedOrder)) {
+      throw providerError("prepared callable-provider descriptor appended suffix is stale");
+    }
+    const denominator = this.describeDenominator(this.currentDescriptionOrder());
+    this.assertSameDenominator(payload.denominator, denominator);
+    if (payload.importDescriptor) {
+      const importRegistry = this.ctx.programAbiCallableImports;
+      if (!importRegistry) {
+        throw providerError("prepared callable-provider import descriptor lost its exact registry");
+      }
+      for (const expected of payload.selected) {
+        if (expected.ownerKind !== "provisional-import") continue;
+        const bindingId = importRegistry.preparedDescriptorBindingId(
+          payload.importDescriptor,
+          expected.provider.locator.value as Import,
+        );
+        if (bindingId !== expected.canonicalOwner) {
+          throw providerError(
+            `prepared callable provider ${expected.provider.structuralReferenceKey} changed provisional import ownership`,
+          );
+        }
+      }
+    }
+    const actual = this.describeSelectedEntries(
+      denominator.filter(({ provider }) =>
+        payload.selected.some((entry) => entry.provider.structuralReferenceKey === provider.structuralReferenceKey),
+      ),
+      payload.importDescriptor,
+    );
+    if (actual.length !== payload.selected.length) {
+      throw providerError("prepared callable-provider descriptor selection closure is stale");
+    }
+    payload.selected.forEach((expected, index) => this.assertSameSelectedEntry(expected, actual[index]!));
+  }
+
+  publishPreparedDescriptor(descriptor: PreparedCallableProviderDescriptor): ReadonlyMap<string, IrBindingId> {
+    this.assertPreparedDescriptorCurrent(descriptor);
+    const payload = this.requirePreparedDescriptor(descriptor);
+    for (const entry of payload.selected) {
+      if (
+        entry.ownerKind === "provisional-import" &&
+        (this.session.locatorBindingId(entry.provider.locator.value) !== entry.canonicalOwner ||
+          !this.session.hasPlan(entry.canonicalOwner))
+      ) {
+        throw providerError(
+          `prepared callable provider ${entry.provider.structuralReferenceKey} cannot publish before its exact import descriptor`,
+        );
+      }
+    }
+    this.observationOrder ??= Object.freeze(payload.denominator.map(({ provider }) => provider.structuralReferenceKey));
+    for (const entry of payload.selected) this.planPreparedEntry(entry);
+    return new Map(
+      payload.returnKeys.map((key) => {
+        const id = this.plannedByKey.get(key);
+        if (!id) throw providerError(`prepared callable provider ${key} did not produce an ABI binding`);
+        return [key, id] as const;
+      }),
+    );
+  }
+
   planPrepared(structuralReferenceKeys: ReadonlySet<string>): ReadonlyMap<string, IrBindingId> {
     if (this.plannedValue) {
       return new Map(
@@ -242,44 +477,7 @@ export class ProgramAbiCallableProviderRegistry {
         }),
       );
     }
-    const order = this.sealObservationOrder();
-    const requestedProviders = [...structuralReferenceKeys].map((key) => {
-      const provider = this.observed.get(key);
-      if (!provider) {
-        throw providerError(`prepared callable provider ${key} was not observed before discovery sealed`);
-      }
-      if (
-        provider.locator.kind === "import-function" &&
-        this.session.locatorBindingId(provider.locator.value) === undefined
-      ) {
-        throw providerError(
-          `prepared callable provider ${key} cannot own an import before its canonical import identity is planned`,
-        );
-      }
-      return provider;
-    });
-    const selected = new Set(structuralReferenceKeys);
-    for (const candidate of this.observed.values()) {
-      if (requestedProviders.some((requested) => sameLocator(requested.locator, candidate.locator))) {
-        selected.add(candidate.structuralReferenceKey);
-      }
-    }
-    for (let ordinal = 0; ordinal < order.length; ordinal++) {
-      const key = order[ordinal]!;
-      if (!selected.has(key)) continue;
-      const provider = this.observed.get(key)!;
-      if (currentCallableIndex(this.ctx, provider.locator) === undefined) {
-        throw providerError(`prepared callable provider ${key} lost its exact allocator object`);
-      }
-      this.planProvider(provider, ordinal);
-    }
-    return new Map(
-      [...selected].map((key) => {
-        const id = this.plannedByKey.get(key);
-        if (!id) throw providerError(`prepared callable provider ${key} did not produce an ABI binding`);
-        return [key, id] as const;
-      }),
-    );
+    return this.publishPreparedDescriptor(this.describePrepared(structuralReferenceKeys));
   }
 
   /**
@@ -309,6 +507,297 @@ export class ProgramAbiCallableProviderRegistry {
     }
     this.plannedValue = new Map(this.plannedByKey);
     return this.plannedValue;
+  }
+
+  private requirePreparedDescriptor(
+    descriptor: PreparedCallableProviderDescriptor,
+  ): PreparedCallableProviderDescriptorPayload {
+    const payload = preparedCallableProviderDescriptors.get(descriptor);
+    if (!payload || payload.registry !== this) {
+      throw providerError("prepared callable-provider descriptor is forged or belongs to another registry");
+    }
+    return payload;
+  }
+
+  private currentDescriptionOrder(): readonly string[] {
+    const order =
+      this.observationOrder === undefined
+        ? [...this.observed.keys()].sort()
+        : [...this.observationOrder, ...this.appendedOrder];
+    if (
+      new Set(order).size !== order.length ||
+      order.length !== this.observed.size ||
+      order.some((key) => !this.observed.has(key))
+    ) {
+      throw providerError("callable-provider observation order does not cover the exact observed population");
+    }
+    return Object.freeze(order);
+  }
+
+  private describeDenominator(keys: readonly string[]): readonly PreparedCallableProviderDenominatorEntry[] {
+    const entrySourceId = canonicalEntrySource(this.session);
+    const exactBindingIds = new Set<IrBindingId>();
+    return Object.freeze(
+      keys.map((key, ordinal) => {
+        const provider = this.observed.get(key);
+        if (!provider || provider.structuralReferenceKey !== key) {
+          throw providerError(`callable-provider denominator key ${key} has no exact observation`);
+        }
+        const typeIndex = callableTypeIndex(provider.locator);
+        if (!Number.isSafeInteger(typeIndex) || typeIndex < 0) {
+          throw providerError(`callable provider ${key} has invalid function type ${String(typeIndex)}`);
+        }
+        const signature = callableSignature(this.ctx.mod, provider.locator);
+        const bindingId = createIrBindingId({
+          ownerId: entrySourceId,
+          domain: "callable",
+          role: `${provider.binding.kind}-provider`,
+          ordinal,
+        });
+        if (exactBindingIds.has(bindingId)) {
+          throw providerError(`callable provider ${key} collides on projected binding ${bindingId}`);
+        }
+        exactBindingIds.add(bindingId);
+        return Object.freeze({
+          provider,
+          ordinal,
+          typeIndex,
+          signature,
+          typeContract: cloneProgramAbiCallableTypeContract(signature),
+        });
+      }),
+    );
+  }
+
+  private describeSelectedEntries(
+    selected: readonly PreparedCallableProviderDenominatorEntry[],
+    exactImportDescriptor: PreparedCallableImportDescriptor | undefined,
+  ): readonly PreparedCallableProviderEntry[] {
+    const entrySourceId = canonicalEntrySource(this.session);
+    const importRegistry = this.ctx.programAbiCallableImports;
+    const bindingIds = new Map(
+      selected.map((entry) => [
+        entry.provider.structuralReferenceKey,
+        createIrBindingId({
+          ownerId: entrySourceId,
+          domain: "callable",
+          role: `${entry.provider.binding.kind}-provider`,
+          ordinal: entry.ordinal,
+        }),
+      ]),
+    );
+    const groupOwner = new Map<
+      object,
+      { readonly id: IrBindingId; readonly kind: PreparedCallableProviderOwnerKind }
+    >();
+    for (const entry of selected) {
+      const locatorObject = entry.provider.locator.value;
+      if (groupOwner.has(locatorObject)) continue;
+      const group = selected.filter((candidate) => sameLocator(candidate.provider.locator, entry.provider.locator));
+      let canonicalOwner = this.session.locatorBindingId(locatorObject);
+      let ownerKind: PreparedCallableProviderOwnerKind = "committed";
+      let descriptorOwner: IrBindingId | undefined;
+      if (entry.provider.locator.kind === "import-function" && exactImportDescriptor) {
+        if (!importRegistry) {
+          throw providerError("prepared callable-provider import descriptor lost its exact registry");
+        }
+        descriptorOwner = importRegistry.preparedDescriptorBindingId(
+          exactImportDescriptor,
+          entry.provider.locator.value,
+        );
+        if (descriptorOwner !== undefined) {
+          if (canonicalOwner !== undefined && canonicalOwner !== descriptorOwner) {
+            throw providerError(
+              `callable provider ${entry.provider.structuralReferenceKey} changed its exact import descriptor owner`,
+            );
+          }
+          canonicalOwner = descriptorOwner;
+          ownerKind = "provisional-import";
+        }
+      }
+      if (canonicalOwner === undefined) {
+        if (entry.provider.locator.kind === "import-function") {
+          throw providerError(
+            `prepared callable provider ${entry.provider.structuralReferenceKey} cannot own an import without its exact import descriptor`,
+          );
+        }
+        canonicalOwner = bindingIds.get(group[0]!.provider.structuralReferenceKey)!;
+        ownerKind = "batch-provider";
+      } else if (ownerKind === "committed") {
+        const ownerDraft = this.session.getDraft(canonicalOwner);
+        if (
+          !ownerDraft ||
+          ownerDraft.intent.kind !== "callable" ||
+          ownerDraft.slotPolicy !== "required" ||
+          !this.session.hasLocator(canonicalOwner, locatorObject) ||
+          !programAbiCallableSignaturesEqual(
+            ownerDraft.intent.signature,
+            canonicalProgramAbiCallableTypeContract(entry.typeContract),
+          )
+        ) {
+          throw providerError(
+            `callable provider ${entry.provider.structuralReferenceKey} has a malformed committed locator owner`,
+          );
+        }
+      }
+      groupOwner.set(locatorObject, Object.freeze({ id: canonicalOwner, kind: ownerKind }));
+    }
+
+    return Object.freeze(
+      selected.map((entry) => {
+        if (currentCallableIndex(this.ctx, entry.provider.locator) === undefined) {
+          throw providerError(
+            `prepared callable provider ${entry.provider.structuralReferenceKey} lost its exact allocator object`,
+          );
+        }
+        if (
+          callableTypeIndex(entry.provider.locator) !== entry.typeIndex ||
+          callableSignature(this.ctx.mod, entry.provider.locator) !== entry.signature ||
+          !callableTypeContractsEqual(
+            entry.typeContract,
+            cloneProgramAbiCallableTypeContract(callableSignature(this.ctx.mod, entry.provider.locator)),
+          )
+        ) {
+          throw providerError(
+            `prepared callable provider ${entry.provider.structuralReferenceKey} changed its exact signature`,
+          );
+        }
+        const bindingId = bindingIds.get(entry.provider.structuralReferenceKey)!;
+        const owner = groupOwner.get(entry.provider.locator.value)!;
+        const ownsLocator = bindingId === owner.id;
+        const common = {
+          id: bindingId,
+          structuralOrder: Object.freeze({
+            ...this.session.structuralOrder.forSource(entrySourceId, {
+              domain: "callable" as const,
+              roleOrdinal: PROGRAM_ABI_PROVIDER_ROLE_ORDINAL,
+              derivedOrdinal: entry.ordinal,
+            }),
+          }),
+          structuralReferenceKey: entry.provider.structuralReferenceKey,
+          displayName: entry.provider.binding.symbol,
+          intent: Object.freeze({
+            kind: "callable" as const,
+            origin: entry.provider.binding.kind,
+            signature: canonicalProgramAbiCallableTypeContract(entry.typeContract),
+          }),
+        };
+        const draft = Object.freeze(
+          ownsLocator
+            ? { ...common, slotPolicy: "required" as const, slotSpace: "function" as const }
+            : { ...common, slotPolicy: "alias" as const, aliasOf: owner.id },
+        ) satisfies ProgramAbiDraft;
+        const planned = this.plannedByKey.get(entry.provider.structuralReferenceKey);
+        if (planned !== undefined && planned !== bindingId) {
+          throw providerError(
+            `callable provider ${entry.provider.structuralReferenceKey} changed its sealed structural identity`,
+          );
+        }
+        const session = Object.freeze({
+          draft: this.session.getDraft(bindingId),
+          structuralReferenceBindingIds: Object.freeze([
+            ...this.session.bindingIdsForStructuralReference(entry.provider.structuralReferenceKey),
+          ]),
+          locatorOwner: this.session.locatorBindingId(entry.provider.locator.value),
+          hasExactLocator: this.session.hasLocator(bindingId, entry.provider.locator.value),
+        });
+        const expectedIds = planned ? Object.freeze([bindingId]) : Object.freeze([]);
+        const ownerCurrent =
+          owner.kind === "provisional-import"
+            ? session.locatorOwner === undefined || session.locatorOwner === owner.id
+            : session.locatorOwner === (owner.kind === "batch-provider" ? undefined : owner.id);
+        if (
+          !callableDraftsEqual(session.draft, planned ? draft : undefined) ||
+          !exactBindingIdsEqual(session.structuralReferenceBindingIds, expectedIds) ||
+          !ownerCurrent ||
+          session.hasExactLocator !== (planned !== undefined && ownsLocator)
+        ) {
+          throw providerError(
+            `prepared callable provider ${entry.provider.structuralReferenceKey} disagrees with current session ownership`,
+          );
+        }
+        return Object.freeze({
+          ...entry,
+          bindingId,
+          draft,
+          canonicalOwner: owner.id,
+          ownerKind: owner.kind,
+          ownsLocator,
+          planned,
+          session,
+        });
+      }),
+    );
+  }
+
+  private assertSameDenominator(
+    expected: readonly PreparedCallableProviderDenominatorEntry[],
+    actual: readonly PreparedCallableProviderDenominatorEntry[],
+  ): void {
+    if (
+      expected.length !== actual.length ||
+      expected.some((entry, index) => {
+        const current = actual[index]!;
+        return (
+          entry.provider !== current.provider ||
+          entry.provider.binding !== current.provider.binding ||
+          entry.provider.structuralReferenceKey !== current.provider.structuralReferenceKey ||
+          entry.provider.locator !== current.provider.locator ||
+          entry.provider.locator.value !== current.provider.locator.value ||
+          entry.ordinal !== current.ordinal ||
+          entry.typeIndex !== current.typeIndex ||
+          entry.signature !== current.signature ||
+          !callableTypeContractsEqual(entry.typeContract, current.typeContract)
+        );
+      })
+    ) {
+      throw providerError("prepared callable-provider descriptor denominator is stale");
+    }
+  }
+
+  private assertSameSelectedEntry(
+    expected: PreparedCallableProviderEntry,
+    actual: PreparedCallableProviderEntry,
+  ): void {
+    const expectedOwnerTransition =
+      expected.ownerKind === "provisional-import" &&
+      expected.session.locatorOwner === undefined &&
+      actual.session.locatorOwner === expected.canonicalOwner;
+    if (
+      expected.provider !== actual.provider ||
+      expected.ordinal !== actual.ordinal ||
+      expected.typeIndex !== actual.typeIndex ||
+      expected.signature !== actual.signature ||
+      expected.bindingId !== actual.bindingId ||
+      expected.canonicalOwner !== actual.canonicalOwner ||
+      expected.ownerKind !== actual.ownerKind ||
+      expected.ownsLocator !== actual.ownsLocator ||
+      expected.planned !== actual.planned ||
+      !callableTypeContractsEqual(expected.typeContract, actual.typeContract) ||
+      !callableDraftsEqual(expected.draft, actual.draft) ||
+      !callableDraftsEqual(expected.session.draft, actual.session.draft) ||
+      !exactBindingIdsEqual(
+        expected.session.structuralReferenceBindingIds,
+        actual.session.structuralReferenceBindingIds,
+      ) ||
+      (!expectedOwnerTransition && expected.session.locatorOwner !== actual.session.locatorOwner) ||
+      expected.session.hasExactLocator !== actual.session.hasExactLocator
+    ) {
+      throw providerError(`prepared callable provider ${expected.provider.structuralReferenceKey} descriptor is stale`);
+    }
+  }
+
+  private planPreparedEntry(entry: PreparedCallableProviderEntry): IrBindingId {
+    const existing = this.plannedByKey.get(entry.provider.structuralReferenceKey);
+    if (existing) return existing;
+    this.session.ensurePlan(entry.draft);
+    if (entry.ownsLocator) {
+      this.session.attachLocator(entry.bindingId, entry.provider.locator as ProgramAbiSlotLocator);
+    }
+    this.session.registerCallableTypeContract(entry.bindingId, entry.typeContract);
+    this.session.registerStructuralReference(entry.bindingId, entry.provider.structuralReferenceKey);
+    this.plannedByKey.set(entry.provider.structuralReferenceKey, entry.bindingId);
+    return entry.bindingId;
   }
 
   /**

--- a/tests/issue-3520-callable-provider-abi.test.ts
+++ b/tests/issue-3520-callable-provider-abi.test.ts
@@ -9,9 +9,10 @@ import {
   catalogProgramAbiCallableImports,
   planProgramAbiCallableImports,
 } from "../src/codegen/program-abi-import-planning.js";
+import { PROGRAM_ABI_CALLABLE_ROLE } from "../src/codegen/program-abi-planning.js";
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
 import { irCallableBindingKey, irIntrinsicFuncRef, irRuntimeFuncRef } from "../src/ir/callable-bindings.js";
-import { buildIrUnitInventory } from "../src/ir/identity.js";
+import { buildIrUnitInventory, createIrBindingId } from "../src/ir/identity.js";
 import { IR_STRING_COMPARE_FN } from "../src/ir/from-ast.js";
 import { ProgramAbiInvariantError } from "../src/ir/program-abi.js";
 import {
@@ -50,12 +51,18 @@ function fixture(module: WasmModule) {
 type CallableProviderRegistry = ReturnType<typeof fixture>["providers"];
 type PreparedProviderDescriptor = ReturnType<CallableProviderRegistry["describePrepared"]>;
 type CallableImportRegistry = NonNullable<ReturnType<typeof fixture>["ctx"]["programAbiCallableImports"]>;
+type PreparedImportDescriptor = ReturnType<CallableImportRegistry["describePrepared"]>;
 
 function sessionPublicationCardinalities(session: ProgramAbiSession) {
   const state = session as unknown as Record<string, ReadonlyMap<unknown, unknown>>;
-  return ["drafts", "draftOrderOwners", "locators", "structuralReferenceKeys", "callableTypeContracts"].map(
-    (key) => state[key]!.size,
-  );
+  return [
+    "drafts",
+    "draftOrderOwners",
+    "locators",
+    "locatorOwners",
+    "structuralReferenceKeys",
+    "callableTypeContracts",
+  ].map((key) => state[key]!.size);
 }
 
 function providerPublicationSnapshot(registry: CallableProviderRegistry, session: ProgramAbiSession) {
@@ -146,6 +153,30 @@ function observeRuntimeProvider(providers: CallableProviderRegistry, name: strin
   const ref = irRuntimeFuncRef(name);
   providers.observe(ref, index);
   return irCallableBindingKey(ref.binding);
+}
+
+function planForeignProviderOrder(session: ProgramAbiSession, derivedOrdinal: number, label: string) {
+  const entrySource = session.inventory.sources.find(({ kind }) => kind === "entry")!;
+  const id = createIrBindingId({
+    ownerId: entrySource.id,
+    domain: "callable",
+    role: `foreign-${label}`,
+    ordinal: derivedOrdinal,
+  });
+  session.plan({
+    id,
+    structuralOrder: session.structuralOrder.forSource(entrySource.id, {
+      domain: "callable",
+      roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.callableProvider,
+      derivedOrdinal,
+    }),
+    structuralReferenceKey: `foreign:${label}`,
+    displayName: label,
+    slotPolicy: "required",
+    slotSpace: "function",
+    intent: { kind: "callable", origin: "runtime", signature: { params: [], results: [] } },
+  });
+  return id;
 }
 
 function sealedProviderSuffixFixture() {
@@ -312,6 +343,72 @@ describe("#3520 runtime/intrinsic callable-provider Program ABI", () => {
     expect(previewed.ids).toHaveLength(2);
   });
 
+  it("authenticates provider descriptors without changing provider or session state", () => {
+    const target = definedProviderFixture("target");
+    const targetKey = observeRuntimeProvider(target.providers, "target", 0);
+    const descriptor = describePreparedProvidersWithoutPublishing(
+      target.providers,
+      target.session,
+      new Set([targetKey]),
+    );
+    const forged = Object.freeze({ kind: "prepared-callable-provider-descriptor" }) as PreparedProviderDescriptor;
+
+    const foreign = definedProviderFixture("foreign");
+    const foreignKey = observeRuntimeProvider(foreign.providers, "foreign", 0);
+    const foreignDescriptor = describePreparedProvidersWithoutPublishing(
+      foreign.providers,
+      foreign.session,
+      new Set([foreignKey]),
+    );
+
+    for (const candidate of [forged, foreignDescriptor]) {
+      expectPreparedProviderFailureWithoutPublishing(target.providers, target.session, () =>
+        target.providers.assertPreparedDescriptorCurrent(candidate),
+      );
+      expectPreparedProviderFailureWithoutPublishing(target.providers, target.session, () =>
+        target.providers.publishPreparedDescriptor(candidate),
+      );
+    }
+    target.providers.assertPreparedDescriptorCurrent(descriptor);
+  });
+
+  it("rejects occupied prepared-provider order slots without sealing and tolerates unrelated order", () => {
+    {
+      const { providers, session } = definedProviderFixture("selected");
+      const key = observeRuntimeProvider(providers, "selected", 0);
+      planForeignProviderOrder(session, 0, "before-provider-description");
+      expectPreparedProviderFailureWithoutPublishing(providers, session, () =>
+        providers.describePrepared(new Set([key])),
+      );
+    }
+
+    {
+      const { providers, session } = definedProviderFixture("selected");
+      const key = observeRuntimeProvider(providers, "selected", 0);
+      const descriptor = describePreparedProvidersWithoutPublishing(providers, session, new Set([key]));
+      planForeignProviderOrder(session, 0, "after-provider-description");
+      expectPreparedProviderFailureWithoutPublishing(providers, session, () =>
+        providers.assertPreparedDescriptorCurrent(descriptor),
+      );
+      expectPreparedProviderFailureWithoutPublishing(providers, session, () =>
+        providers.publishPreparedDescriptor(descriptor),
+      );
+    }
+
+    {
+      const { functions, providers, session } = definedProviderFixture("selected");
+      const key = observeRuntimeProvider(providers, "selected", 0);
+      const descriptor = describePreparedProvidersWithoutPublishing(providers, session, new Set([key]));
+      const foreignId = planForeignProviderOrder(session, 1, "unrelated-provider-order");
+      const beforeCurrentness = providerPublicationSnapshot(providers, session);
+      providers.assertPreparedDescriptorCurrent(descriptor);
+      expect(providerPublicationSnapshot(providers, session)).toEqual(beforeCurrentness);
+      const ids = providers.publishPreparedDescriptor(descriptor);
+      expect(session.getDraft(foreignId)?.structuralOrder.derivedOrdinal).toBe(1);
+      expect(session.hasLocator(ids.get(key)!, functions[0])).toBe(true);
+    }
+  });
+
   it("freezes the sorted provider prefix and retains the appended discovery-order suffix", () => {
     const { aKey, middleKey, providers, sealedSnapshot, session, zKey } = sealedProviderSuffixFixture();
     expect(sealedSnapshot).toMatchObject({
@@ -460,6 +557,17 @@ describe("#3520 runtime/intrinsic callable-provider Program ABI", () => {
     };
 
     const positive = createImportBackedFixture();
+    const forgedImportDescriptor = Object.freeze({
+      kind: "prepared-callable-import-descriptor",
+    }) as PreparedImportDescriptor;
+    expectPreparedProviderFailureWithoutPublishing(positive.providers, positive.session, () =>
+      positive.providers.describePrepared(new Set([positive.key]), forgedImportDescriptor),
+    );
+    const foreign = createImportBackedFixture();
+    const foreignImportDescriptor = foreign.imports.describePrepared(new Set([foreign.targetImport]));
+    expectPreparedProviderFailureWithoutPublishing(positive.providers, positive.session, () =>
+      positive.providers.describePrepared(new Set([positive.key]), foreignImportDescriptor),
+    );
     expectPreparedProviderFailureWithoutPublishing(positive.providers, positive.session, () =>
       positive.providers.describePrepared(new Set([positive.key])),
     );

--- a/tests/issue-3520-callable-provider-abi.test.ts
+++ b/tests/issue-3520-callable-provider-abi.test.ts
@@ -47,6 +47,79 @@ function fixture(module: WasmModule) {
   return { ctx, providers, session };
 }
 
+type CallableProviderRegistry = ReturnType<typeof fixture>["providers"];
+type PreparedProviderDescriptor = ReturnType<CallableProviderRegistry["describePrepared"]>;
+type CallableImportRegistry = NonNullable<ReturnType<typeof fixture>["ctx"]["programAbiCallableImports"]>;
+
+function sessionPublicationCardinalities(session: ProgramAbiSession) {
+  const state = session as unknown as Record<string, ReadonlyMap<unknown, unknown>>;
+  return ["drafts", "draftOrderOwners", "locators", "structuralReferenceKeys", "callableTypeContracts"].map(
+    (key) => state[key]!.size,
+  );
+}
+
+function providerPublicationSnapshot(registry: CallableProviderRegistry, session: ProgramAbiSession) {
+  const state = registry as unknown as {
+    readonly observed: ReadonlyMap<string, unknown>;
+    readonly observationOrder: readonly string[] | undefined;
+    readonly appendedOrder: readonly string[];
+    readonly plannedByKey: ReadonlyMap<string, unknown>;
+    readonly plannedValue: ReadonlyMap<string, unknown> | undefined;
+  };
+  return {
+    observedKeys: [...state.observed.keys()],
+    observationOrder: state.observationOrder ? [...state.observationOrder] : null,
+    appendedOrder: [...state.appendedOrder],
+    plannedKeys: [...state.plannedByKey.keys()],
+    plannedValueSize: state.plannedValue?.size ?? null,
+    session: sessionPublicationCardinalities(session),
+  };
+}
+
+function callableImportPublicationSnapshot(registry: CallableImportRegistry, session: ProgramAbiSession) {
+  const state = registry as unknown as {
+    readonly sealedEntries: readonly unknown[] | undefined;
+    readonly plannedByImport: ReadonlyMap<Import, unknown>;
+    readonly plannedValue: ReadonlyMap<string, unknown> | undefined;
+  };
+  return {
+    sealedEntryCount: state.sealedEntries?.length ?? null,
+    plannedImports: [...state.plannedByImport.keys()],
+    plannedValueSize: state.plannedValue?.size ?? null,
+    session: sessionPublicationCardinalities(session),
+  };
+}
+
+function withoutProviderPublication<T>(
+  registry: CallableProviderRegistry,
+  session: ProgramAbiSession,
+  action: () => T,
+): T {
+  const before = providerPublicationSnapshot(registry, session);
+  try {
+    return action();
+  } finally {
+    expect(providerPublicationSnapshot(registry, session)).toEqual(before);
+  }
+}
+
+function describePreparedProvidersWithoutPublishing(
+  registry: CallableProviderRegistry,
+  session: ProgramAbiSession,
+  keys: ReadonlySet<string>,
+  exactImportDescriptor?: Parameters<CallableProviderRegistry["describePrepared"]>[1],
+): PreparedProviderDescriptor {
+  return withoutProviderPublication(registry, session, () => registry.describePrepared(keys, exactImportDescriptor));
+}
+
+function expectPreparedProviderFailureWithoutPublishing(
+  registry: CallableProviderRegistry,
+  session: ProgramAbiSession,
+  action: () => unknown,
+): void {
+  expect(() => withoutProviderPublication(registry, session, action)).toThrowError(ProgramAbiInvariantError);
+}
+
 function functionImport(module: string, name: string, typeIdx: number): Import {
   return { module, name, desc: { kind: "func", typeIdx } };
 }
@@ -59,6 +132,30 @@ function definedFunction(name: string, typeIdx: number): WasmFunction {
     body: [{ op: "f64.const", value: 0 }],
     exported: false,
   };
+}
+
+function definedProviderFixture(...names: readonly string[]) {
+  const module = createEmptyModule();
+  module.types.push(F64_TO_F64);
+  const functions = names.map((name) => definedFunction(name, 0));
+  module.functions.push(...functions);
+  return { ...fixture(module), functions, module };
+}
+
+function observeRuntimeProvider(providers: CallableProviderRegistry, name: string, index: number): string {
+  const ref = irRuntimeFuncRef(name);
+  providers.observe(ref, index);
+  return irCallableBindingKey(ref.binding);
+}
+
+function sealedProviderSuffixFixture() {
+  const result = definedProviderFixture("middle", "z-appended", "a-appended");
+  const middleKey = observeRuntimeProvider(result.providers, "middle", 0);
+  expect(result.providers.planPrepared(new Set())).toEqual(new Map());
+  const sealedSnapshot = providerPublicationSnapshot(result.providers, result.session);
+  const zKey = observeRuntimeProvider(result.providers, "z-appended", 1);
+  const aKey = observeRuntimeProvider(result.providers, "a-appended", 2);
+  return { ...result, aKey, middleKey, sealedSnapshot, zKey };
 }
 
 function providerFixture(reverseObservation: boolean) {
@@ -181,6 +278,233 @@ describe("#3520 runtime/intrinsic callable-provider Program ABI", () => {
     );
   });
 
+  it("keeps an abandoned provider preview out of ordering and matches the unpreviewed control", () => {
+    const run = (preview: boolean) => {
+      const { module, providers, session } = definedProviderFixture("z-provider", "a-provider");
+      const zKey = observeRuntimeProvider(providers, "z-provider", 0);
+      const descriptor = preview
+        ? describePreparedProvidersWithoutPublishing(providers, session, new Set([zKey]))
+        : undefined;
+
+      // If description had sealed the order, this lexically earlier provider
+      // would be appended and the two runs would mint different ordinals.
+      const aKey = observeRuntimeProvider(providers, "a-provider", 1);
+      if (descriptor) {
+        expectPreparedProviderFailureWithoutPublishing(providers, session, () =>
+          providers.publishPreparedDescriptor(descriptor),
+        );
+      }
+      const ids = providers.planRetained();
+      const entries = session.publish(module).abi.entries();
+      return {
+        ids: [...ids],
+        entries,
+        aOrdinal: session.getDraft(ids.get(aKey)!)?.structuralOrder.derivedOrdinal,
+        zOrdinal: session.getDraft(ids.get(zKey)!)?.structuralOrder.derivedOrdinal,
+      };
+    };
+
+    const previewed = run(true);
+    const control = run(false);
+    expect(previewed).toEqual(control);
+    expect(previewed.aOrdinal).toBe(0);
+    expect(previewed.zOrdinal).toBe(1);
+    expect(previewed.ids).toHaveLength(2);
+  });
+
+  it("freezes the sorted provider prefix and retains the appended discovery-order suffix", () => {
+    const { aKey, middleKey, providers, sealedSnapshot, session, zKey } = sealedProviderSuffixFixture();
+    expect(sealedSnapshot).toMatchObject({
+      observationOrder: [middleKey],
+      appendedOrder: [],
+      plannedKeys: [],
+    });
+    const descriptor = describePreparedProvidersWithoutPublishing(providers, session, new Set([middleKey, zKey, aKey]));
+    const beforeCurrentness = providerPublicationSnapshot(providers, session);
+    providers.assertPreparedDescriptorCurrent(descriptor);
+    expect(providerPublicationSnapshot(providers, session)).toEqual(beforeCurrentness);
+    const ids = providers.publishPreparedDescriptor(descriptor);
+
+    expect(session.getDraft(ids.get(middleKey)!)?.structuralOrder.derivedOrdinal).toBe(0);
+    expect(session.getDraft(ids.get(zKey)!)?.structuralOrder.derivedOrdinal).toBe(1);
+    expect(session.getDraft(ids.get(aKey)!)?.structuralOrder.derivedOrdinal).toBe(2);
+    expect(providerPublicationSnapshot(providers, session)).toMatchObject({
+      observationOrder: [middleKey],
+      appendedOrder: [zKey, aKey],
+      plannedKeys: [middleKey, zKey, aKey],
+    });
+  });
+
+  it("rejects an appended suffix reorder and provider contract drift without publishing", () => {
+    {
+      const { providers, session } = definedProviderFixture("present");
+      expectPreparedProviderFailureWithoutPublishing(providers, session, () =>
+        providers.describePrepared(new Set([irCallableBindingKey(irRuntimeFuncRef("missing").binding)])),
+      );
+    }
+
+    {
+      const { aKey, middleKey, providers, session, zKey } = sealedProviderSuffixFixture();
+      const descriptor = describePreparedProvidersWithoutPublishing(
+        providers,
+        session,
+        new Set([middleKey, zKey, aKey]),
+      );
+      const state = providers as unknown as { readonly appendedOrder: string[] };
+      state.appendedOrder.reverse();
+      expectPreparedProviderFailureWithoutPublishing(providers, session, () =>
+        providers.publishPreparedDescriptor(descriptor),
+      );
+    }
+
+    const mutations: readonly [string, (module: WasmModule, providers: CallableProviderRegistry) => void][] = [
+      ["removed locator", (module) => (module.functions = [])],
+      ["replaced locator", (module) => (module.functions[0] = definedFunction("replacement", 0))],
+      ["changed signature", (module) => (module.functions[0]!.typeIdx = 1)],
+      [
+        "changed structural key",
+        (_module, providers) => {
+          const state = providers as unknown as {
+            readonly observed: Map<string, { readonly structuralReferenceKey: string }>;
+          };
+          const [key, row] = [...state.observed.entries()][0]!;
+          state.observed.set(key, Object.freeze({ ...row, structuralReferenceKey: `${key}|drift` }));
+        },
+      ],
+    ];
+    for (const [, mutate] of mutations) {
+      const { module, providers, session } = definedProviderFixture("selected");
+      module.types.push({ kind: "func", params: [{ kind: "i32" }], results: [] });
+      const key = observeRuntimeProvider(providers, "selected", 0);
+      const descriptor = describePreparedProvidersWithoutPublishing(providers, session, new Set([key]));
+      mutate(module, providers);
+      expectPreparedProviderFailureWithoutPublishing(providers, session, () =>
+        providers.publishPreparedDescriptor(descriptor),
+      );
+    }
+  });
+
+  it("closes every same-locator sibling and rejects a sibling discovered after description", () => {
+    const positive = definedProviderFixture("shared");
+    const shared = positive.functions[0]!;
+    const runtimeRef = irRuntimeFuncRef("runtime-shared");
+    const intrinsicRef = irIntrinsicFuncRef("intrinsic-shared");
+    const runtimeKey = irCallableBindingKey(runtimeRef.binding);
+    const intrinsicKey = irCallableBindingKey(intrinsicRef.binding);
+    positive.providers.observe(runtimeRef, 0);
+    positive.providers.observe(intrinsicRef, 0);
+    const descriptor = describePreparedProvidersWithoutPublishing(
+      positive.providers,
+      positive.session,
+      new Set([runtimeKey]),
+    );
+    expect(Object.isFrozen(descriptor)).toBe(true);
+    expect(Object.isFrozen(shared)).toBe(false);
+    expect(Object.isFrozen(positive.module.types[0])).toBe(false);
+    positive.module.imports.unshift(functionImport("late", "index-shift", 0));
+    positive.ctx.numImportFuncs++;
+    const beforeIndexShiftCheck = providerPublicationSnapshot(positive.providers, positive.session);
+    positive.providers.assertPreparedDescriptorCurrent(descriptor);
+    expect(providerPublicationSnapshot(positive.providers, positive.session)).toEqual(beforeIndexShiftCheck);
+    const ids = positive.providers.publishPreparedDescriptor(descriptor);
+    expect([...ids.keys()].sort()).toEqual([intrinsicKey, runtimeKey].sort());
+    const canonicalKey = [intrinsicKey, runtimeKey].sort()[0]!;
+    const aliasKey = canonicalKey === intrinsicKey ? runtimeKey : intrinsicKey;
+    expect(positive.session.hasLocator(ids.get(canonicalKey)!, shared)).toBe(true);
+    expect(positive.session.getDraft(ids.get(aliasKey)!)).toMatchObject({
+      slotPolicy: "alias",
+      aliasOf: ids.get(canonicalKey),
+    });
+
+    const control = definedProviderFixture("shared");
+    control.providers.observe(runtimeRef, 0);
+    control.providers.observe(intrinsicRef, 0);
+    control.module.imports.unshift(functionImport("late", "index-shift", 0));
+    control.ctx.numImportFuncs++;
+    const compatibilityIds = control.providers.planPrepared(new Set([runtimeKey]));
+    expect([...ids]).toEqual([...compatibilityIds]);
+    const retained = control.providers.planRetained();
+    const retainedSnapshot = providerPublicationSnapshot(control.providers, control.session);
+    expect(control.providers.planPrepared(new Set([runtimeKey])).get(runtimeKey)).toBe(retained.get(runtimeKey));
+    expect(providerPublicationSnapshot(control.providers, control.session)).toEqual(retainedSnapshot);
+    expect(positive.session.publish(positive.module).abi.entries()).toEqual(
+      control.session.publish(control.module).abi.entries(),
+    );
+
+    const stale = definedProviderFixture("shared");
+    stale.providers.observe(runtimeRef, 0);
+    const staleDescriptor = describePreparedProvidersWithoutPublishing(
+      stale.providers,
+      stale.session,
+      new Set([runtimeKey]),
+    );
+    stale.providers.observe(intrinsicRef, 0);
+    expectPreparedProviderFailureWithoutPublishing(stale.providers, stale.session, () =>
+      stale.providers.publishPreparedDescriptor(staleDescriptor),
+    );
+  });
+
+  it("requires the exact provisional import owner and rejects its locator drift", () => {
+    const createImportBackedFixture = () => {
+      const module = createEmptyModule();
+      module.types.push(F64_TO_F64);
+      const targetImport = functionImport("env", "runtime_target", 0);
+      const siblingImport = functionImport("env", "sibling", 0);
+      module.imports.push(targetImport, siblingImport);
+      const result = fixture(module);
+      const key = observeRuntimeProvider(result.providers, "runtime_target", 0);
+      catalogProgramAbiCallableImports(result.ctx);
+      const imports = result.ctx.programAbiCallableImports;
+      if (!imports) throw new Error("missing callable-import registry");
+      return { ...result, imports, key, module, siblingImport, targetImport };
+    };
+
+    const positive = createImportBackedFixture();
+    expectPreparedProviderFailureWithoutPublishing(positive.providers, positive.session, () =>
+      positive.providers.describePrepared(new Set([positive.key])),
+    );
+    const wrongImportBefore = callableImportPublicationSnapshot(positive.imports, positive.session);
+    const wrongImportDescriptor = positive.imports.describePrepared(new Set([positive.siblingImport]));
+    expect(callableImportPublicationSnapshot(positive.imports, positive.session)).toEqual(wrongImportBefore);
+    expectPreparedProviderFailureWithoutPublishing(positive.providers, positive.session, () =>
+      positive.providers.describePrepared(new Set([positive.key]), wrongImportDescriptor),
+    );
+    const importBefore = callableImportPublicationSnapshot(positive.imports, positive.session);
+    const importDescriptor = positive.imports.describePrepared(new Set([positive.targetImport]));
+    expect(callableImportPublicationSnapshot(positive.imports, positive.session)).toEqual(importBefore);
+    const providerDescriptor = describePreparedProvidersWithoutPublishing(
+      positive.providers,
+      positive.session,
+      new Set([positive.key]),
+      importDescriptor,
+    );
+    positive.imports.publishPreparedDescriptor(importDescriptor);
+    const importId = positive.imports.preparedDescriptorBindingId(importDescriptor, positive.targetImport)!;
+    const providerIds = positive.providers.publishPreparedDescriptor(providerDescriptor);
+    const providerId = providerIds.get(positive.key)!;
+    expect(positive.session.getDraft(providerId)).toMatchObject({
+      slotPolicy: "alias",
+      aliasOf: importId,
+    });
+    expect(positive.session.hasLocator(importId, positive.targetImport)).toBe(true);
+    expect(positive.session.hasLocator(providerId)).toBe(false);
+
+    const stale = createImportBackedFixture();
+    const staleImportBefore = callableImportPublicationSnapshot(stale.imports, stale.session);
+    const staleImportDescriptor = stale.imports.describePrepared(new Set([stale.targetImport]));
+    expect(callableImportPublicationSnapshot(stale.imports, stale.session)).toEqual(staleImportBefore);
+    const staleProviderDescriptor = describePreparedProvidersWithoutPublishing(
+      stale.providers,
+      stale.session,
+      new Set([stale.key]),
+      staleImportDescriptor,
+    );
+    stale.module.imports[0] = functionImport("env", "runtime_target", 0);
+    expectPreparedProviderFailureWithoutPublishing(stale.providers, stale.session, () =>
+      stale.providers.publishPreparedDescriptor(staleProviderDescriptor),
+    );
+  });
+
   it("discards a dead import observed only by an IR candidate that later withdrew", () => {
     const module = createEmptyModule();
     module.types.push(F64_TO_F64);
@@ -218,14 +542,14 @@ describe("#3520 runtime/intrinsic callable-provider Program ABI", () => {
     const prepared = providers.planPrepared(new Set([fmodKey]));
     expect([...prepared.keys()]).toEqual([fmodKey]);
     expect(session.hasLocator(prepared.get(fmodKey)!, fmod)).toBe(true);
-    expect(() => providers.observe(irRuntimeFuncRef("__late_provider"), 1)).toThrowError(
-      expect.objectContaining<ProgramAbiInvariantError>({ code: "planning-sealed" }),
-    );
+    const lateRef = irRuntimeFuncRef("__late_provider");
+    const lateKey = irCallableBindingKey(lateRef.binding);
+    expect(providers.observe(lateRef, 1)).toBe(1);
 
     module.imports = [];
     ctx.numImportFuncs = 0;
     expect(planProgramAbiCallableImports(ctx).size).toBe(0);
-    expect([...providers.planRetained().keys()]).toEqual([fmodKey]);
+    expect([...providers.planRetained().keys()].sort()).toEqual([fmodKey, lateKey].sort());
     expect(session.publish(module).abi.resolveFinalIndex(prepared.get(fmodKey)!)).toEqual({
       space: "function",
       index: 0,
@@ -293,7 +617,7 @@ describe("#3520 runtime/intrinsic callable-provider Program ABI", () => {
     expect(result.irPostClaimErrors).toEqual([]);
     expect(result.programAbi).toBeDefined();
 
-    for (const ref of [irRuntimeFuncRef("Math_sin"), irIntrinsicFuncRef("__fmod")]) {
+    for (const ref of [irIntrinsicFuncRef("math.sin"), irIntrinsicFuncRef("__fmod")]) {
       const key = irCallableBindingKey(ref.binding);
       const entries = result.programAbi!.abi.entries().filter((entry) => entry.structuralReferenceKey === key);
       expect(entries).toHaveLength(1);

--- a/tests/issue-3520-program-abi-import-callable-planning.test.ts
+++ b/tests/issue-3520-program-abi-import-callable-planning.test.ts
@@ -30,9 +30,14 @@ type PreparedImportDescriptor = ReturnType<CallableImportRegistry["describePrepa
 
 function sessionPublicationCardinalities(session: ProgramAbiSession) {
   const state = session as unknown as Record<string, ReadonlyMap<unknown, unknown>>;
-  return ["drafts", "draftOrderOwners", "locators", "structuralReferenceKeys", "callableTypeContracts"].map(
-    (key) => state[key]!.size,
-  );
+  return [
+    "drafts",
+    "draftOrderOwners",
+    "locators",
+    "locatorOwners",
+    "structuralReferenceKeys",
+    "callableTypeContracts",
+  ].map((key) => state[key]!.size);
 }
 
 function importPublicationSnapshot(registry: CallableImportRegistry, session: ProgramAbiSession) {
@@ -90,6 +95,35 @@ function preparedImportFixture(
   const registry = result.ctx.programAbiCallableImports;
   if (!registry) throw new Error("missing callable-import registry");
   return { ...result, module, registry };
+}
+
+function planForeignCallableOrder(
+  session: ProgramAbiSession,
+  roleOrdinal: number,
+  derivedOrdinal: number,
+  label: string,
+) {
+  const entrySource = session.inventory.sources.find(({ kind }) => kind === "entry")!;
+  const id = createIrBindingId({
+    ownerId: entrySource.id,
+    domain: "callable",
+    role: `foreign-${label}`,
+    ordinal: derivedOrdinal,
+  });
+  session.plan({
+    id,
+    structuralOrder: session.structuralOrder.forSource(entrySource.id, {
+      domain: "callable",
+      roleOrdinal,
+      derivedOrdinal,
+    }),
+    structuralReferenceKey: `foreign:${label}`,
+    displayName: label,
+    slotPolicy: "required",
+    slotSpace: "function",
+    intent: { kind: "callable", origin: "runtime", signature: { params: [], results: [] } },
+  });
+  return id;
 }
 
 function structuralKey(module: string, field: string, adapterName = field): string {
@@ -334,6 +368,79 @@ describe("#3520 production imported-callable Program ABI planning", () => {
 
     expect([...explicitCatalog]).toEqual([...compatibilityCatalog]);
     expect(explicitEntries).toEqual(compatibilityEntries);
+  });
+
+  it("authenticates import descriptors and keeps empty compatibility preparation a no-op", () => {
+    const selected = functionImport("env", "selected", 0);
+    const target = preparedImportFixture([selected]);
+    const descriptor = describePreparedImportsWithoutPublishing(target.registry, target.session, new Set([selected]));
+    const forged = Object.freeze({ kind: "prepared-callable-import-descriptor" }) as PreparedImportDescriptor;
+
+    const foreignImport = functionImport("env", "foreign", 0);
+    const foreign = preparedImportFixture([foreignImport]);
+    const foreignDescriptor = describePreparedImportsWithoutPublishing(
+      foreign.registry,
+      foreign.session,
+      new Set([foreignImport]),
+    );
+
+    for (const candidate of [forged, foreignDescriptor]) {
+      expectPreparedImportFailureWithoutPublishing(target.registry, target.session, () =>
+        target.registry.assertPreparedDescriptorCurrent(candidate),
+      );
+      expectPreparedImportFailureWithoutPublishing(target.registry, target.session, () =>
+        target.registry.publishPreparedDescriptor(candidate),
+      );
+    }
+    target.registry.assertPreparedDescriptorCurrent(descriptor);
+
+    const beforeFreshEmpty = importPublicationSnapshot(target.registry, target.session);
+    target.registry.planPrepared(new Set());
+    expect(importPublicationSnapshot(target.registry, target.session)).toEqual(beforeFreshEmpty);
+    expect(beforeFreshEmpty.sealedEntries).toBeNull();
+
+    const retained = preparedImportFixture([functionImport("env", "retained", 0)]);
+    retained.registry.planRetained();
+    const beforeEmpty = importPublicationSnapshot(retained.registry, retained.session);
+    retained.registry.planPrepared(new Set());
+    expect(importPublicationSnapshot(retained.registry, retained.session)).toEqual(beforeEmpty);
+  });
+
+  it("rejects occupied prepared-import order slots without sealing and tolerates unrelated order", () => {
+    {
+      const selected = functionImport("env", "selected", 0);
+      const { registry, session } = preparedImportFixture([selected]);
+      planForeignCallableOrder(session, 4, 0, "before-import-description");
+      expectPreparedImportFailureWithoutPublishing(registry, session, () =>
+        registry.describePrepared(new Set([selected])),
+      );
+    }
+
+    {
+      const selected = functionImport("env", "selected", 0);
+      const { registry, session } = preparedImportFixture([selected]);
+      const descriptor = describePreparedImportsWithoutPublishing(registry, session, new Set([selected]));
+      planForeignCallableOrder(session, 4, 0, "after-import-description");
+      expectPreparedImportFailureWithoutPublishing(registry, session, () =>
+        registry.assertPreparedDescriptorCurrent(descriptor),
+      );
+      expectPreparedImportFailureWithoutPublishing(registry, session, () =>
+        registry.publishPreparedDescriptor(descriptor),
+      );
+    }
+
+    {
+      const selected = functionImport("env", "selected", 0);
+      const { registry, session } = preparedImportFixture([selected]);
+      const descriptor = describePreparedImportsWithoutPublishing(registry, session, new Set([selected]));
+      const foreignId = planForeignCallableOrder(session, 4, 1, "unrelated-import-order");
+      const beforeCurrentness = importPublicationSnapshot(registry, session);
+      registry.assertPreparedDescriptorCurrent(descriptor);
+      expect(importPublicationSnapshot(registry, session)).toEqual(beforeCurrentness);
+      registry.publishPreparedDescriptor(descriptor);
+      expect(session.getDraft(foreignId)?.structuralOrder.derivedOrdinal).toBe(1);
+      expect(session.locatorBindingId(selected)).toBeDefined();
+    }
   });
 
   it("rejects invalid import descriptions and one-fact descriptor drift without publishing", () => {

--- a/tests/issue-3520-program-abi-import-callable-planning.test.ts
+++ b/tests/issue-3520-program-abi-import-callable-planning.test.ts
@@ -25,8 +25,71 @@ function fixture(module: WasmModule, entryFile = source()) {
   return { ctx, inventory, session };
 }
 
+type CallableImportRegistry = NonNullable<ReturnType<typeof fixture>["ctx"]["programAbiCallableImports"]>;
+type PreparedImportDescriptor = ReturnType<CallableImportRegistry["describePrepared"]>;
+
+function sessionPublicationCardinalities(session: ProgramAbiSession) {
+  const state = session as unknown as Record<string, ReadonlyMap<unknown, unknown>>;
+  return ["drafts", "draftOrderOwners", "locators", "structuralReferenceKeys", "callableTypeContracts"].map(
+    (key) => state[key]!.size,
+  );
+}
+
+function importPublicationSnapshot(registry: CallableImportRegistry, session: ProgramAbiSession) {
+  const state = registry as unknown as {
+    readonly sealedEntries: readonly { readonly value: Import }[] | undefined;
+    readonly plannedByImport: ReadonlyMap<Import, unknown>;
+    readonly plannedValue: ReadonlyMap<string, unknown> | undefined;
+  };
+  return {
+    sealedEntries: state.sealedEntries?.map((entry) => entry.value) ?? null,
+    plannedImports: [...state.plannedByImport.keys()],
+    plannedValueSize: state.plannedValue?.size ?? null,
+    session: sessionPublicationCardinalities(session),
+  };
+}
+
+function withoutImportPublication<T>(registry: CallableImportRegistry, session: ProgramAbiSession, action: () => T): T {
+  const before = importPublicationSnapshot(registry, session);
+  try {
+    return action();
+  } finally {
+    expect(importPublicationSnapshot(registry, session)).toEqual(before);
+  }
+}
+
+function describePreparedImportsWithoutPublishing(
+  registry: CallableImportRegistry,
+  session: ProgramAbiSession,
+  values: ReadonlySet<Import>,
+): PreparedImportDescriptor {
+  return withoutImportPublication(registry, session, () => registry.describePrepared(values));
+}
+
+function expectPreparedImportFailureWithoutPublishing(
+  registry: CallableImportRegistry,
+  session: ProgramAbiSession,
+  action: () => unknown,
+): void {
+  expect(() => withoutImportPublication(registry, session, action)).toThrowError(ProgramAbiInvariantError);
+}
+
 function functionImport(module: string, name: string, typeIdx: number): Import {
   return { module, name, desc: { kind: "func", typeIdx } };
+}
+
+function preparedImportFixture(
+  imports: readonly Import[],
+  types: readonly TypeDef[] = [{ kind: "func", params: [], results: [] }],
+) {
+  const module = createEmptyModule();
+  module.types.push(...types);
+  module.imports.push(...imports);
+  const result = fixture(module);
+  catalogProgramAbiCallableImports(result.ctx);
+  const registry = result.ctx.programAbiCallableImports;
+  if (!registry) throw new Error("missing callable-import registry");
+  return { ...result, module, registry };
 }
 
 function structuralKey(module: string, field: string, adapterName = field): string {
@@ -234,6 +297,94 @@ describe("#3520 production imported-callable Program ABI planning", () => {
     expect(abi.entries().map((entry) => entry.id)).toEqual([retainedId]);
   });
 
+  it("describes a unique import population without publishing and preserves compatibility output", () => {
+    const makePreparedFixture = () => {
+      const alpha = functionImport("env", "alpha", 0);
+      const zeta = functionImport("env", "zeta", 0);
+      return { ...preparedImportFixture([zeta, alpha]), alpha, zeta };
+    };
+
+    const explicit = makePreparedFixture();
+    const descriptor = describePreparedImportsWithoutPublishing(
+      explicit.registry,
+      explicit.session,
+      new Set([explicit.alpha]),
+    );
+    expect(Object.isFrozen(descriptor)).toBe(true);
+    expect(Object.isFrozen(explicit.alpha)).toBe(false);
+    expect(Object.isFrozen(explicit.module.types[0])).toBe(false);
+
+    // Unique exact objects may move numerically without changing the sorted
+    // structural denominator or any descriptor-owned contract.
+    explicit.module.imports = [explicit.alpha, explicit.zeta];
+    const beforeCurrentness = importPublicationSnapshot(explicit.registry, explicit.session);
+    explicit.registry.assertPreparedDescriptorCurrent(descriptor);
+    expect(importPublicationSnapshot(explicit.registry, explicit.session)).toEqual(beforeCurrentness);
+    explicit.registry.publishPreparedDescriptor(descriptor);
+    const explicitAlphaId = explicit.registry.preparedDescriptorBindingId(descriptor, explicit.alpha);
+    expect(explicitAlphaId).toBeDefined();
+    const explicitCatalog = planProgramAbiCallableImports(explicit.registry.ctx);
+    const explicitEntries = explicit.session.publish(explicit.module).abi.entries();
+
+    const compatibility = makePreparedFixture();
+    compatibility.module.imports = [compatibility.alpha, compatibility.zeta];
+    compatibility.registry.planPrepared(new Set([compatibility.alpha]));
+    const compatibilityCatalog = planProgramAbiCallableImports(compatibility.registry.ctx);
+    const compatibilityEntries = compatibility.session.publish(compatibility.module).abi.entries();
+
+    expect([...explicitCatalog]).toEqual([...compatibilityCatalog]);
+    expect(explicitEntries).toEqual(compatibilityEntries);
+  });
+
+  it("rejects invalid import descriptions and one-fact descriptor drift without publishing", () => {
+    {
+      const present = functionImport("env", "present", 0);
+      const { registry, session } = preparedImportFixture([present]);
+      expectPreparedImportFailureWithoutPublishing(registry, session, () =>
+        registry.describePrepared(new Set([functionImport("env", "present", 0)])),
+      );
+    }
+
+    {
+      const repeated = functionImport("env", "repeated", 0);
+      const { registry, session } = preparedImportFixture([repeated, repeated]);
+      expectPreparedImportFailureWithoutPublishing(registry, session, () =>
+        registry.describePrepared(new Set([repeated])),
+      );
+    }
+
+    const mutations: readonly [string, (module: WasmModule, selected: Import) => void][] = [
+      ["denominator", (module) => module.imports.push(functionImport("late", "added", 0))],
+      ["locator", (module, selected) => (module.imports[0] = { ...selected, desc: { ...selected.desc } })],
+      ["structural key", (_module, selected) => (selected.name = "renamed")],
+      ["signature", (_module, selected) => (selected.desc = { kind: "func", typeIdx: 1 })],
+    ];
+    for (const [, mutate] of mutations) {
+      const selected = functionImport("env", "selected", 0);
+      const { module, registry, session } = preparedImportFixture(
+        [selected],
+        [
+          { kind: "func", params: [], results: [] },
+          { kind: "func", params: [{ kind: "i32" }], results: [] },
+        ],
+      );
+      const descriptor = describePreparedImportsWithoutPublishing(registry, session, new Set([selected]));
+      mutate(module, selected);
+      expectPreparedImportFailureWithoutPublishing(registry, session, () =>
+        registry.publishPreparedDescriptor(descriptor),
+      );
+    }
+
+    const first = functionImport("env", "duplicate", 0);
+    const second = functionImport("env", "duplicate", 0);
+    const { module, registry, session } = preparedImportFixture([first, second]);
+    const descriptor = describePreparedImportsWithoutPublishing(registry, session, new Set([first, second]));
+    module.imports = [second, first];
+    expectPreparedImportFailureWithoutPublishing(registry, session, () =>
+      registry.publishPreparedDescriptor(descriptor),
+    );
+  });
+
   it("prepares one import from a stable pre-DCE denominator and gives later imports trailing identities", () => {
     const module = createEmptyModule();
     module.types.push({ kind: "func", params: [], results: [] });
@@ -258,6 +409,12 @@ describe("#3520 production imported-callable Program ABI planning", () => {
     const late = functionImport("late", "after-seal", 0);
     const lateKey = structuralKey("late", "after-seal");
     module.imports = [late, required];
+    const sealedDescriptor = describePreparedImportsWithoutPublishing(importRegistry, session, new Set([required]));
+    expect(importRegistry.preparedDescriptorBindingId(sealedDescriptor, required)).toBe(requiredId);
+    const beforeCurrentness = importPublicationSnapshot(importRegistry, session);
+    importRegistry.assertPreparedDescriptorCurrent(sealedDescriptor);
+    importRegistry.publishPreparedDescriptor(sealedDescriptor);
+    expect(importPublicationSnapshot(importRegistry, session)).toEqual(beforeCurrentness);
     const finalCatalog = planProgramAbiCallableImports(ctx);
     const lateId = finalCatalog.get(lateKey)!;
     expect(finalCatalog.get(requiredKey)).toBe(requiredId);
@@ -275,6 +432,37 @@ describe("#3520 production imported-callable Program ABI planning", () => {
     const { abi } = session.publish(module);
     expect(abi.resolveFinalIndex(lateId)).toEqual({ space: "function", index: 0 });
     expect(abi.resolveFinalIndex(requiredId)).toEqual({ space: "function", index: 1 });
+  });
+
+  it("leaves an abandoned preview outside the post-DCE denominator and rejects its stale publish", () => {
+    const run = (preview: boolean) => {
+      const dead = functionImport("env", "a-dead", 0);
+      const retained = functionImport("env", "z-retained", 0);
+      const { ctx, module, registry, session } = preparedImportFixture([dead, retained]);
+      const descriptor = preview
+        ? describePreparedImportsWithoutPublishing(registry, session, new Set([retained]))
+        : undefined;
+
+      module.imports = [retained];
+      if (descriptor) {
+        expectPreparedImportFailureWithoutPublishing(registry, session, () =>
+          registry.publishPreparedDescriptor(descriptor),
+        );
+      }
+      const catalog = planProgramAbiCallableImports(ctx);
+      const retainedId = catalog.get(structuralKey("env", "z-retained"))!;
+      return {
+        catalog: [...catalog],
+        draft: session.getDraft(retainedId),
+        entries: session.publish(module).abi.entries(),
+      };
+    };
+
+    const previewed = run(true);
+    const control = run(false);
+    expect(previewed).toEqual(control);
+    expect(previewed.draft?.structuralOrder.derivedOrdinal).toBe(0);
+    expect(previewed.catalog).toHaveLength(1);
   });
 
   it("gives allocator-distinct duplicate imports unique plans while preserving one structural resolver target", () => {


### PR DESCRIPTION
## Summary

- add behavior-neutral immutable descriptions for prepared import and callable-provider plans
- freeze exact state-aware denominators, ownership, locator, signature, alias, and Program ABI evidence without publishing registry state
- fail closed on stale or forged descriptor order slots while preserving immediate planPrepared compatibility behavior

This is descriptor implementation PR A from the approved #4260 plan. It is deliberately dormant and does not change prepared-component sealing, fallback behavior, runtime bytes, or production selection. The later atomic behavioral PR B remains gated until this descriptor checkpoint merges.

## Dependency and commit chain

Plan PR #4959 merged as ff56e3d9b5abbd85201dc8087106431128915f49 and contains exact parent 7342dd1a27fbfd22bdeaa4705f15cdee5b9e3d4d.

The unchanged signed implementation chain is:

- 875ee21b27779260d4a4131d044f1def9f8c510c — descriptor implementation
- 81361bc6dcd3386a1b42f56503739dd7dd31bd6e — focused descriptor contracts
- c30e35a66fa2273511a134965bddfe50c2bec779 — stale structural-order hardening

Each commit is authored by Thomas Tränkler, contains one SSH signature block, and carries one Codex co-author trailer.

## Exact scope

- src/codegen/program-abi-import-planning.ts
- src/codegen/program-abi-provider-planning.ts
- tests/issue-3520-callable-provider-abi.test.ts
- tests/issue-3520-program-abi-import-callable-planning.test.ts

Four files, 1693 insertions and 55 deletions. Live main had no changes to these files after the merged plan parent.

## Validation

Strict load gate remained finite and nonnegative with 10 logical cores and exact limit below 8 before every heavy command and push.

- focused Vitest suites: 29/29 passed (15 provider ABI, 14 import planning)
- TypeScript 7 and TypeScript 5 typechecks passed
- targeted Prettier and Biome passed
- IR layering, dialect, fallback, oracle, coercion, optimization-retirement, dead-export, LOC, and function-growth gates passed
- normal pre-push hook passed without skips: typecheck/lint, full format check, oracle, coercion, numeric-local parity 18/18, and issue integrity

No rebase, merge, amend, force-push, or skipped hook was used.