### PR TITLE
fix(typedarray): implement standalone species semantics

### DIFF
--- a/plan/issues/4449-typedarray-standalone-semantics-residual.md
+++ b/plan/issues/4449-typedarray-standalone-semantics-residual.md
@@ -16,10 +16,13 @@ related: [4444, 2159, 2175]
 loc-budget-allow:
   - src/codegen/array-methods.ts
   - src/codegen/dataview-native.ts
+  - src/codegen/ta-dyn-mop.ts
   - src/codegen/expressions/call-receiver-method.ts
 func-budget-allow:
   - src/codegen/array-methods.ts::compileArrayMethodCall
   - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
+  - src/codegen/ta-dyn-mop.ts::fillTaDynViewMopArms
+  - src/codegen/ta-dyn-mop.ts::buildStringKeyArm
 ---
 
 # #4449 — TypedArray.prototype standalone semantics residual
@@ -192,3 +195,33 @@ method-specific argument tuple, reject incompatible/non-TypedArray results,
 and write producer values into the returned view. Rerun the exact 55-row host
 and pinned standalone controls before claiming a gain; host's 52/55 result is
 the regression floor. Detached-buffer and reflection work remain out of scope.
+
+## 2026-08-27 clean-delivery resumed species plan
+
+This branch is the clean upstream delivery branch behind draft PR #5022.
+
+1. Add focused dynamic-view controls for own `constructor` shadowing and
+   `constructor[Symbol.species]` lookup/defaulting, including original abrupt
+   value propagation, before modifying producer algorithms.
+2. Implement one reusable TypedArraySpeciesCreate seam, then wire a single
+   producer method first. Preserve method-specific constructor arguments and
+   validate returned dynamic views before widening to the other methods.
+3. Land only independently proven producer slices; keep detached-buffer,
+   reflection metadata, and BigInt carriers out of scope.
+4. Rerun the frozen 55-row cohort in standalone and host after every completed
+   slice. Draft PR #5022 may be marked ready only when the owned implementation
+   is complete, standalone is 55/55 with zero non-passes, and host is 55/55.
+
+### 2026-08-27 dynamic constructor control checkpoint
+
+The dynamic-view MOP now checks an own `constructor` expando before walking the
+selected prototype, preserving original getter abrupt completions and explicit
+own values. The focused standalone controls in
+`tests/issue-4449-species-controls.test.ts` pass 5/5 with zero `env` imports:
+own constructor shadowing, abrupt constructor getter, inherited constructor
+getter, own `Symbol.species`, and abrupt `Symbol.species` getter. The existing
+`issue-3058-dyn-view-proto-methods` regression suite remains green (11/11).
+
+This checkpoint intentionally does not claim producer-method progress; the
+55-row species cohort remains at the 0/55 standalone baseline until the shared
+species-create seam is wired.

--- a/plan/issues/4449-typedarray-standalone-semantics-residual.md
+++ b/plan/issues/4449-typedarray-standalone-semantics-residual.md
@@ -225,3 +225,47 @@ getter, own `Symbol.species`, and abrupt `Symbol.species` getter. The existing
 This checkpoint intentionally does not claim producer-method progress; the
 55-row species cohort remains at the 0/55 standalone baseline until the shared
 species-create seam is wired.
+
+## 2026-08-27 clean-delivery producer checkpoint (partial)
+
+The resumed branch wires one shared standalone `TypedArraySpeciesCreate` seam
+for dynamic-view `map`, `filter`, `slice`, and `subarray`. It now performs the
+constructor/`@@species` lookup and nullish defaulting, preserves abrupt getter
+completion, invokes custom constructors with the method-specific argument
+tuple, validates a returned dynamic view and minimum length, and copies the
+ordinary producer vector into the species result. The dynamic MOP own
+`constructor` shadow path remains in front of prototype lookup. Detached
+buffers, reflection metadata, and BigInt value carriers remain out of scope.
+
+Focused evidence from this worktree:
+
+- `tests/issue-4449-species-controls.test.ts` plus
+  `tests/issue-4449-species-producers.test.ts`: **12/12 passed**, zero
+  standalone `env` imports.
+- An all-nine non-BigInt-constructor pin covering custom `map`, `filter`,
+  `slice`, and shared-buffer `subarray` passed **36/36**.
+- Tracked source delta at checkpoint: `array-methods.ts` +318 lines,
+  `dataview-native.ts` +366 lines, `call-receiver-method.ts` +13/-2, and
+  `ta-dyn-mop.ts` +41/-7; the added focused producer test is 197 lines. The
+  dataview addition is the single shared protocol and dynamic-kind copy seam;
+  the array-method addition is the four producer-specific argument/order arms
+  plus one runtime two-arm wrapper. No debug instrumentation is retained.
+
+The exact frozen cohort remains `/private/tmp/js2-4449-species-55.txt` (55
+rows). Fresh bounded runs used `COMPILER_POOL_SIZE=2`,
+`--official-scope-only`, and the exact path-file filter:
+
+| Lane | Run | Pass | Fail | Compile errors | Timeouts | Skips | Denominator |
+|---|---|---:|---:|---:|---:|---:|---:|
+| standalone (pinned QuickJS artifact `2e2d7736713beeda`) | `20260827-074318` | 20 | 35 | 0 | 0 | 0 | 55 |
+| host | `20260827-075040` | 52 | 3 | 0 | 0 | 0 | 55 |
+
+The standalone run is a **partial improvement only**, not an acceptance
+claim. Its 35 residuals are concentrated in constructor/default identity (8),
+invalid constructor/species and returned-view handling (11), custom invocation
+`this`/result copying (12), and the same-buffer offset/subarray cases (4), with
+method totals `map 9`, `filter 8`, `slice 10`, `subarray 8`. Host remains at
+the 52/55 control floor; its three failures are the pre-existing Float64
+`slice`/`subarray` custom-constructor receiver and invocation-argument rows.
+Draft PR #5022 must remain draft and this issue remains in progress until a
+future checkpoint reaches standalone 55/55 and host 55/55 with zero nonpasses.

--- a/plan/issues/4449-typedarray-standalone-semantics-residual.md
+++ b/plan/issues/4449-typedarray-standalone-semantics-residual.md
@@ -4,7 +4,7 @@ title: "standalone: TypedArray.prototype ES6 semantics residual (~556 non-reflec
 status: in-progress
 sprint: current
 created: 2026-08-15
-updated: 2026-08-25
+updated: 2026-08-27
 priority: high
 horizon: l
 feasibility: hard
@@ -126,3 +126,69 @@ clusters satisfy the acceptance criteria below.
 - Sub-bucket counts above driven to zero (or re-attributed to #2175 with
   evidence) with scoped-run measurements
   (`TEST262_TARGET=standalone TEST262_PATH_FILTER="built-ins/TypedArray"`).
+## 2026-08-27 Luna/max wave plan — exact species cohort
+
+The cached ES2015 baseline joins exactly 11,704 paths. Within it, the exact
+`speciesctor` cohort contains 55 rows: cached host is 45 pass / 10 fail and
+cached standalone is 0 pass / 55 fail. These counts select the cohort only;
+the implementation branch must rerun all 55 rows on the combined PR head before
+and after its change.
+
+1. Freeze the exact 55 paths and separate constructor lookup, `@@species`
+   lookup/defaulting, abrupt completion, invocation arguments, and returned-view
+   validation by row. Do not treat the shared error text as a bucket boundary.
+2. Implement the narrowest shared TypedArraySpeciesCreate path used by `map`,
+   `filter`, `slice`, and `subarray`, preserving lookup order and abrupt values.
+   Do not touch reflection-only method metadata or detached-buffer handling.
+3. Add permanent focused coverage for one success, one default-species case,
+   one abrupt constructor lookup, and one incompatible returned object.
+4. Rerun the exact 55 paths in host and standalone. Record every denominator,
+   any losses, and residual handoff here; integrate only a net-correct proven
+   slice into draft PR #5010.
+
+## 2026-08-27 exact-cohort control and handoff
+
+The exact cohort is frozen at `/private/tmp/js2-4449-species-55.txt` (55
+non-BigInt ES2015 paths covering `map`, `filter`, `slice`, and `subarray`
+`speciesctor-*`, `get-ctor-*`, and `get-species-*` cases). Fresh controls were
+run from combined-PR base `114f8a95a` with
+`pnpm run test:262 --official-scope-only`, two workers, and the pinned
+standalone artifact directory
+`/private/tmp/js2-quickjs-artifact-2e2d7736713beeda`:
+
+| Lane | Run | Pass | Fail | Compile errors | Timeouts | Skips | Denominator |
+|---|---|---:|---:|---:|---:|---:|---:|
+| host | `20260827-035118` | 52 | 3 | 0 | 0 | 0 | 55 |
+| standalone | `20260827-035511` | 0 | 55 | 0 | 0 | 0 | 55 |
+
+The host failures are the two `slice`/`subarray` custom-constructor identity
+cases (the ordinary array result is rejected by the TypedArray receiver path)
+and the `subarray` custom invocation-arguments case. The standalone failures
+are assertion failures rather than compile/runtime errors: constructor and
+`@@species` getters are not observed, custom constructors receive no calls,
+default results have the wrong identity, and custom result lengths/values are
+not honored.
+
+### Root cause
+
+The standalone test262 shim passes each `TA` constructor through the dynamic
+`$__ta_ctor`/`$__ta_dyn_view` carrier. `compileArrayMethodCall` currently
+materializes that carrier to an ordinary f64 vector and routes `map`, `filter`,
+and `slice` through ordinary vector allocation; `subarray` creates a shared
+dynamic view directly. None of these producer paths performs
+`Get(O, "constructor")`, `Get(C, @@species)`, defaulting, `Construct`, or
+returned-view validation. In addition, the dynamic MOP's intrinsic named
+`constructor` arm precedes expando lookup, so an own `sample.constructor`
+override cannot reliably reach the species object. This is a shared
+TypedArraySpeciesCreate gap, not a reflection-only metadata failure.
+
+### Handoff
+
+No source or test change is claimed in this checkpoint. Implementers should
+first make dynamic-view own `constructor` shadowing observable, then add one
+shared species-create helper for the four producer methods. The helper must
+preserve lookup/abrupt-completion order, invoke custom constructors with the
+method-specific argument tuple, reject incompatible/non-TypedArray results,
+and write producer values into the returned view. Rerun the exact 55-row host
+and pinned standalone controls before claiming a gain; host's 52/55 result is
+the regression floor. Detached-buffer and reflection work remain out of scope.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -46,8 +46,11 @@ import {
   isTaViewTypeIdx,
 } from "./registry/types.js";
 import {
+  emitTaDynSpeciesCreate,
+  pushElemSizeForKind,
   emitTaDynViewToVec,
   emitTaDynViewValidate,
+  emitTaDynViewWriteF64Vec,
   emitTaViewToVec,
   emitTaViewValidate,
   emitTaViewWriteBack,
@@ -1406,6 +1409,308 @@ function shouldWrapDynViewTwoArm(
   );
 }
 
+const DYN_VIEW_SPECIES_METHODS = new Set<string>(["map", "filter", "slice", "subarray"]);
+
+function shouldWrapDynViewSpeciesTwoArm(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  callExpr: ts.CallExpression,
+  methodName: string,
+  skipDynViewWrap: boolean,
+): boolean {
+  return (
+    !skipDynViewWrap &&
+    noJsHost(ctx) &&
+    ctx.moduleUsesDynTaView &&
+    !dynViewTwoArmActive.has(callExpr) &&
+    ts.isPropertyAccessExpression(propAccess) &&
+    DYN_VIEW_SPECIES_METHODS.has(methodName) &&
+    ts.isIdentifier(propAccess.expression) &&
+    dynViewReceiverIsExternref(fctx, propAccess.expression.text)
+  );
+}
+
+/**
+ * (#4449) Runtime-kind producer arm for dynamic TypedArray views.  The
+ * existing ordinary vector methods remain the callback/index algorithms; this
+ * wrapper only supplies their f64 materialized input, performs one shared
+ * TypedArraySpeciesCreate, and copies the result into the returned dynamic
+ * view.  The ELSE arm is the exact pre-existing call lowering for a plain
+ * externref receiver.
+ */
+function emitDynViewSpeciesMethodTwoArm(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  receiverType: ts.Type | undefined,
+  methodName: string,
+  expectedType: ValType | undefined,
+): ValType | null | undefined | typeof VOID_RESULT {
+  const receiverExpr = propAccess.expression;
+  if (!ts.isIdentifier(receiverExpr)) return undefined;
+  const name = receiverExpr.text;
+  const dynIdx = getOrRegisterTaDynViewType(ctx);
+
+  const rt = compileExpression(ctx, fctx, receiverExpr);
+  if (rt && rt.kind !== "externref") coerceType(ctx, fctx, rt, { kind: "externref" });
+  const recvExt = allocLocal(fctx, `__dvs_recv_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: recvExt });
+  const recvAny = allocLocal(fctx, `__dvs_any_${fctx.locals.length}`, { kind: "anyref" });
+  fctx.body.push(
+    { op: "local.get", index: recvExt },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: recvAny },
+  );
+
+  const dvLocal = allocLocal(fctx, `__dvs_dv_${fctx.locals.length}`, { kind: "ref", typeIdx: dynIdx });
+  const outer = fctx.body;
+  const thenArm: Instr[] = [];
+  const elseArm: Instr[] = [];
+  fctx.savedBodies.push(outer, thenArm, elseArm);
+
+  const abandon = (): undefined => {
+    fctx.body = outer;
+    fctx.savedBodies.pop();
+    fctx.savedBodies.pop();
+    fctx.savedBodies.pop();
+    return undefined;
+  };
+
+  fctx.body = thenArm;
+  fctx.body.push(
+    { op: "local.get", index: recvAny },
+    { op: "ref.cast", typeIdx: dynIdx },
+    { op: "local.set", index: dvLocal },
+  );
+  emitTaDynViewValidate(ctx, fctx, dvLocal);
+  const f64VecIdx = emitTaDynViewToVec(ctx, fctx, dvLocal);
+  const matLocal = allocLocal(fctx, `__dvs_mat_${fctx.locals.length}`, { kind: "ref", typeIdx: f64VecIdx });
+  fctx.body.push({ op: "local.set", index: matLocal });
+
+  const boxNumIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+  if (boxNumIdx === undefined) return abandon();
+
+  const boxI32 = (valueLocal: number, tag: string): number => {
+    const out = allocLocal(fctx, `__dvs_${tag}_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push(
+      { op: "local.get", index: valueLocal },
+      { op: "f64.convert_i32_s" },
+      { op: "call", funcIdx: boxNumIdx },
+      { op: "local.set", index: out },
+    );
+    return out;
+  };
+
+  const bindSpeciesResult = (speciesLocal: number): number => {
+    const anyLocal = allocLocal(fctx, `__dvs_species_any_${fctx.locals.length}`, { kind: "anyref" });
+    const resultDv = allocLocal(fctx, `__dvs_species_dv_${fctx.locals.length}`, { kind: "ref", typeIdx: dynIdx });
+    fctx.body.push(
+      { op: "local.get", index: speciesLocal },
+      { op: "any.convert_extern" },
+      { op: "local.set", index: anyLocal },
+      { op: "local.get", index: anyLocal },
+      { op: "ref.cast", typeIdx: dynIdx },
+      { op: "local.set", index: resultDv },
+    );
+    return resultDv;
+  };
+
+  const captureVec = (
+    r: ValType | null | undefined | typeof VOID_RESULT,
+    tag: string,
+  ): { local: number; typeIdx: number; elemType: ValType; lenLocal: number } | undefined => {
+    if (!r || r === VOID_RESULT || (r.kind !== "ref" && r.kind !== "ref_null") || !("typeIdx" in r)) return undefined;
+    const typeIdx = r.typeIdx;
+    const arrIdx = getArrTypeIdxFromVec(ctx, typeIdx);
+    const arrDef = arrIdx < 0 ? undefined : ctx.mod.types[arrIdx];
+    if (!arrDef || arrDef.kind !== "array") return undefined;
+    const local = allocLocal(fctx, `__dvs_${tag}_${fctx.locals.length}`, r);
+    fctx.body.push({ op: "local.set", index: local });
+    const lenLocal = allocLocal(fctx, `__dvs_${tag}_len_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push(
+      { op: "local.get", index: local },
+      { op: "struct.get", typeIdx, fieldIdx: 0 },
+      { op: "local.set", index: lenLocal },
+    );
+    return { local, typeIdx, elemType: arrDef.element, lenLocal };
+  };
+
+  const copySpeciesResult = (
+    speciesLocal: number,
+    source: { local: number; typeIdx: number; elemType: ValType; lenLocal: number },
+    countLocal: number,
+  ): void => {
+    const resultDv = bindSpeciesResult(speciesLocal);
+    emitTaDynViewWriteF64Vec(ctx, fctx, resultDv, source.local, source.typeIdx, source.elemType, countLocal);
+  };
+
+  let outputSpecies: number | undefined;
+  if (methodName === "map") {
+    const sourceLen = allocLocal(fctx, `__dvs_map_len_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push(
+      { op: "local.get", index: matLocal },
+      { op: "struct.get", typeIdx: f64VecIdx, fieldIdx: 0 },
+      { op: "local.set", index: sourceLen },
+    );
+    const countArg = boxI32(sourceLen, "map_count");
+    outputSpecies =
+      emitTaDynSpeciesCreate(ctx, fctx, { dvLocal, argLocals: [countArg], requestedLengthLocal: sourceLen }) ??
+      undefined;
+    if (outputSpecies === undefined) return abandon();
+    const savedBind = fctx.localMap.get(name);
+    fctx.localMap.set(name, matLocal);
+    const r = compileArrayMethodCall(ctx, fctx, propAccess, callExpr, receiverType, methodName, expectedType, true);
+    if (savedBind !== undefined) fctx.localMap.set(name, savedBind);
+    else fctx.localMap.delete(name);
+    const mapped = captureVec(r, "map_result");
+    if (!mapped) return abandon();
+    copySpeciesResult(outputSpecies, mapped, sourceLen);
+  } else if (methodName === "filter") {
+    const savedBind = fctx.localMap.get(name);
+    fctx.localMap.set(name, matLocal);
+    const r = compileArrayMethodCall(ctx, fctx, propAccess, callExpr, receiverType, methodName, expectedType, true);
+    if (savedBind !== undefined) fctx.localMap.set(name, savedBind);
+    else fctx.localMap.delete(name);
+    const filtered = captureVec(r, "filter_result");
+    if (!filtered) return abandon();
+    outputSpecies =
+      emitTaDynSpeciesCreate(ctx, fctx, {
+        dvLocal,
+        argLocals: [boxI32(filtered.lenLocal, "filter_count")],
+        requestedLengthLocal: filtered.lenLocal,
+      }) ?? undefined;
+    if (outputSpecies === undefined) return abandon();
+    copySpeciesResult(outputSpecies, filtered, filtered.lenLocal);
+  } else if (methodName === "slice") {
+    const savedBind = fctx.localMap.get(name);
+    fctx.localMap.set(name, matLocal);
+    const r = compileArrayMethodCall(ctx, fctx, propAccess, callExpr, receiverType, methodName, expectedType, true);
+    if (savedBind !== undefined) fctx.localMap.set(name, savedBind);
+    else fctx.localMap.delete(name);
+    const sliced = captureVec(r, "slice_result");
+    if (!sliced) return abandon();
+    outputSpecies =
+      emitTaDynSpeciesCreate(ctx, fctx, {
+        dvLocal,
+        argLocals: [boxI32(sliced.lenLocal, "slice_count")],
+        requestedLengthLocal: sliced.lenLocal,
+      }) ?? undefined;
+    if (outputSpecies === undefined) return abandon();
+    copySpeciesResult(outputSpecies, sliced, sliced.lenLocal);
+  } else {
+    // subarray: the method does not materialize/copy. Compute the normalized
+    // element window, then pass the backing buffer and byte tuple to species.
+    const sourceLen = allocLocal(fctx, `__dvs_sub_len_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push(
+      { op: "local.get", index: matLocal },
+      { op: "struct.get", typeIdx: f64VecIdx, fieldIdx: 0 },
+      { op: "local.set", index: sourceLen },
+    );
+    const begin = allocLocal(fctx, `__dvs_sub_begin_${fctx.locals.length}`, { kind: "i32" });
+    const end = allocLocal(fctx, `__dvs_sub_end_${fctx.locals.length}`, { kind: "i32" });
+    if (callExpr.arguments.length >= 1) {
+      compileExpression(ctx, fctx, callExpr.arguments[0]!, { kind: "f64" });
+      fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+    } else fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "local.set", index: begin });
+    emitClampIndex(fctx, begin, sourceLen);
+    const endArg = callExpr.arguments.length >= 2 ? callExpr.arguments[1]! : undefined;
+    const endUndefined = endArg !== undefined && ts.isIdentifier(endArg) && endArg.text === "undefined";
+    if (endArg !== undefined && !endUndefined) {
+      compileExpression(ctx, fctx, endArg, { kind: "f64" });
+      fctx.body.push({ op: "i32.trunc_sat_f64_s" }, { op: "local.set", index: end });
+      emitClampIndex(fctx, end, sourceLen);
+    } else {
+      fctx.body.push({ op: "local.get", index: sourceLen }, { op: "local.set", index: end });
+    }
+    const subLen = allocLocal(fctx, `__dvs_sub_count_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push(
+      { op: "local.get", index: end },
+      { op: "local.get", index: begin },
+      { op: "i32.sub" },
+      { op: "local.set", index: subLen },
+    );
+    emitClampNonNeg(fctx, subLen);
+    const kind = allocLocal(fctx, `__dvs_sub_kind_${fctx.locals.length}`, { kind: "i32" });
+    const elemSize = allocLocal(fctx, `__dvs_sub_es_${fctx.locals.length}`, { kind: "i32" });
+    const byteOffset = allocLocal(fctx, `__dvs_sub_off_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push(
+      { op: "local.get", index: dvLocal },
+      { op: "struct.get", typeIdx: dynIdx, fieldIdx: 3 },
+      { op: "local.set", index: kind },
+    );
+    pushElemSizeForKind(fctx, kind);
+    fctx.body.push(
+      { op: "local.set", index: elemSize },
+      { op: "local.get", index: dvLocal },
+      { op: "struct.get", typeIdx: dynIdx, fieldIdx: 2 },
+      { op: "local.get", index: begin },
+      { op: "local.get", index: elemSize },
+      { op: "i32.mul" },
+      { op: "i32.add" },
+      { op: "local.set", index: byteOffset },
+    );
+    const bufferArg = allocLocal(fctx, `__dvs_sub_buffer_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push(
+      { op: "local.get", index: dvLocal },
+      { op: "struct.get", typeIdx: dynIdx, fieldIdx: 1 },
+      { op: "extern.convert_any" },
+      { op: "local.set", index: bufferArg },
+    );
+    outputSpecies =
+      emitTaDynSpeciesCreate(ctx, fctx, {
+        dvLocal,
+        argLocals: [bufferArg, boxI32(byteOffset, "sub_offset"), boxI32(subLen, "sub_length")],
+      }) ?? undefined;
+    if (outputSpecies === undefined) return abandon();
+  }
+
+  // The branch result is the species-created view after any producer copy.
+  // Keep the full dynamic arm in the `if` so creation and validation execute
+  // only for a dynamic view, then leave the constructed view on its value
+  // stack for the enclosing call expression.
+  if (outputSpecies === undefined) return undefined;
+  thenArm.push({ op: "local.get", index: outputSpecies });
+
+  fctx.body = elseArm;
+  dynViewTwoArmActive.add(callExpr);
+  const rElse = compileExpression(ctx, fctx, callExpr, expectedType);
+  dynViewTwoArmActive.delete(callExpr);
+  const elseOk = coerceArmToExternref(ctx, fctx, rElse, true);
+  fctx.body = outer;
+  fctx.savedBodies.pop();
+  fctx.savedBodies.pop();
+  fctx.savedBodies.pop();
+  if (!elseOk) return undefined;
+  outer.push(
+    { op: "local.get", index: recvAny },
+    { op: "ref.test", typeIdx: dynIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: thenArm,
+      else: elseArm,
+    },
+  );
+  return { kind: "externref" };
+}
+
+/** Entry point for the earlier any/externref receiver dispatcher. */
+export function tryCompileDynViewSpeciesMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  receiverType: ts.Type,
+  expectedType?: ValType,
+): ValType | null | undefined | typeof VOID_RESULT {
+  const methodName = propAccess.name.text;
+  if (!shouldWrapDynViewSpeciesTwoArm(ctx, fctx, propAccess, callExpr, methodName, false)) return undefined;
+  return emitDynViewSpeciesMethodTwoArm(ctx, fctx, propAccess, callExpr, receiverType, methodName, expectedType);
+}
+
 function emitDynViewMethodTwoArm(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1549,6 +1854,19 @@ export function compileArrayMethodCall(
   const methodName =
     overrideMethodName ?? (ts.isPropertyAccessExpression(propAccess) ? propAccess.name.text : undefined);
   if (!methodName || !ARRAY_METHODS.has(methodName)) return undefined;
+
+  if (shouldWrapDynViewSpeciesTwoArm(ctx, fctx, propAccess, callExpr, methodName, skipDynViewWrap)) {
+    const species = emitDynViewSpeciesMethodTwoArm(
+      ctx,
+      fctx,
+      propAccess as ts.PropertyAccessExpression,
+      callExpr,
+      receiverType,
+      methodName,
+      expectedType,
+    );
+    if (species !== undefined) return species;
+  }
 
   // (#3058) Runtime-kind proto-method dispatch on a boxed `$__ta_dyn_view` receiver
   // (dynamic `new <ctorVar>(rab)` where the element kind is only known at runtime).

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -60,6 +60,9 @@ import { undefinedExternInstrs } from "./any-helpers.js"; // (#3177) OOB read = 
 import { ensureObjectRuntime } from "./object-runtime.js"; // (#2872) $Object array-like construct arm
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { coerceType } from "./type-coercion.js";
+import { ensureReflectIsConstructor } from "./reflect-construct-native.js"; // (#4449) TypedArraySpeciesCreate
+import { reserveNativeConstructDriver } from "./native-construct.js"; // (#4449) custom species constructors
+import { ensureSymbolCarrier } from "./symbol-native.js"; // (#4449) Symbol.species key
 
 /** DataView accessor descriptor parsed from a method name like "getUint32". */
 interface DvAccessor {
@@ -4678,6 +4681,369 @@ export function emitTaDynCtorConstructFromLocals(
     else: int8Arm,
   });
   fctx.body.push({ op: "local.get", index: resultLocal });
+}
+
+/**
+ * (#4449) Emit the shared TypedArraySpeciesCreate protocol for a boxed
+ * `$__ta_dyn_view` exemplar.
+ *
+ * The producer methods all have the same observable constructor protocol:
+ * `Get(exemplar, "constructor")`, `Get(C, @@species)`, nullish defaulting,
+ * `IsConstructor`, `Construct`, and `ValidateTypedArray`.  Keeping this in
+ * one emitter is important here because the dynamic-view receiver reaches the
+ * methods through an `externref` and cannot use the static typed-array
+ * constructor folds.  `argLocals` are already-evaluated externref arguments
+ * (the requested element count for map/filter/slice, or buffer/offset/length
+ * for subarray).
+ *
+ * The returned local always contains the constructed externref.  On an
+ * incompatible result or an invalid constructor the emitted code throws a
+ * catchable TypeError before returning.  `requestedLengthLocal`, when present,
+ * additionally implements TypedArrayCreate's single-number minimum-length
+ * check; subarray deliberately omits it because its constructor receives the
+ * buffer tuple rather than a requested result length.
+ */
+export interface TaDynSpeciesCreateOptions {
+  dvLocal: number;
+  argLocals: readonly number[];
+  requestedLengthLocal?: number;
+}
+
+export function emitTaDynSpeciesCreate(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  options: TaDynSpeciesCreateOptions,
+): number | null {
+  if (!noJsHost(ctx)) return null;
+
+  const dynIdx = getOrRegisterTaDynViewType(ctx);
+  ensureObjectRuntime(ctx);
+  ensureSymbolCarrier(ctx);
+
+  // These helpers are native in the standalone/WASI lane.  Resolve them
+  // before emitting any body that captures their indices; this also keeps a
+  // partially-equipped context from producing an invalid call instruction.
+  const externGetIdx = ensureLateImport(
+    ctx,
+    "__extern_get",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  const isUndefinedIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+  const typeofObjectIdx = ensureLateImport(ctx, "__typeof_object", [{ kind: "externref" }], [{ kind: "i32" }]);
+  const typeofFunctionIdx = ensureLateImport(ctx, "__typeof_function", [{ kind: "externref" }], [{ kind: "i32" }]);
+  const symbolBoxIdx = ctx.funcMap.get("__box_symbol");
+  const isConstructorIdx = ensureReflectIsConstructor(ctx);
+  const driverIdx = reserveNativeConstructDriver(
+    ctx,
+    options.argLocals.length,
+    stringConstantExternrefInstrs(ctx, "prototype"),
+  );
+
+  const resultLocal = allocLocal(fctx, `__tasc_res_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "ref.null.extern" }, { op: "local.set", index: resultLocal });
+
+  if (
+    externGetIdx === undefined ||
+    isUndefinedIdx === undefined ||
+    typeofObjectIdx === undefined ||
+    typeofFunctionIdx === undefined ||
+    symbolBoxIdx === undefined
+  ) {
+    emitThrowTypeError(ctx, fctx, "TypedArray species constructor is unavailable");
+    return resultLocal;
+  }
+
+  const kindLocal = allocLocal(fctx, `__tasc_kind_${fctx.locals.length}`, { kind: "i32" });
+  const selectedLocal = allocLocal(fctx, `__tasc_selected_${fctx.locals.length}`, { kind: "externref" });
+  const constructorLocal = allocLocal(fctx, `__tasc_ctor_${fctx.locals.length}`, { kind: "externref" });
+  const speciesLocal = allocLocal(fctx, `__tasc_species_${fctx.locals.length}`, { kind: "externref" });
+  const selectedAnyLocal = allocLocal(fctx, `__tasc_selected_any_${fctx.locals.length}`, { kind: "anyref" });
+  const resultAnyLocal = allocLocal(fctx, `__tasc_result_any_${fctx.locals.length}`, { kind: "anyref" });
+  const resultDvLocal = allocLocal(fctx, `__tasc_result_dv_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: dynIdx,
+  });
+  const resultKindLocal = allocLocal(fctx, `__tasc_result_kind_${fctx.locals.length}`, { kind: "i32" });
+  const resultEsLocal = allocLocal(fctx, `__tasc_result_es_${fctx.locals.length}`, { kind: "i32" });
+  const typeErrorArm = (message: string): Instr[] => {
+    const saved = fctx.body;
+    const body: Instr[] = [];
+    fctx.body = body;
+    emitThrowTypeError(ctx, fctx, message);
+    fctx.body = saved;
+    return body;
+  };
+
+  // Push the default concrete constructor selected by the exemplar's runtime
+  // kind.  The `$__ta_ctor` singleton is also the identity emitted for a bare
+  // TypedArray constructor in the dynamic harness, including kind 0; using it
+  // here keeps `result.constructor === TA` true without creating a second
+  // constructor carrier.
+  const pushDefaultConstructor = (): void => {
+    fctx.body.push(
+      { op: "local.get", index: options.dvLocal },
+      { op: "struct.get", typeIdx: dynIdx, fieldIdx: 3 },
+      { op: "local.set", index: kindLocal },
+    );
+    let chain: Instr[] = [{ op: "ref.null.extern" }];
+    for (let k = TA_CTOR_KINDS.length - 1; k >= 0; k--) {
+      const globalIdx = getOrRegisterTaCtorSingleton(ctx, k);
+      chain = [
+        { op: "local.get", index: kindLocal },
+        { op: "i32.const", value: k },
+        { op: "i32.eq" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: [{ op: "global.get", index: globalIdx }, { op: "extern.convert_any" }],
+          else: chain,
+        },
+      ];
+    }
+    fctx.body.push(...chain, { op: "local.set", index: selectedLocal });
+  };
+
+  pushDefaultConstructor();
+
+  // C = ? Get(exemplar, "constructor"). The dynamic MOP has already handled
+  // own expandos and inherited prototype accessors, so this call preserves
+  // their exact abrupt completion and lookup order.
+  fctx.body.push(
+    { op: "local.get", index: options.dvLocal },
+    { op: "extern.convert_any" },
+    ...stringConstantExternrefInstrs(ctx, "constructor"),
+    { op: "call", funcIdx: externGetIdx },
+    { op: "local.set", index: constructorLocal },
+    { op: "local.get", index: constructorLocal },
+    { op: "call", funcIdx: isUndefinedIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [], // undefined C keeps the intrinsic default in selectedLocal
+      else: [
+        // null is not a constructor object. Keep it separate from the
+        // Type(Object(null)) classifier, whose null policy is intentionally
+        // different for ordinary dynamic reads.
+        { op: "local.get", index: constructorLocal },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: typeErrorArm("TypedArray constructor is not an object"),
+          else: [],
+        },
+        { op: "local.get", index: constructorLocal },
+        { op: "call", funcIdx: typeofObjectIdx },
+        { op: "local.get", index: constructorLocal },
+        { op: "call", funcIdx: typeofFunctionIdx },
+        { op: "i32.or" },
+        { op: "i32.eqz" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: typeErrorArm("TypedArray constructor is not an object"),
+          else: [],
+        },
+        { op: "local.get", index: constructorLocal },
+        { op: "i32.const", value: 5 },
+        { op: "call", funcIdx: symbolBoxIdx },
+        { op: "call", funcIdx: externGetIdx },
+        { op: "local.set", index: speciesLocal },
+        { op: "local.get", index: speciesLocal },
+        { op: "ref.is_null" },
+        { op: "local.get", index: speciesLocal },
+        { op: "call", funcIdx: isUndefinedIdx },
+        { op: "i32.or" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [], // null/undefined species keeps the intrinsic default
+          else: [
+            { op: "local.get", index: speciesLocal },
+            { op: "local.set", index: selectedLocal },
+          ],
+        },
+      ],
+    },
+  );
+
+  // SpeciesConstructor requires an actual constructor before Construct.  The
+  // classifier is finalized after closure registration and understands both
+  // native TA carriers and compiled closure constructors.
+  fctx.body.push(
+    { op: "local.get", index: selectedLocal },
+    { op: "call", funcIdx: isConstructorIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: typeErrorArm("TypedArray species is not a constructor"),
+      else: [],
+    },
+    { op: "local.get", index: selectedLocal },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: selectedAnyLocal },
+  );
+
+  // Native TA constructors are handled inline. A null result means that the
+  // selected species is an ordinary closure, so dispatch it through the
+  // reserve/fill native construct driver with the method-specific arguments.
+  emitTaDynCtorConstructFromLocals(ctx, fctx, selectedAnyLocal, options.argLocals);
+  fctx.body.push({ op: "local.set", index: resultLocal });
+  fctx.body.push(
+    { op: "local.get", index: resultLocal },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: selectedLocal },
+        { op: "ref.null.extern" },
+        ...options.argLocals.flatMap((index): Instr[] => [{ op: "local.get", index }]),
+        { op: "call", funcIdx: driverIdx },
+        { op: "local.set", index: resultLocal },
+      ],
+      else: [],
+    },
+  );
+
+  // TypedArrayCreate validates the constructed result before the producer
+  // writes to it. This catches ordinary objects, null, and too-short custom
+  // views with the required TypeError.
+  fctx.body.push(
+    { op: "local.get", index: resultLocal },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: resultAnyLocal },
+    { op: "ref.test", typeIdx: dynIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: typeErrorArm("TypedArray species constructor returned a non-TypedArray"),
+      else: [],
+    },
+    { op: "local.get", index: resultAnyLocal },
+    { op: "ref.cast", typeIdx: dynIdx },
+    { op: "local.set", index: resultDvLocal },
+  );
+  emitTaDynViewValidate(ctx, fctx, resultDvLocal);
+
+  if (options.requestedLengthLocal !== undefined) {
+    fctx.body.push(
+      { op: "local.get", index: resultDvLocal },
+      { op: "struct.get", typeIdx: dynIdx, fieldIdx: 3 },
+      { op: "local.set", index: resultKindLocal },
+    );
+    pushElemSizeForKind(fctx, resultKindLocal);
+    fctx.body.push({ op: "local.set", index: resultEsLocal });
+    pushTaDynViewInBoundsLen(ctx, fctx, resultDvLocal, resultEsLocal);
+    fctx.body.push(
+      { op: "local.get", index: options.requestedLengthLocal },
+      { op: "i32.lt_s" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: typeErrorArm("TypedArray species constructor returned too short"),
+        else: [],
+      },
+    );
+  }
+  return resultLocal;
+}
+
+/**
+ * (#4449) Copy a native numeric result vector into a dynamically-kinded
+ * TypedArray result.  `countLocal` is bounded by the species-create minimum
+ * length check; trailing capacity on an oversized custom result is left at
+ * its constructor-initialized zero value.
+ */
+export function emitTaDynViewWriteF64Vec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  resultDvLocal: number,
+  sourceVecLocal: number,
+  sourceVecTypeIdx: number,
+  sourceElemType: ValType,
+  countLocal: number,
+): void {
+  const dynIdx = getOrRegisterTaDynViewType(ctx);
+  const { vecTypeIdx: byteVecIdx, arrTypeIdx: byteArrIdx } = i32ByteVec(ctx);
+  const sourceArrIdx = getArrTypeIdxFromVec(ctx, sourceVecTypeIdx);
+  if (sourceArrIdx < 0) return;
+
+  const kindLocal = allocLocal(fctx, `__tadw_kind_${fctx.locals.length}`, { kind: "i32" });
+  const esLocal = allocLocal(fctx, `__tadw_es_${fctx.locals.length}`, { kind: "i32" });
+  const arrLocal = allocLocal(fctx, `__tadw_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: byteArrIdx });
+  const baseLocal = allocLocal(fctx, `__tadw_base_${fctx.locals.length}`, { kind: "i32" });
+  const iLocal = allocLocal(fctx, `__tadw_i_${fctx.locals.length}`, { kind: "i32" });
+  const offLocal = allocLocal(fctx, `__tadw_off_${fctx.locals.length}`, { kind: "i32" });
+  const valueLocal = allocLocal(fctx, `__tadw_value_${fctx.locals.length}`, { kind: "f64" });
+  const leLocal = allocLocal(fctx, `__tadw_le_${fctx.locals.length}`, { kind: "i32" });
+
+  fctx.body.push(
+    { op: "local.get", index: resultDvLocal },
+    { op: "struct.get", typeIdx: dynIdx, fieldIdx: 3 },
+    { op: "local.set", index: kindLocal },
+  );
+  pushElemSizeForKind(fctx, kindLocal);
+  fctx.body.push({ op: "local.set", index: esLocal });
+  fctx.body.push(
+    { op: "local.get", index: resultDvLocal },
+    { op: "struct.get", typeIdx: dynIdx, fieldIdx: 1 },
+    { op: "struct.get", typeIdx: byteVecIdx, fieldIdx: 1 },
+    { op: "local.set", index: arrLocal },
+    { op: "local.get", index: resultDvLocal },
+    { op: "struct.get", typeIdx: dynIdx, fieldIdx: 2 },
+    { op: "local.set", index: baseLocal },
+    { op: "i32.const", value: 1 },
+    { op: "local.set", index: leLocal },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: iLocal },
+  );
+
+  const loopBody: Instr[] = [];
+  const saved = fctx.body;
+  fctx.body = loopBody;
+  fctx.body.push(
+    { op: "local.get", index: iLocal },
+    { op: "local.get", index: countLocal },
+    { op: "i32.ge_s" },
+    { op: "br_if", depth: 1 },
+    { op: "local.get", index: sourceVecLocal },
+    { op: "struct.get", typeIdx: sourceVecTypeIdx, fieldIdx: 1 },
+    { op: "local.get", index: iLocal },
+    {
+      op: sourceElemType.kind === "i8" ? "array.get_u" : sourceElemType.kind === "i16" ? "array.get_s" : "array.get",
+      typeIdx: sourceArrIdx,
+    },
+  );
+  if (sourceElemType.kind === "i32" || sourceElemType.kind === "i8" || sourceElemType.kind === "i16") {
+    fctx.body.push({ op: "f64.convert_i32_s" });
+  } else if (sourceElemType.kind !== "f64") {
+    coerceType(ctx, fctx, sourceElemType, { kind: "f64" });
+  }
+  fctx.body.push({ op: "local.set", index: valueLocal });
+  fctx.body.push(
+    { op: "local.get", index: baseLocal },
+    { op: "local.get", index: iLocal },
+    { op: "local.get", index: esLocal },
+    { op: "i32.mul" },
+    { op: "i32.add" },
+    { op: "local.set", index: offLocal },
+    ...emitDynEncodeDispatch(ctx, fctx, kindLocal, arrLocal, offLocal, valueLocal, leLocal, byteArrIdx),
+    { op: "local.get", index: iLocal },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: iLocal },
+    { op: "br", depth: 0 },
+  );
+  fctx.body = saved;
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody }],
+  });
 }
 
 /**

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -23,7 +23,7 @@ import {
   isSymbolType,
 } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
-import { compileArrayMethodCall, resolveArrayInfo } from "../array-methods.js";
+import { compileArrayMethodCall, resolveArrayInfo, tryCompileDynViewSpeciesMethodCall } from "../array-methods.js";
 import { compileArrayConcatNativeSpec } from "../array-concat-spec.js";
 import { isWiredTypedArrayViewName } from "../array-object-proto.js";
 import { ensureWrapperProtoDynamicMember } from "../wrapper-proto-dynamic-demand.js"; // (#4619)
@@ -742,6 +742,13 @@ export function compileReceiverMethodCall(
   const receiverIsExternrefTagged =
     ts.isIdentifier(receiverTagExpr) && ctx.externrefAccessorVars.has(receiverTagExpr.text);
 
+  // (#4449) Dynamic TypedArray producer methods must be recognized before the
+  // generic native-string ladder below: `any` receivers are intentionally
+  // eligible for that ladder, but a boxed dynamic view has its own species
+  // semantics for map/filter/slice/subarray.
+  const dynSpecies = tryCompileDynViewSpeciesMethodCall(ctx, fctx, propAccess, expr, receiverType, expectedType);
+  if (dynSpecies !== undefined) return dynSpecies;
+
   // TextEncoder/TextDecoder under no-JS-host targets. These are standard
   // Web/Node APIs, but WASI/standalone cannot rely on env.TextEncoder_* host
   // imports. Lower the narrow UTF-8 surface natively.
@@ -928,7 +935,9 @@ export function compileReceiverMethodCall(
   if (isExternalDeclaredClass(receiverType, ctx.checker)) {
     const externResult = compileExternMethodCall(ctx, fctx, propAccess, expr);
     // undefined means method not found in extern class hierarchy — fall through to generic handlers
-    if (externResult !== undefined) return externResult;
+    if (externResult !== undefined) {
+      return externResult;
+    }
   }
 
   // (#2865) `.next()` on a DRIVEN async-generator object (typed receiver).
@@ -3499,6 +3508,8 @@ export function compileReceiverMethodCall(
 
     if (isAnyOrExternref) {
       const methodName = propAccess.name.text;
+      const dynSpecies = tryCompileDynViewSpeciesMethodCall(ctx, fctx, propAccess, expr, receiverType, expectedType);
+      if (dynSpecies !== undefined) return dynSpecies;
       const nativeResult = tryCompileNativeGeneratorMethodCall(
         ctx,
         fctx,

--- a/src/codegen/ta-dyn-mop.ts
+++ b/src/codegen/ta-dyn-mop.ts
@@ -44,6 +44,7 @@ import {
   emitDynDecodeDispatch,
   emitDynEncodeDispatch,
   i32ByteVec,
+  getOrRegisterTaCtorSingleton,
   pushElemSizeForKind,
   pushTaDynViewInBoundsLen,
 } from "./dataview-native.js";
@@ -365,6 +366,12 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
     return; // object runtime not in this module — nothing routes here anyway
   }
 
+  // Dynamic view constructor reads are runtime-kind dispatches. Ensure every
+  // non-migrated TypedArray kind has an identity-stable singleton available
+  // before the MOP body captures its fallback chain; the source-level ctor
+  // value may be emitted after this finalize-time fill.
+  for (let k = 1; k < TA_CTOR_KINDS.length; k++) getOrRegisterTaCtorSingleton(ctx, k);
+
   const findFn = (name: string) => {
     const idx = ctx.funcMap.get(name);
     return idx === undefined ? undefined : definedFuncAt(ctx, idx);
@@ -525,8 +532,10 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
     // index after the helper-owned locals avoids aliasing an i32 temporary with
     // this externref slot.
     let aProto = -1;
+    let aProtoValue = -1;
     const hasOwnIdx = ctx.funcMap.get("__hasOwnProperty");
     const getProtoIdx = ctx.funcMap.get("__getPrototypeOf");
+    const isUndefinedIdx = ctx.funcMap.get("__extern_is_undefined");
     const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
     fn.locals.push(
       { name: "__tam_any", type: { kind: "anyref" } },
@@ -566,6 +575,10 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
     if ((mode === "get" || mode === "has") && getProtoIdx !== undefined) {
       aProto = numParams + fn.locals.length;
       fn.locals.push({ name: "__tam_proto", type: { kind: "externref" } });
+    }
+    if (mode === "get") {
+      aProtoValue = numParams + fn.locals.length;
+      fn.locals.push({ name: "__tam_proto_value", type: { kind: "externref" } });
     }
     // key = __to_property_key(key)
     inner.push({ op: "local.get", index: 1 });
@@ -693,14 +706,35 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
           { op: "local.get", index: 0 },
           { op: "call", funcIdx: getProtoIdx },
           { op: "local.set", index: aProto },
-          { op: "local.get", index: aProto },
-          { op: "ref.is_null" },
-          { op: "if", blockType: { kind: "empty" }, then: fallback },
-          { op: "local.get", index: aProto },
-          { op: "local.get", index: aKey },
-          { op: "call", funcIdx: selfIdx },
-          { op: "return" },
         );
+        out.push({ op: "local.get", index: aProto }, { op: "ref.is_null" });
+        out.push({ op: "if", blockType: { kind: "empty" }, then: fallback });
+        if (mode === "get" && isUndefinedIdx !== undefined) {
+          // A freshly materialized native prototype has no companion entry
+          // unless the module also flows that prototype through reflection.
+          // Treat that missing constructor as the intrinsic kind default so a
+          // dynamic view still exposes `view.constructor === TA`.  Keep an
+          // explicitly own expando value on the earlier path, and preserve
+          // non-undefined prototype values (including abrupt getter results).
+          out.push(
+            { op: "local.get", index: aProto },
+            { op: "local.get", index: aKey },
+            { op: "call", funcIdx: selfIdx },
+            { op: "local.set", index: aProtoValue },
+            { op: "local.get", index: aProtoValue },
+            { op: "call", funcIdx: isUndefinedIdx },
+            { op: "if", blockType: { kind: "empty" }, then: fallback },
+            { op: "local.get", index: aProtoValue },
+            { op: "return" },
+          );
+        } else {
+          out.push(
+            { op: "local.get", index: aProto },
+            { op: "local.get", index: aKey },
+            { op: "call", funcIdx: selfIdx },
+            { op: "return" },
+          );
+        }
       } else {
         out.push(...fallback);
       }

--- a/src/codegen/ta-dyn-mop.ts
+++ b/src/codegen/ta-dyn-mop.ts
@@ -520,6 +520,14 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
     const aKey = base + 5; // normalized key externref
     const aN = base + 6; // parsed numeric key f64
     const aExp = base + 7; // (#3177 slice 4) expando $Object externref
+    // `pushTaDynViewInBoundsLen` below allocates scratch locals, so append the
+    // prototype scratch slot only after that helper has finished. Keeping its
+    // index after the helper-owned locals avoids aliasing an i32 temporary with
+    // this externref slot.
+    let aProto = -1;
+    const hasOwnIdx = ctx.funcMap.get("__hasOwnProperty");
+    const getProtoIdx = ctx.funcMap.get("__getPrototypeOf");
+    const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
     fn.locals.push(
       { name: "__tam_any", type: { kind: "anyref" } },
       { name: "__tam_dv", type: { kind: "ref_null", typeIdx: dynIdx } },
@@ -555,6 +563,10 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
     inner.push({ op: "local.set", index: aEs });
     pushTaDynViewInBoundsLen(ctx, fctxLike, aDv, aEs);
     inner.push({ op: "local.set", index: aLen });
+    if ((mode === "get" || mode === "has") && getProtoIdx !== undefined) {
+      aProto = numParams + fn.locals.length;
+      fn.locals.push({ name: "__tam_proto", type: { kind: "externref" } });
+    }
     // key = __to_property_key(key)
     inner.push({ op: "local.get", index: 1 });
     inner.push({ op: "call", funcIdx: tpkIdx });
@@ -578,7 +590,6 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
               ? "__reflect_set"
               : "__delete_property",
     );
-    const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
     const loadExpando = (): Instr[] => [
       { op: "local.get", index: aDv },
       { op: "ref.as_non_null" },
@@ -634,6 +645,65 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
       out.push({ op: "local.get", index: aKey });
       out.push({ op: "call", funcIdx: selfIdx });
       out.push({ op: "return" });
+      return out;
+    };
+
+    // `constructor` is the one named TypedArray property whose ordinary
+    // lookup is observable by the species protocol.  It must consult an own
+    // expando property first, then the selected prototype (which may carry an
+    // inherited getter installed by the test), before falling back to the
+    // intrinsic per-kind carrier.  The old namedValue arm ran first and made
+    // an own `view.constructor = C` invisible to `SpeciesConstructor`.
+    //
+    // Keep the recursive call on the ordinary MOP rather than reaching into
+    // the property table here: that preserves accessor invocation and abrupt
+    // completion propagation for both the expando and prototype paths.
+    const constructorLookup = (): Instr[] => {
+      const fallback: Instr[] =
+        mode === "get"
+          ? [...namedValue("constructor", aDv, aKind, aEs, aLen), { op: "return" }]
+          : [{ op: "i32.const", value: 1 }, { op: "return" }];
+      const out: Instr[] = [];
+      out.push(...loadExpando());
+      if (hasOwnIdx !== undefined && selfIdx !== undefined) {
+        const own: Instr[] = [
+          { op: "local.get", index: aExp },
+          { op: "local.get", index: aKey },
+          { op: "call", funcIdx: hasOwnIdx },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: aExp },
+              { op: "local.get", index: aKey },
+              { op: "call", funcIdx: selfIdx },
+              { op: "return" },
+            ],
+          },
+        ];
+        out.push(
+          { op: "local.get", index: aExp },
+          { op: "ref.is_null" },
+          { op: "i32.eqz" },
+          { op: "if", blockType: { kind: "empty" }, then: own },
+        );
+      }
+      if ((mode === "get" || mode === "has") && getProtoIdx !== undefined && selfIdx !== undefined) {
+        out.push(
+          { op: "local.get", index: 0 },
+          { op: "call", funcIdx: getProtoIdx },
+          { op: "local.set", index: aProto },
+          { op: "local.get", index: aProto },
+          { op: "ref.is_null" },
+          { op: "if", blockType: { kind: "empty" }, then: fallback },
+          { op: "local.get", index: aProto },
+          { op: "local.get", index: aKey },
+          { op: "call", funcIdx: selfIdx },
+          { op: "return" },
+        );
+      } else {
+        out.push(...fallback);
+      }
       return out;
     };
     // (§23.2.3.34) `view[Symbol.toStringTag]` — the %TypedArray%.prototype
@@ -700,9 +770,11 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
           op: "if",
           blockType: { kind: "empty" },
           then:
-            mode === "get"
-              ? [...namedValue(prop, aDv, aKind, aEs, aLen), { op: "return" }]
-              : [{ op: "i32.const", value: 1 }, { op: "return" }],
+            prop === "constructor"
+              ? constructorLookup()
+              : mode === "get"
+                ? [...namedValue(prop, aDv, aKind, aEs, aLen), { op: "return" }]
+                : [{ op: "i32.const", value: 1 }, { op: "return" }],
         });
       }
     }

--- a/tests/issue-4449-species-controls.test.ts
+++ b/tests/issue-4449-species-controls.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, { fileName: "issue-4449-controls.ts", target: "standalone" });
+  expect(result.success, (result.errors ?? []).map((e) => e.message).join("\n")).toBe(true);
+  expect(result.imports.filter((entry) => entry.module === "env")).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#4449 TypedArray species lookup controls", () => {
+  it("honors an own constructor shadow on a dynamic view", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(16);
+          let answer = 0;
+          for (const C of ctors) {
+            const view: any = new C(buffer);
+            view.constructor = 17;
+            answer = view.constructor === 17 ? 1 : 0;
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("propagates an abrupt own constructor getter unchanged", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(16);
+          let answer = 0;
+          for (const C of ctors) {
+            const view: any = new C(buffer);
+            Object.defineProperty(view, "constructor", { get: function(): any { throw 73; } });
+            try { view.constructor; } catch (error) { answer = error === 73 ? 1 : 2; }
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("walks the selected prototype for an inherited constructor getter", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          Object.defineProperty(Int32Array.prototype, "constructor", {
+            get: function(): any { return 91; }, configurable: true
+          });
+          const buffer = new ArrayBuffer(16);
+          let answer = 0;
+          for (const C of ctors) {
+            const view: any = new C(buffer);
+            answer = view.constructor === 91 ? 1 : 0;
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("reads an own Symbol.species value after the constructor shadow", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(16);
+          let answer = 0;
+          for (const C of ctors) {
+            const view: any = new C(buffer);
+            const constructorObject: any = {};
+            view.constructor = constructorObject;
+            constructorObject[Symbol.species] = 123;
+            answer = view.constructor[Symbol.species] === 123 ? 1 : 0;
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("propagates an abrupt Symbol.species getter unchanged", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(16);
+          let answer = 0;
+          for (const C of ctors) {
+            const view: any = new C(buffer);
+            const constructorObject: any = {};
+            view.constructor = constructorObject;
+            Object.defineProperty(constructorObject, Symbol.species,
+              { get: function(): any { throw 79; } });
+            try { view.constructor[Symbol.species]; } catch (error) { answer = error === 79 ? 1 : 2; }
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1);
+  });
+});

--- a/tests/issue-4449-species-producers.test.ts
+++ b/tests/issue-4449-species-producers.test.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, { fileName: "issue-4449-producers.ts", target: "standalone" });
+  expect(result.success, (result.errors ?? []).map((e) => e.message).join("\n")).toBe(true);
+  expect(result.imports.filter((entry) => entry.module === "env")).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#4449 dynamic TypedArray species producers", () => {
+  it("map constructs the custom species and writes its result", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(16);
+          let calls = 0;
+          let other: any;
+          let answer = 0;
+          for (const C of ctors) {
+            const sample: any = new C(buffer);
+            const holder: any = {};
+            holder[Symbol.species] = function(count: number): any {
+              calls++;
+              other = new C(count);
+              return other;
+            };
+            sample.constructor = holder;
+            sample[0] = 40;
+            sample[1] = 41;
+            const result: any = sample.map(function(value: number): number { return value + 7; });
+            answer = calls * 1000 + (result === other ? 100 : 0) + result[0] + result[1];
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1195);
+  });
+
+  it("map defaults nullish species to the original constructor", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(8);
+          let answer = 0;
+          for (const C of ctors) {
+            const sample: any = new C(buffer);
+            const holder: any = {};
+            sample.constructor = holder;
+            const result: any = sample.map(function(value: number): number { return value + 1; });
+            answer = (result.constructor === C ? 1 : 0) * 10 + result[0];
+            holder[Symbol.species] = null;
+            const result2: any = sample.map(function(value: number): number { return value + 2; });
+            answer += (result2.constructor === C ? 1 : 0) * 100 + result2[0];
+          }
+          return answer;
+        }
+      `),
+    ).toBe(113);
+  });
+
+  it("map propagates an abrupt species getter", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(8);
+          let answer = 0;
+          for (const C of ctors) {
+            const sample: any = new C(buffer);
+            const holder: any = {};
+            sample.constructor = holder;
+            Object.defineProperty(holder, Symbol.species, { get: function(): any { throw 79; } });
+            try { sample.map(function(value: number): number { return value; }); }
+            catch (error) { answer = error === 79 ? 1 : 2; }
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("map rejects a custom result shorter than the requested length", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(12);
+          let answer = 0;
+          for (const C of ctors) {
+            const sample: any = new C(buffer);
+            const holder: any = {};
+            holder[Symbol.species] = function(): any { return new C(1); };
+            sample.constructor = holder;
+            try { sample.map(function(value: number): number { return value; }); }
+            catch (error) { answer = error instanceof TypeError ? 1 : 2; }
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("filter constructs the custom species and copies selected values", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(12);
+          let calls = 0;
+          let other: any;
+          let answer = 0;
+          for (const C of ctors) {
+            const sample: any = new C(buffer);
+            const holder: any = {};
+            holder[Symbol.species] = function(count: number): any {
+              calls++;
+              other = new C(count);
+              return other;
+            };
+            sample.constructor = holder;
+            sample[0] = 1;
+            sample[1] = 2;
+            sample[2] = 3;
+            const result: any = sample.filter(function(value: number): boolean { return value >= 2; });
+            answer = calls * 1000 + (result === other ? 100 : 0) + result[0] + result[1];
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1105);
+  });
+
+  it("slice constructs the custom species and copies the window", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(12);
+          let calls = 0;
+          let other: any;
+          let answer = 0;
+          for (const C of ctors) {
+            const sample: any = new C(buffer);
+            const holder: any = {};
+            holder[Symbol.species] = function(count: number): any {
+              calls++;
+              other = new C(count);
+              return other;
+            };
+            sample.constructor = holder;
+            sample[0] = 10;
+            sample[1] = 20;
+            sample[2] = 30;
+            const result: any = sample.slice(1, 3);
+            answer = calls * 1000 + (result === other ? 100 : 0) + result[0] + result[1];
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1150);
+  });
+
+  it("subarray constructs the custom species over the shared buffer", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const ctors: any[] = [Int32Array];
+          const buffer = new ArrayBuffer(12);
+          let calls = 0;
+          let other: any;
+          let answer = 0;
+          for (const C of ctors) {
+            const sample: any = new C(buffer);
+            const holder: any = {};
+            holder[Symbol.species] = function(bufferArg: any, offset: number, length: number): any {
+              calls++;
+              other = new C(bufferArg, offset, length);
+              return other;
+            };
+            sample.constructor = holder;
+            sample[0] = 10;
+            sample[1] = 20;
+            sample[2] = 30;
+            const result: any = sample.subarray(1, 3);
+            answer = calls * 1000 + (result === other ? 100 : 0) + result[0] + result[1];
+          }
+          return answer;
+        }
+      `),
+    ).toBe(1150);
+  });
+});


### PR DESCRIPTION
## Description

This draft implements standalone TypedArray species semantics for dynamic views. It exposes dynamic constructor/species controls, routes `map`, `filter`, `slice`, and `subarray` through a shared species-create path, and now publishes constructor carriers before prototype seeding so default-constructor identity is preserved.

Focused controls pass 12/12, all nine non-BigInt constructor pins pass 36/36, and the constructor/default-identity cluster improves from 0/8 to 8/8 standalone. The full exact cohort is now 28/55 standalone and 52/55 host. It is not yet mergeable because 27 standalone rows and three host rows remain unresolved.

The exact residual partition, implementation plan, validation commands, and handoff are recorded in `plan/issues/4449-typedarray-standalone-semantics-residual.md`.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA
