### PR TITLE
feat(ir): own exact Math.fround calls

### DIFF
--- a/plan/issues/5118-ir-exact-ambient-math-fround.md
+++ b/plan/issues/5118-ir-exact-ambient-math-fround.md
@@ -1,7 +1,7 @@
 ---
 id: 5118
 title: "IR: own exact ambient Math.fround calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -165,6 +165,32 @@ than silently dropping the popped value.
   before claim without invariants or post-claim errors.
 - The narrow rollback, affected regressions, TypeScript 7, and all pre-push
   gates pass.
+
+## Outcome
+
+Completed on 2026-08-28 in non-draft PR
+[#5135](https://github.com/loopdive/js2/pull/5135), stacked on #5132.
+
+- Added `math.fround` as the twenty-ninth certified pure-Math intrinsic and
+  attached the dependency-free, host-free `backend.f64.fround` provider for
+  WasmGC and linear policies.
+- Added the one-member `backend-sequence` contract and lowered it through the
+  typed emitter seam as exactly `f32.demote_f64` then `f64.promote_f32`.
+  Bytecode remains fail-loud and Porffor now rejects both conversions
+  explicitly.
+- Exact ambient one-number calls are IR-owned on WasmGC and production linear;
+  excluded/coercive forms still decline before claim, and
+  `JS2WASM_IR_MATH_FROUND=0` provides narrow rollback.
+- Focused validation passed 15/15 cases, including production-linear ownership,
+  malformed-sequence rejection, zero-import standalone execution, and raw-bit
+  parity across custom NaNs, signed zero, f32 midpoint ties, subnormal/normal
+  boundaries, overflow, finite extremes, and infinities.
+- The 13 affected #3526 integration, manifest, and linear-legality tests passed.
+  TypeScript 7, IR kind-neutrality, formatting, lint, ratchets, numeric-local
+  parity, issue integrity, and the full pre-push suite passed.
+- Final Luna Max review returned GO with no actionable P0/P1 findings. At the
+  implementation checkpoint, PR #5135 was non-draft, cleanly mergeable, and
+  green on CLA and automation checks.
 
 ## Non-goals
 

--- a/plan/issues/5118-ir-exact-ambient-math-fround.md
+++ b/plan/issues/5118-ir-exact-ambient-math-fround.md
@@ -1,0 +1,185 @@
+---
+id: 5118
+title: "IR: own exact ambient Math.fround calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5118-ir-math-fround
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, backend, codegen
+language_feature: math-builtins
+goal: ir-full-coverage
+depends_on: [5117]
+related: [78, 111, 936, 1371, 1437, 3526, 4787, 5116, 5117]
+files:
+  - src/ir/nodes.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/intrinsic-support.ts
+  - src/ir/lower.ts
+  - src/ir/select.ts
+  - src/ir/backend/emitter.ts
+  - src/ir/backend/legality.ts
+  - src/ir/backend/porffor/sink.ts
+  - scripts/check-ir-kind-neutrality.mjs
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-3526-ir-linear-math-intrinsics.test.ts
+  - tests/issue-5118-ir-math-fround.test.ts
+loc-budget-allow:
+  - src/ir/nodes.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/intrinsic-support.ts
+  - src/ir/lower.ts
+  - src/ir/select.ts
+  - src/ir/backend/emitter.ts
+  - src/ir/backend/legality.ts
+  - src/ir/backend/porffor/sink.ts
+func-budget-allow:
+  - src/ir/select.ts::selectorSupportsMathPlan
+  - src/ir/intrinsic-support.ts::providerAttachment
+  - src/ir/intrinsic-support.ts::sameProvider
+  - src/ir/lower.ts::emitPreparedIntrinsic
+  - src/ir/backend/legality.ts::linearInstrError
+  - src/ir/backend/porffor/sink.ts::PorfforEmitter.emitNumericConversion
+---
+
+# #5118 — Exact ambient `Math.fround` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.fround(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent the source call as the twenty-ninth versioned pure-Math
+intrinsic and attach one closed native backend-sequence provider that emits
+`f32.demote_f64` followed by `f64.promote_f32` on both WasmGC and linear.
+
+This checkpoint is intentionally stacked on #5132/#5117. It introduces no
+runtime helper, import, or public f32 source/IR signature: `math.fround` remains
+strictly `(f64) -> f64`, and f32 exists only as the backend stack intermediate
+between the two exact conversion instructions.
+
+## Measured residual and feasibility
+
+`compileMathCall` already implements exact `Math.fround` behavior as the two
+native Wasm conversions. Both direct WasmGC and linear instruction encoders
+support them, including IEEE round-to-nearest-ties-even, NaN, signed zero,
+subnormal, finite overflow-to-infinity, and infinity behavior. Exact numeric
+calls remain absent from `IR_MATH_METHOD_TABLE`, so they currently emit legacy
+bodies.
+
+The semantic provider layer currently models either one closed f64 backend op
+or one callable. A Luna Max audit found no P0 blocker and identified one narrow
+P1 prerequisite: add a closed `backend-sequence` provider whose only vocabulary
+member is `f64.fround`. An architecture review rejected arbitrary instruction
+arrays, a self-hosted f64 approximation, and exposing f32 in the semantic
+signature.
+
+## Exact admitted grammar
+
+Admit only a non-optional `Math.fround(argument)` when `Math` is the unshadowed
+ambient binding, there is exactly one non-spread argument, the selector proves
+primitive `number`, and the containing unit passes ordinary ownership and
+call-graph gates. Aliased, computed, optional, shadowed, coercive, Symbol,
+spread, and wrong-arity forms remain direct.
+
+## Closed backend-sequence contract
+
+Add one semantic provider variant:
+
+```ts
+type IrIntrinsicBackendSequence = "f64.fround";
+
+type IrIntrinsicProvider =
+  | { kind: "backend-op"; opcode: IrIntrinsicBackendOp }
+  | { kind: "backend-sequence"; sequence: IrIntrinsicBackendSequence }
+  | { kind: "callable"; target: IrFuncRef };
+```
+
+`backend.f64.fround` provides `math.fround` with unary-f64 signature, no
+dependency, no host capability, and both WasmGC/linear support. Lowering must
+match the closed sequence exhaustively and emit exactly:
+
+```text
+f32.demote_f64
+f64.promote_f32
+```
+
+The implementation extends the existing typed `BackendNumericConversionOp`
+emitter seam with those two conversion names and calls
+`emitNumericConversion` twice. It does not widen `IrUnop`, add a generic raw
+sequence, allocate a local, or evaluate the source argument more than once.
+WasmGC and linear already append typed conversion instructions through this
+seam. Bytecode remains fail-loud through its existing unsupported-conversion
+arm, and Porffor must reject the two new conversion names explicitly rather
+than silently dropping the popped value.
+
+## Implementation plan
+
+1. Add the closed `IrIntrinsicBackendSequence` vocabulary and
+   `backend-sequence` provider attachment shape. Extend the runtime provider
+   implementation union and math-only extraction without changing the five
+   single-op `IrIntrinsicBackendOp` members.
+2. Teach provider attachment/equality to preserve and compare the sequence.
+   Add exhaustive lowering for `f64.fround` through two typed numeric
+   conversions and explicit non-Wasm backend rejection.
+3. Add `math.fround` and `backend.f64.fround` to the intrinsic, feature,
+   provider, and signature catalogues with no dependencies/capabilities.
+4. Add a sequence-marked `fround` method plan so both the WasmGC symbolic path
+   and linear selector admit it, and add independent
+   `JS2WASM_IR_MATH_FROUND=0` rollback. Keep generic from-AST emission.
+5. Widen linear legality from five to six native Math semantics only for the
+   closed fround sequence. Unknown/malformed sequence values, missing
+   providers, unsupported adapters, and provider-shape drift must fail closed.
+6. Widen #3526 exhaustive vocabulary, integration, manifest, linear-legality,
+   and neutrality evidence from twenty-eight to twenty-nine source Math
+   intrinsics.
+7. Add focused host, zero-import standalone, and production-linear ownership
+   and execution; provider attachment for both policies; exact two-op WAT;
+   raw-bit direct parity; rollback; and pre-claim exclusions. Pin custom NaNs,
+   both zeros, f32 midpoint ties and adjacent doubles, f64/f32 subnormals,
+   finite f32 overflow boundaries, large values, and infinities.
+8. Re-run existing fround/Test262-focused regressions, affected #3526 suites,
+   TypeScript 7, formatting/lint/ratchets, and full pre-push checks; then open a
+   non-draft PR stacked on #5132.
+
+## Acceptance criteria
+
+- Exact ambient one-number `Math.fround` calls emit IR only on WasmGC and
+  linear, with one closed `backend-sequence` provider and no helper/import.
+- Lowering evaluates one f64 argument once, emits exactly demote then promote,
+  and returns f64 without exposing an f32 semantic value.
+- Host, zero-import standalone, and production linear execution are raw-bit
+  identical to direct codegen across NaN payload behavior, signed zero,
+  midpoint ties, subnormals, finite range edges, and infinities.
+- The provider closure is exactly `math.fround`; malformed/unknown sequences,
+  missing providers/adapters, and unsupported non-Wasm sinks fail loudly.
+- Coercive and all other excluded shapes preserve direct behavior and decline
+  before claim without invariants or post-claim errors.
+- The narrow rollback, affected regressions, TypeScript 7, and all pre-push
+  gates pass.
+
+## Non-goals
+
+- Arbitrary backend instruction arrays or a general sequence DSL.
+- A public f32 source/IR signature, f32 locals, or a self-hosted approximation.
+- Changes to legacy WasmGC/linear direct `Math.fround` lowering.
+- `Math.clz32`/`imul` ownership before the shared `ToUint32` saturation bug is
+  fixed; variadic `min/max/hypot`; or stateful `Math.random`.
+- Async, class, module-init, or broader ownership expansion.
+
+## Risk and rollback
+
+The main architectural risk is turning one exact closed sequence into an
+untyped raw-instruction escape hatch; the one-member vocabulary and exhaustive
+switch prevent that. Numeric risk is conversion order or hidden re-evaluation,
+guarded by raw-bit direct parity and exact WAT assertions.
+`JS2WASM_IR_MATH_FROUND=0` provides narrow rollback;
+`JS2WASM_IR_FIRST=0` remains the global control.

--- a/scripts/check-ir-kind-neutrality.mjs
+++ b/scripts/check-ir-kind-neutrality.mjs
@@ -183,7 +183,7 @@ const VERDICTS = {
   intrinsic: {
     verdict: "unresolved",
     why:
-      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 28 `math.*` ids drawn " +
+      "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 29 `math.*` ids drawn " +
       "explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals " +
       "implementation-approximated, so most of them carry no ECMAScript commitment at all — while " +
       "`math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -40,39 +40,39 @@
     "binary": {
       "verdict": "unresolved",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1018",
+      "declaredAt": "src/ir/nodes.ts:1022",
       "why": "The kind is a neutral envelope; its OPCODE ENUM is not. `IrBinop` mixes ~30 one-to-one Wasm primitives with six `js.*` COMPOSITES (`js.bitand|bitor|bitxor|shl|shr_s|shr_u`), each documented as ToInt32(lhs); ToInt32(rhs); i32.<op>; convert back to f64 — ECMA-262 §7.1.6. `i64.rem_s` is likewise labelled a guarded JS Number remainder fast path. So the declaration cannot be placed on either side: moving `IrInstrBinary` would exile `f64.add`, leaving it in core keeps six ECMAScript operators there. (#4551's contested-family list does not mention `binary`; this is a finding, not a restatement.)",
-      "evidence": ["src/ir/nodes.ts:966", "src/ir/nodes.ts:954"],
+      "evidence": ["src/ir/nodes.ts:970", "src/ir/nodes.ts:958"],
       "settledBy": "Split `IrBinop`: the six `js.*` composites (and the `i64.rem_s` fast path's ECMAScript justification) move to the dialect as a separate opcode union; the Wasm primitives stay. The unit of the fix is the enum, not the interface."
     },
     "box": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1104",
+      "declaredAt": "src/ir/nodes.ts:1108",
       "why": "One boxing concept over a tagged carrier. It also serves plain scalar tagged unions with no JS involvement, so it is not a JS-only operation and moving it to the dialect would be wrong.",
-      "evidence": ["src/ir/nodes.ts:1089"],
+      "evidence": ["src/ir/nodes.ts:1093"],
       "residual": "The JS content is TYPE-LEVEL, via `toType.kind === \"dynamic\"` and the dynamic leaf's `tag?: TagId` refinement — #3954 phase 1's `TagDomain` seam, not a dialect question. Phase 1 made the refinement neutral at the declaration; what is still ECMAScript is the LOWERING, which crosses `TagId -> JsTag` (`lower.ts` `jsTagOf`) to meet the #3029-S1-frozen `IrDynamicLowering` contract. That is #3954 phase 3's W2/W6, and it moves no declaration."
     },
     "br": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2399",
+      "declaredAt": "src/ir/nodes.ts:2403",
       "why": "Unconditional branch with block arguments in place of phi nodes.",
-      "evidence": ["src/ir/nodes.ts:2378"]
+      "evidence": ["src/ir/nodes.ts:2382"]
     },
     "br_if": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2405",
+      "declaredAt": "src/ir/nodes.ts:2409",
       "why": "Two-target conditional branch on an i32 condition.",
-      "evidence": ["src/ir/nodes.ts:2404"]
+      "evidence": ["src/ir/nodes.ts:2408"]
     },
     "br.label": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2129",
+      "declaredAt": "src/ir/nodes.ts:2133",
       "why": "Branch to a named enclosing loop frame in break or continue mode. Labeled break/continue is C-family, not ECMAScript-specific.",
-      "evidence": ["src/ir/nodes.ts:2106"]
+      "evidence": ["src/ir/nodes.ts:2110"]
     },
     "call": {
       "verdict": "neutral",
@@ -84,87 +84,87 @@
     "class.call": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1536",
+      "declaredAt": "src/ir/nodes.ts:1540",
       "why": "Virtual dispatch against the receiver's shape with the receiver prepended. Accessors are a member kind, shared with Kotlin/C#/Dart.",
-      "evidence": ["src/ir/nodes.ts:1521"]
+      "evidence": ["src/ir/nodes.ts:1525"]
     },
     "class.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1499",
+      "declaredAt": "src/ir/nodes.ts:1503",
       "why": "Struct field read by declared name.",
-      "evidence": ["src/ir/nodes.ts:1488"]
+      "evidence": ["src/ir/nodes.ts:1492"]
     },
     "class.instanceof": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1600",
+      "declaredAt": "src/ir/nodes.ts:1604",
       "why": "A CLOSED-WORLD NOMINAL TYPE TEST, not the JS operator it is named after: the operand must be statically `IrType.class`, and the test compares a hidden tag against the target's tag plus its transitive children. No prototype chain walk, no `Symbol.hasInstance`, no TypeError on a non-callable right-hand side. This is Java's `instanceof` / Kotlin's `is`.",
-      "evidence": ["src/ir/nodes.ts:1592"]
+      "evidence": ["src/ir/nodes.ts:1596"]
     },
     "class.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1481",
+      "declaredAt": "src/ir/nodes.ts:1485",
       "why": "Allocates a nominal class instance through the class-owned constructor wrapper. No `new.target`, no constructor-returns-object override.",
-      "evidence": ["src/ir/nodes.ts:295", "src/ir/nodes.ts:1470"]
+      "evidence": ["src/ir/nodes.ts:295", "src/ir/nodes.ts:1474"]
     },
     "class.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1514",
+      "declaredAt": "src/ir/nodes.ts:1518",
       "why": "Struct field write by declared name.",
-      "evidence": ["src/ir/nodes.ts:1505"]
+      "evidence": ["src/ir/nodes.ts:1509"]
     },
     "class.static_call": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1616",
+      "declaredAt": "src/ir/nodes.ts:1620",
       "why": "Direct call to a static member slot, no receiver.",
-      "evidence": ["src/ir/nodes.ts:1606"]
+      "evidence": ["src/ir/nodes.ts:1610"]
     },
     "class.super_call": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1577",
+      "declaredAt": "src/ir/nodes.ts:1581",
       "why": "Statically dispatches to the parent's method slot, bypassing the override — the same operation as Java's `super.m()`.",
-      "evidence": ["src/ir/nodes.ts:1567"]
+      "evidence": ["src/ir/nodes.ts:1571"]
     },
     "class.super_init": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1559",
+      "declaredAt": "src/ir/nodes.ts:1563",
       "why": "Runs the parent's initializer on an ALREADY-ALLOCATED `self`. That is the C++/Java allocate-then-initialize order, which is precisely NOT ECMAScript's derived-constructor protocol (where the base creates `this` and it is in TDZ until `super()` returns).",
-      "evidence": ["src/ir/nodes.ts:1545"]
+      "evidence": ["src/ir/nodes.ts:1549"]
     },
     "closure.call": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1412",
+      "declaredAt": "src/ir/nodes.ts:1416",
       "why": "Indirect call through a typed funcref with EXACT arity — not the ECMAScript call model.",
-      "evidence": ["src/ir/nodes.ts:1393"],
+      "evidence": ["src/ir/nodes.ts:1397"],
       "residual": "`IrClosureSignature.defaultParamStart` lets a caller omit a trailing numeric suffix, padded with a reserved missing-argument sentinel. Optional parameters are widely shared, but the sentinel is a value-model artifact — phase 1 territory, and a signature field rather than an instruction, so it does not move with this kind either way."
     },
     "closure.cap": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1386",
+      "declaredAt": "src/ir/nodes.ts:1390",
       "why": "Reads capture slot N out of the closure's own self parameter.",
-      "evidence": ["src/ir/nodes.ts:1387"]
+      "evidence": ["src/ir/nodes.ts:1391"]
     },
     "closure.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1361",
+      "declaredAt": "src/ir/nodes.ts:1365",
       "why": "Lifted function plus a capture struct — the standard closure conversion, older than JS.",
-      "evidence": ["src/ir/nodes.ts:1344"]
+      "evidence": ["src/ir/nodes.ts:1348"]
     },
     "coerce.to_externref": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1841",
+      "declaredAt": "src/ir/nodes.ts:1845",
       "why": "A representation conversion (`extern.convert_any`, or a no-op when the input is already externref). Crossing to the host is a HOST-boundary concern, not a language one — the same reading #4551 records for the backend's emitToExternref/emitFromExternref.",
-      "evidence": ["src/ir/nodes.ts:1834"]
+      "evidence": ["src/ir/nodes.ts:1838"]
     },
     "const": {
       "verdict": "neutral",
@@ -212,9 +212,9 @@
     "early.return": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1936",
+      "declaredAt": "src/ir/nodes.ts:1940",
       "why": "A Wasm `return` from inside a nested buffer. Its soundness scope cites ECMAScript, but as a RESTRICTION against dialect kinds (it is refused inside `try` and `forof.iter`), not as a semantic of its own.",
-      "evidence": ["src/ir/nodes.ts:1920"]
+      "evidence": ["src/ir/nodes.ts:1924"]
     },
     "extern.call": {
       "verdict": "js",
@@ -254,30 +254,30 @@
     "fnctor.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1290",
+      "declaredAt": "src/ir/nodes.ts:1294",
       "why": "Reads a declared field from a nominal constructor carrier; field identity and representation come from the resolved layout.",
-      "evidence": ["src/ir/nodes.ts:1288"]
+      "evidence": ["src/ir/nodes.ts:1292"]
     },
     "fnctor.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1281",
+      "declaredAt": "src/ir/nodes.ts:1285",
       "why": "Materializes a nominal function-style constructor through an exact ABI handle; the operation is not an ECMAScript protocol by itself.",
-      "evidence": ["src/ir/nodes.ts:1270"]
+      "evidence": ["src/ir/nodes.ts:1274"]
     },
     "for.loop": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2041",
+      "declaredAt": "src/ir/nodes.ts:2045",
       "why": "Pre-test loop with an update buffer. The init clause is ordinary IR emitted before it.",
-      "evidence": ["src/ir/nodes.ts:2023"]
+      "evidence": ["src/ir/nodes.ts:2027"]
     },
     "forof.iter": {
       "verdict": "js",
       "where": "dialect",
       "declaredAt": "src/ir/dialect/js.ts:381",
       "why": "`for (x of it)` over the @@iterator protocol, as a statement form.",
-      "evidence": ["src/ir/nodes.ts:1805"]
+      "evidence": ["src/ir/nodes.ts:1809"]
     },
     "forof.string": {
       "verdict": "js",
@@ -289,9 +289,9 @@
     "forof.vec": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1784",
+      "declaredAt": "src/ir/nodes.ts:1788",
       "why": "An index counter over a dense vector — and deliberately NOT ECMAScript's ArrayIterator: the length is read ONCE into a slot before the loop, where §23.1.5.1 re-reads it every step. A producer whose language wants a snapshot loop gets exactly that.",
-      "evidence": ["src/ir/nodes.ts:1750"]
+      "evidence": ["src/ir/nodes.ts:1754"]
     },
     "gen.epilogue": {
       "verdict": "js",
@@ -324,37 +324,37 @@
     "global.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:869",
+      "declaredAt": "src/ir/nodes.ts:873",
       "why": "Symbolic module-global read.",
-      "evidence": ["src/ir/nodes.ts:867"]
+      "evidence": ["src/ir/nodes.ts:871"]
     },
     "global.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:875",
+      "declaredAt": "src/ir/nodes.ts:879",
       "why": "Symbolic module-global write.",
-      "evidence": ["src/ir/nodes.ts:873"]
+      "evidence": ["src/ir/nodes.ts:877"]
     },
     "if": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1065",
+      "declaredAt": "src/ir/nodes.ts:1069",
       "why": "Value-producing short-circuiting if/else over an i32 condition. Truthiness is NOT part of it — `dyn.truthy` is, and that already lives in the dialect.",
-      "evidence": ["src/ir/nodes.ts:1045"]
+      "evidence": ["src/ir/nodes.ts:1049"]
     },
     "if.stmt": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2155",
+      "declaredAt": "src/ir/nodes.ts:2159",
       "why": "Statement-level if/else over an i32 condition, no carrier values.",
-      "evidence": ["src/ir/nodes.ts:2137"]
+      "evidence": ["src/ir/nodes.ts:2141"]
     },
     "intrinsic": {
       "verdict": "unresolved",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:860",
-      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 28 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:34"],
+      "declaredAt": "src/ir/nodes.ts:864",
+      "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 29 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:35"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {
@@ -395,87 +395,87 @@
     "labeled.block": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2170",
+      "declaredAt": "src/ir/nodes.ts:2174",
       "why": "A break-only labeled frame lowering to one Wasm block.",
-      "evidence": ["src/ir/nodes.ts:2162"]
+      "evidence": ["src/ir/nodes.ts:2166"]
     },
     "object.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1322",
+      "declaredAt": "src/ir/nodes.ts:1326",
       "why": "Static field read by name, resolved to a struct index at lowering. Dynamic keys are `dyn.member_get`, which is in the dialect.",
-      "evidence": ["src/ir/nodes.ts:1315", "src/ir/dialect/js.ts:225"]
+      "evidence": ["src/ir/nodes.ts:1319", "src/ir/dialect/js.ts:225"]
     },
     "object.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1309",
+      "declaredAt": "src/ir/nodes.ts:1313",
       "why": "Constructs a record from a declared field layout. No prototype, no descriptors, no insertion order semantics.",
-      "evidence": ["src/ir/nodes.ts:197", "src/ir/nodes.ts:1310"]
+      "evidence": ["src/ir/nodes.ts:197", "src/ir/nodes.ts:1314"]
     },
     "object.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1333",
+      "declaredAt": "src/ir/nodes.ts:1337",
       "why": "Static field write by name. The JS `[[Set]]` path is `dyn.member_set`, which is in the dialect.",
-      "evidence": ["src/ir/nodes.ts:1328", "src/ir/dialect/js.ts:241"]
+      "evidence": ["src/ir/nodes.ts:1332", "src/ir/dialect/js.ts:241"]
     },
     "raw.wasm": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1080",
+      "declaredAt": "src/ir/nodes.ts:1084",
       "why": "An opaque backend instruction sequence. Nothing about it is language-specific.",
-      "evidence": ["src/ir/nodes.ts:1074"],
+      "evidence": ["src/ir/nodes.ts:1078"],
       "residual": "Backend axis, not the language axis: it carries `Instr[]`, i.e. concrete backend opcodes, so it is a backend-agnosticism leak (docs/architecture/codegen-axes.md), not an ECMAScript one."
     },
     "refcell.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1436",
+      "declaredAt": "src/ir/nodes.ts:1440",
       "why": "Reads the cell's single field.",
-      "evidence": ["src/ir/nodes.ts:1430"]
+      "evidence": ["src/ir/nodes.ts:1434"]
     },
     "refcell.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1425",
+      "declaredAt": "src/ir/nodes.ts:1429",
       "why": "One-field mutable cell — the standard boxing of a mutable capture.",
-      "evidence": ["src/ir/nodes.ts:1418"]
+      "evidence": ["src/ir/nodes.ts:1422"]
     },
     "refcell.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1447",
+      "declaredAt": "src/ir/nodes.ts:1451",
       "why": "Writes the cell's single field.",
-      "evidence": ["src/ir/nodes.ts:1441"]
+      "evidence": ["src/ir/nodes.ts:1445"]
     },
     "return": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2393",
+      "declaredAt": "src/ir/nodes.ts:2397",
       "why": "Block terminator returning the function's results.",
-      "evidence": ["src/ir/nodes.ts:2392"]
+      "evidence": ["src/ir/nodes.ts:2396"]
     },
     "select": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1037",
+      "declaredAt": "src/ir/nodes.ts:1041",
       "why": "Wasm `select`: both arms evaluated, no short-circuit, no coercion.",
-      "evidence": ["src/ir/nodes.ts:1031"]
+      "evidence": ["src/ir/nodes.ts:1035"]
     },
     "slot.read": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1652",
+      "declaredAt": "src/ir/nodes.ts:1656",
       "why": "Reads a function-level Wasm local.",
-      "evidence": ["src/ir/nodes.ts:1644"]
+      "evidence": ["src/ir/nodes.ts:1648"]
     },
     "slot.write": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1663",
+      "declaredAt": "src/ir/nodes.ts:1667",
       "why": "Writes a function-level Wasm local.",
-      "evidence": ["src/ir/nodes.ts:1657"]
+      "evidence": ["src/ir/nodes.ts:1661"]
     },
     "string.char_at": {
       "verdict": "js",
@@ -494,31 +494,31 @@
     "string.concat": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1212",
+      "declaredAt": "src/ir/nodes.ts:1216",
       "why": "Concatenation of two values already statically known to be strings — no ToString, no `+` overload.",
-      "evidence": ["src/ir/nodes.ts:1207"]
+      "evidence": ["src/ir/nodes.ts:1211"]
     },
     "string.const": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1186",
+      "declaredAt": "src/ir/nodes.ts:1190",
       "why": "Materializes a literal; storage/materializer are backend selections made during preparation.",
-      "evidence": ["src/ir/nodes.ts:1187"],
+      "evidence": ["src/ir/nodes.ts:1191"],
       "residual": "Carrier: the literal's length is counted in UTF-16 code units, the same family commitment that leaves `string.len` unresolved. Settling `string.len` settles this too."
     },
     "string.eq": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1228",
+      "declaredAt": "src/ir/nodes.ts:1232",
       "why": "Value equality of two strings. No abstract equality, no coercion — `dyn.eq` covers that and is already in the dialect.",
-      "evidence": ["src/ir/nodes.ts:1224"]
+      "evidence": ["src/ir/nodes.ts:1228"]
     },
     "string.len": {
       "verdict": "unresolved",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1244",
+      "declaredAt": "src/ir/nodes.ts:1248",
       "why": "The MEANING is settled and it is not encoding-parameterized: every backend returns the UTF-16 CODE-UNIT count. The linear backend calls `__str_length_utf16` regardless of `inputEncoding`, and the WasmGC native provider reads a field documented as the UTF-16 code-unit length. What is NOT settled is the placement: that commitment is shared verbatim with Java/C#/the whole UTF-16 family, so it is not ECMAScript-specific the way `char_at`'s out-of-range sentinel is, yet it is a language commitment a Rust or Python producer could not use.",
-      "evidence": ["src/ir/nodes.ts:1260", "src/ir/backend/linear-integration.ts:1611", "src/ir/string-runtime.ts:15"],
+      "evidence": ["src/ir/nodes.ts:1264", "src/ir/backend/linear-integration.ts:1611", "src/ir/string-runtime.ts:15"],
       "settledBy": "A policy call phase 2 has to make anyway: does `js` mean ECMAScript-SPECIFIC, or LANGUAGE-COMMITTED? If the former, `string.len` stays in core with a documented commitment; if the latter it moves — and the same answer then governs a future `utf16-string` dialect shared by the family, which is the third option."
     },
     "string.repeat": {
@@ -531,96 +531,96 @@
     "switch": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2203",
+      "declaredAt": "src/ir/nodes.ts:2207",
       "why": "The C-family fall-through ladder. Case selection compares literals in the discriminant's own value type, so the NaN/-0 behaviour it documents is IEEE-754's, reached through `f64.eq`, not an ECMAScript rule.",
-      "evidence": ["src/ir/nodes.ts:2183"]
+      "evidence": ["src/ir/nodes.ts:2187"]
     },
     "tag.test": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1160",
+      "declaredAt": "src/ir/nodes.ts:1164",
       "why": "Runtime tag discriminator over a tagged carrier; serves scalar unions as well as the dynamic carrier.",
-      "evidence": ["src/ir/nodes.ts:1145"],
+      "evidence": ["src/ir/nodes.ts:1149"],
       "residual": "Same as `unbox`: the operand is a neutral `tagId?: TagId` since #3954 phase 3 (W4/W5); the residual is the `TagId -> JsTag` crossing in the lowering pass (W2/W6), a seam question."
     },
     "throw": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1903",
+      "declaredAt": "src/ir/nodes.ts:1907",
       "why": "Raises through one Wasm tag with a reference payload. No Error hierarchy, no completion record, no type-based dispatch — a typed language would test in the handler, which this model permits.",
-      "evidence": ["src/ir/nodes.ts:1888"]
+      "evidence": ["src/ir/nodes.ts:1892"]
     },
     "try": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2084",
+      "declaredAt": "src/ir/nodes.ts:2088",
       "why": "Structured try/catch/finally with one untyped handler. Notably it does NOT model completion records: `early.return` is REFUSED inside these buffers rather than being made to run the inlined finally, so the ECMAScript machinery is excluded rather than encoded.",
-      "evidence": ["src/ir/nodes.ts:2055"]
+      "evidence": ["src/ir/nodes.ts:2059"]
     },
     "unary": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1025",
+      "declaredAt": "src/ir/nodes.ts:1029",
       "why": "Every `IrUnop` member is a single Wasm opcode (`f64.neg`, `i32.eqz`, `i32.trunc_sat_f64_s`, `ref.is_null`, the Math f64 family). Their USES are JS-motivated; the operations are not. Contrast `binary`, whose enum carries composite `js.*` ops.",
-      "evidence": ["src/ir/nodes.ts:983"]
+      "evidence": ["src/ir/nodes.ts:987"]
     },
     "unbox": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1136",
+      "declaredAt": "src/ir/nodes.ts:1140",
       "why": "Payload extraction from a tagged carrier after the tag is proven; the union operand form has no JS content.",
-      "evidence": ["src/ir/nodes.ts:1141"],
+      "evidence": ["src/ir/nodes.ts:1145"],
       "residual": "Same as `box`. #3954 phase 3 (W4/W5) made the operand itself neutral — the field is `tagId?: TagId` and `IrFunctionBuilder` asks a `TagDomain` — so the residual is now only the `TagId -> JsTag` crossing in the lowering pass (W2/W6), which is a seam question."
     },
     "unreachable": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2413",
+      "declaredAt": "src/ir/nodes.ts:2417",
       "why": "Unreachable terminator.",
-      "evidence": ["src/ir/nodes.ts:2412"]
+      "evidence": ["src/ir/nodes.ts:2416"]
     },
     "vec.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1691",
+      "declaredAt": "src/ir/nodes.ts:1695",
       "why": "Planned in-bounds `array.get` at an i32 index.",
-      "evidence": ["src/ir/nodes.ts:1681", "(absent from src/ir/: array-holes)"]
+      "evidence": ["src/ir/nodes.ts:1685", "(absent from src/ir/: array-holes)"]
     },
     "vec.len": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1676",
+      "declaredAt": "src/ir/nodes.ts:1680",
       "why": "Reads a dense vector's logical length. Element count is a language-independent unit (contrast `string.len`, whose unit is a language commitment).",
-      "evidence": ["src/ir/nodes.ts:1669"],
+      "evidence": ["src/ir/nodes.ts:1673"],
       "residual": "The result defaults to f64 to compose with the JS number model; `integer?: true` opts back into a physical i32, which is what shows it is a REPRESENTATION default rather than part of the operation. #3954 phase 1."
     },
     "vec.new_fixed": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1733",
+      "declaredAt": "src/ir/nodes.ts:1737",
       "why": "Builds a dense vector from statically-known elements. Sparse literals are explicitly out of scope and fall back to legacy, so no hole can reach this node.",
       "evidence": ["src/ir/from-ast.ts:4502"]
     },
     "vec.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1703",
+      "declaredAt": "src/ir/nodes.ts:1707",
       "why": "One planned in-bounds store. Bounds and growth policy stay explicit in the surrounding IR; a holey-array store is routed to a runtime helper instead.",
-      "evidence": ["src/ir/nodes.ts:1697", "src/ir/from-ast.ts:380"]
+      "evidence": ["src/ir/nodes.ts:1701", "src/ir/from-ast.ts:380"]
     },
     "vec.set_length": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1711",
+      "declaredAt": "src/ir/nodes.ts:1715",
       "why": "Writes a resizable vector's logical length.",
-      "evidence": ["src/ir/nodes.ts:1709"]
+      "evidence": ["src/ir/nodes.ts:1713"]
     },
     "while.loop": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1985",
+      "declaredAt": "src/ir/nodes.ts:1989",
       "why": "Pre-test loop over a condition buffer whose value is an i32. Truthiness conversion happens before it, in `dyn.truthy`.",
-      "evidence": ["src/ir/nodes.ts:1986"]
+      "evidence": ["src/ir/nodes.ts:1990"]
     }
   }
 }

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -66,7 +66,12 @@ type VecLayout = IrVecLowering | LinearVecLowering;
  * sink, while each backend still chooses its native typed representation.
  */
 export type BackendScalarConstType = "i32" | "f64";
-export type BackendNumericConversionOp = "i32.trunc_sat_f64_u" | "f64.convert_i32_s" | "f64.convert_i32_u";
+export type BackendNumericConversionOp =
+  | "i32.trunc_sat_f64_u"
+  | "f32.demote_f64"
+  | "f64.convert_i32_s"
+  | "f64.convert_i32_u"
+  | "f64.promote_f32";
 export type BackendI32BitwiseOp = "i32.and" | "i32.or" | "i32.xor" | "i32.shl" | "i32.shr_s" | "i32.shr_u";
 
 /**

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -246,6 +246,7 @@ function linearInstrError(instr: IrInstr): string | null {
         case "math.abs":
         case "math.ceil":
         case "math.floor":
+        case "math.fround":
         case "math.sqrt":
         case "math.trunc":
           return null;

--- a/src/ir/backend/porffor/sink.ts
+++ b/src/ir/backend/porffor/sink.ts
@@ -771,6 +771,9 @@ export class PorfforEmitter implements BackendEmitter<PorfforSink> {
       case "f64.convert_i32_u":
         out.push(convertExpr("f64", convertExpr("u32", value, 0), 0));
         return;
+      case "f32.demote_f64":
+      case "f64.promote_f32":
+        throw new Error(`porffor backend does not support numeric conversion '${op}'`);
     }
   }
 

--- a/src/ir/intrinsic-support.ts
+++ b/src/ir/intrinsic-support.ts
@@ -121,6 +121,9 @@ function providerAttachment(id: IrInstrIntrinsic["id"], provider: RuntimeProvide
   if (provider.implementation.kind === "backend-op") {
     return Object.freeze({ kind: "backend-op", opcode: provider.implementation.opcode });
   }
+  if (provider.implementation.kind === "backend-sequence") {
+    return Object.freeze({ kind: "backend-sequence", sequence: provider.implementation.sequence });
+  }
   return Object.freeze({
     kind: "callable",
     // Structural identity remains the semantic ID. The compatibility name is
@@ -132,6 +135,9 @@ function providerAttachment(id: IrInstrIntrinsic["id"], provider: RuntimeProvide
 function sameProvider(left: IrIntrinsicProvider, right: IrIntrinsicProvider): boolean {
   if (left.kind !== right.kind) return false;
   if (left.kind === "backend-op" && right.kind === "backend-op") return left.opcode === right.opcode;
+  if (left.kind === "backend-sequence" && right.kind === "backend-sequence") {
+    return left.sequence === right.sequence;
+  }
   return (
     left.kind === "callable" &&
     right.kind === "callable" &&

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -27,6 +27,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.exp",
   "math.expm1",
   "math.floor",
+  "math.fround",
   "math.log",
   "math.log10",
   "math.log1p",
@@ -45,7 +46,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
 export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the twenty-eight intrinsic entry points.
+ * Provider requirements reachable from the twenty-nine intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -64,6 +65,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.exp",
   "math.expm1",
   "math.floor",
+  "math.fround",
   "math.log",
   "math.log10",
   "math.log1p",
@@ -170,6 +172,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.exp": definition("math.exp", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.expm1": definition("math.expm1", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.floor": definition("math.floor", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.fround": definition("math.fround", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log": definition("math.log", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log10": definition("math.log10", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log1p": definition("math.log1p", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -402,8 +402,25 @@ function emitPreparedIntrinsic<S>(
       `ir/lower: semantic intrinsic ${instr.id} has no frozen provider (${funcName})`,
     );
   }
-  if (instr.provider.kind === "backend-op") emitter.emitUnary(instr.provider.opcode, out);
-  else emitter.emitCall(resolver.resolveFunc(instr.provider.target), out);
+  if (instr.provider.kind === "backend-op") {
+    emitter.emitUnary(instr.provider.opcode, out);
+    return;
+  }
+  if (instr.provider.kind === "backend-sequence") {
+    switch (instr.provider.sequence) {
+      case "f64.fround":
+        emitter.emitNumericConversion("f32.demote_f64", out);
+        emitter.emitNumericConversion("f64.promote_f32", out);
+        return;
+    }
+    const sequence: never = instr.provider.sequence;
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "lower",
+      `ir/lower: semantic intrinsic ${instr.id} has unsupported backend sequence ${String(sequence)} (${funcName})`,
+    );
+  }
+  emitter.emitCall(resolver.resolveFunc(instr.provider.target), out);
 }
 
 /**

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -842,6 +842,9 @@ export interface IrInstrCall extends IrInstrBase {
 /** Backend primitive choices available to the first semantic-intrinsic family. */
 export type IrIntrinsicBackendOp = "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.ceil" | "f64.trunc";
 
+/** Closed multi-op backend expansions available to semantic intrinsics. */
+export type IrIntrinsicBackendSequence = "f64.fround";
+
 /**
  * Provider attachment selected after middle-end transforms and manifest
  * freeze. Source/type lowering emits no provider; preparation attaches either
@@ -849,6 +852,7 @@ export type IrIntrinsicBackendOp = "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.c
  */
 export type IrIntrinsicProvider =
   | { readonly kind: "backend-op"; readonly opcode: IrIntrinsicBackendOp }
+  | { readonly kind: "backend-sequence"; readonly sequence: IrIntrinsicBackendSequence }
   | { readonly kind: "callable"; readonly target: IrFuncRef };
 
 /**

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -9,7 +9,7 @@
  * frozen arrays/records. Lowering receives lookup-only `resolveProvider` calls;
  * a request absent from the frozen plan is a typed invariant.
  */
-import { irTypeEquals, type IrIntrinsicBackendOp } from "./nodes.js";
+import { irTypeEquals, type IrIntrinsicBackendOp, type IrIntrinsicBackendSequence } from "./nodes.js";
 import {
   ASYNC_HOST_CAPABILITY_IDS,
   ASYNC_OPTIONAL_RUNTIME_FEATURES,
@@ -49,6 +49,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "backend.f64.abs",
   "backend.f64.ceil",
   "backend.f64.floor",
+  "backend.f64.fround",
   "backend.f64.sqrt",
   "backend.f64.trunc",
   "selfhost.math.acos",
@@ -86,6 +87,10 @@ export type RuntimeProviderImplementation =
       readonly opcode: IrIntrinsicBackendOp;
     }
   | {
+      readonly kind: "backend-sequence";
+      readonly sequence: IrIntrinsicBackendSequence;
+    }
+  | {
       readonly kind: "self-hosted";
       /** Concrete ABI spelling, deliberately below the semantic feature. */
       readonly symbol: string;
@@ -107,7 +112,7 @@ export type RuntimeProviderImplementation =
 
 export type MathRuntimeProviderImplementation = Extract<
   RuntimeProviderImplementation,
-  { readonly kind: "backend-op" | "self-hosted" }
+  { readonly kind: "backend-op" | "backend-sequence" | "self-hosted" }
 >;
 
 export interface RuntimeProviderDefinition {
@@ -197,6 +202,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.exp": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.expm1": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.floor": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.fround": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log10": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log1p": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -320,6 +326,10 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
     kind: "backend-op",
     opcode: "f64.floor",
   }),
+  "math.fround": provider("backend.f64.fround", "math.fround", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "backend-sequence",
+    sequence: "f64.fround",
+  }),
   "math.log": provider("selfhost.math.log", "math.log", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "self-hosted",
     symbol: "Math_log",
@@ -399,7 +409,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderD
   }),
 });
 
-/** Canonically ordered default provider catalogue for the twenty-eight-method slice. */
+/** Canonically ordered default provider catalogue for the twenty-nine-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -76,7 +76,13 @@ import { selectWithEnvironmentClosures } from "./with-environment.js";
 // (#1373b C-1) Pure-syntactic async helpers from the LEAF module (safe for
 // ir/* — async-static.ts imports only ts-api, so no codegen/index cycle).
 import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "./async-static.js";
-import { closureSignatureEquals, type IrClassShape, type IrClosureSignature, type IrType } from "./nodes.js";
+import {
+  closureSignatureEquals,
+  type IrClassShape,
+  type IrClosureSignature,
+  type IrIntrinsicBackendSequence,
+  type IrType,
+} from "./nodes.js";
 import type { IrImportedFunctionResolver, IrResolvedFunctionTarget } from "./imported-functions.js";
 import { programCallablePhase1Verdict, visitProgramCallableUse } from "./program-callable-selection.js";
 import { isAffineThreeDeepElementAccess, unwrapTypeErasedExpression } from "./select-expression-structure.js";
@@ -277,20 +283,27 @@ export type IrMathMethodPlan =
       readonly intrinsic: IntrinsicId;
       readonly op: "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.ceil" | "f64.trunc";
     }
+  | {
+      readonly arity: 1;
+      readonly intrinsic: IntrinsicId;
+      readonly sequence: IrIntrinsicBackendSequence;
+    }
   | { readonly arity: 1 | 2; readonly intrinsic: IntrinsicId };
 
 /**
  * Exact-arity Math surface shared by selection, call-graph closure, and the
  * AST→IR builder. Every accepted method becomes a versioned semantic
- * intrinsic. `op` remains only as a selector compatibility signal for the
- * five methods that never require a callable provider; provider selection is
- * performed after middle-end transforms. Keeping arity here prevents
- * selector/builder drift and preserves ambient-Math identity checks.
+ * intrinsic. `op` remains the selector compatibility signal for the five
+ * single-op methods, while `sequence` marks the closed native multi-op path;
+ * provider selection is performed after middle-end transforms. Keeping arity
+ * here prevents selector/builder drift and preserves ambient-Math identity
+ * checks.
  */
 export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = {
   abs: { arity: 1, intrinsic: "math.abs", op: "f64.abs" },
   sqrt: { arity: 1, intrinsic: "math.sqrt", op: "f64.sqrt" },
   floor: { arity: 1, intrinsic: "math.floor", op: "f64.floor" },
+  fround: { arity: 1, intrinsic: "math.fround", sequence: "f64.fround" },
   ceil: { arity: 1, intrinsic: "math.ceil", op: "f64.ceil" },
   trunc: { arity: 1, intrinsic: "math.trunc", op: "f64.trunc" },
   asin: { arity: 1, intrinsic: "math.asin" },
@@ -6501,13 +6514,14 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.cosh" && process.env.JS2WASM_IR_MATH_COSH === "0") return false;
   if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
   if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
+  if (plan.intrinsic === "math.fround" && process.env.JS2WASM_IR_MATH_FROUND === "0") return false;
   if (plan.intrinsic === "math.round" && process.env.JS2WASM_IR_MATH_ROUND === "0") return false;
   if (plan.intrinsic === "math.sign" && process.env.JS2WASM_IR_MATH_SIGN === "0") return false;
   if (plan.intrinsic === "math.expm1" && process.env.JS2WASM_IR_MATH_EXPM1 === "0") return false;
   if (plan.intrinsic === "math.asinh" && process.env.JS2WASM_IR_MATH_ASINH === "0") return false;
   if (plan.intrinsic === "math.acosh" && process.env.JS2WASM_IR_MATH_ACOSH === "0") return false;
   if (plan.intrinsic === "math.atanh" && process.env.JS2WASM_IR_MATH_ATANH === "0") return false;
-  return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
+  return "op" in plan || "sequence" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
 }
 
 function selectorSupportsNumberToString(): boolean {

--- a/tests/issue-3526-ir-linear-math-intrinsics.test.ts
+++ b/tests/issue-3526-ir-linear-math-intrinsics.test.ts
@@ -10,10 +10,11 @@ import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js"
 
 const identities = createTestIrFunctionIdentityFactory("issue-3526-ir-linear-math-intrinsics");
 const F64 = irVal({ kind: "f64" });
-const LINEAR_BACKEND_OP_INTRINSICS = [
+const LINEAR_NATIVE_INTRINSICS = [
   "math.abs",
   "math.ceil",
   "math.floor",
+  "math.fround",
   "math.sqrt",
   "math.trunc",
 ] as const satisfies readonly IntrinsicId[];
@@ -29,17 +30,17 @@ function intrinsicFunction(id: IntrinsicId): IrFunction {
 }
 
 describe("#3526 linear semantic Math intrinsic legality", () => {
-  it("admits exactly the five semantic intrinsics backed by native linear f64 operations", () => {
+  it("admits exactly the six semantic intrinsics backed by native linear operations", () => {
     const admitted = PURE_MATH_INTRINSIC_IDS.filter(
       (id) => verifyIrBackendLegality(intrinsicFunction(id), "linear").length === 0,
     );
 
-    expect(admitted).toStrictEqual(LINEAR_BACKEND_OP_INTRINSICS);
+    expect(admitted).toStrictEqual(LINEAR_NATIVE_INTRINSICS);
   });
 
   it("rejects every callable-backed Math intrinsic at the linear boundary", () => {
     const callableBacked = PURE_MATH_INTRINSIC_IDS.filter(
-      (id) => !LINEAR_BACKEND_OP_INTRINSICS.includes(id as (typeof LINEAR_BACKEND_OP_INTRINSICS)[number]),
+      (id) => !LINEAR_NATIVE_INTRINSICS.includes(id as (typeof LINEAR_NATIVE_INTRINSICS)[number]),
     );
 
     for (const id of callableBacked) {

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -17,7 +17,8 @@ import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js"
 
 const identities = createTestIrFunctionIdentityFactory("issue-3526-ir-math-intrinsic-integration");
 const F64 = irVal({ kind: "f64" });
-const BACKEND_INTRINSICS = new Set<IntrinsicId>(["math.abs", "math.sqrt", "math.floor", "math.ceil", "math.trunc"]);
+const BACKEND_OP_INTRINSICS = new Set<IntrinsicId>(["math.abs", "math.sqrt", "math.floor", "math.ceil", "math.trunc"]);
+const BACKEND_SEQUENCE_INTRINSICS = new Set<IntrinsicId>(["math.fround"]);
 
 const METHODS = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length));
 
@@ -71,7 +72,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
           + Math.asinh(x) + Math.acosh(x) + Math.atanh(x)
           + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
-          + Math.cbrt(x) + Math.round(x) + Math.sign(x)
+          + Math.cbrt(x) + Math.fround(x) + Math.round(x) + Math.sign(x)
           + Math.exp(x) + Math.expm1(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
@@ -103,8 +104,10 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
 
     expect(prepared.manifest.intrinsicUses.map((use) => use.id).sort()).toEqual([...PURE_MATH_INTRINSIC_IDS].sort());
     for (const instr of instructions) {
-      if (BACKEND_INTRINSICS.has(instr.id)) {
+      if (BACKEND_OP_INTRINSICS.has(instr.id)) {
         expect(instr.provider).toMatchObject({ kind: "backend-op" });
+      } else if (BACKEND_SEQUENCE_INTRINSICS.has(instr.id)) {
+        expect(instr.provider).toEqual({ kind: "backend-sequence", sequence: "f64.fround" });
       } else {
         expect(instr.provider).toMatchObject({
           kind: "callable",
@@ -136,6 +139,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function cosh(): number { return Math.cosh(0.75); }
       export function tanh(): number { return Math.tanh(0.75); }
       export function cbrt(): number { return Math.cbrt(27); }
+      export function fround(): number { return Math.fround(1.337); }
       export function round(): number { return Math.round(-27.5); }
       export function sign(): number { return Math.sign(-27); }
       export function exp(): number { return Math.exp(1.25); }
@@ -176,6 +180,8 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
     for (const opcode of ["f64.abs", "f64.sqrt", "f64.floor", "f64.ceil", "f64.trunc"]) {
       expect(ir.wat).toContain(opcode);
     }
+    expect(ir.wat).toContain("f32.demote_f64");
+    expect(ir.wat).toContain("f64.promote_f32");
     for (const helper of [
       "asin",
       "acos",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,12 +88,12 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact twenty-eight certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact twenty-nine certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(28);
+    expect(intrinsicMethods).toHaveLength(29);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
@@ -107,6 +107,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         "math.cbrt",
         "math.cosh",
         "math.expm1",
+        "math.fround",
         "math.log10",
         "math.log1p",
         "math.reduce-trig",
@@ -139,7 +140,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(28);
+    expect(first.intrinsicUses).toHaveLength(29);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -158,6 +159,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.tanh"]).toEqual(["math.exp"]);
     expect(dependencies["math.cbrt"]).toEqual([]);
     expect(dependencies["math.expm1"]).toEqual(["math.exp"]);
+    expect(dependencies["math.fround"]).toEqual([]);
     expect(dependencies["math.round"]).toEqual([]);
     expect(dependencies["math.sign"]).toEqual([]);
     expect(dependencies["math.asinh"]).toEqual(["math.log"]);
@@ -184,6 +186,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
           "math.acosh",
           "math.atanh",
           "math.sin",
+          "math.fround",
           "math.round",
           "math.sign",
           "math.tan",
@@ -217,6 +220,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
       "math.cosh",
       "math.exp",
       "math.expm1",
+      "math.fround",
       "math.log",
       "math.log10",
       "math.log1p",

--- a/tests/issue-5118-ir-math-fround.test.ts
+++ b/tests/issue-5118-ir-math-fround.test.ts
@@ -1,0 +1,379 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { getLastLinearIrReport } from "../src/ir/backend/linear-integration.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5118-ir-math-fround");
+const SOURCE = `export function fround(value: number): number { return Math.fround(value); }`;
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = result.importObject ?? buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+function numberFromBits(bits: bigint): number {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setBigUint64(0, bits);
+  return view.getFloat64(0);
+}
+
+function numberBits(value: number): bigint {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value);
+  return view.getBigUint64(0);
+}
+
+function f32FromBits(bits: number): number {
+  const buffer = new ArrayBuffer(4);
+  const view = new DataView(buffer);
+  view.setUint32(0, bits);
+  return view.getFloat32(0);
+}
+
+function adjacent(value: number, direction: 1n | -1n): number {
+  if (Number.isNaN(value) || value === Number.POSITIVE_INFINITY || value === Number.NEGATIVE_INFINITY) return value;
+  if (value === 0) return direction === 1n ? Number.MIN_VALUE : -Number.MIN_VALUE;
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value);
+  const step = value > 0 ? direction : -direction;
+  view.setBigUint64(0, view.getBigUint64(0) + step);
+  return view.getFloat64(0);
+}
+
+function nextUp(value: number): number {
+  return adjacent(value, 1n);
+}
+
+function nextDown(value: number): number {
+  return adjacent(value, -1n);
+}
+
+function parityValues(): number[] {
+  const minSubnormal = f32FromBits(0x0000_0001);
+  const maxSubnormal = f32FromBits(0x007f_ffff);
+  const minNormal = f32FromBits(0x0080_0000);
+  const maxFinite = f32FromBits(0x7f7f_ffff);
+  const zeroTie = 2 ** -150;
+  const secondSubnormalTie = 3 * 2 ** -150;
+  const normalBoundaryTie = minNormal - minSubnormal / 2;
+  const evenDownTie = 1 + 2 ** -24;
+  const evenUpTie = 1 + 3 * 2 ** -24;
+  const overflowTie = maxFinite + 2 ** 103;
+  const positive = [
+    Number.MIN_VALUE,
+    nextDown(zeroTie),
+    zeroTie,
+    nextUp(zeroTie),
+    minSubnormal,
+    nextDown(secondSubnormalTie),
+    secondSubnormalTie,
+    nextUp(secondSubnormalTie),
+    maxSubnormal,
+    nextDown(normalBoundaryTie),
+    normalBoundaryTie,
+    nextUp(normalBoundaryTie),
+    minNormal,
+    nextDown(evenDownTie),
+    evenDownTie,
+    nextUp(evenDownTie),
+    nextDown(evenUpTie),
+    evenUpTie,
+    nextUp(evenUpTie),
+    maxFinite,
+    nextDown(overflowTie),
+    overflowTie,
+    nextUp(overflowTie),
+    Number.MAX_VALUE,
+    Number.POSITIVE_INFINITY,
+  ];
+  return [
+    numberFromBits(0x7ff0_0000_0000_0001n),
+    numberFromBits(0x7ff8_0000_0000_0042n),
+    numberFromBits(0xfff0_0000_0000_0001n),
+    numberFromBits(0xfff8_0000_0000_0042n),
+    ...positive.flatMap((value) => [-value, value]),
+    -0,
+    0,
+  ];
+}
+
+function minimalResolver(): IrLowerResolver {
+  let nextType = 0;
+  return {
+    resolveFunc: () => 0,
+    resolveGlobal: () => {
+      throw new Error("resolveGlobal not used in this test");
+    },
+    resolveType: () => {
+      throw new Error("resolveType not used in this test");
+    },
+    internFuncType: () => nextType++,
+  };
+}
+
+const exclusionCases = [
+  [
+    "shadowed Math",
+    `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5118 shadowed Math is intentionally not ambient.
+      return Math.fround(x);
+    }`,
+  ],
+  ["aliased fround", `const fround = Math.fround; export function f(x: number): number { return fround(x); }`],
+  ["computed fround", `export function f(x: number): number { return Math["fround"](x); }`],
+  ["optional invocation", `export function f(x: number): number { return Math.fround?.(x); }`],
+  ["optional receiver", `export function f(x: number): number { return Math?.fround(x); }`],
+  [
+    "wrong arity",
+    `export function f(x: number): number {
+      // @ts-expect-error #5118 intentionally exercises extra arity.
+      return Math.fround(x, x);
+    }`,
+  ],
+  ["spread argument", `export function f(x: number): number { return Math.fround(...([x] as [number])); }`],
+  [
+    "non-number argument",
+    `export function f(): number {
+      const text: string = "1";
+      return Math.fround(text as never);
+    }`,
+  ],
+] as const;
+
+describe("#5118 exact ambient Math.fround IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims the exact one-number call on the %s target", async (label, target) => {
+    const result = await compile(SOURCE, {
+      fileName: `issue-5118-${label}.ts`,
+      ...(target === undefined ? {} : { target }),
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "fround")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irCompiledFuncs ?? []).toContain("fround");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.wat).not.toContain("$Math_fround");
+    const demote = result.wat?.indexOf("f32.demote_f64") ?? -1;
+    const promote = result.wat?.indexOf("f64.promote_f32") ?? -1;
+    expect(demote).toBeGreaterThanOrEqual(0);
+    expect(promote).toBeGreaterThan(demote);
+
+    const fround = (await instantiate(result)).fround as (value: number) => number;
+    expect(fround(1 + 2 ** -24)).toBe(1);
+    expect(fround(1 + 3 * 2 ** -24)).toBe(1 + 2 ** -22);
+    expect(Object.is(fround(-(2 ** -150)), -0)).toBe(true);
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("claims and executes the same closed sequence on production linear", async () => {
+    const result = await compile(SOURCE, {
+      fileName: "issue-5118-linear.ts",
+      target: "linear",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    const report = getLastLinearIrReport();
+    expect(report?.compiled).toContain("fround");
+    expect(report?.rejected).toEqual([]);
+    expect(result.wat).toContain("f32.demote_f64");
+    expect(result.wat).toContain("f64.promote_f32");
+    const fround = (await instantiate(result)).fround as (value: number) => number;
+    expect(fround(1 + 2 ** -24)).toBe(1);
+    expect(Object.is(fround(-0), -0)).toBe(true);
+  });
+
+  it("attaches one dependency-free host-free sequence provider for both Wasm backends", () => {
+    const analysis = analyzeSource(SOURCE);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing fround declaration");
+
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("fround").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic.map((instr) => instr.id)).toEqual(["math.fround"]);
+    expect(semantic[0]?.args).toHaveLength(1);
+    expect(semantic[0]?.provider).toBeUndefined();
+
+    for (const backend of ["wasmgc", "linear"] as const) {
+      const prepared = prepareIrRuntimeManifest({
+        functions: [lowered],
+        sourceFile: analysis.sourceFile.fileName,
+        policy: { target: "standalone", backend },
+      });
+      if (!prepared) throw new Error("expected a non-empty runtime manifest");
+      expect(prepared.manifest.intrinsicUses.map((use) => use.id)).toEqual(["math.fround"]);
+      expect(prepared.manifest.features).toEqual(["math.fround"]);
+      expect(prepared.manifest.hostCapabilities).toEqual([]);
+      expect(prepared.manifest.providers).toEqual([
+        expect.objectContaining({
+          id: "backend.f64.fround",
+          feature: "math.fround",
+          dependencies: [],
+          implementation: { kind: "backend-sequence", sequence: "f64.fround" },
+        }),
+      ]);
+      expect(intrinsicInstructions(prepared.functions[0]!)[0]?.provider).toEqual({
+        kind: "backend-sequence",
+        sequence: "f64.fround",
+      });
+    }
+  });
+
+  it("is raw-bit identical to direct codegen on WasmGC and to the same oracle on linear", async () => {
+    const [irGc, directGc, irLinear] = await Promise.all([
+      compile(SOURCE, { fileName: "issue-5118-ir-gc.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(SOURCE, { fileName: "issue-5118-direct-gc.ts", experimentalIR: false }),
+      compile(SOURCE, {
+        fileName: "issue-5118-ir-linear-parity.ts",
+        target: "linear",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      }),
+    ]);
+    for (const result of [irGc, directGc, irLinear]) expectSuccess(result);
+    expect(outcomeFor(irGc, "fround")).toMatchObject({ kind: "emitted", irBodyEmitted: true });
+
+    const [irGcExports, directGcExports, irLinearExports] = await Promise.all([
+      instantiate(irGc),
+      instantiate(directGc),
+      instantiate(irLinear),
+    ]);
+    const directOracle = directGcExports.fround;
+    const pairs = [
+      [irGcExports.fround, directOracle, "wasmgc"],
+      [irLinearExports.fround, directOracle, "linear"],
+    ] as const;
+    for (const [irExport, directExport, backend] of pairs) {
+      const irFround = irExport as (value: number) => number;
+      const directFround = directExport as (value: number) => number;
+      for (const value of parityValues()) {
+        const label = `${backend} fround parity for 0x${numberBits(value).toString(16)}`;
+        expect(numberBits(irFround(value)), label).toBe(numberBits(directFround(value)));
+      }
+    }
+  });
+
+  it("fails loudly on a malformed backend sequence", () => {
+    const analysis = analyzeSource(SOURCE);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing fround declaration");
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("malformed").unitId,
+      exported: true,
+    }).main;
+    const malformed = {
+      ...lowered,
+      blocks: lowered.blocks.map((block) => ({
+        ...block,
+        instrs: block.instrs.map((instr) =>
+          instr.kind === "intrinsic"
+            ? {
+                ...instr,
+                provider: { kind: "backend-sequence", sequence: "f64.unknown" },
+              }
+            : instr,
+        ),
+      })),
+    } as unknown as IrFunction;
+    expect(() => lowerIrFunctionToWasm(malformed, minimalResolver())).toThrowError(/unsupported backend sequence/);
+  });
+
+  it("withdraws only fround through its narrow rollback", async () => {
+    const flag = "JS2WASM_IR_MATH_FROUND";
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(SOURCE, {
+        fileName: "issue-5118-rollback.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      expectSuccess(result);
+      expect(outcomeFor(result, "fround")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5118-${label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- add `math.fround` as the 29th certified pure Math intrinsic
- attach one closed `backend-sequence` provider that emits `f32.demote_f64` then `f64.promote_f32`
- claim exact ambient one-number calls on WasmGC and production linear without helpers or imports
- preserve direct routing for shadowed, aliased, computed, optional, spread, wrong-arity, and coercive forms

## Validation

- 15 focused #5118 tests passed, including raw-bit parity at f32 ties, subnormal/normal boundaries, overflow, NaNs, infinities, and signed zero
- 13 affected #3526 integration, runtime-manifest, and linear-legality tests passed
- TypeScript 7 typecheck passed
- IR kind-neutrality gate passed
- full pre-push typecheck, lint, formatting, ratchets, numeric-local parity, and issue-integrity gates passed

## Stack

- base: #5132 (`codex/5117-ir-math-round`)