### PR TITLE
fix(standalone): normalize array iterator overrides

### DIFF
--- a/plan/issues/1719-array-destructuring-ignores-overridden-array-prototype-iterator.md
+++ b/plan/issues/1719-array-destructuring-ignores-overridden-array-prototype-iterator.md
@@ -1,7 +1,7 @@
 ---
 id: 1719
 title: "Array destructuring ignores overridden Array.prototype[Symbol.iterator] ('items[Symbol.iterator] must be a function', 71 fails)"
-status: ready
+status: in-progress
 created: 2026-05-29
 updated: 2026-08-27
 priority: high
@@ -1282,3 +1282,45 @@ Route unrelated iterator, GC eager-buffering, `#1750`, and array object-value
 representation findings to their existing owners. Land each coherent
 checkpoint as a ready PR only after its own static, focused, and normal hook
 gates pass.
+
+## 2026-08-27 checkpoint 1a — normalize the shared standalone CPR result
+
+The first implementation checkpoint closes only the already-admitted
+non-receiver producer/consumer ABI edge. It extracts one exact AST-only
+predicate for direct `Array.prototype[Symbol.iterator] = value` and
+`Array.prototype.values = value` statements, then changes the shared
+`emitArrayProtoIteratorDrive` producer in standalone mode to reserve and settle
+the canonical `__iterator` helper before retaining shiftable identities. The
+producer re-resolves the override global and CPR driver after settlement,
+drives the captured override once, normalizes the raw generator state exactly
+once, and stores that `$IterRec`-compatible externref for every existing
+`__iterator_next` consumer. No consumer-local workaround and no widened
+`__iterator_next` ABI is introduced.
+
+The non-standalone branch deliberately retains its prior caller-supplied
+override-global index and the direct `reserveProtoIteratorDriver` result. Exact
+artifact comparison pins GC and WASI unchanged for both override keys and pins
+the override-free standalone artifact unchanged. Focused WAT evidence requires
+one `__iterator` call and one authoritative store of its result. When the
+mandatory peephole pass fuses the first `local.set`/`local.get` pair, the exact
+`local.tee` value must feed only the established null guard, after which every
+`__iterator_next` reloads that same local; without fusion, every consumer also
+loads the stored local. Runtime evidence covers declaration, parameter,
+for-of-head, assignment, and #1749 spread for both override keys with zero host
+imports. The shipped-default inliner remains runtime-correct, while the
+structural probe explicitly disables and restores its environment setting.
+Child execution is bounded by timeout and rejects spawn errors, signals, and
+nonzero status.
+
+Checkpoint evidence is 19/19 focused tests across the new regression and the
+existing #1719 S1 controls, TypeScript 7 and 5, targeted formatting/lint, and
+the LOC/function ratchets. Production growth is +103 LOC without a budget
+baseline change. GC, WASI, and override-free standalone binaries/WAT are
+byte-identical to the exact parent; only the intended standalone override
+artifacts change.
+
+This does not close #1719. The bounded receiver-state/capture and re-entrant
+generator proof, guarded multi-source finalizer parity, source-order matrix,
+mutation proof, and test262 denominator remain the next checkpoints. The issue
+therefore stays `in-progress`; #1750 and the broader array object-value model
+remain out of scope.

--- a/src/codegen/array-proto-iterator-override-ast.ts
+++ b/src/codegen/array-proto-iterator-override-ast.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** AST-only recognition for the two already-supported #1719 CPR write targets. */
+import { ts } from "../ts-api.js";
+
+export type ArrayProtoIteratorOverrideKey = "@@iterator" | "values";
+
+/** True when `expression` is exactly the unwrapped builtin `Array.prototype`. */
+function isArrayPrototype(expression: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === "prototype" &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === "Array"
+  );
+}
+
+/**
+ * Resolve an exact CPR assignment target without checker/codegen state.
+ * Transparent receiver wrappers deliberately remain outside this bounded seam
+ * (#1750); the existing conservative whole-source brand scan still sees them.
+ */
+export function arrayProtoIteratorOverrideKeyFromTarget(
+  target: ts.Expression,
+): ArrayProtoIteratorOverrideKey | undefined {
+  if (ts.isPropertyAccessExpression(target)) {
+    return isArrayPrototype(target.expression) && target.name.text === "values" ? "values" : undefined;
+  }
+  if (!ts.isElementAccessExpression(target) || !isArrayPrototype(target.expression)) return undefined;
+  const key = target.argumentExpression;
+  if (
+    ts.isPropertyAccessExpression(key) &&
+    ts.isIdentifier(key.expression) &&
+    key.expression.text === "Symbol" &&
+    key.name.text === "iterator"
+  ) {
+    return "@@iterator";
+  }
+  if (ts.isStringLiteral(key) && key.text === "values") return "values";
+  return undefined;
+}
+
+export function isArrayProtoIteratorAssignTarget(target: ts.Expression): boolean {
+  return arrayProtoIteratorOverrideKeyFromTarget(target) !== undefined;
+}
+
+export interface DirectArrayProtoIteratorAssignment {
+  readonly assignment: ts.BinaryExpression;
+  readonly key: ArrayProtoIteratorOverrideKey;
+  readonly statement: ts.ExpressionStatement;
+  readonly value: ts.Expression;
+}
+
+/**
+ * Recognize exactly `Array.prototype[Symbol.iterator] = value;` or
+ * `Array.prototype.values = value;` as a direct expression statement. This is
+ * the shared future admission seam for the checkpoint-2 receiver exception;
+ * checkpoint 1 only installs/tests the predicate and does not broaden native
+ * generator eligibility.
+ */
+export function directArrayProtoIteratorAssignment(node: ts.Node): DirectArrayProtoIteratorAssignment | undefined {
+  if (!ts.isExpressionStatement(node) || !ts.isBinaryExpression(node.expression)) return undefined;
+  const assignment = node.expression;
+  if (assignment.operatorToken.kind !== ts.SyntaxKind.EqualsToken) return undefined;
+  const key = arrayProtoIteratorOverrideKeyFromTarget(assignment.left);
+  return key === undefined ? undefined : { assignment, key, statement: node, value: assignment.right };
+}

--- a/src/codegen/expressions/proto-override.ts
+++ b/src/codegen/expressions/proto-override.ts
@@ -25,8 +25,16 @@ import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { allocLocal } from "../context/locals.js";
 import { nextModuleGlobalIdx } from "../registry/imports.js";
 import { addFuncType } from "../registry/types.js";
-import { compileArrowAsClosure, resolveComputedKeyExpression } from "../shared.js";
+import {
+  compileArrowAsClosure,
+  ensureLateImport,
+  flushLateImportShifts,
+  resolveComputedKeyExpression,
+} from "../shared.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S2 read chokepoint / S3b stable-regime minting)
+import { arrayProtoIteratorOverrideKeyFromTarget } from "../array-proto-iterator-override-ast.js";
+
+export { isArrayProtoIteratorAssignTarget } from "../array-proto-iterator-override-ast.js";
 
 /** Canonical proto-owner token for `Array.prototype`. */
 const ARRAY_PROTO_TOKEN = "Array";
@@ -37,6 +45,8 @@ const ARRAY_PROTO_TOKEN = "Array";
  * for `.values`), or `undefined` when it is not a recognised iterator override.
  */
 function arrayProtoOverrideKey(ctx: CodegenContext, target: ts.Expression): string | undefined {
+  const exactKey = arrayProtoIteratorOverrideKeyFromTarget(target);
+  if (exactKey !== undefined) return exactKey;
   // Element access: Array.prototype[Symbol.iterator]
   if (ts.isElementAccessExpression(target)) {
     if (!isArrayPrototype(target.expression)) return undefined;
@@ -52,36 +62,6 @@ function arrayProtoOverrideKey(ctx: CodegenContext, target: ts.Expression): stri
     return undefined;
   }
   return undefined;
-}
-
-/**
- * (#1719 CPR) AST-only predicate (no `ctx`) for the module-init statement filter:
- * true when `target` is `Array.prototype[Symbol.iterator]` / `Array.prototype.values`,
- * so the override assignment is kept in `__module_init` instead of being dropped.
- * Matches the LHS shape recognised by `sourceOverridesArrayIterator`.
- */
-export function isArrayProtoIteratorAssignTarget(target: ts.Expression): boolean {
-  if (ts.isElementAccessExpression(target)) {
-    if (!isArrayPrototype(target.expression)) return false;
-    const arg = target.argumentExpression;
-    // `Array.prototype[Symbol.iterator]` — Symbol.iterator is a property access
-    // `Symbol.iterator`; accept it structurally (the precise key resolves later).
-    if (
-      ts.isPropertyAccessExpression(arg) &&
-      ts.isIdentifier(arg.expression) &&
-      arg.expression.text === "Symbol" &&
-      arg.name.text === "iterator"
-    ) {
-      return true;
-    }
-    // `Array.prototype["values"]`
-    if (ts.isStringLiteral(arg) && arg.text === "values") return true;
-    return false;
-  }
-  if (ts.isPropertyAccessExpression(target)) {
-    return isArrayPrototype(target.expression) && target.name.text === "values";
-  }
-  return false;
 }
 
 /** True when `e` is exactly `Array.prototype`. */
@@ -229,12 +209,21 @@ function reserveProtoIteratorDriver(ctx: CodegenContext): number {
 export function fillProtoIteratorDriver(ctx: CodegenContext): void {
   if (!ctx.protoIteratorDriverReserved) return;
   const driverIdx = ctx.funcMap.get(DRIVE_PROTO_ITERATOR);
-  if (driverIdx === undefined) return;
+  if (driverIdx === undefined) {
+    if (ctx.standalone) throw new Error("#1719 standalone CPR driver identity could not be resolved at fill");
+    return;
+  }
   const driverFn = definedFuncAt(ctx, driverIdx);
-  if (!driverFn) return;
+  if (!driverFn) {
+    if (ctx.standalone) throw new Error("#1719 standalone CPR driver body could not be resolved at fill");
+    return;
+  }
 
   const callMethod0 = ctx.funcMap.get("__call_fn_method_0");
   if (callMethod0 === undefined) {
+    if (ctx.standalone) {
+      throw new Error("#1719 standalone CPR driver dispatcher could not be resolved at fill");
+    }
     // No arity-0 closure dispatcher emitted (no qualifying closure) — the driver
     // is unreachable from any live read-drive in that case, but keep a valid
     // body so the module verifies: return undefined (null externref).
@@ -256,31 +245,72 @@ export function fillProtoIteratorDriver(ctx: CodegenContext): void {
  * `arrayIteratorMaybeOverridden && arrayIteratorOverrideGlobalIdx(ctx)!==undefined`.
  *
  * Lowers (§7.4.2 GetIterator + §8.5.2 IteratorBindingInitialization):
- *   1. `extern.convert_any` the vec → the array-as-`this` externref;
- *   2. `global.get` the captured override closure;
- *   3. `call __drive_proto_iterator(array, closure)` → the override-produced
- *      iterator externref, stashed in `iterLocal`.
+ *   1. in standalone, reserve/settle the canonical `__iterator` normalizer;
+ *   2. re-resolve the override global + driver after that settlement;
+ *   3. `extern.convert_any` the vec → the array-as-`this` externref;
+ *   4. `global.get` the captured override closure;
+ *   5. `call __drive_proto_iterator(array, closure)` → the override-produced
+ *      raw iterator externref;
+ *   6. in standalone, call `__iterator(raw)` exactly once and stash the
+ *      resulting `$IterRec` externref in `iterLocal`.
  *
- * Returns the local holding the iterator externref. The caller drains it via
- * `__iterator_next` into the binding elements. Standalone-clean: the drive runs
- * in-Wasm (no host import, no host-Array reflection); only the per-element drain
- * uses the existing `__iterator_next` host import (dual-mode boundary, same as
- * for-of). The brand only fires here at the observation boundary, so internal
- * array iterations inside the override body stay on the typed-vec fast path —
- * no re-entrancy.
+ * Returns the local holding the consumer-ready iterator externref. The caller
+ * drains it via `__iterator_next` into the binding elements. In GC/host this is
+ * the legacy raw iterator contract. In standalone it is the native `$IterRec`
+ * contract established by `__iterator`; both calls remain in-Wasm and add no
+ * host import. WASI deliberately retains its previous bytes in this checkpoint.
+ * The brand only fires here at the observation boundary, so internal array
+ * iterations inside the override body stay on the typed-vec fast path — no
+ * re-entrancy.
  */
 export function emitArrayProtoIteratorDrive(
   ctx: CodegenContext,
   fctx: FunctionContext,
-  overrideGlobalIdx: number,
+  overrideGlobalIdxBeforeSettlement: number,
 ): number {
-  const driverIdx = reserveProtoIteratorDriver(ctx);
+  let iteratorIdx: number | undefined;
+  let overrideGlobalIdx = overrideGlobalIdxBeforeSettlement;
+  let driverIdx: number;
+  if (ctx.standalone) {
+    // #1719 standalone contract: `__iterator_next` accepts only a canonical
+    // `$IterRec`, while the captured generator override returns a raw
+    // `$GenState_*`. Reserve the shared normalizer BEFORE retaining any
+    // shiftable global/function index, then settle the late-import batch and
+    // resolve every identity again from its authoritative registry.
+    ensureLateImport(ctx, "__iterator", [{ kind: "externref" }], [{ kind: "externref" }]);
+    flushLateImportShifts(ctx, fctx);
+    iteratorIdx = ctx.funcMap.get("__iterator");
+    if (iteratorIdx === undefined) {
+      throw new Error("#1719 standalone CPR normalizer '__iterator' could not be resolved");
+    }
+    const settledOverrideGlobalIdx = arrayIteratorOverrideGlobalIdx(ctx);
+    if (settledOverrideGlobalIdx === undefined) {
+      throw new Error("#1719 CPR override global could not be resolved after iterator settlement");
+    }
+    overrideGlobalIdx = settledOverrideGlobalIdx;
+    reserveProtoIteratorDriver(ctx);
+    const settledDriverIdx = ctx.funcMap.get(DRIVE_PROTO_ITERATOR);
+    if (settledDriverIdx === undefined) {
+      throw new Error("#1719 CPR driver could not be resolved after iterator settlement");
+    }
+    driverIdx = settledDriverIdx;
+  } else {
+    // Preserve the established GC/WASI path literally: its caller-resolved
+    // global and the direct reserve result remain authoritative.
+    driverIdx = reserveProtoIteratorDriver(ctx);
+  }
   // Stack: [vec-ref]. Convert to the array-as-`this` externref.
   fctx.body.push({ op: "extern.convert_any" });
   // Push the override closure.
   fctx.body.push({ op: "global.get", index: overrideGlobalIdx });
-  // Drive: __drive_proto_iterator(array, closure) -> iterator externref.
+  // Drive: __drive_proto_iterator(array, closure) -> raw iterator externref.
   fctx.body.push({ op: "call", funcIdx: driverIdx });
+  if (iteratorIdx !== undefined) {
+    // Standalone only: normalize the raw `$GenState_*` exactly once. Every
+    // existing declaration/parameter/for-of-head/assignment/spread consumer
+    // can keep its proven `__iterator_next($IterRec)` ABI unchanged.
+    fctx.body.push({ op: "call", funcIdx: iteratorIdx });
+  }
   const iterLocal = allocLocal(fctx, `__cpr_iter_${fctx.locals.length}`, { kind: "externref" } as ValType);
   fctx.body.push({ op: "local.set", index: iterLocal });
   return iterLocal;

--- a/src/codegen/source-scan-predicates.ts
+++ b/src/codegen/source-scan-predicates.ts
@@ -9,6 +9,7 @@
 // walk-until-found shape and have no dependency on `CodegenContext`.
 
 import { ts, forEachChild } from "../ts-api.js";
+import { directArrayProtoIteratorAssignment } from "./array-proto-iterator-override-ast.js";
 import type { TypeOracle } from "../checker/oracle.js";
 import { isStrictContext } from "./helpers/is-strict-function.js";
 import { TYPED_ARRAY_NAMES } from "./index.js";
@@ -648,6 +649,12 @@ export function sourceOverridesArrayIterator(sourceFile: ts.SourceFile): boolean
   }
   function walk(node: ts.Node): void {
     if (found) return;
+    // Exact direct assignment statements share the same AST-only predicate as
+    // the CPR write arm and checkpoint-2's bounded generator admission seam.
+    if (directArrayProtoIteratorAssignment(node) !== undefined) {
+      found = true;
+      return;
+    }
     // (i) assignment: Array.prototype[Symbol.iterator] = … / Array.prototype.values = …
     if (
       ts.isBinaryExpression(node) &&

--- a/tests/issue-1719-standalone-cpr-normalizer.test.ts
+++ b/tests/issue-1719-standalone-cpr-normalizer.test.ts
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1719 checkpoint 1 — standalone CPR results cross the canonical iterator
+ * normalizer exactly once before any existing consumer calls
+ * `__iterator_next`.
+ */
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import { directArrayProtoIteratorAssignment } from "../src/codegen/array-proto-iterator-override-ast.js";
+import { compile, type CompileResult } from "../src/index.js";
+import { tsRuntime } from "../src/ts-api.js";
+
+const STANDALONE_RUNNER = `
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const module = new WebAssembly.Module(Buffer.concat(chunks));
+  const imports = WebAssembly.Module.imports(module)
+    .map(({ module, name }) => module + "." + name)
+    .sort();
+  const instance = await WebAssembly.instantiate(module, {});
+  const values = {};
+  for (const name of process.env.JS2WASM_1719_EXPORTS.split(",")) {
+    values[name] = instance.exports[name]();
+  }
+  process.stdout.write(JSON.stringify({ imports, values }));
+`;
+
+const EXPECTED_VALUES = {
+  assignment: 708,
+  declaration: 708,
+  forOfHead: 9,
+  parameter: 708,
+  spread: 708,
+} as const;
+const CONSUMER_EXPORTS = Object.keys(EXPECTED_VALUES) as (keyof typeof EXPECTED_VALUES)[];
+
+interface WatFunction {
+  readonly name: string;
+  readonly body: string;
+}
+
+interface WatInstruction {
+  readonly op: "call" | "local.get" | "local.set" | "local.tee";
+  readonly operand: string;
+  readonly target?: string;
+}
+
+function compileFailure(result: CompileResult): string {
+  return result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n");
+}
+
+function parseWatFunctions(wat: string): readonly WatFunction[] {
+  const starts = [...wat.matchAll(/^ {2}\(func \$([^\s(]+)/gm)].map((match) => ({
+    name: match[1]!,
+    index: match.index,
+  }));
+  return starts.map(({ name, index }, position) => ({
+    name,
+    body: wat.slice(index, starts[position + 1]?.index ?? wat.length),
+  }));
+}
+
+function watCallTargets(wat: string, body: string): readonly string[] {
+  const imports = [...wat.matchAll(/^\s*\(import .+ \(func(?: \$([^\s(]+))?/gm)].map(
+    (match) => match[1] ?? "<anonymous-import>",
+  );
+  const definitions = [...wat.matchAll(/^\s*\(func \$([^\s(]+)/gm)].map((match) => match[1]!);
+  const names = [...imports, ...definitions];
+  return [...body.matchAll(/\b(?:return_)?call (\d+)/g)].map((match) => {
+    const target = names[Number(match[1])] ?? "<missing>";
+    return target.endsWith("_import") ? target.slice(0, -"_import".length) : target;
+  });
+}
+
+function watInstructions(wat: string, body: string): readonly WatInstruction[] {
+  const imports = [...wat.matchAll(/^\s*\(import .+ \(func(?: \$([^\s(]+))?/gm)].map(
+    (match) => match[1] ?? "<anonymous-import>",
+  );
+  const definitions = [...wat.matchAll(/^\s*\(func \$([^\s(]+)/gm)].map((match) => match[1]!);
+  const names = [...imports, ...definitions];
+  return [...body.matchAll(/\b((?:return_)?call|local\.(?:get|set|tee)) ([^\s()]+)/g)].map((match) => {
+    const op = match[1]!.endsWith("call") ? "call" : (match[1] as WatInstruction["op"]);
+    const operand = match[2]!;
+    const target = op === "call" ? (names[Number(operand)] ?? "<missing>").replace(/_import$/, "") : undefined;
+    return { op, operand, target };
+  });
+}
+
+function expectNormalizedCprPath(result: CompileResult, functionName: string): void {
+  const functions = parseWatFunctions(result.wat).filter(({ name }) => name === functionName);
+  expect(functions, `unique WAT function $${functionName}`).toHaveLength(1);
+  const calls = watCallTargets(result.wat, functions[0]!.body);
+  const drive = calls.indexOf("__drive_proto_iterator");
+  expect(drive, `${functionName}: CPR driver call in ${JSON.stringify(calls)}`).toBeGreaterThanOrEqual(0);
+  expect(calls[drive + 1], `${functionName}: raw result normalized immediately`).toBe("__iterator");
+  expect(calls.indexOf("__iterator_next", drive + 2), `${functionName}: normalized result consumed`).toBeGreaterThan(
+    drive + 1,
+  );
+  expect(calls.filter((name) => name === "__drive_proto_iterator")).toHaveLength(1);
+
+  const instructions = watInstructions(result.wat, functions[0]!.body);
+  const iteratorCalls = instructions
+    .map((instruction, index) => ({ index, instruction }))
+    .filter(({ instruction }) => instruction.op === "call" && instruction.target === "__iterator");
+  expect(iteratorCalls, `${functionName}: exactly one canonical normalization`).toHaveLength(1);
+  const iteratorCallIndex = iteratorCalls[0]!.index;
+  const iteratorStore = instructions[iteratorCallIndex + 1];
+  expect(["local.set", "local.tee"], `${functionName}: normalized result stored immediately`).toContain(
+    iteratorStore?.op,
+  );
+  const iteratorLocal = iteratorStore!.operand;
+  expect(
+    instructions.filter(
+      (instruction) =>
+        (instruction.op === "local.set" || instruction.op === "local.tee") && instruction.operand === iteratorLocal,
+    ),
+    `${functionName}: one authoritative normalized iterator local`,
+  ).toHaveLength(1);
+  const nextCallIndices = instructions.flatMap((instruction, index) =>
+    instruction.op === "call" && instruction.target === "__iterator_next" ? [index] : [],
+  );
+  expect(nextCallIndices.length, `${functionName}: direct iterator consumers`).toBeGreaterThan(0);
+  const firstNextCallIndex = nextCallIndices[0]!;
+  if (iteratorStore!.op === "local.tee") {
+    const watLines = functions[0]!.body
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    const iteratorCallLine = watLines.indexOf(`call ${iteratorCalls[0]!.instruction.operand}`);
+    const firstNextOperand = instructions[firstNextCallIndex]!.operand;
+    const firstNextLine = watLines.indexOf(`call ${firstNextOperand}`, iteratorCallLine + 1);
+    expect(
+      watLines.slice(iteratorCallLine + 1, firstNextLine + 1),
+      `${functionName}: tee value consumed only by the established null guard before first __iterator_next`,
+    ).toEqual([
+      `local.tee ${iteratorLocal}`,
+      "ref.is_null",
+      "i32.eqz",
+      "(if",
+      "(then",
+      `local.get ${iteratorLocal}`,
+      `call ${firstNextOperand}`,
+    ]);
+  }
+  for (const nextCallIndex of nextCallIndices) {
+    expect(nextCallIndex, `${functionName}: iterator consumer after normalization`).toBeGreaterThan(iteratorCallIndex);
+    expect(
+      instructions[nextCallIndex - 1],
+      `${functionName}: exact normalized local feeds every __iterator_next`,
+    ).toMatchObject({
+      op: "local.get",
+      operand: iteratorLocal,
+    });
+  }
+}
+
+function sourceFor(overrideTarget: "symbol" | "values"): string {
+  const target = overrideTarget === "symbol" ? "Array.prototype[Symbol.iterator]" : "Array.prototype.values";
+  return `
+    ${target} = function* () { yield 7; yield 8; yield 9; };
+
+    export function declaration(): number {
+      const [a, b] = [1, 2];
+      return a * 100 + b;
+    }
+
+    function take([a, b]: number[]): number { return a * 100 + b; }
+    export function parameter(): number { return take([1, 2]); }
+
+    export function forOfHead(): number {
+      let result = 0;
+      for (var [a, b, c] of [[1, 2, 3]]) result = c;
+      return result;
+    }
+
+    export function assignment(): number {
+      let a = 0;
+      let b = 0;
+      [a, b] = [1, 2];
+      return a * 100 + b;
+    }
+
+    export function spread(): number {
+      const result = [...[1, 2]];
+      return result[0] * 100 + result[1];
+    }
+  `;
+}
+
+async function compileStandalone(source: string, disableInlining = false): Promise<CompileResult> {
+  const previousInline = process.env.JS2WASM_IR_INLINE;
+  if (disableInlining) process.env.JS2WASM_IR_INLINE = "0";
+  let result: CompileResult;
+  try {
+    result = await compile(source, {
+      emitWat: true,
+      experimentalIR: false,
+      fileName: "issue-1719-standalone-cpr-normalizer.ts",
+      hostBridge: "off",
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+    });
+  } finally {
+    if (disableInlining) {
+      if (previousInline === undefined) Reflect.deleteProperty(process.env, "JS2WASM_IR_INLINE");
+      else process.env.JS2WASM_IR_INLINE = previousInline;
+    }
+  }
+  expect(result.success, compileFailure(result)).toBe(true);
+  expect(result.imports, "standalone compiler import descriptors").toEqual([]);
+  expect(result.hostImportSummary?.total ?? 0, "standalone host-import inventory").toBe(0);
+  return result;
+}
+
+function runStandalone(result: CompileResult): {
+  readonly imports: readonly string[];
+  readonly values: Readonly<Record<string, number>>;
+} {
+  const child = spawnSync(
+    process.execPath,
+    ["--experimental-wasm-exnref", "--input-type=module", "--eval", STANDALONE_RUNNER],
+    {
+      input: result.binary,
+      encoding: "utf8",
+      env: { ...process.env, JS2WASM_1719_EXPORTS: CONSUMER_EXPORTS.join(",") },
+      maxBuffer: 8 * 1024 * 1024,
+      timeout: 30_000,
+    },
+  );
+  expect(child.error, child.error?.message).toBeUndefined();
+  expect(child.signal, child.stderr).toBeNull();
+  expect(child.status, child.stderr || child.error?.message).toBe(0);
+  return JSON.parse(child.stdout) as {
+    readonly imports: readonly string[];
+    readonly values: Readonly<Record<string, number>>;
+  };
+}
+
+describe("#1719 shared direct CPR assignment predicate", () => {
+  function direct(source: string) {
+    const file = tsRuntime.createSourceFile("t.ts", source, tsRuntime.ScriptTarget.Latest, true);
+    return directArrayProtoIteratorAssignment(file.statements[0]!);
+  }
+
+  it("recognizes only the exact direct Symbol.iterator and values assignments", () => {
+    expect(direct(`Array.prototype[Symbol.iterator] = function* () {};`)?.key).toBe("@@iterator");
+    expect(direct(`Array.prototype.values = function* () {};`)?.key).toBe("values");
+    expect(direct(`Array.prototype["values"] = function* () {};`)?.key).toBe("values");
+  });
+
+  it("rejects wrapped, foreign, nested-expression, and non-assignment shapes", () => {
+    expect(direct(`(Array.prototype as any)[Symbol.iterator] = function* () {};`)).toBeUndefined();
+    expect(direct(`String.prototype[Symbol.iterator] = function* () {};`)).toBeUndefined();
+    expect(direct(`consume(Array.prototype.values = function* () {});`)).toBeUndefined();
+    expect(direct(`Array.prototype.values;`)).toBeUndefined();
+  });
+});
+
+describe.each(["symbol", "values"] as const)("#1719 standalone CPR normalizer — %s", (overrideTarget) => {
+  it("drives all five consumers through drive -> __iterator -> __iterator_next", async () => {
+    // #4157's shipped inliner folds the three-instruction driver into
+    // `__call_fn_method_0`. Pin it off only for this shape assertion so the
+    // producer/normalizer/consumer edge remains directly observable.
+    const result = await compileStandalone(sourceFor(overrideTarget), true);
+    const probe = runStandalone(result);
+    expect(probe.imports).toEqual([]);
+    for (const name of CONSUMER_EXPORTS) expect(probe.values[name], name).toBe(EXPECTED_VALUES[name]);
+
+    for (const functionName of ["declaration", "take", "forOfHead", "assignment", "spread"]) {
+      expectNormalizedCprPath(result, functionName);
+    }
+  });
+});
+
+it("keeps the shipped default inliner runtime-correct and host-free", async () => {
+  const previousInline = process.env.JS2WASM_IR_INLINE;
+  Reflect.deleteProperty(process.env, "JS2WASM_IR_INLINE");
+  let result: CompileResult;
+  try {
+    result = await compileStandalone(sourceFor("symbol"));
+  } finally {
+    if (previousInline !== undefined) process.env.JS2WASM_IR_INLINE = previousInline;
+  }
+  const probe = runStandalone(result);
+  expect(probe.imports).toEqual([]);
+  for (const name of CONSUMER_EXPORTS) expect(probe.values[name], name).toBe(EXPECTED_VALUES[name]);
+});
+
+it("keeps an override-free standalone module free of all CPR machinery", async () => {
+  const result = await compileStandalone(`
+    export function run(): number {
+      const [a, b] = [1, 2];
+      const spread = [...[3, 4]];
+      return a + b + spread[0] + spread[1];
+    }
+  `);
+  expect(result.wat).not.toContain("$__drive_proto_iterator");
+  expect(result.wat).not.toContain("$__array_proto_iterator_override");
+});


### PR DESCRIPTION
## Summary
- normalize the shared standalone CPR generator result through canonical `__iterator` before every existing `__iterator_next` consumer
- extract an exact AST-only predicate for direct `Array.prototype[Symbol.iterator]` and `.values` assignments
- keep GC, WASI, and override-free standalone artifacts byte-identical; receiver state and multi-source finalization remain later #1719 checkpoints

## Validation
- independent read-only review: approved
- focused #1719 normalizer + S1: 19/19
- current-main parent/F2 artifact matrix: GC and WASI clear/Symbol/values exact; standalone clear exact; only intended standalone override artifacts move by 12 bytes, with zero imports
- TypeScript 7 and 5; IR layering; vacuity shapes; Prettier/Biome
- LOC/function ratchets (net +103 production LOC, no baseline change)
- normal pre-commit and pre-push hooks, unskipped

This is checkpoint 1a and keeps #1719 in progress.

Refs #1719