### PR TITLE
fix(#5186): stop refusing a shared stack-polymorphic body in stack-balance

### DIFF
--- a/plan/issues/5186-stack-balance-hard-error-family.md
+++ b/plan/issues/5186-stack-balance-hard-error-family.md
@@ -1,0 +1,189 @@
+---
+id: 5186
+title: "stack-balance (#1058) hard error refuses a shared body the repair pass never touches — 2,580 standalone CEs, net −947"
+status: done
+created: 2026-08-29
+updated: 2026-08-29
+completed: 2026-08-29
+priority: critical
+horizon: m
+task_type: bugfix
+area: codegen
+goal: correctness
+sprint: current
+assignee: ttraenkler/opus-dev-5186
+feasibility: hard
+reasoning_effort: max
+related: [5180, 5183, 5184, 1058]
+loc-budget-allow:
+  # 2026-08-29 — +51 lines in the god-file, of which ~40 are the doc comment on
+  # `isContextInvariantBody` that carries the SOUNDNESS PROOF for relaxing a
+  # hard compile error (the `fixBranch` UNREACHABLE early-out plus the fact
+  # that `fixBranchType` has exactly one call site, inside `fixBranch`). The
+  # executable change is ~12 lines. Splitting the predicate into a new module
+  # would separate the proof from the guard it justifies, which is the failure
+  # mode that produced this regression in the first place.
+  - src/codegen/stack-balance.ts
+---
+
+# stack-balance (#1058) hard error refuses a shared body the repair pass never touches
+
+## Impact
+
+`main` carried a net **−947** test262 regression (35,377 → 34,430) from
+**2,580 standalone `compile_error`s**, all one family. Every merge group failed
+its regression gate against the pre-regression baseline, so the whole queue was
+blocked and PRs #5188 / #5212 / #5216 were parked behind it.
+
+Victims: 15× `built-ins/Error/prototype/stack/**` (`makeNativeError`), 7×
+harness `deepEqual-*` / `testTypedArray*` closures, 2× `instanceof
+S15.3.5.3_*`, plus 2,556 absorbed into existing path buckets.
+
+## Attribution
+
+Introduced by `8f161cbf15` ("feat(selfhost): compile TypeScript 5 parser graph
+to Wasm", PR #5204), established by dev-5180's per-commit walk. That commit
+converted the stack-balance pass from a **tree** walk to a **DAG** walk —
+`eliminateDeadCode`, `fixBody` and `assertLocalRefsInRange` all gained
+visited-sets (`walkInstructions` → `walkInstructionDag`) so the selfhost
+parser's heavily-shared instruction graph terminates in linear time instead of
+re-walking every shared subtree once per incoming edge.
+
+Visiting each physical array **once** is what makes the pass affordable on that
+graph, but it also means the single repair applied to a shared array has to be
+valid for *all* of its owners. `contextAmbiguousFunctions` was added in the same
+commit as the correctness guard for that: it fails the compile
+(`recordHardStackBalanceError`, `src/codegen/stack-balance.ts:~2803`) when one
+array is reached from two different functions, or from two different block
+contexts inside one function.
+
+## Root cause
+
+The **block-context** half of that guard is too coarse. It compares
+`branchContextKey(expected, blockType)` for every incoming edge, but the repair
+it is protecting is not always context-sensitive.
+
+Measured on every victim (`JS2WASM_DEBUG_SHARE` instrumentation of the
+preflight, 2026-08-29), the conflict is **one shape, 100 % of the time** — never
+the cross-function arm:
+
+```
+[share] context: func="makeNativeError" priorVia=if.then@makeNativeError[6] nowVia=if.then@makeNativeError[12]
+        prior=0:{"kind":"empty"} now=1:{"kind":"val","type":{"kind":"externref"}}
+        len=4 ops=global.get,extern.convert_any,call,throw
+```
+
+That body is a **terminal throw** — stack-polymorphic. It validates as a void
+`if` arm and as an externref-valued `if` arm alike, which is exactly why the
+producer shares it. The producer is `src/codegen/expressions/calls.ts:4921-4934`
+(`wantTaCtorArm`, the `$__ta_ctor` [[Call]] arm): one
+`buildThrowJsErrorInstrs(...)` array is used both as
+
+- `then:` of an `{kind:"val", type:externref}` `if` (calls.ts:4932 — its own
+  comment already says *"terminal throw — stack-polymorphic, validates as
+  externref"*), and
+- `onMatch` inside `buildInt8ArrayCarrierMatch`, which nests it as `then:` of an
+  `{kind:"empty"}` `if` (`src/codegen/dataview-native.ts:3570`).
+
+Two contexts, one array — refused, and the refusal takes down the **whole
+function**, hence the blast radius.
+
+The refusal is provably unnecessary here. The only context-dependent repairs in
+the pass are `fixBranch` (value count) and `fixBranchType` (value type), and
+`fixBranchType` is reachable **only** from inside `fixBranch`
+(`stack-balance.ts:1109`, the single call site). `fixBranch` opens with
+
+```ts
+const actual = sequenceDelta(body, types, sigs);
+if (actual === UNREACHABLE) return 0; // unreachable branch -- validator accepts anything
+```
+
+and `sequenceDelta` returns `UNREACHABLE` as soon as any element's `instrDelta`
+does — which is exactly the `isTerminator` op set (`return`, `return_call`,
+`return_call_ref`, `br`, `throw`, `rethrow`, `unreachable`) and nothing else
+(structured blocks report their `blockType` delta, never `UNREACHABLE`). So
+"this array contains a top-level terminator" is *identical* to "`fixBranch`
+returns 0 without mutating it", for **every** `expected` / `blockType`.
+
+## Decision: (b) — fix the repair pass, not the producers
+
+Both routes were on the table.
+
+**(a) Producers emit distinct arrays** (the error message's own advice) — a
+one-line `[...throwInstrs]` at `calls.ts:4924` clears this family. Rejected as
+*the* fix:
+
+- It treats a **legitimate** producer pattern as a defect. Sharing one terminal
+  throw sequence across arms of different block types is sound Wasm and the
+  author had explicitly reasoned it through in the comment at calls.ts:4932.
+- It is site-by-site. There are ~40 `buildThrowJsErrorInstrs` call sites and
+  more terminal-sequence builders besides; any of them can reintroduce the
+  same failure, and the next occurrence is another queue-blocking
+  multi-thousand-CE event.
+- It duplicates instructions in the emitted module for no validator benefit.
+
+**(b) Teach the preflight what it is actually protecting** — chosen. A body that
+is stack-polymorphic is *repair-invariant with respect to block context*, so
+differing incoming contexts are not a disagreement and must not fail the
+compile. This is provable from the two functions above rather than heuristic,
+it is general (covers every producer, present and future), and it is ~15 lines.
+
+Explicitly **not** done: demoting the hard error to a warning. The invariant
+`8f161cbf15` needs is that a once-visited shared array is repaired identically
+for all owners; that invariant is preserved exactly, and the two arms that
+really can disagree still fail closed —
+
+- a shared body whose repair **does** depend on the context (no terminator:
+  `fixBranch` would append a `drop` for the empty arm and leave a value for the
+  valued arm) is still refused;
+- the **cross-function** `firstOwner` refusal is untouched. Stack-polymorphism
+  says nothing there: `fixLocalSetCoercion` / `fixCallArgTypesInBody` /
+  `fixStructNewFieldCoercion` resolve local indices against the owning
+  function, so a body shared between two functions is unsafe regardless of how
+  it ends.
+
+## Fix
+
+`src/codegen/stack-balance.ts` — in `contextAmbiguousFunctions`, skip the
+context-key comparison for bodies where `isContextInvariantBody` holds (a
+top-level terminator is present). Memoized in a `WeakMap` so a heavily-shared
+DAG stays linear in instructions rather than in edges, preserving the
+performance property `8f161cbf15` added the DAG walk for.
+
+## Test Results
+
+`tests/issue-5186-stack-balance-shared-throw-body.test.ts` — 4 cases, all
+verified to fail/pass in the right direction by swapping the base file back in:
+
+| case | base | fixed |
+| --- | --- | --- |
+| shared terminal throw across empty + valued `if` arms → no error, body unmutated | FAIL | PASS |
+| construct-owner + plain-call-owner TS source, standalone → clean compile + `WebAssembly.compile` | FAIL | PASS |
+| context-sensitive shared body still refused (guard) | PASS | PASS |
+| terminal throw shared across two functions still refused (guard) | PASS | PASS |
+
+Family victims, `runTest262File(..., "standalone")`, before → after:
+
+| file | base | fixed |
+| --- | --- | --- |
+| `harness/deepEqual-circular.js` | compile_error | **pass** |
+| `harness/deepEqual-array.js` | compile_error | **pass** |
+| `harness/deepEqual-deep.js` | compile_error | **pass** |
+| `harness/deepEqual-object.js` | compile_error | **pass** |
+| `harness/deepEqual-mapset.js` | compile_error | **pass** |
+| `built-ins/Error/prototype/stack/getter-error-instance.js` | compile_error | fail (runtime) |
+| `built-ins/Error/prototype/stack/getter-data-property-shadows.js` | compile_error | fail (runtime) |
+| `built-ins/Error/prototype/stack/getter-error-as-prototype.js` | compile_error | fail (runtime) |
+| `built-ins/Error/prototype/stack/getter-error-prototype.js` | compile_error | fail (runtime) |
+| `built-ins/Error/prototype/stack/getter-subclass.js` | compile_error | fail (runtime) |
+| `built-ins/Error/prototype/stack/instance-no-own-stack.js` | compile_error | fail (runtime) |
+
+The `Error/prototype/stack` family clears the hard error but still fails at
+runtime — that matches its **pre-regression** state (dev-5180 measured
+`getter-error-instance.js` failing at runtime at `8f161cbf15^`), so it is not a
+pass this fix owns. The recovered passes live in the other victims; the merge
+group measures the aggregate.
+
+Selfhost lane, unchanged: `tests/issue-1058-*.test.ts` — **45 files, 151 tests,
+all passing**, including `issue-1058-stack-balance-dag.test.ts`'s own
+"refuses one shared leaf with incompatible valued and empty block contexts".

--- a/src/codegen/stack-balance.ts
+++ b/src/codegen/stack-balance.ts
@@ -2613,11 +2613,51 @@ interface StackBalanceFeatures {
   structured: boolean;
 }
 
+/**
+ * (#5186) Whether the block-context part of the repair is provably a NO-OP for
+ * this body, so two incompatible incoming contexts cannot disagree about it.
+ *
+ * The only context-dependent repairs in this pass are `fixBranch` (value count)
+ * and `fixBranchType` (value type), and `fixBranchType` is reachable ONLY from
+ * inside `fixBranch`. `fixBranch` opens with
+ *
+ *     const actual = sequenceDelta(body, types, sigs);
+ *     if (actual === UNREACHABLE) return 0;   // validator accepts anything
+ *
+ * and `sequenceDelta` returns UNREACHABLE as soon as any element's `instrDelta`
+ * does — which happens for exactly the `isTerminator` op set and for nothing
+ * else (structured blocks report their `blockType` delta, never UNREACHABLE).
+ * So "this array contains a top-level terminator" is *identical* to
+ * "`fixBranch` returns 0 without mutating it", for every `expected`/`blockType`.
+ *
+ * Such a body is stack-polymorphic: `[global.get, extern.convert_any, call,
+ * throw]` validates as a void `if` arm and as an externref-typed `if` arm
+ * alike, which is why producers legitimately share one terminal throw sequence
+ * across arms of different block types (`expressions/calls.ts` hands one
+ * `buildThrowJsErrorInstrs` array to both a `{kind:"val"}` arm and the
+ * `{kind:"empty"}` arm inside `buildInt8ArrayCarrierMatch`).
+ *
+ * This says nothing about the *function-local* repairs (local/call-arg/
+ * struct.new coercion), which resolve local indices against the owning
+ * function — the separate cross-function `firstOwner` refusal still covers
+ * those, and is deliberately left untouched.
+ */
+function isContextInvariantBody(body: Instr[]): boolean {
+  for (const instr of body) {
+    if (isTerminator(instr.op)) return true;
+  }
+  return false;
+}
+
 function contextAmbiguousFunctions(
   mod: WasmModule,
   tags: Array<{ typeIdx: number }>,
 ): { blocked: Set<WasmFunction>; features: Map<WasmFunction, StackBalanceFeatures> } {
   const firstOwner = new WeakMap<Instr[], WasmFunction>();
+  // (#5186) Memoized `isContextInvariantBody`. A shared array is reached once
+  // per incoming edge, so answering from the map keeps the walk linear in
+  // instructions rather than in edges.
+  const contextInvariant = new WeakMap<Instr[], boolean>();
   const blocked = new Set<WasmFunction>();
   const invalidLocalRefFunctions = new Set<WasmFunction>();
   const features = new Map<WasmFunction, StackBalanceFeatures>();
@@ -2655,9 +2695,20 @@ function contextAmbiguousFunctions(
         firstOwner.set(body, func);
       }
 
-      const prior = contexts.get(body);
-      if (prior !== undefined && prior !== context) blocked.add(func);
-      else if (prior === undefined) contexts.set(body, context);
+      // (#5186) Only bodies whose repair actually depends on the incoming
+      // block context can be in conflict about it. A stack-polymorphic body is
+      // left untouched by `fixBranch` under every context, so differing
+      // contexts there are not a disagreement and must not fail the compile.
+      let invariant = contextInvariant.get(body);
+      if (invariant === undefined) {
+        invariant = isContextInvariantBody(body);
+        contextInvariant.set(body, invariant);
+      }
+      if (!invariant) {
+        const prior = contexts.get(body);
+        if (prior !== undefined && prior !== context) blocked.add(func);
+        else if (prior === undefined) contexts.set(body, context);
+      }
       if (expanded.has(body)) continue;
       expanded.add(body);
 

--- a/tests/issue-5186-stack-balance-shared-throw-body.test.ts
+++ b/tests/issue-5186-stack-balance-shared-throw-body.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5186 — the #1058 hard stack-balance refusal fired on a body that the repair
+// pass provably never touches. A terminal throw sequence is stack-polymorphic,
+// so producers share ONE such array between an `{kind:"empty"}` `if` arm and a
+// `{kind:"val", externref}` `if` arm; the preflight read the two block-type
+// contexts as a disagreement and failed the whole function's compile.
+//
+// The guard the refusal exists for is unchanged: a body whose repair really
+// does depend on the incoming block context is still refused (third case), and
+// so is a body reached from two different FUNCTIONS (fourth case) — local
+// indices are resolved against the owner there, which no terminator makes safe.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { stackBalance } from "../src/codegen/stack-balance.js";
+import type { CodegenError } from "../src/codegen/context/types.js";
+import type { Instr, WasmModule } from "../src/ir/types.js";
+
+/** Minimal module skeleton around a caller-supplied function list. */
+function moduleWith(functions: unknown[]): WasmModule {
+  return {
+    types: [{ kind: "func", params: [], results: [] }],
+    imports: [],
+    functions,
+    globals: [],
+    tags: [{ typeIdx: 0 }],
+    funcOrdinalToPosition: [],
+  } as unknown as WasmModule;
+}
+
+describe("#5186 shared stack-polymorphic body across block contexts", () => {
+  it("accepts one terminal throw body reached from an empty and a valued if arm", () => {
+    // The exact shape measured in the failing modules: the SAME physical array
+    // is `then` of a void `if` and `then` of an externref-valued `if`.
+    const throwBody: Instr[] = [
+      { op: "global.get", index: 0 },
+      { op: "extern.convert_any" },
+      { op: "throw", tagIdx: 0 },
+    ];
+    const mod = moduleWith([
+      {
+        name: "makeNativeError",
+        typeIdx: 0,
+        locals: [],
+        body: [
+          { op: "i32.const", value: 1 },
+          { op: "if", blockType: { kind: "empty" }, then: throwBody, else: [] },
+          { op: "i32.const", value: 1 },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: throwBody,
+            else: [{ op: "ref.null.extern" }],
+          },
+          { op: "drop" },
+        ],
+      },
+    ]);
+
+    const diagnostics: CodegenError[] = [];
+    stackBalance(mod, diagnostics);
+
+    expect(diagnostics.map((error) => error.message).join("\n")).not.toMatch(
+      /incompatible control-flow or function-local contexts/,
+    );
+    expect(mod.codegenErrors ?? []).toEqual([]);
+    // The shared body is stack-polymorphic, so the pass must leave it alone
+    // rather than append a drop for one owner and a value for the other.
+    expect(throwBody).toEqual([
+      { op: "global.get", index: 0 },
+      { op: "extern.convert_any" },
+      { op: "throw", tagIdx: 0 },
+    ]);
+  });
+
+  it("still refuses a shared body whose repair DOES depend on the block context", () => {
+    // No terminator: `fixBranch` would append a `drop` for the empty arm and
+    // leave the value for the i32 arm. Refusing remains correct.
+    const leaf: Instr[] = [{ op: "i32.const", value: 1 }];
+    const mod = moduleWith([
+      {
+        name: "ambiguous",
+        typeIdx: 0,
+        locals: [],
+        body: [
+          { op: "block", blockType: { kind: "val", type: { kind: "i32" } }, body: leaf },
+          { op: "drop" },
+          { op: "block", blockType: { kind: "empty" }, body: leaf },
+        ],
+      },
+    ]);
+
+    const diagnostics: CodegenError[] = [];
+    stackBalance(mod, diagnostics);
+
+    expect(diagnostics.map((error) => error.message).join("\n")).toMatch(
+      /incompatible control-flow or function-local contexts/,
+    );
+    expect(leaf).toEqual([{ op: "i32.const", value: 1 }]);
+  });
+
+  it("still refuses a terminal throw body shared across two functions", () => {
+    // Cross-function sharing is a DIFFERENT hazard — the local/call-arg/
+    // struct.new repairs resolve indices against the owning function — and is
+    // deliberately NOT relaxed by the stack-polymorphism argument.
+    const throwBody: Instr[] = [
+      { op: "global.get", index: 0 },
+      { op: "throw", tagIdx: 0 },
+    ];
+    const mod = moduleWith([
+      { name: "a", typeIdx: 0, locals: [], body: [{ op: "block", blockType: { kind: "empty" }, body: throwBody }] },
+      { name: "b", typeIdx: 0, locals: [], body: [{ op: "block", blockType: { kind: "empty" }, body: throwBody }] },
+    ]);
+
+    const diagnostics: CodegenError[] = [];
+    stackBalance(mod, diagnostics);
+
+    expect(diagnostics.map((error) => error.message).join("\n")).toMatch(
+      /incompatible control-flow or function-local contexts/,
+    );
+  });
+
+  it("compiles the construct-owner + plain-call-owner source shape (standalone)", async () => {
+    // Reduced from test262 `harness/nativeErrors.js` `makeNativeError`: one
+    // callee reached as `new Ctor(...)` and as `Ctor(...)`. The TypedArray use
+    // is load-bearing — it is what makes codegen emit the `$__ta_ctor`
+    // [[Call]] arm whose terminal throw is the shared array.
+    const result = await compile(
+      `
+      function makeNativeError(Ctor: any, msg: string): any {
+        let e: any;
+        if (msg.length > 0) {
+          e = new Ctor(msg);
+        }
+        if (msg.length > 1) {
+          e = Ctor(msg);
+        }
+        return e;
+      }
+
+      const buf = new Int8Array(4);
+      buf[0] = 1;
+
+      export function test(): number {
+        const err = makeNativeError(TypeError, "x");
+        return err !== null && buf[0] === 1 ? 1 : 0;
+      }
+      `,
+      { target: "standalone", nativeStrings: true } as never,
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    await expect(WebAssembly.compile(result.binary)).resolves.toBeInstanceOf(WebAssembly.Module);
+  });
+});


### PR DESCRIPTION
Fixes [#5186](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5186-stack-balance-hard-error-family).

## The regression this clears

`main` carried a net **−947** test262 regression (35,377 → 34,430) from **2,580
standalone `compile_error`s**, all one family, so every merge group failed its
regression gate against the pre-regression baseline and PRs #5188 / #5212 /
#5216 were parked behind it.

Introduced by `8f161cbf15` (selfhost, PR #5204), which converted the
stack-balance pass from a tree walk to a **DAG** walk (visited-sets in
`eliminateDeadCode` / `fixBody` / `assertLocalRefsInRange`) so the selfhost
parser's shared instruction graph terminates in linear time. Visiting each
physical array once means the one repair applied to a shared array must be
valid for all its owners, and `contextAmbiguousFunctions` was added as the guard
for that — failing the compile when an array is reached from two functions, or
from two different block contexts inside one function.

## Root cause

The **block-context** half of that guard is too coarse. Instrumenting the
preflight shows the conflict is one shape, on 100 % of the victims — never the
cross-function arm:

```
[share] context: func="makeNativeError" priorVia=if.then@…[6] nowVia=if.then@…[12]
        prior=0:{"kind":"empty"} now=1:{"kind":"val","type":{"kind":"externref"}}
        len=4 ops=global.get,extern.convert_any,call,throw
```

A **terminal throw** — stack-polymorphic. It validates as a void `if` arm and as
an externref-valued `if` arm alike, which is exactly why the producer shares it:
`src/codegen/expressions/calls.ts:4921-4934` hands one `buildThrowJsErrorInstrs`
array both to a `{kind:"val", externref}` arm and, through
`buildInt8ArrayCarrierMatch`, to a `{kind:"empty"}` arm
(`src/codegen/dataview-native.ts:3570`). Two contexts, one array → refused, and
the refusal takes down the **whole function**.

The refusal is provably unnecessary for that shape. The only context-dependent
repairs are `fixBranch` and `fixBranchType`, and `fixBranchType` has exactly one
call site — inside `fixBranch`. `fixBranch` opens with `if (actual ===
UNREACHABLE) return 0`, and `sequenceDelta` returns `UNREACHABLE` for exactly
the `isTerminator` op set and nothing else. So "contains a top-level terminator"
is *identical* to "`fixBranch` returns 0 without mutating it", under every
`expected`/`blockType`.

## Fix — the pass, not the producers

Skip the context-key comparison for stack-polymorphic bodies (memoized in a
`WeakMap`, so a heavily-shared DAG stays linear in instructions rather than in
edges — preserving the property the DAG walk was added for).

The producer-side alternative (a one-line `[...throwInstrs]` at calls.ts:4924)
was rejected as *the* fix: it treats a legitimate, deliberately-reasoned Wasm
pattern as a defect, and it is site-by-site across ~40 `buildThrowJsErrorInstrs`
callers, so the next occurrence is another queue-blocking event. The hard error
was **not** demoted to a warning — the invariant the selfhost lane depends on is
preserved and both arms that really can disagree still fail closed:

- a shared body whose repair **does** depend on the context is still refused;
- the **cross-function** `firstOwner` refusal is untouched — the local/call-arg/
  struct.new repairs resolve indices against the owning function, which no
  terminator makes safe.

## Validation

`tests/issue-5186-stack-balance-shared-throw-body.test.ts` — 4 cases, each
verified in both directions by swapping the pre-fix file back in:

| case | base | fixed |
| --- | --- | --- |
| shared terminal throw across empty + valued `if` arms → no error, body unmutated | FAIL | PASS |
| construct-owner + plain-call-owner TS source, standalone → clean compile + `WebAssembly.compile` | FAIL | PASS |
| context-sensitive shared body still refused (guard) | PASS | PASS |
| terminal throw shared across two functions still refused (guard) | PASS | PASS |

Family victims, `runTest262File(…, "standalone")` — `harness/deepEqual-{circular,
array,deep,object,mapset}` go **compile_error → pass**; the six
`built-ins/Error/prototype/stack/*` victims clear the hard error and fall back to
their pre-regression runtime failure, so they are not passes this PR claims.

Selfhost lane unchanged: `tests/issue-1058-*.test.ts` — **45 files, 151 tests,
all passing**, including `issue-1058-stack-balance-dag.test.ts`'s own "refuses
one shared leaf with incompatible valued and empty block contexts".

The aggregate recovery is measured by the merge group, not claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_