### PR TITLE
fix(codegen): keep runtime eval global sync indices live

### DIFF
--- a/src/codegen/expressions/runtime-eval-provider.ts
+++ b/src/codegen/expressions/runtime-eval-provider.ts
@@ -253,8 +253,8 @@ function ensureRuntimeEvalGlobalLexicalCell(
   return { globalIdx, refCellTypeIdx };
 }
 
-function runtimeEvalSyncFunctionContext(name: string): FunctionContext {
-  return {
+function runtimeEvalSyncFunctionContext(ctx: CodegenContext, name: string): FunctionContext {
+  const fctx: FunctionContext = {
     name,
     params: [],
     locals: [],
@@ -267,6 +267,14 @@ function runtimeEvalSyncFunctionContext(name: string): FunctionContext {
     labelMap: new Map(),
     savedBodies: [],
   };
+  // Attach the reserved body before populating it. Global-string imports may
+  // be registered by later names while this helper is still being built;
+  // fixupModuleGlobalIndices walks module function bodies, so keeping this
+  // array reachable makes earlier global.get/set instructions shift with them.
+  const funcIdx = ctx.funcMap.get(name);
+  const func = funcIdx === undefined ? undefined : definedFuncAt(ctx, funcIdx);
+  if (func) func.body = fctx.body;
+  return fctx;
 }
 
 function reserveRuntimeEvalGlobalBindingSync(ctx: CodegenContext): void {
@@ -534,9 +542,9 @@ function emitRuntimeEvalGlobalBindingPullBody(ctx: CodegenContext, fctx: Functio
 function ensureRuntimeEvalGlobalBindingSync(ctx: CodegenContext): void {
   reserveRuntimeEvalGlobalBindingSync(ctx);
   if (ctx.runtimeEvalGlobalSyncFilled) return;
-  const pushFctx = runtimeEvalSyncFunctionContext(RUNTIME_EVAL_PUSH_GLOBALS);
+  const pushFctx = runtimeEvalSyncFunctionContext(ctx, RUNTIME_EVAL_PUSH_GLOBALS);
   emitRuntimeEvalGlobalBindingPushBody(ctx, pushFctx);
-  const pullFctx = runtimeEvalSyncFunctionContext(RUNTIME_EVAL_PULL_GLOBALS);
+  const pullFctx = runtimeEvalSyncFunctionContext(ctx, RUNTIME_EVAL_PULL_GLOBALS);
   emitRuntimeEvalGlobalBindingPullBody(ctx, pullFctx);
   const pushFn = definedFuncAt(ctx, ctx.funcMap.get(RUNTIME_EVAL_PUSH_GLOBALS)!);
   const pullFn = definedFuncAt(ctx, ctx.funcMap.get(RUNTIME_EVAL_PULL_GLOBALS)!);
@@ -571,7 +579,7 @@ export function emitHostEvalGlobalBindingSeed(ctx: CodegenContext, fctx: Functio
   if (ctx.standalone || ctx.wasi) return;
   reserveRuntimeEvalGlobalBindingSync(ctx);
   if (!ctx.runtimeEvalGlobalSyncFilled) {
-    const pushFctx = runtimeEvalSyncFunctionContext(RUNTIME_EVAL_PUSH_GLOBALS);
+    const pushFctx = runtimeEvalSyncFunctionContext(ctx, RUNTIME_EVAL_PUSH_GLOBALS);
     emitRuntimeEvalGlobalBindingPushBody(ctx, pushFctx, false);
     const pushFn = definedFuncAt(ctx, ctx.funcMap.get(RUNTIME_EVAL_PUSH_GLOBALS)!);
     if (pushFn) {

--- a/tests/issue-4516-es5-residuals.test.ts
+++ b/tests/issue-4516-es5-residuals.test.ts
@@ -28,6 +28,8 @@ const EXACT_RUNTIME_EVAL_ROWS = [
   "annexB/language/eval-code/direct/func-switch-case-eval-func-existing-var-no-init.js",
 ] as const;
 
+const EXACT_HOST_REGRESSION_ROWS = ["built-ins/eval/name.js"] as const;
+
 let liveQuickjsAvailable = false;
 try {
   liveQuickjsAvailable = selectCachedRuntimeEvalProvider().engine === "quickjs";
@@ -63,6 +65,11 @@ async function runStandaloneScript(source: string): Promise<void> {
 }
 
 describe.skipIf(!TEST262_READY)("ES5 standalone residual cluster", () => {
+  it.each(EXACT_HOST_REGRESSION_ROWS)("keeps the host lane valid for %s", async (file) => {
+    const result = await runTest262File(join(TEST262, file), "issue-4516-es5-host-regression", 120_000);
+    expect(result.status, `${file}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
+  });
+
   it.each(EXACT_HOST_FREE_ROWS)("passes the exact residual row %s", async (file) => {
     const result = await runTest262File(join(TEST262, file), "issue-4516-es5-residuals", 120_000, "standalone");
     expect(result.status, `${file}: ${result.reason ?? result.error ?? ""}`).toBe("pass");


### PR DESCRIPTION
## Summary

- attach reserved runtime-eval sync bodies before populating them
- keep already-emitted global.get/set instructions visible to late imported-global fixups
- add exact host-lane coverage for test/built-ins/eval/name.js

## Context

Follow-up to #5030. Its merge-group Test262 aggregation found one real host regression: eval/name.js changed from pass to invalid Wasm because __runtime_eval_push_globals read the stale pre-shift $Hole slot (now an i32 argc global) before extern.convert_any. The original ES5 fixes landed; this one-commit PR contains only the merge-group repair.

## Validation

- exact eval/name.js host row passes
- focused ES5 residual suite: 15/15 via normal pre-commit hook
- typecheck, lint, Prettier, LOC/function budgets, oracle/host-import/dead-export/coercion/any-box/speculative/fallback/stack gates pass
- normal pre-push hook passes, including #3765 18/18 and issue integrity
- no baseline, timeout, dependency, or CI-policy changes