### PR TITLE
feat(ir): own exact ambient Math.expm1 calls

### DIFF
--- a/plan/issues/5114-ir-exact-ambient-math-expm1.md
+++ b/plan/issues/5114-ir-exact-ambient-math-expm1.md
@@ -1,0 +1,112 @@
+---
+id: 5114
+title: "IR: own exact ambient Math.expm1 calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5114-ir-math-expm1
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5111]
+related: [1371, 3141, 3204, 3526, 4787, 5092, 5094, 5101, 5103, 5105, 5106, 5110]
+files:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5114-ir-math-expm1.test.ts
+loc-budget-allow:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5114 — Exact ambient `Math.expm1` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.expm1(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent the source call as a versioned semantic intrinsic and
+reuse the existing host-free `Math_expm1` helper plus its `Math_exp`
+dependency.
+
+This checkpoint is intentionally stacked on #5118/#5111. It changes ownership
+only; the established Taylor/general algorithm and direct-codegen fallback
+remain untouched.
+
+## Measured residual
+
+`expm1` is absent from `IR_MATH_METHOD_TABLE`, so the selector declines and the
+legacy builtin path emits `Math_expm1`. The self-hosted runtime body already
+exists in `src/stdlib/math.ts`, declares `Math_exp` as its sole callee, and is
+already covered by direct codegen's `needExp` closure. The missing contract is
+the closed semantic intrinsic/provider entry.
+
+## Exact admitted grammar
+
+Admit only a non-optional `Math.expm1(argument)` when `Math` is the unshadowed
+ambient binding, there is exactly one non-spread argument, the selector proves
+primitive `number`, symbolic Math helpers are available, and the containing
+unit passes ordinary ownership/call-graph gates. Aliased, computed, optional,
+shadowed, coercive, spread, and wrong-arity forms remain direct.
+
+## Implementation plan
+
+1. Add `math.expm1` to the closed intrinsic/runtime-feature vocabularies with
+   a unary-f64 signature.
+2. Add `selfhost.math.expm1 -> Math_expm1` with `math.exp` as its sole
+   dependency.
+3. Add `expm1` to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
+   call-graph walker, from-AST emitter, manifest, and provider materializer.
+4. Add an independent `JS2WASM_IR_MATH_EXPM1=0` rollback.
+5. Widen #3526 exhaustive vocabulary, dependency, integration,
+   linear-legality, and neutrality evidence from twenty-two to twenty-three
+   source Math intrinsics.
+6. Add focused host/standalone ownership, exact provider closure, bit-exact
+   direct parity, Taylor-threshold/native-oracle, rollback, and pre-claim
+   exclusion tests across signed zero, tiny values, branch boundaries, finite
+   interiors, NaN, and infinities.
+7. Re-run existing expm1/self-hosted Math regressions, affected #3526 suites,
+   TypeScript 7, formatting/lint/ratchets, and full pre-push checks; then open a
+   non-draft PR stacked on #5118.
+
+## Acceptance criteria
+
+- Exact ambient one-number `Math.expm1` calls emit IR only and attach the
+  existing self-hosted callable through one `math.exp` dependency.
+- Host and zero-import standalone execution are bit-identical to the direct
+  path across the Taylor boundary, signed zero, finite values, NaN, and
+  infinities.
+- A native-Math oracle pins explicit Taylor/general accuracy bounds while
+  separately proving the oracle ran on an IR-only body.
+- The narrow rollback and all excluded shapes decline before claim without
+  invariants or post-claim errors.
+- Affected regressions, TypeScript 7, and all pre-push gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, computed/extracted calls, optional
+  chaining, `.call`, or `.apply`.
+- A new expm1 approximation, host import, or direct-codegen behavior change.
+- Inverse hyperbolics, async, class, or module-init ownership expansion.
+
+## Risk and rollback
+
+The principal risks are cancellation near zero and behavior at the strict
+`|x| < 1e-5` Taylor boundary. Direct-path bit identity remains the hard
+migration invariant and native Math supplies method-specific independent
+accuracy bounds. The method-specific environment flag provides narrow
+rollback; `JS2WASM_IR_FIRST=0` remains the global control.

--- a/plan/issues/5114-ir-exact-ambient-math-expm1.md
+++ b/plan/issues/5114-ir-exact-ambient-math-expm1.md
@@ -103,6 +103,29 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
 - A new expm1 approximation, host import, or direct-codegen behavior change.
 - Inverse hyperbolics, async, class, or module-init ownership expansion.
 
+## Measured numerical disposition
+
+The existing direct and self-hosted paths share the same order-four Taylor
+arm and degree-seven `Math_exp` dependency. The ownership change deliberately
+preserves that implementation. A Luna audit measured and the focused suite
+now pins three separate envelopes instead of presenting one misleading global
+accuracy claim:
+
+- strict Taylor inputs immediately below `|x| = 1e-5`: at most `3e-21`
+  absolute error, `3e-16` relative error, and two ULPs;
+- the fallback inputs at and immediately above the strict boundary: at most
+  `2e-16` absolute error, `2e-11` relative error, and 100,000 ULPs;
+- representative finite inputs in the safe `[-709, 709]` range: at most
+  `3e-8` relative/scaled-absolute error and 200 million ULPs.
+
+The large ULP ceilings expose inherited approximation behavior rather than
+endorsing correct rounding. In particular, cancellation in `Math_exp(x) - 1`
+produces roughly 57,000 ULPs at the positive threshold, and the existing
+repeated-squaring `Math_exp` overflows near `709.43613930310403` while native
+`Math.expm1` remains finite until roughly `709.782712893384`. Exact IR/direct
+parity covers both sides of the Taylor branch and that overflow band. Improving
+the shared numerical algorithm remains separate from this ownership-only PR.
+
 ## Risk and rollback
 
 The principal risks are cancellation near zero and behavior at the strict

--- a/plan/issues/5114-ir-exact-ambient-math-expm1.md
+++ b/plan/issues/5114-ir-exact-ambient-math-expm1.md
@@ -1,7 +1,7 @@
 ---
 id: 5114
 title: "IR: own exact ambient Math.expm1 calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -95,6 +95,31 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
 - The narrow rollback and all excluded shapes decline before claim without
   invariants or post-claim errors.
 - Affected regressions, TypeScript 7, and all pre-push gates pass.
+
+## Implementation outcome and validation
+
+- `math.expm1` is now the twenty-third closed source-level Math intrinsic. It
+  reuses the generic exact-ambient selector, call-graph walker, from-AST
+  intrinsic emitter, and provider materializer.
+- The frozen manifest attaches the existing host-free `Math_expm1` callable,
+  closes it over exactly one shared `math.exp` dependency, and requests no
+  host capability. No Math algorithm or direct-codegen file changed.
+- `JS2WASM_IR_MATH_EXPM1=0` withdraws only this claim. Shadowed, aliased,
+  computed, optional-invocation, optional-receiver, wrong-arity, spread, and
+  non-number forms all decline before claim without invariants or post-claim
+  errors.
+- Six focused/affected and legacy suites pass 78/78. They cover host and
+  zero-import standalone execution, exact provider closure, direct-path bit
+  parity across adjacent Taylor-boundary values, IEEE specials, extreme
+  magnitudes, and the inherited overflow band, plus explicit native-Math
+  envelopes, rollback, exhaustive manifest/integration contracts, and linear
+  legality.
+- TypeScript 7, Prettier, Biome lint, the IR kind-neutrality gate, LOC/function
+  budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue
+  integrity pass. Luna Max final review independently reran the focused and
+  affected evidence and returned GO with no P0/P1 finding.
+- PR #5121 is open non-draft and conflict-free, stacked on #5118's exact
+  `Math.cbrt` ownership branch.
 
 ## Non-goals
 

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 22 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 23 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,8 +353,8 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 22 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:30"],
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 23 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:31"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -22,6 +22,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.cos",
   "math.cosh",
   "math.exp",
+  "math.expm1",
   "math.floor",
   "math.log",
   "math.log10",
@@ -39,7 +40,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the twenty-two intrinsic entry points.
+ * Provider requirements reachable from the twenty-three intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -53,6 +54,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.cos",
   "math.cosh",
   "math.exp",
+  "math.expm1",
   "math.floor",
   "math.log",
   "math.log10",
@@ -153,6 +155,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.cos": definition("math.cos", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cosh": definition("math.cosh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.exp": definition("math.exp", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.expm1": definition("math.expm1", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.floor": definition("math.floor", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log": definition("math.log", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log10": definition("math.log10", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -59,6 +59,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.cos",
   "selfhost.math.cosh",
   "selfhost.math.exp",
+  "selfhost.math.expm1",
   "selfhost.math.log",
   "selfhost.math.log10",
   "selfhost.math.log1p",
@@ -186,6 +187,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.cos": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cosh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.exp": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.expm1": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.floor": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log10": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -276,6 +278,13 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     kind: "self-hosted",
     symbol: "Math_exp",
   }),
+  "math.expm1": provider(
+    "selfhost.math.expm1",
+    "math.expm1",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_expm1" },
+    ["math.exp"],
+  ),
   "math.floor": provider("backend.f64.floor", "math.floor", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "backend-op",
     opcode: "f64.floor",
@@ -351,7 +360,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
   }),
 });
 
-/** Canonically ordered default provider catalogue for the twenty-two-method slice. */
+/** Canonically ordered default provider catalogue for the twenty-three-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -304,6 +304,7 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   cosh: { arity: 1, intrinsic: "math.cosh" },
   tanh: { arity: 1, intrinsic: "math.tanh" },
   exp: { arity: 1, intrinsic: "math.exp" },
+  expm1: { arity: 1, intrinsic: "math.expm1" },
   log: { arity: 1, intrinsic: "math.log" },
   log10: { arity: 1, intrinsic: "math.log10" },
   log1p: { arity: 1, intrinsic: "math.log1p" },
@@ -6495,6 +6496,7 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.cosh" && process.env.JS2WASM_IR_MATH_COSH === "0") return false;
   if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
   if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
+  if (plan.intrinsic === "math.expm1" && process.env.JS2WASM_IR_MATH_EXPM1 === "0") return false;
   return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
 }
 

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -71,7 +71,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
           + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
           + Math.cbrt(x)
-          + Math.exp(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
+          + Math.exp(x) + Math.expm1(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
     `);
@@ -133,6 +133,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function tanh(): number { return Math.tanh(0.75); }
       export function cbrt(): number { return Math.cbrt(27); }
       export function exp(): number { return Math.exp(1.25); }
+      export function expm1(): number { return Math.expm1(1.25); }
       export function log(): number { return Math.log(3.5); }
       export function log10(): number { return Math.log10(1000); }
       export function log1p(): number { return Math.log1p(3.5); }
@@ -181,6 +182,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       "tanh",
       "cbrt",
       "exp",
+      "expm1",
       "log",
       "log10",
       "log1p",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,12 +88,12 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact twenty-two certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact twenty-three certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(22);
+    expect(intrinsicMethods).toHaveLength(23);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
@@ -103,6 +103,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         "math.atan",
         "math.cbrt",
         "math.cosh",
+        "math.expm1",
         "math.log10",
         "math.log1p",
         "math.reduce-trig",
@@ -133,7 +134,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(22);
+    expect(first.intrinsicUses).toHaveLength(23);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -151,6 +152,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.sinh"]).toEqual(["math.exp"]);
     expect(dependencies["math.tanh"]).toEqual(["math.exp"]);
     expect(dependencies["math.cbrt"]).toEqual([]);
+    expect(dependencies["math.expm1"]).toEqual(["math.exp"]);
     expect(dependencies["math.sin"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.tan"]).toEqual(["math.cos", "math.sin"]);
@@ -176,6 +178,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
           "math.cosh",
           "math.tanh",
           "math.cbrt",
+          "math.expm1",
           "math.pow",
           "math.atan2",
         ]);
@@ -195,6 +198,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       "math.cos",
       "math.cosh",
       "math.exp",
+      "math.expm1",
       "math.log",
       "math.log10",
       "math.log1p",

--- a/tests/issue-5114-ir-math-expm1.test.ts
+++ b/tests/issue-5114-ir-math-expm1.test.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5114-ir-math-expm1");
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+const exclusionCases = [
+  [
+    "shadowed Math",
+    `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5114 shadowed Math is intentionally not ambient.
+      return Math.expm1(x);
+    }`,
+  ],
+  ["aliased expm1", `const minusOne = Math.expm1; export function f(x: number): number { return minusOne(x); }`],
+  ["computed expm1", `export function f(x: number): number { return Math["expm1"](x); }`],
+  ["optional invocation", `export function f(x: number): number { return Math.expm1?.(x); }`],
+  ["optional receiver", `export function f(x: number): number { return Math?.expm1(x); }`],
+  [
+    "wrong arity",
+    `export function f(x: number): number {
+      // @ts-expect-error #5114 intentionally exercises extra arity.
+      return Math.expm1(x, x);
+    }`,
+  ],
+  ["spread argument", `export function f(x: number): number { return Math.expm1(...([x] as [number])); }`],
+  [
+    "non-number argument",
+    `export function f(): number {
+      const text: string = "1";
+      return Math.expm1(text as never);
+    }`,
+  ],
+] as const;
+
+describe("#5114 exact ambient Math.expm1 IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims and executes the exact one-number call on the %s target", async (_label, target) => {
+    const result = await compile(`export function expm1(value: number): number { return Math.expm1(value); }`, {
+      fileName: `issue-5114-${_label}.ts`,
+      ...(target === undefined ? {} : { target }),
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "expm1")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irCompiledFuncs ?? []).toContain("expm1");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.wat).toContain("$Math_expm1");
+    expect(result.wat).toContain("$Math_exp");
+
+    const expm1 = (await instantiate(result)).expm1 as (value: number) => number;
+    expect(Object.is(expm1(-0), -0)).toBe(true);
+    expect(expm1(0)).toBe(0);
+    expect(expm1(Number.NEGATIVE_INFINITY)).toBe(-1);
+    expect(expm1(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(Math.abs(expm1(1e-7) - Math.expm1(1e-7))).toBeLessThanOrEqual(1e-22);
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches Math_expm1 and its sole deduplicated Math_exp dependency", () => {
+    const analysis = analyzeSource(`export function expm1(value: number): number { return Math.expm1(value); }`);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing expm1 declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("expm1").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id)).toEqual(["math.expm1"]);
+    expect(semantic[0]?.provider).toBeUndefined();
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id)).toEqual(["math.expm1"]);
+    expect(prepared.manifest.features).toEqual(["math.exp", "math.expm1"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    expect(prepared.manifest.providers).toEqual([
+      expect.objectContaining({
+        id: "selfhost.math.exp",
+        feature: "math.exp",
+        dependencies: [],
+        implementation: { kind: "self-hosted", symbol: "Math_exp" },
+      }),
+      expect.objectContaining({
+        id: "selfhost.math.expm1",
+        feature: "math.expm1",
+        dependencies: ["math.exp"],
+        implementation: { kind: "self-hosted", symbol: "Math_expm1" },
+      }),
+    ]);
+    expect(intrinsicInstructions(prepared.functions[0]!)[0]?.provider).toMatchObject({
+      kind: "callable",
+      target: { name: "Math_expm1", binding: { kind: "intrinsic", symbol: "math.expm1" } },
+    });
+  });
+
+  it("is bit-identical to the direct path across the Taylor boundary and IEEE specials", async () => {
+    const source = `export function expm1(value: number): number { return Math.expm1(value); }`;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5114-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5114-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+    expect(outcomeFor(ir, "expm1")).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+
+    const irExpm1 = (await instantiate(ir)).expm1 as (value: number) => number;
+    const directExpm1 = (await instantiate(direct)).expm1 as (value: number) => number;
+    for (const value of [
+      Number.NaN,
+      Number.NEGATIVE_INFINITY,
+      -20,
+      -2.5,
+      -1,
+      -1e-5,
+      -9.999999999e-6,
+      -1e-7,
+      -Number.MIN_VALUE,
+      -0,
+      0,
+      Number.MIN_VALUE,
+      1e-7,
+      9.999999999e-6,
+      1e-5,
+      0.1,
+      1,
+      2.5,
+      20,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      expect(Object.is(irExpm1(value), directExpm1(value)), `expm1 parity for ${String(value)}`).toBe(true);
+    }
+  });
+
+  it("pins Taylor and general-branch native-Math accuracy on an IR-only body", async () => {
+    const result = await compile(`export function expm1(value: number): number { return Math.expm1(value); }`, {
+      fileName: "issue-5114-native-oracle.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(outcomeFor(result, "expm1")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    const expm1 = (await instantiate(result)).expm1 as (value: number) => number;
+
+    for (const value of [-9.999999999e-6, -1e-7, -Number.MIN_VALUE, Number.MIN_VALUE, 1e-7, 9.999999999e-6]) {
+      expect(Math.abs(expm1(value) - Math.expm1(value)), `Taylor absolute error for ${value}`).toBeLessThanOrEqual(
+        1e-20,
+      );
+    }
+    for (const value of [-20, -2.5, -1, -1e-5, 1e-5, 0.1, 1, 2.5, 20]) {
+      const actual = expm1(value);
+      const expected = Math.expm1(value);
+      const relativeError = Math.abs(actual - expected) / Math.max(Math.abs(expected), Number.MIN_VALUE);
+      expect(relativeError, `general relative error for ${value}`).toBeLessThanOrEqual(2e-8);
+    }
+  });
+
+  it("withdraws only expm1 through its narrow rollback", async () => {
+    const flag = "JS2WASM_IR_MATH_EXPM1";
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(`export function expm1(value: number): number { return Math.expm1(value); }`, {
+        fileName: "issue-5114-rollback.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      expectSuccess(result);
+      expect(outcomeFor(result, "expm1")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5114-${_label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});

--- a/tests/issue-5114-ir-math-expm1.test.ts
+++ b/tests/issue-5114-ir-math-expm1.test.ts
@@ -13,6 +13,35 @@ import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js"
 
 const identities = createTestIrFunctionIdentityFactory("issue-5114-ir-math-expm1");
 
+function adjacent(value: number, direction: 1n | -1n): number {
+  if (Number.isNaN(value) || value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY) return value;
+  if (value === 0) return direction === 1n ? Number.MIN_VALUE : -Number.MIN_VALUE;
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value);
+  const step = value > 0 ? direction : -direction;
+  view.setBigUint64(0, view.getBigUint64(0) + step);
+  return view.getFloat64(0);
+}
+
+function nextUp(value: number): number {
+  return adjacent(value, 1n);
+}
+
+function nextDown(value: number): number {
+  return adjacent(value, -1n);
+}
+
+function ulpDistance(left: number, right: number): bigint {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, left);
+  const leftBits = view.getBigUint64(0);
+  view.setFloat64(0, right);
+  const rightBits = view.getBigUint64(0);
+  return leftBits >= rightBits ? leftBits - rightBits : rightBits - leftBits;
+}
+
 function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
   const instructions: IrInstrIntrinsic[] = [];
   for (const block of fn.blocks) {
@@ -166,26 +195,39 @@ describe("#5114 exact ambient Math.expm1 IR ownership", () => {
 
     const irExpm1 = (await instantiate(ir)).expm1 as (value: number) => number;
     const directExpm1 = (await instantiate(direct)).expm1 as (value: number) => number;
+    const threshold = 1e-5;
     for (const value of [
       Number.NaN,
       Number.NEGATIVE_INFINITY,
+      -Number.MAX_VALUE,
+      -709.7,
       -20,
       -2.5,
       -1,
-      -1e-5,
-      -9.999999999e-6,
+      -0.1,
+      -nextUp(threshold),
+      -threshold,
+      -nextDown(threshold),
       -1e-7,
       -Number.MIN_VALUE,
       -0,
       0,
       Number.MIN_VALUE,
       1e-7,
-      9.999999999e-6,
-      1e-5,
+      nextDown(threshold),
+      threshold,
+      nextUp(threshold),
       0.1,
       1,
       2.5,
       20,
+      709,
+      709.43613930310391,
+      709.43613930310403,
+      709.7,
+      709.78271289338397,
+      709.8,
+      Number.MAX_VALUE,
       Number.POSITIVE_INFINITY,
     ]) {
       expect(Object.is(irExpm1(value), directExpm1(value)), `expm1 parity for ${String(value)}`).toBe(true);
@@ -207,16 +249,35 @@ describe("#5114 exact ambient Math.expm1 IR ownership", () => {
     });
     const expm1 = (await instantiate(result)).expm1 as (value: number) => number;
 
-    for (const value of [-9.999999999e-6, -1e-7, -Number.MIN_VALUE, Number.MIN_VALUE, 1e-7, 9.999999999e-6]) {
-      expect(Math.abs(expm1(value) - Math.expm1(value)), `Taylor absolute error for ${value}`).toBeLessThanOrEqual(
-        1e-20,
-      );
-    }
-    for (const value of [-20, -2.5, -1, -1e-5, 1e-5, 0.1, 1, 2.5, 20]) {
+    const threshold = 1e-5;
+    for (const value of [-nextDown(threshold), -1e-7, -Number.MIN_VALUE, Number.MIN_VALUE, 1e-7, nextDown(threshold)]) {
       const actual = expm1(value);
       const expected = Math.expm1(value);
-      const relativeError = Math.abs(actual - expected) / Math.max(Math.abs(expected), Number.MIN_VALUE);
-      expect(relativeError, `general relative error for ${value}`).toBeLessThanOrEqual(2e-8);
+      const absoluteError = Math.abs(actual - expected);
+      const relativeError = absoluteError / Math.max(Math.abs(expected), Number.MIN_VALUE);
+      expect(absoluteError, `Taylor absolute error for ${value}`).toBeLessThanOrEqual(3e-21);
+      expect(relativeError, `Taylor relative error for ${value}`).toBeLessThanOrEqual(3e-16);
+      expect(ulpDistance(actual, expected), `Taylor ULP distance for ${value}`).toBeLessThanOrEqual(2n);
+    }
+
+    for (const value of [-nextUp(threshold), -threshold, threshold, nextUp(threshold)]) {
+      const actual = expm1(value);
+      const expected = Math.expm1(value);
+      const absoluteError = Math.abs(actual - expected);
+      const relativeError = absoluteError / Math.max(Math.abs(expected), Number.MIN_VALUE);
+      expect(absoluteError, `threshold absolute error for ${value}`).toBeLessThanOrEqual(2e-16);
+      expect(relativeError, `threshold relative error for ${value}`).toBeLessThanOrEqual(2e-11);
+      expect(ulpDistance(actual, expected), `threshold ULP distance for ${value}`).toBeLessThanOrEqual(100_000n);
+    }
+
+    for (const value of [-709, -20, -2.5, -1, -0.1, 0.1, 0.346574, 1, 2.5, 20, 709]) {
+      const actual = expm1(value);
+      const expected = Math.expm1(value);
+      const absoluteError = Math.abs(actual - expected);
+      const scale = Math.max(Math.abs(expected), Number.MIN_VALUE);
+      expect(absoluteError / scale, `general relative error for ${value}`).toBeLessThanOrEqual(3e-8);
+      expect(absoluteError, `general scaled absolute error for ${value}`).toBeLessThanOrEqual(3e-8 * scale);
+      expect(ulpDistance(actual, expected), `general ULP distance for ${value}`).toBeLessThanOrEqual(200_000_000n);
     }
   });
 


### PR DESCRIPTION
## Summary

- represent exact ambient Math.expm1(number) calls as the 23rd closed IR Math intrinsic
- attach the existing host-free Math_expm1 provider through its sole deduplicated Math_exp dependency
- preserve direct-codegen bit identity across the strict Taylor boundary, IEEE specials, and inherited overflow band
- retain all coercive or dynamic shapes on the legacy path and add a method-specific rollback flag

## Numerical disposition

This ownership-only checkpoint preserves the shared approximation. Focused evidence separates strict-Taylor, threshold-fallback, and broad safe-range native envelopes and documents inherited cancellation near 1e-5 plus premature Math_exp overflow.

## Validation

- 78/78 focused, IR-contract, and legacy Math tests passed
- 14/14 expanded Math.expm1 ownership tests passed after the numerical audit
- typecheck, lint, formatting, ratchets, numeric-local parity, and issue-integrity pre-push gates passed

## Stack

- stacked on #5118 (Math.cbrt IR ownership)