### PR TITLE
docs(issues): clarify repository-local records for 5091 and 5099 ✓

### DIFF
--- a/plan/issues/5091-es2015-set-foreach-symbol-callback.md
+++ b/plan/issues/5091-es2015-set-foreach-symbol-callback.md
@@ -4,7 +4,8 @@ title: "ES2015 standalone Set.prototype.forEach rejects Symbol callbacks"
 status: done
 sprint: current
 created: 2026-08-27
-updated: 2026-08-27
+updated: 2026-08-28
+completed: 2026-08-28
 priority: high
 horizon: s
 feasibility: easy
@@ -24,7 +25,11 @@ loc-budget-allow:
   - src/codegen/map-runtime.ts
 ---
 
-# #5091 — ES2015 standalone `Set.prototype.forEach` rejects Symbol callbacks
+# Repository-local markdown issue 5091 — ES2015 standalone `Set.prototype.forEach` rejects Symbol callbacks
+
+This is the repository-local issue record at
+`plan/issues/5091-es2015-set-foreach-symbol-callback.md`; it is not a GitHub
+issue.
 
 ## Problem
 
@@ -35,8 +40,10 @@ throw a `TypeError`; the standalone native collection path does not classify a
 Symbol callback as statically non-callable and falls through to the host
 `Set_forEach` import instead.
 
-This is the one Symbol-shaped tail left by #3573, whose five literal callback
-cases (`null`, `undefined`, number, boolean, and string) are already green.
+This is the one Symbol-shaped tail left by the repository-local issue record
+`plan/issues/3573-standalone-set-foreach-noncallable-symbol-matchall.md`, whose
+five literal callback cases (`null`, `undefined`, number, boolean, and string)
+are already green.
 The change is limited to the native `Set`/`Map` forEach callback guard. Dynamic
 callbacks and Wasm closures must retain their existing routing.
 
@@ -131,10 +138,9 @@ for the selected row before the source change.
 
 ## Handoff
 
-Upstream tracking issue: #5091. The provisional local reservation `#4789`
-collided with an existing merged PR and was replaced before publication. The
-canonical delivery branch is `codex/5091-set-foreach-symbol` in
-`/private/tmp/js2-5091-set-foreach-symbol`. The completed fix is published as
-non-draft upstream PR #5093 against `loopdive/js2:main`. Root owns CI and
-merge-queue shepherding; implementation heads are `e0a1d88454` and
-`13d94cbc9b` before this publication handoff checkpoint.
+This repository-local issue record is complete at
+`plan/issues/5091-es2015-set-foreach-symbol-callback.md`; no GitHub issue was
+created for this work. The completed implementation was delivered by upstream
+pull request #5093 and is merged into `loopdive/js2:main` at merge commit
+`63e80e392879e286569ba5ebf8de33f546c3632b` (2026-08-28). The frontmatter
+therefore records `status: done` and `completed: 2026-08-28`.

--- a/plan/issues/5099-string-iterator-next-metadata.md
+++ b/plan/issues/5099-string-iterator-next-metadata.md
@@ -1,10 +1,11 @@
 ---
 id: 5099
 title: "fix(standalone): expose StringIteratorPrototype.next metadata"
-status: ready
+status: done
 sprint: current
 created: 2026-08-27
 updated: 2026-08-28
+completed: 2026-08-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -23,7 +24,10 @@ files:
   - tests/issue-5099.test.ts
 ---
 
-# #5099 — expose StringIteratorPrototype.next metadata
+# Repository-local markdown issue 5099 — expose StringIteratorPrototype.next metadata
+
+This is the repository-local issue record at
+`plan/issues/5099-string-iterator-next-metadata.md`; it is not a GitHub issue.
 
 ## Problem / evidence
 
@@ -44,9 +48,9 @@ A previous broad experiment in `/private/tmp/js2-es2015-next-bounded-fix-9` chan
 five call/dispatch modules and added a temporary debug script; it remained
 standalone `0/4` for a larger iterator cohort and is intentionally preserved as
 failed-experiment evidence. This fix remains metadata-only and does not change
-iterator stepping or generic assert/call dispatch. The transient GitHub issue
-#5099 was closed by the user after the draft checkpoint; this markdown file is
-the sole canonical issue record for this work.
+iterator stepping or generic assert/call dispatch. The repository-local issue
+record at `plan/issues/5099-string-iterator-next-metadata.md` is the sole
+canonical record for this work; no GitHub issue was created.
 
 ## Implementation plan
 
@@ -115,10 +119,12 @@ A hermetic temporary root with no `test262` checkout reports **2/2 passed and
 4/4 intentionally skipped**, proving the changed-root CI shape while retaining
 non-vacuous host and standalone coverage.
 
-Post-sync CI for PR #5103 head `e0159876d6` (Actions run `33123862203`) was
-fully green (all required jobs successful or intentionally skipped), and the
-branch was mergeable against `upstream/main` `5321bfbbfa`. The subsequent
-tracker-only handoff head `a7fdb491e0` and post-#5085 sync merge `41e71fba9a`
-were each validated locally; fresh CI on the final pushed head is required
-before readiness changes. The PR remains draft and held outside the merge
-queue pending the parent’s readiness/queue operation.
+Post-sync CI for upstream PR #5103 head `e0159876d6` (Actions run
+`33123862203`) was fully green (all required jobs successful or intentionally
+skipped), and the branch was mergeable against `upstream/main`
+`5321bfbbfa`. The subsequent tracker-only handoff head `a7fdb491e0` and
+post-#5085 sync merge `41e71fba9a` were each validated locally. Upstream PR
+#5103 is merged into `loopdive/js2:main` at merge commit
+`b1cc63d1b1fd9d4cd301fa2c3ece9c23e81d6e2d` (2026-08-28); this repository-local
+issue record at `plan/issues/5099-string-iterator-next-metadata.md` therefore
+records `status: done` and `completed: 2026-08-28`. No GitHub issue was created.


### PR DESCRIPTION
## Description

### Problem

The repository-local markdown records at `plan/issues/5091-es2015-set-foreach-symbol-callback.md` and `plan/issues/5099-string-iterator-next-metadata.md` contained wording that could be mistaken for GitHub issue tracking, including a stale upstream-tracking line and a transient GitHub-issue narrative.

### Behavior

Both records now explicitly identify themselves as repository-local markdown issues, use their full paths in the handoff, state that no GitHub issue was created, and record the accurate `done` status and completion date. The records cite the already merged upstream PRs #5093 and #5103 rather than describing pending delivery. Only these paths changed:

- `plan/issues/5091-es2015-set-foreach-symbol-callback.md`
- `plan/issues/5099-string-iterator-next-metadata.md`

### Tests

- `git diff --check` passed.
- Prettier passed for both changed markdown paths.
- TypeScript 7 typecheck, Biome lint, format check, LOC/function budgets, oracle/coercion ratchets, numeric-local parity (18/18), conformance sync, and issue-integrity checks passed.

### Tracking

The canonical records are `plan/issues/5091-es2015-set-foreach-symbol-callback.md` and `plan/issues/5099-string-iterator-next-metadata.md`. No GitHub issue was created for this documentation-policy correction.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->