### PR TITLE
fix(es2015): reject Symbol targets in Reflect.get and Reflect.has

### DIFF
--- a/plan/issues/5119-es2015-reflect-symbol-target.md
+++ b/plan/issues/5119-es2015-reflect-symbol-target.md
@@ -1,7 +1,7 @@
 ---
 id: 5119
 title: "ES2015 standalone Reflect.get/has reject Symbol targets"
-status: in-progress
+status: ready
 created: 2026-08-28
 updated: 2026-08-28
 priority: medium
@@ -127,6 +127,29 @@ the controls include a callee-before-caller dynamic `any` target for both
 methods. Every compile-heavy control has a 150 s Vitest timeout and every
 corpus arm has a 150 s timeout with a 130 s runner timeout.
 
+## Final integrated-head evidence
+
+The implementation was integrated without rewriting its earlier commits:
+merge commit `6ad04842a76d15a13d5da89985c61578c93d5415` has parents
+`e7eae37185ffcf9b1899d3ec54475d9c64d35f0d` and freshly fetched
+`upstream/main` `f8a9017448468a216fe2a12dde768101a90785ca`. On that head:
+
+- The focused Vitest suite passed **24/24** (20 controls plus four
+  existence-guarded exact-row arms), with host and standalone lanes, dynamic
+  callee-before-caller targets, later abrupt arguments, no-key-coercion,
+  receiver, object, array, and callable controls.
+- The final assembled harness passed both exact rows in both lanes: host
+  **2/2**, standalone **2/2**. Compared with the retained local arms, host is
+  pass→pass for both rows and standalone is fail→pass for exactly both rows.
+- TypeScript 5 and 7, Prettier, changed-file Biome lint, LOC/function budgets,
+  oracle-ratchet, coercion-sites, synchronization, issue integrity, issue spec
+  coverage, and the pinned numeric-local pre-push test passed. Full lint exits
+  successfully with the repository's pre-existing capped **1,749**
+  diagnostics (the two changed files are clean).
+- The full equivalence gate passed with **1,680** passing and **24** failing;
+  all 24 failures are in the committed known-failure baseline, so there were
+  no new regressions.
+
 ## Acceptance
 
 - Both named Test262 rows flip standalone `fail -> pass`; host remains pass.
@@ -144,10 +167,10 @@ corpus arm has a 150 s timeout with a 130 s runner timeout.
 
 ## Handoff
 
-The plan checkpoint is intentionally separate from the implementation commit.
-After pushing it, continue on `codex/5119-es2015-reflect-symbol-target` in
-`/private/tmp/js2-es2015-reflect-symbol-target-20260828`; push each subsequent
-checkpoint to `ttraenkler/js2`. Do not create a GitHub issue or PR. Report the
-final source review, exact host/standalone rows and controls, full gates,
-clean status, branch, and head SHA to the coordinating agent for review and
-the single upstream PR.
+The dedicated worktree is clean on `codex/5119-es2015-reflect-symbol-target`.
+The read-only fork check currently returns no
+`codex/5119-es2015-reflect-symbol-target` ref: both the plan checkpoint and
+implementation checkpoints remain local because the execution policy rejects
+this child pushing private repository content to `ttraenkler/js2`. Root should
+push the reviewed branch from an explicitly authorized context, then open the
+single non-draft upstream PR. Do not create a GitHub issue or PR here.

--- a/plan/issues/5119-es2015-reflect-symbol-target.md
+++ b/plan/issues/5119-es2015-reflect-symbol-target.md
@@ -13,12 +13,16 @@ area: codegen
 es_edition: 2015
 language_feature: reflect-target-validation
 goal: standalone-mode
-assignee: codex/5119-es2015-reflect-symbol-target
+assignee: ttraenkler/codex/5119-es2015-reflect-symbol-target
 related: [4722, 4724]
 files:
   - src/codegen/expressions/call-namespace-static.ts
   - tests/issue-5119-es2015-reflect-symbol-target.test.ts
   - plan/issues/5119-es2015-reflect-symbol-target.md
+loc-budget-allow:
+  - src/codegen/expressions/call-namespace-static.ts
+func-budget-allow:
+  - src/codegen/expressions/call-namespace-static.ts::compileNamespaceStaticCall
 ---
 
 # #5119 — Standalone Reflect.get/has Symbol-target validation
@@ -90,6 +94,38 @@ body runs.
    object targets, and zero standalone imports. Add an existence-guarded exact
    corpus check only if the Test262 checkout exposes both target rows; use a
    Vitest timeout greater than 120 s for that optional check.
+
+## Implementation checkpoint
+
+The native standalone route now evaluates every supplied get/has argument once
+into temporary externref locals, then tests only the native `$Symbol` carrier
+before invoking `__extern_get`, `__extern_has`, or the explicit-receiver helper.
+This intentionally does not reuse the broader `$Object` guard: arrays,
+callables, typed arrays, and other native object carriers are sibling heap types
+and must continue to reach their existing helpers. The host route uses the same
+argument-local evaluation and rejects statically known Symbol targets before its
+host wrapper's property-key conversion; no runtime helper or unrelated Reflect
+method was changed.
+
+The Symbol-carrier guard is lazily emitted only when the oracle's `TypeFact`
+for the target can contain `symbol`, `any`, `unknown`, or an unresolvable value
+(including a union containing one of those facts). Concrete object, array, and
+function targets do not add a second guard or direct checker query; the
+oracle-ratchet gate remains net-neutral. A read-only standalone compile probe
+confirmed that the existing native Reflect/object runtime already registers
+the shared `$Symbol`/`__box_symbol` and TypeError machinery for any Reflect
+get/has call, while the new guard contributes only the conditional call-site
+instructions for Symbol-capable targets.
+
+Post-change assembled-harness A/B arms (each with the mandatory pass/fail
+controls and 120 s per-file timeout) are `.tmp/5119-after-host.jsonl` and
+`.tmp/5119-after-standalone.jsonl`. Host remains **2/2 pass**. Standalone is
+**2/2 pass**, with local-vs-local partition `fail -> pass: 2`, `pass -> fail: 0`,
+and no other status changes. The focused suite's 24 tests (20 controls and
+four existence-guarded corpus arms) pass in both host and standalone lanes;
+the controls include a callee-before-caller dynamic `any` target for both
+methods. Every compile-heavy control has a 150 s Vitest timeout and every
+corpus arm has a 150 s timeout with a 130 s runner timeout.
 
 ## Acceptance
 

--- a/plan/issues/5119-es2015-reflect-symbol-target.md
+++ b/plan/issues/5119-es2015-reflect-symbol-target.md
@@ -1,9 +1,10 @@
 ---
 id: 5119
 title: "ES2015 standalone Reflect.get/has reject Symbol targets"
-status: ready
+status: done
 created: 2026-08-28
 updated: 2026-08-28
+completed: 2026-08-28
 priority: medium
 horizon: s
 feasibility: medium
@@ -13,6 +14,7 @@ area: codegen
 es_edition: 2015
 language_feature: reflect-target-validation
 goal: standalone-mode
+pr: 5133
 assignee: ttraenkler/codex/5119-es2015-reflect-symbol-target
 related: [4722, 4724]
 files:
@@ -168,9 +170,8 @@ merge commit `6ad04842a76d15a13d5da89985c61578c93d5415` has parents
 ## Handoff
 
 The dedicated worktree is clean on `codex/5119-es2015-reflect-symbol-target`.
-The read-only fork check currently returns no
-`codex/5119-es2015-reflect-symbol-target` ref: both the plan checkpoint and
-implementation checkpoints remain local because the execution policy rejects
-this child pushing private repository content to `ttraenkler/js2`. Root should
-push the reviewed branch from an explicitly authorized context, then open the
-single non-draft upstream PR. Do not create a GitHub issue or PR here.
+Root pushed the exact validated head to `ttraenkler/js2` and opened the single
+non-draft upstream PR: <https://github.com/loopdive/js2/pull/5133>. It targets
+`loopdive/js2:main`, uses the repository template with the CLA checked, and was
+audited as mergeable with no comments, reviews, or unresolved review threads
+at creation. No GitHub issue was created.

--- a/plan/issues/5119-es2015-reflect-symbol-target.md
+++ b/plan/issues/5119-es2015-reflect-symbol-target.md
@@ -1,0 +1,117 @@
+---
+id: 5119
+title: "ES2015 standalone Reflect.get/has reject Symbol targets"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+es_edition: 2015
+language_feature: reflect-target-validation
+goal: standalone-mode
+assignee: codex/5119-es2015-reflect-symbol-target
+related: [4722, 4724]
+files:
+  - src/codegen/expressions/call-namespace-static.ts
+  - tests/issue-5119-es2015-reflect-symbol-target.test.ts
+  - plan/issues/5119-es2015-reflect-symbol-target.md
+---
+
+# #5119 — Standalone Reflect.get/has Symbol-target validation
+
+## Scope
+
+Own exactly the two current standalone residual rows:
+
+- `test/built-ins/Reflect/get/target-is-symbol-throws.js`
+- `test/built-ins/Reflect/has/target-is-symbol-throws.js`
+
+The corresponding host rows are passing. This slice does not change the
+native object helpers, property-key conversion, optional receiver semantics,
+or unrelated Reflect methods. Ordinary object targets and valid property keys
+remain controls.
+
+## Live baseline and source review
+
+The authoritative snapshots are `/private/tmp/js2-baseline-host-current-20260828.jsonl`
+and `/private/tmp/js2-baseline-standalone-current-20260828.jsonl`, recorded on
+2026-08-28 with `oracle_version: 13` and `oracle_lane: honest`, at the current
+`upstream/main` head `796d8c2cd28648d21de2ada5a0b662e758f7dda3`:
+
+| Test262 row | Host | Standalone |
+| --- | ---: | ---: |
+| `Reflect/get/target-is-symbol-throws.js` | pass | **fail** — `Expected a TypeError to be thrown but no exception was thrown at all` |
+| `Reflect/has/target-is-symbol-throws.js` | pass | **fail** — `Expected a TypeError to be thrown but no exception was thrown at all` |
+
+The current-main A/B was independently re-run in the dedicated worktree with
+the assembled-harness `scripts/harness-flip-probe.ts`, using the host lane and
+`--target standalone` lane separately, with a 120 s per-file timeout. Each run
+first observed `control-must-pass -> pass` and `control-must-fail -> fail`.
+The local arms are retained as `.tmp/5119-base-host.jsonl` and
+`.tmp/5119-base-standalone.jsonl` (untracked): host **2/2 pass**; standalone
+**2/2 fail**, matching the authoritative rows and error text.
+
+In `src/codegen/expressions/call-namespace-static.ts`, the native standalone
+`Reflect.get(target, key)` and `Reflect.has(target, key)` arms currently call
+`emitReflectArgs` directly and then invoke `__extern_get` / `__extern_has`.
+Unlike the neighboring `Reflect.set` arm, they have no call-site validation for
+the ECMAScript requirement that `target` be an Object. The shared
+`emitNonObjectArgGuard` already recognizes `ESSymbolLike` (from the landed
+Reflect validation work), so the missing piece is the narrow get/has call-site
+ordering.
+
+The governing algorithms are ECMAScript §28.1.5 (`Reflect.get`) and §28.1.8
+(`Reflect.has`): after `ArgumentListEvaluation`, step 1 rejects a non-Object
+target, step 2 performs `ToPropertyKey`, and `Reflect.get` then supplies the
+implicit receiver. `ArgumentListEvaluation` is §13.3.8.1; all supplied
+argument expressions are evaluated in source order before the Reflect method
+body runs.
+
+## Implementation plan
+
+1. In the native standalone `Reflect.get` and `Reflect.has` call routes, first
+   evaluate every supplied argument expression exactly once, in source order,
+   into temporary externref locals. This includes an optional receiver and any
+   extra arguments (which the built-in ignores after evaluation), so a later
+   abrupt argument expression wins over target validation as required by
+   §13.3.8.1.
+2. After argument evaluation, validate the saved first argument with the
+   existing TypeError path, including statically typed Symbols, before loading
+   the key into any native helper or using the optional receiver. Keep later
+   property-key/receiver coercion hooks untouched when the target is invalid.
+3. Invoke the existing native get/has helpers with the saved values, preserving
+   current object-target behavior. Add focused Vitest coverage for exact
+   TypeError identity, Symbol targets, argument ordering/abrupt completion,
+   no post-validation key coercion, optional receiver behavior, ordinary
+   object targets, and zero standalone imports. Add an existence-guarded exact
+   corpus check only if the Test262 checkout exposes both target rows; use a
+   Vitest timeout greater than 120 s for that optional check.
+
+## Acceptance
+
+- Both named Test262 rows flip standalone `fail -> pass`; host remains pass.
+- Invalid Symbol targets throw the engine's exact TypeError in both methods.
+- All supplied argument expressions still run once in source order; a later
+  abrupt argument expression wins over invalid-target validation.
+- For an invalid Symbol target, property-key conversion and optional-receiver
+  coercion hooks do not run after argument evaluation.
+- Positive object-target get/has behavior and optional receiver behavior remain
+  correct; no unrelated Reflect row changes.
+- Standalone output has zero host imports for the focused cases.
+- Structural host and standalone controls pass, and the focused Vitest suite,
+  TypeScript 5/7 checks, lint, Prettier, budget/oracle/coercion gates, and
+  pinned pre-push checks pass.
+
+## Handoff
+
+The plan checkpoint is intentionally separate from the implementation commit.
+After pushing it, continue on `codex/5119-es2015-reflect-symbol-target` in
+`/private/tmp/js2-es2015-reflect-symbol-target-20260828`; push each subsequent
+checkpoint to `ttraenkler/js2`. Do not create a GitHub issue or PR. Report the
+final source review, exact host/standalone rows and controls, full gates,
+clean status, branch, and head SHA to the coordinating agent for review and
+the single upstream PR.

--- a/src/codegen/expressions/call-namespace-static.ts
+++ b/src/codegen/expressions/call-namespace-static.ts
@@ -76,7 +76,12 @@ import {
 import type { InnerResult } from "../shared.js";
 import { brandExternMethodResult, coerceType, compileExpression, VOID_RESULT } from "../shared.js";
 import { emitSetExtrasArgv, maybeSetArgcForKnownCall } from "../statements/nested-declarations.js";
-import { ensureNativeSymbolBoundaryBridge, ensureSymbolRegistry, usesNativeSymbolProvider } from "../symbol-native.js";
+import {
+  ensureNativeSymbolBoundaryBridge,
+  ensureSymbolCarrier,
+  ensureSymbolRegistry,
+  usesNativeSymbolProvider,
+} from "../symbol-native.js";
 import { tryCompileTemporalStaticCall } from "../temporal-native.js";
 import { pushDefaultValue } from "../type-coercion.js";
 import { ensureDateDaysFromCivilHelper } from "./builtins.js";
@@ -667,6 +672,32 @@ export function compileNamespaceStaticCall(
       }
     };
 
+    // JavaScript evaluates every supplied argument before entering the
+    // Reflect builtin. Native get/has still need their arguments in locals so
+    // the target can be validated after that evaluation, but before the native
+    // helper performs ToPropertyKey (or consumes the optional receiver).
+    const emitReflectArgumentLocals = (): number[] => {
+      const argLocals: number[] = [];
+      for (const arg of expr.arguments) {
+        const argTy = compileExpression(ctx, fctx, arg, externRef);
+        if (argTy && argTy.kind !== "externref") {
+          coerceType(ctx, fctx, argTy, externRef);
+        } else if (argTy === null) {
+          fctx.body.push({ op: "ref.null.extern" });
+        }
+        const local = allocTempLocal(fctx, externRef);
+        fctx.body.push({ op: "local.set", index: local });
+        argLocals.push(local);
+      }
+      return argLocals;
+    };
+
+    const releaseReflectArgumentLocals = (argLocals: readonly number[]): void => {
+      for (let i = argLocals.length - 1; i >= 0; i--) {
+        releaseTempLocal(fctx, argLocals[i]!);
+      }
+    };
+
     // Helper — drop N pushed args and return a fallback constant when the import is unavailable.
     // (#2046 cleanup) `i32-false` is the safer default for boolean-returning
     // Reflect methods on a registration failure (the module is already marked
@@ -694,6 +725,16 @@ export function compileNamespaceStaticCall(
       const type = ctx.checker.getTypeAtLocation(argument);
       return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
     };
+    const mayCarryNativeReflectSymbol = (argument: ts.Expression | undefined): boolean => {
+      if (!argument) return false;
+      const includesSymbol = (fact: ReturnType<typeof ctx.oracle.typeFactOf>): boolean => {
+        if (fact.kind === "symbol" || fact.kind === "any" || fact.kind === "unknown" || fact.kind === "unresolvable") {
+          return true;
+        }
+        return fact.kind === "union" && fact.parts.some(includesSymbol);
+      };
+      return includesSymbol(ctx.oracle.typeFactOf(argument));
+    };
     const emitNativeReflectTargetGuard = (targetLocal: number, message: string): void => {
       const ort = ensureObjectRuntime(ctx);
       const admittedIdx = boundaryReflectInterop ? ctx.funcMap.get("__boundary_object_is_admitted") : undefined;
@@ -718,6 +759,18 @@ export function compileNamespaceStaticCall(
       }
       fctx.body.push({ op: "i32.eqz" });
       fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: throwInstrs });
+    };
+    const emitNativeReflectSymbolTargetGuard = (targetLocal: number, message: string): void => {
+      const symbolTypeIdx = ensureSymbolCarrier(ctx);
+      const before = fctx.body.length;
+      emitThrowTypeError(ctx, fctx, message);
+      const throwInstrs = fctx.body.splice(before);
+      fctx.body.push(
+        { op: "local.get", index: targetLocal },
+        { op: "any.convert_extern" },
+        { op: "ref.test", typeIdx: symbolTypeIdx },
+        { op: "if", blockType: { kind: "empty" }, then: throwInstrs },
+      );
     };
 
     // ── #1472 Phase C — Reflect.* under --target standalone ───────────────
@@ -744,6 +797,18 @@ export function compileNamespaceStaticCall(
     //   stay refused until their native invariants are proven end-to-end.
     if (nativeReflectProvider) {
       if (reflectMethod === "get" && expr.arguments.length >= 2) {
+        const argLocals = emitReflectArgumentLocals();
+        const targetLocal = argLocals[0]!;
+
+        // §28.1.5 step 1: reject the native Symbol carrier after
+        // ArgumentListEvaluation, but before native property-key conversion
+        // or receiver use. Other native object carriers are sibling heap types
+        // (not subtypes of `$Object`) and must remain on their existing helper
+        // paths; a complete Type(V)-is-Object classifier is out of this scope.
+        if (mayCarryNativeReflectSymbol(expr.arguments[0])) {
+          emitNativeReflectSymbolTargetGuard(targetLocal, "Reflect.get called on non-object");
+        }
+
         // (#2046/#4397) Preserve the optional receiver in Wasm. A native
         // target uses __reflect_get_receiver; an admitted caller-owned JS
         // target alone uses the boundary adapter. Runtime admission, rather
@@ -755,22 +820,8 @@ export function compileNamespaceStaticCall(
           const boundaryIdx = boundaryReflectInterop ? ctx.funcMap.get("__boundary_object_reflect_get") : undefined;
           const admittedIdx = boundaryReflectInterop ? ctx.funcMap.get("__boundary_object_is_admitted") : undefined;
           if (nativeIdx !== undefined) {
-            const argLocals: number[] = [];
-            for (let i = 0; i < 3; i++) {
-              const arg = expr.arguments[i];
-              if (arg !== undefined) {
-                const argTy = compileExpression(ctx, fctx, arg, externRef);
-                if (argTy && argTy.kind !== "externref") coerceType(ctx, fctx, argTy, externRef);
-                else if (argTy === null) fctx.body.push({ op: "ref.null.extern" });
-              } else {
-                fctx.body.push({ op: "ref.null.extern" });
-              }
-              const local = allocTempLocal(fctx, externRef);
-              fctx.body.push({ op: "local.set", index: local });
-              argLocals.push(local);
-            }
             const callWithLocals = (funcIdx: number): Instr[] => [
-              ...argLocals.map((index): Instr => ({ op: "local.get", index })),
+              ...argLocals.slice(0, 3).map((index): Instr => ({ op: "local.get", index })),
               { op: "call", funcIdx },
             ];
             if (boundaryIdx !== undefined && admittedIdx !== undefined) {
@@ -787,7 +838,7 @@ export function compileNamespaceStaticCall(
             } else {
               fctx.body.push(...callWithLocals(nativeIdx));
             }
-            for (let i = argLocals.length - 1; i >= 0; i--) releaseTempLocal(fctx, argLocals[i]!);
+            releaseReflectArgumentLocals(argLocals);
             return { kind: "externref" };
           }
           reportError(
@@ -795,17 +846,23 @@ export function compileNamespaceStaticCall(
             expr,
             "Codegen error: Reflect.get with an explicit receiver could not register its native provider (#2046).",
           );
+          releaseReflectArgumentLocals(argLocals);
           fctx.body.push({ op: "ref.null.extern" });
           return { kind: "externref" };
         }
-        emitReflectArgs(2);
+
+        fctx.body.push({ op: "local.get", index: argLocals[0]! });
+        fctx.body.push({ op: "local.get", index: argLocals[1]! });
         const funcIdx = ensureLateImport(ctx, "__extern_get", [externRef, externRef], [externRef]);
         flushLateImportShifts(ctx, fctx);
         if (funcIdx !== undefined) {
           fctx.body.push({ op: "call", funcIdx });
+          releaseReflectArgumentLocals(argLocals);
           return { kind: "externref" };
         }
-        return fallbackReturn(2, "extern-null");
+        const fallback = fallbackReturn(2, "extern-null");
+        releaseReflectArgumentLocals(argLocals);
+        return fallback;
       }
 
       if (reflectMethod === "set" && expr.arguments.length >= 2) {
@@ -856,16 +913,30 @@ export function compileNamespaceStaticCall(
       }
 
       if (reflectMethod === "has" && expr.arguments.length >= 2) {
-        emitReflectArgs(2);
+        const argLocals = emitReflectArgumentLocals();
+        const targetLocal = argLocals[0]!;
+
+        // §28.1.8 step 1: reject the native Symbol carrier before the native
+        // helper performs ToPropertyKey. Extra arguments were already
+        // evaluated above as part of ArgumentListEvaluation. Other native
+        // object carriers remain on their existing helper paths.
+        if (mayCarryNativeReflectSymbol(expr.arguments[0])) {
+          emitNativeReflectSymbolTargetGuard(targetLocal, "Reflect.has called on non-object");
+        }
+        fctx.body.push({ op: "local.get", index: argLocals[0]! });
+        fctx.body.push({ op: "local.get", index: argLocals[1]! });
         const funcIdx = ensureLateImport(ctx, "__extern_has", [externRef, externRef], [i32Ty]);
         flushLateImportShifts(ctx, fctx);
         if (funcIdx !== undefined) {
           fctx.body.push({ op: "call", funcIdx });
+          releaseReflectArgumentLocals(argLocals);
           return { kind: "i32" };
         }
         // (#2046 cleanup) i32-false: a registration failure should not report
         // a phantom `true` for `Reflect.has`.
-        return fallbackReturn(2, "i32-false");
+        const fallback = fallbackReturn(2, "i32-false");
+        releaseReflectArgumentLocals(argLocals);
+        return fallback;
       }
 
       if (reflectMethod === "deleteProperty" && expr.arguments.length >= 2) {
@@ -1472,14 +1543,32 @@ export function compileNamespaceStaticCall(
 
     // Reflect.get(target, key, [receiver]) — returns externref.
     if (reflectMethod === "get" && expr.arguments.length >= 2) {
-      emitReflectArgs(3);
+      const argLocals = emitReflectArgumentLocals();
+      // The compatibility host helper performs ToPropertyKey before calling
+      // host Reflect.get. A statically-known Symbol target must therefore be
+      // rejected here, after all arguments have run but before that helper.
+      if (ctx.oracle.staticJsTypeOf(expr.arguments[0]!) === "symbol") {
+        emitThrowTypeError(ctx, fctx, "Reflect.get called on non-object");
+        releaseReflectArgumentLocals(argLocals);
+        return { kind: "externref" };
+      }
+      fctx.body.push(
+        { op: "local.get", index: argLocals[0]! },
+        { op: "local.get", index: argLocals[1]! },
+        ...(argLocals[2] === undefined
+          ? ([{ op: "ref.null.extern" }] as Instr[])
+          : ([{ op: "local.get", index: argLocals[2] }] as Instr[])),
+      );
       const funcIdx = ensureLateImport(ctx, "__reflect_get", [externRef, externRef, externRef], [externRef]);
       flushLateImportShifts(ctx, fctx);
       if (funcIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx });
+        releaseReflectArgumentLocals(argLocals);
         return { kind: "externref" };
       }
-      return fallbackReturn(3, "extern-null");
+      const fallback = fallbackReturn(3, "extern-null");
+      releaseReflectArgumentLocals(argLocals);
+      return fallback;
     }
 
     // Reflect.set(target, key, value, [receiver]) — returns i32 (boolean).
@@ -1496,14 +1585,25 @@ export function compileNamespaceStaticCall(
 
     // Reflect.has(target, key) — returns i32 (boolean).
     if (reflectMethod === "has" && expr.arguments.length >= 2) {
-      emitReflectArgs(2);
+      const argLocals = emitReflectArgumentLocals();
+      // Keep target validation ahead of the host helper's ToPropertyKey path
+      // for statically-known Symbols while preserving full argument ordering.
+      if (ctx.oracle.staticJsTypeOf(expr.arguments[0]!) === "symbol") {
+        emitThrowTypeError(ctx, fctx, "Reflect.has called on non-object");
+        releaseReflectArgumentLocals(argLocals);
+        return { kind: "i32" };
+      }
+      fctx.body.push({ op: "local.get", index: argLocals[0]! }, { op: "local.get", index: argLocals[1]! });
       const funcIdx = ensureLateImport(ctx, "__reflect_has", [externRef, externRef], [i32Ty]);
       flushLateImportShifts(ctx, fctx);
       if (funcIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx });
+        releaseReflectArgumentLocals(argLocals);
         return { kind: "i32" };
       }
-      return fallbackReturn(2, "i32-true");
+      const fallback = fallbackReturn(2, "i32-true");
+      releaseReflectArgumentLocals(argLocals);
+      return fallback;
     }
 
     // Reflect.deleteProperty(target, key) — returns i32 (boolean).

--- a/tests/issue-5119-es2015-reflect-symbol-target.test.ts
+++ b/tests/issue-5119-es2015-reflect-symbol-target.test.ts
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5119 — ES2015 §28.1.5 / §28.1.8: Reflect.get/has must reject a Symbol
+// target before ToPropertyKey (and before an explicit receiver is consumed).
+// ArgumentListEvaluation still evaluates every supplied argument first.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+type Lane = "host" | "standalone";
+const CONTROL_TIMEOUT_MS = 150_000;
+
+async function run(source: string, lane: Lane): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-5119.ts",
+    skipSemanticDiagnostics: true,
+    ...(lane === "standalone" ? { target: "standalone" as const } : {}),
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), `${lane} module failed validation`).toBe(true);
+
+  const module = new WebAssembly.Module(result.binary);
+  const imports = WebAssembly.Module.imports(module).map((entry) => `${entry.module}::${entry.name}`);
+  if (lane === "standalone") {
+    expect(imports, "standalone Reflect.get/has must not import a host helper").toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    return (instance.exports as { test: () => number }).test();
+  }
+
+  const importObject = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  (importObject as { __setInstance?: (value: WebAssembly.Instance) => void }).__setInstance?.(instance);
+  return (instance.exports as { test: () => number }).test();
+}
+
+const GET_SYMBOL_TARGET = `
+  export function test(): number {
+    try {
+      Reflect.get(Symbol(1), "missing");
+      return 0;
+    } catch (error) {
+      return error instanceof TypeError ? 1 : 0;
+    }
+  }
+`;
+
+const HAS_SYMBOL_TARGET = `
+  export function test(): number {
+    try {
+      Reflect.has(Symbol(1), "missing");
+      return 0;
+    } catch (error) {
+      return error instanceof TypeError ? 1 : 0;
+    }
+  }
+`;
+
+const DYNAMIC_SYMBOL_TARGETS = `
+  function get(target: any): any {
+    return Reflect.get(target, "missing");
+  }
+  function has(target: any): boolean {
+    return Reflect.has(target, "missing");
+  }
+  export function test(): number {
+    let getCaught = 0;
+    let hasCaught = 0;
+    try {
+      get(Symbol(1));
+    } catch (error) {
+      getCaught = error instanceof TypeError ? 1 : 0;
+    }
+    try {
+      has(Symbol(2));
+    } catch (error) {
+      hasCaught = error instanceof TypeError ? 1 : 0;
+    }
+    return getCaught && hasCaught ? 1 : 0;
+  }
+`;
+
+const GET_SYMBOL_TARGET_NO_KEY_COERCION = `
+  let toStringCalls = 0;
+  const key: any = {
+    toString(): string {
+      toStringCalls = toStringCalls + 1;
+      return "missing";
+    },
+  };
+  export function test(): number {
+    try {
+      Reflect.get(Symbol(1), key);
+      return 0;
+    } catch (error) {
+      return error instanceof TypeError && toStringCalls === 0 ? 1 : 0;
+    }
+  }
+`;
+
+const HAS_SYMBOL_TARGET_NO_KEY_COERCION = `
+  let toStringCalls = 0;
+  const key: any = {
+    toString(): string {
+      toStringCalls = toStringCalls + 1;
+      return "missing";
+    },
+  };
+  export function test(): number {
+    try {
+      Reflect.has(Symbol(1), key);
+      return 0;
+    } catch (error) {
+      return error instanceof TypeError && toStringCalls === 0 ? 1 : 0;
+    }
+  }
+`;
+
+const GET_LATE_ARGUMENT_ABRUPTION = `
+  let order = 0;
+  function mark(value: number): any {
+    order = order * 10 + value;
+    return "missing";
+  }
+  function abrupt(): any {
+    order = order * 10 + 3;
+    throw 99;
+  }
+  export function test(): number {
+    try {
+      Reflect.get(Symbol(1), mark(2), abrupt());
+      return 0;
+    } catch (error) {
+      return order === 23 && error === 99 ? 1 : 0;
+    }
+  }
+`;
+
+const HAS_LATE_ARGUMENT_ABRUPTION = `
+  let order = 0;
+  function mark(value: number): any {
+    order = order * 10 + value;
+    return "missing";
+  }
+  function abrupt(): any {
+    order = order * 10 + 3;
+    throw 99;
+  }
+  export function test(): number {
+    try {
+      Reflect.has(Symbol(1), mark(2), abrupt());
+      return 0;
+    } catch (error) {
+      return order === 23 && error === 99 ? 1 : 0;
+    }
+  }
+`;
+
+const OBJECT_TARGETS = `
+  export function test(): number {
+    const target: any = { value: 41 };
+    return Reflect.get(target, "value") === 41 && Reflect.has(target, "value") ? 1 : 0;
+  }
+`;
+
+const OBJECT_TARGET_EXPLICIT_RECEIVER = `
+  export function test(): number {
+    const target: any = {};
+    Object.defineProperty(target, "value", {
+      get: function (): number { return (this as any).marker; },
+    });
+    const receiver: any = { marker: 42 };
+    return Reflect.get(target, "value", receiver) === 42 ? 1 : 0;
+  }
+`;
+
+const NATIVE_SIBLING_OBJECT_TARGETS = `
+  export function test(): number {
+    const array: any = [41];
+    return Reflect.get(array, "0") === 41 &&
+      Reflect.has(array, "0") &&
+      Reflect.get(function callable(): number { return 42; }, "length") === 0 ? 1 : 0;
+  }
+`;
+
+describe("#5119 — Reflect.get/has Symbol target validation", () => {
+  for (const lane of ["host", "standalone"] as const) {
+    it(
+      `${lane}: get rejects a Symbol target with the exact TypeError identity`,
+      { timeout: CONTROL_TIMEOUT_MS },
+      async () => {
+        await expect(run(GET_SYMBOL_TARGET, lane)).resolves.toBe(1);
+      },
+    );
+
+    it(
+      `${lane}: has rejects a Symbol target with the exact TypeError identity`,
+      { timeout: CONTROL_TIMEOUT_MS },
+      async () => {
+        await expect(run(HAS_SYMBOL_TARGET, lane)).resolves.toBe(1);
+      },
+    );
+
+    it(
+      `${lane}: callee-before-caller dynamic Symbol targets still reject in get and has`,
+      { timeout: CONTROL_TIMEOUT_MS },
+      async () => {
+        await expect(run(DYNAMIC_SYMBOL_TARGETS, lane)).resolves.toBe(1);
+      },
+    );
+
+    it(`${lane}: get validates the target before key ToPropertyKey`, { timeout: CONTROL_TIMEOUT_MS }, async () => {
+      await expect(run(GET_SYMBOL_TARGET_NO_KEY_COERCION, lane)).resolves.toBe(1);
+    });
+
+    it(`${lane}: has validates the target before key ToPropertyKey`, { timeout: CONTROL_TIMEOUT_MS }, async () => {
+      await expect(run(HAS_SYMBOL_TARGET_NO_KEY_COERCION, lane)).resolves.toBe(1);
+    });
+
+    it(
+      `${lane}: get evaluates a later abrupt argument after earlier arguments`,
+      { timeout: CONTROL_TIMEOUT_MS },
+      async () => {
+        await expect(run(GET_LATE_ARGUMENT_ABRUPTION, lane)).resolves.toBe(1);
+      },
+    );
+
+    it(
+      `${lane}: has evaluates a later abrupt argument after earlier arguments`,
+      { timeout: CONTROL_TIMEOUT_MS },
+      async () => {
+        await expect(run(HAS_LATE_ARGUMENT_ABRUPTION, lane)).resolves.toBe(1);
+      },
+    );
+
+    it(`${lane}: object targets remain positive`, { timeout: CONTROL_TIMEOUT_MS }, async () => {
+      await expect(run(OBJECT_TARGETS, lane)).resolves.toBe(1);
+    });
+
+    it(
+      `${lane}: get still consumes an explicit receiver for object targets`,
+      { timeout: CONTROL_TIMEOUT_MS },
+      async () => {
+        await expect(run(OBJECT_TARGET_EXPLICIT_RECEIVER, lane)).resolves.toBe(1);
+      },
+    );
+
+    it(
+      `${lane}: array and callable sibling carriers remain object targets`,
+      { timeout: CONTROL_TIMEOUT_MS },
+      async () => {
+        await expect(run(NATIVE_SIBLING_OBJECT_TARGETS, lane)).resolves.toBe(1);
+      },
+    );
+  }
+});
+
+const TEST262_ROOT = join(__dirname, "..", "test262");
+const TARGET_ROWS = [
+  "built-ins/Reflect/get/target-is-symbol-throws.js",
+  "built-ins/Reflect/has/target-is-symbol-throws.js",
+] as const;
+const TARGET_ROWS_AVAILABLE = TARGET_ROWS.every((relativePath) => existsSync(join(TEST262_ROOT, "test", relativePath)));
+
+describe.skipIf(!TARGET_ROWS_AVAILABLE)("#5119 exact Test262 rows", () => {
+  for (const lane of ["host", "standalone"] as const) {
+    for (const relativePath of TARGET_ROWS) {
+      it(`${lane}: ${relativePath} passes`, { timeout: 150_000 }, async () => {
+        const result = await runTest262File(
+          join(TEST262_ROOT, "test", relativePath),
+          "issue-5119-reflect-symbol-target",
+          130_000,
+          lane === "standalone" ? lane : undefined,
+        );
+        expect(result.status, result.error ?? result.reason ?? "").toBe("pass");
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Description

- Problem: standalone `Reflect.get` and `Reflect.has` accepted native Symbol targets instead of throwing the ES2015-required `TypeError`.
- Behavior: evaluate every supplied argument exactly once before validation, reject static and dynamic Symbol carriers ahead of key coercion or receiver use, and preserve object, array, callable, and explicit-receiver paths.
- Tests: the focused suite passes 24/24; both exact Test262 rows pass in host (2/2) and standalone (2/2), including callee-before-caller and later-abrupt-completion controls with zero standalone imports.
- Quality: TypeScript 5 and 7, lint, Prettier, oracle/coercion ratchets, LOC/function budgets, issue integrity, numeric-local parity, the full equivalence gate (1,680 passing with only 24 committed known failures), and the complete pre-push hook passed.
- Tracking: `plan/issues/5119-es2015-reflect-symbol-target.md` contains the implementation plan, evidence, and handoff. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
