### PR TITLE
docs(npm-compat): plan remaining upstream test gaps

### DIFF
--- a/plan/issues/3801-react-upstream-unit-tests.md
+++ b/plan/issues/3801-react-upstream-unit-tests.md
@@ -3,6 +3,7 @@ id: 3801
 title: "Run React's own upstream unit tests against compiled React, and make them pass"
 status: ready
 created: 2026-07-31
+updated: 2026-08-26
 priority: high
 horizon: xl
 feasibility: hard
@@ -91,9 +92,16 @@ streams, and the Node stream capability used by the Fizz lanes. This removes
 the previous production/dev renderer peer mismatch and lets all admitted tests
 reach either the native oracle or the compiled call.
 
-The current exact run admits and executes **272/273** tests, has zero
-compile-quarantined batches, and scores **92/178** against compiled Wasm. The
-remaining 94 native-oracle-incompatible tests are recorded rather than
-silently omitted; they are dominated by production warning expectations,
-renderer semantics, and opaque compiled component closures at the
-Wasm/host boundary. Making those tests green is still open work.
+The current exact run admits and executes **272/273** discovered tests, has zero
+compile-quarantined batches, and scores **133/180** against compiled Wasm. The
+remaining **92** tests are explicitly classified as harness-incompatible; they
+are not counted as passes or failures. The **47** scored failures are dominated
+by host-instantiated class/instance behavior, `instance.props`, children/JSX
+identity, symbol/context identity, and async `act` capture/unwrapping.
+
+Implementation continues in
+[`#4618`](4618-react-upstream-async-act-lanes.md). Start with the class/instance
+bridge and props sidecar because that unblocks several files without changing
+the test adapter. Keep children/JSX/symbol identity and async `act` as a second,
+independently measurable slice. Every checkpoint must rerun the unchanged full
+React suite and report passed/scored/admitted/discovered separately.

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -13,7 +13,7 @@ language_feature: n/a
 goal: dogfood
 sprint: Backlog
 horizon: m
-related: [1058, 3587, 3672, 3958, 3982, 3997, 3999, 4000, 4287, 4299, 4301, 4302, 4303]
+related: [1058, 3587, 3672, 3958, 3982, 3997, 3999, 4000, 4287, 4299, 4301, 4302, 4303, 4756]
 oracle-ratchet-allow:
   # The Hono fix compares the actual registered Wasm carriers for two inferred
   # anonymous object literals. TypeOracle deliberately exposes only
@@ -1490,3 +1490,20 @@ registrations fail natively and are not admitted. Of 20 selected modules,
 `src/middleware/trailing-slash/index.test.ts` module itself compiles, validates,
 and passes **36/36**. Separately, **2,031 registrations in 100 deferred files**
 remain unavailable infrastructure; they are not counted as scored failures.
+
+## 2026-08-26 successor implementation plan
+
+The merged integration checkpoint advances Hono to **180/322** admitted
+upstream callbacks, with Node at **322/322** on the same admitted denominator.
+All 20 selected modules are attempted: **17/20 compile** and **16/20 validate**.
+The unchanged inventory still records **2,031 registrations in 100 files** as
+deferred infrastructure. The npm-compat artifact generated earlier that day is
+a partial refresh with stale package rows, so these post-merge row-level results
+remain the authoritative Hono checkpoint until the next complete refresh.
+
+The package-wide remaining-test census and ordered implementation lanes now live
+in [`#4756`](4756-close-curated-npm-upstream-test-gaps.md). Continue this issue
+as the shared upstream-source/admission contract; file correctness fixes in the
+package-specific child issues named there. Exact denominators, unavailable
+infrastructure, native-oracle exclusions, compile failures, validation failures,
+and scored Wasm failures must remain separate at every checkpoint.

--- a/plan/issues/4299-jsdom-original-api-suite.md
+++ b/plan/issues/4299-jsdom-original-api-suite.md
@@ -4,7 +4,7 @@ title: "Compile jsdom and run its 318 original API tests against Wasm"
 status: ready
 sprint: current
 created: 2026-08-09
-updated: 2026-08-13
+updated: 2026-08-26
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -91,6 +91,19 @@ Resume at the compiler, not the adapter: profile the 180-second
 `compileProject(package/lib/api.js)` child by graph and finalization phase. Do
 not replace jsdom with a reduced implementation, count native-only execution,
 or turn the entry-barrel validation result into a package pass.
+
+## 2026-08-26 selected-suite checkpoint
+
+The pinned adapter now executes **6/6** selected `VirtualConsole` tests against
+compiled Wasm. Those six rows are useful correctness evidence, but they do not
+close the package-wide infrastructure gap: **312/318** original API tests remain
+unavailable and the full published `lib/api.js` project still exhausts the
+180-second compile budget without producing a binary.
+
+Resume by profiling and bounding the real full graph, then expand the adapter
+from the same immutable 318-test inventory. Do not extrapolate the 6/6 selected
+result to the deferred rows, and do not proxy the jsdom implementation through
+native host jsdom.
 
 ## Acceptance criteria
 

--- a/plan/issues/4535-three-mathutils-silent-wasm-failures.md
+++ b/plan/issues/4535-three-mathutils-silent-wasm-failures.md
@@ -1,10 +1,10 @@
 ---
 id: 4535
-title: "three.js: MathUtils module validates but 0/18 tests pass in Wasm, all silently — including trivial clamp/euclideanModulo"
+title: "three.js: MathUtils.damp differs from Node in the final floating result (17/18 pass)"
 status: ready
 sprint: current
 created: 2026-08-16
-updated: 2026-08-16
+updated: 2026-08-26
 priority: medium
 horizon: m
 feasibility: medium
@@ -19,27 +19,23 @@ files:
   - tests/dogfood/upstream-suite-runner.mjs
 ---
 
-# three.js MathUtils: one validated module, 18 uniform silent failures
+# three.js MathUtils: isolate the remaining `damp` numeric mismatch
 
 ## Problem
 
-The three.js pinned slice (`test/unit/src/math/MathUtils.tests.js`, 18 QUnit
-tests): the single generated module **compiles and validates** (138 KB), all
-18 pass natively, and **0/18 pass in Wasm** — with `wasmError: null` on
-every row (2026-08-16, `a9b20d4c`, matches the npm-compat card).
+The pinned upstream slice (`test/unit/src/math/MathUtils.tests.js`) now compiles,
+validates, and passes **17/18** tests in Wasm. Node passes **18/18**. The earlier
+uniform 0/18 result was a runner-observability defect fixed by the merged
+per-test runner work; it is not the current compiler problem.
 
-Two observations that shape the diagnosis:
+Only `damp` remains. The exact result is:
 
-1. **`clamp` and `euclideanModulo` fail too.** Those bodies are 1–2 lines of
-   pure `Math.min/max` arithmetic. 18/18 uniform failure across trivial and
-   non-trivial bodies points at a *shared* defect — the QUnit
-   assert-adapter, the `runUpstreamTests` export path, or the module's
-   shared prelude — not 18 independent math bugs.
-2. **No error text.** The generic runner's status array comes back all-zero
-   with empty error strings. The in-flight PR #4619 rewrites
-   `upstream-suite-compile-worker.mjs` / `upstream-suite-runner.mjs` to a
-   per-test entry point (`runUpstreamTest(index)`) with real error capture —
-   after it lands, this suite should produce per-test messages for free.
+```text
+number:1.1478562110442545 !== number:1.1478562110337887
+```
+
+This is a real numeric parity failure on the same runtime-owned inputs, not an
+unavailable test or a reason to relax the upstream assertion.
 
 ## Reproduction
 
@@ -49,24 +45,20 @@ node --import tsx tests/dogfood/three-upstream-suite.mjs --json
 
 ## Implementation Plan (Fable; implement per the plan/implement split)
 
-1. **Wait for / rebase on PR #4619** (upstream-suite runner error capture),
-   then re-run — with real error text this issue may reduce to an existing
-   bucket (typeof-on-boxed #4529, assert-shim mismatch, etc.). Do not
-   hand-roll a parallel error-capture mechanism; #4619 already does it.
-2. If #4619's text shows a shared prelude/adapter failure: reduce the QUnit
-   `assert` object flow — the shim passes an `assert` object into each
-   callback (`__upstreamTests[i].body(__qunitAssert)`); a single defect in
-   calling method-on-parameter-object (`assert.ok(...)` where `assert` is a
-   boxed parameter) would fail all 18 uniformly. Cross-check #4123
-   (prototype method on parameter receiver returns null).
-3. Reduce to `.tmp/` probe, fix at the identified compiler site, commit the
-   reduction as `tests/issue-4535.test.ts`.
-4. **Validation gates**: three slice 0/18 → ≥16/18 (record exact); the two
-   sibling QUnit-style suites (webpack, stylelint — same generic runner)
-   re-measured for collateral movement; equivalence green.
+1. Reduce the exact `damp` inputs and record every intermediate value in Node
+   and Wasm, especially the `Math.exp` result, subtraction, multiplication,
+   and final addition.
+2. Determine whether the divergence comes from a generic numeric lowering,
+   evaluation-order, host `Math.exp`, or unintended `f32` conversion boundary.
+3. Fix the generic compiler/runtime path. Do not special-case three.js, change
+   the expected value, precompute the answer, or add a package-only tolerance.
+4. Commit a focused regression as `tests/issue-4535.test.ts`, then re-run the
+   unchanged pinned upstream suite and adjacent numeric/equivalence tests.
 
 ## Acceptance criteria
 
-- [ ] Root cause named with per-test error evidence (post-#4619).
-- [ ] three MathUtils slice ≥ 16/18, residual named.
+- [x] Root cause of the obsolete uniform 0/18 result is named and fixed.
+- [x] The remaining failure is isolated to `MathUtils.damp` at **17/18**.
+- [ ] The exact upstream slice passes **18/18** with unchanged inputs and
+      expectations.
 - [ ] Reduction test committed.

--- a/plan/issues/4756-close-curated-npm-upstream-test-gaps.md
+++ b/plan/issues/4756-close-curated-npm-upstream-test-gaps.md
@@ -1,0 +1,186 @@
+---
+id: 4756
+title: "npm-compat: close every remaining curated upstream-test and unavailable-infrastructure gap"
+status: ready
+created: 2026-08-26
+updated: 2026-08-26
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: dogfood, ci, codegen
+language_feature: npm-packages, host-boundaries, async, modules
+goal: npm-library-support
+sprint: current
+related: [3995, 4585, 4604, 4618, 4526, 4527, 3982, 3977, 4299, 3994, 4287, 1400]
+---
+
+# Close every remaining curated npm upstream-test gap
+
+## Problem
+
+The curated npm page contains 24 packages, but a green selected slice is not
+the same thing as the original package suite being green. Only Acorn, Cookie,
+clsx, and UUID currently have a complete measured denominator with no deferred
+original tests. The other packages have scored failures, uncompiled test
+modules, unavailable host/test infrastructure, or large entry graphs that do
+not emit a valid package binary.
+
+The current published artifact is also not a reliable single source for the
+four packages advanced by merged
+[PR 4849](https://github.com/loopdive/js2/pull/4849). The artifact generated at
+`2026-08-26T09:19:46.561Z` is a partial refresh and marks 23 of 24 package rows
+stale. For UUID, Axios, Hono, and Redux, the unchanged-suite post-merge run in
+that PR is newer than the retained package partials. This issue records both
+provenances rather than silently choosing the larger number.
+
+Every result below uses original pinned test callbacks and inputs in both Node
+and Wasm. Cached answers, package-specific source rewrites, and harness-authored
+substitutes do not count.
+
+## Exact census at the 2026-08-26 checkpoint
+
+`Scored` is Wasm passes over the same Node-compatible callback denominator.
+`Outside scored` is separate and must never be added to either passes or
+failures. `Entry C/V` is the package-card entry compile/validate result, not the
+selected test-module result.
+
+| package | scored | outside scored | entry C/V | active owner and next boundary |
+| --- | ---: | ---: | ---: | --- |
+| Acorn 8.16.0 | **3518/3518** | 0 | 1/1 | Complete control; retain the full denominator. |
+| Cookie 2.0.1 | **63740/63740** | 0 | 1/1 | Complete control; retain the full denominator. |
+| clsx 2.1.1 | **32/32** | 0 | 1/1 | Complete control; retain the full denominator. |
+| UUID 14.0.1 | **75/75** | 0 | 1/1 | Resolved by [UUID original-suite gaps](./4383-uuid-original-suite-runtime-and-callref-gaps.md); the published 28/75 row is stale. |
+| Redux 5.0.1 | **55/82** | 0 | 1/1 | [Redux remaining observable, shadowing, and call clusters](./4526-redux-runtime-null-deref-illegal-cast-clusters.md): 27 scored failures, all 9 modules valid. |
+| Axios 1.16.1 | **187/231** | 414 registrations / 16 files | 0/1 | [Axios remaining dynamic callback ABI](./4527-axios-class-call-concat-vararg-invalid-module.md): 44 scored failures; all 33 selected modules compile and validate. |
+| Hono 4.12.16 | **180/322** | 2,031 registrations / 100 files; 2 native-incompatible registrations | 1/1 | [Original-suite umbrella](./3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md): 142 scored failures; selected modules 17/20 compile and 16/20 validate. |
+| React 19.2.6 | **133/180** | 92 harness-incompatible from 272/273 executed | 1/1 | [React async/act and class bridge](./4618-react-upstream-async-act-lanes.md): element/children identity, class lifecycle, forwardRef/StrictMode, JSX and mock-call clusters. |
+| React DOM 19.2.6 | **18/194** | 984 harness-incompatible; 533 implementation-invalid in the 2,003-test inventory | 0/1 | [React DOM original suite](./3982-react-dom-own-unit-tests-against-compiled-wasm.md): client ref/global typing first; server/Fizz lanes independently. |
+| TypeScript 5.9.3 | **9/11** | 1,750 registrations | 0/1 | [TypeScript pseudo-BigInt correctness](./4757-typescript-pseudobigint-octal-large.md) owns the two scored failures; [package graph traversal](./3994-bound-recursive-package-graph-traversal-for-typescript.md) separately owns the 600 s entry timeout. |
+| ESLint 10.0.3 | **50/158** | the adapter currently covers five utility files only | 0/1 | [ESLint package entry](./1400-eslint-package-entry-valid-wasm.md) plus this issue: typed ref-array higher-order functions and serialization helpers; entry compile times out. |
+| lodash 4.18.1 | **51/62** | 1,691 registrations | 0/1 | [Lodash module-init and lane report](./4533-lodash-module-init-null-call-and-es-lane-report.md): predicate/falsey/realm observations, iterable/string conversions; keep CJS entry diagnostics separate. |
+| lodash-es 4.18.1 | **44/62** | 1,691 registrations | 1/1 | Same owner as lodash; modular string/predicate/conversion paths remain. |
+| Jest 30.4.2 | **325/356** | 2,930 unavailable; 2 harness-incompatible | 1/1 | This issue: 31 scored failures in descriptor/clone/error/prompt semantics and timer/queue/call-ref paths. Old get-type and accessor-import headlines no longer describe the current rows. |
+| Prettier 3.8.1 | **48/151** | 4 source files remain deferred | 1/0 | [AstPath heterogeneous stack](./4531-prettier-astpath-heterogeneous-stack-illegal-cast.md) and [Error subclass names](./4532-error-subclass-constructor-name.md). Selected modules 16/16 compile, 10/16 validate. |
+| Moment 2.30.1 | **4/10** | 2,628 registrations | 1/1 | [Moment live JS resolution](./4384-moment-js-entry-resolves-to-adjacent-declaration.md) and [closure capture validation](./4525-moment-closure-capture-i32-ref-validation.md). A 10/10 branch checkpoint is not a mainline claim until landed and rerun. |
+| Marked 18.0.2 | **0/30** on the card; synchronous Hooks **0/15** | 15 async Hooks callbacks plus 5 heavier files | 0/1 | [Marked host/runtime gap](./4435-marked-upstream-host-runtime-gap.md): `use` receiver/callback path, then generic async callback continuation. The separate fixture lane is 8/8. |
+| Lit 3.3.3 | **0/151** | 432 harness-incompatible; 398 implementation-invalid in 587 discovered tests | 1/0 | [Lit original suite](./3977-lit-own-unit-tests-against-compiled-wasm.md) and [published-byte invalid module](./3978-lit-html-published-bytes-emit-invalid-module.md): fix ref operands before directive semantics. |
+| Three.js 0.185.1 | **17/18** | 1,295 registrations | 0/1 | [MathUtils `damp` numeric mismatch](./4535-three-mathutils-silent-wasm-failures.md): one exact floating result differs. |
+| jsdom 30.0.1 | selected **6/6** | 312 API registrations | 0/1 | [Full jsdom API suite](./4299-jsdom-original-api-suite.md): the six VirtualConsole tests are green; full `lib/api.js` still produces no binary within 180 s. |
+| webpack 5.109.2 | selected **16/16** | 1,341 registrations | 0/1 | [Webpack/Tailwind compile budget](./4287-webpack-tailwind-package-compile-budget.md) plus this issue for coverage expansion. |
+| Tailwind CSS 4.3.3 | selected **13/13** | 1,363 registrations | 0/1 | Same owner as webpack; selected utilities are green, entry graph times out. |
+| styled-components 6.4.4 | selected **9/9** | 659 registrations | 1/1 | This issue owns expansion beyond pure utilities into React/DOM/SSR/Stylis without relabeling it as already passing. |
+| Stylelint 17.14.1 | selected **108/108** | 1,466 registrations | 0/1 | This issue owns coverage expansion; the former array/webpack residual issue is complete. |
+
+## Failure families, not error-message buckets
+
+Error text identifies where execution stopped, not necessarily one root cause.
+Implementers must reduce representative rows and prove attribution by removing
+the candidate fix. The current work separates into these independently
+measurable families:
+
+1. **Scored dynamic-call and object-carrier semantics** — Redux, Axios, Hono,
+   React, ESLint, lodash/lodash-es, Jest and Prettier.
+2. **Invalid test or package modules** — React DOM, Lit, Marked and some Hono
+   modules. Repair validity before interpreting downstream runtime failures.
+3. **Small numeric/value correctness residues** — TypeScript's two
+   `parsePseudoBigInt` rows and Three's one `MathUtils.damp` row.
+4. **Package-graph scale** — TypeScript, jsdom, ESLint, webpack, Tailwind,
+   Stylelint and the CommonJS lodash entry. A timeout is not a unit-test fail.
+5. **Unavailable test infrastructure** — async callbacks/fake timers,
+   snapshots, filesystem/server/socket/stream fixtures, DOM/resource loading,
+   browser/WebGL, native/Rust helpers, and large multi-package graphs.
+
+## Implementation plan
+
+### Phase 0 — make the measurement impossible to overstate
+
+1. Keep one immutable upstream pin and complete file/registration inventory per
+   package.
+2. Emit, for every run: Node passes/total, Wasm passes/total, admitted,
+   discovered, harness-incompatible, implementation-invalid, unavailable,
+   selected module compile/validate, and package-entry compile/validate.
+3. Reject a silent-empty result: every adapter has a positive registration
+   floor and a deliberately failing assertion control.
+4. Fix the partial-refresh path under [npm refresh resilience](./4585-npm-compat-refresh-resilience.md)
+   and [refresh timeout](./4604-npm-compat-refresh-runtime-exceeds-timeout.md)
+   so a stale package partial cannot overwrite a newer verified checkpoint.
+
+### Phase 1 — close bounded scored denominators in parallel
+
+These first three lanes have unchanged, fully enumerated denominators and do
+not need new host infrastructure:
+
+1. [TypeScript pseudo-BigInt correctness](./4757-typescript-pseudobigint-octal-large.md):
+   `9/11 -> 11/11`.
+2. [Redux remaining observable, shadowing, and call clusters](./4526-redux-runtime-null-deref-illegal-cast-clusters.md):
+   `55/82 -> 82/82` with all 9 modules still valid.
+3. [React async/act and class bridge](./4618-react-upstream-async-act-lanes.md):
+   first remove the bounded async/class/props substrate failures, then rerun the
+   complete 273-test inventory.
+
+Next, without overlapping those files, take Axios's iterable/Error carrier,
+Hono's route tuple/private dispatch, Three's one numeric mismatch, Prettier's
+two existing child issues, and Moment's resolver/capture issues. Do not dispatch
+Axios while its existing issue claim remains live.
+
+### Phase 2 — valid modules before semantic interpretation
+
+1. React DOM client: repair `trackValueOnNode` ref/global typing and module-init
+   null carriers; rerun the client lane only.
+2. React DOM server/Fizz: keep legacy server stack balance, browser timeout,
+   and Node async-in-try as independent A/Bs.
+3. Lit: repair published `lit-html`/`lit-element` GC-ref versus externref call
+   operands, then separately address ReactiveElement closure/callable-class
+   frames and directive null carriers.
+4. Marked: make the Hooks implementation module and mixed-arity `use` receiver
+   path valid before admitting the 15 async callbacks.
+
+### Phase 3 — expand original tests by reusable infrastructure
+
+Expand complete original files in ascending dependency cost; do not cherry-pick
+individual passing callbacks:
+
+1. synchronous dependency-light utilities and package-internal modules;
+2. promises, async callbacks, fake timers, mocks and lifecycle hooks;
+3. snapshots, filesystem, HTTP/server/socket/stream fixtures;
+4. DOM/resource loading and browser/WebGL/native-helper graphs.
+
+Every infrastructure addition must be generic, covered by a runner regression,
+and reused by at least one independent package control where practical. A newly
+admitted failing test increases the scored denominator; it is not a regression
+and must not be moved back to `unavailable`.
+
+### Phase 4 — full package-entry compile and validation
+
+Profile phase and graph-unit progress before raising a timeout. Land generic
+bounded scheduling/compile-once work for TypeScript, jsdom, ESLint, webpack,
+Tailwind, Stylelint and lodash, preserving all natively reachable modules.
+Selected utility modules passing does not excuse a red package entry.
+
+### Phase 5 — CI and publication
+
+Wire every expanded package adapter into the merge-only npm-compat workflow.
+The workflow must refuse missing numeric results, retain the last good result
+with explicit stale provenance when a worker fails, and publish the same
+denominators used by the implementation PR. Performance remains reported but
+is not a merge gate.
+
+## Acceptance criteria
+
+- [ ] All 24 curated packages retain an immutable upstream pin and complete
+      original test inventory.
+- [ ] Every original test is either executed in both Node and Wasm or has one
+      exact, reviewable infrastructure reason; no test silently disappears.
+- [ ] All Node-compatible original tests pass in Wasm, with unchanged callback
+      bodies, inputs and expectations.
+- [ ] Unavailable infrastructure reaches zero except tests that the pinned
+      upstream suite itself cannot execute in the selected Node environment.
+- [ ] Every package entry compiles within a measured bounded budget and emits a
+      valid Wasm module, independently of selected test-module success.
+- [ ] Acorn 3518/3518, Cookie 63740/63740, clsx 32/32, and UUID 75/75 remain
+      non-vacuous zero-withdrawal controls.
+- [ ] The merge-only npm-compat workflow publishes the fresh per-package rows;
+      performance measurements are informational, never a correctness gate.
+

--- a/plan/issues/4756-close-curated-npm-upstream-test-gaps.md
+++ b/plan/issues/4756-close-curated-npm-upstream-test-gaps.md
@@ -183,4 +183,3 @@ is not a merge gate.
       non-vacuous zero-withdrawal controls.
 - [ ] The merge-only npm-compat workflow publishes the fresh per-package rows;
       performance measurements are informational, never a correctness gate.
-

--- a/plan/issues/4757-typescript-pseudobigint-octal-large.md
+++ b/plan/issues/4757-typescript-pseudobigint-octal-large.md
@@ -88,4 +88,3 @@ it with a harness implementation or expected-value table.
       precomputed answer and no upstream callback/expectation rewrite is used.
 - [ ] The 1,750 unavailable TypeScript registrations and the full package-entry
       timeout remain reported separately rather than being inferred fixed.
-

--- a/plan/issues/4757-typescript-pseudobigint-octal-large.md
+++ b/plan/issues/4757-typescript-pseudobigint-octal-large.md
@@ -1,0 +1,91 @@
+---
+id: 4757
+title: "TypeScript parsePseudoBigInt: octal and large literals return 0x11ffff instead of 0xfffff"
+status: ready
+created: 2026-08-26
+updated: 2026-08-26
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: max
+task_type: bugfix
+area: codegen, dogfood
+language_feature: strings, numeric-conversion, bitwise
+goal: npm-library-support
+sprint: current
+related: [3994, 3995, 4756]
+files:
+  - tests/dogfood/typescript-upstream-suite.mjs
+  - tests/issue-4757.test.ts
+---
+
+# TypeScript `parsePseudoBigInt` octal and large-literal mismatch
+
+## Problem
+
+The unchanged original TypeScript 5.9.3
+`src/testRunner/unittests/parsePseudoBigInt.ts` file passes **5/5** in Node but
+only **3/5** after compiling the exact release implementation and its
+`CharacterCodes` carrier to Wasm. The full selected TypeScript slice is
+therefore **9/11 Wasm** versus **11/11 Node**.
+
+The two failures are:
+
+- `can parse octal literals`;
+- `can parse large literals`.
+
+The first retained assertion message is exact:
+
+```text
+equal mismatch; string:1179647 != string:1048575
+```
+
+Those values are `0x11ffff` and `0x0fffff`, a deterministic extra `0x20000`.
+The binary and hex rows in the same original file pass. This is runtime numeric
+or character-to-digit semantics, not the separate 600-second full TypeScript
+package-entry timeout owned by
+[package graph traversal](./3994-bound-recursive-package-graph-traversal-for-typescript.md).
+
+## Reproduction
+
+```sh
+node --import tsx tests/dogfood/typescript-upstream-suite.mjs --json
+```
+
+Use the immutable upstream pin
+`microsoft/TypeScript@c63de15a992d37f0d6cec03ac7631872838602cb`.
+The adapter must continue extracting the exact release function; do not replace
+it with a harness implementation or expected-value table.
+
+## Implementation plan
+
+1. Capture the exact input and output of all five upstream callbacks and add a
+   positive control that distinguishes `0xfffff` from `0x11ffff`.
+2. Reduce the release implementation to its radix prefix, character-code to
+   digit conversion, accumulator update, and decimal-string result. Preserve
+   runtime input so constant folding cannot hide the defect.
+3. Compare the reduction in Node and compiled Wasm at each intermediate value.
+   Determine whether the first divergence is string indexing/charCode,
+   octal-radix selection, bitwise coercion, integer-to-decimal conversion, or
+   a value-carrier merge. Error text alone is not attribution.
+4. Fix the narrow generic compiler/runtime site. Do not special-case
+   TypeScript, `parsePseudoBigInt`, the failing literals, or the expected
+   string.
+5. Commit the reduction in `tests/issue-4757.test.ts`, including passing binary,
+   octal, hex, large, and negative/sign controls where the upstream function
+   supports them.
+6. Rerun the unchanged three-file TypeScript selected suite and at least one
+   independent numeric/string-conversion control. Keep the package-entry
+   timeout result separate.
+
+## Acceptance criteria
+
+- [ ] The exact original `parsePseudoBigInt.ts` file reaches **5/5 Wasm** and
+      remains **5/5 Node**.
+- [ ] The full selected TypeScript lane reaches **11/11 Wasm** and **11/11
+      Node**, with the same three modules compiling and validating.
+- [ ] The fix is generic and covered by a runtime-input regression; no cached or
+      precomputed answer and no upstream callback/expectation rewrite is used.
+- [ ] The 1,750 unavailable TypeScript registrations and the full package-entry
+      timeout remain reported separately rather than being inferred fixed.
+


### PR DESCRIPTION
## Summary\n\n- adds the [curated npm upstream-test gap plan](https://github.com/loopdive/js2/blob/codex/4756-npm-remaining-tests-plan/plan/issues/4756-close-curated-npm-upstream-test-gaps.md) with exact scored, deferred, compile, and validation denominators for all 24 packages\n- adds the focused [TypeScript parsePseudoBigInt correctness issue](https://github.com/loopdive/js2/blob/codex/4756-npm-remaining-tests-plan/plan/issues/4757-typescript-pseudobigint-octal-large.md)\n- refreshes the React, jsdom, Three, and shared upstream-suite handoffs so implementation starts from current results instead of stale partial-refresh cards\n- separates correctness failures from unavailable infrastructure and package-entry compile budgets\n- defines three independent first implementation lanes for React, Redux, and TypeScript\n\n## Validation\n\n- node scripts/check-issue-ids.mjs\n- Prettier check for all six planning files\n- git diff --check\n- full pre-push typecheck, lint, format, issue-integrity, numeric-local IR parity, and compiler ratchet checks\n\n## Notes\n\nPerformance remains informational and is not introduced as a merge gate. The plan preserves unchanged upstream tests and exact Node/Wasm denominators.