### PR TITLE
docs(issues): file #5176/#5177 — adjacent defects from the #3481 symbol[] slice ✓

### DIFF
--- a/plan/issues/5176-proxy-ownkeys-trap-return-ignored.md
+++ b/plan/issues/5176-proxy-ownkeys-trap-return-ignored.md
@@ -1,0 +1,49 @@
+---
+id: 5176
+title: "Proxy ownKeys trap's return value is ignored entirely — a trap returning ['x'] still yields length 0"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+goal: core-semantics
+related: [3481]
+---
+
+# `ownKeys` trap results never reach the caller
+
+Found during the #3481 `symbol[]` slice (PR #5198) and **proved symbol-unrelated
+on base**: a Proxy whose `ownKeys` trap returns a plain string-key literal —
+
+```js
+const p = new Proxy({}, { ownKeys: t => ['x'] });
+Object.getOwnPropertyNames(p).length   // 0, spec: 1
+```
+
+— also yields length `0`. The trap runs (or is never consulted — the dispatched
+fix must establish which); its return value is discarded either way.
+
+This is what still blocks the third `symbol[]` test262 row after PR #5198:
+`built-ins/Proxy/ownKeys/call-parameters-object-getownpropertysymbols.js` now
+loses its Symbol-coercion error and fails on
+`SameValue(«undefined», «Symbol(a)»)` — the keys list comes back empty. The
+measurement trail is in PR #5198's body ("The third `symbol[]` row does not
+flip") and the #3481 issue file's updated cluster record.
+
+First step: establish whether the MOP routing for `getOwnPropertyNames`/
+`getOwnPropertySymbols`/`Reflect.ownKeys` ever consults the proxy handler at
+all in each lane, or consults it and drops the result — the fix differs.
+
+## Acceptance criteria
+
+- The shape above answers `1` (and the trap-invocation route per lane is
+  recorded, measured); the #3481 third row's failure moves past the empty-keys
+  stage or flips to pass.
+- Byte-identity for programs with no Proxy `ownKeys` usage (per-row sha256
+  over a reachable cohort); pinned tests red on base; equivalence shards
+  clean by name.

--- a/plan/issues/5177-map-foreach-nonnumeric-key-corruption.md
+++ b/plan/issues/5177-map-foreach-nonnumeric-key-corruption.md
@@ -1,0 +1,57 @@
+---
+id: 5177
+title: "Map.prototype.forEach silently corrupts non-numeric keys to NaN when the entries literal infers Map<number, number>"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: medium
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+goal: core-semantics
+related: [3481, 2949]
+---
+
+# Silent key corruption — the loud Symbol throw is the visible tip
+
+Found and measured during the #3481 Map-sub-family re-diagnosis (PR #5198),
+where the filed "statically-symbol keys" cause was refuted. The real mechanism,
+measured on base:
+
+- `new Map([[4, 4], ['foo3', 3], [s, 2]])` is inferred **by TypeScript
+  itself** as `Map<number, number>` (heterogeneous entries literal).
+- The `forEach` callback's parameters therefore lower to `f64`, and the
+  WebAssembly JS API's own argument coercion applies ToNumber to whatever the
+  host passes: a **Symbol key throws** (the loud case #3481 tracked), a
+  **string key silently becomes `NaN`** — `'foo3'` reads back as `NaN`, no
+  throw, no diagnostic.
+- Control: binding the callback to a `var` first makes all three test262 rows
+  pass; `Map<any, any>` annotation also works (union lowers to `externref`).
+
+**A representation-only fix was built, measured, and REVERTED in PR #5198**:
+widening the callback's parameter representation to `externref` for `Map`/`Set`
+`forEach` fixed shapes where the parameter is never stored, but flipped zero
+test262 rows — the row bodies do `results.push({value, key})` and the object
+literal's field types re-narrow to `f64` from the same TS types (confirmed in
+WAT: `struct.new` with `__unbox_number` on both fields). What it actually
+needs: the parameters must be `any` in the **type system** — a node-level
+dynamic-parameter override consulted by every site deriving a representation
+from `getTypeAtLocation`. That is design-adjacent to #2949 (dynamic value
+representation) but is not the same work; do not fold it in without measuring.
+
+Full evidence: PR #5198's "Map rows — re-diagnosed" section and the #3481
+issue file's updated record.
+
+## Acceptance criteria
+
+- `new Map([[4,4],['foo3',3]]).forEach((v,k) => …)` observes the string key
+  `'foo3'` (not `NaN`), and the Symbol-key case stops throwing, in the gc
+  lane; the three #3481 Map test262 rows flip or their residual is re-measured
+  and recorded.
+- No blast-radius regression: the reverted-fix lesson means the change must be
+  validated on shapes that STORE the callback parameters, not only pass-through
+  shapes; byte-identity for programs without `Map`/`Set` `forEach`.
+- Pinned tests red on base; equivalence shards clean by name.


### PR DESCRIPTION
## Description

Docs-only batch filing the two independent defects measured during PR #5198's #3481 `symbol[]` work:

- **New issue [#5176](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5176-proxy-ownkeys-trap-return-ignored)** — a Proxy `ownKeys` trap's return value is ignored entirely (a trap returning `['x']` still yields length 0; proved symbol-unrelated on base). This is what still blocks the third `symbol[]` test262 row.
- **New issue [#5177](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5177-map-foreach-nonnumeric-key-corruption)** — `Map.prototype.forEach` silently corrupts non-numeric keys to `NaN` when the entries literal infers `Map<number, number>`; records the representation-only fix that was built, measured at zero conformance yield, and reverted in PR #5198, and why the real fix is a type-system-level dynamic-parameter override.

Both cite the measurement trail in PR #5198 and [#3481](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3481-bigint-symbol-coercion-value-rep)'s updated record. Ids reserved via `claim-issue.mjs --allocate` (5176, 5177). No code paths touched; gates green (0 changed src files).

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_