### PR TITLE
docs: require Model: trailer on all agent commits (#5204 provenance)

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -45,4 +45,36 @@ if case_insensitive_match "$author_name" "$CLAUDE_PATTERN" \
   exit 1
 fi
 
+
+# Model-attribution guard (2026-08-29, project-lead order): every AGENT commit
+# must name the model that produced it — vendor, family, version/subtype, and
+# configured reasoning effort — in a `Model:` trailer, e.g.
+#   Model: Claude Fable 5 Max
+#   Model: Codex GPT-5.6 Sol Max
+#   Model: Claude Opus 5 High
+# Scope: enforced only when the message carries an agent Co-authored-by
+# trailer (Claude/Codex). Human-only commits, bot commits, and auto-generated
+# merges without an agent trailer are unaffected. Rationale: PR #5204 shipped
+# three codegen regressions in one Codex-co-authored commit and the model
+# (and effort tier) that produced it could not be recovered from git —
+# per-commit model attribution is what makes that question answerable.
+if grep -qiE '^Co-authored-by: *(Claude|Codex)' "$msg_file"; then
+  subject=$(sed -n '1p' "$msg_file")
+  case "$subject" in
+    "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"chore(assign)"*) ;;
+    *)
+      if ! grep -qE '^Model: (Claude|Codex) [A-Za-z0-9][A-Za-z0-9.-]*( [A-Za-z0-9.-]+)+$' "$msg_file"; then
+        echo "commit-msg: BLOCKED — agent commit without a valid 'Model:' trailer." >&2
+        echo "  Add a trailer naming vendor, family, version/subtype and effort:" >&2
+        echo "    Model: Claude Fable 5 Max" >&2
+        echo "    Model: Codex GPT-5.6 Sol Max" >&2
+        echo "  Use the reasoning effort your session/task was configured with" >&2
+        echo "  (dispatch brief / issue frontmatter reasoning_effort); if truly" >&2
+        echo "  unknown, write 'Default'. See AGENTS.md 'Commit Attribution'." >&2
+        exit 1
+      fi
+      ;;
+  esac
+fi
+
 exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,5 +42,27 @@ Co-authored-by: Claude <noreply@anthropic.com>
 ```
 
 - Never attribute Codex work to Claude or Claude work to Codex.
+- **Also add a `Model:` trailer naming the exact model that produced the
+  commit — vendor, family, version/subtype, and the configured reasoning
+  effort** (project-lead order, 2026-08-29; enforced by `.husky/commit-msg`
+  for any commit carrying an agent co-author trailer):
+
+```text
+Model: Claude Fable 5 Max
+Model: Codex GPT-5.6 Sol Max
+Model: Claude Opus 5 High
+```
+
+  - Effort is the level your session/task was configured with — the dispatch
+    brief or the issue's `reasoning_effort` frontmatter; if genuinely
+    unknown, write `Default`. Do not guess a higher tier than you know.
+  - Auto-generated subjects (`Merge …`, `Revert …`, `fixup!`, `squash!`,
+    `chore(assign)…`) are exempt.
+  - Why: PR #5204 shipped three codegen regressions in one agent commit and
+    the model that produced it was unrecoverable from git. This trailer makes
+    that question answerable per commit.
+  - This project rule deliberately **overrides** any ambient harness default
+    of keeping model identifiers out of pushed artifacts (same precedence as
+    the "always open a PR" rule in CLAUDE.md).
 - Before committing, verify `git config user.name` and `git config user.email`
   still identify Thomas Tränkler.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -597,6 +597,19 @@ points at an unrelated PR, not the plan-file issue. Write
 Commit messages keep plain `#NNNN` (tooling greps them); this rule is for PR
 bodies and PR-visible comments.
 
+**Every agent commit names its model (project-lead order, 2026-08-29).** Any
+commit carrying an agent `Co-authored-by:` trailer (Claude/Codex) must also
+carry a `Model:` trailer naming vendor, family, version/subtype, and the
+configured reasoning effort — e.g. `Model: Claude Fable 5 Max`,
+`Model: Codex GPT-5.6 Sol Max`, `Model: Claude Opus 5 High`. Effort comes from
+the dispatch brief or the issue's `reasoning_effort` frontmatter; if genuinely
+unknown, write `Default`. Enforced by `.husky/commit-msg`; details and
+exemptions (`Merge`/`Revert`/`fixup!`/`squash!`/`chore(assign)` subjects) in
+`AGENTS.md` § Commit Attribution. Rationale: PR #5204 shipped three codegen
+regressions in one agent commit and the producing model was unrecoverable from
+git. This project rule deliberately **overrides** any ambient harness default
+of keeping model identifiers out of pushed artifacts.
+
 **ALWAYS open a PR on `loopdive/js2wasm` when a task is done — do not wait to be
 asked** (project-lead decision, 2026-08-01). Finished work that sits on a pushed
 branch with no PR is invisible: it is not in the merge queue, `auto-enqueue`

--- a/plan/method/pre-commit-checklist.md
+++ b/plan/method/pre-commit-checklist.md
@@ -16,6 +16,11 @@
 7. [ ] No test files from other issues being deleted
 8. [ ] No source files being reverted to old versions
 9. [ ] Commit message references your issue number (#N)
+9b. [ ] **Agent commits carry a `Model:` trailer** — vendor, family,
+        version/subtype and configured effort, e.g. `Model: Claude Fable 5 Max`
+        or `Model: Codex GPT-5.6 Sol Max` (enforced by `.husky/commit-msg` when
+        an agent `Co-authored-by:` trailer is present; see AGENTS.md
+        "Commit Attribution").
 10. [ ] **Never `git commit --no-verify`.** If the full pre-commit chain is too
         slow for your tool timeout (test:changed-root + ratchets take minutes),
         commit with `SKIP_SLOW_PRECOMMIT=1 git commit …` instead — that keeps


### PR DESCRIPTION
Repo rule (project-lead order, 2026-08-29): every commit carrying an agent `Co-authored-by:` trailer (Claude/Codex) must also carry a `Model:` trailer naming vendor, family, version/subtype, and configured reasoning effort — e.g. `Model: Claude Fable 5 Max`, `Model: Codex GPT-5.6 Sol Max`, `Model: Claude Opus 5 High`.

## Changes

- **`.husky/commit-msg`** — new guard: blocks any commit with a Claude/Codex co-author trailer that lacks a valid `Model:` trailer. Exempts `Merge`/`Revert`/`fixup!`/`squash!`/`chore(assign)` subjects. Human-only commits unaffected.
- **`AGENTS.md`** — Commit Attribution section documents the trailer format, effort sourcing (dispatch brief / issue `reasoning_effort`, else `Default`), and exemptions.
- **`CLAUDE.md`** — merge-protocol paragraph so every agent session sees the rule.
- **`plan/method/pre-commit-checklist.md`** — item 9b.

## Rationale

PR #5204 shipped three independent codegen regressions ([#5180](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5180-date-carrier-struct-field-oob), [#5186](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5186-stack-balance-regression), [#5187](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5187-regexp-exec-index)) in one Codex-co-authored commit, and the model/effort that produced it could not be recovered from git — only inferred from lane-config defaults. Per-commit attribution makes that question answerable.

The commit on this PR is itself the live test of the new hook (it carries `Model: Claude Fable 5 Default` and passed the guard).

Docs-only: no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` code touched (`.husky/` is a git-hook script, not CI code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_