### PR TITLE
feat(ir): own exact hyperbolic Math calls

### DIFF
--- a/plan/issues/5110-ir-exact-ambient-math-hyperbolic.md
+++ b/plan/issues/5110-ir-exact-ambient-math-hyperbolic.md
@@ -1,7 +1,7 @@
 ---
 id: 5110
 title: "IR: own exact ambient Math.sinh/Math.cosh/Math.tanh calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -101,6 +101,34 @@ remain direct.
 - Each rollback withdraws only its corresponding method, and excluded shapes
   decline before claim without invariants or post-claim errors.
 - Affected regressions, TypeScript 7, and all pre-push gates pass.
+
+## Implementation outcome and validation
+
+- `math.sinh`, `math.cosh`, and `math.tanh` are now the nineteenth through
+  twenty-first closed source-level Math intrinsics. They reuse the shared Math
+  table, generic selector and call-graph walker, and from-AST intrinsic emitter.
+- The frozen manifest attaches the existing `Math_sinh`, `Math_cosh`, and
+  `Math_tanh` callables, declares `math.exp` as each provider's sole
+  dependency, and materializes that dependency once. No Math algorithm or
+  direct-codegen file changed.
+- Independent `JS2WASM_IR_MATH_SINH=0`, `JS2WASM_IR_MATH_COSH=0`, and
+  `JS2WASM_IR_MATH_TANH=0` controls withdraw only their corresponding claim.
+  Shadowed, aliased, computed, optional-invocation, optional-receiver,
+  wrong-arity, spread, and non-number forms all decline before claim.
+- Four focused/affected contract suites pass 45/45. They cover host and
+  zero-import standalone ownership, semantic/provider evidence, exact shared
+  dependency closure, bit-identical direct parity across cancellation,
+  saturation, overflow, NaN, infinities, and signed zero, method-specific
+  native-Math relative-error bounds, independent rollbacks, every
+  target/backend manifest policy, and linear-backend legality.
+- The existing self-hosted Math regressions pass 70/70 across #3141, #1437,
+  and `math-inline`. The local Test262 submodule was absent, so repository PR
+  automation owns the focused standards rows.
+- TypeScript 7, Prettier, Biome lint, the IR kind-neutrality gate, LOC/function
+  budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue
+  integrity pass. Luna Max re-review after binding the numerical oracle to
+  explicit IR-only outcomes returned GO with no P0/P1 finding.
+- PR #5115 is open non-draft, clean, and green, stacked on #5111's exact head.
 
 ## Non-goals
 

--- a/plan/issues/5110-ir-exact-ambient-math-hyperbolic.md
+++ b/plan/issues/5110-ir-exact-ambient-math-hyperbolic.md
@@ -1,0 +1,120 @@
+---
+id: 5110
+title: "IR: own exact ambient Math.sinh/Math.cosh/Math.tanh calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5110-ir-math-hyperbolic
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5106]
+related: [1371, 3141, 3204, 3526, 4787, 5092, 5094, 5101, 5103, 5105]
+files:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5110-ir-math-hyperbolic.test.ts
+loc-budget-allow:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5110 — Exact ambient `Math.sinh` / `Math.cosh` / `Math.tanh` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.sinh(numberExpression)`, `Math.cosh(numberExpression)`, and
+`Math.tanh(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent the coherent hyperbolic family as versioned semantic
+intrinsics and reuse the existing host-free helpers plus their shared
+`Math_exp` dependency.
+
+This checkpoint is intentionally stacked on #5111/#5106. It changes ownership
+only; the established approximations and direct-codegen fallback remain
+untouched.
+
+## Measured residual
+
+None of the three methods appears in `IR_MATH_METHOD_TABLE`, so the selector
+declines and the legacy builtin path emits `Math_sinh`, `Math_cosh`, or
+`Math_tanh`. All three self-hosted runtime bodies already exist in
+`src/stdlib/math.ts`, declare `Math_exp` as their sole callee, and are already
+covered by direct codegen's `needExp` closure. The missing contract is the
+closed semantic intrinsic/provider graph.
+
+## Exact admitted grammar
+
+For each method, admit only a non-optional `Math.<method>(argument)` when
+`Math` is the unshadowed ambient binding, there is exactly one non-spread
+argument, the selector proves primitive `number`, symbolic Math helpers are
+available, and the containing unit passes ordinary ownership/call-graph gates.
+Aliased, computed, optional, shadowed, coercive, spread, and wrong-arity forms
+remain direct.
+
+## Implementation plan
+
+1. Add `math.sinh`, `math.cosh`, and `math.tanh` to the closed
+   intrinsic/runtime-feature vocabularies with unary-f64 signatures.
+2. Add `selfhost.math.sinh -> Math_sinh`, `selfhost.math.cosh -> Math_cosh`,
+   and `selfhost.math.tanh -> Math_tanh`; declare `math.exp` as each provider's
+   sole dependency.
+3. Add all three methods to `IR_MATH_METHOD_TABLE` and reuse the generic
+   selector, call-graph walker, from-AST emitter, manifest, and provider
+   materializer.
+4. Add independent `JS2WASM_IR_MATH_SINH=0`,
+   `JS2WASM_IR_MATH_COSH=0`, and `JS2WASM_IR_MATH_TANH=0` rollbacks.
+5. Widen #3526 exhaustive vocabulary, dependency, integration,
+   linear-legality, and neutrality evidence from eighteen to twenty-one source
+   Math intrinsics.
+6. Add focused host/standalone, provider-closure, bit-exact direct parity,
+   method-specific native-oracle, rollback, and pre-claim exclusion tests.
+7. Re-run the existing self-hosted Math regressions, affected #3526 suites,
+   TypeScript 7, formatting/lint/ratchets, and full pre-push checks; then open a
+   non-draft PR stacked on #5111.
+
+## Acceptance criteria
+
+- Exact ambient one-number calls for all three methods emit IR only and attach
+  their existing self-hosted callables.
+- The manifest closes all three features over exactly one deduplicated
+  `math.exp` provider and requests no host capability.
+- Host and zero-import standalone execution are bit-identical to the direct
+  path across signed zero, finite interiors, saturation/overflow boundaries,
+  NaN, and infinities.
+- Native-Math sanity checks use explicit method-specific bounds that preserve
+  the known approximation envelope without pretending to be libm conformance.
+- Each rollback withdraws only its corresponding method, and excluded shapes
+  decline before claim without invariants or post-claim errors.
+- Affected regressions, TypeScript 7, and all pre-push gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, computed/extracted calls, optional
+  chaining, `.call`, or `.apply`.
+- A new hyperbolic approximation, host import, or direct-codegen behavior
+  change.
+- `Math.cbrt`, `Math.expm1`, inverse hyperbolics, async, class, or module-init
+  ownership expansion.
+
+## Risk and rollback
+
+The principal risks are dependency deduplication and inherited cancellation or
+overflow behavior. The semantic features must share one `math.exp` provider,
+while direct-path bit identity remains the hard migration invariant and native
+Math only supplies a coarse numerical sanity bound. Independent environment
+flags provide narrow rollback; `JS2WASM_IR_FIRST=0` remains the global control.

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 18 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 21 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,8 +353,8 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 18 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:28"],
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 21 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:29"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -19,6 +19,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.atan2",
   "math.ceil",
   "math.cos",
+  "math.cosh",
   "math.exp",
   "math.floor",
   "math.log",
@@ -27,15 +28,17 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.log2",
   "math.pow",
   "math.sin",
+  "math.sinh",
   "math.sqrt",
   "math.tan",
+  "math.tanh",
   "math.trunc",
 ] as const);
 
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the eighteen intrinsic entry points.
+ * Provider requirements reachable from the twenty-one intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -46,6 +49,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.atan2",
   "math.ceil",
   "math.cos",
+  "math.cosh",
   "math.exp",
   "math.floor",
   "math.log",
@@ -55,8 +59,10 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.pow",
   "math.reduce-trig",
   "math.sin",
+  "math.sinh",
   "math.sqrt",
   "math.tan",
+  "math.tanh",
   "math.trunc",
 ] as const);
 
@@ -142,6 +148,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.atan2": definition("math.atan2", F64_BINARY_INTRINSIC_SIGNATURE),
   "math.ceil": definition("math.ceil", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cos": definition("math.cos", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.cosh": definition("math.cosh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.exp": definition("math.exp", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.floor": definition("math.floor", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log": definition("math.log", F64_UNARY_INTRINSIC_SIGNATURE),
@@ -150,8 +157,10 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.log2": definition("math.log2", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.pow": definition("math.pow", F64_BINARY_INTRINSIC_SIGNATURE),
   "math.sin": definition("math.sin", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.sinh": definition("math.sinh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.sqrt": definition("math.sqrt", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.tan": definition("math.tan", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.tanh": definition("math.tanh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.trunc": definition("math.trunc", F64_UNARY_INTRINSIC_SIGNATURE),
 });
 

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -56,6 +56,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.atan",
   "selfhost.math.atan2",
   "selfhost.math.cos",
+  "selfhost.math.cosh",
   "selfhost.math.exp",
   "selfhost.math.log",
   "selfhost.math.log10",
@@ -64,7 +65,9 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.pow",
   "selfhost.math.reduce-trig",
   "selfhost.math.sin",
+  "selfhost.math.sinh",
   "selfhost.math.tan",
+  "selfhost.math.tanh",
 ] as const);
 
 export type MathRuntimeProviderId = (typeof PURE_MATH_RUNTIME_PROVIDER_IDS)[number];
@@ -179,6 +182,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.atan2": F64_BINARY_INTRINSIC_SIGNATURE,
   "math.ceil": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cos": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.cosh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.exp": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.floor": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -188,8 +192,10 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.pow": F64_BINARY_INTRINSIC_SIGNATURE,
   "math.reduce-trig": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sin": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.sinh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sqrt": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.tan": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.tanh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.trunc": F64_UNARY_INTRINSIC_SIGNATURE,
 });
 
@@ -253,6 +259,13 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     { kind: "self-hosted", symbol: "Math_cos" },
     ["math.reduce-trig"],
   ),
+  "math.cosh": provider(
+    "selfhost.math.cosh",
+    "math.cosh",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_cosh" },
+    ["math.exp"],
+  ),
   "math.exp": provider("selfhost.math.exp", "math.exp", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "self-hosted",
     symbol: "Math_exp",
@@ -301,6 +314,13 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     { kind: "self-hosted", symbol: "Math_sin" },
     ["math.reduce-trig"],
   ),
+  "math.sinh": provider(
+    "selfhost.math.sinh",
+    "math.sinh",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_sinh" },
+    ["math.exp"],
+  ),
   "math.sqrt": provider("backend.f64.sqrt", "math.sqrt", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "backend-op",
     opcode: "f64.sqrt",
@@ -312,13 +332,20 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     { kind: "self-hosted", symbol: "Math_tan" },
     ["math.cos", "math.sin"],
   ),
+  "math.tanh": provider(
+    "selfhost.math.tanh",
+    "math.tanh",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_tanh" },
+    ["math.exp"],
+  ),
   "math.trunc": provider("backend.f64.trunc", "math.trunc", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "backend-op",
     opcode: "f64.trunc",
   }),
 });
 
-/** Canonically ordered default provider catalogue for the eighteen-method slice. */
+/** Canonically ordered default provider catalogue for the twenty-one-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -299,6 +299,9 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   sin: { arity: 1, intrinsic: "math.sin" },
   cos: { arity: 1, intrinsic: "math.cos" },
   tan: { arity: 1, intrinsic: "math.tan" },
+  sinh: { arity: 1, intrinsic: "math.sinh" },
+  cosh: { arity: 1, intrinsic: "math.cosh" },
+  tanh: { arity: 1, intrinsic: "math.tanh" },
   exp: { arity: 1, intrinsic: "math.exp" },
   log: { arity: 1, intrinsic: "math.log" },
   log10: { arity: 1, intrinsic: "math.log10" },
@@ -6487,6 +6490,9 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.tan" && process.env.JS2WASM_IR_MATH_TAN === "0") return false;
   if (plan.intrinsic === "math.log10" && process.env.JS2WASM_IR_MATH_LOG10 === "0") return false;
   if (plan.intrinsic === "math.log1p" && process.env.JS2WASM_IR_MATH_LOG1P === "0") return false;
+  if (plan.intrinsic === "math.sinh" && process.env.JS2WASM_IR_MATH_SINH === "0") return false;
+  if (plan.intrinsic === "math.cosh" && process.env.JS2WASM_IR_MATH_COSH === "0") return false;
+  if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
   return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
 }
 

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -69,6 +69,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function allMath(x: number, y: number): number {
         return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.trunc(x)
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
+          + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
           + Math.exp(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
@@ -126,6 +127,9 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function sin(): number { return Math.sin(0.75); }
       export function cos(): number { return Math.cos(0.75); }
       export function tan(): number { return Math.tan(0.75); }
+      export function sinh(): number { return Math.sinh(0.75); }
+      export function cosh(): number { return Math.cosh(0.75); }
+      export function tanh(): number { return Math.tanh(0.75); }
       export function exp(): number { return Math.exp(1.25); }
       export function log(): number { return Math.log(3.5); }
       export function log10(): number { return Math.log10(1000); }
@@ -170,6 +174,9 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       "sin",
       "cos",
       "tan",
+      "sinh",
+      "cosh",
+      "tanh",
       "exp",
       "log",
       "log10",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,12 +88,12 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact eighteen certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact twenty-one certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(18);
+    expect(intrinsicMethods).toHaveLength(21);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
@@ -101,10 +101,13 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         "math.acos",
         "math.asin",
         "math.atan",
+        "math.cosh",
         "math.log10",
         "math.log1p",
         "math.reduce-trig",
+        "math.sinh",
         "math.tan",
+        "math.tanh",
       ]),
     );
     const intrinsicFeatures = new Set<string>(PURE_MATH_INTRINSIC_IDS);
@@ -129,7 +132,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(18);
+    expect(first.intrinsicUses).toHaveLength(21);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -143,6 +146,9 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.atan2"]).toEqual(["math.atan"]);
     expect(dependencies["math.log10"]).toEqual(["math.log"]);
     expect(dependencies["math.log1p"]).toEqual(["math.log"]);
+    expect(dependencies["math.cosh"]).toEqual(["math.exp"]);
+    expect(dependencies["math.sinh"]).toEqual(["math.exp"]);
+    expect(dependencies["math.tanh"]).toEqual(["math.exp"]);
     expect(dependencies["math.sin"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.tan"]).toEqual(["math.cos", "math.sin"]);
@@ -164,6 +170,9 @@ describe("#3526 typed IR runtime manifest foundation", () => {
           "math.tan",
           "math.log10",
           "math.log1p",
+          "math.sinh",
+          "math.cosh",
+          "math.tanh",
           "math.pow",
           "math.atan2",
         ]);
@@ -180,6 +189,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       "math.atan",
       "math.atan2",
       "math.cos",
+      "math.cosh",
       "math.exp",
       "math.log",
       "math.log10",
@@ -187,7 +197,9 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       "math.pow",
       "math.reduce-trig",
       "math.sin",
+      "math.sinh",
       "math.tan",
+      "math.tanh",
     ]);
   });
 

--- a/tests/issue-5110-ir-math-hyperbolic.test.ts
+++ b/tests/issue-5110-ir-math-hyperbolic.test.ts
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5110-ir-math-hyperbolic");
+const METHODS = ["sinh", "cosh", "tanh"] as const;
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+const exclusionCases = METHODS.flatMap(
+  (method) =>
+    [
+      [
+        `${method} with shadowed Math`,
+        `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5110 shadowed Math is intentionally not ambient.
+      return Math.${method}(x);
+    }`,
+      ],
+      [
+        `aliased ${method}`,
+        `const hyperbolic = Math.${method};
+    export function f(x: number): number { return hyperbolic(x); }`,
+      ],
+      [`computed ${method}`, `export function f(x: number): number { return Math["${method}"](x); }`],
+      [`optional invocation ${method}`, `export function f(x: number): number { return Math.${method}?.(x); }`],
+      [`optional receiver ${method}`, `export function f(x: number): number { return Math?.${method}(x); }`],
+      [
+        `${method} wrong arity`,
+        `export function f(x: number): number {
+      // @ts-expect-error #5110 intentionally exercises extra arity.
+      return Math.${method}(x, x);
+    }`,
+      ],
+      [
+        `${method} spread argument`,
+        `export function f(x: number): number {
+      return Math.${method}(...([x] as [number]));
+    }`,
+      ],
+      [
+        `${method} non-number argument`,
+        `export function f(): number {
+      const text: string = "1";
+      return Math.${method}(text as never);
+    }`,
+      ],
+    ] as const,
+);
+
+describe("#5110 exact ambient hyperbolic Math IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims all three exact one-number calls on the %s target", async (_label, target) => {
+    const result = await compile(
+      `
+        export function sinh(value: number): number { return Math.sinh(value); }
+        export function cosh(value: number): number { return Math.cosh(value); }
+        export function tanh(value: number): number { return Math.tanh(value); }
+      `,
+      {
+        fileName: `issue-5110-${_label}.ts`,
+        ...(target === undefined ? {} : { target }),
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+      },
+    );
+    expectSuccess(result);
+
+    for (const method of METHODS) {
+      expect(outcomeFor(result, method)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(result.irCompiledFuncs ?? []).toContain(method);
+      expect(result.wat).toContain(`$Math_${method}`);
+    }
+    expect(result.wat).toContain("$Math_exp");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const exports = await instantiate(result);
+    for (const method of METHODS) expect(typeof exports[method]).toBe("function");
+
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches all three providers to one deduplicated Math_exp dependency", () => {
+    const analysis = analyzeSource(`
+      export function hyperbolic(value: number): number {
+        return Math.sinh(value) + Math.cosh(value) + Math.tanh(value);
+      }
+    `);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing hyperbolic declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("hyperbolic").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id).sort()).toEqual(["math.cosh", "math.sinh", "math.tanh"]);
+    expect(semantic.every((instr) => instr.provider === undefined)).toBe(true);
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id).sort()).toEqual([
+      "math.cosh",
+      "math.sinh",
+      "math.tanh",
+    ]);
+    expect(prepared.manifest.features).toEqual(["math.cosh", "math.exp", "math.sinh", "math.tanh"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    const dependencies = Object.fromEntries(
+      prepared.manifest.providers.map((provider) => [provider.feature, provider.dependencies]),
+    );
+    expect(dependencies).toMatchObject({
+      "math.cosh": ["math.exp"],
+      "math.exp": [],
+      "math.sinh": ["math.exp"],
+      "math.tanh": ["math.exp"],
+    });
+    expect(new Set(prepared.manifest.providers.map((provider) => provider.id))).toEqual(
+      new Set(["selfhost.math.cosh", "selfhost.math.exp", "selfhost.math.sinh", "selfhost.math.tanh"]),
+    );
+
+    for (const instr of intrinsicInstructions(prepared.functions[0]!)) {
+      expect(instr.provider).toMatchObject({
+        kind: "callable",
+        target: { name: `Math_${instr.id.slice(5)}`, binding: { kind: "intrinsic", symbol: instr.id } },
+      });
+    }
+  });
+
+  it("is bit-identical to the direct path across cancellation, saturation, and overflow boundaries", async () => {
+    const source = `
+      export function sinh(value: number): number { return Math.sinh(value); }
+      export function cosh(value: number): number { return Math.cosh(value); }
+      export function tanh(value: number): number { return Math.tanh(value); }
+    `;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5110-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5110-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+
+    const irExports = await instantiate(ir);
+    const directExports = await instantiate(direct);
+    const samples = [
+      Number.NaN,
+      Number.NEGATIVE_INFINITY,
+      -710,
+      -20.0000001,
+      -20,
+      -1,
+      -Number.MIN_VALUE,
+      -0,
+      0,
+      Number.MIN_VALUE,
+      1,
+      20,
+      20.0000001,
+      710,
+      Number.POSITIVE_INFINITY,
+    ];
+
+    for (const method of METHODS) {
+      expect(outcomeFor(ir, method)).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+      const irFn = irExports[method] as (value: number) => number;
+      const directFn = directExports[method] as (value: number) => number;
+      for (const value of samples) {
+        expect(Object.is(irFn(value), directFn(value)), `${method} parity for ${String(value)}`).toBe(true);
+      }
+    }
+
+    expect(Object.is((irExports.sinh as (value: number) => number)(-0), -0)).toBe(true);
+    expect(Object.is((irExports.tanh as (value: number) => number)(-0), -0)).toBe(true);
+    expect((irExports.cosh as (value: number) => number)(-0)).toBe(1);
+  });
+
+  it("pins the established native-Math relative-error envelopes in the finite interior", async () => {
+    const result = await compile(
+      `
+        export function sinh(value: number): number { return Math.sinh(value); }
+        export function cosh(value: number): number { return Math.cosh(value); }
+        export function tanh(value: number): number { return Math.tanh(value); }
+      `,
+      { fileName: "issue-5110-native-oracle.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expectSuccess(result);
+    const exports = await instantiate(result);
+    const samples = [-20, -10, -3, -1, -0.5, 0.5, 1, 3, 10, 20];
+    const maxRelativeError = { sinh: 2.5e-8, cosh: 1e-8, tanh: 2.5e-8 } as const;
+
+    for (const method of METHODS) {
+      const compiled = exports[method] as (value: number) => number;
+      const native = Math[method];
+      for (const value of samples) {
+        const actual = compiled(value);
+        const expected = native(value);
+        const relativeError = Math.abs(actual - expected) / Math.max(Math.abs(expected), Number.MIN_VALUE);
+        expect(relativeError, `${method} relative error for ${value}`).toBeLessThanOrEqual(maxRelativeError[method]);
+      }
+    }
+  });
+
+  it.each([
+    ["sinh", "JS2WASM_IR_MATH_SINH", ["cosh", "tanh"]],
+    ["cosh", "JS2WASM_IR_MATH_COSH", ["sinh", "tanh"]],
+    ["tanh", "JS2WASM_IR_MATH_TANH", ["sinh", "cosh"]],
+  ] as const)("withdraws only %s through its narrow rollback", async (disabled, flag, retained) => {
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(
+        `
+          export function sinh(value: number): number { return Math.sinh(value); }
+          export function cosh(value: number): number { return Math.cosh(value); }
+          export function tanh(value: number): number { return Math.tanh(value); }
+        `,
+        { fileName: `issue-5110-${disabled}-rollback.ts`, experimentalIR: true, trackIrOutcomes: true },
+      );
+      expectSuccess(result);
+      expect(outcomeFor(result, disabled)).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      for (const method of retained) {
+        expect(outcomeFor(result, method)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+      }
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5110-${_label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});

--- a/tests/issue-5110-ir-math-hyperbolic.test.ts
+++ b/tests/issue-5110-ir-math-hyperbolic.test.ts
@@ -240,11 +240,17 @@ describe("#5110 exact ambient hyperbolic Math IR ownership", () => {
       { fileName: "issue-5110-native-oracle.ts", experimentalIR: true, trackIrOutcomes: true },
     );
     expectSuccess(result);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
     const exports = await instantiate(result);
     const samples = [-20, -10, -3, -1, -0.5, 0.5, 1, 3, 10, 20];
     const maxRelativeError = { sinh: 2.5e-8, cosh: 1e-8, tanh: 2.5e-8 } as const;
 
     for (const method of METHODS) {
+      expect(outcomeFor(result, method)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
       const compiled = exports[method] as (value: number) => number;
       const native = Math[method];
       for (const value of samples) {


### PR DESCRIPTION
## Summary

- represent exact ambient `Math.sinh(number)`, `Math.cosh(number)`, and `Math.tanh(number)` calls as semantic IR intrinsics
- attach the existing host-free helpers through one deduplicated `Math_exp` provider dependency
- add independent rollback flags and exhaustive ownership, exclusion, direct-parity, and method-specific numerical coverage

## Validation

- 45/45 focused and affected contract tests passed
- 70/70 legacy self-hosted Math regressions passed
- TypeScript 7, Biome lint, Prettier, oracle/coercion ratchets, numeric-local parity 18/18, and issue integrity passed

## Stack

- stacked on #5111 (`codex/5106-ir-math-log10-log1p`)
- non-draft; repository automation may merge it after its parent lands