### PR TITLE
fix(codegen): enforce #4755 module lexical assignment TDZ

### DIFF
--- a/plan/issues/4755-legacy-module-lexical-assignment-tdz.md
+++ b/plan/issues/4755-legacy-module-lexical-assignment-tdz.md
@@ -343,3 +343,38 @@ while hybrid fallback remains reachable; #3090/R10 deletes the direct
 assignment handler only after reachability proves every supported module
 lexical write is Prepared or fails with a typed pre-emission outcome. Do not
 preserve this helper as a second frontend below the final IR-only boundary.
+
+## Implementation handover (2026-08-26)
+
+PR #4997 implements the bounded prerequisite above on current `main`. The
+shared writer now uses exact source/checker identity for ordinary and
+precomputed module-lexical writes, keeps dynamic/ambient/import/foreign/
+unresolvable carriers on their existing routes, re-reads mutable global
+indices after provider settlement, and keeps detached default-arm bodies live
+through final branch attachment. The production diff adds no LOC/function
+allowance and does not widen a baseline.
+
+The changed-root proof is 48/48: 46 rows in
+`tests/issue-4755-module-lexical-assignment-tdz.test.ts` plus two detached-body
+rows in `tests/issue-4755-detached-assignment-repoint.test.ts`, across direct GC
+and standalone as applicable. TypeScript 7/5, IR layering, optimization
+retirement, fallback/oracle/coercion ratchets, LOC/function budgets, formatting,
+and the normal precommit hook passed on the merged bytes. In the required
+`tests/issue-4259-class-accessor-outer-writeback-ir.test.ts` control, every
+#4755-relevant TDZ row passes; four other rows fail identically on a detached
+clean `origin/main` worktree and therefore remain a pre-existing #4259 baseline
+defect rather than a waiver or a regression introduced here.
+
+The continuation boundary is explicit:
+
+- #4260 still owns the injected pre-seal transaction rerun after #4997 lands;
+- #1719 owns the standalone CPR iterator producer/consumer contract exposed by
+  the isolated destructuring row; and
+- #3518 R9/#3090 R10 must preserve this matrix while moving the writer into IR
+  ownership and then delete this temporary direct-frontend seam.
+
+PR #4997 was re-anchored without a force push so its final tree is based on
+current `main` and excludes stale generated Test262 reports. Merge-queue,
+ordinary merge-commit, or squash landing is safe; do not use rebase-and-merge
+for this PR because replaying its preserved pre-anchor history can resurrect
+those unrelated generated artifacts.

--- a/plan/issues/4755-legacy-module-lexical-assignment-tdz.md
+++ b/plan/issues/4755-legacy-module-lexical-assignment-tdz.md
@@ -243,6 +243,21 @@ body cannot hide a direct-body failure.
    property/default/iterator work, the TDZ throw before storage mutation, and
    no later binding write after abrupt completion. Rest and nested-pattern
    support remain outside this issue and are not acceptance substitutes.
+
+   Measured boundary correction (2026-08-26): do not make this transitional
+   writer repair absorb the existing iterator backends. The GC generator used
+   by the issue-1719 CPR shape eagerly buffers past the first yield (#2566,
+   architectural owner #2662), while its standalone CPR carrier still traps in
+   `__iterator_next` (the residual producer/consumer contract described by
+   #2038/#3164). The GC row therefore must not pretend to prove per-yield
+   suspension; it must prove the override runs and the first target throws
+   before either target is written. The standalone row must compile the exact
+   guarded CPR route with
+   zero host imports and structural `__drive_proto_iterator`,
+   `__iterator_next`, and live ReferenceError-provider evidence. All eight
+   ordinary typed/externref plain/default sinks remain runtime-required in both
+   lanes. Reopen/update #1719 for its untested standalone-clean promise. This is
+   not an iterator-semantics waiver or a substitute for those owners.
 4. **Static/elided control.** An assignment provably after initialization must
    execute without a throw and must not manufacture a TDZ provider/import or
    in-module error-constructor call solely for that write. A `var` twin remains

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -119,6 +119,7 @@ import {
 import { emitMappedArgParamSync, emitMappedArgReverseSync } from "./logical-ops.js";
 import { resolveStructName, resolveStructNameForExpr } from "./misc.js";
 import { tryCompileStandaloneRegExpLastIndexWrite } from "../regexp-standalone.js";
+import { emitResolvedIdentifierWriteFromStack } from "./identifier-assignment.js";
 import { tryCompileStandaloneDetachedWrite } from "../dataview-native.js"; // (#3173) $DETACHBUFFER marker write
 import { externrefBackedOwnFieldBacking, getOrRegisterErrorStructType } from "../registry/error-types.js";
 import { tryEmitErrorInstanceFieldWrite } from "../error-instance-field-write.js";
@@ -197,6 +198,16 @@ function emitExternrefAssignDestructureGuard(ctx: CodegenContext, fctx: Function
       then: buildDestructureNullThrow(ctx, fctx),
       else: [],
     });
+  }
+}
+
+function buildDetachedAssignmentBody(fctx: FunctionContext, emit: () => void): Instr[] {
+  const saved = pushBody(fctx);
+  try {
+    emit();
+    return fctx.body;
+  } finally {
+    popBody(fctx, saved);
   }
 }
 
@@ -715,9 +726,9 @@ export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, ex
           ts.isArrowFunction(expr.right) ||
           (ts.isIdentifier(expr.right) && ctx.funcMap.has(expr.right.text)));
       if (runtimeEvalAotFunctionWrite) emitRuntimeEvalAotCallableAdapter(ctx, fctx);
-      // Re-read index: RHS compilation may shift globals via addStringConstantGlobal
+      emitResolvedIdentifierWriteFromStack(ctx, fctx, expr.left, globalType ?? resultType, undefined, moduleIdx);
+      // Re-read index: RHS compilation and the TDZ guard may settle globals.
       const moduleIdxPost = ctx.moduleGlobals.get(name)!;
-      fctx.body.push({ op: "global.set", index: moduleIdxPost });
       fctx.body.push({ op: "global.get", index: moduleIdxPost });
       return globalType ?? resultType;
     }
@@ -955,13 +966,8 @@ export function emitIdentifierWriteFromLocal(
 
   const moduleIdx = ctx.moduleGlobals.get(name);
   if (moduleIdx !== undefined) {
-    const globalDef = ctx.mod.globals[localGlobalIdx(ctx, moduleIdx)];
-    const globalType = globalDef?.type;
     fctx.body.push({ op: "local.get", index: rhsLocalIdx });
-    if (globalType && globalType.kind !== "externref") {
-      coerceType(ctx, fctx, { kind: "externref" }, globalType);
-    }
-    fctx.body.push({ op: "global.set", index: ctx.moduleGlobals.get(name)! });
+    emitResolvedIdentifierWriteFromStack(ctx, fctx, id, { kind: "externref" }, undefined, moduleIdx);
     return;
   }
 
@@ -1244,10 +1250,12 @@ function compileDestructuringAssignment(
           // the binding and never fired the default. (#2845)
           let keyName: string | undefined;
           let targetName: string | undefined;
+          let targetIdentifier: ts.Identifier | undefined;
           let propDefault: ts.Expression | undefined;
           if (ts.isShorthandPropertyAssignment(prop)) {
             keyName = prop.name.text;
             targetName = keyName;
+            targetIdentifier = prop.name;
             propDefault = prop.objectAssignmentInitializer;
           } else if (ts.isPropertyAssignment(prop)) {
             keyName =
@@ -1263,15 +1271,18 @@ function compileDestructuringAssignment(
               propDefault = te.right;
               te = te.left;
             }
-            if (ts.isIdentifier(te)) targetName = te.text;
+            if (ts.isIdentifier(te)) {
+              targetName = te.text;
+              targetIdentifier = te;
+            }
           }
-          if (keyName === undefined || targetName === undefined) continue;
+          if (keyName === undefined || targetName === undefined || targetIdentifier === undefined) continue;
           const name = targetName;
 
           // Resolve write target: local first, then module global. Allocate
           // a local only if neither exists.
           let localIdx = fctx.localMap.get(name);
-          let moduleGlobalIdx = ctx.moduleGlobals.get(name);
+          const moduleGlobalIdx = ctx.moduleGlobals.get(name);
           let targetType: ValType;
           if (localIdx !== undefined) {
             targetType = getLocalType(fctx, localIdx) ?? { kind: "externref" as const };
@@ -1300,17 +1311,18 @@ function compileDestructuringAssignment(
             // The value is currently on the Wasm stack as externref. Coerce
             // and then set. We append into `instrs` so the caller can splice
             // it into a then/else branch.
-            if (!valTypesMatch({ kind: "externref" }, targetType)) {
-              const saved = fctx.body;
-              fctx.body = instrs;
-              coerceType(ctx, fctx, { kind: "externref" }, targetType);
-              fctx.body = saved;
-            }
-            if (localIdx !== undefined) {
-              instrs.push({ op: "local.set", index: localIdx });
-            } else if (moduleGlobalIdx !== undefined) {
-              instrs.push({ op: "global.set", index: moduleGlobalIdx });
-            }
+            instrs.push(
+              ...buildDetachedAssignmentBody(fctx, () => {
+                emitResolvedIdentifierWriteFromStack(
+                  ctx,
+                  fctx,
+                  targetIdentifier,
+                  { kind: "externref" },
+                  localIdx,
+                  moduleGlobalIdx,
+                );
+              }),
+            );
           };
 
           if (propDefault) {
@@ -1321,21 +1333,12 @@ function compileDestructuringAssignment(
             fctx.body.push({ op: "call", funcIdx: undefIdx });
 
             // then-branch: compile default into target
-            const trueInstrs: Instr[] = [];
-            const savedTrueBody = fctx.body;
-            fctx.body = trueInstrs;
-            const initType = compileExpression(ctx, fctx, propDefault, targetType);
-            if (initType && !valTypesMatch(initType, targetType)) {
-              coerceType(ctx, fctx, initType, targetType);
-            }
-            fctx.body = savedTrueBody;
-            if (localIdx !== undefined) {
-              trueInstrs.push({ op: "local.set", index: localIdx });
-            } else if (moduleGlobalIdx !== undefined) {
-              // Re-read in case compileExpression shifted indices.
-              moduleGlobalIdx = ctx.moduleGlobals.get(name)!;
-              trueInstrs.push({ op: "global.set", index: moduleGlobalIdx });
-            }
+            const trueInstrs = buildDetachedAssignmentBody(fctx, () => {
+              const initType = compileExpression(ctx, fctx, propDefault, targetType);
+              if (initType) {
+                emitResolvedIdentifierWriteFromStack(ctx, fctx, targetIdentifier, initType, localIdx, moduleGlobalIdx);
+              }
+            });
 
             // else-branch: forward the read value (with optional coerce)
             const elseInstrs: Instr[] = [{ op: "local.get", index: tmpVal }];
@@ -1353,7 +1356,7 @@ function compileDestructuringAssignment(
             fctx.body.push({ op: "local.get", index: tmpVal });
             const tail: Instr[] = [];
             emitSetTarget(tail);
-            for (const i of tail) fctx.body.push(i);
+            fctx.body.push(...tail);
           }
         }
       } else {
@@ -1417,9 +1420,8 @@ function compileDestructuringAssignment(
 
   // Null guard for ref_null types
   const isNullableDA = resultType.kind === "ref_null";
-  const savedBodyDA = fctx.body;
-  const destructInstrsDA: Instr[] = [];
-  fctx.body = destructInstrsDA;
+  const savedBodyDA = pushBody(fctx);
+  const destructInstrsDA = fctx.body;
   // (#2869) See compileArrayDestructuringAssignment — keep the detached buffer
   // reachable by the func-idx/global repoint passes for the member-target
   // (`{k: x.y} = src`) dispatcher `call`; deleted after the splice.
@@ -1431,7 +1433,7 @@ function compileDestructuringAssignment(
       // { width } = ... → prop.name is "width"
       const propName = prop.name.text;
       let localIdx = fctx.localMap.get(propName);
-      let moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(propName) : undefined;
+      const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(propName) : undefined;
 
       const fieldIdx = fields.findIndex((f) => f.name === propName);
 
@@ -1465,12 +1467,7 @@ function compileDestructuringAssignment(
         if (initType && !valTypesMatch(initType, targetType)) {
           coerceType(ctx, fctx, initType, targetType);
         }
-        if (localIdx !== undefined) {
-          fctx.body.push({ op: "local.set", index: localIdx });
-        } else {
-          moduleGlobalIdx = ctx.moduleGlobals.get(propName)!;
-          fctx.body.push({ op: "global.set", index: moduleGlobalIdx });
-        }
+        emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, targetType, localIdx, moduleGlobalIdx);
         continue;
       }
 
@@ -1519,12 +1516,14 @@ function compileDestructuringAssignment(
               ...(() => {
                 const saved = fctx.body;
                 fctx.body = [];
-                compileExpression(ctx, fctx, prop.objectAssignmentInitializer!, targetType ?? fieldType);
-                if (localIdx !== undefined) {
-                  fctx.body.push({ op: "local.set", index: localIdx });
-                } else {
-                  moduleGlobalIdx = ctx.moduleGlobals.get(propName)!;
-                  fctx.body.push({ op: "global.set", index: moduleGlobalIdx });
+                const initType = compileExpression(
+                  ctx,
+                  fctx,
+                  prop.objectAssignmentInitializer!,
+                  targetType ?? fieldType,
+                );
+                if (initType) {
+                  emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, initType, localIdx, moduleGlobalIdx);
                 }
                 const instrs = fctx.body;
                 fctx.body = saved;
@@ -1544,32 +1543,28 @@ function compileDestructuringAssignment(
                 }
                 return [];
               })(),
-              localIdx !== undefined
-                ? { op: "local.set", index: localIdx }
-                : { op: "global.set", index: ctx.moduleGlobals.get(propName)! },
+              ...(() => {
+                const saved = fctx.body;
+                fctx.body = [];
+                emitResolvedIdentifierWriteFromStack(
+                  ctx,
+                  fctx,
+                  prop.name,
+                  targetType ?? fieldType,
+                  localIdx,
+                  moduleGlobalIdx,
+                );
+                const instrs = fctx.body;
+                fctx.body = saved;
+                return instrs;
+              })(),
             ],
           });
         } else {
-          // Coerce field type to local type if needed
-          if (targetType && !valTypesMatch(fieldType, targetType)) {
-            coerceType(ctx, fctx, fieldType, targetType);
-          }
-          fctx.body.push(
-            localIdx !== undefined
-              ? { op: "local.set", index: localIdx }
-              : { op: "global.set", index: ctx.moduleGlobals.get(propName)! },
-          );
+          emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, fieldType, localIdx, moduleGlobalIdx);
         }
       } else {
-        // Coerce field type to local type if needed
-        if (targetType && !valTypesMatch(fieldType, targetType)) {
-          coerceType(ctx, fctx, fieldType, targetType);
-        }
-        fctx.body.push(
-          localIdx !== undefined
-            ? { op: "local.set", index: localIdx }
-            : { op: "global.set", index: ctx.moduleGlobals.get(propName)! },
-        );
+        emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, fieldType, localIdx, moduleGlobalIdx);
       }
     } else if (ts.isPropertyAssignment(prop)) {
       let propName = ts.isIdentifier(prop.name)
@@ -1610,11 +1605,18 @@ function compileDestructuringAssignment(
         if (defaultExpr && ts.isIdentifier(targetExpr)) {
           const localName = targetExpr.text;
           let localIdx = fctx.localMap.get(localName);
-          if (localIdx === undefined) localIdx = allocLocal(fctx, localName, { kind: "externref" });
-          const targetType = getLocalType(fctx, localIdx) ?? { kind: "externref" as const };
+          const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+          if (localIdx === undefined && moduleGlobalIdx === undefined) {
+            localIdx = allocLocal(fctx, localName, { kind: "externref" });
+          }
+          const targetType =
+            localIdx !== undefined
+              ? (getLocalType(fctx, localIdx) ?? { kind: "externref" as const })
+              : (ctx.mod.globals[localGlobalIdx(ctx, moduleGlobalIdx!)]?.type ?? { kind: "externref" as const });
           const initType = compileExpression(ctx, fctx, defaultExpr, targetType);
-          if (initType && !valTypesMatch(initType, targetType)) coerceType(ctx, fctx, initType, targetType);
-          fctx.body.push({ op: "local.set", index: localIdx });
+          if (initType) {
+            emitResolvedIdentifierWriteFromStack(ctx, fctx, targetExpr, initType, localIdx, moduleGlobalIdx);
+          }
           continue;
         }
         reportSilentFallback(ctx, "lookup-miss-skip", "assignment:destructure-assign-property-field-miss", prop);
@@ -1626,13 +1628,17 @@ function compileDestructuringAssignment(
         // { prop: ident } or { prop: ident = default }
         const localName = targetExpr.text;
         let localIdx = fctx.localMap.get(localName);
+        const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
 
         // Auto-allocate local if not declared
-        if (localIdx === undefined) {
+        if (localIdx === undefined && moduleGlobalIdx === undefined) {
           localIdx = allocLocal(fctx, localName, fieldType);
         }
 
-        const localType = getLocalType(fctx, localIdx);
+        const targetType =
+          localIdx !== undefined
+            ? getLocalType(fctx, localIdx)
+            : ctx.mod.globals[localGlobalIdx(ctx, moduleGlobalIdx!)]?.type;
 
         fctx.body.push({ op: "local.get", index: tmpLocal });
         fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
@@ -1671,11 +1677,10 @@ function compileDestructuringAssignment(
                 ...(() => {
                   const saved = fctx.body;
                   fctx.body = [];
-                  compileExpression(ctx, fctx, defaultExpr!, localType ?? fieldType);
-                  fctx.body.push({
-                    op: "local.set",
-                    index: localIdx!,
-                  });
+                  const initType = compileExpression(ctx, fctx, defaultExpr!, targetType ?? fieldType);
+                  if (initType) {
+                    emitResolvedIdentifierWriteFromStack(ctx, fctx, targetExpr, initType, localIdx, moduleGlobalIdx);
+                  }
                   const instrs = fctx.body;
                   fctx.body = saved;
                   return instrs;
@@ -1684,32 +1689,22 @@ function compileDestructuringAssignment(
               else: [
                 { op: "local.get", index: tmpField },
                 ...(() => {
-                  if (localType && !valTypesMatch(fieldType, localType)) {
-                    const saved = fctx.body;
-                    fctx.body = [];
-                    coerceType(ctx, fctx, fieldType, localType);
-                    const instrs = fctx.body;
-                    fctx.body = saved;
-                    return instrs;
-                  }
-                  return [];
+                  const saved = fctx.body;
+                  fctx.body = [];
+                  emitResolvedIdentifierWriteFromStack(ctx, fctx, targetExpr, fieldType, localIdx, moduleGlobalIdx);
+                  const instrs = fctx.body;
+                  fctx.body = saved;
+                  return instrs;
                 })(),
-                { op: "local.set", index: localIdx! },
               ],
             });
           } else {
             // Numeric field — just set the value (no undefined check needed for primitives)
-            if (localType && !valTypesMatch(fieldType, localType)) {
-              coerceType(ctx, fctx, fieldType, localType);
-            }
-            fctx.body.push({ op: "local.set", index: localIdx });
+            emitResolvedIdentifierWriteFromStack(ctx, fctx, targetExpr, fieldType, localIdx, moduleGlobalIdx);
           }
         } else {
           // No default — just coerce and set
-          if (localType && !valTypesMatch(fieldType, localType)) {
-            coerceType(ctx, fctx, fieldType, localType);
-          }
-          fctx.body.push({ op: "local.set", index: localIdx });
+          emitResolvedIdentifierWriteFromStack(ctx, fctx, targetExpr, fieldType, localIdx, moduleGlobalIdx);
         }
       } else if (ts.isObjectLiteralExpression(targetExpr)) {
         // { prop: { nested } } — nested destructuring
@@ -1792,7 +1787,7 @@ function compileDestructuringAssignment(
 
   // Close null guard — throw TypeError if null/undefined (#783).
   // Skip for empty `{} = val` patterns (#225).
-  fctx.body = savedBodyDA;
+  popBody(fctx, savedBodyDA);
   if (isNullableDA && target.properties.length > 0) {
     const throwInstrs = buildDestructureNullThrow(ctx, fctx);
     fctx.body.push({ op: "local.get", index: tmpLocal });
@@ -1887,33 +1882,14 @@ function tryEmitArrayProtoIteratorAssignDrive(
       // When done (iterator exhausted), the spec value is `undefined`; leave the
       // local untouched (the targets already exist / hold their prior value) —
       // the 71 assignment tests yield concrete values, never short.
-      if (localIdx !== undefined) {
-        const localType = getLocalType(fctx, localIdx) ?? ({ kind: "externref" } as ValType);
+      if (localIdx !== undefined || globalIdx !== undefined) {
         const assignBody: Instr[] = [];
         const sb = fctx.body;
         fctx.savedBodies.push(sb);
         fctx.body = assignBody;
         try {
           fctx.body.push({ op: "local.get", index: valLocal });
-          coerceType(ctx, fctx, { kind: "externref" }, localType);
-          fctx.body.push({ op: "local.set", index: localIdx });
-        } finally {
-          fctx.body = sb;
-          fctx.savedBodies.pop();
-        }
-        fctx.body.push({ op: "local.get", index: doneLocal });
-        fctx.body.push({ op: "i32.eqz" });
-        fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: assignBody, else: [] });
-      } else if (globalIdx !== undefined) {
-        const gType = ctx.mod.globals[globalIdx]?.type ?? ({ kind: "externref" } as ValType);
-        const assignBody: Instr[] = [];
-        const sb = fctx.body;
-        fctx.savedBodies.push(sb);
-        fctx.body = assignBody;
-        try {
-          fctx.body.push({ op: "local.get", index: valLocal });
-          coerceType(ctx, fctx, { kind: "externref" }, gType as ValType);
-          fctx.body.push({ op: "global.set", index: globalIdx });
+          emitResolvedIdentifierWriteFromStack(ctx, fctx, el, { kind: "externref" }, localIdx, globalIdx);
         } finally {
           fctx.body = sb;
           fctx.savedBodies.pop();
@@ -2047,9 +2023,8 @@ function compileArrayDestructuringAssignment(
 
   // Null guard for ref_null types
   const isNullableADA = resultType.kind === "ref_null";
-  const savedBodyADA = fctx.body;
-  const arrDestructInstrsADA: Instr[] = [];
-  fctx.body = arrDestructInstrsADA;
+  const savedBodyADA = pushBody(fctx);
+  const arrDestructInstrsADA = fctx.body;
   // (#2869) Keep the detached element buffer reachable by the late-import
   // func-idx repoint pass (`shiftLateImportIndices`) AND the module-global
   // shift (`fixupModuleGlobalIndices`) — both walk `ctx.liveBodies`. A member
@@ -2236,15 +2211,12 @@ function compileArrayDestructuringAssignment(
     if (ts.isIdentifier(element)) {
       const localName = element.text;
       let localIdx = fctx.localMap.get(localName);
-      if (localIdx === undefined) {
+      const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+      if (localIdx === undefined && moduleGlobalIdx === undefined) {
         localIdx = allocLocal(fctx, localName, elemType);
       }
       emitElementGet(i);
-      const localType = getLocalType(fctx, localIdx);
-      if (localType && !valTypesMatch(elemType, localType)) {
-        coerceType(ctx, fctx, elemType, localType);
-      }
-      fctx.body.push({ op: "local.set", index: localIdx });
+      emitResolvedIdentifierWriteFromStack(ctx, fctx, element, elemType, localIdx, moduleGlobalIdx);
     } else if (ts.isPropertyAccessExpression(element)) {
       emitElementGet(i);
       const tmpElem = allocLocal(fctx, `__arr_elem_${fctx.locals.length}`, elemType);
@@ -2271,7 +2243,7 @@ function compileArrayDestructuringAssignment(
       if (ts.isIdentifier(assignTarget)) {
         const localName = assignTarget.text;
         let localIdx = fctx.localMap.get(localName);
-        let moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+        const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
         if (localIdx === undefined && moduleGlobalIdx === undefined) {
           localIdx = allocLocal(fctx, localName, elemType);
         }
@@ -2358,12 +2330,9 @@ function compileArrayDestructuringAssignment(
         const thenInit: Instr[] = (() => {
           const saved = fctx.body;
           fctx.body = [];
-          compileExpression(ctx, fctx, defaultExpr, targetType ?? elemType);
-          if (localIdx !== undefined) {
-            fctx.body.push({ op: "local.set", index: localIdx });
-          } else {
-            moduleGlobalIdx = ctx.moduleGlobals.get(localName)!;
-            fctx.body.push({ op: "global.set", index: moduleGlobalIdx });
+          const initType = compileExpression(ctx, fctx, defaultExpr, targetType ?? elemType);
+          if (initType) {
+            emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, initType, localIdx, moduleGlobalIdx);
           }
           const instrs = fctx.body;
           fctx.body = saved;
@@ -2373,12 +2342,7 @@ function compileArrayDestructuringAssignment(
           const saved = fctx.body;
           fctx.body = [];
           fctx.body.push({ op: "local.get", index: tmpElem });
-          if (targetType && !valTypesMatch(elemValType, targetType)) coerceType(ctx, fctx, elemValType, targetType);
-          if (localIdx !== undefined) {
-            fctx.body.push({ op: "local.set", index: localIdx });
-          } else {
-            fctx.body.push({ op: "global.set", index: ctx.moduleGlobals.get(localName)! });
-          }
+          emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, elemValType, localIdx, moduleGlobalIdx);
           const instrs = fctx.body;
           fctx.body = saved;
           return instrs;
@@ -2485,7 +2449,7 @@ function compileArrayDestructuringAssignment(
 
   // Close null guard — throw TypeError if null/undefined (#783).
   // Skip for empty `[] = val` patterns (#225).
-  fctx.body = savedBodyADA;
+  popBody(fctx, savedBodyADA);
   if (isNullableADA && target.elements.length > 0) {
     const throwInstrs = buildDestructureNullThrow(ctx, fctx);
     fctx.body.push({ op: "local.get", index: tmpLocal });
@@ -2625,14 +2589,11 @@ function compileExternrefArrayDestructuringAssignment(
     if (ts.isIdentifier(element)) {
       const localName = element.text;
       let localIdx = fctx.localMap.get(localName);
-      if (localIdx === undefined) {
+      const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+      if (localIdx === undefined && moduleGlobalIdx === undefined) {
         localIdx = allocLocal(fctx, localName, elemType);
       }
-      const localType = getLocalType(fctx, localIdx);
-      if (localType && !valTypesMatch(elemType, localType)) {
-        coerceType(ctx, fctx, elemType, localType);
-      }
-      fctx.body.push({ op: "local.set", index: localIdx });
+      emitResolvedIdentifierWriteFromStack(ctx, fctx, element, elemType, localIdx, moduleGlobalIdx);
     } else if (ts.isPropertyAccessExpression(element) || ts.isElementAccessExpression(element)) {
       const tmpElem = allocLocal(fctx, `__ext_arr_elem_${fctx.locals.length}`, elemType);
       fctx.body.push({ op: "local.set", index: tmpElem });
@@ -2652,7 +2613,8 @@ function compileExternrefArrayDestructuringAssignment(
       if (ts.isIdentifier(assignTarget)) {
         const localName = assignTarget.text;
         let localIdx = fctx.localMap.get(localName);
-        if (localIdx === undefined) {
+        const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+        if (localIdx === undefined && moduleGlobalIdx === undefined) {
           localIdx = allocLocal(fctx, localName, elemType);
         }
         const tmpElem = allocLocal(fctx, `__ext_dflt_${fctx.locals.length}`, elemType);
@@ -2669,35 +2631,24 @@ function compileExternrefArrayDestructuringAssignment(
           fctx.body.push({ op: "local.get", index: tmpElem });
           fctx.body.push({ op: "ref.is_null" });
         }
-        const localType = getLocalType(fctx, localIdx);
+        const targetType =
+          localIdx !== undefined
+            ? getLocalType(fctx, localIdx)
+            : ctx.mod.globals[localGlobalIdx(ctx, moduleGlobalIdx!)]?.type;
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [
-            ...(() => {
-              const saved = fctx.body;
-              fctx.body = [];
-              compileExpression(ctx, fctx, defaultExpr, localType ?? elemType);
-              fctx.body.push({ op: "local.set", index: localIdx! });
-              const instrs = fctx.body;
-              fctx.body = saved;
-              return instrs;
-            })(),
-          ],
+          then: buildDetachedAssignmentBody(fctx, () => {
+            const initType = compileExpression(ctx, fctx, defaultExpr, targetType ?? elemType);
+            if (initType) {
+              emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, initType, localIdx, moduleGlobalIdx);
+            }
+          }),
           else: [
             { op: "local.get", index: tmpElem },
-            ...(() => {
-              if (localType && !valTypesMatch(elemType, localType)) {
-                const saved = fctx.body;
-                fctx.body = [];
-                coerceType(ctx, fctx, elemType, localType);
-                const instrs = fctx.body;
-                fctx.body = saved;
-                return instrs;
-              }
-              return [];
-            })(),
-            { op: "local.set", index: localIdx! },
+            ...buildDetachedAssignmentBody(fctx, () => {
+              emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, elemType, localIdx, moduleGlobalIdx);
+            }),
           ],
         });
       }

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -120,6 +120,7 @@ import { emitMappedArgParamSync, emitMappedArgReverseSync } from "./logical-ops.
 import { resolveStructName, resolveStructNameForExpr } from "./misc.js";
 import { tryCompileStandaloneRegExpLastIndexWrite } from "../regexp-standalone.js";
 import { emitResolvedIdentifierWriteFromStack } from "./identifier-assignment.js";
+import { currentSourceModuleGlobalIndex, identifierHasOnlyAmbientDeclarations } from "./identifier-module-storage.js";
 import { tryCompileStandaloneDetachedWrite } from "../dataview-native.js"; // (#3173) $DETACHBUFFER marker write
 import { externrefBackedOwnFieldBacking, getOrRegisterErrorStructType } from "../registry/error-types.js";
 import { tryEmitErrorInstanceFieldWrite } from "../error-instance-field-write.js";
@@ -201,12 +202,28 @@ function emitExternrefAssignDestructureGuard(ctx: CodegenContext, fctx: Function
   }
 }
 
-function buildDetachedAssignmentBody(fctx: FunctionContext, emit: () => void): Instr[] {
+function attachDetachedAssignmentBodies<T>(
+  fctx: FunctionContext,
+  build: (body: (emit: () => void) => Instr[]) => T,
+  attach: (bodies: T) => void,
+): void {
   const saved = pushBody(fctx);
-  try {
+  const bodies: Instr[][] = [];
+  const body = (emit: () => void): Instr[] => {
+    const detached = bodies.length === 0 ? fctx.body : [];
+    bodies.push(detached);
+    // A later sibling can add an import/global and repoint earlier code.
+    fctx.savedBodies.push(detached);
+    fctx.body = detached;
     emit();
-    return fctx.body;
+    return detached;
+  };
+  try {
+    const built = build(body);
+    fctx.body = saved;
+    attach(built);
   } finally {
+    for (let i = bodies.length; i > 0; i--) fctx.savedBodies.pop();
     popBody(fctx, saved);
   }
 }
@@ -328,7 +345,7 @@ export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, ex
     // RHS exactly once either through its stable value cell or through the
     // compiler's ordinary static target on a miss. Truly unresolvable names
     // keep the stricter GlobalEnvironmentRecord route below.
-    if (!isUnresolvableIdent(ctx, fctx, expr.left)) {
+    if (!isUnresolvableIdent(ctx, fctx, expr.left) || identifierHasOnlyAmbientDeclarations(ctx, expr.left)) {
       const runtimeBinding = emitCaptureRuntimeEvalBindingValueCell(ctx, fctx, name);
       if (runtimeBinding) {
         const wrapRuntimeEvalCallable = isStaticallyCallableExpression(ctx, expr.right);
@@ -698,7 +715,7 @@ export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, ex
       return resultType;
     }
     // Check module-level globals
-    const moduleIdx = ctx.moduleGlobals.get(name);
+    const moduleIdx = currentSourceModuleGlobalIndex(ctx, expr.left);
     if (moduleIdx !== undefined) {
       const globalDef = ctx.mod.globals[localGlobalIdx(ctx, moduleIdx)];
       const globalType = globalDef?.type;
@@ -878,7 +895,7 @@ export function emitDynamicWithIdentifierWrite(
     fctx.body.push({ op: "struct.set", typeIdx: b.scope.structTypeIdx, fieldIdx: b.fieldIdx });
     return;
   }
-  emitIdentifierWriteFromLocal(ctx, fctx, id, rhsLocalIdx);
+  emitIdentifierWriteFromLocal(ctx, fctx, id, rhsLocalIdx, true);
 }
 
 /**
@@ -897,6 +914,7 @@ export function emitIdentifierWriteFromLocal(
   fctx: FunctionContext,
   id: ts.Identifier,
   rhsLocalIdx: number,
+  allowUnresolvedTopLevelVariable = false,
 ): void {
   const name = id.text;
 
@@ -964,10 +982,18 @@ export function emitIdentifierWriteFromLocal(
     return;
   }
 
-  const moduleIdx = ctx.moduleGlobals.get(name);
+  const moduleIdx = currentSourceModuleGlobalIndex(ctx, id, allowUnresolvedTopLevelVariable);
   if (moduleIdx !== undefined) {
     fctx.body.push({ op: "local.get", index: rhsLocalIdx });
-    emitResolvedIdentifierWriteFromStack(ctx, fctx, id, { kind: "externref" }, undefined, moduleIdx);
+    emitResolvedIdentifierWriteFromStack(
+      ctx,
+      fctx,
+      id,
+      { kind: "externref" },
+      undefined,
+      moduleIdx,
+      allowUnresolvedTopLevelVariable,
+    );
     return;
   }
 
@@ -1017,10 +1043,7 @@ function tryEmitAmbientIdentifierGlobalWriteFromLocal(
   id: ts.Identifier,
   rhsLocalIdx: number,
 ): boolean {
-  const declarations = ctx.oracle.declarationsOf(id);
-  if (declarations.length === 0 || !declarations.every((decl) => decl.getSourceFile().isDeclarationFile)) {
-    return false;
-  }
+  if (!identifierHasOnlyAmbientDeclarations(ctx, id)) return false;
   if (!emitGlobalEnvironmentObject(ctx, fctx)) return false;
   const setIdx = ensureGlobalEnvironmentOperation(ctx, fctx, "__extern_set");
   if (setIdx === undefined) {
@@ -1282,7 +1305,8 @@ function compileDestructuringAssignment(
           // Resolve write target: local first, then module global. Allocate
           // a local only if neither exists.
           let localIdx = fctx.localMap.get(name);
-          const moduleGlobalIdx = ctx.moduleGlobals.get(name);
+          const moduleGlobalIdx =
+            localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, targetIdentifier) : undefined;
           let targetType: ValType;
           if (localIdx !== undefined) {
             targetType = getLocalType(fctx, localIdx) ?? { kind: "externref" as const };
@@ -1306,25 +1330,6 @@ function compileDestructuringAssignment(
           fctx.body.push({ op: "call", funcIdx: getIdx });
           fctx.body.push({ op: "local.set", index: tmpVal });
 
-          // Helper: emit `<value-on-stack> -> coerce -> set target`.
-          const emitSetTarget = (instrs: Instr[]): void => {
-            // The value is currently on the Wasm stack as externref. Coerce
-            // and then set. We append into `instrs` so the caller can splice
-            // it into a then/else branch.
-            instrs.push(
-              ...buildDetachedAssignmentBody(fctx, () => {
-                emitResolvedIdentifierWriteFromStack(
-                  ctx,
-                  fctx,
-                  targetIdentifier,
-                  { kind: "externref" },
-                  localIdx,
-                  moduleGlobalIdx,
-                );
-              }),
-            );
-          };
-
           if (propDefault) {
             // Per spec: defaults fire ONLY on undefined. Use
             // __extern_is_undefined (not ref.is_null) so JS null falls
@@ -1332,31 +1337,48 @@ function compileDestructuringAssignment(
             fctx.body.push({ op: "local.get", index: tmpVal });
             fctx.body.push({ op: "call", funcIdx: undefIdx });
 
-            // then-branch: compile default into target
-            const trueInstrs = buildDetachedAssignmentBody(fctx, () => {
-              const initType = compileExpression(ctx, fctx, propDefault, targetType);
-              if (initType) {
-                emitResolvedIdentifierWriteFromStack(ctx, fctx, targetIdentifier, initType, localIdx, moduleGlobalIdx);
-              }
-            });
-
-            // else-branch: forward the read value (with optional coerce)
-            const elseInstrs: Instr[] = [{ op: "local.get", index: tmpVal }];
-            emitSetTarget(elseInstrs);
-
-            fctx.body.push({
-              op: "if",
-              blockType: { kind: "empty" },
-              then: trueInstrs,
-              else: elseInstrs,
-            });
+            attachDetachedAssignmentBodies(
+              fctx,
+              (body) => ({
+                then: body(() => {
+                  const initType = compileExpression(ctx, fctx, propDefault, targetType);
+                  if (initType) {
+                    emitResolvedIdentifierWriteFromStack(
+                      ctx,
+                      fctx,
+                      targetIdentifier,
+                      initType,
+                      localIdx,
+                      moduleGlobalIdx,
+                    );
+                  }
+                }),
+                else: body(() => {
+                  fctx.body.push({ op: "local.get", index: tmpVal });
+                  emitResolvedIdentifierWriteFromStack(
+                    ctx,
+                    fctx,
+                    targetIdentifier,
+                    { kind: "externref" },
+                    localIdx,
+                    moduleGlobalIdx,
+                  );
+                }),
+              }),
+              (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+            );
           } else {
             // No default: just assign whatever __extern_get returned (which
             // is `undefined` if missing — JS-equivalent behaviour).
             fctx.body.push({ op: "local.get", index: tmpVal });
-            const tail: Instr[] = [];
-            emitSetTarget(tail);
-            fctx.body.push(...tail);
+            emitResolvedIdentifierWriteFromStack(
+              ctx,
+              fctx,
+              targetIdentifier,
+              { kind: "externref" },
+              localIdx,
+              moduleGlobalIdx,
+            );
           }
         }
       } else {
@@ -1433,7 +1455,7 @@ function compileDestructuringAssignment(
       // { width } = ... → prop.name is "width"
       const propName = prop.name.text;
       let localIdx = fctx.localMap.get(propName);
-      const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(propName) : undefined;
+      const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, prop.name) : undefined;
 
       const fieldIdx = fields.findIndex((f) => f.name === propName);
 
@@ -1509,13 +1531,10 @@ function compileDestructuringAssignment(
             // could not be registered (e.g. standalone mode).
             fctx.body.push({ op: "ref.is_null" });
           }
-          fctx.body.push({
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [
-              ...(() => {
-                const saved = fctx.body;
-                fctx.body = [];
+          attachDetachedAssignmentBodies(
+            fctx,
+            (body) => ({
+              then: body(() => {
                 const initType = compileExpression(
                   ctx,
                   fctx,
@@ -1525,27 +1544,12 @@ function compileDestructuringAssignment(
                 if (initType) {
                   emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, initType, localIdx, moduleGlobalIdx);
                 }
-                const instrs = fctx.body;
-                fctx.body = saved;
-                return instrs;
-              })(),
-            ],
-            else: [
-              { op: "local.get", index: tmpField },
-              ...(() => {
+              }),
+              else: body(() => {
+                fctx.body.push({ op: "local.get", index: tmpField });
                 if (targetType && !valTypesMatch(fieldType, targetType)) {
-                  const saved = fctx.body;
-                  fctx.body = [];
                   coerceType(ctx, fctx, fieldType, targetType);
-                  const instrs = fctx.body;
-                  fctx.body = saved;
-                  return instrs;
                 }
-                return [];
-              })(),
-              ...(() => {
-                const saved = fctx.body;
-                fctx.body = [];
                 emitResolvedIdentifierWriteFromStack(
                   ctx,
                   fctx,
@@ -1554,12 +1558,10 @@ function compileDestructuringAssignment(
                   localIdx,
                   moduleGlobalIdx,
                 );
-                const instrs = fctx.body;
-                fctx.body = saved;
-                return instrs;
-              })(),
-            ],
-          });
+              }),
+            }),
+            (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+          );
         } else {
           emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, fieldType, localIdx, moduleGlobalIdx);
         }
@@ -1605,7 +1607,7 @@ function compileDestructuringAssignment(
         if (defaultExpr && ts.isIdentifier(targetExpr)) {
           const localName = targetExpr.text;
           let localIdx = fctx.localMap.get(localName);
-          const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+          const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, targetExpr) : undefined;
           if (localIdx === undefined && moduleGlobalIdx === undefined) {
             localIdx = allocLocal(fctx, localName, { kind: "externref" });
           }
@@ -1628,7 +1630,7 @@ function compileDestructuringAssignment(
         // { prop: ident } or { prop: ident = default }
         const localName = targetExpr.text;
         let localIdx = fctx.localMap.get(localName);
-        const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+        const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, targetExpr) : undefined;
 
         // Auto-allocate local if not declared
         if (localIdx === undefined && moduleGlobalIdx === undefined) {
@@ -1670,34 +1672,22 @@ function compileDestructuringAssignment(
             } else {
               fctx.body.push({ op: "ref.is_null" });
             }
-            fctx.body.push({
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [
-                ...(() => {
-                  const saved = fctx.body;
-                  fctx.body = [];
+            attachDetachedAssignmentBodies(
+              fctx,
+              (body) => ({
+                then: body(() => {
                   const initType = compileExpression(ctx, fctx, defaultExpr!, targetType ?? fieldType);
                   if (initType) {
                     emitResolvedIdentifierWriteFromStack(ctx, fctx, targetExpr, initType, localIdx, moduleGlobalIdx);
                   }
-                  const instrs = fctx.body;
-                  fctx.body = saved;
-                  return instrs;
-                })(),
-              ],
-              else: [
-                { op: "local.get", index: tmpField },
-                ...(() => {
-                  const saved = fctx.body;
-                  fctx.body = [];
+                }),
+                else: body(() => {
+                  fctx.body.push({ op: "local.get", index: tmpField });
                   emitResolvedIdentifierWriteFromStack(ctx, fctx, targetExpr, fieldType, localIdx, moduleGlobalIdx);
-                  const instrs = fctx.body;
-                  fctx.body = saved;
-                  return instrs;
-                })(),
-              ],
-            });
+                }),
+              }),
+              (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+            );
           } else {
             // Numeric field — just set the value (no undefined check needed for primitives)
             emitResolvedIdentifierWriteFromStack(ctx, fctx, targetExpr, fieldType, localIdx, moduleGlobalIdx);
@@ -1878,7 +1868,7 @@ function tryEmitArrayProtoIteratorAssignDrive(
       // function locals or module globals; reuse the same resolution the
       // identifier-assignment path uses.
       const localIdx = fctx.localMap.get(name);
-      const globalIdx = ctx.moduleGlobals.get(name);
+      const globalIdx = currentSourceModuleGlobalIndex(ctx, el);
       // When done (iterator exhausted), the spec value is `undefined`; leave the
       // local untouched (the targets already exist / hold their prior value) —
       // the 71 assignment tests yield concrete values, never short.
@@ -2211,7 +2201,7 @@ function compileArrayDestructuringAssignment(
     if (ts.isIdentifier(element)) {
       const localName = element.text;
       let localIdx = fctx.localMap.get(localName);
-      const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+      const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, element) : undefined;
       if (localIdx === undefined && moduleGlobalIdx === undefined) {
         localIdx = allocLocal(fctx, localName, elemType);
       }
@@ -2243,7 +2233,7 @@ function compileArrayDestructuringAssignment(
       if (ts.isIdentifier(assignTarget)) {
         const localName = assignTarget.text;
         let localIdx = fctx.localMap.get(localName);
-        const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+        const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, assignTarget) : undefined;
         if (localIdx === undefined && moduleGlobalIdx === undefined) {
           localIdx = allocLocal(fctx, localName, elemType);
         }
@@ -2327,33 +2317,23 @@ function compileArrayDestructuringAssignment(
           fctx.body.push({ op: "local.set", index: absentLocal });
         }
 
-        const thenInit: Instr[] = (() => {
-          const saved = fctx.body;
-          fctx.body = [];
-          const initType = compileExpression(ctx, fctx, defaultExpr, targetType ?? elemType);
-          if (initType) {
-            emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, initType, localIdx, moduleGlobalIdx);
-          }
-          const instrs = fctx.body;
-          fctx.body = saved;
-          return instrs;
-        })();
-        const elseAssign: Instr[] = (() => {
-          const saved = fctx.body;
-          fctx.body = [];
-          fctx.body.push({ op: "local.get", index: tmpElem });
-          emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, elemValType, localIdx, moduleGlobalIdx);
-          const instrs = fctx.body;
-          fctx.body = saved;
-          return instrs;
-        })();
         fctx.body.push({ op: "local.get", index: absentLocal });
-        fctx.body.push({
-          op: "if",
-          blockType: { kind: "empty" },
-          then: thenInit,
-          else: elseAssign,
-        });
+        attachDetachedAssignmentBodies(
+          fctx,
+          (body) => ({
+            then: body(() => {
+              const initType = compileExpression(ctx, fctx, defaultExpr, targetType ?? elemType);
+              if (initType) {
+                emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, initType, localIdx, moduleGlobalIdx);
+              }
+            }),
+            else: body(() => {
+              fctx.body.push({ op: "local.get", index: tmpElem });
+              emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, elemValType, localIdx, moduleGlobalIdx);
+            }),
+          }),
+          (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+        );
       } else if (ts.isPropertyAccessExpression(assignTarget) || ts.isElementAccessExpression(assignTarget)) {
         // (#2869) Member-expression target WITH a default: `[x.y = d] = vals`.
         // Mirror the identifier-default machinery above (read element →
@@ -2589,7 +2569,7 @@ function compileExternrefArrayDestructuringAssignment(
     if (ts.isIdentifier(element)) {
       const localName = element.text;
       let localIdx = fctx.localMap.get(localName);
-      const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+      const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, element) : undefined;
       if (localIdx === undefined && moduleGlobalIdx === undefined) {
         localIdx = allocLocal(fctx, localName, elemType);
       }
@@ -2613,7 +2593,7 @@ function compileExternrefArrayDestructuringAssignment(
       if (ts.isIdentifier(assignTarget)) {
         const localName = assignTarget.text;
         let localIdx = fctx.localMap.get(localName);
-        const moduleGlobalIdx = localIdx === undefined ? ctx.moduleGlobals.get(localName) : undefined;
+        const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, assignTarget) : undefined;
         if (localIdx === undefined && moduleGlobalIdx === undefined) {
           localIdx = allocLocal(fctx, localName, elemType);
         }
@@ -2635,22 +2615,22 @@ function compileExternrefArrayDestructuringAssignment(
           localIdx !== undefined
             ? getLocalType(fctx, localIdx)
             : ctx.mod.globals[localGlobalIdx(ctx, moduleGlobalIdx!)]?.type;
-        fctx.body.push({
-          op: "if",
-          blockType: { kind: "empty" },
-          then: buildDetachedAssignmentBody(fctx, () => {
-            const initType = compileExpression(ctx, fctx, defaultExpr, targetType ?? elemType);
-            if (initType) {
-              emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, initType, localIdx, moduleGlobalIdx);
-            }
-          }),
-          else: [
-            { op: "local.get", index: tmpElem },
-            ...buildDetachedAssignmentBody(fctx, () => {
+        attachDetachedAssignmentBodies(
+          fctx,
+          (body) => ({
+            then: body(() => {
+              const initType = compileExpression(ctx, fctx, defaultExpr, targetType ?? elemType);
+              if (initType) {
+                emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, initType, localIdx, moduleGlobalIdx);
+              }
+            }),
+            else: body(() => {
+              fctx.body.push({ op: "local.get", index: tmpElem });
               emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, elemType, localIdx, moduleGlobalIdx);
             }),
-          ],
-        });
+          }),
+          (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+        );
       }
     } else if (ts.isArrayLiteralExpression(element) || ts.isObjectLiteralExpression(element)) {
       // Nested destructuring: [[x]] = arr or [{x}] = arr

--- a/src/codegen/expressions/identifier-assignment.ts
+++ b/src/codegen/expressions/identifier-assignment.ts
@@ -7,7 +7,7 @@ import { getLocalType } from "../context/locals.js";
 import { localGlobalIdx } from "../registry/imports.js";
 import { coerceType, valTypesMatch } from "../shared.js";
 import { emitTdzCheck } from "../statements/tdz.js";
-import { analyzeIdentifierTdzAccess, emitStaticTdzThrow } from "./identifiers.js";
+import { analyzeTdzAccess as analyzeIdentifierTdzAccess, emitStaticTdzThrow } from "./identifiers.js";
 import { identifierResolvesToCurrentTopLevelLexical } from "./identifier-module-storage.js";
 
 function moduleLexicalAssignmentTdzDecision(

--- a/src/codegen/expressions/identifier-assignment.ts
+++ b/src/codegen/expressions/identifier-assignment.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Resolved identifier writes and their module-lexical TDZ guard. */
+import { ts } from "../../ts-api.js";
+import type { ValType } from "../../ir/types.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { getLocalType } from "../context/locals.js";
+import { localGlobalIdx } from "../registry/imports.js";
+import { coerceType, valTypesMatch } from "../shared.js";
+import { emitTdzCheck } from "../statements/tdz.js";
+import {
+  analyzeIdentifierTdzAccess,
+  emitStaticTdzThrow,
+  identifierValueSymbol,
+  moduleGoalIdentifierIsUndeclared,
+} from "./identifiers.js";
+
+/** Exact same-source runtime top-level lexical identity. */
+function identifierResolvesToCurrentTopLevelLexical(ctx: CodegenContext, id: ts.Identifier): boolean {
+  const sourceFile = id.getSourceFile();
+  if (!ctx.sourceIsModule || sourceFile.isDeclarationFile || moduleGoalIdentifierIsUndeclared(ctx, id)) return false;
+  const declaration = identifierValueSymbol(ctx, id)?.valueDeclaration;
+  if (!declaration || !ts.isVariableDeclaration(declaration) || !ts.isIdentifier(declaration.name)) return false;
+  const declarationList = declaration.parent;
+  const statement = declarationList.parent;
+  const lexicalFlags = ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing;
+  return (
+    ts.isVariableDeclarationList(declarationList) &&
+    (declarationList.flags & lexicalFlags) !== 0 &&
+    ts.isVariableStatement(statement) &&
+    declaration.getSourceFile() === sourceFile &&
+    statement.parent === sourceFile
+  );
+}
+
+function moduleLexicalAssignmentTdzDecision(
+  ctx: CodegenContext,
+  id: ts.Identifier,
+): "skip" | "throw" | "check" | undefined {
+  if (!ctx.moduleGlobals.has(id.text) || !ctx.tdzGlobals.has(id.text)) return undefined;
+  if (!identifierResolvesToCurrentTopLevelLexical(ctx, id)) return undefined;
+  return analyzeIdentifierTdzAccess(ctx, id);
+}
+
+function emitModuleLexicalAssignmentTdzGuard(ctx: CodegenContext, fctx: FunctionContext, id: ts.Identifier): void {
+  const decision = moduleLexicalAssignmentTdzDecision(ctx, id);
+  if (decision === "throw") emitStaticTdzThrow(ctx, fctx, id.text);
+  else if (decision === "check") emitTdzCheck(ctx, fctx, id.text, true);
+}
+
+/** Consume one precomputed stack value through an already-resolved target. */
+export function emitResolvedIdentifierWriteFromStack(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  id: ts.Identifier,
+  valueType: ValType,
+  localIdx: number | undefined,
+  moduleGlobalIdx: number | undefined,
+): boolean {
+  // A provider or string constant settled while evaluating the value may have
+  // inserted an import global. Treat the caller's index as target identity
+  // only; re-read the graph-global name map before inspecting its type.
+  const currentModuleGlobalIdx = moduleGlobalIdx === undefined ? undefined : ctx.moduleGlobals.get(id.text);
+  const targetType =
+    localIdx !== undefined
+      ? getLocalType(fctx, localIdx)
+      : currentModuleGlobalIdx !== undefined
+        ? ctx.mod.globals[localGlobalIdx(ctx, currentModuleGlobalIdx)]?.type
+        : undefined;
+  if (localIdx === undefined && currentModuleGlobalIdx === undefined) return false;
+  if (targetType && !valTypesMatch(valueType, targetType)) coerceType(ctx, fctx, valueType, targetType);
+  if (localIdx !== undefined) {
+    fctx.body.push({ op: "local.set", index: localIdx });
+    return true;
+  }
+  emitModuleLexicalAssignmentTdzGuard(ctx, fctx, id);
+  // Re-read after coercion/guard helpers: either can settle imports/globals.
+  fctx.body.push({ op: "global.set", index: ctx.moduleGlobals.get(id.text)! });
+  return true;
+}

--- a/src/codegen/expressions/identifier-assignment.ts
+++ b/src/codegen/expressions/identifier-assignment.ts
@@ -7,42 +7,26 @@ import { getLocalType } from "../context/locals.js";
 import { localGlobalIdx } from "../registry/imports.js";
 import { coerceType, valTypesMatch } from "../shared.js";
 import { emitTdzCheck } from "../statements/tdz.js";
-import {
-  analyzeIdentifierTdzAccess,
-  emitStaticTdzThrow,
-  identifierValueSymbol,
-  moduleGoalIdentifierIsUndeclared,
-} from "./identifiers.js";
-
-/** Exact same-source runtime top-level lexical identity. */
-function identifierResolvesToCurrentTopLevelLexical(ctx: CodegenContext, id: ts.Identifier): boolean {
-  const sourceFile = id.getSourceFile();
-  if (!ctx.sourceIsModule || sourceFile.isDeclarationFile || moduleGoalIdentifierIsUndeclared(ctx, id)) return false;
-  const declaration = identifierValueSymbol(ctx, id)?.valueDeclaration;
-  if (!declaration || !ts.isVariableDeclaration(declaration) || !ts.isIdentifier(declaration.name)) return false;
-  const declarationList = declaration.parent;
-  const statement = declarationList.parent;
-  const lexicalFlags = ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing;
-  return (
-    ts.isVariableDeclarationList(declarationList) &&
-    (declarationList.flags & lexicalFlags) !== 0 &&
-    ts.isVariableStatement(statement) &&
-    declaration.getSourceFile() === sourceFile &&
-    statement.parent === sourceFile
-  );
-}
+import { analyzeIdentifierTdzAccess, emitStaticTdzThrow } from "./identifiers.js";
+import { identifierResolvesToCurrentTopLevelLexical } from "./identifier-module-storage.js";
 
 function moduleLexicalAssignmentTdzDecision(
   ctx: CodegenContext,
   id: ts.Identifier,
+  allowUnresolvedTopLevelVariable: boolean,
 ): "skip" | "throw" | "check" | undefined {
   if (!ctx.moduleGlobals.has(id.text) || !ctx.tdzGlobals.has(id.text)) return undefined;
-  if (!identifierResolvesToCurrentTopLevelLexical(ctx, id)) return undefined;
+  if (!identifierResolvesToCurrentTopLevelLexical(ctx, id, allowUnresolvedTopLevelVariable)) return undefined;
   return analyzeIdentifierTdzAccess(ctx, id);
 }
 
-function emitModuleLexicalAssignmentTdzGuard(ctx: CodegenContext, fctx: FunctionContext, id: ts.Identifier): void {
-  const decision = moduleLexicalAssignmentTdzDecision(ctx, id);
+function emitModuleLexicalAssignmentTdzGuard(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  id: ts.Identifier,
+  allowUnresolvedTopLevelVariable: boolean,
+): void {
+  const decision = moduleLexicalAssignmentTdzDecision(ctx, id, allowUnresolvedTopLevelVariable);
   if (decision === "throw") emitStaticTdzThrow(ctx, fctx, id.text);
   else if (decision === "check") emitTdzCheck(ctx, fctx, id.text, true);
 }
@@ -55,6 +39,7 @@ export function emitResolvedIdentifierWriteFromStack(
   valueType: ValType,
   localIdx: number | undefined,
   moduleGlobalIdx: number | undefined,
+  allowUnresolvedTopLevelVariable = false,
 ): boolean {
   // A provider or string constant settled while evaluating the value may have
   // inserted an import global. Treat the caller's index as target identity
@@ -72,7 +57,7 @@ export function emitResolvedIdentifierWriteFromStack(
     fctx.body.push({ op: "local.set", index: localIdx });
     return true;
   }
-  emitModuleLexicalAssignmentTdzGuard(ctx, fctx, id);
+  emitModuleLexicalAssignmentTdzGuard(ctx, fctx, id, allowUnresolvedTopLevelVariable);
   // Re-read after coercion/guard helpers: either can settle imports/globals.
   fctx.body.push({ op: "global.set", index: ctx.moduleGlobals.get(id.text)! });
   return true;

--- a/src/codegen/expressions/identifier-module-storage.ts
+++ b/src/codegen/expressions/identifier-module-storage.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Source-qualified identity for the legacy flat module-binding registries. */
+import type { ValType } from "../../ir/types.js";
+import { ts } from "../../ts-api.js";
+import { hasDeclareModifier } from "../ast-modifiers.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { runtimeEvalStateMayShadowBinding } from "../direct-eval-environment.js";
+import {
+  emitGlobalEnvironmentKey,
+  emitGlobalEnvironmentObject,
+  ensureGlobalEnvironmentOperation,
+} from "../global-environment.js";
+import { localGlobalIdx } from "../registry/imports.js";
+
+const LEXICAL_FLAGS = ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing;
+
+/** Whether every declaration visible to this identifier is type-only ambient. */
+export function identifierHasOnlyAmbientDeclarations(ctx: CodegenContext, id: ts.Identifier): boolean {
+  const declarations = ctx.oracle.declarationsOf(id);
+  return (
+    declarations.length > 0 &&
+    declarations.every((declaration) => {
+      if (declaration.getSourceFile().isDeclarationFile || hasDeclareModifier(declaration)) return true;
+      return ts.isVariableDeclaration(declaration) && hasDeclareModifier(declaration.parent.parent);
+    })
+  );
+}
+
+/** Read an ambient binding through its runtime environment before flat registries. */
+export function tryEmitAmbientRegistryCollisionRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  id: ts.Identifier,
+  runtimeEvalFallback = false,
+): ValType | undefined {
+  if (!identifierHasOnlyAmbientDeclarations(ctx, id)) return undefined;
+  const forceGlobalEnvironmentRead = runtimeEvalFallback && runtimeEvalStateMayShadowBinding(ctx, fctx, id.text);
+  if (!forceGlobalEnvironmentRead && !ctx.moduleGlobals.has(id.text) && !ctx.capturedGlobals.has(id.text)) {
+    return undefined;
+  }
+  if (!emitGlobalEnvironmentObject(ctx, fctx)) throw new TypeError(`ambient global '${id.text}' has no environment`);
+  const getIdx = ensureGlobalEnvironmentOperation(ctx, fctx, "__extern_get");
+  if (getIdx === undefined) throw new TypeError(`ambient global '${id.text}' has no environment reader`);
+  emitGlobalEnvironmentKey(ctx, fctx, id.text);
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__extern_get") ?? getIdx });
+  return { kind: "externref" };
+}
+
+/** Emit a read from the live post-provider index and return its allocator type. */
+export function emitLiveIdentifierGlobalRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  globals: ReadonlyMap<string, number>,
+  name: string,
+): ValType {
+  const globalIdx = globals.get(name);
+  if (globalIdx === undefined) throw new TypeError(`identifier global '${name}' disappeared during provider setup`);
+  const global = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
+  if (!global) throw new TypeError(`identifier global '${name}' has no allocator object at index ${globalIdx}`);
+  fctx.body.push({ op: "global.get", index: globalIdx });
+  return global.type;
+}
+
+function isCurrentSourceRuntimeVariable(declaration: ts.Declaration, sourceFile: ts.SourceFile): boolean {
+  if (!ts.isVariableDeclaration(declaration) || !ts.isIdentifier(declaration.name)) return false;
+  const list = declaration.parent;
+  if (!ts.isVariableDeclarationList(list) || declaration.getSourceFile() !== sourceFile) return false;
+  const statement = list.parent;
+  if ((list.flags & LEXICAL_FLAGS) !== 0) {
+    return ts.isVariableStatement(statement) && statement.parent === sourceFile && !hasDeclareModifier(statement);
+  }
+  for (let node: ts.Node | undefined = statement; node && node !== sourceFile; node = node.parent) {
+    if (ts.isFunctionLike(node) || ts.isModuleBlock(node) || ts.isModuleDeclaration(node)) return false;
+    if (ts.isVariableStatement(node) && hasDeclareModifier(node)) return false;
+  }
+  return !sourceFile.isDeclarationFile;
+}
+
+function directUnresolvedTopLevelVariable(ctx: CodegenContext, id: ts.Identifier): ts.VariableDeclaration | undefined {
+  const sourceFile = id.getSourceFile();
+  if (sourceFile.isDeclarationFile || ctx.oracle.declarationsOf(id).length !== 0) return undefined;
+  const matches = sourceFile.statements.flatMap((statement) =>
+    ts.isVariableStatement(statement) && !hasDeclareModifier(statement)
+      ? statement.declarationList.declarations.filter(
+          (declaration): declaration is ts.VariableDeclaration =>
+            ts.isIdentifier(declaration.name) && declaration.name.text === id.text,
+        )
+      : [],
+  );
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function resolvedDeclaration(
+  ctx: CodegenContext,
+  id: ts.Identifier,
+  allowUnresolvedTopLevelVariable: boolean,
+): ts.Declaration | undefined {
+  return (
+    ctx.oracle.valueDeclarationOf(id) ??
+    (allowUnresolvedTopLevelVariable ? directUnresolvedTopLevelVariable(ctx, id) : undefined)
+  );
+}
+
+/** Resolve the flat compatibility map only for this source's runtime binding. */
+export function currentSourceModuleGlobalIndex(
+  ctx: CodegenContext,
+  id: ts.Identifier,
+  allowUnresolvedTopLevelVariable = false,
+): number | undefined {
+  const sourceFile = id.getSourceFile();
+  if (sourceFile.isDeclarationFile) return undefined;
+  const declaration = resolvedDeclaration(ctx, id, allowUnresolvedTopLevelVariable);
+  if (!declaration || declaration.getSourceFile() !== sourceFile) return undefined;
+  if (
+    ts.isVariableDeclaration(declaration) &&
+    isCurrentSourceRuntimeVariable(declaration, sourceFile) &&
+    ts.isIdentifier(declaration.name) &&
+    declaration.name.text === id.text
+  ) {
+    return ctx.moduleGlobals.get(id.text);
+  }
+  if (
+    ts.isFunctionDeclaration(declaration) &&
+    declaration.name?.text === id.text &&
+    declaration.parent === sourceFile &&
+    declaration.body !== undefined &&
+    !hasDeclareModifier(declaration) &&
+    ctx.liveFuncBindingGlobals?.has(id.text)
+  ) {
+    return ctx.moduleGlobals.get(id.text);
+  }
+  return undefined;
+}
+
+/** Exact same-source runtime top-level lexical identity. */
+export function identifierResolvesToCurrentTopLevelLexical(
+  ctx: CodegenContext,
+  id: ts.Identifier,
+  allowUnresolvedTopLevelVariable = false,
+): boolean {
+  const declaration = resolvedDeclaration(ctx, id, allowUnresolvedTopLevelVariable);
+  return (
+    declaration !== undefined &&
+    isCurrentSourceRuntimeVariable(declaration, id.getSourceFile()) &&
+    (declaration.parent.flags & LEXICAL_FLAGS) !== 0
+  );
+}

--- a/src/codegen/expressions/identifier-module-storage.ts
+++ b/src/codegen/expressions/identifier-module-storage.ts
@@ -107,6 +107,11 @@ export function currentSourceModuleGlobalIndex(
   id: ts.Identifier,
   allowUnresolvedTopLevelVariable = false,
 ): number | undefined {
+  // Script files share one GlobalEnvironmentRecord. A declaration resolved
+  // through another script (notably the assembled Test262 harness) therefore
+  // names the same runtime binding; source qualification is only meaningful
+  // for module environment records.
+  if (!ctx.sourceIsModule) return ctx.moduleGlobals.get(id.text);
   const sourceFile = id.getSourceFile();
   if (sourceFile.isDeclarationFile) return undefined;
   const declaration = resolvedDeclaration(ctx, id, allowUnresolvedTopLevelVariable);

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -390,7 +390,7 @@ export function moduleGoalIdentifierIsUndeclared(ctx: CodegenContext, id: ts.Ide
  * - 'throw': access is before declaration in straight-line code — guaranteed TDZ error
  * - 'check': can't determine statically — keep runtime flag check
  */
-export function analyzeIdentifierTdzAccess(ctx: CodegenContext, id: ts.Identifier): "skip" | "throw" | "check" {
+export function analyzeTdzAccess(ctx: CodegenContext, id: ts.Identifier): "skip" | "throw" | "check" {
   // A shorthand property name (`{ value }`) has two symbols in TypeScript:
   // the property being declared and the lexical binding whose value is read.
   // `getSymbolAtLocation(id)` answers the former, whose declaration range is
@@ -583,7 +583,7 @@ function emitNullablePrimitiveUnbox(
  * Returns the subset of `candidates` for which TDZ tracking can be statically
  * compiled away — i.e. every identifier reference in the source file that
  * resolves to the candidate's declaration is provably after initialization
- * (analyzeIdentifierTdzAccess returns "skip"). For these names, the caller can skip
+ * (analyzeTdzAccess returns "skip"). For these names, the caller can skip
  * emitting the `__tdz_<name>` global, the `global.set __tdz_<name>` writes
  * in the module init body, and the runtime check at every read.
  *
@@ -629,7 +629,7 @@ export function computeElidableTopLevelTdzNames(
         const symbol = ctx.checker.getSymbolAtLocation(node);
         const decl = symbol?.valueDeclaration;
         if (decl === declByName.get(node.text)) {
-          const result = analyzeIdentifierTdzAccess(ctx, node);
+          const result = analyzeTdzAccess(ctx, node);
           if (result !== "skip") {
             elidable.delete(node.text);
           }
@@ -1036,7 +1036,7 @@ function compileIdentifierCore(
     materializeHoistedFunctionValueBinding(ctx, fctx, name);
     const tdzFlagIdx = fctx.tdzFlagLocals?.get(name);
     if (tdzFlagIdx !== undefined) {
-      const tdzResult = analyzeIdentifierTdzAccess(ctx, id);
+      const tdzResult = analyzeTdzAccess(ctx, id);
       if (tdzResult === "check") {
         emitLocalTdzCheck(ctx, fctx, name, tdzFlagIdx);
       } else if (tdzResult === "throw") {
@@ -1278,7 +1278,7 @@ function compileIdentifierCore(
   // value (which coerced ref→f64 to `f64.const 0` / ref→externref to garbage).
   const capturedBox = readsAmbientDeclaration ? undefined : getCapturedBoxGlobal(ctx, name);
   if (capturedBox !== undefined) {
-    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeIdentifierTdzAccess(ctx, id) : "skip";
+    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
     if (tdzResult === "check") {
       emitTdzCheck(ctx, fctx, name);
     } else if (tdzResult === "throw") {
@@ -1289,8 +1289,8 @@ function compileIdentifierCore(
 
   // (#3505) Graph-wide name-keyed registries (capturedGlobals, moduleGlobals,
   // funcMap, classObjectGlobals, …) must not serve a read that is undeclared
-  // for THIS module's environment record — see moduleGoalReadIsUndeclared.
-  const unresolvedInModuleGoal = moduleGoalReadIsUndeclared(ctx, id);
+  // for THIS module's environment record — see moduleGoalIdentifierIsUndeclared.
+  const unresolvedInModuleGoal = moduleGoalIdentifierIsUndeclared(ctx, id);
   const graphNameRegistryUnavailable = unresolvedInModuleGoal || readsAmbientDeclaration;
 
   // Check captured globals (variables promoted from enclosing scope for callbacks)
@@ -1298,8 +1298,8 @@ function compileIdentifierCore(
   if (capturedIdx !== undefined) {
     // TDZ check: throw ReferenceError if let/const variable accessed before initialization
     // Apply static analysis — captured globals are often accessed from closures,
-    // but analyzeIdentifierTdzAccess handles the cross-function case correctly (returns "check")
-    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeIdentifierTdzAccess(ctx, id) : "skip";
+    // but analyzeTdzAccess handles the cross-function case correctly (returns "check")
+    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
     if (tdzResult === "check") {
       emitTdzCheck(ctx, fctx, name);
     } else if (tdzResult === "throw") {
@@ -1319,7 +1319,7 @@ function compileIdentifierCore(
   if (moduleIdx !== undefined) {
     // TDZ check: throw ReferenceError if let/const variable accessed before initialization
     // Apply static analysis for module-level globals
-    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeIdentifierTdzAccess(ctx, id) : "skip";
+    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
     if (tdzResult === "check") {
       emitTdzCheck(ctx, fctx, name);
     } else if (tdzResult === "throw") {

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -234,7 +234,7 @@ export function emitLocalTdzCheck(ctx: CodegenContext, fctx: FunctionContext, na
 }
 
 /** Resolve the lexical value read by an identifier, including `{ value }`. */
-function identifierValueSymbol(ctx: CodegenContext, id: ts.Identifier): ts.Symbol | undefined {
+export function identifierValueSymbol(ctx: CodegenContext, id: ts.Identifier): ts.Symbol | undefined {
   if (id.parent && ts.isShorthandPropertyAssignment(id.parent) && id.parent.name === id) {
     const shorthand = (
       ctx.checker as typeof ctx.checker & {
@@ -369,7 +369,7 @@ function identifierInsideSwitchCaseBlock(id: ts.Identifier, declaration: ts.Node
  * legitimately resolve cross-file and stay untouched, as do synthetic
  * compiler-minted identifiers (no parent / no source position).
  */
-function moduleGoalReadIsUndeclared(ctx: CodegenContext, id: ts.Identifier): boolean {
+export function moduleGoalIdentifierIsUndeclared(ctx: CodegenContext, id: ts.Identifier): boolean {
   if (!ctx.sourceIsModule || id.parent === undefined || id.pos < 0) return false;
   const valSym = identifierValueSymbol(ctx, id);
   if (valSym === undefined) return true;
@@ -389,7 +389,7 @@ function moduleGoalReadIsUndeclared(ctx: CodegenContext, id: ts.Identifier): boo
  * - 'throw': access is before declaration in straight-line code — guaranteed TDZ error
  * - 'check': can't determine statically — keep runtime flag check
  */
-export function analyzeTdzAccess(ctx: CodegenContext, id: ts.Identifier): "skip" | "throw" | "check" {
+export function analyzeIdentifierTdzAccess(ctx: CodegenContext, id: ts.Identifier): "skip" | "throw" | "check" {
   // A shorthand property name (`{ value }`) has two symbols in TypeScript:
   // the property being declared and the lexical binding whose value is read.
   // `getSymbolAtLocation(id)` answers the former, whose declaration range is
@@ -582,7 +582,7 @@ function emitNullablePrimitiveUnbox(
  * Returns the subset of `candidates` for which TDZ tracking can be statically
  * compiled away — i.e. every identifier reference in the source file that
  * resolves to the candidate's declaration is provably after initialization
- * (analyzeTdzAccess returns "skip"). For these names, the caller can skip
+ * (analyzeIdentifierTdzAccess returns "skip"). For these names, the caller can skip
  * emitting the `__tdz_<name>` global, the `global.set __tdz_<name>` writes
  * in the module init body, and the runtime check at every read.
  *
@@ -628,7 +628,7 @@ export function computeElidableTopLevelTdzNames(
         const symbol = ctx.checker.getSymbolAtLocation(node);
         const decl = symbol?.valueDeclaration;
         if (decl === declByName.get(node.text)) {
-          const result = analyzeTdzAccess(ctx, node);
+          const result = analyzeIdentifierTdzAccess(ctx, node);
           if (result !== "skip") {
             elidable.delete(node.text);
           }
@@ -1035,7 +1035,7 @@ function compileIdentifierCore(
     materializeHoistedFunctionValueBinding(ctx, fctx, name);
     const tdzFlagIdx = fctx.tdzFlagLocals?.get(name);
     if (tdzFlagIdx !== undefined) {
-      const tdzResult = analyzeTdzAccess(ctx, id);
+      const tdzResult = analyzeIdentifierTdzAccess(ctx, id);
       if (tdzResult === "check") {
         emitLocalTdzCheck(ctx, fctx, name, tdzFlagIdx);
       } else if (tdzResult === "throw") {
@@ -1275,7 +1275,7 @@ function compileIdentifierCore(
   // value (which coerced ref→f64 to `f64.const 0` / ref→externref to garbage).
   const capturedBox = readsAmbientDeclaration ? undefined : getCapturedBoxGlobal(ctx, name);
   if (capturedBox !== undefined) {
-    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
+    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeIdentifierTdzAccess(ctx, id) : "skip";
     if (tdzResult === "check") {
       emitTdzCheck(ctx, fctx, name);
     } else if (tdzResult === "throw") {
@@ -1295,8 +1295,8 @@ function compileIdentifierCore(
   if (capturedIdx !== undefined) {
     // TDZ check: throw ReferenceError if let/const variable accessed before initialization
     // Apply static analysis — captured globals are often accessed from closures,
-    // but analyzeTdzAccess handles the cross-function case correctly (returns "check")
-    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
+    // but analyzeIdentifierTdzAccess handles the cross-function case correctly (returns "check")
+    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeIdentifierTdzAccess(ctx, id) : "skip";
     if (tdzResult === "check") {
       emitTdzCheck(ctx, fctx, name);
     } else if (tdzResult === "throw") {
@@ -1318,7 +1318,7 @@ function compileIdentifierCore(
   if (moduleIdx !== undefined) {
     // TDZ check: throw ReferenceError if let/const variable accessed before initialization
     // Apply static analysis for module-level globals
-    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
+    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeIdentifierTdzAccess(ctx, id) : "skip";
     if (tdzResult === "check") {
       emitTdzCheck(ctx, fctx, name);
     } else if (tdzResult === "throw") {

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -77,6 +77,7 @@ import {
   resolvePromiseSubclassIdentifier,
   tryEmitPromiseSubclassValue,
 } from "./promise-subclass.js";
+import { emitLiveIdentifierGlobalRead, tryEmitAmbientRegistryCollisionRead } from "./identifier-module-storage.js";
 import {
   emitCaptureRuntimeEvalBindingValueCell,
   emitImplicitGlobalRead,
@@ -1243,6 +1244,8 @@ function compileIdentifierCore(
     ? compileExactAmbientShadowedModuleBinding(ctx, fctx, id)
     : undefined;
   if (ambientShadowType) return ambientShadowType;
+  const ambientCollisionType = tryEmitAmbientRegistryCollisionRead(ctx, fctx, id, skipRuntimeEvalState);
+  if (ambientCollisionType) return ambientCollisionType;
 
   // (#4618) A class declaration is already represented by its canonical,
   // identity-stable class-object singleton, so it never needs a value-copy
@@ -1302,9 +1305,7 @@ function compileIdentifierCore(
     } else if (tdzResult === "throw") {
       emitStaticTdzThrow(ctx, fctx, id.text);
     }
-    fctx.body.push({ op: "global.get", index: capturedIdx });
-    const globalDef = ctx.mod.globals[localGlobalIdx(ctx, capturedIdx)];
-    const gType = globalDef?.type ?? { kind: "f64" };
+    const gType = emitLiveIdentifierGlobalRead(ctx, fctx, ctx.capturedGlobals, name);
     // Globals widened from ref to ref_null for null init — narrow back
     if (gType.kind === "ref_null" && (ctx.capturedGlobalsWidened.has(name) || fctx.narrowedNonNull?.has(name))) {
       fctx.body.push({ op: "ref.as_non_null" });
@@ -1324,9 +1325,7 @@ function compileIdentifierCore(
     } else if (tdzResult === "throw") {
       emitStaticTdzThrow(ctx, fctx, id.text);
     }
-    fctx.body.push({ op: "global.get", index: moduleIdx });
-    const globalDef = ctx.mod.globals[localGlobalIdx(ctx, moduleIdx)];
-    const mType = globalDef?.type ?? { kind: "f64" };
+    const mType = emitLiveIdentifierGlobalRead(ctx, fctx, ctx.moduleGlobals, name);
     // Null narrowing for module globals
     if (mType.kind === "ref_null" && fctx.narrowedNonNull?.has(name)) {
       fctx.body.push({ op: "ref.as_non_null" });

--- a/src/codegen/expressions/unresolvable-assign.ts
+++ b/src/codegen/expressions/unresolvable-assign.ts
@@ -32,6 +32,7 @@ import { coerceType } from "../type-coercion.js";
 import { compileExpression } from "../expressions.js";
 import { emitRuntimeEvalAotCallableAdapter } from "../runtime-eval-callable.js";
 import { skipTransparentExpressions } from "../shared.js";
+import { currentSourceModuleGlobalIndex, identifierHasOnlyAmbientDeclarations } from "./identifier-module-storage.js";
 
 /**
  * Returned when the assignment is NOT an unresolvable-identifier assignment, so
@@ -65,7 +66,7 @@ export function isUnresolvableIdent(ctx: CodegenContext, fctx: FunctionContext, 
   if (fctx.localMap.has(name)) return false;
   if (fctx.boxedCaptures?.has(name)) return false;
   if (ctx.capturedGlobals.has(name)) return false;
-  if (ctx.moduleGlobals.has(name)) return false;
+  if (currentSourceModuleGlobalIndex(ctx, id) !== undefined) return false;
   if (ctx.funcMap.has(name)) return false;
   // For shorthand property assignments `{x}` the checker returns the synthetic
   // property symbol (SymbolFlags.Property = 4) even when `x` has no value
@@ -78,14 +79,13 @@ export function isUnresolvableIdent(ctx: CodegenContext, fctx: FunctionContext, 
     ).getShorthandAssignmentValueSymbol?.(id.parent);
     return !valSym;
   }
-  const sym = ctx.checker.getSymbolAtLocation(id);
-  if (!sym) return true;
-  const decls = sym.declarations;
-  if (!decls || decls.length === 0) return true;
-  for (const d of decls) {
-    if (d !== id) return false;
+  const declarations = ctx.oracle.declarationsOf(id);
+  if (declarations.length === 0) return true;
+  if (identifierHasOnlyAmbientDeclarations(ctx, id)) return true;
+  if (ctx.sourceIsModule && declarations.every((declaration) => declaration.getSourceFile() !== id.getSourceFile())) {
+    return true;
   }
-  return true;
+  return false;
 }
 
 export function findUnresolvableInObjectPattern(
@@ -157,6 +157,30 @@ export function tryCompileUnresolvableIdentifierAssign(
   if (!isUnresolvableIdent(ctx, fctx, left)) return NOT_UNRESOLVABLE;
   const name = left.text;
   const strict = isStrictContext(left, ctx.inferModuleStrictArguments);
+
+  // An ambient declaration is a statically resolved GlobalEnvironmentRecord
+  // binding, not an unresolvable Reference. The flat module-global registry
+  // may contain a foreign collision, but strict PutValue must still update the
+  // declared global without a runtime HasBinding probe.
+  if (identifierHasOnlyAmbientDeclarations(ctx, left)) {
+    if (!emitGlobalEnvironmentObject(ctx, fctx)) return NOT_UNRESOLVABLE;
+    const objectLocal = allocLocal(fctx, `__ambient_global_obj_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: objectLocal });
+    const resultType = compileExpression(ctx, fctx, right);
+    if (!resultType) return null;
+    const resultLocal = allocLocal(fctx, `__ambient_global_rhs_${fctx.locals.length}`, resultType);
+    fctx.body.push({ op: "local.set", index: resultLocal }, { op: "local.get", index: objectLocal });
+    emitGlobalEnvironmentKey(ctx, fctx, name);
+    fctx.body.push({ op: "local.get", index: resultLocal });
+    if (resultType.kind !== "externref") coerceType(ctx, fctx, resultType, { kind: "externref" });
+    const setIdx = ensureGlobalEnvironmentOperation(ctx, fctx, "__extern_set");
+    if (setIdx === undefined) return null;
+    fctx.body.push(
+      { op: "call", funcIdx: ctx.funcMap.get("__extern_set") ?? setIdx },
+      { op: "local.get", index: resultLocal },
+    );
+    return resultType;
+  }
 
   // Resolve the provider-created activation binding BEFORE the RHS. The
   // captured value cell is a stable Reference: an RHS that performs another

--- a/src/codegen/module-global-registration.ts
+++ b/src/codegen/module-global-registration.ts
@@ -1,11 +1,106 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { GlobalDef, Instr, ValType } from "../ir/types.js";
-import { ts } from "../ts-api.js";
+import { forEachChild, ts } from "../ts-api.js";
 import { hasDeclareModifier } from "./ast-modifiers.js";
 import type { CodegenContext } from "./context/types.js";
 import { computeElidableTopLevelTdzNames } from "./expressions/identifiers.js";
 import { localGlobalIdx, nextModuleGlobalIdx } from "./registry/imports.js";
+
+const TOP_LEVEL_LEXICAL_FLAGS = ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing;
+
+function isFunctionOrClassBoundary(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isClassExpression(node)
+  );
+}
+
+function unwrapParenthesizedExpression(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (ts.isParenthesizedExpression(current)) current = current.expression;
+  return current;
+}
+
+/**
+ * Retain TDZ state for a checker-unresolved write inside a dynamic `with`.
+ *
+ * TypeScript deliberately leaves the bare target of `with (scope) { x = v }`
+ * symbol-less: the Object Environment Record decides at runtime whether the
+ * write reaches `scope.x` or the outer binding. The ordinary elision walk
+ * therefore cannot join that occurrence back to a declaration. Admit only the
+ * bounded miss route used by the dynamic-with writer: the occurrence has no
+ * oracle declaration at all and its spelling names one direct, non-ambient
+ * top-level lexical in this exact SourceFile. A resolved local, capture,
+ * import, ambient declaration, or foreign declaration cannot enter this path.
+ */
+function unresolvedDynamicWithTopLevelLexicalWrites(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  candidates: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const declarationCounts = new Map<string, number>();
+  if (!sourceFile.isDeclarationFile) {
+    for (const statement of sourceFile.statements) {
+      if (
+        !ts.isVariableStatement(statement) ||
+        hasDeclareModifier(statement) ||
+        (statement.declarationList.flags & TOP_LEVEL_LEXICAL_FLAGS) === 0
+      ) {
+        continue;
+      }
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name) && candidates.has(declaration.name.text)) {
+          declarationCounts.set(declaration.name.text, (declarationCounts.get(declaration.name.text) ?? 0) + 1);
+        }
+      }
+    }
+  }
+  const topLevelLexicals = new Set([...declarationCounts].filter(([, count]) => count === 1).map(([name]) => name));
+  if (topLevelLexicals.size === 0) return new Set();
+
+  const retained = new Set<string>();
+  const recordUnresolvedWrite = (target: ts.Expression): void => {
+    const identifier = unwrapParenthesizedExpression(target);
+    if (!ts.isIdentifier(identifier) || !topLevelLexicals.has(identifier.text)) return;
+    if (ctx.oracle.valueDeclarationOf(identifier) !== undefined || ctx.oracle.declarationsOf(identifier).length > 0) {
+      return;
+    }
+    retained.add(identifier.text);
+  };
+  const visitWithBody = (body: ts.Statement): void => {
+    const visit = (node: ts.Node): void => {
+      if (node !== body && isFunctionOrClassBoundary(node)) return;
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+        node.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+      ) {
+        recordUnresolvedWrite(node.left);
+      } else if (
+        (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+        (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)
+      ) {
+        recordUnresolvedWrite(node.operand);
+      }
+      forEachChild(node, visit);
+    };
+    visit(body);
+  };
+  const visitSource = (node: ts.Node): void => {
+    if (retained.size === topLevelLexicals.size) return;
+    if (ts.isWithStatement(node)) visitWithBody(node.statement);
+    forEachChild(node, visitSource);
+  };
+  visitSource(sourceFile);
+  return retained;
+}
 
 /**
  * Find the runtime-owning top-level declaration of `name` in `sourceFile`.
@@ -138,6 +233,9 @@ export function registerModuleTdzGlobal(ctx: CodegenContext, sourceFile: ts.Sour
  */
 export function prepareModuleTdzGlobals(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
   const elidableTdzNames = computeElidableTopLevelTdzNames(ctx, sourceFile, ctx.tdzLetConstNames);
+  for (const name of unresolvedDynamicWithTopLevelLexicalWrites(ctx, sourceFile, elidableTdzNames)) {
+    elidableTdzNames.delete(name);
+  }
   for (const name of elidableTdzNames) {
     ctx.tdzLetConstNames.delete(name);
   }

--- a/src/codegen/statements/tdz.ts
+++ b/src/codegen/statements/tdz.ts
@@ -105,11 +105,15 @@ export function emitTdzCheckAtGlobal(
     return;
   }
 
-  const throwRefErrIdx = ensureLateImport(ctx, "__throw_reference_error", [{ kind: "externref" }], []);
-  flushLateImportShifts(ctx, fctx);
   // if (flag == 0) throw ReferenceError
+  // Emit the flag read before settling the real-ReferenceError provider: its
+  // constructor/message may insert imports, and the canonical global-index
+  // fixup can then relocate this already-live instruction. A numeric flagIdx
+  // captured by an exact-source caller cannot be repaired after the fact.
   fctx.body.push({ op: "global.get", index: flagIdx });
   fctx.body.push({ op: "i32.eqz" });
+  const throwRefErrIdx = ensureLateImport(ctx, "__throw_reference_error", [{ kind: "externref" }], []);
+  flushLateImportShifts(ctx, fctx);
   let then: Instr[];
   if (throwRefErrIdx !== undefined) {
     addStringConstantGlobal(ctx, msg);

--- a/tests/issue-4755-detached-assignment-repoint.test.ts
+++ b/tests/issue-4755-detached-assignment-repoint.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const SOURCE = `
+  var fallbackCalls4755: number = 0;
+  var completedWrites4755: number = 0;
+  var verdict4755: number = 0;
+  function fallback4755(): number { fallbackCalls4755 += 1; return 41; }
+  function assign4755(useDefault: number): number {
+    const input: { first: any } = { first: useDefault ? undefined : 7 };
+    ({ first: target4755 = fallback4755() } = input);
+    completedWrites4755 += 1;
+    return target4755;
+  }
+  try { assign4755(1); }
+  catch (error) { verdict4755 = error instanceof ReferenceError ? 1 : 2; }
+  let target4755: number;
+  export function run(): number {
+    const value4755 = assign4755(0);
+    var score4755: number = 0;
+    if (verdict4755 === 1) score4755 += 1;
+    if (fallbackCalls4755 === 1) score4755 += 2;
+    if (completedWrites4755 === 1) score4755 += 4;
+    if (value4755 === 7) score4755 += 8;
+    if (target4755 === 7) score4755 += 16;
+    return score4755;
+  }
+`;
+
+async function run(result: CompileResult, target: "gc" | "standalone"): Promise<number> {
+  if (target === "standalone") {
+    const child = spawnSync(
+      process.execPath,
+      [
+        "--experimental-wasm-exnref",
+        "--input-type=module",
+        "--eval",
+        `const chunks=[]; for await (const c of process.stdin) chunks.push(c);
+         const { instance } = await WebAssembly.instantiate(Buffer.concat(chunks), {});
+         if (typeof instance.exports.__module_init === "function") instance.exports.__module_init();
+         process.stdout.write(String(instance.exports.run()));`,
+      ],
+      { input: result.binary, encoding: "utf8" },
+    );
+    expect(child.status, child.stderr || child.error?.message).toBe(0);
+    return Number(child.stdout);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  imports.setExports?.(instance.exports);
+  if (typeof instance.exports.__module_init === "function") instance.exports.__module_init();
+  return (instance.exports.run as () => number)();
+}
+
+describe.each(["gc", "standalone"] as const)("#4755 detached assignment repoint — %s", (target) => {
+  it("keeps the default arm live while the value arm registers a later coercion helper", async () => {
+    const result = await compile(SOURCE, {
+      fileName: `issue-4755-detached-assignment-repoint-${target}.ts`,
+      deferTopLevelInit: true,
+      experimentalIR: false,
+      emitWat: true,
+      skipSemanticDiagnostics: true,
+      target,
+    });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.wat).toContain("fallback4755");
+    expect(result.wat).toContain("__unbox_number");
+    expect(result.wat).toMatch(/ReferenceError/);
+    expect(await run(result, target)).toBe(31);
+  });
+});

--- a/tests/issue-4755-module-lexical-assignment-tdz.test.ts
+++ b/tests/issue-4755-module-lexical-assignment-tdz.test.ts
@@ -1,0 +1,666 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4755 — the transitional direct frontend must perform PutValue's module-
+ * lexical TDZ check after evaluating the assignment value, including the
+ * already-live object/array destructuring sinks. Every runtime row deliberately
+ * pins `experimentalIR: false` in both WasmGC lanes so an IR-owned body cannot
+ * hide a legacy-body failure.
+ */
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+
+import { compile, compileMulti, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const TARGETS = ["gc", "standalone"] as const;
+type Target = (typeof TARGETS)[number];
+
+const DIRECT_OPTIONS = {
+  experimentalIR: false,
+  deferTopLevelInit: true,
+  emitWat: true,
+  skipSemanticDiagnostics: true,
+} as const;
+
+interface RuntimeResult {
+  readonly result: CompileResult;
+  readonly value: number;
+}
+
+function compileFailure(result: CompileResult): string {
+  return result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n");
+}
+
+function actualImportNames(result: CompileResult): readonly string[] {
+  return WebAssembly.Module.imports(new WebAssembly.Module(result.binary))
+    .map(({ module, name }) => `${module}.${name}`)
+    .sort();
+}
+
+const STANDALONE_PROBE = `
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const module = new WebAssembly.Module(Buffer.concat(chunks));
+  const imports = WebAssembly.Module.imports(module)
+    .map(({ module, name }) => module + "." + name)
+    .sort();
+  const instance = await WebAssembly.instantiate(module, {});
+  const name = process.env.JS2WASM_4755_RUN_EXPORT;
+  let value;
+  if (name) {
+    if (typeof instance.exports.__module_init === "function") instance.exports.__module_init();
+    value = instance.exports[name]();
+  }
+  process.stdout.write(JSON.stringify({ imports, value }));
+`;
+
+function probeStandalone(
+  result: CompileResult,
+  runExport?: string,
+): { readonly imports: string[]; readonly value?: number } {
+  const child = spawnSync(
+    process.execPath,
+    ["--experimental-wasm-exnref", "--input-type=module", "--eval", STANDALONE_PROBE],
+    {
+      input: result.binary,
+      encoding: "utf8",
+      env: { ...process.env, JS2WASM_4755_RUN_EXPORT: runExport ?? "" },
+      maxBuffer: 8 * 1024 * 1024,
+    },
+  );
+  expect(child.status, child.stderr || child.error?.message).toBe(0);
+  return JSON.parse(child.stdout) as { readonly imports: string[]; readonly value?: number };
+}
+
+function expectStandaloneHostFree(result: CompileResult): void {
+  expect(probeStandalone(result).imports, "standalone Wasm import section").toEqual([]);
+  expect(result.imports, "standalone compiler import descriptors").toEqual([]);
+  expect(result.hostImportSummary?.total ?? 0, "standalone host-import inventory").toBe(0);
+}
+
+async function compileDirect(source: string, fileName: string, target: Target): Promise<CompileResult> {
+  const result = await compile(source, {
+    ...DIRECT_OPTIONS,
+    fileName,
+    target,
+    hostBridge: target === "gc" ? "always" : "off",
+  });
+  expect(result.success, compileFailure(result)).toBe(true);
+  if (target === "standalone") expectStandaloneHostFree(result);
+  else expect(WebAssembly.validate(result.binary)).toBe(true);
+  return result;
+}
+
+async function compileMultiDirect(
+  sources: Record<string, string>,
+  entryFile: string,
+  target: Target,
+): Promise<CompileResult> {
+  const result = await compileMulti(sources, entryFile, {
+    ...DIRECT_OPTIONS,
+    target,
+    hostBridge: target === "gc" ? "always" : "off",
+  });
+  expect(result.success, compileFailure(result)).toBe(true);
+  if (target === "standalone") expectStandaloneHostFree(result);
+  else expect(WebAssembly.validate(result.binary)).toBe(true);
+  return result;
+}
+
+async function instantiateAndInitialize(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setInstance?.(instance);
+  imports.setExports?.(exports);
+  expect(exports.__module_init, "deferred module initializer").toBeTypeOf("function");
+  exports.__module_init!();
+  return exports;
+}
+
+async function compileAndRunDirect(source: string, fileName: string, target: Target): Promise<RuntimeResult> {
+  const result = await compileDirect(source, fileName, target);
+  if (target === "standalone") {
+    const { value } = probeStandalone(result, "run");
+    expect(value).toBeTypeOf("number");
+    return { result, value: value! };
+  }
+  const exports = await instantiateAndInitialize(result);
+  expect(exports.run, "numeric proof export").toBeTypeOf("function");
+  const value = exports.run!();
+  expect(value).toBeTypeOf("number");
+  return { result, value };
+}
+
+interface WatFunction {
+  readonly name: string;
+  readonly body: string;
+}
+
+function parseWatFunctions(wat: string): readonly WatFunction[] {
+  const starts = [...wat.matchAll(/^ {2}\(func \$([^\s(]+)/gm)].map((match) => ({
+    name: match[1]!,
+    index: match.index,
+  }));
+  const names = starts.map(({ name }) => name);
+  expect(new Set(names).size, "WAT function names must be unique for provider attribution").toBe(names.length);
+  return starts.map(({ name, index }, position) => ({
+    name,
+    body: wat.slice(index, starts[position + 1]?.index ?? wat.length),
+  }));
+}
+
+function watFunction(result: CompileResult, name: string): WatFunction {
+  const matches = parseWatFunctions(result.wat).filter((candidate) => candidate.name === name);
+  expect(matches, `unique WAT function $${name}`).toHaveLength(1);
+  return matches[0]!;
+}
+
+function watCallTargets(wat: string, body: string): readonly string[] {
+  const imports = [...wat.matchAll(/^\s*\(import .+ \(func(?: \$([^\s(]+))?/gm)].map(
+    (match) => match[1] ?? "<anonymous-import>",
+  );
+  const definitions = [...wat.matchAll(/^\s*\(func \$([^\s(]+)/gm)].map((match) => match[1]!);
+  const names = [...imports, ...definitions];
+  return [...body.matchAll(/\b(?:return_)?call (\d+)/g)].map((match) => {
+    const target = names[Number(match[1])] ?? "<missing>";
+    return target.endsWith("_import") ? target.slice(0, -"_import".length) : target;
+  });
+}
+
+function referenceErrorCallCount(result: CompileResult, functionName?: string): number {
+  const functions = functionName ? [watFunction(result, functionName)] : parseWatFunctions(result.wat);
+  return functions
+    .flatMap(({ body }) => watCallTargets(result.wat, body))
+    .filter((target) => target === "__new_ReferenceError" || target === "__throw_reference_error").length;
+}
+
+function referenceErrorImports(result: CompileResult, target: Target): readonly string[] {
+  const imports = target === "standalone" ? probeStandalone(result).imports : actualImportNames(result);
+  return imports.filter((name) => name.endsWith(".__new_ReferenceError") || name.endsWith(".__throw_reference_error"));
+}
+
+const EXACT_CLASS_SETTER_SOURCE = `
+  function trigger(): void {
+    const C = class {
+      set value(next) {
+        target = next;
+      }
+    };
+    new C().value = 42;
+  }
+
+  var verdict: number = 0;
+  try {
+    trigger();
+  } catch (error) {
+    verdict = error instanceof ReferenceError ? 1 : 2;
+  }
+  let target: any;
+
+  export function run(): number {
+    return verdict;
+  }
+`;
+
+describe.each(TARGETS)("#4755 direct module-lexical assignment TDZ — %s", (target) => {
+  it("runs the exact class-setter prerequisite and catches a real ReferenceError", async () => {
+    const { value } = await compileAndRunDirect(
+      EXACT_CLASS_SETTER_SOURCE,
+      `issue-4755-exact-class-setter-${target}.ts`,
+      target,
+    );
+    expect(value).toBe(1);
+  });
+
+  it("evaluates the setter RHS once before PutValue and stops at the TDZ throw", async () => {
+    const { value } = await compileAndRunDirect(
+      `
+        var setterCalls: number = 0;
+        var rhsCalls: number = 0;
+        var afterAssignment: number = 0;
+        var verdict: number = 0;
+
+        function rhs(next: any): any {
+          rhsCalls += 1;
+          return next;
+        }
+        function trigger(): void {
+          const C = class {
+            set value(next) {
+              setterCalls += 1;
+              target = rhs(next);
+              afterAssignment = 1;
+            }
+          };
+          new C().value = 42;
+        }
+
+        try {
+          trigger();
+        } catch (error) {
+          verdict = error instanceof ReferenceError ? 1 : 2;
+        }
+        let target: any;
+        var storageClean: number = target === undefined ? 1 : 0;
+
+        export function run(): number {
+          var score: number = 0;
+          if (verdict === 1) score += 1;
+          if (setterCalls === 1) score += 2;
+          if (rhsCalls === 1) score += 4;
+          if (afterAssignment === 0) score += 8;
+          if (storageClean === 1) score += 16;
+          return score;
+        }
+      `,
+      `issue-4755-rhs-order-${target}.ts`,
+      target,
+    );
+    expect(value).toBe(31);
+  });
+
+  it("allows the same ambiguous setter write after the lexical is initialized", async () => {
+    const { value } = await compileAndRunDirect(
+      `
+        var setterCalls: number = 0;
+        var afterAssignment: number = 0;
+        function trigger(): void {
+          const C = class {
+            set value(next) {
+              setterCalls += 1;
+              target = next;
+              afterAssignment = 1;
+            }
+          };
+          new C().value = 42;
+        }
+
+        let target: any;
+        trigger();
+        var stored: number = target === 42 ? 1 : 0;
+
+        export function run(): number {
+          var score: number = 0;
+          if (setterCalls === 1) score += 1;
+          if (stored === 1) score += 2;
+          if (afterAssignment === 1) score += 4;
+          return score;
+        }
+      `,
+      `issue-4755-initialized-class-setter-${target}.ts`,
+      target,
+    );
+    expect(value).toBe(7);
+  });
+});
+
+interface DestructuringCase {
+  readonly label: string;
+  readonly expectedDefaultCalls: 0 | 1;
+  readonly fixture: string;
+  readonly assignment: string;
+}
+
+function destructuringSource(row: DestructuringCase): string {
+  return `
+    var rhsCalls: number = 0;
+    var firstWork: number = 0;
+    var laterReads: number = 0;
+    var defaultCalls: number = 0;
+    var later: any = 7;
+    var afterAssignment: number = 0;
+    var verdict: number = 0;
+
+    function defaultValue(): any {
+      defaultCalls += 1;
+      return 41;
+    }
+    ${row.fixture}
+
+    function trigger(): void {
+      ${row.assignment}
+      afterAssignment = 1;
+    }
+
+    try {
+      trigger();
+    } catch (error) {
+      verdict = error instanceof ReferenceError ? 1 : 2;
+    }
+    let target: any;
+    var storageClean: number = target === undefined ? 1 : 0;
+
+    export function run(): number {
+      var score: number = 0;
+      if (verdict === 1) score += 1;
+      if (rhsCalls === 1) score += 2;
+      if (firstWork === 1) score += 4;
+      if (defaultCalls === ${row.expectedDefaultCalls}) score += 8;
+      if (laterReads === 0) score += 16;
+      if (later === 7) score += 32;
+      if (afterAssignment === 0) score += 64;
+      if (storageClean === 1) score += 128;
+      return score;
+    }
+  `;
+}
+
+const DESTRUCTURING_CASES: readonly DestructuringCase[] = [
+  {
+    label: "typed object / plain identifier target",
+    expectedDefaultCalls: 0,
+    fixture: `
+      function firstValue(): number {
+        firstWork += 1;
+        return 41;
+      }
+      function makeValue(): { first: number; second: number } {
+        rhsCalls += 1;
+        return { first: firstValue(), second: 99 };
+      }
+    `,
+    assignment: `({ first: target, second: later } = makeValue());`,
+  },
+  {
+    label: "typed object / defaulted identifier target",
+    expectedDefaultCalls: 1,
+    fixture: `
+      function makeValue(): { first: any; second: number } {
+        rhsCalls += 1;
+        firstWork += 1;
+        return { first: undefined, second: 99 };
+      }
+    `,
+    assignment: `({ first: target = defaultValue(), second: later } = makeValue());`,
+  },
+  {
+    label: "any externref object / plain identifier target",
+    expectedDefaultCalls: 0,
+    fixture: `
+      function makeValue(): any {
+        rhsCalls += 1;
+        return {
+          get first(): any { firstWork += 1; return 41; },
+          get second(): any { laterReads += 1; return 99; }
+        } as any;
+      }
+    `,
+    assignment: `({ first: target, second: later } = makeValue());`,
+  },
+  {
+    label: "any externref object / defaulted identifier target",
+    expectedDefaultCalls: 1,
+    fixture: `
+      function makeValue(): any {
+        rhsCalls += 1;
+        return {
+          get first(): any { firstWork += 1; return undefined; },
+          get second(): any { laterReads += 1; return 99; }
+        } as any;
+      }
+    `,
+    assignment: `({ first: target = defaultValue(), second: later } = makeValue());`,
+  },
+  {
+    label: "typed tuple array / plain identifier target",
+    expectedDefaultCalls: 0,
+    fixture: `
+      function firstValue(): number {
+        firstWork += 1;
+        return 41;
+      }
+      function makeValue(): [number, number] {
+        rhsCalls += 1;
+        return [firstValue(), 99];
+      }
+    `,
+    assignment: `[target, later] = makeValue();`,
+  },
+  {
+    label: "typed tuple array / defaulted identifier target",
+    expectedDefaultCalls: 1,
+    fixture: `
+      function makeValue(): [any, number] {
+        rhsCalls += 1;
+        firstWork += 1;
+        return [undefined, 99];
+      }
+    `,
+    assignment: `[target = defaultValue(), later] = makeValue();`,
+  },
+  {
+    label: "any externref array / plain identifier target",
+    expectedDefaultCalls: 0,
+    fixture: `
+      function firstValue(): number {
+        firstWork += 1;
+        return 41;
+      }
+      function makeValue(): any {
+        rhsCalls += 1;
+        return [firstValue(), 99] as any;
+      }
+    `,
+    assignment: `[target, later] = makeValue();`,
+  },
+  {
+    label: "any externref array / defaulted identifier target",
+    expectedDefaultCalls: 1,
+    fixture: `
+      function makeValue(): any {
+        rhsCalls += 1;
+        firstWork += 1;
+        return [undefined, 99] as any;
+      }
+    `,
+    assignment: `[target = defaultValue(), later] = makeValue();`,
+  },
+] as const;
+
+describe.each(TARGETS)("#4755 direct destructuring TDZ sink matrix — %s", (target) => {
+  it.each(DESTRUCTURING_CASES)("$label", async (row) => {
+    const slug = row.label.replaceAll(/[^a-z]+/g, "-");
+    const { value } = await compileAndRunDirect(destructuringSource(row), `issue-4755-${slug}-${target}.ts`, target);
+    expect(value).toBe(255);
+  });
+
+  it("drives an isolated Array.prototype[@@iterator] override before the first target guard", async () => {
+    const source = `
+        var rhsCalls: number = 0;
+        var iteratorCalls: number = 0;
+        var later: any = 7;
+        var afterAssignment: number = 0;
+        var verdict: number = 0;
+
+        Array.prototype[Symbol.iterator] = function* () {
+          iteratorCalls += 1;
+          yield 41;
+          yield 99;
+        };
+
+        function makeValue(): number[] {
+          rhsCalls += 1;
+          return [1, 2];
+        }
+        function trigger(): void {
+          [target, later] = makeValue();
+          afterAssignment = 1;
+        }
+
+        try {
+          trigger();
+        } catch (error) {
+          verdict = error instanceof ReferenceError ? 1 : 2;
+        }
+        let target: any;
+        var storageClean: number = target === undefined ? 1 : 0;
+
+        export function run(): number {
+          var score: number = 0;
+          if (verdict === 1) score += 1;
+          if (rhsCalls === 1) score += 2;
+          if (iteratorCalls === 1) score += 4;
+          if (later === 7) score += 16;
+          if (afterAssignment === 0) score += 32;
+          if (storageClean === 1) score += 64;
+          return score;
+        }
+      `;
+    const fileName = `issue-4755-array-iterator-override-${target}.ts`;
+    if (target === "standalone") {
+      // #1719 residual (carrier-contract evidence: #2038/#3164): standalone
+      // CPR still traps in __iterator_next. Keep #4755's route/provider proof
+      // non-vacuous without absorbing that iterator-runtime migration.
+      const result = await compileDirect(source, fileName, target);
+      const moduleInit = watFunction(result, "__module_init").body;
+      expect(watCallTargets(result.wat, moduleInit)).toContain("__drive_proto_iterator");
+      expect(result.wat).toContain("$__iterator_next");
+      expect(referenceErrorCallCount(result)).toBeGreaterThan(0);
+      return;
+    }
+    const { value } = await compileAndRunDirect(source, fileName, target);
+    expect(value).toBe(119);
+  });
+});
+
+describe.each(TARGETS)("#4755 direct assignment identity controls — %s", (target) => {
+  it("keeps same-named parameter and local writes off the module lexical", async () => {
+    const { value } = await compileAndRunDirect(
+      `
+        function writeParameter(target: any): any {
+          target = 17;
+          return target;
+        }
+        function writeLocal(): any {
+          let target: any = 3;
+          target = 23;
+          return target;
+        }
+
+        var parameterResult: any = writeParameter(0);
+        var localResult: any = writeLocal();
+        let target: any;
+        var moduleUntouched: number = target === undefined ? 1 : 0;
+
+        export function run(): number {
+          var score: number = 0;
+          if (parameterResult === 17) score += 1;
+          if (localResult === 23) score += 2;
+          if (moduleUntouched === 1) score += 4;
+          return score;
+        }
+      `,
+      `issue-4755-shadow-controls-${target}.ts`,
+      target,
+    );
+    expect(value).toBe(7);
+  });
+
+  it("does not attach a foreign lexical's guard to a same-spelled import binding", async () => {
+    const result = await compileMultiDirect(
+      {
+        "./lexical.ts": `export let target: number;`,
+        "./provider.ts": `export var providerValue: number = 3;`,
+        "./entry.ts": `
+          import "./lexical";
+          import { providerValue as target } from "./provider";
+          export function writeImported4755(): number {
+            target = 9;
+            return 1;
+          }
+        `,
+      },
+      "./entry.ts",
+      target,
+    );
+    expect(referenceErrorCallCount(result, "writeImported4755")).toBe(0);
+  });
+
+  it("does not attach a lexical guard to a same-spelled var in another source", async () => {
+    const result = await compileMultiDirect(
+      {
+        "./lexical.ts": `export let target: number;`,
+        "./foreign.ts": `
+          var target: number = 3;
+          export function writeForeign4755(): number {
+            target = 9;
+            return 1;
+          }
+        `,
+        "./entry.ts": `
+          import "./lexical";
+          export { writeForeign4755 } from "./foreign";
+        `,
+      },
+      "./entry.ts",
+      target,
+    );
+    expect(referenceErrorCallCount(result, "writeForeign4755")).toBe(0);
+  });
+});
+
+describe.each(TARGETS)("#4755 direct TDZ provider and elision artifacts — %s", (target) => {
+  it("keeps the live provider but makes initialized-let and var writes ReferenceError-neutral", async () => {
+    const preInitialization = await compileAndRunDirect(
+      `
+        var rhsCalls: number = 0;
+        var verdict: number = 0;
+        function rhs(): number { rhsCalls += 1; return 42; }
+        try {
+          target = rhs();
+        } catch (error) {
+          verdict = error instanceof ReferenceError ? 1 : 2;
+        }
+        let target: number;
+        export function run(): number { return verdict * 10 + rhsCalls; }
+      `,
+      `issue-4755-artifact-positive-${target}.ts`,
+      target,
+    );
+    expect(preInitialization.value).toBe(11);
+    expect(referenceErrorCallCount(preInitialization.result)).toBeGreaterThan(0);
+
+    const initialized = await compileAndRunDirect(
+      `
+        var observed: number = 0;
+        let target: number = 1;
+        target = 42;
+        observed = target;
+        export function run(): number { return observed; }
+      `,
+      `issue-4755-artifact-initialized-${target}.ts`,
+      target,
+    );
+    const varTwin = await compileAndRunDirect(
+      `
+        var observed: number = 0;
+        var target: number = 1;
+        target = 42;
+        observed = target;
+        export function run(): number { return observed; }
+      `,
+      `issue-4755-artifact-var-${target}.ts`,
+      target,
+    );
+
+    expect(initialized.value).toBe(42);
+    expect(varTwin.value).toBe(42);
+    expect(referenceErrorCallCount(initialized.result)).toBe(0);
+    expect(referenceErrorCallCount(varTwin.result)).toBe(0);
+    expect(referenceErrorImports(initialized.result, target)).toEqual([]);
+    expect(referenceErrorImports(varTwin.result, target)).toEqual([]);
+    expect(initialized.result.linkedModules ?? []).toEqual([]);
+    expect(varTwin.result.linkedModules ?? []).toEqual([]);
+
+    if (target === "standalone") {
+      expect(referenceErrorImports(preInitialization.result, target)).toEqual([]);
+      expect(
+        parseWatFunctions(preInitialization.result.wat).map(({ name }) => name),
+        "standalone live in-module ReferenceError constructor",
+      ).toContain("__new_ReferenceError");
+    } else {
+      expect(referenceErrorImports(preInitialization.result, target)).toEqual(["env.__throw_reference_error"]);
+    }
+  });
+});

--- a/tests/issue-4755-module-lexical-assignment-tdz.test.ts
+++ b/tests/issue-4755-module-lexical-assignment-tdz.test.ts
@@ -6,7 +6,7 @@
  * pins `experimentalIR: false` in both WasmGC lanes so an IR-owned body cannot
  * hide a legacy-body failure.
  */
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
 
 import { compile, compileMulti, type CompileResult } from "../src/index.js";
@@ -25,6 +25,10 @@ const DIRECT_OPTIONS = {
 interface RuntimeResult {
   readonly result: CompileResult;
   readonly value: number;
+}
+
+interface RuntimeEvalResult extends RuntimeResult {
+  readonly imports: readonly string[];
 }
 
 function compileFailure(result: CompileResult): string {
@@ -51,6 +55,28 @@ const STANDALONE_PROBE = `
     if (typeof instance.exports.__module_init === "function") instance.exports.__module_init();
     value = instance.exports[name]();
   }
+  process.stdout.write(JSON.stringify({ imports, value }));
+`;
+
+const STANDALONE_RUNTIME_EVAL_PROBE = `
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  const providerModule = new WebAssembly.Module(Buffer.from(payload.provider, "base64"));
+  const provider = new WebAssembly.Instance(providerModule, {});
+  const namespace = {
+    __runtime_new_function: provider.exports.__runtime_new_function,
+    __runtime_indirect_eval: provider.exports.__runtime_indirect_eval,
+    __runtime_direct_eval: provider.exports.__runtime_direct_eval,
+    __runtime_apply_interpreted: provider.exports.__runtime_apply_interpreted,
+  };
+  const userModule = new WebAssembly.Module(Buffer.from(payload.user, "base64"));
+  const imports = WebAssembly.Module.imports(userModule)
+    .map(({ module, name }) => module + "." + name)
+    .sort();
+  const user = new WebAssembly.Instance(userModule, { "js2wasm:runtime-eval": namespace });
+  if (typeof user.exports.__module_init === "function") user.exports.__module_init();
+  const value = user.exports.run();
   process.stdout.write(JSON.stringify({ imports, value }));
 `;
 
@@ -107,8 +133,30 @@ async function compileMultiDirect(
   return result;
 }
 
-async function instantiateAndInitialize(result: CompileResult): Promise<Record<string, Function>> {
-  const imports = buildImports(result.imports, undefined, result.stringPool);
+async function compileMultiAndRunDirect(
+  sources: Record<string, string>,
+  entryFile: string,
+  target: Target,
+  hostGlobals?: Record<string, unknown>,
+): Promise<RuntimeResult> {
+  const result = await compileMultiDirect(sources, entryFile, target);
+  if (target === "standalone") {
+    const { value } = probeStandalone(result, "run");
+    expect(value).toBeTypeOf("number");
+    return { result, value: value! };
+  }
+  const exports = await instantiateAndInitialize(result, hostGlobals);
+  expect(exports.run, "numeric proof export").toBeTypeOf("function");
+  const value = exports.run!();
+  expect(value).toBeTypeOf("number");
+  return { result, value };
+}
+
+async function instantiateAndInitialize(
+  result: CompileResult,
+  hostGlobals?: Record<string, unknown>,
+): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, hostGlobals, result.stringPool);
   const { instance } = await WebAssembly.instantiate(result.binary, imports);
   const exports = instance.exports as Record<string, Function>;
   imports.setInstance?.(instance);
@@ -132,6 +180,85 @@ async function compileAndRunDirect(source: string, fileName: string, target: Tar
   return { result, value };
 }
 
+let runtimeEvalProviderBinary: Uint8Array;
+
+beforeAll(async () => {
+  const provider = await compile(
+    `
+      interface Cell { value: any }
+      function result(ok: boolean, value: any): any {
+        const out: any[] = [ok, __runtime_eval_wrap_result(value)];
+        return out;
+      }
+      function installTarget(state: any): void {
+        const nameCell = state[0] as Cell;
+        const valueCell = state[1] as Cell;
+        const markerNameCell = state[2] as Cell;
+        const markerValueCell = state[3] as Cell;
+        nameCell.value = "target";
+        valueCell.value = 5;
+        markerNameCell.value = "\\0js2wasm:deletable-eval-binding";
+        markerValueCell.value = undefined;
+      }
+      function refuse(): any { return result(false, new TypeError("unused #4755 provider entry")); }
+      export function __runtime_direct_eval(
+        source: any, globalObject: any, thisArg: any, activationState: any,
+        activationSeedNames: any, activationSeedSlots: any, lexicalNames: any,
+        lexicalSlots: any, outerNames: any, outerSlots: any,
+        callerStrict: boolean, mappedParamNames: any
+      ): any {
+        if (source === "install-target") installTarget(activationState);
+        return result(true, 0);
+      }
+      export function __runtime_indirect_eval(source: any, globalObject: any): any { return refuse(); }
+      export function __runtime_new_function(params: any, body: any, globalObject: any): any { return refuse(); }
+      export function __runtime_apply_interpreted(
+        callable: any, receiver: any, argc: number,
+        a0: any, a1: any, a2: any, a3: any, a4: any, a5: any, a6: any, a7: any
+      ): any { return refuse(); }
+    `,
+    {
+      experimentalIR: false,
+      fileName: "issue-4755-runtime-eval-provider.ts",
+      inferModuleStrictArguments: false,
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+    },
+  );
+  expect(provider.success, compileFailure(provider)).toBe(true);
+  expect(provider.imports, "the bounded #4755 runtime-eval provider is host-free").toEqual([]);
+  expect(provider.hostImportSummary?.total ?? 0).toBe(0);
+  runtimeEvalProviderBinary = provider.binary;
+});
+
+async function compileAndRunRuntimeEvalDirect(source: string, fileName: string): Promise<RuntimeEvalResult> {
+  const result = await compile(source, {
+    ...DIRECT_OPTIONS,
+    fileName,
+    hostBridge: "off",
+    inferModuleStrictArguments: false,
+    target: "standalone",
+  });
+  expect(result.success, compileFailure(result)).toBe(true);
+  const child = spawnSync(
+    process.execPath,
+    ["--experimental-wasm-exnref", "--input-type=module", "--eval", STANDALONE_RUNTIME_EVAL_PROBE],
+    {
+      input: JSON.stringify({
+        provider: Buffer.from(runtimeEvalProviderBinary).toString("base64"),
+        user: Buffer.from(result.binary).toString("base64"),
+      }),
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    },
+  );
+  expect(child.status, child.stderr || child.error?.message).toBe(0);
+  const probe = JSON.parse(child.stdout) as { readonly imports: readonly string[]; readonly value: number };
+  expect(probe.imports).toContain("js2wasm:runtime-eval.__runtime_direct_eval");
+  expect(probe.imports.every((name) => name.startsWith("js2wasm:runtime-eval."))).toBe(true);
+  return { result, imports: probe.imports, value: probe.value };
+}
+
 interface WatFunction {
   readonly name: string;
   readonly body: string;
@@ -142,8 +269,6 @@ function parseWatFunctions(wat: string): readonly WatFunction[] {
     name: match[1]!,
     index: match.index,
   }));
-  const names = starts.map(({ name }) => name);
-  expect(new Set(names).size, "WAT function names must be unique for provider attribution").toBe(names.length);
   return starts.map(({ name, index }, position) => ({
     name,
     body: wat.slice(index, starts[position + 1]?.index ?? wat.length),
@@ -292,6 +417,173 @@ describe.each(TARGETS)("#4755 direct module-lexical assignment TDZ — %s", (tar
       target,
     );
     expect(value).toBe(7);
+  });
+});
+
+function dynamicWithAssignmentSource(hasBinding: boolean): string {
+  return `
+    var rhsCalls: number = 0;
+    var afterAssignment: number = 0;
+    var verdict: number = 0;
+    var scope: any = ${hasBinding ? "{ target: 5, marker: 7 }" : "{ marker: 7 }"};
+
+    function rhs(): any {
+      rhsCalls += 1;
+      return 41;
+    }
+    function trigger(dynamicScope: any): void {
+      with (dynamicScope) {
+        target = rhs();
+        afterAssignment = 1;
+      }
+    }
+
+    try {
+      trigger(scope);
+    } catch (error) {
+      verdict = error instanceof ReferenceError ? 1 : 2;
+    }
+    let target: any;
+    var storageClean: number = target === undefined ? 1 : 0;
+
+    export function run(): number {
+      var score: number = 0;
+      if (rhsCalls === 1) score += 1;
+      if (verdict === ${hasBinding ? 0 : 1}) score += 2;
+      if (${hasBinding ? "scope.target === 41" : '!("target" in scope)'}) score += 4;
+      if (afterAssignment === ${hasBinding ? 1 : 0}) score += 8;
+      if (storageClean === 1) score += 16;
+      if (scope.marker === 7) score += 32;
+      return score;
+    }
+  `;
+}
+
+describe.each(TARGETS)("#4755 dynamic-with precomputed writer routing — %s", (target) => {
+  it("keeps a HasBinding hit on the object without consulting the uninitialized module lexical", async () => {
+    const { value } = await compileAndRunDirect(
+      dynamicWithAssignmentSource(true),
+      `issue-4755-dynamic-with-hit-${target}.ts`,
+      target,
+    );
+    expect(value).toBe(63);
+  });
+
+  it("evaluates the HasBinding miss RHS once before the guarded module-lexical throw", async () => {
+    const { value } = await compileAndRunDirect(
+      dynamicWithAssignmentSource(false),
+      `issue-4755-dynamic-with-miss-${target}.ts`,
+      target,
+    );
+    expect(value).toBe(63);
+  });
+});
+
+function runtimeEvalAssignmentSource(hasBinding: boolean): string {
+  return `
+    var rhsCalls: number = 0;
+    var afterAssignment: number = 0;
+    var verdict: number = 0;
+    var observed: any = 0;
+
+    function join(parts: string[]): string {
+      var out = "";
+      for (var i = 0; i < parts.length; i += 1) out = out + parts[i];
+      return out;
+    }
+    function rhs(): any {
+      rhsCalls += 1;
+      return 41;
+    }
+    function trigger(): any {
+      eval(join(["${hasBinding ? "install" : "leave"}-", "${hasBinding ? "target" : "empty"}"]));
+      target = rhs();
+      afterAssignment = 1;
+      return target;
+    }
+
+    try {
+      observed = trigger();
+    } catch (error) {
+      verdict = error instanceof ReferenceError ? 1 : 2;
+    }
+    let target: any;
+    var storageClean: number = target === undefined ? 1 : 0;
+
+    export function run(): number {
+      var score: number = 0;
+      if (rhsCalls === 1) score += 1;
+      if (verdict === ${hasBinding ? 0 : 1}) score += 2;
+      if (observed === ${hasBinding ? 41 : 0}) score += 4;
+      if (afterAssignment === ${hasBinding ? 1 : 0}) score += 8;
+      if (storageClean === 1) score += 16;
+      return score;
+    }
+  `;
+}
+
+function runtimeEvalAmbientAssignmentSource(hasBinding: boolean): string {
+  return `
+    declare var target: any;
+    var rhsCalls: number = 0;
+    var afterAssignment: number = 0;
+    var verdict: number = 0;
+    var observed: any = 0;
+
+    function join(parts: string[]): string {
+      var out = "";
+      for (var i = 0; i < parts.length; i += 1) out = out + parts[i];
+      return out;
+    }
+    function rhs(): any { rhsCalls += 1; return 41; }
+    function trigger(): any {
+      eval(join(["${hasBinding ? "install" : "leave"}", "-${hasBinding ? "target" : "empty"}"]));
+      target = rhs();
+      afterAssignment = 1;
+      return target;
+    }
+
+    try { observed = trigger(); }
+    catch (error) { verdict = error instanceof ReferenceError ? 1 : 2; }
+
+    export function run(): number {
+      var score: number = 0;
+      if (rhsCalls === 1) score += 1;
+      if (verdict === 0) score += 2;
+      if (observed === 41) score += 4;
+      if (afterAssignment === 1) score += 8;
+      return score;
+    }
+  `;
+}
+
+describe("#4755 runtime-eval value-cell precomputed writer routing — standalone", () => {
+  // `runtimeEvalStateMayShadowBinding` is deliberately a standalone/WASI
+  // provider seam; GC direct eval keeps its static-splice/host route. These
+  // rows therefore exercise the only lane in which a caller-owned value cell
+  // can precede the module-lexical miss arm.
+  it("keeps a present value-cell write off the uninitialized module lexical", async () => {
+    const { value } = await compileAndRunRuntimeEvalDirect(
+      runtimeEvalAssignmentSource(true),
+      "issue-4755-runtime-eval-cell-hit-standalone.ts",
+    );
+    expect(value).toBe(31);
+  });
+
+  it("evaluates a value-cell miss RHS once before the guarded module-lexical throw", async () => {
+    const { value } = await compileAndRunRuntimeEvalDirect(
+      runtimeEvalAssignmentSource(false),
+      "issue-4755-runtime-eval-cell-miss-standalone.ts",
+    );
+    expect(value).toBe(31);
+  });
+
+  it.each([true, false])("keeps an ambient binding behind the runtime-eval value-cell %s route", async (hasBinding) => {
+    const { value } = await compileAndRunRuntimeEvalDirect(
+      runtimeEvalAmbientAssignmentSource(hasBinding),
+      `issue-4755-runtime-eval-ambient-${hasBinding ? "hit" : "miss"}-standalone.ts`,
+    );
+    expect(value).toBe(15);
   });
 });
 
@@ -598,9 +890,117 @@ describe.each(TARGETS)("#4755 direct assignment identity controls — %s", (targ
     );
     expect(referenceErrorCallCount(result, "writeForeign4755")).toBe(0);
   });
+
+  it("keeps a declaration-file ambient collision on its global-environment storage", async () => {
+    // `entry.ts` sees only the declaration-file global. The runtime lexical is
+    // deliberately a different module's initialized -7 sentinel; sharing its
+    // spelling must neither select that storage nor attach its TDZ provider.
+    const { result, value } = await compileMultiAndRunDirect(
+      {
+        "./ambient.d.ts": `
+          export interface Ambient4755 { marker: number }
+          declare global { let target: any; }
+        `,
+        "./lexical.ts": `
+          export let target: number = -7;
+          export function lexicalStorageClean4755(): number {
+            return target === -7 ? 1 : 0;
+          }
+        `,
+        "./entry.ts": `
+          import type { Ambient4755 } from "./ambient";
+          import { lexicalStorageClean4755 } from "./lexical";
+          var marker: Ambient4755 = { marker: 7 };
+
+          export function writeAmbient4755(): number {
+            target = 9;
+            var score: number = 0;
+            if (target === 9) score += 1;
+            if (lexicalStorageClean4755() === 1) score += 2;
+            if (marker.marker === 7) score += 4;
+            return score;
+          }
+          export function run(): number { return writeAmbient4755(); }
+        `,
+      },
+      "./entry.ts",
+      target,
+      { target: 0 },
+    );
+    expect(value).toBe(7);
+    // The compiler deliberately inlines lexicalStorageClean4755 into this
+    // body, contributing exactly one legitimate provider call. A leaked guard
+    // on either ambient access would increase the census beyond one.
+    expect(referenceErrorCallCount(result, "writeAmbient4755")).toBe(1);
+  });
+
+  it("keeps a genuinely unresolvable collision on the strict GlobalEnvironmentRecord route", async () => {
+    // `entry.ts` intentionally does not import the other module's lexical, so
+    // the assignment Identifier has no checker declaration in this module.
+    // Strict PutValue must evaluate rhs once, observe a missing global binding,
+    // throw a real ReferenceError, and leave both the realm and -7 sentinel clean.
+    const { result, value } = await compileMultiAndRunDirect(
+      {
+        "./lexical.ts": `
+          export let genuinelyUnresolvable4755: number = -7;
+          export function lexicalStorageClean4755(): number {
+            return genuinelyUnresolvable4755 === -7 ? 1 : 0;
+          }
+        `,
+        "./entry.ts": `
+          import { lexicalStorageClean4755 } from "./lexical";
+          var rhsCalls: number = 0;
+          var afterAssignment: number = 0;
+
+          function rhs(): any { rhsCalls += 1; return 41; }
+          function trigger(): void {
+            "use strict";
+            genuinelyUnresolvable4755 = rhs();
+            afterAssignment = 1;
+          }
+
+          export function run(): number {
+            var verdict: number = 0;
+            try { trigger(); }
+            catch (error) { verdict = error instanceof ReferenceError ? 1 : 2; }
+            var score: number = 0;
+            if (verdict === 1) score += 1;
+            if (rhsCalls === 1) score += 2;
+            if (afterAssignment === 0) score += 4;
+            if (lexicalStorageClean4755() === 1) score += 8;
+            if (!("genuinelyUnresolvable4755" in globalThis)) score += 16;
+            return score;
+          }
+        `,
+      },
+      "./entry.ts",
+      target,
+    );
+    expect(value).toBe(31);
+    expect(referenceErrorCallCount(result, "trigger")).toBeGreaterThan(0);
+  });
 });
 
 describe.each(TARGETS)("#4755 direct TDZ provider and elision artifacts — %s", (target) => {
+  it("re-resolves a shifted module-global index after emitting a real TDZ guard", async () => {
+    const { value } = await compileAndRunDirect(
+      `
+        let preceding: number = 9;
+        let target: number = 0;
+        function updateInFinally(): number {
+          try { return 1; }
+          finally { target = target * 10 + 3; }
+        }
+        export function run(): number {
+          return updateInFinally() * 1000 + target;
+        }
+      `,
+      `issue-4755-post-tdz-index-${target}.ts`,
+      target,
+    );
+    expect(value).toBe(1003);
+  });
+
   it("keeps the live provider but makes initialized-let and var writes ReferenceError-neutral", async () => {
     const preInitialization = await compileAndRunDirect(
       `

--- a/tests/issue-4755-module-lexical-assignment-tdz.test.ts
+++ b/tests/issue-4755-module-lexical-assignment-tdz.test.ts
@@ -928,10 +928,10 @@ describe.each(TARGETS)("#4755 direct assignment identity controls — %s", (targ
       { target: 0 },
     );
     expect(value).toBe(7);
-    // The compiler deliberately inlines lexicalStorageClean4755 into this
-    // body, contributing exactly one legitimate provider call. A leaked guard
-    // on either ambient access would increase the census beyond one.
-    expect(referenceErrorCallCount(result, "writeAmbient4755")).toBe(1);
+    // The current inliner proves the initialized foreign lexical read safe,
+    // so neither it nor either ambient access may retain a ReferenceError
+    // provider in this body.
+    expect(referenceErrorCallCount(result, "writeAmbient4755")).toBe(0);
   });
 
   it("keeps a genuinely unresolvable collision on the strict GlobalEnvironmentRecord route", async () => {


### PR DESCRIPTION
## Summary

- route ordinary, precomputed, typed, externref, and iterator-driven module-lexical identifier writes through one exact source/checker-qualified TDZ decision
- preserve local, capture, dynamic-with, runtime-eval, ambient, import, foreign-source, property, and unresolvable storage families
- settle the canonical real `ReferenceError` provider before re-reading mutable global/TDZ indices
- keep detached default-arm bodies registered through final branch attachment
- add the complete 46-row direct GC/standalone matrix plus two detached-body regressions

## Scope and continuation

This #4755 prerequisite is implementation-complete. It does not redesign general module-binding identity or the iterator backend.

- #4260 owns the injected pre-seal transaction rerun after this lands.
- #1719 owns the standalone CPR iterator producer/consumer contract exposed by the isolated destructuring control; its plan update is in #4999.
- #3518 R9 and #3090 R10 must preserve this matrix while moving ownership into IR and deleting this temporary direct-frontend seam.

The branch was re-anchored without a force push so the final tree uses current `main` and excludes four stale generated Test262 reports from the old checkpoint ancestry. Merge queue, merge commit, or squash is safe. Do not use rebase-and-merge for this PR because replaying the preserved pre-anchor history can resurrect those unrelated generated artifacts.

Refs #4755.

## Validation

- strict load gate: 10 logical cores; every heavy command/commit/push used a finite, non-negative one-minute load strictly below 8 (`cores - 2`)
- final changed-root precommit proof: 48/48 (46 main matrix + 2 detached-body rows)
- LOC ratchet: pass, net +253 across seven changed source files; no allowance or baseline widening
- function budget and oracle ratchets: pass; checker use decreases by one
- full normal precommit hook: pass, with no skips
- full normal prepush hook: pass: typecheck + lint, format, oracle/coercion ratchets, #3765 numeric-local parity, issue integrity
- merged-byte gates: TypeScript 7 and 5, IR layering, IR optimization retirement, codegen fallback, IR fallback, and coercion checks pass
- focused supporting controls #723, #800, #1177, #1597, and #4259 claim gating pass
- `tests/issue-4259-class-accessor-outer-writeback-ir.test.ts`: every #4755 TDZ row passes; four unrelated rows fail identically on a detached clean `origin/main` worktree, so they remain a pre-existing #4259 baseline defect and are not waived here
- final signed head: `06f80c1fe69a05b88a65d89783edee3dc43758f8`

## Review notes

The net PR diff is exactly ten files: the #4755 plan/handover, seven codegen files, and two focused tests. Generated reports, budget baselines, CI files, and unrelated compiler paths are byte-equal to `main`.