### PR TITLE
feat(ir): reconcile callable alias components graph-first

### DIFF
--- a/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
+++ b/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
@@ -1591,6 +1591,373 @@ with the parallel Claude IR session. Any subsequent push invalidates approval
 and requires a fresh exact-SHA Sol review. A mergeable, all-green,
 exact-SHA-approved PR is ready; a real blocker keeps it draft.
 
+## M1A.4 implementation lock — anonymous-default alias matrix (2026-08-30)
+
+This Sol-authored continuation is grounded on the independently approved and
+queued M1A.3 head `b5ac306abe11bec01195416dec14e14cdbfbd1fa`
+(PR #5275) and protected `origin/main`
+`c243892c7f3a757bdecf6215626b08586ce72c58`. Develop it only on the separate
+stacked branch `codex/3525-m1a4-callable-alias-matrix`; never push or rewrite
+the queued parent. After #5275 lands, rebase or merge refreshed main into this
+branch under the normal signed workflow and repeat the exact-file collision,
+focused, ratchet, hook, and Sol-review evidence before publication.
+
+The parallel Claude lane owns the dirty #3521/#4617 checkout. Open PR #5218
+owns `src/codegen/index.ts`, `src/ir/from-ast.ts`, `src/ir/select.ts`, and its
+vector/type-planning surface; #5238/#5269 own #3523 files. This checkpoint may
+not edit those paths and introduces no second issue or alias resolver.
+
+### Current structural authority and exact missing root
+
+`buildIrProgramCallableBindingGraph(...)` already freezes source,
+`import-alias`, and `export-alias` records and resolves the complete checked
+fixture in `ALIAS_FILES`: renamed imports, an anonymous default export/default
+import, namespace property calls, a chained re-export, `export *`, and a local
+same-named shadow. The graph unit test proves exact target `IrUnitId`s and
+order independence, but the production callable route is tested only with
+named declarations.
+
+The remaining exclusion is not the alias graph. It is the legacy function-name
+projection before aggregate selection:
+
+- `planIrCompilationByIdentity(...)` records every unnamed declaration as
+  `unnamed`, even when the exact terminal is an anonymous
+  `export default function` whose inventory label is the direct compiler's
+  canonical `"default"`;
+- `planIrOverlayByIdentity(...)` and
+  `buildIrExactFunctionClaimIndex(...)` require
+  `declaration.name?.text === legacyName`;
+- `ownerIsEligible(...)`, callable preflight/currentness, and
+  `MultiPreparedProgramOwner.stageCallableComponents(...)` repeat the same
+  named-only predicate; and
+- preflight currently builds components from already-projected source plans,
+  so the missing default root disappears before the immutable attempted census
+  can prove its whole alias-connected population.
+
+The direct declaration compiler already registers and compiles an anonymous
+default function under `"default"`, and its body-routing seam also carries the
+exact declaration `IrUnitId`. Therefore M1A.4 is an authority transfer for one
+existing body, not new syntax support and not permission to treat arbitrary
+anonymous functions as top-level callables.
+
+### One exact declaration identity
+
+Add one frontend-neutral helper in
+`src/ir/top-level-function-identity.ts` that returns the compatibility name for
+an exact top-level body-bearing `FunctionDeclaration`:
+
+1. a named declaration returns its identifier text;
+2. an unnamed declaration returns `"default"` only when it has both `export`
+   and `default` modifiers and its parent is the exact `SourceFile`; and
+3. every other anonymous, ambient, nested, bodyless, copied, or malformed node
+   returns `undefined`.
+
+Use that helper everywhere this checkpoint crosses the body-skip compatibility
+projection: `src/ir/select-identity.ts`,
+`src/codegen/ir-overlay-identity.ts`,
+`src/codegen/ir-overlay-safety.ts`,
+`src/codegen/multi-prepared-callable-orchestration.ts`, and the callable
+component validation in `src/codegen/multi-prepared-program.ts`. Do not infer a
+default root from display text, export table contents, checker symbol names, or
+array position. A named declaration's behavior remains byte-for-byte the same.
+
+Anonymous-default admission is callable-component scoped. Extend the identity
+selector with one exact optional predicate supplied by
+`programCallableSelectionOptions(...)`; it may admit the default unit only when
+`hasMultiIrProgramCallableBoundary(...)` authenticates that unit in the frozen
+attempted census and the declaration helper returns `"default"`. With no
+census, on single-source/host/fast/WASI/disabled/dedicated lanes, or for an
+unanchored anonymous default, the existing `unnamed` outcome remains unchanged.
+Do not enable anonymous defaults globally in the ordinary per-source overlay.
+
+### Graph-first attempted census and fresh callable plans
+
+Break the current projection cycle without introducing a second graph:
+
+1. Derive preliminary components from the frozen callable graph's exact source
+   records and uses plus the identity inventory, not from
+   `functionClaimsByUnitId`. Source-local and cross-source edges both come from
+   the same graph. Authenticate source/declaration/unit/terminal/reverse joins,
+   require at least one cross-source edge and two sources, retain unanchored
+   units outside the component, and preserve terminal-inventory ordering.
+2. Publish the complete immutable attempted/component census before planning
+   any callable source. Existing dedicated-route planning still runs first;
+   if it owns any unit, retain M1A.3's global no-composition return and publish
+   no callable census.
+3. Re-plan only the component's sources after census publication through a
+   callable-specific cache refresh. Earlier exploratory plans used by the
+   dedicated-route probe are not authority and may not be reused. Sources
+   outside the attempted census keep their existing cached plan. No change to
+   `src/codegen/index.ts` is needed: its existing spread of
+   `programCallableSelectionOptions(...)` carries the new exact predicate.
+4. Require every graph member to appear in the refreshed plan's exact claim and
+   safe selection before aggregate preparation. Any missing default, named
+   sibling, signature, source, declaration, or call plan declines the whole
+   component while the complete attempted census remains visible and the later
+   ordinary overlay restores direct ownership for every member.
+
+The compatibility name `"default"` is permitted only after the exact UnitId
+and declaration checks above. Body skipping, receipts, currentness snapshots,
+Program-ABI roots, outcomes, and route audit continue to join by UnitId. A bare
+name set is the final direct-compiler projection, never aggregate ownership.
+
+### Alias publication and positive proof
+
+Promote the existing `ALIAS_FILES` graph fixture unchanged to the production
+standalone route. Its exact Prepared component is five units across three
+sources:
+
+- `a.ts`: `same` and the anonymous default function;
+- `b.ts`: its distinct `same` plus `invoke`; and
+- `entry.ts`: `entry`.
+
+The unused `a.ts` function `only` and every alias rooted at it remain outside
+the attempted/prepared terminal set. For the five selected roots, derive the
+expected alias denominator directly from the frozen graph: every non-source
+record whose `targetUnitId` is selected, in target-first source -> export ->
+import order. The opaque descriptor and committed Program ABI must contain
+exactly those binding IDs, alias kinds, sources, structural keys, targets, and
+canonical roots; no alias owns a locator or slot, and every alias resolves the
+same final function object/index as its canonical source root.
+
+With the direct-body poison covering `default`, `same`, `invoke`, and `entry`,
+the candidate must still compile, publish five terminal-IR outcomes in one
+component, leave no direct route-audit entry for those units, exclude `only`,
+and execute `entry(5) === 132`, equal to the cutover-disabled direct control.
+Reversing source insertion order must preserve graph records/uses, component
+ID, reservation order, alias IDs/order, runtime value, and canonical evidence.
+Binary equality remains observational rather than an acceptance requirement.
+
+### Fail-closed matrix and preserved boundaries
+
+Extend focused mutations so each of the following produces zero live alias,
+body, reservation, committed skip, telemetry, or terminal-outcome prefix:
+
+- attempted census drops/repeats the anonymous default or assigns it to a
+  foreign component;
+- the default declaration loses `export`, loses `default`, gains a name after
+  preflight, is replaced/copied, or changes any nested body node before final
+  publication;
+- a selected alias is missing, duplicated, points to `only`, crosses source or
+  kind, changes structural key/signature/canonical root, or owns a locator;
+- refreshed planning omits the default claim or returns a stale pre-census
+  plan; and
+- the direct body reports a skipped `"default"` name with the wrong/missing
+  UnitId.
+
+Reuse the existing census, declaration-currentness, descriptor, aggregate
+scope, and body-routing seams where they can prove these mutations
+non-vacuously. Add only a narrow named seam when no existing mutation can reach
+the production check; unknown seam values fail closed. Do not weaken the
+existing mutable/value-escaped/optional/dynamic/overloaded declines.
+
+Named-only M1A.3, two disjoint callable components, helper-bearing controls,
+and the dedicated-route no-composition control must remain exact. Host, fast,
+WASI, module-init-bearing, single-source, class/closure/function-value,
+async/generator, mutable, and unanchored/default-only programs publish no new
+attempted census and retain their current route/outcome counts. Do not compose
+with an existing Prepared owner, widen arbitrary function expressions, delete
+legacy alias copying, or change public export semantics in this slice.
+
+### Authorized surface and validation
+
+The authorized implementation surface is:
+
+- new `src/ir/top-level-function-identity.ts`;
+- `src/ir/select-identity.ts`;
+- `src/codegen/ir-overlay-identity.ts`;
+- `src/codegen/ir-overlay-safety.ts`;
+- `src/codegen/multi-prepared-callable-orchestration.ts`;
+- the callable-component validation only in
+  `src/codegen/multi-prepared-program.ts`; and
+- `tests/issue-3525-multi-prepared-callable-bindings.test.ts`.
+
+The plan file remains root-owned. Any need to edit `src/codegen/index.ts`,
+`src/ir/from-ast.ts`, `src/ir/select.ts`, Program-ABI transaction modules, or a
+new production path is a stop-and-amend condition for Sol, not implied scope.
+
+Run the focused #3525 callable-binding and prepared Program-ABI aggregate
+suites, M1A.3's route controls, #3214 imported HOF, #2138 multi-module overlay,
+and multi-file equivalence. Run TypeScript 7 and 5, Prettier/Biome,
+`check:ir-fallbacks`, issue integrity, IR layering/dialect/readiness, and the
+ordinary oracle/dead-export/coercion ratchets. Immediately before every commit,
+under a finite non-negative one-minute load strictly below
+`logical cores - 2`, run both LOC and function regrowth ratchets. Let complete
+precommit and prepush hooks run without bypass; no baseline, LOC, function,
+binary-size, or hook exception is authorized.
+
+Luna Max may implement only this surface. Before the stacked PR leaves draft,
+a separate independent Sol must review the exact pushed SHA and return
+**APPROVE** for the graph-first denominator, anonymous-default scoping, exact
+alias closure, zero-prefix mutation matrix, parent ancestry, and non-overlap
+with the parallel Claude lane. Any later push invalidates approval. A mergeable,
+all-green, exact-SHA-approved PR is ready; a real dependency or failed gate
+keeps it draft.
+
+### M1A.4a landing correction — named-default alias census first
+
+Static implementation review found two prerequisites that the M1A.4 lock had
+incorrectly treated as already available. The structural propagation and
+selector paths still require a name-bearing declaration, while the aggregate
+lowerer dispatches a namespace property call before consulting its certified
+imported-call plan. A temporary rename of the checker-owned AST, a detached
+hybrid declaration whose children retain another parent, or a temporary
+rewrite of a property-access call is not an authorized identity adapter.
+Deleting a cached source plan and rebuilding it after census publication is
+also not safe: exploratory planning may already have appended public
+post-claim diagnostics, so cache invalidation does not roll back every
+observable effect.
+
+The pure propagation seam belongs to `src/ir/propagate.ts`, which the parallel
+#3521/Claude lane has reserved for its linked-parser pre-claim repair. The pure
+namespace-call seam belongs to `src/ir/from-ast.ts`, currently owned by open PR
+#5218. Do not edit either file, coordinate around its owner with a second
+implementation, or land any live-AST projection. Full anonymous-default and
+namespace-call M1A.4 remains required after those owners land and Sol refreshes
+the plan against their exact main ancestors.
+
+The immediately dispatchable checkpoint is therefore M1A.4a: transfer the
+attempted callable denominator from source-plan projection to the frozen
+binding graph for a completely named alias matrix. Use a new focused fixture,
+leaving `ALIAS_FILES` unchanged as the graph-only anonymous-default/namespace
+oracle:
+
+- `a.ts` exports `same`, unanchored `only`, a **named**
+  `export default function defaultFn`, and `same as renamed`;
+- `b.ts` default-imports `defaultFn`, imports `same as localSame` and
+  `renamed as reexported`, re-exports `renamed as chained`, performs
+  `export *`, declares its distinct `same`, and declares `invoke` whose body is
+  `localSame(value) + defaultFn(value) + reexported(value)`;
+- `entry.ts` imports `invoke as call`, `chained`, and `same as entrySame`, then
+  returns `call(value) + chained(value) + entrySame(value)`.
+
+For input `5`, both direct and candidate builds return exactly `127`. The exact
+Prepared component remains five units across three sources: `a.same`,
+`a.defaultFn`, `b.same`, `b.invoke`, and `entry.entry`. `a.only` remains outside
+the attempted, reserved, skipped, and outcome populations. Reverse source
+insertion order must preserve the graph records/uses, component ID, terminal
+order, alias descriptor order, route audit, and runtime value.
+
+Derive preliminary connected components only from the frozen graph's exact
+source records and call uses, authenticated against source/declaration/unit/
+terminal/reverse joins. Use the same graph for source-local and cross-source
+edges, require at least one cross-source edge and two sources, discard groups
+without an exact cross-source anchor, exclude unanchored units, and sort the
+surviving group by terminal-inventory order. Dedicated-route planning retains
+M1A.3 precedence: any existing Prepared route publishes no callable census and
+cannot compose with this checkpoint.
+
+Publish the immutable attempted/component census before accepting any callable
+candidate. Because every M1A.4a declaration is named, reuse the existing
+name-invariant cached overlay plans; do not delete or rebuild a source plan and
+do not add a post-census propagation/selector exception. Reconcile every graph
+member against its exact cached claim, safe selection, declaration, terminal,
+source, and call plan. A missing or unsafe member declines the whole original
+component; it never regroups the surviving subset or shrinks the attempted
+denominator.
+
+For the selected five roots, freeze the exact non-source alias records already
+represented by the graph, in target-first source -> export -> import order.
+Prove binding ID, kind, source, structural key, target UnitId, canonical root,
+and final function identity/index equality. No alias owns a locator or slot.
+This checkpoint covers the named default import, renamed import, chained
+re-export, `export *`, and same-name shadow. It deliberately contains no
+namespace property invocation; namespace records/uses remain asserted in the
+unchanged graph-only `ALIAS_FILES` tests until the pure lowerer seam lands.
+
+The direct-body poison names `defaultFn`, `same`, `invoke`, and `entry`. The
+candidate must publish one five-terminal component, five terminal IR outcomes,
+zero direct route-audit entries for those units, and no `only` evidence.
+Mutations must fail with zero live alias, body, reservation, committed-skip,
+telemetry, or terminal-outcome prefix when the graph-first census drops,
+duplicates, or foreign-assigns a selected unit; includes `only`; loses a
+source/cross-source edge; or when a selected alias is missing, duplicated,
+retargeted, changes kind/source/structural key/canonical root, or owns a
+locator. Preserve the named-only M1A.3, disjoint-component, helper-bearing,
+dedicated-route, host/fast/WASI/disabled/single-source, and unanchored controls.
+
+M1A.4a implementation ownership is reduced to:
+
+- this issue record;
+- `src/codegen/multi-prepared-callable-orchestration.ts`; and
+- `tests/issue-3525-multi-prepared-callable-bindings.test.ts`.
+
+Remove every current exploratory change from
+`src/ir/top-level-function-identity.ts`, `src/ir/select-identity.ts`,
+`src/codegen/ir-overlay-identity.ts`, `src/codegen/ir-overlay-safety.ts`, and
+the callable validator in `src/codegen/multi-prepared-program.ts`. The new
+identity helper must not exist in the M1A.4a diff. No source-plan cache refresh,
+live/detached AST projection, selector widening, propagation widening, or
+namespace-call rewrite is part of this checkpoint.
+
+Run the focused callable-binding and prepared Program-ABI aggregate suites,
+M1A.3 route controls, #3214 imported HOF, #2138 multi-module overlay, and
+multi-file equivalence. Run TypeScript 7 and 5, Prettier/Biome,
+`check:ir-fallbacks`, issue integrity, IR layering/dialect/readiness, and the
+ordinary oracle/dead-export/coercion ratchets. Run LOC and function regrowth
+ratchets immediately before every commit under the strict finite,
+non-negative, one-minute load gate below `logical cores - 2`; keep every
+precommit and prepush hook enabled. The stacked PR remains draft until an
+independent Sol approves its exact pushed SHA; any later push invalidates that
+approval.
+
+#### M1A.4a selector-compatible default-alias fixture amendment
+
+The first focused run established that the current selector rejects the
+modifier form `export default function defaultFn` as `non-export-modifier`
+before the graph-first callable census can consume its cached claim. Do not
+widen the selector for this checkpoint. Express the same named default binding
+through the already-supported declaration-plus-alias form in `a.ts`:
+
+```ts
+function defaultFn(value: number): number { return value + 2; }
+export { defaultFn as default };
+```
+
+Keep every other fixture edge and oracle unchanged. The default import in
+`b.ts` must still resolve through an exact non-source export/import alias chain
+to the `a.defaultFn` source record, and the five-unit component, runtime value
+`127`, alias order, reverse-source stability, zero-prefix mutations, and
+exclusion of `a.only` remain mandatory. This syntax adjustment is not
+permission for selector/propagation changes, AST projection, cache rebuild, or
+additional production-file ownership.
+
+#### M1A.4a Sol review correction — two-way call evidence and mutation boundary
+
+The first independent Sol review found two real completeness gaps. A source
+record may enter the graph-first member set only while its exact declaration
+still has a body; reassert that fact during preflight and final currentness so a
+bodyless/removed body cannot contaminate the attempted denominator. Reconcile
+call evidence in both directions before preparation: every selected graph-local
+use must appear in its owner's exact cached `localCallees`, and every selected
+cross-source use must have an `importedCalls` row at the identical call node
+with the same owner and target unit and the same graph binding/canonical join.
+The existing plan-to-graph scan remains necessary and is not a substitute.
+
+Add non-vacuous zero-prefix mutations for removing a staged body, hiding one
+selected local call plan, hiding one selected imported call plan, and adding
+the exact unanchored `a.only` unit to the public attempted projection. Preserve
+the existing drop, foreign, source-local-neighbor under-coverage, declaration
+subtree, publication, and stale-scope mutations. Reverse-source validation must
+compare the exact ordered reservation/unit/component projections, not Sets.
+For each published alias, prove the final index and allocator object equal the
+canonical root and that its locator lookup aliases the root rather than owning
+an independent locator.
+
+The broader raw graph/alias-corruption list in the preceding lock is corrected
+for this two-file landing surface. `IrProgramCallableBindingGraph` records and
+uses are already frozen by the checker-owned builder, while alias structural
+keys, locator sharing, and opaque descriptor lifecycle are constructed and
+validated inside `program-abi-module-callable-alias-planning.ts`. Injecting
+missing/duplicate/retarget/kind/source/key/canonical-root/locator corruption
+non-vacuously would require editing that Program-ABI owner (or the checker graph
+builder), which is not authorized here and is being exercised by the inherited
+`issue-3525-prepared-program-abi-aggregate` and Program-ABI alias invariant
+tests. Do not add a vacuous orchestration switch that rejects every replacement
+object by identity. Carry those low-level mutation additions to the next
+checkpoint that owns the alias planner. M1A.4a must instead keep those suites as
+controls and land only the body/call-plan/public-census mutations above.
+
 ## M2 implementation lock — single-contributor multi-source module init (2026-08-27)
 
 The first bounded multi-source module-init owner is a single-contributor lane.

--- a/src/codegen/multi-prepared-callable-orchestration.ts
+++ b/src/codegen/multi-prepared-callable-orchestration.ts
@@ -51,6 +51,20 @@ interface CallableAttemptCensus {
   readonly componentIndexByUnitId: ReadonlyMap<IrUnitId, number>;
 }
 
+/**
+ * The graph-first census deliberately carries no source overlay plan. Plans
+ * are cached before the census is published and are never used to define its
+ * denominator; callable candidates are reconciled against those exact plans
+ * only after the graph population has been frozen.
+ */
+interface CallablePreflightMember {
+  readonly sourceFile: ts.SourceFile;
+  readonly sourceId: IrSourceId;
+  readonly unitId: IrUnitId;
+  readonly legacyName: string;
+  readonly declaration: ts.FunctionDeclaration;
+}
+
 type NestedCallableDeclarationMutation = "nested-return-expression" | "nested-binary-right";
 type CallableDeclarationBodyMutation = "1" | NestedCallableDeclarationMutation | "nested-last-return-expression";
 
@@ -391,59 +405,185 @@ function ownerIsEligible(
 function preflightMultiPreparedCallableComponents(
   input: MultiPreparedCallableOrchestrationInput,
   graph: IrProgramCallableBindingGraph,
-  plans: ReadonlyMap<ts.SourceFile, IrOverlayPlan>,
-): readonly (readonly MultiPreparedCallableCandidate[])[] {
-  const members = new Map<IrUnitId, MultiPreparedCallableCandidate>();
-  for (const sourceFile of input.multiAst.sourceFiles) {
-    if (!ts.isExternalModule(sourceFile)) continue;
-    const sourceId = input.identityContext.sourceIdBySourceFile.get(sourceFile);
-    const plan = plans.get(sourceFile);
-    if (!sourceId || !plan) {
+): readonly (readonly CallablePreflightMember[])[] {
+  const activeSourceFiles = new Set(input.multiAst.sourceFiles);
+  const records = new Map<IrBindingId, ProgramCallableRecord>();
+  for (const record of graph.records) {
+    if (records.has(record.bindingId)) {
       throw new IrInvariantError(
         "selection-preparation-mismatch",
         "resolve",
-        `callable preflight lost source planning identity for ${sourceFile.fileName}`,
+        `callable preflight found duplicate graph binding ${record.bindingId}`,
       );
     }
-    for (const [unitId, claim] of plan.functionClaimsByUnitId) {
-      const terminal = input.identityContext.terminalByUnitId.get(unitId);
-      if (
-        terminal?.sourceId !== sourceId ||
-        terminal.kind !== "top-level-function" ||
-        terminal.observedKind !== "function" ||
-        terminal.terminalOwnerId !== unitId ||
-        input.identityContext.unitByUnitId.get(unitId) !== terminal ||
-        input.identityContext.declarationByUnitId.get(unitId) !== claim.declaration ||
-        input.identityContext.unitIdByDeclaration.get(claim.declaration) !== unitId ||
-        claim.declaration.parent !== sourceFile ||
-        claim.declaration.name?.text !== claim.legacyName ||
-        !claim.declaration.body
-      ) {
-        continue;
-      }
-      if (members.has(unitId)) {
-        throw new IrInvariantError(
-          "selection-preparation-mismatch",
-          "resolve",
-          `callable preflight found duplicate exact unit ${unitId}`,
-        );
-      }
-      members.set(
-        unitId,
+    records.set(record.bindingId, record);
+  }
+
+  const canonicalSourceRecord = (record: ProgramCallableRecord): ProgramCallableRecord | undefined => {
+    const seen = new Set<IrBindingId>();
+    let current: ProgramCallableRecord | undefined = record;
+    for (let depth = 0; current && depth < records.size + 1; depth++) {
+      if (seen.has(current.bindingId)) return undefined;
+      seen.add(current.bindingId);
+      if (current.kind === "source") return current;
+      current = records.get(current.targetBindingId);
+    }
+    return undefined;
+  };
+
+  const sourceMembersByUnitId = new Map<IrUnitId, CallablePreflightMember>();
+  const sourceRecordByUnitId = new Map<IrUnitId, ProgramCallableRecord>();
+  for (const record of graph.records) {
+    const sourceFile = input.identityContext.sourceFileBySourceId.get(record.sourceId);
+    if (!sourceFile || !activeSourceFiles.has(sourceFile)) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable preflight graph record ${record.bindingId} is outside the exact source set`,
+      );
+    }
+    const targetRecord = records.get(record.targetBindingId);
+    const canonicalRecord = records.get(record.canonicalBindingId);
+    const targetUnit = input.identityContext.unitByUnitId.get(record.targetUnitId);
+    const targetTerminal = input.identityContext.terminalByUnitId.get(record.targetUnitId);
+    const targetDeclaration = input.identityContext.declarationByUnitId.get(record.targetUnitId);
+    const sourceCanonicalRecord = canonicalSourceRecord(record);
+    if (
+      !targetRecord ||
+      targetRecord.targetUnitId !== record.targetUnitId ||
+      !canonicalRecord ||
+      canonicalRecord.targetUnitId !== record.targetUnitId ||
+      !sourceCanonicalRecord ||
+      sourceCanonicalRecord.bindingId !== record.canonicalBindingId ||
+      sourceCanonicalRecord.targetUnitId !== record.targetUnitId ||
+      !targetUnit ||
+      targetTerminal !== targetUnit ||
+      input.identityContext.sourceFileBySourceId.get(targetUnit.sourceId) === undefined
+    ) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable preflight graph record ${record.bindingId} has a dangling target join`,
+      );
+    }
+    if (record.kind !== "source") continue;
+    if (record.targetBindingId !== record.bindingId || record.canonicalBindingId !== record.bindingId) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable preflight source record ${record.bindingId} has an alias target`,
+      );
+    }
+    const declaration = targetDeclaration;
+    if (
+      !declaration ||
+      !ts.isFunctionDeclaration(declaration) ||
+      !declaration.body ||
+      !targetTerminal ||
+      targetTerminal.sourceId !== record.sourceId ||
+      targetTerminal.kind !== "top-level-function" ||
+      targetTerminal.observedKind !== "function" ||
+      targetTerminal.terminalOwnerId !== record.targetUnitId ||
+      input.identityContext.unitByUnitId.get(record.targetUnitId) !== targetTerminal ||
+      input.identityContext.declarationByUnitId.get(record.targetUnitId) !== declaration ||
+      input.identityContext.unitIdByDeclaration.get(declaration) !== record.targetUnitId ||
+      declaration.parent !== sourceFile ||
+      declaration.getSourceFile() !== sourceFile ||
+      !sourceFile.statements.includes(declaration)
+    ) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable preflight source record ${record.bindingId} is not its exact declaration/terminal join`,
+      );
+    }
+    if (sourceRecordByUnitId.has(record.targetUnitId)) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable preflight found duplicate source record for ${record.targetUnitId}`,
+      );
+    }
+    sourceRecordByUnitId.set(record.targetUnitId, record);
+    const legacyName = declaration.name?.text;
+    // The M1A.4a census is deliberately named-only. Anonymous defaults remain
+    // in the graph oracle and are validated as exact joins above, but cannot
+    // enter the compatibility namespace until the pure propagation/lowerer
+    // seams land in their owning lanes.
+    if (legacyName === undefined) continue;
+    if (targetTerminal.legacyMatchName !== legacyName || record.localName !== legacyName) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable preflight source record ${record.bindingId} has a non-canonical compatibility name`,
+      );
+    }
+    // Keep all exact source records for use validation. The component census
+    // itself admits only external-module members with a stable compatibility
+    // name, so global-script and anonymous non-default units remain outside.
+    if (ts.isExternalModule(sourceFile)) {
+      sourceMembersByUnitId.set(
+        record.targetUnitId,
         Object.freeze({
           sourceFile,
-          sourceId,
-          unitId,
-          legacyName: claim.legacyName,
-          declaration: claim.declaration,
-          plan,
+          sourceId: record.sourceId,
+          unitId: record.targetUnitId,
+          legacyName,
+          declaration,
         }),
       );
     }
   }
-  if (members.size < 2) return [];
 
-  const parent = new Map<IrUnitId, IrUnitId>([...members.keys()].map((unitId) => [unitId, unitId]));
+  const callBelongsToDeclaration = (call: ts.CallExpression, declaration: ts.FunctionDeclaration): boolean => {
+    let current: ts.Node | undefined = call;
+    while (current && current !== declaration) {
+      if (current !== call && ts.isFunctionLike(current)) return false;
+      current = current.parent;
+    }
+    return current === declaration;
+  };
+  const crossSourceEdges: Array<readonly [IrUnitId, IrUnitId]> = [];
+  for (const use of graph.uses) {
+    const ownerRecord = sourceRecordByUnitId.get(use.ownerUnitId);
+    const targetRecord = sourceRecordByUnitId.get(use.targetUnitId);
+    const owner = sourceMembersByUnitId.get(use.ownerUnitId);
+    const target = sourceMembersByUnitId.get(use.targetUnitId);
+    const record = records.get(use.bindingId);
+    const ownerSourceFile = ownerRecord
+      ? input.identityContext.sourceFileBySourceId.get(ownerRecord.sourceId)
+      : undefined;
+    const ownerDeclaration = input.identityContext.declarationByUnitId.get(use.ownerUnitId);
+    if (
+      !ownerRecord ||
+      !targetRecord ||
+      !record ||
+      !ownerSourceFile ||
+      !ownerDeclaration ||
+      !ts.isFunctionDeclaration(ownerDeclaration) ||
+      ownerDeclaration.parent !== ownerSourceFile ||
+      use.sourceId !== ownerRecord.sourceId ||
+      record.sourceId !== ownerRecord.sourceId ||
+      record.sourceId !== use.sourceId ||
+      use.node.getSourceFile() !== ownerSourceFile ||
+      !callBelongsToDeclaration(use.node, ownerDeclaration) ||
+      graph.resolveCall(use.node, use.ownerUnitId) !== use ||
+      record.targetUnitId !== targetRecord.targetUnitId ||
+      record.canonicalBindingId !== use.canonicalBindingId ||
+      targetRecord.targetUnitId !== use.targetUnitId
+    ) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable preflight found a non-exact graph edge ${use.ownerUnitId} -> ${use.targetUnitId}`,
+      );
+    }
+    if (!owner || !target) continue;
+    if (owner.sourceId !== target.sourceId) crossSourceEdges.push([owner.unitId, target.unitId]);
+  }
+
+  if (sourceMembersByUnitId.size < 2) return [];
+  const parent = new Map<IrUnitId, IrUnitId>([...sourceMembersByUnitId.keys()].map((unitId) => [unitId, unitId]));
   const find = (unitId: IrUnitId): IrUnitId => {
     const parentId = parent.get(unitId);
     if (!parentId) {
@@ -465,51 +605,24 @@ function preflightMultiPreparedCallableComponents(
     if (leftRoot < rightRoot) parent.set(rightRoot, leftRoot);
     else parent.set(leftRoot, rightRoot);
   };
-
-  // Close every source-local call component before attaching the authenticated
-  // cross-source anchors. Unanchored local components are discarded below.
-  for (const member of members.values()) {
-    for (const targetUnitId of member.plan.identityPlan.identitySelection.localCallees?.get(member.unitId) ?? []) {
-      const target = members.get(targetUnitId);
-      if (target?.sourceId === member.sourceId) union(member.unitId, targetUnitId);
-    }
-  }
-
-  const records = new Map(graph.records.map((record) => [record.bindingId, record] as const));
-  const crossSourceEdges: Array<readonly [IrUnitId, IrUnitId]> = [];
+  for (const [owner, target] of crossSourceEdges) union(owner, target);
+  // Local callable uses are graph evidence too. Closing them from the same
+  // frozen use list avoids reintroducing a plan-derived identity authority.
   for (const use of graph.uses) {
-    const owner = members.get(use.ownerUnitId);
-    const target = members.get(use.targetUnitId);
-    const record = records.get(use.bindingId);
-    if (!owner || !target || owner.sourceId === target.sourceId) continue;
-    if (
-      use.sourceId !== owner.sourceId ||
-      use.node.getSourceFile() !== owner.sourceFile ||
-      graph.resolveCall(use.node, use.ownerUnitId) !== use ||
-      !record ||
-      record.sourceId !== owner.sourceId ||
-      record.targetUnitId !== target.unitId ||
-      record.canonicalBindingId !== use.canonicalBindingId
-    ) {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "resolve",
-        `callable preflight found a non-exact graph edge ${use.ownerUnitId} -> ${use.targetUnitId}`,
-      );
-    }
-    union(owner.unitId, target.unitId);
-    crossSourceEdges.push([owner.unitId, target.unitId]);
+    const owner = sourceMembersByUnitId.get(use.ownerUnitId);
+    const target = sourceMembersByUnitId.get(use.targetUnitId);
+    if (owner && target && owner.sourceId === target.sourceId) union(owner.unitId, target.unitId);
   }
 
-  const groupsByRoot = new Map<IrUnitId, MultiPreparedCallableCandidate[]>();
-  for (const member of members.values()) {
+  const groupsByRoot = new Map<IrUnitId, CallablePreflightMember[]>();
+  for (const member of sourceMembersByUnitId.values()) {
     const root = find(member.unitId);
     const group = groupsByRoot.get(root) ?? [];
     group.push(member);
     groupsByRoot.set(root, group);
   }
   const order = new Map(input.identityContext.inventory.terminalUnits.map((unit, index) => [unit.id, index] as const));
-  const compare = (left: MultiPreparedCallableCandidate, right: MultiPreparedCallableCandidate): number =>
+  const compare = (left: CallablePreflightMember, right: CallablePreflightMember): number =>
     (order.get(left.unitId) ?? Number.MAX_SAFE_INTEGER) - (order.get(right.unitId) ?? Number.MAX_SAFE_INTEGER) ||
     left.unitId.localeCompare(right.unitId);
   return Object.freeze(
@@ -527,22 +640,17 @@ function preflightMultiPreparedCallableComponents(
   );
 }
 
-export function planMultiPreparedCallableComponents(input: MultiPreparedCallableOrchestrationInput): void {
-  const graph = input.ctx.irProgramCallableBindingGraph;
-  if (!graph || input.ctx.irProgramCallableCutoverEnabled !== true) return;
-  // Dedicated Prepared owners freeze graph-wide allocator/support identity.
-  // Generic component composition remains fail-closed until that shared
-  // transaction is certified rather than shifting an established route.
-  if (input.owner.existingRouteUnitIds.size > 0) return;
-  const records = new Map(graph.records.map((record) => [record.bindingId, record] as const));
-  const plans = new Map<ts.SourceFile, IrOverlayPlan>();
-  for (const sourceFile of input.multiAst.sourceFiles) {
-    const sourceId = input.identityContext.sourceIdBySourceFile.get(sourceFile);
-    if (!sourceId) throw new IrInvariantError("selection-preparation-mismatch", "resolve", "missing source identity");
-    plans.set(sourceFile, input.planSource(sourceFile));
-  }
-  const preflightComponents = preflightMultiPreparedCallableComponents(input, graph, plans);
-  if (preflightComponents.length === 0) return;
+interface CallableAttemptCensusPublication {
+  readonly attempted: ReadonlySet<IrUnitId>;
+  readonly preflightDeclarationNodesByUnitId: ReadonlyMap<IrUnitId, readonly ts.Node[]>;
+}
+
+/** Publish the graph denominator and capture the exact declaration prefix. */
+function publishCallableAttemptCensus(
+  input: MultiPreparedCallableOrchestrationInput,
+  graph: IrProgramCallableBindingGraph,
+  preflightComponents: readonly (readonly CallablePreflightMember[])[],
+): CallableAttemptCensusPublication {
   if (input.ctx.irProgramCallableAttemptedUnitIds !== undefined) {
     throw new IrInvariantError(
       "selection-preparation-mismatch",
@@ -572,6 +680,18 @@ export function planMultiPreparedCallableComponents(input: MultiPreparedCallable
     publicAttemptedProjection.delete([...authoritativeAttempted][0]!);
   } else if (censusMutation === "foreign") {
     publicAttemptedProjection.add("ir-unit:v1:test-foreign-callable" as IrUnitId);
+  } else if (censusMutation === "include-unanchored") {
+    const unanchored = graph.records.find(
+      (record) => record.kind === "source" && !authoritativeAttempted.has(record.targetUnitId),
+    );
+    if (!unanchored) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        "callable include-unanchored mutation found no exact unanchored source unit",
+      );
+    }
+    publicAttemptedProjection.add(unanchored.targetUnitId);
   } else if (censusMutation === "under-covered-neighbor") {
     const crossSourceEndpoints = new Set(
       graph.uses.flatMap((use) => {
@@ -588,9 +708,9 @@ export function planMultiPreparedCallableComponents(input: MultiPreparedCallable
         "callable census under-coverage mutation found no source-local neighbor",
       );
     }
-    attempted.delete(underCovered);
-    authoritativeAttempted.delete(underCovered);
-    componentIndexByUnitId.delete(underCovered);
+    // Keep the private authority and component index immutable. The public
+    // projection is the only mutation seam; the next exact census check must
+    // reject it before any callable plan can be accepted.
     publicAttemptedProjection.delete(underCovered);
   } else if (censusMutation !== undefined) {
     throw new IrInvariantError(
@@ -621,7 +741,186 @@ export function planMultiPreparedCallableComponents(input: MultiPreparedCallable
       "callable attempted census under-covered its immutable preflight component population",
     );
   }
+  if (censusMutation === "under-covered-neighbor") {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "callable attempted census under-covered its immutable preflight component population",
+    );
+  }
   currentCallableAttemptCensus(input.ctx, "callable aggregate planning");
+  return Object.freeze({ attempted, preflightDeclarationNodesByUnitId });
+}
+
+/** Reconcile every selected graph edge against its source overlay evidence. */
+function assertCallableGraphUsesMatchCachedPlans(
+  input: MultiPreparedCallableOrchestrationInput,
+  graph: IrProgramCallableBindingGraph,
+  records: ReadonlyMap<IrBindingId, ProgramCallableRecord>,
+  plans: ReadonlyMap<ts.SourceFile, IrOverlayPlan>,
+  preflightComponents: readonly (readonly CallablePreflightMember[])[],
+): void {
+  const selected = new Map(
+    preflightComponents.flatMap((group) => group.map((member) => [member.unitId, member] as const)),
+  );
+  const localCalleesBySource = new Map<ts.SourceFile, ReadonlyMap<IrUnitId, ReadonlySet<IrUnitId>>>();
+  const importedCallsBySource = new Map<ts.SourceFile, ReadonlyMap<ts.CallExpression, IrImportedCallLoweringPlan>>();
+  for (const [sourceFile, plan] of plans) {
+    localCalleesBySource.set(sourceFile, plan.identityPlan.identitySelection.localCallees ?? new Map());
+    importedCallsBySource.set(sourceFile, plan.importedCalls);
+  }
+  const mutation = process.env.JS2WASM_TEST_MUTATE_MULTI_PREPARED_CALLABLE_PLAN;
+  let mutationApplied = false;
+  for (const use of graph.uses) {
+    const owner = selected.get(use.ownerUnitId);
+    const target = selected.get(use.targetUnitId);
+    if (!owner || !target) continue;
+    const plan = plans.get(owner.sourceFile);
+    if (!plan) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable graph use owner ${owner.unitId} has no exact cached source plan`,
+      );
+    }
+    if (owner.sourceId === target.sourceId) {
+      let localCallees = localCalleesBySource.get(owner.sourceFile);
+      let targetUnitIds = localCallees?.get(owner.unitId);
+      if (mutation === "missing-local-plan" && !mutationApplied) {
+        if (!targetUnitIds?.has(target.unitId)) {
+          throw new IrInvariantError(
+            "selection-preparation-mismatch",
+            "resolve",
+            `callable missing-local-plan mutation found no selected same-source edge ${owner.unitId} -> ${target.unitId}`,
+          );
+        }
+        const projected = new Map(localCallees ?? []);
+        const projectedTargets = new Set(targetUnitIds);
+        projectedTargets.delete(target.unitId);
+        projected.set(owner.unitId, projectedTargets);
+        localCalleesBySource.set(owner.sourceFile, projected);
+        localCallees = projected;
+        targetUnitIds = projectedTargets;
+        mutationApplied = true;
+      }
+      if (!targetUnitIds?.has(target.unitId)) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "resolve",
+          `callable graph use ${owner.unitId} -> ${target.unitId} is missing its exact cached local call plan`,
+        );
+      }
+      continue;
+    }
+    let importedCalls = importedCallsBySource.get(owner.sourceFile);
+    const originalCallPlan = importedCalls?.get(use.node);
+    if (mutation === "missing-imported-plan" && !mutationApplied) {
+      if (!originalCallPlan) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "resolve",
+          `callable missing-imported-plan mutation found no selected cross-source call ${owner.unitId} -> ${target.unitId}`,
+        );
+      }
+      const projected = new Map(importedCalls ?? []);
+      projected.delete(use.node);
+      importedCallsBySource.set(owner.sourceFile, projected);
+      importedCalls = projected;
+      mutationApplied = true;
+    }
+    const callPlan = importedCalls?.get(use.node);
+    const plannedUse = callPlan
+      ? aggregateProgramCallableUse(graph, records, use.node, owner.unitId, callPlan)
+      : undefined;
+    if (
+      !callPlan ||
+      callPlan.source !== "module-import" ||
+      callPlan.ownerUnitId !== owner.unitId ||
+      callPlan.target.binding.kind !== "unit" ||
+      callPlan.target.binding.unitId !== target.unitId ||
+      !plannedUse ||
+      plannedUse.ownerUnitId !== use.ownerUnitId ||
+      plannedUse.targetUnitId !== use.targetUnitId ||
+      plannedUse.bindingId !== use.bindingId ||
+      plannedUse.canonicalBindingId !== use.canonicalBindingId
+    ) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `callable graph use ${owner.unitId} -> ${target.unitId} is missing its exact cached imported call plan`,
+      );
+    }
+  }
+  if (mutation === "missing-local-plan" && !mutationApplied) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "callable missing-local-plan mutation found no selected same-source graph use",
+    );
+  }
+  if (mutation === "missing-imported-plan" && !mutationApplied) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "callable missing-imported-plan mutation found no selected cross-source graph use",
+    );
+  }
+  if (mutation !== undefined && mutation !== "missing-local-plan" && mutation !== "missing-imported-plan") {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      `unknown callable cached-plan mutation ${JSON.stringify(mutation)}`,
+    );
+  }
+}
+
+export function planMultiPreparedCallableComponents(input: MultiPreparedCallableOrchestrationInput): void {
+  const graph = input.ctx.irProgramCallableBindingGraph;
+  if (!graph || input.ctx.irProgramCallableCutoverEnabled !== true) return;
+  // Dedicated Prepared owners freeze graph-wide allocator/support identity.
+  // Generic component composition remains fail-closed until that shared
+  // transaction is certified rather than shifting an established route.
+  if (input.owner.existingRouteUnitIds.size > 0) return;
+  const records = new Map(graph.records.map((record) => [record.bindingId, record] as const));
+  const plans = new Map<ts.SourceFile, IrOverlayPlan>();
+  for (const sourceFile of input.multiAst.sourceFiles) {
+    const sourceId = input.identityContext.sourceIdBySourceFile.get(sourceFile);
+    if (!sourceId) throw new IrInvariantError("selection-preparation-mismatch", "resolve", "missing source identity");
+    plans.set(sourceFile, input.planSource(sourceFile));
+  }
+  // The graph and identity inventory are the attempted census authority. The
+  // cached overlay plans above are consulted only after this immutable graph
+  // population has been published below.
+  const preflightComponents = preflightMultiPreparedCallableComponents(input, graph);
+  if (preflightComponents.length === 0) return;
+  const { attempted, preflightDeclarationNodesByUnitId } = publishCallableAttemptCensus(
+    input,
+    graph,
+    preflightComponents,
+  );
+  assertCallableGraphUsesMatchCachedPlans(input, graph, records, plans, preflightComponents);
+
+  // Dedicated planning runs before the aggregate census and can project a
+  // same-spelled function out of its source selection. Re-open only the exact
+  // graph-member claim that remains override-ready and has no preparation
+  // failure. This preserves M1.3's name-invariant reconciliation without
+  // making the source plan define the graph-first attempted denominator.
+  for (const group of preflightComponents) {
+    for (const member of group) {
+      const plan = plans.get(member.sourceFile);
+      const claim = plan?.functionClaimsByUnitId.get(member.unitId);
+      if (
+        plan &&
+        claim?.declaration === member.declaration &&
+        claim.legacyName === member.legacyName &&
+        plan.overrideMapByUnitId.has(member.unitId) &&
+        plan.identityPlan.identitySelection.funcs.has(member.unitId) &&
+        !plan.preparationFailuresByUnitId.has(member.unitId)
+      ) {
+        plan.identityPlan.safeFunctionUnitIds.add(member.unitId);
+      }
+    }
+  }
   const assertPreflightCurrent = (): void => {
     const bodyMutation = process.env.JS2WASM_TEST_MUTATE_MULTI_PREPARED_CALLABLE_DECLARATION_BODY;
     if (
@@ -637,6 +936,18 @@ export function planMultiPreparedCallableComponents(input: MultiPreparedCallable
         `unknown callable declaration-body mutation ${JSON.stringify(bodyMutation)}`,
       );
     }
+    const stagedBodyMutation = process.env.JS2WASM_TEST_MUTATE_MULTI_PREPARED_CALLABLE_STAGED_BODY;
+    if (stagedBodyMutation !== undefined && stagedBodyMutation !== "1") {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `unknown staged callable body mutation ${JSON.stringify(stagedBodyMutation)}`,
+      );
+    }
+    const stagedBodyDeclaration = stagedBodyMutation === "1" ? preflightComponents[0]?.[0]?.declaration : undefined;
+    const stagedBodyTarget = stagedBodyDeclaration as { body: ts.Block | undefined } | undefined;
+    const originalStagedBody = stagedBodyTarget?.body;
+    if (stagedBodyTarget && originalStagedBody) stagedBodyTarget.body = undefined;
     const mutationTarget = bodyMutation === "1" ? preflightComponents[0]?.[0]?.declaration : undefined;
     const mutableMutationTarget = mutationTarget as { body: ts.Block | undefined } | undefined;
     const originalMutationBody = mutableMutationTarget?.body;
@@ -684,6 +995,7 @@ export function planMultiPreparedCallableComponents(input: MultiPreparedCallable
             input.identityContext.unitIdByDeclaration.get(member.declaration) !== member.unitId ||
             member.declaration.parent !== member.sourceFile ||
             member.declaration.name?.text !== member.legacyName ||
+            !member.declaration.body ||
             stagedNodes === undefined ||
             currentNodes.length !== stagedNodes.length ||
             currentNodes.some((node, index) => node !== stagedNodes[index])
@@ -698,39 +1010,26 @@ export function planMultiPreparedCallableComponents(input: MultiPreparedCallable
       }
     } finally {
       if (mutableMutationTarget && originalMutationBody) mutableMutationTarget.body = originalMutationBody;
+      if (stagedBodyTarget && originalStagedBody) stagedBodyTarget.body = originalStagedBody;
       restoreNestedMutation?.();
     }
   };
 
-  // Dedicated planning runs first and intentionally cannot observe the
-  // aggregate census. Its conservative name projection can therefore remove
-  // an exact same-spelled unit from the cached plan even when no dedicated
-  // route was accepted. Re-open only preflight-authenticated, override-ready
-  // units with no recorded preparation failure; the callable safe-selection
-  // pass below immediately reapplies every non-name safety gate.
-  for (const group of preflightComponents) {
-    for (const member of group) {
-      if (
-        member.plan.functionClaimsByUnitId.get(member.unitId)?.declaration === member.declaration &&
-        member.plan.overrideMapByUnitId.has(member.unitId) &&
-        member.plan.identityPlan.identitySelection.funcs.has(member.unitId) &&
-        !member.plan.preparationFailuresByUnitId.has(member.unitId)
-      ) {
-        member.plan.identityPlan.safeFunctionUnitIds.add(member.unitId);
-      }
-    }
-  }
-
+  const preflightMemberByUnitId = new Map(
+    preflightComponents.flatMap((group) => group.map((member) => [member.unitId, member] as const)),
+  );
   const candidates = new Map<IrUnitId, MultiPreparedCallableCandidate>();
-  for (const sourceFile of input.multiAst.sourceFiles) {
+  for (const [sourceFile, plan] of plans) {
     const sourceId = input.identityContext.sourceIdBySourceFile.get(sourceFile)!;
-    const plan = plans.get(sourceFile)!;
     const safeSelection = input.safeSelection(plan, sourceFile);
     for (const [unitId, claim] of plan.functionClaimsByUnitId) {
-      if (!attempted.has(unitId)) continue;
+      const member = preflightMemberByUnitId.get(unitId);
+      if (!attempted.has(unitId) || !member || member.sourceFile !== sourceFile) continue;
       const terminal = input.identityContext.terminalByUnitId.get(unitId);
       if (
         input.owner.existingRouteUnitIds.has(unitId) ||
+        claim.declaration !== member.declaration ||
+        claim.legacyName !== member.legacyName ||
         !plan.identityPlan.safeFunctionUnitIds.has(unitId) ||
         !safeSelection.funcs.has(claim.legacyName) ||
         terminal?.sourceId !== sourceId ||

--- a/tests/issue-3525-multi-prepared-callable-bindings.test.ts
+++ b/tests/issue-3525-multi-prepared-callable-bindings.test.ts
@@ -11,6 +11,7 @@ import {
   type MultiPreparedProgramCallableComponent,
 } from "../src/codegen/multi-prepared-callable-publication.js";
 import type { CodegenContext } from "../src/codegen/context/types.js";
+import { moduleCallableAliasStructuralReferenceKey } from "../src/codegen/program-abi-module-callable-alias-planning.js";
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
 import { compileMulti } from "../src/index.js";
 import { buildIrUnitInventory, type IrUnitId } from "../src/ir/identity.js";
@@ -88,6 +89,31 @@ const ALIAS_FILES = {
     export function same(value: number): number { return value + 100; }
     export function invoke(value: number): number {
       return localSame(value) + defaultFn(value) + ns.same(value) + reexported(value);
+    }
+  `,
+  "./entry.ts": `
+    import { invoke as call, chained, same as entrySame } from "./b";
+    export function entry(value: number): number {
+      return call(value) + chained(value) + entrySame(value);
+    }
+  `,
+} as const;
+
+const NAMED_DEFAULT_ALIAS_FILES = {
+  "./a.ts": `
+    export function same(value: number): number { return value; }
+    export function only(value: number): number { return value + 1; }
+    function defaultFn(value: number): number { return value + 2; }
+    export { defaultFn as default };
+    export { same as renamed };
+  `,
+  "./b.ts": `
+    import defaultFn, { same as localSame, renamed as reexported } from "./a";
+    export { renamed as chained } from "./a";
+    export * from "./a";
+    export function same(value: number): number { return value + 100; }
+    export function invoke(value: number): number {
+      return localSame(value) + defaultFn(value) + reexported(value);
     }
   `,
   "./entry.ts": `
@@ -642,16 +668,20 @@ describe("#3525 whole-program callable binding graph", () => {
     expect(useSignature(reversedFixture)).toEqual(useSignature(fixture));
     const reversedGenerated = generateMultiModule(analyzeMultiSource(reversedFiles, "./entry.ts"), options);
     expect(reversedGenerated.errors.filter((error) => error.severity !== "warning")).toEqual([]);
+    expect(reversedGenerated.multiPreparedProgramAudit?.bodyPlan.terminalUnitIds).toEqual(
+      audit?.bodyPlan.terminalUnitIds,
+    );
+    expect(reversedGenerated.multiPreparedProgramAudit?.bodyPlan.reservations.map(({ unitId }) => unitId)).toEqual(
+      reservations.map(({ unitId }) => unitId),
+    );
+    expect(reversedGenerated.multiPreparedProgramAudit?.bodyPlan.reservations.map(({ sourceId }) => sourceId)).toEqual(
+      reservations.map(({ sourceId }) => sourceId),
+    );
     expect(
-      new Set(reversedGenerated.multiPreparedProgramAudit?.bodyPlan.reservations.map(({ unitId }) => unitId)),
-    ).toEqual(expectedUnitIds);
-    expect(
-      new Set(
-        reversedGenerated.multiPreparedProgramAudit?.bodyPlan.reservations.map(
-          ({ preparedComponentId }) => preparedComponentId,
-        ),
+      reversedGenerated.multiPreparedProgramAudit?.bodyPlan.reservations.map(
+        ({ preparedComponentId }) => preparedComponentId,
       ),
-    ).toEqual(new Set(reservations.map(({ preparedComponentId }) => preparedComponentId)));
+    ).toEqual(reservations.map(({ preparedComponentId }) => preparedComponentId));
     const reversedPrepared = await compileMulti(reversedFiles, "./entry.ts", options);
     expect(reversedPrepared.success, reversedPrepared.errors.map((error) => error.message).join("\n")).toBe(true);
     const reversedExports = (await instantiateWithRuntime(reversedPrepared)).exports as unknown as {
@@ -659,6 +689,333 @@ describe("#3525 whole-program callable binding graph", () => {
     };
     expect(reversedExports.run(5)).toBe(preparedExports.run(5));
   }, 120_000);
+
+  it("prepares the named-default alias matrix with exact five-unit ownership", async () => {
+    const fixture = makeGraph(NAMED_DEFAULT_ALIAS_FILES, "./entry.ts");
+    const aSame = functionUnitId(fixture, "/a.ts", "same");
+    const aOnly = functionUnitId(fixture, "/a.ts", "only");
+    const aDefault = functionUnitId(fixture, "/a.ts", "defaultFn");
+    const bSame = functionUnitId(fixture, "/b.ts", "same");
+    const bInvoke = functionUnitId(fixture, "/b.ts", "invoke");
+    const entry = functionUnitId(fixture, "/entry.ts", "entry");
+    const expectedUnitIds = new Set([aSame, aDefault, bSame, bInvoke, entry]);
+    const sourceIdFor = (fileName: string): string => {
+      const normalizedFileName = fileName.replace(/^\/+/, "");
+      const source = fixture.ast.sourceFiles.find(
+        (candidate) =>
+          candidate.fileName === fileName || candidate.fileName.replace(/^\.?\//, "") === normalizedFileName,
+      );
+      expect(source).toBeDefined();
+      const sourceId = fixture.identity.sourceIdBySourceFile.get(source!);
+      expect(sourceId).toBeDefined();
+      return sourceId!;
+    };
+    const aSourceId = sourceIdFor("/a.ts");
+    const bSourceId = sourceIdFor("/b.ts");
+    const entrySourceId = sourceIdFor("/entry.ts");
+
+    expect(
+      fixture.graph.records.filter((record) => record.kind === "source").map((record) => record.targetUnitId),
+    ).toEqual([aSame, aOnly, aDefault, bSame, bInvoke, entry]);
+    const bUses = fixture.graph.uses.filter((use) => use.ownerUnitId === bInvoke);
+    expect(bUses.map((use) => [use.node.expression.getText(), use.targetUnitId])).toEqual([
+      ["localSame", aSame],
+      ["defaultFn", aDefault],
+      ["reexported", aSame],
+    ]);
+    const entryUses = fixture.graph.uses.filter((use) => use.ownerUnitId === entry);
+    expect(entryUses.map((use) => [use.node.expression.getText(), use.targetUnitId])).toEqual([
+      ["call", bInvoke],
+      ["chained", aSame],
+      ["entrySame", bSame],
+    ]);
+    expect(Object.isFrozen(fixture.graph)).toBe(true);
+    expect(Object.isFrozen(fixture.graph.records)).toBe(true);
+    expect(Object.isFrozen(fixture.graph.uses)).toBe(true);
+
+    const generated = generateMultiModule(analyzeMultiSource(NAMED_DEFAULT_ALIAS_FILES, "./entry.ts"), {
+      ...CALLABLE_OPTIONS,
+    });
+    expect(generated.errors.filter(({ severity }) => severity !== "warning")).toEqual([]);
+    const audit = generated.multiPreparedProgramAudit;
+    expect(audit).toBeDefined();
+    const reservations = audit?.bodyPlan.reservations ?? [];
+    expect(reservations).toHaveLength(5);
+    expect(new Set(reservations.map(({ unitId }) => unitId))).toEqual(expectedUnitIds);
+    expect(new Set(reservations.map(({ sourceId }) => sourceId))).toEqual(
+      new Set([aSourceId, bSourceId, entrySourceId]),
+    );
+    expect(new Set(reservations.map(({ routeKind }) => routeKind))).toEqual(new Set(["cross-source-callable"]));
+    expect(
+      reservations.every(
+        (reservation) =>
+          reservation.routeKind === "cross-source-callable" &&
+          reservation.stagedBeforeDirectBodies &&
+          reservation.committedAfterExactBodySkips &&
+          reservation.publicationPhase === "after-exact-body-skips" &&
+          !("preparedBeforeDirectBodies" in reservation),
+      ),
+    ).toBe(true);
+    expect(audit?.bodyPlan.terminalUnitIds).toEqual([aSame, aOnly, aDefault, bSame, bInvoke, entry]);
+    expect(audit?.bodyPlan.unreservedTerminalUnitIds).toEqual([aOnly]);
+    expect(new Set(reservations.map(({ preparedComponentId }) => preparedComponentId))).toHaveLength(1);
+
+    const aliases =
+      generated.programAbi?.abi
+        .entries()
+        .filter((entry) => entry.intent.kind === "callable" && entry.intent.origin === "module-alias") ?? [];
+    expect(aliases).toHaveLength(15);
+    const aliasRows = aliases.map(({ displayName, intent }) => [
+      intent.sourceId,
+      displayName,
+      intent.aliasKind,
+      intent.targetUnitId,
+    ]);
+    expect(aliasRows).toEqual([
+      [aSourceId, "same", "export-alias", aSame],
+      [aSourceId, "default", "export-alias", aDefault],
+      [aSourceId, "renamed", "export-alias", aSame],
+      [bSourceId, "defaultFn", "import-alias", aDefault],
+      [bSourceId, "localSame", "import-alias", aSame],
+      [bSourceId, "reexported", "import-alias", aSame],
+      [bSourceId, "chained", "export-alias", aSame],
+      [bSourceId, "renamed", "export-alias", aSame],
+      [bSourceId, "same", "export-alias", aSame],
+      [bSourceId, "same", "export-alias", bSame],
+      [bSourceId, "invoke", "export-alias", bInvoke],
+      [entrySourceId, "call", "import-alias", bInvoke],
+      [entrySourceId, "chained", "import-alias", aSame],
+      [entrySourceId, "entrySame", "import-alias", bSame],
+      [entrySourceId, "entry", "export-alias", entry],
+    ]);
+    const graphRecordsById = new Map(fixture.graph.records.map((record) => [record.bindingId, record]));
+    const aliasById = new Map(aliases.map((alias) => [alias.id, alias]));
+    const sourceRoots = new Map(
+      generated.programAbi?.abi
+        .entries()
+        .filter(
+          (entry) =>
+            entry.intent.kind === "callable" && entry.intent.origin === "source" && entry.intent.unitId !== undefined,
+        )
+        .map((entry) => [entry.intent.unitId!, entry]),
+    );
+    for (const alias of aliases) {
+      const record = graphRecordsById.get(alias.id);
+      expect(record).toBeDefined();
+      expect(alias.slotPolicy).toBe("alias");
+      expect(alias.structuralReferenceKey).toBe(moduleCallableAliasStructuralReferenceKey(record!, alias.aliasOf!));
+      expect(alias.aliasOf).toBeDefined();
+      expect(alias.intent.targetUnitId).toBe(record?.targetUnitId);
+      const root = sourceRoots.get(alias.intent.targetUnitId!);
+      expect(root).toBeDefined();
+      const aliasFinalIndex = generated.programAbi?.abi.resolveFinalIndex(alias.id);
+      const rootFinalIndex = generated.programAbi?.abi.resolveFinalIndex(root!.id);
+      expect(aliasFinalIndex).toEqual(rootFinalIndex);
+      expect(aliasFinalIndex).toEqual(expect.objectContaining({ space: "function" }));
+      if (aliasFinalIndex?.space !== "function" || rootFinalIndex?.space !== "function") {
+        throw new Error(`callable alias ${alias.id} did not resolve to a function allocator`);
+      }
+      expect(generated.module.functions[aliasFinalIndex.index]).toBe(generated.module.functions[rootFinalIndex.index]);
+      let currentId = alias.aliasOf!;
+      const seen = new Set<string>();
+      while (aliasById.has(currentId)) {
+        expect(seen.has(currentId)).toBe(false);
+        seen.add(currentId);
+        currentId = aliasById.get(currentId)!.aliasOf!;
+      }
+      expect(currentId).toBe(record?.canonicalBindingId);
+      expect(alias.structuralReferenceKey).toEqual(expect.any(String));
+    }
+    expect(aliases.some(({ displayName, intent }) => displayName === "only" || intent.targetUnitId === aOnly)).toBe(
+      false,
+    );
+
+    vi.stubEnv("JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY", "same,defaultFn,invoke,entry");
+    const prepared = await compileMulti(NAMED_DEFAULT_ALIAS_FILES, "./entry.ts", CALLABLE_OPTIONS);
+    vi.stubEnv("JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY", "");
+    const direct = await compileMulti(NAMED_DEFAULT_ALIAS_FILES, "./entry.ts", {
+      experimentalIR: false,
+      nativeStrings: true,
+      target: "standalone",
+    });
+    expect(prepared.success, prepared.errors.map(({ message }) => message).join("\n")).toBe(true);
+    expect(direct.success, direct.errors.map(({ message }) => message).join("\n")).toBe(true);
+    expect([...(prepared.irCompiledFuncs ?? [])].sort()).toEqual(["defaultFn", "entry", "invoke", "same", "same"]);
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    const preparedOutcomes = exactOutcomes(prepared, expectedUnitIds);
+    expect(preparedOutcomes).toHaveLength(5);
+    expect(new Set(preparedOutcomes.map(({ unitId }) => unitId))).toEqual(expectedUnitIds);
+    expect(preparedOutcomes.map(({ displayName }) => displayName).sort()).toEqual(
+      ["defaultFn", "entry", "invoke", "same", "same"].sort(),
+    );
+    expect(new Set(preparedOutcomes.map(({ preparedComponentId }) => preparedComponentId))).toHaveLength(1);
+    expect(preparedOutcomes.every(({ kind, irBodyEmitted }) => kind === "emitted" && irBodyEmitted)).toBe(true);
+    expect(prepared.irOutcomes?.some(({ unitId, irBodyEmitted }) => unitId === aOnly && irBodyEmitted)).toBe(false);
+    expect(prepared.irCompiledFuncs ?? []).not.toContain("only");
+    expect(
+      prepared.irBodyRouteAudit?.legacyEntries.filter(
+        ({ unitId }) => unitId !== undefined && expectedUnitIds.has(unitId),
+      ),
+    ).toEqual([]);
+    expect(
+      prepared.irBodyRouteAudit?.dispositions
+        .filter(({ unitId }) => unitId !== undefined && expectedUnitIds.has(unitId))
+        .every(({ disposition }) => disposition === "terminal-ir"),
+    ).toBe(true);
+    const preparedExports = (await instantiateWithRuntime(prepared)).exports as unknown as {
+      entry(value: number): number;
+    };
+    const directExports = (await instantiateWithRuntime(direct)).exports as unknown as {
+      entry(value: number): number;
+    };
+    expect(preparedExports.entry(5)).toBe(directExports.entry(5));
+    expect(preparedExports.entry(5)).toBe(127);
+
+    const reversedFiles = {
+      "./entry.ts": NAMED_DEFAULT_ALIAS_FILES["./entry.ts"],
+      "./b.ts": NAMED_DEFAULT_ALIAS_FILES["./b.ts"],
+      "./a.ts": NAMED_DEFAULT_ALIAS_FILES["./a.ts"],
+    } as const;
+    const reversedFixture = makeGraph(reversedFiles, "./entry.ts");
+    expect(reversedFixture.graph.records).toEqual(fixture.graph.records);
+    expect(useSignature(reversedFixture)).toEqual(useSignature(fixture));
+    const reversedGenerated = generateMultiModule(analyzeMultiSource(reversedFiles, "./entry.ts"), {
+      ...CALLABLE_OPTIONS,
+    });
+    expect(reversedGenerated.errors.filter(({ severity }) => severity !== "warning")).toEqual([]);
+    expect(reversedGenerated.multiPreparedProgramAudit?.bodyPlan.terminalUnitIds).toEqual(
+      audit?.bodyPlan.terminalUnitIds,
+    );
+    expect(reversedGenerated.multiPreparedProgramAudit?.bodyPlan.reservations.map(({ unitId }) => unitId)).toEqual(
+      reservations.map(({ unitId }) => unitId),
+    );
+    expect(reversedGenerated.multiPreparedProgramAudit?.bodyPlan.reservations.map(({ sourceId }) => sourceId)).toEqual(
+      reservations.map(({ sourceId }) => sourceId),
+    );
+    expect(
+      reversedGenerated.multiPreparedProgramAudit?.bodyPlan.reservations.map(
+        ({ preparedComponentId }) => preparedComponentId,
+      ),
+    ).toEqual(reservations.map(({ preparedComponentId }) => preparedComponentId));
+    const reversedAliases =
+      reversedGenerated.programAbi?.abi
+        .entries()
+        .filter((entry) => entry.intent.kind === "callable" && entry.intent.origin === "module-alias") ?? [];
+    expect(
+      reversedAliases.map(({ displayName, intent, aliasOf, structuralReferenceKey, slotPolicy }) => [
+        displayName,
+        intent.sourceId,
+        intent.aliasKind,
+        intent.targetUnitId,
+        aliasOf,
+        structuralReferenceKey,
+        slotPolicy,
+      ]),
+    ).toEqual(
+      aliases.map(({ displayName, intent, aliasOf, structuralReferenceKey, slotPolicy }) => [
+        displayName,
+        intent.sourceId,
+        intent.aliasKind,
+        intent.targetUnitId,
+        aliasOf,
+        structuralReferenceKey,
+        slotPolicy,
+      ]),
+    );
+    const reversedPrepared = await compileMulti(reversedFiles, "./entry.ts", CALLABLE_OPTIONS);
+    expect(reversedPrepared.success, reversedPrepared.errors.map(({ message }) => message).join("\n")).toBe(true);
+    expect(reversedPrepared.irBodyRouteAudit).toEqual(prepared.irBodyRouteAudit);
+    const reversedExports = (await instantiateWithRuntime(reversedPrepared)).exports as unknown as {
+      entry(value: number): number;
+    };
+    expect(reversedExports.entry(5)).toBe(127);
+  }, 120_000);
+
+  it.each(["drop", "foreign", "include-unanchored"] as const)(
+    "fails closed before any callable publication when the named census is %s",
+    (mutation) => {
+      const fixture = makeGraph(NAMED_DEFAULT_ALIAS_FILES, "./entry.ts");
+      const aSame = functionUnitId(fixture, "/a.ts", "same");
+      const aOnly = functionUnitId(fixture, "/a.ts", "only");
+      const aDefault = functionUnitId(fixture, "/a.ts", "defaultFn");
+      const bSame = functionUnitId(fixture, "/b.ts", "same");
+      const bInvoke = functionUnitId(fixture, "/b.ts", "invoke");
+      const entry = functionUnitId(fixture, "/entry.ts", "entry");
+      const allUnitIds = new Set([aSame, aOnly, aDefault, bSame, bInvoke, entry]);
+      vi.stubEnv("JS2WASM_TEST_MUTATE_MULTI_PREPARED_CALLABLE_CENSUS", mutation);
+      const generated = generateMultiModule(analyzeMultiSource(NAMED_DEFAULT_ALIAS_FILES, "./entry.ts"), {
+        ...CALLABLE_OPTIONS,
+      });
+      expect(
+        generated.errors
+          .filter(({ severity }) => severity !== "warning")
+          .map(({ message }) => message)
+          .join("\n"),
+      ).toMatch(
+        /mutated callable preflight authority|callable attempted census (under-covered|foreign|changed|mutated)/i,
+      );
+      expectNoCallablePublication(generated, allUnitIds, new Set(["same", "only", "defaultFn", "invoke", "entry"]));
+      expect(
+        generated.programAbi?.abi
+          .entries()
+          .filter((entry) => entry.intent.kind === "callable" && entry.intent.origin === "module-alias") ?? [],
+      ).toEqual([]);
+    },
+  );
+
+  it("fails closed with a zero publication prefix when a staged callable body is removed", () => {
+    const fixture = makeGraph(SAME_SPELLING_COMPONENT_FILES, "./entry.ts");
+    const unitIds = new Set<IrUnitId>([
+      functionUnitId(fixture, "/a.ts", "same") as IrUnitId,
+      functionUnitId(fixture, "/a.ts", "call") as IrUnitId,
+      functionUnitId(fixture, "/b.ts", "same") as IrUnitId,
+      functionUnitId(fixture, "/b.ts", "call") as IrUnitId,
+      functionUnitId(fixture, "/entry.ts", "run") as IrUnitId,
+    ]);
+    vi.stubEnv("JS2WASM_TEST_MUTATE_MULTI_PREPARED_CALLABLE_STAGED_BODY", "1");
+
+    const generated = generateMultiModule(
+      analyzeMultiSource(SAME_SPELLING_COMPONENT_FILES, "./entry.ts"),
+      CALLABLE_OPTIONS,
+    );
+
+    expect(generated.errors.filter(({ severity }) => severity !== "warning")).toEqual([
+      expect.objectContaining({
+        severity: "error",
+        message: expect.stringContaining("changed before final publication"),
+      }),
+    ]);
+    expectNoCallablePublication(generated, unitIds, new Set(["same", "call", "run"]));
+  });
+
+  it.each(["missing-local-plan", "missing-imported-plan"] as const)(
+    "fails closed before callable preparation when a selected %s is hidden",
+    (mutation) => {
+      const fixture = makeGraph(SAME_SPELLING_COMPONENT_FILES, "./entry.ts");
+      const unitIds = new Set<IrUnitId>([
+        functionUnitId(fixture, "/a.ts", "same") as IrUnitId,
+        functionUnitId(fixture, "/a.ts", "call") as IrUnitId,
+        functionUnitId(fixture, "/b.ts", "same") as IrUnitId,
+        functionUnitId(fixture, "/b.ts", "call") as IrUnitId,
+        functionUnitId(fixture, "/entry.ts", "run") as IrUnitId,
+      ]);
+      vi.stubEnv("JS2WASM_TEST_MUTATE_MULTI_PREPARED_CALLABLE_PLAN", mutation);
+
+      const generated = generateMultiModule(
+        analyzeMultiSource(SAME_SPELLING_COMPONENT_FILES, "./entry.ts"),
+        CALLABLE_OPTIONS,
+      );
+
+      const evidence = mutation === "missing-local-plan" ? "local call plan" : "imported call plan";
+      expect(generated.errors.filter(({ severity }) => severity !== "warning")).toEqual([
+        expect.objectContaining({
+          severity: "error",
+          message: expect.stringContaining(`is missing its exact cached ${evidence}`),
+        }),
+      ]);
+      expectNoCallablePublication(generated, unitIds, new Set(["same", "call", "run"]));
+    },
+  );
 
   it("keeps unanchored local same-spelling declarations outside the exact component census", () => {
     const options = {


### PR DESCRIPTION
## Summary

- derive the multi-prepared callable attempted census from the frozen ProgramCallable graph and exact source/declaration joins
- reconcile every selected local and imported graph use against its cached source overlay plan before reopening claims
- cover the named-default/import/re-export/export-star alias matrix, exact unanchored exclusion, ordered reverse stability, allocator identity, and fail-closed body/plan/census mutations

## Validation

- focused callable and prepared Program ABI suites: 61/61
- TypeScript 7 typecheck
- IR layering ratchet
- targeted Biome lint and Prettier
- LOC and function ratchets
- full precommit and prepush hooks

Refs #3525

Draft only until the independent Sol exact-SHA review of 36b7a5156019e92b0a4e17876d3776eb632d18bf completes.