### PR TITLE
docs(ir): lock #3525 whole-program M0 census ✓

### DIFF
--- a/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
+++ b/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
@@ -1,10 +1,12 @@
 ---
 id: 3525
 title: "IR-only R5: whole-program single- and multi-source Prepared ownership"
-status: blocked
-sprint: Backlog
+status: in-progress
+sprint: current
 created: 2026-07-21
-updated: 2026-07-21
+updated: 2026-08-26
+assignee: ttraenkler/codex
+branch: codex/3525-m0-program-container-plan
 priority: critical
 horizon: xl
 complexity: XL
@@ -20,7 +22,7 @@ model: gpt-5.6-sol
 parent: 3518
 depends_on: [3520, 3521, 3522, 3523]
 required_by: [3527, 3528]
-related: [1277, 1983, 2138, 2771, 2930, 2931, 3142, 3214, 3493, 3495, 3505, 3518]
+related: [1277, 1983, 2138, 2771, 2930, 2931, 3142, 3214, 3493, 3495, 3505, 3518, 4589, 4590, 4591]
 origin: "#3518 R5 — replace per-source M0 overlays with one whole-program preparation owner"
 files:
   - src/index.ts
@@ -131,6 +133,262 @@ ordered source set and entry source exactly once. It must produce:
 Single-source compilation must call this same entry with a one-element source
 set. Maintaining a separate single-source semantic planner would leave two
 front-ends and make R8 backend convergence unprovable.
+
+## M0 implementation lock — whole-program census and coordinator (2026-08-26)
+
+This section supersedes the generic M0 wording below for the next bounded
+implementation PR. It is grounded on current `origin/main` at
+`d86ebfb89fd20fb328cdf5206b5a296681134c78` and deliberately does **not** call
+the present structural candidate API production-ready.
+
+### Current-main facts that constrain M0
+
+`generateMultiModule` already creates one `IrUnitInventory`, one
+`IrPlanningIdentityContext`, and one `ProgramAbiSession` over the complete
+`MultiTypedAST`. The missing owner is the route lifecycle around those shared
+objects:
+
+- `planEarlyMultiIrOverlay` independently invokes the scalar, array,
+  function-value, and Fibonacci-pair route planners, merges their mutable
+  `Map<SourceFile, EarlyMultiPreparedScalarLeafState>` results, and rejects
+  overlap only at the source-file level.
+- The direct-body loop consumes that map once per source. The later
+  `compileMultiIrOverlaySource` loop consumes it again and otherwise creates a
+  fresh per-source plan with `resolveModuleBindings: false` after direct bodies
+  exist. There is no immutable program object proving which exact terminal
+  units were reserved before the body boundary and which remained unreserved.
+- The already-landed standalone cutovers are real Prepared routes: #4589
+  scalar leaf, #4590 function-value benchmark leaf, #4591 Fibonacci pair, and
+  #3518 numeric array leaf. They must become registrations in one owner rather
+  than four precedents for more route-specific maps.
+- `src/ir/program.ts` and `src/ir/prepare.ts` explicitly label their
+  `PreparedIrProgram` records `unvalidated-candidate`, set
+  `reconciliation: "pending-production-wiring"`, and accept only
+  `top-level-function` terminals. Production uses that API nowhere outside
+  `tests/issue-3521-prepared-ir-program.test.ts`. M0 must not populate it with
+  invented direct candidates for classes/module init or present it as the
+  production ownership proof.
+- `ProgramAbiSession` is the production ABI transaction. Its per-component
+  scopes seal genuine Prepared dependencies, while the one final `publish`
+  reconciles the complete inventory. M0 must bind to that exact session and
+  inventory, not build a second `ProgramAbiMap` or a test-only shadow ABI.
+
+The bounded checkpoint is therefore a behavior-preserving program census and
+coordinator. It moves the existing pre-body routes under one exact owner and
+creates the lifecycle seam that M1 can widen. It does not pre-plan late routes
+whose lowering still depends on legacy-populated registries, and it does not
+claim the final R5 acceptance criteria early.
+
+### Exact production shape
+
+Add `src/codegen/multi-prepared-program.ts` with a single stateful construction
+owner and immutable snapshots. Names may vary only to fit repository style;
+the following semantics are fixed:
+
+```ts
+type MultiPreparedProgramState =
+  | "collecting"
+  | "body-boundary-sealed"
+  | "routes-complete"
+  | "complete"
+  | "failed";
+
+interface MultiPreparedProgramSourceCensus {
+  sourceId: IrSourceId;
+  sourceKey: string;
+  canonicalOrder: number;
+  semanticOrder: number;
+  kind: IrSourceKind;
+  terminalUnitIds: readonly IrUnitId[];
+}
+
+interface MultiPreparedProgramReservation {
+  unitId: IrUnitId;
+  sourceId: IrSourceId;
+  routeKind: "scalar" | "array" | "function-value" | "fibonacci-pair";
+  preparedComponentId: string;
+  preparedBeforeDirectBodies: true;
+}
+
+interface MultiPreparedProgramBodyPlan<Plan> {
+  schema: "multi-prepared-program-body-plan-v1";
+  entrySourceId: IrSourceId;
+  canonicalSourceIds: readonly IrSourceId[];
+  semanticSourceIds: readonly IrSourceId[];
+  expectedBodySourceIds: readonly IrSourceId[];
+  expectedOverlaySourceIds: readonly IrSourceId[];
+  terminalUnitIds: readonly IrUnitId[];
+  sources: readonly MultiPreparedProgramSourceCensus[];
+  reservations: readonly MultiPreparedProgramReservation[];
+  unreservedTerminalUnitIds: readonly IrUnitId[];
+}
+```
+
+The construction owner is created exactly once immediately after the shared
+identity context, ABI session, and `CodegenContext` are created. It receives
+the exact `MultiTypedAST`, identity context, and ABI session by object identity.
+It must fail closed unless:
+
+1. the ABI session inventory is the identity context inventory;
+2. every `MultiTypedAST.sourceFiles` object resolves to exactly one inventory
+   source and every inventory source resolves back to exactly one AST object;
+3. the entry file resolves to the one source whose kind is `entry`;
+4. canonical source order is exactly `inventory.sources[].order`, while the
+   separate semantic order is exactly `MultiTypedAST.sourceFiles` order; and
+5. every terminal record belongs to one known source and occurs exactly once in
+   both the whole denominator and its source-local denominator.
+
+After declaration allocation and the existing four early-route planners run,
+the owner seals one `MultiPreparedProgramBodyPlan`. The route planners remain
+the eligibility/lowering authorities for this checkpoint; they return their
+current states to the owner rather than directly to both body loops. Sealing
+must validate every stored state and reservation by exact object/identity join:
+
+- the source-file key is the exact object owned by the identity context;
+- each plan carries that same identity context/inventory;
+- each route declaration maps to its exact terminal `IrUnitId` and source;
+- scalar, array, and function-value routes reserve their one receipt unit;
+  Fibonacci reserves both the recursive and wrapper units under the one exact
+  prepared component ID;
+- every receipt is `kind: "prepared"`, every reserved unit is terminal and
+  top-level-function, and no unit/source/component is registered twice;
+- all route Prepared reports, completed/skip projections, allocated function
+  objects, and component IDs remain the exact objects already proved by the
+  route-specific validators; and
+- every terminal not reserved by an early route is listed once as
+  `unreservedTerminalUnitIds`. “Unreserved” describes the pre-body boundary;
+  it is not an invented claim that the unit will necessarily direct-emit or
+  cannot later receive the existing overlay.
+
+The frozen body plan, not the original mutable map, is then the only value
+consumed by both phases:
+
+1. the direct-body loop calls the coordinator's phase-checked
+   `stateForBodySource(sf)` and preserves the existing
+   skip/preserve/module-init behavior exactly;
+2. the late overlay loop calls `stateForOverlaySource(sf)`, reuses the early
+   `plan` where one exists, and preserves the current late per-source planning
+   fallback only for an unplanned source; and
+3. the owner records exact source visits for both phases. The expected body
+   sequence is always the semantic source sequence. The expected overlay
+   sequence is that same sequence only when the existing
+   `options.experimentalIR && !ctx.fast` loop is enabled, and is explicitly
+   empty otherwise; `trackIrOutcomes` alone must not manufacture an overlay
+   visit.
+
+The final audit is exposed only on `GeneratedCodegenModule` as internal
+codegen evidence (the public `CompileResult` need not grow in M0). It contains
+the body plan plus exact body-loop and overlay-loop source ID sequences and an
+`abiSessionBound: true` proof. After the late loop the owner seals its route
+visits as `routes-complete`; after `ProgramAbiSession.publish`, clean
+compilations pass that exact publication to `complete`, which asserts
+`publication.abi.inventory === identityContext.inventory` and creates the
+audit. The coordinator never seals or publishes ABI itself.
+
+All arrays/maps exposed by the body plan or audit must be defensively owned and
+runtime read-only. The existing route state remains private to the coordinator:
+its one required `skippedFunctionUnitIds` correlation mutation is permitted
+only during the body accessor/consumer pair, and the late accessor returns that
+same exact state afterward. The census never exposes the mutable state map.
+AST, route, Wasm function, report, and ABI objects may be referenced for
+identity validation but must not be cloned, replaced, or otherwise mutated.
+Repeated sealing/completion is allowed only as an idempotent read of the same
+result; any other post-seal mutation fails with a stable invariant code.
+
+### Required code movement and deletion
+
+The implementation PR owns only:
+
+- new `src/codegen/multi-prepared-program.ts`;
+- the narrow orchestration edits in `src/codegen/index.ts` needed to construct,
+  seal, consume, complete, and expose the program audit; and
+- new `tests/issue-3525-multi-prepared-program-census.test.ts` plus focused
+  updates to an existing route test only if an exact integration assertion
+  belongs beside its fixture.
+
+Do not edit `src/ir/program.ts`, `src/ir/prepare.ts`, `src/ir/program-abi.ts`,
+the four route selectors/lowerers, `src/codegen/declarations.ts`, or public
+compiler/index APIs in M0. If the coordinator cannot consume a route without
+changing its eligibility or lowering contract, stop and amend this plan rather
+than widening ownership opportunistically.
+
+Delete the hand-merged `scalarStates`/`arrayStates`/`functionValueStates`
+plumbing from `planEarlyMultiIrOverlay` as it becomes coordinator-owned. Do not
+add another route-kind switch in `generateMultiModule`; route enumeration and
+reservation extraction belong in the new owner. No LOC-budget allowance,
+function-budget allowance, baseline change, or size-regression exception is
+authorized. Run `pnpm run check:loc-budget` immediately before committing.
+
+### Mutation and integration proof
+
+The new focused test must exercise the owner directly with table-driven
+mutations and through real `generateMultiModule` fixtures.
+
+Direct mutations must reject, with stable codes:
+
+1. missing/duplicate/foreign source object or source ID;
+2. missing/duplicate/reordered canonical source record;
+3. missing/duplicate/foreign entry source;
+4. missing/duplicate terminal in either whole or source-local denominator;
+5. terminal attached to the wrong source;
+6. route stored under the wrong source object;
+7. unknown, non-terminal, cross-source, or duplicate reserved unit;
+8. duplicate prepared component ID across distinct components;
+9. Fibonacci with only one member, distinct component IDs, or reversed
+   receipt ownership;
+10. stale identity context, plan, declaration, receipt, Prepared report,
+    skip projection, or allocated function object;
+11. missing/duplicate/out-of-order body or overlay source visit;
+12. completion before both visit censuses, mutation after seal, and a different
+    second seal/completion input; and
+13. an ABI publication whose inventory is not the construction inventory.
+
+Positive structural controls must prove two sources may contain the same
+display-name function while retaining distinct source/unit IDs, and that
+reordering a test-only `Map` insertion does not change the canonical snapshot.
+Semantic source-order reversal is represented separately and must never rewrite
+canonical identities.
+
+Real standalone integration controls must cover all four current early routes:
+
+- #4589 exact scalar leaf: one scalar reservation;
+- #4590 benchmark loop: one function-value reservation with its existing
+  support receipt unchanged;
+- #4591 Fibonacci: two reserved terminals, one component ID;
+- #3518 benchmark numeric array leaf: one array reservation (including its optional
+  function-value support receipt without manufacturing another terminal);
+- each route’s existing kill switch: identical source/terminal census, zero
+  corresponding early reservation, and unchanged late/direct behavior; and
+- a non-candidate multi-source fixture: complete denominator, no reservation,
+  and exact source visits.
+
+For every lane, retain the existing direct-body poison, Prepared outcome,
+Program ABI object/slot, raw and optimized body, surface, runtime, and no-growth
+assertions from the route-specific suites. M0 adds ownership evidence; it may
+not weaken or replace those oracles. An injected coordinator failure must occur
+before the first direct body, while a clean lane must remain artifact- and
+runtime-equivalent to current main.
+
+### Validation and checkpoint boundary
+
+Before commit and push, with the strict finite/nonnegative one-minute load gate
+`load < logicalCores - 2`:
+
+1. run TypeScript validation and the new #3525 test;
+2. run #4589, #4590, #4591, and the #3518 benchmark-array cutover together;
+3. run #2138 multi-module overlay plus the multi-file/equivalence suites named
+   below;
+4. run the IR fallback/neutrality and issue-integrity gates;
+5. run `pnpm run check:loc-budget` immediately before the signed commit; and
+6. allow the complete precommit and prepush hooks to run without bypass.
+
+M0 is complete only when one integrated program owner supplies both body loops,
+the exact source/terminal/reservation census is published, all mutations fail
+closed, all prior route evidence remains green, and the old hand-merged map
+plumbing is deleted. It does **not** complete #3525: M1 must move cross-file
+binding/call components into pre-body preparation; M2 must move classes,
+closures, globals, and ordered module init; final R5 must converge the
+single-source entry and delete the late per-source overlay and flat-name gates.
 
 ## Ownership and resolution invariants
 


### PR DESCRIPTION
## Summary

- reground #3525 on the current multi-source IR and Program ABI architecture
- lock one fail-closed whole-program source, terminal, and pre-body reservation census
- move the four existing standalone Prepared routes toward one coordinator without claiming the unvalidated PreparedIrProgram candidate API is production-ready
- define exact mutations, deletion targets, integration proofs, and the M1/M2 boundary

## Validation

- Prettier check passed for the issue plan
- issue integrity and staged issue-ID checks passed
- LOC and function regrowth ratchets passed
- complete precommit hooks passed, including changed-root and oracle gates
- complete prepush hooks passed: typecheck, lint, repository format, oracle, coercion, #3765 (18/18), and issue integrity
- strict load gate passed at commit and push: 10 logical cores, limit 8

## Scope

Planning-only checkpoint. No compiler routing or runtime behavior changes.

Refs #3525