### PR TITLE
docs: correct the #5187 root cause; bank #5183 instances and queue-edit-window rules

### DIFF
--- a/plan/issues/5183-merge-queue-lands-prs-from-failed-groups.md
+++ b/plan/issues/5183-merge-queue-lands-prs-from-failed-groups.md
@@ -89,3 +89,28 @@ regression got in and STAYED in through three consecutive red groups.
 Found during the #5173/#5209 park post-mortem (see that issue's §7 for the
 full evidence chain). The regression itself is owned separately (dev lane on
 the stack-balance family + #5180); do not fold that fix in here.
+
+## Additional instances (2026-08-29 morning)
+
+- **#5220** merged out of a failed group (its `Test262 Sharded` group run
+  33238916982 concluded `failure` at 06:57; the PR merged anyway).
+- **#5223** merged at ~10:21 out of a failed group (group run 33245241857,
+  `failure` at 09:38) **while carrying the auto-park `hold` label** — the
+  same hold-does-not-gate shape as #5216's instance.
+
+## Process rules from the #5229/#5237 collision post-mortem (2026-08-29)
+
+1. **The window to edit a green PR closes the moment `auto-enqueue` picks it
+   up** — about one workflow-startup after the last required check goes
+   green. A frontmatter edit that might collide with another open PR has to
+   come out *before* the PR goes clean; after enqueue, GH006 blocks the
+   branch until ejection.
+2. **Queue membership is not observable from refs.** A
+   `gh-readonly-queue/main/pr-N-…` ref marks only the entry *currently
+   building*; queued-but-waiting entries have no ref and are push-blocked
+   identically. The reliable membership signals are the GH006 rejection
+   itself and the queue API — never infer "not queued" from a missing build
+   ref.
+3. **`enable_pr_auto_merge`-style API calls are silent no-ops on a PR that is
+   already `CLEAN`** in this merge-queue repo — verify a queue entry exists
+   (sweep log or queue API) instead of trusting the call's success message.

--- a/plan/issues/5187-regexp-exec-index-wrong-after-5204.md
+++ b/plan/issues/5187-regexp-exec-index-wrong-after-5204.md
@@ -1,7 +1,8 @@
 ---
 id: 5187
-title: "RegExp exec result `.index` reads 0 instead of the match offset — ~224 test262 regressions from #5204"
-status: ready
+title: "A WasmGC carrier names a receiver for members it does not have — array expando reads return null (#5204)"
+status: in-review
+pr: 5237
 sprint: current
 created: 2026-08-29
 updated: 2026-08-29
@@ -11,7 +12,7 @@ feasibility: medium
 task_type: bugfix
 area: codegen
 goal: core-semantics
-related: [5180, 5204, 5216, 2547]
+related: [5180, 5190, 5204, 5216, 2547]
 ---
 
 > **Note on the id:** this is issue **#5187**, allocated by
@@ -19,79 +20,96 @@ related: [5180, 5204, 5216, 2547]
 > it collides by name with **PR #5187** (the #4644 fix, unrelated). Link to this
 > issue by slug, not by bare `#5187`.
 
-# #5187 — `/re/.exec(s).index` is 0 for every match
+# #5187 — an expando property on an array reads back `null`
 
 ## Problem
 
 ```js
-var m = /b/.exec("abc");
-m.index          // wasm: 0     node: 1
+var a = ["1"];
+a.foo = 7;
+a.foo          // wasm: null    node: 7
 ```
 
-Measured on plain `origin/main` (`ddab1b0743`, scratch worktree) and on
-`origin/issue-5178-method-return-struct-type`. Compiles clean, runs, returns the
-wrong number — no diagnostic, no trap.
+Compiles clean, runs, returns the wrong value — no diagnostic, no trap.
+Verified on `origin/main` and on `origin/issue-5178-method-return-struct-type`.
 
-## Why this matters now
+## Root cause (dev-5180)
 
-It is the **largest single runtime cluster** in the merge-group regression that
-auto-parked PRs #5169/#5178/#5216 (run
-[33236737382](https://github.com/loopdive/js2/actions/runs/33236737382),
-`hold` + `auto-park-bot:merge-group-failure`):
+#5204's carrier-name fallback in `resolveStructNameForExpr`
+(`src/codegen/property-access.ts:1147`) names a receiver by **the WasmGC carrier
+it lowers to**. A JS array lowers to `__vec_<elem>`, whose only fields are
+`length` and `data`. So the *read* of `a.foo` was diverted onto the struct path
+while the *write* stayed dynamic — the value is stored in the expando side
+table and read from a struct that never had the field.
+
+Fix (**PR #5237**): a carrier may name the receiver only for a member it
+actually **has**.
+
+**Dead end, recorded so nobody repeats it:** screening by *name* instead
+(`isSyntheticStructName`) fixes arrays and **breaks `__regexp_match_vec`**.
+Measured by dev-5180, not assumed.
+
+## Correction — this issue's original diagnosis was wrong
+
+It was first filed as *"RegExp exec result `.index` reads 0 instead of the match
+offset"*. That framing was wrong and is kept here rather than quietly rewritten,
+because the way it went wrong is reusable:
+
+* The test262 assertion text names `__executed.index`, so the failing side
+  looked like the exec result. The fixture is
+  `__expected = ["1"]; __expected.index = 0;` — **the null was on the
+  `__expected` side**, an ordinary array expando. Reading the assertion message
+  as if it named the broken operand is what produced a RegExp-shaped hypothesis
+  for a bug with no RegExp in it.
+* My own probe (`/b/.exec("abc").index` → `0`) *was* a real defect, but a
+  **different** one — see #5190 below. Two symptoms from the same commit landing
+  in one probe made a single cause look confirmed.
+
+The bisect in the original file stands and is unchanged: correct at
+`fc6fd3b5f3` and `4dfedbdc92` (#5203 is clean), broken at `523bd0428b`
+(**#5204**). #5204 introduced *at least three* distinct defects: #5180, this
+one, and #5190.
+
+## Not fixed here — the host-lane exec result (#5190)
+
+Exec-result `.index` / `.input` in the **host** lane is a separate, unlocalized
+defect: correct before #5204, a constant `0` on main (so index-0 matches pass by
+accident), and `NaN` with #5237 applied. Standalone is correct throughout. With
+#5237 the cluster rows get past `.index` and stop at `__executed.input`.
+
+Filed as **#5190**, with dev-5180's failed localization attempts recorded there
+(a per-file revert scan over all 71 files of `8f161cbf15`, run on the coherent
+tree at that commit, flips nothing; ten files crash when reverted alone and also
+when reverted together; the property-access pair reverted together still gives
+`NaN`). Next method suggested there: per-hunk reverts inside the coupled ten, or
+a WAT diff of the reading function.
+
+## Effect on the merge-group park
+
+Context for the auto-park of #5169/#5178/#5216 (run
+[33236737382](https://github.com/loopdive/js2/actions/runs/33236737382)), from
+that run's own artifact — 931 non-timeout regressions, fine-gate net **-876**:
 
 | cluster | count | cause |
 | --- | --- | --- |
-| `pass → compile_error … struct field index out of range` | **595** | #5180 — fixed by PR #5223 |
-| `pass → fail … __executed.index is expected to equal …` | **224** | **this issue — NOT fixed by #5223** |
-| `pass → fail … __split.constructor is expected to equal …` | 65 | separate + older, see below |
+| `pass → compile_error … struct field index out of range` | 595 | #5180 — PR #5223 |
+| `pass → fail … __executed.index is expected to equal …` | 224 | **this issue** (the `__expected` side) + #5190 |
+| `pass → fail … __split.constructor is expected to equal …` | 65 | older, predates this window |
 | everything else | ~47 | — |
 
-Totals from the run's own artifact (`test262-regressions-detail.txt`, artifact
-9710358902), 931 non-timeout regressions, fine-gate net **-876**.
+**None of these were caused by the three parked PRs** — both dominant clusters
+reproduce on plain `main`.
 
-**None of these are caused by the three parked PRs.** Both dominant clusters
-reproduce on plain `main`. The queue is parking PRs for defects `main` already
-carries; the baseline they are diffed against still records these tests as
-`pass`.
+## Measured effect of PR #5237
 
-## Attribution — bisected, not guessed
-
-The 5-line repro above makes bisection cheap (the #5180 investigation could not
-bisect only because its repro was the 157 KB polyfill bundle):
-
-| revision | `.index` |
-| --- | --- |
-| `fc6fd3b5f3` (#5196) | **1** — correct |
-| `4dfedbdc92` (#5203, ES2015 standalone) | **1** — correct, #5203 is clean |
-| `523bd0428b` (**#5204**, `claude/pr-5183-fix-osgkt9`) | **0** — broken |
-| `ddab1b0743` (current main) | **0** — broken |
-
-So **#5204 introduced two distinct defects**: #5180 (the `__Date` field-metadata
-drift, fixed by #5223) and this one. Verified separately that applying #5223's
-fix (`structGrowsWithMetadata` guard + helper) to a tree containing #5204 leaves
-`.index` at 0 — **#5223 does not fix this**, so closing #5180 must not be read
-as closing the park.
-
-## The `.constructor` cluster is NOT this bug
-
-`"a,b".split(",").constructor === Array` is already `false` at `fc6fd3b5f3`, so
-those 65 regressions predate this window and have a different cause. Recorded
-here so the next investigator does not fold them in; they need their own probe
-(the probe used here is coarse — the test262 cases compare against a species
-constructor, not `Array`, so confirm before filing).
-
-## Reproduce
-
-```js
-// .tmp/probe.mjs — compile with { allowJs: true, skipSemanticDiagnostics: true },
-// instantiate, compare against node.
-var __executed = /b/.exec("abc");
-console.log("index=" + __executed.index);
-```
+dev-5180's A/B over 252 rows (String/match, RegExp/Symbol.match, Array/concat,
+RegExp/exec): pass **146 → 151, net +5**. Six fixed (`S15.5.4.10_A2_T*`), one
+broken — `regexp-builtin-exec-v-u-flag.js`, which was passing by luck.
 
 ## Acceptance
 
-* `/b/.exec("abc").index === 1` in compiled output.
-* The `__executed.index` cluster clears from the merge-group regression diff.
-* A regression test asserting the value, not just a clean compile — this bug
+* `var a = ["1"]; a.foo = 7; a.foo === 7` in compiled output.
+* A regression test asserting the **value**, not just a clean compile — this bug
   produces a valid module and a wrong answer.
+* The `__executed.index` cluster clears once #5190 lands too; #5237 alone moves
+  it to `__executed.input`.


### PR DESCRIPTION
Docs-only follow-up to PR #5229, which landed the [#5187](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5187-regexp-exec-index-input-null) issue file with a root cause that has since been disproven.

## Changes

- **Correct [#5187](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5187-regexp-exec-index-input-null)'s root cause** (cherry-picked from the blocked `docs-5180-5187-followups` correction commit): it is not RegExp at all — #5204's carrier-name fallback diverted array-expando *reads* onto the struct path (`var a = ["1"]; a.foo = 7; a.foo` → `null`); the test fixture's null was on `__expected`, not the exec result. The fix for this half is PR #5237; the residual host-lane `.index` defect is [#5190](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5190-exec-result-index-read-host-lane).
- **Bank two more [#5183](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5183-merge-queue-lands-prs-from-failed-groups) instances**: #5220 merged out of a failed group; #5223 merged out of a failed group *while hold-labeled*.
- **Record three queue process rules** from today's collision post-mortem: the green-PR edit window closes at auto-enqueue pickup; queue membership is not observable from `gh-readonly-queue` refs; auto-merge API calls silently no-op on CLEAN PRs here.

No `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_