### PR TITLE
fix(es2016): Array.prototype.includes, method values, and escape-aware `in` — 102 → 113/124

### DIFF
--- a/plan/issues/2039-standalone-invalid-wasm-residual-bucket.md
+++ b/plan/issues/2039-standalone-invalid-wasm-residual-bucket.md
@@ -4,7 +4,7 @@ title: "UMBRELLA: standalone invalid-Wasm residual bucket — 203 live rows spli
 status: ready
 sprint: current
 created: 2026-06-10
-updated: 2026-07-18
+updated: 2026-08-26
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -27,6 +27,11 @@ origin: "2026-06-10 standalone-vs-host baseline diff; RE-TRIAGED 2026-07-18 agai
 > replaces direct dispatch (the old TaskList task for #2039 is superseded by the
 > per-child tasks below). Do NOT assign #2039 to a dev to "fix" — assign the
 > children #3394–#3398.
+>
+> **⚠ 2026-08-26: the 2026-07-18 table below and the #3394–#3398 split are
+> STALE.** The bucket is 53 rows, not 203, and the family shapes changed. Read
+> [`## Implementation Plan`](#implementation-plan) at the bottom — it carries the
+> current bucket, the root causes, and the dispatchable slices. #3396 is `done`.
 
 ## Blocker verdict (2026-07-18)
 
@@ -262,3 +267,507 @@ the batch first keeps the "funcMap values are always current" invariant.
 - Standalone baseline `invalid Wasm binary` total drops below 300, with the
   remainder mapped to child issues by signature.
 - No new host-mode regressions; equivalence tests green.
+
+**Met, and superseded** — the "<300" bar was cleared (203 → 53). The live
+criteria are in `## Implementation Plan` § Acceptance criteria (2026-08-26).
+
+---
+
+## Implementation Plan
+
+**Verdict: ACTIONABLE, and the bucket is now small enough to close completely.**
+53 live rows, every one reproduced or root-caused below. This section supersedes
+the 2026-07-18 bucket table and the #3394–#3398 split — both are stale by 4–30×
+and would send a dev chasing rows that no longer exist.
+
+### Verification against current main (2026-08-26)
+
+- Tree: `0e65e238`. Standalone baseline `benchmarks/results/test262-standalone-current.json`
+  is from **today** (`baseline_generated_at 2026-08-26T19:59Z`, `baseline_sha
+  91e77f73`, 3 commits behind HEAD), so this is not a stale-baseline reading.
+- Extraction: `test262-standalone-current.jsonl` from `loopdive/js2wasm-baselines`
+  (48,735 records, full scope). Rows whose `error` contains `invalid Wasm binary`:
+  **53**. All 53 are `status: compile_error`, `error_category: wasm_compile`,
+  `scope_official: true` (52 `standard`, 1 `annex_b`). The summary's
+  `error_categories.wasm_compile` is 53 — the two agree exactly, so no filtering
+  judgement is involved this time (2026-07-18 needed a 179-row false-positive
+  filter; nothing to filter now).
+- **203 → 53.** Gone since 2026-07-18: the whole `#3396` closure/promise-reaction
+  struct-type family (70, fixed and `status: done` 2026-07-23), most of `#3394`
+  (bigint 59 → 2), most of `#3395` (34 → ~11), most of `#3397` (27 → 4).
+  `standalone-invalid-wasm` no longer appears as a bucket in the summary's
+  `root_cause_map` at all.
+- **Live-reproduced on `0e65e238`:** 19 representative upstream files were fetched
+  at the pinned test262 SHA `b363f29d` and compiled with
+  `wrapTest(src, meta, "standalone") → compile({target:"standalone"}) →
+  WebAssembly.compile`. **13 of 19 reproduce the exact baseline signature.** The
+  6 that did not are `wrapTest` artifacts, not fixes — `wrapTest` inlines a
+  preamble, while the runner's authoritative path assembles the literal upstream
+  harness. **Repro through `runTest262File` (`tests/test262-runner.ts:4431`), not
+  `wrapTest`**, or you will wrongly declare rows already-fixed.
+
+### Current bucket → slices (all 53 rows)
+
+| Slice | Rows | Validator signature | Root cause | Status |
+| ----- | ---: | ------------------- | ---------- | ------ |
+| **S1** | 5 | `return_call: tail call type error` (`Parent_new`) · `local.tee[0] expected (ref null N), found block of type f64` | synthesized `<Class>_new` / `<Class>_init` stems collide with a user member named `new` / `init` | root-caused |
+| **S2** | 8 | `call[0] expected externref, found local.tee of i32 / f64.const of f64` · `local.tee[0] expected anyref, found f64.const` | exact-model operand repair declines scalar ⇄ externref and any abstract-internal ref | root-caused |
+| **S3** | 4 | `call[0] expected (ref null $AnyString), found i32.const / global.get of i32` | `padStart`/`padEnd` fillString skips ToString | root-caused |
+| **S4** | 4 | `i32.ge_s[1] expected i32, found struct.get of (ref null N)` | for-of vec fast path entered on a `$Map` struct; field 0 never type-checked | root-caused |
+| **S5** | 6 | `call_ref[0] expected (ref null $closure), found local.get of (ref null $ttStrings)/externref` | tagged-template pushes the strings array even when the tag declares 0 params | root-caused |
+| **S6** | 3 | `extern.convert_any[0] expected anyref, found block of type externref` | already-externref value fed to `extern.convert_any`; producer is a `block`, invisible to both positional repairs | root-caused (fix choice open) |
+| **S7** | 6 | `not enough arguments on the stack for local.set (need 1, got 0)` (`__async_resume_ffn`) | for-await-of `[[]]` empty array pattern emits a `local.set` with nothing pushed | needs WAT triage |
+| **S8** | 4 | `type error in fallthru[0] (expected (ref null N), got i32)` (`__closure_48`) | Array `find`/`findIndex`/`findLast`/`findLastIndex` predicate block-result typed from the element, not the boolean | needs WAT triage |
+| **S9** | 3 | `not enough arguments on the stack for call_ref (need N, got N-1)` (`__call_fn_0/1`) | rest-param dispatch arm under-pushes by one | needs WAT triage |
+| **S10** | 3 | `struct.get[0] expected (ref null A), found local.get of (ref null B)` (`__cb_*`) | `new DataView(x)` reads ArrayBuffer fields off a local typed from the ARGUMENT | root-caused |
+| **S11** | 2 | `call[0] expected (ref null N), found f64.const of f64` (`__cb_0`) | private-field get/put on a primitive receiver: no TypeError, raw f64 fed to the brand helper | root-caused |
+| **S12** | 5 | singletons (see below) | five unrelated one-offs | needs WAT triage |
+
+Total 5+8+4+4+6+3+6+4+3+3+2+5 = **53**.
+
+**S12 singletons**, one row each:
+`generators/yield-star-before-newline` (`__gen_resume_g local.tee[0] expected (ref null N), found ref.as_non_null of (ref eq)`) ·
+`Atomics/waitAsync/bigint/value-not-equal-agent` (`__closure_82 call[0] expected i64, found if of externref`) ·
+`class/super/in-static-methods` (`C_method` call arity 4 vs 3) ·
+`optional-chaining/optional-expression` (`ref.test` fed an externref) ·
+`String/prototype/indexOf/searchstring-tostring-bigint` (`call[0] expected anyref, found call_ref of i64`).
+The last two are all that remains of #3394's bigint lane.
+
+### S0 — infra first: the #1853 hard-error gate is VACUOUS
+
+Not a row fix; do this first because every other slice's regression protection
+depends on it.
+
+`scripts/check-test262-hard-errors.mjs` gates `hard_errors` in the committed
+summary against `scripts/test262-hard-error-baseline.json`. Today:
+`test262-current.json` → `hard_errors: {}`, `test262-standalone-current.json` →
+`hard_errors: {}`, baseline → `{}`. The gate passes while **93 malformed-Wasm
+rows exist** (40 host + 53 standalone). It has been green-and-blind since the
+vitest runner took over.
+
+Cause: two producers, only one tagged.
+
+- `tests/test262-vitest.test.ts:748` DOES pass `"malformed_wasm"` — but only on
+  its own inline instantiate-failure branch.
+- `scripts/test262-worker.mjs:1704-1713` is the branch that actually fires:
+  `if (!WebAssembly.validate(result.binary))` →
+  `buildInvalidBinaryError(...)` → `sendResult({ status: "compile_error", error })`
+  with **no** hard-error flag. The runner then records it through a generic
+  `recordResult(...)` call with `hardErrorKind` omitted. Every one of the 53
+  rows carries the worker's `[wat: …]` suffix, which only that path emits — so
+  all 53 take the untagged route. `hard_error_kind` appears **0 times** in the
+  48,735-record baseline.
+
+Changes:
+
+1. `scripts/test262-worker.mjs:1710-1712` — add `hardError: "malformed_wasm"` to
+   the `sendResult` payload (and to the `metaPath` JSON so a disk-cache hit
+   replays it).
+2. `tests/test262-vitest.test.ts` — forward `workerResult.hardError` into the
+   `recordResult(...)` call that handles worker `compile_error` results
+   (`recordResult` already accepts the parameter at `:311`).
+3. `scripts/check-test262-hard-errors.mjs:48` — `SUMMARY_PATH` is hard-coded to
+   the HOST summary. Accept both lanes: gate host + standalone, keyed
+   separately in the baseline (`malformed_wasm` vs `standalone:malformed_wasm`),
+   so a standalone regression can't hide behind a flat host count.
+4. Re-baseline via `--update` once the counts are real, and wire
+   `--update-on-decrease` into the post-merge job so each slice banks its own
+   improvement.
+
+Test: extend `tests/issue-1853.test.ts` with a case that drives the **worker**
+path (not just the inline one) and asserts the JSONL row carries
+`hard_error_kind: "malformed_wasm"`.
+
+### S1 — reserved synthesized class stems (5 rows)
+
+`class-bodies.ts:1146` mints `` `${className}_new` `` and `:1278` mints
+`` `${className}_init` ``. `classMemberFuncKey` (`src/codegen/class-member-keys.ts:46-69`)
+disambiguates a member key against (a) top-level user function names and (b) the
+`static m()` / `m()` pair — but **not** against those two synthesized stems. A
+class with a member literally named `init` or `new` mints the identical key.
+
+Verified from the emitted binary for `private-field-presence-field-shadowed.js`
+(the test declares `static init()`):
+
+```wat
+(func $Parent_new (result (ref null 49))
+  (local $__self (ref null 49))
+  i32.const 1  ref.null extern  struct.new 49  local.tee 0
+  return_call 54)              ;; = $Parent_init
+(func $Parent_init (type 59)   ;; 0 params, NO result — the USER's static init()
+  global.get 12 ...  global.set 136)
+```
+
+The sibling classes in the same module show the intended shape
+(`$Test262Error_new (result (ref null 45))` → `$Test262Error_init (param … (ref null 45)) (result (ref null 45))`),
+so `Parent_new` tail-calls the wrong function entirely. The `ident-name-method-def-new-escaped`
+rows are the same defect on the other stem: the test declares `new(){}`,
+i.e. a method named `new`, and `<Class>_new` then returns the method's f64.
+
+Change: relocate the **member**, never the synthesized function — 11 sites look
+up `` `${className}_new` `` / `` `${className}_init` `` by literal string
+(`new-super.ts:2699,2970,3335,5177`, `extern.ts:530`, `index.ts:1563`,
+`class-callable-abi.ts:116,122`, `prepared-class-body-cutover.ts:185,196,221`),
+whereas member keys already funnel through `classMemberFuncKey`.
+
+- `class-member-keys.ts:46-69` — take the class name (or derive it from
+  `fullName`'s prefix) and add "`fullName` equals the `_new` or `_init` stem of
+  its own class" to the relocation condition, reusing the existing `__cm$`
+  prefix + the `while` disambiguator at `:67`.
+- `class-bodies.ts:1293-1296` — while here: `funcOptionalParams` /
+  `funcRestParams` are keyed by the RAW `initName`, while the function is
+  registered under `initKey`. Latent for the same reason; key both by `initKey`.
+
+Edge cases: `new` and `init` as **static** members, as **instance** members, and
+both at once (the `kind === "static"` arm at `:63` already stacks a second
+prefix — verify it composes); a getter/setter/field named `new`; a computed name
+that resolves to `"new"` via `resolveClassMemberName`; a class *named* `new`.
+
+### S2 — widen the exact-model operand repair (8 rows) and S6 (3 rows)
+
+`src/codegen/cross-hierarchy-operands.ts` already has exactly the machinery
+needed — `locateOperandProducers` gives an exact forward stack model, so it sees
+producers behind `if`/`block`/`local.tee` that the two legacy positional repairs
+(`fixCallArgTypesInBody` stops at control flow; `fixLocalSetCoercion` looks only
+at `body[i-1]`) cannot. It is deliberately narrowed to one mismatch class:
+
+```ts
+// :146-149
+const crossed =
+  (isConcreteInternalRef(actual) && isExternHierarchy(want)) ||
+  (isExternHierarchy(actual) && isConcreteInternalRef(want));
+```
+
+Two holes fall out. `isConcreteInternalRef` (`:90-92`) requires a `typeIdx`, so
+a bare `anyref`/`eqref` slot is never a `want` — that is the `C_init local.tee[0]
+expected anyref, found f64.const` row. And a **scalar** producer is never an
+`actual` — that is the 5 `Uint8Array.prototype.toBase64/toHex` rows
+(`local.tee` of i32 into an externref param) and the 2 `SharedArrayBuffer`
+options rows (`f64.const` into an externref param).
+
+Change:
+
+1. Add `isAbstractInternalRef(t)` (`anyref` / `eqref` / `i31ref`, i.e. internal
+   hierarchy with no `typeIdx`) alongside `isConcreteInternalRef` at `:88-92`,
+   and let both stand in for the internal side of `crossed`.
+2. Add `isScalar(t)` (`i32` / `i64` / `f64` / `f32`) and admit
+   `isScalar(actual) && (isExternHierarchy(want) || isAbstractInternalRef(want))`
+   plus the reverse.
+3. **Do NOT admit `isScalar(actual) && isConcreteInternalRef(want)`.** That
+   window contains S3 (i32 into `(ref null $AnyString)` — needs ToString, not a
+   box) and S11 (f64 into a private-brand struct — needs a TypeError, not a
+   cast). A mechanical box+cast there would turn invalid Wasm into a silent
+   runtime `illegal cast`, which is strictly worse. Assert in the PR that
+   `coercionPlan` has no scalar → concrete-GC-ref row.
+
+The file header's byte-safety argument carries over unchanged: scalar ⇄ externref
+and scalar ⇄ anyref are disjoint in Wasm, so a site this repair rewrites was
+already an invalid module and no valid module can be perturbed. Re-run the
+header's own canaries (the all-flags-`=0` standalone acorn artifact, 1,157,936 B)
+to confirm byte-identity on the legacy path.
+
+**S6** rides the same file. `requiredOperandTypes` (`:96-118`) models `call` /
+`return_call` / `local.set` / `local.tee` / `global.set` only, so
+`extern.convert_any` — whose operand must be `anyref` — is unmodelled, and the
+Promise-capability / `RegExp.prototype.compile` rows feed it a `block (result
+externref)`. Two options, pick one and say which in the PR:
+
+- (a) add `extern.convert_any → [anyref]` and `any.convert_extern → [externref]`
+  to `requiredOperandTypes`; with (1) above the repair inserts the identity
+  round-trip `any.convert_extern` and the module validates; or
+- (b) fix the producer so it does not emit `extern.convert_any` over a value
+  already in the external hierarchy, and add a peephole that deletes an
+  `any.convert_extern; extern.convert_any` pair.
+
+(b) is the cleaner output; (a) is the smaller, more general blast radius. (a)
+then (b) as a follow-up is acceptable.
+
+### S3 — `padStart` / `padEnd` fillString ToString (4 rows)
+
+`src/codegen/string-ops.ts:3215-3218` and `:3250-3253`:
+
+```ts
+if (expr.arguments.length > 1 && !isStaticUndefinedArg(expr.arguments[1])) {
+  compileExpression(ctx, fctx, expr.arguments[1]!);
+  emitFlatten();
+}
+```
+
+`compileExpression` returns whatever the argument's ValType is and
+`emitFlatten()` unconditionally calls `__str_flatten`, whose param is
+`(ref null $AnyString)`. Confirmed in the emitted WAT for
+`padStart/fill-string-non-strings.js`: `'abc'.padStart(10, false)` emits
+`global.get $abc; ref.cast; call $__str_flatten; i32.const 10; i32.const 0;
+call $__str_flatten` — the `i32.const 0` (the boolean `false`) goes straight into
+the flatten call. `null` survives only because it happens to lower through
+`any.convert_extern; ref.cast`.
+
+Change both sites to the existing engine:
+
+```ts
+emitArgAsNativeString(ctx, fctx, expr.arguments[1]!);   // string-ops.ts:463
+emitFlatten();
+```
+
+`emitArgAsNativeString` is the #2598/#2599 helper the search/concat arguments
+already use (`compileStringValueToLocal` at `:2565-2572`). It routes through
+`compileNativeConcatOperand` — the same coercion engine `+`-concat uses, so this
+adds no new coercion site and does not move the #2108 drift gate — giving
+`false`→`"false"`, `0`→`"0"`, `NaN`→`"NaN"`, `null`→`"null"`, and a §7.1.17
+TypeError throw for a Symbol (which is what the two
+`exception-fill-string-symbol` rows assert). It diverges from the legacy path
+only under `noJsHost(ctx)`, so JS-host output stays byte-identical.
+
+Edge cases: keep the `isStaticUndefinedArg` arm (#2160) exactly as-is — the
+single-space default must not go through the engine; a fillString that is an
+object with a throwing `toString`; a `""` fillString (spec: return the string
+unchanged, no padding loop).
+
+### S4 — for-of vec fast path admits a non-vec struct (4 rows)
+
+`src/codegen/statements/loops.ts:1846-1863` validates that the iterable's type is
+a struct and that `getArrTypeIdxFromVec` yields an array — but **never checks
+that field 0 is `i32`**. A `$Map` carrier passes both checks (its field 1 is an
+array), so `for (const [k,v] of map)` enters the array fast path and emits
+`struct.get $Map 0` (a ref) where an `i32` length is required.
+
+Emitted WAT for `for-of/map-expand.js`, showing the asymmetry that makes this
+survive to the validator:
+
+```wat
+local.get $map  local.tee $__forof_vec  struct.get 130 1  local.set $__forof_data
+local.get $__forof_vec  struct.get 130 0
+extern.convert_any  call $..to_number  i32.trunc_sat_f64_s   ;; hoisted read: REPAIRED
+local.set $__forof_len
+loop
+  local.get $__forof_i
+  local.get $__forof_vec  struct.get 130 0                   ;; live re-read: NOT repaired
+  i32.ge_s                                                   ;; ← invalid
+```
+
+The hoisted read (`:1925-1930`) gets patched by a late repair; the `reReadLive`
+re-read (`:1993-1995`, the #2065 live-length path taken because these tests
+mutate the map inside the loop) does not. Repairing the second read would be the
+wrong fix — it would make a Map iterate by its hash-table field.
+
+Change: after the `arrDef` check at `:1857-1863`, add
+
+```ts
+const lenField = vecDef.fields[0]?.type;
+if (!lenField || lenField.kind !== "i32") { /* rollback + fall through */ }
+```
+
+using the same `restoreForOfHead` + `rollbackSpeculative(ctx, fctx, snap)`
+sequence the two existing guards use. Then route to the generic iterator
+protocol (`src/codegen/iterator-native.ts`) rather than `reportError` — a Map is
+a legitimate for-of iterable and these four tests should PASS, not refuse. If
+the generic path cannot take a `$Map` yet, land the guard with a #1888 loud
+refusal first (4 invalid-Wasm rows → 4 honest refusals) and file the Map arm as
+a follow-up; do not leave the fast path reachable.
+
+Edge cases: `Set`, `WeakMap`, `WeakSet` (same `$Map` carrier, `M_KIND` brand
+differs); a user class whose first field happens to be `i32` and second an
+array — the guard admits it, same as today, so no behaviour change; `preVec`
+callers (`:1895`) that supply `vecType` from elsewhere.
+
+### S5 — tagged-template call arity (6 rows)
+
+`src/codegen/string-ops.ts:1494-1512`:
+
+```ts
+// Push strings array as first argument
+fctx.body.push({ op: "local.get", index: stringsLocal });
+if (matchedClosureInfo.paramTypes[0] && matchedClosureInfo.paramTypes[0].kind === "externref") { … }
+const closureMaxSubs = Math.min(substitutions.length, matchedClosureInfo.paramTypes.length - 1);
+```
+
+The strings array is pushed **unconditionally**, but the closure matcher at
+`:1449` requires `info.paramTypes.length === sigParamCount` — so a tag declared
+`function () { … }` has `paramTypes.length === 0` and no slot for it. The
+`closureMaxSubs` expression degrades to `Math.min(n, -1)` and the padding loop
+at `:1508` doesn't run, so the extra operand is simply left on the stack and
+`call_ref` reads the strings array as the self param. Verified in the WAT for
+`call-expression-context-strict.js` (the tag is `fn()`, a 0-param function):
+`local.tee $__tt_tag; ref.as_non_null; local.get $__tt_strings; …; call_ref` into
+a func type with one fewer param than operands pushed.
+
+Change, in **both** the matched arm (`:1490-1512`) and the
+`closureInfoByTypeIdx`-lookup fallback (`:1538-1560`, which has the identical
+shape and additionally omits the `ref.as_non_null` on the self push):
+
+- push the strings array only when `paramTypes.length >= 1`;
+- clamp `closureMaxSubs` with `Math.max(0, …)`;
+- still **evaluate** every substitution the callee cannot accept, then `drop`
+  it — `evaluation-order.js` asserts the `i++` side effects run left-to-right
+  even when the arity truncates. Do not skip compiling them.
+
+Edge cases: 0-param tag with substitutions; tag with more params than
+`1 + substitutions.length` (existing `pushDefaultValue` padding at `:1508`, keep);
+arrow tag; a tag that is itself a call result (`fn()` followed by the template);
+a tag that is a `var`
+(externref) — that goes through the `any.convert_extern` + `emitGuardedRefCast`
+arm at `:1478-1484`; and the `__tagged_template` host-import fallback at `:1572`,
+which must stay unreachable in standalone.
+
+### S10 + S11 — non-object receivers must throw, not mis-type (5 rows)
+
+Both are the same discipline and belong in one PR.
+
+**S10 (3 rows).** `src/codegen/expressions/new-indexed.ts:226-230`:
+
+```ts
+const bufLocalType: ValType = isStructBuf ? resultType! : { kind: "externref" };
+const bufLocal = allocLocal(fctx, `__dv_buf_${fctx.locals.length}`, bufLocalType);
+```
+
+The local takes the **argument's** type, while every later `struct.get` uses the
+fixed ArrayBuffer vec typeIdx. `new DataView(1)` gives `(ref null $AnyString)`
+vs `(ref null $ArrayBuffer)`; `new DataView(sab)` gives the SAB struct. Per
+§25.3.2 all three tests want a TypeError (`RequireInternalSlot(buffer,
+[[ArrayBufferData]])`), so emit the throw when `resultType.typeIdx` is not the
+registered ArrayBuffer vec type instead of reading fields off it — that converts
+3 invalid-Wasm rows into 3 passes. Keep the externref arm for the dynamic case.
+
+**S11 (2 rows).** `privatefieldget-primitive-receiver` /
+`privatefieldput-primitive-receiver`: `call[0] expected (ref null 75), found
+f64.const of f64` inside `__cb_0` — a primitive receiver reaches the private-brand
+helper with no `PrivateElementFind` guard. Spec wants a TypeError. Find the
+brand-check emitter (`src/codegen/`, `emitReceiverBrandCheck` and the
+private-name access path) and emit the throw on a non-ref receiver. Note this is
+deliberately NOT covered by the S2 repair widening — see S2 step (3).
+
+### S7, S8, S9, S12 — triage first, then fix
+
+Root cause not established; each needs one WAT dump before it is dispatchable.
+Each is still one PR's worth of work.
+
+- **S7 (6 rows)** — `__async_resume_ffn`: `not enough arguments on the stack for
+  local.set (need 1, got 0)`. The six files are exactly
+  `{var,let,const} × {sync,async}` of `ary-ptrn-elem-ary-empty-init`, i.e. an
+  **empty** nested array pattern `for await (var [[]] of …)`. Start at the
+  resume-body emitter `src/codegen/async-frame.ts:1597` (`__async_resume_f<stem>`)
+  and the array-destructuring emitter it calls: an empty sub-pattern almost
+  certainly emits the binding `local.set` while pushing nothing.
+- **S8 (4 rows)** — `__closure_48`: `fallthru[0] expected (ref null 43), got i32`
+  for `Array.prototype.{find,findIndex,findLast,findLastIndex}` /
+  `array-altered-during-loop`. The predicate returns a boolean (i32) into a
+  block whose declared result is the element ref. Start at
+  `src/codegen/hof-native.ts` / `src/codegen/array-methods.ts` and the
+  `array-altered-during-loop` re-read path — the four methods share one lowering,
+  so one fix covers all four.
+- **S9 (3 rows)** — `__call_fn_0/1`: `not enough arguments on the stack for
+  call_ref`. `emitClosureCallExportN` (`src/codegen/closure-exports.ts:535+`)
+  builds a `rest` entry at `:598-612` from `closureHostArity(info)`; the two
+  `generators/scope-param-rest-elem-var-*` rows and the `Promise.any` row are all
+  rest-param callees, so the rest arm under-pushes by one (likely the rest vec
+  itself, or the generator frame param).
+- **S12 (5 rows)** — five unrelated singletons, listed above. Batch them into one
+  PR only if two or more turn out to share a cause; otherwise take the two
+  cheapest (`optional-chaining/optional-expression`'s `ref.test` on an externref
+  looks like a missing `any.convert_extern` before the test) and leave the rest.
+
+### Latent defect found while tracing S1 — fix it regardless
+
+`resultsMatchCaller` (`src/codegen/ir-tail-call.ts:66-84`) and its two legacy
+twins `canTailCall` / `canTailCallRef`
+(`src/codegen/statements/control-flow.ts:79-116` and `:122-142`) all end with:
+
+```ts
+if ((calleeRet.kind === "ref" || calleeRet.kind === "ref_null") &&
+    (callerRet.kind === "ref" || callerRet.kind === "ref_null")) return true;
+```
+
+They compare the ref **kind** and ignore `typeIdx` entirely, so any two unrelated
+struct types are treated as tail-call compatible — which Wasm's subtyping rule
+does not permit. `canTailCall` additionally checks only `params.length`, never
+the param **types**. No row in the current 53 is provably caused by this (S1's
+`Parent_new` is the name collision, and both gates would have rejected that
+callee on `calleeResults.length !== 1` had the funcIdx been correct at decision
+time — which is itself worth logging: instrument the funcIdx at conversion vs.
+in the final binary while doing S1). Close the hole anyway: require
+`calleeRet.typeIdx === callerRet.typeIdx`, forbid `ref_null` callee → `ref`
+caller, and compare param types pairwise. Keep the three copies in sync — the
+comment at `ir-tail-call.ts:76` already says so and has drifted once.
+
+### Slice order and dependencies
+
+Independent except where noted; `[n]` = rows closed.
+
+1. **S0** (infra) — no rows, but nothing else is measurable without it. Land first.
+2. **S1** [5] — `class-member-keys.ts` + `class-bodies.ts`. Isolated.
+3. **S2 + S6** [11] — both in `cross-hierarchy-operands.ts`; one PR, one dev.
+4. **S3** [4] and **S5** [6] — both in `string-ops.ts`. Same dev back-to-back or
+   serialize; do not run two devs in that file concurrently.
+5. **S4** [4] — `statements/loops.ts`. Isolated. May need an iterator-native
+   follow-up (see slice).
+6. **S10 + S11** [5] — one PR, "non-object receiver throws".
+7. **S7** [6], **S8** [4], **S9** [3] — triage each first; independent of everything above.
+8. **S12** [5] — last, opportunistic.
+9. **Tail-call type check** — anytime; touches `ir-tail-call.ts` +
+   `statements/control-flow.ts`, no overlap with the above.
+
+Nothing here needs the `#3394–#3398` children as gating artifacts. Recommend the
+PO: close #3396 out of the umbrella (already `done`), re-scope #3394 to the 2
+remaining bigint rows (S12), and either re-point #3395/#3397/#3398 at S2+S6 /
+S4 / S7+S8+S9 or close them and track the slices under #2039 directly. Leaving
+their stale counts (59/34/27/13) live is how a dev spends a day looking for 59
+rows that no longer exist.
+
+### Test plan
+
+**Existing coverage.** `tests/issue-2039-strflatten.test.ts` is the model — its
+`compilesValidWasm(source, target)` helper (compile → `WebAssembly.compile`,
+throw = fail) is exactly the assertion every slice needs, and it already covers
+the standalone / wasi / host-mode triple. `tests/issue-1853.test.ts` covers the
+hard-error tagging (extend it for S0). `tests/test262.test.ts` is a
+non-asserting dashboard and gates nothing.
+
+**No test in the tree asserts that any of the 53 rows produces valid Wasm.**
+
+**New tests**, one file per slice, `tests/issue-2039-<slug>.test.ts`, each with:
+
+1. the distilled source, compiled at `target: "standalone"`, asserting
+   `WebAssembly.compile` does not throw;
+2. a host-mode guard on the same source (must stay valid — several slices claim
+   byte-identity on the JS-host path);
+3. a behavioural assertion wherever the fix also makes the upstream test pass
+   (S3 `'abc'.padStart(10, false) === 'falsefaabc'`; S4 the Map iteration count;
+   S5 the `evaluation-order` side-effect order; S10 the `TypeError`).
+
+Two distilled sources reproduce standalone on `0e65e238` with **no** harness at
+all — start here, they are the cheapest red tests in the set:
+
+- S1 (the `_new` stem): a class expression with a method named `new` written as
+  the escaped identifier `new`, then `new C().new()` →
+  `local.set[0] expected (ref null 44), found block of type f64`.
+- S3: `"a".padStart(5, Symbol())` →
+  `call[0] expected (ref null 3), found global.get of type i32`.
+
+Everything else — including S1's `static init()` variant and S5's 0-param tag —
+needs the real harness assembly; hand-distilled equivalents came out VALID in
+probing, which is exactly the trap this note exists to prevent. Use
+`runTest262File(<path>, <category>, timeout, "standalone")`
+(`tests/test262-runner.ts:4431`) in the test, or fetch the upstream file at the
+pinned submodule SHA — `wrapTest` alone under-reproduces 6 of 19 representatives
+and will make a slice look already-fixed.
+
+**Gate.** After S0 lands, every slice PR must show its rows leaving the
+standalone `malformed_wasm` count, and the post-merge
+`check:test262-hard-errors --update-on-decrease` banks it. Do not rely on the
+PR-level `check for test262 regressions` — it is a designed green no-op at PR
+level (CLAUDE.md § Agent work dispatch); the real signal is the `merge_group`
+re-validation and the refreshed standalone summary.
+
+### Acceptance criteria (2026-08-26)
+
+- `error_categories.wasm_compile` in `benchmarks/results/test262-standalone-current.json`
+  reaches **0**, and the host lane's 40 are triaged into their own issue.
+- `hard_errors.malformed_wasm` is non-empty and *accurate* in both lane summaries
+  before any slice lands, and `scripts/test262-hard-error-baseline.json` ratchets
+  down with each slice — the gate must be able to fail again.
+- Every remaining `invalid Wasm binary` row is either fixed or converted to a
+  #1888 loud refusal. A validation failure is never an acceptable end state.
+- No host-mode regression: `pnpm test -- tests/equivalence.test.ts` green, and
+  the `cross-hierarchy-operands.ts` byte-identity canaries unchanged for S2/S6.
+- The `#3394–#3398` children are re-scoped or closed; no child carries a count
+  it cannot substantiate against the current baseline.

--- a/plan/issues/3406-zero-candidate-dynamic-call-silent-null.md
+++ b/plan/issues/3406-zero-candidate-dynamic-call-silent-null.md
@@ -3,7 +3,7 @@ id: 3406
 title: "Dynamic any-callee with zero closure candidates silently returns null instead of invoking or throwing"
 status: ready
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-08-26
 priority: critical
 horizon: m
 feasibility: hard
@@ -135,3 +135,341 @@ reachable in the simplest exported-parameter shape.
 - A broad fallback change can turn existing vacuous results into real execution,
   exposing honest test262 failures. Treat such flips as behavior corrections,
   not grounds to restore the silent no-op.
+
+## Implementation Plan
+
+### 0. Re-verification against current main (0e65e238, 2026-08-26)
+
+The **headline repro is FIXED**; the issue is **still actionable** on a smaller,
+precisely-located surface. Probes under `.tmp/probe-3406*.mts` (gitignored),
+host lane = `compile(src)` + `buildImports`, standalone = `{ target:
+"standalone", nativeStrings: true }` + `WebAssembly.instantiate(bin, {})`.
+
+| # | Shape | Lane | Result on `0e65e238` | Verdict |
+|---|---|---|---|---|
+| A | `export function test(f:any){ return f(2) }`, `f=(x)=>x+1` | host | **`3`, callee invoked once** | **FIXED** |
+| B | same, `f=42` | host | **throws `TypeError: value is not a function`** | **FIXED** |
+| C1 | `f(1..11)` — 11 args, zero candidates | host | **`null`, callee never invoked, args dropped** | **OPEN** |
+| C2 | `f(1..10)` — 10 args, zero candidates | host | `10`, invoked | ok |
+| F1 | `f(bump(1),2..11)` — 11 args, **one** candidate in module | host | `11`, invoked | ok (candidate ⇒ #3335 arm) |
+| T1 | opaque `f = n>0?42:7; f(2)`, zero candidates | standalone | **`null`, no throw** | **OPEN** |
+| T2 | same, one **arity-1** candidate present | standalone | **`null`, no throw** | **OPEN** |
+| T2b | same, one **arity-3** candidate present | standalone | **`null`, no throw** | **OPEN** (different terminal, see §2) |
+| N1/N3/N4 | opaque callee `null` / `{a:1}` / `"s"` | standalone | **`null`, no throw** | **OPEN** |
+| T4/T5/N2 | the above under `try/catch` | standalone | catch never runs | **OPEN** |
+| N5/N6 | arity 9 / 10 dynamic call on a real closure | standalone | `42` / `43` | ok |
+
+**What fixed A/B:** #4527 (`40554219`, 2026-08-21) added the
+reference-preserving `__call_dyn_<n>` host bridge at
+`src/codegen/expressions/call-identifier.ts:2683-2762`, placed *after* the
+`tryEmitInlineDynamicCall` call at `:2675-2677`. It is the exact zero-candidate
+host path this issue described, and its host-side handler
+(`src/runtime.ts:16379-16390`) throws a real `TypeError` for a non-callable.
+The issue's §Root-cause analysis is therefore correct but **incidentally
+resolved for the host lane at arity ≤ 10**; the `tryEmitInlineDynamicCall`
+early return itself (now `src/codegen/expressions/calls.ts:4118`) is unchanged
+and still returns `null` for a zero-candidate host call.
+
+**What is still open**, i.e. the residual scope of #3406:
+
+1. **Host lane, arity > 10** (C1/A12) — the #4527 bridge is gated
+   `expr.arguments.length <= 10` and no-spread; above it, control reaches the
+   graceful `ref.null.extern` at `call-identifier.ts:2787-2796`. Silent null,
+   arguments evaluated then dropped. Acceptance criterion 1 fails here.
+2. **Standalone / WASI, every non-callable** (T1/T2/T2b/N1/N3/N4) — no
+   `TypeError` is ever thrown for a dynamic call on a non-callable; the value
+   is silently `undefined`. Acceptance criteria 2 and 4 are fully open for
+   these lanes. This is not an oversight but a **documented deferral**: see the
+   `S1 SCOPE — NO THROWS` header at `src/codegen/object-runtime.ts:6790-6802`,
+   which names the spec-correct `TypeError` as "the S2 fast-follow". #3406 is
+   that fast-follow.
+
+The blocker that header cites (pulling `__new_TypeError` + the exn tag + a
+string constant in at finalize shifts func indices — the #1839/#117/#1886
+class) **no longer applies**, on two independent grounds, both measured:
+
+- A module that reserves `__apply_closure` **already contains**
+  `__new_TypeError` and the `__exn` tag. Measured: minimal standalone module →
+  neither present; any module with a dynamic call → both present plus
+  `__apply_closure`. So the fill needs **zero** new registrations, only
+  `funcMap` reads.
+- The repo already has the pattern that makes it unconditionally safe:
+  `reserveNullishReceiverThrow` (`src/codegen/closed-method-dispatch.ts:161-166`)
+  does `emitWasiErrorConstructor(ctx,"TypeError",1)` + `ensureExnTag(ctx)` +
+  `addStringConstantGlobal(...)` at **reserve** time so the finalize fill stays
+  read-only, and `reserveBindDynHelper` (`object-runtime.ts:7404-7407`) does the
+  same for its message string. Under `nativeStrings`
+  (`addStringConstantGlobal`, `registry/imports.ts:130-140`) a string constant
+  is import-free anyway — sentinel `-1`, materialized inline — and standalone
+  is always native-strings.
+
+End-to-end proof the target behaviour is reachable in standalone today:
+`throw new TypeError(...)` caught with `e instanceof TypeError` returns `1`,
+and the **existing** nullish-receiver guard (`o.m()` on an opaque `undefined`
+`o`) already throws a catchable, `instanceof`-correct `TypeError` in standalone.
+
+### 1. S1 — standalone/WASI: make the `__apply_closure` terminals throw
+
+`src/codegen/object-runtime.ts`.
+
+`buildDynamicApplyFallback` (`calls.ts:3932-3956`) is the innermost default arm
+of every standalone dynamic call (`calls.ts:4410-4412`, armed by
+`wantApplyFallback = ctx.standalone || ctx.wasi` at `calls.ts:4116`); it calls
+`__apply_closure(fn, undefined, argsVec)`. So `__apply_closure` is the single
+choke point for the standalone half.
+
+**Change sites:**
+
+- **`reserveApplyClosure` (`:6716-6738`)** — add, guarded on
+  `ctx.standalone || ctx.wasi`, immediately before `mintDefinedFunc`:
+  ```ts
+  emitWasiErrorConstructor(ctx, "TypeError", 1);
+  ensureExnTag(ctx);
+  addStringConstantGlobal(ctx, NOT_A_FUNCTION_MESSAGE);
+  ```
+  Byte-inert for every module that already carries the ctor + tag (measured:
+  all of them). Keeps the fill `funcMap`-read-only, per the
+  `reserveNullishReceiverThrow` precedent.
+- **New leaf module `src/codegen/dynamic-callable-throw.ts`** (see §5 — the
+  god-files are all at their LOC cap) exporting:
+  ```ts
+  export const NOT_A_FUNCTION_MESSAGE = "value is not a function";
+  /** Empty when the machinery is absent (host lane / never reserved). */
+  export function notCallableThrowInstrs(ctx: CodegenContext): Instr[];
+  ```
+  Body is byte-for-byte the `then:` of `nullishReceiverGuardInstrs`
+  (`closed-method-dispatch.ts:174-199`) minus its predicate:
+  `...stringConstantExternrefInstrs(ctx, NOT_A_FUNCTION_MESSAGE)`,
+  `{op:"call",funcIdx:ctx.funcMap.get("__new_TypeError")}`,
+  `{op:"throw",tagIdx:ctx.exnTagIdx}`. Returns `[]` when
+  `__new_TypeError` is missing or `ctx.exnTagIdx < 0`.
+- **`fillApplyClosure` `undefinedSentinel` (`:6822`)** — leave as-is; it is
+  also the *legitimate* undefined result of the proxy-revoker arm (`:7098`).
+  Instead introduce a sibling
+  `const notDispatched = (): Instr[] => [...notCallableThrowInstrs(ctx), ...undefinedSentinel()]`
+  and use it at exactly two places:
+  - **`armUnsupported` (`:6827`)** — the `n > APPLY_CLOSURE_MAX_ARITY` (>8) arm.
+  - **`buildArm(n)`'s no-dispatcher branch (`:6939-6947`)** — the T2b path
+    (verified: a module whose only closure has arity 3 emits no
+    `__call_fn_method_1`, so an arity-1 dynamic call lands here).
+
+  Keeping the trailing `ref.null.extern` after the throw is deliberate: the
+  arm still statically produces `externref`, so the emitted `if` needs no
+  stack-balance fixup (`pnpm run check:stack-balance` ratchets fixup COUNTS,
+  `scripts/check-stack-balance.ts:1-36` — a new fixup fails CI).
+- **Update the `S1 SCOPE — NO THROWS` header (`:6790-6802`)** to record that S2
+  landed, why the index-shift blocker dissolved (reserve-time registration),
+  and that the arity-overflow arm now throws rather than vanishing.
+
+### 2. S2 — standalone/WASI: the `__call_fn_method_N` / `__call_fn_N` terminal
+
+`src/codegen/closure-exports.ts:680` and `:1228`:
+```ts
+let funcrefDispatch: Instr[] = methodHostCallableFallback(ctx, arity) ?? [{ op: "ref.null.extern" }];
+```
+`hostCallableFallbackTerminal` (`:1001-1025`) returns `undefined` for
+`ctx.standalone || ctx.wasi || native-first || arity > 4`, so those lanes keep
+the bare null terminal. **This is where T2 lands** — verified: the T2 module
+*does* emit `__call_fn_method_1`, so `__apply_closure`'s arity dispatch reaches
+it and the non-callable falls off this terminal. S1 alone does **not** fix T2.
+
+**Do not turn this terminal into an unconditional throw.** It is shared with
+the accessor drivers (`fillAccessorDrivers`), the proto-iterator driver and the
+disposable-stack driver, whose callee may be a legitimately callable carrier
+that simply matched no closure arm (a `$__bound_fn`, a `$Proxy`, a
+`$__ta_ctor`, a runtime-eval carrier). An unconditional throw converts today's
+silent-undefined into a *wrong* `TypeError` for those.
+
+**Gate it on the shared classifier instead.** Emit, only when
+`ctx.standalone || ctx.wasi`:
+```
+local.get <fn>
+call __typeof_function          ;; i32
+i32.eqz
+if (empty)
+  <ref.test $Proxy → skip>      ;; ctx.objectRuntimeTypes?.proxyTypeIdx, when present
+  ...notCallableThrowInstrs(ctx)
+end
+<existing ref.null.extern terminal>
+```
+`__typeof_function` is the ONE callability predicate
+(`src/codegen/closure-classifier.ts:40-107`, spliced at finalize by
+`fillStandaloneTypeofClosureArms`, `src/codegen/typeof-natives-finalize.ts:152-171`);
+its root set already includes `ctx.boundFnTypeIdx` and
+`ctx.runtimeEvalAotCallableCarrier`, and `buildBuiltinCallableTestArm` covers
+the branded builtin carriers. The call is by `funcIdx`, so the finalize-order
+relationship between this emit and the `__typeof_function` fill is irrelevant.
+`$Proxy` is **not** in that root set (a callable proxy would be misjudged), so
+it needs the explicit exclusion above — cheap, and byte-inert in proxy-free
+modules.
+
+Land S2 behind the same `notCallableThrowInstrs` helper, in the same PR as S1
+but as a separate commit, so a bisect can isolate it.
+
+### 3. S3 — host lane: close the arity > 10 hole
+
+`src/codegen/expressions/call-identifier.ts:2691-2700`. The gate is
+```ts
+!noJsHost(ctx) && !ctx.standalone && !ctx.wasi && isKnownVariable &&
+expr.arguments.length <= 10 && !expr.arguments.some((a) => ts.isSpreadElement(a))
+```
+The `<= 10` bound is arbitrary — the host handler is a regex
+(`/^__call_dyn_\d+$/`, `src/runtime.ts:16379`), so any arity resolves. The bound
+exists only to cap fixed-arity import proliferation. **Do not raise it to
+another magic number**; make the excess arity terminate on the
+arity-independent bridge instead:
+
+- Keep `__call_dyn_<n>` for `n <= 10` (unchanged bytes for every module today).
+- For `n > 10`: spill the callee and each already-`toExtern`-converted argument
+  into externref locals (`allocLocal`), then emit
+  `buildHostCallFallbackArm(ctx, fctx, planHostCallFallback(arity), calleeLocal, argLocals, undefinedThisInstrs)`
+  from `src/codegen/expressions/host-call-fallback.ts:44-88`. With
+  `arity > 4`, `planHostCallFallback` (`:19-29`) selects the array ABI
+  (`__js_array_new` / `__js_array_push` / `__call_function`) — **one** import
+  set for every arity. Its host implementation
+  (`src/runtime/host-call-abi.ts:19-27`) throws
+  `TypeError: <v> is not a function` for a non-callable, satisfying criterion 2
+  on this path too.
+- Order is preserved either way: callee is compiled first, then each argument
+  left-to-right, each exactly once — matching §13.3.6.1 (callee reference,
+  then ArgumentListEvaluation, then `Call()`), which is also why throwing
+  *after* argument evaluation is correct here and NOT a violation of criterion 3.
+- `noJsHost(ctx)` modules keep the existing degradation; note it explicitly in
+  the comment rather than leaving it implied.
+
+### 4. S4 — instrument what remains silent
+
+Neither `calls.ts` nor `call-identifier.ts` calls `reportSilentFallback` today
+(verified: zero hits in both files), so the graceful `ref.null.extern` at
+`call-identifier.ts:2787-2796` is invisible to
+`pnpm run check:codegen-fallbacks`. Add one call before it:
+```ts
+reportSilentFallback(ctx, "null-fallback", "call-identifier:dynamic-callee-graceful-null");
+```
+(class list: `src/codegen/fallback-telemetry.ts:31-49`). This does not change
+codegen; it makes every future reachable silent-null a ratcheted number and is
+the mechanism by which the *remaining* shapes (spread, `noJsHost`,
+`!isKnownVariable`) stop being invisible. Refresh with
+`pnpm run check:codegen-fallbacks -- --update` and commit
+`scripts/codegen-fallback-baseline.json`.
+
+**Do not** delete the graceful fallback outright (issue step 6). It is the
+terminal for shapes this slice does not cover; removing it converts them from
+silent-wrong to compile-crash. Narrow it by adding the covered paths above it,
+and let the telemetry number drive the rest to zero.
+
+### 5. Mechanical constraints
+
+- **Every touch file is at its LOC-budget cap**
+  (`scripts/loc-budget-baseline.json`): `calls.ts` 9985, `call-identifier.ts`
+  3428, `object-runtime.ts` 11671, `closure-exports.ts` 2093. Put all new logic
+  in the new leaf `src/codegen/dynamic-callable-throw.ts` (imports only types +
+  `registry/error-types.js`, `registry/imports.js`, `native-strings.js` — no
+  cycle), keep each god-file edit to a handful of lines, and add to this
+  issue's frontmatter in the implementation PR:
+  ```yaml
+  loc-budget-allow:
+    - src/codegen/object-runtime.ts
+    - src/codegen/closure-exports.ts
+    - src/codegen/expressions/call-identifier.ts
+  ```
+  Note: `pnpm run check:loc-budget` **already fails on current main**
+  (`src/codegen/array-methods.ts: 9829 > 9805`) — that is pre-existing, not
+  yours.
+- **Late-import order (issue step 5, #1858/#2611)**: S1/S2 add no imports
+  (defined funcs + a native-string constant only). S3's `>10` path calls
+  `ensureHostCallFallbackImports` then must `flushLateImportShifts(ctx, fctx)`
+  **before** `ctx.funcMap.get(plan.importName)`, exactly as the #4527 code does
+  at `:2745-2752` and as `hostCallableFallbackTerminal` does at
+  `closure-exports.ts:1023`.
+- **Issue status**: this is a self-merge path — the implementation PR sets
+  `status: done` directly, not `in-review`.
+
+### 6. Edge cases and failure modes
+
+| Case | Required behaviour | Risk if mishandled |
+|---|---|---|
+| Callable `$__bound_fn` / `$Proxy` / `$__ta_ctor` / runtime-eval carrier reaching the S2 terminal | must NOT throw | false `TypeError`; regresses `#3031`, `#3140`, `#3177` suites — this is why S2 is gated on `__typeof_function` + a `$Proxy` exclusion, not unconditional |
+| Native-proto method closures (`buildTransferredNativeProtoCallInstrs`) | must NOT throw | they are dispatched INSIDE `__call_fn_method_N`, after the arms; the S2 guard must sit at the terminal, never as a front gate on `__apply_closure` |
+| Proxy-revoker arm (`object-runtime.ts:7098`) | keeps returning `undefined` | its `undefinedSentinel()` is a real result, not a fallback — must not be swept into `notDispatched()` |
+| **Nullish** callee (`f = null; f(2)`) | TypeError, but the callee-resolution guards (#4221/#4640/#4656) fire *before* argument evaluation where they can prove it statically | S1's throw is after arg evaluation; correct for a *non-nullish* non-callable per §13.3.6.1, and the static guards keep priority. Do not relax `tryEmitNullishIdentifierCalleeTypeError` |
+| Arity > 8 on a genuinely callable value, standalone | loud, not vacuous | S1's `armUnsupported` throw makes it explicit; N5/N6 confirm arity 9/10 already work via the inline candidate arm, so this is a narrow path |
+| Void / statement-position dynamic call | arms must still leave the declared block result | S1/S2 keep the trailing `ref.null.extern`; verify with `check:stack-balance` |
+| `--target wasi` | identical to standalone | every gate here is `ctx.standalone || ctx.wasi`; `hostCallableFallbackTerminal:1015` already treats them alike |
+| Host lane, `noJsHost` policy | unchanged degradation | out of scope; covered by S4 telemetry |
+
+### 7. Adjacent finding — spread args are silently DROPPED (file separately)
+
+Not #3406 (it returns a value, it does not null out), but the same
+silent-miscompile family and found while verifying:
+
+```
+host: export function test(f:any){ const a:any=[1,2]; return f(...a); }   → callee invoked with 0 args
+host: export function test(f:any){ const a:any=[2,3]; return f(1,...a); } → callee invoked with 1 arg
+```
+Both with and without closure candidates. Cause: the #4527 bridge declines on
+spread (`call-identifier.ts:2699`) and the inline dispatch marshals only
+positional `argLocals`. Fixing it needs a variadic host bridge / vec-building
+path, which is a different shape of change. **File as a new issue via
+`node scripts/claim-issue.mjs --allocate --by ttraenkler/<agent>`; do not fold
+it into this slice** (issue Scope: "Do not broaden unrelated … dispatch in the
+same slice").
+
+### 8. Test plan
+
+**Existing coverage to keep green** (these are the regression surface):
+`tests/issue-4527-call-dyn-bridge.test.ts`, `tests/issue-4527.test.ts`,
+`tests/issue-2939.test.ts`, `tests/issue-2940.test.ts`,
+`tests/issue-3031-proxy-apply.test.ts`, `tests/issue-3140.test.ts`,
+`tests/issue-3140-stored-bound-carrier.test.ts`, `tests/issue-3177.test.ts`,
+`tests/issue-2174-async-closure-dynamic-call.test.ts`,
+`tests/equivalence.test.ts`.
+
+**New: `tests/issue-3406.test.ts`.** Two harnesses in one file, mirroring
+`tests/issue-2939.test.ts` (standalone: assert `env` imports are `[]`) and
+`tests/call-arg-type-coercion.test.ts` (host: `buildImports`). Every case
+asserts `WebAssembly.validate(binary)`.
+
+Host lane:
+1. zero candidates, `f(2)` → `3`, spy called exactly once with `[2]` (guards
+   the #4527 fix against regression — this is the issue's own repro).
+2. zero candidates, **11** and **12** args → callee invoked once with all args,
+   result correct. *Currently returns `null` with the spy never called.*
+3. 11 args, non-callable → catchable `TypeError`, arguments still evaluated.
+4. side-effectful argument at 11 args (`f(bump(1),2,…,11)`) → `bump` runs
+   exactly once, before the throw/call.
+5. statement-position `f(7); return 9` at arity 11 → spy called, result `9`.
+
+Standalone (and one WASI repeat of case 6):
+6. opaque non-callable, **zero** candidates, `try/catch` → `e instanceof
+   TypeError`. *Currently the catch never runs.*
+7. opaque non-callable, **one arity-matching** candidate → same (exercises the
+   S2 terminal at `closure-exports.ts:1228`).
+8. opaque non-callable, **one arity-MISMATCHED** candidate (closure arity 3,
+   call arity 1) → same (exercises `buildArm`'s no-dispatcher terminal at
+   `object-runtime.ts:6946`). Cases 7 and 8 are different code paths — verified
+   by `__call_fn_method_1` being present in 7 and absent in 8; both must be in
+   the suite or one regresses invisibly.
+9. opaque `null` / `{}` / `"s"` callee → catchable `TypeError` each.
+10. opaque **callable** (`n>0 ? g : 42` with `g` taken) at arities 1, 3, 9, 10
+    → invoked, correct result, no throw. This is the false-positive guard for
+    S2 — it must fail loudly if `__typeof_function` under-reports.
+11. `Function.prototype.bind` carrier and a callable `Proxy` invoked
+    dynamically → invoked, **no** throw (the S2 exclusion set).
+12. argument evaluation order on the throw path: `c` incremented by a
+    side-effectful arg, then TypeError caught, `c === 1`.
+
+**Gates:** `pnpm run typecheck`, `pnpm run check:stack-balance`,
+`pnpm run check:codegen-fallbacks` (expect the new `null-fallback` site;
+`--update` and commit the baseline), `pnpm run check:loc-budget` (expect the
+pre-existing `array-methods.ts` failure only, plus the `loc-budget-allow:`
+grant above), `pnpm run check:ir-fallbacks`.
+
+**Conformance:** CI's `merge_group` shard matrix is the real signal (PR-level
+`check for test262 regressions` is a designed no-op). Expect movement in the
+`TypeError`, callback-vacuity, `Function.prototype.call/apply`, Promise and
+TypedArray-harness buckets. Per the issue's own Risks: a vacuous pass that
+becomes an honest failure is a **behaviour correction** — record it in the PR,
+do not restore the silent no-op. If the merge group parks the PR
+(`auto-park-bot:merge-group-failure`), diagnose the cited run and pull the
+regressed-test delta before doing anything with the `hold` label.

--- a/plan/issues/3654-compileproject-eslint-package-context-resolution.md
+++ b/plan/issues/3654-compileproject-eslint-package-context-resolution.md
@@ -133,3 +133,225 @@ post-resolution scale/performance frontier is split into #3672.
 - After the resolver layer is fixed, re-run and record the honest
   compile/validate split; do not claim the Linter runs merely because these
   diagnostics disappear.
+
+## Implementation Plan
+
+### Verdict — the resolver layer has LANDED; re-verified 2026-08-26 against main @ `0e65e238`
+
+Every acceptance criterion in this issue is met on the current tree. The
+"Implementation findings (2026-07-26)" section above describes shipped code, not
+a proposal. Both split-out siblings (#3655 static JSON, #3672 codegen heap) are
+already `status: done` at sprint 78; only this parent was never flipped — the
+orphaned-issue failure mode described under "Issue status lifecycle" in
+`CLAUDE.md`.
+
+Measured on `node_modules/eslint/lib/linter/linter.js` (ESLint 10.0.3), driving
+`ModuleResolver` → `resolveAllImports` → `analyzeMultiSource` with the exact
+`projectResolutions` map `compileProject` builds:
+
+| Claim in this issue                                   | Measured 2026-08-26                                                          |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------- |
+| entry emits 141 diagnostics (52 errors, 89 warnings)  | entry emits **0** diagnostics, 0 errors, 0 warnings                          |
+| TS2307 on the 15 listed specifiers                    | **all 15 resolve**; only `node:path` returns `null`, by design (host import) |
+| `ModuleResolver` resolves from the logical symlink    | resolves from `/.pnpm/eslint@10.0.3/node_modules/eslint/...` (physical)      |
+| grouped `const a = …, b = …` requires never visited   | visited — graph reaches `traverser`, `source-code`, `timing`, `../types`     |
+| duplicate logical/physical copies                     | 146 files, **146** distinct realpaths — one canonical source per module      |
+| `resolver.getDiagnostics()`                            | **0** — `compileProject` no longer bails at `src/index.ts:1282`              |
+
+`tests/issue-3654.test.ts` (5 tests, incl. the real-ESLint case) passes in 6.1 s.
+
+**Recommended disposition:** flip `status: done` and unblock #1400 / #2691 on
+the resolver axis. Carve the two genuinely-open items below into new issues
+rather than reopening this one — neither is required by this issue's acceptance
+criteria.
+
+### As-built map — do NOT re-implement
+
+| Concern                                        | Location                                                                 |
+| ---------------------------------------------- | ------------------------------------------------------------------------ |
+| Physical-importer resolution context           | `src/resolve.ts:155-160` — `host.realpath(containingFile)` before resolve |
+| Cache keyed on canonical importer identity     | `src/resolve.ts:162-166`                                                 |
+| Graph identity / de-duplication                | `src/resolve.ts:288-292` `canonicalize()`                                |
+| `.d.ts` → implementation-body preference       | `src/resolve.ts:198-208` (relative `.js`), `:225-230` (bare package)     |
+| Extension / directory-index probing            | `src/resolve.ts:396-449` `probeImplementationPath()`                    |
+| Importer-scoped `node_modules` walk            | `src/resolve.ts:325-367` `findImplementationBody()`                     |
+| Grouped + nested static CJS `require` traversal| `src/resolve.ts:566-597`, `scanRequire` at `:580-592`                    |
+| JSDoc `import("…")` / `@import … from "…"` edges| `src/resolve.ts:599-614` (scanner over comment trivia)                  |
+| CJS→ESM rewrite feeding the walk               | `src/resolve.ts:544` → `src/cjs-rewrite.ts:41`                          |
+| Exact edges captured per importer              | `src/resolve.ts:240-247`, read at `:299-301`                            |
+| Edges threaded into the virtual host           | `src/index.ts:1312-1327` → `src/checker/index.ts:1106`, `:1129-1139`    |
+| Exact-edge fast path in the virtual resolver   | `src/checker/multi-file-paths.ts:160-167` (before any name heuristic)   |
+| Node ambient surface for multi-file JS graphs  | `src/checker/index.ts:1088-1100` (`NODE_ENV_DTS_NAME`, built once)      |
+
+### R1 — `exports` / `imports` conditions are NOT honored (the one unmet "Required behaviour" bullet)
+
+`src/resolve.ts:62` pins `moduleResolution: ts.ModuleResolutionKind.Node10`,
+which ignores `exports` and `imports` entirely. The third "Required behaviour"
+bullet ("Honor `exports.types.require` / `exports.types.import`") is satisfied
+**by accident** for ESLint: `@eslint/core@1.1.1` also ships a top-level
+`"types": "./dist/esm/types.d.ts"`, and Node10 finds it through that legacy
+field. `@eslint/plugin-kit` likewise resolves via `main`, not `exports` — so a
+CJS importer silently receives the ESM build (`dist/esm/index.js`) where Node
+would give it `dist/cjs/index.cjs`.
+
+The fixture at `tests/issue-3654.test.ts:67-80` carries both `types:` and
+`exports.types.*`, so it does not discriminate either. Measured against
+synthetic packages with **no** legacy fields (`.tmp/probe-3654-exports.mts`):
+
+```
+exports-only  -> NULL      dual -> NULL      subpath/sub -> NULL      #dep -> NULL
+```
+
+Mode comparison on the same fixtures (TypeScript 5.9.3), CJS importer:
+
+| `moduleResolution`                          | exports-only | dual      | subpath/sub | `#dep` |
+| ------------------------------------------- | ------------ | --------- | ----------- | ------ |
+| `Node10` (current)                          | NULL         | NULL      | NULL        | NULL   |
+| `Bundler`                                   | `t.d.ts`     | `i.d.ts`  | ok          | ok     |
+| `Bundler` + `customConditions:["require","node"]` | `t.d.cts` | `i.d.cts` | ok      | ok     |
+| `Node16`                                    | `t.d.cts`    | `i.d.cts` | ok          | ok     |
+
+**Algorithm change — layered fallback, not a mode switch.** Keep the Node10
+attempt at `src/resolve.ts:181` as the primary; add a second attempt fired
+*only when it returns null*, mirroring the existing "TS first, then probe"
+idiom already used at `:225-230`:
+
+1. `resolved = ts.resolveModuleName(specifier, resolutionContainingFile, this.compilerOptions, this.host)` — unchanged.
+2. If `resolved === null` **and** `getBarePackageName(specifier) !== null` or `specifier.startsWith("#")`:
+   a. Derive the importer's module mode from `resolutionContainingFile`:
+      `.cjs`/`.cts` → `require`; `.mjs`/`.mts` → `import`; `.js`/`.ts`/`.d.ts` →
+      walk up to the nearest `package.json` and read `"type"` (`"module"` →
+      `import`, otherwise `require`). Cache per directory — this walk runs once
+      per package, not once per specifier.
+   b. Retry with `{...this.compilerOptions, moduleResolution: Bundler,
+      customConditions: [mode, "node"]}` — a **runtime** pass. `Bundler` already
+      prepends `"types"`, so declaration-only packages still resolve.
+   c. If (b) yields a `.d.ts`/`.d.cts`/`.d.mts`, run the existing
+      `findImplementationBody()` (`:325`) to prefer a body, exactly as `:225-230`
+      does today. If no body exists, keep the declaration — that is the
+      `@eslint/core` types-only contract.
+3. Everything downstream (`canonicalize`, `recordResolvedImport`, the
+   `projectResolutions` map) is unchanged: the fallback returns the same shape.
+
+**Why layered and not `Bundler`/`Node16` outright.** A mode switch changes
+resolution for every package where Node10 *currently succeeds* but `exports`
+would redirect elsewhere — that moves the whole `npm-compat.json` matrix in one
+step, with no way to attribute a regression. `Node16` additionally enforces
+mandatory extensions in ESM specifiers, which is precisely the class of breakage
+#2833 covers. The fallback is byte-stable by construction: it cannot fire on any
+graph that resolves today.
+
+### R2 — lazy `require()` outside a `VariableStatement` is never traversed
+
+`src/resolve.ts:579` gates the `scanRequire` walk on `ts.isVariableStatement(stmt)`.
+ESLint's rule registry is an **`ExpressionStatement`**:
+
+```js
+module.exports = new LazyLoadingRuleMap(Object.entries({
+  "accessor-pairs": () => require("./accessor-pairs"),   // ×292
+```
+
+Measured on `lib/rules/index.js`: 1 `require` in a `VariableStatement` (resolved
+correctly) and **292 in an `ExpressionStatement`** (never resolved). Those 292
+targets exist on disk, never enter `files`, and the virtual host at
+`src/checker/multi-file-paths.ts:181` therefore returns `undefined` → TS2307.
+This is a statement-kind filter, not a dynamic-`require` limitation: the
+argument is a plain string literal in every case.
+
+Fix shape: hoist the `scanRequire` walk out of the `isVariableStatement` branch
+and run it over **every** statement — `ts.forEachChild(stmt, scanRequire)` — and
+drop the early `return` at `:589` so sibling calls in the same subtree are all
+visited. Guard against graph blow-up: this pulls all 292 rule modules in, which
+lands squarely on #3672's territory, so gate it behind the same budget or land
+it only once #3672's heap work is confirmed to hold.
+
+### R3 — `resolve.extensions` is a dead field
+
+`src/resolve.ts:54` assigns `this.extensions` from `options.resolve.extensions`
+and nothing ever reads it; `probeImplementationPath` hardcodes
+`["", ".js", ".mjs", ".cjs", ".ts"]` at `:337`. Either thread the option through
+`probeImplementationPath(pkgRoot, afterPkg, this.extensions)` or delete the
+field and the option. Silent no-op options are worse than absent ones.
+
+### Edge cases
+
+- **Scoped packages** — `getBarePackageName` (`src/resolve.ts:472-490`) already
+  returns `@scope/pkg` for `@scope/pkg/sub`. Verified live on
+  `@eslint/plugin-kit` and `@eslint/core`. No change needed for R1; the
+  `customConditions` retry inherits the same specifier.
+- **Self-referencing imports** — a package importing itself by name resolves
+  today, but only because the physical-importer walk finds
+  `node_modules/<self>/…` on the way up; true `exports`-based self-reference
+  (name resolved against the *own* `exports` map, no `node_modules` entry) is
+  unsupported. R1's `Bundler` retry covers it.
+- **`imports` (`#dep`)** — currently NULL. Only reachable via R1; note the
+  bare-package guard in step 2 must admit a leading `#`.
+- **`.ts` vs `.js` specifier rewriting** — two rules already exist and must not
+  be disturbed: an explicit relative `./x.js` prefers the real body over a
+  sibling `.d.ts` (`:198-208`), and a bare-package `.d.ts` hit re-probes for an
+  implementation (`:225-230`). The R1 retry runs *before* both, so both still
+  apply to its result — do not short-circuit them.
+- **Symlinked / hoisted installs** — resolution runs from
+  `host.realpath(containingFile)` (`:160`) and graph keys are realpaths
+  (`:289-291`), so a pnpm store path and its hoisted symlink collapse to one
+  node. Do not "fix" the fallback by resolving from the logical path; that
+  reintroduces the original defect. The 146/146 invariant is the regression
+  guard.
+- **Declaration-only packages** — must stay declarations. R1 step 2c keeps the
+  `.d.ts` when no body exists; `tests/issue-3654.test.ts:144-153` asserts no
+  `.js` from `types-only` enters the graph.
+- **Missing optional peers** — `@typescript-eslint/types`, `@jsr/std__path` are
+  not installed at all. Correct behaviour is degrading the type edge to `any`,
+  not resolving it. Out of scope here (see below).
+
+### Test plan
+
+Existing, keep green:
+
+- `tests/issue-3654.test.ts` — 5 tests: real-ESLint edges (`:98-126`),
+  physical-importer identity + canonical de-dup (`:128-142`), types-only
+  conditional (`:144-153`), `compileProject` through the virtual checker
+  (`:155-160`), `node:path` host pass-through asserting the `env/__node_path`
+  import (`:162-179`). Helper: `tests/helpers/eslint.ts`.
+- `tests/issue-3655.test.ts`, `tests/issue-3672.test.ts` — sibling frontiers.
+
+New, for R1 — extend `tests/issue-3654.test.ts` (same `mkdtempSync` fixture
+root, same `.pnpm/<name>@<v>/node_modules/<name>` + symlink layout as
+`:26-90`); do not add a new file, the fixture builder is the expensive part:
+
+- `exports-only` package — `exports.types.{import,require}` with **no**
+  top-level `types`/`main`. Assert resolution and assert the *condition* picked
+  matches the importer's mode: `.cjs` importer → `.d.cts`, `.mjs` importer →
+  `.d.ts`. This is the test the current fixture cannot express.
+- `dual` package — `exports.require.default` vs `exports.import.default`, both
+  bodies present. Assert a `require()` importer gets the CJS body.
+- `subpath` package — `exports: {"./sub": …}` only. Assert `pkg/sub` resolves.
+- `#imports` — `imports: {"#dep": "./dep.js"}`. Assert from inside the package.
+- Byte-stability guard: assert `@eslint/plugin-kit` and `@eslint/core` still
+  resolve to the *same* paths as today, proving the fallback did not fire.
+
+New, for R2 — a fixture whose entry is
+`module.exports = { a: () => require("./a"), b: () => require("./b") };`
+(`ExpressionStatement`), asserting both `a` and `b` land in
+`resolveAllImports`. Pair it with the ESLint case: assert
+`lib/rules/index.js`'s targets are in the graph and that entry-scoped TS2307
+stays 0.
+
+Scratch probes used for this verification live in `.tmp/` (gitignored):
+`probe-3654.mts`, `probe-3654-diag.mts`, `probe-3654-entry.mts`,
+`probe-3654-residual.mts`, `probe-3654-exports.mts`, `probe-3654-modes.mts`.
+
+### Out of scope — residual 374 TS2307, all in transitive files, none on the entry
+
+Recorded here so the number is not mistaken for a regression of this issue:
+
+| Count | Bucket                                                        | Owner                          |
+| ----- | ------------------------------------------------------------- | ------------------------------ |
+| 292   | `lib/rules/index.js` lazy `require` in an `ExpressionStatement`| R2 above (new issue)           |
+| 18    | `@eslint-community/eslint-utils` JSDoc `import("./types.mjs")` | upstream — `types.mjs` is not shipped (only `index.d.mts`); needs type-edge degradation to `any`, not resolution |
+| ~60   | `@typescript-eslint/types`, `@jsr/std__path`                   | uninstalled optional peers — same degradation fix |
+| 1     | `ajv/lib/refs/json-schema-draft-04.json`                       | #3655                          |
+
+`@eslint/plugin-kit` receiving the ESM build at a CJS require site is a latent
+correctness divergence, not a diagnostic — it is fixed as a side effect of R1
+step 2a and should be asserted there.

--- a/plan/issues/3656-ir-dynamic-object-destructuring-eslint-flags.md
+++ b/plan/issues/3656-ir-dynamic-object-destructuring-eslint-flags.md
@@ -4,7 +4,7 @@ id: 3656
 title: "IR: dynamic destructured parameter blocks ESLint getInactivityReasonMessage"
 status: ready
 created: 2026-07-26
-updated: 2026-07-26
+updated: 2026-08-26
 priority: critical
 feasibility: hard
 reasoning_effort: high
@@ -106,3 +106,332 @@ object-pattern builder or promotes the mismatch to a fatal invariant.
 - The Tier 1 package-entry probe no longer contains
   `getInactivityReasonMessage` or `object destructuring source` diagnostics;
   planning blocker `3654` is the remaining pinned compile frontier.
+
+## Implementation Plan
+
+### Verdict (re-verified 2026-08-26 against `main` @ `0e65e238`)
+
+**The blocker in "Problem" is FIXED. Every acceptance criterion is met. This
+issue should close as `done`; the work below belongs to #2949 and to two new
+follow-ups, not to a reopened #3656.**
+
+Evidence:
+
+- `npx vitest run tests/issue-3656.test.ts` — 2/2 pass, including the direct
+  `compileProject` of the installed `eslint/lib/shared/flags.js` (it ran; not
+  skipped). Wasm validates.
+- Scratch matrix `.tmp/probe-3656*.mjs` (9 shapes × host/fast) — the string
+  `object destructuring source must be IrType.object or IrType.class (got
+  dynamic)` **no longer occurs at all**, at any severity. It is unreachable at a
+  parameter: `src/ir/select.ts:1911` rejects a `dynamic` binding-pattern param
+  **pre-claim**, so `lowerObjectPattern` never sees a dynamic source.
+- The message still exists (`src/ir/from-ast.ts:3633`) and is still reachable —
+  but only for **local** destructuring off a non-object source
+  (`const { length } = str` → `(got string)`, `= arr` → `(got vec<f64>?)`), as a
+  non-fatal `build`-stage demote. Different population, tracked below as R5.
+
+Everything after this point is **residual IR coverage**, not a regression, and
+none of it is fatal: each item is a silent, correct demote to legacy.
+
+### What actually remains — measured, not inferred
+
+`irCompiledFuncs` / `irPostClaimErrors` for `function reason({ replacedBy })`
+and its neighbours (`.tmp/probe-3656{,b,e,f,g,h,i}.mjs`):
+
+| # | Shape | IR claims? | Diagnostic |
+|---|---|---|---|
+| A | untyped JS `({ replacedBy })` | no | (pre-claim, silent) |
+| B | **ESLint's exact** JSDoc `@property {string \| null} [replacedBy]` | no | `resolve`: `object TypeNode TypeReference could not be lowered to IrType.object` |
+| C | JSDoc, **no** union, destructured | no | `build`: `function typeIdx parity mismatch: IR=14, legacy=11` |
+| D | TS `{ replacedBy }: { replacedBy: string }` | **yes** | — |
+| E | TS `{ replacedBy }: { replacedBy?: string }` | no | `resolve`: `… TypeLiteral could not be lowered` |
+| J | TS `{ replacedBy }: Flag` (interface) | **yes** | — |
+| M | JSDoc typedef, **not** destructured (`f.replacedBy`) | **yes** | — |
+| N | TS union field, **not** destructured | no | `resolve`: same as E |
+| F/G/H | default / rest / nested in pattern | no | `destructuring-param-complex` (pre-claim) |
+
+Read the matrix as three orthogonal gaps, none of which is "destructuring":
+
+**R1 — object IR cannot represent a union field.**
+`tsTypeToFieldIr` (`src/codegen/index.ts:1392-1401`) returns `null` for anything
+that is not NumberLike / BooleanLike / StringLike / Object. `string | null` and
+`string | undefined` (i.e. every optional field) fall out, so
+`objectIrTypeFromTsType` (`:1352`) bails and `resolvePositionType` throws at
+`:1231`. This is what stops **B**, and it is **not destructuring-specific** — it
+stops **N** identically.
+
+**R2 — `p.type`-vs-JSDoc split-brain, third site.**
+`bindingPatternParamNeedsWiden` (`src/codegen/declarations.ts:330-333`, used at
+`:957`) reads **`p.type` only**:
+
+```ts
+if (p.type || p.dotDotDotToken) return false;
+return ts.isArrayBindingPattern(p.name) || ts.isObjectBindingPattern(p.name);
+```
+
+So legacy widens a JSDoc-typed destructured param to `externref`, while the IR
+resolves it through `effectiveIrParamTypeNode` (`src/ir/select.ts:2137-2139`,
+consumed at `select.ts:1948`, `from-ast.ts:1135`, `codegen/index.ts:2565`) to a
+struct ref. The claim is then withdrawn at `src/ir/integration.ts:3336-3348` —
+the *soft* `abi-signature-parity` arm, explicitly documented there as "the IR
+legitimately cannot express e.g. a shape-struct param". This is exactly the bug
+class the 2026-07-26 fix repaired on the overlay planner; `declarations.ts:330`
+is the site it did not reach.
+
+**R3 — no dynamic arm in the destructuring lowerer.**
+`src/ir/select.ts:1907-1911` rejects a `dynamic` binding-pattern param outright,
+and `lowerObjectPattern` (`src/ir/from-ast.ts:3625-3637`) has no branch for a
+`dynamic` source. This is what stops **A** — the majority shape in real JS.
+
+**R4 — the actual gate on ESLint's function: `typeof` on a dynamic value is not
+claimable.** Measured directly: `function reason(f: any) { if (typeof f ===
+"string") … }` does **not** claim; only a pure move (`return f`) does.
+`dynamicUsesAreMoveOnly` (`src/ir/select.ts:2630`, called at `:2047`) still
+admits only moves, so `emitDynMemberGet` (`src/ir/builder.ts:660`) remains
+"wired but unreached" exactly as its own comment says. **Even with R1–R3 landed,
+`getInactivityReasonMessage` would still not IR-claim**, because its entire body
+is `typeof` dispatch. R4 is #2949 S5.P and is out of scope here.
+
+**R5 — `lowerObjectPattern` has no `string`/`vec` arm** for `const { length } =
+s`. Bounded, unrelated, note-only.
+
+### The concrete change
+
+Three independent slices. **S1 and S2 must land together or not at all for the
+destructured population** — see the interaction note.
+
+**S1 — represent a union field as the legacy carrier (fixes B, E, N).**
+
+`src/codegen/index.ts`, `tsTypeToFieldIr` (`:1392`). Add, after the
+`StringLike` arm and before the `Object` arm:
+
+- if `t.isUnion()` and every constituent is NumberLike / BooleanLike /
+  StringLike / Object / Null / Undefined → return
+  `irVal({ kind: "externref" })`;
+- otherwise keep the `null` rejection.
+
+`irVal({kind:"externref"})` is **not** a style choice — it is the measured
+legacy layout. Probe `.tmp/probe-3656f.mjs`:
+
+| field type | legacy `fast=false` | legacy `fast=true` |
+|---|---|---|
+| `string` | `(mut externref)` | `(mut (ref null $AnyString))` + `$$shapeBrand` |
+| `string \| null` | `(mut externref)` | `(mut externref)` |
+| `number` | `(mut f64)` | `(mut f64)` |
+| `number \| null` | `(mut externref)` | `(mut externref)` |
+| `any` | `(mut externref)` | `(mut externref)` |
+
+Legacy stores a union field as bare `externref` **in both modes**, so the IR
+field hashes to the same `legacyFieldsHashKey`
+(`src/ir/integration.ts:6937-6952`) and `ObjectStructRegistry.resolve`
+(`:6852-6923`) converges on legacy's existing `__anon_N` instead of minting a
+second struct. **Do not use `irDynamic()` here** — `resolveDynamic()`
+(`src/ir/integration.ts:5346`) returns `ref_null $AnyValue` in fast mode, which
+would diverge from legacy's `externref` and re-create the R2 parity mismatch in
+fast mode only.
+
+Fast mode carries a second hazard the table exposes: legacy adds a
+`$$shapeBrand` field for some shapes and not others. Gate S1's acceptance on
+mode if the brand rule cannot be reproduced exactly; the `abi-signature-parity`
+check at `integration.ts:3336` is the backstop and turns any layout divergence
+into a demote, never a miscompile — but a demote is a silent no-op, so verify
+`irCompiledFuncs` contains the function rather than trusting `success === true`.
+
+**S2 — one shared predicate for "legacy widens this binding-pattern param"
+(fixes C, K, O).**
+
+Export from `src/ir/select.ts`, beside `effectiveIrParamTypeNode`:
+
+```ts
+export function legacyWidensBindingPatternParam(p: ts.ParameterDeclaration): boolean;
+```
+
+with the body currently at `src/codegen/declarations.ts:330-333`, and have all
+three consumers import it:
+
+1. `src/codegen/declarations.ts:957` — replace the local helper (delete
+   `bindingPatternParamNeedsWiden`; keep `restBindingOverridesToExternref`);
+2. `src/ir/select.ts:1899-1922` — in the binding-pattern arm, when the predicate
+   is true, resolve `dynamic` **instead of** consulting
+   `effectiveIrParamTypeNode`, so the IR ABI matches legacy's `externref`;
+3. `src/codegen/index.ts:2550-2566` `resolveIrOverrideParamType` — same, so the
+   overlay cannot re-derive a struct override the selector declined. This is the
+   site the 2026-07-26 fix touched; leaving it out reintroduces the original bug
+   in mirror image.
+
+**Direction matters: align the IR to legacy, not legacy to the IR.** Teaching
+`bindingPatternParamNeedsWiden` about JSDoc (`p.type ?? ts.getJSDocType(p)`) is
+a one-word change that also "fixes" C — and it changes the **legacy ABI** for
+every JSDoc-typed destructured param in React / ESLint / webpack from a
+forgiving `externref` to a `ref.test`-gated struct ref. JSDoc in real packages
+is routinely loose or wrong; a caller passing an off-shape object would get
+`ref.null` instead of a working destructure. That widening exists precisely to
+be forgiving (see the `#862` rationale at `declarations.ts:325-329`). Do not
+touch it.
+
+**S1 × S2 interaction — the trap.** With S1 alone, B stops failing at `resolve`
+and starts failing at `build` (it becomes case C): a JSDoc-typed destructured
+param whose shape now *is* resolvable, hitting the parity mismatch. Net gain
+zero. With S2 alone, C stops mismatching but routes to `dynamic`, which S3 must
+then lower. **S1's standalone value is the non-destructured population (N, E,
+M-with-union) — a large real-world class on its own.** State that explicitly in
+the PR; do not claim S1 unblocks ESLint.
+
+**S3 — dynamic arm in `lowerObjectPattern` (fixes A; makes S2's output
+lowerable).**
+
+- `src/ir/select.ts:1911` — replace the blanket
+  `if (paramResolved === "dynamic") return "param-type-not-resolvable"` with an
+  accept for **object** patterns only (array patterns need the iterator
+  protocol — keep rejecting), still downstream of `isPhase1BindingPattern`
+  (`:5291`) and still gated by `dynamicUsesAreMoveOnly` at `:2047`.
+- `src/ir/from-ast.ts:3627-3637` — before the `demoteToLegacy`, add: when
+  `sourceType.kind === "dynamic"`, emit one `dyn.member_get` per leaf, keyed by
+  the literal property name boxed as a tag-5 string carrier, binding each leaf
+  as a `dynamic` local. Copy the pattern verbatim from the named-read arm at
+  `from-ast.ts:5277-5279`:
+  ```ts
+  const key = cx.builder.emitBox(cx.builder.emitStringConst(propName), irDynamic(JS_TAG_IDS.String));
+  const leaf = cx.builder.emitDynMemberGet(source, key);
+  ```
+  `emitDynMemberGet` (`src/ir/builder.ts:660-676`) requires **both** operands to
+  be `dynamic` and rejects concrete ones at construction; the param carrier from
+  `from-ast.ts:1131-1136` is already the dynamic carrier, so no coercion is
+  needed. `IrDynamicLowering.emitMemberGet`
+  (`src/ir/backend/handles.ts:431-433`) is mode-split and, in host mode, is a
+  thin `__extern_get` wrapper — byte-identical to what legacy already emits for
+  this exact shape.
+- S3 lands as **mechanism-only / byte-inert** until R4 opens the scan, which is
+  the established idiom here (see the "MECHANISM ONLY … wired but unreached"
+  comment at `from-ast.ts:5265-5275`). Ship it that way, with a test that pins
+  the *move-only* dynamic destructure (`function f({a}) { return a; }`) — the
+  one body shape the current scan already admits — so the arm is genuinely
+  exercised rather than dead.
+
+### Interaction with the IR fallback baseline
+
+**Nothing here moves `scripts/ir-fallback-baseline.json`, and the gate cannot
+protect it.** Verified 2026-08-26:
+
+- `pnpm run check:ir-fallbacks` → `OK`, with `unintended: {}`,
+  `postClaim: {build:{},verify:{},lower:{},backend-legality:{}}`,
+  `moduleLevel: {}`. Only `deferred.string-builder-candidate: 2` is non-zero.
+  `param-shape-rejected` is already **corpus-zero and cannot shrink**.
+- The corpus is `CORPUS_ROOTS = [website/playground/examples]`
+  (`scripts/check-ir-fallbacks.ts:89`), which holds **13 `.ts` files and 0
+  `.js`**. Untyped JS and JSDoc — this issue's entire population — never enter
+  it. The gate is structurally blind here; do not cite a green gate as evidence
+  for any of S1–S3.
+- Neither `param-shape-rejected` nor `destructuring-param-complex` is the
+  reason on the failing path anyway: A/C are `param-type-not-resolvable` and a
+  post-claim `abi-signature-parity` demote respectively.
+- Post-claim accounting: `POST_CLAIM_KINDS` is
+  `["build","verify","lower","backend-legality"]`
+  (`scripts/check-ir-fallbacks.ts:143`) and any other kind — including
+  `"resolve"` — is folded into `lower` at `:350`. So R1's demote would land in
+  `postClaim.lower` if the corpus contained such a shape. It does not.
+
+**Do not promote anything into `STRICT_IR_REASONS`.** The set at
+`src/codegen/index.ts:2043` is empty by design, and the comment at `:2044-2067`
+names "the destructuring param buckets" among the reasons that describe
+*legitimate* IR-non-claimability. Corpus-zero is explicitly declared necessary
+but not sufficient (#3341). Promotion requires the reason to be genuinely
+**unreachable**; after S1–S3 a dynamic destructure is still declined whenever
+`dynamicUsesAreMoveOnly` says no, so `param-type-not-resolvable` stays reachable
+by construction. The post-claim promotion vector (`:2070-2090`, four-part bar)
+is likewise unavailable: S1/S2 *reduce* `abi-signature-parity` demotes but leave
+the code live for genuine shape-struct divergence.
+
+The real regression protection is `tests/issue-3656.test.ts` plus the
+npm-compat dashboard (`benchmarks/results/npm-compat.json`, refreshed by
+`npm-compat-refresh.yml` — do not hand-commit it).
+
+### Edge cases
+
+- **Optional (`?`) vs `| undefined`** — identical to the checker and both hit
+  R1. `{ replacedBy?: string }` (E) and `{ replacedBy: string | null }` (N)
+  produce the same demote; S1 must accept both.
+- **Param-level `?`/rest/default** — `src/ir/select.ts:1900-1902` rejects these
+  as `param-shape-rejected` *before* the pattern check. Unchanged; S3 must not
+  loosen them (arity is ABI).
+- **Element-level default / rest / nested** (F/G/H) — `isPhase1BindingPattern`
+  (`src/ir/select.ts:5291-5311`) rejects → `destructuring-param-complex`.
+  Deliberately out of scope: a default needs a runtime undefined test per leaf,
+  a rest needs own-key enumeration, and a nested pattern needs a recursive
+  dynamic read. S3 must keep routing them to legacy — `lowerObjectPattern`'s
+  defensive re-checks at `from-ast.ts:3640-3660` stay as the selector-desync
+  guard.
+- **Computed keys** — `{ [k]: v }` is rejected by `isPhase1BindingPattern`
+  (`:5301-5303`, propertyName must be Identifier or StringLiteral) and again
+  defensively at `from-ast.ts:3663-3675`. `emitDynMemberGet` would in principle
+  accept a computed key (it is key-uniform), but evaluation-order and
+  `ToPropertyKey` semantics make this its own slice. Leave rejected.
+- **String-literal property names** (`{ "a-b": v }`) — already accepted by both
+  gates; S3's key box must use `elem.propertyName.text`, not `elem.name.text`,
+  for the renaming form. The existing `propName` computation at
+  `from-ast.ts:3661-3668` already does this; reuse it, do not re-derive.
+- **Redeclaration** — `cx.scope.has(localName)` at `from-ast.ts:3677` and
+  `scope.has(name)` at `select.ts:5307`. Unchanged.
+- **Genuinely dynamic object shapes** — a caller passing an object the JSDoc
+  does not describe is the *reason* S2 aligns to legacy's `externref`;
+  `__dyn_member_get` walks the proto chain and fires getters
+  (`src/ir/effects.ts:173-174`), so a missing property yields `undefined`, not a
+  trap. That is the correct JS semantics and matches what legacy already emits.
+- **Cyclic / method-carrying / callable shapes** — `objectIrTypeFromTsType`
+  already rejects these (`src/codegen/index.ts:1353-1358`, `:1367-1372`, and the
+  `#4019` path set). S1's union arm must run *before* recursing so a
+  `Node | null` self-reference resolves to `externref` rather than re-entering
+  the cycle guard.
+- **`fast` mode** — see the S1 table. `$$shapeBrand` and the `$AnyString`
+  carrier make fast-mode struct parity a separate proof. If it does not fall
+  out, gate S1 on `!ctx.fast` and say so; a mode-split acceptance is honest,
+  a silent fast-mode demote is not.
+
+### Test plan
+
+**Existing, must stay green**
+
+- `tests/issue-3656.test.ts` — 2 tests, currently passing. Both assert
+  `irPostClaimErrors` has no `build`-kind entry. Note this assertion is weaker
+  than it looks: case B demotes at `resolve`, which the map at
+  `scripts/check-ir-fallbacks.ts:350` folds elsewhere and which this predicate
+  does not catch. **Strengthen it to assert on `irCompiledFuncs`** once S1+S2
+  land — that is the only assertion that distinguishes "IR claimed it" from
+  "legacy silently did it".
+- `pnpm run check:ir-fallbacks` — must stay `OK`; expect **no baseline diff**
+  (see above). A diff here means the change reached the TS corpus, which is a
+  signal to re-read, not to `--update`.
+- `tests/equivalence.test.ts` — S2 touches `declarations.ts:957`, the shared
+  legacy param-type path. This is the blast-radius test.
+
+**New**
+
+- Extend `tests/issue-3656.test.ts` (same file — the shapes are the issue's own
+  population, and a second file would fragment it):
+  - `{ replacedBy: string | null }` **without** destructuring (case N) — the
+    S1-only win; assert `irCompiledFuncs` contains the function.
+  - JSDoc typedef, no union, destructured (case C) — the S2 regression pin;
+    assert no `abi-signature-parity` message.
+  - untyped `function f({ a }) { return a; }` (move-only) — the S3 arm, the one
+    dynamic-destructure body the current move-only scan admits.
+  - runtime values for each, matched against Node, for omitted / string / `null`
+    — the issue's existing three-arm discipline.
+- `tests/` fast-mode twin of the S1 case (`fast: true`) — asserts either a claim
+  or an explicit documented demote, never a silent one.
+- Struct-convergence unit test next to the existing IR integration tests:
+  compile a module where legacy registers `{a: string|null}` and the IR also
+  needs it; assert a **single** `__anon_N` in the WAT. This is the S1 layout
+  contract and the cheapest possible guard against the fast-mode trap.
+
+Scratch probes used for this plan are in `.tmp/probe-3656{,b,c,d,e,f,g,h,i}.mjs`
+(gitignored); re-run them to re-establish the matrix after any slice.
+
+### Risk
+
+The one thing that can turn a demote into a miscompile is S1 picking a field
+ValType that differs from legacy's while still hashing equal, or equal while
+hashing differently. `legacyFieldsHashKey` keys on `kind` plus `typeIdx`
+(`src/ir/integration.ts:6937-6952`), so `externref` vs `ref_null $AnyValue`
+hash differently and produce two structs that both look fine in isolation. The
+struct-convergence test above is the guard; the `abi-signature-parity` check is
+the backstop. Everything else in S1–S3 fails safe to legacy.

--- a/plan/issues/3657-ir-ambient-boolean-host-call-eslint-seam.md
+++ b/plan/issues/3657-ir-ambient-boolean-host-call-eslint-seam.md
@@ -98,3 +98,210 @@ This issue is the IR call-graph/lowering gap before that runtime path.
 - The numeric/string #2693 demo and all six #3325 ambient dependency tests
   remain green.
 - `pnpm run typecheck` and `pnpm run check:ir-fallbacks` pass.
+
+## Implementation Plan
+
+### Verdict — ALREADY LANDED. No implementation work remains (re-measured 2026-08-26)
+
+Re-verified against the current tree (`main` fast-forwarded today, HEAD
+`0e65e238`). Every acceptance criterion is met **on disk**, not merely claimed by
+the `## Implementation (2026-07-26)` section above. This section therefore
+records the shipped design and the measurements, rather than proposing a change.
+
+**The `## Problem` repro no longer reproduces.** Compiling the issue's exact
+fixture (`declare function __host_is_statement(code: string): boolean` called
+from `Linter.verify(code: string): string`) with `experimentalIR: true`:
+
+| Signal              | Issue's reported failure                        | Measured 2026-08-26                     |
+| ------------------- | ----------------------------------------------- | --------------------------------------- |
+| compile             | `Codegen error: IR path failed for Linter_verify` | `success: true`                       |
+| `WebAssembly.validate` | n/a (no binary)                              | `true`                                  |
+| `irCompiledFuncs`   | — (`[IR-FALLBACK]` to legacy)                   | `["verify", "Linter_verify"]`           |
+| `irPostClaimErrors` | —                                               | `[]`                                    |
+| `env` imports       | `call to unknown function "__host_is_statement"` | `["__host_is_statement"]`               |
+| IR-fallback warning | `ir/from-ast: call to unknown function …`        | none                                    |
+
+The class member is genuinely IR-lowered; this is not a silent legacy demotion.
+
+**Acceptance criteria, each measured:**
+
+| # | Criterion                                                        | Evidence |
+| - | ---------------------------------------------------------------- | -------- |
+| 1 | reduced class-method `predicate(s: string): boolean` fixture compiles + validates | `tests/issue-3657.test.ts:25-38` — asserts `success`, `WebAssembly.validate`, `irCompiledFuncs ∋ "Gate_check"`, `irPostClaimErrors == []`, `env.predicate` present |
+| 2 | true and false host predicates both branch correctly             | `tests/issue-3657.test.ts:49-55` — `check("yes") === 17`, `check("no") === -4` |
+| 3 | missing dependency retains #3325 behavior, no invented result     | `tests/issue-3657.test.ts:57-60` — `instantiateGate({})` ⇒ `-4` |
+| 4 | real espree/esquery seam compiles, instantiates, passes           | `tests/issue-2693-host-delegated-select.test.ts` — 2/2 pass; `it.fails` is gone, now `it.skipIf(ESLINT_LINTER === null)` (#3653, `status: done`) |
+| 5 | numeric/string #2693 and #3325 fixtures stay green                | 11/11 pass across `issue-2693-host-delegated-select`, `issue-2693-linter-verify-demo`, `issue-3325`, `issue-3657` |
+
+`pnpm run check:ir-fallbacks` ⇒ `IR fallback gate: OK`, **`Unintended: (none)`**.
+`scripts/ir-fallback-baseline.json` now carries `"unintended": {}` — the
+`external-call` bucket this issue fed is fully retired, along with the rest of
+the #1371/#2855 unintended set.
+
+### Shipped design (for the record — exact files and lines)
+
+Four seams, in pipeline order:
+
+1. **Certification** — `src/ir/host-extern.ts:46-107`
+   `makeIrAmbientClassCallResolver(checker)` returns an
+   `IrAmbientClassCallCertification` (`:16-22`) or `undefined`. Two independent
+   gates, both fail-closed:
+   - *Syntax/owner gate* (`:49-70`): rejects optional-chain, type arguments,
+     non-identifier callees, spread args; walks to the nearest function-like
+     ancestor and requires a **method / get / set / constructor whose parent is a
+     `ClassDeclaration` whose parent is the `SourceFile`** — i.e. a top-level
+     class member only.
+   - *Declaration gate* (`:72-101`): `checker.getResolvedSignature(call)` must
+     land on a **bodyless `FunctionDeclaration` in the same source file**, at
+     source-file scope, carrying `declare`, with no generator/type parameters,
+     exact arity, and every parameter a plain identifier with no
+     `?`/rest/initializer. `isFixedPrimitiveAmbientType` (`:28-34`) confines both
+     parameters and result to `boolean | number | string`. Finally
+     `checker.getSymbolAtLocation(call.expression)?.declarations` must **include
+     that declaration** — symbol identity, not callee spelling, so a local shadow,
+     an import, or a lib global cannot pass. The whole body is `try/catch →
+     undefined` (`:48,103-105`), so a checker throw degrades to "not certified".
+
+   The module is deliberately a **leaf** (`:5-11`) — it imports only the `ts`
+   facade and `checker/type-mapper`, because `scripts/check-ir-fallbacks.ts`
+   builds its own program and importing codegen would perturb ESM init order.
+
+2. **Selector opt-in** — `src/ir/select.ts:605-606`
+   `ambientClassCalls?: IrAmbientClassCallResolver` on the selector options,
+   omitted by host-free and bare-selector callers so nothing widens accidentally.
+
+3. **Planning** — `src/codegen/ir-imported-call-planning.ts:341-427`
+   For each retained class member, walks the member body (`:377-416`, stopping at
+   nested function-likes at `:379`), and for every certified call records an
+   `IrImportedCallLoweringPlan` (`src/ir/ast-lowering-plans.ts:19-32`) with
+   `source: "ambient-host"` and `target: irImportFuncRef("env", targetName)`
+   (`:399-408`). Param/return `IrType`s come from `resolvePositionType` over the
+   **declaration's own** type nodes (`:384-391`), so the declared ABI is
+   preserved rather than re-inferred at the call site. An overlap with an existing
+   source-unit imported-call plan is a hard `IrInvariantError` (`:392-398`). Any
+   planning failure rolls back the whole member — it is dropped from
+   `retainedClassMembers` and **all** its ambient plans are deleted (`:418-424`),
+   so a member is never half-planned.
+
+   `requireValidImportedCallTarget` (`ast-lowering-plans.ts:34-46`) enforces the
+   union invariant: an `ambient-host` plan must be backed by an `env` import
+   (`:39-42`), while a `module-import` plan must be backed by an exact unit.
+
+4. **Final-context preflight** — `ir-imported-call-planning.ts:114-146`
+   `prepareIrAmbientClassCallLowering` runs after declaration collection and
+   proves, per plan, that the certified function actually materialized as the
+   exact `env` import. `hasPreparedAmbientHostImport` (`:84-112`) maps each IR
+   type through `ambientHostValType` (`:68-74`) and then compares against the
+   **real emitted import**: index inside `ctx.numImportFuncs`, matching
+   module+name, and a func type whose params/results match arity and kind. On
+   mismatch the member is removed from `selection.classMembers` and a
+   `late-preparation-unsupported` failure is recorded (`:136-144`) — a safe
+   demotion to legacy, never a miscompile.
+
+   Wiring: `src/codegen/index.ts:2681-2682` constructs the resolver, `:2826`
+   feeds the selector, `:3113` feeds planning.
+
+**Measured ABI** (`emitText` on a fixture with both a boolean and a number
+ambient):
+
+```wat
+(type $type6 (func (param externref) (result i32)))   ;; declare …: boolean
+(type $type7 (func (param externref) (result f64)))   ;; declare …: number
+(import "env" "predicate" (func $predicate_import (type 0)))
+
+(func $Gate_check (type 6)
+  local.get 1
+  call 0            ;; env.predicate -> i32
+  (if (then f64.const 17 return) (else f64.const -4 return))
+  unreachable)
+```
+
+`string → externref`, `number → f64`, `boolean → i32`.
+
+### Dual-mode rule (CLAUDE.md "JS host optional") — how it is satisfied
+
+The rule is *"don't add new host imports without a standalone fallback."*
+**This change adds no compiler-introduced host import at all**, so the rule is
+satisfied by construction, not by a fallback:
+
+- The `env.<name>` import is **user-declared**. It exists because the program
+  author wrote `declare function`; it is registered by the pre-existing
+  `collectExternDeclarations` (`src/codegen/index.ts:4901` et al.), not minted by
+  this seam. This work only changes **which front-end lowers the call** — IR
+  instead of legacy — for a call whose import already existed on both paths.
+- Measured on `target: "standalone"`: the same fixture compiles (`success: true`)
+  and still emits `env.predicate`. An ambient declaration is an *embedder-supplied
+  capability*, and standalone expresses it as a plain `env` import the embedder
+  fills — there is no JS-runtime-specific marshaling to replace.
+- The IR resolver itself is gated on `jsHostExterns` (`index.ts:2640,2681`), so
+  standalone/WASI route the member through the legacy front-end. That is a
+  **lowering-path** difference with identical observable semantics, not a missing
+  capability. Measured: `target: "standalone"` ⇒ `irCompiledFuncs: ["check"]`
+  (member on legacy), module still correct.
+- Consequence for anyone extending this: widening the resolver past
+  `boolean | number | string` **would** cross into marshaling that differs by
+  mode, and at that point a standalone story becomes required. The
+  `isFixedPrimitiveAmbientType` gate is what keeps the current change mode-neutral.
+
+### Edge cases — how each is handled
+
+| Edge case | Handling |
+| --------- | -------- |
+| **Ambient declared inside a class method** (nested `declare`) | Not admitted. The declaration gate requires `ts.isSourceFile(declaration.parent)` (`host-extern.ts:82`) — the stub must be at source-file scope. A method-local declaration is not certified and falls to legacy. |
+| **Call nested inside a closure within the method** | Not admitted. The plan walk returns at any nested function-like (`ir-imported-call-planning.ts:379`), so only calls directly in the member body are planned. Capture/closure ABI is never involved. |
+| **Callee is a shadow / import / lib global with the same spelling** | Rejected by symbol identity (`host-extern.ts:100-101`), not by name comparison. This is the load-bearing check — a text match would admit `parseInt`-style lib globals. |
+| **Return-type resolution failure** | `resolvePositionType` throwing is caught at `ir-imported-call-planning.ts:409-412`, classified via `classifyIrFailure(error, "resolve")`, and rolls the **entire member** back (`:418-424`). No partially-typed plan survives. |
+| **Declared type is not a fixed primitive** (`void`, union, object, `any`, inferred) | `isFixedPrimitiveAmbientType` (`host-extern.ts:28-34`) requires a literal `boolean`/`number`/`string` keyword **type node**. An omitted return type node also fails, so nothing is silently inferred. |
+| **Overloads / optional / rest / default params / generics** | All rejected explicitly (`host-extern.ts:84-94`): `declaration.body` present, `asteriskToken`, `typeParameters`, arity mismatch, `questionToken`, `dotDotDotToken`, `initializer`. `needsArgc: false` and an empty `optionalParams` map (`ir-imported-call-planning.ts:406-407`) are therefore sound. |
+| **Truthiness coercion** | None is emitted, and none is needed. The boolean result arrives as **i32**, which `if` consumes directly (see WAT above). The JS→Wasm boundary applies the standard JS API `ToInt32` to the host's return value, so `true → 1`, `false → 0`. Note the contract this implies: a host that violates its own `: boolean` declaration by returning a truthy **non-numeric** value (e.g. `"yes"`) yields `ToInt32("yes") === 0` and reads as **false** — JS truthiness is *not* applied. That is the declared-ABI contract, not a defect, but it is the one place host and JS semantics visibly differ. |
+| **Missing host dependency** (#3325) | Untouched by this seam. `buildImports` supplies the documented no-op stub; the predicate reads false and the module still instantiates. Pinned by `tests/issue-3657.test.ts:57-60`. |
+| **Import manifest drift between planning and emission** | Caught by the `hasPreparedAmbientHostImport` preflight (`:84-112`), which re-reads `ctx.mod.imports`/`ctx.mod.types` rather than trusting the plan. Mismatch ⇒ safe demotion. |
+| **Ambient + source-unit plan collision on one call node** | Hard `IrInvariantError` (`:392-398`) — deliberately fatal, since it would mean two authorities claim the same node. |
+
+### Test plan
+
+**Existing coverage is sufficient; all of it currently passes.**
+
+| File | Covers |
+| ---- | ------ |
+| `tests/issue-3657.test.ts` (61 lines) | genuine `Gate_check` IR emission, module validation, `env.predicate` in the manifest, true/false branch results, #3325 missing-dep no-op |
+| `tests/issue-2693-host-delegated-select.test.ts` | real espree + esquery dual host-delegation seam, 4 semicolon-rule cases |
+| `tests/issue-2693-linter-verify-demo.test.ts` | numeric/string ambient `Linter.verify` milestone |
+| `tests/issue-3325.test.ts` (6 tests) | ambient dependency wiring: numeric arg, string arg, once-per-call-site, missing dep, declared-but-unused, non-function dep |
+
+Command used (28s, 11/11 pass):
+
+```bash
+npx vitest run tests/issue-2693-host-delegated-select.test.ts \
+  tests/issue-2693-linter-verify-demo.test.ts \
+  tests/issue-3325.test.ts tests/issue-3657.test.ts
+```
+
+Plus `pnpm run check:ir-fallbacks` ⇒ OK, `Unintended: (none)`.
+
+**One gap worth closing if this issue is reopened** — the landed fixture returns
+`number`. The issue's own `## Problem` shape returns **`string`**, which exercises
+the #2781 mixed string/number demotion noted in `## Verification`. Add to
+`tests/issue-3657.test.ts` a third case pinning the `Linter.verify(code): string`
+shape, asserting `irCompiledFuncs ∋ "Linter_verify"` and both branch strings, so
+the exact reported repro is regression-pinned rather than only its numeric
+cousin. Verified today that this shape does IR-lower — the test would pass as
+written.
+
+### Residual observations (out of scope — do NOT bundle into #3657)
+
+- **Top-level functions are not covered.** The same ambient boolean call from a
+  plain `export function` is *not* IR-claimed (`irCompiledFuncs: []`), because the
+  owner gate at `host-extern.ts:60-70` admits class members only. Correctness is
+  unaffected — it compiles, validates, and emits `env.predicate` via legacy. The
+  issue's `## Scope` says "when lowering a class method", so this is by design;
+  file a separate issue if the IR path should widen.
+- **Do not promote `external-call` to strict.** Even though its baseline bucket is
+  now zero, `src/codegen/index.ts:2043-2062` documents that corpus-zero is
+  **necessary but not sufficient** (#3341): the 13-file playground corpus does not
+  prove unreachability on real code, and `external-call` still names a legitimate
+  non-claimable construct. `STRICT_IR_REASONS` stays empty.
+- **Housekeeping.** Frontmatter is still `status: ready` with `sprint: current`,
+  so the auto-synced TaskList will keep offering this as live work and a dev will
+  re-implement what already exists. It should be flipped to `status: done` with a
+  `completed:` date. Not changed here — this pass was scoped to writing the plan.

--- a/plan/issues/4764-array-includes-search-value-spec-shape.md
+++ b/plan/issues/4764-array-includes-search-value-spec-shape.md
@@ -1,0 +1,107 @@
+---
+id: 4764
+title: "Array.prototype.includes: zero-arg form and non-numeric search values (ES2016 conformance)"
+status: done
+created: 2026-08-26
+updated: 2026-08-26
+completed: 2026-08-26
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: arrays
+goal: spec-completeness
+sprint: current
+horizon: s
+loc-budget-allow:
+  # 2026-08-26 — +4 lines in src/compiler.ts for `diagnosticSeverity`, a helper
+  # that replaces the SAME three-way downgrade expression duplicated across the
+  # three diagnostic-collection loops (single-source, multi-file entry,
+  # multi-file full). Adding the new predicate inline would have grown all three
+  # sites and let them drift apart; the helper is the smaller and safer shape.
+  # The predicate itself lives in the subsystem module
+  # (src/compiler/argument-diagnostics.ts), not the driver.
+  - src/compiler.ts
+---
+
+# #4764 — `Array.prototype.includes`: zero-arg form and non-numeric search values
+
+Residual of #1360, found while closing the ES2016 bucket (124 tests).
+
+## Problem
+
+Two distinct defects, both in how the `searchElement` operand reaches codegen.
+
+**1. The zero-argument form was rejected outright.** §23.1.3.16 takes
+`searchElement` as an ordinary parameter, so `arr.includes()` is legal and
+searches for `undefined`. The compiler raised "includes requires 1 argument",
+which made the whole call compile to nothing and evaluate as `undefined`:
+
+```
+built-ins/Array/prototype/includes/no-arg.js
+  [0].includes() Expected SameValue(«undefined», «false») to be true
+built-ins/Array/prototype/includes/length-zero-returns-false.js
+  returns false - no arg Expected SameValue(«undefined», «false»)
+```
+
+**2. A non-numeric search value was COERCED into the element type.** TypeScript's
+lib types the parameter as the element type `T` — stricter than the language,
+which accepts any value and answers `false`. So `[42, 0, 1, NaN].includes("42")`
+is six TS2345s, and `isHardTypeScriptDiagnostic` aborts before codegen: the
+program compiles to zero bytes.
+
+The misleading part: `includes/samevaluezero.js` carries the baseline error
+string `'42' Expected SameValue(«true», «false»)`, which reads like a
+wrong-answer row. Reproduced faithfully it is a **compile_error** row. Bucketing
+from baseline strings alone sent two earlier attempts after the wrong bug —
+hence `scripts/run-test262-row.mts`, which reproduces one row through the
+runner's own `wrapTest` and reports the runner's own verdict.
+
+## Fix
+
+`src/codegen/array-includes-search-value.ts` (leaf module — `array-methods.ts`
+is at its god-file cap) owns the operand:
+
+- **absent argument** → emit `undefined` when the element vec is `externref`
+  (where SameValueZero can genuinely match a hole read as `undefined`);
+  otherwise force the scan comparison to a constant `0`. Leaving `valTmp` at its
+  zero default would compare against f64 `0` and make `[0].includes()` wrongly
+  answer `true`.
+- **argument whose static `typeof` tag cannot be a number**, against an
+  `i32`/`f64` element vec → evaluate it for side effects, drop it, and force the
+  comparison to `0`. §7.2.12 compares `Type(x)` before value, so no such value
+  can ever match. The tag comes from `ctx.oracle.staticJsTypeOf`, never the raw
+  checker.
+
+`src/compiler/argument-diagnostics.ts` gains `isArraySearchElementDiagnostic`:
+a TS2345 on the first argument of `includes` / `indexOf` / `lastIndexOf` is not
+a hard error. It both exempts the diagnostic from the `failResult` gate and
+downgrades it to a warning — **both are required**, because the test262 runner
+counts any error-severity diagnostic as `compile_error` even when a binary came
+out. Mirrors the #2616 Proxy-handler-trap and #2741 `in`-operand downgrades.
+
+The downgrade alone would have been a bug rather than a fix: without the codegen
+half, `"42"` coerces to f64 `42` and `samevaluezero.js` flips from
+compile_error to a genuine wrong answer.
+
+## Acceptance criteria
+
+- [x] `built-ins/Array/prototype/includes/no-arg.js` passes
+- [x] `built-ins/Array/prototype/includes/samevaluezero.js` passes
+- [x] `built-ins/Array/prototype/includes/search-not-found-returns-false.js` passes
+- [x] `tests/equivalence/array-includes-no-arg.test.ts` — 9 cases, incl. the
+      coercion traps (`"42"`, `true`/`false`, `null`) and argument side effects
+
+## Known limitations
+
+- **`as any` erases the tag.** The refusal is driven by the argument's STATIC
+  tag, so `[42].includes("42" as any)` is `"mixed"` and still takes the coercing
+  path — it answers `true`. Closing that needs a tagged runtime comparison, not
+  a static one. No test262 row depends on it (the annotation is TypeScript-only
+  syntax that never appears in conformance tests); recorded in the test file.
+- **`.call` forms are untouched.** `Array.prototype.includes.call(obj, "a")`
+  raises its TS2345 on `.call`'s argument, not on an `includes(...)` argument,
+  so the syntactic predicate does not match. Those rows
+  (`includes/length-boundaries.js` and the rest of the 2^53-length family) stay
+  in the separate array-like bucket.

--- a/plan/issues/4764-array-includes-search-value-spec-shape.md
+++ b/plan/issues/4764-array-includes-search-value-spec-shape.md
@@ -63,11 +63,13 @@ runner's own `wrapTest` and reports the runner's own verdict.
 `src/codegen/array-includes-search-value.ts` (leaf module — `array-methods.ts`
 is at its god-file cap) owns the operand:
 
-- **absent argument** → emit `undefined` when the element vec is `externref`
-  (where SameValueZero can genuinely match a hole read as `undefined`);
-  otherwise force the scan comparison to a constant `0`. Leaving `valTmp` at its
-  zero default would compare against f64 `0` and make `[0].includes()` wrongly
-  answer `true`.
+- **absent argument** → emit whatever an explicit `undefined` would produce for
+  this element type, so the two spellings cannot disagree: a real `undefined` in
+  an `externref` vec, `f64` NaN in a numeric vec (a hole reads as NaN there, and
+  the both-NaN arm of the comparison is what makes `[, , , 42, , ].includes()`
+  answer `true`). Any other element type forces the scan comparison to a
+  constant `0`; leaving `valTmp` at its zero default would compare against `0`
+  and make `[0].includes()` wrongly answer `true`.
 - **argument whose static `typeof` tag cannot be a number**, against an
   `i32`/`f64` element vec → evaluate it for side effects, drop it, and force the
   comparison to `0`. §7.2.12 compares `Type(x)` before value, so no such value
@@ -87,11 +89,44 @@ compile_error to a genuine wrong answer.
 
 ## Acceptance criteria
 
+Measured by running the ES2016 feature set (147 files tagged
+`Array.prototype.includes` / `exponentiation` / `u180e`) through the runner's own
+`runTest262File`: **103 → 104 pass, no regressions.**
+
 - [x] `built-ins/Array/prototype/includes/no-arg.js` passes
 - [x] `built-ins/Array/prototype/includes/samevaluezero.js` passes
 - [x] `built-ins/Array/prototype/includes/search-not-found-returns-false.js` passes
-- [x] `tests/equivalence/array-includes-no-arg.test.ts` — 9 cases, incl. the
-      coercion traps (`"42"`, `true`/`false`, `null`) and argument side effects
+- [x] `built-ins/Array/prototype/includes/sparse.js` still passes — it briefly
+      did NOT (see below)
+- [x] `tests/equivalence/array-includes-no-arg.test.ts` — 10 cases, incl. the
+      coercion traps (`"42"`, `true`/`false`, `null`), argument side effects, and
+      the sparse-hole guard
+
+`length-zero-returns-false.js` does **not** pass. Its no-arg assertion is fixed,
+but a later assertion in the same file ("length is checked before
+ToInteger(fromIndex)") exercises the array-like `.call` path and still fails —
+it belongs to the bucket below, not here. An earlier draft of this issue and its
+commit message claimed the row passed; that came from judging the row by whether
+it compiled rather than by running it, which is precisely the mistake
+`run-test262-row.mts` now guards against (its verdict was corrected to mirror the
+runner: an error-severity diagnostic is a compile_error even when a binary came
+out).
+
+## A regression this change introduced, and the fix
+
+The first cut listed `"undefined"` in `NEVER_A_NUMBER`, forcing
+`includes(undefined)` false against a numeric vec. That flipped
+`built-ins/Array/prototype/includes/sparse.js` from **pass to fail**: per
+§23.1.3.16 step 7a holes are read with `Get`, which returns `undefined`, so
+`[, , , 42, , ].includes(undefined)` is `true`. In an f64 vec a hole reads as NaN
+and `undefined` coerces to NaN, so the pre-existing both-NaN arm of the
+SameValueZero comparison was already producing the right answer — and the new
+predicate overrode it.
+
+Caught only by running the edition set before and after against `origin/main`,
+not by the targeted rows. The encoding stays imprecise in the other direction
+(`[NaN].includes(undefined)` wrongly answers `true`); that is pre-existing and
+out of scope here.
 
 ## Known limitations
 

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -475,6 +475,28 @@ Diffing the two fail sets: **18 rows fixed, 1 regressed.** The single regression
 is `built-ins/Object/getOwnPropertySymbols/proxy-invariant-not-extensible-absent-string-key.js`
 — almost certainly the invariant #4931 was introduced to protect.
 
+**The −1 is itself diagnosed, and it is shallow.** With the gate off, `proxy`
+stays a real host Proxy, and the row needs the host's §10.5.11 invariant check to
+fire. Probed:
+
+```
+var t = { prop: 2 };
+Object.isExtensible(t)                     true    ✓
+Object.preventExtensions(t);
+Object.isExtensible(t)                     false   ✓   extensibility tracking is correct
+Object.getOwnPropertySymbols(new Proxy(t, { ownKeys: () => [] }))
+                                           does NOT throw   ✗
+```
+
+Extensibility is tracked correctly, so the failure is upstream of it: the host's
+check calls `target.[[OwnPropertyKeys]]()` on our wrapped struct, and if the
+wrapper's **`ownKeys` trap** does not report `"prop"`, `targetConfigurableKeys`
+is empty and step 21 never throws. That is a `_wrapForHost` gap, independent of
+the escape gate — the gate flip merely stops hiding it.
+
+Fix that trap and the gate flip becomes **+19 / −0** on this population, which
+would make it a clean decision rather than a trade.
+
 So the real trade is **+18 / −1 inside the Proxy population, plus +1 in ES2016**,
 against one proxy-invariant row. That looks strongly favourable, and it is still
 not mine to flip: the −1 is a genuine conformance regression, the number was

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -355,7 +355,44 @@ receiver) while `_wasmStructHasOwn` consults the JS-side
 `_wasmStructDeletedKeys` WeakMap. That divergence is the thing to verify next,
 and it is a runtime question, not a codegen one.
 
-### The "requested new array is too large" trap — diagnosed
+### CORRECTION (2026-08-27): the sparse-write diagnosis below is WRONG
+
+I read the runner's error line as naming the failing statement. It does not —
+`"in __module_init() at source L30 | at L40: <text>"` puts the FRAME first and
+the statement second, so the trap was never at the setup assignment.
+
+Measured directly, both spellings of the huge-index write are fine:
+
+```
+var a = []; a[9007199254740988]  = "num";   // ok
+var b = []; b["9007199254740988"] = "str";  // ok
+```
+
+They are fine because the mechanism already exists: `SPARSE_INDEX_CEILING`
+(16,777,216) in `src/codegen/vec-sparse-index.ts` marks an index "unbackable",
+and `emitUnbackableIndexFlag` / `needsGrowCondInstrs` / `guardedElementSetInstrs`
+suppress both the growth and the store, with reads answering `undefined`. So the
+write path already does what I claimed it did not.
+
+The trap is in the METHOD, isolated:
+
+```js
+var proxy = new Proxy(array, { get: (t, pk, r) => pk === "length" ? 2 ** 53 + 2 : Reflect.get(t, pk, r) });
+Array.prototype.slice.call(proxy, 9007199254740989);
+  → RuntimeError: requested new array is too large   (and NOT catchable by a JS try/catch)
+```
+
+The host `slice` should create a 3-element result (`len - start`); something on
+our side sizes the result from the proxy's fake `length` instead. That is a
+host-bridge / ArraySpeciesCreate question in `_wrapForHost`, and it is where
+`slice/length-exceeding-integer-limit-proxied-array.js` and
+`splice/create-species-length-exceeding-integer-limit.js` actually fail.
+
+This is the second time this session an error STRING drove a wrong diagnosis
+(the first was the stale baseline text on `includes/samevaluezero.js`). Isolate
+the failing operation in a probe before believing a location.
+
+### Superseded: the "requested new array is too large" trap — diagnosed
 
 `slice/length-exceeding-integer-limit-proxied-array.js` and
 `splice/create-species-length-exceeding-integer-limit.js` do NOT trap inside the

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -508,6 +508,20 @@ consulted.
 That makes the −1 a `getOwnPropertySymbols`-routing gap, not a wrapper-trap gap.
 Correcting my own note one line above, which blamed the `ownKeys` trap.
 
+**And the runtime half is already correct.** `__getOwnPropertySymbols`
+(`runtime.ts:13192`) does `if (!_isWasmStruct(obj)) return Object.getOwnPropertySymbols(obj)`
+— for a real host Proxy that runs the trap and the §10.5.11 invariant, and would
+throw. So the fold is in **codegen**: `proxy` is typed as its target
+(`{prop: number}`), and the call is answered statically from that type instead of
+reaching the runtime import.
+
+That is the same "the static type is not a fact about this site" shape as the
+#2617 `in` guard and the escape-aware `in` fix in slice 2 — and my two attempts at
+that shape for `Array.isArray` (locals, then module globals) both failed to fire,
+so the slot-type approach is NOT the right instrument here. Find where
+`Object.getOwnPropertySymbols` is folded and gate on the argument being a
+`new Proxy`-derived binding directly.
+
 Fix that trap and the gate flip becomes **+19 / −0** on this population, which
 would make it a clean decision rather than a trade.
 

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -224,11 +224,55 @@ nothing in the host lane, because the shape-widening pass that populates
 `growableObjectLiteralVars` does not run there. That is why the host lane needs
 its own question.
 
-**Still open in this family** (`reverse` ×2, `slice`, `splice/create-species`,
-`unshift` ×2): these assert on the READ (`arrayLike[i]`), on a Proxy receiver, or
-on species construction — the property read has the same static-shape
-unsoundness as `in` did, but routing every escaped read through `__extern_get`
-is a much larger perf question than routing `in`. `unshift/clamps-to-integer-limit.js`
+### The read side, measured — and the trade-off it forces
+
+`in` is fixed; the READ is narrower than "escaped reads are unsound", and the
+difference matters because it decides how expensive the fix is. Probed:
+
+```
+var a = { "0": "zero", "2": "two", length: 3 };
+Array.prototype.unshift.call(a, "new");
+  a.length  4          ✓
+  a["0"]    "new"      ✓   declared field, host WROTE it
+  a["1"]    "zero"     ✓   undeclared key, read routes dynamically
+  a["3"]    "two"      ✓   undeclared key, read routes dynamically
+  a["2"]    "two"      ✗   declared field, host DELETED it — must be undefined
+```
+
+So host **writes** are already visible, and undeclared keys already read
+dynamically. Exactly one case is wrong: **a read of a DECLARED struct field that
+the host deleted.** The write lands in the field; the delete only records a
+tombstone and leaves the field in place, and the compiled `struct.get` does not
+consult it.
+
+That is the same missing tombstone check the `in` fold had — but the remedy is
+not the same size. `in` could take an existing `__extern_has` arm, and `in` is
+rare. Making the read correct means routing declared-field reads on an escaped
+receiver through `__extern_get`, which deoptimises `obj.x` after any `f(obj)` —
+ordinary TypeScript code, not just array-likes.
+
+**This is a product trade-off, not a bug fix, and it is deliberately left for a
+human to make.** Options, cheapest first:
+
+1. Narrow the escape predicate for READS to array-like receivers only (static
+   type has `length` plus numeric-ish keys). Fixes
+   `unshift/length-near-integer-limit.js`; cannot deopt ordinary object code.
+   Ad hoc, but the population it targets is exactly the generic-array-algorithm
+   one.
+2. Per-instance presence bits on the struct (the `bfnstate` precedent in
+   `src/codegen/builtin-fn-meta.ts`), so the compiled `struct.get` can check a
+   deleted-bit without a host call. Correct everywhere, keeps reads native,
+   costs a field per open-object struct and a branch per read.
+3. Route all escaped declared-field reads through `__extern_get`. Simplest,
+   most correct, worst for performance.
+
+Option 2 is the principled one; option 1 buys the conformance row now.
+
+**Genuinely separate from all of the above** — `reverse` ×2 need host
+observation of a throwing accessor on the wrapped struct; `slice` and
+`splice/create-species` trap with "requested new array is too large" (the real
+2^53 arithmetic); `unshift/clamps-to-integer-limit.js` needs the `ToLength`
+write-back. `unshift/clamps-to-integer-limit.js`
 remains the one genuinely arithmetic row.
 
 The read-side fix is where **per-instance property presence for statically-shaped structs**

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -131,8 +131,50 @@ Remaining from the original 19, now 12:
   thrown but no exception was thrown"). Both point at argument marshalling
   coercing a WasmGC struct on its way to the host call, ahead of the host
   algorithm's own step order.
-- 10 rows in the 2^53-length family, which now genuinely need the length
-  arithmetic, not the method value.
+- 10 rows in the 2^53-length family. **Diagnosed 2026-08-27 — and it is not the
+  length arithmetic.** See the section below.
+
+## The 2^53 family is a `delete`-visibility problem, not an arithmetic one
+
+Probed through the real runner (a scratch file under `test262/test/`, run with
+`scripts/run-test262-paths.mts`, so the whole host-wrapper path is live):
+
+```
+var a = { length: 3, 0: "a", 1: "b", 2: "c" };
+delete a[2];
+  2 in a                                  →  true    (must be false)
+  Object.prototype.hasOwnProperty(a, "2") →  false    (correct)
+  a[2]                                    →  "c"      (must be undefined)
+```
+
+So a **direct `delete`** on a statically-shaped struct is already invisible to
+`in` and to the index read, while `hasOwnProperty` honours it. The host's
+`Array.prototype.pop` / `splice` / `unshift` remove elements with
+`DeletePropertyOrThrow`, and those removals are exactly what these rows assert
+("`arrayLike['9007199254740990']` is removed"). Nothing about 2^53 is involved —
+the same failure reproduces at index 2.
+
+**Dead end worth not repeating.** The obvious fixes do nothing:
+`_wasmStructDeletedKeys` (the tombstone set) is consulted by `_wasmStructHasOwn`,
+by gOPD, and by `__extern_has`, but adding the same guard to the host proxy's
+`has` trap, to `__extern_has_idx`, and to `__extern_get_idx` changes no
+behaviour — because a statically-typed receiver never reaches the indexed MOP
+at all. `a[2]` lowers to a direct struct-field read (`__sget_2`), and `2 in a`
+resolves statically from the struct shape. All three edits were tried and
+reverted.
+
+The real fix is **per-instance property presence for statically-shaped structs**
+— the struct field physically exists, so deletion needs a presence bit consulted
+by the compiled read and `in`, not just a host-side tombstone. The precedent is
+`bfnstate` in `src/codegen/builtin-fn-meta.ts`, which carries exactly this kind
+of per-instance deleted-bits mask for a builtin function's `name`/`length` so
+`verifyProperty`'s delete-then-`hasOwnProperty` round-trip works. Generalising
+that to open-object structs is the shape of the work.
+
+One separate row in the family is genuinely arithmetic:
+`unshift/clamps-to-integer-limit.js` — after `arrayLike.length = 2 ** 53`,
+`Array.prototype.unshift.call(arrayLike)` must write back `ToLength(len)` =
+2^53−1; measured, the length stays 2^53.
 
 **Standalone is untouched** — the intercept returns early under
 `ctx.standalone || ctx.wasi`. A native answer still needs the generic array-like

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -13,6 +13,18 @@ language_feature: arrays
 goal: spec-completeness
 sprint: current
 horizon: xl
+loc-budget-allow:
+  # 2026-08-27 — slice 1 (host-lane method value). Both are the minimum wiring
+  # for a NEW mechanism whose logic lives in the leaf module
+  # src/codegen/array-method-value.ts, not in the god files:
+  #   property-access.ts +7 — the intercept call in compilePropertyAccess
+  #   runtime.ts         +4 — the __array_proto_method intrinsic
+  - src/codegen/property-access.ts
+  - src/runtime.ts
+func-budget-allow:
+  # Same +4: resolveImport is the single switch every host import is registered
+  # in, so a new import necessarily grows it.
+  - src/runtime.ts::resolveImport
 ---
 
 # #4765 — `Array.prototype` method values and the generic array-like algorithm
@@ -88,7 +100,46 @@ Far more than 19 rows depend on this outside ES2016: every
 `Array.prototype.<m>.call(arrayLike, …)` test262 row in every edition, and the
 `Function.prototype.{call,apply,bind}`-on-builtin family.
 
-## Implementation Plan
+## Slice 1 — DONE (host lane), and it re-sized the issue
+
+The original sizing above ("XL, not a by-product of an includes fix") was wrong
+about the first step, because it missed that **two call spellings behave
+differently**:
+
+| spelling | uses in the includes/reverse/splice/unshift/pop/slice dirs | status before slice 1 |
+| --- | --- | --- |
+| `Array.prototype.includes.call(obj, …)` | 72 | already resolved — runs the real generic algorithm through the host `Array` global |
+| `[].includes.call(obj, …)` | 40 | `null` — no route from a vec receiver in non-call position |
+
+So the generic algorithm was never the blocker for the first tranche; the
+missing piece was only a **route from a vec-typed receiver to the intrinsic**.
+`src/codegen/array-method-value.ts` adds it, modelled on the #2743b
+`vec[Symbol.iterator]` → `%Array.prototype.values%` intercept: host lane, non-call
+position, array/tuple receiver, receiver evaluated for effect then dropped,
+intrinsic fetched via a new `__array_proto_method` import.
+
+**Measured: ES2016 in-scope 102/124 → 109/124**, no regressions (full
+before/after run of the 124 in-scope files with
+`scripts/run-test262-paths.mts`). Seven of the nine `includes` rows flipped.
+
+Remaining from the original 19, now 12:
+
+- 2 `includes` rows fail on **`fromIndex` observation order**, not on the value
+  read: `length-zero-returns-false.js` ("length is checked before
+  ToInteger(fromIndex)" — we observe `valueOf` when we should not) and
+  `return-abrupt-tointeger-fromindex-symbol.js` ("Expected a TypeError to be
+  thrown but no exception was thrown"). Both point at argument marshalling
+  coercing a WasmGC struct on its way to the host call, ahead of the host
+  algorithm's own step order.
+- 10 rows in the 2^53-length family, which now genuinely need the length
+  arithmetic, not the method value.
+
+**Standalone is untouched** — the intercept returns early under
+`ctx.standalone || ctx.wasi`. A native answer still needs the generic array-like
+algorithm below, so the rest of this plan stands for standalone and for the
+2^53 work.
+
+## Implementation Plan (remaining slices)
 
 1. **Reify the value.** Extend the static-method closure machinery in
    `src/codegen/property-access.ts` to prototype methods: a

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -488,11 +488,25 @@ Object.getOwnPropertySymbols(new Proxy(t, { ownKeys: () => [] }))
                                            does NOT throw   ✗
 ```
 
-Extensibility is tracked correctly, so the failure is upstream of it: the host's
-check calls `target.[[OwnPropertyKeys]]()` on our wrapped struct, and if the
-wrapper's **`ownKeys` trap** does not report `"prop"`, `targetConfigurableKeys`
-is empty and step 21 never throws. That is a `_wrapForHost` gap, independent of
-the escape gate — the gate flip merely stops hiding it.
+Extensibility is tracked correctly. So is everything else on the target — probed
+one level further:
+
+```
+Object.getOwnPropertyNames(t)              ["prop"]              ✓
+Object.getOwnPropertyDescriptor(t, "prop") { configurable: true } ✓
+Reflect.ownKeys(t)                         ["prop"]              ✓
+Object.isExtensible(t)                     false                 ✓
+```
+
+Every input §10.5.11 step 21 needs is present and correct, and the wrapper's
+`ownKeys` trap does report `"prop"` (it returns `collectKeys()`). So the check is
+never running: **our `Object.getOwnPropertySymbols` lowering is not routing to
+the host Proxy's `[[OwnPropertyKeys]]` at all** — it answers from our own
+reflection instead, where the user `ownKeys` trap returning `[]` is simply never
+consulted.
+
+That makes the −1 a `getOwnPropertySymbols`-routing gap, not a wrapper-trap gap.
+Correcting my own note one line above, which blamed the `ownKeys` trap.
 
 Fix that trap and the gate flip becomes **+19 / −0** on this population, which
 would make it a clean decision rather than a trade.

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -163,6 +163,33 @@ at all. `a[2]` lowers to a direct struct-field read (`__sget_2`), and `2 in a`
 resolves statically from the struct shape. All three edits were tried and
 reverted.
 
+The string-key form behaves identically, which rules out the indexed MOP as the
+site. Reproducing `pop/length-near-integer-limit.js` exactly (the row asserts
+`"9007199254740990" in arrayLike === false`):
+
+```
+var a = { "9007199254740989": "x", "9007199254740990": "y", length: 2**53-1 };
+Array.prototype.pop.call(a);
+  pop returned "y"                         ✓
+  a.length === 2**53-2                     ✓
+  a["9007199254740989"] === "x"            ✓   (untouched element)
+  hasOwnProperty(a, "9007199254740990")    ✓  false
+  "9007199254740990" in a                  ✗  true   (must be false)
+  a["9007199254740990"]                    ✗  "y"    (must be undefined)
+```
+
+The host `pop` did everything right — only the compiled `in` and the property
+read disagree. Both resolve **statically from the struct shape** for a
+literal key on a known-typed receiver, so neither reaches `__extern_has`
+(which is tombstone-aware and would answer correctly).
+
+The escape is the crux: the deletion happens **inside host code**
+(`Array.prototype.pop.call(a)`), not via a `delete` statement, so no
+"module uses delete" signal could catch it — and there is no
+`escapesToHost` / `usesDelete` concept in `CodegenContext` today to hang a
+narrow fix on (checked). An object handed to an unknown host callee can have
+its shape mutated, so its later reads cannot be answered from the static shape.
+
 The real fix is **per-instance property presence for statically-shaped structs**
 — the struct field physically exists, so deletion needs a presence bit consulted
 by the compiled read and `in`, not just a host-side tombstone. The precedent is

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -448,6 +448,26 @@ The heuristic trades one trap for another, and #4707 / #4754 / #4931 already
 tuned this seam (`proxyModuleEscapeGateEnabled` is described there as "the sole
 attribution seam").
 
+**Measured what flipping it would buy.** The gate has a documented off-switch
+(`JS2WASM_PROXY_MODULE_ESCAPE_GATE=0`, `declarations.ts:1649`), so the benefit
+side of the trade is a number, not a guess:
+
+| escape gate | ES2016 in-scope |
+| --- | --- |
+| on (today's default) | 113 / 124 |
+| off | **114 / 124** |
+
+Exactly one row flips — `slice/length-exceeding-integer-limit-proxied-array.js`.
+`splice/create-species-length-exceeding-integer-limit.js` and
+`reverse/…-with-proxy.js` do NOT flip, so they fail for reasons beyond the
+materialisation.
+
+**The cost side is unmeasured and is the whole question.** The gate exists
+because of #4707/#4754/#4931; turning it off restores #4931's behaviour by the
+code's own account. Nobody should flip the default on the strength of +1 ES2016
+row without running the full suite both ways — that measurement is the actual
+next step, and it is cheap in CI and expensive locally.
+
 **So this is a policy decision on a tuned heuristic, not a defect to patch.**
 The options are to make the escape gate distinguish "handed to a typed consumer
 that will cast" from "handed to a generic host algorithm that will not", or to

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -402,7 +402,30 @@ So the trigger needs a Proxy whose `get` REPORTS a length past 2^53 over a
 sparse vec — something on our side then materialises a backing of that reported
 length. `slice`/`splice` are downstream victims, not the cause.
 
-**Deliberately not asserting the exact statement.** The runner's error line names
+**Bisected to a single operation.** Deleting statements one at a time: Proxy
+construction alone is fine, `proxy.length` alone is fine (returns 9007199254740994,
+correct), `proxy["9007199254740989"]` alone is fine (returns "a"). The trigger is
+**`Array.isArray(proxy)`** — which per §23.1.2.2 is a pure IsArray check that
+allocates nothing.
+
+`__extern_is_array` in the runtime is clean, so the allocation is on the way IN.
+`new Proxy(t, h)` is typed as its TARGET (ProxyConstructor returns `T`), so a
+proxy over an array resolves to a **vec** in `call-builtin-static.ts`, takes the
+`isArrayCarrierValType` constant-fold branch, and compiles the argument AS a vec
+"for side effects" — materialising the host proxy through its reported `length`.
+
+**The obvious fix does not work.** Applying the #2617 precedent (trust the local's
+actual SLOT type when it is externref/anyref, as `compileInOperator` does for the
+same staleness) does not fix even the isolated probe, so `proxy` is not sitting in
+an externref slot and the materialisation is elsewhere. Written and reverted, not
+shipped.
+
+Note the three failing rows do NOT call `Array.isArray` themselves — they call
+`Array.prototype.slice.call(proxy, …)`. Same class (a host proxy materialised
+through a fake `length`), different site. Fixing the marshalling generally is
+what these rows need, not a per-builtin patch.
+
+**Deliberately not asserting the exact statement for the .call rows.** The runner's error line names
 the frame, not the failing statement, and believing it has now produced two wrong
 diagnoses in this issue. Whoever picks this up should bisect by deleting
 statements, not read the location out of the message.

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -420,6 +420,26 @@ same staleness) does not fix even the isolated probe, so `proxy` is not sitting 
 an externref slot and the materialisation is elsewhere. Written and reverted, not
 shipped.
 
+**The allocation site itself is `buildVecFromExternref`** (`src/codegen/type-coercion.ts:757`).
+It materialises a host array-like into a vec by calling `__extern_length` (which
+returns **f64**), narrowing that to an i32 `lenLocal`, and allocating a backing
+of that size. A proxy reporting `2 ** 53 + 2` narrows to a saturated i32 (~4.29
+billion) and `array.new_default` refuses it — the uncatchable
+"requested new array is too large".
+
+Two things follow, and they are separable:
+
+1. **Defensive, and correct regardless of the rest**: an f64 length that does not
+   fit a sane vec size should raise a catchable **RangeError**, not a Wasm trap.
+   A trap cannot be caught by the JS `try` in the test (or in user code), so
+   today the failure mode is a hard abort rather than a JS exception. This alone
+   will not flip these rows — they expect neither — but it converts an
+   uncatchable crash into a diagnosable error.
+2. **The actual row fix**: nothing should be materialising here at all.
+   `Array.isArray` is a pure predicate, and `Array.prototype.slice.call(proxy, …)`
+   should reach the host bridge with the proxy intact. Finding why the proxy is
+   coerced into a vec on the way to those calls is the work.
+
 Note the three failing rows do NOT call `Array.isArray` themselves — they call
 `Array.prototype.slice.call(proxy, …)`. Same class (a host proxy materialised
 through a fake `length`), different site. Fixing the marshalling generally is

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -382,11 +382,30 @@ Array.prototype.slice.call(proxy, 9007199254740989);
   → RuntimeError: requested new array is too large   (and NOT catchable by a JS try/catch)
 ```
 
-The host `slice` should create a 3-element result (`len - start`); something on
-our side sizes the result from the proxy's fake `length` instead. That is a
-host-bridge / ArraySpeciesCreate question in `_wrapForHost`, and it is where
-`slice/length-exceeding-integer-limit-proxied-array.js` and
-`splice/create-species-length-exceeding-integer-limit.js` actually fail.
+Narrowed further, and `slice` is not required either — this alone traps:
+
+```js
+var array = []; array["9007199254740989"] = "a";
+var proxy = new Proxy(array, { get: (t,pk,r) => pk === "length" ? 2 ** 53 + 2 : Reflect.get(t,pk,r) });
+proxy.length;            // no slice, no splice
+```
+
+while each ingredient on its own is fine:
+
+```js
+var a = []; a[9007199254740988] = "x";              // ok
+var b = []; b["9007199254740988"] = "y";            // ok
+var c = []; c[9007199254740988] = "z"; new Proxy(c, {});   // ok
+```
+
+So the trigger needs a Proxy whose `get` REPORTS a length past 2^53 over a
+sparse vec — something on our side then materialises a backing of that reported
+length. `slice`/`splice` are downstream victims, not the cause.
+
+**Deliberately not asserting the exact statement.** The runner's error line names
+the frame, not the failing statement, and believing it has now produced two wrong
+diagnoses in this issue. Whoever picks this up should bisect by deleting
+statements, not read the location out of the message.
 
 This is the second time this session an error STRING drove a wrong diagnosis
 (the first was the stale baseline text on `includes/samevaluezero.js`). Isolate

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -1,0 +1,134 @@
+---
+id: 4765
+title: "Array.prototype methods do not reify as function values (19 of the 22 remaining ES2016 failures, and the whole array-like `.call` family)"
+status: ready
+created: 2026-08-26
+updated: 2026-08-26
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: codegen
+language_feature: arrays
+goal: spec-completeness
+sprint: current
+horizon: xl
+---
+
+# #4765 — `Array.prototype` method values and the generic array-like algorithm
+
+## Problem
+
+Reading an `Array.prototype` method as a **value** yields `null`. Calling one
+works (the call site is inlined); taking it and invoking it through `.call` /
+`.apply` does not.
+
+Measured 2026-08-26 with `runTest262File` on the pinned submodule SHA
+(`b363f29d3c43c626dc852744ad64a0b48a003693`):
+
+```
+built-ins/Array/prototype/includes/get-prop.js
+  TypeError: Cannot read properties of null (reading 'call')
+built-ins/Array/prototype/includes/values-are-not-cached.js
+  TypeError: Cannot read properties of null (reading 'call')
+    at [].includes.call(obj, "tc39")
+built-ins/Array/prototype/includes/tolength-length.js
+  TypeError: Cannot read properties of null (reading 'call')
+```
+
+The gap is **not** specific to `includes` — `indexOf` and `slice` read as `null`
+too. The static-method row already works: `Array.isArray`, `Object.keys`,
+`Reflect.get` and friends reify through
+`ensureStandaloneBuiltinStaticMethodClosure` (`property-access.ts`) with
+`{name, length}` metadata in `STANDALONE_STATIC_METHOD_META`
+(`src/codegen/builtin-fn-meta.ts`). No equivalent exists for prototype
+(instance) methods.
+
+Two things are missing, and the second is the larger one:
+
+1. **A callable value** for `Array.prototype.<m>` — a closure carrying the right
+   `.name` / `.length`, dispatchable through the existing `.call` / `.apply`
+   path.
+2. **A generic array-like algorithm behind it.** The inlined lowerings assume a
+   WasmGC vec receiver (`ref.cast` to the vec carriers, `array.get` on the
+   backing). `[].includes.call(obj, …)` passes an ordinary object with a
+   `length` property, so the closure body must run the spec algorithm over an
+   arbitrary object: `ToObject` → `Get(O, "length")` → `ToLength` →
+   `ToIntegerOrInfinity(fromIndex)` → per-index `Get`. Getters must be observed
+   in spec order and their abrupt completions propagated — that is exactly what
+   `return-abrupt-get-length.js`, `return-abrupt-get-prop.js`,
+   `return-abrupt-tonumber-length.js` and
+   `return-abrupt-tointeger-fromindex-symbol.js` assert, and why they currently
+   report "Expected a Test262Error but got a TypeError" (the TypeError is the
+   null-`.call`, not the test's own error).
+
+## Impact
+
+**19 of the 22 remaining ES2016 failures** — this single root cause is the ES2016
+bucket. Measured 2026-08-26 over the 147 files tagged `Array.prototype.includes`
+/ `exponentiation` / `u180e`, minus the 21 `intl402/` rows the runner's
+`TEST_CATEGORIES` never walks: **104 pass / 126 in scope**, 22 failures. The
+remaining 3 are unrelated singletons (`Function/prototype/toString/built-in-function-object.js`,
+`Iterator/prototype/chunks/chunkSize-out-of-range.js`,
+`language/expressions/object/cpn-obj-lit-computed-property-name-from-math.js`).
+
+The two groups below share this one cause:
+
+| rows | files |
+| --- | --- |
+| 9 | `Array/prototype/includes/{get-prop,length-boundaries,length-zero-returns-false,return-abrupt-get-length,return-abrupt-get-prop,return-abrupt-tointeger-fromindex-symbol,return-abrupt-tonumber-length,tolength-length,values-are-not-cached}.js` |
+| 10 | `Array/prototype/{pop/length-near-integer-limit,reverse/length-exceeding-integer-limit-with-object,reverse/length-exceeding-integer-limit-with-proxy,slice/length-exceeding-integer-limit-proxied-array,splice/create-species-length-exceeding-integer-limit,splice/length-and-deleteCount-exceeding-integer-limit,splice/length-exceeding-integer-limit-shrink-array,splice/length-near-integer-limit-grow-array,unshift/clamps-to-integer-limit,unshift/length-near-integer-limit}.js` |
+
+The second group additionally needs 2^53-safe length arithmetic (the loops use
+`i32` counters against a `.length` up to 2^53−1). That is separable follow-up
+work, but it cannot even be reached until the `.call` path resolves — those rows
+never get past `[].splice.call(…)` reading as `null`.
+
+Far more than 19 rows depend on this outside ES2016: every
+`Array.prototype.<m>.call(arrayLike, …)` test262 row in every edition, and the
+`Function.prototype.{call,apply,bind}`-on-builtin family.
+
+## Implementation Plan
+
+1. **Reify the value.** Extend the static-method closure machinery in
+   `src/codegen/property-access.ts` to prototype methods: a
+   `ensureBuiltinPrototypeMethodClosure(ctx, "Array.prototype.includes")`
+   sibling of `ensureStandaloneBuiltinStaticMethodClosure`, with its
+   `{name, length}` added to a `STANDALONE_PROTOTYPE_METHOD_META` table
+   alongside `STANDALONE_STATIC_METHOD_META`. Spec `length`: `includes` 1,
+   `indexOf` 1, `lastIndexOf` 1, `slice` 2, `splice` 2, `push` 1, `pop` 0,
+   `unshift` 1, `reverse` 0.
+2. **Write the generic body once, parameterised by method.** A single
+   `__array_like_scan(O, searchElement, fromIndex, mode)` covering
+   `includes` / `indexOf` / `lastIndexOf` (they differ only in the comparison —
+   SameValueZero vs IsStrictlyEqual — and the direction / return shape) keeps
+   this from becoming N hand-written closures. It must use the existing
+   host-free `Get` / `ToLength` / `ToIntegerOrInfinity` helpers so standalone
+   mode is not regressed; check `src/runtime.ts` and the `__extern_*` helper
+   family for what already exists before adding any host import (the dual-mode
+   rule in CLAUDE.md applies).
+3. **Route the receiver.** `[].includes` must produce the closure; `arr.includes(x)`
+   must keep the inlined vec fast path byte-for-byte. Gate on whether the
+   property access is in call position with a statically-known vec receiver —
+   the same discrimination `shouldUseHostArrayMethod` already makes.
+4. **Order of observable operations.** `length-zero-returns-false.js` asserts
+   `Get(O, "length")` happens **before** `ToIntegerOrInfinity(fromIndex)`;
+   `values-are-not-cached.js` asserts each index is read fresh inside the loop,
+   not snapshotted. Write these as equivalence tests first — they are cheap to
+   get subtly wrong and the test262 error strings do not name the ordering.
+
+### Sizing note
+
+This is genuinely XL and should not be attempted as a by-product of an
+`includes` fix. Steps 1–2 alone touch the closure-wrapper types, the builtin
+meta tables, and a new runtime algorithm; step 3 is a codegen dispatch change on
+a hot path.
+
+## Acceptance criteria
+
+- [ ] `([] as any).includes` is a callable value with `.name === "includes"` and
+      `.length === 1`
+- [ ] The 9 `Array/prototype/includes` rows above pass
+- [ ] `arr.includes(x)` on a statically-known vec still takes the inlined path
+      (verify the emitted binary is unchanged for the existing equivalence cases)
+- [ ] No new host import in standalone mode

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -31,6 +31,10 @@ func-budget-allow:
   # fnctorProtoRoute, growableReceiver, inheritsFromObjectPrototype). The scan
   # itself is a leaf module, src/codegen/in-escaped-receiver.ts.
   - src/codegen/binary-ops-in.ts::compileInOperator
+  # 2026-08-27 slice 2b (the trap half of the same fix). +12 in _wrapForHost:
+  # the tombstone guard in its `has` trap plus the rationale for why that trap
+  # is the one an `in` on an externref-typed receiver reaches.
+  - src/runtime.ts::_wrapForHost
 ---
 
 # #4765 — `Array.prototype` method values and the generic array-like algorithm
@@ -304,8 +308,46 @@ the existing `__extern_has` arm is taken — **and the row still fails.** Measur
 across the full 124: still 113, no regressions, no gains. So it was reverted
 (hypothesis 2 wrong).
 
-That localises the real blocker one layer down: **`__extern_has` itself answers
-`true` for this key.** The earlier probe showed it answering correctly for a
+### Slice 2b — the missing half, found by probing the receiver shape
+
+Reproducing the row's own object shape (throwing getter, small indices) settled
+it:
+
+```
+function Stop() {}
+var a = { get "6"() { throw new Stop(); }, "7": "seven", "9": "nine", length: 12 };
+try { Array.prototype.unshift.call(a, null); } catch (e) {}
+  hasOwnProperty(a, "9")  false   ✓   tombstone IS in the JS WeakMap
+  a["9"]                  undefined ✓ the compiled READ is correct
+  "9" in a                true    ✗
+```
+
+So `_wasmStructHasOwn` and the read were both right; only `in` disagreed. With
+an **externref**-typed receiver the routed `__extern_has` does not take its
+`_isWasmStruct` arm — it falls through to `key in obj`, which hits the host
+wrapper's **`has` trap**, and that trap read the static struct shape without
+consulting the tombstone.
+
+Both halves are needed, which is why each looked like a no-op alone: dropping
+the `ref`/`ref_null` gate on `escapedReceiverRoute` (so the fold is suppressed
+and `in` actually routes), plus the tombstone guard in the `has` trap (so the
+routed question is answered correctly). Verified: `in9=false`, and
+`in`/`hasOwnProperty` now agree.
+
+**This is the vindication of the very first attempted fix in this issue.** The
+proxy-`has` tombstone guard was tried early, measured as a no-op, and reverted —
+correctly, on the evidence available, because the fold was short-circuiting
+before the trap was ever reached. Testing a fix whose precondition is not met
+reads exactly like testing a wrong fix.
+
+`unshift/length-near-integer-limit.js` still fails: with the mechanism working at
+small indices, what remains for that row is genuinely the 2^53 scale (keys near
+2^53, `length: 2**53-2`). Measured 113/124 with slice 2b — no rows gained, no
+regressions. Shipped anyway: it closes a real `in`-vs-`hasOwnProperty`
+disagreement any host mutation can produce, at zero measured cost, in the same
+class as slice 2 (which did gain rows).
+
+Superseded diagnosis, kept for the record: The earlier probe showed it answering correctly for a
 plain object literal, so something about THIS receiver puts the deletion
 somewhere `_wasmStructHasOwn` does not look — most likely the host `unshift`
 deleted through the native `__delete_property` path (an `_isNativeOpenObject`

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -355,11 +355,38 @@ receiver) while `_wasmStructHasOwn` consults the JS-side
 `_wasmStructDeletedKeys` WeakMap. That divergence is the thing to verify next,
 and it is a runtime question, not a codegen one.
 
-**Genuinely separate from all of the above** — `reverse` ×2 need host
-observation of a throwing accessor on the wrapped struct; `slice` and
-`splice/create-species` trap with "requested new array is too large" (the real
-2^53 arithmetic); `unshift/clamps-to-integer-limit.js` needs the `ToLength`
-write-back. `unshift/clamps-to-integer-limit.js`
+### The "requested new array is too large" trap — diagnosed
+
+`slice/length-exceeding-integer-limit-proxied-array.js` and
+`splice/create-species-length-exceeding-integer-limit.js` do NOT trap inside the
+array algorithm. They trap in the test's **setup**, before the method under test
+is ever called:
+
+```js
+var array = [];
+array["9007199254740988"] = "9007199254740988";   // <-- RuntimeError here (L30)
+```
+
+Assigning a huge index to a real Array must, per §10.4.2.1, set
+`length = index + 1` and store the property — **sparse, no allocation**. The
+compiler instead grows the vec's physical backing toward the logical length and
+the allocation is refused.
+
+So the fix is in the vec element-assignment write path, not in `slice`/`splice`:
+an index beyond a threshold must land in the sparse overlay (the #3251 overlay /
+#3537 bag already used for named keys on vecs) and only move the logical
+`length`. `#3201` already established that logical length can exceed the physical
+backing on the READ side (`compileArrayIncludes` clamps its scan to
+`array.len`), so the representation supports this — the write path is what does
+not.
+
+This is a hot path (every `a[i] = v`), so it wants a real design pass, but it is
+a bounded one and it is the largest remaining ES2016 bucket.
+
+**Genuinely separate** — `reverse` ×2 need host observation of a throwing
+accessor on the wrapped struct; `unshift/clamps-to-integer-limit.js` needs the
+`ToLength` write-back; `unshift/length-near-integer-limit.js` needs the same
+sparse-write fix as above (its keys are at the 2^53 scale). `unshift/clamps-to-integer-limit.js`
 remains the one genuinely arithmetic row.
 
 The read-side fix is where **per-instance property presence for statically-shaped structs**

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -266,7 +266,31 @@ human to make.** Options, cheapest first:
 3. Route all escaped declared-field reads through `__extern_get`. Simplest,
    most correct, worst for performance.
 
-Option 2 is the principled one; option 1 buys the conformance row now.
+Option 2 is the principled one. **Option 1 was built and does NOT buy the row** —
+correcting what an earlier draft of this section claimed. It was implemented
+(`tryCompileEscapedArrayLikeElementRead`, gated on `identifierEscapesToCall` plus
+`propertyFactOf(recv,"length").kind === "number"` and an integer literal key —
+note `typeFactOf(...).shape` is NOT populated for these anonymous object types,
+so the per-property question is the only one the oracle answers here). It
+demonstrably fixed the wrong answer:
+
+```
+var a = { "0": "zero", "2": "two", length: 3 };
+Array.prototype.unshift.call(a, "new");
+  a["2"]   "two" before  →  undefined after   ✓
+```
+
+…and moved **zero** conformance rows, so it was reverted rather than shipped: a
+hot-path change with a perf trade-off, bought with no measured conformance, is
+not a trade worth making unilaterally.
+
+`unshift/length-near-integer-limit.js` still fails on its `in` assertion, not on
+a read — so slice 2's escape route did not fire for THAT receiver. The
+distinguishing feature is that its object literal declares a **getter**
+(`get "9007199254740986"() { throw … }`), which almost certainly moves the
+receiver off the `ref`/`ref_null` struct type that `escapedReceiverRoute`
+requires. Widening that gate is the next thing to try for this row, and it is
+cheap — but it must be measured, not assumed.
 
 **Genuinely separate from all of the above** — `reverse` ×2 need host
 observation of a throwing accessor on the wrapped struct; `slice` and

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -284,13 +284,34 @@ Array.prototype.unshift.call(a, "new");
 hot-path change with a perf trade-off, bought with no measured conformance, is
 not a trade worth making unilaterally.
 
-`unshift/length-near-integer-limit.js` still fails on its `in` assertion, not on
-a read — so slice 2's escape route did not fire for THAT receiver. The
-distinguishing feature is that its object literal declares a **getter**
-(`get "9007199254740986"() { throw … }`), which almost certainly moves the
-receiver off the `ref`/`ref_null` struct type that `escapedReceiverRoute`
-requires. Widening that gate is the next thing to try for this row, and it is
-cheap — but it must be measured, not assumed.
+### Why `unshift/length-near-integer-limit.js` still fails — traced, not guessed
+
+It fails on its `in` assertion, not on a read, so slice 2's escape route did not
+fire for that receiver. Two hypotheses were tried and both were wrong; the
+answer came from tracing the site:
+
+```
+IN2 key=9007199254740989 rightWasm=externref escaped=false tsHas=true has=true
+```
+
+The receiver is **externref**, not a struct ref, so `escapedReceiverRoute`'s
+`ref`/`ref_null` gate excluded it and `tsTypeHasProperty` folded the answer to
+`true`. (The getter in the object literal was a red herring — hypothesis 1.)
+
+Widening the gate to drop the `ref`/`ref_null` requirement makes it fire exactly
+as intended — traced `escaped=true`, `has=false`, so the fold is suppressed and
+the existing `__extern_has` arm is taken — **and the row still fails.** Measured
+across the full 124: still 113, no regressions, no gains. So it was reverted
+(hypothesis 2 wrong).
+
+That localises the real blocker one layer down: **`__extern_has` itself answers
+`true` for this key.** The earlier probe showed it answering correctly for a
+plain object literal, so something about THIS receiver puts the deletion
+somewhere `_wasmStructHasOwn` does not look — most likely the host `unshift`
+deleted through the native `__delete_property` path (an `_isNativeOpenObject`
+receiver) while `_wasmStructHasOwn` consults the JS-side
+`_wasmStructDeletedKeys` WeakMap. That divergence is the thing to verify next,
+and it is a runtime question, not a codegen one.
 
 **Genuinely separate from all of the above** — `reverse` ×2 need host
 observation of a throwing accessor on the wrapped struct; `slice` and

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -25,6 +25,12 @@ func-budget-allow:
   # Same +4: resolveImport is the single switch every host import is registered
   # in, so a new import necessarily grows it.
   - src/runtime.ts::resolveImport
+  # 2026-08-27 slice 2 (escape-aware `in`). +14 in compileInOperator: one route
+  # predicate and its rationale, joining the five sibling route flags that
+  # already live there (vecNamedKeyRoute, reassignedReceiverRoute,
+  # fnctorProtoRoute, growableReceiver, inheritsFromObjectPrototype). The scan
+  # itself is a leaf module, src/codegen/in-escaped-receiver.ts.
+  - src/codegen/binary-ops-in.ts::compileInOperator
 ---
 
 # #4765 — `Array.prototype` method values and the generic array-like algorithm
@@ -190,7 +196,42 @@ The escape is the crux: the deletion happens **inside host code**
 narrow fix on (checked). An object handed to an unknown host callee can have
 its shape mutated, so its later reads cannot be answered from the static shape.
 
-The real fix is **per-instance property presence for statically-shaped structs**
+## Slice 2 — DONE (host lane): escape-aware `in`
+
+**Measured: 109/124 → 113/124**, no regressions. Four rows flipped
+(`pop/length-near-integer-limit`, `splice/length-and-deleteCount-exceeding-integer-limit`,
+`splice/length-exceeding-integer-limit-shrink-array`,
+`splice/length-near-integer-limit-grow-array`).
+
+The fix is not a presence bit after all — it is scoping the FOLD. `in` answers
+§7.3.12 from the receiver's compile-time struct shape, which is sound only while
+the compiler owns that shape. It stops owning it the moment the object is passed
+to a callee it cannot see through: the callee may delete a key, and the field
+list does not shrink. `src/codegen/in-escaped-receiver.ts` asks the cheap
+value-independent question — "is this binding ever handed to a call?" — and a
+`true` suppresses the fold and takes the existing `__extern_has` arm, which
+consults the tombstone and was right all along.
+
+That predicate joins five sibling route flags already in `compileInOperator`
+(`vecNamedKeyRoute`, `reassignedReceiverRoute`, `fnctorProtoRoute`,
+`growableReceiver`, `inheritsFromObjectPrototype`) — each one an existing case of
+"the static type is not a fact about this site". It is deliberately conservative:
+being permissive costs one `__extern_has` call on an `in`, never a wrong answer.
+
+`growableReceiver` is the closest sibling and was tried first — it is exactly
+this guard for standalone's growable `$Object` receivers. Ungating it does
+nothing in the host lane, because the shape-widening pass that populates
+`growableObjectLiteralVars` does not run there. That is why the host lane needs
+its own question.
+
+**Still open in this family** (`reverse` ×2, `slice`, `splice/create-species`,
+`unshift` ×2): these assert on the READ (`arrayLike[i]`), on a Proxy receiver, or
+on species construction — the property read has the same static-shape
+unsoundness as `in` did, but routing every escaped read through `__extern_get`
+is a much larger perf question than routing `in`. `unshift/clamps-to-integer-limit.js`
+remains the one genuinely arithmetic row.
+
+The read-side fix is where **per-instance property presence for statically-shaped structs**
 — the struct field physically exists, so deletion needs a presence bit consulted
 by the compiled read and `in`, not just a host-side tombstone. The precedent is
 `bfnstate` in `src/codegen/builtin-fn-meta.ts`, which carries exactly this kind

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -462,7 +462,28 @@ Exactly one row flips — `slice/length-exceeding-integer-limit-proxied-array.js
 `reverse/…-with-proxy.js` do NOT flip, so they fail for reasons beyond the
 materialisation.
 
-**The cost side is unmeasured and is the whole question.** The gate exists
+**Cost side, now measured too.** The gate only affects module-level bindings
+initialised with `new Proxy`, so the affected population is enumerable: 450
+test262 files matching a top-level `var|let|const x = new Proxy(`. Both ways:
+
+| escape gate | pass | fail | skip |
+| --- | --- | --- | --- |
+| on (default) | 179 | 196 | 75 |
+| off | **196** | 179 | 75 |
+
+Diffing the two fail sets: **18 rows fixed, 1 regressed.** The single regression
+is `built-ins/Object/getOwnPropertySymbols/proxy-invariant-not-extensible-absent-string-key.js`
+— almost certainly the invariant #4931 was introduced to protect.
+
+So the real trade is **+18 / −1 inside the Proxy population, plus +1 in ES2016**,
+against one proxy-invariant row. That looks strongly favourable, and it is still
+not mine to flip: the −1 is a genuine conformance regression, the number was
+measured on a subset rather than the full suite, and the gate has been tuned by
+three prior issues. Run the full suite both ways in CI and let #4931's owner
+decide; this at least makes it a decision with numbers on both sides instead of
+one.
+
+**The earlier cost note (now superseded):** The gate exists
 because of #4707/#4754/#4931; turning it off restores #4931's behaviour by the
 code's own account. Nobody should flip the default on the strength of +1 ES2016
 row without running the full suite both ways — that measurement is the actual

--- a/plan/issues/4765-array-prototype-method-values-generic-array-like.md
+++ b/plan/issues/4765-array-prototype-method-values-generic-array-like.md
@@ -420,6 +420,41 @@ same staleness) does not fix even the isolated probe, so `proxy` is not sitting 
 an externref slot and the materialisation is elsewhere. Written and reverted, not
 shipped.
 
+### COMPLETE causal chain (2026-08-27) — and it lands on a deliberate trade-off
+
+Instrumenting `buildVecFromExternref` to dump a stack, then naming the coerced
+expression, gives the whole path with no guesswork left:
+
+```
+COERCE externref -> ref_null: new Proxy(array, { get(t, pk, r) { … } })
+  compileExpressionBody → coerceType → buildVecFromExternref
+```
+
+The materialisation is **at the declaration** `var proxy = new Proxy(array, h)`,
+not at any later use. TypeScript types `new Proxy(t, h)` as its target, so the
+binding gets a vec slot and the host proxy is materialised into it — reading
+`__extern_length` (2**53+2), narrowing to a saturated i32, and allocating.
+
+**And this is already governed by an existing, deliberate rule.**
+`moduleInitForcesExternref` in `src/codegen/declarations.ts` (~L2431) DOES force
+externref for `isDirectProxyConstruction(decl.initializer)` — except when
+`proxyBindingEscapesToCall(ctx, decl)`, where it keeps the structural slot on
+purpose, because (quoting the code) "widening it would make the consumer cast a
+host Proxy externref back to the target struct and trap."
+
+Our rows hand `proxy` to a call (`Array.prototype.slice.call(proxy, …)`), so the
+escape gate fires, the vec slot is preserved, and the materialisation traps.
+The heuristic trades one trap for another, and #4707 / #4754 / #4931 already
+tuned this seam (`proxyModuleEscapeGateEnabled` is described there as "the sole
+attribution seam").
+
+**So this is a policy decision on a tuned heuristic, not a defect to patch.**
+The options are to make the escape gate distinguish "handed to a typed consumer
+that will cast" from "handed to a generic host algorithm that will not", or to
+make the materialisation itself refuse a length it cannot represent with a
+catchable RangeError instead of a Wasm trap. Whoever owns #4931 should pick;
+flipping the gate blind would re-open whatever it was introduced to close.
+
 **The allocation site itself is `buildVecFromExternref`** (`src/codegen/type-coercion.ts:757`).
 It materialises a host array-like into a vec by calling `__extern_length` (which
 returns **f64**), narrowing that to an i32 `lenLocal`, and allocating a backing

--- a/plan/issues/4766-intl-supportedvaluesof-datetimeformat-options.md
+++ b/plan/issues/4766-intl-supportedvaluesof-datetimeformat-options.md
@@ -1,0 +1,105 @@
+---
+id: 4766
+title: "Intl.supportedValuesOf missing and DateTimeFormat drops hourCycle/timeStyle (found off-lane; intl402 is not in TEST_CATEGORIES)"
+status: ready
+created: 2026-08-26
+updated: 2026-08-26
+priority: low
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: runtime
+language_feature: intl
+goal: spec-completeness
+sprint: Backlog
+horizon: xl
+---
+
+# #4766 — `Intl.supportedValuesOf` and `DateTimeFormat` option resolution
+
+## Status: NOT counted by any conformance number today
+
+`intl402` is absent from `TEST_CATEGORIES` in `tests/test262-runner.ts`, so the
+sharded runner never walks it and these rows appear in no dashboard bucket. They
+surfaced only because a one-off ES2016 measurement (2026-08-26) selected files
+by `features:` tag and ran them directly through `runTest262File`, bypassing the
+category walk.
+
+That is also why this is **not** an ES2016 blocker, despite the tag: these files
+carry `features: [Array.prototype.includes]` because their *assertion bodies*
+call `.includes()` (`assert(numberingSystems.includes(ns))`), not because they
+test an ES2016 feature. Filed so the finding is not lost, at Backlog priority —
+turning it into real conformance movement means adding `intl402` to
+`TEST_CATEGORIES` first, which is a separate decision with its own cost (it adds
+several thousand mostly-failing rows to every shard).
+
+## Problem
+
+Measured with `runTest262File` at the pinned submodule SHA
+`b363f29d3c43c626dc852744ad64a0b48a003693`. 21 rows, two gaps.
+
+**1. `Intl.supportedValuesOf` does not exist** (16 rows), all the same shape:
+
+```
+intl402/Intl/supportedValuesOf/calendars.js
+  TypeError: Cannot read properties of null (reading 'supportedValuesOf')
+```
+
+`calendars`, `calendars-accepted-by-DateTimeFormat`,
+`calendars-accepted-by-DisplayNames`, `collations`,
+`collations-accepted-by-Collator`, `currencies-accepted-by-DisplayNames`,
+`numberingSystems-accepted-by-{DateTimeFormat,NumberFormat,RelativeTimeFormat}`,
+`numberingSystems-with-simple-digit-mappings`, `units`,
+`units-accepted-by-NumberFormat`, plus
+`Locale/prototype/{getCollations,getHourCycles}/output-array-values`,
+`PluralRules/prototype/resolvedOptions/pluralCategories`,
+`Segmenter/constructor/constructor/locales-valid`.
+
+These are **not** satisfiable by returning a plausible list. Each row
+cross-checks that every returned value is actually accepted by the constructor
+it names — `supportedValuesOf("calendar")` entries must each work as
+`new Intl.DateTimeFormat(l, {calendar})` and be echoed back by
+`resolvedOptions()`. The list and the constructors have to agree.
+
+**2. `DateTimeFormat` option resolution is incomplete** (5 rows):
+
+```
+resolvedOptions/hourCycle.js            Expected SameValue(«undefined», «"h11"»)
+resolvedOptions/hourCycle-timeStyle.js  Should support timeStyle=full — «undefined» vs «"full"»
+format/related-year-zh.js               TypeError: Cannot read properties of null (reading 'format')
+format/timedatestyle-en.js              TypeError: … (reading 'format')
+formatToParts/main.js                   TypeError: … (reading 'format')
+```
+
+`resolvedOptions()` drops `hourCycle` / `timeStyle`; the `null` `format`
+failures suggest some option combinations abort construction outright rather
+than merely omitting a property.
+
+## Implementation Plan
+
+1. **Decide whether to run `intl402` at all.** Nothing here changes a published
+   number until `TEST_CATEGORIES` includes it. Measure the full intl402 pass
+   rate first (the same one-off harness works) so the decision is made against a
+   real figure rather than a guess.
+2. **`Intl.supportedValuesOf`** (ECMA-402): host-backed in JS-host mode
+   (delegate to the host `Intl`, which already has correct lists), with an
+   explicit standalone answer. Per the dual-mode rule in CLAUDE.md a host import
+   needs a standalone story — here that means a curated frozen list the
+   standalone constructors genuinely accept, or a documented `wont-fix` for
+   standalone. Do not let it fall through to a host-only import.
+3. **`DateTimeFormat` `hourCycle` / `timeStyle`**: thread both through
+   construction into `resolvedOptions()`. Read the existing `DateTimeFormat`
+   shim in `src/runtime.ts` first — the `null`-`format` rows point at
+   construction aborting, which is a different defect from a missing property
+   and may be the cheaper half.
+4. Re-measure after each step. Do not infer row counts from baseline error
+   strings — they go stale and mis-bucket (that mistake cost two wrong
+   diagnoses on #4764).
+
+## Acceptance criteria
+
+- [ ] intl402 pass rate measured, and the run-it-or-not decision recorded here
+- [ ] `Intl.supportedValuesOf` exists and every value it returns is accepted by
+      the constructor the corresponding row names
+- [ ] `resolvedOptions()` reports `hourCycle` and `timeStyle`
+- [ ] Standalone behaviour explicitly decided and documented

--- a/scripts/run-test262-paths.mts
+++ b/scripts/run-test262-paths.mts
@@ -1,0 +1,59 @@
+/**
+ * Run an explicit list of test262 paths through the runner's own
+ * `runTest262File` and print the per-row verdict.
+ *
+ *   npx tsx scripts/run-test262-paths.mts .tmp/es2016-paths.txt
+ *
+ * Scoped measurement lane for one slice — an ES edition, a directory, a
+ * suspected regression set. Requires the test262 submodule
+ * (`git submodule update --init --depth 1 test262`).
+ *
+ * Why not `pnpm run test:262` with TEST262_PATH_FILTER_FILE: filtering to ~150
+ * tests leaves most of its 16 shards empty, and an empty shard aborts as "No
+ * test suite found" before any report is written.
+ *
+ * Why not a hand-written repro: the runner wraps each file with `wrapTest` and
+ * judges it by its own rules, so a row can compile fine and still be a
+ * compile_error (any error-SEVERITY diagnostic counts). Judging a slice by
+ * anything else is how #4764 got two wrong diagnoses and shipped a regression
+ * that only a before/after run of the whole slice caught.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { runTest262File } from "../tests/test262-runner.js";
+
+const listFile = process.argv[2];
+if (!listFile) {
+  console.error("usage: run-test262-paths.mts <file-of-test262-relative-paths>");
+  process.exit(2);
+}
+const paths = readFileSync(listFile, "utf-8")
+  .split("\n")
+  .map((l) => l.trim())
+  .filter(Boolean);
+
+const counts: Record<string, number> = {};
+const failures: string[] = [];
+
+for (const rel of paths) {
+  const abs = resolve("test262/test", rel);
+  const category = rel.split("/").slice(0, 2).join("/");
+  let status = "error";
+  let reason = "";
+  try {
+    const r = await runTest262File(abs, category);
+    status = r.status;
+    reason = (r as { reason?: string; error?: string }).reason ?? (r as { error?: string }).error ?? "";
+  } catch (e) {
+    reason = String((e as Error)?.message ?? e).split("\n")[0] ?? "";
+  }
+  counts[status] = (counts[status] ?? 0) + 1;
+  if (status !== "pass" && status !== "skip") {
+    failures.push(`${status.padEnd(14)} ${rel}\n                 ${reason.split("\n")[0]?.slice(0, 160) ?? ""}`);
+  }
+}
+
+console.log("\n=== counts ===");
+console.log(counts);
+console.log(`\n=== ${failures.length} non-pass (excluding skip) ===`);
+for (const f of failures) console.log(f);

--- a/scripts/run-test262-row.mts
+++ b/scripts/run-test262-row.mts
@@ -57,7 +57,12 @@ async function main(): Promise<void> {
   console.log(`compile: success=${result.success} errors=${errors.length} warnings=${diags.length - errors.length}`);
   for (const d of diags.slice(0, 5)) console.log(`  ${d.severity} @${d.line ?? "?"}: ${d.message}`);
 
-  if (!result.binary?.length) {
+  // Mirror the runner's own criterion (tests/test262-runner.ts): an
+  // error-SEVERITY diagnostic is a compile_error row even when a binary came
+  // out. Judging by `binary.length` alone reports "pass" for a row the real
+  // runner still counts as failing — which is exactly how a downgrade that
+  // forgot the severity map looks green locally.
+  if (!result.success || errors.length > 0 || !result.binary?.length) {
     // Note: an empty binary with ZERO errors is itself a defect worth chasing —
     // the compile refused without saying why.
     console.log("RESULT: compile_error");

--- a/scripts/run-test262-row.mts
+++ b/scripts/run-test262-row.mts
@@ -1,0 +1,77 @@
+/**
+ * Reproduce ONE test262 row locally, without the test262 submodule.
+ *
+ *   npx tsx scripts/run-test262-row.mts built-ins/Array/prototype/includes/no-arg.js
+ *
+ * Why this exists: diagnosing a single conformance failure previously required
+ * either the ~GB test262 submodule checkout or a full sharded CI run, and
+ * hand-written repros are misleading — the runner compiles each test as
+ * TypeScript through `wrapTest`, so the shape that reaches codegen is not the
+ * shape you get by pasting the test body into a .ts file. Guessing at it sends
+ * you after the wrong bug: `includes/samevaluezero.js` looks like a wrong-answer
+ * row from its baseline error string, but reproduced faithfully it is a
+ * COMPILE_ERROR row (TypeScript rejects `[42].includes("42")` because its lib
+ * types searchElement as the element type, stricter than the language).
+ *
+ * The file is fetched from tc39/test262 at the pinned submodule SHA, wrapped by
+ * the runner's own `wrapTest`, compiled with the runner's options, then
+ * instantiated and run. Output is the row's verdict: compile_error / fail / pass.
+ *
+ * Requires network access to raw.githubusercontent.com. Pass --sha <sha> to
+ * pin a different revision (defaults to the submodule commit recorded below).
+ */
+import { compile } from "../src/index.js";
+import { parseMeta, wrapTest } from "../tests/test262-runner.js";
+
+/** The test262 submodule commit this repo pins (`git submodule status test262`). */
+const DEFAULT_SHA = "b363f29d3c43c626dc852744ad64a0b48a003693";
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const shaFlag = args.indexOf("--sha");
+  const sha = shaFlag >= 0 ? (args[shaFlag + 1] ?? DEFAULT_SHA) : DEFAULT_SHA;
+  const rel = args.find((a) => a.endsWith(".js"));
+  if (!rel) {
+    console.error("usage: run-test262-row.mts <path-under-test262/test> [--sha <sha>]");
+    process.exit(2);
+  }
+
+  const url = `https://raw.githubusercontent.com/tc39/test262/${sha}/test/${rel}`;
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    console.error(`fetch failed: ${resp.status} ${url}`);
+    process.exit(1);
+  }
+  const source = await resp.text();
+  const meta = parseMeta(source);
+  const wrapped = wrapTest(source, meta);
+
+  const result = (await compile(wrapped.source, { fileName: "test.ts", emitWat: false })) as {
+    success: boolean;
+    binary: Uint8Array;
+    errors?: { message: string; line?: number; severity: string }[];
+    importObject?: WebAssembly.Imports;
+  };
+  const diags = result.errors ?? [];
+  const errors = diags.filter((d) => d.severity === "error");
+  console.log(`compile: success=${result.success} errors=${errors.length} warnings=${diags.length - errors.length}`);
+  for (const d of diags.slice(0, 5)) console.log(`  ${d.severity} @${d.line ?? "?"}: ${d.message}`);
+
+  if (!result.binary?.length) {
+    // Note: an empty binary with ZERO errors is itself a defect worth chasing —
+    // the compile refused without saying why.
+    console.log("RESULT: compile_error");
+    return;
+  }
+
+  try {
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+    const exports = instance.exports as Record<string, () => void>;
+    (exports._start ?? exports.__module_init ?? (() => {}))();
+    console.log("RESULT: pass");
+  } catch (error) {
+    console.log(`RESULT: fail — ${String((error as Error)?.message ?? error).split("\n")[0]}`);
+  }
+}
+
+await main();

--- a/src/codegen/array-includes-search-value.ts
+++ b/src/codegen/array-includes-search-value.ts
@@ -1,7 +1,18 @@
 import type ts from "typescript";
-import type { CodegenContext, FunctionContext, ValType } from "../types.js";
+import type { ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { compileExpression } from "./expressions.js";
 import { emitUndefined } from "./expressions/late-imports.js";
+
+/**
+ * Can a value with this static `typeof` tag ever BE an element of a numeric
+ * (i32/f64) element vec? SameValueZero (§7.2.12) compares Type(x) first, so a
+ * search value of any other tag can never match — no matter what it coerces to.
+ *
+ * "number" and "mixed" are absent deliberately: both may match, so they take the
+ * ordinary compile-into-`valTmp` path.
+ */
+const NEVER_A_NUMBER = new Set(["string", "boolean", "bigint", "symbol", "undefined", "object", "function"]);
 
 /**
  * Emit the `searchElement` operand for `Array.prototype.includes` into `valTmp`.
@@ -28,8 +39,22 @@ export function emitIncludesSearchValue(
   valType: ValType,
   valTmp: number,
 ): boolean {
-  if (callExpr.arguments.length > 0) {
-    compileExpression(ctx, fctx, callExpr.arguments[0]!, valType);
+  const searchArg = callExpr.arguments[0];
+  if (searchArg !== undefined) {
+    // §7.2.12 SameValueZero compares Type(x) BEFORE value, so a search value
+    // that is statically not a number can never equal an element of a numeric
+    // vec. Compiling it into `valType` anyway would COERCE it — that is how
+    // `[42, 0, 1, NaN].includes("42")` answered true (test262
+    // `includes/samevaluezero.js`): "42" became f64 42 and matched. The
+    // argument is still evaluated (it may have side effects) and dropped.
+    if (
+      (valType.kind === "f64" || valType.kind === "i32") &&
+      NEVER_A_NUMBER.has(ctx.oracle.staticJsTypeOf(searchArg))
+    ) {
+      if (compileExpression(ctx, fctx, searchArg) !== null) fctx.body.push({ op: "drop" });
+      return true;
+    }
+    compileExpression(ctx, fctx, searchArg, valType);
     fctx.body.push({ op: "local.set", index: valTmp });
     return false;
   }

--- a/src/codegen/array-includes-search-value.ts
+++ b/src/codegen/array-includes-search-value.ts
@@ -1,0 +1,40 @@
+import type ts from "typescript";
+import type { CodegenContext, FunctionContext, ValType } from "../types.js";
+import { compileExpression } from "./expressions.js";
+import { emitUndefined } from "./expressions/late-imports.js";
+
+/**
+ * Emit the `searchElement` operand for `Array.prototype.includes` into `valTmp`.
+ *
+ * §23.1.3.16 takes `searchElement` as an ordinary parameter, so the zero-argument
+ * form is legal and searches for `undefined`. Rejecting it (as this used to) made
+ * the whole call compile to nothing and evaluate as `undefined` — exactly what
+ * test262's `includes/no-arg.js` and `includes/length-zero-returns-false.js`
+ * report as "Expected SameValue(«undefined», «false»)".
+ *
+ * `undefined` is representable only in an externref element vec, where
+ * SameValueZero can genuinely match a hole read as undefined (`[,].includes()` is
+ * true). In a numeric or ref element vec no stored element can BE undefined, so
+ * the caller must force the comparison false — this returns `true` to say so.
+ * That is load-bearing: leaving `valTmp` at its zero default would compare
+ * against f64 `0` and make `[0].includes()` wrongly answer true.
+ *
+ * @returns true when the scan comparison must be replaced by a constant 0.
+ */
+export function emitIncludesSearchValue(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  callExpr: ts.CallExpression,
+  valType: ValType,
+  valTmp: number,
+): boolean {
+  if (callExpr.arguments.length > 0) {
+    compileExpression(ctx, fctx, callExpr.arguments[0]!, valType);
+    fctx.body.push({ op: "local.set", index: valTmp });
+    return false;
+  }
+  if (valType.kind !== "externref") return true;
+  emitUndefined(ctx, fctx);
+  fctx.body.push({ op: "local.set", index: valTmp });
+  return false;
+}

--- a/src/codegen/array-includes-search-value.ts
+++ b/src/codegen/array-includes-search-value.ts
@@ -11,8 +11,18 @@ import { emitUndefined } from "./expressions/late-imports.js";
  *
  * "number" and "mixed" are absent deliberately: both may match, so they take the
  * ordinary compile-into-`valTmp` path.
+ *
+ * **"undefined" is absent, and that is load-bearing.** A HOLE in an f64 vec
+ * reads as NaN, and `undefined` coerces to f64 NaN too, so the existing
+ * both-NaN arm of the SameValueZero comparison is what makes
+ * `[, , , 42, , ].includes(undefined)` answer true (test262 `includes/sparse.js`,
+ * §23.1.3.16 step 7a — holes are read with Get, which returns undefined).
+ * Listing "undefined" here forces that comparison false and breaks the row.
+ * The encoding is imprecise in the other direction — `[NaN].includes(undefined)`
+ * wrongly answers true — but that is pre-existing, orthogonal, and not what this
+ * predicate is for.
  */
-const NEVER_A_NUMBER = new Set(["string", "boolean", "bigint", "symbol", "undefined", "object", "function"]);
+const NEVER_A_NUMBER = new Set(["string", "boolean", "bigint", "symbol", "object", "function"]);
 
 /**
  * Emit the `searchElement` operand for `Array.prototype.includes` into `valTmp`.
@@ -23,12 +33,14 @@ const NEVER_A_NUMBER = new Set(["string", "boolean", "bigint", "symbol", "undefi
  * test262's `includes/no-arg.js` and `includes/length-zero-returns-false.js`
  * report as "Expected SameValue(«undefined», «false»)".
  *
- * `undefined` is representable only in an externref element vec, where
- * SameValueZero can genuinely match a hole read as undefined (`[,].includes()` is
- * true). In a numeric or ref element vec no stored element can BE undefined, so
- * the caller must force the comparison false — this returns `true` to say so.
- * That is load-bearing: leaving `valTmp` at its zero default would compare
- * against f64 `0` and make `[0].includes()` wrongly answer true.
+ * The absent argument is emitted as whatever an explicit `undefined` would
+ * produce for this element type, so the two spellings cannot disagree: the
+ * externref vec gets a real `undefined` (SameValueZero matches a hole read as
+ * undefined), and the f64 vec gets NaN (which matches a hole, per the note on
+ * NEVER_A_NUMBER above). Any other element type can hold no value that is
+ * `undefined`, so the caller must force the comparison false — this returns
+ * `true` to say so. That is load-bearing: leaving `valTmp` at its zero default
+ * would compare against `0` and make `[0].includes()` wrongly answer true.
  *
  * @returns true when the scan comparison must be replaced by a constant 0.
  */
@@ -58,8 +70,13 @@ export function emitIncludesSearchValue(
     fctx.body.push({ op: "local.set", index: valTmp });
     return false;
   }
-  if (valType.kind !== "externref") return true;
-  emitUndefined(ctx, fctx);
+  if (valType.kind === "externref") {
+    emitUndefined(ctx, fctx);
+  } else if (valType.kind === "f64") {
+    fctx.body.push({ op: "f64.const", value: Number.NaN });
+  } else {
+    return true;
+  }
   fctx.body.push({ op: "local.set", index: valTmp });
   return false;
 }

--- a/src/codegen/array-method-value.ts
+++ b/src/codegen/array-method-value.ts
@@ -1,0 +1,68 @@
+import ts from "typescript";
+import type { ValType } from "../ir/types.js";
+import { ARRAY_METHODS } from "./array-methods.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { compileExpression } from "./expressions.js";
+import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+
+/**
+ * (#4765 slice 1) `[].includes` read as a VALUE, not called.
+ *
+ * `arr.includes(x)` is inlined at the call site against the WasmGC vec, so the
+ * method never needs to exist as a value — and it didn't: `[].includes`
+ * evaluated to `null`, and `[].includes.call(obj, "a")` died with
+ * "Cannot read properties of null (reading 'call')". That is the whole failure
+ * mode of nine test262 `Array/prototype/includes` rows.
+ *
+ * The sibling spelling already worked: `Array.prototype.includes.call(obj, …)`
+ * resolves through the host `Array` global and runs the real generic algorithm
+ * (which is why the array-like rows written that way fail on their own merits —
+ * getter observation, 2^53 lengths — rather than on a null). So the gap is
+ * narrow: a vec-typed receiver in NON-CALL position has no route to the
+ * intrinsic. Hand it the same host function the working spelling gets, so
+ * `[].includes === Array.prototype.includes` and both run one algorithm.
+ *
+ * Modelled directly on the #2743b `vec[Symbol.iterator]` → `%Array.prototype.values%`
+ * intercept: host/gc lane only, receiver evaluated for effect then dropped,
+ * intrinsic fetched by a late import.
+ *
+ * **Host lane only, deliberately.** Standalone has no host `Array.prototype` to
+ * borrow, and a native answer needs the generic array-like algorithm that
+ * #4765's remaining slices build. Returning `undefined` here leaves standalone
+ * exactly as it was rather than inventing a second, diverging implementation.
+ */
+export function tryCompileArrayMethodValue(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.PropertyAccessExpression,
+): ValType | null | undefined {
+  if (ctx.standalone || ctx.wasi) return undefined;
+  if (ts.isPrivateIdentifier(expr.name)) return undefined;
+  const methodName = expr.name.text;
+  if (!ARRAY_METHODS.has(methodName)) return undefined;
+
+  // Call position keeps the inlined vec lowering — this must not divert
+  // `arr.includes(x)`, which is the hot path and byte-identical today.
+  const parent = expr.parent;
+  if (parent && ts.isCallExpression(parent) && parent.expression === expr) return undefined;
+
+  // Only a receiver the compiler knows to be an array. Anything else already
+  // has its own (host or dynamic) route to the property. Asked through the
+  // oracle (#1930), not the raw checker.
+  const recvFact = ctx.oracle.typeFactOf(expr.expression);
+  if (recvFact.kind !== "array" && recvFact.kind !== "tuple") return undefined;
+
+  const methodIdx = ensureLateImport(ctx, "__array_proto_method", [{ kind: "externref" }], [{ kind: "externref" }]);
+  if (methodIdx === undefined) return undefined;
+  addStringConstantGlobal(ctx, methodName);
+  flushLateImportShifts(ctx, fctx);
+
+  // The receiver may have side effects (`f().includes`), so evaluate it and
+  // drop — the intrinsic is shared, not per-receiver.
+  if (compileExpression(ctx, fctx, expr.expression) !== null) fctx.body.push({ op: "drop" });
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, methodName));
+  fctx.body.push({ op: "call", funcIdx: methodIdx });
+  return { kind: "externref" };
+}

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -64,6 +64,7 @@ import {
   registerEmitBoundsCheckedArrayGet,
   VOID_RESULT,
 } from "./shared.js";
+import { emitIncludesSearchValue } from "./array-includes-search-value.js";
 import { emitUndefined, ensureGetUndefined } from "./expressions/late-imports.js";
 import { ensureExternSameValueZeroHelper, ensureExternStrictEqHelper, undefinedExternInstrs } from "./any-helpers.js";
 import {
@@ -3135,11 +3136,6 @@ function compileArrayIncludes(
   arrTypeIdx: number,
   elemType: ValType,
 ): ValType | null {
-  if (callExpr.arguments.length < 1) {
-    reportError(ctx, callExpr, "includes requires 1 argument");
-    return null;
-  }
-
   const vecTmp = allocLocal(fctx, `__arr_inc_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const dataTmp = allocLocal(fctx, `__arr_inc_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const iTmp = allocLocal(fctx, `__arr_inc_i_${fctx.locals.length}`, { kind: "i32" });
@@ -3186,8 +3182,7 @@ function compileArrayIncludes(
   });
   fctx.body.push({ op: "local.set", index: effLenTmp });
 
-  compileExpression(ctx, fctx, callExpr.arguments[0]!, valType);
-  fctx.body.push({ op: "local.set", index: valTmp });
+  const incNeverMatches = emitIncludesSearchValue(ctx, fctx, callExpr, valType, valTmp);
 
   // fromIndex (optional 2nd arg, default 0)
   if (callExpr.arguments.length >= 2) {
@@ -3335,6 +3330,8 @@ function compileArrayIncludes(
       { op: eqOp },
     ];
   }
+
+  if (incNeverMatches) comparisonInstrs = [{ op: "i32.const", value: 0 }];
 
   const loopBody: Instr[] = [
     { op: "local.get", index: iTmp },

--- a/src/codegen/binary-ops-in.ts
+++ b/src/codegen/binary-ops-in.ts
@@ -429,7 +429,6 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
     const escapedReceiverRoute =
       !ctx.standalone &&
       !ctx.wasi &&
-      (rightWasm.kind === "ref" || rightWasm.kind === "ref_null") &&
       ts.isIdentifier(expr.right) &&
       identifierEscapesToCall(expr.right.getSourceFile(), expr.right.text);
     const has =

--- a/src/codegen/binary-ops-in.ts
+++ b/src/codegen/binary-ops-in.ts
@@ -29,6 +29,7 @@ import { emitInPresence } from "./closed-struct-presence.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, flushLateImportShifts } from "./shared.js";
 import { inRhsIsExclusivelyPrimitive } from "./binary-ops.js";
+import { identifierEscapesToCall } from "./in-escaped-receiver.js";
 import { identifierIsWrittenTo } from "./native-ordinary-instanceof.js"; // (#4484) reassigned-binding guard
 import { overlayRouteActive } from "./typed-lane-overlay-route.js"; // (#4222) overlay-aware index presence
 // (#4062 array bag / #4491 T9 Date+RegExp bag) a statically-known key may live in
@@ -420,7 +421,19 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
       ctx.standalone &&
       !hasExplicitNullObjectPrototype(ctx, expr.right) &&
       objectPrototypeInheritsInName(staticKey, inReceiverIsObjectShaped(rightWasm.kind));
-    const has = inheritsFromObjectPrototype || (!growableReceiver && (hasInStruct || tsTypeHasProperty));
+    // (#4765) Host lane: the receiver was handed to a callee the compiler
+    // cannot see through, so its compile-time struct shape is no longer a fact
+    // about this site — the callee may have DELETED the key and the field list
+    // does not shrink. Suppress the fold and take the `__extern_has` arm, which
+    // consults the delete tombstone. See `in-escaped-receiver.ts`.
+    const escapedReceiverRoute =
+      !ctx.standalone &&
+      !ctx.wasi &&
+      (rightWasm.kind === "ref" || rightWasm.kind === "ref_null") &&
+      ts.isIdentifier(expr.right) &&
+      identifierEscapesToCall(expr.right.getSourceFile(), expr.right.text);
+    const has =
+      inheritsFromObjectPrototype || (!growableReceiver && !escapedReceiverRoute && (hasInStruct || tsTypeHasProperty));
     // (#1444) When RHS is externref/anyref AND static analysis came up empty
     // (no struct field, no TS-typed prop), the answer is NOT reliably false
     // — the host object may carry dynamic keys (e.g. regex `result.groups`).
@@ -462,6 +475,7 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
         rightWasm.kind === "anyref" ||
         vecNamedKeyRoute ||
         reassignedReceiverRoute ||
+        escapedReceiverRoute ||
         fnctorProtoRoute)
     ) {
       const hasIdx = ensureLateImport(

--- a/src/codegen/in-escaped-receiver.ts
+++ b/src/codegen/in-escaped-receiver.ts
@@ -1,0 +1,58 @@
+import ts from "typescript";
+
+/**
+ * (#4765) Has `name` been handed to a call as an argument or as a `this`
+ * value anywhere in `file`?
+ *
+ * The `in` fold answers §7.3.12 from the receiver's COMPILE-TIME struct shape.
+ * That is sound only while the compiler owns the object's shape — and it stops
+ * owning it the moment the object is passed to a callee it cannot see through.
+ * The callee may delete a property, and the struct's field list does not shrink
+ * on delete, so the fold keeps reporting the key as present:
+ *
+ *   var a = { "9007199254740990": "y", length: 2 ** 53 - 1 };
+ *   Array.prototype.pop.call(a);          // host pop deletes the last index
+ *   "9007199254740990" in a               // folded true; spec says false
+ *
+ * `hasOwnProperty` was already correct here — it consults the delete tombstone
+ * (`_wasmStructDeletedKeys`). So does `__extern_has`. Only the fold disagreed,
+ * which is what the test262 "…is removed" family asserts across
+ * `Array.prototype.{pop,splice,unshift}`.
+ *
+ * Note the deletion comes from HOST code, not from a `delete` statement, so no
+ * "this module uses delete" signal can catch it — the receiver escaping is the
+ * only observable. Standalone already has an equivalent guard for its own
+ * growable-`$Object` receivers (`growableObjectLiteralVars`), but that set is
+ * populated by a shape-widening pass that does not run in the host lane, so the
+ * host lane needs this separate, value-independent question.
+ *
+ * Deliberately conservative and cheap, mirroring `identifierIsWrittenTo`
+ * (the #4484 D / #4515 guard in the same function, which scans the file for
+ * writes to the receiver binding for exactly the same "the static type is not a
+ * fact about this site" reason). Being wrong in the permissive direction only
+ * costs one `__extern_has` call on an `in` — never a wrong answer — whereas
+ * being wrong in the restrictive direction is the folded-`true` bug above.
+ */
+export function identifierEscapesToCall(file: ts.SourceFile, name: string): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
+      for (const arg of node.arguments ?? []) {
+        if (ts.isIdentifier(arg) && arg.text === name) {
+          found = true;
+          return;
+        }
+        // `f.call(a, …)` / `f.apply(a, …)` pass `a` as the `this` value — the
+        // shape of the call that actually reaches these test262 rows.
+        if (ts.isSpreadElement(arg) && ts.isIdentifier(arg.expression) && arg.expression.text === name) {
+          found = true;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return found;
+}

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -157,6 +157,7 @@ import {
   localGlobalIdx,
   recordInModuleInitFlagRead,
 } from "./registry/imports.js";
+import { tryCompileArrayMethodValue } from "./array-method-value.js";
 import { receiverIsRealmGlobalObject } from "./helpers/sloppy-this-global.js"; // (#4500 Slice A) realm-global receiver
 import { dvDetachedThrowInstrs, getOrRegisterDvWindowType } from "./dataview-native.js"; // (#2159/#38) DataView windowing; (#3173) detached TypeError
 import {
@@ -3679,6 +3680,12 @@ export function compilePropertyAccess(
   if (expr.questionDotToken) {
     return compileOptionalPropertyAccess(ctx, fctx, expr);
   }
+
+  // (#4765 slice 1) `[].includes` as a VALUE — the host intrinsic, so
+  // `[].includes.call(obj, …)` runs the generic algorithm instead of dying on a
+  // null. Non-call position and an array receiver only; see the module comment.
+  const arrayMethodValue = tryCompileArrayMethodValue(ctx, fctx, expr);
+  if (arrayMethodValue !== undefined) return arrayMethodValue;
 
   // Static field initializers can contain a folded direct eval. Its AST is
   // foreign, but `this.<name>` still denotes the surrounding class constructor

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -40,6 +40,7 @@ import { buildCompileExplanation } from "./compile-explain.js";
 import {
   findSmallestNodeAtPosition,
   isBindingPatternFalsePositive,
+  isArraySearchElementDiagnostic,
   isJsDefaultInferredParamFalsePositive,
 } from "./compiler/argument-diagnostics.js";
 import {
@@ -504,6 +505,17 @@ function isInOperatorOperandDiagnostic(diag: ts.Diagnostic): boolean {
   return false;
 }
 
+/** Warning when codegen handles the construct anyway — by diagnostic code, or by a
+ * node-shape predicate for a TypeScript typing stricter than the language it models.
+ * Shared by all three collection loops so single-source and multi-file cannot drift. */
+function diagnosticSeverity(diag: ts.Diagnostic, checker: ts.TypeChecker): "warning" | "error" {
+  return DOWNGRADE_DIAG_CODES.has(diag.code) ||
+    isGuardedNullablePrimitiveDiagnostic(diag, checker) ||
+    isArraySearchElementDiagnostic(diag)
+    ? "warning"
+    : "error";
+}
+
 function isHardTypeScriptDiagnostic(diag: ts.Diagnostic, checker?: ts.TypeChecker): boolean {
   if (diag.category !== 1 || !HARD_TS_DIAG_CODES.has(diag.code)) return false;
   if (checker && isBindingPatternFalsePositive(diag, checker)) return false;
@@ -511,6 +523,7 @@ function isHardTypeScriptDiagnostic(diag: ts.Diagnostic, checker?: ts.TypeChecke
   if (checker && isGuardedNullablePrimitiveDiagnostic(diag, checker)) return false;
   if (isProxyHandlerTrapDiagnostic(diag)) return false;
   if (isInOperatorOperandDiagnostic(diag)) return false;
+  if (isArraySearchElementDiagnostic(diag)) return false;
   return true;
 }
 
@@ -1630,10 +1643,7 @@ export function compileSourceSync(
       // user wrote rather than the rewritten text. A no-op when no rewrite fired
       // (identity map) — same result as the old direct lookup.
       const pos = remapDiagnosticPosition(diag, source, positionMap);
-      const severity =
-        DOWNGRADE_DIAG_CODES.has(diag.code) || isGuardedNullablePrimitiveDiagnostic(diag, ast.checker)
-          ? "warning"
-          : "error";
+      const severity = diagnosticSeverity(diag, ast.checker);
       // #1929 — flatten the full DiagnosticMessageChain (keeps the "because…"
       // elaboration) instead of only the head .messageText.
       let message = ts.flattenDiagnosticMessageText(diag.messageText, "\n");
@@ -1818,10 +1828,7 @@ export async function compileMultiSource(
   for (const diag of multiAst.diagnostics) {
     if (diag.category === 1 && isEntryDiag(diag)) {
       const pos = diag.file ? diag.file.getLineAndCharacterOfPosition(diag.start ?? 0) : { line: 0, character: 0 };
-      const severity =
-        DOWNGRADE_DIAG_CODES.has(diag.code) || isGuardedNullablePrimitiveDiagnostic(diag, multiAst.checker)
-          ? "warning"
-          : "error";
+      const severity = diagnosticSeverity(diag, multiAst.checker);
       errors.push({
         // #1929 — flatten the full DiagnosticMessageChain (keeps the "because…"
         // elaboration) and attribute the source file for multi-file compiles.
@@ -1950,10 +1957,7 @@ export async function compileFilesSource(entryPath: string, options: CompileOpti
   for (const diag of multiAst.diagnostics) {
     if (diag.category === 1) {
       const pos = diag.file ? diag.file.getLineAndCharacterOfPosition(diag.start ?? 0) : { line: 0, character: 0 };
-      const severity =
-        DOWNGRADE_DIAG_CODES.has(diag.code) || isGuardedNullablePrimitiveDiagnostic(diag, multiAst.checker)
-          ? "warning"
-          : "error";
+      const severity = diagnosticSeverity(diag, multiAst.checker);
       errors.push({
         // #1929 — flatten the full DiagnosticMessageChain (keeps the "because…"
         // elaboration) and attribute the source file for multi-file compiles.

--- a/src/compiler/argument-diagnostics.ts
+++ b/src/compiler/argument-diagnostics.ts
@@ -112,3 +112,44 @@ export function isJsDefaultInferredParamFalsePositive(diag: ts.Diagnostic, check
   if (!paramDecl?.initializer) return false;
   return !ts.getJSDocParameterTags(paramDecl).some((tag) => tag.typeExpression !== undefined);
 }
+
+/**
+ * (#5013) Detect a TS2345 raised on the `searchElement` argument of
+ * `Array.prototype.includes` / `indexOf` / `lastIndexOf`.
+ *
+ * These take an UNRESTRICTED value per spec — §23.1.3.16 compares it with
+ * SameValueZero, §23.1.3.17/18 with IsStrictlyEqual — and simply answer
+ * `false`/`-1` when nothing matches. TypeScript's lib types the parameter as the
+ * element type `T`, which is stricter than the language, so `[42].includes("42")`
+ * is a hard error and the whole program compiles to zero bytes. That is what the
+ * `built-ins/Array/prototype/includes/samevaluezero.js` family reports — as a
+ * COMPILE_ERROR row, not the wrong-answer row its baseline error string suggests.
+ *
+ * Downgrading alone would be a bug, not a fix: the codegen must also refuse to
+ * COERCE the mismatched search value into the element type (see
+ * `emitIncludesSearchValue`), or `"42"` becomes f64 42 and matches.
+ *
+ * Tightly scoped: only a 2345 whose node sits inside the FIRST argument of a
+ * call to one of those three method names. Mirrors the #2616 Proxy-handler-trap
+ * and #2741 `in`-operand downgrades.
+ */
+const ARRAY_SEARCH_METHODS = new Set(["includes", "indexOf", "lastIndexOf"]);
+
+export function isArraySearchElementDiagnostic(diag: ts.Diagnostic): boolean {
+  if (diag.code !== 2345) return false;
+  const file = diag.file;
+  if (!file || diag.start === undefined) return false;
+  let n = findSmallestNodeAtPosition(file, diag.start);
+  while (n) {
+    if (
+      ts.isCallExpression(n) &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      ARRAY_SEARCH_METHODS.has(n.expression.name.text)
+    ) {
+      const searchArg = n.arguments[0];
+      return searchArg !== undefined && diag.start >= searchArg.getStart(file) && diag.start < searchArg.getEnd();
+    }
+    n = n.parent;
+  }
+  return false;
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -11212,6 +11212,10 @@ assert._isSameValue = isSameValue;
       // what the conformance tests compare. Used by the vec computed-get when
       // the key is a `Symbol.iterator` (host-mode only).
       if (name === "__array_proto_values") return () => Array.prototype.values;
+      // (#4765 slice 1) `%Array.prototype.<m>%` — the value of a NON-CALL method
+      // read on a vec (`[].includes`), which used to read as null. Rationale and
+      // scope: `src/codegen/array-method-value.ts`.
+      if (name === "__array_proto_method") return (k: any) => (Array.prototype as any)[String(k)];
       if (name === "__extern_set")
         return (obj: any, key: any, val: any) => {
           // (#860) When a Wasm closure struct is stored as a property value

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7691,6 +7691,18 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
         const sc = _wasmStructProps.get(obj);
         return !!sc && key in sc;
       }
+      // (#4765) A DELETED key is absent for HasProperty too. `fieldNamesForHost()`
+      // below is the STATIC struct shape and does not shrink on delete, so
+      // `"k" in wrapped` stayed true after the host's own
+      // `Array.prototype.{pop,splice,unshift}` removed `k` via
+      // DeletePropertyOrThrow — the "…is removed" test262 family.
+      // `_wasmStructHasOwn` (hasOwnProperty) and the compiled read already
+      // consult this set; the proxy's `has` trap was the one that did not, and
+      // it is what an `in` on an externref-typed receiver reaches.
+      {
+        const tomb = _wasmStructDeletedKeys.get(obj);
+        if (tomb?.has(typeof key === "symbol" ? key : String(key))) return false;
+      }
       if (safeGetField(key) !== undefined) return true;
       const sc = _wasmStructProps.get(obj);
       if (sc && key in sc) return true;

--- a/tests/equivalence/array-includes-no-arg.test.ts
+++ b/tests/equivalence/array-includes-no-arg.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+// §23.1.3.16 takes `searchElement` as an ordinary parameter, so `includes()`
+// with no argument searches for `undefined`. The compiler used to reject the
+// zero-argument form outright ("includes requires 1 argument"), which made the
+// whole call evaluate as `undefined` — test262's
+// built-ins/Array/prototype/includes/no-arg.js and
+// .../length-zero-returns-false.js both report it as
+// "Expected SameValue(«undefined», «false»)".
+//
+// The numeric cases are the ones that regress silently if the search value is
+// left to its zero default: `[0].includes()` would compare against f64 0 and
+// answer true.
+describe("Array.prototype.includes with no argument (ES2016)", () => {
+  it("is false for a numeric array containing 0", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [0, 1, 2];
+        return arr.includes() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("is false for an empty array", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [];
+        return arr.includes() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("is false for a string array", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: string[] = ["a", "b"];
+        return arr.includes() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("is true when an element is undefined", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: any[] = [1, undefined, 3];
+        return arr.includes() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("leaves the one-argument form unchanged", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [0, 1, 2];
+        return (arr.includes(1) ? 2 : 0) + (arr.includes(9) ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});

--- a/tests/equivalence/array-includes-no-arg.test.ts
+++ b/tests/equivalence/array-includes-no-arg.test.ts
@@ -196,3 +196,47 @@ describe("Array.prototype methods read as values (host lane)", () => {
     );
   });
 });
+
+// (#4765 slice 2) `in` answers §7.3.12 from the receiver's compile-time struct
+// shape. That is sound only while the compiler owns the shape — and it stops
+// owning it once the object is handed to a callee it cannot see through, which
+// may delete a key. The field list does not shrink on delete, so the fold kept
+// reporting deleted keys as present. `hasOwnProperty` was always correct here
+// (it consults the tombstone), which is what made the disagreement visible.
+describe("`in` on a receiver that escaped to a host call", () => {
+  it("reports a host-deleted key as absent", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var a: any = { 0: "x", 1: "y", length: 2 };
+        Array.prototype.pop.call(a);
+        return (("1" in a) ? 4 : 0) + (("0" in a) ? 2 : 0) + (a.length === 1 ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("agrees with hasOwnProperty after the deletion", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var a: any = { 0: "x", 1: "y", length: 2 };
+        Array.prototype.pop.call(a);
+        var inSays: boolean = "1" in a;
+        var ownSays: boolean = Object.prototype.hasOwnProperty.call(a, "1");
+        return inSays === ownSays ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("still answers present keys correctly on an escaped receiver", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var a: any = { p: 1, q: 2 };
+        function touch(o: any): number { return 0; }
+        touch(a);
+        return (("p" in a) ? 4 : 0) + (("q" in a) ? 2 : 0) + (("zz" in a) ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});

--- a/tests/equivalence/array-includes-no-arg.test.ts
+++ b/tests/equivalence/array-includes-no-arg.test.ts
@@ -63,3 +63,61 @@ describe("Array.prototype.includes with no argument (ES2016)", () => {
     );
   });
 });
+
+// §7.2.12 SameValueZero compares Type(x) before value, so a non-number search
+// value can never match an element of a numeric array. TypeScript types the
+// parameter as the element type, which is stricter than the language — these
+// used to be hard TS2345s that compiled the whole program to zero bytes
+// (test262 `includes/samevaluezero.js` is a COMPILE_ERROR row for exactly
+// this). Coercing the value instead would be worse than refusing: `"42"` would
+// become f64 42 and wrongly match.
+//
+// Known hole: none of these may be written `arr.includes("42" as any)`. The
+// refusal is driven by the argument's STATIC tag, so `as any` erases it to
+// "mixed" and the old coercing path runs — `[42].includes("42" as any)` still
+// answers true. Closing that needs a tagged runtime comparison, not a static
+// one; test262 never writes the annotation, so no conformance row depends on it.
+describe("Array.prototype.includes with a non-numeric search value", () => {
+  it("is false for a numeric string that would coerce to a member", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [42, 0, 1];
+        return arr.includes("42") ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("is false for booleans that would coerce to 0 and 1", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [0, 1];
+        return (arr.includes(true) ? 2 : 0) + (arr.includes(false) ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("is false for null, which would coerce to 0", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [0, 1, 2];
+        return arr.includes(null) ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("still evaluates the search argument for its side effects", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [1, 2];
+        var calls: number = 0;
+        function probe(): string { calls = calls + 1; return "1"; }
+        var found: boolean = arr.includes(probe());
+        return (found ? 10 : 0) + calls;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});

--- a/tests/equivalence/array-includes-no-arg.test.ts
+++ b/tests/equivalence/array-includes-no-arg.test.ts
@@ -240,3 +240,37 @@ describe("`in` on a receiver that escaped to a host call", () => {
     );
   });
 });
+
+// (#4765 slice 2b) The other half of the escape-aware `in` fix. Suppressing the
+// fold routes the question to `__extern_has`, which for an externref-typed
+// receiver lands on the host wrapper's `has` trap — and that trap read the
+// STATIC struct shape, which does not shrink on delete. So `in` still answered
+// true for a key the host had removed, while `hasOwnProperty` (which consults
+// the tombstone) said false. Both halves are needed: the fold suppression alone
+// changes nothing, and the trap guard alone is never reached.
+describe("`in` agrees with hasOwnProperty after a host deletion", () => {
+  it("reports a key removed by a throwing-getter unshift as absent", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        function Stop() {}
+        var a: any = { get "1"() { throw new Stop(); }, "2": "two", length: 3 };
+        try { Array.prototype.unshift.call(a, null); } catch (e) {}
+        var inSays: boolean = "2" in a;
+        var ownSays: boolean = Object.prototype.hasOwnProperty.call(a, "2");
+        return (inSays === ownSays ? 2 : 0) + (inSays ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("keeps reporting keys the host did not touch", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var a: any = { "0": "zero", "1": "one", length: 2 };
+        Array.prototype.pop.call(a);
+        return (("0" in a) ? 2 : 0) + (("1" in a) ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});

--- a/tests/equivalence/array-includes-no-arg.test.ts
+++ b/tests/equivalence/array-includes-no-arg.test.ts
@@ -53,6 +53,25 @@ describe("Array.prototype.includes with no argument (ES2016)", () => {
     );
   });
 
+  // §23.1.3.16 step 7a reads each index with Get, which returns `undefined` for
+  // a hole — so a sparse array containing only holes and numbers still includes
+  // `undefined`. In an f64 vec a hole reads as NaN and `undefined` coerces to
+  // NaN, so the both-NaN arm of the SameValueZero comparison is what carries
+  // this. Forcing the comparison false for a statically-`undefined` search value
+  // broke it (test262 `includes/sparse.js` regressed from pass to fail); this
+  // pins both spellings — explicit `undefined` and the absent argument.
+  it("is true for a hole in a numeric sparse array", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        // No annotation: \`number[]\` would make the holes a hard TS2322, and
+        // test262 is plain JS with no annotation to begin with.
+        var arr = [, , , 42, , ];
+        return (arr.includes(undefined) ? 2 : 0) + (arr.includes() ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
   it("leaves the one-argument form unchanged", async () => {
     await assertEquivalent(
       `export function test(): number {

--- a/tests/equivalence/array-includes-no-arg.test.ts
+++ b/tests/equivalence/array-includes-no-arg.test.ts
@@ -140,3 +140,59 @@ describe("Array.prototype.includes with a non-numeric search value", () => {
     );
   });
 });
+
+// (#4765 slice 1) An `Array.prototype` method read as a VALUE. `arr.m(x)` is
+// inlined against the WasmGC vec, so the method never needed to exist as a
+// value — and it didn't: `[].includes` read as `null`, so
+// `[].includes.call(obj, "a")` died with "Cannot read properties of null
+// (reading 'call')". The sibling spelling `Array.prototype.includes.call(obj, …)`
+// already worked, which is why the gap stayed invisible.
+describe("Array.prototype methods read as values (host lane)", () => {
+  it("is callable through .call on an array-like object", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var obj: any = { length: 3, 0: "a", 1: "b", 2: "c" };
+        // No \`as any\` on the receiver: the intercept keys on the STATIC array
+        // fact, and a cast erases it. test262 is plain JS, so this is the shape
+        // that matters.
+        var arr: string[] = [];
+        var found: any = arr.includes.call(obj, "b");
+        var missing: any = arr.includes.call(obj, "z");
+        return (found ? 2 : 0) + (missing ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("has the same identity as the Array.prototype spelling", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: string[] = [];
+        return (arr.includes as any) === (Array.prototype as any).includes ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("leaves the inlined call path alone", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [4, 5, 6];
+        return (arr.includes(5) ? 2 : 0) + (arr.includes(9) ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("evaluates a side-effecting receiver exactly once", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var calls: number = 0;
+        function mk(): number[] { calls = calls + 1; return [1, 2]; }
+        var f: any = mk().includes;
+        return (f ? 10 : 0) + calls;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
Raises ES2016 test262 conformance from **102/124 to 113/124** in-scope. Every number below comes from running all 124 in-scope files before and after with `scripts/run-test262-paths.mts` (added here).

Closes [#4764](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4764-array-includes-search-value-spec-shape). Advances [#4765](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4765-array-prototype-method-values-generic-array-like) (slices 1, 2, 2b). Files [#4766](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4766-intl-supportedvaluesof-datetimeformat-options).

## Four fixes

| | ES2016 |
| --- | --- |
| 1. `includes` zero-arg form + non-numeric search values | 102 → 104 |
| 2. `Array.prototype` methods reify as values on a vec receiver | 104 → 109 |
| 3. Escape-aware `in` | 109 → 113 |
| 4. Host-wrapper `has` trap consults the delete tombstone | 113 (correctness, 0 rows) |

**1 — `includes` search value.** §23.1.3.16 takes `searchElement` as an ordinary parameter, so `arr.includes()` is legal and searches for `undefined`; the compiler rejected it outright. Separately, TypeScript types the parameter as the element type `T` — stricter than the language — so `[42,0,1,NaN].includes("42")` was six TS2345s and compiled to zero bytes. `isArraySearchElementDiagnostic` makes that non-hard *and* downgrades it to a warning (the runner counts any error-severity diagnostic as `compile_error` even when a binary came out), while `emitIncludesSearchValue` refuses to *coerce* a statically-non-numeric value into a numeric vec — without which `"42"` becomes f64 42 and the row flips from compile-error to a wrong answer.

**2 — method values.** `[].includes` read as `null`, so `[].includes.call(obj, "a")` died with "Cannot read properties of null". The sibling spelling `Array.prototype.includes.call(…)` already worked (72 uses vs 40 in these directories), which is why the gap stayed invisible — the generic array-like algorithm was never the blocker for this tranche, only a route from a vec receiver in non-call position to the intrinsic.

**3 — escape-aware `in`.** `in` answers §7.3.12 from the receiver's compile-time struct shape, which is sound only while the compiler owns that shape. A host callee can delete a key and the field list does not shrink, so `"…" in arrayLike` stayed true after `Array.prototype.pop.call` removed it.

**4 — the `has` trap.** Suppressing the fold routes the question to `__extern_has`, which for an externref receiver lands on the host wrapper's `has` trap — and that trap read the static shape without consulting the tombstone. Both halves are needed; each measures as a no-op alone.

## A regression this PR introduced and then fixed (`83f1cc31`)

The first cut listed `"undefined"` in `NEVER_A_NUMBER`, flipping `includes/sparse.js` from **pass to fail**: holes are read with `Get`, so `[, , , 42, , ].includes(undefined)` is `true`. Caught only by running the whole edition set before and after — every targeted row still passed. An equivalence case now pins both spellings.

## Verification

19 equivalence cases in `tests/equivalence/array-includes-no-arg.test.ts`, plus 46 existing array cases and 28 in-operator/delete/object cases. All five source-ratchet gates green; `pnpm run typecheck` clean.

`tests/equivalence/delete-sentinel.test.ts` → "delete string property makes it undefined" fails on this branch **and identically on `origin/main`** (A/B verified) — pre-existing, not from this change.

## Remaining ES2016 gap (11 rows), all reproduced and recorded in #4765

1 proxy escape-gate policy flip (measured +18/−1 across its 450 affected files, owned by #4931 — deliberately not flipped here) · 1 `getOwnPropertySymbols` codegen fold · 2 `reverse` on proxy/throwing accessor · 2 `fromIndex` observation order · 1 `ToLength` write-back · 1 sparse write at 2^53 · 1 `splice` species construction · 3 unrelated singletons.

#4765 also records seven attempted fixes that measured as no-ops and were reverted rather than shipped, so they are not retried.

## Known limitations

- **`as any` erases the static tag** — `[42].includes("42" as any)` is `"mixed"` and still coerces. Needs a tagged runtime comparison; no test262 row depends on it.
- **Standalone is untouched** by fixes 2–4 — it has no host `Array.prototype` to borrow, and a native answer needs the generic array-like algorithm in #4765's later slices.
- **`[NaN].includes(undefined)` wrongly answers `true`** — the f64 hole/undefined encoding is imprecise in that direction. Pre-existing and orthogonal.