### PR TITLE
fix(standalone): ES2015 test262 conformance — wave 5 (assignment destructuring, iterators)

### DIFF
--- a/plan/issues/5146-es2015-standalone-assignment-wave1.md
+++ b/plan/issues/5146-es2015-standalone-assignment-wave1.md
@@ -1,0 +1,359 @@
+---
+id: 5146
+title: "ES2015 standalone: assignment conformance wave 1"
+status: in-review
+sprint: current
+created: 2026-08-28
+updated: 2026-08-28
+priority: high
+horizon: l
+feasibility: medium
+task_type: conformance
+area: codegen
+es_edition: ES2015
+goal: standalone-mode
+requested_by: claude/fable-es2015
+loc-budget-allow:
+  - src/runtime.ts
+  - src/codegen/expressions/assignment.ts
+  - src/codegen/expressions/identifier-assignment.ts
+  - src/codegen/iterator-native.ts
+  - src/codegen/function-instance-meta.ts
+  - src/codegen/js-errors.ts
+  - src/compiler/early-errors/node-checks.ts
+  - src/codegen/statements/destructuring.ts
+  # 2026-08-28 (#5146 cluster E): the `.name` fold needs a simple-assignment
+  # NamedEvaluation probe (`x = (0, function(){})` must stay unnamed), which
+  # lives next to `resolveLogicalAssignmentName` in property-access.ts and is
+  # consumed by the `.name` arm in property-access-dispatch.ts.
+  - src/codegen/property-access.ts
+  - src/codegen/property-access-dispatch.ts
+func-budget-allow:
+  # 2026-08-28 (#5146 clusters C/D/F): the PutValue guards, the computed-key
+  # evaluation and the nested-pattern default arms are new emitted-code paths
+  # inside the existing destructuring drivers, not refactors.
+  - src/codegen/expressions/assignment.ts::compileDestructuringAssignment
+  - src/codegen/expressions/assignment.ts::compileArrayDestructuringAssignment
+  - src/codegen/property-access-dispatch.ts::tryLengthAndNameReads
+---
+
+# #5146 — ES2015 standalone: assignment conformance wave 1
+
+## Problem
+
+All 98 ES2015-bucket "assignment" work-package tests still fail on the
+standalone target (re-verified per-test on head `86739f05`, 2026-08-28:
+84 FAIL + 14 COMPILE_ERROR, 0 already fixed since the baseline). 96 of the 98
+are `language/expressions/assignment/dstr/` — destructuring assignment
+*expressions*. The lowering (`src/codegen/expressions/assignment.ts`)
+eagerly materializes the RHS iterable via `__array_from_iter_n`, then returns
+the materialized vec as the expression's completion value (spec: the original
+rval), silently drops element-access and nested-initializer targets, and skips
+the PutValue const/TDZ/strict-unresolvable checks. This is the same
+§13.15.5.2/.5 semantics family that #5144 fixes for for-of heads; landing both
+closes the largest remaining `language/expressions` gap on the road to 100 %
+ES2015 standalone. Growth allowance for the files above granted 2026-08-28 for
+this change-set (rationale: per-element iterator drive + PutValue guards are
+new emitted-code paths, not refactors).
+
+Target list (regenerated today, authoritative):
+`.tmp/es2015/wp-assignment-current-fails.txt` (98 paths).
+Minimal repro probes used below are in `.tmp/es2015/asn/*.js`
+(run via `npx tsx .tmp/probe-one.mts <abs-path>`).
+
+## Current failure clusters
+
+Counts verified by classifying all 98 paths; sums to 98. Sample paths are
+relative to `test262/test/language/expressions/assignment/`.
+
+| # | Cluster | Count | Root cause (file:function) | Sample tests |
+|---|---------|-------|----------------------------|--------------|
+| G | generator-coupled (gated on #5141/#680) | 26 (14 CE + 12 FAIL) | Native generator lowering (`src/codegen/generators-native.ts` candidacy gates, #680): `yield` inside a destructuring assignment is not an admitted shape. 12 `*rtrn-close*` CE with "sequential numeric yields only"; 10 `*yield-expr*` compile but resume wrong (`.next().value` = `[object Object]`, expected `undefined`); `array-iteration`/`array-rest-iteration` trap `unreachable in __gen_resume___closure` on bare `yield;`. Same admission-gate clusters as #5141 A1/A2/A3. | `dstr/array-elem-iter-rtrn-close.js`, `dstr/obj-id-init-yield-expr.js`, `dstr/array-iteration.js` |
+| B | IteratorClose fidelity + abrupt/order | 23 | `assignment.ts:2439` (`compileExternrefArrayDestructuringAssignment`): materialize-first via `__array_from_iter_n` (`:2471-2486`) calls all `next()`s before any target lref is evaluated (order test expects `[source, iterator, target, target-key, iterator-step, …]`, we produce `[source, iterator, iterator-step, iterator-done, target]`); an abrupt completion during target assignment never triggers IteratorClose and non-identifier targets don't even throw (probe `p-thrw.js`: thrower never runs, returnCount=0). Empty pattern `[] = iterable` skips GetIterator entirely (`target.elements.length > 0` gate at `:2470`). `__iterator_return` (`iterator-native.ts:541`, body `:1589`-area) discards return()'s result — `*close-null*` tests need "inner result not an Object ⇒ TypeError" on normal-completion close. | `dstr/array-elem-iter-thrw-close.js`, `dstr/array-empty-iter-close.js`, `dstr/array-elem-iter-nrml-close-null.js` |
+| A | completion value ≠ rval | 13 | `assignment.ts:2635`: pushes `tmpLocal` as the expression result, but `tmpLocal` was overwritten with the materialized vec at `:2484` — `result = [x] = vals` yields the internal vec, not `vals` (probe `probe1.js`: `result === iterable` false while nextCount/returnCount are already correct). Every `assert.sameValue(result, vals)` in the suite fails on this; these 13 fail on *only* this. | `dstr/array-elem-iter-nrml-close.js`, `dstr/array-elem-target-simple-no-strict.js`, `dstr/array-elision-iter-nrml-close-skip.js` |
+| C | PutValue guards: const/TDZ/strict-unresolvable | 13 | Destructuring writes land via `emitResolvedIdentifierWriteFromStack` (`identifier-assignment.ts:35`) without the guards plain assignment has: assignment to `const` silently no-ops (probe `p-const.js`, spec: TypeError), write before `let` in scope skips TDZ (probe `p-tdz.js`, spec: ReferenceError; plain assignments use `emitModuleLexicalAssignmentTdzGuard`, `identifier-assignment.ts:23`), and strict-mode unresolvable throws a **null payload** — `emitStrictPutValueThrow` (`assignment.ts:1115`) emits `ref.null.extern; throw`, so tests see "Thrown value was not an object!" instead of a ReferenceError instance (probe `p-unres.js`). | `dstr/obj-id-put-const.js`, `dstr/obj-id-put-let.js`, `dstr/obj-id-put-unresolvable-strict.js` |
+| E | NamedEvaluation (fn-name) | 9 | `function-instance-meta.ts:256` (`fnInstanceNameOf`): no arm for `ShorthandPropertyAssignment.objectAssignmentInitializer` (`{ x = function(){} } = {}` → name ""); `fnInstanceMetaOf` (`:320`) excludes `ClassExpression` entirely, so `cls = class {}` has `cls.name === undefined` (probe `p-fnname.js`: `fn=|cls=undefined|arrow=`). `fn-name-cover` additionally shows the comma form `(0, function(){})` getting named — verify the paren-only walk at `:284` isn't bypassed by a second naming source (checker-symbol fallback in `property-access-dispatch.ts:2876-2890`). | `dstr/obj-id-init-fn-name-fn.js`, `fn-name-class.js`, `dstr/array-elem-init-fn-name-class.js` |
+| F | nested-pattern initializers dropped | 6 | Nested patterns recurse (`assignment.ts:2624` array path; object path `:1137`ff) but the recursion never applies defaults: `({ a: { x = 5 } } = { a: {} })`, `[ { y = 6 } ]`, `[ [ z = 7 ] ]` all leave the target `undefined` (probe `p-nested.js`). Top-level initializers work (`:1491` handles `objectAssignmentInitializer`); the nested entry points bypass that handling. | `dstr/obj-prop-nested-obj-yield-ident-valid.js`, `dstr/array-elem-nested-array-yield-ident-valid.js` |
+| D | member/computed targets dropped | 6 | `emitAssignToTarget` (`assignment.ts:2735`): the ElementAccess arm (`:2790`) handles only wasm-vec receivers (`{length,data}` struct) and silently `return`s for externref/object receivers — `[ x[k] ] = [33]` drops the write while `[ y.prop ] = [44]` works (probe `p-elemtarget.js`; the PropertyAccess arm routes misses through `emitDynamicMemberSet` `:2664` since #2869 — the ElementAccess arm never got the same fix). Rest-to-member (`[...x[k]] = vals`) is dropped too: the rest branch (`:2519`) handles only `ts.isIdentifier(restTarget)`. Computed property *names* in object patterns (`{ [a.b]: x } = {}`) don't evaluate the key, so its TypeError never throws. | `dstr/array-elem-target-yield-valid.js`, `dstr/array-rest-yield-ident-valid.js`, `dstr/obj-prop-name-evaluation-error.js` |
+| H | early-error false positives (parser) | 2 | `src/compiler/early-errors/node-checks.ts:1926`: the escaped-`let` check fires on every Identifier `let` containing `\u`, including property-name positions where `let` is a legal IdentifierName (`{ let: x } = { let: 42 }`); the `break`-escaped twin passes because only `let` has this blanket check. `node-checks.ts:1357`: duplicate `__proto__` early error applies to object *literals* but must not apply when the ObjectLiteral covers an ObjectAssignmentPattern (`({ __proto__: x, __proto__: y } = value)` is legal). | `dstr/ident-name-prop-name-literal-let-escaped.js`, `destructuring/obj-prop-__proto__dup.js` |
+
+## Implementation Plan
+
+Written 2026-08-28 against head `86739f05`. Re-run
+`npx tsx .tmp/run-standalone.mts --list .tmp/es2015/wp-assignment-current-fails.txt`
+plus the spotcheck list after each step; error text shifts as clusters land, so
+re-cluster rather than trusting the table's strings after step 2. All work is
+Wasm-native — **no new host imports without a standalone fallback** (the runner
+fails any test whose module emits host imports); host-mode (`src/runtime.ts`)
+twins may need matching fidelity fixes to keep equivalence tests green.
+
+**Step 0 — do NOT implement cluster G here.** The 26 generator-coupled tests
+(`*rtrn-close*`, `*yield-expr*`, `array-iteration`, `array-rest-iteration`)
+are #5141's scope (its native-generator admission-gate steps, tracking #680).
+None of the steps below touch `generators-native*.ts`. After #5141 lands,
+re-run the full list and fold G's survivors into a re-cluster.
+
+**Step 1 — Cluster A (13, plus a hidden co-failure in ~every dstr test): keep
+the original rval as the completion value.** One-local fix, do it first.
+In `compileExternrefArrayDestructuringAssignment` (`assignment.ts:2439`), the
+`__array_from_iter_n` result overwrites `tmpLocal` (`:2484`); the tail
+(`:2635`) then pushes `tmpLocal` as "the RHS value". Allocate a separate
+`__arr_destruct_mat_*` local for the materialized vec, keep `tmpLocal` holding
+the original externref, and push `tmpLocal` at the tail. Audit the object path
+(`compileDestructuringAssignment`, `:1137`) and the strict-throw early-outs for
+the same invariant (they push `ref.null.extern` — fine, unreachable).
+Accept: probe `probe1.js` reports `resultIsIterable=true`; the 13 A tests pass.
+
+**Step 2 — Cluster B (23): per-element iterator drive + IteratorClose for
+ArrayAssignmentPattern.** The big one. **Coordinate with #5144 Step 2** — it
+builds the identical per-element drive for for-of heads
+(`for-of-destructuring.ts:2055`) and pushes the §7.4.4/§7.4.9 refinements
+*into the shared runtime* (`__iterator_next` result-must-be-Object TypeError,
+`iterator-native.ts:516`; `__iterator_return` close-result validation,
+`buildIteratorReturnBody` `iterator-native.ts:1589`). Whoever lands first
+builds those runtime refinements once; the other consumes them. For this
+issue's path, replace the eager materialization in
+`compileExternrefArrayDestructuringAssignment` (`:2470-2486`) with:
+- GetIterator once (`__iterator`), keep a `done` i32 local (IteratorRecord
+  `[[done]]`).
+- Per AssignmentElement in §13.15.5.5 order: (1) evaluate the target lref
+  FIRST when the target is not a nested pattern — member/element targets
+  evaluate receiver+key here (fixes the two `evaluation-order` tests and the
+  `{}[thrower()]` shape); (2) IteratorStep via `__iterator_next` — a throw
+  from next propagates WITHOUT close; (3) default check + PutValue; (4) any
+  abrupt completion in (1)/(3), while `done` is false, runs IteratorClose with
+  that throw completion (return()'s own result/errors swallowed on throw
+  completions) and rethrows.
+- After the last element, no rest: if `done` false → IteratorClose with
+  NORMAL completion, which must validate: `return` absent/undefined ⇒ no-op,
+  non-callable ⇒ TypeError, call result not an Object ⇒ TypeError (the
+  `*close-null*` tests).
+- Empty patterns `[] = iterable`: still GetIterator then immediately close —
+  remove the `elements.length > 0` gate (fixes `array-empty-iter-close*`,
+  `array-empty-iter-get-err`).
+- Elisions consume an IteratorStep each; rest drains until done (rest path
+  keeps its unbounded drain but through the same live record so close/abrupt
+  rules apply — fixes `array-rest-lref*`, `array-rest-iter-thrw-close*`).
+- Wasm pattern for close-on-abrupt: `try_table` with **empty blocktype** only
+  (`1f 40`) — model callers `promise-executor.ts:192`, `calls.ts:152`. #5141
+  cluster-B found the codebase's one result-typed `try_table` traps V8 12.4;
+  do not add a second.
+- Keep the wasm-vec/tuple fast paths (`:1962`ff) untouched for statically
+  typed sources — the live drive is the externref/user-iterable lane only
+  (byte-stability for the common case, same rule as #5144 Step 2).
+- Prior art: `buildArrayFromIterNBody`'s bounded-stop close (#3100 S5,
+  `iterator-native.ts:769`ff) shows the record/next/return call shapes; #1454
+  is the host-mode ancestor of this exact bug class.
+Accept: all 23 B tests pass; A tests still pass.
+
+**Step 3 — Cluster C (13): PutValue guards on destructuring identifier
+writes.** All in the write funnel, so array+object paths get fixed together:
+- In `emitResolvedIdentifierWriteFromStack` (`identifier-assignment.ts:35`) —
+  or a thin wrapper used by the destructuring call sites — add the same
+  const/TDZ handling plain assignment has: reuse
+  `emitModuleLexicalAssignmentTdzGuard` (`identifier-assignment.ts:23`) /
+  `emitTdzCheck` (`statements/tdz.ts:61`) for `let` targets in their TDZ
+  (mimic #1128's declaration-side work), and emit
+  `emitThrowTypeError(ctx, fctx, "Assignment to constant variable.")`
+  (`js-errors.ts:111`) when the resolved symbol's declaration is a `const`
+  (use `ctx.oracle` / the declaration node — do NOT call the raw TS checker;
+  oracle-ratchet gate #1930/#3273).
+- Fix `emitStrictPutValueThrow` (`assignment.ts:1115`) to throw a real
+  ReferenceError instance via `emitThrowReferenceError` (`js-errors.ts:119`)
+  instead of `ref.null.extern` — fixes all four `*put-unresolvable-strict`
+  ("Thrown value was not an object!") and the `p-unres.js` probe.
+Accept: 13 C tests pass; `dstr/array-elem-put-unresolvable-no-strict.js`
+(sloppy: global write succeeds) must NOT regress — it's in cluster A's list.
+
+**Step 4 — Cluster E (9): NamedEvaluation in assignment positions.**
+- `fnInstanceNameOf` (`function-instance-meta.ts:256`): add an arm for
+  `ts.isShorthandPropertyAssignment(parent) && parent.objectAssignmentInitializer === node`
+  → `parent.name.text` (the `{ x = function(){} } = {}` shape; array-element
+  defaults `[x = fn]` already hit the BinaryExpression arm at `:300`).
+- `fnInstanceMetaOf` (`:320`): admit `ClassExpression` — anonymous classes
+  must carry `name` (+ correct descriptor: writable false, enumerable false,
+  configurable true — the tests use `verifyProperty`). Follow #1119/#1049
+  (the declaration-side SingleNameBinding fix,
+  `property-access-dispatch.ts:2876-2890`) for where the name surfaces in the
+  property model; class statics layout lives in `class-bodies.ts` — check how
+  named class expressions publish `name` today and reuse that slot.
+- `fn-name-cover`: `xCover = (0, function(){})` must stay UNnamed; if step
+  probes show it named, find and gate the second naming source (checker-symbol
+  contextual naming) with the same comma-vs-paren walk `fnInstanceNameOf` uses.
+Accept: 9 E tests pass; probe `p-fnname.js` prints `fn=x|cls=c|arrow=a`.
+
+**Step 5 — Cluster F (6): apply initializers in nested patterns.** Route the
+nested-pattern recursion through the same default-check used at top level: the
+array path's nested branch (`assignment.ts:2624`,
+`emitObjectDestructureFromLocal` `:2840`ff) and the object path's nested
+property handling must, for each leaf with an initializer, do the
+`__extern_is_undefined`-guarded default emit exactly as `:1491-1530` does
+(undefined fires the default, JS null does NOT). Standalone note:
+`__extern_is_undefined`'s `ensureLateImport` has a native registration —
+verify it resolves in standalone (the `:1508` comment warns the fallback
+treats null as undefined; that fallback would break `null`-vs-`undefined`
+tests). #4719 (in-review) touches the adjacent nested-array-undefined throw —
+merge its branch first or rebase over it.
+Accept: probe `p-nested.js` prints `x=5 y=6 z=7`; the 6 F tests pass.
+
+**Step 6 — Cluster D (6): stop dropping member/computed targets.**
+- `emitAssignToTarget` ElementAccess arm (`assignment.ts:2790`): when the
+  receiver is not a wasm-vec struct, route through `emitDynamicMemberSet`
+  (`:2664`) with the computed key — exactly what the PropertyAccess arm does
+  since #2869 (its comment at `:2785` documents the silent-drop hazard this
+  arm still has). Fixes `[ x[k] ] = [33]` (probe `p-elemtarget.js`).
+- Rest branch (`:2519`): accept PropertyAccess/ElementAccess rest targets —
+  drain into a fresh vec (existing `__extern_slice` shape), then assign via
+  `emitAssignToTarget` instead of requiring an Identifier.
+- Object-pattern computed property names (`{ [expr]: x } = v`): evaluate
+  `expr` (its abrupt completion must propagate — `obj-prop-name-evaluation-error`
+  expects the TypeError from `a.b` on undefined `a`) before the property read.
+- The two `obj-literal-prop-ref-init(-active)` tests: property-access target
+  with initializer — the lref (receiver+key) must be evaluated once, the
+  getter NOT invoked, the setter invoked with the final value; make sure the
+  step-2 lref-first ordering plus the default check compose here.
+Accept: 6 D tests pass.
+
+**Step 7 — Cluster H (2): early-error precision.**
+- `node-checks.ts:1926` (escaped `let`): skip identifier-NAME positions —
+  property names in PropertyAssignment/PropertyAccess/Method/PropertyDeclaration
+  (reuse the `isPropertyName` predicate shape at `:1740`). `let` as a
+  *binding/keyword* position must still error (spotcheck has
+  `syntax-error-ident-ref-let-escaped.js`-family tests — do not over-relax).
+- `node-checks.ts:1357` (duplicate `__proto__`): suppress when the
+  ObjectLiteralExpression is a destructuring assignment pattern — LHS of `=`
+  (walk parents through parens/nesting to a BinaryExpression EqualsToken LHS
+  position or a for-of/for-in head; `src/compiler/early-errors/assignment.ts`
+  already classifies pattern positions — reuse it).
+Accept: both H tests pass; spotcheck escaped-keyword tests still pass.
+
+**What NOT to do:**
+- No new host imports without a standalone fallback (dual-mode rule; the
+  standalone runner hard-fails on any `env::*` import — #2961 gate).
+- Never edit `tests/test262-runner.ts`, skip lists, or `scripts/*baseline*.json`.
+- Do not touch `generators-native*.ts` (that's #5141; avoids cross-PR
+  conflicts and the #5060 regression zone).
+- Do not "fix" cluster A by changing what `__array_from_iter_n` returns — its
+  vec result shape is load-bearing for #5144/for-of and spread consumers.
+- Do not regress the vec/tuple fast paths for typed sources — externref/user
+  -iterable lane only for the new drive.
+- Do not use result-typed `try_table` blocktypes (V8 12.4 trap, #5141 B).
+
+## Acceptance criteria
+
+- All tests in `.tmp/es2015/wp-assignment-current-fails.txt` pass via
+  `npx tsx .tmp/run-standalone.mts --list .tmp/es2015/wp-assignment-current-fails.txt`
+  — with the carve-out that the 26 cluster-G paths (the `*rtrn-close*` /
+  `*yield-expr*` / `array-iteration` / `array-rest-iteration` families listed
+  above) are gated on #5141; if #5141 has not merged, wave-1 is complete when
+  the remaining 72 pass and cluster G's failures are unchanged-or-better.
+- Every test in `.tmp/es2015/wp-assignment-passing-spotcheck.txt` still passes
+  (baseline today: 40/40, verified on head `86739f05`).
+- Ratchet gates pass (`node scripts/check-loc-budget.mjs && node
+  scripts/check-func-budget.mjs && node scripts/check-coercion-sites.mjs &&
+  npm run -s check:oracle-ratchet && npm run -s check:dead-exports`, chained,
+  plus the `LOC_GATE_BASE` CI-base simulation per CLAUDE.md).
+- Equivalence tests pass (`npm test -- tests/equivalence.test.ts`).
+
+## References
+
+- **#5141** (`plan/issues/5141-es2015-standalone-generators-wave1.md`) — owns
+  cluster G's root cause (generator admission gates, #680); its Step 1 also
+  fixes the #5060 resume-trap.
+- **#5144** (`plan/issues/5144-es2015-standalone-forof-wave1.md`) — sibling
+  wave building the SAME per-element iterator drive + shared
+  `__iterator_next`/`__iterator_return` refinements (its Step 2). Build the
+  runtime refinements once between the two PRs.
+- **#680** — native generator complex shapes (status: ready); cluster G's
+  upstream tracking issue.
+- **#1454, #1016, #1219, #1347** (done) — IteratorClose/error-propagation
+  prior art on other destructuring paths.
+- **#2904, #3100** (done) — `__array_from_iter_n` native drain + GetIterator
+  dispatch this plan builds on.
+- **#2869, #2664** (done) — dynamic member-set dispatcher; cluster D extends
+  it to the ElementAccess arm.
+- **#1119, #1049** (done) — SingleNameBinding/fn-name-cover NamedEvaluation
+  prior art for cluster E.
+- **#1128** (done) — destructuring TDZ prior art for cluster C.
+- **#4719** (in-review) — nested array element undefined throw; step 5
+  rebases over it.
+- **#2961** (done) — standalone host-import leak gate that makes cluster
+  fixes standalone-real.
+
+## Results
+
+Measured 2026-08-28 on this branch with
+`npx tsx .tmp/run-standalone.mts --list .tmp/es2015/wp-assignment-current-fails.txt`
+(98 paths) and the 40-path spotcheck.
+
+| | before | after |
+|---|---|---|
+| pass | 1 | 47 |
+| fail | 84 | 39 |
+| compile_error | 13 | 12 |
+| spotcheck | 40/40 | 40/40 |
+
+Note on the "before" numbers: the target list's own baseline reads 84 FAIL /
+14 CE. On this box two of those FAILs were an environment miss (the quickjs
+eval artifact was not reachable from a fresh worktree); after symlinking
+`.test262-cache` the pre-change state is 84 FAIL / 13 CE / 1 PASS, which is
+the baseline the table compares against.
+
+### Fixed
+
+- **Cluster A (completion value)** — the materialized vec now lands in its own
+  `__arr_destruct_mat_*` local, so `result = [x] = vals` yields `vals`
+  (`assignment.ts::compileExternrefArrayDestructuringAssignment`). An
+  out-of-range element of a vec source also reads `undefined` instead of JS
+  `null` (`emitBoundsCheckedArrayGet(..., ctx, true)`).
+- **Cluster C (PutValue guards)** — `emitStrictPutValueThrow` throws a real
+  ReferenceError instance; a new `emitPutValueTargetGuard`
+  (`identifier-assignment.ts`) applies the TDZ-then-const checks on every
+  destructuring identifier write, including rest targets and the
+  "field absent, value is undefined" arm; TDZ *reads* throw a ReferenceError
+  instance in the host-free lane.
+- **Cluster D (member / computed targets)** — the ElementAccess arm of
+  `emitAssignToTarget` routes a non-vec receiver through a new
+  `emitDynamicElementSet` (`__extern_set_strict`) instead of silently dropping
+  the write; an unresolvable computed property NAME is now evaluated for its
+  effect, so `({ [a.b]: x } = {})` throws.
+- **Cluster E (NamedEvaluation)** — `fnInstanceNameOf` gained the
+  ShorthandPropertyAssignment initializer arm, and the `.name` fold no longer
+  names a binding whose only assignments install a covered form
+  (`x = (0, function(){})`).
+- **Cluster F (nested patterns)** — nested array patterns accept member targets
+  and initializers; nested OBJECT patterns over an externref source are
+  destructured at all (new `emitExternrefObjectPatternWrites`) instead of
+  stopping at the null guard; the array-like rest-object reader stopped folding
+  a non-index key to element 0 and now honours defaults.
+- **Cluster B (partial)** — the `elements.length > 0` gate is gone, so
+  `[] = iterable` performs GetIterator and closes it
+  (`array-empty-iter-close`, `-close-err`, `-get-err`).
+- **Cluster H (partial)** — the duplicate-`__proto__` Early Error no longer
+  fires when the ObjectLiteral covers an ObjectAssignmentPattern.
+
+### Skipped — carried forward
+
+- **Cluster G (12 CE + ~10 FAIL)** — generator-coupled, owned by #5141 as the
+  plan's Step 0 says. Untouched.
+- **Cluster B, the per-element iterator drive (~20)** — `*-thrw-close*`,
+  `*-nrml-close-null*`, `array-rest-lref*`, the two `evaluation-order` tests.
+  This is the plan's Step 2 and needs the lref-first / IteratorClose rewrite
+  plus the shared §7.4.9 runtime refinements co-owned with #5144. One concrete
+  blocker found while scoping it: the close-result "must be an Object"
+  TypeError cannot be added inside `__iterator_return` alone, because the same
+  helper serves BOTH normal-completion closes (validate ⇒ throw) and
+  throw-completion closes (swallow); the completion kind has to reach it first.
+- **The 4 class-`name` tests** (`fn-name-class`, `*-init-fn-name-class`) —
+  `cls.name` already folds to `"cls"`, but the own-property DESCRIPTOR still
+  reports the compiler's synthetic `__anonClass_cls_1`. Setting the
+  NamedEvaluation name in `collectClassDeclaration` was verified to reach
+  `classObjectNameMetadata` with the right `displayName` and still did not
+  change the emitted descriptor, so a second, unidentified source publishes
+  that value; the change was reverted rather than shipped unproven.
+- **`obj-id-put-let` (1)** — a module-level `let x;` with NO initializer is not
+  registered in `ctx.tdzGlobals`, so the write-side guard has no flag to test.
+  Registering initializer-less lexicals is a broader change than this wave.
+- **`obj-prop-elem-target-obj-literal-prop-ref-init{,-active}` (2)** — member
+  target with an initializer over an object-literal receiver; needs the
+  step-2 lref-first ordering to compose with the default check.

--- a/plan/issues/5147-es2015-standalone-iterators-wave1.md
+++ b/plan/issues/5147-es2015-standalone-iterators-wave1.md
@@ -1,0 +1,416 @@
+---
+id: 5147
+title: "ES2015 standalone: iterators conformance wave 1"
+status: in-review
+sprint: current
+created: 2026-08-28
+updated: 2026-08-28
+priority: high
+horizon: l
+feasibility: medium
+task_type: conformance
+area: codegen
+es_edition: ES2015
+goal: standalone-mode
+requested_by: claude/fable-es2015
+loc-budget-allow:
+  - src/runtime.ts
+  - src/codegen/iterator-native.ts
+  - src/codegen/iter-lazy-native.ts
+  - src/codegen/array-object-proto.ts
+  - src/codegen/native-proto.ts
+  - src/codegen/expressions/call-tail-dispatch.ts
+  - src/codegen/expressions/call-receiver-method.ts
+  - src/codegen/closed-method-dispatch.ts
+  - src/codegen/property-access-dispatch.ts
+  - src/codegen/map-runtime.ts
+  # 2026-08-28 wave-1 implementation: the chunks/windows lazy kinds and the
+  # §7.4.11 result-object / native-`.next()` routing add new emitted-code paths
+  # (new struct field + steppers, two new reserve-then-fill helpers, one new
+  # dispatcher arm), plus their reserve-then-fill flags on the context type and
+  # their two finalize calls in the driver.
+  - src/codegen/context/types.ts
+  - src/codegen/index.ts
+  - src/codegen/expressions/call-tail-dispatch.ts
+func-budget-allow:
+  # 2026-08-28: `ensureLazyStepper` gains two more kind arms (chunks/windows,
+  # each a full buffered stepping loop) in the same one-function kind-dispatch
+  # shape every existing lazy kind lives in; the four other growths are the
+  # single new dispatcher arm / routing branch each site needed.
+  - src/codegen/iter-lazy-native.ts::ensureLazyStepper
+  - src/codegen/closed-method-dispatch.ts::fillClosedMethodDispatch
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
+  - src/codegen/expressions/call-tail-dispatch.ts::compileTailDispatch
+  - src/codegen/index.ts::generateModule
+---
+
+# #5147 — ES2015 standalone: iterators conformance wave 1
+
+## Problem
+
+95 of the 96 "iterators" work-package tests still fail on the standalone
+target (re-verified per-test on head `86739f05`, 2026-08-28: 95 FAIL, 1 —
+`SetIteratorPrototype/next/does-not-have-mapiterator-internal-slots-set.js` —
+already passes since the day-old baseline). The failures split cleanly:
+46 are the missing `Iterator.prototype.chunks`/`windows` methods (the
+iterator-chunking family, counted in this bucket by the runner — it is NOT
+in `PROPOSAL_FEATURES`, so it scores against conformance), and 49 are
+holes in the native iterator-protocol reification that #1320/#2038/#3013
+built: source-level `.next()` on a native iterator carrier returns null,
+the Array/Map/Set iterator-prototype singletons have no own `next`, and the
+`@@iterator` call arm only routes arrays. All are pure-Wasm work — no new
+host imports. Growth allowance for the files above granted 2026-08-28 for
+this change-set (rationale: new lazy-helper kinds, new GetIterator arms,
+and result-object materialization are new emitted-code paths, not
+refactors).
+
+Target list (regenerated today, authoritative):
+`.tmp/es2015/wp-iterators-current-fails.txt` (95 paths).
+Minimal repro probes used below are in `.tmp/probes5147/*.js`
+(run via `npx tsx .tmp/probe-one.mts <abs-path>`).
+
+## Current failure clusters
+
+Counts verified by classifying all 95 paths; sums to 95. Sample paths are
+relative to `test262/test/built-ins/`.
+
+| # | Cluster | Count | Root cause (file:function) | Sample tests |
+|---|---------|-------|----------------------------|--------------|
+| A | `Iterator.prototype.chunks`/`windows` missing | 46 | `src/codegen/iter-lazy-native.ts:60` `LAZY_ITER_METHODS` has no chunks/windows kinds, so the standalone lazy-helper dispatch (`closed-method-dispatch.ts:399`, `call-receiver-method.ts:3972`) never routes them → TypeError "called value is not a function" before any iteration. 42/46 call the method directly on a generator (`g().windows(2)`); 4 go through the runner's `Iterator.prototype` shim reflectively. | `Iterator/prototype/chunks/chunks-evenly-divisible.js`, `Iterator/prototype/windows/windows-basic.js`, `Iterator/prototype/chunks/callable.js` |
+| D | proto `next` not an own property + no brand check | 17 | `src/codegen/array-object-proto.ts:3156` `emitIteratorPrototypeSingleton` seeds only `@@toStringTag` for kinds Array/Map/Set; the own `next` closure exists only for String (#5099, same function, `kind === "String"` branch). `proto.next` → undefined → `verifyProperty` throws "Cannot convert undefined or null to object", `.call(...)` throws "reading 'call'". | `MapIteratorPrototype/next/name.js`, `SetIteratorPrototype/next/this-not-object-throw-values.js`, `ArrayIteratorPrototype/next/property-descriptor.js` |
+| B | `.next()` on a native iterator carrier returns null | 15 | `src/codegen/expressions/call-receiver-method.ts` ~L3585 (any/externref generic arm): `methodName === "next"` routes to `tryEmitAsyncGenNextDispatch`/`__gen_next`, neither of which recognizes the `$__IterRec` VEC carrier (`iterator-native.ts`, #1320/#2038) or the Map/Set carriers (`map-runtime.ts:1113` `__map_iter_next`) → nullish result; the subsequent `.value`/`.done` read (`property-access-dispatch.ts:3645`) throws "Cannot access property on null or undefined". Probe `s-nullish.js` proves `([1,2][Symbol.iterator]()).next() == null` is `true`. The `iteration-mutable` rows additionally need LIVE stepping (the VEC carrier snapshots eagerly at creation — probe test creates the iterator on an empty array, pushes, then nexts). | `ArrayIteratorPrototype/next/iteration.js`, `MapIteratorPrototype/next/iteration.js`, `ArrayIteratorPrototype/next/Float32Array.js` (9 TypedArray rows) |
+| C | `arguments[Symbol.iterator]` not routed | 8 | `src/codegen/expressions/call-tail-dispatch.ts:738-796` (@@iterator arm): only checker-proven arrays get the native `.values()` route (`:749`, #3013); an arguments-object receiver falls into the native `__iterator` GetIterator ladder (`iterator-native.ts` `buildIteratorBody`), which has no arguments-carrier arm → TypeError "called value is not a function". | `ArrayIteratorPrototype/next/args-mapped-iteration.js`, `ArrayIteratorPrototype/next/args-unmapped-expansion-before-exhaustion.js` |
+| E | `%IteratorPrototype%` not modeled | 6 | The kind singletons' `$Object.$proto` (field 0) is never set, so `Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))` is null → member access on null throws. `%IteratorPrototype%[@@iterator]` (a self-returning function, §25.1.2.1) does not exist anywhere. `join/not-a-constructor.js` needs `Iterator.prototype.join` to at least exist as a non-constructor function. | `Iterator/prototype/Symbol.iterator/prop-desc.js`, `Iterator/prototype/Symbol.iterator/return-val.js`, `Iterator/prototype/join/not-a-constructor.js` |
+| G | `"str"[Symbol.iterator]()` throws | 2 | Same @@iterator arm as C: no string arm, and the GetIterator ladder rejects `$AnyString` (#3388 non-iterable TypeError). String for-of works via a different lowering (`ensureStrToCharVecHelper`, #1470) — the computed-symbol call never reaches it. | `StringIteratorPrototype/next/next-iteration.js`, `StringIteratorPrototype/next/next-iteration-surrogate-pairs.js` |
+| F | detach-during-iteration unobservable | 1 | Eager VEC snapshot at iterator creation: the TypedArray iterator never re-reads its source, so `$DETACHBUFFER` mid-loop (runner sidecar `__detached__`, #1515) cannot throw the §23.2.3 TypeError. Needs a live TypedArray stepping arm + IsDetachedBuffer check. | `ArrayIteratorPrototype/next/detach-typedarray-in-progress.js` |
+
+**Dependency note (load-bearing for cluster A):** every chunks/windows test
+drives a generator source. Head carries the #5060 regression that makes every
+native-generator first resume trap `unreachable` (documented and owned by
+**#5141** cluster R0 — probe `r-genforof.js`: even `for (x of g())` traps on
+head). The cluster-A dispatch/implementation work is independent and can land
+first, but its test yield only realizes once #5141-R0 has landed. Clusters
+B/C/D/E/G/F use arrays/Map/Set/strings — not blocked.
+
+## Implementation Plan
+
+Ordered by cluster count descending (A → D → B → C → E → G → F), with one
+shared step first because D and B both consume it. Each step is
+independently landable; partial completion maximizes yield.
+
+**Step 0 — shared: native CreateIterResultObject (§7.4.11).**
+Add `ensureNativeIterResultObject(ctx)` in `src/codegen/iterator-native.ts`:
+a defined func `__iter_result_obj(done i32, value externref) -> externref`
+that builds a real `$Object` via `__new_plain_object` + two `__extern_set`
+(or `__defineProperty_value` with writable/enumerable/configurable = true —
+these are CreateDataPropertyOrThrow data properties) for keys "value"/"done";
+`value` when done must be the undefined singleton (`undefinedExternInstrs`,
+`src/codegen/any-helpers.ts`, #2106), never null. String keys via
+`nativeStringLiteralInstrs` (#3119 pattern, already imported in this file).
+Follow the reserve-then-fill funcIdx discipline of #1719 if any dependency is
+finalize-time; here all deps (`ensureObjectRuntime`) are eager, so a plain
+idempotent ensure-helper works. Then make the two IteratorResult read fast
+paths accept a `$Object` result: `property-access-dispatch.ts:3645` routes
+IteratorResult-typed `.value`/`.done` to `__gen_result_value`/`__gen_result_done`
+when those exist in funcMap — verify what fills them in standalone
+(`generators-native-consumer.ts:877-936`) and add a `ref.test $Object` →
+`__extern_get` arm to their bodies (or decline the fast path when the funcs
+are absent so the generic `__extern_get` dispatch reads the `$Object`
+naturally). Do NOT reuse `$MapIterResult`/`$NativeGeneratorResult` closed
+structs as the source-visible result — tests read properties dynamically and
+closed structs are invisible to `__extern_get` (the exact #25/#2038 trap).
+
+**Step A — `Iterator.prototype.chunks` / `windows` (46 tests).**
+Mimic the #2903 R3 lazy-helper pattern in `src/codegen/iter-lazy-native.ts`
+end-to-end — it is the existing analogous implementation (`map/filter/take/
+drop/flatMap` over one `$LazyIterHelper` closed struct + a single
+kind-dispatched `__lazy_iter_step`):
+1. Add kinds `chunks: 5`, `windows: 6` to `KIND` (`:63`) and both names to
+   `LAZY_ITER_METHODS` (`:60`); extend `isLazyIterForm` — chunks arity 1,
+   windows arity 1-2, and the arg is a NUMBER, not a callable (adjust any
+   callable-arg assumption in the wrapper allocation: store chunkSize/
+   windowSize in the `state` f64 field; the `fn` field stays null; the
+   `inner` externref field carries the accumulating buffer vec for chunks /
+   the rolling window vec for windows; windows' `undersized` mode
+   ("only-full" default vs "allow-partial") needs one more bit — pack it
+   into `state`'s sign/fraction or add one i32 field to the struct, all
+   kinds share the layout so a new field is mechanical).
+2. Validation at CALL time per the proposal (before the wrapper is
+   returned): ToIntegerOrInfinity, then RangeError unless in [1, 2^32-1]
+   (`windowSize-out-of-range.js` checks 0, -0, -1, 2^32, Infinity, NaN…),
+   with IteratorClose(underlying) before the throw. Throw pattern:
+   `emitWasiErrorConstructor` (`src/codegen/registry/error-types.ts`), same
+   as the #3388 TypeError in `iterator-native.ts` — check it supports
+   RangeError; the second windows arg validates `undersized` against
+   {"only-full","allow-partial"} → TypeError otherwise. CAUTION:
+   `chunks/chunkSize-not-a-number.js` currently PASSES (it is in the
+   spotcheck file) — keep its expected TypeError-on-non-number behavior.
+3. Stepping in `__lazy_iter_step`: chunks — pull from src via
+   `__iter_hof_next` into the buffer; when buffer length == chunkSize, emit
+   a REAL array (fresh vec each time — `yields-distinct-arrays.js` checks
+   `chunks[0] !== chunks[1]`); on src done, flush a non-empty partial
+   buffer (`chunks-last-chunk-partial.js`) and do NOT call src.return
+   (`exhaustion-does-not-call-return.js`). windows — same, but after the
+   first full window shift-by-one (copy, don't alias); "only-full" yields
+   nothing when src is shorter than windowSize (`undersized-default.js`),
+   "allow-partial" yields the one short window (`windows-allow-partial.js`).
+4. Reflective seeds: register both (plus a minimal non-constructor `join` —
+   eager string-concat over the source with "," default separator is enough
+   for `join/not-a-constructor.js`, which only checks it is a non-constructor
+   function) as own function properties of the %IteratorPrototype% singleton
+   from Step E, via `ensureStandaloneNativeMethodClosure`
+   (`src/codegen/native-proto.ts:780`) so `Iterator.prototype.chunks.call(...)`
+   and `isConstructor(...)` checks resolve (`callable.js`,
+   `non-constructible.js` — the closure must not be constructable, which
+   the native-method closure ABI already satisfies).
+5. Protocol-fidelity tail (get-next-method-only-once, next-method-throws,
+   *-throwing-done/value, underlying-iterator-advanced/closed-in-parallel,
+   return-is-forwarded*): these ride on the USER/OBJ carrier arms of
+   `__iter_hof_open`/`__iter_hof_next` (GetIteratorDirect must read `next`
+   ONCE at wrapper creation and cache it; abrupt `next` results must
+   propagate; `.return` on the wrapper forwards to the underlying iterator
+   exactly once, and not after exhaustion). Fix in `iter-hof-native.ts`'s
+   open/step helpers, not per-kind. Several of these also use
+   `class X extends Iterator` with accessor `next` — expect this sub-tail
+   to be bounded by class/accessor fidelity; land the rest first.
+
+**Step D — own `next` on the Array/Map/Set iterator-prototype singletons (17).**
+Extend `emitIteratorPrototypeSingleton` (`src/codegen/array-object-proto.ts:3156`):
+replicate the `kind === "String"` #5099 branch for Array/Map/Set. Each needs
+a per-kind brand glue à la `ensureStringNativeProtoGlue` (`:2187`) +
+`ensureStandaloneNativeMethodClosure(ctx, brand, "next", "method")`, seeded
+with descriptor bits writable:true/enumerable:false/configurable:true
+(`0x01|0x04`, exactly as the String branch). That alone fixes the metadata
+rows (`name.js`, `length.js`, `property-descriptor.js` — the #5099 machinery
+already emits correct `name`/`length` rows; proof: `StringIteratorPrototype/
+next/name.js+length.js` pass today). The closure BODY must be behavioral,
+not a stub: brand-check `this` via `ref.test` against the kind's carrier
+struct (`$__IterRec` for Array; the Map/Set iterator structs in
+`map-runtime.ts` — see `__map_iter_next` `:1113`), step it (Step B's
+routing), wrap via `__iter_result_obj`; any other receiver — primitives,
+plain objects, cross-kind iterators (`this-not-object-throw-*.js`,
+`does-not-have-*iterator-internal-slots*.js` do BOTH directions) — throws a
+native TypeError (#3388 pattern). Coordinate with in-flight **#4777**
+(Map/Set @@toStringTag on the same singletons — same function, additive
+branches) to avoid a textual conflict.
+
+**Step B — make `.next()` on native iterator carriers actually step (15).**
+Two routing layers:
+1. Static: in `call-receiver-method.ts`, BEFORE the generator/`__gen_next`
+   arms, add an arm keyed the same way #3013/#4747/#4777 key their
+   getPrototypeOf routing (`call-builtin-static.ts:2148-2200`): receiver
+   checker symbol `ArrayIterator`/`MapIterator`/`SetIterator`/`StringIterator`
+   (use `ctx.oracle` for any NEW type queries — raw `ctx.checker.*` additions
+   trip the oracle-ratchet gate) with methodName `next` (0-arg) → compile
+   receiver to externref, call `__iterator_next` (multivalue `i32 done,
+   externref value` — `iterator-native.ts:2393` `buildIteratorNextBody`), wrap
+   via `__iter_result_obj`. Also `return` (§23.1.5.2.2 has none for array
+   iterators, skip) — only `next` is needed for this list.
+2. Dynamic: the same tests often hold the iterator in an untyped var; in the
+   any/externref generic arm (~L3585) prepend a runtime `ref.test $__IterRec`
+   dispatch (pattern: the #2865 `tryEmitAsyncGenNextDispatch` runtime
+   dispatch in the same file) that steps via `__iterator_next` on hit and
+   falls through to the existing `__gen_next` behavior on miss.
+3. Live stepping for the `iteration-mutable` rows (3 of the 15): the VEC
+   snapshot is taken at iterator creation, so mutations are invisible. Add a
+   live arm to the carrier — hold the SOURCE array struct + cursor and
+   re-read `vec.length` each step — following the #4708 pattern (it replaced
+   the standalone Set-values snapshot with a live `$Map`-entry cursor for
+   for-of; reuse its carrier if reachable). The 9 TypedArray rows work with
+   the plain snapshot fix (their arrays aren't mutated) — do not block them
+   on this.
+4. Map/Set: `new Map(...).keys().next()` must route through the Map runtime's
+   own stepping (`__map_iter_next`, `map-runtime.ts:1113`, returns
+   `$MapIterResult {value anyref, done i32}`) — unwrap into
+   `__iter_result_obj`, entries yield the `[k,v]` pair array exactly as the
+   for-of lowering already builds it.
+
+**Step C — arguments-object `@@iterator` (8).**
+In the @@iterator arm (`call-tail-dispatch.ts:749`), the #3013 array route
+keys on `resolveArrayInfo(ctx, receiverType)`. An `arguments` receiver
+compiles to whatever carrier the arguments-object lowering uses — find it
+(grep `arguments` in `src/codegen/expressions/identifiers.ts` /
+`func-space`), and route it like an array: §22.1.3.40 — the arguments
+iterator IS `Array.prototype.values` semantics over the captured elements.
+If arguments already lowers to a vec-backed carrier, `compileArrayMethodCall
+(..., "values")` may work as-is once the receiver is admitted; the
+mapped-vs-unmapped distinction (`args-mapped-*` vs `args-unmapped-*`) only
+matters through the parameter-alias writes the tests do BEFORE/AFTER
+grabbing the iterator — snapshot semantics of the existing carrier decide
+how many of the 8 land; take the iteration ones first
+(`args-*-iteration.js`), the expansion/truncation ones need the live arm
+from Step B-3.
+
+**Step E — `%IteratorPrototype%` singleton (6).**
+Add kind `"Iterator"` (the root) to `emitIteratorPrototypeSingleton`: mint
+one more `$Object` global. Wire the four kind singletons' `$proto`
+(`$Object` field 0 — the #1472 Phase C prototype-chain slot that
+`Object.getPrototypeOf`'s dynamic `$Object` path already reads; verify via
+`object-runtime.ts:11987`) to it at their init. Seed it with own property
+`[Symbol.iterator]` (boxed well-known symbol id 0 — reuse the `__box_symbol`
++ `__defineProperty_value` recipe already in this function for
+@@toStringTag; descriptor writable:true/enumerable:false/configurable:true
+per `prop-desc.js`): a native closure that RETURNS ITS RECEIVER
+(`return-val.js` does `getIterator.call(thisValue) === thisValue`), with
+function metadata name `"[Symbol.iterator]"` and length 0 (`name.js`,
+`length.js`). This also makes the runner's `Iterator` shim
+(`Iterator.prototype = getProtoOf(getProtoOf([][Symbol.iterator]()))`)
+resolve to this object — which is what Step A-4's reflective seeds and
+cluster A's 4 reflective tests stand on.
+
+**Step G — string `@@iterator` (2).**
+Same arm as Step C: admit checker-proven string receivers (and
+`$AnyString`-carrier dynamics) and produce the string code-point iterator
+the existing machinery already knows how to build — `ensureStrToCharVecHelper`
+(#1470, `native-strings.ts`; it is what `__extern_slice`'s $AnyString rest
+arm uses) → per-code-point char vec → VEC `$__IterRec`. Surrogate pairs
+must stay paired (`next-iteration-surrogate-pairs.js`) — the #1470 helper is
+already code-point-correct. The static result type will be
+`StringIterator`, which keeps #4747's getPrototypeOf routing coherent.
+
+**Step F — detach-during-iteration (1, stretch).**
+Requires a live TypedArray arm in the IterRec (Step B-3's shape, holding the
+TA view) + an IsDetachedBuffer check per step consulting the runner's
+`__detached__` sidecar the DataView dispatch already checks (#1515 — grep
+`__detached__` in `src/codegen/`). Defer if the live arm doesn't land;
+1 test.
+
+**What NOT to do:**
+- No new host imports without a standalone fallback (the runner FAILS any
+  standalone module that emits host imports — `standaloneHostImportError`).
+  Everything above is defined-Wasm-function work.
+- Never edit `tests/test262-runner.ts`, skip lists, or
+  `scripts/*baseline*.json` (main is the baselines' sole writer). The
+  runner's `Iterator` shim stays as-is — make the compiled code satisfy it.
+- New type-info queries go through `ctx.oracle` (`src/checker/oracle.ts`),
+  not raw `ctx.checker.*` — the oracle-ratchet gate blocks raw additions
+  (grant `oracle-ratchet-allow:` only for genuine ValType-level questions).
+- Don't return closed structs (`$MapIterResult`, `$NativeGeneratorResult`,
+  `$LazyIterHelper`) as source-visible iterator RESULTS — dynamic property
+  reads can't see them (`__extern_get` gates on `$Object`); wrap through
+  `__iter_result_obj`.
+- Don't re-fix the generator-resume `unreachable` regression here — #5141
+  owns it (its R0). If it hasn't landed when cluster A is done, report the
+  A-cluster tests as blocked-on-#5141 rather than chasing the trap.
+- Late imports: use `ensureLateImport` + `flushLateImportShifts` and the
+  reserve-then-fill discipline (#1719/#2043) — no bare funcIdx caching
+  across late additions.
+
+## Acceptance criteria
+
+- All 95 tests in `.tmp/es2015/wp-iterators-current-fails.txt` pass via the
+  probe (`npx tsx .tmp/run-standalone.mts --list
+  .tmp/es2015/wp-iterators-current-fails.txt` → SUMMARY all pass), with the
+  cluster-A generator-sourced rows evaluated on a head that includes the
+  #5141-R0 regression fix (report them separately if that has not landed).
+- Every test in `.tmp/es2015/wp-iterators-passing-spotcheck.txt` (19 paths,
+  includes `chunks/chunkSize-not-a-number.js` and the #5099 String rows)
+  still passes.
+- Source-ratchet gates pass, chained before commit: `node
+  scripts/check-loc-budget.mjs && node scripts/check-func-budget.mjs && node
+  scripts/check-coercion-sites.mjs && npm run -s check:oracle-ratchet && npm
+  run -s check:dead-exports`.
+- Equivalence tests pass (`npm test -- tests/equivalence.test.ts`).
+
+## Results (wave 1, 2026-08-28)
+
+Measured with `npx tsx .tmp/run-standalone.mts --list …` on this branch.
+
+| List | Before | After |
+|---|---|---|
+| `.tmp/es2015/wp-iterators-current-fails.txt` (95) | 0 pass / 95 fail | **16 pass / 79 fail** |
+| `.tmp/es2015/wp-iterators-passing-spotcheck.txt` (19) | 19 pass | **19 pass** (no regression) |
+| whole `Iterator/prototype/{chunks,windows}` dir (78) | 9 pass | **26 pass** |
+
+**Landed**
+
+- **Cluster A (partial, +16).** `Iterator.prototype.chunks` / `.windows` are
+  implemented as two new `$LazyIterHelper` kinds in
+  `src/codegen/iter-lazy-native.ts`: a `$Vec` buffer in the wrapper's `inner`
+  field (four new primitives `__lazy_buf_{new,push,copy,shift}`), a new
+  mutable `flags` field (bit 0 = source exhausted, bit 1 = windows
+  `allow-partial`), and full call-time argument validation — TypeError for a
+  non-Number / non-integral / non-finite size, RangeError outside
+  `[1, 2^32-1]`, TypeError for an `undersized` other than `undefined` /
+  `"only-full"` / `"allow-partial"`. All the yield-shape rows pass
+  (evenly-divisible, partial last chunk, size-1, size-larger-than-iterator,
+  distinct arrays, sliding windows 1/2/3, allow-partial, undersized-default,
+  already-exhausted, out-of-range, callable).
+  - The dispatcher (`closed-method-dispatch.ts`) passes the second source-level
+    argument plus an i32 "was it supplied" flag: a null externref cannot
+    distinguish an absent argument from a source-level `null`, and
+    `windows(1, null)` must throw while `windows(1)` must not.
+- **Shared step 0.** `__iter_result_obj(done, value)` builds a real `$Object`
+  (§7.4.11) with `value` / `done` data properties — never a closed struct, which
+  `__extern_get` cannot see. `__iter_next_result(recv)` packages one ladder step
+  as a single-result call.
+- **`.next()` on a native carrier.** `__call_m_next_0` gains a
+  `ref.test __IterRec ∨ $LazyIterHelper` arm ahead of the
+  `__extern_method_call` fallback, and the two `.next()` call sites in
+  `call-receiver-method.ts` route through `__any_iter_next` (whose miss arm is
+  the pre-existing `__gen_next`). `__iterator` also gained the §7.4.1 identity
+  arm for an `$__IterRec` subject.
+
+**Skipped / follow-ups**
+
+- **Clusters B, C, D, E, F, G are NOT done** (79 remaining). The blocker is one
+  shared fact: `<array>[Symbol.iterator]()` still lowers to
+  `Array.prototype.values`' SNAPSHOT vec (`call-tail-dispatch.ts`), and a vec
+  has no cursor, so `.next()` on it cannot step. Switching that arm to
+  `__iterator(recv)` (a real `$__IterRec`) was implemented and measured on this
+  branch: it fixed `Array.from(it)` and simple `it.next()` shapes but left the
+  95-list at the same 16 and broke `array[Symbol.iterator]().next()` for a
+  variable receiver, so it was reverted (the note is left in the code). The
+  carrier migration must move `%ArrayIteratorPrototype%` (#3013/#4747) with it —
+  that is the next wave's first task, and clusters B and D fall out of it.
+- Cluster A's remaining rows split into (i) the reflective/metadata set
+  (`is-function`, `prop-desc`, `name`, `length`, `non-constructible`,
+  `result-is-iterator`), which needs the Step E `%IteratorPrototype%` singleton
+  plus the Step A-4 seeds, and (ii) the protocol-fidelity tail
+  (`get-next-method-only-once`, `next-method-*`, `return-is-*`,
+  `underlying-iterator-*`), which drives `class X extends Iterator` receivers
+  through `__iter_hof_open`/`__iter_hof_next` and needs the GetIteratorDirect
+  read-`next`-once + abrupt-completion work in `iter-hof-native.ts`.
+- **Latent bug found and worked around, worth its own issue:** feeding a
+  MULTI-RESULT call straight into a two-parameter call
+  (`call __iterator_next` → `call __iter_result_obj`) is mis-read by
+  `stack-balance.ts`'s call-argument repair once that sequence is cloned into
+  another body — it models one pushed result, under-flows, and "repairs" the
+  receiver by unboxing it to i32, producing a module that fails validation.
+  `__iter_next_result` spills to locals to avoid it.
+
+**Validation**: all five source-ratchet gates green (loc/func allowances
+granted in this file's frontmatter). Equivalence: the 50 iterator/generator/
+array/map/set/destructuring/spread files run clean except
+`tests/equivalence/array-inline-return.test.ts`, which fails identically on an
+unmodified `src/` (pre-existing). The full 219-file equivalence directory OOMs
+in this container, so it was run as that subset.
+
+## References
+
+- **#5141** — generators wave 1: owns the head `unreachable`-on-first-resume
+  regression (PR #5060) that gates cluster A's yield; shares
+  `iterator-native.ts`.
+- **#5139 / #5146** — sibling ES2015-standalone wave-1 issues (class /
+  assignment), same head, same probe tooling.
+- **#3013** — `%ArrayIteratorPrototype%` singleton + array `@@iterator` →
+  `.values()` routing (the pattern Steps C/G extend).
+- **#5099** (done) — String iterator-prototype `next` metadata closure (the
+  pattern Step D replicates per kind).
+- **#4747** — `%StringIteratorPrototype%` getPrototypeOf routing.
+- **#4777** (in-progress) — Map/Set iterator-prototype @@toStringTag; same
+  `emitIteratorPrototypeSingleton` function as Step D — coordinate.
+- **#4731** (in-progress) — Set iterator non-constructor semantics
+  (`Set/prototype/*` rows — disjoint test set, adjacent machinery).
+- **#4708** (done) — live `$Map`-entry cursor replacing the Set-values
+  snapshot (the live-stepping pattern for Step B-3).
+- **#4742** (done) — `Array.prototype[Symbol.iterator]` exposure.
+- **#1320 / #2038 / #3388** — the native `$__IterRec` GetIterator ladder
+  this issue extends (design notes at the top of
+  `src/codegen/iterator-native.ts`).
+- **#2903 R3** — lazy iterator helpers (`iter-lazy-native.ts`), the direct
+  template for chunks/windows.
+- **#1718** (done) — js-host iterator sequencing helpers (prior art for the
+  helper semantics, host mode).
+- **#681 / #2860** — standalone iterator-protocol / standalone-gap
+  umbrellas.

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -45,7 +45,8 @@ import { ensureNativeArrayHof, NATIVE_HOF_METHODS } from "./hof-native.js";
 import { COLLECTION_KIND, ensureMapHelpers, MAP_LAYOUT } from "./map-runtime.js"; // (#3309) $Map brand arm
 import { ensureSetHelpers } from "./set-runtime.js"; // (#3309) __set_add for the `add` arm
 import { ensureNativeIterHof, isIterHofForm, NATIVE_ITER_HOF_METHODS } from "./iter-hof-native.js"; // (#2903)
-import { ensureNativeLazyIter, isLazyIterForm, LAZY_ITER_METHODS } from "./iter-lazy-native.js"; // (#2903 R3)
+import { ensureNativeLazyIter, isLazyIterForm, LAZY_ITER_ARG2_METHODS, LAZY_ITER_METHODS } from "./iter-lazy-native.js"; // (#2903 R3)
+import { ensureNativeIteratorRuntime, ensureNativeIterResultObject } from "./iterator-native.js"; // (#5147)
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { ensureObjVecBuilders, reserveApplyClosure } from "./object-runtime.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
@@ -399,6 +400,13 @@ export function reserveClosedMethodDispatch(ctx: CodegenContext, methodName: str
   if (ctx.standalone && LAZY_ITER_METHODS.has(methodName) && isLazyIterForm(methodName, arity)) {
     ensureNativeLazyIter(ctx, methodName);
   }
+
+  // (#5147) `.next()` on a dynamic receiver may hit a native iterator carrier —
+  // register the GetIterator ladder + the §7.4.11 result-object builder NOW so
+  // the fill only READS funcMap (#1719).
+  // (`__iter_result_obj` itself is registered from `ensureNativeIteratorRuntime`
+  // — registering it HERE would add imports mid-body and shift funcIdxs under
+  // the caller.)
 
   // Signature: (recv, arg0..arg{arity-1}) all externref → externref.
   const params: ValType[] = Array.from({ length: arity + 1 }, () => ({ kind: "externref" }) as ValType);
@@ -947,9 +955,19 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
       ) {
         const lazyCall: Instr[] = [
           { op: "local.get", index: 0 }, // recv
-          { op: "local.get", index: 1 }, // arg0 (mapper/predicate | count)
-          { op: "call", funcIdx: lazyCtorIdx },
+          { op: "local.get", index: 1 }, // arg0 (mapper/predicate | count | size)
         ];
+        // (#5147) chunks/windows take a second source-level argument
+        // (`windows(size, undersized)`); pass undefined-as-null when the call
+        // site supplied only one.
+        if (LAZY_ITER_ARG2_METHODS.has(methodName)) {
+          // The trailing i32 says whether the call site SUPPLIED arg1 at all —
+          // `windows(1, null)` must throw while `windows(1)` must not, and a
+          // null externref cannot distinguish "absent" from source-level `null`.
+          lazyCall.push(arity >= 2 ? { op: "local.get", index: 2 } : { op: "ref.null.extern" });
+          lazyCall.push({ op: "i32.const", value: arity >= 2 ? 1 : 0 });
+        }
+        lazyCall.push({ op: "call", funcIdx: lazyCtorIdx });
         // isNotIterTarget = null ∨ $Object ∨ $__vec_base ∨ $ObjVec — a NULL/
         // $Object/vec receiver keeps the legacy route; everything else (iterator
         // carriers) constructs the lazy wrapper.
@@ -981,6 +999,40 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
             blockType: { kind: "val", type: { kind: "externref" } },
             then: current,
             else: lazyCall,
+          },
+        ];
+      }
+    }
+
+    // (#5147) NATIVE-ITERATOR `.next()` arm. `it.next()` on a value holding a
+    // `$IterRec` (what `[1,2][Symbol.iterator]()` / `new Map().keys()` produce)
+    // or a `$LazyIterHelper` (`.chunks(2)`) previously fell to
+    // `__extern_method_call`, which answers null on a non-`$Object` receiver —
+    // so `.value`/`.done` then threw "Cannot access property on null". Step the
+    // carrier through the fully-armed `__iterator_next` and materialize a REAL
+    // §7.4.11 result object. Placed outermost: a user closed struct with its own
+    // `next` is neither carrier, so the `ref.test` misses and precedence holds.
+    if (ctx.standalone && methodName === "next" && arity === 0) {
+      const stepResultIdx = ctx.funcMap.get("__iter_next_result");
+      const carrierTypeIdxs = [ctx.structMap.get("__IterRec"), ctx.structMap.get("$LazyIterHelper")].filter(
+        (t): t is number => t !== undefined,
+      );
+      if (stepResultIdx !== undefined && carrierTypeIdxs.length > 0) {
+        const carrierTest: Instr[] = [];
+        for (const t of carrierTypeIdxs) {
+          carrierTest.push({ op: "local.get", index: anyLocalIdx }, { op: "ref.test", typeIdx: t });
+          if (carrierTest.length > 2) carrierTest.push({ op: "i32.or" });
+        }
+        current = [
+          ...carrierTest,
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: [
+              { op: "local.get", index: 0 },
+              { op: "call", funcIdx: stepResultIdx },
+            ],
+            else: current,
           },
         ];
       }

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2325,6 +2325,17 @@ export interface CodegenContext extends StandaloneCapabilityDemandState, BodyRou
    */
   nativeIteratorUserArmPending?: boolean;
   /**
+   * (#5147) Set by `reserveAnyIterNext` — `__any_iter_next` was minted with a
+   * placeholder body that `fillAnyIterNext` must replace at finalize (it needs
+   * the `$LazyIterHelper` type and the ladder's late arms, which only exist by
+   * then). Same reserve-then-fill discipline as `nativeIteratorUserArmPending`.
+   */
+  anyIterNextPending?: boolean;
+  /** (#5147) `__iter_result_obj` reserved with a placeholder body; filled at finalize. */
+  iterResultObjPending?: boolean;
+  /** (#5147) the `$__IterRec` identity arm was already prepended to `__iterator`. */
+  iterRecIdentityArmDone?: boolean;
+  /**
    * Static property initializer expressions to compile into __module_init.
    * `className` (#1395) is the owning class name — used to set
    * `enclosingClassName` + `isStaticContext` on the initFctx so `this`

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -119,7 +119,7 @@ import {
 import { emitMappedArgParamSync, emitMappedArgReverseSync } from "./logical-ops.js";
 import { resolveStructName, resolveStructNameForExpr } from "./misc.js";
 import { tryCompileStandaloneRegExpLastIndexWrite } from "../regexp-standalone.js";
-import { emitResolvedIdentifierWriteFromStack } from "./identifier-assignment.js";
+import { emitPutValueTargetGuard, emitResolvedIdentifierWriteFromStack } from "./identifier-assignment.js";
 import { currentSourceModuleGlobalIndex, identifierHasOnlyAmbientDeclarations } from "./identifier-module-storage.js";
 import { tryCompileStandaloneDetachedWrite } from "../dataview-native.js"; // (#3173) $DETACHBUFFER marker write
 import { externrefBackedOwnFieldBacking, getOrRegisterErrorStructType } from "../registry/error-types.js";
@@ -1114,9 +1114,23 @@ function objectLiteralInitializerHasProperty(ctx: CodegenContext, receiver: ts.I
  */
 function emitStrictPutValueThrow(ctx: CodegenContext, fctx: FunctionContext): void {
   fctx.body.push({ op: "drop" });
-  const tagIdx = ensureExnTag(ctx);
-  fctx.body.push({ op: "ref.null.extern" });
-  fctx.body.push({ op: "throw", tagIdx });
+  // (#5146 cluster C) Throw a real ReferenceError INSTANCE. The previous
+  // `ref.null.extern; throw` produced a null payload, so `assert.throws(
+  // ReferenceError, …)` reported "Thrown value was not an object!".
+  emitThrowReferenceError(ctx, fctx, "assignment to undeclared variable");
+}
+
+/**
+ * (#5146 cluster D) §13.15.5.3 step 1: a computed PropertyName is EVALUATED
+ * before the property is read, so its abrupt completion propagates —
+ * `({ [a.b]: x } = {})` with `a === undefined` must throw a TypeError. The
+ * destructuring paths skip keys they cannot fold to a literal string; evaluate
+ * such a key for its effect (and drop the value) instead of skipping silently.
+ */
+function emitUnresolvedComputedKeyForEffect(ctx: CodegenContext, fctx: FunctionContext, name: ts.PropertyName): void {
+  if (!ts.isComputedPropertyName(name)) return;
+  const keyType = compileExpression(ctx, fctx, name.expression);
+  if (keyType && typeof keyType !== "symbol") fctx.body.push({ op: "drop" });
 }
 
 function collectObjectRestExcludedKeys(ctx: CodegenContext, target: ts.ObjectLiteralExpression): string[] {
@@ -1277,6 +1291,9 @@ function compileDestructuringAssignment(
               targetName = te.text;
               targetIdentifier = te;
             }
+          }
+          if (keyName === undefined && ts.isPropertyAssignment(prop)) {
+            emitUnresolvedComputedKeyForEffect(ctx, fctx, prop.name);
           }
           if (keyName === undefined || targetName === undefined || targetIdentifier === undefined) continue;
           const name = targetName;
@@ -1449,10 +1466,10 @@ function compileDestructuringAssignment(
       // holds undefined).
       if (fieldIdx === -1) {
         if (!prop.objectAssignmentInitializer) {
-          // No default, no field — silently skip (the destructured local
-          // is already undefined / its zero value). This matches the
-          // "primitive RHS / no destructure" branch above which lets
-          // bindings stay at their defaults.
+          // No default, no field — the value is `undefined`. The store itself
+          // is a no-op (the binding already holds undefined), but PutValue's
+          // const/TDZ checks still run (#5146 cluster C).
+          emitPutValueTargetGuard(ctx, fctx, prop.name, false);
           continue;
         }
         // Auto-allocate local if not declared. Use externref so a
@@ -1559,7 +1576,10 @@ function compileDestructuringAssignment(
       if (!propName && ts.isComputedPropertyName(prop.name)) {
         propName = resolveComputedKeyExpression(ctx, prop.name.expression);
       }
-      if (!propName) continue; // truly unresolvable property name — skip
+      if (!propName) {
+        emitUnresolvedComputedKeyForEffect(ctx, fctx, prop.name);
+        continue; // truly unresolvable property name — skip
+      }
 
       // Determine the target and optional default value FIRST — the missing-
       // field arm below needs the default to fire it on an absent property. (#2845)
@@ -2018,7 +2038,10 @@ function compileArrayDestructuringAssignment(
     if (isVecStruct) {
       fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 1 }); // get data array
       fctx.body.push({ op: "i32.const", value: i });
-      emitBoundsCheckedArrayGet(fctx, arrTypeIdx, arrDef!.element);
+      // (#5146) An out-of-range element of an ArrayAssignmentPattern is
+      // `undefined` (the iterator is exhausted), not JS `null` — pass the
+      // undefined sentinel like the other destructuring readers do.
+      emitBoundsCheckedArrayGet(fctx, arrTypeIdx, arrDef!.element, ctx, true);
     } else {
       // Tuple: direct struct.get with field index
       fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: i });
@@ -2135,6 +2158,8 @@ function compileArrayDestructuringAssignment(
         // Dispatch on the rest target kind (mirrors the non-rest element
         // dispatch below). The collected vec lives in `tmpRestVec`.
         if (ts.isIdentifier(restTarget)) {
+          // (#5146 cluster C) A rest target obeys PutValue like any other target.
+          if (emitPutValueTargetGuard(ctx, fctx, restTarget, false)) continue;
           const restName = restTarget.text;
           let restLocalIdx = fctx.localMap.get(restName);
           if (restLocalIdx === undefined) {
@@ -2467,7 +2492,15 @@ function compileExternrefArrayDestructuringAssignment(
   // consumes EXACTLY target.elements.length iterator steps rather than
   // draining a lazy generator; a rest element passes -1 → unbounded, which is
   // byte-identical to the legacy __array_from_iter drain (#1592).
-  if (resultType.kind === "externref" && target.elements.length > 0) {
+  //
+  // (#5146 cluster A) The materialized vec goes into its OWN local: the
+  // completion value of a destructuring assignment is the ORIGINAL rval
+  // (§13.15.2 step 4 returns `rval`), not the internal materialization.
+  // Overwriting `tmpLocal` here made `result = [x] = vals` yield the vec.
+  let matLocal = tmpLocal;
+  // (#5146 cluster B) `[] = iterable` still performs GetIterator and closes it
+  // immediately (§13.15.5.2), so the empty-pattern gate is gone.
+  if (resultType.kind === "externref") {
     const matStepCount = patternIteratorStepCount(target.elements);
     const matIterIdx = ensureLateImport(
       ctx,
@@ -2477,10 +2510,11 @@ function compileExternrefArrayDestructuringAssignment(
     );
     flushLateImportShifts(ctx, fctx);
     if (matIterIdx !== undefined) {
+      matLocal = allocLocal(fctx, `__arr_destruct_mat_${fctx.locals.length}`, resultType);
       fctx.body.push({ op: "local.get", index: tmpLocal });
       fctx.body.push({ op: "f64.const", value: matStepCount });
       fctx.body.push({ op: "call", funcIdx: matIterIdx });
-      fctx.body.push({ op: "local.set", index: tmpLocal });
+      fctx.body.push({ op: "local.set", index: matLocal });
     }
   }
 
@@ -2515,6 +2549,8 @@ function compileExternrefArrayDestructuringAssignment(
     if (ts.isSpreadElement(element)) {
       const restTarget = element.expression;
       if (ts.isIdentifier(restTarget)) {
+        // (#5146 cluster C) A rest target obeys PutValue like any other target.
+        if (emitPutValueTargetGuard(ctx, fctx, restTarget, false)) continue;
         const restName = restTarget.text;
         let restLocalIdx = fctx.localMap.get(restName);
         if (restLocalIdx === undefined) {
@@ -2529,7 +2565,7 @@ function compileExternrefArrayDestructuringAssignment(
           getIdx = ctx.funcMap.get(readName);
         }
         if (sliceIdx !== undefined) {
-          fctx.body.push({ op: "local.get", index: tmpLocal });
+          fctx.body.push({ op: "local.get", index: matLocal });
           fctx.body.push({ op: "f64.const", value: i });
           fctx.body.push({ op: "call", funcIdx: sliceIdx });
           fctx.body.push({ op: "local.set", index: restLocalIdx });
@@ -2538,7 +2574,7 @@ function compileExternrefArrayDestructuringAssignment(
       continue;
     }
 
-    fctx.body.push({ op: "local.get", index: tmpLocal });
+    fctx.body.push({ op: "local.get", index: matLocal });
     fctx.body.push({ op: "f64.const", value: i });
     if (!useIdxReads) fctx.body.push({ op: "call", funcIdx: boxIdx! });
     fctx.body.push({ op: "call", funcIdx: getIdx! });
@@ -2732,6 +2768,50 @@ function emitDynamicMemberSet(
   if (setIdx !== undefined) fctx.body.push({ op: "call", funcIdx: setIdx });
 }
 
+/**
+ * (#5146 cluster D) `obj[key] = value` for a destructuring ElementAccess target
+ * whose receiver is NOT a wasm vec. The receiver is already on the stack (the
+ * caller compiled it); the key is evaluated here, both are coerced to
+ * `externref`, and the write goes through the `__extern_set_strict` terminal —
+ * the ElementAccess twin of `emitDynamicMemberSet`.
+ */
+function emitDynamicElementSet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.ElementAccessExpression,
+  recvType: ValType,
+  valueLocal: number,
+  valueType: ValType,
+): void {
+  if (recvType.kind !== "externref") coerceType(ctx, fctx, recvType, { kind: "externref" });
+  const objLocal = allocLocal(fctx, `__dstr_eset_obj_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: objLocal });
+
+  const keyType = compileExpression(ctx, fctx, target.argumentExpression, { kind: "externref" });
+  if (!keyType) return;
+  if (keyType.kind !== "externref") coerceType(ctx, fctx, keyType, { kind: "externref" });
+  const keyLocal = allocLocal(fctx, `__dstr_eset_key_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: keyLocal });
+
+  fctx.body.push({ op: "local.get", index: valueLocal });
+  if (valueType.kind !== "externref") coerceType(ctx, fctx, valueType, { kind: "externref" });
+  const valLocal = allocLocal(fctx, `__dstr_eset_val_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: valLocal });
+
+  const setIdx = ensureLateImport(
+    ctx,
+    "__extern_set_strict",
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (setIdx === undefined) return;
+  fctx.body.push({ op: "local.get", index: objLocal });
+  fctx.body.push({ op: "local.get", index: keyLocal });
+  fctx.body.push({ op: "local.get", index: valLocal });
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__extern_set_strict") ?? setIdx });
+}
+
 export function emitAssignToTarget(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -2789,7 +2869,16 @@ export function emitAssignToTarget(
     return;
   } else if (ts.isElementAccessExpression(target)) {
     const arrType = compileExpression(ctx, fctx, target.expression);
-    if (!arrType || (arrType.kind !== "ref" && arrType.kind !== "ref_null")) return;
+    if (!arrType) return;
+    if (arrType.kind !== "ref" && arrType.kind !== "ref_null") {
+      // (#5146 cluster D) Non-vec receiver (`{}`/accessor/host object): the arm
+      // used to `return` here with the receiver still on the stack and the
+      // write SILENTLY DROPPED — `[ x[k] ] = [33]` never assigned. Route it
+      // through the same `__extern_set_strict` terminal the PropertyAccess arm
+      // reaches via `emitDynamicMemberSet` (#2869).
+      emitDynamicElementSet(ctx, fctx, target, arrType, valueLocal, valueType);
+      return;
+    }
     const tIdx = (arrType as { typeIdx: number }).typeIdx;
     const tDef = ctx.mod.types[tIdx];
     // Handle vec struct
@@ -2837,6 +2926,130 @@ export function emitAssignToTarget(
   }
 }
 
+/**
+ * (#5146 cluster F) Apply an ObjectAssignmentPattern to an EXTERNREF source
+ * held in `srcLocal`, reading each key through `__extern_get`. Nested object
+ * patterns previously stopped at the null guard here, so `[{ x = 5 }] = [{}]`
+ * left `x` untouched — the element value of a heterogeneous vec is an
+ * externref, which is exactly the shape every nested object pattern sees.
+ *
+ * Supported leaves: shorthand (with or without initializer), `key: target`
+ * with an identifier / member / nested-pattern target, and initializers on
+ * both. The default fires only on `undefined` (`__extern_is_undefined`),
+ * never on JS `null`, per §13.15.5.5.
+ */
+function emitExternrefObjectPatternWrites(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  pattern: ts.ObjectLiteralExpression,
+  srcLocal: number,
+): void {
+  ensureLateImport(ctx, "__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  const undefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+  flushLateImportShifts(ctx, fctx);
+  const getIdx = ctx.funcMap.get("__extern_get");
+  if (getIdx === undefined || undefIdx === undefined) return;
+  const valType: ValType = { kind: "externref" };
+
+  for (const prop of pattern.properties) {
+    let keyName: string | undefined;
+    let targetExpr: ts.Expression | undefined;
+    let initializer: ts.Expression | undefined;
+    if (ts.isShorthandPropertyAssignment(prop)) {
+      keyName = prop.name.text;
+      targetExpr = prop.name;
+      initializer = prop.objectAssignmentInitializer;
+    } else if (ts.isPropertyAssignment(prop)) {
+      keyName = ts.isComputedPropertyName(prop.name)
+        ? resolveComputedKeyExpression(ctx, prop.name.expression)
+        : ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name) || ts.isNumericLiteral(prop.name)
+          ? prop.name.text
+          : undefined;
+      targetExpr = prop.initializer;
+      if (
+        targetExpr !== undefined &&
+        ts.isBinaryExpression(targetExpr) &&
+        targetExpr.operatorToken.kind === ts.SyntaxKind.EqualsToken
+      ) {
+        initializer = targetExpr.right;
+        targetExpr = targetExpr.left;
+      }
+    }
+    if (keyName === undefined || targetExpr === undefined) continue;
+
+    addStringConstantGlobal(ctx, keyName);
+    const tmpVal = allocLocal(fctx, `__ext_obj_val_${fctx.locals.length}`, valType);
+    fctx.body.push({ op: "local.get", index: srcLocal });
+    for (const instr of stringConstantExternrefInstrs(ctx, keyName)) fctx.body.push(instr);
+    fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__extern_get") ?? getIdx });
+    fctx.body.push({ op: "local.set", index: tmpVal });
+
+    // Nested pattern target: recurse on the read value (defaults apply first).
+    if (ts.isObjectLiteralExpression(targetExpr) || ts.isArrayLiteralExpression(targetExpr)) {
+      const nested = targetExpr;
+      if (ts.isObjectLiteralExpression(nested)) {
+        emitExternrefAssignDestructureGuard(ctx, fctx, tmpVal);
+        emitExternrefObjectPatternWrites(ctx, fctx, nested, tmpVal);
+      } else {
+        fctx.body.push({ op: "local.get", index: tmpVal });
+        const nestedResult = compileExternrefArrayDestructuringAssignment(ctx, fctx, nested, valType);
+        if (nestedResult) fctx.body.push({ op: "drop" });
+      }
+      continue;
+    }
+
+    const writeResolved = (fromDefault: boolean): void => {
+      if (ts.isIdentifier(targetExpr!)) {
+        const id = targetExpr as ts.Identifier;
+        let localIdx = fctx.localMap.get(id.text);
+        const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, id) : undefined;
+        if (localIdx === undefined && moduleGlobalIdx === undefined) {
+          localIdx = allocLocal(fctx, id.text, valType);
+        }
+        const targetType =
+          localIdx !== undefined
+            ? (getLocalType(fctx, localIdx) ?? valType)
+            : (ctx.mod.globals[localGlobalIdx(ctx, moduleGlobalIdx!)]?.type ?? valType);
+        if (fromDefault) {
+          const initType = compileExpression(ctx, fctx, initializer!, targetType);
+          if (initType) emitResolvedIdentifierWriteFromStack(ctx, fctx, id, initType, localIdx, moduleGlobalIdx);
+          return;
+        }
+        fctx.body.push({ op: "local.get", index: tmpVal });
+        emitResolvedIdentifierWriteFromStack(ctx, fctx, id, valType, localIdx, moduleGlobalIdx);
+        return;
+      }
+      if (!ts.isPropertyAccessExpression(targetExpr!) && !ts.isElementAccessExpression(targetExpr!)) return;
+      const resolved = allocLocal(fctx, `__ext_obj_res_${fctx.locals.length}`, valType);
+      if (fromDefault) {
+        const initType = compileExpression(ctx, fctx, initializer!, valType);
+        if (!initType) return;
+        if (initType.kind !== "externref") coerceType(ctx, fctx, initType, valType);
+      } else {
+        fctx.body.push({ op: "local.get", index: tmpVal });
+      }
+      fctx.body.push({ op: "local.set", index: resolved });
+      emitAssignToTarget(ctx, fctx, targetExpr!, resolved, valType);
+    };
+
+    if (initializer === undefined) {
+      writeResolved(false);
+      continue;
+    }
+    fctx.body.push({ op: "local.get", index: tmpVal });
+    fctx.body.push({ op: "call", funcIdx: undefIdx });
+    attachDetachedAssignmentBodies(
+      fctx,
+      (body) => ({
+        then: body(() => writeResolved(true)),
+        else: body(() => writeResolved(false)),
+      }),
+      (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+    );
+  }
+}
+
 /** Destructure an object from a local variable (used for nested patterns) */
 function emitObjectDestructureFromLocal(
   ctx: CodegenContext,
@@ -2845,10 +3058,10 @@ function emitObjectDestructureFromLocal(
   srcLocal: number,
   srcType: ValType,
 ): void {
-  // Externref: emit null/undefined guard. We can't currently destructure externref
-  // object assignments, but at minimum we must throw per spec §14.3.3.1 (#dstr_null_undefined).
+  // Externref: null/undefined guard per §14.3.3.1, then the dynamic key reads.
   if (srcType.kind === "externref") {
     emitExternrefAssignDestructureGuard(ctx, fctx, srcLocal);
+    emitExternrefObjectPatternWrites(ctx, fctx, pattern, srcLocal);
     return;
   }
   if (srcType.kind !== "ref" && srcType.kind !== "ref_null") return;
@@ -2883,8 +3096,28 @@ function emitObjectDestructureFromLocal(
     if (ts.isShorthandPropertyAssignment(prop)) {
       const propName = prop.name.text;
       const fieldIdx = fields.findIndex((f) => f.name === propName);
+      const initializer = prop.objectAssignmentInitializer;
       if (fieldIdx === -1) {
-        reportSilentFallback(ctx, "lookup-miss-skip", "assignment:object-destructure-shorthand-field-miss", prop);
+        // (#5146 cluster F) A NESTED `{ x = d }` over a source without an `x`
+        // field reads `undefined`, so the default fires. Previously skipped
+        // outright, leaving the target untouched.
+        if (initializer === undefined) {
+          reportSilentFallback(ctx, "lookup-miss-skip", "assignment:object-destructure-shorthand-field-miss", prop);
+          continue;
+        }
+        let missLocalIdx = fctx.localMap.get(propName);
+        const missGlobalIdx = missLocalIdx === undefined ? currentSourceModuleGlobalIndex(ctx, prop.name) : undefined;
+        if (missLocalIdx === undefined && missGlobalIdx === undefined) {
+          missLocalIdx = allocLocal(fctx, propName, { kind: "externref" });
+        }
+        const missTargetType =
+          missLocalIdx !== undefined
+            ? (getLocalType(fctx, missLocalIdx) ?? { kind: "externref" as const })
+            : (ctx.mod.globals[localGlobalIdx(ctx, missGlobalIdx!)]?.type ?? { kind: "externref" as const });
+        const missInitType = compileExpression(ctx, fctx, initializer, missTargetType);
+        if (missInitType) {
+          emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, missInitType, missLocalIdx, missGlobalIdx);
+        }
         continue;
       }
 
@@ -2893,9 +3126,39 @@ function emitObjectDestructureFromLocal(
         localIdx = allocLocal(fctx, propName, fields[fieldIdx]!.type);
       }
 
+      const fieldType = fields[fieldIdx]!.type;
+      if (initializer !== undefined && fieldType.kind === "externref") {
+        // (#5146) `{ x = d }` with the field present: the default fires only
+        // when the read value is `undefined` (never for JS `null`).
+        const tmpField = allocLocal(fctx, `__nested_dflt_${fctx.locals.length}`, fieldType);
+        const undefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+        if (undefIdx !== undefined) flushLateImportShifts(ctx, fctx);
+        fctx.body.push({ op: "local.get", index: srcLocal });
+        fctx.body.push({ op: "struct.get", typeIdx: srcTypeIdx, fieldIdx });
+        fctx.body.push({ op: "local.set", index: tmpField });
+        fctx.body.push({ op: "local.get", index: tmpField });
+        if (undefIdx !== undefined) fctx.body.push({ op: "call", funcIdx: undefIdx });
+        else fctx.body.push({ op: "ref.is_null" });
+        const localTypeWithDefault = getLocalType(fctx, localIdx) ?? fieldType;
+        attachDetachedAssignmentBodies(
+          fctx,
+          (body) => ({
+            then: body(() => {
+              const initType = compileExpression(ctx, fctx, initializer, localTypeWithDefault);
+              if (initType) emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, initType, localIdx, undefined);
+            }),
+            else: body(() => {
+              fctx.body.push({ op: "local.get", index: tmpField });
+              emitResolvedIdentifierWriteFromStack(ctx, fctx, prop.name, fieldType, localIdx, undefined);
+            }),
+          }),
+          (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+        );
+        continue;
+      }
+
       fctx.body.push({ op: "local.get", index: srcLocal });
       fctx.body.push({ op: "struct.get", typeIdx: srcTypeIdx, fieldIdx });
-      const fieldType = fields[fieldIdx]!.type;
       const localType = getLocalType(fctx, localIdx);
       if (localType && !valTypesMatch(fieldType, localType)) {
         coerceType(ctx, fctx, fieldType, localType);
@@ -2913,7 +3176,10 @@ function emitObjectDestructureFromLocal(
       if (!propName && ts.isComputedPropertyName(prop.name)) {
         propName = resolveComputedKeyExpression(ctx, prop.name.expression);
       }
-      if (!propName) continue; // truly unresolvable property name — skip
+      if (!propName) {
+        emitUnresolvedComputedKeyForEffect(ctx, fctx, prop.name);
+        continue; // truly unresolvable property name — skip
+      }
       const fieldIdx = fields.findIndex((f) => f.name === propName);
       if (fieldIdx === -1) {
         reportSilentFallback(
@@ -3151,6 +3417,59 @@ function emitArrayDestructureFromLocal(
       emitElemGet(i);
       fctx.body.push({ op: "local.set", index: tmpElem });
       emitArrayDestructureFromLocal(ctx, fctx, element, tmpElem, elemType);
+    } else if (ts.isPropertyAccessExpression(element) || ts.isElementAccessExpression(element)) {
+      // (#5146 cluster F) Member target inside a NESTED array pattern —
+      // `[[ x[k] ]] = vals`. Previously skipped, so the write was dropped.
+      const tmpElem = allocLocal(fctx, `__arr_nested_m_${fctx.locals.length}`, elemType);
+      emitElemGet(i);
+      fctx.body.push({ op: "local.set", index: tmpElem });
+      emitAssignToTarget(ctx, fctx, element, tmpElem, elemType);
+    } else if (
+      ts.isBinaryExpression(element) &&
+      element.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(element.left)
+    ) {
+      // (#5146 cluster F) Initializer inside a NESTED array pattern —
+      // `[[ x = 5 ]] = vals`. §13.15.5.5: the default fires only on `undefined`.
+      const assignTarget = element.left;
+      let localIdx = fctx.localMap.get(assignTarget.text);
+      const moduleGlobalIdx = localIdx === undefined ? currentSourceModuleGlobalIndex(ctx, assignTarget) : undefined;
+      if (localIdx === undefined && moduleGlobalIdx === undefined) {
+        localIdx = allocLocal(fctx, assignTarget.text, elemType);
+      }
+      const targetType =
+        localIdx !== undefined
+          ? getLocalType(fctx, localIdx)
+          : ctx.mod.globals[localGlobalIdx(ctx, moduleGlobalIdx!)]?.type;
+      const tmpElem = allocLocal(fctx, `__arr_nested_d_${fctx.locals.length}`, elemType);
+      const undefIdx =
+        elemType.kind === "externref"
+          ? ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }])
+          : undefined;
+      if (undefIdx !== undefined) flushLateImportShifts(ctx, fctx);
+      emitElemGet(i);
+      fctx.body.push({ op: "local.set", index: tmpElem });
+      fctx.body.push({ op: "local.get", index: tmpElem });
+      if (undefIdx !== undefined) fctx.body.push({ op: "call", funcIdx: undefIdx });
+      else if (elemType.kind === "externref" || elemType.kind === "ref" || elemType.kind === "ref_null")
+        fctx.body.push({ op: "ref.is_null" });
+      else fctx.body.push({ op: "i32.const", value: 0 });
+      attachDetachedAssignmentBodies(
+        fctx,
+        (body) => ({
+          then: body(() => {
+            const initType = compileExpression(ctx, fctx, element.right, targetType ?? elemType);
+            if (initType) {
+              emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, initType, localIdx, moduleGlobalIdx);
+            }
+          }),
+          else: body(() => {
+            fctx.body.push({ op: "local.get", index: tmpElem });
+            emitResolvedIdentifierWriteFromStack(ctx, fctx, assignTarget, elemType, localIdx, moduleGlobalIdx);
+          }),
+        }),
+        (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+      );
     }
     // else: unsupported nested target — skip (existing behavior)
   }
@@ -3203,8 +3522,15 @@ function emitVecArrayLikeObjectDestructure(
       fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
       return { kind: "i32" };
     }
-    // Numeric index → bounds-checked element read (OOB → undefined sentinel).
+    // (#5146) A key that is neither `length` nor a canonical array index is
+    // ABSENT on an array-like, so it reads `undefined`. `Number("x") | 0` used
+    // to fold to 0 and hand back ELEMENT 0 instead (`[...{ x = 5 }] = [{}]`
+    // bound the object rather than firing the default).
     const idx = Number(key);
+    if (!Number.isInteger(idx) || idx < 0 || String(idx) !== key) {
+      emitUndefined(ctx, fctx);
+      return { kind: "externref" };
+    }
     fctx.body.push({ op: "local.get", index: srcLocal });
     fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 }); // data array
     fctx.body.push({ op: "i32.const", value: idx | 0 });
@@ -3238,11 +3564,53 @@ function emitVecArrayLikeObjectDestructure(
     // else: unsupported target — value already consumed into tmpVal; skip.
   };
 
+  // (#5146) `{ k = d }` over an array-like: the default fires when the read
+  // value is `undefined`. `bindDefaulted` replaces the value on the stack with
+  // the initializer's when so, then binds as usual.
+  const bindDefaulted = (targetExpr: ts.Expression, valueType: ValType, initializer: ts.Expression): void => {
+    const tmpRead = allocLocal(fctx, `__rest_obj_dflt_${fctx.locals.length}`, valueType);
+    fctx.body.push({ op: "local.set", index: tmpRead });
+    if (valueType.kind !== "externref") {
+      // A statically typed read is never `undefined` — bind it directly.
+      fctx.body.push({ op: "local.get", index: tmpRead });
+      bindTarget(targetExpr, valueType);
+      return;
+    }
+    const undefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+    if (undefIdx === undefined) {
+      fctx.body.push({ op: "local.get", index: tmpRead });
+      bindTarget(targetExpr, valueType);
+      return;
+    }
+    flushLateImportShifts(ctx, fctx);
+    fctx.body.push({ op: "local.get", index: tmpRead });
+    fctx.body.push({ op: "call", funcIdx: undefIdx });
+    attachDetachedAssignmentBodies(
+      fctx,
+      (body) => ({
+        then: body(() => {
+          const initType = compileExpression(ctx, fctx, initializer, valueType);
+          if (initType && initType.kind !== "externref") coerceType(ctx, fctx, initType, valueType);
+          bindTarget(targetExpr, valueType);
+        }),
+        else: body(() => {
+          fctx.body.push({ op: "local.get", index: tmpRead });
+          bindTarget(targetExpr, valueType);
+        }),
+      }),
+      (branches) => fctx.body.push({ op: "if", blockType: { kind: "empty" }, ...branches }),
+    );
+  };
+
   for (const prop of pattern.properties) {
     if (ts.isShorthandPropertyAssignment(prop)) {
       // `{ length }` — key === target identifier.
       const valueType = readKey(prop.name.text);
-      bindTarget(prop.name, valueType);
+      if (prop.objectAssignmentInitializer) {
+        bindDefaulted(prop.name, valueType, prop.objectAssignmentInitializer);
+      } else {
+        bindTarget(prop.name, valueType);
+      }
     } else if (ts.isPropertyAssignment(prop)) {
       // `{ 0: x }` / `{ "k": x }` / `{ [expr]: x }`.
       const key =
@@ -3252,14 +3620,15 @@ function emitVecArrayLikeObjectDestructure(
             ? resolveComputedKeyExpression(ctx, prop.name.expression)
             : undefined;
       if (key === undefined) continue; // unresolvable key — skip
-      // Strip a default initializer (`{ 0: x = d }`); the default arm is a
-      // narrow tail not yet handled — bind the raw value rather than dropping.
       let targetExpr = prop.initializer;
+      let initializer: ts.Expression | undefined;
       if (ts.isBinaryExpression(targetExpr) && targetExpr.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+        initializer = targetExpr.right;
         targetExpr = targetExpr.left;
       }
       const valueType = readKey(key);
-      bindTarget(targetExpr, valueType);
+      if (initializer !== undefined) bindDefaulted(targetExpr, valueType, initializer);
+      else bindTarget(targetExpr, valueType);
     }
   }
 }

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -70,7 +70,7 @@ import {
   isDataViewAccessor,
   usesNativeDataViewProvider,
 } from "../dataview-native.js";
-import { ensureNativeArrayFromIterN, ensureNativeArrayFromMapped } from "../iterator-native.js";
+import { ensureNativeArrayFromIterN, ensureNativeArrayFromMapped, reserveAnyIterNext } from "../iterator-native.js";
 import { tryCompileNativeGeneratorMethodCall } from "../generators-native.js";
 import { NATIVE_HOF_METHODS } from "../hof-native.js";
 import {
@@ -983,8 +983,14 @@ export function compileReceiverMethodCall(
     );
     if (nativeResult !== undefined) return nativeResult;
     if (methodName === "next") {
+      // (#5147) `Iterator`/`IterableIterator`-typed receivers include the
+      // NATIVE carriers (`[1,2][Symbol.iterator]()` → `$IterRec`), which
+      // `__gen_next` does not recognize. `__any_iter_next` tests for them and
+      // falls back to `__gen_next` on a miss.
+      const anyIterNextIdx = reserveAnyIterNext(ctx);
+      if (anyIterNextIdx !== undefined) flushLateImportShifts(ctx, fctx);
       compileExpression(ctx, fctx, propAccess.expression);
-      const funcIdx = ctx.funcMap.get("__gen_next");
+      const funcIdx = anyIterNextIdx ?? ctx.funcMap.get("__gen_next");
       if (funcIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx });
         return { kind: "externref" }; // Returns IteratorResult as externref
@@ -3611,6 +3617,14 @@ export function compileReceiverMethodCall(
         }
         const genNextIdx = ctx.funcMap.get("__gen_next");
         if (genNextIdx !== undefined) {
+          // (#5147) An `any`-typed receiver may hold a NATIVE iterator carrier
+          // (`$IterRec` from `[1,2][Symbol.iterator]()`, or a `$LazyIterHelper`
+          // from `.chunks(2)`), which `__gen_next` does not recognize — it
+          // answered null and the following `.value` read threw. Route through
+          // `__any_iter_next`, whose miss arm IS `__gen_next`.
+          const anyIterNextIdx = reserveAnyIterNext(ctx);
+          const nextTargetIdx = anyIterNextIdx ?? genNextIdx;
+          flushLateImportShifts(ctx, fctx);
           compileExpression(ctx, fctx, propAccess.expression, {
             kind: "externref",
           });
@@ -3621,7 +3635,7 @@ export function compileReceiverMethodCall(
               fctx.body.push({ op: "drop" });
             }
           }
-          fctx.body.push({ op: "call", funcIdx: genNextIdx });
+          fctx.body.push({ op: "call", funcIdx: nextTargetIdx });
           return { kind: "externref" };
         }
       }

--- a/src/codegen/expressions/call-tail-dispatch.ts
+++ b/src/codegen/expressions/call-tail-dispatch.ts
@@ -775,6 +775,12 @@ export function compileTailDispatch(
         // keeps the existing `__iterator` bridge (byte-inert). Async iterator and
         // non-array receivers fall through unchanged.
         if (methodName === "@@iterator" && (ctx.standalone || ctx.wasi) && resolveArrayInfo(ctx, receiverType)) {
+          // (#5147 note) This SNAPSHOT-vec result is why `.next()` on
+          // `[1,2][Symbol.iterator]()` still answers null: a vec has no cursor.
+          // Switching it to `__iterator(recv)` (a real `$__IterRec`) was tried
+          // and is NOT a drop-in — the array-iterator prototype/metadata rows
+          // key off the vec carrier — so the carrier migration is left to the
+          // follow-up that also moves `%ArrayIteratorPrototype%`.
           const nativeResult = compileArrayMethodCall(ctx, fctx, elemAccess, expr, receiverType, "values");
           if (nativeResult !== undefined && nativeResult !== null) return nativeResult as ValType;
           // Fall through to the host bridge if the native path declined.

--- a/src/codegen/expressions/identifier-assignment.ts
+++ b/src/codegen/expressions/identifier-assignment.ts
@@ -7,6 +7,7 @@ import { getLocalType } from "../context/locals.js";
 import { localGlobalIdx } from "../registry/imports.js";
 import { coerceType, valTypesMatch } from "../shared.js";
 import { emitTdzCheck } from "../statements/tdz.js";
+import { emitThrowTypeError, noJsHost } from "./helpers.js";
 import { analyzeTdzAccess as analyzeIdentifierTdzAccess, emitStaticTdzThrow } from "./identifiers.js";
 import { identifierResolvesToCurrentTopLevelLexical } from "./identifier-module-storage.js";
 
@@ -31,6 +32,43 @@ function emitModuleLexicalAssignmentTdzGuard(
   else if (decision === "check") emitTdzCheck(ctx, fctx, id.text, true);
 }
 
+/**
+ * (#5146 cluster C) §6.2.5.6 PutValue guards every identifier assignment target
+ * must observe, including the ones reached through a destructuring pattern:
+ * a write to a lexical binding still in its TDZ is a ReferenceError, and a write
+ * to a `const` binding is a TypeError. The TDZ check must precede the const
+ * check — an uninitialised `const` is a ReferenceError, not a TypeError.
+ * Consumes the pending stack value when it takes over (returns true).
+ */
+export function emitPutValueTargetGuard(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  id: ts.Identifier,
+  pendingStackValue = true,
+): boolean {
+  const name = id.text;
+  if (ctx.tdzGlobals.has(name)) {
+    const tdzResult = analyzeIdentifierTdzAccess(ctx, id);
+    if (tdzResult === "throw") {
+      if (pendingStackValue) fctx.body.push({ op: "drop" });
+      emitStaticTdzThrow(ctx, fctx, name);
+      return true;
+    }
+    if (tdzResult === "check") emitTdzCheck(ctx, fctx, name, noJsHost(ctx));
+  }
+  const declaration = ctx.oracle.variableDeclarationOf(id);
+  const isConst =
+    fctx.constBindings?.has(name) === true ||
+    (declaration !== undefined &&
+      ts.isVariableDeclaration(declaration) &&
+      (declaration.parent.flags & ts.NodeFlags.Const) !== 0);
+  if (!isConst) return false;
+  if (pendingStackValue) fctx.body.push({ op: "drop" });
+  emitThrowTypeError(ctx, fctx, "Assignment to constant variable.");
+  fctx.body.push({ op: "unreachable" });
+  return true;
+}
+
 /** Consume one precomputed stack value through an already-resolved target. */
 export function emitResolvedIdentifierWriteFromStack(
   ctx: CodegenContext,
@@ -44,6 +82,7 @@ export function emitResolvedIdentifierWriteFromStack(
   // A provider or string constant settled while evaluating the value may have
   // inserted an import global. Treat the caller's index as target identity
   // only; re-read the graph-global name map before inspecting its type.
+  if (emitPutValueTargetGuard(ctx, fctx, id)) return true;
   const currentModuleGlobalIdx = moduleGlobalIdx === undefined ? undefined : ctx.moduleGlobals.get(id.text);
   const targetType =
     localIdx !== undefined

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -814,7 +814,7 @@ function compileCapturedGlobalRead(
 ): ValType {
   const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
   if (tdzResult === "check") {
-    emitTdzCheck(ctx, fctx, name);
+    emitTdzCheck(ctx, fctx, name, noJsHost(ctx));
   } else if (tdzResult === "throw") {
     emitStaticTdzThrow(ctx, fctx, id.text);
   }
@@ -889,7 +889,7 @@ function compileExactAmbientShadowedModuleBinding(
     if (tdzLocalIdx < 0) return undefined;
     const tdzResult = analyzeTdzAccess(ctx, id);
     if (tdzResult === "check") {
-      emitTdzCheckAtGlobal(ctx, fctx, ctx.numImportGlobals + tdzLocalIdx, id.text);
+      emitTdzCheckAtGlobal(ctx, fctx, ctx.numImportGlobals + tdzLocalIdx, id.text, noJsHost(ctx));
     } else if (tdzResult === "throw") {
       emitStaticTdzThrow(ctx, fctx, id.text);
     }
@@ -1343,7 +1343,7 @@ function compileIdentifierCore(
   if (capturedBox !== undefined) {
     const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
     if (tdzResult === "check") {
-      emitTdzCheck(ctx, fctx, name);
+      emitTdzCheck(ctx, fctx, name, noJsHost(ctx));
     } else if (tdzResult === "throw") {
       emitStaticTdzThrow(ctx, fctx, id.text);
     }
@@ -1373,7 +1373,7 @@ function compileIdentifierCore(
     // Apply static analysis for module-level globals
     const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
     if (tdzResult === "check") {
-      emitTdzCheck(ctx, fctx, name);
+      emitTdzCheck(ctx, fctx, name, noJsHost(ctx));
     } else if (tdzResult === "throw") {
       emitStaticTdzThrow(ctx, fctx, id.text);
     }

--- a/src/codegen/function-instance-meta.ts
+++ b/src/codegen/function-instance-meta.ts
@@ -293,6 +293,12 @@ export function fnInstanceNameOf(decl: ts.Node): string {
     if (ts.isIdentifier(key) || ts.isStringLiteral(key) || ts.isNumericLiteral(key)) return key.text;
     return "";
   }
+  // (#5146 cluster E) `({ x = function () {} } = {})` — the shorthand
+  // property's assignment initializer is an AssignmentElement default, and
+  // §13.15.5.5 applies NamedEvaluation with the shorthand's own name.
+  if (ts.isShorthandPropertyAssignment(parent) && parent.objectAssignmentInitializer === node) {
+    return parent.name.text;
+  }
   if (ts.isPropertyDeclaration(parent) && parent.initializer === node) {
     const key = parent.name;
     return ts.isIdentifier(key) || ts.isPrivateIdentifier(key) || ts.isStringLiteral(key) ? key.text : "";

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -291,7 +291,12 @@ import {
 // (#4491 wave-5 T7 slice B) §20.2.2 own-key surface of the provider-realm
 // `%Function%` marker — see runtime-eval-intrinsic-own-props.ts.
 import { fillRuntimeEvalIntrinsicFunctionOwnProps } from "./runtime-eval-intrinsic-own-props.js";
-import { ensureNativeIteratorRuntime, fillNativeIteratorLateArms } from "./iterator-native.js";
+import {
+  ensureNativeIteratorRuntime,
+  fillAnyIterNext,
+  fillIterResultObject,
+  fillNativeIteratorLateArms,
+} from "./iterator-native.js";
 import { emitResizableAbExports } from "./dataview-native.js"; // (#3058)
 import { fillCombinatorToVec } from "./promise-combinators.js"; // (#2922) dynamic combinator-arg drain fill
 import { fillClosedMethodDispatch, fillPromiseThenableHelpers } from "./closed-method-dispatch.js";
@@ -5652,6 +5657,12 @@ export function generateModule(
     // MUST run AFTER `fillNativeIteratorLateArms` (which rebuilds those bodies).
     // No-op unless a lazy wrapper was constructed.
     fillLazyIterLadderArms(ctx);
+
+    // (#5147) Fill `__any_iter_next` — source-level `.next()` on a native
+    // iterator carrier. MUST run after both fills above: it delegates to the
+    // fully-armed `__iterator_next`.
+    fillIterResultObject(ctx);
+    fillAnyIterNext(ctx);
 
     // (#2922) Rebuild `__combinator_to_vec`'s user-iterable arm with the same
     // closed-struct dispatchers (identical five-dispatcher condition, so the

--- a/src/codegen/iter-lazy-native.ts
+++ b/src/codegen/iter-lazy-native.ts
@@ -53,14 +53,34 @@ import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js
 import { reserveIterHofSteppers } from "./iter-hof-native.js";
 import { ensureNativeArrayFromIterN, ensureNativeIteratorRuntime } from "./iterator-native.js";
 import { ensureObjectRuntime, reserveApplyClosure } from "./object-runtime.js";
-import { addFuncType } from "./registry/types.js";
+import { ensureExternStrictEqHelper } from "./any-helpers.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import { addUnionImportsViaRegistry } from "./shared.js";
 
 /** Method names served by {@link ensureNativeLazyIter}. */
-export const LAZY_ITER_METHODS: ReadonlySet<string> = new Set(["map", "filter", "take", "drop", "flatMap"]);
+export const LAZY_ITER_METHODS: ReadonlySet<string> = new Set([
+  "map",
+  "filter",
+  "take",
+  "drop",
+  "flatMap",
+  "chunks",
+  "windows",
+]);
+
+/**
+ * (#5147) Lazy helpers whose constructor takes a SECOND source-level argument
+ * (`windows(windowSize, undersized)`; `chunks` shares the 3-param ctor shape so
+ * one dispatch rule covers both). The closed-method dispatcher pushes
+ * `ref.null.extern` for the absent arg when the call site has arity 1.
+ */
+export const LAZY_ITER_ARG2_METHODS: ReadonlySet<string> = new Set(["chunks", "windows"]);
 
 /** `state` semantics differ by kind (see module header). */
-const KIND: Record<string, number> = { map: 0, filter: 1, take: 2, drop: 3, flatMap: 4 };
+const KIND: Record<string, number> = { map: 0, filter: 1, take: 2, drop: 3, flatMap: 4, chunks: 5, windows: 6 };
 
 /** Field indices of `$LazyIterHelper` — load-bearing order. */
 const F_KIND = 0;
@@ -68,6 +88,16 @@ const F_SRC = 1;
 const F_FN = 2;
 const F_STATE = 3;
 const F_INNER = 4; // flatMap: the current inner-iterator handle (or null)
+const F_FLAGS = 5; // (#5147) bit0 = source exhausted, bit1 = windows "allow-partial"
+
+/** (#5147) §27.1.4.x argument-validation messages / `undersized` enum values. */
+const CHUNK_SIZE_TYPE_MSG = "size must be an integral Number";
+const CHUNK_SIZE_RANGE_MSG = "size out of range";
+const UNDERSIZED_MSG = "undersized must be 'only-full' or 'allow-partial'";
+const ONLY_FULL = "only-full";
+const ALLOW_PARTIAL = "allow-partial";
+/** Inclusive upper bound on chunkSize/windowSize (2^32 - 1). */
+const MAX_CHUNK_SIZE = 4294967295;
 
 /** True when `methodName`/`arity` is a form the lazy arm services. */
 export function isLazyIterForm(methodName: string, arity: number): boolean {
@@ -87,6 +117,7 @@ function getOrRegisterLazyHelperType(ctx: CodegenContext): number {
     { name: "fn", type: { kind: "externref" as const }, mutable: false },
     { name: "state", type: { kind: "f64" as const }, mutable: true },
     { name: "inner", type: { kind: "externref" as const }, mutable: true },
+    { name: "flags", type: { kind: "i32" as const }, mutable: true },
   ];
   const typeIdx = ctx.mod.types.length;
   ctx.mod.types.push({ kind: "struct", name: "$LazyIterHelper", fields });
@@ -109,6 +140,230 @@ interface LazyDeps {
   objVecPushIdx: number;
   arrayFromIterNIdx: number;
   iteratorIdx: number;
+  /** (#5147) chunks/windows buffer geometry + helpers; undefined ⇒ no chunk arm. */
+  buf?: LazyBufHelpers;
+  /** (#5147) argument-validation helpers for chunks/windows. */
+  typeofNumIdx?: number;
+  typeofUndefIdx?: number;
+  strictEqIdx?: number;
+}
+
+/** (#5147) The `$Vec`-backed buffer helpers chunks/windows accumulate into. */
+interface LazyBufHelpers {
+  vecTypeIdx: number;
+  arrTypeIdx: number;
+  newIdx: number;
+  pushIdx: number;
+  copyIdx: number;
+  shiftIdx: number;
+}
+
+/**
+ * (#5147) Emit (idempotently) the four `$Vec` buffer primitives the chunks /
+ * windows steppers accumulate through: allocate, append (doubling), snapshot-
+ * copy, and shift-left-by-one. The buffer IS the source-visible array a chunk
+ * yields, so it must be the same `__vec_externref` carrier `Array.from` /
+ * `__extern_length` / `__extern_get_idx` already understand — NOT `$ObjVec`
+ * (invisible to the array-like reads `assert.compareArray` performs).
+ */
+function ensureLazyBufHelpers(ctx: CodegenContext): LazyBufHelpers | undefined {
+  const vecTypeIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return undefined;
+  const existing = ctx.funcMap.get("__lazy_buf_new");
+  if (existing !== undefined) {
+    const pushIdx = ctx.funcMap.get("__lazy_buf_push");
+    const copyIdx = ctx.funcMap.get("__lazy_buf_copy");
+    const shiftIdx = ctx.funcMap.get("__lazy_buf_shift");
+    if (pushIdx === undefined || copyIdx === undefined || shiftIdx === undefined) return undefined;
+    return { vecTypeIdx, arrTypeIdx, newIdx: existing, pushIdx, copyIdx, shiftIdx };
+  }
+  const arrRefNull: ValType = { kind: "ref_null", typeIdx: arrTypeIdx };
+  const vecRefNull: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
+
+  const register = (
+    name: string,
+    params: ValType[],
+    results: ValType[],
+    locals: { name: string; type: ValType }[],
+    body: Instr[],
+  ): number => {
+    const typeIdx = addFuncType(ctx, params, results);
+    const funcIdx = mintDefinedFunc(ctx);
+    ctx.funcMap.set(name, funcIdx);
+    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals, body, exported: false });
+    return funcIdx;
+  };
+
+  // __lazy_buf_new() -> externref : $Vec { length: 0, data: externref[4] }.
+  const newIdx = register(
+    "__lazy_buf_new",
+    [],
+    [{ kind: "externref" }],
+    [],
+    [
+      { op: "i32.const", value: 0 },
+      { op: "i32.const", value: 4 },
+      { op: "array.new_default", typeIdx: arrTypeIdx },
+      { op: "struct.new", typeIdx: vecTypeIdx },
+      { op: "extern.convert_any" },
+    ],
+  );
+
+  // __lazy_buf_push(buf, v) : append, doubling the backing array when full.
+  // locals: 2 vec, 3 arr, 4 len, 5 cap, 6 narr
+  const pushIdx = register(
+    "__lazy_buf_push",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [],
+    [
+      { name: "vec", type: vecRefNull },
+      { name: "arr", type: arrRefNull },
+      { name: "len", type: { kind: "i32" } },
+      { name: "cap", type: { kind: "i32" } },
+      { name: "narr", type: arrRefNull },
+    ],
+    [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: vecTypeIdx },
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 2 },
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+      { op: "local.set", index: 3 },
+      { op: "local.get", index: 2 },
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+      { op: "local.set", index: 4 },
+      { op: "local.get", index: 3 },
+      { op: "array.len" },
+      { op: "local.set", index: 5 },
+      { op: "local.get", index: 4 },
+      { op: "local.get", index: 5 },
+      { op: "i32.ge_s" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 5 },
+          { op: "i32.const", value: 2 },
+          { op: "i32.mul" },
+          { op: "i32.const", value: 4 },
+          { op: "i32.add" },
+          { op: "local.set", index: 5 },
+          { op: "local.get", index: 5 },
+          { op: "array.new_default", typeIdx: arrTypeIdx },
+          { op: "local.set", index: 6 },
+          { op: "local.get", index: 6 },
+          { op: "i32.const", value: 0 },
+          { op: "local.get", index: 3 },
+          { op: "i32.const", value: 0 },
+          { op: "local.get", index: 4 },
+          { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx },
+          { op: "local.get", index: 6 },
+          { op: "local.set", index: 3 },
+          { op: "local.get", index: 2 },
+          { op: "local.get", index: 6 },
+          { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 1 },
+        ],
+      },
+      { op: "local.get", index: 3 },
+      { op: "local.get", index: 4 },
+      { op: "local.get", index: 1 },
+      { op: "array.set", typeIdx: arrTypeIdx },
+      { op: "local.get", index: 2 },
+      { op: "local.get", index: 4 },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 },
+    ],
+  );
+
+  // __lazy_buf_copy(buf) -> externref : a FRESH $Vec holding the same elements
+  // (`yields-distinct-arrays.js` — every yielded window must be a new array).
+  // locals: 1 vec, 2 len, 3 narr
+  const copyIdx = register(
+    "__lazy_buf_copy",
+    [{ kind: "externref" }],
+    [{ kind: "externref" }],
+    [
+      { name: "vec", type: vecRefNull },
+      { name: "len", type: { kind: "i32" } },
+      { name: "narr", type: arrRefNull },
+    ],
+    [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: vecTypeIdx },
+      { op: "local.set", index: 1 },
+      { op: "local.get", index: 1 },
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 2 },
+      { op: "array.new_default", typeIdx: arrTypeIdx },
+      { op: "local.set", index: 3 },
+      { op: "local.get", index: 3 },
+      { op: "i32.const", value: 0 },
+      { op: "local.get", index: 1 },
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+      { op: "i32.const", value: 0 },
+      { op: "local.get", index: 2 },
+      { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx },
+      { op: "local.get", index: 2 },
+      { op: "local.get", index: 3 },
+      { op: "struct.new", typeIdx: vecTypeIdx },
+      { op: "extern.convert_any" },
+    ],
+  );
+
+  // __lazy_buf_shift(buf) : drop element 0 (memmove semantics — array.copy is
+  // defined to handle overlap). No-op on an empty buffer.
+  // locals: 1 vec, 2 len, 3 arr
+  const shiftIdx = register(
+    "__lazy_buf_shift",
+    [{ kind: "externref" }],
+    [],
+    [
+      { name: "vec", type: vecRefNull },
+      { name: "len", type: { kind: "i32" } },
+      { name: "arr", type: arrRefNull },
+    ],
+    [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: vecTypeIdx },
+      { op: "local.set", index: 1 },
+      { op: "local.get", index: 1 },
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 1 },
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+      { op: "local.set", index: 3 },
+      { op: "local.get", index: 2 },
+      { op: "i32.const", value: 0 },
+      { op: "i32.gt_s" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 3 },
+          { op: "i32.const", value: 0 },
+          { op: "local.get", index: 3 },
+          { op: "i32.const", value: 1 },
+          { op: "local.get", index: 2 },
+          { op: "i32.const", value: 1 },
+          { op: "i32.sub" },
+          { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx },
+          { op: "local.get", index: 1 },
+          { op: "local.get", index: 2 },
+          { op: "i32.const", value: 1 },
+          { op: "i32.sub" },
+          { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 },
+        ],
+      },
+    ],
+  );
+
+  return { vecTypeIdx, arrTypeIdx, newIdx, pushIdx, copyIdx, shiftIdx };
 }
 
 /** Gather (registering as needed) every dependency the lazy runtime needs.
@@ -145,8 +400,24 @@ function gatherLazyDeps(ctx: CodegenContext): LazyDeps | undefined {
   ) {
     return undefined;
   }
+  // (#5147) chunks/windows extras: the $Vec buffer primitives + the argument-
+  // validation helpers (§27.1.4.x steps 4-6 throw TypeError/RangeError BEFORE
+  // any coercion, so the number check must be a `typeof`, never an unbox).
+  const buf = ensureLazyBufHelpers(ctx);
+  emitWasiErrorConstructor(ctx, "TypeError", 1); // idempotent
+  emitWasiErrorConstructor(ctx, "RangeError", 1); // idempotent
+  addStringConstantGlobal(ctx, CHUNK_SIZE_TYPE_MSG);
+  addStringConstantGlobal(ctx, CHUNK_SIZE_RANGE_MSG);
+  addStringConstantGlobal(ctx, UNDERSIZED_MSG);
+  addStringConstantGlobal(ctx, ONLY_FULL);
+  addStringConstantGlobal(ctx, ALLOW_PARTIAL);
+  const strictEqIdx = ensureExternStrictEqHelper(ctx);
   return {
     helperTypeIdx,
+    buf,
+    typeofNumIdx: ctx.funcMap.get("__typeof_number"),
+    typeofUndefIdx: ctx.funcMap.get("__typeof_undefined"),
+    strictEqIdx,
     openIdx: steppers.openIdx,
     nextIdx: steppers.nextIdx,
     closeIdx: steppers.closeIdx,
@@ -175,9 +446,25 @@ export function ensureNativeLazyIter(ctx: CodegenContext, methodName: string): n
 
   const deps = gatherLazyDeps(ctx);
   if (deps === undefined) return undefined;
+  // (#5147) chunks/windows need the buffer primitives AND the validation
+  // helpers; without them the method must keep its pre-#5147 "not a function"
+  // behaviour rather than silently mis-implementing the proposal.
+  if (LAZY_ITER_ARG2_METHODS.has(methodName) && !chunkDepsReady(deps)) return undefined;
 
   ensureLazyStepper(ctx, deps);
-  return emitLazyConstructor(ctx, methodName, deps);
+  return LAZY_ITER_ARG2_METHODS.has(methodName)
+    ? emitChunkingConstructor(ctx, methodName, deps)
+    : emitLazyConstructor(ctx, methodName, deps);
+}
+
+/** True when every chunks/windows dependency resolved. */
+function chunkDepsReady(deps: LazyDeps): boolean {
+  return (
+    deps.buf !== undefined &&
+    deps.typeofNumIdx !== undefined &&
+    deps.typeofUndefIdx !== undefined &&
+    deps.strictEqIdx !== undefined
+  );
 }
 
 /** Reserve the shared `__lazy_iter_step` / `__lazy_iter_close`. Idempotent. */
@@ -404,6 +691,188 @@ function ensureLazyStepper(ctx: CodegenContext, deps: LazyDeps): void {
     },
   ];
 
+  // ── (#5147) chunks / windows (iterator-chunking proposal §27.1.4.x) ──
+  // Both accumulate into a `$Vec` buffer held in `inner`; `state` carries the
+  // chunk/window size and `flags` bit0 records source exhaustion (so a step
+  // AFTER the final partial flush answers done instead of re-flushing), bit1
+  // the windows `allow-partial` mode. `chunks` yields the buffer itself and
+  // starts a fresh one; `windows` yields a COPY and shifts by one, so every
+  // yielded array is distinct (`yields-distinct-arrays.js`).
+  const FLG = 10;
+  const BLEN = 11;
+  const buf = deps.buf;
+  const bufLen = (): Instr[] =>
+    buf === undefined
+      ? []
+      : [
+          { op: "local.get", index: INNER },
+          { op: "any.convert_extern" },
+          { op: "ref.cast", typeIdx: buf.vecTypeIdx },
+          { op: "struct.get", typeIdx: buf.vecTypeIdx, fieldIdx: 0 },
+        ];
+  // flg = helper.flags; exhausted (bit0) ⇒ done. Then ensure a buffer exists.
+  const chunkPrologue = (): Instr[] =>
+    buf === undefined
+      ? []
+      : [
+          ...cast(),
+          { op: "struct.get", typeIdx: helperTypeIdx, fieldIdx: F_FLAGS },
+          { op: "local.set", index: FLG },
+          { op: "local.get", index: FLG },
+          { op: "i32.const", value: 1 },
+          { op: "i32.and" },
+          { op: "if", blockType: { kind: "empty" }, then: [...doneReturn] },
+          ...cast(),
+          { op: "struct.get", typeIdx: helperTypeIdx, fieldIdx: F_INNER },
+          { op: "local.set", index: INNER },
+          { op: "local.get", index: INNER },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "call", funcIdx: buf.newIdx },
+              { op: "local.set", index: INNER },
+              ...cast(),
+              { op: "local.get", index: INNER },
+              { op: "struct.set", typeIdx: helperTypeIdx, fieldIdx: F_INNER },
+            ],
+          },
+        ];
+  // helper.flags |= 1 (source exhausted).
+  const markExhausted = (): Instr[] => [
+    ...cast(),
+    { op: "local.get", index: FLG },
+    { op: "i32.const", value: 1 },
+    { op: "i32.or" },
+    { op: "struct.set", typeIdx: helperTypeIdx, fieldIdx: F_FLAGS },
+  ];
+  // Yield `inner` and detach it from the wrapper (a fresh buffer next step).
+  const yieldBuffer = (): Instr[] => [
+    ...cast(),
+    { op: "ref.null.extern" },
+    { op: "struct.set", typeIdx: helperTypeIdx, fieldIdx: F_INNER },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: INNER },
+    { op: "return" },
+  ];
+
+  const chunksArm: Instr[] =
+    buf === undefined
+      ? [...doneReturn]
+      : [
+          ...chunkPrologue(),
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: SRC },
+              { op: "call", funcIdx: nextIdx },
+              { op: "local.set", index: VAL },
+              { op: "local.set", index: DONE },
+              { op: "local.get", index: DONE },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  ...markExhausted(),
+                  ...bufLen(),
+                  { op: "i32.const", value: 0 },
+                  { op: "i32.gt_s" },
+                  { op: "if", blockType: { kind: "empty" }, then: yieldBuffer() },
+                  ...doneReturn,
+                ],
+              },
+              // buffer.push(value)
+              { op: "local.get", index: INNER },
+              { op: "local.get", index: VAL },
+              { op: "call", funcIdx: buf.pushIdx },
+              // full ⇒ yield it.
+              ...bufLen(),
+              { op: "f64.convert_i32_s" },
+              { op: "local.get", index: ST },
+              { op: "f64.ge" },
+              { op: "if", blockType: { kind: "empty" }, then: yieldBuffer() },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ];
+
+  const windowsArm: Instr[] =
+    buf === undefined
+      ? [...doneReturn]
+      : [
+          ...chunkPrologue(),
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: SRC },
+              { op: "call", funcIdx: nextIdx },
+              { op: "local.set", index: VAL },
+              { op: "local.set", index: DONE },
+              { op: "local.get", index: DONE },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  ...markExhausted(),
+                  ...bufLen(),
+                  { op: "local.set", index: BLEN },
+                  // allow-partial ∧ 0 < buffered < windowSize ⇒ one short window.
+                  { op: "local.get", index: FLG },
+                  { op: "i32.const", value: 2 },
+                  { op: "i32.and" },
+                  { op: "i32.const", value: 0 },
+                  { op: "i32.ne" }, // normalize to 0/1 before the i32.and chain
+                  { op: "local.get", index: BLEN },
+                  { op: "i32.const", value: 0 },
+                  { op: "i32.gt_s" },
+                  { op: "i32.and" },
+                  { op: "local.get", index: BLEN },
+                  { op: "f64.convert_i32_s" },
+                  { op: "local.get", index: ST },
+                  { op: "f64.lt" },
+                  { op: "i32.and" },
+                  { op: "if", blockType: { kind: "empty" }, then: yieldBuffer() },
+                  ...doneReturn,
+                ],
+              },
+              // Rolling window: drop the oldest once the buffer is full.
+              ...bufLen(),
+              { op: "f64.convert_i32_s" },
+              { op: "local.get", index: ST },
+              { op: "f64.ge" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: INNER },
+                  { op: "call", funcIdx: buf.shiftIdx },
+                ],
+              },
+              { op: "local.get", index: INNER },
+              { op: "local.get", index: VAL },
+              { op: "call", funcIdx: buf.pushIdx },
+              ...bufLen(),
+              { op: "f64.convert_i32_s" },
+              { op: "local.get", index: ST },
+              { op: "f64.ge" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "i32.const", value: 0 },
+                  { op: "local.get", index: INNER },
+                  { op: "call", funcIdx: buf.copyIdx },
+                  { op: "return" },
+                ],
+              },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ];
+
   const stepBody: Instr[] = [
     { op: "local.get", index: P },
     { op: "any.convert_extern" },
@@ -447,6 +916,16 @@ function ensureLazyStepper(ctx: CodegenContext, deps: LazyDeps): void {
     { op: "i32.const", value: 4 },
     { op: "i32.eq" },
     { op: "if", blockType: { kind: "empty" }, then: flatMapArm },
+    // if kind==chunks (#5147)
+    { op: "local.get", index: KIND_L },
+    { op: "i32.const", value: 5 },
+    { op: "i32.eq" },
+    { op: "if", blockType: { kind: "empty" }, then: chunksArm },
+    // if kind==windows (#5147)
+    { op: "local.get", index: KIND_L },
+    { op: "i32.const", value: 6 },
+    { op: "i32.eq" },
+    { op: "if", blockType: { kind: "empty" }, then: windowsArm },
     // fallthrough: unknown kind ⇒ done.
     ...doneReturn,
   ];
@@ -467,6 +946,8 @@ function ensureLazyStepper(ctx: CodegenContext, deps: LazyDeps): void {
       { name: "args", type: { kind: "externref" } },
       { name: "res", type: { kind: "externref" } },
       { name: "inner", type: { kind: "externref" } },
+      { name: "flg", type: { kind: "i32" } },
+      { name: "blen", type: { kind: "i32" } },
     ],
     body: stepBody,
     exported: false,
@@ -548,6 +1029,7 @@ function emitLazyConstructor(ctx: CodegenContext, methodName: string, deps: Lazy
     isCount ? { op: "ref.null.extern" } : { op: "local.get", index: 1 }, // fn
     isCount ? { op: "local.get", index: 3 } : { op: "f64.const", value: 0 }, // state
     { op: "ref.null.extern" }, // inner
+    { op: "i32.const", value: 0 }, // flags (#5147)
     { op: "struct.new", typeIdx: helperTypeIdx },
     { op: "extern.convert_any" },
   );
@@ -561,6 +1043,149 @@ function emitLazyConstructor(ctx: CodegenContext, methodName: string, deps: Lazy
     locals: [
       { name: "src", type: { kind: "externref" } },
       { name: "cnt", type: { kind: "f64" } },
+    ],
+    body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
+/**
+ * (#5147) Emit `__iter_lazy_{chunks,windows}(recv, size, undersized) -> externref`.
+ *
+ * Argument validation runs BEFORE the wrapper exists and before any coercion
+ * (§27.1.4.x: "If chunkSize is not a Number, throw a TypeError" — a `typeof`
+ * test, never a ToNumber, which is what `chunkSize-no-coercion.js` pins):
+ *   - not a Number, non-integral, or non-finite ⇒ TypeError
+ *   - outside [1, 2^32-1]                       ⇒ RangeError
+ *   - `undersized` (windows only) other than undefined / "only-full" /
+ *     "allow-partial"                           ⇒ TypeError
+ */
+function emitChunkingConstructor(ctx: CodegenContext, methodName: string, deps: LazyDeps): number {
+  const { helperTypeIdx, openIdx, unboxNumIdx, typeofNumIdx, typeofUndefIdx, strictEqIdx } = deps;
+  const kind = KIND[methodName]!;
+  const isWindows = methodName === "windows";
+  const ctorName = `__iter_lazy_${methodName}`;
+  const tagIdx = ensureExnTag(ctx);
+  const newTypeErrIdx = ctx.funcMap.get("__new_TypeError");
+  const newRangeErrIdx = ctx.funcMap.get("__new_RangeError");
+
+  // FRESH instrs per call (#2169b — never alias one Instr into two bodies).
+  const throwWith = (ctorIdx: number | undefined, msg: string): Instr[] =>
+    ctorIdx === undefined
+      ? [{ op: "unreachable" }]
+      : [...stringConstantExternrefInstrs(ctx, msg), { op: "call", funcIdx: ctorIdx }, { op: "throw", tagIdx }];
+
+  // Locals: 0 recv, 1 size, 2 undersized, 3 hasUndersized (params);
+  //         4 src, 5 n (f64), 6 flags.
+  const SRC = 4;
+  const N = 5;
+  const FLAGS = 6;
+  const body: Instr[] = [
+    // typeof size !== "number" ⇒ TypeError.
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: typeofNumIdx! },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: throwWith(newTypeErrIdx, CHUNK_SIZE_TYPE_MSG) },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: unboxNumIdx },
+    { op: "local.set", index: N },
+    // non-integral (covers NaN: floor(NaN) != NaN) ⇒ TypeError.
+    { op: "local.get", index: N },
+    { op: "f64.floor" },
+    { op: "local.get", index: N },
+    { op: "f64.ne" },
+    // non-finite (n - n is NaN for ±Infinity) ⇒ TypeError.
+    { op: "local.get", index: N },
+    { op: "local.get", index: N },
+    { op: "f64.sub" },
+    { op: "f64.const", value: 0 },
+    { op: "f64.ne" },
+    { op: "i32.or" },
+    { op: "if", blockType: { kind: "empty" }, then: throwWith(newTypeErrIdx, CHUNK_SIZE_TYPE_MSG) },
+    // outside [1, 2^32-1] ⇒ RangeError.
+    { op: "local.get", index: N },
+    { op: "f64.const", value: 1 },
+    { op: "f64.lt" },
+    { op: "local.get", index: N },
+    { op: "f64.const", value: MAX_CHUNK_SIZE },
+    { op: "f64.gt" },
+    { op: "i32.or" },
+    { op: "if", blockType: { kind: "empty" }, then: throwWith(newRangeErrIdx, CHUNK_SIZE_RANGE_MSG) },
+  ];
+
+  if (isWindows) {
+    // undersized: undefined/absent ⇒ "only-full"; "allow-partial" ⇒ flag bit 1;
+    // "only-full" ⇒ 0; anything else ⇒ TypeError.
+    body.push(
+      // Absent (arity-1 call site) or explicitly `undefined` ⇒ "only-full".
+      // Source-level `null` is NOT absent — it must reach the TypeError.
+      { op: "local.get", index: 3 },
+      { op: "i32.eqz" },
+      { op: "local.get", index: 2 },
+      { op: "call", funcIdx: typeofUndefIdx! },
+      { op: "i32.or" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        else: [
+          { op: "local.get", index: 2 },
+          ...stringConstantExternrefInstrs(ctx, ALLOW_PARTIAL),
+          { op: "call", funcIdx: strictEqIdx! },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "i32.const", value: 2 },
+              { op: "local.set", index: FLAGS },
+            ],
+            else: [
+              { op: "local.get", index: 2 },
+              ...stringConstantExternrefInstrs(ctx, ONLY_FULL),
+              { op: "call", funcIdx: strictEqIdx! },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: throwWith(newTypeErrIdx, UNDERSIZED_MSG),
+              },
+            ],
+          },
+        ],
+        then: [],
+      },
+    );
+  }
+
+  body.push(
+    // src = __iter_hof_open(recv) — GetIteratorDirect, AFTER validation.
+    { op: "local.get", index: 0 },
+    { op: "call", funcIdx: openIdx },
+    { op: "local.set", index: SRC },
+    { op: "i32.const", value: kind },
+    { op: "local.get", index: SRC },
+    { op: "ref.null.extern" }, // fn (unused)
+    { op: "local.get", index: N }, // state = chunk/window size
+    { op: "ref.null.extern" }, // inner = buffer (lazily allocated)
+    { op: "local.get", index: FLAGS },
+    { op: "struct.new", typeIdx: helperTypeIdx },
+    { op: "extern.convert_any" },
+  );
+
+  const typeIdx = addFuncType(
+    ctx,
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }, { kind: "i32" }],
+    [{ kind: "externref" }],
+  );
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set(ctorName, funcIdx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: ctorName,
+    typeIdx,
+    locals: [
+      { name: "src", type: { kind: "externref" } },
+      { name: "n", type: { kind: "f64" } },
+      { name: "flags", type: { kind: "i32" } },
     ],
     body,
     exported: false,

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -70,7 +70,10 @@ import { ensureNativeArrayHof } from "./hof-native.js";
 import { ensureStrToCharVecHelper, nativeStringLiteralInstrs } from "./native-strings.js";
 // (#3119) The OBJ arm's miss/undefined value matches `__extern_get`'s miss
 // representation (the #2106 S1 `$undefined` singleton when active, else null).
-import { undefinedExternInstrs } from "./any-helpers.js";
+import { canonicalUndefinedExternInstrs, undefinedExternInstrs } from "./any-helpers.js";
+// (#5147) `__iter_result_obj` string keys + the union-import bootstrap it needs.
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { addUnionImportsViaRegistry } from "./shared.js";
 // (#3388) GetIterator §7.4.1: a non-iterable subject must throw a catchable
 // `TypeError`, not trap (`ref.cast $Vec` on a non-vec → `illegal cast`). The
 // error constructor + message global are registered EAGERLY (idempotent) so the
@@ -571,6 +574,13 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
   // (#2038) Defer the USER arm to finalize (closed-struct dispatchers not yet
   // emitted). The eager bodies above are a valid vec-only carrier.
   ctx.nativeIteratorUserArmPending = true;
+
+  // (#5147) Reserve the §7.4.11 result-object builder alongside the ladder. It
+  // is registered HERE — not from the `.next()` dispatcher reserve — because
+  // its own dependency bootstrap (`ensureObjectRuntime` /
+  // `addUnionImportsViaRegistry`) can add imports, and doing that from inside a
+  // mid-body reserve shifts funcIdxs under the function being compiled.
+  ensureNativeIterResultObject(ctx);
 }
 
 /**
@@ -629,6 +639,275 @@ export function ensureIterStepScratchGlobal(ctx: CodegenContext): number {
  * and patched by `shiftLateImportIndices` like any other defined body if a later
  * import shifts them.
  */
+/**
+ * (#5147) Register `__iter_result_obj(done i32, value externref) -> externref`
+ * — §7.4.11 CreateIterResultObject as a REAL `$Object` with data properties
+ * `value` / `done`.
+ *
+ * Deliberately NOT a closed struct (`$MapIterResult`, `$NativeGeneratorResult`):
+ * source code reads `r.value` / `r.done` dynamically, and `__extern_get` only
+ * sees `$Object` — a closed struct answers `undefined` there (the #25/#2038
+ * trap). `value` for a done result is the canonical `undefined` singleton, not
+ * a null externref (which surfaces as JS `null`).
+ *
+ * RESERVE-then-FILL (#1719/#2043): the body is written by
+ * {@link fillIterResultObject} at finalize, so the funcIdxs it bakes in
+ * (`__new_plain_object` / `__extern_set` / `__box_boolean`) are the FINAL ones.
+ * Baking them at reserve time is what breaks: a later late-import addition
+ * shifts them under an already-emitted body.
+ *
+ * Returns undefined when the object runtime is unavailable (host lane).
+ */
+export function ensureNativeIterResultObject(ctx: CodegenContext): number | undefined {
+  const existing = ctx.funcMap.get("__iter_result_obj");
+  if (existing !== undefined) return existing;
+  if (!(ctx.standalone || ctx.wasi)) return undefined;
+  ensureObjectRuntime(ctx);
+  addUnionImportsViaRegistry(ctx);
+  addStringConstantGlobal(ctx, "value");
+  addStringConstantGlobal(ctx, "done");
+  const typeIdx = addFuncType(ctx, [{ kind: "i32" }, { kind: "externref" }], [{ kind: "externref" }]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__iter_result_obj", funcIdx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: "__iter_result_obj",
+    typeIdx,
+    locals: [{ name: "obj", type: { kind: "externref" } }],
+    body: [{ op: "unreachable" }], // placeholder — replaced immediately below
+    exported: false,
+  });
+  ctx.iterResultObjPending = true;
+  // Write the real body NOW: the helper funcIdxs it bakes in must be resolved
+  // in the same pass that registered them (a finalize-time re-read of
+  // `__box_boolean` & co. answers a stale index once the union-import registry
+  // has been rebuilt).
+  fillIterResultObject(ctx);
+
+  // (#5147) `__iter_next_result(recv) -> externref` — ONE step of the ladder,
+  // packaged as a SINGLE-result externref→externref call. Call sites must use
+  // this rather than emitting `call __iterator_next` (multi-result) followed by
+  // `call __iter_result_obj` inline: a two-call sequence whose intermediate is a
+  // multi-value stack is mis-typed by the later argument-coercion repair when
+  // the sequence is cloned into another body (it inserted a ToNumber before the
+  // step call and the module failed to validate).
+  const stepTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
+  const stepIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__iter_next_result", stepIdx);
+  const iterNextIdx = ctx.funcMap.get("__iterator_next");
+  pushDefinedFunc(ctx, stepIdx, {
+    name: "__iter_next_result",
+    typeIdx: stepTypeIdx,
+    // The two results are SPILLED to locals before the result-object call.
+    // Feeding a multi-result call straight into a two-parameter call is what
+    // `stack-balance`'s call-argument repair mis-reads (it models one pushed
+    // result, under-flows, and "fixes" the receiver by unboxing it to i32).
+    locals: [
+      { name: "done", type: { kind: "i32" } },
+      { name: "val", type: { kind: "externref" } },
+    ],
+    body:
+      iterNextIdx === undefined
+        ? [{ op: "ref.null.extern" }]
+        : [
+            { op: "local.get", index: 0 },
+            { op: "call", funcIdx: iterNextIdx },
+            { op: "local.set", index: 2 },
+            { op: "local.set", index: 1 },
+            { op: "local.get", index: 1 },
+            { op: "local.get", index: 2 },
+            { op: "call", funcIdx },
+          ],
+    exported: false,
+  });
+  return funcIdx;
+}
+
+/** (#5147) FINALIZE fill for {@link ensureNativeIterResultObject}. */
+export function fillIterResultObject(ctx: CodegenContext): void {
+  if (!ctx.iterResultObjPending) return;
+  const selfIdx = ctx.funcMap.get("__iter_result_obj");
+  if (selfIdx === undefined) return;
+  const fn = definedFuncAt(ctx, selfIdx);
+  if (!fn) return;
+  const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object");
+  const externSetIdx = ctx.funcMap.get("__extern_set");
+  const boxBoolIdx = ctx.funcMap.get("__box_boolean");
+  if (newPlainObjectIdx === undefined || externSetIdx === undefined || boxBoolIdx === undefined) {
+    // No object runtime in this module — answer null (the pre-#5147 behaviour of
+    // every call site that routes here) instead of leaving an `unreachable`.
+    fn.body = [{ op: "ref.null.extern" }];
+    return;
+  }
+  // params: 0 = done (i32), 1 = value (externref); locals: 2 = obj.
+  fn.body = [
+    { op: "call", funcIdx: newPlainObjectIdx },
+    { op: "local.set", index: 2 },
+    { op: "local.get", index: 2 },
+    ...stringConstantExternrefInstrs(ctx, "value"),
+    { op: "local.get", index: 1 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: canonicalUndefinedExternInstrs(ctx),
+      else: [{ op: "local.get", index: 1 }],
+    },
+    { op: "call", funcIdx: externSetIdx },
+    { op: "local.get", index: 2 },
+    ...stringConstantExternrefInstrs(ctx, "done"),
+    { op: "local.get", index: 0 },
+    { op: "call", funcIdx: boxBoolIdx },
+    { op: "call", funcIdx: externSetIdx },
+    { op: "local.get", index: 2 },
+  ];
+}
+
+/**
+ * (#5147) Reserve `__any_iter_next(recv) -> externref` — source-level
+ * `it.next()` on a value that may be a NATIVE iterator carrier rather than a
+ * generator frame.
+ *
+ * Before this, an `any`-typed `.next()` went straight to `__gen_next`, which
+ * does not recognize the `$IterRec` carrier `[1,2][Symbol.iterator]()` produces
+ * nor the `$LazyIterHelper` a lazy helper returns — so `.next()` answered null
+ * and the following `.value`/`.done` read threw. The body is filled at FINALIZE
+ * (the `$LazyIterHelper` type and the ladder's lazy arms only exist by then);
+ * the reserve is append-only so no funcIdx shifts (#1719).
+ *
+ * Returns undefined when the pieces are unavailable — callers then keep their
+ * original `__gen_next` route byte-for-byte.
+ */
+export function reserveAnyIterNext(ctx: CodegenContext): number | undefined {
+  const existing = ctx.funcMap.get("__any_iter_next");
+  if (existing !== undefined) return existing;
+  if (!(ctx.standalone || ctx.wasi)) return undefined;
+  ensureNativeIteratorRuntime(ctx);
+  if (ensureNativeIterResultObject(ctx) === undefined) return undefined;
+  if (ctx.funcMap.get("__iterator_next") === undefined) return undefined;
+  const genNextIdxAtReserve = ctx.funcMap.get("__gen_next");
+  const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__any_iter_next", funcIdx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: "__any_iter_next",
+    typeIdx,
+    locals: [
+      { name: "recvAny", type: { kind: "anyref" } },
+      { name: "done", type: { kind: "i32" } },
+      { name: "val", type: { kind: "externref" } },
+    ],
+    // Placeholder — replaced by `fillAnyIterNext`. It is the PRE-#5147
+    // behaviour (plain `__gen_next`), not `unreachable`, so a pipeline that
+    // never reaches the fill (e.g. the multi-source finalize) degrades to the
+    // old answer instead of trapping.
+    body:
+      genNextIdxAtReserve === undefined
+        ? [{ op: "ref.null.extern" }]
+        : [
+            { op: "local.get", index: 0 },
+            { op: "call", funcIdx: genNextIdxAtReserve },
+          ],
+    exported: false,
+  });
+  ctx.anyIterNextPending = true;
+  return funcIdx;
+}
+
+/**
+ * (#5147) §7.4.1 GetIterator on a value that IS already a native iterator
+ * record answers the record itself (`%ArrayIteratorPrototype%[@@iterator]`
+ * returns `this`). Without this arm `Array.from([1,2][Symbol.iterator]())` —
+ * and every other re-iteration of an iterator — threw "value is not iterable"
+ * once `[Symbol.iterator]()` started producing a real `$__IterRec` cursor
+ * instead of a snapshot vec. Prepended, so it precedes the vec/family arms.
+ * Fresh Instr objects (#2169b). Idempotent per module.
+ */
+function prependIterRecIdentityArm(ctx: CodegenContext): void {
+  if (ctx.iterRecIdentityArmDone) return;
+  const iterRecTypeIdx = ctx.structMap.get("__IterRec");
+  const iteratorIdx = ctx.funcMap.get("__iterator");
+  if (iterRecTypeIdx === undefined || iteratorIdx === undefined) return;
+  const fn = definedFuncAt(ctx, iteratorIdx);
+  if (!fn) return;
+  ctx.iterRecIdentityArmDone = true;
+  fn.body = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: iterRecTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: 0 }, { op: "return" }],
+    },
+    ...fn.body,
+  ];
+}
+
+/**
+ * (#5147) FINALIZE fill for {@link reserveAnyIterNext}. Must run AFTER
+ * `fillNativeIteratorLateArms` and `fillLazyIterLadderArms` so `__iterator_next`
+ * already carries every carrier arm this delegates to.
+ */
+export function fillAnyIterNext(ctx: CodegenContext): void {
+  prependIterRecIdentityArm(ctx);
+  if (!ctx.anyIterNextPending) return;
+  const selfIdx = ctx.funcMap.get("__any_iter_next");
+  const iterNextIdx = ctx.funcMap.get("__iterator_next");
+  const resultObjIdx = ctx.funcMap.get("__iter_result_obj");
+  if (selfIdx === undefined || iterNextIdx === undefined || resultObjIdx === undefined) return;
+  const fn = definedFuncAt(ctx, selfIdx);
+  if (!fn) return;
+  const iterRecTypeIdx = ctx.structMap.get("__IterRec");
+  const lazyTypeIdx = ctx.structMap.get("$LazyIterHelper");
+  const genNextIdx = ctx.funcMap.get("__gen_next");
+
+  // recognized = ref.test $IterRec ∨ ref.test $LazyIterHelper
+  const recognized: Instr[] = [];
+  for (const t of [iterRecTypeIdx, lazyTypeIdx]) {
+    if (t === undefined) continue;
+    recognized.push({ op: "local.get", index: 1 }, { op: "ref.test", typeIdx: t });
+    if (recognized.length > 2) recognized.push({ op: "i32.or" });
+  }
+  if (recognized.length === 0) {
+    // Nothing native to recognize — behave exactly like the legacy route.
+    fn.body =
+      genNextIdx === undefined
+        ? [{ op: "ref.null.extern" }]
+        : [
+            { op: "local.get", index: 0 },
+            { op: "call", funcIdx: genNextIdx },
+          ];
+    return;
+  }
+
+  fn.body = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: 1 },
+    ...recognized,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: iterNextIdx },
+        { op: "local.set", index: 3 },
+        { op: "local.set", index: 2 },
+        { op: "local.get", index: 2 },
+        { op: "local.get", index: 3 },
+        { op: "call", funcIdx: resultObjIdx },
+        { op: "return" },
+      ],
+    },
+    ...(genNextIdx === undefined
+      ? ([{ op: "ref.null.extern" }] satisfies Instr[])
+      : ([
+          { op: "local.get", index: 0 },
+          { op: "call", funcIdx: genNextIdx },
+        ] satisfies Instr[])),
+  ];
+}
+
 export function ensureNativeArrayFromIterN(ctx: CodegenContext): number {
   const existing = ctx.funcMap.get("__array_from_iter_n");
   if (existing !== undefined) return existing;

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -179,6 +179,7 @@ import {
   receiverIsCatchClauseBinding,
   receiverIsNativeStringValType,
   resolveInheritedStaticProp,
+  assignsCoveredFunctionValue,
   resolveLogicalAssignmentName,
   resolveStructNameForExpr,
   runtimeAccessorDescriptorKey,
@@ -2955,8 +2956,11 @@ export function tryLengthAndNameReads(
               initExpr = decl.initializer;
             }
             if (
-              initExpr !== undefined &&
-              (!isAnonymousFunctionDefinition(initExpr) || classExpressionDefinesOwnName(initExpr))
+              (initExpr !== undefined &&
+                (!isAnonymousFunctionDefinition(initExpr) || classExpressionDefinesOwnName(initExpr))) ||
+              // (#5146) No initializer, but every simple assignment to the
+              // binding installs a COVERED form (`x = (0, function(){})`).
+              (initExpr === undefined && decl !== undefined && assignsCoveredFunctionValue(ctx, expr.expression, decl))
             ) {
               // Covered form — .name is "" (or whatever the inner fn already has).
               // (#2756) A class with its own `static name` member overrides the

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -617,6 +617,36 @@ const LOGICAL_ASSIGNMENT_TOKENS = new Set<ts.SyntaxKind>([
  * Returns the inferred `.name` string, or undefined when no qualifying
  * logical-assignment is found.
  */
+/**
+ * (#5146 cluster E) True when the only simple assignments to `sym` install a
+ * COVERED function value — `xCover = (0, function () {})`. A comma expression
+ * is not an AnonymousFunctionDefinition, so §13.15.2 NamedEvaluation does NOT
+ * run and `.name` stays `""`. Without this, the `.name` fold fell back to the
+ * receiver identifier's own text and published `"xCover"`.
+ */
+export function assignsCoveredFunctionValue(ctx: CodegenContext, id: ts.Identifier, binding: ts.Declaration): boolean {
+  const sourceFile = id.getSourceFile();
+  let sawAssignment = false;
+  let allCovered = true;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left) &&
+      node.left.text === id.text &&
+      ctx.oracle.declarationsOf(node.left).includes(binding)
+    ) {
+      let rhs: ts.Expression = node.right;
+      while (ts.isParenthesizedExpression(rhs)) rhs = rhs.expression;
+      sawAssignment = true;
+      if (isAnonymousFunctionDefinition(rhs)) allCovered = false;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return sawAssignment && allCovered;
+}
+
 export function resolveLogicalAssignmentName(
   ctx: CodegenContext,
   id: ts.Identifier,

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -1354,9 +1354,47 @@ on([ts.SyntaxKind.BinaryExpression], (ctx, node) => {
   }
 });
 
+/**
+ * (#5146 cluster H) True when `node` is covered by an ObjectAssignmentPattern /
+ * ArrayAssignmentPattern — the LHS of `=`, or a for-of / for-in head, possibly
+ * nested inside another pattern. The duplicate-`__proto__` Early Error applies
+ * to object LITERALS only; `({ __proto__: x, __proto__: y } = value)` is legal.
+ */
+function isAssignmentPatternPosition(node: ts.Node): boolean {
+  let child: ts.Node = node;
+  let parent: ts.Node | undefined = node.parent;
+  while (parent !== undefined) {
+    if (ts.isParenthesizedExpression(parent)) {
+      child = parent;
+      parent = parent.parent;
+      continue;
+    }
+    if (ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      // `pattern = value`, or a nested `target = default` inside a pattern.
+      if (parent.left === child) return true;
+      return false;
+    }
+    if ((ts.isForOfStatement(parent) || ts.isForInStatement(parent)) && parent.initializer === child) return true;
+    if (
+      ts.isArrayLiteralExpression(parent) ||
+      ts.isObjectLiteralExpression(parent) ||
+      ts.isPropertyAssignment(parent) ||
+      ts.isShorthandPropertyAssignment(parent) ||
+      ts.isSpreadElement(parent) ||
+      ts.isSpreadAssignment(parent)
+    ) {
+      child = parent;
+      parent = parent.parent;
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
 // ── Duplicate __proto__ in object literal ────────────────────────
 on([ts.SyntaxKind.ObjectLiteralExpression], (ctx, node) => {
-  if (ts.isObjectLiteralExpression(node)) {
+  if (ts.isObjectLiteralExpression(node) && !isAssignmentPatternPosition(node)) {
     let protoCount = 0;
     for (const prop of node.properties) {
       if (ts.isPropertyAssignment(prop)) {


### PR DESCRIPTION
## Description

Fifth integration batch toward 100% ES2015 test262 pass rate in standalone mode (follows merged [#5173](https://github.com/loopdive/js2/pull/5173), [#5175](https://github.com/loopdive/js2/pull/5175), [#5179](https://github.com/loopdive/js2/pull/5179), [#5191](https://github.com/loopdive/js2/pull/5191)):

- **Assignment destructuring wave 1** ([#5146](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5146-es2015-standalone-assignment-wave1)) — +46 tests (98-path bucket measures 51 passing on the integrated tree). Destructuring-assignment PutValue semantics: element-access targets on non-vec receivers, evaluation order, nested patterns.
- **Iterators wave 1** ([#5147](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5147-es2015-standalone-iterators-wave1)) — +16 tests. Iterator-prototype built-ins (%ArrayIteratorPrototype%/Map/Set iterator surfaces).

Merge-resolution note: #5144 (merged in wave 4) and #5146 had twin implementations of the dynamic element-set for destructuring targets; this branch keeps #5144's null-receiver-tolerant version — re-verified by probe (assignment bucket 51/98 passing on the integrated tree, above the agent's own 46).

Validation on the integrated branch: equivalence gate green (1705 passing, 24 known baseline failures, no new regressions); ratchet gates green; `origin/main` (post-wave-4) merged in.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_013QXS328H9un2guFo43hR5e)_