### PR TITLE
fix(standalone): honor deleted NativeError prototype names

### DIFF
--- a/plan/issues/5214-es2015-native-error-prototype-name-configurability.md
+++ b/plan/issues/5214-es2015-native-error-prototype-name-configurability.md
@@ -1,0 +1,191 @@
+---
+id: 5214
+title: "ES2015 standalone: NativeError prototype name configurability (6 rows)"
+status: in-progress
+created: 2026-08-30
+updated: 2026-08-30
+priority: high
+horizon: s
+feasibility: medium
+model: gpt-5.6-luna
+reasoning_effort: max
+task_type: conformance
+area: codegen
+language_feature: native-errors
+es_edition: ES2015
+goal: standalone-mode
+assignee: ttraenkler/codex-es6-native-error-name
+related: [4444, 5156, 4248]
+---
+
+# #5214 — NativeError prototype `name` configurability
+
+## Problem and exact scope
+
+Issue #5156 added the ES2015 `name` data property and descriptor for each
+NativeError prototype. The remaining propertyHelper failure is narrower:
+deleting the configurable `name` property removes its own descriptor, but the
+shared NativeProto presence path still reports `hasOwnProperty("name")` true.
+The inherited `Error.prototype.name` keeps the `in` operator true, so that
+disagreement makes the six exact ES2015 rows below fail their
+`configurable: true` check:
+
+```text
+test/built-ins/NativeErrors/EvalError/prototype/name.js
+test/built-ins/NativeErrors/RangeError/prototype/name.js
+test/built-ins/NativeErrors/ReferenceError/prototype/name.js
+test/built-ins/NativeErrors/SyntaxError/prototype/name.js
+test/built-ins/NativeErrors/TypeError/prototype/name.js
+test/built-ins/NativeErrors/URIError/prototype/name.js
+```
+
+The maintained 2026-08-28 host artifact reports **6/6 pass**. The fresh
+standalone census on detached diagnostic source
+`1f1004f3df195cc5f9e804efcbb2896d3871ca37` has so far recorded five of these
+rows, all as `fail/assertion_fail` with the exact signature `name descriptor
+should be configurable`; the sixth row had not yet been emitted when this task
+was filed. This diagnostic source predates current upstream and is dispatch
+evidence only. Before crediting a fix, the worker must establish the six-row
+baseline on its current-upstream worktree after the shared census releases the
+global test-worker lock.
+
+## Root-cause seam
+
+`src/codegen/native-proto-own-props.ts` already distinguishes immutable CSV
+members from seeded mutable companion entries. A deleted seeded data property
+must take its presence answer from the companion; a later CSV/spec shortcut
+must not resurrect it. The #5156 handoff established that the `name` value,
+descriptor, deletion, and `in` result are already correct, leaving the
+NativeError `name` registration/routing through that authoritative companion
+ladder as the bounded seam. The implementation must preserve the initial own
+property and its ES2015 attributes while making deletion and subsequent
+redefinition observable consistently across `hasOwnProperty`, `Object.hasOwn`,
+`propertyIsEnumerable`, and `getOwnPropertyDescriptor`.
+
+## Implementation plan
+
+1. Reproduce one row with a reduced semantic probe that checks the initial
+   value/descriptor, deletes `name`, then compares `hasOwnProperty`, `in`, and
+   `getOwnPropertyDescriptor`; confirm which NativeError brand/member mapping
+   bypasses the seeded-companion ladder.
+2. Route exactly the six NativeError `name` data properties through the existing
+   authoritative mutable-companion presence path in
+   `native-proto-own-props.ts`/its registration source. Do not special-case the
+   Test262 helper, make every prototype member mutable, or change unrelated
+   `message`, method, constructor, or symbol-member behavior.
+3. Add a focused regression test covering initial ownership and attributes,
+   successful deletion, absence on every reflective surface, and a write or
+   `defineProperty` revival. Include at least one unaffected builtin-prototype
+   method/data-property control.
+4. After the census releases the two-worker lock, run the exact six rows in
+   standalone and host modes with at most two workers, then run the focused
+   test, typecheck, formatting, budgets, and the normal hooks without skips or
+   bypasses. Record exact commands, counts, artifacts, and any residual in this
+   file.
+5. Commit with the required Thomas Tränkler authorship, Luna Max model trailer,
+   and Codex co-author trailer. Push only to `ttraenkler/js2` and open one
+   separate, non-draft PR against `loopdive/js2:main` only when the fix is
+   complete, current, tested, and mergeable; otherwise leave a truthful draft
+   checkpoint and handoff.
+
+## Implementation, evidence, and handoff checkpoint
+
+Static implementation is now present in
+`src/codegen/native-proto-own-props.ts`. The shared NativeProto presence arm
+uses three results: `1` for a present advertised member, `0` for a known seeded
+member whose companion entry is absent, and `-1` to decline so the original
+predicate can continue handling non-prototype receivers and ordinary
+expandos. The three own-property predicates preserve `0` as authoritative for
+known deleted companion entries, preventing a later CSV/intrinsic fallback
+from resurrecting a deleted NativeError `name`; the enumerable predicate
+rechecks known entries through the companion so a later enumerable redefinition
+is visible too. Its companion path tests for the `$Object` carrier before
+re-entry, so an unseeded NativeProto receiver passes through without
+recursing. This keeps the existing
+`seededNativeProtoOwnMembersByBrand` data-property registration unchanged and
+scopes the behavior to the shared presence seam.
+
+The focused regression is
+`tests/issue-5214-native-error-prototype-name.test.ts`. It covers all six
+NativeError prototypes, initial ES2015 descriptor attributes, deletion and
+own-absence across `hasOwnProperty`, `Object.hasOwn`, gOPD, and
+`propertyIsEnumerable`, preserves the inherited `in` result, checks assignment
+revival, and includes unaffected Date-method and ordinary-expando controls.
+
+Validation is complete on tested commit
+`a62aacba5ccc154f6fc378235aaaeeb4a7204231` (the requested upstream base), with
+`TEST262_WORKERS=1`, `COMPILER_POOL_SIZE=1`, and one canonical worker:
+
+```text
+focused Vitest regression: 1 file, 1 test passed
+canonical FYI worker exact matrix: 12/12 passed
+  gc host lane:         6/6 passed, runtime phase, reachedTest=true
+  standalone lane:     6/6 passed, runtime phase, reachedTest=true
+```
+
+The exact matrix used the six paths above and forked a fresh canonical worker
+realm for each intentional `verifyProperty` deletion (the expected
+`TEST262_REALM_CANARY=recycle` drift reports were observed). A preliminary
+direct in-process host diagnostic passed each primary variant but failed its
+strict rerun after the destructive deletion; that runner-realm limitation is
+not used as acceptance evidence. The canonical forked-worker run is the
+authoritative host evidence.
+
+Proportionate static gates also pass: targeted Prettier, Biome lint, both
+TypeScript no-emit configurations, LOC and function budgets, oracle/coercion
+ratchets, stack balance, codegen fallback checks, and issue-index integrity.
+The compiler bundle was rebuilt before the final matrix. No commit, remote, or
+PR state has been changed; commit hooks and delivery remain with the parent
+agent after review authorization.
+
+Commands recorded for this checkpoint (all from the isolated worktree):
+
+```text
+TEST262_WORKERS=1 COMPILER_POOL_SIZE=1 node node_modules/vitest/dist/cli.js run \
+  tests/issue-5214-native-error-prototype-name.test.ts \
+  --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=verbose
+
+TEST262_WORKERS=1 COMPILER_POOL_SIZE=1 TEST262_REALM_CANARY=recycle \
+  node --import tsx --input-type=module -e '<canonical FyiSourceExecutor matrix over the six paths above, target gc then standalone>'
+
+node_modules/.bin/esbuild src/index.ts --bundle --platform=node --format=esm \
+  --outfile=scripts/compiler-bundle.mjs --external:typescript --external:binaryen
+node_modules/.bin/prettier --check src/codegen/native-proto-own-props.ts \
+  tests/issue-5214-native-error-prototype-name.test.ts \
+  plan/issues/5214-es2015-native-error-prototype-name-configurability.md
+node_modules/.bin/biome lint src/codegen/native-proto-own-props.ts \
+  tests/issue-5214-native-error-prototype-name.test.ts --diagnostic-level=error
+node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json
+node node_modules/typescript/lib/tsc.js --noEmit
+node scripts/check-loc-budget.mjs
+node scripts/check-func-budget.mjs
+node scripts/check-oracle-ratchet.mjs
+node scripts/check-coercion-sites.mjs
+node --import tsx scripts/check-stack-balance.ts
+node --import tsx scripts/check-codegen-fallbacks.ts
+node scripts/update-issues.mjs --check
+```
+
+The omitted inline matrix body is the one-shot command used for the final
+12-row result above; it assembled each raw Test262 file with
+`parseMeta`/`assembleOriginalHarness`, then reused one
+`FyiSourceExecutor(120000)` serially per target.
+
+## Acceptance
+
+- All six exact rows pass standalone with zero fail, compile error, timeout, or
+  skip, and their six host controls remain passing.
+- The focused test proves both deletion and revival rather than only the
+  initial descriptor.
+- Unrelated builtin-prototype own-property, descriptor, and deletion controls
+  do not regress.
+- The issue records the tested commit SHA and upstream PR URL/state. A separate
+  shepherd verifies the exact head, body template, CI, reviews, conflicts, and
+  readiness before landing.
+
+## Handoff
+
+This task owns only the six NativeError prototype-`name` rows and their shared
+mutable-companion presence seam. It must not absorb #5156's remaining Symbol,
+Function, Error-stack, realm, or NewTarget clusters. No GitHub issue is to be
+created; this markdown file is the issue of record.

--- a/plan/issues/5214-es2015-native-error-prototype-name-configurability.md
+++ b/plan/issues/5214-es2015-native-error-prototype-name-configurability.md
@@ -1,9 +1,10 @@
 ---
 id: 5214
 title: "ES2015 standalone: NativeError prototype name configurability (6 rows)"
-status: in-progress
+status: done
 created: 2026-08-30
 updated: 2026-08-30
+completed: 2026-08-30
 priority: high
 horizon: s
 feasibility: medium
@@ -14,6 +15,7 @@ area: codegen
 language_feature: native-errors
 es_edition: ES2015
 goal: standalone-mode
+pr: 5287
 assignee: ttraenkler/codex-es6-native-error-name
 related: [4444, 5156, 4248]
 ---
@@ -112,9 +114,9 @@ own-absence across `hasOwnProperty`, `Object.hasOwn`, gOPD, and
 `propertyIsEnumerable`, preserves the inherited `in` result, checks assignment
 revival, and includes unaffected Date-method and ordinary-expando controls.
 
-Validation is complete on tested commit
-`a62aacba5ccc154f6fc378235aaaeeb4a7204231` (the requested upstream base), with
-`TEST262_WORKERS=1`, `COMPILER_POOL_SIZE=1`, and one canonical worker:
+Validation is complete on the implementation tree based on upstream commit
+`a62aacba5ccc154f6fc378235aaaeeb4a7204231`, with `TEST262_WORKERS=1`,
+`COMPILER_POOL_SIZE=1`, and one canonical worker:
 
 ```text
 focused Vitest regression: 1 file, 1 test passed
@@ -134,9 +136,14 @@ authoritative host evidence.
 Proportionate static gates also pass: targeted Prettier, Biome lint, both
 TypeScript no-emit configurations, LOC and function budgets, oracle/coercion
 ratchets, stack balance, codegen fallback checks, and issue-index integrity.
-The compiler bundle was rebuilt before the final matrix. No commit, remote, or
-PR state has been changed; commit hooks and delivery remain with the parent
-agent after review authorization.
+The compiler bundle was rebuilt before the final matrix. The complete commit
+hook then passed without a skip, including lint-staged formatting/lint, budgets,
+the changed-root focused regression (1/1), and the oracle ratchet. The complete
+pre-push hook passed typecheck plus lint, repository Prettier, oracle/coercion
+ratchets, numeric-local parity (18/18), conformance synchronization, and issue
+integrity. Implementation commit
+`ceb7399ab603343a12c91b2563b7c6b52299f034` was published to the fork and read
+back at that exact SHA without rewriting history.
 
 Commands recorded for this checkpoint (all from the isolated worktree):
 
@@ -189,3 +196,11 @@ This task owns only the six NativeError prototype-`name` rows and their shared
 mutable-companion presence seam. It must not absorb #5156's remaining Symbol,
 Function, Error-stack, realm, or NewTarget clusters. No GitHub issue is to be
 created; this markdown file is the issue of record.
+
+The single completed-fix PR is
+<https://github.com/loopdive/js2/pull/5287>. It is a non-draft PR from
+`ttraenkler:codex/5214-native-error-prototype-name` to `loopdive/js2:main` with
+the exact repository Description/CLA format. A dedicated Luna Max PR shepherd
+owns exact-head, body, readiness, conflict, review, CI, and queue verification.
+Any later documentation-only handoff commit does not change the validated code
+at implementation head `ceb7399ab603343a12c91b2563b7c6b52299f034`.

--- a/src/codegen/native-proto-own-props.ts
+++ b/src/codegen/native-proto-own-props.ts
@@ -48,12 +48,14 @@
  *
  * ## Consult-only, and builtin-only
  *
- * The arm answers `1` and returns, or falls through to the untouched original
- * body. It never answers `0` authoritatively, so a prototype carrying an
- * ordinary expando still finds it through the existing path. It also declines
- * on `$isClass != 0`: a user CLASS proto is a `$NativeProto` façade over the
- * class's own machinery (#2101), whose own-property question is answered
- * elsewhere, and widening it here would change behaviour no test asked for.
+ * The arm answers `1` for a present advertised member or `0` for a known
+ * advertised member whose companion entry was deleted, and returns in either
+ * case. It answers `-1` when it does not own the query so the untouched
+ * original body can still find an ordinary expando (or answer for a non-proto
+ * receiver). It also declines on `$isClass != 0`: a user CLASS proto is a
+ * `$NativeProto` façade over the class's own machinery (#2101), whose
+ * own-property question is answered elsewhere, and widening it here would
+ * change behaviour no test asked for.
  *
  * ## Demand gate
  *
@@ -91,6 +93,8 @@ const STR_OFF = 1;
 const STR_DATA = 2;
 /** The CSV delimiter the glue joins member names with. */
 const COMMA = 0x2c;
+/** `__nproto_hasown` declines, leaving the original predicate body in charge. */
+const NATIVE_PROTO_NO_DECISION = -1;
 
 export const NATIVE_PROTO_HASOWN_FN = "__nproto_hasown";
 
@@ -203,8 +207,10 @@ function nativeProtoHasInstanceOwnArm(
 }
 
 /**
- * Register `__nproto_hasown(obj externref, key externref) -> i32`: 1 when `key`
- * names an OWN property of a BUILTIN prototype object `obj`, else 0.
+ * Register `__nproto_hasown(obj externref, key externref) -> i32`: 1 when
+ * `key` names a present OWN property of a BUILTIN prototype object `obj`, 0
+ * when it names a known seeded member whose companion entry is absent, and -1
+ * when this arm declines so the original predicate body can continue.
  *
  * Returns the funcIdx, or `undefined` when the module has no `$NativeProto`
  * (the demand gate) or the native-string subsystem is absent.
@@ -252,7 +258,7 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
     { name: "c", type: { kind: "i32" } },
   ];
 
-  const returnZero: Instr[] = [{ op: "i32.const", value: 0 }, { op: "return" }];
+  const returnNoDecision: Instr[] = [{ op: "i32.const", value: NATIVE_PROTO_NO_DECISION }, { op: "return" }];
   /** `<flat>.data[<flat>.off + <index expr>]` as an unsigned char code. */
   const charAt = (strLocal: number, indexExpr: Instr[]): Instr[] => [
     { op: "local.get", index: strLocal },
@@ -273,12 +279,12 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
     { op: "local.tee", index: L_ANY },
     { op: "ref.test", typeIdx: protoTypeIdx },
     { op: "i32.eqz" },
-    { op: "if", blockType: { kind: "empty" }, then: returnZero },
+    { op: "if", blockType: { kind: "empty" }, then: returnNoDecision },
     // … for a BUILTIN, not a user class (see the module note).
     { op: "local.get", index: L_ANY },
     { op: "ref.cast", typeIdx: protoTypeIdx },
     { op: "struct.get", typeIdx: protoTypeIdx, fieldIdx: NP_IS_CLASS },
-    { op: "if", blockType: { kind: "empty" }, then: returnZero },
+    { op: "if", blockType: { kind: "empty" }, then: returnNoDecision },
     // Symbol.hasInstance is an own Function.prototype method.
     ...nativeProtoHasInstanceOwnArm(protoTypeIdx, functionBrand, symbolType, L_ANY),
     // Well-known symbol tags are own data properties of the collection
@@ -377,7 +383,7 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
     { op: "any.convert_extern" },
     { op: "ref.test", typeIdx: anyStr },
     { op: "i32.eqz" },
-    { op: "if", blockType: { kind: "empty" }, then: returnZero },
+    { op: "if", blockType: { kind: "empty" }, then: returnNoDecision },
     { op: "local.get", index: 1 },
     { op: "any.convert_extern" },
     { op: "ref.cast", typeIdx: anyStr },
@@ -440,7 +446,7 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
     { op: "any.convert_extern" },
     { op: "ref.test", typeIdx: anyStr },
     { op: "i32.eqz" },
-    { op: "if", blockType: { kind: "empty" }, then: returnZero },
+    { op: "if", blockType: { kind: "empty" }, then: returnNoDecision },
     { op: "local.get", index: L_ANY },
     { op: "ref.cast", typeIdx: protoTypeIdx },
     { op: "struct.get", typeIdx: protoTypeIdx, fieldIdx: NP_MEMBER_CSV },
@@ -550,7 +556,7 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
         },
       ],
     },
-    { op: "i32.const", value: 0 },
+    { op: "i32.const", value: NATIVE_PROTO_NO_DECISION },
   ];
 
   const typeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
@@ -580,21 +586,72 @@ export function registerNativeProtoHasOwn(ctx: CodegenContext): number | undefin
  */
 export function unshiftNativeProtoHasOwnArms(ctx: CodegenContext): void {
   const funcIdx = registerNativeProtoHasOwn(ctx);
+  const protoOwnRecvIdx = ctx.funcMap.get("__protoidx_own_recv");
+  const objectTypeIdx = ctx.objectRuntimeTypes?.objectTypeIdx;
   if (funcIdx === undefined) return;
   for (const name of ["__hasOwnProperty", "__object_hasOwn", "__propertyIsEnumerable"]) {
     const fn = ctx.mod.functions.find((candidate) => candidate.name === name);
     if (!fn) continue;
+    const predicateIdx = ctx.funcMap.get(name);
+    const fnType = ctx.mod.types[fn.typeIdx];
+    const paramCount = fnType?.kind === "func" ? fnType.params.length : 2;
+    const resultLocal = fn.locals.length + paramCount;
+    fn.locals.push({ name: "__nproto_result", type: { kind: "i32" } });
+    const companionLocal =
+      name === "__propertyIsEnumerable" &&
+      protoOwnRecvIdx !== undefined &&
+      predicateIdx !== undefined &&
+      objectTypeIdx !== undefined
+        ? fn.locals.length + paramCount
+        : undefined;
+    if (companionLocal !== undefined) {
+      fn.locals.push({ name: "__nproto_companion", type: { kind: "externref" } });
+    }
     fn.body.unshift(
       { op: "local.get", index: 0 },
       { op: "local.get", index: 1 },
       { op: "call", funcIdx },
+      { op: "local.tee", index: resultLocal },
+      { op: "i32.const", value: NATIVE_PROTO_NO_DECISION },
+      { op: "i32.ne" },
       {
         op: "if",
         blockType: { kind: "empty" },
         then: [
-          // §15.x.4 — every builtin prototype member is `{ DontEnum }`, so the
-          // enumerability predicate answers 0 where presence answers 1.
-          { op: "i32.const", value: name === "__propertyIsEnumerable" ? 0 : 1 },
+          // The NativeProto arm returns 0 for a known seeded member whose
+          // companion entry was deleted, so that absence must be authoritative
+          // instead of falling through to a stale CSV/intrinsic answer. For
+          // propertyIsEnumerable, re-run the predicate on the companion so a
+          // post-seed redefinition's enumerable flag is observed as well. The
+          // initial advertised members are `{ DontEnum }`, and a deleted entry
+          // naturally returns 0 from the companion's ordinary object path. An
+          // unseeded brand's own-receiver helper passes the `$NativeProto`
+          // through; the `$Object` type test below keeps that path from
+          // recursively re-entering this wrapper.
+          ...(name === "__propertyIsEnumerable"
+            ? protoOwnRecvIdx !== undefined &&
+              predicateIdx !== undefined &&
+              objectTypeIdx !== undefined &&
+              companionLocal !== undefined
+              ? [
+                  { op: "local.get", index: 0 } as Instr,
+                  { op: "call", funcIdx: protoOwnRecvIdx } as Instr,
+                  { op: "local.tee", index: companionLocal } as Instr,
+                  { op: "any.convert_extern" } as Instr,
+                  { op: "ref.test", typeIdx: objectTypeIdx } as Instr,
+                  {
+                    op: "if",
+                    blockType: { kind: "val", type: { kind: "i32" } },
+                    then: [
+                      { op: "local.get", index: companionLocal } as Instr,
+                      { op: "local.get", index: 1 } as Instr,
+                      { op: "call", funcIdx: predicateIdx } as Instr,
+                    ],
+                    else: [{ op: "i32.const", value: 0 }],
+                  } as Instr,
+                ]
+              : [{ op: "i32.const", value: 0 } as Instr]
+            : [{ op: "local.get", index: resultLocal } as Instr]),
           { op: "return" },
         ],
       },

--- a/tests/issue-5214-native-error-prototype-name.test.ts
+++ b/tests/issue-5214-native-error-prototype-name.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5214 — NativeError prototype `name` must remain configurable through the
+// standalone NativeProto companion's own-property presence path.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(body: string): Promise<number> {
+  const result = await compile(`export function test(): number { ${body} }`, {
+    allowJs: true,
+    fileName: "issue-5214-native-error-prototype-name.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  if (!result.success) return -1;
+  expect(result.imports.filter((entry) => entry.module === "env")).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#5214 — standalone NativeError prototype name configurability", () => {
+  it("keeps all six names visible, deletable, absent, and revivable", async () => {
+    await expect(
+      runStandalone(`
+        function check(proto: any, key: string, expected: string): boolean {
+          const initial: any = Object.getOwnPropertyDescriptor(proto, key);
+          if (initial === undefined || initial.value !== expected ||
+              initial.writable !== true || initial.enumerable !== false ||
+              initial.configurable !== true) return false;
+          if (!Object.prototype.hasOwnProperty.call(proto, key) ||
+              !Object.hasOwn(proto, key) ||
+              proto.propertyIsEnumerable(key)) return false;
+          const inheritedBefore = key in proto;
+
+          if (!delete proto[key]) return false;
+          if (Object.prototype.hasOwnProperty.call(proto, key)) return false;
+          if (Object.hasOwn(proto, key)) return false;
+          if (Object.getOwnPropertyDescriptor(proto, key) !== undefined) return false;
+          if ((key in proto) !== inheritedBefore) return false;
+          if (proto.propertyIsEnumerable(key)) return false;
+
+          proto[key] = expected;
+          const revived: any = Object.getOwnPropertyDescriptor(proto, key);
+          return revived !== undefined && revived.value === expected &&
+            revived.writable === true && revived.enumerable === true &&
+            revived.configurable === true && Object.hasOwn(proto, key) &&
+            proto.propertyIsEnumerable(key);
+        }
+
+        function methodControl(proto: any, key: string): boolean {
+          const descriptor: any = Object.getOwnPropertyDescriptor(proto, key);
+          return descriptor !== undefined && descriptor.writable === true &&
+            descriptor.enumerable === false && descriptor.configurable === true &&
+            Object.hasOwn(proto, key) && !proto.propertyIsEnumerable(key);
+        }
+
+        function expandoControl(proto: any): boolean {
+          const key = "issue5214Expando";
+          proto[key] = 7;
+          const present = Object.hasOwn(proto, key) &&
+            Object.prototype.hasOwnProperty.call(proto, key);
+          const removed = delete proto[key] && !Object.hasOwn(proto, key) &&
+            Object.getOwnPropertyDescriptor(proto, key) === undefined;
+          return present && removed;
+        }
+
+        if (!check(EvalError.prototype, "name", "EvalError")) return 1;
+        if (!check(RangeError.prototype, "name", "RangeError")) return 1;
+        if (!check(ReferenceError.prototype, "name", "ReferenceError")) return 1;
+        if (!check(SyntaxError.prototype, "name", "SyntaxError")) return 1;
+        if (!check(TypeError.prototype, "name", "TypeError")) return 1;
+        if (!check(URIError.prototype, "name", "URIError")) return 1;
+        if (!methodControl(Date.prototype, "toString")) return 2;
+        if (!expandoControl(Date.prototype)) return 3;
+        return 0;
+      `),
+    ).resolves.toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

Problem: Deleting the configurable name property from each ES2015 NativeError prototype removed its descriptor but stale advertised NativeProto membership still made own-property predicates report it present.

Behavior: Make native-prototype own-property lookup tri-state so deleted seeded companion entries are authoritative, and recheck enumerable state through the mutable companion while preserving ordinary expandos, class prototypes, non-native receivers, and immutable builtin members.

Tests: Focused NativeError regression 1/1; exact canonical matrix 12/12 across six host and six standalone rows; TypeScript 5 and 7; numeric-local parity 18/18; complete commit and pre-push hooks.

Quality: Prettier, Biome, LOC and function budgets, oracle and coercion ratchets, stack balance, codegen fallback checks, issue integrity, and git diff checks passed.

Tracking: plan/issues/5214-es2015-native-error-prototype-name-configurability.md. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->