### PR TITLE
fix(dataview): return canonical undefined from setters ✓

### DIFF
--- a/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
+++ b/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
@@ -265,7 +265,9 @@ implementation PR. The implementation branch is ready for root to open as a
 new non-draft PR targeting `loopdive/js2:main`, and no PR was opened by this
 worker. The implementation commit is
 `97334bd6a5659d3595e6c480e08e8a8f95d2815e`; the handoff-evidence commit below
-records this final validation, and the branch will be pushed without force for
-root to inspect. The plan checkpoint remains
+records this final validation. The normal non-force push was attempted but was
+blocked by the execution environment's external-write approval policy; the
+fork ref remains at the earlier plan checkpoint, so root must publish this
+branch with the permitted fork write. The plan checkpoint remains
 `c808092cb828e9b2abef4ef6af27d95e1d822ee1`.
 No GitHub issue was created.

--- a/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
+++ b/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
@@ -2,6 +2,7 @@
 id: 5137
 title: "ES2015 standalone DataView setter undefined result carrier"
 status: done
+pr: 5274
 sprint: current
 created: 2026-08-28
 updated: 2026-08-30
@@ -261,13 +262,12 @@ warning.
 Worktree: `/private/tmp/js2-es2015-dataview-setter-undefined-20260828`.
 Branch: `codex/5137-es2015-dataview-setter-undefined`.
 The plan-only upstream PR #5152 is merged in `upstream/main`; it is not the
-implementation PR. The implementation branch is ready for root to open as a
-new non-draft PR targeting `loopdive/js2:main`, and no PR was opened by this
-worker. The implementation commit is
-`97334bd6a5659d3595e6c480e08e8a8f95d2815e`; the handoff-evidence commit below
-records this final validation. The normal non-force push was attempted but was
-blocked by the execution environment's external-write approval policy; the
-fork ref remains at the earlier plan checkpoint, so root must publish this
-branch with the permitted fork write. The plan checkpoint remains
+implementation PR. The completed implementation is published as non-draft
+upstream PR #5274 from `ttraenkler/js2` at
+<https://github.com/loopdive/js2/pull/5274>. Root corrected the unpublished
+commit-message attribution marker without changing the trees, reran the
+focused 36/36 suite through the normal commit hooks, and then published the
+branch with the complete pre-push chain green. The final implementation commit
+is `744806b52bf7b28cdb233525fb87b8941d7e74df`; the plan checkpoint remains
 `c808092cb828e9b2abef4ef6af27d95e1d822ee1`.
 No GitHub issue was created.

--- a/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
+++ b/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
@@ -1,10 +1,11 @@
 ---
 id: 5137
 title: "ES2015 standalone DataView setter undefined result carrier"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-28
-updated: 2026-08-28
+updated: 2026-08-30
+completed: 2026-08-30
 priority: high
 horizon: s
 feasibility: easy
@@ -23,8 +24,9 @@ files:
   - tests/issue-5137-es2015-dataview-setter-undefined-carrier.test.ts
   - plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
 # Both legacy producers live in established DataView dispatch functions. The
-# intended growth is limited to the lane-correct import and invariant comments;
-# no new dispatch path or coercion vocabulary is introduced.
+# implementation also closes the exposed integer-setter edge: ToIntN/ToUintN
+# must normalize ±Infinity to zero before the existing modular byte codec.
+# No new dispatch path or runner/fixture exemption is introduced.
 loc-budget-allow:
   - src/codegen/dataview-native.ts
   - src/codegen/expressions/call-receiver-method.ts
@@ -151,8 +153,9 @@ result that is unconditionally `undefined`.
 1. Replace both semantic setter-result producers—the expression-position arm
    in `call-receiver-method.ts` and the result in `ensureDvAccessorHelper`—with
    `canonicalUndefinedExternInstrs(ctx)`, updating the adjacent invariant
-   comments. Keep statement-position setters void. Do not alter byte codecs,
-   coercion order, error order, bounds checks, or getter boxing.
+   comments. Keep statement-position setters void. In the shared integer byte
+   codec, normalize ±Infinity to zero before the existing modular conversion;
+   preserve coercion order, error order, bounds checks, and getter boxing.
 2. Add a focused regression suite that runs all fourteen exact rows in host and
    standalone modes through the maintained runner. Add direct controls that
    force the runtime-receiver/helper path and prove the returned value is
@@ -182,24 +185,76 @@ result that is unconditionally `undefined`.
 - The setter still stores the expected value, and DataView getters, direct
   typed calls, coercion/error ordering, and sibling runtime helpers regress
   neither host nor standalone behavior.
-- The implementation remains bounded to the shared result producer, focused
-  tests, and this tracker. Excluded `setUint8`, BigInt, and Float16 blockers are
-  reported as collateral only and are not silently claimed.
+- The implementation remains bounded to the two shared result producers, the
+  required integer ToIntN/ToUintN Infinity normalization exposed by the exact
+  rows, focused tests, and this tracker. Excluded `setUint8`, BigInt, and
+  Float16 blockers are reported as collateral only and are not silently
+  claimed.
 - The final non-draft PR targets `loopdive/js2:main`, originates from
   `ttraenkler/js2`, follows the repository Description/CLA body template, and
   cites this markdown issue rather than a GitHub issue.
+
+## Implementation and handoff evidence (2026-08-30)
+
+The implementation was replayed on the freshly fetched `upstream/main`
+`4881206ab3001505fcfca875589aff8daf375ff9` with a normal fast-forward merge.
+The only merge conflict was the `dataview-native.ts` import block; it was
+resolved manually by retaining upstream's `funcSignatureOf` import and the
+implementation's `canonicalUndefinedExternInstrs` import. No upstream source
+change was discarded.
+
+The two semantic setter-result producers now use
+`canonicalUndefinedExternInstrs(ctx)`: the direct expression-position arm in
+`compileReceiverMethodCall` and the runtime/reflective
+`ensureDvAccessorHelper`. Statement-position setters remain `VOID_RESULT`.
+Once that correction exposed the next assertion in the exact standalone rows,
+the shared integer setter codec also received the spec-required
+ToIntegerOrInfinity normalization: ±Infinity maps to zero before the existing
+modular `i64.trunc_sat_f64_s`/wrap path, while NaN and finite values retain their
+established behavior. This is a real codec correction required by the owned
+rows, not a test or runner exception.
+
+The focused regression suite is
+`tests/issue-5137-es2015-dataview-setter-undefined-carrier.test.ts`. It pins
+both producer routes, direct typed and widened receivers, statement position,
+missing-value NaN/zero writes, value-conversion ordering, bounds ordering,
+reflective prototype dispatch, and the full exact fourteen-row corpus. The
+value-order control uses an object `valueOf` side effect so it distinguishes
+ToIndex-before-ToNumber without incorrectly treating JavaScript argument
+expression evaluation as deferred.
+
+Fresh bounded runs used `COMPILER_POOL_SIZE=2`, Vitest's one-file/no-file
+parallelism controls, and the pinned QuickJS artifact directory
+`/private/tmp/js2-4760-promise-then/.test262-cache/quickjs-artifact-2e2d7736713beeda`
+(`libquickjs.wasm` SHA-256
+`073742801ba76347371be277f6d275488badce1df6bfb480741548ec2a279d45`):
+
+| run | exact scope | result |
+| --- | --- | --- |
+| host exact | fourteen owned rows | **14/14 pass**, 0 compile errors, 0 timeouts, 0 skips |
+| standalone exact | fourteen owned rows | **14/14 pass**, 0 compile errors, 0 timeouts, 0 skips |
+| focused full file | 7 controls + 14 host rows + 14 standalone rows + standalone repeat | **36/36 pass** in 118.73s |
+
+The focused standalone controls verified an empty Wasm import manifest. The
+exact tests reached their bodies and passed; no timeout, filter, fixture,
+oracle, or skip workaround is involved. TypeScript 5 and TypeScript 7
+typechecks, targeted Biome lint, targeted Prettier check, and `git diff
+--check` are also clean at this checkpoint. The final commit SHA and complete
+pre-push evidence will be appended after the documentation and graph updates.
+
+The adjacent regression controls for #3173, #3183, and #2872 ran with the same
+two-worker bound: **66/67 pass**. The sole failure is the pre-existing
+`#2872.test.ts` dynamic non-typed-array callee control (`expected 7, received
+NaN`); it does not execute the DataView setter producers or touch this change.
 
 ## Handoff
 
 Worktree: `/private/tmp/js2-es2015-dataview-setter-undefined-20260828`.
 Branch: `codex/5137-es2015-dataview-setter-undefined`.
-Draft upstream PR: <https://github.com/loopdive/js2/pull/5152>.
-
-The plan checkpoint is `c808092cb828e9b2abef4ef6af27d95e1d822ee1`.
-It was pushed without force after the full pre-push hook passed. The PR is
-intentionally draft because this checkpoint contains the plan and baseline,
-not the implementation.
-
-The implementation commit, exact post-fix A/B, quality evidence, upstream PR
-URL/head, and final queue state will be appended here as the work progresses.
+The plan-only upstream PR #5152 is merged in `upstream/main`; it is not the
+implementation PR. The implementation branch is ready for root to open as a
+new non-draft PR targeting `loopdive/js2:main`, and no PR was opened by this
+worker. The plan checkpoint remains `c808092cb828e9b2abef4ef6af27d95e1d822ee1`;
+the final implementation commit, push head, and pre-push result will be
+recorded here before handoff.
 No GitHub issue was created.

--- a/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
+++ b/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
@@ -239,13 +239,22 @@ The focused standalone controls verified an empty Wasm import manifest. The
 exact tests reached their bodies and passed; no timeout, filter, fixture,
 oracle, or skip workaround is involved. TypeScript 5 and TypeScript 7
 typechecks, targeted Biome lint, targeted Prettier check, and `git diff
---check` are also clean at this checkpoint. The final commit SHA and complete
-pre-push evidence will be appended after the documentation and graph updates.
+--check` are also clean. Implementation commit:
+`97334bd6a5659d3595e6c480e08e8a8f95d2815e`.
 
 The adjacent regression controls for #3173, #3183, and #2872 ran with the same
 two-worker bound: **66/67 pass**. The sole failure is the pre-existing
 `#2872.test.ts` dynamic non-typed-array callee control (`expected 7, received
 NaN`); it does not execute the DataView setter producers or touch this change.
+
+The complete pre-push hook passed against that implementation commit. Its
+checks were TypeScript 7 typecheck, repository Biome lint, Prettier format,
+oracle and coercion ratchets, the #3765 numeric-local parity file (**18/18**),
+conformance-number synchronization (**0 updated, 5 unchanged**), and committed
+plus working-tree issue integrity. The TypeScript 5 check, targeted format and
+lint checks, LOC/function budgets, and `git diff --check` also passed before
+the hook; the done-status checker passed with its documented baseline-unavailable
+warning.
 
 ## Handoff
 
@@ -254,7 +263,9 @@ Branch: `codex/5137-es2015-dataview-setter-undefined`.
 The plan-only upstream PR #5152 is merged in `upstream/main`; it is not the
 implementation PR. The implementation branch is ready for root to open as a
 new non-draft PR targeting `loopdive/js2:main`, and no PR was opened by this
-worker. The plan checkpoint remains `c808092cb828e9b2abef4ef6af27d95e1d822ee1`;
-the final implementation commit, push head, and pre-push result will be
-recorded here before handoff.
+worker. The implementation commit is
+`97334bd6a5659d3595e6c480e08e8a8f95d2815e`; the handoff-evidence commit below
+records this final validation, and the branch will be pushed without force for
+root to inspect. The plan checkpoint remains
+`c808092cb828e9b2abef4ef6af27d95e1d822ee1`.
 No GitHub issue was created.

--- a/plan/log/issues-log.md
+++ b/plan/log/issues-log.md
@@ -539,6 +539,7 @@ sprint: 0
 | 3924 | 2026-08-09 | Sound opt-in linear call-arena reset reclaims primitive-only exported calls while aggregate boundaries and heap-backed globals fall back to monotonic allocation | Current |
 | 4747 | 2026-08-26 | ES2015 StringIteratorPrototype now has the exact Symbol.toStringTag value and descriptor in standalone, with host Test262 realm restoration parity | Current |
 | 4758 | 2026-08-26 | ES2015 destructuring residual compile-timeout cluster now survives deleted Array iterators in worker cleanup and host callback dispatch; exact 40/40 host pins pass and standalone parity is recorded for integration into #5010 | Current |
+| 5137 | 2026-08-30 | ES2015 DataView setter expressions now return canonical undefined across direct/helper routes; exact 14/14 host and 14/14 standalone rows pass | Current |
 
 > **IR retirement checkpoint:** #3518 remains in progress; #3520 is ready as
 > the next R1 slice. R2–R8 remain blocked on the dependency spine.

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -57,7 +57,7 @@ import {
   taCtorKindOf,
 } from "./registry/types.js";
 import { funcSignatureOf, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#2872) __ta_dyn_fill minting
-import { undefinedExternInstrs } from "./any-helpers.js"; // (#3177) OOB read = undefined, not null
+import { canonicalUndefinedExternInstrs, undefinedExternInstrs } from "./any-helpers.js"; // (#2864) semantic undefined vs null
 import { ensureObjectRuntime } from "./object-runtime.js"; // (#2872) $Object array-like construct arm
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { coerceType } from "./type-coercion.js";
@@ -1824,8 +1824,8 @@ export function emitDataViewAccessor(
  * Sequence (§24.3.1.1 GetViewValue / §24.3.1.2 SetViewValue):
  *   brand TypeError → ToIndex(requestIndex) RangeError → [ToNumber(value)] →
  *   ToBoolean(littleEndian) → detached TypeError → bounds RangeError → op.
- * Getters box the f64 result (`__box_number`); setters return undefined
- * (null extern). noJsHost lane only; idempotent per member.
+ * Getters box the f64 result (`__box_number`); setters return the canonical
+ * semantic `undefined` externref. noJsHost lane only; idempotent per member.
  *
  * IMPORT DISCIPLINE: every reachable helper (`__to_primitive`/`__unbox_number`
  * via the externref→f64 coercion, `__is_truthy`, `__box_number`, the error
@@ -1971,9 +1971,11 @@ export function ensureDvAccessorHelper(ctx: CodegenContext, member: string): num
     coerceType(ctx, fctx, acc.int64 ? { kind: "i64", bigint: true } : { kind: "f64" }, { kind: "externref" });
   } else {
     emitWriteBytes(ctx, fctx, acc, arrLocal, offLocal, valLocal, leLocal, arrTypeIdx);
-    // Setters return undefined — standalone lowers `undefined` to the null
-    // externref (`x === undefined` is `ref.is_null`), so this IS undefined.
-    fctx.body.push({ op: "ref.null.extern" });
+    // Setters return the semantic `undefined` value. The helper returns an
+    // externref, so use the canonical lane-correct producer: standalone's
+    // tag-1 singleton is distinct from `null`, while host mode obtains the
+    // real host `undefined` when this helper is used there.
+    fctx.body.push(...canonicalUndefinedExternInstrs(ctx));
   }
 
   pushDefinedFunc(ctx, funcIdx, {
@@ -2484,6 +2486,29 @@ function emitStoreByte(
  * convert to the integer/bit representation then store each byte with an
  * endianness branch.
  */
+function integerToI64Instrs(valLocal: number): Instr[] {
+  // ToIntN/ToUintN first apply ToIntegerOrInfinity. The saturating Wasm
+  // conversion already maps NaN to zero, but it maps ±Infinity to the i64
+  // extrema. ECMAScript's modulo conversion maps both infinities to zero,
+  // so handle them before truncating; finite values keep the existing exact
+  // path used for the conformance range (|value| <= 2^53).
+  return [
+    { op: "local.get", index: valLocal },
+    { op: "f64.const", value: Infinity },
+    { op: "f64.eq" },
+    { op: "local.get", index: valLocal },
+    { op: "f64.const", value: -Infinity },
+    { op: "f64.eq" },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i64" } },
+      then: [{ op: "i64.const", value: 0n }],
+      else: [{ op: "local.get", index: valLocal }, { op: "i64.trunc_sat_f64_s" }],
+    },
+  ];
+}
+
 function emitWriteBytes(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -2504,13 +2529,7 @@ function emitWriteBytes(
       arrLocal,
       offLocal,
       0,
-      [
-        { op: "local.get", index: valLocal },
-        { op: "i64.trunc_sat_f64_s" },
-        { op: "i32.wrap_i64" },
-        { op: "i32.const", value: 0xff },
-        { op: "i32.and" },
-      ],
+      [...integerToI64Instrs(valLocal), { op: "i32.wrap_i64" }, { op: "i32.const", value: 0xff }, { op: "i32.and" }],
       arrTypeIdx,
     );
     fctx.body.push(...out);
@@ -2522,8 +2541,11 @@ function emitWriteBytes(
     // bits = i64.trunc_sat_f64_s(val) — the numeric-rep BigInt value truncated
     // toward zero (exact for |v| < 2^53); store 8 bytes either way.
     const bitsLocal = allocLocal(fctx, `__dvn_bits64_${fctx.locals.length}`, { kind: "i64" });
-    fctx.body.push({ op: "local.get", index: valLocal });
-    fctx.body.push({ op: acc.int64 ? "i64.trunc_sat_f64_s" : "i64.reinterpret_f64" });
+    if (acc.int64) {
+      fctx.body.push(...integerToI64Instrs(valLocal));
+    } else {
+      fctx.body.push({ op: "local.get", index: valLocal }, { op: "i64.reinterpret_f64" });
+    }
     fctx.body.push({ op: "local.set", index: bitsLocal });
     const storeAll = (little: boolean): Instr[] => {
       const out: Instr[] = [];
@@ -2553,8 +2575,8 @@ function emitWriteBytes(
 
   // 2 or 4 byte integers (or Float32/Float16) — derive an i32 bit pattern.
   const bitsLocal = allocLocal(fctx, `__dvn_bits32_${fctx.locals.length}`, { kind: "i32" });
-  fctx.body.push({ op: "local.get", index: valLocal });
   if (acc.f16) {
+    fctx.body.push({ op: "local.get", index: valLocal });
     // (#3173) Float16: encode via the minted `__f16_encode` helper
     // (roundTiesToEven directly from the f64 bits — single rounding).
     const encIdx = ctx.funcMap.get("__f16_encode");
@@ -2565,6 +2587,7 @@ function emitWriteBytes(
       fctx.body.push({ op: "i32.const", value: 0 });
     }
   } else if (acc.float) {
+    fctx.body.push({ op: "local.get", index: valLocal });
     // Float32: demote f64→f32, reinterpret to i32 bits.
     fctx.body.push({ op: "f32.demote_f64" });
     fctx.body.push({ op: "i32.reinterpret_f32" });
@@ -2577,7 +2600,7 @@ function emitWriteBytes(
     // `acc.bytes` of those are stored below, giving the correct modular result
     // for 2- and 4-byte signed/unsigned setters across the ±2^53 integer range
     // that conformance exercises.
-    fctx.body.push({ op: "i64.trunc_sat_f64_s" });
+    fctx.body.push(...integerToI64Instrs(valLocal));
     fctx.body.push({ op: "i32.wrap_i64" });
   }
   fctx.body.push({ op: "local.set", index: bitsLocal });

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -44,7 +44,7 @@ import {
 } from "../closed-method-dispatch.js";
 import { compileArrowAsClosure, computeClosureWrapperSig } from "../closures.js";
 import { tryEmitDirectTwinCall } from "../typed-this.js"; // (#3683 S3) direct-call devirtualization
-import { undefinedExternInstrs } from "../any-helpers.js"; // (#3683 S3b) arity-padding sentinel
+import { canonicalUndefinedExternInstrs, undefinedExternInstrs } from "../any-helpers.js"; // (#2864) semantic undefined producer
 import { pushBody } from "../context/bodies.js";
 import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
@@ -873,11 +873,10 @@ export function compileReceiverMethodCall(
         // strict equality). Statement position keeps the zero-cost
         // VOID_RESULT.
         if (!ts.isExpressionStatement(expr.parent)) {
-          // Standalone lowers `undefined` to the null externref (undefined ≡
-          // null-extern; `x === undefined` is `ref.is_null` — see
-          // `__extern_is_undefined`, object-runtime.ts), so this IS the
-          // canonical undefined here.
-          fctx.body.push({ op: "ref.null.extern" });
+          // Setters return semantic `undefined`; the result is carried as an
+          // externref in expression position, so preserve the distinction
+          // between standalone's canonical tag-1 singleton and `null`.
+          fctx.body.push(...canonicalUndefinedExternInstrs(ctx));
           return { kind: "externref" };
         }
         return VOID_RESULT;

--- a/tests/issue-5137-es2015-dataview-setter-undefined-carrier.test.ts
+++ b/tests/issue-5137-es2015-dataview-setter-undefined-carrier.test.ts
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #5137 — DataView setters must return the canonical `undefined` value.
+ *
+ * The native setter write is already correct. The residual defect was in the
+ * two expression-position carriers: statically typed DataView calls used the
+ * direct native accessor arm, while widened/reflective calls used
+ * `ensureDvAccessorHelper`. Both used `ref.null.extern`, which is JavaScript
+ * `null` after the standalone value model separated it from `undefined`.
+ *
+ * The exact ES2015 cohort is deliberately kept here, rather than represented
+ * by a hand-written approximation: every row runs through the maintained
+ * `runTest262File` runner in both host and standalone lanes. The standalone
+ * lane also checks its actual Wasm import manifest before instantiation.
+ */
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildImports, compile, instantiateWasm } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+
+type Lane = "host" | "standalone";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TEST262_ROOT = join(REPO_ROOT, "test262");
+
+const SETTER_MEMBERS = [
+  "setFloat32",
+  "setFloat64",
+  "setInt16",
+  "setInt32",
+  "setInt8",
+  "setUint16",
+  "setUint32",
+] as const;
+
+const EXACT_ROWS = SETTER_MEMBERS.flatMap((member) => [
+  `built-ins/DataView/prototype/${member}/set-values-return-undefined.js`,
+  `built-ins/DataView/prototype/${member}/no-value-arg.js`,
+]);
+
+/**
+ * One source module exercises both result producers, a direct getter, and the
+ * write itself. The statically typed receiver selects `emitDataViewAccessor`
+ * and the `any` receiver selects the runtime-receiver helper.
+ */
+const CARRIER_CONTROL_SOURCE = `
+  export function test(): number {
+    let checks = 0;
+
+    const direct = new DataView(new ArrayBuffer(8));
+    const directResult: any = direct.setUint16(0, 0x1234, false);
+    if (directResult === undefined) checks += 1;
+    if (directResult !== null) checks += 2;
+    if (typeof directResult === "undefined") checks += 4;
+    if (direct.getUint16(0, false) === 0x1234) checks += 8;
+    if (direct.getUint8(0) === 0x12 && direct.getUint8(1) === 0x34) checks += 16;
+
+    // A statement-position setter remains a void operation and still writes.
+    direct.setUint8(2, 0x56);
+    if (direct.getUint8(2) === 0x56) checks += 32;
+
+    // The any receiver is the closed-method/runtime helper route.
+    const dynamic: any = new DataView(new ArrayBuffer(8));
+    const dynamicResult: any = dynamic.setUint32(0, 0x01020304, false);
+    if (dynamicResult === undefined) checks += 64;
+    if (dynamicResult !== null) checks += 128;
+    if (typeof dynamicResult === "undefined") checks += 256;
+    if (dynamic.getUint32(0, false) === 0x01020304) checks += 512;
+    if (
+      dynamic.getUint8(0) === 1 &&
+      dynamic.getUint8(1) === 2 &&
+      dynamic.getUint8(2) === 3 &&
+      dynamic.getUint8(3) === 4
+    ) checks += 1024;
+
+    const directRead: any = direct.getUint16(0, false);
+    if (directRead === 0x1234 && typeof directRead === "number" && directRead !== null) checks += 2048;
+    const dynamicRead: any = dynamic.getUint32(0, false);
+    if (dynamicRead === 0x01020304 && typeof dynamicRead === "number" && dynamicRead !== null) checks += 4096;
+
+    return checks;
+  }
+`;
+
+/** Missing value coercion remains observable while the result is undefined. */
+const MISSING_VALUE_CONTROL_SOURCE = `
+  export function test(): number {
+    let checks = 0;
+    const dv = new DataView(new ArrayBuffer(8));
+
+    const floatResult: any = dv.setFloat32(0);
+    if (floatResult === undefined) checks += 1;
+    if (floatResult !== null) checks += 2;
+    const floatValue: any = dv.getFloat32(0);
+    if (floatValue !== floatValue) checks += 4;
+
+    dv.setInt32(0, 42);
+    const intResult: any = dv.setInt32(0);
+    if (intResult === undefined) checks += 8;
+    if (intResult !== null) checks += 16;
+    if (dv.getInt32(0) === 0) checks += 32;
+
+    return checks;
+  }
+`;
+
+/** The index RangeError fires before converting the setter value. */
+const INDEX_ORDER_CONTROL_SOURCE = `
+  let evaluated = 0;
+  const value: any = { valueOf: function(): number { evaluated += 1; return 7; } };
+  export function test(): number {
+    const dv = new DataView(new ArrayBuffer(8));
+    try { dv.setInt16(-1, value); } catch (e) {}
+    return evaluated === 0 ? 1 : 0;
+  }
+`;
+
+/** The bounds RangeError fires only after evaluating the setter value. */
+const BOUNDS_ORDER_CONTROL_SOURCE = `
+  let evaluated = 0;
+  function value(): number { evaluated += 1; return 7; }
+  export function test(): number {
+    const dv = new DataView(new ArrayBuffer(8));
+    try { dv.setInt16(100, value()); } catch (e) {}
+    return evaluated === 1 ? 1 : 0;
+  }
+`;
+
+/**
+ * Reflective access is standalone-only: the host lane intentionally delegates
+ * this shape to the JavaScript DataView binding, whose receiver representation
+ * is different. Standalone's DataView prototype closure must use the same
+ * helper carrier as a closed any-receiver call.
+ */
+const REFLECTIVE_CONTROL_SOURCE = `
+  export function test(): number {
+    const dynamic: any = new DataView(new ArrayBuffer(8));
+    const setter: any = DataView.prototype.setInt16;
+    const result: any = setter.call(dynamic, 2, -0x1234, true);
+    let checks = 0;
+    if (result === undefined) checks += 1;
+    if (result !== null) checks += 2;
+    if (typeof result === "undefined") checks += 4;
+    if (dynamic.getInt16(2, true) === -0x1234) checks += 8;
+    if (dynamic.getUint8(2) === 0xcc && dynamic.getUint8(3) === 0xed) checks += 16;
+    return checks;
+  }
+`;
+
+async function runControl(source: string, lane: Lane): Promise<{ value: number; imports: string[] }> {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-5137-es2015-dataview-setter-undefined-carrier.ts",
+    skipSemanticDiagnostics: true,
+    ...(lane === "standalone" ? { target: "standalone" as const } : {}),
+  });
+  expect(
+    result.success,
+    `${lane} control compile failed:\n${result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")}`,
+  ).toBe(true);
+  if (!result.success) return { value: -1, imports: [] };
+
+  const module = await WebAssembly.compile(result.binary);
+  const imports = WebAssembly.Module.imports(module).map((entry) => `${entry.module}::${entry.name}`);
+  if (lane === "standalone") {
+    expect(imports, "standalone DataView controls must emit zero imports").toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    return { value: (instance.exports as { test: () => number }).test(), imports };
+  }
+
+  const built = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setInstance?.(instance);
+  return { value: (instance.exports as { test: () => number }).test(), imports };
+}
+
+async function runExactRow(relativePath: string, lane: Lane) {
+  const filePath = join(TEST262_ROOT, "test", relativePath);
+  try {
+    return await runTest262File(filePath, `issue-5137-${lane}`, 120_000, lane === "standalone" ? lane : undefined);
+  } finally {
+    restoreHostBuiltins();
+  }
+}
+
+describe("#5137 ES2015 DataView setter undefined carrier", () => {
+  it("direct and helper carriers preserve undefined, bytes, and getter values in host mode", async () => {
+    const outcome = await runControl(CARRIER_CONTROL_SOURCE, "host");
+    expect(outcome.value).toBe(8191);
+  });
+
+  it("direct and helper carriers preserve undefined, bytes, and getter values host-free", async () => {
+    const outcome = await runControl(CARRIER_CONTROL_SOURCE, "standalone");
+    expect(outcome.value).toBe(8191);
+    expect(outcome.imports).toEqual([]);
+  });
+
+  it("missing-value coercion still writes NaN/zero and returns undefined in host mode", async () => {
+    expect((await runControl(MISSING_VALUE_CONTROL_SOURCE, "host")).value).toBe(63);
+  });
+
+  it("missing-value coercion still writes NaN/zero and returns undefined host-free", async () => {
+    const outcome = await runControl(MISSING_VALUE_CONTROL_SOURCE, "standalone");
+    expect(outcome.value).toBe(63);
+    expect(outcome.imports).toEqual([]);
+  });
+
+  it("keeps index-before-value coercion order in both lanes", async () => {
+    expect((await runControl(INDEX_ORDER_CONTROL_SOURCE, "host")).value).toBe(1);
+    expect((await runControl(INDEX_ORDER_CONTROL_SOURCE, "standalone")).value).toBe(1);
+  });
+
+  it("keeps value-before-bounds coercion order in both lanes", async () => {
+    expect((await runControl(BOUNDS_ORDER_CONTROL_SOURCE, "host")).value).toBe(1);
+    expect((await runControl(BOUNDS_ORDER_CONTROL_SOURCE, "standalone")).value).toBe(1);
+  });
+
+  it("reflective DataView prototype setter uses the helper carrier host-free", async () => {
+    const outcome = await runControl(REFLECTIVE_CONTROL_SOURCE, "standalone");
+    expect(outcome.value).toBe(31);
+    expect(outcome.imports).toEqual([]);
+  });
+
+  for (const relativePath of EXACT_ROWS) {
+    it(`host exact Test262 row: ${relativePath}`, { timeout: 180_000 }, async () => {
+      const result = await runExactRow(relativePath, "host");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    });
+
+    it(`standalone exact Test262 row: ${relativePath}`, { timeout: 180_000 }, async () => {
+      const result = await runExactRow(relativePath, "standalone");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    });
+  }
+
+  it("standalone exact cohort repeats deterministically", { timeout: 180_000 }, async () => {
+    for (const relativePath of EXACT_ROWS) {
+      const result = await runExactRow(relativePath, "standalone");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    }
+  });
+});


### PR DESCRIPTION
## Description

- Problem: DataView setter expressions emitted wasm null instead of JavaScript `undefined` in both the direct and helper result producers, and the exact integer-setter rows exposed incorrect ±Infinity normalization.
- Behavior: use the canonical lane-correct undefined carrier for expression-position setters while retaining the statement-position void path; normalize integer setter infinities to zero before the existing modular byte codec.
- Tests: the exact ES2015 cohort passes 14/14 in host mode and 14/14 in standalone mode, repeats deterministically, and the focused carrier/coercion suite passes 36/36.
- Quality: TypeScript 5 and 7, lint, formatting, LOC/function budgets, oracle/coercion ratchets, 18/18 numeric-local parity, issue integrity, and the complete pre-push chain pass.
- Tracking: `plan/issues/5137-es2015-dataview-setter-undefined-carrier.md` contains the implementation plan, exact evidence, and handoff. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
