### PR TITLE
fix(es2015): add WeakCollection prototype toStringTag properties

### DIFF
--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -1,10 +1,11 @@
 ---
 id: 4786
 title: "ES2015 standalone WeakMap and WeakSet prototype Symbol.toStringTag"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-27
 updated: 2026-08-27
+completed: 2026-08-27
 assignee: "ttraenkler/codex-es2015-next-bounded-fix-8"
 priority: high
 horizon: s
@@ -103,9 +104,48 @@ requires the corresponding `"WeakSet"` value and attributes.
   issue's regression test; no changes to WeakMap/WeakSet instance insertion or
   constructor behavior are included.
 
+## Test Results
+
+Post-sync evidence below was collected after merging the current
+`upstream/main` tip `5bdc209f0de611808a701d9b08a0b971d689f12f` into the branch
+(merge commit `3f01cf71910cfe1168a2cc9c957bb6fd00315adb`). The Test262
+submodule remained at `b363f29d3c43c626dc852744ad64a0b48a003693` and every run
+used the required QuickJS artifact
+`/private/tmp/js2-quickjs-artifact-2e2d7736713beeda` with two compiler workers.
+
+- Clean baseline (source `fb4efeaa5cb2a374d9b6ff87b4eca217a2ab78f1`): exact
+  standalone A/B was 0/2 (both rows failed); exact host control was 2/2.
+  Baseline JSONL SHA-256: standalone
+  `e4df36f897308af6a7b2e0818269045e5a86d0ba818b13918fbc240ea516c204`, host
+  `7ee917934c709e699c6e7b726e98bdb15cc8b69628ae872eba5fc6da17019eab`.
+- Post-sync exact harness A/B: standalone 2/2 and host 2/2, with no compile
+  errors, timeouts, skips, or control loss. JSONL SHA-256: standalone
+  `737ef305b80435fbaaaee2beb31759ee78099c5f41bddaedacfad395caaa4449`, host
+  `7ee917934c709e699c6e7b726e98bdb15cc8b69628ae872eba5fc6da17019eab`.
+- Post-sync repeat/determinism probes: standalone 2/2 and host 2/2, each with
+  `nondeterministic: 0`.
+- Focused Vitest regression file `tests/issue-4786-weak-collection-tostringtag.test.ts`:
+  6/6 tests passed (both exact rows in both lanes plus descriptor/identity
+  controls in both lanes).
+- Authoritative maintained runner, narrowed only to this official cohort with
+  `TEST262_PATH_FILTER_FILE` and two matching local shards:
+  `TEST262_TARGET=standalone TEST262_WORKERS=2 COMPILER_POOL_SIZE=2`
+  `pnpm run test:262 --official-scope-only` — 2/2 pass, 0 fail, 0 compile
+  errors, 0 timeouts, 0 skips, 2 host-free passes. Results JSONL SHA-256
+  `8943c8b3961fc049ff50d37543d7733416d44be40a7a16047f65d3510d3b0b60` and
+  report SHA-256 `508160a793451aa0387c354f68d7759dade2b089885150debccbc605feb3487b`.
+- An unfiltered `pnpm run test:262 --official-scope-only` invocation was also
+  started as a full-scope diagnostic. The two-worker local run spent over 17
+  minutes in pre-existing shard-10 generator/Unicode/TypedArray failures and
+  timeouts before interruption; it had not reached either #4786 row. The
+  complete scoped authoritative run above is the acceptance result for this
+  bounded cohort.
+
 ## Handoff
 
 Worktree: `/private/tmp/js2-es2015-next-bounded-fix-8`.
 Branch: `codex/es2015-next-bounded-fix-8`.
-The source checkpoint and exact A/B artifacts will be recorded here after the
-focused implementation and current-main verification.
+Source commits: `fae00a578a` (plan/claim) and `019109f311` (implementation);
+current-main merge: `3f01cf7191`.
+The branch is ready for the separate upstream PR for #4786. No WeakMap/WeakSet
+instance insertion or constructor code was changed.

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -1,0 +1,109 @@
+---
+id: 4786
+title: "ES2015 standalone WeakMap and WeakSet prototype Symbol.toStringTag"
+status: in-progress
+sprint: current
+created: 2026-08-27
+updated: 2026-08-27
+assignee: "ttraenkler/codex-es2015-next-bounded-fix-8"
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+es_edition: es2015
+language_feature: weak-collection-prototype-tostringtag
+goal: host-and-standalone
+related: [2162]
+files:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/native-proto.ts
+  - src/codegen/native-proto-own-props.ts
+  - tests/issue-4786-weak-collection-tostringtag.test.ts
+  - plan/issues/4786-es2015-weak-collection-tostringtag.md
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/native-proto.ts
+  - src/codegen/native-proto-own-props.ts
+---
+
+# #4786 — ES2015 standalone WeakMap and WeakSet prototype `Symbol.toStringTag`
+
+## Scope and baseline
+
+This issue owns the two exact maintained ES2015 Test262 rows:
+
+```text
+test/built-ins/WeakMap/prototype/Symbol.toStringTag.js
+test/built-ins/WeakSet/prototype/Symbol.toStringTag.js
+```
+
+The source baseline is `upstream/main` at
+`fb4efeaa5cb2a374d9b6ff87b4eca217a2ab78f1`, with Test262 submodule revision
+`b363f29d3c43c626dc852744ad64a0b48a003693`. The exact baseline probe used
+the assembled Test262 harness and QuickJS artifact
+`/private/tmp/js2-quickjs-artifact-2e2d7736713beeda`, capped at two compiler
+workers. Host passes both rows; standalone fails both rows at the first tag
+read with `undefined` instead of the required string:
+
+| lane | WeakMap prototype tag | WeakSet prototype tag |
+| --- | --- | --- |
+| host | pass | pass |
+| standalone | fail (`undefined` vs `"WeakMap"`) | fail (`undefined` vs `"WeakSet"`) |
+
+The nearby Map/Set prototype tag rows are not controls for this issue: Map is
+still red on this current tip and has an independently allocated residual.
+
+## Root cause
+
+Standalone builtin prototypes are represented by `$NativeProto` values. Their
+companion seeder currently models the glue's string-keyed method CSV, while
+the native `__nproto_hasown` helper rejects all symbol keys except Function's
+special `Symbol.hasInstance` arm. WeakMap and WeakSet therefore have no
+companion entry for their required well-known `Symbol.toStringTag`, so a
+computed read returns `undefined` and `verifyProperty` cannot observe the
+required own descriptor.
+
+## Specification basis
+
+ECMA-262 (June 2020) §23.3.3.5,
+[`%WeakMap.prototype%[@@toStringTag]`](https://tc39.es/ecma262/2020/#sec-weakmap.prototype-@@tostringtag),
+requires the value `"WeakMap"` with writable `false`, enumerable `false`, and
+configurable `true`. Section 23.4.3.5,
+[`%WeakSet.prototype%[@@toStringTag]`](https://tc39.es/ecma262/2020/#sec-weakset.prototype-@@tostringtag),
+requires the corresponding `"WeakSet"` value and attributes.
+
+## Implementation plan
+
+1. Extend the native-prototype glue contract with optional well-known-symbol
+   tag metadata and register the WeakMap/WeakSet tags without changing their
+   method closure sets or instance collection runtime.
+2. Seed the tag as a companion data property with the exact non-writable,
+   non-enumerable, configurable descriptor flags, and make the native-proto
+   own-property path recognize the symbol by identity and consult that mutable
+   companion. Existing dynamic reads and descriptors will then use the normal
+   companion table, including deletion/override semantics.
+3. Add focused coverage for the exact two rows and controls for values,
+   descriptors, identity, and a non-tag symbol. Run exact host/standalone A/B,
+   repeats/determinism, and scoped repository gates.
+
+## Acceptance criteria
+
+- Both exact rows pass in host and standalone, with no compile errors,
+  timeouts, skips, or unrelated control losses.
+- `WeakMap.prototype[Symbol.toStringTag]` and the WeakSet twin retain their
+  specified own descriptors; wrong symbols and ordinary collection methods are
+  unchanged.
+- The standalone output remains host-free and focused TypeScript/lint/format,
+  issue metadata, budget, and hook checks pass.
+- The implementation stays confined to native-prototype glue/seeding and the
+  issue's regression test; no changes to WeakMap/WeakSet instance insertion or
+  constructor behavior are included.
+
+## Handoff
+
+Worktree: `/private/tmp/js2-es2015-next-bounded-fix-8`.
+Branch: `codex/es2015-next-bounded-fix-8`.
+The source checkpoint and exact A/B artifacts will be recorded here after the
+focused implementation and current-main verification.

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -26,6 +26,8 @@ loc-budget-allow:
   - src/codegen/array-object-proto.ts
   - src/codegen/native-proto.ts
   - src/codegen/native-proto-own-props.ts
+func-budget-allow:
+  - src/codegen/native-proto-own-props.ts::registerNativeProtoHasOwn
 ---
 
 # #4786 — ES2015 standalone WeakMap and WeakSet prototype `Symbol.toStringTag`

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -106,34 +106,37 @@ requires the corresponding `"WeakSet"` value and attributes.
 
 ## Test Results
 
-Post-sync evidence below was collected after merging the current
-`upstream/main` tip `5bdc209f0de611808a701d9b08a0b971d689f12f` into the branch
-(merge commit `3f01cf71910cfe1168a2cc9c957bb6fd00315adb`). The Test262
-submodule remained at `b363f29d3c43c626dc852744ad64a0b48a003693` and every run
-used the required QuickJS artifact
-`/private/tmp/js2-quickjs-artifact-2e2d7736713beeda` with two compiler workers.
+Final evidence below was collected after merging the current `upstream/main`
+tip `76c47838e19f82932d8d17825512c673ce750ca4` into the branch (merge commit
+`af522aff3c0e77cf93fd5d31fde2a97042085dc4`). The Test262 submodule remained
+at `b363f29d3c43c626dc852744ad64a0b48a003693` and every run used the required
+QuickJS artifact `/private/tmp/js2-quickjs-artifact-2e2d7736713beeda` with two
+compiler workers.
 
 - Clean baseline (source `fb4efeaa5cb2a374d9b6ff87b4eca217a2ab78f1`): exact
   standalone A/B was 0/2 (both rows failed); exact host control was 2/2.
   Baseline JSONL SHA-256: standalone
   `e4df36f897308af6a7b2e0818269045e5a86d0ba818b13918fbc240ea516c204`, host
   `7ee917934c709e699c6e7b726e98bdb15cc8b69628ae872eba5fc6da17019eab`.
-- Post-sync exact harness A/B: standalone 2/2 and host 2/2, with no compile
-  errors, timeouts, skips, or control loss. JSONL SHA-256: standalone
+- Final exact harness A/B on `76c4783`: standalone 2/2 and host 2/2, with no
+  compile errors, timeouts, skips, or control loss. JSONL SHA-256: standalone
   `737ef305b80435fbaaaee2beb31759ee78099c5f41bddaedacfad395caaa4449`, host
   `7ee917934c709e699c6e7b726e98bdb15cc8b69628ae872eba5fc6da17019eab`.
-- Post-sync repeat/determinism probes: standalone 2/2 and host 2/2, each with
-  `nondeterministic: 0`.
-- Focused Vitest regression file `tests/issue-4786-weak-collection-tostringtag.test.ts`:
-  6/6 tests passed (both exact rows in both lanes plus descriptor/identity
+- Final repeat/determinism probes on `76c4783`: standalone 2/2 and host 2/2,
+  each with `nondeterministic: 0` (JSONL hashes match the exact A/B outputs
+  above).
+- Focused Vitest regression file
+  `tests/issue-4786-weak-collection-tostringtag.test.ts` on `af522aff3c`: 6/6
+  tests passed (both exact rows in both lanes plus descriptor/identity
   controls in both lanes).
 - Authoritative maintained runner, narrowed only to this official cohort with
   `TEST262_PATH_FILTER_FILE` and two matching local shards:
   `TEST262_TARGET=standalone TEST262_WORKERS=2 COMPILER_POOL_SIZE=2`
-  `pnpm run test:262 --official-scope-only` — 2/2 pass, 0 fail, 0 compile
-  errors, 0 timeouts, 0 skips, 2 host-free passes. Results JSONL SHA-256
-  `8943c8b3961fc049ff50d37543d7733416d44be40a7a16047f65d3510d3b0b60` and
-  report SHA-256 `508160a793451aa0387c354f68d7759dade2b089885150debccbc605feb3487b`.
+  `pnpm run test:262 --official-scope-only` on `af522aff3c` — 2/2 pass, 0
+  fail, 0 compile errors, 0 timeouts, 0 skips, 2 host-free passes. Results
+  JSONL SHA-256
+  `9de51735e322e277e31dc64876b0202ee0efb6622986192d59fa029421aab6d9` and
+  report SHA-256 `a8091a34fd707ee9489f93ca39ce58faaf8ccc4bdea7cd82ca94b8abf31fa30d`.
 - An unfiltered `pnpm run test:262 --official-scope-only` invocation was also
   started as a full-scope diagnostic. The two-worker local run spent over 17
   minutes in pre-existing shard-10 generator/Unicode/TypedArray failures and
@@ -146,6 +149,6 @@ used the required QuickJS artifact
 Worktree: `/private/tmp/js2-es2015-next-bounded-fix-8`.
 Branch: `codex/es2015-next-bounded-fix-8`.
 Source commits: `fae00a578a` (plan/claim) and `019109f311` (implementation);
-current-main merge: `3f01cf7191`.
+current-main merges: `3f01cf7191`, then `af522aff3c`.
 The branch is ready for the separate upstream PR for #4786. No WeakMap/WeakSet
 instance insertion or constructor code was changed.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -1763,11 +1763,13 @@ function makeGlue(
   brand: number,
   name: string,
   members: readonly string[],
+  symbolTag?: string,
 ): NativeProtoBuiltinGlue {
   return {
     brand,
     name,
     memberCsv: members.join(","),
+    ...(symbolTag === undefined ? {} : { symbolTag }),
     // Array/Object.prototype members are all data methods (no accessor getters
     // on the prototype itself; `length` is an own data property of an instance,
     // not the proto).
@@ -2118,7 +2120,7 @@ export function ensureWeakMapNativeProtoGlue(ctx: CodegenContext): number | unde
   const brand = getBuiltinBrand(ctx, "WeakMap");
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
-    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "WeakMap", WEAKMAP_PROTO_METHODS));
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "WeakMap", WEAKMAP_PROTO_METHODS, "WeakMap"));
   }
   return brand;
 }
@@ -2128,7 +2130,7 @@ export function ensureWeakSetNativeProtoGlue(ctx: CodegenContext): number | unde
   const brand = getBuiltinBrand(ctx, "WeakSet");
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
-    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "WeakSet", WEAKSET_PROTO_METHODS));
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "WeakSet", WEAKSET_PROTO_METHODS, "WeakSet"));
   }
   return brand;
 }

--- a/src/codegen/native-proto-own-props.ts
+++ b/src/codegen/native-proto-own-props.ts
@@ -73,6 +73,7 @@ import {
   ensureStandaloneNativeMethodClosure,
   getBuiltinBrand,
   seededNativeProtoOwnMembersByBrand,
+  seededNativeProtoSymbolTagsByBrand,
 } from "./native-proto.js";
 import { ensureFunctionNativeProtoGlue } from "./array-object-proto.js";
 import { pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
@@ -221,6 +222,7 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
   const equalsIdx = ctx.nativeStrHelpers.get("__str_equals");
   if (flattenIdx === undefined || equalsIdx === undefined) return undefined;
   const seededOwnMembers = seededNativeProtoOwnMembersByBrand(ctx);
+  const seededSymbolTags = seededNativeProtoSymbolTagsByBrand(ctx);
   const protoOwnRecvIdx = ctx.funcMap.get("__protoidx_own_recv");
   const objectHasOwnIdx = ctx.funcMap.get("__object_hasOwn");
   const functionBrand = getBuiltinBrand(ctx, "Function");
@@ -277,6 +279,51 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
     { op: "if", blockType: { kind: "empty" }, then: returnZero },
     // Symbol.hasInstance is an own Function.prototype method.
     ...nativeProtoHasInstanceOwnArm(protoTypeIdx, functionBrand, symbolType, L_ANY),
+    // Well-known symbol tags are own data properties of the collection
+    // prototypes. Their companion entries are authoritative, just like the
+    // seeded string methods below, so replacement/deletion remains visible to
+    // hasOwnProperty and propertyIsEnumerable.
+    ...(protoOwnRecvIdx === undefined || objectHasOwnIdx === undefined || symbolType === undefined
+      ? []
+      : [...seededSymbolTags.keys()].flatMap((brand) => [
+          { op: "local.get", index: L_ANY } as Instr,
+          { op: "ref.cast", typeIdx: protoTypeIdx } as Instr,
+          { op: "struct.get", typeIdx: protoTypeIdx, fieldIdx: NP_BRAND } as Instr,
+          { op: "i32.const", value: brand } as Instr,
+          { op: "i32.eq" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 1 },
+              { op: "any.convert_extern" },
+              { op: "ref.test", typeIdx: symbolType },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: 1 },
+                  { op: "any.convert_extern" },
+                  { op: "ref.cast", typeIdx: symbolType },
+                  { op: "struct.get", typeIdx: symbolType, fieldIdx: 0 },
+                  { op: "i32.const", value: 4 }, // Symbol.toStringTag
+                  { op: "i32.eq" },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [
+                      { op: "local.get", index: 0 },
+                      { op: "call", funcIdx: protoOwnRecvIdx },
+                      { op: "local.get", index: 1 },
+                      { op: "call", funcIdx: objectHasOwnIdx },
+                      { op: "return" },
+                    ],
+                  },
+                ],
+              },
+            ],
+          } as Instr,
+        ])),
     // A non-string key (other symbols, boxed number) names no member of a prototype.
     { op: "local.get", index: 1 },
     { op: "any.convert_extern" },

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -38,6 +38,7 @@ import { ensureBuiltinFnMetaType, pushBuiltinFnSingletonValueInstrs } from "./bu
 import { addFuncType, getOrRegisterVecType } from "./registry/types.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { ensureSymbolCarrier } from "./symbol-native.js";
 // (#4491 T9) `constructor` is an own data property of every builtin prototype and
 // is deliberately NOT in `memberCsv`; the companion gets it from the #4200 carrier.
 import { pushCompanionConstructorSeed } from "./builtin-proto-constructor-seed.js";
@@ -148,6 +149,13 @@ export interface NativeProtoBuiltinGlue {
   /** Own member-name CSV for the proto object (string-named members; `@@<id>`
    *  sentinels for well-known-symbol members — see spec §"Symbol cell"). */
   memberCsv: string;
+  /**
+   * Optional own `Symbol.toStringTag` data property. The tag is not part of
+   * `memberCsv` because it is symbol-keyed, but a flowing prototype companion
+   * still needs the identity-stable symbol entry for dynamic reads and
+   * descriptors.
+   */
+  symbolTag?: string;
   /** Which members are accessor getters (`kind:"getter"`) vs data methods
    *  (`kind:"method"`). `@@<id>` symbol members are always `"method"`. */
   memberKind: (member: string) => "getter" | "method";
@@ -449,6 +457,22 @@ export function seededNativeProtoOwnMembersByBrand(ctx: CodegenContext): Readonl
 }
 
 /**
+ * Return the symbol-keyed own tags seeded on native-prototype companions.
+ * `__nproto_hasown` uses the map to recognize `Symbol.toStringTag` before its
+ * historical string-only CSV ladder. The seeder registry is the demand gate:
+ * no materialized/seeded prototype means no extra own-property arm.
+ */
+export function seededNativeProtoSymbolTagsByBrand(ctx: CodegenContext): ReadonlyMap<number, string> {
+  const out = new Map<number, string>();
+  for (const [brand, seederName] of nativeProtoSeederRegistry(ctx)) {
+    if (ctx.funcMap.get(seederName) === undefined) continue;
+    const tag = getNativeProtoBuiltinGlue(ctx, brand)?.symbolTag;
+    if (tag !== undefined) out.set(brand, tag);
+  }
+  return out;
+}
+
+/**
  * §17 attributes for a builtin prototype METHOD, in the
  * `__defineProperty_value` host flag encoding: `{writable: true, enumerable:
  * false, configurable: true}` — value bits `0b101` + all three "specified"
@@ -458,6 +482,9 @@ export function seededNativeProtoOwnMembersByBrand(ctx: CodegenContext): Readonl
  * §17 rule.
  */
 const PROTO_METHOD_DEFINE_FLAGS = 0xbd;
+
+/** §17 attributes for an intrinsic `Symbol.toStringTag` data property. */
+const PROTO_SYMBOL_TAG_DEFINE_FLAGS = 0xbc;
 
 /** §17 accessor attributes in `__defineProperty_accessor`'s flag encoding. */
 const PROTO_ACCESSOR_DEFINE_FLAGS = (1 << 4) | (1 << 5) | (1 << 2);
@@ -609,6 +636,29 @@ export function ensureNativeProtoCompanionSeeder(ctx: CodegenContext, brand: num
     }
     body.push({ op: "drop" }); // the helper returns the target
     installed++;
+  }
+
+  // Well-known symbol tags are ordinary data properties with
+  // { writable:false, enumerable:false, configurable:true }. They are seeded
+  // into the same companion as string members so flowing reads, own checks,
+  // descriptors, writes, and deletes all observe one mutable entry.
+  if (glue.symbolTag !== undefined) {
+    // The symbol carrier is normally requested by the computed-key read before
+    // this seeder runs. Ensure it here as well so an early prototype materializer
+    // cannot silently omit its own tag.
+    ensureSymbolCarrier(ctx);
+    const boxSymbolIdx = ctx.funcMap.get("__box_symbol");
+    const defineIdx = ctx.funcMap.get("__defineProperty_value") ?? defineValueIdx;
+    if (boxSymbolIdx !== undefined && defineIdx !== undefined) {
+      const body = seedFctx.body;
+      body.push({ op: "local.get", index: 0 });
+      body.push({ op: "i32.const", value: 4 }, { op: "call", funcIdx: boxSymbolIdx });
+      addStringConstantGlobal(ctx, glue.symbolTag);
+      body.push(...stringConstantExternrefInstrs(ctx, glue.symbolTag));
+      body.push({ op: "f64.const", value: PROTO_SYMBOL_TAG_DEFINE_FLAGS });
+      body.push({ op: "call", funcIdx: defineIdx }, { op: "drop" });
+      installed++;
+    }
   }
 
   if (installed === 0) {

--- a/tests/issue-4786-weak-collection-tostringtag.test.ts
+++ b/tests/issue-4786-weak-collection-tostringtag.test.ts
@@ -3,6 +3,7 @@
 // #4786 — standalone WeakMap/WeakSet prototypes own their ES2015
 // Symbol.toStringTag data properties.
 
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
@@ -15,6 +16,8 @@ const EXACT_FILES = [
   "built-ins/WeakMap/prototype/Symbol.toStringTag.js",
   "built-ins/WeakSet/prototype/Symbol.toStringTag.js",
 ] as const;
+
+const TEST262_AVAILABLE = existsSync(join("test262", "harness", "assert.js"));
 
 const CONTROL_SOURCE = `
   export function test(): number {
@@ -59,7 +62,7 @@ async function runControl(lane: Lane): Promise<number> {
   return (instance.exports as { test: () => number }).test();
 }
 
-describe("#4786 — WeakMap/WeakSet prototype Symbol.toStringTag", () => {
+describe.skipIf(!TEST262_AVAILABLE)("#4786 — WeakMap/WeakSet prototype Symbol.toStringTag", () => {
   it.each(EXACT_FILES)("passes the exact host Test262 row %s", async (file) => {
     const result = await runTest262File(join("test262/test", file), "issue-4786", 120_000);
     expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");

--- a/tests/issue-4786-weak-collection-tostringtag.test.ts
+++ b/tests/issue-4786-weak-collection-tostringtag.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4786 — standalone WeakMap/WeakSet prototypes own their ES2015
+// Symbol.toStringTag data properties.
+
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+type Lane = "host" | "standalone";
+
+const EXACT_FILES = [
+  "built-ins/WeakMap/prototype/Symbol.toStringTag.js",
+  "built-ins/WeakSet/prototype/Symbol.toStringTag.js",
+] as const;
+
+const CONTROL_SOURCE = `
+  export function test(): number {
+    const weakMapPrototype: any = WeakMap.prototype;
+    const weakSetPrototype: any = WeakSet.prototype;
+    if (weakMapPrototype === weakSetPrototype) return 1;
+    if (weakMapPrototype[Symbol.toStringTag] !== "WeakMap") return 2;
+    if (weakSetPrototype[Symbol.toStringTag] !== "WeakSet") return 3;
+
+    const weakMapDescriptor: any = Object.getOwnPropertyDescriptor(weakMapPrototype, Symbol.toStringTag);
+    const weakSetDescriptor: any = Object.getOwnPropertyDescriptor(weakSetPrototype, Symbol.toStringTag);
+    if (
+      weakMapDescriptor === undefined ||
+      weakMapDescriptor.value !== "WeakMap" ||
+      weakMapDescriptor.writable !== false ||
+      weakMapDescriptor.enumerable !== false ||
+      weakMapDescriptor.configurable !== true
+    ) return 4;
+    if (
+      weakSetDescriptor === undefined ||
+      weakSetDescriptor.value !== "WeakSet" ||
+      weakSetDescriptor.writable !== false ||
+      weakSetDescriptor.enumerable !== false ||
+      weakSetDescriptor.configurable !== true
+    ) return 5;
+    if (!Object.prototype.hasOwnProperty.call(weakMapPrototype, Symbol.toStringTag)) return 6;
+    if (Object.prototype.propertyIsEnumerable.call(weakSetPrototype, Symbol.toStringTag)) return 7;
+    if (weakMapPrototype[Symbol("unrelated")] !== undefined) return 8;
+    return 0;
+  }
+`;
+
+async function runControl(lane: Lane): Promise<number> {
+  const options = lane === "standalone" ? { target: "standalone" as const } : {};
+  const result = await compile(CONTROL_SOURCE, { fileName: "issue-4786-control.ts", ...options });
+  expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("\n")).toBe(true);
+  if (!result.success) return -1;
+
+  const imports = lane === "host" ? buildImports(result.imports, undefined, result.stringPool) : {};
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#4786 — WeakMap/WeakSet prototype Symbol.toStringTag", () => {
+  it.each(EXACT_FILES)("passes the exact host Test262 row %s", async (file) => {
+    const result = await runTest262File(join("test262/test", file), "issue-4786", 120_000);
+    expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+  });
+
+  it.each(EXACT_FILES)("passes the exact standalone Test262 row %s", async (file) => {
+    const result = await runTest262File(join("test262/test", file), "issue-4786", 120_000, "standalone");
+    expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+  });
+
+  it("keeps WeakMap and WeakSet tags identity-stable with exact descriptors in host mode", async () => {
+    await expect(runControl("host")).resolves.toBe(0);
+  });
+
+  it("keeps WeakMap and WeakSet tags identity-stable with exact descriptors in standalone mode", async () => {
+    const result = await compile(CONTROL_SOURCE, { fileName: "issue-4786-control.ts", target: "standalone" });
+    expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("\n")).toBe(true);
+    if (!result.success) return;
+    const module = await WebAssembly.compile(result.binary);
+    expect(WebAssembly.Module.imports(module), "Weak collection tags stay host-free").toEqual([]);
+    await expect(runControl("standalone")).resolves.toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

- seed the specified `Symbol.toStringTag` own properties for standalone `WeakMap.prototype` and `WeakSet.prototype`
- preserve exact descriptor flags, symbol identity, deletion/override behavior, collection methods, and host-free lowering through the native-prototype companion path
- add focused host and standalone coverage for the two exact ES2015 Test262 rows plus descriptor and identity controls
- track the implementation plan, authoritative evidence, and handoff in `plan/issues/4786-es2015-weak-collection-tostringtag.md`

Validation:

- exact baseline: host 2/2, standalone 0/2; final host 2/2 and standalone 2/2
- repeat/determinism probes: host 2/2 and standalone 2/2 with zero nondeterminism
- focused regression: 6/6 passed
- authoritative maintained standalone runner: 2/2 passed with zero failures, compile errors, timeouts, skips, or host imports
- normal pre-push typecheck, lint, formatting, ratchets, numeric-local parity, and issue-integrity gates passed

Tracking: `plan/issues/4786-es2015-weak-collection-tostringtag.md`.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->