### PR TITLE
fix(promise): reify species and prototype tag

### DIFF
--- a/plan/issues/5197-es2015-standalone-promise-r2.md
+++ b/plan/issues/5197-es2015-standalone-promise-r2.md
@@ -1,13 +1,13 @@
 ---
 id: 5197
 title: "ES2015 standalone promise — r2 residual pass"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-08-29
-priority: medium
+updated: 2026-08-30
+priority: high
 horizon: m
-feasibility: medium
+feasibility: hard
 task_type: conformance
 area: codegen
 es_edition: ES2015
@@ -21,30 +21,137 @@ requested_by: claude/fable-es2015
 
 State after the 2026-08-29 session: wave 1 (#5143, part of PR #5179) plus a
 second pass that yielded only +5 (PR #5213, added
-`src/codegen/promise-newtarget.ts`). The small r2 yield is the signal: the
-easy wins under the existing plan are exhausted, and the remaining failures
-likely sit in deeper semantics (job-queue ordering, species/subclass
-construction, resolve-function identity) that need their own clustering —
-not another pass over the wave-1 plan.
+`src/codegen/promise-newtarget.ts`). The stopped r2 planning pass has now been
+completed against exact upstream `main`
+`b6adee3156e9642ed221174a69e6f6f1a381484f`.
+
+The implementation branch was rebased onto upstream `main`
+`02b7a33b58362ef16c703f29d687842066beaae1` on 2026-08-30 before fanout.
+The intervening upstream changes are host-init marshalling, issue metadata, and
+npm-compat artifacts; they do not replace the isolated evidence below. The
+implementer must rerun Slice A on the rebased head before claiming a fix.
+
+The force-refreshed maintained artifacts supplied 152 ES2015
+`built-ins/Promise/**` rows whose standalone status was not pass. Every row was
+rerun in a fresh child process through `runTest262File`, with two workers and
+the QuickJS eval adapter present. Fresh standalone is **12 pass / 138 fail / 2
+compile_error / 0 timeout / 0 skip**. Fresh host is **75 pass / 77 fail**.
+
+Cross-lane classification is 64 standalone-fail/host-pass, one standalone-
+compile-error/host-pass, 74 fail/fail, one compile-error/host-fail, ten
+pass/pass, and two standalone-pass/host-fail. The last two host regressions are
+`promise.js` and `undefined-newtarget.js`; they remain explicit controls even
+though the authoritative completion target is standalone.
 
 ## Implementation Plan
 
-Planning pass required before implementation (plan/implement split).
+### Fresh residual table
 
-- Step 0 — regenerate the promise residual list (`built-ins/Promise/**`) on
-  current main via the standalone probe (see #5194 step 0 for probe shape and
-  the `.test262-cache` caveat).
-- Step 1 — cluster by error signature; write the cluster table into this
-  file. Separate "needs new machinery" clusters from "plan-coverage gap"
-  clusters explicitly.
-- Step 2 — implement per cluster; re-probe; spot-checks stay green.
-- Step 3 — five ratchet gates + equivalence gate.
+| Provider surface | Rows | Fresh standalone | Fresh host | Primary invariant |
+| --- | ---: | --- | --- | --- |
+| `Promise.all` | 46 | 1 pass / 45 fail | 10 pass / 36 fail | observable element pipeline and resolve-element closures |
+| `Promise.race` | 35 | 1 pass / 34 fail | 11 pass / 24 fail | same element pipeline with shared capability functions |
+| `Promise.prototype.then` | 16 | 1 pass / 15 fail | 11 pass / 5 fail | SpeciesConstructor and NewPromiseCapability |
+| executor/resolve/reject function metadata | 15 | 0 pass / 15 fail | 13 pass / 2 fail | escaped synthesized closures must be real callable objects |
+| `Promise.resolve` / `Promise.reject` | 14 | 2 pass / 12 fail | 13 pass / 1 fail | generic constructor capability and settlement identity |
+| `Promise.prototype.catch` | 7 | 2 pass / 5 fail | 6 pass / 1 fail | generic `Invoke(this, "then", ...)` |
+| constructor / settlement core | 6 | 2 pass / 4 fail | 5 pass / 1 fail | already-resolved guards and thenable job timing |
+| `allSettled` / `any` iterator-close tail | 4 | 0 pass / 4 fail | 0 pass / 4 fail | shared abrupt-combinator iterator closing |
+| arbitrary NewTarget/prototype | 3 | 1 pass / 2 CE | 1 pass / 2 fail | #3371 Reflect.construct NewTarget substrate |
+| Promise prototype misc | 3 | 2 pass / 1 fail | 3 pass | canonical `@@toStringTag` |
+| `Promise[Symbol.species]` | 2 | 0 pass / 2 fail | 2 pass | canonical species accessor value/descriptor |
+| cross-realm prototype | 1 | 0 pass / 1 fail | 0 pass / 1 fail | realm-correct Promise prototype identity |
+
+The two remaining compile errors are
+`get-prototype-abrupt-executor-not-callable.js` (host passes) and
+`get-prototype-abrupt.js` (host fails), both still refused by the documented
+#3371 arbitrary-NewTarget boundary. The twelve fresh standalone passes remain
+in the 152-row regression corpus; do not count them as new r2 yield.
+
+### Implementation slices
+
+Each completed slice is one separate mergeable upstream PR. A checkpoint that
+only changes a compile error into a runtime failure is not a completed fix.
+
+1. **Slice A — Promise symbol object model (3 rows).** Add the two
+   `Promise/Symbol.species` rows and `prototype/Symbol.toStringTag.js` to
+   `tests/issue-5197-es2015-promise-r2.test.ts`. Reuse the canonical builtin
+   species accessor and native-prototype symbol-tag machinery; direct value
+   reads and property descriptors must agree, with no Promise-specific fake
+   object. Acceptance is standalone 3/3 and host 3/3.
+2. **Slice B — synthesized promise callables (15-row metadata corpus).** Make
+   executor, resolve, and reject functions escape as the repository's standard
+   non-constructible callable carrier. They need `typeof === "function"`,
+   `Function.prototype`, extensibility, own `length` then `name` descriptors,
+   correct invocation arguments, and `new fn()` TypeError behavior. Apply the
+   same substrate to combinator resolve-element functions rather than creating
+   another representation.
+3. **Slice C — generic catch/then capability.** Implement `catch` as observable
+   `Invoke(this, "then", «undefined, onRejected»)` for arbitrary objects, then
+   route native `$Promise.prototype.then` through ordered constructor/species
+   Gets and NewPromiseCapability when those properties are observable. Keep the
+   intrinsic unpatched fast path. Re-run the exact 23-row then/catch corpus,
+   including its three already-passing controls.
+4. **Slice D — generic Promise resolve/reject and settlement.** Generalize
+   NewPromiseCapability for `Promise.resolve/reject.call(C, value)`, preserve
+   constructor identity and already-resolved guards, and schedule custom
+   thenables in the established microtask ring. Close the 12 static-method and
+   four settlement-core failures without regressing the two host-only controls.
+5. **Slice E — common observable combinator pipeline.** Build one shared
+   provider for `Get(C, "resolve")` once, per-element Call, observable Get/Call
+   of `then`, per-element interleaving, and IteratorClose on abrupt completion.
+   It must compose the existing native thenable scheduler and the Slice-B
+   callable carrier, not add host imports or drain the iterable before
+   subscription.
+6. **Slices F1-F3 — completed combinators separately.** Wire the common
+   provider into `all`, `race`, then `allSettled`/`any`. A PR is complete only
+   when its exact method corpus passes; preserve aggregate identity,
+   remaining-element/once semantics, result ordering, and the method's shared
+   resolve/reject function identity. Combine methods only when the same changed
+   helper closes their full claimed corpora.
+7. **Slice G — arbitrary NewTarget (2 rows), delegated to #3371.** Keep both
+   rows in acceptance, but do not weaken Reflect.construct semantics or the
+   diagnostic locally. Re-measure after #3371 supplies distinct-NewTarget
+   prototype lookup and abrupt propagation.
+8. **Slice H — cross-realm tail (1 row).** Close `proto-from-ctor-realm.js`
+   through the canonical eval-realm Promise provider; never special-case the
+   Test262 harness or treat the primary realm prototype as universal.
+
+For every completed slice, run isolated exact host and standalone rows, the
+other 152 rows as a regression sweep, already-green Promise/async controls,
+TS5/TS7, zero-host-import assertions, formatting/lint, LOC/function budgets,
+oracle/coercion ratchets, numeric-local parity, issue integrity, and the full
+commit/pre-push hooks with at most two workers.
+
+### Handoff
+
+Planning/implementation worktree:
+`/private/tmp/js2-es2015-promise-symbol-object-model-20260830`.
+Planning/implementation branch: `codex/5197-promise-symbol-object-model`.
+Exact candidate list: `/private/tmp/js2-promise-r2-baseline152.txt`.
+Exact owned Slice-A list:
+`/private/tmp/js2-promise-symbol-object-model3.txt`.
+Fresh isolated results:
+`/private/tmp/js2-promise-r2-fresh-main-{standalone,host}.jsonl`.
+
+The implementation owner must use a separately provisioned worktree, update
+this markdown issue with exact before/after evidence and remaining rows, push
+checkpoints to `ttraenkler/js2` without force, and open a completed fix as a
+non-draft PR on `loopdive/js2`. A semantically incomplete/non-mergeable
+checkpoint may remain draft with explicit blockers. No GitHub issue is to be
+created.
 
 ## Acceptance criteria
 
-- Cluster table with measured counts in this file before implementation.
-- Measurable net gain on the regenerated list; no spot-check or equivalence
-  regressions.
+- All 152 exact rows pass standalone with zero host imports; interim PRs pass
+  every row they claim and do not lose any previously passing row.
+- The 75 currently passing host controls remain green. The two host-only
+  regressions are restored by the shared provider work that owns their
+  invariant, not hidden from the corpus.
+- Both compile errors become passes after #3371 lands, never merely runtime
+  failures.
+- Exact isolated sweeps, focused tests, async/equivalence controls, ratchets,
+  issue integrity, and complete repository hooks are green for every fix.
 
 ## References
 

--- a/plan/issues/5197-es2015-standalone-promise-r2.md
+++ b/plan/issues/5197-es2015-standalone-promise-r2.md
@@ -13,6 +13,7 @@ area: codegen
 es_edition: ES2015
 goal: standalone-mode
 requested_by: claude/fable-es2015
+pr: 5292
 ---
 
 # #5197 — promise r2: cluster and fix the residual promise-bucket failures
@@ -167,9 +168,10 @@ avoids the `builtin-static-globals -> builtin-ctor-own-props ->
 builtin-static-gopd -> property-access -> builtin-static-globals` ESM cycle.
 
 Validation was run after integrating the exact fetched
-`upstream/main` head `c243892c7f3a757bdecf6215626b08586ce72c58` in this
-worktree. The worktree currently has no publication commit; root owns
-transplanting this diff onto a fresh c243-based branch.
+`upstream/main` head `c243892c7f3a757bdecf6215626b08586ce72c58` in the
+implementation worktree. Root transplanted the planning and implementation
+commits onto a fresh publication branch and then integrated current upstream
+head `3e89b5f95318b45fd69c9cf8209da84a7a06351a` without conflict.
 
 Focused exact matrix (one Vitest fork; 8/8):
 
@@ -224,12 +226,29 @@ IR-kind-neutrality, IR-layering, and issue-integrity/ID checks passed. The
 issue checker reports only its existing ready-issue probe warnings and no
 changed done-status violation.
 
-Remaining Slice-A handoff: the three owned rows are green in both lanes, with
-no standalone regression in the 152-row comparison. Root should transplant
-the changed files onto a fresh c243-based publication branch, retain the host
-runner limitation and the unrelated #2984 known-gap failure as explicit
-follow-up notes, and perform final review/history/publication. No commit,
-push, GitHub issue, or PR was created by this worker.
+Slice-A completion: the three owned rows are green in both lanes, with no
+standalone regression in the 152-row comparison. The host runner limitation
+and unrelated #2984 known-gap failure remain explicit follow-up notes. No
+GitHub issue was created.
+
+#### Slice A publication handoff (2026-08-30)
+
+The single completed-fix PR is
+<https://github.com/loopdive/js2/pull/5292>. It is a non-draft PR from
+`ttraenkler:codex/5197-promise-symbol-object-model-final` to
+`loopdive/js2:main`; no GitHub issue was created. Its description uses the
+repository's exact Description and CLA sections and links this markdown issue.
+A dedicated Luna Max PR shepherd owns exact-head, body, readiness, conflict,
+review, CI, and queue verification.
+
+The publication branch is
+`/private/tmp/js2-promise-symbol-pr-20260830`. Implementation commit
+`fd13172095d3773627433bba0d4c0e2648ab6e93` has the same tree as the fully
+validated implementation worktree. Integration commit
+`d469014322b88d5c01d45d728177086f86fdb498` adds only the newly merged upstream
+history; a post-integration focused rerun passed 8/8 and the complete pre-push
+hook passed without bypasses. This documentation-only handoff does not alter
+the validated Promise behavior.
 
 ## Acceptance criteria
 

--- a/plan/issues/5197-es2015-standalone-promise-r2.md
+++ b/plan/issues/5197-es2015-standalone-promise-r2.md
@@ -141,6 +141,96 @@ non-draft PR on `loopdive/js2`. A semantically incomplete/non-mergeable
 checkpoint may remain draft with explicit blockers. No GitHub issue is to be
 created.
 
+#### Slice A implementation checkpoint (validated in the dedicated worktree)
+
+This worker owns exactly these three rows, as recorded in
+`/private/tmp/js2-promise-symbol-object-model3.txt`:
+
+- `test/built-ins/Promise/Symbol.species/prop-desc.js`
+- `test/built-ins/Promise/Symbol.species/symbol-species.js`
+- `test/built-ins/Promise/prototype/Symbol.toStringTag.js`
+
+The provider invariant is one object model in standalone: the identity-stable
+`Promise` constructor `$Object` carrier owns the `Symbol.species` accessor
+entry, and both runtime reflection and the compile-time gOPD arm use the same
+canonical `get [Symbol.species]` singleton (receiver-preserving, setter
+`undefined`, enumerable `false`, configurable `true`). `Promise.prototype`
+uses the existing native-prototype companion seeder with `symbolTag: "Promise"`
+and the standard non-writable, non-enumerable, configurable descriptor. No
+Promise-specific fake object or host fallback is introduced. Exact-row host
+invocations are wrapped in `restoreHostBuiltins()` because the Test262
+descriptor helpers destructively probe configurable properties. The shared
+species closure now lives in `src/codegen/builtin-fn-meta.ts`, the neutral
+metadata seam consumed by both the ctor carrier and static gOPD synthesis; this
+keeps `builtin-ctor-own-props.ts` from importing `builtin-static-gopd.ts` and
+avoids the `builtin-static-globals -> builtin-ctor-own-props ->
+builtin-static-gopd -> property-access -> builtin-static-globals` ESM cycle.
+
+Validation was run after integrating the exact fetched
+`upstream/main` head `c243892c7f3a757bdecf6215626b08586ce72c58` in this
+worktree. The worktree currently has no publication commit; root owns
+transplanting this diff onto a fresh c243-based branch.
+
+Focused exact matrix (one Vitest fork; 8/8):
+
+```text
+PATH=/Users/thomas/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/thomas/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH \
+node node_modules/vitest/dist/cli.js run tests/issue-5197-es2015-promise-r2.test.ts \
+  --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=verbose
+```
+
+`3/3` exact host rows passed, `3/3` exact standalone rows passed, and the
+host/standalone descriptor controls passed `2/2`. The standalone control
+asserted `result.imports?.length === 0`.
+
+The standalone 152-row regression sweep used the provisioned QuickJS artifact:
+
+```text
+JS2WASM_QUICKJS_ARTIFACT_DIR=/Users/thomas/Code/js2/.test262-cache/quickjs-artifact-2e2d7736713beeda \
+node --import tsx scripts/harness-flip-probe.ts \
+  --files /private/tmp/js2-promise-r2-baseline152.txt --target standalone \
+  --timeout 120000 --out /private/tmp/js2-promise-r2-sliceA-after-standalone-quickjs.jsonl
+```
+
+The run completed with `15 pass / 135 fail / 2 compile_error` (`152` total;
+controls `must-pass -> pass`, `must-fail -> fail`). Against
+`/private/tmp/js2-promise-r2-fresh-main-standalone.jsonl` (`12 pass / 138 fail /
+2 compile_error`), the partition is `149 unchanged`, exactly three
+fail-to-pass rows (the three owned rows above), `0 pass-to-fail`, and `0 other
+status changes`.
+
+The ordinary host sweep initially aborted after row 9 because
+`harness-flip-probe.ts` does not install an unhandled-rejection handler; the
+row itself returned `fail`, then the process exited on `TypeError: undefined is
+not a function`. The same authentic 152-row run was completed with a
+process-level observer that only swallowed those existing unhandled rejections
+(no repository file change): `75 pass / 77 fail`, `152` total. Compared with
+`/private/tmp/js2-promise-r2-fresh-main-host.jsonl` (`75 pass / 77 fail`), all
+`152` statuses were unchanged (`0` flips in either direction). This runner
+limitation is the only corpus measurement blocker.
+
+Additional one-worker controls:
+
+- `tests/issue-4167-test262.test.ts tests/reflected-symbol-promise-statics.test.ts tests/promise-expando-standalone.test.ts`: `12/12` passed.
+- `tests/issue-3765-numeric-locals.test.ts`: `18/18` passed.
+- `tests/issue-2984-species.test.ts tests/issue-2984-ctor-carrier-own-props.test.ts tests/issue-4746.test.ts tests/issue-3319.test.ts tests/issue-5116-map-set-prototype-tostringtag.test.ts`: `51/52` passed. The sole failure is the test's explicitly labeled pre-existing `KNOWN GAP (pre-existing): a dynamic write bypasses the non-writable flag`; all 51 other controls, including both #4746 Promise-order rows and all #5116 Map/Set tag rows, passed.
+
+Quality evidence (all completed without history mutation): TS5 and TS7 direct
+typechecks passed; full Prettier check passed; full Biome lint exited 0;
+host-import policy reported `legacySemanticImports=0` and `unknownImports=0`;
+oracle/coercion ratchets reported no net growth; stack-balance buckets had
+zero deltas; codegen-fallback, any-box, speculative-rollback, IR dialect,
+IR-kind-neutrality, IR-layering, and issue-integrity/ID checks passed. The
+issue checker reports only its existing ready-issue probe warnings and no
+changed done-status violation.
+
+Remaining Slice-A handoff: the three owned rows are green in both lanes, with
+no standalone regression in the 152-row comparison. Root should transplant
+the changed files onto a fresh c243-based publication branch, retain the host
+runner limitation and the unrelated #2984 known-gap failure as explicit
+follow-up notes, and perform final review/history/publication. No commit,
+push, GitHub issue, or PR was created by this worker.
+
 ## Acceptance criteria
 
 - All 152 exact rows pass standalone with zero host imports; interim PRs pass

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -2372,14 +2372,14 @@ export function ensureNativeErrorNativeProtoGlue(ctx: CodegenContext, builtinNam
 /**
  * (#2861) Register `Promise.prototype` glue (idempotent) and return its brand.
  * Scoped to the static `.prototype` VALUE read + method-closure value reads
- * (`then`/`catch`/`finally`) — the proto OBJECT is a pure value object
- * (member CSV only; `emitLazyNativeProtoGet` never re-emits a body that touches
- * the async-capability runtime state, which is what #1907 found to null-deref). */
+ * (`then`/`catch`/`finally`) and intrinsic `Symbol.toStringTag`; the proto
+ * OBJECT remains a pure value object (member CSV + tag), so lazy reads never
+ * touch async-capability runtime state (#1907). */
 export function ensurePromiseNativeProtoGlue(ctx: CodegenContext): number | undefined {
   const brand = getBuiltinBrand(ctx, "Promise");
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
-    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Promise", PROMISE_PROTO_METHODS));
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Promise", PROMISE_PROTO_METHODS, "Promise"));
   }
   return brand;
 }

--- a/src/codegen/builtin-ctor-own-props.ts
+++ b/src/codegen/builtin-ctor-own-props.ts
@@ -78,12 +78,17 @@ import {
   tryEnsureNativeProtoBrand,
 } from "./builtin-value-read.js";
 import { ensureStandaloneBuiltinStaticMethodClosure } from "./property-access.js";
-import { BUILTIN_STATIC_METHOD_ARITY, pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
+import {
+  BUILTIN_STATIC_METHOD_ARITY,
+  ensureStandaloneSpeciesGetterClosure,
+  pushBuiltinFnSingletonValueInstrs,
+} from "./builtin-fn-meta.js";
 import { pushMarkBuiltinCarrierCallable } from "./builtin-callable-brand.js";
 import { emitLazyNativeProtoGet } from "./native-proto.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+import { ensureSymbolCarrier } from "./symbol-native.js";
 
 /**
  * Spec `length` for ctors that DO get a runtime carrier but are absent from the
@@ -101,6 +106,11 @@ const EXTRA_CTOR_ARITY: Record<string, number> = { AggregateError: 2 };
  */
 const HOST_FLAG_CONFIGURABLE = 0x04;
 const HOST_FLAG_WRITABLE = 0x01;
+// Accessor descriptors carry the enumerable/configurable specified bits in
+// addition to the configurable value bit.  This is the native
+// `__defineProperty_accessor` encoding for `{ enumerable:false,
+// configurable:true }` (no writable bit for accessors).
+const HOST_ACCESSOR_CONFIGURABLE = (1 << 4) | (1 << 5) | HOST_FLAG_CONFIGURABLE;
 
 /**
  * (#4234) Per-ctor NUMERIC own data constants to seed alongside
@@ -283,6 +293,43 @@ export function pushBuiltinCtorOwnPropSeed(
       fctx.body.push({ op: "extern.convert_any" });
       fctx.body.push({ op: "f64.const", value: HOST_FLAG_WRITABLE | HOST_FLAG_CONFIGURABLE });
       fctx.body.push({ op: "call", funcIdx: defineIdx });
+      fctx.body.push({ op: "drop" });
+      return { commit: true, value: undefined };
+    });
+  }
+
+  // Promise[@@species] is an own accessor whose getter returns the receiver
+  // (§27.2.4.4).  The static gOPD synthesis in builtin-static-gopd.ts already
+  // uses this canonical getter singleton, but a bare `Promise` value reaches
+  // this real `$Object` carrier at runtime.  Seed the same accessor there so
+  // direct computed reads and runtime descriptor/attribute queries observe one
+  // property model instead of a synthetic descriptor-only answer.
+  if (builtinName === "Promise") {
+    withSpeculativeCompile(ctx, fctx, () => {
+      const closure = ensureStandaloneSpeciesGetterClosure(ctx, builtinName);
+      if (!closure) return { commit: false, value: undefined };
+      // ensureObjectRuntime (the caller of this seeder) normally creates the
+      // native symbol carrier before entering here. Re-ensure it defensively;
+      // this is a defined helper in standalone and cannot introduce a late
+      // function-index shift.
+      // `ensureSymbolCarrier` returns the `$Symbol` *type* index. The boxing
+      // function is a defined helper registered by that call; resolve its
+      // function index from the map after registration (using the type index
+      // here makes the emitted `call` target an unrelated function).
+      ensureSymbolCarrier(ctx);
+      const boxSymbolIdx = ctx.funcMap.get("__box_symbol");
+      const defineAccessorIdx = ctx.funcMap.get("__defineProperty_accessor");
+      if (boxSymbolIdx === undefined || defineAccessorIdx === undefined) {
+        return { commit: false, value: undefined };
+      }
+      fctx.body.push({ op: "local.get", index: objLocal });
+      fctx.body.push({ op: "i32.const", value: 5 }); // Symbol.species
+      fctx.body.push({ op: "call", funcIdx: boxSymbolIdx });
+      fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, closure));
+      fctx.body.push({ op: "extern.convert_any" });
+      fctx.body.push({ op: "ref.null.extern" }); // setter = undefined
+      fctx.body.push({ op: "f64.const", value: HOST_ACCESSOR_CONFIGURABLE });
+      fctx.body.push({ op: "call", funcIdx: defineAccessorIdx });
       fctx.body.push({ op: "drop" });
       return { commit: true, value: undefined };
     });

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -38,9 +38,15 @@
  *   `struct.new` sites therefore push an extra `i32.const 0`
  *   (`pushBuiltinFnClosureValueInstrs` below).
  */
-import type { Instr } from "../ir/types.js";
-import type { ClosureInfo, CodegenContext } from "./context/types.js";
-import { closureArityField, closureBagField, closureBagInitInstr } from "./closures/funcref-wrapper-types.js";
+import type { Instr, ValType } from "../ir/types.js";
+import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
+import {
+  closureArityField,
+  closureBagField,
+  closureBagInitInstr,
+  getOrCreateFuncRefWrapperTypes,
+} from "./closures/funcref-wrapper-types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 
 /**
  * (#4241) Field indices of the meta-typed closure subtype, derived from the
@@ -384,4 +390,73 @@ export function pushBuiltinFnSingletonValueInstrs(
     { op: "global.get", index: globalIdx },
     { op: "ref.as_non_null" },
   ];
+}
+
+/**
+ * (#2984 / #5197) Canonical per-constructor `get [Symbol.species]` closure.
+ *
+ * Keep this builder beside the builtin-function metadata substrate rather than
+ * in `builtin-static-gopd.ts`: both compile-time descriptor synthesis and the
+ * reified constructor carrier need the exact same identity-stable accessor,
+ * while the latter is imported by `builtin-static-globals.ts`.  Depending on
+ * the higher-level property-access module here would close that initialization
+ * cycle.
+ *
+ * The getter's first user parameter is the original receiver (`this`).  Its
+ * unique metadata subtype makes the singleton's reflective `.name`/`.length`
+ * surface spec-correct and registering that subtype as receiver-aware keeps a
+ * reflective `.call(value)` from dropping the receiver.
+ */
+export function ensureStandaloneSpeciesGetterClosure(
+  ctx: CodegenContext,
+  builtinName: string,
+): { type: { kind: "ref"; typeIdx: number }; funcIdx: number } | null {
+  const userParams: ValType[] = [{ kind: "externref" }];
+  const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, userParams, [{ kind: "externref" }]);
+  if (!wrapperTypes) return null;
+
+  const funcName = `__builtin_species_get_${builtinName}`;
+  let funcIdx = ctx.funcMap.get(funcName);
+  if (funcIdx === undefined) {
+    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.liftedSelfTypeIdx };
+    const closureFctx: FunctionContext = {
+      name: funcName,
+      params: [{ name: "__self", type: selfType }, ...userParams.map((type, i) => ({ name: `arg${i}`, type }))],
+      locals: [],
+      localMap: new Map(),
+      returnType: { kind: "externref" },
+      body: [{ op: "local.get", index: 1 }],
+      blockDepth: 0,
+      breakStack: [],
+      continueStack: [],
+      labelMap: new Map(),
+      savedBodies: [],
+    };
+    for (let i = 0; i < closureFctx.params.length; i++) {
+      closureFctx.localMap.set(closureFctx.params[i]!.name, i);
+    }
+    funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, {
+      name: funcName,
+      typeIdx: wrapperTypes.liftedFuncTypeIdx,
+      locals: closureFctx.locals,
+      body: closureFctx.body,
+      exported: false,
+    });
+    ctx.funcMap.set(funcName, funcIdx);
+    if (!ctx.nativeClosureMeta) ctx.nativeClosureMeta = new Map();
+    ctx.nativeClosureMeta.set(funcIdx, { name: "get [Symbol.species]", length: 0 });
+  }
+
+  const metaTypeIdx = ensureBuiltinFnMetaType(
+    ctx,
+    wrapperTypes.structTypeIdx,
+    wrapperTypes.closureInfo,
+    `species:${builtinName}`,
+    "get [Symbol.species]",
+    0,
+  );
+  if (!ctx.nativeProtoReceiverClosureStructTypes) ctx.nativeProtoReceiverClosureStructTypes = new Set();
+  ctx.nativeProtoReceiverClosureStructTypes.add(metaTypeIdx);
+  return { type: { kind: "ref", typeIdx: metaTypeIdx }, funcIdx };
 }

--- a/src/codegen/builtin-static-gopd.ts
+++ b/src/codegen/builtin-static-gopd.ts
@@ -63,18 +63,15 @@ import { emitUndefinedExtern, undefinedExternInstrs } from "./any-helpers.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import {
   BUILTIN_STATIC_METHOD_ARITY,
-  ensureBuiltinFnMetaType,
+  ensureStandaloneSpeciesGetterClosure,
   pushBuiltinFnSingletonValueInstrs,
 } from "./builtin-fn-meta.js";
-import { getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { allocLocal } from "./context/locals.js";
-import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { emitLazyNativeProtoGet } from "./native-proto.js";
 import { nativeStringLiteralInstrs, stringConstantExternrefInstrs } from "./native-strings.js";
 import {
   BUILTIN_CTOR_ARITY,
   ensureStandaloneBuiltinStaticMethodClosure,
-  makeBuiltinClosureFctx,
   MATH_CONSTANT_VALUES,
   NUMBER_CONSTANT_VALUES,
   TYPED_ARRAY_BYTES_PER_ELEMENT,
@@ -413,69 +410,6 @@ export function isSymbolSpeciesKeyExpression(fctx: FunctionContext, expr: ts.Exp
     e.expression.text === "Symbol" &&
     !(fctx.localMap.has("Symbol") || (fctx.boxedCaptures?.has("Symbol") ?? false))
   );
-}
-
-/**
- * (#2984 "builtin receiver + non-literal key") The per-constructor
- * `get [Symbol.species]` accessor closure — spec `get <Ctor> [ @@species ]`
- * (§23.1.2.5, §25.1.5.3, §24.1.2.2, §24.2.2.2, §27.2.4.4, §22.2.6.2): the body
- * is exactly "Return the this value" (param 1, the lifted receiver slot).
- *
- * The value struct is the UNIQUE per-ctor meta subtype (`species:<Ctor>`), so
- * (a) `pushBuiltinFnSingletonValueInstrs`' per-typeIdx singleton global gives
- * identity-stable reads (`gOPD(Array, Symbol.species).get` is the SAME object
- * across calls) while Array's getter stays distinct from Map's (each ctor owns
- * its OWN accessor function per spec), and (b) the reflective `__builtinfn_*`
- * natives answer `name`/`length` at runtime — `"get [Symbol.species]"` / 0
- * (§10.2.9 accessor spelling) — which is what the test262 propertyHelper reads
- * (`verifyProperty(desc.get, "name"|"length", …)`).
- *
- * The meta type is registered in `nativeProtoReceiverClosureStructTypes`
- * (#2193 PR-B): the getter's FIRST user param IS the receiver, so a statically
- * resolvable `g.call(thisVal)` threads `thisVal` into param 1 (→ returns it)
- * instead of dropping it. Only the meta subtype is registered — the shared
- * signature-wrapper base is left alone (other closures of the same signature
- * take a plain first ARG there, not a receiver).
- */
-function ensureStandaloneSpeciesGetterClosure(
-  ctx: CodegenContext,
-  builtinName: string,
-): { type: { kind: "ref"; typeIdx: number }; funcIdx: number } | null {
-  const userParams: ValType[] = [{ kind: "externref" }]; // param 1 = `this`
-  const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, userParams, [{ kind: "externref" }]);
-  if (!wrapperTypes) return null;
-
-  const funcName = `__builtin_species_get_${builtinName}`;
-  let funcIdx = ctx.funcMap.get(funcName);
-  if (funcIdx === undefined) {
-    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.liftedSelfTypeIdx };
-    const closureFctx = makeBuiltinClosureFctx(funcName, selfType, userParams, { kind: "externref" });
-    // Step 1 (the whole algorithm): Return the this value.
-    closureFctx.body.push({ op: "local.get", index: 1 });
-    funcIdx = mintDefinedFunc(ctx);
-    pushDefinedFunc(ctx, funcIdx, {
-      name: funcName,
-      typeIdx: wrapperTypes.liftedFuncTypeIdx,
-      locals: closureFctx.locals,
-      body: closureFctx.body,
-      exported: false,
-    });
-    ctx.funcMap.set(funcName, funcIdx);
-    if (!ctx.nativeClosureMeta) ctx.nativeClosureMeta = new Map();
-    ctx.nativeClosureMeta.set(funcIdx, { name: "get [Symbol.species]", length: 0 });
-  }
-
-  const metaTypeIdx = ensureBuiltinFnMetaType(
-    ctx,
-    wrapperTypes.structTypeIdx,
-    wrapperTypes.closureInfo,
-    `species:${builtinName}`,
-    "get [Symbol.species]",
-    0,
-  );
-  if (!ctx.nativeProtoReceiverClosureStructTypes) ctx.nativeProtoReceiverClosureStructTypes = new Set();
-  ctx.nativeProtoReceiverClosureStructTypes.add(metaTypeIdx);
-  return { type: { kind: "ref", typeIdx: metaTypeIdx }, funcIdx };
 }
 
 /**

--- a/tests/issue-5197-es2015-promise-r2.test.ts
+++ b/tests/issue-5197-es2015-promise-r2.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5197 — ES2015 Promise Symbol.species / Symbol.toStringTag object model.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile, instantiateWasm } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+type Lane = "host" | "standalone";
+
+const TEST262_ROOT = join(import.meta.dirname ?? ".", "..", "test262");
+const TEST262_AVAILABLE =
+  process.env.JS2_TEST262_AVAILABLE !== "0" && existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+
+const EXACT_ROWS = [
+  "built-ins/Promise/Symbol.species/prop-desc.js",
+  "built-ins/Promise/Symbol.species/symbol-species.js",
+  "built-ins/Promise/prototype/Symbol.toStringTag.js",
+] as const;
+
+// The species checks intentionally use both the syntactic constructor and an
+// any-typed alias. The former exercises the canonical static gOPD/direct-key
+// path; the latter reaches the materialized `$Object` carrier and verifies that
+// its runtime accessor entry agrees with the synthesized descriptor. The
+// prototype checks similarly flow through the native-prototype companion, so a
+// tag that exists only in the immutable `$NativeProto` view cannot pass.
+const CONTROL_SOURCE = `
+  export function test(): number {
+    const promiseCtor: any = Promise;
+    const species: any = Promise[Symbol.species];
+    if (species !== Promise) return 1;
+    if (promiseCtor[Symbol.species] !== promiseCtor) return 2;
+
+    const staticSpeciesDescriptor: any = Object.getOwnPropertyDescriptor(Promise, Symbol.species);
+    const dynamicSpeciesDescriptor: any = Object.getOwnPropertyDescriptor(promiseCtor, Symbol.species);
+    if (
+      staticSpeciesDescriptor === undefined ||
+      typeof staticSpeciesDescriptor.get !== "function" ||
+      staticSpeciesDescriptor.set !== undefined ||
+      staticSpeciesDescriptor.enumerable !== false ||
+      staticSpeciesDescriptor.configurable !== true
+    ) return 3;
+    if (
+      dynamicSpeciesDescriptor === undefined ||
+      dynamicSpeciesDescriptor.get !== staticSpeciesDescriptor.get ||
+      dynamicSpeciesDescriptor.set !== undefined ||
+      dynamicSpeciesDescriptor.enumerable !== false ||
+      dynamicSpeciesDescriptor.configurable !== true
+    ) return 4;
+
+    const promiseProto: any = Promise.prototype;
+    const tagKey: any = Symbol.toStringTag;
+    if (promiseProto[tagKey] !== "Promise") return 5;
+    if (!Object.prototype.hasOwnProperty.call(promiseProto, tagKey)) return 6;
+    const tagDescriptor: any = Object.getOwnPropertyDescriptor(promiseProto, tagKey);
+    if (
+      tagDescriptor === undefined ||
+      tagDescriptor.value !== "Promise" ||
+      tagDescriptor.writable !== false ||
+      tagDescriptor.enumerable !== false ||
+      tagDescriptor.configurable !== true
+    ) return 7;
+    if (Object.prototype.propertyIsEnumerable.call(promiseProto, tagKey)) return 8;
+    if (promiseProto[Symbol("toStringTag")] !== undefined) return 9;
+    return 0;
+  }
+`;
+
+async function runExactRow(relativePath: (typeof EXACT_ROWS)[number], lane: Lane) {
+  try {
+    return await runTest262File(
+      join(TEST262_ROOT, "test", relativePath),
+      "issue-5197",
+      120_000,
+      lane === "standalone" ? lane : undefined,
+    );
+  } finally {
+    // The host runner executes in-process. These descriptor rows deliberately
+    // probe configurable properties with delete, so restore the shared host
+    // realm before the next exact row (and before Vitest's strict rerun).
+    restoreHostBuiltins();
+  }
+}
+
+async function runControl(lane: Lane): Promise<number> {
+  try {
+    const result = await compile(CONTROL_SOURCE, {
+      fileName: "issue-5197-es2015-promise-r2-control.ts",
+      ...(lane === "standalone" ? { target: "standalone" as const, nativeStrings: true } : {}),
+    });
+    expect(
+      result.success,
+      result.success ? "" : result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n"),
+    ).toBe(true);
+    if (!result.success) return -1;
+
+    if (lane === "standalone") {
+      expect(result.imports?.length ?? 0, "standalone control must remain host-free").toBe(0);
+    }
+    const built = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await instantiateWasm(
+      result.binary,
+      built.env,
+      built.string_constants,
+      built.string_constants16,
+    );
+    built.setInstance?.(instance);
+    return (instance.exports as { test: () => number }).test();
+  } finally {
+    // Keep host compiler/runtime controls isolated as well; a future control
+    // may add a destructive descriptor probe without weakening this harness.
+    restoreHostBuiltins();
+  }
+}
+
+describe("#5197 ES2015 Promise Symbol.species and Symbol.toStringTag", () => {
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_ROWS)(
+    "passes the exact host Test262 row %s",
+    async (relativePath) => {
+      const result = await runExactRow(relativePath, "host");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    },
+    180_000,
+  );
+
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_ROWS)(
+    "passes the exact standalone Test262 row %s",
+    async (relativePath) => {
+      const result = await runExactRow(relativePath, "standalone");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    },
+    180_000,
+  );
+
+  for (const lane of ["host", "standalone"] as const) {
+    it(`${lane}: keeps species and prototype tag descriptors aligned`, async () => {
+      await expect(runControl(lane)).resolves.toBe(0);
+    });
+  }
+});

--- a/tests/test262-restore-builtins.ts
+++ b/tests/test262-restore-builtins.ts
@@ -67,6 +67,10 @@ const PROTOS: ReadonlyArray<[string, object]> = [
   ["WeakMap.prototype", WeakMap.prototype],
   ["WeakSet.prototype", WeakSet.prototype],
   ["Promise.prototype", Promise.prototype],
+  // (#5197) Promise/Symbol.species/prop-desc.js deletes this configurable
+  // static accessor during verifyConfigurable(). Snapshot the constructor so
+  // the following exact Promise species row starts from the fresh host realm.
+  ["Promise", Promise],
   // (#5129) The ArrayBuffer @@toStringTag Test262 descriptor probe deletes
   // this configurable own property during its sloppy pass. Snapshot the
   // prototype so the in-process strict rerun sees the fresh-realm value.
@@ -146,6 +150,19 @@ function sameDataDescriptor(
   if (!expected) return true;
   return (
     actual.writable === expected.writable &&
+    actual.enumerable === expected.enumerable &&
+    actual.configurable === expected.configurable
+  );
+}
+
+function sameAccessorDescriptor(
+  actual: PropertyDescriptor | undefined,
+  expected: PropertyDescriptor | undefined,
+): boolean {
+  if (!actual || !expected || "value" in actual || "value" in expected) return false;
+  return (
+    actual.get === expected.get &&
+    actual.set === expected.set &&
     actual.enumerable === expected.enumerable &&
     actual.configurable === expected.configurable
   );
@@ -283,6 +300,21 @@ export function restoreHostBuiltins(): boolean {
         const final = Object.getOwnPropertyDescriptor(proto, key);
         if (!sameDataDescriptor(final, originalDesc, orig)) clean = false;
       }
+    }
+    // (#5197) Accessor properties have no `value` entry, so the data-value
+    // restore above cannot recreate one after verifyProperty() deletes it.
+    // Restore deleted/replaced accessors from the original descriptor as well
+    // (notably Promise[Symbol.species]) before the next in-process row.
+    for (const [key, originalDesc] of descs) {
+      if (values.has(key) || "value" in originalDesc) continue;
+      const cur = Object.getOwnPropertyDescriptor(proto, key);
+      if (sameAccessorDescriptor(cur, originalDesc)) continue;
+      try {
+        Object.defineProperty(proto, key, originalDesc);
+      } catch {
+        /* residual check below */
+      }
+      if (!sameAccessorDescriptor(Object.getOwnPropertyDescriptor(proto, key), originalDesc)) clean = false;
     }
   }
   // (#3470) Restore function .name/.length sub-properties poisoned by


### PR DESCRIPTION
## Description

Problem: Standalone Promise reflection did not expose the canonical `Symbol.species` accessor on the constructor or the intrinsic `Symbol.toStringTag` descriptor on `Promise.prototype`.

Behavior: Reify both properties through the existing constructor-carrier and native-prototype object models, share one identity-stable species getter across metadata paths, and restore destructive host descriptor probes between exact Test262 rows.

Tests: The focused host/standalone matrix passes 8/8, including all three owned Test262 rows in both lanes. The 152-row standalone Promise sweep improved from 12 pass / 138 fail / 2 compile_error to 15 pass / 135 fail / 2 compile_error with exactly three owned fail-to-pass changes and zero regressions; the host sweep remained 75 pass / 77 fail.

Quality: Typecheck, lint, Prettier, LOC/function budgets, host-import policy, oracle/coercion ratchets, stack/fallback/IR gates, issue integrity, 18/18 numeric-local parity, normal commit hooks, and full pre-push hooks passed on current upstream main.

Tracking: `plan/issues/5197-es2015-standalone-promise-r2.md` contains the implementation plan, exact validation evidence, remaining Promise slices, and handoff. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->