### PR TITLE
docs(issues): file #4774 + #4775 from the #4406 slice; attribute the §1.3 drift

### DIFF
--- a/plan/issues/3754-method-axis-dispatch-gap.md
+++ b/plan/issues/3754-method-axis-dispatch-gap.md
@@ -258,3 +258,25 @@ That is the recommended slice: strengthen the admission for write-once
 - **#3755** (per-call `__str_flatten`) — measured, worth 0, closed wont-fix.
 - **#3765** (numeric locals stay boxed) — the tokenizer's real remaining lever,
   filed from the same profiling round.
+
+## 2026-08-27 — this issue's test file is 9/10 RED on main
+
+`tests/issue-3754-numeric-return-twin.test.ts`, shipped by this issue's impl PR,
+now fails 9 of its 10 tests on `origin/main` @ `7e0b03ebb7`. Every failure is
+`expected '' to be '<type>'` from `trampolineResultType("__dc_P_inc_0_g")` — the
+helper's "no such function" answer, i.e. the direct-call trampoline the file was
+written to observe is no longer emitted for its `methodAxis` shape. The one
+passing test is the value-level one, which does not read the WAT.
+
+Found — and verified pre-existing, by reverting an in-flight PR's source files
+to `HEAD` and re-running — during
+[#4406](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4406-return-type-unboxing-abi)
+Phase 0+1 (PR #5061). The file is in no required check, which is why it stayed
+red unnoticed.
+
+Not reopening this issue: the mechanism it shipped is alive at scale
+(`sites=3976 trampolines=545 twinFills=516 genericFills=29 legacyFills=0` on the
+acorn lane today, measured the same day). Tracked as
+[#4775](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4775-numeric-return-twin-suite-red-on-main),
+which has to decide first whether the test's shape stopped qualifying for
+devirtualization or the devirtualization itself regressed.

--- a/plan/issues/4406-return-type-unboxing-abi.md
+++ b/plan/issues/4406-return-type-unboxing-abi.md
@@ -598,7 +598,14 @@ does.** The plan's exact probe (`pp.eat = function (x) { return this.n === x; }`
 then `("" + p.eat(5)).length`) now answers **4**, matching node. A predicate
 whose body is a bare comparison already carries a boolean-branded i32 through
 its DECLARED signature, so `refinedTwinReturnType` declines on it
-(`declared.kind !== "externref"`). The `&&`-of-calls shape — which is acorn's
+(`declared.kind !== "externref"`). Cause of the drift: #4414 (done 2026-08-14)
+fixed the three stringification consumers that decided boolean-ness from the
+static TS type alone and ignored the i32 brand (`compileNativeConcatOperand`
+and the template-literal span path in `src/codegen/string-ops.ts`, plus the
+`String(x)` i32 arm in `src/codegen/expressions/call-identifier.ts`) — #4414's
+own measurement of this repro shows `refined=undefined`, so the twin refinement
+was never the producer there, and `JS2WASM_NUMERIC_TWINS=0` fixes this slice's
+surviving witness while #4414 measured it as not fixing theirs. The `&&`-of-calls shape — which is acorn's
 own idiom (`eatContextual`, `shouldParseArrow`, every `regexp_eat*`) — still
 reaches the refinement and still miscompiles:
 

--- a/plan/issues/4774-invalid-module-mixed-return-prototype-concat.md
+++ b/plan/issues/4774-invalid-module-mixed-return-prototype-concat.md
@@ -1,0 +1,118 @@
+---
+id: 4774
+title: "invalid module: mixed boolean/number prototype method + string concat emits a binary WebAssembly.compile rejects"
+status: ready
+sprint: current
+created: 2026-08-27
+priority: high
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen
+related: [4406, 4414, 3754]
+# (2026-08-27) Reserved with `--allow-unscanned` because this container has no
+# `gh`, so `claim-issue.mjs`'s open-PR id scan degrades unconditionally. The
+# scan was NOT skipped — it was run directly against the REST API with curl:
+# 5 open PRs on loopdive/js2 touch issue ids {2949, 4406, 4768, 4770, 4771,
+# 4773}. 4774 is not among them.
+---
+
+# #4774 — `compile()` says success, `WebAssembly.compile()` rejects the binary
+
+## Problem
+
+A prototype method whose return set is **mixed** boolean/number, installed
+directly on `P.prototype`, and whose result is consumed by **string
+concatenation**, emits a module that fails wasm validation. The compiler
+reports `success: true` and produces no diagnostic, so the failure surfaces
+only when someone instantiates the binary.
+
+Found while implementing
+[#4406](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4406-return-type-unboxing-abi)
+Phase 0+1 (PR #5061) — it broke a negative test written for that slice. It is
+**not** caused by that work: it reproduces identically with
+`JS2WASM_RET_UNBOX_ABI` set and unset, and on `origin/main` @ `7e0b03ebb7`
+with every file that PR touches reverted to `HEAD`.
+
+## Repro
+
+`target: "standalone"`, `optimize: 0`, no flags set:
+
+```js
+function P(n) { this.n = n; }
+P.prototype.eq   = function (x) { return this.n === x; };
+P.prototype.pred = function (x) { if (x > 100) { return 7; } return this.eq(x) && this.eq(x); };
+function inner() { var p = new P(5); return ("" + p.pred(5)).length; }
+export function run() { return inner(); }
+```
+
+```
+result.success === true            // no diagnostic at all
+await WebAssembly.instantiate(result.binary, {})
+  CompileError: Compiling function #63:"inner" failed:
+    struct.get[0] expected type (ref null 6), found block of type (ref null 71)
+```
+
+With two concat sites (`… + ("" + p.pred(200)).length`) the same failure reads
+`found call of type (ref null 71)` — same class, different producer instruction
+under the `struct.get`.
+
+## Bisect — all THREE ingredients are required
+
+Measured 2026-08-27; change any one row's condition and the module is valid:
+
+| variant | result |
+| --- | --- |
+| `P.prototype.pred = …` mixed return, 2 concat sites | **INVALID MODULE** |
+| `P.prototype.pred = …` mixed return, 1 concat site | **INVALID MODULE** |
+| same, consumed by a CONDITION instead of concat (`p.pred(5) ? 1 : 0`) | valid, `run = 8` |
+| same, but the return set is PURE boolean | valid, `run = 9` (and correct) |
+| same mixed return, installed as `var pp = P.prototype; pp.pred = …` | valid, `run = 2` |
+
+So it needs all of: (1) the direct `P.prototype.<m> = …` install form, **not**
+the aliased one; (2) a return set the whole-program fixpoint sees as mixed
+boolean/number (`if (…) return 7;` plus a boolean tail); (3) a string-concat
+consumer.
+
+The `(ref null 71)` vs `(ref null 6)` mismatch says a `struct.get` is handed a
+value of the wrong struct type — the shape of an ABI disagreement between the
+producer of `p.pred(5)`'s result and the concat lowering that consumes it, not
+of a stack-height bug.
+
+## Why it matters
+
+`compile()` returning `success: true` for a module no engine will accept is the
+worst failure mode available: nothing in the compile-time diagnostics, the
+equivalence suites, or a `--wat` inspection flags it. It is caught only by
+instantiating, which a caller may do far from the compile.
+
+The VALUE is also wrong in the neighbouring *valid* cases — `("" + p.pred(5))`
+on a mixed-return method reads `"1"` where node says `"true"`. That is
+[#4414](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4414-boolean-returns-minted-as-f64-numeric-twins)'s
+residual (the f64 numeric twin for a method the boolean fixpoint withdrew), and
+it is a **separate** defect: the wrong-value variants above still produce a
+valid module. Do not conflate the two.
+
+## Acceptance criteria
+
+- The repro compiles to a module `WebAssembly.compile` accepts, or `compile()`
+  reports a diagnostic instead of claiming success.
+- An equivalence test covering the shape (mixed-return prototype method under
+  string concatenation), oracled against plain JS — the js-host lane cannot run
+  the prototype-method shape at all (#4227 family, see #4414's closing note).
+- The bisect table above still discriminates. A "fix" that makes both install
+  forms decline would hide the defect rather than close it.
+
+## Pointers
+
+- `refinedTwinReturnType` (`src/codegen/typed-this.ts`) is what gives the mixed
+  method an `f64` twin — `Prover.isNumeric` answers true for booleans and the
+  `numericFunctions` loop carries no `isBooleanish` filter (see #4414's Problem
+  section and #4406's plan §1.2).
+- `compileNativeConcatOperand` (`src/codegen/string-ops.ts`) is the standalone
+  `+`-concat cascade #4414 already had to teach about the boolean brand; it is
+  deliberately not routed through the coercion engine.
+- The install-form sensitivity (`P.prototype.m =` vs `pp.m =`) points at
+  `fnctorEscapeGate.protoMethodWriteOnce` / `writeOnceMethodKeyOf`: the two
+  forms produce different write-once verdicts, which is why only one of them
+  reaches the refinement at all.

--- a/plan/issues/4775-numeric-return-twin-suite-red-on-main.md
+++ b/plan/issues/4775-numeric-return-twin-suite-red-on-main.md
@@ -1,0 +1,88 @@
+---
+id: 4775
+title: "tests/issue-3754-numeric-return-twin.test.ts is 9/10 RED on main and nothing gates it"
+status: ready
+sprint: current
+created: 2026-08-27
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: testing
+related: [3754, 3753, 4406, 4405]
+# (2026-08-27) Reserved with `--allow-unscanned` — no `gh` in this container, so
+# `claim-issue.mjs`'s open-PR scan degrades unconditionally. The scan was run
+# directly against the REST API with curl instead: 5 open PRs on loopdive/js2
+# touch issue ids {2949, 4406, 4768, 4770, 4771, 4773}. 4775 is not among them.
+---
+
+# #4775 — the numeric-return-twin suite is red on main, unnoticed
+
+## Problem
+
+`tests/issue-3754-numeric-return-twin.test.ts` fails **9 of its 10 tests** on
+`origin/main` @ `7e0b03ebb7`. Every failure is the same shape:
+
+```
+AssertionError: expected '' to be 'externref'   (and 'f64', and 'i32')
+  at trampolineResultType("__dc_P_inc_0_g")
+```
+
+The helper returns `''` when the module has no function of that name — so the
+`__dc_P_inc_0_g` direct-call trampoline that file was written to observe is no
+longer emitted for its `methodAxis` shape. The one passing test is the
+value-level one ("a dynamic call still reaches the same value through the
+shim"), which does not read the WAT.
+
+Found while implementing
+[#4406](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4406-return-type-unboxing-abi)
+Phase 0+1 (PR #5061). **Verified pre-existing**: every source file that PR
+touches was reverted to `HEAD` and the suite re-run — the same 9 failures.
+
+## Why nobody noticed
+
+The file is not in a required check. The required six are `cheap gate`,
+`quality`, `merge shard reports`, `check for test262 regressions`,
+`equivalence-gate` and `cla-check`; this file lives under `tests/`, not
+`tests/equivalence/`, so `equivalence-gate` does not run it, and the general
+`npm test` lane does not gate. A shape-assertion suite that silently stopped
+observing its subject is exactly the failure family #4157 entry 22 names: a
+green (here: unwatched) run over a path that no longer exists proves nothing.
+
+## The question this issue has to answer first
+
+**Is the mechanism regressed, or is the test stale?** Both are plausible and
+they need opposite fixes:
+
+- *Stale test* — the direct-call admission rules moved (arity padding,
+  receiver-flow proof, the `no-write-once-verdict` decline) and the file's
+  `methodAxis` shape no longer reserves a trampoline. Then the fix is to
+  re-derive the shape, not to relax the assertions: #3754's whole point is
+  that the trampoline's result must FOLLOW the twin's, and an assertion
+  loosened to keep the file green would prove nothing.
+- *Regressed mechanism* — a devirtualization that used to happen no longer
+  does, which would be a silent perf regression on the `method` axis #3754 was
+  measured against (6.21× node at the time).
+
+The instrument that distinguishes them already exists:
+`JS2WASM_DIRECT_CALLS_DEBUG=1` prints `sites / trampolines / twinFills /
+genericFills / legacyFills` plus a decline histogram. On the acorn lane today
+that reads `sites=3976 trampolines=545 twinFills=516 genericFills=29
+legacyFills=0`, so the machinery is alive at scale — which makes "the test's
+own shape stopped qualifying" the more likely of the two. Run it on the file's
+`methodAxis` source and read the decline reason.
+
+`JS2WASM_RET_UNBOX_STATS=1` (added by #4406 Phase 0) prints the per-name
+`twin=` / `tramp=` table for the same program and is the quicker read.
+
+## Acceptance criteria
+
+- The suite is green on main, with each assertion still pinning what its name
+  claims (the trampoline result follows the twin; the negative cases still keep
+  the boxed ABI).
+- The issue records WHICH of the two causes it was, with the decline reason or
+  the mechanism delta quoted.
+- If the file's shape had to change, say what changed about admission and when
+  — a shape that silently stopped qualifying once will do it again.
+- Consider whether this suite (and its siblings under `tests/issue-37*.test.ts`)
+  belong in a gating lane. A shape suite nobody runs is a comment.


### PR DESCRIPTION
Docs-only. Three records coming out of the [#4406](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4406-return-type-unboxing-abi) Phase 0+1 slice (PR #5061, merged):

- **[#4774](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4774-mixed-boolean-number-prototype-method-invalid-module)** (priority high): a mixed boolean/number prototype method consumed by string concatenation emits an **invalid module** — `compile()` reports success, `WebAssembly.compile` rejects (`struct.get[0] expected (ref null 6), found (ref null 71)`). Bisected to three required ingredients (direct `P.prototype.m = …` install form, mixed return set, string-concat consumer); flag-independent, reproduces on base. The neighbouring valid variants returning `"1"` for `true` are #4414's residual, recorded as a distinct defect.
- **[#4775](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4775-issue-3754-numeric-return-twin-suite-red)**: `tests/issue-3754-numeric-return-twin.test.ts` is 9/10 red on main (verified against clean HEAD; not in a required check, which is why it stayed invisible). The open question — stale test vs regressed devirtualization — is the actionable item. Closed #3754 carries a dated addendum pointing here; its shipped mechanism is alive at scale (`sites=3976 trampolines=545 twinFills=516 legacyFills=0`).
- **#4406 drift attribution**: the plan's §1.3 miscompile witness stopped reproducing because #4414 fixed three stringification consumers that ignored the i32 boolean brand; `refined=undefined` in #4414's own measurement proves the twin refinement was never the producer in that repro.

Issue ids reserved via `claim-issue.mjs --allocate` with the open-PR scan run against the REST API directly (no `gh` in the container); no in-flight PR carries either id.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_