### PR TITLE
docs(issues): file #5160/#5161/#5162 from wave-6 findings; #4406 third-site record

### DIFF
--- a/plan/issues/4406-return-type-unboxing-abi.md
+++ b/plan/issues/4406-return-type-unboxing-abi.md
@@ -1416,3 +1416,12 @@ zero newly-fixed, so the failing NAME set is unchanged.
   phases at once.** That is deliberate (they compose, and Phase 4's filter is
   unsound to enable without Phase 1's arm), but it means a future bisect of any
   one half needs a finer switch added first.
+- **A third boolean site the Phase 4 filter deliberately leaves alone
+  (2026-08-28, PR #5171):** `var f = this.pred(x); "" + f` still reads `"1"` —
+  the prover's *internal* call arm consumes `numericFunctionNames` before the
+  publication-boundary filter runs. Fixable only by the measured-and-rejected
+  loop variant, at **+51,252 executed `__box_boolean` (+19.9 %)** on the acorn
+  self-parse; taking that trade is a deliberate future decision, not a rider.
+  The property-write form of the same shape is already correct via #2847's
+  boolean brand. (The unrelated constructor→own-prototype-method trap found by
+  the same probe set is filed as #5162.)

--- a/plan/issues/5155-string-indexof-no-argument-gc.md
+++ b/plan/issues/5155-string-indexof-no-argument-gc.md
@@ -18,7 +18,8 @@ related: [3763, 5095, 5121]
 # loc-budget-allow / func-budget-allow justification (2026-08-28): the
 # executable change is ONE list entry — `method === "indexOf"` added to the
 # `padsUndefined` set inside `compileReceiverMethodCall` — which the gate scores
-# as +19/+19 only because the existing 4-condition `||` had to be reflowed onto
+# as +19 ins/−1 del (net +18) only because the existing 4-condition `||` had to
+# be reflowed onto
 # one condition per line and because 14 of the 19 lines are comment. Those
 # comments are the load-bearing part: they record (a) why `lastIndexOf` was
 # already correct and `indexOf` was not, so the next reader does not "simplify"

--- a/plan/issues/5160-padsundefined-siblings-includes-startswith-search.md
+++ b/plan/issues/5160-padsundefined-siblings-includes-startswith-search.md
@@ -1,0 +1,53 @@
+---
+id: 5160
+title: "includes()/startsWith()/search() with no argument are wrong in the gc lane — the same padsUndefined omission #5155 fixed for indexOf"
+status: ready
+sprint: current
+created: 2026-08-28
+updated: 2026-08-28
+priority: low
+horizon: s
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: string-methods
+goal: core-semantics
+related: [5155, 3763]
+---
+
+# Three more one-entry fixes in the `padsUndefined` set
+
+Found during #5155 (PR #5168), which surveyed the zero-argument form of the
+whole `String.prototype` family (15 methods, both lanes). Three more methods
+carry the identical defect — the omitted externref argument slot reaches the
+host as `ref.null.extern` (JS `null`) instead of `undefined`, so the host
+coerces the wrong search value. All gc-lane-only; standalone is correct:
+
+| shape | gc (measured) | standalone | spec |
+| --- | --- | --- | --- |
+| `"aundefinedb".includes()` | **false** | `true` | `true` |
+| `"undefinedb".startsWith()` | **false** | `true` | `true` |
+| `"aundefinedb".search()` | **-1** | `0` | `0` |
+
+Each fix is one more entry in the `padsUndefined` set inside
+`compileReceiverMethodCall` (`src/codegen/expressions/call-receiver-method.ts`)
+— the exact change PR #5168 made for `indexOf`, whose record documents the
+mechanism and the evidence pattern to reuse.
+
+**The current wrong values are PINNED as tests** in
+`tests/issue-5155-string-indexof-no-argument.test.ts` (with the spec answers in
+comments) so the behavior cannot drift silently — the fix MUST update those
+pins to the spec values.
+
+Note for `search()`: §22.1.3.19 routes through `RegExp(undefined)` = an empty
+regexp matching at 0, not `ToString`; verify the host arm actually receives
+`undefined` and produces `0` before assuming the same one-entry shape suffices.
+
+## Acceptance criteria
+
+- The three shapes answer the spec values in the gc lane; standalone unchanged.
+- The #5168 pins updated; byte-identity for every other `String.prototype`
+  shape in both lanes (reuse the #5168 43-shape sweep).
+- A/B per the established method; pinned tests red on base; equivalence shards
+  clean by name.

--- a/plan/issues/5161-nativestrings-fast-error-options-toprimitive.md
+++ b/plan/issues/5161-nativestrings-fast-error-options-toprimitive.md
@@ -1,0 +1,47 @@
+---
+id: 5161
+title: "nativeStrings and fast host configs throw on new Error(msg, {cause}) — opaque-struct ToPrimitive at the constructor boundary"
+status: ready
+sprint: current
+created: 2026-08-28
+updated: 2026-08-28
+priority: low
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+goal: core-semantics
+related: [5159, 3481]
+---
+
+# Two host configs still throw where the default host now succeeds
+
+Measured during #5159 (PR #5169) via file-copy A/B — **pre-existing**,
+identical before and after that fix:
+
+| host config | `new Error("m", {cause: c})` |
+| --- | --- |
+| default | works (fixed by #5169: `e.cause === c`) |
+| `nativeStrings` | **TypeError: Cannot convert object to primitive value** |
+| `fast` | **TypeError: Cannot convert object to primitive value** |
+
+Same defect class as #3481 cause-2 (fixed for the default host in PR #5161's
+`_errorMessageToString`): a WasmGC struct crosses the host boundary opaquely
+and V8's own coercion cannot introspect it. In these two configs the throw
+happens before #5159's `__error_install_cause` companion can run, so the whole
+construction fails rather than merely dropping `cause`.
+
+Start by measuring WHICH boundary throws in each config (the ctor's message
+slot, the options slot, or the companion import) — the two configs may differ.
+The #3481 cause-2 record (`plan/issues/3481-bigint-symbol-coercion-value-rep.md`)
+and the #5159 resolution record document the walker rules
+(`_hostToPrimitive` "found nothing" sentinels, the refused-NUMBER rule) any fix
+must not violate.
+
+## Acceptance criteria
+
+- `new Error("m", {cause: c}).cause === c` in `nativeStrings` and `fast`
+  configs; the #5159 (30) and #3481 cause-2 (37) suites stay green.
+- Byte-identity for option-less Error constructions in all configs.
+- A/B with base at first edit; pinned tests red on base; equivalence clean.

--- a/plan/issues/5162-prototype-method-from-own-constructor-trap.md
+++ b/plan/issues/5162-prototype-method-from-own-constructor-trap.md
@@ -1,0 +1,52 @@
+---
+id: 5162
+title: "A prototype method called from its own constructor traps at runtime — plain numeric callee, all five boolean-ABI lanes, pre-existing"
+status: ready
+sprint: current
+created: 2026-08-28
+updated: 2026-08-28
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+goal: core-semantics
+related: [4406, 4405]
+---
+
+# Constructor → own prototype method call traps
+
+Found as a control during #4406 Phase 4 (PR #5171) and verified **unrelated to
+that issue**: the failing callee is a plain numeric method, and the trap
+reproduces identically on base in all five boolean-ABI lanes
+(`JS2WASM_RET_UNBOX_ABI` on/off, `NUMERIC_TWINS=0`, `DIRECT_CALLS=0`,
+`NUMERIC_OPERANDS=0`), so no #4406 switch reaches it.
+
+Shape (from the Phase 4 probe set):
+
+```js
+function PP(x) { this.v = this.twice(x); }   // calls own prototype method
+PP.prototype.twice = function (x) { return x + x; };
+new PP(5);                                    // traps at runtime
+```
+
+The likely mechanism (unverified — the dispatched fix must establish it): at
+the point the constructor body compiles, the prototype assignment has not been
+processed, so the method-call lowering resolves against an incomplete
+class/prototype view — the same family as #5096's scope-blind `ctx.classSet`,
+but for compile-order rather than scope.
+
+First step is a minimal repro matrix: method defined before vs after the
+constructor in source order, `class` syntax vs prototype-assignment syntax,
+gc vs standalone. That decides whether this is an ordering bug (fixable) or a
+structural gap in the fnctor model (then route to the #3521/codex lane and
+record — check the ledger before dispatch).
+
+## Acceptance criteria
+
+- The repro matrix measured and recorded; the shape above returns `10` via
+  `new PP(5).v`, or the structural verdict is recorded with the owning issue
+  cited.
+- Byte-identity for constructors that do not call own prototype methods.
+- Pinned tests red on base; equivalence shards clean by name.


### PR DESCRIPTION
Docs-only batch — three new issues and two record updates, all from measured findings in the wave-6 PRs (#5168/#5169/#5171):

- **[#5160](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5160-padsundefined-siblings-includes-startswith-search)** (new): `includes()`/`startsWith()`/`search()` with no argument are wrong in the gc lane — the identical `padsUndefined` omission PR #5168 fixed for `indexOf`, one list entry each. The current wrong values are pinned as tests in `tests/issue-5155-string-indexof-no-argument.test.ts` so the fix must update the pins.
- **[#5161](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5161-nativestrings-fast-error-options-toprimitive)** (new): the `nativeStrings` and `fast` host configs throw `TypeError: Cannot convert object to primitive value` on `new Error(msg, {cause})` — pre-existing (A/B'd identical across PR #5169's fix), same opaque-struct-ToPrimitive class as [#3481](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3481-bigint-symbol-coercion-value-rep) cause-2.
- **[#5162](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5162-prototype-method-from-own-constructor-trap)** (new): a prototype method called from its own constructor traps at runtime — plain numeric callee, reproduces identically in all five boolean-ABI lanes on base, so unrelated to [#4406](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4406-return-type-unboxing-abi); found as a Phase-4 control.
- **#4406 record**: the Phase-4 "What remains" section now records the third boolean site (`var f = this.pred(x); "" + f`) with its measured +19.9 % trade-off, so the deliberate non-fix cannot read as an oversight.
- **#5155 record**: the frontmatter figure corrected to +19 ins/−1 del (net +18).

Ids reserved on the upstream `issue-assignments` ref (pr_scan degraded; `check:issue-ids` arbitrates). The plan-file id 5161 coinciding with merged PR #5161 is the known separate-sequence overlap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_