### PR TITLE
feat(ir): own exact ambient Math.clz32 calls

### DIFF
--- a/plan/issues/5119-ir-exact-touint32-prerequisite.md
+++ b/plan/issues/5119-ir-exact-touint32-prerequisite.md
@@ -16,7 +16,7 @@ area: ir, backend, codegen
 language_feature: math-builtins, numeric-coercion
 goal: ir-full-coverage
 depends_on: [5118]
-required_by: [5120, 5121]
+required_by: [5125, 5126]
 related: [83, 111, 936, 1094, 1126, 1371, 3526, 3739, 5118]
 files:
   - src/ir/backend/wasm-int32-coercion.ts

--- a/plan/issues/5125-ir-exact-ambient-math-clz32.md
+++ b/plan/issues/5125-ir-exact-ambient-math-clz32.md
@@ -1,0 +1,168 @@
+---
+id: 5125
+title: "IR: own exact ambient Math.clz32 calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5125-ir-math-clz32
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, backend, codegen
+language_feature: math-builtins, numeric-coercion
+goal: ir-full-coverage
+depends_on: [5119]
+required_by: [5126]
+related: [78, 83, 111, 936, 1094, 1126, 1371, 3526, 3739, 5118, 5119]
+files:
+  - plan/issues/5119-ir-exact-touint32-prerequisite.md
+  - src/ir/nodes.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/lower.ts
+  - src/ir/select.ts
+  - src/ir/backend/legality.ts
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-3526-ir-linear-math-intrinsics.test.ts
+  - tests/issue-5125-ir-math-clz32.test.ts
+loc-budget-allow:
+  - src/ir/nodes.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/lower.ts
+  - src/ir/select.ts
+  - src/ir/backend/legality.ts
+func-budget-allow:
+  - src/ir/lower.ts::lowerIrFunctionBody
+  - src/ir/lower.ts::emitInstrTree
+  - src/ir/select.ts::selectorSupportsMathPlan
+  - src/ir/backend/legality.ts::linearInstrError
+---
+
+# #5125 — Exact ambient `Math.clz32` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.clz32(numberExpression)` calls in otherwise IR-eligible synchronous
+functions. Represent the source operation as a typed
+`math.clz32: f64 -> u32` semantic intrinsic and freeze one host-free composite
+provider that applies the exact shared `ToUint32` expansion from #5119 followed
+by native `i32.clz` on WasmGC and production linear.
+
+This checkpoint is intentionally stacked on #5137/#5119. It claims only
+`Math.clz32`; `Math.imul` remains the independent #5126 follow-up.
+
+## Existing exact substrate
+
+Direct codegen currently compiles `Math.clz32(x)` as a call to the collected
+`__toUint32` helper followed by `i32.clz` and signed i32-to-f64 conversion.
+#5119 repaired that helper for values beyond signed i64 and extracted the same
+IEEE-754 sign/exponent/significand expansion into
+`emitWasmInt32Coercion`. The IR lowerer already uses that expansion for
+`js.to_uint32` and bitwise coercion with one lazily allocated four-i64 scratch
+pool.
+
+The remaining gap is source ownership: `clz32` is absent from
+`IR_MATH_METHOD_TABLE`, the pure-Math intrinsic catalogue, and the runtime
+provider catalogue, so exact calls still emit legacy bodies.
+
+## Exact admitted grammar
+
+Admit only a non-optional `Math.clz32(argument)` when `Math` is the unshadowed
+ambient binding, there is exactly one non-spread argument, the selector proves
+primitive `number`, and the containing unit passes ordinary ownership and
+call-graph gates. Aliased, computed, optional, shadowed, coercive, Symbol,
+spread, zero-argument, and extra-argument forms remain direct.
+
+The semantic result is unsigned i32 because `Math.clz32` returns an integer in
+`[0, 32]` and the existing propagation contract classifies it as `u32`.
+Ordinary number return/export boundaries must widen it with
+`f64.convert_i32_u`; no signed `-1` interpretation is permitted to leak from
+the raw i32 carrier.
+
+## Closed provider contract
+
+Extend the backend-composite vocabulary with exactly `math.clz32`. Its provider
+consumes one f64, emits the shared exact low-32-bit expansion, then emits one
+`i32.clz`, leaving a u32-shaped i32 result. The provider is dependency-free in
+the runtime graph because it calls no helper/provider at runtime; #5119 is the
+implementation prerequisite and the shared expansion is linked code, not a
+second semantic invocation.
+
+The provider must:
+
+- evaluate the source argument exactly once;
+- import no host function and call no `__toUint32` or Math helper;
+- preserve exact `ToUint32` behavior for every f64, including NaN, infinities,
+  fractions, and finite magnitudes beyond signed i64;
+- emit the same closed instruction stream on WasmGC and production linear;
+- remain rejected by bytecode and Porffor before emission.
+
+## Implementation plan
+
+1. Renumber #5119's stale follow-up references to the atomically reserved
+   #5125/#5126 IDs.
+2. Add `math.clz32` to the certified pure-Math ID and runtime-feature
+   catalogues with the existing f64-to-u32 signature. Add one
+   `backend.js.math.clz32` composite provider for all targets and both Wasm
+   backends, with no dependencies or host capabilities.
+3. Add a composite-marked `clz32` method plan and narrow
+   `JS2WASM_IR_MATH_CLZ32=0` rollback. Preserve the generic ambient binding,
+   exact arity, non-spread, and primitive-number selector/from-AST path.
+4. Extend the closed composite operation union and lower `math.clz32` by
+   reusing `emitWasmInt32Coercion` with the existing lazy i64 scratch pool,
+   followed by one `i32.clz`.
+5. Admit only `math.clz32` at the linear legality boundary; bytecode and
+   Porffor retain explicit semantic-intrinsic rejection.
+6. Widen the #3526 exhaustive catalogue, runtime manifest, and exact native
+   linear set from twenty-nine to thirty Math methods while special-casing the
+   typed u32 result assertion.
+7. Add focused host, zero-import standalone, and production-linear ownership;
+   provider attachment; exact WAT; direct parity over boundary and huge-finite
+   values; rollback; and pre-claim exclusions.
+8. Run focused Math/ToUint32 regressions, TypeScript 7, formatting, lint,
+   neutrality, LOC/function ratchets, and the full pre-push suite. Push the
+   plan and implementation as separate checkpoints and open a non-draft PR
+   stacked on #5137.
+
+## Acceptance criteria
+
+- Exact ambient one-number `Math.clz32` calls emit IR only on WasmGC and
+  production linear with one typed u32 result and no helper/import.
+- Runtime results match native JavaScript across zero/high-bit patterns,
+  fractions, signed zero, NaN, infinities, `2**32` boundaries, `2**63`,
+  `2**64`, `2**65`, `1e20`, and `Number.MAX_VALUE`.
+- The frozen provider is dependency-free and host-free, evaluates one f64
+  once, uses the shared exact coercion, and ends with one `i32.clz`.
+- Export and arithmetic boundaries preserve the result as numeric 0..32 on
+  both Wasm backends.
+- Missing/malformed providers and unsupported bytecode/Porffor policies fail
+  before emission; no saturation or callable fallback is introduced.
+- Coercive and excluded call shapes keep direct ownership, and rollback causes
+  a clean pre-claim decline with no post-claim errors.
+
+## Non-goals
+
+- `Math.imul`, variadic `min`/`max`/`hypot`, or stateful `Math.random`.
+- General object/Symbol/BigInt ToNumber coercion admission.
+- A generic arbitrary instruction-sequence provider or expansion DSL.
+- Replacing the legacy `__toUint32` helper, which remains required by direct
+  `Math.clz32`/`Math.imul` fallbacks.
+
+## Risk and rollback
+
+The primary risk is losing unsigned-result evidence at an IR or export
+boundary. Focused result-type/provider assertions and runtime checks at 32-bit
+high-bit inputs guard that seam. The second risk is selector overreach into
+coercive or optional calls; exclusion and rollback tests keep those shapes
+legacy-owned. `JS2WASM_IR_MATH_CLZ32=0` provides narrow rollback, while
+`JS2WASM_IR_FIRST=0` remains the global control.
+
+## Outcome
+
+Pending implementation and final Luna Max review.

--- a/plan/issues/5125-ir-exact-ambient-math-clz32.md
+++ b/plan/issues/5125-ir-exact-ambient-math-clz32.md
@@ -1,7 +1,7 @@
 ---
 id: 5125
 title: "IR: own exact ambient Math.clz32 calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -25,6 +25,8 @@ files:
   - src/ir/lower.ts
   - src/ir/select.ts
   - src/ir/backend/legality.ts
+  - src/ir/backend/wasm-int32-coercion.ts
+  - scripts/ir-kind-neutrality-baseline.json
   - tests/issue-3526-ir-math-intrinsic-integration.test.ts
   - tests/issue-3526-ir-runtime-manifest.test.ts
   - tests/issue-3526-ir-linear-math-intrinsics.test.ts
@@ -50,9 +52,9 @@ func-budget-allow:
 Retire the direct AST-to-Wasm route for exact ambient
 `Math.clz32(numberExpression)` calls in otherwise IR-eligible synchronous
 functions. Represent the source operation as a typed
-`math.clz32: f64 -> u32` semantic intrinsic and freeze one host-free composite
+`math.clz32: f64 -> f64` semantic intrinsic and freeze one host-free composite
 provider that applies the exact shared `ToUint32` expansion from #5119 followed
-by native `i32.clz` on WasmGC and production linear.
+by native `i32.clz` and Number conversion on WasmGC and production linear.
 
 This checkpoint is intentionally stacked on #5137/#5119. It claims only
 `Math.clz32`; `Math.imul` remains the independent #5126 follow-up.
@@ -79,25 +81,25 @@ primitive `number`, and the containing unit passes ordinary ownership and
 call-graph gates. Aliased, computed, optional, shadowed, coercive, Symbol,
 spread, zero-argument, and extra-argument forms remain direct.
 
-The semantic result is unsigned i32 because `Math.clz32` returns an integer in
-`[0, 32]` and the existing propagation contract classifies it as `u32`.
-Ordinary number return/export boundaries must widen it with
-`f64.convert_i32_u`; no signed `-1` interpretation is permitted to leak from
-the raw i32 carrier.
+The semantic result remains f64 because JavaScript exposes `Math.clz32` as a
+Number. The closed provider may use an unsigned i32 carrier internally because
+the count is always in `[0, 32]`, then restores the semantic Number boundary
+with `f64.convert_i32_s` after `i32.clz`.
 
 ## Closed provider contract
 
 Extend the backend-composite vocabulary with exactly `math.clz32`. Its provider
-consumes one f64, emits the shared exact low-32-bit expansion, then emits one
-`i32.clz`, leaving a u32-shaped i32 result. The provider is dependency-free in
-the runtime graph because it calls no helper/provider at runtime; #5119 is the
-implementation prerequisite and the shared expansion is linked code, not a
-second semantic invocation.
+consumes one f64, emits the shared exact low-32-bit expansion, then emits
+`i32.clz` and `f64.convert_i32_s`, leaving the JavaScript Number result. The
+provider is dependency-free in the runtime graph because it calls no
+helper/provider at runtime; #5119 is the implementation prerequisite and the
+shared expansion is linked code, not a second semantic invocation.
 
 The provider must:
 
 - evaluate the source argument exactly once;
-- import no host function and call no `__toUint32` or Math helper;
+- import no host function and call no `__toUint32` or Math helper from the IR
+  body;
 - preserve exact `ToUint32` behavior for every f64, including NaN, infinities,
   fractions, and finite magnitudes beyond signed i64;
 - emit the same closed instruction stream on WasmGC and production linear;
@@ -108,20 +110,19 @@ The provider must:
 1. Renumber #5119's stale follow-up references to the atomically reserved
    #5125/#5126 IDs.
 2. Add `math.clz32` to the certified pure-Math ID and runtime-feature
-   catalogues with the existing f64-to-u32 signature. Add one
-   `backend.js.math.clz32` composite provider for all targets and both Wasm
+   catalogues with the existing f64-unary signature. Add one
+   `backend.math.clz32` composite provider for all targets and both Wasm
    backends, with no dependencies or host capabilities.
 3. Add a composite-marked `clz32` method plan and narrow
    `JS2WASM_IR_MATH_CLZ32=0` rollback. Preserve the generic ambient binding,
    exact arity, non-spread, and primitive-number selector/from-AST path.
 4. Extend the closed composite operation union and lower `math.clz32` by
    reusing `emitWasmInt32Coercion` with the existing lazy i64 scratch pool,
-   followed by one `i32.clz`.
+   followed by `i32.clz` and `f64.convert_i32_s`.
 5. Admit only `math.clz32` at the linear legality boundary; bytecode and
    Porffor retain explicit semantic-intrinsic rejection.
 6. Widen the #3526 exhaustive catalogue, runtime manifest, and exact native
-   linear set from twenty-nine to thirty Math methods while special-casing the
-   typed u32 result assertion.
+   linear set from twenty-nine to thirty Math methods.
 7. Add focused host, zero-import standalone, and production-linear ownership;
    provider attachment; exact WAT; direct parity over boundary and huge-finite
    values; rollback; and pre-claim exclusions.
@@ -133,7 +134,7 @@ The provider must:
 ## Acceptance criteria
 
 - Exact ambient one-number `Math.clz32` calls emit IR only on WasmGC and
-  production linear with one typed u32 result and no helper/import.
+  production linear with one typed f64 Number result and no helper call/import.
 - Runtime results match native JavaScript across zero/high-bit patterns,
   fractions, signed zero, NaN, infinities, `2**32` boundaries, `2**63`,
   `2**64`, `2**65`, `1e20`, and `Number.MAX_VALUE`.
@@ -165,4 +166,14 @@ legacy-owned. `JS2WASM_IR_MATH_CLZ32=0` provides narrow rollback, while
 
 ## Outcome
 
-Pending implementation and final Luna Max review.
+Implemented in PR #5141. Exact ambient one-number `Math.clz32` calls now enter
+semantic IR as `f64 -> f64`, freeze a dependency-free `backend.math.clz32`
+composite, and lower through the shared exact IEEE-754 ToUint32 expansion plus
+`i32.clz`/`f64.convert_i32_s` on both WasmGC and production linear. Bytecode and
+Porffor remain fail-closed, excluded/coercive shapes remain direct, and
+`JS2WASM_IR_MATH_CLZ32=0` withdraws only this claim.
+
+Validation covers 23 focused ownership/catalogue/provider cases, native and
+direct parity through huge finite values, zero-import standalone, composed
+Number semantics, TypeScript 7, LOC/function/oracle/coercion ratchets, issue
+integrity, and the mechanically refreshed no-growth neutrality baseline.

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -354,7 +354,7 @@
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:868",
       "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 29 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:36"],
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:37"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -246,6 +246,7 @@ function linearInstrError(instr: IrInstr): string | null {
         case "js.to_uint32":
         case "math.abs":
         case "math.ceil":
+        case "math.clz32":
         case "math.floor":
         case "math.fround":
         case "math.sqrt":

--- a/src/ir/backend/wasm-int32-coercion.ts
+++ b/src/ir/backend/wasm-int32-coercion.ts
@@ -95,3 +95,9 @@ export function emitWasmInt32Coercion(out: Instr[], scratch: WasmInt32CoercionSc
     },
   );
 }
+
+/** Consume one f64 and leave the exact Number result of `Math.clz32`. */
+export function emitWasmMathClz32(out: Instr[], scratch: WasmInt32CoercionScratch): void {
+  emitWasmInt32Coercion(out, scratch);
+  out.push({ op: "i32.clz" }, { op: "f64.convert_i32_s" });
+}

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -23,6 +23,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.atanh",
   "math.cbrt",
   "math.ceil",
+  "math.clz32",
   "math.cos",
   "math.cosh",
   "math.exp",
@@ -51,7 +52,7 @@ export const INTRINSIC_IDS = Object.freeze([...NUMERIC_COERCION_INTRINSIC_IDS, .
 export type IntrinsicId = (typeof INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the twenty-nine intrinsic entry points.
+ * Provider requirements reachable from the thirty intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -65,6 +66,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.atanh",
   "math.cbrt",
   "math.ceil",
+  "math.clz32",
   "math.cos",
   "math.cosh",
   "math.exp",
@@ -194,6 +196,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.atanh": definition("math.atanh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cbrt": definition("math.cbrt", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.ceil": definition("math.ceil", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.clz32": definition("math.clz32", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cos": definition("math.cos", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.cosh": definition("math.cosh", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.exp": definition("math.exp", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -58,7 +58,11 @@ import type {
   IrVecLowering,
 } from "./backend/handles.js";
 import { WasmGcEmitter } from "./backend/wasmgc-emitter.js";
-import { emitWasmInt32Coercion, type WasmInt32CoercionScratch } from "./backend/wasm-int32-coercion.js";
+import {
+  emitWasmInt32Coercion,
+  emitWasmMathClz32,
+  type WasmInt32CoercionScratch,
+} from "./backend/wasm-int32-coercion.js";
 import {
   type AllocSiteId,
   type IrBlock,
@@ -1624,6 +1628,9 @@ export function lowerIrFunctionBody<S, Slot>(
               );
             }
             switch (operation) {
+              case "math.clz32":
+                emitWasmMathClz32(compositeOut as Instr[], ensureJsBitwiseI64Scratch());
+                return;
               case "to-uint32":
                 emitWasmInt32Coercion(compositeOut as Instr[], ensureJsBitwiseI64Scratch());
                 return;

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -846,7 +846,7 @@ export type IrIntrinsicBackendOp = "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.c
 export type IrIntrinsicBackendSequence = "f64.fround";
 
 /** Closed backend-neutral composite scalar semantics with backend-owned scratch. */
-export type IrIntrinsicBackendComposite = "to-uint32";
+export type IrIntrinsicBackendComposite = "math.clz32" | "to-uint32";
 
 /**
  * Provider attachment selected after middle-end transforms and manifest

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -60,6 +60,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "backend.f64.fround",
   "backend.f64.sqrt",
   "backend.f64.trunc",
+  "backend.math.clz32",
   "selfhost.math.acos",
   "selfhost.math.acosh",
   "selfhost.math.asin",
@@ -126,7 +127,7 @@ export type RuntimeProviderImplementation =
 
 export type MathRuntimeProviderImplementation = Extract<
   RuntimeProviderImplementation,
-  { readonly kind: "backend-op" | "backend-sequence" | "self-hosted" }
+  { readonly kind: "backend-op" | "backend-sequence" | "backend-composite" | "self-hosted" }
 >;
 
 export type IntrinsicRuntimeProviderImplementation = Extract<
@@ -217,6 +218,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.atanh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cbrt": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.ceil": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.clz32": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cos": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.cosh": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.exp": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -323,6 +325,10 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<PureMathRuntimeFeature, RuntimeProvi
   "math.ceil": provider("backend.f64.ceil", "math.ceil", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "backend-op",
     opcode: "f64.ceil",
+  }),
+  "math.clz32": provider("backend.math.clz32", "math.clz32", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "backend-composite",
+    operation: "math.clz32",
   }),
   "math.cos": provider(
     "selfhost.math.cos",
@@ -436,7 +442,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<PureMathRuntimeFeature, RuntimeProvi
   }),
 });
 
-/** Canonically ordered default provider catalogue for the twenty-nine-method slice. */
+/** Canonically ordered default provider catalogue for the thirty-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -80,6 +80,7 @@ import {
   closureSignatureEquals,
   type IrClassShape,
   type IrClosureSignature,
+  type IrIntrinsicBackendComposite,
   type IrIntrinsicBackendSequence,
   type IrType,
 } from "./nodes.js";
@@ -288,16 +289,21 @@ export type IrMathMethodPlan =
       readonly intrinsic: IntrinsicId;
       readonly sequence: IrIntrinsicBackendSequence;
     }
+  | {
+      readonly arity: 1;
+      readonly intrinsic: IntrinsicId;
+      readonly composite: IrIntrinsicBackendComposite;
+    }
   | { readonly arity: 1 | 2; readonly intrinsic: IntrinsicId };
 
 /**
  * Exact-arity Math surface shared by selection, call-graph closure, and the
  * AST→IR builder. Every accepted method becomes a versioned semantic
  * intrinsic. `op` remains the selector compatibility signal for the five
- * single-op methods, while `sequence` marks the closed native multi-op path;
- * provider selection is performed after middle-end transforms. Keeping arity
- * here prevents selector/builder drift and preserves ambient-Math identity
- * checks.
+ * single-op methods, while `sequence` and `composite` mark closed native
+ * multi-op paths; provider selection is performed after middle-end transforms.
+ * Keeping arity here prevents selector/builder drift and preserves ambient-
+ * Math identity checks.
  */
 export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = {
   abs: { arity: 1, intrinsic: "math.abs", op: "f64.abs" },
@@ -305,6 +311,7 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   floor: { arity: 1, intrinsic: "math.floor", op: "f64.floor" },
   fround: { arity: 1, intrinsic: "math.fround", sequence: "f64.fround" },
   ceil: { arity: 1, intrinsic: "math.ceil", op: "f64.ceil" },
+  clz32: { arity: 1, intrinsic: "math.clz32", composite: "math.clz32" },
   trunc: { arity: 1, intrinsic: "math.trunc", op: "f64.trunc" },
   asin: { arity: 1, intrinsic: "math.asin" },
   acos: { arity: 1, intrinsic: "math.acos" },
@@ -6515,13 +6522,19 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
   if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
   if (plan.intrinsic === "math.fround" && process.env.JS2WASM_IR_MATH_FROUND === "0") return false;
+  if (plan.intrinsic === "math.clz32" && process.env.JS2WASM_IR_MATH_CLZ32 === "0") return false;
   if (plan.intrinsic === "math.round" && process.env.JS2WASM_IR_MATH_ROUND === "0") return false;
   if (plan.intrinsic === "math.sign" && process.env.JS2WASM_IR_MATH_SIGN === "0") return false;
   if (plan.intrinsic === "math.expm1" && process.env.JS2WASM_IR_MATH_EXPM1 === "0") return false;
   if (plan.intrinsic === "math.asinh" && process.env.JS2WASM_IR_MATH_ASINH === "0") return false;
   if (plan.intrinsic === "math.acosh" && process.env.JS2WASM_IR_MATH_ACOSH === "0") return false;
   if (plan.intrinsic === "math.atanh" && process.env.JS2WASM_IR_MATH_ATANH === "0") return false;
-  return "op" in plan || "sequence" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
+  return (
+    "op" in plan ||
+    "sequence" in plan ||
+    "composite" in plan ||
+    currentSelectionOptions?.supportsSymbolicMathHelpers === true
+  );
 }
 
 function selectorSupportsNumberToString(): boolean {

--- a/tests/issue-3526-ir-linear-math-intrinsics.test.ts
+++ b/tests/issue-3526-ir-linear-math-intrinsics.test.ts
@@ -13,6 +13,7 @@ const F64 = irVal({ kind: "f64" });
 const LINEAR_NATIVE_INTRINSICS = [
   "math.abs",
   "math.ceil",
+  "math.clz32",
   "math.floor",
   "math.fround",
   "math.sqrt",
@@ -30,7 +31,7 @@ function intrinsicFunction(id: IntrinsicId): IrFunction {
 }
 
 describe("#3526 linear semantic Math intrinsic legality", () => {
-  it("admits exactly the six semantic intrinsics backed by native linear operations", () => {
+  it("admits exactly the seven semantic intrinsics backed by native linear operations", () => {
     const admitted = PURE_MATH_INTRINSIC_IDS.filter(
       (id) => verifyIrBackendLegality(intrinsicFunction(id), "linear").length === 0,
     );

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -19,6 +19,7 @@ const identities = createTestIrFunctionIdentityFactory("issue-3526-ir-math-intri
 const F64 = irVal({ kind: "f64" });
 const BACKEND_OP_INTRINSICS = new Set<IntrinsicId>(["math.abs", "math.sqrt", "math.floor", "math.ceil", "math.trunc"]);
 const BACKEND_SEQUENCE_INTRINSICS = new Set<IntrinsicId>(["math.fround"]);
+const BACKEND_COMPOSITE_INTRINSICS = new Set<IntrinsicId>(["math.clz32"]);
 
 const METHODS = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length));
 
@@ -68,7 +69,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
   it("keeps source meaning provider-free until the frozen manifest attaches exact providers", () => {
     const analysis = analyzeSource(`
       export function allMath(x: number, y: number): number {
-        return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.trunc(x)
+        return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.clz32(x) + Math.trunc(x)
           + Math.asin(x) + Math.acos(x) + Math.atan(x) + Math.sin(x) + Math.cos(x) + Math.tan(x)
           + Math.asinh(x) + Math.acosh(x) + Math.atanh(x)
           + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
@@ -108,6 +109,8 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
         expect(instr.provider).toMatchObject({ kind: "backend-op" });
       } else if (BACKEND_SEQUENCE_INTRINSICS.has(instr.id)) {
         expect(instr.provider).toEqual({ kind: "backend-sequence", sequence: "f64.fround" });
+      } else if (BACKEND_COMPOSITE_INTRINSICS.has(instr.id)) {
+        expect(instr.provider).toEqual({ kind: "backend-composite", operation: "math.clz32" });
       } else {
         expect(instr.provider).toMatchObject({
           kind: "callable",
@@ -125,6 +128,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function sqrt(): number { return Math.sqrt(144); }
       export function floor(): number { return Math.floor(3.9); }
       export function ceil(): number { return Math.ceil(3.1); }
+      export function clz32(): number { return Math.clz32(0x100); }
       export function trunc(): number { return Math.trunc(-3.9); }
       export function asin(): number { return Math.asin(0.5); }
       export function acos(): number { return Math.acos(0.5); }
@@ -182,6 +186,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
     }
     expect(ir.wat).toContain("f32.demote_f64");
     expect(ir.wat).toContain("f64.promote_f32");
+    expect(ir.wat).toContain("i32.clz");
     for (const helper of [
       "asin",
       "acos",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,12 +88,12 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact twenty-nine certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact thirty certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(29);
+    expect(intrinsicMethods).toHaveLength(30);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
@@ -105,6 +105,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         "math.atan",
         "math.atanh",
         "math.cbrt",
+        "math.clz32",
         "math.cosh",
         "math.expm1",
         "math.fround",
@@ -140,7 +141,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(29);
+    expect(first.intrinsicUses).toHaveLength(30);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -158,6 +159,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.sinh"]).toEqual(["math.exp"]);
     expect(dependencies["math.tanh"]).toEqual(["math.exp"]);
     expect(dependencies["math.cbrt"]).toEqual([]);
+    expect(dependencies["math.clz32"]).toEqual([]);
     expect(dependencies["math.expm1"]).toEqual(["math.exp"]);
     expect(dependencies["math.fround"]).toEqual([]);
     expect(dependencies["math.round"]).toEqual([]);

--- a/tests/issue-5125-ir-math-clz32.test.ts
+++ b/tests/issue-5125-ir-math-clz32.test.ts
@@ -1,0 +1,341 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { getLastLinearIrReport } from "../src/ir/backend/linear-integration.js";
+import { verifyIrBackendLegality } from "../src/ir/backend/legality.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5125-ir-math-clz32");
+const SOURCE = `export function clz32(value: number): number { return Math.clz32(value); }`;
+const COMPOSITION_SOURCE = `
+  export function add(value: number): number { return Math.clz32(value) + 1; }
+  export function nested(value: number): number { return Math.abs(Math.clz32(value)); }
+  export function reclz(value: number): number { return Math.clz32(Math.clz32(value)); }
+  export function isZeroBits(value: number): boolean { return Math.clz32(value) === 32; }
+`;
+
+const EDGE_VALUES = [
+  Number.NaN,
+  Number.NEGATIVE_INFINITY,
+  Number.POSITIVE_INFINITY,
+  -0,
+  0,
+  -Number.MIN_VALUE,
+  Number.MIN_VALUE,
+  -3.9,
+  3.9,
+  -1,
+  1,
+  0x80,
+  0x100,
+  0x8000,
+  0x1_0000,
+  0x80_0000,
+  0x100_0000,
+  0x2000_0000,
+  0x4000_0000,
+  0x8000_0000,
+  0xffff_ffff,
+  2 ** 31,
+  2 ** 32 - 1,
+  2 ** 32,
+  2 ** 32 + 1,
+  -(2 ** 32) - 1,
+  2 ** 63,
+  2 ** 63 + 2048,
+  2 ** 64,
+  2 ** 64 + 4096,
+  2 ** 65 + 8192,
+  -(2 ** 64) - 4096,
+  -1e20,
+  1e20,
+  -Number.MAX_VALUE,
+  Number.MAX_VALUE,
+] as const;
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = result.importObject ?? buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function lowerSource(): IrFunction {
+  const analysis = analyzeSource(SOURCE);
+  const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+  if (!declaration) throw new Error("missing clz32 declaration");
+  return lowerFunctionAstToIr(declaration, {
+    ownerUnitId: identities.next("clz32").unitId,
+    exported: true,
+  }).main;
+}
+
+function minimalResolver(): IrLowerResolver {
+  let nextType = 0;
+  return {
+    resolveFunc: () => 0,
+    resolveGlobal: () => {
+      throw new Error("resolveGlobal not used in this test");
+    },
+    resolveType: () => {
+      throw new Error("resolveType not used in this test");
+    },
+    internFuncType: () => nextType++,
+  };
+}
+
+const exclusionCases = [
+  [
+    "shadowed Math",
+    `export function f(x: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5125 shadowed Math is intentionally not ambient.
+      return Math.clz32(x);
+    }`,
+  ],
+  ["aliased clz32", `const clz32 = Math.clz32; export function f(x: number): number { return clz32(x); }`],
+  ["optional invocation", `export function f(x: number): number { return Math.clz32?.(x); }`],
+  ["spread argument", `export function f(x: number): number { return Math.clz32(...([x] as [number])); }`],
+  [
+    "wrong arity",
+    `export function f(x: number): number {
+      // @ts-expect-error #5125 intentionally exercises extra arity.
+      return Math.clz32(x, x);
+    }`,
+  ],
+] as const;
+
+describe("#5125 exact ambient Math.clz32 IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims the exact one-number call on the %s target", async (label, target) => {
+    const result = await compile(SOURCE, {
+      fileName: `issue-5125-${label}.ts`,
+      ...(target === undefined ? {} : { target }),
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "clz32")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irCompiledFuncs ?? []).toContain("clz32");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const wat = result.wat ?? "";
+    expect(wat).toContain("i64.reinterpret_f64");
+    expect(wat).toContain("i32.clz");
+    expect(wat).toContain("f64.convert_i32_s");
+    expect(wat).not.toContain("i64.trunc_sat_f64_s");
+    expect(wat).not.toContain("$Math_clz32");
+    const bodyStart = wat.indexOf("  (func $clz32");
+    const bodyEnd = wat.indexOf("\n  (func $", bodyStart + 1);
+    const clz32Wat = wat.slice(bodyStart, bodyEnd < 0 ? wat.length : bodyEnd);
+    expect(bodyStart).toBeGreaterThanOrEqual(0);
+    expect(clz32Wat).not.toContain("call");
+    expect(clz32Wat).not.toContain("$__toUint32");
+
+    const clz32 = (await instantiate(result)).clz32 as (value: number) => number;
+    for (const value of EDGE_VALUES) {
+      expect(clz32(value), `${label} Math.clz32(${String(value)})`).toBe(Math.clz32(value));
+    }
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("claims the same closed composite on production linear", async () => {
+    const result = await compile(SOURCE, {
+      fileName: "issue-5125-linear.ts",
+      target: "linear",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(getLastLinearIrReport()?.compiled).toContain("clz32");
+    expect(getLastLinearIrReport()?.rejected).toEqual([]);
+    expect(result.wat).toContain("i64.reinterpret_f64");
+    expect(result.wat).toContain("i32.clz");
+    const clz32 = (await instantiate(result)).clz32 as (value: number) => number;
+    for (const value of EDGE_VALUES) expect(clz32(value)).toBe(Math.clz32(value));
+  });
+
+  it("attaches one dependency-free host-free composite provider for both Wasm backends", () => {
+    const lowered = lowerSource();
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic).toEqual([
+      expect.objectContaining({
+        id: "math.clz32",
+        resultType: { kind: "val", val: { kind: "f64" } },
+      }),
+    ]);
+    expect(semantic[0]?.provider).toBeUndefined();
+    expect(() => lowerIrFunctionToWasm(lowered, minimalResolver())).toThrowError(
+      /semantic intrinsic math\.clz32 has no frozen provider/,
+    );
+
+    for (const backend of ["wasmgc", "linear"] as const) {
+      const prepared = prepareIrRuntimeManifest({
+        functions: [lowered],
+        sourceFile: "issue-5125-provider.ts",
+        policy: { target: "standalone", backend },
+      });
+      if (!prepared) throw new Error("expected a non-empty runtime manifest");
+      expect(prepared.manifest.features).toEqual(["math.clz32"]);
+      expect(prepared.manifest.hostCapabilities).toEqual([]);
+      expect(prepared.manifest.providers).toEqual([
+        expect.objectContaining({
+          id: "backend.math.clz32",
+          feature: "math.clz32",
+          dependencies: [],
+          hostCapabilities: [],
+          implementation: { kind: "backend-composite", operation: "math.clz32" },
+        }),
+      ]);
+      expect(intrinsicInstructions(prepared.functions[0]!)[0]?.provider).toEqual({
+        kind: "backend-composite",
+        operation: "math.clz32",
+      });
+      expect(verifyIrBackendLegality(prepared.functions[0]!, backend)).toEqual([]);
+      expect(verifyIrBackendLegality(prepared.functions[0]!, "bytecode")[0]?.message).toContain(
+        "bytecode backend does not support semantic intrinsic 'math.clz32'",
+      );
+      expect(verifyIrBackendLegality(prepared.functions[0]!, "porffor")[0]?.message).toContain(
+        "porffor backend does not support semantic intrinsic 'math.clz32'",
+      );
+    }
+  });
+
+  it("keeps the JavaScript Number boundary through arithmetic, nesting, and comparison", async () => {
+    const result = await compile(COMPOSITION_SOURCE, {
+      fileName: "issue-5125-composition.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    for (const name of ["add", "nested", "reclz", "isZeroBits"]) {
+      expect(outcomeFor(result, name)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+    }
+    const exports = await instantiate(result);
+    const value = 0x100;
+    expect((exports.add as (input: number) => number)(value)).toBe(Math.clz32(value) + 1);
+    expect((exports.nested as (input: number) => number)(value)).toBe(Math.abs(Math.clz32(value)));
+    expect((exports.reclz as (input: number) => number)(value)).toBe(Math.clz32(Math.clz32(value)));
+    expect((exports.isZeroBits as (input: number) => number)(0)).toBe(1);
+  });
+
+  it("matches direct codegen for huge finite inputs", async () => {
+    const [ir, direct] = await Promise.all([
+      compile(SOURCE, { fileName: "issue-5125-ir-parity.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(SOURCE, { fileName: "issue-5125-direct-parity.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+    const [irExports, directExports] = await Promise.all([instantiate(ir), instantiate(direct)]);
+    const irClz32 = irExports.clz32 as (value: number) => number;
+    const directClz32 = directExports.clz32 as (value: number) => number;
+    for (const value of EDGE_VALUES) expect(irClz32(value)).toBe(directClz32(value));
+  });
+
+  it("fails loudly on a malformed backend composite", () => {
+    const lowered = lowerSource();
+    const malformed = {
+      ...lowered,
+      blocks: lowered.blocks.map((block) => ({
+        ...block,
+        instrs: block.instrs.map((instr) =>
+          instr.kind === "intrinsic"
+            ? { ...instr, provider: { kind: "backend-composite", operation: "math.unknown" } }
+            : instr,
+        ),
+      })),
+    } as unknown as IrFunction;
+    expect(() => lowerIrFunctionToWasm(malformed, minimalResolver())).toThrowError(/unsupported backend composite/);
+  });
+
+  it("withdraws only clz32 through its narrow rollback", async () => {
+    const flag = "JS2WASM_IR_MATH_CLZ32";
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(SOURCE, {
+        fileName: "issue-5125-rollback.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      expectSuccess(result);
+      expect(outcomeFor(result, "clz32")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5125-${label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- claim exact ambient one-number `Math.clz32` calls as `f64 -> f64` semantic IR
- freeze a dependency-free `backend.math.clz32` composite for WasmGC and production linear
- reuse #5119's exact IEEE-754 ToUint32 expansion, then emit `i32.clz` and `f64.convert_i32_s`
- preserve direct ownership for excluded/coercive shapes and add a narrow rollback

## Validation

- 23/23 focused ownership, catalogue, provider, target, rollback, exclusion, and parity tests
- 3/3 exhaustive #3526 Math integration tests
- 3/3 #5119 exact ToUint32 prerequisite tests
- TypeScript 7, lint, focused Prettier, neutrality, LOC/function, oracle, coercion, and issue-integrity gates passed
- full pre-push suite passed, including 18/18 numeric-local parity tests
- final Luna Max architecture review: GO, no actionable blockers

## Stack

- base: #5137 / issue #5119
- head: `5aa72e0360`