### PR TITLE
fix(ir): seal telemetry-only program owner

### DIFF
--- a/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
+++ b/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
@@ -4,7 +4,7 @@ title: "IR-only R5: whole-program single- and multi-source Prepared ownership"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-27
+updated: 2026-08-28
 assignee: ttraenkler/codex
 branch: codex/3525-unit-keyed-body-skips
 priority: critical
@@ -1066,6 +1066,99 @@ executable source plans; Prepared reservations; direct roots; IR and legacy
 module-init outcomes; and callable-component reservations. Adjacent #3523,
 #2138, #3505, #3525 census, multi-file, equivalence, typecheck,
 `check:ir-fallbacks`, issue integrity, and LOC-budget gates remain required.
+
+## M0.1 repair lock — telemetry-only owner lifecycle (2026-08-28)
+
+Current `main` creates the shared identity context, `ProgramAbiSession`, and
+`MultiPreparedProgramOwner` when either `experimentalIR` or
+`trackIrOutcomes` is enabled. `makeIrPlanningAuthority`, however, is absent in
+the telemetry-only lane (`experimentalIR: false, trackIrOutcomes: true`), so
+`planMultiPreparedProgramRoutes` returns without sealing the owner. The first
+body visit then fails with
+`multi-prepared-program:completion-order: owner is collecting, expected
+body-boundary-sealed`. This is a production lifecycle defect in the M0 owner,
+not a reason to weaken the #4590 benchmark-loop test or to make telemetry an IR
+selection authority.
+
+The repair must remain outside `src/codegen/index.ts`, which is concurrently
+owned by the in-flight Deno integration PR. Exact production implementation
+ownership is limited to:
+
+- `src/codegen/multi-prepared-program.ts`;
+- `tests/issue-3525-multi-prepared-program-census.test.ts`; and
+- this issue record.
+
+The mandatory changed-root lane also exposed obsolete current-`main` physical
+pins in the otherwise-green #4590 and #4591 suites. This checkpoint may carry
+only their separately documented pin maintenance in the two owning issue files
+and tests; those validation-only edits must not weaken or dynamically derive
+any semantic, body, artifact, Program ABI, or runtime expectation.
+
+`createMultiPreparedProgramOwner` must immediately seal the ordinary no-route
+body boundary only for the exact telemetry-only mode:
+`trackIrOutcomes === true && experimentalIR !== true`. The resulting frozen
+body plan must contain the complete source/terminal denominator, semantic body
+visit sequence, zero reservations, every terminal in
+`unreservedTerminalUnitIds`, and an empty overlay visit sequence. It must then
+accept each direct body visit exactly once, seal `routes-complete`, bind the
+exact `ProgramAbiSession.publish()` result, and publish the ordinary M0 audit.
+It must not run a route planner, create a Prepared component, skip a direct
+body, visit an overlay, or synthesize an IR outcome.
+
+All other modes retain their existing lifecycle:
+
+- `experimentalIR: true` remains collecting until the existing route
+  orchestration plans candidates and seals the boundary, including fast,
+  disabled, Unsupported, and zero-reservation cases;
+- neither option enabled still creates no identity/session/owner; and
+- repeated or late planning/registration against the telemetry-only sealed
+  owner fails closed through the existing state machine rather than reopening
+  collection.
+
+The focused production regression must compile a real multi-source fixture
+with `experimentalIR: false, trackIrOutcomes: true` and prove: no fatal
+completion-order error; exact body-source census; zero overlay visits and
+reservations; all units unreserved; direct-only outcomes/legacy body evidence;
+and artifact, imports, public surface, and runtime parity with the same direct
+compile without telemetry. A direct-body poison is the non-vacuity control: it
+must reach the named direct body and report that poison, never stop first in
+owner lifecycle validation. A companion `experimentalIR: true` control must
+still require normal route planning and must not be pre-sealed by the factory.
+Direct owner mutations must reject a body visit before sealing, a second or
+out-of-order visit, a late route/component/module-init registration, and
+publication before `routes-complete` with the existing stable invariant codes.
+
+No baseline, binary-size, LOC, function-size, or hook exception is authorized.
+Before the signed commit and push, sample the finite, non-negative one-minute
+load and require it to be strictly below `logical cores - 2`; run the focused
+#3525 census and #4590 benchmark-loop suites, TypeScript 7 and 5 checks, IR
+fallback/layering/dialect/optimization gates, then the LOC and function
+ratchets immediately before committing. Let the complete precommit and
+prepush hooks run without bypass. Open the PR ready only after the branch is
+mergeable; otherwise keep it draft until the exact blocker is removed.
+
+### M0.1 implementation checkpoint
+
+`createMultiPreparedProgramOwner` now constructs the ordinary owner and seals
+its no-route body boundary immediately only for
+`trackIrOutcomes: true, experimentalIR: false`. The production regression
+proves the frozen two-source/two-terminal denominator, zero reservations and
+overlays, all terminals unreserved, exact direct `inc`/`run` body-route rows,
+empty requested IR outcomes, byte/WAT/import/export/runtime parity with the
+untracked direct compile, and the exact direct-body poison failure. Separate
+factory and state-machine mutations prove that the ordinary IR route remains
+collecting and that pre-seal visits, repeated visits, late route/callable/
+module-init registration, and early publication still fail closed.
+
+On refreshed `main` at `48abcb949c9d1b539cb58472256e4545cacd9dc8`, the
+focused census is 17/17 passing with exact empty error lists on both clean
+production controls. The complete #4590 benchmark-loop suite is restored to
+21/21 after preserving its exact semantics and maintaining only the measured
+raw binary delta (28 rather than 35 bytes) and direct trampoline/cache slots
+(290/136 rather than 252/129). The adjacent #4591 Fibonacci-pair suite is
+restored to 27/27 after maintaining only its direct cache slot from 135 to 136;
+its direct trampoline remains 291. The exact pin rationale and unchanged
+authority assertions live in the respective #4590 and #4591 issue records.
 
 ## Ownership and resolution invariants
 

--- a/plan/issues/4590-bench-loop-function-value-prepared-cutover.md
+++ b/plan/issues/4590-bench-loop-function-value-prepared-cutover.md
@@ -175,6 +175,66 @@ immediately before the signed commit. After #3525 merges, refresh and rebase the
 separate declaration-snapshot checkpoint onto these maintained pins. No
 baseline, LOC, function, precommit, or prepush exception is authorized.
 
+## 2026-08-28 CI optimizer-refusal oracle
+
+PR #5165's Linux `quality` job exposed a second environment-sensitive test
+assumption after every production and telemetry assertion passed. The
+changed-root lane compiled both `optimize: true` controls successfully but
+returned their original binaries: Prepared was 131,207 bytes and direct was
+131,235 bytes. The existing optimized-only equality then compared those two
+raw artifacts and failed 20/21. The same head passes 21/21 locally with and
+without `JS2WASM_EVAL_ENGINE=interpreter`, so the engine label is not the
+oracle. The compiler's explicit `wasm-opt` fallback warning and byte retention
+are.
+
+Repair only the optimized-parity test and this plan. Compile one raw control
+for each lane alongside the two optimize-request controls, then classify the
+result from exact compiler evidence. Both raw lanes already carry ten canonical
+#2961 host-import warnings. Require each optimize-request diagnostic population
+to begin with the byte-for-byte exact diagnostics of its own raw control, and
+classify only the remaining optimizer-added suffix; a changed, missing, or
+reordered pre-existing diagnostic is a failure, not optimizer evidence. Pin the
+raw authority as exactly ten ordered warnings with their exact severity/message
+sequence and every stable source-position field (`line`, `column`, `code`, and
+the expected `ENTRY`/`HELPERS` file identity where present). Merely proving two
+equally empty or equally drifted raw populations is not sufficient.
+
+- When neither optimize-request result carries a `wasm-opt` fallback warning,
+  retain the existing optimized authority unchanged: Prepared/direct binary
+  sizes, `bench_loop`, and trampoline bodies are exact, both bodies retain the
+  125,000 literal, and all surfaces/runtime remain exact.
+- When optimization is explicitly refused, require both lanes to carry the
+  same single recognized `wasm-opt` fallback warning as their diagnostic
+  suffix. Reject an asymmetric, duplicate, unrelated, or unrecognized
+  optimizer delta. Compare the complete suffix diagnostic rows across lanes,
+  including source anchoring and optional code/file fields; use the message
+  only to recognize the authorized fallback class. Because this test requests
+  the default O3 pass, a process-failure warning is recognized only as
+  `wasm-opt -O3 failed: ...`, never another optimization level. Prove each
+  optimize-request binary is byte-for-byte identical to its own separately
+  compiled raw control; pin the raw sizes at
+  131,207 and 131,235 and the exact Prepared reduction at 28 bytes. In this
+  arm, require the raw `bench_loop` bodies to remain text-exact and compare
+  trampolines only through the existing `normalizedRawTrampoline`
+  allocator-label normalization. Keep the 125,000 literal, public surface,
+  DTS/helper, string pool, validity, and runtime checks on both lanes.
+- Do not branch on `CI`, operating system, `JS2WASM_EVAL_ENGINE`, size
+  coincidence, or a loose inequality. Do not derive an expected byte count
+  from the result under test. A warning without exact raw-byte retention, raw
+  bytes without an authorized warning, or mixed optimized/refused lanes must
+  fail closed.
+
+Keep the classifier mutations in the test itself. They must reject an equally
+empty/drifted raw warning population, missing/asymmetric/duplicated suffixes,
+wrong severity, wrong source anchoring, unrelated/unrecognized messages, mixed
+recognized fallback messages, and fabricated O0/O9 process-failure warnings.
+
+Run #4590 in both the ordinary local lane and the explicit interpreter-labelled
+lane after the edit. Then repeat the #3525/#4590/#4591 changed-root set, the
+adjacent controls, LOC and function ratchets immediately before the signed
+commit, and the complete precommit and prepush hooks. Keep PR #5165 ready for
+review (not draft) and re-enqueue it only through the protected merge queue.
+
 ## Completion evidence
 
 - `tests/issue-4590-bench-loop-prepared-cutover.test.ts`: 21/21 passed.

--- a/plan/issues/4590-bench-loop-function-value-prepared-cutover.md
+++ b/plan/issues/4590-bench-loop-function-value-prepared-cutover.md
@@ -3,7 +3,7 @@ id: 4590
 title: "Cut the exact bench_loop function-value leaf over to Prepared IR"
 status: done
 created: 2026-08-21
-updated: 2026-08-21
+updated: 2026-08-28
 completed: 2026-08-21
 priority: critical
 feasibility: medium
@@ -130,6 +130,50 @@ preallocated trampoline/cache resolve to function/global slots 78/10; the true
 old control resolves the same binding roles to 252/129. Each final slot points
 to the single expected allocator object, the trampoline signature agrees with
 its published callable intent, and the cache is one mutable `externref` global.
+
+## 2026-08-28 current-main pin maintenance and telemetry-only control
+
+Unrelated allocator growth since the original landing changed the physical
+whole-module positions while leaving every semantic #4590 invariant intact.
+On current `main` at `48abcb949c9d1b539cb58472256e4545cacd9dc8`, under the
+strict 10-core load gate (`finite, non-negative load < 8`), the exact raw
+artifacts are now:
+
+- Prepared: 131,207 bytes, SHA-256
+  `8cd1ba375acef40b417be2aa534065c865eda06072a14c6911ba453ec22227e8`;
+- direct kill-switch control: 131,235 bytes, SHA-256
+  `935b394bced571155c15a889a488ed449ce395dea3e10d6f50f3bfc1e5eddb88`;
+- exact Prepared reduction: 28 bytes, replacing the obsolete 35-byte pin;
+- Prepared source/trampoline/cache slots: `76 / 78 / 10` (unchanged); and
+- direct source/trampoline/cache slots: `76 / 290 / 136`, replacing the
+  obsolete `76 / 252 / 129` physical positions.
+
+Both lanes contain exactly 321 defined functions and 165 globals. The existing
+raw/optimized target and trampoline body equality, Program ABI binding IDs and
+intents, exact singleton allocator objects, signatures, import/export surface,
+string pool, DTS/helper, binary validity, and runtime result remain the
+authority. Update only the obsolete physical pins after remeasuring them on the
+rebased implementation head. Do not replace them with inequalities, derive the
+expected slots from the actual objects under test, or relabel allocator drift
+as a size regression.
+
+The M0 telemetry lifecycle defect tracked by #3525 is independently
+non-vacuous in `tests/issue-3525-multi-prepared-program-census.test.ts`: with
+`experimentalIR: false`, `trackIrOutcomes: true`, and a poisoned direct body,
+compilation must reach and report the exact direct-body poison rather than stop
+earlier with `multi-prepared-program:completion-order`. The production repair
+belongs only to #3525's telemetry-only owner lifecycle; #4590 must not bypass
+the owner, disable tracking, or accept the lifecycle error as expected output.
+
+Carry this pin-only maintenance in the same #3525 repair checkpoint because
+the mandatory changed-root hook selects the full #4590 suite and current
+`main` already fails its two obsolete physical assertions. This is not an
+allowance: require #4590 to return to 21/21 before the commit, then run its
+adjacent #4589, #4591, #3525, #3518, and #2138 controls, TypeScript 7 and 5, IR
+fallback/layering/dialect/optimization gates, and the LOC and function ratchets
+immediately before the signed commit. After #3525 merges, refresh and rebase the
+separate declaration-snapshot checkpoint onto these maintained pins. No
+baseline, LOC, function, precommit, or prepush exception is authorized.
 
 ## Completion evidence
 

--- a/plan/issues/4590-bench-loop-function-value-prepared-cutover.md
+++ b/plan/issues/4590-bench-loop-function-value-prepared-cutover.md
@@ -218,6 +218,15 @@ equally empty or equally drifted raw populations is not sufficient.
   trampolines only through the existing `normalizedRawTrampoline`
   allocator-label normalization. Keep the 125,000 literal, public surface,
   DTS/helper, string pool, validity, and runtime checks on both lanes.
+- Select the WAT authority only after the certified optimizer disposition is
+  known. The optimized arm continues to parse the optimized binaries with
+  Binaryen. The fallback arm must use `rawPrepared.wat` and `rawDirect.wat`
+  from the separately compiled raw controls, after byte-for-byte equality has
+  proved that each optimize-request result retained that exact raw binary.
+  Do not feed the raw GC bytes back through `binaryen.readBinary`: Linux
+  Binaryen rejects their distinct recursive groups without an explicit GC
+  parser feature before the body oracle can run. Do not enable a global parser
+  feature or waive the body checks merely to make this harness path parse.
 - Do not branch on `CI`, operating system, `JS2WASM_EVAL_ENGINE`, size
   coincidence, or a loose inequality. Do not derive an expected byte count
   from the result under test. A warning without exact raw-byte retention, raw

--- a/plan/issues/4591-fib-pair-prepared-cutover.md
+++ b/plan/issues/4591-fib-pair-prepared-cutover.md
@@ -3,7 +3,7 @@ id: 4591
 title: "Cut the exact Fibonacci call component over to Prepared IR"
 status: done
 created: 2026-08-21
-updated: 2026-08-21
+updated: 2026-08-28
 completed: 2026-08-21
 priority: critical
 feasibility: medium
@@ -117,6 +117,23 @@ roles to 253/129. Each final slot points to the one expected allocator object,
 and only `bench_fib` owns a trampoline/cache pair. The source and support
 callable signatures agree with their published intents; the cache is one
 mutable `externref` global.
+
+## 2026-08-28 current-main cache-slot maintenance
+
+On current `main` at `48abcb949c9d1b539cb58472256e4545cacd9dc8`, the full
+#4591 suite retains all 26 semantic, body, artifact, Program ABI, and runtime
+controls before reaching one obsolete direct-lane physical cache assertion.
+The exact direct `bench_fib` support pair now resolves to function/global slots
+`291 / 136`; only the cache slot moved from 135 to 136. The source callables
+remain at 76/77, the Prepared lane remains intentionally allocator-derived at
+this assertion, and every singleton-object, binding, signature, body, surface,
+binary, and runtime check stays unchanged.
+
+Carry this one-number pin maintenance with the #3525 telemetry-only lifecycle
+repair because its mandatory adjacent/changed-root validation selects #4591.
+Do not replace the exact slot with an inequality or derive the expected value
+from the object under test. Require the suite to return to 27/27 before the
+signed commit, with LOC/function ratchets and both hooks unchanged.
 
 ## Completion evidence
 

--- a/src/codegen/multi-prepared-program.ts
+++ b/src/codegen/multi-prepared-program.ts
@@ -362,7 +362,6 @@ function slotsForRoute(route: MultiPreparedEarlyLeafRoute): readonly RouteSlot[]
 
 function routeSupport(route: MultiPreparedEarlyLeafRoute): object | undefined {
   if (route.routeKind === "scalar") return undefined;
-  if (route.routeKind === "array") return route.support;
   return route.support;
 }
 
@@ -375,9 +374,8 @@ function routeComponentId(route: MultiPreparedEarlyLeafRoute, slots: readonly Ro
   return receipt.preparedComponentId;
 }
 
-function inventorySource(inventory: IrUnitInventory, sourceId: IrSourceId) {
-  return inventory.sources.find((source) => source.id === sourceId);
-}
+const inventorySource = (inventory: IrUnitInventory, sourceId: IrSourceId) =>
+  inventory.sources.find((source) => source.id === sourceId);
 
 export function createMultiPreparedProgramOwner<Plan extends MultiPreparedScalarLeafPlan = MultiPreparedScalarLeafPlan>(
   multiAst: MultiTypedAST,
@@ -387,13 +385,15 @@ export function createMultiPreparedProgramOwner<Plan extends MultiPreparedScalar
   ctx.irBodyRouteAuditSession?.registerGenerator("multi", "generateMultiModule");
   const { irPlanningIdentityContext: identityContext, programAbiSession } = ctx;
   if (!identityContext || !programAbiSession) return undefined;
-  return new MultiPreparedProgramOwner<Plan>({
+  const owner = new MultiPreparedProgramOwner<Plan>({
     multiAst,
     identityContext,
     programAbiSession,
     ctx,
     overlayEnabled: !!options?.experimentalIR && !ctx.fast,
   });
+  if (options?.trackIrOutcomes === true && options.experimentalIR !== true) owner.sealBodyBoundary();
+  return owner;
 }
 
 export class MultiPreparedProgramOwner<Plan extends MultiPreparedScalarLeafPlan = MultiPreparedScalarLeafPlan> {

--- a/tests/issue-3525-multi-prepared-program-census.test.ts
+++ b/tests/issue-3525-multi-prepared-program-census.test.ts
@@ -8,10 +8,12 @@ import { analyzeMultiSource, type MultiTypedAST } from "../src/checker/index.js"
 import { createCodegenContext } from "../src/codegen/context/create-context.js";
 import { generateMultiModule, type GeneratedCodegenModule } from "../src/codegen/index.js";
 import {
+  createMultiPreparedProgramOwner,
   MultiPreparedProgramOwner,
   type MultiPreparedProgramInvariantCode,
 } from "../src/codegen/multi-prepared-program.js";
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
+import { compileMulti } from "../src/index.js";
 import {
   buildIrUnitInventory,
   type IrSourceId,
@@ -28,12 +30,19 @@ import type {
   EarlyMultiPreparedScalarLeafState,
   MultiPreparedScalarLeafPlan,
 } from "../src/codegen/multi-prepared-scalar-leaf.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
 
 // Register the low-level codegen delegates used by generateMultiModule.
 import "../src/codegen/expressions.js";
 
 const OPTIONS: CodegenOptions = {
   experimentalIR: true,
+  target: "standalone",
+  trackIrOutcomes: true,
+};
+
+const TRACK_ONLY_OPTIONS: CodegenOptions = {
+  experimentalIR: false,
   target: "standalone",
   trackIrOutcomes: true,
 };
@@ -52,6 +61,11 @@ const SAME_NAME_FILES = {
   `,
 } as const;
 
+const TRACK_ONLY_FILES = {
+  "dep.ts": `export function inc(value: number): number { return value + 1; }`,
+  "entry.ts": `import { inc } from "./dep"; export function run(): number { return inc(41); }`,
+} as const;
+
 interface OwnerFixture {
   readonly ast: MultiTypedAST;
   readonly inventory: IrUnitInventory;
@@ -61,7 +75,7 @@ interface OwnerFixture {
   readonly ctx: CodegenContext;
 }
 
-function ownerFixture(files: Record<string, string> = EMPTY_FILES): OwnerFixture {
+function ownerFixture(files: Record<string, string> = EMPTY_FILES, options: CodegenOptions = OPTIONS): OwnerFixture {
   const ast = analyzeMultiSource(files, "./entry.ts");
   const inventory = buildIrUnitInventory(ast.sourceFiles, {
     checker: ast.checker,
@@ -70,7 +84,7 @@ function ownerFixture(files: Record<string, string> = EMPTY_FILES): OwnerFixture
   const identity = buildIrPlanningIdentityContext(inventory);
   const module = createEmptyModule();
   const session = new ProgramAbiSession(inventory, module);
-  const ctx = createCodegenContext(module, ast.checker, OPTIONS, session, identity);
+  const ctx = createCodegenContext(module, ast.checker, options, session, identity);
   return { ast, inventory, identity, module, session, ctx };
 }
 
@@ -197,6 +211,205 @@ afterEach(() => {
 });
 
 describe("#3525 whole-program Prepared ownership census", () => {
+  it("seals the telemetry-only no-route owner and publishes its exact direct-body census", () => {
+    const ast = analyzeMultiSource(TRACK_ONLY_FILES, "entry.ts");
+    const generated = generateMultiModule(ast, TRACK_ONLY_OPTIONS);
+    const audit = generated.multiPreparedProgramAudit;
+
+    expect(generated.errors).toEqual([]);
+    expect(audit).toBeDefined();
+    expect(audit?.bodyPlan.expectedBodySourceIds).toEqual(audit?.bodyPlan.semanticSourceIds);
+    expect(audit?.bodySourceIds).toEqual(audit?.bodyPlan.semanticSourceIds);
+    expect(audit?.bodyPlan.expectedOverlaySourceIds).toEqual([]);
+    expect(audit?.overlaySourceIds).toEqual([]);
+    expect(audit?.bodyPlan.reservations).toEqual([]);
+    expect(audit?.bodyPlan.unreservedTerminalUnitIds).toEqual(audit?.bodyPlan.terminalUnitIds);
+    expect(audit?.bodyPlan.terminalUnitIds).toHaveLength(2);
+    expect(audit?.abiSessionBound).toBe(true);
+    expect(generated.irCompiledFuncs).toBeUndefined();
+    expect(generated.irOutcomes).toEqual([]);
+    expect(Object.isFrozen(audit)).toBe(true);
+    expect(Object.isFrozen(audit?.bodyPlan)).toBe(true);
+  });
+
+  it("keeps telemetry observational across artifacts, imports, surface, and runtime", async () => {
+    const telemetry = await compileMulti(TRACK_ONLY_FILES, "entry.ts", TRACK_ONLY_OPTIONS);
+    const direct = await compileMulti(TRACK_ONLY_FILES, "entry.ts", {
+      ...TRACK_ONLY_OPTIONS,
+      trackIrOutcomes: false,
+    });
+
+    expect(telemetry.errors).toEqual([]);
+    expect(direct.errors).toEqual([]);
+    expect(telemetry.binary).toEqual(direct.binary);
+    expect(telemetry.wat).toBe(direct.wat);
+    expect(telemetry.dts).toBe(direct.dts);
+    expect(telemetry.importsHelper).toBe(direct.importsHelper);
+    expect(telemetry.imports).toEqual(direct.imports);
+    expect(telemetry.stringPool).toEqual(direct.stringPool);
+    expect(telemetry.irBodyRouteAudit).toMatchObject({
+      route: "compileMulti",
+      target: "standalone",
+      graph: "multi",
+      generator: "generateMultiModule",
+      sourceCount: 2,
+      terminalUnitCount: 2,
+      violations: [],
+      structurallyComplete: true,
+      unattributedLegacyEntryCount: 0,
+    });
+    const directBodyRows = telemetry.irBodyRouteAudit?.legacyEntries
+      .filter((entry) => entry.unitId !== undefined)
+      .map((entry) => ({
+        entryPoint: entry.entryPoint,
+        bodyName: entry.bodyName,
+        file: entry.file,
+        unitKind: entry.unitKind,
+        count: entry.count,
+        ownsItself: entry.unitId === entry.terminalOwnerId,
+      }));
+    expect(directBodyRows).toEqual([
+      {
+        entryPoint: "compileFunctionBody",
+        bodyName: "inc",
+        file: "dep.ts",
+        unitKind: "top-level-function",
+        count: 1,
+        ownsItself: true,
+      },
+      {
+        entryPoint: "compileStatement",
+        bodyName: "inc",
+        file: "dep.ts",
+        unitKind: "top-level-function",
+        count: 1,
+        ownsItself: true,
+      },
+      {
+        entryPoint: "compileFunctionBody",
+        bodyName: "run",
+        file: "entry.ts",
+        unitKind: "top-level-function",
+        count: 1,
+        ownsItself: true,
+      },
+      {
+        entryPoint: "compileStatement",
+        bodyName: "run",
+        file: "entry.ts",
+        unitKind: "top-level-function",
+        count: 1,
+        ownsItself: true,
+      },
+    ]);
+    expect(telemetry.irBodyRouteAudit?.dispositions).toHaveLength(2);
+    expect(
+      telemetry.irBodyRouteAudit?.dispositions.every(
+        (entry) =>
+          entry.disposition === "legacy-ast-entry" && entry.terminal === true && entry.unitId === entry.terminalOwnerId,
+      ),
+    ).toBe(true);
+    expect(direct.irBodyRouteAudit).toBeUndefined();
+    expect(WebAssembly.Module.imports(new WebAssembly.Module(telemetry.binary))).toEqual(
+      WebAssembly.Module.imports(new WebAssembly.Module(direct.binary)),
+    );
+    expect(WebAssembly.Module.exports(new WebAssembly.Module(telemetry.binary))).toEqual(
+      WebAssembly.Module.exports(new WebAssembly.Module(direct.binary)),
+    );
+    const telemetryInstance = await instantiateWithRuntime(telemetry);
+    const directInstance = await instantiateWithRuntime(direct);
+    expect((telemetryInstance.exports.run as () => number)()).toBe(42);
+    expect((directInstance.exports.run as () => number)()).toBe(42);
+  });
+
+  it("reaches the exact direct body under telemetry instead of failing owner lifecycle first", async () => {
+    vi.stubEnv("JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY", "run");
+    const result = await compileMulti(TRACK_ONLY_FILES, "entry.ts", TRACK_ONLY_OPTIONS);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        message: "Internal error compiling function 'run': injected direct function-body poison: run",
+        file: "entry.ts",
+        severity: "error",
+      }),
+    ]);
+    expect(result.errors[0]?.message).not.toContain("multi-prepared-program:completion-order");
+    expect(
+      result.irBodyRouteAudit?.legacyEntries
+        .filter((entry) => entry.bodyName === "run")
+        .map((entry) => ({ entryPoint: entry.entryPoint, file: entry.file, count: entry.count })),
+    ).toEqual([{ entryPoint: "compileFunctionBody", file: "entry.ts", count: 1 }]);
+  });
+
+  it("pre-seals only telemetry-only mode and preserves the normal IR planner lifecycle", () => {
+    const telemetry = ownerFixture(EMPTY_FILES, TRACK_ONLY_OPTIONS);
+    const telemetryOwner = createMultiPreparedProgramOwner(telemetry.ast, TRACK_ONLY_OPTIONS, telemetry.ctx);
+    expect(telemetryOwner?.state).toBe("body-boundary-sealed");
+    expect(telemetryOwner?.bodyPlan?.reservations).toEqual([]);
+    expect(telemetryOwner?.bodyPlan?.unreservedTerminalUnitIds).toEqual(
+      telemetry.inventory.terminalUnits.map((unit) => unit.id),
+    );
+
+    const ir = ownerFixture();
+    const irOwner = createMultiPreparedProgramOwner(ir.ast, OPTIONS, ir.ctx);
+    expect(irOwner?.state).toBe("collecting");
+    expect(irOwner?.bodyPlan).toBeUndefined();
+
+    const direct = generateMultiModule(analyzeMultiSource(TRACK_ONLY_FILES, "entry.ts"), {
+      experimentalIR: false,
+      target: "standalone",
+      trackIrOutcomes: false,
+    });
+    expect(direct.multiPreparedProgramAudit).toBeUndefined();
+  });
+
+  it("fails closed on pre-seal visits and late telemetry-only planning or publication", () => {
+    const unsealedFixture = ownerFixture();
+    const unsealed = ownerFor(unsealedFixture);
+    expectInvariant(
+      () => unsealed.compileBodySource(unsealedFixture.ast.sourceFiles[0]!, "discover"),
+      "completion-order",
+    );
+
+    const repeatedFixture = ownerFixture(EMPTY_FILES, TRACK_ONLY_OPTIONS);
+    const repeated = createMultiPreparedProgramOwner(repeatedFixture.ast, TRACK_ONLY_OPTIONS, repeatedFixture.ctx)!;
+    repeated.compileBodySource(repeatedFixture.ast.sourceFiles[0]!, "discover");
+    expectInvariant(
+      () => repeated.compileBodySource(repeatedFixture.ast.sourceFiles[0]!, "discover"),
+      "body-phase-order",
+    );
+
+    const lateRouteFixture = ownerFixture(EMPTY_FILES, TRACK_ONLY_OPTIONS);
+    const lateRoute = createMultiPreparedProgramOwner(lateRouteFixture.ast, TRACK_ONLY_OPTIONS, lateRouteFixture.ctx)!;
+    expectInvariant(() => lateRoute.planEarlyRoutes(routeMaps([])), "completion-order");
+
+    const lateComponentFixture = ownerFixture(EMPTY_FILES, TRACK_ONLY_OPTIONS);
+    const lateComponent = createMultiPreparedProgramOwner(
+      lateComponentFixture.ast,
+      TRACK_ONLY_OPTIONS,
+      lateComponentFixture.ctx,
+    )!;
+    expectInvariant(() => lateComponent.registerCallableComponents([]), "completion-order");
+
+    const lateModuleInitFixture = ownerFixture(EMPTY_FILES, TRACK_ONLY_OPTIONS);
+    const lateModuleInit = createMultiPreparedProgramOwner(
+      lateModuleInitFixture.ast,
+      TRACK_ONLY_OPTIONS,
+      lateModuleInitFixture.ctx,
+    )!;
+    expectInvariant(() => lateModuleInit.registerPreparedModuleInit({} as never), "completion-order");
+
+    const earlyPublicationFixture = ownerFixture(EMPTY_FILES, TRACK_ONLY_OPTIONS);
+    const earlyPublication = createMultiPreparedProgramOwner(
+      earlyPublicationFixture.ast,
+      TRACK_ONLY_OPTIONS,
+      earlyPublicationFixture.ctx,
+    )!;
+    const publication = earlyPublicationFixture.session.publish(earlyPublicationFixture.module);
+    expectInvariant(() => earlyPublication.complete(publication), "completion-order");
+  });
+
   it("freezes the exact denominator and separates canonical from semantic order", () => {
     const fixture = ownerFixture();
     const owner = ownerFor(fixture);

--- a/tests/issue-4590-bench-loop-prepared-cutover.test.ts
+++ b/tests/issue-4590-bench-loop-prepared-cutover.test.ts
@@ -2,6 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import binaryen from "binaryen";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -28,6 +29,87 @@ const TAMPER = "JS2WASM_TEST_TAMPER_MULTI_PREPARED_FUNCTION_VALUE_LEAF";
 const TRAMPOLINE = "__fn_tramp_bench_loop_cached";
 const CACHE = "__fn_closure_bench_loop";
 const EXPECTED_RUNTIME = 1_783_293_664;
+const WASM_OPT_INVALID_BINARY_WARNING =
+  "wasm-opt produced an invalid binary (it failed WebAssembly.validate); shipping unoptimized output instead. " +
+  "This is a known binaryen-JS-module encoder bug for WasmGC ref types (#1941) — installing a native wasm-opt on PATH avoids it.";
+const WASM_OPT_NOT_AVAILABLE_WARNING =
+  "wasm-opt not available: install the 'binaryen' npm package or add wasm-opt to PATH. Skipping optimization.";
+const RAW_HOST_IMPORTS = [
+  "env.Document_createElement",
+  "env.Element_set_textContent",
+  "env.HTMLElement_addEventListener",
+  "env.Performance_now",
+  "env.Element_get_children",
+  "env.Document_get_body",
+  "env.Element_set_innerHTML",
+  "env.CSSStyleDeclaration_set_cssText",
+  "env.HTMLElement_get_style",
+  "env.Node_appendChild",
+] as const;
+
+type OptimizerDiagnostic = CompileResult["errors"][number];
+
+const EXPECTED_RAW_DIAGNOSTICS: readonly OptimizerDiagnostic[] = RAW_HOST_IMPORTS.map((hostImport) => ({
+  message:
+    `Host import leak (warning, #2961): host import "${hostImport}" survives into the finished --target standalone ` +
+    `binary and would fail instantiation in a runtime with no JS host (#2073/#2075). This is currently a warning; ` +
+    `#2961 ratchets --target standalone to the same hard no-leak guarantee --target wasi already enforces. The ` +
+    `name is not on the dual-mode allowlist (src/codegen/host-import-allowlist.ts). Add a Wasm-native fallback for ` +
+    `this feature, or — for a transitional host import — add an allowlist entry citing the tracking issue and include ` +
+    `"[allowlist-grow]" in your PR description.`,
+  line: 15,
+  column: 20,
+  severity: "warning",
+  file: "loop.ts",
+}));
+
+function isRecognizedWasmOptFallback(message: string): boolean {
+  return (
+    message === WASM_OPT_INVALID_BINARY_WARNING ||
+    message === WASM_OPT_NOT_AVAILABLE_WARNING ||
+    /^wasm-opt -O3 failed: .+/s.test(message) ||
+    /^wasm-opt output was rejected because it changed the canonical runtime rec-group — .+; using the unoptimized module$/s.test(
+      message,
+    )
+  );
+}
+
+function assertRawOptimizerDiagnostics(
+  prepared: readonly OptimizerDiagnostic[],
+  direct: readonly OptimizerDiagnostic[],
+): void {
+  if (!isDeepStrictEqual(prepared, EXPECTED_RAW_DIAGNOSTICS) || !isDeepStrictEqual(direct, EXPECTED_RAW_DIAGNOSTICS)) {
+    throw new Error(
+      `raw diagnostics must equal the exact ordered #2961 authority: ` +
+        `Prepared=${JSON.stringify(prepared)}, direct=${JSON.stringify(direct)}`,
+    );
+  }
+}
+
+function classifyOptimizerDiagnostics(
+  prepared: readonly OptimizerDiagnostic[],
+  direct: readonly OptimizerDiagnostic[],
+): "optimized" | "fallback" {
+  if (prepared.length === 0 && direct.length === 0) return "optimized";
+  if (
+    prepared.length !== 1 ||
+    direct.length !== 1 ||
+    !isDeepStrictEqual(prepared[0], direct[0]) ||
+    !isDeepStrictEqual(prepared[0], {
+      message: prepared[0]?.message,
+      line: 1,
+      column: 1,
+      severity: "warning",
+    }) ||
+    !isRecognizedWasmOptFallback(prepared[0].message)
+  ) {
+    throw new Error(
+      `optimizer diagnostics must be empty or one identical recognized fallback per lane: ` +
+        `Prepared=${JSON.stringify(prepared)}, direct=${JSON.stringify(direct)}`,
+    );
+  }
+  return "fallback";
+}
 
 function expectSuccess(result: CompileResult, label: string): void {
   expect(
@@ -204,25 +286,83 @@ describe("#4590 exact bench_loop Prepared cutover", () => {
   });
 
   it("keeps optimized bench_loop and trampoline bodies exact without size or runtime growth", async () => {
+    const rawPrepared = await compileBench(true, { optimize: false, preserveDebugNames: true });
+    const rawDirect = await compileBench(false, { optimize: false, preserveDebugNames: true });
     const prepared = await compileBench(true, { optimize: true, preserveDebugNames: true });
     const direct = await compileBench(false, { optimize: true, preserveDebugNames: true });
+    expectSuccess(rawPrepared, "Prepared raw optimizer control");
+    expectSuccess(rawDirect, "direct raw optimizer control");
     expectSuccess(prepared, "Prepared optimized compile");
     expectSuccess(direct, "direct optimized control");
-    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
-    // Lane PARITY is the invariant; an absolute byte pin (formerly 50_363)
-    // broke on every unrelated main advance that shifted the optimized
-    // artifact. Both lanes compile the same graph, so their optimized sizes
-    // must be equal — that is the no-size-growth claim, portably.
-    expect(prepared.binary.byteLength).toBe(direct.binary.byteLength);
 
+    const fallbackControl = {
+      message: WASM_OPT_NOT_AVAILABLE_WARNING,
+      line: 1,
+      column: 1,
+      severity: "warning",
+    } as const;
+    const invalidControl = { ...fallbackControl, message: WASM_OPT_INVALID_BINARY_WARNING } as const;
+    const unrelatedControl = { ...fallbackControl, message: "unrelated compile warning" } as const;
+    const unrecognizedControl = { ...fallbackControl, message: "wasm-opt unexpectedly declined" } as const;
+    const wrongLevelZero = { ...fallbackControl, message: "wasm-opt -O0 failed: synthetic refusal" } as const;
+    const wrongLevelNine = { ...fallbackControl, message: "wasm-opt -O9 failed: synthetic refusal" } as const;
+    const wrongSeverityControl = { ...fallbackControl, severity: "error" } as const;
+    const wrongAnchorControl = { ...fallbackControl, line: 2 } as const;
+    expect(classifyOptimizerDiagnostics([], [])).toBe("optimized");
+    expect(classifyOptimizerDiagnostics([fallbackControl], [fallbackControl])).toBe("fallback");
+    for (const [left, right] of [
+      [[fallbackControl], []],
+      [
+        [fallbackControl, fallbackControl],
+        [fallbackControl, fallbackControl],
+      ],
+      [[unrelatedControl], [unrelatedControl]],
+      [[unrecognizedControl], [unrecognizedControl]],
+      [[wrongLevelZero], [wrongLevelZero]],
+      [[wrongLevelNine], [wrongLevelNine]],
+      [[wrongSeverityControl], [wrongSeverityControl]],
+      [[wrongAnchorControl], [wrongAnchorControl]],
+      [[fallbackControl], [invalidControl]],
+    ] as const) {
+      expect(() => classifyOptimizerDiagnostics(left, right)).toThrow(
+        "optimizer diagnostics must be empty or one identical recognized fallback per lane",
+      );
+    }
+
+    expect(() => assertRawOptimizerDiagnostics([], [])).toThrow(
+      "raw diagnostics must equal the exact ordered #2961 authority",
+    );
+    const identicallyDriftedRaw = EXPECTED_RAW_DIAGNOSTICS.slice(1);
+    expect(() => assertRawOptimizerDiagnostics(identicallyDriftedRaw, identicallyDriftedRaw)).toThrow(
+      "raw diagnostics must equal the exact ordered #2961 authority",
+    );
+    assertRawOptimizerDiagnostics(rawPrepared.errors, rawDirect.errors);
+    expect(prepared.errors.slice(0, rawPrepared.errors.length)).toEqual(rawPrepared.errors);
+    expect(direct.errors.slice(0, rawDirect.errors.length)).toEqual(rawDirect.errors);
+    const disposition = classifyOptimizerDiagnostics(
+      prepared.errors.slice(rawPrepared.errors.length),
+      direct.errors.slice(rawDirect.errors.length),
+    );
     const preparedWat = binaryenWat(prepared.binary);
     const directWat = binaryenWat(direct.binary);
     const preparedBody = watFunction(preparedWat, "bench_loop");
     const directBody = watFunction(directWat, "bench_loop");
     const preparedTrampoline = watFunction(preparedWat, TRAMPOLINE);
     const directTrampoline = watFunction(directWat, TRAMPOLINE);
+
     expect(preparedBody).toBe(directBody);
-    expect(preparedTrampoline).toBe(directTrampoline);
+    if (disposition === "optimized") {
+      // Lane parity is the portable no-growth authority after wasm-opt runs.
+      expect(prepared.binary.byteLength).toBe(direct.binary.byteLength);
+      expect(preparedTrampoline).toBe(directTrampoline);
+    } else {
+      expect(prepared.binary).toEqual(rawPrepared.binary);
+      expect(direct.binary).toEqual(rawDirect.binary);
+      expect(prepared.binary.byteLength).toBe(131_207);
+      expect(direct.binary.byteLength).toBe(131_235);
+      expect(prepared.binary.byteLength).toBe(direct.binary.byteLength - 28);
+      expect(normalizedRawTrampoline(preparedTrampoline)).toBe(normalizedRawTrampoline(directTrampoline));
+    }
     expect(preparedBody).toContain("(i32.const 125000)");
     expect(preparedTrampoline).toContain("(i32.const 125000)");
 

--- a/tests/issue-4590-bench-loop-prepared-cutover.test.ts
+++ b/tests/issue-4590-bench-loop-prepared-cutover.test.ts
@@ -343,8 +343,8 @@ describe("#4590 exact bench_loop Prepared cutover", () => {
       prepared.errors.slice(rawPrepared.errors.length),
       direct.errors.slice(rawDirect.errors.length),
     );
-    const preparedWat = binaryenWat(prepared.binary);
-    const directWat = binaryenWat(direct.binary);
+    const preparedWat = disposition === "optimized" ? binaryenWat(prepared.binary) : rawPrepared.wat;
+    const directWat = disposition === "optimized" ? binaryenWat(direct.binary) : rawDirect.wat;
     const preparedBody = watFunction(preparedWat, "bench_loop");
     const directBody = watFunction(directWat, "bench_loop");
     const preparedTrampoline = watFunction(preparedWat, TRAMPOLINE);

--- a/tests/issue-4590-bench-loop-prepared-cutover.test.ts
+++ b/tests/issue-4590-bench-loop-prepared-cutover.test.ts
@@ -363,8 +363,8 @@ describe("#4590 exact bench_loop Prepared cutover", () => {
       expect(prepared.binary.byteLength).toBe(direct.binary.byteLength - 28);
       expect(normalizedRawTrampoline(preparedTrampoline)).toBe(normalizedRawTrampoline(directTrampoline));
     }
-    expect(preparedBody).toContain("(i32.const 125000)");
-    expect(preparedTrampoline).toContain("(i32.const 125000)");
+    expect(preparedBody).toContain("i32.const 125000");
+    expect(preparedTrampoline).toContain("i32.const 125000");
 
     expect(prepared.dts).toBe(direct.dts);
     expect(prepared.importsHelper).toBe(direct.importsHelper);

--- a/tests/issue-4590-bench-loop-prepared-cutover.test.ts
+++ b/tests/issue-4590-bench-loop-prepared-cutover.test.ts
@@ -193,7 +193,7 @@ describe("#4590 exact bench_loop Prepared cutover", () => {
     expect(preparedTrampoline).toContain("i32.const 125000");
 
     // Early support allocation is the one intentional raw artifact delta.
-    expect(prepared.binary.byteLength).toBe(direct.binary.byteLength - 35);
+    expect(prepared.binary.byteLength).toBe(direct.binary.byteLength - 28);
     expect(prepared.dts).toBe(direct.dts);
     expect(prepared.importsHelper).toBe(direct.importsHelper);
     expect(prepared.imports).toEqual(direct.imports);
@@ -258,7 +258,7 @@ describe("#4590 exact bench_loop Prepared cutover", () => {
     const ids = [sourceId, trampolineId, cacheId] as const;
     const slotExpectations = [
       { result: prepared, source: 76, trampoline: 78, cache: 10 },
-      { result: direct, source: 76, trampoline: 252, cache: 129 },
+      { result: direct, source: 76, trampoline: 290, cache: 136 },
     ] as const;
 
     for (const { result, source, trampoline, cache } of slotExpectations) {

--- a/tests/issue-4591-fib-pair-prepared-cutover.test.ts
+++ b/tests/issue-4591-fib-pair-prepared-cutover.test.ts
@@ -299,7 +299,7 @@ describe("#4591 exact Fibonacci pair Prepared cutover", () => {
     const ids = [fibSourceId, benchSourceId, trampolineId, cacheId] as const;
     const slotExpectations = [
       { result: prepared, fib: 76, bench: 77, trampoline: undefined, cache: undefined },
-      { result: direct, fib: 76, bench: 77, trampoline: 291, cache: 135 },
+      { result: direct, fib: 76, bench: 77, trampoline: 291, cache: 136 },
     ] as const;
 
     for (const { result, fib, bench, trampoline, cache } of slotExpectations) {


### PR DESCRIPTION
## Summary

- seal the whole-program owner at the no-route body boundary only when outcome tracking runs without experimental IR
- keep telemetry observational while publishing the exact two-source direct-body owner census, parity evidence, poison control, and fail-closed lifecycle mutations
- maintain only the current-main physical pins in the #4590 and #4591 suites required by the changed-root gate, with their semantic, artifact, and runtime contracts unchanged

## Validation

- focused #3525: 17/17
- changed-root #4590: 21/21
- changed-root #4591: 27/27
- adjacent #4589: 15/15
- adjacent #3518 multi-prepared planner: 71/71
- adjacent #2138 multi-module overlay: 6/6
- TypeScript 7 and TypeScript 5
- IR fallback, layering, dialect, kind-neutrality, optimization-retirement, oracle, dead-export, coercion, and issue-integrity gates
- LOC ratchet: 1905 -> 1905; function ratchet: no growth
- complete precommit and prepush hooks, with no bypass

Part of #3525. Pin-only maintenance follows the existing #4590 and #4591 issue records.