### PR TITLE
test(test262): guard optional WeakCollection corpus rows

### DIFF
--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -200,8 +200,9 @@ CI-style no-corpus checkouts still exercise the two mandatory controls.
 
 Final follow-up branch: `/private/tmp/js2-4786-optional-corpus-guard`,
 `codex/4786-optional-corpus-guard`, at fork head
-`fa3b69487116a4a34c2a5f5e4380f99409aeb49e`. PR creation was blocked by the
-external approval policy; the exact authorized command is:
+verified with `git ls-remote fork refs/heads/codex/4786-optional-corpus-guard`.
+PR creation was blocked by the external approval policy; the exact authorized
+command is:
 
 ```text
 gh pr create --repo loopdive/js2 --head ttraenkler:codex/4786-optional-corpus-guard --base main --title 'test(test262): guard optional WeakCollection corpus rows ✓' --body-file /private/tmp/issue-4786-pr-body.md

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -175,9 +175,11 @@ missing files, so it could not reach the two self-contained compiler controls.
 
 ### Follow-up evidence
 
-- Validation source: current `upstream/main` `eafd6700ac`, with the pinned
-  Test262 gitlink `b363f29d3c43c626dc852744ad64a0b48a003693`; compiler worker
-  count was capped at two.
+- Validation source: `upstream/main` `eafd6700ac` when the focused checks ran,
+  with the pinned Test262 gitlink
+  `b363f29d3c43c626dc852744ad64a0b48a003693`; compiler worker count was capped
+  at two. The branch was then synchronized with the current upstream merge
+  `18785a67c6` before handoff.
 - Corpus present: the focused Vitest file passed **6/6** — four exact
   host/standalone rows and both mandatory controls.
 - Hermetic no-corpus shape (only `harness/assert.js` was temporarily moved in
@@ -195,3 +197,7 @@ issue file. It does not change the already-merged WeakMap/WeakSet compiler
 implementation, instance insertion, constructors, or the Test262 gitlink.
 The focused test remains fully enforced when the corpus is present while
 CI-style no-corpus checkouts still exercise the two mandatory controls.
+
+Final follow-up branch: `/private/tmp/js2-4786-optional-corpus-guard`,
+`codex/4786-optional-corpus-guard`, with checkpoint head recorded in the PR
+and fork branch. No Test262 submodule content or pointer is included.

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -172,6 +172,9 @@ missing files, so it could not reach the two self-contained compiler controls.
    (host and standalone), yielding four conditional corpus assertions.
 3. Keep both descriptor/identity compiler controls as ordinary mandatory
    `it` tests. Do not skip the enclosing suite or alter `runTest262File`.
+4. Give the exact-row tables the same explicit 120-second Vitest budget as
+   `runTest262File`; otherwise a valid standalone result can be preempted by
+   the suite's 35-second default timeout under normal concurrent load.
 
 ### Follow-up evidence
 
@@ -183,6 +186,14 @@ missing files, so it could not reach the two self-contained compiler controls.
   handoff (the latter was recorded by merge checkpoint `10695cabd5`).
 - Corpus present: the focused Vitest file passed **6/6** — four exact
   host/standalone rows and both mandatory controls.
+- A frozen-head publication rerun reproduced a latent timeout mismatch: both
+  standalone rows exceeded Vitest's 35-second default (44.2s and 36.9s) even
+  though `runTest262File` already allowed 120 seconds. The follow-up now applies
+  the same 120-second budget at the Vitest case boundary; final evidence below
+  supersedes that diagnostic run.
+- Final frozen-head publication rerun after aligning the case timeout: **6/6**
+  passed in 129.53s (four exact corpus rows plus both mandatory controls); the
+  standalone rows completed normally in 20.5s and 22.9s.
 - Hermetic no-corpus shape (only `harness/assert.js` was temporarily moved in
   this worktree and restored): **2 passed, 4 skipped**. The four skips were
   exactly the host and standalone WeakMap/WeakSet rows; both controls ran and

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -6,6 +6,7 @@ sprint: current
 created: 2026-08-27
 updated: 2026-08-28
 completed: 2026-08-27
+pr: 5114
 assignee: "ttraenkler/codex-es2015-next-bounded-fix-8"
 priority: high
 horizon: s
@@ -211,13 +212,8 @@ The focused test remains fully enforced when the corpus is present while
 CI-style no-corpus checkouts still exercise the two mandatory controls.
 
 Final follow-up branch: `/private/tmp/js2-4786-optional-corpus-guard`,
-`codex/4786-optional-corpus-guard`, at fork head
-verified with `git ls-remote fork refs/heads/codex/4786-optional-corpus-guard`.
-PR creation was blocked by the external approval policy; the exact authorized
-command is:
-
-```text
-gh pr create --repo loopdive/js2 --head ttraenkler:codex/4786-optional-corpus-guard --base main --title 'test(test262): guard optional WeakCollection corpus rows ✓' --body-file /private/tmp/issue-4786-pr-body.md
-```
+`codex/4786-optional-corpus-guard`. The completed non-draft upstream review is
+[PR #5114](https://github.com/loopdive/js2/pull/5114), targeting
+`loopdive/js2:main` from the `ttraenkler/js2` fork.
 
 No Test262 submodule content or pointer is included.

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -199,5 +199,12 @@ The focused test remains fully enforced when the corpus is present while
 CI-style no-corpus checkouts still exercise the two mandatory controls.
 
 Final follow-up branch: `/private/tmp/js2-4786-optional-corpus-guard`,
-`codex/4786-optional-corpus-guard`, with checkpoint head recorded in the PR
-and fork branch. No Test262 submodule content or pointer is included.
+`codex/4786-optional-corpus-guard`, at fork head
+`6285d9f30fbd3d0cfc9475f362bff3f1ea9bffde`. PR creation was blocked by the
+external approval policy; the exact authorized command is:
+
+```text
+gh pr create --repo loopdive/js2 --head ttraenkler:codex/4786-optional-corpus-guard --base main --title 'test(test262): guard optional WeakCollection corpus rows ✓' --body-file /private/tmp/issue-4786-pr-body.md
+```
+
+No Test262 submodule content or pointer is included.

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -178,8 +178,9 @@ missing files, so it could not reach the two self-contained compiler controls.
 - Validation source: `upstream/main` `eafd6700ac` when the focused checks ran,
   with the pinned Test262 gitlink
   `b363f29d3c43c626dc852744ad64a0b48a003693`; compiler worker count was capped
-  at two. The branch was then synchronized with the current upstream merge
-  `18785a67c6` before handoff.
+  at two. The branch was then synchronized with upstream merges
+  `18785a67c6` and current `upstream/main` `0ccc264fa1` before handoff (the
+  latter was recorded by merge checkpoint `cb64e597da`).
 - Corpus present: the focused Vitest file passed **6/6** — four exact
   host/standalone rows and both mandatory controls.
 - Hermetic no-corpus shape (only `harness/assert.js` was temporarily moved in

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone WeakMap and WeakSet prototype Symbol.toStringTag"
 status: done
 sprint: current
 created: 2026-08-27
-updated: 2026-08-27
+updated: 2026-08-28
 completed: 2026-08-27
 assignee: "ttraenkler/codex-es2015-next-bounded-fix-8"
 priority: high
@@ -152,3 +152,46 @@ Source commits: `fae00a578a` (plan/claim) and `019109f311` (implementation);
 current-main merges: `3f01cf7191`, then `af522aff3c`.
 The branch is ready for the separate upstream PR for #4786. No WeakMap/WeakSet
 instance insertion or constructor code was changed.
+
+## Post-merge follow-up: optional Test262 corpus guard
+
+PR #5085 (`698ecb8f1661454037eaed810cb2a6770f6acf7f`) merged the compiler
+implementation and its focused regression file on 2026-08-27. The later
+optional-corpus checkpoint (`2be342f92ebb108910fa451f15de86e4e37013fc`) was
+not included in that merge: it is not an ancestor of the merge commit or the
+current `upstream/main`. Consequently, a checkout that intentionally omits
+the Test262 submodule tried to execute the four exact-row assertions against
+missing files, so it could not reach the two self-contained compiler controls.
+
+### Implementation plan
+
+1. Detect only the optional corpus fixture
+   `test262/harness/assert.js`, using a worktree-independent path derived from
+   the test module.
+2. Apply `it.skipIf(!TEST262_AVAILABLE)` to each of the two exact-row tables
+   (host and standalone), yielding four conditional corpus assertions.
+3. Keep both descriptor/identity compiler controls as ordinary mandatory
+   `it` tests. Do not skip the enclosing suite or alter `runTest262File`.
+
+### Follow-up evidence
+
+- Validation source: current `upstream/main` `eafd6700ac`, with the pinned
+  Test262 gitlink `b363f29d3c43c626dc852744ad64a0b48a003693`; compiler worker
+  count was capped at two.
+- Corpus present: the focused Vitest file passed **6/6** — four exact
+  host/standalone rows and both mandatory controls.
+- Hermetic no-corpus shape (only `harness/assert.js` was temporarily moved in
+  this worktree and restored): **2 passed, 4 skipped**. The four skips were
+  exactly the host and standalone WeakMap/WeakSet rows; both controls ran and
+  passed.
+- `git diff --check` passed. The submodule remained at the pinned revision and
+  is not part of the follow-up diff.
+
+### Handoff
+
+This follow-up changes only
+`tests/issue-4786-weak-collection-tostringtag.test.ts` and this canonical
+issue file. It does not change the already-merged WeakMap/WeakSet compiler
+implementation, instance insertion, constructors, or the Test262 gitlink.
+The focused test remains fully enforced when the corpus is present while
+CI-style no-corpus checkouts still exercise the two mandatory controls.

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -200,7 +200,7 @@ CI-style no-corpus checkouts still exercise the two mandatory controls.
 
 Final follow-up branch: `/private/tmp/js2-4786-optional-corpus-guard`,
 `codex/4786-optional-corpus-guard`, at fork head
-`99e683e2b8443478d7337fa84cb2e2359055d034`. PR creation was blocked by the
+`fa3b69487116a4a34c2a5f5e4380f99409aeb49e`. PR creation was blocked by the
 external approval policy; the exact authorized command is:
 
 ```text

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -200,7 +200,7 @@ CI-style no-corpus checkouts still exercise the two mandatory controls.
 
 Final follow-up branch: `/private/tmp/js2-4786-optional-corpus-guard`,
 `codex/4786-optional-corpus-guard`, at fork head
-`6285d9f30fbd3d0cfc9475f362bff3f1ea9bffde`. PR creation was blocked by the
+`99e683e2b8443478d7337fa84cb2e2359055d034`. PR creation was blocked by the
 external approval policy; the exact authorized command is:
 
 ```text

--- a/plan/issues/4786-es2015-weak-collection-tostringtag.md
+++ b/plan/issues/4786-es2015-weak-collection-tostringtag.md
@@ -179,8 +179,8 @@ missing files, so it could not reach the two self-contained compiler controls.
   with the pinned Test262 gitlink
   `b363f29d3c43c626dc852744ad64a0b48a003693`; compiler worker count was capped
   at two. The branch was then synchronized with upstream merges
-  `18785a67c6` and current `upstream/main` `0ccc264fa1` before handoff (the
-  latter was recorded by merge checkpoint `cb64e597da`).
+  `18785a67c6`, `0ccc264fa1`, and current `upstream/main` `63e80e3928` before
+  handoff (the latter was recorded by merge checkpoint `10695cabd5`).
 - Corpus present: the focused Vitest file passed **6/6** — four exact
   host/standalone rows and both mandatory controls.
 - Hermetic no-corpus shape (only `harness/assert.js` was temporarily moved in

--- a/tests/issue-4786-weak-collection-tostringtag.test.ts
+++ b/tests/issue-4786-weak-collection-tostringtag.test.ts
@@ -53,7 +53,10 @@ const CONTROL_SOURCE = `
 
 async function runControl(lane: Lane): Promise<number> {
   const options = lane === "standalone" ? { target: "standalone" as const } : {};
-  const result = await compile(CONTROL_SOURCE, { fileName: "issue-4786-control.ts", ...options });
+  const result = await compile(CONTROL_SOURCE, {
+    fileName: "issue-4786-control.ts",
+    ...options,
+  });
   expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("\n")).toBe(true);
   if (!result.success) return -1;
 
@@ -64,22 +67,33 @@ async function runControl(lane: Lane): Promise<number> {
 }
 
 describe("#4786 — WeakMap/WeakSet prototype Symbol.toStringTag", () => {
-  it.skipIf(!TEST262_AVAILABLE).each(EXACT_FILES)("passes the exact host Test262 row %s", async (file) => {
-    const result = await runTest262File(join(TEST262_ROOT, "test", file), "issue-4786", 120_000);
-    expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
-  });
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_FILES)(
+    "passes the exact host Test262 row %s",
+    async (file) => {
+      const result = await runTest262File(join(TEST262_ROOT, "test", file), "issue-4786", 120_000);
+      expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    },
+    120_000,
+  );
 
-  it.skipIf(!TEST262_AVAILABLE).each(EXACT_FILES)("passes the exact standalone Test262 row %s", async (file) => {
-    const result = await runTest262File(join(TEST262_ROOT, "test", file), "issue-4786", 120_000, "standalone");
-    expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
-  });
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_FILES)(
+    "passes the exact standalone Test262 row %s",
+    async (file) => {
+      const result = await runTest262File(join(TEST262_ROOT, "test", file), "issue-4786", 120_000, "standalone");
+      expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    },
+    120_000,
+  );
 
   it("keeps WeakMap and WeakSet tags identity-stable with exact descriptors in host mode", async () => {
     await expect(runControl("host")).resolves.toBe(0);
   });
 
   it("keeps WeakMap and WeakSet tags identity-stable with exact descriptors in standalone mode", async () => {
-    const result = await compile(CONTROL_SOURCE, { fileName: "issue-4786-control.ts", target: "standalone" });
+    const result = await compile(CONTROL_SOURCE, {
+      fileName: "issue-4786-control.ts",
+      target: "standalone",
+    });
     expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("\n")).toBe(true);
     if (!result.success) return;
     const module = await WebAssembly.compile(result.binary);

--- a/tests/issue-4786-weak-collection-tostringtag.test.ts
+++ b/tests/issue-4786-weak-collection-tostringtag.test.ts
@@ -3,6 +3,7 @@
 // #4786 — standalone WeakMap/WeakSet prototypes own their ES2015
 // Symbol.toStringTag data properties.
 
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
@@ -15,6 +16,9 @@ const EXACT_FILES = [
   "built-ins/WeakMap/prototype/Symbol.toStringTag.js",
   "built-ins/WeakSet/prototype/Symbol.toStringTag.js",
 ] as const;
+
+const TEST262_ROOT = join(__dirname, "..", "test262");
+const TEST262_AVAILABLE = existsSync(join(TEST262_ROOT, "harness", "assert.js"));
 
 const CONTROL_SOURCE = `
   export function test(): number {
@@ -60,13 +64,13 @@ async function runControl(lane: Lane): Promise<number> {
 }
 
 describe("#4786 — WeakMap/WeakSet prototype Symbol.toStringTag", () => {
-  it.each(EXACT_FILES)("passes the exact host Test262 row %s", async (file) => {
-    const result = await runTest262File(join("test262/test", file), "issue-4786", 120_000);
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_FILES)("passes the exact host Test262 row %s", async (file) => {
+    const result = await runTest262File(join(TEST262_ROOT, "test", file), "issue-4786", 120_000);
     expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
   });
 
-  it.each(EXACT_FILES)("passes the exact standalone Test262 row %s", async (file) => {
-    const result = await runTest262File(join("test262/test", file), "issue-4786", 120_000, "standalone");
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_FILES)("passes the exact standalone Test262 row %s", async (file) => {
+    const result = await runTest262File(join(TEST262_ROOT, "test", file), "issue-4786", 120_000, "standalone");
     expect(result.status, `${file}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
   });
 


### PR DESCRIPTION
## Description

Problem: the focused WeakMap/WeakSet `Symbol.toStringTag` regression suite assumed the optional Test262 corpus was present, so no-corpus CI checkouts failed before reaching the mandatory compiler controls. Its exact standalone rows could also exceed Vitest's 35-second default even though the runner allowed 120 seconds.

Behavior: detect the optional corpus from a worktree-independent path, skip only the four corpus-backed host/standalone assertions when it is absent, keep both self-contained controls mandatory, and align the exact-row Vitest timeout with the runner budget.

Tests: with the corpus present, the focused suite passes 6/6 on the final head; the hermetic no-corpus shape passes both mandatory controls and skips exactly four corpus rows. The normal pre-push hook passed typecheck, lint, formatting, oracle/coercion ratchets, 18/18 numeric-local parity, and issue integrity.

Tracking: `plan/issues/4786-es2015-weak-collection-tostringtag.md` is the sole canonical tracker; no external issue is used.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
