### PR TITLE
fix(es2015): reject DataView Symbol byte offsets ✓

### DIFF
--- a/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
+++ b/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
@@ -1,0 +1,148 @@
+---
+id: 5117
+title: "ES2015 standalone DataView byteOffset Symbol conversion"
+status: in-progress
+sprint: current
+created: 2026-08-28
+updated: 2026-08-28
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: codegen
+es_edition: ES2015
+language_feature: dataview-byteoffset-toindex-symbol
+goal: standalone-mode
+assignee: "ttraenkler/codex/es2015-next-lane-h"
+files:
+  - src/codegen/dataview-native.ts
+  - tests/issue-5117-dataview-byteoffset-symbol.test.ts
+  - plan/issues/5117-es2015-dataview-byteoffset-symbol.md
+---
+
+# Local plan 5117 — ES2015 standalone DataView byteOffset Symbol conversion
+
+## Exact cohort and baseline evidence
+
+The exact 16-row ES2015 cohort is:
+
+```text
+built-ins/DataView/prototype/getFloat32/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/getFloat64/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/getInt16/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/getInt32/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/getInt8/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/getUint16/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/getUint32/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/getUint8/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/setFloat32/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/setFloat64/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/setInt16/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/setInt32/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/setInt8/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/setUint16/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/setUint32/return-abrupt-from-tonumber-byteoffset-symbol.js
+built-ins/DataView/prototype/setUint8/return-abrupt-from-tonumber-byteoffset-symbol.js
+```
+
+All 16 paths map to ES2015 (`editions[2] == "ES2015"`) in
+`website/public/benchmarks/results/test262-file-editions.json`. The supplied
+authoritative snapshots are dated 2026-08-28, oracle version 13, honest lane,
+standard scope, both strictness modes. Every host row is `pass` with
+`reached_test: true`; every standalone row reaches the test but is `fail` with
+`error_category: assertion_fail` and
+`error_signature: Expected a TypeError but got a RangeError`.
+
+| direction | rows | status | reached test | diagnostic |
+| --- | ---: | --- | --- | --- |
+| JS-host | 16 | pass | true | — |
+| standalone | 16 | fail | true | `Expected a TypeError but got a RangeError` |
+
+The authoritative raw rows are read from:
+
+```text
+/private/tmp/js2-baseline-host-current-20260828.jsonl
+/private/tmp/js2-baseline-standalone-current-20260828.jsonl
+```
+
+Before code, the same paths were run through the assembled local harness from
+current `upstream/main` at
+`7dd9f3b5b996a94f254a50ed0cafedd821d8bfa7`. Host was `16/16 pass`; standalone
+was `16/16 fail` with the diagnostic above. The local artifacts are:
+
+```text
+.tmp/issue-5117/baseline-host.jsonl
+  sha256 2e15df276233e0d7ccf00111a420b1d3c0eac7a8d4c2da091f93726683d6f595
+.tmp/issue-5117/baseline-standalone.jsonl
+  sha256 acbab9499e4b1cb3a0fe20b60df9a8cf88fbd33322195ecad4dfca03910efe05
+```
+
+Both local runs observed the required structural controls in both directions:
+`control-must-pass -> pass` and `control-must-fail -> fail`. The local A/B
+diff will compare these local artifacts with post-fix local artifacts only;
+the supplied authoritative snapshots are evidence, not a diff arm.
+
+## Root cause
+
+The direct native path `emitDataViewAccessor` handles every DataView get/set
+member through one shared byteOffset conversion. It currently compiles an
+explicit `args[0]` with an `{ kind: "f64" }` hint before applying the shared
+NaN-to-zero, truncation, and RangeError checks. In standalone code generation,
+a statically known `Symbol` is represented physically as an i32 symbol handle,
+so this path treats the handle as a numeric offset. The operation then reaches
+the bounds check and reports a RangeError instead of the required TypeError
+from `ToNumber(Symbol)`/`ToIndex`.
+
+The same module already uses `ctx.oracle.staticJsTypeOf` plus
+`emitThrowTypeError` for setter values, and `emitToIndexI32` has the required
+static-Symbol guard for typed-array construction. The missing guard is this
+shared direct DataView byteOffset conversion. A correct guard must still
+compile and drop the offset expression first, preserving its side effects,
+then throw before a setter evaluates its value or littleEndian arguments.
+
+## Implementation plan
+
+1. In `emitDataViewAccessor`, gate a static-Symbol byteOffset guard to
+   `noJsHost(ctx)`, evaluate the expression for side effects, drop its physical
+   result, emit the existing in-module TypeError machinery, and leave a typed
+   unreachable f64 sentinel for the shared downstream locals.
+2. Keep the current dynamic ToIndex conversion, NaN/truncation/range checks,
+   native DataView read/write paths, setter value and littleEndian order, and
+   JS-host lowering unchanged.
+3. Add mandatory no-corpus compiler controls that always compile/validate and
+   instantiate standalone modules with zero `env` imports. They will cover
+   static Symbol getter/setter throws, offset-expression side effects, the
+   setter throw-priority over value/littleEndian expressions, and a dynamic
+   numeric offset round trip.
+4. Add the exact host and standalone corpus checks behind a worktree-independent
+   `test262` availability guard, with explicit Vitest timeouts above the
+   120-second per-row runner budget.
+5. Run exact local host/standalone A/B, repeat standalone determinism,
+   structural controls, focused/related tests, no-corpus shape controls,
+   type/lint/format, budgets/ratchets, and the full pre-push gate with at most
+   two workers. Record all results and hashes below.
+
+## Acceptance criteria
+
+- All 16 exact rows pass in standalone and remain pass in JS-host mode.
+- Static Symbol byteOffset conversion throws a catchable TypeError, after
+  evaluating the offset expression and before later setter arguments.
+- Dynamic numeric byteOffsets still read/write correctly, and omitted/default
+  littleEndian behavior remains unchanged.
+- Mandatory no-corpus standalone controls validate, instantiate with an empty
+  import object, and report zero host imports.
+- The local A/B has exactly 16 standalone fail-to-pass flips, zero losses or
+  status churn, and the repeat reports no nondeterminism.
+- The checked-in plan, focused regression, metadata, normal gates, and
+  pre-push checks are clean. No GitHub issue is created or updated.
+
+## Handoff
+
+Implementation is limited to the two owned code/test files plus this plan:
+`src/codegen/dataview-native.ts`,
+`tests/issue-5117-dataview-byteoffset-symbol.test.ts`, and this document.
+The delivery branch is `codex/5117-es2015-dataview-byteoffset-symbol`, based
+directly on the freshly fetched `upstream/main` at the recorded SHA. After
+validation, the clean head and full evidence will be handed to the root agent
+for one upstream PR; no external issue will be created.

--- a/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
+++ b/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
@@ -1,10 +1,11 @@
 ---
 id: 5117
 title: "ES2015 standalone DataView byteOffset Symbol conversion"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-28
 updated: 2026-08-28
+completed: 2026-08-28
 priority: high
 horizon: s
 feasibility: easy
@@ -69,9 +70,13 @@ The authoritative raw rows are read from:
 ```
 
 Before code, the same paths were run through the assembled local harness from
-current `upstream/main` at
+the initial `upstream/main` at
 `7dd9f3b5b996a94f254a50ed0cafedd821d8bfa7`. Host was `16/16 pass`; standalone
-was `16/16 fail` with the diagnostic above. The local artifacts are:
+was `16/16 fail` with the diagnostic above. After the required refresh, the
+delivery branch is rebased onto final `upstream/main`
+`796d8c2cd28648d21de2ada5a0b662e758f7dda3`; the refreshed A/B and focused
+results below are from that final base. The local pre-refresh baseline
+artifacts are:
 
 ```text
 .tmp/issue-5117/baseline-host.jsonl
@@ -82,8 +87,8 @@ was `16/16 fail` with the diagnostic above. The local artifacts are:
 
 Both local runs observed the required structural controls in both directions:
 `control-must-pass -> pass` and `control-must-fail -> fail`. The local A/B
-diff will compare these local artifacts with post-fix local artifacts only;
-the supplied authoritative snapshots are evidence, not a diff arm.
+diff below compares clean final-base artifacts with final post-fix artifacts;
+the supplied authoritative snapshots are independent evidence, not a diff arm.
 
 ## Post-fix local A/B and determinism evidence
 
@@ -93,17 +98,21 @@ modes. The structural controls remained `control-must-pass -> pass` and
 `control-must-fail -> fail` in each run.
 
 ```text
-.tmp/issue-5117/post-host.jsonl
+.tmp/issue-5117/final-baseline-host.jsonl
   sha256 2e15df276233e0d7ccf00111a420b1d3c0eac7a8d4c2da091f93726683d6f595
-.tmp/issue-5117/post-standalone.jsonl
+.tmp/issue-5117/final-baseline-standalone.jsonl
+  sha256 acbab9499e4b1cb3a0fe20b60df9a8cf88fbd33322195ecad4dfca03910efe05
+.tmp/issue-5117/final-post-host.jsonl
+  sha256 2e15df276233e0d7ccf00111a420b1d3c0eac7a8d4c2da091f93726683d6f595
+.tmp/issue-5117/final-post-standalone.jsonl
   sha256 62b12dc40f9aa8f3440bf8bfb98672a6344dc7888fca17b9ac4e3d178bfe397a
-.tmp/issue-5117/post-standalone-repeat.jsonl
+.tmp/issue-5117/final-post-standalone-repeat.jsonl
   sha256 62b12dc40f9aa8f3440bf8bfb98672a6344dc7888fca17b9ac4e3d178bfe397a
 ```
 
-The row-level comparison is `16` standalone fail-to-pass flips, `0` losses,
-`0` status churn, and `0` host losses. The repeated standalone output is
-byte-identical (`16/16` rows; nondeterminism `0`). The focused lane test
+The final-base row-level comparison is `16` standalone fail-to-pass flips,
+`0` losses, `0` status churn, and `0` host losses. The repeated standalone
+output is byte-identical (`16/16` rows; nondeterminism `0`). The focused lane test
 passed all `13` tests (five mandatory no-corpus controls and eight chunked
 host/standalone corpus checks) without an unhandled Vitest worker timeout.
 The related `#2199b` and `#2199` suites passed `19` tests. The optional `#1654`
@@ -176,6 +185,7 @@ Implementation is limited to the two owned code/test files plus this plan:
 `src/codegen/dataview-native.ts`,
 `tests/issue-5117-dataview-byteoffset-symbol.test.ts`, and this document.
 The delivery branch is `codex/5117-es2015-dataview-byteoffset-symbol`, based
-directly on the freshly fetched `upstream/main` at the recorded SHA. After
-validation, the clean head and full evidence will be handed to the root agent
+directly on freshly fetched `upstream/main` at
+`796d8c2cd28648d21de2ada5a0b662e758f7dda3`. After validation, the clean head
+and full evidence will be handed to the root agent
 for one upstream PR; no external issue will be created.

--- a/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
+++ b/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
@@ -15,6 +15,8 @@ es_edition: ES2015
 language_feature: dataview-byteoffset-toindex-symbol
 goal: standalone-mode
 assignee: "ttraenkler/codex/es2015-next-lane-h"
+loc-budget-allow:
+  - src/codegen/dataview-native.ts
 files:
   - src/codegen/dataview-native.ts
   - tests/issue-5117-dataview-byteoffset-symbol.test.ts
@@ -83,6 +85,32 @@ Both local runs observed the required structural controls in both directions:
 diff will compare these local artifacts with post-fix local artifacts only;
 the supplied authoritative snapshots are evidence, not a diff arm.
 
+## Post-fix local A/B and determinism evidence
+
+After the static-Symbol guard and argument-expression controls were added, the
+same assembled harness completed `16/16 pass` in both host and standalone
+modes. The structural controls remained `control-must-pass -> pass` and
+`control-must-fail -> fail` in each run.
+
+```text
+.tmp/issue-5117/post-host.jsonl
+  sha256 2e15df276233e0d7ccf00111a420b1d3c0eac7a8d4c2da091f93726683d6f595
+.tmp/issue-5117/post-standalone.jsonl
+  sha256 62b12dc40f9aa8f3440bf8bfb98672a6344dc7888fca17b9ac4e3d178bfe397a
+.tmp/issue-5117/post-standalone-repeat.jsonl
+  sha256 62b12dc40f9aa8f3440bf8bfb98672a6344dc7888fca17b9ac4e3d178bfe397a
+```
+
+The row-level comparison is `16` standalone fail-to-pass flips, `0` losses,
+`0` status churn, and `0` host losses. The repeated standalone output is
+byte-identical (`16/16` rows; nondeterminism `0`). The focused lane test
+passed all `13` tests (five mandatory no-corpus controls and eight chunked
+host/standalone corpus checks) without an unhandled Vitest worker timeout.
+The related `#2199b` and `#2199` suites passed `19` tests. The optional `#1654`
+WASI suite reproduced three `RuntimeError: illegal cast` failures in its
+existing runtime exercise; its other `21` tests passed, and the failure uses
+numeric/WASI paths outside this static-Symbol change.
+
 ## Root cause
 
 The direct native path `emitDataViewAccessor` handles every DataView get/set
@@ -98,15 +126,19 @@ The same module already uses `ctx.oracle.staticJsTypeOf` plus
 `emitThrowTypeError` for setter values, and `emitToIndexI32` has the required
 static-Symbol guard for typed-array construction. The missing guard is this
 shared direct DataView byteOffset conversion. A correct guard must still
-compile and drop the offset expression first, preserving its side effects,
-then throw before a setter evaluates its value or littleEndian arguments.
+compile and drop every supplied argument expression in source order, preserving
+their side effects, then throw without applying later ToNumber/ToBoolean
+coercions. An abrupt later argument expression must win over the method's
+static-Symbol TypeError, while an object's `valueOf` must remain untouched.
 
 ## Implementation plan
 
 1. In `emitDataViewAccessor`, gate a static-Symbol byteOffset guard to
-   `noJsHost(ctx)`, evaluate the expression for side effects, drop its physical
-   result, emit the existing in-module TypeError machinery, and leave a typed
-   unreachable f64 sentinel for the shared downstream locals.
+   `noJsHost(ctx)`, evaluate and drop every supplied argument expression in
+   source order, emit the existing in-module TypeError machinery, and leave a
+   typed unreachable f64 sentinel for the shared downstream locals. This
+   preserves argument-expression effects and abrupt later arguments but does
+   not invoke later value/littleEndian coercion hooks.
 2. Keep the current dynamic ToIndex conversion, NaN/truncation/range checks,
    native DataView read/write paths, setter value and littleEndian order, and
    JS-host lowering unchanged.
@@ -126,8 +158,9 @@ then throw before a setter evaluates its value or littleEndian arguments.
 ## Acceptance criteria
 
 - All 16 exact rows pass in standalone and remain pass in JS-host mode.
-- Static Symbol byteOffset conversion throws a catchable TypeError, after
-  evaluating the offset expression and before later setter arguments.
+- Static Symbol byteOffset conversion throws a catchable TypeError after
+  evaluating all argument expressions; later coercions are not invoked, and an
+  abrupt later expression wins.
 - Dynamic numeric byteOffsets still read/write correctly, and omitted/default
   littleEndian behavior remains unchanged.
 - Mandatory no-corpus standalone controls validate, instantiate with an empty

--- a/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
+++ b/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
@@ -1,10 +1,11 @@
 ---
 id: 5117
 title: "ES2015 standalone DataView byteOffset Symbol conversion"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-28
 updated: 2026-08-28
+completed: 2026-08-28
 priority: high
 horizon: s
 feasibility: easy
@@ -14,6 +15,7 @@ area: codegen
 es_edition: ES2015
 language_feature: dataview-byteoffset-toindex-symbol
 goal: standalone-mode
+pr: 5124
 assignee: "ttraenkler/codex/es2015-next-lane-h"
 loc-budget-allow:
   - src/codegen/dataview-native.ts
@@ -185,6 +187,13 @@ Implementation is limited to the two owned code/test files plus this plan:
 `tests/issue-5117-dataview-byteoffset-symbol.test.ts`, and this document.
 The delivery branch is `codex/5117-es2015-dataview-byteoffset-symbol`, based
 directly on freshly fetched `upstream/main` at
-`796d8c2cd28648d21de2ada5a0b662e758f7dda3`. After validation, the clean head
-and full evidence will be handed to the root agent
-for one upstream PR; no external issue will be created.
+`796d8c2cd28648d21de2ada5a0b662e758f7dda3`. The implementation and evidence
+checkpoints culminated at `d92e5a0d19e5598c9c9fde981014c10ba98aaca0`
+and were pushed without force after the normal pre-push suite passed. The
+single non-draft upstream delivery PR is
+https://github.com/loopdive/js2/pull/5124 against `loopdive/js2:main`.
+
+Root review independently reran the focused suite at the rebased head (13/13,
+including all 16 exact rows in both lanes), confirmed the exact PR template and
+fork/base routing, and retained CI, review-thread, exact-head, and merge-queue
+shepherding as the remaining handoff. No GitHub issue was created or updated.

--- a/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
+++ b/plan/issues/5117-es2015-dataview-byteoffset-symbol.md
@@ -1,15 +1,14 @@
 ---
 id: 5117
 title: "ES2015 standalone DataView byteOffset Symbol conversion"
-status: done
+status: in-progress
 sprint: current
 created: 2026-08-28
 updated: 2026-08-28
-completed: 2026-08-28
 priority: high
 horizon: s
 feasibility: easy
-reasoning_effort: medium
+reasoning_effort: max
 task_type: bug
 area: codegen
 es_edition: ES2015

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -1500,28 +1500,48 @@ export function emitDataViewAccessor(
   // RangeError BEFORE any access. Capture the f64 request, derive the i32
   // getIndex (the *view-relative* index, before adding base), then guard.
   const reqLocal = allocLocal(fctx, `__dvn_req_${fctx.locals.length}`, { kind: "f64" });
-  if (args.length >= 1) {
-    compileExpr(args[0]!, { kind: "f64" });
-  } else {
-    // ToIndex(undefined) = 0 (§7.1.22 step 1).
-    fctx.body.push({ op: "f64.const", value: 0 });
-  }
-  fctx.body.push({ op: "local.set", index: reqLocal });
-
   // (#3173) §7.1.22 ToIndex: integer = ToIntegerOrInfinity(value) — NaN → +0,
   // truncate toward zero — then RangeError iff integer < 0 or > 2^53-1. The
   // NaN → 0 rewrite runs FIRST (a NaN request reads offset 0; the previous code
   // wrongly threw). The range check runs in the f64 domain so ±Infinity / 2^53
   // requests throw at ToIndex time (BEFORE a setter's ToNumber(value) — the
   // index-check-before-value-conversion ordering), not at the bounds check.
-  fctx.body.push({ op: "local.get", index: reqLocal }); // val-if-true: req
-  fctx.body.push({ op: "f64.const", value: 0 }); // val-if-false: 0
-  fctx.body.push({ op: "local.get", index: reqLocal });
-  fctx.body.push({ op: "local.get", index: reqLocal });
-  fctx.body.push({ op: "f64.eq" }); // req == req (false only for NaN)
-  fctx.body.push({ op: "select" });
-  fctx.body.push({ op: "f64.trunc" }); // toward zero (−0.9 → −0, not negative)
+  // (#5117) Symbols are represented as i32 handles in standalone mode. A
+  // direct f64-hinted compile would therefore treat the handle as an offset,
+  // eventually producing the bounds RangeError instead of ToNumber's
+  // TypeError. Evaluate every supplied argument expression in source order
+  // first (the call's ArgumentListEvaluation happens before ToIndex), then
+  // throw without applying later ToNumber/ToBoolean coercions. Host lowering
+  // deliberately keeps the old path byte-for-byte unchanged.
+  const staticSymbolOffset = args.length >= 1 && noJsHost(ctx) && ctx.oracle.staticJsTypeOf(args[0]!) === "symbol";
+  if (staticSymbolOffset) {
+    for (const arg of args) {
+      const argType = compileExpr(arg);
+      if (argType !== null) fctx.body.push({ op: "drop" });
+    }
+    emitThrowTypeError(ctx, fctx, "Cannot convert a Symbol value to a number");
+    // Unreachable-but-validated value for the shared ToIndex locals below.
+    fctx.body.push({ op: "f64.const", value: 0 });
+  } else {
+    if (args.length >= 1) {
+      compileExpr(args[0]!, { kind: "f64" });
+    } else {
+      // ToIndex(undefined) = 0 (§7.1.22 step 1).
+      fctx.body.push({ op: "f64.const", value: 0 });
+    }
+  }
   fctx.body.push({ op: "local.set", index: reqLocal });
+
+  if (!staticSymbolOffset) {
+    fctx.body.push({ op: "local.get", index: reqLocal }); // val-if-true: req
+    fctx.body.push({ op: "f64.const", value: 0 }); // val-if-false: 0
+    fctx.body.push({ op: "local.get", index: reqLocal });
+    fctx.body.push({ op: "local.get", index: reqLocal });
+    fctx.body.push({ op: "f64.eq" }); // req == req (false only for NaN)
+    fctx.body.push({ op: "select" });
+    fctx.body.push({ op: "f64.trunc" }); // toward zero (−0.9 → −0, not negative)
+    fctx.body.push({ op: "local.set", index: reqLocal });
+  }
 
   const getIdxLocal = allocLocal(fctx, `__dvn_gidx_${fctx.locals.length}`, { kind: "i32" });
   fctx.body.push({ op: "local.get", index: reqLocal });

--- a/tests/issue-5117-dataview-byteoffset-symbol.test.ts
+++ b/tests/issue-5117-dataview-byteoffset-symbol.test.ts
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #5117 — standalone DataView ToIndex must reject a static Symbol byteOffset.
+ *
+ * The corpus rows are optional so compiler-only validation remains runnable in
+ * a worktree without the linked Test262 checkout. The no-corpus controls below
+ * are mandatory and exercise the same direct native accessor path, including
+ * side-effect and setter argument-order behavior.
+ */
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_ROOT = resolve(__dirname, "..", "test262");
+const HAVE_TEST262 = existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+const CORPUS_TIMEOUT = 180_000;
+
+const ROWS = [
+  "built-ins/DataView/prototype/getFloat32/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/getFloat64/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/getInt16/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/getInt32/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/getInt8/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/getUint16/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/getUint32/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/getUint8/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/setFloat32/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/setFloat64/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/setInt16/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/setInt32/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/setInt8/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/setUint16/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/setUint32/return-abrupt-from-tonumber-byteoffset-symbol.js",
+  "built-ins/DataView/prototype/setUint8/return-abrupt-from-tonumber-byteoffset-symbol.js",
+] as const;
+
+const ROW_CHUNKS = [ROWS.slice(0, 4), ROWS.slice(4, 8), ROWS.slice(8, 12), ROWS.slice(12, 16)];
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-5117.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors?.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "standalone module must validate").toBe(true);
+
+  const module = new WebAssembly.Module(result.binary);
+  const imports = WebAssembly.Module.imports(module);
+  expect(
+    imports.map((entry) => `${entry.module}::${entry.name}`),
+    "standalone must be host-free",
+  ).toEqual([]);
+
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { run: () => number }).run();
+}
+
+async function runCorpus(relative: string, target?: "standalone") {
+  return runTest262File(join(TEST262_ROOT, "test", relative), "built-ins/DataView", 120_000, target);
+}
+
+describe("#5117 ES2015 DataView byteOffset Symbol conversion", () => {
+  it("rejects a static Symbol byteOffset with a catchable TypeError without host imports", async () => {
+    await expect(
+      runStandalone(`
+        export function run(): number {
+          const view = new DataView(new ArrayBuffer(4));
+          const offset = Symbol("offset");
+          try {
+            view.getUint8(offset);
+          } catch (error) {
+            return error instanceof TypeError ? 1 : 2;
+          }
+          return 0;
+        }
+      `),
+    ).resolves.toBe(1);
+  });
+
+  it("evaluates every supplied argument expression before the Symbol TypeError", async () => {
+    await expect(
+      runStandalone(`
+        export function run(): number {
+          const view = new DataView(new ArrayBuffer(4));
+          let offsetEvaluated = false;
+          let valueEvaluated = false;
+          let littleEndianEvaluated = false;
+          function offset(): symbol {
+            offsetEvaluated = true;
+            return Symbol("offset");
+          }
+          function value(): number {
+            valueEvaluated = true;
+            return 7;
+          }
+          function littleEndian(): boolean {
+            littleEndianEvaluated = true;
+            return true;
+          }
+          let caughtTypeError = false;
+          try {
+            view.setInt8(offset(), value(), littleEndian());
+          } catch (error) {
+            caughtTypeError = error instanceof TypeError;
+          }
+          return caughtTypeError && offsetEvaluated && valueEvaluated && littleEndianEvaluated ? 1 : 0;
+        }
+      `),
+    ).resolves.toBe(1);
+  });
+
+  it("evaluates setter argument expressions without invoking later coercion hooks", async () => {
+    await expect(
+      runStandalone(`
+        export function run(): number {
+          const view = new DataView(new ArrayBuffer(4));
+          let valueExpressionEvaluated = false;
+          let littleEndianExpressionEvaluated = false;
+          let valueOfCalls = 0;
+          let littleEndianValueOfCalls = 0;
+          const valueObject: any = {
+            valueOf: function(): number {
+              valueOfCalls++;
+              return 7;
+            }
+          };
+          const littleEndianObject: any = {
+            valueOf: function(): number {
+              littleEndianValueOfCalls++;
+              return 1;
+            }
+          };
+          function offset(): symbol {
+            return Symbol("offset");
+          }
+          function value(): any {
+            valueExpressionEvaluated = true;
+            return valueObject;
+          }
+          function littleEndian(): any {
+            littleEndianExpressionEvaluated = true;
+            return littleEndianObject;
+          }
+          let caughtTypeError = false;
+          try {
+            view.setInt8(offset(), value(), littleEndian());
+          } catch (error) {
+            caughtTypeError = error instanceof TypeError;
+          }
+          return caughtTypeError && valueExpressionEvaluated && littleEndianExpressionEvaluated && valueOfCalls === 0 && littleEndianValueOfCalls === 0 ? 1 : 0;
+        }
+      `),
+    ).resolves.toBe(1);
+  });
+
+  it("lets an abrupt later argument expression win over the Symbol TypeError", async () => {
+    await expect(
+      runStandalone(`
+        export function run(): number {
+          const view = new DataView(new ArrayBuffer(4));
+          function offset(): symbol {
+            return Symbol("offset");
+          }
+          function later(): number {
+            throw 42;
+          }
+          try {
+            view.setInt8(offset(), later(), false);
+          } catch (error) {
+            return error === 42 ? 1 : 2;
+          }
+          return 0;
+        }
+      `),
+    ).resolves.toBe(1);
+  });
+
+  it("keeps dynamic numeric byteOffset read/write behavior", async () => {
+    await expect(
+      runStandalone(`
+        export function run(): number {
+          const view = new DataView(new ArrayBuffer(4));
+          const offset = 1;
+          view.setUint8(offset, 42);
+          return view.getUint8(offset) === 42 ? 1 : 0;
+        }
+      `),
+    ).resolves.toBe(1);
+  });
+
+  for (const [chunkIndex, chunk] of ROW_CHUNKS.entries()) {
+    it.skipIf(!HAVE_TEST262)(
+      `passes exact host rows ${chunkIndex + 1}/${ROW_CHUNKS.length}`,
+      { timeout: CORPUS_TIMEOUT },
+      async () => {
+        for (const relative of chunk) {
+          const result = await runCorpus(relative);
+          expect(result.status, `${relative}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
+        }
+      },
+    );
+
+    it.skipIf(!HAVE_TEST262)(
+      `passes exact standalone rows ${chunkIndex + 1}/${ROW_CHUNKS.length}`,
+      { timeout: CORPUS_TIMEOUT },
+      async () => {
+        for (const relative of chunk) {
+          const result = await runCorpus(relative, "standalone");
+          expect(result.status, `${relative}: ${result.reason ?? result.error ?? ""}`).toBe("pass");
+        }
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Description

Standalone native DataView accessors compiled a statically known Symbol byteOffset with an f64 hint, treating the Symbol handle as a numeric offset and producing a RangeError instead of ToIndex's required TypeError. This change adds a standalone-only guard in the shared accessor path.

The guard preserves full ArgumentListEvaluation: every supplied expression runs once in source order, abrupt later expressions win, and later value/littleEndian coercion hooks are not invoked after the invalid byteOffset. Dynamic numeric access and host lowering remain unchanged.

All 16 exact ES2015 rows now pass 16/16 in host mode, 16/16 in standalone mode, and 16/16 on the deterministic standalone repeat, with zero losses. The focused suite passes 13/13, including five mandatory host-free controls; related DataView suites pass 19/19, and the full pre-push gates are green.

Tracking: `plan/issues/5117-es2015-dataview-byteoffset-symbol.md`

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
