### PR TITLE
fix(ir): authenticate direct-call owners exactly

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -3510,3 +3510,14 @@ baseline changes. F2 remains `in-progress` work under #3522. F3 dormant
 field-call evidence and F4 bounded admission remain separate post-merge
 checkpoints and inherit the same independent-review, strict-load,
 signed-commit, and unskipped-hook gates.
+
+The post-push kind-neutrality gate found one evidence location made stale by
+the added `integration.ts` lines. The `forof.string` row keeps its existing
+`js` verdict, `dialect` placement, rationale, declaration, and two-entry
+evidence set; only the integration evidence location moves from line 5109 to
+line 5146. The relocked
+baseline SHA-256 is
+`42686323c13fcb8539e82b179efd89a4d2feba10edefc7d4772ca65130a91a42`.
+`check:ir-kind-neutrality` again reports 85 kinds: 55 neutral, 27 JS-dialect,
+and 3 unresolved, with 58 core placements and 27 dialect placements. No row,
+verdict, placement, or phase-two move was added, removed, or widened.

--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -4,9 +4,9 @@ title: "IR-only R3: compile-once classes, members, and closures"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-26
-assignee: ttraenkler/fable-lead
-branch: claude/ir-3522-static-nested-family
+updated: 2026-08-27
+assignee: ttraenkler/codex
+branch: codex/3522-f2-owner-aware-direct-calls
 priority: critical
 horizon: xl
 complexity: XL
@@ -3138,6 +3138,9 @@ Limit production changes to:
 - **src/ir/integration.ts**;
 - **src/codegen/index.ts**, to thread the already-built identity resolver to
   every identity-aware projection/reconciliation call; and
+- **src/codegen/ir-prepared-free-functions.ts**, to merge the full-selection
+  and remaining-selection authenticated plan maps only through exact equality;
+  and
 - **src/ir/imported-functions.ts** only if the existing resolver interface
   needs a narrowly shared certification method rather than a new resolver.
 
@@ -3190,6 +3193,14 @@ explicit-constructor, stale AST, copied SourceFile, wrong owner, same-spelled
 foreign target, binding, name, and signature mutations. **from-ast.ts** needs
 no change: it already consumes an exact AST-site plan and verifies its owner
 before emitting the symbolic target.
+
+The implicit-constructor control in F2 is deliberately negative: with the
+field-call gate closed, any natural call owned by an implicit constructor would
+have to occur in an instance-field initializer, and that exact shape remains
+unbounded until F3/F4. Its support/nonterminal owner must therefore reject the
+identity-aware collector. Do not fabricate a terminal implicit constructor or
+admit a call-bearing field to manufacture a positive F2 row. F4 owns the first
+natural positive implicit-constructor field-call control.
 
 #### F3. Retain dormant source-qualified field-call evidence
 
@@ -3441,3 +3452,61 @@ Every heavy command and every commit/push boundary requires a fresh finite,
 non-negative one-minute load strictly below **logical cores - 2**. Each signed
 checkpoint receives independent read-only review before push and is shepherded
 through actual merge before its successor is published.
+
+### 2026-08-27 F2 implementation checkpoint — exact-owner direct-call plans
+
+F2 is implemented as the behavior-neutral authority split specified above.
+`collectIrDirectCallLoweringPlansByIdentity` is a distinct collector; the
+context-free collector used by resolver-less linear and stdlib-selfhost routes
+retains its prior contract. The identity-aware path requires the exact source
+and planning owner for each AST call, active self-owned owner and target
+terminals, and the one source resolver's
+`resolveTopLevelFunctionValueTarget` certification. Declaration object,
+source-qualified unit, callable binding, compatibility name, and canonical
+closure signature are revalidated before one retained plan can be projected or
+reconciled. Copied roots/sites, lexical ancestry drift, same-spelled foreign
+targets, stale owners, bindings, names, signatures, or source identities fail
+closed.
+
+The one resolver is threaded through single- and multi-source overlay planning
+and integration reconciliation. Source-unit targets remain disjoint from the
+non-unit runtime/intrinsic compatibility projection. A duplicate producer may
+only reuse an identical authenticated row; `Map.set` never resolves an owner
+collision, including when full-selection and remaining-selection plan maps are
+combined. The existing field-call selector gate stays closed, so this slice
+does not admit a class field, change a claim/outcome, or alter emitted behavior.
+
+Focused evidence covers outer-root, nested-function, implicit/explicit
+constructor, admitted nested-method, copied AST/source, ancestry, wrong-owner,
+foreign-target, binding/name/signature, and collision controls. The #3522
+GC/standalone matrix is 7/7 and the new #3520 collector/collision/mutation
+controls are 4/4. TypeScript 7 and 5, formatting, IR layering, fallback
+controls, and the function ratchet pass. The full adjacent #3520 suite is
+13/13. Its host-void-callback fixture now supplies the exact admitted
+`HTMLElement_addEventListener` operation certificate, so missing/stale owner
+mutations reach the intended callback-plan invariant instead of stopping at the
+earlier generic capability guard. With only that test-fixture correction, exact
+parent `5bdc209f0de611808a701d9b08a0b971d689f12f` passes the original denominator
+9/9; F2 passes all 13. Against that same parent, F2 is
+byte-identical within every measured target/option: GC direct is 974 bytes,
+SHA-256 `b9358ef967232d9248c5e14b660fba012397e344f45d108bc926329516300d77`;
+GC experimental is 981 bytes,
+`b18876938bb429a377c5abdb3a476cf3a6c554fd8ca3d9dec64c68861d70259e`;
+standalone direct is 49,113 bytes,
+`e1a48a77e3c902f5097cc4329c7787f70dc99af68621d2ac418da3c9e34229ee`;
+and standalone experimental is 49,120 bytes,
+`33b6777e092efee30c6f20e2266aba9125ed0efcd75de15831a7153dd0d02041`.
+The pre-existing 7-byte direct-versus-experimental difference is unchanged and
+is not attributed to F2.
+
+Production growth is confined to the five files authorized by F2: +152 in
+`src/ir/ast-lowering-plans.ts`, +29 in
+`src/codegen/ir-overlay-identity.ts`, +25 in
+`src/codegen/ir-prepared-free-functions.ts`, +30 in
+`src/codegen/index.ts`, and +37 in `src/ir/integration.ts`. The existing
+issue-scoped LOC allowances for `index.ts` and `integration.ts` cover those
+measured changes when this plan is included in the checkpoint; no budget
+baseline changes. F2 remains `in-progress` work under #3522. F3 dormant
+field-call evidence and F4 bounded admission remain separate post-merge
+checkpoints and inherit the same independent-review, strict-load,
+signed-commit, and unskipped-hook gates.

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -284,7 +284,7 @@
       "where": "dialect",
       "declaredAt": "src/ir/dialect/js.ts:713",
       "why": "This is `%String.prototype%[@@iterator]` inlined as a statement form. The per-iteration element is a CODE POINT rendered as a one-element string — the intent field resolves to `__str_charAt_cp`, deliberately not the code-unit `string.char_at` next door. Its general sibling `forof.iter` is already in the dialect, so keeping the string specialization in core splits one protocol across the boundary.",
-      "evidence": ["src/ir/dialect/js.ts:722", "src/ir/integration.ts:5109"]
+      "evidence": ["src/ir/dialect/js.ts:722", "src/ir/integration.ts:5146"]
     },
     "forof.vec": {
       "verdict": "neutral",

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2301,6 +2301,8 @@ export interface IrOverlayPlan {
   /** Exact Promise-delay plans, keyed separately by each owned AST call. */
   readonly promiseDelays: IrPromiseDelayLoweringPlans;
   readonly suspendingAsyncUnitIds: ReadonlySet<IrUnitId>;
+  /** One checker-backed resolver shared by source direct-call projection and reconciliation. */
+  readonly directCallResolver: irOverlayIdentity.IrIdentityImportedFunctionResolver;
   readonly importedFunctionResolver?: irOverlayIdentity.IrIdentityImportedFunctionResolver;
   /** Exact late #3521 fnctor parameter projection, when fully prepared. */
   readonly fnctorParameterPreselection?: IrFnctorParameterPreselectionPlan;
@@ -2608,23 +2610,46 @@ function resolveIrOverrideParamType(
   return resolvePositionType(effectiveIrParamTypeNode(parameter), mapped, ctx, classShapes);
 }
 
+function makeIrResolver(
+  checker: ts.TypeChecker,
+  identityContext: IrPlanningIdentityContext,
+  existing?: irOverlayIdentity.IrIdentityImportedFunctionResolver,
+): irOverlayIdentity.IrIdentityImportedFunctionResolver {
+  return existing ?? irOverlayIdentity.makeIrOverlayImportedResolver(checker, identityContext);
+}
+
+interface IrPlanningAuthority {
+  readonly identityContext: IrPlanningIdentityContext;
+  readonly resolver: irOverlayIdentity.IrIdentityImportedFunctionResolver;
+}
+
+function makeIrPlanningAuthority(
+  checker: ts.TypeChecker,
+  identityContext: IrPlanningIdentityContext | undefined,
+  enabled: boolean | undefined,
+): IrPlanningAuthority | undefined {
+  return enabled && identityContext
+    ? { identityContext, resolver: makeIrResolver(checker, identityContext) }
+    : undefined;
+}
+
+interface IrOverlayPlanningOptions {
+  readonly resolveModuleBindings?: boolean;
+  readonly resolver?: irOverlayIdentity.IrIdentityImportedFunctionResolver;
+  readonly importedFunctions?: irOverlayIdentity.IrIdentityImportedFunctionResolver;
+  /** Transaction B2 is single-source only; Transaction C owns graph composition. */
+  readonly enableCountedStringAppendProof?: boolean;
+  /** Exact post-legacy route snapshot for dormant #3521 L1 evidence. */
+  readonly fnctorArgumentProjectionRoute?: IrFnctorArgumentProjectionRoute;
+  /** C2 supplies the already-certified multi-source string loop only. */
+  readonly countedStringAppendProof?: { readonly loop: ts.ForStatement; readonly plan: IrCountedStringAppendPlan };
+}
+
 function planIrOverlay(
   ctx: CodegenContext,
   ast: TypedAST,
   identityContext: IrPlanningIdentityContext,
-  options: {
-    readonly resolveModuleBindings?: boolean;
-    readonly importedFunctions?: irOverlayIdentity.IrIdentityImportedFunctionResolver;
-    /** Transaction B2 is single-source only; Transaction C owns graph composition. */
-    readonly enableCountedStringAppendProof?: boolean;
-    /** Exact post-legacy route snapshot for dormant #3521 L1 evidence. */
-    readonly fnctorArgumentProjectionRoute?: IrFnctorArgumentProjectionRoute;
-    /** C2 supplies the already-certified multi-source string loop only. */
-    readonly countedStringAppendProof?: {
-      readonly loop: ts.ForStatement;
-      readonly plan: IrCountedStringAppendPlan;
-    };
-  } = {},
+  options: IrOverlayPlanningOptions = {},
 ): IrOverlayPlan {
   const identityImportedFunctions = options.importedFunctions;
   const legacyImportedFunctions = irOverlayIdentity.projectIrOverlayImportedResolver(identityImportedFunctions);
@@ -3235,6 +3260,7 @@ function planIrOverlay(
     ...calendarLoweringPlans,
     promiseDelays,
     suspendingAsyncUnitIds: collectPreparedIrAsyncOwners(ctx, identityPlan, safeSelection.funcs),
+    directCallResolver: makeIrResolver(ast.checker, identityContext, options.resolver ?? options.importedFunctions),
     ...(options.importedFunctions ? { importedFunctionResolver: options.importedFunctions } : {}),
     ...(fnctorParameterPreselection ? { fnctorParameterPreselection } : {}),
     ...(fnctorParameterPreselection?.nativeStringBoundaries
@@ -3655,6 +3681,7 @@ function planMultiIrOverlaySource(
   multiAst: MultiTypedAST,
   sourceFile: ts.SourceFile,
   identityContext: IrPlanningIdentityContext,
+  identityResolver: irOverlayIdentity.IrIdentityImportedFunctionResolver,
   hostImportedFunctions: irOverlayIdentity.IrIdentityImportedFunctionResolver | undefined,
   fnctorArgumentProjectionRoute?: IrFnctorArgumentProjectionRoute,
   countedStringAppendProof?: { readonly loop: ts.ForStatement; readonly plan: IrCountedStringAppendPlan },
@@ -3668,6 +3695,7 @@ function planMultiIrOverlaySource(
   };
   return planIrOverlay(ctx, sourceAst, identityContext, {
     resolveModuleBindings: false,
+    resolver: identityResolver,
     ...(hostImportedFunctions ? { importedFunctions: hostImportedFunctions } : {}),
     ...(fnctorArgumentProjectionRoute ? { fnctorArgumentProjectionRoute } : {}),
     ...(countedStringAppendProof ? { countedStringAppendProof } : {}),
@@ -3698,12 +3726,13 @@ function compileMultiIrOverlaySource(
   sourceFile: ts.SourceFile,
   identityContext: IrPlanningIdentityContext,
   safety: MultiIrGraphSafety,
+  identityResolver: irOverlayIdentity.IrIdentityImportedFunctionResolver,
   hostImportedFunctions: irOverlayIdentity.IrIdentityImportedFunctionResolver | undefined,
   early?: EarlyMultiPreparedScalarLeafState<IrOverlayPlan>,
 ): MultiPreparedProgramOverlayResult {
   const plan =
     early?.plan ??
-    planMultiIrOverlaySource(ctx, multiAst, sourceFile, identityContext, hostImportedFunctions, {
+    planMultiIrOverlaySource(ctx, multiAst, sourceFile, identityContext, identityResolver, hostImportedFunctions, {
       experimentalIR: true,
       postLegacyPhysicalReservation: true,
       irFirstEnvironment: process.env.JS2WASM_IR_FIRST,
@@ -8916,9 +8945,10 @@ function planMultiPreparedProgramRoutes(
   multiAst: MultiTypedAST,
   options: CodegenOptions | undefined,
   ctx: CodegenContext,
-  identityContext: IrPlanningIdentityContext | undefined,
+  authority: IrPlanningAuthority | undefined,
 ): void {
-  if (!owner || !identityContext) return;
+  if (!owner || !authority) return;
+  const { identityContext, resolver } = authority;
   planMultiPreparedProgramEarlyRoutes({
     owner,
     multiAst,
@@ -8932,6 +8962,7 @@ function planMultiPreparedProgramRoutes(
         multiAst,
         sourceFile,
         identityContext,
+        resolver,
         undefined,
         undefined,
         stringShape ? { loop: stringShape.loop, plan: stringShape.plan } : undefined,
@@ -8967,15 +8998,13 @@ function compileMultiPreparedProgramOverlays(
   multiAst: MultiTypedAST,
   options: CodegenOptions | undefined,
   ctx: CodegenContext,
-  identityContext: IrPlanningIdentityContext | undefined,
+  authority: IrPlanningAuthority | undefined,
 ): void {
   // Multi-source targets can have legacy callers, so fast-mode's i32 `number`
   // ABI cannot safely be replaced by the current f64 IR ABI.
-  if (!options?.experimentalIR || ctx.fast) return;
-  const hostImportedFunctions =
-    ctx.standalone || ctx.wasi || ctx.strictNoHostImports
-      ? undefined
-      : irOverlayIdentity.makeIrOverlayImportedResolver(multiAst.checker, identityContext!);
+  if (!options?.experimentalIR || ctx.fast || !authority) return;
+  const { identityContext, resolver } = authority;
+  const hostImportedFunctions = ctx.standalone || ctx.wasi || ctx.strictNoHostImports ? undefined : resolver;
   const safety = buildMultiIrGraphSafety(ctx, multiAst.sourceFiles, multiAst.checker);
   profilePhase("ir-overlay", () => {
     for (const sourceFile of multiAst.sourceFiles) {
@@ -8987,6 +9016,7 @@ function compileMultiPreparedProgramOverlays(
             sourceFile,
             identityContext!,
             safety,
+            resolver,
             hostImportedFunctions,
             early,
           );
@@ -9016,6 +9046,7 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
     ? new ProgramAbiSession(irPlanningIdentityContext.inventory, mod)
     : undefined;
   const ctx = createCodegenContext(mod, multiAst.checker, options, programAbiSession, irPlanningIdentityContext);
+  const irAuthority = makeIrPlanningAuthority(multiAst.checker, irPlanningIdentityContext, options?.experimentalIR);
   const multiPreparedProgram = initializeMultiPreparedProgram(ctx, multiAst, options, explicitlyDisabledEnv);
   const standaloneCalendar = planMultiCalendar(ctx, multiAst.checker, multiAst.sourceFiles, multiAst.entryFile);
   ctx.runtimeEvalBoundaryPlan = buildIrRuntimeEvalBoundaryPlan(multiAst.sourceFiles, ctx.oracle);
@@ -9411,7 +9442,7 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
 
     standaloneCalendar.reserveDirectCallbacks(irPlanningIdentityContext);
 
-    planMultiPreparedProgramRoutes(multiPreparedProgram, multiAst, options, ctx, irPlanningIdentityContext);
+    planMultiPreparedProgramRoutes(multiPreparedProgram, multiAst, options, ctx, irAuthority);
 
     // Phase 3: Compile all function bodies.
     //
@@ -9475,10 +9506,9 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
     frameStage(ctx, "finalizeMethodTrampolines");
     profileCount("functions-after-bodies", ctx.mod.functions.length);
 
-    compileMultiPreparedProgramOverlays(multiPreparedProgram, multiAst, options, ctx, irPlanningIdentityContext);
+    compileMultiPreparedProgramOverlays(multiPreparedProgram, multiAst, options, ctx, irAuthority);
 
     multiPreparedProgram?.sealRoutesComplete();
-
     // Fixup pass: reconcile struct.new argument counts with actual struct field counts.
     profilePhase("fixup-struct-new-args", () => fixupStructNewArgCounts(ctx));
     frameStage(ctx, "fixupStructNewArgCounts");

--- a/src/codegen/ir-overlay-identity.ts
+++ b/src/codegen/ir-overlay-identity.ts
@@ -2,7 +2,8 @@
 
 import { ts } from "../ts-api.js";
 import {
-  collectIrDirectCallLoweringPlans,
+  collectIrDirectCallLoweringPlansByIdentity,
+  irDirectCallLoweringPlanEquals,
   type IrDirectCallTarget,
   type IrIntegrationLoweringPlans,
 } from "../ir/ast-lowering-plans.js";
@@ -298,6 +299,7 @@ export function projectIrIntegrationLoweringPlans(
   plan: {
     readonly identityPlan: IrOverlayIdentityPlan;
     readonly overrideMapByUnitId: IrIntegrationLoweringPlans["signaturesByUnitId"];
+    readonly directCallResolver?: IrIdentityImportedFunctionResolver;
     readonly directCalls?: IrIntegrationLoweringPlans["directCalls"];
     readonly classShapesById?: IrIntegrationLoweringPlans["classShapesById"];
     readonly postWasmStartTdzSafeBindingsByOwnerUnitId?: IrIntegrationLoweringPlans["postWasmStartTdzSafeBindingsByOwnerUnitId"];
@@ -353,16 +355,41 @@ export function projectIrIntegrationLoweringPlans(
     });
   }
   const directCalls = new Map(plan.directCalls ?? []);
+  const retainDirectCall = (
+    call: ts.CallExpression,
+    directCall: import("../ir/ast-lowering-plans.js").IrDirectCallLoweringPlan,
+  ): void => {
+    const existing = directCalls.get(call);
+    if (existing && !irDirectCallLoweringPlanEquals(existing, directCall)) {
+      mismatch(`direct-call plan at ${call.getSourceFile().fileName}:${call.pos} has conflicting producers`);
+    }
+    if (!existing) directCalls.set(call, directCall);
+  };
   for (const { unitId } of ownerProjection.entries) {
     const declaration = plan.identityPlan.identityContext.declarationByUnitId.get(unitId);
     if (!declaration) continue;
-    for (const [call, directCall] of collectIrDirectCallLoweringPlans(declaration, unitId, directCallTargets)) {
+    if (!plan.directCallResolver) continue;
+    let collected: ReadonlyMap<ts.CallExpression, import("../ir/ast-lowering-plans.js").IrDirectCallLoweringPlan>;
+    try {
+      collected = collectIrDirectCallLoweringPlansByIdentity(declaration, unitId, {
+        identityContext: plan.identityPlan.identityContext,
+        resolver: plan.directCallResolver,
+        activeOwnerUnitIds,
+        signaturesByUnitId: callableSignaturesByUnitId,
+        targetsByLegacyName: directCallTargets,
+      });
+    } catch (error) {
+      mismatch(
+        `direct-call identity for ${unitId} disagrees with the retained source projection: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    for (const [call, directCall] of collected) {
       // The projected callable ABI is authoritative for every exact active
       // source edge. In particular, a prepared suspending async target keeps
       // its numeric fulfillment type in `signaturesByUnitId`, while calls to
       // its source slot observe the Promise-returning externref ABI. A stale
       // pre-projection plan would otherwise unbox that Promise as a number.
-      directCalls.set(call, directCall);
+      retainDirectCall(call, directCall);
     }
   }
   const countedStringAppends = new Map<
@@ -406,6 +433,7 @@ export function projectIrIntegrationLoweringPlans(
   }
   return {
     identityContext: plan.identityPlan.identityContext,
+    ...(plan.directCallResolver ? { directCallResolver: plan.directCallResolver } : {}),
     ...(fnctorParameterPreselection ? { fnctorParameterPreselection } : {}),
     ...(fnctorNativeStringBoundaries && fnctorNativeStringBoundaries.size > 0 ? { fnctorNativeStringBoundaries } : {}),
     ...(fnctorParameterPreselection && plan.fnctorParameterPreselectionIsCurrent
@@ -416,6 +444,7 @@ export function projectIrIntegrationLoweringPlans(
     ownerUnitIdByLegacyName,
     directCalls,
     signaturesByUnitId,
+    directCallSignaturesByUnitId: callableSignaturesByUnitId,
     importedCalls: plan.importedCalls,
     topLevelFunctionValues: plan.topLevelFunctionValues,
     hostVoidCallbacks: plan.hostVoidCallbacks,

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -1,6 +1,11 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import type { IrHostVoidCallbackLoweringPlan, IrIntegrationLoweringPlans } from "../ir/ast-lowering-plans.js";
+import {
+  irDirectCallLoweringPlanEquals,
+  type IrDirectCallLoweringPlan,
+  type IrHostVoidCallbackLoweringPlan,
+  type IrIntegrationLoweringPlans,
+} from "../ir/ast-lowering-plans.js";
 import { requireValidPreparedCountedStringAppendReceipt } from "../ir/counted-string-append-provenance.js";
 import { isBoundedPreparedAccessorClass, isBoundedPreparedNestedOrdinaryClass } from "../ir/class-accessor-safety.js";
 import { compilerTimerShimTerminalUnitIds } from "../ir/compiler-timer-shim-preparation.js";
@@ -1816,10 +1821,10 @@ export function completePreparedIrIntegration(input: {
         // A deferred caller can still target a dependency whose sealed body
         // was settled by the early report. Retain those exact AST-site plans
         // without re-adding the prepared owner to the emission population.
-        directCalls: new Map([
-          ...input.projectLoweringPlans(input.selection).directCalls,
-          ...remainingLoweringPlans.directCalls,
-        ]),
+        directCalls: mergePreparedIrDirectCallLoweringPlans(
+          input.projectLoweringPlans(input.selection).directCalls,
+          remainingLoweringPlans.directCalls,
+        ),
       }
     : remainingLoweringPlans;
   const remainingReport = compileIrPathFunctions(
@@ -1831,4 +1836,24 @@ export function completePreparedIrIntegration(input: {
     loweringPlans,
   );
   return input.preparedReport ? mergeIrIntegrationReports(input.preparedReport, remainingReport) : remainingReport;
+}
+
+/** Merge two authenticated projections without allowing later authority to replace an exact AST-site row. */
+export function mergePreparedIrDirectCallLoweringPlans(
+  full: ReadonlyMap<ts.CallExpression, IrDirectCallLoweringPlan>,
+  remaining: ReadonlyMap<ts.CallExpression, IrDirectCallLoweringPlan>,
+): Map<ts.CallExpression, IrDirectCallLoweringPlan> {
+  const merged = new Map(full);
+  for (const [call, plan] of remaining) {
+    const prior = merged.get(call);
+    if (prior && !irDirectCallLoweringPlanEquals(prior, plan)) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `prepared IR direct-call projections disagree for ${call.expression.getText(call.getSourceFile())}`,
+      );
+    }
+    if (!prior) merged.set(call, plan);
+  }
+  return merged;
 }

--- a/src/ir/ast-lowering-plans.ts
+++ b/src/ir/ast-lowering-plans.ts
@@ -1,14 +1,28 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { IrBindingId, IrClassId, IrSourceId, IrUnitId } from "./identity.js";
-import type { IrClassShape, IrClosureSignature, IrFuncRef, IrGlobalRef, IrType } from "./nodes.js";
+import {
+  closureSignatureEquals,
+  type IrClassShape,
+  type IrClosureSignature,
+  type IrFuncRef,
+  type IrGlobalRef,
+  type IrType,
+} from "./nodes.js";
 import type { IrCountedStringAppendPlan } from "./analysis/counted-string-append.js";
 import type { IrCountedStringAppendSiteId } from "./counted-string-append-provenance.js";
-import type { IrLegacyUnitProjection, IrPlanningIdentityContext } from "./planning-identity.js";
+import {
+  requireIrPlanningOwnerUnitId,
+  requireIrPlanningSourceId,
+  type IrLegacyUnitProjection,
+  type IrPlanningIdentityContext,
+} from "./planning-identity.js";
 import type { IrPromiseDelayLoweringPlans } from "./promise-delay-lowering.js";
 import type { IrFnctorArgumentProjection } from "./fnctor-argument-projection.js";
 import type { IrFnctorShape } from "./fnctor-abi.js";
 import type { FuncHandle, FuncTypeDef, ValType, WasmFunction } from "./types.js";
+import { sameIrCallableBinding } from "./callable-bindings.js";
+import type { IrIdentityImportedFunctionResolver } from "./imported-functions.js";
 import { ts } from "../ts-api.js";
 import { requireCompilerTimerShimPlan } from "./timer-shim-lowering.js";
 
@@ -171,6 +185,140 @@ export function collectIrDirectCallLoweringPlans(
   return plans;
 }
 
+export interface IrIdentityDirectCallCollectionOptions {
+  readonly identityContext: IrPlanningIdentityContext;
+  readonly resolver: IrIdentityImportedFunctionResolver;
+  readonly activeOwnerUnitIds: ReadonlySet<IrUnitId>;
+  readonly signaturesByUnitId: ReadonlyMap<IrUnitId, IrClosureSignature>;
+  readonly targetsByLegacyName: ReadonlyMap<string, IrDirectCallTarget>;
+}
+
+function directCallIdentityMismatch(detail: string): never {
+  throw new Error(`ir/direct-call identity: ${detail}`);
+}
+
+function requireExactDirectCallAst(node: ts.Node, sourceFile: ts.SourceFile, label: string): void {
+  if (node.getSourceFile() !== sourceFile) {
+    directCallIdentityMismatch(`${label} is detached from exact source ${sourceFile.fileName}`);
+  }
+  for (let current = node; current !== sourceFile; ) {
+    const parent = current.parent;
+    let retainedByParent = false;
+    if (parent) ts.forEachChild(parent, (child) => void (retainedByParent ||= child === current));
+    if (!parent || !retainedByParent) {
+      directCallIdentityMismatch(`${label} is a copied or stale AST node in ${sourceFile.fileName}`);
+    }
+    current = parent;
+  }
+}
+
+function requireActiveDirectCallTerminal(
+  identityContext: IrPlanningIdentityContext,
+  activeOwnerUnitIds: ReadonlySet<IrUnitId>,
+  unitId: IrUnitId,
+  role: "owner" | "target",
+) {
+  const terminal = identityContext.terminalByUnitId.get(unitId);
+  if (
+    !activeOwnerUnitIds.has(unitId) ||
+    terminal === undefined ||
+    identityContext.unitByUnitId.get(unitId) !== terminal ||
+    terminal.terminal !== true ||
+    terminal.terminalOwnerId !== unitId
+  ) {
+    directCallIdentityMismatch(`${role} ${unitId} is not an exact active self-owned terminal`);
+  }
+  return terminal;
+}
+
+/** Structural equality for duplicate producers of one exact direct-call AST site. */
+export function irDirectCallLoweringPlanEquals(
+  left: IrDirectCallLoweringPlan,
+  right: IrDirectCallLoweringPlan,
+): boolean {
+  return (
+    left.ownerUnitId === right.ownerUnitId &&
+    left.target.name === right.target.name &&
+    sameIrCallableBinding(left.target.binding, right.target.binding) &&
+    closureSignatureEquals(left.signature, right.signature)
+  );
+}
+
+/**
+ * Collect source-unit calls through exact AST, owner, checker, and inventory
+ * identity. The legacy-name map is only a projection after the checker has
+ * authenticated the target; it never selects a target by identifier text.
+ */
+export function collectIrDirectCallLoweringPlansByIdentity(
+  root: ts.Node,
+  ownerUnitId: IrUnitId,
+  options: IrIdentityDirectCallCollectionOptions,
+): ReadonlyMap<ts.CallExpression, IrDirectCallLoweringPlan> {
+  const { identityContext, resolver, activeOwnerUnitIds, signaturesByUnitId, targetsByLegacyName } = options;
+  const owner = requireActiveDirectCallTerminal(identityContext, activeOwnerUnitIds, ownerUnitId, "owner");
+  const sourceFile = identityContext.sourceFileBySourceId.get(owner.sourceId);
+  if (!sourceFile || identityContext.sourceIdBySourceFile.get(sourceFile) !== owner.sourceId) {
+    directCallIdentityMismatch(`owner ${ownerUnitId} has no exact source object for ${owner.sourceId}`);
+  }
+  if (requireIrPlanningSourceId(identityContext, sourceFile) !== owner.sourceId) {
+    directCallIdentityMismatch(`root for ${ownerUnitId} is detached from its exact source ${owner.sourceId}`);
+  }
+  requireExactDirectCallAst(root, sourceFile, `root for ${ownerUnitId}`);
+
+  const plans = new Map<ts.CallExpression, IrDirectCallLoweringPlan>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      requireExactDirectCallAst(node, sourceFile, `call at ${node.pos}`);
+      const actualOwnerUnitId = requireIrPlanningOwnerUnitId(identityContext, node);
+      if (actualOwnerUnitId === ownerUnitId) {
+        const resolved = resolver.resolveTopLevelFunctionValueTarget(node.expression);
+        if (resolved) {
+          const retained = targetsByLegacyName.get(resolved.targetName);
+          if (retained) {
+            if (resolved.legacyProjection !== "unambiguous") {
+              directCallIdentityMismatch(
+                `target ${resolved.targetUnitId} cannot cross the legacy-name projection unambiguously`,
+              );
+            }
+            const target = requireActiveDirectCallTerminal(
+              identityContext,
+              activeOwnerUnitIds,
+              resolved.targetUnitId,
+              "target",
+            );
+            const targetSourceFile = identityContext.sourceFileBySourceId.get(target.sourceId);
+            const expectedSignature = signaturesByUnitId.get(resolved.targetUnitId);
+            if (
+              target.sourceId !== owner.sourceId ||
+              targetSourceFile !== sourceFile ||
+              resolved.declaration.getSourceFile() !== sourceFile ||
+              identityContext.declarationByUnitId.get(resolved.targetUnitId) !== resolved.declaration ||
+              identityContext.unitIdByDeclaration.get(resolved.declaration) !== resolved.targetUnitId ||
+              retained.target.binding.kind !== "unit" ||
+              retained.target.binding.unitId !== resolved.targetUnitId ||
+              retained.target.name !== resolved.targetName ||
+              expectedSignature === undefined ||
+              !closureSignatureEquals(retained.signature, expectedSignature)
+            ) {
+              directCallIdentityMismatch(
+                `target ${resolved.targetName} at ${sourceFile.fileName}:${node.pos} disagrees with its retained source identity`,
+              );
+            }
+            plans.set(node, {
+              ownerUnitId,
+              target: retained.target,
+              signature: retained.signature,
+            });
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return plans;
+}
+
 export interface IrHostVoidCallbackLoweringPlan {
   readonly ownerUnitId: IrUnitId;
   readonly ownerName: string;
@@ -234,6 +382,8 @@ export interface ModuleBindingGlobal {
 
 export interface IrIntegrationLoweringPlans {
   readonly identityContext: IrPlanningIdentityContext;
+  /** Checker authority retained for exact source-unit direct-call reconciliation. */
+  readonly directCallResolver?: IrIdentityImportedFunctionResolver;
   /** Exact late #3521 fnctor parameter projection, when fully prepared. */
   readonly fnctorParameterPreselection?: IrFnctorParameterPreselectionPlan;
   /** Exact native-string runtime boundaries owned by that projection. */
@@ -246,6 +396,8 @@ export interface IrIntegrationLoweringPlans {
   readonly ownerProjection: IrLegacyUnitProjection;
   readonly ownerUnitIdByLegacyName: ReadonlyMap<string, IrUnitId>;
   readonly signaturesByUnitId: ReadonlyMap<IrUnitId, IrClosureSignature>;
+  /** Exact callable signatures used to authenticate source direct-call sites. */
+  readonly directCallSignaturesByUnitId?: ReadonlyMap<IrUnitId, IrClosureSignature>;
   readonly directCalls: ReadonlyMap<ts.CallExpression, IrDirectCallLoweringPlan>;
   readonly importedCalls: ReadonlyMap<ts.CallExpression, IrImportedCallLoweringPlan>;
   readonly topLevelFunctionValues: ReadonlyMap<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -191,6 +191,8 @@ import { prepareSuspendingIrFunction } from "./async-prepare.js";
 import { parseIrDateSnapshotGetter } from "./date-runtime.js";
 import {
   collectIrDirectCallLoweringPlans,
+  collectIrDirectCallLoweringPlansByIdentity,
+  irDirectCallLoweringPlanEquals,
   type IrDirectCallLoweringPlan,
   type IrDirectCallTarget,
   type IrFnctorParameterPreselectionPlan,
@@ -218,7 +220,6 @@ import {
   irSupportFuncRef,
   irUnitCallableBindingId,
   irUnitFuncRef,
-  sameIrCallableBinding,
 } from "./callable-bindings.js";
 import {
   buildIrUnitInventory,
@@ -879,6 +880,58 @@ function makeAmbientStringBindingPredicate(checker: ts.TypeChecker): (node: ts.I
   };
 }
 
+function makeIrDirectCallReconciler(
+  sourceFile: ts.SourceFile,
+  loweringPlans: IrIntegrationLoweringPlans | undefined,
+  targets: ReadonlyMap<string, IrDirectCallTarget>,
+): {
+  readonly directCalls: Map<ts.CallExpression, IrDirectCallLoweringPlan>;
+  readonly collect: (root: ts.Node, ownerUnitId: IrUnitId) => ReadonlyMap<ts.CallExpression, IrDirectCallLoweringPlan>;
+} {
+  const sourceTargets = new Map([...targets].filter(([, target]) => target.target.binding.kind === "unit"));
+  const compatibilityTargets = new Map([...targets].filter(([, target]) => target.target.binding.kind !== "unit"));
+  const activeOwnerUnitIds = new Set(loweringPlans?.ownerProjection.entries.map(({ unitId }) => unitId) ?? []);
+  const sourceSignatures = loweringPlans?.directCallSignaturesByUnitId ?? loweringPlans?.signaturesByUnitId;
+  const directCalls = new Map<ts.CallExpression, IrDirectCallLoweringPlan>(loweringPlans?.directCalls);
+  const collect = (root: ts.Node, ownerUnitId: IrUnitId): ReadonlyMap<ts.CallExpression, IrDirectCallLoweringPlan> => {
+    let sourcePlans: ReadonlyMap<ts.CallExpression, IrDirectCallLoweringPlan> = new Map();
+    if (loweringPlans?.directCallResolver && sourceTargets.size > 0) {
+      try {
+        sourcePlans = collectIrDirectCallLoweringPlansByIdentity(root, ownerUnitId, {
+          identityContext: loweringPlans.identityContext,
+          resolver: loweringPlans.directCallResolver,
+          activeOwnerUnitIds,
+          signaturesByUnitId: sourceSignatures!,
+          targetsByLegacyName: sourceTargets,
+        });
+      } catch (error) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "resolve",
+          `direct-call identity at ${sourceFile.fileName} disagrees with exact integration evidence: ${error instanceof Error ? error.message : String(error)}`,
+          error,
+        );
+      }
+    }
+    for (const [call, plan] of [
+      ...sourcePlans,
+      ...collectIrDirectCallLoweringPlans(root, ownerUnitId, compatibilityTargets),
+    ]) {
+      const existing = directCalls.get(call);
+      if (existing && !irDirectCallLoweringPlanEquals(existing, plan)) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "resolve",
+          `direct-call plan at ${sourceFile.fileName}:${call.pos} disagrees with exact integration identity`,
+        );
+      }
+      if (!existing) directCalls.set(call, plan);
+    }
+    return directCalls;
+  };
+  return { directCalls, collect };
+}
+
 export function compileIrPathFunctions(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
@@ -1242,8 +1295,9 @@ export function compileIrPathFunctions(
 
   const directCallTargets = new Map<string, IrDirectCallTarget>();
   if (loweringPlans) {
+    const sourceSignatures = loweringPlans.directCallSignaturesByUnitId ?? loweringPlans.signaturesByUnitId;
     for (const [legacyName, unitId] of loweringPlans.ownerUnitIdByLegacyName) {
-      const signature = loweringPlans.signaturesByUnitId.get(unitId);
+      const signature = sourceSignatures.get(unitId);
       if (!signature) continue;
       directCallTargets.set(legacyName, {
         target: irUnitFuncRef({ unitId, name: legacyName }),
@@ -1300,29 +1354,11 @@ export function compileIrPathFunctions(
       });
     }
   }
-  const preparedDirectCalls = new Map<ts.CallExpression, IrDirectCallLoweringPlan>(loweringPlans?.directCalls);
-  const directCallsFor = (
-    root: ts.Node,
-    ownerUnitId: IrUnitId,
-  ): ReadonlyMap<ts.CallExpression, IrDirectCallLoweringPlan> => {
-    for (const [call, plan] of collectIrDirectCallLoweringPlans(root, ownerUnitId, directCallTargets)) {
-      const existing = preparedDirectCalls.get(call);
-      if (
-        existing &&
-        (existing.ownerUnitId !== plan.ownerUnitId ||
-          !sameIrCallableBinding(existing.target.binding, plan.target.binding) ||
-          existing.target.name !== plan.target.name)
-      ) {
-        throw new IrInvariantError(
-          "selection-preparation-mismatch",
-          "resolve",
-          `direct-call plan at ${sourceFile.fileName}:${call.pos} disagrees with exact integration identity`,
-        );
-      }
-      if (!existing) preparedDirectCalls.set(call, plan);
-    }
-    return preparedDirectCalls;
-  };
+  const { directCalls: preparedDirectCalls, collect: directCallsFor } = makeIrDirectCallReconciler(
+    sourceFile,
+    loweringPlans,
+    directCallTargets,
+  );
 
   for (const owner of unsupportedHostDateOwners.values()) {
     failures.record(
@@ -2033,11 +2069,12 @@ export function compileIrPathFunctions(
           `ir/integration: module init artifact ${moduleInitUnitId} does not match terminal owner ${moduleInitOwner.unitId}`,
         );
       }
+      for (const statement of population) directCallsFor(statement, moduleInitUnitId);
       const result = lowerFunctionAstToIr(synthetic, {
         exported: false,
         funcName: MODULE_INIT_UNIT_NAME,
         ownerUnitId: moduleInitUnitId,
-        directCalls: directCallsFor(synthetic, moduleInitUnitId),
+        directCalls: preparedDirectCalls,
         fnctorParameterPreselection: loweringPlans?.fnctorParameterPreselection,
         fnctorNativeStringBoundaries: loweringPlans?.fnctorNativeStringBoundaries,
         returnTypeOverride: null,

--- a/tests/issue-3520-lowering-plan-identity.test.ts
+++ b/tests/issue-3520-lowering-plan-identity.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   collectIrDirectCallLoweringPlans,
+  collectIrDirectCallLoweringPlansByIdentity,
+  irDirectCallLoweringPlanEquals,
   type IrDirectCallTarget,
   type IrDirectCallLoweringPlan,
   type IrHostVoidCallbackLoweringPlan,
@@ -19,8 +21,11 @@ import {
   irUnitFuncRef,
 } from "../src/ir/callable-bindings.js";
 import { lowerFunctionAstToIr, type IrExternClassMeta, type LoweredFunctionResult } from "../src/ir/from-ast.js";
-import type { IrUnitId } from "../src/ir/identity.js";
+import { buildIrUnitInventory, type IrUnitId } from "../src/ir/identity.js";
+import { makeIrIdentityImportedFunctionResolver } from "../src/ir/imported-functions.js";
 import { irVal, type IrClosureSignature, type IrType } from "../src/ir/nodes.js";
+import { buildIrPlanningIdentityContext, requireIrPlanningOwnerUnitId } from "../src/ir/planning-identity.js";
+import { mergePreparedIrDirectCallLoweringPlans } from "../src/codegen/ir-prepared-free-functions.js";
 import { ts } from "../src/ts-api.js";
 import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
 
@@ -54,6 +59,70 @@ function firstDescendant<T extends ts.Node>(node: ts.Node, predicate: (candidate
   visit(node);
   if (!match) throw new Error("expected matching descendant");
   return match;
+}
+
+function checkedIdentityFixture(files: Readonly<Record<string, string>>, entryName = Object.keys(files)[0]!) {
+  const textByName = new Map(Object.entries(files));
+  const options: ts.CompilerOptions = {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    noLib: true,
+    target: ts.ScriptTarget.ES2022,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (fileName) => textByName.has(fileName),
+    readFile: (fileName) => textByName.get(fileName),
+    getSourceFile: (fileName, languageVersion) => {
+      const text = textByName.get(fileName);
+      return text === undefined
+        ? undefined
+        : ts.createSourceFile(fileName, text, languageVersion, true, ts.ScriptKind.TS);
+    },
+    getDefaultLibFileName: () => "/repo/lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/repo",
+    getDirectories: () => [],
+    directoryExists: (directoryName) => directoryName === "/repo",
+    realpath: (path) => path,
+    getCanonicalFileName: (fileName) => fileName,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+  };
+  const rootNames = Object.keys(files);
+  const program = ts.createProgram(rootNames, options, host);
+  const checker = program.getTypeChecker();
+  const sourceFiles = rootNames.map((fileName) => program.getSourceFile(fileName)!);
+  const byName = new Map(sourceFiles.map((sourceFile) => [sourceFile.fileName, sourceFile] as const));
+  const entrySource = byName.get(entryName)!;
+  const identityContext = buildIrPlanningIdentityContext(buildIrUnitInventory(sourceFiles, { checker, entrySource }));
+  return {
+    checker,
+    sourceFiles,
+    byName,
+    identityContext,
+    resolver: makeIrIdentityImportedFunctionResolver(checker, sourceFiles, identityContext),
+  };
+}
+
+function namedFunction(sourceFile: ts.SourceFile, name: string): ts.FunctionDeclaration {
+  const declaration = sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === name,
+  );
+  if (!declaration) throw new Error(`missing function ${name}`);
+  return declaration;
+}
+
+function callsNamed(root: ts.Node, name: string): ts.CallExpression[] {
+  const calls: ts.CallExpression[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === name) {
+      calls.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return calls;
 }
 
 function planOwnerEvidence(ownerUnitId: IrUnitId | undefined): { readonly ownerUnitId?: IrUnitId } {
@@ -149,18 +218,21 @@ function callbackFixture(): {
   plan(planOwnerUnitId: IrUnitId | undefined): IrHostVoidCallbackLoweringPlan;
 } {
   const declaration = sourceFunction(`
-    export function owner(target: EventTarget): void {
+    export function owner(target: HTMLElement): void {
       target.addEventListener("tick", () => { return; });
       return;
     }
   `);
+  const call = firstDescendant(declaration, ts.isCallExpression);
+  const access = call.expression;
+  if (!ts.isPropertyAccessExpression(access)) throw new Error("expected a property call");
   const callback = firstDescendant(declaration, ts.isArrowFunction);
   const externref = { kind: "externref" } as const;
   const eventTarget: IrExternClassMeta = {
-    className: "EventTarget",
-    importPrefix: "EventTarget",
+    className: "HTMLElement",
+    importPrefix: "HTMLElement",
     constructorParams: [],
-    methods: new Map([["addEventListener", { params: [externref, externref, externref], results: [] }]]),
+    methods: new Map([["addEventListener", { params: [externref, externref, externref, externref], results: [] }]]),
     properties: new Map(),
   };
   const plan = (ownerUnitId: IrUnitId | undefined): IrHostVoidCallbackLoweringPlan =>
@@ -177,9 +249,23 @@ function callbackFixture(): {
       lowerFunctionAstToIr(declaration, {
         ownerUnitId: OWNER_ID,
         exported: true,
-        paramTypeOverrides: [{ kind: "extern", className: "EventTarget" }],
+        paramTypeOverrides: [{ kind: "extern", className: "HTMLElement" }],
         returnTypeOverride: null,
-        resolver: { getExternClassInfo: (className) => (className === "EventTarget" ? eventTarget : undefined) },
+        resolver: {
+          getExternClassInfo: (className) => (className === "HTMLElement" ? eventTarget : undefined),
+          standaloneDomOperation: (node) =>
+            node === call
+              ? {
+                  kind: "member-call",
+                  importName: "HTMLElement_addEventListener",
+                  call,
+                  access,
+                  receiverClass: "HTMLElement",
+                  resultClass: null,
+                  argumentBoundaries: ["native-string", "native-callback-zero-void", "nullish"],
+                }
+              : undefined,
+        },
         hostVoidCallbacks: new Map([[callback, plan(planOwnerUnitId)]]),
       }),
   };
@@ -336,5 +422,276 @@ describe("#3520 lowering-plan owner identity", () => {
       new Map([["target", { target: provider, signature: NUMBER_SIGNATURE } satisfies IrDirectCallTarget]]),
     );
     expect([...providerPlans.values()].map((plan) => plan.target)).toEqual([provider, provider]);
+  });
+
+  it("collects source calls only for their exact active terminal owner", () => {
+    const graph = checkedIdentityFixture({
+      "/repo/entry.ts": `
+        function target(value: number): number { return value + 1; }
+        export function outer(): number {
+          function nested(): number { return target(1); }
+          class Explicit {
+            constructor() { target(2); }
+            method(): number { return target(3); }
+          }
+          class Implicit { method(): number { return 0; } }
+          target(4);
+          return nested() + new Explicit().method() + new Implicit().method();
+        }
+      `,
+    });
+    const sourceFile = graph.byName.get("/repo/entry.ts")!;
+    const target = namedFunction(sourceFile, "target");
+    const outer = namedFunction(sourceFile, "outer");
+    const targetUnitId = graph.identityContext.unitIdByDeclaration.get(target)!;
+    const outerUnitId = graph.identityContext.unitIdByDeclaration.get(outer)!;
+    const classes = [...outer.body!.statements].filter(ts.isClassDeclaration);
+    const explicit = classes.find((candidate) => candidate.name?.text === "Explicit")!;
+    const implicit = classes.find((candidate) => candidate.name?.text === "Implicit")!;
+    const constructorDeclaration = explicit.members.find(ts.isConstructorDeclaration)!;
+    const method = explicit.members.find(ts.isMethodDeclaration)!;
+    const constructorUnitId = graph.identityContext.unitIdByDeclaration.get(constructorDeclaration)!;
+    const methodUnitId = graph.identityContext.unitIdByDeclaration.get(method)!;
+    const implicitConstructorUnitId = graph.identityContext.unitIdByDeclaration.get(implicit)!;
+    const activeOwnerUnitIds = new Set(graph.identityContext.terminalByUnitId.keys());
+    const targetsByLegacyName = new Map<string, IrDirectCallTarget>([
+      ["target", { target: irUnitFuncRef({ unitId: targetUnitId, name: "target" }), signature: NUMBER_SIGNATURE }],
+    ]);
+    const options = {
+      identityContext: graph.identityContext,
+      resolver: graph.resolver,
+      activeOwnerUnitIds,
+      signaturesByUnitId: new Map([[targetUnitId, NUMBER_SIGNATURE]]),
+      targetsByLegacyName,
+    };
+
+    const outerPlans = collectIrDirectCallLoweringPlansByIdentity(outer, outerUnitId, options);
+    expect([...outerPlans.keys()].map((call) => call.arguments[0]?.getText(sourceFile))).toEqual(["1", "4"]);
+    expect([...outerPlans.values()].every((plan) => plan.ownerUnitId === outerUnitId)).toBe(true);
+
+    const constructorPlans = collectIrDirectCallLoweringPlansByIdentity(
+      constructorDeclaration,
+      constructorUnitId,
+      options,
+    );
+    expect([...constructorPlans.keys()].map((call) => call.arguments[0]?.getText(sourceFile))).toEqual(["2"]);
+    const methodPlans = collectIrDirectCallLoweringPlansByIdentity(method, methodUnitId, options);
+    expect([...methodPlans.keys()].map((call) => call.arguments[0]?.getText(sourceFile))).toEqual(["3"]);
+
+    expect(() => collectIrDirectCallLoweringPlansByIdentity(method, implicitConstructorUnitId, options)).toThrow(
+      "is not an exact active self-owned terminal",
+    );
+    expect(requireIrPlanningOwnerUnitId(graph.identityContext, constructorPlans.keys().next().value!)).toBe(
+      constructorUnitId,
+    );
+  });
+
+  it("rejects stale source and mutated target evidence before retaining a source call", () => {
+    const sourceText = `
+      function target(value: number): number { return value + 1; }
+      export function owner(): number { return target(1); }
+    `;
+    const graph = checkedIdentityFixture({ "/repo/entry.ts": sourceText });
+    const sourceFile = graph.byName.get("/repo/entry.ts")!;
+    const target = namedFunction(sourceFile, "target");
+    const owner = namedFunction(sourceFile, "owner");
+    const targetUnitId = graph.identityContext.unitIdByDeclaration.get(target)!;
+    const ownerUnitId = graph.identityContext.unitIdByDeclaration.get(owner)!;
+    const activeOwnerUnitIds = new Set(graph.identityContext.terminalByUnitId.keys());
+    const signaturesByUnitId = new Map([[targetUnitId, NUMBER_SIGNATURE]]);
+    const exactTarget: IrDirectCallTarget = {
+      target: irUnitFuncRef({ unitId: targetUnitId, name: "target" }),
+      signature: NUMBER_SIGNATURE,
+    };
+    const collect = (retained: IrDirectCallTarget, signatures = signaturesByUnitId) =>
+      collectIrDirectCallLoweringPlansByIdentity(owner, ownerUnitId, {
+        identityContext: graph.identityContext,
+        resolver: graph.resolver,
+        activeOwnerUnitIds,
+        signaturesByUnitId: signatures,
+        targetsByLegacyName: new Map([["target", retained]]),
+      });
+
+    expect(collect(exactTarget).size).toBe(1);
+    expect(() => collect({ ...exactTarget, target: irUnitFuncRef({ unitId: ownerUnitId, name: "target" }) })).toThrow(
+      "disagrees with its retained source identity",
+    );
+    expect(() => collect({ ...exactTarget, target: irUnitFuncRef({ unitId: targetUnitId, name: "renamed" }) })).toThrow(
+      "disagrees with its retained source identity",
+    );
+    expect(() => collect({ ...exactTarget, signature: VOID_SIGNATURE })).toThrow(
+      "disagrees with its retained source identity",
+    );
+    expect(() => collect(exactTarget, new Map([[targetUnitId, VOID_SIGNATURE]]))).toThrow(
+      "disagrees with its retained source identity",
+    );
+
+    const copiedSource = ts.createSourceFile(
+      sourceFile.fileName,
+      sourceText,
+      ts.ScriptTarget.ES2022,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const copiedOwner = namedFunction(copiedSource, "owner");
+    expect(() =>
+      collectIrDirectCallLoweringPlansByIdentity(copiedOwner, ownerUnitId, {
+        identityContext: graph.identityContext,
+        resolver: graph.resolver,
+        activeOwnerUnitIds,
+        signaturesByUnitId,
+        targetsByLegacyName: new Map([["target", exactTarget]]),
+      }),
+    ).toThrow("detached from exact source");
+    (copiedOwner as ts.FunctionDeclaration & { parent: ts.Node }).parent = sourceFile;
+    expect(() =>
+      collectIrDirectCallLoweringPlansByIdentity(copiedOwner, ownerUnitId, {
+        identityContext: graph.identityContext,
+        resolver: graph.resolver,
+        activeOwnerUnitIds,
+        signaturesByUnitId,
+        targetsByLegacyName: new Map([["target", exactTarget]]),
+      }),
+    ).toThrow("copied or stale AST node");
+
+    const duplicate = checkedIdentityFixture(
+      {
+        "/repo/a.ts": `export function target(value: number): number { return value + 1; } export function owner(): number { return target(1); }`,
+        "/repo/b.ts": `export function target(value: number): number { return value + 2; }`,
+      },
+      "/repo/a.ts",
+    );
+    const a = duplicate.byName.get("/repo/a.ts")!;
+    const b = duplicate.byName.get("/repo/b.ts")!;
+    const duplicateOwner = namedFunction(a, "owner");
+    const duplicateOwnerId = duplicate.identityContext.unitIdByDeclaration.get(duplicateOwner)!;
+    const foreignTarget = namedFunction(b, "target");
+    const foreignTargetId = duplicate.identityContext.unitIdByDeclaration.get(foreignTarget)!;
+    expect(() =>
+      collectIrDirectCallLoweringPlansByIdentity(duplicateOwner, duplicateOwnerId, {
+        identityContext: duplicate.identityContext,
+        resolver: duplicate.resolver,
+        activeOwnerUnitIds: new Set(duplicate.identityContext.terminalByUnitId.keys()),
+        signaturesByUnitId: new Map([[foreignTargetId, NUMBER_SIGNATURE]]),
+        targetsByLegacyName: new Map([
+          [
+            "target",
+            {
+              target: irUnitFuncRef({ unitId: foreignTargetId, name: "target" }),
+              signature: NUMBER_SIGNATURE,
+            },
+          ],
+        ]),
+      }),
+    ).toThrow("cannot cross the legacy-name projection unambiguously");
+
+    const imported = checkedIdentityFixture(
+      {
+        "/repo/entry.ts": `import { target } from "./lib"; export function owner(): number { return target(1); }`,
+        "/repo/lib.ts": `export function target(value: number): number { return value + 1; }`,
+      },
+      "/repo/entry.ts",
+    );
+    const importedEntry = imported.byName.get("/repo/entry.ts")!;
+    const importedTarget = namedFunction(imported.byName.get("/repo/lib.ts")!, "target");
+    const importedOwner = namedFunction(importedEntry, "owner");
+    const importedTargetId = imported.identityContext.unitIdByDeclaration.get(importedTarget)!;
+    expect(
+      collectIrDirectCallLoweringPlansByIdentity(
+        importedOwner,
+        imported.identityContext.unitIdByDeclaration.get(importedOwner)!,
+        {
+          identityContext: imported.identityContext,
+          resolver: imported.resolver,
+          activeOwnerUnitIds: new Set(imported.identityContext.terminalByUnitId.keys()),
+          signaturesByUnitId: new Map([[importedTargetId, NUMBER_SIGNATURE]]),
+          targetsByLegacyName: new Map([
+            [
+              "target",
+              {
+                target: irUnitFuncRef({ unitId: importedTargetId, name: "target" }),
+                signature: NUMBER_SIGNATURE,
+              },
+            ],
+          ]),
+        },
+      ).size,
+    ).toBe(0);
+
+    for (const shadowingSource of [
+      `function target(): number { return 1; } export function owner(): number { const target = () => 2; return target(); }`,
+      `function target(): number { return 1; } target = function (): number { return 2; }; export function owner(): number { return target(); }`,
+    ]) {
+      const shadowed = checkedIdentityFixture({ "/repo/entry.ts": shadowingSource });
+      const shadowedSource = shadowed.byName.get("/repo/entry.ts")!;
+      const shadowedOwner = namedFunction(shadowedSource, "owner");
+      const shadowedTarget = namedFunction(shadowedSource, "target");
+      const shadowedOwnerId = shadowed.identityContext.unitIdByDeclaration.get(shadowedOwner)!;
+      const shadowedTargetId = shadowed.identityContext.unitIdByDeclaration.get(shadowedTarget)!;
+      expect(
+        collectIrDirectCallLoweringPlansByIdentity(shadowedOwner, shadowedOwnerId, {
+          identityContext: shadowed.identityContext,
+          resolver: shadowed.resolver,
+          activeOwnerUnitIds: new Set(shadowed.identityContext.terminalByUnitId.keys()),
+          signaturesByUnitId: new Map([[shadowedTargetId, NUMBER_SIGNATURE]]),
+          targetsByLegacyName: new Map([
+            [
+              "target",
+              {
+                target: irUnitFuncRef({ unitId: shadowedTargetId, name: "target" }),
+                signature: NUMBER_SIGNATURE,
+              },
+            ],
+          ]),
+        }).size,
+      ).toBe(0);
+    }
+  });
+
+  it("reuses only an identical authenticated row from a second producer", () => {
+    const plan: IrDirectCallLoweringPlan = {
+      ownerUnitId: OWNER_ID,
+      target: irUnitFuncRef({ unitId: TARGET_ID, name: "target" }),
+      signature: NUMBER_SIGNATURE,
+    };
+    expect(irDirectCallLoweringPlanEquals(plan, { ...plan })).toBe(true);
+    expect(irDirectCallLoweringPlanEquals(plan, { ...plan, ownerUnitId: STALE_OWNER_ID })).toBe(false);
+    expect(
+      irDirectCallLoweringPlanEquals(plan, {
+        ...plan,
+        target: irUnitFuncRef({ unitId: STALE_OWNER_ID, name: "target" }),
+      }),
+    ).toBe(false);
+    expect(
+      irDirectCallLoweringPlanEquals(plan, {
+        ...plan,
+        target: irUnitFuncRef({ unitId: TARGET_ID, name: "renamed" }),
+      }),
+    ).toBe(false);
+    expect(irDirectCallLoweringPlanEquals(plan, { ...plan, signature: VOID_SIGNATURE })).toBe(false);
+  });
+
+  it("fails closed when full and remaining prepared projections disagree for one AST call", () => {
+    const declaration = sourceFunction(`export function owner(): number { return target(); }`);
+    const call = firstDescendant(declaration, ts.isCallExpression);
+    const plan: IrDirectCallLoweringPlan = {
+      ownerUnitId: OWNER_ID,
+      target: irUnitFuncRef({ unitId: TARGET_ID, name: "target" }),
+      signature: NUMBER_SIGNATURE,
+    };
+    expect(
+      mergePreparedIrDirectCallLoweringPlans(new Map([[call, plan]]), new Map([[call, { ...plan }]])).get(call),
+    ).toBe(plan);
+
+    for (const divergent of [
+      { ...plan, ownerUnitId: STALE_OWNER_ID },
+      { ...plan, target: irUnitFuncRef({ unitId: STALE_OWNER_ID, name: "target" }) },
+      { ...plan, target: irUnitFuncRef({ unitId: TARGET_ID, name: "renamed" }) },
+      { ...plan, signature: VOID_SIGNATURE },
+    ]) {
+      expect(() =>
+        mergePreparedIrDirectCallLoweringPlans(new Map([[call, plan]]), new Map([[call, divergent]])),
+      ).toThrow(/prepared IR direct-call projections disagree/);
+    }
   });
 });

--- a/tests/issue-3522-ir-nested-class-ownership.test.ts
+++ b/tests/issue-3522-ir-nested-class-ownership.test.ts
@@ -20,6 +20,29 @@ export function run(): number {
 }
 `;
 
+const OWNER_AWARE_CALL_SOURCE = `
+function seed(value: number): number { return value + 1; }
+export function run(): number {
+  class Calculator {
+    value: number;
+    constructor(value: number) { this.value = seed(value); }
+    add(delta: number): number { return seed(this.value + delta); }
+  }
+  return new Calculator(39).add(1);
+}
+`;
+
+const CLOSED_FIELD_CALL_SOURCE = `
+function seed(value: number): number { return value + 2; }
+export function run(): number {
+  class Box {
+    value = seed(40);
+    read(): number { return this.value; }
+  }
+  return new Box().read();
+}
+`;
+
 function outcome(result: CompileResult, name: string): IrObservedOutcome {
   const observed = (result.irOutcomes ?? []).filter((candidate) => candidate.displayName.startsWith(name));
   expect(observed, `terminal outcome count for ${name}`).toHaveLength(1);
@@ -102,6 +125,100 @@ describe("#3522 nested ordinary class ownership", () => {
     expect(watFunctionBody(prepared.wat, "Calculator_add")).toContain("struct.get");
     expect(watFunctionBody(prepared.wat, "Calculator_scale")).toContain("struct.get");
   });
+
+  it.each(TARGETS)("keeps nested constructor and method calls on their exact owners in the %s lane", async (target) => {
+    const direct = await compile(OWNER_AWARE_CALL_SOURCE, {
+      fileName: `nested-owner-call-direct-${target}.ts`,
+      experimentalIR: false,
+      target,
+    });
+    const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+    const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Calculator_new,Calculator_add";
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "seed,run";
+      prepared = await compile(OWNER_AWARE_CALL_SOURCE, {
+        fileName: `nested-owner-call-prepared-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        target,
+      });
+    } finally {
+      if (previousClassPoison === undefined)
+        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+      if (previousFunctionPoison === undefined)
+        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!()).toBe(42);
+    }
+    const seedOutcome = outcome(prepared, "seed");
+    const ownerOutcomes = [
+      outcome(prepared, "run"),
+      outcome(prepared, "Calculator_new"),
+      outcome(prepared, "Calculator_add"),
+    ];
+    const observed = [seedOutcome, ...ownerOutcomes];
+    expect(new Set(ownerOutcomes.map((candidate) => candidate.preparedComponentId)).size).toBe(1);
+    expect(seedOutcome.preparedComponentId).not.toBe(ownerOutcomes[0]!.preparedComponentId);
+    for (const candidate of observed) {
+      expect(candidate).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+    }
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it.each(TARGETS)(
+    "keeps the call-bearing nested field family closed and behavior-neutral in the %s lane",
+    async (target) => {
+      const fileName = `nested-field-call-${target}.ts`;
+      const direct = await compile(CLOSED_FIELD_CALL_SOURCE, {
+        fileName,
+        experimentalIR: false,
+        target,
+      });
+      const preparedControl = await compile(CLOSED_FIELD_CALL_SOURCE, {
+        fileName,
+        experimentalIR: true,
+        target,
+      });
+      const preparedObserved = await compile(CLOSED_FIELD_CALL_SOURCE, {
+        fileName,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        target,
+      });
+
+      for (const compiled of [direct, preparedControl, preparedObserved]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!()).toBe(42);
+      }
+      expect(Array.from(preparedObserved.binary)).toEqual(Array.from(preparedControl.binary));
+      expect(preparedObserved.irPostClaimErrors ?? []).toEqual([]);
+      expect(preparedObserved.irOutcomes ?? []).toHaveLength(2);
+      expect(outcome(preparedObserved, "seed")).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(outcome(preparedObserved, "run")).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+    },
+  );
 
   it("withdraws the complete nested class component when one body captures its enclosing frame", async () => {
     const result = await compile(


### PR DESCRIPTION
## Summary
- add a distinct source/AST/owner/checker-certified direct-call collector while preserving the context-free compatibility collector
- thread one resolver and exact callable signatures through single/multi overlay and integration reconciliation, including async targets
- fail closed on stale/copy/foreign identity drift and on divergent full/remaining plan collisions; keep the field-call gate closed

## Validation
- independent read-only review: approved after collision and callback-fixture repairs
- #3520 lowering-plan identity: 13/13; #3522 GC/standalone matrix: 7/7; changed-root hook: 20/20
- TypeScript 7 and 5; Prettier/Biome; IR layering; IR/codegen fallback gates
- exact parent artifact A/B: GC and standalone byte-identical within direct and experimental options
- LOC/function ratchets (net +273 production LOC under existing #3522 issue-scoped grants; no baseline change)
- normal pre-commit and pre-push hooks, unskipped

F2 is behavior-neutral and keeps #3522 in progress; F3/F4 retain dormant field-call evidence and bounded admission.

Refs #3522