### PR TITLE
feat(ir): own exact ambient Math.imul calls

### DIFF
--- a/plan/issues/5126-ir-exact-ambient-math-imul.md
+++ b/plan/issues/5126-ir-exact-ambient-math-imul.md
@@ -1,0 +1,150 @@
+---
+id: 5126
+title: "IR: own exact ambient Math.imul calls"
+status: in-progress
+created: 2026-08-28
+updated: 2026-08-28
+assignee: ttraenkler/codex
+branch: codex/5126-ir-math-imul
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: max
+task_type: refactor
+area: ir, backend, codegen
+language_feature: math-builtins, numeric-coercion
+goal: ir-full-coverage
+depends_on: [5125]
+required_by: []
+related: [78, 83, 111, 936, 1094, 1126, 1371, 3526, 3739, 5119, 5125]
+files:
+  - src/ir/nodes.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/lower.ts
+  - src/ir/select.ts
+  - src/ir/backend/legality.ts
+  - src/ir/backend/wasm-int32-coercion.ts
+  - scripts/ir-kind-neutrality-baseline.json
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-3526-ir-linear-math-intrinsics.test.ts
+  - tests/issue-5126-ir-math-imul.test.ts
+loc-budget-allow:
+  - src/ir/nodes.ts
+  - src/ir/intrinsics.ts
+  - src/ir/runtime-manifest.ts
+  - src/ir/lower.ts
+  - src/ir/select.ts
+  - src/ir/backend/legality.ts
+  - src/ir/backend/wasm-int32-coercion.ts
+func-budget-allow:
+  - src/ir/lower.ts::lowerIrFunctionBody
+  - src/ir/lower.ts::emitInstrTree
+  - src/ir/select.ts::selectorSupportsMathPlan
+  - src/ir/backend/legality.ts::linearInstrError
+---
+
+# #5126 — Exact ambient `Math.imul` IR ownership
+
+## Objective
+
+Retire the direct AST-to-Wasm route for exact ambient
+`Math.imul(numberExpression, numberExpression)` calls in otherwise IR-eligible
+synchronous functions. Represent the operation as a typed
+`math.imul: (f64, f64) -> f64` semantic intrinsic and freeze one host-free
+backend composite that applies #5119's exact ToUint32 expansion to both
+operands, multiplies their low 32-bit patterns, and restores the signed Int32
+result as a JavaScript Number.
+
+This checkpoint stacks on #5125. It completes the two direct Math consumers of
+the exact shared ToUint32 substrate; variadic and stateful Math methods remain
+separate work.
+
+## Exact admitted grammar
+
+Admit only a non-optional `Math.imul(left, right)` when `Math` is the unshadowed
+ambient binding, there are exactly two non-spread arguments, both are proven
+primitive `number`, and the containing unit passes ordinary IR ownership and
+call-graph gates. Aliased, computed, optional, shadowed, coercive, Symbol,
+BigInt, spread, missing-argument, and extra-argument forms remain direct.
+
+The semantic signature is f64/f64 to f64 because ECMAScript exposes the result
+as Number. The composite's two internal i32 patterns are implementation detail;
+`i32.mul` naturally keeps their low 32 bits and `f64.convert_i32_s` restores the
+required signed Int32 result, including negative values and positive zero.
+
+## Closed binary composite
+
+`emitPreparedIntrinsic` evaluates arguments left-to-right and leaves both f64s
+on the Wasm stack before invoking a composite. For stack `[left, right]`, the
+closed `math.imul` expansion must:
+
+1. consume and exactly coerce `right` with `emitWasmInt32Coercion`;
+2. stash that i32 in one lazily allocated backend local;
+3. consume and exactly coerce `left` using the same four-i64 scratch pool;
+4. reload the right i32, emit `i32.mul`, then `f64.convert_i32_s`.
+
+The runtime provider has no semantic dependency on `js.to_uint32`: it calls no
+provider/helper at runtime, and the shared expansion is linked backend code.
+WasmGC and linear receive the same closed instruction stream. Bytecode and
+Porffor remain rejected by legality before emission.
+
+## Implementation plan
+
+1. Add `math.imul` to the certified Math ID/runtime-feature catalogues with the
+   existing f64-binary signature and add dependency-free
+   `backend.math.imul` composite provider metadata.
+2. Add a binary composite-marked selector plan and the narrow
+   `JS2WASM_IR_MATH_IMUL=0` rollback while retaining the shared ambient-binding,
+   exact-arity, non-spread, and primitive-number admission gates.
+3. Extend the closed composite union and add an exact binary Wasm wrapper that
+   uses one i32 rhs local plus #5119's reusable i64 coercion scratch.
+4. Admit only `math.imul` at the linear semantic-intrinsic legality boundary;
+   bytecode and Porffor remain fail-closed.
+5. Widen #3526's exhaustive catalogue, manifest, provider attachment, and
+   native-linear fixtures from thirty to thirty-one Math methods.
+6. Add focused host, zero-import standalone, and production-linear ownership;
+   provider shape; WAT ordering; direct/native parity over modulo and huge
+   finite values; signed-result/zero behavior; composition; rollback; exact
+   argument evaluation; and pre-claim exclusions.
+7. Run TypeScript 7, focused prerequisites/integration suites, formatting,
+   lint, neutrality, LOC/function/oracle/coercion ratchets, issue integrity, and
+   the full pre-push gate. Push plan and implementation as separate checkpoints
+   to a non-draft PR stacked on #5141.
+
+## Acceptance criteria
+
+- Exact ambient two-number `Math.imul` calls emit IR-only bodies on WasmGC and
+  production linear with no Math/ToUint32 helper call or host import.
+- Runtime results match native JavaScript and direct codegen for NaN,
+  infinities, fractions, signed zero, high-bit 32-bit patterns, `2**32`
+  boundaries, values beyond signed i64, `1e20`, and `Number.MAX_VALUE`.
+- Left and right arguments are each evaluated exactly once in source order.
+- The provider is frozen, dependency-free, host-free, and emits right coercion,
+  one i32 stash, left coercion, `i32.mul`, and `f64.convert_i32_s` in that order.
+- Missing/malformed providers and unsupported bytecode/Porffor consumers fail
+  closed; excluded/coercive shapes and rollback cleanly retain direct ownership.
+
+## Non-goals
+
+- Variadic `Math.min`/`max`/`hypot`, stateful `Math.random`, or general object
+  ToNumber admission.
+- Making the early direct import collector IR-aware; a dead legacy
+  `__toUint32` definition may remain in whole-module WAT, but the IR body may
+  not call it.
+- A generic arbitrary backend expansion DSL or cross-provider instruction
+  inlining.
+
+## Risk and rollback
+
+The primary risk is reversing operands or destroying the left f64 while the
+right operand is coerced. Stack-shape assertions, non-commutative coercion edge
+vectors, and side-effect-order tests guard that seam. The second risk is using
+saturating conversion for huge values; #5119 regression vectors remain in the
+focused bundle. `JS2WASM_IR_MATH_IMUL=0` withdraws only this claim, while
+`JS2WASM_IR_FIRST=0` remains the global control.
+
+## Outcome
+
+Pending implementation and final Luna Max review.

--- a/plan/issues/5126-ir-exact-ambient-math-imul.md
+++ b/plan/issues/5126-ir-exact-ambient-math-imul.md
@@ -1,7 +1,7 @@
 ---
 id: 5126
 title: "IR: own exact ambient Math.imul calls"
-status: in-progress
+status: done
 created: 2026-08-28
 updated: 2026-08-28
 assignee: ttraenkler/codex
@@ -147,4 +147,17 @@ focused bundle. `JS2WASM_IR_MATH_IMUL=0` withdraws only this claim, while
 
 ## Outcome
 
-Pending implementation and final Luna Max review.
+Implemented exact ambient two-number `Math.imul` ownership as a typed binary
+semantic intrinsic backed by one dependency-free, host-free Wasm composite.
+The shared exact ToUint32 expansion coerces right then left, reuses the existing
+i64 scratch pool plus one lazy i32 rhs local, multiplies with `i32.mul`, and
+returns the signed Int32 result as f64. WasmGC and production linear emit the
+same closed body; bytecode and Porffor remain fail-closed, and
+`JS2WASM_IR_MATH_IMUL=0` provides the narrow rollback.
+
+Validation passed for the 14 focused #5126 cases, the #3526 linear,
+integration, and manifest suites, the #5119 exact-coercion prerequisite (30/30
+tests total), TypeScript 7, lint, formatting, IR kind-neutrality, LOC/function
+budgets, oracle/coercion ratchets, and issue integrity. Luna Max architecture
+and test audits confirmed the stack discipline, provider boundary, and focused
+coverage with no checkpoint-scoped blockers.

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -354,7 +354,7 @@
       "where": "core",
       "declaredAt": "src/ir/nodes.ts:868",
       "why": "Neutral envelope, ECMAScript-sourced vocabulary. `IntrinsicId` is 29 `math.*` ids drawn explicitly from the JS `Math` surface, but ECMA-262 §21.3 leaves the transcendentals implementation-approximated, so most of them carry no ECMAScript commitment at all — while `math.pow` does (§21.3.2.26 mandates pow(1, NaN) = NaN, where C99 pow returns 1).",
-      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:37"],
+      "evidence": ["src/ir/intrinsics.ts:8", "src/ir/intrinsics.ts:38"],
       "settledBy": "State whether a `math.*` id denotes an ECMA-262 clause or an IEEE/libm operation. If the former, the vocabulary (not the instruction) is what moves; if the latter, `intrinsic` is neutral outright and `math.pow` needs an ECMAScript-specific sibling."
     },
     "iter.done": {

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -249,6 +249,7 @@ function linearInstrError(instr: IrInstr): string | null {
         case "math.clz32":
         case "math.floor":
         case "math.fround":
+        case "math.imul":
         case "math.sqrt":
         case "math.trunc":
           return null;

--- a/src/ir/backend/wasm-int32-coercion.ts
+++ b/src/ir/backend/wasm-int32-coercion.ts
@@ -101,3 +101,11 @@ export function emitWasmMathClz32(out: Instr[], scratch: WasmInt32CoercionScratc
   emitWasmInt32Coercion(out, scratch);
   out.push({ op: "i32.clz" }, { op: "f64.convert_i32_s" });
 }
+
+/** Consume two f64s and leave the exact Number result of `Math.imul`. */
+export function emitWasmMathImul(out: Instr[], scratch: WasmInt32CoercionScratch, rhsLocal: number): void {
+  emitWasmInt32Coercion(out, scratch);
+  out.push({ op: "local.set", index: rhsLocal });
+  emitWasmInt32Coercion(out, scratch);
+  out.push({ op: "local.get", index: rhsLocal }, { op: "i32.mul" }, { op: "f64.convert_i32_s" });
+}

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -30,6 +30,7 @@ export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
   "math.expm1",
   "math.floor",
   "math.fround",
+  "math.imul",
   "math.log",
   "math.log10",
   "math.log1p",
@@ -52,7 +53,7 @@ export const INTRINSIC_IDS = Object.freeze([...NUMERIC_COERCION_INTRINSIC_IDS, .
 export type IntrinsicId = (typeof INTRINSIC_IDS)[number];
 
 /**
- * Provider requirements reachable from the thirty intrinsic entry points.
+ * Provider requirements reachable from the thirty-one intrinsic entry points.
  * `math.reduce-trig` is the sole provider-only dependency in this slice.
  */
 export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
@@ -73,6 +74,7 @@ export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
   "math.expm1",
   "math.floor",
   "math.fround",
+  "math.imul",
   "math.log",
   "math.log10",
   "math.log1p",
@@ -203,6 +205,7 @@ export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefini
   "math.expm1": definition("math.expm1", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.floor": definition("math.floor", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.fround": definition("math.fround", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.imul": definition("math.imul", F64_BINARY_INTRINSIC_SIGNATURE),
   "math.log": definition("math.log", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log10": definition("math.log10", F64_UNARY_INTRINSIC_SIGNATURE),
   "math.log1p": definition("math.log1p", F64_UNARY_INTRINSIC_SIGNATURE),

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -61,6 +61,7 @@ import { WasmGcEmitter } from "./backend/wasmgc-emitter.js";
 import {
   emitWasmInt32Coercion,
   emitWasmMathClz32,
+  emitWasmMathImul,
   type WasmInt32CoercionScratch,
 } from "./backend/wasm-int32-coercion.js";
 import {
@@ -1192,15 +1193,18 @@ export function lowerIrFunctionBody<S, Slot>(
     }
     return jsBitwiseI64Scratch;
   };
+  const ensureJsBitwiseRhsI32 = (): number => {
+    if (jsBitwiseRhsIdxI32 === null) {
+      jsBitwiseRhsIdxI32 = func.params.length + locals.length;
+      const type: ValType = { kind: "i32" };
+      locals.push({ name: "$js_bitwise_rhs_i32", type, logicalType: { kind: "val", val: type } });
+    }
+    return jsBitwiseRhsIdxI32;
+  };
   const ensureJsBitwiseScratch = (rhsIsI32: boolean): { rhs: number; tmp: number } => {
     const tmp = ensureJsBitwiseTmp();
     if (rhsIsI32) {
-      if (jsBitwiseRhsIdxI32 === null) {
-        jsBitwiseRhsIdxI32 = func.params.length + locals.length;
-        const type: ValType = { kind: "i32" };
-        locals.push({ name: "$js_bitwise_rhs_i32", type, logicalType: { kind: "val", val: type } });
-      }
-      return { rhs: jsBitwiseRhsIdxI32, tmp };
+      return { rhs: ensureJsBitwiseRhsI32(), tmp };
     }
     if (jsBitwiseRhsIdxF64 === null) {
       jsBitwiseRhsIdxF64 = func.params.length + locals.length;
@@ -1630,6 +1634,9 @@ export function lowerIrFunctionBody<S, Slot>(
             switch (operation) {
               case "math.clz32":
                 emitWasmMathClz32(compositeOut as Instr[], ensureJsBitwiseI64Scratch());
+                return;
+              case "math.imul":
+                emitWasmMathImul(compositeOut as Instr[], ensureJsBitwiseI64Scratch(), ensureJsBitwiseRhsI32());
                 return;
               case "to-uint32":
                 emitWasmInt32Coercion(compositeOut as Instr[], ensureJsBitwiseI64Scratch());

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -846,7 +846,7 @@ export type IrIntrinsicBackendOp = "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.c
 export type IrIntrinsicBackendSequence = "f64.fround";
 
 /** Closed backend-neutral composite scalar semantics with backend-owned scratch. */
-export type IrIntrinsicBackendComposite = "math.clz32" | "to-uint32";
+export type IrIntrinsicBackendComposite = "math.clz32" | "math.imul" | "to-uint32";
 
 /**
  * Provider attachment selected after middle-end transforms and manifest

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -61,6 +61,7 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "backend.f64.sqrt",
   "backend.f64.trunc",
   "backend.math.clz32",
+  "backend.math.imul",
   "selfhost.math.acos",
   "selfhost.math.acosh",
   "selfhost.math.asin",
@@ -225,6 +226,7 @@ export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature,
   "math.expm1": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.floor": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.fround": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.imul": F64_BINARY_INTRINSIC_SIGNATURE,
   "math.log": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log10": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.log1p": F64_UNARY_INTRINSIC_SIGNATURE,
@@ -363,6 +365,10 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<PureMathRuntimeFeature, RuntimeProvi
     kind: "backend-sequence",
     sequence: "f64.fround",
   }),
+  "math.imul": provider("backend.math.imul", "math.imul", F64_BINARY_INTRINSIC_SIGNATURE, {
+    kind: "backend-composite",
+    operation: "math.imul",
+  }),
   "math.log": provider("selfhost.math.log", "math.log", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "self-hosted",
     symbol: "Math_log",
@@ -442,7 +448,7 @@ const PROVIDERS_BY_FEATURE: Readonly<Record<PureMathRuntimeFeature, RuntimeProvi
   }),
 });
 
-/** Canonically ordered default provider catalogue for the thirty-method slice. */
+/** Canonically ordered default provider catalogue for the thirty-one-method slice. */
 export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
   PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
     left.id.localeCompare(right.id),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -290,7 +290,7 @@ export type IrMathMethodPlan =
       readonly sequence: IrIntrinsicBackendSequence;
     }
   | {
-      readonly arity: 1;
+      readonly arity: 1 | 2;
       readonly intrinsic: IntrinsicId;
       readonly composite: IrIntrinsicBackendComposite;
     }
@@ -312,6 +312,7 @@ export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = 
   fround: { arity: 1, intrinsic: "math.fround", sequence: "f64.fround" },
   ceil: { arity: 1, intrinsic: "math.ceil", op: "f64.ceil" },
   clz32: { arity: 1, intrinsic: "math.clz32", composite: "math.clz32" },
+  imul: { arity: 2, intrinsic: "math.imul", composite: "math.imul" },
   trunc: { arity: 1, intrinsic: "math.trunc", op: "f64.trunc" },
   asin: { arity: 1, intrinsic: "math.asin" },
   acos: { arity: 1, intrinsic: "math.acos" },
@@ -6523,6 +6524,7 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
   if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
   if (plan.intrinsic === "math.fround" && process.env.JS2WASM_IR_MATH_FROUND === "0") return false;
   if (plan.intrinsic === "math.clz32" && process.env.JS2WASM_IR_MATH_CLZ32 === "0") return false;
+  if (plan.intrinsic === "math.imul" && process.env.JS2WASM_IR_MATH_IMUL === "0") return false;
   if (plan.intrinsic === "math.round" && process.env.JS2WASM_IR_MATH_ROUND === "0") return false;
   if (plan.intrinsic === "math.sign" && process.env.JS2WASM_IR_MATH_SIGN === "0") return false;
   if (plan.intrinsic === "math.expm1" && process.env.JS2WASM_IR_MATH_EXPM1 === "0") return false;

--- a/tests/issue-3526-ir-linear-math-intrinsics.test.ts
+++ b/tests/issue-3526-ir-linear-math-intrinsics.test.ts
@@ -16,6 +16,7 @@ const LINEAR_NATIVE_INTRINSICS = [
   "math.clz32",
   "math.floor",
   "math.fround",
+  "math.imul",
   "math.sqrt",
   "math.trunc",
 ] as const satisfies readonly IntrinsicId[];
@@ -25,13 +26,16 @@ function intrinsicFunction(id: IntrinsicId): IrFunction {
   const left = builder.addParam("left", F64);
   const right = builder.addParam("right", F64);
   builder.openBlock();
-  const result = builder.emitIntrinsic(id, id === "math.atan2" || id === "math.pow" ? [left, right] : [left]);
+  const result = builder.emitIntrinsic(
+    id,
+    id === "math.atan2" || id === "math.imul" || id === "math.pow" ? [left, right] : [left],
+  );
   builder.terminate({ kind: "return", values: [result] });
   return builder.finish();
 }
 
 describe("#3526 linear semantic Math intrinsic legality", () => {
-  it("admits exactly the seven semantic intrinsics backed by native linear operations", () => {
+  it("admits exactly the eight semantic intrinsics backed by native linear operations", () => {
     const admitted = PURE_MATH_INTRINSIC_IDS.filter(
       (id) => verifyIrBackendLegality(intrinsicFunction(id), "linear").length === 0,
     );

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -19,7 +19,7 @@ const identities = createTestIrFunctionIdentityFactory("issue-3526-ir-math-intri
 const F64 = irVal({ kind: "f64" });
 const BACKEND_OP_INTRINSICS = new Set<IntrinsicId>(["math.abs", "math.sqrt", "math.floor", "math.ceil", "math.trunc"]);
 const BACKEND_SEQUENCE_INTRINSICS = new Set<IntrinsicId>(["math.fround"]);
-const BACKEND_COMPOSITE_INTRINSICS = new Set<IntrinsicId>(["math.clz32"]);
+const BACKEND_COMPOSITE_INTRINSICS = new Set<IntrinsicId>(["math.clz32", "math.imul"]);
 
 const METHODS = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length));
 
@@ -74,6 +74,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
           + Math.asinh(x) + Math.acosh(x) + Math.atanh(x)
           + Math.sinh(x) + Math.cosh(x) + Math.tanh(x)
           + Math.cbrt(x) + Math.fround(x) + Math.round(x) + Math.sign(x)
+          + Math.imul(x, y)
           + Math.exp(x) + Math.expm1(x) + Math.log(x) + Math.log10(x) + Math.log1p(x) + Math.log2(x)
           + Math.pow(x, y) + Math.atan2(x, y);
       }
@@ -110,7 +111,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       } else if (BACKEND_SEQUENCE_INTRINSICS.has(instr.id)) {
         expect(instr.provider).toEqual({ kind: "backend-sequence", sequence: "f64.fround" });
       } else if (BACKEND_COMPOSITE_INTRINSICS.has(instr.id)) {
-        expect(instr.provider).toEqual({ kind: "backend-composite", operation: "math.clz32" });
+        expect(instr.provider).toEqual({ kind: "backend-composite", operation: instr.id });
       } else {
         expect(instr.provider).toMatchObject({
           kind: "callable",
@@ -144,6 +145,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
       export function tanh(): number { return Math.tanh(0.75); }
       export function cbrt(): number { return Math.cbrt(27); }
       export function fround(): number { return Math.fround(1.337); }
+      export function imul(): number { return Math.imul(0x7fffffff, 0x7fffffff); }
       export function round(): number { return Math.round(-27.5); }
       export function sign(): number { return Math.sign(-27); }
       export function exp(): number { return Math.exp(1.25); }
@@ -187,6 +189,7 @@ describe("#3526 M1 semantic Math intrinsic integration", () => {
     expect(ir.wat).toContain("f32.demote_f64");
     expect(ir.wat).toContain("f64.promote_f32");
     expect(ir.wat).toContain("i32.clz");
+    expect(ir.wat).toContain("i32.mul");
     for (const helper of [
       "asin",
       "acos",

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -88,12 +88,12 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
 }
 
 describe("#3526 typed IR runtime manifest foundation", () => {
-  it("is exhaustive for the exact thirty certified pure Math methods and excludes random", () => {
+  it("is exhaustive for the exact thirty-one certified pure Math methods and excludes random", () => {
     const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
     const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
 
     expect(intrinsicMethods).toEqual(certifiedMethods);
-    expect(intrinsicMethods).toHaveLength(30);
+    expect(intrinsicMethods).toHaveLength(31);
     expect(intrinsicMethods).not.toContain("random");
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
     expect(PURE_MATH_RUNTIME_FEATURES).toEqual(
@@ -109,6 +109,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         "math.cosh",
         "math.expm1",
         "math.fround",
+        "math.imul",
         "math.log10",
         "math.log1p",
         "math.reduce-trig",
@@ -141,7 +142,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     const first = forward.freeze();
     const second = reverse.freeze();
     expect(second).toEqual(first);
-    expect(first.intrinsicUses).toHaveLength(30);
+    expect(first.intrinsicUses).toHaveLength(31);
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
@@ -162,6 +163,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.clz32"]).toEqual([]);
     expect(dependencies["math.expm1"]).toEqual(["math.exp"]);
     expect(dependencies["math.fround"]).toEqual([]);
+    expect(dependencies["math.imul"]).toEqual([]);
     expect(dependencies["math.round"]).toEqual([]);
     expect(dependencies["math.sign"]).toEqual([]);
     expect(dependencies["math.asinh"]).toEqual(["math.log"]);

--- a/tests/issue-5126-ir-math-imul.test.ts
+++ b/tests/issue-5126-ir-math-imul.test.ts
@@ -1,0 +1,363 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { LinearEmitter } from "../src/ir/backend/linear-emitter.js";
+import { getLastLinearIrReport } from "../src/ir/backend/linear-integration.js";
+import { verifyIrBackendLegality } from "../src/ir/backend/legality.js";
+import { WasmGcEmitter } from "../src/ir/backend/wasmgc-emitter.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+import { forEachInstrDeep, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-5126-ir-math-imul");
+const SOURCE = `export function imul(left: number, right: number): number { return Math.imul(left, right); }`;
+const COMPOSITION_SOURCE = `
+  export function add(left: number, right: number): number { return Math.imul(left, right) + 1; }
+  export function nested(left: number, right: number): number { return Math.imul(Math.imul(left, right), 3); }
+  export function clz(left: number, right: number): number { return Math.clz32(Math.imul(left, right)); }
+  export function unsigned(left: number, right: number): number { return Math.imul(left, right) >>> 0; }
+`;
+
+const EDGE_PAIRS = [
+  [Number.NaN, 1],
+  [Number.NEGATIVE_INFINITY, 3],
+  [Number.POSITIVE_INFINITY, -3],
+  [-0, 7],
+  [0, -7],
+  [-3.9, 5.9],
+  [3.9, -5.9],
+  [-1, 2],
+  [0xffff_ffff, 2],
+  [0x8000_0000, 2],
+  [0x7fff_ffff, 0x7fff_ffff],
+  [0xffff_ffff, 0xffff_ffff],
+  [2 ** 32 + 1, 2 ** 32 + 1],
+  [-(2 ** 32) - 1, 3],
+  [2 ** 63 + 2048, 3],
+  [2 ** 64 + 4096, 5],
+  [2 ** 65 + 8192, -7],
+  [2 ** 80, 11],
+  [-1e20, 13],
+  [1e20, -13],
+  [Number.MAX_VALUE, 17],
+  [-Number.MAX_VALUE, -17],
+] as const;
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = result.importObject ?? buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function lowerSource(): IrFunction {
+  const analysis = analyzeSource(SOURCE);
+  const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+  if (!declaration) throw new Error("missing imul declaration");
+  return lowerFunctionAstToIr(declaration, {
+    ownerUnitId: identities.next("imul").unitId,
+    exported: true,
+  }).main;
+}
+
+function minimalResolver(): IrLowerResolver {
+  let nextType = 0;
+  return {
+    resolveFunc: () => 0,
+    resolveGlobal: () => {
+      throw new Error("resolveGlobal not used in this test");
+    },
+    resolveType: () => {
+      throw new Error("resolveType not used in this test");
+    },
+    internFuncType: () => nextType++,
+  };
+}
+
+const exclusionCases = [
+  [
+    "shadowed Math",
+    `export function f(x: number, y: number): number {
+      const Math: number = x;
+      // @ts-expect-error #5126 shadowed Math is intentionally not ambient.
+      return Math.imul(x, y);
+    }`,
+  ],
+  ["aliased imul", `const imul = Math.imul; export function f(x: number, y: number): number { return imul(x, y); }`],
+  ["optional invocation", `export function f(x: number, y: number): number { return Math.imul?.(x, y); }`],
+  [
+    "spread arguments",
+    `export function f(x: number, y: number): number { return Math.imul(...([x, y] as [number, number])); }`,
+  ],
+  [
+    "wrong arity",
+    `export function f(x: number, y: number): number {
+      // @ts-expect-error #5126 intentionally exercises extra arity.
+      return Math.imul(x, y, x);
+    }`,
+  ],
+  [
+    "non-number argument",
+    `export function f(y: number): number {
+      const text: string = "2";
+      return Math.imul(text as never, y);
+    }`,
+  ],
+] as const;
+
+describe("#5126 exact ambient Math.imul IR ownership", () => {
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("claims the exact two-number call on the %s target", async (label, target) => {
+    const result = await compile(SOURCE, {
+      fileName: `issue-5126-${label}.ts`,
+      ...(target === undefined ? {} : { target }),
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "imul")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const wat = result.wat ?? "";
+    const bodyStart = wat.indexOf("  (func $imul");
+    const bodyEnd = wat.indexOf("\n  (func $", bodyStart + 1);
+    const imulWat = wat.slice(bodyStart, bodyEnd < 0 ? wat.length : bodyEnd);
+    expect(bodyStart).toBeGreaterThanOrEqual(0);
+    expect(imulWat.match(/i64\.reinterpret_f64/g)).toHaveLength(2);
+    expect(imulWat).toContain("i32.mul");
+    expect(imulWat).toContain("f64.convert_i32_s");
+    expect(imulWat).not.toContain("i64.trunc_sat_f64_s");
+    expect(imulWat).not.toContain("call");
+    expect(imulWat).not.toContain("$__toUint32");
+    expect(wat).not.toContain("$Math_imul");
+
+    const imul = (await instantiate(result)).imul as (left: number, right: number) => number;
+    for (const [left, right] of EDGE_PAIRS) {
+      const actual = imul(left, right);
+      expect(actual, `${label} Math.imul(${String(left)}, ${String(right)})`).toBe(Math.imul(left, right));
+      if (actual === 0) expect(Object.is(actual, -0)).toBe(false);
+    }
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+  });
+
+  it("claims the same closed composite on production linear", async () => {
+    const result = await compile(SOURCE, {
+      fileName: "issue-5126-linear.ts",
+      target: "linear",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      emitWat: true,
+    });
+    expectSuccess(result);
+    expect(getLastLinearIrReport()?.compiled).toContain("imul");
+    expect(getLastLinearIrReport()?.rejected).toEqual([]);
+    const imul = (await instantiate(result)).imul as (left: number, right: number) => number;
+    for (const [left, right] of EDGE_PAIRS) expect(imul(left, right)).toBe(Math.imul(left, right));
+  });
+
+  it("attaches one dependency-free composite and emits the exact shared stack sequence", () => {
+    const lowered = lowerSource();
+    const semantic = intrinsicInstructions(lowered);
+    expect(semantic).toEqual([
+      expect.objectContaining({
+        id: "math.imul",
+        args: [expect.any(Number), expect.any(Number)],
+        resultType: { kind: "val", val: { kind: "f64" } },
+      }),
+    ]);
+    expect(semantic[0]?.args).toEqual([0, 1]);
+    expect(semantic[0]?.provider).toBeUndefined();
+    expect(() => lowerIrFunctionToWasm(lowered, minimalResolver())).toThrowError(
+      /semantic intrinsic math\.imul has no frozen provider/,
+    );
+
+    for (const backend of ["wasmgc", "linear"] as const) {
+      const prepared = prepareIrRuntimeManifest({
+        functions: [lowered],
+        sourceFile: "issue-5126-provider.ts",
+        policy: { target: "standalone", backend },
+      });
+      if (!prepared) throw new Error("expected a non-empty runtime manifest");
+      expect(prepared.manifest.features).toEqual(["math.imul"]);
+      expect(prepared.manifest.hostCapabilities).toEqual([]);
+      expect(prepared.manifest.providers).toEqual([
+        expect.objectContaining({
+          id: "backend.math.imul",
+          feature: "math.imul",
+          dependencies: [],
+          hostCapabilities: [],
+          implementation: { kind: "backend-composite", operation: "math.imul" },
+        }),
+      ]);
+      expect(intrinsicInstructions(prepared.functions[0]!)[0]?.provider).toEqual({
+        kind: "backend-composite",
+        operation: "math.imul",
+      });
+      expect(verifyIrBackendLegality(prepared.functions[0]!, backend)).toEqual([]);
+      expect(verifyIrBackendLegality(prepared.functions[0]!, "bytecode")[0]?.message).toContain(
+        "bytecode backend does not support semantic intrinsic 'math.imul'",
+      );
+      expect(verifyIrBackendLegality(prepared.functions[0]!, "porffor")[0]?.message).toContain(
+        "porffor backend does not support semantic intrinsic 'math.imul'",
+      );
+    }
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: "issue-5126-stack.ts",
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+    const wasmgc = lowerIrFunctionToWasm(prepared.functions[0]!, minimalResolver(), new WasmGcEmitter()).func;
+    const linear = lowerIrFunctionToWasm(prepared.functions[0]!, minimalResolver(), new LinearEmitter()).func;
+    expect(linear.body).toEqual(wasmgc.body);
+    const rhs = wasmgc.locals.findIndex((local) => local.name === "$js_bitwise_rhs_i32") + 2;
+    expect(rhs).toBeGreaterThanOrEqual(2);
+    const ops = wasmgc.body.map((instr) => instr.op);
+    const reinterpret = ops.flatMap((op, index) => (op === "i64.reinterpret_f64" ? [index] : []));
+    const rhsSet = wasmgc.body.findIndex((instr) => instr.op === "local.set" && instr.index === rhs);
+    const rhsGet = wasmgc.body.findIndex((instr) => instr.op === "local.get" && instr.index === rhs);
+    expect(reinterpret).toHaveLength(2);
+    expect(reinterpret[0]).toBeLessThan(rhsSet);
+    expect(rhsSet).toBeLessThan(reinterpret[1]!);
+    expect(reinterpret[1]).toBeLessThan(rhsGet);
+    expect(rhsGet).toBeLessThan(ops.indexOf("i32.mul"));
+  });
+
+  it("keeps signed Number composition exact", async () => {
+    const result = await compile(COMPOSITION_SOURCE, {
+      fileName: "issue-5126-composition.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    for (const name of ["add", "nested", "clz", "unsigned"]) {
+      expect(outcomeFor(result, name)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+    }
+    const exports = await instantiate(result);
+    const left = 0xffff_ffff;
+    const right = 2;
+    const expected = Math.imul(left, right);
+    expect((exports.add as (a: number, b: number) => number)(left, right)).toBe(expected + 1);
+    expect((exports.nested as (a: number, b: number) => number)(left, right)).toBe(Math.imul(expected, 3));
+    expect((exports.clz as (a: number, b: number) => number)(left, right)).toBe(Math.clz32(expected));
+    expect((exports.unsigned as (a: number, b: number) => number)(left, right)).toBe(expected >>> 0);
+  });
+
+  it("matches direct codegen across exact coercion edges", async () => {
+    const [ir, direct] = await Promise.all([
+      compile(SOURCE, { fileName: "issue-5126-ir-parity.ts", experimentalIR: true, trackIrOutcomes: true }),
+      compile(SOURCE, { fileName: "issue-5126-direct-parity.ts", experimentalIR: false }),
+    ]);
+    expectSuccess(ir);
+    expectSuccess(direct);
+    const [irExports, directExports] = await Promise.all([instantiate(ir), instantiate(direct)]);
+    const irImul = irExports.imul as (left: number, right: number) => number;
+    const directImul = directExports.imul as (left: number, right: number) => number;
+    for (const [left, right] of EDGE_PAIRS) expect(irImul(left, right)).toBe(directImul(left, right));
+  });
+
+  it("fails loudly on a malformed backend composite", () => {
+    const lowered = lowerSource();
+    const malformed = {
+      ...lowered,
+      blocks: lowered.blocks.map((block) => ({
+        ...block,
+        instrs: block.instrs.map((instr) =>
+          instr.kind === "intrinsic"
+            ? { ...instr, provider: { kind: "backend-composite", operation: "math.unknown" } }
+            : instr,
+        ),
+      })),
+    } as unknown as IrFunction;
+    expect(() => lowerIrFunctionToWasm(malformed, minimalResolver())).toThrowError(/unsupported backend composite/);
+  });
+
+  it("withdraws only imul through its narrow rollback", async () => {
+    const flag = "JS2WASM_IR_MATH_IMUL";
+    const previous = process.env[flag];
+    process.env[flag] = "0";
+    try {
+      const result = await compile(SOURCE, {
+        fileName: "issue-5126-rollback.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      expectSuccess(result);
+      expect(outcomeFor(result, "imul")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
+      else process.env[flag] = previous;
+    }
+  });
+
+  it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-5126-${label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(outcomeFor(result, "f")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irCompiledFuncs ?? []).not.toContain("f");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- own exact ambient two-number Math.imul calls in typed IR
- lower through a dependency-free, host-free binary Wasm composite
- reuse the exact ToUint32 backend expansion for both operands while preserving source-order evaluation
- emit the same closed body for WasmGC and production linear, with a narrow JS2WASM_IR_MATH_IMUL=0 rollback
- keep bytecode, Porffor, coercive, shadowed, spread, and non-exact-arity forms fail-closed or direct

## Validation

- 14/14 focused #5126 tests passed
- #3526 linear, integration, and runtime-manifest suites plus #5119 prerequisite passed: 30/30 total
- TypeScript 7, lint, formatting, IR kind-neutrality, LOC/function budgets, oracle/coercion ratchets, and issue integrity passed
- full pre-push gate passed, including numeric-local parity 18/18
- Luna Max architecture and test audits found no checkpoint-scoped blockers

## Stack

- stacked on #5141, which supplies the exact shared ToUint32 substrate and Math.clz32 checkpoint