### PR TITLE
fix(codegen): pad undefined for zero-arg includes/startsWith/search in gc lane (#5160) ✓

### DIFF
--- a/plan/issues/5160-padsundefined-siblings-includes-startswith-search.md
+++ b/plan/issues/5160-padsundefined-siblings-includes-startswith-search.md
@@ -1,10 +1,11 @@
 ---
 id: 5160
 title: "includes()/startsWith()/search() with no argument are wrong in the gc lane — the same padsUndefined omission #5155 fixed for indexOf"
-status: ready
+status: done
 sprint: current
 created: 2026-08-28
 updated: 2026-08-28
+completed: 2026-08-28
 priority: low
 horizon: s
 feasibility: easy
@@ -14,6 +15,30 @@ area: codegen
 language_feature: string-methods
 goal: core-semantics
 related: [5155, 3763]
+# loc-budget-allow / func-budget-allow justification (2026-08-28): the
+# executable change is THREE list entries — `includes`, `search` and
+# `startsWith` added to the `padsUndefined` set inside
+# `compileReceiverMethodCall` — which the gate scores as +13 lines only because
+# 10 of the 13 are comment. Non-comment source delta is +3 lines, one per
+# method. The comments are the load-bearing part: they record (a) that `search`
+# is NOT a ToString case (§22.1.3.19 goes through `RegExp(undefined)`, the empty
+# regexp) so the next reader does not "correct" it toward the includes/
+# startsWith story, (b) the two base measurements that established the one-entry
+# fix is sufficient for `search` anyway, and (c) that the f64 position slot of
+# includes/startsWith is deliberately untouched and keeps its #2002 NaN
+# sentinel, so the entry is not later widened into that arm.
+#
+# This restates the same grant #5155 carried for this file rather than relying
+# on it: #5155's issue file is not modified by this PR, so its allowance would
+# be a stranded grant that CI's merge-preview base cannot see.
+#
+# The fix cannot move to a subsystem module: the set it edits is a local inside
+# the pad loop of the host-import call path, and extracting it would be a far
+# larger change to a god-function than three one-cell bugs warrant.
+loc-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts
+func-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
 ---
 
 # Three more one-entry fixes in the `padsUndefined` set
@@ -51,3 +76,165 @@ regexp matching at 0, not `ToString`; verify the host arm actually receives
   shape in both lanes (reuse the #5168 43-shape sweep).
 - A/B per the established method; pinned tests red on base; equivalence shards
   clean by name.
+
+## Resolution (2026-08-28) — three list entries, and `search` verified first
+
+All figures below are **measured** in this worktree unless labelled *reasoned*.
+The A/B artifacts are `.tmp/sweep-base.json` and `.tmp/sweep-fixed.json`,
+generated 2026-08-28 by `.tmp/sweep.ts` from a base copy of the source
+(`.tmp/base-call-receiver-method.ts`, captured with `git show HEAD:…` at the
+first edit) against branch base `origin/main` @ `02b050f8f0`.
+
+### The `search()` question, answered by measurement before the fix was written
+
+The issue flagged `search` as the one that might not fit the one-entry shape,
+because §22.1.3.19 does **not** run `ToString` — it builds `RegExp(searchValue)`,
+and `RegExp(undefined)` is the *empty* regexp `/(?:)/`, which matches at 0 for
+any receiver. Two rows of the base sweep settle it without guessing:
+
+| base measurement | result | what it establishes |
+| --- | --- | --- |
+| gc `search()` sha256 = `af9af665d18f` | **identical** to gc `search(null)` `af9af665d18f` | the absent slot really was reaching the host as JS `null`, i.e. `RegExp(null)` = `/null/` |
+| gc `search(undefined)` | **`0`** (already correct on base) | the host arm handles `undefined` correctly and yields the empty-regexp answer |
+
+So passing `undefined` is sufficient for `search` too, and no larger fix was
+needed. Confirmed after the fix: gc `search()` is now `417a35200518`, which is
+byte-identical to `search(undefined)`, and no longer equal to `search(null)`
+(still `af9af665d18f`, still `-1`).
+
+Two consequences of `search` being a regexp case rather than a ToString case,
+both measured and both pinned as tests: `"abc".search()` and `"".search()`
+answer **0**, not `-1` — unlike `includes`/`startsWith`, whose zero-argument
+form on a receiver without `"undefined"` stays `false`.
+
+### The change
+
+Three entries added to the `padsUndefined` set inside
+`compileReceiverMethodCall` (`src/codegen/expressions/call-receiver-method.ts`)
+— `includes`, `search`, `startsWith`, joining `endsWith`, `indexOf`,
+`lastIndexOf`, `padStart`, `padEnd`. That set names the methods whose omitted
+**externref** slots must be padded with JS `undefined` (via the
+`__get_undefined` import) instead of `ref.null.extern`. Non-comment source
+delta: **+3 lines**, one per method; +13 total with the comment.
+
+The f64 position slot of `includes`/`startsWith` is untouched — it is padded on
+a different arm with the #2002 NaN sentinel, and `padsUndefined` only rewrites
+externref slots. Measured, not reasoned: every one-argument shape
+(`includes("b")`, `includes(dyn)`, `startsWith("u")`, `startsWith("n",1)`, …)
+is byte-identical across the A/B.
+
+### Measured before/after — the three target shapes
+
+Values are gc → gc and standalone → standalone; hashes are sha256 of the
+emitted module, first 12 hex, gc lane.
+
+| shape | before (gc / sa) | after (gc / sa) | spec |
+| --- | --- | --- | --- |
+| `"aundefinedb".includes()` | **`false`** `d042df53c6d7` / `true` | **`true`** `cd5ed9225c9a` / `true` | `true` |
+| `"undefinedb".startsWith()` | **`false`** `f020a3cd1962` / `true` | **`true`** `9ad61d5833f1` / `true` | `true` |
+| `"aundefinedb".search()` | **`-1`** `af9af665d18f` / `0` | **`0`** `417a35200518` / `0` | `0` |
+
+And the receiver variants, all gc lane, all previously wrong:
+
+| shape | before | after |
+| --- | --- | --- |
+| `"aundefinedb".includes()` literal recv | `false` | `true` |
+| `a[0]!.includes()` dynamic recv | `false` | `true` |
+| `"undefinedb".startsWith()` literal recv | `false` | `true` |
+| `a[0]!.startsWith()` dynamic recv | `false` | `true` |
+| `"aundefinedb".search()` literal recv | `-1` | `0` |
+| `a[0]!.search()` dynamic recv | `-1` | `0` |
+| `"".search()` empty recv | `-1` | `0` |
+
+### Byte-identity — each zero-arg form IS its `undefined` spelling
+
+The preferred acceptance outcome, achieved for all three rather than explained
+away. After the fix each zero-argument form compiles to **one binary** with its
+explicit-`undefined` spelling, where on base all three differed:
+
+| pair | base | after |
+| --- | --- | --- |
+| `includes()` vs `includes(undefined)` | `d042df53c6d7` ≠ `cd5ed9225c9a` | both `cd5ed9225c9a` |
+| `startsWith()` vs `startsWith(undefined)` | `f020a3cd1962` ≠ `9ad61d5833f1` | both `9ad61d5833f1` |
+| `search()` vs `search(undefined)` | `af9af665d18f` ≠ `417a35200518` | both `417a35200518` |
+
+Pinned as a test so the spellings cannot drift apart. This mirrors what #5155
+achieved for `indexOf`.
+
+### Sweep: 66 shapes × 2 lanes = 132 cells, 120 byte-identical
+
+The sweep extends the #5155 43-shape one to 66 shapes so the three target
+methods get the same receiver/argument coverage `indexOf` had. **The 12 cells
+that moved are all gc-lane and all the zero-argument form of the three fixed
+methods** — four receiver variants each:
+
+| moved cell (gc lane) | before | after |
+| --- | --- | --- |
+| `includes()` | `false` `d042df53c6d7` | `true` `cd5ed9225c9a` |
+| `includes()` no match | `false` `377a74a4980f` | `false` `e097b50d413e` |
+| `includes()` literal recv | `false` `0e85dbb6a2c5` | `true` `64147e83f82c` |
+| `includes()` dynamic recv | `false` `3853c5360ff3` | `true` `ae7906eb64b2` |
+| `startsWith()` | `false` `f020a3cd1962` | `true` `9ad61d5833f1` |
+| `startsWith()` no match | `false` `ddf4565b939b` | `false` `cd7da134b66b` |
+| `startsWith()` literal recv | `false` `79dda4949669` | `true` `aff84cba58e8` |
+| `startsWith()` dynamic recv | `false` `9f7a74e5ce4d` | `true` `7207c45fa2c5` |
+| `search()` | `-1` `af9af665d18f` | `0` `417a35200518` |
+| `search()` empty recv | `-1` `41cdd03e9935` | `0` `8b931949a47d` |
+| `search()` literal recv | `-1` `0c2afdb10194` | `0` `d05759ca6028` |
+| `search()` dynamic recv | `-1` `4894bff12da6` | `0` `f7cf81c96e87` |
+
+Two of those twelve move bytes with **no value change** (`includes()` /
+`startsWith()` on `"abc"`): the search value changed from `"null"` to
+`"undefined"`, and both miss. That is the expected shape of the fix, and both
+rows are pinned so a future "simplification" that returns a fixed answer fails.
+
+**The standalone lane is 66/66 unchanged** — every cell byte-identical, which is
+the evidence this was host argument padding and not a semantics gap.
+
+Everything else is byte-identical in **both** lanes: `indexOf` in all 14 of its
+sweep shapes, `lastIndexOf()`/`lastIndexOf(undefined)`/`lastIndexOf("b")`/
+`lastIndexOf("n",5)`, every explicit-argument `includes`/`startsWith`/`search`
+spelling (including the `null` ones and `search(/b/)`/`search(/zz/)`),
+`endsWith()`/`endsWith("b")`, `padStart()`/`padStart(5)`/`padEnd(5)`,
+`substring()`/`substring(1)`, `slice()`/`slice(1)`, `split()`, `charAt()`,
+`concat()`, `repeat()`, `at()`, `replace()`, `codePointAt()`, and the whole
+Array-side family (`arr.indexOf()`, `arr.indexOf(20)`, `arr.lastIndexOf()`,
+`arr.includes()`, `arr.at()`, `["x",undefined,"z"].indexOf()`).
+
+### Tests
+
+- `tests/issue-5155-string-indexof-no-argument.test.ts` — the #5155 pin block
+  that recorded the three wrong values (`0` / `0` / `-1`) now carries the spec
+  answers (`1` / `1` / `0`). That pin existed precisely so this follow-up could
+  not diverge silently, and it did its job: the block fails on base.
+- `tests/issue-5160-padsundefined-siblings.test.ts` — 13 tests: both lanes per
+  method, the `search`-is-a-regexp evidence (`"abc"`/`""` → 0), the no-match
+  guards, literal and dynamic receivers, the "was searching for null" rows, the
+  three byte-identity pins, explicit-argument regression guards, the #2002 NaN
+  position-slot guard, and the `indexOf`/`endsWith`/`padStart`/`padEnd`/
+  Array-family/other-String-shape guards.
+- `tests/equivalence/string-search-family-no-arg.test.ts` — 13 rows against real
+  JS execution, modelled on `string-indexof-no-arg.test.ts` (#5155).
+
+**Non-vacuity, measured:** with only the source file reverted to base
+(`cp .tmp/base-call-receiver-method.ts src/…`), **15 of the 48 assertions across
+these three files FAIL**, including the updated #5155 pin block. The 33 that
+pass are exactly the intended regression guards (standalone lane, no-match,
+null spellings, explicit arguments, position slot, `indexOf`/`lastIndexOf`,
+`endsWith`/`padStart`/`padEnd`, Array family, other String shapes). Restored
+from `.tmp/fixed-call-receiver-method.ts` afterwards; all 48 pass.
+
+One equivalence row had to be re-spelled: `startsWith(undefined)` does not
+typecheck under the equivalence harness (it does not set
+`skipSemanticDiagnostics`), so that row asserts against the explicit
+`"undefined"` string instead, and the byte-identity pin against
+`startsWith(undefined)` lives in the unit file.
+
+### test262 sizing — reasoned, not measured
+
+Not measured here (no local test262 run). By the same reasoning #5155 recorded
+for `indexOf`: the zero-argument spelling is vanishingly rare in the
+`String/prototype` tree, so the expected conformance delta is **0 tests**. The
+value is correctness of a shape test262 happens not to probe, and closing the
+`padsUndefined` list — with these three, every String method whose omitted
+externref slot is spec-visible is now on it.

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -3321,15 +3321,28 @@ export function compileReceiverMethodCall(
         // when `args[0]` exists — a zero-argument call never reached it.)
         // Also covers indexOf's boxed fromIndex slot, which is spec-equivalent:
         // ToIntegerOrInfinity of `null` and of `undefined` are both +0.
-        // Deliberately NOT widened to `includes`/`startsWith`/`search`, which
-        // have the identical defect from this list — see the follow-up section
-        // in `plan/issues/5155-string-indexof-no-argument-gc.md`.
+        // #5160 — the three siblings #5155 deliberately left out join the list.
+        // Same one-cell defect, same lane: the absent search slot reached the
+        // host as `ref.null.extern`, so `"aundefinedb".includes()` searched for
+        // "null" (false, spec true), `"undefinedb".startsWith()` likewise
+        // (false, spec true), and `"aundefinedb".search()` built `RegExp(null)`
+        // = /null/ (-1, spec 0). `search` is NOT a ToString case: §22.1.3.19
+        // routes an absent/undefined argument through `RegExp(undefined)` = the
+        // empty regexp `/(?:)/`, which matches at 0 — measured on the base, the
+        // gc lane's `search()` and `search(null)` compiled to ONE binary while
+        // `search(undefined)` already answered 0, so passing `undefined` is all
+        // that is needed here too. The f64 position slot of
+        // includes/startsWith is untouched by this set — it keeps the #2002 NaN
+        // sentinel below.
         const padsUndefined =
           method === "endsWith" ||
+          method === "includes" ||
           method === "indexOf" ||
           method === "lastIndexOf" ||
           method === "padStart" ||
-          method === "padEnd";
+          method === "padEnd" ||
+          method === "search" ||
+          method === "startsWith";
         let undefIdx: number | undefined;
         if (padsUndefined) {
           undefIdx = ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);

--- a/tests/equivalence/string-search-family-no-arg.test.ts
+++ b/tests/equivalence/string-search-family-no-arg.test.ts
@@ -1,0 +1,165 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./helpers.js";
+
+// #5160 — zero-argument `includes()`, `startsWith()` and `search()`. In the gc
+// (JS-host) lane the absent externref search slot used to be padded with
+// `ref.null.extern`, so the host searched for "null" (includes/startsWith) or
+// built `RegExp(null)` = /null/ (search) instead of applying the spec default.
+//
+// includes/startsWith are §22.1.3.14/§22.1.3.23 ToString cases: an absent
+// argument becomes the string "undefined". `search` is NOT — §22.1.3.19 routes
+// it through `RegExp(undefined)`, the EMPTY regexp `/(?:)/`, which matches at 0
+// for every receiver. Both behaviours are checked against real JS here.
+//
+// Sibling of string-indexof-no-arg.test.ts (#5155), which fixed `indexOf` from
+// the same `padsUndefined` list.
+//
+// TypeScript types these methods as requiring their argument, so the
+// zero-argument form is only writable where the harness tolerates the
+// diagnostic — return position. (test262 is plain JS and has no such
+// constraint.)
+describe("String.prototype includes/startsWith/search with no argument", () => {
+  it('includes() finds "undefined" in a receiver that contains it', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return s.includes() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('includes() is false when the receiver does not contain "undefined"', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "abc";
+        return s.includes() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('includes() does not search for "null"', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "anullb";
+        return s.includes() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("includes() agrees with the includes(undefined) spelling", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return (s.includes() === s.includes(undefined) ? 100 : 0) + (s.includes() ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('startsWith() matches a receiver that begins with "undefined"', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "undefinedb";
+        return s.startsWith() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('startsWith() is false when "undefined" is present but not at the start', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return s.startsWith() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('startsWith() does not search for "null"', async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "nullb";
+        return s.startsWith() ? 1 : 0;
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it('startsWith() agrees with the explicit "undefined" string spelling', async () => {
+    // The `startsWith(undefined)` spelling does not typecheck under this
+    // harness (it does not set `skipSemanticDiagnostics`), so the byte-identity
+    // pin against it lives in tests/issue-5160-padsundefined-siblings.test.ts.
+    // Here the equivalent ToString target is asserted against real JS instead.
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "undefinedb";
+        return (s.startsWith() === s.startsWith("undefined") ? 100 : 0) + (s.startsWith() ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("search() matches at 0 via the empty regexp, whatever the receiver holds", async () => {
+    // The distinguishing property: not a "undefined" substring search. All
+    // three receivers answer 0 — including one with no "undefined" in it and
+    // one that is empty.
+    await assertEquivalent(
+      `export function test(): number {
+        var a: string = "aundefinedb";
+        var b: string = "abc";
+        var c: string = "";
+        return a.search() * 100 + b.search() * 10 + c.search();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("search() does not build RegExp(null)", async () => {
+    // /null/ would match this receiver at 1; /(?:)/ matches at 0.
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "anullb";
+        return s.search();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("search() agrees with the search(undefined) spelling", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return (s.search() === s.search(undefined) ? 100 : 0) + s.search();
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("leaves explicit arguments unchanged across all three", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        return (s.includes("b") ? 1000 : 0) + (s.startsWith("a") ? 100 : 0) + s.search(/b/);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("keeps the omitted position slot of a one-argument call unchanged", async () => {
+    await assertEquivalent(
+      `export function test(): number {
+        var s: string = "aundefinedb";
+        var needles: string[] = ["b", "zz", "a"];
+        return (s.includes(needles[0]) ? 1000 : 0)
+          + (s.includes(needles[1]) ? 100 : 0)
+          + (s.startsWith(needles[2]) ? 10 : 0)
+          + (s.startsWith(needles[1]) ? 1 : 0);
+      }`,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});

--- a/tests/issue-5155-string-indexof-no-argument.test.ts
+++ b/tests/issue-5155-string-indexof-no-argument.test.ts
@@ -22,11 +22,14 @@ import { compile } from "../src/index.ts";
 //   `tryCompileIndexOfHoistedUndefinedSearch` only fires when `args[0]` exists,
 //   so a zero-argument call never reached it.
 //
-//   NOT fixed here — the identical defect in three siblings that share this
-//   list (measured on the same base, gc lane): `"aundefinedb".includes()` is
-//   false, `"undefinedb".startsWith()` is false, and `"aundefinedb".search()`
-//   is -1, all spec-wrong and all correct in standalone. They are recorded as a
-//   follow-up in the issue file rather than widened into this change.
+//   Not fixed here — the identical defect in three siblings that share this
+//   list (measured on the same base, gc lane): `"aundefinedb".includes()` was
+//   false, `"undefinedb".startsWith()` was false, and `"aundefinedb".search()`
+//   was -1, all spec-wrong and all correct in standalone. They were recorded as
+//   a follow-up rather than widened into this change, and their wrong values
+//   pinned below. #5160 has since fixed all three by adding them to the same
+//   `padsUndefined` set, so those pins now carry the spec answers; the full
+//   evidence lives in `tests/issue-5160-padsundefined-siblings.test.ts`.
 //
 //   `skipSemanticDiagnostics` mirrors the test262 runner — TS types these
 //   methods as requiring an argument, which is not a hard error there.
@@ -138,14 +141,16 @@ describe("#5155 — String.prototype.indexOf with no argument", () => {
     expect(await runGc(fn("const a=[10,20,30]; return a.at();"))).toBe(10);
   });
 
-  it("records the three siblings this change deliberately does NOT fix", async () => {
-    // Same `padsUndefined` omission, same lane. Pinned as the OBSERVED wrong
-    // values (with the spec answer named in the comment) so the follow-up that
-    // fixes them is forced to update this test rather than silently diverge.
-    // Spec: includes() → true, startsWith() → true, search() → 0.
-    expect(await runGc(fn(HIT + " return s.includes()?1:0;"))).toBe(0);
-    expect(await runGc(fn('const s="undefinedb"; return s.startsWith()?1:0;'))).toBe(0);
-    expect(await runGc(fn(HIT + " return s.search();"))).toBe(-1);
+  it("records the three siblings — FIXED by the #5160 follow-up", async () => {
+    // Same `padsUndefined` omission, same lane. These were pinned here as the
+    // OBSERVED WRONG values (0 / 0 / -1) when #5155 deliberately left them out,
+    // precisely so the follow-up could not diverge silently. #5160 added
+    // `includes`, `startsWith` and `search` to the same set, so the pins are
+    // now the spec answers: includes() → true, startsWith() → true,
+    // search() → 0 (§22.1.3.19 → `RegExp(undefined)` = /(?:)/, matching at 0).
+    expect(await runGc(fn(HIT + " return s.includes()?1:0;"))).toBe(1);
+    expect(await runGc(fn('const s="undefinedb"; return s.startsWith()?1:0;'))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.search();"))).toBe(0);
     // …and that standalone already gets all three right, which is the evidence
     // they are the same host-padding defect and not a semantics gap.
     expect(await runStandalone(fn(HIT + " return s.includes()?1:0;"))).toBe(1);

--- a/tests/issue-5160-padsundefined-siblings.test.ts
+++ b/tests/issue-5160-padsundefined-siblings.test.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #5160 — the three siblings #5155 left out: zero-argument `includes()`,
+//   `startsWith()` and `search()` were wrong in the gc (JS-host) lane, from the
+//   same one-cell omission in the `padsUndefined` set inside
+//   `compileReceiverMethodCall` (src/codegen/expressions/call-receiver-method.ts).
+//   The absent externref search slot was padded with `ref.null.extern`, so the
+//   host received JS `null`:
+//
+//     "aundefinedb".includes()   false  (spec true  — ToString(undefined))
+//     "undefinedb".startsWith()  false  (spec true  — ToString(undefined))
+//     "aundefinedb".search()     -1     (spec 0     — RegExp(undefined))
+//
+//   `search` is NOT a ToString case and was verified separately before assuming
+//   the one-entry fix would carry it: §22.1.3.19 routes an absent/undefined
+//   argument through `RegExp(undefined)`, which is the EMPTY regexp `/(?:)/` and
+//   matches at index 0 — not the string "undefined". Two measurements on the
+//   pre-fix base established that passing `undefined` is nonetheless sufficient:
+//   (a) `search()` and `search(null)` compiled to ONE binary, so `null` really
+//   was what reached the host, and (b) `search(undefined)` in the gc lane
+//   already answered 0, so the host arm handles `undefined` correctly. Both are
+//   pinned below.
+//
+//   Standalone was already correct for all three, which is the evidence this is
+//   host argument padding and not a semantics gap.
+//
+//   `skipSemanticDiagnostics` mirrors the test262 runner — TS types these
+//   methods as requiring an argument, which is not a hard error there.
+
+interface CompileResult {
+  success: boolean;
+  errors?: Array<{ message: string }>;
+  binary: Uint8Array;
+  importObject?: WebAssembly.Imports;
+}
+
+async function build(src: string, standalone: boolean): Promise<CompileResult> {
+  const opts = standalone ? { target: "standalone", skipSemanticDiagnostics: true } : { skipSemanticDiagnostics: true };
+  const r = (await compile(src, opts as never)) as never as CompileResult;
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  return r;
+}
+
+async function runGc(src: string): Promise<unknown> {
+  const r = await build(src, false);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await build(src, true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function digestGc(src: string): Promise<string> {
+  const r = await build(src, false);
+  return createHash("sha256").update(r.binary).digest("hex");
+}
+
+const fn = (body: string) => `export function test(): number { ${body} }`;
+// "undefined" occurs at index 1; "null" occurs nowhere, so a wrong answer that
+// came from searching for "null" is distinguishable from a generic miss.
+const HIT = 'const s="aundefinedb";';
+const SW = 'const s="undefinedb";';
+
+describe("#5160 — zero-argument includes/startsWith/search in the gc lane", () => {
+  it('includes() searches for the string "undefined" in both lanes', async () => {
+    expect(await runGc(fn(HIT + " return s.includes()?1:0;"))).toBe(1);
+    expect(await runStandalone(fn(HIT + " return s.includes()?1:0;"))).toBe(1);
+  });
+
+  it('startsWith() searches for the string "undefined" in both lanes', async () => {
+    expect(await runGc(fn(SW + " return s.startsWith()?1:0;"))).toBe(1);
+    expect(await runStandalone(fn(SW + " return s.startsWith()?1:0;"))).toBe(1);
+  });
+
+  it("search() builds the EMPTY regexp and matches at 0 in both lanes", async () => {
+    // §22.1.3.19: RegExp(undefined) is /(?:)/, so the answer is 0 for ANY
+    // receiver — including one that contains neither "undefined" nor "null",
+    // and including the empty string. That is what distinguishes search() from
+    // the two ToString siblings above, and it is asserted rather than assumed.
+    expect(await runGc(fn(HIT + " return s.search();"))).toBe(0);
+    expect(await runStandalone(fn(HIT + " return s.search();"))).toBe(0);
+    expect(await runGc(fn('const s="abc"; return s.search();'))).toBe(0);
+    expect(await runGc(fn('const s=""; return s.search();'))).toBe(0);
+  });
+
+  it("keeps the no-match guards honest — the fix is not a fixed answer", async () => {
+    // Receivers containing neither "undefined" nor "null". includes/startsWith
+    // must still be false; only their SEARCH VALUE changed, not their result
+    // shape. (These two rows moved bytes with no value change.)
+    expect(await runGc(fn('const s="abc"; return s.includes()?1:0;'))).toBe(0);
+    expect(await runStandalone(fn('const s="abc"; return s.includes()?1:0;'))).toBe(0);
+    expect(await runGc(fn('const s="abc"; return s.startsWith()?1:0;'))).toBe(0);
+    expect(await runStandalone(fn('const s="abc"; return s.startsWith()?1:0;'))).toBe(0);
+  });
+
+  it("applies to literal and dynamic receivers, not just a const binding", async () => {
+    expect(await runGc(fn('return "aundefinedb".includes()?1:0;'))).toBe(1);
+    expect(await runGc(fn('const a=["aundefinedb"]; return a[0]!.includes()?1:0;'))).toBe(1);
+    expect(await runGc(fn('return "undefinedb".startsWith()?1:0;'))).toBe(1);
+    expect(await runGc(fn('const a=["undefinedb"]; return a[0]!.startsWith()?1:0;'))).toBe(1);
+    expect(await runGc(fn('return "aundefinedb".search();'))).toBe(0);
+    expect(await runGc(fn('const a=["aundefinedb"]; return a[0]!.search();'))).toBe(0);
+  });
+
+  it('was searching for "null" — the explicit null spellings are unchanged', async () => {
+    // The defect made the host receive JS `null`. Those spellings genuinely
+    // mean "null" / RegExp(null) = /null/ and must keep doing so; only the
+    // ABSENT argument changed meaning.
+    expect(await runGc(fn('const s="anullb"; return s.includes(null as any)?1:0;'))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.includes(null as any)?1:0;"))).toBe(0);
+    expect(await runGc(fn('const s="nullb"; return s.startsWith(null as any)?1:0;'))).toBe(1);
+    expect(await runGc(fn(SW + " return s.startsWith(null as any)?1:0;"))).toBe(0);
+    // search(null) === /null/ — absent from the probe, so still -1, and this is
+    // the row that proves search() is no longer compiling to search(null).
+    expect(await runGc(fn(HIT + " return s.search(null as any);"))).toBe(-1);
+  });
+
+  it("compiles each zero-argument form byte-identically to its undefined spelling", async () => {
+    // The #5155/#5121 pin pattern: the two spellings become ONE binary, so they
+    // cannot drift apart later. None of the three were identical before the fix.
+    const pairs: Array<[string, string]> = [
+      [HIT + " return s.includes()?1:0;", HIT + " return s.includes(undefined)?1:0;"],
+      [SW + " return s.startsWith()?1:0;", SW + " return s.startsWith(undefined)?1:0;"],
+      [HIT + " return s.search();", HIT + " return s.search(undefined as any);"],
+    ];
+    for (const [absent, explicit] of pairs) {
+      expect(await digestGc(fn(absent))).toBe(await digestGc(fn(explicit)));
+    }
+  });
+
+  it("leaves explicit-argument values unchanged for all three methods", async () => {
+    expect(await runGc(fn(HIT + ' return s.includes("b")?1:0;'))).toBe(1);
+    expect(await runGc(fn(HIT + ' return s.includes("b",0)?1:0;'))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.includes(undefined)?1:0;"))).toBe(1);
+    expect(await runGc(fn(SW + ' return s.startsWith("u")?1:0;'))).toBe(1);
+    expect(await runGc(fn(SW + ' return s.startsWith("n",1)?1:0;'))).toBe(1);
+    expect(await runGc(fn(SW + " return s.startsWith(undefined)?1:0;"))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.search(/b/);"))).toBe(10);
+    expect(await runGc(fn(HIT + " return s.search(/zz/);"))).toBe(-1);
+  });
+
+  it("keeps the omitted position slot on its #2002 NaN sentinel", async () => {
+    // includes/startsWith carry their optional position as an f64, padded with
+    // NaN so the host shim drops it and JS applies the spec default. That arm
+    // is untouched by `padsUndefined` (which only rewrites externref slots), so
+    // a one-argument call must be unaffected — asserted by value with a dynamic
+    // needle, which avoids any static-needle fold.
+    expect(await runGc(fn('const p=["b"]; ' + HIT + " return s.includes(p[0]!)?1:0;"))).toBe(1);
+    expect(await runGc(fn('const p=["zz"]; ' + HIT + " return s.includes(p[0]!)?1:0;"))).toBe(0);
+    expect(await runGc(fn('const p=["u"]; ' + SW + " return s.startsWith(p[0]!)?1:0;"))).toBe(1);
+    expect(await runGc(fn('const p=["zz"]; ' + SW + " return s.startsWith(p[0]!)?1:0;"))).toBe(0);
+  });
+
+  it("leaves indexOf/lastIndexOf — the #5155 cells — untouched", async () => {
+    expect(await runGc(fn(HIT + " return s.indexOf();"))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.lastIndexOf();"))).toBe(1);
+    expect(await runGc(fn(HIT + ' return s.indexOf("b");'))).toBe(10);
+    expect(await runGc(fn('const s="abc"; return s.indexOf();'))).toBe(-1);
+  });
+
+  it("leaves endsWith/padStart/padEnd — the other padsUndefined members — correct", async () => {
+    expect(await runGc(fn('const s="bundefined"; return s.endsWith()?1:0;'))).toBe(1);
+    expect(await runGc(fn(HIT + ' return s.endsWith("b")?1:0;'))).toBe(1);
+    expect(await runGc(fn('const s="ab"; return s.padStart().length;'))).toBe(2);
+    expect(await runGc(fn('const s="ab"; return s.padStart(5).length;'))).toBe(5);
+    expect(await runGc(fn('const s="ab"; return s.padEnd(5).length;'))).toBe(5);
+  });
+
+  it("does not touch the Array-side family fixed by #5095/#5121", async () => {
+    expect(await runGc(fn("const a=[10,20,30]; return a.includes()?1:0;"))).toBe(0);
+    expect(await runGc(fn("const a=[10,20,30]; return a.indexOf();"))).toBe(-1);
+    expect(await runGc(fn("const a=[10,20,30]; return a.lastIndexOf();"))).toBe(-1);
+    expect(await runGc(fn("const a=[10,20,30]; return a.at();"))).toBe(10);
+  });
+
+  it("does not touch the other String.prototype omitted-argument shapes", async () => {
+    expect(await runGc(fn(HIT + " return s.substring().length;"))).toBe(11);
+    expect(await runGc(fn(HIT + " return s.slice().length;"))).toBe(11);
+    expect(await runGc(fn(HIT + " return s.split().length;"))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.charAt().length;"))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.concat().length;"))).toBe(11);
+    expect(await runGc(fn('const s="ab"; return s.repeat().length;'))).toBe(0);
+    expect(await runGc(fn(HIT + " return (s.at() ?? '').length;"))).toBe(1);
+    expect(await runGc(fn(HIT + " return s.codePointAt() ?? -1;"))).toBe(97);
+  });
+});


### PR DESCRIPTION
Closes [#5160](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5160-padsundefined-siblings-includes-startswith-search) — the three siblings [#5155](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5155-string-indexof-no-argument-gc) deliberately left out.

## What was wrong

In the gc (JS-host) lane the omitted **externref** search slot of three `String.prototype` methods was padded with `ref.null.extern`, so the host received JS `null` and coerced the wrong search value. All three were gc-lane-only; standalone was already correct.

| shape | gc before | gc after | standalone | spec |
| --- | --- | --- | --- | --- |
| `"aundefinedb".includes()` | **`false`** | `true` | `true` | `true` |
| `"undefinedb".startsWith()` | **`false`** | `true` | `true` | `true` |
| `"aundefinedb".search()` | **`-1`** | `0` | `0` | `0` |

## The change

Three entries added to the `padsUndefined` set inside `compileReceiverMethodCall` (`src/codegen/expressions/call-receiver-method.ts`) — `includes`, `search`, `startsWith`, joining `endsWith`, `indexOf`, `lastIndexOf`, `padStart`, `padEnd`. **Non-comment source delta: +3 lines**, one per method.

The f64 position slot of `includes`/`startsWith` is untouched and keeps its #2002 NaN sentinel — `padsUndefined` only rewrites externref slots.

## `search()` was verified before assuming the one-entry shape carried it

§22.1.3.19 routes an absent argument through `RegExp(undefined)` — the **empty** regexp `/(?:)/`, matching at 0 — not `ToString`. Two base measurements settled it rather than assuming:

| base measurement | result | what it establishes |
| --- | --- | --- |
| gc `search()` sha256 `af9af665d18f` | **identical** to gc `search(null)` | `null` really was reaching the host, i.e. `RegExp(null)` = `/null/` |
| gc `search(undefined)` | already **`0`** on base | the host arm handles `undefined` correctly |

So passing `undefined` suffices. Consequence, measured and pinned: `"abc".search()` and `"".search()` answer **0**, not `-1` — unlike `includes`/`startsWith`, whose zero-arg form on a receiver without `"undefined"` stays `false`.

## Validation

**Sweep: 66 shapes × 2 lanes = 132 cells, 120 byte-identical.** Base copy captured at first edit; A/B by file copy. The 12 cells that moved are all gc-lane and all the zero-argument form of the three fixed methods across their four receiver variants:

| moved cell (gc) | before | after |
| --- | --- | --- |
| `includes()` | `false` `d042df53c6d7` | `true` `cd5ed9225c9a` |
| `includes()` no match | `false` `377a74a4980f` | `false` `e097b50d413e` |
| `includes()` literal recv | `false` `0e85dbb6a2c5` | `true` `64147e83f82c` |
| `includes()` dynamic recv | `false` `3853c5360ff3` | `true` `ae7906eb64b2` |
| `startsWith()` | `false` `f020a3cd1962` | `true` `9ad61d5833f1` |
| `startsWith()` no match | `false` `ddf4565b939b` | `false` `cd7da134b66b` |
| `startsWith()` literal recv | `false` `79dda4949669` | `true` `aff84cba58e8` |
| `startsWith()` dynamic recv | `false` `9f7a74e5ce4d` | `true` `7207c45fa2c5` |
| `search()` | `-1` `af9af665d18f` | `0` `417a35200518` |
| `search()` empty recv | `-1` `41cdd03e9935` | `0` `8b931949a47d` |
| `search()` literal recv | `-1` `0c2afdb10194` | `0` `d05759ca6028` |
| `search()` dynamic recv | `-1` `4894bff12da6` | `0` `f7cf81c96e87` |

Two of the twelve move bytes with **no value change** (`includes()`/`startsWith()` on `"abc"`) — the search value changed from `"null"` to `"undefined"` and both still miss. Both are pinned so a "simplification" returning a fixed answer fails.

**The standalone lane is 66/66 unchanged.** `indexOf` (all 14 sweep shapes), `lastIndexOf`, every explicit-argument spelling, `endsWith`/`padStart`/`padEnd`, `substring`/`slice`/`split`/`charAt`/`concat`/`repeat`/`at`/`replace`/`codePointAt`, and the whole Array-side family are byte-identical in both lanes.

**Byte-identity achieved, not explained away:** each zero-arg form now compiles to one binary with its explicit-`undefined` spelling (`includes()` = `includes(undefined)`, `startsWith()` = `startsWith(undefined)`, `search()` = `search(undefined)`), where all three differed on base. Pinned as tests.

**Tests.** The #5155 pin block that recorded the wrong values (`0`/`0`/`-1`) now carries the spec answers — that pin existed exactly so this follow-up could not diverge silently, and it did its job. New: `tests/issue-5160-padsundefined-siblings.test.ts` (13 tests) and `tests/equivalence/string-search-family-no-arg.test.ts` (13 rows against real JS).

**Non-vacuity, measured:** with only the source file reverted to base, **15 of the 48 assertions FAIL**. The 33 that pass are exactly the intended regression guards (standalone lane, no-match, null spellings, explicit arguments, position slot, `indexOf`/`lastIndexOf`, `endsWith`/`padStart`/`padEnd`, Array family, other String shapes).

**Gates**, run bare and chained before committing — `check-loc-budget`, `check-func-budget`, `check-coercion-sites`, `check:oracle-ratchet`, `check:dead-exports` all exit 0, and again under `LOC_GATE_BASE=origin/main` to simulate CI's merge-preview base. The +13-line growth is granted in this PR's own issue file, which **restates** the allowance #5155 held for the same path rather than relying on it — #5155's file is not modified here, so its grant would be stranded.

**test262 sizing (reasoned, not measured):** expected delta **0 tests** — the zero-argument spelling is vanishingly rare in the `String/prototype` tree. The value is correctness of a shape test262 does not probe, and closing the `padsUndefined` list.

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_