### PR TITLE
fix(es2015): preserve intrinsic Set constructor adder

### DIFF
--- a/plan/issues/5100-es2015-set-newtarget.md
+++ b/plan/issues/5100-es2015-set-newtarget.md
@@ -1,0 +1,76 @@
+---
+id: 5100
+title: "ES2015 standalone Set constructor preserves intrinsic add"
+created: 2026-08-28
+updated: 2026-08-28
+status: in-progress
+priority: medium
+depends_on: []
+es_edition: es2015
+language_feature: Set constructor iterable initialization
+task_type: bug
+loc-budget-allow:
+  - src/codegen/expressions/new-super.ts
+files:
+  - src/codegen/expressions/new-super.ts
+  - tests/issue-5100-set-newtarget.test.ts
+---
+
+# #5100 — ES2015 standalone `Set` constructor / intrinsic `add`
+
+## Scope
+
+Close the bounded standalone residual in
+`test/built-ins/Set/set-newtarget.js`.  The test constructs both an empty Set
+and a Set from an array literal, then checks their prototypes.  The array form
+must use the intrinsic `Set.prototype.add` operation while preserving the
+existing native collection representation.
+
+This is an independent lane.  It does not touch the active/completed ES2015
+lanes for #4779, #4785, #4786, #5091, #5099, #1691, or StringIterator
+metadata/stepping.
+
+## Baseline
+
+The authoritative standalone JSONL was fetched from
+`loopdive/js2wasm-baselines` at revision
+`bb9ce870dc2bb4b547dddbbe9b7c42fc56dfbe52` on 2026-08-28.  The tested source
+head was canonical `upstream/main` commit
+`857b343f344d566f3f382168a8538dd8dca26f2c`.
+
+For `test/built-ins/Set/set-newtarget.js` the baseline row was generated at
+`28.8.2026, 00:10:29`, reached the test, and reported:
+
+| Lane | Result | Error signature |
+| --- | --- | --- |
+| host | pass | — |
+| standalone | fail | `type_error:TypeError: Set.prototype.add is not yet implemented in --target standalone` |
+
+The adjacent controls `Set/prototype/add/returns-this.js`,
+`Set/prototype/has/returns-false-when-value-not-present-boolean.js`, and
+`Set/set-get-add-method-failure.js` were green in the same standalone
+baseline.  No full Test262 run is performed locally.
+
+## Root cause and plan
+
+When a builtin prototype flows through `Object.getPrototypeOf`, the standalone
+prototype companion is materialized and seeded with its intrinsic members.
+`prepareNativeSetAdderDispatch` previously treated the seeded intrinsic
+`Set.prototype.add` entry as a user override.  The constructor then invoked the
+first-class member closure, whose intentional standalone refusal produced the
+residual TypeError instead of using native `__set_add`.
+
+The repair gates the custom-adder lookup on the pre-scanned named-prototype
+write bit.  A prototype value read alone therefore keeps the native fast path;
+assignment and descriptor writes still enter the existing override dispatch.
+The host lane and direct Set method lowering remain unchanged.
+
+Validation covers the exact Test262 row on host and standalone, the three
+nearby controls on both lanes, a focused constructor/prototype identity probe,
+and the normal typecheck, lint, formatting, ratchet, oracle, and hook checks.
+
+## Handoff
+
+Status and exact post-repair counts will be appended here before the initial
+push.  The PR must remain non-draft only after the focused validation is green;
+the repository-local issue is the only issue tracker entry for this lane.

--- a/plan/issues/5100-es2015-set-newtarget.md
+++ b/plan/issues/5100-es2015-set-newtarget.md
@@ -69,8 +69,26 @@ Validation covers the exact Test262 row on host and standalone, the three
 nearby controls on both lanes, a focused constructor/prototype identity probe,
 and the normal typecheck, lint, formatting, ratchet, oracle, and hook checks.
 
-## Handoff
+## Validation and handoff
 
-Status and exact post-repair counts will be appended here before the initial
-push.  The PR must remain non-draft only after the focused validation is green;
-the repository-local issue is the only issue tracker entry for this lane.
+Post-repair focused validation on commit `d14dade81693cbbd8b0004edf9305f652cdc40cc`
+was green:
+
+| Check | Result |
+| --- | --- |
+| Exact Test262 row, host | pass |
+| Exact Test262 row, standalone | pass |
+| Three host/standalone controls | 6/6 pass |
+| Standalone + host constructor/prototype probe | 2/2 pass |
+| Repeat exact row (host + standalone, twice) | 4/4 pass |
+| Normal changed-root hook (`TEST262_WORKERS=2`) | 10/10 pass |
+| TypeScript 5 / TypeScript 7 | pass / pass |
+| Biome lint, Prettier, LOC/function budgets | pass / pass / pass with issue-local allowance |
+| Oracle and coercion-site ratchets | pass / pass |
+
+The branch is clean and contains one repair commit with Thomas authorship and
+the Codex trailer.  The initial fork push is pending the execution environment
+allowing the explicitly requested `git push`; no GitHub issue or API mutation
+was performed from this lane.  Once pushed, the PR should be non-draft with
+this exact body and the lane may enter the queue only after fresh PR CI is
+green.

--- a/plan/issues/5100-es2015-set-newtarget.md
+++ b/plan/issues/5100-es2015-set-newtarget.md
@@ -3,7 +3,7 @@ id: 5100
 title: "ES2015 standalone Set constructor preserves intrinsic add"
 created: 2026-08-28
 updated: 2026-08-28
-status: in-progress
+status: done
 priority: medium
 depends_on: []
 es_edition: es2015
@@ -86,9 +86,8 @@ was green:
 | Biome lint, Prettier, LOC/function budgets | pass / pass / pass with issue-local allowance |
 | Oracle and coercion-site ratchets | pass / pass |
 
-The branch is clean and contains one repair commit with Thomas authorship and
-the Codex trailer.  The initial fork push is pending the execution environment
-allowing the explicitly requested `git push`; no GitHub issue or API mutation
-was performed from this lane.  Once pushed, the PR should be non-draft with
-this exact body and the lane may enter the queue only after fresh PR CI is
-green.
+The completed fix is published from `codex/5100-set-newtarget` as non-draft
+upstream PR #5106 against `loopdive/js2:main`.  This markdown file is the only
+issue record; no GitHub issue was opened.  Root owns fresh PR CI and merge-queue
+shepherding, and the lane may enter the queue only after the published head is
+mergeable with every required check green.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -3721,6 +3721,15 @@ function prepareNativeSetAdderDispatch(
   fctx: FunctionContext,
   collTmp: number,
 ): NativeSetAdderDispatch | undefined {
+  // Reading a builtin prototype as a value (for example the Test262
+  // `Object.getPrototypeOf(s)` assertion) arms the companion store and seeds
+  // its intrinsic members, but it does not install a user override.  Treating
+  // that seeded `Set.prototype.add` as custom makes the constructor invoke the
+  // deliberately-refusing first-class member closure instead of the native
+  // `__set_add` fast path.  The pre-scan's named-write bit is the narrow gate
+  // for an observable override; descriptor and assignment writes both set it.
+  if (!ctx.protoNamedDirty) return undefined;
+
   const hasIdx = ctx.funcMap.get("__protoidx_has_r");
   const getIdx = ctx.funcMap.get("__protoidx_get_r");
   if (hasIdx === undefined || getIdx === undefined) return undefined;

--- a/tests/issue-5100-set-newtarget.test.ts
+++ b/tests/issue-5100-set-newtarget.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5100 — a flowing Set prototype must not turn the intrinsic constructor adder
+// into a refusing first-class closure.
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+type Lane = "host" | "standalone";
+
+const EXACT = "built-ins/Set/set-newtarget.js";
+const CONTROLS = [
+  "built-ins/Set/prototype/add/returns-this.js",
+  "built-ins/Set/prototype/has/returns-false-when-value-not-present-boolean.js",
+  "built-ins/Set/set-get-add-method-failure.js",
+] as const;
+
+const PROBE = `
+  export function test(): number {
+    const empty = new Set();
+    const seeded = new Set([1, 2]);
+    return Object.getPrototypeOf(empty) === Set.prototype &&
+      Object.getPrototypeOf(seeded) === Set.prototype &&
+      empty.size === 0 && seeded.size === 2 ? 1 : 0;
+  }
+`;
+
+async function runProbe(lane: Lane): Promise<number> {
+  const options = lane === "standalone" ? { target: "standalone" as const, nativeStrings: true } : {};
+  const result = await compile(PROBE, { fileName: "issue-5100-probe.ts", ...options });
+  expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("\n")).toBe(true);
+  if (!result.success) return -1;
+  if (lane === "standalone") expect(result.imports ?? []).toHaveLength(0);
+  const imports = lane === "host" ? buildImports(result.imports, undefined, result.stringPool) : {};
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#5100 standalone Set constructor intrinsic add", () => {
+  it("passes the exact host Test262 row", async () => {
+    const result = await runTest262File(join("test262/test", EXACT), "issue-5100", 120_000);
+    expect(result.status, result.error ?? result.reason ?? "").toBe("pass");
+  });
+
+  it("passes the exact standalone Test262 row", async () => {
+    const result = await runTest262File(join("test262/test", EXACT), "issue-5100", 120_000, "standalone");
+    expect(result.status, result.error ?? result.reason ?? "").toBe("pass");
+  });
+
+  for (const control of CONTROLS) {
+    it(`keeps the host control green: ${control}`, async () => {
+      const result = await runTest262File(join("test262/test", control), "issue-5100", 120_000);
+      expect(result.status, result.error ?? result.reason ?? "").toBe("pass");
+    });
+
+    it(`keeps the standalone control green: ${control}`, async () => {
+      const result = await runTest262File(join("test262/test", control), "issue-5100", 120_000, "standalone");
+      expect(result.status, result.error ?? result.reason ?? "").toBe("pass");
+    });
+  }
+
+  it("preserves Set prototype identity and native collection state in standalone", async () => {
+    await expect(runProbe("standalone")).resolves.toBe(1);
+  });
+
+  it("preserves Set prototype identity and native collection state on host", async () => {
+    await expect(runProbe("host")).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

- preserve the native standalone Set constructor fast path when reading Set.prototype only materializes its seeded intrinsic add entry
- reserve custom-adder dispatch for actual named prototype writes, retaining assignment and descriptor override behavior
- add focused host and standalone coverage for the exact ES2015 Test262 row, adjacent controls, prototype identity, and repeatability
- track the implementation plan, authoritative evidence, and handoff in `plan/issues/5100-es2015-set-newtarget.md`

Validation:

- exact row: host 1/1 and standalone 1/1 passed (standalone baseline failed)
- adjacent host and standalone controls: 6/6 passed
- focused constructor/prototype probes: 2/2 passed
- repeat exact-row runs: 4/4 passed
- normal pre-push typecheck, lint, formatting, ratchets, numeric-local parity, and issue-integrity gates passed

Tracking: `plan/issues/5100-es2015-set-newtarget.md`.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->