### PR TITLE
fix(ir): render branded booleans in host-free console

### DIFF
--- a/plan/issues/5094-ir-host-free-boolean-console-rendering.md
+++ b/plan/issues/5094-ir-host-free-boolean-console-rendering.md
@@ -1,9 +1,9 @@
 ---
 id: 5094
 title: "IR: render branded booleans through the host-free standalone console sink"
-status: in-progress
+status: done
 created: 2026-08-27
-updated: 2026-08-27
+updated: 2026-08-28
 assignee: ttraenkler/codex
 branch: codex/5094-ir-host-free-boolean-console
 priority: high
@@ -88,9 +88,9 @@ builder; today only its branded-boolean carrier demotes.
    `legacyBodyEmitted: false`.
 5. Add negative boundary cases for an unbranded integer (still numeric) and a
    shape the existing selector excludes, proving no accidental claim widening.
-6. Pin both controls: `experimentalIR: false` must restore the direct body, and
-   the global `JS2WASM_IR_FIRST=0` control must not leave an IR-only dependency
-   in the legacy path.
+6. Pin the actual per-compile control: `experimentalIR: false` must restore the
+   direct body without leaving an IR-only dependency in the legacy path. The
+   repository-wide `JS2WASM_IR_FIRST=0` contract remains owned by #3143.
 
 ## Acceptance criteria
 
@@ -103,6 +103,25 @@ builder; today only its branded-boolean carrier demotes.
 - `experimentalIR: false` compiles and executes through the direct path.
 - Existing #4462 console tests and #4503 boolean-brand tests remain green.
 - Typecheck, formatting, lint, and repository IR ratchets pass.
+
+## Implementation outcome and validation
+
+- `lowerHostFreeConsoleArgument` now dispatches an exact branded `i32` through
+  #4503's `lowerBooleanToString` before the unbranded numeric-i32 arm. No
+  selector, capability, runtime, or direct-codegen path changed.
+- Focused #5094 coverage passes 4/4: all five console methods, representative
+  branded producers, zero imports, IR-only body telemetry, an unbranded
+  `s.length` numeric control, the excluded multi-argument shape, and the
+  `experimentalIR: false` control.
+- #4503 boolean-brand regression coverage passes 29/29. TypeScript 7 typecheck
+  passes after merging current `upstream/main`.
+- #4462 passes 14/15 both on this branch and on a clean `upstream/main`
+  control. Its one failing historical assertion expects `calendar.ts::el` to
+  remain DOM-unsupported; current main emits that unit through the exact
+  standalone DOM provider added after #4462. The identical control failure is
+  recorded as an upstream stale expectation, not a #5094 regression.
+- Commit hooks passed targeted formatting, lint, and LOC/function budgets. The
+  required full pre-push checks run before publication.
 
 ## Non-goals
 

--- a/plan/issues/5094-ir-host-free-boolean-console-rendering.md
+++ b/plan/issues/5094-ir-host-free-boolean-console-rendering.md
@@ -1,0 +1,126 @@
+---
+id: 5094
+title: "IR: render branded booleans through the host-free standalone console sink"
+status: in-progress
+created: 2026-08-27
+updated: 2026-08-27
+assignee: ttraenkler/codex
+branch: codex/5094-ir-host-free-boolean-console
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: console
+goal: ir-full-coverage
+depends_on: [4462, 4503]
+related: [2961, 3143, 3469]
+files:
+  - src/ir/from-ast.ts
+  - tests/issue-5094-ir-host-free-boolean-console.test.ts
+loc-budget-allow:
+  # The existing host-free console renderer is the single owner of converting
+  # lowered argument carriers to strings. The new boolean arm belongs beside
+  # its string/f64/i32 arms so claim and rendering cannot drift.
+  - src/ir/from-ast.ts
+func-budget-allow:
+  # One exact branded-i32 dispatch arm reusing #4503's canonical renderer.
+  - src/ir/from-ast.ts::lowerHostFreeConsoleArgument
+---
+
+# #5094 — Host-free standalone console rendering for branded booleans
+
+## Objective
+
+Move exact boolean `console.log|warn|error|info|debug` statements in prepared
+standalone functions from direct codegen to the existing IR-first host-free
+console path. Render JavaScript booleans as `"true"` / `"false"`, preserve a
+zero-import module, and keep all unsupported shapes outside the claim boundary.
+
+## Current fact and direct-codegen residual
+
+#4462 gave standalone IR a host-free console sink and string/number argument
+rendering. Its measured residual is explicit: branded boolean `i32` values are
+rejected in `src/ir/from-ast.ts::lowerHostFreeConsoleArgument` because printing
+the carrier as an integer would produce `1` / `0` instead of JavaScript's
+`true` / `false` spelling.
+
+When that IR build rejects, the body is emitted by the direct path:
+
+1. `src/codegen/expressions/calls.ts` recognizes ambient `console.<method>`;
+2. `src/codegen/expressions/builtins.ts::compileConsoleCall` selects standalone
+   output handling;
+3. `src/codegen/native-strings.ts::emitStandaloneStdoutAppendValue` services
+   the legacy sink.
+
+This remains useful IR migration work: selection already names the exact
+console surface, the sink already has an IR runtime binding, and #4503 already
+owns the canonical boolean-to-string semantics. The missing work is one honest
+carrier arm, not a new console subsystem.
+
+## Existing ownership to reuse
+
+- `irTypeIsBoolean` proves the shared `i32` carrier carries a JavaScript
+  boolean; an unbranded `i32` remains numeric.
+- `lowerBooleanToString` emits a lazy value-position IR `if` selecting native
+  string constants `"true"` and `"false"`.
+- `lowerHostFreeConsoleCall` appends the rendered value plus one newline through
+  `IR_CONSOLE_SINK_APPEND_FN` / `__stdout_acc`.
+- `consoleSurfaceCapability` and the existing selector already restrict the
+  surface to an available host-free sink, an ambient unshadowed console, the
+  five supported methods, statement position, and exactly one argument.
+
+No selector widening is required. The selected shape already reaches the
+builder; today only its branded-boolean carrier demotes.
+
+## Bounded implementation plan
+
+1. In `lowerHostFreeConsoleArgument`, check `irTypeIsBoolean(valueType)` before
+   the unbranded-i32 numeric arm and delegate to
+   `lowerBooleanToString(cx.builder, value)`.
+2. Keep dispatch on the lowered IR type. Do not use checker type guesses and do
+   not treat every `i32` as boolean.
+3. Add a focused issue test that compiles a single prepared standalone `main`
+   containing exact branded boolean producers and all five console methods.
+4. Drain the existing host-free stdout exports and assert JavaScript spelling,
+   newline behavior, zero imports, successful IR emission, and
+   `legacyBodyEmitted: false`.
+5. Add negative boundary cases for an unbranded integer (still numeric) and a
+   shape the existing selector excludes, proving no accidental claim widening.
+6. Pin both controls: `experimentalIR: false` must restore the direct body, and
+   the global `JS2WASM_IR_FIRST=0` control must not leave an IR-only dependency
+   in the legacy path.
+
+## Acceptance criteria
+
+- Standalone output for representative exact producers is
+  `true\nfalse\ntrue\nfalse\n1\n` and matches Node's boolean spelling.
+- The compiled Wasm module has zero imports.
+- The prepared `main` outcome is `emitted`, with `irBodyEmitted: true` and
+  `legacyBodyEmitted: false` when IR is enabled.
+- No `irPostClaimErrors` or invariant outcomes are recorded.
+- `experimentalIR: false` compiles and executes through the direct path.
+- Existing #4462 console tests and #4503 boolean-brand tests remain green.
+- Typecheck, formatting, lint, and repository IR ratchets pass.
+
+## Non-goals
+
+- Multi-argument or zero-argument console calls.
+- Console calls used in expression position.
+- Shadowed/local `console` bindings or methods outside
+  `log|warn|error|info|debug`.
+- Dynamic, `any`, `unknown`, union, boxed/reference, or conditional argument
+  rendering beyond carriers already proven boolean by the IR brand.
+- Module-init ownership, WASI output, JavaScript-host console imports, or
+  changing the direct-codegen fallback.
+- Adding a new boolean runtime formatter, boxed-dynamic representation, or a
+  new IR boolean type.
+
+## Risk and refusal contract
+
+The only semantic hazard is confusing a native integer with a JavaScript
+boolean. The arm therefore keys exclusively on `irTypeIsBoolean`; absence of
+the brand is not proof of boolean-ness. Every other carrier continues through
+the existing string/number arms or the typed unsupported channel. This keeps
+wrong output impossible while preserving the current fallback boundary.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -7038,10 +7038,9 @@ function lowerHostFreeConsoleArgument(value: IrValueId, cx: LowerCtx, methodName
     }
     return lowerNativeNumberToString(value, cx.funcName, cx);
   }
+  if (irTypeIsBoolean(valueType)) return lowerBooleanToString(cx.builder, value);
   // A number that propagation narrowed to i32 is still a number; widen and use
   // the same formatter so `console.log(x|0)` prints what `x.toString()` would.
-  // `boolean: true` is excluded — a boolean prints "true"/"false", not "1"/"0",
-  // and that rendering is not in this slice.
   if (valueType.kind === "val" && valueType.val.kind === "i32" && valueType.val.boolean !== true) {
     const widened = cx.builder.emitUnary("f64.convert_i32_s", value, irVal({ kind: "f64" }));
     return lowerHostFreeConsoleArgument(widened, cx, methodName);

--- a/tests/issue-5094-ir-host-free-boolean-console.test.ts
+++ b/tests/issue-5094-ir-host-free-boolean-console.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+
+const HOST_BRIDGE = { hostBridge: "always" } as const;
+
+const BRANDED_BOOLEAN_SOURCE = `
+export function main(flag: boolean): void {
+  const local: boolean = flag;
+  console.log(flag);
+  console.warn(!flag);
+  console.error(flag === true);
+  console.info(1 < 0);
+  console.debug(local);
+  console.log(true);
+  console.warn(false);
+}
+`;
+
+const EXPECTED_BRANDED_BOOLEAN_STDOUT = "true\nfalse\ntrue\nfalse\ntrue\ntrue\nfalse\n";
+
+type StandaloneRun = {
+  readonly result: CompileResult;
+  readonly stdout: string;
+  readonly importCount: number;
+};
+
+async function runStandalone(
+  source: string,
+  mainArgs: readonly number[] = [],
+  experimentalIR = true,
+): Promise<StandaloneRun> {
+  const result = await compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    experimentalIR,
+    trackIrOutcomes: true,
+    ...HOST_BRIDGE,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  if (!result.success) throw new Error("standalone compilation failed");
+
+  const module = new WebAssembly.Module(result.binary);
+  const instance = new WebAssembly.Instance(module, {});
+  const exports = instance.exports as Record<string, unknown>;
+  const init = exports.__module_init as (() => void) | undefined;
+  init?.();
+  const main = exports.main as (...args: number[]) => void;
+  main(...mainArgs);
+
+  const prepare = exports.__stdout_prepare as () => number;
+  const char = exports.__stdout_char as (index: number) => number;
+  const length = prepare();
+  let stdout = "";
+  for (let i = 0; i < length; i++) stdout += String.fromCharCode(char(i));
+
+  return {
+    result,
+    stdout,
+    importCount: WebAssembly.Module.imports(module).length,
+  };
+}
+
+function outcomeFor(outcomes: readonly IrObservedOutcome[], displayName: string): IrObservedOutcome {
+  const outcome = outcomes.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+describe("issue #5094: host-free console boolean lowering", () => {
+  it("renders every exact branded boolean producer with no imports", async () => {
+    const { result, stdout, importCount } = await runStandalone(BRANDED_BOOLEAN_SOURCE, [1]);
+
+    expect(stdout).toBe(EXPECTED_BRANDED_BOOLEAN_STDOUT);
+    expect(importCount).toBe(0);
+
+    const main = outcomeFor(result.irOutcomes ?? [], "main");
+    expect(main).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps an unbranded i32 number on the numeric rendering path", async () => {
+    const { result, stdout, importCount } = await runStandalone(
+      `
+export function main(): void {
+  const s: string = "a";
+  console.log(s.length);
+}
+`,
+    );
+
+    expect(stdout).toBe("1\n");
+    expect(importCount).toBe(0);
+    expect(outcomeFor(result.irOutcomes ?? [], "main")).toMatchObject({
+      kind: "emitted",
+      irBodyEmitted: true,
+      legacyBodyEmitted: false,
+    });
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("does not claim an excluded console selector shape", async () => {
+    const result = await compile(
+      `
+export function main(): void {
+  console.log(true, false);
+}
+`,
+      {
+        fileName: "test.ts",
+        target: "standalone",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        ...HOST_BRIDGE,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    const main = outcomeFor(result.irOutcomes ?? [], "main");
+    expect(main).toMatchObject({ kind: "unsupported", code: "host-surface-unavailable" });
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("preserves the legacy control when experimental IR is disabled", async () => {
+    const { result, stdout, importCount } = await runStandalone(BRANDED_BOOLEAN_SOURCE, [1], false);
+
+    // The legacy standalone scalar fallback intentionally drops bare boolean
+    // carriers; this control only proves the direct path still compiles and
+    // executes without introducing imports. Boolean spelling belongs to IR.
+    expect(stdout).toBe("\n".repeat(7));
+    expect(importCount).toBe(0);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- render boolean-branded i32 console arguments through the canonical IR Boolean-to-string lowering
- preserve the unbranded numeric-i32 path and the existing exact console selector boundary
- prove all five host-free console methods emit JavaScript `true` / `false` spelling with zero imports and no legacy body

## Validation

- focused #5094 tests: 4 passed
- #4503 boolean-brand regressions: 29 passed
- TypeScript 7 typecheck passed after syncing current `main`
- required pre-push typecheck, lint, formatting, ratchets, numeric-local parity, and issue-integrity checks passed
- `git diff --check` passed

## Upstream baseline note

`tests/issue-4462.test.ts` is 14/15 on both this branch and a clean current-main control. Its stale DOM assertion expects `calendar.ts::el` to remain unsupported even though the later exact standalone DOM provider now emits it IR-only; #5094 does not change that outcome.