### PR TITLE
feat(ir): own exact ambient inverse-hyperbolic calls

### DIFF
--- a/plan/issues/5115-ir-exact-ambient-math-inverse-hyperbolic.md
+++ b/plan/issues/5115-ir-exact-ambient-math-inverse-hyperbolic.md
@@ -1,0 +1,122 @@
+---
+id: 5115
+title: "IR: own exact ambient Math.asinh/Math.acosh/Math.atanh calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5115-ir-math-inverse-hyperbolic
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5114]
+related: [1371, 3141, 3204, 3526, 4787, 5092, 5094, 5101, 5103, 5105, 5106, 5110, 5111]
+files:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5115-ir-math-inverse-hyperbolic.test.ts
+loc-budget-allow:
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5115 — Exact ambient inverse-hyperbolic Math IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.asinh(numberExpression)`, `Math.acosh(numberExpression)`, and
+`Math.atanh(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent all three source calls as versioned semantic intrinsics
+and reuse their existing host-free helpers plus one deduplicated `Math_log`
+dependency.
+
+This checkpoint is intentionally stacked on #5121/#5114. It changes ownership
+only; the established formulas, approximation behavior, and direct-codegen
+fallback remain untouched.
+
+## Measured residual
+
+The three methods are absent from `IR_MATH_METHOD_TABLE`, so the selector
+declines and the legacy builtin path emits `Math_asinh`, `Math_acosh`, or
+`Math_atanh`. Their self-hosted runtime bodies already exist in
+`src/stdlib/math.ts`, each declares `Math_log` as its sole sibling callee, and
+direct codegen already closes all three over that helper. The missing contract
+is the closed semantic intrinsic/provider entry for each source method.
+
+## Exact admitted grammar
+
+Admit only a non-optional `Math.<method>(argument)` when `Math` is the
+unshadowed ambient binding, `<method>` is `asinh`, `acosh`, or `atanh`, there is
+exactly one non-spread argument, the selector proves primitive `number`,
+symbolic Math helpers are available, and the containing unit passes ordinary
+ownership/call-graph gates. Aliased, computed, optional, shadowed, coercive,
+spread, and wrong-arity forms remain direct.
+
+## Implementation plan
+
+1. Add `math.asinh`, `math.acosh`, and `math.atanh` to the closed
+   intrinsic/runtime-feature vocabularies with unary-f64 signatures.
+2. Add `selfhost.math.asinh -> Math_asinh`, `selfhost.math.acosh ->
+   Math_acosh`, and `selfhost.math.atanh -> Math_atanh`, each with `math.log`
+   as its sole dependency.
+3. Add all three methods to `IR_MATH_METHOD_TABLE` and reuse the generic
+   selector, call-graph walker, from-AST emitter, manifest, and provider
+   materializer.
+4. Add independent `JS2WASM_IR_MATH_ASINH=0`,
+   `JS2WASM_IR_MATH_ACOSH=0`, and `JS2WASM_IR_MATH_ATANH=0` rollbacks.
+5. Widen #3526 exhaustive vocabulary, dependency, integration,
+   linear-legality, and neutrality evidence from twenty-three to twenty-six
+   source Math intrinsics.
+6. Add focused host/standalone ownership, exact shared-provider closure,
+   bit-exact direct parity, method-specific native-oracle, rollback, and
+   pre-claim exclusion tests across domains, signed zero, tiny values, finite
+   interiors, range edges, NaN, and infinities.
+7. Re-run existing inverse-hyperbolic/self-hosted Math regressions, affected
+   #3526 suites, TypeScript 7, formatting/lint/ratchets, and full pre-push
+   checks; then open a non-draft PR stacked on #5121.
+
+## Acceptance criteria
+
+- Exact ambient one-number calls for all three methods emit IR only and attach
+  their existing self-hosted callables.
+- The manifest closes all three features over exactly one deduplicated
+  `math.log` provider and requests no host capability.
+- Host and zero-import standalone execution are bit-identical to the direct
+  path across domain boundaries, signed zero, tiny values, finite interiors,
+  inherited range edges, NaN, and infinities.
+- Native-Math checks pin explicit method-specific safe-range envelopes while
+  separately proving every oracle ran on an IR-only body.
+- Each narrow rollback withdraws only its corresponding method, and excluded
+  shapes decline before claim without invariants or post-claim errors.
+- Affected regressions, TypeScript 7, and all pre-push gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, computed/extracted calls, optional
+  chaining, `.call`, or `.apply`.
+- New inverse-hyperbolic approximations, host imports, or direct-codegen
+  behavior changes.
+- Async, class, module-init, or broader non-Math ownership expansion.
+
+## Risk and rollback
+
+The principal risks are inherited cancellation near zero, domain endpoints,
+and multiplication overflow in the existing `x * x` formulas for large finite
+inputs. Direct-path bit identity remains the hard migration invariant; native
+Math evidence will use separately measured safe ranges rather than disguise
+known approximation limits. Independent environment flags provide narrow
+rollback; `JS2WASM_IR_FIRST=0` remains the global control.

--- a/plan/issues/5115-ir-exact-ambient-math-inverse-hyperbolic.md
+++ b/plan/issues/5115-ir-exact-ambient-math-inverse-hyperbolic.md
@@ -1,7 +1,7 @@
 ---
 id: 5115
 title: "IR: own exact ambient Math.asinh/Math.acosh/Math.atanh calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -103,6 +103,34 @@ spread, and wrong-arity forms remain direct.
 - Each narrow rollback withdraws only its corresponding method, and excluded
   shapes decline before claim without invariants or post-claim errors.
 - Affected regressions, TypeScript 7, and all pre-push gates pass.
+
+## Implementation outcome and validation
+
+- `math.asinh`, `math.acosh`, and `math.atanh` are now the twenty-fourth
+  through twenty-sixth closed source-level Math intrinsics. They reuse the
+  generic exact-ambient selector, call-graph walker, from-AST intrinsic
+  emitter, and provider materializer.
+- The frozen manifest attaches the existing host-free `Math_asinh`,
+  `Math_acosh`, and `Math_atanh` callables, closes each over `math.log`,
+  materializes that dependency once, and requests no host capability. No Math
+  algorithm or direct-codegen file changed.
+- Independent `JS2WASM_IR_MATH_ASINH=0`, `JS2WASM_IR_MATH_ACOSH=0`, and
+  `JS2WASM_IR_MATH_ATANH=0` controls withdraw only their corresponding claim.
+  Shadowed, aliased, computed, optional-invocation, optional-receiver,
+  wrong-arity, spread, and non-number forms all decline before claim.
+- Four focused/affected contract suites pass 45/45. They cover host and
+  zero-import standalone execution, exact dependency-first provider closure,
+  direct-path bit parity across domains, adjacent endpoints, signed zero,
+  subnormals, infinities, and the inherited square-overflow boundary,
+  method-specific native envelopes, independent rollbacks, every
+  target/backend manifest policy, and explicit production linear deferral.
+- Existing inverse-hyperbolic/self-hosted Math regressions pass 51/51 across
+  #3141 and `math-inline`.
+- TypeScript 7, Prettier, Biome lint, the IR kind-neutrality gate, LOC/function
+  budgets, oracle/coercion ratchets, numeric-local parity (18/18), and issue
+  integrity pass. Luna Max final review returned GO with no P0/P1 finding.
+- PR #5123 is open non-draft, conflict-free, and green, stacked on #5121's
+  exact `Math.expm1` ownership branch.
 
 ## Non-goals
 

--- a/plan/issues/5115-ir-exact-ambient-math-inverse-hyperbolic.md
+++ b/plan/issues/5115-ir-exact-ambient-math-inverse-hyperbolic.md
@@ -112,6 +112,28 @@ spread, and wrong-arity forms remain direct.
   behavior changes.
 - Async, class, module-init, or broader non-Math ownership expansion.
 
+## Measured numerical disposition
+
+The existing direct and self-hosted paths share the same formulas and
+`Math_log` approximation. This ownership checkpoint preserves them exactly. A
+Luna Max audit measured distinct safe-range envelopes, now pinned by the
+focused IR-only oracle:
+
+- `asinh` on moderate `|x| >= 1e-3`: at most `2e-12` relative error, with a
+  `2e-16` absolute envelope for tiny values;
+- `acosh` away from one: at most `2e-12` relative error, with a measured
+  `5e-13` absolute envelope immediately above one;
+- `atanh` in the regular interior: at most `2e-8` relative error, with
+  `2e-16` absolute error near zero and `1e-8` near the domain endpoints.
+
+These are regression envelopes, not correct-rounding claims. The existing
+`x * x` formulas overflow above roughly `1.3407807929942596e154`, so `asinh`
+and `acosh` return positive or signed infinity while native Math remains
+finite. `asinh` also maps subnormals to signed zero, and `atanh` maps
+`-Number.MIN_VALUE` to positive zero. Exact IR/direct parity explicitly covers
+these inherited range and cancellation behaviors; improving the shared
+algorithms remains separate from this ownership-only PR.
+
 ## Risk and rollback
 
 The principal risks are inherited cancellation near zero, domain endpoints,

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 23 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 26 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,8 +353,8 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 23 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:31"],
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 26 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:34"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -14,9 +14,12 @@ import { irTypeEquals, type IrInstr, type IrType } from "./nodes.js";
 export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.abs",
   "math.acos",
+  "math.acosh",
   "math.asin",
+  "math.asinh",
   "math.atan",
   "math.atan2",
+  "math.atanh",
   "math.cbrt",
   "math.ceil",
   "math.cos",
@@ -40,15 +43,18 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the twenty-three intrinsic entry points.
+ * Provider requirements reachable from the twenty-six intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.abs",
   "math.acos",
+  "math.acosh",
   "math.asin",
+  "math.asinh",
   "math.atan",
   "math.atan2",
+  "math.atanh",
   "math.cbrt",
   "math.ceil",
   "math.cos",
@@ -147,9 +153,12 @@ function definition(id: IntrinsicId, signature: IntrinsicSignature, feature: Run
 export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefinition>> = Object.freeze({
   "math.abs": definition("math.abs", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.acos": definition("math.acos", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.acosh": definition("math.acosh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.asin": definition("math.asin", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.asinh": definition("math.asinh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.atan": definition("math.atan", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.atan2": definition("math.atan2", F64_BINARY_INTRINSIC_SIGNATURE),
+  "math.atanh": definition("math.atanh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cbrt": definition("math.cbrt", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.ceil": definition("math.ceil", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cos": definition("math.cos", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -52,9 +52,12 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "backend.f64.sqrt",
   "backend.f64.trunc",
   "selfhost.math.acos",
+  "selfhost.math.acosh",
   "selfhost.math.asin",
+  "selfhost.math.asinh",
   "selfhost.math.atan",
   "selfhost.math.atan2",
+  "selfhost.math.atanh",
   "selfhost.math.cbrt",
   "selfhost.math.cos",
   "selfhost.math.cosh",
@@ -179,9 +182,12 @@ const ALL_BACKENDS = Object.freeze<readonly RuntimeBackend[]>(["linear", "wasmgc
 export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature, IntrinsicSignature>>> = Object.freeze({
   "math.abs": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.acos": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.acosh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.asin": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.asinh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.atan": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.atan2": F64_BINARY_INTRINSIC_SIGNATURE,
+  "math.atanh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cbrt": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.ceil": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cos": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -234,12 +240,26 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     { kind: "self-hosted", symbol: "Math_acos" },
     ["math.atan"],
   ),
+  "math.acosh": provider(
+    "selfhost.math.acosh",
+    "math.acosh",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_acosh" },
+    ["math.log"],
+  ),
   "math.asin": provider(
     "selfhost.math.asin",
     "math.asin",
     F64_UNARY_INTRINSIC_SIGNATURE,
     { kind: "self-hosted", symbol: "Math_asin" },
     ["math.atan"],
+  ),
+  "math.asinh": provider(
+    "selfhost.math.asinh",
+    "math.asinh",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_asinh" },
+    ["math.log"],
   ),
   "math.atan": provider("selfhost.math.atan", "math.atan", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "self-hosted",
@@ -251,6 +271,13 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     F64_BINARY_INTRINSIC_SIGNATURE,
     { kind: "self-hosted", symbol: "Math_atan2" },
     ["math.atan"],
+  ),
+  "math.atanh": provider(
+    "selfhost.math.atanh",
+    "math.atanh",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_atanh" },
+    ["math.log"],
   ),
   "math.cbrt": provider("selfhost.math.cbrt", "math.cbrt", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "self-hosted",
@@ -360,7 +387,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
   }),
 });
 
-/** Canonically ordered default provider catalogue for the twenty-three-method slice. */
+/** Canonically ordered default provider catalogue for the twenty-six-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -295,7 +295,10 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   trunc: { arity: 1, intrinsic: "math.trunc", op: "f64.trunc" },
   asin: { arity: 1, intrinsic: "math.asin" },
   acos: { arity: 1, intrinsic: "math.acos" },
+  asinh: { arity: 1, intrinsic: "math.asinh" },
+  acosh: { arity: 1, intrinsic: "math.acosh" },
   atan: { arity: 1, intrinsic: "math.atan" },
+  atanh: { arity: 1, intrinsic: "math.atanh" },
   cbrt: { arity: 1, intrinsic: "math.cbrt" },
   sin: { arity: 1, intrinsic: "math.sin" },
   cos: { arity: 1, intrinsic: "math.cos" },
@@ -6497,6 +6500,9 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
   if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
   if (plan.intrinsic === "math.expm1" && process.env.JS2WASM_IR_MATH_EXPM1 === "0") return false;
+  if (plan.intrinsic === "math.asinh" && process.env.JS2WASM_IR_MATH_ASINH === "0") return false;
+  if (plan.intrinsic === "math.acosh" && process.env.JS2WASM_IR_MATH_ACOSH === "0") return false;
+  if (plan.intrinsic === "math.atanh" && process.env.JS2WASM_IR_MATH_ATANH === "0") return false;
   return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
 }
 

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -69,6 +69,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function allMath(x: number, y: number): number {
         return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.trunc(x)
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
+          + Math.asinh(x) + Math.acosh(x) + Math.atanh(x)
           + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
           + Math.cbrt(x)
           + Math.exp(x) + Math.expm1(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
@@ -125,6 +126,9 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function asin(): number { return Math.asin(0.5); }
       export function acos(): number { return Math.acos(0.5); }
       export function atan(): number { return Math.atan(1); }
+      export function asinh(): number { return Math.asinh(1); }
+      export function acosh(): number { return Math.acosh(2); }
+      export function atanh(): number { return Math.atanh(0.5); }
       export function sin(): number { return Math.sin(0.75); }
       export function cos(): number { return Math.cos(0.75); }
       export function tan(): number { return Math.tan(0.75); }
@@ -174,6 +178,9 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       "asin",
       "acos",
       "atan",
+      "asinh",
+      "acosh",
+      "atanh",
       "sin",
       "cos",
       "tan",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,19 +88,22 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact twenty-three certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact twenty-six certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(23);
+    expect(intrinsicMethods).toHaveLength(26);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
       expect.arrayContaining([
         "math.acos",
+        "math.acosh",
         "math.asin",
+        "math.asinh",
         "math.atan",
+        "math.atanh",
         "math.cbrt",
         "math.cosh",
         "math.expm1",
@@ -134,7 +137,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(23);
+    expect(first.intrinsicUses).toHaveLength(26);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -153,6 +156,9 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.tanh"]).toEqual(["math.exp"]);
     expect(dependencies["math.cbrt"]).toEqual([]);
     expect(dependencies["math.expm1"]).toEqual(["math.exp"]);
+    expect(dependencies["math.asinh"]).toEqual(["math.log"]);
+    expect(dependencies["math.acosh"]).toEqual(["math.log"]);
+    expect(dependencies["math.atanh"]).toEqual(["math.log"]);
     expect(dependencies["math.sin"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.tan"]).toEqual(["math.cos", "math.sin"]);
@@ -170,6 +176,9 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         addUses(builder, [
           "math.asin",
           "math.acos",
+          "math.asinh",
+          "math.acosh",
+          "math.atanh",
           "math.sin",
           "math.tan",
           "math.log10",
@@ -191,9 +200,12 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(new Set(semanticClosures.map((features) => features.join("|")))).toHaveLength(1);
     expect(semanticClosures[0]).toEqual([
       "math.acos",
+      "math.acosh",
       "math.asin",
+      "math.asinh",
       "math.atan",
       "math.atan2",
+      "math.atanh",
       "math.cbrt",
       "math.cos",
       "math.cosh",

--- a/tests/issue-5115-ir-math-inverse-hyperbolic.test.ts
+++ b/tests/issue-5115-ir-math-inverse-hyperbolic.test.ts
@@ -1,0 +1,423 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5115-ir-math-inverse-hyperbolic");
+const METHODS = ["asinh", "acosh", "atanh"] as const;
+
+function adjacent(value: number, direction: 1n | -1n): number {
+  if (Number.isNaN(value) || value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY) return value;
+  if (value === 0) return direction === 1n ? Number.MIN_VALUE : -Number.MIN_VALUE;
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value);
+  const step = value > 0 ? direction : -direction;
+  view.setBigUint64(0, view.getBigUint64(0) + step);
+  return view.getFloat64(0);
+}
+
+function nextUp(value: number): number {
+  return adjacent(value, 1n);
+}
+
+function nextDown(value: number): number {
+  return adjacent(value, -1n);
+}
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+const exclusionCases = METHODS.flatMap(
+  (method) =>
+    [
+      [
+        `${method} with shadowed Math`,
+        `export function f(x: number): number {
+          const Math: number = x;
+          // @ts-expect-error #5115 shadowed Math is intentionally not ambient.
+          return Math.${method}(x);
+        }`,
+      ],
+      [
+        `aliased ${method}`,
+        `const inverseHyperbolic = Math.${method};
+        export function f(x: number): number { return inverseHyperbolic(x); }`,
+      ],
+      [`computed ${method}`, `export function f(x: number): number { return Math["${method}"](x); }`],
+      [`optional invocation ${method}`, `export function f(x: number): number { return Math.${method}?.(x); }`],
+      [`optional receiver ${method}`, `export function f(x: number): number { return Math?.${method}(x); }`],
+      [
+        `${method} wrong arity`,
+        `export function f(x: number): number {
+          // @ts-expect-error #5115 intentionally exercises extra arity.
+          return Math.${method}(x, x);
+        }`,
+      ],
+      [
+        `${method} spread argument`,
+        `export function f(x: number): number { return Math.${method}(...([x] as [number])); }`,
+      ],
+      [
+        `${method} non-number argument`,
+        `export function f(): number {
+          const text: string = "1";
+          return Math.${method}(text as never);
+        }`,
+      ],
+    ] as const,
+);
+
+describe("#5115 exact ambient inverse-hyperbolic Math IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims and executes all three exact one-number calls on the %s target", async (_label, target) => {
+    const result = await compile(
+      `
+        export function asinh(value: number): number { return Math.asinh(value); }
+        export function acosh(value: number): number { return Math.acosh(value); }
+        export function atanh(value: number): number { return Math.atanh(value); }
+      `,
+      {
+        fileName: `issue-5115-${_label}.ts`,
+        ...(target === undefined ? {} : { target }),
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+      },
+    );
+    expectSuccess(result);
+    for (const method of METHODS) {
+      expect(outcomeFor(result, method)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(result.irCompiledFuncs ?? []).toContain(method);
+      expect(result.wat).toContain(`$Math_${method}`);
+    }
+    expect(result.wat).toContain("$Math_log");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const exports = await instantiate(result);
+    const asinh = exports.asinh as (value: number) => number;
+    const acosh = exports.acosh as (value: number) => number;
+    const atanh = exports.atanh as (value: number) => number;
+    expect(Object.is(asinh(-0), -0)).toBe(true);
+    expect(asinh(Number.NEGATIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY);
+    expect(asinh(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(acosh(1)).toBe(0);
+    expect(Number.isNaN(acosh(nextDown(1)))).toBe(true);
+    expect(acosh(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+    expect(Object.is(atanh(-0), -0)).toBe(true);
+    expect(atanh(-1)).toBe(Number.NEGATIVE_INFINITY);
+    expect(atanh(1)).toBe(Number.POSITIVE_INFINITY);
+    expect(Number.isNaN(atanh(nextUp(1)))).toBe(true);
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches all three providers to one deduplicated Math_log dependency", () => {
+    const analysis = analyzeSource(`
+      export function inverseHyperbolic(value: number): number {
+        return Math.asinh(value) + Math.acosh(value) + Math.atanh(value);
+      }
+    `);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing inverseHyperbolic declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("inverseHyperbolic").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id).sort()).toEqual(["math.acosh", "math.asinh", "math.atanh"]);
+    expect(semantic.every((instr) => instr.provider === undefined)).toBe(true);
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id).sort()).toEqual([
+      "math.acosh",
+      "math.asinh",
+      "math.atanh",
+    ]);
+    expect(prepared.manifest.features).toEqual(["math.acosh", "math.asinh", "math.atanh", "math.log"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    const dependencies = Object.fromEntries(
+      prepared.manifest.providers.map((provider) => [provider.feature, provider.dependencies]),
+    );
+    expect(dependencies).toEqual({
+      "math.acosh": ["math.log"],
+      "math.asinh": ["math.log"],
+      "math.atanh": ["math.log"],
+      "math.log": [],
+    });
+    expect(new Set(prepared.manifest.providers.map((provider) => provider.id))).toEqual(
+      new Set(["selfhost.math.acosh", "selfhost.math.asinh", "selfhost.math.atanh", "selfhost.math.log"]),
+    );
+    expect(prepared.manifest.providerComponents.map((component) => component.features)).toEqual([
+      ["math.log"],
+      ["math.acosh"],
+      ["math.asinh"],
+      ["math.atanh"],
+    ]);
+    for (const instr of intrinsicInstructions(prepared.functions[0]!)) {
+      expect(instr.provider).toMatchObject({
+        kind: "callable",
+        target: { name: `Math_${instr.id.slice(5)}`, binding: { kind: "intrinsic", symbol: instr.id } },
+      });
+    }
+  });
+
+  it("is bit-identical to the direct path across domains, cancellation, and inherited overflow edges", async () => {
+    const source = `
+      export function asinh(value: number): number { return Math.asinh(value); }
+      export function acosh(value: number): number { return Math.acosh(value); }
+      export function atanh(value: number): number { return Math.atanh(value); }
+    `;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5115-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5115-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+    const irExports = await instantiate(ir);
+    const directExports = await instantiate(direct);
+    const squareOverflow = 1.3407807929942596e154;
+    const samples = {
+      asinh: [
+        Number.NaN,
+        Number.NEGATIVE_INFINITY,
+        -Number.MAX_VALUE,
+        -nextUp(squareOverflow),
+        -squareOverflow,
+        -nextDown(squareOverflow),
+        -1e154,
+        -1,
+        -Number.MIN_VALUE,
+        -0,
+        0,
+        Number.MIN_VALUE,
+        1,
+        1e154,
+        nextDown(squareOverflow),
+        squareOverflow,
+        nextUp(squareOverflow),
+        Number.MAX_VALUE,
+        Number.POSITIVE_INFINITY,
+      ],
+      acosh: [
+        Number.NaN,
+        Number.NEGATIVE_INFINITY,
+        -1,
+        0,
+        nextDown(1),
+        1,
+        nextUp(1),
+        2,
+        1e154,
+        nextDown(squareOverflow),
+        squareOverflow,
+        nextUp(squareOverflow),
+        Number.MAX_VALUE,
+        Number.POSITIVE_INFINITY,
+      ],
+      atanh: [
+        Number.NaN,
+        Number.NEGATIVE_INFINITY,
+        -2,
+        -nextUp(1),
+        -1,
+        -nextDown(1),
+        -0.5,
+        -Number.MIN_VALUE,
+        -0,
+        0,
+        Number.MIN_VALUE,
+        0.5,
+        nextDown(1),
+        1,
+        nextUp(1),
+        2,
+        Number.POSITIVE_INFINITY,
+      ],
+    } as const;
+
+    for (const method of METHODS) {
+      expect(outcomeFor(ir, method)).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+      const irFn = irExports[method] as (value: number) => number;
+      const directFn = directExports[method] as (value: number) => number;
+      for (const value of samples[method]) {
+        expect(Object.is(irFn(value), directFn(value)), `${method} parity for ${String(value)}`).toBe(true);
+      }
+    }
+
+    const irAsinh = irExports.asinh as (value: number) => number;
+    const irAcosh = irExports.acosh as (value: number) => number;
+    const irAtanh = irExports.atanh as (value: number) => number;
+    expect(Object.is(irAsinh(Number.MIN_VALUE), 0)).toBe(true);
+    expect(Object.is(irAsinh(-Number.MIN_VALUE), -0)).toBe(true);
+    expect(irAsinh(nextUp(squareOverflow))).toBe(Number.POSITIVE_INFINITY);
+    expect(irAcosh(nextUp(squareOverflow))).toBe(Number.POSITIVE_INFINITY);
+    expect(Object.is(irAtanh(-Number.MIN_VALUE), 0)).toBe(true);
+  });
+
+  it("pins established native-Math safe-range envelopes on IR-only bodies", async () => {
+    const result = await compile(
+      `
+        export function asinh(value: number): number { return Math.asinh(value); }
+        export function acosh(value: number): number { return Math.acosh(value); }
+        export function atanh(value: number): number { return Math.atanh(value); }
+      `,
+      { fileName: "issue-5115-native-oracle.ts", experimentalIR: true, trackIrOutcomes: true },
+    );
+    expectSuccess(result);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    const exports = await instantiate(result);
+    const relativeSamples = {
+      asinh: [-20, -10, -3, -1, -0.5, -0.001, 0.001, 0.5, 1, 3, 10, 20],
+      acosh: [1.001, 1.01, 1.1, 2, 3.5, 10, 20],
+      atanh: [-0.99, -0.9, -0.5, -0.1, 0.1, 0.5, 0.9, 0.99],
+    } as const;
+    const relativeBounds = { asinh: 2e-12, acosh: 2e-12, atanh: 2e-8 } as const;
+
+    for (const method of METHODS) {
+      expect(outcomeFor(result, method)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      const compiled = exports[method] as (value: number) => number;
+      const native = Math[method];
+      for (const value of relativeSamples[method]) {
+        const actual = compiled(value);
+        const expected = native(value);
+        const relativeError = Math.abs(actual - expected) / Math.max(Math.abs(expected), Number.MIN_VALUE);
+        expect(relativeError, `${method} relative error for ${value}`).toBeLessThanOrEqual(relativeBounds[method]);
+      }
+    }
+
+    const asinh = exports.asinh as (value: number) => number;
+    const acosh = exports.acosh as (value: number) => number;
+    const atanh = exports.atanh as (value: number) => number;
+    for (const value of [-1e-12, -Number.MIN_VALUE, Number.MIN_VALUE, 1e-12]) {
+      expect(Math.abs(asinh(value) - Math.asinh(value)), `asinh tiny absolute error for ${value}`).toBeLessThanOrEqual(
+        2e-16,
+      );
+      expect(Math.abs(atanh(value) - Math.atanh(value)), `atanh tiny absolute error for ${value}`).toBeLessThanOrEqual(
+        2e-16,
+      );
+    }
+    for (const value of [nextUp(1), 1 + 1e-12, 1 + 1e-8]) {
+      expect(Math.abs(acosh(value) - Math.acosh(value)), `acosh edge absolute error for ${value}`).toBeLessThanOrEqual(
+        5e-13,
+      );
+    }
+    for (const value of [-nextDown(1), nextDown(1)]) {
+      expect(Math.abs(atanh(value) - Math.atanh(value)), `atanh edge absolute error for ${value}`).toBeLessThanOrEqual(
+        1e-8,
+      );
+    }
+  });
+
+  it.each([
+    ["asinh", "JS2WASM_IR_MATH_ASINH", ["acosh", "atanh"]],
+    ["acosh", "JS2WASM_IR_MATH_ACOSH", ["asinh", "atanh"]],
+    ["atanh", "JS2WASM_IR_MATH_ATANH", ["asinh", "acosh"]],
+  ] as const)("withdraws only %s through its narrow rollback", async (disabled, flag, retained) => {
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(
+        `
+          export function asinh(value: number): number { return Math.asinh(value); }
+          export function acosh(value: number): number { return Math.acosh(value); }
+          export function atanh(value: number): number { return Math.atanh(value); }
+        `,
+        { fileName: `issue-5115-${disabled}-rollback.ts`, experimentalIR: true, trackIrOutcomes: true },
+      );
+      expectSuccess(result);
+      expect(outcomeFor(result, disabled)).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      for (const method of retained) {
+        expect(outcomeFor(result, method)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+      }
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5115-${_label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- represent exact ambient Math.asinh, Math.acosh, and Math.atanh calls as the 24th through 26th closed IR Math intrinsics
- attach the existing host-free helpers through one deduplicated Math.log provider
- preserve direct-codegen bit identity across domains, signed zero, tiny values, and inherited square-overflow edges
- retain dynamic or coercive shapes on the legacy path and add independent method rollback flags

## Numerical disposition

This ownership-only checkpoint preserves the shared formulas and Math.log approximation. Focused evidence records separate safe-range bounds and explicitly pins inherited subnormal cancellation plus asinh/acosh overflow above roughly 1.3407807929942596e154.

## Validation

- 45/45 focused and affected IR contract tests passed
- 51/51 legacy self-hosted Math regressions passed
- typecheck, lint, formatting, ratchets, numeric-local parity, and issue-integrity pre-push gates passed

## Stack

- stacked on #5121 (Math.expm1 IR ownership)