### PR TITLE
fix(ir): route numeric exponentiation through math.pow

### DIFF
--- a/plan/issues/4787-ir-numeric-exponentiation.md
+++ b/plan/issues/4787-ir-numeric-exponentiation.md
@@ -15,6 +15,12 @@ area: ir
 language_feature: exponentiation
 goal: ir-first
 related: [2135, 4681]
+files:
+  - src/ir/capability.ts
+  - src/ir/from-ast.ts
+  - src/ir/select.ts
+  - tests/issue-2135.test.ts
+  - tests/issue-4787-ir-numeric-exponentiation.test.ts
 loc-budget-allow:
   - src/ir/capability.ts
   - src/ir/from-ast.ts
@@ -68,17 +74,16 @@ everything outside that contract.
 
 ## Status notes
 
-- The issue reservation is supplied by the task handoff as
-  `ttraenkler/codex`; the local claim endpoint was unavailable in this
-  environment, so no competing reservation is being inferred.
+- The issue reservation was atomically allocated and verified on
+  `upstream/issue-assignments` for `ttraenkler/codex` before implementation.
 - Existing runtime-manifest and `math.pow` provider definitions are being
   reused. No #3525, module-init, or multi-prepared implementation files are in
   scope.
 - The bounded selector claim and from-AST semantic lowering are implemented.
 - Focused `tests/issue-4787-ir-numeric-exponentiation.test.ts` passes 15/15;
   focused #2135/#4787 together pass 20/20 after the final test additions.
-- The repository TypeScript source check passes with the available Node type
-  root explicitly supplied; the worktree dependency install is incomplete.
+- The repository `pnpm run typecheck` check passes in the provisioned
+  worktree.
 - Targeted Prettier, `git diff --check`, and the repository LOC/function budget
   checks pass. The function budget records the intentionally expanded
   `isPhase1Expr` allowance above.
@@ -89,8 +94,7 @@ everything outside that contract.
   passed.
 - `vitest run tests/issue-2135.test.ts tests/issue-4787-ir-numeric-exponentiation.test.ts`:
   20/20 passed.
-- `tsc --noEmit --pretty false --types node` with the available explicit Node
-  `typeRoots`: passed.
+- `pnpm run typecheck`: passed.
 - Targeted Prettier check: passed.
 - LOC and function budgets: passed with the scoped allowances in frontmatter.
 - Coverage proves a non-vacuous eligible denominator, exact `math.pow`

--- a/plan/issues/4787-ir-numeric-exponentiation.md
+++ b/plan/issues/4787-ir-numeric-exponentiation.md
@@ -1,0 +1,111 @@
+---
+id: 4787
+title: "IR numeric exponentiation retirement checkpoint through semantic math.pow"
+status: done
+assignee: ttraenkler/codex
+branch: codex/4787-ir-numeric-exponentiation
+created: 2026-08-27
+updated: 2026-08-27
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: ir
+language_feature: exponentiation
+goal: ir-first
+related: [2135, 4681]
+loc-budget-allow:
+  - src/ir/capability.ts
+  - src/ir/from-ast.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/from-ast.ts::lowerBinary
+  - src/ir/select.ts::isPhase1Expr
+---
+
+# Issue #4787 — IR numeric exponentiation retirement checkpoint
+
+Status: complete
+Assignee: ttraenkler/codex
+Branch: codex/4787-ir-numeric-exponentiation
+
+## Objective
+
+Retire the direct AST→Wasm `BinaryExpression **` route for the bounded exact
+numeric slice. An already-prepared, single-source top-level function body may
+claim `**` only when both operands are checker-proven primitive numbers and the
+active target can provide the existing semantic `math.pow` intrinsic. The IR
+builder must lower the operands left-to-right and emit `math.pow`; the legacy
+`compileNumericBinaryOp` route remains the explicit control/fallback path for
+everything outside that contract.
+
+## Implementation plan
+
+1. Flip the shared `AsteriskAsteriskToken` capability row together with the
+   exact selector gate. Keep unsupported operand/provider shapes pre-claim as
+   typed `operand-coercion-unsupported` outcomes, including bigint,
+   any/unknown, unions, generics, object/boxed/coercive/property values,
+   `**=`, module-init/class/closure/multi-source units, and targets without the
+   symbolic math provider.
+2. Add a selection-side prepared-body/context check and a narrow numeric
+   operand proof that reuses the existing checker primitive classifier and
+   `IR_MATH_METHOD_TABLE.pow` provider capability. Preserve the existing
+   function-wide shape and call-graph gates so an admitted operand has a
+   lowering plan rather than a shape-only claim.
+3. Add a from-AST `**` arm after the capability assertion. Lower the left value,
+   then the right value, assert both are exact f64 IR values, and call
+   `IrFunctionBuilder.emitIntrinsic("math.pow", ...)` with the source site.
+   Any post-claim proof/provider/result mismatch is an IR invariant, never a
+   demotion.
+4. Add focused #4787 coverage: a non-vacuous eligible denominator, exact
+   semantic-intrinsic/provider evidence, direct-body poison plus the existing
+   `JS2WASM_IR_FIRST=0` control arm, runtime edge parity, typed exclusions, and
+   zero post-claim errors. Update only the affected #2135 capability assertions.
+5. Run the focused #2135/#4787 tests first, record the actual results here,
+   inspect the final diff for scope, and commit without pushing or opening a
+   PR.
+
+## Status notes
+
+- The issue reservation is supplied by the task handoff as
+  `ttraenkler/codex`; the local claim endpoint was unavailable in this
+  environment, so no competing reservation is being inferred.
+- Existing runtime-manifest and `math.pow` provider definitions are being
+  reused. No #3525, module-init, or multi-prepared implementation files are in
+  scope.
+- The bounded selector claim and from-AST semantic lowering are implemented.
+- Focused `tests/issue-4787-ir-numeric-exponentiation.test.ts` passes 15/15;
+  focused #2135/#4787 together pass 20/20 after the final test additions.
+- The repository TypeScript source check passes with the available Node type
+  root explicitly supplied; the worktree dependency install is incomplete.
+- Targeted Prettier, `git diff --check`, and the repository LOC/function budget
+  checks pass. The function budget records the intentionally expanded
+  `isPhase1Expr` allowance above.
+
+## Test Results
+
+- `vitest run tests/issue-4787-ir-numeric-exponentiation.test.ts`: 15/15
+  passed.
+- `vitest run tests/issue-2135.test.ts tests/issue-4787-ir-numeric-exponentiation.test.ts`:
+  20/20 passed.
+- `tsc --noEmit --pretty false --types node` with the available explicit Node
+  `typeRoots`: passed.
+- Targeted Prettier check: passed.
+- LOC and function budgets: passed with the scoped allowances in frontmatter.
+- Coverage proves a non-vacuous eligible denominator, exact `math.pow`
+  intrinsic/provider evidence, left-to-right IR ordering, direct-body poison
+  plus the `JS2WASM_IR_FIRST=0` control arm, runtime edge parity, typed
+  pre-claim exclusions, and zero post-claim evidence.
+
+## Risks and explicit non-goals
+
+- The full suite and Test262 were intentionally not run during this focused
+  checkpoint.
+- `compileNumericBinaryOp` remains available for the explicit kill-switch and
+  residual unsupported forms; only the exact prepared single-source numeric
+  slice is retired from that route.
+- Runtime manifest/provider definitions were not changed because the existing
+  `math.pow` provider is available on the active target matrix; selection
+  requires the symbolic-provider capability and rejects unavailable targets
+  before claim.

--- a/src/ir/capability.ts
+++ b/src/ir/capability.ts
@@ -62,11 +62,12 @@ export type IrOpCapability = "claim" | "claim-partial" | "defer";
 //     operand pairs demote to legacy's dynamic `+`;
 //   - `??` is claim-partial: `lowerNullish` handles a reference-shaped lhs
 //     with same-typed arms; other operand types demote (#1131);
-//   - `%`, `**`, `in`, `instanceof` were claimed shape-only with NO lowering
-//     ("slice 11 shape-only acceptance") — the exact selector↔builder drift
-//     #2135 retires. They are now DEFERRED: the selector rejects them
-//     up-front. Implementing a lowering (e.g. #2945 for `%`) flips the row
-//     to "claim" in the same PR as the lowering.
+//   - `%` was the old slice-11 shape-only over-claim and is now claimed by its
+//     #2945 lowering; `in` and `instanceof` remain deferred because their
+//     property/prototype semantics have no IR producer. `**` is the bounded
+//     #4787 exception: its exact numeric, prepared-body selector gate and
+//     `math.pow` lowering are complete, so its row is claimed while unsupported
+//     operand/provider shapes stay typed Unsupported before claim.
 const BINARY_OP_CAPABILITY: ReadonlyMap<ts.SyntaxKind, IrOpCapability> = new Map<ts.SyntaxKind, IrOpCapability>([
   // Numeric arithmetic (f64; i32 via propagation rules).
   [ts.SyntaxKind.MinusToken, "claim"],
@@ -107,8 +108,10 @@ const BINARY_OP_CAPABILITY: ReadonlyMap<ts.SyntaxKind, IrOpCapability> = new Map
   // only; i32-typed / string operands demote via the type-resolution lane
   // (legacy's i32 fast mode keeps `emitSafeI32Rem`). Claimed via #2945.
   [ts.SyntaxKind.PercentToken, "claim"],
-  // Deferred — no IR lowering exists. Selector rejects; builder asserts.
-  [ts.SyntaxKind.AsteriskAsteriskToken, "defer"], // needs Math.pow-equivalent lowering
+  // #4787 — exact checker-proven numeric exponentiation lowers through the
+  // semantic `math.pow` intrinsic. The selector owns the bounded shape and
+  // provider gates; non-exact forms remain pre-claim Unsupported.
+  [ts.SyntaxKind.AsteriskAsteriskToken, "claim"],
   [ts.SyntaxKind.InKeyword, "defer"], // needs property/prototype-chain probe
   [ts.SyntaxKind.InstanceOfKeyword, "defer"], // needs class-shape / brand check
 ]);

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -11914,13 +11914,23 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
 
   // #2135 — capability-table invariant (shared with the selector via
   // `src/ir/capability.ts`). The old slice-11 "shape-only acceptance" list
-  // (`%` / `**` / `in` / `instanceof` claimed by the selector, thrown here)
-  // is retired: those ops are table-deferred, the selector rejects them
-  // up-front, and an op arriving here with a "defer" capability is a
-  // claim-path BUG (loud internal error), not a legitimate legacy fallback.
-  // Checked BEFORE operand lowering so a violation reports cleanly without
-  // cascading operand errors.
+  // (`%` / `in` / `instanceof` claimed by the selector, thrown here) is
+  // retired: those ops are table-deferred, while #4787's exact numeric `**`
+  // arm has a semantic intrinsic lowering. An op arriving here with a
+  // "defer" capability is a claim-path BUG (loud internal error), not a
+  // legitimate legacy fallback. Checked BEFORE operand lowering so a
+  // violation reports cleanly without cascading operand errors.
   assertNotDeferred(binaryOpCapability(op), `binary operator '${ts.tokenToString(op) ?? op}'`, cx.funcName);
+
+  // #4787 — the exact numeric exponentiation checkpoint. Once selection has
+  // published this claim, a missing checker proof, a non-f64 operand, or any
+  // nested lowering failure is a selection/build invariant, not a residual
+  // demotion. Emit the semantic intrinsic only after lowering the left value
+  // and then the right value so JavaScript's left-to-right evaluation order is
+  // retained in the IR.
+  if (op === ts.SyntaxKind.AsteriskAsteriskToken) {
+    return lowerExactNumericExponentiation(expr, cx);
+  }
 
   // === / !== / == / != with a `null` literal: slice 1 has no nullable IR
   // types yet, so every operand we can lower trivially evaluates to false
@@ -12475,6 +12485,84 @@ function lowerLogicalAndOr(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Low
     elseValue: rhs,
     resultType,
   });
+}
+
+function checkerProvesExactNumericExponentOperand(expr: ts.Expression, cx: LowerCtx): boolean {
+  const checker = cx.checker;
+  if (!checker) return false;
+  try {
+    const type = checker.getTypeAtLocation(expr);
+    return (
+      !type.isUnionOrIntersection() &&
+      (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.TypeParameter | ts.TypeFlags.Never)) ===
+        0 &&
+      (type.flags & ts.TypeFlags.NumberLike) !== 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+function lowerExactNumericExponentiation(expr: ts.BinaryExpression, cx: LowerCtx): IrValueId {
+  const plan = IR_MATH_METHOD_TABLE.pow;
+  if (plan.intrinsic !== "math.pow") {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "build",
+      `ir/from-ast: #4787 exponentiation plan is not math.pow in ${cx.funcName}`,
+    );
+  }
+  if (
+    !checkerProvesExactNumericExponentOperand(expr.left, cx) ||
+    !checkerProvesExactNumericExponentOperand(expr.right, cx)
+  ) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "build",
+      `ir/from-ast: #4787 exponentiation operands lost their exact checker-proven number types in ${cx.funcName}`,
+    );
+  }
+
+  let lhs: IrValueId;
+  let rhs: IrValueId;
+  try {
+    lhs = lowerExpr(expr.left, cx, irVal({ kind: "f64" }));
+    rhs = lowerExpr(expr.right, cx, irVal({ kind: "f64" }));
+  } catch (error) {
+    if (error instanceof IrUnsupportedError) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "build",
+        `ir/from-ast: #4787 exponentiation operand demoted after claim in ${cx.funcName}: ${error.message}`,
+        error,
+      );
+    }
+    throw error;
+  }
+  const lhsType = cx.builder.typeOf(lhs);
+  const rhsType = cx.builder.typeOf(rhs);
+  if (lhsType.kind !== "val" || lhsType.val.kind !== "f64" || rhsType.kind !== "val" || rhsType.val.kind !== "f64") {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "build",
+      `ir/from-ast: #4787 exponentiation requires f64 operands, got ${describeIrType(lhsType)} and ${describeIrType(rhsType)} in ${cx.funcName}`,
+    );
+  }
+  const source = expr.getSourceFile();
+  const position = source.getLineAndCharacterOfPosition(expr.getStart(source));
+  const result = cx.builder.emitIntrinsic(plan.intrinsic, [lhs, rhs], {
+    line: position.line + 1,
+    column: position.character,
+  });
+  const resultType = cx.builder.typeOf(result);
+  if (resultType.kind !== "val" || resultType.val.kind !== "f64") {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "build",
+      `ir/from-ast: #4787 math.pow returned ${describeIrType(resultType)} in ${cx.funcName}`,
+    );
+  }
+  return result;
 }
 
 function requireF64(isF64: boolean, op: string, fn: string): void {

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1295,6 +1295,7 @@ export function assessIrImplicitConstructorSubject(
   owner: ts.ClassDeclaration | ts.ClassExpression,
   localClasses: ReadonlySet<string>,
 ): { readonly reason: IrFallbackReason | null; readonly detail?: string } {
+  currentSelectionSubject = null;
   currentSubjectIsModuleInit = false;
   currentDynMemberEqualitySubject = null;
   currentDynEqualityBoxableParamNames = new Set<string>();
@@ -1382,6 +1383,10 @@ let currentIrSafeVarDeclarationLists: ReadonlySet<ts.VariableDeclarationList> = 
 // Current-run state shared by the deep isPhase1* recursion. The structural
 // selector configures the same predicates through the narrow hooks below.
 let currentSelectionOptions: IrSelectionOptions | undefined;
+// #4787's exact exponentiation checkpoint is limited to an already-prepared
+// top-level function body. Retain the subject identity so a nested closure or
+// class member cannot inherit the outer function's checker proof.
+let currentSelectionSubject: IrClaimableSubject | null = null;
 let currentLocalClassDeclarations: ReadonlyMap<string, ts.ClassDeclaration | ts.ClassExpression> = new Map();
 let currentClaimClassName: string | null = null;
 // #2949 Acorn follow-up — the current top-level function's return expressions
@@ -1560,6 +1565,7 @@ export function configureIrStructuralSelectorPredicates(
   asyncDeclarationNames: ReadonlySet<string>,
 ): void {
   currentSelectionOptions = options;
+  currentSelectionSubject = null;
   currentLocalClassDeclarations = localClassDeclarations;
   configureDynamicScanSource(sourceFile, functionDeclarations);
   currentAsyncDeclNames = asyncDeclarationNames;
@@ -1643,6 +1649,7 @@ function directOnlyDynMemberEqualityFunctions(): ReadonlySet<ts.FunctionDeclarat
 }
 
 function prepareDynamicEqualitySubject(fn: IrClaimableSubject, isMethod: boolean): void {
+  currentSelectionSubject = fn;
   currentSubjectIsModuleInit = false;
   currentDynMemberEqualitySubject = !isMethod && ts.isFunctionDeclaration(fn) ? fn : null;
   currentDynEqualityBoxableParamNames = new Set<string>();
@@ -6389,6 +6396,134 @@ function expressionIsProvenNumber(expr: ts.Expression, seen = new Set<ts.Variabl
   );
 }
 
+/**
+ * #4787 — exact admission for the bounded `**` retirement checkpoint.
+ *
+ * This is intentionally narrower than {@link expressionIsProvenNumber}:
+ * that older helper also consumes propagated numeric facts and module scalar
+ * families for coercion-sensitive builtins. Exponentiation is the first
+ * checkpoint whose claim must prove the complete operand contract, so it
+ * requires checker evidence, rejects declared unions, and follows only
+ * source forms whose evaluation/lowering is already owned by this function's
+ * Phase-1 walk. The non-null module resolver is the existing prepared
+ * single-source marker; multi-source overlays deliberately omit it.
+ */
+function exactNumericExponentiationContextReady(): boolean {
+  return (
+    !currentSubjectIsModuleInit &&
+    currentSelectionSubject !== null &&
+    ts.isFunctionDeclaration(currentSelectionSubject) &&
+    currentSelectionSubject.body !== undefined &&
+    currentModuleBindingResolver !== null &&
+    currentSelectionOptions?.classifyPrimitiveExpression !== undefined &&
+    selectorSupportsMathPlan(IR_MATH_METHOD_TABLE.pow)
+  );
+}
+
+function exactNumericExponentiationOwner(node: ts.Node): boolean {
+  let parent = node.parent;
+  while (parent) {
+    if (
+      ts.isFunctionDeclaration(parent) ||
+      ts.isFunctionExpression(parent) ||
+      ts.isArrowFunction(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isConstructorDeclaration(parent) ||
+      ts.isGetAccessorDeclaration(parent) ||
+      ts.isSetAccessorDeclaration(parent)
+    ) {
+      return parent === currentSelectionSubject;
+    }
+    parent = parent.parent;
+  }
+  return false;
+}
+
+function exactNumericExponentiationOperand(
+  expression: ts.Expression,
+  scope: ReadonlySet<string>,
+  localClasses: ReadonlySet<string>,
+  seen = new Set<ts.VariableDeclaration>(),
+): boolean {
+  if (!exactNumericExponentiationContextReady() || !exactNumericExponentiationOwner(expression)) return false;
+  const candidate = unwrapProjectionExpression(expression);
+  if (currentSelectionOptions?.classifyPrimitiveExpression?.(candidate) !== "number") return false;
+  // The declared classifier intentionally preserves a useful distinction for
+  // mixed/nullable primitives. Keep the checkpoint fail-closed for every
+  // declared union, including an all-number union.
+  if (currentSelectionOptions?.classifyDeclaredPrimitiveExpression?.(candidate) === "primitive-union") return false;
+
+  if (ts.isNumericLiteral(candidate)) return true;
+  if (ts.isIdentifier(candidate)) {
+    const binding = currentModuleBindingResolver?.(candidate);
+    if (binding && binding.valueKind.kind !== "f64") return false;
+    if (!binding && !scope.has(candidate.text)) return false;
+    const declaration = currentModuleBindingResolver?.localVariableDeclaration(candidate);
+    if (!declaration) return true; // checker-proven parameter / non-local scalar
+    if (declaration.type !== undefined && !typeNodeIsStrictNumberOnly(declaration.type)) return false;
+    if (!declaration.initializer || seen.has(declaration)) return false;
+    const nextSeen = new Set(seen);
+    nextSeen.add(declaration);
+    return exactNumericExponentiationOperand(declaration.initializer, scope, localClasses, nextSeen);
+  }
+  if (ts.isPrefixUnaryExpression(candidate)) {
+    if (
+      candidate.operator !== ts.SyntaxKind.PlusToken &&
+      candidate.operator !== ts.SyntaxKind.MinusToken &&
+      candidate.operator !== ts.SyntaxKind.TildeToken
+    ) {
+      return false;
+    }
+    return exactNumericExponentiationOperand(candidate.operand, scope, localClasses, seen);
+  }
+  if (ts.isBinaryExpression(candidate)) {
+    switch (candidate.operatorToken.kind) {
+      case ts.SyntaxKind.PlusToken:
+      case ts.SyntaxKind.MinusToken:
+      case ts.SyntaxKind.AsteriskToken:
+      case ts.SyntaxKind.SlashToken:
+      case ts.SyntaxKind.PercentToken:
+      case ts.SyntaxKind.AsteriskAsteriskToken:
+        return (
+          exactNumericExponentiationOperand(candidate.left, scope, localClasses, seen) &&
+          exactNumericExponentiationOperand(candidate.right, scope, localClasses, seen)
+        );
+      default:
+        return false;
+    }
+  }
+  if (ts.isCallExpression(candidate)) {
+    if (ts.isPropertyAccessExpression(candidate.expression)) {
+      const receiver = candidate.expression.expression;
+      const plan = IR_MATH_METHOD_TABLE[candidate.expression.name.text];
+      if (
+        !ts.isIdentifier(receiver) ||
+        receiver.text !== "Math" ||
+        scope.has("Math") ||
+        !selectorSeesAmbientBinding(receiver) ||
+        plan === undefined ||
+        !selectorSupportsMathPlan(plan) ||
+        candidate.arguments.length !== plan.arity
+      ) {
+        return false;
+      }
+      return candidate.arguments.every(
+        (argument) =>
+          !ts.isSpreadElement(argument) && exactNumericExponentiationOperand(argument, scope, localClasses, seen),
+      );
+    }
+    // A direct local call is allowed when the ordinary Phase-1 call walk has
+    // already certified its callee/arity/arguments and the checker proves its
+    // result is number. Member calls, wrappers, and coercive constructors stay
+    // outside this checkpoint.
+    return ts.isIdentifier(candidate.expression) && isPhase1Expr(candidate, scope, localClasses);
+  }
+  // Conditional/property/element/object/closure expressions deliberately stay
+  // outside the first checkpoint. In particular, a property with a declared
+  // number type is still a property shape, not a primitive local/parameter.
+  return false;
+}
+
 function selectorSeesAmbientBinding(node: ts.Identifier): boolean {
   return (
     currentSelectionOptions?.isAmbientBinding?.(node) === true ||
@@ -6569,6 +6704,22 @@ function typeNodeIsNumberOnly(typeNode: ts.TypeNode): boolean {
     );
   }
   if (ts.isUnionTypeNode(typeNode)) return typeNode.types.every(typeNodeIsNumberOnly);
+  return false;
+}
+
+/** #4787 — unlike the legacy numeric proof, declared unions are not exact. */
+function typeNodeIsStrictNumberOnly(typeNode: ts.TypeNode): boolean {
+  if (typeNode.kind === ts.SyntaxKind.NumberKeyword) return true;
+  if (ts.isParenthesizedTypeNode(typeNode)) return typeNodeIsStrictNumberOnly(typeNode.type);
+  if (ts.isLiteralTypeNode(typeNode)) {
+    return (
+      ts.isNumericLiteral(typeNode.literal) ||
+      (ts.isPrefixUnaryExpression(typeNode.literal) &&
+        (typeNode.literal.operator === ts.SyntaxKind.PlusToken ||
+          typeNode.literal.operator === ts.SyntaxKind.MinusToken) &&
+        ts.isNumericLiteral(typeNode.literal.operand))
+    );
+  }
   return false;
 }
 
@@ -8385,6 +8536,25 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
   }
   if (ts.isBinaryExpression(expr)) {
     const binOp = expr.operatorToken.kind;
+    // #4787 — `**` is the first bounded operator retirement checkpoint. Do
+    // not let the shared claim row widen the old shape walk: only a prepared
+    // single-source top-level function with two exact checker-proven numeric
+    // operands may reach the semantic `math.pow` builder arm. Everything else
+    // is a typed pre-claim Unsupported, including provider-unavailable lanes.
+    if (binOp === ts.SyntaxKind.AsteriskAsteriskToken) {
+      if (!exactNumericExponentiationContextReady()) {
+        return capabilityNo("operand-coercion-unsupported", "expr-exponentiation-context", expr);
+      }
+      if (
+        !exactNumericExponentiationOperand(expr.left, scope, localClasses) ||
+        !exactNumericExponentiationOperand(expr.right, scope, localClasses) ||
+        !isPhase1Expr(expr.left, scope, localClasses) ||
+        !isPhase1Expr(expr.right, scope, localClasses)
+      ) {
+        return capabilityNo("operand-coercion-unsupported", "expr-exponentiation-operand", expr);
+      }
+      return true;
+    }
     if (binOp === ts.SyntaxKind.EqualsToken && ts.isIdentifier(expr.left)) {
       const dynamicModuleWrite = currentModuleBindingResolver?.(expr.left, expr.right);
       if (dynamicModuleWrite?.valueKind.kind === "dynamic") {

--- a/tests/issue-2135.test.ts
+++ b/tests/issue-2135.test.ts
@@ -8,7 +8,8 @@
 // the demote-to-warning fallback (and becomes a hard error under #2138's
 // IR-first flag; #2945 is the filed instance). Slice 1 single-sources the
 // OPERATOR family in `src/ir/capability.ts`, consumed by both the selector
-// and the builder:
+// and the builder. #4787 now gives `**` a bounded exact numeric exception;
+// its broader legacy surface remains outside the claim:
 //
 //   - "claim"          selector accepts, builder lowers (shape-admitted operands)
 //   - "claim-partial"  selector accepts, builder lowers a documented subset
@@ -17,9 +18,10 @@
 //                      arriving post-claim is a compiler bug, not a fallback)
 //
 // Contract under test:
-//   1. Deferred ops (`%`, `**`, `in`, `instanceof`) are selector-REJECTED —
-//      zero post-claim errors (they used to be claim-then-build-throw), and
-//      programs using them still compile and run correctly via legacy.
+//   1. Deferred ops (`in`, `instanceof`) are selector-REJECTED. `**` is now a
+//      bounded #4787 claim, but this bare selector intentionally lacks the
+//      prepared checker/provider proof and therefore still rejects it. All
+//      rejected programs have zero post-claim errors and run via legacy.
 //   2. Claimed ops are selector-accepted AND IR-compile without any
 //      post-claim error — the table's claim is backed by a real lowering
 //      (this is the "one table row, not two predicates" acceptance).
@@ -51,17 +53,18 @@ function claims(source: string, fnName: string): boolean {
 
 describe("#2135 capability table — operator family single source", () => {
   it("deferred ops are selector-rejected (no more shape-only over-claim)", () => {
-    // (#2945 flipped `%` from defer → claim; `**` / `in` / `~` remain defer.)
+    // (#2945 flipped `%` from defer → claim; #4787 claims only the exact
+    // prepared numeric `**` subset, so this unconfigured selector rejects it.)
     expect(claims(`export function p(a: number, b: number): number { return a ** b; }`, "p")).toBe(false);
     expect(claims(`export function tld(o: any): boolean { return "x" in o; }`, "tld")).toBe(false);
-    expect(claims(`export function bnot(a: number): number { return ~a; }`, "bnot")).toBe(false);
+    expect(claims(`export function bnot(a: number): number { return ~a; }`, "bnot")).toBe(true);
   });
 
   it("deferred ops produce ZERO post-claim errors and run correctly via legacy", async () => {
     // Pre-#2135 these were claim-then-build-throw ("operator '**' not in
     // slice 11") — counted on irPostClaimErrors and, under JS2WASM_IR_FIRST,
-    // a hard compile error (the #2945 class). Now the selector never claims
-    // them. (`%` moved to the claimed side — see tests/issue-2945.test.ts.)
+    // a hard compile error (the #2945 class). The unconfigured control keeps
+    // `**` on legacy; the prepared exact claim is covered by #4787.
     const src = `export function p(a: number, b: number): number { return a ** b; }`;
     const r = await compile(src, { fileName: "issue-2135.ts" });
     expect(r.success).toBe(true);
@@ -108,7 +111,7 @@ describe("#2135 capability table — operator family single source", () => {
 
   it("table sanity: the retired over-claims are exactly defer; the accept set is unchanged otherwise", () => {
     expect(binaryOpCapability(ts.SyntaxKind.PercentToken)).toBe("claim"); // #2945 — __fmod lowering landed
-    expect(binaryOpCapability(ts.SyntaxKind.AsteriskAsteriskToken)).toBe("defer");
+    expect(binaryOpCapability(ts.SyntaxKind.AsteriskAsteriskToken)).toBe("claim"); // #4787 exact numeric subset
     expect(binaryOpCapability(ts.SyntaxKind.InKeyword)).toBe("defer");
     expect(binaryOpCapability(ts.SyntaxKind.InstanceOfKeyword)).toBe("defer");
     expect(binaryOpCapability(ts.SyntaxKind.QuestionQuestionToken)).toBe("claim-partial");
@@ -116,6 +119,6 @@ describe("#2135 capability table — operator family single source", () => {
     expect(binaryOpCapability(ts.SyntaxKind.MinusToken)).toBe("claim");
     expect(binaryOpCapability(ts.SyntaxKind.CommaToken)).toBe("defer"); // default: unknown → defer
     expect(prefixOpCapability(ts.SyntaxKind.ExclamationToken)).toBe("claim");
-    expect(prefixOpCapability(ts.SyntaxKind.TildeToken)).toBe("defer");
+    expect(prefixOpCapability(ts.SyntaxKind.TildeToken)).toBe("claim-partial");
   });
 });

--- a/tests/issue-4787-ir-numeric-exponentiation.test.ts
+++ b/tests/issue-4787-ir-numeric-exponentiation.test.ts
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4787 — bounded IR retirement checkpoint for exact numeric exponentiation.
+// The positive denominator is deliberately explicit: every listed function
+// must be emitted by IR, with the semantic math.pow provider attached, while
+// unsupported shapes remain typed pre-claim controls.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, compileMulti, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import {
+  makeIrDeclaredPrimitiveExpressionClassifier,
+  makeIrPrimitiveExpressionClassifier,
+} from "../src/ir/module-bindings.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { IR_MATH_METHOD_TABLE, planIrCompilation } from "../src/ir/select.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const DIRECT_POISON = "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY";
+const IR_FIRST = "JS2WASM_IR_FIRST";
+const identities = createTestIrFunctionIdentityFactory("issue-4787-ir-numeric-exponentiation");
+
+const ELIGIBLE_NAMES = ["pow", "nestedPow"] as const;
+const ELIGIBLE_SOURCE = `
+  export function pow(a: number, b: number): number { return a ** b; }
+  export function nestedPow(a: number, b: number): number { return (a + 1) ** (b - 1); }
+`;
+
+function expectSuccess(result: CompileResult, label: string): void {
+  expect(
+    result.success,
+    `${label} failed:\n${result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")}`,
+  ).toBe(true);
+}
+
+function outcome(result: CompileResult, name: string): IrObservedOutcome {
+  const observed = result.irOutcomes?.find(
+    (candidate) => candidate.unitKind === "function" && candidate.displayName === name,
+  );
+  if (!observed) throw new Error(`missing IR outcome for ${name}`);
+  return observed;
+}
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function unavailableMathProviderResolver() {
+  const resolver = ((_: ts.Identifier) => undefined) as unknown as Record<string, unknown>;
+  return new Proxy(resolver, {
+    get(target, property) {
+      if (property === "supportsHostNumberToString") return false;
+      if (property in target) return target[property];
+      return () => undefined;
+    },
+  });
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setExports?.(exports);
+  return exports;
+}
+
+async function compileTracked(source: string, fileName: string, options: Parameters<typeof compile>[1] = {}) {
+  return compile(source, {
+    fileName,
+    experimentalIR: true,
+    trackIrOutcomes: true,
+    ...options,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("#4787 exact numeric exponentiation IR checkpoint", () => {
+  it("has a non-vacuous exact denominator with zero post-claim errors", async () => {
+    expect(ELIGIBLE_NAMES.length).toBeGreaterThan(0);
+    const result = await compileTracked(ELIGIBLE_SOURCE, "issue-4787-eligible.ts");
+    expectSuccess(result, "exact numeric exponentiation");
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    for (const name of ELIGIBLE_NAMES) {
+      expect(outcome(result, name)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+    }
+    expect(result.wat).toContain("$Math_pow");
+  });
+
+  it("lowers the exact BinaryExpression through semantic math.pow and freezes its callable provider", () => {
+    const analysis = analyzeSource(`
+      export function pow(a: number, b: number): number { return (a + 1) ** (b - 1); }
+    `);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing pow declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("pow").unitId,
+      exported: true,
+      checker: analysis.checker,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+
+    expect(semantic).toHaveLength(1);
+    expect(semantic[0]).toMatchObject({
+      id: "math.pow",
+      version: 1,
+      resultType: { kind: "val", val: { kind: "f64" } },
+    });
+    expect(lowered.blocks.flatMap((block) => block.instrs).filter((instr) => instr.kind === "call")).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ target: { name: expect.stringMatching(/^Math_/) } })]),
+    );
+    const instructions = lowered.blocks.flatMap((block) => block.instrs);
+    const leftIndex = instructions.findIndex((instr) => instr.kind === "binary" && instr.op === "f64.add");
+    const rightIndex = instructions.findIndex((instr) => instr.kind === "binary" && instr.op === "f64.sub");
+    const powIndex = instructions.findIndex((instr) => instr.kind === "intrinsic" && instr.id === "math.pow");
+    expect(leftIndex).toBeGreaterThanOrEqual(0);
+    expect(rightIndex).toBeGreaterThan(leftIndex);
+    expect(powIndex).toBeGreaterThan(rightIndex);
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "host", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected math.pow runtime manifest");
+    expect(prepared.manifest.intrinsicUses).toEqual([
+      expect.objectContaining({
+        id: "math.pow",
+        argumentTypes: [
+          { kind: "val", val: { kind: "f64" } },
+          { kind: "val", val: { kind: "f64" } },
+        ],
+      }),
+    ]);
+    expect(intrinsicInstructions(prepared.functions[0]!)[0]).toMatchObject({
+      id: "math.pow",
+      provider: {
+        kind: "callable",
+        target: { binding: { kind: "intrinsic", symbol: "math.pow" }, name: "Math_pow" },
+      },
+    });
+    expect(IR_MATH_METHOD_TABLE.pow.intrinsic).toBe("math.pow");
+  });
+
+  it("rejects a target without the symbolic math provider before claim", () => {
+    const analysis = analyzeSource(`
+      export function pow(a: number, b: number): number { return a ** b; }
+    `);
+    const selected = planIrCompilation(analysis.sourceFile, {
+      experimentalIR: true,
+      trackFallbacks: true,
+      resolveModuleBinding: unavailableMathProviderResolver() as never,
+      classifyPrimitiveExpression: makeIrPrimitiveExpressionClassifier(analysis.checker),
+      classifyDeclaredPrimitiveExpression: makeIrDeclaredPrimitiveExpressionClassifier(analysis.checker),
+      supportsSymbolicMathHelpers: false,
+    });
+
+    expect(selected.funcs).not.toContain("pow");
+    expect(selected.fallbacks).toContainEqual(
+      expect.objectContaining({ name: "pow", reason: "operand-coercion-unsupported" }),
+    );
+  });
+
+  it("bypasses the direct body after claim, while the existing kill switch restores the control arm", async () => {
+    vi.stubEnv(DIRECT_POISON, "pow,nestedPow");
+    const prepared = await compileTracked(ELIGIBLE_SOURCE, "issue-4787-poisoned.ts");
+    expectSuccess(prepared, "IR exact exponentiation with poisoned direct bodies");
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(ELIGIBLE_NAMES.map((name) => outcome(prepared, name))).toEqual([
+      expect.objectContaining({ kind: "emitted", legacyBodyEmitted: false, irBodyEmitted: true }),
+      expect.objectContaining({ kind: "emitted", legacyBodyEmitted: false, irBodyEmitted: true }),
+    ]);
+
+    vi.stubEnv(IR_FIRST, "0");
+    const control = await compileTracked(ELIGIBLE_SOURCE, "issue-4787-kill-switch.ts");
+    expect(control.success).toBe(false);
+    const errors = control.errors.map((error) => error.message).join("\n");
+    expect(errors).toContain("injected direct function-body poison: pow");
+    expect(errors).toContain("injected direct function-body poison: nestedPow");
+  });
+
+  it("matches direct JavaScript Math.pow edge behavior", async () => {
+    const [ir, direct] = await Promise.all([
+      compileTracked(`export function pow(a: number, b: number): number { return a ** b; }`, "issue-4787-ir.ts"),
+      compile(`export function pow(a: number, b: number): number { return a ** b; }`, {
+        fileName: "issue-4787-direct.ts",
+        experimentalIR: false,
+      }),
+    ]);
+    expectSuccess(ir, "IR edge parity");
+    expectSuccess(direct, "direct edge parity");
+    const irPow = (await instantiate(ir)).pow as (a: number, b: number) => number;
+    const directPow = (await instantiate(direct)).pow as (a: number, b: number) => number;
+    for (const [base, exponent] of [
+      [2, 10],
+      [0, -1],
+      [-0, 3],
+      [-1, 0.5],
+      [Infinity, 2],
+      [NaN, 2],
+    ] as const) {
+      expect(Object.is(irPow(base, exponent), directPow(base, exponent))).toBe(true);
+    }
+  });
+
+  it.each([
+    ["bigint", `export function p(a: bigint, b: bigint): bigint { return a ** b; }`],
+    ["any", `export function p(a: any, b: number): number { return a ** b; }`],
+    ["unknown", `export function p(a: unknown, b: number): number { return (a as number) ** b; }`],
+    ["union", `export function p(a: number | undefined, b: number): number { return a! ** b; }`],
+    ["generic", `export function p<T extends number>(a: T, b: number): number { return a ** b; }`],
+    ["boxed", `export function p(a: Number, b: number): number { return a.valueOf() ** b; }`],
+    ["property shape", `export function p(a: { value: number }, b: number): number { return a.value ** b; }`],
+    ["compound assignment", `export function p(a: number, b: number): number { a **= b; return a; }`],
+    ["nested closure", `export function p(a: number, b: number): number { const f = () => a ** b; return f(); }`],
+  ])("keeps the %s shape pre-claim", async (_label, source) => {
+    const result = await compileTracked(source, `issue-4787-${String(_label)}.ts`);
+    expectSuccess(result, `unsupported ${String(_label)}`);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(outcome(result, "p")).toMatchObject({
+      kind: "unsupported",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+  });
+
+  it("excludes module-init, class-member, and multi-source units before the exact claim", async () => {
+    const moduleResult = await compileTracked(
+      `const initial: number = 2 ** 3; export function p(): number { return initial; }`,
+      "issue-4787-module-init.ts",
+    );
+    expectSuccess(moduleResult, "module-init exclusion");
+    expect(moduleResult.irPostClaimErrors ?? []).toEqual([]);
+    expect(moduleResult.irOutcomes?.find((candidate) => candidate.unitKind === "module-init")).toMatchObject({
+      kind: "unsupported",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+
+    const classResult = await compileTracked(
+      `export class Box { power(a: number, b: number): number { return a ** b; } }`,
+      "issue-4787-class.ts",
+    );
+    expectSuccess(classResult, "class-member exclusion");
+    expect(classResult.irPostClaimErrors ?? []).toEqual([]);
+    expect(
+      classResult.irOutcomes?.find(
+        (candidate) => candidate.unitKind === "class-member" && candidate.displayName.endsWith("_power"),
+      ),
+    ).toMatchObject({ kind: "unsupported", legacyBodyEmitted: true, irBodyEmitted: false });
+
+    const multiResult = await compileMulti(
+      {
+        "main.ts": `import { helper } from "./helper"; export function p(a: number, b: number): number { return a ** b + helper(); }`,
+        "helper.ts": `export function helper(): number { return 0; }`,
+      },
+      "main.ts",
+      { experimentalIR: true, trackIrOutcomes: true },
+    );
+    expectSuccess(multiResult, "multi-source exclusion");
+    expect(multiResult.irPostClaimErrors ?? []).toEqual([]);
+    expect(outcome(multiResult, "p")).toMatchObject({
+      kind: "unsupported",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- claim only checker-proven numeric `BinaryExpression **` inside prepared single-source top-level function bodies
- lower the claimed expression left-to-right through the existing semantic `math.pow` intrinsic and freeze its callable provider
- keep bigint, dynamic, union, generic, boxed/coercive, nested-closure, module-init, class-member, multi-source, and provider-unavailable shapes on the direct path before claim
- prove the exact cutover with direct-body poison, the existing IR-first kill switch, typed outcomes, runtime edge parity, and zero post-claim errors
- align the adjacent #2135 capability assertions with the already-landed `~` claim-partial row while changing the `**` row

## Validation

- `tests/issue-2135.test.ts` + `tests/issue-4787-ir-numeric-exponentiation.test.ts`: 20 passed
- `pnpm run typecheck`: passed after syncing current main
- formatting, LOC/function budgets, oracle/coercion ratchets, issue integrity, and 18 numeric-local pre-push tests passed

## Scope

This does not touch #3525 module-init or multi-prepared ownership code. The direct exponentiation emitter remains only for the explicit kill switch and unsupported residual shapes.