### PR TITLE
feat(ir): authenticate #4550 linear census ✓

### DIFF
--- a/scripts/check-linear-ir.ts
+++ b/scripts/check-linear-ir.ts
@@ -1,139 +1,621 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * #2956 L1 — linear-IR parity ratchet (acceptance criterion 3, a clone of the
- * #1376 `check:ir-fallbacks` shape for the LINEAR overlay).
+ * #2956/#4550 — fail-closed linear-IR parity ratchet.
  *
- * Compiles the fixed corpus (`website/playground/examples/*.ts`) with
- * `--target linear` with the overlay explicitly ON (`JS2WASM_LINEAR_IR=1`), reads each
- * module's `LinearIrResult` report, and aggregates:
- *
- *   - `compiled`  — functions the overlay lowered via IR + LinearEmitter
- *   - per-reason demotion buckets (`illegal:instr-*`, `illegal:valtype-*`,
- *     `build`, `verify`, `lifted-closures`, …)
- *
- * Gate semantics vs `scripts/linear-ir-baseline.json`:
- *   - `compiled` must NOT DECREASE (parity progress banks; a drop means an
- *     IR-claimed-and-lowered function fell back to the direct path).
- *   - No demotion bucket may INCREASE.
- *   Decreasing buckets / increasing compiled succeed; run with `--update`
- *   to refresh the committed baseline in the same PR (visible in review).
- *
- * The overlay is default-on since L4. This script still pins `=1` so a caller's
- * ambient rollback setting cannot silently turn the ratchet into a direct-path
- * compile.
- *
- * Usage:
- *   pnpm run check:linear-ir              # gate against baseline
- *   pnpm run check:linear-ir -- --update  # refresh the committed baseline
- *   pnpm run check:linear-ir -- --json    # machine-readable output
+ * The fixed playground corpus and threshold predicates are unchanged. Each
+ * compile is authenticated by a fresh complete coverage census so a crash,
+ * early validation return, missing report, or stale last-write-wins value can
+ * never be counted as an empty success.
  */
+import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// The overlay gate reads the env at compile time — set it before importing
-// the compiler so any module-load-time capture also sees it.
-process.env.JS2WASM_LINEAR_IR = "1";
+export const LINEAR_IR_RATCHET_SCHEMA = "linear-ir-ratchet-evidence-v2" as const;
 
-const { compile } = await import("../src/index.js");
-const { getLastLinearIrReport } = await import("../src/ir/backend/linear-integration.js");
+export interface LinearIrBaseline {
+  readonly compiled: number;
+  readonly buckets: Readonly<Record<string, number>>;
+}
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = resolve(__dirname, "..");
+export interface LinearIrInstrumentationFailure {
+  readonly logicalFileName: string;
+  readonly code: string;
+  readonly detail: string;
+}
+
+export interface LinearIrCompileErrorEvidence {
+  readonly message: string;
+  readonly line: number;
+  readonly column: number;
+  readonly severity: "error" | "warning";
+  readonly code: number | null;
+  readonly file: string | null;
+}
+
+export interface LinearIrCompileErrorProjection {
+  readonly errors: readonly LinearIrCompileErrorEvidence[];
+  readonly truncated: boolean;
+}
+
+interface RatchetModules {
+  readonly compile: typeof import("../src/index.js").compile;
+  readonly ts: typeof import("../src/ts-api.js").ts;
+  readonly buildIrUnitInventory: typeof import("../src/ir/identity.js").buildIrUnitInventory;
+  readonly buildIrPlanningIdentityContext: typeof import("../src/ir/planning-identity.js").buildIrPlanningIdentityContext;
+  readonly getLastLinearIrReport: typeof import("../src/ir/backend/linear-integration.js").getLastLinearIrReport;
+  readonly resetLastLinearIrReport: typeof import("../src/ir/backend/linear-integration.js").resetLastLinearIrReport;
+  readonly indexLinearIrSourceOwners: typeof import("../src/ir/backend/linear-integration.js").indexLinearIrSourceOwners;
+  readonly getLastLinearIrCoverageCensus: typeof import("../src/ir/backend/linear-ir-coverage.js").getLastLinearIrCoverageCensus;
+  readonly resetLastLinearIrCoverageCensus: typeof import("../src/ir/backend/linear-ir-coverage.js").resetLastLinearIrCoverageCensus;
+  readonly validateLinearIrCoverageCensus: typeof import("../src/ir/backend/linear-ir-coverage.js").validateLinearIrCoverageCensus;
+  readonly linearIrCoverageDigestProjection: typeof import("../src/ir/backend/linear-ir-coverage.js").linearIrCoverageDigestProjection;
+  readonly canonicalLinearIrCoverageJson: typeof import("../src/ir/backend/linear-ir-coverage.js").canonicalLinearIrCoverageJson;
+}
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(scriptDirectory, "..");
 const BASELINE_PATH = join(REPO_ROOT, "scripts/linear-ir-baseline.json");
 const CORPUS_ROOTS = [join(REPO_ROOT, "website/playground/examples")];
+const LINEAR_IR_ENV = "JS2WASM_LINEAR_IR";
+const LINEAR_IR_COVERAGE_ENV = "JS2WASM_LINEAR_IR_COVERAGE";
 
-interface Baseline {
-  readonly compiled: number;
-  readonly buckets: Record<string, number>;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: evidence sanitization deliberately replaces C0 controls.
+const ALL_CONTROL_CHARACTERS = /[\u0000-\u001f]/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: evidence sanitization deliberately retains only layout controls.
+const NON_LAYOUT_CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g;
+
+export function compareLinearIrRatchetText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
-function walk(dir: string, out: string[]): void {
-  if (!existsSync(dir)) return;
-  for (const entry of readdirSync(dir)) {
-    const p = join(dir, entry);
-    if (statSync(p).isDirectory()) walk(p, out);
-    else if (p.endsWith(".ts") && !p.endsWith(".d.ts")) out.push(p);
-  }
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
-const files: string[] = [];
-for (const root of CORPUS_ROOTS) walk(root, files);
-files.sort();
+function exactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort(compareLinearIrRatchetText);
+  const wanted = [...expected].sort(compareLinearIrRatchetText);
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+}
 
-let compiledTotal = 0;
-const buckets = new Map<string, number>();
-const perFile: { file: string; compiled: string[]; rejected: { func: string; reason: string }[] }[] = [];
+function safeCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
 
-for (const file of files) {
-  const source = readFileSync(file, "utf-8");
+/** Parse the committed two-field threshold contract; no implicit seeding. */
+export function parseLinearIrBaseline(text: string | undefined): LinearIrBaseline {
+  if (text === undefined) throw new Error("linear-ir baseline is missing");
+  let parsed: unknown;
   try {
-    await compile(source, { target: "linear", fileName: file });
+    parsed = JSON.parse(text);
   } catch {
-    // A compile crash is a direct-path concern, not the overlay's — the
-    // overlay demotes internally and never throws out of generateLinearModule.
+    throw new Error("linear-ir baseline is not valid JSON");
   }
-  const report = getLastLinearIrReport();
-  if (!report) continue;
-  compiledTotal += report.compiled.length;
-  for (const rej of report.rejected) {
-    buckets.set(rej.reason, (buckets.get(rej.reason) ?? 0) + 1);
+  if (!plainRecord(parsed) || !exactKeys(parsed, ["compiled", "buckets"]) || !safeCount(parsed.compiled)) {
+    throw new Error("linear-ir baseline fields are malformed");
   }
-  if (report.compiled.length > 0 || report.rejected.length > 0) {
-    perFile.push({
-      file: file.slice(REPO_ROOT.length + 1),
-      compiled: [...report.compiled],
-      rejected: report.rejected.map((r) => ({ func: r.func, reason: r.reason })),
+  if (!plainRecord(parsed.buckets)) throw new Error("linear-ir baseline buckets are malformed");
+  const buckets: Record<string, number> = {};
+  for (const key of Object.keys(parsed.buckets).sort(compareLinearIrRatchetText)) {
+    const count = parsed.buckets[key];
+    if (key.length === 0 || !safeCount(count)) throw new Error("linear-ir baseline bucket entry is malformed");
+    buckets[key] = count;
+  }
+  return Object.freeze({ compiled: parsed.compiled, buckets: Object.freeze(buckets) });
+}
+
+/** Missing/malformed input is replaceable only in explicit update mode. */
+export function loadLinearIrBaselineForMode(
+  text: string | undefined,
+  update: boolean,
+): { readonly baseline?: LinearIrBaseline; readonly replacementRequired: boolean } {
+  try {
+    return { baseline: parseLinearIrBaseline(text), replacementRequired: false };
+  } catch (error) {
+    if (!update) throw error;
+    return { replacementRequired: true };
+  }
+}
+
+function walk(directory: string, output: string[]): void {
+  if (!existsSync(directory)) return;
+  for (const entry of readdirSync(directory).sort(compareLinearIrRatchetText)) {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) walk(path, output);
+    else if (path.endsWith(".ts") && !path.endsWith(".d.ts")) output.push(path);
+  }
+}
+
+function logicalFileName(path: string): string {
+  return relative(REPO_ROOT, path).split(sep).join("/");
+}
+
+function stableError(error: unknown): { readonly code: string; readonly detail: string } {
+  const record = error !== null && typeof error === "object" ? (error as { name?: unknown; message?: unknown }) : {};
+  const rawCode = typeof record.name === "string" ? record.name : "ThrownValue";
+  const code = /^[A-Za-z][A-Za-z0-9_.-]{0,127}$/.test(rawCode) ? rawCode : "ThrownValue";
+  const detail = String(record.message ?? error)
+    .replaceAll(REPO_ROOT, "<repo>")
+    .replace(/(?:file:\/\/)?(?:[A-Za-z]:[\\/]|\/)(?:[^\s:;,)}\]]+[\\/]?)+/g, "<path>")
+    .replace(/\r\n?/g, "\n")
+    .replace(ALL_CONTROL_CHARACTERS, " ")
+    .slice(0, 512);
+  return { code, detail: detail || "unknown failure" };
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+const MAX_COMPILE_ERROR_ROWS = 256;
+
+function stableCompileErrorText(value: string, max: number): string {
+  return value
+    .replaceAll(REPO_ROOT, "<repo>")
+    .replace(/(?:file:\/\/)?(?:[A-Za-z]:[\\/]|\/)(?:[^\s:;,)}\]]+[\\/]?)+/g, "<path>")
+    .replace(/\r\n?/g, "\n")
+    .replace(NON_LAYOUT_CONTROL_CHARACTERS, " ")
+    .slice(0, max);
+}
+
+/** Stable bounded diagnostics retained even when generation precedes public failure. */
+export function projectLinearIrCompileErrors(
+  errors: readonly {
+    readonly message: string;
+    readonly line: number;
+    readonly column: number;
+    readonly severity: "error" | "warning";
+    readonly code?: number;
+    readonly file?: string;
+  }[],
+): LinearIrCompileErrorProjection {
+  const projected = errors.map(
+    (error): LinearIrCompileErrorEvidence => ({
+      message: stableCompileErrorText(error.message, 512),
+      line: safeCount(error.line) ? error.line : 0,
+      column: safeCount(error.column) ? error.column : 0,
+      severity: error.severity,
+      code: safeCount(error.code) ? error.code : null,
+      file: error.file === undefined ? null : stableCompileErrorText(error.file, 256),
+    }),
+  );
+  projected.sort((left, right) => compareLinearIrRatchetText(JSON.stringify(left), JSON.stringify(right)));
+  return Object.freeze({
+    errors: Object.freeze(projected.slice(0, MAX_COMPILE_ERROR_ROWS).map((error) => Object.freeze(error))),
+    truncated: projected.length > MAX_COMPILE_ERROR_ROWS,
+  });
+}
+
+export function digestLinearIrCompileErrors(errorCount: number, projection: LinearIrCompileErrorProjection): string {
+  if (
+    !safeCount(errorCount) ||
+    errorCount < projection.errors.length ||
+    projection.truncated !== errorCount > projection.errors.length
+  ) {
+    throw new Error("linear-ir compile error projection does not reconcile with its exact count");
+  }
+  return sha256(JSON.stringify({ errorCount, errors: projection.errors, truncated: projection.truncated }));
+}
+
+export function linearIrGenerationContributionEligible(input: {
+  readonly compileStatus: "returned" | "threw";
+  readonly censusStatus: "complete" | "generation-failed" | "missing" | "malformed";
+  readonly instrumentationFailureCount: number;
+}): boolean {
+  return (
+    input.compileStatus === "returned" && input.censusStatus === "complete" && input.instrumentationFailureCount === 0
+  );
+}
+
+async function loadRatchetModules(): Promise<RatchetModules> {
+  const [compiler, tsApi, identity, planningIdentity, integration, coverage] = await Promise.all([
+    import("../src/index.js"),
+    import("../src/ts-api.js"),
+    import("../src/ir/identity.js"),
+    import("../src/ir/planning-identity.js"),
+    import("../src/ir/backend/linear-integration.js"),
+    import("../src/ir/backend/linear-ir-coverage.js"),
+  ]);
+  return {
+    compile: compiler.compile,
+    ts: tsApi.ts,
+    buildIrUnitInventory: identity.buildIrUnitInventory,
+    buildIrPlanningIdentityContext: planningIdentity.buildIrPlanningIdentityContext,
+    getLastLinearIrReport: integration.getLastLinearIrReport,
+    resetLastLinearIrReport: integration.resetLastLinearIrReport,
+    indexLinearIrSourceOwners: integration.indexLinearIrSourceOwners,
+    getLastLinearIrCoverageCensus: coverage.getLastLinearIrCoverageCensus,
+    resetLastLinearIrCoverageCensus: coverage.resetLastLinearIrCoverageCensus,
+    validateLinearIrCoverageCensus: coverage.validateLinearIrCoverageCensus,
+    linearIrCoverageDigestProjection: coverage.linearIrCoverageDigestProjection,
+    canonicalLinearIrCoverageJson: coverage.canonicalLinearIrCoverageJson,
+  };
+}
+
+interface ExpectedOwnerIdentity {
+  readonly ownerUnitId: string;
+  readonly sourceId: string;
+  readonly sourceKey: string;
+  readonly legacyName: string;
+  readonly terminalKind: string;
+  readonly observedKind: string;
+}
+
+function expectedPopulation(modules: RatchetModules, fileName: string, source: string) {
+  const sourceFile = modules.ts.createSourceFile(
+    fileName,
+    source,
+    modules.ts.ScriptTarget.ESNext,
+    true,
+    modules.ts.ScriptKind.TS,
+  );
+  const inventory = modules.buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
+  if (inventory.sources.length !== 1 || inventory.sources[0]?.originalFileName !== fileName) {
+    throw new Error(`logical source ${fileName} did not produce one exact inventory row`);
+  }
+  const row = inventory.sources[0]!;
+  const identityContext = modules.buildIrPlanningIdentityContext(inventory);
+  const owners = modules.indexLinearIrSourceOwners(sourceFile, identityContext).owners.map((owner) => {
+    const terminal = identityContext.terminalByUnitId.get(owner.ownerUnitId);
+    if (!terminal) throw new Error(`expected owner ${owner.ownerUnitId} lost its terminal row`);
+    return {
+      ownerUnitId: owner.ownerUnitId,
+      sourceId: terminal.sourceId,
+      sourceKey: row.sourceKey,
+      legacyName: owner.legacyName,
+      terminalKind: terminal.kind,
+      observedKind: terminal.observedKind,
+    };
+  });
+  owners.sort((left, right) => compareLinearIrRatchetText(left.ownerUnitId, right.ownerUnitId));
+  return {
+    source: { sourceId: row.id, sourceKey: row.sourceKey, kind: row.kind, order: row.order },
+    owners,
+  };
+}
+
+function sameSourceRow(
+  actual: { readonly sourceId: string; readonly sourceKey: string; readonly kind: string; readonly order: number },
+  expected: { readonly sourceId: string; readonly sourceKey: string; readonly kind: string; readonly order: number },
+): boolean {
+  return (
+    actual.sourceId === expected.sourceId &&
+    actual.sourceKey === expected.sourceKey &&
+    actual.kind === expected.kind &&
+    actual.order === expected.order
+  );
+}
+
+export function sameLinearIrOwnerPopulation(
+  actual: readonly ExpectedOwnerIdentity[],
+  expected: readonly ExpectedOwnerIdentity[],
+): boolean {
+  return (
+    actual.length === expected.length &&
+    actual.every((owner, index) => {
+      const wanted = expected[index];
+      return (
+        wanted !== undefined &&
+        owner.ownerUnitId === wanted.ownerUnitId &&
+        owner.sourceId === wanted.sourceId &&
+        owner.sourceKey === wanted.sourceKey &&
+        owner.legacyName === wanted.legacyName &&
+        owner.terminalKind === wanted.terminalKind &&
+        owner.observedKind === wanted.observedKind
+      );
+    })
+  );
+}
+
+interface FileEvidence {
+  readonly logicalFileName: string;
+  readonly generationSequence: number;
+  readonly expectedEntry: { readonly sourceId: string; readonly sourceKey: string };
+  readonly compile:
+    | {
+        readonly status: "returned";
+        readonly success: boolean;
+        readonly errorCount: number;
+        readonly errorProjection: LinearIrCompileErrorProjection;
+        readonly errorsSha256: string;
+      }
+    | { readonly status: "threw"; readonly code: string; readonly detail: string };
+  readonly report:
+    | {
+        readonly status: "present";
+        readonly compiled: readonly string[];
+        readonly rejected: readonly { readonly func: string; readonly reason: string }[];
+      }
+    | { readonly status: "missing" };
+  readonly census:
+    | { readonly status: "missing" | "malformed" }
+    | {
+        readonly status: "complete" | "generation-failed";
+        readonly counts: {
+          readonly sources: number;
+          readonly owners: number;
+          readonly compiled: number;
+          readonly rejected: number;
+          readonly notAttempted: number;
+        };
+        readonly sha256: string;
+        readonly evidence: unknown;
+      };
+  readonly instrumentationFailures: readonly LinearIrInstrumentationFailure[];
+}
+
+async function measureFile(
+  modules: RatchetModules,
+  path: string,
+  generationSequence: number,
+): Promise<{ readonly evidence: FileEvidence; readonly baselineContribution?: LinearIrBaseline }> {
+  const fileName = logicalFileName(path);
+  const source = readFileSync(path, "utf8");
+  const expected = expectedPopulation(modules, fileName, source);
+  const failures: LinearIrInstrumentationFailure[] = [];
+  const fail = (code: string, detail: string): void => {
+    failures.push({ logicalFileName: fileName, code, detail });
+  };
+
+  modules.resetLastLinearIrReport();
+  const watermark = modules.resetLastLinearIrCoverageCensus();
+  let result: Awaited<ReturnType<RatchetModules["compile"]>> | undefined;
+  let thrown: unknown;
+  let didThrow = false;
+  try {
+    result = await modules.compile(source, { target: "linear", fileName });
+  } catch (error) {
+    didThrow = true;
+    thrown = error;
+  }
+  // Capture both channels before any other compile or compiler-derived work.
+  const report = modules.getLastLinearIrReport();
+  const rawCensus = modules.getLastLinearIrCoverageCensus();
+
+  const compileEvidence = didThrow
+    ? ({ status: "threw", ...stableError(thrown) } as const)
+    : (() => {
+        const errors = result?.errors ?? [];
+        const errorProjection = projectLinearIrCompileErrors(errors);
+        return {
+          status: "returned",
+          success: result?.success === true,
+          errorCount: errors.length,
+          errorProjection,
+          errorsSha256: digestLinearIrCompileErrors(errors.length, errorProjection),
+        } as const;
+      })();
+  if (compileEvidence.status === "threw") fail("compile-threw", compileEvidence.detail);
+
+  const reportEvidence = report
+    ? ({
+        status: "present",
+        compiled: Object.freeze([...report.compiled]),
+        rejected: Object.freeze(report.rejected.map(({ func, reason }) => ({ func, reason }))),
+      } as const)
+    : ({ status: "missing" } as const);
+  if (!report) fail("missing-compatibility-report", "linear generator did not publish its compatibility report");
+
+  let censusEvidence: FileEvidence["census"] = { status: "missing" };
+  let contribution: LinearIrBaseline | undefined;
+  if (!rawCensus) {
+    fail("missing-coverage-census", "linear generator did not finalize a coverage census");
+  } else {
+    try {
+      const census = modules.validateLinearIrCoverageCensus(rawCensus, { afterWatermark: watermark });
+      const projection = modules.linearIrCoverageDigestProjection(census);
+      const canonical = modules.canonicalLinearIrCoverageJson(projection);
+      censusEvidence = {
+        status: census.status,
+        counts: census.counts,
+        sha256: sha256(canonical),
+        evidence: projection,
+      };
+      if (census.generationKind !== "single-source") fail("wrong-generation-kind", census.generationKind);
+      if (census.status !== "complete") fail("generation-failed", census.failure?.detail ?? "missing failure detail");
+      if (
+        census.sources.length !== 1 ||
+        !sameSourceRow(census.sources[0]!, expected.source) ||
+        census.entrySourceId !== expected.source.sourceId ||
+        census.entrySourceKey !== expected.source.sourceKey
+      ) {
+        fail("source-identity-mismatch", "census entry/source rows do not match the logical compiler input");
+      }
+      if (!sameLinearIrOwnerPopulation(census.owners, expected.owners)) {
+        fail("owner-population-mismatch", "census owner rows do not match the authoritative logical-input population");
+      }
+      if (
+        report &&
+        (report.compiled.length !== census.counts.compiled || report.rejected.length !== census.counts.rejected)
+      ) {
+        fail("report-census-count-mismatch", "compatibility report counts do not match structural owner outcomes");
+      }
+      if (
+        linearIrGenerationContributionEligible({
+          compileStatus: compileEvidence.status,
+          censusStatus: census.status,
+          instrumentationFailureCount: failures.length,
+        })
+      ) {
+        const bucketCounts = new Map<string, number>();
+        for (const owner of census.owners) {
+          if (owner.outcome.kind === "rejected") {
+            bucketCounts.set(owner.outcome.reason, (bucketCounts.get(owner.outcome.reason) ?? 0) + 1);
+          }
+        }
+        contribution = {
+          compiled: census.counts.compiled,
+          buckets: Object.fromEntries([...bucketCounts].sort(([a], [b]) => compareLinearIrRatchetText(a, b))),
+        };
+      }
+    } catch (error) {
+      censusEvidence = { status: "malformed" };
+      fail("malformed-coverage-census", stableError(error).detail);
+    }
+  }
+  return {
+    evidence: {
+      logicalFileName: fileName,
+      generationSequence,
+      expectedEntry: { sourceId: expected.source.sourceId, sourceKey: expected.source.sourceKey },
+      compile: compileEvidence,
+      report: reportEvidence,
+      census: censusEvidence,
+      instrumentationFailures: Object.freeze(failures),
+    },
+    ...(contribution ? { baselineContribution: contribution } : {}),
+  };
+}
+
+function mergeContributions(contributions: readonly LinearIrBaseline[]): LinearIrBaseline {
+  let compiled = 0;
+  const buckets = new Map<string, number>();
+  for (const contribution of contributions) {
+    compiled += contribution.compiled;
+    for (const [reason, count] of Object.entries(contribution.buckets)) {
+      buckets.set(reason, (buckets.get(reason) ?? 0) + count);
+    }
+  }
+  return {
+    compiled,
+    buckets: Object.fromEntries([...buckets].sort(([a], [b]) => compareLinearIrRatchetText(a, b))),
+  };
+}
+
+export function compareLinearIrBaseline(current: LinearIrBaseline, baseline: LinearIrBaseline): readonly string[] {
+  const failures: string[] = [];
+  if (current.compiled < baseline.compiled) {
+    failures.push(`IR-compiled function count DECREASED: ${baseline.compiled} → ${current.compiled}`);
+  }
+  for (const [reason, count] of Object.entries(current.buckets)) {
+    const prior = baseline.buckets[reason] ?? 0;
+    if (count > prior) failures.push(`demotion bucket '${reason}' INCREASED: ${prior} → ${count}`);
+  }
+  return failures;
+}
+
+export async function runLinearIrRatchet(args: readonly string[] = process.argv.slice(2)): Promise<number> {
+  const unknownArgs = args.filter((arg) => arg !== "--json" && arg !== "--update");
+  const json = args.includes("--json");
+  const update = args.includes("--update");
+  const files: string[] = [];
+  for (const root of CORPUS_ROOTS) walk(root, files);
+  files.sort((left, right) => compareLinearIrRatchetText(logicalFileName(left), logicalFileName(right)));
+  const expectedFiles = files.map(logicalFileName);
+  const allFailures: LinearIrInstrumentationFailure[] = unknownArgs.map((arg) => ({
+    logicalFileName: "<arguments>",
+    code: "unknown-argument",
+    detail: arg,
+  }));
+  if (expectedFiles.length === 0) {
+    allFailures.push({
+      logicalFileName: "<census>",
+      code: "empty-corpus",
+      detail: "no expected TypeScript files were discovered",
     });
   }
+
+  const priorLinearIr = process.env[LINEAR_IR_ENV];
+  const priorCoverage = process.env[LINEAR_IR_COVERAGE_ENV];
+  process.env[LINEAR_IR_ENV] = "1";
+  process.env[LINEAR_IR_COVERAGE_ENV] = "1";
+  const perFile: FileEvidence[] = [];
+  const contributions: LinearIrBaseline[] = [];
+  try {
+    const modules = await loadRatchetModules();
+    for (let index = 0; index < files.length; index++) {
+      if (!json) process.stderr.write(`linear-ir ratchet: measuring ${expectedFiles[index]}\n`);
+      const measured = await measureFile(modules, files[index]!, index + 1);
+      perFile.push(measured.evidence);
+      allFailures.push(...measured.evidence.instrumentationFailures);
+      if (measured.baselineContribution) contributions.push(measured.baselineContribution);
+    }
+  } finally {
+    if (priorLinearIr === undefined) delete process.env[LINEAR_IR_ENV];
+    else process.env[LINEAR_IR_ENV] = priorLinearIr;
+    if (priorCoverage === undefined) delete process.env[LINEAR_IR_COVERAGE_ENV];
+    else process.env[LINEAR_IR_COVERAGE_ENV] = priorCoverage;
+  }
+
+  const observedFiles = perFile.map((row) => row.logicalFileName);
+  if (
+    observedFiles.length !== expectedFiles.length ||
+    observedFiles.some((file, index) => file !== expectedFiles[index])
+  ) {
+    allFailures.push({
+      logicalFileName: "<census>",
+      code: "file-census-mismatch",
+      detail: `expected ${expectedFiles.length}, observed ${observedFiles.length}`,
+    });
+  }
+  const current = mergeContributions(contributions);
+  let baseline: LinearIrBaseline | undefined;
+  let replacementRequired = false;
+  try {
+    const loaded = loadLinearIrBaselineForMode(
+      existsSync(BASELINE_PATH) ? readFileSync(BASELINE_PATH, "utf8") : undefined,
+      update,
+    );
+    baseline = loaded.baseline;
+    replacementRequired = loaded.replacementRequired;
+  } catch (error) {
+    allFailures.push({ logicalFileName: "<baseline>", code: "invalid-baseline", detail: stableError(error).detail });
+  }
+  const thresholdFailures = baseline ? compareLinearIrBaseline(current, baseline) : [];
+  const instrumentationPassed = allFailures.length === 0 && contributions.length === expectedFiles.length;
+  let baselineUpdated = false;
+  if (update && instrumentationPassed) {
+    writeFileSync(BASELINE_PATH, `${JSON.stringify(current, null, 2)}\n`);
+    baselineUpdated = true;
+  }
+  const passed = instrumentationPassed && (update || (baseline !== undefined && thresholdFailures.length === 0));
+  const evidence = {
+    schema: LINEAR_IR_RATCHET_SCHEMA,
+    expectedFiles,
+    observedFiles,
+    current,
+    baseline: baseline ?? null,
+    replacementRequired,
+    baselineUpdated,
+    perFile,
+    instrumentationFailures: allFailures,
+    thresholdFailures,
+    status: passed ? "PASS" : "FAIL",
+  } as const;
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+  } else if (passed) {
+    process.stdout.write(
+      `linear-ir ratchet: OK — files=${observedFiles.length}, compiled=${current.compiled}, buckets=${JSON.stringify(current.buckets)}${baselineUpdated ? " [baseline updated]" : ""}\n`,
+    );
+  } else {
+    process.stderr.write("linear-ir ratchet: FAIL\n");
+    for (const failure of allFailures) {
+      process.stderr.write(`  - ${failure.logicalFileName} ${failure.code}: ${failure.detail}\n`);
+    }
+    for (const failure of thresholdFailures) process.stderr.write(`  - ${failure}\n`);
+  }
+  return passed ? 0 : 1;
 }
 
-const current: Baseline = {
-  compiled: compiledTotal,
-  buckets: Object.fromEntries([...buckets.entries()].sort(([a], [b]) => a.localeCompare(b))),
-};
-
-const args = process.argv.slice(2);
-const update = args.includes("--update");
-const json = args.includes("--json");
-
-if (json) {
-  console.log(JSON.stringify({ current, perFile }, null, 2));
-}
-
-if (update || !existsSync(BASELINE_PATH)) {
-  writeFileSync(BASELINE_PATH, `${JSON.stringify(current, null, 2)}\n`);
-  console.log(
-    `linear-ir ratchet: baseline ${update ? "updated" : "seeded"} — compiled=${current.compiled}, buckets=${JSON.stringify(current.buckets)}`,
-  );
-  process.exit(0);
-}
-
-const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf-8")) as Baseline;
-const failures: string[] = [];
-
-if (current.compiled < baseline.compiled) {
-  failures.push(`IR-compiled function count DECREASED: ${baseline.compiled} → ${current.compiled}`);
-}
-for (const [reason, count] of Object.entries(current.buckets)) {
-  const base = baseline.buckets[reason] ?? 0;
-  if (count > base) {
-    failures.push(`demotion bucket '${reason}' INCREASED: ${base} → ${count}`);
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = await runLinearIrRatchet();
+  } catch (error) {
+    const failure = stableError(error);
+    if (process.argv.includes("--json")) {
+      process.stdout.write(
+        `${JSON.stringify({ schema: LINEAR_IR_RATCHET_SCHEMA, status: "FAIL", instrumentationFailures: [failure] }, null, 2)}\n`,
+      );
+    } else {
+      process.stderr.write(`linear-ir ratchet: FAIL — ${failure.code}: ${failure.detail}\n`);
+    }
+    process.exitCode = 1;
   }
 }
-
-if (failures.length > 0) {
-  console.error("linear-ir ratchet: FAIL");
-  for (const f of failures) console.error(`  - ${f}`);
-  console.error(
-    "If the change is intended (e.g. a claim intentionally re-scoped), run `pnpm run check:linear-ir -- --update` and commit the refreshed baseline.",
-  );
-  process.exit(1);
-}
-
-const improved =
-  current.compiled > baseline.compiled ||
-  Object.entries(baseline.buckets).some(([reason, base]) => (current.buckets[reason] ?? 0) < base);
-console.log(
-  `linear-ir ratchet: OK — compiled=${current.compiled} (baseline ${baseline.compiled}), buckets=${JSON.stringify(current.buckets)}${improved ? " [improved — consider --update to bank it]" : ""}`,
-);

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-25",
+  "generated": "2026-08-26",
   "populationRule": "A kind is in scope iff it is the `readonly kind` discriminant of a top-level `export interface` that is an arm of the `IrInstr` or `IrTerminator` union in src/ir/nodes.ts. Excluded: the symbolic-reference types IrFuncRef/IrGlobalRef/IrTypeRef (kinds func/global/type) and every inline union member of a payload type. See scripts/check-ir-kind-neutrality.mjs.",
   "ratchet": {
     "unresolved": 3,
@@ -518,7 +518,7 @@
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:1244",
       "why": "The MEANING is settled and it is not encoding-parameterized: every backend returns the UTF-16 CODE-UNIT count. The linear backend calls `__str_length_utf16` regardless of `inputEncoding`, and the WasmGC native provider reads a field documented as the UTF-16 code-unit length. What is NOT settled is the placement: that commitment is shared verbatim with Java/C#/the whole UTF-16 family, so it is not ECMAScript-specific the way `char_at`'s out-of-range sentinel is, yet it is a language commitment a Rust or Python producer could not use.",
-      "evidence": ["src/ir/nodes.ts:1260", "src/ir/backend/linear-integration.ts:1665", "src/ir/string-runtime.ts:15"],
+      "evidence": ["src/ir/nodes.ts:1260", "src/ir/backend/linear-integration.ts:1637", "src/ir/string-runtime.ts:15"],
       "settledBy": "A policy call phase 2 has to make anyway: does `js` mean ECMAScript-SPECIFIC, or LANGUAGE-COMMITTED? If the former, `string.len` stays in core with a documented commitment; if the latter it moves — and the same answer then governs a future `utf16-string` dialect shared by the family, which is the third option."
     },
     "string.repeat": {

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -16,6 +16,7 @@ import {
 import { createEmptyModule } from "../ir/types.js";
 import { linearAllocatorPolicy, type LinearAllocatorPolicyId } from "../ir/analysis/linear-memory-plan.js";
 import * as linearIr from "../ir/backend/linear-integration.js";
+import * as linearCoverage from "../ir/backend/linear-ir-coverage.js";
 import { compileResolvedArrayPointer, emitResolvedArrayLocal } from "./array-pointer.js";
 import type { CollectionKind, FinallyEntry, LinearContext, LinearFuncContext } from "./context.js";
 import { addLocal } from "./context.js";
@@ -53,13 +54,8 @@ import { linearStringLiteralInstrs } from "./string-literals.js";
 const CLASS_TYPE_TAG = 5;
 
 /**
- * Data segment base address — must be below HEAP_START (1024).
- *
- * **Standalone mode only** (#4540). In linked mode the segment is PASSIVE and
- * this value stops being an address: it becomes the base the literal offsets
- * were assigned from, which `__rodata_bias` corrects at runtime. An active
- * segment at 64 would be written at instantiation into the memory owner's
- * shadow stack, before any instruction of ours runs. See ADR-0022.
+ * Standalone data address below HEAP_START. Linked mode uses it only as the
+ * passive-segment offset base corrected by `__rodata_bias`; see ADR-0022.
  */
 const DATA_SEGMENT_BASE = 64;
 
@@ -85,11 +81,7 @@ function sourceMayUseLinearIrStringRuntime(sourceFile: ts.SourceFile): boolean {
   return found;
 }
 
-/**
- * Extract a 1-based {line, column} from an AST node for diagnostics (#1937).
- * Mirrors the GC backend's extractLocation (src/codegen/context/errors.ts);
- * falls back to {0,0} for synthetic nodes without a source file.
- */
+/** Extract a 1-based diagnostic location, or {0,0} for synthetic nodes (#1937). */
 function nodeLoc(node: ts.Node): { line: number; column: number } {
   try {
     const sf = node.getSourceFile();
@@ -108,11 +100,8 @@ function nodeLoc(node: ts.Node): { line: number; column: number } {
  */
 export interface LinearOptions {
   /**
-   * Enable conservative exported-call reclamation and expose the explicit
-   * arena-management exports `__arena_reset` / `__arena_used`. Only modules
-   * with primitive boundaries and no heap-backed globals are auto-wrapped;
-   * others retain the monotonic arena so escaped pointers stay live.
-   * See {@link import("./runtime.js").ArenaOptions}.
+   * Expose arena management and conservatively reclaim primitive-boundary
+   * exports; heap-backed escapees retain the monotonic arena.
    */
   exposeArenaReset?: boolean;
   /** Shared IR allocation policy. Direct-backend fallbacks remain arena-backed. */
@@ -137,18 +126,8 @@ export interface LinearOptions {
     indexType?: "i32" | "i64";
   };
   /**
-   * Linked-mode heap (#4540) — REQUIRED whenever {@link importMemory} is set.
-   *
-   * Names the extern-C import that provides the host allocator. `__malloc` then
-   * bump-allocates inside chunks carved from it and never calls `memory.grow`,
-   * so the memory's owner stays its only grower.
-   *
-   * It is required rather than optional because the alternative is the measured
-   * failure this option exists to remove: with a memory we do not own and the
-   * standalone arena, `__heap_ptr` starts at 1024 — inside the pinned
-   * artifact's 64 KiB shadow stack — so the first allocation writes through the
-   * engine's stack. Making that combination unrepresentable is the fix; a
-   * default would just move the trap.
+   * Required with imported memory: carve bump chunks from the named host
+   * allocator so this module never grows or overwrites its owner's memory.
    */
   linkedHeap?: {
     /** Name of the extern-C import providing `malloc(size: i32) -> ptr: i32`. */
@@ -157,31 +136,15 @@ export interface LinearOptions {
     chunkBytes?: number;
   };
   /**
-   * Which allocator backs the heap (#4557).
-   *
-   * `"malloc-v1"` emits the real allocator — free lists, boundary tags,
-   * coalescing, in-place `realloc` — and exports `js2wasm_malloc` /
-   * `js2wasm_calloc` / `js2wasm_free` / `js2wasm_realloc` /
-   * `js2wasm_usable_size` so the QuickJS artifact can install them through
-   * `JS_NewRuntime2`. `__malloc` keeps its bump fast path; only the source of
-   * its chunks moves, from the engine's heap to ours.
-   *
-   * Defaults to `"bump"`, which is #4540's shipped fallback and the reason it
-   * was kept: if the measured comparison against the artifact's dlmalloc does
-   * not hold, this option is simply not set.
+   * Heap provider (#4557). `malloc-v1` exports the full allocator API while
+   * preserving `__malloc`'s bump fast path; the measured fallback is `bump`.
    */
   heapAllocator?: "bump" | "malloc-v1";
 }
 
 /**
- * Resolve {@link LinearOptions.linkedHeap} into the runtime's concrete form,
- * and make the catastrophic combination unrepresentable (#4540).
- *
- * `importMemory` without `linkedHeap` is the measured corruption: the arena
- * would start bump-allocating at 1024, inside the memory owner's shadow stack.
- * `linkedHeap` without `importMemory` is meaningless — we own the memory, so
- * there is no host allocator to defer to. Both are refused here, before any
- * bytes exist, rather than diagnosed later from a corrupted heap.
+ * Resolve the linked heap and reject either unsafe half-configuration before
+ * an imported-memory arena can overlap its owner's stack (#4540).
  */
 function resolveLinkedHeap(
   opts: LinearOptions,
@@ -216,25 +179,20 @@ function resolveLinkedHeap(
  * Generate a WasmModule using the linear-memory backend.
  * Compiles TS functions to standard Wasm with i32/f64 values.
  */
-export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): WasmModule {
+function generateLinearModuleBody(
+  ast: TypedAST,
+  opts: LinearOptions,
+  coveragePopulation?: linearIr.PreparedLinearIrCoveragePopulation,
+): WasmModule {
   const mod = createEmptyModule();
-  // #4539 — imports FIRST, before any runtime function exists. A function's
-  // index is `numImportFuncs + position`, so a later import would shift every
-  // index; `declareExternCImports` throws rather than allow that. With no
-  // imports requested this is a no-op and emitted output is unchanged.
+  // #4539 — imports precede every runtime/user function so indices cannot shift.
   if (opts.importMemory) {
     const { module, name, min, max, indexType } = opts.importMemory;
     declareImportedMemory(mod, module, name, min, max, indexType);
   }
   const externImportIndices = declareExternCImports(mod, opts.externImports ?? []);
-  // The index lives here rather than only in funcMap because an ambient
-  // `declare function` of the same name is later registered as a user
-  // function and would overwrite the funcMap entry — silently retargeting the
-  // call at a body-less local slot with a TS-derived (f64) signature. Keeping
-  // the extern binding in its own map makes it authoritative.
-  // Types are RESOLVED through the address model here (#4554) so every later
-  // consumer — the call site's boundary marshalling included — sees concrete
-  // Wasm types and never has to re-decide how wide a handle is.
+  // Keep extern indices outside funcMap so ambient declarations cannot shadow
+  // them; resolve address-model types once for all boundary consumers (#4554).
   const externImportSigs = new Map<string, { index: number; params: ValType[]; results: ValType[] }>();
   for (const spec of opts.externImports ?? []) {
     const index = externImportIndices.get(spec.name);
@@ -284,10 +242,7 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     init: [{ op: "i32.const", value: 0 }],
   });
 
-  // #4540 — linked mode rebases every literal reference through one global.
-  // It must exist BEFORE any function is compiled, because each literal site
-  // reads its index while being emitted. Not created in standalone mode, so
-  // that lane's global layout (and emitted bytes) is untouched.
+  // #4540 — create linked literal rebasing before sites capture its index.
   let roDataBiasGlobalIdx: number | undefined;
   if (linkedHeap !== undefined) {
     roDataBiasGlobalIdx = mod.globals.length;
@@ -304,8 +259,7 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     checker: ast.checker,
     oracle: createTypeOracle(ast.checker, opts.oracleBackend),
     funcMap: new Map(),
-    // #4539 — derived, not hard-coded. Zero when nothing is imported, so
-    // output is unchanged for every existing caller.
+    // #4539 — derived from imports; zero preserves legacy output.
     numImportFuncs: countImportedFuncs(mod),
     currentFunc: null,
     errors: [],
@@ -321,12 +275,16 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     ...(roDataBiasGlobalIdx !== undefined ? { roDataBiasGlobalIdx } : {}),
   };
   const preparedLinearIr = linearIr.linearIrEnabled()
-    ? linearIr.prepareLinearIrOverlay(ctx, ast.sourceFile, opts.irInventoryOptions, repeatReservation)
+    ? linearIr.prepareLinearIrOverlay(
+        ctx,
+        ast.sourceFile,
+        opts.irInventoryOptions,
+        repeatReservation,
+        coveragePopulation,
+      )
     : undefined;
 
-  // #4539 — extern imports are callable by name. They occupy indices [0, n),
-  // so registering them here lets the ordinary call path resolve them; the
-  // signature map drives boundary marshalling at each call site.
+  // #4539 — register extern names; their signature map drives marshalling.
   for (const spec of opts.externImports ?? []) {
     const idx = externImportIndices.get(spec.name);
     if (idx !== undefined) ctx.funcMap.set(spec.name, idx);
@@ -404,9 +362,7 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     compileClassDeclaration(ctx, classDecl);
   }
 
-  // ── #2956: IR overlay for selector-claimed top-level functions ──
-  // collection, but before top-level body insertion. Demotions retain the
-  // direct path and JS2WASM_LINEAR_IR=0 remains the escape hatch.
+  // #2956 — compile claimed bodies before direct insertion; demotions stay direct.
   const linearIrResult = preparedLinearIr
     ? linearIr.compileLinearIr(ctx, allocationPolicy, linearIrLegacySlots, preparedLinearIr)
     : undefined;
@@ -416,9 +372,7 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     const irArtifact = linearIrResult?.compiledArtifactFor(decl);
     if (irArtifact) {
       const { func: irFunc, legacySlot } = irArtifact;
-      // Insert the IR-lowered body at this decl's slot position (push order
-      // must match the forward-registered funcMap indices). Mirror
-      // compileFunction's export record.
+      // Preserve the forward-registered slot and mirror direct export records.
       ctx.mod.functions.push(irFunc);
       if (irFunc.exported) {
         ctx.mod.exports.push({
@@ -431,8 +385,7 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     compileFunction(ctx, decl);
   }
 
-  // Aggregate/ref-cell helpers follow every user slot, keeping funcMap stable
-  // while IR lowering discovers object shapes lazily.
+  // Deferred IR helpers follow user slots so funcMap remains stable.
   for (const helper of linearIrResult?.helpers ?? []) {
     const actualFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     if (actualFuncIdx !== helper.funcIdx) {
@@ -449,25 +402,39 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
 
   emitClosureTable(ctx);
 
-  // #4540 — LAST, so the start function's index is stable: every earlier
-  // finalizer may still append functions, and a start index computed before
-  // them would name someone else's body.
+  // #4540 — finalize linked data last so the start-function index is stable.
   if (roDataBiasGlobalIdx !== undefined) {
     finalizeLinkedDataImage(mod, roDataBiasGlobalIdx, dataSegmentBase);
   }
 
-  // Surface codegen diagnostics so compiler.ts fails the compile rather than
-  // emitting a structurally invalid binary for unsupported constructs (#1868).
+  // Surface unsupported codegen rather than emit invalid bytes (#1868).
   if (ctx.errors.length > 0) mod.codegenErrors = ctx.errors;
 
   return mod;
+}
+
+export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): WasmModule {
+  if (!linearCoverage.linearIrCoverageEnabled()) return generateLinearModuleBody(ast, opts);
+  return linearCoverage.runSingleSourceLinearIrCoverageGeneration(
+    () =>
+      linearIr.prepareLinearIrCoveragePopulation(
+        [ast.sourceFile],
+        ast.sourceFile,
+        ast.checker,
+        opts.irInventoryOptions,
+      ),
+    linearIr.resetLastLinearIrReport,
+    linearIr.getLastLinearIrReport,
+    linearIr.linearIrEnabled(),
+    (population) => generateLinearModuleBody(ast, opts, population),
+  );
 }
 
 /**
  * Generate a WasmModule from multiple TS source files using the linear-memory backend.
  * Cross-file imports are resolved by the TypeScript checker; we iterate all source files.
  */
-export function generateLinearMultiModule(multiAst: MultiTypedAST, opts: LinearOptions = {}): WasmModule {
+function generateLinearMultiModuleBody(multiAst: MultiTypedAST, opts: LinearOptions): WasmModule {
   const mod = createEmptyModule();
 
   addRuntime(mod, { exposeArenaReset: opts.exposeArenaReset });
@@ -621,11 +588,19 @@ export function generateLinearMultiModule(multiAst: MultiTypedAST, opts: LinearO
 
   emitClosureTable(ctx);
 
-  // Surface codegen diagnostics so compiler.ts fails the compile rather than
-  // emitting a structurally invalid binary for unsupported constructs (#1868).
+  // Surface unsupported codegen rather than emit invalid bytes (#1868).
   if (ctx.errors.length > 0) mod.codegenErrors = ctx.errors;
 
   return mod;
+}
+
+export function generateLinearMultiModule(multiAst: MultiTypedAST, opts: LinearOptions = {}): WasmModule {
+  if (!linearCoverage.linearIrCoverageEnabled()) return generateLinearMultiModuleBody(multiAst, opts);
+  return linearCoverage.runMultiSourceLinearIrCoverageGeneration(
+    () => linearIr.prepareLinearIrCoveragePopulation(multiAst.sourceFiles, multiAst.entryFile, multiAst.checker),
+    linearIr.resetLastLinearIrReport,
+    () => generateLinearMultiModuleBody(multiAst, opts),
+  );
 }
 
 /** Like compileFunction but only exports if isEntry is true or re-exported */

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -101,12 +101,7 @@ import {
   type IrType,
   type IrTypeRef,
 } from "../nodes.js";
-import {
-  buildIrUnitInventory,
-  type BuildIrUnitInventoryOptions,
-  type IrTerminalUnitRecord,
-  type IrUnitId,
-} from "../identity.js";
+import { buildIrUnitInventory, type BuildIrUnitInventoryOptions, type IrUnitId } from "../identity.js";
 import {
   buildIrPlanningIdentityContext,
   IrPlanningIdentityInvariantError,
@@ -136,6 +131,12 @@ import { prepareIrRuntimeManifest } from "../intrinsic-support.js";
 import type { TypeConverter } from "./contract.js";
 import { verifyIrBackendLegality } from "./legality.js";
 import { LinearEmitter } from "./linear-emitter.js";
+import * as linearCoverage from "./linear-ir-coverage.js";
+import type {
+  LinearIrSourceOwner,
+  LinearIrSourceOwnerIndex,
+  PreparedLinearIrCoveragePopulation,
+} from "./linear-ir-coverage.js";
 import type {
   IrRefCellLowering,
   IrVecLowering,
@@ -199,16 +200,6 @@ export interface LinearIrResult {
   readonly preparedCountedStringAppendReceipts: readonly PreparedCountedStringAppendReceipt[];
 }
 
-export interface LinearIrSourceOwner {
-  readonly ownerUnitId: IrUnitId;
-  readonly legacyName: string;
-  readonly declaration: ts.Node;
-}
-
-export interface LinearIrSourceOwnerIndex {
-  readonly owners: readonly LinearIrSourceOwner[];
-}
-
 /** Direct-backend registration before the ProgramAbiSession cutover. */
 export interface LinearIrLegacySlotInput {
   readonly declaration: ts.Node;
@@ -258,69 +249,26 @@ function requireUniqueLinearOwner(
   return owners[0]!;
 }
 
-function isLinearIrAttemptRoot(terminal: IrTerminalUnitRecord): boolean {
-  return !(
-    terminal.kind === "synthetic-support" &&
-    terminal.syntheticRole === "compiler-unit:timer-shim:set-timeout" &&
-    terminal.terminalOwnerId === terminal.id &&
-    terminal.lexicalOwnerId === null
-  );
-}
+export const indexLinearIrSourceOwners = linearCoverage.indexLinearIrSourceOwners;
+const isLinearIrAttemptRoot = linearCoverage.isLinearIrAttemptRoot;
 
-/**
- * Validate the complete structural population received by the linear source
- * seam. Every direction is checked against the same authoritative planning
- * context. Display-label collisions remain distinct here; only the explicit
- * legacy-slot adapter below is permitted to cross into concrete slot names.
- */
-export function indexLinearIrSourceOwners(
-  sourceFile: ts.SourceFile,
-  identityContext: IrPlanningIdentityContext,
-): LinearIrSourceOwnerIndex {
-  const sourceId = requireIrPlanningSourceId(identityContext, sourceFile);
-  if (identityContext.sourceFileBySourceId.get(sourceId) !== sourceFile) {
-    return linearOwnerInvariant(
-      "source-record-mismatch",
-      `linear IR source ${sourceId} does not resolve back to the exact planning SourceFile`,
-    );
-  }
-
-  const expected = identityContext.inventory.terminalUnits.filter(
-    (terminal) =>
-      terminal.sourceId === sourceId &&
-      (terminal.observedKind === "function" || terminal.observedKind === "class-member") &&
-      isLinearIrAttemptRoot(terminal),
-  );
-  const liveNodes = new Set<ts.Node>();
-  const visit = (node: ts.Node): void => {
-    liveNodes.add(node);
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-
-  const owners = expected.map((terminal): LinearIrSourceOwner => {
-    const declaration = identityContext.declarationByUnitId.get(terminal.id);
-    if (
-      identityContext.unitByUnitId.get(terminal.id) !== terminal ||
-      identityContext.terminalByUnitId.get(terminal.id) !== terminal ||
-      terminal.terminalOwnerId !== terminal.id ||
-      !declaration ||
-      !liveNodes.has(declaration) ||
-      declaration.getSourceFile() !== sourceFile ||
-      identityContext.unitIdByDeclaration.get(declaration) !== terminal.id
-    ) {
-      return linearOwnerInvariant(
-        "terminal-record-mismatch",
-        `linear IR source owner ${terminal.id} does not round-trip through the authoritative population`,
-      );
-    }
-    return Object.freeze({
-      ownerUnitId: terminal.id,
-      legacyName: terminal.legacyMatchName,
-      declaration,
-    });
+export function prepareLinearIrCoveragePopulation(
+  sourceFiles: readonly ts.SourceFile[],
+  entrySource: ts.SourceFile,
+  checker: ts.TypeChecker,
+  inventoryOptions: BuildIrUnitInventoryOptions = {},
+): PreparedLinearIrCoveragePopulation {
+  const inventory = buildIrUnitInventory(sourceFiles, {
+    ...inventoryOptions,
+    entrySource,
+    checker,
   });
-  return Object.freeze({ owners: Object.freeze(owners) });
+  return linearCoverage.prepareLinearIrCoveragePopulation(
+    sourceFiles,
+    entrySource,
+    checker,
+    buildIrPlanningIdentityContext(inventory),
+  );
 }
 
 /**
@@ -419,14 +367,20 @@ function planLinearIrOverlay(
   sourceFile: ts.SourceFile,
   inventoryOptions: BuildIrUnitInventoryOptions,
   oracle: TypeOracle,
+  coveragePopulation?: PreparedLinearIrCoveragePopulation,
 ) {
   const sourceFiles = [sourceFile];
-  const inventory = buildIrUnitInventory(sourceFiles, {
-    ...inventoryOptions,
-    entrySource: sourceFile,
-    checker: ctx.checker,
-  });
-  const identityContext = buildIrPlanningIdentityContext(inventory);
+  if (coveragePopulation) {
+    linearCoverage.authenticateLinearIrCoveragePopulation(coveragePopulation, sourceFiles, sourceFile, ctx.checker);
+  }
+  const inventory =
+    coveragePopulation?.identityContext.inventory ??
+    buildIrUnitInventory(sourceFiles, {
+      ...inventoryOptions,
+      entrySource: sourceFile,
+      checker: ctx.checker,
+    });
+  const identityContext = coveragePopulation?.identityContext ?? buildIrPlanningIdentityContext(inventory);
   const propagated = buildIrUnitTypeMap(sourceFiles, ctx.checker, identityContext);
   const recursiveTypeEvidence = buildIrRecursiveTypeEvidence(sourceFiles, ctx.checker, propagated, identityContext);
   const evidenceChecker = overlayCertifiedCheckerTypes(ctx.checker, recursiveTypeEvidence.checkerTypeOverrides);
@@ -536,6 +490,7 @@ export function prepareLinearIrOverlay(
   sourceFile: ts.SourceFile,
   inventoryOptions: BuildIrUnitInventoryOptions = {},
   directReservation?: LinearStringRepeatReservation,
+  coveragePopulation?: PreparedLinearIrCoveragePopulation,
 ): PreparedLinearIrOverlay {
   const oracle = ctx.oracle;
   if (!oracle) {
@@ -551,7 +506,7 @@ export function prepareLinearIrOverlay(
     oracle: TypeOracle;
     reservationReceipt?: LinearStringRepeatReservationReceipt;
   } = {
-    ...planLinearIrOverlay(ctx, sourceFile, inventoryOptions, oracle),
+    ...planLinearIrOverlay(ctx, sourceFile, inventoryOptions, oracle, coveragePopulation),
     context: ctx,
     sourceFile,
     oracle,
@@ -667,6 +622,23 @@ let lastReport: LinearIrResult | undefined;
 export function getLastLinearIrReport(): LinearIrResult | undefined {
   return lastReport;
 }
+
+export function resetLastLinearIrReport(): void {
+  if (linearCoverage.linearIrCoverageGenerationIsActive()) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "linear-ir: cannot reset the compatibility report during an active coverage generation",
+    );
+  }
+  lastReport = undefined;
+}
+
+export type {
+  LinearIrSourceOwner,
+  LinearIrSourceOwnerIndex,
+  PreparedLinearIrCoveragePopulation,
+} from "./linear-ir-coverage.js";
 
 function prepareLinearIntrinsicFunctions(functions: readonly IrFunction[], sourceFile: string): readonly IrFunction[] {
   return (

--- a/src/ir/backend/linear-ir-coverage.ts
+++ b/src/ir/backend/linear-ir-coverage.ts
@@ -1,0 +1,1320 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../../ts-api.js";
+import {
+  createIrSourceId,
+  type IrSourceId,
+  type IrSourceKind,
+  type IrTerminalObservedKind,
+  type IrTerminalUnitRecord,
+  type IrUnitId,
+  type IrUnitKind,
+} from "../identity.js";
+import { IrInvariantError } from "../outcomes.js";
+import {
+  IrPlanningIdentityInvariantError,
+  requireIrPlanningSourceId,
+  type IrPlanningIdentityContext,
+  type IrPlanningIdentityInvariantCode,
+} from "../planning-identity.js";
+
+export const LINEAR_IR_COVERAGE_SCHEMA = "linear-ir-coverage-census-v1" as const;
+
+export type LinearIrCoverageGenerationKind = "single-source" | "multi-source";
+export type LinearIrCoverageStatus = "complete" | "generation-failed";
+export type LinearIrCoverageNotAttemptedReason =
+  | "selector-omitted"
+  | "overlay-disabled"
+  | "generation-aborted"
+  | "multi-source-overlay-unimplemented";
+
+export interface LinearIrCoverageSourceV1 {
+  readonly sourceId: IrSourceId;
+  readonly sourceKey: string;
+  readonly kind: IrSourceKind;
+  readonly order: number;
+}
+
+export type LinearIrCoverageOutcomeV1 =
+  | { readonly kind: "compiled" }
+  | { readonly kind: "rejected"; readonly reason: string; readonly detail?: string }
+  | { readonly kind: "not-attempted"; readonly reason: LinearIrCoverageNotAttemptedReason };
+
+export interface LinearIrCoverageOwnerV1 {
+  readonly ownerUnitId: IrUnitId;
+  readonly sourceId: IrSourceId;
+  readonly sourceKey: string;
+  readonly legacyName: string;
+  readonly terminalKind: IrUnitKind;
+  readonly observedKind: Extract<IrTerminalObservedKind, "function" | "class-member">;
+  readonly outcome: LinearIrCoverageOutcomeV1;
+}
+
+export interface LinearIrCoverageCountsV1 {
+  readonly sources: number;
+  readonly owners: number;
+  readonly compiled: number;
+  readonly rejected: number;
+  readonly notAttempted: number;
+}
+
+export interface LinearIrCoverageFailureV1 {
+  readonly phase: string;
+  readonly code: string;
+  readonly detail: string;
+}
+
+export type LinearIrCoverageCensusV1 = Readonly<{
+  readonly schema: typeof LINEAR_IR_COVERAGE_SCHEMA;
+  readonly generationOrdinal: number;
+  readonly generationKind: LinearIrCoverageGenerationKind;
+  readonly entrySourceId: IrSourceId;
+  readonly entrySourceKey: string;
+  readonly status: LinearIrCoverageStatus;
+  readonly sources: readonly LinearIrCoverageSourceV1[];
+  readonly owners: readonly LinearIrCoverageOwnerV1[];
+  readonly counts: LinearIrCoverageCountsV1;
+  readonly failure?: LinearIrCoverageFailureV1;
+}>;
+
+/** Compiler-owned source identity retained only for one in-memory transaction. */
+export interface LinearIrCoverageSourceDescriptor extends LinearIrCoverageSourceV1 {
+  readonly sourceFile: object;
+  readonly originalFileName: string;
+}
+
+/** Compiler-owned owner identity retained only for one in-memory transaction. */
+export interface LinearIrCoverageOwnerDescriptor {
+  readonly ownerUnitId: IrUnitId;
+  readonly sourceId: IrSourceId;
+  readonly sourceKey: string;
+  readonly legacyName: string;
+  readonly terminalKind: IrUnitKind;
+  readonly observedKind: Extract<IrTerminalObservedKind, "function" | "class-member">;
+  readonly declaration: object;
+  readonly terminalRecord: object;
+}
+
+export interface LinearIrSourceOwner {
+  readonly ownerUnitId: IrUnitId;
+  readonly legacyName: string;
+  readonly declaration: ts.Node;
+}
+
+export interface LinearIrSourceOwnerIndex {
+  readonly owners: readonly LinearIrSourceOwner[];
+}
+
+export interface PreparedLinearIrCoveragePopulation {
+  readonly sourceFiles: readonly ts.SourceFile[];
+  readonly entrySource: ts.SourceFile;
+  readonly checker: ts.TypeChecker;
+  readonly identityContext: IrPlanningIdentityContext;
+  readonly sources: readonly LinearIrCoverageSourceDescriptor[];
+  readonly owners: readonly LinearIrCoverageOwnerDescriptor[];
+}
+
+export interface BeginLinearIrCoverageGenerationInput {
+  readonly populationToken: object;
+  readonly generationKind: LinearIrCoverageGenerationKind;
+  readonly entrySourceId: IrSourceId;
+  readonly entrySourceKey: string;
+  readonly sources: readonly LinearIrCoverageSourceDescriptor[];
+  readonly owners: readonly LinearIrCoverageOwnerDescriptor[];
+}
+
+export type LinearIrCoverageOwnerEvidence =
+  | {
+      readonly outcome: "compiled";
+      readonly ownerUnitId: IrUnitId;
+      readonly legacyName: string;
+    }
+  | {
+      readonly outcome: "rejected";
+      readonly ownerUnitId: IrUnitId;
+      readonly legacyName: string;
+      readonly rejection: { readonly func: string; readonly reason: string; readonly detail?: string };
+    };
+
+export interface FinalizeLinearIrCoverageGenerationInput {
+  readonly populationToken: object;
+  readonly status: LinearIrCoverageStatus;
+  readonly ownerEvidence: readonly LinearIrCoverageOwnerEvidence[];
+  readonly publicCompiled: readonly string[];
+  readonly publicRejected: readonly { readonly func: string; readonly reason: string; readonly detail?: string }[];
+  readonly unresolvedReason: LinearIrCoverageNotAttemptedReason;
+  readonly failure?: LinearIrCoverageFailureV1;
+}
+
+export interface LinearIrCoverageCompatibilityEvidence {
+  readonly ownerEvidence: readonly LinearIrCoverageOwnerEvidence[];
+  readonly compiled: readonly string[];
+  readonly rejected: readonly { readonly func: string; readonly reason: string; readonly detail?: string }[];
+}
+
+declare const linearIrCoverageTransactionBrand: unique symbol;
+export interface LinearIrCoverageGenerationTransaction {
+  readonly [linearIrCoverageTransactionBrand]: true;
+}
+
+interface TransactionPayload {
+  readonly populationToken: object;
+  readonly ordinal: number;
+  readonly generationKind: LinearIrCoverageGenerationKind;
+  readonly entrySourceId: IrSourceId;
+  readonly entrySourceKey: string;
+  readonly sources: readonly LinearIrCoverageSourceDescriptor[];
+  readonly owners: readonly LinearIrCoverageOwnerDescriptor[];
+  state: "fresh" | "finalized";
+}
+
+const transactions = new WeakMap<object, TransactionPayload>();
+let activeTransaction: object | undefined;
+let generationOrdinal = 0;
+let lastCensus: LinearIrCoverageCensusV1 | undefined;
+
+const SOURCE_KINDS = new Set<IrSourceKind>(["entry", "source", "library", "synthetic"]);
+const OBSERVED_KINDS = new Set<IrTerminalObservedKind>(["function", "class-member"]);
+const FUNCTION_TERMINAL_KINDS = new Set<IrUnitKind>(["top-level-function", "synthetic-support"]);
+const CLASS_MEMBER_TERMINAL_KINDS = new Set<IrUnitKind>([
+  "class-constructor",
+  "class-implicit-constructor",
+  "class-instance-method",
+  "class-static-method",
+  "class-instance-getter",
+  "class-static-getter",
+  "class-instance-setter",
+  "class-static-setter",
+]);
+const UNIT_KINDS = new Set<IrUnitKind>([
+  "top-level-function",
+  "nested-function",
+  "function-expression",
+  "arrow-function",
+  "class-constructor",
+  "class-implicit-constructor",
+  "class-instance-method",
+  "class-static-method",
+  "class-instance-getter",
+  "class-static-getter",
+  "class-instance-setter",
+  "class-static-setter",
+  "class-instance-field-initializer",
+  "class-static-field-initializer",
+  "class-static-block",
+  "object-method",
+  "object-getter",
+  "object-setter",
+  "export-assignment",
+  "module-init",
+  "synthetic-support",
+]);
+const NOT_ATTEMPTED_REASONS = new Set<LinearIrCoverageNotAttemptedReason>([
+  "selector-omitted",
+  "overlay-disabled",
+  "generation-aborted",
+  "multi-source-overlay-unimplemented",
+]);
+// biome-ignore lint/suspicious/noControlCharactersInRegex: schema validation rejects non-layout C0 controls.
+const NON_LAYOUT_CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: failure sanitization replaces every non-layout C0 control.
+const NON_LAYOUT_CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g;
+
+export function compareLinearIrCoverageText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function coverageInvariant(detail: string): never {
+  throw new IrInvariantError("selection-preparation-mismatch", "resolve", `linear-ir coverage: ${detail}`);
+}
+
+function ownerInvariant(code: IrPlanningIdentityInvariantCode, detail: string): never {
+  throw new IrPlanningIdentityInvariantError(code, detail);
+}
+
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function exactKeys(record: Record<string, unknown>, expected: readonly string[], label: string): void {
+  const actual = Object.keys(record).sort(compareLinearIrCoverageText);
+  const canonicalExpected = [...expected].sort(compareLinearIrCoverageText);
+  if (actual.length !== canonicalExpected.length || actual.some((key, index) => key !== canonicalExpected[index])) {
+    coverageInvariant(`${label} fields are not exact`);
+  }
+}
+
+function nonEmptyString(value: unknown, label: string, max = 1_024): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > max ||
+    NON_LAYOUT_CONTROL_CHARACTER.test(value)
+  ) {
+    return coverageInvariant(`${label} must be a bounded non-empty string`);
+  }
+  return value;
+}
+
+function safeCount(value: unknown, label: string, minimum = 0): number {
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    return coverageInvariant(`${label} must be a finite non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function sourceId(value: unknown, label: string): IrSourceId {
+  const id = nonEmptyString(value, label);
+  if (!id.startsWith("ir-source:v1:")) return coverageInvariant(`${label} is not a canonical source ID`);
+  return id as IrSourceId;
+}
+
+function ownerUnitId(value: unknown, label: string, source: IrSourceId, terminalKind: IrUnitKind): IrUnitId {
+  const id = nonEmptyString(value, label);
+  const directTail = id.startsWith(`ir-unit:v1:${encodeURIComponent(source)}:`)
+    ? id.slice(`ir-unit:v1:${encodeURIComponent(source)}:`.length)
+    : undefined;
+  const directParts = directTail?.split(":");
+  const direct =
+    directParts?.length === 3 &&
+    directParts[0]!.length > 0 &&
+    directParts[1] === terminalKind &&
+    /^\d{16}$/.test(directParts[2]!);
+  const derived = /^ir-unit:v1:derived:[^:]+:[^:]+:\d{16}$/.test(id);
+  if (!direct && !derived) return coverageInvariant(`${label} is not a canonical source or derived unit ID`);
+  return id as IrUnitId;
+}
+
+function canonicalSourceKey(value: unknown, label: string): string {
+  const key = nonEmptyString(value, label);
+  const segments = key.split("/");
+  if (
+    /^(?:[A-Za-z]:[\\/]|[\\/]|file:)/.test(key) ||
+    key.includes("\\") ||
+    segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")
+  ) {
+    return coverageInvariant(`${label} is not a canonical program-relative source key`);
+  }
+  return key;
+}
+
+function terminalKind(value: unknown, observedKind: IrTerminalObservedKind, label: string): IrUnitKind {
+  const kind = nonEmptyString(value, label) as IrUnitKind;
+  if (!UNIT_KINDS.has(kind)) return coverageInvariant(`${label} is unknown`);
+  const allowed = observedKind === "function" ? FUNCTION_TERMINAL_KINDS : CLASS_MEMBER_TERMINAL_KINDS;
+  if (!allowed.has(kind)) return coverageInvariant(`${label} does not match the observed owner kind`);
+  return kind;
+}
+
+function exactSourceIdentity(input: {
+  readonly id: unknown;
+  readonly key: unknown;
+  readonly kind: unknown;
+  readonly order: unknown;
+  readonly label: string;
+}): { readonly sourceId: IrSourceId; readonly sourceKey: string; readonly kind: IrSourceKind; readonly order: number } {
+  const kind = nonEmptyString(input.kind, `${input.label}.kind`) as IrSourceKind;
+  if (!SOURCE_KINDS.has(kind)) return coverageInvariant(`${input.label}.kind is unknown`);
+  const sourceKey = canonicalSourceKey(input.key, `${input.label}.sourceKey`);
+  const order = safeCount(input.order, `${input.label}.order`);
+  const id = sourceId(input.id, `${input.label}.sourceId`);
+  if (id !== createIrSourceId({ kind, order, sourceKey })) {
+    return coverageInvariant(`${input.label}.sourceId does not match its canonical kind/order/key`);
+  }
+  return { sourceId: id, sourceKey, kind, order };
+}
+
+function stableDetail(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  const detail = String(value)
+    .replace(/\r\n?/g, "\n")
+    .replace(/(?:file:\/\/)?(?:[A-Za-z]:[\\/]|\/)(?:[^\s:;,)}\]]+[\\/]?)+/g, "<path>")
+    .replace(NON_LAYOUT_CONTROL_CHARACTERS, " ")
+    .slice(0, 512);
+  return detail.length > 0 ? detail : undefined;
+}
+
+function freezeSource(source: LinearIrCoverageSourceDescriptor): LinearIrCoverageSourceDescriptor {
+  return Object.freeze({ ...source });
+}
+
+function freezeOwner(owner: LinearIrCoverageOwnerDescriptor): LinearIrCoverageOwnerDescriptor {
+  return Object.freeze({ ...owner });
+}
+
+function validateSourceDescriptor(
+  value: LinearIrCoverageSourceDescriptor,
+  label: string,
+): LinearIrCoverageSourceDescriptor {
+  if (!plainRecord(value)) return coverageInvariant(`${label} must be a plain record`);
+  exactKeys(value, ["sourceFile", "sourceId", "sourceKey", "kind", "order", "originalFileName"], label);
+  if (value.sourceFile === null || typeof value.sourceFile !== "object") {
+    return coverageInvariant(`${label}.sourceFile must retain an exact compiler object`);
+  }
+  const identity = exactSourceIdentity({
+    id: value.sourceId,
+    key: value.sourceKey,
+    kind: value.kind,
+    order: value.order,
+    label,
+  });
+  const originalFileName = nonEmptyString(value.originalFileName, `${label}.originalFileName`, 4_096);
+  if (
+    !ts.isSourceFile(value.sourceFile as ts.Node) ||
+    (value.sourceFile as ts.SourceFile).fileName !== originalFileName
+  ) {
+    return coverageInvariant(`${label}.sourceFile does not join its exact caller-supplied logical filename`);
+  }
+  return freezeSource({
+    sourceFile: value.sourceFile,
+    ...identity,
+    originalFileName,
+  });
+}
+
+function validateOwnerDescriptor(
+  value: LinearIrCoverageOwnerDescriptor,
+  label: string,
+): LinearIrCoverageOwnerDescriptor {
+  if (!plainRecord(value)) return coverageInvariant(`${label} must be a plain record`);
+  exactKeys(
+    value,
+    [
+      "ownerUnitId",
+      "sourceId",
+      "sourceKey",
+      "legacyName",
+      "terminalKind",
+      "observedKind",
+      "declaration",
+      "terminalRecord",
+    ],
+    label,
+  );
+  if (value.declaration === null || typeof value.declaration !== "object") {
+    return coverageInvariant(`${label}.declaration must retain an exact compiler object`);
+  }
+  if (value.terminalRecord === null || typeof value.terminalRecord !== "object") {
+    return coverageInvariant(`${label}.terminalRecord must retain an exact inventory object`);
+  }
+  const observedKind = nonEmptyString(value.observedKind, `${label}.observedKind`) as IrTerminalObservedKind;
+  if (!OBSERVED_KINDS.has(observedKind)) return coverageInvariant(`${label}.observedKind is not attemptable`);
+  const source = sourceId(value.sourceId, `${label}.sourceId`);
+  const kind = terminalKind(value.terminalKind, observedKind, `${label}.terminalKind`);
+  return freezeOwner({
+    ownerUnitId: ownerUnitId(value.ownerUnitId, `${label}.ownerUnitId`, source, kind),
+    sourceId: source,
+    sourceKey: canonicalSourceKey(value.sourceKey, `${label}.sourceKey`),
+    legacyName: nonEmptyString(value.legacyName, `${label}.legacyName`),
+    terminalKind: kind,
+    observedKind: observedKind as Extract<IrTerminalObservedKind, "function" | "class-member">,
+    declaration: value.declaration,
+    terminalRecord: value.terminalRecord,
+  });
+}
+
+const preparedPopulations = new WeakSet<PreparedLinearIrCoveragePopulation>();
+
+export function isLinearIrAttemptRoot(terminal: IrTerminalUnitRecord): boolean {
+  return !(
+    terminal.kind === "synthetic-support" &&
+    terminal.syntheticRole === "compiler-unit:timer-shim:set-timeout" &&
+    terminal.terminalOwnerId === terminal.id &&
+    terminal.lexicalOwnerId === null
+  );
+}
+
+/** Authenticate the complete structural attempt-root population for one source. */
+export function indexLinearIrSourceOwners(
+  sourceFile: ts.SourceFile,
+  identityContext: IrPlanningIdentityContext,
+): LinearIrSourceOwnerIndex {
+  const id = requireIrPlanningSourceId(identityContext, sourceFile);
+  if (identityContext.sourceFileBySourceId.get(id) !== sourceFile) {
+    return ownerInvariant("source-record-mismatch", `linear IR source ${id} does not resolve to its SourceFile`);
+  }
+  const expected = identityContext.inventory.terminalUnits.filter(
+    (terminal) =>
+      terminal.sourceId === id &&
+      (terminal.observedKind === "function" || terminal.observedKind === "class-member") &&
+      isLinearIrAttemptRoot(terminal),
+  );
+  const liveNodes = new Set<ts.Node>();
+  const visit = (node: ts.Node): void => {
+    liveNodes.add(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  const owners = expected.map((terminal): LinearIrSourceOwner => {
+    const declaration = identityContext.declarationByUnitId.get(terminal.id);
+    if (
+      identityContext.unitByUnitId.get(terminal.id) !== terminal ||
+      identityContext.terminalByUnitId.get(terminal.id) !== terminal ||
+      terminal.terminalOwnerId !== terminal.id ||
+      !declaration ||
+      !liveNodes.has(declaration) ||
+      declaration.getSourceFile() !== sourceFile ||
+      identityContext.unitIdByDeclaration.get(declaration) !== terminal.id
+    ) {
+      return ownerInvariant(
+        "terminal-record-mismatch",
+        `linear IR source owner ${terminal.id} does not round-trip through the authoritative population`,
+      );
+    }
+    return Object.freeze({ ownerUnitId: terminal.id, legacyName: terminal.legacyMatchName, declaration });
+  });
+  return Object.freeze({ owners: Object.freeze(owners) });
+}
+
+/** Project the already-authenticated linear owner seam into one coverage population. */
+export function prepareLinearIrCoveragePopulation(
+  sourceFiles: readonly ts.SourceFile[],
+  entrySource: ts.SourceFile,
+  checker: ts.TypeChecker,
+  identityContext: IrPlanningIdentityContext,
+): PreparedLinearIrCoveragePopulation {
+  const inventory = identityContext.inventory;
+  if (
+    sourceFiles.length === 0 ||
+    inventory.sources.length !== sourceFiles.length ||
+    !sourceFiles.includes(entrySource) ||
+    new Set(sourceFiles).size !== sourceFiles.length ||
+    identityContext.sourceIdBySourceFile.size !== sourceFiles.length ||
+    identityContext.sourceFileBySourceId.size !== sourceFiles.length
+  ) {
+    return coverageInvariant("coverage source population is empty, duplicate, or incomplete");
+  }
+  const requestedFiles = new Set(sourceFiles);
+  const sourceById = new Map(inventory.sources.map((source) => [source.id, source] as const));
+  const fileById = new Map<IrSourceId, ts.SourceFile>();
+  for (const sourceFile of sourceFiles) {
+    const id = requireIrPlanningSourceId(identityContext, sourceFile);
+    const record = sourceById.get(id);
+    if (
+      !record ||
+      record.originalFileName !== sourceFile.fileName ||
+      identityContext.sourceFileBySourceId.get(id) !== sourceFile ||
+      identityContext.sourceIdBySourceFile.get(sourceFile) !== id ||
+      fileById.has(id)
+    ) {
+      return coverageInvariant(`source ${sourceFile.fileName} does not round-trip through its inventory`);
+    }
+    fileById.set(id, sourceFile);
+  }
+  const sources = inventory.sources.map((source): LinearIrCoverageSourceDescriptor => {
+    const sourceFile = fileById.get(source.id);
+    if (!sourceFile || !requestedFiles.has(sourceFile)) {
+      return coverageInvariant(`inventory source ${source.id} has no exact requested SourceFile`);
+    }
+    return Object.freeze({
+      sourceFile,
+      sourceId: source.id,
+      sourceKey: source.sourceKey,
+      kind: source.kind,
+      order: source.order,
+      originalFileName: source.originalFileName,
+    });
+  });
+  const entryId = requireIrPlanningSourceId(identityContext, entrySource);
+  if (sourceById.get(entryId)?.kind !== "entry") {
+    return coverageInvariant("coverage entry is not the exact inventory entry row");
+  }
+
+  const owners: LinearIrCoverageOwnerDescriptor[] = [];
+  const ownerIds = new Set<IrUnitId>();
+  const declarations = new Set<ts.Node>();
+  for (const sourceFile of sourceFiles) {
+    const id = requireIrPlanningSourceId(identityContext, sourceFile);
+    const source = sourceById.get(id)!;
+    for (const owner of indexLinearIrSourceOwners(sourceFile, identityContext).owners) {
+      const terminal = identityContext.terminalByUnitId.get(owner.ownerUnitId);
+      const terminalRows = inventory.terminalUnits.filter((row) => row.id === owner.ownerUnitId);
+      const unitRows = inventory.allUnits.filter((row) => row.id === owner.ownerUnitId);
+      if (
+        !terminal ||
+        terminalRows.length !== 1 ||
+        terminalRows[0] !== terminal ||
+        unitRows.length !== 1 ||
+        unitRows[0] !== terminal ||
+        identityContext.unitByUnitId.get(owner.ownerUnitId) !== terminal ||
+        terminal.sourceId !== id ||
+        terminal.terminalOwnerId !== owner.ownerUnitId ||
+        terminal.legacyMatchName !== owner.legacyName ||
+        (terminal.observedKind !== "function" && terminal.observedKind !== "class-member") ||
+        identityContext.declarationByUnitId.get(owner.ownerUnitId) !== owner.declaration ||
+        identityContext.unitIdByDeclaration.get(owner.declaration) !== owner.ownerUnitId ||
+        owner.declaration.getSourceFile() !== sourceFile ||
+        ownerIds.has(owner.ownerUnitId) ||
+        declarations.has(owner.declaration)
+      ) {
+        return coverageInvariant(`owner ${owner.ownerUnitId} lost its source/terminal/declaration join`);
+      }
+      ownerIds.add(owner.ownerUnitId);
+      declarations.add(owner.declaration);
+      owners.push(
+        Object.freeze({
+          ownerUnitId: owner.ownerUnitId,
+          sourceId: id,
+          sourceKey: source.sourceKey,
+          legacyName: owner.legacyName,
+          terminalKind: terminal.kind,
+          observedKind: terminal.observedKind,
+          declaration: owner.declaration,
+          terminalRecord: terminal as IrTerminalUnitRecord,
+        }),
+      );
+    }
+  }
+  const population = Object.freeze({
+    sourceFiles: Object.freeze([...sourceFiles]),
+    entrySource,
+    checker,
+    identityContext,
+    sources: Object.freeze(sources),
+    owners: Object.freeze(owners),
+  });
+  preparedPopulations.add(population);
+  return population;
+}
+
+export function authenticateLinearIrCoveragePopulation(
+  population: PreparedLinearIrCoveragePopulation,
+  sourceFiles: readonly ts.SourceFile[],
+  entrySource: ts.SourceFile,
+  checker: ts.TypeChecker,
+): void {
+  if (
+    !preparedPopulations.has(population) ||
+    population.entrySource !== entrySource ||
+    population.checker !== checker ||
+    population.sourceFiles.length !== sourceFiles.length ||
+    population.sourceFiles.some((sourceFile, index) => sourceFile !== sourceFiles[index])
+  ) {
+    coverageInvariant("coverage population is foreign, stale, or belongs to another source/checker generation");
+  }
+}
+
+/** Exact default-off browser-safe coverage predicate. */
+export function linearIrCoverageEnabled(host: unknown = globalThis): boolean {
+  if (host === null || (typeof host !== "object" && typeof host !== "function")) return false;
+  const processLike = (host as { process?: unknown }).process;
+  if (processLike === null || (typeof processLike !== "object" && typeof processLike !== "function")) return false;
+  const env = (processLike as { env?: unknown }).env;
+  if (env === null || typeof env !== "object") return false;
+  return (env as { JS2WASM_LINEAR_IR_COVERAGE?: unknown }).JS2WASM_LINEAR_IR_COVERAGE === "1";
+}
+
+/** Clear the finalized census without rewinding the process-global ordinal. */
+export function resetLastLinearIrCoverageCensus(): number {
+  if (activeTransaction !== undefined) return coverageInvariant("cannot reset a live generation transaction");
+  lastCensus = undefined;
+  return generationOrdinal;
+}
+
+export function getLastLinearIrCoverageCensus(): LinearIrCoverageCensusV1 | undefined {
+  return lastCensus;
+}
+
+export function linearIrCoverageGenerationIsActive(): boolean {
+  return activeTransaction !== undefined;
+}
+
+export function beginLinearIrCoverageGeneration(
+  input: BeginLinearIrCoverageGenerationInput,
+): LinearIrCoverageGenerationTransaction {
+  if (activeTransaction !== undefined) return coverageInvariant("overlapping generations are not supported");
+  if (!plainRecord(input) || input.populationToken === null || typeof input.populationToken !== "object") {
+    return coverageInvariant("generation input or population token is not authenticatable");
+  }
+  exactKeys(
+    input,
+    ["populationToken", "generationKind", "entrySourceId", "entrySourceKey", "sources", "owners"],
+    "generation input",
+  );
+  if (input.generationKind !== "single-source" && input.generationKind !== "multi-source") {
+    return coverageInvariant("generation kind is unknown");
+  }
+  if (!Array.isArray(input.sources) || input.sources.length === 0 || !Array.isArray(input.owners)) {
+    return coverageInvariant("generation population is malformed or empty at the source boundary");
+  }
+  const sources = input.sources.map((source, index) => validateSourceDescriptor(source, `sources[${index}]`));
+  sources.sort((left, right) => compareLinearIrCoverageText(left.sourceKey, right.sourceKey));
+  const sourceIds = new Set<IrSourceId>();
+  const sourceKeys = new Set<string>();
+  const sourceFiles = new Set<object>();
+  const sourceOrders = new Set<number>();
+  for (const source of sources) {
+    if (
+      sourceIds.has(source.sourceId) ||
+      sourceKeys.has(source.sourceKey) ||
+      sourceFiles.has(source.sourceFile) ||
+      sourceOrders.has(source.order)
+    ) {
+      return coverageInvariant("generation sources contain a duplicate ID, key, file, or order");
+    }
+    sourceIds.add(source.sourceId);
+    sourceKeys.add(source.sourceKey);
+    sourceFiles.add(source.sourceFile);
+    sourceOrders.add(source.order);
+  }
+  if ([...sourceOrders].sort((left, right) => left - right).some((order, index) => order !== index)) {
+    return coverageInvariant("generation source orders are not a complete zero-based population");
+  }
+  const entrySourceId = sourceId(input.entrySourceId, "entrySourceId");
+  const entrySourceKey = canonicalSourceKey(input.entrySourceKey, "entrySourceKey");
+  const entryRows = sources.filter(
+    (source) => source.sourceId === entrySourceId && source.sourceKey === entrySourceKey && source.kind === "entry",
+  );
+  if (entryRows.length !== 1 || sources.filter((source) => source.kind === "entry").length !== 1) {
+    return coverageInvariant("generation entry does not join one exact source row");
+  }
+  if (input.generationKind === "single-source" && sources.length !== 1) {
+    return coverageInvariant("single-source generation retained more than one source");
+  }
+  const owners = input.owners.map((owner, index) => validateOwnerDescriptor(owner, `owners[${index}]`));
+  owners.sort((left, right) => compareLinearIrCoverageText(left.ownerUnitId, right.ownerUnitId));
+  const ownerIds = new Set<IrUnitId>();
+  const declarations = new Set<object>();
+  const terminalRecords = new Set<object>();
+  const sourceById = new Map(sources.map((source) => [source.sourceId, source] as const));
+  for (const owner of owners) {
+    const source = sourceById.get(owner.sourceId);
+    if (!source || source.sourceKey !== owner.sourceKey) {
+      return coverageInvariant(`owner ${owner.ownerUnitId} does not join its exact source ID/key`);
+    }
+    const declaration = owner.declaration as ts.Node;
+    const terminal = owner.terminalRecord as Partial<IrTerminalUnitRecord>;
+    if (
+      typeof declaration.getSourceFile !== "function" ||
+      declaration.getSourceFile() !== source.sourceFile ||
+      terminal.id !== owner.ownerUnitId ||
+      terminal.sourceId !== owner.sourceId ||
+      terminal.kind !== owner.terminalKind ||
+      terminal.observedKind !== owner.observedKind ||
+      terminal.terminal !== true ||
+      terminal.terminalOwnerId !== owner.ownerUnitId ||
+      terminal.legacyMatchName !== owner.legacyName
+    ) {
+      return coverageInvariant(`owner ${owner.ownerUnitId} lost its exact source/declaration/terminal record`);
+    }
+    if (
+      ownerIds.has(owner.ownerUnitId) ||
+      declarations.has(owner.declaration) ||
+      terminalRecords.has(owner.terminalRecord)
+    ) {
+      return coverageInvariant("generation owners contain a duplicate UnitId, declaration, or terminal record");
+    }
+    ownerIds.add(owner.ownerUnitId);
+    declarations.add(owner.declaration);
+    terminalRecords.add(owner.terminalRecord);
+  }
+  const prepared = input.populationToken as PreparedLinearIrCoveragePopulation;
+  const exactSources = new Set(prepared.sources);
+  const exactOwners = new Set(prepared.owners);
+  if (
+    !preparedPopulations.has(prepared) ||
+    input.sources.length !== prepared.sources.length ||
+    input.owners.length !== prepared.owners.length ||
+    input.sources.some((source) => !exactSources.has(source)) ||
+    input.owners.some((owner) => !exactOwners.has(owner))
+  ) {
+    return coverageInvariant("generation population token or descriptors are not an exact prepared population");
+  }
+  if (generationOrdinal >= Number.MAX_SAFE_INTEGER) return coverageInvariant("generation ordinal exhausted");
+  lastCensus = undefined;
+  const ordinal = ++generationOrdinal;
+  const transaction = Object.freeze({}) as LinearIrCoverageGenerationTransaction;
+  transactions.set(transaction, {
+    populationToken: input.populationToken,
+    ordinal,
+    generationKind: input.generationKind,
+    entrySourceId,
+    entrySourceKey,
+    sources: Object.freeze(sources),
+    owners: Object.freeze(owners),
+    state: "fresh",
+  });
+  activeTransaction = transaction;
+  return transaction;
+}
+
+export function beginPreparedLinearIrCoverageGeneration(
+  population: PreparedLinearIrCoveragePopulation,
+  generationKind: LinearIrCoverageGenerationKind,
+): LinearIrCoverageGenerationTransaction {
+  authenticateLinearIrCoveragePopulation(
+    population,
+    population.sourceFiles,
+    population.entrySource,
+    population.checker,
+  );
+  const entryId = requireIrPlanningSourceId(population.identityContext, population.entrySource);
+  const entry = population.sources.find((source) => source.sourceId === entryId);
+  if (!entry || entry.kind !== "entry") return coverageInvariant("prepared population lost its exact entry source");
+  return beginLinearIrCoverageGeneration({
+    populationToken: population,
+    generationKind,
+    entrySourceId: entry.sourceId,
+    entrySourceKey: entry.sourceKey,
+    sources: population.sources,
+    owners: population.owners,
+  });
+}
+
+function evidenceKey(value: { readonly func: string; readonly reason: string; readonly detail?: string }): string {
+  return `${value.func}\u0000${value.reason}\u0000${value.detail ?? ""}`;
+}
+
+function sameStringMultiset(left: readonly string[], right: readonly string[]): boolean {
+  const a = [...left].sort(compareLinearIrCoverageText);
+  const b = [...right].sort(compareLinearIrCoverageText);
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function freezeOutcome(outcome: LinearIrCoverageOutcomeV1): LinearIrCoverageOutcomeV1 {
+  return Object.freeze({ ...outcome });
+}
+
+function freezeCensus(input: {
+  readonly payload: TransactionPayload;
+  readonly status: LinearIrCoverageStatus;
+  readonly outcomes: ReadonlyMap<IrUnitId, LinearIrCoverageOutcomeV1>;
+  readonly unresolvedReason: LinearIrCoverageNotAttemptedReason;
+  readonly failure?: LinearIrCoverageFailureV1;
+}): LinearIrCoverageCensusV1 {
+  const { payload } = input;
+  const sources = Object.freeze(
+    payload.sources.map((source) =>
+      Object.freeze({
+        sourceId: source.sourceId,
+        sourceKey: source.sourceKey,
+        kind: source.kind,
+        order: source.order,
+      }),
+    ),
+  );
+  const owners = Object.freeze(
+    payload.owners.map((owner) =>
+      Object.freeze({
+        ownerUnitId: owner.ownerUnitId,
+        sourceId: owner.sourceId,
+        sourceKey: owner.sourceKey,
+        legacyName: owner.legacyName,
+        terminalKind: owner.terminalKind,
+        observedKind: owner.observedKind,
+        outcome: freezeOutcome(
+          input.outcomes.get(owner.ownerUnitId) ?? {
+            kind: "not-attempted",
+            reason: input.unresolvedReason,
+          },
+        ),
+      }),
+    ),
+  );
+  let compiled = 0;
+  let rejected = 0;
+  let notAttempted = 0;
+  for (const owner of owners) {
+    if (owner.outcome.kind === "compiled") compiled++;
+    else if (owner.outcome.kind === "rejected") rejected++;
+    else notAttempted++;
+  }
+  const counts = Object.freeze({
+    sources: sources.length,
+    owners: owners.length,
+    compiled,
+    rejected,
+    notAttempted,
+  });
+  return Object.freeze({
+    schema: LINEAR_IR_COVERAGE_SCHEMA,
+    generationOrdinal: payload.ordinal,
+    generationKind: payload.generationKind,
+    entrySourceId: payload.entrySourceId,
+    entrySourceKey: payload.entrySourceKey,
+    status: input.status,
+    sources,
+    owners,
+    counts,
+    ...(input.failure ? { failure: Object.freeze({ ...input.failure }) } : {}),
+  });
+}
+
+export function finalizeLinearIrCoverageGeneration(
+  transaction: LinearIrCoverageGenerationTransaction,
+  input: FinalizeLinearIrCoverageGenerationInput,
+): LinearIrCoverageCensusV1 {
+  const payload = transactions.get(transaction);
+  if (
+    !payload ||
+    payload.state !== "fresh" ||
+    activeTransaction !== transaction ||
+    !plainRecord(input) ||
+    input.populationToken !== payload.populationToken
+  ) {
+    return coverageInvariant("generation transaction is foreign, stale, reused, or cross-population");
+  }
+  payload.state = "finalized";
+  activeTransaction = undefined;
+  const expectedKeys = [
+    "populationToken",
+    "status",
+    "ownerEvidence",
+    "publicCompiled",
+    "publicRejected",
+    "unresolvedReason",
+    ...(input.failure === undefined ? [] : ["failure"]),
+  ];
+  exactKeys(input, expectedKeys, "finalization input");
+  if (input.status !== "complete" && input.status !== "generation-failed") {
+    return coverageInvariant("finalization status is unknown");
+  }
+  if (!NOT_ATTEMPTED_REASONS.has(input.unresolvedReason)) {
+    return coverageInvariant("finalization unresolved reason is unknown");
+  }
+  const failure = input.failure === undefined ? undefined : validateLinearIrCoverageFailure(input.failure);
+  if ((input.status === "generation-failed") !== (failure !== undefined)) {
+    return coverageInvariant("generation failure status and failure evidence disagree");
+  }
+  if (
+    !Array.isArray(input.ownerEvidence) ||
+    !Array.isArray(input.publicCompiled) ||
+    !Array.isArray(input.publicRejected)
+  ) {
+    return coverageInvariant("finalization evidence arrays are malformed");
+  }
+  const ownerById = new Map(payload.owners.map((owner) => [owner.ownerUnitId, owner] as const));
+  const outcomes = new Map<IrUnitId, LinearIrCoverageOutcomeV1>();
+  const compiledNames: string[] = [];
+  const rejectedRows: string[] = [];
+  for (const [index, evidence] of input.ownerEvidence.entries()) {
+    if (!plainRecord(evidence)) return coverageInvariant(`ownerEvidence[${index}] must be a plain record`);
+    const rawOwnerId = nonEmptyString(evidence.ownerUnitId, `ownerEvidence[${index}].ownerUnitId`) as IrUnitId;
+    const ownerCandidate = ownerById.get(rawOwnerId);
+    const ownerId = ownerCandidate
+      ? ownerUnitId(
+          rawOwnerId,
+          `ownerEvidence[${index}].ownerUnitId`,
+          ownerCandidate.sourceId,
+          ownerCandidate.terminalKind,
+        )
+      : rawOwnerId;
+    const owner = ownerById.get(ownerId);
+    if (!owner || outcomes.has(ownerId) || evidence.legacyName !== owner.legacyName) {
+      return coverageInvariant(`owner evidence ${ownerId} is unknown, duplicate, or label-drifted`);
+    }
+    if (evidence.outcome === "compiled") {
+      exactKeys(evidence, ["outcome", "ownerUnitId", "legacyName"], `ownerEvidence[${index}]`);
+      compiledNames.push(owner.legacyName);
+      outcomes.set(ownerId, { kind: "compiled" });
+      continue;
+    }
+    if (evidence.outcome !== "rejected" || !plainRecord(evidence.rejection)) {
+      return coverageInvariant(`ownerEvidence[${index}] has an unknown outcome`);
+    }
+    exactKeys(evidence, ["outcome", "ownerUnitId", "legacyName", "rejection"], `ownerEvidence[${index}]`);
+    const rawRejection = evidence.rejection;
+    const rejectionHasDetail = Object.prototype.hasOwnProperty.call(rawRejection, "detail");
+    exactKeys(
+      rawRejection,
+      ["func", "reason", ...(rejectionHasDetail ? ["detail"] : [])],
+      `ownerEvidence[${index}].rejection`,
+    );
+    const func = nonEmptyString(rawRejection.func, `ownerEvidence[${index}].rejection.func`);
+    const reason = nonEmptyString(rawRejection.reason, `ownerEvidence[${index}].rejection.reason`, 256);
+    if (func !== owner.legacyName) return coverageInvariant(`rejection ${ownerId} lost its exact legacy label`);
+    if (rawRejection.detail !== undefined && typeof rawRejection.detail !== "string") {
+      return coverageInvariant(`ownerEvidence[${index}].rejection.detail must be a string`);
+    }
+    const rawDetail = rawRejection.detail;
+    const detail = stableDetail(rawDetail);
+    rejectedRows.push(evidenceKey({ func, reason, ...(rawDetail === undefined ? {} : { detail: rawDetail }) }));
+    outcomes.set(ownerId, { kind: "rejected", reason, ...(detail === undefined ? {} : { detail }) });
+  }
+  for (const [index, value] of input.publicCompiled.entries()) {
+    nonEmptyString(value, `publicCompiled[${index}]`);
+  }
+  const publicRejected = input.publicRejected.map((value, index) => {
+    if (!plainRecord(value)) return coverageInvariant(`publicRejected[${index}] must be a plain record`);
+    const rejectionHasDetail = Object.prototype.hasOwnProperty.call(value, "detail");
+    exactKeys(value, ["func", "reason", ...(rejectionHasDetail ? ["detail"] : [])], `publicRejected[${index}]`);
+    const func = nonEmptyString(value.func, `publicRejected[${index}].func`);
+    const reason = nonEmptyString(value.reason, `publicRejected[${index}].reason`, 256);
+    if (value.detail !== undefined && typeof value.detail !== "string") {
+      return coverageInvariant(`publicRejected[${index}].detail must be a string`);
+    }
+    const detail = value.detail;
+    return evidenceKey({ func, reason, ...(detail === undefined ? {} : { detail }) });
+  });
+  if (!sameStringMultiset(compiledNames, input.publicCompiled) || !sameStringMultiset(rejectedRows, publicRejected)) {
+    return coverageInvariant("public compiled/rejected rows do not reconcile with structural owner evidence");
+  }
+  const census = freezeCensus({
+    payload,
+    status: input.status,
+    outcomes,
+    unresolvedReason: input.unresolvedReason,
+    ...(failure ? { failure } : {}),
+  });
+  lastCensus = validateLinearIrCoverageCensus(census, { afterWatermark: payload.ordinal - 1 });
+  return lastCensus;
+}
+
+export function finalizePreparedLinearIrCoverageGeneration(
+  transaction: LinearIrCoverageGenerationTransaction,
+  population: PreparedLinearIrCoveragePopulation,
+  input: {
+    readonly status: LinearIrCoverageStatus;
+    readonly evidence?: LinearIrCoverageCompatibilityEvidence;
+    readonly unresolvedReason: LinearIrCoverageNotAttemptedReason;
+    readonly failure?: LinearIrCoverageFailureV1;
+  },
+): LinearIrCoverageCensusV1 {
+  authenticateLinearIrCoveragePopulation(
+    population,
+    population.sourceFiles,
+    population.entrySource,
+    population.checker,
+  );
+  return finalizeLinearIrCoverageGeneration(transaction, {
+    populationToken: population,
+    status: input.status,
+    ownerEvidence: input.evidence?.ownerEvidence ?? [],
+    publicCompiled: input.evidence?.compiled ?? [],
+    publicRejected: input.evidence?.rejected ?? [],
+    unresolvedReason: input.unresolvedReason,
+    ...(input.failure ? { failure: input.failure } : {}),
+  });
+}
+
+/** Synchronous generation wrapper used only after the opt-in predicate succeeds. */
+export function runPreparedLinearIrCoverageGeneration<T>(input: {
+  readonly generationKind: LinearIrCoverageGenerationKind;
+  readonly preparePopulation: () => PreparedLinearIrCoveragePopulation;
+  readonly resetCompatibility: () => void;
+  readonly readCompatibility: () => LinearIrCoverageCompatibilityEvidence | undefined;
+  readonly unresolvedReason: LinearIrCoverageNotAttemptedReason;
+  readonly failureUnresolvedReason: LinearIrCoverageNotAttemptedReason;
+  readonly failurePhase: string;
+  readonly generate: (population: PreparedLinearIrCoveragePopulation) => T;
+}): T {
+  input.resetCompatibility();
+  resetLastLinearIrCoverageCensus();
+  const population = input.preparePopulation();
+  const transaction = beginPreparedLinearIrCoverageGeneration(population, input.generationKind);
+  let generated = false;
+  try {
+    const value = input.generate(population);
+    generated = true;
+    finalizePreparedLinearIrCoverageGeneration(transaction, population, {
+      status: "complete",
+      evidence: input.readCompatibility(),
+      unresolvedReason: input.unresolvedReason,
+    });
+    return value;
+  } catch (error) {
+    if (!generated) {
+      try {
+        finalizePreparedLinearIrCoverageGeneration(transaction, population, {
+          status: "generation-failed",
+          evidence: input.readCompatibility(),
+          unresolvedReason: input.failureUnresolvedReason,
+          failure: projectLinearIrCoverageFailure(input.failurePhase, error),
+        });
+      } catch {
+        // Preserve the generator's original exception. The consumer observes
+        // the missing census as a separate fail-closed instrumentation error.
+      }
+    }
+    throw error;
+  }
+}
+
+export function runSingleSourceLinearIrCoverageGeneration<T>(
+  preparePopulation: () => PreparedLinearIrCoveragePopulation,
+  resetCompatibility: () => void,
+  readCompatibility: () => LinearIrCoverageCompatibilityEvidence | undefined,
+  overlayEnabled: boolean,
+  generate: (population: PreparedLinearIrCoveragePopulation) => T,
+): T {
+  return runPreparedLinearIrCoverageGeneration({
+    generationKind: "single-source",
+    preparePopulation,
+    resetCompatibility,
+    readCompatibility,
+    unresolvedReason: overlayEnabled ? "selector-omitted" : "overlay-disabled",
+    failureUnresolvedReason: "generation-aborted",
+    failurePhase: "single-source-generation",
+    generate,
+  });
+}
+
+export function runMultiSourceLinearIrCoverageGeneration<T>(
+  preparePopulation: () => PreparedLinearIrCoveragePopulation,
+  resetCompatibility: () => void,
+  generate: () => T,
+): T {
+  return runPreparedLinearIrCoverageGeneration({
+    generationKind: "multi-source",
+    preparePopulation,
+    resetCompatibility,
+    readCompatibility: () => undefined,
+    unresolvedReason: "multi-source-overlay-unimplemented",
+    failureUnresolvedReason: "multi-source-overlay-unimplemented",
+    failurePhase: "multi-source-generation",
+    generate,
+  });
+}
+
+export function projectLinearIrCoverageFailure(phase: string, error: unknown): LinearIrCoverageFailureV1 {
+  const errorRecord =
+    error !== null && typeof error === "object" ? (error as { name?: unknown; message?: unknown }) : {};
+  const detail = stableDetail(errorRecord.message ?? error) ?? "generation failed";
+  const codeCandidate = typeof errorRecord.name === "string" ? errorRecord.name : "ThrownValue";
+  const code = /^[A-Za-z][A-Za-z0-9_.-]{0,127}$/.test(codeCandidate) ? codeCandidate : "ThrownValue";
+  return Object.freeze({
+    phase: nonEmptyString(phase, "failure phase", 128),
+    code,
+    detail,
+  });
+}
+
+function validateLinearIrCoverageFailure(value: unknown): LinearIrCoverageFailureV1 {
+  if (!plainRecord(value)) return coverageInvariant("failure must be a plain record");
+  exactKeys(value, ["phase", "code", "detail"], "failure");
+  const phase = nonEmptyString(value.phase, "failure.phase", 128);
+  const code = nonEmptyString(value.code, "failure.code", 128);
+  const detail = nonEmptyString(value.detail, "failure.detail", 512);
+  if (!/^[A-Za-z][A-Za-z0-9_.-]{0,127}$/.test(code)) {
+    return coverageInvariant("failure.code is not a stable bounded identifier");
+  }
+  if (/^(?:[A-Za-z]:[\\/]|[\\/]|file:)/.test(detail) || /\/(?:private|tmp|Users|home)\//.test(detail)) {
+    return coverageInvariant("failure.detail contains an absolute or temporary path");
+  }
+  return Object.freeze({ phase, code, detail });
+}
+
+function validateCensusSource(value: unknown, index: number): LinearIrCoverageSourceV1 {
+  if (!plainRecord(value)) return coverageInvariant(`census.sources[${index}] must be a plain record`);
+  exactKeys(value, ["sourceId", "sourceKey", "kind", "order"], `census.sources[${index}]`);
+  return Object.freeze(
+    exactSourceIdentity({
+      id: value.sourceId,
+      key: value.sourceKey,
+      kind: value.kind,
+      order: value.order,
+      label: `census.sources[${index}]`,
+    }),
+  );
+}
+
+function validateCensusOutcome(value: unknown, label: string): LinearIrCoverageOutcomeV1 {
+  if (!plainRecord(value)) return coverageInvariant(`${label} must be a plain record`);
+  if (value.kind === "compiled") {
+    exactKeys(value, ["kind"], label);
+    return Object.freeze({ kind: "compiled" });
+  }
+  if (value.kind === "rejected") {
+    exactKeys(value, ["kind", "reason", ...(value.detail === undefined ? [] : ["detail"])], label);
+    const reason = nonEmptyString(value.reason, `${label}.reason`, 256);
+    const detail = value.detail === undefined ? undefined : nonEmptyString(value.detail, `${label}.detail`, 512);
+    return Object.freeze({ kind: "rejected", reason, ...(detail === undefined ? {} : { detail }) });
+  }
+  if (value.kind === "not-attempted") {
+    exactKeys(value, ["kind", "reason"], label);
+    const reason = nonEmptyString(value.reason, `${label}.reason`) as LinearIrCoverageNotAttemptedReason;
+    if (!NOT_ATTEMPTED_REASONS.has(reason)) return coverageInvariant(`${label}.reason is unknown`);
+    return Object.freeze({ kind: "not-attempted", reason });
+  }
+  return coverageInvariant(`${label}.kind is unknown`);
+}
+
+function validateCensusOwner(value: unknown, index: number): LinearIrCoverageOwnerV1 {
+  if (!plainRecord(value)) return coverageInvariant(`census.owners[${index}] must be a plain record`);
+  exactKeys(
+    value,
+    ["ownerUnitId", "sourceId", "sourceKey", "legacyName", "terminalKind", "observedKind", "outcome"],
+    `census.owners[${index}]`,
+  );
+  const observedKind = nonEmptyString(value.observedKind, `census.owners[${index}].observedKind`);
+  if (!OBSERVED_KINDS.has(observedKind as IrTerminalObservedKind)) {
+    return coverageInvariant(`census.owners[${index}].observedKind is not attemptable`);
+  }
+  const source = sourceId(value.sourceId, `census.owners[${index}].sourceId`);
+  const kind = terminalKind(
+    value.terminalKind,
+    observedKind as IrTerminalObservedKind,
+    `census.owners[${index}].terminalKind`,
+  );
+  return Object.freeze({
+    ownerUnitId: ownerUnitId(value.ownerUnitId, `census.owners[${index}].ownerUnitId`, source, kind),
+    sourceId: source,
+    sourceKey: canonicalSourceKey(value.sourceKey, `census.owners[${index}].sourceKey`),
+    legacyName: nonEmptyString(value.legacyName, `census.owners[${index}].legacyName`),
+    terminalKind: kind,
+    observedKind: observedKind as Extract<IrTerminalObservedKind, "function" | "class-member">,
+    outcome: validateCensusOutcome(value.outcome, `census.owners[${index}].outcome`),
+  });
+}
+
+export function validateLinearIrCoverageCensus(
+  value: unknown,
+  options: { readonly afterWatermark?: number } = {},
+): LinearIrCoverageCensusV1 {
+  if (!plainRecord(value)) return coverageInvariant("census must be a plain record");
+  const status = value.status;
+  const hasFailure = value.failure !== undefined;
+  exactKeys(
+    value,
+    [
+      "schema",
+      "generationOrdinal",
+      "generationKind",
+      "entrySourceId",
+      "entrySourceKey",
+      "status",
+      "sources",
+      "owners",
+      "counts",
+      ...(hasFailure ? ["failure"] : []),
+    ],
+    "census",
+  );
+  if (value.schema !== LINEAR_IR_COVERAGE_SCHEMA) return coverageInvariant("census schema is unknown");
+  const generationOrdinalValue = safeCount(value.generationOrdinal, "census.generationOrdinal", 1);
+  if (options.afterWatermark !== undefined) {
+    const watermark = safeCount(options.afterWatermark, "validation watermark");
+    if (generationOrdinalValue !== watermark + 1) return coverageInvariant("census generation ordinal is stale");
+  }
+  if (value.generationKind !== "single-source" && value.generationKind !== "multi-source") {
+    return coverageInvariant("census generation kind is unknown");
+  }
+  if (status !== "complete" && status !== "generation-failed") return coverageInvariant("census status is unknown");
+  const failure = hasFailure ? validateLinearIrCoverageFailure(value.failure) : undefined;
+  if ((status === "generation-failed") !== (failure !== undefined)) {
+    return coverageInvariant("census failure evidence and status disagree");
+  }
+  if (!Array.isArray(value.sources) || value.sources.length === 0 || !Array.isArray(value.owners)) {
+    return coverageInvariant("census source or owner arrays are malformed");
+  }
+  const sources = value.sources.map(validateCensusSource);
+  const owners = value.owners.map(validateCensusOwner);
+  if (
+    sources.some(
+      (source, index) => index > 0 && compareLinearIrCoverageText(sources[index - 1]!.sourceKey, source.sourceKey) >= 0,
+    ) ||
+    owners.some(
+      (owner, index) =>
+        index > 0 && compareLinearIrCoverageText(owners[index - 1]!.ownerUnitId, owner.ownerUnitId) >= 0,
+    )
+  ) {
+    return coverageInvariant("census rows are not in strict canonical order");
+  }
+  const sourceById = new Map<IrSourceId, LinearIrCoverageSourceV1>();
+  const sourceKeys = new Set<string>();
+  const orders = new Set<number>();
+  for (const source of sources) {
+    if (sourceById.has(source.sourceId) || sourceKeys.has(source.sourceKey) || orders.has(source.order)) {
+      return coverageInvariant("census contains duplicate source ID, key, or order");
+    }
+    sourceById.set(source.sourceId, source);
+    sourceKeys.add(source.sourceKey);
+    orders.add(source.order);
+  }
+  if ([...orders].sort((left, right) => left - right).some((order, index) => order !== index)) {
+    return coverageInvariant("census source order is incomplete");
+  }
+  const entrySourceIdValue = sourceId(value.entrySourceId, "census.entrySourceId");
+  const entrySourceKeyValue = canonicalSourceKey(value.entrySourceKey, "census.entrySourceKey");
+  const entryRows = sources.filter(
+    (source) =>
+      source.kind === "entry" && source.sourceId === entrySourceIdValue && source.sourceKey === entrySourceKeyValue,
+  );
+  if (entryRows.length !== 1 || sources.filter((source) => source.kind === "entry").length !== 1) {
+    return coverageInvariant("census entry source join drifted");
+  }
+  if (value.generationKind === "single-source" && sources.length !== 1) {
+    return coverageInvariant("single-source census contains multiple sources");
+  }
+  let compiled = 0;
+  let rejected = 0;
+  let notAttempted = 0;
+  for (const owner of owners) {
+    const source = sourceById.get(owner.sourceId);
+    if (!source || source.sourceKey !== owner.sourceKey) return coverageInvariant("census owner source join drifted");
+    if (owner.outcome.kind === "compiled") compiled++;
+    else if (owner.outcome.kind === "rejected") rejected++;
+    else notAttempted++;
+  }
+  if (!plainRecord(value.counts)) return coverageInvariant("census.counts must be a plain record");
+  exactKeys(value.counts, ["sources", "owners", "compiled", "rejected", "notAttempted"], "census.counts");
+  const counts = Object.freeze({
+    sources: safeCount(value.counts.sources, "census.counts.sources"),
+    owners: safeCount(value.counts.owners, "census.counts.owners"),
+    compiled: safeCount(value.counts.compiled, "census.counts.compiled"),
+    rejected: safeCount(value.counts.rejected, "census.counts.rejected"),
+    notAttempted: safeCount(value.counts.notAttempted, "census.counts.notAttempted"),
+  });
+  if (
+    counts.sources !== sources.length ||
+    counts.owners !== owners.length ||
+    counts.compiled !== compiled ||
+    counts.rejected !== rejected ||
+    counts.notAttempted !== notAttempted ||
+    counts.owners !== counts.compiled + counts.rejected + counts.notAttempted
+  ) {
+    return coverageInvariant("census counts do not reconcile with the complete population");
+  }
+  return Object.freeze({
+    schema: LINEAR_IR_COVERAGE_SCHEMA,
+    generationOrdinal: generationOrdinalValue,
+    generationKind: value.generationKind,
+    entrySourceId: entrySourceIdValue,
+    entrySourceKey: entrySourceKeyValue,
+    status,
+    sources: Object.freeze(sources),
+    owners: Object.freeze(owners),
+    counts,
+    ...(failure ? { failure } : {}),
+  });
+}
+
+export function linearIrCoverageDigestProjection(census: unknown): Omit<LinearIrCoverageCensusV1, "generationOrdinal"> {
+  const validated = validateLinearIrCoverageCensus(census);
+  return Object.freeze({
+    schema: validated.schema,
+    generationKind: validated.generationKind,
+    entrySourceId: validated.entrySourceId,
+    entrySourceKey: validated.entrySourceKey,
+    status: validated.status,
+    sources: validated.sources,
+    owners: validated.owners,
+    counts: validated.counts,
+    ...(validated.failure ? { failure: validated.failure } : {}),
+  });
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return coverageInvariant("canonical JSON contains a non-finite number");
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(canonicalJsonValue);
+  if (!plainRecord(value)) return coverageInvariant("canonical JSON contains an unsupported value");
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort(compareLinearIrCoverageText)
+      .map((key) => {
+        const member = value[key];
+        if (member === undefined) return coverageInvariant("canonical JSON contains undefined");
+        return [key, canonicalJsonValue(member)];
+      }),
+  );
+}
+
+export function canonicalLinearIrCoverageJson(value: unknown): string {
+  return JSON.stringify(canonicalJsonValue(value));
+}

--- a/tests/issue-4550-linear-ir-census.test.ts
+++ b/tests/issue-4550-linear-ir-census.test.ts
@@ -1,0 +1,646 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { compile, compileMulti, type CompileResult } from "../src/index.js";
+import {
+  getLastLinearIrReport,
+  prepareLinearIrCoveragePopulation,
+  resetLastLinearIrReport,
+} from "../src/ir/backend/linear-integration.js";
+import {
+  beginLinearIrCoverageGeneration,
+  beginPreparedLinearIrCoverageGeneration,
+  canonicalLinearIrCoverageJson,
+  finalizeLinearIrCoverageGeneration,
+  finalizePreparedLinearIrCoverageGeneration,
+  getLastLinearIrCoverageCensus,
+  linearIrCoverageDigestProjection,
+  linearIrCoverageEnabled,
+  resetLastLinearIrCoverageCensus,
+  runPreparedLinearIrCoverageGeneration,
+  validateLinearIrCoverageCensus,
+  type LinearIrCoverageCensusV1,
+  type PreparedLinearIrCoveragePopulation,
+} from "../src/ir/backend/linear-ir-coverage.js";
+import { ts } from "../src/ts-api.js";
+import {
+  compareLinearIrBaseline,
+  digestLinearIrCompileErrors,
+  linearIrGenerationContributionEligible,
+  loadLinearIrBaselineForMode,
+  parseLinearIrBaseline,
+  projectLinearIrCompileErrors,
+  sameLinearIrOwnerPopulation,
+} from "../scripts/check-linear-ir.js";
+
+const COVERAGE_FLAG = "JS2WASM_LINEAR_IR_COVERAGE";
+const OVERLAY_FLAG = "JS2WASM_LINEAR_IR";
+const savedCoverage = process.env[COVERAGE_FLAG];
+const savedOverlay = process.env[OVERLAY_FLAG];
+
+function setFlag(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function clearDiagnostics(): void {
+  resetLastLinearIrReport();
+  resetLastLinearIrCoverageCensus();
+}
+
+beforeEach(() => {
+  setFlag(COVERAGE_FLAG, undefined);
+  setFlag(OVERLAY_FLAG, undefined);
+  clearDiagnostics();
+});
+
+afterEach(() => {
+  clearDiagnostics();
+  setFlag(COVERAGE_FLAG, savedCoverage);
+  setFlag(OVERLAY_FLAG, savedOverlay);
+});
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("; ")).toBe(true);
+}
+
+function binarySnapshot(result: CompileResult) {
+  return {
+    binary: [...result.binary],
+    errors: result.errors.map(({ message, line, column, severity }) => ({ message, line, column, severity })),
+    exports: WebAssembly.Module.exports(new WebAssembly.Module(result.binary)),
+  };
+}
+
+async function runtimeValue(result: CompileResult, exportName: string, ...args: number[]): Promise<unknown> {
+  const { instance } = await WebAssembly.instantiate(result.binary);
+  return (instance.exports[exportName] as (...values: number[]) => unknown)(...args);
+}
+
+function makeProgram(sources: Readonly<Record<string, string>>): {
+  readonly files: readonly ts.SourceFile[];
+  readonly checker: ts.TypeChecker;
+} {
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    noLib: true,
+    noResolve: true,
+  };
+  const host = ts.createCompilerHost(options, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  const hasSource = (fileName: string): boolean => Object.prototype.hasOwnProperty.call(sources, fileName);
+  host.fileExists = hasSource;
+  host.readFile = (fileName) => sources[fileName];
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) =>
+    hasSource(fileName)
+      ? ts.createSourceFile(fileName, sources[fileName]!, languageVersion, true, ts.ScriptKind.TS)
+      : originalGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+  const names = Object.keys(sources);
+  const program = ts.createProgram({ rootNames: names, options, host });
+  return { files: names.map((name) => program.getSourceFile(name)!), checker: program.getTypeChecker() };
+}
+
+function population(
+  sources: Readonly<Record<string, string>> = {
+    "/virtual/entry.ts": `
+      export function accepted(value: number): number { return value + 1; }
+      export function rejected(value: number = 1): number { return value + 2; }
+    `,
+  },
+): PreparedLinearIrCoveragePopulation {
+  const built = makeProgram(sources);
+  return prepareLinearIrCoveragePopulation(built.files, built.files[0]!, built.checker);
+}
+
+function completePopulation(
+  prepared: PreparedLinearIrCoveragePopulation,
+  unresolvedReason: "selector-omitted" | "multi-source-overlay-unimplemented" = "selector-omitted",
+): LinearIrCoverageCensusV1 {
+  const transaction = beginPreparedLinearIrCoverageGeneration(
+    prepared,
+    prepared.sourceFiles.length === 1 ? "single-source" : "multi-source",
+  );
+  return finalizePreparedLinearIrCoverageGeneration(transaction, prepared, {
+    status: "complete",
+    unresolvedReason,
+  });
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function digest(census: LinearIrCoverageCensusV1): string {
+  return createHash("sha256")
+    .update(canonicalLinearIrCoverageJson(linearIrCoverageDigestProjection(census)))
+    .digest("hex");
+}
+
+describe("#4550 linear IR coverage census", { timeout: 60_000 }, () => {
+  it("keeps its browser-safe predicate default-off and exact", () => {
+    expect(linearIrCoverageEnabled(null)).toBe(false);
+    expect(linearIrCoverageEnabled({})).toBe(false);
+    expect(linearIrCoverageEnabled({ process: null })).toBe(false);
+    expect(linearIrCoverageEnabled({ process: {} })).toBe(false);
+    expect(linearIrCoverageEnabled({ process: { env: null } })).toBe(false);
+    expect(linearIrCoverageEnabled({ process: { env: {} } })).toBe(false);
+    expect(linearIrCoverageEnabled({ process: { env: { [COVERAGE_FLAG]: "0" } } })).toBe(false);
+    expect(linearIrCoverageEnabled({ process: { env: { [COVERAGE_FLAG]: "true" } } })).toBe(false);
+    expect(linearIrCoverageEnabled({ process: { env: { [COVERAGE_FLAG]: "1" } } })).toBe(true);
+  });
+
+  it("publishes a nonempty exact single-source denominator with compiled and rejected owners", async () => {
+    setFlag(COVERAGE_FLAG, "1");
+    setFlag(OVERLAY_FLAG, "1");
+    const result = await compile(
+      `
+        export function accepted(value: number): number { return value + 1; }
+        export function withDefault(value: number = 1): number { return value + 2; }
+      `,
+      { target: "linear", fileName: "fixtures/coverage-positive.ts" },
+    );
+    expectSuccess(result);
+    const census = validateLinearIrCoverageCensus(getLastLinearIrCoverageCensus());
+    expect(census.generationKind).toBe("single-source");
+    expect(census.status).toBe("complete");
+    expect(census.sources).toHaveLength(1);
+    expect(census.owners.length).toBeGreaterThan(1);
+    expect(census.counts.compiled).toBeGreaterThan(0);
+    expect(census.counts.rejected).toBeGreaterThan(0);
+    expect(census.counts.owners).toBe(census.counts.compiled + census.counts.rejected + census.counts.notAttempted);
+    expect(census.owners.some((owner) => owner.outcome.kind === "compiled")).toBe(true);
+    expect(census.owners.some((owner) => owner.outcome.kind === "rejected")).toBe(true);
+    expect(JSON.stringify(census)).not.toContain("fixtures/coverage-positive.ts");
+  });
+
+  it("is byte/error/export/runtime neutral for single and multi-source compiles", async () => {
+    const singleSource = `export function run(value: number): number { return value * 2 + 1; }`;
+    setFlag(COVERAGE_FLAG, undefined);
+    const singleOff = await compile(singleSource, { target: "linear", fileName: "ab/single.ts" });
+    expectSuccess(singleOff);
+    expect(getLastLinearIrCoverageCensus()).toBeUndefined();
+    clearDiagnostics();
+    setFlag(COVERAGE_FLAG, "1");
+    const singleOn = await compile(singleSource, { target: "linear", fileName: "ab/single.ts" });
+    expectSuccess(singleOn);
+    expect("linearIrCoverage" in singleOn).toBe(false);
+    expect(binarySnapshot(singleOn)).toEqual(binarySnapshot(singleOff));
+    expect(await runtimeValue(singleOn, "run", 4)).toBe(await runtimeValue(singleOff, "run", 4));
+    expect(validateLinearIrCoverageCensus(getLastLinearIrCoverageCensus()).counts.owners).toBeGreaterThan(0);
+
+    const files = {
+      "lib.ts": `export function twice(value: number): number { return value * 2; }`,
+      "entry.ts": `import { twice } from "./lib.js"; export function run(value: number): number { return twice(value) + 1; }`,
+    };
+    clearDiagnostics();
+    setFlag(COVERAGE_FLAG, undefined);
+    const multiOff = await compileMulti(files, "entry.ts", { target: "linear" });
+    expectSuccess(multiOff);
+    expect(getLastLinearIrCoverageCensus()).toBeUndefined();
+    clearDiagnostics();
+    setFlag(COVERAGE_FLAG, "1");
+    const multiOn = await compileMulti(files, "entry.ts", { target: "linear" });
+    expectSuccess(multiOn);
+    expect(binarySnapshot(multiOn)).toEqual(binarySnapshot(multiOff));
+    expect(await runtimeValue(multiOn, "run", 4)).toBe(await runtimeValue(multiOff, "run", 4));
+    expect(getLastLinearIrReport()).toBeUndefined();
+    const multiCensus = validateLinearIrCoverageCensus(getLastLinearIrCoverageCensus());
+    expect(multiCensus.generationKind).toBe("multi-source");
+    expect(multiCensus.sources).toHaveLength(2);
+    expect(multiCensus.owners.length).toBeGreaterThan(1);
+    expect(multiCensus.owners.every((owner) => owner.outcome.kind === "not-attempted")).toBe(true);
+    expect(
+      multiCensus.owners.every(
+        (owner) =>
+          owner.outcome.kind === "not-attempted" && owner.outcome.reason === "multi-source-overlay-unimplemented",
+      ),
+    ).toBe(true);
+  });
+
+  it("observes overlay-disabled direct mode without reserving or emitting IR runtime bytes", async () => {
+    const source = `export function run(value: number): number { return value + 3; }`;
+    setFlag(OVERLAY_FLAG, "0");
+    setFlag(COVERAGE_FLAG, undefined);
+    const off = await compile(source, { target: "linear", fileName: "ab/direct.ts" });
+    expectSuccess(off);
+    clearDiagnostics();
+    setFlag(COVERAGE_FLAG, "1");
+    const on = await compile(source, { target: "linear", fileName: "ab/direct.ts" });
+    expectSuccess(on);
+    expect(binarySnapshot(on)).toEqual(binarySnapshot(off));
+    expect(await runtimeValue(on, "run", 4)).toBe(await runtimeValue(off, "run", 4));
+    expect(getLastLinearIrReport()).toBeUndefined();
+    const census = validateLinearIrCoverageCensus(getLastLinearIrCoverageCensus());
+    expect(census.owners.length).toBeGreaterThan(0);
+    expect(
+      census.owners.every(
+        (owner) => owner.outcome.kind === "not-attempted" && owner.outcome.reason === "overlay-disabled",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps colliding display labels distinct by source and UnitId", () => {
+    const prepared = population({
+      "/virtual/a.ts": `export function same(value: number): number { return value + 1; }`,
+      "/virtual/b.ts": `export function same(value: number): number { return value + 2; }`,
+    });
+    const census = completePopulation(prepared, "multi-source-overlay-unimplemented");
+    expect(census.sources).toHaveLength(2);
+    expect(census.owners).toHaveLength(2);
+    expect(census.owners.map((owner) => owner.legacyName)).toEqual(["same", "same"]);
+    expect(new Set(census.owners.map((owner) => owner.sourceId)).size).toBe(2);
+    expect(new Set(census.owners.map((owner) => owner.ownerUnitId)).size).toBe(2);
+  });
+
+  it("prevents a failed pre-generator compile from inheriting prior diagnostics", async () => {
+    setFlag(COVERAGE_FLAG, "1");
+    const firstWatermark = resetLastLinearIrCoverageCensus();
+    const first = await compile(`export function run(value: number): number { return value + 1; }`, {
+      target: "linear",
+      fileName: "sequence/first.ts",
+    });
+    expectSuccess(first);
+    expect(
+      validateLinearIrCoverageCensus(getLastLinearIrCoverageCensus(), { afterWatermark: firstWatermark }),
+    ).toBeTruthy();
+    expect(getLastLinearIrReport()).toBeTruthy();
+
+    resetLastLinearIrReport();
+    const secondWatermark = resetLastLinearIrCoverageCensus();
+    const second = await compile(`export function broken(`, {
+      target: "linear",
+      fileName: "sequence/broken.ts",
+    });
+    expect(second.success).toBe(false);
+    expect(getLastLinearIrReport()).toBeUndefined();
+    expect(getLastLinearIrCoverageCensus()).toBeUndefined();
+    expect(resetLastLinearIrCoverageCensus()).toBe(secondWatermark);
+  });
+
+  it("retains returned failure diagnostics while admitting only its exact completed generation", async () => {
+    setFlag(COVERAGE_FLAG, "1");
+    const result = await compile(
+      `
+        export function accepted(value: number): number { return value + 1; }
+        export function directOnly(): number { return document.body.childElementCount; }
+      `,
+      { target: "linear", fileName: "fixtures/post-generation-failure.ts" },
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(getLastLinearIrReport()).toBeTruthy();
+    const census = validateLinearIrCoverageCensus(getLastLinearIrCoverageCensus());
+    expect(census.status).toBe("complete");
+    expect(census.counts.owners).toBeGreaterThan(0);
+
+    const projection = projectLinearIrCompileErrors([
+      ...result.errors,
+      {
+        message: "late error at /private/tmp/checkout/file.ts",
+        line: 1,
+        column: 2,
+        severity: "error" as const,
+        file: "/private/tmp/checkout/file.ts",
+      },
+    ]);
+    expect(JSON.stringify(projection)).not.toContain("/private/tmp");
+    expect(projection.errors.length).toBe(result.errors.length + 1);
+    const errorDigest = digestLinearIrCompileErrors(result.errors.length + 1, projection);
+    expect(errorDigest).toMatch(/^[0-9a-f]{64}$/);
+    const reversedProjection = projectLinearIrCompileErrors(
+      [
+        ...result.errors,
+        {
+          file: "/private/tmp/checkout/file.ts",
+          severity: "error" as const,
+          column: 2,
+          line: 1,
+          message: "late error at /private/tmp/checkout/file.ts",
+        },
+      ].reverse(),
+    );
+    expect(reversedProjection).toEqual(projection);
+    expect(digestLinearIrCompileErrors(result.errors.length + 1, reversedProjection)).toBe(errorDigest);
+    const bounded = projectLinearIrCompileErrors(
+      Array.from({ length: 257 }, (_, index) => ({
+        message: `error ${index}`,
+        line: index + 1,
+        column: 1,
+        severity: "error" as const,
+      })),
+    );
+    expect(bounded).toMatchObject({ truncated: true });
+    expect(bounded.errors).toHaveLength(256);
+    expect(digestLinearIrCompileErrors(257, bounded)).toMatch(/^[0-9a-f]{64}$/);
+    expect(
+      linearIrGenerationContributionEligible({
+        compileStatus: "returned",
+        censusStatus: census.status,
+        instrumentationFailureCount: 0,
+      }),
+    ).toBe(true);
+    for (const mutation of [
+      { compileStatus: "threw" as const, censusStatus: "complete" as const, instrumentationFailureCount: 0 },
+      { compileStatus: "returned" as const, censusStatus: "missing" as const, instrumentationFailureCount: 0 },
+      {
+        compileStatus: "returned" as const,
+        censusStatus: "generation-failed" as const,
+        instrumentationFailureCount: 0,
+      },
+      { compileStatus: "returned" as const, censusStatus: "complete" as const, instrumentationFailureCount: 1 },
+    ]) {
+      expect(linearIrGenerationContributionEligible(mutation)).toBe(false);
+    }
+  });
+
+  it("retains partial exact evidence and the full denominator on a late generation failure", () => {
+    const prepared = population();
+    const first = prepared.owners[0]!;
+    const partial = {
+      ownerEvidence: [{ outcome: "compiled" as const, ownerUnitId: first.ownerUnitId, legacyName: first.legacyName }],
+      compiled: [first.legacyName],
+      rejected: [],
+    };
+    expect(() =>
+      runPreparedLinearIrCoverageGeneration({
+        generationKind: "single-source",
+        preparePopulation: () => prepared,
+        resetCompatibility: () => undefined,
+        readCompatibility: () => partial,
+        unresolvedReason: "selector-omitted",
+        failureUnresolvedReason: "generation-aborted",
+        failurePhase: "test-generation",
+        generate: () => {
+          throw new Error("late failure at /tmp/private-output");
+        },
+      }),
+    ).toThrowError("late failure");
+    const census = validateLinearIrCoverageCensus(getLastLinearIrCoverageCensus());
+    expect(census.status).toBe("generation-failed");
+    expect(census.counts.owners).toBe(prepared.owners.length);
+    expect(census.counts.compiled).toBe(1);
+    expect(census.counts.notAttempted).toBe(prepared.owners.length - 1);
+    expect(
+      census.owners
+        .filter((owner) => owner.ownerUnitId !== first.ownerUnitId)
+        .every((owner) => owner.outcome.kind === "not-attempted" && owner.outcome.reason === "generation-aborted"),
+    ).toBe(true);
+    expect(census.failure?.detail).not.toContain("/tmp");
+
+    const multi = population({
+      "/virtual/a.ts": `export function a(): number { return 1; }`,
+      "/virtual/b.ts": `export function b(): number { return 2; }`,
+    });
+    expect(() =>
+      runPreparedLinearIrCoverageGeneration({
+        generationKind: "multi-source",
+        preparePopulation: () => multi,
+        resetCompatibility: () => undefined,
+        readCompatibility: () => undefined,
+        unresolvedReason: "multi-source-overlay-unimplemented",
+        failureUnresolvedReason: "multi-source-overlay-unimplemented",
+        failurePhase: "test-multi-generation",
+        generate: () => {
+          throw new Error("multi failure");
+        },
+      }),
+    ).toThrowError("multi failure");
+    const failedMulti = validateLinearIrCoverageCensus(getLastLinearIrCoverageCensus());
+    expect(failedMulti.status).toBe("generation-failed");
+    expect(
+      failedMulti.owners.every(
+        (owner) =>
+          owner.outcome.kind === "not-attempted" && owner.outcome.reason === "multi-source-overlay-unimplemented",
+      ),
+    ).toBe(true);
+  });
+
+  it("authenticates transactions and rejects missing, duplicate, unknown, and cross-population evidence", () => {
+    const prepared = population();
+    const owner = prepared.owners[0]!;
+    const begin = () => beginPreparedLinearIrCoverageGeneration(prepared, "single-source");
+    const empty = { status: "complete" as const, unresolvedReason: "selector-omitted" as const };
+
+    const missing = begin();
+    expect(() =>
+      finalizePreparedLinearIrCoverageGeneration(missing, prepared, {
+        ...empty,
+        evidence: { ownerEvidence: [], compiled: [owner.legacyName], rejected: [] },
+      }),
+    ).toThrow(/do not reconcile/);
+
+    const duplicate = begin();
+    const compiled = { outcome: "compiled" as const, ownerUnitId: owner.ownerUnitId, legacyName: owner.legacyName };
+    expect(() =>
+      finalizePreparedLinearIrCoverageGeneration(duplicate, prepared, {
+        ...empty,
+        evidence: { ownerEvidence: [compiled, compiled], compiled: [owner.legacyName], rejected: [] },
+      }),
+    ).toThrow(/unknown, duplicate/);
+
+    const unknown = begin();
+    expect(() =>
+      finalizePreparedLinearIrCoverageGeneration(unknown, prepared, {
+        ...empty,
+        evidence: {
+          ownerEvidence: [{ ...compiled, ownerUnitId: `${owner.ownerUnitId}-unknown` as typeof owner.ownerUnitId }],
+          compiled: [owner.legacyName],
+          rejected: [],
+        },
+      }),
+    ).toThrow(/unknown, duplicate/);
+
+    const live = begin();
+    expect(() =>
+      finalizeLinearIrCoverageGeneration({} as typeof live, {
+        populationToken: prepared,
+        status: "complete",
+        ownerEvidence: [],
+        publicCompiled: [],
+        publicRejected: [],
+        unresolvedReason: "selector-omitted",
+      }),
+    ).toThrow(/foreign, stale, reused/);
+    expect(() => begin()).toThrow(/overlapping/);
+    expect(() => resetLastLinearIrReport()).toThrow(/active coverage generation/);
+    expect(() => resetLastLinearIrCoverageCensus()).toThrow(/live generation/);
+    const finalized = finalizePreparedLinearIrCoverageGeneration(live, prepared, empty);
+    expect(finalized.status).toBe("complete");
+    expect(() => finalizePreparedLinearIrCoverageGeneration(live, prepared, empty)).toThrow(/foreign, stale, reused/);
+
+    const other = population({ "/virtual/other.ts": `export function other(): number { return 1; }` });
+    const cross = begin();
+    expect(() => finalizePreparedLinearIrCoverageGeneration(cross, other, empty)).toThrow(/cross-population/);
+    finalizePreparedLinearIrCoverageGeneration(cross, prepared, empty);
+
+    const duplicateOwners = [prepared.owners[0]!, prepared.owners[0]!];
+    expect(() =>
+      beginLinearIrCoverageGeneration({
+        populationToken: prepared,
+        generationKind: "single-source",
+        entrySourceId: prepared.sources[0]!.sourceId,
+        entrySourceKey: prepared.sources[0]!.sourceKey,
+        sources: prepared.sources,
+        owners: duplicateOwners,
+      }),
+    ).toThrow(/duplicate UnitId/);
+
+    const multi = population({
+      "/virtual/a.ts": `export function a(): number { return 1; }`,
+      "/virtual/b.ts": `export function b(): number { return 2; }`,
+    });
+    const entry = multi.sources.find((source) => source.kind === "entry")!;
+    expect(() =>
+      beginLinearIrCoverageGeneration({
+        populationToken: multi,
+        generationKind: "multi-source",
+        entrySourceId: entry.sourceId,
+        entrySourceKey: entry.sourceKey,
+        sources: [entry, entry],
+        owners: multi.owners,
+      }),
+    ).toThrow(/duplicate ID, key, file, or order/);
+
+    const source = prepared.sources[0]!;
+    expect(() =>
+      beginLinearIrCoverageGeneration({
+        populationToken: prepared,
+        generationKind: "single-source",
+        entrySourceId: source.sourceId,
+        entrySourceKey: source.sourceKey,
+        sources: [{ ...source, originalFileName: "/different/input.ts" }],
+        owners: prepared.owners,
+      }),
+    ).toThrow(/caller-supplied logical filename/);
+    const firstOwner = prepared.owners[0]!;
+    expect(() =>
+      beginLinearIrCoverageGeneration({
+        populationToken: prepared,
+        generationKind: "single-source",
+        entrySourceId: source.sourceId,
+        entrySourceKey: source.sourceKey,
+        sources: prepared.sources,
+        owners: [
+          {
+            ...firstOwner,
+            terminalRecord: { ...(firstOwner.terminalRecord as object), legacyMatchName: "other" },
+          },
+          ...prepared.owners.slice(1),
+        ],
+      }),
+    ).toThrow(/source\/declaration\/terminal record/);
+    expect(() =>
+      beginLinearIrCoverageGeneration({
+        populationToken: {},
+        generationKind: "single-source",
+        entrySourceId: source.sourceId,
+        entrySourceKey: source.sourceKey,
+        sources: prepared.sources,
+        owners: prepared.owners,
+      }),
+    ).toThrow(/not an exact prepared population/);
+  });
+
+  it("rejects source, entry, kind, ordinal, count, and serializable-row mutations", () => {
+    const census = completePopulation(population());
+    const mutations: unknown[] = [];
+    const wrongSource = clone(census);
+    (wrongSource.sources[0] as { sourceKey: string }).sourceKey = "/absolute/entry.ts";
+    mutations.push(wrongSource);
+    const wrongEntry = clone(census);
+    (wrongEntry as { entrySourceKey: string }).entrySourceKey = "other.ts";
+    mutations.push(wrongEntry);
+    const wrongKind = clone(census);
+    (wrongKind.owners[0] as { terminalKind: string }).terminalKind = "module-init";
+    mutations.push(wrongKind);
+    const wrongSourceKind = clone(census);
+    (wrongSourceKind.sources[0] as { kind: string }).kind = "source";
+    mutations.push(wrongSourceKind);
+    const wrongCount = clone(census);
+    (wrongCount.counts as { owners: number }).owners++;
+    mutations.push(wrongCount);
+    const arrayOutcome = clone(census) as unknown as { owners: { outcome: unknown }[] };
+    arrayOutcome.owners[0]!.outcome = [];
+    mutations.push(arrayOutcome);
+    const mapCounts = clone(census) as unknown as { counts: unknown };
+    mapCounts.counts = new Map();
+    mutations.push(mapCounts);
+    const nonFinite = clone(census) as unknown as { counts: { compiled: number } };
+    nonFinite.counts.compiled = Number.NaN;
+    mutations.push(nonFinite);
+    for (const mutation of mutations) expect(() => validateLinearIrCoverageCensus(mutation)).toThrow();
+    const wrongOrdinal = clone(census) as unknown as { generationOrdinal: number };
+    wrongOrdinal.generationOrdinal += 2;
+    expect(() =>
+      validateLinearIrCoverageCensus(wrongOrdinal, { afterWatermark: census.generationOrdinal - 1 }),
+    ).toThrow(/stale/);
+    expect(() => validateLinearIrCoverageCensus(census, { afterWatermark: census.generationOrdinal })).toThrow(/stale/);
+    expect(validateLinearIrCoverageCensus(census, { afterWatermark: census.generationOrdinal - 1 })).toEqual(census);
+    expect(JSON.stringify(census)).not.toContain("/virtual/");
+    expect(sameLinearIrOwnerPopulation(census.owners.slice(1), census.owners)).toBe(false);
+    expect(sameLinearIrOwnerPopulation([...census.owners, census.owners[0]!], census.owners)).toBe(false);
+    expect(sameLinearIrOwnerPopulation(census.owners, census.owners)).toBe(true);
+  });
+
+  it("canonicalizes input order, property order, and excludes raw ordinals from persistent digests", () => {
+    const prepared = population({
+      "/virtual/z.ts": `export function zed(): number { return 2; }`,
+      "/virtual/a.ts": `export function aye(): number { return 1; }`,
+    });
+    const runRaw = (reverse: boolean): LinearIrCoverageCensusV1 => {
+      const sources = reverse ? [...prepared.sources].reverse() : prepared.sources;
+      const owners = reverse ? [...prepared.owners].reverse() : prepared.owners;
+      const entry = prepared.sources.find((source) => source.kind === "entry")!;
+      const transaction = beginLinearIrCoverageGeneration({
+        populationToken: prepared,
+        generationKind: "multi-source",
+        entrySourceId: entry.sourceId,
+        entrySourceKey: entry.sourceKey,
+        sources,
+        owners,
+      });
+      return finalizeLinearIrCoverageGeneration(transaction, {
+        populationToken: prepared,
+        status: "complete",
+        ownerEvidence: [],
+        publicCompiled: [],
+        publicRejected: [],
+        unresolvedReason: "multi-source-overlay-unimplemented",
+      });
+    };
+    const reversed = runRaw(true);
+    const canonical = runRaw(false);
+    expect(reversed.generationOrdinal).not.toBe(canonical.generationOrdinal);
+    expect(linearIrCoverageDigestProjection(reversed)).toEqual(linearIrCoverageDigestProjection(canonical));
+    expect(digest(reversed)).toBe(digest(canonical));
+    expect(digest(canonical)).toMatch(/^[0-9a-f]{64}$/);
+    const projection = linearIrCoverageDigestProjection(canonical) as unknown as Record<string, unknown>;
+    const reordered = Object.fromEntries(Object.entries(projection).reverse());
+    expect(canonicalLinearIrCoverageJson(reordered)).toBe(canonicalLinearIrCoverageJson(projection));
+    expect(canonicalLinearIrCoverageJson(projection)).not.toContain("generationOrdinal");
+  });
+
+  it("keeps the committed baseline byte-exact and refuses implicit missing/malformed seeding", () => {
+    expect(readFileSync(new URL("../scripts/linear-ir-baseline.json", import.meta.url), "utf8")).toBe(
+      '{\n  "compiled": 8,\n  "buckets": {\n    "select:async-function": 4,\n    "select:body-shape-rejected": 24,\n    "select:call-graph-closure": 11,\n    "select:string-builder-candidate": 2\n  }\n}\n',
+    );
+    expect(() => parseLinearIrBaseline(undefined)).toThrow(/missing/);
+    expect(() => parseLinearIrBaseline("{")).toThrow(/valid JSON/);
+    expect(() => parseLinearIrBaseline('{"compiled":0,"buckets":{},"extra":true}')).toThrow(/fields/);
+    expect(() => loadLinearIrBaselineForMode(undefined, false)).toThrow(/missing/);
+    expect(loadLinearIrBaselineForMode(undefined, true)).toEqual({ replacementRequired: true });
+    expect(loadLinearIrBaselineForMode("{", true)).toEqual({ replacementRequired: true });
+    expect(compareLinearIrBaseline({ compiled: 7, buckets: {} }, { compiled: 8, buckets: {} })).toEqual([
+      "IR-compiled function count DECREASED: 8 → 7",
+    ]);
+    expect(
+      compareLinearIrBaseline({ compiled: 8, buckets: { build: 2 } }, { compiled: 8, buckets: { build: 1 } }),
+    ).toEqual(["demotion bucket 'build' INCREASED: 1 → 2"]);
+    expect(
+      compareLinearIrBaseline({ compiled: 9, buckets: { build: 0 } }, { compiled: 8, buckets: { build: 1 } }),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- add the default-off, compile-scoped `linear-ir-coverage-census-v1` report for exact `JS2WASM_LINEAR_IR_COVERAGE=1`
- authenticate one-shot single-source and multi-source census generation while preserving existing live-report consumers and emitted Wasm behavior
- harden the existing 13-file linear-IR ratchet against missing, stale, or malformed census evidence without widening its committed corpus or baseline
- keep the checkpoint dormant in normal builds; it changes no selection, fallback, runtime, or output bytes unless the exact diagnostic switch is enabled

## Dependency and scope

- implementation plan prerequisite #4963 is merged; exact plan parent `1ebf7043d1804879d9298d625f80d2a9a17d72c3` is contained in current `main`
- exact signed head: `2fb36f1887f9732d93581706dcc44c1cfd8483a6`
- stable semantic patch ID: `8bb99517ecde8212ee326fcc6304e74e447fe644`
- exact scope: five files, 2,668 insertions and 273 deletions
- behavioral checkpoint C2 remains gated on this C1 checkpoint merging to `main`

## Validation

- `pnpm exec vitest run tests/issue-4550-linear-ir-census.test.ts`: 12/12 passed, including process-absent and exact-switch controls
- all existing `getLastLinearIrReport` test consumers: 20 passed, 2 intentional skips across 4 files
- `pnpm run check:linear-ir`: PASS; files=13, compiled=10, buckets={select:async-function:4, select:body-shape-rejected:24, select:call-graph-closure:11}
- `pnpm run build:playground`: PASS; 2,277 modules transformed
- `pnpm run typecheck` and `pnpm run typecheck:ts5`: PASS
- scoped Prettier and Biome: PASS
- IR layering, dialect, fallback, LOC-regrowth, function-budget, oracle, and coercion ratchets: PASS
- normal pre-push hook: PASS with no skips; typecheck/lint, repository-wide format, oracle/coercion ratchets, numeric-local parity 18/18, and issue integrity
- push load gate: 5.96484375 on 10 logical cores, strictly below the cores−2 limit of 8
