### PR TITLE
feat(ir): retain dormant class field-call evidence

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -4,7 +4,7 @@ title: "IR-only R3: compile-once classes, members, and closures"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-27
+updated: 2026-08-28
 assignee: ttraenkler/codex
 branch: codex/3522-f2-owner-aware-direct-calls
 priority: critical
@@ -28,6 +28,8 @@ files:
   - .github/workflows/test262-sharded.yml
   - .github/workflows/refresh-baseline.yml
   - src/ir/identity.ts
+  - src/ir/class-accessor-safety.ts
+  - src/ir/class-field-call-planning.ts
   - src/ir/class-instance-initializers.ts
   - src/ir/builder.ts
   - src/ir/extern-support.ts
@@ -51,6 +53,7 @@ files:
   - src/codegen/closures.ts
   - src/codegen/declarations.ts
   - src/codegen/ir-overlay-safety.ts
+  - src/codegen/ir-overlay-identity.ts
   - src/codegen/ir-imported-call-planning.ts
   - src/codegen/ir-plain-implicit-constructors.ts
   - src/codegen/ir-prepared-free-functions.ts
@@ -67,6 +70,11 @@ files:
   - tests/issue-3214-callable-abi.test.ts
   - tests/issue-2859.test.ts
   - tests/issue-3522-ir-nested-class-expression-ownership.test.ts
+  - tests/issue-3522-ir-nested-class-ownership.test.ts
+  - tests/issue-3522-nested-class-field-call-planning.test.ts
+  - tests/issue-3520-ir-first-identity.test.ts
+  - tests/issue-3520-ir-unit-identity.test.ts
+  - tests/issue-3520-planning-owner.test.ts
   - tests/issue-3520-inherited-class-integration-abi.test.ts
   - tests/issue-3521-prepared-free-function-routing.test.ts
   - tests/issue-3521-prepared-component-dependencies.test.ts
@@ -3300,6 +3308,73 @@ inventory and typed fallback/outcome rows, never by an admitted body.
 F3 shares the identity-selection and direct-call sidecar seam with #3521.
 Rebase it onto the exact landed #3521 L1/L3 API and use that API's ownership and
 copy-on-write rules. Do not land a competing resolver or mutable sidecar.
+
+##### F3a disjoint dormant-evidence checkpoint (2026-08-28, non-authoritative)
+
+The disjoint F3 core is intentionally separable from the active
+`src/codegen/index.ts` merge surface. It establishes the following contracts
+without activating F4:
+
+- `isNestedOrdinaryClassFieldCallInventoryCandidate` is a syntax-only
+  inventory predicate. The existing
+  `isBoundedPreparedNestedOrdinaryClass` selector/preparation gate remains
+  unchanged.
+- The inventory promotes only that exact direct-nested candidate's constructor
+  and body members to terminal identities, keeps every field initializer as a
+  constructor-owned support row, and retains an immutable marker tied to the
+  exact inventory, source, class, constructor, containing terminal, fields,
+  calls, and terminal-member rows.
+- `class-field-call-planning.ts` reuses the exact identity imported-function
+  resolver's same-source top-level value path. It retains a frozen
+  source-qualified `IrFuncRef`, explicit stable callable signature, and exact
+  argument population only after every forward/reverse AST and inventory join
+  revalidates.
+- Selection consumes the proof-independent marker only to force every newly
+  inventoried constructor/member terminal to
+  `class-member-unsupported@select`; it does not consume the optional proof for
+  admission. Identity and overlay plans retain the marker and optional proof
+  sidecar as dormant evidence.
+
+This checkpoint is **not F3 acceptance** while the final production seam is
+unwired. The overlap audit originally found #5154 at `be5ec432…`, #5148 at
+`fd7b280c…`, and #5097 at `f10283be…` touching `src/codegen/index.ts`. #5154 is
+now present in the refreshed `a2191bb09520…` base; the disjoint branch still
+deliberately leaves that file untouched while #5148/#5097 remain adjacent.
+After those heads settle, the remaining narrow follow-up is:
+
+1. construct the already-shared exact resolver once before identity selection;
+2. call `planIrNestedClassFieldCalls` over the exact planning context and pass
+   its sidecar through `IrIdentitySelectionOptions`;
+3. retain that same sidecar on the outer overlay plan without rebuilding it;
+4. run the proof-enabled/proof-disabled full compiler A/B matrix and pin exact
+   inventory/outcome deltas, unchanged claims/preparation/runtime/bytes, and
+   proof-only sidecar variance.
+
+Direct planner/identity tests are necessary evidence for this checkpoint but
+cannot substitute for that final compile A/B. Until the follow-up lands, the
+production path intentionally behaves as proof-disabled: the typed candidate
+inventory and exact unsupported terminal outcomes exist, but no field-call
+body is admitted or prepared.
+
+Checkpoint evidence on the refreshed `a2191bb09520…` base. The only
+intervening changes since the measured `9f5c421b9849…` baseline were the
+unrelated #5157/#5158 issue plans; they did not touch this source or test
+surface:
+
+- TS 7 and TS 5 no-emit checks pass.
+- The focused dormant-planner matrix passes **16/16** and the four directly
+  affected identity/ownership files pass **55/55**.
+- The complete 20-file #3522 matrix on code-identical `9f5c421b9849…` reports
+  **300 pass / 17 fail**. A clean detached worktree at that same base reproduces
+  those exact 17 failures in the same four files (two cross-owner expectations,
+  eleven stale GC import-surface expectations, and four nested-static poison
+  expectations), so they are current-main baseline debt rather than an F3a
+  delta.
+- Prettier, IR layering, IR fallback, IR-only readiness, IR adoption,
+  codegen-fallback, oracle, coercion-site, optimization-retirement,
+  dead-export, LOC, and function-budget gates pass. The LOC gate measures
+  **+669 src LOC** with no unallowed growth; the existing issue-local function
+  grant accounts for `planIrCompilationByIdentity` growing **481 → 542**.
 
 #### F4. Activate only the exact prepared field-call family
 

--- a/src/codegen/ir-overlay-identity.ts
+++ b/src/codegen/ir-overlay-identity.ts
@@ -8,7 +8,8 @@ import {
   type IrIntegrationLoweringPlans,
 } from "../ir/ast-lowering-plans.js";
 import { irIntrinsicFuncRef, irUnitFuncRef } from "../ir/callable-bindings.js";
-import type { IrUnitId } from "../ir/identity.js";
+import type { IrNestedClassFieldCallInventoryCandidate, IrUnitId } from "../ir/identity.js";
+import type { IrNestedClassFieldCallProofSidecar } from "../ir/class-field-call-planning.js";
 import { irVal } from "../ir/nodes.js";
 import {
   makeIrIdentityImportedFunctionResolver,
@@ -61,6 +62,10 @@ export interface IrOverlayIdentityPlan {
   readonly unitIdByLegacyName: ReadonlyMap<string, IrUnitId>;
   readonly functionUnitIdByLegacyName: ReadonlyMap<string, IrUnitId>;
   readonly declarationByLegacyName: ReadonlyMap<string, ts.FunctionDeclaration>;
+  /** Typed-but-unclaimed F3 inventory population for this exact source. */
+  readonly nestedClassFieldCallCandidates?: readonly IrNestedClassFieldCallInventoryCandidate[];
+  /** Optional dormant evidence built before selection; never an admission input in F3. */
+  readonly nestedClassFieldCallProofs?: IrNestedClassFieldCallProofSidecar;
   readonly safeFunctionUnitIds: Set<IrUnitId>;
 }
 
@@ -162,6 +167,12 @@ export function planIrOverlayByIdentity(
     unitIdByLegacyName,
     functionUnitIdByLegacyName,
     declarationByLegacyName,
+    ...(identitySelection.nestedClassFieldCallCandidates
+      ? { nestedClassFieldCallCandidates: identitySelection.nestedClassFieldCallCandidates }
+      : {}),
+    ...(identitySelection.nestedClassFieldCallProofs
+      ? { nestedClassFieldCallProofs: identitySelection.nestedClassFieldCallProofs }
+      : {}),
     safeFunctionUnitIds: new Set(),
   };
 }

--- a/src/ir/class-accessor-safety.ts
+++ b/src/ir/class-accessor-safety.ts
@@ -106,6 +106,47 @@ function boundedPreparedInstanceFieldInitializer(initializer: ts.Expression): bo
   return bounded;
 }
 
+/**
+ * Exact syntax-only field-call candidate retained by #3522 F3.
+ *
+ * This is deliberately narrower than general call syntax: the initializer is
+ * the call itself, its target is one bare identifier, and its fixed argument
+ * population contains no nested executable/call/construct edge. Checker-backed
+ * target identity is proved separately; syntax alone never admits the class.
+ */
+export function isBoundedPreparedNestedFieldCallInitializer(
+  initializer: ts.Expression,
+): initializer is ts.CallExpression {
+  if (
+    !ts.isCallExpression(initializer) ||
+    !ts.isIdentifier(initializer.expression) ||
+    initializer.questionDotToken !== undefined ||
+    (initializer.typeArguments?.length ?? 0) !== 0 ||
+    initializer.arguments.some(ts.isSpreadElement)
+  ) {
+    return false;
+  }
+  let bounded = true;
+  const visit = (node: ts.Node): void => {
+    if (!bounded) return;
+    if (
+      ts.isCallExpression(node) ||
+      ts.isNewExpression(node) ||
+      ts.isTaggedTemplateExpression(node) ||
+      ts.isFunctionLike(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node) ||
+      node.kind === ts.SyntaxKind.SuperKeyword
+    ) {
+      bounded = false;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  for (const argument of initializer.arguments) visit(argument);
+  return bounded;
+}
+
 function hasFixedPreparedParameters(parameters: readonly ts.ParameterDeclaration[]): boolean {
   return parameters.every(
     (parameter) =>
@@ -174,12 +215,16 @@ function hasFixedPreparedParameters(parameters: readonly ts.ParameterDeclaration
  * see `prepareImplicitConstructorSupports`, which now pulls such a class into
  * the pre-seal support population.
  */
-export function isBoundedPreparedNestedOrdinaryClass(declaration: ts.ClassDeclaration | ts.ClassExpression): boolean {
+function isPreparedNestedOrdinaryClassShape(
+  declaration: ts.ClassDeclaration | ts.ClassExpression,
+  fieldCallInventoryCandidate: boolean,
+): boolean {
   if (declaration.heritageClauses?.length || hasDecorators(declaration) || declaration.members.length === 0) {
     return false;
   }
   let constructorCount = 0;
   let callableMemberCount = 0;
+  let fieldCallCount = 0;
   for (const member of declaration.members) {
     if (hasDecorators(member)) return false;
     const isStatic = hasModifier(member, ts.SyntaxKind.StaticKeyword);
@@ -189,7 +234,10 @@ export function isBoundedPreparedNestedOrdinaryClass(declaration: ts.ClassDeclar
         return false;
       }
       if (member.initializer !== undefined && !boundedPreparedInstanceFieldInitializer(member.initializer)) {
-        return false;
+        if (!fieldCallInventoryCandidate || !isBoundedPreparedNestedFieldCallInitializer(member.initializer)) {
+          return false;
+        }
+        fieldCallCount++;
       }
       continue;
     }
@@ -236,7 +284,38 @@ export function isBoundedPreparedNestedOrdinaryClass(declaration: ts.ClassDeclar
     }
     return false;
   }
-  return constructorCount <= 1 && callableMemberCount > 0;
+  return (
+    constructorCount <= 1 &&
+    callableMemberCount > 0 &&
+    (fieldCallInventoryCandidate ? fieldCallCount > 0 : fieldCallCount === 0)
+  );
+}
+
+export function isBoundedPreparedNestedOrdinaryClass(declaration: ts.ClassDeclaration | ts.ClassExpression): boolean {
+  return isPreparedNestedOrdinaryClassShape(declaration, false);
+}
+
+/**
+ * Syntax-only inventory population for one still-unclaimed bare field-call
+ * family. Only the identity scanner may use this predicate in F3; selection
+ * continues to use {@link isBoundedPreparedNestedOrdinaryClass} exclusively.
+ */
+export function isNestedOrdinaryClassFieldCallInventoryCandidate(
+  declaration: ts.ClassDeclaration | ts.ClassExpression,
+): boolean {
+  if (!isPreparedNestedOrdinaryClassShape(declaration, true)) return false;
+  if (ts.isClassDeclaration(declaration)) return declaration.name !== undefined;
+  const variable = declaration.parent;
+  if (
+    !ts.isVariableDeclaration(variable) ||
+    variable.initializer !== declaration ||
+    !ts.isIdentifier(variable.name) ||
+    !ts.isVariableDeclarationList(variable.parent) ||
+    (variable.parent.flags & ts.NodeFlags.Const) === 0
+  ) {
+    return false;
+  }
+  return declaration.name === undefined || declaration.name.text === variable.name.text;
 }
 
 /**

--- a/src/ir/class-field-call-planning.ts
+++ b/src/ir/class-field-call-planning.ts
@@ -1,0 +1,376 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import { irUnitFuncRef } from "./callable-bindings.js";
+import { isBoundedPreparedNestedFieldCallInitializer } from "./class-accessor-safety.js";
+import {
+  getIrNestedClassFieldCallInventoryCandidates,
+  type IrNestedClassFieldCallFieldCandidate,
+  type IrNestedClassFieldCallInventoryCandidate,
+  type IrUnitId,
+} from "./identity.js";
+import type { IrIdentityImportedFunctionResolver, IrIdentityResolvedFunctionTarget } from "./imported-functions.js";
+import {
+  closureSignatureEquals,
+  irTypeEquals,
+  irVal,
+  type IrClosureSignature,
+  type IrFuncRef,
+  type IrType,
+} from "./nodes.js";
+import { requireIrPlanningOwnerUnitId, type IrPlanningIdentityContext } from "./planning-identity.js";
+import { irClosureSignatureFromFunctionDeclaration } from "./select.js";
+
+export interface IrNestedClassFieldCallArgumentProjection {
+  readonly index: number;
+  readonly expression: ts.Expression;
+  readonly kind: "number" | "string" | "boolean";
+}
+
+export interface IrNestedClassFieldCallArityProjection {
+  readonly arity: number;
+  readonly arguments: readonly IrNestedClassFieldCallArgumentProjection[];
+}
+
+/** Stable signature authority supplied by the pre-selection type-planning seam. */
+export interface IrNestedClassFieldCallSignatureAuthority {
+  resolveSignature(targetUnitId: IrUnitId, declaration: ts.FunctionDeclaration): IrClosureSignature | undefined;
+}
+
+/** Dormant source-qualified proof for one exact constructor-owned field call. */
+export interface IrNestedClassFieldCallProof {
+  readonly candidate: IrNestedClassFieldCallInventoryCandidate;
+  readonly fieldCandidate: IrNestedClassFieldCallFieldCandidate;
+  readonly sourceFile: ts.SourceFile;
+  readonly sourceId: IrNestedClassFieldCallInventoryCandidate["source"]["id"];
+  readonly classDeclaration: IrNestedClassFieldCallInventoryCandidate["declaration"];
+  readonly fieldDeclaration: ts.PropertyDeclaration;
+  readonly constructorDeclaration: IrNestedClassFieldCallInventoryCandidate["constructorDeclaration"];
+  readonly call: ts.CallExpression;
+  readonly callee: ts.Identifier;
+  readonly calleeDeclaration: ts.FunctionDeclaration;
+  readonly classId: IrNestedClassFieldCallInventoryCandidate["classRecord"]["id"];
+  readonly fieldSupportUnitId: IrUnitId;
+  readonly constructorUnitId: IrUnitId;
+  readonly containingTerminalUnitId: IrUnitId;
+  readonly calleeUnitId: IrUnitId;
+  readonly target: IrFuncRef;
+  readonly signature: IrClosureSignature;
+  readonly argumentProjection: IrNestedClassFieldCallArityProjection;
+}
+
+export interface PlanIrNestedClassFieldCallsInput {
+  readonly identityContext: IrPlanningIdentityContext;
+  readonly resolver: IrIdentityImportedFunctionResolver;
+  /** Optional wider pre-selection authority; explicit primitive source ABI is the default. */
+  readonly signatures?: IrNestedClassFieldCallSignatureAuthority;
+  /** F3 A/B switch. Inventory candidates exist regardless of this value. */
+  readonly enabled?: boolean;
+}
+
+const proofSidecarAuthority = Object.freeze({});
+const authenticProofSidecars = new WeakSet<IrNestedClassFieldCallProofSidecar>();
+
+/** Immutable optional sidecar. The private index is populated once. */
+export class IrNestedClassFieldCallProofSidecar {
+  readonly inventory: IrPlanningIdentityContext["inventory"];
+  readonly entries: readonly IrNestedClassFieldCallProof[];
+  readonly #byCall: ReadonlyMap<ts.CallExpression, IrNestedClassFieldCallProof>;
+
+  /** @internal Construct through {@link planIrNestedClassFieldCalls}. */
+  constructor(
+    inventory: IrPlanningIdentityContext["inventory"],
+    entries: readonly IrNestedClassFieldCallProof[],
+    authority: typeof proofSidecarAuthority,
+  ) {
+    if (authority !== proofSidecarAuthority) {
+      throw new TypeError("nested class field-call sidecars require planner authority");
+    }
+    const byCall = new Map<ts.CallExpression, IrNestedClassFieldCallProof>();
+    for (const entry of entries) {
+      if (byCall.has(entry.call)) {
+        throw new Error("one nested class field call produced more than one dormant proof");
+      }
+      byCall.set(entry.call, entry);
+    }
+    this.inventory = inventory;
+    this.entries = Object.freeze([...entries]);
+    this.#byCall = byCall;
+    authenticProofSidecars.add(this);
+    Object.freeze(this);
+  }
+
+  get(call: ts.CallExpression): IrNestedClassFieldCallProof | undefined {
+    return this.#byCall.get(call);
+  }
+}
+
+/** Fail-closed authenticity check for selection/overlay retention. */
+export function isIrNestedClassFieldCallProofSidecarForInventory(
+  sidecar: IrNestedClassFieldCallProofSidecar,
+  inventory: IrPlanningIdentityContext["inventory"],
+): boolean {
+  return authenticProofSidecars.has(sidecar) && sidecar.inventory === inventory;
+}
+
+function ownPrimitiveType(type: IrType): IrType | undefined {
+  if (type.kind === "string") return Object.freeze({ kind: "string" });
+  if (type.kind !== "val" || (type.val.kind !== "f64" && type.val.kind !== "i32")) return undefined;
+  return Object.freeze({
+    kind: "val",
+    val: Object.freeze({ kind: type.val.kind }),
+    ...(type.signed === undefined ? {} : { signed: type.signed }),
+  });
+}
+
+function ownSignature(signature: IrClosureSignature): IrClosureSignature | undefined {
+  if (signature.defaultParamStart !== undefined || signature.returnType === null) return undefined;
+  const params = signature.params.map(ownPrimitiveType);
+  const returnType = ownPrimitiveType(signature.returnType);
+  if (!returnType || params.some((type) => type === undefined)) return undefined;
+  return Object.freeze({
+    params: Object.freeze(params as IrType[]),
+    returnType,
+  });
+}
+
+function boundedArgumentType(
+  expression: ts.Expression,
+): { readonly kind: IrNestedClassFieldCallArgumentProjection["kind"]; readonly type: IrType } | undefined {
+  if (ts.isNumericLiteral(expression)) return { kind: "number", type: irVal({ kind: "f64" }) };
+  if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+    return { kind: "string", type: { kind: "string" } };
+  }
+  if (expression.kind === ts.SyntaxKind.TrueKeyword || expression.kind === ts.SyntaxKind.FalseKeyword) {
+    return { kind: "boolean", type: irVal({ kind: "i32" }) };
+  }
+  return undefined;
+}
+
+function argumentProjection(
+  call: ts.CallExpression,
+  signature: IrClosureSignature,
+): IrNestedClassFieldCallArityProjection | undefined {
+  if (call.arguments.length !== signature.params.length) return undefined;
+  const arguments_: IrNestedClassFieldCallArgumentProjection[] = [];
+  for (let index = 0; index < call.arguments.length; index++) {
+    const expression = call.arguments[index]!;
+    const projected = boundedArgumentType(expression);
+    if (!projected || !irTypeEquals(projected.type, signature.params[index]!)) return undefined;
+    arguments_.push(Object.freeze({ index, expression, kind: projected.kind }));
+  }
+  return Object.freeze({
+    arity: call.arguments.length,
+    arguments: Object.freeze(arguments_),
+  });
+}
+
+function candidateIsCurrent(
+  candidate: IrNestedClassFieldCallInventoryCandidate,
+  identityContext: IrPlanningIdentityContext,
+): boolean {
+  const { inventory } = identityContext;
+  if (
+    candidate.inventory !== inventory ||
+    !getIrNestedClassFieldCallInventoryCandidates(inventory).includes(candidate) ||
+    identityContext.sourceIdBySourceFile.get(candidate.sourceFile) !== candidate.source.id ||
+    identityContext.sourceFileBySourceId.get(candidate.source.id) !== candidate.sourceFile ||
+    !inventory.sources.includes(candidate.source) ||
+    candidate.declaration.getSourceFile() !== candidate.sourceFile ||
+    identityContext.classIdByDeclaration.get(candidate.declaration) !== candidate.classRecord.id ||
+    identityContext.declarationByClassId.get(candidate.classRecord.id) !== candidate.declaration ||
+    !inventory.classes.includes(candidate.classRecord) ||
+    candidate.classRecord.sourceId !== candidate.source.id ||
+    candidate.classRecord.lexicalOwnerId !== candidate.containingTerminalRecord.id ||
+    identityContext.unitIdByDeclaration.get(candidate.constructorDeclaration) !== candidate.constructorRecord.id ||
+    identityContext.declarationByUnitId.get(candidate.constructorRecord.id) !== candidate.constructorDeclaration ||
+    identityContext.terminalByUnitId.get(candidate.constructorRecord.id) !== candidate.constructorRecord ||
+    identityContext.unitByUnitId.get(candidate.constructorRecord.id) !== candidate.constructorRecord ||
+    candidate.constructorRecord.sourceId !== candidate.source.id ||
+    candidate.constructorRecord.lexicalOwnerId !== candidate.classRecord.id ||
+    candidate.constructorRecord.observedKind !== "class-member" ||
+    candidate.constructorRecord.terminalOwnerId !== candidate.constructorRecord.id ||
+    candidate.constructorRecord.containingTerminalOwnerId !== candidate.containingTerminalRecord.id ||
+    identityContext.terminalByUnitId.get(candidate.containingTerminalRecord.id) !==
+      candidate.containingTerminalRecord ||
+    identityContext.unitByUnitId.get(candidate.containingTerminalRecord.id) !== candidate.containingTerminalRecord ||
+    candidate.containingTerminalRecord.sourceId !== candidate.source.id ||
+    candidate.containingTerminalRecord.terminalOwnerId !== candidate.containingTerminalRecord.id
+  ) {
+    return false;
+  }
+
+  const expectedTerminals = inventory.terminalUnits.filter(
+    (record) =>
+      record.sourceId === candidate.source.id &&
+      record.lexicalOwnerId === candidate.classRecord.id &&
+      record.observedKind === "class-member" &&
+      record.containingTerminalOwnerId === candidate.containingTerminalRecord.id,
+  );
+  if (
+    expectedTerminals.length !== candidate.terminalMembers.length ||
+    candidate.terminalMembers.some(
+      ({ declaration, record }) =>
+        !expectedTerminals.includes(record) ||
+        identityContext.unitIdByDeclaration.get(declaration) !== record.id ||
+        identityContext.declarationByUnitId.get(record.id) !== declaration ||
+        identityContext.terminalByUnitId.get(record.id) !== record ||
+        record.lexicalOwnerId !== candidate.classRecord.id ||
+        record.containingTerminalOwnerId !== candidate.containingTerminalRecord.id,
+    ) ||
+    !candidate.terminalMembers.some(({ record }) => record === candidate.constructorRecord)
+  ) {
+    return false;
+  }
+
+  const expectedFields = candidate.declaration.members.filter(
+    (member): member is ts.PropertyDeclaration =>
+      ts.isPropertyDeclaration(member) &&
+      member.initializer !== undefined &&
+      isBoundedPreparedNestedFieldCallInitializer(member.initializer),
+  );
+  if (expectedFields.length !== candidate.fields.length || expectedFields.length === 0) return false;
+  return candidate.fields.every(({ declaration, record, call }, index) => {
+    if (
+      declaration !== expectedFields[index] ||
+      call !== declaration.initializer ||
+      call.getSourceFile() !== candidate.sourceFile ||
+      identityContext.unitIdByDeclaration.get(declaration) !== record.id ||
+      identityContext.declarationByUnitId.get(record.id) !== declaration ||
+      identityContext.unitByUnitId.get(record.id) !== record ||
+      !inventory.allUnits.includes(record) ||
+      record.sourceId !== candidate.source.id ||
+      record.lexicalOwnerId !== candidate.classRecord.id ||
+      record.kind !== "class-instance-field-initializer" ||
+      record.terminal ||
+      record.terminalOwnerId !== candidate.constructorRecord.id
+    ) {
+      return false;
+    }
+    try {
+      return requireIrPlanningOwnerUnitId(identityContext, call) === candidate.constructorRecord.id;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function resolveProof(
+  candidate: IrNestedClassFieldCallInventoryCandidate,
+  fieldCandidate: IrNestedClassFieldCallFieldCandidate,
+  input: PlanIrNestedClassFieldCallsInput,
+): IrNestedClassFieldCallProof | undefined {
+  if (!candidateIsCurrent(candidate, input.identityContext) || !candidate.fields.includes(fieldCandidate)) {
+    return undefined;
+  }
+  const { call } = fieldCandidate;
+  if (!ts.isIdentifier(call.expression)) return undefined;
+  let resolved: IrIdentityResolvedFunctionTarget | undefined;
+  try {
+    resolved = input.resolver.resolveTopLevelFunctionValueTarget(call.expression);
+  } catch {
+    return undefined;
+  }
+  const targetRecord = resolved ? input.identityContext.terminalByUnitId.get(resolved.targetUnitId) : undefined;
+  if (
+    !resolved ||
+    resolved.legacyProjection !== "unambiguous" ||
+    resolved.targetName !== call.expression.text ||
+    resolved.declaration.name?.text !== resolved.targetName ||
+    resolved.declaration.getSourceFile() !== candidate.sourceFile ||
+    resolved.declaration.parent !== candidate.sourceFile ||
+    input.identityContext.sourceIdBySourceFile.get(resolved.declaration.getSourceFile()) !== candidate.source.id ||
+    input.identityContext.unitIdByDeclaration.get(resolved.declaration) !== resolved.targetUnitId ||
+    input.identityContext.declarationByUnitId.get(resolved.targetUnitId) !== resolved.declaration ||
+    !targetRecord ||
+    targetRecord.sourceId !== candidate.source.id ||
+    targetRecord.kind !== "top-level-function" ||
+    targetRecord.observedKind !== "function"
+  ) {
+    return undefined;
+  }
+  const currentSignature = input.signatures
+    ? input.signatures.resolveSignature(resolved.targetUnitId, resolved.declaration)
+    : irClosureSignatureFromFunctionDeclaration(resolved.declaration);
+  if (!currentSignature) return undefined;
+  const signature = ownSignature(currentSignature);
+  if (!signature) return undefined;
+  const projectedArguments = argumentProjection(call, signature);
+  if (!projectedArguments) return undefined;
+  return Object.freeze({
+    candidate,
+    fieldCandidate,
+    sourceFile: candidate.sourceFile,
+    sourceId: candidate.source.id,
+    classDeclaration: candidate.declaration,
+    fieldDeclaration: fieldCandidate.declaration,
+    constructorDeclaration: candidate.constructorDeclaration,
+    call,
+    callee: call.expression,
+    calleeDeclaration: resolved.declaration,
+    classId: candidate.classRecord.id,
+    fieldSupportUnitId: fieldCandidate.record.id,
+    constructorUnitId: candidate.constructorRecord.id,
+    containingTerminalUnitId: candidate.containingTerminalRecord.id,
+    calleeUnitId: resolved.targetUnitId,
+    target: irUnitFuncRef({ unitId: resolved.targetUnitId, name: resolved.targetName }),
+    signature,
+    argumentProjection: projectedArguments,
+  });
+}
+
+/** Build dormant proofs only; this function never changes selection. */
+export function planIrNestedClassFieldCalls(
+  input: PlanIrNestedClassFieldCallsInput,
+): IrNestedClassFieldCallProofSidecar {
+  const candidates = getIrNestedClassFieldCallInventoryCandidates(input.identityContext.inventory);
+  if (input.enabled === false) {
+    return new IrNestedClassFieldCallProofSidecar(input.identityContext.inventory, [], proofSidecarAuthority);
+  }
+  const entries: IrNestedClassFieldCallProof[] = [];
+  for (const candidate of candidates) {
+    for (const field of candidate.fields) {
+      const proof = resolveProof(candidate, field, input);
+      if (proof) entries.push(proof);
+    }
+  }
+  return new IrNestedClassFieldCallProofSidecar(input.identityContext.inventory, entries, proofSidecarAuthority);
+}
+
+/** Revalidate every AST, owner, target, argument, and signature join. */
+export function isIrNestedClassFieldCallProofCurrent(
+  proof: IrNestedClassFieldCallProof,
+  input: PlanIrNestedClassFieldCallsInput,
+): boolean {
+  if (input.enabled === false || !candidateIsCurrent(proof.candidate, input.identityContext)) return false;
+  const current = resolveProof(proof.candidate, proof.fieldCandidate, input);
+  if (!current) return false;
+  return (
+    current.sourceFile === proof.sourceFile &&
+    current.sourceId === proof.sourceId &&
+    current.classDeclaration === proof.classDeclaration &&
+    current.fieldDeclaration === proof.fieldDeclaration &&
+    current.constructorDeclaration === proof.constructorDeclaration &&
+    current.call === proof.call &&
+    current.callee === proof.callee &&
+    current.calleeDeclaration === proof.calleeDeclaration &&
+    current.classId === proof.classId &&
+    current.fieldSupportUnitId === proof.fieldSupportUnitId &&
+    current.constructorUnitId === proof.constructorUnitId &&
+    current.containingTerminalUnitId === proof.containingTerminalUnitId &&
+    current.calleeUnitId === proof.calleeUnitId &&
+    current.target.binding.kind === "unit" &&
+    proof.target.binding.kind === "unit" &&
+    current.target.binding.unitId === proof.target.binding.unitId &&
+    current.target.name === proof.target.name &&
+    closureSignatureEquals(current.signature, proof.signature) &&
+    current.argumentProjection.arity === proof.argumentProjection.arity &&
+    current.argumentProjection.arguments.length === proof.argumentProjection.arguments.length &&
+    current.argumentProjection.arguments.every(
+      (argument, index) =>
+        argument.index === proof.argumentProjection.arguments[index]?.index &&
+        argument.expression === proof.argumentProjection.arguments[index]?.expression &&
+        argument.kind === proof.argumentProjection.arguments[index]?.kind,
+    )
+  );
+}

--- a/src/ir/identity.ts
+++ b/src/ir/identity.ts
@@ -2,7 +2,11 @@
 
 import { ts } from "../ts-api.js";
 import type { CompilerSourceOrigin, CompilerSourceProducer } from "../position-map.js";
-import { isBoundedPreparedNestedOrdinaryClass } from "./class-accessor-safety.js";
+import {
+  isBoundedPreparedNestedFieldCallInitializer,
+  isBoundedPreparedNestedOrdinaryClass,
+  isNestedOrdinaryClassFieldCallInventoryCandidate,
+} from "./class-accessor-safety.js";
 import { collectModuleInitPopulation, MODULE_INIT_UNIT_NAME } from "./module-init.js";
 import type { IrPreparationFailure } from "./outcomes.js";
 
@@ -185,6 +189,50 @@ export interface IrUnitInventory {
   /** Exact R0 attempt-root population; no support unit manufactures a row. */
   readonly terminalUnits: readonly IrTerminalUnitRecord[];
 }
+
+export type IrNestedClassFieldCallConstructorDeclaration =
+  | ts.ConstructorDeclaration
+  | ts.ClassDeclaration
+  | ts.ClassExpression;
+
+/** Exact constructor/member row retained for one still-dormant F3 candidate. */
+export interface IrNestedClassFieldCallTerminalCandidate {
+  readonly declaration:
+    | IrNestedClassFieldCallConstructorDeclaration
+    | ts.MethodDeclaration
+    | ts.GetAccessorDeclaration
+    | ts.SetAccessorDeclaration;
+  readonly record: IrTerminalUnitRecord;
+}
+
+/** Exact constructor-owned field support and its one syntax-only call edge. */
+export interface IrNestedClassFieldCallFieldCandidate {
+  readonly declaration: ts.PropertyDeclaration;
+  readonly record: IrOwnedSupportUnitRecord;
+  readonly call: ts.CallExpression;
+}
+
+/**
+ * Immutable proof-independent marker for the narrow F3 inventory population.
+ *
+ * The marker is keyed to one exact inventory object and retains AST object
+ * identity. It is evidence that IDs exist, never evidence that the class is
+ * selectable or lowerable.
+ */
+export interface IrNestedClassFieldCallInventoryCandidate {
+  readonly inventory: IrUnitInventory;
+  readonly sourceFile: ts.SourceFile;
+  readonly source: IrSourceRecord;
+  readonly declaration: ts.ClassDeclaration | ts.ClassExpression;
+  readonly classRecord: IrClassRecord;
+  readonly constructorDeclaration: IrNestedClassFieldCallConstructorDeclaration;
+  readonly constructorRecord: IrTerminalUnitRecord;
+  readonly containingTerminalRecord: IrTerminalUnitRecord;
+  readonly terminalMembers: readonly IrNestedClassFieldCallTerminalCandidate[];
+  readonly fields: readonly IrNestedClassFieldCallFieldCandidate[];
+}
+
+type PendingIrNestedClassFieldCallInventoryCandidate = Omit<IrNestedClassFieldCallInventoryCandidate, "inventory">;
 
 export interface BuildIrUnitInventoryOptions {
   /** Marks the entry explicitly without deriving it from caller insertion order. */
@@ -605,6 +653,7 @@ export interface IrInventoryScannerMetadata {
     readonly declaration: ts.ClassDeclaration | ts.ClassExpression;
     readonly record: IrClassRecord;
   }[];
+  readonly fieldCallCandidates: readonly IrNestedClassFieldCallInventoryCandidate[];
 }
 
 /** AST nodes stay outside the serializable identity records. */
@@ -615,12 +664,20 @@ export function getIrInventoryScannerMetadata(inventory: IrUnitInventory): IrInv
   return scannerMetadataByInventory.get(inventory);
 }
 
+/** Exact proof-independent F3 markers for this inventory object. */
+export function getIrNestedClassFieldCallInventoryCandidates(
+  inventory: IrUnitInventory,
+): readonly IrNestedClassFieldCallInventoryCandidate[] {
+  return scannerMetadataByInventory.get(inventory)?.fieldCallCandidates ?? Object.freeze([]);
+}
+
 class SourceInventoryBuilder {
   readonly classes: IrClassRecord[] = [];
   readonly allUnits: IrUnitRecord[] = [];
   readonly terminalUnits: IrTerminalUnitRecord[] = [];
   readonly unitDeclarations: IrInventoryScannerMetadata["units"][number][] = [];
   readonly classDeclarations: IrInventoryScannerMetadata["classes"][number][] = [];
+  readonly fieldCallCandidates: PendingIrNestedClassFieldCallInventoryCandidate[] = [];
 
   private readonly unitOrdinals = new Map<string, number>();
   private readonly classOrdinals = new Map<string, number>();
@@ -965,6 +1022,8 @@ class SourceInventoryBuilder {
     );
     const directNestedClass =
       !topLevelDeclaration && inheritedTerminalOwnerId !== null && lexicalOwnerId === inheritedTerminalOwnerId;
+    const fieldCallInventoryCandidate = directNestedClass && isNestedOrdinaryClassFieldCallInventoryCandidate(node);
+    const fieldCallTerminalMembers: IrNestedClassFieldCallTerminalCandidate[] = [];
     const deferredModuleInitScans: ((moduleOwner: IrUnitId) => void)[] = [];
     const definitionExpressions: ts.Expression[] = [...decoratorExpressions(node)];
     for (const clause of node.heritageClauses ?? []) {
@@ -996,6 +1055,7 @@ class SourceInventoryBuilder {
         }
       : undefined;
     let explicitConstructor: IrUnitRecord | undefined;
+    let explicitConstructorDeclaration: IrNestedClassFieldCallConstructorDeclaration | undefined;
     let hasExecutableConstructor = false;
     let firstInstanceInitializer: ts.PropertyDeclaration | undefined;
     let firstStaticInitialization: ts.Node | undefined;
@@ -1059,7 +1119,7 @@ class SourceInventoryBuilder {
         (ts.isGetAccessorDeclaration(functionalMember) || ts.isSetAccessorDeclaration(functionalMember));
       const promoteNestedOrdinary =
         directNestedClass &&
-        isBoundedPreparedNestedOrdinaryClass(node) &&
+        (isBoundedPreparedNestedOrdinaryClass(node) || fieldCallInventoryCandidate) &&
         (ts.isConstructorDeclaration(functionalMember) || ts.isMethodDeclaration(functionalMember));
       const promoteNestedMember = promoteNestedAccessor || promoteNestedOrdinary;
 
@@ -1091,7 +1151,13 @@ class SourceInventoryBuilder {
               legacyName,
               memberSyntheticRole,
             );
-      if (ts.isConstructorDeclaration(functionalMember)) explicitConstructor = unit;
+      if (ts.isConstructorDeclaration(functionalMember)) {
+        explicitConstructor = unit;
+        explicitConstructorDeclaration = functionalMember;
+      }
+      if (fieldCallInventoryCandidate && unit.terminal) {
+        fieldCallTerminalMembers.push({ declaration: functionalMember, record: unit });
+      }
       this.scanCallable(
         functionalMember,
         unit.id,
@@ -1100,7 +1166,9 @@ class SourceInventoryBuilder {
     }
 
     const promoteNestedImplicitInitializer =
-      directNestedClass && !hasExecutableConstructor && isBoundedPreparedNestedOrdinaryClass(node);
+      directNestedClass &&
+      !hasExecutableConstructor &&
+      (isBoundedPreparedNestedOrdinaryClass(node) || fieldCallInventoryCandidate);
     if (!hasExecutableConstructor && firstInstanceInitializer) {
       explicitConstructor =
         topLevelDeclaration || promoteNestedImplicitInitializer
@@ -1126,6 +1194,10 @@ class SourceInventoryBuilder {
               `${displayName}_new`,
               compilerOrigin ? compilerUnitRole(compilerOrigin) : undefined,
             );
+      explicitConstructorDeclaration = node;
+      if (fieldCallInventoryCandidate && explicitConstructor.terminal) {
+        fieldCallTerminalMembers.push({ declaration: node, record: explicitConstructor });
+      }
     } else if (!hasExecutableConstructor && !hasDeclareModifier(node)) {
       explicitConstructor = this.addSupportUnit(
         "class-implicit-constructor",
@@ -1138,6 +1210,7 @@ class SourceInventoryBuilder {
     }
 
     const instanceTerminalOwner = explicitConstructor?.terminal ? explicitConstructor.id : inheritedTerminalOwnerId;
+    const fieldCallFields: IrNestedClassFieldCallFieldCandidate[] = [];
     for (const field of instanceInitializers) {
       const fieldCompilerOrigin = this.compilerOrigin(field) ?? compilerOrigin;
       const unit = this.addSupportUnit(
@@ -1148,7 +1221,45 @@ class SourceInventoryBuilder {
         `${displayName}.${memberBaseName(field.name)}`,
         fieldCompilerOrigin ? compilerUnitRole(fieldCompilerOrigin) : undefined,
       );
+      if (
+        fieldCallInventoryCandidate &&
+        isBoundedPreparedNestedFieldCallInitializer(field.initializer!) &&
+        unit.terminalOwnerId !== null
+      ) {
+        fieldCallFields.push({ declaration: field, record: unit, call: field.initializer });
+      }
       this.scanNode(field.initializer!, unit.id, instanceTerminalOwner);
+    }
+
+    if (fieldCallInventoryCandidate) {
+      const constructorRecord = explicitConstructor?.terminal ? explicitConstructor : undefined;
+      const containingTerminalRecord = this.terminalUnits.find((record) => record.id === inheritedTerminalOwnerId);
+      if (
+        !constructorRecord ||
+        !explicitConstructorDeclaration ||
+        constructorRecord.containingTerminalOwnerId !== inheritedTerminalOwnerId ||
+        !containingTerminalRecord ||
+        fieldCallFields.length === 0 ||
+        fieldCallFields.some((field) => field.record.terminalOwnerId !== constructorRecord.id) ||
+        fieldCallTerminalMembers.some(
+          (member) =>
+            member.record.lexicalOwnerId !== classRecord.id ||
+            member.record.containingTerminalOwnerId !== inheritedTerminalOwnerId,
+        )
+      ) {
+        throw new Error(`invalid dormant field-call identity population for class ${classRecord.id}`);
+      }
+      this.fieldCallCandidates.push({
+        sourceFile: this.sourceFile,
+        source: this.source,
+        declaration: node,
+        classRecord,
+        constructorDeclaration: explicitConstructorDeclaration,
+        constructorRecord,
+        containingTerminalRecord,
+        terminalMembers: fieldCallTerminalMembers,
+        fields: fieldCallFields,
+      });
     }
 
     return {
@@ -1262,6 +1373,7 @@ export function buildIrUnitInventory(
   const terminalUnits: IrTerminalUnitRecord[] = [];
   const scannedUnits: IrInventoryScannerMetadata["units"][number][] = [];
   const scannedClasses: IrInventoryScannerMetadata["classes"][number][] = [];
+  const pendingFieldCallCandidates: PendingIrNestedClassFieldCallInventoryCandidate[] = [];
   for (let index = 0; index < keyed.length; index++) {
     const builder = new SourceInventoryBuilder(keyed[index]!.sourceFile, sources[index]!, options);
     builder.build();
@@ -1270,6 +1382,7 @@ export function buildIrUnitInventory(
     terminalUnits.push(...builder.terminalUnits);
     scannedUnits.push(...builder.unitDeclarations);
     scannedClasses.push(...builder.classDeclarations);
+    pendingFieldCallCandidates.push(...builder.fieldCallCandidates);
   }
   const inventory: IrUnitInventory = Object.freeze({
     sources: Object.freeze(sources),
@@ -1277,6 +1390,16 @@ export function buildIrUnitInventory(
     allUnits: Object.freeze(allUnits),
     terminalUnits: Object.freeze(terminalUnits),
   });
+  const fieldCallCandidates = Object.freeze(
+    pendingFieldCallCandidates.map((candidate) =>
+      Object.freeze({
+        inventory,
+        ...candidate,
+        terminalMembers: Object.freeze(candidate.terminalMembers.map((member) => Object.freeze({ ...member }))),
+        fields: Object.freeze(candidate.fields.map((field) => Object.freeze({ ...field }))),
+      }),
+    ),
+  );
   scannerMetadataByInventory.set(
     inventory,
     Object.freeze({
@@ -1285,6 +1408,7 @@ export function buildIrUnitInventory(
       ),
       units: Object.freeze(scannedUnits.map((entry) => Object.freeze(entry))),
       classes: Object.freeze(scannedClasses.map((entry) => Object.freeze(entry))),
+      fieldCallCandidates,
     }),
   );
   return inventory;

--- a/src/ir/select-identity.ts
+++ b/src/ir/select-identity.ts
@@ -2,7 +2,19 @@
 
 import { ts, forEachChild } from "../ts-api.js";
 import type { IrCountedStringAppendPlan } from "./analysis/counted-string-append.js";
-import type { IrClassId, IrSourceId, IrTerminalUnitRecord, IrUnitId, IrUnitRecord } from "./identity.js";
+import {
+  isIrNestedClassFieldCallProofSidecarForInventory,
+  type IrNestedClassFieldCallProofSidecar,
+} from "./class-field-call-planning.js";
+import {
+  getIrNestedClassFieldCallInventoryCandidates,
+  type IrClassId,
+  type IrNestedClassFieldCallInventoryCandidate,
+  type IrSourceId,
+  type IrTerminalUnitRecord,
+  type IrUnitId,
+  type IrUnitRecord,
+} from "./identity.js";
 import { collectModuleInitPopulation } from "./module-init.js";
 import {
   IrPlanningIdentityInvariantError,
@@ -98,6 +110,10 @@ export interface IrIdentitySelection {
   readonly fnctorArgumentProjections?: readonly IrFnctorArgumentProjection[];
   /** Exact counted-string plans owned by claimed function units. */
   readonly countedStringAppendPlans?: ReadonlyMap<IrUnitId, readonly IrCountedStringAppendPlan[]>;
+  /** Proof-independent typed inventory population for the still-dormant F3 family. */
+  readonly nestedClassFieldCallCandidates?: readonly IrNestedClassFieldCallInventoryCandidate[];
+  /** Optional dormant proof sidecar; its presence never changes claims. */
+  readonly nestedClassFieldCallProofs?: IrNestedClassFieldCallProofSidecar;
   readonly moduleInit?: IrIdentityModuleInitAssessment;
   /** Policy needed only while projecting back through the legacy name seam. */
   readonly legacyProjection?: {
@@ -151,6 +167,8 @@ export type IrIdentitySelectionOptions = Omit<IrSelectionOptions, "recursiveType
   readonly fnctorArgumentProjections?: readonly IrFnctorArgumentProjection[];
   /** Exact checker/reservation authority used to re-resolve every retained fnctor AST edge. */
   readonly fnctorArgumentProjectionAuthority?: IrFnctorArgumentProjectionAuthority;
+  /** Pre-selection dormant field-call evidence over this exact inventory. */
+  readonly nestedClassFieldCallProofs?: IrNestedClassFieldCallProofSidecar;
 };
 
 export interface IrLegacySelectionProjection {
@@ -802,7 +820,43 @@ export function planIrCompilationByIdentity(
       `IR identity selector source ${sourceId} does not resolve back to the exact SourceFile`,
     );
   }
-  if (!options?.experimentalIR) return { units: new Map(), funcs: new Map() };
+  const nestedClassFieldCallCandidates = getIrNestedClassFieldCallInventoryCandidates(identityContext.inventory).filter(
+    (candidate) => candidate.sourceFile === sourceFile && candidate.source.id === sourceId,
+  );
+  const fieldCallCandidateByClassId = new Map<IrClassId, IrNestedClassFieldCallInventoryCandidate>();
+  for (const candidate of nestedClassFieldCallCandidates) {
+    if (
+      candidate.inventory !== identityContext.inventory ||
+      identityContext.classIdByDeclaration.get(candidate.declaration) !== candidate.classRecord.id ||
+      identityContext.declarationByClassId.get(candidate.classRecord.id) !== candidate.declaration ||
+      fieldCallCandidateByClassId.has(candidate.classRecord.id)
+    ) {
+      return selectorIdentityInvariant(
+        "class-record-mismatch",
+        `IR field-call candidate ${candidate.classRecord.id} is detached from its exact inventory class`,
+      );
+    }
+    fieldCallCandidateByClassId.set(candidate.classRecord.id, candidate);
+  }
+  if (
+    options?.nestedClassFieldCallProofs &&
+    !isIrNestedClassFieldCallProofSidecarForInventory(options.nestedClassFieldCallProofs, identityContext.inventory)
+  ) {
+    return selectorIdentityInvariant(
+      "unit-record-mismatch",
+      "IR field-call proof sidecar belongs to a different inventory",
+    );
+  }
+  if (!options?.experimentalIR) {
+    return {
+      units: new Map(),
+      funcs: new Map(),
+      ...(nestedClassFieldCallCandidates.length ? { nestedClassFieldCallCandidates } : {}),
+      ...(options?.nestedClassFieldCallProofs
+        ? { nestedClassFieldCallProofs: options.nestedClassFieldCallProofs }
+        : {}),
+    };
+  }
   const population = selectionFunctionPopulation(sourceFile, sourceId, identityContext, options);
   const { functions, fnctorArgumentProjections, functionsByName, units } = population;
 
@@ -919,6 +973,7 @@ export function planIrCompilationByIdentity(
       const parentIsLocal = parentName !== null && localClasses.has(parentName);
       const boundedAccessorClass = isBoundedPreparedAccessorClass(declaration);
       const boundedNestedOrdinaryClass = nestedClass && isBoundedPreparedNestedOrdinaryClass(declaration);
+      const nestedFieldCallCandidate = fieldCallCandidateByClassId.get(classId);
       const boundedTopLevelAccessorClass =
         !nestedClass && ts.isClassDeclaration(declaration) && declaration.parent === sourceFile && boundedAccessorClass;
       // (#3522) Arms the accessor-only WRITEBACK contract (exact syntax-key
@@ -948,6 +1003,28 @@ export function planIrCompilationByIdentity(
           }
         }
       };
+      if (nestedFieldCallCandidate) {
+        // F3 retains exact terminal identities but keeps admission closed. An
+        // implicit constructor may have been tentatively selected above, so
+        // normalize the complete marker-authored terminal set explicitly.
+        for (const { record } of nestedFieldCallCandidate.terminalMembers) {
+          const populated = units.get(record.id);
+          if (
+            !populated ||
+            populated.kind !== "class-member" ||
+            populated.classId !== classId ||
+            identityContext.terminalByUnitId.get(record.id) !== record
+          ) {
+            return selectorIdentityInvariant(
+              "terminal-record-mismatch",
+              `IR field-call candidate terminal ${record.id} is detached from class ${classId}`,
+            );
+          }
+          classClaims.delete(record.id);
+          if (trackFallbacks) reasons.set(record.id, "class-member-unsupported");
+        }
+        continue;
+      }
       if (nestedClass && !boundedAccessorClass && !boundedNestedOrdinaryClass) {
         markBoundedClassFallback();
         continue;
@@ -1266,6 +1343,8 @@ export function planIrCompilationByIdentity(
     ...(fnctorAdmissions ? { fnctorAdmissions } : {}),
     ...(fnctorArgumentProjections ? { fnctorArgumentProjections } : {}),
     ...(countedStringAppendPlans ? { countedStringAppendPlans } : {}),
+    ...(nestedClassFieldCallCandidates.length ? { nestedClassFieldCallCandidates } : {}),
+    ...(options.nestedClassFieldCallProofs ? { nestedClassFieldCallProofs: options.nestedClassFieldCallProofs } : {}),
     ...(moduleInit ? { moduleInit } : {}),
     legacyProjection: { includeEmptyModuleInit: true, demoteOnLegacyCaller },
   };

--- a/tests/issue-3520-ir-first-identity.test.ts
+++ b/tests/issue-3520-ir-first-identity.test.ts
@@ -190,16 +190,18 @@ describe("#3520 identity-keyed IR-first local-call edges", () => {
 
     expect(targets(edges, moduleInitId)).toEqual([targetId]);
     expect(targets(edges, constructorId)).toEqual([targetId]);
-    expect(targets(edges, outerId)).toEqual([targetId]);
+    expect(targets(edges, outerId)).toEqual([]);
+    expect(targets(edges, unsupportedConstructorId)).toEqual([targetId]);
     expect(context.unitByUnitId.get(unsupportedConstructorId)).toMatchObject({
-      terminal: false,
-      terminalOwnerId: outerId,
+      terminal: true,
+      terminalOwnerId: unsupportedConstructorId,
+      containingTerminalOwnerId: outerId,
     });
     expect(context.unitByUnitId.get(unitId(context, unsupportedField))).toMatchObject({
       terminal: false,
-      terminalOwnerId: outerId,
+      terminalOwnerId: unsupportedConstructorId,
     });
-    expect(edges.callees.has(unsupportedConstructorId)).toBe(false);
+    expect(edges.callees.has(unsupportedConstructorId)).toBe(true);
     expect([...edges.calleesFromUnownedCallers]).toEqual([]);
   });
 

--- a/tests/issue-3520-ir-unit-identity.test.ts
+++ b/tests/issue-3520-ir-unit-identity.test.ts
@@ -798,18 +798,19 @@ describe("#3520 structural IR identity", () => {
     expect(unsupportedConstructorRecord).toMatchObject({
       sourceId,
       lexicalOwnerId: unsupportedClassId,
-      terminal: false,
-      terminalOwnerId: outerId,
+      terminal: true,
+      terminalOwnerId: unsupportedConstructorId,
+      containingTerminalOwnerId: outerId,
     });
-    expect(context.terminalByUnitId.has(unsupportedConstructorId)).toBe(false);
+    expect(context.terminalByUnitId.get(unsupportedConstructorId)).toBe(unsupportedConstructorRecord);
     expect(unsupportedFieldRecord).toMatchObject({
       sourceId,
       lexicalOwnerId: unsupportedClassId,
       terminal: false,
-      terminalOwnerId: outerId,
+      terminalOwnerId: unsupportedConstructorId,
     });
-    expect(requireIrPlanningOwnerUnitId(context, unsupportedConstructor.body!)).toBe(outerId);
-    expect(requireIrPlanningOwnerUnitId(context, unsupportedField.initializer!)).toBe(outerId);
+    expect(requireIrPlanningOwnerUnitId(context, unsupportedConstructor.body!)).toBe(unsupportedConstructorId);
+    expect(requireIrPlanningOwnerUnitId(context, unsupportedField.initializer!)).toBe(unsupportedConstructorId);
   });
 
   it("keeps planning declaration identities stable when source input order reverses", () => {

--- a/tests/issue-3520-planning-owner.test.ts
+++ b/tests/issue-3520-planning-owner.test.ts
@@ -164,13 +164,16 @@ describe("#3520 exact planning owner identity", () => {
     const unsupportedConstructorId = unitId(context, unsupportedConstructor);
     const unsupportedField = unsupported.members.find(ts.isPropertyDeclaration)!;
 
-    expect(context.terminalByUnitId.has(unsupportedConstructorId)).toBe(false);
+    expect(context.terminalByUnitId.get(unsupportedConstructorId)).toBe(
+      context.unitByUnitId.get(unsupportedConstructorId),
+    );
     expect(context.unitByUnitId.get(unsupportedConstructorId)).toMatchObject({
-      terminal: false,
-      terminalOwnerId: outerId,
+      terminal: true,
+      terminalOwnerId: unsupportedConstructorId,
+      containingTerminalOwnerId: outerId,
     });
-    expect(requireIrPlanningOwnerUnitId(context, unsupportedConstructor.body!)).toBe(outerId);
-    expect(requireIrPlanningOwnerUnitId(context, unsupportedField.initializer!)).toBe(outerId);
+    expect(requireIrPlanningOwnerUnitId(context, unsupportedConstructor.body!)).toBe(unsupportedConstructorId);
+    expect(requireIrPlanningOwnerUnitId(context, unsupportedField.initializer!)).toBe(unsupportedConstructorId);
   });
 
   it("returns the outer terminal for nested, arrow, object-method, and Promise-like support units", () => {

--- a/tests/issue-3522-ir-nested-class-ownership.test.ts
+++ b/tests/issue-3522-ir-nested-class-ownership.test.ts
@@ -206,7 +206,7 @@ describe("#3522 nested ordinary class ownership", () => {
       }
       expect(Array.from(preparedObserved.binary)).toEqual(Array.from(preparedControl.binary));
       expect(preparedObserved.irPostClaimErrors ?? []).toEqual([]);
-      expect(preparedObserved.irOutcomes ?? []).toHaveLength(2);
+      expect(preparedObserved.irOutcomes ?? []).toHaveLength(4);
       expect(outcome(preparedObserved, "seed")).toMatchObject({
         kind: "emitted",
         legacyBodyEmitted: false,
@@ -217,6 +217,15 @@ describe("#3522 nested ordinary class ownership", () => {
         legacyBodyEmitted: true,
         irBodyEmitted: false,
       });
+      for (const name of ["Box_new", "Box_read"]) {
+        expect(outcome(preparedObserved, name)).toMatchObject({
+          kind: "unsupported",
+          code: "class-member-unsupported",
+          stage: "select",
+          legacyBodyEmitted: true,
+          irBodyEmitted: false,
+        });
+      }
     },
   );
 

--- a/tests/issue-3522-nested-class-field-call-planning.test.ts
+++ b/tests/issue-3522-nested-class-field-call-planning.test.ts
@@ -1,0 +1,384 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import {
+  isIrNestedClassFieldCallProofCurrent,
+  planIrNestedClassFieldCalls,
+  type IrNestedClassFieldCallProof,
+} from "../src/ir/class-field-call-planning.js";
+import { buildIrUnitInventory, getIrNestedClassFieldCallInventoryCandidates } from "../src/ir/identity.js";
+import { makeIrIdentityImportedFunctionResolver } from "../src/ir/imported-functions.js";
+import { irUnitFuncRef } from "../src/ir/callable-bindings.js";
+import { buildIrPlanningIdentityContext } from "../src/ir/planning-identity.js";
+import { planIrCompilationByIdentity } from "../src/ir/select-identity.js";
+import { buildIrOverlayIdentityMaps, planIrOverlayByIdentity } from "../src/codegen/ir-overlay-identity.js";
+import { ts } from "../src/ts-api.js";
+
+const POSITIVE_SOURCE = `
+  function seed(value: number): number { return value + 2; }
+  export function run(): number {
+    class Box {
+      value: number = seed(40);
+      read(): number { return this.value; }
+    }
+    return new Box().read();
+  }
+`;
+
+function fixture(files: Readonly<Record<string, string>>) {
+  const textByName = new Map(Object.entries(files));
+  const rootNames = Object.keys(files);
+  const options: ts.CompilerOptions = {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    noLib: true,
+    strict: false,
+    target: ts.ScriptTarget.ES2022,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (fileName) => textByName.has(fileName),
+    readFile: (fileName) => textByName.get(fileName),
+    getSourceFile: (fileName, languageVersion) => {
+      const text = textByName.get(fileName);
+      return text === undefined
+        ? undefined
+        : ts.createSourceFile(fileName, text, languageVersion, true, ts.ScriptKind.TS);
+    },
+    getDefaultLibFileName: () => "/repo/lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/repo",
+    getDirectories: () => [],
+    directoryExists: (directoryName) => directoryName === "/repo",
+    realpath: (path) => path,
+    getCanonicalFileName: (fileName) => fileName,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+  };
+  const program = ts.createProgram(rootNames, options, host);
+  const checker = program.getTypeChecker();
+  const sourceFiles = rootNames.map((fileName) => program.getSourceFile(fileName)!);
+  const byName = new Map(sourceFiles.map((sourceFile) => [sourceFile.fileName, sourceFile] as const));
+  const entry = byName.get("/repo/entry.ts") ?? sourceFiles[0]!;
+  const context = buildIrPlanningIdentityContext(buildIrUnitInventory(sourceFiles, { checker, entrySource: entry }));
+  const resolver = makeIrIdentityImportedFunctionResolver(checker, sourceFiles, context);
+  return { checker, sourceFiles, byName, entry, context, resolver };
+}
+
+function positiveFixture() {
+  return fixture({ "/repo/entry.ts": POSITIVE_SOURCE });
+}
+
+function decisionSnapshot(selection: ReturnType<typeof planIrCompilationByIdentity>) {
+  return {
+    funcs: [...selection.funcs.keys()].sort(),
+    classMembers: [...(selection.classMembers?.keys() ?? [])].sort(),
+    fallbacks: [...(selection.fallbacks ?? [])]
+      .map(([unitId, fallback]) => [unitId, fallback.reason] as const)
+      .sort(([left], [right]) => left.localeCompare(right)),
+    moduleInit: selection.moduleInit,
+  };
+}
+
+describe("#3522 dormant nested-class field-call planning", () => {
+  it("mints immutable constructor-owned inventory markers without admitting the class", () => {
+    const graph = positiveFixture();
+    const candidates = getIrNestedClassFieldCallInventoryCandidates(graph.context.inventory);
+    expect(candidates).toHaveLength(1);
+    const [candidate] = candidates;
+    expect(candidate).toBeDefined();
+    expect(candidate!.inventory).toBe(graph.context.inventory);
+    expect(candidate!.sourceFile).toBe(graph.entry);
+    expect(candidate!.constructorRecord.kind).toBe("class-implicit-constructor");
+    expect(candidate!.constructorRecord.terminal).toBe(true);
+    expect(candidate!.constructorRecord.containingTerminalOwnerId).toBe(candidate!.containingTerminalRecord.id);
+    expect(candidate!.fields).toHaveLength(1);
+    expect(candidate!.fields[0]!.record.kind).toBe("class-instance-field-initializer");
+    expect(candidate!.fields[0]!.record.terminalOwnerId).toBe(candidate!.constructorRecord.id);
+    expect(candidate!.terminalMembers.map(({ record }) => record.kind).sort()).toEqual([
+      "class-implicit-constructor",
+      "class-instance-method",
+    ]);
+    expect(Object.isFrozen(candidates)).toBe(true);
+    expect(Object.isFrozen(candidate)).toBe(true);
+    expect(Object.isFrozen(candidate!.fields)).toBe(true);
+    expect(Object.isFrozen(candidate!.terminalMembers)).toBe(true);
+
+    const disabledProofs = planIrNestedClassFieldCalls({
+      identityContext: graph.context,
+      resolver: graph.resolver,
+      enabled: false,
+    });
+    const selection = planIrCompilationByIdentity(graph.entry, graph.context, {
+      experimentalIR: true,
+      trackFallbacks: true,
+      nestedClassFieldCallProofs: disabledProofs,
+    });
+    expect(selection.nestedClassFieldCallCandidates).toEqual(candidates);
+    expect(selection.nestedClassFieldCallProofs).toBe(disabledProofs);
+    expect(selection.classMembers?.size ?? 0).toBe(0);
+    for (const { record } of candidate!.terminalMembers) {
+      expect(selection.fallbacks?.get(record.id)?.reason).toBe("class-member-unsupported");
+    }
+    expect(selection.units.has(candidate!.fields[0]!.record.id)).toBe(false);
+  });
+
+  it("normalizes a field-call candidate's getter and setter terminals without claiming them", () => {
+    const graph = fixture({
+      "/repo/entry.ts": `
+        function seed(value: number): number { return value + 2; }
+        export function run(): number {
+          class Box {
+            value: number = seed(40);
+            get current(): number { return this.value; }
+            set current(value: number) { this.value = value; }
+          }
+          return new Box().current;
+        }
+      `,
+    });
+    const candidates = getIrNestedClassFieldCallInventoryCandidates(graph.context.inventory);
+    expect(candidates).toHaveLength(1);
+    const candidate = candidates[0]!;
+    expect(candidate.terminalMembers.map(({ record }) => record.kind).sort()).toEqual([
+      "class-implicit-constructor",
+      "class-instance-getter",
+      "class-instance-setter",
+    ]);
+    const proofs = planIrNestedClassFieldCalls({ identityContext: graph.context, resolver: graph.resolver });
+    expect(proofs.entries).toHaveLength(1);
+    const selection = planIrCompilationByIdentity(graph.entry, graph.context, {
+      experimentalIR: true,
+      trackFallbacks: true,
+      nestedClassFieldCallProofs: proofs,
+    });
+    expect(selection.classMembers?.size ?? 0).toBe(0);
+    for (const { record } of candidate.terminalMembers) {
+      expect(selection.fallbacks?.get(record.id)?.reason).toBe("class-member-unsupported");
+    }
+  });
+
+  it("retains the exact const class-expression candidate and proof without admitting it", () => {
+    const graph = fixture({
+      "/repo/entry.ts": `
+        function seed(value: number): number { return value + 2; }
+        export function run(): number {
+          const Box = class {
+            value: number = seed(40);
+            read(): number { return this.value; }
+          };
+          return new Box().read();
+        }
+      `,
+    });
+    const candidates = getIrNestedClassFieldCallInventoryCandidates(graph.context.inventory);
+    expect(candidates).toHaveLength(1);
+    const candidate = candidates[0]!;
+    expect(ts.isClassExpression(candidate.declaration)).toBe(true);
+    expect(candidate.constructorRecord.kind).toBe("class-implicit-constructor");
+    expect(candidate.fields[0]!.record.terminalOwnerId).toBe(candidate.constructorRecord.id);
+    const proofs = planIrNestedClassFieldCalls({ identityContext: graph.context, resolver: graph.resolver });
+    expect(proofs.entries).toHaveLength(1);
+    expect(proofs.entries[0]!.candidate).toBe(candidate);
+    const selection = planIrCompilationByIdentity(graph.entry, graph.context, {
+      experimentalIR: true,
+      trackFallbacks: true,
+      nestedClassFieldCallProofs: proofs,
+    });
+    expect(selection.classMembers?.size ?? 0).toBe(0);
+    for (const { record } of candidate.terminalMembers) {
+      expect(selection.fallbacks?.get(record.id)?.reason).toBe("class-member-unsupported");
+    }
+  });
+
+  it("retains one exact source-qualified proof and rejects stale joins", () => {
+    const graph = positiveFixture();
+    const input = { identityContext: graph.context, resolver: graph.resolver } as const;
+    const sidecar = planIrNestedClassFieldCalls(input);
+    expect(sidecar.entries).toHaveLength(1);
+    const proof = sidecar.entries[0]!;
+    expect(sidecar.get(proof.call)).toBe(proof);
+    expect(proof.call).toBe(proof.fieldDeclaration.initializer);
+    expect(proof.callee.text).toBe("seed");
+    expect(proof.calleeDeclaration.name?.text).toBe("seed");
+    expect(proof.fieldSupportUnitId).toBe(proof.fieldCandidate.record.id);
+    expect(proof.constructorUnitId).toBe(proof.candidate.constructorRecord.id);
+    expect(proof.target).toEqual(irUnitFuncRef({ unitId: proof.calleeUnitId, name: "seed" }));
+    expect(proof.signature.params).toEqual([{ kind: "val", val: { kind: "f64" } }]);
+    expect(proof.signature.returnType).toEqual({ kind: "val", val: { kind: "f64" } });
+    expect(proof.argumentProjection.arity).toBe(1);
+    expect(proof.argumentProjection.arguments[0]!.expression).toBe(proof.call.arguments[0]);
+    expect(proof.argumentProjection.arguments[0]!.kind).toBe("number");
+    expect(Object.isFrozen(sidecar)).toBe(true);
+    expect(Object.isFrozen(sidecar.entries)).toBe(true);
+    expect(Object.isFrozen(proof)).toBe(true);
+    expect(Object.isFrozen(proof.signature.params)).toBe(true);
+    expect(Object.isFrozen(proof.signature.params[0])).toBe(true);
+    expect(Object.isFrozen(proof.signature.returnType)).toBe(true);
+    expect(Object.isFrozen(proof.argumentProjection.arguments)).toBe(true);
+    expect(isIrNestedClassFieldCallProofCurrent(proof, input)).toBe(true);
+
+    const wrongOwner = {
+      ...proof,
+      constructorUnitId: proof.containingTerminalUnitId,
+    } as IrNestedClassFieldCallProof;
+    const wrongTarget = {
+      ...proof,
+      target: irUnitFuncRef({ unitId: proof.containingTerminalUnitId, name: "seed" }),
+    } as IrNestedClassFieldCallProof;
+    const staleSignature = {
+      ...proof,
+      signature: { params: proof.signature.params, returnType: null },
+    } as IrNestedClassFieldCallProof;
+    const staleArguments = {
+      ...proof,
+      argumentProjection: { arity: 0, arguments: [] },
+    } as IrNestedClassFieldCallProof;
+    const copiedFieldCandidate = {
+      ...proof,
+      fieldCandidate: { ...proof.fieldCandidate },
+    } as IrNestedClassFieldCallProof;
+    expect(isIrNestedClassFieldCallProofCurrent(wrongOwner, input)).toBe(false);
+    expect(isIrNestedClassFieldCallProofCurrent(wrongTarget, input)).toBe(false);
+    expect(isIrNestedClassFieldCallProofCurrent(staleSignature, input)).toBe(false);
+    expect(isIrNestedClassFieldCallProofCurrent(staleArguments, input)).toBe(false);
+    expect(isIrNestedClassFieldCallProofCurrent(copiedFieldCandidate, input)).toBe(false);
+
+    const copied = ts.createSourceFile(
+      graph.entry.fileName,
+      graph.entry.text,
+      ts.ScriptTarget.ES2022,
+      true,
+      ts.ScriptKind.TS,
+    );
+    let copiedCall: ts.CallExpression | undefined;
+    const visit = (node: ts.Node): void => {
+      if (
+        !copiedCall &&
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "seed"
+      ) {
+        copiedCall = node;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(copied);
+    expect(copiedCall).toBeDefined();
+    expect(sidecar.get(copiedCall!)).toBeUndefined();
+
+    const rebuilt = positiveFixture();
+    expect(
+      isIrNestedClassFieldCallProofCurrent(proof, {
+        identityContext: rebuilt.context,
+        resolver: rebuilt.resolver,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps proof-enabled and proof-disabled identity/overlay decisions identical", () => {
+    const graph = positiveFixture();
+    const enabled = planIrNestedClassFieldCalls({ identityContext: graph.context, resolver: graph.resolver });
+    const disabled = planIrNestedClassFieldCalls({
+      identityContext: graph.context,
+      resolver: graph.resolver,
+      enabled: false,
+    });
+    const maps = buildIrOverlayIdentityMaps(graph.entry, graph.checker, graph.context);
+    const enabledPlan = planIrOverlayByIdentity(
+      graph.entry,
+      graph.context,
+      { experimentalIR: true, trackFallbacks: true, nestedClassFieldCallProofs: enabled },
+      maps,
+    );
+    const disabledPlan = planIrOverlayByIdentity(
+      graph.entry,
+      graph.context,
+      { experimentalIR: true, trackFallbacks: true, nestedClassFieldCallProofs: disabled },
+      maps,
+    );
+    expect(decisionSnapshot(enabledPlan.identitySelection)).toEqual(decisionSnapshot(disabledPlan.identitySelection));
+    expect(enabledPlan.nestedClassFieldCallCandidates).toEqual(disabledPlan.nestedClassFieldCallCandidates);
+    expect(enabledPlan.nestedClassFieldCallProofs).toBe(enabled);
+    expect(disabledPlan.nestedClassFieldCallProofs).toBe(disabled);
+    expect(enabled.entries).toHaveLength(1);
+    expect(disabled.entries).toHaveLength(0);
+  });
+
+  it.each([
+    ["optional", "value = seed?.(40);"],
+    ["spread", "value = seed(...[40]);"],
+    ["generic", "value = seed<number>(40);"],
+    ["member", "value = Math.floor(40);"],
+    ["mutable class expression", "", "let Box = class { value = seed(40); read() { return this.value; } };"],
+  ])("rejects %s syntax before proof collection", (_label, field, customClass) => {
+    const source = `
+      function seed(value: number): number { return value; }
+      export function run(): number {
+        ${customClass ?? `class Box { ${field} read() { return this.value; } }`}
+        return new Box().read();
+      }
+    `;
+    const graph = fixture({ "/repo/entry.ts": source });
+    expect(getIrNestedClassFieldCallInventoryCandidates(graph.context.inventory)).toHaveLength(0);
+    expect(
+      planIrNestedClassFieldCalls({ identityContext: graph.context, resolver: graph.resolver }).entries,
+    ).toHaveLength(0);
+  });
+
+  it.each([
+    [
+      "unknown target",
+      { "/repo/entry.ts": POSITIVE_SOURCE.replace("function seed(value: number): number { return value + 2; }", "") },
+    ],
+    [
+      "enclosing-frame argument",
+      {
+        "/repo/entry.ts": POSITIVE_SOURCE.replace(
+          "export function run(): number",
+          "export function run(input: number): number",
+        ).replace("seed(40)", "seed(input)"),
+      },
+    ],
+    [
+      "reassigned target",
+      {
+        "/repo/entry.ts": POSITIVE_SOURCE.replace(
+          "export function run",
+          "seed = (value: number) => value; export function run",
+        ),
+      },
+    ],
+    [
+      "overloaded target",
+      {
+        "/repo/entry.ts": POSITIVE_SOURCE.replace(
+          "function seed(value: number): number",
+          "function seed(value: number): number; function seed(value: number): number",
+        ),
+      },
+    ],
+    [
+      "same-spelled foreign target",
+      {
+        "/repo/entry.ts": POSITIVE_SOURCE,
+        "/repo/foreign.ts": "export function seed(value: number): number { return value - 1; }",
+      },
+    ],
+    [
+      "cross-source import",
+      {
+        "/repo/provider.ts": "export function seed(value: number): number { return value + 2; }",
+        "/repo/entry.ts": POSITIVE_SOURCE.replace(
+          "function seed(value: number): number { return value + 2; }",
+          'import { seed } from "./provider";',
+        ),
+      },
+    ],
+  ])("retains the marker but rejects a %s proof", (_label, files) => {
+    const graph = fixture(files);
+    expect(getIrNestedClassFieldCallInventoryCandidates(graph.context.inventory)).toHaveLength(1);
+    expect(
+      planIrNestedClassFieldCalls({ identityContext: graph.context, resolver: graph.resolver }).entries,
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- inventory the exact direct-nested class family whose field initializer is a bounded source-local function call
- retain a deep-frozen, source-qualified field-call proof sidecar with exact AST, identity, signature, argument, and forward/reverse inventory joins
- normalize every newly typed constructor/member terminal to `class-member-unsupported@select` while keeping claims and preparation closed
- document the non-authoritative F3a checkpoint and its remaining production wiring in the #3522 plan

## Scope

This is the disjoint, dormant F3a checkpoint for #3522. It deliberately does **not** wire the planner through `src/codegen/index.ts`, activate F4 admission, prepare a field-call body, or change lowering, runtime behavior, or emitted bytes. The narrow production wiring and proof-enabled/proof-disabled compiler A/B remain follow-up work after the overlapping `src/codegen/index.ts` heads settle.

## Validation

- TS 7 no-emit: pass
- TS 5 no-emit: pass
- focused field-call planner matrix: 16/16 pass
- directly affected identity/ownership matrix: 55/55 pass
- full changed-root pre-commit matrix: 71/71 pass
- LOC ratchet: pass at +669 source LOC
- function ratchet: pass with the existing #3522 grant for `planIrCompilationByIdentity` (481 -> 542)
- full pre-push hook: typecheck + lint, Prettier, oracle, coercion, #3765 18/18, and issue integrity all pass
- complete code-identical #3522 matrix: 300 pass / 17 current-main baseline failures; a clean detached baseline reproduces the same failures in the same four files

Refs #3522
