### PR TITLE
feat(ir): attach authenticated async runtime manifests

### DIFF
--- a/plan/issues/3526-ir-r6-semantic-runtime-contract.md
+++ b/plan/issues/3526-ir-r6-semantic-runtime-contract.md
@@ -29,6 +29,7 @@ files:
   - src/ir/async-plan.ts
   - src/ir/nodes.ts
   - src/ir/intrinsic-support.ts
+  - src/ir/extern-support.ts
   - src/ir/math-runtime-providers.ts
   - src/ir/types.ts
   - src/ir/effects.ts
@@ -506,6 +507,207 @@ async plan, concrete import spelling/signature/order, lowering, or Wasm policy.
 The issue remains `blocked`: public import-intent projection, provider
 transactions, lazy-registration deletion, and typed permission/mode authority
 still require their separately approved upstream checkpoints.
+
+### A2 implementation plan — per-owner provider and backend-requirement attachment (2026-08-28)
+
+A1 freezes exact host capability records, but it does not yet preserve the
+complete provider decision consumed by each async function. During
+`prepareIrRuntimeManifest`, the implementation resolves each plan's
+`runtimeIntents` to exact provider records, derives a temporary host/native
+projection, and then discards those records. The global manifest is a union
+across functions. Backend code consequently re-filters the global
+`ASYNC_RUNTIME_PROVIDERS` catalog from `fn.asyncPlan.runtimeIntents`, and both
+the adapter materializer and frame lowerer reread `runtimeIntents` to decide
+whether native `undefined` support is required. A multi-function manifest can
+therefore describe a strict superset of one owner's needs, while the backend
+is again responsible for reconstructing the per-owner semantic choice.
+
+A2 is a behavior-neutral authority transfer. It retains the exact selected
+provider records and a closed backend-requirement projection on each prepared
+async runtime, then makes both codegen consumers use only that attachment. It
+does not change async selection, runtime semantics, target policy, public
+`ImportIntent`, provider choice, import spelling/order/signature, Wasm output,
+or runtime results. It also does not delete the existing scheduler, native
+Promise, number-boundary, or canonical-undefined provider implementations;
+turning those mutable registries into a fully staged transaction is a later
+#4260/R6 checkpoint.
+
+#### Closed attachment contract
+
+Add the canonical backend requirement vocabulary:
+
+```ts
+type RuntimeBackendRequirement =
+  | "async.native.drive"
+  | "async.native.number-boundary"
+  | "async.native.undefined";
+```
+
+The order above is canonical. Host providers project no backend requirements.
+Every standalone-native async owner projects `async.native.drive` and
+`async.native.number-boundary`; only an owner whose exact selected provider set
+contains `native.value.undefined` also projects `async.native.undefined`.
+Unknown, duplicate, missing, extra, or reordered requirements are invariants.
+
+`FrozenRuntimeManifest` publishes `backendRequirements` as the deeply frozen,
+canonical union selected by all manifest providers. `PreparedIrAsyncRuntime`
+retains, for one exact owner:
+
+- the exact frozen manifest object used for selection;
+- the exact frozen `IrAsyncPlan` object it authenticates;
+- the exact provider objects selected for that plan, in their canonical
+  manifest order;
+- the exact per-owner backend requirements; and
+- the existing attached state bodies, type layouts, and host adapters.
+
+Do not clone provider definitions into a new async catalog. Each attached
+provider must be the exact object in `manifest.providers`, and each host
+adapter record must remain the exact object in
+`manifest.hostCapabilityRecords`. A shared IR-side validator must prove, before
+any backend allocation, that the plan and manifest objects are current; the
+provider feature set is exactly the plan's canonical intent set; every
+provider ID, feature, dependency, implementation, target, backend, and host
+capability belongs to the frozen manifest record; the per-owner requirements
+are exactly the projection of those providers; and the runtime kind, adapter
+set, and target policy agree. This validator owns the semantic join. Codegen
+may call it but may not inspect `runtimeIntents` or a global provider catalog.
+The attachment envelope, state array and state records, and every attached
+state-body instruction tree must remain frozen; trusted copy-on-write passes
+re-seal only the exact body they rewrote, while final consumers reject mutable
+post-authentication evidence.
+
+The global union is evidence and a freeze-time late-request guard, not
+permission to widen an owner. In a two-function standalone manifest where only
+one function returns `void`, the global manifest contains
+`async.native.undefined`, the void owner contains it, and the non-void owner
+does not.
+
+#### Exact production ownership
+
+The A2 implementation owns only:
+
+- `src/ir/runtime-manifest.ts`: define and canonicalize the closed backend
+  requirements; derive the frozen global union from the selected provider
+  objects; and expose one shared exact projection helper.
+- `src/ir/async-plan.ts`: extend the prepared runtime attachment and own its
+  fail-closed plan/manifest/provider/requirement currentness validator. The
+  target-neutral `IrAsyncPlan` schema and `runtimeIntents` remain unchanged.
+- `src/ir/intrinsic-support.ts`: retain each owner's selected manifest provider
+  objects, attach the exact plan/manifest references, and derive the per-owner
+  requirement vector through the shared helper.
+- `src/ir/extern-support.ts`: preserve the attachment's frozen-container
+  contract when its trusted copy-on-write pass adds extern provider references
+  to prepared async state bodies. This is the only post-manifest pass in A2's
+  production order that otherwise returns mutable runtime/state containers;
+  the final frame consumer remains fail-closed and never repairs evidence.
+- `src/codegen/ir-async-runtime-adapters.ts`: delete
+  `expectedHostCapabilities`, the `ASYNC_RUNTIME_PROVIDERS` import, and the
+  `IrAsyncRuntimeIntent` import. Validate every function and build a complete
+  allocation-free request census first; only then materialize attached host
+  records or reserve the three attached native requirements. One malformed
+  later function must leave imports, types, scheduler state, Promise boundary,
+  and canonical-undefined state untouched.
+- `src/codegen/ir-async-frame.ts`: remove the semantic-intent read. Derive
+  canonical-undefined frame behavior only from the authenticated
+  `async.native.undefined` attachment. The existing idempotent drive-runtime
+  lookup may remain to resolve its already-reserved Promise type; it cannot
+  become a fallback semantic selector.
+- `tests/issue-3526-ir-runtime-manifest.test.ts` and
+  `tests/issue-4104-ir-async-plan-runtime-consumer.test.ts`: own all A2
+  attachment, mutation, allocation-boundary, and two-owner controls.
+
+Do not edit `src/ir/async-runtime-providers.ts`, `src/ir/verify.ts`,
+`tests/issue-4103-ir-async-runtime-providers.test.ts`,
+`src/codegen/async-frame.ts`, `src/codegen/async-scheduler.ts`,
+`src/ir/integration.ts`, `src/codegen/index.ts`, context files, public compiler
+APIs, or backend emitters. The in-flight Deno integration branch owns several
+of those adjacent files. Recheck open PRs and dirty Claude worktrees before
+every mutation; stop rather than expanding this slice into a live owner.
+
+#### Anti-vacuity and mutation matrix
+
+Positive controls must cover full host, partial host, standalone non-void, and
+standalone void provider projections. Reverse input function, feature, and
+provider traversal and require identical frozen manifestations, per-owner
+attachments, concrete imports, Program ABI dependencies, and runtime output.
+Repeating structurally identical manifest preparation must publish another
+current authenticated attachment rather than fail on stale object identity.
+Use a two-function host control to prove each owner receives only its selected
+capability records, and a two-function standalone control to prove optional
+undefined support does not leak from the broader owner through the global
+union. Host keeps the exact current imports; standalone keeps zero host
+imports. Add a static source assertion that both codegen consumers contain
+neither `runtimeIntents` nor `ASYNC_RUNTIME_PROVIDERS`.
+
+Reject before the first allocation:
+
+1. a dropped, duplicated, reordered, cloned, substituted, or cross-wired
+   provider object;
+2. provider ID, feature, dependency, implementation, supported-target,
+   supported-backend, or host-capability drift;
+3. a dropped, duplicated, unknown, reordered, or extra backend requirement;
+4. `native.value.undefined` without `async.native.undefined`, or the
+   requirement without that exact provider;
+5. a host provider with native requirements, a native provider with host
+   adapters, a mixed host/native owner, or a host attachment presented to a
+   strict-no-host or linear-backend context;
+6. a cloned/cross-wired plan or manifest, plan-intent drift, a dropped whole
+   runtime attachment, a runtime without a plan, both plan and runtime authority
+   dropped from an async owner, and one owner receiving another owner's broader
+   provider set;
+7. the existing malformed host record/target/ABI cases; and
+8. a valid first function followed by a malformed second function, proving the
+   materializer validates the full request census before mutating any registry.
+
+Provider and requirement arrays, their nested provider fields, the manifest,
+every prepared runtime attachment, and attached state-body instruction trees
+must be frozen. Canonical reordering of input traversal may not change digests
+or output; reordering an already prepared attachment is corruption and must
+fail.
+
+#### Validation and landing boundary
+
+The signed A1 baseline is 26/26 across the runtime-manifest, async-provider,
+and async-consumer suites (7 + 9 + 10). Retain those and run unchanged controls:
+#2864 terminal undefined (5), #2895 async frame (8), #4574 standalone native
+async family (14), #4106 async fetch user (7), and #4167 async rejection
+identity (5). The last two each retain one known standalone
+`WebAssembly.validate` failure from A1; compare exact current-main signatures
+instead of relabelling them as A2 fixes or weakening their assertions.
+
+Refreshed `main` at `48abcb949c9d1b539cb58472256e4545cacd9dc8` under Node
+24.4.1 has a broader environment/runtime baseline than A1. In a clean detached
+control with exnref disabled by Node's default, these five unchanged files total
+18 passing and 24 failing tests: all five #2864 cases stop at Node compile with
+`Invalid opcode 0x1f (enable --experimental-wasm-exnref)`; #2895 has three
+standalone `WebAssembly.validate(...) === false` controls; #4106 and #4167 each
+retain one; and all fourteen #4574 standalone-native cases retain the same
+false validation result. The A2 branch must reproduce that exact membership and
+failure signature with zero net drift; it may not mark those rows green, delete
+them, weaken assertions, or claim them as A2 defects. The extra #4110
+vector/async diagnostic likewise remains exactly 18/19 on both current main and
+the A2 branch, with only its existing standalone validation row false.
+The final A2 refresh to `f727d529abb40cdb63803a802b1502f91e4e9016`
+changes only documentation and benchmark data, so this source/test control
+membership remains the applicable final-main baseline.
+
+The A2-owned authority tests remain independently green: require the refreshed
+runtime-manifest, async-provider, and async-consumer set to pass 34/34, plus the
+trusted extern-support controls 9/9. Full repository hooks and CI remain the
+landing authority in their configured environment; current-main equivalence is
+diagnostic evidence, not permission to bypass a hook or accept a new branch-only
+failure.
+
+No LOC or function-budget allowance is authorized. Keep every touched source
+file below 1,500 lines and every function below 300 lines by extracting bounded
+helpers inside the owned files. Before the signed commit and push, take a fresh
+finite, non-negative one-minute load sample strictly below
+`logical cores - 2`; run focused and affected tests, TypeScript 7 and 5,
+formatting, IR layering/dialect/fallback/oracle/optimization gates, then LOC and
+function ratchets immediately before committing. Run complete precommit and
+prepush hooks without bypass. Obtain an independent read-only audit of the
+signed head, and open the PR ready only when its scoped diff and required gates
+are mergeable; otherwise keep it draft with the exact blocker.
 
 ### Later measured family slices
 

--- a/src/codegen/ir-async-frame.ts
+++ b/src/codegen/ir-async-frame.ts
@@ -5,13 +5,14 @@ import { emitPreparedAsyncFrameStateMachine, type AsyncFrameInfo, type HostAsync
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { ERROR_FIELD, MODE_FIELD, PARAM_FIELD_OFFSET, SENT_FIELD, sanitizeTypeName } from "./frame-core.js";
 import type { AsyncHostCapabilityId } from "../ir/async-runtime-providers.js";
+import { assertPreparedIrAsyncRuntimeCurrent, type CurrentPreparedIrAsyncRuntime } from "../ir/async-plan.js";
 import { irTypeBindingKey } from "../ir/abi-bindings.js";
 import { asVal, type IrFuncRef, type IrFunction, type IrType } from "../ir/nodes.js";
 import type { FieldDef, ValType, WasmFunction } from "../ir/types.js";
 import { coerceType } from "./shared.js";
 import { definedFuncAt } from "./func-space.js";
 import { allocLocal } from "./context/locals.js";
-import { ensureAsyncDriveRuntime } from "./async-scheduler.js";
+import { getPreparedAsyncDrivePromiseTypeIdx } from "./ir-async-runtime-adapters.js";
 
 export interface PreparedIrAsyncFrameResolver {
   resolveFunc(ref: IrFuncRef): number;
@@ -58,6 +59,7 @@ function buildFrameInfo(
   params: readonly { readonly name: string; readonly type: ValType }[],
   hostImports: HostAsyncImports | undefined,
   promiseTypeIdx: number,
+  runtime: CurrentPreparedIrAsyncRuntime,
 ): PreparedIrAsyncFrameLayout {
   const plan = fn.asyncPlan;
   if (!plan) throw new Error(`IR async function ${fn.name} has no prepared plan`);
@@ -117,7 +119,8 @@ function buildFrameInfo(
     resultPromiseFieldIdx,
     promiseTypeIdx,
     host: hostImports !== undefined,
-    canonicalUndefinedResult: hostImports === undefined && plan.runtimeIntents.includes("value.undefined"),
+    canonicalUndefinedResult:
+      hostImports === undefined && runtime.backendRequirements.includes("async.native.undefined"),
     alwaysAsyncAwait: hostImports === undefined,
     ...(hostImports ? { hostImports } : {}),
   };
@@ -363,6 +366,7 @@ export function lowerPreparedIrAsyncFunction(
   resolver: PreparedIrAsyncFrameResolver,
   existing: WasmFunction,
 ): WasmFunction {
+  const runtime = assertPreparedIrAsyncRuntimeCurrent(fn.unitId, fn.name, fn.asyncPlan, fn.asyncRuntime);
   const signature = ctx.mod.types[existing.typeIdx];
   if (
     !signature ||
@@ -390,11 +394,9 @@ export function lowerPreparedIrAsyncFunction(
     labelMap: new Map(),
     savedBodies: [],
   };
-  const runtime = fn.asyncRuntime;
-  if (!runtime) throw new Error(`IR async function ${fn.name} has no prepared runtime attachment`);
   const hostImports = runtime.kind === "host-wasmgc" ? preparedHostImports(fn, resolver) : undefined;
-  const promiseTypeIdx = runtime.kind === "standalone-native-wasmgc" ? ensureAsyncDriveRuntime(ctx).promiseTypeIdx : -1;
-  const layout = buildFrameInfo(ctx, fn, params, hostImports, promiseTypeIdx);
+  const promiseTypeIdx = runtime.kind === "standalone-native-wasmgc" ? getPreparedAsyncDrivePromiseTypeIdx(ctx) : -1;
+  const layout = buildFrameInfo(ctx, fn, params, hostImports, promiseTypeIdx, runtime);
   const previous = ctx.currentFunc;
   ctx.currentFunc = fctx;
   try {

--- a/src/codegen/ir-async-runtime-adapters.ts
+++ b/src/codegen/ir-async-runtime-adapters.ts
@@ -1,15 +1,13 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import {
-  ASYNC_RUNTIME_PROVIDERS,
-  assertCanonicalAsyncHostCapabilityRecord,
   type AsyncHostAdapter,
   type AsyncHostAdapterValueType,
   type AsyncHostCapabilityId,
 } from "../ir/async-runtime-providers.js";
-import type { IrAsyncRuntimeIntent } from "../ir/async-plan.js";
-import { sameIrCallableBinding, irImportFuncRef } from "../ir/callable-bindings.js";
+import { assertPreparedIrAsyncRuntimeCurrent } from "../ir/async-plan.js";
 import type { IrFunction } from "../ir/nodes.js";
+import { RUNTIME_BACKEND_REQUIREMENTS, type RuntimeBackendRequirement } from "../ir/runtime-manifest.js";
 import type { FuncTypeDef, Import, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { canonicalUndefinedExternInstrs } from "./any-helpers.js";
@@ -62,43 +60,35 @@ function findExactImport(ctx: CodegenContext, adapter: AsyncHostAdapter): Import
   return undefined;
 }
 
-function expectedHostCapabilities(intents: readonly IrAsyncRuntimeIntent[]): ReadonlySet<AsyncHostCapabilityId> {
-  const capabilities = new Set<AsyncHostCapabilityId>();
-  for (const intent of intents) {
-    const providers = ASYNC_RUNTIME_PROVIDERS.filter(
-      (provider) =>
-        provider.feature === intent &&
-        provider.supportedTargets.includes("host") &&
-        provider.supportedBackends.includes("wasmgc"),
-    );
-    if (providers.length !== 1) {
-      throw new Error(`IR async runtime intent ${intent} has ${providers.length} exact host-WasmGC providers`);
-    }
-    for (const capability of providers[0]!.hostCapabilities) capabilities.add(capability);
-  }
-  return capabilities;
+interface PreparedAsyncRuntimeRequestCensus {
+  readonly hostRecords: readonly AsyncHostAdapter[];
+  readonly backendRequirements: readonly RuntimeBackendRequirement[];
 }
 
-/**
- * Materialize the concrete host adapter projection selected after semantic
- * runtime-manifest freeze. This runs before prepared component / Program ABI
- * sealing. Existing imports from the transitional AST collector are validated
- * and reused; no body-lowering path may lazily invent another adapter.
- */
-export function materializePreparedAsyncHostAdapters(ctx: CodegenContext, functions: readonly IrFunction[]): void {
-  const requested = new Map<AsyncHostCapabilityId, AsyncHostAdapter>();
-  let nativeRuntimeRequested = false;
-  let nativeUndefinedRequested = false;
+const preparedAsyncDrivePromiseTypeIdxByContext = new WeakMap<CodegenContext, number>();
 
+/** Lookup-only frame type reservation populated by the pre-allocation census consumer. */
+export function getPreparedAsyncDrivePromiseTypeIdx(ctx: CodegenContext): number {
+  const promiseTypeIdx = preparedAsyncDrivePromiseTypeIdxByContext.get(ctx);
+  if (promiseTypeIdx === undefined) {
+    throw new Error("IR async native drive runtime was not reserved before frame lowering");
+  }
+  return promiseTypeIdx;
+}
+
+function collectPreparedAsyncRuntimeRequests(
+  ctx: CodegenContext,
+  functions: readonly IrFunction[],
+): PreparedAsyncRuntimeRequestCensus {
+  const requested = new Map<AsyncHostCapabilityId, AsyncHostAdapter>();
+  const requirements = new Set<RuntimeBackendRequirement>();
   for (const fn of functions) {
-    if (!fn.asyncRuntime) continue;
-    if (!fn.asyncPlan || fn.funcKind !== "async") {
+    if (!fn.asyncPlan && !fn.asyncRuntime && fn.funcKind !== "async") continue;
+    if (!fn.asyncPlan || !fn.asyncRuntime || fn.funcKind !== "async") {
       throw new Error(`IR async runtime attachment for ${fn.name} has no valid async plan owner`);
     }
-    if (fn.asyncRuntime.kind === "standalone-native-wasmgc") {
-      if (fn.asyncRuntime.adapters.length !== 0) {
-        throw new Error(`IR async function ${fn.name} attached host capability records to a native runtime`);
-      }
+    const runtime = assertPreparedIrAsyncRuntimeCurrent(fn.unitId, fn.name, fn.asyncPlan, fn.asyncRuntime);
+    if (runtime.kind === "standalone-native-wasmgc") {
       if (
         !ctx.standalone ||
         ctx.wasi ||
@@ -108,64 +98,58 @@ export function materializePreparedAsyncHostAdapters(ctx: CodegenContext, functi
       ) {
         throw new Error(`IR async function ${fn.name} selected a native standalone runtime on the wrong target`);
       }
-      nativeRuntimeRequested = true;
-      nativeUndefinedRequested ||= fn.asyncPlan.runtimeIntents.includes("value.undefined");
-      continue;
+    } else if (
+      ctx.targetProfile.target !== "gc" ||
+      ctx.targetProfile.backend !== "wasmgc" ||
+      ctx.targetProfile.environment !== "javascript" ||
+      ctx.targetProfile.capabilityPolicy !== "ambient-js" ||
+      ctx.strictNoHostImports
+    ) {
+      throw new Error(`IR async function ${fn.name} selected a host runtime on the wrong target`);
     }
-    const expectedCapabilities = expectedHostCapabilities(fn.asyncPlan.runtimeIntents);
-    if (fn.asyncRuntime.adapters.length !== expectedCapabilities.size) {
-      throw new Error(
-        `IR async function ${fn.name} has ${fn.asyncRuntime.adapters.length} frozen adapter records; expected ${expectedCapabilities.size}`,
-      );
-    }
-    const attachedCapabilities = new Set<AsyncHostCapabilityId>();
-    for (const attached of fn.asyncRuntime.adapters) {
-      assertCanonicalAsyncHostCapabilityRecord(attached.record);
-      if (attached.capability !== attached.record.capability) {
-        throw new Error(`IR async adapter ${attached.capability} carries record ${attached.record.capability}`);
+    for (const requirement of runtime.backendRequirements) requirements.add(requirement);
+    for (const adapter of runtime.adapters) {
+      const prior = requested.get(adapter.capability);
+      if (prior && prior !== adapter.record) {
+        throw new Error(`IR async adapter ${adapter.capability} differs across prepared functions`);
       }
-      if (!expectedCapabilities.has(attached.capability)) {
-        throw new Error(`IR async function ${fn.name} carries unrequested adapter ${attached.capability}`);
-      }
-      if (attachedCapabilities.has(attached.capability)) {
-        throw new Error(`IR async function ${fn.name} repeats adapter ${attached.capability}`);
-      }
-      attachedCapabilities.add(attached.capability);
-      const expectedTarget = irImportFuncRef(attached.record.module, attached.record.field, attached.record.field);
-      if (
-        !sameIrCallableBinding(attached.target.binding, expectedTarget.binding) ||
-        attached.target.name !== expectedTarget.name
-      ) {
-        throw new Error(`IR async adapter ${attached.capability} does not match its frozen import projection`);
-      }
-      const prior = requested.get(attached.capability);
-      if (prior && prior !== attached.record) {
-        throw new Error(`IR async adapter ${attached.capability} differs across prepared functions`);
-      }
-      requested.set(attached.capability, attached.record);
-    }
-    for (const capability of expectedCapabilities) {
-      if (!attachedCapabilities.has(capability)) {
-        throw new Error(`IR async function ${fn.name} is missing frozen adapter ${capability}`);
-      }
+      requested.set(adapter.capability, adapter.record);
     }
   }
+  return Object.freeze({
+    hostRecords: Object.freeze(
+      [...requested.values()].sort((left, right) =>
+        left.capability < right.capability ? -1 : left.capability > right.capability ? 1 : 0,
+      ),
+    ),
+    backendRequirements: Object.freeze(
+      RUNTIME_BACKEND_REQUIREMENTS.filter((requirement) => requirements.has(requirement)),
+    ),
+  });
+}
 
-  if (nativeRuntimeRequested) {
-    ensureAsyncDriveRuntime(ctx);
-    prepareNativePromiseNumberBoundary(ctx);
-    if (nativeUndefinedRequested) {
-      // Promise<void> must settle with the canonical native `undefined`
-      // singleton, not the null externref sentinel. Reserve it before Program
-      // ABI sealing so async-frame lowering remains allocation-free.
-      canonicalUndefinedExternInstrs(ctx);
-    }
+/**
+ * Materialize the concrete host adapter projection selected after semantic
+ * runtime-manifest freeze. This runs before prepared component / Program ABI
+ * sealing. Existing imports from the transitional AST collector are validated
+ * and reused; no body-lowering path may lazily invent another adapter.
+ */
+export function materializePreparedAsyncHostAdapters(ctx: CodegenContext, functions: readonly IrFunction[]): void {
+  const census = collectPreparedAsyncRuntimeRequests(ctx, functions);
+  for (const adapter of census.hostRecords) {
+    const imported = findExactImport(ctx, adapter);
+    if (imported) assertImportSignature(ctx, imported, adapter);
   }
-
-  const selectedRecords = [...requested.values()].sort((left, right) =>
-    left.capability < right.capability ? -1 : left.capability > right.capability ? 1 : 0,
-  );
-  for (const adapter of selectedRecords) {
+  for (const requirement of census.backendRequirements) {
+    if (requirement === "async.native.drive") {
+      if (!preparedAsyncDrivePromiseTypeIdxByContext.has(ctx)) {
+        const runtime = ensureAsyncDriveRuntime(ctx);
+        preparedAsyncDrivePromiseTypeIdxByContext.set(ctx, runtime.promiseTypeIdx);
+      }
+    } else if (requirement === "async.native.number-boundary") prepareNativePromiseNumberBoundary(ctx);
+    else canonicalUndefinedExternInstrs(ctx);
+  }
+  for (const adapter of census.hostRecords) {
     let imported = findExactImport(ctx, adapter);
     if (!imported) {
       const signature = expectedSignature(adapter);

--- a/src/ir/async-plan.ts
+++ b/src/ir/async-plan.ts
@@ -16,11 +16,13 @@
 
 import {
   ASYNC_RUNTIME_FEATURES,
+  assertCanonicalAsyncHostCapabilityRecord,
   isAsyncRuntimeFeature,
   type AsyncHostAdapter,
   type AsyncHostCapabilityId,
   type AsyncRuntimeFeature,
 } from "./async-runtime-providers.js";
+import { irImportFuncRef, sameIrCallableBinding } from "./callable-bindings.js";
 import type { IrUnitId } from "./identity.js";
 import {
   collectUses,
@@ -32,6 +34,12 @@ import {
   type IrVecLayoutRef,
   type IrValueId,
 } from "./nodes.js";
+import {
+  projectRuntimeBackendRequirements,
+  type FrozenRuntimeManifest,
+  type RuntimeBackendRequirement,
+  type RuntimeProviderDefinition,
+} from "./runtime-manifest.js";
 
 export type IrAsyncStateId = number & { readonly __brand: "IrAsyncStateId" };
 export type IrAsyncHandlerId = number & { readonly __brand: "IrAsyncHandlerId" };
@@ -195,6 +203,17 @@ export interface PreparedIrAsyncHostAdapter {
 }
 
 interface PreparedIrAsyncRuntimeBase {
+  // Optional in the structural type only for legacy generic-pass fixtures that
+  // model a pre-manifest placeholder. Production consumers must call
+  // `assertPreparedIrAsyncRuntimeCurrent`, which requires all four fields.
+  /** Exact semantic plan authenticated when this backend decision was attached. */
+  readonly plan?: IrAsyncPlan;
+  /** Exact frozen whole-program manifest used to select this owner's providers. */
+  readonly manifest?: FrozenRuntimeManifest;
+  /** Exact manifest provider objects selected for this owner, in manifest order. */
+  readonly providers?: readonly RuntimeProviderDefinition[];
+  /** Closed, canonical backend reservations projected from `providers`. */
+  readonly backendRequirements?: readonly RuntimeBackendRequirement[];
   /** Backend-only layouts keyed by the exact logical types in `asyncPlan`. */
   readonly typeLayouts?: readonly {
     readonly logicalType: IrType;
@@ -215,6 +234,291 @@ export type PreparedIrAsyncRuntime =
       readonly kind: "standalone-native-wasmgc";
       readonly adapters: readonly [];
     });
+
+export type CurrentPreparedIrAsyncRuntime = PreparedIrAsyncRuntime & {
+  readonly plan: IrAsyncPlan;
+  readonly manifest: FrozenRuntimeManifest;
+  readonly providers: readonly RuntimeProviderDefinition[];
+  readonly backendRequirements: readonly RuntimeBackendRequirement[];
+};
+
+type PreparedIrAsyncRuntimeInput = {
+  readonly plan: IrAsyncPlan;
+  readonly manifest: FrozenRuntimeManifest;
+  readonly providers: readonly RuntimeProviderDefinition[];
+  readonly backendRequirements: readonly RuntimeBackendRequirement[];
+  readonly states: readonly IrAsyncState[];
+  readonly typeLayouts?: PreparedIrAsyncRuntimeBase["typeLayouts"];
+} & (
+  | {
+      readonly kind: "host-wasmgc";
+      readonly adapters: readonly PreparedIrAsyncHostAdapter[];
+    }
+  | {
+      readonly kind: "standalone-native-wasmgc";
+      readonly adapters: readonly [];
+    }
+);
+
+const preparedManifestByPlan = new WeakMap<IrAsyncPlan, FrozenRuntimeManifest>();
+
+function runtimeAttachmentError(owner: string, detail: string): never {
+  throw new Error(`IR async runtime attachment for ${owner} ${detail}`);
+}
+
+function sameOrderedStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function expectedAsyncProviders(
+  owner: string,
+  plan: IrAsyncPlan,
+  manifest: FrozenRuntimeManifest,
+): readonly RuntimeProviderDefinition[] {
+  const intents = new Set<AsyncRuntimeFeature>();
+  for (const intent of plan.runtimeIntents) {
+    if (!isAsyncRuntimeFeature(intent) || intents.has(intent)) {
+      runtimeAttachmentError(owner, `has an unknown or duplicated semantic intent ${String(intent)}`);
+    }
+    intents.add(intent);
+  }
+  const providers = manifest.providers.filter((provider) => intents.has(provider.feature as AsyncRuntimeFeature));
+  if (
+    providers.length !== intents.size ||
+    providers.some((provider) => !intents.has(provider.feature as AsyncRuntimeFeature))
+  ) {
+    runtimeAttachmentError(owner, "does not have one exact manifest provider per semantic intent");
+  }
+  return providers;
+}
+
+function assertFrozenProvider(owner: string, provider: RuntimeProviderDefinition): void {
+  if (
+    !Object.isFrozen(provider) ||
+    !Object.isFrozen(provider.dependencies) ||
+    !Object.isFrozen(provider.hostCapabilities) ||
+    !Object.isFrozen(provider.supportedTargets) ||
+    !Object.isFrozen(provider.supportedBackends) ||
+    !Object.isFrozen(provider.implementation)
+  ) {
+    runtimeAttachmentError(owner, `carries mutable provider ${provider.id}`);
+  }
+}
+
+/** Freeze one attached state body in place without cloning symbolic IR identities. */
+function freezePreparedIrAsyncStateBody(body: readonly IrInstr[]): readonly IrInstr[] {
+  const seen = new WeakSet<object>();
+  const freezeValue = (value: unknown): void => {
+    if (value === null || typeof value !== "object" || seen.has(value)) return;
+    seen.add(value);
+    for (const key of Reflect.ownKeys(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor && "value" in descriptor) freezeValue(descriptor.value);
+    }
+    Object.freeze(value);
+  };
+  freezeValue(body);
+  return body;
+}
+
+function isPreparedIrAsyncStateBodyFrozen(body: readonly IrInstr[]): boolean {
+  const seen = new WeakSet<object>();
+  const isFrozen = (value: unknown): boolean => {
+    if (value === null || typeof value !== "object" || seen.has(value)) return true;
+    seen.add(value);
+    if (!Object.isFrozen(value)) return false;
+    for (const key of Reflect.ownKeys(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor && "value" in descriptor && !isFrozen(descriptor.value)) return false;
+    }
+    return true;
+  };
+  return isFrozen(body);
+}
+
+function sealPreparedIrAsyncStates(states: readonly IrAsyncState[]): readonly IrAsyncState[] {
+  let changed = !Object.isFrozen(states);
+  const sealed = states.map((state) => {
+    const body = freezePreparedIrAsyncStateBody(state.body);
+    if (Object.isFrozen(state) && body === state.body) return state;
+    changed = true;
+    return Object.freeze({ ...state, body });
+  });
+  return changed ? Object.freeze(sealed) : states;
+}
+
+/**
+ * Prove that one backend attachment is the exact current decision for its
+ * semantic owner. This is deliberately allocation-free and is shared by every
+ * codegen consumer before it reserves imports, types, helpers, or globals.
+ */
+export function assertPreparedIrAsyncRuntimeCurrent(
+  ownerUnitId: IrUnitId,
+  ownerName: string,
+  plan: IrAsyncPlan | undefined,
+  runtime: PreparedIrAsyncRuntime | undefined,
+): CurrentPreparedIrAsyncRuntime {
+  if (!plan || !runtime) runtimeAttachmentError(ownerName, "is incomplete");
+  if (runtime.plan !== plan || plan.ownerUnitId !== ownerUnitId) {
+    runtimeAttachmentError(ownerName, "does not retain its exact semantic plan owner");
+  }
+  const manifest = runtime.manifest;
+  if (!manifest || preparedManifestByPlan.get(plan) !== manifest) {
+    runtimeAttachmentError(ownerName, "does not retain its authenticated frozen manifest");
+  }
+  if (
+    !Object.isFrozen(runtime) ||
+    !Object.isFrozen(runtime.states) ||
+    runtime.states.some((state) => !Object.isFrozen(state) || !isPreparedIrAsyncStateBodyFrozen(state.body)) ||
+    !Object.isFrozen(runtime.adapters) ||
+    runtime.adapters.some((adapter) => !Object.isFrozen(adapter)) ||
+    (runtime.typeLayouts !== undefined &&
+      (!Object.isFrozen(runtime.typeLayouts) || runtime.typeLayouts.some((entry) => !Object.isFrozen(entry)))) ||
+    !Object.isFrozen(plan) ||
+    !Object.isFrozen(manifest) ||
+    !Object.isFrozen(manifest.policy) ||
+    !Object.isFrozen(manifest.providers) ||
+    !Object.isFrozen(manifest.hostCapabilityRecords) ||
+    !Object.isFrozen(manifest.backendRequirements)
+  ) {
+    runtimeAttachmentError(ownerName, "contains mutable attachment, plan, or manifest state");
+  }
+  const providers = runtime.providers;
+  const requirements = runtime.backendRequirements;
+  if (!providers || !requirements || !Object.isFrozen(providers) || !Object.isFrozen(requirements)) {
+    runtimeAttachmentError(ownerName, "is missing frozen provider or backend-requirement evidence");
+  }
+  const expectedProviders = expectedAsyncProviders(ownerName, plan, manifest);
+  if (
+    providers.length !== expectedProviders.length ||
+    providers.some((provider, index) => provider !== expectedProviders[index])
+  ) {
+    runtimeAttachmentError(ownerName, "does not retain exact providers in canonical manifest order");
+  }
+  for (const provider of providers) {
+    assertFrozenProvider(ownerName, provider);
+    if (
+      !provider.supportedTargets.includes(manifest.policy.target) ||
+      !provider.supportedBackends.includes(manifest.policy.backend) ||
+      provider.dependencies.some((feature) => !manifest.features.includes(feature)) ||
+      provider.hostCapabilities.some((capability) => !manifest.hostCapabilities.includes(capability))
+    ) {
+      runtimeAttachmentError(ownerName, `carries detached provider ${provider.id}`);
+    }
+  }
+  const expectedRequirements = projectRuntimeBackendRequirements(providers);
+  if (!sameOrderedStrings(requirements, expectedRequirements)) {
+    runtimeAttachmentError(ownerName, "has a non-canonical backend-requirement projection");
+  }
+  if (requirements.some((requirement) => !manifest.backendRequirements.includes(requirement))) {
+    runtimeAttachmentError(ownerName, "requests a backend requirement absent from the frozen manifest");
+  }
+  const hostProviders = providers.every(
+    (provider) => provider.implementation.kind === "host-capability" || provider.implementation.kind === "host-managed",
+  );
+  const nativeProviders = providers.every((provider) => provider.implementation.kind === "native-managed");
+  if (runtime.kind === "standalone-native-wasmgc") {
+    if (
+      !nativeProviders ||
+      hostProviders ||
+      manifest.policy.target !== "standalone" ||
+      manifest.policy.backend !== "wasmgc" ||
+      runtime.adapters.length !== 0
+    ) {
+      runtimeAttachmentError(ownerName, "has a native runtime outside the exact standalone/WasmGC provider policy");
+    }
+  } else {
+    if (
+      !hostProviders ||
+      nativeProviders ||
+      manifest.policy.target !== "host" ||
+      manifest.policy.backend !== "wasmgc" ||
+      requirements.length !== 0
+    ) {
+      runtimeAttachmentError(ownerName, "has a host runtime outside the exact host/WasmGC provider policy");
+    }
+    const capabilities = new Set(providers.flatMap((provider) => provider.hostCapabilities));
+    const records = manifest.hostCapabilityRecords.filter((record) => capabilities.has(record.capability));
+    if (runtime.adapters.length !== records.length) {
+      runtimeAttachmentError(ownerName, `has ${runtime.adapters.length} adapters; expected ${records.length}`);
+    }
+    for (let index = 0; index < records.length; index++) {
+      const adapter = runtime.adapters[index]!;
+      const record = records[index]!;
+      assertCanonicalAsyncHostCapabilityRecord(adapter.record);
+      const target = irImportFuncRef(record.module, record.field, record.field);
+      if (
+        adapter.record !== record ||
+        adapter.capability !== record.capability ||
+        !sameIrCallableBinding(adapter.target.binding, target.binding) ||
+        adapter.target.name !== target.name
+      ) {
+        runtimeAttachmentError(ownerName, `has a detached adapter at canonical index ${index}`);
+      }
+    }
+  }
+  return runtime as CurrentPreparedIrAsyncRuntime;
+}
+
+/** Create and authenticate one exact per-owner backend attachment. */
+export function createPreparedIrAsyncRuntime(input: PreparedIrAsyncRuntimeInput): CurrentPreparedIrAsyncRuntime {
+  const previous = preparedManifestByPlan.get(input.plan);
+  if (previous && previous !== input.manifest) {
+    runtimeAttachmentError(String(input.plan.ownerUnitId), "was already attached to another frozen manifest");
+  }
+  const runtime = Object.freeze({
+    ...input,
+    states: sealPreparedIrAsyncStates(input.states),
+  }) as CurrentPreparedIrAsyncRuntime;
+  preparedManifestByPlan.set(input.plan, input.manifest);
+  try {
+    return assertPreparedIrAsyncRuntimeCurrent(
+      input.plan.ownerUnitId,
+      String(input.plan.ownerUnitId),
+      input.plan,
+      runtime,
+    );
+  } catch (error) {
+    if (!previous) preparedManifestByPlan.delete(input.plan);
+    throw error;
+  }
+}
+
+/**
+ * Restore the immutable attachment envelope after a generic IR pass has
+ * copy-on-write rewritten only state bodies or prepared type layouts. Semantic
+ * joins remain untouched and are authenticated separately by the validator.
+ */
+export function sealPreparedIrAsyncRuntimeContainers(runtime: PreparedIrAsyncRuntime): PreparedIrAsyncRuntime {
+  const states = sealPreparedIrAsyncStates(runtime.states);
+  const adapters =
+    Object.isFrozen(runtime.adapters) && runtime.adapters.every((adapter) => Object.isFrozen(adapter))
+      ? runtime.adapters
+      : Object.freeze(
+          runtime.adapters.map((adapter) => (Object.isFrozen(adapter) ? adapter : Object.freeze({ ...adapter }))),
+        );
+  const typeLayouts =
+    runtime.typeLayouts === undefined ||
+    (Object.isFrozen(runtime.typeLayouts) && runtime.typeLayouts.every((entry) => Object.isFrozen(entry)))
+      ? runtime.typeLayouts
+      : Object.freeze(
+          runtime.typeLayouts.map((entry) => (Object.isFrozen(entry) ? entry : Object.freeze({ ...entry }))),
+        );
+  if (
+    Object.isFrozen(runtime) &&
+    states === runtime.states &&
+    adapters === runtime.adapters &&
+    typeLayouts === runtime.typeLayouts
+  ) {
+    return runtime;
+  }
+  return Object.freeze({
+    ...runtime,
+    states,
+    adapters,
+    ...(typeLayouts === undefined ? {} : { typeLayouts }),
+  }) as PreparedIrAsyncRuntime;
+}
 
 export type IrAsyncPlanInvariantCode =
   | "forbidden-data"

--- a/src/ir/extern-support.ts
+++ b/src/ir/extern-support.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { irImportFuncRef, sameIrCallableBinding } from "./callable-bindings.js";
+import { sealPreparedIrAsyncRuntimeContainers } from "./async-plan.js";
 import { mapNestedBuffers, type IrFuncRef, type IrFunction, type IrInstr } from "./nodes.js";
 
 function mapArray<T>(values: readonly T[], map: (value: T) => T): readonly T[] {
@@ -73,7 +74,9 @@ export function attachIrExternSupport(fn: IrFunction): IrFunction {
           const body = mapBuffer(state.body);
           return body === state.body ? state : { ...state, body };
         });
-        return states === fn.asyncRuntime.states ? fn.asyncRuntime : { ...fn.asyncRuntime, states };
+        return states === fn.asyncRuntime.states
+          ? fn.asyncRuntime
+          : sealPreparedIrAsyncRuntimeContainers({ ...fn.asyncRuntime, states });
       })()
     : undefined;
   return blocks === fn.blocks && asyncRuntime === fn.asyncRuntime

--- a/src/ir/intrinsic-support.ts
+++ b/src/ir/intrinsic-support.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { irImportFuncRef, irIntrinsicFuncRef, sameIrCallableBinding } from "./callable-bindings.js";
-import { createIrAsyncPlan, type IrAsyncPlan, type PreparedIrAsyncRuntime } from "./async-plan.js";
+import { createIrAsyncPlan, createPreparedIrAsyncRuntime, type IrAsyncPlan } from "./async-plan.js";
 import type { AsyncHostCapabilityId } from "./async-runtime-providers.js";
 import { IR_ASYNC_CLOCK_SNAPSHOT_FN } from "./async-semantic-runtime.js";
 import { intrinsicEffectEvidence, INTRINSIC_DEFINITIONS } from "./intrinsics.js";
@@ -19,6 +19,7 @@ import {
 } from "./nodes.js";
 import {
   RuntimeManifestBuilder,
+  projectRuntimeBackendRequirements,
   type FrozenRuntimeManifest,
   type RuntimeManifestPolicy,
   type RuntimeProviderPlan,
@@ -280,7 +281,11 @@ export function prepareIrRuntimeManifest(input: {
   const attachAsyncRuntime = (fn: IrFunction): IrFunction => {
     const plan = asyncPlans.get(fn.unitId);
     if (!plan) return fn;
-    const selectedProviders = plan.runtimeIntents.map((intent) => builder.resolveProvider(intent));
+    const intents = new Set<string>(plan.runtimeIntents);
+    const selectedProviders = Object.freeze(manifest.providers.filter((provider) => intents.has(provider.feature)));
+    if (selectedProviders.length !== intents.size) {
+      throw new Error(`IR async runtime attachment for ${fn.name} is missing an exact provider`);
+    }
     const nativeProjection = selectedProviders.every((provider) => provider.implementation.kind === "native-managed");
     const hostProjection = selectedProviders.every(
       (provider) =>
@@ -304,10 +309,23 @@ export function prepareIrRuntimeManifest(input: {
         return body === state.body ? state : Object.freeze({ ...state, body });
       }),
     );
-    const runtime: PreparedIrAsyncRuntime = nativeProjection
-      ? Object.freeze({ kind: "standalone-native-wasmgc", adapters: Object.freeze([] as const), states })
-      : Object.freeze({
+    const backendRequirements = projectRuntimeBackendRequirements(selectedProviders);
+    const runtime = nativeProjection
+      ? createPreparedIrAsyncRuntime({
+          kind: "standalone-native-wasmgc",
+          plan,
+          manifest,
+          providers: selectedProviders,
+          backendRequirements,
+          adapters: Object.freeze([] as const),
+          states,
+        })
+      : createPreparedIrAsyncRuntime({
           kind: "host-wasmgc",
+          plan,
+          manifest,
+          providers: selectedProviders,
+          backendRequirements,
           adapters: Object.freeze(
             records.map((record) =>
               Object.freeze({

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -52,6 +52,13 @@ export type RuntimeBackend = "wasmgc" | "linear";
 export type RuntimeFeature = IntrinsicRuntimeFeature | AsyncRuntimeFeature;
 export type HostCapabilityId = AsyncHostCapabilityId;
 
+export const RUNTIME_BACKEND_REQUIREMENTS = Object.freeze([
+  "async.native.drive",
+  "async.native.number-boundary",
+  "async.native.undefined",
+] as const);
+export type RuntimeBackendRequirement = (typeof RUNTIME_BACKEND_REQUIREMENTS)[number];
+
 export interface RuntimeManifestPolicy {
   readonly target: RuntimeTarget;
   readonly backend: RuntimeBackend;
@@ -154,6 +161,43 @@ export interface RuntimeProviderDefinition {
   readonly implementation: RuntimeProviderImplementation;
 }
 
+/**
+ * Project concrete backend reservations from already selected providers.
+ * This is the only semantic-to-backend requirement projection: consumers
+ * receive the resulting closed vector and never rediscover it from features.
+ */
+export function projectRuntimeBackendRequirements(
+  providers: readonly RuntimeProviderDefinition[],
+): readonly RuntimeBackendRequirement[] {
+  const requirements = new Set<RuntimeBackendRequirement>();
+  let family: "host" | "native" | null = null;
+  for (const provider of providers) {
+    const kind = provider.implementation.kind;
+    if (kind === "host-capability" || kind === "host-managed") {
+      if (family === "native") {
+        throw new RuntimeManifestInvariantError(
+          "invalid-backend-requirement-projection",
+          "runtime provider projection mixes host and native async providers",
+        );
+      }
+      family = "host";
+      continue;
+    }
+    if (kind !== "native-managed") continue;
+    if (family === "host") {
+      throw new RuntimeManifestInvariantError(
+        "invalid-backend-requirement-projection",
+        "runtime provider projection mixes host and native async providers",
+      );
+    }
+    family = "native";
+    requirements.add("async.native.drive");
+    requirements.add("async.native.number-boundary");
+    if (provider.feature === "value.undefined") requirements.add("async.native.undefined");
+  }
+  return Object.freeze(RUNTIME_BACKEND_REQUIREMENTS.filter((requirement) => requirements.has(requirement)));
+}
+
 /** Semantic-intrinsic lowering view; async providers are consumed by later adapters. */
 export type RuntimeProviderPlan = RuntimeProviderDefinition & {
   readonly implementation: IntrinsicRuntimeProviderImplementation;
@@ -174,6 +218,8 @@ export interface FrozenRuntimeManifest {
   readonly hostCapabilities: readonly HostCapabilityId[];
   /** Exact selected ABI records, in the same canonical capability-ID order. */
   readonly hostCapabilityRecords: readonly AsyncHostAdapter[];
+  /** Canonical union of concrete backend reservations selected before lowering. */
+  readonly backendRequirements: readonly RuntimeBackendRequirement[];
 }
 
 export type RuntimeManifestInvariantCode =
@@ -192,6 +238,7 @@ export type RuntimeManifestInvariantCode =
   | "ambiguous-runtime-provider"
   | "provider-target-unavailable"
   | "missing-backend-adapter"
+  | "invalid-backend-requirement-projection"
   | "provider-signature-mismatch"
   | "undeclared-provider-cycle"
   | "declared-cycle-mismatch"
@@ -878,6 +925,7 @@ export class RuntimeManifestBuilder {
     const hostCapabilityRecords = Object.freeze(
       hostCapabilities.map((capability) => resolveAsyncHostCapabilityRecord(capabilityCatalog, capability)),
     );
+    const backendRequirements = projectRuntimeBackendRequirements(providers);
 
     for (const use of intrinsicUses) this.#plannedIntrinsicIds.add(use.id);
     for (const value of providers) this.#plannedProviderIds.add(value.id);
@@ -891,6 +939,7 @@ export class RuntimeManifestBuilder {
       providerComponents,
       hostCapabilities,
       hostCapabilityRecords,
+      backendRequirements,
     });
   }
 

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -15,9 +15,16 @@ import {
 } from "../src/ir/intrinsics.js";
 import { asValueId, irVal, type IrInstr } from "../src/ir/nodes.js";
 import {
+  ASYNC_RUNTIME_FEATURES,
+  ASYNC_RUNTIME_PROVIDERS,
+  type AsyncRuntimeFeature,
+} from "../src/ir/async-runtime-providers.js";
+import {
   PURE_MATH_RUNTIME_PROVIDERS,
+  RUNTIME_BACKEND_REQUIREMENTS,
   RuntimeManifestBuilder,
   RuntimeManifestInvariantError,
+  projectRuntimeBackendRequirements,
   type FrozenRuntimeManifest,
   type RuntimeBackend,
   type RuntimeManifestPolicy,
@@ -85,6 +92,7 @@ function semanticView(manifest: FrozenRuntimeManifest): object {
     providerComponents: manifest.providerComponents,
     hostCapabilities: manifest.hostCapabilities,
     hostCapabilityRecords: manifest.hostCapabilityRecords,
+    backendRequirements: manifest.backendRequirements,
   };
 }
 
@@ -150,6 +158,7 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
     expect(first.hostCapabilities).toEqual([]);
     expect(first.hostCapabilityRecords).toEqual([]);
+    expect(first.backendRequirements).toEqual([]);
 
     const dependencies = Object.fromEntries(
       first.providers.map((provider) => [provider.feature, provider.dependencies]),
@@ -179,6 +188,38 @@ describe("#3526 typed IR runtime manifest foundation", () => {
     expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
     expect(dependencies["math.tan"]).toEqual(["math.cos", "math.sin"]);
     expect(first.features.filter((feature) => feature === "math.reduce-trig")).toHaveLength(1);
+  });
+
+  it("projects one canonical backend-requirement union from exact async providers", () => {
+    const build = (
+      target: "host" | "standalone",
+      intents: readonly AsyncRuntimeFeature[],
+      providers = ASYNC_RUNTIME_PROVIDERS,
+    ): FrozenRuntimeManifest => {
+      const builder = new RuntimeManifestBuilder(policy(target), { providers });
+      for (const intent of intents) builder.requestFeature(intent);
+      return builder.freeze();
+    };
+    const host = build("host", ASYNC_RUNTIME_FEATURES);
+    const native = build("standalone", ASYNC_RUNTIME_FEATURES);
+    const nativeVoid = build("standalone", [...ASYNC_RUNTIME_FEATURES, "value.undefined"]);
+    const reversed = build(
+      "standalone",
+      [...ASYNC_RUNTIME_FEATURES, "value.undefined"].reverse(),
+      [...ASYNC_RUNTIME_PROVIDERS].reverse(),
+    );
+
+    expect(host.backendRequirements).toEqual([]);
+    expect(native.backendRequirements).toEqual(RUNTIME_BACKEND_REQUIREMENTS.slice(0, 2));
+    expect(nativeVoid.backendRequirements).toEqual(RUNTIME_BACKEND_REQUIREMENTS);
+    expect(reversed).toEqual(nativeVoid);
+    expect(Object.isFrozen(nativeVoid.backendRequirements)).toBe(true);
+    expect(() =>
+      projectRuntimeBackendRequirements([
+        ASYNC_RUNTIME_PROVIDERS.find((provider) => provider.id === "host.promise.resolve")!,
+        ASYNC_RUNTIME_PROVIDERS.find((provider) => provider.id === "native.promise.resolve")!,
+      ]),
+    ).toThrowError(thrown("invalid-backend-requirement-projection"));
   });
 
   it("keeps the pure fixed point host-free in every target/backend policy", () => {

--- a/tests/issue-4104-ir-async-plan-runtime-consumer.test.ts
+++ b/tests/issue-4104-ir-async-plan-runtime-consumer.test.ts
@@ -1,12 +1,25 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import { createCodegenContext } from "../src/codegen/context/create-context.js";
-import { materializePreparedAsyncHostAdapters } from "../src/codegen/ir-async-runtime-adapters.js";
+import { lowerPreparedIrAsyncFunction } from "../src/codegen/ir-async-frame.js";
+import {
+  getPreparedAsyncDrivePromiseTypeIdx,
+  materializePreparedAsyncHostAdapters,
+} from "../src/codegen/ir-async-runtime-adapters.js";
 import { planProgramAbiCallableImports } from "../src/codegen/program-abi-import-planning.js";
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
-import { asAsyncStateId, canonicalPromiseAbi, createIrAsyncPlan, type IrAsyncPlan } from "../src/ir/async-plan.js";
+import {
+  asAsyncStateId,
+  assertPreparedIrAsyncRuntimeCurrent,
+  canonicalPromiseAbi,
+  createIrAsyncPlan,
+  type IrAsyncPlan,
+  type PreparedIrAsyncRuntime,
+} from "../src/ir/async-plan.js";
 import {
   ASYNC_HOST_ADAPTERS,
   ASYNC_HOST_CAPABILITY_RECORDS,
@@ -14,11 +27,18 @@ import {
   type AsyncHostAdapter,
 } from "../src/ir/async-runtime-providers.js";
 import { irCallableBindingKey } from "../src/ir/callable-bindings.js";
+import { attachIrExternSupport } from "../src/ir/extern-support.js";
 import { buildIrUnitInventory, type IrTerminalUnitRecord } from "../src/ir/identity.js";
 import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
 import { asBlockId, asValueId, irVal, type IrFunction } from "../src/ir/nodes.js";
 import { derivePreparedComponentDependencies } from "../src/ir/prepared-component-dependencies.js";
-import { RuntimeManifestInvariantError } from "../src/ir/runtime-manifest.js";
+import {
+  RUNTIME_BACKEND_REQUIREMENTS,
+  RuntimeManifestInvariantError,
+  type FrozenRuntimeManifest,
+  type RuntimeBackendRequirement,
+  type RuntimeProviderDefinition,
+} from "../src/ir/runtime-manifest.js";
 import { createEmptyModule } from "../src/ir/types.js";
 import { verifyIrFunction } from "../src/ir/verify.js";
 import { ts } from "../src/ts-api.js";
@@ -142,6 +162,57 @@ function irFunction(unit: IrTerminalUnitRecord, withIntrinsic = false, voidResul
   };
 }
 
+function externStateIrFunction(unit: IrTerminalUnitRecord): IrFunction {
+  const promise = asValueId(0);
+  const resumed = asValueId(1);
+  const listFormat = asValueId(2);
+  const plan = createIrAsyncPlan({
+    schemaVersion: 1,
+    ownerUnitId: unit.id,
+    kind: "async-function",
+    abi: canonicalPromiseAbi(F64),
+    entry: asAsyncStateId(0),
+    params: [{ value: promise, type: EXTERN }],
+    values: [
+      { value: promise, type: EXTERN },
+      { value: resumed, type: F64 },
+      { value: listFormat, type: { kind: "extern", className: "ListFormat" } },
+    ],
+    spills: [],
+    states: [
+      {
+        id: asAsyncStateId(0),
+        body: [],
+        terminator: {
+          kind: "suspend",
+          awaited: promise,
+          resume: { state: asAsyncStateId(1), value: resumed },
+          rejected: { kind: "reject" },
+          live: [],
+        },
+      },
+      {
+        id: asAsyncStateId(1),
+        resume: { value: resumed, type: F64, source: "fulfilled" },
+        body: [
+          {
+            kind: "extern.new",
+            className: "ListFormat",
+            importPrefix: "Intl_ListFormat",
+            args: [],
+            result: listFormat,
+            resultType: { kind: "extern", className: "ListFormat" },
+          },
+        ],
+        terminator: { kind: "resolve", value: resumed },
+      },
+    ],
+    handlers: [],
+    runtimeIntents: ASYNC_RUNTIME_FEATURES,
+  });
+  return { ...irFunction(unit), asyncPlan: plan, valueCount: 3 };
+}
+
 function settleOnlyIrFunction(unit: IrTerminalUnitRecord): IrFunction {
   const value = asValueId(0);
   const plan = createIrAsyncPlan({
@@ -212,6 +283,23 @@ function prepare(fn: IrFunction) {
   return prepareForTarget(fn, "host");
 }
 
+function replaceRuntime(fn: IrFunction, update: Partial<PreparedIrAsyncRuntime>): IrFunction {
+  if (!fn.asyncRuntime) throw new Error("missing prepared async runtime");
+  return { ...fn, asyncRuntime: Object.freeze({ ...fn.asyncRuntime, ...update }) as PreparedIrAsyncRuntime };
+}
+
+function allocationShape(ctx: ReturnType<typeof createCodegenContext>) {
+  return {
+    imports: ctx.mod.imports.length,
+    types: ctx.mod.types.length,
+    functions: ctx.mod.functions.length,
+    globals: ctx.mod.globals.length,
+    funcMap: ctx.funcMap.size,
+    structMap: ctx.structMap.size,
+    undefinedGlobalIdx: ctx.undefinedGlobalIdx,
+  };
+}
+
 describe("#4104 IR async plan runtime consumer", () => {
   it("closes a semantic plan to the exact frozen capability records without contaminating semantic edges", () => {
     const { unit } = fixture();
@@ -229,6 +317,32 @@ describe("#4104 IR async plan runtime consumer", () => {
     expect(
       fn.asyncRuntime?.adapters.every(
         (adapter, index) => adapter.record === prepared.manifest.hostCapabilityRecords[index],
+      ),
+    ).toBe(true);
+    expect(fn.asyncRuntime?.plan).toBe(fn.asyncPlan);
+    expect(fn.asyncRuntime?.manifest).toBe(prepared.manifest);
+    expect(fn.asyncRuntime?.providers).toEqual(prepared.manifest.providers);
+    expect(
+      fn.asyncRuntime?.providers?.every((provider, index) => provider === prepared.manifest.providers[index]),
+    ).toBe(true);
+    expect(fn.asyncRuntime?.backendRequirements).toEqual([]);
+    expect(Object.isFrozen(fn.asyncRuntime)).toBe(true);
+    expect(Object.isFrozen(fn.asyncRuntime?.providers)).toBe(true);
+    expect(Object.isFrozen(fn.asyncRuntime?.backendRequirements)).toBe(true);
+    expect(Object.isFrozen(fn.asyncRuntime?.states)).toBe(true);
+    expect(fn.asyncRuntime?.states.every((state) => Object.isFrozen(state))).toBe(true);
+    expect(fn.asyncRuntime?.states.every((state) => Object.isFrozen(state.body))).toBe(true);
+    expect(Object.isFrozen(fn.asyncRuntime?.adapters)).toBe(true);
+    expect(fn.asyncRuntime?.adapters.every((adapter) => Object.isFrozen(adapter))).toBe(true);
+    expect(
+      fn.asyncRuntime?.providers?.every(
+        (provider) =>
+          Object.isFrozen(provider) &&
+          Object.isFrozen(provider.dependencies) &&
+          Object.isFrozen(provider.hostCapabilities) &&
+          Object.isFrozen(provider.supportedTargets) &&
+          Object.isFrozen(provider.supportedBackends) &&
+          Object.isFrozen(provider.implementation),
       ),
     ).toBe(true);
     expect(verifyIrFunction(fn)).toEqual([]);
@@ -252,7 +366,24 @@ describe("#4104 IR async plan runtime consumer", () => {
     expect(prepared.manifest.hostCapabilityRecords).toEqual(ASYNC_HOST_CAPABILITY_RECORDS);
     expect(fn.asyncRuntime?.adapters.map((adapter) => adapter.record)).toEqual(ASYNC_HOST_CAPABILITY_RECORDS);
     expect(fn.asyncRuntime?.adapters.at(-1)?.capability).toBe("async.value.undefined");
+    expect(fn.asyncRuntime?.backendRequirements).toEqual([]);
     expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("repeats structurally identical manifest preparation without stale attachment evidence", () => {
+    const { unit } = fixture("-repeat-preparation");
+    const first = prepare(irFunction(unit));
+    const second = prepare(first.functions[0]!);
+    expect(second.manifest).toEqual(first.manifest);
+    expect(second.functions[0]!.asyncRuntime).toEqual(first.functions[0]!.asyncRuntime);
+    expect(() =>
+      assertPreparedIrAsyncRuntimeCurrent(
+        second.functions[0]!.unitId,
+        second.functions[0]!.name,
+        second.functions[0]!.asyncPlan,
+        second.functions[0]!.asyncRuntime,
+      ),
+    ).not.toThrow();
   });
 
   it("preserves a valid partial semantic provider closure without widening it to all six imports", () => {
@@ -285,6 +416,8 @@ describe("#4104 IR async plan runtime consumer", () => {
     expect(semantic).toMatchObject({ kind: "intrinsic", id: "math.abs" });
     expect(semantic).not.toHaveProperty("provider");
     expect(lowered).toMatchObject({ kind: "intrinsic", id: "math.abs", provider: { kind: "backend-op" } });
+    expect(Object.isFrozen(fn.asyncRuntime!.states[1]!.body)).toBe(true);
+    expect(Object.isFrozen(lowered)).toBe(true);
     expect(verifyIrFunction(fn)).toEqual([]);
   });
 
@@ -300,14 +433,412 @@ describe("#4104 IR async plan runtime consumer", () => {
     expect(standalone.manifest.features).toEqual(ASYNC_RUNTIME_FEATURES);
     expect(standalone.manifest.hostCapabilities).toEqual([]);
     expect(standalone.manifest.hostCapabilityRecords).toEqual([]);
+    expect(standalone.manifest.backendRequirements).toEqual(RUNTIME_BACKEND_REQUIREMENTS.slice(0, 2));
     expect(standalone.manifest.providers.every((provider) => provider.implementation.kind === "native-managed")).toBe(
       true,
     );
     expect(fn.asyncRuntime).toMatchObject({ kind: "standalone-native-wasmgc", adapters: [] });
+    expect(fn.asyncRuntime?.providers?.every((provider) => provider.implementation.kind === "native-managed")).toBe(
+      true,
+    );
+    expect(fn.asyncRuntime?.backendRequirements).toEqual(RUNTIME_BACKEND_REQUIREMENTS.slice(0, 2));
+    expect(fn.asyncRuntime?.states.every((state) => Object.isFrozen(state.body))).toBe(true);
+    expect(fn.asyncRuntime?.states.flatMap((state) => state.body).every((instr) => Object.isFrozen(instr))).toBe(true);
     expect(fn.asyncPlan).toEqual(sourcePlan);
     expect(fn.asyncPlan).toEqual(host.functions[0]!.asyncPlan);
     expect(sourceFunction.asyncRuntime).toBeUndefined();
     expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("keeps global unions separate from exact per-owner host and native attachments", () => {
+    const { units } = pairFixture();
+    const hostInputs = [irFunction(units[0]!), settleOnlyIrFunction(units[1]!)];
+    const hostForward = prepareIrRuntimeManifest({
+      functions: hostInputs,
+      sourceFile: "/repo/async-plan-consumer-pair.ts",
+      policy: { target: "host", backend: "wasmgc" },
+    });
+    const hostReverse = prepareIrRuntimeManifest({
+      functions: [...hostInputs].reverse(),
+      sourceFile: "/repo/async-plan-consumer-pair.ts",
+      policy: { target: "host", backend: "wasmgc" },
+    });
+    if (!hostForward || !hostReverse) throw new Error("missing host pair runtime manifest");
+    const ownerView = (functions: readonly IrFunction[]) =>
+      functions
+        .map((fn) => ({
+          name: fn.name,
+          providers: fn.asyncRuntime?.providers?.map((provider) => provider.id),
+          requirements: fn.asyncRuntime?.backendRequirements,
+          adapters: fn.asyncRuntime?.adapters.map((adapter) => adapter.capability),
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name));
+    expect(hostReverse.manifest).toEqual(hostForward.manifest);
+    expect(ownerView(hostReverse.functions)).toEqual(ownerView(hostForward.functions));
+    expect(hostForward.manifest.hostCapabilityRecords).toEqual(ASYNC_HOST_ADAPTERS);
+    expect(hostForward.manifest.backendRequirements).toEqual([]);
+    expect(hostForward.functions[0]!.asyncRuntime?.adapters).toHaveLength(6);
+    expect(hostForward.functions[1]!.asyncRuntime?.adapters).toHaveLength(2);
+
+    const native = prepareIrRuntimeManifest({
+      functions: [irFunction(units[0]!), irFunction(units[1]!, false, true)],
+      sourceFile: "/repo/async-plan-consumer-pair.ts",
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!native) throw new Error("missing native pair runtime manifest");
+    expect(native.manifest.hostCapabilityRecords).toEqual([]);
+    expect(native.manifest.backendRequirements).toEqual(RUNTIME_BACKEND_REQUIREMENTS);
+    expect(native.functions[0]!.asyncRuntime?.backendRequirements).toEqual(RUNTIME_BACKEND_REQUIREMENTS.slice(0, 2));
+    expect(native.functions[1]!.asyncRuntime?.backendRequirements).toEqual(RUNTIME_BACKEND_REQUIREMENTS);
+  });
+
+  it("rejects provider, requirement, owner, and attachment-container corruption before allocation", () => {
+    const { units } = pairFixture();
+    const host = prepareIrRuntimeManifest({
+      functions: [irFunction(units[0]!), settleOnlyIrFunction(units[1]!)],
+      sourceFile: "/repo/async-plan-consumer-pair.ts",
+      policy: { target: "host", backend: "wasmgc" },
+    });
+    const native = prepareIrRuntimeManifest({
+      functions: [irFunction(units[0]!), irFunction(units[1]!, false, true)],
+      sourceFile: "/repo/async-plan-consumer-pair.ts",
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!host || !native) throw new Error("missing paired async runtime manifests");
+    const hostFull = host.functions[0]!;
+    const hostPartial = host.functions[1]!;
+    const nativeBase = native.functions[0]!;
+    const nativeVoid = native.functions[1]!;
+    if (hostFull.asyncRuntime?.kind !== "host-wasmgc" || hostPartial.asyncRuntime?.kind !== "host-wasmgc") {
+      throw new Error("missing host runtime attachments");
+    }
+    if (
+      nativeBase.asyncRuntime?.kind !== "standalone-native-wasmgc" ||
+      nativeVoid.asyncRuntime?.kind !== "standalone-native-wasmgc"
+    ) {
+      throw new Error("missing native runtime attachments");
+    }
+
+    const rejectHost = (malformed: IrFunction, detail: RegExp): void => {
+      const ctx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker);
+      const before = allocationShape(ctx);
+      expect(() => materializePreparedAsyncHostAdapters(ctx, [malformed])).toThrow(detail);
+      expect(allocationShape(ctx)).toEqual(before);
+    };
+    const rejectNative = (malformed: IrFunction, detail: RegExp): void => {
+      const ctx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker, { standalone: true });
+      const before = allocationShape(ctx);
+      expect(() => materializePreparedAsyncHostAdapters(ctx, [malformed])).toThrow(detail);
+      expect(allocationShape(ctx)).toEqual(before);
+    };
+
+    const hostProviders = hostFull.asyncRuntime.providers;
+    const firstProvider = hostProviders[0]!;
+    const secondProvider = hostProviders[1]!;
+    const providerMutations: readonly (readonly RuntimeProviderDefinition[])[] = [
+      Object.freeze(hostProviders.slice(1)),
+      Object.freeze([firstProvider, firstProvider, ...hostProviders.slice(2)]),
+      Object.freeze([...hostProviders].reverse()),
+      Object.freeze([secondProvider, firstProvider, ...hostProviders.slice(2)]),
+      Object.freeze([Object.freeze({ ...firstProvider }), ...hostProviders.slice(1)]),
+      Object.freeze([Object.freeze({ ...firstProvider, id: secondProvider.id }), ...hostProviders.slice(1)]),
+      Object.freeze([Object.freeze({ ...firstProvider, feature: secondProvider.feature }), ...hostProviders.slice(1)]),
+      Object.freeze([
+        Object.freeze({ ...firstProvider, dependencies: Object.freeze([secondProvider.feature]) }),
+        ...hostProviders.slice(1),
+      ]),
+      Object.freeze([
+        Object.freeze({ ...firstProvider, implementation: secondProvider.implementation }),
+        ...hostProviders.slice(1),
+      ]),
+      Object.freeze([
+        Object.freeze({ ...firstProvider, supportedTargets: Object.freeze(["standalone"] as const) }),
+        ...hostProviders.slice(1),
+      ]),
+      Object.freeze([
+        Object.freeze({ ...firstProvider, supportedBackends: Object.freeze(["linear"] as const) }),
+        ...hostProviders.slice(1),
+      ]),
+      Object.freeze([
+        Object.freeze({ ...firstProvider, hostCapabilities: Object.freeze(secondProvider.hostCapabilities) }),
+        ...hostProviders.slice(1),
+      ]),
+    ];
+    for (const providers of providerMutations) {
+      rejectHost(replaceRuntime(hostFull, { providers }), /exact providers/);
+    }
+    rejectHost(
+      replaceRuntime(hostPartial, { providers: Object.freeze([...hostFull.asyncRuntime.providers]) }),
+      /exact providers/,
+    );
+    rejectHost(
+      replaceRuntime(hostFull, { providers: Object.freeze([...nativeBase.asyncRuntime.providers]) }),
+      /exact providers/,
+    );
+    rejectHost(
+      replaceRuntime(hostFull, {
+        providers: Object.freeze([nativeBase.asyncRuntime.providers[0]!, ...hostProviders.slice(1)]),
+      }),
+      /exact providers/,
+    );
+
+    const nativeRequirements = nativeVoid.asyncRuntime.backendRequirements;
+    const requirementMutations: readonly (readonly RuntimeBackendRequirement[])[] = [
+      Object.freeze(nativeRequirements.slice(1)),
+      Object.freeze([nativeRequirements[0]!, nativeRequirements[0]!, ...nativeRequirements.slice(2)]),
+      Object.freeze([...nativeRequirements].reverse()),
+      Object.freeze([...nativeRequirements, "async.native.drive"]),
+      Object.freeze(["async.native.undefined"]),
+      Object.freeze(["async.native.drive", "async.native.undefined"]),
+      Object.freeze(["async.native.drive", "async.native.number-boundary", "async.native.unknown"] as never[]),
+    ];
+    for (const backendRequirements of requirementMutations) {
+      rejectNative(replaceRuntime(nativeVoid, { backendRequirements }), /backend-requirement projection/);
+    }
+    rejectNative(
+      replaceRuntime(nativeBase, { backendRequirements: Object.freeze([...RUNTIME_BACKEND_REQUIREMENTS]) }),
+      /backend-requirement projection/,
+    );
+    rejectHost(
+      replaceRuntime(hostFull, { backendRequirements: Object.freeze(["async.native.drive"]) }),
+      /backend-requirement projection/,
+    );
+
+    rejectNative(
+      replaceRuntime(nativeBase, {
+        kind: "host-wasmgc",
+        adapters: hostFull.asyncRuntime.adapters,
+      } as Partial<PreparedIrAsyncRuntime>),
+      /host runtime outside/,
+    );
+    rejectHost(
+      replaceRuntime(hostFull, {
+        kind: "standalone-native-wasmgc",
+        adapters: Object.freeze([]),
+      } as Partial<PreparedIrAsyncRuntime>),
+      /native runtime outside/,
+    );
+
+    const clonedPlan = createIrAsyncPlan(hostFull.asyncPlan!);
+    rejectHost(
+      {
+        ...hostFull,
+        asyncPlan: clonedPlan,
+        asyncRuntime: Object.freeze({ ...hostFull.asyncRuntime, plan: clonedPlan }),
+      },
+      /authenticated frozen manifest/,
+    );
+    const driftedPlan = Object.freeze({
+      ...hostFull.asyncPlan!,
+      runtimeIntents: Object.freeze([...hostFull.asyncPlan!.runtimeIntents, "value.undefined"]),
+    }) as IrAsyncPlan;
+    rejectHost(
+      {
+        ...hostFull,
+        asyncPlan: driftedPlan,
+        asyncRuntime: Object.freeze({ ...hostFull.asyncRuntime, plan: driftedPlan }),
+      },
+      /authenticated frozen manifest/,
+    );
+    rejectHost(
+      {
+        ...hostFull,
+        asyncPlan: hostPartial.asyncPlan,
+        asyncRuntime: Object.freeze({ ...hostFull.asyncRuntime, plan: hostPartial.asyncPlan }),
+      },
+      /exact semantic plan owner/,
+    );
+    const clonedManifest = Object.freeze({ ...host.manifest }) as FrozenRuntimeManifest;
+    rejectHost(replaceRuntime(hostFull, { manifest: clonedManifest }), /authenticated frozen manifest/);
+    rejectHost(replaceRuntime(hostFull, { manifest: native.manifest }), /authenticated frozen manifest/);
+
+    rejectHost({ ...hostFull, asyncRuntime: { ...hostFull.asyncRuntime } }, /mutable attachment/);
+    rejectHost(
+      replaceRuntime(hostFull, { providers: [...hostFull.asyncRuntime.providers] }),
+      /missing frozen provider/,
+    );
+    rejectHost(replaceRuntime(hostFull, { backendRequirements: [] }), /missing frozen provider/);
+    rejectHost(replaceRuntime(hostFull, { adapters: [...hostFull.asyncRuntime.adapters] }), /mutable attachment/);
+    const mutableBody = [...hostFull.asyncRuntime.states[0]!.body];
+    rejectHost(
+      replaceRuntime(hostFull, {
+        states: Object.freeze([
+          Object.freeze({ ...hostFull.asyncRuntime.states[0]!, body: mutableBody }),
+          ...hostFull.asyncRuntime.states.slice(1),
+        ]),
+      }),
+      /mutable attachment/,
+    );
+    rejectHost(
+      replaceRuntime(hostFull, {
+        adapters: Object.freeze([
+          { ...hostFull.asyncRuntime.adapters[0]! },
+          ...hostFull.asyncRuntime.adapters.slice(1),
+        ]),
+      }),
+      /mutable attachment/,
+    );
+    rejectHost(
+      replaceRuntime(hostFull, {
+        typeLayouts: Object.freeze([{ logicalType: F64, layout: {} as never }]),
+      }),
+      /mutable attachment/,
+    );
+  });
+
+  it("validates the complete host and native request census before allocating", () => {
+    const { units } = pairFixture();
+    const host = prepareIrRuntimeManifest({
+      functions: units.map((unit) => irFunction(unit)),
+      sourceFile: "/repo/async-plan-consumer-pair.ts",
+      policy: { target: "host", backend: "wasmgc" },
+    });
+    const native = prepareIrRuntimeManifest({
+      functions: [irFunction(units[0]!), irFunction(units[1]!, false, true)],
+      sourceFile: "/repo/async-plan-consumer-pair.ts",
+      policy: { target: "standalone", backend: "wasmgc" },
+    });
+    if (!host || !native) throw new Error("missing paired async runtime manifests");
+
+    const malformedHost = replaceRuntime(host.functions[1]!, {
+      providers: Object.freeze(host.functions[1]!.asyncRuntime!.providers!.slice(1)),
+    });
+    const hostCtx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker);
+    const hostBefore = allocationShape(hostCtx);
+    expect(() => materializePreparedAsyncHostAdapters(hostCtx, [host.functions[0]!, malformedHost])).toThrow(
+      /exact providers/,
+    );
+    expect(allocationShape(hostCtx)).toEqual(hostBefore);
+
+    const droppedRuntime: IrFunction = { ...host.functions[1]!, asyncRuntime: undefined };
+    const droppedCtx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker);
+    const droppedBefore = allocationShape(droppedCtx);
+    expect(() => materializePreparedAsyncHostAdapters(droppedCtx, [host.functions[0]!, droppedRuntime])).toThrow(
+      /no valid async plan owner/,
+    );
+    expect(allocationShape(droppedCtx)).toEqual(droppedBefore);
+
+    const droppedAuthority: IrFunction = {
+      ...host.functions[1]!,
+      asyncPlan: undefined,
+      asyncRuntime: undefined,
+    };
+    const droppedAuthorityCtx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker);
+    const droppedAuthorityBefore = allocationShape(droppedAuthorityCtx);
+    expect(() =>
+      materializePreparedAsyncHostAdapters(droppedAuthorityCtx, [host.functions[0]!, droppedAuthority]),
+    ).toThrow(/no valid async plan owner/);
+    expect(allocationShape(droppedAuthorityCtx)).toEqual(droppedAuthorityBefore);
+
+    const runtimeWithoutPlan: IrFunction = { ...host.functions[1]!, asyncPlan: undefined };
+    const orphanCtx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker);
+    const orphanBefore = allocationShape(orphanCtx);
+    expect(() => materializePreparedAsyncHostAdapters(orphanCtx, [host.functions[0]!, runtimeWithoutPlan])).toThrow(
+      /no valid async plan owner/,
+    );
+    expect(allocationShape(orphanCtx)).toEqual(orphanBefore);
+
+    const malformedNative = replaceRuntime(native.functions[1]!, {
+      backendRequirements: Object.freeze(RUNTIME_BACKEND_REQUIREMENTS.slice(0, 2)),
+    });
+    const nativeCtx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker, { standalone: true });
+    const nativeBefore = allocationShape(nativeCtx);
+    expect(() => materializePreparedAsyncHostAdapters(nativeCtx, [native.functions[0]!, malformedNative])).toThrow(
+      /backend-requirement projection/,
+    );
+    expect(allocationShape(nativeCtx)).toEqual(nativeBefore);
+
+    const strictCtx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker, {
+      strictNoHostImports: true,
+    });
+    const strictBefore = allocationShape(strictCtx);
+    expect(() => materializePreparedAsyncHostAdapters(strictCtx, host.functions)).toThrow(
+      /host runtime on the wrong target/,
+    );
+    expect(allocationShape(strictCtx)).toEqual(strictBefore);
+
+    const linearCtx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker, { target: "linear" });
+    const linearBefore = allocationShape(linearCtx);
+    expect(() => materializePreparedAsyncHostAdapters(linearCtx, host.functions)).toThrow(
+      /host runtime on the wrong target/,
+    );
+    expect(allocationShape(linearCtx)).toEqual(linearBefore);
+
+    const nativeFirstHostCtx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker, {
+      semanticProviders: "native-first",
+    });
+    materializePreparedAsyncHostAdapters(nativeFirstHostCtx, host.functions);
+    expect(nativeFirstHostCtx.mod.imports).toHaveLength(ASYNC_HOST_ADAPTERS.length);
+  });
+
+  it("requires native drive reservation before frame lowering and resolves it without lazy allocation", () => {
+    const { unit } = fixture("-native-drive-reservation");
+    const fn = prepareForTarget(irFunction(unit), "standalone").functions[0]!;
+    const module = createEmptyModule();
+    module.types.push({ kind: "func", params: [{ kind: "externref" }], results: [{ kind: "externref" }] });
+    const existing = { name: fn.name, typeIdx: 0, locals: [], body: [], exported: true };
+    const ctx = createCodegenContext(module, {} as ts.TypeChecker, { standalone: true });
+    const before = allocationShape(ctx);
+    expect(() =>
+      lowerPreparedIrAsyncFunction(
+        ctx,
+        fn,
+        {
+          resolveFunc: () => {
+            throw new Error("native runtime must not resolve a host function");
+          },
+        },
+        existing,
+      ),
+    ).toThrow(/native drive runtime was not reserved/);
+    expect(allocationShape(ctx)).toEqual(before);
+    expect(() => getPreparedAsyncDrivePromiseTypeIdx(ctx)).toThrow(/not reserved/);
+
+    materializePreparedAsyncHostAdapters(ctx, [fn]);
+    const promiseTypeIdx = getPreparedAsyncDrivePromiseTypeIdx(ctx);
+    expect(promiseTypeIdx).toBeGreaterThanOrEqual(0);
+    expect(module.types[promiseTypeIdx]).toMatchObject({ kind: "struct", name: "$Promise" });
+  });
+
+  it("preserves frozen attachment evidence across the trusted extern-state copy-on-write pass", () => {
+    const { unit } = fixture("-extern-transform");
+    const fn = prepare(externStateIrFunction(unit)).functions[0]!;
+    expect(fn.asyncRuntime?.states[1]!.body[0]).not.toHaveProperty("provider");
+
+    const attached = attachIrExternSupport(fn);
+    expect(attached.asyncRuntime?.states[1]!.body[0]).toMatchObject({
+      kind: "extern.new",
+      provider: { binding: { kind: "import", module: "env", field: "Intl_ListFormat_new" } },
+    });
+    expect(Object.isFrozen(attached.asyncRuntime)).toBe(true);
+    expect(Object.isFrozen(attached.asyncRuntime?.states)).toBe(true);
+    expect(attached.asyncRuntime?.states.every((state) => Object.isFrozen(state))).toBe(true);
+    expect(attached.asyncRuntime?.states.every((state) => Object.isFrozen(state.body))).toBe(true);
+    expect(Object.isFrozen(attached.asyncRuntime?.states[1]!.body[0])).toBe(true);
+    expect(() =>
+      assertPreparedIrAsyncRuntimeCurrent(attached.unitId, attached.name, attached.asyncPlan, attached.asyncRuntime),
+    ).not.toThrow();
+
+    const mutable: IrFunction = {
+      ...attached,
+      asyncRuntime: {
+        ...attached.asyncRuntime!,
+        states: [...attached.asyncRuntime!.states],
+      },
+    };
+    const ctx = createCodegenContext(createEmptyModule(), {} as ts.TypeChecker);
+    const before = allocationShape(ctx);
+    expect(() => materializePreparedAsyncHostAdapters(ctx, [mutable])).toThrow(/mutable attachment/);
+    expect(allocationShape(ctx)).toEqual(before);
+  });
+
+  it("keeps backend consumers free of semantic-intent and global-provider rediscovery", () => {
+    for (const relative of ["../src/codegen/ir-async-runtime-adapters.ts", "../src/codegen/ir-async-frame.ts"]) {
+      const source = readFileSync(new URL(relative, import.meta.url), "utf8");
+      expect(source, relative).not.toContain(["runtime", "Intents"].join(""));
+      expect(source, relative).not.toContain(["ASYNC", "RUNTIME", "PROVIDERS"].join("_"));
+      if (relative.endsWith("ir-async-frame.ts")) expect(source, relative).not.toContain("ensureAsyncDriveRuntime");
+    }
   });
 
   it("materializes, reuses, and Program-ABI-plans all six imports before component sealing", () => {
@@ -317,18 +848,10 @@ describe("#4104 IR async plan runtime consumer", () => {
     const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
     const prepared = prepare(irFunction(unit));
 
-    const reversed = [
-      {
-        ...prepared.functions[0]!,
-        asyncRuntime: Object.freeze({
-          ...prepared.functions[0]!.asyncRuntime!,
-          adapters: Object.freeze([...prepared.functions[0]!.asyncRuntime!.adapters].reverse()),
-        }),
-      },
-    ];
-    materializePreparedAsyncHostAdapters(ctx, reversed);
+    const functions = [prepared.functions[0]!];
+    materializePreparedAsyncHostAdapters(ctx, functions);
     const typeCount = module.types.length;
-    materializePreparedAsyncHostAdapters(ctx, reversed);
+    materializePreparedAsyncHostAdapters(ctx, functions);
 
     expect(module.imports.map((imported) => `${imported.module}.${imported.name}`)).toEqual(
       ASYNC_HOST_ADAPTERS.map((adapter) => `${adapter.module}.${adapter.field}`),
@@ -339,7 +862,7 @@ describe("#4104 IR async plan runtime consumer", () => {
     const planned = planProgramAbiCallableImports(ctx);
     expect(planned.size).toBe(6);
     const report = derivePreparedComponentDependencies({
-      module: { functions: reversed },
+      module: { functions },
       terminalUnitIds: new Set([unit.id]),
       inventory,
       abi: {
@@ -351,7 +874,7 @@ describe("#4104 IR async plan runtime consumer", () => {
     expect(
       report.components[0]?.externalCallables.map((dependency) => dependency.structuralReferenceKey).sort(),
     ).toEqual(
-      reversed[0]!.asyncRuntime!.adapters.map((adapter) => irCallableBindingKey(adapter.target.binding)).sort(),
+      functions[0]!.asyncRuntime!.adapters.map((adapter) => irCallableBindingKey(adapter.target.binding)).sort(),
     );
     expect(report.components[0]?.externalCallables.every((dependency) => dependency.programAbiBindingId !== null)).toBe(
       true,
@@ -380,28 +903,29 @@ describe("#4104 IR async plan runtime consumer", () => {
 
     const first = adapters[0]!;
     const second = adapters[1]!;
-    reject(adapters.slice(1), /frozen adapter records/);
-    reject([first, first, ...adapters.slice(2)], /repeats adapter/);
-    reject([{ ...first, record: second.record }, ...adapters.slice(1)], /carries record/);
-    reject([{ ...first, capability: second.capability }, ...adapters.slice(1)], /carries record/);
-    reject([{ ...first, target: second.target }, ...adapters.slice(1)], /frozen import projection/);
+    reject(adapters.slice(1), /has 5 adapters; expected 6/);
+    reject([first, first, ...adapters.slice(2)], /detached adapter/);
+    reject([...adapters].reverse(), /detached adapter/);
+    reject([Object.freeze({ ...first, record: second.record }), ...adapters.slice(1)], /detached adapter/);
+    reject([Object.freeze({ ...first, capability: second.capability }), ...adapters.slice(1)], /detached adapter/);
+    reject([Object.freeze({ ...first, target: second.target }), ...adapters.slice(1)], /detached adapter/);
     reject(
       [
-        {
+        Object.freeze({
           ...first,
           record: {
             ...first.record,
             params: [...first.record.params],
             results: [...first.record.results],
           } as AsyncHostAdapter,
-        },
+        }),
         ...adapters.slice(1),
       ],
       /not the canonical catalog record/,
     );
   });
 
-  it("keeps import order and Program-ABI dependencies stable under function and attachment reordering", () => {
+  it("keeps import order and Program-ABI dependencies stable under function input traversal reordering", () => {
     const { inventory, units } = pairFixture();
     const prepared = prepareIrRuntimeManifest({
       functions: units.map((unit) => irFunction(unit)),
@@ -411,13 +935,7 @@ describe("#4104 IR async plan runtime consumer", () => {
     if (!prepared) throw new Error("missing paired async runtime manifest");
     const functions = [...prepared.functions].reverse().map((fn) => {
       if (fn.asyncRuntime?.kind !== "host-wasmgc") throw new Error("missing paired host runtime");
-      return {
-        ...fn,
-        asyncRuntime: Object.freeze({
-          ...fn.asyncRuntime,
-          adapters: Object.freeze([...fn.asyncRuntime.adapters].reverse()),
-        }),
-      };
+      return fn;
     });
     const module = createEmptyModule();
     const session = new ProgramAbiSession(inventory, module);


### PR DESCRIPTION
## Summary

- attach each prepared async owner to the exact authenticated frozen manifest provider objects and canonical backend requirements
- validate the complete multi-owner request census, target policy, ownership, referential joins, and immutable attachment containers before any codegen allocation
- reserve native async helpers only during materialization and expose a lookup-only Promise type index to frame lowering
- preserve immutable runtime evidence across intrinsic and extern copy-on-write transforms

Refs #3526 — IR-only R6: typed semantic runtime contract and frozen feature manifest.

## Validation

- focused runtime-manifest/provider/consumer authority plus extern controls: 43/43
- TypeScript 7 and TypeScript 5 typechecks
- IR layering, dialect, fallback, oracle, optimization-retirement, verdict-oracle, and vacuity-shape gates
- LOC and function regrowth ratchets immediately before commit
- complete precommit hooks: prettier, biome, both ratchets, 25/25 changed-root tests, oracle ratchet
- complete prepush hooks: typecheck/lint, format check, oracle/coercion ratchets, 18/18 numeric-local parity, issue integrity
- affected current-main parity unchanged: #2864 0/5 known exnref-opcode rows; #2895 5/8, #4574 0/14, #4106 6/7, #4167 7/8, and #4110 18/19 with the same known standalone WebAssembly.validate false rows

Signed head: a0dc3b9357bf2f4db6fc568561152e1feab3f763
Approved patch SHA-256: 3a0a97ab78732db9b5504b078bd42b0a6db5449d9fb3de96e31de05ef1a45ae7