### PR TITLE
feat(ir): own exact Math.sign calls

### DIFF
--- a/plan/issues/5116-ir-exact-ambient-math-sign.md
+++ b/plan/issues/5116-ir-exact-ambient-math-sign.md
@@ -1,7 +1,7 @@
 ---
 id: 5116
 title: "IR: own exact ambient Math.sign calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -53,13 +53,13 @@ finite values while leaving coercive and dynamic forms on direct codegen.
 
 ## Measured residual
 
-`sign` is absent from `IR_MATH_METHOD_TABLE`, so exact numeric calls currently
-produce selector-stage `body-shape-rejected` telemetry and emit a legacy body.
-The direct implementation in `compileMathCall` evaluates the argument once,
-passes through NaN and signed zero, and otherwise applies the operand sign to
-one. Unlike the previous 26 methods, no self-hosted `Math_sign` helper exists,
-so this checkpoint first expresses that established behavior in the verified
-stdlib dialect.
+Before this checkpoint, `sign` was absent from `IR_MATH_METHOD_TABLE`, so exact
+numeric calls produced selector-stage `body-shape-rejected` telemetry and
+emitted a legacy body. The direct implementation in `compileMathCall`
+evaluates the argument once, canonicalizes NaN, passes through signed zero, and
+otherwise applies the operand sign to one. Unlike the previous 26 methods, no
+self-hosted `Math_sign` helper existed, so this checkpoint first expressed that
+established behavior in the verified stdlib dialect.
 
 Two Luna Max audits ranked `Math.sign` as the lowest-risk remaining pure Math
 residual. `Math.random` is explicitly unsuitable for this slice because the
@@ -108,6 +108,34 @@ shadowed, coercive, Symbol, spread, and wrong-arity forms remain direct.
 - The narrow rollback, affected regressions, TypeScript 7, and all pre-push
   gates pass.
 
+## Implementation outcome and validation
+
+- `math.sign` is the twenty-seventh certified pure Math intrinsic. Exact
+  ambient one-number calls now emit IR-only bodies and resolve through the
+  dependency-free `selfhost.math.sign` provider and `Math_sign` symbol.
+- The self-hosted source canonicalizes NaN to the same raw f64 bits as direct
+  codegen, preserves both signed zeros, and returns exact sign units for
+  subnormals, finite values, and infinities. The IR instruction carries one SSA
+  argument, preserving one evaluation before the call boundary.
+- Host execution requests no Math import; standalone execution has zero Wasm
+  imports. The manifest closure contains only `math.sign`, with no dependency
+  or host capability.
+- Shadowed, aliased, computed, optional-invocation, optional-receiver,
+  wrong-arity, spread, and non-number forms decline before claim. The existing
+  Symbol path remains direct and throws `TypeError`.
+- Focused ownership tests pass 14/14, the affected #3526 manifest,
+  integration, and linear-legality suites pass 13/13, and existing scoped
+  `Math.sign` equivalence, stdlib, #324, and Symbol regressions pass 6/6.
+  TypeScript 7, kind-neutrality, Prettier, Biome, LOC/function budgets,
+  oracle/coercion ratchets, numeric-local parity (18/18), and issue integrity
+  pass.
+- Luna Max final review returned GO with no P0/P1 finding and independently
+  confirmed canonical NaN bits, signed zero, one evaluation, fallback
+  boundaries, host-free materialization, and linear legality.
+- PR #5129 is open non-draft, clean, and green, stacked directly on #5123's
+  inverse-hyperbolic ownership branch with merge automation armed; CLA and
+  native-messaging smoke checks pass.
+
 ## Non-goals
 
 - General ToNumber coercion, aliases, computed/extracted calls, optional
@@ -120,7 +148,7 @@ shadowed, coercive, Symbol, spread, and wrong-arity forms remain direct.
 ## Risk and rollback
 
 The primary semantic risk is changing evaluation or bit identity for NaN and
-negative zero while replacing the direct body with a self-hosted helper. Exact
-direct/IR parity and existing Symbol-coercion tests are the hard boundaries.
+negative zero while adding the IR-owned self-hosted path. Exact direct/IR
+parity and existing Symbol-coercion tests are the hard boundaries.
 `JS2WASM_IR_MATH_SIGN=0` provides narrow rollback;
 `JS2WASM_IR_FIRST=0` remains the global control.

--- a/plan/issues/5116-ir-exact-ambient-math-sign.md
+++ b/plan/issues/5116-ir-exact-ambient-math-sign.md
@@ -44,8 +44,8 @@ func-budget-allow:
 Retire the direct AST-to-Wasm route for exact ambient
 `Math.sign(numberExpression)` calls in otherwise IR-eligible synchronous
 functions. Represent the source call as a versioned semantic intrinsic and
-replace its hand-emitted direct body with one dependency-free, host-free
-self-hosted provider shared by direct and IR materialization.
+materialize it through one dependency-free, host-free self-hosted provider.
+Excluded forms retain the established hand-emitted direct fallback.
 
 This checkpoint is intentionally stacked on #5123/#5115. It preserves the
 existing exact semantics for NaN, signed zero, infinities, subnormals, and
@@ -87,7 +87,7 @@ shadowed, coercive, Symbol, spread, and wrong-arity forms remain direct.
 5. Widen #3526 exhaustive vocabulary, integration, linear-deferral, and
    neutrality evidence from twenty-six to twenty-seven source Math intrinsics.
 6. Add focused host/standalone ownership, dependency-free provider closure,
-   exact direct parity, rollback, explicit production-linear deferral, and
+   exact direct parity, rollback, explicit linear-backend rejection, and
    pre-claim exclusion tests across NaN, signed zero, subnormals, finite signs,
    and infinities. Retain the existing Symbol TypeError regression.
 7. Re-run existing Math.sign equivalence/coercion regressions, affected #3526
@@ -100,8 +100,9 @@ shadowed, coercive, Symbol, spread, and wrong-arity forms remain direct.
   dependency-free, host-free self-hosted callable.
 - Host and zero-import standalone execution are bit-identical to the direct
   path across NaN, signed zero, subnormals, finite values, and infinities.
-- Production linear selection remains explicit legacy deferral; the manifest's
-  catalogue support must not be mistaken for backend legality.
+- Linear legality rejects the callable provider; the production target's
+  established direct `Math.sign` limitation remains explicit, and catalogue
+  support is not mistaken for backend support.
 - Symbol/coercive and all other excluded shapes preserve direct behavior and
   decline before claim without invariants or post-claim errors.
 - The narrow rollback, affected regressions, TypeScript 7, and all pre-push

--- a/plan/issues/5116-ir-exact-ambient-math-sign.md
+++ b/plan/issues/5116-ir-exact-ambient-math-sign.md
@@ -1,0 +1,125 @@
+---
+id: 5116
+title: "IR: own exact ambient Math.sign calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5116-ir-math-sign
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5115]
+related: [1371, 1732, 3141, 3204, 3526, 4787, 5092, 5094, 5101, 5103, 5105, 5106, 5110, 5111, 5114]
+files:
+  - src/stdlib/math.ts
+  - src/codegen/index.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5116-ir-math-sign.test.ts
+loc-budget-allow:
+  - src/stdlib/math.ts
+  - src/codegen/index.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5116 — Exact ambient `Math.sign` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.sign(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent the source call as a versioned semantic intrinsic and
+replace its hand-emitted direct body with one dependency-free, host-free
+self-hosted provider shared by direct and IR materialization.
+
+This checkpoint is intentionally stacked on #5123/#5115. It preserves the
+existing exact semantics for NaN, signed zero, infinities, subnormals, and
+finite values while leaving coercive and dynamic forms on direct codegen.
+
+## Measured residual
+
+`sign` is absent from `IR_MATH_METHOD_TABLE`, so exact numeric calls currently
+produce selector-stage `body-shape-rejected` telemetry and emit a legacy body.
+The direct implementation in `compileMathCall` evaluates the argument once,
+passes through NaN and signed zero, and otherwise applies the operand sign to
+one. Unlike the previous 26 methods, no self-hosted `Math_sign` helper exists,
+so this checkpoint first expresses that established behavior in the verified
+stdlib dialect.
+
+Two Luna Max audits ranked `Math.sign` as the lowest-risk remaining pure Math
+residual. `Math.random` is explicitly unsuitable for this slice because the
+current semantic intrinsic contract is pure while RNG is observably stateful
+and target-capability dependent.
+
+## Exact admitted grammar
+
+Admit only a non-optional `Math.sign(argument)` when `Math` is the unshadowed
+ambient binding, there is exactly one non-spread argument, the selector proves
+primitive `number`, symbolic Math helpers are available, and the containing
+unit passes ordinary ownership/call-graph gates. Aliased, computed, optional,
+shadowed, coercive, Symbol, spread, and wrong-arity forms remain direct.
+
+## Implementation plan
+
+1. Add a dependency-free `Math_sign` self-hosted source that evaluates NaN,
+   signed zero, and sign exactly like the current direct body; register it in
+   `SELF_HOSTED_MATH` and the direct helper-demand set.
+2. Add `math.sign` to the closed intrinsic/runtime-feature vocabularies with a
+   unary-f64 signature and a dependency-free `selfhost.math.sign` provider.
+3. Add `sign` to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
+   call-graph walker, from-AST emitter, manifest, and provider materializer.
+4. Add an independent `JS2WASM_IR_MATH_SIGN=0` rollback.
+5. Widen #3526 exhaustive vocabulary, integration, linear-deferral, and
+   neutrality evidence from twenty-six to twenty-seven source Math intrinsics.
+6. Add focused host/standalone ownership, dependency-free provider closure,
+   exact direct parity, rollback, explicit production-linear deferral, and
+   pre-claim exclusion tests across NaN, signed zero, subnormals, finite signs,
+   and infinities. Retain the existing Symbol TypeError regression.
+7. Re-run existing Math.sign equivalence/coercion regressions, affected #3526
+   suites, TypeScript 7, formatting/lint/ratchets, and full pre-push checks;
+   then open a non-draft PR stacked on #5123.
+
+## Acceptance criteria
+
+- Exact ambient one-number `Math.sign` calls emit IR only and attach one
+  dependency-free, host-free self-hosted callable.
+- Host and zero-import standalone execution are bit-identical to the direct
+  path across NaN, signed zero, subnormals, finite values, and infinities.
+- Production linear selection remains explicit legacy deferral; the manifest's
+  catalogue support must not be mistaken for backend legality.
+- Symbol/coercive and all other excluded shapes preserve direct behavior and
+  decline before claim without invariants or post-claim errors.
+- The narrow rollback, affected regressions, TypeScript 7, and all pre-push
+  gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, computed/extracted calls, optional
+  chaining, `.call`, or `.apply`.
+- `Math.round`, `fround`, `clz32`, `imul`, variadic Math methods, or Number
+  predicate/formatting expansion.
+- `Math.random`; RNG requires a stateful effect and target-capability design.
+- Async, class, module-init, or broader ownership expansion.
+
+## Risk and rollback
+
+The primary semantic risk is changing evaluation or bit identity for NaN and
+negative zero while replacing the direct body with a self-hosted helper. Exact
+direct/IR parity and existing Symbol-coercion tests are the hard boundaries.
+`JS2WASM_IR_MATH_SIGN=0` provides narrow rollback;
+`JS2WASM_IR_FIRST=0` remains the global control.

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 26 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 27 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,7 +353,7 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 26 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 27 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
       "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:34"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -10246,6 +10246,7 @@ export const MATH_HOST_METHODS_1ARG = new Set([
   "asinh",
   "atanh",
   "cbrt",
+  "sign",
   "expm1",
   "log1p",
 ]);

--- a/src/codegen/math-helpers.ts
+++ b/src/codegen/math-helpers.ts
@@ -297,7 +297,7 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
   }
 
   // ─── Self-hosted subset (#3141) ───────────────────────────────────
-  // sinh/cosh/tanh, asinh/acosh/atanh, cbrt, expm1 and log1p are no
+  // sinh/cosh/tanh, asinh/acosh/atanh, cbrt, sign, expm1 and log1p are no
   // longer hand-emitted `Instr[]`. Their bodies are ordinary TS source
   // in `src/stdlib/math.ts`, compiled through the compiler's own IR
   // pipeline (`stdlib-selfhost.ts`) and registered here, at the same

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -32,6 +32,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.log1p",
   "math.log2",
   "math.pow",
+  "math.sign",
   "math.sin",
   "math.sinh",
   "math.sqrt",
@@ -43,7 +44,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the twenty-six intrinsic entry points.
+ * Provider requirements reachable from the twenty-seven intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -68,6 +69,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.log2",
   "math.pow",
   "math.reduce-trig",
+  "math.sign",
   "math.sin",
   "math.sinh",
   "math.sqrt",
@@ -171,6 +173,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.log1p": definition("math.log1p", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log2": definition("math.log2", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.pow": definition("math.pow", F64_BINARY_INTRINSIC_SIGNATURE),
+  "math.sign": definition("math.sign", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.sin": definition("math.sin", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.sinh": definition("math.sinh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.sqrt": definition("math.sqrt", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -69,6 +69,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.log2",
   "selfhost.math.pow",
   "selfhost.math.reduce-trig",
+  "selfhost.math.sign",
   "selfhost.math.sin",
   "selfhost.math.sinh",
   "selfhost.math.tan",
@@ -201,6 +202,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.log2": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.pow": F64_BINARY_INTRINSIC_SIGNATURE,
   "math.reduce-trig": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.sign": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sin": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sinh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sqrt": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -349,6 +351,10 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     kind: "self-hosted",
     symbol: "__math_reduce_trig",
   }),
+  "math.sign": provider("selfhost.math.sign", "math.sign", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "self-hosted",
+    symbol: "Math_sign",
+  }),
   "math.sin": provider(
     "selfhost.math.sin",
     "math.sin",
@@ -387,7 +393,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
   }),
 });
 
-/** Canonically ordered default provider catalogue for the twenty-six-method slice. */
+/** Canonically ordered default provider catalogue for the twenty-seven-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -300,6 +300,7 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   atan: { arity: 1, intrinsic: "math.atan" },
   atanh: { arity: 1, intrinsic: "math.atanh" },
   cbrt: { arity: 1, intrinsic: "math.cbrt" },
+  sign: { arity: 1, intrinsic: "math.sign" },
   sin: { arity: 1, intrinsic: "math.sin" },
   cos: { arity: 1, intrinsic: "math.cos" },
   tan: { arity: 1, intrinsic: "math.tan" },
@@ -6499,6 +6500,7 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.cosh" && process.env.JS2WASM_IR_MATH_COSH === "0") return false;
   if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
   if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
+  if (plan.intrinsic === "math.sign" && process.env.JS2WASM_IR_MATH_SIGN === "0") return false;
   if (plan.intrinsic === "math.expm1" && process.env.JS2WASM_IR_MATH_EXPM1 === "0") return false;
   if (plan.intrinsic === "math.asinh" && process.env.JS2WASM_IR_MATH_ASINH === "0") return false;
   if (plan.intrinsic === "math.acosh" && process.env.JS2WASM_IR_MATH_ACOSH === "0") return false;

--- a/src/stdlib/math.ts
+++ b/src/stdlib/math.ts
@@ -75,6 +75,19 @@ export function Math_cbrt(x: number): number {
 `;
 
 /**
+ * Math.sign — preserve signed zero, canonicalize NaN like the direct emitter,
+ * and otherwise return the exact sign unit. The argument is evaluated once by
+ * the ordinary call boundary.
+ */
+const SIGN_SOURCE = `
+export function Math_sign(x: number): number {
+  if (x !== x) return 0 / 0;
+  if (x === 0) return x;
+  return x < 0 ? -1 : 1;
+}
+`;
+
+/**
  * Math.sinh = (exp(x) - 1/exp(x)) / 2. §21.3.2.31: sinh(±0) = ±0.
  * ±Infinity specials dropped: Math_exp(+Inf)=Inf → (Inf - 0)/2 = Inf;
  * Math_exp(-Inf)=0 → (0 - Inf)/2 = -Inf — identical to the hand ladder.
@@ -625,6 +638,7 @@ export const POW_BUILTIN: StdlibMathBuiltin = {
  */
 export const SELF_HOSTED_MATH: ReadonlyMap<string, StdlibMathBuiltin> = new Map([
   ["cbrt", { name: "Math_cbrt", callees: [], source: CBRT_SOURCE }],
+  ["sign", { name: "Math_sign", callees: [], source: SIGN_SOURCE }],
   ["sinh", { name: "Math_sinh", callees: ["Math_exp"], source: SINH_SOURCE }],
   ["cosh", { name: "Math_cosh", callees: ["Math_exp"], source: COSH_SOURCE }],
   ["tanh", { name: "Math_tanh", callees: ["Math_exp"], source: TANH_SOURCE }],

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -71,7 +71,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
           + Math.asinh(x) + Math.acosh(x) + Math.atanh(x)
           + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
-          + Math.cbrt(x)
+          + Math.cbrt(x) + Math.sign(x)
           + Math.exp(x) + Math.expm1(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
@@ -136,6 +136,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function cosh(): number { return Math.cosh(0.75); }
       export function tanh(): number { return Math.tanh(0.75); }
       export function cbrt(): number { return Math.cbrt(27); }
+      export function sign(): number { return Math.sign(-27); }
       export function exp(): number { return Math.exp(1.25); }
       export function expm1(): number { return Math.expm1(1.25); }
       export function log(): number { return Math.log(3.5); }
@@ -188,6 +189,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       "cosh",
       "tanh",
       "cbrt",
+      "sign",
       "exp",
       "expm1",
       "log",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,12 +88,12 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact twenty-six certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact twenty-seven certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(26);
+    expect(intrinsicMethods).toHaveLength(27);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
@@ -110,6 +110,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         "math.log10",
         "math.log1p",
         "math.reduce-trig",
+        "math.sign",
         "math.sinh",
         "math.tan",
         "math.tanh",
@@ -137,7 +138,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(26);
+    expect(first.intrinsicUses).toHaveLength(27);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -156,6 +157,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.tanh"]).toEqual(["math.exp"]);
     expect(dependencies["math.cbrt"]).toEqual([]);
     expect(dependencies["math.expm1"]).toEqual(["math.exp"]);
+    expect(dependencies["math.sign"]).toEqual([]);
     expect(dependencies["math.asinh"]).toEqual(["math.log"]);
     expect(dependencies["math.acosh"]).toEqual(["math.log"]);
     expect(dependencies["math.atanh"]).toEqual(["math.log"]);
@@ -180,6 +182,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
           "math.acosh",
           "math.atanh",
           "math.sin",
+          "math.sign",
           "math.tan",
           "math.log10",
           "math.log1p",
@@ -216,6 +219,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       "math.log1p",
       "math.pow",
       "math.reduce-trig",
+      "math.sign",
       "math.sin",
       "math.sinh",
       "math.tan",

--- a/tests/issue-5116-ir-math-sign.test.ts
+++ b/tests/issue-5116-ir-math-sign.test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5116-ir-math-sign");
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+function numberFromBits(bits: bigint): number {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setBigUint64(0, bits);
+  return view.getFloat64(0);
+}
+
+function numberBits(value: number): bigint {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value);
+  return view.getBigUint64(0);
+}
+
+const exclusionCases = [
+  [
+    "shadowed Math",
+    `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5116 shadowed Math is intentionally not ambient.
+      return Math.sign(x);
+    }`,
+  ],
+  ["aliased sign", `const sign = Math.sign; export function f(x: number): number { return sign(x); }`],
+  ["computed sign", `export function f(x: number): number { return Math["sign"](x); }`],
+  ["optional invocation", `export function f(x: number): number { return Math.sign?.(x); }`],
+  ["optional receiver", `export function f(x: number): number { return Math?.sign(x); }`],
+  [
+    "wrong arity",
+    `export function f(x: number): number {
+      // @ts-expect-error #5116 intentionally exercises extra arity.
+      return Math.sign(x, x);
+    }`,
+  ],
+  ["spread argument", `export function f(x: number): number { return Math.sign(...([x] as [number])); }`],
+  [
+    "non-number argument",
+    `export function f(): number {
+      const text: string = "1";
+      return Math.sign(text as never);
+    }`,
+  ],
+] as const;
+
+describe("#5116 exact ambient Math.sign IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims the exact one-number call on the %s target", async (label, target) => {
+    const result = await compile(`export function sign(value: number): number { return Math.sign(value); }`, {
+      fileName: `issue-5116-${label}.ts`,
+      ...(target === undefined ? {} : { target }),
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "sign")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irCompiledFuncs ?? []).toContain("sign");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.wat).toContain("$Math_sign");
+
+    const sign = (await instantiate(result)).sign as (value: number) => number;
+    expect(sign(-1)).toBe(-1);
+    expect(Object.is(sign(-0), -0)).toBe(true);
+    expect(Object.is(sign(0), 0)).toBe(true);
+    expect(sign(1)).toBe(1);
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches one dependency-free host-free Math_sign provider", () => {
+    const analysis = analyzeSource(`export function sign(value: number): number { return Math.sign(value); }`);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing sign declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("sign").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id)).toEqual(["math.sign"]);
+    expect(semantic[0]?.args).toHaveLength(1);
+    expect(semantic[0]?.provider).toBeUndefined();
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id)).toEqual(["math.sign"]);
+    expect(prepared.manifest.features).toEqual(["math.sign"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    expect(prepared.manifest.providers).toEqual([
+      expect.objectContaining({
+        id: "selfhost.math.sign",
+        feature: "math.sign",
+        dependencies: [],
+        implementation: { kind: "self-hosted", symbol: "Math_sign" },
+      }),
+    ]);
+    expect(intrinsicInstructions(prepared.functions[0]!)[0]?.provider).toMatchObject({
+      kind: "callable",
+      target: { name: "Math_sign", binding: { kind: "intrinsic", symbol: "math.sign" } },
+    });
+  });
+
+  it("is bit-identical to direct codegen across NaNs, signed zero, subnormals, finite values, and infinities", async () => {
+    const source = `export function sign(value: number): number { return Math.sign(value); }`;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5116-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5116-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+    expect(outcomeFor(ir, "sign")).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+
+    const irSign = (await instantiate(ir)).sign as (value: number) => number;
+    const directSign = (await instantiate(direct)).sign as (value: number) => number;
+    for (const value of [
+      numberFromBits(0x7ff8_0000_0000_0001n),
+      numberFromBits(0xfff8_0000_0000_0042n),
+      Number.NEGATIVE_INFINITY,
+      -Number.MAX_VALUE,
+      -1,
+      -Number.MIN_VALUE,
+      -0,
+      0,
+      Number.MIN_VALUE,
+      1,
+      Number.MAX_VALUE,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      expect(numberBits(irSign(value)), `sign parity for ${String(value)}`).toBe(numberBits(directSign(value)));
+    }
+  });
+
+  it("leaves the established production-linear limitation outside IR ownership", async () => {
+    const result = await compile(`export function sign(value: number): number { return Math.sign(value); }`, {
+      fileName: "issue-5116-linear.ts",
+      target: "linear",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain("Unsupported method call: .sign()");
+    expect(result.irOutcomes ?? []).toEqual([]);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("withdraws only sign through its narrow rollback", async () => {
+    const flag = "JS2WASM_IR_MATH_SIGN";
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(`export function sign(value: number): number { return Math.sign(value); }`, {
+        fileName: "issue-5116-rollback.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      expectSuccess(result);
+      expect(outcomeFor(result, "sign")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5116-${label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- route exact ambient one-number Math.sign calls through the semantic IR intrinsic pipeline
- materialize a dependency-free, host-free self-hosted Math_sign provider
- preserve bit-identical NaN, signed-zero, subnormal, finite, and infinity behavior
- keep dynamic/coercive shapes and the existing linear limitation outside this ownership slice
- widen the exhaustive 27-method runtime, integration, legality, and neutrality contracts

## Validation

- 14 focused Math.sign ownership tests passed
- 14 affected #3526 manifest, integration, and linear-legality tests passed
- TypeScript 7 and IR kind-neutrality passed
- full pre-push typecheck, lint, formatting, oracle/coercion ratchets, numeric-local parity, and issue-integrity gates passed