### PR TITLE
test(#5164): retire pre-adoption comma-operator pins rotted by the IR claim ✓

### DIFF
--- a/plan/issues/5172-rotted-untouched-test-rows.md
+++ b/plan/issues/5172-rotted-untouched-test-rows.md
@@ -1,0 +1,137 @@
+---
+id: 5172
+title: "Four rotted test rows fail on current main but never run in CI (fix-on-touch ratchet blind spot): #3529 dataflow unary `!` ×2, #3529 externref console identity, #3522 standalone console parity"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ir, tests
+goal: ir-full-coverage
+related: [3529, 3522, 5092]
+origin: "2026-08-29 PR #5102 drive-to-green — clean merge-base attribution during the issue-4502 fix-on-touch repair"
+---
+
+# #5172 — four rotted test rows, red on main, never run in CI
+
+## Problem
+
+During PR #5102's drive-to-green (commit `7fb7dc2b` on
+`codex/5092-ir-conditional-expression`), a clean attribution pass found four
+test rows that fail on a tree byte-identical to origin/main's source (verified:
+the branch's merge-base `33099f2` has an EMPTY `git diff … origin/main -- src/
+scripts/`), reproduced with CI's own vitest flags
+(`--pool=forks --singleFork --no-file-parallelism`):
+
+1. `#3529` dataflow unary `!` — two rows;
+2. `#3529` externref console identity — one row;
+3. `#3522` standalone console parity — one row.
+
+Counts: 4 failed / 47 passed across their files, identical at the clean
+merge-base and at the PR branch head.
+
+## Why CI is green anyway
+
+`ci.yml`'s changed-root gate runs ONLY the `tests/*.test.ts` files a PR
+touches ("Untouched root test files do NOT run at PR time … touching a rotted
+one means fixing it — the fix-on-touch ratchet"). Nothing on main touches
+these files, so the rot is invisible until someone edits them — at which point
+the editor inherits four unrelated failures (this nearly cost PR #5102 a
+second CI cycle).
+
+## What to do
+
+1. Reproduce each row on current main with CI's vitest flags; classify: stale
+   expectation (product moved, pin not updated) vs real regression (find the
+   introducing commit — `git log -S` on the asserted strings).
+2. Fix product or pin per classification; each edited file then enters the
+   fix-on-touch ratchet, so the WHOLE file must be green.
+3. Deliberately left out of PR #5102 to avoid widening it — this issue is the
+   tracked follow-up.
+
+## Acceptance criteria
+
+- The four rows green on main under CI's flags, with the rest of their files
+  green (fix-on-touch).
+- Each fix's classification stated (stale pin vs regression + introducing
+  commit).
+- Ratchet gates chained bare before commit.
+
+---
+
+## 2026-08-29 — inventory addition: `tests/comma-operator.test.ts` (fixed here)
+
+`tests/comma-operator.test.ts` failed **5/5** on `origin/main` at `ddab1b0743`.
+It is a fifth instance of the class above and is repaired in this PR; the
+systemic CI-selection gap stays this issue's scope.
+
+**All five rows are OBSOLETE PINs of the compiler's IMPORT SURFACE, not of
+comma-operator semantics.** Every row compiled successfully and returned the
+correct value on both pipelines the whole time — the file's hand-rolled
+WebAssembly import object (only `env.console_log_{number,string,bool}`) simply
+stopped being a complete import surface. **Zero real regressions.**
+
+Classification, with the runtime value measured on each pipeline against a
+hand-written JavaScript reference run on Node:
+
+| # | Row | Node | IR | legacy | Owner (`trackIrOutcomes`) | Class |
+| - | --- | ---- | -- | ------ | ------------------------- | ----- |
+| 1 | returns the right-hand value `(1, 2)` | 2 | 2 | 2 | IR `emitted` | OBSOLETE PIN (harness) |
+| 2 | evaluates left side for side effects `x = (x = 5, x + 10)` | 15 | 15 | 15 | legacy, `body-shape-rejected` | OBSOLETE PIN (harness) |
+| 3 | chains multiple commas `(1, 2, 3)` | 3 | 3 | 3 | IR `emitted` | OBSOLETE PIN (harness) |
+| 4 | for-loop update `i = i + 1, a = a + 1` | 15 | 15 | 15 | IR `emitted` | OBSOLETE PIN (harness) |
+| 5 | different types `(x = 10, x + 1)` | 11 | 11 | 11 | legacy, `body-shape-rejected` | OBSOLETE PIN (harness) |
+
+No post-claim demotions on any row. Rows 2 and 5 staying legacy-owned is the
+**#4459 discard-purity line** that #5164 inherited — a comma whose LEFT operand
+mutates is rejected pre-claim — and row 4 being IR-owned is #5164 S2, where each
+side of a for-incrementor comma re-enters the update-clause rules and the
+mutating `i++` idiom is admissible. The rewrite pins that split explicitly, so
+the boundary can no longer move silently.
+
+### Attribution — NOT #5164/#5211
+
+The natural suspect was PR #5211 (#5164, the comma IR adoption, merged
+`efb50daeca` 2026-08-29 02:30Z), since it is the comma operator's most recent
+change. **It is not the cause.** Two independent proofs:
+
+- The failure reproduces identically with `experimentalIR: false`, and #5211's
+  entire diff is `src/ir/*` + its own test + plan docs — it touches nothing on
+  the legacy lowering path or the import surface.
+- The failing import, `string_constants`, was introduced **2026-08-08** by
+  `6786454b4f` (`perf(#4157): hoist constant number boxing to module globals`)
+  / #4219 — three weeks earlier. Constant boxing moved to module globals, and
+  from then on every module imports the string-constant pool that carries its
+  export names, even a module with no user string literals (`stringPool` for
+  `export function test()` is `["test", ""]`).
+
+So the row rotted on 2026-08-08 and sat red for three weeks. This is worth
+recording as a pattern: **the blind spot makes the most recent related change
+look guilty**, because the rotted row surfaces only when someone touches the
+file for an unrelated reason. Attribution must be measured (`git log -S` on the
+failing symbol), never inferred from topical adjacency.
+
+### The class is much larger than four rows — measured
+
+21 test files hand-roll the same import object (`console_log_number: () => {}`
+with no `string_constants` and no `buildImports`). Running all 21 on
+`ddab1b0743`:
+
+- **18 of 21 files fail — 120 failed / 55 passed (175 tests).**
+- **117 of the 120 failures are this identical `string_constants` rot**
+  (`Import #0 module="string_constants"` ×114, `Import #1` ×3).
+- The remaining 3 are NOT the harness and need their own triage:
+  `tests/typed-array-basic.test.ts` (Float32Array / Uint16Array — `Compile
+  failed`), and `tests/issue-328.test.ts` (array holes/elision — `Compile
+  failed` plus one genuine wrong answer, `expected 10 to be 15`).
+
+The one-line repair for the 117 is mechanical: build the import object with
+`buildImports(result.imports, undefined, result.stringPool)` from
+`src/runtime.ts` instead of hand-rolling it. The two suspected real defects
+behind the remaining 3 are the reason the sweep should not be done blind as a
+single mass edit — each file entering the fix-on-touch ratchet must be green,
+and those two carry findings, not pins.

--- a/tests/comma-operator.test.ts
+++ b/tests/comma-operator.test.ts
@@ -1,51 +1,142 @@
-import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Comma operator — runtime semantics, pinned against BOTH pipelines.
+//
+// This file predates #5164 (the IR adoption of the comma operator). It used to
+// hand-roll its own WebAssembly import object with nothing but the three
+// `console_log_*` host functions. That stopped being a complete import surface
+// on 2026-08-08, when constant boxing moved to module globals (#4157/#4219) and
+// every module — even one with no user string literals — began importing the
+// `string_constants` pool that carries its export names. From that day all five
+// rows failed identically at INSTANTIATION with
+//
+//     Import #0 module="string_constants": module is not an object or function
+//
+// while the compiled answers were correct the whole time. No CI gate runs this
+// file (it is not in `tests/guard-suite.json` and does not match the `issue-*`
+// changed-root selector), so it sat red in silence — the rotted-untouched-row
+// class tracked by #5172.
+//
+// The fix is to build the import object the way every current test does, via
+// `buildImports` from the runtime. Since the shapes below are now partly
+// IR-owned, each row additionally asserts THREE-WAY agreement — legacy
+// (`experimentalIR: false`), IR, and the JavaScript reference value — plus which
+// pipeline actually owns it. Ownership is read from `trackIrOutcomes`
+// (`kind: "emitted"`), never from a bare selector claim: a claim that never
+// reaches a body is a vacuous pass.
+//
+// The ownership split is the #4459 discard-purity line that #5164 inherited: a
+// comma whose operands are pure is IR-emitted, and one whose LEFT operand
+// MUTATES (`x = (x = 5, x + 10)`) stays legacy-owned, rejected pre-claim as
+// `body-shape-rejected`.
 
-async function compileAndRun(source: string) {
-  const result = await compile(source);
+import { describe, expect, it } from "vitest";
+
+import { compile, type IrObservedOutcome } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+interface RunResult {
+  readonly exports: Record<string, (...args: unknown[]) => unknown>;
+  readonly emitted: ReadonlySet<string>;
+  readonly outcomes: readonly IrObservedOutcome[];
+  readonly postClaim: readonly { kind: string; func: string; message: string }[];
+}
+
+async function compileAndRun(source: string, experimentalIR: boolean): Promise<RunResult> {
+  const result = await compile(source, {
+    fileName: "test.ts",
+    experimentalIR,
+    trackIrOutcomes: true,
+  });
   expect(
     result.success,
-    `Compile failed:\n${result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+    `Compile failed (${experimentalIR ? "IR" : "legacy"}):\n${result.errors
+      .map((e) => `L${e.line}: ${e.message}`)
+      .join("\n")}`,
   ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
+
+  const built = buildImports(result.imports as never, undefined, result.stringPool) as Record<string, never> & {
+    env: Record<string, unknown>;
+    setExports?: (exports: unknown) => void;
   };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
+  built.env.console_log_number = () => {};
+  built.env.console_log_string = () => {};
+  built.env.console_log_bool = () => {};
+
+  const { instance } = await WebAssembly.instantiate(result.binary, built as never);
+  built.setExports?.(instance.exports);
+
+  return {
+    exports: instance.exports as Record<string, (...args: unknown[]) => unknown>,
+    emitted: new Set(
+      (result.irOutcomes ?? []).filter((outcome) => outcome.kind === "emitted").map((outcome) => outcome.displayName),
+    ),
+    outcomes: result.irOutcomes ?? [],
+    postClaim: result.irPostClaimErrors ?? [],
+  };
+}
+
+/** The terminal outcome code the selector recorded for `fn`. */
+function outcomeCode(outcomes: readonly IrObservedOutcome[], fn: string): string | undefined {
+  const outcome = outcomes.find((entry) => entry.displayName === fn);
+  return (outcome as { code?: string } | undefined)?.code;
+}
+
+/**
+ * Assert legacy ≡ IR ≡ the JavaScript reference for `test()`, and pin which
+ * pipeline owns the body. `owner: "ir"` requires a genuine emission;
+ * `owner: "legacy"` requires a PRE-claim rejection, not a claim-then-demote.
+ */
+async function expectParity(source: string, expected: number, owner: "ir" | "legacy"): Promise<void> {
+  const legacy = await compileAndRun(source, false);
+  const ir = await compileAndRun(source, true);
+
+  expect(legacy.exports.test!(), "legacy value matches the JavaScript reference").toBe(expected);
+  expect(ir.exports.test!(), "IR value matches legacy + JavaScript").toBe(expected);
+
+  expect(ir.postClaim, "no post-claim demotions").toStrictEqual([]);
+  if (owner === "ir") {
+    expect(ir.emitted.has("test"), "genuinely IR-emitted (a claim alone is not evidence)").toBe(true);
+  } else {
+    expect(ir.emitted.has("test"), "stays legacy-owned").toBe(false);
+    expect(outcomeCode(ir.outcomes, "test"), "rejected pre-claim on body shape").toBe("body-shape-rejected");
+  }
 }
 
 describe("comma operator", () => {
   it("returns the right-hand value", async () => {
-    const e = await compileAndRun(`
-      export function test(): number { return (1, 2); }
-    `);
-    expect(e.test()).toBe(2);
+    // JavaScript reference: (1, 2) === 2.
+    await expectParity(`export function test(): number { return (1, 2); }`, 2, "ir");
   });
 
   it("evaluates left side for side effects", async () => {
-    const e = await compileAndRun(`
+    // JavaScript reference: x = ((x = 5), x + 10) ⇒ 15. The left operand
+    // MUTATES, so #4459's purity line keeps this legacy-owned.
+    await expectParity(
+      `
       export function test(): number {
         let x: number = 0;
         x = (x = 5, x + 10);
         return x;
       }
-    `);
-    expect(e.test()).toBe(15);
+    `,
+      15,
+      "legacy",
+    );
   });
 
   it("chains multiple comma operators", async () => {
-    const e = await compileAndRun(`
-      export function test(): number { return (1, 2, 3); }
-    `);
-    expect(e.test()).toBe(3);
+    // JavaScript reference: (1, 2, 3) === 3.
+    await expectParity(`export function test(): number { return (1, 2, 3); }`, 3, "ir");
   });
 
   it("works inside a for-loop update expression", async () => {
-    const e = await compileAndRun(`
+    // JavaScript reference: a increments 5 times (0..4), b increments 5 times
+    // by 2 ⇒ 5 + 10 = 15. The mutating `a = a + 1` IS admissible here: #5164 S2
+    // re-enters the update-clause rules for each side of a for-incrementor
+    // comma, where that idiom is exactly what the clause is for.
+    await expectParity(
+      `
       export function test(): number {
         let a: number = 0;
         let b: number = 0;
@@ -54,18 +145,24 @@ describe("comma operator", () => {
         }
         return a + b;
       }
-    `);
-    // a increments 5 times (0..4), b increments 5 times by 2
-    expect(e.test()).toBe(15);
+    `,
+      15,
+      "ir",
+    );
   });
 
   it("works with different types on left and right", async () => {
-    const e = await compileAndRun(`
+    // JavaScript reference: ((x = 10), x + 1) ⇒ 11. Mutating left operand ⇒
+    // legacy-owned, same boundary as the side-effects row above.
+    await expectParity(
+      `
       export function test(): number {
         let x: number = 42;
         return (x = 10, x + 1);
       }
-    `);
-    expect(e.test()).toBe(11);
+    `,
+      11,
+      "legacy",
+    );
   });
 });


### PR DESCRIPTION
`tests/comma-operator.test.ts` failed **5/5** on `origin/main` at `ddab1b0743`. No CI gate runs the file — it is not in `tests/guard-suite.json` and does not match the `issue-*` changed-root selector — so it sat red in silence. That is the blind spot tracked by [#5172](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5172-rotted-untouched-test-rows).

## Verdict: 5/5 OBSOLETE PIN, zero real regressions

All five failures are **one** cause, and it is not comma semantics: the file hand-rolled its WebAssembly import object with nothing but `env.console_log_{number,string,bool}`, which stopped being a complete import surface. Every row **compiled successfully and returned the correct value on both pipelines the whole time** — the failure was at instantiation:

```
WebAssembly.instantiate(): Import #0 module="string_constants": module is not an object or function
```

### Per-row classification, with runtime evidence

Each value measured by compiling and executing the shape on both pipelines and comparing against a hand-written JavaScript reference run on Node. Ownership read from `trackIrOutcomes` (`kind: "emitted"`), never from a bare selector claim.

| # | Row | Node | IR | legacy | Owner | Class |
| - | --- | ---- | -- | ------ | ----- | ----- |
| 1 | returns the right-hand value `(1, 2)` | 2 | 2 | 2 | IR `emitted` | OBSOLETE PIN (harness) |
| 2 | evaluates left side for side effects `x = (x = 5, x + 10)` | 15 | 15 | 15 | legacy, `body-shape-rejected` | OBSOLETE PIN (harness) |
| 3 | chains multiple commas `(1, 2, 3)` | 3 | 3 | 3 | IR `emitted` | OBSOLETE PIN (harness) |
| 4 | for-loop update `i = i + 1, a = a + 1` | 15 | 15 | 15 | IR `emitted` | OBSOLETE PIN (harness) |
| 5 | different types `(x = 10, x + 1)` | 11 | 11 | 11 | legacy, `body-shape-rejected` | OBSOLETE PIN (harness) |

No post-claim demotions on any row. **No codegen change was needed and none was made.**

## Attribution: NOT [#5164](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5164-ir-comma-and-in-operators) / PR #5211

The natural suspect was the comma operator's most recent change — PR #5211, which merged the IR adoption of the comma operator and a bounded dynamic-lane `in` hours earlier. It is not the cause. Two independent proofs:

- The failure reproduces identically with `experimentalIR: false`, and #5211's entire diff is `src/ir/*` plus its own test and plan docs — it touches nothing on the legacy lowering path or the import surface.
- The failing import arrived **2026-08-08** via `6786454b4f` (`perf(#4157): hoist constant number boxing to module globals`). From then on every module imports the string-constant pool carrying its export names, even one with no user string literals — `stringPool` for `export function test()` is `["test", ""]`.

So the row rotted three weeks *before* the comma adoption landed. Worth recording as a pattern: **the blind spot makes the most recent related change look guilty**, because a rotted row only surfaces when someone touches the file for an unrelated reason. Attribution has to be measured (`git log -S` on the failing symbol), not inferred from topical adjacency.

## What changed

`tests/comma-operator.test.ts` now builds imports via `buildImports(result.imports, undefined, result.stringPool)` and, mirroring the treatment in `tests/issue-5164-comma-and-in.test.ts`, asserts **three-way parity** (legacy / IR / JavaScript reference) plus which pipeline owns each body.

That makes the adopted boundary explicit rather than incidental:

- A comma whose **left operand mutates** — rows 2 and 5 — stays legacy-owned, rejected pre-claim as `body-shape-rejected`. This is the #4459 discard-purity line that #5164 inherited, and it is preserved exactly as the task requires.
- The pure forms (rows 1, 3) and the **for-incrementor** comma (row 4) are genuinely IR-emitted. Row 4 is #5164 S2: each side of a for-incrementor comma re-enters the update-clause rules, where the mutating `i++` idiom is admissible.

The boundary can no longer move silently in either direction.

## The class is much larger than four rows — measured

21 test files hand-roll the same import object (`console_log_number: () => {}`, no `string_constants`, no `buildImports`). Running all 21 on `ddab1b0743`:

- **18 of 21 files fail — 120 failed / 55 passed (175 tests).**
- **117 of the 120 failures are this identical rot** (`Import #0 module="string_constants"` ×114, `Import #1` ×3).
- The remaining 3 are **not** the harness and need their own triage: `tests/typed-array-basic.test.ts` (Float32Array / Uint16Array, `Compile failed`) and `tests/issue-328.test.ts` (array holes/elision — `Compile failed` plus one genuine wrong answer, `expected 10 to be 15`).

The repair for the 117 is mechanical, but the sweep should not be done blind as one mass edit: each file entering the fix-on-touch ratchet must be green, and those last two carry findings rather than pins. Recorded in the #5172 inventory; the systemic CI-selection gap remains that issue's scope.

**Note on the #5172 file:** it did not exist on `main`. It lived only on the pushed branch `claude/ir-migration-plan-nqb6pz` with **no open PR**, so this PR carries it onto `main` along with the appended note, rescuing it from stranding.

## Validation

| Suite | Result |
| ----- | ------ |
| `tests/comma-operator.test.ts` | **5/5 green** |
| `tests/issue-5164-comma-and-in.test.ts` | **17/17 green** |
| `tests/issue-4459.test.ts` | **37/37 green** |

Ratchet gates run bare (no pipes), each exit status captured directly:

| Gate | Exit |
| ---- | ---- |
| `check-loc-budget.mjs` | 0 |
| `check-func-budget.mjs` | 0 |
| `check-coercion-sites.mjs` | 0 |
| `check:oracle-ratchet` | 0 |
| `check:dead-exports` | 0 (23 known, 0 new) |
| `LOC_GATE_BASE=origin/main` LOC simulation | 0 |
| `LOC_GATE_BASE=origin/main` func simulation | 0 |
| `typecheck` | 0 |
| `biome lint` (edited file) | 0 |

Pre-commit and pre-push hooks ran in full; `--no-verify` was never used.

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_019aFp8EAQaf21QYQU3yEFw1)_