### PR TITLE
docs(issues): file #5209 (ctor-arg vec host .filter) and #5210 (IIFE fallthru CE)

### DIFF
--- a/plan/issues/5209-ctor-arg-array-vec-host-filter.md
+++ b/plan/issues/5209-ctor-arg-array-vec-host-filter.md
@@ -1,0 +1,73 @@
+---
+id: 5209
+title: An array-literal constructor argument reaches the host extern-method dispatcher as a compiled vec — `.filter` throws "filter is not a function"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+feasibility: hard
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5209 — `.filter` on a constructor argument dispatches against a compiled vec
+
+## Problem
+
+Tenth Temporal module-init blocker (#4628). With the full fix stack plus the
+#5207 fix (PR #5279), the polyfill advances past "Invalid era data" and stops
+at:
+
+```
+TypeError: filter is not a function
+    at src/runtime.ts:14131          (extern-method dispatcher "no arm matched" throw)
+    at invokeReusable                 src/runtime/fixed-extern-method-call.ts:27
+    at GregorianBaseHelper_init ← OrthodoxBaseHelper_init ← EthiopicHelper_init ← __module_init
+```
+
+Source: the polyfill's `n.filter((e => null != e.reverseOf)).length > 1`
+guard. `moduleInitRuns` stays false.
+
+## Reduced repro (dev-5207, verified pre-existing on pristine origin/main; no IIFE involved)
+
+```js
+class HelperBase { constructor() {} }
+class G extends HelperBase {
+  constructor(e, t) { super(); this.eras = t.filter((x) => x.code); }
+}
+class Sub extends G { constructor(e, t) { super(e, t); } }
+new Sub("c", [{ code: "a" }, { code: "b" }]);
+// js2wasm: TypeError: filter is not a function · native: works
+```
+
+An array literal passed through a derived-class constructor chain arrives at
+the `.filter` call site as a compiled vec struct, and the host extern-method
+dispatch path (`fixed-extern-method-call.ts`) has no arm for it. Likely fix
+direction: either keep the value on the compiled path (compiled `.filter` on
+vecs exists) — the dispatch decision is wrongly routing to the host — or
+marshal the vec before host dispatch. Decide with evidence; prefer the
+compiled path (order-preservation, no host round-trip).
+
+## Acceptance criteria
+
+1. Reduced repro passes host AND standalone; also the polyfill's exact
+   `.filter(cb).length` shape and a plain non-class control
+   (`function f(t){ return t.filter(x=>x.code); }`). New
+   tests/issue-5209-*.test.ts failing on base.
+2. Temporal harness measured before/after on the full stack (#5252 → #5258 →
+   #5262 → #5264 → #5266 → #5271 → #5279 → this). Advances past
+   `filter is not a function`; new later blocker → report precisely for
+   filing (coordinator allocates ids); `moduleInitRuns` true → say so LOUDLY.
+3. No regressions in issue-5207 tests, array-method scoped runs, equivalence
+   shards touching arrays (name them). Gates green.
+
+## Notes
+
+- Found by dev-5207 while validating PR #5279; pre-existing on origin/main
+  (unmasked by the #5207 fix, not caused by it).
+- Sibling #5210 covers the separate wasm-validation defect found at the same
+  time.
+- Id #5209 reserved with a degraded PR scan; manually verified against open
+  PR head branches 2026-08-30. `check:issue-ids:against-main` arbitrates.

--- a/plan/issues/5210-derived-ctor-inline-iife-fallthru-type-error.md
+++ b/plan/issues/5210-derived-ctor-inline-iife-fallthru-type-error.md
@@ -1,0 +1,53 @@
+---
+id: 5210
+title: Wasm validation error when a derived-class constructor field is assigned from an inlined IIFE result — "type error in fallthru[0] (expected externref, got (ref null N))"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+goal: core-semantics
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5210 — derived-ctor field from inlined IIFE result fails wasm validation
+
+## Problem
+
+In a derived-class constructor, assigning a field from an inlined IIFE's
+result fails compilation:
+
+```
+Compiling function "G_init" failed: type error in fallthru[0]
+(expected externref, got (ref null N))
+```
+
+Occurs even when the IIFE simply returns its parameter unchanged — no array
+methods involved. Found by dev-5207 during #5207 validation; verified
+PRE-EXISTING on pristine origin/main (unmasked, not caused, by PR #5279).
+
+## Direction
+
+The inline-IIFE lowering's result type ((ref null N)) is not coerced to the
+externref the field-assignment fallthru expects. Likely a missing
+`extern.convert_any` / coerceType call on the inline arm's result when it
+flows into a class-field store inside a derived constructor. Reproduce
+first (derived class + `this.x = (function(p){ return p; })(arg)` shape),
+then locate the arm; keep the fix to the coercion site.
+
+## Acceptance criteria
+
+1. Reduced repro compiles, validates, and runs correctly, host AND
+   standalone; new tests/issue-5210-*.test.ts failing (CE) on base.
+2. No regressions in issue-5207 tests + inline-IIFE scoped runs (name them).
+   Gates green.
+3. Not known to be on the #4628 critical path — do not gate Temporal
+   measurements on it, but note harness state if run.
+
+## Notes
+
+- Sibling #5209 is the current Temporal front blocker; this one is
+  independent (compile-time, not dispatch).
+- Id #5210 reserved with a degraded PR scan; manually verified against open
+  PR head branches 2026-08-30. `check:issue-ids:against-main` arbitrates.


### PR DESCRIPTION
Docs-only PR — files two defects found by dev-5207 while validating PR #5279. (Originally pushed to `docs-5207-5208-filing`, but PR #5273 had already merged at its earlier SHA, stranding the commit; this is the same commit cherry-picked onto a fresh branch from main.)

- [#5209](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5209-ctor-arg-array-vec-host-filter) — **tenth Temporal blocker** ([#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-global-runtime)): an array-literal constructor argument reaches the host extern-method dispatcher as a compiled vec, so `.filter` throws "filter is not a function". Reproduces with no IIFE at all; pre-existing on main; the polyfill's current stop. A fix agent is already dispatched on it.
- [#5210](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5210-derived-ctor-inline-iife-fallthru-type-error) — wasm validation error (`type error in fallthru[0] (expected externref, got (ref null N))`) when a derived-class constructor field is assigned from an inlined IIFE result. Pre-existing; off the Temporal critical path.

No `src/`, `tests/`, `scripts/`, `.github/`, or `benchmarks/` files touched. Ids allocated via `claim-issue.mjs --allocate` (degraded PR scan, manually verified against open PR head branches).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_