### PR TITLE
docs: record the #5209 park diagnosis; file #5183 — merge queue lands PRs from failed groups

### DIFF
--- a/plan/issues/5173-temporal-official-es2026-reclassification.md
+++ b/plan/issues/5173-temporal-official-es2026-reclassification.md
@@ -250,3 +250,55 @@ reclassification is due. Their runner scope is also independently
 corroborated by the baseline: the 511 non-Temporal proposal-scope rows are
 exactly `language/expressions/import.source` + `AbstractModuleSource`
 (source-phase-imports) and `language/import` (import-defer).
+
+### 7. Merge-queue park of PR #5209 (2026-08-29) — NOT caused by this change
+
+PR #5209 was auto-parked. Two required checks failed in the `merge_group`
+(run 33233874554): `merge shard reports` with **"Standalone root-cause map
+has 24 unclassified failures; threshold is 0"**, and `check for test262
+regressions` with **net −947 pass (35,377 → 34,430)**.
+
+The working hypothesis at park time was that the reclassification pushed
+~4.5k Temporal failures into the standard/official bucket and that 24 of
+them had no root-cause classifier. **That mechanism does not exist**, and
+the 24 are not Temporal:
+
+- **The root-cause map is scope-blind.** In `build-test262-report.mjs`,
+  `rootCauseRecords` collects *every* non-pass/non-skip standalone row —
+  there is no `scope` / `scope_official` filter anywhere in the ingestion
+  loop or the dedup. The `temporal-proposal` bucket matches on the **path**
+  `built-ins/temporal`, not on scope. So no record can enter or leave the
+  map because of this PR. Confirmed empirically: building the standalone
+  report from the current main baseline gives **0 unclassified**.
+- **The 24 are one codegen family, zero Temporal.** All 24 are
+  `compile_error` with
+  `stack-balance (#1058): function "…" reaches an instruction array from
+  incompatible control-flow or function-local contexts. The repair pass
+  refuses to mutate one shared body for all owners`:
+  15 × `built-ins/Error/prototype/stack/**` (`makeNativeError`),
+  7 × `harness/**` (`deepEqual-*`, `testTypedArray*`; `cacheComparison`,
+  `__closure_69`), 2 × `language/expressions/instanceof/S15.3.5.3_*`
+  (`__closure_61`). The family has **2,580** occurrences across the merged
+  run and **0** in main's promoted baseline; the other 2,556 are absorbed
+  by existing path buckets, leaving these 24 unowned.
+- **This PR changes no compiler code.** `git diff --name-only` against main
+  lists nine files: `.gitignore`, `README.md`, the high-water JSON, this
+  issue file, two `scripts/generate-*.ts`, the deleted `runner-bundle.mjs`,
+  and two files under `tests/`. Zero under `src/`, so the merged state's
+  emitted Wasm is identical to main's.
+- **Another PR reproduced it first.** PR #5199's `merge_group` run
+  (33232469498, base `bdb19824b0`, ~40 min earlier, unrelated work) failed
+  with the *identical* "24 unclassified failures" line and the *identical*
+  `Net: -947 pass (35377 → 34430)`. Two unrelated PRs cannot share a net to
+  the test — the −947 belongs to `main`. The regression job says as much
+  itself: it printed a shared bucket signature plus a **BASELINE DRIFT
+  WARNING** (baseline 6 test262-relevant commits behind main HEAD).
+
+**No map change was made, deliberately.** Adding a bucket for a live,
+unfixed codegen regression is functionally identical to raising the
+threshold by 24: it turns the gate green while the 2,580 CEs stand. That is
+the same accounting-laundering the strict `--max-unclassified-root-causes 0`
+policy (#2961) exists to prevent, and the same defect class as
+special-casing Temporal out of the official bucket — which is what this
+issue removes. The unclassified gate is doing its job; the fix belongs with
+the `#1058` stack-balance change on `main`, not here.

--- a/plan/issues/5183-merge-queue-lands-prs-from-failed-groups.md
+++ b/plan/issues/5183-merge-queue-lands-prs-from-failed-groups.md
@@ -1,0 +1,84 @@
+---
+id: 5183
+title: "Merge queue landed three PRs out of FAILED merge groups — required merge_group checks did not block the merge"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: critical
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: ci, merge-queue
+goal: correctness
+related: [2547, 5173, 5175]
+---
+
+# #5183 — Merge queue lands PRs out of failed groups
+
+## What happened (2026-08-29, three instances in one night)
+
+Three PRs merged to `main` although their merge-group runs FAILED required
+checks:
+
+| PR | group run | failed checks in the group | merged as |
+| --- | --- | --- | --- |
+| #5199 | 33232469498 | `merge shard reports` (24 unclassified root-causes), `check for test262 regressions` (net −947) | `7e0dbb303e` |
+| #5209 | 33233874554 (parked!) then carried in #5211's group | same two | `2fe59c4c10` |
+| #5211 | 33234653745 | same two — `merge shard reports` job 99055521433, regressions job 99055521440; the "promote merged report to main baseline" job was `skipped` | in main |
+
+#5209 additionally carried the auto-park `hold` label at merge time — the
+label neither prevented re-queueing nor merging.
+
+Verified from the runs themselves (not inferred): the failing step in each is
+the VERDICT step ("Standalone root-cause map has 24 unclassified failures;
+threshold is 0" / "Fail on regressions"), not setup. The regression they
+should have blocked — the 2,580-CE stack-balance (#1058) family, net −947
+passes — is live on `main` as of `ddab1b0743`, with the baseline stale
+(promote skipped in every failed group).
+
+## Why this is critical
+
+The merge_group re-validation is the ONLY gate that sees the merged state
+(PR-level test262 checks are designed green no-ops — see CLAUDE.md). If PRs
+merge while that gate is red, every guard downstream of it — auto-park
+(#2547), the catastrophic guard (#1668), the net gate — is decorative. This
+regression got in and STAYED in through three consecutive red groups.
+
+## Investigation entry points
+
+1. **Which check contexts are required, exactly, versus what the merge_group
+   workflow now publishes.** `gh api repos/loopdive/js2/rules/branches/main`
+   (docs/ci-policy.md §7 lists six required contexts). If a required context's
+   JOB is failing but the queue sees a DIFFERENT (green or skipped) check run
+   with the required name on the group head — e.g. after a job rename, a
+   matrix restructure, or the #3597 step-naming work — branch protection is
+   satisfied by the wrong run. The `test262-pr-stub.yml` pattern (a stub that
+   publishes a green context where the real workflow skips) is a candidate
+   mechanism for this failure mode reaching merge groups.
+2. **Timeline per group**: did the merge happen BEFORE the failing checks
+   reported (a race where the queue saw only green-so-far + required-satisfied
+   stubs)? Compare check-run timestamps against the merge commit times.
+3. **The `hold` label path**: auto-park labels and comments (#2547) are
+   advisory to the enqueuer (`auto-enqueue` skips `hold`), but nothing appears
+   to eject an already-queued PR when the label lands, and the label does not
+   gate the merge itself. #5209 was dequeued and still merged via #5211's
+   group — establish how it re-entered.
+
+## Acceptance criteria
+
+1. The mechanism is identified and stated with evidence from the three runs.
+2. A red required merge-group check blocks the merge again — demonstrated on
+   a deliberately-red test group or by construction with the ruleset.
+3. The three bypasses are documented in `docs/ci-policy.md` as an incident
+   note, with the fix.
+4. Decide and document whether #5199/#5209/#5211 need revert-or-forward-fix
+   action beyond the already-owned regression work (the −947 family has an
+   owner; this issue is about the GATE).
+
+## Notes
+
+Found during the #5173/#5209 park post-mortem (see that issue's §7 for the
+full evidence chain). The regression itself is owned separately (dev lane on
+the stack-balance family + #5180); do not fold that fix in here.


### PR DESCRIPTION
Docs-only, two commits: the §7 diagnosis appended to [#5173](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5173-temporal-official-es2026-reclassification)'s issue file, and a new critical issue [#5183](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5183-merge-queue-lands-prs-from-failed-groups).

## §7 — why PR #5209 was parked (and why it wasn't this PR's fault)

The 24 unclassified root-cause rows contain zero Temporal tests: they are one codegen family — `stack-balance (#1058)` refusals, 2,580 occurrences in the merged run, 0 in the promoted baseline — and the root-cause map is scope-blind, so the ES2026 reclassification cannot reach that gate. Two unrelated PRs' groups printed the identical failure and the identical **net −947 pass**, which two unrelated diffs cannot share: the regression belongs to `main` (window `fc6fd3b5f3`..`bdb19824b0`; candidates `77a08f7be9` / `12097f4c70` / the #5146/#5147 waves). §7 also records the deliberate refusal to classify the family into a bucket — doing so would be threshold-raising by another name, the accounting-laundering the `--max-unclassified-root-causes 0` policy (#2961) exists to prevent. The "absorbed into the baseline" theory is corrected with measurements: the promote step was **skipped** in every failed group; the baseline is stale, and the −947 is still live.

## [#5183](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5183-merge-queue-lands-prs-from-failed-groups) — the graver finding, filed critical

**Three PRs (#5199, #5209, #5211) merged out of merge groups whose required verdict checks FAILED**, one of them carrying the auto-park `hold` label at merge time. The merge_group re-validation is the only gate that sees the merged state — PR-level test262 checks are designed green no-ops — so if PRs land while it is red, auto-park (#2547), the catastrophic guard (#1668) and the net gate are all decorative. The issue carries the three runs' evidence and investigation entry points (required-context vs published-check mismatch, stub-context contamination reaching merge groups, a merge-vs-report race, and the `hold` label's non-gating).

The −947 regression itself is separately owned (the stack-balance family + #5180 lane); #5183 is about the **gate**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_