### PR TITLE
docs(issue): correct #5137 PR metadata

### DIFF
--- a/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
+++ b/plan/issues/5137-es2015-dataview-setter-undefined-carrier.md
@@ -18,7 +18,6 @@ language_feature: dataview-setter-return-undefined
 goal: standalone-mode
 assignee: "ttraenkler/codex-5137-es2015-dataview-setter-undefined"
 branch: codex/5137-es2015-dataview-setter-undefined
-pr: 5152
 files:
   - src/codegen/dataview-native.ts
   - src/codegen/expressions/call-receiver-method.ts


### PR DESCRIPTION
## Description

- Problem: `plan/issues/5137-es2015-dataview-setter-undefined-carrier.md` retained a stale second `pr: 5152` field after the completed implementation landed as PR #5274, so last-key-wins YAML consumers could resolve the wrong pull request.
- Behavior: remove the stale duplicate and leave `pr: 5274` as the issue's single authoritative pull-request citation.
- Tests: Prettier, issue-index check, done-status integrity, issue-ID integrity, issue-spec coverage, TypeScript checks, lint, repository-wide format check, oracle/coercion ratchets, numeric-local parity (18/18), and the normal pre-push issue-integrity gate passed.
- Tracking: `plan/issues/5137-es2015-dataview-setter-undefined-carrier.md` records the completed ES2015 DataView fix and exact landed PR. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
