### PR TITLE
feat(ir): own exact Math.round calls

### DIFF
--- a/plan/issues/5117-ir-exact-ambient-math-round.md
+++ b/plan/issues/5117-ir-exact-ambient-math-round.md
@@ -1,0 +1,161 @@
+---
+id: 5117
+title: "IR: own exact ambient Math.round calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5117-ir-math-round
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5116]
+related: [87, 249, 1371, 1732, 3141, 3526, 4787, 5092, 5116]
+files:
+  - src/stdlib/math.ts
+  - src/codegen/index.ts
+  - src/codegen/math-helpers.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/codegen.test.ts
+  - tests/equivalence/issue-1371.test.ts
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-5117-ir-math-round.test.ts
+loc-budget-allow:
+  - src/stdlib/math.ts
+  - src/codegen/index.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+---
+
+# #5117 — Exact ambient `Math.round` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.round(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent the source call as the twenty-eighth versioned pure-Math
+intrinsic and materialize it through one dependency-free, host-free
+self-hosted provider while excluded forms retain direct codegen.
+
+This checkpoint is intentionally stacked on #5129/#5116. It preserves the
+established direct algorithm exactly, including ties toward positive infinity,
+signed zero, NaN payload behavior, infinities, subnormals, and large integral
+f64 values.
+
+## Measured residual and feasibility
+
+`round` is absent from `IR_MATH_METHOD_TABLE`, so exact numeric calls currently
+emit legacy bodies. `compileMathCall` already implements the correct algorithm
+without the incorrect `floor(x + 0.5)` shortcut: compute `floor(x)`, compare the
+fraction with `0.5`, select `ceil(x)` or the floor, then restore the required
+zero sign. This makes `-1.5 -> -1`, `-0.5 -> -0`, `[-0.5, -0) -> -0`, and
+preserves already-integral large f64 values.
+
+A Luna Max dialect probe compiled an ordinary TypeScript mirror through the
+current self-hosted IR pipeline and matched direct host/standalone behavior on
+edge values. No P0 feasibility blocker exists for WasmGC host or standalone.
+The P1 boundary is raw-bit parity for custom NaNs and signed zero. Linear
+callable providers remain unsupported and are not widened by this slice.
+
+## Exact admitted grammar
+
+Admit only a non-optional `Math.round(argument)` when `Math` is the unshadowed
+ambient binding, there is exactly one non-spread argument, the selector proves
+primitive `number`, symbolic Math helpers are available, and the containing
+unit passes ordinary ownership and call-graph gates. Aliased, computed,
+optional, shadowed, coercive, Symbol, spread, and wrong-arity forms remain
+direct.
+
+## Provider algorithm and contract
+
+The self-hosted body mirrors the direct schedule and must not canonicalize NaN
+with an early `0 / 0` arm:
+
+```ts
+export function Math_round(x: number): number {
+  let floorValue: number = Math.floor(x);
+  let fraction: number = x - floorValue;
+  let result: number = fraction >= 0.5 ? Math.ceil(x) : floorValue;
+  if (result === 0) {
+    if (x === 0) return x;
+    return x < 0 ? -0 : 0;
+  }
+  return result;
+}
+```
+
+`math.round` resolves to `selfhost.math.round` / `Math_round` with unary-f64
+signature, no manifest dependency, and no host capability. The source-level
+`Math.floor` and `Math.ceil` operations lower to existing native f64
+instructions inside the helper; they are not callable provider dependencies.
+
+## Implementation plan
+
+1. Add `ROUND_SOURCE` to `src/stdlib/math.ts`, register it in
+   `SELF_HOSTED_MATH`, include `round` in direct helper demand, and update the
+   self-hosted-family commentary. Keep the established direct fallback body.
+2. Add `math.round` to the closed intrinsic and runtime-feature vocabularies
+   with a unary-f64 signature and dependency-free `selfhost.math.round`
+   provider.
+3. Add `round` to `IR_MATH_METHOD_TABLE`, reuse the generic selection,
+   from-AST, manifest, and materialization path, and add the independent
+   `JS2WASM_IR_MATH_ROUND=0` rollback.
+4. Widen #3526 exhaustive vocabulary, integration, linear-legality, and
+   neutrality evidence from twenty-seven to twenty-eight source Math
+   intrinsics. Refresh stale tests that still describe `round` as a legacy
+   `f64.nearest` or unsupported path.
+5. Add focused host/standalone IR ownership, zero-import execution,
+   dependency-free provider closure, direct raw-bit parity, one-SSA-argument,
+   rollback, linear rejection, and pre-claim exclusion coverage. Pin custom
+   NaNs, both zeros, values adjacent to positive and negative half ties,
+   subnormals, infinities, and large representable integers.
+6. Re-run existing #249, #1371, Symbol-coercion, Math equivalence, and stdlib
+   regressions; run affected #3526 contracts, TypeScript 7, formatting,
+   lint/ratchets, and full pre-push hooks; then open a non-draft PR stacked on
+   #5129.
+
+## Acceptance criteria
+
+- Exact ambient one-number `Math.round` calls emit IR only and attach one
+  dependency-free, host-free self-hosted callable.
+- Host and zero-import standalone execution are raw-bit identical to direct
+  codegen across NaN payloads, signed zero, ties, subnormals, finite range
+  edges, and infinities.
+- Ties remain toward positive infinity, `[-0.5, -0)` remains negative zero,
+  and already-integral large values remain unchanged.
+- Linear legality rejects the callable provider without widening the five
+  native linear Math intrinsics.
+- Coercive and all other excluded shapes preserve direct behavior and decline
+  before claim without invariants or post-claim errors.
+- The narrow rollback, affected regressions, TypeScript 7, and all pre-push
+  gates pass.
+
+## Non-goals
+
+- General ToNumber coercion, aliases, computed/extracted calls, optional
+  chaining, `.call`, or `.apply`.
+- A new rounding algorithm, native linear `Math.round`, `Math.fround`,
+  `Math.clz32`, `Math.imul`, variadic Math methods, or Number formatting.
+- `Math.random`; RNG requires a stateful effect and target-capability design.
+- Async, class, module-init, or broader ownership expansion.
+
+## Risk and rollback
+
+The primary risks are accidentally canonicalizing NaN, losing negative zero,
+or using the wrong tie rule while moving the established direct schedule into
+source. Raw-bit direct/IR parity is the migration invariant.
+`JS2WASM_IR_MATH_ROUND=0` provides narrow rollback;
+`JS2WASM_IR_FIRST=0` remains the global control.

--- a/plan/issues/5117-ir-exact-ambient-math-round.md
+++ b/plan/issues/5117-ir-exact-ambient-math-round.md
@@ -1,7 +1,7 @@
 ---
 id: 5117
 title: "IR: own exact ambient Math.round calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -142,6 +142,34 @@ instructions inside the helper; they are not callable provider dependencies.
   before claim without invariants or post-claim errors.
 - The narrow rollback, affected regressions, TypeScript 7, and all pre-push
   gates pass.
+
+## Implementation outcome and validation
+
+- `math.round` is the twenty-eighth certified pure Math intrinsic. Exact
+  ambient one-number calls now emit IR-only bodies and resolve through the
+  dependency-free `selfhost.math.round` provider and `Math_round` symbol.
+- The self-hosted source mirrors the established floor/fraction/ceil schedule.
+  Raw-bit direct/IR parity passes for custom positive and negative NaNs, both
+  zeros, adjacent half ties, subnormals, finite range edges, large integral
+  values, and infinities. Ties remain toward positive infinity and
+  `[-0.5, 0)` remains negative zero.
+- Host execution requests no Math import; standalone execution has zero Wasm
+  imports. The manifest closure contains only `math.round`, with no dependency
+  or host capability, and the intrinsic carries one SSA argument.
+- Shadowed, aliased, computed, optional-invocation, optional-receiver,
+  wrong-arity, spread, and non-number forms decline before claim. Symbol and
+  coercive forms retain the direct path and established `TypeError` behavior.
+- Focused ownership tests pass 14/14, affected #3526 manifest, integration,
+  and linear-legality suites pass 13/13, and scoped #249, #1371, Symbol,
+  equivalence, and codegen regressions pass 9/9. TypeScript 7,
+  kind-neutrality, Prettier, Biome, LOC/function budgets, oracle/coercion
+  ratchets, numeric-local parity (18/18), and issue integrity pass.
+- Luna Max final review returned GO with no P0/P1 finding and independently
+  confirmed NaN payload parity, signed zero, the tie rule, large integrals,
+  one evaluation, provider materialization, fallbacks, rollback, linear
+  legality, and all twenty-eight-entry contracts.
+- PR #5132 is open non-draft and mergeable, stacked directly on #5129's exact
+  `Math.sign` ownership branch with CLA green and merge automation armed.
 
 ## Non-goals
 

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 27 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 28 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -353,7 +353,7 @@
       "verdict": "unresolved",
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 27 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 28 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
       "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:34"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -10246,6 +10246,7 @@ export const MATH_HOST_METHODS_1ARG = new Set([
   "asinh",
   "atanh",
   "cbrt",
+  "round",
   "sign",
   "expm1",
   "log1p",

--- a/src/codegen/math-helpers.ts
+++ b/src/codegen/math-helpers.ts
@@ -297,7 +297,7 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
   }
 
   // ─── Self-hosted subset (#3141) ───────────────────────────────────
-  // sinh/cosh/tanh, asinh/acosh/atanh, cbrt, sign, expm1 and log1p are no
+  // sinh/cosh/tanh, asinh/acosh/atanh, cbrt, round, sign, expm1 and log1p are no
   // longer hand-emitted `Instr[]`. Their bodies are ordinary TS source
   // in `src/stdlib/math.ts`, compiled through the compiler's own IR
   // pipeline (`stdlib-selfhost.ts`) and registered here, at the same

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -32,6 +32,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.log1p",
   "math.log2",
   "math.pow",
+  "math.round",
   "math.sign",
   "math.sin",
   "math.sinh",
@@ -44,7 +45,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the twenty-seven intrinsic entry points.
+ * Provider requirements reachable from the twenty-eight intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -69,6 +70,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.log2",
   "math.pow",
   "math.reduce-trig",
+  "math.round",
   "math.sign",
   "math.sin",
   "math.sinh",
@@ -173,6 +175,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.log1p": definition("math.log1p", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log2": definition("math.log2", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.pow": definition("math.pow", F64_BINARY_INTRINSIC_SIGNATURE),
+  "math.round": definition("math.round", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.sign": definition("math.sign", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.sin": definition("math.sin", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.sinh": definition("math.sinh", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -69,6 +69,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.log2",
   "selfhost.math.pow",
   "selfhost.math.reduce-trig",
+  "selfhost.math.round",
   "selfhost.math.sign",
   "selfhost.math.sin",
   "selfhost.math.sinh",
@@ -202,6 +203,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.log2": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.pow": F64_BINARY_INTRINSIC_SIGNATURE,
   "math.reduce-trig": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.round": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sign": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sin": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.sinh": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -351,6 +353,10 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     kind: "self-hosted",
     symbol: "__math_reduce_trig",
   }),
+  "math.round": provider("selfhost.math.round", "math.round", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "self-hosted",
+    symbol: "Math_round",
+  }),
   "math.sign": provider("selfhost.math.sign", "math.sign", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "self-hosted",
     symbol: "Math_sign",
@@ -393,7 +399,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
   }),
 });
 
-/** Canonically ordered default provider catalogue for the twenty-seven-method slice. */
+/** Canonically ordered default provider catalogue for the twenty-eight-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -300,6 +300,7 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   atan: { arity: 1, intrinsic: "math.atan" },
   atanh: { arity: 1, intrinsic: "math.atanh" },
   cbrt: { arity: 1, intrinsic: "math.cbrt" },
+  round: { arity: 1, intrinsic: "math.round" },
   sign: { arity: 1, intrinsic: "math.sign" },
   sin: { arity: 1, intrinsic: "math.sin" },
   cos: { arity: 1, intrinsic: "math.cos" },
@@ -6500,6 +6501,7 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.cosh" && process.env.JS2WASM_IR_MATH_COSH === "0") return false;
   if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
   if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
+  if (plan.intrinsic === "math.round" && process.env.JS2WASM_IR_MATH_ROUND === "0") return false;
   if (plan.intrinsic === "math.sign" && process.env.JS2WASM_IR_MATH_SIGN === "0") return false;
   if (plan.intrinsic === "math.expm1" && process.env.JS2WASM_IR_MATH_EXPM1 === "0") return false;
   if (plan.intrinsic === "math.asinh" && process.env.JS2WASM_IR_MATH_ASINH === "0") return false;

--- a/src/stdlib/math.ts
+++ b/src/stdlib/math.ts
@@ -75,6 +75,25 @@ export function Math_cbrt(x: number): number {
 `;
 
 /**
+ * Math.round — floor/fraction/ceil implements ties toward +Infinity without
+ * perturbing large integral f64 values. The explicit zero arm preserves -0
+ * for x === -0 and every x in [-0.5, 0). NaN follows the same floor path as
+ * the direct emitter so its payload behavior remains identical.
+ */
+const ROUND_SOURCE = `
+export function Math_round(x: number): number {
+  let floorValue: number = Math.floor(x);
+  let fraction: number = x - floorValue;
+  let result: number = fraction >= 0.5 ? Math.ceil(x) : floorValue;
+  if (result === 0) {
+    if (x === 0) return x;
+    return x < 0 ? -0 : 0;
+  }
+  return result;
+}
+`;
+
+/**
  * Math.sign — preserve signed zero, canonicalize NaN like the direct emitter,
  * and otherwise return the exact sign unit. The argument is evaluated once by
  * the ordinary call boundary.
@@ -638,6 +657,7 @@ export const POW_BUILTIN: StdlibMathBuiltin = {
  */
 export const SELF_HOSTED_MATH: ReadonlyMap<string, StdlibMathBuiltin> = new Map([
   ["cbrt", { name: "Math_cbrt", callees: [], source: CBRT_SOURCE }],
+  ["round", { name: "Math_round", callees: [], source: ROUND_SOURCE }],
   ["sign", { name: "Math_sign", callees: [], source: SIGN_SOURCE }],
   ["sinh", { name: "Math_sinh", callees: ["Math_exp"], source: SINH_SOURCE }],
   ["cosh", { name: "Math_cosh", callees: ["Math_exp"], source: COSH_SOURCE }],

--- a/tests/codegen.test.ts
+++ b/tests/codegen.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
 import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("comparison operators", () => {
@@ -166,23 +167,20 @@ describe("math host imports", () => {
     expect(exports.expLog(1)).toBeCloseTo(1);
   });
 
-  it("Math.round via native f64.nearest", async () => {
+  it("Math.round uses the exact host-free implementation", async () => {
     const result = await compile(`
       export function roundVal(x: number): number {
         return Math.round(x);
       }
     `);
     expect(result.success).toBe(true);
-    // Should NOT create a host import for round (uses f64.nearest)
-    expect(result.wat).not.toContain("Math_round");
+    expect(result.imports.some((descriptor) => descriptor.name === "Math_round")).toBe(false);
+    expect(result.wat).not.toContain("f64.nearest");
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const imports = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
     const exports = instance.exports as any;
+    (imports as { setExports?: (value: typeof exports) => void }).setExports?.(exports);
     expect(exports.roundVal(3.7)).toBe(4);
     expect(exports.roundVal(3.2)).toBe(3);
   });

--- a/tests/equivalence/issue-1371.test.ts
+++ b/tests/equivalence/issue-1371.test.ts
@@ -22,10 +22,10 @@ import { compile } from "../../src/index.js";
 // f64-mapped ops that the IR claims, the call-graph leaves alone, and the
 // lowerer maps to `emitUnary` with the corresponding `f64.<op>` IrUnop tag.
 //
-// `Math.round` is intentionally excluded — JS `Math.round(0.5)` rounds to
-// 1 (away from zero), but Wasm `f64.nearest` rounds to even. A 1:1 lowering
-// would be unsound. Same reason `Math.min/max` (binary) are deferred to a
-// follow-up that extends `IrBinop`.
+// `Math.round` is intentionally excluded from that native-op set — JS ties
+// round toward +Infinity, while Wasm `f64.nearest` rounds to even. It is owned
+// separately by an exact self-hosted semantic intrinsic. `Math.min/max`
+// remain deferred because their variadic evaluation requires a wider plan.
 
 describe("#1371 — IR Math.* unary whitelist", () => {
   it("Math.sqrt — IR-claimed, emits f64.sqrt without host import", async () => {
@@ -74,9 +74,9 @@ describe("#1371 — IR Math.* unary whitelist", () => {
     expect(exp.truncate!(-3.7)).toBe(-3);
   });
 
-  it("Math.<not-whitelisted>(arg) still routes to legacy (round, min, max, pow)", async () => {
-    // These should still compile (via legacy path) and behave correctly —
-    // we are only confirming the whitelist doesn't accidentally over-claim.
+  it("self-hosted and legacy Math calls coexist (round, min, max, pow)", async () => {
+    // round and pow use semantic callable providers; variadic min/max remain
+    // direct. Their ownership split must not change source behavior.
     const exp = await compileToWasm(`
       export function rnd(x: number): number { return Math.round(x); }
       export function mn(a: number, b: number): number { return Math.min(a, b); }

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -71,7 +71,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
           + Math.asinh(x) + Math.acosh(x) + Math.atanh(x)
           + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
-          + Math.cbrt(x) + Math.sign(x)
+          + Math.cbrt(x) + Math.round(x) + Math.sign(x)
           + Math.exp(x) + Math.expm1(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
@@ -136,6 +136,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function cosh(): number { return Math.cosh(0.75); }
       export function tanh(): number { return Math.tanh(0.75); }
       export function cbrt(): number { return Math.cbrt(27); }
+      export function round(): number { return Math.round(-27.5); }
       export function sign(): number { return Math.sign(-27); }
       export function exp(): number { return Math.exp(1.25); }
       export function expm1(): number { return Math.expm1(1.25); }
@@ -189,6 +190,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       "cosh",
       "tanh",
       "cbrt",
+      "round",
       "sign",
       "exp",
       "expm1",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,12 +88,12 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact twenty-seven certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact twenty-eight certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(27);
+    expect(intrinsicMethods).toHaveLength(28);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
@@ -110,6 +110,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         "math.log10",
         "math.log1p",
         "math.reduce-trig",
+        "math.round",
         "math.sign",
         "math.sinh",
         "math.tan",
@@ -138,7 +139,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(27);
+    expect(first.intrinsicUses).toHaveLength(28);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -157,6 +158,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.tanh"]).toEqual(["math.exp"]);
     expect(dependencies["math.cbrt"]).toEqual([]);
     expect(dependencies["math.expm1"]).toEqual(["math.exp"]);
+    expect(dependencies["math.round"]).toEqual([]);
     expect(dependencies["math.sign"]).toEqual([]);
     expect(dependencies["math.asinh"]).toEqual(["math.log"]);
     expect(dependencies["math.acosh"]).toEqual(["math.log"]);
@@ -182,6 +184,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
           "math.acosh",
           "math.atanh",
           "math.sin",
+          "math.round",
           "math.sign",
           "math.tan",
           "math.log10",
@@ -219,6 +222,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       "math.log1p",
       "math.pow",
       "math.reduce-trig",
+      "math.round",
       "math.sign",
       "math.sin",
       "math.sinh",

--- a/tests/issue-5117-ir-math-round.test.ts
+++ b/tests/issue-5117-ir-math-round.test.ts
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5117-ir-math-round");
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+function numberFromBits(bits: bigint): number {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setBigUint64(0, bits);
+  return view.getFloat64(0);
+}
+
+function numberBits(value: number): bigint {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value);
+  return view.getBigUint64(0);
+}
+
+function adjacent(value: number, direction: 1n | -1n): number {
+  if (Number.isNaN(value) || value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY) return value;
+  if (value === 0) return direction === 1n ? Number.MIN_VALUE : -Number.MIN_VALUE;
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value);
+  const step = value > 0 ? direction : -direction;
+  view.setBigUint64(0, view.getBigUint64(0) + step);
+  return view.getFloat64(0);
+}
+
+function nextUp(value: number): number {
+  return adjacent(value, 1n);
+}
+
+function nextDown(value: number): number {
+  return adjacent(value, -1n);
+}
+
+const exclusionCases = [
+  [
+    "shadowed Math",
+    `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5117 shadowed Math is intentionally not ambient.
+      return Math.round(x);
+    }`,
+  ],
+  ["aliased round", `const round = Math.round; export function f(x: number): number { return round(x); }`],
+  ["computed round", `export function f(x: number): number { return Math["round"](x); }`],
+  ["optional invocation", `export function f(x: number): number { return Math.round?.(x); }`],
+  ["optional receiver", `export function f(x: number): number { return Math?.round(x); }`],
+  [
+    "wrong arity",
+    `export function f(x: number): number {
+      // @ts-expect-error #5117 intentionally exercises extra arity.
+      return Math.round(x, x);
+    }`,
+  ],
+  ["spread argument", `export function f(x: number): number { return Math.round(...([x] as [number])); }`],
+  [
+    "non-number argument",
+    `export function f(): number {
+      const text: string = "1";
+      return Math.round(text as never);
+    }`,
+  ],
+] as const;
+
+describe("#5117 exact ambient Math.round IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims the exact one-number call on the %s target", async (label, target) => {
+    const result = await compile(`export function round(value: number): number { return Math.round(value); }`, {
+      fileName: `issue-5117-${label}.ts`,
+      ...(target === undefined ? {} : { target }),
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "round")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irCompiledFuncs ?? []).toContain("round");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.wat).toContain("$Math_round");
+
+    const round = (await instantiate(result)).round as (value: number) => number;
+    expect(round(-1.5)).toBe(-1);
+    expect(Object.is(round(-0.5), -0)).toBe(true);
+    expect(Object.is(round(-Number.MIN_VALUE), -0)).toBe(true);
+    expect(Object.is(round(-0), -0)).toBe(true);
+    expect(round(0.5)).toBe(1);
+    expect(round(1.5)).toBe(2);
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("attaches one dependency-free host-free Math_round provider", () => {
+    const analysis = analyzeSource(`export function round(value: number): number { return Math.round(value); }`);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing round declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("round").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id)).toEqual(["math.round"]);
+    expect(semantic[0]?.args).toHaveLength(1);
+    expect(semantic[0]?.provider).toBeUndefined();
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id)).toEqual(["math.round"]);
+    expect(prepared.manifest.features).toEqual(["math.round"]);
+    expect(prepared.manifest.hostCapabilities).toEqual([]);
+    expect(prepared.manifest.providers).toEqual([
+      expect.objectContaining({
+        id: "selfhost.math.round",
+        feature: "math.round",
+        dependencies: [],
+        implementation: { kind: "self-hosted", symbol: "Math_round" },
+      }),
+    ]);
+    expect(intrinsicInstructions(prepared.functions[0]!)[0]?.provider).toMatchObject({
+      kind: "callable",
+      target: { name: "Math_round", binding: { kind: "intrinsic", symbol: "math.round" } },
+    });
+  });
+
+  it("is raw-bit identical to direct codegen across NaNs, zeros, ties, subnormals, range edges, and infinities", async () => {
+    const source = `export function round(value: number): number { return Math.round(value); }`;
+    const [ir, direct] = await Promise.all([
+      compile(source, { fileName: "issue-5117-ir.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(source, { fileName: "issue-5117-direct.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+    expect(outcomeFor(ir, "round")).toMatchObject({ kind: "emitted", irBodyEmitted: true, legacyBodyEmitted: false });
+
+    const irRound = (await instantiate(ir)).round as (value: number) => number;
+    const directRound = (await instantiate(direct)).round as (value: number) => number;
+    for (const value of [
+      numberFromBits(0x7ff8_0000_0000_0001n),
+      numberFromBits(0xfff8_0000_0000_0042n),
+      Number.NEGATIVE_INFINITY,
+      -Number.MAX_VALUE,
+      -Number.MAX_SAFE_INTEGER,
+      nextDown(-1.5),
+      -1.5,
+      nextUp(-1.5),
+      nextDown(-0.5),
+      -0.5,
+      nextUp(-0.5),
+      -Number.MIN_VALUE,
+      -0,
+      0,
+      Number.MIN_VALUE,
+      nextDown(0.5),
+      0.5,
+      nextUp(0.5),
+      nextDown(1.5),
+      1.5,
+      nextUp(1.5),
+      Number.MAX_SAFE_INTEGER,
+      Number.MAX_VALUE,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      expect(numberBits(irRound(value)), `round parity for ${String(value)}`).toBe(numberBits(directRound(value)));
+    }
+  });
+
+  it("leaves the established production-linear limitation outside IR ownership", async () => {
+    const result = await compile(`export function round(value: number): number { return Math.round(value); }`, {
+      fileName: "issue-5117-linear.ts",
+      target: "linear",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.map((error) => error.message).join("\n")).toContain("Unsupported method call: .round()");
+    expect(result.irOutcomes ?? []).toEqual([]);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("withdraws only round through its narrow rollback", async () => {
+    const flag = "JS2WASM_IR_MATH_ROUND";
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(`export function round(value: number): number { return Math.round(value); }`, {
+        fileName: "issue-5117-rollback.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      expectSuccess(result);
+      expect(outcomeFor(result, "round")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5117-${label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- route exact ambient one-number Math.round calls through the semantic IR intrinsic pipeline
- materialize a dependency-free, host-free self-hosted Math_round provider
- preserve raw NaN behavior, signed zero, ties toward positive infinity, subnormals, infinities, and large integral f64 values
- keep coercive/dynamic shapes and the existing linear limitation outside this ownership slice
- widen the exhaustive pure-Math contracts from 27 to 28 methods and refresh stale round ownership tests

## Validation

- 14 focused Math.round ownership tests passed
- 13 affected #3526 manifest, integration, and linear-legality tests passed
- 9 scoped #249/#1371/Symbol/equivalence/codegen regressions passed
- TypeScript 7 and IR kind-neutrality passed
- full pre-push typecheck, lint, formatting, oracle/coercion ratchets, numeric-local parity, and issue-integrity gates passed