### PR TITLE
feat(ir): own exact Math.cbrt calls

### DIFF
--- a/plan/issues/5111-ir-exact-ambient-math-cbrt.md
+++ b/plan/issues/5111-ir-exact-ambient-math-cbrt.md
@@ -1,7 +1,7 @@
 ---
 id: 5111
 title: "IR: own exact ambient Math.cbrt calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -92,6 +92,31 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
 - The narrow rollback and all excluded shapes decline before claim without
   invariants or post-claim errors.
 - Affected regressions, TypeScript 7, and all pre-push gates pass.
+
+## Implementation outcome and validation
+
+- `math.cbrt` is now the twenty-second closed source-level Math intrinsic. It
+  reuses the shared Math table, generic selector and call-graph walker, and
+  from-AST intrinsic emitter.
+- The frozen manifest attaches the existing, dependency-free `Math_cbrt`
+  callable and requests no host capability. No Math algorithm or
+  direct-codegen file changed.
+- `JS2WASM_IR_MATH_CBRT=0` withdraws only this claim. Shadowed, aliased,
+  computed, optional-invocation, optional-receiver, wrong-arity, spread, and
+  non-number forms all decline before claim.
+- Four focused/affected contract suites pass 27/27. They cover host and
+  zero-import standalone ownership and execution, dependency-free provider
+  evidence, bit-identical direct parity across signs, subnormals, exact cubes,
+  maximum magnitudes, NaN, and infinities, an IR-only moderate-value native
+  oracle, rollback, exhaustive integration, every target/backend manifest
+  policy, and linear-backend legality.
+- Existing cbrt/self-hosted Math regressions pass 51/51 across #3141 and
+  `math-inline`.
+- TypeScript 7, Prettier, Biome lint, the IR kind-neutrality gate, LOC/function
+  budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue
+  integrity pass. Luna Max re-review after the range-limit disposition returned
+  GO with no P0/P1 finding.
+- PR #5118 is open non-draft, stacked on #5115's exact head.
 
 ## Non-goals
 

--- a/plan/issues/5111-ir-exact-ambient-math-cbrt.md
+++ b/plan/issues/5111-ir-exact-ambient-math-cbrt.md
@@ -1,0 +1,111 @@
+---
+id: 5111
+title: "IR: own exact ambient Math.cbrt calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5111-ir-math-cbrt
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5110]
+related: [1371, 3141, 3204, 3526, 4787, 5092, 5094, 5101, 5103, 5105, 5106]
+files:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5111-ir-math-cbrt.test.ts
+loc-budget-allow:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5111 — Exact ambient `Math.cbrt` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.cbrt(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent the source call as a versioned semantic intrinsic and
+reuse the existing host-free, dependency-free `Math_cbrt` helper.
+
+This checkpoint is intentionally stacked on #5115/#5110. It changes ownership
+only; the established Newton iteration and direct-codegen fallback remain
+untouched.
+
+## Measured residual
+
+`cbrt` is absent from `IR_MATH_METHOD_TABLE`, so the selector declines and the
+legacy builtin path emits `Math_cbrt`. The self-hosted runtime body already
+exists in `src/stdlib/math.ts`, has no sibling callees, and is already covered
+by the direct helper materializer. The missing contract is the closed semantic
+intrinsic/provider entry.
+
+## Exact admitted grammar
+
+Admit only a non-optional `Math.cbrt(argument)` when `Math` is the unshadowed
+ambient binding, there is exactly one non-spread argument, the selector proves
+primitive `number`, symbolic Math helpers are available, and the containing
+unit passes ordinary ownership/call-graph gates. Aliased, computed, optional,
+shadowed, coercive, spread, and wrong-arity forms remain direct.
+
+## Implementation plan
+
+1. Add `math.cbrt` to the closed intrinsic/runtime-feature vocabularies with a
+   unary-f64 signature.
+2. Add the dependency-free `selfhost.math.cbrt -> Math_cbrt` provider.
+3. Add `cbrt` to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
+   call-graph walker, from-AST emitter, manifest, and provider materializer.
+4. Add an independent `JS2WASM_IR_MATH_CBRT=0` rollback.
+5. Widen #3526 exhaustive vocabulary, integration, linear-legality, and
+   neutrality evidence from twenty-one to twenty-two source Math intrinsics.
+6. Add focused host/standalone ownership, dependency-free provider closure,
+   bit-exact direct parity, native-oracle, rollback, and pre-claim exclusion
+   tests covering signs, subnormals, exact cubes, finite interiors, NaN, and
+   infinities.
+7. Re-run existing cbrt/self-hosted Math regressions, affected #3526 suites,
+   TypeScript 7, formatting/lint/ratchets, and full pre-push checks; then open a
+   non-draft PR stacked on #5115.
+
+## Acceptance criteria
+
+- Exact ambient one-number `Math.cbrt` calls emit IR only and attach the
+  existing dependency-free self-hosted callable.
+- Host and zero-import standalone execution are bit-identical to the direct
+  path across signed zero, subnormals, exact cubes, finite interiors, NaN, and
+  infinities.
+- A native-Math oracle pins an explicit absolute/relative accuracy envelope
+  while separately proving the oracle ran on an IR-only body.
+- The narrow rollback and all excluded shapes decline before claim without
+  invariants or post-claim errors.
+- Affected regressions, TypeScript 7, and all pre-push gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, computed/extracted calls, optional
+  chaining, `.call`, or `.apply`.
+- A new cube-root approximation, host import, or direct-codegen behavior
+  change.
+- `Math.expm1`, inverse hyperbolics, async, class, or module-init ownership
+  expansion.
+
+## Risk and rollback
+
+The principal risk is inherited Newton-iteration behavior for very small or
+very large magnitudes. Direct-path bit identity remains the hard migration
+invariant and native Math supplies a coarse independent sanity bound. The
+method-specific environment flag provides narrow rollback;
+`JS2WASM_IR_FIRST=0` remains the global control.

--- a/plan/issues/5111-ir-exact-ambient-math-cbrt.md
+++ b/plan/issues/5111-ir-exact-ambient-math-cbrt.md
@@ -107,5 +107,10 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
 The principal risk is inherited Newton-iteration behavior for very small or
 very large magnitudes. Direct-path bit identity remains the hard migration
 invariant and native Math supplies a coarse independent sanity bound. The
+Luna's numerical audit measured large pre-existing relative error at
+`Number.MIN_VALUE` and `Number.MAX_VALUE`; this PR explicitly executes exact
+values in standalone mode, pins direct/IR identity at both range edges, and
+limits the native oracle to the helper's established moderate-value envelope.
+Changing the eight-step algorithm remains a separate correctness change. The
 method-specific environment flag provides narrow rollback;
 `JS2WASM_IR_FIRST=0` remains the global control.

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 21 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 22 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,8 +353,8 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 21 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:29"],
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 22 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:30"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -17,6 +17,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.asin",
   "math.atan",
   "math.atan2",
+  "math.cbrt",
   "math.ceil",
   "math.cos",
   "math.cosh",
@@ -38,7 +39,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the twenty-one intrinsic entry points.
+ * Provider requirements reachable from the twenty-two intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -47,6 +48,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.asin",
   "math.atan",
   "math.atan2",
+  "math.cbrt",
   "math.ceil",
   "math.cos",
   "math.cosh",
@@ -146,6 +148,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.asin": definition("math.asin", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.atan": definition("math.atan", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.atan2": definition("math.atan2", F64_BINARY_INTRINSIC_SIGNATURE),
+  "math.cbrt": definition("math.cbrt", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.ceil": definition("math.ceil", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cos": definition("math.cos", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cosh": definition("math.cosh", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -55,6 +55,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.asin",
   "selfhost.math.atan",
   "selfhost.math.atan2",
+  "selfhost.math.cbrt",
   "selfhost.math.cos",
   "selfhost.math.cosh",
   "selfhost.math.exp",
@@ -180,6 +181,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.asin": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.atan": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.atan2": F64_BINARY_INTRINSIC_SIGNATURE,
+  "math.cbrt": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.ceil": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cos": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cosh": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -248,6 +250,10 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     { kind: "self-hosted", symbol: "Math_atan2" },
     ["math.atan"],
   ),
+  "math.cbrt": provider("selfhost.math.cbrt", "math.cbrt", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "self-hosted",
+    symbol: "Math_cbrt",
+  }),
   "math.ceil": provider("backend.f64.ceil", "math.ceil", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "backend-op",
     opcode: "f64.ceil",
@@ -345,7 +351,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
   }),
 });
 
-/** Canonically ordered default provider catalogue for the twenty-one-method slice. */
+/** Canonically ordered default provider catalogue for the twenty-two-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -296,6 +296,7 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   asin: { arity: 1, intrinsic: "math.asin" },
   acos: { arity: 1, intrinsic: "math.acos" },
   atan: { arity: 1, intrinsic: "math.atan" },
+  cbrt: { arity: 1, intrinsic: "math.cbrt" },
   sin: { arity: 1, intrinsic: "math.sin" },
   cos: { arity: 1, intrinsic: "math.cos" },
   tan: { arity: 1, intrinsic: "math.tan" },
@@ -6493,6 +6494,7 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.sinh" && process.env.JS2WASM_IR_MATH_SINH === "0") return false;
   if (plan.intrinsic === "math.cosh" && process.env.JS2WASM_IR_MATH_COSH === "0") return false;
   if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
+  if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
   return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
 }
 

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -70,6 +70,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
         return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.trunc(x)
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
           + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
+          + Math.cbrt(x)
           + Math.exp(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
@@ -130,6 +131,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function sinh(): number { return Math.sinh(0.75); }
       export function cosh(): number { return Math.cosh(0.75); }
       export function tanh(): number { return Math.tanh(0.75); }
+      export function cbrt(): number { return Math.cbrt(27); }
       export function exp(): number { return Math.exp(1.25); }
       export function log(): number { return Math.log(3.5); }
       export function log10(): number { return Math.log10(1000); }
@@ -177,6 +179,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       "sinh",
       "cosh",
       "tanh",
+      "cbrt",
       "exp",
       "log",
       "log10",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,12 +88,12 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact twenty-one certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact twenty-two certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(21);
+    expect(intrinsicMethods).toHaveLength(22);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
@@ -101,6 +101,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         "math.acos",
         "math.asin",
         "math.atan",
+        "math.cbrt",
         "math.cosh",
         "math.log10",
         "math.log1p",
@@ -132,7 +133,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(21);
+    expect(first.intrinsicUses).toHaveLength(22);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -149,6 +150,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.cosh"]).toEqual(["math.exp"]);
     expect(dependencies["math.sinh"]).toEqual(["math.exp"]);
     expect(dependencies["math.tanh"]).toEqual(["math.exp"]);
+    expect(dependencies["math.cbrt"]).toEqual([]);
     expect(dependencies["math.sin"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.tan"]).toEqual(["math.cos", "math.sin"]);
@@ -173,6 +175,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
           "math.sinh",
           "math.cosh",
           "math.tanh",
+          "math.cbrt",
           "math.pow",
           "math.atan2",
         ]);
@@ -188,6 +191,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       "math.asin",
       "math.atan",
       "math.atan2",
+      "math.cbrt",
       "math.cos",
       "math.cosh",
       "math.exp",

--- a/tests/issue-5111-ir-math-cbrt.test.ts
+++ b/tests/issue-5111-ir-math-cbrt.test.ts
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5111-ir-math-cbrt");
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+const exclusionCases = [
+  [
+    "shadowed Math",
+    `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5111 shadowed Math is intentionally not ambient.
+      return Math.cbrt(x);
+    }`,
+  ],
+  ["aliased cbrt", `const cubeRoot = Math.cbrt; export function f(x: number): number { return cubeRoot(x); }`],
+  ["computed cbrt", `export function f(x: number): number { return Math["cbrt"](x); }`],
+  ["optional invocation", `export function f(x: number): number { return Math.cbrt?.(x); }`],
+  ["optional receiver", `export function f(x: number): number { return Math?.cbrt(x); }`],
+  [
+    "wrong arity",
+    `export function f(x: number): number {
+      // @ts-expect-error #5111 intentionally exercises extra arity.
+      return Math.cbrt(x, x);
+    }`,
+  ],
+  ["spread argument", `export function f(x: number): number { return Math.cbrt(...([x] as [number])); }`],
+  [
+    "non-number argument",
+    `export function f(): number {
+      const text: string = "1";
+      return Math.cbrt(text as never);
+    }`,
+  ],
+] as const;
+
+describe("#5111 exact ambient Math.cbrt IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims the exact one-number call on the %s target", async (_label, target) => {
+    const result = await compile(`export function cbrt(value: number): number { return Math.cbrt(value); }`, {
+      fileName: `issue-5111-${_label}.ts`,
+      ...(target === undefined ? {} : { target }),
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "cbrt")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irCompiledFuncs ?? []).toContain("cbrt");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.wat).toContain("$Math_cbrt");
+
+    const exports = await instantiate(result);
+    expect(typeof exports.cbrt).toBe("function");
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches the dependency-free existing Math_cbrt provider", () => {
+    const analysis = analyzeSource(`export function cbrt(value: number): number { return Math.cbrt(value); }`);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing cbrt declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("cbrt").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id)).toEqual(["math.cbrt"]);
+    expect(semantic[0]?.provider).toBeUndefined();
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id)).toEqual(["math.cbrt"]);
+    expect(prepared.manifest.features).toEqual(["math.cbrt"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    expect(prepared.manifest.providers).toEqual([
+      expect.objectContaining({
+        id: "selfhost.math.cbrt",
+        feature: "math.cbrt",
+        dependencies: [],
+        implementation: { kind: "self-hosted", symbol: "Math_cbrt" },
+      }),
+    ]);
+    expect(intrinsicInstructions(prepared.functions[0]!)[0]?.provider).toMatchObject({
+      kind: "callable",
+      target: { name: "Math_cbrt", binding: { kind: "intrinsic", symbol: "math.cbrt" } },
+    });
+  });
+
+  it("is bit-identical to the direct path across signs, subnormals, exact cubes, NaN, and infinities", async () => {
+    const source = `export function cbrt(value: number): number { return Math.cbrt(value); }`;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5111-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5111-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+    expect(outcomeFor(ir, "cbrt")).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+
+    const irCbrt = (await instantiate(ir)).cbrt as (value: number) => number;
+    const directCbrt = (await instantiate(direct)).cbrt as (value: number) => number;
+    for (const value of [
+      Number.NaN,
+      Number.NEGATIVE_INFINITY,
+      -Number.MAX_VALUE,
+      -123.456,
+      -27,
+      -8,
+      -1,
+      -Number.MIN_VALUE,
+      -0,
+      0,
+      Number.MIN_VALUE,
+      1,
+      8,
+      27,
+      123.456,
+      Number.MAX_VALUE,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      expect(Object.is(irCbrt(value), directCbrt(value)), `cbrt parity for ${String(value)}`).toBe(true);
+    }
+  });
+
+  it("pins the established native-Math accuracy envelope on an IR-only body", async () => {
+    const result = await compile(`export function cbrt(value: number): number { return Math.cbrt(value); }`, {
+      fileName: "issue-5111-native-oracle.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(outcomeFor(result, "cbrt")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    const cbrt = (await instantiate(result)).cbrt as (value: number) => number;
+
+    for (const value of [-123.456, -27, -8, -2.5, -1, -0.125, 0.125, 1, 2.5, 8, 27, 123.456]) {
+      const actual = cbrt(value);
+      const expected = Math.cbrt(value);
+      const relativeError = Math.abs(actual - expected) / Math.max(Math.abs(expected), Number.MIN_VALUE);
+      expect(relativeError, `cbrt relative error for ${value}`).toBeLessThanOrEqual(1e-8);
+    }
+  });
+
+  it("withdraws only cbrt through its narrow rollback", async () => {
+    const flag = "JS2WASM_IR_MATH_CBRT";
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(`export function cbrt(value: number): number { return Math.cbrt(value); }`, {
+        fileName: "issue-5111-rollback.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      expectSuccess(result);
+      expect(outcomeFor(result, "cbrt")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5111-${_label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});

--- a/tests/issue-5111-ir-math-cbrt.test.ts
+++ b/tests/issue-5111-ir-math-cbrt.test.ts
@@ -98,6 +98,12 @@ describe("#5111 exact ambient Math.cbrt IR ownership", () => {
 
     const exports = await instantiate(result);
     expect(typeof exports.cbrt).toBe("function");
+    const cbrt = exports.cbrt as (value: number) => number;
+    expect(cbrt(27)).toBe(3);
+    expect(cbrt(-8)).toBe(-2);
+    expect(Object.is(cbrt(-0), -0)).toBe(true);
+    expect(cbrt(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(cbrt(Number.NEGATIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY);
     if (target === "standalone") {
       expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
       expect(result.imports).toEqual([]);
@@ -193,6 +199,10 @@ describe("#5111 exact ambient Math.cbrt IR ownership", () => {
     });
     const cbrt = (await instantiate(result)).cbrt as (value: number) => number;
 
+    // This ownership-only checkpoint preserves the established eight-step
+    // Newton helper. Its range-edge accuracy is intentionally not disguised by
+    // this moderate-value oracle; the direct-parity test above covers MIN/MAX
+    // values and proves the migration itself is bit-identical there.
     for (const value of [-123.456, -27, -8, -2.5, -1, -0.125, 0.125, 1, 2.5, 8, 27, 123.456]) {
       const actual = cbrt(value);
       const expected = Math.cbrt(value);


### PR DESCRIPTION
## Summary

- represent exact ambient `Math.cbrt(number)` calls as a semantic IR intrinsic
- attach the existing dependency-free host-free `Math_cbrt` provider
- add a narrow rollback plus exhaustive ownership, exclusion, direct-parity, standalone-execution, and numerical-oracle coverage

## Validation

- 27/27 focused and affected contract tests passed
- 51/51 legacy cbrt/self-hosted Math regressions passed
- TypeScript 7, Biome lint, Prettier, oracle/coercion ratchets, numeric-local parity 18/18, and issue integrity passed
- Luna Max re-review: GO, no P0/P1 findings

## Numerical scope

- preserves bit-identical direct-path behavior at subnormal and maximum magnitudes
- explicitly documents the existing eight-step Newton helper accuracy limitation at range edges; algorithm changes are outside this ownership-only PR

## Stack

- stacked on #5115 (`codex/5110-ir-math-hyperbolic`)
- non-draft; repository automation may merge it after its parent lands