### PR TITLE
feat(ir): own exact Math.log10 and Math.log1p calls

### DIFF
--- a/plan/issues/5106-ir-exact-ambient-math-derived-log.md
+++ b/plan/issues/5106-ir-exact-ambient-math-derived-log.md
@@ -105,9 +105,9 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
   changed.
 - Independent `JS2WASM_IR_MATH_LOG10=0` and
   `JS2WASM_IR_MATH_LOG1P=0` controls withdraw only their corresponding claim.
-  Shadowed, aliased, computed, wrong-arity, spread, and non-number forms all
-  decline before claim.
-- Four focused/affected suites pass 32/32. They cover host and zero-import
+  Shadowed, aliased, computed, optional-invocation, optional-receiver,
+  wrong-arity, spread, and non-number forms all decline before claim.
+- Four focused/affected suites pass 36/36. They cover host and zero-import
   standalone ownership, semantic/provider evidence, exact dependency closure,
   bit-identical direct-path parity across domain boundaries and the established
   `log10` snap window, explicit native-Math accuracy envelopes, independent
@@ -115,8 +115,10 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
   and linear-backend legality.
 - TypeScript 7, Prettier, Biome lint, the IR kind-neutrality gate, LOC/function
   budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue
-  integrity pass. Luna Max dependency and numerical-risk audits confirmed the
-  ownership-only scope and the method-specific oracle bounds.
+  integrity pass. Luna Max re-review after tightening the optional-call claim
+  boundary returned GO with no P0/P1 finding; it also confirmed the `log10`
+  snap is inherited #3226 behavior preserved bit-for-bit by this ownership
+  migration.
 - PR #5111 is open non-draft, clean, and green, stacked on #5110's exact head.
 
 ## Non-goals

--- a/plan/issues/5106-ir-exact-ambient-math-derived-log.md
+++ b/plan/issues/5106-ir-exact-ambient-math-derived-log.md
@@ -1,0 +1,111 @@
+---
+id: 5106
+title: "IR: own exact ambient Math.log10/Math.log1p calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5106-ir-math-log10-log1p
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5105]
+related: [1371, 3204, 3226, 3526, 4787, 5092, 5094, 5101, 5103]
+files:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5106-ir-math-derived-log.test.ts
+loc-budget-allow:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5106 — Exact ambient `Math.log10` / `Math.log1p` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.log10(numberExpression)` and `Math.log1p(numberExpression)` calls in
+otherwise IR-eligible synchronous functions. Represent both source calls as
+versioned semantic intrinsics and reuse the existing host-free `Math_log10`
+and `Math_log1p` implementations plus their shared `Math_log` dependency.
+
+This paired derived-log checkpoint is intentionally stacked on #5110/#5105.
+It changes ownership only; the established approximations and direct-codegen
+fallback remain untouched.
+
+## Measured residual
+
+Neither method appears in `IR_MATH_METHOD_TABLE`, so the selector declines and
+the legacy builtin path emits `Math_log10` / `Math_log1p`. Both self-hosted
+runtime bodies already exist in `src/stdlib/math.ts`, and direct codegen already
+materializes `Math_log` before either derived helper. The missing contract is
+the closed semantic intrinsic/provider graph.
+
+## Exact admitted grammar
+
+For each method, admit only `Math.<method>(argument)` when `Math` is the
+unshadowed ambient binding, there is exactly one non-spread argument, the
+selector proves primitive `number`, symbolic Math helpers are available, and
+the containing unit passes ordinary ownership/call-graph gates. Aliased,
+computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
+
+## Implementation plan
+
+1. Add `math.log10` and `math.log1p` to the closed intrinsic/runtime-feature
+   vocabularies with unary-f64 signatures.
+2. Add `selfhost.math.log10 -> Math_log10` and
+   `selfhost.math.log1p -> Math_log1p`; declare `math.log` as the dependency of
+   each provider.
+3. Add both methods to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
+   call-graph walker, from-AST emitter, manifest, and provider materializer.
+4. Add independent `JS2WASM_IR_MATH_LOG10=0` and
+   `JS2WASM_IR_MATH_LOG1P=0` rollbacks so either claim can be withdrawn alone.
+5. Widen #3526 exhaustive vocabulary, dependency, integration,
+   linear-legality, and neutrality evidence from sixteen to eighteen source
+   Math intrinsics.
+6. Add focused host/standalone, provider-closure, numerical-parity and
+   native-oracle, rollback, and pre-claim exclusion tests for both methods.
+7. Run focused suites, TypeScript 7, formatting/lint/ratchets, full pre-push
+   checks, then push and open a non-draft PR stacked on #5110.
+
+## Acceptance criteria
+
+- Exact ambient one-number `Math.log10` and `Math.log1p` calls emit IR only and
+  attach the existing self-hosted callables.
+- The manifest closes both features over exactly one deduplicated `math.log`
+  provider and requests no host capability.
+- Host and zero-import standalone execution preserve direct-path behavior and
+  stay inside explicit native-Math absolute/ULP regression bounds.
+- Each rollback withdraws only its corresponding method.
+- Excluded shapes decline before claim without invariants or post-claim errors.
+- Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, computed/extracted calls, `.call`, or
+  `.apply`.
+- A new logarithm approximation, host import, or direct-codegen behavior
+  change.
+- Async, class, module-init, or multi-source ownership expansion.
+
+## Risk and rollback
+
+The principal risk is dependency or numerical-evidence drift. Both semantic
+features must depend on `math.log` without duplicating its provider, and the
+shared table must remain the sole grammar contract. Independent environment
+flags provide narrow checkpoint rollback; `JS2WASM_IR_FIRST=0` remains the
+global control.

--- a/plan/issues/5106-ir-exact-ambient-math-derived-log.md
+++ b/plan/issues/5106-ir-exact-ambient-math-derived-log.md
@@ -1,7 +1,7 @@
 ---
 id: 5106
 title: "IR: own exact ambient Math.log10/Math.log1p calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -93,6 +93,31 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
 - Each rollback withdraws only its corresponding method.
 - Excluded shapes decline before claim without invariants or post-claim errors.
 - Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
+
+## Implementation outcome and validation
+
+- `math.log10` and `math.log1p` are now the seventeenth and eighteenth
+  closed source-level Math intrinsics. Both reuse the shared table, generic
+  selector, call-graph walker, and from-AST intrinsic emitter.
+- The frozen manifest attaches the existing `Math_log10` and `Math_log1p`
+  callables, declares `math.log` as each provider's sole dependency, and
+  materializes that dependency once. No Math algorithm or direct-codegen file
+  changed.
+- Independent `JS2WASM_IR_MATH_LOG10=0` and
+  `JS2WASM_IR_MATH_LOG1P=0` controls withdraw only their corresponding claim.
+  Shadowed, aliased, computed, wrong-arity, spread, and non-number forms all
+  decline before claim.
+- Four focused/affected suites pass 32/32. They cover host and zero-import
+  standalone ownership, semantic/provider evidence, exact dependency closure,
+  bit-identical direct-path parity across domain boundaries and the established
+  `log10` snap window, explicit native-Math accuracy envelopes, independent
+  rollbacks, exhaustive integration, every target/backend manifest policy,
+  and linear-backend legality.
+- TypeScript 7, Prettier, Biome lint, the IR kind-neutrality gate, LOC/function
+  budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue
+  integrity pass. Luna Max dependency and numerical-risk audits confirmed the
+  ownership-only scope and the method-specific oracle bounds.
+- PR #5111 is open non-draft, clean, and green, stacked on #5110's exact head.
 
 ## Non-goals
 

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 16 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 18 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,8 +353,8 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 16 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:26"],
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 18 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:28"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -22,6 +22,8 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.exp",
   "math.floor",
   "math.log",
+  "math.log10",
+  "math.log1p",
   "math.log2",
   "math.pow",
   "math.sin",
@@ -33,7 +35,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the sixteen intrinsic entry points.
+ * Provider requirements reachable from the eighteen intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -47,6 +49,8 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.exp",
   "math.floor",
   "math.log",
+  "math.log10",
+  "math.log1p",
   "math.log2",
   "math.pow",
   "math.reduce-trig",
@@ -141,6 +145,8 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.exp": definition("math.exp", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.floor": definition("math.floor", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log": definition("math.log", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.log10": definition("math.log10", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.log1p": definition("math.log1p", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log2": definition("math.log2", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.pow": definition("math.pow", F64_BINARY_INTRINSIC_SIGNATURE),
   "math.sin": definition("math.sin", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -58,6 +58,8 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.cos",
   "selfhost.math.exp",
   "selfhost.math.log",
+  "selfhost.math.log10",
+  "selfhost.math.log1p",
   "selfhost.math.log2",
   "selfhost.math.pow",
   "selfhost.math.reduce-trig",
@@ -180,6 +182,8 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.exp": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.floor": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.log10": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.log1p": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log2": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.pow": F64_BINARY_INTRINSIC_SIGNATURE,
   "math.reduce-trig": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -261,6 +265,20 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     kind: "self-hosted",
     symbol: "Math_log",
   }),
+  "math.log10": provider(
+    "selfhost.math.log10",
+    "math.log10",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_log10" },
+    ["math.log"],
+  ),
+  "math.log1p": provider(
+    "selfhost.math.log1p",
+    "math.log1p",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_log1p" },
+    ["math.log"],
+  ),
   "math.log2": provider("selfhost.math.log2", "math.log2", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "self-hosted",
     symbol: "Math_log2",
@@ -300,7 +318,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
   }),
 });
 
-/** Canonically ordered default provider catalogue for the sixteen-method slice. */
+/** Canonically ordered default provider catalogue for the eighteen-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -6384,7 +6384,7 @@ function expressionIsProvenNumber(expr: ts.Expression, seen = new Set<ts.Variabl
       recv.text === "Math" &&
       selectorSeesAmbientBinding(recv) &&
       plan !== undefined &&
-      selectorSupportsMathPlan(plan) &&
+      selectorSupportsMathPlan(plan, candidate) &&
       candidate.arguments.length === plan.arity &&
       candidate.arguments.every((arg) => !ts.isSpreadElement(arg) && expressionIsProvenNumber(arg, seen))
     );
@@ -6474,7 +6474,13 @@ function selectorPrimitiveWrapperOrGenericBinary(
   return isPhase1Expr(expr.left, scope, localClasses) && isPhase1Expr(expr.right, scope, localClasses);
 }
 
-function selectorSupportsMathPlan(plan: IrMathMethodPlan): boolean {
+function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpression): boolean {
+  if (
+    call.questionDotToken !== undefined ||
+    (ts.isPropertyAccessExpression(call.expression) && call.expression.questionDotToken !== undefined)
+  ) {
+    return false;
+  }
   if (plan.intrinsic === "math.asin" && process.env.JS2WASM_IR_MATH_ASIN === "0") return false;
   if (plan.intrinsic === "math.acos" && process.env.JS2WASM_IR_MATH_ACOS === "0") return false;
   if (plan.intrinsic === "math.atan" && process.env.JS2WASM_IR_MATH_ATAN === "0") return false;
@@ -8710,7 +8716,7 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         selectorSeesAmbientBinding(expr.expression.expression) &&
         !scope.has(expr.expression.expression.text) &&
         mathPlan !== undefined &&
-        selectorSupportsMathPlan(mathPlan) &&
+        selectorSupportsMathPlan(mathPlan, expr) &&
         expr.arguments.length === mathPlan.arity
       ) {
         return expr.arguments.every(
@@ -9841,7 +9847,7 @@ export function buildLocalCallGraph(
             node.expression.expression.text === "Math" &&
             selectorSeesAmbientBinding(node.expression.expression) &&
             mathPlan !== undefined &&
-            selectorSupportsMathPlan(mathPlan) &&
+            selectorSupportsMathPlan(mathPlan, node) &&
             node.arguments.length === mathPlan.arity
           ) {
             for (const a of node.arguments) visit(a);

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -301,6 +301,8 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   tan: { arity: 1, intrinsic: "math.tan" },
   exp: { arity: 1, intrinsic: "math.exp" },
   log: { arity: 1, intrinsic: "math.log" },
+  log10: { arity: 1, intrinsic: "math.log10" },
+  log1p: { arity: 1, intrinsic: "math.log1p" },
   log2: { arity: 1, intrinsic: "math.log2" },
   pow: { arity: 2, intrinsic: "math.pow" },
   atan2: { arity: 2, intrinsic: "math.atan2" },
@@ -6477,6 +6479,8 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan): boolean {
   if (plan.intrinsic === "math.acos" && process.env.JS2WASM_IR_MATH_ACOS === "0") return false;
   if (plan.intrinsic === "math.atan" && process.env.JS2WASM_IR_MATH_ATAN === "0") return false;
   if (plan.intrinsic === "math.tan" && process.env.JS2WASM_IR_MATH_TAN === "0") return false;
+  if (plan.intrinsic === "math.log10" && process.env.JS2WASM_IR_MATH_LOG10 === "0") return false;
+  if (plan.intrinsic === "math.log1p" && process.env.JS2WASM_IR_MATH_LOG1P === "0") return false;
   return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
 }
 

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -69,7 +69,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function allMath(x: number, y: number): number {
         return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.trunc(x)
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
-          + Math.exp(x) + Math.log(x) + Math.log2(x)
+          + Math.exp(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
     `);
@@ -128,6 +128,8 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function tan(): number { return Math.tan(0.75); }
       export function exp(): number { return Math.exp(1.25); }
       export function log(): number { return Math.log(3.5); }
+      export function log10(): number { return Math.log10(1000); }
+      export function log1p(): number { return Math.log1p(3.5); }
       export function log2(): number { return Math.log2(32); }
       export function pow(): number { return Math.pow(2.5, 3); }
       export function atan2(): number { return Math.atan2(1, -1); }
@@ -161,7 +163,21 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
     for (const opcode of ["f64.abs", "f64.sqrt", "f64.floor", "f64.ceil", "f64.trunc"]) {
       expect(ir.wat).toContain(opcode);
     }
-    for (const helper of ["asin", "acos", "atan", "sin", "cos", "tan", "exp", "log", "log2", "pow", "atan2"]) {
+    for (const helper of [
+      "asin",
+      "acos",
+      "atan",
+      "sin",
+      "cos",
+      "tan",
+      "exp",
+      "log",
+      "log10",
+      "log1p",
+      "log2",
+      "pow",
+      "atan2",
+    ]) {
       expect(ir.wat).toContain(`$Math_${helper}`);
     }
     expect(ir.wat).not.toContain("$__box_number");

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,16 +88,24 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact sixteen certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact eighteen certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(16);
+    expect(intrinsicMethods).toHaveLength(18);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
-      expect.arrayContaining(["math.acos", "math.asin", "math.atan", "math.reduce-trig", "math.tan"]),
+      expect.arrayContaining([
+        "math.acos",
+        "math.asin",
+        "math.atan",
+        "math.log10",
+        "math.log1p",
+        "math.reduce-trig",
+        "math.tan",
+      ]),
     );
     const intrinsicFeatures = new Set<string>(PURE_MATH_INTRINSIC_IDS);
     expect(PURE_MATH_RUNTIME_FEATURES.filter((feature) => !intrinsicFeatures.has(feature))).toEqual([
@@ -121,7 +129,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(16);
+    expect(first.intrinsicUses).toHaveLength(18);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -133,6 +141,8 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.acos"]).toEqual(["math.atan"]);
     expect(dependencies["math.asin"]).toEqual(["math.atan"]);
     expect(dependencies["math.atan2"]).toEqual(["math.atan"]);
+    expect(dependencies["math.log10"]).toEqual(["math.log"]);
+    expect(dependencies["math.log1p"]).toEqual(["math.log"]);
     expect(dependencies["math.sin"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.tan"]).toEqual(["math.cos", "math.sin"]);
@@ -147,7 +157,16 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     for (const target of targets) {
       for (const backend of backends) {
         const builder = new RuntimeManifestBuilder(policy(target, backend));
-        addUses(builder, ["math.asin", "math.acos", "math.sin", "math.tan", "math.pow", "math.atan2"]);
+        addUses(builder, [
+          "math.asin",
+          "math.acos",
+          "math.sin",
+          "math.tan",
+          "math.log10",
+          "math.log1p",
+          "math.pow",
+          "math.atan2",
+        ]);
         const manifest = builder.freeze();
         semanticClosures.push([...manifest.features]);
         expect(manifest.hostCapabilities, `${target}/${backend}`).toEqual([]);
@@ -163,6 +182,8 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       "math.cos",
       "math.exp",
       "math.log",
+      "math.log10",
+      "math.log1p",
       "math.pow",
       "math.reduce-trig",
       "math.sin",

--- a/tests/issue-5106-ir-math-derived-log.test.ts
+++ b/tests/issue-5106-ir-math-derived-log.test.ts
@@ -77,6 +77,8 @@ const exclusionCases = METHODS.flatMap(
     export function f(x: number): number { return derivedLog(x); }`,
       ],
       [`computed ${method}`, `export function f(x: number): number { return Math["${method}"](x); }`],
+      [`optional invocation ${method}`, `export function f(x: number): number { return Math.${method}?.(x); }`],
+      [`optional receiver ${method}`, `export function f(x: number): number { return Math?.${method}(x); }`],
       [
         `${method} wrong arity`,
         `export function f(x: number): number {
@@ -252,6 +254,9 @@ describe("#5106 exact ambient Math.log10/Math.log1p IR ownership", () => {
     }
 
     const irLog10 = irExports.log10 as (value: number) => number;
+    // #3226 deliberately pins this source-faithful snap-to-integer behavior.
+    // Native Math.log10 returns a small negative value; changing the inherited
+    // approximation is separate from this ownership-only migration.
     expect(Object.is(irLog10(0.999999999999), -0)).toBe(true);
   });
 

--- a/tests/issue-5106-ir-math-derived-log.test.ts
+++ b/tests/issue-5106-ir-math-derived-log.test.ts
@@ -1,0 +1,347 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5106-ir-math-derived-log");
+const METHODS = ["log10", "log1p"] as const;
+const U64_MASK = (1n << 64n) - 1n;
+const U64_SIGN = 1n << 63n;
+
+function orderedFloatBits(value: number): bigint {
+  const view = new DataView(new ArrayBuffer(8));
+  view.setFloat64(0, value, false);
+  const bits = view.getBigUint64(0, false);
+  return (bits & U64_SIGN) !== 0n ? ~bits & U64_MASK : bits | U64_SIGN;
+}
+
+function ulpDistance(left: number, right: number): bigint {
+  const leftBits = orderedFloatBits(left);
+  const rightBits = orderedFloatBits(right);
+  return leftBits > rightBits ? leftBits - rightBits : rightBits - leftBits;
+}
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+const exclusionCases = METHODS.flatMap(
+  (method) =>
+    [
+      [
+        `${method} with shadowed Math`,
+        `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5106 shadowed Math is intentionally not ambient.
+      return Math.${method}(x);
+    }`,
+      ],
+      [
+        `aliased ${method}`,
+        `const derivedLog = Math.${method};
+    export function f(x: number): number { return derivedLog(x); }`,
+      ],
+      [`computed ${method}`, `export function f(x: number): number { return Math["${method}"](x); }`],
+      [
+        `${method} wrong arity`,
+        `export function f(x: number): number {
+      // @ts-expect-error #5106 intentionally exercises extra arity.
+      return Math.${method}(x, x);
+    }`,
+      ],
+      [
+        `${method} spread argument`,
+        `export function f(x: number): number {
+      return Math.${method}(...([x] as [number]));
+    }`,
+      ],
+      [
+        `${method} non-number argument`,
+        `export function f(): number {
+      const text: string = "1";
+      return Math.${method}(text as never);
+    }`,
+      ],
+    ] as const,
+);
+
+describe("#5106 exact ambient Math.log10/Math.log1p IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims both exact one-number calls on the %s target", async (_label, target) => {
+    const result = await compile(
+      `
+        export function log10(value: number): number { return Math.log10(value); }
+        export function log1p(value: number): number { return Math.log1p(value); }
+      `,
+      {
+        fileName: `issue-5106-${_label}.ts`,
+        ...(target === undefined ? {} : { target }),
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+      },
+    );
+    expectSuccess(result);
+
+    for (const method of METHODS) {
+      expect(outcomeFor(result, method)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(result.irCompiledFuncs ?? []).toContain(method);
+      expect(result.wat).toContain(`$Math_${method}`);
+    }
+    expect(result.wat).toContain("$Math_log");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const exports = await instantiate(result);
+    expect(typeof exports.log10).toBe("function");
+    expect(typeof exports.log1p).toBe("function");
+
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches both existing providers to one deduplicated Math_log dependency", () => {
+    const analysis = analyzeSource(`
+      export function derivedLog(value: number): number {
+        return Math.log10(value) + Math.log1p(value);
+      }
+    `);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing derivedLog declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("derivedLog").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id).sort()).toEqual(["math.log10", "math.log1p"]);
+    expect(semantic.every((instr) => instr.provider === undefined)).toBe(true);
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id).sort()).toEqual(["math.log10", "math.log1p"]);
+    expect(prepared.manifest.features).toEqual(["math.log", "math.log10", "math.log1p"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    const dependencies = Object.fromEntries(
+      prepared.manifest.providers.map((provider) => [provider.feature, provider.dependencies]),
+    );
+    expect(dependencies).toMatchObject({
+      "math.log": [],
+      "math.log10": ["math.log"],
+      "math.log1p": ["math.log"],
+    });
+    expect(new Set(prepared.manifest.providers.map((provider) => provider.id))).toEqual(
+      new Set(["selfhost.math.log", "selfhost.math.log10", "selfhost.math.log1p"]),
+    );
+
+    for (const instr of intrinsicInstructions(prepared.functions[0]!)) {
+      expect(instr.provider).toMatchObject({
+        kind: "callable",
+        target: { name: `Math_${instr.id.slice(5)}`, binding: { kind: "intrinsic", symbol: instr.id } },
+      });
+    }
+  });
+
+  it("is bit-identical to the direct path across boundaries and the log10 snap window", async () => {
+    const source = `
+      export function log10(value: number): number { return Math.log10(value); }
+      export function log1p(value: number): number { return Math.log1p(value); }
+    `;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5106-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5106-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+
+    const irExports = await instantiate(ir);
+    const directExports = await instantiate(direct);
+    const samples = {
+      log10: [
+        Number.NaN,
+        Number.NEGATIVE_INFINITY,
+        -1,
+        -0,
+        0,
+        Number.MIN_VALUE,
+        0.5,
+        0.999999999999,
+        1,
+        2,
+        10,
+        Number.MAX_VALUE,
+        Number.POSITIVE_INFINITY,
+      ],
+      log1p: [
+        Number.NaN,
+        Number.NEGATIVE_INFINITY,
+        -2,
+        -1.0000000000000002,
+        -1,
+        -0,
+        0,
+        -Number.MIN_VALUE,
+        Number.MIN_VALUE,
+        -0.5,
+        -0.0001,
+        -0.00009999999999999,
+        0.00009999999999999,
+        0.5,
+        4.5,
+        Number.MAX_VALUE,
+        Number.POSITIVE_INFINITY,
+      ],
+    } as const;
+
+    for (const method of METHODS) {
+      expect(outcomeFor(ir, method)).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+      const irFn = irExports[method] as (value: number) => number;
+      const directFn = directExports[method] as (value: number) => number;
+      for (const value of samples[method]) {
+        expect(Object.is(irFn(value), directFn(value)), `${method} parity for ${String(value)}`).toBe(true);
+      }
+    }
+
+    const irLog10 = irExports.log10 as (value: number) => number;
+    expect(Object.is(irLog10(0.999999999999), -0)).toBe(true);
+  });
+
+  it("pins the established native-Math accuracy envelopes away from the log10 snap window", async () => {
+    const result = await compile(
+      `
+        export function log10(value: number): number { return Math.log10(value); }
+        export function log1p(value: number): number { return Math.log1p(value); }
+      `,
+      { fileName: "issue-5106-native-oracle.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expectSuccess(result);
+    const exports = await instantiate(result);
+    const log10 = exports.log10 as (value: number) => number;
+    const log1p = exports.log1p as (value: number) => number;
+
+    for (const value of [0.5, 0.75, 1.5, 2, 3, 123.456, 1e-15, 1e15]) {
+      expect(Math.abs(log10(value) - Math.log10(value)), `log10 absolute error for ${value}`).toBeLessThanOrEqual(5e-9);
+    }
+
+    for (const value of [
+      -0.00009999999999999,
+      -1e-6,
+      -Number.MIN_VALUE,
+      0,
+      Number.MIN_VALUE,
+      1e-6,
+      0.00009999999999999,
+    ]) {
+      const actual = log1p(value);
+      const expected = Math.log1p(value);
+      expect(Math.abs(actual - expected), `log1p Taylor absolute error for ${value}`).toBeLessThanOrEqual(3e-17);
+      expect(ulpDistance(actual, expected), `log1p Taylor ULP distance for ${value}`).toBeLessThanOrEqual(2048n);
+    }
+
+    for (const value of [-0.875, -0.75, -0.5, -0.1, -0.01, 0.01, 0.1, 0.5, 1, 4.5, 1e6]) {
+      expect(Math.abs(log1p(value) - Math.log1p(value)), `log1p absolute error for ${value}`).toBeLessThanOrEqual(
+        1.25e-8,
+      );
+    }
+  });
+
+  it.each([
+    ["log10", "JS2WASM_IR_MATH_LOG10", "log1p"],
+    ["log1p", "JS2WASM_IR_MATH_LOG1P", "log10"],
+  ] as const)("withdraws only %s through its narrow rollback", async (disabled, flag, retained) => {
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(
+        `
+          export function log10(value: number): number { return Math.log10(value); }
+          export function log1p(value: number): number { return Math.log1p(value); }
+        `,
+        { fileName: `issue-5106-${disabled}-rollback.ts`, experimentalIR: true, trackIrOutcomes: true },
+      );
+      expectSuccess(result);
+      expect(outcomeFor(result, disabled)).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(outcomeFor(result, retained)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5106-${_label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- represent exact ambient `Math.log10(number)` and `Math.log1p(number)` calls as semantic IR intrinsics
- attach the existing host-free helpers through one deduplicated `Math_log` provider dependency
- add independent rollback flags and exhaustive ownership, exclusion, parity, and numerical-oracle coverage

## Validation

- 32/32 focused and affected contract tests passed
- TypeScript 7, Biome lint, Prettier, oracle/coercion ratchets, numeric-local parity 18/18, and issue integrity passed
- local and remote head both `88ba558af6c07b554d4b1b516f3f6fdf02efad59`

## Stack

- stacked on #5110 (`codex/5105-ir-math-inverse-trig`)
- non-draft; repository automation may merge it after its parent lands