### PR TITLE
fix(#4628): measure the Temporal polyfill's THIRD gate, isolate the blocker (#5191)

### DIFF
--- a/plan/issues/4628-temporal-runtime-object-spike.md
+++ b/plan/issues/4628-temporal-runtime-object-spike.md
@@ -568,14 +568,24 @@ lines:
 
 ```js
 class C extends Array {}
+C == null;             // spec: false. js2wasm: TRUE
 C.zzz === undefined;   // spec: true.  js2wasm: throws
 ```
 
-Reading an **absent** property off the constructor object of a class that
-extends a **builtin** throws instead of yielding `undefined`. `class C {}`,
+**A class extending a builtin evaluates to `null` as a value.** The property
+access throws only because the receiver it loaded is null. `class C {}`,
 `class C extends B {}` (user base), `function C(){}` and `const C = {}` are all
-correct; `Array`, `Error` and `Map` bases all throw. Filed with the full
-receiver table and two adjacent symptoms as
+correct; `Array`, `Error` and `Map` bases are all null. It stays hidden because
+`typeof C`, `C.name` and `new C()` are served by static arms that never
+materialise the constructor object.
+
+Located to one line: `src/codegen/class-bodies.ts` (~L1188) skips registering
+the class-object singleton when `ctx.classBuiltinParentMap.has(className)`
+(#1366a), because `emitLazyClassObjectGet`
+(`src/codegen/expressions/extern.ts:362`) builds that object as a `struct.new`
+of the `$ClassName` WasmGC struct, which an externref-backed subclass does not
+have. So the guard is not gratuitous and the fix is not deleting it — the lane
+needs a different carrier. Filed with the full receiver table as
 [#5191](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5191-builtin-derived-ctor-property-miss-throws),
 recorded in `depends_on` above.
 

--- a/plan/issues/4628-temporal-runtime-object-spike.md
+++ b/plan/issues/4628-temporal-runtime-object-spike.md
@@ -2,10 +2,10 @@
 id: 4628
 title: "Temporal as a real runtime object: spike @js-temporal/polyfill vs porting engine262's abstract-ops (2,206 × 'Temporal is not defined')"
 status: in-progress
-assignee: ttraenkler/opus-dev-4628
+assignee: ttraenkler/opus-dev-temporal
 sprint: current
 created: 2026-08-23
-updated: 2026-08-23
+updated: 2026-08-29
 priority: high
 horizon: l
 feasibility: hard
@@ -15,8 +15,8 @@ area: codegen, runtime
 language_feature: temporal
 goal: spec-completeness
 test262_fail: 2206
-depends_on: [4627]
-related: [661]
+depends_on: [4627, 5191]
+related: [661, 5192]
 ---
 
 # #4628 — Temporal as a real runtime object
@@ -492,3 +492,202 @@ into a required check on work nobody has committed to yet.
   compilation stops terminating.
 - No runtime / differential-execution lane. Compile + validate only, by design.
 - Step 0 (see above).
+
+---
+
+## Step 3 attempt — 2026-08-29 (`ttraenkler/opus-dev-temporal`, branch `issue-4628-temporal-global`)
+
+Measured on `origin/main` @ `279ce9a4f2`. **Outcome: Option A is confirmed as
+the right path and is BLOCKED on one specific compiler defect, now filed as
+#5191.** Acceptance criteria 1–3 are NOT met and are not claimed. What follows
+is what was measured, what was decided, and what is left.
+
+### Step 0 — the baseline the spike left outstanding, now taken
+
+`node scripts/fetch-baseline-jsonl.mjs --force`, 2026-08-29, 48,735 entries
+(85,308,991 B), bucketed by `.tmp/bucket-baseline.mjs` over rows whose path
+contains `Temporal`. **This supersedes the "Measured baseline" numbers at the
+top of this file, which were pre-#4627.**
+
+| Bucket | Pre-#4627 (2026-08-23) | **Now (2026-08-29)** |
+| --- | --- | --- |
+| Temporal-path rows | 4,611 | 4,611 |
+| `pass` | 207 | **594** |
+| `compile_error` status | 1,487 | **0** |
+| `Temporal is not defined` | 2,206 | **1,589** |
+| other `fail` | ~711 | 2,428 |
+
+Two corrections that matter for how this issue is scoped:
+
+- **#4627 landed and the compile-error bucket is gone.** Those rows now
+  instantiate and fail on substance, which is exactly the predicted growth in
+  the semantic bucket (711 → 2,428).
+- **The headline is 1,589, not 2,206.** Any delta claim against this issue must
+  cite this run, not the numbers in the Problem section.
+
+Largest non-`not defined` failure buckets now: `Cannot read properties of null
+[in __module_init()]` 487, `Expected a RangeError but got a TypeError` 155,
+`round is not a function` 77, `until` 65, `since` 64. By directory:
+ZonedDateTime 818, PlainDateTime 686, PlainDate 531, Duration 474,
+PlainYearMonth 447, Instant 407, PlainTime 390, PlainMonthDay 186, Now 65.
+
+### Gate re-verification on this branch base
+
+`node --import tsx tests/dogfood/temporal-polyfill-harness.mjs --no-umd` —
+ESM linked lane, 157,541 B: compile **success, 0 errors / 2 warnings** in
+21,418 ms, binary **1,095,206 B**, `WebAssembly.compile()` **OK**. The spike's
+whole-bundle non-termination is **gone** — 45+ minutes then, 21 s now. Plain
+`node` fails on `bundle-manifest.js` with `ERR_MODULE_NOT_FOUND`; use
+`node --import tsx`.
+
+The UMD lane was run for the first time (90,724 ms, 0 errors, 1,644,531 B) and
+**fails validation**: `#470:"__closure_35" … return[0] (expected externref, got
+i32)`. Filed as [#5192](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5192-umd-closure-return-type-invalid-wasm),
+deliberately not fixed here — it is a second, independent bundle shape and is
+not on Option A's critical path.
+
+### The finding that decides this step: a THIRD gate the spike never reached
+
+Compile and validate are different gates — the spike said so and checked both.
+**Instantiate is a third gate, and the polyfill fails it.** The ESM binary
+validates and then throws a `WebAssembly.Exception` the moment its module init
+runs, so it produces **no exports at all**. No wiring choice can install a
+`Temporal` global from a module that never finishes initialising, which is why
+this blocks every integration option equally rather than favouring one.
+
+The harness now measures it (`measure({ instantiate })`, `--no-instantiate` to
+skip) and the summary carries `moduleInitRuns` / `moduleInitError`, so no
+future run can read "validates" as "works". Current headline:
+`"compiled + validates, but module init THROWS"`.
+
+**Root cause, isolated.** Bisecting the linked bundle by top-level-statement
+prefix (`.tmp/probe-bisect.mts`, 9 compiles) puts the first failing prefix at
+statement **2 of 341** — prefix 1 instantiates, prefix 2 does not. Statement 2
+is jsbi's static-table block on `class JSBI extends Array`. Reduced to three
+lines:
+
+```js
+class C extends Array {}
+C.zzz === undefined;   // spec: true.  js2wasm: throws
+```
+
+Reading an **absent** property off the constructor object of a class that
+extends a **builtin** throws instead of yielding `undefined`. `class C {}`,
+`class C extends B {}` (user base), `function C(){}` and `const C = {}` are all
+correct; `Array`, `Error` and `Map` bases all throw. Filed with the full
+receiver table and two adjacent symptoms as
+[#5191](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5191-builtin-derived-ctor-property-miss-throws),
+recorded in `depends_on` above.
+
+This is precisely the "free, prioritized compiler-bug backlog against a
+real-world library" #661 predicted — and note it was invisible to both gates
+the spike used.
+
+### Integration approach — decided, with the number that decides it
+
+**Compile-once, never per-test.** The polyfill's compile costs **21.4 s**
+(measured, above). The test262 runner compiles one synthetic module per test
+(preamble + body, `tests/test262-runner.ts`), and `$262` shows the established
+way to inject a global is a **source-level preamble declaration** compiled with
+the body — there is no host-injection path for realm objects. Prepending the
+polyfill would therefore cost 21.4 s × 4,611 Temporal rows ≈ **27 hours** of
+added compile, or ~1.7 h on each of the 16 merge-group shards against a job
+that runs ~19 minutes today. Option (c), source-level prepend, is arithmetically
+dead. So is any scheme keyed on the test body, because the runner's disk cache
+key includes it.
+
+That leaves **option (a), compile-once + link per test**, and the machinery
+already exists: `src/package-linker.ts` compiles a bare-package edge into its
+own Wasm binary, content-addresses it into a provider cache
+(`cachePaths()` → `<cacheKey>.wasm`), and hands the application graph an import
+map via the internal `linkedPackageBindings` option, over a frozen cross-module
+type group (`RUNTIME_RECGROUP_ABI_VERSION`,
+`src/emit/canonical-recgroup.ts`). `scripts/build-runtime-provider.mjs` is the
+existing precedent for publishing a compiler-owned provider artifact this way.
+
+Concretely, the intended shape:
+
+1. A build step compiles the linked polyfill **once** into a provider `.wasm`
+   (21 s, cached, content-addressed) — the same acquisition/link path the
+   dogfood harness already pins.
+2. The runner passes `linkedPackageBindings` mapping `Temporal` to that
+   provider's export, for the tests that need it.
+3. Per-test cost becomes the ordinary body compile plus a second instantiation.
+
+Option (b) — instantiate the polyfill in the JS host and hand `Temporal` to the
+test module as an imported `externref` — was considered and **rejected**: the
+polyfill's objects would be js2wasm WasmGC structs, opaque to the JS host, so
+the host cannot serve property access on them; and injecting the *untranspiled*
+JS polyfill as a host object instead would abandon standalone mode, which the
+dual-mode architecture principle forbids without a Wasm-native fallback.
+
+**None of this was implemented, because #5191 makes it unmeasurable.** A
+provider artifact whose module init throws is worth nothing, and wiring built
+against it could not be validated. The order is: fix #5191 → re-run the
+harness's instantiate lane → then build the provider wiring.
+
+### `src/codegen/temporal-native.ts` — KEEP, unchanged
+
+Measured, not assumed: the 594 passing Temporal rows in the current baseline
+are the compile-time lowering's, and `tests/issue-661.test.ts` passes **5/5**
+on this branch. The polyfill path covers **zero** of them today — it cannot
+produce a `Temporal` object at all. The plan's instruction was to measure before
+removing; the measurement says removing it would forfeit the project's only
+Temporal conformance for nothing. Precedence between the lowering and a real
+global is a decision that belongs to the PR that first makes the global exist;
+it cannot be defined against a global that does not.
+
+### `CLOSURE_UNSAFE_HOST_AMBIENTS` — deliberately NOT changed, and here is why
+
+`src/codegen/array-methods.ts:447` still reads
+`new Set(["Temporal", "TemporalHelpers", "Intl", "$262"])`.
+
+Reading the gate (`hofRefElemClosureLaneSafe`) settles when the removal is
+correct. The deny list is checked **before** the generic
+`decl === undefined || decl.getSourceFile().isDeclarationFile` test. So:
+
+- While `Temporal` is a **host ambient** (today), the generic test already
+  classifies it unsafe. The explicit entry is redundant but harmless.
+- Once `Temporal` is a **compiled, user-source binding** (a linked provider
+  import), the generic test would classify it **safe** — and the explicit entry
+  is then the only thing wrongly forcing it onto the host-callback path, which
+  for a ref-element receiver is the #3126 silent no-op.
+
+So the entry must be removed **in the PR that makes `Temporal` real, not
+before**. Removing it now would re-create the PR #2838 hazard (212 Temporal
+tests pass→fail) with no compensating benefit, because there is nothing yet for
+the closure lane to resolve. `TemporalHelpers` stays regardless — it is a
+harness ambient and is not what this issue makes real, exactly as the plan
+says.
+
+### Scoped validation actually run on this branch
+
+- `tests/dogfood/temporal-polyfill-harness.mjs --no-umd` — ESM lane: compile
+  0 errors / validates / **instantiate FAILS** (the finding above).
+- `tests/dogfood/temporal-polyfill-harness.mjs --no-whole` — UMD lane: compile
+  0 errors / **validate FAILS** (#5192).
+- `tests/dogfood/temporal-polyfill-harness.mjs --no-umd --no-whole --slices=200`
+  — slice lane, 342/342 statements, 0 skipped.
+- `npx vitest run tests/issue-661.test.ts` — **5/5 pass**.
+- `npx tsx scripts/run-test262-paths.mts .tmp/paths.txt --isolate` over five
+  hand-picked Temporal rows through the runner's own `runTest262File`:
+  `getOwnPropertyNames.js` → `ReferenceError: Temporal is not defined`;
+  `prop-desc.js` → `Expected SameValue(«"undefined"», «"object"»)`;
+  `PlainDate/prototype/add/argument-duration-max.js` → `Temporal is not
+  defined`; `Instant/prototype/toString/basic.js` → `Expected
+  SameValue(«"null"», …)`. These are acceptance criterion 1's own tests, and
+  they still fail — recorded, not claimed as met.
+- Minimal-repro matrices for #5191 are in `.tmp/probe-min{,2,…,6}.mts` on this
+  branch (not committed — `.tmp/` is scratch by convention).
+
+### What remains
+
+1. **#5191** — the blocker. Nothing else here can be measured until it clears.
+2. Provider-artifact build step + `linkedPackageBindings` wiring in the runner
+   (design above; no code written).
+3. Precedence between `temporal-native.ts` and the real global, once one exists.
+4. Remove `"Temporal"` from `CLOSURE_UNSAFE_HOST_AMBIENTS` **in that same PR**,
+   re-verifying against the full Temporal bucket per the PR #2838 hazard.
+5. #5192 (UMD lane) — independent, not on the critical path.
+6. jsbi is userland-BigInt (`class JSBI extends Array`); further defects it
+   surfaces get their own issues rather than widening this one.

--- a/plan/issues/5191-builtin-derived-ctor-property-miss-throws.md
+++ b/plan/issues/5191-builtin-derived-ctor-property-miss-throws.md
@@ -1,0 +1,120 @@
+---
+id: 5191
+title: "Reading an absent property off the constructor of a builtin-derived class throws instead of yielding undefined (blocks the Temporal polyfill's module init)"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: classes
+goal: core-semantics
+related: [4628, 661]
+---
+
+# #5191 — property miss on a builtin-derived class constructor throws
+
+## Problem
+
+For a class whose `extends` clause names a **builtin** constructor (`Array`,
+`Error`, `Map`, …), reading a property that is not present on the *constructor
+object* throws a WasmGC exception instead of evaluating to `undefined`.
+
+```js
+class C extends Array {}
+C.zzz === undefined; // spec: true.  js2wasm: throws
+```
+
+Plain classes, classes derived from a **user** base, ordinary functions and
+object literals all behave correctly — so the defect is specific to the
+builtin-derived constructor object, not to expando statics in general.
+
+Measured on `origin/main` @ `279ce9a4f2`, 2026-08-29, with the test262 runner's
+compile options (`allowJs: true, skipSemanticDiagnostics: true, sourceMap:
+true`) and `WebAssembly.instantiate(result.binary, result.importObject)`:
+
+| Receiver | `C.zzz === undefined` |
+| --- | --- |
+| `class C {}` | `1` (correct) |
+| `class B {}; class C extends B {}` | `1` (correct) |
+| `function C(){}` | `1` (correct) |
+| `const C = {}` | `1` (correct) |
+| `class C extends Array {}` | **throws** |
+| `class C extends Error {}` | **throws** |
+| `class C extends Map {}` | **throws** |
+
+Two adjacent symptoms share the receiver and are almost certainly the same
+root cause:
+
+| Shape | Result |
+| --- | --- |
+| `class C extends Array {}; C.a = 1; Object.getOwnPropertyNames(C).length` | throws **TypeError** |
+| `class C extends Array {}; C.a = 1, C.b = 2; C.b` | throws |
+
+Not affected, and useful for bisecting the dispatch: `"a" in C` returns the
+right answer, a *single* statically-paired write+read (`C.a = 1; C.a`) returns
+`1`, and the same two writes as **separate statements** (`C.a=1; C.b=2;`)
+return `2`. Only the comma-sequence form degrades — i.e. the failure appears
+once the access leaves the statically-resolved arm and reaches the generic
+constructor-object dispatch.
+
+## Why it matters now
+
+This is the **first thing the compiled `@js-temporal/polyfill` bundle hits at
+runtime**, and it is what blocks [#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-runtime-object-spike)
+step 3. `jsbi@4.3.0` — the polyfill's single dependency — is
+`class JSBI extends Array`, and its **second top-level statement** is one long
+comma sequence of static-table assignments:
+
+```js
+JSBI.__kMaxLength=33554432,JSBI.__kMaxLengthBits=JSBI.__kMaxLength<<5,…
+```
+
+Bisecting the linked 157,541-byte bundle by top-level-statement prefix
+(9 compiles, `.tmp/probe-bisect.mts` in the #4628 branch) puts the first
+instantiate failure at exactly statement 2 of 341: prefix 1 instantiates,
+prefix 2 throws. So the whole Option-A path — `Temporal` installed from the
+compiled polyfill's exports — is gated on this one defect. A module whose init
+throws has no exports to install, and no wiring choice routes around that.
+
+## Reproduce
+
+```bash
+npx tsx -e "
+import {compile} from './src/index.ts';
+const r = await compile('class C extends Array {}\nexport function probe(){ return C.zzz === undefined ? 1 : 0; }',
+  {fileName:'t.js', allowJs:true, skipSemanticDiagnostics:true, sourceMap:true});
+const {instance} = await WebAssembly.instantiate(r.binary, r.importObject);
+r.importObject.__setInstance?.(instance);
+console.log(instance.exports.probe());   // expect 1; today: throws
+"
+```
+
+## Acceptance criteria
+
+1. All seven receiver rows in the table above yield `1`.
+2. `Object.getOwnPropertyNames(C)` on a builtin-derived class returns its own
+   static keys instead of throwing.
+3. The comma-sequence static-write shape (`C.a=1, C.b=C.a<<5;` at module top
+   level on a `class C extends Array`) instantiates and reads back correctly.
+4. `tests/dogfood/temporal-polyfill-harness.mjs --no-umd` advances past
+   statement 2 — i.e. the reported `moduleInitError` changes or clears. (It is
+   NOT a criterion that the whole polyfill init succeeds; later statements may
+   surface further defects, which get their own issues.)
+5. No regression in the Temporal bucket or the class/subclass equivalence
+   tests.
+
+## Notes
+
+Start at the constructor-object property-access dispatch
+(`src/codegen/property-access-dispatch.ts`) and the builtin-derived class
+paths (`src/codegen/builtin-proto-constructor.ts`,
+`src/codegen/standalone-subclass-ctors.ts`,
+`src/codegen/class-static-metadata.ts`). The working `class C extends B {}`
+case is the reference behaviour to converge on: something in the
+builtin-extends arm makes an unresolved key trap rather than fall through to
+the `undefined` result.

--- a/plan/issues/5191-builtin-derived-ctor-property-miss-throws.md
+++ b/plan/issues/5191-builtin-derived-ctor-property-miss-throws.md
@@ -1,6 +1,6 @@
 ---
 id: 5191
-title: "Reading an absent property off the constructor of a builtin-derived class throws instead of yielding undefined (blocks the Temporal polyfill's module init)"
+title: "A class extending a builtin has NO class-object singleton, so its own name evaluates to null (C == null is true; blocks the Temporal polyfill's module init)"
 status: ready
 sprint: current
 created: 2026-08-29
@@ -16,51 +16,94 @@ goal: core-semantics
 related: [4628, 661]
 ---
 
-# #5191 — property miss on a builtin-derived class constructor throws
+# #5191 — a builtin-derived class evaluates to `null` as a value
 
 ## Problem
 
-For a class whose `extends` clause names a **builtin** constructor (`Array`,
-`Error`, `Map`, …), reading a property that is not present on the *constructor
-object* throws a WasmGC exception instead of evaluating to `undefined`.
+A class whose `extends` clause names a **builtin** constructor (`Array`,
+`Error`, `Map`, …) gets **no class-object singleton**, so its own name
+evaluates to `null` whenever it is read as a first-class value:
 
 ```js
 class C extends Array {}
-C.zzz === undefined; // spec: true.  js2wasm: throws
+C == null;      // spec: false.  js2wasm: TRUE
+Boolean(C);     // spec: true.   js2wasm: FALSE
+C.zzz;          // spec: undefined. js2wasm: throws
+                //   TypeError: Cannot access property on null or undefined
 ```
 
+That last one is a *consequence*, not the defect: the property access throws
+because the receiver it loaded is `null`.
+
 Plain classes, classes derived from a **user** base, ordinary functions and
-object literals all behave correctly — so the defect is specific to the
-builtin-derived constructor object, not to expando statics in general.
+object literals are all correct — the defect is specific to builtin-derived
+classes.
 
 Measured on `origin/main` @ `279ce9a4f2`, 2026-08-29, with the test262 runner's
 compile options (`allowJs: true, skipSemanticDiagnostics: true, sourceMap:
 true`) and `WebAssembly.instantiate(result.binary, result.importObject)`:
 
-| Receiver | `C.zzz === undefined` |
-| --- | --- |
-| `class C {}` | `1` (correct) |
-| `class B {}; class C extends B {}` | `1` (correct) |
-| `function C(){}` | `1` (correct) |
-| `const C = {}` | `1` (correct) |
-| `class C extends Array {}` | **throws** |
-| `class C extends Error {}` | **throws** |
-| `class C extends Map {}` | **throws** |
+| Receiver | `C == null` (expect `false`) | `C.zzz === undefined` (expect `true`) |
+| --- | --- | --- |
+| `class C {}` | false ✓ | true ✓ |
+| `class B {}; class C extends B {}` | false ✓ | true ✓ |
+| `function C(){}` | false ✓ | true ✓ |
+| `const C = {}` | false ✓ | true ✓ |
+| `class C extends Array {}` | **true ✗** | **throws** |
+| `class C extends Error {}` | **true ✗** | **throws** |
+| `class C extends Map {}` | **true ✗** | **throws** |
 
-Two adjacent symptoms share the receiver and are almost certainly the same
-root cause:
+`Boolean(C)` is `false` for `class C extends Array {}`. Identity (`const v = C;
+v === C`) reports `true` only because `null === null`.
+
+What masks it: `typeof C === "function"` and `C.name === "C"` both answer
+correctly, and `new C()` works — those are served by static arms that never
+materialise the constructor object. So the binding looks fine until something
+reads it as a value.
+
+Adjacent symptoms, same root cause:
 
 | Shape | Result |
 | --- | --- |
 | `class C extends Array {}; C.a = 1; Object.getOwnPropertyNames(C).length` | throws **TypeError** |
 | `class C extends Array {}; C.a = 1, C.b = 2; C.b` | throws |
 
-Not affected, and useful for bisecting the dispatch: `"a" in C` returns the
-right answer, a *single* statically-paired write+read (`C.a = 1; C.a`) returns
-`1`, and the same two writes as **separate statements** (`C.a=1; C.b=2;`)
-return `2`. Only the comma-sequence form degrades — i.e. the failure appears
-once the access leaves the statically-resolved arm and reaches the generic
-constructor-object dispatch.
+Useful for bisecting: `"a" in C` answers correctly, a single statically-paired
+write+read (`C.a = 1; C.a`) returns `1`, and the same two writes as *separate
+statements* return `2`. Only shapes that leave the statically-resolved arm and
+load the constructor object as a value degrade.
+
+## Root cause — located
+
+`src/codegen/class-bodies.ts` (~L1188), where the class-object singleton is
+registered:
+
+```ts
+// (#1395) Register a class-object singleton global … Skip for
+// externref-backed builtin subclasses (#1366a) — those don't have a
+// `$ClassName` WasmGC struct.
+if (!ctx.classBuiltinParentMap.has(className)) {
+  … ctx.classObjectGlobals.set(className, classObjectGlobalIdx);
+}
+```
+
+Builtin-derived classes are deliberately excluded. The consumer,
+`emitLazyClassObjectGet` (`src/codegen/expressions/extern.ts:362`), returns
+`false` when `classObjectGlobals` has no entry — so the identifier read in
+`src/codegen/expressions/identifiers.ts:1350` falls through every subsequent
+registry and ends at a null.
+
+The exclusion is not gratuitous: `emitLazyClassObjectGet` builds the class
+object as a `struct.new` of the `$ClassName` WasmGC struct, which an
+externref-backed subclass does not have. **So the fix is not "delete the
+guard"** — it needs a different carrier for the class object on this lane.
+`src/codegen/builtin-static-globals.ts:144` ("#3006 — emit a GENUINE,
+identity-stable reified builtin-constructor object") is the closest existing
+precedent and the natural place to start.
+
+Whatever carrier is chosen has to keep `new C()`, `C.prototype`, static
+methods, `instanceof` and the standalone lane working, which is why this is
+`feasibility: hard` rather than a one-line change.
 
 ## Why it matters now
 
@@ -86,35 +129,46 @@ throws has no exports to install, and no wiring choice routes around that.
 ```bash
 npx tsx -e "
 import {compile} from './src/index.ts';
-const r = await compile('class C extends Array {}\nexport function probe(){ return C.zzz === undefined ? 1 : 0; }',
+const r = await compile('class C extends Array {}\nexport function probe(){ return C == null ? 1 : 0; }',
   {fileName:'t.js', allowJs:true, skipSemanticDiagnostics:true, sourceMap:true});
 const {instance} = await WebAssembly.instantiate(r.binary, r.importObject);
 r.importObject.__setInstance?.(instance);
-console.log(instance.exports.probe());   // expect 1; today: throws
+console.log(instance.exports.probe());   // expect 0; today: 1
 "
 ```
 
+Swap the body for `C.zzz === undefined ? 1 : 0` to see the derived symptom (a
+thrown `TypeError: Cannot access property on null or undefined`, read off the
+module's `__exn_tag` export).
+
 ## Acceptance criteria
 
-1. All seven receiver rows in the table above yield `1`.
-2. `Object.getOwnPropertyNames(C)` on a builtin-derived class returns its own
+1. `C == null` is `false` and `Boolean(C)` is `true` for every builtin base in
+   the table (`Array`, `Error`, `Map`), matching the plain-class rows.
+2. `C.zzz === undefined` is `true` for those same receivers.
+3. `Object.getOwnPropertyNames(C)` on a builtin-derived class returns its own
    static keys instead of throwing.
-3. The comma-sequence static-write shape (`C.a=1, C.b=C.a<<5;` at module top
+4. The comma-sequence static-write shape (`C.a=1, C.b=C.a<<5;` at module top
    level on a `class C extends Array`) instantiates and reads back correctly.
-4. `tests/dogfood/temporal-polyfill-harness.mjs --no-umd` advances past
+5. `tests/dogfood/temporal-polyfill-harness.mjs --no-umd` advances past
    statement 2 — i.e. the reported `moduleInitError` changes or clears. (It is
    NOT a criterion that the whole polyfill init succeeds; later statements may
    surface further defects, which get their own issues.)
-5. No regression in the Temporal bucket or the class/subclass equivalence
+6. `new C()`, `C.prototype`, static methods and `instanceof` are unregressed on
+   builtin-derived classes, on both the host and standalone lanes.
+7. No regression in the Temporal bucket or the class/subclass equivalence
    tests.
 
 ## Notes
 
-Start at the constructor-object property-access dispatch
-(`src/codegen/property-access-dispatch.ts`) and the builtin-derived class
-paths (`src/codegen/builtin-proto-constructor.ts`,
+Reference behaviour to converge on is the working `class C extends B {}` path.
+Related code besides the two sites named above:
+`src/codegen/builtin-proto-constructor.ts`,
 `src/codegen/standalone-subclass-ctors.ts`,
-`src/codegen/class-static-metadata.ts`). The working `class C extends B {}`
-case is the reference behaviour to converge on: something in the
-builtin-extends arm makes an unresolved key trap rather than fall through to
-the `undefined` result.
+`src/codegen/class-static-metadata.ts`.
+
+The `classBuiltinParentMap` guard has been there since #1366a, so this has
+presumably been wrong for every builtin-derived class since — the reason it
+went unnoticed is the masking described above (`typeof`, `.name` and `new C()`
+all answer correctly). Expect the blast radius of a fix to be wider than the
+Temporal bucket, in both directions.

--- a/plan/issues/5192-umd-closure-return-type-invalid-wasm.md
+++ b/plan/issues/5192-umd-closure-return-type-invalid-wasm.md
@@ -1,0 +1,91 @@
+---
+id: 5192
+title: "UMD/ES5 lane emits invalid Wasm: __closure_35 returns i32 where the type declares externref"
+status: ready
+sprint: current
+created: 2026-08-29
+updated: 2026-08-29
+priority: medium
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: closures
+goal: core-semantics
+related: [4628, 5191]
+---
+
+# #5192 — closure return-type mismatch on the ES5/UMD polyfill bundle
+
+## Problem
+
+`@js-temporal/polyfill@0.5.1`'s **UMD** bundle (`dist/index.umd.js`,
+Babel-transpiled to ES5, self-contained — jsbi is bundled in) compiles with
+**zero errors** and then emits a binary the Wasm validator rejects:
+
+```
+WebAssembly.compile(): Compiling function #470:"__closure_35" failed:
+  type error in return[0] (expected externref, got i32) @+332400
+```
+
+A synthesized closure body returns an `i32` where the closure's declared
+function type says `externref`. That is a codegen defect, not a source
+problem: the compile gate reported nothing, so the only signal is the
+validator.
+
+## Measured
+
+`origin/main` @ `279ce9a4f2`, 2026-08-29, via
+`node --import tsx tests/dogfood/temporal-polyfill-harness.mjs --no-whole`
+(the harness's UMD lane; compile options are the test262 runner's):
+
+| | |
+| --- | --- |
+| source | 242 KB, `dist/index.umd.js`, no link step needed |
+| compile | success, **0 errors / 0 warnings**, 90,724 ms |
+| binary | 1,644,531 bytes |
+| `WebAssembly.compile()` | **FAILS** — the message above |
+
+The sibling **ESM** lane (jsbi linked in by the harness, 157,541 B) compiles
+in ~21 s and **does** validate, so this is specific to the ES5-transpiled
+shape, not to the polyfill's logic.
+
+Note the two lanes fail at different gates and for different reasons — the ESM
+lane validates and then throws during module init, which is
+[#5191](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5191-builtin-derived-ctor-property-miss-throws).
+Neither issue subsumes the other.
+
+## Why it is filed separately from #4628
+
+[#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-runtime-object-spike)
+step 3 builds the `Temporal` global from the **ESM** lane. The UMD lane is not
+on that critical path; it is a second, independent shape that happens to
+exercise the ES5 downlevel output of a large real-world library, and its
+failure is a generic closure-emission bug worth fixing on its own merits.
+
+## Reproduce
+
+```bash
+node --import tsx tests/dogfood/temporal-polyfill-harness.mjs --no-whole
+# then read tests/dogfood/report/temporal-polyfill-surface.json → lanes.umd.validation
+```
+
+`--no-instantiate` skips the third gate if only the validator answer is wanted.
+
+## Acceptance criteria
+
+1. The UMD lane's binary passes `WebAssembly.compile()`.
+2. A reduced repro of the offending closure shape is added under `tests/` so
+   the class of defect is pinned, not just this one bundle.
+3. No regression in the ESM lane's compile/validate result.
+
+## Notes
+
+The failing function is a compiler-synthesized `__closure_N`, so start from the
+closure lifting / return-type computation rather than from user-visible
+lowering. `@+332400` is a byte offset into the emitted binary — dump the WAT
+(`emitWat: true`) and read the function at that offset for the exact shape.
+The ~91 s compile makes bisecting the 242 KB source by top-level-statement
+prefix expensive but viable (the same technique that located #5191 in nine
+compiles).

--- a/tests/dogfood/temporal-polyfill-harness.mjs
+++ b/tests/dogfood/temporal-polyfill-harness.mjs
@@ -27,6 +27,13 @@
 //   4. VALIDATE — WebAssembly.compile(binary). Compiling and validating are
 //                 DIFFERENT gates: #4627 is exactly a case where the first
 //                 passed and the second did not.
+//   4b. INSTANTIATE — WebAssembly.instantiate(binary). A THIRD gate, added in
+//                 #4628 step 3, for the same reason 4 exists: on 2026-08-29
+//                 the ESM lane passed 3 and 4 and still threw the instant its
+//                 module init ran. Option A installs `Temporal` from this
+//                 module's exports, so a module that never finishes init has
+//                 no exports to install and no wiring can route around it.
+//                 Disable with `--no-instantiate`.
 //   5. BUCKET   — group diagnostics by normalized rejection reason, largest
 //                 first. This list is the real artifact — a prioritized
 //                 compiler-bug backlog against a real-world library, useful
@@ -130,9 +137,9 @@ function bucketDiagnostics(errors) {
 }
 
 // ---------------------------------------------------------------------------
-// One compile+validate lane.
+// One compile + validate + instantiate lane.
 // ---------------------------------------------------------------------------
-async function measure({ label, fileName, source, log }) {
+async function measure({ label, fileName, source, log, instantiate = true }) {
   const lane = { label, fileName, sourceBytes: source.length };
 
   const t0 = performance.now();
@@ -194,6 +201,49 @@ async function measure({ label, fileName, source, log }) {
       ? `[dogfood] ${label}: WebAssembly.compile() OK — binary validates`
       : `[dogfood] ${label}: WebAssembly.compile() FAILED — ${validationError}`,
   );
+
+  // INSTANTIATE — a THIRD gate, separate from both above (#4628 step 3).
+  //
+  // The spike stopped at validate, and that left the decisive question
+  // unasked: a module can compile and validate and still throw the moment its
+  // module-init runs. It does. Option A installs `Temporal` from this module's
+  // exports, so an instantiate failure is a hard blocker — no wiring choice
+  // can route around a module that never produces exports. Reported as its
+  // own lane so a future run cannot mistake "validates" for "works".
+  if (instantiate && validates) {
+    const t1 = performance.now();
+    let instantiated = false;
+    let instantiateError = null;
+    try {
+      const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+      result.importObject?.__setInstance?.(instance);
+      instantiated = true;
+      lane.instantiation = {
+        instantiated,
+        ms: Math.round(performance.now() - t1),
+        exportCount: Object.keys(instance.exports).length,
+      };
+    } catch (e) {
+      // A module-init throw arrives as a WebAssembly.Exception whose payload
+      // needs the module's own `__exn_tag` export to read — unavailable here,
+      // because the throw happened BEFORE there is an instance. Record the
+      // shape; `.tmp` bisection is how the offending statement gets named.
+      instantiateError =
+        typeof WebAssembly !== "undefined" && e instanceof WebAssembly.Exception
+          ? "WebAssembly.Exception thrown from module init (payload unreadable: no instance, so no __exn_tag)"
+          : e instanceof Error
+            ? `${e.name}: ${e.message}`
+            : String(e);
+      lane.instantiation = { instantiated, ms: Math.round(performance.now() - t1), error: instantiateError };
+    }
+    log(
+      instantiated
+        ? `[dogfood] ${label}: WebAssembly.instantiate() OK — module init ran`
+        : `[dogfood] ${label}: WebAssembly.instantiate() FAILED — ${instantiateError}`,
+    );
+  } else {
+    lane.instantiation = { instantiated: false, skipped: instantiate ? "binary does not validate" : "lane disabled" };
+  }
 
   return lane;
 }
@@ -331,7 +381,14 @@ async function measureSlices({ source, fileName, perSlice, skip, log }) {
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
-export async function runHarness({ quiet = false, umd = true, slices = 0, skipSlices = [], whole = true } = {}) {
+export async function runHarness({
+  quiet = false,
+  umd = true,
+  slices = 0,
+  skipSlices = [],
+  whole = true,
+  instantiate = true,
+} = {}) {
   const log = quiet ? () => {} : (...a) => console.log(...a);
 
   const report = {
@@ -382,6 +439,7 @@ export async function runHarness({ quiet = false, umd = true, slices = 0, skipSl
       fileName: "temporal-polyfill.esm.mjs",
       source: linked.source,
       log,
+      instantiate,
     });
   }
 
@@ -391,6 +449,7 @@ export async function runHarness({ quiet = false, umd = true, slices = 0, skipSl
       fileName: "temporal-polyfill.umd.js",
       source: readUmdSource(setup),
       log,
+      instantiate,
     });
   }
 
@@ -398,22 +457,31 @@ export async function runHarness({ quiet = false, umd = true, slices = 0, skipSl
   const esm = report.lanes.esm ?? {
     compile: { threw: null, success: false, errorCount: null, distinctReasons: null },
     validation: { validates: false },
+    instantiation: { instantiated: false },
     compileMs: null,
   };
   report.summary = {
     headline:
-      esm.compile.threw != null
-        ? "compile() THREW on the polyfill"
-        : !esm.compile.success
-          ? `compile reported failure — ${esm.compile.errorCount} errors`
-          : esm.validation.validates
-            ? "compiled + binary validates"
-            : "compiled, but binary INVALID",
+      report.lanes.esm === undefined
+        ? "esm lane NOT RUN (--no-whole) — this summary describes no measurement"
+        : esm.compile.threw != null
+          ? "compile() THREW on the polyfill"
+          : !esm.compile.success
+            ? `compile reported failure — ${esm.compile.errorCount} errors`
+            : !esm.validation.validates
+              ? "compiled, but binary INVALID"
+              : esm.instantiation?.instantiated
+                ? "compiled + validates + module init ran"
+                : "compiled + validates, but module init THROWS",
     // The number #4628 exists to produce.
     compileErrorCount: esm.compile.errorCount,
     distinctReasons: esm.compile.distinctReasons ?? null,
     compileSuccess: esm.compile.success ?? false,
     binaryValidates: esm.validation.validates,
+    // The gate the spike never reached. `false` here means Option A is blocked
+    // no matter how the Temporal global is wired — see #4628 step 3.
+    moduleInitRuns: esm.instantiation?.instantiated ?? false,
+    moduleInitError: esm.instantiation?.error ?? null,
     compileMs: esm.compileMs,
     // #661's thresholds: <50 ship A · 50-200 staged A · >200 Option B.
     threshold661:
@@ -428,6 +496,7 @@ export async function runHarness({ quiet = false, umd = true, slices = 0, skipSl
       ? {
           compileErrorCount: report.lanes.umd.compile.errorCount,
           binaryValidates: report.lanes.umd.validation.validates,
+          moduleInitRuns: report.lanes.umd.instantiation?.instantiated ?? false,
         }
       : null,
   };
@@ -475,6 +544,7 @@ if (invokedDirectly) {
     whole: !process.argv.includes("--no-whole"),
     slices: sliceArg ? Number(sliceArg.split("=")[1] ?? 25) : 0,
     skipSlices: numListArg("--skip-slices"),
+    instantiate: !process.argv.includes("--no-instantiate"),
   });
   if (json) process.stdout.write(JSON.stringify(report) + "\n");
 }


### PR DESCRIPTION
Step 3 of [#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-runtime-object-spike) — making `Temporal` a real runtime global by compiling `@js-temporal/polyfill@0.5.1` + `jsbi@4.3.0`.

**The step is not complete and this PR does not claim it is.** `status` stays `in-progress`. What it does is replace three assumptions with measurements and name the one defect everything else waits on.

## Step 0, finally taken

The spike left the baseline re-measurement outstanding. Taken here (`fetch-baseline-jsonl.mjs --force`, 48,735 entries, 2026-08-29). The issue's headline numbers were pre-#4627 and are **superseded**:

| Bucket | Issue file said | Actually, now |
| --- | --- | --- |
| Temporal `pass` | 207 | **594** |
| `compile_error` | 1,487 | **0** |
| `Temporal is not defined` | 2,206 | **1,589** |

Every later delta claim on this issue must cite this run.

## The finding: a THIRD gate the spike never reached

Compile and validate are different gates and the spike checked both. **Instantiate is a third gate, and the polyfill fails it.** The 157 KB linked ESM bundle compiles in 21.4 s with 0 errors, validates, and then throws the instant its module init runs — so it produces *no exports at all*. No wiring choice can install a global from a module that never initialises, which is why this blocks every integration option equally rather than favouring one.

The dogfood harness now measures it (`--no-instantiate` to skip) and reports `moduleInitRuns` / `moduleInitError`, so a future run cannot read "validates" as "works".

**Root cause, isolated.** Bisecting the bundle by top-level-statement prefix (9 compiles) lands on statement 2 of 341 — `jsbi`'s static tables on `class JSBI extends Array`. Reduced to three lines:

```js
class C extends Array {}
C == null;             // spec: false. js2wasm: TRUE
C.zzz === undefined;   // spec: true.  js2wasm: throws
```

**A class extending a builtin evaluates to `null` as a value.** The property access throws only because the receiver it loaded is null. It stays hidden because `typeof C`, `C.name` and `new C()` are served by static arms that never materialise the constructor object.

Located to one line: `src/codegen/class-bodies.ts` (~L1188) skips registering the class-object singleton for `classBuiltinParentMap` members (#1366a), because `emitLazyClassObjectGet` builds that object as a `struct.new` of the `$ClassName` WasmGC struct — which an externref-backed subclass does not have. The guard is not gratuitous and the fix is not deleting it; the lane needs a different carrier. Filed with the full receiver table as [#5191](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5191-builtin-derived-ctor-property-miss-throws).

The UMD lane was run for the first time and fails the **validate** gate on an unrelated closure return-type mismatch (`__closure_35`, expected externref got i32) — filed separately as [#5192](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5192-umd-closure-return-type-invalid-wasm), deliberately not fixed here.

Also worth recording: the spike's whole-bundle **non-termination is gone** — 45+ minutes then, 21 s now.

## Decisions recorded, with the evidence

- **Integration = compile-once, never per-test.** Source-level prepend costs 21.4 s × 4,611 Temporal rows ≈ 27 h of added compile. The only viable shape is the existing package linker (content-addressed provider `.wasm` + the internal `linkedPackageBindings` import map, over the frozen cross-module recgroup). Host-injected `externref` was considered and rejected: WasmGC objects are opaque to the JS host, and injecting the untranspiled JS polyfill instead would abandon standalone mode. **None of it was implemented** — a provider whose init throws cannot be validated.
- **`temporal-native.ts` stays.** Measured, not assumed: the 594 passing rows are its, `tests/issue-661.test.ts` is 5/5 on this branch, and the polyfill path covers none of them today.
- **`Temporal` stays in `CLOSURE_UNSAFE_HOST_AMBIENTS`.** The deny list is checked *before* the generic user-source test, so the entry only becomes wrong once `Temporal` is a compiled binding. Removing it now would re-create the PR #2838 hazard (212 tests pass→fail) for no benefit. It comes out in the PR that makes the global real; `TemporalHelpers` stays regardless.

## What actually ran

- dogfood ESM lane — 0 errors / validates / **instantiate fails**
- dogfood UMD lane — 0 errors / **validate fails** (#5192)
- dogfood slice lane — 342/342 statements, 0 skipped
- `tests/issue-661.test.ts` — 5/5 pass
- 5 hand-picked Temporal rows through the runner's own `runTest262File`: `getOwnPropertyNames.js` → `Temporal is not defined`; `prop-desc.js` → `Expected SameValue(«"undefined"», «"object"»)`. These are acceptance criterion 1's own tests and they still fail — recorded, not claimed as met.
- loc / func / coercion / oracle-ratchet / dead-exports / issue-ids gates green

## Diff

Harness gains an instantiate lane (`tests/dogfood/temporal-polyfill-harness.mjs`); the rest is issue files. No `src/` change.

Note on issue ids: #5191/#5192 were reserved with `--allow-unscanned` (gh unavailable in the agent container, open-PR scan degraded); the required `check:issue-ids:against-main` gate arbitrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_