### PR TITLE
docs(issues): file #5203 (init-window static dispatch) and #5204 (bridge f64 params)

### DIFF
--- a/plan/issues/5203-init-window-static-method-closure-wrap.md
+++ b/plan/issues/5203-init-window-static-method-closure-wrap.md
@@ -1,0 +1,78 @@
+---
+id: 5203
+title: Dynamic static-method dispatch during module init — `_wrapForHost` needs exports, so `JSBI.__clz30(t)` throws in the init window
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: standalone-gap
+feasibility: hard
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-29
+---
+
+# #5203 — init-window dynamic static-method dispatch (closure/`_wrapForHost` facet)
+
+## Problem
+
+Fifth Temporal module-init blocker (#4628 Option A). With #5191 (merged),
+#5193 (PR #5252), #5201 (PR #5256) and #5202 (PR #5258) applied, the
+polyfill bundle advances past `__clzmsd` and stops at:
+
+```
+TypeError: __clz30 is not a function
+```
+
+`jsbi.mjs` calls `JSBI.__clz30(t)` — a STATIC method on the builtin-derived
+class, reached dynamically — during module init. `moduleInitRuns` stays
+`false`.
+
+## Reduced repro (from dev-5202, with after-init control)
+
+```ts
+class D extends Array {
+  constructor(n: number) { super(n); }
+  static clz(): number { return 9; }
+}
+function g(c: any): number { return c.clz(); }
+const A: number = g(D);                              // THROWS: clz is not a function
+export function test(): number { return g(D); }      // 9 — the control
+```
+
+Same family as #5193/#5202 (works after init, throws during it), different
+surface: a static reaches the host as a raw closure struct in the
+`__register_class_static_method` sidecar, and `_wrapForHost` needs `exports`
+to turn it into a callable — the CLOSURE facet, not the dispatch-export
+facet #5202 closed. Statically-resolved static calls (`D.clz()` written
+directly) already work at init and are unaffected.
+
+## Direction
+
+Extend the #5193/#5202 start-exports channel to whatever export(s)
+`_wrapForHost` needs, OR route init-window closure wrapping through the
+registered funcrefs. Caution from dev-5202: `_wrapForHost`'s export argument
+feeds a lot of unrelated behaviour — widening it deserves its own
+measurement; keep the late path untouched and standalone/WASI out of scope.
+
+## Acceptance criteria
+
+1. Reduced repro above: `A === 9` at init, control still 9; new
+   tests/issue-5203-*.test.ts failing on base (= the #5202 stack), passing
+   with fix.
+2. Temporal harness advances past `__clz30` on a probe tree with
+   #5252+#5256+#5258+this. New later blocker → file it (coordinator
+   allocates ids); `moduleInitRuns` true → say so LOUDLY.
+3. No regressions in issue-5193/5201/5202 test files + scoped
+   static-method/class runs (name them). Gates green.
+
+## Notes
+
+- Blocker chain: #5191 → #5193 → #5201 → #5202 → this.
+- Stack on PR #5258's branch (issue-5202-init-window-prototypes) —
+  sanctioned predecessor-stacking; lands after #5252 and #5258.
+- Sibling issue #5204 covers the NON-timing parameter-bridge gap that will
+  hit right after this (methods with arguments).
+- Id #5203 reserved with a degraded PR scan (gh offline); manually verified
+  against open PR head branches 2026-08-29. `check:issue-ids:against-main`
+  arbitrates.

--- a/plan/issues/5204-host-class-bridge-f64-params.md
+++ b/plan/issues/5204-host-class-bridge-f64-params.md
@@ -1,0 +1,66 @@
+---
+id: 5204
+title: Builtin-derived methods with arguments, rest params, and getters never bridge to the host — supportsHostClassBridgeParam rejects f64
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: standalone-gap
+feasibility: hard
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-29
+---
+
+# #5204 — host class bridge rejects f64 parameters (NOT a timing issue)
+
+## Problem
+
+On a builtin-derived class (`class D extends Array`), instance members
+beyond zero-arg methods never work through the host dispatch path — at init
+time AND after init (measured by dev-5202 with after-init-only controls on
+base, so this is pre-existing and NOT the #5193/#5202/#5203 timing window):
+
+- a method taking arguments (`add(x: number, y: number)`) →
+  `add is not a function`;
+- a rest-param method (`sum(...xs: number[])`) → `sum is not a function`;
+- a getter (`get g()`) → reads `NaN`.
+
+## Mechanism (located by dev-5202)
+
+`emitExternrefClassMethodDispatch` publishes the class-qualified bridge only
+when every parameter passes `supportsHostClassBridgeParam`, and an `f64`
+parameter does not pass. jsbi's `__clzmsd()` is zero-arg, which is why the
+Temporal harness got past it — but the next jsbi instance method with
+arguments will hit this, so it sits directly on the #4628 critical path
+behind #5203.
+
+## Direction
+
+Teach the host class bridge to marshal `f64` (and the rest-param vec)
+parameters — the generic host-call marshalling for free functions already
+handles numbers, so the gap is likely the bridge's parameter-type allowlist
+plus the call-site coercion, not new marshalling machinery. Getters need
+the `__call_get_*` surface to accept the same widening. Decide with
+evidence; measure the allowlist's other rejections while there and record
+which remain (don't widen speculatively beyond f64/rest/getter).
+
+## Acceptance criteria
+
+1. New tests/issue-5204-*.test.ts: `add(x,y)`, `sum(...xs)`, `get g()` on
+   `class D extends Array`, host lane, at-init AND after-init, failing on
+   base, passing with fix.
+2. Temporal harness measured before/after on the full stack
+   (#5252+#5256+#5258+#5203-fix+this) — record where init stops.
+3. No regressions in the issue-5191/5201/5202 test files + scoped class
+   method runs (name them). Gates green.
+
+## Notes
+
+- Blocker chain context: #5191 → #5193 → #5201 → #5202 → #5203 (timing) →
+  this (capability). Both #5203 and this are expected to be needed before
+  `moduleInitRuns` flips true.
+- Id #5204 reserved with a degraded PR scan (gh offline); manually verified
+  against open PR head branches 2026-08-29. Note: PR #5204 (the selfhost
+  PR) shares the number — unrelated; ids and PR numbers share one sequence.
+  `check:issue-ids:against-main` arbitrates.


### PR DESCRIPTION
Files the fifth Temporal module-init blocker and its known successor, both found by the #5202 lane while validating PR #5258:

- [#5203](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5203-init-window-static-method-closure-wrap) — `JSBI.__clz30(t)`: dynamic STATIC-method dispatch during module init throws; a static reaches the host as a raw closure struct and `_wrapForHost` needs exports — the closure facet of the #5193 timing window (the dispatch-export facet was closed by #5202/PR #5258).
- [#5204](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5204-host-class-bridge-f64-params) — pre-existing, NOT timing: `supportsHostClassBridgeParam` rejects `f64`, so builtin-derived methods with arguments, rest-param methods, and getters never bridge to the host at all. jsbi's zero-arg `__clzmsd` slipped past it; the next jsbi method with arguments won't.

Blocker chain: #5191 → #5193 (PR #5252) → #5201 (PR #5256) → #5202 (PR #5258) → #5203 → #5204. Gates [#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-runtime-object-spike) Option A.

Ids reserved with a degraded PR scan (gh offline); manually verified against open PR head branches. `check:issue-ids:against-main` arbitrates.

Docs-only: two issue files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_