### PR TITLE
fix(es5): preserve sparse vectors and arguments length semantics

### DIFF
--- a/src/codegen/array-filter-spec-access.ts
+++ b/src/codegen/array-filter-spec-access.ts
@@ -128,13 +128,6 @@ export function overlayFilterAccess(
   if (!overlayRouteActive(ctx)) return null;
   const anyValueElem = isAnyValue(elemType, ctx);
   if (elemType.kind !== "f64" && elemType.kind !== "externref" && !anyValueElem) return null;
-  // (#2001) A module with array-literal elisions keeps the `$Hole` dense route:
-  // `__extern_has_idx`'s vec arm answers on `i < length` alone, so it would
-  // report a `$Hole` slot as PRESENT and leak the sentinel through
-  // `__extern_get_idx`. Holes and accessor descriptors together are rare; the
-  // dense route is the conservative answer for that intersection.
-  if (ctx.usesArrayHoles && (elemType.kind === "externref" || anyValueElem)) return null;
-
   const hasIdxFn = ensureLateImport(
     ctx,
     "__extern_has_idx",

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -359,7 +359,7 @@ import { fillErrorPropHelpers } from "./error-props.js"; // (#4098) native Error
 import { fillVecPropHelpers } from "./vec-props.js"; // (#3537) array ($Vec) expando side table
 import { fillProtoIndexStore } from "./proto-index-store.js"; // (#4160) prototype-index companions
 import { fillHoleyArrayHasIdxArm } from "./holey-array-presence.js"; // (#4222) nominal sparse carrier
-import { fillF64HoleHasIdxArms } from "./vec-f64-hole-presence.js"; // (#4491 T11) f64 absence marker
+import { fillSparseHoleHasIdxArms } from "./vec-externref-hole-presence.js"; // (#4491/#2001) sparse absence markers
 import { finalizeFunctionPoisonPillCalls } from "./function-poison-pill.js";
 import { fillDataViewConstructProtoArm, fillTaDynViewMopArms } from "./ta-dyn-mop.js"; // (#3177/#3371) native view prototype arms
 import { fillObjVecReflectionHelpers } from "./objvec-array-proto.js"; // (#3666) RegExp indices Array reflection
@@ -5935,7 +5935,7 @@ export function generateModule(
     // preamble shape) and after `fillProtoIndexStore`; it prepends at body[0]
     // and only ever RETURNS 0 for a slot that literally holds the marker, so
     // taking the front slot cannot shadow another receiver's answer.
-    fillF64HoleHasIdxArms(ctx);
+    fillSparseHoleHasIdxArms(ctx);
     // (#4446) Native concat preserves absent source indices in `$ObjVec` via
     // the shared `$Hole` marker. Patch its dynamic readers and add the sparse
     // physical-backing HasProperty guard after every competing vec fill.
@@ -9595,7 +9595,7 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
     // preamble shape) and after `fillProtoIndexStore`; it prepends at body[0]
     // and only ever RETURNS 0 for a slot that literally holds the marker, so
     // taking the front slot cannot shadow another receiver's answer.
-    fillF64HoleHasIdxArms(ctx);
+    fillSparseHoleHasIdxArms(ctx);
     // (#4446) Multi-source parity for concat's `$Hole`-aware ObjVec readers
     // and sparse-tail HasProperty guard.
     fillConcatNativeHoleArms(ctx);

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -5,7 +5,6 @@
  * Extracted from expressions.ts to keep concerns separated.
  * Contains: coerceType, pushDefaultValue, defaultValueInstrs, coercionInstrs.
  */
-
 import type { ArrayTypeDef, Instr, StructTypeDef, TypeDef, ValType, WasmFunction } from "../ir/types.js";
 import { coercionPlan } from "./coercion-plan.js";
 import { recordVecFromExternMaterializer } from "./compiler-support-abi.js";
@@ -24,6 +23,7 @@ import { symbolBoundaryCoercionInstrs } from "./symbol-field-carrier.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
+import { f64HoleToExternrefInstrs } from "./vec-f64-hole-coercion.js";
 import {
   elemGetOp,
   ensureExternrefToStringProvider,
@@ -2634,7 +2634,7 @@ export function coerceType(
       // and the standalone any-box tag-1 recovery (any-helpers.ts) — which box
       // a value read from a slot that genuinely holds `undefined`, never a
       // fresh arithmetic result.
-      fctx.body.push({ op: "call", funcIdx });
+      fctx.body.push(...f64HoleToExternrefInstrs(ctx, fctx, [{ op: "call", funcIdx }]));
       return;
     }
     // Fallback: drop f64 and push null externref

--- a/src/codegen/vec-externref-hole-presence.ts
+++ b/src/codegen/vec-externref-hole-presence.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Standalone presence bridge for externref-element vectors.
+ *
+ * A sparse numeric literal may first be emitted as an f64 vector and then be
+ * widened to the canonical externref carrier at an opaque boundary.  The
+ * conversion preserves the private `$Hole` marker; this finalize-time arm
+ * makes `HasProperty` treat that marker as an absent own index while retaining
+ * an accessor stored in the descriptor overlay as present.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { undefinedExternInstrs } from "./any-helpers.js";
+import { definedFuncAt } from "./func-space.js";
+import { holeTestInstrs } from "./array-holes.js";
+import { protoIndexGetIdxMissInstrs, protoIndexHasIdxInstrs } from "./proto-index-store.js";
+import { getArrTypeIdxFromVec } from "./registry/types.js";
+import { fillF64HoleHasIdxArms } from "./vec-f64-hole-presence.js";
+import { holeCompanionNoOwnDescriptor } from "./vec-hole-companion.js";
+import { walkChildren } from "./walk-instructions.js";
+
+/**
+ * Add the externref `$Hole` presence arm to `__extern_has_idx`.
+ *
+ * A companion entry takes precedence over the marker: an own accessor may
+ * deliberately leave the backing slot as `$Hole` while still making the index
+ * present.  A marker with no own descriptor continues through the numeric
+ * prototype store, exactly as an ordinary `HasProperty` miss should.
+ */
+export function fillExternrefHoleHasIdxArms(ctx: CodegenContext): void {
+  if (!ctx.standalone || !ctx.usesArrayHoles) return;
+  const funcIdx = ctx.funcMap.get("__extern_has_idx");
+  if (funcIdx === undefined) return;
+  const fn = definedFuncAt(ctx, funcIdx);
+  if (!fn || fn.locals.some((local) => local.name === "__externrefhole_has_any")) return;
+
+  const seen = new Set<number>();
+  const carriers: { typeIdx: number; arrTypeIdx: number }[] = [];
+  for (const vecTypeIdx of ctx.vecTypeMap.values()) {
+    if (seen.has(vecTypeIdx)) continue;
+    const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+    if (arrTypeIdx < 0) continue;
+    const arrDef = ctx.mod.types[arrTypeIdx];
+    if (!arrDef || arrDef.kind !== "array" || arrDef.element.kind !== "externref") continue;
+    seen.add(vecTypeIdx);
+    carriers.push({ typeIdx: vecTypeIdx, arrTypeIdx });
+  }
+  if (carriers.length === 0) return;
+  carriers.sort((a, b) => a.typeIdx - b.typeIdx);
+
+  const anyLocal = 2 + fn.locals.length;
+  const indexLocal = anyLocal + 1;
+  const compLocal = anyLocal + 2;
+  const types = ctx.objectRuntimeTypes;
+  const noOwnDescriptor = holeCompanionNoOwnDescriptor(ctx, anyLocal, compLocal);
+  fn.locals.push(
+    { name: "__externrefhole_has_any", type: { kind: "anyref" } },
+    { name: "__externrefhole_has_i", type: { kind: "i32" } },
+  );
+  if (noOwnDescriptor !== undefined) {
+    fn.locals.push({ name: "__externrefhole_has_comp", type: { kind: "ref_null", typeIdx: types!.objectTypeIdx } });
+  }
+
+  const holeMiss = (): Instr[] => protoIndexHasIdxInstrs(ctx, 1, 1) ?? [{ op: "i32.const", value: 0 }];
+  const arms: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: anyLocal },
+  ];
+  for (const { typeIdx, arrTypeIdx } of carriers) {
+    const inDomain: Instr[] = [
+      { op: "local.get", index: 1 },
+      { op: "i32.trunc_sat_f64_s" },
+      { op: "local.tee", index: indexLocal },
+      { op: "i32.const", value: 0 },
+      { op: "i32.ge_s" },
+      { op: "local.get", index: indexLocal },
+      { op: "local.get", index: anyLocal },
+      { op: "ref.cast", typeIdx },
+      { op: "struct.get", typeIdx, fieldIdx: 0 },
+      { op: "i32.lt_s" },
+      { op: "i32.and" },
+      { op: "local.get", index: indexLocal },
+      { op: "local.get", index: anyLocal },
+      { op: "ref.cast", typeIdx },
+      { op: "struct.get", typeIdx, fieldIdx: 1 },
+      { op: "array.len" },
+      { op: "i32.lt_s" },
+      { op: "i32.and" },
+    ];
+    arms.push(
+      { op: "local.get", index: anyLocal },
+      { op: "ref.test", typeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          ...inDomain,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: anyLocal },
+              { op: "ref.cast", typeIdx },
+              { op: "struct.get", typeIdx, fieldIdx: 1 },
+              { op: "local.get", index: indexLocal },
+              { op: "array.get", typeIdx: arrTypeIdx },
+              ...holeTestInstrs(ctx),
+              ...(noOwnDescriptor ?? [{ op: "i32.const", value: 1 }]),
+              { op: "i32.and" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [...holeMiss(), { op: "return" }],
+              },
+            ],
+          },
+        ],
+      },
+    );
+  }
+  fn.body.splice(0, 0, ...arms);
+}
+
+/**
+ * Translate a `$Hole` loaded from an externref vec at the dynamic read
+ * boundary. The overlay read prologue runs before the typed vec arms, so an
+ * own accessor/value remains authoritative; only a raw marker reaches this
+ * patch. Editing the existing `array.get` keeps the eager helper's import and
+ * late-index bookkeeping intact.
+ */
+export function fillExternrefHoleGetIdxArms(ctx: CodegenContext): void {
+  if (!ctx.standalone || !ctx.usesArrayHoles || !ctx.externGetIdxReserved) return;
+  const funcIdx = ctx.funcMap.get("__extern_get_idx");
+  if (funcIdx === undefined) return;
+  const fn = definedFuncAt(ctx, funcIdx);
+  if (!fn || fn.locals.some((local) => local.name === "__externrefhole_get_v")) return;
+
+  const arrTypes = new Set<number>();
+  for (const vecTypeIdx of ctx.vecTypeMap.values()) {
+    const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+    if (arrTypeIdx < 0) continue;
+    const arrDef = ctx.mod.types[arrTypeIdx];
+    if (arrDef?.kind === "array" && arrDef.element.kind === "externref") arrTypes.add(arrTypeIdx);
+  }
+  if (arrTypes.size === 0) return;
+
+  const hits: { body: Instr[]; index: number }[] = [];
+  const pending: Instr[][] = [fn.body];
+  while (pending.length > 0) {
+    const body = pending.pop()!;
+    for (let index = 0; index < body.length; index++) {
+      const instr = body[index]!;
+      if (instr.op === "array.get" && arrTypes.has(instr.typeIdx)) hits.push({ body, index });
+      walkChildren(instr, (child) => pending.push(child));
+    }
+  }
+  if (hits.length === 0) return;
+
+  const valueLocal = 2 + fn.locals.length;
+  fn.locals.push({ name: "__externrefhole_get_v", type: { kind: "externref" } });
+  const holeMiss = (): Instr[] =>
+    protoIndexGetIdxMissInstrs(ctx, 0, 1, 1) ?? undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
+  const byBody = new Map<Instr[], number[]>();
+  for (const hit of hits) {
+    const indexes = byBody.get(hit.body);
+    if (indexes === undefined) byBody.set(hit.body, [hit.index]);
+    else indexes.push(hit.index);
+  }
+  for (const [body, indexes] of byBody) {
+    indexes.sort((a, b) => b - a);
+    for (const index of indexes) {
+      body.splice(
+        index + 1,
+        0,
+        {
+          op: "local.tee",
+          index: valueLocal,
+        },
+        ...holeTestInstrs(ctx),
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: holeMiss(),
+          else: [{ op: "local.get", index: valueLocal }],
+        },
+      );
+    }
+  }
+}
+
+/** Fill both scalar-hole representations in their required finalize order. */
+export function fillSparseHoleHasIdxArms(ctx: CodegenContext): void {
+  fillF64HoleHasIdxArms(ctx);
+  fillExternrefHoleHasIdxArms(ctx);
+  fillExternrefHoleGetIdxArms(ctx);
+}

--- a/src/codegen/vec-f64-hole-coercion.ts
+++ b/src/codegen/vec-f64-hole-coercion.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Preserve the sparse f64 absence marker across a vec representation change. */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { allocTempLocal, releaseTempLocal } from "./context/locals.js";
+import { holeSentinelInstrs } from "./array-holes.js";
+import { f64HoleTestInstrs } from "./vec-f64-hole-presence.js";
+
+/**
+ * Wrap the ordinary f64→externref coercion so an internal sparse marker stays
+ * a marker. The caller has already built `normalCoercion`, keeping this helper
+ * independent from the general coercion engine and its import graph.
+ */
+export function f64HoleToExternrefInstrs(ctx: CodegenContext, fctx: FunctionContext, normalCoercion: Instr[]): Instr[] {
+  if (!ctx.usesArrayHoles) return normalCoercion;
+  const elemLocal = allocTempLocal(fctx, { kind: "f64" });
+  const instrs: Instr[] = [
+    { op: "local.tee", index: elemLocal },
+    ...f64HoleTestInstrs(),
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: holeSentinelInstrs(ctx),
+      else: [{ op: "local.get", index: elemLocal }, ...normalCoercion],
+    },
+  ];
+  releaseTempLocal(fctx, elemLocal);
+  return instrs;
+}

--- a/src/codegen/vec-f64-hole-presence.ts
+++ b/src/codegen/vec-f64-hole-presence.ts
@@ -58,6 +58,7 @@ import { definedFuncAt } from "./func-space.js";
 import { protoIndexHasIdxInstrs } from "./proto-index-store.js";
 import { getArrTypeIdxFromVec } from "./registry/types.js";
 import { HOLE_F64_BITS, UNDEF_F64_BITS } from "./value-tags.js";
+import { holeCompanionNoOwnDescriptor } from "./vec-hole-companion.js";
 
 /**
  * The single demand gate for the whole presence half. See the module header:
@@ -170,47 +171,18 @@ export function fillF64HoleHasIdxArms(ctx: CodegenContext): void {
   // the overlay's own prologue and the dense tail then answer as they always
   // did. `__vec_overlay_lookup` returns null for a vec with no companion —
   // the common case, one call.
-  const types = ctx.objectRuntimeTypes;
-  const lookupIdx = ctx.funcMap.get("__vec_overlay_lookup");
-  const objFindIdx = ctx.funcMap.get("__obj_find");
-  const numToStringIdx = ctx.funcMap.get("number_toString");
-  const overlayConsult =
-    types !== undefined && lookupIdx !== undefined && objFindIdx !== undefined && numToStringIdx !== undefined;
-
   const anyLocal = 2 + fn.locals.length;
   const indexLocal = anyLocal + 1;
   const compLocal = anyLocal + 2;
+  const types = ctx.objectRuntimeTypes;
+  const noOwnDescriptor = holeCompanionNoOwnDescriptor(ctx, anyLocal, compLocal);
   fn.locals.push(
     { name: "__f64hole_has_any", type: { kind: "anyref" } },
     { name: "__f64hole_has_i", type: { kind: "i32" } },
   );
-  if (overlayConsult) {
-    fn.locals.push({ name: "__f64hole_has_comp", type: { kind: "ref_null", typeIdx: types.objectTypeIdx } });
+  if (noOwnDescriptor !== undefined) {
+    fn.locals.push({ name: "__f64hole_has_comp", type: { kind: "ref_null", typeIdx: types!.objectTypeIdx } });
   }
-
-  /** `[] → [i32]` — 1 iff the companion has NO entry for this index. */
-  const noOwnDescriptor = (): Instr[] =>
-    overlayConsult
-      ? [
-          { op: "local.get", index: anyLocal },
-          { op: "call", funcIdx: lookupIdx },
-          { op: "local.tee", index: compLocal },
-          { op: "ref.is_null" },
-          {
-            op: "if",
-            blockType: { kind: "val", type: { kind: "i32" } },
-            then: [{ op: "i32.const", value: 1 }],
-            else: [
-              { op: "local.get", index: compLocal },
-              { op: "ref.as_non_null" },
-              { op: "local.get", index: 1 },
-              { op: "call", funcIdx: numToStringIdx },
-              { op: "call", funcIdx: objFindIdx },
-              { op: "ref.is_null" },
-            ],
-          },
-        ]
-      : [{ op: "i32.const", value: 1 }];
 
   // An own hole is NOT the end of HasProperty: §7.3.11 walks the prototype
   // chain, so `[0, , 2]` with `Array.prototype[1]` defined answers TRUE at
@@ -277,7 +249,7 @@ export function fillF64HoleHasIdxArms(ctx: CodegenContext): void {
               { op: "local.get", index: indexLocal },
               { op: "array.get", typeIdx: arrTypeIdx },
               ...f64HoleTestInstrs(),
-              ...noOwnDescriptor(),
+              ...(noOwnDescriptor ?? [{ op: "i32.const", value: 1 }]),
               { op: "i32.and" },
               {
                 op: "if",

--- a/src/codegen/vec-hole-companion.ts
+++ b/src/codegen/vec-hole-companion.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Shared companion-table check for sparse-vector marker arms. */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+
+/**
+ * Build `1` when a vector has no own descriptor for the current numeric key.
+ * `undefined` means the overlay runtime is not available and callers can use
+ * the constant-present fallback without allocating the companion local.
+ */
+export function holeCompanionNoOwnDescriptor(
+  ctx: CodegenContext,
+  anyLocal: number,
+  compLocal: number,
+): Instr[] | undefined {
+  const types = ctx.objectRuntimeTypes;
+  const lookupIdx = ctx.funcMap.get("__vec_overlay_lookup");
+  const objFindIdx = ctx.funcMap.get("__obj_find");
+  const numToStringIdx = ctx.funcMap.get("number_toString");
+  if (types === undefined || lookupIdx === undefined || objFindIdx === undefined || numToStringIdx === undefined) {
+    return undefined;
+  }
+  return [
+    { op: "local.get", index: anyLocal },
+    { op: "call", funcIdx: lookupIdx },
+    { op: "local.tee", index: compLocal },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "i32.const", value: 1 }],
+      else: [
+        { op: "local.get", index: compLocal },
+        { op: "ref.as_non_null" },
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: numToStringIdx },
+        { op: "call", funcIdx: objFindIdx },
+        { op: "ref.is_null" },
+      ],
+    },
+  ];
+}

--- a/src/codegen/vec-length-descriptor.ts
+++ b/src/codegen/vec-length-descriptor.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Shared descriptor instructions for the `$Vec` length overlay.
+ *
+ * Arrays and arguments objects share the physical vector representation, but
+ * their ordinary `length` properties have different default configurability.
+ * Keep the brand-sensitive seed and descriptor reads out of the overlay
+ * emitter so the length implementation remains within its subsystem budget.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { buildArgumentsBrandBit } from "./arguments-length-brand.js";
+
+const FLAG_CONFIGURABLE = 0x04;
+
+/** Seed flags for a length companion, preserving the arguments default. */
+export function buildLengthSeedFlags(ctx: CodegenContext, anyLocal: number, arrayFlags: number): Instr[] {
+  const argumentsTypeIdx = ctx.structMap.get("__arguments_vec");
+  if (argumentsTypeIdx === undefined) return [{ op: "f64.const", value: arrayFlags }];
+  return [
+    { op: "local.get", index: anyLocal },
+    { op: "ref.test", typeIdx: argumentsTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } },
+      then: [{ op: "f64.const", value: arrayFlags | FLAG_CONFIGURABLE }],
+      else: [{ op: "f64.const", value: arrayFlags }],
+    },
+  ];
+}
+
+/**
+ * Read a synthesized length's configurable bit. An existing companion entry
+ * wins over the brand default, while object integrity still clears the bit.
+ */
+export function buildVecLengthConfig(
+  argumentsTypeIdx: number | undefined,
+  entryLocal: number,
+  propEntryTypeIdx: number,
+  integrityBit: (bit: number) => Instr[],
+  integrityMask: number,
+): Instr[] {
+  return [
+    { op: "local.get", index: entryLocal },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [
+        ...buildArgumentsBrandBit(0, argumentsTypeIdx),
+        ...integrityBit(integrityMask),
+        { op: "i32.eqz" },
+        { op: "i32.and" },
+      ],
+      else: [
+        { op: "local.get", index: entryLocal },
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+        { op: "i32.const", value: FLAG_CONFIGURABLE },
+        { op: "i32.and" },
+        { op: "i32.const", value: 0 },
+        { op: "i32.ne" },
+        ...integrityBit(integrityMask),
+        { op: "i32.and" },
+      ],
+    },
+  ];
+}

--- a/src/codegen/vec-length-set.ts
+++ b/src/codegen/vec-length-set.ts
@@ -45,7 +45,13 @@
  */
 import type { Instr } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
-import { buildArgumentsLengthAbsentTail, buildArgumentsLengthReviveCall } from "./arguments-length-brand.js"; // (#4658)
+import {
+  ARGUMENTS_LENGTH_ABSENT_FIELD,
+  ARGUMENTS_LENGTH_OVERRIDE_FIELD,
+  ARGUMENTS_LENGTH_VALUE_FIELD,
+  buildArgumentsLengthAbsentTail,
+  buildArgumentsLengthReviveCall,
+} from "./arguments-length-brand.js"; // (#4658)
 import { nativeStringLiteralInstrs, stringConstantExternrefInstrs } from "./native-strings.js";
 import { NON_ARRAY_BYTE_VEC_ELEM_KINDS } from "./object-runtime.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
@@ -153,6 +159,44 @@ export function fillVecLengthDynamicArms(ctx: CodegenContext): void {
       { name: "__veclen_newdata", type: { kind: "anyref" } },
     );
 
+    // An arguments object's `length` is an ordinary, configurable data
+    // property (§10.4.4), not the Array-exotic index-domain length carried by
+    // the shared vec prefix.  In particular, propertyHelper writes the string
+    // "unlikelyValue" through `__extern_set` while checking writability.  The
+    // numeric ArraySetLength arm below must not feed that value through
+    // `__unbox_number` and silently leave the old physical length unchanged.
+    // Preserve the value in the nominal arguments subtype and let the dynamic
+    // read arm return it.  The static member-set dispatcher has the same
+    // fields/semantics; this is its runtime-keyed counterpart.
+    const argumentsTypeIdx = ctx.structMap.get("__arguments_vec");
+    const argumentsLengthWrite: Instr[] =
+      argumentsTypeIdx === undefined
+        ? []
+        : [
+            { op: "local.get", index: lAny },
+            { op: "ref.test", typeIdx: argumentsTypeIdx },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: lAny },
+                { op: "ref.cast", typeIdx: argumentsTypeIdx },
+                { op: "local.get", index: 2 },
+                { op: "struct.set", typeIdx: argumentsTypeIdx, fieldIdx: ARGUMENTS_LENGTH_VALUE_FIELD },
+                { op: "local.get", index: lAny },
+                { op: "ref.cast", typeIdx: argumentsTypeIdx },
+                { op: "i32.const", value: 1 },
+                { op: "struct.set", typeIdx: argumentsTypeIdx, fieldIdx: ARGUMENTS_LENGTH_OVERRIDE_FIELD },
+                { op: "local.get", index: lAny },
+                { op: "ref.cast", typeIdx: argumentsTypeIdx },
+                { op: "i32.const", value: 0 },
+                { op: "struct.set", typeIdx: argumentsTypeIdx, fieldIdx: ARGUMENTS_LENGTH_ABSENT_FIELD },
+                ...publishSuccess(),
+                { op: "return" },
+              ],
+            },
+          ];
+
     const growArms: Instr[] = [];
     for (const { typeIdx, arrTypeIdx } of carriers) {
       growArms.push(
@@ -215,6 +259,7 @@ export function fillVecLengthDynamicArms(ctx: CodegenContext): void {
             op: "if",
             blockType: { kind: "empty" },
             then: [
+              ...argumentsLengthWrite,
               // n = ToNumber(ToPrimitive(value)); valid: integral ∧ 0 ≤ n ≤ 2**32-1.
               { op: "local.get", index: 2 },
               ...toNumberInstrs,

--- a/src/codegen/vec-overlay-hole-bail.ts
+++ b/src/codegen/vec-overlay-hole-bail.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Build the sparse-hole guard used by the vector descriptor reader. */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { holeTestInstrs } from "./array-holes.js";
+import { f64HoleTestInstrs } from "./vec-f64-hole-presence.js";
+import type { OverlayCarrier } from "./vec-overlay-carriers.js";
+
+/**
+ * Return a fresh `__vec_gopd` miss arm for every active sparse carrier.
+ *
+ * The f64 and externref representations use different marker tests.  A
+ * descriptor in the overlay wins over either marker because an accessor can
+ * intentionally leave the physical slot untouched while creating an own
+ * property.
+ */
+export function buildVecGopdHoleBail(
+  ctx: CodegenContext,
+  carriers: readonly OverlayCarrier[],
+  inheritedSetHolePresenceActive: boolean,
+  bailMiss: () => Instr[],
+): Instr[] {
+  const f64HolePresenceActive = ctx.f64HoleMarkerEmitted === true;
+  if (!inheritedSetHolePresenceActive && !f64HolePresenceActive) return [];
+  const arms: Instr[] = [];
+  for (const carrier of carriers) {
+    const f64Carrier = carrier.kind === "f64";
+    if (!f64Carrier && carrier.kind !== "externref") continue;
+    if (f64Carrier && !f64HolePresenceActive) continue;
+    if (!f64Carrier && !inheritedSetHolePresenceActive) continue;
+    arms.push(
+      { op: "local.get", index: 2 },
+      { op: "ref.test", typeIdx: carrier.vecTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx: carrier.vecTypeIdx },
+          { op: "struct.get", typeIdx: carrier.vecTypeIdx, fieldIdx: 1 },
+          { op: "local.get", index: 4 },
+          { op: "array.get", typeIdx: carrier.arrTypeIdx },
+          ...(f64Carrier ? f64HoleTestInstrs() : holeTestInstrs(ctx)),
+          { op: "if", blockType: { kind: "empty" }, then: bailMiss() },
+        ],
+      },
+    );
+  }
+  return arms;
+}

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -104,11 +104,9 @@ import { canonicalNumericKeyGuard } from "./vec-index-domain.js"; // (#4434) ind
 import { SPARSE_INDEX_CEILING } from "./vec-sparse-index.js";
 import { growHighArrayIndexLength, markNumericLikeNamedKey } from "./vec-overlay-high-index.js";
 import { holeTestInstrs } from "./array-holes.js";
-import {
-  buildArgumentsBrandBit,
-  buildArgumentsLengthDeletedBail,
-  fillArgumentsLengthBrand,
-} from "./arguments-length-brand.js"; // (#4658)
+import { buildVecGopdHoleBail } from "./vec-overlay-hole-bail.js"; // (#4491 T11) sparse marker descriptor guard
+import { buildLengthSeedFlags, buildVecLengthConfig } from "./vec-length-descriptor.js";
+import { buildArgumentsLengthDeletedBail, fillArgumentsLengthBrand } from "./arguments-length-brand.js"; // (#4658)
 import {
   allowedCarriers,
   carrierDefaultInstrs,
@@ -957,7 +955,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               { op: "struct.get", typeIdx: vecBaseIdx, fieldIdx: 0 },
               { op: "f64.convert_i32_s" },
               { op: "call", funcIdx: s3.boxNumIdx },
-              { op: "f64.const", value: LENGTH_SEED_FLAGS },
+              ...buildLengthSeedFlags(ctx, l.any, LENGTH_SEED_FLAGS),
               { op: "call", funcIdx: dpValueIdx },
               { op: "drop" },
             ],
@@ -1838,36 +1836,9 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               },
             ];
       const bailMiss = (): Instr[] => [...missExtern(), { op: "return" }];
-      // A backed externref `$Hole` is storage, not an implicit array-element
-      // descriptor. `__vec_gopd` feeds both getOwnPropertyDescriptor and the
-      // vec hasOwn prologue, so screening it here keeps the public own view in
-      // step with the active #4504 write decision. This runs only after the
-      // index has passed the backed-length test below.
-      const holeBail = (): Instr[] => {
-        if (!inheritedSetHolePresenceActive) return [];
-        const arms: Instr[] = [];
-        for (const carrier of carriers) {
-          if (carrier.kind !== "externref") continue;
-          arms.push(
-            { op: "local.get", index: 2 },
-            { op: "ref.test", typeIdx: carrier.vecTypeIdx },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [
-                { op: "local.get", index: 2 },
-                { op: "ref.cast", typeIdx: carrier.vecTypeIdx },
-                { op: "struct.get", typeIdx: carrier.vecTypeIdx, fieldIdx: 1 },
-                { op: "local.get", index: 4 },
-                { op: "array.get", typeIdx: carrier.arrTypeIdx },
-                ...holeTestInstrs(ctx),
-                { op: "if", blockType: { kind: "empty" }, then: bailMiss() },
-              ],
-            },
-          );
-        }
-        return arms;
-      };
+      // A backed sparse marker is storage, not an implicit array-element
+      // descriptor. Keep the public own view aligned with the live overlay.
+      const holeBail = (): Instr[] => buildVecGopdHoleBail(ctx, carriers, inheritedSetHolePresenceActive, bailMiss);
       const setKey = (key: string, valueInstrs: Instr[]): Instr[] => [
         { op: "local.get", index: 6 },
         ...nativeStringLiteralInstrs(ctx, key),
@@ -1949,10 +1920,13 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               // `arguments` object (§10.4.4) — ANDed with §7.3.14 integrity, so
               // a sealed/frozen arguments object stays non-configurable.
               ...setKey("configurable", [
-                ...buildArgumentsBrandBit(0, ctx.structMap.get("__arguments_vec")),
-                ...integrityBit(OBJ_FLAG_SEALED | OBJ_FLAG_FROZEN),
-                { op: "i32.eqz" },
-                { op: "i32.and" },
+                ...buildVecLengthConfig(
+                  ctx.structMap.get("__arguments_vec"),
+                  7,
+                  propEntryTypeIdx,
+                  integrityBit,
+                  OBJ_FLAG_SEALED | OBJ_FLAG_FROZEN,
+                ),
                 { op: "call", funcIdx: boxBoolIdx },
               ]),
               { op: "local.get", index: 6 },

--- a/tests/es5-standalone-array-filter.test.ts
+++ b/tests/es5-standalone-array-filter.test.ts
@@ -54,7 +54,7 @@ async function bothLanes(src: string, expected: unknown): Promise<void> {
 }
 
 const FILTER_TEST262_ROOT = join(process.cwd(), "test262", "test", "built-ins", "Array", "prototype", "filter");
-const EXACT_ES5_FILTER_ROWS = ["15.4.4.20-5-7.js", "15.4.4.20-9-b-2.js", "15.4.4.20-9-b-15.js"] as const;
+const EXACT_ES5_FILTER_ROWS = ["15.4.4.20-9-b-5.js", "15.4.4.20-9-b-7.js", "15.4.4.20-9-b-11.js"] as const;
 
 describe.skipIf(!TEST262)("§15.4.4.20 exact ES5 standalone residual rows", () => {
   const previousEvalEngine = process.env.JS2WASM_EVAL_ENGINE;
@@ -234,6 +234,48 @@ describe("§15.4.4.20 filter — accessor indices installed by defineProperty", 
         "standalone",
       ),
     ).toBe(22);
+  });
+
+  it("preserves a sparse numeric hole across widening before a prototype add", async () => {
+    // An unannotated literal is widened to the externref carrier because its
+    // accessor makes filter's indexed reads dynamic.  The original f64 hole
+    // must remain an internal `$Hole`, so the callback sees the prototype
+    // accessor added while visiting index 0 rather than a boxed NaN value.
+    expect(
+      await run(
+        `var arr = [0, , 2];
+        Object.defineProperty(arr, "0", { get: function (): number {
+          Object.defineProperty(Array.prototype, "1", { get: function (): number { return 6.99; }, configurable: true });
+          return 0;
+        }, configurable: true });
+        export function test(): number {
+          var out = arr.filter(function (): boolean { return true; });
+          return out.length * 100 + (out[1] === 6.99 ? 1 : 0);
+        }`,
+        "standalone",
+      ),
+    ).toBe(301);
+  });
+
+  it("preserves a sparse numeric hole across widening before a prototype delete", async () => {
+    // The same carrier conversion must not turn the deleted prototype slot
+    // into an own value.  Once the callback removes Array.prototype[1], index
+    // 1 is absent and filter copies only indices 0 and 2.
+    expect(
+      await run(
+        `var arr = [0, , 2];
+        Object.defineProperty(arr, "0", { get: function (): number {
+          delete Array.prototype[1];
+          return 0;
+        }, configurable: true });
+        Array.prototype[1] = 1;
+        export function test(): number {
+          var out = arr.filter(function (): boolean { return true; });
+          return out.length * 10 + (out[1] === 2 ? 1 : 0);
+        }`,
+        "standalone",
+      ),
+    ).toBe(21);
   });
 });
 

--- a/tests/issue-4622.test.ts
+++ b/tests/issue-4622.test.ts
@@ -15,20 +15,29 @@
 // `.message` is `undefined`, which is why it read as a compiler crash rather
 // than a wrong answer).
 //
-// `__vec_gopd` cannot be fixed here: it is shared with real arrays and there is
-// no runtime brand separating an arguments vec from one (#4620 family B). So
-// the arm is SYNTACTIC — the compiler-materialized `arguments` local of this
-// function, a static `length` key — and DECLINES whenever the object is
-// reachable as a value (`Object.defineProperty(arguments, …)`, `Object.seal`,
-// `var esc = arguments`, `with`, direct `eval`), because those can legitimately
-// make `length` non-configurable and a wrong `true` is worse than no fold.
+// `__vec_gopd` is shared with real arrays, so the arguments-vs-array distinction
+// lives in a WasmGC subtype brand. The syntactic delete arm still declines when
+// the object can be reconfigured (`Object.defineProperty`, `Object.seal`, `with`,
+// direct `eval`); the generic runtime path then consults the branded descriptor.
+// That distinction matters for escaped and dynamic receivers: a fresh arguments
+// object's `length` remains configurable, so those deletes must return `true`.
 //
 // Every case runs in a MODULE, so the code is STRICT — which is the half where
 // the defect threw. The sloppy half (`false` instead of `true`) is covered by
 // the test262 rows themselves; `language/arguments-object/S10.6_A5_T3` runs in
 // both goals and flipped FAIL → PASS with this change.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_ROOT = join(__dirname, "..", "test262", "test");
+const EXACT_ARGUMENTS_ROWS = [
+  "language/arguments-object/10.6-6-2.js",
+  "language/arguments-object/10.6-7-1.js",
+] as const;
+const TEST262 = existsSync(join(TEST262_ROOT, EXACT_ARGUMENTS_ROWS[0]));
 
 async function runModule(src: string): Promise<number | string> {
   const r = await compile(src, {
@@ -65,6 +74,15 @@ ${body}
 /** `1` when the delete succeeded, `2` when it was refused, `9` on TypeError. */
 const deleteResult = (expr: string): string => fn(`      return (${expr}) ? 1 : 2;`);
 
+describe.skipIf(!TEST262)("§10.6 exact arguments-object residual rows", () => {
+  for (const file of EXACT_ARGUMENTS_ROWS) {
+    it(`passes the literal Test262 row ${file}`, async () => {
+      const result = await runTest262File(join(TEST262_ROOT, file), "language/arguments-object", 120_000, "standalone");
+      expect(result.status, result.error ?? file).toBe("pass");
+    }, 180_000);
+  }
+});
+
 describe("#4622 delete arguments.length no longer throws", () => {
   it("evaluates to true instead of throwing a TypeError (§10.4.4: length is configurable)", async () => {
     expect(await runModule(deleteResult("delete arguments.length"))).toBe(1);
@@ -92,13 +110,11 @@ describe("#4622 delete arguments.length no longer throws", () => {
   });
 });
 
-describe("#4622 the arm declines rather than answering wrongly", () => {
-  // Object.defineProperty / Object.seal can make `length` non-configurable, at
-  // which point §10.4.4's fresh-object attribute table no longer describes this
-  // object. Each of these passes `arguments` as a VALUE, which is the signal the
-  // guard keys on; the generic `__delete_property` path then keeps its own
-  // answer (a strict refusal ⇒ TypeError). The first two are also the
-  // SPEC-CORRECT answers, not merely conservative ones.
+describe("#4622 dynamic descriptor paths preserve the real arguments semantics", () => {
+  // Object.defineProperty / Object.seal can make `length` non-configurable. Each
+  // passes `arguments` as a VALUE, which is the signal the guard keys on; the
+  // generic `__delete_property` path then consults the descriptor and keeps the
+  // strict refusal (a TypeError).
   it("declines after Object.defineProperty(arguments, 'length', {configurable:false})", async () => {
     expect(
       await runModule(
@@ -117,22 +133,22 @@ describe("#4622 the arm declines rather than answering wrongly", () => {
     ).toBe(9);
   });
 
-  it("declines once the arguments object escapes into a variable", async () => {
+  it("allows delete after the arguments object escapes into a variable", async () => {
     expect(
       await runModule(
         fn(`      var esc = arguments;
       return (delete arguments.length) ? 1 : 2;`),
       ),
-    ).toBe(9);
+    ).toBe(1);
   });
 
-  it("declines for a dynamic key", async () => {
+  it("allows delete through a dynamic key while length is configurable", async () => {
     expect(
       await runModule(
         fn(`      var k = "length";
       return (delete arguments[k]) ? 1 : 2;`),
       ),
-    ).toBe(9);
+    ).toBe(1);
   });
 });
 
@@ -160,7 +176,28 @@ describe("#4622 neighbouring delete shapes are unchanged", () => {
   });
 });
 
-describe("#4622 measured residuals — the $Vec representation cannot express these", () => {
+describe("#4622 arguments length write controls", () => {
+  it("updates an escaped arguments object through the dynamic length path", async () => {
+    expect(
+      await runModule(
+        fn(`      var alias = arguments;
+      alias.length = 1;
+      return alias.length;`),
+      ),
+    ).toBe(1);
+  });
+
+  it("does not apply the arguments override to a real array", async () => {
+    expect(
+      await runModule(`
+    var arr = [1, 2];
+    arr.length = 1;
+    export function test() { return arr.length; }`),
+    ).toBe(1);
+  });
+});
+
+describe("#4622 remaining measured residual", () => {
   // The delete now REPORTS success, but the property SURVIVES: `arguments.length`
   // folds to the vec's length field and `hasOwnProperty` / `in` / the descriptor
   // all go through the shared vec helpers, none of which has anywhere to record
@@ -171,13 +208,9 @@ describe("#4622 measured residuals — the $Vec representation cannot express th
     expect(await runModule(fn(`      delete arguments.length;\n      return arguments.length;`))).toBe(-1);
   });
 
-  // `Object.getOwnPropertyDescriptor(arguments, "length").configurable` is
-  // `false` because `__vec_gopd` (vec-overlay.ts) answers with Array rules. This
-  // is what `language/arguments-object/10.6-6-2` and `10.6-7-1` assert, and both
-  // still fail. Splitting it needs a runtime brand distinguishing the arguments
-  // vec from an array — #4620's family-B finding. Owner: #4620 family B /
-  // the vec-overlay + gOPD lane.
-  it.fails("(#4620 family B) the length descriptor still reports configurable:false", async () => {
+  // The runtime brand now supplies the §10.4.4 default, while an existing
+  // companion entry preserves an explicit configurable:false override.
+  it("(#4620 family B) the fresh length descriptor reports configurable:true", async () => {
     expect(
       await runModule(
         fn(`      var d = Object.getOwnPropertyDescriptor(arguments, "length");
@@ -186,11 +219,11 @@ describe("#4622 measured residuals — the $Vec representation cannot express th
     ).toBe(1);
   });
 
-  // An ESCAPED arguments object (`var a = arguments; delete a.length`) is
-  // declined by the guard above — deliberately, since a syntactic arm cannot
-  // follow the value. #4620 recorded the same wall for `Array.isArray(arguments)`:
-  // it needs the runtime brand, not a wider syntactic net. Owner: #4620 family B.
-  it.fails("(#4620 family B) delete through an escaped alias is still refused", async () => {
+  // An ESCAPED arguments object (`var a = arguments; delete a.length`) uses the
+  // generic runtime path. Its fresh length is configurable, so the delete
+  // succeeds; the runtime brand makes this safe without widening the syntactic
+  // fast path. Owner: #4620 family B.
+  it("(#4620 family B) delete through an escaped alias succeeds", async () => {
     expect(
       await runModule(`
     function f() { return arguments; }


### PR DESCRIPTION
## Summary

- preserve sparse numeric holes when filter widens an f64 vector to externref
- route branded arguments `length` writes, descriptor overrides, and deletes through the correct companion state
- add exact Test262 residual coverage and focused array/arguments controls
- extract the new vector helpers so LOC and per-function budgets remain green

## Validation

- authoritative residual cluster: 5/5 (filter 3/3, arguments 2/2); pre-fix measurement on `0e65e238f` was 0/5
- `tests/es5-standalone-array-filter.test.ts`: 16/16
- `tests/issue-4622.test.ts`: 20/20
- `tests/es5-array-isarray-arguments.test.ts`: 3/3
- `tests/issue-4658.test.ts -t "root 2"`: 11/11
- numeric-local parity: 18/18
- typecheck, lint, format, host-import policy, LOC/function budgets, oracle ratchet, dead exports, coercion-site ratchet, and issue integrity passed

Closes #4622 — standalone: `delete arguments.length` crashes the compiler.