### PR TITLE
fix(ir): fail closed on invalid vec export provenance

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -3635,3 +3635,90 @@ on this corpus, not that no program can produce one. Items 1–3 of the resume
 checkpoint (`LegacyAbiAdapter` routing, exports as ABI aliases, session
 notification from allocator replacement / dead-type elimination / compaction)
 are untouched, and R1 acceptance still requires the red suite above to clear.
+
+## 2026-08-30 C36 implementation lock — fail-closed vec export provenance
+
+This Sol-authored checkpoint is grounded on protected `origin/main`
+`c243892c7f3a757bdecf6215626b08586ce72c58`. PRs #5210 and #5233 are already
+merged; their startup-policy and source-qualified vec-export work is not a
+pending task and must not be reimplemented. No open PR, assignment, or parallel
+Claude lane owns the three files below.
+
+### Current false-pass
+
+`finalizeVecHostBridgeExports(...)` authenticates each compiler-owned export
+descriptor against the exact allocator object before rebasing its public Wasm
+index. Its descriptors still cross the dual handle regime: a live absolute
+index is resolved against the final live import prefix, while a value at or
+above `STABLE_FUNC_BASE` is an allocator-stable handle resolved through
+`definedFuncAt(...)`. The current truthiness check conflates a valid stable
+handle (whose raw subtraction is intentionally outside `mod.functions`) with
+an invalid live index. A live index exactly one past the defined-function
+population therefore returns `undefined`, bypasses the ownership error, and is
+silently rewritten to the expected allocator slot. That is a fail-open
+provenance repair: malformed state becomes valid output at the freeze boundary.
+
+The same function already contains the correct disabled-host-bridge invariant:
+standalone/WASI must remove every recorded compiler-owned vec descriptor, and a
+single survivor is fatal. Its focused mutation table does not exercise that
+branch, so a later deletion of the guard could pass all current tests. The
+function comment still describes the operation as a generic late-import
+"rebase" even though the post-#5233 authority is the captured descriptor and
+allocator identity; update the wording to name the authentication/freeze
+boundary without changing behavior.
+
+### Exact repair and ownership
+
+Own only:
+
+- `plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md`;
+- `src/codegen/vec-access-exports.ts`; and
+- `tests/issue-3520-vec-support-callable-abi.test.ts`.
+
+Resolve the observed allocator through two explicit, non-overlapping regimes:
+for `entry.desc.index < STABLE_FUNC_BASE`, use the existing final live-import
+prefix and direct `mod.functions[currentPosition]` lookup; for a stable handle,
+use `definedFuncAt(...)`. Then apply one unconditional object-identity
+assertion: `currentAllocation !== allocation.func` is fatal whether the
+observed value is another function or `undefined`. Do not choose the stable
+resolver merely because a live lookup is out of range, clamp the index, infer
+ownership from an export name, consult `funcMap`, or repair a malformed
+descriptor before the assertion. Preserve the subsequent assignment as a
+position-only rebase for an already-authenticated descriptor.
+
+Extend the existing table-driven mutation test with an exact live-regime
+out-of-range case whose index is
+`live function-import count + module.functions.length` and is asserted below
+`STABLE_FUNC_BASE`. It must reach `finalizeVecHostBridgeExports(...)` and fail
+with the same different-allocator invariant as an in-range retarget, proving
+`undefined` cannot bypass the guard while genuine stable descriptors still
+resolve. Add a separate disabled-policy mutation that starts
+from a real generated host-bridge descriptor, changes only the policy to
+disabled, retains that exact descriptor in `mod.exports`, and requires the
+existing survivor invariant. The test must restore any captured context state
+even when an assertion fails.
+
+Do not replace the existing semantic corpus anti-vacuity
+`corpusOwnedFunctions > 0` with the historical raw `24` count. The plan's
+current-main drift record deliberately rejects brittle corpus-number pins; C36
+closes the concrete descriptor false-pass and records the remaining denominator
+decision without pretending to finish R1.
+
+### Boundaries and acceptance
+
+This slice changes no normal output, callable allocation, export naming,
+standalone/WASI stripping policy, Program-ABI schema, legacy fallback, or route
+selection. It is file-disjoint from queued #5275, open #5218/#5238/#5269, and
+the dirty shared #3521/#4617 checkout. Larger `LegacyAbiAdapter`, ABI-driven
+export publication, allocator-replacement notification, and red-suite work
+remain separate R1 continuations after their active dependencies land.
+
+Acceptance requires the focused vec support callable-ABI suite, TypeScript
+typecheck, formatting/lint, IR fallback and issue-integrity controls, plus the
+LOC and function regrowth ratchets immediately before every commit. Run every
+heavy command only when the one-minute load is finite, non-negative, and
+strictly below `logical cores - 2`. Let the complete precommit and prepush hooks
+run without bypass. No baseline, LOC, function-size, binary-size, or hook
+exception is authorized. A Luna implementation remains draft until an
+independent Sol review approves the exact pushed SHA; any later push invalidates
+that approval.

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -8,6 +8,7 @@
 // finalize passes and re-exports `reserveVecMethodHelper` for its compile-time
 // callers (calls.ts, property-access.ts, closed-method-dispatch.ts).
 
+import { STABLE_FUNC_BASE } from "../emit/resolve-layout.js";
 import type { FuncHandle, Instr, ValType, WasmExport, WasmFunction } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import { undefinedExternInstrs } from "./any-helpers.js"; // (#3315)
@@ -259,12 +260,14 @@ function publishVecHostBridgeExports(ctx: CodegenContext): void {
 }
 
 /**
- * Rebase the public vec bridge exports after dead-layout elimination and the
- * final import batch. The bridge functions are allocated early with live
- * indices, while later compatibility imports can move the defined-function
- * suffix. Most emitters are repaired by the late-import shifter, but exports
- * published before the last batch have no function-body traversal to repair
- * them. Resolve by the allocator-owned function object at the freeze point.
+ * Authenticate and freeze the compiler-owned vec bridge exports after
+ * dead-layout elimination and the final import batch. The bridge functions
+ * are published initially with stable handles, while a previously finalized
+ * descriptor can carry its already-rebased live index. Later compatibility
+ * imports can move the live defined-function suffix. Most emitters are
+ * repaired by the late-import shifter, but exports published before the last
+ * batch have no function-body traversal to repair them. Resolve both regimes
+ * by the captured allocator-owned function object at this boundary.
  */
 export function finalizeVecHostBridgeExports(ctx: CodegenContext): void {
   const allocations = vecHostBridgeAllocations.get(ctx);
@@ -285,8 +288,8 @@ export function finalizeVecHostBridgeExports(ctx: CodegenContext): void {
     return;
   }
   // Dead-import elimination can remove speculative imports without updating
-  // the context's cached `numImportFuncs`. Public export descriptors are raw
-  // Wasm indices at this point, so derive the live prefix from the module.
+  // the context's cached `numImportFuncs`. Derive the current prefix used to
+  // interpret any live-regime public descriptor directly from the module.
   const numImportFuncs = ctx.mod.imports.filter((entry) => entry.desc.kind === "func").length;
   const seen = new Set<WasmExport>();
   for (const { allocation, entry, name } of published) {
@@ -317,8 +320,9 @@ export function finalizeVecHostBridgeExports(ctx: CodegenContext): void {
     if (currentPosition < 0) {
       throw new Error(`vec host bridge export descriptor ${name} resolves to a function import`);
     }
-    const currentAllocation = ctx.mod.functions[currentPosition];
-    if (currentAllocation && currentAllocation !== allocation.func) {
+    const currentAllocation =
+      entry.desc.index < STABLE_FUNC_BASE ? ctx.mod.functions[currentPosition] : definedFuncAt(ctx, entry.desc.index);
+    if (currentAllocation !== allocation.func) {
       throw new Error(`vec host bridge export descriptor ${name} resolves to a different allocator function`);
     }
     entry.desc.index = numImportFuncs + position;

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -10,7 +10,6 @@ import { analyzeSource } from "../src/checker/index.js";
 import { definedFuncAt } from "../src/codegen/func-space.js";
 import { generateModule } from "../src/codegen/index.js";
 import { ProgramAbiCallableRegistry } from "../src/codegen/program-abi-callable-planning.js";
-import { emitBinary } from "../src/emit/binary.js";
 import {
   VEC_HOST_BRIDGE_ROLE,
   type VecHostBridgeKind,
@@ -18,6 +17,8 @@ import {
   resolveVecHostBridgeHelper,
   vecHostBridgePhysicalExportBase,
 } from "../src/codegen/vec-access-exports.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { STABLE_FUNC_BASE } from "../src/emit/resolve-layout.js";
 import { type CompileResult, compile } from "../src/index.js";
 import { irSupportFuncRef } from "../src/ir/callable-bindings.js";
 import { buildIrUnitInventory } from "../src/ir/identity.js";
@@ -487,6 +488,15 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
         expected: /resolves to a different allocator function/,
       },
       {
+        name: "one-past-defined-functions",
+        mutate: (_registry, result, entry) => {
+          const liveImportCount = result.module.imports.filter((candidate) => candidate.desc.kind === "func").length;
+          entry.desc.index = liveImportCount + result.module.functions.length;
+          expect(entry.desc.index).toBeLessThan(STABLE_FUNC_BASE);
+        },
+        expected: /resolves to a different allocator function/,
+      },
+      {
         name: "kind-changed",
         mutate: (_registry, _result, entry) => {
           entry.desc = { kind: "global", index: entry.desc.index };
@@ -513,6 +523,23 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
       if (!entry) throw new Error(`missing compiler-owned vec export for ${mutation.name}`);
       mutation.mutate(registry, result, entry);
       expect(() => finalizeVecHostBridgeExports(registry.ctx), mutation.name).toThrow(mutation.expected);
+    }
+  });
+
+  it("fails closed when disabled host-bridge policy retains a compiler-owned descriptor", () => {
+    const { registry, result } = generateWithCapturedRegistry(ARRAY_SOURCE, "vec-export-disabled-policy-survivor.ts");
+    const entry = result.module.exports.find(
+      (candidate) => candidate.name === "__vec_len" && candidate.desc.kind === "func",
+    );
+    if (!entry) throw new Error("missing compiler-owned vec export for disabled-policy-survivor");
+
+    const originalEmitHostBridge = registry.ctx.emitHostBridge;
+    try {
+      registry.ctx.emitHostBridge = false;
+      expect(result.module.exports).toContain(entry);
+      expect(() => finalizeVecHostBridgeExports(registry.ctx)).toThrow(/survived disabled host-bridge policy/);
+    } finally {
+      registry.ctx.emitHostBridge = originalEmitHostBridge;
     }
   });
 


### PR DESCRIPTION
## Summary

- authenticate compiler-owned vec host bridge descriptors through the exact live or stable handle regime before rebasing
- reject one-past live descriptors instead of silently repairing malformed provenance
- cover disabled host-bridge policy survivors and document the bounded C36 implementation lock

Part of #3520.

## Validation

- focused issue-3520 vec support callable-ABI suite: 14/14
- TypeScript 7 typecheck
- IR fallback, issue integrity, LOC, function, oracle, and coercion-site ratchets
- full precommit and prepush hooks (no bypass)

## Review state

Draft pending independent Sol review of exact pushed SHA 90fa59a6a771a1fe00fd7c57fdc9a4a2cbfe03fe. Any later push invalidates that approval.