### PR TITLE
fix(regexp): preserve standalone lastIndex semantics

### DIFF
--- a/plan/issues/5198-es2015-standalone-regexp-r2.md
+++ b/plan/issues/5198-es2015-standalone-regexp-r2.md
@@ -13,6 +13,7 @@ area: codegen
 es_edition: ES2015
 goal: standalone-mode
 requested_by: claude/fable-es2015
+pr: 5296
 loc-budget-allow:
   - src/codegen/regexp-standalone.ts
   - src/codegen/native-regex.ts
@@ -252,15 +253,22 @@ The existing focused controls also passed in one worker: `tests/issue-1525.test.
 `tests/issue-3481-step3-toprimitive-field-number-hint.test.ts`, and
 `tests/issue-3481-toprimitive-wrapper-unwrap.test.ts` — `5 files, 82 tests`.
 
-Publication handoff: the implementation checkpoint is the branch tip on
-`/private/tmp/js2-es2015-regexp-lastindex-slice-a-20260830`, branch
-`codex/5198-regexp-lastindex-slice-a`; this owner does not push or open a PR.
-Upstream/main advanced to `c882d1b110` (including merged #5290 at
-`4b715bada1`) while this dirty checkpoint was being validated. Root must
-transplant the implementation and issue/test evidence onto a clean current-main
-worktree, rerun the focused rows and controls there, then publish the single
-completed Slice A change upstream. Do not mark the umbrella issue done until
-Slices B-H close.
+Publication handoff: root replayed the planning and Luna implementation
+checkpoints onto exact upstream `main` `c882d1b110`, producing planning commit
+`a0f86cbaceda6e5e723f737cfc8447e88248394b` and implementation commit
+`44c610a1016b1c1e413a93f14237d774e4f6d245`. The clean integrated worktree
+repassed the focused matrix at `20/20`, the identity/coercion controls at
+`82/82`, standalone at `24/165 pass, 137/165 fail, 4/165 compile_error`, and
+host at `126/165 pass, 39/165 fail`; both 165-row sweeps had zero status drift
+from the Luna checkpoint. TS5/TS7, lint, Prettier, budgets, ratchets, numeric
+parity, issue integrity, and the normal pre-push hook were green.
+
+The exact checkpoint was pushed without force to
+`ttraenkler:codex/5198-regexp-lastindex-slice-a-final` and published as ready
+upstream PR <https://github.com/loopdive/js2/pull/5296>. No GitHub issue was
+created. The dedicated PR shepherd owns CI and merge-queue monitoring; do not
+push after the PR receives a non-null queue entry. The umbrella remains
+`in-progress` until Slices B-H close.
 
 The implementation owner must use a separately provisioned worktree, update
 this markdown issue with exact before/after evidence and remaining rows, push

--- a/plan/issues/5198-es2015-standalone-regexp-r2.md
+++ b/plan/issues/5198-es2015-standalone-regexp-r2.md
@@ -1,13 +1,13 @@
 ---
 id: 5198
 title: "ES2015 standalone regexp — r2 residual pass"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-08-29
-priority: medium
+updated: 2026-08-30
+priority: high
 horizon: m
-feasibility: medium
+feasibility: hard
 task_type: conformance
 area: codegen
 es_edition: ES2015
@@ -20,32 +20,147 @@ requested_by: claude/fable-es2015
 ## Problem
 
 State after the 2026-08-29 session: wave 1 (#5142, part of PR #5179) plus a
-second pass that yielded only +8 (PR #5213). As with promise (#5197), the
-small r2 yield means the wave-1 plan is mined out; residuals need fresh
-clustering (`built-ins/RegExp/**`, `built-ins/String/prototype/{match,replace,search,split}/**`
-symbol-protocol tests).
+second pass that yielded only +8 (PR #5213). The stopped r2 planning pass has
+now been completed against exact upstream `main`
+`4881206ab3001505fcfca875589aff8daf375ff9`.
 
-Related known defect, separate issue: the shared-realm strict-rerun
-regression on `cstm-matcher-on-boolean-primitive.js` is #5200 (test-infra,
-not a codegen gap — do not chase it here).
+The implementation branch was rebased onto upstream `main`
+`02b7a33b58362ef16c703f29d687842066beaae1` on 2026-08-30 before fanout.
+The intervening upstream changes are host-init marshalling, issue metadata, and
+npm-compat artifacts; they do not replace the isolated evidence below. The
+implementer must rerun Slice A on the rebased head before claiming a fix.
+
+The force-refreshed maintained artifacts supplied 165 ES2015 rows under
+`built-ins/RegExp/**` and the String
+`{match,replace,search,split}` symbol-protocol families whose standalone status
+was not pass. Every row was then rerun in a fresh child process through
+`runTest262File`, with two workers and the QuickJS eval adapter present. Fresh
+standalone is **3 pass / 158 fail / 4 compile_error / 0 timeout / 0 skip**.
+Fresh host is **126 pass / 39 fail**. Cross-lane classification is:
+
+- 119 standalone-fail / host-pass;
+- 4 standalone-compile-error / host-pass;
+- 39 fail in both lanes; and
+- 3 pass in both lanes.
+
+The 123 host-pass rows are the authoritative standalone conformance delta. The
+39 dual-lane failures are real regression controls, not shared-realm poison:
+every row ran in a separate process. A provider fix must not hide them or make
+the 126 currently passing host controls worse.
+
+Related known defect, separate issue: the shared-realm strict-rerun regression
+on `cstm-matcher-on-boolean-primitive.js` is #5200 (test-infra, not a codegen
+gap). It is not part of this isolated 165-row corpus and must not be chased
+here.
 
 ## Implementation Plan
 
-Planning pass required before implementation (plan/implement split).
+### Fresh residual table
 
-- Step 0 — regenerate the regexp residual list on current main via the
-  standalone probe (see #5194 step 0 for probe shape and the
-  `.test262-cache` caveat).
-- Step 1 — cluster by error signature; write the cluster table into this
-  file.
-- Step 2 — implement per cluster; re-probe; spot-checks stay green.
-- Step 3 — five ratchet gates + equivalence gate.
+| Provider surface | Rows | Fresh standalone | Fresh host | Primary invariant |
+| --- | ---: | --- | --- | --- |
+| `RegExp.prototype[@@replace]` | 38 | 0 pass / 38 fail | 33 pass / 5 fail | observable RegExpExec result/coercion loop |
+| `RegExp.prototype[@@match]` | 33 | 0 pass / 30 fail / 3 CE | 29 pass / 4 fail | RegExpExec loop plus runtime flags |
+| `RegExp.prototype[@@split]` | 31 | 2 pass / 29 fail | 24 pass / 7 fail | SpeciesConstructor and sticky splitter loop |
+| `RegExp.prototype[@@search]` | 15 | 0 pass / 15 fail | 14 pass / 1 fail | observable lastIndex save/restore and result index |
+| String symbol-protocol dispatch | 15 | 0 pass / 14 fail / 1 CE | 10 pass / 5 fail | `GetMethod(searchValue, @@method)` before builtin fallback |
+| RegExp constructor / regexp-like input | 8 | 1 pass / 7 fail | 3 pass / 5 fail | observable `IsRegExp`, constructor short-circuit, source/flags Gets |
+| Cross-realm prototype/flag accessors | 7 | 0 pass / 7 fail | 0 pass / 7 fail | realm-correct builtin prototype identity and brands |
+| `RegExp.prototype.exec` | 6 | 0 pass / 6 fail | 6 pass | observable g/y lastIndex Get/Set |
+| Generic `flags` getter | 5 | 0 pass / 5 fail | 0 pass / 5 fail | generic ordered flag Gets, no receiver brand requirement |
+| `RegExp.prototype.test` | 3 | 0 pass / 3 fail | 3 pass | same g/y lastIndex Set contract as exec |
+| Runtime `u`-pattern syntax | 3 | 0 pass / 3 fail | 3 pass | reject restricted identity escapes in runtime compiler |
+| `RegExp[Symbol.species]` | 1 | 0 pass / 1 fail | 1 pass | canonical species getter value |
+
+The three fresh passes are
+`call_with_regexp_not_same_constructor.js` and the two `@@split` undefined-
+species rows. Keep them as controls; do not count them as new r2 yield.
+
+### Implementation slices
+
+Each completed slice is one separate mergeable upstream PR. Do not publish a
+half-demotion that merely changes `compile_error` into `fail`; every claimed
+row must pass the maintained runner. If a shared helper proves two table rows
+are one invariant, combine only those rows and document the proof here.
+
+1. **Slice A — observable builtin-exec lastIndex (9 rows).** Add the exact six
+   `prototype/exec` and three `prototype/test` rows to
+   `tests/issue-5198-es2015-regexp-r2.test.ts`. Centralize g/y lastIndex read
+   and write around `emitRegexSearchCall` and `emitRegExpTestFromLocals` in
+   `src/codegen/regexp-standalone.ts`: preserve the deferred raw assignment,
+   perform `ToLength` at execution time, and honor the ordinary property
+   descriptor/companion on Set so a non-writable `lastIndex` throws instead of
+   silently mutating the struct. Reuse `__regex_search`; do not add a matcher.
+   Acceptance for this PR is standalone 9/9 and host 9/9.
+2. **Slice B — common observable RegExpExec substrate.** Implement one helper
+   used by the four symbol methods: observable `Get(rx, "exec")`; call a
+   callable override with `rx`; require Object-or-null; otherwise run the
+   existing builtin exec path. Its Get/Set lastIndex behavior must reuse Slice
+   A. Start with the exact invocation/error/invalid-result rows, then update
+   this issue with the measured yield before rebuilding method-specific loops.
+3. **Slices C1-C4 — one completed symbol-method loop at a time.** Rebuild
+   `@@search`, `@@match`, `@@replace`, and `@@split` around the common helper,
+   in that order of increasing surface area. Preserve observable coercion and
+   error order. `@@match` must read flags at runtime rather than rejecting the
+   three dynamic-flag rows; `@@replace` must read generic result properties;
+   `@@split` must implement SpeciesConstructor and the sticky splitter walk.
+   Existing closed static string-receiver paths remain performance controls.
+4. **Slice D — String symbol-protocol dispatch (15 rows).** In the standalone
+   String method dispatcher, implement the spec's `GetMethod(searchValue,
+   @@match/@@replace/@@search/@@split)` and callable invocation before native
+   regexp or string fallback. Close the custom-replace compile error rather
+   than suppressing its diagnostic. Reuse the reified symbol-method closures;
+   do not add host imports.
+5. **Slice E — regexp-like constructor semantics (8-row corpus).** Implement
+   observable `IsRegExp` via `@@match`, called-as-function same-constructor
+   short-circuit, and ordered abrupt `source`/`flags` Gets. The already-passing
+   `call_with_regexp_not_same_constructor.js` is the regression control.
+6. **Slice F — generic flags getter (5 rows).** For `flags` only, accept any
+   Object and perform ordered `ToBoolean(Get(R, global/ignoreCase/multiline/
+   unicode/sticky))`; keep brand checks on the individual flag getters. Fix the
+   shared host/open-object behavior too, since all five rows currently fail in
+   both lanes.
+7. **Slice G — runtime Unicode syntax (3 rows).** Tighten the emitted runtime
+   RegExp compiler, not only `regex/parse.ts`, so `u` mode rejects the three
+   restricted identity-escape rows with a catchable construction-time
+   `SyntaxError`.
+8. **Slice H — realm/species tail (8 rows).** Repair cross-realm RegExp
+   prototype identity/brand handling for the seven isolated realm rows, then
+   close the independent canonical `RegExp[Symbol.species]` getter row as a
+   separate fix if it does not share the changed invariant.
+
+For every slice, run the exact owned rows in isolated host and standalone
+mode, the other 165 rows as a regression sweep, already-green RegExp controls,
+TS5/TS7, zero-host-import assertions, formatting/lint, LOC/function budgets,
+oracle/coercion ratchets, numeric-local parity, issue integrity, and the full
+commit/pre-push hooks with at most two workers.
+
+### Handoff
+
+Planning/implementation worktree:
+`/private/tmp/js2-es2015-regexp-lastindex-20260830`.
+Planning/implementation branch: `codex/5198-regexp-lastindex`.
+Exact candidate list: `/private/tmp/js2-regexp-r2-baseline165.txt`.
+Exact owned Slice-A list: `/private/tmp/js2-regexp-lastindex9.txt`.
+Fresh isolated results:
+`/private/tmp/js2-regexp-r2-fresh-main-{standalone,host}.jsonl`.
+
+The implementation owner must use a separately provisioned worktree, update
+this markdown issue with exact before/after evidence and remaining rows, push
+checkpoints to `ttraenkler/js2` without force, and open a completed fix as a
+non-draft PR on `loopdive/js2`. A semantically incomplete/non-mergeable
+checkpoint may remain draft with explicit blockers. No GitHub issue is to be
+created.
 
 ## Acceptance criteria
 
-- Cluster table with measured counts in this file before implementation.
-- Measurable net gain on the regenerated list; no spot-check or equivalence
-  regressions.
+- All 165 exact rows pass standalone with zero host imports; interim PRs pass
+  every row they claim and do not lose any previously passing row.
+- The 126 currently passing host controls remain green. Any of the 39 dual-lane
+  failures touched by a shared provider fix pass in both lanes.
+- The four current compile errors become passes, never merely runtime failures.
+- Exact isolated sweeps, focused tests, equivalence checks, ratchets, issue
+  integrity, and complete repository hooks are green for every completed fix.
 
 ## References
 

--- a/plan/issues/5198-es2015-standalone-regexp-r2.md
+++ b/plan/issues/5198-es2015-standalone-regexp-r2.md
@@ -13,6 +13,14 @@ area: codegen
 es_edition: ES2015
 goal: standalone-mode
 requested_by: claude/fable-es2015
+loc-budget-allow:
+  - src/codegen/regexp-standalone.ts
+  - src/codegen/native-regex.ts
+  - src/codegen/context/types.ts
+  - src/codegen/type-coercion.ts
+func-budget-allow:
+  - src/codegen/native-regex.ts::ensureRegexSearch
+  - src/codegen/type-coercion.ts::coerceType
 ---
 
 # #5198 — regexp r2: cluster and fix the residual regexp-bucket failures
@@ -24,11 +32,12 @@ second pass that yielded only +8 (PR #5213). The stopped r2 planning pass has
 now been completed against exact upstream `main`
 `4881206ab3001505fcfca875589aff8daf375ff9`.
 
-The implementation branch was rebased onto upstream `main`
-`02b7a33b58362ef16c703f29d687842066beaae1` on 2026-08-30 before fanout.
-The intervening upstream changes are host-init marshalling, issue metadata, and
-npm-compat artifacts; they do not replace the isolated evidence below. The
-implementer must rerun Slice A on the rebased head before claiming a fix.
+The implementation branch is now based directly on upstream `main`
+`a62aacba5ccc154f6fc378235aaaeeb4a7204231`, after a normal migration of the
+static checkpoint on 2026-08-30. The earlier planning/census snapshots remain
+isolated evidence below; the intervening upstream changes do not replace them.
+The implementer must rerun Slice A on this integrated head before claiming a
+fix.
 
 The force-refreshed maintained artifacts supplied 165 ES2015 rows under
 `built-ins/RegExp/**` and the String
@@ -144,6 +153,114 @@ Exact candidate list: `/private/tmp/js2-regexp-r2-baseline165.txt`.
 Exact owned Slice-A list: `/private/tmp/js2-regexp-lastindex9.txt`.
 Fresh isolated results:
 `/private/tmp/js2-regexp-r2-fresh-main-{standalone,host}.jsonl`.
+
+### Slice A implementation checkpoint (pre-validation)
+
+The implementation work is limited to the following nine rows, each pinned by
+`tests/issue-5198-es2015-regexp-r2.test.ts` in both host and standalone lanes:
+
+1. `built-ins/RegExp/prototype/exec/failure-lastindex-access.js`
+2. `built-ins/RegExp/prototype/exec/success-lastindex-access.js`
+3. `built-ins/RegExp/prototype/exec/u-lastindex-adv.js`
+4. `built-ins/RegExp/prototype/exec/y-fail-lastindex-no-write.js`
+5. `built-ins/RegExp/prototype/exec/y-fail-lastindex.js`
+6. `built-ins/RegExp/prototype/exec/y-fail-return.js`
+7. `built-ins/RegExp/prototype/test/y-fail-lastindex-no-write.js`
+8. `built-ins/RegExp/prototype/test/y-fail-lastindex.js`
+9. `built-ins/RegExp/prototype/test/y-fail-return.js`
+
+The fresh isolated baseline recorded in
+`/private/tmp/js2-regexp-r2-fresh-main-{standalone,host}.jsonl` is standalone
+0/9 and host 9/9 for this exact slice. Static diagnosis identifies two
+observable-exec gaps: non-g/y `exec`/`test` skipped the mandated
+`Get(R, "lastIndex")` + `ToLength`, and g/y writeback bypassed the ordinary
+non-writable descriptor state. The implementation centralizes one deferred
+raw-aware read around `emitRegexSearchCall` (and the recovered-local test
+helper), preserves raw values until execution-time coercion, and consults the
+existing `ctx.nonWritableExternKeys` descriptor companion before strict g/y
+writeback. The proof is intentionally narrow: it fires only for a statically
+resolved identifier receiver whose explicit `writable: false` define was
+recorded; a dynamic/recovered externref receiver has no expression-scoped
+companion and declines this guard for the later common-substrate slices. No
+matcher was added.
+
+`src/codegen/regex/parse.ts` is intentionally part of this nine-row slice only
+for `exec/u-lastindex-adv.js`: a lone BMP surrogate atom in `/u` mode must not
+match the trail half of a valid input surrogate pair. It now lowers that atom
+through the existing `CPCLASS` code-point boundary guard; the astral and
+ordinary regex paths are otherwise unchanged. This is not ownership of the
+broader runtime Unicode-syntax slice.
+
+Validation and after-evidence remain pending while the authoritative census
+holds both test-worker slots. The owner must rerun the exact nine rows on the
+integrated current-main head, then append the measured standalone/host result
+and regression evidence before claiming Slice A complete.
+
+## Slice A completion evidence (2026-08-30)
+
+Slice A is complete on the dedicated checkpoint worktree. The implementation
+worktree is based on upstream/main `3e89b5f95318b45fd69c9cf8209da84a7a06351a`
+(planning commit `3c89d8815cc9dd8fb1777de299218d33920ea1ac`, transplanted as
+`05b08dff3e`), with the implementation and validation changes described below.
+The umbrella issue remains `in-progress`; Slices B-H are still open.
+
+Implementation summary:
+
+- `emitRegexSearchCall` and the recovered-local test path now perform one
+  deferred `Get(lastIndex)`/`ToLength` read for every exec/test call, including
+  non-global/non-sticky expressions, and reuse that value for g/y starts.
+- g/y writeback retains the raw assignment until execution and consults the
+  existing statically-known non-writable descriptor companion before Set,
+  preserving the required TypeError and evaluation order.
+- Ref-like raw assignments use direct `extern.convert_any` so the exact RHS
+  object survives `lastIndex` identity checks. A per-FunctionContext nominal-shape
+  marker prevents only the later same-frame identity coercion from materializing
+  a fresh `$Object`; it is not a module-wide context flag.
+- The native-regex leading-literal prefilter is disabled for sticky searches,
+  so it cannot advance past the sole permitted start position.
+- Lone BMP surrogate atoms in `/u` patterns use the existing CPCLASS
+  code-point-boundary guard and no longer match the trail half of a valid pair.
+
+Exact nine-row command and result:
+
+```text
+PATH=/private/tmp/codex-npx2:/private/tmp/codex-pnpm10/node_modules/.bin:/Users/thomas/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/thomas/Code/js2/node_modules/.bin:/opt/homebrew/opt/llvm@18/bin:$PATH \
+JS2WASM_QUICKJS_ARTIFACT_DIR=/private/tmp/js2-quickjs-artifact-2e2d7736713beeda \
+pnpm exec vitest run tests/issue-5198-es2015-regexp-r2.test.ts --pool=forks --maxWorkers=1 --minWorkers=1 --reporter=dot
+```
+
+`20 passed (20)`: host `9/9`, standalone `9/9`, plus two standalone
+same-shape identity/reification controls. The standalone rows emitted zero
+host imports and had zero compile errors, timeouts, or skips. The two focused
+controls were also run A/B with and without the raw lastIndex assignment; both
+returned the expected `8`.
+
+The one-worker 165-row before/after sweep used the exact candidate list
+`/private/tmp/js2-regexp-r2-baseline165.txt` and `runTest262File` in sequential
+host and standalone lanes. Before: standalone `3/165 pass, 158/165 fail,
+4/165 compile_error, 0 timeout, 0 skip`; host `126/165 pass, 39/165 fail`.
+After: standalone `24/165 pass, 137/165 fail, 4/165 compile_error, 0 timeout,
+0 skip`; host `126/165 pass, 39/165 fail`. There were 21 standalone
+`fail -> pass` transitions (including all nine owned rows), zero
+`pass -> non-pass` transitions in either lane, and zero host regressions. The
+four unchanged standalone compile errors and all remaining failures belong to
+Slices B-H; none are claimed by Slice A.
+
+The existing focused controls also passed in one worker: `tests/issue-1525.test.ts`,
+`tests/issue-1917-any-param-toprimitive.test.ts`,
+`tests/issue-4208-ordinary-to-primitive-ir.test.ts`,
+`tests/issue-3481-step3-toprimitive-field-number-hint.test.ts`, and
+`tests/issue-3481-toprimitive-wrapper-unwrap.test.ts` — `5 files, 82 tests`.
+
+Publication handoff: the implementation checkpoint is the branch tip on
+`/private/tmp/js2-es2015-regexp-lastindex-slice-a-20260830`, branch
+`codex/5198-regexp-lastindex-slice-a`; this owner does not push or open a PR.
+Upstream/main advanced to `c882d1b110` (including merged #5290 at
+`4b715bada1`) while this dirty checkpoint was being validated. Root must
+transplant the implementation and issue/test evidence onto a clean current-main
+worktree, rerun the focused rows and controls there, then publish the single
+completed Slice A change upstream. Do not mark the umbrella issue done until
+Slices B-H close.
 
 The implementation owner must use a separately provisioned worktree, update
 this markdown issue with exact before/after evidence and remaining rows, push

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -643,6 +643,13 @@ export interface FunctionContext {
    * Reads keep the boxed carrier; concrete consumers perform coercion at use. */
   mixedAssignmentCarrierVars?: Set<string>;
   /**
+   * Concrete object shapes whose values were written to a standalone RegExp's
+   * raw `lastIndex` slot in this function. Later ref→externref coercions in
+   * the same expression frame must retain that exact GC identity instead of
+   * making the normal ToPrimitive `$Object` value copy.
+   */
+  regexpLastIndexIdentityStructTypes?: Set<number>;
+  /**
    * Callback captures whose ABI deliberately remains externref.  Their
    * checker type may be a concrete array/object, but the value crossed a host
    * callback boundary and must stay dynamically dispatched rather than being

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -2072,9 +2072,18 @@ export function ensureRegexSearch(ctx: CodegenContext): number {
             // regular attempt (a CHAR program fails there anyway, but keeping
             // the loop shape identical avoids reasoning about EOL/lookaround
             // interactions).
+            // A sticky search has exactly one permitted start position.  The
+            // leading-literal filter advances `I` over non-matching code
+            // units, which would silently turn `/b/y` at lastIndex 0 on
+            // `"ab"` into a match at index 1.  Keep the filter on the
+            // ordinary (non-sticky) scan only; the VM attempt itself must
+            // decide the sticky result at the requested position.
+            { op: "local.get", index: STICKY },
+            { op: "i32.eqz" },
             { op: "local.get", index: LEADCH },
             { op: "i32.const", value: 0 },
             { op: "i32.ge_s" },
+            { op: "i32.and" },
             {
               op: "if",
               blockType: { kind: "empty" },

--- a/src/codegen/regex/parse.ts
+++ b/src/codegen/regex/parse.ts
@@ -300,7 +300,9 @@ class Parser {
 
   /** Lower a single code point atom in u/v mode. Case-insensitive atoms are
    *  enumerated through the host (spec Canonicalize — Kelvin sign and friends);
-   *  otherwise BMP → CHAR, astral → lead+trail concat. */
+   *  otherwise BMP → CHAR, except surrogate code units use CPCLASS so the VM's
+   *  code-point guard does not match the trail half of a valid pair; astral
+   *  scalars remain lead+trail sequences. */
   private uChar(cp: number): ReNode {
     if (this.iState) {
       return this.cpClass(enumerateClassRanges(codePointSource(cp), this.enumFlags()));
@@ -315,6 +317,9 @@ class Parser {
           { kind: "char", code: trail },
         ],
       };
+    }
+    if (cp >= 0xd800 && cp <= 0xdfff) {
+      return this.cpClass([[cp, cp]]);
     }
     return { kind: "char", code: cp };
   }

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -79,7 +79,7 @@ import {
 import { emitReceiverBrandCheck } from "./receiver-brand.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression } from "./shared.js";
-import { noJsHost, emitThrowTypeError } from "./js-errors.js"; // (#4439) pairs the poison with its guard
+import { buildThrowJsErrorInstrs, noJsHost, emitThrowTypeError } from "./js-errors.js"; // (#4439) pairs the poison with its guard
 import { compileStringLiteral } from "./string-ops.js";
 import { tryCompileCoercedStringMatch, tryCompileCoercedStringSearch } from "./string-search-value.js";
 import { isPlainToStringReplacement } from "./string-proto-replace.js";
@@ -93,6 +93,7 @@ import { emitBuiltinConstructorIdentity } from "./builtin-static-globals.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { addFuncType } from "./registry/types.js";
 import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "../ir/regexp-runtime-contract.js";
+import { integrityVarKey } from "./widened-var-key.js";
 import { emitTestCapsAcquire, emitTestCapsRelease } from "./regex-scratch-pool.js";
 import {
   ensureDynamicPatternTokenDecoder,
@@ -2915,6 +2916,34 @@ function standaloneRegExpLastIndexAsF64(
 }
 
 /**
+ * Guard an ordinary `lastIndex` Set against a statically recorded non-writable
+ * descriptor. `Object.defineProperty` records explicit `writable: false`
+ * entries in `ctx.nonWritableExternKeys`, the same compile-time companion
+ * consulted by ordinary property assignment. The exact Slice-A call sites all
+ * carry a static RegExp identifier, so this narrow proof is sufficient without
+ * inventing a second runtime descriptor table for closed RegExp carriers.
+ *
+ * The throw sequence is built after the call-site body has evaluated its RHS;
+ * this preserves the strict Set evaluation order while allowing the shared
+ * error builder to flush any late TypeError dependency it registers.
+ */
+function standaloneRegExpLastIndexSetGuardInstrs(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  regexpExpr?: ts.Expression,
+): Instr[] {
+  if (regexpExpr === undefined) return [];
+  const receiver = stripStaticWrapper(regexpExpr);
+  if (!ts.isIdentifier(receiver)) return [];
+  const key = `${integrityVarKey(ctx, receiver)}:lastIndex`;
+  if (!ctx.nonWritableExternKeys.has(key)) return [];
+  const throwInstrs = buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot assign to read only property 'lastIndex'", {
+    flush: fctx,
+  });
+  return throwInstrs;
+}
+
+/**
  * (#2175 S1) Brand-recovery prologue for a *dynamic* (externref) RegExp `this`.
  *
  * The reflective forms — `RegExp.prototype.test.call(re, s)`,
@@ -2981,11 +3010,14 @@ export function emitRegexSearchCall(
      * (#1913): start the scan at ToLength(lastIndex) (i32.trunc_sat maps
      * NaN→0 and the search loop rejects starts past the subject, matching
      * the lastIndex>length null result), then on return set lastIndex to
-     * the match end (or 0 on failure). Only passed when the flags are
-     * STATICALLY known to include g or y — non-g/y exec neither reads nor
-     * writes lastIndex.
+     * the match end (or 0 on failure). The separate `readLastIndex` switch
+     * models RegExpBuiltinExec's unconditional Get/ToLength step: non-g/y
+     * exec/test still reads and coerces lastIndex, but always starts at zero
+     * and never writes it back.
      */
     gyLastIndex?: boolean | "runtime";
+    /** Read/ToLength `lastIndex` even when the operation is non-g/non-y. */
+    readLastIndex?: boolean;
     /** Pre-evaluated native-string receiver supplied by guarded dispatch. */
     inputOverride?: () => ValType | null;
     /** (#4016) Pre-materialised `$NativeRegExp` — see `string-search-value.ts`. */
@@ -3049,6 +3081,23 @@ export function emitRegexSearchCall(
   });
   fctx.body.push({ op: "local.set", index: inputLocal });
 
+  // RegExpBuiltinExec performs Get(R, "lastIndex") + ToLength after the
+  // subject has been coerced, regardless of the g/y flags. Keep one execution-
+  // time f64 result so the g/y start path does not invoke a deferred raw value
+  // twice; non-g/y callers deliberately leave the value unused.
+  let lastIndexLocal: number | undefined;
+  if (options?.readLastIndex) {
+    lastIndexLocal = allocLocal(fctx, `__re_lastindex_read_${fctx.locals.length}`, { kind: "f64" });
+    fctx.body.push(...standaloneRegExpLastIndexAsF64(ctx, fctx, regexpLocal, structTypeIdx), {
+      op: "local.set",
+      index: lastIndexLocal,
+    });
+  }
+  const lastIndexInstrs = (): Instr[] =>
+    lastIndexLocal === undefined
+      ? standaloneRegExpLastIndexAsF64(ctx, fctx, regexpLocal, structTypeIdx)
+      : [{ op: "local.get", index: lastIndexLocal }];
+
   // caps = array.new_default(2 * nGroups + nScratch) — scratch slots back the
   // PROGRESS empty-loop guards (#1959); they ride along in the caps array.
   const capsLocal = allocLocal(fctx, `__re_caps_${fctx.locals.length}`, { kind: "ref", typeIdx: i32Arr });
@@ -3090,12 +3139,12 @@ export function emitRegexSearchCall(
     fctx.body.push({
       op: "if",
       blockType: { kind: "val", type: { kind: "i32" } },
-      then: [...standaloneRegExpLastIndexAsF64(ctx, fctx, regexpLocal, structTypeIdx), { op: "i32.trunc_sat_f64_s" }],
+      then: [...lastIndexInstrs(), { op: "i32.trunc_sat_f64_s" }],
       else: [{ op: "i32.const", value: 0 }],
     });
   } else if (options?.gyLastIndex) {
     fctx.body.push(
-      ...standaloneRegExpLastIndexAsF64(ctx, fctx, regexpLocal, structTypeIdx),
+      ...lastIndexInstrs(),
       // trunc_sat: NaN→0 (= ToLength(NaN)); huge values saturate and the search
       // loop's `start > slen` check yields the spec's no-match result. Negative
       // values clamp to 0 inside __regex_search, matching ToLength.
@@ -3113,6 +3162,7 @@ export function emitRegexSearchCall(
     const matchedTmp = allocLocal(fctx, `__re_matched_${fctx.locals.length}`, { kind: "i32" });
     fctx.body.push({ op: "local.set", index: matchedTmp });
     const updateLastIndex: Instr[] = [
+      ...standaloneRegExpLastIndexSetGuardInstrs(ctx, fctx, regexpExpr ?? undefined),
       { op: "local.get", index: regexpLocal },
       { op: "local.get", index: matchedTmp },
       {
@@ -3313,6 +3363,7 @@ export function tryCompileStandaloneRegExpTest(
     const testFlags0 = staticRegExpFlags(ctx, propAccess.expression);
     const emitted0 = emitRegexSearchCall(ctx, fctx, propAccess.expression, propAccess.expression, {
       gyLastIndex: testFlags0 === null ? "runtime" : flagsHaveGlobalOrSticky(testFlags0),
+      readLastIndex: true,
       inputOverride: () => undefinedSubjectOverride(ctx, fctx),
     });
     if (emitted0 === null) return null;
@@ -3341,6 +3392,7 @@ export function tryCompileStandaloneRegExpTest(
   const testFlags = staticRegExpFlags(ctx, propAccess.expression);
   const emitted = emitRegexSearchCall(ctx, fctx, propAccess.expression, expr.arguments[0]!, {
     gyLastIndex: testFlags === null ? "runtime" : flagsHaveGlobalOrSticky(testFlags),
+    readLastIndex: true,
   });
   if (emitted === null) return null;
   return { kind: "i32" };
@@ -3606,6 +3658,7 @@ export function emitRegexExecArrayCall(
   inputExpr: ts.Expression | null,
   options?: {
     gyLastIndex?: boolean | "runtime";
+    readLastIndex?: boolean;
     inputOverride?: () => ValType | null;
     regexpOverride?: { regexpLocal: number; structTypeIdx: number };
   },
@@ -3744,6 +3797,7 @@ export function tryCompileStandaloneRegExpExec(
     const flags0 = staticRegExpFlags(ctx, propAccess.expression);
     return emitRegexExecArrayCall(ctx, fctx, propAccess.expression, propAccess.expression, {
       gyLastIndex: flags0 === null ? "runtime" : flagsHaveGlobalOrSticky(flags0),
+      readLastIndex: true,
       inputOverride: () => undefinedSubjectOverride(ctx, fctx),
     });
   }
@@ -3763,9 +3817,11 @@ export function tryCompileStandaloneRegExpExec(
   const flags = staticRegExpFlags(ctx, propAccess.expression);
 
   // §22.2.7.2 — g/y exec starts at [[LastIndex]] and writes back the match
-  // end (or 0 on failure); non-g/y exec ignores lastIndex entirely (#1913).
+  // end (or 0 on failure). All exec calls have already performed the
+  // observable Get/ToLength step above; non-g/y exec simply ignores its value.
   return emitRegexExecArrayCall(ctx, fctx, propAccess.expression, expr.arguments[0]!, {
     gyLastIndex: flags === null ? "runtime" : flagsHaveGlobalOrSticky(flags),
+    readLastIndex: true,
   });
 }
 
@@ -4716,7 +4772,8 @@ export const STANDALONE_REGEXP_REFLECTION_PROPS: ReadonlySet<string> = new Set([
  *   from the bitfield (§22.2.6.4).
  * - flag booleans (`.global`, `.ignoreCase`, …) → `(flags & bit) != 0`
  *   (§22.2.6.5–.12 RegExpHasFlag).
- * - `.lastIndex` → struct field 5 (f64).
+ * - `.lastIndex` → the deferred raw value when present, otherwise a boxed
+ *   numeric fast-slot value (externref at the ordinary property boundary).
  *
  * Returns `undefined` when the receiver/property is not a standalone RegExp
  * reflection read (caller falls through), `null` after reporting a narrowed
@@ -4926,8 +4983,30 @@ export function emitRegExpReflectionFieldRead(
     return nativeStringType(ctx);
   }
   if (propName === "lastIndex") {
-    fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_LASTINDEX });
-    return { kind: "f64" };
+    // A deferred object/string assignment must retain identity on an ordinary
+    // read (`r.lastIndex === counter`). Box only the numeric fast-slot value
+    // when no raw assignment is pending; callers already consume this result
+    // through the externref property boundary.
+    fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_LASTINDEX_RAW_PRESENT });
+    const savedBody = fctx.body;
+    const boxedNumber: Instr[] = [];
+    fctx.body = boxedNumber;
+    fctx.body.push(
+      { op: "local.get", index: regexpLocal },
+      { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_LASTINDEX },
+    );
+    coerceType(ctx, fctx, { kind: "f64" }, { kind: "externref" });
+    fctx.body = savedBody;
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [
+        { op: "local.get", index: regexpLocal },
+        { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_LASTINDEX_RAW },
+      ],
+      else: boxedNumber,
+    });
+    return { kind: "externref" };
   }
   // Flag boolean getter: (flags & bit) != 0.
   fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_FLAGS });
@@ -4991,6 +5070,15 @@ export function emitRegExpTestFromLocals(
   fctx.body.push({ op: "i32.ne" });
   fctx.body.push({ op: "local.set", index: gyLocal });
 
+  // RegExpBuiltinExec reads and ToLength-coerces `lastIndex` even for a
+  // non-global/non-sticky receiver. The recovered closure path has no static
+  // flag spelling, so retain one execution-time value for both branches.
+  const lastIndexLocal = allocLocal(fctx, `__re_tlastindex_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push(...standaloneRegExpLastIndexAsF64(ctx, fctx, regexpLocal, structTypeIdx), {
+    op: "local.set",
+    index: lastIndexLocal,
+  });
+
   // __regex_search(prog, classTable, nSlots, inData, inOff, inLen, start=0, sticky, caps)
   fctx.body.push({ op: "local.get", index: regexpLocal });
   fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_PROG });
@@ -5007,7 +5095,7 @@ export function emitRegExpTestFromLocals(
   fctx.body.push({
     op: "if",
     blockType: { kind: "val", type: { kind: "i32" } },
-    then: [...standaloneRegExpLastIndexAsF64(ctx, fctx, regexpLocal, structTypeIdx), { op: "i32.trunc_sat_f64_s" }],
+    then: [{ op: "local.get", index: lastIndexLocal }, { op: "i32.trunc_sat_f64_s" }],
     else: [{ op: "i32.const", value: 0 }],
   });
   fctx.body.push({ op: "local.get", index: stickyLocal });
@@ -5023,6 +5111,7 @@ export function emitRegExpTestFromLocals(
     op: "if",
     blockType: { kind: "empty" },
     then: [
+      ...standaloneRegExpLastIndexSetGuardInstrs(ctx, fctx),
       { op: "local.get", index: regexpLocal },
       { op: "local.get", index: matchedLocal },
       {
@@ -5320,8 +5409,7 @@ function emitRegExpProtoMemberBody(
     // externref so the closure-call ABI and the descriptor `.get` both see one
     // type: native-string refs (`.flags`/`.source`) box via `extern.convert_any`,
     // i32 flag booleans via `__box_boolean` (a JS boolean, not the number 0/1),
-    // and the defensive f64 (lastIndex is a method-kind member, never a getter)
-    // via `__box_number`.
+    // and any numeric field result via `__box_number`.
     const fieldType = emitRegExpReflectionFieldRead(ctx, fctx, member, regexpLocal, structTypeIdx);
     if (fieldType.kind === "ref" || fieldType.kind === "ref_null") {
       fctx.body.push({ op: "extern.convert_any" });
@@ -5369,6 +5457,7 @@ function emitRegExpProtoMemberBody(
     const subjLocal = flattenExternrefArgToString(ctx, fctx, 2);
     const emitted = emitRegexExecArrayCall(ctx, fctx, null, null, {
       gyLastIndex: "runtime",
+      readLastIndex: true,
       inputOverride: () => {
         fctx.body.push({ op: "local.get", index: subjLocal });
         return nativeStringType(ctx);
@@ -5605,6 +5694,10 @@ export function tryCompileStandaloneRegExpLastIndexWrite(
   // observable `valueOf` during assignment, before a surrounding try/catch.
   const valType = compileExpression(ctx, fctx, value);
   if (!valType) return null;
+  // OrdinarySet evaluates the RHS first, then rejects a non-writable
+  // descriptor before touching the carrier storage. Keep this guard outside
+  // the numeric/raw branches so both assignment representations agree.
+  fctx.body.push(...standaloneRegExpLastIndexSetGuardInstrs(ctx, fctx, target.expression));
   if (valType.kind === "i32" || valType.kind === "f64") {
     if (valType.kind === "i32") {
       fctx.body.push({ op: "f64.convert_i32_s" });
@@ -5625,7 +5718,28 @@ export function tryCompileStandaloneRegExpLastIndexWrite(
   // Preserve object/string/BigInt/null/undefined values opaquely. `externref`
   // is the common boundary representation; this conversion does not perform
   // ToPrimitive and therefore keeps user code deferred until exec.
-  if (valType.kind !== "externref") {
+  //
+  // A typed object carrying valueOf/toString is normally reified by
+  // `coerceType(ref → externref)` so a later dynamic ToPrimitive can inspect
+  // it. That is the wrong representation for this raw property slot: the
+  // assignment must retain the exact RHS object (`r.lastIndex === value`),
+  // while ToLength is deliberately deferred until the next g/y operation.
+  // Convert the GC reference directly at this identity-preserving boundary.
+  // Keep the native-string undefined sentinel arm in `coerceType`, where the
+  // nullable `$AnyString` → externref mapping is canonicalized to `undefined`.
+  const isNullableNativeString =
+    ctx.nativeStrings && valType.kind === "ref_null" && ctx.anyStrTypeIdx >= 0 && valType.typeIdx === ctx.anyStrTypeIdx;
+  if (valType.kind === "ref" || valType.kind === "ref_null") {
+    // The same nominal object can be observed later by an untyped assertion
+    // helper.  Remember this concrete shape before it crosses the raw slot so
+    // that the generic ref→externref coercion keeps the original GC reference
+    // instead of making a value-semantics `$Object` copy.
+    (fctx.regexpLastIndexIdentityStructTypes ??= new Set()).add(valType.typeIdx);
+  }
+  if (valType.kind === "ref" || valType.kind === "ref_null" || valType.kind === "anyref" || valType.kind === "eqref") {
+    if (isNullableNativeString) coerceType(ctx, fctx, valType, { kind: "externref" });
+    else fctx.body.push({ op: "extern.convert_any" });
+  } else if (valType.kind !== "externref" && valType.kind !== "ref_extern") {
     coerceType(ctx, fctx, valType, { kind: "externref" });
   }
   const rawTmp = allocLocal(fctx, `__re_lastindex_raw_${fctx.locals.length}`, { kind: "externref" });

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -3025,6 +3025,7 @@ export function coerceType(
       (ctx.standalone === true || ctx.wasi === true) &&
       name !== undefined &&
       structMustReifyAtExternrefBoundary(ctx, name) &&
+      !fctx.regexpLastIndexIdentityStructTypes?.has(typeIdx) &&
       materializeStructAsObject(ctx, fctx, typeIdx)
     ) {
       return;

--- a/tests/issue-5198-es2015-regexp-r2.test.ts
+++ b/tests/issue-5198-es2015-regexp-r2.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5198 Slice A — observable RegExpBuiltinExec lastIndex behavior.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+
+type Lane = "host" | "standalone";
+
+const TEST262_ROOT = fileURLToPath(new URL("../test262/", import.meta.url));
+
+const EXACT_ROWS = [
+  "built-ins/RegExp/prototype/exec/failure-lastindex-access.js",
+  "built-ins/RegExp/prototype/exec/success-lastindex-access.js",
+  "built-ins/RegExp/prototype/exec/u-lastindex-adv.js",
+  "built-ins/RegExp/prototype/exec/y-fail-lastindex-no-write.js",
+  "built-ins/RegExp/prototype/exec/y-fail-lastindex.js",
+  "built-ins/RegExp/prototype/exec/y-fail-return.js",
+  "built-ins/RegExp/prototype/test/y-fail-lastindex-no-write.js",
+  "built-ins/RegExp/prototype/test/y-fail-lastindex.js",
+  "built-ins/RegExp/prototype/test/y-fail-return.js",
+] as const;
+
+const TEST262_AVAILABLE =
+  process.env.JS2_TEST262_AVAILABLE !== "0" &&
+  existsSync(join(TEST262_ROOT, "harness", "assert.js")) &&
+  EXACT_ROWS.every((relativePath) => existsSync(join(TEST262_ROOT, "test", relativePath)));
+const itWithTest262 = TEST262_AVAILABLE ? it : it.skip;
+
+async function runExactRow(relativePath: (typeof EXACT_ROWS)[number], lane: Lane) {
+  try {
+    return await runTest262File(
+      join(TEST262_ROOT, "test", relativePath),
+      "issue-5198-slice-a",
+      180_000,
+      lane === "standalone" ? lane : undefined,
+    );
+  } finally {
+    restoreHostBuiltins();
+  }
+}
+
+async function runStandaloneIdentityScopeControl(source: string): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-5198-lastindex-identity-scope.ts",
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports).toHaveLength(0);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#5198 RegExpBuiltinExec lastIndex Slice A", () => {
+  for (const lane of ["host", "standalone"] as const) {
+    for (const relativePath of EXACT_ROWS) {
+      itWithTest262(`${lane}: ${relativePath}`, { timeout: 200_000 }, async () => {
+        const result = await runExactRow(relativePath, lane);
+        expect(`${result.status}: ${result.error ?? ""}`, `${lane} ${relativePath}`).toBe("pass: ");
+      });
+    }
+  }
+
+  it("keeps same-shape unrelated objects on normal ToPrimitive after raw lastIndex", async () => {
+    expect(
+      await runStandaloneIdentityScopeControl(`
+        function addOne(value: any): number { return value + 1; }
+        type Value = { valueOf: () => number };
+        function makeValue(number: number): Value {
+          return { valueOf: function () { return number; } };
+        }
+        export function test(): number {
+          const assigned = makeValue(4);
+          const unrelated = makeValue(7);
+          const regexp = /a/;
+          // @ts-expect-error RegExp.lastIndex stores this object opaquely.
+          regexp.lastIndex = assigned;
+          return addOne(unrelated);
+        }
+      `),
+    ).toBe(8);
+  });
+
+  it("keeps the no-raw-slot baseline for the same-shape object (A/B)", async () => {
+    expect(
+      await runStandaloneIdentityScopeControl(`
+        function addOne(value: any): number { return value + 1; }
+        type Value = { valueOf: () => number };
+        function makeValue(number: number): Value {
+          return { valueOf: function () { return number; } };
+        }
+        export function test(): number {
+          const unrelated = makeValue(7);
+          const regexp = /a/;
+          regexp.lastIndex = 0;
+          return addOne(unrelated);
+        }
+      `),
+    ).toBe(8);
+  });
+});


### PR DESCRIPTION
## Description

Problem: Standalone `RegExpBuiltinExec` skipped the observable `lastIndex` read for non-global/non-sticky expressions, lost raw object identity, bypassed non-writable writeback, allowed sticky scans to advance, and matched lone `/u` surrogate atoms inside valid pairs.

Behavior: Read and coerce `lastIndex` exactly once at execution time, preserve deferred raw values and ordinary descriptor failures, keep sticky matching anchored, and route lone Unicode surrogate atoms through the existing code-point boundary guard.

Tests: The focused current-main matrix passes 20/20: all nine owned Test262 rows pass in host and standalone lanes, plus two same-nominal-type identity/reification A/B controls. The exact 165-row standalone sweep improved from 3 pass / 158 fail / 4 compile_error to 24 pass / 137 fail / 4 compile_error with 21 fail-to-pass changes and zero regressions; the host sweep remained 126 pass / 39 fail with zero status drift. An additional 82/82 coercion and identity control matrix passed.

Quality: TS5/TS7 typecheck, lint, Prettier, LOC/function budgets, oracle/coercion ratchets, issue integrity, 18/18 numeric-local parity, normal commit hooks, and the full pre-push hook passed on current upstream main `c882d1b110`.

Tracking: `plan/issues/5198-es2015-standalone-regexp-r2.md` contains the implementation plan, exact validation evidence, remaining RegExp slices, and handoff. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->