### PR TITLE
fix(standalone): preserve Map and Set subclass iterables

### DIFF
--- a/plan/issues/5212-es2015-class-map-set-iterable-super.md
+++ b/plan/issues/5212-es2015-class-map-set-iterable-super.md
@@ -1,0 +1,214 @@
+---
+id: 5212
+title: "ES2015 standalone class Map/Set subclasses preserve iterable constructor state"
+status: in-progress
+sprint: current
+created: 2026-08-30
+updated: 2026-08-30
+priority: high
+horizon: s
+feasibility: medium
+task_type: conformance
+area: codegen
+es_edition: ES2015
+goal: standalone-mode
+assignee: ttraenkler/codex-luna-class-collections
+requested_by: codex/es2015-closeout
+loc-budget-allow:
+  - src/codegen/class-bodies.ts
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/literals.ts
+func-budget-allow:
+  - src/codegen/class-bodies.ts::compileClassBodiesInner
+  - src/codegen/literals.ts::compileArrayLiteral
+  - src/codegen/class-bodies.ts::compileSuperCall
+  - src/codegen/expressions/new-super.ts::compileNewExpression
+  - src/codegen/class-bodies.ts::collectClassDeclaration
+---
+
+# #5212 — faithful Map/Set subclass iterable construction
+
+## Problem
+
+The exact ES2015 rows
+
+- `test/language/statements/class/subclass/builtin-objects/Map/regular-subclassing.js`; and
+- `test/language/statements/class/subclass/builtin-objects/Set/regular-subclassing.js`
+
+pass on the host lane but fail standalone on the pre-fix evidence recorded by
+#5195. `class M extends Map {}` and `class S extends Set {}` already allocate a
+correctly branded native `$Map` carrier, but
+`emitStandaloneCollectionSuperCtor` drops every forwarded constructor argument.
+The resulting subclasses therefore begin empty instead of consuming their
+array-literal iterables. This issue is the isolated Map/Set provider slice from
+#5195; no GitHub issue is to be created.
+
+The implementation worktree starts at fetched `loopdive/js2` upstream main
+`a62aacba5ccc154f6fc378235aaaeeb4a7204231` on branch
+`codex/5212-class-collection-super`.
+
+## Implementation plan
+
+1. Add `tests/issue-5212-es2015-class-collection-super.test.ts` pinning the two
+   exact Test262 files in host and standalone, zero standalone imports, and
+   focused controls for iterable evaluation order, Map key/value retention, Set
+   de-duplication, `.size`, inherited mutation, subclass identity, and parent
+   brand identity.
+2. Make implicit and explicit builtin-subclass construction forward the actual
+   statically observed `super(...)` value at the correct externref arity. Do not
+   recompile or re-evaluate the argument in the provider.
+3. Reuse or extract the existing native `new Map([[k, v], ...])` and
+   `new Set([v, ...])` seeding invariant from
+   `src/codegen/expressions/new-super.ts`. The subclass route must initialize
+   the same branded carrier through `__map_set` / `__set_add`, then retain that
+   carrier while the class path applies subclass prototype and user-brand
+   metadata. Do not introduce a parallel fake collection representation.
+4. Preserve the collection constructor's nullish/no-argument behavior and
+   observable argument ordering. Unsupported general/dynamic iterables must
+   decline explicitly for later work rather than silently masquerading as a
+   completed implementation. WeakMap/WeakSet and the other builtin providers
+   remain outside this issue.
+5. After the authoritative census releases the global two-worker lock, run the
+   two exact rows and focused matrix in standalone and host with at most two
+   workers, then run adjacent existing Map/Set constructor and subclass controls,
+   TS5/TS7, formatting, lint, LOC/function budgets, oracle/coercion ratchets,
+   numeric-local parity, issue integrity, and the complete commit/pre-push hooks.
+
+## Delivery and handoff
+
+Worktree: `/private/tmp/js2-es2015-class-collection-super-20260830`.
+Branch: `codex/5212-class-collection-super`.
+Parent planning issue: `plan/issues/5195-es2015-standalone-class-r2.md`.
+
+This issue was atomically allocated with `scripts/claim-issue.mjs --allocate`.
+The Luna Max implementer works only in this worktree, must not run validation
+while the full census owns both test workers, and must update this file with
+exact evidence and remaining limitations. A completed, current, mergeable fix
+gets one separate non-draft PR from `ttraenkler/js2` to `loopdive/js2:main`.
+Only a genuinely incomplete/non-mergeable checkpoint may be draft. The
+dedicated PR shepherd must verify the exact head, body/CLA format, CI,
+mergeability, and ready/queue state before landing.
+
+## Acceptance criteria
+
+- Both exact rows pass standalone with zero host imports and pass host control.
+- Map and Set subclass iterable values, sizes, inherited mutation, and brands
+  agree with their direct native constructors.
+- No regression in no-argument/nullish direct Map/Set construction or existing
+  subclass identity behavior.
+- The branch is integrated with then-current upstream main and all required
+  focused and repository gates pass before publication.
+
+## Static implementation checkpoint (2026-08-30)
+
+The bounded provider slice is authored on the allocated worktree/branch. The
+implementation invariant is:
+
+> The first `super(...)` externref is evaluated exactly once by the caller. For
+> Map/Set, the defined per-arity native subclass helper consumes that same
+> value only when it is one of the compiler's native array carriers, walking it
+> through finalized `__extern_length` / `__extern_get_idx` readers and seeding
+> the fresh correctly branded `$Map` with `__map_set` / `__set_add`. The helper
+> never receives or re-evaluates the source AST.
+
+The call-site seam in `class-bodies.ts` and `expressions/new-super.ts` forces
+only a statically visible Map/Set array literal (including nested Map entry
+pairs) to remain a native vec carrier in standalone/WASI. Its collection-only
+nested-carrier mode uses `vec<externref>` recursively, avoiding the contextual
+tuple representation that the provider cannot index while leaving host
+lowering and later constructor arguments unchanged. The same seam keeps an
+explicit subclass constructor's first parameter at the open `externref`
+boundary, so a typed `ReadonlyArray<readonly [K, V]>` annotation cannot coerce
+the lossless carrier back into a tuple ABI before the provider sees it.
+Nullish/no-argument forwarding remains empty. A non-array carrier takes the
+explicit native TypeError path; general iterator protocol, dynamic typed tuple
+arrays, WeakMap/WeakSet, and other builtin providers remain outside this issue.
+
+Changed files:
+
+- `src/codegen/standalone-subclass-ctors.ts` — per-arity Map/Set carrier walk,
+  native seeding, nullish/unsupported-input handling, and provider rationale.
+- `src/codegen/class-bodies.ts` — first-argument-only array-carrier seam for
+  explicit Map/Set `super(...)` calls.
+- `src/codegen/expressions/new-super.ts` — matching seam for direct local
+  subclass construction.
+- `src/codegen/literals.ts` — collection-only recursive `vec<externref>` mode
+  so contextual tuple pairs stay indexable as native nested array carriers.
+- `tests/issue-5212-es2015-class-collection-super.test.ts` — exact-row hooks
+  plus host/standalone controls for state, ordering, de-duplication, mutation,
+  identity, brands, and empty forms.
+
+No tests, probes, compiles, typechecks, builds, hooks, or other CPU-heavy
+validation were run while the full census owned both workers. Root should run
+the exact rows and focused matrix after the census lock is released, then
+review the remaining limitation around dynamic/general iterables before any
+publication.
+
+## Bounded validation (2026-08-30)
+
+The census lock was later released and root authorized one worker for this
+lane. The focused command was run directly through the provisioned local
+Vitest entrypoint (the worktree's shared `node_modules` link is present, but
+`pnpm exec` attempted an unavailable registry install because its package
+manager metadata differs):
+
+```text
+TEST262_WORKERS=1 COMPILER_POOL_SIZE=1 VITEST_FORK_MAX_OLD_SPACE_SIZE=4096 \
+  node node_modules/vitest/vitest.mjs run \
+  tests/issue-5212-es2015-class-collection-super.test.ts \
+  --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism \
+  --reporter=verbose
+```
+
+Result: 1 file and 6 tests passed. Both host and standalone controls passed;
+both exact Map/Set Test262 rows passed in both lanes, and standalone reported
+zero imports as asserted.
+
+Adjacent one-worker command:
+
+```text
+TEST262_WORKERS=1 COMPILER_POOL_SIZE=1 VITEST_FORK_MAX_OLD_SPACE_SIZE=4096 \
+  node node_modules/vitest/vitest.mjs run \
+  tests/issue-3972-standalone-subclass-builtins.test.ts \
+  tests/issue-2620-extends-set-standalone-refusal.test.ts \
+  tests/issue-1103a-standalone-map.test.ts tests/issue-2162-standalone-set.test.ts \
+  tests/map-set-basic.test.ts tests/map-set.test.ts \
+  --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot
+```
+
+Result: 4 suites passed (60 tests). `tests/map-set-basic.test.ts` could not
+collect because its existing `../../src/runtime.js` import is absent in this
+source checkout. Three `tests/map-set.test.ts` cases retain the pre-existing
+strict `Map.get` possibly-undefined diagnostic. These failures are outside the
+changed subclass provider seam.
+
+For before/after evidence, the identical adjacent command was run from a
+source-only tar snapshot of clean commit `a62aacba5c` (the sandbox disallowed a
+second Git worktree because shared `.git` metadata is read-only). It produced
+the same 4 passing suites / 60 passing tests and the same four failures: the
+`map-set-basic` collection error and the three strict `map-set` diagnostics.
+Therefore the adjacent failures are pre-existing and unchanged by #5212.
+
+Additional bounded gates, all run serially with `COMPILER_POOL_SIZE=1` where a
+compiler/test process was involved:
+
+- TypeScript 5 (`node node_modules/typescript/lib/tsc.js --noEmit`) passed.
+- TypeScript 7 (`node node_modules/typescript7/lib/tsc.js --noEmit -p
+  tsconfig.ts7.json`) passed.
+- Prettier repository check passed after formatting only the changed files.
+- Full Biome lint and focused Biome lint for all five changed TypeScript files
+  exited 0.
+- LOC and function-budget ratchets passed with the explicit allowances above.
+- Oracle and coercion-site ratchets passed with no net growth.
+- Numeric-local parity passed: 18 tests.
+- `update-issues.mjs --check`, committed issue integrity, done-status
+  integrity, and IR optimization retirement checks passed.
+- Verdict-oracle bump check passed; no oracle bump was required.
+- Final focused rerun passed: 1 file / 6 tests.
+
+The complete Git hooks were not invoked: this checkpoint must not create a
+commit, and the pre-push hook contains a conformance synchronizer that may
+auto-commit as well as parallel typecheck/lint and a push-ref stdin protocol.
+Their non-mutating gates were run individually above. The all-issues coverage
+audit remains red only for the repository's pre-existing missing references;
+#5212 has its permanent test reference and is not among those failures.

--- a/plan/issues/5212-es2015-class-map-set-iterable-super.md
+++ b/plan/issues/5212-es2015-class-map-set-iterable-super.md
@@ -1,10 +1,11 @@
 ---
 id: 5212
 title: "ES2015 standalone class Map/Set subclasses preserve iterable constructor state"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-30
 updated: 2026-08-30
+completed: 2026-08-30
 priority: high
 horizon: s
 feasibility: medium
@@ -12,6 +13,7 @@ task_type: conformance
 area: codegen
 es_edition: ES2015
 goal: standalone-mode
+pr: 5286
 assignee: ttraenkler/codex-luna-class-collections
 requested_by: codex/es2015-closeout
 loc-budget-allow:
@@ -206,9 +208,26 @@ compiler/test process was involved:
 - Verdict-oracle bump check passed; no oracle bump was required.
 - Final focused rerun passed: 1 file / 6 tests.
 
-The complete Git hooks were not invoked: this checkpoint must not create a
-commit, and the pre-push hook contains a conformance synchronizer that may
-auto-commit as well as parallel typecheck/lint and a push-ref stdin protocol.
-Their non-mutating gates were run individually above. The all-issues coverage
-audit remains red only for the repository's pre-existing missing references;
-#5212 has its permanent test reference and is not among those failures.
+The complete commit hook was subsequently invoked without a skip and passed:
+lint-staged formatting/lint, LOC and function budgets, the changed-root focused
+suite (6/6), and the oracle ratchet all completed before implementation commit
+`08ca50d78fffc359204afe57e7ead75ec3ff58b6` was created. The complete pre-push
+hook was also invoked without a skip and passed typecheck plus lint, repository
+Prettier, oracle and coercion ratchets, numeric-local parity (18/18), conformance
+synchronization, and committed/working-tree issue integrity. The published
+`ttraenkler/js2` ref was read back and matched that exact implementation head.
+
+The all-issues coverage audit remains red only for the repository's pre-existing
+missing references; #5212 has its permanent test reference and is not among
+those failures.
+
+## Publication handoff (2026-08-30)
+
+The single completed-fix PR is
+<https://github.com/loopdive/js2/pull/5286>. It is a non-draft PR from
+`ttraenkler:codex/5212-class-collection-super` to `loopdive/js2:main`; no GitHub
+issue was created. Its description uses the repository's exact Description and
+CLA sections and links this markdown issue. A dedicated Luna Max PR shepherd
+owns exact-head, body, readiness, conflict, review, CI, and queue verification.
+Any later documentation-only handoff commit does not change the validated code
+at implementation head `08ca50d78fffc359204afe57e7ead75ec3ff58b6`.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -487,8 +487,75 @@ function computeImplicitDerivedCtorPrefix(
   return { implicitBuiltinParent, implicitForwarderArity, implicitStructCtorParams, prefixParams };
 }
 
-function compileExternrefArgument(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
-  const argResult = compileExpression(ctx, fctx, arg, { kind: "externref" });
+/**
+ * A standalone Map/Set subclass constructor's first parameter is the parent
+ * iterable boundary. Keep that boundary open as externref even when a user
+ * annotation (for example `ReadonlyArray<readonly [K, V]>`) would otherwise
+ * register a `vec<tuple>` ABI. The native subclass provider consumes the
+ * already-evaluated carrier through its dynamic array readers; preserving the
+ * typed tuple ABI here would force a real `vec<externref>` carrier back through
+ * an incompatible tuple conversion before the constructor call.
+ */
+function standaloneCollectionCtorFirstArgType(
+  ctx: CodegenContext,
+  className: string,
+  paramIndex: number,
+  wasmType: ValType,
+): ValType {
+  const parentName = ctx.classBuiltinParentMap.get(className);
+  if (
+    (ctx.standalone || ctx.wasi) &&
+    paramIndex === 0 &&
+    (parentName === "Map" || parentName === "Set") &&
+    (wasmType.kind === "ref" || wasmType.kind === "ref_null") &&
+    [...ctx.vecTypeMap.values()].includes(wasmType.typeIdx)
+  ) {
+    return { kind: "externref" };
+  }
+  return wasmType;
+}
+
+function compileExternrefArgument(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+  forceArrayLiteralVec = false,
+): void {
+  // A Map/Set iterable is an actual JavaScript array value at this boundary.
+  // TypeScript may contextually type its nested `[key, value]` elements as
+  // tuples, but the standalone subclass provider receives only the boxed
+  // value and reads it through `__extern_get_idx`. Reuse the established
+  // `_arrayLiteralForceVec` seam plus its collection-only nested-carrier mode
+  // so both the outer iterable and nested pair literals stay native vector
+  // carriers; do not reconstruct or re-evaluate the AST in the provider.
+  let carrier = arg;
+  while (
+    ts.isParenthesizedExpression(carrier) ||
+    ts.isAsExpression(carrier) ||
+    ts.isTypeAssertionExpression(carrier) ||
+    ts.isSatisfiesExpression(carrier) ||
+    ts.isNonNullExpression(carrier)
+  ) {
+    carrier = carrier.expression;
+  }
+  const shouldForceVec = forceArrayLiteralVec && (ctx.standalone || ctx.wasi) && ts.isArrayLiteralExpression(carrier);
+  const previousForceVec = (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec;
+  const previousCollectionForceVec = (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })
+    ._arrayLiteralForceCollectionVec;
+  if (shouldForceVec) {
+    (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = true;
+    (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })._arrayLiteralForceCollectionVec = true;
+  }
+  let argResult: ValType | null;
+  try {
+    argResult = compileExpression(ctx, fctx, arg, { kind: "externref" });
+  } finally {
+    if (shouldForceVec) {
+      (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = previousForceVec;
+      (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })._arrayLiteralForceCollectionVec =
+        previousCollectionForceVec;
+    }
+  }
   if (argResult === null) {
     emitUndefined(ctx, fctx);
     return;
@@ -1253,6 +1320,7 @@ export function collectClassDeclaration(
         const paramType = ctx.checker.getTypeAtLocation(param);
         // (#3673) explicit native annotation pins the constructor parameter type
         let wasmType = nativeTypeOfDeclaration(ctx.checker, param) ?? resolveWasmType(ctx, paramType);
+        wasmType = standaloneCollectionCtorFirstArgType(ctx, className, i, wasmType);
         // Widen ref to ref_null for params with defaults
         if (param.initializer && wasmType.kind === "ref") {
           wasmType = { kind: "ref_null", typeIdx: (wasmType as any).typeIdx };
@@ -2185,6 +2253,7 @@ function compileClassBodiesInner(
         const paramName = ts.isIdentifier(param.name) ? param.name.text : `__param${pi}`;
         const paramType = ctx.checker.getTypeAtLocation(param);
         let wasmType = resolveWasmType(ctx, paramType);
+        wasmType = standaloneCollectionCtorFirstArgType(ctx, className, pi, wasmType);
         // Widen ref to ref_null for params with defaults or optional params
         // (caller passes ref.null as sentinel). Must match collection phase (#702)
         if ((param.initializer || param.questionToken) && wasmType.kind === "ref") {
@@ -2381,16 +2450,43 @@ function compileClassBodiesInner(
         // default's array literals to compile as vec (not tuple) — same
         // rationale as the method site below. See function-body.ts:701.
         const ctorIsArrayPatternExternref = ts.isArrayBindingPattern(param.name) && paramType.kind === "externref";
+        let defaultCarrier = param.initializer;
+        while (
+          defaultCarrier &&
+          (ts.isParenthesizedExpression(defaultCarrier) ||
+            ts.isAsExpression(defaultCarrier) ||
+            ts.isTypeAssertionExpression(defaultCarrier) ||
+            ts.isSatisfiesExpression(defaultCarrier) ||
+            ts.isNonNullExpression(defaultCarrier))
+        ) {
+          defaultCarrier = defaultCarrier.expression;
+        }
+        const collectionParent = ctx.classBuiltinParentMap.get(className);
+        const ctorIsCollectionArrayDefault =
+          (ctx.standalone || ctx.wasi) &&
+          paramIdx === 0 &&
+          (collectionParent === "Map" || collectionParent === "Set") &&
+          defaultCarrier !== undefined &&
+          ts.isArrayLiteralExpression(defaultCarrier);
         const ctorPrevForceVec = (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec;
-        if (ctorIsArrayPatternExternref) {
+        const ctorPrevCollectionForceVec = (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })
+          ._arrayLiteralForceCollectionVec;
+        if (ctorIsArrayPatternExternref || ctorIsCollectionArrayDefault) {
           (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = true;
+        }
+        if (ctorIsCollectionArrayDefault) {
+          (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })._arrayLiteralForceCollectionVec = true;
         }
         let ctorDfltType: ValType | null;
         try {
           ctorDfltType = compileExpression(ctx, fctx, param.initializer, paramType);
         } finally {
-          if (ctorIsArrayPatternExternref) {
+          if (ctorIsArrayPatternExternref || ctorIsCollectionArrayDefault) {
             (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = ctorPrevForceVec;
+          }
+          if (ctorIsCollectionArrayDefault) {
+            (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })._arrayLiteralForceCollectionVec =
+              ctorPrevCollectionForceVec;
           }
         }
         if (ctorDfltType && !valTypesMatch(ctorDfltType, paramType)) {
@@ -3784,11 +3880,14 @@ export function compileSuperCall(
     const hasSpread = args.some((a) => ts.isSpreadElement(a));
     const importName = getParentConstructorImportName(ctx, builtinParent);
     const forwardArity = getBuiltinConstructorForwardArity(ctx, builtinParent);
+    const forceCollectionArrayVec = builtinParent === "Map" || builtinParent === "Set";
     const forwardParams = externrefParams(forwardArity);
     // Standalone / WASI: explicit `super(...)` routes through the same shared
     // native-`__new_<Parent>` dispatch ladder as the implicit forwarder
     // (`resolveStandaloneBuiltinSuperCtorIdx`). Args are still evaluated below
-    // and forwarded (Array honors them; Object/vec builtins ignore them).
+    // and forwarded: Array honors them, Map/Set consume their first native
+    // array carrier, and Object/identity/vec/Weak* providers keep their
+    // existing bounded behavior.
     // JS-host mode / parents with no native ctor yet keep the host import.
     let funcIdx: number | undefined;
     const nativeCtorIdx = resolveStandaloneBuiltinSuperCtorIdx(ctx, builtinParent, forwardArity);
@@ -3803,7 +3902,11 @@ export function compileSuperCall(
       if (flatArgs) {
         for (let i = 0; i < forwardArity; i++) {
           if (i < flatArgs.length) {
-            compileExternrefArgument(ctx, fctx, flatArgs[i]!);
+            // Map/Set consume only the first parent argument as their iterable;
+            // keep any later constructor arguments on their ordinary lowering
+            // path so a tuple-typed second argument is not widened by this
+            // collection-specific carrier hint.
+            compileExternrefArgument(ctx, fctx, flatArgs[i]!, forceCollectionArrayVec && i === 0);
           } else {
             emitUndefined(ctx, fctx);
           }

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -190,8 +190,54 @@ export function isStringTypedArg(ctx: CodegenContext, arg: ts.Expression): boole
   }
 }
 
-function compileCtorArgument(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression, expected?: ValType): void {
-  const result = compileExpression(ctx, fctx, arg, expected);
+function compileCtorArgument(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+  expected?: ValType,
+  forceArrayLiteralVec = false,
+): void {
+  // A Map/Set subclass's implicit constructor eventually forwards this value to
+  // the native collection provider as externref. In that boundary a contextual
+  // `[key, value]` tuple must remain a real nested array carrier: the provider
+  // intentionally has no AST and consumes the already-evaluated value through
+  // `__extern_get_idx`. Reuse the established narrow force-vec seam (with its
+  // collection-only nested-carrier mode), but only for standalone/WASI and an
+  // actual array literal. The expected type may be either externref or the vec
+  // ref used by a typed array parameter; ordinary primitive argument lowering
+  // remains unchanged.
+  let carrier = arg;
+  while (
+    ts.isParenthesizedExpression(carrier) ||
+    ts.isAsExpression(carrier) ||
+    ts.isTypeAssertionExpression(carrier) ||
+    ts.isSatisfiesExpression(carrier) ||
+    ts.isNonNullExpression(carrier)
+  ) {
+    carrier = carrier.expression;
+  }
+  const shouldForceVec =
+    forceArrayLiteralVec &&
+    (expected?.kind === "externref" || expected?.kind === "ref" || expected?.kind === "ref_null") &&
+    (ctx.standalone || ctx.wasi) &&
+    ts.isArrayLiteralExpression(carrier);
+  const previousForceVec = (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec;
+  const previousCollectionForceVec = (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })
+    ._arrayLiteralForceCollectionVec;
+  if (shouldForceVec) {
+    (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = true;
+    (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })._arrayLiteralForceCollectionVec = true;
+  }
+  let result: ValType | null;
+  try {
+    result = compileExpression(ctx, fctx, arg, expected);
+  } finally {
+    if (shouldForceVec) {
+      (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = previousForceVec;
+      (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })._arrayLiteralForceCollectionVec =
+        previousCollectionForceVec;
+    }
+  }
   if (result === null) {
     if (expected) pushDefaultValue(fctx, expected, ctx);
     return;
@@ -6370,6 +6416,8 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     // Compile constructor arguments with type hints
     const paramTypes = getFuncParamTypes(ctx, funcIdx);
     const args = expr.arguments ?? [];
+    const forceCollectionArrayVec =
+      ctx.classBuiltinParentMap.get(className) === "Map" || ctx.classBuiltinParentMap.get(className) === "Set";
     const ctorRestInfo = ctx.funcRestParams.get(ctorName);
     let ctorActualArgCount = args.length;
 
@@ -6392,7 +6440,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       if (flatCtorArgs) {
         ctorActualArgCount = flatCtorArgs.length;
         for (let i = 0; i < flatCtorArgs.length && i < paramTypes.length; i++) {
-          compileCtorArgument(ctx, fctx, flatCtorArgs[i]!, paramTypes[i]);
+          compileCtorArgument(ctx, fctx, flatCtorArgs[i]!, paramTypes[i], forceCollectionArrayVec && i === 0);
         }
         for (let i = paramTypes.length; i < flatCtorArgs.length; i++) {
           evaluateCtorExtraArgument(ctx, fctx, flatCtorArgs[i]!);
@@ -6409,7 +6457,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       // Calling a rest-param constructor: pack trailing args into a GC array
       for (let i = 0; i < ctorRestInfo.restIndex; i++) {
         if (i < args.length) {
-          compileCtorArgument(ctx, fctx, args[i]!, paramTypes?.[i]);
+          compileCtorArgument(ctx, fctx, args[i]!, paramTypes?.[i], forceCollectionArrayVec && i === 0);
         } else {
           pushDefaultValue(fctx, paramTypes?.[i] ?? { kind: "f64" }, ctx);
         }
@@ -6418,7 +6466,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       const restArgCount = Math.max(0, args.length - ctorRestInfo.restIndex);
       fctx.body.push({ op: "i32.const", value: restArgCount });
       for (let i = ctorRestInfo.restIndex; i < args.length; i++) {
-        compileCtorArgument(ctx, fctx, args[i]!, ctorRestInfo.elemType);
+        compileCtorArgument(ctx, fctx, args[i]!, ctorRestInfo.elemType, forceCollectionArrayVec && i === 0);
       }
       fctx.body.push({
         op: "array.new_fixed",
@@ -6429,7 +6477,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     } else {
       const positionalParamCount = paramTypes?.length ?? args.length;
       for (let i = 0; i < args.length && i < positionalParamCount; i++) {
-        compileCtorArgument(ctx, fctx, args[i]!, paramTypes?.[i]);
+        compileCtorArgument(ctx, fctx, args[i]!, paramTypes?.[i], forceCollectionArrayVec && i === 0);
       }
       for (let i = positionalParamCount; i < args.length; i++) {
         evaluateCtorExtraArgument(ctx, fctx, args[i]!);

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -5613,6 +5613,22 @@ export function compileArrayLiteral(
     const innerVecIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
     elemWasm = { kind: "ref_null", typeIdx: innerVecIdx };
   }
+  // (#5212) A Map/Set subclass forwards its first constructor argument through
+  // an externref provider that can only index native array carriers. The
+  // ordinary contextual type for `ReadonlyArray<readonly [K, V]>` selects an
+  // outer `vec<tuple>` while the nested literal, with tuple lowering disabled,
+  // selects a numeric/reference vec — an invalid `array.new_fixed` mismatch.
+  // Under the call-site-only collection carrier flag, use the lossless outer
+  // `vec<externref>` representation for every literal in the carrier tree;
+  // nested array literals remain real native vec values and are explicitly
+  // boxed into that outer carrier by the element loop below. This flag is
+  // narrower than `_arrayLiteralForceVec` and is never set by ordinary
+  // tuple/destructure lowering.
+  const forceCollectionArrayVec = (ctx as unknown as { _arrayLiteralForceCollectionVec?: boolean })
+    ._arrayLiteralForceCollectionVec;
+  if (forceCollectionArrayVec) {
+    elemWasm = { kind: "externref" };
+  }
   if (forcedElementType !== undefined) elemWasm = forcedElementType;
   // (#2769) for-of over a direct array LITERAL whose binding pattern has an
   // element default / nested sub-pattern: the OUTER literal must not coerce an
@@ -5688,7 +5704,16 @@ export function compileArrayLiteral(
           objectElement !== null && staticObjectLiteralDataKeys(ctx, objectElement) !== null
             ? compileObjectLiteralAsExternref(ctx, fctx, objectElement)
             : null;
-        if (openObjectType === null) compileExpression(ctx, fctx, el, elemWasm);
+        if (openObjectType === null) {
+          const compiledElementType = compileExpression(ctx, fctx, el, elemWasm);
+          if (
+            forceCollectionArrayVec &&
+            compiledElementType !== null &&
+            !valTypesMatch(compiledElementType, elemWasm)
+          ) {
+            coerceType(ctx, fctx, compiledElementType, elemWasm);
+          }
+        }
       }
     }
     fctx.body.push({ op: "array.new_fixed", typeIdx: arrTypeIdx, length: expr.elements.length });

--- a/src/codegen/standalone-subclass-ctors.ts
+++ b/src/codegen/standalone-subclass-ctors.ts
@@ -43,11 +43,13 @@
  *     whereas a plain object carries no false brand.
  *
  * ── SCOPE, STATED PLAINLY ───────────────────────────────────────────────────
- * Construction and identity, NOT faithful behaviour. The instance is not a
- * functional Date/RegExp/Promise/…: no [[DateValue]], no compiled pattern, no
- * executor is run, no byteLength, and constructor arguments are still
- * side-effect-evaluated at the call site (§13.3.7.1) and then DROPPED. This is
- * the same scope as the existing #3239 TypedArray/SharedArrayBuffer rung.
+ * Construction and identity, NOT blanket faithful behaviour. The identity and
+ * wrapper parents still ignore their already side-effect-evaluated arguments;
+ * they are not functional Date/RegExp/Promise/… instances (no [[DateValue]],
+ * compiled pattern, executor, or byteLength). Map/Set are the deliberate
+ * exception covered by this issue: their first forwarded value is consumed as
+ * a native array carrier below. This is the same bounded scope as the
+ * existing #3239 TypedArray/SharedArrayBuffer rung for every other parent.
  *
  * That bound is set by measurement, not optimism: of 25,692 passing standalone
  * test262 rows, ZERO contain `extends <one of these parents>` in their source,
@@ -73,6 +75,8 @@ import { addFuncType } from "./registry/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { COLLECTION_KIND, ensureMapHelpers } from "./map-runtime.js";
+import { ensureSetHelpers } from "./set-runtime.js";
+import { buildThrowJsErrorInstrs } from "./js-errors.js";
 
 /** `externref × count` — the forwarder ABI every arm below declares. */
 function externrefParams(count: number): ValType[] {
@@ -83,11 +87,17 @@ function externrefParams(count: number): ValType[] {
  * Register a defined `<key> : (externref × argCount) -> externref` whose body is
  * `body`, and record it in `ctx.funcMap` under `key`. Returns the funcIdx.
  */
-function registerSuperCtor(ctx: CodegenContext, key: string, argCount: number, body: Instr[]): number {
+function registerSuperCtor(
+  ctx: CodegenContext,
+  key: string,
+  argCount: number,
+  body: Instr[],
+  locals: { name: string; type: ValType }[] = [],
+): number {
   const typeIdx = addFuncType(ctx, externrefParams(argCount), [{ kind: "externref" }], `${key}_type`);
   const funcIdx = mintDefinedFunc(ctx);
   ctx.funcMap.set(key, funcIdx);
-  pushDefinedFunc(ctx, funcIdx, { name: key, typeIdx, locals: [], body, exported: false });
+  pushDefinedFunc(ctx, funcIdx, { name: key, typeIdx, locals, body, exported: false });
   return funcIdx;
 }
 
@@ -174,8 +184,15 @@ export const STANDALONE_COLLECTION_BUILTIN_PARENTS: ReadonlyMap<string, number> 
  * inherited `sub.add(1)` on a subclass-typed receiver still resolve host-free
  * (measured), which is why the #2620 refusal could be narrowed rather than kept.
  *
- * The iterable-initialiser form (`new Sub([[k, v]])`) is part of the deferred
- * behaviour scope: the arguments are dropped, per the file header.
+ * Map/Set iterable initialisers are the one behaviour slice handled here. The
+ * caller compiles the first `super(...)` value once as an `externref`; this
+ * helper consumes that exact carrier through the existing native array readers
+ * (`__extern_length` / `__extern_get_idx`) and seeds the fresh `$Map` with the
+ * same `__map_set` / `__set_add` operations used by direct `new Map` / `new
+ * Set`. No AST is available here and none is recompiled. The carrier walk is
+ * intentionally bounded to the native array carriers those readers understand;
+ * general iterator protocol remains an explicit follow-up rather than silently
+ * producing a successful empty subclass.
  */
 export function emitStandaloneCollectionSuperCtor(
   ctx: CodegenContext,
@@ -188,17 +205,179 @@ export function emitStandaloneCollectionSuperCtor(
   const existing = ctx.funcMap.get(key);
   if (existing !== undefined) return existing;
 
+  // Map/Set construction reuses the object-runtime's finalized array-reader
+  // contract. WeakMap/WeakSet stay on the #3972 empty-carrier path: their
+  // iterable semantics and weak-key checks are a separate slice and must not
+  // be widened as a side effect of this issue.
+  const isMapOrSet = parentName === "Map" || parentName === "Set";
+  const needsIterableWalk = isMapOrSet && argCount > 0;
+  if (needsIterableWalk) ensureObjectRuntime(ctx);
   ensureMapHelpers(ctx);
   const mapNewIdx = ctx.mapHelpers.get("__map_new");
   if (mapNewIdx === undefined) return undefined; // defensive: substrate unavailable
 
-  // `extern.convert_any` is the same no-op boxing the object runtime uses to
-  // expose `$Object`/vec structs as externref.
-  return registerSuperCtor(ctx, key, argCount, [
+  const collectionLocal = argCount;
+  const lenLocal = argCount + 1;
+  const iLocal = argCount + 2;
+  const entryLocal = argCount + 3;
+  const keyLocal = argCount + 4;
+  const valueLocal = argCount + 5;
+  const locals: { name: string; type: ValType }[] = needsIterableWalk
+    ? [
+        { name: "collection", type: { kind: "ref", typeIdx: ctx.mapTypeIdx } },
+        { name: "len", type: { kind: "f64" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "entry", type: { kind: "externref" } },
+        { name: "key", type: { kind: "anyref" } },
+        { name: "value", type: { kind: "anyref" } },
+      ]
+    : [];
+
+  const body: Instr[] = [
     { op: "i32.const", value: kind },
     { op: "call", funcIdx: mapNewIdx },
-    { op: "extern.convert_any" },
-  ]);
+  ];
+
+  // Preserve the compact #3972 helper for the no-argument/Weak* arms. Only a
+  // Map/Set helper with a forwarded argument needs the object-runtime readers
+  // and its extra locals; this keeps unrelated collection subclasses out of
+  // the iterable-specific generated shape.
+  if (!needsIterableWalk) {
+    body.push({ op: "extern.convert_any" });
+    return registerSuperCtor(ctx, key, argCount, body);
+  }
+
+  body.push({ op: "local.set", index: collectionLocal });
+
+  if (needsIterableWalk) {
+    const externLengthIdx = ctx.funcMap.get("__extern_length");
+    const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx");
+    const isUndefinedIdx = ctx.funcMap.get("__extern_is_undefined");
+    const isArrayIdx = ctx.funcMap.get("__extern_is_array");
+    const mapSetIdx = parentName === "Map" ? ctx.mapHelpers.get("__map_set") : undefined;
+    if (parentName === "Set") ensureSetHelpers(ctx);
+    const setAddIdx = parentName === "Set" ? ctx.mapHelpers.get("__set_add") : undefined;
+
+    // `ensureObjectRuntime` normally installs all three readers before this
+    // helper is registered. Keep the defensive guard so a partially available
+    // substrate still returns a correctly branded empty carrier instead of
+    // baking an invalid call target.
+    if (
+      externLengthIdx !== undefined &&
+      externGetIdxIdx !== undefined &&
+      isArrayIdx !== undefined &&
+      ((parentName === "Map" && mapSetIdx !== undefined) || (parentName === "Set" && setAddIdx !== undefined))
+    ) {
+      // The native reader returns the logical length as f64. Keep the same
+      // i32 loop/index convention as Map.groupBy and the direct Set array
+      // walk. The loop body is retained as a named array so each arm can add
+      // its seeding operation without relying on positional casts into the
+      // surrounding instruction list.
+      const loopBody: Instr[] = [
+        { op: "local.get", index: iLocal },
+        { op: "f64.convert_i32_s" },
+        { op: "local.get", index: lenLocal },
+        { op: "f64.ge" },
+        { op: "br_if", depth: 1 },
+        // `entry = __extern_get_idx(iterable, f64(i))` — this is the
+        // already-evaluated `super(...)` value, never the source AST.
+        { op: "local.get", index: 0 },
+        { op: "local.get", index: iLocal },
+        { op: "f64.convert_i32_s" },
+        { op: "call", funcIdx: externGetIdxIdx },
+        { op: "local.set", index: entryLocal },
+      ];
+      const iterateBody: Instr[] = [
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: externLengthIdx },
+        { op: "local.set", index: lenLocal },
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: iLocal },
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody }],
+        },
+      ];
+
+      if (parentName === "Map") {
+        loopBody.push(
+          // Map entries are the same two-element array carriers accepted by
+          // direct `new Map([[k, v], ...])`. The finalized reader boxes each
+          // key/value without re-evaluating either expression.
+          { op: "local.get", index: entryLocal },
+          { op: "f64.const", value: 0 },
+          { op: "call", funcIdx: externGetIdxIdx },
+          { op: "any.convert_extern" },
+          { op: "local.set", index: keyLocal },
+          { op: "local.get", index: entryLocal },
+          { op: "f64.const", value: 1 },
+          { op: "call", funcIdx: externGetIdxIdx },
+          { op: "any.convert_extern" },
+          { op: "local.set", index: valueLocal },
+          { op: "local.get", index: collectionLocal },
+          { op: "local.get", index: keyLocal },
+          { op: "local.get", index: valueLocal },
+          { op: "call", funcIdx: mapSetIdx! },
+          { op: "drop" },
+        );
+      } else {
+        loopBody.push(
+          // Set stores every value as both key and value through __set_add;
+          // the shared Map runtime therefore supplies SameValueZero dedup.
+          { op: "local.get", index: collectionLocal },
+          { op: "local.get", index: entryLocal },
+          { op: "any.convert_extern" },
+          { op: "call", funcIdx: setAddIdx! },
+          { op: "drop" },
+        );
+      }
+      loopBody.push(
+        { op: "local.get", index: iLocal },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.set", index: iLocal },
+        { op: "br", depth: 0 },
+      );
+
+      // `new Map()` / `new Set()` and their nullish forms are empty. The
+      // implicit forwarder pads missing arguments with undefined, while an
+      // explicit `super(null)` passes a null externref; both must skip the
+      // reader walk. Under the undefined-singleton regime the native predicate
+      // distinguishes undefined from null without changing the ABI.
+      const nullishGuard: Instr[] = [{ op: "local.get", index: 0 }, { op: "ref.is_null" }];
+      if (isUndefinedIdx !== undefined) {
+        nullishGuard.push({ op: "local.get", index: 0 }, { op: "call", funcIdx: isUndefinedIdx }, { op: "i32.or" });
+      }
+      const invalidIterable = buildThrowJsErrorInstrs(
+        ctx,
+        "TypeError",
+        `${parentName} subclass constructor requires an array iterable`,
+        { forceInModuleCtor: true },
+      );
+      body.push({ op: "local.get", index: 0 }, ...nullishGuard.slice(1), {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [],
+        else: [
+          { op: "local.get", index: 0 },
+          { op: "call", funcIdx: isArrayIdx },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: invalidIterable,
+            else: iterateBody,
+          },
+        ],
+      });
+    }
+  }
+
+  // `extern.convert_any` is the same no-op boxing the object runtime uses to
+  // expose `$Object`/vec structs as externref.
+  body.push({ op: "local.get", index: collectionLocal }, { op: "extern.convert_any" });
+  return registerSuperCtor(ctx, key, argCount, body, locals);
 }
 
 /**

--- a/tests/issue-5212-es2015-class-collection-super.test.ts
+++ b/tests/issue-5212-es2015-class-collection-super.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5212 — a standalone Map/Set subclass must consume the value already
+// evaluated for `super(iterable)`. The provider is deliberately tested with
+// the same literal carrier shape as direct `new Map([[k, v]])` /
+// `new Set([v])`: no AST is available after the class call has crossed the
+// externref boundary, and the argument must not be evaluated twice.
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildImports, compile, instantiateWasm } from "../src/index.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+type Lane = "host" | "standalone";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TEST262_ROOT = join(REPO_ROOT, "test262");
+
+// These are the two exact rows allocated to this issue. They are skipped when
+// the optional test262 submodule is absent from a local checkout, while CI runs
+// both rows in both lanes whenever the corpus is available.
+const EXACT_ROWS = [
+  "language/statements/class/subclass/builtin-objects/Map/regular-subclassing.js",
+  "language/statements/class/subclass/builtin-objects/Set/regular-subclassing.js",
+] as const;
+
+const CONTROL_SOURCE = `
+  class ImplicitMap extends Map<number, number> {}
+  class ExplicitMap extends Map<number, number> {
+    constructor(entries?: ReadonlyArray<readonly [number, number]> | null) {
+      super(entries);
+    }
+  }
+  class ImplicitSet extends Set<number> {}
+  class ExplicitSet extends Set<number> {
+    constructor(values?: ReadonlyArray<number> | null) {
+      super(values);
+    }
+  }
+
+  let order = 0;
+  function mapKey(): number {
+    order = order * 10 + 1;
+    return 1;
+  }
+  function mapValue(): number {
+    order = order * 10 + 2;
+    return 7;
+  }
+
+  export function test(): number {
+    // Implicit and explicit subclass constructors both retain the native
+    // iterable state, then inherited Map mutation operates on that same map.
+    const implicitMap = new ImplicitMap([[1, 10], [2, 20]]);
+    implicitMap.set(3, 30);
+    const explicitMap = new ExplicitMap([[4, 40]]);
+    explicitMap.set(5, 50);
+    if (
+      implicitMap.size !== 3 ||
+      implicitMap.get(1) !== 10 ||
+      implicitMap.get(2) !== 20 ||
+      implicitMap.get(3) !== 30 ||
+      explicitMap.size !== 2 ||
+      explicitMap.get(4) !== 40 ||
+      explicitMap.get(5) !== 50 ||
+      !(implicitMap instanceof ImplicitMap) ||
+      !(implicitMap instanceof Map) ||
+      !(explicitMap instanceof ExplicitMap) ||
+      !(explicitMap instanceof Map)
+    ) return 1;
+
+    // Set seeding uses the same native carrier contract and SameValueZero
+    // storage as direct new Set construction, so duplicates do not increase size.
+    const implicitSet = new ImplicitSet([1, 1, 2]);
+    implicitSet.add(3);
+    const explicitSet = new ExplicitSet([4, 4]);
+    explicitSet.add(5);
+    if (
+      implicitSet.size !== 3 ||
+      !implicitSet.has(2) ||
+      !implicitSet.has(3) ||
+      explicitSet.size !== 2 ||
+      !explicitSet.has(4) ||
+      !explicitSet.has(5) ||
+      !(implicitSet instanceof ImplicitSet) ||
+      !(implicitSet instanceof Set) ||
+      !(explicitSet instanceof ExplicitSet) ||
+      !(explicitSet instanceof Set)
+    ) return 2;
+
+    // The callbacks run while the source array is materialized. The provider
+    // must only read that carrier, preserving order and avoiding re-evaluation.
+    const ordered = new ImplicitMap([[mapKey(), mapValue()]]);
+    if (order !== 12 || ordered.get(1) !== 7 || ordered.size !== 1) return 3;
+
+    // Missing, null, and undefined iterable arguments all produce empty
+    // collections, matching direct native Map/Set construction.
+    const emptyMap = new ImplicitMap();
+    const nullMap = new ImplicitMap(null);
+    const undefinedMap = new ImplicitMap(undefined);
+    const emptySet = new ImplicitSet();
+    const nullSet = new ImplicitSet(null);
+    const undefinedSet = new ImplicitSet(undefined);
+    return emptyMap.size === 0 && nullMap.size === 0 && undefinedMap.size === 0 &&
+      emptySet.size === 0 && nullSet.size === 0 && undefinedSet.size === 0 ? 0 : 4;
+  }
+`;
+
+async function runControl(source: string, lane: Lane): Promise<number> {
+  const result = await compile(source, {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    fileName: "issue-5212-es2015-class-collection-super.ts",
+    ...(lane === "standalone" ? { target: "standalone" as const } : {}),
+  });
+  expect(
+    result.success,
+    `${lane} control compile failed:\n${result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")}`,
+  ).toBe(true);
+  if (!result.success) return -1;
+
+  if (lane === "standalone") {
+    const imports = result.imports.map((entry) => `${entry.module}::${entry.name}`);
+    expect(imports, "Map/Set subclass controls must stay host-free").toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    return (instance.exports as { test: () => number }).test();
+  }
+
+  const built = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setInstance?.(instance);
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function runExactRow(relativePath: (typeof EXACT_ROWS)[number], lane: Lane) {
+  const filePath = join(TEST262_ROOT, "test", relativePath);
+  try {
+    return await runTest262File(filePath, `issue-5212-${lane}`, 120_000, lane === "standalone" ? lane : undefined);
+  } finally {
+    restoreHostBuiltins();
+  }
+}
+
+describe("#5212 standalone Map/Set subclass iterable construction", () => {
+  it("host control retains iterable state, ordering, identity, and empty forms", async () => {
+    await expect(runControl(CONTROL_SOURCE, "host")).resolves.toBe(0);
+  });
+
+  it("standalone control retains iterable state without host imports", async () => {
+    await expect(runControl(CONTROL_SOURCE, "standalone")).resolves.toBe(0);
+  });
+
+  for (const relativePath of EXACT_ROWS) {
+    const filePath = join(TEST262_ROOT, "test", relativePath);
+    const exactIt = existsSync(filePath) && existsSync(join(TEST262_ROOT, "harness", "assert.js")) ? it : it.skip;
+
+    exactIt(`host exact Test262 row: ${relativePath}`, { timeout: 180_000 }, async () => {
+      const result = await runExactRow(relativePath, "host");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    });
+
+    exactIt(`standalone exact Test262 row: ${relativePath}`, { timeout: 180_000 }, async () => {
+      const result = await runExactRow(relativePath, "standalone");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    });
+  }
+});


### PR DESCRIPTION
## Description

Problem: ES2015 standalone Map and Set subclass constructors discarded their forwarded array iterables, leaving correctly branded collections empty.

Behavior: Forward the already evaluated first super argument as a narrow native array carrier, seed Map and Set through the canonical runtime helpers, preserve nullish empty construction, and reject unsupported non-array carriers. General dynamic iterables, dynamic tuple arrays, and weak collections remain explicit residual work.

Tests: Focused suite 6/6, including both exact Test262 rows in host and standalone with zero standalone imports; adjacent controls 60 passed with four pre-existing failures reproduced on clean upstream; TypeScript 5 and 7; numeric-local parity 18/18; complete commit and pre-push hooks.

Quality: Prettier, Biome, LOC and function budgets, oracle and coercion ratchets, issue integrity, IR retirement, verdict-oracle checks, and git diff checks passed.

Tracking: plan/issues/5212-es2015-class-map-set-iterable-super.md. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->