### PR TITLE
feat(ir): freeze async host capability records

### DIFF
--- a/plan/issues/3526-ir-r6-semantic-runtime-contract.md
+++ b/plan/issues/3526-ir-r6-semantic-runtime-contract.md
@@ -4,7 +4,7 @@ title: "IR-only R6: typed semantic runtime contract and frozen feature manifest"
 status: blocked
 sprint: Backlog
 created: 2026-07-21
-updated: 2026-08-26
+updated: 2026-08-28
 priority: critical
 horizon: xl
 complexity: XL
@@ -474,6 +474,38 @@ fresh finite, non-negative one-minute load sample strictly below
 audit of the exact signed head before push, open the implementation PR ready
 for review, and keep production R6 routing blocked until its upstream
 transactions and typed permission/mode contract are separately approved.
+
+#### A1 implementation evidence — 2026-08-28
+
+The bounded A1 checkpoint is implemented without opening production R6
+routing. `async-runtime-providers.ts` now owns one exact, deeply frozen
+seven-record catalog. Manifest freeze validates that complete catalog, resolves
+each selected provider capability ID once, and publishes the corresponding
+canonical record identities beside the compatibility ID projection. Prepared
+host attachments retain those exact records, and codegen authenticates their
+identity, capability, and symbolic binding before any type/import allocation.
+ABI materialization reads only the attached records; the semantic provider
+graph supplies only the expected capability-ID census, including a focused
+control proving that a valid two-capability plan is not widened to all six
+imports.
+
+The three owned suites pass 26 focused tests covering reversed provider,
+feature, catalog, function, and attachment traversal; full and partial provider
+closure; the optional seventh record; exact record/target joins; Program-ABI
+dependencies; deep freeze; and malformed, missing, duplicated, cloned,
+substituted, or cross-wired catalogs and attachments. TypeScript 7 and 5,
+Prettier, IR layering, IR/codegen fallback, IR dialect, and oracle ratchets pass.
+The unchanged #4106 and #4167 affected controls each retain one
+standalone-native `WebAssembly.validate` failure that reproduces identically on
+clean `fb4c01e6ad4f00c116897d7686d5c96c31426465`; their other 13 assertions pass.
+That preserved baseline is not A1 acceptance evidence, was not weakened, and
+A1 makes no standalone-native runtime acceptance claim.
+
+The checkpoint changes no provider choice, public compile result, semantic
+async plan, concrete import spelling/signature/order, lowering, or Wasm policy.
+The issue remains `blocked`: public import-intent projection, provider
+transactions, lazy-registration deletion, and typed permission/mode authority
+still require their separately approved upstream checkpoints.
 
 ### Later measured family slices
 

--- a/src/codegen/ir-async-runtime-adapters.ts
+++ b/src/codegen/ir-async-runtime-adapters.ts
@@ -1,11 +1,13 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import {
-  ALL_ASYNC_HOST_ADAPTERS,
+  ASYNC_RUNTIME_PROVIDERS,
+  assertCanonicalAsyncHostCapabilityRecord,
   type AsyncHostAdapter,
   type AsyncHostAdapterValueType,
   type AsyncHostCapabilityId,
 } from "../ir/async-runtime-providers.js";
+import type { IrAsyncRuntimeIntent } from "../ir/async-plan.js";
 import { sameIrCallableBinding, irImportFuncRef } from "../ir/callable-bindings.js";
 import type { IrFunction } from "../ir/nodes.js";
 import type { FuncTypeDef, Import, ValType } from "../ir/types.js";
@@ -60,6 +62,23 @@ function findExactImport(ctx: CodegenContext, adapter: AsyncHostAdapter): Import
   return undefined;
 }
 
+function expectedHostCapabilities(intents: readonly IrAsyncRuntimeIntent[]): ReadonlySet<AsyncHostCapabilityId> {
+  const capabilities = new Set<AsyncHostCapabilityId>();
+  for (const intent of intents) {
+    const providers = ASYNC_RUNTIME_PROVIDERS.filter(
+      (provider) =>
+        provider.feature === intent &&
+        provider.supportedTargets.includes("host") &&
+        provider.supportedBackends.includes("wasmgc"),
+    );
+    if (providers.length !== 1) {
+      throw new Error(`IR async runtime intent ${intent} has ${providers.length} exact host-WasmGC providers`);
+    }
+    for (const capability of providers[0]!.hostCapabilities) capabilities.add(capability);
+  }
+  return capabilities;
+}
+
 /**
  * Materialize the concrete host adapter projection selected after semantic
  * runtime-manifest freeze. This runs before prepared component / Program ABI
@@ -68,7 +87,6 @@ function findExactImport(ctx: CodegenContext, adapter: AsyncHostAdapter): Import
  */
 export function materializePreparedAsyncHostAdapters(ctx: CodegenContext, functions: readonly IrFunction[]): void {
   const requested = new Map<AsyncHostCapabilityId, AsyncHostAdapter>();
-  const catalogue = new Map(ALL_ASYNC_HOST_ADAPTERS.map((adapter) => [adapter.capability, adapter] as const));
   let nativeRuntimeRequested = false;
   let nativeUndefinedRequested = false;
 
@@ -78,6 +96,9 @@ export function materializePreparedAsyncHostAdapters(ctx: CodegenContext, functi
       throw new Error(`IR async runtime attachment for ${fn.name} has no valid async plan owner`);
     }
     if (fn.asyncRuntime.kind === "standalone-native-wasmgc") {
+      if (fn.asyncRuntime.adapters.length !== 0) {
+        throw new Error(`IR async function ${fn.name} attached host capability records to a native runtime`);
+      }
       if (
         !ctx.standalone ||
         ctx.wasi ||
@@ -91,14 +112,42 @@ export function materializePreparedAsyncHostAdapters(ctx: CodegenContext, functi
       nativeUndefinedRequested ||= fn.asyncPlan.runtimeIntents.includes("value.undefined");
       continue;
     }
+    const expectedCapabilities = expectedHostCapabilities(fn.asyncPlan.runtimeIntents);
+    if (fn.asyncRuntime.adapters.length !== expectedCapabilities.size) {
+      throw new Error(
+        `IR async function ${fn.name} has ${fn.asyncRuntime.adapters.length} frozen adapter records; expected ${expectedCapabilities.size}`,
+      );
+    }
+    const attachedCapabilities = new Set<AsyncHostCapabilityId>();
     for (const attached of fn.asyncRuntime.adapters) {
-      const adapter = catalogue.get(attached.capability);
-      if (!adapter) throw new Error(`IR async runtime attachment uses unknown capability ${attached.capability}`);
-      const expectedTarget = irImportFuncRef(adapter.module, adapter.field, adapter.field);
-      if (!sameIrCallableBinding(attached.target.binding, expectedTarget.binding)) {
+      assertCanonicalAsyncHostCapabilityRecord(attached.record);
+      if (attached.capability !== attached.record.capability) {
+        throw new Error(`IR async adapter ${attached.capability} carries record ${attached.record.capability}`);
+      }
+      if (!expectedCapabilities.has(attached.capability)) {
+        throw new Error(`IR async function ${fn.name} carries unrequested adapter ${attached.capability}`);
+      }
+      if (attachedCapabilities.has(attached.capability)) {
+        throw new Error(`IR async function ${fn.name} repeats adapter ${attached.capability}`);
+      }
+      attachedCapabilities.add(attached.capability);
+      const expectedTarget = irImportFuncRef(attached.record.module, attached.record.field, attached.record.field);
+      if (
+        !sameIrCallableBinding(attached.target.binding, expectedTarget.binding) ||
+        attached.target.name !== expectedTarget.name
+      ) {
         throw new Error(`IR async adapter ${attached.capability} does not match its frozen import projection`);
       }
-      requested.set(attached.capability, adapter);
+      const prior = requested.get(attached.capability);
+      if (prior && prior !== attached.record) {
+        throw new Error(`IR async adapter ${attached.capability} differs across prepared functions`);
+      }
+      requested.set(attached.capability, attached.record);
+    }
+    for (const capability of expectedCapabilities) {
+      if (!attachedCapabilities.has(capability)) {
+        throw new Error(`IR async function ${fn.name} is missing frozen adapter ${capability}`);
+      }
     }
   }
 
@@ -113,8 +162,10 @@ export function materializePreparedAsyncHostAdapters(ctx: CodegenContext, functi
     }
   }
 
-  for (const adapter of ALL_ASYNC_HOST_ADAPTERS) {
-    if (!requested.has(adapter.capability)) continue;
+  const selectedRecords = [...requested.values()].sort((left, right) =>
+    left.capability < right.capability ? -1 : left.capability > right.capability ? 1 : 0,
+  );
+  for (const adapter of selectedRecords) {
     let imported = findExactImport(ctx, adapter);
     if (!imported) {
       const signature = expectedSignature(adapter);

--- a/src/ir/async-plan.ts
+++ b/src/ir/async-plan.ts
@@ -17,6 +17,7 @@
 import {
   ASYNC_RUNTIME_FEATURES,
   isAsyncRuntimeFeature,
+  type AsyncHostAdapter,
   type AsyncHostCapabilityId,
   type AsyncRuntimeFeature,
 } from "./async-runtime-providers.js";
@@ -189,6 +190,8 @@ export interface IrAsyncPlan {
 export interface PreparedIrAsyncHostAdapter {
   readonly capability: AsyncHostCapabilityId;
   readonly target: IrFuncRef;
+  /** Exact canonical capability record selected by the frozen manifest. */
+  readonly record: AsyncHostAdapter;
 }
 
 interface PreparedIrAsyncRuntimeBase {

--- a/src/ir/async-runtime-providers.ts
+++ b/src/ir/async-runtime-providers.ts
@@ -46,6 +46,8 @@ export const ASYNC_HOST_CAPABILITY_IDS = Object.freeze([
 
 export type AsyncHostCapabilityId = (typeof ASYNC_HOST_CAPABILITY_IDS)[number];
 
+const ASYNC_HOST_CAPABILITY_ID_SET: ReadonlySet<string> = new Set(ASYNC_HOST_CAPABILITY_IDS);
+
 export type AsyncHostAdapterValueType = "externref" | "i32";
 
 /**
@@ -57,7 +59,7 @@ export type AsyncHostAdapterValueType = "externref" | "i32";
 export const ASYNC_CALLBACK_EXCEPTION_POLICY = "module-tag-payload" as const;
 export type AsyncCallbackExceptionPolicy = typeof ASYNC_CALLBACK_EXCEPTION_POLICY;
 
-/** Concrete adapter data, deliberately separate from the semantic manifest. */
+/** Exact concrete capability record selected by the frozen semantic manifest. */
 export interface AsyncHostAdapter {
   readonly capability: AsyncHostCapabilityId;
   readonly module: "env";
@@ -86,8 +88,12 @@ function adapter(
   });
 }
 
-/** Exact host adapter surface consumed by the existing async frame engine. */
-export const ASYNC_HOST_ADAPTERS: readonly AsyncHostAdapter[] = Object.freeze([
+/**
+ * The sole closed authority for async host capability ABI. Every projection
+ * below retains these exact factory-created records; no consumer may rebuild
+ * one from a capability ID or emitted import spelling.
+ */
+export const ASYNC_HOST_CAPABILITY_RECORDS: readonly AsyncHostAdapter[] = Object.freeze([
   adapter(
     "async.callback.wrap",
     "__make_callback",
@@ -100,16 +106,138 @@ export const ASYNC_HOST_ADAPTERS: readonly AsyncHostAdapter[] = Object.freeze([
   adapter("async.promise.resolve", "Promise_resolve", ["externref"], ["externref"]),
   adapter("async.promise.settle.fulfill", "Promise_settle_resolve", ["externref", "externref"], ["externref"]),
   adapter("async.promise.settle.reject", "Promise_settle_reject", ["externref", "externref"], ["externref"]),
-]);
-
-export const ASYNC_OPTIONAL_HOST_ADAPTERS: readonly AsyncHostAdapter[] = Object.freeze([
   adapter("async.value.undefined", "__get_undefined", [], ["externref"]),
 ]);
 
-export const ALL_ASYNC_HOST_ADAPTERS: readonly AsyncHostAdapter[] = Object.freeze([
-  ...ASYNC_HOST_ADAPTERS,
-  ...ASYNC_OPTIONAL_HOST_ADAPTERS,
-]);
+const ASYNC_HOST_CAPABILITY_BY_ID: ReadonlyMap<AsyncHostCapabilityId, AsyncHostAdapter> = new Map(
+  ASYNC_HOST_CAPABILITY_RECORDS.map((record) => [record.capability, record] as const),
+);
+const CANONICAL_ASYNC_HOST_CAPABILITY_RECORDS: ReadonlySet<AsyncHostAdapter> = new Set(ASYNC_HOST_CAPABILITY_RECORDS);
+
+function compareCapabilityRecords(left: AsyncHostAdapter, right: AsyncHostAdapter): number {
+  return left.capability < right.capability ? -1 : left.capability > right.capability ? 1 : 0;
+}
+
+function describeRecord(value: unknown): string {
+  if (value && typeof value === "object" && "capability" in value) return String(value.capability);
+  return String(value);
+}
+
+function assertExactKeys(record: Record<string, unknown>, expected: readonly string[]): void {
+  const actual = Object.keys(record).sort();
+  const canonical = [...expected].sort();
+  if (actual.length !== canonical.length || actual.some((key, index) => key !== canonical[index])) {
+    throw new Error(
+      `async host capability ${describeRecord(record)} keys ${actual.join(",")} do not match ${canonical.join(",")}`,
+    );
+  }
+}
+
+function assertAdapterValueTypes(
+  value: unknown,
+  expected: readonly AsyncHostAdapterValueType[],
+  field: "params" | "results",
+  capability: AsyncHostCapabilityId,
+): void {
+  if (
+    !Array.isArray(value) ||
+    value.length !== expected.length ||
+    value.some((entry, index) => entry !== expected[index])
+  ) {
+    throw new Error(
+      `async host capability ${capability} ${field} ${JSON.stringify(value)} do not match ${JSON.stringify(expected)}`,
+    );
+  }
+}
+
+/**
+ * Validate one record structurally and against the exact closed ABI. This is
+ * intentionally separate from the identity guard so malformed test catalogues
+ * produce a precise preparation-time invariant rather than looking canonical.
+ */
+export function assertAsyncHostCapabilityRecord(value: unknown): asserts value is AsyncHostAdapter {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`async host capability record must be a plain object, got ${String(value)}`);
+  }
+  const record = value as Record<string, unknown>;
+  if (Object.getPrototypeOf(record) !== Object.prototype) {
+    throw new Error(`async host capability ${describeRecord(record)} must be a plain object`);
+  }
+  const capability = record.capability;
+  if (typeof capability !== "string" || !ASYNC_HOST_CAPABILITY_ID_SET.has(capability)) {
+    throw new Error(`unknown async host capability ${String(capability)}`);
+  }
+  const id = capability as AsyncHostCapabilityId;
+  const expected = ASYNC_HOST_CAPABILITY_BY_ID.get(id);
+  if (!expected) throw new Error(`async host capability ${id} has no canonical record`);
+  const keys = ["capability", "field", "kind", "module", "params", "results"];
+  if (expected.exceptionPolicy !== undefined) keys.push("exceptionPolicy");
+  assertExactKeys(record, keys);
+  if (record.module !== expected.module) {
+    throw new Error(`async host capability ${id} module ${String(record.module)} does not match ${expected.module}`);
+  }
+  if (record.field !== expected.field) {
+    throw new Error(`async host capability ${id} field ${String(record.field)} does not match ${expected.field}`);
+  }
+  if (record.kind !== expected.kind) {
+    throw new Error(`async host capability ${id} kind ${String(record.kind)} does not match ${expected.kind}`);
+  }
+  assertAdapterValueTypes(record.params, expected.params, "params", id);
+  assertAdapterValueTypes(record.results, expected.results, "results", id);
+  if (record.exceptionPolicy !== expected.exceptionPolicy) {
+    throw new Error(
+      `async host capability ${id} exception policy ${String(record.exceptionPolicy)} does not match ${String(expected.exceptionPolicy)}`,
+    );
+  }
+}
+
+/** Authenticate that an attached record is the exact factory-created object. */
+export function assertCanonicalAsyncHostCapabilityRecord(value: unknown): asserts value is AsyncHostAdapter {
+  assertAsyncHostCapabilityRecord(value);
+  if (!CANONICAL_ASYNC_HOST_CAPABILITY_RECORDS.has(value)) {
+    throw new Error(`async host capability ${value.capability} is not the canonical catalog record`);
+  }
+}
+
+/** Validate, canonicalize traversal order, and retain the exact record objects. */
+export function canonicalizeAsyncHostCapabilityCatalog(
+  records: readonly AsyncHostAdapter[],
+): readonly AsyncHostAdapter[] {
+  if (!Array.isArray(records)) throw new Error("async host capability catalog must be an array");
+  const seen = new Set<AsyncHostCapabilityId>();
+  for (const record of records) {
+    assertCanonicalAsyncHostCapabilityRecord(record);
+    if (seen.has(record.capability)) {
+      throw new Error(`async host capability catalog duplicates ${record.capability}`);
+    }
+    seen.add(record.capability);
+  }
+  const missing = ASYNC_HOST_CAPABILITY_IDS.filter((capability) => !seen.has(capability));
+  if (missing.length > 0 || records.length !== ASYNC_HOST_CAPABILITY_IDS.length) {
+    throw new Error(`async host capability catalog is incomplete; missing ${missing.join(",") || "none"}`);
+  }
+  return Object.freeze([...records].sort(compareCapabilityRecords));
+}
+
+/** Resolve one selected ID from an already validated catalog, fail-closed. */
+export function resolveAsyncHostCapabilityRecord(
+  records: readonly AsyncHostAdapter[],
+  capability: AsyncHostCapabilityId,
+): AsyncHostAdapter {
+  const record = records.find((candidate) => candidate.capability === capability);
+  if (!record) throw new Error(`async host capability catalog does not define ${capability}`);
+  assertCanonicalAsyncHostCapabilityRecord(record);
+  return record;
+}
+
+/** Mandatory and optional compatibility projections share the same records. */
+export const ASYNC_HOST_ADAPTERS: readonly AsyncHostAdapter[] = Object.freeze(
+  ASYNC_HOST_CAPABILITY_RECORDS.filter((record) => record.capability !== "async.value.undefined"),
+);
+
+export const ASYNC_OPTIONAL_HOST_ADAPTERS: readonly AsyncHostAdapter[] = Object.freeze(
+  ASYNC_HOST_CAPABILITY_RECORDS.filter((record) => record.capability === "async.value.undefined"),
+);
 
 function capabilities(...ids: readonly AsyncHostCapabilityId[]): readonly AsyncHostCapabilityId[] {
   return Object.freeze([...ids].sort());

--- a/src/ir/intrinsic-support.ts
+++ b/src/ir/intrinsic-support.ts
@@ -2,7 +2,7 @@
 
 import { irImportFuncRef, irIntrinsicFuncRef, sameIrCallableBinding } from "./callable-bindings.js";
 import { createIrAsyncPlan, type IrAsyncPlan, type PreparedIrAsyncRuntime } from "./async-plan.js";
-import { ALL_ASYNC_HOST_ADAPTERS, type AsyncHostCapabilityId } from "./async-runtime-providers.js";
+import type { AsyncHostCapabilityId } from "./async-runtime-providers.js";
 import { IR_ASYNC_CLOCK_SNAPSHOT_FN } from "./async-semantic-runtime.js";
 import { intrinsicEffectEvidence, INTRINSIC_DEFINITIONS } from "./intrinsics.js";
 import {
@@ -293,6 +293,10 @@ export function prepareIrRuntimeManifest(input: {
     for (const provider of selectedProviders) {
       for (const capability of provider.hostCapabilities) capabilities.add(capability);
     }
+    const records = manifest.hostCapabilityRecords.filter((record) => capabilities.has(record.capability));
+    if (records.length !== capabilities.size) {
+      throw new Error(`IR async runtime attachment for ${fn.name} is missing a frozen capability record`);
+    }
     const states = Object.freeze(
       plan.states.map((state) => {
         const attached = attachProvidersToBuffer(state.body, providers);
@@ -305,10 +309,11 @@ export function prepareIrRuntimeManifest(input: {
       : Object.freeze({
           kind: "host-wasmgc",
           adapters: Object.freeze(
-            ALL_ASYNC_HOST_ADAPTERS.filter((adapter) => capabilities.has(adapter.capability)).map((adapter) =>
+            records.map((record) =>
               Object.freeze({
-                capability: adapter.capability,
-                target: irImportFuncRef(adapter.module, adapter.field, adapter.field),
+                capability: record.capability,
+                target: irImportFuncRef(record.module, record.field, record.field),
+                record,
               }),
             ),
           ),

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -16,11 +16,15 @@ import {
   type IrIntrinsicBackendSequence,
 } from "./nodes.js";
 import {
+  ASYNC_HOST_CAPABILITY_RECORDS,
   ASYNC_HOST_CAPABILITY_IDS,
   ASYNC_OPTIONAL_RUNTIME_FEATURES,
   ASYNC_RUNTIME_FEATURES,
   ASYNC_RUNTIME_PROVIDERS,
   ASYNC_RUNTIME_PROVIDER_IDS,
+  canonicalizeAsyncHostCapabilityCatalog,
+  resolveAsyncHostCapabilityRecord,
+  type AsyncHostAdapter,
   type AsyncHostCapabilityId,
   type AsyncRuntimeFeature,
   type AsyncRuntimeProviderId,
@@ -168,6 +172,8 @@ export interface FrozenRuntimeManifest {
   readonly providers: readonly RuntimeProviderDefinition[];
   readonly providerComponents: readonly RuntimeProviderComponent[];
   readonly hostCapabilities: readonly HostCapabilityId[];
+  /** Exact selected ABI records, in the same canonical capability-ID order. */
+  readonly hostCapabilityRecords: readonly AsyncHostAdapter[];
 }
 
 export type RuntimeManifestInvariantCode =
@@ -178,6 +184,7 @@ export type RuntimeManifestInvariantCode =
   | "unknown-runtime-feature"
   | "unknown-runtime-provider"
   | "unknown-host-capability"
+  | "invalid-host-capability-catalog"
   | "duplicate-runtime-provider"
   | "duplicate-cycle-declaration"
   | "invalid-cycle-declaration"
@@ -655,6 +662,8 @@ function buildProviderComponents(
 export interface RuntimeManifestBuilderOptions {
   /** Test/integration seam; omission uses the exhaustive production catalogue. */
   readonly providers?: readonly RuntimeProviderDefinition[];
+  /** Test-only traversal/mutation seam; production uses the one closed async catalog. */
+  readonly hostCapabilityRecords?: readonly AsyncHostAdapter[];
 }
 
 type BuilderState = "open" | "building" | "frozen" | "failed";
@@ -664,6 +673,7 @@ export class RuntimeManifestBuilder {
   readonly #uses: IntrinsicUse[] = [];
   readonly #requestedFeatures = new Set<RuntimeFeature>();
   readonly #providers: RuntimeProviderDefinition[];
+  readonly #hostCapabilityRecords: readonly AsyncHostAdapter[];
   readonly #addedDependencies = new Map<RuntimeFeature, Set<RuntimeFeature>>();
   readonly #declaredCycles = new Map<string, readonly RuntimeFeature[]>();
   readonly #plannedIntrinsicIds = new Set<IntrinsicId>();
@@ -682,6 +692,7 @@ export class RuntimeManifestBuilder {
     }
     this.#policy = Object.freeze({ ...policy });
     this.#providers = (options.providers ?? RUNTIME_PROVIDERS).map(cloneProvider);
+    this.#hostCapabilityRecords = options.hostCapabilityRecords ?? ASYNC_HOST_CAPABILITY_RECORDS;
   }
 
   addIntrinsicUse(use: IntrinsicUse, effects: IntrinsicEffectEvidence): void {
@@ -855,6 +866,18 @@ export class RuntimeManifestBuilder {
       for (const capability of provider.hostCapabilities) hostCapabilityIds.add(capability);
     }
     const hostCapabilities = Object.freeze([...hostCapabilityIds].sort(compareStrings));
+    let capabilityCatalog: readonly AsyncHostAdapter[];
+    try {
+      capabilityCatalog = canonicalizeAsyncHostCapabilityCatalog(this.#hostCapabilityRecords);
+    } catch (error) {
+      throw new RuntimeManifestInvariantError(
+        "invalid-host-capability-catalog",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    const hostCapabilityRecords = Object.freeze(
+      hostCapabilities.map((capability) => resolveAsyncHostCapabilityRecord(capabilityCatalog, capability)),
+    );
 
     for (const use of intrinsicUses) this.#plannedIntrinsicIds.add(use.id);
     for (const value of providers) this.#plannedProviderIds.add(value.id);
@@ -867,6 +890,7 @@ export class RuntimeManifestBuilder {
       providers,
       providerComponents,
       hostCapabilities,
+      hostCapabilityRecords,
     });
   }
 

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -84,6 +84,7 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
     features: manifest.features,
     providerComponents: manifest.providerComponents,
     hostCapabilities: manifest.hostCapabilities,
+    hostCapabilityRecords: manifest.hostCapabilityRecords,
   };
 }
 
@@ -148,6 +149,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
+    expect(first.hostCapabilityRecords).toEqual([]);
 
     const dependencies = Object.fromEntries(
       first.providers.map((provider) => [provider.feature, provider.dependencies]),
@@ -211,6 +213,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
         const manifest = builder.freeze();
         semanticClosures.push([...manifest.features]);
         expect(manifest.hostCapabilities, `${target}/${backend}`).toEqual([]);
+        expect(manifest.hostCapabilityRecords, `${target}/${backend}`).toEqual([]);
       }
     }
 
@@ -319,6 +322,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
 
     expect(Object.isFrozen(manifest)).toBe(true);
     expect(Object.isFrozen(manifest.features)).toBe(true);
+    expect(Object.isFrozen(manifest.hostCapabilityRecords)).toBe(true);
     expect(Object.isFrozen(sinProvider)).toBe(true);
     expect(Object.isFrozen(sinProvider.dependencies)).toBe(true);
     expect(builder.manifest).toBe(manifest);

--- a/tests/issue-4103-ir-async-runtime-providers.test.ts
+++ b/tests/issue-4103-ir-async-runtime-providers.test.ts
@@ -4,10 +4,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   ASYNC_HOST_ADAPTERS,
+  ASYNC_HOST_CAPABILITY_RECORDS,
   ASYNC_HOST_CAPABILITY_IDS,
+  ASYNC_OPTIONAL_HOST_ADAPTERS,
   ASYNC_OPTIONAL_RUNTIME_FEATURES,
   ASYNC_RUNTIME_FEATURES,
   ASYNC_RUNTIME_PROVIDERS,
+  type AsyncHostAdapter,
 } from "../src/ir/async-runtime-providers.js";
 import {
   PURE_MATH_RUNTIME_PROVIDERS,
@@ -41,10 +44,25 @@ function asyncProviderIdsForTarget(target: RuntimeTarget, features: ReadonlySet<
     .sort();
 }
 
+function capabilityCatalogWith(
+  capability: AsyncHostAdapter["capability"],
+  update: (record: AsyncHostAdapter) => unknown,
+): readonly AsyncHostAdapter[] {
+  return ASYNC_HOST_CAPABILITY_RECORDS.map((record) =>
+    record.capability === capability ? update(record) : record,
+  ) as readonly AsyncHostAdapter[];
+}
+
 describe("#4103 IR async runtime provider schema", () => {
   it("closes all seven semantic requirements to the exact six existing host imports", () => {
     const forward = builder();
-    const reverse = builder();
+    const reverse = new RuntimeManifestBuilder(
+      { target: "host", backend: "wasmgc" },
+      {
+        providers: [...RUNTIME_PROVIDERS].reverse(),
+        hostCapabilityRecords: [...ASYNC_HOST_CAPABILITY_RECORDS].reverse(),
+      },
+    );
     requestAll(forward, ASYNC_RUNTIME_FEATURES);
     requestAll(reverse, [...ASYNC_RUNTIME_FEATURES].reverse());
 
@@ -67,10 +85,34 @@ describe("#4103 IR async runtime provider schema", () => {
     ]);
     expect(manifest.hostCapabilities).toHaveLength(6);
     expect(new Set(manifest.hostCapabilities)).toHaveLength(6);
-    const semanticManifest = JSON.stringify(manifest);
+    expect(manifest.hostCapabilityRecords).toEqual(ASYNC_HOST_ADAPTERS);
+    expect(
+      manifest.hostCapabilityRecords.every((record, index) => record === ASYNC_HOST_CAPABILITY_RECORDS[index]),
+    ).toBe(true);
+    const semanticManifest = JSON.stringify({
+      features: manifest.features,
+      providers: manifest.providers,
+      providerComponents: manifest.providerComponents,
+      hostCapabilities: manifest.hostCapabilities,
+    });
     for (const adapter of ASYNC_HOST_ADAPTERS) {
       expect(semanticManifest).not.toContain(adapter.field);
     }
+    expect(JSON.stringify(manifest.hostCapabilityRecords)).toContain("Promise_resolve");
+  });
+
+  it("adds only the exact optional undefined record when its provider edge is selected", () => {
+    const mandatory = builder();
+    requestAll(mandatory, ASYNC_RUNTIME_FEATURES);
+    const optional = builder();
+    requestAll(optional, [...ASYNC_RUNTIME_FEATURES, ...ASYNC_OPTIONAL_RUNTIME_FEATURES]);
+
+    const before = mandatory.freeze();
+    const after = optional.freeze();
+    expect(before.hostCapabilityRecords).toEqual(ASYNC_HOST_ADAPTERS);
+    expect(after.hostCapabilityRecords).toEqual(ASYNC_HOST_CAPABILITY_RECORDS);
+    expect(after.hostCapabilityRecords.slice(0, -1)).toEqual(before.hostCapabilityRecords);
+    expect(after.hostCapabilityRecords.at(-1)).toBe(ASYNC_OPTIONAL_HOST_ADAPTERS[0]);
   });
 
   it("closes the standalone catalogue to native-managed providers without host capabilities", () => {
@@ -87,6 +129,7 @@ describe("#4103 IR async runtime provider schema", () => {
       manifest.providers.map(() => ({ kind: "native-managed", service: "native-promise-runtime" })),
     );
     expect(manifest.hostCapabilities).toEqual([]);
+    expect(manifest.hostCapabilityRecords).toEqual([]);
     expect(manifest.providers).toContainEqual(
       expect.objectContaining({
         id: "native.value.undefined",
@@ -251,6 +294,79 @@ describe("#4103 IR async runtime provider schema", () => {
     expect(() => malformedNative.freeze()).toThrowError(thrown("unknown-host-capability"));
   });
 
+  it("rejects every malformed, incomplete, duplicated, or non-canonical capability catalog", () => {
+    const freezeWith = (hostCapabilityRecords: readonly AsyncHostAdapter[]) => {
+      const value = new RuntimeManifestBuilder({ target: "host", backend: "wasmgc" }, { hostCapabilityRecords });
+      value.requestFeature("promise.react");
+      return () => value.freeze();
+    };
+    const invalid = thrown("invalid-host-capability-catalog");
+    const callback = ASYNC_HOST_CAPABILITY_RECORDS[0]!;
+    const resolve = ASYNC_HOST_CAPABILITY_RECORDS.find((record) => record.capability === "async.promise.resolve")!;
+
+    expect(freezeWith(ASYNC_HOST_CAPABILITY_RECORDS.slice(1))).toThrowError(invalid);
+    expect(freezeWith([...ASYNC_HOST_CAPABILITY_RECORDS, callback])).toThrowError(invalid);
+    expect(freezeWith([callback, callback, ...ASYNC_HOST_CAPABILITY_RECORDS.slice(2)])).toThrowError(invalid);
+    expect(
+      freezeWith(
+        capabilityCatalogWith("async.promise.resolve", (record) => ({
+          ...record,
+          capability: "async.promise.unknown",
+        })),
+      ),
+    ).toThrowError(invalid);
+
+    const mutations: readonly ((record: AsyncHostAdapter) => unknown)[] = [
+      (record) => ({ ...record, module: "host" }),
+      (record) => ({ ...record, field: "Promise_resolve_other" }),
+      (record) => ({ ...record, kind: "global" }),
+      (record) => ({ ...record, params: ["i32"] }),
+      (record) => ({ ...record, results: [] }),
+      (record) => {
+        const { field: _field, ...withoutField } = record;
+        return withoutField;
+      },
+      (record) => ({ ...record, extra: true }),
+      (record) => ({ ...record }),
+    ];
+    for (const mutate of mutations) {
+      expect(freezeWith(capabilityCatalogWith("async.promise.resolve", mutate))).toThrowError(invalid);
+    }
+    expect(
+      freezeWith(
+        capabilityCatalogWith("async.promise.resolve", (record) => ({
+          ...record,
+          exceptionPolicy: "module-tag-payload",
+        })),
+      ),
+    ).toThrowError(invalid);
+    expect(
+      freezeWith(
+        capabilityCatalogWith("async.callback.wrap", (record) => ({
+          ...record,
+          exceptionPolicy: undefined,
+        })),
+      ),
+    ).toThrowError(invalid);
+    expect(
+      freezeWith(
+        capabilityCatalogWith("async.callback.wrap", (record) => {
+          const { exceptionPolicy: _exceptionPolicy, ...withoutExceptionPolicy } = record;
+          return withoutExceptionPolicy;
+        }),
+      ),
+    ).toThrowError(invalid);
+    expect(
+      freezeWith(
+        capabilityCatalogWith("async.callback.wrap", (record) => ({
+          ...record,
+          exceptionPolicy: "raw-exception",
+        })),
+      ),
+    ).toThrowError(invalid);
+    expect(resolve).not.toBe(callback);
+  });
+
   it("publishes deeply frozen provider and capability records", () => {
     const value = builder();
     value.requestFeature("promise.react");
@@ -260,8 +376,13 @@ describe("#4103 IR async runtime provider schema", () => {
     expect(Object.isFrozen(manifest)).toBe(true);
     expect(Object.isFrozen(manifest.providers)).toBe(true);
     expect(Object.isFrozen(manifest.hostCapabilities)).toBe(true);
+    expect(Object.isFrozen(manifest.hostCapabilityRecords)).toBe(true);
+    expect(Object.isFrozen(manifest.hostCapabilityRecords[0])).toBe(true);
+    expect(Object.isFrozen(manifest.hostCapabilityRecords[0]!.params)).toBe(true);
+    expect(Object.isFrozen(manifest.hostCapabilityRecords[0]!.results)).toBe(true);
     expect(Object.isFrozen(provider.hostCapabilities)).toBe(true);
     expect(Object.isFrozen(ASYNC_HOST_ADAPTERS[0]!.params)).toBe(true);
     expect(() => (provider.hostCapabilities as string[]).push("async.promise.resolve")).toThrow(TypeError);
+    expect(() => (manifest.hostCapabilityRecords as AsyncHostAdapter[]).reverse()).toThrow(TypeError);
   });
 });

--- a/tests/issue-4104-ir-async-plan-runtime-consumer.test.ts
+++ b/tests/issue-4104-ir-async-plan-runtime-consumer.test.ts
@@ -7,7 +7,12 @@ import { materializePreparedAsyncHostAdapters } from "../src/codegen/ir-async-ru
 import { planProgramAbiCallableImports } from "../src/codegen/program-abi-import-planning.js";
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
 import { asAsyncStateId, canonicalPromiseAbi, createIrAsyncPlan, type IrAsyncPlan } from "../src/ir/async-plan.js";
-import { ASYNC_HOST_ADAPTERS, ASYNC_RUNTIME_FEATURES } from "../src/ir/async-runtime-providers.js";
+import {
+  ASYNC_HOST_ADAPTERS,
+  ASYNC_HOST_CAPABILITY_RECORDS,
+  ASYNC_RUNTIME_FEATURES,
+  type AsyncHostAdapter,
+} from "../src/ir/async-runtime-providers.js";
 import { irCallableBindingKey } from "../src/ir/callable-bindings.js";
 import { buildIrUnitInventory, type IrTerminalUnitRecord } from "../src/ir/identity.js";
 import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
@@ -40,7 +45,29 @@ function fixture(suffix = ""): {
   return { inventory, unit };
 }
 
-function asyncPlan(unit: IrTerminalUnitRecord, withIntrinsic = false): IrAsyncPlan {
+function pairFixture(): {
+  readonly inventory: ReturnType<typeof buildIrUnitInventory>;
+  readonly units: readonly IrTerminalUnitRecord[];
+} {
+  const source = ts.createSourceFile(
+    "/repo/async-plan-consumer-pair.ts",
+    [
+      "export async function fetchUserA(p: Promise<number>): Promise<number> { return await p; }",
+      "export async function fetchUserB(p: Promise<number>): Promise<number> { return await p; }",
+    ].join("\n"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const inventory = buildIrUnitInventory([source], { entrySource: source });
+  const units = inventory.terminalUnits.filter(
+    (candidate) => candidate.kind === "top-level-function" && candidate.displayName.startsWith("fetchUser"),
+  );
+  if (units.length !== 2) throw new Error("missing paired fetchUser inventory units");
+  return { inventory, units };
+}
+
+function asyncPlan(unit: IrTerminalUnitRecord, withIntrinsic = false, voidResult = false): IrAsyncPlan {
   const promise = asValueId(0);
   const resumed = asValueId(1);
   const absolute = asValueId(2);
@@ -48,7 +75,7 @@ function asyncPlan(unit: IrTerminalUnitRecord, withIntrinsic = false): IrAsyncPl
     schemaVersion: 1,
     ownerUnitId: unit.id,
     kind: "async-function",
-    abi: canonicalPromiseAbi(F64),
+    abi: canonicalPromiseAbi(voidResult ? null : F64),
     entry: asAsyncStateId(0),
     params: [{ value: promise, type: EXTERN }],
     values: [
@@ -84,15 +111,15 @@ function asyncPlan(unit: IrTerminalUnitRecord, withIntrinsic = false): IrAsyncPl
               },
             ]
           : [],
-        terminator: { kind: "resolve", value: withIntrinsic ? absolute : resumed },
+        terminator: voidResult ? { kind: "resolve" } : { kind: "resolve", value: withIntrinsic ? absolute : resumed },
       },
     ],
     handlers: [],
-    runtimeIntents: ASYNC_RUNTIME_FEATURES,
+    runtimeIntents: voidResult ? [...ASYNC_RUNTIME_FEATURES, "value.undefined"] : ASYNC_RUNTIME_FEATURES,
   });
 }
 
-function irFunction(unit: IrTerminalUnitRecord, withIntrinsic = false): IrFunction {
+function irFunction(unit: IrTerminalUnitRecord, withIntrinsic = false, voidResult = false): IrFunction {
   const promise = asValueId(0);
   return {
     unitId: unit.id,
@@ -111,7 +138,39 @@ function irFunction(unit: IrTerminalUnitRecord, withIntrinsic = false): IrFuncti
     exported: true,
     valueCount: 2,
     funcKind: "async",
-    asyncPlan: asyncPlan(unit, withIntrinsic),
+    asyncPlan: asyncPlan(unit, withIntrinsic, voidResult),
+  };
+}
+
+function settleOnlyIrFunction(unit: IrTerminalUnitRecord): IrFunction {
+  const value = asValueId(0);
+  const plan = createIrAsyncPlan({
+    schemaVersion: 1,
+    ownerUnitId: unit.id,
+    kind: "async-function",
+    abi: canonicalPromiseAbi(F64),
+    entry: asAsyncStateId(0),
+    params: [{ value, type: F64 }],
+    values: [{ value, type: F64 }],
+    spills: [],
+    states: [{ id: asAsyncStateId(0), body: [], terminator: { kind: "resolve", value } }],
+    handlers: [],
+    runtimeIntents: ["promise.capability.create", "promise.settle.fulfill"],
+  });
+  return {
+    ...irFunction(unit),
+    params: [{ value, type: F64, name: "value" }],
+    blocks: [
+      {
+        id: asBlockId(0),
+        blockArgs: [],
+        blockArgTypes: [],
+        instrs: [],
+        terminator: { kind: "unreachable" },
+      },
+    ],
+    valueCount: 1,
+    asyncPlan: plan,
   };
 }
 
@@ -154,7 +213,7 @@ function prepare(fn: IrFunction) {
 }
 
 describe("#4104 IR async plan runtime consumer", () => {
-  it("closes a semantic plan to exact prepared adapter references without contaminating the plan or manifest", () => {
+  it("closes a semantic plan to the exact frozen capability records without contaminating semantic edges", () => {
     const { unit } = fixture();
     const prepared = prepare(irFunction(unit));
     const fn = prepared.functions[0]!;
@@ -166,10 +225,54 @@ describe("#4104 IR async plan runtime consumer", () => {
     expect(fn.asyncRuntime?.adapters.map((adapter) => adapter.target.binding)).toEqual(
       ASYNC_HOST_ADAPTERS.map((adapter) => ({ kind: "import", module: adapter.module, field: adapter.field })),
     );
+    expect(fn.asyncRuntime?.adapters.map((adapter) => adapter.record)).toEqual(prepared.manifest.hostCapabilityRecords);
+    expect(
+      fn.asyncRuntime?.adapters.every(
+        (adapter, index) => adapter.record === prepared.manifest.hostCapabilityRecords[index],
+      ),
+    ).toBe(true);
     expect(verifyIrFunction(fn)).toEqual([]);
 
-    const semanticData = JSON.stringify({ plan: fn.asyncPlan, manifest: prepared.manifest });
+    const semanticData = JSON.stringify({
+      plan: fn.asyncPlan,
+      features: prepared.manifest.features,
+      providers: prepared.manifest.providers,
+      providerComponents: prepared.manifest.providerComponents,
+      hostCapabilities: prepared.manifest.hostCapabilities,
+    });
     for (const adapter of ASYNC_HOST_ADAPTERS) expect(semanticData).not.toContain(adapter.field);
+    expect(JSON.stringify(prepared.manifest.hostCapabilityRecords)).toContain("Promise_resolve");
+  });
+
+  it("attaches the optional undefined record only when the semantic plan requests it", () => {
+    const { unit } = fixture("-undefined");
+    const prepared = prepare(irFunction(unit, false, true));
+    const fn = prepared.functions[0]!;
+
+    expect(prepared.manifest.hostCapabilityRecords).toEqual(ASYNC_HOST_CAPABILITY_RECORDS);
+    expect(fn.asyncRuntime?.adapters.map((adapter) => adapter.record)).toEqual(ASYNC_HOST_CAPABILITY_RECORDS);
+    expect(fn.asyncRuntime?.adapters.at(-1)?.capability).toBe("async.value.undefined");
+    expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("preserves a valid partial semantic provider closure without widening it to all six imports", () => {
+    const { unit } = fixture("-partial");
+    const prepared = prepare(settleOnlyIrFunction(unit));
+    const fn = prepared.functions[0]!;
+    const expected = ASYNC_HOST_CAPABILITY_RECORDS.filter(
+      (record) =>
+        record.capability === "async.promise.capability.create" || record.capability === "async.promise.settle.fulfill",
+    );
+    expect(prepared.manifest.hostCapabilityRecords).toEqual(expected);
+    expect(fn.asyncRuntime?.adapters.map((adapter) => adapter.record)).toEqual(expected);
+    expect(verifyIrFunction(fn)).toEqual([]);
+
+    const module = createEmptyModule();
+    const ctx = createCodegenContext(module, {} as ts.TypeChecker);
+    materializePreparedAsyncHostAdapters(ctx, prepared.functions);
+    expect(module.imports.map((entry) => `${entry.module}.${entry.name}`)).toEqual(
+      expected.map((record) => `${record.module}.${record.field}`),
+    );
   });
 
   it("keeps semantic plan bodies target-neutral while attaching intrinsic providers to prepared states", () => {
@@ -196,6 +299,7 @@ describe("#4104 IR async plan runtime consumer", () => {
     expect(standalone.manifest.policy).toEqual({ target: "standalone", backend: "wasmgc" });
     expect(standalone.manifest.features).toEqual(ASYNC_RUNTIME_FEATURES);
     expect(standalone.manifest.hostCapabilities).toEqual([]);
+    expect(standalone.manifest.hostCapabilityRecords).toEqual([]);
     expect(standalone.manifest.providers.every((provider) => provider.implementation.kind === "native-managed")).toBe(
       true,
     );
@@ -213,12 +317,21 @@ describe("#4104 IR async plan runtime consumer", () => {
     const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
     const prepared = prepare(irFunction(unit));
 
-    materializePreparedAsyncHostAdapters(ctx, prepared.functions);
+    const reversed = [
+      {
+        ...prepared.functions[0]!,
+        asyncRuntime: Object.freeze({
+          ...prepared.functions[0]!.asyncRuntime!,
+          adapters: Object.freeze([...prepared.functions[0]!.asyncRuntime!.adapters].reverse()),
+        }),
+      },
+    ];
+    materializePreparedAsyncHostAdapters(ctx, reversed);
     const typeCount = module.types.length;
-    materializePreparedAsyncHostAdapters(ctx, prepared.functions);
+    materializePreparedAsyncHostAdapters(ctx, reversed);
 
-    expect(module.imports.map((imported) => `${imported.module}.${imported.name}`).sort()).toEqual(
-      ASYNC_HOST_ADAPTERS.map((adapter) => `${adapter.module}.${adapter.field}`).sort(),
+    expect(module.imports.map((imported) => `${imported.module}.${imported.name}`)).toEqual(
+      ASYNC_HOST_ADAPTERS.map((adapter) => `${adapter.module}.${adapter.field}`),
     );
     expect(module.imports).toHaveLength(6);
     expect(module.types).toHaveLength(typeCount);
@@ -226,7 +339,7 @@ describe("#4104 IR async plan runtime consumer", () => {
     const planned = planProgramAbiCallableImports(ctx);
     expect(planned.size).toBe(6);
     const report = derivePreparedComponentDependencies({
-      module: { functions: prepared.functions },
+      module: { functions: reversed },
       terminalUnitIds: new Set([unit.id]),
       inventory,
       abi: {
@@ -238,13 +351,103 @@ describe("#4104 IR async plan runtime consumer", () => {
     expect(
       report.components[0]?.externalCallables.map((dependency) => dependency.structuralReferenceKey).sort(),
     ).toEqual(
-      prepared.functions[0]!.asyncRuntime!.adapters.map((adapter) =>
-        irCallableBindingKey(adapter.target.binding),
-      ).sort(),
+      reversed[0]!.asyncRuntime!.adapters.map((adapter) => irCallableBindingKey(adapter.target.binding)).sort(),
     );
     expect(report.components[0]?.externalCallables.every((dependency) => dependency.programAbiBindingId !== null)).toBe(
       true,
     );
+  });
+
+  it("rejects dropped, duplicated, substituted, cloned, or cross-wired records before allocation", () => {
+    const { unit } = fixture("-poison");
+    const prepared = prepare(irFunction(unit));
+    const fn = prepared.functions[0]!;
+    if (fn.asyncRuntime?.kind !== "host-wasmgc") throw new Error("missing host async runtime");
+    const adapters = fn.asyncRuntime.adapters;
+
+    const reject = (mutated: readonly (typeof adapters)[number][], detail: RegExp): void => {
+      const module = createEmptyModule();
+      const ctx = createCodegenContext(module, {} as ts.TypeChecker);
+      const typeCount = module.types.length;
+      const malformed: IrFunction = {
+        ...fn,
+        asyncRuntime: Object.freeze({ ...fn.asyncRuntime!, adapters: Object.freeze(mutated) }),
+      };
+      expect(() => materializePreparedAsyncHostAdapters(ctx, [malformed])).toThrow(detail);
+      expect(module.imports).toEqual([]);
+      expect(module.types).toHaveLength(typeCount);
+    };
+
+    const first = adapters[0]!;
+    const second = adapters[1]!;
+    reject(adapters.slice(1), /frozen adapter records/);
+    reject([first, first, ...adapters.slice(2)], /repeats adapter/);
+    reject([{ ...first, record: second.record }, ...adapters.slice(1)], /carries record/);
+    reject([{ ...first, capability: second.capability }, ...adapters.slice(1)], /carries record/);
+    reject([{ ...first, target: second.target }, ...adapters.slice(1)], /frozen import projection/);
+    reject(
+      [
+        {
+          ...first,
+          record: {
+            ...first.record,
+            params: [...first.record.params],
+            results: [...first.record.results],
+          } as AsyncHostAdapter,
+        },
+        ...adapters.slice(1),
+      ],
+      /not the canonical catalog record/,
+    );
+  });
+
+  it("keeps import order and Program-ABI dependencies stable under function and attachment reordering", () => {
+    const { inventory, units } = pairFixture();
+    const prepared = prepareIrRuntimeManifest({
+      functions: units.map((unit) => irFunction(unit)),
+      sourceFile: "/repo/async-plan-consumer-pair.ts",
+      policy: { target: "host", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("missing paired async runtime manifest");
+    const functions = [...prepared.functions].reverse().map((fn) => {
+      if (fn.asyncRuntime?.kind !== "host-wasmgc") throw new Error("missing paired host runtime");
+      return {
+        ...fn,
+        asyncRuntime: Object.freeze({
+          ...fn.asyncRuntime,
+          adapters: Object.freeze([...fn.asyncRuntime.adapters].reverse()),
+        }),
+      };
+    });
+    const module = createEmptyModule();
+    const session = new ProgramAbiSession(inventory, module);
+    const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
+
+    materializePreparedAsyncHostAdapters(ctx, functions);
+    planProgramAbiCallableImports(ctx);
+    expect(module.imports.map((entry) => `${entry.module}.${entry.name}`)).toEqual(
+      ASYNC_HOST_ADAPTERS.map((record) => `${record.module}.${record.field}`),
+    );
+
+    const report = derivePreparedComponentDependencies({
+      module: { functions },
+      terminalUnitIds: new Set(units.map((unit) => unit.id)),
+      inventory,
+      abi: {
+        get: (id) => session.getDraft(id),
+        bindingIdsForStructuralReference: (key) => session.bindingIdsForStructuralReference(key),
+      },
+    });
+    const expectedDependencies = ASYNC_HOST_ADAPTERS.map((record) =>
+      irCallableBindingKey({ kind: "import", module: record.module, field: record.field }),
+    ).sort();
+    expect(report.components).toHaveLength(2);
+    for (const component of report.components) {
+      expect(component.status).toBe("complete");
+      expect(component.externalCallables.map((entry) => entry.structuralReferenceKey).sort()).toEqual(
+        expectedDependencies,
+      );
+    }
   });
 
   it("scans semantic async states instead of the discarded pre-transform await block", () => {


### PR DESCRIPTION
## Summary

- promote the seven shipped async adapter objects into one closed, deeply frozen capability-record catalog
- resolve selected exact record identities during runtime-manifest freeze and retain them on prepared host attachments
- authenticate record/ID/target joins before allocation, preserve partial/optional/native-zero closures, and materialize ABI only from attached records
- record the bounded A1 evidence while keeping production R6 routing blocked

## Validation

- focused: 26/26 tests across #3526, #4103, and #4104
- TypeScript 7 and TypeScript 5 typechecks
- Prettier, IR layering, IR/codegen fallback, IR dialect, oracle, LOC, and function ratchets
- normal precommit and prepush hooks, including changed-root tests and numeric-local parity
- unchanged #4106/#4167 controls: 13 assertions pass; each retains one standalone-native `WebAssembly.validate` failure reproduced on clean `fb4c01e6ad4f00c116897d7686d5c96c31426465`; these are preserved baseline failures, not A1 acceptance evidence

## Scope

This is only #3526 A1. It does not claim standalone-native runtime acceptance, public import-intent projection, provider transactions, lazy-registration deletion, permission/mode authority, or production R6 unblocking.

Refs #3526