### PR TITLE
fix(ir): own ambient inverse-trig calls

### DIFF
--- a/plan/issues/5105-ir-exact-ambient-math-inverse-trig.md
+++ b/plan/issues/5105-ir-exact-ambient-math-inverse-trig.md
@@ -1,0 +1,110 @@
+---
+id: 5105
+title: "IR: own exact ambient Math.asin/Math.acos calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5105-ir-math-inverse-trig
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5103]
+related: [1371, 3204, 3526, 4787, 5092, 5094, 5101]
+files:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5105-ir-math-inverse-trig.test.ts
+loc-budget-allow:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5105 — Exact ambient `Math.asin` / `Math.acos` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.asin(numberExpression)` and `Math.acos(numberExpression)` calls in
+otherwise IR-eligible synchronous functions. Represent both source calls as
+versioned semantic intrinsics and reuse the existing host-free `Math_asin` and
+`Math_acos` implementations plus their established `Math_atan` dependency.
+
+This coherent inverse-trigonometry checkpoint is intentionally stacked on
+#5108/#5103. It changes ownership only; the approximations and direct-codegen
+fallback remain untouched.
+
+## Measured residual
+
+Neither method appears in `IR_MATH_METHOD_TABLE`, so the selector declines and
+the legacy builtin path emits `Math_asin` / `Math_acos`. Both runtime bodies
+already exist in `src/codegen/math-helpers.ts`, where requesting either method
+materializes `Math_atan` before the derived helper. The missing contract is the
+closed semantic intrinsic/provider graph.
+
+## Exact admitted grammar
+
+For each method, admit only `Math.<method>(argument)` when `Math` is the
+unshadowed ambient binding, there is exactly one non-spread argument, the
+selector proves primitive `number`, symbolic Math helpers are available, and
+the containing unit passes ordinary ownership/call-graph gates. Aliased,
+computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
+
+## Implementation plan
+
+1. Add `math.asin` and `math.acos` to the closed intrinsic/runtime-feature
+   vocabularies with unary-f64 signatures.
+2. Add `selfhost.math.asin -> Math_asin` and
+   `selfhost.math.acos -> Math_acos`; declare `math.atan` as the dependency of
+   each provider.
+3. Add both methods to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
+   call-graph walker, from-AST emitter, manifest, and provider materializer.
+4. Add independent `JS2WASM_IR_MATH_ASIN=0` and
+   `JS2WASM_IR_MATH_ACOS=0` rollbacks so either claim can be withdrawn alone.
+5. Widen #3526 exhaustive vocabulary, dependency, integration, linear-legality,
+   and neutrality evidence from fourteen to sixteen source Math intrinsics.
+6. Add focused host/standalone, provider-closure, numerical-parity, rollback,
+   and pre-claim exclusion tests for both methods.
+7. Run focused suites, TypeScript 7, formatting/lint/ratchets, full pre-push
+   checks, then push and open a non-draft PR stacked on #5108.
+
+## Acceptance criteria
+
+- Exact ambient one-number `Math.asin` and `Math.acos` calls emit IR only and
+  attach the existing self-hosted callables.
+- The manifest closes both features over exactly one deduplicated `math.atan`
+  provider and requests no host capability.
+- Host and zero-import standalone execution match the direct path across
+  domain boundaries, finite values, NaN, infinities, and signed zero.
+- Each rollback withdraws only its corresponding method.
+- Excluded shapes decline before claim without invariants or post-claim errors.
+- Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, computed/extracted calls, `.call`, or
+  `.apply`.
+- Another Math-table expansion, a new inverse-trig approximation, host import,
+  or direct-codegen behavior change.
+- Async, class, module-init, or multi-source ownership expansion.
+
+## Risk and rollback
+
+The principal risk is dependency or source-identity drift. Both semantic
+features must depend on `math.atan` without duplicating its provider, while the
+shared table remains the sole grammar contract. Independent environment flags
+provide narrow checkpoint rollback; `JS2WASM_IR_FIRST=0` remains the global
+control.

--- a/plan/issues/5105-ir-exact-ambient-math-inverse-trig.md
+++ b/plan/issues/5105-ir-exact-ambient-math-inverse-trig.md
@@ -1,7 +1,7 @@
 ---
 id: 5105
 title: "IR: own exact ambient Math.asin/Math.acos calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -92,6 +92,31 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
 - Each rollback withdraws only its corresponding method.
 - Excluded shapes decline before claim without invariants or post-claim errors.
 - Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
+
+## Implementation outcome and validation
+
+- `math.asin` and `math.acos` are now the fifteenth and sixteenth closed
+  source-level Math intrinsics. Both reuse the shared table, generic selector,
+  call-graph walker, and from-AST intrinsic emitter.
+- The frozen manifest attaches the existing `Math_asin` and `Math_acos`
+  callables, declares `math.atan` as each provider's sole dependency, and
+  materializes that dependency once. No Math algorithm or direct-codegen file
+  changed.
+- Independent `JS2WASM_IR_MATH_ASIN=0` and
+  `JS2WASM_IR_MATH_ACOS=0` controls withdraw only their corresponding claim.
+  Shadowed, aliased, wrong-arity, spread, and non-number forms decline before
+  claim for both methods.
+- Four focused/affected suites pass 30/30. They cover host and zero-import
+  standalone ownership, semantic/provider evidence, exact dependency closure,
+  direct parity across domain boundaries, NaN, infinities and signed zero,
+  an independent native-Math oracle over fifteen boundary/interior samples per
+  method (at most `1e-9` absolute error plus explicit ULP ratchets), independent
+  rollbacks, exhaustive integration, every target/backend manifest policy, and
+  linear-backend legality.
+- TypeScript 7, Prettier, Biome lint, the IR kind-neutrality gate, LOC/function
+  budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue
+  integrity pass. Luna Max re-review after the numerical-oracle fix returned GO
+  with no P0/P1 finding.
 
 ## Non-goals
 

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 14 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 16 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,8 +353,8 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 14 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:24"],
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 16 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:26"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -13,6 +13,8 @@ import { irTypeEquals, type IrInstr, type IrType } from "./nodes.js";
 
 export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.abs",
+  "math.acos",
+  "math.asin",
   "math.atan",
   "math.atan2",
   "math.ceil",
@@ -31,11 +33,13 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the fourteen intrinsic entry points.
+ * Provider requirements reachable from the sixteen intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.abs",
+  "math.acos",
+  "math.asin",
   "math.atan",
   "math.atan2",
   "math.ceil",
@@ -128,6 +132,8 @@ function definition(id: IntrinsicId, signature: IntrinsicSignature, feature: Run
 /** Exhaustive entry contract. Record typing makes an added ID fail closed. */
 export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefinition>> = Object.freeze({
   "math.abs": definition("math.abs", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.acos": definition("math.acos", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.asin": definition("math.asin", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.atan": definition("math.atan", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.atan2": definition("math.atan2", F64_BINARY_INTRINSIC_SIGNATURE),
   "math.ceil": definition("math.ceil", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -51,6 +51,8 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "backend.f64.floor",
   "backend.f64.sqrt",
   "backend.f64.trunc",
+  "selfhost.math.acos",
+  "selfhost.math.asin",
   "selfhost.math.atan",
   "selfhost.math.atan2",
   "selfhost.math.cos",
@@ -169,6 +171,8 @@ const ALL_BACKENDS = Object.freeze<readonly RuntimeBackend[]>(["linear", "wasmgc
 
 export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature, IntrinsicSignature>>> = Object.freeze({
   "math.abs": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.acos": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.asin": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.atan": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.atan2": F64_BINARY_INTRINSIC_SIGNATURE,
   "math.ceil": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -209,6 +213,20 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     kind: "backend-op",
     opcode: "f64.abs",
   }),
+  "math.acos": provider(
+    "selfhost.math.acos",
+    "math.acos",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_acos" },
+    ["math.atan"],
+  ),
+  "math.asin": provider(
+    "selfhost.math.asin",
+    "math.asin",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_asin" },
+    ["math.atan"],
+  ),
   "math.atan": provider("selfhost.math.atan", "math.atan", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "self-hosted",
     symbol: "Math_atan",
@@ -282,7 +300,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
   }),
 });
 
-/** Canonically ordered default provider catalogue for the fourteen-method slice. */
+/** Canonically ordered default provider catalogue for the sixteen-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -293,6 +293,8 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   floor: { arity: 1, intrinsic: "math.floor", op: "f64.floor" },
   ceil: { arity: 1, intrinsic: "math.ceil", op: "f64.ceil" },
   trunc: { arity: 1, intrinsic: "math.trunc", op: "f64.trunc" },
+  asin: { arity: 1, intrinsic: "math.asin" },
+  acos: { arity: 1, intrinsic: "math.acos" },
   atan: { arity: 1, intrinsic: "math.atan" },
   sin: { arity: 1, intrinsic: "math.sin" },
   cos: { arity: 1, intrinsic: "math.cos" },
@@ -6471,6 +6473,8 @@ function selectorPrimitiveWrapperOrGenericBinary(
 }
 
 function selectorSupportsMathPlan(plan: IrMathMethodPlan): boolean {
+  if (plan.intrinsic === "math.asin" && process.env.JS2WASM_IR_MATH_ASIN === "0") return false;
+  if (plan.intrinsic === "math.acos" && process.env.JS2WASM_IR_MATH_ACOS === "0") return false;
   if (plan.intrinsic === "math.atan" && process.env.JS2WASM_IR_MATH_ATAN === "0") return false;
   if (plan.intrinsic === "math.tan" && process.env.JS2WASM_IR_MATH_TAN === "0") return false;
   return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -68,7 +68,8 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
     const analysis = analyzeSource(`
       export function allMath(x: number, y: number): number {
         return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.trunc(x)
-          + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x) + Math.exp(x) + Math.log(x) + Math.log2(x)
+          + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
+          + Math.exp(x) + Math.log(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
     `);
@@ -119,6 +120,8 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function floor(): number { return Math.floor(3.9); }
       export function ceil(): number { return Math.ceil(3.1); }
       export function trunc(): number { return Math.trunc(-3.9); }
+      export function asin(): number { return Math.asin(0.5); }
+      export function acos(): number { return Math.acos(0.5); }
       export function atan(): number { return Math.atan(1); }
       export function sin(): number { return Math.sin(0.75); }
       export function cos(): number { return Math.cos(0.75); }
@@ -158,7 +161,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
     for (const opcode of ["f64.abs", "f64.sqrt", "f64.floor", "f64.ceil", "f64.trunc"]) {
       expect(ir.wat).toContain(opcode);
     }
-    for (const helper of ["atan", "sin", "cos", "tan", "exp", "log", "log2", "pow", "atan2"]) {
+    for (const helper of ["asin", "acos", "atan", "sin", "cos", "tan", "exp", "log", "log2", "pow", "atan2"]) {
       expect(ir.wat).toContain(`$Math_${helper}`);
     }
     expect(ir.wat).not.toContain("$__box_number");

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,15 +88,17 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact fourteen certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact sixteen certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(14);
+    expect(intrinsicMethods).toHaveLength(16);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
-    expect(PURE_MATH_RUNTIME_FEATURES).toEqual(expect.arrayContaining(["math.atan", "math.reduce-trig", "math.tan"]));
+    expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
+      expect.arrayContaining(["math.acos", "math.asin", "math.atan", "math.reduce-trig", "math.tan"]),
+    );
     const intrinsicFeatures = new Set<string>(PURE_MATH_INTRINSIC_IDS);
     expect(PURE_MATH_RUNTIME_FEATURES.filter((feature) => !intrinsicFeatures.has(feature))).toEqual([
       "math.reduce-trig",
@@ -119,7 +121,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(14);
+    expect(first.intrinsicUses).toHaveLength(16);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -128,6 +130,8 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       first.providers.map((provider) => [provider.feature, provider.dependencies]),
     );
     expect(dependencies["math.pow"]).toEqual(["math.exp", "math.log"]);
+    expect(dependencies["math.acos"]).toEqual(["math.atan"]);
+    expect(dependencies["math.asin"]).toEqual(["math.atan"]);
     expect(dependencies["math.atan2"]).toEqual(["math.atan"]);
     expect(dependencies["math.sin"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
@@ -143,7 +147,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     for (const target of targets) {
       for (const backend of backends) {
         const builder = new RuntimeManifestBuilder(policy(target, backend));
-        addUses(builder, ["math.sin", "math.tan", "math.pow", "math.atan2"]);
+        addUses(builder, ["math.asin", "math.acos", "math.sin", "math.tan", "math.pow", "math.atan2"]);
         const manifest = builder.freeze();
         semanticClosures.push([...manifest.features]);
         expect(manifest.hostCapabilities, `${target}/${backend}`).toEqual([]);
@@ -152,6 +156,8 @@ describe("#3526 typed IR runtime manifest foundation", () => {
 
     expect(new Set(semanticClosures.map((features) => features.join("|")))).toHaveLength(1);
     expect(semanticClosures[0]).toEqual([
+      "math.acos",
+      "math.asin",
       "math.atan",
       "math.atan2",
       "math.cos",

--- a/tests/issue-5105-ir-math-inverse-trig.test.ts
+++ b/tests/issue-5105-ir-math-inverse-trig.test.ts
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5105-ir-math-inverse-trig");
+const METHODS = ["asin", "acos"] as const;
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+const exclusionCases = METHODS.flatMap(
+  (method) =>
+    [
+      [
+        `${method} with shadowed Math`,
+        `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5105 shadowed Math is intentionally not ambient.
+      return Math.${method}(x);
+    }`,
+      ],
+      [
+        `aliased ${method}`,
+        `const inverse = Math.${method};
+    export function f(x: number): number { return inverse(x); }`,
+      ],
+      [
+        `${method} wrong arity`,
+        `export function f(x: number): number {
+      // @ts-expect-error #5105 intentionally exercises extra arity.
+      return Math.${method}(x, x);
+    }`,
+      ],
+      [
+        `${method} spread argument`,
+        `export function f(x: number): number {
+      return Math.${method}(...([x] as [number]));
+    }`,
+      ],
+      [
+        `${method} non-number argument`,
+        `export function f(): number {
+      const text: string = "1";
+      return Math.${method}(text as never);
+    }`,
+      ],
+    ] as const,
+);
+
+describe("#5105 exact ambient Math.asin/Math.acos IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims both exact one-number calls on the %s target", async (_label, target) => {
+    const result = await compile(
+      `
+        export function asin(value: number): number { return Math.asin(value); }
+        export function acos(value: number): number { return Math.acos(value); }
+      `,
+      {
+        fileName: `issue-5105-${_label}.ts`,
+        ...(target === undefined ? {} : { target }),
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+      },
+    );
+    expectSuccess(result);
+
+    for (const method of METHODS) {
+      expect(outcomeFor(result, method)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(result.irCompiledFuncs ?? []).toContain(method);
+      expect(result.wat).toContain(`$Math_${method}`);
+    }
+    expect(result.wat).toContain("$Math_atan");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const exports = await instantiate(result);
+    expect(typeof exports.asin).toBe("function");
+    expect(typeof exports.acos).toBe("function");
+
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches both existing providers to one deduplicated Math_atan dependency", () => {
+    const analysis = analyzeSource(`
+      export function inverse(value: number): number {
+        return Math.asin(value) + Math.acos(value);
+      }
+    `);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing inverse declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("inverse").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id).sort()).toEqual(["math.acos", "math.asin"]);
+    expect(semantic.every((instr) => instr.provider === undefined)).toBe(true);
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id).sort()).toEqual(["math.acos", "math.asin"]);
+    expect(prepared.manifest.features).toEqual(["math.acos", "math.asin", "math.atan"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    const dependencies = Object.fromEntries(
+      prepared.manifest.providers.map((provider) => [provider.feature, provider.dependencies]),
+    );
+    expect(dependencies).toMatchObject({
+      "math.acos": ["math.atan"],
+      "math.asin": ["math.atan"],
+      "math.atan": [],
+    });
+    expect(new Set(prepared.manifest.providers.map((provider) => provider.id))).toEqual(
+      new Set(["selfhost.math.acos", "selfhost.math.asin", "selfhost.math.atan"]),
+    );
+
+    for (const instr of intrinsicInstructions(prepared.functions[0]!)) {
+      expect(instr.provider).toMatchObject({
+        kind: "callable",
+        target: { name: `Math_${instr.id.slice(5)}`, binding: { kind: "intrinsic", symbol: instr.id } },
+      });
+    }
+  });
+
+  it("matches the direct path across domain boundaries, NaN, infinities, and signed zero", async () => {
+    const source = `
+      export function asin(value: number): number { return Math.asin(value); }
+      export function acos(value: number): number { return Math.acos(value); }
+    `;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5105-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5105-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+
+    const irExports = await instantiate(ir);
+    const directExports = await instantiate(direct);
+    for (const method of METHODS) {
+      expect(outcomeFor(ir, method)).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+      const irFn = irExports[method] as (value: number) => number;
+      const directFn = directExports[method] as (value: number) => number;
+      for (const value of [-1, -0.5, -0, 0, 0.5, 1]) {
+        expect(Object.is(irFn(value), directFn(value)), `${method} parity for ${String(value)}`).toBe(true);
+      }
+      for (const value of [Number.NaN, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) {
+        expect(Number.isNaN(irFn(value)), `IR ${method} for ${String(value)}`).toBe(true);
+        expect(Number.isNaN(directFn(value)), `direct ${method} for ${String(value)}`).toBe(true);
+      }
+    }
+  });
+
+  it.each([
+    ["asin", "JS2WASM_IR_MATH_ASIN", "acos"],
+    ["acos", "JS2WASM_IR_MATH_ACOS", "asin"],
+  ] as const)("withdraws only %s through its narrow rollback", async (disabled, flag, retained) => {
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(
+        `
+          export function asin(value: number): number { return Math.asin(value); }
+          export function acos(value: number): number { return Math.acos(value); }
+        `,
+        { fileName: `issue-5105-${disabled}-rollback.ts`, experimentalIR: true, trackIrOutcomes: true },
+      );
+      expectSuccess(result);
+      expect(outcomeFor(result, disabled)).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(outcomeFor(result, retained)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5105-${_label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});

--- a/tests/issue-5105-ir-math-inverse-trig.test.ts
+++ b/tests/issue-5105-ir-math-inverse-trig.test.ts
@@ -13,6 +13,21 @@ import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js"
 
 const identities = createTestIrFunctionIdentityFactory("issue-5105-ir-math-inverse-trig");
 const METHODS = ["asin", "acos"] as const;
+const U64_MASK = (1n << 64n) - 1n;
+const U64_SIGN = 1n << 63n;
+
+function orderedFloatBits(value: number): bigint {
+  const view = new DataView(new ArrayBuffer(8));
+  view.setFloat64(0, value, false);
+  const bits = view.getBigUint64(0, false);
+  return (bits & U64_SIGN) !== 0n ? ~bits & U64_MASK : bits | U64_SIGN;
+}
+
+function ulpDistance(left: number, right: number): bigint {
+  const leftBits = orderedFloatBits(left);
+  const rightBits = orderedFloatBits(right);
+  return leftBits > rightBits ? leftBits - rightBits : rightBits - leftBits;
+}
 
 function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
   const instructions: IrInstrIntrinsic[] = [];
@@ -199,6 +214,36 @@ describe("#5105 exact ambient Math.asin/Math.acos IR ownership", () => {
       for (const value of [Number.NaN, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) {
         expect(Number.isNaN(irFn(value)), `IR ${method} for ${String(value)}`).toBe(true);
         expect(Number.isNaN(directFn(value)), `direct ${method} for ${String(value)}`).toBe(true);
+      }
+    }
+  });
+
+  it("pins the established native-Math accuracy envelope near boundaries and in the interior", async () => {
+    const result = await compile(
+      `
+        export function asin(value: number): number { return Math.asin(value); }
+        export function acos(value: number): number { return Math.acos(value); }
+      `,
+      { fileName: "issue-5105-native-oracle.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expectSuccess(result);
+    const exports = await instantiate(result);
+    const samples = [
+      -1, -0.9999999999999999, -0.999999, -0.99, -0.9, -0.5, -0.1, 0, 0.1, 0.5, 0.9, 0.99, 0.999999, 0.9999999999999999,
+      1,
+    ];
+    const maxUlps = { asin: 4_000_000n, acos: 16_000_000n } as const;
+
+    for (const method of METHODS) {
+      const compiled = exports[method] as (value: number) => number;
+      const native = Math[method];
+      for (const value of samples) {
+        const actual = compiled(value);
+        const expected = native(value);
+        expect(Math.abs(actual - expected), `${method} absolute error for ${value}`).toBeLessThanOrEqual(1e-9);
+        expect(ulpDistance(actual, expected), `${method} ULP distance for ${value}`).toBeLessThanOrEqual(
+          maxUlps[method],
+        );
       }
     }
   });


### PR DESCRIPTION
## Summary

- promote exact ambient `Math.asin(number)` and `Math.acos(number)` to closed semantic IR intrinsics
- attach the existing self-hosted providers with one deduplicated `math.atan` dependency
- preserve independent direct fallbacks through `JS2WASM_IR_MATH_ASIN=0` and `JS2WASM_IR_MATH_ACOS=0`
- extend exhaustive manifest, integration, linear-legality, neutrality, parity, rollback, exclusion, and native-accuracy evidence

## Dependency

This PR is intentionally stacked on #5108. Retarget it to `main` after #5108 lands.

## Validation

- 30/30 focused and affected tests passed across four suites
- independent native-Math oracle covers 15 boundary/interior samples per method with <=1e-9 absolute error and explicit ULP regression ceilings
- TypeScript 7 typecheck passed
- Prettier, Biome lint, IR-kind neutrality, LOC/function budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue integrity passed
- host and zero-import standalone execution match the direct path
- Luna Max re-review after the numerical-oracle fix: GO, no P0/P1 findings