### PR TITLE
fix(es2015): reject Symbol Error coercion in standalone

### DIFF
--- a/plan/issues/5118-es2015-error-symbol-coercion.md
+++ b/plan/issues/5118-es2015-error-symbol-coercion.md
@@ -1,10 +1,11 @@
 ---
 id: 5118
 title: "ES2015 standalone Error ToString(Symbol) must throw TypeError"
-status: ready
+status: done
 sprint: current
 created: 2026-08-28
 updated: 2026-08-28
+completed: 2026-08-28
 priority: high
 horizon: s
 feasibility: medium
@@ -14,6 +15,7 @@ area: codegen
 language_feature: error-symbol-coercion
 es_edition: es2015
 goal: standalone-mode
+pr: 5131
 assignee: "ttraenkler/codex/5118-es2015-error-symbol-coercion"
 files:
   - src/codegen/expressions/new-builtin-globals.ts
@@ -212,5 +214,8 @@ Final evidence on that head:
   was clean after the push.
 
 The later handoff/PR-link commits are documentation-only and do not change the
-validated code. Root owns the single non-draft PR against `loopdive/js2:main`,
-then will record its upstream URL here and mark the issue done.
+validated code. The single non-draft upstream PR is
+<https://github.com/loopdive/js2/pull/5131>. It was opened from the
+`ttraenkler/js2` branch, targets `loopdive/js2:main`, uses the repository PR
+template with the CLA checked, and was audited as mergeable with no comments,
+reviews, or unresolved review threads at creation.

--- a/plan/issues/5118-es2015-error-symbol-coercion.md
+++ b/plan/issues/5118-es2015-error-symbol-coercion.md
@@ -17,12 +17,17 @@ goal: standalone-mode
 assignee: "ttraenkler/codex/5118-es2015-error-symbol-coercion"
 files:
   - src/codegen/expressions/new-builtin-globals.ts
-  - src/codegen/native-strings.ts
+  - src/codegen/array-object-proto.ts
+  - src/codegen/expressions/calls.ts
   - tests/issue-5118-es2015-error-symbol-coercion.test.ts
   - plan/issues/5118-es2015-error-symbol-coercion.md
 loc-budget-allow:
   - src/codegen/expressions/new-builtin-globals.ts
-  - src/codegen/native-strings.ts
+  - src/codegen/array-object-proto.ts
+  - src/codegen/expressions/calls.ts
+func-budget-allow:
+  - src/codegen/array-object-proto.ts::emitErrorProtoToStringBody
+  - src/codegen/expressions/new-builtin-globals.ts::tryCompileBuiltinGlobalNew
 ---
 
 # #5118 — ES2015 standalone Error `ToString(Symbol)` must throw TypeError
@@ -78,13 +83,19 @@ already-coerced message, so the narrow fix belongs at the shared Error-family
 call site and covers Error plus NativeError constructors without changing the
 struct layout.
 
-The native `__error_to_string` helper in `src/codegen/native-strings.ts` reads
-the `$Error_struct` name and message fields. Its message arm recognizes native
-strings and treats every other value as empty; a Symbol carrier therefore
-returns the name instead of throwing. The same helper is shared by native
-Error rendering, so adding a Symbol-only TypeError arm there covers
-`Error.prototype.toString` while leaving ordinary object/string/date paths
-unchanged. The helper must retain its existing name-before-message sequence.
+The existing `$Error_struct` renderer is intentionally limited to native Error
+instances. It cannot implement the failing prototype row: that row invokes
+`Error.prototype.toString` with an ordinary object receiver, whose `name` and
+`message` properties (including accessors and inherited properties) must be
+looked up dynamically. The standalone reflective prototype route is owned by
+`src/codegen/array-object-proto.ts`; before this fix it emitted only the
+catchable refusal body. A shared Error/NativeError body must perform
+the §20.5.3.4 Type(V)-is-Object receiver check (with null/undefined rejected
+separately), then `Get(name)`/ToString(name), then `Get(message)`/ToString(message),
+rejecting a native `$Symbol` carrier at each ToString step. The existing
+general-purpose `__any_to_string` and native
+`__error_to_string` helpers remain unchanged, so ordinary object/string/date
+coercion outside this body is not widened.
 
 ## Evidence before implementation
 
@@ -94,31 +105,52 @@ unchanged. The helper must retain its existing name-before-message sequence.
   interned `$Symbol` carrier when crossing the `externref` message boundary;
   the carrier's nominal type is available as `ctx.symbolTypeIdx`.
 - `emitThrowTypeError` builds the in-module TypeError and exception payload in
-  standalone, preserving the required constructor identity. Existing
-  `emitSymbolOperandCoercionThrow` demonstrates the repository's side-effect
-  ordering rule: evaluate the Symbol operand before emitting the throw.
+  standalone, preserving the required constructor identity. The constructor
+  guard evaluates every supplied argument in source order before emitting the
+  final TypeError, so a later abrupt argument completion wins over the first
+  message's ToString failure. The prototype body keeps name access/coercion
+  before message access/coercion and applies the same strict Symbol check to
+  dynamic carriers.
 - No host import or raw checker query is needed. The constructor guard can
   statically recognize a Symbol expression and evaluate/drop it before
   throwing; the Error stringifier can dynamically `ref.test` the native
-  `$Symbol` carrier after name evaluation.
+  `$Symbol` carrier after name evaluation. Dynamic constructor bodies ensure
+  that carrier before minting their guard only when the oracle message fact
+  can carry Symbol (`symbol`, `any`, `unknown`, `unresolvable`, or a union
+  containing one), so ordinary string messages do not gain the carrier cost.
 
 ## Bounded implementation plan
 
 1. Add a standalone-only Symbol message guard to the shared Error-family
-   constructor lowering. Evaluate the argument exactly once, preserve its
-   side effects, then emit a real TypeError with the canonical Symbol-to-string
-   message. Keep host mode and all non-Symbol message values on their current
-   path; cover both `new` and call-without-`new` through the shared emitter.
-2. Extend the native `$Error_struct` `__error_to_string` message arm with a
-   `$Symbol` carrier check that throws a TypeError before the non-string-empty
-   fallback. Keep name retrieval/coercion before that check and retain existing
-   native string, undefined, object, and date behavior.
+   constructor lowering in `new-builtin-globals.ts`. Evaluate every supplied
+   argument exactly once in source order, preserve its side effects and abrupt
+   completion priority, then emit a real TypeError with the canonical
+   Symbol-to-string message. Keep host mode and all non-Symbol message values
+   on their current path; both `new` and call-without-`new` use this emitter.
+   Evaluate/drop later arguments after a dynamic first message and ensure the
+   native Symbol carrier before baking that dynamic guard, including when the
+   Error callee compiles before its caller.
+2. Implement the standalone reflective Error/NativeError
+   `Error.prototype.toString` body in `array-object-proto.ts`. Enforce the
+   §20.5.3.4 Type(V)-is-Object receiver check (including number, string,
+   boolean, null/undefined, and Symbol receivers), ordered name-before-message
+   property access and coercion, strict dynamic `$Symbol` rejection,
+   empty-name/message cases, inherited NativeError behavior, and ordinary
+   object/function/array messages. The narrow `calls.ts` syntax resolver maps
+   `Error.prototype.toString` and NativeError prototype spellings to this
+   existing glue and promotes only the direct object-literal receivers whose
+   properties need dynamic `[[Get]]`; it does not alter other prototype
+   families. Leave the generic and `$Error_struct` string helpers unchanged.
 3. Add `tests/issue-5118-es2015-error-symbol-coercion.test.ts`. Mandatory
    compiler controls always run without Test262; exact host/standalone corpus
    rows are under a worktree-independent `describe.skipIf` corpus guard. Use
    Vitest timeouts above the runner's 120s per-row budget. Controls cover
    side-effect and throw priority, positive string/undefined messages, exact
-   TypeError identity, and zero standalone host imports.
+   TypeError identity, primitive receiver rejection, ordered getters,
+   empty/inherited/NativeError cases, ordinary object messages, and zero
+   standalone host imports. Include callee-before-caller dynamic-carrier and
+   dynamic-first-message/later-abrupt controls for both constructor spellings,
+   plus a compact host bundle covering the changed host argument path.
 4. Run fresh exact A/B and repeat/determinism using
    `JS2WASM_QUICKJS_ARTIFACT_DIR=/private/tmp/js2-quickjs-artifact-2e2d7736713beeda`
    with at most two workers. Run focused/related tests, no-corpus shape,
@@ -130,8 +162,10 @@ unchanged. The helper must retain its existing name-before-message sequence.
 - The exact three rows are pass in both host and standalone lanes.
 - The standalone implementations throw a real `TypeError` for Symbol message
   coercion, with correct identity, and have zero host imports.
-- Error/NativeError constructor argument evaluation and Error.prototype.toString
-  name-before-message access/coercion order remain observable and correct.
+- Error/NativeError constructor argument evaluation and the shared
+  Error.prototype.toString name-before-message access/coercion order remain
+  observable and correct, including primitive receiver TypeError and
+  empty-name/message handling.
 - Positive string and undefined-message behavior remains correct; unrelated
   object/string/date behavior is unchanged.
 - Mandatory no-corpus compiler controls run and pass even when `test262/test`

--- a/plan/issues/5118-es2015-error-symbol-coercion.md
+++ b/plan/issues/5118-es2015-error-symbol-coercion.md
@@ -1,0 +1,148 @@
+---
+id: 5118
+title: "ES2015 standalone Error ToString(Symbol) must throw TypeError"
+status: in-progress
+sprint: current
+created: 2026-08-28
+updated: 2026-08-28
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: codegen
+language_feature: error-symbol-coercion
+es_edition: es2015
+goal: standalone-mode
+assignee: "ttraenkler/codex/5118-es2015-error-symbol-coercion"
+files:
+  - src/codegen/expressions/new-builtin-globals.ts
+  - src/codegen/native-strings.ts
+  - tests/issue-5118-es2015-error-symbol-coercion.test.ts
+  - plan/issues/5118-es2015-error-symbol-coercion.md
+loc-budget-allow:
+  - src/codegen/expressions/new-builtin-globals.ts
+  - src/codegen/native-strings.ts
+---
+
+# #5118 — ES2015 standalone Error `ToString(Symbol)` must throw TypeError
+
+## Exact cohort and baseline (2026-08-28)
+
+The owned cohort is exactly these three ES2015 Test262 rows:
+
+- `test/built-ins/Error/error-message-tostring-symbol.js`
+- `test/built-ins/Error/prototype/toString/tostring-message-throws-symbol.js`
+- `test/built-ins/NativeErrors/nativeerror-tostring-message-throws-symbol.js`
+
+The authoritative standalone snapshot is
+`/private/tmp/js2-baseline-standalone-current-20260828.jsonl`, SHA256
+`260a57b7fb4d53516fa81e1c949d81337968e30ce790d457bcc2d3945c2e9e1e`.
+The matching host snapshot is
+`/private/tmp/js2-baseline-host-current-20260828.jsonl`, SHA256
+`a395f2a88d289a8e0fd78ccd76e090215ef3a85f1960aa8fe96f7d3a0445bd49`.
+Both contain 48,735 rows at oracle version 13. The three host rows are
+`pass` (3/3); the three standalone rows are `fail` (0/3), all
+`assertion_fail`, `reached_test: true`, with no compile errors, compile
+timeouts, or skips in this cohort.
+
+Exact baseline row evidence:
+
+| row | host | standalone | standalone evidence |
+| --- | --- | --- | --- |
+| `built-ins/Error/error-message-tostring-symbol.js` | pass | fail | `If _message_ is a Symbol, Error must throw TypeError`; no exception was thrown |
+| `built-ins/Error/prototype/toString/tostring-message-throws-symbol.js` | pass | fail | `If message field is a symbol, Error.prototype.toString must throw a TypeError`; no exception was thrown |
+| `built-ins/NativeErrors/nativeerror-tostring-message-throws-symbol.js` | pass | fail | `If _message_ is a Symbol, EvalError should throw a TypeError`; no exception was thrown |
+
+The source checkout is based directly on freshly fetched `upstream/main` at
+`fefcf1348e979651142128098b629cf7328b2517`; its Test262 gitlink is pinned to
+`b363f29d3c43c626dc852744ad64a0b48a003693`.
+
+## Specification and root cause
+
+ECMAScript [§20.5.1.1 Error](https://tc39.es/ecma262/#sec-error-constructor)
+step 3.1 performs `? ToString(message)` whenever `message` is not undefined.
+The NativeError constructors use the same message algorithm in
+§20.5.6.1.1. [§20.5.3.4 Error.prototype.toString](https://tc39.es/ecma262/#sec-error-prototype-tostring)
+gets `name` first, then gets and `ToString`s `message`; a Symbol message must
+therefore throw a TypeError after the name access/coercion has completed.
+
+In standalone/native-first codegen, `new Error(message)` and each NativeError
+constructor are handled by `tryCompileBuiltinGlobalNew` in
+`src/codegen/expressions/new-builtin-globals.ts`. The first argument is coerced
+to `externref` and sent through `__any_to_string`, but that dispatcher has no
+Symbol-carrier arm. A native Symbol is a `$Symbol` carrier (`symbol-native.ts`)
+and consequently falls into the object/non-string fallback instead of throwing.
+The native `$Error_struct` constructor in `registry/error-types.ts` stores the
+already-coerced message, so the narrow fix belongs at the shared Error-family
+call site and covers Error plus NativeError constructors without changing the
+struct layout.
+
+The native `__error_to_string` helper in `src/codegen/native-strings.ts` reads
+the `$Error_struct` name and message fields. Its message arm recognizes native
+strings and treats every other value as empty; a Symbol carrier therefore
+returns the name instead of throwing. The same helper is shared by native
+Error rendering, so adding a Symbol-only TypeError arm there covers
+`Error.prototype.toString` while leaving ordinary object/string/date paths
+unchanged. The helper must retain its existing name-before-message sequence.
+
+## Evidence before implementation
+
+- Host mode is already correct because `env::__new_Error` and the native-error
+  imports resolve to JavaScript constructors; all three host rows pass.
+- Standalone Symbol values are lowered as branded i32 ids and boxed to an
+  interned `$Symbol` carrier when crossing the `externref` message boundary;
+  the carrier's nominal type is available as `ctx.symbolTypeIdx`.
+- `emitThrowTypeError` builds the in-module TypeError and exception payload in
+  standalone, preserving the required constructor identity. Existing
+  `emitSymbolOperandCoercionThrow` demonstrates the repository's side-effect
+  ordering rule: evaluate the Symbol operand before emitting the throw.
+- No host import or raw checker query is needed. The constructor guard can
+  statically recognize a Symbol expression and evaluate/drop it before
+  throwing; the Error stringifier can dynamically `ref.test` the native
+  `$Symbol` carrier after name evaluation.
+
+## Bounded implementation plan
+
+1. Add a standalone-only Symbol message guard to the shared Error-family
+   constructor lowering. Evaluate the argument exactly once, preserve its
+   side effects, then emit a real TypeError with the canonical Symbol-to-string
+   message. Keep host mode and all non-Symbol message values on their current
+   path; cover both `new` and call-without-`new` through the shared emitter.
+2. Extend the native `$Error_struct` `__error_to_string` message arm with a
+   `$Symbol` carrier check that throws a TypeError before the non-string-empty
+   fallback. Keep name retrieval/coercion before that check and retain existing
+   native string, undefined, object, and date behavior.
+3. Add `tests/issue-5118-es2015-error-symbol-coercion.test.ts`. Mandatory
+   compiler controls always run without Test262; exact host/standalone corpus
+   rows are under a worktree-independent `describe.skipIf` corpus guard. Use
+   Vitest timeouts above the runner's 120s per-row budget. Controls cover
+   side-effect and throw priority, positive string/undefined messages, exact
+   TypeError identity, and zero standalone host imports.
+4. Run fresh exact A/B and repeat/determinism using
+   `JS2WASM_QUICKJS_ARTIFACT_DIR=/private/tmp/js2-quickjs-artifact-2e2d7736713beeda`
+   with at most two workers. Run focused/related tests, no-corpus shape,
+   type/lint/format, budgets/ratchets, issue collision checks, and full
+   pre-push. Record all final evidence and the handoff here.
+
+## Acceptance
+
+- The exact three rows are pass in both host and standalone lanes.
+- The standalone implementations throw a real `TypeError` for Symbol message
+  coercion, with correct identity, and have zero host imports.
+- Error/NativeError constructor argument evaluation and Error.prototype.toString
+  name-before-message access/coercion order remain observable and correct.
+- Positive string and undefined-message behavior remains correct; unrelated
+  object/string/date behavior is unchanged.
+- Mandatory no-corpus compiler controls run and pass even when `test262/test`
+  is absent; corpus rows skip only when their exact files are unavailable.
+- Focused and related tests, type/lint/format, budgets/ratchets, collision
+  checks, and full pre-push are clean.
+
+## Handoff
+
+The canonical issue is #5118, already reserved by the root agent. No GitHub
+issue is to be allocated or created from this lane. The delivery branch is
+`codex/5118-es2015-error-symbol-coercion` in
+`/private/tmp/js2-es2015-error-symbol-coercion-20260828`; root owns review and
+the single non-draft PR against `loopdive/js2:main` after this branch is pushed.

--- a/plan/issues/5118-es2015-error-symbol-coercion.md
+++ b/plan/issues/5118-es2015-error-symbol-coercion.md
@@ -1,7 +1,7 @@
 ---
 id: 5118
 title: "ES2015 standalone Error ToString(Symbol) must throw TypeError"
-status: in-progress
+status: ready
 sprint: current
 created: 2026-08-28
 updated: 2026-08-28
@@ -192,8 +192,25 @@ baseline and regression cohort.
 
 ## Handoff
 
-The canonical issue is #5118, already reserved by the root agent. No GitHub
-issue is to be allocated or created from this lane. The delivery branch is
-`codex/5118-es2015-error-symbol-coercion` in
-`/private/tmp/js2-es2015-error-symbol-coercion-20260828`; root owns review and
-the single non-draft PR against `loopdive/js2:main` after this branch is pushed.
+The canonical tracker is this markdown issue, `plan/issues/5118-es2015-error-symbol-coercion.md`;
+no GitHub issue was created. The implementation was synchronized with
+`upstream/main` and validated at code head
+`695893a6b7e519118644f0430de00e5c3b2f879d` on branch
+`codex/5118-es2015-error-symbol-coercion`.
+
+Final evidence on that head:
+
+- focused Vitest: **23/23 passed**;
+- exact Test262 host cohort: **3/3 passed**;
+- exact Test262 standalone cohort: **3/3 passed**;
+- standalone controls emitted zero host imports;
+- TypeScript 7, lint, Prettier, oracle/coercion ratchets, LOC budget, and
+  function budget passed;
+- the repository pre-push hook completed and the exact head was confirmed on
+  `ttraenkler/js2` without rewriting published history;
+- `git diff --check` passed, `upstream/main` is an ancestor, and the worktree
+  was clean after the push.
+
+The later handoff/PR-link commits are documentation-only and do not change the
+validated code. Root owns the single non-draft PR against `loopdive/js2:main`,
+then will record its upstream URL here and mark the issue done.

--- a/plan/issues/5118-es2015-error-symbol-coercion.md
+++ b/plan/issues/5118-es2015-error-symbol-coercion.md
@@ -8,7 +8,7 @@ updated: 2026-08-28
 priority: high
 horizon: s
 feasibility: medium
-reasoning_effort: medium
+reasoning_effort: max
 task_type: conformance
 area: codegen
 language_feature: error-symbol-coercion

--- a/plan/issues/5118-es2015-error-symbol-coercion.md
+++ b/plan/issues/5118-es2015-error-symbol-coercion.md
@@ -119,6 +119,23 @@ coercion outside this body is not widened.
   can carry Symbol (`symbol`, `any`, `unknown`, `unresolvable`, or a union
   containing one), so ordinary string messages do not gain the carrier cost.
 
+### Related unclassified rows
+
+The three same-seam `ToPrimitive` siblings are not classified as ES2015 in
+`test262-file-editions.json`, so they remain regression evidence rather than
+part of the authoritative cohort or exact-row test list. A fresh candidate
+run with the pinned QuickJS artifact and one worker reports host `pass` for
+all three but standalone `fail` for all three:
+
+- `built-ins/Error/error-message-tostring-toprimitive.js`
+- `built-ins/Error/prototype/toString/tostring-message-throws-toprimitive.js`
+- `built-ins/NativeErrors/nativeerror-tostring-message-throws-toprimitive.js`
+
+Their residual is the separate object `ToPrimitive`/method-coercion path; this
+bounded Symbol-only change intentionally does not widen into that helper. The
+follow-up should own those rows if that path is made strict, with a separate
+baseline and regression cohort.
+
 ## Bounded implementation plan
 
 1. Add a standalone-only Symbol message guard to the shared Error-family

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -32,7 +32,7 @@ import {
   type NativeProtoBuiltinGlue,
 } from "./native-proto.js";
 import { pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
-import { emitThrowTypeError } from "./expressions/helpers.js";
+import { buildThrowJsErrorInstrs, emitThrowTypeError } from "./expressions/helpers.js";
 import { ensureNativeArrayHof, NATIVE_HOF_METHODS, NATIVE_HOF_REDUCE } from "./hof-native.js"; // (#4394)
 import { emitArrayBufferProtoMemberBody, emitDataViewProtoMemberBody } from "./dataview-native.js";
 import { emitDateProtoMemberBody } from "./expressions/builtins.js"; // (#3219) reflective Date getter bodies
@@ -50,6 +50,7 @@ import {
   ensureAnyToStringHelper,
   ensureNativeStringHelpers,
   flatStringType,
+  nativeStringLiteralInstrs,
   stringConstantExternrefInstrs,
 } from "./native-strings.js";
 import { COLLECTION_KIND, MAP_LAYOUT, ensureMapHelpers } from "./map-runtime.js"; // (#3171) size getter
@@ -97,6 +98,7 @@ import {
 import { emitBuiltinNamespaceObject } from "./builtin-static-globals.js";
 import { emitFunctionProtoHasInstanceBody, FUNCTION_PROTO_HAS_INSTANCE_MEMBER } from "./function-proto-has-instance.js";
 import { emitSymbolProtoValueOfBody } from "./symbol-proto-valueof.js"; // (#4776)
+import { ensureSymbolCarrier, usesNativeSymbolProvider } from "./symbol-native.js";
 
 /**
  * `Array.prototype`'s own enumerable+non-enumerable method names (ES2024
@@ -301,6 +303,17 @@ const BOOLEAN_PROTO_METHODS = ["toString", "valueOf"] as const;
 /** `Error.prototype`'s own method names (ES2024 §20.5.3). `name`/`message` are
  * data properties (own on the proto), not methods. */
 const ERROR_PROTO_METHODS = ["toString"] as const;
+
+/** Error.prototype.toString is inherited by every NativeError prototype. */
+const ERROR_PROTO_OWNER_NAMES = new Set([
+  "Error",
+  "TypeError",
+  "RangeError",
+  "SyntaxError",
+  "URIError",
+  "EvalError",
+  "ReferenceError",
+]);
 
 /** (#2861) `NativeError.prototype`'s own method names — a `<NativeError>.prototype`
  * (TypeError/RangeError/ReferenceError/SyntaxError/EvalError/URIError) inherits
@@ -1758,6 +1771,210 @@ function makeCollectionGlue(brand: number, name: "Map" | "Set", members: readonl
   };
 }
 
+/**
+ * Emit the shared ES2015 §20.5.3.4 Error.prototype.toString body.
+ *
+ * The native-proto closure ABI supplies the function value in local 0 and the
+ * call's `this` value in local 1. Native `__extern_get` performs the ordinary
+ * property walk (including accessors), which keeps the required name-before-
+ * message Get order observable. The generic standalone ToString dispatcher is
+ * intentionally printable for `String(Symbol())`; this body adds the strict
+ * Symbol rejection required by Error.prototype.toString after each property
+ * read, without changing that general-purpose dispatcher.
+ */
+function emitErrorProtoToStringBody(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
+  if (!ctx.standalone) return null;
+
+  // Register all runtime dependencies before capturing function indices. The
+  // object runtime owns the native __extern_get implementation; no host import
+  // is admitted by this path under the standalone semantic provider.
+  ensureObjectRuntime(ctx);
+  // The reflective callee can be compiled before its argument expression. Make
+  // the native carrier available at body-mint time so the later `Symbol()`
+  // argument is still recognized by this already-emitted `ref.test` arm.
+  const symbolTypeIdx = usesNativeSymbolProvider(ctx) ? ensureSymbolCarrier(ctx) : -1;
+  ensureLateImport(ctx, "__typeof_object", [{ kind: "externref" }], [{ kind: "i32" }]);
+  ensureLateImport(ctx, "__typeof_function", [{ kind: "externref" }], [{ kind: "i32" }]);
+  flushLateImportShifts(ctx, fctx);
+  const anyToStringIdx = ensureAnyToStringHelper(ctx);
+  flushLateImportShifts(ctx, fctx);
+  const externGetIdx = ctx.funcMap.get("__extern_get");
+  const typeofUndefinedIdx = ctx.funcMap.get("__typeof_undefined");
+  const typeofObjectIdx = ctx.funcMap.get("__typeof_object");
+  const typeofFunctionIdx = ctx.funcMap.get("__typeof_function");
+  if (anyToStringIdx === undefined || externGetIdx === undefined) return null;
+  if (typeofObjectIdx === undefined || typeofFunctionIdx === undefined) return null;
+  const concatIdx = ctx.nativeStrHelpers.get("__str_concat");
+  if (concatIdx === undefined || ctx.anyStrTypeIdx < 0) return null;
+
+  const nameValue = allocLocal(fctx, `__error_tostring_name_${fctx.locals.length}`, { kind: "externref" });
+  const messageValue = allocLocal(fctx, `__error_tostring_message_${fctx.locals.length}`, { kind: "externref" });
+
+  const isUndefined = (valueLocal: number): Instr[] =>
+    typeofUndefinedIdx === undefined
+      ? [{ op: "local.get", index: valueLocal }, { op: "ref.is_null" }]
+      : [
+          { op: "local.get", index: valueLocal },
+          { op: "call", funcIdx: typeofUndefinedIdx },
+        ];
+
+  const strictToString = (valueLocal: number): Instr[] => {
+    const convert: Instr[] = [
+      { op: "local.get", index: valueLocal },
+      { op: "any.convert_extern" },
+      { op: "call", funcIdx: anyToStringIdx },
+      { op: "extern.convert_any" },
+    ];
+    if (symbolTypeIdx < 0) return convert;
+    return [
+      { op: "local.get", index: valueLocal },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: symbolTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot convert a Symbol value to a string", {
+          forceInModuleCtor: true,
+        }),
+      },
+      ...convert,
+    ];
+  };
+
+  const key = (value: string): Instr[] => {
+    addStringConstantGlobal(ctx, value);
+    return stringConstantExternrefInstrs(ctx, value);
+  };
+
+  const propertyToString = (valueLocal: number, defaultValue: string): Instr[] => [
+    ...isUndefined(valueLocal),
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: key(defaultValue),
+      else: strictToString(valueLocal),
+    },
+  ];
+
+  // §20.5.3.4 step 2 is the full Type(V)-is-Object guard, not merely
+  // RequireObjectCoercible: numbers, strings, booleans, and Symbols must all
+  // throw before either property is read. `__typeof_object` intentionally
+  // reports the Symbol carrier as object-like, so subtract that carrier after
+  // OR-ing the object and function classifiers. The null/undefined rejection
+  // remains a separate first check because `typeof null` is "object".
+  const rejectNullishReceiver: Instr[] = [{ op: "local.get", index: 1 }, { op: "ref.is_null" }];
+  if (typeofUndefinedIdx !== undefined) {
+    rejectNullishReceiver.push(
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: typeofUndefinedIdx },
+      { op: "i32.or" },
+    );
+  }
+  rejectNullishReceiver.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot convert undefined or null to object", {
+      forceInModuleCtor: true,
+    }),
+  });
+
+  fctx.body.push(...rejectNullishReceiver);
+
+  const isObjectValue: Instr[] = [
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: typeofObjectIdx },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: typeofFunctionIdx },
+    { op: "i32.or" },
+  ];
+  if (symbolTypeIdx >= 0) {
+    isObjectValue.push(
+      { op: "local.get", index: 1 },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: symbolTypeIdx },
+      { op: "i32.eqz" },
+      { op: "i32.and" },
+    );
+  }
+  fctx.body.push(
+    ...isObjectValue,
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: buildThrowJsErrorInstrs(ctx, "TypeError", "Error.prototype.toString called on a non-object", {
+        forceInModuleCtor: true,
+      }),
+    },
+  );
+
+  // §20.5.3.4 steps 3-4: Get/ToString(name) precedes any message access.
+  fctx.body.push(
+    { op: "local.get", index: 1 },
+    ...key("name"),
+    { op: "call", funcIdx: externGetIdx },
+    { op: "local.set", index: nameValue },
+    ...propertyToString(nameValue, "Error"),
+    { op: "local.set", index: nameValue },
+  );
+
+  // §20.5.3.4 steps 5-6: Get/ToString(message), after name has completed.
+  fctx.body.push(
+    { op: "local.get", index: 1 },
+    ...key("message"),
+    { op: "call", funcIdx: externGetIdx },
+    { op: "local.set", index: messageValue },
+    ...propertyToString(messageValue, ""),
+    { op: "local.set", index: messageValue },
+  );
+
+  // Steps 7-9: empty-name / empty-message cases, followed by `name + ": " +
+  // message`. `__str_concat` is already a dependency of __any_to_string.
+  const nameLength = (): Instr[] => [
+    { op: "local.get", index: nameValue },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+    { op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 },
+  ];
+  const messageLength = (): Instr[] => [
+    { op: "local.get", index: messageValue },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+    { op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 },
+  ];
+  fctx.body.push(
+    ...nameLength(),
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [{ op: "local.get", index: messageValue }],
+      else: [
+        ...messageLength(),
+        { op: "i32.eqz" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: [{ op: "local.get", index: nameValue }],
+          else: [
+            { op: "local.get", index: nameValue },
+            { op: "any.convert_extern" },
+            { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+            ...nativeStringLiteralInstrs(ctx, ": "),
+            { op: "call", funcIdx: concatIdx },
+            { op: "local.get", index: messageValue },
+            { op: "any.convert_extern" },
+            { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+            { op: "call", funcIdx: concatIdx },
+            { op: "extern.convert_any" },
+          ],
+        },
+      ],
+    },
+  );
+  return { kind: "externref" };
+}
+
 function makeGlue(
   ctx: CodegenContext,
   brand: number,
@@ -1808,6 +2025,10 @@ function makeGlue(
     // members + all Object members still degrade to a catchable TypeError.
     emitMemberBody: (c, fctx, member) =>
       (name === "Symbol" && member === "valueOf" ? emitSymbolProtoValueOfBody(c, fctx) : null) ??
+      // ES2015 §20.5.3.4 — Error.prototype.toString is inherited by each
+      // NativeError prototype, so all of those glues share the same ordered
+      // property-read and Symbol-rejecting body.
+      (member === "toString" && ERROR_PROTO_OWNER_NAMES.has(name) ? emitErrorProtoToStringBody(c, fctx) : null) ??
       // (#4491 wave-5 T2) `this<X>Value(this)` for the three primitive-wrapper
       // families (§21.1.3.7 / §22.1.3.28 / §20.3.3.3). Routed FIRST so it
       // serves String too — `emitStringProtoMemberBody` would otherwise claim

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -287,6 +287,8 @@ import {
   ensureArrayNativeProtoGlue,
   ensureDataViewNativeProtoGlue,
   ensureDateNativeProtoGlue,
+  ensureErrorNativeProtoGlue,
+  ensureNativeErrorNativeProtoGlue,
   ensureNumberNativeProtoGlue,
   ensureBooleanNativeProtoGlue,
   ensureObjectNativeProtoGlue,
@@ -1206,6 +1208,56 @@ function tryEmitNativeProtoReflectiveCall(
   {
     const syntactic = wrapperProtoSyntacticMember(ctx, unwrapTransparent(receiver), member);
     if (syntactic !== undefined) ({ member, ifaceName } = syntactic);
+  }
+
+  // TypeScript declares `Error.prototype.toString` through the broad Object
+  // method signature, so the member symbol above can report `Object` even
+  // though the value read is an Error-family prototype. Recover the concrete
+  // owner from this exact intrinsic syntax before selecting the native-proto
+  // glue. This is intentionally limited to the Error family; other
+  // `<Builtin>.prototype.toString.call` forms retain their existing resolver.
+  {
+    const syntax = unwrapTransparent(receiver);
+    if (
+      ts.isPropertyAccessExpression(syntax) &&
+      syntax.name.text === "toString" &&
+      ts.isPropertyAccessExpression(syntax.expression) &&
+      syntax.expression.name.text === "prototype" &&
+      ts.isIdentifier(syntax.expression.expression)
+    ) {
+      const owner = resolveBuiltinNamespaceValueName(ctx, syntax.expression.expression);
+      if (
+        owner === "Error" ||
+        owner === "TypeError" ||
+        owner === "RangeError" ||
+        owner === "SyntaxError" ||
+        owner === "URIError" ||
+        owner === "EvalError" ||
+        owner === "ReferenceError"
+      ) {
+        ifaceName = owner;
+        // A direct object-literal argument normally receives a closed
+        // WasmGC struct. Error.prototype.toString performs dynamic [[Get]], so
+        // promote this exact receiver (and a one-hop variable initializer) to
+        // the open object carrier before pushReflectiveCallReceiver compiles
+        // it. Other prototype calls keep their existing representation.
+        const receiverArg = expr.arguments[0];
+        const receiverArgUnwrapped = receiverArg === undefined ? undefined : unwrapTransparent(receiverArg);
+        if (receiverArgUnwrapped && ts.isObjectLiteralExpression(receiverArgUnwrapped)) {
+          ctx.dynamicProtoLiteralNodes.add(receiverArgUnwrapped);
+        } else if (receiverArgUnwrapped && ts.isIdentifier(receiverArgUnwrapped)) {
+          const declaration = ctx.oracle.valueDeclarationOf(receiverArgUnwrapped);
+          if (
+            declaration &&
+            ts.isVariableDeclaration(declaration) &&
+            declaration.initializer &&
+            ts.isObjectLiteralExpression(declaration.initializer)
+          ) {
+            ctx.dynamicProtoLiteralNodes.add(declaration.initializer);
+          }
+        }
+      }
+    }
   }
 
   // (#4119) `Object.prototype.toString.call(v)` written in its DIRECT syntactic
@@ -10012,6 +10064,21 @@ export function emitDynamicCombinatorArg(
 export function nativeProtoBrandForInterface(ctx: CodegenContext, ifaceName: string): number | undefined {
   if (ifaceName === "Array" || ifaceName === "ReadonlyArray") return ensureArrayNativeProtoGlue(ctx);
   if (ifaceName === "Object") return ensureObjectNativeProtoGlue(ctx);
+  // ES2015 Error.prototype.toString is a reflective native-proto member just
+  // like the other standalone Error-family prototype methods. Keep this
+  // resolver arm narrow: the shared body in array-object-proto.ts owns the
+  // actual ordered Get/ToString semantics and NativeError inheritance.
+  if (ifaceName === "Error") return ensureErrorNativeProtoGlue(ctx);
+  if (
+    ifaceName === "TypeError" ||
+    ifaceName === "RangeError" ||
+    ifaceName === "SyntaxError" ||
+    ifaceName === "URIError" ||
+    ifaceName === "EvalError" ||
+    ifaceName === "ReferenceError"
+  ) {
+    return ensureNativeErrorNativeProtoGlue(ctx, ifaceName);
+  }
   if (ifaceName === "String") return ensureStringNativeProtoGlue(ctx); // (#2875)
   if (ifaceName === "DataView") return ensureDataViewNativeProtoGlue(ctx); // (#3173)
   if (ifaceName === "ArrayBuffer") return ensureArrayBufferNativeProtoGlue(ctx); // (#1595)

--- a/src/codegen/expressions/new-builtin-globals.ts
+++ b/src/codegen/expressions/new-builtin-globals.ts
@@ -44,10 +44,11 @@ import {
   isGlobalFunctionIdentifier,
   tryStaticNewFunction,
 } from "./eval-inline.js";
-import { emitThrowTypeError, noJsHost } from "./helpers.js";
+import { buildThrowJsErrorInstrs, emitThrowTypeError, noJsHost } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { emitNewBooleanToBooleanArg } from "../new-boolean-tobooleanarg.js"; // (#4619)
 import { emitSymbolOperandCoercionThrow } from "../tonumber-symbol-throw.js"; // (#3481)
+import { ensureSymbolCarrier } from "../symbol-native.js";
 import { emitHostTypedArrayCarrierRegistration } from "./typed-array-host-carrier.js";
 import {
   emitHostTaBufferConstruct,
@@ -71,6 +72,27 @@ function isDynamicMaybeStringArg(ctx: CodegenContext, arg: ts.Expression): boole
   const fact = ctx.oracle.typeFactOf(arg);
   if (fact.kind === "any" || fact.kind === "unknown" || fact.kind === "unresolvable") return true;
   return fact.kind === "union" && fact.parts.some((p) => p.kind === "string");
+}
+
+/**
+ * Whether an Error message can carry a native Symbol at runtime. Keep the
+ * strict dynamic carrier arm out of statically ordinary string/number/object
+ * messages so those existing constructor bodies remain byte-identical; an
+ * oracle `symbol`, `any`, `unknown`, `unresolvable`, or union containing one
+ * is the bounded set whose value may be a Symbol.
+ */
+function errorMessageMayCarrySymbol(ctx: CodegenContext, arg: ts.Expression): boolean {
+  const fact = ctx.oracle.typeFactOf(arg);
+  if (fact.kind === "symbol" || fact.kind === "any" || fact.kind === "unknown" || fact.kind === "unresolvable") {
+    return true;
+  }
+  return (
+    fact.kind === "union" &&
+    fact.parts.some(
+      (part) =>
+        part.kind === "symbol" || part.kind === "any" || part.kind === "unknown" || part.kind === "unresolvable",
+    )
+  );
 }
 
 /**
@@ -463,8 +485,39 @@ export function tryCompileBuiltinGlobalNew(
       (ctorName === "Test262Error" && !test262StandaloneUserFn)
     ) {
       const args = expr.arguments ?? [];
+      // §7.1.17 step 3 — Error construction performs a strict ToString on a
+      // supplied message. Native Symbols are represented as branded i32 ids,
+      // so compiling one directly as externref would otherwise box it and let
+      // the permissive general-purpose __any_to_string fallback continue.
+      // Evaluate the argument (including side effects) before the catchable
+      // TypeError, then stop this constructor path. Host mode keeps its real JS
+      // constructor and therefore its existing coercion semantics.
+      if (
+        ctx.targetProfile.semanticProviders === "native-first" &&
+        args.length >= 1 &&
+        !isStaticUndefinedExpr(args[0]!, fctx) &&
+        ctx.oracle.staticJsTypeOf(args[0]!) === "symbol"
+      ) {
+        // ArgumentListEvaluation completes before the constructor's message
+        // ToString step. In particular, `new Error(Symbol(), later())` must
+        // run `later()` (and let an abrupt completion from it win) before the
+        // TypeError for the first argument. The shared single-operand helper
+        // intentionally throws immediately, so this whole-argument form is
+        // kept local to Error constructors.
+        for (const arg of args) {
+          const argType = compileExpression(ctx, fctx, arg);
+          if (argType !== null) fctx.body.push({ op: "drop" });
+        }
+        emitThrowTypeError(ctx, fctx, "Cannot convert a Symbol value to a string");
+        return { kind: "externref" };
+      }
+      // ArgumentListEvaluation completes before the constructor's message
+      // ToString step. Keep the first value in a local while evaluating every
+      // later argument in source order; otherwise a dynamic first message
+      // (for example `const m: any = Symbol(); new Error(m, later())`) would
+      // coerce/throw before `later()` ran, or skip `later()` entirely.
+      const msgTmp = allocTempLocal(fctx, { kind: "externref" });
       if (args.length >= 1 && !isStaticUndefinedExpr(args[0]!, fctx)) {
-        // Compile the message argument to externref
         const resultType = compileExpression(ctx, fctx, args[0]!, {
           kind: "externref",
         });
@@ -474,6 +527,11 @@ export function tryCompileBuiltinGlobalNew(
       } else {
         // No message — push null externref (undefined message)
         fctx.body.push({ op: "ref.null.extern" });
+      }
+      fctx.body.push({ op: "local.set", index: msgTmp });
+      for (let i = 1; i < args.length; i++) {
+        const argType = compileExpression(ctx, fctx, args[i]!);
+        if (argType !== null) fctx.body.push({ op: "drop" });
       }
       // (#2969) §20.5.1.1 step 3 — `msg = ToString(message)` at CONSTRUCTION
       // time. In standalone/WASI the native `__new_<Name>` ctor stores its arg
@@ -500,26 +558,57 @@ export function tryCompileBuiltinGlobalNew(
         if (ctx.funcMap.get("number_toString") === undefined) {
           emitNativeNumberFormat(ctx, new Set(["number_toString"]));
         }
+        // The Error constructor body can be minted before the caller that
+        // supplies an `any`-typed Symbol. Register the native carrier before
+        // baking the dynamic ref.test, so that callee-before-caller compilation
+        // cannot leave the strict ToString arm absent.
+        const symbolTypeIdx =
+          ctx.targetProfile.semanticProviders === "native-first" && errorMessageMayCarrySymbol(ctx, args[0]!)
+            ? ensureSymbolCarrier(ctx)
+            : -1;
         const anyToStrIdx = ensureAnyToStringHelper(ctx);
         if (anyToStrIdx >= 0) {
-          const msgTmp = allocTempLocal(fctx, { kind: "externref" });
-          fctx.body.push({ op: "local.set", index: msgTmp }, ...emitNullOrUndefinedMessageTest(ctx, msgTmp), {
-            op: "if",
-            blockType: { kind: "val", type: { kind: "externref" } },
-            // undefined / null argument → keep null (renders name alone).
-            then: [{ op: "ref.null.extern" }],
-            // ToString(message): externref → anyref → __any_to_string
-            // (ref $AnyString) → externref for the ctor's $message field.
-            else: [
-              { op: "local.get", index: msgTmp },
-              { op: "any.convert_extern" },
-              { op: "call", funcIdx: anyToStrIdx },
-              { op: "extern.convert_any" },
-            ],
-          });
-          releaseTempLocal(fctx, msgTmp);
+          fctx.body.push(
+            ...emitNullOrUndefinedMessageTest(ctx, msgTmp),
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "externref" } },
+              // undefined / null argument → keep null (renders name alone).
+              then: [{ op: "ref.null.extern" }],
+              // ToString(message): externref → anyref → __any_to_string
+              // (ref $AnyString) → externref for the ctor's $message field.
+              else: [
+                // Dynamic `any` expressions can still carry a native Symbol
+                // after the static guard above has declined. Check the branded
+                // carrier immediately before the strict ToString call; the
+                // throwing branch is stack-polymorphic and preserves all prior
+                // argument evaluation.
+                ...(symbolTypeIdx >= 0
+                  ? [
+                      { op: "local.get", index: msgTmp } as const,
+                      { op: "any.convert_extern" } as const,
+                      { op: "ref.test", typeIdx: symbolTypeIdx } as const,
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot convert a Symbol value to a string", {
+                          forceInModuleCtor: true,
+                        }),
+                      } as const,
+                    ]
+                  : []),
+                { op: "local.get", index: msgTmp },
+                { op: "any.convert_extern" },
+                { op: "call", funcIdx: anyToStrIdx },
+                { op: "extern.convert_any" },
+              ],
+            },
+            { op: "local.set", index: msgTmp },
+          );
         }
       }
+      fctx.body.push({ op: "local.get", index: msgTmp });
+      releaseTempLocal(fctx, msgTmp);
       // (#1104 Phase 1) In WASI/standalone mode, the JS host is unavailable —
       // use a Wasm-native `__new_<Name>` function that builds a `$Error_struct`
       // instead of a `env.__new_<Name>` host import that would leave the

--- a/tests/issue-5118-es2015-error-symbol-coercion.test.ts
+++ b/tests/issue-5118-es2015-error-symbol-coercion.test.ts
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+const TEST262_ROOT = fileURLToPath(new URL("../test262/", import.meta.url));
+const EXACT_ROWS = [
+  "built-ins/Error/error-message-tostring-symbol.js",
+  "built-ins/Error/prototype/toString/tostring-message-throws-symbol.js",
+  "built-ins/NativeErrors/nativeerror-tostring-message-throws-symbol.js",
+] as const;
+const CORPUS_AVAILABLE = EXACT_ROWS.every((row) => existsSync(join(TEST262_ROOT, "test", row)));
+
+const CONTROL_SOURCE = `
+let trace = 0;
+
+function makeDynamicError(message: any): any {
+  return Error(message);
+}
+
+export function staticConstructorSymbol(): number {
+  trace = 0;
+  try {
+    new Error((trace += 1, Symbol()));
+  } catch (error) {
+    return error instanceof TypeError && trace === 1 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function dynamicConstructorSymbol(): number {
+  trace = 0;
+  const message: any = Symbol();
+  try {
+    new Error(message);
+  } catch (error) {
+    return error instanceof TypeError && trace === 0 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function dynamicCalleeBeforeCaller(): number {
+  try {
+    makeDynamicError(Symbol());
+  } catch (error) {
+    return error instanceof TypeError ? 1 : 0;
+  }
+  return 0;
+}
+
+export function laterArgumentWins(): number {
+  trace = 0;
+  function symbolMessage(): symbol {
+    trace = trace * 10 + 1;
+    return Symbol();
+  }
+  function abruptLater(): any {
+    trace = trace * 10 + 2;
+    throw new Error("later");
+  }
+  try {
+    new Error(symbolMessage(), abruptLater());
+  } catch (error) {
+    return error instanceof Error && !(error instanceof TypeError) && trace === 12 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function dynamicConstructorLaterArgumentWins(): number {
+  trace = 0;
+  const dynamicMessage: any = Symbol();
+  function readMessage(): any {
+    trace = trace * 10 + 1;
+    return dynamicMessage;
+  }
+  function abruptLater(): any {
+    trace = trace * 10 + 2;
+    throw new Error("later");
+  }
+  try {
+    new Error(readMessage(), abruptLater());
+  } catch (error) {
+    return error instanceof Error && !(error instanceof TypeError) && trace === 12 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function dynamicCallLaterArgumentWins(): number {
+  trace = 0;
+  const dynamicMessage: any = Symbol();
+  function readMessage(): any {
+    trace = trace * 10 + 1;
+    return dynamicMessage;
+  }
+  function abruptLater(): any {
+    trace = trace * 10 + 2;
+    throw new Error("later");
+  }
+  try {
+    Error(readMessage(), abruptLater());
+  } catch (error) {
+    return error instanceof Error && !(error instanceof TypeError) && trace === 12 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function positiveMessages(): number {
+  const withString: any = new Error("ok");
+  const withUndefined: any = new Error(undefined);
+  return withString.message === "ok" && String(withUndefined) === "Error" ? 1 : 0;
+}
+
+export function prototypeSymbol(): number {
+  try {
+    Error.prototype.toString.call({ message: Symbol() });
+  } catch (error) {
+    return error instanceof TypeError ? 1 : 0;
+  }
+  return 0;
+}
+
+export function prototypeDynamicSymbol(): number {
+  const message: any = Symbol();
+  const value: any = { message };
+  try {
+    Error.prototype.toString.call(value);
+  } catch (error) {
+    return error instanceof TypeError ? 1 : 0;
+  }
+  return 0;
+}
+
+export function prototypePrimitiveReceiver(): number {
+  try {
+    Error.prototype.toString.call(null);
+  } catch (error) {
+    return error instanceof TypeError ? 1 : 0;
+  }
+  return 0;
+}
+
+export function prototypePrimitiveReceivers(): number {
+  const numberReceiver: any = 1;
+  const stringReceiver: any = "x";
+  const booleanReceiver: any = true;
+  const symbolReceiver: any = Symbol();
+  try {
+    Error.prototype.toString.call(numberReceiver);
+    return 0;
+  } catch (error) {
+    if (!(error instanceof TypeError)) return 0;
+  }
+  try {
+    Error.prototype.toString.call(stringReceiver);
+    return 0;
+  } catch (error) {
+    if (!(error instanceof TypeError)) return 0;
+  }
+  try {
+    Error.prototype.toString.call(booleanReceiver);
+    return 0;
+  } catch (error) {
+    if (!(error instanceof TypeError)) return 0;
+  }
+  try {
+    Error.prototype.toString.call(symbolReceiver);
+    return 0;
+  } catch (error) {
+    return error instanceof TypeError ? 1 : 0;
+  }
+}
+
+export function prototypeOrder(): number {
+  trace = 0;
+  const value: any = {
+    get name() {
+      trace = trace * 10 + 1;
+      return "N";
+    },
+    get message() {
+      trace = trace * 10 + 2;
+      return Symbol();
+    },
+  };
+  try {
+    Error.prototype.toString.call(value);
+  } catch (error) {
+    return error instanceof TypeError && trace === 12 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function prototypeNameSymbolOrder(): number {
+  trace = 0;
+  const value: any = {
+    get name() {
+      trace = 1;
+      return Symbol();
+    },
+    get message() {
+      trace = 2;
+      return "M";
+    },
+  };
+  try {
+    Error.prototype.toString.call(value);
+  } catch (error) {
+    return error instanceof TypeError && trace === 1 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function prototypeValues(): number {
+  const ordinary: any = { name: "N", message: "M" };
+  const emptyName: any = { name: "", message: "M" };
+  const emptyMessage: any = { name: "N", message: "" };
+  const bothEmpty: any = { name: "", message: "" };
+  const ordinaryObjects: any = { name: {}, message: {} };
+  const callable: any = () => {};
+  const array: any = [];
+  const inherited: any = Object.create({ message: "M" });
+  inherited.name = "N";
+  const nativeError: any = new TypeError("M");
+  return (
+    Error.prototype.toString.call(ordinary) === "N: M" &&
+    Error.prototype.toString.call(emptyName) === "M" &&
+    Error.prototype.toString.call(emptyMessage) === "N" &&
+    Error.prototype.toString.call(bothEmpty) === "" &&
+    Error.prototype.toString.call(inherited) === "N: M" &&
+    Error.prototype.toString.call(ordinaryObjects) === "[object Object]: [object Object]" &&
+    Error.prototype.toString.call(callable) === "callable" &&
+    Error.prototype.toString.call(array) === "Error" &&
+    TypeError.prototype.toString.call(nativeError) === "TypeError: M"
+  )
+    ? 1
+    : 0;
+}
+`;
+
+const HOST_CONTROL_SOURCE = `
+let trace = 0;
+
+export function newLaterArgumentWins(): number {
+  trace = 0;
+  const message: any = Symbol();
+  function readMessage(): any {
+    trace = trace * 10 + 1;
+    return message;
+  }
+  function abruptLater(): any {
+    trace = trace * 10 + 2;
+    throw new Error("later");
+  }
+  try {
+    new Error(readMessage(), abruptLater());
+  } catch (error) {
+    return error instanceof Error && !(error instanceof TypeError) && trace === 12 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function callLaterArgumentWins(): number {
+  trace = 0;
+  const message: any = Symbol();
+  function readMessage(): any {
+    trace = trace * 10 + 1;
+    return message;
+  }
+  function abruptLater(): any {
+    trace = trace * 10 + 2;
+    throw new Error("later");
+  }
+  try {
+    Error(readMessage(), abruptLater());
+  } catch (error) {
+    return error instanceof Error && !(error instanceof TypeError) && trace === 12 ? 1 : 0;
+  }
+  return 0;
+}
+
+export function positiveMessage(): number {
+  const error: any = new Error("ok");
+  return error.message === "ok" ? 1 : 0;
+}
+`;
+
+type Controls = {
+  exports: Record<string, () => unknown>;
+  imports: WebAssembly.ModuleImportDescriptor[];
+};
+
+let standaloneControlsPromise: Promise<Controls> | undefined;
+let hostControlsPromise: Promise<Controls> | undefined;
+
+async function compileControls(source: string, target: "standalone" | undefined, fileName: string): Promise<Controls> {
+  const result = await compile(source, {
+    fileName,
+    ...(target === undefined ? {} : { target }),
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success).toBe(true);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const imports = WebAssembly.Module.imports(new WebAssembly.Module(result.binary));
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  result.importObject?.__setExports?.(instance.exports);
+  return { exports: wrapExports(instance.exports, { signatures: result.exportSignatures }), imports };
+}
+
+async function compileHostControls(): Promise<Controls> {
+  return compileControls(HOST_CONTROL_SOURCE, undefined, "issue-5118-host-controls.ts");
+}
+
+function runStandaloneControls(): Promise<Controls> {
+  standaloneControlsPromise ??= compileControls(CONTROL_SOURCE, "standalone", "issue-5118-controls.ts");
+  return standaloneControlsPromise;
+}
+
+function runHostControls(): Promise<Controls> {
+  hostControlsPromise ??= compileHostControls();
+  return hostControlsPromise;
+}
+
+describe("#5118 — standalone Error ToString(Symbol) coercion", () => {
+  it("keeps the standalone compiler host-free", async () => {
+    const { imports } = await runStandaloneControls();
+    expect(imports).toEqual([]);
+  }, 180_000);
+
+  it("throws the real TypeError after evaluating a static Symbol message", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.staticConstructorSymbol()).toBe(1);
+  }, 180_000);
+
+  it("throws the real TypeError for a dynamic Symbol carrier", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.dynamicConstructorSymbol()).toBe(1);
+  }, 180_000);
+
+  it("keeps the dynamic Symbol guard when the Error callee compiles first", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.dynamicCalleeBeforeCaller()).toBe(1);
+  }, 180_000);
+
+  it("evaluates later constructor arguments before the Symbol ToString throw", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.laterArgumentWins()).toBe(1);
+  }, 180_000);
+
+  it("evaluates later arguments after a dynamic first message for new Error", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.dynamicConstructorLaterArgumentWins()).toBe(1);
+  }, 180_000);
+
+  it("evaluates later arguments after a dynamic first message for Error calls", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.dynamicCallLaterArgumentWins()).toBe(1);
+  }, 180_000);
+
+  it("preserves ordinary string and undefined Error messages", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.positiveMessages()).toBe(1);
+  }, 180_000);
+
+  it("throws TypeError for a Symbol message through Error.prototype.toString", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.prototypeSymbol()).toBe(1);
+  }, 180_000);
+
+  it("rejects a dynamic Symbol carrier after the object receiver check", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.prototypeDynamicSymbol()).toBe(1);
+  }, 180_000);
+
+  it("applies the full object receiver check to Error.prototype.toString", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.prototypePrimitiveReceiver()).toBe(1);
+  }, 180_000);
+
+  it("rejects every primitive Error.prototype.toString receiver", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.prototypePrimitiveReceivers()).toBe(1);
+  }, 180_000);
+
+  it("keeps name Get/ToString before message Get/ToString", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.prototypeOrder()).toBe(1);
+  }, 180_000);
+
+  it("throws from name ToString before reading message", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.prototypeNameSymbolOrder()).toBe(1);
+  }, 180_000);
+
+  it("preserves positive, empty, inherited, and NativeError prototype behavior", async () => {
+    const { exports } = await runStandaloneControls();
+    expect(exports.prototypeValues()).toBe(1);
+  }, 180_000);
+});
+
+describe("#5118 — host Error constructor argument evaluation", () => {
+  it("evaluates later arguments before host Error constructor coercion", async () => {
+    const { exports } = await runHostControls();
+    expect(exports.newLaterArgumentWins()).toBe(1);
+    expect(exports.callLaterArgumentWins()).toBe(1);
+  }, 180_000);
+
+  it("preserves ordinary host Error messages", async () => {
+    const { exports } = await runHostControls();
+    expect(exports.positiveMessage()).toBe(1);
+  }, 180_000);
+});
+
+describe.skipIf(!CORPUS_AVAILABLE)("#5118 — exact Test262 corpus rows", () => {
+  it.each(EXACT_ROWS)(
+    "passes %s in the host lane",
+    async (row) => {
+      const result = await runTest262File(join(TEST262_ROOT, "test", row), "issue-5118-host", 180_000);
+      expect(result.status).toBe("pass");
+    },
+    200_000,
+  );
+
+  it.each(EXACT_ROWS)(
+    "passes %s in standalone",
+    async (row) => {
+      const result = await runTest262File(
+        join(TEST262_ROOT, "test", row),
+        "issue-5118-standalone",
+        180_000,
+        "standalone",
+      );
+      expect(result.status).toBe("pass");
+    },
+    200_000,
+  );
+});


### PR DESCRIPTION
## Description

- Problem: standalone Error and NativeError construction, plus `Error.prototype.toString`, accepted native Symbol values where ES2015 requires strict `ToString` to throw a `TypeError`.
- Behavior: reject static and dynamic Symbol carriers after complete argument evaluation, preserve later-abrupt-completion priority, and implement the ordered `name`/`message` reads and coercions for reflective Error-family `toString` calls.
- Tests: the focused regression suite passes 23/23; all three exact Test262 rows pass in both host (3/3) and standalone (3/3); standalone controls emit zero host imports.
- Quality: TypeScript 5 and 7, lint, Prettier, oracle/coercion ratchets, LOC/function budgets, numeric-local parity, issue integrity, and the full pre-push hook passed on the synchronized branch.
- Tracking: `plan/issues/5118-es2015-error-symbol-coercion.md` contains the implementation plan, evidence, and handoff. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
