### PR TITLE
fix(generators): advance yield-star throw delegation

### DIFF
--- a/plan/issues/1691-yieldstar-throw-return-delegation.md
+++ b/plan/issues/1691-yieldstar-throw-return-delegation.md
@@ -310,3 +310,42 @@ committed separately from the remaining standalone work.
   rewrite, runner exemption, or host-oracle dependency is introduced.
 - The upstream PR uses the exact Description/CLA template and remains draft
   until the scoped fix is complete, current-main based, CI-green, and mergeable.
+
+### Closeout handoff — 2026-08-27
+
+The final bounded rerun used the exact 13-row list above, the pinned Test262
+checkout, the maintained assembled harness, the pinned QuickJS artifact
+`/private/tmp/js2-quickjs-artifact-2e2d7736713beeda`, LLVM 18, and two workers.
+The fresh local JSONL artifacts are:
+
+- host: `/private/tmp/js2-1691-host-exact-closeout.jsonl` — **13/13 pass**;
+  0 assertion failures, 0 compile errors, 0 timeouts, 0 skips;
+- standalone: `/private/tmp/js2-1691-standalone-exact-closeout.jsonl` —
+  **9/13 pass**, 4 assertion failures, 0 compile errors, 0 timeouts, 0 skips.
+
+The four standalone residuals are:
+
+- `star-rhs-iter-thrw-thrw-call-non-obj.js`: the delegated primitive result
+  reaches the protocol path, but the caught native `TypeError` is observed as
+  `undefined`;
+- `star-rhs-iter-thrw-violation-no-rtrn.js`: the missing-`throw` getter/fallback
+  count remains `0`;
+- `star-rhs-iter-thrw-violation-rtrn-call-non-obj.js`: the caught native
+  `TypeError` is observed as `undefined`;
+- `star-rhs-iter-thrw-violation-rtrn-invoke.js`: the missing-`throw` getter
+  count remains `0`.
+
+The current source checkpoint is `66d8238c4` (`fix(generators): preserve
+yield-star throw protocol results ✓`), with a clean worktree. It is retained
+because it is materially above the prior 548b34de2 checkpoint: host **13/13**
+and standalone **9/13** on the exact cohort. No additional uncommitted
+experiment is being carried forward.
+
+The host lane is complete for this slice. The remaining standalone failures
+are handed off as a substrate follow-up: native `$Error_struct` payloads do not
+survive the standardized `try_table` catch binding in the generic standalone
+path, and the native plain-object fallback does not observe the accessor
+method reads in these two return-fallback rows. Fixing those requires a
+separate standalone exception/property-dispatch investigation; no further
+scope expansion is made here. Keep the implementation PR draft/hold until
+that follow-up (or an explicitly narrowed acceptance decision) is resolved.

--- a/plan/issues/1691-yieldstar-throw-return-delegation.md
+++ b/plan/issues/1691-yieldstar-throw-return-delegation.md
@@ -20,11 +20,15 @@ loc-budget-allow:
   - src/codegen/iterator-native.ts
   - src/codegen/registry/imports.ts
   - src/runtime.ts
+  - src/codegen/object-ops.ts
+  - src/codegen/property-access-dispatch.ts
 func-budget-allow:
   - src/codegen/generators-native.ts::compileState
   - src/codegen/generators-native.ts::buildNativeGeneratorPlan
   - src/codegen/iterator-native.ts::fillNativeIteratorLateArms
   - src/runtime.ts::resolveImport
+  - src/codegen/object-ops.ts::compileObjectDefineProperty
+  - src/codegen/property-access-dispatch.ts::finalizeStructAndDynamicMemberGet
 ---
 # #1691 — yield* does not delegate throw()/return() to the inner iterator
 
@@ -277,6 +281,25 @@ the remaining semantic cases (primitive result/error propagation, lazy
 pre-existing native-host parity residuals. The generated reports are
 `benchmarks/results/test262-standalone-report-20260827-154226.json` and
 `benchmarks/results/test262-report-20260827-154404.json`.
+
+The next bounded checkpoint (2026-08-27, after the shared value/getter/return
+seam changes) used the same pinned 13-row list and the maintained assembled
+harness in both lanes. Host is now **13/13 pass, 0 assertion failures, 0
+compile errors, 0 timeouts, and 0 skips**; the local JSONL is
+`/private/tmp/js2-1691-host-exact-after-accessors.jsonl`. Standalone is
+**9/13 pass, 4 assertion failures, 0 compile errors, 0 timeouts, and 0
+skips**; the local JSONL is
+`/private/tmp/js2-1691-standalone-exact-after-accessors.jsonl`.
+
+The four standalone residuals are `thrw-call-non-obj` (the delegated
+non-object result's `value` observation), `violation-no-rtrn` (missing
+`throw` getter/fallback count), `violation-rtrn-call-non-obj` (caught
+TypeError visibility), and `violation-rtrn-invoke` (missing `throw` getter
+count). The `res-done-no-value` and `res-value-err` accessor-order rows now
+pass in standalone. The host lane's corresponding four rows pass after
+routing module-global externref receivers through the dynamic property path
+and constructing protocol TypeErrors in the test realm. This checkpoint is
+committed separately from the remaining standalone work.
 
 ### Resume acceptance
 

--- a/plan/issues/1691-yieldstar-throw-return-delegation.md
+++ b/plan/issues/1691-yieldstar-throw-return-delegation.md
@@ -15,6 +15,16 @@ goal: spec-completeness
 parent: 1665
 assignee: ttraenkler/codex-es6-yieldstar-throw
 related: [1042, 1665, 2170, 2173, 3711]
+loc-budget-allow:
+  - src/codegen/generators-native.ts
+  - src/codegen/iterator-native.ts
+  - src/codegen/registry/imports.ts
+  - src/runtime.ts
+func-budget-allow:
+  - src/codegen/generators-native.ts::compileState
+  - src/codegen/generators-native.ts::buildNativeGeneratorPlan
+  - src/codegen/iterator-native.ts::fillNativeIteratorLateArms
+  - src/runtime.ts::resolveImport
 ---
 # #1691 — yield* does not delegate throw()/return() to the inner iterator
 
@@ -221,6 +231,38 @@ bounded protocol-completion slice.
    regression suites, same-base pass-to-nonpass comparison, and mandatory
    gates. Record artifacts, counts, root cause, residual ownership, commit SHA,
    and handoff here.
+
+### Checkpoint evidence — 2026-08-27
+
+The exact candidate list is the 13 sorted files matching
+`language/expressions/yield/star-rhs-iter-thrw-` in the pinned Test262 checkout
+at `b363f29d3c43c626dc852744ad64a0b48a003693`.
+
+- Host lane, maintained runner `20260827-134605`: **0/13 pass, 13/13 fail**;
+  all rows reached execution through the eager/native host helpers. The report
+  is `benchmarks/results/test262-report-20260827-134605.json`.
+- Standalone lane, maintained runner `20260827-134804`: **0/13 pass,
+  13/13 compile_error**. Every row was rejected by the generic `#680`
+  complex-native-generator-shape diagnostic before execution. The report is
+  `benchmarks/results/test262-standalone-report-20260827-134804.json`.
+  Both runs used LLVM 18, two workers, and the pinned QuickJS artifact
+  `/private/tmp/js2-quickjs-artifact-2e2d7736713beeda` (sha256 prefix
+  `073742801ba76347`).
+
+The first native protocol prototype reached execution after widening the
+post-hoc `Symbol.iterator` proof to the enclosing source file. Exact standalone
+runner `20260827-145641` measured **1/13 pass, 2/13 assertion failures, and
+10/13 wasm_compile failures** (the latter were resume branch-depth validation
+errors in `__gen_resume_g`; the two runtime residuals were delegate completion
+value/access-order cases). The generated report is
+`benchmarks/results/test262-standalone-report-20260827-145641.json`.
+
+The current checkpoint additionally fixes the shared resume branch-depth
+calculation and validates the formerly failing `thrw-call-non-obj.js` binary
+directly; the exact 13-row regression is intentionally still pending. The
+remaining semantic work is to preserve the delegate's non-done result identity
+while keeping `IteratorValue` lazy, and to complete the throw/return fallback
+and host-lane parity checks.
 
 ### Resume acceptance
 

--- a/plan/issues/1691-yieldstar-throw-return-delegation.md
+++ b/plan/issues/1691-yieldstar-throw-return-delegation.md
@@ -264,6 +264,20 @@ remaining semantic work is to preserve the delegate's non-done result identity
 while keeping `IteratorValue` lazy, and to complete the throw/return fallback
 and host-lane parity checks.
 
+The bounded exact regression was rerun after the branch-depth and native
+IteratorResult validation changes. Maintained runner `20260827-154226` (the
+standalone/QuickJS lane) records **7/13 pass, 6/13 assertion failures, 0
+compile errors, 0 timeouts, and 0 skips**. Maintained runner `20260827-154404`
+(the host/GC lane) records **3/13 pass, 10/13 assertion failures, 0 compile
+errors, 0 timeouts, and 0 skips**. Both reports contain exactly the 13 filtered
+candidate rows; the empty local shard files are harness noise and are not part
+of the denominator. The standalone failures now execute far enough to expose
+the remaining semantic cases (primitive result/error propagation, lazy
+`value`/getter observation, and return fallback); the host failures remain the
+pre-existing native-host parity residuals. The generated reports are
+`benchmarks/results/test262-standalone-report-20260827-154226.json` and
+`benchmarks/results/test262-report-20260827-154404.json`.
+
 ### Resume acceptance
 
 - The current candidate denominator and both-lane baseline are exact.

--- a/src/codegen/generators-native-consumer.ts
+++ b/src/codegen/generators-native-consumer.ts
@@ -655,7 +655,13 @@ export function tryCompileNativeGeneratorResultProperty(
     // ref-identity and answers UNEQUAL, so the test262 harness shape
     // `assert_sameValue_bool(g.next().done, true)` failed on every native
     // generator (the residual "returned 2" of the #2938 no-yield relax).
-    return propName === "value" ? valVT : { kind: "i32", boolean: true };
+    // Native numeric IteratorResult values use the NaN payload as an internal
+    // stand-in for `undefined`. Preserve that identity through the typed read
+    // as well as the open-result reader; the coercion engine can then restore
+    // canonical `undefined` when an any-valued consumer (for example
+    // `assert.sameValue(result.value, undefined)`) boxes this value.
+    const valueType = valVT.kind === "f64" ? { ...valVT, undefSentinel: true as const } : valVT;
+    return propName === "value" ? valueType : { kind: "i32", boolean: true };
   }
 
   if (resultType?.kind === "externref") {

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -3298,8 +3298,7 @@ function compileState(
     const abruptBody: Instr[] = [];
     const savedAbrupt = fctx.body;
     fctx.body = abruptBody;
-    const genericDelegation = state.terminator.kind === "yield-star" && state.terminator.delegationKind === "iterable";
-    if (genericDelegation) {
+    if (state.terminator.kind === "yield-star" && state.terminator.delegationKind === "iterable") {
       // §14.4.14 / §27.5.3.7: a throw/return resumed at a live generic
       // delegation first acts on the iterator record.  The host lane uses the
       // actual JS iterator object; standalone/WASI uses the native $__IterRec.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -57,7 +57,7 @@ import { bodyNeedsArgumentsObject } from "./helpers/body-uses-arguments.js";
 import { isSimpleParameterList, isStrictFunction } from "./helpers/is-strict-function.js";
 import { resolveSpillLocalValType } from "./statements/variables.js";
 import { resolveWasmType } from "./index.js";
-import { ensureExnTag } from "./registry/imports.js";
+import { addIteratorImports, ensureExnTag } from "./registry/imports.js";
 import { buildTargetTaggedTry } from "../ir/try-table.js";
 // (#2895 PR1) The frame ABI (state-struct field offsets + resume modes) and the
 // field-I/O / spill-store emit helpers now live in the shared resumable-frame
@@ -147,6 +147,8 @@ type StateTerminator =
       siteIndex: number;
       next: number;
       bindResultTo?: string;
+      /** Assignment LHS receiving the delegation completion value. */
+      completionExpr?: ts.Expression;
     }
   // (#2173 slice-2a) `yield* <numeric-array/vec>` — delegate to a NUMERIC
   // iterable by driving a vec cursor directly (the array for-of fast path),
@@ -162,6 +164,7 @@ type StateTerminator =
       vecSiteIndex: number;
       next: number;
       bindResultTo?: string;
+      completionExpr?: ts.Expression;
     }
   // (#2173 slice-2b) `yield* <generic iterable>` — delegate to a `.values()`
   // iterator or a custom `{ [Symbol.iterator]() { return { next() {…} } } }` by
@@ -178,6 +181,7 @@ type StateTerminator =
       iterableSiteIndex: number;
       next: number;
       bindResultTo?: string;
+      completionExpr?: ts.Expression;
     };
 
 /**
@@ -356,7 +360,14 @@ function isNumericExpression(ctx: CodegenContext, expr: ts.Expression | undefine
 function isStringYieldExpression(ctx: CodegenContext, expr: ts.Expression | undefined): boolean {
   if (!expr) return false;
   if (!(ctx.nativeStrings && ctx.anyStrTypeIdx >= 0)) return false;
-  return isStringType(ctx.checker.getTypeAtLocation(expr));
+  try {
+    return isStringType(ctx.checker.getTypeAtLocation(expr));
+  } catch {
+    // A JavaScript object literal with a late-bound `throw` member can trip a
+    // TypeScript checker late-symbol assertion. Treat the operand as non-string
+    // and let the generic iterable proof decide admission.
+    return false;
+  }
 }
 
 /**
@@ -470,6 +481,11 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
   // whose declaration-shape cascade doesn't model a yield* initializer, nor via
   // the `sent`-carrier rule, which types `.next(v)` bindings).
   const delegationBindingNames = new Set<string>();
+  // Synthetic locals used when a yield* expression is the RHS of an assignment
+  // statement (`exprValue = yield* iterable`). The assignment itself runs in
+  // the successor state; the synthetic binding carries the completion value
+  // through the done arm without mistaking the next `.next(v)` argument for it.
+  const delegationBindingTypes = new Map<string, ValType>();
   const spillSet = new Set<string>();
   // (#2864 F1b) The variable declaration that introduced each spilled name, so
   // the spill's wasm type can be resolved at its actual ValType.
@@ -631,6 +647,27 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
       // 1) `yield expr;` as an expression statement.
       if (ts.isExpressionStatement(stmt) && ts.isYieldExpression(stmt.expression)) {
         if (!emitYield(stmt.expression, undefined, unwind)) return false;
+        continue;
+      }
+
+      // `lhs = yield* iterable;` consumes the delegation completion value in a
+      // normal assignment expression. Keep the value in a synthetic spilled
+      // local until the delegate reports done, then execute this assignment in
+      // the successor state. This is distinct from a `let x = yield ...`
+      // resume binding: `.next(value)` must never overwrite the yield* result.
+      if (
+        ts.isExpressionStatement(stmt) &&
+        ts.isBinaryExpression(stmt.expression) &&
+        stmt.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isIdentifier(stmt.expression.left) &&
+        ts.isYieldExpression(stmt.expression.right) &&
+        stmt.expression.right.asteriskToken
+      ) {
+        const syntheticName = `__gen_yieldstar_completion_${delegationBindingTypes.size}`;
+        delegationBindingNames.add(syntheticName);
+        delegationBindingTypes.set(syntheticName, { kind: "f64" });
+        addSpill(syntheticName);
+        if (!emitYield(stmt.expression.right, undefined, unwind, stmt.expression.left, syntheticName)) return false;
         continue;
       }
 
@@ -829,6 +866,8 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
     yieldExpr: ts.YieldExpression,
     bindSentTo: string | undefined,
     unwind: readonly UnwindEntry[],
+    completionExpr?: ts.Expression,
+    completionBindingName?: string,
   ): boolean {
     // (#2170) `yield* <inner-generator-call>` — delegate to an inner native
     // generator. Slice-1 supports a direct call to a native-generator function
@@ -836,11 +875,6 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
     // value of `yield*` consumed, a non-native inner) still bails to the host
     // path / scoped diagnostic.
     if (yieldExpr.asteriskToken) {
-      // (#3050) `yield*` inside a NEW try-region is not modeled — the
-      // delegation states ignore the resume mode, so an abrupt completion
-      // could not be routed into the region's catch/finally. Bail to the host
-      // path (legacy replay-only regions keep today's behavior).
-      if (unwind.some((e) => e.kind !== "replay")) return fail();
       // (#2864 D2) A yield-star terminator SELF-SUSPENDS (its yield arm re-enters
       // the SAME state on the next resume), so it must live in a DEDICATED state:
       //  (a) empty prelude / no resume bindings — otherwise the prelude statements
@@ -861,10 +895,27 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
         resetCursor(starId);
       }
       curAbrupt = {
-        finalizers: unwind.map((e) => [...(e as { statements: readonly ts.Statement[] }).statements]).reverse(),
+        // New try-region entries are handled by the state's throwRoute. Only
+        // legacy replay finalizers belong in this inline abrupt tail; casting a
+        // catch/finally entry to `{ statements }` would otherwise manufacture
+        // an undefined statement list and crash during resume emission.
+        finalizers: unwind
+          .filter((e): e is Extract<UnwindEntry, { kind: "replay" }> => e.kind === "replay")
+          .map((e) => [...e.statements])
+          .reverse(),
       };
       curUnwind = undefined;
       const subject = yieldExpr.expression;
+      const completionStatement =
+        completionExpr !== undefined && (completionBindingName ?? bindSentTo) !== undefined
+          ? ts.factory.createExpressionStatement(
+              ts.factory.createBinaryExpression(
+                completionExpr,
+                ts.factory.createToken(ts.SyntaxKind.EqualsToken),
+                ts.factory.createIdentifier(completionBindingName ?? bindSentTo!),
+              ),
+            )
+          : undefined;
       const innerName = subject ? nativeGeneratorDelegationName(subject) : undefined;
       if (subject && innerName === undefined) {
         // (#2173 slice-2a) Not a native-generator call — try a NUMERIC
@@ -879,9 +930,11 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
           // (#2864 R1) `const x = yield* [..]` — the delegation completion value
           // (§27.5.3.7) of an array is `undefined`; the done-arm delivers the f64
           // undefined sentinel into the binding's spill (a #2106 residual).
-          if (bindSentTo !== undefined) {
-            delegationBindingNames.add(bindSentTo);
-            addSpill(bindSentTo);
+          const completionName = completionBindingName ?? bindSentTo;
+          if (completionName !== undefined) {
+            delegationBindingNames.add(completionName);
+            if (completionBindingName !== undefined) delegationBindingTypes.set(completionName, { kind: "f64" });
+            addSpill(completionName);
           }
           const vecSiteIndex = vecDelegationSites.length;
           vecDelegationSites.push({ subject });
@@ -892,10 +945,11 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
             subject,
             vecSiteIndex,
             next: nextId,
-            bindResultTo: bindSentTo,
+            bindResultTo: completionName,
+            completionExpr,
           });
           curId = reserveState();
-          curStatements = [];
+          curStatements = completionStatement ? [completionStatement] : [];
           curResumeBindings = pendingResumeBindings;
           curAbrupt = pendingAbrupt;
           curUnwind = pendingUnwind;
@@ -918,9 +972,11 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
           // array/`.values()` shape that is `undefined`. The done-arm delivers
           // the outer's undefined sentinel into the binding's spill (#2106
           // residual, exactly as the vec arm).
-          if (bindSentTo !== undefined) {
-            delegationBindingNames.add(bindSentTo);
-            addSpill(bindSentTo);
+          const completionName = completionBindingName ?? bindSentTo;
+          if (completionName !== undefined) {
+            delegationBindingNames.add(completionName);
+            if (completionBindingName !== undefined) delegationBindingTypes.set(completionName, { kind: "f64" });
+            addSpill(completionName);
           }
           const iterableSiteIndex = iterableDelegationSites.length;
           iterableDelegationSites.push({ subject });
@@ -931,10 +987,11 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
             subject,
             iterableSiteIndex,
             next: nextId,
-            bindResultTo: bindSentTo,
+            bindResultTo: completionName,
+            completionExpr,
           });
           curId = reserveState();
-          curStatements = [];
+          curStatements = completionStatement ? [completionStatement] : [];
           curResumeBindings = pendingResumeBindings;
           curAbrupt = pendingAbrupt;
           curUnwind = pendingUnwind;
@@ -959,9 +1016,11 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
       // value (the inner's `return` value). The done-arm writes it inside the
       // same resume call, so it is NOT a resume binding (see the terminator
       // comment); it only needs a typed spill slot.
-      if (bindSentTo !== undefined) {
-        delegationBindingNames.add(bindSentTo);
-        addSpill(bindSentTo);
+      const completionName = completionBindingName ?? bindSentTo;
+      if (completionName !== undefined) {
+        delegationBindingNames.add(completionName);
+        if (completionBindingName !== undefined) delegationBindingTypes.set(completionName, { kind: "f64" });
+        addSpill(completionName);
       }
       const siteIndex = delegationSites.length;
       delegationSites.push({ innerName });
@@ -973,11 +1032,12 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
         innerName,
         siteIndex,
         next: nextId,
-        bindResultTo: bindSentTo,
+        bindResultTo: completionName,
+        completionExpr,
       });
       // Create the successor and make it current (mirrors finishCurrentAsYield).
       curId = reserveState();
-      curStatements = [];
+      curStatements = completionStatement ? [completionStatement] : [];
       curResumeBindings = pendingResumeBindings;
       curAbrupt = pendingAbrupt;
       curUnwind = pendingUnwind;
@@ -1050,12 +1110,61 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
   // native `__iterator` runtime (#2038) then drives it host-free. Mirrors the
   // checker use already present in `nativeGeneratorDelegationName`.
   function isGenericIterableDelegate(ctx: CodegenContext, subject: ts.Expression): boolean {
-    const t = ctx.checker.getTypeAtLocation(subject);
-    if (!t) return false;
-    for (const p of ctx.checker.getPropertiesOfType(t)) {
-      if (p.getName().startsWith("__@iterator")) return true;
+    // TypeScript 5.9 can throw while resolving late-bound members on the
+    // JavaScript `{ throw() { … } }` iterator literals in this cohort.  The
+    // source-level proof below is sufficient for those dynamic assignments;
+    // keep the static shortcut best-effort instead of turning a valid test
+    // into a compiler failure.
+    try {
+      const t = ctx.checker.getTypeAtLocation(subject);
+      if (t) {
+        for (const p of ctx.checker.getPropertiesOfType(t)) {
+          if (p.getName().startsWith("__@iterator")) return true;
+        }
+      }
+    } catch {
+      // Fall through to the narrow assignment proof.
     }
-    return false;
+
+    // Test262's iterator-protocol cohort deliberately installs
+    // `Symbol.iterator` after constructing an otherwise untyped object.  The
+    // checker therefore reports `{}` even though GetIterator is valid at
+    // runtime. Admit only the narrow, source-provable post-hoc assignment
+    // shape; broadening this to arbitrary property writes would turn a native
+    // non-iterable TypeError into a silent delegation.
+    if (!ts.isIdentifier(subject)) return false;
+    let found = false;
+    const sameReceiver = (receiver: ts.Expression): boolean => {
+      // This scan is deliberately scoped to the current source file and does
+      // not cross function scopes, so identifier text equality is sufficient
+      // even for the JavaScript test262 sources that have no declaration-file
+      // symbol for the `var` binding. The cohort installs the property in the
+      // enclosing script before constructing the generator, rather than in
+      // the generator body itself.
+      return ts.isIdentifier(receiver) && receiver.text === subject.text;
+    };
+    const visit = (node: ts.Node): void => {
+      if (found || node === subject) return;
+      // Do not borrow an assignment from a nested function's independent
+      // execution; the subject's iterator property must be installed by the
+      // enclosing script before the delegation executes.
+      if (isFunctionLikeScope(node)) return;
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isElementAccessExpression(node.left) &&
+        ts.isPropertyAccessExpression(node.left.argumentExpression) &&
+        node.left.argumentExpression.expression.getText() === "Symbol" &&
+        node.left.argumentExpression.name.text === "iterator" &&
+        sameReceiver(node.left.expression)
+      ) {
+        found = true;
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(decl.getSourceFile(), visit);
+    return found;
   }
 
   // Reserve the successor of a yield and set up its resume binding/abrupt
@@ -1563,7 +1672,7 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
     // holds the inner's f64 `return` value — always f64 (only f64-elem inners
     // are delegated), independent of the OUTER's carrier.
     if (delegationBindingNames.has(name)) {
-      spillTypes.set(name, { kind: "f64" });
+      spillTypes.set(name, delegationBindingTypes.get(name) ?? { kind: "f64" });
       continue;
     }
     if (resumeBindingNames.has(name)) {
@@ -1732,11 +1841,11 @@ function bodyReferencesUnresolvableIdentifier(ctx: CodegenContext, decl: Generat
  *     plan builder collapses the two suspends (first `next()` returns the
  *     OUTER operand instead of the inner yield's value —
  *     `generators/yield-as-yield-operand.js` returns 0 for `yield yield 1`).
- *   - `yield*` delegation — the host-lane resume fn routes the delegate
- *     through the `__iterator` chain, which traps (`illegal cast`) when the
- *     delegate is a host-side generator object (an eager-lowered inner —
- *     `generators/yield-star-before-newline.js`). Standalone delegates
- *     native→native and is unaffected.
+ *   - `yield*` delegation was previously kept on the eager host path because
+ *     the native state machine had no abrupt iterator arm. The delegation
+ *     runtime now has a host import with the same multi-value ABI as the
+ *     standalone helper, so generic iterable delegation is intentionally
+ *     admitted here; nested-yield operands remain excluded below.
  *
  * Both scans stop at nested function boundaries (a nested generator's yields
  * are its own).
@@ -1757,10 +1866,6 @@ function bodyHasHostUnsupportedYieldShape(decl: GeneratorDecl): boolean {
     if (found) return;
     if (isFunctionLikeScope(node)) return;
     if (ts.isYieldExpression(node)) {
-      if (node.asteriskToken) {
-        found = true; // yield* delegation
-        return;
-      }
       if (node.expression && containsYield(node.expression)) {
         found = true; // yield nested in a yield operand
         return;
@@ -2083,9 +2188,10 @@ export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: GeneratorD
     // exported generator are unaffected: they ride the eager host object,
     // exactly the pre-W6 behavior.)
     if (ts.getModifiers(decl)?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) return false;
-    // (#3032 W6) Body shapes the native machine still miscompiles (nested
-    // yield operands, `yield*` delegation) keep the eager host path — see
-    // bodyHasHostUnsupportedYieldShape.
+    // (#3032 W6 / #1691) Body shapes the native machine still miscompiles
+    // (nested yield operands) keep the eager host path — see
+    // bodyHasHostUnsupportedYieldShape. Generic `yield*` delegation is now
+    // handled by the host iterator-throw ABI and is no longer excluded here.
     if (bodyHasHostUnsupportedYieldShape(decl)) return false;
     // Conservative: a body referencing an UNRESOLVABLE identifier (e.g.
     // `try { yield test262unresolvable } catch (e) {…}`) keeps the eager path —
@@ -3192,135 +3298,334 @@ function compileState(
     const abruptBody: Instr[] = [];
     const savedAbrupt = fctx.body;
     fctx.body = abruptBody;
-    // (#2864 D2) Delegation abrupt forwarding — iterator close through `yield*`
-    // (§27.5.3.7 steps 7.b/7.c). A `.return(v)` / `.throw(e)` on the OUTER while
-    // suspended in a native-gen yield-star state must forward the abrupt to the
-    // INNER first (drive its resume once with the SAME mode + payloads) so the
-    // inner's `finally` blocks run, then continue the outer's own abrupt path
-    // (its finalizers + completion) exactly as before. Gated on the state's
-    // terminator being a native-gen delegation AND the slot being non-null
-    // (mid-delegation) — byte-inert for non-delegating generators, and inert at
-    // runtime for an abrupt resume at the plain-yield suspension that precedes
-    // the delegation (slot still null). A mode-2 inner re-throws after its
-    // finalizers (F2), and a `finally` that itself throws surfaces a NEW error —
-    // both are caught here, stored as the outer's error, and upgrade the outer
-    // to the throw path (a return completion whose close throws becomes a throw
-    // completion, per spec).
-    if (state.terminator.kind === "yield-star" && state.terminator.delegationKind === "native-gen") {
-      const closeSlot = info.delegationSlots?.[state.terminator.siteIndex];
-      const closeInner = closeSlot ? ctx.nativeGenerators.get(closeSlot.innerName) : undefined;
-      if (closeSlot && closeInner) {
-        const closeResumeIdx = ensureNativeGeneratorResumeFunction(ctx, closeInner);
-        const closeDelegLocal = allocLocal(fctx, `__gen_close_deleg_${fctx.locals.length}`, {
-          kind: "ref",
-          typeIdx: closeInner.stateTypeIdx,
+    const genericDelegation = state.terminator.kind === "yield-star" && state.terminator.delegationKind === "iterable";
+    if (genericDelegation) {
+      // §14.4.14 / §27.5.3.7: a throw/return resumed at a live generic
+      // delegation first acts on the iterator record.  The host lane uses the
+      // actual JS iterator object; standalone/WASI uses the native $__IterRec.
+      if (ctx.standalone || ctx.wasi) ensureNativeIteratorRuntime(ctx);
+      else addIteratorImports(ctx);
+      const term = state.terminator;
+      const islot = info.iterableDelegationSlots?.[term.iterableSiteIndex];
+      const iteratorThrowIdx = ctx.funcMap.get("__iterator_throw");
+      const iteratorReturnIdx = ctx.funcMap.get("__iterator_return");
+
+      // Build the ordinary outer completion tails independently for the throw
+      // and return arms.  Instructions are mutable during final index/type
+      // repair, so neither branch may share an Instr object.
+      const buildThrowTail = (): Instr[] => {
+        const tail: Instr[] = [];
+        const savedTail = fctx.body;
+        fctx.body = tail;
+        for (const finalizer of state.abruptResume!.finalizers) {
+          for (const stmt of finalizer) compileStatement(ctx, fctx, stmt);
+        }
+        tail.push(...storeSpills(info, fctx, selfLocal));
+        tail.push(...setStateInstrs(info, selfLocal, info.doneState));
+        tail.push({
+          op: "local.get",
+          index: selfLocal,
         });
-        const closeErrLocal = allocLocal(fctx, `__gen_close_err_${fctx.locals.length}`, { kind: "externref" });
-        // The inner is f64-gated (delegation admission), so its `abrupt` field is
-        // f64: copy the outer's `.return(v)` value when the outer's carrier is
-        // also f64; a boxed-any outer's externref abrupt has no unbox seam here —
-        // deliver undefined (the value is unobservable: the inner result is
-        // discarded and the outer completes with its OWN abrupt field).
-        const closeAbruptPayload: Instr[] =
-          genCarrierFieldType(info.elemValType).kind === "f64"
-            ? [
-                { op: "local.get", index: selfLocal },
-                { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx },
-              ]
-            : [{ op: "f64.const", value: NaN }];
-        const closeCatch: Instr[] = [
-          { op: "local.set", index: closeErrLocal },
+        tail.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD });
+        tail.push({ op: "throw", tagIdx: ensureExnTag(ctx) });
+        fctx.body = savedTail;
+        return tail;
+      };
+      const buildReturnTail = (): Instr[] => {
+        const tail: Instr[] = [];
+        const savedTail = fctx.body;
+        fctx.body = tail;
+        for (const finalizer of state.abruptResume!.finalizers) {
+          for (const stmt of finalizer) compileStatement(ctx, fctx, stmt);
+        }
+        tail.push(...storeSpills(info, fctx, selfLocal));
+        tail.push(...setStateInstrs(info, selfLocal, info.doneState));
+        if (valTypesMatch(genCarrierFieldType(info.elemValType), info.elemValType)) {
+          tail.push({ op: "local.get", index: selfLocal });
+          tail.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx });
+        } else {
+          tail.push(...defaultElemValueInstrs(ctx, info.elemValType));
+        }
+        tail.push({ op: "i32.const", value: 1 });
+        tail.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
+        tail.push({ op: "local.set", index: resultLocal });
+        // The return arm is nested in the outer mode guard and the
+        // throw-vs-return discriminator.
+        // This tail is nested in the mode guard, throw-vs-return discriminator,
+        // and delegate-null test; leave through the trampoline's empty exit
+        // block after those three local labels.
+        tail.push({ op: "br", depth: exitDepth + 1 });
+        fctx.body = savedTail;
+        return tail;
+      };
+      const throwTail = buildThrowTail();
+      const returnTail = buildReturnTail();
+
+      if (islot && iteratorThrowIdx !== undefined && iteratorReturnIdx !== undefined) {
+        const recLocal = allocLocal(fctx, `__gen_throw_iterrec_${fctx.locals.length}`, { kind: "externref" });
+        const doneLocal = allocLocal(fctx, `__gen_throw_done_${fctx.locals.length}`, { kind: "i32" });
+        const valueLocal = allocLocal(fctx, `__gen_throw_value_${fctx.locals.length}`, { kind: "externref" });
+
+        // A completion value from the delegate's done IteratorResult flows to
+        // the `yield*` binding (if any), not through the outer `sent` field.
+        const bindCompletion = (): Instr[] => {
+          if (term.bindResultTo === undefined) return [];
+          const bindLocal = fctx.localMap.get(term.bindResultTo);
+          const bindSpillIdx = info.spillNames.indexOf(term.bindResultTo);
+          if (bindLocal === undefined || bindSpillIdx < 0) return [];
+          const bindType = getLocalType(fctx, bindLocal);
+          const out: Instr[] = [{ op: "local.get", index: valueLocal }];
+          if (bindType && bindType.kind !== "externref") {
+            const savedBind = fctx.body;
+            fctx.body = out;
+            coerceType(ctx, fctx, { kind: "externref" }, bindType, "number");
+            fctx.body = savedBind;
+          }
+          out.push(
+            { op: "local.set", index: bindLocal },
+            { op: "local.get", index: selfLocal },
+            { op: "local.get", index: bindLocal },
+            { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + bindSpillIdx },
+          );
+          return out;
+        };
+
+        const valueInstrs: Instr[] = [];
+        {
+          const savedValue = fctx.body;
+          fctx.body = valueInstrs;
+          valueInstrs.push({ op: "local.get", index: valueLocal });
+          if (info.elemValType.kind === "f64") {
+            coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" }, "number");
+          } else if (info.elemValType.kind === "ref" || info.elemValType.kind === "ref_null") {
+            coerceType(ctx, fctx, { kind: "externref" }, info.elemValType);
+          }
+          fctx.body = savedValue;
+        }
+
+        const throwAtDelegate: Instr[] = [
           { op: "local.get", index: selfLocal },
-          { op: "local.get", index: closeErrLocal },
-          { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD },
-          ...setModeInstrs(info, selfLocal, MODE_THROW),
-        ];
-        abruptBody.push(
-          { op: "local.get", index: selfLocal },
-          { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
+          { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: islot.fieldIdx },
           { op: "ref.is_null" },
-          { op: "i32.eqz" },
           {
             op: "if",
             blockType: { kind: "empty" },
-            then: [
+            then: throwTail,
+            else: [
               { op: "local.get", index: selfLocal },
-              { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
-              { op: "ref.as_non_null" },
-              { op: "local.set", index: closeDelegLocal },
-              // inner.mode = outer.mode; inner.abrupt = payload; inner.error = outer.error
-              { op: "local.get", index: closeDelegLocal },
-              { op: "local.get", index: selfLocal },
-              { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
-              { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: closeInner.modeFieldIdx },
-              { op: "local.get", index: closeDelegLocal },
-              ...closeAbruptPayload,
-              { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: closeInner.abruptFieldIdx },
-              { op: "local.get", index: closeDelegLocal },
+              { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: islot.fieldIdx },
+              { op: "local.set", index: recLocal },
+              { op: "local.get", index: recLocal },
               { op: "local.get", index: selfLocal },
               { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD },
-              { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: ERROR_FIELD },
-              // Drive the inner ONCE (result discarded); catch its mode-2
-              // re-throw / a finally-thrown replacement error. Foreign JS
-              // exceptions (host mode) recover via __get_caught_exception when
-              // the resume emitter acquired it (#3050 wrap parity).
-              buildTargetTaggedTry(
-                ctx,
-                { kind: "empty" },
-                [{ op: "local.get", index: closeDelegLocal }, { op: "call", funcIdx: closeResumeIdx }, { op: "drop" }],
-                [{ tagIdx: ensureExnTag(ctx), body: closeCatch }],
-                getCaughtExnIdx !== undefined ? [{ op: "call", funcIdx: getCaughtExnIdx }, ...closeCatch] : undefined,
-              ),
-              // Close complete — clear the slot.
-              { op: "local.get", index: selfLocal },
-              { op: "ref.null", typeIdx: closeInner.stateTypeIdx },
-              { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
+              { op: "call", funcIdx: iteratorThrowIdx },
+              { op: "local.set", index: valueLocal },
+              { op: "local.set", index: doneLocal },
+              { op: "local.get", index: doneLocal },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: selfLocal },
+                  { op: "ref.null.extern" },
+                  { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: islot.fieldIdx },
+                  ...bindCompletion(),
+                  ...setStateInstrs(info, selfLocal, term.next),
+                  ...setModeInstrs(info, selfLocal, MODE_NEXT),
+                  // The dispatch loop is below four local condition blocks:
+                  // the mode guard, throw/return discriminator, delegate-null
+                  // test, and helper-done test.
+                  // The dispatch loop is below four local condition blocks:
+                  // the mode guard, throw/return discriminator, delegate-null
+                  // test, and helper-done test.
+                  { op: "br", depth: loopDepth + 4 },
+                ],
+                else: [
+                  ...setStateInstrs(info, selfLocal, stateId),
+                  ...setModeInstrs(info, selfLocal, MODE_NEXT),
+                  ...valueInstrs,
+                  { op: "i32.const", value: 0 },
+                  { op: "struct.new", typeIdx: info.resultTypeIdx },
+                  { op: "local.set", index: resultLocal },
+                  { op: "br", depth: exitDepth + 4 },
+                ],
+              },
             ],
-            else: [],
           },
+        ];
+
+        const returnAtDelegate: Instr[] = [
+          { op: "local.get", index: selfLocal },
+          { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: islot.fieldIdx },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: returnTail,
+            else: [
+              { op: "local.get", index: selfLocal },
+              { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: islot.fieldIdx },
+              { op: "call", funcIdx: iteratorReturnIdx },
+              { op: "local.get", index: selfLocal },
+              { op: "ref.null.extern" },
+              { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: islot.fieldIdx },
+              ...returnTail,
+            ],
+          },
+        ];
+        abruptBody.push(
+          { op: "local.get", index: selfLocal },
+          { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+          { op: "i32.const", value: MODE_THROW },
+          { op: "i32.eq" },
+          { op: "if", blockType: { kind: "empty" }, then: throwAtDelegate, else: returnAtDelegate },
+        );
+      } else {
+        // Defensive fallback if a malformed plan lacks its iterator slot or
+        // helper. Preserve the ordinary abrupt completion semantics.
+        abruptBody.push(
+          { op: "local.get", index: selfLocal },
+          { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+          { op: "i32.const", value: MODE_THROW },
+          { op: "i32.eq" },
+          { op: "if", blockType: { kind: "empty" }, then: throwTail, else: returnTail },
         );
       }
-    }
-    for (const finalizer of state.abruptResume.finalizers) {
-      for (const stmt of finalizer) compileStatement(ctx, fctx, stmt);
-    }
-    abruptBody.push(...storeSpills(info, fctx, selfLocal));
-    abruptBody.push(...setStateInstrs(info, selfLocal, info.doneState));
-
-    // mode 2 (throw): re-throw the stored error. `throw` is stack-polymorphic
-    // (control leaves the resume function), so no value/`br` is needed and the
-    // generator surfaces the error to the `.throw(e)` caller, finalizers having
-    // run first (§27.5.3.4 GeneratorResumeAbrupt with a throw completion, no
-    // catch in this slice — try/catch-across-yield stays the next slice).
-    const throwBody: Instr[] = [
-      { op: "local.get", index: selfLocal },
-      { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD },
-      { op: "throw", tagIdx: ensureExnTag(ctx) },
-    ];
-
-    // mode 1 (return): complete with the abrupt value (unchanged from F1). The
-    // `.return(v)` value lives in `abrupt` when its carrier matches the result
-    // `value` type (numeric / boxed-any); for a string generator the abrupt
-    // field stays f64, so complete with the elem default (string `.return(v)` is
-    // a documented follow-up). br depth is exitDepth + 2 — inside the outer
-    // `if (mode != 0)` AND the inner `if (mode == 2) … else …`.
-    const returnBody: Instr[] = [];
-    if (valTypesMatch(genCarrierFieldType(info.elemValType), info.elemValType)) {
-      returnBody.push({ op: "local.get", index: selfLocal });
-      returnBody.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx });
     } else {
-      returnBody.push(...defaultElemValueInstrs(ctx, info.elemValType));
-    }
-    returnBody.push({ op: "i32.const", value: 1 });
-    returnBody.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
-    returnBody.push({ op: "local.set", index: resultLocal });
-    returnBody.push({ op: "br", depth: exitDepth + 2 });
+      // (#2864 D2) Delegation abrupt forwarding — iterator close through `yield*`
+      // (§27.5.3.7 steps 7.b/7.c). A `.return(v)` / `.throw(e)` on the OUTER while
+      // suspended in a native-gen yield-star state must forward the abrupt to the
+      // INNER first (drive its resume once with the SAME mode + payloads) so the
+      // inner's `finally` blocks run, then continue the outer's own abrupt path
+      // (its finalizers + completion) exactly as before. Gated on the state's
+      // terminator being a native-gen delegation AND the slot being non-null
+      // (mid-delegation) — byte-inert for non-delegating generators, and inert at
+      // runtime for an abrupt resume at the plain-yield suspension that precedes
+      // the delegation (slot still null). A mode-2 inner re-throws after its
+      // finalizers (F2), and a `finally` that itself throws surfaces a NEW error —
+      // both are caught here, stored as the outer's error, and upgrade the outer
+      // to the throw path (a return completion whose close throws becomes a throw
+      // completion, per spec).
+      if (state.terminator.kind === "yield-star" && state.terminator.delegationKind === "native-gen") {
+        const closeSlot = info.delegationSlots?.[state.terminator.siteIndex];
+        const closeInner = closeSlot ? ctx.nativeGenerators.get(closeSlot.innerName) : undefined;
+        if (closeSlot && closeInner) {
+          const closeResumeIdx = ensureNativeGeneratorResumeFunction(ctx, closeInner);
+          const closeDelegLocal = allocLocal(fctx, `__gen_close_deleg_${fctx.locals.length}`, {
+            kind: "ref",
+            typeIdx: closeInner.stateTypeIdx,
+          });
+          const closeErrLocal = allocLocal(fctx, `__gen_close_err_${fctx.locals.length}`, { kind: "externref" });
+          // The inner is f64-gated (delegation admission), so its `abrupt` field is
+          // f64: copy the outer's `.return(v)` value when the outer's carrier is
+          // also f64; a boxed-any outer's externref abrupt has no unbox seam here —
+          // deliver undefined (the value is unobservable: the inner result is
+          // discarded and the outer completes with its OWN abrupt field).
+          const closeAbruptPayload: Instr[] =
+            genCarrierFieldType(info.elemValType).kind === "f64"
+              ? [
+                  { op: "local.get", index: selfLocal },
+                  { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx },
+                ]
+              : [{ op: "f64.const", value: NaN }];
+          const closeCatch: Instr[] = [
+            { op: "local.set", index: closeErrLocal },
+            { op: "local.get", index: selfLocal },
+            { op: "local.get", index: closeErrLocal },
+            { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD },
+            ...setModeInstrs(info, selfLocal, MODE_THROW),
+          ];
+          abruptBody.push(
+            { op: "local.get", index: selfLocal },
+            { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
+            { op: "ref.is_null" },
+            { op: "i32.eqz" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: selfLocal },
+                { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
+                { op: "ref.as_non_null" },
+                { op: "local.set", index: closeDelegLocal },
+                // inner.mode = outer.mode; inner.abrupt = payload; inner.error = outer.error
+                { op: "local.get", index: closeDelegLocal },
+                { op: "local.get", index: selfLocal },
+                { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+                { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: closeInner.modeFieldIdx },
+                { op: "local.get", index: closeDelegLocal },
+                ...closeAbruptPayload,
+                { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: closeInner.abruptFieldIdx },
+                { op: "local.get", index: closeDelegLocal },
+                { op: "local.get", index: selfLocal },
+                { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD },
+                { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: ERROR_FIELD },
+                // Drive the inner ONCE (result discarded); catch its mode-2
+                // re-throw / a finally-thrown replacement error. Foreign JS
+                // exceptions (host mode) recover via __get_caught_exception when
+                // the resume emitter acquired it (#3050 wrap parity).
+                buildTargetTaggedTry(
+                  ctx,
+                  { kind: "empty" },
+                  [
+                    { op: "local.get", index: closeDelegLocal },
+                    { op: "call", funcIdx: closeResumeIdx },
+                    { op: "drop" },
+                  ],
+                  [{ tagIdx: ensureExnTag(ctx), body: closeCatch }],
+                  getCaughtExnIdx !== undefined ? [{ op: "call", funcIdx: getCaughtExnIdx }, ...closeCatch] : undefined,
+                ),
+                // Close complete — clear the slot.
+                { op: "local.get", index: selfLocal },
+                { op: "ref.null", typeIdx: closeInner.stateTypeIdx },
+                { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
+              ],
+              else: [],
+            },
+          );
+        }
+      }
+      for (const finalizer of state.abruptResume.finalizers) {
+        for (const stmt of finalizer) compileStatement(ctx, fctx, stmt);
+      }
+      abruptBody.push(...storeSpills(info, fctx, selfLocal));
+      abruptBody.push(...setStateInstrs(info, selfLocal, info.doneState));
 
-    abruptBody.push({ op: "local.get", index: selfLocal });
-    abruptBody.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx });
-    abruptBody.push({ op: "i32.const", value: MODE_THROW });
-    abruptBody.push({ op: "i32.eq" });
-    abruptBody.push({ op: "if", blockType: { kind: "empty" }, then: throwBody, else: returnBody });
+      // mode 2 (throw): re-throw the stored error. `throw` is stack-polymorphic
+      // (control leaves the resume function), so no value/`br` is needed and the
+      // generator surfaces the error to the `.throw(e)` caller, finalizers having
+      // run first (§27.5.3.4 GeneratorResumeAbrupt with a throw completion, no
+      // catch in this slice — try/catch-across-yield stays the next slice).
+      const throwBody: Instr[] = [
+        { op: "local.get", index: selfLocal },
+        { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD },
+        { op: "throw", tagIdx: ensureExnTag(ctx) },
+      ];
+
+      // mode 1 (return): complete with the abrupt value (unchanged from F1). The
+      // `.return(v)` value lives in `abrupt` when its carrier matches the result
+      // `value` type (numeric / boxed-any); for a string generator the abrupt
+      // field stays f64, so complete with the elem default (string `.return(v)` is
+      // a documented follow-up). br depth is exitDepth + 2 — inside the outer
+      // `if (mode != 0)` AND the inner `if (mode == 2) … else …`.
+      const returnBody: Instr[] = [];
+      if (valTypesMatch(genCarrierFieldType(info.elemValType), info.elemValType)) {
+        returnBody.push({ op: "local.get", index: selfLocal });
+        returnBody.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx });
+      } else {
+        returnBody.push(...defaultElemValueInstrs(ctx, info.elemValType));
+      }
+      returnBody.push({ op: "i32.const", value: 1 });
+      returnBody.push({ op: "struct.new", typeIdx: info.resultTypeIdx });
+      returnBody.push({ op: "local.set", index: resultLocal });
+      returnBody.push({ op: "br", depth: exitDepth + 2 });
+
+      abruptBody.push({ op: "local.get", index: selfLocal });
+      abruptBody.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx });
+      abruptBody.push({ op: "i32.const", value: MODE_THROW });
+      abruptBody.push({ op: "i32.eq" });
+      abruptBody.push({ op: "if", blockType: { kind: "empty" }, then: throwBody, else: returnBody });
+    }
     fctx.body = savedAbrupt;
 
     body.push({ op: "local.get", index: selfLocal });
@@ -3583,7 +3888,10 @@ function compileState(
           body.push({ op: "local.set", index: resultLocal });
           break;
         }
-        ensureNativeIteratorRuntime(ctx);
+        // Standalone/WASI owns a native iterator record; the JS-host lane
+        // receives the actual iterator object through the matching imports.
+        if (ctx.standalone || ctx.wasi) ensureNativeIteratorRuntime(ctx);
+        else addIteratorImports(ctx);
         const iteratorIdx = ctx.funcMap.get("__iterator");
         const iteratorNextIdx = ctx.funcMap.get("__iterator_next");
         if (iteratorIdx === undefined || iteratorNextIdx === undefined) {
@@ -3636,21 +3944,28 @@ function compileState(
         body.push({ op: "local.set", index: valueLocal }); // value (top of stack)
         body.push({ op: "local.set", index: doneLocal }); // done
 
-        // (#2864 R1 / #2106 residual) `const x = yield* it` — deliver the
-        // completion value (undefined for the array/`.values()` shape) into the
-        // binding's local AND spill. Sentinel matches the binding's slot type.
+        // (#2864 R1) `const x = yield* it` — deliver the actual completion
+        // value from the delegate's done IteratorResult into the binding's
+        // local AND spill. A missing `value` is represented by the host/native
+        // undefined externref and coerces to the binding's carrier as usual.
         const bindInstrs: Instr[] = [];
         if (term.bindResultTo !== undefined) {
           const bindLocal = fctx.localMap.get(term.bindResultTo);
           const bindSpillIdx = info.spillNames.indexOf(term.bindResultTo);
           if (bindLocal !== undefined && bindSpillIdx >= 0) {
             const bindType = getLocalType(fctx, bindLocal);
-            const undef: Instr = bindType?.kind === "f64" ? { op: "f64.const", value: NaN } : { op: "ref.null.extern" };
+            const bindValue: Instr[] = [{ op: "local.get", index: valueLocal }];
+            if (bindType && bindType.kind !== "externref") {
+              const savedBind = fctx.body;
+              fctx.body = bindValue;
+              coerceType(ctx, fctx, { kind: "externref" }, bindType, "number");
+              fctx.body = savedBind;
+            }
             bindInstrs.push(
-              undef,
+              ...bindValue,
               { op: "local.set", index: bindLocal },
               { op: "local.get", index: selfLocal },
-              undef,
+              { op: "local.get", index: bindLocal },
               {
                 op: "struct.set",
                 typeIdx: info.stateTypeIdx,

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -352,6 +352,9 @@ interface ObjCarrierDeps {
   /** `__sget_return(externref) -> externref` — same for IteratorClose's
    *  `return` read on a closed-struct iterator object. */
   sgetReturnIdx?: number;
+  /** `__sget_throw(externref) -> externref` — the closed-struct iterator's
+   *  `throw` method read used by the §14.4.14 delegation arm. */
+  sgetThrowIdx?: number;
   /** Fresh instrs pushing the string key `name` as externref. */
   keyInstrs: (name: string) => Instr[];
   /** Fresh instrs pushing the miss/undefined externref (matches `__extern_get`). */
@@ -533,6 +536,27 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
       { name: "res", type: { kind: "externref" } },
     ],
     buildIteratorNextBody(types, undefined),
+  );
+
+  // --- __iterator_throw(recExt, error) -> (i32 done, externref value) ---
+  // The native body is rebuilt at finalize once the object/closed-struct
+  // readers are known. Keep the reserve-time locals wide enough for every
+  // carrier arm so the late fill never changes the function ABI.
+  registerNative(
+    "__iterator_throw",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "i32" }, { kind: "externref" }],
+    [
+      { name: "recAny", type: { kind: "anyref" } },
+      { name: "rec", type: iterRecRef },
+      { name: "userIter", type: { kind: "externref" } },
+      { name: "method", type: { kind: "externref" } },
+      { name: "result", type: { kind: "externref" } },
+      { name: "done", type: { kind: "i32" } },
+      { name: "value", type: { kind: "externref" } },
+      { name: "argsArr", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
+    ],
+    [{ op: "unreachable" }],
   );
 
   // --- __iterator_return(recExt: externref) -> ()  (IteratorClose §7.4.8) ---
@@ -1287,7 +1311,8 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
         sgetDoneIdx: ctx.funcMap.get("__sget_done"),
         sgetDoneIsExtern,
         sgetNextIdx: ctx.funcMap.get("__sget_next"),
-        sgetReturnIdx: ctx.funcMap.get("__sget_return"),
+        sgetReturnIdx: externSgetIdx(ctx, "__sget_return"),
+        sgetThrowIdx: externSgetIdx(ctx, "__sget_throw"),
         keyInstrs: (name: string) => [...nativeStringLiteralInstrs(ctx, name), { op: "extern.convert_any" }],
         missInstrs: () => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }],
       };
@@ -1408,6 +1433,7 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
 
   const iteratorIdx = ctx.funcMap.get("__iterator");
   const iteratorNextIdx = ctx.funcMap.get("__iterator_next");
+  const iteratorThrowIdx = ctx.funcMap.get("__iterator_throw");
   if (iteratorIdx === undefined || iteratorNextIdx === undefined) return;
 
   const iteratorFn = definedFuncAt(ctx, iteratorIdx);
@@ -1433,6 +1459,14 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
       iteratorNextFn.locals.push({ name: "__gen_f64tmp", type: { kind: "f64" } });
     }
     iteratorNextFn.body = buildIteratorNextBody(types, deps, objDeps, hostDeps, agDeps, sgDeps);
+  }
+
+  // Rebuild the abrupt-step helper after the late object readers are known.
+  // The eager placeholder is intentionally unreachable; a generic native
+  // delegation can only reach this helper once a real carrier arm exists.
+  const iteratorThrowFn = iteratorThrowIdx !== undefined ? definedFuncAt(ctx, iteratorThrowIdx) : undefined;
+  if (iteratorThrowFn && objDeps) {
+    iteratorThrowFn.body = buildIteratorThrowBody(types, objDeps, nonIterableThrowInstrs(ctx));
   }
 
   // (#3100 S5) `__iterator_rest` was VEC-only — a USER record (custom iterable)
@@ -1766,6 +1800,224 @@ function buildIteratorReturnBody(
     ...hostClose,
     ...objClose,
     ...userClose,
+  ];
+}
+
+/**
+ * Build `__iterator_throw(recExt, error) -> (i32 done, externref value)` for
+ * the plain-object iterator carrier.  This is the native counterpart of the
+ * §14.4.14 `yield*` throw arm: read `throw`, call it with the original error,
+ * and return its IteratorResult; when `throw` is absent, call `return()` for
+ * IteratorClose and then throw a fresh TypeError.  Errors from either getter
+ * or call are deliberately left on the Wasm exception path so the enclosing
+ * generator state route can deliver the original error to its catch block.
+ *
+ * Locals (the reserve-time ABI is fixed in `ensureNativeIteratorRuntime`):
+ *  2 = recAny, 3 = rec, 4 = userIter, 5 = method, 6 = result,
+ *  7 = done, 8 = value, 9 = one-argument array scratch.
+ */
+function buildIteratorThrowBody(
+  types: IterRuntimeTypes,
+  objDeps: ObjCarrierDeps | undefined,
+  nonIterableThrow?: Instr[],
+): Instr[] {
+  const { iterRecTypeIdx } = types;
+  const fail = (): Instr[] =>
+    nonIterableThrow && nonIterableThrow.length > 0
+      ? nonIterableThrow.map((instr) => ({ ...instr }))
+      : [{ op: "unreachable" }];
+
+  if (!objDeps) return fail();
+  const od = objDeps;
+
+  const readMethod = (name: string, closedGetterIdx: number | undefined): Instr[] => [
+    ...objCarrierTest(od, () => [{ op: "local.get", index: 4 }, { op: "any.convert_extern" }]),
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [{ op: "local.get", index: 4 }, ...od.keyInstrs(name), { op: "call", funcIdx: od.externGetIdx }],
+      else:
+        closedGetterIdx !== undefined
+          ? [
+              { op: "local.get", index: 4 },
+              { op: "call", funcIdx: closedGetterIdx },
+            ]
+          : od.missInstrs(),
+    },
+  ];
+
+  // The closure bridge consumes the canonical `$Vec` argument carrier.  Build
+  // a fresh one-element vector containing the original abrupt error.
+  const oneArgVec = (): Instr[] => [
+    { op: "i32.const", value: 1 },
+    { op: "array.new_default", typeIdx: types.arrTypeIdx },
+    { op: "local.set", index: 9 },
+    { op: "local.get", index: 9 },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: 1 },
+    { op: "array.set", typeIdx: types.arrTypeIdx },
+    { op: "i32.const", value: 1 },
+    { op: "local.get", index: 9 },
+    { op: "struct.new", typeIdx: types.vecTypeIdx },
+    { op: "extern.convert_any" },
+  ];
+
+  const readResult: Instr[] = [
+    // A normal object/proxy result uses the dynamic property reader.
+    ...objCarrierTest(od, () => [{ op: "local.get", index: 6 }, { op: "any.convert_extern" }]),
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 6 },
+        ...od.keyInstrs("done"),
+        { op: "call", funcIdx: od.externGetIdx },
+        { op: "call", funcIdx: od.isTruthyIdx },
+        { op: "local.set", index: 7 },
+        { op: "local.get", index: 7 },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          // §14.4.14 only performs IteratorValue when the throw result is
+          // complete.  A non-done result is yielded as-is, so reading its
+          // `value` member here would trigger an observable getter too early.
+          then: [{ op: "local.get", index: 6 }, ...od.keyInstrs("value"), { op: "call", funcIdx: od.externGetIdx }],
+          else: od.missInstrs(),
+        },
+        { op: "local.set", index: 8 },
+      ],
+      else:
+        od.sgetDoneIdx !== undefined && (od.sgetValueIdx !== undefined || od.sgetDoneIsExtern === true)
+          ? [
+              { op: "local.get", index: 6 },
+              { op: "call", funcIdx: od.sgetDoneIdx },
+              { op: "call", funcIdx: od.isTruthyIdx },
+              { op: "local.set", index: 7 },
+              { op: "local.get", index: 7 },
+              {
+                op: "if",
+                blockType: { kind: "val", type: { kind: "externref" } },
+                // A done throw result completes the delegation and therefore
+                // reads `value`; a non-done result is forwarded without an
+                // eager value read (the Test262 getter-observability case).
+                then:
+                  od.sgetValueIdx !== undefined
+                    ? [
+                        { op: "local.get", index: 6 },
+                        { op: "call", funcIdx: od.sgetValueIdx },
+                      ]
+                    : od.missInstrs(),
+                else: od.missInstrs(),
+              },
+              { op: "local.set", index: 8 },
+            ]
+          : fail(),
+    },
+  ];
+
+  const callThrow: Instr[] = [
+    ...readMethod("throw", od.sgetThrowIdx),
+    { op: "local.tee", index: 5 },
+    { op: "call", funcIdx: od.isTruthyIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [],
+      else: [
+        // result = throw.call(userIter, error)
+        { op: "local.get", index: 5 },
+        { op: "local.get", index: 4 },
+        ...oneArgVec(),
+        { op: "call", funcIdx: od.applyClosureIdx },
+        { op: "local.set", index: 6 },
+        ...readResult,
+        { op: "local.get", index: 7 },
+        { op: "local.get", index: 8 },
+        { op: "return" },
+      ],
+    },
+  ];
+
+  const closeThenThrow: Instr[] = [
+    ...readMethod("return", od.sgetReturnIdx),
+    { op: "local.tee", index: 5 },
+    { op: "call", funcIdx: od.isTruthyIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: fail(),
+      else: [
+        // IteratorClose requires the return result to be an object. The
+        // closure bridge's non-object and non-callable cases are already
+        // represented by its null/undefined sentinel; both paths end in the
+        // required TypeError after a successful call.
+        { op: "local.get", index: 5 },
+        { op: "local.get", index: 4 },
+        ...emptyArgsVecInstrs(types),
+        { op: "call", funcIdx: od.applyClosureIdx },
+        { op: "local.set", index: 6 },
+        ...fail(),
+      ],
+    },
+  ];
+
+  const objArm: Instr[] = [
+    { op: "local.get", index: 3 },
+    { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 3 },
+    { op: "local.set", index: 4 },
+    { op: "local.get", index: 4 },
+    { op: "call", funcIdx: od.isTruthyIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: fail(),
+      else: [
+        // If throw is present, it is the only method called. Otherwise the
+        // fallback performs IteratorClose and then throws TypeError.
+        ...callThrow,
+        { op: "local.get", index: 5 },
+        { op: "call", funcIdx: od.isTruthyIdx },
+        { op: "i32.eqz" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: closeThenThrow,
+          else: [],
+        },
+      ],
+    },
+  ];
+
+  return [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: 2 },
+    { op: "ref.test", typeIdx: iterRecTypeIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: fail(),
+      else: [
+        { op: "local.get", index: 2 },
+        { op: "ref.cast", typeIdx: iterRecTypeIdx },
+        { op: "local.set", index: 3 },
+        { op: "local.get", index: 3 },
+        { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 0 },
+        { op: "i32.const", value: ITER_KIND_OBJ },
+        { op: "i32.eq" },
+        { op: "if", blockType: { kind: "empty" }, then: objArm, else: fail() },
+      ],
+    },
+    // Every normal path above either returns an IteratorResult or throws. The
+    // explicit fallback keeps the multi-value ABI well-typed if a future arm
+    // leaves the outer discriminator reachable.
+    { op: "i32.const", value: 1 },
+    { op: "ref.null.extern" },
+    { op: "return" },
   ];
 }
 

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -329,6 +329,11 @@ interface ObjCarrierDeps {
   boxSymbolIdx: number;
   /** The `(externref) -> i32` §7.1.2 ToBoolean helper (reused USER-deps funcIdx). */
   isTruthyIdx: number;
+  /** `__typeof_object(externref) -> i32` — validates an IteratorResult before
+   * falling through to closed-struct field readers. A primitive throw result
+   * (for example `throw() { return 23; }`) must raise TypeError rather than
+   * being mistaken for a closed struct whose `done` field is absent. */
+  typeofObjectIdx: number;
   /** `$Object` struct typeIdx — discriminates the step-result read path. */
   objectTypeIdx: number;
   /** `$Proxy` struct typeIdx — Proxy iterators use the same property path. */
@@ -1298,6 +1303,7 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
       boxSymbolIdx !== undefined &&
       objectTypeIdx !== undefined &&
       isTruthyIdx !== undefined &&
+      ctx.funcMap.get("__typeof_object") !== undefined &&
       ctx.nativeStrTypeIdx >= 0
     ) {
       objDeps = {
@@ -1306,6 +1312,7 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
         objectTypeIdx,
         proxyTypeIdx: ctx.objectRuntimeTypes?.proxyTypeIdx,
         isTruthyIdx,
+        typeofObjectIdx: ctx.funcMap.get("__typeof_object")!,
         applyClosureIdx: reserveApplyClosure(ctx),
         sgetValueIdx: ctx.funcMap.get("__sget_value"),
         sgetDoneIdx: ctx.funcMap.get("__sget_done"),
@@ -1862,6 +1869,33 @@ function buildIteratorThrowBody(
     { op: "extern.convert_any" },
   ];
 
+  const closedResultRead: Instr[] =
+    od.sgetDoneIdx !== undefined && (od.sgetValueIdx !== undefined || od.sgetDoneIsExtern === true)
+      ? [
+          { op: "local.get", index: 6 },
+          { op: "call", funcIdx: od.sgetDoneIdx },
+          { op: "call", funcIdx: od.isTruthyIdx },
+          { op: "local.set", index: 7 },
+          { op: "local.get", index: 7 },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            // A done throw result completes the delegation and therefore
+            // reads `value`; a non-done result is forwarded without an
+            // eager value read (the Test262 getter-observability case).
+            then:
+              od.sgetValueIdx !== undefined
+                ? [
+                    { op: "local.get", index: 6 },
+                    { op: "call", funcIdx: od.sgetValueIdx },
+                  ]
+                : od.missInstrs(),
+            else: od.missInstrs(),
+          },
+          { op: "local.set", index: 8 },
+        ]
+      : fail();
+
   const readResult: Instr[] = [
     // A normal object/proxy result uses the dynamic property reader.
     ...objCarrierTest(od, () => [{ op: "local.get", index: 6 }, { op: "any.convert_extern" }]),
@@ -1886,32 +1920,25 @@ function buildIteratorThrowBody(
         },
         { op: "local.set", index: 8 },
       ],
-      else:
-        od.sgetDoneIdx !== undefined && (od.sgetValueIdx !== undefined || od.sgetDoneIsExtern === true)
-          ? [
-              { op: "local.get", index: 6 },
-              { op: "call", funcIdx: od.sgetDoneIdx },
-              { op: "call", funcIdx: od.isTruthyIdx },
-              { op: "local.set", index: 7 },
-              { op: "local.get", index: 7 },
-              {
-                op: "if",
-                blockType: { kind: "val", type: { kind: "externref" } },
-                // A done throw result completes the delegation and therefore
-                // reads `value`; a non-done result is forwarded without an
-                // eager value read (the Test262 getter-observability case).
-                then:
-                  od.sgetValueIdx !== undefined
-                    ? [
-                        { op: "local.get", index: 6 },
-                        { op: "call", funcIdx: od.sgetValueIdx },
-                      ]
-                    : od.missInstrs(),
-                else: od.missInstrs(),
-              },
-              { op: "local.set", index: 8 },
-            ]
-          : fail(),
+      else: [
+        // A closed struct result is not visible to `__extern_get`, so use the
+        // generated field readers only after confirming that the value is an
+        // ECMAScript Object. In particular, a numeric/string primitive from
+        // `throw()` must take the IteratorResult TypeError path; treating a
+        // missing `done` field as false would incorrectly yield NaN/undefined.
+        { op: "local.get", index: 6 },
+        { op: "ref.is_null" },
+        { op: "i32.eqz" },
+        { op: "local.get", index: 6 },
+        { op: "call", funcIdx: od.typeofObjectIdx },
+        { op: "i32.and" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: closedResultRead,
+          else: fail(),
+        },
+      ],
     },
   ];
 

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -360,6 +360,17 @@ interface ObjCarrierDeps {
   /** `__sget_throw(externref) -> externref` — the closed-struct iterator's
    *  `throw` method read used by the §14.4.14 delegation arm. */
   sgetThrowIdx?: number;
+  /** `__call_accessor_get(externref, externref) -> externref` — the shared
+   *  S5c driver for accessor-backed closed IteratorResult fields. */
+  accessorGetIdx?: number;
+  /** Accessor closure globals for closed `done`/`value` result fields. The
+   *  globals are nullable until their define-site executes, so each arm keeps
+   *  the ordinary generated field reader as its fallback. */
+  accessorGetArms?: Array<{
+    propName: "done" | "value";
+    structTypeIdx: number;
+    globalIdx: number;
+  }>;
   /** Fresh instrs pushing the string key `name` as externref. */
   keyInstrs: (name: string) => Instr[];
   /** Fresh instrs pushing the miss/undefined externref (matches `__extern_get`). */
@@ -1320,6 +1331,24 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
         sgetNextIdx: ctx.funcMap.get("__sget_next"),
         sgetReturnIdx: externSgetIdx(ctx, "__sget_return"),
         sgetThrowIdx: externSgetIdx(ctx, "__sget_throw"),
+        accessorGetIdx: ctx.funcMap.get("__call_accessor_get"),
+        accessorGetArms: (() => {
+          const accessorGetIdx = ctx.funcMap.get("__call_accessor_get");
+          if (accessorGetIdx === undefined) return undefined;
+          const arms: NonNullable<ObjCarrierDeps["accessorGetArms"]> = [];
+          for (const [key, entry] of ctx.structAccessorClosure) {
+            if (entry.getGlobal === undefined) continue;
+            for (const propName of ["done", "value"] as const) {
+              const suffix = `_${propName}`;
+              if (!key.endsWith(suffix)) continue;
+              const structTypeIdx = ctx.structMap.get(key.slice(0, -suffix.length));
+              if (structTypeIdx !== undefined) {
+                arms.push({ propName, structTypeIdx, globalIdx: entry.getGlobal });
+              }
+            }
+          }
+          return arms.length > 0 ? arms : undefined;
+        })(),
         keyInstrs: (name: string) => [...nativeStringLiteralInstrs(ctx, name), { op: "extern.convert_any" }],
         missInstrs: () => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }],
       };
@@ -1869,11 +1898,56 @@ function buildIteratorThrowBody(
     { op: "extern.convert_any" },
   ];
 
+  // S5c accessor closures live in nullable module globals rather than in the
+  // closed struct's field slots. Prefer a live closure for `done`/`value`, but
+  // keep the generated static getter as the fallback for objects whose
+  // define-site has not executed (or which have no accessor at all).
+  const closedFieldRead = (name: "done" | "value", fallback: () => Instr[]): Instr[] => {
+    let result = fallback();
+    const accessorGetIdx = od.accessorGetIdx;
+    const arms = od.accessorGetArms?.filter((arm) => arm.propName === name) ?? [];
+    if (accessorGetIdx === undefined || arms.length === 0) return result;
+    for (const arm of [...arms].reverse()) {
+      result = [
+        { op: "local.get", index: 6 },
+        { op: "any.convert_extern" },
+        { op: "ref.test", typeIdx: arm.structTypeIdx },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: [
+            { op: "global.get", index: arm.globalIdx },
+            { op: "ref.is_null" },
+            { op: "i32.eqz" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "externref" } },
+              then: [
+                { op: "local.get", index: 6 },
+                { op: "global.get", index: arm.globalIdx },
+                { op: "call", funcIdx: accessorGetIdx },
+              ],
+              else: fallback(),
+            },
+          ],
+          else: result,
+        },
+      ];
+    }
+    return result;
+  };
+
+  const hasClosedAccessor = (name: "done" | "value"): boolean =>
+    od.accessorGetIdx !== undefined && (od.accessorGetArms?.some((arm) => arm.propName === name) ?? false);
+
   const closedResultRead: Instr[] =
-    od.sgetDoneIdx !== undefined && (od.sgetValueIdx !== undefined || od.sgetDoneIsExtern === true)
+    od.sgetDoneIdx !== undefined &&
+    (od.sgetValueIdx !== undefined || od.sgetDoneIsExtern === true || hasClosedAccessor("value"))
       ? [
-          { op: "local.get", index: 6 },
-          { op: "call", funcIdx: od.sgetDoneIdx },
+          ...closedFieldRead("done", () => [
+            { op: "local.get", index: 6 },
+            { op: "call", funcIdx: od.sgetDoneIdx! },
+          ]),
           { op: "call", funcIdx: od.isTruthyIdx },
           { op: "local.set", index: 7 },
           { op: "local.get", index: 7 },
@@ -1883,13 +1957,15 @@ function buildIteratorThrowBody(
             // A done throw result completes the delegation and therefore
             // reads `value`; a non-done result is forwarded without an
             // eager value read (the Test262 getter-observability case).
-            then:
+            then: closedFieldRead(
+              "value",
               od.sgetValueIdx !== undefined
-                ? [
+                ? () => [
                     { op: "local.get", index: 6 },
-                    { op: "call", funcIdx: od.sgetValueIdx },
+                    { op: "call", funcIdx: od.sgetValueIdx! },
                   ]
-                : od.missInstrs(),
+                : od.missInstrs,
+            ),
             else: od.missInstrs(),
           },
           { op: "local.set", index: 8 },

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -19,7 +19,7 @@ import {
 } from "./closures.js";
 import { reportError } from "./context/errors.js";
 import { isGlobalObjectExpr } from "./global-environment.js"; // (#4394) host global object, never a struct
-import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
+import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitThrowRangeError, emitThrowTypeError } from "./expressions/helpers.js";
 import { buildThrowJsErrorInstrs } from "./js-errors.js"; // (#3177 slice 4) defineProperty rejection sentinel → TypeError
@@ -28,7 +28,7 @@ import { resolveStructName } from "./expressions/misc.js";
 import { widenedStructNameForUse, integrityVarKey } from "./widened-var-key.js";
 import { addUnionImports, cacheStringLiterals, getOrRegisterTupleType, resolveWasmType } from "./index.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
-import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterRefCellType, getOrRegisterVecType } from "./registry/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import type { InnerResult } from "./shared.js";
@@ -1448,7 +1448,6 @@ export function compileObjectDefineProperty(
   // `emitExternDefinePropertyNoValue` → `__defineProperty_accessor` path). Splitting
   // on this bit fixes the `const o:any` accessor-get bug without regressing the
   // statically struct-typed (class-instance) accessor path.
-  const receiverIsStaticStruct = structName !== undefined;
   // #4504: `C.prototype` is an inherited-descriptor owner, never the
   // instance's physical struct.  The historical static-struct accessor path
   // recorded `${C}_p` in `classAccessorSet`, which later made the closed-field
@@ -1504,6 +1503,27 @@ export function compileObjectDefineProperty(
       }
     }
   }
+
+  // `resolveStructName` describes the checker shape, but a host-mode object
+  // literal carrying a callable field can deliberately lower to an open
+  // `$Object`/externref carrier. In that case a descriptor accessor cannot use
+  // the closed-struct fast path: its generated `${struct}_get_<prop>` function
+  // is invisible to host [[Get]] (and to iterator protocol helpers). Recover
+  // the actual binding slot type so fallback-resolved shapes do not select the
+  // static accessor path when the value is carried as externref.
+  const receiverCarrierType = (() => {
+    if (!ts.isIdentifier(objArg)) return undefined;
+    const localIdx = fctx.localMap.get(objArg.text);
+    if (localIdx !== undefined) return getLocalType(fctx, localIdx);
+    const globalIdx = ctx.moduleGlobals.get(objArg.text);
+    if (globalIdx !== undefined) return ctx.mod.globals[localGlobalIdx(ctx, globalIdx)]?.type;
+    return undefined;
+  })();
+  const receiverIsStaticStruct =
+    structName !== undefined &&
+    (receiverCarrierType === undefined ||
+      receiverCarrierType.kind === "ref" ||
+      receiverCarrierType.kind === "ref_null");
 
   const structTypeIdx = structName ? ctx.structMap.get(structName) : undefined;
   const fields = structName ? ctx.structFields.get(structName) : undefined;

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -4225,8 +4225,24 @@ export function finalizeStructAndDynamicMemberGet(
   // For externref objects (e.g. results of host calls like RegExp.exec()),
   // use __extern_get(obj, key) to dynamically read the property at runtime.
   {
+    // A module-level binding may retain an externref carrier even when the
+    // checker reports `undefined` (the common `var caught;` catch-observation
+    // shape). The checker-derived wasm type is then i32, and the old fallback
+    // treated `caught.constructor` as a constant null instead of reading the
+    // actual caught value. Recover the physical module-global type before
+    // choosing the dynamic property path; local bindings shadowing the same
+    // name remain governed by their local slot type below.
+    const moduleGlobalExternrefReceiver =
+      ts.isIdentifier(expr.expression) &&
+      (() => {
+        if (fctx.localMap.has(expr.expression.text)) return false;
+        const globalIdx = ctx.moduleGlobals.get(expr.expression.text);
+        if (globalIdx === undefined) return false;
+        return ctx.mod.globals[localGlobalIdx(ctx, globalIdx)]?.type.kind === "externref";
+      })();
     const objWasmType =
-      typeName && !ctx.standalone && !ctx.wasi && ctx.classExternrefBackedSet.has(typeName)
+      moduleGlobalExternrefReceiver ||
+      (typeName && !ctx.standalone && !ctx.wasi && ctx.classExternrefBackedSet.has(typeName))
         ? ({ kind: "externref" } as const)
         : resolveWasmType(ctx, objType);
     // (#4249) A direct-eval accessor assignment can widen a function-local
@@ -4242,6 +4258,7 @@ export function finalizeStructAndDynamicMemberGet(
       ts.isIdentifier(expr.expression) && ctx.evalAccessorObjectVars.has(expr.expression.text);
     const isExternObj =
       isEvalAccessorReceiver ||
+      moduleGlobalExternrefReceiver ||
       objWasmType.kind === "externref" ||
       // (#3033 Bug 2b) CHAINED dynamic read: the receiver is itself a purely-
       // undefined-typed member read off an externref receiver (`this.type` in

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -2142,8 +2142,18 @@ export function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
 
 /** Register the iterator protocol host imports if not already registered */
 export function addIteratorImports(ctx: CodegenContext): void {
-  // Guard: only register once
-  if (ctx.funcMap.has("__iterator")) return;
+  // Guard: only register the common iterator imports once.  The throw
+  // operation was added after the original four-name bundle; retain the
+  // idempotent fast path while allowing an older caller that already installed
+  // `__iterator`/`__iterator_next` to acquire the new operation.
+  if (ctx.funcMap.has("__iterator")) {
+    if (!ctx.funcMap.has("__iterator_throw") && !ctx.standalone && !ctx.wasi) {
+      const ER: ValType = { kind: "externref" };
+      ensureLateImport(ctx, "__iterator_throw", [ER, ER], [{ kind: "i32" }, ER]);
+      flushLateImportShifts(ctx, ctx.currentFunc);
+    }
+    return;
+  }
 
   // (#2689) Add via the late-import batch (`ensureLateImport`) + an IMMEDIATE
   // `flushLateImportShifts`. This helper has TWO call contexts: the EARLY
@@ -2166,6 +2176,10 @@ export function addIteratorImports(ctx: CodegenContext): void {
   // see #1620 BLOCKED). The two primitives (i32 + externref) cross the JS↔Wasm
   // multi-value ABI cleanly, eliminating __iterator_done / __iterator_value.
   ensureLateImport(ctx, "__iterator_next", [ER], [{ kind: "i32" }, ER]);
+  // __iterator_throw: (externref, externref) → (i32 done, externref value) —
+  // forwards an abrupt completion to the delegate's `throw` method, applying
+  // IteratorClose when that method is absent (§14.4.14 / §27.5.3.7).
+  ensureLateImport(ctx, "__iterator_throw", [ER, ER], [{ kind: "i32" }, ER]);
   // __iterator_return: (externref) → void — calls iter.return() if it exists
   ensureLateImport(ctx, "__iterator_return", [ER], []);
   // __iterator_rest: (externref) → externref — drains a partially-consumed

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15968,8 +15968,23 @@ assert._isSameValue = isSameValue;
         // return() and then raises the required TypeError.
         return (iter: any, error: any): [number, any] => {
           const exports = callbackState?.getExports();
+          // Keep protocol TypeErrors in the test/module realm. Host-lane
+          // catches compare `caught.constructor` with the sandbox's
+          // `TypeError`; constructing with the runtime realm's global would
+          // produce a distinct constructor identity at that boundary.
+          const throwTypeError = (message: string): never => {
+            const TypeErrorCtor = globalSandbox?.TypeError;
+            if (typeof TypeErrorCtor === "function") throw new TypeErrorCtor(message);
+            throw new TypeError(message);
+          };
           const getMethod = (receiver: any, key: string): any => {
-            let method = receiver?.[key];
+            // Iterator records/results can be opaque WasmGC structs. Reading
+            // them through `receiver[key]` bypasses the runtime sidecar and
+            // generated field readers, so accessor-backed `throw`/`return`
+            // properties look absent in the host lane. `_safeGet` is the
+            // shared [[Get]] boundary for ordinary JS objects and opaque
+            // carriers, and preserves abrupt getter completions.
+            let method = _safeGet(receiver, key, callbackState);
             if (method === undefined) method = _sidecarGet(receiver, key);
             if (method === undefined) method = (exports as any)?.[`__sget_${key}`]?.(receiver);
             return method;
@@ -15987,19 +16002,33 @@ assert._isSameValue = isSameValue;
                 if (typeof callFn1 === "function") return callFn1(method, args[0]);
               }
             }
-            throw new TypeError("Iterator method is not callable");
+            throwTypeError("Iterator method is not callable");
           };
           const readResult = (result: any): [number, any] => {
             if (result === null || (typeof result !== "object" && typeof result !== "function")) {
-              throw new TypeError("Iterator result is not an object");
+              throwTypeError("Iterator result is not an object");
             }
-            let done = result.done;
+            // A returned closed struct does not expose its fields through
+            // ordinary host property syntax, while an accessor in its sidecar
+            // must run before any generated static-field fallback. Read the
+            // completion flag through the same canonical boundary as method
+            // lookup; IteratorValue is intentionally lazy for a non-done
+            // throw result (§14.4.14).
+            const readField = (key: string): any => {
+              let value = _safeGet(result, key, callbackState);
+              if (value === undefined) value = (exports as any)?.[`__sget_${key}`]?.(result);
+              return value;
+            };
+            let done = readField("done");
             if (done === undefined) done = _sidecarGet(result, "done");
             if (done === undefined) done = (exports as any)?.__sget_done?.(result);
-            let value = result.value;
-            if (value === undefined) value = _sidecarGet(result, "value");
-            if (value === undefined) value = (exports as any)?.__sget_value?.(result);
-            return [done ? 1 : 0, done ? undefined : value];
+            let value: any = undefined;
+            if (done) {
+              value = readField("value");
+              if (value === undefined) value = _sidecarGet(result, "value");
+              if (value === undefined) value = (exports as any)?.__sget_value?.(result);
+            }
+            return [done ? 1 : 0, value];
           };
 
           const throwMethod = getMethod(iter, "throw");
@@ -16009,13 +16038,14 @@ assert._isSameValue = isSameValue;
 
           const returnMethod = getMethod(iter, "return");
           if (returnMethod === undefined || returnMethod === null) {
-            throw new TypeError("The iterator does not provide a 'throw' method");
+            throwTypeError("The iterator does not provide a 'throw' method");
           }
           const closeResult = callMethod(returnMethod, iter, []);
           if (closeResult === null || (typeof closeResult !== "object" && typeof closeResult !== "function")) {
-            throw new TypeError("Iterator result is not an object");
+            throwTypeError("Iterator result is not an object");
           }
-          throw new TypeError("The iterator does not provide a 'throw' method");
+          throwTypeError("The iterator does not provide a 'throw' method");
+          return [1, undefined];
         };
       if (name === "__iterator_rest")
         return (iter: any) => {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15959,6 +15959,64 @@ assert._isSameValue = isSameValue;
           // Multi-value ABI: return an iterable of [i32 done, externref value].
           return [done ? 1 : 0, value];
         };
+      if (name === "__iterator_throw")
+        // #1691 — yield*'s abrupt delegation arm. The import receives the
+        // already-materialized iterator object (the host lane does not wrap it
+        // in the native $__IterRec), forwards the original error to `throw`,
+        // and returns the IteratorResult as the same multi-value pair as
+        // __iterator_next. A missing throw method performs IteratorClose via
+        // return() and then raises the required TypeError.
+        return (iter: any, error: any): [number, any] => {
+          const exports = callbackState?.getExports();
+          const getMethod = (receiver: any, key: string): any => {
+            let method = receiver?.[key];
+            if (method === undefined) method = _sidecarGet(receiver, key);
+            if (method === undefined) method = (exports as any)?.[`__sget_${key}`]?.(receiver);
+            return method;
+          };
+          const callMethod = (method: any, receiver: any, args: any[]): any => {
+            if (typeof method === "function") return method.apply(receiver, args);
+            if (_isWasmStruct(method)) {
+              if (args.length === 0) {
+                const callFn0 = (exports as any)?.__call_fn_0;
+                if (typeof callFn0 === "function") return callFn0(method);
+              } else if (args.length === 1) {
+                const callFnM1 = (exports as any)?.__call_fn_method_1;
+                if (typeof callFnM1 === "function") return callFnM1(receiver, method, args[0]);
+                const callFn1 = (exports as any)?.__call_fn_1;
+                if (typeof callFn1 === "function") return callFn1(method, args[0]);
+              }
+            }
+            throw new TypeError("Iterator method is not callable");
+          };
+          const readResult = (result: any): [number, any] => {
+            if (result === null || (typeof result !== "object" && typeof result !== "function")) {
+              throw new TypeError("Iterator result is not an object");
+            }
+            let done = result.done;
+            if (done === undefined) done = _sidecarGet(result, "done");
+            if (done === undefined) done = (exports as any)?.__sget_done?.(result);
+            let value = result.value;
+            if (value === undefined) value = _sidecarGet(result, "value");
+            if (value === undefined) value = (exports as any)?.__sget_value?.(result);
+            return [done ? 1 : 0, done ? undefined : value];
+          };
+
+          const throwMethod = getMethod(iter, "throw");
+          if (throwMethod !== undefined && throwMethod !== null) {
+            return readResult(callMethod(throwMethod, iter, [error]));
+          }
+
+          const returnMethod = getMethod(iter, "return");
+          if (returnMethod === undefined || returnMethod === null) {
+            throw new TypeError("The iterator does not provide a 'throw' method");
+          }
+          const closeResult = callMethod(returnMethod, iter, []);
+          if (closeResult === null || (typeof closeResult !== "object" && typeof closeResult !== "function")) {
+            throw new TypeError("Iterator result is not an object");
+          }
+          throw new TypeError("The iterator does not provide a 'throw' method");
+        };
       if (name === "__iterator_rest")
         return (iter: any) => {
           // #1052 — drain an already-partially-consumed iterator into an Array


### PR DESCRIPTION
## Description

- Checkpoint native `yield*` throw-protocol work while preserving the remaining residuals as an explicit handoff.
- Improve the exact standalone cohort from 7/13 to 9/13, with four assertion failures remaining and no compile errors, timeouts, or skips.
- Track the implementation plan, exact evidence, remaining cases, and handoff in `plan/issues/1691-yieldstar-throw-return-delegation.md`.

This PR remains draft and labeled `hold` because the exact cohort is not complete or mergeable as a finished fix.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
