### PR TITLE
fix(es2015): reject Symbol collection forEach callbacks

### DIFF
--- a/plan/issues/5091-es2015-set-foreach-symbol-callback.md
+++ b/plan/issues/5091-es2015-set-foreach-symbol-callback.md
@@ -1,0 +1,138 @@
+---
+id: 5091
+title: "ES2015 standalone Set.prototype.forEach rejects Symbol callbacks"
+status: done
+sprint: current
+created: 2026-08-27
+updated: 2026-08-27
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: conformance
+area: codegen
+language_feature: set-prototype-foreach
+es_edition: es2015
+goal: standalone-mode
+related: [3573, 2162]
+assignee: "ttraenkler/codex-es2015-residual-20260827"
+files:
+  - src/codegen/map-runtime.ts
+  - tests/issue-5091-set-foreach-symbol-callback.test.ts
+  - plan/issues/5091-es2015-set-foreach-symbol-callback.md
+loc-budget-allow:
+  - src/codegen/map-runtime.ts
+---
+
+# #5091 — ES2015 standalone `Set.prototype.forEach` rejects Symbol callbacks
+
+## Problem
+
+The maintained ES2015 Test262 row
+`built-ins/Set/prototype/forEach/callback-not-callable-symbol.js` passes in the
+host target but fails in standalone. `Set.prototype.forEach(Symbol())` must
+throw a `TypeError`; the standalone native collection path does not classify a
+Symbol callback as statically non-callable and falls through to the host
+`Set_forEach` import instead.
+
+This is the one Symbol-shaped tail left by #3573, whose five literal callback
+cases (`null`, `undefined`, number, boolean, and string) are already green.
+The change is limited to the native `Set`/`Map` forEach callback guard. Dynamic
+callbacks and Wasm closures must retain their existing routing.
+
+## Exact cohort and baseline (2026-08-27)
+
+The focused cohort is exactly one ES2015 row:
+
+- `test/built-ins/Set/prototype/forEach/callback-not-callable-symbol.js`
+
+Fresh authoritative snapshots were fetched with
+`node scripts/fetch-baseline-jsonl.mjs --force` and
+`node scripts/fetch-baseline-jsonl.mjs --standalone --force` from the pinned
+Test262 revision `b363f29d3c43c626dc852744ad64a0b48a003693`. The baseline row
+is **host 1/1 pass** and **standalone 0/1 pass, 1/1 compile error**. The
+standalone error is a `host_import_leak` for `Set_forEach`; there are no
+timeouts or skips in this cohort. The neighboring five #3573 rows remain
+standalone pass controls.
+
+## Implementation plan
+
+1. Extend the existing static non-callable check in
+   `tryCompileNativeCollectionForEach` to recognize a statically known Symbol
+   callback, matching the existing array-HOF `ESSymbolLike` treatment.
+2. Reuse `emitThrowTypeError` and the existing receiver side-effect ordering;
+   do not alter dynamic callback dispatch, closure lowering, collection
+   iteration, or host-target behavior.
+3. Add a focused Vitest regression that checks a native standalone module
+   throws for `Set.forEach(Symbol())`, emits no `Set_forEach` import, and still
+   invokes a closure callback. Run the exact Test262 row in both host and
+   standalone targets.
+4. Record final authoritative counts, focused regression counts, artifacts,
+   commits, and PR handoff here.
+
+## Evidence before implementation
+
+`src/codegen/map-runtime.ts` already emits the required native TypeError for
+literal `null`, `undefined`, numeric, boolean, and string callback arguments
+from #3573. Its static branch intentionally has no Symbol case, while
+`src/codegen/array-methods.ts` already treats `ts.TypeFlags.ESSymbolLike` as
+non-callable. The failing Test262 source uses `features: [Symbol]` and calls
+`s.forEach(Symbol())`, so adding the same type-flag check to the collection
+guard is narrow and preserves runtime values that cannot be classified at
+compile time.
+
+## Implementation
+
+The static non-callable branch in `tryCompileNativeCollectionForEach` now also
+checks `ctx.checker.getTypeAtLocation(cbArg).flags` for
+`ts.TypeFlags.ESSymbolLike`. This is the same compile-time classification used
+by the array-HOF guard. It reuses the existing receiver evaluation and
+`emitThrowTypeError` path, so no collection iteration or dynamic callback
+behavior changes.
+
+## Post-fix evidence (2026-08-27)
+
+The exact one-row cohort was rerun through
+`scripts/harness-flip-probe.ts`, including its structural must-pass and
+must-fail controls. Both lanes report **1/1 pass, 0 fail, 0 compile errors, 0
+compile timeouts, 0 skips**:
+
+- host artifact: `.tmp/issue-4789-final-host.jsonl`
+- standalone artifact: `.tmp/issue-4789-final-standalone.jsonl`
+
+The five existing #3573 literal callback controls were rerun with the selected
+Symbol row. The six-row cohort reports **host 6/6 pass** and **standalone 6/6
+pass**, with no other status. Cohort artifacts are
+`.tmp/issue-4789-final-cohort-host.jsonl` and
+`.tmp/issue-4789-final-cohort-standalone.jsonl`.
+
+The focused Vitest regression `tests/issue-5091-set-foreach-symbol-callback.test.ts`
+reports **4/4 passed** with one worker. TypeScript 7 typecheck, focused Biome
+lint, focused Prettier check, and `git diff --check` pass. The fresh baseline
+artifacts used for selection were:
+
+- host: `.test262-cache/test262-current.jsonl`
+  (`8303f7f87475abbf33a5558727df649bf5268617135c63f992f93df32bebcf22`)
+- standalone: `.test262-cache/test262-standalone-current.jsonl`
+  (`eb5efa0997b0cb070171e770b723f9035d2aa737ba83f63b0921404c318a967f`)
+
+They recorded host **1/1 pass** and standalone **0/1 pass, 1/1 compile error**
+for the selected row before the source change.
+
+## Acceptance
+
+- The exact row passes in host and standalone.
+- Standalone emits no `Set_forEach` import for the Symbol callback and reports
+  no compile error, timeout, or skip.
+- The five existing #3573 literal callback rows remain green.
+- Closure callback behavior and the host target remain green.
+- Focused regression tests pass with at most two workers.
+
+## Handoff
+
+Upstream tracking issue: #5091. The provisional local reservation `#4789`
+collided with an existing merged PR and was replaced before publication. The
+canonical delivery branch is `codex/5091-set-foreach-symbol` in
+`/private/tmp/js2-5091-set-foreach-symbol`. The completed fix is ready for its
+single non-draft PR against `loopdive/js2:main`; root owns merge-queue
+shepherding and will append the PR URL after publication.

--- a/plan/issues/5091-es2015-set-foreach-symbol-callback.md
+++ b/plan/issues/5091-es2015-set-foreach-symbol-callback.md
@@ -134,6 +134,7 @@ for the selected row before the source change.
 Upstream tracking issue: #5091. The provisional local reservation `#4789`
 collided with an existing merged PR and was replaced before publication. The
 canonical delivery branch is `codex/5091-set-foreach-symbol` in
-`/private/tmp/js2-5091-set-foreach-symbol`. The completed fix is ready for its
-single non-draft PR against `loopdive/js2:main`; root owns merge-queue
-shepherding and will append the PR URL after publication.
+`/private/tmp/js2-5091-set-foreach-symbol`. The completed fix is published as
+non-draft upstream PR #5093 against `loopdive/js2:main`. Root owns CI and
+merge-queue shepherding; implementation heads are `e0a1d88454` and
+`13d94cbc9b` before this publication handoff checkpoint.

--- a/plan/issues/5091-es2015-set-foreach-symbol-callback.md
+++ b/plan/issues/5091-es2015-set-foreach-symbol-callback.md
@@ -131,9 +131,11 @@ for the selected row before the source change.
 
 ## Handoff
 
-Upstream tracking issue: #5091. The provisional local reservation `#4789`
-collided with an existing merged PR and was replaced before publication. The
-canonical delivery branch is `codex/5091-set-foreach-symbol` in
+Repository-local tracking file:
+`plan/issues/5091-es2015-set-foreach-symbol-callback.md`. The canonical `5091`
+identifier belongs to this markdown issue; the transient GitHub issue was
+closed because implementation work is tracked only under `plan/issues/`. The
+delivery branch is `codex/5091-set-foreach-symbol` in
 `/private/tmp/js2-5091-set-foreach-symbol`. The completed fix is published as
 non-draft upstream PR #5093 against `loopdive/js2:main`. Root owns CI and
 merge-queue shepherding; implementation heads are `e0a1d88454` and

--- a/plan/issues/5091-es2015-set-foreach-symbol-callback.md
+++ b/plan/issues/5091-es2015-set-foreach-symbol-callback.md
@@ -75,18 +75,19 @@ standalone pass controls.
 `src/codegen/map-runtime.ts` already emits the required native TypeError for
 literal `null`, `undefined`, numeric, boolean, and string callback arguments
 from #3573. Its static branch intentionally has no Symbol case, while
-`src/codegen/array-methods.ts` already treats `ts.TypeFlags.ESSymbolLike` as
+`src/codegen/array-methods.ts` already treats a statically typed Symbol as
 non-callable. The failing Test262 source uses `features: [Symbol]` and calls
-`s.forEach(Symbol())`, so adding the same type-flag check to the collection
-guard is narrow and preserves runtime values that cannot be classified at
-compile time.
+`s.forEach(Symbol())`, so adding the same type classification through
+`ctx.oracle.staticJsTypeOf` is narrow and preserves runtime values that cannot
+be classified at compile time.
 
 ## Implementation
 
 The static non-callable branch in `tryCompileNativeCollectionForEach` now also
-checks `ctx.checker.getTypeAtLocation(cbArg).flags` for
-`ts.TypeFlags.ESSymbolLike`. This is the same compile-time classification used
-by the array-HOF guard. It reuses the existing receiver evaluation and
+checks `ctx.oracle.staticJsTypeOf(cbArg) === "symbol"`. This uses the shared
+oracle type-query boundary rather than reaching directly into the TypeScript
+checker, while preserving the same compile-time classification used by the
+array-HOF guard. It reuses the existing receiver evaluation and
 `emitThrowTypeError` path, so no collection iteration or dynamic callback
 behavior changes.
 

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -1797,7 +1797,7 @@ export function tryCompileNativeCollectionForEach(
       // A Symbol primitive is never callable. Keep this in the same
       // compile-time guard as the #3573 literal cases so standalone does not
       // fall through to the host Set_forEach/Map_forEach import. (#5091)
-      (ctx.checker.getTypeAtLocation(cbArg).flags & ts.TypeFlags.ESSymbolLike) !== 0 ||
+      ctx.oracle.staticJsTypeOf(cbArg) === "symbol" ||
       (ts.isIdentifier(cbArg) && cbArg.text === "undefined" && !fctx.localMap.has("undefined"));
     if (!staticNonCallable) return undefined;
     // Evaluate the receiver for its side effects first (this native path only

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -1794,6 +1794,10 @@ export function tryCompileNativeCollectionForEach(
       ts.isNumericLiteral(cbArg) ||
       ts.isStringLiteral(cbArg) ||
       ts.isNoSubstitutionTemplateLiteral(cbArg) ||
+      // A Symbol primitive is never callable. Keep this in the same
+      // compile-time guard as the #3573 literal cases so standalone does not
+      // fall through to the host Set_forEach/Map_forEach import. (#5091)
+      (ctx.checker.getTypeAtLocation(cbArg).flags & ts.TypeFlags.ESSymbolLike) !== 0 ||
       (ts.isIdentifier(cbArg) && cbArg.text === "undefined" && !fctx.localMap.has("undefined"));
     if (!staticNonCallable) return undefined;
     // Evaluate the receiver for its side effects first (this native path only

--- a/tests/issue-5091-set-foreach-symbol-callback.test.ts
+++ b/tests/issue-5091-set-foreach-symbol-callback.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+const EXACT_ROW = "built-ins/Set/prototype/forEach/callback-not-callable-symbol.js";
+
+async function runControl(target: "host" | "standalone"): Promise<{ result: number; setForEachImports: number }> {
+  const source = `
+    export function test(): number {
+      const set = new Set([1]);
+      try {
+        set.forEach(Symbol());
+        return 0;
+      } catch (error) {
+        let sum = 0;
+        set.forEach((value) => {
+          sum += value;
+        });
+        return sum === 1 ? 1 : 2;
+      }
+    }
+  `;
+  const options = target === "standalone" ? { target: "standalone" as const, nativeStrings: true } : {};
+  const compiled = await compile(source, {
+    fileName: "issue-5091-set-foreach-symbol.ts",
+    skipSemanticDiagnostics: true,
+    ...options,
+  });
+  expect(compiled.success, compiled.errors?.map((error) => error.message).join("\n") ?? "").toBe(true);
+  if (!compiled.success) return { result: -1, setForEachImports: -1 };
+
+  const module = await WebAssembly.compile(compiled.binary);
+  const setForEachImports = WebAssembly.Module.imports(module).filter(
+    (entry) => entry.module === "env" && entry.name === "Set_forEach",
+  ).length;
+  const imports = target === "host" ? buildImports(compiled.imports, undefined, compiled.stringPool) : {};
+  const instance = await WebAssembly.instantiate(module, imports);
+  imports.setInstance?.(instance);
+  const result = (instance.exports as { test: () => number }).test();
+  return { result, setForEachImports };
+}
+
+describe("#5091 Set.prototype.forEach(Symbol()) callback guard", () => {
+  it("passes the exact Test262 row in the host lane", { timeout: 180_000 }, async () => {
+    const outcome = await runTest262File(resolve("test262/test", EXACT_ROW), "issue-5091-host", 120_000);
+    expect(outcome.status, outcome.error ?? outcome.reason).toBe("pass");
+  });
+
+  it("passes the exact Test262 row in standalone", { timeout: 180_000 }, async () => {
+    const outcome = await runTest262File(
+      resolve("test262/test", EXACT_ROW),
+      "issue-5091-standalone",
+      120_000,
+      "standalone",
+    );
+    expect(outcome.status, outcome.error ?? outcome.reason).toBe("pass");
+  });
+
+  it("throws natively without a Set_forEach host import in standalone", async () => {
+    const outcome = await runControl("standalone");
+    expect(outcome).toEqual({ result: 1, setForEachImports: 0 });
+  });
+
+  it("preserves the host Set.forEach TypeError behavior", async () => {
+    const outcome = await runControl("host");
+    expect(outcome.result).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

- classify statically known `Symbol` callbacks as non-callable in native `Set.prototype.forEach` and `Map.prototype.forEach` lowering
- emit the existing catchable `TypeError` in standalone mode instead of leaking a `Set_forEach` or `Map_forEach` host import
- preserve closure callback behavior and route classification through the repository type oracle
- track the implementation plan, evidence, and handoff in `plan/issues/5091-es2015-set-foreach-symbol-callback.md`

Validation:

- exact host row: 1/1 passed
- exact standalone row: 1/1 passed (baseline 0/1 with one compile error)
- six-row host and standalone control cohorts: 6/6 passed in each lane
- focused regression coverage: 4/4 passed
- TypeScript 7, Biome, Prettier, diff checks, oracle/coercion ratchets, numeric-local parity, and issue integrity passed

Tracking: `plan/issues/5091-es2015-set-foreach-symbol-callback.md`.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
