### PR TITLE
docs(test262): record incomplete ES2015 census handoff

### DIFF
--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -1,11 +1,11 @@
 ---
 id: 4444
-title: "UMBRELLA: ES6 (ES2015) standalone edition close-out — 7,695/11,704 (66%) → 100%"
+title: "UMBRELLA: ES6 (ES2015) standalone edition close-out — 8,681/11,704 (74%) → 100%"
 status: in-progress
 sprint: current
 created: 2026-08-15
-updated: 2026-08-15
-assignee: claude/es6-standalone-session
+updated: 2026-08-30
+assignee: codex/es6-test262-closeout
 priority: high
 horizon: xl
 feasibility: hard
@@ -110,4 +110,107 @@ Completion requires a fresh authoritative standalone run on the final
 integrated head reporting exactly 11,704 pass / 11,704 total with zero fail,
 compile error, compile timeout, or skip. Host runs remain required per-slice
 regression controls, not a second completion bar. Until the standalone proof
-exists, this umbrella and its PRs remain in progress/draft.
+exists, this umbrella remains in progress. Individual completed fixes may be
+ready and landed; draft state is reserved for an incomplete or non-mergeable
+checkpoint.
+
+## 2026-08-30 Codex resumption and implementation handoff
+
+The 2026-08-27 reference above to a single draft integration PR #5010 is
+historical and no longer governs delivery. Current delivery uses one separate
+upstream PR per completed fix; only an incomplete or non-mergeable checkpoint
+may be draft.
+
+The latest complete exact-filter artifact available at resumption is the
+2026-08-28 maintained standalone snapshot. Selecting the frozen 11,704-row
+ES2015 map produces **8,681 pass / 2,513 fail / 509 compile_error / 1
+compile_timeout / 0 skip**. The artifact SHA-256 is
+`260a57b7fb4d53516fa81e1c949d81337968e30ce790d457bcc2d3945c2e9e1e`; the
+exact path-map SHA-256 is
+`45de809c6bfce7371cee1d20e327758246b0524ecd75481a08b8c03344fced8a`.
+Because that artifact does not embed its source commit and predates the
+current upstream tree, it is a dispatch baseline, not final acceptance
+evidence. Per-slice gains are never added arithmetically to this headline.
+
+Coordination refreshed `loopdive/js2` upstream main to
+`a62aacba5ccc154f6fc378235aaaeeb4a7204231`; a fresh fetch immediately after
+the diagnostic confirmed that this is still the authoritative upstream head.
+The #5194/#5195/#5197/#5198 worktrees and the new #5212/#5213/#5214 lanes are
+based on that exact commit. #5131 has integrated it locally but still requires
+validation and a corrected commit trailer before its published draft can be
+updated.
+
+The full maintained-runner diagnostic on detached source
+`1f1004f3df195cc5f9e804efcbb2896d3871ca37` finished all 16 shards of the
+11,704-row map with standalone target, two workers, the QuickJS artifact, and
+official-scope-only filtering. Vitest's own final summary proves it registered
+and executed **11,704 tests**. The canonical JSONL is nevertheless incomplete:
+it has **11,685 physical rows / 11,685 unique paths / 8,974 pass / 2,258 fail /
+447 compile_error / 6 compile_timeout / 0 skip**. It contains no malformed
+rows, duplicate identities, or paths outside the filter, but is missing 19
+selected paths. Its SHA-256 is
+`47f34c307c43b06c9c40bb0df754bc22d94435a23cccfdd6de857816e199214a`;
+the generated partial report SHA-256 is
+`f6255daef57aa971bf121b98ea629b53985cf591d47bfc579b54dab538babe59`.
+
+The deficit is localized exactly: shard 10 registered 731 tests and recorded
+712, while every other shard reconciled. Vitest grouped the 19 abandoned
+callbacks under `Error: Test timed out in 90000ms` at
+`tests/test262-shared.ts:644`; the runner then overwrote shard 10's completion
+file with later shards and printed `COMPLETED: 8974 pass / 11685 total`. The
+atomically allocated markdown issue #5215 records all 19 paths and the
+implementation plan for bounded Test262 concurrency, durable per-shard
+completion manifests, and a fail-before-publication completeness validator.
+This artifact remains exact dispatch evidence for the 11,685 emitted paths,
+not an authoritative edition census and not final integrated-head acceptance.
+
+All six recorded timeouts are detached-buffer TypedArray rows: shard 16
+reported `byteLength/detached-buffer.js` and
+`lastIndexOf/detached-buffer.js`; shard 10 reported
+`findIndex/predicate-may-detach-buffer.js` and
+`every/callbackfn-detachbuffer.js`; and shard 1 reported
+`indexOf/detached-buffer.js` and `buffer/detached-buffer.js`. They remain under
+the active #4449 residual and require bounded solo rechecks. The shared census
+test lock is now released. After #5212 and #5214 completed their bounded lanes,
+#5215 and #5213 each received one compiler/test worker; the global ceiling
+remains two and root does not start an overlapping compiler/test lane.
+
+The active work is repository-issue-backed and isolated:
+
+- #5131 owns strict iterator materialization for dynamic spread. Its published
+  PR #5272 remains draft because that published checkpoint is conflicting and
+  non-mergeable (the shepherd measured 2 commits ahead / 525 behind current
+  main); the newer local implementation must integrate current main, pass its
+  full focused matrix, and replace the stale handoff before becoming ready.
+- #5194 owns the exact 25-row TypedArray `set` Slice A and its host regression
+  controls.
+- #5195 owns the exact 12-row faithful builtin-subclass slice, with the
+  generator carrier explicitly delegated to #5199.
+- #5212 is the completed atomically allocated, markdown-only Map/Set provider
+  sub-slice from #5195. Its two exact rows pass host and standalone, and its
+  single non-draft upstream PR is #5286 at final published head
+  `cc653e1cd162ca33a95e659df15a40764d9e7c82`; the dedicated shepherd owns its
+  CI/readiness/queue audit.
+- #5213 is the atomically allocated, markdown-only two-row class instance
+  accessor sub-slice; a separate Luna Max worktree owns the `prototype` key
+  collision without touching the collection provider.
+- #5214 is the completed atomically allocated, markdown-only six-row NativeError
+  prototype-`name` configurability slice. Its exact host/standalone matrix is
+  12/12 pass, and its single non-draft upstream PR is #5287 at final published
+  head `e7fbfda3bdb6f8ea25acd59ba1cdb376a0aa0f23`; the dedicated shepherd owns
+  its CI/readiness/queue audit.
+- #5215 is the atomically allocated, markdown-only Test262 verdict-completeness
+  repair. Its root-filed implementation plan prevents a timed-out shard from
+  being overwritten and published as a complete report; a fresh Luna Max
+  worktree now owns the implementation and one-worker validation.
+- #5197 owns the exact three-row Promise symbol object-model Slice A.
+- #5198 owns the exact nine-row RegExp `exec`/`test` observable-`lastIndex`
+  Slice A.
+
+These numbers refer only to markdown files under `plan/issues`; no GitHub
+issues are to be created. Implementations use Luna Max agents in separate
+provisioned worktrees. Every completed, mergeable fix gets its own non-draft
+PR from `ttraenkler/js2` to `loopdive/js2`; only an incomplete or genuinely
+non-mergeable checkpoint may remain draft. A separate shepherd agent verifies
+the required PR body, mergeability, reviews, CI, exact tested head, and
+ready/queue state before landing.

--- a/plan/issues/4449-typedarray-standalone-semantics-residual.md
+++ b/plan/issues/4449-typedarray-standalone-semantics-residual.md
@@ -4,7 +4,7 @@ title: "standalone: TypedArray.prototype ES6 semantics residual (~556 non-reflec
 status: in-progress
 sprint: current
 created: 2026-08-15
-updated: 2026-08-27
+updated: 2026-08-30
 priority: high
 horizon: l
 feasibility: hard
@@ -269,3 +269,33 @@ the 52/55 control floor; its three failures are the pre-existing Float64
 `slice`/`subarray` custom-constructor receiver and invocation-argument rows.
 Draft PR #5022 must remain draft and this issue remains in progress until a
 future checkpoint reaches standalone 55/55 and host 55/55 with zero nonpasses.
+
+## 2026-08-30 detached-buffer compile-timeout handoff
+
+The full ES2015 diagnostic on detached source
+`1f1004f3df195cc5f9e804efcbb2896d3871ca37` finished all 16 shards. A separate
+runner-completeness defect (#5215) dropped 19 non-TypedArray verdicts from shard
+10, so the preserved dispatch artifact contains 11,685 unique rows rather than
+the selected 11,704: 8,974 pass, 2,258 fail, 447 compile errors, six compile
+timeouts, and no skips. Every recorded timeout is in this issue's existing
+detached-buffer family:
+
+- `test/built-ins/TypedArray/prototype/byteLength/detached-buffer.js`;
+- `test/built-ins/TypedArray/prototype/lastIndexOf/detached-buffer.js`;
+- `test/built-ins/TypedArray/prototype/findIndex/predicate-may-detach-buffer.js`;
+- `test/built-ins/TypedArray/prototype/every/callbackfn-detachbuffer.js`;
+- `test/built-ins/TypedArray/prototype/indexOf/detached-buffer.js`;
+- `test/built-ins/TypedArray/prototype/buffer/detached-buffer.js`.
+
+The first two timings were observed while an accidental competing focused-test
+pool was being terminated; the later four occurred with the census alone and
+make the shared detached-buffer compile path the primary diagnosis. None of
+the 19 missing #5215 rows is a TypedArray path, so the six-row list is exact for
+the emitted artifact. This remains dispatch evidence, not a final regression
+count.
+
+The census has released the global two-worker lock. The current validation
+lanes remain capped at one worker each; when one returns, a Luna Max handoff on
+this existing markdown issue must rerun each path alone with one bounded
+compiler worker, record whether compilation or strict rerun stalls, and fix the
+shared lowering rather than increasing retry budgets.


### PR DESCRIPTION
## Description

Problem: The ES2015 closeout tracker did not preserve the exact 2026-08-30 diagnostic evidence showing that the maintained runner published only 11,685 of 11,704 selected verdicts, nor the six detached-buffer TypedArray timeouts and their ownership.

Behavior: Record the immutable artifact counts and hashes, all 19 missing paths, the shard-overwrite/completeness root cause, current isolated implementation lanes, completed upstream PR handoffs, and the rule that final acceptance still requires a fresh integrated 11,704/11,704 standalone census. No runtime behavior changes.

Tests: Repository Prettier check; git diff checks; complete commit and pre-push hooks; numeric-local parity 18/18.

Quality: Typecheck, lint, oracle and coercion ratchets, conformance synchronization, committed and working-tree issue integrity all passed on current upstream main.

Tracking: plan/issues/4444-es6-standalone-edition-closeout-umbrella.md and plan/issues/4449-typedarray-standalone-semantics-residual.md. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->