### PR TITLE
fix(es2015): propagate isNaN ToPrimitive abrupt results

### DIFF
--- a/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
+++ b/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
@@ -1,7 +1,7 @@
 ---
 id: 5102
 title: "ES2015 standalone isNaN must propagate ToPrimitive abrupt completions"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-28
 updated: 2026-08-28
@@ -131,5 +131,17 @@ Final validation ran after merging and retaining upstream/main at
   integrity, with `TEST262_WORKERS=2`. No full 11,704-row census was run.
 
 The plan checkpoint is `df96e0d86b`; implementation checkpoint is
-`8f1d2a06f7`. The upstream PR handoff URL will be appended after opening the
-single compliant PR; no GitHub issue is created or linked.
+`8f1d2a06f7`. After that validation, upstream/main advanced to
+`eafd6700ac54fdf2b89a6b77eb0560b3b475fdb9` and was merged in
+`ed387a0a18` before the final handoff.
+
+The focused suite now guards only its eight corpus-backed exact host/standalone
+cases with `existsSync(test262/harness/assert.js)`. With the corpus present,
+it ran **10/10 passed** after the `eafd6700ac` merge. In a no-corpus
+temporary root `/private/tmp/js2-5102-no-corpus.7uw5uw`, it ran **2 passed /
+8 skipped**: both self-contained controls remained mandatory and green, while
+only the eight Test262-dependent cases skipped. The direct final exact run on
+the synchronized tree was **4/4 host and 4/4 standalone pass**.
+
+The final evidence commit and upstream synchronization commit will be pushed
+before opening the single compliant PR; no GitHub issue is created or linked.

--- a/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
+++ b/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
@@ -15,8 +15,12 @@ es_edition: es6
 language_feature: isNaN, ToPrimitive, Symbol.toPrimitive
 goal: standalone-mode
 assignee: "ttraenkler/codex/es2015-next-lane-c"
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
+func-budget-allow:
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
 files:
-  - src/codegen/expressions/call-identifier.ts
+  - src/codegen/object-runtime.ts
   - tests/issue-5102-isnan-toprimitive.test.ts
   - plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
 ---
@@ -26,12 +30,12 @@ files:
 ## Problem
 
 The global `isNaN` call lowering coerces its argument to an f64 and then tests
-the result for NaN. On the standalone path, an object with an exotic
-`Symbol.toPrimitive` is represented by a lossy numeric placeholder before the
-required `ToPrimitive` call can throw. That turns required `TypeError` or
-`Test262Error` completions into ordinary boolean results. The host lane already
-passes the target rows, so the fix must stay standalone-only at the narrowest
-global-call/coercion site and preserve the existing numeric fast path.
+the result for NaN. On the standalone path, the native `ToPrimitive` helper did
+not probe an object's own `Symbol.toPrimitive` data property, so it fell
+through to `valueOf`/`toString` and eventually produced a normal NaN/result
+instead of propagating the required `TypeError` or `Test262Error`. The host lane
+already passes the target rows, so the fix stays in the standalone native
+object runtime and preserves the existing numeric fast path.
 
 ## Exact cohort and authoritative baseline (2026-08-27)
 
@@ -64,11 +68,14 @@ No full-corpus census is part of this issue.
    worktree and inspect the emitted standalone coercion path. Confirm that a
    positive numeric/string control still reaches the existing `f64.ne` NaN
    test and that the host lane remains green.
-2. Make the smallest standalone-only change that keeps object arguments on the
-   throwing `ToPrimitive`/`ToNumber` path instead of substituting NaN. Preserve
-   evaluation order, catchability, static numeric fast paths, and host-mode
-   lowering. Do not broaden the change to `Number.isNaN`, unrelated coercions,
-   or the getter-abrupt row whose host baseline is already red.
+2. Make the smallest standalone-only change that probes the well-known Symbol
+   carrier through the native object's own data-property table, invokes a
+   callable method through the existing receiver-aware closure bridge with the
+   "number" hint, and throws for non-callable/object or Symbol results.
+   Preserve evaluation order, catchability, static numeric fast paths, and
+   host-mode lowering. Deliberately leave accessor entries on the existing
+   ordinary path so the getter-abrupt row whose host baseline is already red
+   remains an excluded control; do not broaden the change to `Number.isNaN`.
 3. Add a focused compiler regression test covering all four target shapes plus
    numeric, string, nullish, and ordinary-object controls. Re-run the exact
    Test262 cohort in host and standalone modes and record per-row statuses.

--- a/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
+++ b/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
@@ -1,0 +1,99 @@
+---
+id: 5102
+title: "ES2015 standalone isNaN must propagate ToPrimitive abrupt completions"
+status: in-progress
+sprint: current
+created: 2026-08-28
+updated: 2026-08-28
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+es_edition: es6
+language_feature: isNaN, ToPrimitive, Symbol.toPrimitive
+goal: standalone-mode
+assignee: "ttraenkler/codex/es2015-next-lane-c"
+files:
+  - src/codegen/expressions/call-identifier.ts
+  - tests/issue-5102-isnan-toprimitive.test.ts
+  - plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
+---
+
+# #5102 — ES2015 standalone `isNaN` must propagate `ToPrimitive` abrupt completions
+
+## Problem
+
+The global `isNaN` call lowering coerces its argument to an f64 and then tests
+the result for NaN. On the standalone path, an object with an exotic
+`Symbol.toPrimitive` is represented by a lossy numeric placeholder before the
+required `ToPrimitive` call can throw. That turns required `TypeError` or
+`Test262Error` completions into ordinary boolean results. The host lane already
+passes the target rows, so the fix must stay standalone-only at the narrowest
+global-call/coercion site and preserve the existing numeric fast path.
+
+## Exact cohort and authoritative baseline (2026-08-27)
+
+The cohort is the ES2015 edition (`website/public/benchmarks/results/test262-file-editions.json`
+maps these files to `ES2015`) and consists of exactly these four rows:
+
+- `test/built-ins/isNaN/toprimitive-call-abrupt.js`
+- `test/built-ins/isNaN/toprimitive-not-callable-throws.js`
+- `test/built-ins/isNaN/toprimitive-result-is-object-throws.js`
+- `test/built-ins/isNaN/toprimitive-result-is-symbol-throws.js`
+
+The authoritative host and standalone JSONL snapshots were fetched from
+`loopdive/js2wasm-baselines` on 2026-08-28. Both carry oracle version 13 and
+48,735 rows; the promoted source summary identifies baseline SHA
+`857b343f344d566f3f382168a8538dd8dca26f2c`. The host lane is **4/4 pass**.
+The standalone lane is **0/4 pass, 4/4 fail**; every failure is an
+`assertion_fail` caused by the expected abrupt completion being replaced by a
+normal result. The neighbouring getter-abrupt row
+`toprimitive-get-abrupt.js` is deliberately not in the cohort because its
+authoritative host row also fails; it remains a diagnostic control, not an
+acceptance row.
+
+For context only, the same authoritative ES2015 edition contains 11,704 rows;
+the full edition snapshot is 9,580 standalone passes and 9,606 host passes.
+No full-corpus census is part of this issue.
+
+## Implementation plan
+
+1. Reproduce the four rows through the maintained Test262 runner in this
+   worktree and inspect the emitted standalone coercion path. Confirm that a
+   positive numeric/string control still reaches the existing `f64.ne` NaN
+   test and that the host lane remains green.
+2. Make the smallest standalone-only change that keeps object arguments on the
+   throwing `ToPrimitive`/`ToNumber` path instead of substituting NaN. Preserve
+   evaluation order, catchability, static numeric fast paths, and host-mode
+   lowering. Do not broaden the change to `Number.isNaN`, unrelated coercions,
+   or the getter-abrupt row whose host baseline is already red.
+3. Add a focused compiler regression test covering all four target shapes plus
+   numeric, string, nullish, and ordinary-object controls. Re-run the exact
+   Test262 cohort in host and standalone modes and record per-row statuses.
+4. Run the focused Vitest test, TypeScript/lint/format checks, and the normal
+   scoped pre-push gates with `TEST262_WORKERS<=2`. Record final counts,
+   artifacts, commit SHAs, and the upstream PR handoff below.
+
+## Acceptance
+
+- The four exact rows are **4/4 pass** in both host and standalone lanes.
+- Standalone emits no host imports for the target rows and reports zero
+  failures, compile errors, or compile timeouts for the cohort.
+- The expected `Test262Error` and `TypeError` completions remain catchable and
+  occur in the specified order; numeric, string, nullish, and ordinary-object
+  controls retain their existing `isNaN` results.
+- The neighbouring host-red getter-abrupt row remains unchanged, and no
+  unrelated `isFinite`/`Number.isNaN` or global-function metadata behavior
+  regresses.
+- One ready upstream PR is opened from `ttraenkler/js2` against
+  `loopdive/js2:main` with the exact `## Description` and `## CLA` sections and
+  a checked CLA statement. The issue file remains the tracking record; no
+  GitHub issue is created.
+
+## Evidence and handoff
+
+Implementation and validation evidence will be appended here before the PR is
+handed off. Until then this issue intentionally records only the measured
+baseline and bounded plan above.

--- a/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
+++ b/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
@@ -58,9 +58,11 @@ normal result. The neighbouring getter-abrupt row
 authoritative host row also fails; it remains a diagnostic control, not an
 acceptance row.
 
-For context only, the same authoritative ES2015 edition contains 11,704 rows;
-the full edition snapshot is 9,580 standalone passes and 9,606 host passes.
-No full-corpus census is part of this issue.
+For context only, the authoritative ES2015 edition contains 11,704 rows. The
+source summary at `857b343f` used for the original aggregate note is a
+non-standalone run, so its edition count is not standalone evidence; the
+previously recorded 9,580 figure was mislabeled and has been removed. No
+full-corpus census is part of this bounded issue.
 
 ## Implementation plan
 
@@ -143,5 +145,18 @@ temporary root `/private/tmp/js2-5102-no-corpus.7uw5uw`, it ran **2 passed /
 only the eight Test262-dependent cases skipped. The direct final exact run on
 the synchronized tree was **4/4 host and 4/4 standalone pass**.
 
-The final evidence commit and upstream synchronization commit will be pushed
-before opening the single compliant PR; no GitHub issue is created or linked.
+Implementation is published as upstream PR
+`https://github.com/loopdive/js2/pull/5109` from the `ttraenkler/js2` fork.
+Only an exact pushed head with fresh green CI may enter the merge queue. No
+GitHub issue is created or linked; this file is the canonical task record.
+
+### Aggregate-evidence correction
+
+A post-PR audit on 2026-08-28 compared the authoritative standalone
+`current.before` and `current` per-file snapshots promoted for main
+`18785a67c6682b9fc41d3a220a6b88f3f42dc59e`. ES2015 improved from
+**8,676/11,704** to **8,681/11,704**: five non-pass rows became passes and
+there were **zero pass-to-non-pass transitions**. The earlier 9,580 label did
+not describe the standalone lane and is not used by this issue's acceptance
+evidence. This correction changes only this markdown handoff; the exact
+four-row and focused validation above is unchanged.

--- a/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
+++ b/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
@@ -160,3 +160,12 @@ there were **zero pass-to-non-pass transitions**. The earlier 9,580 label did
 not describe the standalone lane and is not used by this issue's acceptance
 evidence. This correction changes only this markdown handoff; the exact
 four-row and focused validation above is unchanged.
+
+### Mergeability refresh
+
+After the corrected head remained in GitHub's `mergeable: unknown` state,
+current `upstream/main` at `0ccc264fa183484edfa852af4084dd899f9b433f`
+was merged without rewriting history in
+`f18bf910e08b4b50a4a3741894855292ad93562b`. This is the final supported
+base refresh before publication; the focused issue suite and normal pre-push
+gates must be green on this integrated tree before PR #5109 is re-enqueued.

--- a/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
+++ b/plan/issues/5102-es2015-isnan-toprimitive-abrupt.md
@@ -101,6 +101,35 @@ No full-corpus census is part of this issue.
 
 ## Evidence and handoff
 
-Implementation and validation evidence will be appended here before the PR is
-handed off. Until then this issue intentionally records only the measured
-baseline and bounded plan above.
+Implementation is in `src/codegen/object-runtime.ts`. The standalone native
+`__to_primitive` helper now probes the well-known Symbol carrier through
+`__obj_find`, reads only own data entries, invokes callable values through the
+existing receiver-aware `__apply_closure` bridge with the "number" hint, and
+throws for non-callable, object, and Symbol results. Accessor entries continue
+through the prior ordinary path so the excluded getter-abrupt control remains
+unchanged; host-mode codegen is not touched.
+
+Final validation ran after merging and retaining upstream/main at
+`698ecb8f1661454037eaed810cb2a6770f6acf7f` (merge commit
+`6d407b9c67`) and after pushing implementation commit `8f1d2a06f7`:
+
+- The exact four-row authoritative baseline was host **4/4 pass** and
+  standalone **0/4 pass, 4/4 assertion_fail**. The synchronized final tree is
+  host **4/4 pass** and standalone **4/4 pass**.
+- Two complete repeats produced the same result for every approved row (16/16
+  host/standalone executions passed). The diagnostic
+  `toprimitive-get-abrupt.js` control remained **fail** in both modes on both
+  repeats, as required by its host-red baseline and this lane's bounded scope.
+- With `JS2WASM_FUSED_TONUMBER=0` and `JS2WASM_SMI_FASTPATH=0`, the standalone
+  four-row cohort remained **4/4 pass**.
+- Focused `tests/issue-5102-isnan-toprimitive.test.ts`: **10/10 passed**,
+  covering the exact host and standalone rows, numeric/string/nullish/
+  ordinary-object controls, a host-free standalone module, and the excluded
+  getter control.
+- The normal pre-push gates passed on `8f1d2a06f7`: typecheck, lint, Prettier,
+  oracle/coercion-site ratchets, numeric-local IR parity (18/18), and issue
+  integrity, with `TEST262_WORKERS=2`. No full 11,704-row census was run.
+
+The plan checkpoint is `df96e0d86b`; implementation checkpoint is
+`8f1d2a06f7`. The upstream PR handoff URL will be appended after opening the
+single compliant PR; no GitHub issue is created or linked.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -4790,6 +4790,11 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     const L_RESULT = 4;
     // #1910/#1472 S2 — the boxed-primitive internal-slot $PropEntry (or null).
     const L_SLOT = 5;
+    // #5102 — the own Symbol.toPrimitive entry (or null). Keep this probe on
+    // the raw data-property path so the bounded standalone fix does not widen
+    // the known accessor/getter control into a new behavior change.
+    const L_ENTRY = 6;
+    const L_ARGS = 7;
 
     // (#4564) `undefined` is a non-null `$AnyValue` singleton; rejecting it
     // would incorrectly advance from `valueOf` to `toString`. BigInt and the
@@ -4803,7 +4808,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       typeofUndefinedIdx,
       typeofBigintIdx,
     ];
-    const returnIfPrimitive = (localIdx: number): Instr[] => [
+    const returnIfPrimitive = (localIdx: number, includeSymbol = true): Instr[] => [
       { op: "local.get", index: localIdx },
       { op: "ref.is_null" },
       {
@@ -4820,7 +4825,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
           then: [{ op: "local.get", index: localIdx }, { op: "return" }],
         },
       ]),
-      ...(symbolKeysEnabled
+      ...(includeSymbol && symbolKeysEnabled
         ? ([
             { op: "local.get", index: localIdx },
             { op: "any.convert_extern" },
@@ -4917,6 +4922,106 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         ],
       },
     ];
+
+    // (#5102) Standalone ToNumber reaches this helper through isNaN. Probe the
+    // native Symbol.toPrimitive key before OrdinaryToPrimitive, and invoke an
+    // own DATA method with the actual receiver plus the one required hint
+    // argument. The raw __obj_find path is intentional: accessor invocation is
+    // outside this four-row cohort and remains the excluded getter-abrupt
+    // control. Missing/accessor entries continue through the existing ordinary
+    // method path unchanged.
+    const ownSymbolToPrimitive = (): Instr[] => {
+      if (!symbolKeysEnabled) return [];
+      const boxSymbolIdx = ctx.funcMap.get("__box_symbol");
+      if (boxSymbolIdx === undefined) return [];
+      const applyClosureIdx = reserveApplyClosure(ctx);
+      const ownDataMethod: Instr[] = [
+        { op: "local.get", index: L_ENTRY },
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+        { op: "i32.const", value: FLAG_ACCESSOR },
+        { op: "i32.and" },
+        { op: "i32.eqz" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: L_ENTRY },
+            { op: "ref.as_non_null" },
+            { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+            { op: "extern.convert_any" },
+            ...s1ToPrimNorm.map((i) => ({ ...i })),
+            { op: "local.set", index: L_METHOD },
+            { op: "local.get", index: L_METHOD },
+            { op: "ref.is_null" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [],
+              else: [
+                { op: "local.get", index: L_METHOD },
+                { op: "call", funcIdx: typeofFunctionIdx },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    { op: "call", funcIdx: objVecNewIdx },
+                    { op: "local.set", index: L_ARGS },
+                    { op: "local.get", index: L_ARGS },
+                    { op: "local.get", index: 1 },
+                    { op: "call", funcIdx: objVecPushIdx },
+                    { op: "local.get", index: L_METHOD },
+                    { op: "local.get", index: 0 },
+                    { op: "local.get", index: L_ARGS },
+                    { op: "call", funcIdx: applyClosureIdx },
+                    { op: "local.set", index: L_RESULT },
+                    ...returnIfPrimitive(L_RESULT, false),
+                    // ToNumber(Symbol) is abrupt. Keep the Symbol result for
+                    // string-hint users such as ToPropertyKey; number/default
+                    // consumers must throw before __unbox_number can degrade
+                    // the carrier to NaN.
+                    { op: "local.get", index: L_RESULT },
+                    { op: "any.convert_extern" },
+                    { op: "ref.test", typeIdx: symbolTypeIdx },
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: [
+                        ...isStringHint,
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [{ op: "local.get", index: L_RESULT }, { op: "return" }],
+                          else: [...throwTypeError()],
+                        },
+                      ],
+                      else: [...throwTypeError()],
+                    },
+                    ...throwTypeError(),
+                  ],
+                  else: [...throwTypeError()],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      return [
+        { op: "local.get", index: L_ANY },
+        { op: "ref.cast", typeIdx: objectTypeIdx },
+        { op: "i32.const", value: 3 }, // well-known Symbol.toPrimitive
+        { op: "call", funcIdx: boxSymbolIdx },
+        { op: "call", funcIdx: objFindIdx },
+        { op: "local.tee", index: L_ENTRY },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [],
+          else: ownDataMethod,
+        },
+      ];
+    };
 
     // (#4492 wave-5) FACTORIES — each call returns fresh `Instr` objects, so the
     // two emission sites below never alias one array into two tree positions.
@@ -5076,6 +5181,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       // #1910/#1472 S2 — boxed primitive wrapper short-circuit, now GATED on "no
       // own valueOf/toString" (#4492 wave-5). Full rationale + the measured
       // failure on `buildWrapperSlotShortCircuit` / `buildOwnToPrimitiveOverridePresent`.
+      ...ownSymbolToPrimitive(),
       ...ownToPrimitiveOverridePresent(),
       { op: "i32.eqz" },
       { op: "if", blockType: { kind: "empty" }, then: wrapperSlotShortCircuit() },
@@ -5099,6 +5205,8 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         { name: "method", type: { kind: "externref" } },
         { name: "result", type: { kind: "externref" } },
         { name: "slot", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
+        { name: "entry", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
+        { name: "args", type: { kind: "externref" } },
       ],
       body,
     );

--- a/tests/issue-5102-isnan-toprimitive.test.ts
+++ b/tests/issue-5102-isnan-toprimitive.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5102 — standalone isNaN must observe an own data-valued Symbol.toPrimitive
+// method and propagate its abrupt/non-primitive results.
+
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const COHORT = [
+  "built-ins/isNaN/toprimitive-call-abrupt.js",
+  "built-ins/isNaN/toprimitive-not-callable-throws.js",
+  "built-ins/isNaN/toprimitive-result-is-object-throws.js",
+  "built-ins/isNaN/toprimitive-result-is-symbol-throws.js",
+] as const;
+
+const GETTER_CONTROL = "built-ins/isNaN/toprimitive-get-abrupt.js";
+
+const CONTROL_SOURCE = `
+  function catches(f: any): number {
+    try { f(); return 0; } catch (_) { return 1; }
+  }
+
+  export function test(): number {
+    const abrupt: any = {};
+    abrupt[Symbol.toPrimitive] = function (_hint: string): any { throw 1; };
+    const nonCallable: any = {};
+    nonCallable[Symbol.toPrimitive] = 42;
+    const objectResult: any = {};
+    objectResult[Symbol.toPrimitive] = function (_hint: string): any { return [42]; };
+    const symbolResult: any = {};
+    symbolResult[Symbol.toPrimitive] = function (_hint: string): any { return Symbol.toPrimitive; };
+    const ordinary: any = { valueOf: function (): number { return 7; } };
+
+    return catches(function (): any { return isNaN(abrupt); }) +
+      catches(function (): any { return isNaN(nonCallable); }) +
+      catches(function (): any { return isNaN(objectResult); }) +
+      catches(function (): any { return isNaN(symbolResult); }) +
+      (isNaN(1) === false ? 1 : 0) +
+      (isNaN("not-a-number") === true ? 1 : 0) +
+      (isNaN(null) === false ? 1 : 0) +
+      (isNaN(ordinary) === false ? 1 : 0);
+  }
+`;
+
+async function run(file: string, target?: "standalone") {
+  return runTest262File(join("test262/test", file), "issue-5102", 120_000, target);
+}
+
+async function runStandaloneControl(): Promise<{ result: number; imports: string[] }> {
+  const compiled = await compile(CONTROL_SOURCE, {
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+    fileName: "issue-5102-isnan-toprimitive-control.ts",
+  });
+  expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+  if (!compiled.success) return { result: -1, imports: [] };
+  const module = await WebAssembly.compile(compiled.binary);
+  const imports = WebAssembly.Module.imports(module).map((entry) => `${entry.module}::${entry.name}`);
+  const { instance } = await WebAssembly.instantiate(compiled.binary, {});
+  return { result: (instance.exports as { test: () => number }).test(), imports };
+}
+
+describe("#5102 — standalone isNaN Symbol.toPrimitive abrupt results", () => {
+  it.each(COHORT)("passes the exact host row %s", async (file) => {
+    const result = await run(file);
+    expect(result.status, `${file}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
+  });
+
+  it.each(COHORT)("passes the exact standalone row %s", async (file) => {
+    const result = await run(file, "standalone");
+    expect(result.status, `${file}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
+  });
+
+  it("keeps ordinary isNaN conversions and abrupt/non-primitive controls host-free", async () => {
+    const { result, imports } = await runStandaloneControl();
+    expect(result).toBe(8);
+    expect(imports).toEqual([]);
+  });
+
+  it("leaves the excluded accessor/getter-abrupt control unchanged", async () => {
+    const host = await run(GETTER_CONTROL);
+    const standalone = await run(GETTER_CONTROL, "standalone");
+    expect(host.status).toBe("fail");
+    expect(standalone.status).toBe("fail");
+  });
+});

--- a/tests/issue-5102-isnan-toprimitive.test.ts
+++ b/tests/issue-5102-isnan-toprimitive.test.ts
@@ -4,6 +4,7 @@
 // method and propagate its abrupt/non-primitive results.
 
 import { join } from "node:path";
+import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 import { runTest262File } from "./test262-runner.js";
@@ -14,8 +15,6 @@ const COHORT = [
   "built-ins/isNaN/toprimitive-result-is-object-throws.js",
   "built-ins/isNaN/toprimitive-result-is-symbol-throws.js",
 ] as const;
-
-const GETTER_CONTROL = "built-ins/isNaN/toprimitive-get-abrupt.js";
 
 const CONTROL_SOURCE = `
   function catches(f: any): number {
@@ -44,6 +43,23 @@ const CONTROL_SOURCE = `
   }
 `;
 
+const GETTER_CONTROL_SOURCE = `
+  export function test(): number {
+    let getterCalls = 0;
+    const accessor: any = {};
+    Object.defineProperty(accessor, Symbol.toPrimitive, {
+      get: function (): any {
+        getterCalls = getterCalls + 1;
+        throw 1;
+      },
+    });
+    try { isNaN(accessor); } catch (_) {}
+    return getterCalls;
+  }
+`;
+
+const corpusIt = existsSync(join("test262", "harness", "assert.js")) ? it : it.skip;
+
 async function run(file: string, target?: "standalone") {
   return runTest262File(join("test262/test", file), "issue-5102", 120_000, target);
 }
@@ -62,13 +78,25 @@ async function runStandaloneControl(): Promise<{ result: number; imports: string
   return { result: (instance.exports as { test: () => number }).test(), imports };
 }
 
+async function runStandaloneGetterControl(): Promise<number> {
+  const compiled = await compile(GETTER_CONTROL_SOURCE, {
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+    fileName: "issue-5102-isnan-toprimitive-getter-control.ts",
+  });
+  expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+  if (!compiled.success) return -1;
+  const { instance } = await WebAssembly.instantiate(compiled.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
 describe("#5102 — standalone isNaN Symbol.toPrimitive abrupt results", () => {
-  it.each(COHORT)("passes the exact host row %s", async (file) => {
+  corpusIt.each(COHORT)("passes the exact host row %s", async (file) => {
     const result = await run(file);
     expect(result.status, `${file}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
   });
 
-  it.each(COHORT)("passes the exact standalone row %s", async (file) => {
+  corpusIt.each(COHORT)("passes the exact standalone row %s", async (file) => {
     const result = await run(file, "standalone");
     expect(result.status, `${file}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
   });
@@ -80,9 +108,6 @@ describe("#5102 — standalone isNaN Symbol.toPrimitive abrupt results", () => {
   });
 
   it("leaves the excluded accessor/getter-abrupt control unchanged", async () => {
-    const host = await run(GETTER_CONTROL);
-    const standalone = await run(GETTER_CONTROL, "standalone");
-    expect(host.status).toBe("fail");
-    expect(standalone.status).toBe("fail");
+    await expect(runStandaloneGetterControl()).resolves.toBe(0);
   });
 });


### PR DESCRIPTION
## Description

- Problem: standalone global `isNaN` ignored own `Symbol.toPrimitive` data properties, replacing required abrupt completions with normal NaN results.
- Behavior: probe the native object data-property table, invoke callable coercion hooks with the number hint, and preserve catchable errors for non-callable, object, and Symbol results without changing the host lane or excluded accessor path.
- Tests: exact Test262 cohort is 4/4 in both host and standalone across repeats; focused coverage is 10/10 with the corpus and 2 mandatory controls pass with 8 corpus cases skipped in the hermetic no-corpus shape; scoped pre-push gates pass.
- Tracking: `plan/issues/5102-es2015-isnan-toprimitive-abrupt.md`.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->