### PR TITLE
fix(json): preserve reviver abrupt completions in standalone walk

### DIFF
--- a/plan/issues/3176-standalone-json-parse-stringify-residual.md
+++ b/plan/issues/3176-standalone-json-parse-stringify-residual.md
@@ -3,7 +3,7 @@ id: 3176
 title: "standalone: JSON.parse/stringify spec residual — reviver array walk illegal-cast, SyntaxError strictness, replacer/space edges (67 gap tests)"
 status: ready
 created: 2026-07-12
-updated: 2026-07-26
+updated: 2026-08-27
 priority: high
 feasibility: hard
 task_type: bug
@@ -24,6 +24,8 @@ loc-budget-allow:
   - src/codegen/builtin-static-globals.ts
   - src/codegen/native-proto.ts
   - src/codegen/object-runtime.ts
+func-budget-allow:
+  - src/codegen/json-codec-native.ts::emitJsonParseTextReviver
 coercion-sites-allow:
   - src/codegen/json-codec-native.ts
 ---
@@ -304,3 +306,68 @@ Combined validation also passed 25/25 focused tests across rawJSON composition,
 JSON namespace reflection, shared builtin-function metadata, and the
 GeneratorPrototype call/apply safeguards, plus typecheck and the function/LOC
 quality gates.
+
+## 2026-08-27 Luna/max wave plan — seven reviver abrupt-completion rows
+
+The exact ES2015 standalone slice contains these seven non-Proxy `JSON.parse`
+reviver rows: object/array define-property abrupt, object/array delete abrupt,
+object own-keys abrupt, and array length get/coercion abrupt. The cached
+standalone baseline fails all seven because the expected original abrupt value
+is not observed; the worker must establish a fresh authoritative control on its
+checkpoint head.
+
+1. Freeze the seven exact paths and attribute each failure by the reviver walk
+   operation that should complete abruptly. Preserve the original thrown value,
+   not merely the error class.
+2. Fix the existing InternalizeJSONProperty object/array walk at the narrowest
+   shared seam. Do not add a second JSON parser/walker and do not enter Proxy,
+   replacer, stringify, or reflection scope.
+3. Add permanent focused coverage for object define/delete and array
+   define/delete/length abrupt completion, including a normal reviver control.
+4. Rerun exact standalone 7/7 acceptance plus a host regression control. Record
+   denominators, losses, and handoff here. Open a separate ready upstream PR
+   only if complete; otherwise open a draft checkpoint PR.
+
+## 2026-08-27 Luna/max wave — implementation and acceptance
+
+The seven requested rows were frozen to these exact paths (their fixtures use
+Proxy values, but this checkpoint does not modify the Proxy runtime):
+
+- `parse/reviver-object-define-prop-err.js`
+- `parse/reviver-array-define-prop-err.js`
+- `parse/reviver-object-delete-err.js`
+- `parse/reviver-array-delete-err.js`
+- `parse/reviver-object-own-keys-err.js`
+- `parse/reviver-array-length-get-err.js`
+- `parse/reviver-array-length-coerce-err.js`
+
+The fresh pinned-artifact standalone baseline (`run 20260827-043401`) was
+**0/7**: every row completed execution but failed to observe its expected
+`Test262Error`. The shared `__internalize_json_value` walk in
+`src/codegen/json-codec-native.ts` now recognizes the standalone `$Proxy`
+carrier, classifies its array target via `$ObjVec`/`$__vec_base`, and routes
+snapshot enumeration, indexed reads, `length`, deletes, and data-property
+creation through the existing dynamic helpers. Those helpers retain the
+existing Proxy dispatch front guards, so trap exceptions propagate unchanged.
+The walk also uses the lane-aware undefined predicate; under the active
+singleton regime a reviver `undefined` result is no longer confused with JSON
+`null`.
+
+Acceptance and controls:
+
+- exact pinned standalone run `20260827-044840`: **7/7 pass**, **0/7 fail**;
+  denominator is the seven frozen rows (the nine empty generated shards are
+  runner artifacts and are excluded from the conformance report)
+- permanent focused coverage: `tests/issue-3176-reviver-abrupt.test.ts`,
+  **8/8 pass** (all seven trap classes preserve thrown-marker identity, plus a
+  normal reviver control)
+- host-side JSON reviver regression: `tests/issue-2013.test.ts`, **7/7 pass**
+- `pnpm run typecheck`, repository lint, and full Prettier check pass
+- the combined `issue-2013`/`issue-2166` control had one unrelated pre-existing
+  standalone replacer failure in `issue-2166` PR-D3; no JSON reviver control
+  regressed
+
+Handoff: the implementation and focused tests are complete on
+`codex/3176-es2015-reviver-abrupt`; root should open this checkpoint as a
+separate ready PR after verifying topology. The umbrella issue remains ready
+for its other residual rows.

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -49,7 +49,7 @@ import {
   nativeStringType,
   stringConstantExternrefInstrs,
 } from "./native-strings.js";
-import { ensureObjectRuntime, OBJ_FLAG_RAWJSON } from "./object-runtime.js";
+import { ensureObjectRuntime, FLAG_DEFAULT, OBJ_FLAG_RAWJSON } from "./object-runtime.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
 import { addFuncType, getOrRegisterVecBaseType } from "./registry/types.js";
 import { emitJsonQuoteString } from "./json-runtime.js";
@@ -3387,7 +3387,13 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
   const newObjIdx = ctx.funcMap.get("__new_plain_object")!;
   const externSetIdx = ctx.funcMap.get("__extern_set")!;
   const externGetIdx = ctx.funcMap.get("__extern_get")!;
+  const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx")!;
+  const externLengthIdx = ctx.funcMap.get("__extern_length")!;
   const deleteIdx = ctx.funcMap.get("__delete_property")!;
+  const objectKeysIdx = ctx.funcMap.get("__object_keys")!;
+  const createDescriptorIdx = ctx.funcMap.get("__create_descriptor")!;
+  const defineFromDescIdx = ctx.funcMap.get("__obj_define_from_desc")!;
+  const isUndefinedIdx = ctx.funcMap.get("__extern_is_undefined")!;
   const orderedIdx = ctx.funcMap.get("__obj_ordered")!;
   const numToStrIdx = ctx.funcMap.get("number_toString")!;
 
@@ -3401,6 +3407,12 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
   const propEntryTypeIdx = objTypes.propEntryTypeIdx;
   const objVecTypeIdx = objTypes.objVecTypeIdx;
   const objVecArrTypeIdx = objTypes.objVecArrTypeIdx;
+  const proxyTypeIdx = objTypes.proxyTypeIdx;
+  // A literal array uses one of the concrete `__vec_*` carriers, while the
+  // parser's own arrays use `$ObjVec`.  Both are arrays for the purposes of
+  // InternalizeJSONProperty, but neither is a `$Object`; keep this common
+  // supertype test local to the JSON walk rather than widening Proxy itself.
+  const vecBaseTypeIdx = getOrRegisterVecBaseType(ctx);
   const anyStrTypeIdx = ctx.anyStrTypeIdx;
 
   // Pre-register the recursive internalize funcIdx so the body can call itself.
@@ -3432,12 +3444,215 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
   const L_VEC = 12; // ref null $ObjVec
   const L_DATA = 13; // ref $ObjVecArr
   const L_OBJREF = 14; // externref — the $Object/$ObjVec value re-as-externref
+  const L_PROXY_TARGET = 15; // anyref — Proxy [[ProxyTarget]]
+  const L_PROXY_KEYS = 16; // externref — Proxy ownKeys result snapshot
+
+  // The S1 standalone value model carries `undefined` as a non-null singleton;
+  // only the legacy lane conflates it with a null externref.  Keep the branch
+  // predicate lane-aware so JSON `null` is never mistaken for an undefined
+  // reviver result when the singleton is active.
+  const elemIsUndefined = (): Instr[] =>
+    undefinedSingletonActive(ctx)
+      ? [
+          { op: "local.get", index: L_ELEM },
+          { op: "call", funcIdx: isUndefinedIdx },
+        ]
+      : [{ op: "local.get", index: L_ELEM }, { op: "ref.is_null" }];
+
+  // Proxy values are deliberately an opaque standalone struct rather than a
+  // `$Object` subtype.  InternalizeJSONProperty must nevertheless perform the
+  // same observable walk on one: the existing dynamic helpers already carry
+  // the Proxy [[Get]], [[Delete]]/[[OwnPropertyKeys]], and [[DefineOwnProperty]]
+  // front guards, so routing through them preserves both trap abruptness and
+  // the original thrown object.  The array arm obtains `length` through
+  // `__extern_get` before coercing it through the existing array-like
+  // `__extern_length` path; this is the narrow seam needed by the two length
+  // abrupt-completion rows.
+  const proxyObjectArm: Instr[] = [
+    // keys = EnumerableOwnProperties(proxy, "key") — snapshot before walking.
+    { op: "local.get", index: P_VAL },
+    { op: "call", funcIdx: objectKeysIdx },
+    { op: "local.set", index: L_PROXY_KEYS },
+    { op: "local.get", index: L_PROXY_KEYS },
+    { op: "call", funcIdx: externLengthIdx },
+    { op: "i32.trunc_sat_f64_s" },
+    { op: "local.set", index: L_CAP },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: L_I },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L_I },
+            { op: "local.get", index: L_CAP },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            // k = keys[i].  __extern_get_idx handles both `$ObjVec` keys and
+            // a user array returned by an ownKeys trap.
+            { op: "local.get", index: L_PROXY_KEYS },
+            { op: "local.get", index: L_I },
+            { op: "f64.convert_i32_s" },
+            { op: "call", funcIdx: externGetIdxIdx },
+            { op: "local.set", index: L_K },
+            // child = proxy[k] (Proxy [[Get]] front guard).
+            { op: "local.get", index: P_VAL },
+            { op: "local.get", index: L_K },
+            { op: "call", funcIdx: externGetIdx },
+            { op: "local.set", index: L_CHILD },
+            // elem = InternalizeJSONProperty(proxy, k, reviver).
+            { op: "local.get", index: L_CHILD },
+            { op: "local.get", index: P_VAL },
+            { op: "local.get", index: L_K },
+            { op: "local.get", index: P_REVIVER },
+            { op: "call", funcIdx: internFuncIdx },
+            { op: "local.set", index: L_ELEM },
+            // CreateDataProperty(proxy, k, elem), or [[Delete]] for undefined.
+            ...elemIsUndefined(),
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: P_VAL },
+                { op: "local.get", index: L_K },
+                { op: "call", funcIdx: deleteIdx },
+                { op: "drop" },
+              ],
+              else: [
+                { op: "local.get", index: P_VAL },
+                { op: "local.get", index: L_K },
+                { op: "local.get", index: L_ELEM },
+                { op: "i32.const", value: FLAG_DEFAULT },
+                { op: "call", funcIdx: createDescriptorIdx },
+                { op: "call", funcIdx: defineFromDescIdx },
+                { op: "drop" },
+              ],
+            },
+            { op: "local.get", index: L_I },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: L_I },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const proxyArrayArm: Instr[] = [
+    // len = ToLength(Get(proxy, "length")).  Keep the first read on the
+    // Proxy; the temporary ordinary object only reuses the already-native
+    // ToLength(ToNumber(ToPrimitive(...))) implementation.
+    { op: "local.get", index: P_VAL },
+    ...nativeStringLiteralInstrs(ctx, "length"),
+    { op: "extern.convert_any" },
+    { op: "call", funcIdx: externGetIdx },
+    { op: "local.set", index: L_CHILD },
+    { op: "call", funcIdx: newObjIdx },
+    { op: "local.set", index: L_OBJREF },
+    { op: "local.get", index: L_OBJREF },
+    ...nativeStringLiteralInstrs(ctx, "length"),
+    { op: "extern.convert_any" },
+    { op: "local.get", index: L_CHILD },
+    { op: "call", funcIdx: externSetIdx },
+    { op: "local.get", index: L_OBJREF },
+    { op: "call", funcIdx: externLengthIdx },
+    { op: "i32.trunc_sat_f64_s" },
+    { op: "local.set", index: L_CAP },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: L_I },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: L_I },
+            { op: "local.get", index: L_CAP },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: L_I },
+            { op: "f64.convert_i32_s" },
+            { op: "call", funcIdx: numToStrIdx },
+            { op: "local.set", index: L_K },
+            // child = proxy[index] (Proxy [[Get]] front guard).
+            { op: "local.get", index: P_VAL },
+            { op: "local.get", index: L_K },
+            { op: "call", funcIdx: externGetIdx },
+            { op: "local.set", index: L_CHILD },
+            { op: "local.get", index: L_CHILD },
+            { op: "local.get", index: P_VAL },
+            { op: "local.get", index: L_K },
+            { op: "local.get", index: P_REVIVER },
+            { op: "call", funcIdx: internFuncIdx },
+            { op: "local.set", index: L_ELEM },
+            ...elemIsUndefined(),
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: P_VAL },
+                { op: "local.get", index: L_K },
+                { op: "call", funcIdx: deleteIdx },
+                { op: "drop" },
+              ],
+              else: [
+                { op: "local.get", index: P_VAL },
+                { op: "local.get", index: L_K },
+                { op: "local.get", index: L_ELEM },
+                { op: "i32.const", value: FLAG_DEFAULT },
+                { op: "call", funcIdx: createDescriptorIdx },
+                { op: "call", funcIdx: defineFromDescIdx },
+                { op: "drop" },
+              ],
+            },
+            { op: "local.get", index: L_I },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: L_I },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const proxyArm: Instr[] = [
+    { op: "local.get", index: L_ANY },
+    { op: "ref.cast", typeIdx: proxyTypeIdx },
+    { op: "struct.get", typeIdx: proxyTypeIdx, fieldIdx: 1 },
+    { op: "local.set", index: L_PROXY_TARGET },
+    { op: "local.get", index: L_PROXY_TARGET },
+    { op: "ref.test", typeIdx: objVecTypeIdx },
+    { op: "local.get", index: L_PROXY_TARGET },
+    { op: "ref.test", typeIdx: vecBaseTypeIdx },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: proxyArrayArm,
+      else: proxyObjectArm,
+    },
+  ];
 
   const internBody: Instr[] = [
     // any = any.convert_extern(val)
     { op: "local.get", index: P_VAL },
     { op: "any.convert_extern" },
     { op: "local.set", index: L_ANY },
+    // ── $Proxy arm ───────────────────────────────────────────────────────
+    { op: "local.get", index: L_ANY },
+    { op: "ref.test", typeIdx: proxyTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: proxyArm,
+    },
     // ── $Object arm ───────────────────────────────────────────────────────
     { op: "local.get", index: L_ANY },
     { op: "ref.test", typeIdx: objectTypeIdx },
@@ -3496,8 +3711,7 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
                 { op: "call", funcIdx: internFuncIdx },
                 { op: "local.set", index: L_ELEM },
                 // if elem is undefined (null externref) → delete; else set
-                { op: "local.get", index: L_ELEM },
-                { op: "ref.is_null" },
+                ...elemIsUndefined(),
                 {
                   op: "if",
                   blockType: { kind: "empty" },
@@ -3612,6 +3826,8 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
       { count: 1, type: { kind: "ref_null", typeIdx: objVecTypeIdx } }, // L_VEC
       { count: 1, type: { kind: "ref", typeIdx: objVecArrTypeIdx } }, // L_DATA
       { count: 1, type: externref }, // L_OBJREF
+      { count: 1, type: anyref }, // L_PROXY_TARGET
+      { count: 1, type: externref }, // L_PROXY_KEYS
     ],
     body: internBody,
     exported: false,

--- a/tests/issue-3176-reviver-abrupt.test.ts
+++ b/tests/issue-3176-reviver-abrupt.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3176 — JSON.parse reviver abrupt completions (§25.5.1).
+//
+// The native InternalizeJSONProperty walk must route Proxy-backed objects and
+// arrays through their existing MOP helpers.  These checks deliberately throw
+// a caller-owned marker and compare identity after the Wasm boundary: an
+// abrupt completion is not useful if the walk replaces the original value.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const result = await compile(src, { target: "standalone" });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#3176 standalone JSON.parse reviver abrupt completion", () => {
+  it("preserves an object defineProperty trap's thrown identity", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const marker: any = {};
+        const bad: any = new Proxy({ 0: null }, { defineProperty: () => { throw marker; } });
+        try {
+          JSON.parse('["first", null]', function(_: any, value: any) {
+            if (value === "first") this[1] = bad;
+            return value;
+          });
+          return 0;
+        } catch (error) {
+          return error === marker ? 1 : 0;
+        }
+      }`),
+    ).toBe(1);
+  });
+
+  it("preserves an array defineProperty trap's thrown identity", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const marker: any = {};
+        const bad: any = new Proxy([null], { defineProperty: () => { throw marker; } });
+        try {
+          JSON.parse('["first", null]', function(_: any, value: any) {
+            if (value === "first") this[1] = bad;
+            return value;
+          });
+          return 0;
+        } catch (error) {
+          return error === marker ? 1 : 0;
+        }
+      }`),
+    ).toBe(1);
+  });
+
+  it("preserves an object deleteProperty trap's thrown identity", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const marker: any = {};
+        const bad: any = new Proxy({ a: 1 }, { deleteProperty: () => { throw marker; } });
+        try {
+          JSON.parse('[0, 0]', function() { this[1] = bad; });
+          return 0;
+        } catch (error) {
+          return error === marker ? 1 : 0;
+        }
+      }`),
+    ).toBe(1);
+  });
+
+  it("preserves an array deleteProperty trap's thrown identity", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const marker: any = {};
+        const bad: any = new Proxy([0], { deleteProperty: () => { throw marker; } });
+        try {
+          JSON.parse('[0, 0]', function() { this[1] = bad; });
+          return 0;
+        } catch (error) {
+          return error === marker ? 1 : 0;
+        }
+      }`),
+    ).toBe(1);
+  });
+
+  it("preserves an ownKeys trap's thrown identity", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const marker: any = {};
+        const bad: any = new Proxy({}, { ownKeys: () => { throw marker; } });
+        try {
+          JSON.parse('[0, 0]', function() { this[1] = bad; });
+          return 0;
+        } catch (error) {
+          return error === marker ? 1 : 0;
+        }
+      }`),
+    ).toBe(1);
+  });
+
+  it("preserves an array length get trap's thrown identity", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const marker: any = {};
+        const bad: any = new Proxy([], { get: (_: any, name: any) => {
+          if (name === "length") throw marker;
+          return undefined;
+        }});
+        try {
+          JSON.parse('[0, 0]', function() { this[1] = bad; });
+          return 0;
+        } catch (error) {
+          return error === marker ? 1 : 0;
+        }
+      }`),
+    ).toBe(1);
+  });
+
+  it("preserves an array length-coercion trap's thrown identity", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const marker: any = {};
+        const uncoercible: any = { valueOf: () => { throw marker; } };
+        const bad: any = new Proxy([], { get: (_: any, name: any) => {
+          if (name === "length") return uncoercible;
+          return undefined;
+        }});
+        try {
+          JSON.parse('[0, 0]', function() { this[1] = bad; });
+          return 0;
+        } catch (error) {
+          return error === marker ? 1 : 0;
+        }
+      }`),
+    ).toBe(1);
+  });
+
+  it("keeps the ordinary reviver walk intact", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const value: any = JSON.parse('{"items":[1, 2]}', function(_: any, current: any) {
+          return typeof current === "number" ? current + 1 : current;
+        });
+        return value.items[0] === 2 && value.items[1] === 3 ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

This routes Proxy-backed `JSON.parse` reviver containers through the existing object MOP helpers, preserves original abrupt-completion identity during enumeration and mutation, and distinguishes standalone `undefined` from JSON `null`.

The authoritative standalone Test262 slice passes 7/7, focused identity regressions pass 8/8, and host reviver controls pass 7/7, with zero non-passes in the exact slice. The implementation plan and evidence are recorded in issue #3176.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA
