### PR TITLE
feat(ir): add exact ToUint32 semantic prerequisite

### DIFF
--- a/plan/issues/5119-ir-exact-touint32-prerequisite.md
+++ b/plan/issues/5119-ir-exact-touint32-prerequisite.md
@@ -1,0 +1,142 @@
+---
+id: 5119
+title: "IR: share exact ToUint32 lowering prerequisite"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5119-ir-exact-touint32
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, backend, codegen
+language_feature: math-builtins, numeric-coercion
+goal: ir-full-coverage
+depends_on: [5118]
+required_by: [5120, 5121]
+related: [83, 111, 936, 1094, 1126, 1371, 3526, 3739, 5118]
+files:
+  - src/ir/backend/wasm-int32-coercion.ts
+  - src/ir/lower.ts
+  - src/codegen/binary-ops.ts
+  - src/codegen/index.ts
+  - tests/issue-5119-ir-exact-touint32.test.ts
+loc-budget-allow:
+  - src/ir/lower.ts
+  - src/codegen/binary-ops.ts
+  - src/codegen/index.ts
+func-budget-allow:
+  - src/ir/lower.ts::emitJsToInt32
+  - src/codegen/binary-ops.ts::emitToInt32
+  - src/codegen/index.ts::emitToUint32Helper
+---
+
+# #5119 — Shared exact `ToUint32` IR prerequisite
+
+## Objective
+
+Establish one exact Wasm lowering for the 32-bit bit pattern shared by
+ECMAScript `ToInt32` and `ToUint32`, then make both the production IR bitwise
+lowerer and the legacy `Math.clz32`/`Math.imul` helper consume it.
+
+This checkpoint repairs the current large-finite direct-codegen bug and removes
+the duplicated IR/direct implementation before either Math method is admitted
+to IR. It is intentionally stacked on #5135/#5118. The follow-up checkpoints
+can attach `math.clz32` and `math.imul` providers to this exact conversion
+without inheriting a known semantic defect.
+
+## Measured defect
+
+`emitToUint32Helper` currently lowers a finite input with:
+
+```text
+i64.trunc_sat_f64_s
+i32.wrap_i64
+```
+
+That is exact only while the truncated magnitude fits signed i64. Outside that
+range, the first operation saturates before the second keeps its low 32 bits.
+For example, ECMAScript requires `ToUint32(2**63) === 0`, but signed-i64
+saturation produces `INT64_MAX`, whose wrapped low bits are `0xffffffff`.
+Consequently direct `Math.clz32(2**63)` and `Math.imul(2**63, 1)` are wrong.
+
+The production IR bitwise path already avoids this defect. It decomposes the
+f64 IEEE-754 sign, exponent, and significand, selects only the integer bits that
+can reach the low 32 positions, and applies the sign modulo `2**32`. The direct
+bitwise path carries a byte-identical copy. This is the proven implementation
+to centralize; a new floating modulo approximation is unnecessary.
+
+## Exact contract
+
+For every f64 input, the shared Wasm expansion consumes one f64 and leaves one
+i32 whose raw bits equal `ToUint32(input)`:
+
+- `NaN`, `+0`, `-0`, and both infinities produce zero;
+- finite fractions truncate toward zero before wrapping;
+- all finite magnitudes wrap modulo `2**32`, including values outside signed
+  and unsigned i64 range;
+- negative inputs are negated modulo `2**32`;
+- the i32 bit pattern also represents `ToInt32(input)`, with signedness chosen
+  only when a later consumer widens or compares it.
+
+The helper must not import host JavaScript, trap on an f64 input, evaluate the
+input twice, or use a saturating conversion as the semantic modulo operation.
+
+## Implementation plan
+
+1. Extract the existing exact IEEE-754 instruction expansion into a small
+   Wasm-backend utility with an explicit four-i64-local contract. Keep it free
+   of AST, selector, manifest, and `CodegenContext` dependencies.
+2. Route direct `emitToInt32` and the WasmGC/linear arm of IR
+   `emitJsToInt32` through that utility. Preserve their local allocation and
+   release behavior and keep emitted Wasm byte-identical.
+3. Replace `emitToUint32Helper`'s saturating i64 conversion with the same
+   expansion. Add only the four private i64 locals required by the shared
+   contract; preserve the helper name, signature, registration point, and
+   import-free behavior.
+4. Add focused execution vectors for `Math.clz32` and `Math.imul` with IR
+   disabled, including `2**63`, its negative, very large finite f64 values,
+   `2**32` boundaries, fractions, signed zero, NaN, and infinities. Compare to
+   native JavaScript rather than duplicating expected conversion logic.
+5. Assert the synthesized helper uses the shared bit-decomposition shape and
+   no longer contains `i64.trunc_sat_f64_s`. Pin zero imports in standalone
+   mode and exact direct/IR parity for representative bitwise coercions.
+6. Run the existing bitwise, Math builtin, #3526 integration, TypeScript 7,
+   neutrality, formatting/lint/ratchets, and full pre-push suites. Push the
+   plan, implementation, and outcome as separate checkpoints on a non-draft
+   PR stacked on #5135.
+
+## Acceptance criteria
+
+- Direct `Math.clz32` and `Math.imul` match native JavaScript for every focused
+  edge, especially finite values at and beyond `2**63`.
+- Direct and IR bitwise lowering consume one shared exact expansion and retain
+  their existing behavior and instruction shape.
+- The generated `__toUint32` helper is import-free, non-trapping for all f64
+  inputs, and contains no saturating signed-i64 modulo shortcut.
+- WasmGC and production linear parity remain green; bytecode and Porffor
+  support are unchanged because this checkpoint does not widen IR ownership.
+- Existing exact ambient Math ownership, fallback, and neutrality evidence
+  remains green.
+
+## Non-goals
+
+- Claiming `Math.clz32` or `Math.imul` in IR; each gets a later small PR.
+- Changing source coercion admission, object/Symbol/BigInt behavior, or method
+  arity rules.
+- Replacing every independent `ToUint32` implementation in string, RegExp,
+  array-length, typed-array, or runtime code.
+- Migrating variadic `Math.min`/`max`/`hypot` or stateful `Math.random`.
+
+## Risk and rollback
+
+The main risk is local-index drift while moving a stack-sensitive sequence.
+Byte-shape assertions and direct-versus-IR execution parity guard that seam.
+The Math helper keeps its existing registration and call ABI, so rollback is a
+single checkpoint revert with no manifest or public API change.
+
+## Outcome
+
+Pending implementation and final Luna Max review.

--- a/plan/issues/5119-ir-exact-touint32-prerequisite.md
+++ b/plan/issues/5119-ir-exact-touint32-prerequisite.md
@@ -1,9 +1,10 @@
 ---
 id: 5119
 title: "IR: share exact ToUint32 lowering prerequisite"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
+completed: 2026-08-28
 assignee: ttraenkler/codex
 branch: codex/5119-ir-exact-touint32
 priority: high
@@ -19,17 +20,38 @@ required_by: [5120, 5121]
 related: [83, 111, 936, 1094, 1126, 1371, 3526, 3739, 5118]
 files:
   - src/ir/backend/wasm-int32-coercion.ts
+  - src/ir/nodes.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/intrinsic-support.ts
   - src/ir/lower.ts
+  - src/ir/backend/legality.ts
   - src/codegen/binary-ops.ts
+  - src/codegen/expressions/builtins.ts
   - src/codegen/index.ts
   - tests/issue-5119-ir-exact-touint32.test.ts
 loc-budget-allow:
+  - src/ir/nodes.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/intrinsic-support.ts
   - src/ir/lower.ts
+  - src/ir/backend/legality.ts
   - src/codegen/binary-ops.ts
+  - src/codegen/expressions/builtins.ts
   - src/codegen/index.ts
 func-budget-allow:
+  - src/ir/intrinsic-support.ts::providerAttachment
+  - src/ir/intrinsic-support.ts::sameProvider
+  - src/ir/lower.ts::emitPreparedIntrinsic
+  - src/ir/lower.ts::lowerIrFunctionBody
+  - src/ir/lower.ts::emitInstrTree
   - src/ir/lower.ts::emitJsToInt32
+  - src/ir/backend/legality.ts::linearInstrError
+  - src/ir/backend/legality.ts::bytecodeInstrError
+  - src/ir/backend/legality.ts::porfforInstrError
   - src/codegen/binary-ops.ts::emitToInt32
+  - src/codegen/expressions/builtins.ts::compileMathCall
   - src/codegen/index.ts::emitToUint32Helper
 ---
 
@@ -37,9 +59,10 @@ func-budget-allow:
 
 ## Objective
 
-Establish one exact Wasm lowering for the 32-bit bit pattern shared by
-ECMAScript `ToInt32` and `ToUint32`, then make both the production IR bitwise
-lowerer and the legacy `Math.clz32`/`Math.imul` helper consume it.
+Add a typed, provider-backed `js.to_uint32: f64 -> u32` semantic intrinsic and
+establish one exact Wasm lowering for the 32-bit bit pattern shared by
+ECMAScript `ToInt32` and `ToUint32`. Make the production IR bitwise lowerer and
+the legacy `Math.clz32`/`Math.imul` helper consume that same expansion.
 
 This checkpoint repairs the current large-finite direct-codegen bug and removes
 the duplicated IR/direct implementation before either Math method is admitted
@@ -81,8 +104,12 @@ i32 whose raw bits equal `ToUint32(input)`:
 - the i32 bit pattern also represents `ToInt32(input)`, with signedness chosen
   only when a later consumer widens or compares it.
 
-The helper must not import host JavaScript, trap on an f64 input, evaluate the
-input twice, or use a saturating conversion as the semantic modulo operation.
+The semantic signature is post-`ToNumber`: one f64 argument and an unsigned i32
+result. Object, Symbol, BigInt, and dynamic coercion stay outside this
+checkpoint. The provider is a closed `backend-composite` operation, not a
+single Wasm opcode, arbitrary instruction list, or callable helper. It must not
+import host JavaScript, trap on an f64 input, evaluate the input twice, or use a
+saturating conversion as the semantic modulo operation.
 
 ## Implementation plan
 
@@ -92,18 +119,28 @@ input twice, or use a saturating conversion as the semantic modulo operation.
 2. Route direct `emitToInt32` and the WasmGC/linear arm of IR
    `emitJsToInt32` through that utility. Preserve their local allocation and
    release behavior and keep emitted Wasm byte-identical.
-3. Replace `emitToUint32Helper`'s saturating i64 conversion with the same
+3. Add `js.to_uint32` outside the exact twenty-nine-method pure-Math catalogue,
+   with f64-to-unsigned-i32 signature and one host-free `backend-composite`
+   provider available only to WasmGC and production linear preparation.
+   Preserve provider attachment/equality and missing-provider invariants.
+4. Lower the composite provider through the shared exact expansion and the
+   existing lazily allocated four-i64 scratch pool. Admit it in linear legality
+   while keeping bytecode and Porffor explicitly fail-loud before emission.
+5. Replace `emitToUint32Helper`'s saturating i64 conversion with the same
    expansion. Add only the four private i64 locals required by the shared
    contract; preserve the helper name, signature, registration point, and
-   import-free behavior.
-4. Add focused execution vectors for `Math.clz32` and `Math.imul` with IR
+   import-free behavior. Replace the two missing-helper saturation fallbacks
+   with invariants so collection drift cannot silently reintroduce bad output.
+6. Add focused execution vectors for synthetic `js.to_uint32` IR on WasmGC and
+   production linear plus direct `Math.clz32` and `Math.imul` with IR
    disabled, including `2**63`, its negative, very large finite f64 values,
    `2**32` boundaries, fractions, signed zero, NaN, and infinities. Compare to
    native JavaScript rather than duplicating expected conversion logic.
-5. Assert the synthesized helper uses the shared bit-decomposition shape and
+7. Assert both provider and synthesized helper use the shared bit-decomposition
+   shape and that the helper
    no longer contains `i64.trunc_sat_f64_s`. Pin zero imports in standalone
    mode and exact direct/IR parity for representative bitwise coercions.
-6. Run the existing bitwise, Math builtin, #3526 integration, TypeScript 7,
+8. Run the existing bitwise, Math builtin, #3526 integration, TypeScript 7,
    neutrality, formatting/lint/ratchets, and full pre-push suites. Push the
    plan, implementation, and outcome as separate checkpoints on a non-draft
    PR stacked on #5135.
@@ -112,12 +149,14 @@ input twice, or use a saturating conversion as the semantic modulo operation.
 
 - Direct `Math.clz32` and `Math.imul` match native JavaScript for every focused
   edge, especially finite values at and beyond `2**63`.
+- Synthetic `js.to_uint32` IR prepares and executes on WasmGC and production
+  linear with an unsigned-i32 result, no callable/helper, and no host import.
 - Direct and IR bitwise lowering consume one shared exact expansion and retain
   their existing behavior and instruction shape.
 - The generated `__toUint32` helper is import-free, non-trapping for all f64
   inputs, and contains no saturating signed-i64 modulo shortcut.
-- WasmGC and production linear parity remain green; bytecode and Porffor
-  support are unchanged because this checkpoint does not widen IR ownership.
+- Missing providers and unsupported bytecode/Porffor policies fail before
+  emission; no backend silently substitutes saturation.
 - Existing exact ambient Math ownership, fallback, and neutrality evidence
   remains green.
 
@@ -139,4 +178,17 @@ single checkpoint revert with no manifest or public API change.
 
 ## Outcome
 
-Pending implementation and final Luna Max review.
+Implemented one exact IEEE-754 bit-decomposition expansion shared by direct
+`ToInt32`, IR bitwise coercion, the legacy `__toUint32` helper, and the new
+typed `js.to_uint32` semantic intrinsic. The intrinsic freezes to one
+dependency-free, host-free `backend-composite` provider and executes with an
+identical instruction stream on WasmGC and production linear; bytecode and
+Porffor reject it before emission.
+
+The direct Math helper no longer saturates before wrapping, so `Math.clz32`
+and `Math.imul` now match native JavaScript at and beyond the signed-i64 range.
+Focused execution covers f64 boundaries, fractions, signed zero, NaN,
+infinities, `2**63`, `2**64`, `2**65`, and `Number.MAX_VALUE`. The #3739 exact
+ToInt32 suite, #3526 manifest/intrinsic suites, Math stdlib subset, TypeScript 7
+typecheck, formatting, diff integrity, and the reviewed neutrality baseline all
+pass.

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -40,39 +40,39 @@
     "binary": {
       "verdict": "unresolved",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1022",
+      "declaredAt": "src/ir/nodes.ts:1026",
       "why": "The kind is a neutral envelope; its OPCODE ENUM is not. `IrBinop` mixes ~30 one-to-one Wasm primitives with six `js.*` COMPOSITES (`js.bitand|bitor|bitxor|shl|shr_s|shr_u`), each documented as ToInt32(lhs); ToInt32(rhs); i32.<op>; convert back to f64 — ECMA-262 §7.1.6. `i64.rem_s` is likewise labelled a guarded JS Number remainder fast path. So the declaration cannot be placed on either side: moving `IrInstrBinary` would exile `f64.add`, leaving it in core keeps six ECMAScript operators there. (#4551's contested-family list does not mention `binary`; this is a finding, not a restatement.)",
-      "evidence": ["src/ir/nodes.ts:970", "src/ir/nodes.ts:958"],
+      "evidence": ["src/ir/nodes.ts:974", "src/ir/nodes.ts:962"],
       "settledBy": "Split `IrBinop`: the six `js.*` composites (and the `i64.rem_s` fast path's ECMAScript justification) move to the dialect as a separate opcode union; the Wasm primitives stay. The unit of the fix is the enum, not the interface."
     },
     "box": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1108",
+      "declaredAt": "src/ir/nodes.ts:1112",
       "why": "One boxing concept over a tagged carrier. It also serves plain scalar tagged unions with no JS involvement, so it is not a JS-only operation and moving it to the dialect would be wrong.",
-      "evidence": ["src/ir/nodes.ts:1093"],
+      "evidence": ["src/ir/nodes.ts:1097"],
       "residual": "The JS content is TYPE-LEVEL, via `toType.kind === \"dynamic\"` and the dynamic leaf's `tag?: TagId` refinement — #3954 phase 1's `TagDomain` seam, not a dialect question. Phase 1 made the refinement neutral at the declaration; what is still ECMAScript is the LOWERING, which crosses `TagId -> JsTag` (`lower.ts` `jsTagOf`) to meet the #3029-S1-frozen `IrDynamicLowering` contract. That is #3954 phase 3's W2/W6, and it moves no declaration."
     },
     "br": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2403",
+      "declaredAt": "src/ir/nodes.ts:2407",
       "why": "Unconditional branch with block arguments in place of phi nodes.",
-      "evidence": ["src/ir/nodes.ts:2382"]
+      "evidence": ["src/ir/nodes.ts:2386"]
     },
     "br_if": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2409",
+      "declaredAt": "src/ir/nodes.ts:2413",
       "why": "Two-target conditional branch on an i32 condition.",
-      "evidence": ["src/ir/nodes.ts:2408"]
+      "evidence": ["src/ir/nodes.ts:2412"]
     },
     "br.label": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2133",
+      "declaredAt": "src/ir/nodes.ts:2137",
       "why": "Branch to a named enclosing loop frame in break or continue mode. Labeled break/continue is C-family, not ECMAScript-specific.",
-      "evidence": ["src/ir/nodes.ts:2110"]
+      "evidence": ["src/ir/nodes.ts:2114"]
     },
     "call": {
       "verdict": "neutral",
@@ -84,87 +84,87 @@
     "class.call": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1540",
+      "declaredAt": "src/ir/nodes.ts:1544",
       "why": "Virtual dispatch against the receiver's shape with the receiver prepended. Accessors are a member kind, shared with Kotlin/C#/Dart.",
-      "evidence": ["src/ir/nodes.ts:1525"]
+      "evidence": ["src/ir/nodes.ts:1529"]
     },
     "class.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1503",
+      "declaredAt": "src/ir/nodes.ts:1507",
       "why": "Struct field read by declared name.",
-      "evidence": ["src/ir/nodes.ts:1492"]
+      "evidence": ["src/ir/nodes.ts:1496"]
     },
     "class.instanceof": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1604",
+      "declaredAt": "src/ir/nodes.ts:1608",
       "why": "A CLOSED-WORLD NOMINAL TYPE TEST, not the JS operator it is named after: the operand must be statically `IrType.class`, and the test compares a hidden tag against the target's tag plus its transitive children. No prototype chain walk, no `Symbol.hasInstance`, no TypeError on a non-callable right-hand side. This is Java's `instanceof` / Kotlin's `is`.",
-      "evidence": ["src/ir/nodes.ts:1596"]
+      "evidence": ["src/ir/nodes.ts:1600"]
     },
     "class.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1485",
+      "declaredAt": "src/ir/nodes.ts:1489",
       "why": "Allocates a nominal class instance through the class-owned constructor wrapper. No `new.target`, no constructor-returns-object override.",
-      "evidence": ["src/ir/nodes.ts:295", "src/ir/nodes.ts:1474"]
+      "evidence": ["src/ir/nodes.ts:295", "src/ir/nodes.ts:1478"]
     },
     "class.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1518",
+      "declaredAt": "src/ir/nodes.ts:1522",
       "why": "Struct field write by declared name.",
-      "evidence": ["src/ir/nodes.ts:1509"]
+      "evidence": ["src/ir/nodes.ts:1513"]
     },
     "class.static_call": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1620",
+      "declaredAt": "src/ir/nodes.ts:1624",
       "why": "Direct call to a static member slot, no receiver.",
-      "evidence": ["src/ir/nodes.ts:1610"]
+      "evidence": ["src/ir/nodes.ts:1614"]
     },
     "class.super_call": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1581",
+      "declaredAt": "src/ir/nodes.ts:1585",
       "why": "Statically dispatches to the parent's method slot, bypassing the override — the same operation as Java's `super.m()`.",
-      "evidence": ["src/ir/nodes.ts:1571"]
+      "evidence": ["src/ir/nodes.ts:1575"]
     },
     "class.super_init": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1563",
+      "declaredAt": "src/ir/nodes.ts:1567",
       "why": "Runs the parent's initializer on an ALREADY-ALLOCATED `self`. That is the C++/Java allocate-then-initialize order, which is precisely NOT ECMAScript's derived-constructor protocol (where the base creates `this` and it is in TDZ until `super()` returns).",
-      "evidence": ["src/ir/nodes.ts:1549"]
+      "evidence": ["src/ir/nodes.ts:1553"]
     },
     "closure.call": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1416",
+      "declaredAt": "src/ir/nodes.ts:1420",
       "why": "Indirect call through a typed funcref with EXACT arity — not the ECMAScript call model.",
-      "evidence": ["src/ir/nodes.ts:1397"],
+      "evidence": ["src/ir/nodes.ts:1401"],
       "residual": "`IrClosureSignature.defaultParamStart` lets a caller omit a trailing numeric suffix, padded with a reserved missing-argument sentinel. Optional parameters are widely shared, but the sentinel is a value-model artifact — phase 1 territory, and a signature field rather than an instruction, so it does not move with this kind either way."
     },
     "closure.cap": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1390",
+      "declaredAt": "src/ir/nodes.ts:1394",
       "why": "Reads capture slot N out of the closure's own self parameter.",
-      "evidence": ["src/ir/nodes.ts:1391"]
+      "evidence": ["src/ir/nodes.ts:1395"]
     },
     "closure.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1365",
+      "declaredAt": "src/ir/nodes.ts:1369",
       "why": "Lifted function plus a capture struct — the standard closure conversion, older than JS.",
-      "evidence": ["src/ir/nodes.ts:1348"]
+      "evidence": ["src/ir/nodes.ts:1352"]
     },
     "coerce.to_externref": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1845",
+      "declaredAt": "src/ir/nodes.ts:1849",
       "why": "A representation conversion (`extern.convert_any`, or a no-op when the input is already externref). Crossing to the host is a HOST-boundary concern, not a language one — the same reading #4551 records for the backend's emitToExternref/emitFromExternref.",
-      "evidence": ["src/ir/nodes.ts:1838"]
+      "evidence": ["src/ir/nodes.ts:1842"]
     },
     "const": {
       "verdict": "neutral",
@@ -212,9 +212,9 @@
     "early.return": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1940",
+      "declaredAt": "src/ir/nodes.ts:1944",
       "why": "A Wasm `return` from inside a nested buffer. Its soundness scope cites ECMAScript, but as a RESTRICTION against dialect kinds (it is refused inside `try` and `forof.iter`), not as a semantic of its own.",
-      "evidence": ["src/ir/nodes.ts:1924"]
+      "evidence": ["src/ir/nodes.ts:1928"]
     },
     "extern.call": {
       "verdict": "js",
@@ -254,30 +254,30 @@
     "fnctor.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1294",
+      "declaredAt": "src/ir/nodes.ts:1298",
       "why": "Reads a declared field from a nominal constructor carrier; field identity and representation come from the resolved layout.",
-      "evidence": ["src/ir/nodes.ts:1292"]
+      "evidence": ["src/ir/nodes.ts:1296"]
     },
     "fnctor.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1285",
+      "declaredAt": "src/ir/nodes.ts:1289",
       "why": "Materializes a nominal function-style constructor through an exact ABI handle; the operation is not an ECMAScript protocol by itself.",
-      "evidence": ["src/ir/nodes.ts:1274"]
+      "evidence": ["src/ir/nodes.ts:1278"]
     },
     "for.loop": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2045",
+      "declaredAt": "src/ir/nodes.ts:2049",
       "why": "Pre-test loop with an update buffer. The init clause is ordinary IR emitted before it.",
-      "evidence": ["src/ir/nodes.ts:2027"]
+      "evidence": ["src/ir/nodes.ts:2031"]
     },
     "forof.iter": {
       "verdict": "js",
       "where": "dialect",
       "declaredAt": "src/ir/dialect/js.ts:381",
       "why": "`for (x of it)` over the @@iterator protocol, as a statement form.",
-      "evidence": ["src/ir/nodes.ts:1809"]
+      "evidence": ["src/ir/nodes.ts:1813"]
     },
     "forof.string": {
       "verdict": "js",
@@ -289,9 +289,9 @@
     "forof.vec": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1788",
+      "declaredAt": "src/ir/nodes.ts:1792",
       "why": "An index counter over a dense vector — and deliberately NOT ECMAScript's ArrayIterator: the length is read ONCE into a slot before the loop, where §23.1.5.1 re-reads it every step. A producer whose language wants a snapshot loop gets exactly that.",
-      "evidence": ["src/ir/nodes.ts:1754"]
+      "evidence": ["src/ir/nodes.ts:1758"]
     },
     "gen.epilogue": {
       "verdict": "js",
@@ -324,37 +324,37 @@
     "global.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:873",
+      "declaredAt": "src/ir/nodes.ts:877",
       "why": "Symbolic module-global read.",
-      "evidence": ["src/ir/nodes.ts:871"]
+      "evidence": ["src/ir/nodes.ts:875"]
     },
     "global.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:879",
+      "declaredAt": "src/ir/nodes.ts:883",
       "why": "Symbolic module-global write.",
-      "evidence": ["src/ir/nodes.ts:877"]
+      "evidence": ["src/ir/nodes.ts:881"]
     },
     "if": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1069",
+      "declaredAt": "src/ir/nodes.ts:1073",
       "why": "Value-producing short-circuiting if/else over an i32 condition. Truthiness is NOT part of it — `dyn.truthy` is, and that already lives in the dialect.",
-      "evidence": ["src/ir/nodes.ts:1049"]
+      "evidence": ["src/ir/nodes.ts:1053"]
     },
     "if.stmt": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2159",
+      "declaredAt": "src/ir/nodes.ts:2163",
       "why": "Statement-level if/else over an i32 condition, no carrier values.",
-      "evidence": ["src/ir/nodes.ts:2141"]
+      "evidence": ["src/ir/nodes.ts:2145"]
     },
     "intrinsic": {
       "verdict": "unresolved",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:864",
+      "declaredAt": "src/ir/nodes.ts:868",
       "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 29 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:35"],
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:36"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {
@@ -395,87 +395,87 @@
     "labeled.block": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2174",
+      "declaredAt": "src/ir/nodes.ts:2178",
       "why": "A break-only labeled frame lowering to one Wasm block.",
-      "evidence": ["src/ir/nodes.ts:2166"]
+      "evidence": ["src/ir/nodes.ts:2170"]
     },
     "object.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1326",
+      "declaredAt": "src/ir/nodes.ts:1330",
       "why": "Static field read by name, resolved to a struct index at lowering. Dynamic keys are `dyn.member_get`, which is in the dialect.",
-      "evidence": ["src/ir/nodes.ts:1319", "src/ir/dialect/js.ts:225"]
+      "evidence": ["src/ir/nodes.ts:1323", "src/ir/dialect/js.ts:225"]
     },
     "object.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1313",
+      "declaredAt": "src/ir/nodes.ts:1317",
       "why": "Constructs a record from a declared field layout. No prototype, no descriptors, no insertion order semantics.",
-      "evidence": ["src/ir/nodes.ts:197", "src/ir/nodes.ts:1314"]
+      "evidence": ["src/ir/nodes.ts:197", "src/ir/nodes.ts:1318"]
     },
     "object.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1337",
+      "declaredAt": "src/ir/nodes.ts:1341",
       "why": "Static field write by name. The JS `[[Set]]` path is `dyn.member_set`, which is in the dialect.",
-      "evidence": ["src/ir/nodes.ts:1332", "src/ir/dialect/js.ts:241"]
+      "evidence": ["src/ir/nodes.ts:1336", "src/ir/dialect/js.ts:241"]
     },
     "raw.wasm": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1084",
+      "declaredAt": "src/ir/nodes.ts:1088",
       "why": "An opaque backend instruction sequence. Nothing about it is language-specific.",
-      "evidence": ["src/ir/nodes.ts:1078"],
+      "evidence": ["src/ir/nodes.ts:1082"],
       "residual": "Backend axis, not the language axis: it carries `Instr[]`, i.e. concrete backend opcodes, so it is a backend-agnosticism leak (docs/architecture/codegen-axes.md), not an ECMAScript one."
     },
     "refcell.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1440",
+      "declaredAt": "src/ir/nodes.ts:1444",
       "why": "Reads the cell's single field.",
-      "evidence": ["src/ir/nodes.ts:1434"]
+      "evidence": ["src/ir/nodes.ts:1438"]
     },
     "refcell.new": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1429",
+      "declaredAt": "src/ir/nodes.ts:1433",
       "why": "One-field mutable cell — the standard boxing of a mutable capture.",
-      "evidence": ["src/ir/nodes.ts:1422"]
+      "evidence": ["src/ir/nodes.ts:1426"]
     },
     "refcell.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1451",
+      "declaredAt": "src/ir/nodes.ts:1455",
       "why": "Writes the cell's single field.",
-      "evidence": ["src/ir/nodes.ts:1445"]
+      "evidence": ["src/ir/nodes.ts:1449"]
     },
     "return": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2397",
+      "declaredAt": "src/ir/nodes.ts:2401",
       "why": "Block terminator returning the function's results.",
-      "evidence": ["src/ir/nodes.ts:2396"]
+      "evidence": ["src/ir/nodes.ts:2400"]
     },
     "select": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1041",
+      "declaredAt": "src/ir/nodes.ts:1045",
       "why": "Wasm `select`: both arms evaluated, no short-circuit, no coercion.",
-      "evidence": ["src/ir/nodes.ts:1035"]
+      "evidence": ["src/ir/nodes.ts:1039"]
     },
     "slot.read": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1656",
+      "declaredAt": "src/ir/nodes.ts:1660",
       "why": "Reads a function-level Wasm local.",
-      "evidence": ["src/ir/nodes.ts:1648"]
+      "evidence": ["src/ir/nodes.ts:1652"]
     },
     "slot.write": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1667",
+      "declaredAt": "src/ir/nodes.ts:1671",
       "why": "Writes a function-level Wasm local.",
-      "evidence": ["src/ir/nodes.ts:1661"]
+      "evidence": ["src/ir/nodes.ts:1665"]
     },
     "string.char_at": {
       "verdict": "js",
@@ -494,31 +494,31 @@
     "string.concat": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1216",
+      "declaredAt": "src/ir/nodes.ts:1220",
       "why": "Concatenation of two values already statically known to be strings — no ToString, no `+` overload.",
-      "evidence": ["src/ir/nodes.ts:1211"]
+      "evidence": ["src/ir/nodes.ts:1215"]
     },
     "string.const": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1190",
+      "declaredAt": "src/ir/nodes.ts:1194",
       "why": "Materializes a literal; storage/materializer are backend selections made during preparation.",
-      "evidence": ["src/ir/nodes.ts:1191"],
+      "evidence": ["src/ir/nodes.ts:1195"],
       "residual": "Carrier: the literal's length is counted in UTF-16 code units, the same family commitment that leaves `string.len` unresolved. Settling `string.len` settles this too."
     },
     "string.eq": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1232",
+      "declaredAt": "src/ir/nodes.ts:1236",
       "why": "Value equality of two strings. No abstract equality, no coercion — `dyn.eq` covers that and is already in the dialect.",
-      "evidence": ["src/ir/nodes.ts:1228"]
+      "evidence": ["src/ir/nodes.ts:1232"]
     },
     "string.len": {
       "verdict": "unresolved",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1248",
+      "declaredAt": "src/ir/nodes.ts:1252",
       "why": "The MEANING is settled and it is not encoding-parameterized: every backend returns the UTF-16 CODE-UNIT count. The linear backend calls `__str_length_utf16` regardless of `inputEncoding`, and the WasmGC native provider reads a field documented as the UTF-16 code-unit length. What is NOT settled is the placement: that commitment is shared verbatim with Java/C#/the whole UTF-16 family, so it is not ECMAScript-specific the way `char_at`'s out-of-range sentinel is, yet it is a language commitment a Rust or Python producer could not use.",
-      "evidence": ["src/ir/nodes.ts:1264", "src/ir/backend/linear-integration.ts:1611", "src/ir/string-runtime.ts:15"],
+      "evidence": ["src/ir/nodes.ts:1268", "src/ir/backend/linear-integration.ts:1611", "src/ir/string-runtime.ts:15"],
       "settledBy": "A policy call phase 2 has to make anyway: does `js` mean ECMAScript-SPECIFIC, or LANGUAGE-COMMITTED? If the former, `string.len` stays in core with a documented commitment; if the latter it moves — and the same answer then governs a future `utf16-string` dialect shared by the family, which is the third option."
     },
     "string.repeat": {
@@ -531,96 +531,96 @@
     "switch": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2207",
+      "declaredAt": "src/ir/nodes.ts:2211",
       "why": "The C-family fall-through ladder. Case selection compares literals in the discriminant's own value type, so the NaN/-0 behaviour it documents is IEEE-754's, reached through `f64.eq`, not an ECMAScript rule.",
-      "evidence": ["src/ir/nodes.ts:2187"]
+      "evidence": ["src/ir/nodes.ts:2191"]
     },
     "tag.test": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1164",
+      "declaredAt": "src/ir/nodes.ts:1168",
       "why": "Runtime tag discriminator over a tagged carrier; serves scalar unions as well as the dynamic carrier.",
-      "evidence": ["src/ir/nodes.ts:1149"],
+      "evidence": ["src/ir/nodes.ts:1153"],
       "residual": "Same as `unbox`: the operand is a neutral `tagId?: TagId` since #3954 phase 3 (W4/W5); the residual is the `TagId -> JsTag` crossing in the lowering pass (W2/W6), a seam question."
     },
     "throw": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1907",
+      "declaredAt": "src/ir/nodes.ts:1911",
       "why": "Raises through one Wasm tag with a reference payload. No Error hierarchy, no completion record, no type-based dispatch — a typed language would test in the handler, which this model permits.",
-      "evidence": ["src/ir/nodes.ts:1892"]
+      "evidence": ["src/ir/nodes.ts:1896"]
     },
     "try": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2088",
+      "declaredAt": "src/ir/nodes.ts:2092",
       "why": "Structured try/catch/finally with one untyped handler. Notably it does NOT model completion records: `early.return` is REFUSED inside these buffers rather than being made to run the inlined finally, so the ECMAScript machinery is excluded rather than encoded.",
-      "evidence": ["src/ir/nodes.ts:2059"]
+      "evidence": ["src/ir/nodes.ts:2063"]
     },
     "unary": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1029",
+      "declaredAt": "src/ir/nodes.ts:1033",
       "why": "Every `IrUnop` member is a single Wasm opcode (`f64.neg`, `i32.eqz`, `i32.trunc_sat_f64_s`, `ref.is_null`, the Math f64 family). Their USES are JS-motivated; the operations are not. Contrast `binary`, whose enum carries composite `js.*` ops.",
-      "evidence": ["src/ir/nodes.ts:987"]
+      "evidence": ["src/ir/nodes.ts:991"]
     },
     "unbox": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1140",
+      "declaredAt": "src/ir/nodes.ts:1144",
       "why": "Payload extraction from a tagged carrier after the tag is proven; the union operand form has no JS content.",
-      "evidence": ["src/ir/nodes.ts:1145"],
+      "evidence": ["src/ir/nodes.ts:1149"],
       "residual": "Same as `box`. #3954 phase 3 (W4/W5) made the operand itself neutral — the field is `tagId?: TagId` and `IrFunctionBuilder` asks a `TagDomain` — so the residual is now only the `TagId -> JsTag` crossing in the lowering pass (W2/W6), which is a seam question."
     },
     "unreachable": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:2417",
+      "declaredAt": "src/ir/nodes.ts:2421",
       "why": "Unreachable terminator.",
-      "evidence": ["src/ir/nodes.ts:2416"]
+      "evidence": ["src/ir/nodes.ts:2420"]
     },
     "vec.get": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1695",
+      "declaredAt": "src/ir/nodes.ts:1699",
       "why": "Planned in-bounds `array.get` at an i32 index.",
-      "evidence": ["src/ir/nodes.ts:1685", "(absent from src/ir/: array-holes)"]
+      "evidence": ["src/ir/nodes.ts:1689", "(absent from src/ir/: array-holes)"]
     },
     "vec.len": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1680",
+      "declaredAt": "src/ir/nodes.ts:1684",
       "why": "Reads a dense vector's logical length. Element count is a language-independent unit (contrast `string.len`, whose unit is a language commitment).",
-      "evidence": ["src/ir/nodes.ts:1673"],
+      "evidence": ["src/ir/nodes.ts:1677"],
       "residual": "The result defaults to f64 to compose with the JS number model; `integer?: true` opts back into a physical i32, which is what shows it is a REPRESENTATION default rather than part of the operation. #3954 phase 1."
     },
     "vec.new_fixed": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1737",
+      "declaredAt": "src/ir/nodes.ts:1741",
       "why": "Builds a dense vector from statically-known elements. Sparse literals are explicitly out of scope and fall back to legacy, so no hole can reach this node.",
       "evidence": ["src/ir/from-ast.ts:4502"]
     },
     "vec.set": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1707",
+      "declaredAt": "src/ir/nodes.ts:1711",
       "why": "One planned in-bounds store. Bounds and growth policy stay explicit in the surrounding IR; a holey-array store is routed to a runtime helper instead.",
-      "evidence": ["src/ir/nodes.ts:1701", "src/ir/from-ast.ts:380"]
+      "evidence": ["src/ir/nodes.ts:1705", "src/ir/from-ast.ts:380"]
     },
     "vec.set_length": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1715",
+      "declaredAt": "src/ir/nodes.ts:1719",
       "why": "Writes a resizable vector's logical length.",
-      "evidence": ["src/ir/nodes.ts:1713"]
+      "evidence": ["src/ir/nodes.ts:1717"]
     },
     "while.loop": {
       "verdict": "neutral",
       "where": "core",
-      "declaredAt": "src/ir/nodes.ts:1989",
+      "declaredAt": "src/ir/nodes.ts:1993",
       "why": "Pre-test loop over a condition buffer whose value is an i32. Truthiness conversion happens before it, in `dyn.truthy`.",
-      "evidence": ["src/ir/nodes.ts:1990"]
+      "evidence": ["src/ir/nodes.ts:1994"]
     }
   }
 }

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -17,6 +17,7 @@ import {
   isWrapperObjectType,
 } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
+import { emitWasmInt32Coercion } from "../ir/backend/wasm-int32-coercion.js";
 import { ensureAnyFromExternHelper, isAnyValue, undefinedSingletonActive } from "./any-helpers.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
@@ -3412,79 +3413,7 @@ export function emitToInt32(fctx: FunctionContext): void {
   const e = allocTempLocal(fctx, { kind: "i64" });
   const significand = allocTempLocal(fctx, { kind: "i64" });
   const magnitude = allocTempLocal(fctx, { kind: "i64" });
-
-  fctx.body.push({ op: "i64.reinterpret_f64" });
-  fctx.body.push({ op: "local.set", index: bits });
-
-  fctx.body.push({ op: "local.get", index: bits });
-  fctx.body.push({ op: "i64.const", value: 52n });
-  fctx.body.push({ op: "i64.shr_u" });
-  fctx.body.push({ op: "i64.const", value: 0x7ffn });
-  fctx.body.push({ op: "i64.and" });
-  fctx.body.push({ op: "i64.const", value: 1023n });
-  fctx.body.push({ op: "i64.sub" });
-  fctx.body.push({ op: "local.set", index: e });
-
-  fctx.body.push({ op: "local.get", index: bits });
-  fctx.body.push({ op: "i64.const", value: 0xfffffffffffffn });
-  fctx.body.push({ op: "i64.and" });
-  fctx.body.push({ op: "i64.const", value: 0x10000000000000n });
-  fctx.body.push({ op: "i64.or" });
-  fctx.body.push({ op: "local.set", index: significand });
-
-  const shiftLeft: Instr[] = [
-    { op: "local.get", index: significand },
-    { op: "local.get", index: e },
-    { op: "i64.const", value: 52n },
-    { op: "i64.sub" },
-    { op: "i64.shl" },
-  ];
-  const shiftRight: Instr[] = [
-    { op: "local.get", index: significand },
-    { op: "i64.const", value: 52n },
-    { op: "local.get", index: e },
-    { op: "i64.sub" },
-    { op: "i64.shr_u" },
-  ];
-  fctx.body.push({ op: "local.get", index: e });
-  fctx.body.push({ op: "i64.const", value: 0n });
-  fctx.body.push({ op: "i64.ge_s" });
-  fctx.body.push({ op: "local.get", index: e });
-  fctx.body.push({ op: "i64.const", value: 83n });
-  fctx.body.push({ op: "i64.le_s" });
-  fctx.body.push({ op: "i32.and" });
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "val", type: { kind: "i64" } as ValType },
-    then: [
-      { op: "local.get", index: e },
-      { op: "i64.const", value: 52n },
-      { op: "i64.ge_s" },
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "i64" } as ValType },
-        then: shiftLeft,
-        else: shiftRight,
-      },
-    ],
-    else: [{ op: "i64.const", value: 0n }],
-  });
-  fctx.body.push({ op: "local.set", index: magnitude });
-
-  fctx.body.push({ op: "local.get", index: bits });
-  fctx.body.push({ op: "i64.const", value: 0n });
-  fctx.body.push({ op: "i64.lt_s" });
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "val", type: { kind: "i32" } as ValType },
-    then: [
-      { op: "i32.const", value: 0 },
-      { op: "local.get", index: magnitude },
-      { op: "i32.wrap_i64" },
-      { op: "i32.sub" },
-    ],
-    else: [{ op: "local.get", index: magnitude }, { op: "i32.wrap_i64" }],
-  });
+  emitWasmInt32Coercion(fctx.body, { bits, exponent: e, significand, magnitude });
 
   releaseTempLocal(fctx, bits);
   releaseTempLocal(fctx, e);

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -3429,15 +3429,14 @@ function compileMathCall(
 
   // Math.clz32(n) → ToUint32(n) then i32.clz
   // ToUint32: NaN/±Infinity → 0; otherwise truncate then modulo 2^32.
-  // We use the host-imported __toUint32 for correct edge-case handling.
+  // Use the collected in-module helper for exact edge-case handling.
   if (method === "clz32" && expr.arguments.length >= 1) {
     const toU32Idx = ctx.funcMap.get("__toUint32");
-    compileExpression(ctx, fctx, expr.arguments[0]!, f64Hint);
-    if (toU32Idx !== undefined) {
-      fctx.body.push({ op: "call", funcIdx: toU32Idx });
-    } else {
-      fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+    if (toU32Idx === undefined) {
+      throw new Error("Math.clz32 requires the collected __toUint32 helper");
     }
+    compileExpression(ctx, fctx, expr.arguments[0]!, f64Hint);
+    fctx.body.push({ op: "call", funcIdx: toU32Idx });
     fctx.body.push({ op: "i32.clz" });
     fctx.body.push({ op: "f64.convert_i32_s" });
     return { kind: "f64" };
@@ -3446,18 +3445,13 @@ function compileMathCall(
   // Math.imul(a, b) → ToUint32(a) * ToUint32(b), result as signed i32
   if (method === "imul" && expr.arguments.length >= 2) {
     const toU32Idx = ctx.funcMap.get("__toUint32");
+    if (toU32Idx === undefined) {
+      throw new Error("Math.imul requires the collected __toUint32 helper");
+    }
     compileExpression(ctx, fctx, expr.arguments[0]!, f64Hint);
-    if (toU32Idx !== undefined) {
-      fctx.body.push({ op: "call", funcIdx: toU32Idx });
-    } else {
-      fctx.body.push({ op: "i32.trunc_sat_f64_s" });
-    }
+    fctx.body.push({ op: "call", funcIdx: toU32Idx });
     compileExpression(ctx, fctx, expr.arguments[1]!, f64Hint);
-    if (toU32Idx !== undefined) {
-      fctx.body.push({ op: "call", funcIdx: toU32Idx });
-    } else {
-      fctx.body.push({ op: "i32.trunc_sat_f64_s" });
-    }
+    fctx.body.push({ op: "call", funcIdx: toU32Idx });
     fctx.body.push({ op: "i32.mul" });
     fctx.body.push({ op: "f64.convert_i32_s" });
     return { kind: "f64" };

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -52,6 +52,7 @@ import {
 } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, StructTypeDef, ValType, WasmFunction, WasmModule } from "../ir/types.js";
 import { createEmptyModule } from "../ir/types.js";
+import { emitWasmInt32Coercion } from "../ir/backend/wasm-int32-coercion.js";
 import { planCountedStringAppend, type IrCountedStringAppendPlan } from "../ir/analysis/counted-string-append.js";
 import { irSupportFuncRef, irUnitFuncRef } from "../ir/callable-bindings.js";
 import { irModuleGlobalBindingId, irModuleTdzGlobalBindingId, irSupportGlobalRef } from "../ir/abi-bindings.js";
@@ -10268,24 +10269,17 @@ export function emitToUint32Helper(ctx: CodegenContext): void {
   const typeIdx = addFuncType(ctx, [{ kind: "f64" }], [{ kind: "i32" }]);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
   ctx.funcMap.set("__toUint32", funcIdx);
-  const body: Instr[] = [
-    { op: "local.get", index: 0 },
-    { op: "local.get", index: 0 },
-    { op: "f64.ne" },
-    { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
-    { op: "local.get", index: 0 },
-    { op: "f64.abs" },
-    { op: "f64.const", value: Infinity },
-    { op: "f64.eq" },
-    { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
-    { op: "local.get", index: 0 },
-    { op: "i64.trunc_sat_f64_s" },
-    { op: "i32.wrap_i64" },
-  ];
+  const body: Instr[] = [{ op: "local.get", index: 0 }];
+  emitWasmInt32Coercion(body, { bits: 1, exponent: 2, significand: 3, magnitude: 4 });
   ctx.mod.functions.push({
     name: "__toUint32",
     typeIdx,
-    locals: [],
+    locals: [
+      { name: "$to_uint32_bits", type: { kind: "i64" } },
+      { name: "$to_uint32_exponent", type: { kind: "i64" } },
+      { name: "$to_uint32_significand", type: { kind: "i64" } },
+      { name: "$to_uint32_magnitude", type: { kind: "i64" } },
+    ],
     body,
     exported: false,
   });

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -243,6 +243,7 @@ function linearInstrError(instr: IrInstr): string | null {
       }
     case "intrinsic":
       switch (instr.id) {
+        case "js.to_uint32":
         case "math.abs":
         case "math.ceil":
         case "math.floor":
@@ -331,6 +332,8 @@ function bytecodeInstrError(instr: IrInstr): string | null {
       return bytecodeBinopLegal(instr.op) ? null : `bytecode backend does not support binary op '${instr.op}'`;
     case "unary":
       return instr.op === "f64.neg" ? null : `bytecode backend does not support unary op '${instr.op}'`;
+    case "intrinsic":
+      return `bytecode backend does not support semantic intrinsic '${instr.id}'`;
     case "call":
     case "global.get":
     case "global.set":
@@ -392,6 +395,8 @@ function porfforInstrError(instr: IrInstr): string | null {
         : `porffor backend does not support binary op '${instr.op}' before typed composite-op lowering`;
     case "unary":
       return instr.op === "ref.is_null" ? `porffor backend does not support unary op '${instr.op}'` : null;
+    case "intrinsic":
+      return `porffor backend does not support semantic intrinsic '${instr.id}'`;
     case "call":
     case "global.get":
     case "global.set":

--- a/src/ir/backend/wasm-int32-coercion.ts
+++ b/src/ir/backend/wasm-int32-coercion.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr } from "../types.js";
+
+/** Four reusable i64 locals required by the exact Wasm 32-bit coercion. */
+export interface WasmInt32CoercionScratch {
+  readonly bits: number;
+  readonly exponent: number;
+  readonly significand: number;
+  readonly magnitude: number;
+}
+
+/**
+ * Consume one f64 and leave the exact low-32-bit ECMAScript integer pattern.
+ *
+ * `ToInt32` and `ToUint32` differ only in how this i32 pattern is interpreted
+ * afterwards. Decomposing the IEEE-754 value avoids both trapping conversion
+ * and the incorrect saturation-before-wrap shortcut for magnitudes >= 2**63.
+ */
+export function emitWasmInt32Coercion(out: Instr[], scratch: WasmInt32CoercionScratch): void {
+  out.push({ op: "i64.reinterpret_f64" }, { op: "local.set", index: scratch.bits });
+  out.push(
+    { op: "local.get", index: scratch.bits },
+    { op: "i64.const", value: 52n },
+    { op: "i64.shr_u" },
+    { op: "i64.const", value: 0x7ffn },
+    { op: "i64.and" },
+    { op: "i64.const", value: 1023n },
+    { op: "i64.sub" },
+    { op: "local.set", index: scratch.exponent },
+  );
+  out.push(
+    { op: "local.get", index: scratch.bits },
+    { op: "i64.const", value: 0xfffffffffffffn },
+    { op: "i64.and" },
+    { op: "i64.const", value: 0x10000000000000n },
+    { op: "i64.or" },
+    { op: "local.set", index: scratch.significand },
+  );
+
+  const shiftLeft: Instr[] = [
+    { op: "local.get", index: scratch.significand },
+    { op: "local.get", index: scratch.exponent },
+    { op: "i64.const", value: 52n },
+    { op: "i64.sub" },
+    { op: "i64.shl" },
+  ];
+  const shiftRight: Instr[] = [
+    { op: "local.get", index: scratch.significand },
+    { op: "i64.const", value: 52n },
+    { op: "local.get", index: scratch.exponent },
+    { op: "i64.sub" },
+    { op: "i64.shr_u" },
+  ];
+  out.push(
+    { op: "local.get", index: scratch.exponent },
+    { op: "i64.const", value: 0n },
+    { op: "i64.ge_s" },
+    { op: "local.get", index: scratch.exponent },
+    { op: "i64.const", value: 83n },
+    { op: "i64.le_s" },
+    { op: "i32.and" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i64" } },
+      then: [
+        { op: "local.get", index: scratch.exponent },
+        { op: "i64.const", value: 52n },
+        { op: "i64.ge_s" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i64" } },
+          then: shiftLeft,
+          else: shiftRight,
+        },
+      ],
+      else: [{ op: "i64.const", value: 0n }],
+    },
+    { op: "local.set", index: scratch.magnitude },
+  );
+  out.push(
+    { op: "local.get", index: scratch.bits },
+    { op: "i64.const", value: 0n },
+    { op: "i64.lt_s" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [
+        { op: "i32.const", value: 0 },
+        { op: "local.get", index: scratch.magnitude },
+        { op: "i32.wrap_i64" },
+        { op: "i32.sub" },
+      ],
+      else: [{ op: "local.get", index: scratch.magnitude }, { op: "i32.wrap_i64" }],
+    },
+  );
+}

--- a/src/ir/intrinsic-support.ts
+++ b/src/ir/intrinsic-support.ts
@@ -124,6 +124,9 @@ function providerAttachment(id: IrInstrIntrinsic["id"], provider: RuntimeProvide
   if (provider.implementation.kind === "backend-sequence") {
     return Object.freeze({ kind: "backend-sequence", sequence: provider.implementation.sequence });
   }
+  if (provider.implementation.kind === "backend-composite") {
+    return Object.freeze({ kind: "backend-composite", operation: provider.implementation.operation });
+  }
   return Object.freeze({
     kind: "callable",
     // Structural identity remains the semantic ID. The compatibility name is
@@ -137,6 +140,9 @@ function sameProvider(left: IrIntrinsicProvider, right: IrIntrinsicProvider): bo
   if (left.kind === "backend-op" && right.kind === "backend-op") return left.opcode === right.opcode;
   if (left.kind === "backend-sequence" && right.kind === "backend-sequence") {
     return left.sequence === right.sequence;
+  }
+  if (left.kind === "backend-composite" && right.kind === "backend-composite") {
+    return left.operation === right.operation;
   }
   return (
     left.kind === "callable" &&

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -6,7 +6,8 @@
  * These identifiers name meaning, never a concrete helper, import, or module
  * index. The initial vocabulary deliberately matches the exact deterministic,
  * exact-arity f64 Math surface certified by `IR_MATH_METHOD_TABLE`. Widening
- * any of these unions is therefore a reviewed runtime-contract change.
+ * `PURE_MATH_INTRINSIC_IDS` remains the exact source-Math catalogue; other
+ * reviewed semantic families are composed into `INTRINSIC_IDS` separately.
  */
 import { effectsArePure, effectsOf } from "./effects.js";
 import { irTypeEquals, type IrInstr, type IrType } from "./nodes.js";
@@ -43,7 +44,11 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.trunc",
 ] as const);
 
-export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
+export const NUMERIC_COERCION_INTRINSIC_IDS = Object.freeze(["js.to_uint32"] as const);
+
+export const INTRINSIC_IDS = Object.freeze([...NUMERIC_COERCION_INTRINSIC_IDS, ...PURE_MATH_INTRINSIC_IDS] as const);
+
+export type IntrinsicId = (typeof INTRINSIC_IDS)[number];
 
 /**
  * Provider requirements reachable from the twenty-nine intrinsic entry points.
@@ -82,7 +87,16 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.trunc",
 ] as const);
 
-export type RuntimeFeature = (typeof PURE_MATH_RUNTIME_FEATURES)[number];
+export const NUMERIC_COERCION_RUNTIME_FEATURES = Object.freeze(["js.to_uint32"] as const);
+
+export const INTRINSIC_RUNTIME_FEATURES = Object.freeze([
+  ...NUMERIC_COERCION_RUNTIME_FEATURES,
+  ...PURE_MATH_RUNTIME_FEATURES,
+] as const);
+
+export type PureMathRuntimeFeature = (typeof PURE_MATH_RUNTIME_FEATURES)[number];
+export type NumericCoercionRuntimeFeature = (typeof NUMERIC_COERCION_RUNTIME_FEATURES)[number];
+export type RuntimeFeature = (typeof INTRINSIC_RUNTIME_FEATURES)[number];
 
 /**
  * The certified deterministic Math slice is host-free by construction.
@@ -139,6 +153,18 @@ const F64_TYPE = Object.freeze({
   val: Object.freeze({ kind: "f64" as const }),
 });
 
+const U32_TYPE = Object.freeze({
+  kind: "val" as const,
+  val: Object.freeze({ kind: "i32" as const }),
+  signed: false as const,
+});
+
+export const F64_TO_U32_INTRINSIC_SIGNATURE: IntrinsicSignature = Object.freeze({
+  version: INTRINSIC_SIGNATURE_VERSION,
+  params: Object.freeze([F64_TYPE]),
+  result: U32_TYPE,
+});
+
 export const F64_UNARY_INTRINSIC_SIGNATURE: IntrinsicSignature = Object.freeze({
   version: INTRINSIC_SIGNATURE_VERSION,
   params: Object.freeze([F64_TYPE]),
@@ -157,6 +183,7 @@ function definition(id: IntrinsicId, signature: IntrinsicSignature, feature: Run
 
 /** Exhaustive entry contract. Record typing makes an added ID fail closed. */
 export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefinition>> = Object.freeze({
+  "js.to_uint32": definition("js.to_uint32", F64_TO_U32_INTRINSIC_SIGNATURE),
   "math.abs": definition("math.abs", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.acos": definition("math.acos", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.acosh": definition("math.acosh", F64_UNARY_INTRINSIC_SIGNATURE),
@@ -188,7 +215,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.trunc": definition("math.trunc", F64_UNARY_INTRINSIC_SIGNATURE),
 });
 
-const INTRINSIC_ID_SET: ReadonlySet<string> = new Set(PURE_MATH_INTRINSIC_IDS);
+const INTRINSIC_ID_SET: ReadonlySet<string> = new Set(INTRINSIC_IDS);
 
 export function isIntrinsicId(value: string): value is IntrinsicId {
   return INTRINSIC_ID_SET.has(value);

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -58,6 +58,7 @@ import type {
   IrVecLowering,
 } from "./backend/handles.js";
 import { WasmGcEmitter } from "./backend/wasmgc-emitter.js";
+import { emitWasmInt32Coercion, type WasmInt32CoercionScratch } from "./backend/wasm-int32-coercion.js";
 import {
   type AllocSiteId,
   type IrBlock,
@@ -69,6 +70,7 @@ import {
   type IrGlobalRef,
   type IrInstr,
   type IrInstrIntrinsic,
+  type IrIntrinsicBackendComposite,
   type IrLabelId,
   type IrObjectShape,
   type IrStringLengthProvider,
@@ -392,6 +394,7 @@ function emitPreparedIntrinsic<S>(
   emitter: BackendEmitter<S>,
   resolver: IrLowerResolver,
   emitValue: (value: IrValueId, out: S) => void,
+  emitComposite: (operation: IrIntrinsicBackendComposite, out: S) => void,
   funcName: string,
 ): void {
   for (const arg of instr.args) emitValue(arg, out);
@@ -419,6 +422,10 @@ function emitPreparedIntrinsic<S>(
       "lower",
       `ir/lower: semantic intrinsic ${instr.id} has unsupported backend sequence ${String(sequence)} (${funcName})`,
     );
+  }
+  if (instr.provider.kind === "backend-composite") {
+    emitComposite(instr.provider.operation, out);
+    return;
   }
   emitter.emitCall(resolver.resolveFunc(instr.provider.target), out);
 }
@@ -1163,8 +1170,8 @@ export function lowerIrFunctionBody<S, Slot>(
   // (#3739) Lazily-allocated i64 scratch pool for `emitJsToInt32`'s fast
   // bit-manipulation path (WasmGC/linear only — see that function). Kept
   // separate from `jsBitwiseTmpIdx` (f64) since the fast path doesn't use it.
-  let jsBitwiseI64Scratch: { bits: number; e: number; significand: number; magnitude: number } | null = null;
-  const ensureJsBitwiseI64Scratch = (): { bits: number; e: number; significand: number; magnitude: number } => {
+  let jsBitwiseI64Scratch: WasmInt32CoercionScratch | null = null;
+  const ensureJsBitwiseI64Scratch = (): WasmInt32CoercionScratch => {
     if (jsBitwiseI64Scratch === null) {
       const alloc = (name: string): number => {
         const idx = func.params.length + locals.length;
@@ -1174,7 +1181,7 @@ export function lowerIrFunctionBody<S, Slot>(
       };
       jsBitwiseI64Scratch = {
         bits: alloc("$js_bitwise_i64_bits"),
-        e: alloc("$js_bitwise_i64_e"),
+        exponent: alloc("$js_bitwise_i64_e"),
         significand: alloc("$js_bitwise_i64_significand"),
         magnitude: alloc("$js_bitwise_i64_magnitude"),
       };
@@ -1602,7 +1609,34 @@ export function lowerIrFunctionBody<S, Slot>(
         return;
       }
       case "intrinsic": {
-        emitPreparedIntrinsic(instr, out, emitter, resolver, emitValue, func.name);
+        emitPreparedIntrinsic(
+          instr,
+          out,
+          emitter,
+          resolver,
+          emitValue,
+          (operation, compositeOut) => {
+            if (!Array.isArray(compositeOut)) {
+              throw new IrInvariantError(
+                "selection-preparation-mismatch",
+                "lower",
+                `ir/lower: backend ${emitter.backend} cannot emit composite ${operation} (${func.name})`,
+              );
+            }
+            switch (operation) {
+              case "to-uint32":
+                emitWasmInt32Coercion(compositeOut as Instr[], ensureJsBitwiseI64Scratch());
+                return;
+            }
+            const exhaustive: never = operation;
+            throw new IrInvariantError(
+              "selection-preparation-mismatch",
+              "lower",
+              `ir/lower: unsupported backend composite ${String(exhaustive)} (${func.name})`,
+            );
+          },
+          func.name,
+        );
         return;
       }
       case "global.get":
@@ -4359,81 +4393,11 @@ function emitJsToInt32<S>(
   emitter: BackendEmitter<S>,
   out: S,
   tmpLocalIdx: number,
-  allocI64Scratch: () => { bits: number; e: number; significand: number; magnitude: number },
+  allocI64Scratch: () => WasmInt32CoercionScratch,
 ): void {
   if (Array.isArray(out)) {
     const wasmOut = out as Instr[];
-    const { bits, e, significand, magnitude } = allocI64Scratch();
-    wasmOut.push({ op: "i64.reinterpret_f64" }, { op: "local.set", index: bits });
-    wasmOut.push(
-      { op: "local.get", index: bits },
-      { op: "i64.const", value: 52n },
-      { op: "i64.shr_u" },
-      { op: "i64.const", value: 0x7ffn },
-      { op: "i64.and" },
-      { op: "i64.const", value: 1023n },
-      { op: "i64.sub" },
-      { op: "local.set", index: e },
-    );
-    wasmOut.push(
-      { op: "local.get", index: bits },
-      { op: "i64.const", value: 0xfffffffffffffn },
-      { op: "i64.and" },
-      { op: "i64.const", value: 0x10000000000000n },
-      { op: "i64.or" },
-      { op: "local.set", index: significand },
-    );
-    const shiftLeft: Instr[] = [
-      { op: "local.get", index: significand },
-      { op: "local.get", index: e },
-      { op: "i64.const", value: 52n },
-      { op: "i64.sub" },
-      { op: "i64.shl" },
-    ];
-    const shiftRight: Instr[] = [
-      { op: "local.get", index: significand },
-      { op: "i64.const", value: 52n },
-      { op: "local.get", index: e },
-      { op: "i64.sub" },
-      { op: "i64.shr_u" },
-    ];
-    wasmOut.push(
-      { op: "local.get", index: e },
-      { op: "i64.const", value: 0n },
-      { op: "i64.ge_s" },
-      { op: "local.get", index: e },
-      { op: "i64.const", value: 83n },
-      { op: "i64.le_s" },
-      { op: "i32.and" },
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "i64" } },
-        then: [
-          { op: "local.get", index: e },
-          { op: "i64.const", value: 52n },
-          { op: "i64.ge_s" },
-          { op: "if", blockType: { kind: "val", type: { kind: "i64" } }, then: shiftLeft, else: shiftRight },
-        ],
-        else: [{ op: "i64.const", value: 0n }],
-      },
-      { op: "local.set", index: magnitude },
-    );
-    wasmOut.push(
-      { op: "local.get", index: bits },
-      { op: "i64.const", value: 0n },
-      { op: "i64.lt_s" },
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "i32" } },
-        then: [
-          { op: "i32.const", value: 0 },
-          { op: "local.get", index: magnitude },
-          { op: "i32.wrap_i64" },
-          { op: "i32.sub" },
-        ],
-        else: [{ op: "local.get", index: magnitude }, { op: "i32.wrap_i64" }],
-      },
-    );
+    emitWasmInt32Coercion(wasmOut, allocI64Scratch());
     return;
   }
   // Stack: [f64]

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -845,14 +845,18 @@ export type IrIntrinsicBackendOp = "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.c
 /** Closed multi-op backend expansions available to semantic intrinsics. */
 export type IrIntrinsicBackendSequence = "f64.fround";
 
+/** Closed backend-neutral composite scalar semantics with backend-owned scratch. */
+export type IrIntrinsicBackendComposite = "to-uint32";
+
 /**
  * Provider attachment selected after middle-end transforms and manifest
- * freeze. Source/type lowering emits no provider; preparation attaches either
- * a backend primitive or one exact symbolic callable.
+ * freeze. Source/type lowering emits no provider; preparation attaches a
+ * backend primitive, closed composite expansion, or exact symbolic callable.
  */
 export type IrIntrinsicProvider =
   | { readonly kind: "backend-op"; readonly opcode: IrIntrinsicBackendOp }
   | { readonly kind: "backend-sequence"; readonly sequence: IrIntrinsicBackendSequence }
+  | { readonly kind: "backend-composite"; readonly operation: IrIntrinsicBackendComposite }
   | { readonly kind: "callable"; readonly target: IrFuncRef };
 
 /**

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -9,7 +9,12 @@
  * frozen arrays/records. Lowering receives lookup-only `resolveProvider` calls;
  * a request absent from the frozen plan is a typed invariant.
  */
-import { irTypeEquals, type IrIntrinsicBackendOp, type IrIntrinsicBackendSequence } from "./nodes.js";
+import {
+  irTypeEquals,
+  type IrIntrinsicBackendComposite,
+  type IrIntrinsicBackendOp,
+  type IrIntrinsicBackendSequence,
+} from "./nodes.js";
 import {
   ASYNC_HOST_CAPABILITY_IDS,
   ASYNC_OPTIONAL_RUNTIME_FEATURES,
@@ -22,8 +27,10 @@ import {
 } from "./async-runtime-providers.js";
 import {
   F64_BINARY_INTRINSIC_SIGNATURE,
+  F64_TO_U32_INTRINSIC_SIGNATURE,
   F64_UNARY_INTRINSIC_SIGNATURE,
   INTRINSIC_DEFINITIONS,
+  NUMERIC_COERCION_RUNTIME_FEATURES,
   PURE_MATH_HOST_CAPABILITIES,
   PURE_MATH_RUNTIME_FEATURES,
   type IntrinsicEffectEvidence,
@@ -31,13 +38,14 @@ import {
   type IntrinsicSignature,
   type IntrinsicUse,
   type IntrinsicVerificationCode,
-  type RuntimeFeature as MathRuntimeFeature,
+  type PureMathRuntimeFeature,
+  type RuntimeFeature as IntrinsicRuntimeFeature,
   verifyIntrinsicUse,
 } from "./intrinsics.js";
 
 export type RuntimeTarget = "host" | "strict-no-host" | "standalone" | "wasi";
 export type RuntimeBackend = "wasmgc" | "linear";
-export type RuntimeFeature = MathRuntimeFeature | AsyncRuntimeFeature;
+export type RuntimeFeature = IntrinsicRuntimeFeature | AsyncRuntimeFeature;
 export type HostCapabilityId = AsyncHostCapabilityId;
 
 export interface RuntimeManifestPolicy {
@@ -79,7 +87,9 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
 ] as const);
 
 export type MathRuntimeProviderId = (typeof PURE_MATH_RUNTIME_PROVIDER_IDS)[number];
-export type RuntimeProviderId = MathRuntimeProviderId | AsyncRuntimeProviderId;
+export const NUMERIC_COERCION_RUNTIME_PROVIDER_IDS = Object.freeze(["backend.js.to_uint32"] as const);
+export type NumericCoercionRuntimeProviderId = (typeof NUMERIC_COERCION_RUNTIME_PROVIDER_IDS)[number];
+export type RuntimeProviderId = MathRuntimeProviderId | NumericCoercionRuntimeProviderId | AsyncRuntimeProviderId;
 
 export type RuntimeProviderImplementation =
   | {
@@ -89,6 +99,10 @@ export type RuntimeProviderImplementation =
   | {
       readonly kind: "backend-sequence";
       readonly sequence: IrIntrinsicBackendSequence;
+    }
+  | {
+      readonly kind: "backend-composite";
+      readonly operation: IrIntrinsicBackendComposite;
     }
   | {
       readonly kind: "self-hosted";
@@ -115,6 +129,11 @@ export type MathRuntimeProviderImplementation = Extract<
   { readonly kind: "backend-op" | "backend-sequence" | "self-hosted" }
 >;
 
+export type IntrinsicRuntimeProviderImplementation = Extract<
+  RuntimeProviderImplementation,
+  { readonly kind: "backend-op" | "backend-sequence" | "backend-composite" | "self-hosted" }
+>;
+
 export interface RuntimeProviderDefinition {
   readonly id: RuntimeProviderId;
   readonly feature: RuntimeFeature;
@@ -127,9 +146,9 @@ export interface RuntimeProviderDefinition {
   readonly implementation: RuntimeProviderImplementation;
 }
 
-/** Math lowering compatibility view; async providers are consumed by later adapters. */
+/** Semantic-intrinsic lowering view; async providers are consumed by later adapters. */
 export type RuntimeProviderPlan = RuntimeProviderDefinition & {
-  readonly implementation: MathRuntimeProviderImplementation;
+  readonly implementation: IntrinsicRuntimeProviderImplementation;
 };
 
 export interface RuntimeProviderComponent {
@@ -187,6 +206,7 @@ const ALL_TARGETS = Object.freeze<readonly RuntimeTarget[]>(["host", "standalone
 const ALL_BACKENDS = Object.freeze<readonly RuntimeBackend[]>(["linear", "wasmgc"]);
 
 export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature, IntrinsicSignature>>> = Object.freeze({
+  "js.to_uint32": F64_TO_U32_INTRINSIC_SIGNATURE,
   "math.abs": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.acos": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.acosh": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -238,7 +258,14 @@ function provider(
   });
 }
 
-const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderDefinition>> = Object.freeze({
+export const NUMERIC_COERCION_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze([
+  provider("backend.js.to_uint32", "js.to_uint32", F64_TO_U32_INTRINSIC_SIGNATURE, {
+    kind: "backend-composite",
+    operation: "to-uint32",
+  }),
+]);
+
+const PROVIDERS_BY_FEATURE: Readonly<Record<PureMathRuntimeFeature, RuntimeProviderDefinition>> = Object.freeze({
   "math.abs": provider("backend.f64.abs", "math.abs", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "backend-op",
     opcode: "f64.abs",
@@ -418,15 +445,19 @@ export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] =
 
 /** Closed, canonically ordered catalogue used by production manifest builders. */
 export const RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
-  [...PURE_MATH_RUNTIME_PROVIDERS, ...ASYNC_RUNTIME_PROVIDERS].sort((left, right) => left.id.localeCompare(right.id)),
+  [...PURE_MATH_RUNTIME_PROVIDERS, ...NUMERIC_COERCION_RUNTIME_PROVIDERS, ...ASYNC_RUNTIME_PROVIDERS].sort(
+    (left, right) => left.id.localeCompare(right.id),
+  ),
 );
 
 const FEATURE_SET: ReadonlySet<string> = new Set([
+  ...NUMERIC_COERCION_RUNTIME_FEATURES,
   ...PURE_MATH_RUNTIME_FEATURES,
   ...ASYNC_RUNTIME_FEATURES,
   ...ASYNC_OPTIONAL_RUNTIME_FEATURES,
 ]);
 const PROVIDER_ID_SET: ReadonlySet<string> = new Set([
+  ...NUMERIC_COERCION_RUNTIME_PROVIDER_IDS,
   ...PURE_MATH_RUNTIME_PROVIDER_IDS,
   ...ASYNC_RUNTIME_PROVIDER_IDS,
 ]);
@@ -715,7 +746,7 @@ export class RuntimeManifestBuilder {
     return this.#manifest;
   }
 
-  resolveProvider(feature: MathRuntimeFeature): RuntimeProviderPlan;
+  resolveProvider(feature: IntrinsicRuntimeFeature): RuntimeProviderPlan;
   resolveProvider(feature: AsyncRuntimeFeature): RuntimeProviderDefinition;
   resolveProvider(feature: RuntimeFeature): RuntimeProviderDefinition {
     this.#assertFrozen();

--- a/tests/issue-5119-ir-exact-touint32.test.ts
+++ b/tests/issue-5119-ir-exact-touint32.test.ts
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult } from "../src/index.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { LinearEmitter } from "../src/ir/backend/linear-emitter.js";
+import { verifyIrBackendLegality } from "../src/ir/backend/legality.js";
+import { WasmGcEmitter } from "../src/ir/backend/wasmgc-emitter.js";
+import { IrFunctionBuilder } from "../src/ir/builder.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+import { forEachInstrDeep, irVal, irValSigned, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { createEmptyModule, type FuncTypeDef, type Instr, type WasmModule } from "../src/ir/types.js";
+import { buildImports } from "../src/runtime.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5119-ir-exact-touint32");
+const F64 = irVal({ kind: "f64" });
+const U32 = irValSigned({ kind: "i32" }, false);
+
+const EDGE_VALUES = [
+  Number.NaN,
+  Number.NEGATIVE_INFINITY,
+  Number.POSITIVE_INFINITY,
+  -0,
+  0,
+  -Number.MIN_VALUE,
+  Number.MIN_VALUE,
+  -0.999,
+  0.999,
+  -3.9,
+  3.9,
+  -1,
+  2 ** 31 - 1,
+  -(2 ** 31),
+  2 ** 31,
+  -(2 ** 31) - 1,
+  2 ** 32 - 1,
+  2 ** 32,
+  2 ** 32 + 1,
+  -(2 ** 32),
+  -(2 ** 32) - 1,
+  2 ** 63,
+  2 ** 63 + 2048,
+  2 ** 64,
+  2 ** 64 + 4096,
+  2 ** 65 + 8192,
+  -(2 ** 63) - 2048,
+  -(2 ** 64) - 4096,
+  -1e20,
+  1e20,
+  -Number.MAX_VALUE,
+  Number.MAX_VALUE,
+] as const;
+
+const IMUL_PAIRS = [
+  [0xffff_ffff, 2],
+  [0x8000_0000, 2],
+  [0xffff_ffff, 0xffff_ffff],
+  [2 ** 32 + 1, 2 ** 32 + 1],
+  [2 ** 63 + 2048, 3],
+] as const;
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiateCompilation(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = result.importObject ?? buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+function semanticToUint32(): IrFunction {
+  const builder = new IrFunctionBuilder(identities.next("toUint32"), [U32], true);
+  const value = builder.addParam("value", F64);
+  builder.openBlock();
+  const result = builder.emitIntrinsic("js.to_uint32", [value]);
+  builder.terminate({ kind: "return", values: [result] });
+  return builder.finish();
+}
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function resolverFor(module: WasmModule): IrLowerResolver {
+  return {
+    resolveFunc: () => 0,
+    resolveGlobal: () => {
+      throw new Error("resolveGlobal not used in this test");
+    },
+    resolveType: () => {
+      throw new Error("resolveType not used in this test");
+    },
+    internFuncType: (type: FuncTypeDef) => {
+      const index = module.types.length;
+      module.types.push(type);
+      return index;
+    },
+  };
+}
+
+async function lowerAndInstantiate(
+  fn: IrFunction,
+  emitter: WasmGcEmitter | LinearEmitter,
+): Promise<{ body: Instr[]; invoke: (value: number) => number }> {
+  const module = createEmptyModule();
+  const lowered = lowerIrFunctionToWasm(fn, resolverFor(module), emitter).func;
+  module.functions.push(lowered);
+  module.exports.push({ name: lowered.name, desc: { kind: "func", index: 0 } });
+  const { instance } = await WebAssembly.instantiate(emitBinary(module), {});
+  return {
+    body: lowered.body,
+    invoke: instance.exports[lowered.name] as (value: number) => number,
+  };
+}
+
+describe("#5119 exact ToUint32 prerequisite", () => {
+  it("fixes the legacy Math.clz32/imul helper for large finite values", async () => {
+    const result = await compile(
+      `
+        export function clz(value: number): number { return Math.clz32(value); }
+        export function imul1(value: number): number { return Math.imul(value, 1); }
+        export function imul(left: number, right: number): number { return Math.imul(left, right); }
+      `,
+      {
+        fileName: "issue-5119-direct-control.ts",
+        experimentalIR: false,
+        emitWat: true,
+      },
+    );
+    expectSuccess(result);
+
+    const exports = await instantiateCompilation(result);
+    const clz = exports.clz as (value: number) => number;
+    const imul1 = exports.imul1 as (value: number) => number;
+    const imul = exports.imul as (left: number, right: number) => number;
+    for (const value of EDGE_VALUES) {
+      expect(clz(value), `Math.clz32(${String(value)})`).toBe(Math.clz32(value));
+      expect(imul1(value), `Math.imul(${String(value)}, 1)`).toBe(Math.imul(value, 1));
+    }
+    for (const [left, right] of IMUL_PAIRS) {
+      const actual = imul(left, right);
+      expect(actual, `Math.imul(${left}, ${right})`).toBe(Math.imul(left, right));
+      if (actual === 0) expect(Object.is(actual, -0)).toBe(false);
+    }
+
+    const importNames = WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).map((entry) => entry.name);
+    expect(importNames).not.toEqual(expect.arrayContaining(["Math_clz32", "Math_imul", "__toUint32"]));
+    const wat = result.wat ?? "";
+    const helperStart = wat.indexOf("  (func $__toUint32");
+    const helperEnd = wat.indexOf("\n  (func $", helperStart + 1);
+    expect(helperStart).toBeGreaterThanOrEqual(0);
+    const helperWat = wat.slice(helperStart, helperEnd < 0 ? wat.length : helperEnd);
+    expect(helperWat).toContain("i64.reinterpret_f64");
+    expect(helperWat).not.toContain("i64.trunc_sat_f64_s");
+  });
+
+  it("freezes one dependency-free composite provider and rejects unsupported consumers", () => {
+    const raw = semanticToUint32();
+    const rawInstructions = intrinsicInstructions(raw);
+    expect(rawInstructions).toEqual([expect.objectContaining({ id: "js.to_uint32", resultType: U32 })]);
+    expect(rawInstructions[0]?.provider).toBeUndefined();
+    expect(() => lowerIrFunctionToWasm(raw, resolverFor(createEmptyModule()))).toThrowError(
+      /semantic intrinsic js\.to_uint32 has no frozen provider/,
+    );
+
+    for (const backend of ["wasmgc", "linear"] as const) {
+      const prepared = prepareIrRuntimeManifest({
+        functions: [raw],
+        sourceFile: "issue-5119-semantic.ts",
+        policy: { target: "standalone", backend },
+      });
+      if (!prepared) throw new Error("expected a non-empty runtime manifest");
+      expect(prepared.manifest.intrinsicUses.map((use) => use.id)).toEqual(["js.to_uint32"]);
+      expect(prepared.manifest.features).toEqual(["js.to_uint32"]);
+      expect(prepared.manifest.hostCapabilities).toEqual([]);
+      expect(prepared.manifest.providers).toEqual([
+        expect.objectContaining({
+          id: "backend.js.to_uint32",
+          feature: "js.to_uint32",
+          dependencies: [],
+          hostCapabilities: [],
+          implementation: { kind: "backend-composite", operation: "to-uint32" },
+        }),
+      ]);
+      expect(intrinsicInstructions(prepared.functions[0]!)[0]?.provider).toEqual({
+        kind: "backend-composite",
+        operation: "to-uint32",
+      });
+      expect(verifyIrBackendLegality(prepared.functions[0]!, backend)).toEqual([]);
+      expect(verifyIrBackendLegality(prepared.functions[0]!, "bytecode")[0]?.message).toContain(
+        "bytecode backend does not support semantic intrinsic 'js.to_uint32'",
+      );
+      expect(verifyIrBackendLegality(prepared.functions[0]!, "porffor")[0]?.message).toContain(
+        "porffor backend does not support semantic intrinsic 'js.to_uint32'",
+      );
+    }
+  });
+
+  it("executes one identical exact sequence on WasmGC and linear", async () => {
+    const prepared = prepareIrRuntimeManifest({
+      functions: [semanticToUint32()],
+      sourceFile: "issue-5119-runtime.ts",
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+
+    const [wasmgc, linear] = await Promise.all([
+      lowerAndInstantiate(prepared.functions[0]!, new WasmGcEmitter()),
+      lowerAndInstantiate(prepared.functions[0]!, new LinearEmitter()),
+    ]);
+    expect(linear.body).toEqual(wasmgc.body);
+    expect(wasmgc.body).toEqual(expect.arrayContaining([expect.objectContaining({ op: "i64.reinterpret_f64" })]));
+    expect(wasmgc.body).not.toEqual(expect.arrayContaining([expect.objectContaining({ op: "i64.trunc_sat_f64_s" })]));
+    for (const value of EDGE_VALUES) {
+      const expected = value >>> 0;
+      expect(wasmgc.invoke(value) >>> 0, `WasmGC ToUint32(${String(value)})`).toBe(expected);
+      expect(linear.invoke(value) >>> 0, `linear ToUint32(${String(value)})`).toBe(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add typed `js.to_uint32: f64 -> u32` semantics with one dependency-free, host-free composite provider
- share the exact IEEE-754 low-bit expansion across direct ToInt32, IR bitwise coercion, and the legacy `__toUint32` helper
- fix `Math.clz32` and `Math.imul` for finite values beyond the signed-i64 range
- execute the same closed instruction stream on WasmGC and production linear while bytecode and Porffor fail loudly
- keep source ownership of `Math.clz32` and `Math.imul` for the next small checkpoints

## Checkpoints

- implementation plan: `967f21a84f`
- implementation and outcome: `e33ff32c32`

## Validation

- 3/3 focused #5119 semantic/provider/runtime tests
- 5/5 #3739 exact ToInt32 tests, including 2,000 randomized exponent/magnitude cases
- 13/13 #3526 Math intrinsic, manifest, and linear-provider tests
- 6/6 stdlib Math tests
- TypeScript 7 typecheck and Biome lint
- Prettier and diff integrity
- IR kind-neutrality, LOC, function, oracle, and coercion-site ratchets
- 18/18 numeric-local IR parity tests
- issue-integrity pre-push gate

Stacked on #5135. This PR is non-draft and ready for repository automation once CI is green.