### PR TITLE
fix(ci): classify the stack-balance shared-body standalone failures — unblock the merge queue (#5181) ✓

### DIFF
--- a/plan/issues/5181-standalone-stack-balance-error-shift.md
+++ b/plan/issues/5181-standalone-stack-balance-error-shift.md
@@ -1,0 +1,158 @@
+---
+id: 5181
+title: "#5204's selfhost commit shifted 2,580 standalone failures to the stack-balance shared-body refusal — 24 fell outside every root-cause bucket and blocked the merge queue"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: high
+horizon: m
+task_type: bugfix
+area: codegen
+goal: ir-full-coverage
+related: [1058]
+---
+
+# What happened
+
+Every `merge_group` re-validation was failing the required **`merge shard reports`**
+check at its `Build merged standalone test262 report` step:
+
+```
+Standalone root-cause map has 24 unclassified failures; threshold is 0.
+```
+
+That is `scripts/build-test262-report.mjs --target standalone
+--max-unclassified-root-causes 0`. The gate is a hard zero, so 24 rows nobody
+had a bucket for wedged the queue for every open code PR (#5211, #5214, #5217,
+#5218 queued behind it).
+
+## The failures are all one signature
+
+All 24 are `status: compile_error`, `error_category: "other"`, carrying exactly
+one diagnostic — `src/codegen/stack-balance.ts:2804`:
+
+> `stack-balance (#1058): function "…" reaches an instruction array from
+> incompatible control-flow or function-local contexts. The repair pass refuses
+> to mutate one shared body for all owners; emit distinct instruction arrays at
+> the producer.`
+
+In plain terms: two callers that need *different* stack repairs end up pointing
+at the **same** `Instr[]` array, so the repair pass cannot fix one without
+breaking the other, and it refuses rather than guess. It is a fail-loud, not a
+silent miscompile.
+
+That diagnostic entered `main` with commit **`8f161cbf15`** — *"feat(selfhost):
+compile TypeScript 5 parser graph to Wasm"*, landed via **PR #5204** (a PR
+number, not a plan-issue id; parent commit `70e8e3c1ca`). `git log -S 'refuses
+to mutate' -- src/codegen/stack-balance.ts` returns that one commit.
+
+## The measured split — 2,580 rows, 24 orphans
+
+Measured directly on the merged standalone JSONL from the parked run
+(`test262-merged-report` artifact 9709198482 of run 33232469498, merge sha
+`7e0dbb303e`, 48,735 rows):
+
+| population | count |
+| --- | --- |
+| standalone rows carrying the signature | **2,580** (all `compile_error`) |
+| …already claimed by an existing feature-path bucket | 2,556 |
+| …matching no bucket at all → `unclassified` | **24** |
+
+The 2,556 are claimed by path: a leaked `env::__temporal_*` import on a Temporal
+test still lands in `temporal-proposal`, a RegExp test in the RegExp buckets, and
+so on. The 24 orphans are the tests whose *path* no bucket names:
+
+| family | n |
+| --- | --- |
+| `test/built-ins/Error/prototype/stack/*` | 14 |
+| `test/harness/deepEqual-*` | 5 |
+| `test/harness/testTypedArray*` | 3 |
+| `test/language/expressions/instanceof/*` | 2 |
+
+Full list: `getter-error-as-prototype`, `getter-error-instance`,
+`getter-error-prototype`, `getter-subclass`, `instance-no-own-stack`,
+`instance-not-enumerable`, `setter-empty-string`, `setter-no-argument`,
+`setter-non-extensible-receiver`, `setter-non-string-value`,
+`setter-non-writable-stack`, `setter-own-accessor`,
+`setter-receiver-is-other-prototype`, `setter-via-assignment` (all under
+`built-ins/Error/prototype/stack/`); `deepEqual-array`, `deepEqual-circular`,
+`deepEqual-deep`, `deepEqual-mapset`, `deepEqual-primitives`;
+`testTypedArray`, `testTypedArray-conversions`,
+`testTypedArray-conversions-call-error`; `instanceof/S15.3.5.3_A2_T5`,
+`instanceof/S15.3.5.3_A3_T1`.
+
+## What this PR ships (the unblock only)
+
+One new **error-signature** bucket in `STANDALONE_ROOT_CAUSE_BUCKETS`
+(`scripts/build-test262-report.mjs`), `id: stack-balance-shared-body`, matching
+the two spellings of the one signature — the raw `error` keeps the literal
+`(#1058)` while `error_signature` digit-normalises it to `(##)`.
+
+It is placed **with the residual catches near the end of the list**, not at the
+top, deliberately: `find`'s first match wins, so a top placement would pull all
+2,556 already-classified rows out of their feature buckets. The bucket therefore
+claims exactly the 24 orphans and nothing else — verified by diffing every
+bucket count before and after against the real merged JSONL:
+
+```
+BEFORE unclassified: 24    AFTER unclassified: 0
+BEFORE classified: 17226   AFTER classified: 17250  (of 17250)
+BUCKET DELTA stack-balance-shared-body 0 -> 24
+no other bucket changed count — zero poaching
+exit 0
+```
+
+`tests/issue-5181-stack-balance-root-cause.test.ts` pins all three facts:
+unclassified is 0, the bucket claims the residual, and a same-signature row on a
+feature path stays in its feature bucket.
+
+**This is classification, not a fix.** Nothing about the compiler changed; the
+24 tests still fail. It restores the merge queue and makes the failure visible
+under a name that says what it is.
+
+# The real follow-up
+
+## 1. Does the error-mode shift hide genuine regressions?
+
+`8f161cbf15` moved 2,580 standalone rows onto this signature. Unknown, and the
+question that matters: **were any of those 2,580 passing before it?** A row that
+went `pass → compile_error` is a regression that the root-cause map now files
+tidily under a known bucket, which is exactly how a real loss stays invisible.
+
+Spot-check protocol:
+
+1. Sample 20 of the 2,580 from the merged report (stratify: some from each of
+   the large feature buckets, not just the tail).
+2. A/B against `8f161cbf15^` = `70e8e3c1ca`, standalone target, same runner
+   flags. Use the file-copy pattern from `CLAUDE.md`, and capture the base copy
+   **before** the first edit.
+3. Any `pass` at the parent that is `compile_error` at `8f161cbf15` is a
+   regression — count it, then widen the sample toward that family.
+4. Cross-check against the per-SHA baseline diff for the `8f161cbf15` merge if
+   one survives; a `pass → compile_error` transition should have shown there.
+
+If the answer is "none were passing", this is a pure error-mode relabel and the
+bucket is the right permanent home. If any were, the shift is a regression that
+needs its own issue and a revert-or-fix decision.
+
+## 2. Root-cause the shared-body refusal for the `Error.prototype.stack` family
+
+The 24 orphans are not random — 14 of them are one feature (`Error.prototype.
+stack` getter/setter) and 8 more are two harness helpers (`deepEqual`,
+`testTypedArray`). Both shapes are *accessor-heavy closure code*: the reported
+function names are `__closure_NN`, `makeNativeError`, `cacheComparison`,
+`formatSimpleValue`. That is a strong hint the shared-`Instr[]` aliasing comes
+from one producer emitting a single body for several closure owners.
+
+Find that producer and give each owner its own array (that is literally what the
+diagnostic asks for: "emit distinct instruction arrays at the producer"). Fixing
+it should retire the 24 and take a slice of the 2,556 with it.
+
+## Acceptance criteria
+
+- [x] `--max-unclassified-root-causes 0` exits 0 on the real merged standalone
+      JSONL, with the 24 claimed and no other bucket's count changed.
+- [ ] The 20-sample A/B against `70e8e3c1ca` is run and its result recorded here
+      — including "zero regressions found", which is a result, not a non-answer.
+- [ ] The producer that shares one `Instr[]` across closure owners is named.

--- a/plan/issues/5182-merge-group-gate-bypass.md
+++ b/plan/issues/5182-merge-group-gate-bypass.md
@@ -1,0 +1,131 @@
+---
+id: 5182
+title: "Merge queue landed PRs despite red/absent merge_group verdicts — skip-twin check names satisfy the ruleset"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: critical
+horizon: m
+task_type: bugfix
+area: ci
+---
+
+# The merge queue is merging groups whose required checks are RED
+
+The merge-queue re-validation on the merged state is the **only** gate that
+catches a regression the PR-level checks cannot see — that is the whole reason
+`auto-park` (#2547) exists. On 2026-08-29 that gate was reporting `failure` and
+the queue merged anyway. At least six merge shas in a six-hour window landed on
+`main` with a failed required `Test262 Sharded` merge_group run.
+
+## The clearest instance — PR #5199
+
+| fact | value |
+| --- | --- |
+| merge sha (now on `main`) | `7e0dbb303e0bed5e6459380ce0dd1f497dc79832` |
+| merge_group run | [33232469498](https://github.com/loopdive/js2/actions/runs/33232469498), conclusion **failure**, 04:19:18Z |
+| `merge shard reports` (REQUIRED) | **failure** 04:18:10Z — step *Build merged standalone test262 report* |
+| `check for test262 regressions` (REQUIRED) | **failure** 04:19:17Z — step *Fail on regressions* |
+| auto-park bot comment + `hold` label | 04:19:37Z |
+| **merged** | **04:27:46Z by `js2-merge-queue-bot[bot]`** |
+
+The park bot did its job: it diagnosed, commented with both failing steps and
+job-log links, and applied `hold`. Eight minutes later the same sha merged.
+`git log origin/main` shows `7e0dbb303e` in place, and PR #5199 is `merged: true`
+**while still carrying the `hold` label**.
+
+## It is not one PR — the pattern
+
+Every row below is a merge_group `Test262 Sharded` run that concluded `failure`
+on a sha that is now an ancestor of `main`. In all four the shard matrix **did
+run** (111 jobs each), so `SHARDS_RAN` was true — the earlier guess that these
+failed before the matrix started is wrong.
+
+| PR | merge sha | run | failing required job → step |
+| --- | --- | --- | --- |
+| #5203 | `4dfedbdc92` | 33228968665 | `merge shard reports` → *Standalone regression guard (#1897)* |
+| #5204 | `523bd0428b` | 33229815117 | `merge shard reports` → *Fail if required test262 shards did not succeed* |
+| #5187 | `84ad98d6d7` | 33230543407 | `merge shard reports` → *Fail if required test262 shards did not succeed* |
+| #5199 | `7e0dbb303e` | 33232469498 | `merge shard reports` → *Build merged standalone report*; `check for test262 regressions` → *Fail on regressions* |
+
+Two more in the same window fit the shape: run 33223074019 (`62ae321f21`,
+PR #5194) and run 33233874554 (`2fe59c4c10`, PR #5209) both concluded `failure`
+and both shas became the base of the next queue group, i.e. they landed.
+
+**Consequence.** Four consecutive merges carried no passing merged-state sweep.
+#5204 in particular is the commit that introduced the 24-unclassified condition
+tracked by
+[#5181](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5181-standalone-stack-balance-error-shift)
+— its own merge group was already red when it landed, and the gate it broke then
+blocked everyone else.
+
+## The first hypothesis is DISPROVEN — do not build the fix on it
+
+The standing doctrine "a SKIPPED required check SATISFIES the requirement"
+suggested the obvious story: `test262-pr-stub.yml` publishes check runs with the
+same three names, and a `skipped`/`success` twin masked the red real run.
+
+**That is not what happened on the merge sha.** Two independent facts:
+
+1. `test262-pr-stub.yml`'s trigger block is `on: pull_request: branches: [main]`
+   — it has **no `merge_group` trigger**. Its only mentions of `merge_group` are
+   in comments.
+2. Exactly four workflow runs exist on `7e0dbb303e`: `CLA Check` (success),
+   `Differential test` (success), `CI` (success), `Test262 Sharded`
+   (**failure**). No stub run.
+
+So on the merge sha the two required contexts had exactly **one** producer, and
+it reported `failure`. The masking theory may still explain PR-level enqueue
+eligibility; it does not explain the merge.
+
+## What to check next (needs endpoints this investigation could not reach)
+
+The GitHub tooling available here exposes workflow runs and jobs, but not the
+raw check-run list for an arbitrary sha, and not the repo ruleset. Both are
+needed to close this:
+
+1. **`GET /repos/loopdive/js2/commits/<sha>/check-runs`** for all four shas —
+   enumerate every check run by name and conclusion, and identify which run
+   satisfied each required context. This is the direct measurement; everything
+   above is inferred from the Actions API.
+2. **`GET /repos/loopdive/js2/rules/branches/main`** — read the
+   `required_status_checks` rule *and its `bypass_actors`*. The merges were
+   performed by the `js2-merge-queue-bot[bot]` GitHub App. If that app is a
+   bypass actor on the rule, the queue merging a red group is the configured
+   behaviour and the whole gate is decorative. This is the single most likely
+   explanation left standing, and it is one API call to confirm or kill.
+3. The **merge-queue rule's own settings** in the same ruleset —
+   `check_response_timeout_minutes`, `min_entries_to_merge`,
+   `min_entries_to_merge_wait_minutes`, `grouping_strategy`. A timeout that
+   elapses while a 30-minute test262 run is still reporting can let an entry
+   through on a stale verdict.
+4. Whether GitHub **disarmed** native auto-merge on park (auto-arm-merge.yml
+   claims it does) yet the queue entry survived — if the entry was already in
+   flight, disarming the PR does not remove it.
+
+## Proposed fixes, in order of confidence
+
+1. **If a bypass actor is the cause** — remove `js2-merge-queue-bot` from the
+   required-status-checks rule's bypass list. Nothing else needs to change.
+2. **Give merge_group its own check names.** Even though the stub is not the
+   culprit here, one context name with two possible producers is a live trap the
+   repo has already been bitten by once (PR #496, backed out by `c9688f33b`).
+   Publish `merge shard reports (merge_group)` / `check for test262 regressions
+   (merge_group)` from `test262-sharded.yml` on the merge_group event and require
+   *those* names for the queue, leaving the PR-level names to the PR lane.
+3. **Make the stub structurally incapable of reporting on merge_group** — an
+   explicit `if: github.event_name == 'pull_request'` on its three context jobs,
+   so the property is enforced by the file rather than by its trigger list
+   staying correct forever.
+4. **Add a post-merge assertion.** A cheap `push`-on-`main` job that fails loudly
+   when `HEAD`'s merge_group `Test262 Sharded` run concluded `failure` would have
+   caught all six within minutes, whatever the root cause turns out to be.
+
+## Acceptance criteria
+
+- [ ] Check runs on `7e0dbb303e`, `84ad98d6d7`, `523bd0428b`, `4dfedbdc92`
+      enumerated; for each required context, the run that satisfied it is named.
+- [ ] Ruleset bypass actors for `main` read and recorded here.
+- [ ] A fix landed that makes a red merge_group verdict block the merge, with a
+      deliberate re-test proving it.

--- a/scripts/build-test262-report.mjs
+++ b/scripts/build-test262-report.mjs
@@ -788,6 +788,33 @@ const STANDALONE_ROOT_CAUSE_BUCKETS = [
     match: (_record, text) => hasAny(text, ["fail after retry"]),
   },
   {
+    // #5181 — the #1058 stack-balance repair pass refuses to mutate ONE shared
+    // instruction array reached from incompatible control-flow / function-local
+    // contexts, and reports that as a hard compile error (src/codegen/
+    // stack-balance.ts, `contextBlocked`). The selfhost commit 8f161cbf15
+    // ("compile TypeScript 5 parser graph to Wasm", landed by PR #5204 — a PR
+    // number, so deliberately NOT in the `issues` list) grew the shared-body
+    // population sharply: 2,580 standalone rows now carry this signature.
+    // The overwhelming majority of them are ALREADY claimed by a feature-path
+    // bucket above (Temporal, RegExp, TypedArray, …), which is why this bucket
+    // sits DOWN HERE with the other residual catches instead of at the top: a
+    // signature match here must not poach a row a feature bucket already owns.
+    // It exists for the residual that no feature path claims (Error.prototype.
+    // stack, harness/deepEqual-*, harness/testTypedArray*, instanceof) — 24
+    // rows that fell through every bucket and tripped the merge_group's
+    // `--max-unclassified-root-causes 0` gate, blocking the queue. The two
+    // patterns are alternates of one signature: the raw `error` keeps the
+    // literal "(#1058)", while `error_signature` digit-normalises it to "(##)".
+    // Whether this error-mode shift MASKS pre-8f161cbf15 passes is the open
+    // question tracked by #5181, not something this classification answers.
+    id: "stack-balance-shared-body",
+    issues: ["#5181", "#1058"],
+    label:
+      "Stack-balance shared-body refusal (#1058): the repair pass reached one instruction array from incompatible control-flow/function-local contexts and refused to mutate it for all owners — hard compile error; residual not matched by a feature-path bucket",
+    match: (_record, text) =>
+      hasAny(text, ["stack-balance (#1058)", "reaches an instruction array from incompatible control-flow"]),
+  },
+  {
     id: "misc-spec-tail",
     issues: ["#1577", "#779"],
     label: "Miscellaneous low-volume spec-completeness tail",

--- a/tests/issue-5181-stack-balance-root-cause.test.ts
+++ b/tests/issue-5181-stack-balance-root-cause.test.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * #5181 — the #1058 stack-balance shared-body refusal must be a CLASSIFIED
+ * standalone root cause.
+ *
+ * The selfhost commit 8f161cbf15 (PR #5204) shifted 2,580 standalone rows onto
+ * this one compile-error signature. 24 of them (Error.prototype.stack, the
+ * harness deepEqual/testTypedArray helpers, instanceof) matched no feature-path
+ * bucket, so `--max-unclassified-root-causes 0` failed in every merge_group and
+ * wedged the queue. The bucket must claim exactly the residual and must NOT
+ * poach rows an earlier feature-path bucket already owns.
+ */
+describe("#5181 standalone root-cause map — stack-balance shared-body refusal", () => {
+  let tmpDir: string;
+  let report: ReturnType<typeof JSON.parse>;
+
+  const SIGNATURE =
+    'stack-balance (#1058): function "__closure_61" reaches an instruction array from incompatible ' +
+    "control-flow or function-local contexts. The repair pass refuses to mutate one shared body for " +
+    "all owners; emit distinct instruction arrays at the producer.";
+
+  const row = (file: string, extra: Record<string, unknown> = {}) => ({
+    file,
+    category: file.split("/")[1] ?? "",
+    status: "compile_error",
+    error: `L1:0 ${SIGNATURE}`,
+    // The report normalises digits out of `error_signature`, so "(#1058)"
+    // survives only in `error` — both spellings must match the bucket.
+    error_signature: `other:L#:## ${SIGNATURE.replace("#1058", "##")}`,
+    error_category: "other",
+    scope: "standard",
+    scope_official: true,
+    strict: "both",
+    ...extra,
+  });
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-5181-"));
+    const jsonl = join(tmpDir, "standalone.jsonl");
+    const out = join(tmpDir, "standalone-report.json");
+
+    const records = [
+      // The residual: no feature-path bucket claims these four families.
+      row("test/built-ins/Error/prototype/stack/setter-no-argument.js"),
+      row("test/harness/deepEqual-array.js"),
+      row("test/harness/testTypedArray.js"),
+      row("test/language/expressions/instanceof/S15.3.5.3_A3_T1.js"),
+      // Same signature, but a feature-path bucket owns it — the new bucket sits
+      // after those, so this must stay in `temporal-proposal`.
+      row("test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js"),
+      { file: "test/language/x.js", status: "pass", scope: "standard", scope_official: true, strict: "both" },
+    ];
+    writeFileSync(jsonl, records.map((r) => JSON.stringify(r)).join("\n"));
+
+    // The gate CI runs in every merge_group. Threshold 0 means a non-exit-0
+    // here IS the queue-blocking failure.
+    execFileSync(
+      "node",
+      [
+        "scripts/build-test262-report.mjs",
+        "--input",
+        jsonl,
+        "--output",
+        out,
+        "--target",
+        "standalone",
+        "--max-unclassified-root-causes",
+        "0",
+      ],
+      { cwd: process.cwd(), stdio: "pipe" },
+    );
+    report = JSON.parse(readFileSync(out, "utf-8"));
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("leaves no unclassified standalone failure for the merge_group gate", () => {
+    expect(report.root_cause_map.unclassified.count).toBe(0);
+  });
+
+  it("claims the residual under a bucket named for the real cause", () => {
+    const bucket = report.root_cause_map.buckets.find((b: { id: string }) => b.id === "stack-balance-shared-body");
+    expect(bucket, "no stack-balance-shared-body bucket in the root-cause map").toBeTruthy();
+    expect(bucket.count).toBe(4);
+    expect(bucket.issues).toContain("#1058");
+  });
+
+  it("does not poach rows an earlier feature-path bucket already owns", () => {
+    const temporal = report.root_cause_map.buckets.find((b: { id: string }) => b.id === "temporal-proposal");
+    expect(temporal?.count).toBe(1);
+  });
+});


### PR DESCRIPTION
Unblocks the merge queue. Every `merge_group` was failing the required **`merge shard reports`** job at its `Build merged standalone test262 report` step:

```
Standalone root-cause map has 24 unclassified failures; threshold is 0.
```

That gate (`scripts/build-test262-report.mjs --target standalone --max-unclassified-root-causes 0`) is a hard zero, so 24 unbucketed rows wedged every open code PR (#5211, #5214, #5217, #5218 were queued behind it).

## What the 24 are

All 24 are `compile_error` carrying **one** signature — the #1058 stack-balance shared-body refusal at `src/codegen/stack-balance.ts:2804`: two callers needing different stack repairs point at the *same* `Instr[]`, so the repair pass refuses rather than break one of them. It is fail-loud, not a silent miscompile.

The diagnostic entered `main` with **`8f161cbf15`** ("feat(selfhost): compile TypeScript 5 parser graph to Wasm", landed via PR #5204; parent `70e8e3c1ca`).

| population | count |
| --- | --- |
| standalone rows carrying the signature | **2,580** |
| already claimed by a feature-path bucket | 2,556 |
| matching no bucket → `unclassified` | **24** |

The 24: `built-ins/Error/prototype/stack/*` ×14, `harness/deepEqual-*` ×5, `harness/testTypedArray*` ×3, `language/expressions/instanceof/*` ×2.

## The change

One new **error-signature** bucket in `STANDALONE_ROOT_CAUSE_BUCKETS`, `id: stack-balance-shared-body`, matching the two spellings of the one signature (raw `error` keeps `(#1058)`; `error_signature` digit-normalises it to `(##)`). One signature replaces four path globs.

It is placed **with the residual catches near the end of the list**, following the convention of the `#2870` and `#2961` buckets: `find()`'s first match wins, so a top placement would pull all 2,556 already-classified rows out of their feature buckets.

**Classification only — no compiler change. The 24 tests still fail.** This restores the queue and names the failure honestly.

## Verification

Reproduced and re-run against the **real** merged standalone JSONL — the `test262-merged-report` artifact (9709198482) of the parked run [33232469498](https://github.com/loopdive/js2/actions/runs/33232469498), merge sha `7e0dbb303e`, 48,735 rows — with CI's exact invocation:

```
# before  → exit 1: "Standalone root-cause map has 24 unclassified failures; threshold is 0."
# after   → exit 0

BEFORE unclassified: 24    AFTER unclassified: 0
BEFORE classified: 17226   AFTER classified: 17250  (of 17250)
BUCKET DELTA stack-balance-shared-body 0 -> 24
no other bucket changed count — zero poaching
```

`tests/issue-5181-stack-balance-root-cause.test.ts` (3 tests) pins all three facts: unclassified is 0, the bucket claims the residual, and a same-signature row on a feature path stays in its feature bucket.

| gate | result |
| --- | --- |
| `check-loc-budget` / `check-func-budget` | pass (also with `LOC_GATE_BASE=origin/main`) |
| `check-coercion-sites`, `check:oracle-ratchet`, `check:dead-exports` | pass |
| `typecheck` (TS7), `prettier --check`, `biome lint` | pass |
| `check:issue-ids:staged` / `:against-main` | pass |
| `build-test262-report` + `website-issue-links` + new suite | 14/14 pass |

## Follow-ups filed

- [#5181](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5181-standalone-stack-balance-error-shift) — the real work: determine whether the error-mode shift **masks genuine regressions** (were any of the 2,580 passing before `8f161cbf15`? 20-sample A/B against `70e8e3c1ca`), and root-cause the shared-body refusal for the `Error.prototype.stack` family.
- [#5182](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5182-merge-group-gate-bypass) — **critical, separate finding.** The merge queue landed four PRs whose `merge_group` verdicts were red: #5203 (`4dfedbdc92`), #5204 (`523bd0428b`), #5187 (`84ad98d6d7`), #5199 (`7e0dbb303e`). #5199 merged at 04:27:46Z, eight minutes *after* the auto-park bot correctly held it. The "skip-twin from the PR stub" hypothesis is disproven on the merge sha — `test262-pr-stub.yml` has no `merge_group` trigger, and only four workflow runs exist on `7e0dbb303e`, of which `Test262 Sharded` is the sole producer of both contexts and it failed. The issue names what to check next (ruleset bypass actors for `js2-merge-queue-bot`, raw check-runs per sha) and the candidate fixes.

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_019aFp8EAQaf21QYQU3yEFw1)_