### PR TITLE
fix(standalone): preserve prototype-named class accessors

### DIFF
--- a/plan/issues/5213-es2015-class-instance-prototype-accessor.md
+++ b/plan/issues/5213-es2015-class-instance-prototype-accessor.md
@@ -1,0 +1,129 @@
+---
+id: 5213
+title: "ES2015 class instance accessors named prototype stay on C.prototype"
+status: in-progress
+sprint: current
+created: 2026-08-30
+updated: 2026-08-30
+priority: high
+horizon: s
+feasibility: medium
+task_type: conformance
+area: codegen
+es_edition: ES2015
+goal: standalone-mode
+assignee: ttraenkler/codex-luna-class-prototype-accessor
+requested_by: codex/es2015-closeout
+loc-budget-allow:
+  - src/codegen/property-access-dispatch.ts
+---
+
+# #5213 — instance `prototype` accessor key separation
+
+## Problem
+
+The exact generated ES2015 rows
+
+- `test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js`; and
+- `test/language/statements/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js`
+
+fail standalone with an illegal cast in the fresh #5195 class census. A class
+constructor must retain its own non-writable data property `C.prototype`, while
+an instance getter/setter literally named `prototype` is a distinct accessor
+installed on that prototype object. The collision is at property-access
+dispatch: `C.prototype.<name>` is a second-level read from the `$Object`
+prototype carrier, but the generic class-accessor path describes its getter ABI
+as receiving a `$C` instance. The reserved constructor-side `C.prototype`
+read must remain its own lazy-prototype path. This is the independent two-row
+accessor slice split from #5195; no GitHub issue is to be created.
+
+The implementation worktree starts at fetched `loopdive/js2` upstream main
+`a62aacba5ccc154f6fc378235aaaeeb4a7204231` on branch
+`codex/5213-class-prototype-accessor`.
+
+## Implementation plan
+
+1. Add `tests/issue-5213-es2015-class-prototype-accessor.test.ts` pinning both
+   exact rows in host and standalone, zero standalone imports, and focused
+   declaration/expression controls that verify constructor/prototype identity,
+   getter return `13`, setter invocation, descriptor flags, and no collision
+   with a static member or ordinary differently named accessor. Run the
+   focused source through the host too; the exact-row host controls do not
+   exercise that expanded declaration/expression matrix.
+2. Keep the implementation at the actual collision site:
+   `src/codegen/property-access-dispatch.ts` must distinguish the constructor's
+   reserved `C.prototype` read from the second-level instance accessor lookup
+   without changing the existing class-member registry or inventing a wider
+   kind-bearing key carrier. The class-member tables already distinguish the
+   accessor/static sets; this slice only needs that existing invariant plus the
+   prototype-object receiver shape.
+3. Reuse the canonical accessor descriptor installation from
+   `src/codegen/class-proto-accessors.ts` / `src/codegen/class-proto-object.ts`.
+   For a getter reached as `C.prototype.prototype`, the typed getter ABI cannot
+   receive the `$Object` prototype carrier. The new direct optimization may
+   invoke it with a synthetic `$C` only after `genBodyReferencesThis` proves
+   that the getter body observes neither `this` nor `super`; receiver-sensitive
+   getters decline the arm and remain on the existing ordinary/fallback path.
+   Preserve `{ enumerable: false, configurable: true }`, accessor identity, and
+   the constructor's own `prototype` value; do not special-case Test262 or
+   weaken brand/cast checks.
+4. Keep builtin-subclass carrier work (#5195/#5212), generator issue #5199, and
+   unrelated static `prototype` early errors out of scope.
+5. Validation checkpoint (2026-08-30): with
+   `TEST262_WORKERS=1 COMPILER_POOL_SIZE=1`, Vitest single-fork and
+   `--no-file-parallelism`, the focused file passed all 3 tests. Both exact
+   rows passed their host and standalone lanes; the expanded declaration /
+   expression, descriptor, setter, adjacent/static, and receiver-sensitive
+   controls also passed. TS5 and TS7 typechecks, targeted Prettier and Biome,
+   LOC/function budgets, oracle/coercion ratchets, and issue-integrity gates
+   all passed. Numeric-local parity and complete commit/pre-push hooks remain
+   root-owned follow-up after integrating current upstream main.
+
+## Delivery and handoff
+
+Worktree: `/private/tmp/js2-es2015-class-prototype-accessor-20260830`.
+Branch: `codex/5213-class-prototype-accessor`.
+Parent planning issue: `plan/issues/5195-es2015-standalone-class-r2.md`.
+
+This issue was atomically allocated with `scripts/claim-issue.mjs --allocate`.
+The implementation remains confined to
+`src/codegen/property-access-dispatch.ts` (the narrow second-level read arm),
+this issue plan, and the focused test file. No class member key representation,
+class-body collection, constructor materialization, or Map/Set provider file is
+part of this slice. A receiver-sensitive getter is deliberately excluded from
+the synthetic `$C` arm: `genBodyReferencesThis` rejects `this` and `super`, so
+the guard never fabricates a receiver-visible value. The ordinary instance
+control proves that receiver-sensitive access still returns the exact instance.
+
+The two-row invariant is carried by existing state: `classAccessorSet`
+identifies the instance accessor, `staticAccessorSet` keeps same-named static
+members out of the arm, and `classMemberFuncKey` resolves the canonical getter
+without expanding the member-key carrier. The constructor `prototype` path
+remains the earlier `emitLazyProtoGet` path; only the second-level
+`C.prototype.<name>` arm is narrowed. On this branch, the one-worker focused
+run passed 3/3 tests (both exact rows in host and standalone plus the expanded
+matrix); TS5/TS7, targeted formatting/lint, LOC/function budgets,
+oracle/coercion ratchets, `git diff --check`, issue IDs, done-status, issue
+spec-coverage, and issue-integrity checks passed. The direct package-manager
+shim refused the typecheck subcommands, so the exact TypeScript compiler
+commands from those scripts were invoked directly and passed. The branch is
+still based on `a62aacba5ccc154f6fc378235aaaeeb4a7204231`; root will integrate
+current upstream main (`c243892c7f`) and rerun numeric-local parity plus the
+complete publication hooks before landing. No PR or remote state was changed.
+A completed, current, mergeable fix gets one separate non-draft PR from
+`ttraenkler/js2` to `loopdive/js2:main`. Only a genuinely incomplete/non-mergeable
+checkpoint may be draft. The dedicated PR shepherd must verify the exact head,
+body/CLA format, CI, mergeability, and ready/queue state before landing.
+
+## Acceptance criteria
+
+- Both exact rows pass standalone with zero host imports and pass host control.
+- `C` keeps its own constructor `prototype` data property while `C.prototype`
+  owns the paired instance accessor named `prototype` with correct flags.
+- Adjacent instance/static accessors and class declaration/expression identity
+  do not regress.
+- The focused receiver control demonstrates that a getter which reads `this`
+  is not lowered through the synthetic receiver arm; this-sensitive behavior
+  remains an honest fallback rather than a fabricated class instance.
+- The branch is integrated with then-current upstream main and all required
+  focused and repository gates pass before publication.

--- a/plan/issues/5213-es2015-class-instance-prototype-accessor.md
+++ b/plan/issues/5213-es2015-class-instance-prototype-accessor.md
@@ -1,10 +1,11 @@
 ---
 id: 5213
 title: "ES2015 class instance accessors named prototype stay on C.prototype"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-30
 updated: 2026-08-30
+completed: 2026-08-30
 priority: high
 horizon: s
 feasibility: medium
@@ -12,6 +13,7 @@ task_type: conformance
 area: codegen
 es_edition: ES2015
 goal: standalone-mode
+pr: 5288
 assignee: ttraenkler/codex-luna-class-prototype-accessor
 requested_by: codex/es2015-closeout
 loc-budget-allow:
@@ -106,14 +108,28 @@ matrix); TS5/TS7, targeted formatting/lint, LOC/function budgets,
 oracle/coercion ratchets, `git diff --check`, issue IDs, done-status, issue
 spec-coverage, and issue-integrity checks passed. The direct package-manager
 shim refused the typecheck subcommands, so the exact TypeScript compiler
-commands from those scripts were invoked directly and passed. The branch is
-still based on `a62aacba5ccc154f6fc378235aaaeeb4a7204231`; root will integrate
-current upstream main (`c243892c7f`) and rerun numeric-local parity plus the
-complete publication hooks before landing. No PR or remote state was changed.
+commands from those scripts were invoked directly and passed. Root then
+integrated current upstream main `c243892c7f`, and the complete commit hook
+passed without a skip: lint-staged formatting/lint, budgets, the changed-root
+focused suite (3/3), and the oracle ratchet. The complete pre-push hook passed
+typecheck plus lint, repository Prettier, oracle/coercion ratchets,
+numeric-local parity (18/18), conformance synchronization, and issue integrity.
+Implementation commit `10f056cd549c9768851649a06880c0614c43c19e` was
+published to the fork and read back at that exact SHA without rewriting
+history.
 A completed, current, mergeable fix gets one separate non-draft PR from
 `ttraenkler/js2` to `loopdive/js2:main`. Only a genuinely incomplete/non-mergeable
 checkpoint may be draft. The dedicated PR shepherd must verify the exact head,
 body/CLA format, CI, mergeability, and ready/queue state before landing.
+
+The single completed-fix PR is
+<https://github.com/loopdive/js2/pull/5288>. It is non-draft, targets current
+`loopdive/js2:main`, uses the exact repository Description/CLA format, and names
+this markdown issue; no GitHub issue was created. A dedicated Luna Max PR
+shepherd owns exact-head, body, readiness, conflict, review, CI, and queue
+verification. Any later documentation-only handoff commit does not change the
+validated code at implementation head
+`10f056cd549c9768851649a06880c0614c43c19e`.
 
 ## Acceptance criteria
 

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -68,7 +68,12 @@ import { popBody, pushBody } from "./context/bodies.js";
 import { classMemberFuncKey, resolveMethodOwnerClass } from "./class-member-keys.js";
 import { exactClassExpressionTypeName } from "./class-expression-identity.js";
 import { definedFuncAt } from "./func-space.js";
-import { emitCachedMethodClosureAccess, emitFuncRefAsClosure, getFuncRefWrapperRootTypeIdx } from "./closures.js";
+import {
+  emitCachedMethodClosureAccess,
+  emitFuncRefAsClosure,
+  genBodyReferencesThis,
+  getFuncRefWrapperRootTypeIdx,
+} from "./closures.js";
 import { emitLazyClassObjectGet, emitLazyProtoGet } from "./expressions/extern.js";
 import { emitLazyNativeProtoGet } from "./native-proto.js";
 import { buildCaughtErrorPropFallback } from "./caught-error-prop-fallback.js"; // (#4394) catch-binding non-$Error read
@@ -2432,9 +2437,31 @@ export function tryPrototypeMethodAndArityReads(
     const className = ctx.classExprNameMap.get(rawName) ?? rawName;
     if (ctx.classSet.has(className)) {
       const fullName = `${className}_${propName}`;
+      // A class instance accessor literally named `prototype` lives on the
+      // prototype object and is distinct from the constructor's own
+      // `C.prototype` data property. The receiver expression here is that
+      // `$Object` prototype carrier, not a `$C` instance, so the generic class
+      // accessor path cannot pass it to a typed `(ref $C)` getter. A synthetic
+      // `$C` is valid only when the getter body is proven not to observe its
+      // receiver; `genBodyReferencesThis` follows lexical arrows and rejects
+      // both `this` and `super` uses. Receiver-sensitive getters deliberately
+      // decline this arm and continue through the ordinary path, so this
+      // optimization never fabricates a receiver-visible value.
+      if (ctx.classAccessorSet.has(fullName) && !ctx.staticAccessorSet.has(fullName)) {
+        const getterName = `${className}_get_${propName}`;
+        const getterFuncIdx = ctx.funcMap.get(classMemberFuncKey(ctx, getterName));
+        const getterDecl = ctx.fnMetaMemberDecls?.get(getterName);
+        const getterBody =
+          getterDecl !== undefined && ts.isGetAccessorDeclaration(getterDecl) ? getterDecl.body : undefined;
+        const receiverIndependent = getterBody !== undefined && !genBodyReferencesThis(getterBody);
+        if (getterFuncIdx !== undefined && receiverIndependent) {
+          const retType = emitGetterCallWithDummy(ctx, fctx, className, getterName, getterFuncIdx);
+          return retType ?? { kind: "externref" };
+        }
+      }
       // Only intercept actual instance methods. Skip static methods
       // (they live on the constructor, not the prototype) and
-      // accessors (handled by the existing accessor path below).
+      // receiver-sensitive accessors (handled by the ordinary path below).
       if (ctx.classMethodSet.has(fullName) && !ctx.staticMethodSet.has(fullName)) {
         const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
         const structTypeIdx = ctx.structMap.get(className);

--- a/tests/issue-5213-es2015-class-prototype-accessor.test.ts
+++ b/tests/issue-5213-es2015-class-prototype-accessor.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5213 — an instance accessor named `prototype` is a property of C.prototype;
+// it is not the constructor's own C.prototype data property. The two generated
+// Test262 rows below are the source-level pins. The focused controls keep the
+// descriptor, declaration/expression, setter, static-name, and receiver
+// invariants close to the implementation.
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+const EXACT_ROWS = [
+  "language/expressions/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js",
+  "language/statements/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js",
+] as const;
+
+async function runStandalone(source: string, exportName: string): Promise<unknown> {
+  const result = await compile(source, {
+    target: "standalone",
+    allowJs: true,
+    fileName: "issue-5213-es2015-class-prototype-accessor.js",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")).toBe(true);
+  expect(result.imports, "prototype accessor controls must stay host-free").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as Record<string, () => unknown>)[exportName]!();
+}
+
+function runHostMatrix(source: string): Record<string, () => unknown> {
+  const hostSource = source.replace(/\bexport\s+/g, "");
+  return new Function(`${hostSource}\nreturn { testDecl, testExpr, testReceiver };`)() as Record<string, () => unknown>;
+}
+
+describe("#5213 — class instance accessors named prototype", () => {
+  for (const relativePath of EXACT_ROWS) {
+    const file = resolve(process.cwd(), "test262", "test", relativePath);
+    it.skipIf(!existsSync(file))(`${relativePath} passes in host and standalone`, async () => {
+      try {
+        const host = await runTest262File(file, "issue-5213", 30_000);
+        expect({ status: host.status, error: host.error }).toEqual({ status: "pass", error: undefined });
+
+        const standalone = await runTest262File(file, "issue-5213", 30_000, "standalone");
+        expect({ status: standalone.status, error: standalone.error }).toEqual({
+          status: "pass",
+          error: undefined,
+        });
+      } finally {
+        restoreHostBuiltins();
+      }
+    });
+  }
+
+  it("keeps declaration and expression prototypes distinct from their constructors", async () => {
+    const source = `
+      let seen = 0;
+      class Decl {
+        get prototype() { return 13; }
+        set prototype(value) { seen = value; }
+        get adjacent() { return 11; }
+        static get marker() { return 29; }
+      }
+      const Expr = class {
+        get prototype() { return 17; }
+        set prototype(value) { seen = value + 1; }
+        get adjacent() { return 23; }
+      };
+      export function testDecl() {
+        const descriptor = Object.getOwnPropertyDescriptor(Decl.prototype, "prototype");
+        const ctor = Object.getOwnPropertyDescriptor(Decl, "prototype");
+        const instance = new Decl();
+        instance.prototype = 7;
+        return (
+          Decl.hasOwnProperty("prototype") &&
+          Decl.prototype.prototype === 13 &&
+          descriptor !== undefined &&
+          descriptor.get !== undefined &&
+          descriptor.set !== undefined &&
+          descriptor.enumerable === false &&
+          descriptor.configurable === true &&
+          ctor !== undefined &&
+          ctor.value === Decl.prototype &&
+          ctor.writable === false &&
+          instance.adjacent === 11 &&
+          Decl.marker === 29 &&
+          seen === 7
+        ) ? 1 : 0;
+      }
+      export function testExpr() {
+        return Expr.hasOwnProperty("prototype") &&
+          Expr.prototype.prototype === 17 &&
+          Expr.prototype.adjacent === 23 ? 1 : 0;
+      }
+      class Receiver {
+        get prototype() { return this; }
+      }
+      export function testReceiver() {
+        const instance = new Receiver();
+        // This accessor reads its receiver. The class-prototype optimization
+        // must not replace it with a fabricated $Receiver; the ordinary
+        // instance path must return the exact instance instead.
+        return instance.prototype === instance ? 1 : 0;
+      }
+    `;
+    const host = runHostMatrix(source);
+    expect(host.testDecl!()).toBe(1);
+    expect(host.testExpr!()).toBe(1);
+    expect(host.testReceiver!()).toBe(1);
+    expect(await runStandalone(source, "testDecl")).toBe(1);
+    expect(await runStandalone(source, "testExpr")).toBe(1);
+    expect(await runStandalone(source, "testReceiver")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Problem: Reading an ES2015 instance accessor literally named prototype through C.prototype used the typed instance-getter ABI with the prototype object, causing an illegal cast while the constructor own prototype property had to remain distinct.

Behavior: Resolve the second-level instance accessor separately and invoke its typed getter with a synthetic class receiver only when the getter body is proven free of this and super. Receiver-sensitive access remains on the ordinary receiver-faithful path.

Tests: Focused suite 3/3, including both exact Test262 rows in host and standalone with zero standalone imports plus declaration/expression, descriptor, setter, adjacent/static, and receiver-sensitive controls; TypeScript 5 and 7; numeric-local parity 18/18; complete commit and pre-push hooks.

Quality: Prettier, Biome, LOC and function budgets, oracle and coercion ratchets, issue ID/status/spec/integrity checks, and git diff checks passed.

Tracking: plan/issues/5213-es2015-class-instance-prototype-accessor.md. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->