### PR TITLE
fix(dogfood): flush the upstream worker's report before exiting

### DIFF
--- a/plan/issues/4767-upstream-worker-stdout-pipe-truncation.md
+++ b/plan/issues/4767-upstream-worker-stdout-pipe-truncation.md
@@ -16,6 +16,8 @@ sprint: current
 related: [3995, 4756, 4898]
 files:
   - tests/dogfood/upstream-suite-compile-worker.mjs
+  - tests/dogfood/upstream-suite-worker-protocol.mjs
+  - tests/issue-4767.test.ts
 ---
 
 ## Problem
@@ -117,6 +119,23 @@ process.stdout.write(`${JSON.stringify(value)}\n`, () => {
 This preserves #4898's guarantee (the child still exits regardless of lingering
 handles) while making the result survive an arbitrarily large report.
 
+The emit path moves into `tests/dogfood/upstream-suite-worker-protocol.mjs` as
+`emitWorkerResult()` — it is transport, it belongs beside the rest of the worker
+protocol, and putting it there makes it directly testable without standing up a
+compile.
+
+## Repro
+
+`tests/issue-4767.test.ts` guards the transport rather than any one package:
+it spawns a child that emits an over-buffer payload through the real
+`emitWorkerResult`, reads it back over a real pipe, and requires it byte-for-byte.
+
+Confirmed to catch the original defect — with the pre-fix
+`writeFileSync` + immediate `process.exit()` restored, the large-report case
+fails with `SyntaxError: Unterminated string in JSON at position 146176`, while
+the small-report case still passes, which is exactly the size-dependence that
+made this look package-specific.
+
 ## Acceptance criteria
 
 - [x] `pnpm run dogfood:cookie-upstream-suite` reports **63740/63740**, with
@@ -126,6 +145,8 @@ handles) while making the result survive an arbitrarily large report.
 - [x] No `__JS2WASM_COMPILE_COMPLETE__` sentinel appears in any recorded
       `errors[].message`
 - [x] The three small cookie spec files stay at 30/30, 85/85 and 97/97
+- [x] `tests/issue-4767.test.ts` passes on the fix and fails on the pre-fix
+      emit path
 
 ## Notes
 

--- a/plan/issues/4767-upstream-worker-stdout-pipe-truncation.md
+++ b/plan/issues/4767-upstream-worker-stdout-pipe-truncation.md
@@ -1,0 +1,141 @@
+---
+id: 4767
+title: "Upstream-suite worker truncates reports >64 KB at the pipe buffer, wiping cookie from 63740/63740 to 212/63740"
+status: done
+created: 2026-08-26
+updated: 2026-08-26
+completed: 2026-08-26
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: dogfood, tooling
+goal: npm-library-support
+sprint: current
+related: [3995, 4756, 4898]
+files:
+  - tests/dogfood/upstream-suite-compile-worker.mjs
+---
+
+## Problem
+
+The `npm-compat` dashboard reported **cookie at 212 / 63740 (0.3 %)**, down from a
+clean **63740 / 63740**. The drop looked like a catastrophic compiler regression —
+63,528 newly failing tests in one package — but no compiled-cookie behaviour
+changed at all. The measurement harness lost the result.
+
+Every failing test lived in exactly one file:
+
+| file | native | Wasm (before fix) |
+| --- | --- | --- |
+| `src/parse-cookie.spec.ts` | 30/30 | 30/30 |
+| `src/parse-set-cookie.spec.ts` | 85/85 | 85/85 |
+| **`src/stringify-cookie.spec.ts`** | 63528/63528 | **0/63528** |
+| `src/stringify-set-cookie.spec.ts` | 97/97 | 97/97 |
+
+`212 = 30 + 85 + 97` — every other file passed completely. An all-or-nothing
+zero across a single file is the signature of a lost result, not of 63,528
+independent assertion failures.
+
+The recorded "compile error" for that file was the harness's own IPC sentinel
+leaking into the error channel:
+
+```json
+{ "file": "src/stringify-cookie.spec.ts", "success": false, "binaryBytes": 0,
+  "errors": [{ "message": "__JS2WASM_COMPILE_COMPLETE__:4855" }] }
+```
+
+## Root cause
+
+`emit()` in `tests/dogfood/upstream-suite-compile-worker.mjs` wrote the worker's
+single terminal JSON result and exited immediately:
+
+```js
+writeFileSync(process.stdout.fd, `${JSON.stringify(value)}\n`);
+process.exit(exitCode);
+```
+
+The parent (`runIsolatedCompile` in `upstream-suite-runner.mjs`) captures that
+stdout **through a pipe** (`spawn` with `stdio: ["ignore", "pipe", "pipe"]`). A
+pipe accepts only its buffer — 64 KB on Linux — before the remainder has to be
+drained asynchronously by the reader. `process.exit()` does not wait for that
+drain, so any report larger than the pipe buffer was cut off mid-document.
+
+`stringify-cookie.spec.ts` builds a ~63.5 K-case fuzz table (every BMP code
+point) and its report is **~508 KB**, so it was truncated to exactly the buffer
+size. The parent's `JSON.parse(stdout)` then threw, fell into its catch, and
+used `stderr.trim()` as the failure detail — and stderr held nothing but the
+`__JS2WASM_COMPILE_COMPLETE__` sentinel. With no result, all 63,528 tests in the
+file were scored as failures.
+
+Measured on the regressing commit, same worker, same input:
+
+| stdout destination | bytes delivered |
+| --- | --- |
+| file (`> out`) | 508,384 (complete) |
+| **pipe (`\| wc -c`)** — what `spawn` uses | **66,010** (truncated at ~64 KB) |
+
+The three small files each emit far less than 64 KB, complete in one synchronous
+write, and were never affected — which is why the failure looked package-specific
+rather than size-specific.
+
+### Provenance
+
+`git bisect --first-parent` over 111 mainline commits, zero skips, verifying the
+real harness result at each step:
+
+- first bad commit: **`89058479f`** — "Merge pull request #4898 from
+  ttraenkler/codex/npm-package-compile-once" (2026-08-26 02:47 UTC)
+- verified parent `6a5f67238`: `63528/63528 Wasm` ✅
+- verified `89058479f`: `0/63528 Wasm` ❌
+
+#4898 rewrote `emit()` from `process.stdout.write(...)` + `process.exitCode = 1`
+(a natural exit, which flushes) to `writeFileSync` + `process.exit()`. Its
+comment shows the intent — guarantee the disposable child cannot be held open by
+abandoned upstream timers, streams, or scheduler handles, turning a finished
+result into an outer worker timeout. That goal is sound; the flush was the
+casualty.
+
+**The committed artifact lags the code**, which is worth knowing when dating a
+regression from `npm-compat.json`: `npm-compat-refresh` measures for ~24 min and
+promotes through a PR, so the artifact landing on commit X reflects an older
+main. The artifact still read `63740/63740` at `766d91e88`, hours after the bug
+had actually landed. Bisect on observed behaviour, never on artifact timestamps.
+
+## Fix
+
+Keep the forced exit, but take it from the write callback so the payload is
+actually flushed first:
+
+```js
+process.stdout.write(`${JSON.stringify(value)}\n`, () => {
+  process.exit(exitCode);
+});
+```
+
+This preserves #4898's guarantee (the child still exits regardless of lingering
+handles) while making the result survive an arbitrarily large report.
+
+## Acceptance criteria
+
+- [x] `pnpm run dogfood:cookie-upstream-suite` reports **63740/63740**, with
+      `src/stringify-cookie.spec.ts` at `63528/63528 Wasm`
+- [x] The worker's ~508 KB report survives a pipe intact (508,384 bytes through
+      `| wc -c`, matching the file-redirect byte count)
+- [x] No `__JS2WASM_COMPILE_COMPLETE__` sentinel appears in any recorded
+      `errors[].message`
+- [x] The three small cookie spec files stay at 30/30, 85/85 and 97/97
+
+## Notes
+
+- The compiled cookie package was never broken. `compile()`, validation and the
+  21-op differential harness stayed green throughout; only the transport of the
+  result regressed.
+- Any upstream suite whose report crosses 64 KB was exposed to the same
+  truncation, so other packages' counts in `npm-compat.json` measured between
+  `89058479f` and this fix may be understated. The post-merge
+  `npm-compat-refresh` re-measures every package, so the artifact corrects
+  itself on the next cycle — no hand-editing of `npm-compat.json` is needed
+  (main is its sole writer).
+- Reported by the project lead from the dashboard, 2026-08-26.

--- a/tests/dogfood/upstream-suite-compile-worker.mjs
+++ b/tests/dogfood/upstream-suite-compile-worker.mjs
@@ -1,5 +1,5 @@
 import { performance } from "node:perf_hooks";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 
 import { compile, compileProject, instantiateLinkedProject } from "../../src/index.ts";
 import { buildCompiledImports, wrapExports } from "../../src/runtime.ts";
@@ -14,12 +14,22 @@ const generatedPath = process.argv[2];
 const mode = process.argv[3] ?? "project";
 
 function emit(value, exitCode = 0) {
-  // Every invocation of this worker produces exactly one terminal result.
-  // Write it synchronously before exiting so abandoned upstream timers,
-  // streams, or scheduler handles cannot keep the disposable child alive and
-  // turn a completed test result into an outer worker timeout.
-  writeFileSync(process.stdout.fd, `${JSON.stringify(value)}\n`);
-  process.exit(exitCode);
+  // Every invocation of this worker produces exactly one terminal result, and
+  // the child must not be kept alive by abandoned upstream timers, streams, or
+  // scheduler handles — hence the explicit exit rather than `process.exitCode`.
+  //
+  // Exit only from the write callback, though. The parent captures stdout
+  // through a pipe (`spawn` with stdio "pipe"), and a pipe accepts just its
+  // buffer — 64 KB on Linux — before the rest of the write has to be drained
+  // asynchronously. `writeFileSync(process.stdout.fd, …)` followed by an
+  // immediate `process.exit()` therefore truncated any report larger than that
+  // at exactly 64 KB: cookie's stringify-cookie suite emits ~508 KB, the parent
+  // read a half-written JSON document, `JSON.parse` threw, and all 63,528 tests
+  // in the file were recorded as failures (#4767). Small reports fit the buffer
+  // in one synchronous write, which is why only the largest file regressed.
+  process.stdout.write(`${JSON.stringify(value)}\n`, () => {
+    process.exit(exitCode);
+  });
 }
 
 function errorText(error, instance) {

--- a/tests/dogfood/upstream-suite-compile-worker.mjs
+++ b/tests/dogfood/upstream-suite-compile-worker.mjs
@@ -6,6 +6,7 @@ import { buildCompiledImports, wrapExports } from "../../src/runtime.ts";
 import { getWebHostConstructors } from "../../src/runtime/web-host-constructors.ts";
 import {
   configuredUpstreamTestTimeoutMs,
+  emitWorkerResult,
   runSequentialUpstreamTests,
   signalWorkerCompileComplete,
 } from "./upstream-suite-worker-protocol.mjs";
@@ -13,24 +14,7 @@ import {
 const generatedPath = process.argv[2];
 const mode = process.argv[3] ?? "project";
 
-function emit(value, exitCode = 0) {
-  // Every invocation of this worker produces exactly one terminal result, and
-  // the child must not be kept alive by abandoned upstream timers, streams, or
-  // scheduler handles — hence the explicit exit rather than `process.exitCode`.
-  //
-  // Exit only from the write callback, though. The parent captures stdout
-  // through a pipe (`spawn` with stdio "pipe"), and a pipe accepts just its
-  // buffer — 64 KB on Linux — before the rest of the write has to be drained
-  // asynchronously. `writeFileSync(process.stdout.fd, …)` followed by an
-  // immediate `process.exit()` therefore truncated any report larger than that
-  // at exactly 64 KB: cookie's stringify-cookie suite emits ~508 KB, the parent
-  // read a half-written JSON document, `JSON.parse` threw, and all 63,528 tests
-  // in the file were recorded as failures (#4767). Small reports fit the buffer
-  // in one synchronous write, which is why only the largest file regressed.
-  process.stdout.write(`${JSON.stringify(value)}\n`, () => {
-    process.exit(exitCode);
-  });
-}
+const emit = emitWorkerResult;
 
 function errorText(error, instance) {
   let text = error instanceof Error ? `${error.name}: ${error.message}` : String(error);

--- a/tests/dogfood/upstream-suite-worker-protocol.mjs
+++ b/tests/dogfood/upstream-suite-worker-protocol.mjs
@@ -4,6 +4,26 @@ export function signalWorkerCompileComplete(durationMs, stream = process.stderr)
   stream.write(`${WORKER_COMPILE_COMPLETE_PREFIX}${Math.max(0, Math.round(durationMs))}\n`);
 }
 
+/**
+ * Write a worker's single terminal JSON result and exit.
+ *
+ * The exit is explicit — a disposable compile worker must not be held open by
+ * abandoned upstream timers, streams, or scheduler handles, which would turn a
+ * finished result into an outer worker timeout.
+ *
+ * It happens from the write callback, though, and that ordering is the whole
+ * point of this helper. The parent captures stdout through a pipe (`spawn`
+ * with stdio "pipe"), and a pipe accepts only its buffer — 64 KB on Linux —
+ * before the remainder has to be drained asynchronously by the reader.
+ * Writing and then exiting immediately truncates any larger report at exactly
+ * that boundary, leaving the parent a half-written JSON document (#4767).
+ */
+export function emitWorkerResult(value, exitCode = 0, stream = process.stdout) {
+  stream.write(`${JSON.stringify(value)}\n`, () => {
+    process.exit(exitCode);
+  });
+}
+
 export function readWorkerCompileDuration(stderr) {
   const match = String(stderr).match(new RegExp(`${WORKER_COMPILE_COMPLETE_PREFIX}(\\d+)`));
   return match ? Number(match[1]) : null;

--- a/tests/issue-4767.test.ts
+++ b/tests/issue-4767.test.ts
@@ -1,0 +1,76 @@
+// #4767 — a worker's terminal report must survive a pipe, whatever its size.
+//
+// The upstream-suite parent captures worker stdout through a pipe (`spawn`
+// with stdio "pipe"). A pipe accepts only its buffer — 64 KB on Linux — before
+// the remainder has to be drained asynchronously by the reader, so writing the
+// report and then calling `process.exit()` immediately truncates anything
+// larger at exactly that boundary. That left the parent a half-written JSON
+// document: `JSON.parse` threw, the parent fell back to stderr (which held only
+// the `__JS2WASM_COMPILE_COMPLETE__` sentinel), and every test in the affected
+// file was scored as a failure — cookie's stringify-cookie suite emits ~508 KB
+// and went from 63528/63528 to 0/63528.
+//
+// Guard the transport itself rather than any one package: spawn a child that
+// emits an over-buffer payload through the real `emitWorkerResult`, read it
+// through a real pipe, and require it back byte-for-byte.
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+const PROTOCOL_PATH = fileURLToPath(new URL("./dogfood/upstream-suite-worker-protocol.mjs", import.meta.url));
+const PIPE_BUFFER_BYTES = 64 * 1024;
+
+const scratch = mkdtempSync(join(tmpdir(), "issue-4767-"));
+afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+/**
+ * Emit `value` from a child process through `emitWorkerResult` and read the
+ * result back over a pipe, exactly as the upstream-suite parent does.
+ */
+function emitThroughPipe(value: unknown, name: string): Promise<{ stdout: string; code: number | null }> {
+  const scriptPath = join(scratch, `${name}.mjs`);
+  writeFileSync(
+    scriptPath,
+    `import { emitWorkerResult } from ${JSON.stringify(PROTOCOL_PATH)};\n` +
+      `emitWorkerResult(${JSON.stringify(value)});\n`,
+  );
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ stdout, code }));
+  });
+}
+
+describe("#4767 — worker reports survive the stdout pipe", () => {
+  it("delivers a report far larger than the pipe buffer intact", async () => {
+    // 256 KB of filler puts the payload well past the 64 KB boundary, in the
+    // same size class as the real cookie report that exposed this.
+    const report = { marker: "start", filler: "x".repeat(256 * 1024), marker2: "end" };
+    const { stdout, code } = await emitThroughPipe(report, "large");
+
+    expect(stdout.length).toBeGreaterThan(PIPE_BUFFER_BYTES);
+    // The precise failure was a truncated document, so assert the parse rather
+    // than just the length: a cut-off payload throws here.
+    expect(() => JSON.parse(stdout.trim())).not.toThrow();
+    expect(JSON.parse(stdout.trim())).toEqual(report);
+    expect(code).toBe(0);
+  });
+
+  it("still delivers a small report and honours the exit code", async () => {
+    const report = { ok: true };
+    const { stdout, code } = await emitThroughPipe(report, "small");
+
+    expect(JSON.parse(stdout.trim())).toEqual(report);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The npm-compat dashboard showed **cookie at 212 / 63740 (0.3 %)**, down from a clean **63740 / 63740**. Nothing about compiled cookie changed — the measurement harness was losing the result.

Every missing pass was in one file:

| file | native | Wasm (before) |
| --- | --- | --- |
| `src/parse-cookie.spec.ts` | 30/30 | 30/30 |
| `src/parse-set-cookie.spec.ts` | 85/85 | 85/85 |
| **`src/stringify-cookie.spec.ts`** | 63528/63528 | **0/63528** |
| `src/stringify-set-cookie.spec.ts` | 97/97 | 97/97 |

`212 = 30 + 85 + 97`. An all-or-nothing zero across a single file is a lost result, not 63,528 independent assertion failures — and the recorded "compile error" for that file was the harness's own IPC sentinel:

```json
{ "success": false, "binaryBytes": 0,
  "errors": [{ "message": "__JS2WASM_COMPILE_COMPLETE__:4855" }] }
```

## Root cause

`emit()` in `tests/dogfood/upstream-suite-compile-worker.mjs` wrote the worker's single terminal JSON result and exited immediately:

```js
writeFileSync(process.stdout.fd, `${JSON.stringify(value)}\n`);
process.exit(exitCode);
```

The parent captures that stdout **through a pipe** (`spawn` with `stdio: ["ignore", "pipe", "pipe"]`). A pipe accepts only its buffer — 64 KB on Linux — before the remainder has to be drained asynchronously by the reader, and `process.exit()` does not wait for that drain. `stringify-cookie.spec.ts` builds a ~63.5 K-case fuzz table over every BMP code point, so its report is ~508 KB and was cut off mid-document. The parent's `JSON.parse(stdout)` threw, fell into its catch, and used `stderr.trim()` as the detail — which held nothing but the sentinel. With no result, all 63,528 tests were scored as failures.

Measured on the regressing commit, same worker, same input:

| stdout destination | bytes delivered |
| --- | --- |
| file (`> out`) | 508,384 (complete) |
| **pipe (`\| wc -c`)** — what `spawn` uses | **66,010** (truncated at ~64 KB) |

The three small spec files fit the buffer in one synchronous write, which is why this looked package-specific rather than size-specific.

### Provenance

`git bisect --first-parent` over 111 mainline commits, **zero skips**, verifying the real harness result at every step:

- first bad commit **`89058479f`** — "Merge pull request #4898 from ttraenkler/codex/npm-package-compile-once"
- parent `6a5f67238` verified: `63528/63528 Wasm` ✅
- `89058479f` verified: `0/63528 Wasm` ❌

#4898 rewrote `emit()` from `process.stdout.write(...)` + `process.exitCode` (a natural exit, which flushes) to `writeFileSync` + `process.exit()`. Its comment states the intent — guarantee the disposable child cannot be held open by abandoned upstream timers, streams or scheduler handles, turning a finished result into an outer worker timeout. That goal is sound; the flush was the casualty.

## Change

Keep the forced exit, but take it from the write callback so the payload is flushed first:

```js
process.stdout.write(`${JSON.stringify(value)}\n`, () => {
  process.exit(exitCode);
});
```

The emit path moves into `tests/dogfood/upstream-suite-worker-protocol.mjs` as `emitWorkerResult()` — it is transport, so it belongs beside the rest of the worker protocol, and living there makes it exercisable without standing up a full compile. Also drops the now-unused `writeFileSync` import.

## Repro

`tests/issue-4767.test.ts` guards the transport rather than any one package: it spawns a child that emits an over-buffer payload through the real `emitWorkerResult`, reads it back over a real pipe, and requires it byte-for-byte.

**Confirmed to catch the original defect, not merely to pass.** With the pre-fix `writeFileSync` + immediate `process.exit()` restored, the large-report case fails with `SyntaxError: Unterminated string in JSON at position 146176`, while the small-report case still passes — exactly the size-dependence that disguised this as package-specific.

## Validation

- `pnpm run dogfood:cookie-upstream-suite` → **63740/63740**, `stringify-cookie` at `63528/63528 Wasm` (re-verified after the refactor)
- The ~508 KB report now survives a pipe intact: 508,384 bytes through `| wc -c`, matching the file-redirect byte count
- `tests/issue-4767.test.ts` passes on the fix, fails on the pre-fix emit path
- `check:issue-spec-coverage` (#2093) — the gate that failed the first push — now passes
- Gates green locally: loc-budget, func-budget, coercion-sites, oracle-ratchet, dead-exports, changed-root-tests, lint, prettier, issue integrity

## Notes

- The compiled cookie package was never broken — `compile()`, validation and the 21-op differential harness stayed green throughout. Only the transport of the result regressed.
- Any upstream suite whose report crosses 64 KB was exposed to the same truncation, so other packages' counts measured between `89058479f` and this fix may be understated. `npm-compat-refresh` re-measures everything post-merge, so the artifact self-corrects — deliberately **no** hand-edit of `npm-compat.json` here (main is its sole writer).
- **Dating a regression from `npm-compat.json` is unsafe**: the refresh measures for ~24 min and promotes via PR, so the artifact landing on commit X reflects an older main. It still read `63740/63740` at `766d91e88`, hours after the bug landed. This bisect used observed behaviour, not artifact timestamps.

Issue: [#4767](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4767-upstream-worker-stdout-pipe-truncation)
