### PR TITLE
fix(ir): authenticate counted native string repeats

### DIFF
--- a/docs/ir/ir-contract.md
+++ b/docs/ir/ir-contract.md
@@ -1,4 +1,4 @@
-# The IR interchange contract — v5.3
+# The IR interchange contract — v5.4
 
 > **Normative.** The #3030 contract is the union of this document,
 > [`ir-module.schema.json`](ir-module.schema.json), and the exported
@@ -37,8 +37,12 @@ One JSON document per compiled module.
 
 ## D2 — Versioning
 
-`IR_FORMAT_VERSION = "5.3"` (exported from `src/ir/contract.ts`). Version 5.3
-adds optional source-qualified counted-append provenance to the typed
+`IR_FORMAT_VERSION = "5.4"` (exported from `src/ir/contract.ts`). Version 5.4
+adds an optional exact counted-append trip-count proof to the typed
+`string.repeat` instruction. When present, it must match the instruction's
+exact `f64` constant definition and may select the native `(string, i32) ->
+string` provider without materializing a full-semantics adapter. Version 5.3
+added optional source-qualified counted-append provenance to the typed
 JS-dialect `string.repeat` instruction. The provenance is semantic contract
 state: when present it identifies the exact checker-proven source, terminal
 owner, and loop span that produced the aggregate repeat. Version 5.2 appended
@@ -98,7 +102,7 @@ work, as recorded in the slice table below.
    classification") is part of this contract; instruction order within a
    block is program order, and any reordering the compiler performed
    respected the classification (#2134). Effects are _derived_ (published
-   table), not serialized per instruction in v5.3.
+   table), not serialized per instruction in v5.4.
 6. **Source positions.** Instructions and terminators may carry
    `site: {line, column}` (1-based line, 0-based column, in the `source`
    file named by the header). Alloc-site provenance rides on `alloc`
@@ -198,7 +202,7 @@ landed.
 
 ```
 IrModuleDocument
-├─ irVersion: "5.3"
+├─ irVersion: "5.4"
 ├─ source?: string
 ├─ coverage: [{unitId, name, carrier: "ir"|"legacy", exported, reason?}]   (D3.7)
 └─ functions: [IrFunctionDoc]           (exactly the carrier:"ir" entries)
@@ -274,7 +278,7 @@ must not diverge (T4 acceptance).
 | --------------- | ------------ | ----------------- | ---------------------------------------- | ------- |
 | `string.const`  | —            | `value: string`, `storage?: GlobalRef`, `materializer?: FuncRef` | ⇒ `string`; storage and materializer are mutually exclusive | pure    |
 | `string.concat` | `lhs`, `rhs` | —                 | operands `string` ⇒ `string`             | pure    |
-| `string.repeat` | `value`, `count` | `encodingEvidence: "ascii"\|"utf8-guaranteed"\|"wtf16"`, `provider: FuncRef`, `countedStringAppendSite?: IrCountedStringAppendSiteId` | `value` is `string`, `count` is `val:f64` ⇒ `string`; ToIntegerOrInfinity; negative or +∞ throws RangeError (or the backend's documented trap where JS exceptions are unavailable) | full barrier |
+| `string.repeat` | `value`, `count` | `encodingEvidence: "ascii"\|"utf8-guaranteed"\|"wtf16"`, `provider: FuncRef`, `countedStringAppendSite?: IrCountedStringAppendSiteId`, `countedStringAppendTripCount?: number` | `value` is `string`, `count` is `val:f64` ⇒ `string`; ToIntegerOrInfinity; negative or +∞ throws RangeError (or the backend's documented trap where JS exceptions are unavailable) | full barrier |
 | `string.eq`     | `lhs`, `rhs` | `negate: boolean` | operands `string` ⇒ `val:i32`            | pure    |
 | `string.len`    | `value`      | —                 | operand `string` ⇒ `val:f64` (JS Number) | pure    |
 
@@ -309,6 +313,16 @@ authenticate counted-append receipts. Every mapper, provider attachment, and
 in-memory instruction digest preserves/includes this field. Until
 ownership-transfer provenance exists, functions carrying it are ineligible for
 `inline-small` and `monomorphize`.
+
+`countedStringAppendTripCount`, when present, is an integer in `[2,
+2147483647]`, requires `countedStringAppendSite`, and must equal the exact f64
+constant defining the instruction's `count` operand. Its `value` operand must
+also be defined by an exact `string.const`, and the literal's UTF-16 code-unit
+length times the trip count must not exceed `0x40000000`, keeping every native
+rope-doubling intermediate signed-i32-safe. This authenticated proof allows the
+native backend to narrow with `i32.trunc_f64_s` and call its existing
+`__str_repeat` kernel directly. Generic, host, and linear repeat providers keep
+the full f64 contract; a counted-native provider without this proof is invalid.
 
 ### Objects, closures, ref cells, classes
 
@@ -426,9 +440,10 @@ boxed, dynamic`.
 
 ## Slice status
 
-| Slice | What                                                        | Status at v5.3                                               |
+| Slice | What                                                        | Status at v5.4                                               |
 | ----- | ----------------------------------------------------------- | ------------------------------------------------------------ |
 | T1    | this document + schema + `IR_FORMAT_VERSION`                | **v5.3 counted `string.repeat` site provenance** (#3518)     |
+| T1.1  | exact counted-repeat trip proof                             | **v5.4 native counted-provider authentication** (#3518)      |
 | T2    | purge module-relative indices from in-memory `IrType` (D5)  | open — until then, affected functions are `carrier:"legacy"` |
 | T3    | `serializeIrModule`/`deserializeIrModule` + `--emit-ir`     | open                                                         |
 | T4    | verifier re-derivation of the §Node-inventory rules (#1924) | open — D3.3 effective from here                              |

--- a/docs/ir/ir-module.schema.json
+++ b/docs/ir/ir-module.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://loopdive.github.io/js2wasm/ir/ir-module.schema.json",
-  "title": "js2wasm IR interchange module (v5.3)",
+  "title": "js2wasm IR interchange module (v5.4)",
   "description": "One serialized IR module (#3030 D1). Normative companion: docs/ir/ir-contract.md — the schema is the syntax gate; per-instruction operand/result typing is enforced by the IR verifier (the semantic conformance checker). Enum tables are append-only with frozen order (D2); any shape change requires an IR_FORMAT_VERSION bump.",
   "type": "object",
   "properties": {
@@ -532,7 +532,13 @@
               "count": { "$ref": "#/$defs/valueId" },
               "encodingEvidence": { "enum": ["ascii", "utf8-guaranteed", "wtf16"] },
               "provider": { "$ref": "#/$defs/funcRef" },
-              "countedStringAppendSite": { "$ref": "#/$defs/countedStringAppendSiteId" }
+              "countedStringAppendSite": { "$ref": "#/$defs/countedStringAppendSiteId" },
+              "countedStringAppendTripCount": {
+                "description": "Exact checker-authenticated f64 constant eligible for the bounded string.const native i32 repeat provider.",
+                "type": "integer",
+                "minimum": 2,
+                "maximum": 2147483647
+              }
             },
             "required": ["value", "count", "encodingEvidence", "provider", "alloc"]
           }

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -1910,3 +1910,48 @@ next implementation transaction must:
 The broader syntax/provider mutation matrix and final R9 switch deletion remain
 separate follow-ups. No performance, retirement-ready, linear cutover, or
 repository-wide IR-only claim follows from this checkpoint.
+
+#### C2c checkpoint: authenticated counted-native repeat provider (2026-08-27)
+
+The accepted-output regression is removed without weakening generic
+`String.prototype.repeat`. IR format v5.4 adds the optional
+`countedStringAppendTripCount` proof to `string.repeat`. Production from-AST
+lowering emits it only for the exact checker-retained counted-loop trip count in
+the signed-i32 range. The verifier requires a matching source-qualified
+`countedStringAppendSite`, an integer in `[2, 2147483647]`, and an exact f64
+constant definition for the instruction's `count` SSA value. The fragment is
+canonicalized from the checker-proven literal/const-alias chain to an exact
+`string.const`; its UTF-16 length times the trip count must stay at or below the
+native kernel's `0x40000000` result bound. Final provenance association joins
+the same trip count and fragment back to the retained syntax plan. Missing,
+borrowed, out-of-range, non-constant, non-literal, oversized-result, and
+provider-without-proof variants fail closed.
+
+Native WasmGC preparation maps only that authenticated form to
+`__ir_string_repeat_counted_native`, whose physical provider is the existing
+`__str_repeat (string, i32) -> string` kernel. Lowering performs the proven-safe
+`i32.trunc_f64_s` conversion at the call site. It does not materialize the
+generic `__ir_string_repeat_native (string, f64) -> string` validation adapter.
+Site-less repeats, out-of-i32-range counted repeats, host strings, and the linear
+backend retain the generic f64 provider and its complete ToIntegerOrInfinity /
+RangeError behavior. Adapter-manifest string-pool metadata remains byte-for-byte
+compatible with direct output even though the counted artifact has no dead
+RangeError path.
+
+On the current arm64 host, the accepted raw and requested-`optimize: 4`
+artifacts both measure **130,062 bytes Prepared versus 130,308 bytes direct**:
+Prepared is now **246 bytes smaller** and 533 bytes smaller than C2b's 130,595
+byte artifact. Both accepted binaries pass `WebAssembly.validate`, preserve DTS,
+imports/exports, string-pool membership, target UnitId, non-target route rows,
+and return `5000`. Named WAT evidence contains `__str_repeat`, contains no
+`__ir_string_repeat_native`, uses non-saturating `i32.trunc_f64_s`, and reduces
+the target's static call count from four to two with no increase in target
+`array.new` or `struct.new` operations. The focused verifier/provider/contract,
+cutover, and phase-tamper suites pass 36/36, and the TypeScript 7 typecheck
+passes.
+
+The no-growth and structural output gates are therefore met. Promotion of
+`IR-OPT-COUNTED-LITERAL-STRING-APPEND` remains withheld until the durable
+30-valid-sample ABBA runtime driver satisfies the existing 5% direct/direct,
+1.05 median, and 1.10 bootstrap-upper-bound gates. The broader syntax/provider
+mutation matrix and final R9 switch deletion remain later transactions.

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-26",
+  "generated": "2026-08-27",
   "populationRule": "A kind is in scope iff it is the `readonly kind` discriminant of a top-level `export interface` that is an arm of the `IrInstr` or `IrTerminator` union in src/ir/nodes.ts. Excluded: the symbolic-reference types IrFuncRef/IrGlobalRef/IrTypeRef (kinds func/global/type) and every inline union member of a payload type. See scripts/check-ir-kind-neutrality.mjs.",
   "ratchet": {
     "unresolved": 3,
@@ -282,9 +282,9 @@
     "forof.string": {
       "verdict": "js",
       "where": "dialect",
-      "declaredAt": "src/ir/dialect/js.ts:711",
+      "declaredAt": "src/ir/dialect/js.ts:713",
       "why": "This is `%String.prototype%[@@iterator]` inlined as a statement form. The per-iteration element is a CODE POINT rendered as a one-element string — the intent field resolves to `__str_charAt_cp`, deliberately not the code-unit `string.char_at` next door. Its general sibling `forof.iter` is already in the dialect, so keeping the string specialization in core splits one protocol across the boundary.",
-      "evidence": ["src/ir/dialect/js.ts:720", "src/ir/integration.ts:5092"]
+      "evidence": ["src/ir/dialect/js.ts:722", "src/ir/integration.ts:5106"]
     },
     "forof.vec": {
       "verdict": "neutral",
@@ -480,16 +480,16 @@
     "string.char_at": {
       "verdict": "js",
       "where": "dialect",
-      "declaredAt": "src/ir/dialect/js.ts:633",
+      "declaredAt": "src/ir/dialect/js.ts:635",
       "why": "ECMAScript §22.1.3.1, twice over: the index is normalized by ToIntegerOrInfinity (§7.1.5) and an out-of-range index yields the EMPTY STRING rather than trapping. That total-function convention is the thing a non-JS producer would have to work around — Java throws, Rust panics.",
-      "evidence": ["src/ir/dialect/js.ts:631", "src/ir/string-runtime.ts:152"]
+      "evidence": ["src/ir/dialect/js.ts:633", "src/ir/string-runtime.ts:169"]
     },
     "string.char_code_at": {
       "verdict": "js",
       "where": "dialect",
-      "declaredAt": "src/ir/dialect/js.ts:645",
+      "declaredAt": "src/ir/dialect/js.ts:647",
       "why": "ECMAScript §22.1.3.2: out-of-range yields NaN. The repo even carries `utf16CharCodeAt` as the reference semantics for backend-independent evidence tests, which is a spec obligation, not a representation choice.",
-      "evidence": ["src/ir/dialect/js.ts:643", "src/ir/string-runtime.ts:160"]
+      "evidence": ["src/ir/dialect/js.ts:645", "src/ir/string-runtime.ts:177"]
     },
     "string.concat": {
       "verdict": "neutral",
@@ -518,7 +518,7 @@
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:1244",
       "why": "The MEANING is settled and it is not encoding-parameterized: every backend returns the UTF-16 CODE-UNIT count. The linear backend calls `__str_length_utf16` regardless of `inputEncoding`, and the WasmGC native provider reads a field documented as the UTF-16 code-unit length. What is NOT settled is the placement: that commitment is shared verbatim with Java/C#/the whole UTF-16 family, so it is not ECMAScript-specific the way `char_at`'s out-of-range sentinel is, yet it is a language commitment a Rust or Python producer could not use.",
-      "evidence": ["src/ir/nodes.ts:1260", "src/ir/backend/linear-integration.ts:1606", "src/ir/string-runtime.ts:15"],
+      "evidence": ["src/ir/nodes.ts:1260", "src/ir/backend/linear-integration.ts:1611", "src/ir/string-runtime.ts:15"],
       "settledBy": "A policy call phase 2 has to make anyway: does `js` mean ECMAScript-SPECIFIC, or LANGUAGE-COMMITTED? If the former, `string.len` stays in core with a documented commitment; if the latter it moves — and the same answer then governs a future `utf16-string` dialect shared by the family, which is the third option."
     },
     "string.repeat": {
@@ -526,7 +526,7 @@
       "where": "dialect",
       "declaredAt": "src/ir/dialect/js.ts:620",
       "why": "ECMAScript String.prototype.repeat owns both the f64 count normalization through ToIntegerOrInfinity and the negative/+Infinity RangeError. A non-JS producer would have to work around that language contract rather than merely select a backend provider.",
-      "evidence": ["src/ir/dialect/js.ts:611", "src/ir/string-runtime.ts:82"]
+      "evidence": ["src/ir/dialect/js.ts:611", "src/ir/string-runtime.ts:99"]
     },
     "switch": {
       "verdict": "neutral",
@@ -599,14 +599,14 @@
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:1733",
       "why": "Builds a dense vector from statically-known elements. Sparse literals are explicitly out of scope and fall back to legacy, so no hole can reach this node.",
-      "evidence": ["src/ir/from-ast.ts:4497"]
+      "evidence": ["src/ir/from-ast.ts:4502"]
     },
     "vec.set": {
       "verdict": "neutral",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:1703",
       "why": "One planned in-bounds store. Bounds and growth policy stay explicit in the surrounding IR; a holey-array store is routed to a runtime helper instead.",
-      "evidence": ["src/ir/nodes.ts:1697", "src/ir/from-ast.ts:375"]
+      "evidence": ["src/ir/nodes.ts:1697", "src/ir/from-ast.ts:380"]
     },
     "vec.set_length": {
       "verdict": "neutral",

--- a/src/codegen/ir-native-string-repeat.ts
+++ b/src/codegen/ir-native-string-repeat.ts
@@ -7,7 +7,7 @@
  * Typed IR deliberately keeps the JS count as f64, so this adapter owns the
  * observable ToIntegerOrInfinity validation before narrowing and delegation.
  */
-import { IR_STRING_REPEAT_FN } from "../ir/string-runtime.js";
+import { IR_COUNTED_STRING_REPEAT_NATIVE_MAX_RESULT_CODE_UNITS, IR_STRING_REPEAT_FN } from "../ir/string-runtime.js";
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import {
@@ -22,12 +22,13 @@ import { ensureNativeStringHelpers } from "./native-strings.js";
 import { addFuncType } from "./registry/types.js";
 
 export const IR_NATIVE_STRING_REPEAT_PROVIDER_FN = `${IR_STRING_REPEAT_FN}_native`;
+export const IR_NATIVE_STRING_REPEAT_RANGE_ERROR_MESSAGE = "RangeError: Invalid count value";
 /**
  * Keeps the rope-doubling kernel's intermediate signed-i32 length below 2^31.
  * A provider may reject a non-empty result at an implementation-size limit;
  * it must never let integer narrowing change the requested count.
  */
-export const IR_NATIVE_STRING_REPEAT_MAX_RESULT_CODE_UNITS = 0x40000000;
+export const IR_NATIVE_STRING_REPEAT_MAX_RESULT_CODE_UNITS = IR_COUNTED_STRING_REPEAT_NATIVE_MAX_RESULT_CODE_UNITS;
 
 interface NativeStringRepeatState {
   readonly funcIdx: number;
@@ -37,6 +38,41 @@ interface NativeStringRepeatState {
 type NativeStringRepeatContext = CodegenContext & {
   __irNativeStringRepeat?: NativeStringRepeatState;
 };
+
+/** Verify the existing native `(string, i32) -> string` repeat kernel. */
+export function hasExactIrNativeCountedStringRepeatProviderAbi(ctx: CodegenContext, funcIdx: number): boolean {
+  const signature = funcSignatureOf(ctx, funcIdx);
+  return (
+    ctx.nativeStrings === true &&
+    ctx.anyStrTypeIdx >= 0 &&
+    nativeStrHelperHandle(ctx, "__str_repeat") === funcIdx &&
+    definedFuncAt(ctx, funcIdx)?.name === "__str_repeat" &&
+    signature?.params.length === 2 &&
+    signature.params[0]?.kind === "ref" &&
+    signature.params[0].typeIdx === ctx.anyStrTypeIdx &&
+    signature.params[1]?.kind === "i32" &&
+    signature.results.length === 1 &&
+    signature.results[0]?.kind === "ref" &&
+    signature.results[0].typeIdx === ctx.anyStrTypeIdx
+  );
+}
+
+/** Resolve the authenticated counted-repeat provider without creating an adapter. */
+export function ensureIrNativeCountedStringRepeatProvider(ctx: CodegenContext): number {
+  if (!ctx.nativeStrings) throw new Error("counted native IR string.repeat provider requires native strings");
+  ensureNativeStringHelpers(ctx);
+  const funcIdx = nativeStrHelperHandle(ctx, "__str_repeat");
+  if (funcIdx === undefined || !hasExactIrNativeCountedStringRepeatProviderAbi(ctx, funcIdx)) {
+    throw new Error("counted native IR string.repeat provider has a malformed __str_repeat ABI");
+  }
+  // Keep CompileResult/adapter-manifest metadata stable against the direct and
+  // generic-provider lanes. Native modules do not import this pool entry; the
+  // authenticated counted path merely removes its dead code materialization.
+  if (!ctx.mod.stringPool.includes(IR_NATIVE_STRING_REPEAT_RANGE_ERROR_MESSAGE)) {
+    ctx.mod.stringPool.push(IR_NATIVE_STRING_REPEAT_RANGE_ERROR_MESSAGE);
+  }
+  return funcIdx;
+}
 
 function hasExactProvider(ctx: CodegenContext, state: NativeStringRepeatState): boolean {
   const signature = funcSignatureOf(ctx, state.funcIdx);
@@ -73,7 +109,7 @@ export function ensureIrNativeStringRepeatProvider(ctx: CodegenContext): number 
   if (ctx.anyStrTypeIdx < 0) throw new Error("native IR string.repeat provider has no AnyString carrier");
   // This may register exception support/imports. Complete it before reading
   // the raw-helper handle or minting the adapter's stable handle.
-  const throwRangeError = buildThrowJsErrorInstrs(ctx, "RangeError", "RangeError: Invalid count value");
+  const throwRangeError = buildThrowJsErrorInstrs(ctx, "RangeError", IR_NATIVE_STRING_REPEAT_RANGE_ERROR_MESSAGE);
   // Each branch owns distinct instruction objects. Later import-index
   // relocation walks both buffers and must never patch a shared call twice.
   const throwInvalidCount = (): Instr[] => throwRangeError.map((instruction) => ({ ...instruction }));

--- a/src/ir/analysis/counted-string-append.ts
+++ b/src/ir/analysis/counted-string-append.ts
@@ -40,6 +40,7 @@ export interface IrCountedStringAppendPlan {
   readonly fragmentSymbol?: ts.Symbol;
   readonly fragmentConstDeclarations: readonly ts.VariableDeclaration[];
   readonly fragmentType: "string";
+  readonly fragmentValue: string;
   readonly tripCount: number;
 }
 
@@ -78,6 +79,7 @@ interface ResolvedStringFragment {
   readonly declaration?: ts.VariableDeclaration;
   readonly symbol?: ts.Symbol;
   readonly declarations: readonly ts.VariableDeclaration[];
+  readonly value: string;
 }
 
 const ASSIGNMENT_OPERATORS = new Set<ts.SyntaxKind>([
@@ -353,7 +355,7 @@ function resolveStringFragment(
 ): ResolvedStringFragment | null {
   const current = unwrapExpression(expression);
   if (ts.isStringLiteral(current) || ts.isNoSubstitutionTemplateLiteral(current)) {
-    return { expression, declarations: [] };
+    return { expression, declarations: [], value: current.text };
   }
   if (!ts.isIdentifier(current) || context.oracle.staticJsTypeOf(current) !== "string") return null;
   const exact = exactVariableDeclaration(context.checker, current, ts.NodeFlags.Const);
@@ -386,6 +388,7 @@ function resolveStringFragment(
     declaration: exact.declaration,
     symbol: exact.symbol,
     declarations: [exact.declaration, ...initializer.declarations],
+    value: initializer.value,
   };
 }
 
@@ -612,6 +615,7 @@ export function planCountedStringAppend(
     fragmentSymbol: fragment.symbol,
     fragmentConstDeclarations: Object.freeze([...fragment.declarations]),
     fragmentType: "string",
+    fragmentValue: fragment.value,
     tripCount,
   });
 }
@@ -651,6 +655,7 @@ export function countedStringAppendPlanIsCurrent(context: ProofContext, plan: Ir
     current.fragmentSymbol === plan.fragmentSymbol &&
     sameDeclarations(current.fragmentConstDeclarations, plan.fragmentConstDeclarations) &&
     current.fragmentType === plan.fragmentType &&
+    current.fragmentValue === plan.fragmentValue &&
     current.tripCount === plan.tripCount
   );
 }

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -197,8 +197,14 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
     inputEncoding: IrStringEncoding,
     out: Instr[],
     provider?: IrFuncRef,
+    countedStringAppendTripCount?: number,
   ): void {
-    const ops = this.options.stringRuntime?.emitStringRepeat?.(alloc, inputEncoding, provider);
+    const ops = this.options.stringRuntime?.emitStringRepeat?.(
+      alloc,
+      inputEncoding,
+      provider,
+      countedStringAppendTripCount,
+    );
     if (!ops) throw new Error("LinearEmitter: string.repeat runtime is unavailable");
     out.push(...ops);
   }

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -1589,7 +1589,12 @@ function makeLinearIrResolver(
       }
       return [{ op: "call", funcIdx: resolveLinearRuntimeOperation(ctx, operation) }];
     },
-    emitStringRepeat(_alloc?: AllocSiteId, _inputEncoding?: IrStringEncoding, provider?: IrFuncRef): readonly Instr[] {
+    emitStringRepeat(
+      _alloc?: AllocSiteId,
+      _inputEncoding?: IrStringEncoding,
+      provider?: IrFuncRef,
+      _countedStringAppendTripCount?: number,
+    ): readonly Instr[] {
       return [
         {
           op: "call",

--- a/src/ir/backend/string-contract.ts
+++ b/src/ir/backend/string-contract.ts
@@ -22,6 +22,7 @@ export interface StringBackendEmitter<Sink> {
     inputEncoding: IrStringEncoding,
     out: Sink,
     provider?: IrFuncRef,
+    countedStringAppendTripCount?: number,
   ): void;
   emitStringEquals(negate: boolean, out: Sink, provider?: IrFuncRef): void;
   emitStringLength(inputEncoding: IrStringEncoding | undefined, out: Sink, provider?: IrStringLengthProvider): void;

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -81,8 +81,9 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     inputEncoding: IrStringEncoding,
     out: Instr[],
     provider?: IrFuncRef,
+    countedStringAppendTripCount?: number,
   ): void {
-    const ops = this.stringRuntime?.emitStringRepeat?.(alloc, inputEncoding, provider);
+    const ops = this.stringRuntime?.emitStringRepeat?.(alloc, inputEncoding, provider, countedStringAppendTripCount);
     if (!ops) throw new Error("WasmGcEmitter: string.repeat runtime is unavailable");
     out.push(...ops);
   }

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -380,6 +380,7 @@ export class IrFunctionBuilder {
     count: IrValueId,
     encodingEvidence: IrStringEncoding,
     countedStringAppendSite?: IrCountedStringAppendSiteId,
+    countedStringAppendTripCount?: number,
   ): IrValueId {
     const result = this.allocator.fresh();
     const resultType: IrType = { kind: "string" };
@@ -394,6 +395,7 @@ export class IrFunctionBuilder {
       alloc,
       encodingEvidence,
       ...(countedStringAppendSite === undefined ? {} : { countedStringAppendSite }),
+      ...(countedStringAppendTripCount === undefined ? {} : { countedStringAppendTripCount }),
     });
     return result;
   }

--- a/src/ir/contract.ts
+++ b/src/ir/contract.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 //
 // ---------------------------------------------------------------------------
-// The IR interchange contract — v5.3 surface (#3030-T1/#3518/#3520/#3521).
+// The IR interchange contract — v5.4 surface (#3030-T1/#3518/#3520/#3521).
 //
 // NORMATIVE artifacts (this module is their code-side anchor):
 //   - docs/ir/ir-contract.md          the contract: D1–D5, guarantees,
@@ -32,7 +32,7 @@ import type { IrUnitId } from "./identity.js";
  * - The (T5) CI schema snapshot fails any PR that changes the serialized
  *   shape without bumping this constant.
  */
-export const IR_FORMAT_VERSION = "5.3";
+export const IR_FORMAT_VERSION = "5.4";
 
 /**
  * Which pipeline compiled a function's body (#3030 D3.7 — the complete

--- a/src/ir/counted-string-append-provenance.ts
+++ b/src/ir/counted-string-append-provenance.ts
@@ -6,7 +6,11 @@ import type { IrSourceId, IrSourceKind, IrUnitId, IrUnitKind } from "./identity.
 import { digestIrInstructions } from "./instruction-digest.js";
 import { forEachInstrDeep, type IrInstr } from "./nodes.js";
 import { IrInvariantError } from "./outcomes.js";
-import { IR_STRING_REPEAT_FN } from "./string-runtime.js";
+import {
+  IR_STRING_REPEAT_COUNTED_NATIVE_FN,
+  IR_STRING_REPEAT_FN,
+  irCountedStringRepeatFitsNativeKernel,
+} from "./string-runtime.js";
 
 declare const irCountedStringAppendSiteIdBrand: unique symbol;
 
@@ -351,7 +355,22 @@ export function associateFinalIrCountedStringAppendSites(
         ) {
           associationMismatch(`site ${siteId} is borrowed by final artifact ${artifact.artifactUnitId}`);
         }
-        if (!nested.provider || !sameIrCallableBinding(nested.provider.binding, plan.provider.binding)) {
+        const expectedTripCount = irCountedStringRepeatFitsNativeKernel(
+          plan.syntaxPlan.tripCount,
+          plan.syntaxPlan.fragmentValue.length,
+        )
+          ? plan.syntaxPlan.tripCount
+          : undefined;
+        if (nested.countedStringAppendTripCount !== expectedTripCount) {
+          associationMismatch(`site ${siteId} carries a mismatched counted trip-count proof`);
+        }
+        const providerSymbol =
+          nested.provider?.binding.kind === "intrinsic" ? nested.provider.binding.symbol : undefined;
+        const hasCanonicalProvider =
+          nested.provider !== undefined &&
+          (sameIrCallableBinding(nested.provider.binding, plan.provider.binding) ||
+            (expectedTripCount !== undefined && providerSymbol === IR_STRING_REPEAT_COUNTED_NATIVE_FN));
+        if (!hasCanonicalProvider) {
           associationMismatch(`site ${siteId} carries a non-canonical final provider`);
         }
         if (observedSites.has(siteId)) associationMismatch(`site ${siteId} occurs more than once in final IR`);

--- a/src/ir/dialect/js.ts
+++ b/src/ir/dialect/js.ts
@@ -626,6 +626,8 @@ export interface IrInstrStringRepeat extends IrInstrBase {
   readonly provider?: IrFuncRef;
   /** Exact counted-loop provenance; absent for unrelated generic repeat producers. */
   readonly countedStringAppendSite?: IrCountedStringAppendSiteId;
+  /** Exact checker-proven count for a bounded string.const native repeat. */
+  readonly countedStringAppendTripCount?: number;
 }
 
 /** Return one UTF-16 code unit as a string, or the empty string out of bounds. */

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -86,7 +86,12 @@ import {
   irUnitFuncRef,
   sameIrCallableBinding,
 } from "./callable-bindings.js";
-import { IR_NUMBER_TO_FIXED_FN, IR_NUMBER_TO_STRING_FN, IR_STRING_REPEAT_FN } from "./string-runtime.js";
+import {
+  IR_NUMBER_TO_FIXED_FN,
+  IR_NUMBER_TO_STRING_FN,
+  IR_STRING_REPEAT_FN,
+  irCountedStringRepeatFitsNativeKernel,
+} from "./string-runtime.js";
 import { irCountedStringAppendSiteIdIsCurrent } from "./counted-string-append-provenance.js";
 import { timerArg, timerResult } from "./timer-shim-lowering.js";
 import { irBool, irTypeIsBoolean, lowerBooleanToString } from "./boolean-brand.js";
@@ -9709,7 +9714,11 @@ function lowerPreparedCountedStringAppend(stmt: ts.ForStatement, cx: LowerCtx): 
 
   if (plan.tripCount > 0) {
     const lhs = cx.builder.emitSlotReadAs(binding.slotIndex, logicalType);
-    const fragment = lowerExpr(plan.fragmentExpression, cx, logicalType);
+    const useCountedNativeRepeat = irCountedStringRepeatFitsNativeKernel(plan.tripCount, plan.fragmentValue.length);
+    const fragment =
+      plan.tripCount >= 2 && useCountedNativeRepeat
+        ? cx.builder.emitStringConst(plan.fragmentValue)
+        : lowerExpr(plan.fragmentExpression, cx, logicalType);
     const fragmentType = cx.builder.typeOf(fragment);
     if (fragmentType.kind !== "string") {
       throw new IrInvariantError(
@@ -9727,6 +9736,7 @@ function lowerPreparedCountedStringAppend(stmt: ts.ForStatement, cx: LowerCtx): 
             cx.builder.emitConst({ kind: "f64", value: plan.tripCount }, irVal({ kind: "f64" })),
             fragmentEncoding,
             loweringPlan.siteId,
+            useCountedNativeRepeat ? plan.tripCount : undefined,
           );
     const proof = proveTypedStringAppend(
       typedValueEvidence(plan.accumulatorRead, logicalType, binding.stringEncoding ?? "wtf16", cx, logicalType),

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -81,7 +81,11 @@ import {
 } from "../codegen/ir-native-map.js"; // (#4461) externref-ABI adapters over the $Map helpers
 import { ensureIrNativePromiseDelayProvider } from "../codegen/ir-native-promise-delay.js";
 import { ensureIrNativePromiseAllProvider } from "../codegen/ir-native-async-runtime.js";
-import { ensureIrNativeStringRepeatProvider } from "../codegen/ir-native-string-repeat.js";
+import {
+  ensureIrNativeCountedStringRepeatProvider,
+  ensureIrNativeStringRepeatProvider,
+  hasExactIrNativeCountedStringRepeatProviderAbi,
+} from "../codegen/ir-native-string-repeat.js";
 import {
   ensureIrHostStringRepeatProvider,
   hasExactIrStringRepeatProviderAbi,
@@ -397,6 +401,7 @@ import {
   IR_STRING_EQUALS_FN,
   IR_STRING_ITERATOR_CHAR_AT_FN,
   IR_STRING_LITERAL_MATERIALIZE_FN,
+  IR_STRING_REPEAT_COUNTED_NATIVE_FN,
   IR_STRING_REPEAT_FN,
 } from "./string-runtime.js";
 export {
@@ -5068,6 +5073,15 @@ function resolveAndObserveCallableProvider(
       const field = symbol === IR_STRING_EQUALS_FN ? "equals" : "concat";
       index = exactCallableImportIndex(ctx, "wasm:js-string", field);
     }
+  } else if (ref.binding.kind === "intrinsic" && symbol === IR_STRING_REPEAT_COUNTED_NATIVE_FN) {
+    index = ensureIrNativeCountedStringRepeatProvider(ctx);
+    if (index !== undefined && index !== null && !hasExactIrNativeCountedStringRepeatProviderAbi(ctx, index)) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        "prepared counted-native string.repeat provider has a malformed physical ABI",
+      );
+    }
   } else if (ref.binding.kind === "intrinsic" && symbol === IR_STRING_REPEAT_FN) {
     index = ctx.nativeStrings ? ensureIrNativeStringRepeatProvider(ctx) : ensureIrHostStringRepeatProvider(ctx);
     if (index !== undefined && index !== null && !hasExactIrStringRepeatProviderAbi(ctx, index)) {
@@ -5437,9 +5451,15 @@ function makeResolver(
       if (idx === undefined) throw new Error("ir/integration: wasm:js-string concat not registered");
       return [{ op: "call", funcIdx: idx }];
     },
-    emitStringRepeat(_alloc, _inputEncoding, provider): readonly Instr[] {
+    emitStringRepeat(_alloc, _inputEncoding, provider, countedStringAppendTripCount): readonly Instr[] {
       if (!provider) throw new Error("ir/integration: string.repeat has no prepared provider");
       const call = { op: "call" as const, funcIdx: resolver.resolveFunc(provider) };
+      if (provider.binding.kind === "intrinsic" && provider.binding.symbol === IR_STRING_REPEAT_COUNTED_NATIVE_FN) {
+        if (!ctx.nativeStrings || countedStringAppendTripCount === undefined) {
+          throw new Error("ir/integration: counted-native string.repeat has no authenticated native proof");
+        }
+        return [{ op: "i32.trunc_f64_s" }, call];
+      }
       return ctx.nativeStrings ? [call, { op: "ref.as_non_null" }] : [call];
     },
     emitStringEquals(provider): readonly Instr[] {
@@ -5767,13 +5787,20 @@ function prepareStrings(ctx: CodegenContext, fns: BuiltFn[]): BuiltFn[] {
   let usesStringOp = false;
   let usesStringLen = false;
   let usesStringCharAt = false;
-  let usesStringRepeat = false;
+  let usesGenericStringRepeat = false;
+  let usesNativeCountedStringRepeat = false;
   const visit = (instr: IrInstr): void => {
     if (instrUsesStrings(instr)) usesStringOp = true;
     if (instr.kind === "string.const") literals.add(instr.value);
     if (instr.kind === "string.len") usesStringLen = true;
     if (instr.kind === "string.char_at") usesStringCharAt = true;
-    if (instr.kind === "string.repeat") usesStringRepeat = true;
+    if (instr.kind === "string.repeat") {
+      if (ctx.nativeStrings && instr.countedStringAppendTripCount !== undefined) {
+        usesNativeCountedStringRepeat = true;
+      } else {
+        usesGenericStringRepeat = true;
+      }
+    }
     // (#3156) The host guarded-charCodeAt helper wraps the `wasm:js-string`
     // charCodeAt/length builtins — its materialization (resolveFunc) reads
     // `ctx.jsStringImports`, so `addStringImports` must have run BEFORE
@@ -5836,13 +5863,19 @@ function prepareStrings(ctx: CodegenContext, fns: BuiltFn[]): BuiltFn[] {
         throw new Error("ir/integration: prepared string.char_at has no exact env.string_charAt import");
       }
     }
-    if (usesStringRepeat) {
+    if (usesGenericStringRepeat) {
       ensureIrHostStringRepeatProvider(ctx);
     }
-  } else if (usesStringRepeat) {
+  } else if (usesGenericStringRepeat) {
     const index = ensureIrNativeStringRepeatProvider(ctx);
     if (!hasExactIrStringRepeatProviderAbi(ctx, index)) {
       throw new Error("ir/integration: prepared native string.repeat provider has a malformed ABI");
+    }
+  }
+  if (usesNativeCountedStringRepeat) {
+    const index = ensureIrNativeCountedStringRepeatProvider(ctx);
+    if (!hasExactIrNativeCountedStringRepeatProviderAbi(ctx, index)) {
+      throw new Error("ir/integration: prepared counted-native string.repeat provider has a malformed ABI");
     }
   }
   // Native strings: nothing to pre-register here. The native-string struct
@@ -5917,6 +5950,12 @@ function prepareStrings(ctx: CodegenContext, fns: BuiltFn[]): BuiltFn[] {
       storageForConst,
       materializerForConst,
       providerForLength: () => lengthProvider,
+      providerForRepeat: (instr) =>
+        irIntrinsicFuncRef(
+          ctx.nativeStrings && instr.countedStringAppendTripCount !== undefined
+            ? IR_STRING_REPEAT_COUNTED_NATIVE_FN
+            : IR_STRING_REPEAT_FN,
+        ),
     });
     return fn === entry.fn ? entry : { ...entry, fn };
   });

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -287,7 +287,12 @@ export interface IrLowerResolver {
   /** `[call concat]` (host) or `[call __str_concat]` (native). */
   emitStringConcat?(alloc?: AllocSiteId, mode?: IrStringConcatMode, provider?: IrFuncRef): readonly Instr[];
   /** Full-semantics `(string, f64) -> string` repeat provider call. */
-  emitStringRepeat?(alloc?: AllocSiteId, inputEncoding?: IrStringEncoding, provider?: IrFuncRef): readonly Instr[];
+  emitStringRepeat?(
+    alloc?: AllocSiteId,
+    inputEncoding?: IrStringEncoding,
+    provider?: IrFuncRef,
+    countedStringAppendTripCount?: number,
+  ): readonly Instr[];
   /** `[call equals]` (host) or `[call __str_equals]` (native). */
   emitStringEquals?(provider?: IrFuncRef): readonly Instr[];
   /**
@@ -2121,7 +2126,13 @@ export function lowerIrFunctionBody<S, Slot>(
       case "string.repeat": {
         emitValue(instr.value, out);
         emitValue(instr.count, out);
-        emitter.emitStringRepeat(instr.alloc, instr.encodingEvidence, out, instr.provider);
+        emitter.emitStringRepeat(
+          instr.alloc,
+          instr.encodingEvidence,
+          out,
+          instr.provider,
+          instr.countedStringAppendTripCount,
+        );
         return;
       }
       case "string.eq": {

--- a/src/ir/string-runtime.ts
+++ b/src/ir/string-runtime.ts
@@ -23,6 +23,23 @@ export const IR_STRING_CONCAT_FN = "__ir_string_concat";
 export const IR_STRING_CONCAT_OWNED_FN = "__ir_string_concat_owned";
 /** Full `String.prototype.repeat` semantics over the backend's string carrier. */
 export const IR_STRING_REPEAT_FN = "__ir_string_repeat";
+/** Native provider for a checker-authenticated exact i32 repeat count. */
+export const IR_STRING_REPEAT_COUNTED_NATIVE_FN = "__ir_string_repeat_counted_native";
+/** Largest exact counted-repeat proof accepted by the native i32 kernel. */
+export const IR_COUNTED_STRING_REPEAT_I32_MAX = 0x7fff_ffff;
+/** Largest non-empty result whose rope-doubling intermediates stay signed-i32-safe. */
+export const IR_COUNTED_STRING_REPEAT_NATIVE_MAX_RESULT_CODE_UNITS = 0x40000000;
+
+export function irCountedStringRepeatFitsNativeKernel(tripCount: number, fragmentCodeUnits: number): boolean {
+  return (
+    Number.isSafeInteger(tripCount) &&
+    tripCount >= 2 &&
+    tripCount <= IR_COUNTED_STRING_REPEAT_I32_MAX &&
+    Number.isSafeInteger(fragmentCodeUnits) &&
+    fragmentCodeUnits >= 0 &&
+    BigInt(tripCount) * BigInt(fragmentCodeUnits) <= BigInt(IR_COUNTED_STRING_REPEAT_NATIVE_MAX_RESULT_CODE_UNITS)
+  );
+}
 /** Semantic prefix for an exact host-provided fixed-arity concat operation. */
 export const IR_STRING_CONCAT_MANY_PREFIX = "string.concat$arity";
 export const IR_STRING_EQUALS_FN = "__ir_string_equals";

--- a/src/ir/string-support.ts
+++ b/src/ir/string-support.ts
@@ -10,6 +10,7 @@ import {
   type IrInstr,
   type IrInstrStringConst,
   type IrInstrStringLen,
+  type IrInstrStringRepeat,
   type IrStringLengthProvider,
 } from "./nodes.js";
 import {
@@ -26,6 +27,7 @@ export interface IrStringSupportProviders {
   readonly storageForConst: (instr: IrInstrStringConst) => IrGlobalRef | undefined;
   readonly materializerForConst?: (instr: IrInstrStringConst) => IrFuncRef | undefined;
   readonly providerForLength: (instr: IrInstrStringLen) => IrStringLengthProvider | undefined;
+  readonly providerForRepeat?: (instr: IrInstrStringRepeat) => IrFuncRef | undefined;
 }
 
 function mapArray<T>(values: readonly T[], map: (value: T) => T): readonly T[] {
@@ -52,12 +54,15 @@ function sameLengthProvider(left: IrStringLengthProvider, right: IrStringLengthP
 }
 
 /** Semantic callable selected from final string IR, before backend binding. */
-export function irStringCallableProviderRef(instr: IrInstr): IrFuncRef | undefined {
+export function irStringCallableProviderRef(
+  instr: IrInstr,
+  providerForRepeat?: (instr: IrInstrStringRepeat) => IrFuncRef | undefined,
+): IrFuncRef | undefined {
   switch (instr.kind) {
     case "string.concat":
       return irIntrinsicFuncRef(instr.concatMode === "owned-append" ? IR_STRING_CONCAT_OWNED_FN : IR_STRING_CONCAT_FN);
     case "string.repeat":
-      return irIntrinsicFuncRef(IR_STRING_REPEAT_FN);
+      return providerForRepeat?.(instr) ?? irIntrinsicFuncRef(IR_STRING_REPEAT_FN);
     case "string.eq":
       return irIntrinsicFuncRef(IR_STRING_EQUALS_FN);
     case "string.char_at":
@@ -132,7 +137,7 @@ export function attachIrStringSupport(fn: IrFunction, providers: IrStringSupport
       nested.kind === "string.char_code_at" ||
       nested.kind === "forof.string"
     ) {
-      const provider = irStringCallableProviderRef(nested)!;
+      const provider = irStringCallableProviderRef(nested, providers.providerForRepeat)!;
       if (nested.provider) {
         if (!sameIrCallableBinding(nested.provider.binding, provider.binding)) {
           throw new Error(`IR ${nested.kind} already carries a different prepared provider binding`);

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -43,7 +43,12 @@ import type { TagDomain } from "./tag-domain.js";
 import { verifyIrIntrinsicInstruction } from "./intrinsic-support.js";
 import { verifyIrAsyncPlan } from "./async-plan.js";
 import { irFnctorShapeEquals, validateIrFnctorShape } from "./fnctor-abi.js";
-import { IR_STRING_REPEAT_FN } from "./string-runtime.js";
+import {
+  IR_COUNTED_STRING_REPEAT_I32_MAX,
+  IR_STRING_REPEAT_COUNTED_NATIVE_FN,
+  IR_STRING_REPEAT_FN,
+  irCountedStringRepeatFitsNativeKernel,
+} from "./string-runtime.js";
 import { parseIrCountedStringAppendSiteId } from "./counted-string-append-provenance.js";
 // #4418 — shared, cached dominance analysis (formerly a private set-based
 // computation in this file, #1850).
@@ -1919,6 +1924,7 @@ export function typeRuleCoverageProblem(kind: IrInstr["kind"], status: TypeRuleS
 interface RoadmapRuleCtx {
   readonly func: IrFunction;
   readonly typeOf: ReadonlyMap<IrValueId, IrType>;
+  readonly definitions: ReadonlyMap<IrValueId, IrInstr>;
   readonly errors: IrVerifyError[];
   /** `func.slots.length` — the bound every `forof.*` slot index must respect. */
   readonly numSlots: number;
@@ -2361,12 +2367,58 @@ function checkStringRepeatTypeRule(
   if (!(["ascii", "utf8-guaranteed", "wtf16"] as readonly unknown[]).includes(instr.encodingEvidence)) {
     roadmapError(ctx, blockId, `string.repeat has invalid encoding evidence ${String(instr.encodingEvidence)}`);
   }
+  const providerSymbol = instr.provider?.binding.kind === "intrinsic" ? instr.provider.binding.symbol : undefined;
   if (
     instr.provider &&
-    (instr.provider.binding.kind !== "intrinsic" || instr.provider.binding.symbol !== IR_STRING_REPEAT_FN)
+    providerSymbol !== IR_STRING_REPEAT_FN &&
+    providerSymbol !== IR_STRING_REPEAT_COUNTED_NATIVE_FN
   ) {
     roadmapError(ctx, blockId, "string.repeat carries a non-canonical provider binding");
   }
+  const exactTripCount = instr.countedStringAppendTripCount;
+  if (exactTripCount === undefined) {
+    if (providerSymbol === IR_STRING_REPEAT_COUNTED_NATIVE_FN) {
+      roadmapError(ctx, blockId, "string.repeat counted-native provider requires an exact counted trip-count proof");
+    }
+    return;
+  }
+  if (instr.countedStringAppendSite === undefined) {
+    roadmapError(ctx, blockId, "string.repeat counted trip-count proof requires counted-loop provenance");
+  }
+  if (
+    !Number.isSafeInteger(exactTripCount) ||
+    exactTripCount < 2 ||
+    exactTripCount > IR_COUNTED_STRING_REPEAT_I32_MAX
+  ) {
+    roadmapError(ctx, blockId, `string.repeat has invalid counted trip-count proof ${String(exactTripCount)}`);
+  }
+  const countDefinition = ctx.definitions.get(instr.count);
+  if (
+    countDefinition?.kind !== "const" ||
+    countDefinition.value.kind !== "f64" ||
+    !Object.is(countDefinition.value.value, exactTripCount)
+  ) {
+    roadmapError(ctx, blockId, "string.repeat counted trip-count proof does not match its exact f64 constant");
+  }
+  const valueDefinition = ctx.definitions.get(instr.value);
+  if (valueDefinition?.kind !== "string.const") {
+    roadmapError(ctx, blockId, "string.repeat counted trip-count proof requires an exact string.const fragment");
+  } else if (!irCountedStringRepeatFitsNativeKernel(exactTripCount, valueDefinition.value.length)) {
+    roadmapError(ctx, blockId, "string.repeat counted trip-count proof exceeds the native result-length bound");
+  }
+}
+
+function collectIrDefinitions(func: IrFunction): ReadonlyMap<IrValueId, IrInstr> {
+  const definitions = new Map<IrValueId, IrInstr>();
+  const collect = (instr: IrInstr): void => {
+    forEachInstrDeep(instr, (nested) => {
+      if (nested.result !== null) definitions.set(nested.result, nested);
+    });
+  };
+  for (const block of func.blocks) for (const instr of block.instrs) collect(instr);
+  for (const state of func.asyncPlan?.states ?? []) for (const instr of state.body) collect(instr);
+  for (const state of func.asyncRuntime?.states ?? []) for (const instr of state.body) collect(instr);
+  return definitions;
 }
 
 function verifyInstrTypeRules(
@@ -2395,6 +2447,7 @@ function verifyInstrTypeRules(
   const roadmap: RoadmapRuleCtx = {
     func,
     typeOf,
+    definitions: collectIrDefinitions(func),
     errors,
     numSlots,
     callSignatures: new Map(),

--- a/tests/backend-contract.test.ts
+++ b/tests/backend-contract.test.ts
@@ -108,7 +108,7 @@ describe("five-part contract surface (#3029-S1)", () => {
 
 describe("IR interchange contract surface (#3030-T1)", () => {
   it("exports the frozen format version", () => {
-    expect(IR_FORMAT_VERSION).toBe("5.3");
+    expect(IR_FORMAT_VERSION).toBe("5.4");
     expect(IR_FORMAT_VERSION).toMatch(/^\d+\.\d+$/);
   });
 
@@ -120,8 +120,8 @@ describe("IR interchange contract surface (#3030-T1)", () => {
     const kinds: string[] = schema.$defs.instrKind.enum;
     // D4: raw.wasm is never serialized.
     expect(kinds).not.toContain("raw.wasm");
-    // v5.2 appended string.repeat; v5.3 adds only its optional counted-site
-    // field, so the frozen instruction-kind ordering is unchanged.
+    // v5.2 appended string.repeat; v5.3/v5.4 add only optional counted-proof
+    // fields, so the frozen instruction-kind ordering is unchanged.
     expect(kinds.slice(-2)).toEqual(["async.throw", "string.repeat"]);
     expect(kinds.filter((kind) => kind === "string.repeat")).toHaveLength(1);
     const repeatRule = schema.$defs.instr.allOf.find(
@@ -130,11 +130,17 @@ describe("IR interchange contract surface (#3030-T1)", () => {
     );
     expect(repeatRule.then.required).toEqual(["value", "count", "encodingEvidence", "provider", "alloc"]);
     expect(repeatRule.then.properties.countedStringAppendSite.$ref).toBe("#/$defs/countedStringAppendSiteId");
+    expect(repeatRule.then.properties.countedStringAppendTripCount).toMatchObject({
+      type: "integer",
+      minimum: 2,
+      maximum: 0x7fff_ffff,
+    });
     expect(schema.$defs.countedStringAppendSiteId).toMatchObject({
       type: "string",
       pattern: expect.stringContaining("ir-counted-string-append-site:v1"),
     });
     expect(repeatRule.then.required).not.toContain("countedStringAppendSite");
+    expect(repeatRule.then.required).not.toContain("countedStringAppendTripCount");
     const countedSiteGrammar = new RegExp(schema.$defs.countedStringAppendSiteId.pattern);
     const canonicalSite =
       "ir-counted-string-append-site:v1:" +

--- a/tests/issue-3518-bench-string-prepared-cutover.test.ts
+++ b/tests/issue-3518-bench-string-prepared-cutover.test.ts
@@ -44,6 +44,8 @@ async function compileBenchString(options: { optimize?: 4 } = {}): Promise<Compi
     experimentalIR: true,
     target: "standalone",
     trackIrOutcomes: true,
+    emitWat: true,
+    emitWatOnlyFunctions: [TARGET, "__ir_string_repeat_native", "__str_repeat"],
     ...options,
   });
 }
@@ -54,6 +56,22 @@ function wasmSurface(binary: Uint8Array) {
     imports: WebAssembly.Module.imports(module),
     exports: WebAssembly.Module.exports(module),
   };
+}
+
+function watFunction(wat: string, name: string): string {
+  const sameLine = wat.indexOf(`(func $${name} `);
+  const start = sameLine >= 0 ? sameLine : wat.indexOf(`(func $${name}\n`);
+  if (start < 0) throw new Error(`missing WAT function ${name}`);
+  let depth = 0;
+  for (let index = start; index < wat.length; index++) {
+    if (wat[index] === "(") depth++;
+    else if (wat[index] === ")" && --depth === 0) return wat.slice(start, index + 1);
+  }
+  throw new Error(`unterminated WAT function ${name}`);
+}
+
+function watOpCount(body: string, op: string): number {
+  return body.split("\n").filter((line) => line.trimStart().startsWith(op)).length;
 }
 
 async function benchStringRuntime(result: CompileResult): Promise<number> {
@@ -137,6 +155,16 @@ describe("#3518 bench_string Prepared C2 cutover", () => {
     expect(prepared.imports).toEqual(direct.imports);
     expect(new Set(prepared.stringPool)).toEqual(new Set(direct.stringPool));
     expect(wasmSurface(prepared.binary)).toEqual(wasmSurface(direct.binary));
+    expect(prepared.binary.length).toBeLessThanOrEqual(direct.binary.length);
+    expect(prepared.wat).not.toContain("(func $__ir_string_repeat_native");
+    expect(prepared.wat).toContain("(func $__str_repeat");
+    const preparedTarget = watFunction(prepared.wat, TARGET);
+    const directTarget = watFunction(direct.wat, TARGET);
+    expect(preparedTarget).toContain("i32.trunc_f64_s");
+    expect(preparedTarget).not.toContain("i32.trunc_sat_f64_s");
+    expect(watOpCount(preparedTarget, "call ")).toBeLessThanOrEqual(watOpCount(directTarget, "call "));
+    expect(watOpCount(preparedTarget, "array.new")).toBeLessThanOrEqual(watOpCount(directTarget, "array.new"));
+    expect(watOpCount(preparedTarget, "struct.new")).toBeLessThanOrEqual(watOpCount(directTarget, "struct.new"));
     await expect(benchStringRuntime(prepared)).resolves.toBe(5000);
     await expect(benchStringRuntime(direct)).resolves.toBe(5000);
 
@@ -150,6 +178,7 @@ describe("#3518 bench_string Prepared C2 cutover", () => {
     const optimizedDirect = await compileBenchString({ optimize: 4 });
     expectSuccess(optimizedDirect);
     expect(wasmSurface(optimizedPrepared.binary)).toEqual(wasmSurface(optimizedDirect.binary));
+    expect(optimizedPrepared.binary.length).toBeLessThanOrEqual(optimizedDirect.binary.length);
     await expect(benchStringRuntime(optimizedPrepared)).resolves.toBe(5000);
     await expect(benchStringRuntime(optimizedDirect)).resolves.toBe(5000);
 

--- a/tests/issue-3518-counted-string-cutover.test.ts
+++ b/tests/issue-3518-counted-string-cutover.test.ts
@@ -58,7 +58,11 @@ function exactLoop(declaration: ts.FunctionDeclaration): ts.ForStatement {
   return loop;
 }
 
-function fixture(tripCount: number): {
+function fixture(
+  tripCount: number,
+  fragmentExpression = '"xy"',
+  declarations = "",
+): {
   readonly checker: ts.TypeChecker;
   readonly oracle: TsCheckerOracle;
   readonly declaration: ts.FunctionDeclaration;
@@ -70,7 +74,8 @@ function fixture(tripCount: number): {
     `
       export function test(): string {
         let value = "seed";
-        for (let index = 0; index < ${tripCount}; index++) value = value + "xy";
+        ${declarations}
+        for (let index = 0; index < ${tripCount}; index++) value = value + ${fragmentExpression};
         return value;
       }
     `,
@@ -103,8 +108,8 @@ function fixture(tripCount: number): {
   return { checker, oracle, declaration, ownerUnitId, identityContext, loweringPlan };
 }
 
-function lowerCounted(tripCount: number) {
-  const exact = fixture(tripCount);
+function lowerCounted(tripCount: number, fragmentExpression?: string, declarations?: string) {
+  const exact = fixture(tripCount, fragmentExpression, declarations);
   const lowered = lowerFunctionAstToIr(exact.declaration, {
     ownerUnitId: exact.ownerUnitId,
     exported: true,
@@ -188,8 +193,25 @@ describe("#3518 Transaction B2 counted-string Prepared cutover", () => {
     expect(
       aggregate.instructions.find((instruction) => instruction.kind === "string.repeat")?.countedStringAppendSite,
     ).toBe(aggregate.exact.loweringPlan.siteId);
+    expect(
+      aggregate.instructions.find((instruction) => instruction.kind === "string.repeat")?.countedStringAppendTripCount,
+    ).toBe(3);
     expect(aggregate.lowered.main.blocks).toHaveLength(1);
     expect(aggregate.lowered.countedStringAppendPlans).toEqual([aggregate.exact.loweringPlan]);
+  });
+
+  it("canonicalizes const aliases to a bounded literal proof and keeps oversized results generic", () => {
+    const alias = lowerCounted(3, "fragment", 'const fragment = "xy";');
+    const repeat = alias.instructions.find((instruction) => instruction.kind === "string.repeat");
+    expect(repeat?.countedStringAppendTripCount).toBe(3);
+    const fragment = alias.instructions.find((instruction) => instruction.result === repeat?.value);
+    expect(fragment).toMatchObject({ kind: "string.const", value: "xy" });
+    expect(alias.exact.loweringPlan.syntaxPlan.fragmentValue).toBe("xy");
+
+    const oversized = lowerCounted(0x2000_0001);
+    expect(
+      oversized.instructions.find((instruction) => instruction.kind === "string.repeat")?.countedStringAppendTripCount,
+    ).toBeUndefined();
   });
 
   it("fails closed on provider, owner, and consumption drift", () => {

--- a/tests/issue-3518-string-repeat-ir.test.ts
+++ b/tests/issue-3518-string-repeat-ir.test.ts
@@ -9,9 +9,12 @@ import {
   hasExactIrStringRepeatProviderAbi,
 } from "../src/codegen/ir-host-string-repeat.js";
 import {
+  ensureIrNativeCountedStringRepeatProvider,
   ensureIrNativeStringRepeatProvider,
+  hasExactIrNativeCountedStringRepeatProviderAbi,
   IR_NATIVE_STRING_REPEAT_MAX_RESULT_CODE_UNITS,
   IR_NATIVE_STRING_REPEAT_PROVIDER_FN,
+  IR_NATIVE_STRING_REPEAT_RANGE_ERROR_MESSAGE,
 } from "../src/codegen/ir-native-string-repeat.js";
 import { addRuntime } from "../src/codegen-linear/runtime.js";
 import {
@@ -35,7 +38,12 @@ import { irVal, type IrFunction, type IrInstr, type IrType } from "../src/ir/nod
 import { deadCode } from "../src/ir/passes/dead-code.js";
 import { renameInstrOperands } from "../src/ir/passes/inline-small.js";
 import { attachIrStringSupport } from "../src/ir/string-support.js";
-import { IR_STRING_REPEAT_FN, repeatString } from "../src/ir/string-runtime.js";
+import {
+  IR_COUNTED_STRING_REPEAT_I32_MAX,
+  IR_STRING_REPEAT_COUNTED_NATIVE_FN,
+  IR_STRING_REPEAT_FN,
+  repeatString,
+} from "../src/ir/string-runtime.js";
 import { createEmptyModule, type Instr, type ValType } from "../src/ir/types.js";
 import { ts } from "../src/ts-api.js";
 import { verifyIrFunction } from "../src/ir/verify.js";
@@ -72,9 +80,34 @@ function repeatFunction(
 }
 
 function repeatNode(fn: IrFunction): Extract<IrInstr, { kind: "string.repeat" }> {
-  const instruction = fn.blocks[0]!.instrs[0]!;
-  if (instruction.kind !== "string.repeat") throw new Error("fixture lost string.repeat");
+  const instruction = fn.blocks[0]!.instrs.find(
+    (candidate): candidate is Extract<IrInstr, { kind: "string.repeat" }> => candidate.kind === "string.repeat",
+  );
+  if (!instruction) throw new Error("fixture lost string.repeat");
   return instruction;
+}
+
+function exactCountedRepeatFunction(tripCount = 3, proof = tripCount): IrFunction {
+  const registry = new AllocSiteRegistry();
+  const identity = identities.next(`counted-repeat-${tripCount}-${proof}`);
+  const builder = new IrFunctionBuilder(identity, [STRING], false, registry);
+  builder.addParam("dynamicValue", STRING);
+  builder.openBlock();
+  const value = builder.emitStringConst("ab");
+  const count = builder.emitConst({ kind: "f64", value: tripCount }, F64);
+  const site = createIrCountedStringAppendSiteId({
+    sourceId: identities.sourceId,
+    ownerUnitId: identity.unitId,
+    loopStart: 17,
+    loopEnd: 43,
+  });
+  const result = builder.emitStringRepeat(value, count, "ascii", site, proof);
+  builder.terminate({ kind: "return", values: [result] });
+  return attachIrStringSupport(builder.finish(), {
+    storageForConst: () => undefined,
+    providerForLength: () => undefined,
+    providerForRepeat: () => irIntrinsicFuncRef(IR_STRING_REPEAT_COUNTED_NATIVE_FN),
+  });
 }
 
 function resolver(stringType: ValType, callIndex: number): IrLowerResolver {
@@ -196,6 +229,63 @@ describe("#3518 Transaction B — typed string.repeat foundation", () => {
     expect(verifyIrFunction(foreignOwnerSite).some((error) => /malformed or foreign-owner/.test(error.message))).toBe(
       true,
     );
+  });
+
+  it("authenticates the exact counted-native trip proof and rejects every mismatch", () => {
+    const fn = exactCountedRepeatFunction();
+    const node = repeatNode(fn);
+    expect(node).toMatchObject({
+      countedStringAppendTripCount: 3,
+      provider: irIntrinsicFuncRef(IR_STRING_REPEAT_COUNTED_NATIVE_FN),
+    });
+    expect(verifyIrFunction(fn)).toEqual([]);
+
+    const mutate = (replacement: Partial<typeof node>): IrFunction => ({
+      ...fn,
+      blocks: [
+        {
+          ...fn.blocks[0]!,
+          instrs: fn.blocks[0]!.instrs.map((instruction) =>
+            instruction.kind === "string.repeat" ? { ...instruction, ...replacement } : instruction,
+          ),
+        },
+      ],
+    });
+    expect(
+      verifyIrFunction(mutate({ countedStringAppendTripCount: 4 })).some((error) =>
+        /does not match.*f64/.test(error.message),
+      ),
+    ).toBe(true);
+    expect(
+      verifyIrFunction(mutate({ countedStringAppendTripCount: 1 })).some((error) =>
+        /invalid counted trip-count/.test(error.message),
+      ),
+    ).toBe(true);
+    expect(
+      verifyIrFunction(mutate({ countedStringAppendTripCount: IR_COUNTED_STRING_REPEAT_I32_MAX + 1 })).some((error) =>
+        /invalid counted trip-count/.test(error.message),
+      ),
+    ).toBe(true);
+    expect(
+      verifyIrFunction(mutate({ countedStringAppendSite: undefined })).some((error) =>
+        /requires counted-loop provenance/.test(error.message),
+      ),
+    ).toBe(true);
+    expect(
+      verifyIrFunction(mutate({ countedStringAppendTripCount: undefined })).some((error) =>
+        /provider requires.*proof/.test(error.message),
+      ),
+    ).toBe(true);
+    expect(
+      verifyIrFunction(mutate({ value: fn.params[0]!.value })).some((error) =>
+        /requires an exact string\.const/.test(error.message),
+      ),
+    ).toBe(true);
+    expect(
+      verifyIrFunction(exactCountedRepeatFunction(0x2000_0001)).some((error) =>
+        /result-length bound/.test(error.message),
+      ),
+    ).toBe(true);
   });
 
   it("authenticates counted provenance inside semantic async state bodies", () => {
@@ -551,6 +641,28 @@ describe("#3518 Transaction B — typed string.repeat foundation", () => {
     const signature = funcSignatureOf(ctx, index)!;
     signature.params[1] = { kind: "i32" };
     expect(() => ensureIrNativeStringRepeatProvider(ctx)).toThrow(/lost its exact ABI/);
+  });
+
+  it("reuses the exact native i32 kernel for authenticated counted repeats", async () => {
+    await import("../src/codegen/expressions.js");
+    const ctx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker, {
+      target: "standalone",
+      nativeStrings: true,
+    });
+    const index = ensureIrNativeCountedStringRepeatProvider(ctx);
+    expect(index).toBe(nativeStrHelperHandle(ctx, "__str_repeat"));
+    expect(hasExactIrNativeCountedStringRepeatProviderAbi(ctx, index)).toBe(true);
+    expect(funcSignatureOf(ctx, index)).toMatchObject({
+      params: [{ kind: "ref", typeIdx: ctx.anyStrTypeIdx }, { kind: "i32" }],
+      results: [{ kind: "ref", typeIdx: ctx.anyStrTypeIdx }],
+    });
+    expect(ctx.mod.functions.some((fn) => fn.name === IR_NATIVE_STRING_REPEAT_PROVIDER_FN)).toBe(false);
+    expect(ctx.mod.stringPool).toContain(IR_NATIVE_STRING_REPEAT_RANGE_ERROR_MESSAGE);
+
+    const signature = funcSignatureOf(ctx, index)!;
+    signature.params[1] = { kind: "f64" };
+    expect(hasExactIrNativeCountedStringRepeatProviderAbi(ctx, index)).toBe(false);
+    expect(() => ensureIrNativeCountedStringRepeatProvider(ctx)).toThrow(/malformed __str_repeat ABI/);
   });
 
   it("executes the reserved linear provider with validation before empty handling", async () => {

--- a/tests/issue-3520-callable-binding.test.ts
+++ b/tests/issue-3520-callable-binding.test.ts
@@ -142,6 +142,6 @@ describe("#3520 structural callable bindings", () => {
   });
 
   it("retains callable bindings in the class-identity interchange revision", () => {
-    expect(IR_FORMAT_VERSION).toBe("5.3");
+    expect(IR_FORMAT_VERSION).toBe("5.4");
   });
 });


### PR DESCRIPTION
## Summary

- authenticate the counted string-repeat provider with exact IR trip-count and literal-fragment proofs
- reuse the native i32 repeat kernel only for verifier-approved bounded repeats while preserving generic f64 repeat semantics elsewhere
- bump the IR interchange contract to v5.4 and document the provider proof
- update the #3518 implementation plan with C2c evidence and the next runtime gate

## Evidence

- Prepared raw artifact: 130,062 bytes vs direct 130,308 bytes (-246 bytes)
- Prepared target executes correctly and returns 5000
- focused IR/backend tests: 36 passed
- TypeScript 7 typecheck passed
- pre-push typecheck, lint, formatting, oracle/coercion ratchets, numeric-local parity (18 tests), and issue integrity passed

Relates to #3518.