### PR TITLE
fix(codegen): expose Symbol toPrimitive descriptor standalone

### DIFF
--- a/plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
+++ b/plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
@@ -1,9 +1,10 @@
 ---
 id: 5107
 title: "Standalone Symbol prototype toPrimitive descriptor"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
+completed: 2026-08-28
 priority: medium
 horizon: s
 feasibility: medium
@@ -171,3 +172,10 @@ Worktree: `/private/tmp/js2-es2015-next-lane-a-20260828`
 Branch: `codex/es2015-next-lane-a`
 
 Tracking is intentionally md-only; no GitHub issue is created for this lane.
+
+Implementation and validation are complete. The validated implementation
+checkpoint is `a0b66b42ecba9575c87a39e85a2050bf36b5c729`, the current-main sync
+merge is `3853284e9c59dc00caf0e662431100f1218dfb2e`, and the refreshed evidence
+checkpoint is `bebfbbb97c601d29951035ece2f5da0e19d5e2d8`. The branch is ready for
+its single non-draft upstream PR; no additional product work remains in this
+lane.

--- a/plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
+++ b/plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
@@ -15,6 +15,19 @@ goal: standalone-mode
 sprint: current
 assignee: "ttraenkler/codex-es2015-next-lane-a"
 related: [4743, 4776]
+files:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/native-proto.ts
+  - src/codegen/native-proto-own-props.ts
+  - tests/issue-5107-symbol-toprimitive-descriptor.test.ts
+  - tests/test262-restore-builtins.ts
+  - plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/native-proto.ts
+  - src/codegen/native-proto-own-props.ts
+func-budget-allow:
+  - src/codegen/native-proto-own-props.ts::registerNativeProtoHasOwn
 ---
 
 # 5107 — standalone Symbol prototype toPrimitive descriptor
@@ -84,9 +97,50 @@ coercion or alter unrelated Symbol prototype methods.
 - The branch contains one focused regression test, this md-only plan, and one
   compliant upstream PR when all local gates are complete.
 
+## Implementation
+
+The Symbol native-prototype glue now advertises the well-known-symbol
+sentinel `@@3` (`Symbol.toPrimitive`) alongside its existing string methods.
+The standalone companion seeder boxes that sentinel into the identity-stable
+native `$Symbol` carrier, so dynamic reads, own checks, descriptors, writes,
+and deletes all consult one mutable proto-index entry. Its seed uses the
+existing `{ writable:false, enumerable:false, configurable:true }` flag word,
+while ordinary native-prototype methods retain their writable defaults. The
+closure metadata maps the compiler sentinel to the ECMAScript function name
+`[Symbol.toPrimitive]` and keeps the spec length `1`.
+
+The own-property lowering has a symbol-key arm keyed by the carrier ID and
+delegates presence/enumerability to the existing companion object view. It is
+standalone-gated and does not alter host mode or generic ToPrimitive dispatch.
+
+The focused regression contains two mandatory self-contained standalone
+compiler controls (descriptor/identity/name/length and replacement/deletion)
+and two corpus-backed exact-row cases. Corpus-backed cases are guarded only
+by `existsSync(test262/harness/assert.js)`, so a checkout without Test262 still
+executes the product controls. The host Test262 runner snapshot also now
+includes `Symbol.prototype`: Test262's configurable `verifyProperty` probe
+deletes the entry during its sloppy pass, and the snapshot restores the host
+intrinsic before the strict rerun. This is test-realm hygiene, not a product
+runtime fallback; the direct controls instantiate host-free standalone Wasm
+with an empty import object.
+
 ## Test results
 
-Pending implementation.
+On the corpus-present worktree, the focused Vitest file passed **4/4**:
+
+- exact host row: 1/1 pass (including strict rerun)
+- exact standalone row: 1/1 pass
+- self-contained descriptor/identity control: 1/1 pass
+- self-contained mutation/deletion control: 1/1 pass
+
+The corpus-absent temporary-root validation passed **2/2 mandatory controls**
+and skipped only the two corpus-backed cases. TypeScript 7 typecheck passed;
+Biome lint passed with no error diagnostics; Prettier check and
+`git diff --check` passed; oracle-ratchet reported no checker-usage growth
+(`getTypeAtLocation +0`, `ctx.checker +0`). A repeated corpus-present focused
+run also passed **4/4** with the same per-case counts, for **8/8 total
+focused assertions across two runs**. There were no compile errors, timeouts,
+or unexpected skips.
 
 ## Handoff
 

--- a/plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
+++ b/plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
@@ -1,0 +1,97 @@
+---
+id: 5107
+title: "Standalone Symbol prototype toPrimitive descriptor"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+priority: medium
+horizon: s
+feasibility: medium
+task_type: conformance
+area: codegen
+language_feature: Symbol.prototype[Symbol.toPrimitive]
+es_edition: 2015
+goal: standalone-mode
+sprint: current
+assignee: "ttraenkler/codex-es2015-next-lane-a"
+related: [4743, 4776]
+---
+
+# 5107 — standalone Symbol prototype toPrimitive descriptor
+
+## Scope and baseline evidence
+
+The implementation branch starts at upstream `main` commit
+`caeaa2e1cf2aa225297c53076d27f97c8449a527`. The fresh authoritative baseline
+JSONL snapshot was fetched on 2026-08-28 from the maintained baseline source;
+the exact row carries oracle version 13 and the honest lane in both snapshots.
+
+Claimed row:
+
+```text
+test/built-ins/Symbol/prototype/Symbol.toPrimitive/prop-desc.js
+```
+
+Baseline verdicts (the test is reached and runs under both strictness modes):
+
+| lane | snapshot row timestamp | verdict | diagnostic |
+| --- | --- | --- | --- |
+| JS-host | 28.8.2026, 00:44:49 | pass | — |
+| standalone | 28.8.2026, 00:58:11 | fail | `Test262Error: Symbol() should be an own property` |
+
+This is a one-row residual selected after the requested neighboring Reflect
+row was rechecked: `test/built-ins/Reflect/Symbol.toStringTag.js` is already
+standalone-pass and is covered by the existing namespace metadata plan. The
+current row has no exact path mention in an existing plan.
+
+## Problem
+
+In standalone mode, `Symbol.prototype[Symbol.toPrimitive]` is not exposed as
+an own property with the ES2015 descriptor `{ writable: false,
+enumerable: false, configurable: true }`. The host lane's primordial Symbol
+prototype supplies the property, while the native-symbol standalone carrier
+does not currently present the corresponding prototype metadata to
+`verifyProperty`.
+
+The fix must preserve the well-known-symbol identity and the existing native
+Symbol value/`valueOf` behavior. It must not broaden generic ToPrimitive
+coercion or alter unrelated Symbol prototype methods.
+
+## Implementation plan
+
+1. Trace the standalone Symbol prototype construction/read/descriptor paths
+   and identify the narrow missing `@@toPrimitive` own-property metadata seam.
+2. Add the smallest standalone-only metadata or descriptor arm at that seam,
+   using the existing native Symbol key mapping and canonical descriptor
+   flags. Keep host behavior and generic Symbol coercion byte-stable.
+3. Add focused regression coverage for the claimed Test262 row plus exact
+   descriptor, identity, read, and deletion controls. Verify that deletion
+   does not make an inherited or synthetic property appear as an own property.
+4. Run paired authoritative host and standalone rows with repeats and
+   controls using no more than two workers; record exact counts, transitions,
+   and scoped type/lint/oracle gates here before handoff.
+
+## Acceptance criteria
+
+- The claimed row is pass in both host and standalone lanes.
+- Standalone descriptor flags and `Symbol.toPrimitive` identity match the
+  Test262 expectations, including own-property and delete controls.
+- The paired run has exactly one standalone fail-to-pass transition, zero
+  pass-to-fail transitions, zero compile errors/timeouts/skips, and repeat
+  determinism.
+- No new standalone host imports are introduced and no unrelated Symbol
+  ToPrimitive coercion behavior changes.
+- The branch contains one focused regression test, this md-only plan, and one
+  compliant upstream PR when all local gates are complete.
+
+## Test results
+
+Pending implementation.
+
+## Handoff
+
+Worktree: `/private/tmp/js2-es2015-next-lane-a-20260828`
+
+Branch: `codex/es2015-next-lane-a`
+
+Tracking is intentionally md-only; no GitHub issue is created for this lane.

--- a/plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
+++ b/plan/issues/5107-es2015-symbol-toprimitive-descriptor.md
@@ -142,6 +142,28 @@ run also passed **4/4** with the same per-case counts, for **8/8 total
 focused assertions across two runs**. There were no compile errors, timeouts,
 or unexpected skips.
 
+## Refreshed-upstream verification (2026-08-28)
+
+After the implementation checkpoint, the branch fetched upstream `main` at
+`18785a67c6682b9fc41d3a220a6b88f3f42dc59e` and synchronized with a normal
+merge commit `3853284e9c59dc00caf0e662431100f1218dfb2e`. The refreshed branch
+has no uncommitted changes and remains limited to the reserved plan, the
+three native-prototype codegen files, the focused regression, and the one
+Symbol-prototype test-realm snapshot entry.
+
+The refreshed focused corpus-present run passed **4/4** with
+`TEST262_WORKERS=2` and `COMPILER_POOL_SIZE=2`: exact host **1/1**, exact
+standalone **1/1**, descriptor/identity **1/1**, and mutation/deletion **1/1**;
+there were zero compile errors, timeouts, or skips. The corpus-absent
+temporary-root shape was rerun after the refresh and passed **2/2 mandatory
+controls**, skipping only the two exact-row cases. The earlier 35-second
+Vitest timeout under concurrent repository activity was an infrastructure
+timeout only; the explicit 180-second reruns completed successfully.
+
+The implementation checkpoint is `a0b66b42ecba9575c87a39e85a2050bf36b5c729`;
+the refresh merge is intentionally non-rewriting. Final PR handoff must push
+this branch without force and create exactly one PR against `loopdive/js2:main`.
+
 ## Handoff
 
 Worktree: `/private/tmp/js2-es2015-next-lane-a-20260828`

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -335,8 +335,10 @@ const ITERATOR_PROTO_METHODS = [
 const FUNCTION_PROTO_METHODS = ["apply", "bind", "call", "toString", FUNCTION_PROTO_HAS_INSTANCE_MEMBER] as const;
 
 /** `Symbol.prototype`'s own method names (ES2024 §20.4.3). `description` is an
- * accessor getter, resolved by the computed-access path. */
-const SYMBOL_PROTO_METHODS = ["toString", "valueOf"] as const;
+ * accessor getter, resolved by the computed-access path. `@@toPrimitive` is
+ * represented by its native-symbol sentinel so flowing prototype values seed
+ * the same identity-stable well-known-symbol entry as string methods. */
+const SYMBOL_PROTO_METHODS = ["@@3", "toString", "valueOf"] as const;
 
 /** `BigInt.prototype`'s own method names (ES2024 §21.2.3). */
 const BIGINT_PROTO_METHODS = ["toLocaleString", "toString", "valueOf"] as const;

--- a/src/codegen/native-proto-own-props.ts
+++ b/src/codegen/native-proto-own-props.ts
@@ -73,6 +73,7 @@ import {
   ensureStandaloneNativeMethodClosure,
   getBuiltinBrand,
   seededNativeProtoOwnMembersByBrand,
+  seededNativeProtoSymbolMembersByBrand,
   seededNativeProtoSymbolTagsByBrand,
 } from "./native-proto.js";
 import { ensureFunctionNativeProtoGlue } from "./array-object-proto.js";
@@ -222,6 +223,7 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
   const equalsIdx = ctx.nativeStrHelpers.get("__str_equals");
   if (flattenIdx === undefined || equalsIdx === undefined) return undefined;
   const seededOwnMembers = seededNativeProtoOwnMembersByBrand(ctx);
+  const seededSymbolMembers = seededNativeProtoSymbolMembersByBrand(ctx);
   const seededSymbolTags = seededNativeProtoSymbolTagsByBrand(ctx);
   const protoOwnRecvIdx = ctx.funcMap.get("__protoidx_own_recv");
   const objectHasOwnIdx = ctx.funcMap.get("__object_hasOwn");
@@ -322,6 +324,52 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
                 ],
               },
             ],
+          } as Instr,
+        ])),
+    // Well-known symbol members (for example Symbol.prototype[@@toPrimitive])
+    // are also own companion entries, but unlike Symbol.toStringTag they are
+    // represented by `@@<id>` CSV sentinels and must compare the native Symbol
+    // carrier's identity field. Keep this arm separate from the string CSV
+    // ladder so a symbol key can never be coerced into text.
+    ...(protoOwnRecvIdx === undefined || objectHasOwnIdx === undefined || symbolType === undefined
+      ? []
+      : [...seededSymbolMembers.entries()].flatMap(([brand, symbolIds]) => [
+          { op: "local.get", index: L_ANY } as Instr,
+          { op: "ref.cast", typeIdx: protoTypeIdx } as Instr,
+          { op: "struct.get", typeIdx: protoTypeIdx, fieldIdx: NP_BRAND } as Instr,
+          { op: "i32.const", value: brand } as Instr,
+          { op: "i32.eq" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: symbolIds.flatMap((symbolId) => [
+              { op: "local.get", index: 1 } as Instr,
+              { op: "any.convert_extern" } as Instr,
+              { op: "ref.test", typeIdx: symbolType } as Instr,
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: 1 },
+                  { op: "any.convert_extern" },
+                  { op: "ref.cast", typeIdx: symbolType },
+                  { op: "struct.get", typeIdx: symbolType, fieldIdx: 0 },
+                  { op: "i32.const", value: symbolId },
+                  { op: "i32.eq" },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [
+                      { op: "local.get", index: 0 },
+                      { op: "call", funcIdx: protoOwnRecvIdx },
+                      { op: "local.get", index: 1 },
+                      { op: "call", funcIdx: objectHasOwnIdx },
+                      { op: "return" },
+                    ],
+                  },
+                ],
+              },
+            ]),
           } as Instr,
         ])),
     // A non-string key (other symbols, boxed number) names no member of a prototype.

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -473,6 +473,29 @@ export function seededNativeProtoSymbolTagsByBrand(ctx: CodegenContext): Readonl
 }
 
 /**
+ * Return well-known-symbol members seeded on native-prototype companions.
+ * Unlike `symbolTag`, these entries are callable/data members represented by
+ * `@@<id>` CSV sentinels. Keep the IDs separate from string members so own
+ * property checks compare the interned `$Symbol` carrier rather than a native
+ * string spelling.
+ */
+export function seededNativeProtoSymbolMembersByBrand(ctx: CodegenContext): ReadonlyMap<number, readonly number[]> {
+  const out = new Map<number, readonly number[]>();
+  for (const [brand, seederName] of nativeProtoSeederRegistry(ctx)) {
+    if (ctx.funcMap.get(seederName) === undefined) continue;
+    const members =
+      getNativeProtoBuiltinGlue(ctx, brand)
+        ?.memberCsv.split(",")
+        .map((member) => member.trim())
+        .filter((member) => member.startsWith("@@"))
+        .map((member) => Number(member.slice(2)))
+        .filter((id) => Number.isInteger(id)) ?? [];
+    if (members.length > 0) out.set(brand, members);
+  }
+  return out;
+}
+
+/**
  * §17 attributes for a builtin prototype METHOD, in the
  * `__defineProperty_value` host flag encoding: `{writable: true, enumerable:
  * false, configurable: true}` — value bits `0b101` + all three "specified"
@@ -631,7 +654,13 @@ export function ensureNativeProtoCompanionSeeder(ctx: CodegenContext, brand: num
       body.push({ op: "call", funcIdx: defineIdx });
     } else {
       // [obj, key, value, flags] → §17 data entry.
-      body.push({ op: "f64.const", value: PROTO_METHOD_DEFINE_FLAGS });
+      // Symbol.prototype[Symbol.toPrimitive] is the one native-proto method
+      // whose initial descriptor is read-only. Keep its configurable bit so
+      // the companion still observes replacement/deletion exactly like the
+      // spec, while every ordinary method retains the historical flags.
+      const defineFlags =
+        glue.name === "Symbol" && member === "@@3" ? PROTO_SYMBOL_TAG_DEFINE_FLAGS : PROTO_METHOD_DEFINE_FLAGS;
+      body.push({ op: "f64.const", value: defineFlags });
       body.push({ op: "call", funcIdx: defineIdx });
     }
     body.push({ op: "drop" }); // the helper returns the target
@@ -900,7 +929,11 @@ export function ensureStandaloneNativeMethodClosure(
     // `"set <key>"`). The reflective `desc.get.name` read resolves the closure's
     // name from `nativeClosureMeta`, so getter closures must carry the accessor
     // spelling, not the bare member. Methods keep the bare member name.
-    const accessorName = kind === "getter" ? `get ${member}` : member;
+    // Native well-known-symbol sentinels are physical compiler keys, not the
+    // JavaScript function names exposed by SetFunctionName. This member is
+    // Symbol.prototype[Symbol.toPrimitive], whose name is bracketed.
+    const displayMember = member === "@@3" ? "[Symbol.toPrimitive]" : member;
+    const accessorName = kind === "getter" ? `get ${displayMember}` : displayMember;
     ctx.nativeClosureMeta.set(funcIdx, { name: accessorName, length: arity });
   }
 
@@ -912,7 +945,8 @@ export function ensureStandaloneNativeMethodClosure(
   // them through runtime params — a compile-time fold cannot satisfy it). All
   // call paths are unaffected: the meta type subtypes the wrapper the lifted
   // func expects. Getters carry the §10.2.9 accessor spelling ("get <key>").
-  const metaName = kind === "getter" ? `get ${member}` : member;
+  const displayMember = member === "@@3" ? "[Symbol.toPrimitive]" : member;
+  const metaName = kind === "getter" ? `get ${displayMember}` : displayMember;
   const metaTypeIdx = ensureBuiltinFnMetaType(
     ctx,
     wrapperTypes.structTypeIdx,

--- a/tests/issue-5107-symbol-toprimitive-descriptor.test.ts
+++ b/tests/issue-5107-symbol-toprimitive-descriptor.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5107 — standalone Symbol.prototype[Symbol.toPrimitive] own descriptor.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const EXACT_ROW = "built-ins/Symbol/prototype/Symbol.toPrimitive/prop-desc.js";
+const hasTest262Corpus = existsSync(join(process.cwd(), "test262/harness/assert.js"));
+const corpusIt = hasTest262Corpus ? it : it.skip;
+
+const CONTROL_SOURCE = `
+  export function test(): number {
+    const proto: any = Symbol.prototype;
+    const key: any = Symbol.toPrimitive;
+    const first: any = proto[key];
+    const second: any = proto[key];
+    const descriptor: any = Object.getOwnPropertyDescriptor(proto, key);
+    const hasOwn = Object.prototype.hasOwnProperty.call(proto, key);
+    const enumerable = Object.prototype.propertyIsEnumerable.call(proto, key);
+    return typeof first === "function" &&
+      first === second &&
+      descriptor !== undefined &&
+      descriptor.value === first &&
+      first.name === "[Symbol.toPrimitive]" &&
+      first.length === 1 &&
+      descriptor.writable === false &&
+      descriptor.enumerable === false &&
+      descriptor.configurable === true &&
+      hasOwn &&
+      !enumerable ? 1 : 0;
+  }
+`;
+
+const MUTATION_SOURCE = `
+  export function test(): number {
+    const proto: any = Symbol.prototype;
+    const key: any = Symbol.toPrimitive;
+    const original: any = proto[key];
+    const replacement: any = function replacement() { return 1; };
+    let writeBlocked = false;
+    try {
+      proto[key] = replacement;
+      writeBlocked = proto[key] === original;
+    } catch {
+      writeBlocked = proto[key] === original;
+    }
+    const descriptorBeforeDelete: any = Object.getOwnPropertyDescriptor(proto, key);
+    const deleted = delete proto[key];
+    const descriptorAfterDelete: any = Object.getOwnPropertyDescriptor(proto, key);
+    const absent = !Object.prototype.hasOwnProperty.call(proto, key) &&
+      descriptorAfterDelete === undefined &&
+      proto[key] === undefined;
+    return writeBlocked &&
+      descriptorBeforeDelete !== undefined &&
+      descriptorBeforeDelete.value === original &&
+      deleted &&
+      absent ? 1 : 0;
+  }
+`;
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-5107-symbol-toprimitive-descriptor.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  expect(
+    WebAssembly.Module.imports(await WebAssembly.compile(result.binary)),
+    "standalone must stay host-free",
+  ).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#5107 standalone Symbol.prototype[Symbol.toPrimitive] descriptor", () => {
+  corpusIt("passes the exact Test262 host row", async () => {
+    const result = await runTest262File(join("test262/test", EXACT_ROW), "issue-5107", 120_000);
+    expect(result.status, `${result.file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+  });
+
+  corpusIt("passes the exact Test262 standalone row", async () => {
+    const result = await runTest262File(join("test262/test", EXACT_ROW), "issue-5107", 120_000, "standalone");
+    expect(result.status, `${result.file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+  });
+
+  it("exposes the identity-stable function and exact own descriptor", async () => {
+    await expect(runStandalone(CONTROL_SOURCE)).resolves.toBe(1);
+  });
+
+  it("blocks replacement but observes configurable deletion through all own views", async () => {
+    await expect(runStandalone(MUTATION_SOURCE)).resolves.toBe(1);
+  });
+});

--- a/tests/test262-restore-builtins.ts
+++ b/tests/test262-restore-builtins.ts
@@ -57,6 +57,10 @@ const PROTOS: ReadonlyArray<[string, object]> = [
   ["Number.prototype", Number.prototype],
   ["Boolean.prototype", Boolean.prototype],
   ["Function.prototype", Function.prototype],
+  // (#5107) Symbol.prototype[Symbol.toPrimitive] is configurable and the
+  // descriptor helper deletes it during the host lane's sloppy pass. Restore
+  // the intrinsic before the authoritative strict rerun.
+  ["Symbol.prototype", Symbol.prototype],
   ["RegExp.prototype", RegExp.prototype],
   ["Map.prototype", Map.prototype],
   ["Set.prototype", Set.prototype],


### PR DESCRIPTION
## Description

- Problem: standalone `Symbol.prototype` did not expose its own `Symbol.toPrimitive` function or the ES2015 descriptor required by Test262.
- Behavior: seed the well-known-symbol member through the native-prototype companion, preserve its identity and exact read-only/configurable attributes, and make symbol-key own-property checks consult that companion without widening generic coercion.
- Tests: the exact host and standalone row plus descriptor/identity and replacement/deletion controls pass 4/4; the real no-corpus shape keeps both mandatory controls green and skips only the two corpus-backed cases; TypeScript, lint, formatting, budgets, ratchets, and normal pre-push hooks pass.
- Tracking: `plan/issues/5107-es2015-symbol-toprimitive-descriptor.md`.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->