### PR TITLE
fix(playground): unblock GitHub Pages build broken by node builtin named imports

### DIFF
--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -9,7 +9,7 @@
  * section after merge and metadata DCE have completed.
  */
 
-import { createHash } from "node:crypto";
+import * as nodeCrypto from "node:crypto";
 import { WasmEncoder } from "./emit/encoder.js";
 import type { LinkedProviderMetadata } from "./index.js";
 import {
@@ -212,5 +212,5 @@ export function decodeBundleManifest(binary: Uint8Array): BundleManifestV1 {
 }
 
 export function bundleArtifactHash(binary: Uint8Array): string {
-  return createHash("sha256").update(binary).digest("hex");
+  return nodeCrypto.createHash("sha256").update(binary).digest("hex");
 }

--- a/src/package-linker.ts
+++ b/src/package-linker.ts
@@ -11,7 +11,7 @@
  */
 
 import * as path from "path";
-import { createHash } from "node:crypto";
+import * as nodeCrypto from "node:crypto";
 import { ts } from "./ts-api.js";
 import type {
   CompileOptions,
@@ -140,7 +140,7 @@ function wasmBytes(binary: Uint8Array): BufferSource {
 }
 
 function hashText(parts: readonly string[]): string {
-  const hash = createHash("sha256");
+  const hash = nodeCrypto.createHash("sha256");
   for (const part of parts) {
     hash.update(String(part.length));
     hash.update(":");

--- a/src/provider-manifest.ts
+++ b/src/provider-manifest.ts
@@ -9,7 +9,7 @@
  * cycle while still making the artifact content-addressed.
  */
 
-import { createHash } from "node:crypto";
+import * as nodeCrypto from "node:crypto";
 import type { LinkedProviderMetadata } from "./index.js";
 import { WasmEncoder } from "./emit/encoder.js";
 
@@ -350,7 +350,7 @@ export function appendProviderManifest(binary: Uint8Array, manifest: ProviderMan
 
 /** Content hash of the finalized provider bytes. */
 export function providerArtifactHash(binary: Uint8Array, manifest: ProviderManifestV1): string {
-  const hash = createHash("sha256");
+  const hash = nodeCrypto.createHash("sha256");
   hash.update(binary);
   // Keep the manifest argument in the API so callers must pass the decoded
   // finalized artifact rather than accidentally hashing pre-manifest bytes.

--- a/website/playground/stubs/node-fs-stub.js
+++ b/website/playground/stubs/node-fs-stub.js
@@ -16,4 +16,18 @@ export function statSync() {
 export function realpathSync(p) {
   return p;
 }
-export default { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync, realpathSync };
+export function mkdtempSync(prefix) {
+  return `${prefix}browser-stub`;
+}
+export function rmSync() {}
+export default {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+  mkdtempSync,
+  rmSync,
+};

--- a/website/playground/stubs/node-stub.js
+++ b/website/playground/stubs/node-stub.js
@@ -1,3 +1,9 @@
 // Empty stub for Node builtins that are not available in the browser.
 // Used by Vite to suppress "externalized for browser compatibility" warnings.
-export default {};
+export function execFileSync() {
+  throw new Error("execFileSync() is not available in browser builds");
+}
+export function tmpdir() {
+  return "/tmp";
+}
+export default { execFileSync, tmpdir };


### PR DESCRIPTION
## Summary

The GitHub Pages deploy pipeline (`deploy-pages.yml` → `pnpm build:pages` → `pnpm build:playground` → `vite build`) has been failing on every run since 2026-08-25T23:25:48Z (last successful run #6385). Every commit since then — including the compiler fix for the acorn/clsx perf regression ([#4602](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4602-acorn-clsx-perf-regression)) and the npm-compat CI pipeline fixes ([#4604](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4604-npm-compat-refresh-runtime-exceeds-timeout)) — has never actually reached the live site, which is why `npm-compat.html` kept showing stale/wrong numbers despite the committed `benchmarks/results/*.json` being correct.

Root cause: the playground's browser bundle transitively reaches several Node-only compiler-tooling modules whose imports Rollup can't statically resolve against Vite's browser shims:

- `provider-manifest.ts`, `bundle-manifest.ts`, `package-linker.ts` — named `createHash` import from `node:crypto`, which Rollup validates against Vite's empty `__vite-browser-external` shim and hard-fails with `"createHash" is not exported by "__vite-browser-external"`.
- `package-bundler.ts` — `execFileSync`/`tmpdir` (from `node:child_process`/`node:os`) and `mkdtempSync`/`rmSync` (from `node:fs`), which aren't exported by the project's own playground stub files (`website/playground/stubs/node-stub.js`, `node-fs-stub.js`).

## Changes

- `src/provider-manifest.ts`, `src/bundle-manifest.ts`, `src/package-linker.ts`: switch the `createHash` import to a namespace import (`import * as nodeCrypto from "node:crypto"`), which defers the property lookup to runtime instead of Rollup's static named-export check. Real Node callers are unaffected.
- `website/playground/stubs/node-stub.js`: add `execFileSync` (throwing stub) and `tmpdir` (returns `"/tmp"`) named exports.
- `website/playground/stubs/node-fs-stub.js`: add `mkdtempSync`/`rmSync` no-op stubs, matching the existing style of `mkdirSync`/`writeFileSync`.

## Validation

Ran the actual failing CI command directly and confirmed it now succeeds:

```
npx vite build --config website/playground/vite.config.ts
# ✓ built in 1m 26s
```

All pre-commit/pre-push gates pass locally (loc-budget, func-budget, coercion-sites, oracle-ratchet, typecheck, lint, format, numeric-local IR parity).

## Test plan

- [x] `npx vite build --config website/playground/vite.config.ts` succeeds
- [ ] CI green (`deploy-pages.yml` build job in particular)
- [ ] Confirm the next Pages deploy succeeds and the live `npm-compat.html` shows the correct acorn/clsx `standaloneDynamic.ratio` values (~0.125x / ~0.169x)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8)_