### PR TITLE
fix(#5095): Array.prototype.at() with no argument answers element 0

### DIFF
--- a/plan/issues/5095-array-prototype-at-no-argument.md
+++ b/plan/issues/5095-array-prototype-at-no-argument.md
@@ -1,10 +1,17 @@
 ---
 id: 5095
 title: "Array.prototype.at() with NO argument returns the index, not the element (native vec lowering only)"
-status: ready
+status: done
+completed: 2026-08-28
 sprint: current
 created: 2026-08-27
-updated: 2026-08-27
+updated: 2026-08-28
+# +4 lines in src/codegen/array-methods.ts (2026-08-28). The fix itself is a
+# 3-line arm that REPLACES a 4-line hard reject; the growth is the comment that
+# records why the zero-argument form must not be rejected, so the next reader
+# does not restore the reject. Net source delta excluding comments is negative.
+loc-budget-allow:
+  - src/codegen/array-methods.ts
 priority: medium
 horizon: s
 feasibility: easy
@@ -103,3 +110,123 @@ Identical, so #5101 neither caused nor masks it.
 only "does not throw", with a comment pointing here — it refuses to pin the
 wrong value as a fixture. When this lands, that case can be tightened to
 `toBe(10)`.
+
+## Resolution (2026-08-28)
+
+### Root cause
+
+`compileArrayAt` (`src/codegen/array-methods.ts`) opened with a hard reject:
+
+```ts
+if (callExpr.arguments.length < 1) {
+  reportError(ctx, callExpr, "at() requires 1 argument");
+  return null;
+}
+```
+
+`index` is an ordinary parameter, so `arr.at()` is legal JS and is exactly
+`arr.at(0)` (`ToIntegerOrInfinity(undefined)` = `+0`). The reject returned
+`null`, whose diagnostic the caller **swallows** — `compile()` reports
+`success: true` with an EMPTY `errors` array — and the call collapses into the
+caller's degraded fallback, which evaluates to the relative index rather than
+the element.
+
+Fix: replace the reject with an `i32.const 0` index arm, exactly the shape
+`Array.prototype.includes` already uses for its absent `searchElement`
+(`emitIncludesSearchValue`, #2872).
+
+**The filer's diagnosis of the mechanism was right, its blast radius was not** —
+see the TypedArray row below.
+
+### Measured before/after
+
+A/B on `src/codegen/array-methods.ts` alone (file-copy revert, same probe, same
+worktree), sha256 of the emitted module, first 12 hex:
+
+| shape | gc before → after | standalone before → after |
+| --- | --- | --- |
+| `a.at()` | `0f1e06b6d00d` → **`f3eea868812c`** | `75fba8273386` → **`b6ffb5d6d279`** |
+| every other row below | unchanged | unchanged |
+
+17 of the 18 probed shapes are **byte-identical** across the fix: `at(0)`,
+`at(undefined)`, `at(NaN)`, `at(-1)`, `at("1")`, `at(i)`, `ta.at(0)`,
+`ta.at(-1)`, `"abc".at()`, `"abc".at(1)`, `indexOf(20)`, `indexOf()`,
+`includes(20)`, `includes()`, `lastIndexOf()`, `slice(1)`, externref-vec
+`at(0)`. Only the `at()` row moved.
+
+Two things fall out of the hashes:
+
+- After the fix, gc-mode `a.at()` is byte-identical to `a.at(0)` **and**
+  `a.at(undefined)` (all `f3eea868812c`), so the three spellings of index 0
+  cannot drift apart. Pinned as a test.
+- Before the fix, `a.at()` had the SAME hash as `a.indexOf()` and
+  `a.lastIndexOf()` (`0f1e06b6d00d`). That is the shared degraded-fallback
+  collapse, identified by hash rather than inferred — and it is what points at
+  the sibling defect below.
+
+Values (gc mode) before → after: `[10,20,30].at()` `0` → **`10`** in value
+position, `"0"` → **`"10"`** in string position.
+
+### Sibling probes — verdicts
+
+| sibling | verdict |
+| --- | --- |
+| `[10,20,30].at()` on an **empty** array | Now byte-for-byte the same lowering as `at(0)`. Both render the out-of-bounds read as `NaN` (f64 vec) / `null` (externref vec) rather than `undefined` — **pre-existing** and general (`[10].at(5)` does the same), NOT a no-argument defect. Pinned as an equality against `at(0)`, deliberately not as a literal. |
+| negative index | Unchanged, byte-identical (`at(-1)`, `at(-3)`). |
+| `includes()` zero-arg | **Already correct** — #2872 fixed exactly this defect there, and `emitIncludesSearchValue` is the model this fix copies. Guarded so it stays correct. |
+| `indexOf()` / `lastIndexOf()` zero-arg | **BROKEN, same collapse** (identical pre-fix hash). `[10,20,30].indexOf()` answers `0`; §23.1.3.13 requires `-1` (searches `undefined`, strict equality, holes skipped via HasProperty). `[10,undefined,30].indexOf()` answers `0`, should be `1`. **Not fixed here** — the correct answer is not a defaulted index but a different search value with different comparison semantics, so it is a separate change with its own test262 blast radius. Follow-up needed. |
+| `new Int32Array(3).at()` (TypedArray) | **Was BROKEN too** — the issue's table above lists it as correct, which was wrong. It shares `compileArrayAt`, so it answered `0` instead of element 0. Fixed by this same change and pinned in both lanes. |
+| `"abc".at()` (String.prototype.at) | Correct, and byte-identical — a different lowering (`string-ops.ts`), untouched. |
+
+### Follow-up not yet filed
+
+`indexOf()` / `lastIndexOf()` with no argument (the row above) still answer `0`
+where the spec requires `-1`. It is **not** filed as its own issue because
+`scripts/claim-issue.mjs --allocate` refuses to reserve an id when the open-PR
+scan is unavailable (`gh` is absent in this container, exit 6) and hand-picking
+an id is forbidden (#2531). Recorded here and reported to the orchestrator so
+an id can be allocated where `gh` is reachable.
+
+## Test Results
+
+`tests/issue-5095-array-at-no-argument.test.ts` — 13 tests, all pass. Covers the
+no-argument case in value and string position on a non-empty array (gc +
+standalone), the empty-array equality against `at(0)`, the TypedArray receiver
+in both lanes, the gc byte-identity of `at()` / `at(0)` / `at(undefined)`, and
+the already-correct forms as regression guards.
+
+`tests/equivalence/array-at-no-arg.test.ts` — 5 rows, all pass. Modelled on the
+sibling `array-includes-no-arg.test.ts` (#2872, the same defect shape one method
+over): numeric array, agreement with the `at(0)` spelling, string array,
+TypedArray receiver, and the explicit-index forms. The empty-array row is
+deliberately absent — see the sibling table above for why.
+
+Also re-run green: `tests/issue-2644-array-at-index-tointeger.test.ts` (14) and
+`tests/issue-3481-step2-symbol-arg-revalidation.test.ts` (36) — the latter's
+`[].at()` case is tightened from "does not throw" to `toBe(10)`, as this file
+anticipated.
+
+Gates: `typecheck` 0, `lint` 0, `format:check` 0, `check:func-budget` 0,
+`check:coercion-sites` 0, `check:oracle-ratchet` 0, `check:dead-exports` 0,
+`check:issue-ids` 0, `check:done-status-integrity` 0,
+`check:issue-spec-coverage` 0, `check:test-vacuity-shapes` 0,
+`check:ir-fallbacks` unchanged, `check:loc-budget` 0 with the grant above.
+Equivalence gate run as **8 shards**, all green: 24 failing / 1,685 passing
+against 24 known-failures in the baseline — i.e. zero new regressions and the
+failure count is exactly the baseline.
+
+### Acceptance
+
+- [x] `[10, 20, 30].at()` returns `10` in both value and string-coercion position.
+- [x] `at(0)` / `at(undefined)` / `at(NaN)` / `at(-1)` keep their answers — proven
+      byte-identical, not just behaviourally equal.
+- [x] TypedArray path unchanged *in the sense that matters*: it was broken the
+      same way and is now correct; `at(0)` / `at(-1)` on it are byte-identical.
+- [ ] Dynamic-receiver host fallback: `compileArrayMethodExtern` is not touched
+      by this change (no diff reaches it), so it is unchanged by construction.
+      Not re-measured end-to-end — the probe receiver for `const a: any = [...]`
+      is a WasmGC vec, not a JS array, so it throws in the harness for reasons
+      unrelated to this issue.
+- [ ] test262 `built-ins/Array/prototype/at/` + `built-ins/TypedArray/prototype/at/`
+      cohorts: not run locally (devs do not run test262 locally); CI's
+      `merge_group` re-validation is the gate.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3158,11 +3158,6 @@ function compileArrayAt(
   arrTypeIdx: number,
   elemType: ValType,
 ): ValType | null {
-  if (callExpr.arguments.length < 1) {
-    reportError(ctx, callExpr, "at() requires 1 argument");
-    return null;
-  }
-
   const vecTmp = allocLocal(fctx, `__arr_at_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const idxTmp = allocLocal(fctx, `__arr_at_idx_${fctx.locals.length}`, { kind: "i32" });
   const lenTmp = allocLocal(fctx, `__arr_at_len_${fctx.locals.length}`, { kind: "i32" });
@@ -3190,7 +3185,16 @@ function compileArrayAt(
   // following <0 wrap + bounds check clamp it). No new #2108 coercion site —
   // `coerceType` reuse only. The legacy direct-i32 path is kept for the JS-host
   // mode (which coerces strings via a host import).
-  if (noJsHost(ctx)) {
+  // (#5095) `index` is an ORDINARY parameter, so `arr.at()` is legal JS and is
+  // exactly `arr.at(0)` — ToIntegerOrInfinity(undefined) is +0. Rejecting it (an
+  // `at() requires 1 argument` reportError here) collapsed the whole call into the
+  // caller's degraded fallback, so `[10,20,30].at()` answered the INDEX `0`, not
+  // `10` (`undefined` in value position — one collapse, two coercion paths). Same
+  // shape as `includes`'s absent searchElement (`emitIncludesSearchValue`, #2872);
+  // covers the TypedArray receiver too, which shares this lowering.
+  if (callExpr.arguments.length < 1) {
+    fctx.body.push({ op: "i32.const", value: 0 });
+  } else if (noJsHost(ctx)) {
     const argType = compileExpression(ctx, fctx, callExpr.arguments[0]!);
     if (!argType) {
       // void → undefined → ToNumber NaN → ToIntegerOrInfinity 0.

--- a/tests/equivalence/array-at-no-arg.test.ts
+++ b/tests/equivalence/array-at-no-arg.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+// §23.1.3.1 takes `index` as an ordinary parameter, so `at()` with no argument
+// is `at(0)` — ToIntegerOrInfinity(undefined) is +0. The native WasmGC vec
+// lowering used to reject the zero-argument form outright ("at() requires 1
+// argument"), and the caller swallowed that diagnostic into a degraded
+// fallback: `[10,20,30].at()` evaluated to the relative INDEX `0` rather than
+// the element `10`. Same defect shape as the `includes()` zero-argument gap
+// fixed in #2872 (see array-includes-no-arg.test.ts) — the sibling file this
+// one is modelled on.
+//
+// Deliberately NOT covered here: `at()` on an EMPTY array. Index 0 is out of
+// bounds, and the native vec renders an out-of-bounds read of a number vec as
+// NaN rather than `undefined` — a pre-existing, general residual (`[10].at(5)`
+// does the same), unrelated to the argument count. Pinning it as an equivalence
+// row would fail for a reason this issue does not own; it is pinned instead as
+// an equality against `at(0)` in tests/issue-5095-array-at-no-argument.test.ts.
+describe("Array.prototype.at with no argument (ES2022)", () => {
+  it("returns the first element of a numeric array", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [10, 20, 30];
+        return arr.at() as number;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  // TypeScript types `at` as requiring its argument, so the zero-argument form
+  // is only writable where the harness tolerates the diagnostic — return
+  // position. (test262 is plain JS and has no such constraint.)
+  it("agrees with the at(0) spelling", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [10, 20, 30];
+        return ((arr.at() as number) === (arr.at(0) as number) ? 10 : 0) + (arr.at() as number);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("returns the first element of a string array", async () => {
+    await assertEquivalent(
+      `export function test(): string {
+        var arr: string[] = ["a", "b", "c"];
+        return arr.at() as string;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("returns element 0 of a TypedArray, which shares the lowering", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var t: Int32Array = new Int32Array(3);
+        t[0] = 7;
+        t[1] = 8;
+        return t.at() as number;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("leaves the explicit-index forms unchanged", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var arr: number[] = [10, 20, 30];
+        var last: number = arr.at(-1) as number;
+        var mid: number = arr.at(1) as number;
+        return last * 100 + mid;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});

--- a/tests/issue-3481-step2-symbol-arg-revalidation.test.ts
+++ b/tests/issue-3481-step2-symbol-arg-revalidation.test.ts
@@ -189,11 +189,12 @@ describe("#3481 step 2 — regression guards: non-Symbol arguments are untouched
 
   it("[].at() with no argument does not reach the guard", async () => {
     // The guard keys off `arguments[0]`, so an ABSENT argument must leave the
-    // call untouched. Asserting "no throw" rather than a value on purpose:
-    // `at()` with no argument is a separate, PRE-EXISTING gap (measured on
-    // base and on this branch, both answer 0 where §23.1.3.1 says 10), and
-    // pinning that wrong value here would turn a bug into a fixture.
+    // call untouched. This deliberately asserted only "no throw" while the
+    // separate, PRE-EXISTING no-argument gap was open (it answered 0 where
+    // §23.1.3.1 says 10) rather than pinning a wrong value as a fixture. #5095
+    // closed that gap, so the value is now pinned too.
     expect(await throwKind("[10, 20].at();")).toBe("no-throw");
+    expect(await value("return [10, 20].at();")).toBe(10);
   });
 
   it("[].includes(x, fromIndex) still searches", async () => {

--- a/tests/issue-5095-array-at-no-argument.test.ts
+++ b/tests/issue-5095-array-at-no-argument.test.ts
@@ -1,0 +1,168 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #5095 — `Array.prototype.at` with NO argument answered the *index* instead of
+//   the element: `[10,20,30].at()` returned `0` (and `undefined` in value
+//   position) instead of `10`.
+//
+//   §23.1.3.1 takes `index` as an ordinary parameter, so the zero-argument form
+//   is legal JS and is exactly `at(0)`: ToNumber(undefined) is NaN and
+//   ToIntegerOrInfinity(NaN) is +0 (§7.1.5 step 2).
+//
+//   Root cause (src/codegen/array-methods.ts, compileArrayAt): the native WasmGC
+//   vec lowering opened with a hard `at() requires 1 argument` reportError +
+//   `return null`, which the caller swallowed into its degraded fallback. The two
+//   wrong spellings in the report (`0` in string position, `undefined` in value
+//   position) were that one collapse seen through two coercion paths — measured
+//   by hash: pre-fix `a.at()` compiled to the SAME binary as `a.indexOf()` and
+//   `a.lastIndexOf()`, the other two methods that still hard-require their
+//   argument (that sibling defect is NOT fixed here — see the issue file).
+//
+//   Fix: treat the absent argument as index 0, exactly as `includes` already
+//   models its absent `searchElement` (`emitIncludesSearchValue`, #2872). In
+//   gc/host mode the emitted binary for `at()` is byte-identical to `at(0)` and
+//   `at(undefined)` — asserted below, so the three spellings cannot drift apart.
+//
+//   `skipSemanticDiagnostics` mirrors the test262 runner — TS types `at` as
+//   requiring an argument, which is not a hard error there.
+
+interface CompileResult {
+  success: boolean;
+  errors?: Array<{ message: string }>;
+  binary: Uint8Array;
+  importObject?: WebAssembly.Imports;
+}
+
+async function build(src: string, standalone: boolean): Promise<CompileResult> {
+  const opts = standalone ? { target: "standalone", skipSemanticDiagnostics: true } : { skipSemanticDiagnostics: true };
+  const r = (await compile(src, opts as never)) as never as CompileResult;
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  return r;
+}
+
+async function runGc(src: string): Promise<unknown> {
+  const r = await build(src, false);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await build(src, true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function digestGc(src: string): Promise<string> {
+  const r = await build(src, false);
+  return createHash("sha256").update(r.binary).digest("hex");
+}
+
+const ARR = "const a=[10,20,30];";
+
+describe("#5095 Array.prototype.at() with no argument", () => {
+  // The headline bug, in both spellings the report gave.
+  it("value position: [10,20,30].at() → 10 (gc)", async () => {
+    expect(await runGc(`export function test(): number { ${ARR} return a.at() as number; }`)).toBe(10);
+  });
+
+  it("value position: [10,20,30].at() → 10 (standalone)", async () => {
+    expect(await runStandalone(`export function test(): number { ${ARR} return a.at() as number; }`)).toBe(10);
+  });
+
+  it('string position: "" + [10,20,30].at() → "10" (gc)', async () => {
+    expect(await runGc(`export function test(): string { ${ARR} return "" + a.at(); }`)).toBe("10");
+  });
+
+  // A TypedArray receiver shares this exact lowering, so it carried the same
+  // defect (the #5095 report listed it as already-correct — it was not).
+  it("TypedArray receiver: Int32Array at() → element 0 (gc)", async () => {
+    expect(
+      await runGc(
+        `export function test(): number { const t=new Int32Array(3); t[0]=7; return t.at(0+0-0) as number; }`,
+      ),
+    ).toBe(7);
+    expect(
+      await runGc(`export function test(): number { const t=new Int32Array(3); t[0]=7; return t.at() as number; }`),
+    ).toBe(7);
+  });
+
+  it("TypedArray receiver: Int32Array at() → element 0 (standalone)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const t=new Int32Array(3); t[0]=7; return t.at() as number; }`,
+      ),
+    ).toBe(7);
+  });
+
+  // Empty receiver: index 0 is out of bounds, so at() must behave exactly as
+  // at(0) does. Asserted as an EQUALITY against at(0) rather than a literal,
+  // because the native vec lowering renders an out-of-bounds read of a number
+  // vec as NaN rather than undefined — a pre-existing, separate residual that
+  // this issue does not change and must not silently pin as correct.
+  it("empty array: at() behaves exactly as at(0) (gc)", async () => {
+    const noArg = await runGc(`export function test(): string { const a: number[]=[]; return "" + a.at(); }`);
+    const zero = await runGc(`export function test(): string { const a: number[]=[]; return "" + a.at(0); }`);
+    expect(noArg).toBe(zero);
+  });
+
+  it("empty array: at() behaves exactly as at(0) (standalone, value position)", async () => {
+    const noArg = await runStandalone(
+      `export function test(): number { const a: number[]=[]; return a.at() as number; }`,
+    );
+    const zero = await runStandalone(
+      `export function test(): number { const a: number[]=[]; return a.at(0) as number; }`,
+    );
+    expect(noArg).toBe(zero);
+  });
+
+  // Byte-identity: the three spellings of "index 0" must compile to the same
+  // module in gc/host mode, so they cannot drift apart later.
+  it("gc: at() compiles byte-identically to at(0) and at(undefined)", async () => {
+    const noArg = await digestGc(`export function test(): number { ${ARR} return a.at() as number; }`);
+    const zero = await digestGc(`export function test(): number { ${ARR} return a.at(0) as number; }`);
+    const undef = await digestGc(`export function test(): number { ${ARR} return a.at(undefined) as number; }`);
+    expect(noArg).toBe(zero);
+    expect(noArg).toBe(undef);
+  });
+
+  // Already-correct forms — regression guards. Each was byte-identical before
+  // and after the fix (measured A/B on src/codegen/array-methods.ts).
+  it("at(0) / at(undefined) / at(NaN) keep answering 10", async () => {
+    expect(await runGc(`export function test(): number { ${ARR} return a.at(0) as number; }`)).toBe(10);
+    expect(await runGc(`export function test(): number { ${ARR} return a.at(undefined) as number; }`)).toBe(10);
+    expect(await runGc(`export function test(): number { ${ARR} return a.at(NaN) as number; }`)).toBe(10);
+    expect(await runStandalone(`export function test(): number { ${ARR} return a.at(0) as number; }`)).toBe(10);
+    expect(await runStandalone(`export function test(): number { ${ARR} return a.at(NaN) as number; }`)).toBe(10);
+  });
+
+  it("negative index still wraps from the end", async () => {
+    expect(await runGc(`export function test(): number { ${ARR} return a.at(-1) as number; }`)).toBe(30);
+    expect(await runGc(`export function test(): number { ${ARR} return a.at(-3) as number; }`)).toBe(10);
+    expect(await runStandalone(`export function test(): number { ${ARR} return a.at(-1) as number; }`)).toBe(30);
+  });
+
+  it("#2644 string-index ToIntegerOrInfinity path unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at("1"); }`)).toBe(11);
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at("-2.5"); }`)).toBe(
+      12,
+    );
+  });
+
+  it("String.prototype.at() (a different lowering) is unchanged", async () => {
+    expect(await runGc(`export function test(): string { return "abc".at() as string; }`)).toBe("a");
+    expect(await runGc(`export function test(): string { return "abc".at(1) as string; }`)).toBe("b");
+  });
+
+  // Sibling probe, recorded as a NEAR-MISS rather than ignored: `includes()`
+  // with no argument was already correct (#2872 fixed it there) and must stay
+  // so. `indexOf()`/`lastIndexOf()` with no argument are still WRONG (they
+  // answer 0 where §23.1.3.13/§23.1.3.20 require -1) — deliberately NOT pinned
+  // here, and written up as a follow-up in the issue file.
+  it("includes() with no argument stays correct (already fixed by #2872)", async () => {
+    expect(await runGc(`export function test(): boolean { ${ARR} return a.includes(); }`)).toBeFalsy();
+    expect(
+      await runGc(`export function test(): boolean { const a=[10,undefined,30]; return a.includes(); }`),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes [#5095](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5095-array-prototype-at-no-argument) — `[10,20,30].at()` answered `0` (the *index*) instead of `10` (the element).

## Root cause

`compileArrayAt` (`src/codegen/array-methods.ts`) opened with a hard reject:

```ts
if (callExpr.arguments.length < 1) {
  reportError(ctx, callExpr, "at() requires 1 argument");
  return null;
}
```

`index` is an ordinary parameter, so `arr.at()` is legal JS and is exactly `arr.at(0)` — `ToIntegerOrInfinity(undefined)` is `+0` (§7.1.5 step 2). The reject returned `null`, whose diagnostic the caller **swallows** (`compile()` reports `success: true` with an **empty** `errors` array), and the call collapsed into the caller's degraded fallback. The two spellings in the report — `0` in string position, `undefined` in value position — are that one collapse seen through two coercion paths.

Fix: replace the reject with an `i32.const 0` index arm, the same shape `Array.prototype.includes` already uses for its absent `searchElement` (`emitIncludesSearchValue`, [#2872](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2872-standalone-typedarray-prototype-cluster)).

## Measured before/after

A/B on `src/codegen/array-methods.ts` alone (file-copy revert, same probe, same worktree), sha256 of the emitted module:

| shape | gc before → after |
| --- | --- |
| `a.at()` | `0f1e06b6d00d` → **`f3eea868812c`** |
| the other 17 probed shapes | unchanged, byte-identical |

Byte-identical across the fix: `at(0)`, `at(undefined)`, `at(NaN)`, `at(-1)`, `at("1")`, `at(i)`, `ta.at(0)`, `ta.at(-1)`, `"abc".at()`, `"abc".at(1)`, `indexOf(20)`, `indexOf()`, `includes(20)`, `includes()`, `lastIndexOf()`, `slice(1)`, externref-vec `at(0)`.

Two things fall out of the hashes:

- After the fix, gc-mode `a.at()` is byte-identical to `a.at(0)` **and** `a.at(undefined)` — pinned as a test so the three spellings of index 0 cannot drift apart.
- Before the fix, `a.at()` had the **same** hash as `a.indexOf()` and `a.lastIndexOf()`. That is the shared degraded-fallback collapse, identified by hash rather than inferred — and it is what surfaced the sibling defect below.

Values (gc): `[10,20,30].at()` `0` → **`10`** in value position, `"0"` → **`"10"`** in string position.

## Two findings beyond the report

- **The TypedArray receiver was also broken.** The issue's table lists it as already-correct; it is not. It shares this lowering, so `new Int32Array(3).at()` answered `0` rather than element 0. Fixed by the same change, pinned in both lanes.
- **`indexOf()` / `lastIndexOf()` with no argument are broken the same way** — `[10,20,30].indexOf()` answers `0` where §23.1.3.13 requires `-1`. **Not fixed here**: the correct answer is a different search value with different comparison semantics (strict equality, holes skipped via HasProperty), not a defaulted index, so it carries its own test262 blast radius. Written up in the issue file; the follow-up issue is being allocated by the orchestrator.

`includes()` with no argument was already correct and is guarded so. Empty-array `at()` is pinned as an **equality against `at(0)`**, not a literal: the native vec renders an out-of-bounds read of a number vec as `NaN` rather than `undefined`, which is pre-existing and general (`[10].at(5)` does the same) — pinning it as a literal would turn a separate bug into a fixture.

## Tests

- `tests/issue-5095-array-at-no-argument.test.ts` — 13 tests: no-argument case in value and string position (gc + standalone), empty-array equality against `at(0)`, TypedArray receiver in both lanes, the gc byte-identity assertion, and the already-correct forms as regression guards.
- `tests/equivalence/array-at-no-arg.test.ts` — 5 rows, modelled on the sibling `array-includes-no-arg.test.ts`.
- `tests/issue-3481-step2-symbol-arg-revalidation.test.ts` — its `[].at()` case is tightened from "does not throw" to `toBe(10)`, as that file anticipated.

## Gates

`typecheck` · `lint` · `format:check` · `check:func-budget` · `check:coercion-sites` · `check:oracle-ratchet` · `check:dead-exports` · `check:issue-ids` · `check:done-status-integrity` · `check:issue-spec-coverage` · `check:test-vacuity-shapes` — all 0. `check:ir-fallbacks` unchanged. `check:loc-budget` 0 with a `loc-budget-allow` grant in the issue frontmatter (+4 lines: the fix is a 3-line arm replacing a 4-line reject; the growth is the comment recording why the zero-argument form must not be rejected).

Equivalence gate run as **8 shards**, all green: 24 failing / 1,685 passing against 24 known-failures in the baseline — zero new regressions, failure count exactly the baseline.

test262 `built-ins/Array/prototype/at/` and `built-ins/TypedArray/prototype/at/` are not run locally; CI's `merge_group` re-validation is the gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_