### PR TITLE
fix(ir): own exact ambient Math.tan calls

### DIFF
--- a/plan/issues/5103-ir-exact-ambient-math-tan.md
+++ b/plan/issues/5103-ir-exact-ambient-math-tan.md
@@ -1,7 +1,7 @@
 ---
 id: 5103
 title: "IR: own exact ambient Math.tan(number) calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -102,6 +102,26 @@ the direct path.
 - Every excluded form declines before claim with no invariant or post-claim
   failure.
 - Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
+
+## Implementation outcome and validation
+
+- `math.tan` is now the fourteenth closed source-level Math intrinsic. The
+  shared Math table admits only exact ambient one-number calls and the generic
+  from-AST path emits the semantic intrinsic without any tangent-specific
+  builder branch.
+- The frozen manifest attaches `selfhost.math.tan` / `Math_tan`, declares
+  `math.tan -> [math.cos, math.sin]`, and deduplicates the transitive
+  `math.reduce-trig` dependency. The existing provider materializer emits the
+  established helper family; no algorithm or direct-codegen file changed.
+- `JS2WASM_IR_MATH_TAN=0` withdraws only the new claim. Shadowed, aliased,
+  wrong-arity, spread, and non-number forms all decline before claim.
+- Four focused/affected suites pass 23/23, including host and zero-import
+  standalone execution, exact semantic/provider evidence, dependency closure,
+  direct-path parity, rollback, exhaustive Math integration, all-target/backend
+  manifest closure, and linear-backend legality.
+- TypeScript 7, Prettier, Biome lint, the IR kind-neutrality gate, LOC/function
+  budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue
+  integrity pass. Luna Max review returned GO with no P0/P1 finding.
 
 ## Non-goals
 

--- a/plan/issues/5103-ir-exact-ambient-math-tan.md
+++ b/plan/issues/5103-ir-exact-ambient-math-tan.md
@@ -1,0 +1,122 @@
+---
+id: 5103
+title: "IR: own exact ambient Math.tan(number) calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5103-ir-math-tan
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5101]
+related: [1371, 3204, 3526, 4787, 5092, 5094]
+files:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5103-ir-math-tan.test.ts
+loc-budget-allow:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5103 — Exact ambient `Math.tan(number)` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.tan(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent the source call as a versioned semantic intrinsic and
+reuse the existing host-free `Math_tan` implementation together with its
+`Math_sin` and `Math_cos` dependencies.
+
+This checkpoint is intentionally stacked on #5107/#5101 because it extends the
+same closed Math vocabulary and runtime manifest. It does not modify the
+`Math.tan` algorithm or any direct-codegen implementation.
+
+## Measured residual
+
+`Math.tan` is absent from `IR_MATH_METHOD_TABLE`, so selection declines the
+source call and the legacy builtin path emits `Math_tan`. The runtime body is
+already available in `src/codegen/math-helpers.ts`: requesting `tan` emits the
+existing self-hosted `Math_sin`, `Math_cos`, range-reduction helper, and
+`Math_tan` functions in dependency order. The missing contract is the semantic
+IR intrinsic/provider graph, not executable behavior.
+
+## Exact admitted grammar
+
+Admit only `Math.tan(argument)` when:
+
+- `Math` is the unshadowed ambient binding;
+- there is exactly one non-spread argument;
+- the selector proves the argument is primitive `number` and IR-lowerable;
+- symbolic Math helpers are available for the active backend; and
+- the containing unit passes the ordinary ownership and call-graph gates.
+
+Aliased, computed, shadowed, coercive, spread, and wrong-arity forms remain on
+the direct path.
+
+## Implementation plan
+
+1. Add `math.tan` to the closed intrinsic/runtime-feature vocabularies with the
+   existing unary-f64 signature.
+2. Add provider `selfhost.math.tan` targeting `Math_tan`, with declared
+   dependencies on `math.sin` and `math.cos`. Their existing dependencies close
+   over `math.reduce-trig` exactly once.
+3. Add `tan` to `IR_MATH_METHOD_TABLE`; reuse the generic selector,
+   call-graph walker, from-AST intrinsic emitter, manifest preparation, and
+   provider materializer.
+4. Add narrow rollback `JS2WASM_IR_MATH_TAN=0` without withdrawing any other
+   Math intrinsic.
+5. Widen #3526 exhaustive vocabulary, dependency, integration, and neutrality
+   evidence from thirteen to fourteen source-level Math intrinsics.
+6. Add focused tests for host and zero-import standalone ownership, semantic
+   intrinsic/provider attachment, dependency closure, direct-path numerical
+   parity, narrow rollback, and pre-claim exclusions.
+7. Run focused suites, TypeScript 7 typecheck, formatting/lint/ratchets, full
+   pre-push checks, then push and open a non-draft stacked PR.
+
+## Acceptance criteria
+
+- Exact ambient `Math.tan(number)` emits IR only and attaches the existing
+  self-hosted `Math_tan` callable.
+- The frozen manifest declares `math.tan -> [math.cos, math.sin]` and closes
+  transitively over the established trigonometric providers without host
+  capabilities.
+- Host and standalone execution match the direct path, and standalone imports
+  remain empty.
+- `JS2WASM_IR_MATH_TAN=0` keeps only `Math.tan` on the direct path.
+- Every excluded form declines before claim with no invariant or post-claim
+  failure.
+- Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, extracted/computed calls, `.call`, or
+  `.apply`.
+- `Math.asin`, `Math.acos`, hyperbolic methods, random, min/max, or another
+  Math-table expansion.
+- A new tangent approximation, host import, raw helper call in IR, or direct
+  codegen behavior change.
+- Async, class, module-init, or multi-source ownership expansion.
+
+## Risk and rollback
+
+The principal risk is manifest/provider drift: `Math_tan` requires both
+`Math_sin` and `Math_cos`, which share `math.reduce-trig`. The frozen manifest
+must express that graph and prove deterministic deduplication. The shared Math
+table remains the sole source grammar contract. `JS2WASM_IR_MATH_TAN=0` is the
+checkpoint rollback; `JS2WASM_IR_FIRST=0` remains the global control.

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 13 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 14 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,7 +353,7 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 13 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 14 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
       "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:24"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -24,13 +24,14 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.pow",
   "math.sin",
   "math.sqrt",
+  "math.tan",
   "math.trunc",
 ] as const);
 
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the thirteen intrinsic entry points.
+ * Provider requirements reachable from the fourteen intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -47,6 +48,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.reduce-trig",
   "math.sin",
   "math.sqrt",
+  "math.tan",
   "math.trunc",
 ] as const);
 
@@ -137,6 +139,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.pow": definition("math.pow", F64_BINARY_INTRINSIC_SIGNATURE),
   "math.sin": definition("math.sin", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.sqrt": definition("math.sqrt", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.tan": definition("math.tan", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.trunc": definition("math.trunc", F64_UNARY_INTRINSIC_SIGNATURE),
 });
 

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -60,6 +60,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.pow",
   "selfhost.math.reduce-trig",
   "selfhost.math.sin",
+  "selfhost.math.tan",
 ] as const);
 
 export type MathRuntimeProviderId = (typeof PURE_MATH_RUNTIME_PROVIDER_IDS)[number];
@@ -180,6 +181,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.reduce-trig": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sin": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sqrt": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.tan": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.trunc": F64_UNARY_INTRINSIC_SIGNATURE,
 });
 
@@ -267,13 +269,20 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     kind: "backend-op",
     opcode: "f64.sqrt",
   }),
+  "math.tan": provider(
+    "selfhost.math.tan",
+    "math.tan",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_tan" },
+    ["math.cos", "math.sin"],
+  ),
   "math.trunc": provider("backend.f64.trunc", "math.trunc", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "backend-op",
     opcode: "f64.trunc",
   }),
 });
 
-/** Canonically ordered default provider catalogue for the thirteen-method slice. */
+/** Canonically ordered default provider catalogue for the fourteen-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -296,6 +296,7 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   atan: { arity: 1, intrinsic: "math.atan" },
   sin: { arity: 1, intrinsic: "math.sin" },
   cos: { arity: 1, intrinsic: "math.cos" },
+  tan: { arity: 1, intrinsic: "math.tan" },
   exp: { arity: 1, intrinsic: "math.exp" },
   log: { arity: 1, intrinsic: "math.log" },
   log2: { arity: 1, intrinsic: "math.log2" },
@@ -6471,6 +6472,7 @@ function selectorPrimitiveWrapperOrGenericBinary(
 
 function selectorSupportsMathPlan(plan: IrMathMethodPlan): boolean {
   if (plan.intrinsic === "math.atan" && process.env.JS2WASM_IR_MATH_ATAN === "0") return false;
+  if (plan.intrinsic === "math.tan" && process.env.JS2WASM_IR_MATH_TAN === "0") return false;
   return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
 }
 

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -68,7 +68,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
     const analysis = analyzeSource(`
       export function allMath(x: number, y: number): number {
         return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.trunc(x)
-          + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.exp(x) + Math.log(x) + Math.log2(x)
+          + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x) + Math.exp(x) + Math.log(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
     `);
@@ -122,6 +122,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function atan(): number { return Math.atan(1); }
       export function sin(): number { return Math.sin(0.75); }
       export function cos(): number { return Math.cos(0.75); }
+      export function tan(): number { return Math.tan(0.75); }
       export function exp(): number { return Math.exp(1.25); }
       export function log(): number { return Math.log(3.5); }
       export function log2(): number { return Math.log2(32); }
@@ -157,7 +158,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
     for (const opcode of ["f64.abs", "f64.sqrt", "f64.floor", "f64.ceil", "f64.trunc"]) {
       expect(ir.wat).toContain(opcode);
     }
-    for (const helper of ["atan", "sin", "cos", "exp", "log", "log2", "pow", "atan2"]) {
+    for (const helper of ["atan", "sin", "cos", "tan", "exp", "log", "log2", "pow", "atan2"]) {
       expect(ir.wat).toContain(`$Math_${helper}`);
     }
     expect(ir.wat).not.toContain("$__box_number");

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,15 +88,15 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact thirteen certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact fourteen certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(13);
+    expect(intrinsicMethods).toHaveLength(14);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
-    expect(PURE_MATH_RUNTIME_FEATURES).toEqual(expect.arrayContaining(["math.atan", "math.reduce-trig"]));
+    expect(PURE_MATH_RUNTIME_FEATURES).toEqual(expect.arrayContaining(["math.atan", "math.reduce-trig", "math.tan"]));
     const intrinsicFeatures = new Set<string>(PURE_MATH_INTRINSIC_IDS);
     expect(PURE_MATH_RUNTIME_FEATURES.filter((feature) => !intrinsicFeatures.has(feature))).toEqual([
       "math.reduce-trig",
@@ -119,7 +119,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(13);
+    expect(first.intrinsicUses).toHaveLength(14);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -131,6 +131,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.atan2"]).toEqual(["math.atan"]);
     expect(dependencies["math.sin"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
+    expect(dependencies["math.tan"]).toEqual(["math.cos", "math.sin"]);
     expect(first.features.filter((feature) => feature === "math.reduce-trig")).toHaveLength(1);
   });
 
@@ -142,7 +143,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     for (const target of targets) {
       for (const backend of backends) {
         const builder = new RuntimeManifestBuilder(policy(target, backend));
-        addUses(builder, ["math.sin", "math.pow", "math.atan2"]);
+        addUses(builder, ["math.sin", "math.tan", "math.pow", "math.atan2"]);
         const manifest = builder.freeze();
         semanticClosures.push([...manifest.features]);
         expect(manifest.hostCapabilities, `${target}/${backend}`).toEqual([]);
@@ -153,11 +154,13 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(semanticClosures[0]).toEqual([
       "math.atan",
       "math.atan2",
+      "math.cos",
       "math.exp",
       "math.log",
       "math.pow",
       "math.reduce-trig",
       "math.sin",
+      "math.tan",
     ]);
   });
 

--- a/tests/issue-5103-ir-math-tan.test.ts
+++ b/tests/issue-5103-ir-math-tan.test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { INTRINSIC_DEFINITIONS } from "../src/ir/intrinsics.js";
+import { forEachInstrDeep, irVal, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5103-ir-math-tan");
+const F64 = irVal({ kind: "f64" });
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+describe("#5103 exact ambient Math.tan IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims the exact one-number call on the %s target", async (_label, target) => {
+    const result = await compile(`export function tan(value: number): number { return Math.tan(value); }`, {
+      fileName: `issue-5103-${_label}.ts`,
+      ...(target === undefined ? {} : { target }),
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+
+    expect(outcomeFor(result, "tan")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irCompiledFuncs ?? []).toContain("tan");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const exports = await instantiate(result);
+    const tan = exports.tan as (value: number) => number;
+    expect(typeof tan).toBe("function");
+    expect(Object.is(tan(0), 0)).toBe(true);
+    expect(result.wat).toContain("$Math_tan");
+    expect(result.wat).toContain("$Math_sin");
+    expect(result.wat).toContain("$Math_cos");
+    expect(result.wat).toContain("$__math_reduce_trig");
+
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches the existing Math_tan provider and its canonical dependency closure", () => {
+    const analysis = analyzeSource(`
+      export function tan(value: number): number {
+        return Math.tan(value);
+      }
+    `);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing tan declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("tan").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic).toHaveLength(1);
+    expect(semantic[0]).toMatchObject({
+      id: "math.tan",
+      version: INTRINSIC_DEFINITIONS["math.tan"].signature.version,
+      resultType: F64,
+    });
+    expect(semantic[0]?.provider).toBeUndefined();
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id)).toEqual(["math.tan"]);
+    expect(prepared.manifest.features).toEqual(["math.cos", "math.reduce-trig", "math.sin", "math.tan"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    const dependencies = Object.fromEntries(
+      prepared.manifest.providers.map((provider) => [provider.feature, provider.dependencies]),
+    );
+    expect(dependencies).toMatchObject({
+      "math.cos": ["math.reduce-trig"],
+      "math.sin": ["math.reduce-trig"],
+      "math.tan": ["math.cos", "math.sin"],
+    });
+    expect(new Set(prepared.manifest.providers.map((provider) => provider.id))).toEqual(
+      new Set(["selfhost.math.cos", "selfhost.math.reduce-trig", "selfhost.math.sin", "selfhost.math.tan"]),
+    );
+    expect(intrinsicInstructions(prepared.functions[0]!)[0]).toMatchObject({
+      id: "math.tan",
+      provider: {
+        kind: "callable",
+        target: { name: "Math_tan", binding: { kind: "intrinsic", symbol: "math.tan" } },
+      },
+    });
+  });
+
+  it("matches the direct path for finite values, NaN, infinities, and signed zero", async () => {
+    const source = `export function tan(value: number): number { return Math.tan(value); }`;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5103-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5103-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+    expect(outcomeFor(ir, "tan")).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+
+    const irTan = (await instantiate(ir)).tan as (value: number) => number;
+    const directTan = (await instantiate(direct)).tan as (value: number) => number;
+    for (const value of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      expect(Number.isNaN(irTan(value)), `IR result for ${String(value)}`).toBe(true);
+      expect(Number.isNaN(directTan(value)), `direct result for ${String(value)}`).toBe(true);
+    }
+    for (const value of [0, -0]) {
+      expect(Object.is(irTan(value), directTan(value)), `signed-zero parity for ${String(value)}`).toBe(true);
+    }
+    for (const value of [0.75, -0.75]) {
+      expect(irTan(value), `finite path parity for ${String(value)}`).toBe(directTan(value));
+    }
+  });
+
+  it("uses the narrow env rollback for tan without withdrawing sin or cos", async () => {
+    const previous = process.env.JS2WASM_IR_MATH_TAN;
+    process.env.JS2WASM_IR_MATH_TAN = "0";
+    try {
+      const result = await compile(
+        `
+          export function tan(value: number): number { return Math.tan(value); }
+          export function sin(value: number): number { return Math.sin(value); }
+          export function cos(value: number): number { return Math.cos(value); }
+        `,
+        { fileName: "issue-5103-rollback.ts", experimentalIR: true, trackIrOutcomes: true },
+      );
+      expectSuccess(result);
+      expect(outcomeFor(result, "tan")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      for (const name of ["sin", "cos"]) {
+        expect(outcomeFor(result, name)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+      }
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_IR_MATH_TAN");
+      else process.env.JS2WASM_IR_MATH_TAN = previous;
+    }
+  });
+
+  it.each([
+    [
+      "shadowed Math",
+      `export function f(x: number): number {
+        const Math: number = x;
+        // @ts-expect-error #5103 shadowed Math is intentionally not ambient.
+        return Math.tan(x);
+      }`,
+    ],
+    [
+      "aliased tan",
+      `const tan = Math.tan;
+      export function f(x: number): number { return tan(x); }`,
+    ],
+    [
+      "wrong arity",
+      `export function f(x: number): number {
+        // @ts-expect-error #5103 intentionally exercises extra arity.
+        return Math.tan(x, x);
+      }`,
+    ],
+    [
+      "spread argument",
+      `export function f(x: number): number {
+        return Math.tan(...([x] as [number]));
+      }`,
+    ],
+    [
+      "non-number argument",
+      `export function f(): number {
+        const text: string = "1";
+        return Math.tan(text as never);
+      }`,
+    ],
+  ])("rejects %s before claim", async (_label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5103-${_label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- promote exact ambient `Math.tan(number)` to the fourteenth closed source-level Math intrinsic
- attach the existing self-hosted `Math_tan` provider with explicit `math.cos` and `math.sin` dependencies
- preserve direct fallback through the narrow `JS2WASM_IR_MATH_TAN=0` rollback
- extend exhaustive manifest, integration, linear-legality, neutrality, parity, and exclusion evidence

## Dependency

This PR is intentionally stacked on #5107. Retarget it to `main` after #5107 lands.

## Validation

- 23/23 focused and affected tests passed across four suites
- TypeScript 7 typecheck passed
- Prettier, Biome lint, IR-kind neutrality, LOC/function budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue integrity passed
- host and zero-import standalone execution match the direct path
- independent Luna Max review: GO, no P0/P1 findings