### PR TITLE
fix(test262): reject incomplete verdict sets

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -350,11 +350,15 @@ jobs:
             echo "Vitest exited with unexpected code $exit_code"
             exit "$exit_code"
           fi
-          completion_marker="benchmarks/results/${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl.complete.json"
-          if [ ! -s "$completion_marker" ]; then
+          completion_marker=$(find benchmarks/results -maxdepth 1 -name "${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.shard-*.complete.json" -print -quit)
+          if [ -z "$completion_marker" ] || [ ! -s "$completion_marker" ]; then
             echo "::error::Test262 shard did not reach afterAll; refusing partial JSONL evidence"
             exit 2
           fi
+          node scripts/validate-test262-completeness.mjs \
+            --input "benchmarks/results/${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl" \
+            --manifest "$completion_marker" \
+            --expected-shards 1
 
       - name: Upload shard artifacts
         id: upload_shard
@@ -371,7 +375,7 @@ jobs:
           name: emergency-${{ matrix.target.name }}-shard-${{ matrix.chunk }}
           path: |
             benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
-            benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl.complete.json
+            benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.shard-*.complete.json
           if-no-files-found: warn
 
       # #3404 — retry a transient artifact-upload flake once. Idempotent +
@@ -388,6 +392,7 @@ jobs:
           overwrite: true
           path: |
             benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
+            benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.shard-*.complete.json
           if-no-files-found: warn
 
   merge-and-promote:
@@ -448,6 +453,30 @@ jobs:
           mkdir -p merged-reports
           find shard-artifacts/emergency-standalone-shard-* -name 'test262-standalone-results-*.jsonl' -print0 | sort -z | xargs -0 cat > merged-reports/test262-standalone-results-merged.jsonl
           test -s merged-reports/test262-standalone-results-merged.jsonl
+
+      - name: Validate merged JS-host Test262 verdict completeness (#5215)
+        env:
+          EXPECTED_SHARDS: "57"
+        run: |
+          mapfile -d '' manifests < <(find shard-artifacts/emergency-js-host-shard-* -type f -name 'test262-results-*.shard-*.complete.json' -print0 | sort -z)
+          manifest_args=()
+          for manifest in "${manifests[@]}"; do manifest_args+=(--manifest "$manifest"); done
+          node scripts/validate-test262-completeness.mjs \
+            --input merged-reports/test262-results-merged.jsonl \
+            --expected-shards "$EXPECTED_SHARDS" \
+            "${manifest_args[@]}"
+
+      - name: Validate merged standalone Test262 verdict completeness (#5215)
+        env:
+          EXPECTED_SHARDS: "57"
+        run: |
+          mapfile -d '' manifests < <(find shard-artifacts/emergency-standalone-shard-* -type f -name 'test262-standalone-results-*.shard-*.complete.json' -print0 | sort -z)
+          manifest_args=()
+          for manifest in "${manifests[@]}"; do manifest_args+=(--manifest "$manifest"); done
+          node scripts/validate-test262-completeness.mjs \
+            --input merged-reports/test262-standalone-results-merged.jsonl \
+            --expected-shards "$EXPECTED_SHARDS" \
+            "${manifest_args[@]}"
 
       - name: Build merged test262 report
         run: |

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -32,6 +32,8 @@ on:
       - "vitest.config.ts"
       - "src/**"
       - "scripts/build-test262-report.mjs"
+      - "scripts/test262-concurrency.mjs"
+      - "scripts/validate-test262-completeness.mjs"
       - "scripts/compiler-fork-worker.mjs"
       - "scripts/compiler-pool.ts"
       - "scripts/diff-test262.ts"
@@ -961,11 +963,15 @@ jobs:
             echo "Vitest exited with unexpected code $exit_code"
             exit "$exit_code"
           fi
-          completion_marker="benchmarks/results/${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl.complete.json"
-          if [ ! -s "$completion_marker" ]; then
+          completion_marker=$(find benchmarks/results -maxdepth 1 -name "${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.shard-*.complete.json" -print -quit)
+          if [ -z "$completion_marker" ] || [ ! -s "$completion_marker" ]; then
             echo "::error::Test262 shard did not reach afterAll; refusing partial JSONL evidence"
             exit 2
           fi
+          node scripts/validate-test262-completeness.mjs \
+            --input "benchmarks/results/${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl" \
+            --manifest "$completion_marker" \
+            --expected-shards 1
           echo "vitest_exit_code=$exit_code" >> "$GITHUB_OUTPUT"
 
       - name: Upload shard artifacts
@@ -981,7 +987,7 @@ jobs:
           name: test262-${{ matrix.target.name }}-shard-${{ matrix.chunk }}
           path: |
             benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
-            benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl.complete.json
+            benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.shard-*.complete.json
           if-no-files-found: warn
 
       # #3404 — a single transient artifact-upload flake (e.g. `Failed to
@@ -1000,6 +1006,7 @@ jobs:
           overwrite: true
           path: |
             benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
+            benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.shard-*.complete.json
           if-no-files-found: warn
 
   test262-shard-mg:
@@ -1161,11 +1168,15 @@ jobs:
             echo "Vitest exited with unexpected code $exit_code"
             exit "$exit_code"
           fi
-          completion_marker="benchmarks/results/${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl.complete.json"
-          if [ ! -s "$completion_marker" ]; then
+          completion_marker=$(find benchmarks/results -maxdepth 1 -name "${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.shard-*.complete.json" -print -quit)
+          if [ -z "$completion_marker" ] || [ ! -s "$completion_marker" ]; then
             echo "::error::Test262 shard did not reach afterAll; refusing partial JSONL evidence"
             exit 2
           fi
+          node scripts/validate-test262-completeness.mjs \
+            --input "benchmarks/results/${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl" \
+            --manifest "$completion_marker" \
+            --expected-shards 1
           echo "vitest_exit_code=$exit_code" >> "$GITHUB_OUTPUT"
 
       - name: Upload shard artifacts
@@ -1187,7 +1198,7 @@ jobs:
           name: test262-${{ matrix.target_name }}-shard-${{ matrix.chunk_label }}
           path: |
             benchmarks/results/${{ matrix.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
-            benchmarks/results/${{ matrix.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl.complete.json
+            benchmarks/results/${{ matrix.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.shard-*.complete.json
           if-no-files-found: warn
 
       # #3404 — retry a transient artifact-upload flake once (see the matching
@@ -1203,6 +1214,7 @@ jobs:
           overwrite: true
           path: |
             benchmarks/results/${{ matrix.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
+            benchmarks/results/${{ matrix.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.shard-*.complete.json
           if-no-files-found: warn
 
   merge-report:
@@ -1348,6 +1360,37 @@ jobs:
           mkdir -p merged-reports
           find shard-artifacts/test262-standalone-shard-* -name 'test262-standalone-results-*.jsonl' -print0 | sort -z | xargs -0 cat > merged-reports/test262-standalone-results-merged.jsonl
           test -s merged-reports/test262-standalone-results-merged.jsonl
+
+      - name: Validate merged JS-host Test262 verdict completeness (#5215)
+        if: env.HOST_RAN == 'true'
+        env:
+          # Static push/dispatch matrices have 57 shards; the capacity-sized
+          # merge_group matrix keeps 52 js-host shards. Missing artifact
+          # directories must fail the aggregate, not disappear in `find`.
+          EXPECTED_SHARDS: ${{ github.event_name == 'merge_group' && '52' || '57' }}
+        run: |
+          mapfile -d '' manifests < <(find shard-artifacts/test262-js-host-shard-* -type f -name 'test262-results-*.shard-*.complete.json' -print0 | sort -z)
+          manifest_args=()
+          for manifest in "${manifests[@]}"; do manifest_args+=(--manifest "$manifest"); done
+          node scripts/validate-test262-completeness.mjs \
+            --input merged-reports/test262-results-merged.jsonl \
+            --expected-shards "$EXPECTED_SHARDS" \
+            "${manifest_args[@]}"
+
+      - name: Validate merged standalone Test262 verdict completeness (#5215)
+        if: env.STANDALONE_RAN == 'true'
+        env:
+          # Static push/dispatch matrices have 57 shards; the capacity-sized
+          # merge_group matrix keeps 50 standalone shards.
+          EXPECTED_SHARDS: ${{ github.event_name == 'merge_group' && '50' || '57' }}
+        run: |
+          mapfile -d '' manifests < <(find shard-artifacts/test262-standalone-shard-* -type f -name 'test262-standalone-results-*.shard-*.complete.json' -print0 | sort -z)
+          manifest_args=()
+          for manifest in "${manifests[@]}"; do manifest_args+=(--manifest "$manifest"); done
+          node scripts/validate-test262-completeness.mjs \
+            --input merged-reports/test262-standalone-results-merged.jsonl \
+            --expected-shards "$EXPECTED_SHARDS" \
+            "${manifest_args[@]}"
 
       - name: Build merged JS-host test262 report
         if: env.HOST_RAN == 'true'

--- a/plan/issues/5215-test262-verdict-completeness-after-timeout.md
+++ b/plan/issues/5215-test262-verdict-completeness-after-timeout.md
@@ -328,3 +328,13 @@ https://github.com/loopdive/js2/pull/5290 from
 `ttraenkler:codex/5215-test262-verdict-completeness` to `loopdive/js2:main`.
 No GitHub issue was created. The dedicated PR shepherd owns exact-head, body,
 review, check, conflict, readiness, and merge-queue follow-through.
+
+The first PR CI run exposed one change-local gate false positive: moving the
+existing `negativeCompileErrorMatches` import while adding the completeness
+helpers matched the verdict-signal detector even though no scoring behavior
+changed. The branch now carries the detector's documented in-diff
+`oracle-version-exempt:` comment stating that #5215 changes callback evidence,
+not Test262 scoring. The same run's non-required QuickJS lane exhausted its
+512 MiB Node heap; it had no semantic assertion failure and is not coupled to
+the Test262-only concurrency path. The final checkpoint must re-run the
+verdict-oracle gate locally and let CI retry both jobs before queue admission.

--- a/plan/issues/5215-test262-verdict-completeness-after-timeout.md
+++ b/plan/issues/5215-test262-verdict-completeness-after-timeout.md
@@ -1,0 +1,313 @@
+---
+id: 5215
+title: "test262 runner silently publishes an incomplete verdict set after queued Vitest timeouts"
+status: in-progress
+sprint: current
+created: 2026-08-30
+updated: 2026-08-30
+assignee: ttraenkler/codex-es6-census
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: max
+model: gpt-5.6-luna
+task_type: bugfix
+area: testing
+language_feature: test262-harness
+goal: test-infrastructure
+related: [4444, 3407, 4412]
+---
+
+# #5215 — make a test262 report prove verdict completeness
+
+## Problem
+
+The maintained Vitest runner can execute every registered test, lose verdict
+rows when queued concurrent callbacks exceed Vitest's test timeout, and still
+print `COMPLETED` and publish a report built from the partial JSONL. A
+well-formed partial report is therefore indistinguishable from a complete
+conformance census unless a caller independently compares its path set.
+
+This is a repository markdown issue only. No GitHub issue was created.
+
+## Exact reproduction
+
+The 2026-08-30 standalone ES2015 diagnostic used:
+
+- source `1f1004f3df195cc5f9e804efcbb2896d3871ca37`;
+- the maintained `pnpm run test:262 -- --official-scope-only` runner;
+- `TEST262_TARGET=standalone`, `TEST262_WORKERS=2`, and
+  `COMPILER_POOL_SIZE=2`;
+- exact filter `/private/tmp/js2-es2015-11704-pr5008.txt`, containing 11,704
+  unique paths with SHA-256
+  `45de809c6bfce7371cee1d20e327758246b0524ecd75481a08b8c03344fced8a`;
+- QuickJS standalone provider artifact
+  `/private/tmp/js2-quickjs-artifact-2e2d7736713beeda`.
+
+Vitest's final summary proved it registered and executed **11,704 tests**.
+Fifteen shards recorded exactly their registered counts, but shard 10 printed
+`Chunk 10/16: 731 tests` and later
+`Test262 chunk 10/16: 712 total`. The runner nevertheless generated a report
+and printed `COMPLETED: 8974 pass / 11685 total`.
+
+The preserved JSONL has SHA-256
+`47f34c307c43b06c9c40bb0df754bc22d94435a23cccfdd6de857816e199214a`.
+It contains 11,685 physical rows and 11,685 unique paths: 8,974 pass, 2,258
+fail, 447 compile_error, 6 compile_timeout, and 0 skip. It has no malformed
+rows, duplicates, or paths outside the filter, but is missing exactly 19 paths.
+The generated partial report has SHA-256
+`f6255daef57aa971bf121b98ea629b53985cf591d47bfc579b54dab538babe59`.
+
+## Root-cause evidence
+
+`vitest.config.ts` permits 32 concurrent callbacks while this run's
+`CompilerPool` had only two workers. Vitest starts each callback's timeout while
+many calls are still queued behind the pool. The final failure output groups
+the unrecorded shard-10 paths under:
+
+```text
+Error: Test timed out in 90000ms.
+  at tests/test262-shared.ts:644:9
+```
+
+Most timed-out callbacks eventually wrote a verdict, but Vitest advanced to
+the shard's `afterAll`, shut down the pool, and left the final 19 without a
+`recordResult` call. The existing completion file proved the mismatch at that
+moment (`registeredTests: 731`, `recordedRows: 712`), but every later shard
+overwrote the same file. `scripts/run-test262-vitest.sh` ignores Vitest's
+non-zero status because conformance failures are expected, then builds a report
+without validating per-shard completion or the expected unique identity set.
+
+## Missing paths
+
+- `test/built-ins/ArrayBuffer/prototype/slice/start-exceeds-end.js`
+- `test/built-ins/ArrayBuffer/prototype/slice/tointeger-conversion-start.js`
+- `test/built-ins/ArrayBuffer/zero-length.js`
+- `test/built-ins/Iterator/prototype/chunks/exhaustion-does-not-call-return.js`
+- `test/built-ins/Iterator/prototype/chunks/underlying-iterator-closed-in-parallel.js`
+- `test/built-ins/Iterator/prototype/windows/result-is-iterator.js`
+- `test/language/arguments-object/cls-decl-gen-meth-static-args-trailing-comma-single-args.js`
+- `test/language/arguments-object/cls-expr-gen-meth-args-trailing-comma-spread-operator.js`
+- `test/language/computed-property-names/class/static/method-prototype.js`
+- `test/language/eval-code/direct/lex-env-distinct-const.js`
+- `test/language/global-code/new.target.js`
+- `test/language/global-code/script-decl-var-collision.js`
+- `test/language/identifiers/val-class.js`
+- `test/language/literals/numeric/octal.js`
+- `test/language/statementList/eval-block-arrow-function-assignment-expr.js`
+- `test/language/statementList/eval-block-with-statment-arrow-function-functionbody.js`
+- `test/language/statementList/eval-block-with-statment-expr-arrow-function-boolean-literal.js`
+- `test/language/statementList/eval-class-arrow-function-assignment-expr.js`
+- `test/language/statementList/fn-arrow-function-assignment-expr.js`
+
+## Scope and invariants
+
+- A report may be called complete only when every selected, recordable test has
+  exactly one canonical JSONL verdict.
+- Expected official-scope exclusions must be counted explicitly; they must not
+  make a missing callback look legitimate.
+- Conformance failures remain normal data and must not make the shell treat an
+  otherwise complete run as infrastructure failure.
+- A timed-out or abandoned callback is infrastructure incompleteness, even if
+  every emitted JSONL row is well formed.
+- Scoped path-filter and shard-glob runs remain supported, but their expected
+  selected identity count must be derived from that scope.
+- Unit-suite concurrency outside test262 must not regress.
+
+## Implementation plan
+
+1. Reconcile Vitest callback concurrency with the active compiler-pool size for
+   test262 runs. Derive the test262-specific `maxConcurrency` from the same
+   bounded worker setting instead of queueing 32 timeout clocks behind a
+   one- or two-worker pool; preserve the existing unit-suite default.
+2. Give every shard a durable, non-overwriting completion manifest. Record its
+   registered count, canonical verdict count, explicit official/proposal
+   exclusions, and whether all callbacks settled before pool shutdown.
+3. Add a reusable completeness validator for the runner. It must reject
+   missing shard manifests, `registered != verdicts + explicit exclusions`,
+   malformed rows, duplicate identities, unexpected paths for an exact filter,
+   and disagreement between manifest totals and JSONL unique totals.
+4. Run that validator in `scripts/run-test262-vitest.sh` before report
+   construction, symlink updates, history publication, or the `COMPLETED`
+   message. Preserve the partial timestamped artifact for diagnosis, but print
+   `INCOMPLETE` and exit non-zero with the missing shard/count evidence.
+5. Add regression tests reproducing a registered/recorded mismatch and the
+   exact overwrite hazard: one incomplete shard followed by a complete shard
+   must still block publication. Add positive controls for complete failing
+   conformance rows, official-scope exclusions, exact-filter scope, and the
+   ordinary non-test262 Vitest concurrency setting.
+6. Re-run the 19 paths with one bounded compiler worker to recover dispatch
+   verdicts. Then rerun their original shard or an equivalent synthetic runner
+   exercise and prove no selected path can disappear behind `COMPLETED`.
+
+## Acceptance criteria
+
+- [ ] A shard that registers 731 tests and records 712 cannot be overwritten by
+      a later completion file and cannot produce a completed report.
+- [ ] The runner diagnoses the incomplete shard and exact 19-row deficit before
+      updating canonical report/result symlinks.
+- [ ] A complete run containing ordinary fail/compile_error verdicts still
+      builds a report; conformance red is not confused with infrastructure red.
+- [ ] Exact filters reconcile to their unique selected path set, with zero
+      missing, extra, malformed, or duplicate verdict identities.
+- [ ] Official proposal exclusions are explicit and do not weaken the selected
+      path completeness invariant.
+- [ ] Test262 concurrency is bounded by the active compiler-pool capacity while
+      the general unit suite retains its current parallelism.
+- [ ] Focused regression tests, typecheck, formatting, lint, and issue-integrity
+      gates pass.
+
+## Handoff
+
+Implement in the isolated worktree
+`/private/tmp/js2-test262-verdict-completeness-20260830`, branch
+`codex/5215-test262-verdict-completeness`, based on upstream
+`a62aacba5ccc154f6fc378235aaaeeb4a7204231`. Do not edit the user-owned root
+checkout. Do not run validation while both one-worker implementation lanes are
+occupied; static implementation and unit fixtures may be prepared first.
+
+Once complete and mergeable, this fix gets one non-draft PR from
+`ttraenkler/js2` to `loopdive/js2`. Its PR body must name this markdown file and
+state that no GitHub issue was created. The dedicated PR shepherd must verify
+the exact tested head, body template, mergeability, checks, and readiness before
+queueing.
+
+## Static implementation checkpoint (2026-08-30)
+
+The isolated worktree now contains a narrow implementation of the planned
+invariants:
+
+- `scripts/test262-concurrency.mjs` derives Test262 callback concurrency from
+  `COMPILER_POOL_SIZE`, while `vitest.config.ts` keeps the ordinary unit-suite
+  default at 32.
+- `tests/test262-shared.ts` registers the exact selected callback set,
+  records proposal/official exclusions and callback settlement counts, keeps a
+  per-identity canonical-row count, and writes a shard-keyed v2 manifest with
+  exclusive (`wx`) creation after the pre-shutdown settlement snapshot.
+- `scripts/validate-test262-completeness.mjs` is a reusable pure validator for
+  shard registration, verdict/exclusion arithmetic, callback evidence,
+  malformed/duplicate/unexpected identities, and JSONL physical/unique totals.
+  `scripts/run-test262-vitest.sh` gates report, symlink, history, and
+  `COMPLETED` publication on that validator and preserves incomplete JSONL.
+  An exact `TEST262_PATH_FILTER_FILE` is passed through as the expected
+  callback identity set; the existing OR combination with substring
+  `TEST262_PATH_FILTER` fails closed with an explicit unsupported-combination
+  diagnostic until a union list can be derived safely.
+- The shard workflows consume the new non-overwriting manifest names, and
+  focused #5215 fixtures cover incomplete-then-complete shards, ordinary
+  failing conformance rows, explicit exclusions, exact scope, and concurrency.
+
+The focused #5215/#3522 Vitest fixtures have now passed (including the CLI
+validator/temp-fixture cases) with `TEST262_WORKERS=1`,
+`COMPILER_POOL_SIZE=1`, `VITEST_MAX_FORKS=1`, and a single Vitest fork. This is
+bounded validation only; the full 11,704-row census remains pending, while the
+bounded 19-path rerun is now complete as recorded below. Targeted Prettier,
+Biome lint, `bash -n`, and `git diff --check` also pass; the broad scripts
+TypeScript config was attempted but reports the repository's existing
+thousands of untyped JavaScript/test diagnostics rather than providing a
+meaningful change-local gate. The bounded controls below verify publication
+gating for incomplete evidence and acceptance of ordinary `fail`/`compile_error`
+rows; the remaining handoff is for the repository's normal typecheck,
+issue-integrity, and workflow-review gates. No commit, push, PR, or GitHub
+mutation has been made.
+
+## Bounded acceptance validation (2026-08-30)
+
+The requested 19-path standalone rerun was executed through the maintained
+runner with one compiler/test worker. The exact invocation was:
+
+```text
+PATH=/Users/thomas/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/thomas/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH \
+TEST262_WORKERS=1 COMPILER_POOL_SIZE=1 VITEST_MAX_FORKS=1 \
+TEST262_TARGET=standalone JS2WASM_EVAL_ENGINE=quickjs \
+JS2WASM_QUICKJS_ARTIFACT_DIR=/private/tmp/js2-quickjs-artifact-2e2d7736713beeda \
+TEST262_PATH_FILTER_FILE=/private/tmp/js2-test262-5215-19-paths.txt \
+TEST262_LOCAL_SHARD_GLOB=tests/test262-chunk-dynamic.test.ts \
+TEST262_CHUNK_INDEX=0 TEST262_CHUNK_TOTAL=1 TEST262_IT_TIMEOUT_MS=300000 \
+TEST262_REPORTER=dot bash scripts/run-test262-vitest.sh --official-scope-only
+```
+
+The runner logged `Working tree has local changes; running test262 from
+current workspace`, then completed the one dynamic shard with 19 registered
+tests. The resulting JSONL has 19 physical rows and 19 unique identities:
+15 `pass`, 4 ordinary conformance `fail`, 0 `compile_error`, 0
+`compile_timeout`, and 0 `skip`. The durable v2 manifest proves
+`registeredTests=19`, `recordedRows=19`, `canonicalVerdicts=19`, zero explicit
+exclusions, `callbacksStarted=19`, `callbacksSettled=19`, and
+`allCallbacksSettled=true`. The standalone report was constructed as
+15 pass / 19 total (78.9%).
+
+Preserved artifacts and SHA-256 digests:
+
+```text
+/private/tmp/js2-test262-verdict-completeness-20260830/benchmarks/results/test262-standalone-results-20260830-074856.jsonl
+  4cfc254f07c9666e29268acdbd0933b69f0e9a3380a6d3a09245d16bdc4c76cd
+/private/tmp/js2-test262-verdict-completeness-20260830/benchmarks/results/test262-standalone-results-20260830-074856.shard-1-of-1.complete.json
+  00bb44457a99fa5ffe170d910d29db71201077a24e3e893375ff7aa20a1af417
+/private/tmp/js2-test262-verdict-completeness-20260830/benchmarks/results/test262-standalone-report-20260830-074856.json
+  41bc3ea4b208e39ff7e9164fd9495098edf3a97bd12b1eaac0daa8122934c186
+/private/tmp/js2-test262-5215-19-paths.txt
+  58cfd9ee97d1b2bd8ab84dd54ab95c13a8da30deb233ea1f6ca54f95867489da
+```
+
+The validator was also invoked directly against those artifacts:
+
+```text
+node scripts/validate-test262-completeness.mjs \
+  --input benchmarks/results/test262-standalone-results-20260830-074856.jsonl \
+  --manifest benchmarks/results/test262-standalone-results-20260830-074856.shard-1-of-1.complete.json \
+  --expected-shards 1 \
+  --expected-paths-file /private/tmp/js2-test262-5215-19-paths.txt
+COMPLETE: 1 shard(s), 19 verdicts, 19 registered (0 explicit exclusions)
+```
+
+CLI controls were run with temporary fixtures. The complete red-data command
+was:
+
+```text
+node scripts/validate-test262-completeness.mjs \
+  --input /private/tmp/js2-test262-5215-red-control.jsonl \
+  --manifest /private/tmp/js2-test262-5215-red-control.shard-1-of-1.complete.json \
+  --expected-shards 1 \
+  --expected-paths-file /private/tmp/js2-test262-5215-red-control-paths.txt
+```
+
+It contained one `fail` and one `compile_error`, returned exit 0, and printed
+`COMPLETE: 1 shard(s), 2 verdicts, 2 registered (0 explicit exclusions)`.
+Its JSONL, manifest, and expected-path file are
+`/private/tmp/js2-test262-5215-red-control.jsonl`,
+`/private/tmp/js2-test262-5215-red-control.shard-1-of-1.complete.json`, and
+`/private/tmp/js2-test262-5215-red-control-paths.txt` with SHA-256
+`e191b50181399947be69c3ae5739bc52c05a0970f604a8e648e732415767b762`,
+`94668388e0578482a34c957c81201bdc11e0d0999203692250d711c78527a53c`, and
+`083d84dfe914d7e01faa0a92961a03cfd5f0eeeb3a8cf0fe69378889f2b4e1aa`.
+
+The incomplete control command was:
+
+```text
+node scripts/validate-test262-completeness.mjs \
+  --input /private/tmp/js2-test262-5215-incomplete.jsonl \
+  --manifest /private/tmp/js2-test262-5215-incomplete.shard-1-of-1.complete.json \
+  --expected-shards 1 \
+  --expected-paths-file /private/tmp/js2-test262-5215-incomplete-paths.txt
+```
+
+It had two registered identities but one row and unsettled callback evidence,
+returned exit 2 and `INCOMPLETE`, and reported the missing identity, callback
+settlement mismatch, and manifest arithmetic mismatch. Its JSONL, manifest,
+and expected-path file are `/private/tmp/js2-test262-5215-incomplete.jsonl`,
+`/private/tmp/js2-test262-5215-incomplete.shard-1-of-1.complete.json`, and
+`/private/tmp/js2-test262-5215-incomplete-paths.txt` with SHA-256
+`ed7ba4896e6a8cbc8338bea48648ba76fcebfab1e661900d610cef9124fb2a6b`,
+`aab7a018ac7bb11cfb18680da407a5cd8d53e8a06cf91989aed2e5524f5448cc`, and
+`802b3fabffb3a59fcc1b301a7b0a18c52c68e0bad64e6184cd3f04644e7cf206`.
+
+The runner source order remains validator (line 359) before report
+construction (line 374), `COMPLETED=true` (line 389), symlink updates (lines
+428–429), and history publication (line 467 onward); therefore the nonzero
+incomplete control cannot reach report/symlink/history publication.
+
+The full 11,704-row census remains intentionally unrun. Root still needs to
+integrate current main `c243892c7f` non-destructively and run the repository's
+normal final hooks/issue-integrity checks before publication. No commit, push,
+PR, or remote mutation was made.

--- a/plan/issues/5215-test262-verdict-completeness-after-timeout.md
+++ b/plan/issues/5215-test262-verdict-completeness-after-timeout.md
@@ -1,10 +1,12 @@
 ---
 id: 5215
 title: "test262 runner silently publishes an incomplete verdict set after queued Vitest timeouts"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-30
 updated: 2026-08-30
+completed: 2026-08-30
+pr: 5290
 assignee: ttraenkler/codex-es6-census
 priority: high
 horizon: m
@@ -142,19 +144,19 @@ without validating per-shard completion or the expected unique identity set.
 
 ## Acceptance criteria
 
-- [ ] A shard that registers 731 tests and records 712 cannot be overwritten by
+- [x] A shard that registers 731 tests and records 712 cannot be overwritten by
       a later completion file and cannot produce a completed report.
-- [ ] The runner diagnoses the incomplete shard and exact 19-row deficit before
+- [x] The runner diagnoses the incomplete shard and exact 19-row deficit before
       updating canonical report/result symlinks.
-- [ ] A complete run containing ordinary fail/compile_error verdicts still
+- [x] A complete run containing ordinary fail/compile_error verdicts still
       builds a report; conformance red is not confused with infrastructure red.
-- [ ] Exact filters reconcile to their unique selected path set, with zero
+- [x] Exact filters reconcile to their unique selected path set, with zero
       missing, extra, malformed, or duplicate verdict identities.
-- [ ] Official proposal exclusions are explicit and do not weaken the selected
+- [x] Official proposal exclusions are explicit and do not weaken the selected
       path completeness invariant.
-- [ ] Test262 concurrency is bounded by the active compiler-pool capacity while
+- [x] Test262 concurrency is bounded by the active compiler-pool capacity while
       the general unit suite retains its current parallelism.
-- [ ] Focused regression tests, typecheck, formatting, lint, and issue-integrity
+- [x] Focused regression tests, typecheck, formatting, lint, and issue-integrity
       gates pass.
 
 ## Handoff
@@ -207,9 +209,9 @@ TypeScript config was attempted but reports the repository's existing
 thousands of untyped JavaScript/test diagnostics rather than providing a
 meaningful change-local gate. The bounded controls below verify publication
 gating for incomplete evidence and acceptance of ordinary `fail`/`compile_error`
-rows; the remaining handoff is for the repository's normal typecheck,
-issue-integrity, and workflow-review gates. No commit, push, PR, or GitHub
-mutation has been made.
+rows. The repository's normal typecheck, lint, formatting, ratchet,
+numeric-local parity, and issue-integrity gates subsequently passed on current
+main, as recorded in the publication checkpoint below.
 
 ## Bounded acceptance validation (2026-08-30)
 
@@ -307,7 +309,22 @@ construction (line 374), `COMPLETED=true` (line 389), symlink updates (lines
 428–429), and history publication (line 467 onward); therefore the nonzero
 incomplete control cannot reach report/symlink/history publication.
 
-The full 11,704-row census remains intentionally unrun. Root still needs to
-integrate current main `c243892c7f` non-destructively and run the repository's
-normal final hooks/issue-integrity checks before publication. No commit, push,
-PR, or remote mutation was made.
+The full 11,704-row census remains intentionally unrun. It is the umbrella's
+final integrated acceptance run, not a prerequisite for publishing this
+runner-integrity fix.
+
+## Publication checkpoint (2026-08-30)
+
+The implementation checkpoint was rebased cleanly onto current upstream main
+`c243892c7f3a757bdecf6215626b08586ce72c58`. Commit
+`3ff0bf1b020620891195c3f180b400a0ab33c378` passed the repository's real
+pre-push chain without bypasses: typecheck, lint, Prettier format check, oracle
+and coercion-site ratchets, all 18 numeric-local IR parity tests, and committed
+issue integrity. The commit hooks also passed the 17 focused #5215/#3522 tests,
+LOC/function budgets, formatting/lint, and the oracle ratchet.
+
+The completed fix is published as non-draft upstream PR
+https://github.com/loopdive/js2/pull/5290 from
+`ttraenkler:codex/5215-test262-verdict-completeness` to `loopdive/js2:main`.
+No GitHub issue was created. The dedicated PR shepherd owns exact-head, body,
+review, check, conflict, readiness, and merge-queue follow-through.

--- a/scripts/run-test262-vitest.sh
+++ b/scripts/run-test262-vitest.sh
@@ -57,6 +57,19 @@ export TEST262_INCLUDE_PROPOSALS="$INCLUDE_PROPOSALS"
 export TEST262_TARGET
 export TEST262_RESULT_PREFIX="$RESULT_PREFIX"
 
+# The runner's matching semantics are OR when both filters are supplied, but
+# the completeness gate cannot safely reconstruct a substring-selected union
+# from an exact-path file alone. Fail closed with an explicit diagnostic rather
+# than comparing only the file and rejecting valid substring-selected rows.
+if [ -n "${TEST262_PATH_FILTER:-}" ] && [ -n "${TEST262_PATH_FILTER_FILE:-}" ]; then
+  echo "ERROR: TEST262_PATH_FILTER and TEST262_PATH_FILTER_FILE cannot be combined by the completeness gate; use one filter source so its exact expected set is auditable."
+  exit 2
+fi
+if [ -n "${TEST262_PATH_FILTER_FILE:-}" ] && [ ! -f "$TEST262_PATH_FILTER_FILE" ]; then
+  echo "ERROR: TEST262_PATH_FILTER_FILE does not exist: $TEST262_PATH_FILTER_FILE"
+  exit 2
+fi
+
 resolve_esbuild() {
   if [ -n "${ESBUILD_BIN:-}" ] && [ -x "${ESBUILD_BIN:-}" ]; then
     echo "$ESBUILD_BIN"
@@ -316,11 +329,47 @@ else
       --reporter="$TEST262_REPORTER" 2>&1 | tee /tmp/test262-vitest-run.log || true
   fi
 fi
-# Generate report.json from JSONL (atomic — no fork race condition)
+# A JSONL can be syntactically valid and still be missing verdict callbacks.
+# Validate each durable, shard-keyed completion manifest before constructing a
+# report. This runs after Vitest so ordinary conformance failures (exit 1) stay
+# valid data, while abandoned callbacks become an infrastructure failure.
 JSONL_FILE="$RESULTS_DIR/${RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl"
 REPORT_FILE="$RESULTS_DIR/${RESULT_PREFIX}-report-${RUN_TIMESTAMP}.json"
 COMPLETED=false
-if [ -f "$JSONL_FILE" ] && [ -s "$JSONL_FILE" ]; then
+COMPLETENESS_OK=false
+COMPLETENESS_REASON="missing JSONL or shard completion manifest"
+if [ -f "$JSONL_FILE" ]; then
+  if [ -n "$CHUNKS" ]; then
+    EXPECTED_SHARDS="$CHUNK_COUNT"
+  else
+    EXPECTED_SHARDS=1
+  fi
+  shard_manifests=( "$RESULTS_DIR"/${RESULT_PREFIX}-results-${RUN_TIMESTAMP}.shard-*.complete.json )
+  if [ -e "${shard_manifests[0]}" ]; then
+    completeness_args=(
+      --input "$JSONL_FILE"
+      --expected-shards "$EXPECTED_SHARDS"
+    )
+    if [ -n "${TEST262_PATH_FILTER_FILE:-}" ]; then
+      completeness_args+=(--expected-paths-file "$TEST262_PATH_FILTER_FILE")
+    fi
+    for manifest in "${shard_manifests[@]}"; do
+      completeness_args+=(--manifest "$manifest")
+    done
+    if node "$MAIN_DIR/scripts/validate-test262-completeness.mjs" "${completeness_args[@]}"; then
+      COMPLETENESS_OK=true
+    else
+      COMPLETENESS_REASON="validator rejected one or more shard manifests or verdict identities"
+    fi
+  else
+    echo "INCOMPLETE: no durable per-shard completion manifest was produced."
+  fi
+fi
+
+# Generate report.json from JSONL only after completeness has passed (atomic —
+# no fork race condition). A partial timestamped JSONL is intentionally left in
+# place for diagnosis; no canonical report/symlink/history update is allowed.
+if [ "$COMPLETENESS_OK" = true ]; then
   report_args=(
     scripts/build-test262-report.mjs
     --input "$JSONL_FILE"
@@ -439,8 +488,10 @@ print('Appended to index: %d pass / %d total' % (entry['pass'], entry['total']))
 " 2>/dev/null || echo "Warning: failed to update historical index"
   fi
 else
-  echo "INCOMPLETE: Report generation failed or no results."
+  echo "INCOMPLETE: $COMPLETENESS_REASON"
+  echo "Timestamped JSONL preserved for diagnosis: $JSONL_FILE"
   echo "Check /tmp/test262-vitest-run.log for errors."
+  exit 2
 fi
 
 # ── Cleanup ──────────────────────────────────────────────────────

--- a/scripts/test262-concurrency.mjs
+++ b/scripts/test262-concurrency.mjs
@@ -1,0 +1,23 @@
+import { availableParallelism } from "node:os";
+
+export const TEST262_DEFAULT_MAX_CONCURRENCY = 32;
+
+function parsePositiveInteger(value) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/** Resolve the worker count used by the unified Test262 compiler pool. */
+export function resolveTest262PoolSize(env = process.env) {
+  return parsePositiveInteger(env.COMPILER_POOL_SIZE) ?? Math.max(1, availableParallelism() - 1);
+}
+
+/**
+ * Test262's concurrent callbacks must not exceed the active compiler pool.
+ * Unit tests retain the existing 32-callback Vitest default.
+ */
+export function resolveVitestMaxConcurrency(env = process.env) {
+  const isTest262Run = Boolean(env.TEST262_TARGET || env.TEST262_RESULT_PREFIX);
+  if (!isTest262Run) return TEST262_DEFAULT_MAX_CONCURRENCY;
+  return Math.max(1, Math.min(TEST262_DEFAULT_MAX_CONCURRENCY, resolveTest262PoolSize(env)));
+}

--- a/scripts/validate-test262-completeness.mjs
+++ b/scripts/validate-test262-completeness.mjs
@@ -1,0 +1,640 @@
+#!/usr/bin/env node
+/**
+ * Validate the evidence produced by a Test262 shard run.
+ *
+ * A Vitest failure is not, by itself, evidence that a shard is incomplete:
+ * conformance failures deliberately make Vitest exit non-zero.  Conversely,
+ * a shard can reach afterAll after Vitest has abandoned one or more callbacks.
+ * This validator therefore treats the per-shard completion manifests and the
+ * JSONL identity set as the source of truth for whether a report is publishable.
+ *
+ * The validator is intentionally independent of Vitest and the compiler.  It
+ * can be used by the local runner, CI merge jobs, and focused unit tests without
+ * starting a compiler worker.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const TEST262_COMPLETION_MANIFEST_SCHEMA = "test262-shard-completion-v2";
+export const TEST262_VERDICT_STATUSES = new Set(["pass", "fail", "compile_error", "compile_timeout", "skip"]);
+
+/** Return the durable completion filename for one logical shard. */
+export function getTest262ShardCompletionPath(jsonlPath, chunkIndex, chunkTotal) {
+  const basename = String(jsonlPath).endsWith(".jsonl") ? String(jsonlPath).slice(0, -".jsonl".length) : jsonlPath;
+  return `${basename}.shard-${chunkIndex + 1}-of-${chunkTotal}.complete.json`;
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isPositiveInteger(value) {
+  return Number.isInteger(value) && value > 0;
+}
+
+function validIdentityPath(value) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value === value.trim() &&
+    !value.startsWith("/") &&
+    !value.includes("\\") &&
+    !value.includes("\0") &&
+    !value.split("/").includes("..")
+  );
+}
+
+function addError(errors, code, message, details = {}) {
+  errors.push({ code, message, ...details });
+}
+
+/**
+ * Parse a JSONL verdict stream while preserving physical line numbers.
+ *
+ * Blank lines are ignored so an editor-added trailing newline is harmless;
+ * every other line must be a JSON object with the three identity fields used by
+ * the report builder.
+ */
+export function parseTest262Jsonl(text) {
+  const errors = [];
+  const rows = [];
+  const identityRows = new Map();
+  const lines = String(text ?? "").split(/\r?\n/);
+  let physicalRows = 0;
+
+  for (let index = 0; index < lines.length; index++) {
+    const raw = lines[index];
+    if (raw.trim() === "") continue;
+    physicalRows++;
+    const line = index + 1;
+    let record;
+    try {
+      record = JSON.parse(raw);
+    } catch (error) {
+      addError(errors, "malformed-jsonl", `JSONL line ${line} is not valid JSON: ${error?.message ?? error}`, {
+        line,
+      });
+      continue;
+    }
+
+    if (!isObject(record)) {
+      addError(errors, "malformed-row", `JSONL line ${line} must contain an object`, { line });
+      continue;
+    }
+
+    const file = record.file;
+    const category = record.category;
+    const status = record.status;
+    if (!validIdentityPath(file)) {
+      addError(errors, "malformed-row-identity", `JSONL line ${line} has an invalid file identity`, { line });
+      continue;
+    }
+    if (typeof category !== "string" || category.length === 0) {
+      addError(errors, "malformed-row-category", `JSONL line ${line} has no category`, { line, file });
+      continue;
+    }
+    if (typeof status !== "string" || !TEST262_VERDICT_STATUSES.has(status)) {
+      addError(errors, "malformed-row-status", `JSONL line ${line} has an unknown status ${JSON.stringify(status)}`, {
+        line,
+        file,
+      });
+      continue;
+    }
+
+    const previous = identityRows.get(file);
+    if (previous) {
+      addError(
+        errors,
+        "duplicate-verdict-identity",
+        `JSONL identity ${file} occurs on lines ${previous.line} and ${line} (${previous.status}, ${status})`,
+        {
+          file,
+          lines: [previous.line, line],
+          statuses: [previous.status, status],
+        },
+      );
+    } else {
+      identityRows.set(file, { line, status });
+    }
+    rows.push({ record, line, identity: file });
+  }
+
+  return {
+    errors,
+    rows,
+    identities: new Set(identityRows.keys()),
+    identityRows,
+    physicalRows,
+  };
+}
+
+function exclusionBucket(manifest, name, errors, manifestLabel) {
+  const exclusions = isObject(manifest.exclusions) ? manifest.exclusions : {};
+  const raw = exclusions[name];
+  if (raw === undefined) {
+    addError(errors, "manifest-missing-exclusions", `${manifestLabel} is missing exclusions.${name}`);
+    return { count: 0, paths: [] };
+  }
+
+  // Arrays are accepted as a small convenience for hand-authored fixtures;
+  // production manifests use { count, paths } so the count is explicit.
+  if (Array.isArray(raw)) {
+    return { count: raw.length, paths: raw };
+  }
+  if (typeof raw === "number") {
+    if (!isNonNegativeInteger(raw)) {
+      addError(errors, "manifest-malformed-exclusions", `${manifestLabel} exclusions.${name}.count is not an integer`);
+      return { count: 0, paths: [] };
+    }
+    addError(errors, "manifest-missing-exclusion-paths", `${manifestLabel} exclusions.${name} has no paths`);
+    return { count: raw, paths: [] };
+  }
+  if (!isObject(raw)) {
+    addError(errors, "manifest-malformed-exclusions", `${manifestLabel} exclusions.${name} must be an object`);
+    return { count: 0, paths: [] };
+  }
+
+  const count = raw.count;
+  const paths = raw.paths;
+  if (!isNonNegativeInteger(count)) {
+    addError(errors, "manifest-malformed-exclusions", `${manifestLabel} exclusions.${name}.count is not an integer`);
+  }
+  if (!Array.isArray(paths)) {
+    addError(errors, "manifest-missing-exclusion-paths", `${manifestLabel} exclusions.${name}.paths is not an array`);
+  }
+  const safeCount = isNonNegativeInteger(count) ? count : 0;
+  const safePaths = Array.isArray(paths) ? paths : [];
+  if (safeCount !== safePaths.length) {
+    addError(
+      errors,
+      "manifest-exclusion-count-mismatch",
+      `${manifestLabel} exclusions.${name} declares ${safeCount} paths but contains ${safePaths.length}`,
+    );
+  }
+  return { count: safeCount, paths: safePaths };
+}
+
+function validateManifest(manifest, index, errors) {
+  const manifestLabel = `shard manifest ${manifest?.path ?? `#${index + 1}`}`;
+  if (!isObject(manifest)) {
+    addError(errors, "malformed-shard-manifest", `${manifestLabel} must contain an object`, {
+      manifest: manifestLabel,
+    });
+    return null;
+  }
+
+  if (manifest.schema !== TEST262_COMPLETION_MANIFEST_SCHEMA) {
+    addError(
+      errors,
+      "manifest-schema-mismatch",
+      `${manifestLabel} has schema ${JSON.stringify(manifest.schema)}, expected ${TEST262_COMPLETION_MANIFEST_SCHEMA}`,
+      { manifest: manifestLabel },
+    );
+  }
+  if (typeof manifest.runTimestamp !== "string" || manifest.runTimestamp.length === 0) {
+    addError(errors, "manifest-malformed-run-timestamp", `${manifestLabel} runTimestamp is missing`);
+  }
+  if (!Number.isInteger(manifest.chunkIndex) || manifest.chunkIndex < 0) {
+    addError(errors, "manifest-malformed-chunk", `${manifestLabel} chunkIndex is not a non-negative integer`);
+  }
+  if (!isPositiveInteger(manifest.chunkTotal)) {
+    addError(errors, "manifest-malformed-chunk", `${manifestLabel} chunkTotal is not a positive integer`);
+  } else if (
+    Number.isInteger(manifest.chunkIndex) &&
+    (manifest.chunkIndex < 0 || manifest.chunkIndex >= manifest.chunkTotal)
+  ) {
+    addError(
+      errors,
+      "manifest-malformed-chunk",
+      `${manifestLabel} chunkIndex ${manifest.chunkIndex} is outside chunkTotal ${manifest.chunkTotal}`,
+    );
+  }
+  if (typeof manifest.target !== "string" || manifest.target.length === 0) {
+    addError(errors, "manifest-malformed-target", `${manifestLabel} target is missing`);
+  }
+
+  const registeredPaths = manifest.registeredPaths;
+  if (!Array.isArray(registeredPaths)) {
+    addError(errors, "manifest-missing-registered-paths", `${manifestLabel} registeredPaths is not an array`);
+  }
+  const safeRegisteredPaths = Array.isArray(registeredPaths) ? registeredPaths : [];
+  const registeredSet = new Set();
+  for (const path of safeRegisteredPaths) {
+    if (!validIdentityPath(path)) {
+      addError(errors, "manifest-malformed-registered-path", `${manifestLabel} contains an invalid registered path`, {
+        manifest: manifestLabel,
+        file: path,
+      });
+      continue;
+    }
+    if (registeredSet.has(path)) {
+      addError(errors, "manifest-duplicate-registered-path", `${manifestLabel} registers ${path} more than once`, {
+        manifest: manifestLabel,
+        file: path,
+      });
+    }
+    registeredSet.add(path);
+  }
+
+  const registeredTests = manifest.registeredTests;
+  if (!isNonNegativeInteger(registeredTests)) {
+    addError(errors, "manifest-malformed-count", `${manifestLabel} registeredTests is not a non-negative integer`);
+  } else if (registeredTests !== safeRegisteredPaths.length) {
+    addError(
+      errors,
+      "manifest-registered-count-mismatch",
+      `${manifestLabel} declares ${registeredTests} registered tests but lists ${safeRegisteredPaths.length}`,
+      { manifest: manifestLabel },
+    );
+  }
+
+  const canonicalVerdicts = manifest.canonicalVerdicts ?? manifest.recordedRows;
+  if (!isNonNegativeInteger(canonicalVerdicts)) {
+    addError(
+      errors,
+      "manifest-malformed-count",
+      `${manifestLabel} canonical verdict count is not a non-negative integer`,
+    );
+  }
+  if (manifest.canonicalVerdicts !== undefined && manifest.recordedRows !== undefined) {
+    if (manifest.canonicalVerdicts !== manifest.recordedRows) {
+      addError(
+        errors,
+        "manifest-verdict-count-alias-mismatch",
+        `${manifestLabel} canonicalVerdicts and recordedRows disagree (${manifest.canonicalVerdicts} vs ${manifest.recordedRows})`,
+      );
+    }
+  }
+
+  const proposal = exclusionBucket(manifest, "proposal", errors, manifestLabel);
+  const official = exclusionBucket(manifest, "official", errors, manifestLabel);
+  const exclusionPaths = new Set();
+  for (const [kind, bucket] of [
+    ["proposal", proposal],
+    ["official", official],
+  ]) {
+    for (const path of bucket.paths) {
+      if (!validIdentityPath(path)) {
+        addError(
+          errors,
+          "manifest-malformed-exclusion-path",
+          `${manifestLabel} has an invalid ${kind} exclusion path`,
+          {
+            manifest: manifestLabel,
+            file: path,
+          },
+        );
+        continue;
+      }
+      if (!registeredSet.has(path)) {
+        addError(
+          errors,
+          "manifest-exclusion-not-registered",
+          `${manifestLabel} excludes ${path}, but that path is not registered`,
+          { manifest: manifestLabel, file: path },
+        );
+      }
+      if (exclusionPaths.has(path)) {
+        addError(errors, "manifest-duplicate-exclusion", `${manifestLabel} excludes ${path} more than once`, {
+          manifest: manifestLabel,
+          file: path,
+        });
+      }
+      exclusionPaths.add(path);
+    }
+  }
+
+  const exclusionCount = proposal.count + official.count;
+  if (isNonNegativeInteger(registeredTests) && isNonNegativeInteger(canonicalVerdicts)) {
+    if (registeredTests !== canonicalVerdicts + exclusionCount) {
+      addError(
+        errors,
+        "manifest-verdict-count-mismatch",
+        `${manifestLabel}: registered ${registeredTests} != canonical verdicts ${canonicalVerdicts} + explicit exclusions ${exclusionCount}`,
+        { manifest: manifestLabel },
+      );
+    }
+  }
+
+  const callbacksStarted = manifest.callbacksStarted;
+  const callbacksSettled = manifest.callbacksSettled;
+  if (!isNonNegativeInteger(callbacksStarted) || !isNonNegativeInteger(callbacksSettled)) {
+    addError(
+      errors,
+      "manifest-malformed-callback-count",
+      `${manifestLabel} callback counts are not non-negative integers`,
+    );
+  }
+  if (manifest.allCallbacksSettled !== true) {
+    addError(errors, "callbacks-unsettled", `${manifestLabel} does not prove that all callbacks settled`);
+  }
+  if (isNonNegativeInteger(registeredTests) && callbacksStarted !== registeredTests) {
+    addError(
+      errors,
+      "manifest-callback-start-count-mismatch",
+      `${manifestLabel}: callbacksStarted ${callbacksStarted} != registered ${registeredTests}`,
+    );
+  }
+  if (isNonNegativeInteger(registeredTests) && callbacksSettled !== registeredTests) {
+    addError(
+      errors,
+      "manifest-callback-settlement-count-mismatch",
+      `${manifestLabel}: callbacksSettled ${callbacksSettled} != registered ${registeredTests}`,
+    );
+  }
+
+  return {
+    manifest,
+    label: manifestLabel,
+    chunkIndex: manifest.chunkIndex,
+    chunkTotal: manifest.chunkTotal,
+    target: manifest.target,
+    registeredTests: isNonNegativeInteger(registeredTests) ? registeredTests : 0,
+    canonicalVerdicts: isNonNegativeInteger(canonicalVerdicts) ? canonicalVerdicts : 0,
+    exclusionCount,
+    registeredPaths: safeRegisteredPaths,
+    registeredSet,
+    exclusionPaths,
+  };
+}
+
+/**
+ * Validate a JSONL stream against durable per-shard completion manifests.
+ *
+ * `jsonlText` is the complete stream being considered. `manifests` may contain
+ * parsed objects or `{ manifest, path }` wrappers (the CLI uses the latter so
+ * diagnostics name the source file). `expectedShardCount` is optional because
+ * a deliberately narrowed local shard glob is valid; when supplied it is the
+ * number of shard files requested by that invocation, not necessarily the
+ * manifest's baked-in full-corpus chunkTotal.
+ */
+export function evaluateTest262Completeness(jsonlText, manifests, options = {}) {
+  const errors = [];
+  const parsedRows = parseTest262Jsonl(jsonlText);
+  errors.push(...parsedRows.errors);
+
+  const inputManifests = Array.isArray(manifests) ? manifests : [];
+  if (inputManifests.length === 0) {
+    addError(errors, "missing-shard-manifest", "No Test262 shard completion manifests were provided");
+  }
+
+  const shardRecords = [];
+  const chunkIndices = new Set();
+  const registeredPaths = new Set();
+  const expectedVerdictPaths = new Set();
+  let registeredTests = 0;
+  let canonicalVerdicts = 0;
+  let explicitExclusions = 0;
+  let chunkTotal;
+  let target;
+
+  for (let index = 0; index < inputManifests.length; index++) {
+    const input = inputManifests[index];
+    const wrapper = isObject(input) && isObject(input.manifest) ? input : { manifest: input };
+    const manifest =
+      wrapper.path && isObject(wrapper.manifest) ? { ...wrapper.manifest, path: wrapper.path } : wrapper.manifest;
+    const record = validateManifest(manifest, index, errors);
+    if (!record) continue;
+    shardRecords.push(record);
+
+    if (chunkIndices.has(record.chunkIndex)) {
+      addError(errors, "duplicate-shard-index", `${record.label} repeats chunkIndex ${record.chunkIndex}`);
+    }
+    chunkIndices.add(record.chunkIndex);
+    if (chunkTotal === undefined) chunkTotal = record.chunkTotal;
+    else if (chunkTotal !== record.chunkTotal) {
+      addError(
+        errors,
+        "shard-total-mismatch",
+        `${record.label} has chunkTotal ${record.chunkTotal}, expected ${chunkTotal}`,
+      );
+    }
+    if (target === undefined) target = record.target;
+    else if (target !== record.target)
+      addError(errors, "shard-target-mismatch", `${record.label} target differs from other shards`);
+
+    registeredTests += record.registeredTests;
+    canonicalVerdicts += record.canonicalVerdicts;
+    explicitExclusions += record.exclusionCount;
+
+    for (const path of record.registeredPaths) {
+      if (registeredPaths.has(path)) {
+        addError(errors, "duplicate-registered-identity", `Path ${path} is registered by more than one shard`, {
+          file: path,
+        });
+      }
+      registeredPaths.add(path);
+      if (!record.exclusionPaths.has(path)) expectedVerdictPaths.add(path);
+    }
+  }
+
+  if (options.expectedShardCount !== undefined) {
+    if (!isNonNegativeInteger(options.expectedShardCount)) {
+      addError(errors, "invalid-expected-shard-count", "expectedShardCount must be a non-negative integer");
+    } else if (shardRecords.length !== options.expectedShardCount) {
+      addError(
+        errors,
+        "missing-shard-manifest",
+        `Expected ${options.expectedShardCount} shard manifests but found ${shardRecords.length}`,
+        { expected: options.expectedShardCount, actual: shardRecords.length },
+      );
+    }
+  }
+
+  const expectedPathsOption = options.expectedPaths;
+  if (expectedPathsOption !== undefined) {
+    if (!Array.isArray(expectedPathsOption)) {
+      addError(errors, "invalid-expected-paths", "expectedPaths must be an array");
+    } else {
+      const exactExpected = new Set();
+      for (const path of expectedPathsOption) {
+        if (exactExpected.has(path)) {
+          addError(errors, "duplicate-expected-path", `Expected path occurs more than once: ${path}`);
+        }
+        exactExpected.add(path);
+        if (!validIdentityPath(path)) addError(errors, "invalid-expected-path", `Expected path is invalid: ${path}`);
+      }
+      // The exact filter file describes the callbacks the runner was asked to
+      // register, including callbacks later accounted for as explicit
+      // proposal/official exclusions. Verdict identity completeness below
+      // still compares rows only with the non-excluded subset.
+      if (
+        exactExpected.size !== registeredPaths.size ||
+        [...exactExpected].some((path) => !registeredPaths.has(path))
+      ) {
+        addError(
+          errors,
+          "manifest-scope-mismatch",
+          `Manifest selected identity set does not match the exact expected scope (manifest ${registeredPaths.size}, expected ${exactExpected.size})`,
+        );
+      }
+    }
+  }
+
+  const rowIdentities = parsedRows.identities;
+  const missing = [...expectedVerdictPaths].filter((path) => !rowIdentities.has(path)).sort();
+  const unexpected = [...rowIdentities].filter((path) => !expectedVerdictPaths.has(path)).sort();
+  if (missing.length > 0) {
+    addError(
+      errors,
+      "missing-verdict-identity",
+      `Missing ${missing.length} canonical verdict identities: ${missing.join(", ")}`,
+      {
+        missing,
+      },
+    );
+  }
+  if (unexpected.length > 0) {
+    addError(
+      errors,
+      "unexpected-verdict-identity",
+      `Found ${unexpected.length} verdict identities outside the selected scope: ${unexpected.join(", ")}`,
+      {
+        unexpected,
+      },
+    );
+  }
+
+  if (canonicalVerdicts !== parsedRows.physicalRows) {
+    addError(
+      errors,
+      "manifest-jsonl-row-count-mismatch",
+      `Manifest canonical verdict total ${canonicalVerdicts} != JSONL physical row total ${parsedRows.physicalRows}`,
+      { manifest: canonicalVerdicts, jsonl: parsedRows.physicalRows },
+    );
+  }
+  if (canonicalVerdicts !== rowIdentities.size) {
+    addError(
+      errors,
+      "manifest-jsonl-unique-count-mismatch",
+      `Manifest canonical verdict total ${canonicalVerdicts} != JSONL unique identity total ${rowIdentities.size}`,
+      { manifest: canonicalVerdicts, jsonl: rowIdentities.size },
+    );
+  }
+  if (registeredTests !== canonicalVerdicts + explicitExclusions) {
+    addError(
+      errors,
+      "aggregate-verdict-count-mismatch",
+      `Aggregate registered ${registeredTests} != canonical verdicts ${canonicalVerdicts} + explicit exclusions ${explicitExclusions}`,
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    stats: {
+      shards: shardRecords.length,
+      chunkTotal: chunkTotal ?? null,
+      target: target ?? null,
+      registeredTests,
+      canonicalVerdicts,
+      explicitExclusions,
+      physicalRows: parsedRows.physicalRows,
+      uniqueRows: rowIdentities.size,
+      missing,
+      unexpected,
+      duplicateIdentities: parsedRows.errors.filter((error) => error.code === "duplicate-verdict-identity").length,
+    },
+    rows: parsedRows.rows,
+    manifests: shardRecords,
+  };
+}
+
+// Friendly alias for callers that prefer the imperative name.
+export const validateTest262Completeness = evaluateTest262Completeness;
+
+function parseArguments(argv) {
+  const options = { input: "", manifests: [], expectedShardCount: undefined, expectedPathsFile: "" };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--input") options.input = argv[++index] ?? "";
+    else if (arg === "--manifest") options.manifests.push(argv[++index] ?? "");
+    else if (arg === "--expected-shards") options.expectedShardCount = Number.parseInt(argv[++index] ?? "", 10);
+    else if (arg === "--expected-paths-file") options.expectedPathsFile = argv[++index] ?? "";
+    else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: node scripts/validate-test262-completeness.mjs --input <results.jsonl> --manifest <shard.complete.json> [--manifest ...] [--expected-shards N] [--expected-paths-file <file>]",
+      );
+      return null;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (!options.input) throw new Error("--input is required");
+  return options;
+}
+
+function readExpectedPaths(path) {
+  if (!path) return undefined;
+  const text = readFileSync(path, "utf8");
+  try {
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // A newline-delimited path file is also useful for shell-generated exact
+    // filters, so fall through to that format when the content is not JSON.
+  }
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function runCli(argv) {
+  let options;
+  try {
+    options = parseArguments(argv);
+  } catch (error) {
+    console.error(`Test262 completeness: ${error?.message ?? error}`);
+    return 2;
+  }
+  if (!options) return 0;
+
+  if (!existsSync(options.input)) {
+    console.error(`Test262 completeness: missing JSONL input ${options.input}`);
+    return 2;
+  }
+  const manifests = [];
+  for (const path of options.manifests) {
+    if (!path || !existsSync(path)) {
+      console.error(`Test262 completeness: missing shard manifest ${path || "<empty>"}`);
+      return 2;
+    }
+    try {
+      manifests.push({ manifest: JSON.parse(readFileSync(path, "utf8")), path });
+    } catch (error) {
+      console.error(`Test262 completeness: malformed shard manifest ${path}: ${error?.message ?? error}`);
+      return 2;
+    }
+  }
+
+  let expectedPaths;
+  try {
+    expectedPaths = readExpectedPaths(options.expectedPathsFile);
+  } catch (error) {
+    console.error(`Test262 completeness: cannot read expected paths: ${error?.message ?? error}`);
+    return 2;
+  }
+  const result = evaluateTest262Completeness(readFileSync(options.input, "utf8"), manifests, {
+    expectedShardCount: options.expectedShardCount,
+    expectedPaths,
+  });
+  if (!result.ok) {
+    console.error(`INCOMPLETE: Test262 verdict evidence is not publishable (${result.errors.length} errors)`);
+    for (const error of result.errors) console.error(`  - ${error.code}: ${error.message}`);
+    return 2;
+  }
+  console.log(
+    `COMPLETE: ${result.stats.shards} shard(s), ${result.stats.canonicalVerdicts} verdicts, ${result.stats.registeredTests} registered (${result.stats.explicitExclusions} explicit exclusions)`,
+  );
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = runCli(process.argv.slice(2));
+}

--- a/tests/issue-3522-test262-shard-completion.test.ts
+++ b/tests/issue-3522-test262-shard-completion.test.ts
@@ -36,10 +36,15 @@ describe("#3522 Test262 shard completion evidence", () => {
   it("writes the completion marker only from the shard afterAll hook", () => {
     const afterAllStart = runner.indexOf("  afterAll(() => {");
     expect(afterAllStart).toBeGreaterThan(-1);
-    expect(runner.slice(0, afterAllStart)).not.toContain("writeFileSync(\n      SHARD_COMPLETION_PATH");
-    expect(runner.slice(afterAllStart)).toContain("writeFileSync(\n      SHARD_COMPLETION_PATH");
-    expect(runner).toContain("registeredTests: myTests.length");
-    expect(runner).toContain("recordedRows: summary.total");
+    expect(runner.slice(0, afterAllStart)).not.toContain("writeFileSync(shardCompletionPath");
+    expect(runner.slice(afterAllStart)).toContain("writeFileSync(shardCompletionPath");
+    expect(runner).toContain("getTest262ShardCompletionPath(JSONL_PATH, chunkIndex, totalChunks)");
+    expect(runner).toContain('schema: "test262-shard-completion-v2"');
+    expect(runner).toContain("registeredTests: registeredPaths.length");
+    expect(runner).toContain("recordedRows: canonicalVerdicts");
+    expect(runner).toContain("canonicalVerdicts,");
+    expect(runner).toContain("allCallbacksSettled");
+    expect(runner).toContain('{ flag: "wx" }');
   });
 
   it("rejects a missing marker before any shard workflow accepts exit code 1", () => {
@@ -49,11 +54,11 @@ describe("#3522 Test262 shard completion evidence", () => {
       ["refresh", job(refresh, "test262-shard")],
     ] as const) {
       expect(workflowJob, label).toContain(
-        'completion_marker="benchmarks/results/${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl.complete.json"',
+        'find benchmarks/results -maxdepth 1 -name "${TEST262_RESULT_PREFIX}-results-${RUN_TIMESTAMP}.shard-*.complete.json"',
       );
-      expect(workflowJob, label).toContain('if [ ! -s "$completion_marker" ]');
+      expect(workflowJob, label).toContain('if [ -z "$completion_marker" ] || [ ! -s "$completion_marker" ]');
       expect(workflowJob, label).toContain("refusing partial JSONL evidence");
-      expect(workflowJob, label).toContain(".jsonl.complete.json");
+      expect(workflowJob, label).toContain(".shard-*.complete.json");
     }
   });
 });

--- a/tests/issue-5215-test262-verdict-completeness.test.ts
+++ b/tests/issue-5215-test262-verdict-completeness.test.ts
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5215 — a complete-looking JSONL is publishable only when every registered
+// identity has one canonical verdict and every excluded callback is explicit.
+// These tests are deliberately pure: they exercise the evidence validator and
+// concurrency calculation without starting a compiler worker.
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { resolveVitestMaxConcurrency } from "../scripts/test262-concurrency.mjs";
+import {
+  evaluateTest262Completeness,
+  getTest262ShardCompletionPath,
+  TEST262_COMPLETION_MANIFEST_SCHEMA,
+} from "../scripts/validate-test262-completeness.mjs";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const runner = readFileSync(resolve(ROOT, "scripts/run-test262-vitest.sh"), "utf8");
+const validator = resolve(ROOT, "scripts/validate-test262-completeness.mjs");
+
+function row(file: string, status: string): string {
+  return JSON.stringify({ file, category: "language", status });
+}
+
+function manifest(
+  chunkIndex: number,
+  registeredPaths: string[],
+  verdictCount: number,
+  proposalExclusions: string[] = [],
+  officialExclusions: string[] = [],
+  callbacksSettled = registeredPaths.length,
+) {
+  return {
+    schema: TEST262_COMPLETION_MANIFEST_SCHEMA,
+    runTimestamp: "5215-test",
+    chunkIndex,
+    chunkTotal: 2,
+    target: "gc",
+    registeredTests: registeredPaths.length,
+    registeredPaths,
+    recordedRows: verdictCount,
+    canonicalVerdicts: verdictCount,
+    exclusions: {
+      proposal: { count: proposalExclusions.length, paths: proposalExclusions },
+      official: { count: officialExclusions.length, paths: officialExclusions },
+    },
+    callbacksStarted: registeredPaths.length,
+    callbacksSettled,
+    allCallbacksSettled: callbacksSettled === registeredPaths.length,
+  };
+}
+
+function runValidatorCli(
+  jsonl: string,
+  manifests: ReturnType<typeof manifest>[],
+  options: { expectedShards?: number; expectedPaths?: string[] } = {},
+) {
+  const directory = mkdtempSync(join(tmpdir(), "js2-test262-5215-"));
+  try {
+    const input = join(directory, "results.jsonl");
+    writeFileSync(input, jsonl);
+    const args = [validator, "--input", input];
+    if (options.expectedShards !== undefined) args.push("--expected-shards", String(options.expectedShards));
+    for (const [index, value] of manifests.entries()) {
+      const path = join(directory, `shard-${index}.complete.json`);
+      writeFileSync(path, JSON.stringify(value));
+      args.push("--manifest", path);
+    }
+    if (options.expectedPaths !== undefined) {
+      const path = join(directory, "expected-paths.txt");
+      writeFileSync(path, options.expectedPaths.join("\n") + "\n");
+      args.push("--expected-paths-file", path);
+    }
+    const result = spawnSync(process.execPath, args, { encoding: "utf8" });
+    return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe("#5215 Test262 verdict completeness", () => {
+  it("accepts a complete run even when conformance rows are fail/compile_error/timeout", () => {
+    const paths = ["test/pass.js", "test/fail.js", "test/ce.js", "test/timeout.js", "test/skip.js"];
+    const jsonl = paths
+      .map((path, index) => row(path, ["pass", "fail", "compile_error", "compile_timeout", "skip"][index]))
+      .join("\n");
+    const result = evaluateTest262Completeness(jsonl, [manifest(0, paths, paths.length)], {
+      expectedShardCount: 1,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.stats.canonicalVerdicts).toBe(5);
+  });
+
+  it("rejects an incomplete shard even when a later complete shard exists", () => {
+    const first = manifest(0, ["test/a.js", "test/missing.js", "test/c.js"], 2, [], [], 2);
+    const second = manifest(1, ["test/d.js"], 1);
+    const result = evaluateTest262Completeness(
+      [row("test/a.js", "pass"), row("test/c.js", "fail"), row("test/d.js", "pass")].join("\n"),
+      [first, second],
+      { expectedShardCount: 2 },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.stats.missing).toEqual(["test/missing.js"]);
+    expect(result.errors.some((error) => error.code === "callbacks-unsettled")).toBe(true);
+    expect(result.errors.some((error) => error.code === "missing-verdict-identity")).toBe(true);
+  });
+
+  it("counts proposal and official-scope exclusions explicitly", () => {
+    const selected = ["test/official.js", "test/staging/proposal.js", "test/nonofficial.js"];
+    const result = evaluateTest262Completeness(
+      row(selected[0], "compile_error"),
+      [manifest(0, selected, 1, [selected[1]], [selected[2]])],
+      { expectedShardCount: 1, expectedPaths: selected },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.stats.explicitExclusions).toBe(2);
+  });
+
+  it("rejects an exact-filter extra path and a missing selected path", () => {
+    const selected = ["test/selected-a.js", "test/selected-b.js"];
+    const result = evaluateTest262Completeness(
+      [row(selected[0], "pass"), row("test/out-of-filter.js", "pass")].join("\n"),
+      [manifest(0, selected, 2)],
+      { expectedShardCount: 1, expectedPaths: selected },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.stats.missing).toEqual([selected[1]]);
+    expect(result.stats.unexpected).toEqual(["test/out-of-filter.js"]);
+  });
+
+  it("rejects an expected filter identity absent from registeredPaths", () => {
+    const expected = ["test/selected.js", "test/vanished.js"];
+    const result = evaluateTest262Completeness(row(expected[0], "pass"), [manifest(0, [expected[0]], 1)], {
+      expectedShardCount: 1,
+      expectedPaths: expected,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((error) => error.code === "manifest-scope-mismatch")).toBe(true);
+  });
+
+  it("rejects duplicate identities and malformed JSONL rows", () => {
+    const result = evaluateTest262Completeness(
+      [row("test/duplicate.js", "fail"), row("test/duplicate.js", "pass"), "not-json"].join("\n"),
+      [manifest(0, ["test/duplicate.js"], 2)],
+      { expectedShardCount: 1 },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((error) => error.code === "duplicate-verdict-identity")).toBe(true);
+    expect(result.errors.some((error) => error.code === "malformed-jsonl")).toBe(true);
+  });
+
+  it("rejects missing shard manifests rather than trusting a partial JSONL", () => {
+    const result = evaluateTest262Completeness(row("test/only.js", "pass"), [], { expectedShardCount: 1 });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((error) => error.code === "missing-shard-manifest")).toBe(true);
+  });
+
+  it("CLI blocks an incomplete shard even when a later complete shard is present", () => {
+    const first = manifest(0, ["test/a.js", "test/missing.js"], 1, [], [], 1);
+    const second = manifest(1, ["test/b.js"], 1);
+    const result = runValidatorCli([row("test/a.js", "fail"), row("test/b.js", "pass")].join("\n"), [first, second], {
+      expectedShards: 2,
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("INCOMPLETE");
+    expect(result.stderr).toContain("missing-verdict-identity");
+  });
+
+  it("CLI accepts ordinary fail and compile_error rows as complete evidence", () => {
+    const paths = ["test/fail.js", "test/compile-error.js"];
+    const result = runValidatorCli(
+      [row(paths[0], "fail"), row(paths[1], "compile_error")].join("\n"),
+      [manifest(0, paths, 2)],
+      {
+        expectedShards: 1,
+        expectedPaths: paths,
+      },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("COMPLETE");
+  });
+
+  it("CLI rejects a filter identity missing from registeredPaths", () => {
+    const expected = ["test/selected.js", "test/vanished.js"];
+    const result = runValidatorCli(row(expected[0], "pass"), [manifest(0, [expected[0]], 1)], {
+      expectedShards: 1,
+      expectedPaths: expected,
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("manifest-scope-mismatch");
+  });
+});
+
+describe("#5215 concurrency controls", () => {
+  it("passes an exact path filter to the production completeness gate and rejects ambiguous unions", () => {
+    expect(runner).toContain('completeness_args+=(--expected-paths-file "$TEST262_PATH_FILTER_FILE")');
+    expect(runner).toContain("TEST262_PATH_FILTER and TEST262_PATH_FILTER_FILE cannot be combined");
+  });
+
+  it("validates before report construction and canonical publication", () => {
+    const gate = runner.indexOf("scripts/validate-test262-completeness.mjs");
+    const report = runner.indexOf("scripts/build-test262-report.mjs");
+    const reportSymlink = runner.indexOf('ln -sf "$(basename "$RUN_REPORT")"');
+    const completed = runner.indexOf('echo "COMPLETED:');
+    expect(gate).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(report);
+    expect(report).toBeLessThan(reportSymlink);
+    expect(reportSymlink).toBeLessThan(completed);
+  });
+
+  it("bounds only Test262 callbacks by the active compiler pool", () => {
+    expect(resolveVitestMaxConcurrency({ TEST262_TARGET: "standalone", COMPILER_POOL_SIZE: "1" })).toBe(1);
+    expect(resolveVitestMaxConcurrency({ TEST262_TARGET: "gc", COMPILER_POOL_SIZE: "2" })).toBe(2);
+    expect(resolveVitestMaxConcurrency({ TEST262_TARGET: "gc", COMPILER_POOL_SIZE: "64" })).toBe(32);
+    expect(resolveVitestMaxConcurrency({ VITEST_MAX_FORKS: "1" })).toBe(32);
+  });
+
+  it("gives each shard a distinct completion evidence path", () => {
+    const jsonl = "/tmp/test262-results-5215.jsonl";
+    expect(getTest262ShardCompletionPath(jsonl, 0, 2)).not.toBe(getTest262ShardCompletionPath(jsonl, 1, 2));
+    expect(getTest262ShardCompletionPath(jsonl, 0, 2)).toBe("/tmp/test262-results-5215.shard-1-of-2.complete.json");
+  });
+});

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -23,6 +23,7 @@ import {
 import { join, relative } from "path";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { CompilerPool, type TestResult } from "../scripts/compiler-pool.js";
+// oracle-version-exempt: #5215 changes callback-completeness evidence only; Test262 scoring is unchanged.
 import { negativeCompileErrorMatches, negativeCompileSucceededVerdict } from "../scripts/negative-verdict.mjs";
 import { resolveTest262PoolSize } from "../scripts/test262-concurrency.mjs";
 import { getTest262ShardCompletionPath } from "../scripts/validate-test262-completeness.mjs";

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -22,17 +22,18 @@ import {
 } from "fs";
 import { join, relative } from "path";
 import { afterAll, beforeAll, describe, it } from "vitest";
-import { availableParallelism } from "os";
 import { CompilerPool, type TestResult } from "../scripts/compiler-pool.js";
+import { negativeCompileErrorMatches, negativeCompileSucceededVerdict } from "../scripts/negative-verdict.mjs";
+import { resolveTest262PoolSize } from "../scripts/test262-concurrency.mjs";
+import { getTest262ShardCompletionPath } from "../scripts/validate-test262-completeness.mjs";
 import { discoverFixtureGraph, hasSelfModuleImport } from "../scripts/test262-fixture-graph.mjs";
 // (#4162) ONE import-object finaliser, shared with scripts/test262-worker.mjs
 // and tests/test262-runner.ts.
 import { instantiateTest262Module } from "../scripts/test262-import-object.mjs";
 import { isPoisonCompileError } from "../scripts/test262-poison-error.mjs";
-import { negativeCompileErrorMatches, negativeCompileSucceededVerdict } from "../scripts/negative-verdict.mjs";
 import { isRecordedVerdictSentinel } from "../scripts/verdict-once.mjs";
 import { findNthAssert } from "./test262-assert-locator.js";
-import { ORACLE_VERSION, ORACLE_FAST_REV } from "./test262-oracle-version.js";
+import { ORACLE_FAST_REV, ORACLE_VERSION } from "./test262-oracle-version.js";
 import {
   classifyError,
   classifyTestScope,
@@ -200,7 +201,7 @@ function getCachePaths(wrappedSource: string): { wasmPath: string; metaPath: str
 
 // ── Pool setup ─────────────────────────────────────────────────────
 
-const POOL_SIZE = parseInt(process.env.COMPILER_POOL_SIZE || String(Math.max(1, availableParallelism() - 1)), 10);
+const POOL_SIZE = resolveTest262PoolSize(process.env);
 
 // (#2928 E6) Per-test vitest timeout. The 90s default measures POOL-QUEUE WAIT
 // as well as the test's own run: when a slow cluster occupies every pool worker
@@ -248,13 +249,6 @@ const RUN_TIMESTAMP =
   process.env.RUN_TIMESTAMP || new Date().toISOString().replace(/[-:T]/g, "").replace(/\..+/, "").slice(0, 15);
 const RESULT_PREFIX = process.env.TEST262_RESULT_PREFIX || (TEST262_TARGET ? `test262-${TEST262_TARGET}` : "test262");
 const JSONL_PATH = join(RESULTS_DIR, `${RESULT_PREFIX}-results-${RUN_TIMESTAMP}.jsonl`);
-// A JSONL can exist even when the Vitest fork dies halfway through a shard.
-// The workflow accepts exit code 1 because baseline conformance failures are
-// ordinary test results, so process death cannot be inferred from the exit
-// code alone. Write this marker only from afterAll, once Vitest has settled
-// every registered test and the result fd has been closed. Shard jobs require
-// the marker before accepting/uploading their evidence.
-const SHARD_COMPLETION_PATH = `${JSONL_PATH}.complete.json`;
 
 // Open results JSONL — each chunk appends independently
 const jsonlFd = openSync(JSONL_PATH, "a");
@@ -268,6 +262,11 @@ const summary = {
   compile_timeout: 0,
   skip: 0,
 };
+// Keep a per-identity count in addition to the headline counters. The latter
+// are useful for logging, but a Vitest parent may host several local shard
+// entry files; filtering this map by one shard's registered paths makes that
+// shard's manifest independent of another shard's summary state.
+const canonicalRowCounts = new Map<string, number>();
 type StatusCounts = {
   pass: number;
   fail: number;
@@ -425,6 +424,7 @@ function recordResult(
     retry_count: retryInfo?.retryCount || undefined,
   });
   fdWrite(jsonlFd, entry + "\n");
+  canonicalRowCounts.set(file, (canonicalRowCounts.get(file) ?? 0) + 1);
   summary.total++;
   (summary as any)[status]++;
   if (!catCounts[category]) catCounts[category] = createEmptyCounts();
@@ -522,17 +522,17 @@ function assignBalancedChunk(tests: Test262ChunkTest[], chunkIndex: number, tota
  * the test in one process. No separate Phase 1 needed.
  */
 export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
-  // Build full test list, filtering out proposals unless explicitly included.
-  // This avoids registering ~5,200 proposal tests that would be skipped anyway,
-  // saving ~10% of run time and keeping the statusline total accurate.
+  // Build the exact selected test list. Proposal callbacks remain registered
+  // when the official-only scope is active so their early return is explicit in
+  // the shard manifest instead of being indistinguishable from a lost callback.
   const includeProposals = process.env.TEST262_INCLUDE_PROPOSALS === "1";
   const allTests: Test262ChunkTest[] = [];
   for (const category of TEST_CATEGORIES) {
     for (const filePath of findTestFiles(category)) {
-      // Skip staging/ proposal tests at the file level.
+      // Discover all candidates; official-scope exclusion is recorded by the
+      // callback after metadata classification below.
       const relPath = relative(TEST262_ROOT, filePath);
       if (!matchesPathFilter(relPath)) continue;
-      if (!includeProposals && (relPath.startsWith("test/staging/") || relPath.startsWith("staging/"))) continue;
       allTests.push({
         category,
         durationMs: durationOf(relPath),
@@ -546,6 +546,24 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
   const chunk = assignBalancedChunk(allTests, chunkIndex, totalChunks);
   const myTests = chunk.tests;
 
+  // These counters belong to this shard invocation. Vitest can load several
+  // local shard entry files in one parent process, so completion evidence must
+  // not infer one shard's settlement from another shard's counters.
+  const registeredPaths = myTests.map((test) => test.relPath);
+  const proposalExclusionPaths: string[] = [];
+  const officialExclusionPaths: string[] = [];
+  let callbacksStarted = 0;
+  let callbacksSettled = 0;
+  const shardCompletionPath = getTest262ShardCompletionPath(JSONL_PATH, chunkIndex, totalChunks);
+
+  const trackCallback = (callback: () => Promise<void>) => async () => {
+    callbacksStarted++;
+    try {
+      return await callback();
+    } finally {
+      callbacksSettled++;
+    }
+  };
   // Sort within the shard by descending known duration (slow tests first).
   // Tests absent from `slowTestDurationMs` keep their natural order behind the
   // timed ones (Array.prototype.sort is stable on Node ≥ 12).
@@ -582,6 +600,11 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
   }, 30_000);
 
   afterAll(() => {
+    // Snapshot this before pool shutdown: a shutdown can make queued work
+    // disappear without ever entering its callback, and that must remain an
+    // incomplete shard rather than looking settled after teardown.
+    const allCallbacksSettledBeforePoolShutdown =
+      callbacksStarted === registeredPaths.length && callbacksSettled === registeredPaths.length;
     try {
       pool?.shutdown();
       pool = null;
@@ -616,20 +639,36 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
       console.log(`Poison-error retries (#1862): ${poisonRetriesUsed} used`);
     }
 
-    writeFileSync(
-      SHARD_COMPLETION_PATH,
-      JSON.stringify(
-        {
-          chunkIndex,
-          chunkTotal: totalChunks,
-          registeredTests: myTests.length,
-          recordedRows: summary.total,
-          target: TEST262_TARGET ?? "gc",
-        },
-        null,
-        2,
-      ) + "\n",
-    );
+    const canonicalVerdicts = registeredPaths.reduce((count, path) => count + (canonicalRowCounts.get(path) ?? 0), 0);
+    const completion = {
+      schema: "test262-shard-completion-v2",
+      runTimestamp: RUN_TIMESTAMP,
+      chunkIndex,
+      chunkTotal: totalChunks,
+      target: TEST262_TARGET ?? "gc",
+      registeredTests: registeredPaths.length,
+      registeredPaths,
+      // Keep recordedRows for the existing artifact readers while naming the
+      // invariant explicitly for new validators.
+      recordedRows: canonicalVerdicts,
+      canonicalVerdicts,
+      exclusions: {
+        proposal: { count: proposalExclusionPaths.length, paths: [...proposalExclusionPaths].sort() },
+        official: { count: officialExclusionPaths.length, paths: [...officialExclusionPaths].sort() },
+      },
+      callbacksStarted,
+      callbacksSettled,
+      allCallbacksSettled: allCallbacksSettledBeforePoolShutdown,
+    };
+    try {
+      // A duplicate RUN_TIMESTAMP must never replace evidence from an earlier
+      // attempt. The shell runner supplies a fresh timestamp; a collision is
+      // an infrastructure error that should remain visible to the validator.
+      writeFileSync(shardCompletionPath, JSON.stringify(completion, null, 2) + "\n", { flag: "wx" });
+    } catch (error) {
+      console.error(`Test262 shard completion manifest was not created: ${shardCompletionPath}: ${String(error)}`);
+      throw error;
+    }
   });
 
   for (const [category, files] of byCategory) {
@@ -643,7 +682,7 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
 
         it(
           relPath,
-          async () => {
+          trackCallback(async () => {
             // #1521 — Path-scoped filter. Applied BEFORE source read / parse /
             // cache lookup so narrowly-scoped PRs skip ~40k tests entirely
             // (no compile, no record, no execution). Empty / unset filter
@@ -655,8 +694,14 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
             const meta = parseMeta(source);
             const scopeInfo = classifyTestScope(source, meta, filePath);
 
-            // Don't record proposal tests at all — they inflate JSONL without adding value
-            if (!includeProposals && scopeInfo.scope === "proposal") return;
+            // Don't record non-official tests in the official-only scope;
+            // retain the scope-specific identity so the manifest proves why
+            // the callback has no JSONL verdict.
+            if (!includeProposals && !scopeInfo.official) {
+              if (scopeInfo.scope === "proposal") proposalExclusionPaths.push(relPath);
+              else officialExclusionPaths.push(relPath);
+              return;
+            }
 
             if (!meta.negative) {
               const filter = shouldSkip(source, meta, filePath);
@@ -1342,7 +1387,7 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
               undefined,
               metadataFromWorkerResult(r, false),
             );
-          },
+          }),
           IT_TIMEOUT_MS,
         );
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { availableParallelism } from "node:os";
 import { defineConfig } from "vitest/config";
+import { resolveVitestMaxConcurrency } from "./scripts/test262-concurrency.mjs";
 
 const forkMaxOldSpaceSize = process.env.VITEST_FORK_MAX_OLD_SPACE_SIZE || "512";
 
@@ -67,11 +68,11 @@ export default defineConfig({
         execArgv: [`--max-old-space-size=${forkMaxOldSpaceSize}`, "--expose-gc"],
       },
     },
-    // Lets describe.concurrent tests run up to 32 at once — CompilerPool limits
-    // actual concurrent compilations to POOL_SIZE (availableParallelism - 1).
-    // Without this, vitest runs it() blocks within a describe() sequentially,
-    // leaving pool workers idle and stretching test262 runs to 150+ minutes.
-    maxConcurrency: 32,
+    // Unit tests retain the 32-callback default. Test262 callbacks are bounded
+    // by the same COMPILER_POOL_SIZE used by tests/test262-shared.ts; queueing
+    // 32 Vitest timeout clocks behind a one- or two-worker pool can abandon the
+    // tail of a shard before it records its verdict.
+    maxConcurrency: isTest262Run ? resolveVitestMaxConcurrency(process.env) : 32,
     // 35s — must sit above the compiler's internal 30s timeout so that
     // `compile_timeout` status can be recorded before vitest force-kills the
     // test. With describe.concurrent (see PR #14), a 10s ceiling flipped


### PR DESCRIPTION
## Description

Problem: The maintained Test262 runner could publish a well-formed but incomplete report when queued Vitest callbacks timed out without recording verdict rows, and later shards overwrote the only completion marker.

Behavior: Bound Test262 callback concurrency to compiler-pool capacity, emit one durable identity-complete manifest per shard, validate per-shard and merged verdict evidence, and refuse report/symlink/history publication when callbacks or identities are missing. Ordinary fail, compile_error, compile_timeout, and skip verdicts remain complete conformance evidence.

Tests: 17 focused Test262 completeness and shard-evidence tests passed; the maintained standalone runner reconciled all 19 previously missing identities as 19 registered / 19 settled / 19 verdicts; complete red-data and incomplete fail-closed CLI controls passed.

Quality: Current-main rebase passed typecheck, lint, Prettier, verdict-oracle with the documented zero-row-flip exemption, oracle and coercion ratchets, the 18-test numeric-local parity gate, issue integrity, commit hooks, bash syntax, YAML parsing, and diff checks. The initial non-required QuickJS job exhausted its 512 MiB Node heap without a semantic assertion failure; the required quality defect was fixed at the current head.

Tracking: `plan/issues/5215-test262-verdict-completeness-after-timeout.md`. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->