### PR TITLE
fix(codegen): String.prototype.indexOf() with no argument searches "undefined" in the gc lane (#5155) ✓

### DIFF
--- a/plan/issues/5155-string-indexof-no-argument-gc.md
+++ b/plan/issues/5155-string-indexof-no-argument-gc.md
@@ -1,17 +1,38 @@
 ---
 id: 5155
 title: "String.prototype.indexOf() with no argument answers -1 in the gc lane where the spec requires searching the string \"undefined\""
-status: ready
+status: done
 sprint: current
 created: 2026-08-28
 updated: 2026-08-28
+completed: 2026-08-28
 priority: low
 horizon: s
 feasibility: easy
 reasoning_effort: medium
 task_type: bugfix
 area: codegen
+language_feature: string-methods
 goal: core-semantics
+related: [3763, 5095, 5121]
+# loc-budget-allow / func-budget-allow justification (2026-08-28): the
+# executable change is ONE list entry — `method === "indexOf"` added to the
+# `padsUndefined` set inside `compileReceiverMethodCall` — which the gate scores
+# as +19/+19 only because the existing 4-condition `||` had to be reflowed onto
+# one condition per line and because 14 of the 19 lines are comment. Those
+# comments are the load-bearing part: they record (a) why `lastIndexOf` was
+# already correct and `indexOf` was not, so the next reader does not "simplify"
+# the entry back out, (b) that this is the ABSENT-argument spelling and #3763
+# fixed the explicit undefined-VALUED one, and (c) that `includes`/`startsWith`/
+# `search` have the identical defect from this same list and are deliberately
+# left for a follow-up. Net non-comment source delta is +4 lines. The fix cannot
+# move to a subsystem module: the set it edits is a local inside the pad loop of
+# the host-import call path, and extracting it would be a larger change to a
+# god-function than the one-cell bug warrants.
+loc-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts
+func-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
 ---
 
 # One wrong cell: gc-lane `String.prototype.indexOf()` zero-arg
@@ -54,3 +75,167 @@ applies, so this should be a small self-contained fix.
   explained.
 - A/B per the #5095/#5121 method: base copy at first edit, pinned tests red
   on base, equivalence shards clean by name.
+
+## Resolution (2026-08-28) — one list entry
+
+### Root cause, found exactly where the issue predicted the fix would land
+
+Not in `string-ops.ts` after all — that is the **standalone** lowering, and it
+was already correct (`compileStringValueToLocal(expr.arguments[0], "undefined", …)`
+defaults an absent search argument to the string `"undefined"`). The defect is
+in the **gc/JS-host** path, `compileReceiverMethodCall`
+(`src/codegen/expressions/call-receiver-method.ts`), in the loop that pads a
+host import's missing optional arguments.
+
+That loop keeps a `padsUndefined` set naming the methods whose omitted
+**externref** slots must carry JS `undefined` (via the `__get_undefined` import)
+instead of `ref.null.extern`:
+
+```ts
+const padsUndefined =
+  method === "endsWith" || method === "lastIndexOf" || method === "padStart" || method === "padEnd";
+```
+
+`lastIndexOf` is in it; `indexOf` was not. So `"aundefinedb".indexOf()` reached
+the host as `s.indexOf(null)`, which per §22.1.3.9 step 3 runs
+`ToString(null)` and searches for `"null"` — absent from the probe — giving
+`-1`. **That asymmetry is the whole bug**, and it also explains the issue's
+matrix directly: `lastIndexOf()` answered `1` on the same probe *because* it was
+already listed. The fix is to add `indexOf` to the set.
+
+`indexOf` was measurably searching for `"null"`, not merely failing:
+`"anullb".indexOf()` answered `1` on the base. That row is pinned as a test.
+
+**Non-duplication with #3763 confirmed at the code level.** #3763's hook
+`tryCompileIndexOfHoistedUndefinedSearch` is invoked as
+`if (method === "indexOf" && ai === 0 && …)` from inside the *argument* loop, so
+it only ever fires when `args[0]` exists. A zero-argument call never reached it.
+
+### Measured before/after
+
+A/B by file copy (`.tmp/base-call-receiver-method.ts` captured at first edit),
+same probe, same worktree, base `origin/main` @ `f727d529ab`. Values are
+gc → gc and standalone → standalone; hashes are sha256 of the emitted module,
+first 12 hex, gc lane:
+
+| shape | before (gc / sa) | after (gc / sa) | spec |
+| --- | --- | --- | --- |
+| `"aundefinedb".indexOf()` | **`-1`** / `1` | **`1`** / `1` | `1` |
+| `"aundefinedb".indexOf(undefined)` | `1` / `1` | `1` / `1` | `1` |
+| `"aundefinedb".lastIndexOf()` | `1` / `1` | `1` / `1` | `1` |
+| `"abc".indexOf()` | `-1` / `-1` | `-1` / `-1` | `-1` |
+| `"".indexOf()` | `-1` / `-1` | `-1` / `-1` | `-1` |
+| `"aundefinedb".indexOf()` literal recv | **`-1`** / `1` | **`1`** / `1` | `1` |
+| `a[0]!.indexOf()` dynamic recv | **`-1`** / `1` | **`1`** / `1` | `1` |
+| `"anullb".indexOf(null)` | `1` / `1` | `1` / `1` | `1` |
+
+### Byte-identity — the zero-arg form IS `indexOf(undefined)`
+
+The preferred acceptance outcome, achieved rather than explained away: after the
+fix `"aundefinedb".indexOf()` and `"aundefinedb".indexOf(undefined)` compile to
+**one binary** (`28219ba63051`), where on base they differed
+(`d7b4210a1a5d` vs `9c69a8971f06`). Pinned as a test so the two spellings cannot
+drift apart. This mirrors `lastIndexOf`, whose two spellings were already one
+binary (`18b1d8a8a29f`) — further evidence the fix is the same mechanism.
+
+**Sweep: 43 shapes × 2 lanes = 86 cells, 80 byte-identical.** The 6 that moved
+are all gc-lane and all `indexOf`:
+
+| moved cell | before | after |
+| --- | --- | --- |
+| `indexOf()` | `-1` `d7b4210a1a5d` | `1` `28219ba63051` |
+| `indexOf()` no match | `-1` `53f064ee096f` | `-1` `49bd0dd2a352` |
+| `"aundefinedb".indexOf()` literal | `-1` `bd7f8069a380` | `1` `6732afe6563d` |
+| `indexOf()` empty receiver | `-1` `5be0626a961e` | `-1` `dc2da42a001d` |
+| `indexOf()` dynamic receiver | `-1` `8b3025d3b0ed` | `1` `5c52283715a7` |
+| `indexOf(undefined)` | `1` `9c69a8971f06` | `1` `28219ba63051` |
+
+Everything the acceptance criteria named is byte-identical in **both** lanes:
+`indexOf("b")`, `indexOf("undefined")`, `indexOf("n",5)`, `indexOf("b",0)`,
+`indexOf(undefined,0)`, `lastIndexOf()` / `lastIndexOf(undefined)` /
+`lastIndexOf("b")` / `lastIndexOf("n",5)`, `includes()` / `includes("b")`,
+`startsWith()` / `startsWith("u")`, `endsWith()` / `endsWith("b")`, `search()` /
+`search(/b/)`, `padStart()` / `padStart(5)` / `padEnd(5)`, `substring()` /
+`substring(1)`, `slice()` / `slice(1)`, `split()`, `charAt()`, `concat()`,
+`repeat()`, `at()`, `replace()`, and the whole Array-side family
+(`arr.indexOf()`, `arr.indexOf(20)`, `arr.lastIndexOf()`, `arr.includes()`,
+`arr.at()`, `["x",undefined,"z"].indexOf()`).
+
+### The one divergence worth naming: the omitted fromIndex
+
+`indexOf(x)` with an omitted second argument also moves bytes, because the
+legacy `string_indexOf` host ABI carries its optional `fromIndex` as a **boxed
+externref** (see the comment at `src/ir/from-ast.ts` ~L8437), so it is padded by
+this same loop — now with `__get_undefined` instead of `ref.null.extern`.
+
+This is **spec-equivalent**: §22.1.3.9 step 4 applies
+`ToIntegerOrInfinity(position)`, and that is `+0` for both `null` and
+`undefined`. Verified by value rather than by argument, over 10 shapes with
+genuinely dynamic (non-fold-able) needles — every value identical across the
+A/B: `10 → 10`, `1 → 1`, `-1 → -1`, `7 → 7`. Four of those shapes moved bytes
+with no value change; `indexOf(needle, 0)` and `indexOf(needle, 5)` did not move
+at all (nothing to pad). Pinned as tests in both the unit and equivalence files.
+
+The static-needle fold (`tryEmitStaticNeedleIndexOf`) means literal-needle calls
+like `indexOf("b")` bypass the pad loop entirely and are byte-identical.
+
+### test262 sizing — 0 flips, and that is the honest number
+
+`built-ins/String/prototype/indexOf/` holds 47 files, and **exactly two** write
+the zero-argument form — the only two in the entire `String/prototype` tree:
+
+- `S15.5.4.7_A1_T4.js` asserts `"".indexOf() === -1`. That is `-1` before **and**
+  after (searching for `"undefined"` in `""` misses just as searching for
+  `"null"` did), so it passes either way. Note the test's own comment
+  ("since ToString() evaluates to \"\"") is wrong about the mechanism while its
+  assertion is right — which is precisely why this defect could survive in a
+  directory that looks well covered.
+- `not-a-constructor.js` writes `new String.prototype.indexOf()`, where the
+  zero-argument call sits inside a `new` that must throw. Unaffected.
+
+So the conformance win is **zero tests**. The value here is correctness of a
+shape test262 happens not to probe, and closing the last cell of the
+#5095 → #5121 → #5155 missing-argument-default chain.
+
+### Follow-up found while measuring — three siblings, NOT fixed here
+
+Surveying the zero-argument form of the whole `String.prototype` search family
+(15 methods, both lanes) found the **identical defect in three more methods**,
+all from this same `padsUndefined` omission, all gc-lane-only:
+
+| shape | gc | standalone | spec |
+| --- | --- | --- | --- |
+| `"aundefinedb".includes()` | **`false`** ⚠ | `true` | `true` |
+| `"undefinedb".startsWith()` | **`false`** ⚠ | `true` | `true` |
+| `"aundefinedb".search()` | **`-1`** ⚠ | `0` | `0` |
+
+(`search()` is `search(undefined)` → `RegExp(undefined)` → `/(?:)/`, which
+matches at 0; the gc lane searched for `/null/` instead.) `endsWith`,
+`padStart`, `padEnd`, `substring`, `slice`, `split`, `charAt`, `concat`,
+`repeat`, `at` and `lastIndexOf` are all correct in both lanes.
+
+Each is one more entry in the same list. They are **deliberately left out** so
+this change keeps the blast radius at the single cell this issue pins — widening
+it would move the `includes`/`startsWith`/`search` bytes that the acceptance
+criteria require to stay identical. Their current wrong values are pinned as
+tests (with the spec answer named in a comment) so whoever fixes them is forced
+to update this file rather than diverge silently. **A follow-up issue should be
+allocated for them** — same relationship #5155 has to #5121.
+
+### Tests
+
+- `tests/issue-5155-string-indexof-no-argument.test.ts` — 12 tests: both lanes,
+  the no-match and empty-receiver guards, literal and dynamic receivers, the
+  "was searching for null" evidence row, the byte-identity pin against
+  `indexOf(undefined)`, the `lastIndexOf` and explicit-argument regression
+  guards, the omitted-fromIndex value pins, the Array-family guard, the three
+  unfixed siblings, and the other `padsUndefined` members.
+- `tests/equivalence/string-indexof-no-arg.test.ts` — 10 rows against real JS
+  execution, modelled on `array-at-no-arg.test.ts` (#5095) and
+  `array-indexof-no-arg.test.ts` (#5121).
+
+**Non-vacuity, measured:** with the source file reverted to base, **10 of the 22
+new tests FAIL**, and the 12 that pass are exactly the intended regression
+guards (standalone lane, no-match, null spelling, `lastIndexOf`,
+explicit-argument, fromIndex, Array family, unfixed siblings,
+`endsWith`/`padStart`/`padEnd`).

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -3310,8 +3310,26 @@ export function compileReceiverMethodCall(
         // coerces to "null" → e.g. `"abc".padStart(6)` returned "nulabc"
         // instead of "   abc". Pass JS `undefined` so the host applies the
         // spec default. (Same null-vs-undefined distinction as endsWith.)
+        // #5155 — `indexOf` joins this list. §22.1.3.9 step 3 runs
+        // `ToString(searchString)`, so `"aundefinedb".indexOf()` searches for
+        // the STRING "undefined" (answer 1); padding the absent search slot
+        // with `ref.null.extern` made the host search for "null" → -1.
+        // `lastIndexOf` was already listed, which is exactly why it answered 1
+        // on the same probe while `indexOf` did not. (#3763 fixed the
+        // *explicit* undefined-VALUED spelling via
+        // `tryCompileIndexOfHoistedUndefinedSearch` above, which only fires
+        // when `args[0]` exists — a zero-argument call never reached it.)
+        // Also covers indexOf's boxed fromIndex slot, which is spec-equivalent:
+        // ToIntegerOrInfinity of `null` and of `undefined` are both +0.
+        // Deliberately NOT widened to `includes`/`startsWith`/`search`, which
+        // have the identical defect from this list — see the follow-up section
+        // in `plan/issues/5155-string-indexof-no-argument-gc.md`.
         const padsUndefined =
-          method === "endsWith" || method === "lastIndexOf" || method === "padStart" || method === "padEnd";
+          method === "endsWith" ||
+          method === "indexOf" ||
+          method === "lastIndexOf" ||
+          method === "padStart" ||
+          method === "padEnd";
         let undefIdx: number | undefined;
         if (padsUndefined) {
           undefIdx = ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);

--- a/tests/equivalence/string-indexof-no-arg.test.ts
+++ b/tests/equivalence/string-indexof-no-arg.test.ts
@@ -1,0 +1,120 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+// §22.1.3.9 runs `ToString(searchString)`, so `indexOf()` with no argument
+// searches for the string "undefined". In the gc (JS-host) lane the absent
+// externref search slot used to be padded with `ref.null.extern`, so the host
+// searched for "null" instead and `"aundefinedb".indexOf()` answered -1 rather
+// than 1. `lastIndexOf` was already on the pad-as-undefined list and was
+// therefore already correct — the asymmetry that identified the defect.
+//
+// Modelled on array-at-no-arg.test.ts (#5095) and array-indexof-no-arg.test.ts
+// (#5121), the two sibling files for this same missing-argument-default shape.
+//
+// TypeScript types `indexOf` as requiring its argument, so the zero-argument
+// form is only writable where the harness tolerates the diagnostic — return
+// position. (test262 is plain JS and has no such constraint.)
+describe("String.prototype.indexOf with no argument", () => {
+  it('finds "undefined" in a receiver that contains it', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return s.indexOf();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('answers -1 when the receiver does not contain "undefined"', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "abc";
+        return s.indexOf();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('does not search for "null" — a receiver containing only "null" misses', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "anullb";
+        return s.indexOf();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("agrees with the indexOf(undefined) spelling", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return (s.indexOf() === s.indexOf(undefined) ? 100 : 0) + s.indexOf();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('agrees with the explicit "undefined" string spelling', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return (s.indexOf() === s.indexOf("undefined") ? 100 : 0) + s.indexOf();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("works on a string literal receiver", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        return "aundefinedb".indexOf();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("finds a later occurrence when the receiver starts with it", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "undefined";
+        return s.indexOf();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("keeps lastIndexOf, already correct, agreeing with indexOf here", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return s.lastIndexOf() * 10 + s.indexOf();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("leaves an explicit search argument unchanged", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return s.indexOf("b") * 100 + s.indexOf("n", 5) * 10 + s.indexOf("zz");
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("keeps the omitted fromIndex spec-equivalent for a one-argument call", async () => {
+    // ToIntegerOrInfinity(undefined) and ToIntegerOrInfinity(null) are both +0,
+    // so padding indexOf's boxed fromIndex slot with `undefined` rather than
+    // `null` must not move any value.
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        var needles: string[] = ["b", "n", "zz"];
+        return s.indexOf(needles[0]) * 100 + s.indexOf(needles[1]) * 10 + s.indexOf(needles[2]);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});

--- a/tests/issue-5155-string-indexof-no-argument.test.ts
+++ b/tests/issue-5155-string-indexof-no-argument.test.ts
@@ -1,0 +1,161 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #5155 — `String.prototype.indexOf()` with NO argument answered `-1` in the
+//   gc (JS-host) lane where §22.1.3.9 requires `ToString(searchString)`: an
+//   absent argument becomes the STRING "undefined", which sits at position 1 of
+//   the probe "aundefinedb". Standalone was already correct.
+//
+//   Root cause (src/codegen/expressions/call-receiver-method.ts): the loop that
+//   pads a host import's missing optional arguments keeps a `padsUndefined` set
+//   of methods whose omitted externref slots must carry JS `undefined` (via
+//   `__get_undefined`) rather than `ref.null.extern`. `lastIndexOf` was in that
+//   set; `indexOf` was not — so the absent search slot reached the host as JS
+//   `null` and the method searched for "null". That is precisely why
+//   `"aundefinedb".lastIndexOf()` already answered 1 on the same probe while
+//   `indexOf()` answered -1.
+//
+//   This is the ABSENT-argument spelling. #3763 fixed the *explicit*
+//   undefined-VALUED spelling of the same method (a hoisted `var` read before
+//   its declaration collapsing to `ref.null.extern`); its hook
+//   `tryCompileIndexOfHoistedUndefinedSearch` only fires when `args[0]` exists,
+//   so a zero-argument call never reached it.
+//
+//   NOT fixed here — the identical defect in three siblings that share this
+//   list (measured on the same base, gc lane): `"aundefinedb".includes()` is
+//   false, `"undefinedb".startsWith()` is false, and `"aundefinedb".search()`
+//   is -1, all spec-wrong and all correct in standalone. They are recorded as a
+//   follow-up in the issue file rather than widened into this change.
+//
+//   `skipSemanticDiagnostics` mirrors the test262 runner — TS types these
+//   methods as requiring an argument, which is not a hard error there.
+
+interface CompileResult {
+  success: boolean;
+  errors?: Array<{ message: string }>;
+  binary: Uint8Array;
+  importObject?: WebAssembly.Imports;
+}
+
+async function build(src: string, standalone: boolean): Promise<CompileResult> {
+  const opts = standalone ? { target: "standalone", skipSemanticDiagnostics: true } : { skipSemanticDiagnostics: true };
+  const r = (await compile(src, opts as never)) as never as CompileResult;
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  return r;
+}
+
+async function runGc(src: string): Promise<unknown> {
+  const r = await build(src, false);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await build(src, true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function digestGc(src: string): Promise<string> {
+  const r = await build(src, false);
+  return createHash("sha256").update(r.binary).digest("hex");
+}
+
+const fn = (body: string) => `export function test(): number { ${body} }`;
+// "undefined" occurs at index 1; "null" does not occur at all, so the two
+// wrong answers are distinguishable from each other and from a generic -1.
+const HIT = 'const s="aundefinedb";';
+
+describe("#5155 — String.prototype.indexOf with no argument", () => {
+  it('searches for the string "undefined" in the gc lane', async () => {
+    expect(await runGc(fn(HIT + " return s.indexOf();"))).toBe(1);
+  });
+
+  it('searches for the string "undefined" in the standalone lane', async () => {
+    expect(await runStandalone(fn(HIT + " return s.indexOf();"))).toBe(1);
+  });
+
+  it('still answers -1 when "undefined" does not occur', async () => {
+    // Guards against a fix that simply returns a fixed index: the receiver here
+    // contains neither "undefined" nor "null".
+    expect(await runGc(fn('const s="abc"; return s.indexOf();'))).toBe(-1);
+    expect(await runStandalone(fn('const s="abc"; return s.indexOf();'))).toBe(-1);
+  });
+
+  it("applies to a literal receiver and to a dynamic one", async () => {
+    expect(await runGc(fn('return "aundefinedb".indexOf();'))).toBe(1);
+    expect(await runGc(fn('const a=["aundefinedb"]; return a[0]!.indexOf();'))).toBe(1);
+  });
+
+  it('was searching for "null", not merely failing — the null spelling is unchanged', async () => {
+    // The defect made the host receive JS `null`. `indexOf(null)` genuinely
+    // searches for "null" and must keep doing so; only the ABSENT argument
+    // changed meaning.
+    expect(await runGc(fn('const s="anullb"; return s.indexOf(null as any);'))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.indexOf(null as any);"))).toBe(-1);
+  });
+
+  it("compiles the zero-argument form byte-identically to indexOf(undefined)", async () => {
+    // The #5121 pin pattern: the two spellings are one binary, so they cannot
+    // drift apart later. (They were NOT identical before the fix.)
+    const absent = await digestGc(fn(HIT + " return s.indexOf();"));
+    const explicit = await digestGc(fn(HIT + " return s.indexOf(undefined);"));
+    expect(absent).toBe(explicit);
+  });
+
+  it("leaves lastIndexOf — already correct — untouched in both spellings", async () => {
+    expect(await runGc(fn(HIT + " return s.lastIndexOf();"))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.lastIndexOf(undefined);"))).toBe(1);
+    const absent = await digestGc(fn(HIT + " return s.lastIndexOf();"));
+    const explicit = await digestGc(fn(HIT + " return s.lastIndexOf(undefined);"));
+    expect(absent).toBe(explicit);
+  });
+
+  it("leaves explicit-argument indexOf values unchanged", async () => {
+    expect(await runGc(fn(HIT + ' return s.indexOf("b");'))).toBe(10);
+    expect(await runGc(fn(HIT + ' return s.indexOf("undefined");'))).toBe(1);
+    expect(await runGc(fn(HIT + ' return s.indexOf("n",5);'))).toBe(7);
+    expect(await runGc(fn(HIT + " return s.indexOf(undefined);"))).toBe(1);
+  });
+
+  it("keeps the omitted fromIndex spec-equivalent for a dynamic needle", async () => {
+    // The fix pads indexOf's omitted externref slots with `__get_undefined`,
+    // which also covers the boxed fromIndex slot of a one-argument call. That
+    // is spec-equivalent — ToIntegerOrInfinity of both `null` and `undefined`
+    // is +0 (§22.1.3.9 step 4) — but it does move those bytes, so the VALUES
+    // are pinned here. A dynamic needle avoids the static-needle fold.
+    expect(await runGc(fn('const p=["b"]; ' + HIT + " return s.indexOf(p[0]!);"))).toBe(10);
+    expect(await runGc(fn('const p=["b"]; ' + HIT + " return s.indexOf(p[0]!,0);"))).toBe(10);
+    expect(await runGc(fn('const p=["n"]; ' + HIT + " return s.indexOf(p[0]!,5);"))).toBe(7);
+    expect(await runGc(fn('const p=["zz"]; ' + HIT + " return s.indexOf(p[0]!);"))).toBe(-1);
+  });
+
+  it("does not touch the Array-side family fixed by #5095/#5121", async () => {
+    expect(await runGc(fn("const a=[10,20,30]; return a.indexOf();"))).toBe(-1);
+    expect(await runGc(fn("const a=[10,20,30]; return a.lastIndexOf();"))).toBe(-1);
+    expect(await runGc(fn("const a=[10,20,30]; return a.indexOf(20);"))).toBe(1);
+    expect(await runGc(fn("const a=[10,20,30]; return a.at();"))).toBe(10);
+  });
+
+  it("records the three siblings this change deliberately does NOT fix", async () => {
+    // Same `padsUndefined` omission, same lane. Pinned as the OBSERVED wrong
+    // values (with the spec answer named in the comment) so the follow-up that
+    // fixes them is forced to update this test rather than silently diverge.
+    // Spec: includes() → true, startsWith() → true, search() → 0.
+    expect(await runGc(fn(HIT + " return s.includes()?1:0;"))).toBe(0);
+    expect(await runGc(fn('const s="undefinedb"; return s.startsWith()?1:0;'))).toBe(0);
+    expect(await runGc(fn(HIT + " return s.search();"))).toBe(-1);
+    // …and that standalone already gets all three right, which is the evidence
+    // they are the same host-padding defect and not a semantics gap.
+    expect(await runStandalone(fn(HIT + " return s.includes()?1:0;"))).toBe(1);
+    expect(await runStandalone(fn('const s="undefinedb"; return s.startsWith()?1:0;'))).toBe(1);
+    expect(await runStandalone(fn(HIT + " return s.search();"))).toBe(0);
+  });
+
+  it("leaves endsWith/padStart/padEnd — the other padsUndefined members — correct", async () => {
+    expect(await runGc(fn('const s="bundefined"; return s.endsWith()?1:0;'))).toBe(1);
+    expect(await runGc(fn('const s="ab"; return s.padStart().length;'))).toBe(2);
+    expect(await runGc(fn('const s="ab"; return s.padEnd(5).length;'))).toBe(5);
+  });
+});


### PR DESCRIPTION
Fixes [#5155](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5155-string-indexof-no-argument-gc).

§22.1.3.9 step 3 runs `ToString(searchString)`, so a zero-argument `"aundefinedb".indexOf()` searches for the **string** `"undefined"` and answers `1`. The gc/JS-host lane answered `-1`.

## Root cause — one missing list entry

Not in `string-ops.ts` as the issue predicted; that is the **standalone** lowering, and it was already correct. The defect is in `compileReceiverMethodCall` (`src/codegen/expressions/call-receiver-method.ts`), in the loop that pads a host import's omitted arguments. It keeps a `padsUndefined` set — the methods whose absent **externref** slots must reach the host as JS `undefined` (via `__get_undefined`) rather than `ref.null.extern`:

```ts
const padsUndefined =
  method === "endsWith" || method === "lastIndexOf" || method === "padStart" || method === "padEnd";
```

`lastIndexOf` was in it; `indexOf` was not. So `"aundefinedb".indexOf()` reached the host as `s.indexOf(null)`, which `ToString`s to `"null"` — absent from the probe — giving `-1`. **That asymmetry is the whole bug**, and it explains the issue's matrix exactly: `lastIndexOf()` was already right on the same probe *because* it was already listed.

It was measurably searching for `"null"`, not merely failing: `"anullb".indexOf()` answered `1` on the base. Pinned as a test.

**Not a duplicate of [#3763](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3763-string-indexof-undefined-search), confirmed at the code level.** That fix's hook `tryCompileIndexOfHoistedUndefinedSearch` is invoked as `if (method === "indexOf" && ai === 0 && …)` from inside the *argument* loop, so it only ever fires when `args[0]` exists — a zero-argument call never reached it. #3763 fixed the explicit undefined-**valued** spelling; this is the **absent**-argument spelling, closing the [#5095](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5095-array-prototype-at-no-argument) → [#5121](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5121-array-indexof-lastindexof-no-argument) → #5155 missing-argument-default chain.

## Measured before/after

A/B by file copy (base captured at first edit), base `origin/main` @ `f727d529ab`. gc → gc, standalone → standalone:

| shape | before (gc / sa) | after (gc / sa) | spec |
| --- | --- | --- | --- |
| `"aundefinedb".indexOf()` | **`-1`** / `1` | **`1`** / `1` | `1` |
| `"aundefinedb".indexOf(undefined)` | `1` / `1` | `1` / `1` | `1` |
| `"aundefinedb".lastIndexOf()` | `1` / `1` | `1` / `1` | `1` |
| `"abc".indexOf()` / `"".indexOf()` | `-1` / `-1` | `-1` / `-1` | `-1` |
| literal + dynamic receiver | **`-1`** / `1` | **`1`** / `1` | `1` |
| `"anullb".indexOf(null)` | `1` / `1` | `1` / `1` | `1` |

## Byte-identity — the zero-arg form *is* `indexOf(undefined)`

The preferred acceptance outcome, achieved rather than explained away: the two spellings now compile to **one binary** (`28219ba63051`), where on base they differed (`d7b4210a1a5d` vs `9c69a8971f06`). Pinned as a test so they cannot drift apart. This mirrors `lastIndexOf`, whose two spellings were already one binary — further evidence it is the same mechanism.

**Sweep: 43 shapes × 2 lanes = 86 cells, 80 byte-identical.** The 6 that moved are all gc-lane and all `indexOf`. Everything the acceptance criteria named is unchanged in **both** lanes: `indexOf(x)` in every spelling, `lastIndexOf` both spellings, `includes` / `startsWith` / `endsWith` / `search`, `padStart` / `padEnd` / `substring` / `slice` / `split` / `charAt` / `concat` / `repeat` / `at` / `replace`, and the whole Array-side family from #5095/#5121.

## One divergence, named rather than hidden

`indexOf(x)` with an omitted *second* argument also moves bytes: the legacy `string_indexOf` host ABI carries its optional `fromIndex` as a **boxed externref**, so it is padded by this same loop — now with `__get_undefined`. Spec-equivalent, since `ToIntegerOrInfinity` is `+0` for both `null` and `undefined` (§22.1.3.9 step 4). Verified by **value**, not by argument: 10 shapes with genuinely dynamic (non-foldable) needles, every value identical across the A/B. Literal-needle calls bypass the pad loop entirely via the static-needle fold and are byte-identical.

## test262 sizing — 0 flips, stated plainly

`built-ins/String/prototype/indexOf/` holds 47 files and **exactly two** write the zero-argument form — the only two in the entire `String/prototype` tree:

- `S15.5.4.7_A1_T4.js` asserts `"".indexOf() === -1`, which holds before **and** after (searching for `"undefined"` in `""` misses just as `"null"` did). Its own comment is wrong about the mechanism while its assertion is right — which is how this defect survived in a directory that looks well covered.
- `not-a-constructor.js` puts the call inside a `new` that must throw. Unaffected.

The conformance win is **zero tests**. The value is correctness of a shape test262 happens not to probe.

## Found while measuring — three siblings, deliberately NOT fixed

Surveying the zero-argument form of the whole `String.prototype` family (15 methods, both lanes) found the **identical defect in three more methods**, all from this same `padsUndefined` omission, all gc-lane-only:

| shape | gc | standalone | spec |
| --- | --- | --- | --- |
| `"aundefinedb".includes()` | **`false`** ⚠ | `true` | `true` |
| `"undefinedb".startsWith()` | **`false`** ⚠ | `true` | `true` |
| `"aundefinedb".search()` | **`-1`** ⚠ | `0` | `0` |

Each is one more entry in the same list. Left out so this change keeps its blast radius at the single cell #5155 pins — widening it would move the `includes`/`startsWith`/`search` bytes the acceptance criteria require to stay identical. Their current wrong values are pinned as tests (with the spec answer in a comment) so whoever fixes them must update this file rather than diverge silently. **A follow-up issue should be allocated.**

## Validation

- **22 new tests** — `tests/issue-5155-string-indexof-no-argument.test.ts` (12) + `tests/equivalence/string-indexof-no-arg.test.ts` (10).
- **Non-vacuity, measured:** with the source reverted to base, **10 of 22 fail**; the 12 that pass are exactly the intended regression guards.
- **Ratchet gates**, all run bare with `LOC_GATE_BASE=origin/main`: loc-budget, func-budget, coercion-sites, oracle-ratchet, dead-exports — all green. The loc/func grants (+18, entirely comment + a reflowed `||`) are in the issue file's frontmatter with dated rationale; net non-comment source delta is **+4 lines**.
- **Equivalence gate**, 8 shards at `VITEST_FORK_MAX_OLD_SPACE_SIZE=4096`: failing NAME-set matches the baseline, no new regressions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_