### PR TITLE
fix(ci): stop deploy-pages.yml livelocking on cancel-in-progress

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,7 +30,13 @@ env:
 
 concurrency:
   group: github-pages
-  cancel-in-progress: true
+  # false, not true: with push + workflow_run + workflow_dispatch triggers all
+  # sharing this group, cancel-in-progress livelocks whenever triggers arrive
+  # faster than one build+deploy completes — each run gets killed by the next
+  # before finishing, and none ever reaches "deploy" (same failure mode as the
+  # npm-compat-refresh incident this file's history warns about). Queueing
+  # instead means a burst of triggers still drains to a real deploy.
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Follow-up to #5011. That PR fixed the Vite/Rollup build failure blocking `deploy-pages.yml`, but after it merged, the deploy still never reached production: runs #6477-#6480 (one `push`, two `workflow_dispatch`, one `workflow_run`) all fired within about 4 minutes and cancelled each other in sequence, so no run ever reached the `deploy` job.

Root cause: `deploy-pages.yml` triggers on `push` (every merge to `main`), `workflow_run` (Refresh Benchmarks completing), and `workflow_dispatch`, all sharing one `concurrency` group with `cancel-in-progress: true`. Whenever triggers arrive faster than one build+deploy completes, every in-flight run gets killed by the next trigger before finishing — a livelock, not a flake.

This is the same failure mode this repo's own `CLAUDE.md` documents for an earlier `npm-compat-refresh.yml` incident ("never `cancel-in-progress` a job longer than its own trigger interval"): the fix there was the same — stop cancelling in-flight runs and let triggers queue instead.

## Change

`.github/workflows/deploy-pages.yml`: `cancel-in-progress: true` → `false`. A burst of triggers now queues instead of repeatedly killing the in-flight run, so it still drains to a real deploy.

## Validation

- YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- All pre-commit/pre-push gates pass locally (no `src/` files touched, so loc/func/oracle/coercion gates are no-ops; typecheck, lint, format, numeric-local IR parity all green).
- This is a one-line concurrency-policy change with no code path to unit test directly; confidence comes from the observed cancel/skip pattern in `deploy-pages.yml`'s own run history (runs #6477-#6480) matching the documented livelock signature exactly.

## Test plan

- [ ] Confirm the next `deploy-pages.yml` run (or a burst of them) completes successfully instead of cancelling
- [ ] Confirm the live `npm-compat.html` on GitHub Pages finally reflects the acorn/clsx fix from #5011 (~0.125x / ~0.169x `standaloneDynamic.ratio`), closing out the original perf-regression report


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkegY9sUFwPH5kCreP6M8)_