### PR TITLE
docs(issues): #5180 root cause + in-review; file #5187 — RegExp .exec().index broken by #5204

### DIFF
--- a/plan/issues/5180-jsbi-toprimitive-struct-field-out-of-range.md
+++ b/plan/issues/5180-jsbi-toprimitive-struct-field-out-of-range.md
@@ -1,7 +1,8 @@
 ---
 id: 5180
 title: "`JSBI___toPrimitive` binary emit fails with struct field index out of range — new on main, blocks the temporal-polyfill lane"
-status: ready
+status: in-review
+pr: 5223
 sprint: current
 created: 2026-08-29
 updated: 2026-08-29
@@ -11,7 +12,7 @@ feasibility: medium
 task_type: bugfix
 area: codegen
 goal: dogfood
-related: [4628, 5178, 3481, 5147]
+related: [4628, 5178, 3481, 5147, 5204]
 ---
 
 # #5180 — `struct field index out of range` on `JSBI___toPrimitive`
@@ -44,36 +45,89 @@ Measured 2026-08-29, in this order:
 So it entered `main` between `fc6fd3b5f3` and `bdb19824b0`. The source-touching
 merges in that window are **#5203** (`claude/es2015-test262-standalone-9vij99`)
 and **#5204** (`claude/pr-5183-fix-osgkt9`); #5187 is #4644, which the green run
-above already contained, and the rest are docs/artifact commits. **The window is
-narrowed, not resolved — do not treat either PR as confirmed without a probe.**
+above already contained, and the rest are docs/artifact commits.
 
 A per-commit bisect on plain `main` is impractical for the polyfill: without
 #4645 the compile is the superlinear case that issue exists to fix (the probe at
-`fc6fd3b5f3` did not finish in 10 minutes). Bisect on a tree that has #4645
-merged, or reduce first.
+`fc6fd3b5f3` did not finish in 10 minutes). **Reducing first was the right move
+and is what closed the window** — see Root cause below: #5204, `8f161cbf15`.
 
 ## Reproduce
 
-```bash
-node --import tsx .tmp/repro-bundle.mjs   # links jsbi + polyfill, compiles, validates
+Three lines, no polyfill needed (reduction by dev-5180; **re-verified
+independently on this branch**, same error class, `__module_init` instead of
+`JSBI___toPrimitive`):
+
+```js
+const d = new Date(0); const t = d.valueOf;
 ```
 
-or the dogfood lane:
+```
+Binary emit error: RangeError: Codegen error: struct field index out of range
+— 1 (valid: [0, 1)) at function '__module_init'
+```
+
+Whole-bundle form:
 
 ```bash
+node --import tsx .tmp/repro-bundle.mjs   # links jsbi + polyfill, compiles, validates
 DOGFOOD_TEMPORAL_POLYFILL=1 node node_modules/vitest/dist/cli.js run \
   tests/dogfood/temporal-polyfill.test.ts
 ```
 
-## Where to start
+## Root cause (dev-5180) — window closed to #5204
 
-`JSBI___toPrimitive` is a synthesized `Symbol.toPrimitive` method export. The
-emitted `struct.get`/`struct.set` names field 1 of a struct that has exactly one
-field, at instruction position 97 in a body with 21 declared locals — i.e. a
-field index computed against one struct layout and emitted against another. The
-`emitToPrimitiveMethodExports` path in `src/codegen/index.ts` and the
-symbol-carrier layout work from #3481 are the two places where a `@@toPrimitive`
-carrier's field list is decided.
+This issue's original "where to start" guess — `emitToPrimitiveMethodExports`
+in `src/codegen/index.ts`, or the #3481 symbol-carrier layout — was **wrong on
+both counts**, and is dropped rather than left to mislead. The function name was
+a red herring: `JSBI___toPrimitive` was simply the first function in the bundle
+to reach the bad candidate. The only part of that guess that held up was the
+mechanical read, "a field index computed against one struct layout and emitted
+against another", which is exactly the drift below.
+
+`ensureDateStruct` registers `mod.types[$__Date].fields` and
+`ctx.structFields.get("__Date")` as **two separate arrays**. The dynamic
+field auto-registration in `finalizeStructAndDynamicMemberGet` appends to the
+metadata array only, so the two drift; `findAlternateStructsForField` then
+offers `__Date` as a `valueOf` candidate at field 1 and emits
+`struct.get $__Date 1` against a one-field struct.
+
+**Attribution: #5204, commit `8f161cbf15` (selfhost) — #5203 is clean.** That
+commit made the pre-existing drift *reachable* by adding the `receiverWasm`
+carrier-name fallback in `resolveStructNameForExpr`
+(`src/codegen/property-access.ts:1147-1149`, confirmed present), which resolves
+a `Date` receiver to `typeName === "__Date"`. The narrowed-but-unresolved
+window recorded above is therefore now closed.
+
+Fix: **PR #5223** (`issue-5180-struct-field-index-oob`) — one line, never grow a
+struct whose field metadata is a separate array.
+
+## Effect on the temporal-polyfill lane
+
+Measured by dev-5180 (their numbers, not re-run here):
+
+| tree | result |
+| --- | --- |
+| `origin/issue-5178-method-return-struct-type` + #5180 fix | **0 hard errors, VALIDATE OK**, 1,095,247 bytes |
+| plain `main` + #5180 fix | 1,097,367 bytes, fails validation: `immutable global #1226 cannot be assigned` in `JSBI_BigInt` |
+
+That second residual is **not** a new defect: dev-5180 verified it is also
+present on unfixed `main` (by bypassing the emitter's struct-field check) and at
+base `3abe6a72de` + their fix, and that it disappears with the #5178 stack —
+i.e. it is the #5169 immutable-global bug, still in flight as PR #5212. No new
+issue was filed for it, correctly.
+
+So **#5180 + #5178 (which carries #5169) together restore the lane**; neither
+alone does.
+
+## Status note
+
+Held at `in-review`, not `done`: PR #5223 is **open, not merged** (verified via
+the API at the time of writing). This file lives only on
+`origin/issue-5178-method-return-struct-type` (PR #5216) because duplicating it
+on the fix branch would collide on the issue-id gate, so the fix PR cannot carry
+its own status flip — the handoff case `in-review` exists for. Whoever observes
+#5223 merge flips this to `done`.
 
 ## Acceptance
 

--- a/plan/issues/5183-merge-queue-lands-prs-from-failed-groups.md
+++ b/plan/issues/5183-merge-queue-lands-prs-from-failed-groups.md
@@ -31,6 +31,13 @@ checks:
 #5209 additionally carried the auto-park `hold` label at merge time — the
 label neither prevented re-queueing nor merging.
 
+**Fourth instance (added 2026-08-29 07:06):** #5216 merged at 06:57 while
+carrying the `hold` label AND with auto-merge explicitly disabled (the
+coordinator had disabled it at ~06:45 to release the branch; `auto_merge:
+null` was confirmed before the merge). Its earlier group (run 33236737382)
+had failed the same two verdict checks. Whatever merged it did so from a
+queue entry that survived both the park and the auto-merge removal.
+
 Verified from the runs themselves (not inferred): the failing step in each is
 the VERDICT step ("Standalone root-cause map has 24 unclassified failures;
 threshold is 0" / "Fail on regressions"), not setup. The regression they

--- a/plan/issues/5187-regexp-exec-index-wrong-after-5204.md
+++ b/plan/issues/5187-regexp-exec-index-wrong-after-5204.md
@@ -1,0 +1,97 @@
+---
+id: 5187
+title: "RegExp exec result `.index` reads 0 instead of the match offset — ~224 test262 regressions from #5204"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: high
+horizon: m
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: core-semantics
+related: [5180, 5204, 5216, 2547]
+---
+
+> **Note on the id:** this is issue **#5187**, allocated by
+> `claim-issue.mjs --allocate`. Issue ids and PR numbers share one sequence, so
+> it collides by name with **PR #5187** (the #4644 fix, unrelated). Link to this
+> issue by slug, not by bare `#5187`.
+
+# #5187 — `/re/.exec(s).index` is 0 for every match
+
+## Problem
+
+```js
+var m = /b/.exec("abc");
+m.index          // wasm: 0     node: 1
+```
+
+Measured on plain `origin/main` (`ddab1b0743`, scratch worktree) and on
+`origin/issue-5178-method-return-struct-type`. Compiles clean, runs, returns the
+wrong number — no diagnostic, no trap.
+
+## Why this matters now
+
+It is the **largest single runtime cluster** in the merge-group regression that
+auto-parked PRs #5169/#5178/#5216 (run
+[33236737382](https://github.com/loopdive/js2/actions/runs/33236737382),
+`hold` + `auto-park-bot:merge-group-failure`):
+
+| cluster | count | cause |
+| --- | --- | --- |
+| `pass → compile_error … struct field index out of range` | **595** | #5180 — fixed by PR #5223 |
+| `pass → fail … __executed.index is expected to equal …` | **224** | **this issue — NOT fixed by #5223** |
+| `pass → fail … __split.constructor is expected to equal …` | 65 | separate + older, see below |
+| everything else | ~47 | — |
+
+Totals from the run's own artifact (`test262-regressions-detail.txt`, artifact
+9710358902), 931 non-timeout regressions, fine-gate net **-876**.
+
+**None of these are caused by the three parked PRs.** Both dominant clusters
+reproduce on plain `main`. The queue is parking PRs for defects `main` already
+carries; the baseline they are diffed against still records these tests as
+`pass`.
+
+## Attribution — bisected, not guessed
+
+The 5-line repro above makes bisection cheap (the #5180 investigation could not
+bisect only because its repro was the 157 KB polyfill bundle):
+
+| revision | `.index` |
+| --- | --- |
+| `fc6fd3b5f3` (#5196) | **1** — correct |
+| `4dfedbdc92` (#5203, ES2015 standalone) | **1** — correct, #5203 is clean |
+| `523bd0428b` (**#5204**, `claude/pr-5183-fix-osgkt9`) | **0** — broken |
+| `ddab1b0743` (current main) | **0** — broken |
+
+So **#5204 introduced two distinct defects**: #5180 (the `__Date` field-metadata
+drift, fixed by #5223) and this one. Verified separately that applying #5223's
+fix (`structGrowsWithMetadata` guard + helper) to a tree containing #5204 leaves
+`.index` at 0 — **#5223 does not fix this**, so closing #5180 must not be read
+as closing the park.
+
+## The `.constructor` cluster is NOT this bug
+
+`"a,b".split(",").constructor === Array` is already `false` at `fc6fd3b5f3`, so
+those 65 regressions predate this window and have a different cause. Recorded
+here so the next investigator does not fold them in; they need their own probe
+(the probe used here is coarse — the test262 cases compare against a species
+constructor, not `Array`, so confirm before filing).
+
+## Reproduce
+
+```js
+// .tmp/probe.mjs — compile with { allowJs: true, skipSemanticDiagnostics: true },
+// instantiate, compare against node.
+var __executed = /b/.exec("abc");
+console.log("index=" + __executed.index);
+```
+
+## Acceptance
+
+* `/b/.exec("abc").index === 1` in compiled output.
+* The `__executed.index` cluster clears from the merge-group regression diff.
+* A regression test asserting the value, not just a clean compile — this bug
+  produces a valid module and a wrong answer.


### PR DESCRIPTION
Docs-only, two commits cherry-picked from the merged #5216's branch (they landed there after its queue merge and were orphaned).

- **#5180's issue file** now carries dev-5180's measured root cause (`ensureDateStruct` registering struct fields and metadata from two separate array literals; #5204's carrier-name fallback made the desync reachable), `pr: 5223`, and is deliberately held at **`in-review`, not `done`** — PR #5223 is open, not merged, and a `done` claim would be false on main until it lands. The file's original "where to start" pointer (wrong, per the bisect) is dropped with a note rather than silently.
- **New issue [#5187](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5187-regexp-exec-index-wrong-after-5204)** — the third distinct defect from #5204 (`8f161cbf15`): RegExp `.exec()` results carry a wrong `.index` (224 test262 pass→fail rows, `__executed.index is expected to equal …`). Bisected with a 5-line repro (`/b/.exec("abc").index`): clean at `fc6fd3b5f3` and #5203, broken at #5204. Verified NOT fixed by #5223 (the guard applied to a #5204 tree leaves `.index` at 0). Reproduces on plain `origin/main`. Fix assigned (branch `issue-5187-regexp-exec-index`).

Context: #5204 introduced three independent defects — #5180 (PR #5223, queued), #5187 (this filing, fix in flight), #5186 (stack-balance −947, PR #5228, in CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_