### PR TITLE
fix(codegen): fail closed for unsupported Proxy spreads

### DIFF
--- a/plan/issues/5122-es2015-proxy-symbol-targets.md
+++ b/plan/issues/5122-es2015-proxy-symbol-targets.md
@@ -1,7 +1,7 @@
 ---
 id: 5122
 title: "ES2015 standalone Proxy rejects Symbol target and handler"
-status: in-progress
+status: in-review
 sprint: current
 created: 2026-08-28
 updated: 2026-08-30
@@ -16,7 +16,7 @@ language_feature: proxy-constructor-validation
 goal: standalone-mode
 assignee: "ttraenkler/codex/5122-proxy-spread-regression-main"
 branch: codex/5122-proxy-spread-regression-main
-pr: 5138
+pr: 5270
 related: [5131]
 files:
   - src/codegen/expressions/new-builtin-globals.ts
@@ -296,18 +296,20 @@ the ordinary/static ordering and sibling matrix in both modes, the canonical
 host dynamic/nested-spread controls, and the standalone fail-closed controls.
 TypeScript 5 and TypeScript 7 no-emit checks passed. Numeric-local parity passed
 **18/18**. Focused Biome and Prettier checks, LOC/function budgets,
-oracle/coercion ratchets, issue integrity, and the full commit-hook changed-root
-suite also passed. The remaining complete pre-push gate and final follow-up PR
-audit must pass before this issue can move to `done`.
+oracle/coercion ratchets, issue integrity, the full commit-hook changed-root
+suite, and the complete pre-push chain also passed.
 
 ## Handoff
 
 Continue only in
 `/private/tmp/js2-es2015-proxy-spread-regression-20260830` on branch
-`codex/5122-proxy-spread-regression-main`. The current synchronized local head
-is `0055e7cf6866e54cc1e3a74cf699eb65c5748364`; the issue update remains
-uncommitted while the full gate runs. Open one new non-draft upstream fix PR
-from `ttraenkler/js2` only when the branch is fully validated and mergeable.
-If a gate exposes an actual blocker, publish that checkpoint as draft and state
-the blocker explicitly. Do not create a GitHub issue; this markdown file remains
-the canonical tracker.
+`codex/5122-proxy-spread-regression-main`. The implementation checkpoint is
+`0055e7cf6866e54cc1e3a74cf699eb65c5748364`; the first published combined head
+is `86494ad1c16d4f38c7c92a4cd9879a670e770eca`, and local/fork heads were
+verified equal before publication. The non-draft upstream follow-up is PR 5270:
+<https://github.com/loopdive/js2/pull/5270>. Its live audit confirms base
+`loopdive/js2:main`, head
+`ttraenkler:codex/5122-proxy-spread-regression-main`, the required
+Description/CLA body, and a checked CLA box. CI and merge-queue validation are
+now the remaining blockers to `done`; freeze the exact head once queued. Do not
+create a GitHub issue; this markdown file remains the canonical tracker.

--- a/plan/issues/5122-es2015-proxy-symbol-targets.md
+++ b/plan/issues/5122-es2015-proxy-symbol-targets.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone Proxy rejects Symbol target and handler"
 status: in-progress
 sprint: current
 created: 2026-08-28
-updated: 2026-08-28
+updated: 2026-08-30
 priority: high
 horizon: s
 feasibility: medium
@@ -14,8 +14,8 @@ area: codegen
 es_edition: ES2015
 language_feature: proxy-constructor-validation
 goal: standalone-mode
-assignee: "ttraenkler/codex/5122-es2015-proxy-symbol-targets"
-branch: codex/5122-es2015-proxy-symbol-targets
+assignee: "ttraenkler/codex/5122-proxy-spread-regression-main"
+branch: codex/5122-proxy-spread-regression-main
 pr: 5138
 related: [5131]
 files:
@@ -261,15 +261,53 @@ external remote-head verification.
   files was changed by this fix, and no host import is emitted by standalone
   controls.
 
+## Current-main regression repair (2026-08-30)
+
+Upstream PR 5138 merged its initial implementation at published head
+`772dd0a24ffd30cff0a2cc8995632416b28e3c22`. The later independent review found
+that its Proxy-specific dynamic-spread loop exposed the permissive internal
+iterator bridge as ECMAScript spread. That is a landed correctness regression,
+so the bounded fail-closed repair is a separate follow-up fix rather than a
+continuation of the already-merged PR.
+
+The shared upstream reference was force-refreshed from `loopdive/js2` on
+2026-08-30 to `4881206ab3001505fcfca875589aff8daf375ff9`. A Git patch-equivalence
+audit (`git cherry -v upstream/main HEAD`) identified
+`d37893746de821ec9363d5fcdea31aa038040b4f` as the sole reviewed repair not
+already represented on main. Replaying that commit onto a fresh branch from
+the exact upstream head was conflict-free and produced synchronized checkpoint
+`0055e7cf6866e54cc1e3a74cf699eb65c5748364`. The replayed commit now carries
+the repository-required `Model: Codex GPT-5.6 Luna Max` attribution in addition
+to the Thomas author identity and real Codex co-author trailer.
+
+The repair removes the permissive `__iterator`/`__iterator_next` route from
+Proxy ArgumentListEvaluation. Host-mode dynamic and nested spreads use the
+canonical strict materializer; standalone reports a sticky compile error for
+those still-unsupported shapes before emitting a partial body. Ordinary and
+statically flattenable array-literal spreads retain complete source-order
+evaluation, Symbol validation, trap suppression, and zero-import native
+behavior.
+
+Focused validation on the synchronized checkpoint used the pinned QuickJS
+artifact and at most two workers: `vitest run
+tests/issue-5122-es2015-proxy-symbol-targets.test.ts --maxWorkers=2` passed
+**10/10**. That includes both exact Test262 rows in host and standalone modes,
+the ordinary/static ordering and sibling matrix in both modes, the canonical
+host dynamic/nested-spread controls, and the standalone fail-closed controls.
+TypeScript 5 and TypeScript 7 no-emit checks passed. Numeric-local parity passed
+**18/18**. Focused Biome and Prettier checks, LOC/function budgets,
+oracle/coercion ratchets, issue integrity, and the full commit-hook changed-root
+suite also passed. The remaining complete pre-push gate and final follow-up PR
+audit must pass before this issue can move to `done`.
+
 ## Handoff
 
-Work only in `/private/tmp/js2-es2015-proxy-symbol-targets-20260828` on branch
-`codex/5122-es2015-proxy-symbol-targets`. PR 5138 is draft, its current
-published head is `e75f7311aee6ebcec493737fcac5c0cd0de9b845`, and it is
-explicitly outside the merge queue. The uncommitted focused-test additions in
-this worktree are review evidence for the strict matrix; their cases have been
-preserved in markdown issue 5131. Remove those uncommitted strict-only additions
-with `apply_patch`, retain bounded fail-closed controls owned here, and implement
-the scope decision above. Do not publish a source checkpoint or change PR state
-until the focused current-main matrix and independent review pass. Do not create
-a GitHub issue; this markdown file remains the canonical tracker.
+Continue only in
+`/private/tmp/js2-es2015-proxy-spread-regression-20260830` on branch
+`codex/5122-proxy-spread-regression-main`. The current synchronized local head
+is `0055e7cf6866e54cc1e3a74cf699eb65c5748364`; the issue update remains
+uncommitted while the full gate runs. Open one new non-draft upstream fix PR
+from `ttraenkler/js2` only when the branch is fully validated and mergeable.
+If a gate exposes an actual blocker, publish that checkpoint as draft and state
+the blocker explicitly. Do not create a GitHub issue; this markdown file remains
+the canonical tracker.

--- a/src/codegen/expressions/new-builtin-globals.ts
+++ b/src/codegen/expressions/new-builtin-globals.ts
@@ -38,7 +38,6 @@ import { coerceType, compileArrowAsClosure, compileExpression } from "../shared.
 import type { InnerResult } from "../shared.js";
 import { compileStringLiteral } from "../string-ops.js";
 import { coerceType as coerceTypeImpl } from "../type-coercion.js";
-import { ensureNativeIteratorRuntime } from "../iterator-native.js";
 import { ensureDateDaysFromCivilHelper, ensureDateFormatStringHelper, ensureDateStruct } from "./builtins.js";
 import { emitStandaloneDateTimestamp } from "../standalone-clock-capability.js";
 import { emitObjectCoercion } from "./calls-guards.js";
@@ -62,6 +61,7 @@ import {
 } from "./new-super.js";
 import { tryEmitStandaloneDateCtorValueArg } from "../date-ctor-value-arg.js"; // (#5156) §21.4.2.2 step 4
 import { emitStandaloneBooleanConstructorValue } from "./standalone-primitive-tail.js";
+import { reportError } from "../context/errors.js";
 
 /** Sentinel: the `new` target is not one of the built-in global constructors. */
 export const NEW_GLOBAL_FALLTHROUGH = Symbol("new-builtin-global-fallthrough");
@@ -172,9 +172,10 @@ function nativeProxyArgsMayCarrySymbol(ctx: CodegenContext, args: readonly ts.Ex
 /**
  * Mirror the existing static call/new spread fast path: direct array-literal
  * spreads can be flattened without materializing an intermediate iterable.
- * A non-literal source stays on the iterator path; nested spread elements are
- * intentionally retained for that path, matching the canonical one-level
- * call-argument flattener.
+ * A non-literal source returns `null`; the host arm selects the canonical
+ * strict materializer and the standalone arm declines the Proxy-specific
+ * native path until the strict provider from #5131 exists. Nested spread
+ * elements are retained and likewise declined by the standalone arm.
  */
 function flattenProxyArguments(args: readonly ts.Expression[]): ts.Expression[] | null {
   const flattened: ts.Expression[] = [];
@@ -194,22 +195,19 @@ interface ExpandedProxyArgumentLocals {
   handler: number;
   count: number;
   value: number;
-  source: number;
-  iterator: number;
-  done: number;
+  cleanup: readonly number[];
 }
 
 /**
- * Emit Proxy's full ArgumentListEvaluation for a call containing a spread.
+ * Emit Proxy's full ArgumentListEvaluation for a statically flattened spread.
  *
- * A SpreadElement contributes zero or more positional values. Drive every
- * spread through the iterator protocol used by for-of and array spread,
- * retaining only the first two expanded values while evaluating all the rest.
- * The caller resolves the Proxy provider after this emitter has finished, so
- * late imports registered by argument expressions cannot stale that call.
+ * `flattenProxyArguments` has already removed every direct array-literal
+ * SpreadElement, so this helper only evaluates ordinary expressions. Keeping
+ * this path separate from the generic iterator provider is deliberate: the
+ * native iterator bridge has an internal flattenable fallback and is not an
+ * ECMAScript spread implementation.
  */
 function emitExpandedProxyArguments(
-  ctx: CodegenContext,
   fctx: FunctionContext,
   args: readonly ts.Expression[],
   compileValue: (arg: ts.Expression) => void,
@@ -218,11 +216,110 @@ function emitExpandedProxyArguments(
   const handlerLocal = allocTempLocal(fctx, { kind: "externref" });
   const countLocal = allocTempLocal(fctx, { kind: "i32" });
   const valueLocal = allocTempLocal(fctx, { kind: "externref" });
-  const sourceLocal = allocTempLocal(fctx, { kind: "externref" });
-  const iteratorLocal = allocTempLocal(fctx, { kind: "externref" });
-  const doneLocal = allocTempLocal(fctx, { kind: "i32" });
 
   // Missing target/handler use the same nullish carrier as the ordinary path.
+  fctx.body.push(
+    { op: "ref.null.extern" },
+    { op: "local.set", index: targetLocal },
+    { op: "ref.null.extern" },
+    { op: "local.set", index: handlerLocal },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: countLocal },
+  );
+
+  const captureValue = (): Instr[] => [
+    { op: "local.get", index: countLocal },
+    { op: "i32.const", value: 0 },
+    { op: "i32.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: valueLocal },
+        { op: "local.set", index: targetLocal },
+      ],
+      else: [
+        { op: "local.get", index: countLocal },
+        { op: "i32.const", value: 1 },
+        { op: "i32.eq" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: valueLocal },
+            { op: "local.set", index: handlerLocal },
+          ],
+          else: [{ op: "local.get", index: valueLocal }, { op: "drop" }],
+        },
+      ],
+    },
+    { op: "local.get", index: countLocal },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: countLocal },
+  ];
+
+  for (const arg of args) {
+    // The caller proves this invariant before selecting the helper. Keep a
+    // defensive skip rather than treating an unsupported spread as one value;
+    // unsupported dynamic cases are rejected before any body is emitted.
+    if (ts.isSpreadElement(arg)) continue;
+    compileValue(arg);
+    fctx.body.push({ op: "local.set", index: valueLocal });
+    fctx.body.push(...captureValue());
+  }
+
+  return {
+    target: targetLocal,
+    handler: handlerLocal,
+    count: countLocal,
+    value: valueLocal,
+    cleanup: [valueLocal, countLocal, handlerLocal, targetLocal],
+  };
+}
+
+/**
+ * Emit Proxy ArgumentListEvaluation through the canonical host strict spread
+ * materializer. This is the host-only fallback for a non-literal or nested
+ * spread: `__array_from_iter_strict` owns ECMAScript GetIterator validation,
+ * while the ordinary externref readers expose every materialized element in
+ * source order. The Proxy-specific path never calls the internal iterator
+ * bridge here.
+ */
+function emitHostCanonicalExpandedProxyArguments(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  args: readonly ts.Expression[],
+  compileValue: (arg: ts.Expression | undefined) => void,
+): ExpandedProxyArgumentLocals {
+  const targetLocal = allocTempLocal(fctx, { kind: "externref" });
+  const handlerLocal = allocTempLocal(fctx, { kind: "externref" });
+  const countLocal = allocTempLocal(fctx, { kind: "i32" });
+  const valueLocal = allocTempLocal(fctx, { kind: "externref" });
+  const sourceLocal = allocTempLocal(fctx, { kind: "externref" });
+  const iteratorLocal = allocTempLocal(fctx, { kind: "externref" });
+  const lengthLocal = allocTempLocal(fctx, { kind: "f64" });
+  const indexLocal = allocTempLocal(fctx, { kind: "f64" });
+
+  // Reserve all canonical provider imports before compiling any argument.
+  // Later source expressions can register additional imports; the terminal
+  // flush and name lookups below keep every emitted call index current.
+  const iterFn = ensureLateImport(ctx, "__array_from_iter_strict", [{ kind: "externref" }], [{ kind: "externref" }]);
+  const lengthFn = ensureLateImport(ctx, "__extern_length", [{ kind: "externref" }], [{ kind: "f64" }]);
+  const getFn = ensureLateImport(
+    ctx,
+    "__extern_get_idx",
+    [{ kind: "externref" }, { kind: "f64" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  const iterIdx = ctx.funcMap.get("__array_from_iter_strict") ?? iterFn;
+  const lengthIdx = ctx.funcMap.get("__extern_length") ?? lengthFn;
+  const getIdx = ctx.funcMap.get("__extern_get_idx") ?? getFn;
+  if (iterIdx === undefined || lengthIdx === undefined || getIdx === undefined) {
+    throw new Error("strict host spread providers were not registered");
+  }
+
   fctx.body.push(
     { op: "ref.null.extern" },
     { op: "local.set", index: targetLocal },
@@ -272,33 +369,21 @@ function emitExpandedProxyArguments(
       continue;
     }
 
-    // Evaluate the source once, obtain its iterator, and drain it before the
-    // next argument. Abrupt source/iterator steps therefore win over Proxy
-    // validation exactly as they do in JavaScript ArgumentListEvaluation.
-    const sourceType = compileExpression(ctx, fctx, arg.expression);
-    if (sourceType === null) {
-      fctx.body.push({ op: "ref.null.extern" });
-    } else if (sourceType.kind !== "externref") {
-      coerceTypeImpl(ctx, fctx, sourceType, { kind: "externref" });
-    }
+    // Evaluate the spread source once, then strictly materialize it before
+    // evaluating the following argument. This preserves both source and
+    // iterator-step ordering, including a later abrupt completion.
+    compileValue(arg.expression);
     fctx.body.push({ op: "local.set", index: sourceLocal });
     flushLateImportShifts(ctx, fctx);
-
-    const iterIdx = ctx.funcMap.get("__iterator");
-    const nextIdx = ctx.funcMap.get("__iterator_next");
-    if (iterIdx === undefined || nextIdx === undefined) {
-      // The iterator runtime/imports are registered before this helper. Keep a
-      // defensive index-space-frozen fallback that still evaluates the source
-      // and preserves the old one-positional behavior without invalid Wasm.
-      fctx.body.push({ op: "local.get", index: sourceLocal }, { op: "local.set", index: valueLocal });
-      fctx.body.push(...captureValue());
-      continue;
-    }
-
     fctx.body.push(
       { op: "local.get", index: sourceLocal },
       { op: "call", funcIdx: iterIdx },
       { op: "local.set", index: iteratorLocal },
+      { op: "local.get", index: iteratorLocal },
+      { op: "call", funcIdx: lengthIdx },
+      { op: "local.set", index: lengthLocal },
+      { op: "f64.const", value: 0 },
+      { op: "local.set", index: indexLocal },
       {
         op: "block",
         blockType: { kind: "empty" },
@@ -307,13 +392,19 @@ function emitExpandedProxyArguments(
             op: "loop",
             blockType: { kind: "empty" },
             body: [
-              { op: "local.get", index: iteratorLocal },
-              { op: "call", funcIdx: nextIdx },
-              { op: "local.set", index: valueLocal },
-              { op: "local.set", index: doneLocal },
-              { op: "local.get", index: doneLocal },
+              { op: "local.get", index: indexLocal },
+              { op: "local.get", index: lengthLocal },
+              { op: "f64.ge" },
               { op: "br_if", depth: 1 },
+              { op: "local.get", index: iteratorLocal },
+              { op: "local.get", index: indexLocal },
+              { op: "call", funcIdx: getIdx },
+              { op: "local.set", index: valueLocal },
               ...captureValue(),
+              { op: "local.get", index: indexLocal },
+              { op: "f64.const", value: 1 },
+              { op: "f64.add" },
+              { op: "local.set", index: indexLocal },
               { op: "br", depth: 0 },
             ],
           },
@@ -327,9 +418,7 @@ function emitExpandedProxyArguments(
     handler: handlerLocal,
     count: countLocal,
     value: valueLocal,
-    source: sourceLocal,
-    iterator: iteratorLocal,
-    done: doneLocal,
+    cleanup: [iteratorLocal, sourceLocal, indexLocal, lengthLocal, valueLocal, countLocal, handlerLocal, targetLocal],
   };
 }
 
@@ -1143,12 +1232,24 @@ export function tryCompileBuiltinGlobalNew(
   if (ts.isIdentifier(expr.expression) && expr.expression.text === "Proxy") {
     if (ctx.standalone || ctx.targetProfile.semanticProviders === "native-first") {
       const args = expr.arguments ?? [];
+      const hasSpread = args.some((arg) => ts.isSpreadElement(arg));
+      const proxyArgs = hasSpread ? flattenProxyArguments(args) : args;
+      if (hasSpread && (proxyArgs === null || proxyArgs.some((arg) => ts.isSpreadElement(arg)))) {
+        reportError(
+          ctx,
+          expr,
+          "Proxy spread requires the strict iterator provider; dynamic and nested spreads are not available in standalone (#5131)",
+          "error",
+          { sticky: true },
+        );
+        return null;
+      }
       // `ensureNativeProxyRuntime` mints `__proxy_create` before the argument
       // expressions are visited.  Pre-register the already-supported native
       // Symbol carrier whenever the target or handler can carry one, so the
       // construction-time object classifier has a stable carrier to test even
       // when this callee is compiled before its Symbol-producing caller.
-      if (nativeProxyArgsMayCarrySymbol(ctx, args)) ensureSymbolCarrier(ctx);
+      if (nativeProxyArgsMayCarrySymbol(ctx, proxyArgs ?? args)) ensureSymbolCarrier(ctx);
       // Force the object runtime (which registers the native __proxy_create +
       // the trap dispatch helpers + the front-guards) before we look up the idx.
       ensureNativeProxyRuntime(ctx);
@@ -1194,14 +1295,8 @@ export function tryCompileBuiltinGlobalNew(
         }
       };
 
-      if (args.some((arg) => ts.isSpreadElement(arg))) {
-        const proxyArgs = flattenProxyArguments(args) ?? args;
-        // Standalone/native-first uses the native GetIterator bridge for
-        // non-literal sources (and for nested spreads retained by the
-        // canonical one-level flattener). Register it before compiling any
-        // such source so late helper registration cannot stale its calls.
-        if (proxyArgs.some((arg) => ts.isSpreadElement(arg))) ensureNativeIteratorRuntime(ctx);
-        const locals = emitExpandedProxyArguments(ctx, fctx, proxyArgs, (arg) => compileToExternref(arg));
+      if (hasSpread) {
+        const locals = emitExpandedProxyArguments(fctx, proxyArgs!, (arg) => compileToExternref(arg));
         flushLateImportShifts(ctx, fctx);
         const proxyCreateIdx = ctx.funcMap.get("__proxy_create");
         if (proxyCreateIdx !== undefined) {
@@ -1221,15 +1316,7 @@ export function tryCompileBuiltinGlobalNew(
             { op: "ref.null.extern" },
           );
         }
-        for (const local of [
-          locals.done,
-          locals.iterator,
-          locals.source,
-          locals.value,
-          locals.count,
-          locals.handler,
-          locals.target,
-        ]) {
+        for (const local of locals.cleanup) {
           releaseTempLocal(fctx, local);
         }
         return { kind: "externref" };
@@ -1290,16 +1377,12 @@ export function tryCompileBuiltinGlobalNew(
       };
 
       if (args.some((arg) => ts.isSpreadElement(arg))) {
-        const proxyArgs = flattenProxyArguments(args) ?? args;
-        // The host provider exposes the same iterator protocol as for-of. Do
-        // the registration up front for any source that remains dynamic, then
-        // resolve its indices after each source expression adds late imports.
-        if (proxyArgs.some((arg) => ts.isSpreadElement(arg))) {
-          ensureLateImport(ctx, "__iterator", [{ kind: "externref" }], [{ kind: "externref" }]);
-          ensureLateImport(ctx, "__iterator_next", [{ kind: "externref" }], [{ kind: "i32" }, { kind: "externref" }]);
-          flushLateImportShifts(ctx, fctx);
-        }
-        const locals = emitExpandedProxyArguments(ctx, fctx, proxyArgs, (arg) => compileHostProxyArg(arg));
+        const flattenedProxyArgs = flattenProxyArguments(args);
+        const isStaticSpread =
+          flattenedProxyArgs !== null && !flattenedProxyArgs.some((arg) => ts.isSpreadElement(arg));
+        const locals = isStaticSpread
+          ? emitExpandedProxyArguments(fctx, flattenedProxyArgs, (arg) => compileHostProxyArg(arg))
+          : emitHostCanonicalExpandedProxyArguments(ctx, fctx, args, (arg) => compileHostProxyArg(arg));
 
         // Emit the provider only after ArgumentListEvaluation has completed.
         let proxyIdx = ensureLateImport(
@@ -1325,15 +1408,7 @@ export function tryCompileBuiltinGlobalNew(
             { op: "ref.null.extern" },
           );
         }
-        for (const local of [
-          locals.done,
-          locals.iterator,
-          locals.source,
-          locals.value,
-          locals.count,
-          locals.handler,
-          locals.target,
-        ]) {
+        for (const local of locals.cleanup) {
           releaseTempLocal(fctx, local);
         }
         return { kind: "externref" };

--- a/tests/issue-5122-es2015-proxy-symbol-targets.test.ts
+++ b/tests/issue-5122-es2015-proxy-symbol-targets.test.ts
@@ -75,48 +75,30 @@ function laterAbrupt(): any {
   throw new Error("later extra argument");
 }
 
-function dynamicProxyArgs(): any[] {
-  order = order * 10 + 2;
-  return [mark(3), mark(4)];
-}
-
-function expectSpreadValid(args: any[]): number {
+function expectStaticSpreadValid(): number {
   try {
-    const proxy = new Proxy(...args);
+    const proxy = new Proxy(...[{}, {}]);
     return proxy === null ? 0 : 1;
   } catch (_error) {
     return 0;
   }
 }
 
-function expectSpreadTypeError(args: any[]): number {
+function expectEmptySpreadTypeError(): number {
   try {
-    new Proxy(...args);
+    new Proxy(...[]);
     return 0;
   } catch (error) {
     return error instanceof TypeError ? 1 : 2;
   }
 }
 
-function abruptSpreadIterable(): any {
-  return {
-    [Symbol.iterator](): any {
-      return {
-        next(): any {
-          order = order * 10 + 6;
-          throw new Error("iterator step");
-        },
-      };
-    },
-  };
-}
-
 function proxyCalleeBeforeSymbolCaller(target: any, handler: any): number {
   return expectTypeError(target, handler);
 }
 
-function proxyCalleeBeforeSpreadCaller(args: any[]): number {
-  return expectSpreadValid(args);
+function proxyCalleeBeforeSpreadCaller(): number {
+  return expectStaticSpreadValid();
 }
 
 function symbolCaller(): any {
@@ -132,29 +114,50 @@ export function test(): number {
   if (proxyCalleeBeforeSymbolCaller(symbolCaller(), {}) !== 1) return 3;
   if (proxyCalleeBeforeSymbolCaller({}, symbolCaller()) !== 1) return 4;
 
-  // Static and dynamic spread sources expand before Proxy validation. The
-  // dynamic helper also exercises the callee-before-caller index-shift seam.
-  if (expectSpreadValid([{}, {}]) !== 1) return 5;
-  if (expectSpreadValid([{}, {}, {}, {}]) !== 1) return 6;
-  if (expectSpreadTypeError([]) !== 1) return 34;
+  // Static array-literal spreads expand before Proxy validation. The helper
+  // call also exercises the callee-before-caller index-shift seam.
+  if (expectStaticSpreadValid() !== 1) return 5;
+  if (proxyCalleeBeforeSpreadCaller() !== 1) return 6;
+  if (expectEmptySpreadTypeError() !== 1) return 7;
   try {
-    const nestedSpread = new Proxy(...[...[{}, {}]]);
-    if (nestedSpread === null) return 35;
+    const multipleSpread = new Proxy(...[{}], ...[{}]);
+    if (multipleSpread === null) return 42;
   } catch (_error) {
-    return 36;
+    return 43;
   }
-  if (proxyCalleeBeforeSpreadCaller([{}, {}]) !== 1) return 7;
-  if (expectSpreadTypeError([Symbol(), {}]) !== 1) return 8;
-  if (expectSpreadTypeError([{}, Symbol()]) !== 1) return 9;
+  try {
+    new Proxy(...[Symbol(), {}]);
+    return 8;
+  } catch (error) {
+    if (!(error instanceof TypeError)) return 9;
+  }
+  try {
+    new Proxy(...[{}, Symbol()]);
+    return 10;
+  } catch (error) {
+    if (!(error instanceof TypeError)) return 11;
+  }
+  try {
+    new Proxy(...[, {}]);
+    return 38;
+  } catch (error) {
+    if (!(error instanceof TypeError)) return 39;
+  }
+  try {
+    new Proxy(...[{}, ,]);
+    return 40;
+  } catch (error) {
+    if (!(error instanceof TypeError)) return 41;
+  }
 
   // ArgumentListEvaluation: retain target/handler, then evaluate every extra
   // exactly once and in order before the constructor validates either value.
   order = 0;
   try {
     const proxy = new Proxy(mark(1), mark(2), mark(3), mark(4));
-    if (proxy === null || order !== 1234) return 10;
+    if (proxy === null || order !== 1234) return 12;
   } catch (_error) {
-    return 11;
+    return 13;
   }
 
   // Mixed ordinary and spread arguments preserve source evaluation order, and
@@ -162,15 +165,7 @@ export function test(): number {
   order = 0;
   try {
     const proxy = new Proxy(mark(1), ...[mark(2), mark(3)], mark(4));
-    if (proxy === null || order !== 1234) return 12;
-  } catch (_error) {
-    return 13;
-  }
-
-  order = 0;
-  try {
-    const proxy = new Proxy(mark(1), ...dynamicProxyArgs(), mark(5));
-    if (proxy === null || order !== 12345) return 14;
+    if (proxy === null || order !== 1234) return 14;
   } catch (_error) {
     return 15;
   }
@@ -182,16 +177,6 @@ export function test(): number {
     return 16;
   } catch (error) {
     if (!(error instanceof Error) || error instanceof TypeError || order !== 1234) return 17;
-  }
-
-  // The iterator itself is driven before Proxy validation; an abrupt later
-  // step wins even when the syntactic target is valid.
-  order = 0;
-  try {
-    new Proxy({}, ...abruptSpreadIterable());
-    return 18;
-  } catch (error) {
-    if (!(error instanceof Error) || error instanceof TypeError || order !== 6) return 19;
   }
 
   // Target validation precedes all handler trap reads.
@@ -206,34 +191,126 @@ export function test(): number {
   if (trapReads !== 0) return 21;
 
   trapReads = 0;
-  if (expectSpreadTypeError([Symbol(), handlerWithGetter]) !== 1) return 22;
-  if (trapReads !== 0) return 23;
+  try {
+    new Proxy(...[Symbol(), handlerWithGetter]);
+    return 22;
+  } catch (error) {
+    if (!(error instanceof TypeError)) return 23;
+  }
+  if (trapReads !== 0) return 24;
 
   // Expanded object/array/function/nested-Proxy carriers remain valid.
-  if (expectSpreadValid([{}, {}]) !== 1) return 24;
-  if (expectSpreadValid([[], {}]) !== 1) return 25;
-  if (expectSpreadValid([function spreadCallable() {}, {}]) !== 1) return 26;
+  if (expectStaticSpreadValid() !== 1) return 25;
+  try {
+    if (new Proxy(...[[], {}]) === null) return 26;
+  } catch (_error) {
+    return 27;
+  }
+  try {
+    if (new Proxy(...[function spreadCallable() {}, {}]) === null) return 28;
+  } catch (_error) {
+    return 29;
+  }
   const spreadNested = new Proxy({}, {});
-  if (expectSpreadValid([spreadNested, {}]) !== 1) return 27;
+  try {
+    if (new Proxy(...[spreadNested, {}]) === null) return 30;
+  } catch (_error) {
+    return 31;
+  }
 
   // Valid object-like siblings: ordinary object, array, callable, and nested
   // Proxy carriers remain accepted by the shared native constructor.
-  if (expectValid({}, {}) !== 1) return 28;
-  if (expectValid([], {}) !== 1) return 29;
-  if (expectValid(function callable() {}, {}) !== 1) return 30;
+  if (expectValid({}, {}) !== 1) return 32;
+  if (expectValid([], {}) !== 1) return 33;
+  if (expectValid(function callable() {}, {}) !== 1) return 34;
   const nested = new Proxy({}, {});
-  if (expectValid(nested, {}) !== 1) return 31;
+  if (expectValid(nested, {}) !== 1) return 35;
 
   // Keep the original reported blocker as a direct static regression, not
   // only through the dynamic helper above.
   try {
     const directSpread = new Proxy(...[{}, {}]);
-    if (directSpread === null) return 32;
+    if (directSpread === null) return 36;
   } catch (_error) {
-    return 33;
+    return 37;
   }
 
   return 0;
+}
+`;
+
+const DYNAMIC_SPREAD_SOURCE = `
+let order = 0;
+let trapReads = 0;
+
+function mark(value: number): any {
+  order = order * 10 + value;
+  return {};
+}
+
+function dynamicArgs(): any[] {
+  order = order * 10 + 2;
+  return [mark(3), mark(4)];
+}
+
+function invalidArgs(handler: any): any[] {
+  order = order * 10 + 6;
+  return [Symbol(), handler];
+}
+
+function abruptArgs(): any[] {
+  order = order * 10 + 6;
+  return [{}, {}];
+}
+
+function laterAbrupt(): any {
+  order = order * 10 + 7;
+  throw new Error("later extra argument");
+}
+
+export function test(): number {
+  order = 0;
+  try {
+    const proxy = new Proxy(mark(1), ...dynamicArgs(), mark(5));
+    if (proxy === null || order !== 12345) return 1;
+  } catch (_error) {
+    return 2;
+  }
+
+  trapReads = 0;
+  const handlerWithGetter: any = {
+    get get() {
+      trapReads = trapReads + 1;
+      return undefined;
+    },
+  };
+  order = 0;
+  try {
+    new Proxy(...invalidArgs(handlerWithGetter));
+    return 3;
+  } catch (error) {
+    if (!(error instanceof TypeError) || order !== 6 || trapReads !== 0) return 4;
+  }
+
+  order = 0;
+  try {
+    new Proxy({}, ...abruptArgs(), laterAbrupt());
+    return 5;
+  } catch (error) {
+    if (!(error instanceof Error) || error instanceof TypeError || order !== 67) return 6;
+  }
+  return 0;
+}
+`;
+
+const NESTED_SPREAD_SOURCE = `
+export function test(): number {
+  try {
+    const proxy = new Proxy(...[...[{}, {}]]);
+    return proxy === null ? 0 : 1;
+  } catch (_error) {
+    return 0;
+  }
 }
 `;
 
@@ -252,6 +329,35 @@ async function runControl(lane: Lane): Promise<number> {
   const { instance } = await WebAssembly.instantiate(result.binary, imports);
   imports.setInstance?.(instance);
   return Number((instance.exports as { test: () => number }).test());
+}
+
+async function runHostCanonicalSpread(source: string, fileName: string): Promise<number> {
+  const result = await compile(source, {
+    fileName,
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("\n")).toBe(true);
+  if (!result.success) return -1;
+  expect(result.imports.some((entry) => entry.name === "__array_from_iter_strict")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  return Number((instance.exports as { test: () => number }).test());
+}
+
+async function expectStandaloneSpreadFailClosed(source: string, fileName: string): Promise<void> {
+  const result = await compile(source, {
+    fileName,
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    nativeStrings: true,
+  });
+  expect(result.success).toBe(false);
+  expect(
+    result.errors.some((error) => error.message.includes("Proxy spread requires the strict iterator provider")),
+    result.errors.map((error) => error.message).join(" | "),
+  ).toBe(true);
+  expect(result.imports).toEqual([]);
 }
 
 describe("#5122 Proxy Symbol target/handler validation", () => {
@@ -285,6 +391,40 @@ describe("#5122 Proxy Symbol target/handler validation", () => {
     "passes the static/dynamic, ordering, validation, and sibling controls host-free",
     async () => {
       await expect(runControl("standalone")).resolves.toBe(0);
+    },
+    CONTROL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps a canonical strict host fallback for unsupported dynamic Proxy spread",
+    async () => {
+      await expect(runHostCanonicalSpread(DYNAMIC_SPREAD_SOURCE, "issue-5122-host-canonical-spread.ts")).resolves.toBe(
+        0,
+      );
+    },
+    CONTROL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps the canonical host fallback for nested Proxy spread",
+    async () => {
+      await expect(runHostCanonicalSpread(NESTED_SPREAD_SOURCE, "issue-5122-host-nested-spread.ts")).resolves.toBe(1);
+    },
+    CONTROL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "fails closed for non-literal Proxy spread in standalone mode",
+    async () => {
+      await expectStandaloneSpreadFailClosed(DYNAMIC_SPREAD_SOURCE, "issue-5122-standalone-dynamic-spread.ts");
+    },
+    CONTROL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "fails closed for nested Proxy spread in standalone mode",
+    async () => {
+      await expectStandaloneSpreadFailClosed(NESTED_SPREAD_SOURCE, "issue-5122-standalone-nested-spread.ts");
     },
     CONTROL_TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## Description

- Problem: merged PR #5138 routed dynamic and nested Proxy constructor spreads through the permissive internal iterator bridge, which accepts malformed iterator records and can silently change standalone behavior.
- Behavior: keep ordinary and statically flattenable array-literal Proxy arguments on the native path, use the canonical strict spread materializer in host mode, and fail closed with a sticky diagnostic for unsupported dynamic or nested standalone spreads until the strict provider is available.
- Tests: 10/10 focused Proxy tests passed, including both owned Test262 rows in host and standalone modes, ordering/trap controls, canonical host dynamic/nested spreads, standalone fail-closed behavior, and zero-import native controls.
- Quality: TypeScript 5 and 7, Biome, Prettier, LOC/function budgets, oracle/coercion ratchets, issue integrity, 18/18 numeric-local parity, commit hooks, and the complete pre-push chain passed.
- Tracking: `plan/issues/5122-es2015-proxy-symbol-targets.md` contains the implementation plan, regression evidence, and handoff. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
