### PR TITLE
fix(ir): authenticate Date carrier bridge exports

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -3722,3 +3722,119 @@ run without bypass. No baseline, LOC, function-size, binary-size, or hook
 exception is authorized. A Luna implementation remains draft until an
 independent Sol review approves the exact pushed SHA; any later push invalidates
 that approval.
+
+## 2026-08-30 C37 implementation lock — preserve user-owned core vec exports
+
+This Sol-authored checkpoint is stacked only on the independently reviewed C36
+head `90fa59a6a771a1fe00fd7c57fdc9a4a2cbfe03fe` (PR #5294). Develop it on
+`codex/3520-c37-user-vec-export-provenance`; never push, amend, or otherwise
+rewrite the queued parent. Refreshed protected `origin/main` is
+`3e89b5f95318b45fd69c9cf8209da84a7a06351a`. After #5294 lands, verify its
+exact head is an ancestor of refreshed main, re-anchor this child through the
+normal signed workflow if required, and repeat collision, focused, ratchet,
+hook, and exact-SHA Sol-review evidence before making the child ready.
+
+The C36/C37 labels in the older #3521 linked-parser validation tracker refer to
+that tracker's signed prerequisite commits, not this prospective #3520
+checkpoint. Its final R2-v2 collector rerun is outside this slice. The unchanged
+#4035 size ceiling remains a control and must not be reported as a new
+regression.
+
+### Current deterministic false-pass
+
+`stripHostBridgeExports(...)` currently removes an export when either its
+descriptor is authenticated as a compiler-published vec bridge **or** its name
+matches the broad host-bridge namespace. Vec collision publication deliberately
+does not publish a compiler logical descriptor when the user already owns that
+name. The user descriptor is therefore absent from the compiler-owned WeakMap,
+but the second spelling test still deletes it in standalone and WASI.
+
+The false-pass covers the six core logical names (`__vec_len`, `__vec_get`,
+`__is_vec`, `__vec_mut_supported`, `__vec_push`, `__vec_pop`) and the exact
+physical families `$v0` through `$v5`. The focused test whose title claims user
+collisions survive exercises only `$v0$`, which the old exact-alias set never
+matched; it proves neither the logical names nor the unsuffixed physical names.
+Host mode appears correct because stripping is disabled there, masking the
+standalone/WASI loss.
+
+### Exact ownership and classification
+
+Own only:
+
+- this issue record;
+- `src/codegen/host-bridge-exports.ts`;
+- `src/codegen/vec-access-exports.ts`; and
+- `tests/issue-3520-vec-support-callable-abi.test.ts`.
+
+Derive and export one exact core-vec public-name predicate from the six frozen
+`VEC_HOST_BRIDGE_DEFINITIONS`: each definition's logical name plus its physical
+base `$v<ordinal>` followed by zero or more literal `$` suffix characters.
+Reject near-prefix spellings (`$v00`, `$v0x`, `$v6`, arbitrary `__vec_*`) from
+this exception. Do not copy a second name table into the stripping sink.
+
+For this bounded core-vec namespace, spelling is not ownership. Strip an entry
+only when exact provenance authenticates it as compiler-owned: the recorded
+descriptor identity remains authoritative, and a replacement/cloned function
+descriptor is also compiler-owned when its current live-or-stable handle
+resolves to one exact captured vec allocator function. A function descriptor
+resolving to a different, genuine user allocator is retained. Keep C36's dual
+handle interpretation and unconditional final allocator-identity checks; do
+not select a stable resolver merely because a live lookup is out of range,
+repair an invalid descriptor, infer ownership from the export name, or consult
+`funcMap`.
+
+`stripHostBridgeExports(...)` must apply that provenance result first. If a
+non-compiler entry has an exact core-vec public name, retain it. For every other
+host-bridge family and spelling, preserve the existing name-based removal
+unchanged; C37 is not a general host-export ownership migration. Memory,
+`_start`, `__exn_tag`, ordinary user exports, bridge markers, closure/struct/
+exception/stdout families, and their compact aliases keep their current policy.
+
+### Required focused matrix
+
+Extend the existing fixtures rather than replacing their host-mode coverage:
+
+1. Compile `ALL_PUBLIC_COLLISION_SOURCE` in standalone and WASI with tracking
+   both disabled and enabled. All eight user-owned collision exports survive
+   and return exactly `101` through `106`, `901`, and `902`; compiler-owned
+   physical successors are absent; the host-import list is empty; and the
+   tracked and untracked binaries are byte-identical for each target.
+2. Compile `PREFIX_ONLY_COLLISION_SOURCE` in standalone and WASI. User `$v0`
+   through `$v5` survive and return exactly `201` through `206`; no
+   compiler-owned successor for those occupied names remains public.
+3. Keep the existing `$v0$` standalone/WASI control green, proving a suffixed
+   user collision remains outside compiler provenance.
+4. Keep array-free logical and physical spoof fixtures host-free and public
+   without allocating or publishing a vec bridge family.
+5. Add a direct mutation that replaces one recorded descriptor object with a
+   clone targeting the same exact compiler allocator. The clone must still be
+   stripped under disabled policy (or rejected before publication); descriptor
+   replacement cannot reclassify compiler code as user-owned.
+6. Preserve the retarget/name/kind/lost-function matrix, C36's exact one-past
+   live mutation, and C36's disabled-policy survivor mutation. Host-mode
+   collision behavior and collision-free GC/standalone/WASI binaries remain
+   unchanged.
+
+Every tracked/untracked and target comparison must assert the complete public
+name/value census rather than only absence of the bridge prefix. No compact
+count may substitute for exact names, descriptor targets, or runtime values.
+The standalone and WASI controls must not introduce host imports merely to
+observe the exports.
+
+### Boundaries and acceptance
+
+This slice changes no vec allocator order, stable-handle minting, Program ABI,
+bridge bodies, collision suffix allocation, host runtime adapter, general
+host-bridge policy, direct/IR routing, or legacy fallback. It is intentionally
+stacked on C36 because both touch the vec ownership helper and focused test;
+it overlaps no other open PR or inspected parallel Claude lane.
+
+Acceptance requires the focused vec support callable-ABI suite, TypeScript
+typecheck, Prettier/Biome and `git diff --check`, IR fallback and issue
+integrity, plus relevant oracle/coercion/dead-export controls. Immediately
+before every signed commit, run both LOC and function regrowth ratchets. Run
+each heavy command only after a finite, non-negative one-minute load sample is
+strictly below `logical cores - 2`; keep complete precommit and prepush hooks
+enabled. No baseline, LOC, function-size, binary-size, size-ceiling, or hook
+exception is authorized. The stacked PR remains draft until an independent Sol
+approves its exact pushed SHA; any later push invalidates that approval.

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -3945,3 +3945,143 @@ precommit and prepush hooks run without bypass. No baseline, size, LOC,
 function, or hook exception is authorized. A Luna implementation remains draft
 until a separate Sol approves the exact pushed SHA; any later push invalidates
 that approval.
+
+## 2026-08-30 C39 implementation lock — Date carrier export provenance
+
+This Sol-authored checkpoint is stacked only on the independently approved C38
+head `d4a6c363539b885b82a8cccbb7317e4079569ee2` (draft PR #5298). Develop it on
+`codex/3520-c39-date-host-bridge-provenance`; never amend or push C38, C37,
+C36, or a queued parent. Keep the C39 PR draft until every parent is an exact
+ancestor of refreshed `main`, then re-anchor and repeat the complete validation
+and exact-SHA review cycle. The unchanged #4035 size ceiling remains a
+pre-existing control failure, not a C39 regression or an authorized edit.
+
+### Deterministic false-pass
+
+`emitDateHostBridge(...)` unconditionally publishes three JS-host carrier
+helpers whenever `__Date` exists:
+
+- `__\0js2_is_date`;
+- `__\0js2_date_value`; and
+- `__\0js2_date_set_value`.
+
+Both single- and multi-source compilation publish these entries before
+`stripHostBridgeExports(...)`. The policy sink recognizes exact compact bridge
+aliases, ordinary bridge prefixes, and NUL-containing names only when they also
+contain `host_bridge`. None of the three Date names matches. An ordinary Date
+program therefore retains all three compiler-only exports in standalone and
+WASI, where no JavaScript host consumes them, and the exports keep their
+functions and carrier types live through DCE. The #4035 marker census omits the
+three names, so the leak passes the existing size-policy control.
+
+Do not repair this by broadening the generic `js2_` infix or prefix table. That
+would make spelling alone deletion authority for unrelated NUL-labelled
+exports and repeat the user-export ownership defects repaired by C37 and C38.
+
+### Exact ownership and policy contract
+
+Own only:
+
+- this issue record;
+- `src/codegen/date-host-bridge.ts`;
+- `src/codegen/host-bridge-exports.ts`; and
+- new `tests/issue-3520-date-host-bridge-export-provenance.test.ts`.
+
+Retain the current one-shot Date bridge emission, function order, bodies,
+types, public names, and runtime lookup. At publication, record each exact
+`WasmExport` descriptor, its original name, and the exact `WasmFunction`
+allocator that was pushed for it. Freeze one complete three-entry census for
+the context; no name scan, `funcMap` lookup, Program-ABI role, or reconstructed
+index may replace that record.
+
+Export one bounded namespace predicate that accepts exactly the three names
+above. It accepts no suffix, prefix, alternate NUL label, or near spelling.
+Authenticate an entry as compiler-owned when it is one recorded descriptor,
+regardless of later spelling, or when a replacement/copy in that exact
+three-name namespace is a function descriptor resolving to one recorded exact
+allocator. Resolve a live descriptor against the module's current function-
+import prefix. Resolve a stable handle with `definedFuncAt`. An invalid live
+lookup must not fall through to the stable regime; do not repair an index,
+consult `funcMap`, or infer ownership from the function/export name. A
+same-spelled descriptor targeting a different user function and every near
+spelling remain user-owned.
+
+Before the policy decision, validate every recorded Date descriptor exactly
+once. Missing or repeated descriptor identity, renamed entry, non-function
+kind, retargeted or one-past function index, missing allocator object, an
+incomplete/duplicate census, or any target that no longer resolves to its
+recorded allocator is fatal. Validation precedes both the enabled-policy early
+return and every export write in the disabled sink.
+
+In `stripHostBridgeExports(...)`, run the Date, constructor-closure, and vec
+provenance predicates before any shared-name retention predicate. Remove an
+authenticated Date entry when host-bridge publication is disabled, then retain
+unowned entries in the exact Date namespace, and finally preserve C37, C38,
+and the general legacy policy byte-for-byte. This ordering must also remove a
+recorded Date descriptor renamed after finalization into `$v0` or `$ch`, while
+preserving a distinct genuine user entry at that spelling.
+
+Do not change Date allocation, carrier layout, host runtime conversion,
+`Date.prototype` lowering, import order, direct/IR routing, public JS-host
+behavior, Program-ABI roles/ordinals, vec/closure registries, or fallback.
+
+### Required focused matrix
+
+1. With host bridge auto-enabled and with `hostBridge: "always"`, compile a
+   Date-bearing program and prove exactly three compiler Date descriptors,
+   exact names, exact function targets, and unchanged runtime behavior.
+2. In standalone and WASI under auto/off policy, with Program-ABI tracking both
+   disabled and enabled, require all authenticated Date carrier entries absent,
+   exact public export/import censuses, tracked/untracked binary equality, and
+   runtime value `5` for a standalone-safe typed probe using
+   `new Date(5).getTime()`.
+3. In standalone and WASI with `hostBridge: "always"`, require all three exact
+   helpers retained and the same runtime value. A Date-free control publishes
+   no Date census or carrier entry in any target.
+4. Exercise the independent multi-source emitter with a Date constructed in a
+   non-entry provider and an imported typed entry call. In standalone, prove
+   auto/off removes the exact three entries, `hostBridge: "always"` retains
+   them, tracked/untracked binaries remain equal within each policy, exact
+   descriptor targets/censuses hold, and both policies execute to `5`.
+5. Direct provenance cases must prove that a copied exact-name descriptor
+   targeting the recorded allocator is removable; the same exact name
+   targeting a different user allocator survives; a near name targeting the
+   compiler allocator is not reclassified; and a recorded Date descriptor
+   renamed to `$v0` is removed before vec-name retention while a distinct user
+   `$v0` survives.
+6. A fail-closed mutation table must cover missing, duplicate, renamed, kind-
+   changed, retargeted, one-past-defined-function, and allocator-removed
+   recorded entries. Every case must fail before policy publication; no compact
+   count or prefix-only absence is acceptance evidence.
+7. Preserve the complete C37 vec and C38 constructor-closure suites, the #4616
+   Date carrier/ToPrimitive suite, and the #4035 policy suite as controls. Do
+   not edit #4035's size ceiling or call its unchanged failure a regression.
+
+Every target/tracking comparison must assert exact descriptor names and
+targets, public names, imports, runtime values, and binary parity where
+specified. The `any`-typed #4616 host-marshalling fixture remains a host
+control; standalone acceptance uses the typed probe above.
+
+### Dependencies and acceptance
+
+The open-PR, worktree, and claim audit found no C39/Date-export owner. The
+parallel Claude work is confined to callable publication and `from-ast`/
+propagation lanes. C39 intentionally overlaps only its stacked C37/C38
+`host-bridge-exports.ts` parent and must wait for PRs #5294, #5295, and #5298 to
+land before becoming ready.
+
+Acceptance requires the focused Date provenance suite, complete C37 vec and
+C38 closure suites, #4616 Date controls, and the unchanged #4035 control
+result; TypeScript 7 and 5; Prettier/Biome and `git diff --check`; IR fallback,
+issue integrity, IR layering/readiness, and applicable oracle/coercion/dead-
+export ratchets. Run every heavy command only after a finite, non-negative
+one-minute load sample is strictly below `logical cores - 2`. Immediately
+before every signed commit, run both LOC and function regrowth ratchets, then
+let all precommit and prepush hooks run without bypass. No baseline, size, LOC,
+function, or hook exception is authorized.
+
+Luna Max may implement only the authorized surface above. Before the stacked
+PR leaves draft, an independent Sol must review its exact pushed SHA and return
+**APPROVE** for the three-entry census, live/stable target regimes, fail-closed
+mutation boundary, cross-namespace ordering, target matrix, parent ancestry,
+and non-overlap with the Claude lane. Any later push invalidates approval.

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -3838,3 +3838,110 @@ strictly below `logical cores - 2`; keep complete precommit and prepush hooks
 enabled. No baseline, LOC, function-size, binary-size, size-ceiling, or hook
 exception is authorized. The stacked PR remains draft until an independent Sol
 approves its exact pushed SHA; any later push invalidates that approval.
+
+## 2026-08-30 C38 implementation lock — constructor-closure export provenance
+
+This Sol-authored checkpoint is stacked only on the current signed C37 head
+`a75f7d6d3c9364039268f64ad1ede5ab4cb4101b` (draft PR #5295). Develop it on
+`codex/3520-c38-ctor-closure-export-provenance`; never amend or push C37, C36,
+or their queued parents. Re-anchor to refreshed main and repeat the complete
+validation/review cycle only after every parent is an exact ancestor. The
+unchanged #4035 size ceiling remains a control, not a new regression claim.
+
+### Deterministic false-pass
+
+#4661 added closure-host-bridge availability bit 17 with logical export
+`__is_ctor_closure` and compact family `$ch`. `stripHostBridgeExports(...)`
+still recognizes only `$c0` through `$cg`; none of its prefixes matches
+`__is_ctor_closure`. When `constructibleClosureTypeIdxs` is populated, both
+compiler-owned exports therefore survive `emitHostBridge=false` in standalone
+and WASI, retaining the classifier and its types through DCE. The closure ABI
+test also stops its physical census at `$cg`, and #4035's marker list omits both
+names, so the leak currently passes every control.
+
+Do not repair this by adding the two spellings to the legacy strip table. That
+would delete genuine user exports and repeat the ownership bug C37 just closed.
+
+### Exact ownership and provenance contract
+
+Own only:
+
+- this issue record;
+- `src/codegen/closure-exports.ts`;
+- `src/codegen/host-bridge-exports.ts`; and
+- `tests/issue-3520-closure-host-bridge-abi.test.ts`.
+
+At bit 17 publication, retain each compiler-published `WasmExport` descriptor
+beside the exact `WasmFunction` already captured for the availability manifest.
+Export one predicate for the bounded shared namespace: exact
+`__is_ctor_closure`, or `$ch` followed by zero or more literal `$` characters.
+Near spellings such as `$ch0`, `$chi`, `$ch_extra`, and
+`__is_ctor_closure_extra` are not in this namespace.
+
+Authenticate an entry as compiler-owned when it is one recorded bit-17
+descriptor, regardless of later spelling, or when a replacement/copy in the
+exact namespace is a function descriptor resolving to the captured allocator
+object. Resolve live descriptors using the current module function-import
+prefix; resolve stable handles with `definedFuncAt`. Never fall through from an
+invalid live lookup to the stable regime, repair an index, consult `funcMap`, or
+infer ownership from spelling alone. A same-spelled descriptor targeting a
+different user allocator remains user-owned. A near-spelled descriptor is not
+inferred compiler-owned merely because it targets the classifier.
+
+`stripHostBridgeExports(...)` must remove authenticated bit-17 entries first,
+then retain noncompiler entries in the exact constructor-closure namespace,
+then apply the existing legacy host-bridge name policy unchanged. This order
+must coexist with C37's vec provenance branch without coupling the two
+registries. Do not change closure allocation, manifest bits/table layout,
+Program ABI role/ordinal 14, runtime lookup, collision suffix allocation, any
+other closure family, direct/IR routing, or fallback.
+
+### Required focused matrix
+
+1. In host mode and `hostBridge: "always"`, prove the logical and terminal
+   physical compiler descriptors resolve to the same exact allocator, the
+   availability manifest binds bit 17, and the Program ABI entry remains
+   closure-host-bridge derived ordinal 14.
+2. In standalone and WASI, with tracking disabled and enabled, compile a
+   constructible-closure fixture and require compiler `__is_ctor_closure` and
+   every `$ch` family member to be absent, host imports empty, tracked/untracked
+   binaries byte-identical, the complete public-name census exact, and the
+   fixture's runtime value unchanged.
+3. Add user collisions for `__is_ctor_closure`, `$ch`, and sparse `$ch$$`.
+   Standalone/WASI must preserve their exact values while removing generated
+   gap/terminal aliases. Host mode must preserve all user values and publish
+   the compiler classifier only at free suffixes, with exact allocator joins.
+4. In a fixture with no constructible closure, exact user logical/physical
+   spoof exports survive standalone/WASI and no ordinal-14 Program ABI row or
+   constructor-classifier family is created.
+5. Direct mutations must prove: a copied descriptor targeting the classifier
+   remains removable; the same spelling targeting a different user allocator
+   survives; a near-prefix targeting the classifier is not reclassified; and
+   recorded name/kind/target/lost-function/duplicate mutations still fail
+   closed before final publication.
+6. Preserve the complete C31 closure suite, C37 vec suite, and #4035 policy
+   suite as controls. Update a marker/census only if required to make the
+   existing test truthful; do not change #4035's ceiling or characterize the
+   already-present leak as a new size regression.
+
+Every target/tracking comparison must publish exact names, descriptor targets,
+runtime values, import census, and binary parity where specified. Prefix-only
+absence and compact counts are not acceptance evidence.
+
+### Dependencies and acceptance
+
+The open-PR and worktree audit found no other owner of `closure-exports.ts` or
+the focused closure ABI test; the visible Claude lane is confined to #3521.
+This intentional child overlaps only `host-bridge-exports.ts` in its C37 base.
+Any newly observed overlap is a stop-and-report condition.
+
+Acceptance requires the focused closure and vec suites, #4035 policy controls,
+TypeScript 7, Prettier/Biome and `git diff --check`, IR fallback and issue
+integrity, IR layering/readiness, and applicable oracle/coercion/dead-export
+ratchets. Run every heavy command only after a finite, non-negative one-minute
+load sample is strictly below `logical cores - 2`. Immediately before every
+signed commit run both LOC and function regrowth ratchets, then let all
+precommit and prepush hooks run without bypass. No baseline, size, LOC,
+function, or hook exception is authorized. A Luna implementation remains draft
+until a separate Sol approves the exact pushed SHA; any later push invalidates
+that approval.

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -8,7 +8,8 @@
 // (generateModule), which imports these back.
 
 import { ts } from "../ts-api.js";
-import type { FuncTypeDef, Instr, ValType, WasmFunction } from "../ir/types.js";
+import { STABLE_FUNC_BASE } from "../emit/resolve-layout.js";
+import type { FuncTypeDef, Instr, ValType, WasmExport, WasmFunction } from "../ir/types.js";
 import type { ClosureInfo, CodegenContext } from "./context/types.js";
 import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
 import { addUnionImports } from "./registry/imports.js";
@@ -36,7 +37,7 @@ import {
 } from "./program-abi-planning.js";
 import { recordClosureArgcDispatcher } from "./compiler-support-abi.js";
 import { DATA_STRUCT_HOST_BRIDGE_ORDINAL, publishDataStructHostBridge } from "./data-struct-host-bridge.js";
-import { definedFuncHandleOf } from "./func-space.js";
+import { definedFuncAt, definedFuncHandleOf } from "./func-space.js";
 import {
   STANDALONE_TIMER_CALLBACK_BINDINGS_EXPORT,
   STANDALONE_TIMER_CALLBACK_BINDINGS_PHYSICAL_BASE,
@@ -59,6 +60,15 @@ const CLOSURE_HOST_BRIDGE_BINDINGS_PHYSICAL_BASE = "$cu";
 const CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC = 0x5a200000;
 const publishedClosureHostBridgeBits = new WeakMap<CodegenContext, number>();
 const publishedClosureHostBridgeFuncs = new WeakMap<CodegenContext, Map<number, WasmFunction>>();
+interface PublishedCtorClosureHostBridgeExport {
+  readonly entry: WasmExport;
+  readonly name: string;
+  readonly func: WasmFunction;
+}
+const publishedCtorClosureHostBridgeExports = new WeakMap<
+  CodegenContext,
+  readonly PublishedCtorClosureHostBridgeExport[]
+>();
 const publishedClosureHostBridgeManifests = new WeakSet<CodegenContext>();
 const publishedStandaloneTimerCallbackManifests = new WeakSet<CodegenContext>();
 
@@ -133,6 +143,16 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
   const definition = closureHostBridgeDefinition(func.name);
   const occupied = new Set(ctx.mod.exports.map((entry) => entry.name));
   const physicalBase = definition.physicalBase;
+  const publishedCtorExports: PublishedCtorClosureHostBridgeExport[] | undefined =
+    definition.bit === 17 ? [] : undefined;
+  const publishExport = (name: string): void => {
+    const entry: WasmExport = {
+      name,
+      desc: { kind: "func", index: funcIdx },
+    };
+    ctx.mod.exports.push(entry);
+    publishedCtorExports?.push(Object.freeze({ entry, name, func }));
+  };
   let maxOccupiedSuffix = -1;
   for (const name of occupied) {
     if (!name.startsWith(physicalBase)) continue;
@@ -141,19 +161,13 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
   }
   const logicalNameOccupied = occupied.has(func.name);
   if (!logicalNameOccupied) {
-    ctx.mod.exports.push({
-      name: func.name,
-      desc: { kind: "func", index: funcIdx },
-    });
+    publishExport(func.name);
     occupied.add(func.name);
   }
   for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
     const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
     if (occupied.has(physicalName)) continue;
-    ctx.mod.exports.push({
-      name: physicalName,
-      desc: { kind: "func", index: funcIdx },
-    });
+    publishExport(physicalName);
     occupied.add(physicalName);
   }
   publishedClosureHostBridgeBits.set(ctx, (publishedClosureHostBridgeBits.get(ctx) ?? 0) | (1 << definition.bit));
@@ -163,7 +177,87 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
     publishedClosureHostBridgeFuncs.set(ctx, publishedFuncs);
   }
   publishedFuncs.set(definition.bit, func);
+  if (publishedCtorExports) {
+    if (publishedCtorClosureHostBridgeExports.has(ctx)) {
+      throw new Error("constructor-closure host bridge exports were published more than once");
+    }
+    publishedCtorClosureHostBridgeExports.set(ctx, Object.freeze(publishedCtorExports));
+  }
   return funcIdx;
+}
+
+/**
+ * Exact public names reserved by the bit-17 constructor-closure classifier.
+ *
+ * The logical spelling is one exact name. Its compact physical family is the
+ * base `$ch` followed only by literal `$` suffixes; near-prefix user exports
+ * such as `$ch0` and `$ch_extra` are deliberately outside this namespace.
+ */
+export function isCoreCtorClosureHostBridgePublicName(name: string): boolean {
+  return name === "__is_ctor_closure" || (name.startsWith("$ch") && /^\$*$/.test(name.slice("$ch".length)));
+}
+
+/** Resolve a constructor-closure descriptor under its exact handle regime. */
+function resolveCtorClosureHostBridgeExportTarget(ctx: CodegenContext, entry: WasmExport): WasmFunction | undefined {
+  if (entry.desc.kind !== "func") return undefined;
+  if (entry.desc.index < STABLE_FUNC_BASE) {
+    const currentImportCount = ctx.mod.imports.filter((candidate) => candidate.desc.kind === "func").length;
+    const currentPosition = entry.desc.index - currentImportCount;
+    return currentPosition < 0 ? undefined : ctx.mod.functions[currentPosition];
+  }
+  return definedFuncAt(ctx, entry.desc.index);
+}
+
+/**
+ * Authenticate a constructor-closure export by descriptor provenance.
+ *
+ * A compiler descriptor is authoritative by object identity. A copied
+ * descriptor may still be authenticated only inside the bounded namespace,
+ * and only when its live or stable handle resolves to the exact classifier
+ * allocator captured at publication.
+ */
+export function isCompilerOwnedCtorClosureHostBridgeExport(ctx: CodegenContext, entry: WasmExport): boolean {
+  const published = publishedCtorClosureHostBridgeExports.get(ctx);
+  if (!published) return false;
+  if (published.some((candidate) => candidate.entry === entry)) return true;
+  if (!isCoreCtorClosureHostBridgePublicName(entry.name)) return false;
+  const target = resolveCtorClosureHostBridgeExportTarget(ctx, entry);
+  return target !== undefined && published.some((candidate) => candidate.func === target);
+}
+
+/**
+ * Validate every recorded bit-17 descriptor before the availability manifest
+ * is frozen. This is the mutation boundary: replacing, duplicating, renaming,
+ * retargeting, changing kind, or removing the allocator cannot be repaired by
+ * the later export sink.
+ */
+export function finalizeCtorClosureHostBridgeExports(ctx: CodegenContext): void {
+  const published = publishedCtorClosureHostBridgeExports.get(ctx);
+  if (!published) return;
+  for (const { entry, name, func } of published) {
+    if (ctx.mod.exports.indexOf(entry) < 0) {
+      throw new Error(`constructor-closure host bridge export descriptor ${name} disappeared before finalization`);
+    }
+    if (ctx.mod.exports.indexOf(entry) !== ctx.mod.exports.lastIndexOf(entry)) {
+      throw new Error(`constructor-closure host bridge export descriptor ${name} appears more than once in the module`);
+    }
+    if (entry.name !== name) {
+      throw new Error(
+        `constructor-closure host bridge export descriptor ${name} changed its published name to ${entry.name}`,
+      );
+    }
+    if (entry.desc.kind !== "func") {
+      throw new Error(`constructor-closure host bridge export descriptor ${name} changed kind to ${entry.desc.kind}`);
+    }
+    if (!ctx.mod.functions.includes(func)) {
+      throw new Error(`constructor-closure host bridge export descriptor ${name} lost its allocator function`);
+    }
+    if (resolveCtorClosureHostBridgeExportTarget(ctx, entry) !== func) {
+      throw new Error(
+        `constructor-closure host bridge export descriptor ${name} resolves to a different allocator function`,
+      );
+    }
+  }
 }
 
 /**

--- a/src/codegen/date-host-bridge.ts
+++ b/src/codegen/date-host-bridge.ts
@@ -1,9 +1,21 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
+import { STABLE_FUNC_BASE } from "../emit/resolve-layout.js";
+import type { Instr, WasmExport, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt } from "./func-space.js";
 import { addFuncType } from "./registry/types.js";
 
-const emitted = new WeakSet<CodegenContext>();
+const DATE_HOST_BRIDGE_NAMES = Object.freeze(["__\0js2_is_date", "__\0js2_date_value", "__\0js2_date_set_value"]);
+
+interface DateHostBridgePublishedExport {
+  readonly entry: WasmExport;
+  readonly name: string;
+  readonly func: WasmFunction;
+}
+
+const dateHostBridgePublishedExports = new WeakMap<CodegenContext, readonly DateHostBridgePublishedExport[]>();
+const dateHostBridgeFinalized = new WeakSet<CodegenContext>();
 
 /**
  * Expose the native `$__Date` carrier to the JS host method bridge.
@@ -14,28 +26,39 @@ const emitted = new WeakSet<CodegenContext>();
  * carrier without mistaking an ordinary `{ timestamp }` object for a Date.
  */
 export function emitDateHostBridge(ctx: CodegenContext): void {
-  if (emitted.has(ctx)) return;
+  if (dateHostBridgePublishedExports.has(ctx)) return;
   const dateTypeIdx = ctx.structMap.get("__Date");
   if (dateTypeIdx === undefined) return;
-  emitted.add(ctx);
 
   const publish = (
     name: string,
     params: Parameters<typeof addFuncType>[1],
     results: Parameters<typeof addFuncType>[2],
-    body: import("../ir/types.js").Instr[],
+    body: Instr[],
+    published: DateHostBridgePublishedExport[],
   ): void => {
     const typeIdx = addFuncType(ctx, params, results, `$${name}_type`);
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({ name, typeIdx, locals: [], body, exported: true });
-    ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
+    const func: WasmFunction = {
+      name,
+      typeIdx,
+      locals: [],
+      body,
+      exported: true,
+    };
+    const entry: WasmExport = { name, desc: { kind: "func", index: funcIdx } };
+    ctx.mod.functions.push(func);
+    ctx.mod.exports.push(entry);
+    published.push({ entry, name, func });
   };
 
+  const published: DateHostBridgePublishedExport[] = [];
   publish(
     "__\0js2_is_date",
     [{ kind: "externref" }],
     [{ kind: "i32" }],
     [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "ref.test", typeIdx: dateTypeIdx }],
+    published,
   );
   publish(
     "__\0js2_date_value",
@@ -47,6 +70,7 @@ export function emitDateHostBridge(ctx: CodegenContext): void {
       { op: "ref.cast", typeIdx: dateTypeIdx },
       { op: "struct.get", typeIdx: dateTypeIdx, fieldIdx: 0 },
     ],
+    published,
   );
   publish(
     "__\0js2_date_set_value",
@@ -57,5 +81,109 @@ export function emitDateHostBridge(ctx: CodegenContext): void {
       { op: "local.get", index: 1 },
       { op: "struct.set", typeIdx: dateTypeIdx, fieldIdx: 0 },
     ],
+    published,
   );
+  if (published.length !== DATE_HOST_BRIDGE_NAMES.length) {
+    throw new Error(
+      `Date host bridge published ${published.length} entries, expected ${DATE_HOST_BRIDGE_NAMES.length}`,
+    );
+  }
+  dateHostBridgePublishedExports.set(ctx, Object.freeze(published));
+}
+
+/** Exact logical and compact names owned by the three-entry Date bridge. */
+export function isCoreDateHostBridgePublicName(name: string): boolean {
+  return DATE_HOST_BRIDGE_NAMES.includes(name);
+}
+
+/**
+ * Resolve a Date bridge export through its current descriptor regime.
+ *
+ * Live handles are interpreted against the CURRENT function-import prefix. A
+ * failed live lookup is deliberately terminal: it must not fall through to a
+ * stable lookup or a name-keyed reconstruction. Stable handles use the
+ * registry-owned `definedFuncAt` path instead.
+ */
+function resolveDateHostBridgeExportTarget(ctx: CodegenContext, entry: WasmExport): WasmFunction | undefined {
+  if (entry.desc.kind !== "func") return undefined;
+  if (entry.desc.index >= STABLE_FUNC_BASE) return definedFuncAt(ctx, entry.desc.index);
+  const currentImportCount = ctx.mod.imports.filter((candidate) => candidate.desc.kind === "func").length;
+  const currentPosition = entry.desc.index - currentImportCount;
+  return currentPosition < 0 ? undefined : ctx.mod.functions[currentPosition];
+}
+
+/**
+ * Authenticate a Date bridge export by exact descriptor provenance.
+ *
+ * The recorded descriptor object is authoritative. A copied descriptor is
+ * removable only in the bounded Date namespace and only when its live/stable
+ * target resolves to the exact allocator captured at publication.
+ */
+export function isCompilerOwnedDateHostBridgeExport(ctx: CodegenContext, entry: WasmExport): boolean {
+  const published = dateHostBridgePublishedExports.get(ctx);
+  if (!published) return false;
+  if (published.some((candidate) => candidate.entry === entry)) return true;
+  if (!isCoreDateHostBridgePublicName(entry.name)) return false;
+  const target = resolveDateHostBridgeExportTarget(ctx, entry);
+  return target !== undefined && published.some((candidate) => candidate.func === target);
+}
+
+/**
+ * Validate the complete Date provenance census before host-bridge policy runs.
+ * This is an authentication-only boundary: a malformed descriptor cannot be
+ * repaired or leave a partially rewritten export section behind.
+ */
+export function finalizeDateHostBridgeExports(ctx: CodegenContext): void {
+  const published = dateHostBridgePublishedExports.get(ctx);
+  if (!published) return;
+  if (dateHostBridgeFinalized.has(ctx)) return;
+  if (published.length !== DATE_HOST_BRIDGE_NAMES.length) {
+    throw new Error(`Date host bridge census is incomplete: ${published.length} of ${DATE_HOST_BRIDGE_NAMES.length}`);
+  }
+
+  const seenEntries = new Set<WasmExport>();
+  const seenNames = new Set<string>();
+
+  for (const { entry, name, func } of published) {
+    if (seenEntries.has(entry)) {
+      throw new Error(`Date host bridge descriptor ${name} is recorded more than once`);
+    }
+    seenEntries.add(entry);
+    if (seenNames.has(name)) {
+      throw new Error(`Date host bridge census records name ${name} more than once`);
+    }
+    seenNames.add(name);
+    if (!isCoreDateHostBridgePublicName(name)) {
+      throw new Error(`Date host bridge census contains unknown name ${name}`);
+    }
+    if (ctx.mod.exports.indexOf(entry) < 0) {
+      throw new Error(`Date host bridge export descriptor ${name} disappeared before finalization`);
+    }
+    if (ctx.mod.exports.indexOf(entry) !== ctx.mod.exports.lastIndexOf(entry)) {
+      throw new Error(`Date host bridge export descriptor ${name} appears more than once in the module`);
+    }
+    if (entry.name !== name) {
+      throw new Error(`Date host bridge export descriptor ${name} changed its published name to ${entry.name}`);
+    }
+    if (entry.desc.kind !== "func") {
+      throw new Error(`Date host bridge export descriptor ${name} changed kind to ${entry.desc.kind}`);
+    }
+    if (ctx.mod.functions.indexOf(func) < 0) {
+      throw new Error(`Date host bridge export descriptor ${name} lost its allocator function`);
+    }
+    if (ctx.mod.functions.indexOf(func) !== ctx.mod.functions.lastIndexOf(func)) {
+      throw new Error(`Date host bridge allocator for ${name} appears more than once in the module`);
+    }
+    if (resolveDateHostBridgeExportTarget(ctx, entry) !== func) {
+      throw new Error(`Date host bridge export descriptor ${name} resolves to a different allocator function`);
+    }
+  }
+
+  if (seenNames.size !== DATE_HOST_BRIDGE_NAMES.length || DATE_HOST_BRIDGE_NAMES.some((name) => !seenNames.has(name))) {
+    throw new Error("Date host bridge census is incomplete or contains duplicate names");
+  }
+  // The live descriptor is already maintained by the normal import-shifting
+  // machinery. This provenance sink authenticates it; it must never repair an
+  // index or substitute a reconstructed one after validation.
+  dateHostBridgeFinalized.add(ctx);
 }

--- a/src/codegen/host-bridge-exports.ts
+++ b/src/codegen/host-bridge-exports.ts
@@ -24,12 +24,17 @@
 // spread the policy across the codegen and risk a partially-built bridge.
 
 import type { WasmModule } from "../ir/types.js";
-import type { CodegenContext } from "./context/types.js";
 import {
   finalizeCtorClosureHostBridgeExports,
   isCompilerOwnedCtorClosureHostBridgeExport,
   isCoreCtorClosureHostBridgePublicName,
 } from "./closure-exports.js";
+import type { CodegenContext } from "./context/types.js";
+import {
+  finalizeDateHostBridgeExports,
+  isCompilerOwnedDateHostBridgeExport,
+  isCoreDateHostBridgePublicName,
+} from "./date-host-bridge.js";
 import { isCompilerOwnedVecHostBridgeExport, isCoreVecHostBridgePublicName } from "./vec-access-exports.js";
 
 /**
@@ -106,17 +111,25 @@ export function stripHostBridgeExports(ctx: CodegenContext): number {
   // recorded constructor descriptors there, while allowing post-generation
   // callers to exercise the provenance sink with copied descriptors.
   if (!ctx.indexSpaceFrozen) finalizeCtorClosureHostBridgeExports(ctx);
+  // Date provenance is exact-once: a post-finalization rename into another
+  // shared namespace remains removable by descriptor identity, while every
+  // ordinary policy decision is preceded by the initial full census check.
+  finalizeDateHostBridgeExports(ctx);
   if (ctx.emitHostBridge) return 0;
   const mod: WasmModule = ctx.mod;
   const before = mod.exports.length;
   mod.exports = mod.exports.filter((ex) => {
     // Authenticate recorded provenance before consulting either shared public
-    // namespace. A recorded constructor descriptor can be copied or renamed
-    // into the vec family by a late mutation; its identity must still win over
-    // the vec name-retention rule. The same ordering keeps the two sinks
-    // symmetric for cross-namespace descriptor mutations.
+    // namespace. A recorded Date or constructor descriptor can be copied or
+    // renamed into another shared family by a late mutation; its identity must
+    // still win over the public-name retention rule.
+    if (isCompilerOwnedDateHostBridgeExport(ctx, ex)) return false;
     if (isCompilerOwnedCtorClosureHostBridgeExport(ctx, ex)) return false;
     if (isCompilerOwnedVecHostBridgeExport(ctx, ex)) return false;
+    // Exact Date names are a shared public namespace: only exact compiler
+    // provenance authorizes removal in standalone/WASI. A user descriptor
+    // with one of these spellings remains public.
+    if (isCoreDateHostBridgePublicName(ex.name)) return true;
     // Core vec names are a shared public namespace: only exact compiler
     // provenance authorizes removal. A user export with a matching spelling
     // must survive standalone/WASI stripping.

--- a/src/codegen/host-bridge-exports.ts
+++ b/src/codegen/host-bridge-exports.ts
@@ -25,6 +25,11 @@
 
 import type { WasmModule } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import {
+  finalizeCtorClosureHostBridgeExports,
+  isCompilerOwnedCtorClosureHostBridgeExport,
+  isCoreCtorClosureHostBridgePublicName,
+} from "./closure-exports.js";
 import { isCompilerOwnedVecHostBridgeExport, isCoreVecHostBridgePublicName } from "./vec-access-exports.js";
 
 /**
@@ -97,15 +102,29 @@ export function isHostBridgeExportName(name: string): boolean {
  * pure-Wasm host still needs to catch), and every user export.
  */
 export function stripHostBridgeExports(ctx: CodegenContext): number {
+  // The internal policy sink runs before index-space freeze. Validate the
+  // recorded constructor descriptors there, while allowing post-generation
+  // callers to exercise the provenance sink with copied descriptors.
+  if (!ctx.indexSpaceFrozen) finalizeCtorClosureHostBridgeExports(ctx);
   if (ctx.emitHostBridge) return 0;
   const mod: WasmModule = ctx.mod;
   const before = mod.exports.length;
   mod.exports = mod.exports.filter((ex) => {
+    // Authenticate recorded provenance before consulting either shared public
+    // namespace. A recorded constructor descriptor can be copied or renamed
+    // into the vec family by a late mutation; its identity must still win over
+    // the vec name-retention rule. The same ordering keeps the two sinks
+    // symmetric for cross-namespace descriptor mutations.
+    if (isCompilerOwnedCtorClosureHostBridgeExport(ctx, ex)) return false;
     if (isCompilerOwnedVecHostBridgeExport(ctx, ex)) return false;
     // Core vec names are a shared public namespace: only exact compiler
     // provenance authorizes removal. A user export with a matching spelling
     // must survive standalone/WASI stripping.
     if (isCoreVecHostBridgePublicName(ex.name)) return true;
+    // Constructor-closure names are a separate shared namespace: only the
+    // recorded bit-17 descriptor or an exact allocator join authorizes
+    // removal. A same-spelled user export must survive standalone/WASI.
+    if (isCoreCtorClosureHostBridgePublicName(ex.name)) return true;
     return !isHostBridgeExportName(ex.name);
   });
   return before - mod.exports.length;

--- a/src/codegen/host-bridge-exports.ts
+++ b/src/codegen/host-bridge-exports.ts
@@ -25,7 +25,7 @@
 
 import type { WasmModule } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
-import { isCompilerOwnedVecHostBridgeExport } from "./vec-access-exports.js";
+import { isCompilerOwnedVecHostBridgeExport, isCoreVecHostBridgePublicName } from "./vec-access-exports.js";
 
 /**
  * Export-name prefixes owned by the bridge. Short aliases (`$v0`, `$c0`, `$d0`,
@@ -100,8 +100,13 @@ export function stripHostBridgeExports(ctx: CodegenContext): number {
   if (ctx.emitHostBridge) return 0;
   const mod: WasmModule = ctx.mod;
   const before = mod.exports.length;
-  mod.exports = mod.exports.filter(
-    (ex) => !isCompilerOwnedVecHostBridgeExport(ctx, ex) && !isHostBridgeExportName(ex.name),
-  );
+  mod.exports = mod.exports.filter((ex) => {
+    if (isCompilerOwnedVecHostBridgeExport(ctx, ex)) return false;
+    // Core vec names are a shared public namespace: only exact compiler
+    // provenance authorizes removal. A user export with a matching spelling
+    // must survive standalone/WASI stripping.
+    if (isCoreVecHostBridgePublicName(ex.name)) return true;
+    return !isHostBridgeExportName(ex.name);
+  });
   return before - mod.exports.length;
 }

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -128,6 +128,33 @@ const vecHostBridgeAllocations = new WeakMap<CodegenContext, ReadonlyMap<VecHost
 const vecHostBridgePublishedExports = new WeakMap<CodegenContext, readonly VecHostBridgePublishedExport[]>();
 
 /**
+ * Exact public names reserved by the six core vec bridge helpers.
+ *
+ * The logical names are compiler-owned only when their descriptor provenance
+ * says so. The physical `$v<ordinal>` family has the same rule, including
+ * only literal `$` suffixes; a near-prefix such as `$v00` or `$v0x` is a
+ * normal user export and must not enter this namespace.
+ */
+export function isCoreVecHostBridgePublicName(name: string): boolean {
+  return VEC_HOST_BRIDGE_DEFINITIONS.some((definition) => {
+    if (name === definition.name) return true;
+    const physicalBase = `$v${definition.ordinal}`;
+    return name.startsWith(physicalBase) && /^\$*$/.test(name.slice(physicalBase.length));
+  });
+}
+
+/** Resolve a public function descriptor under C36's two handle regimes. */
+function resolveVecHostBridgeExportTarget(ctx: CodegenContext, entry: WasmExport): WasmFunction | undefined {
+  if (entry.desc.kind !== "func") return undefined;
+  if (entry.desc.index < STABLE_FUNC_BASE) {
+    const currentImportCount = ctx.mod.imports.filter((candidate) => candidate.desc.kind === "func").length;
+    const currentPosition = entry.desc.index - currentImportCount;
+    return currentPosition < 0 ? undefined : ctx.mod.functions[currentPosition];
+  }
+  return definedFuncAt(ctx, entry.desc.index);
+}
+
+/**
  * Authenticate one export descriptor as a compiler-published core vec bridge.
  *
  * Standalone/WASI stripping must use descriptor identity rather than widening
@@ -135,7 +162,16 @@ const vecHostBridgePublishedExports = new WeakMap<CodegenContext, readonly VecHo
  * and those same suffixes remain a valid user-export namespace.
  */
 export function isCompilerOwnedVecHostBridgeExport(ctx: CodegenContext, entry: WasmExport): boolean {
-  return vecHostBridgePublishedExports.get(ctx)?.some((published) => published.entry === entry) ?? false;
+  const published = vecHostBridgePublishedExports.get(ctx);
+  if (!published) return false;
+  if (published.some((candidate) => candidate.entry === entry)) return true;
+  // A copied descriptor is still compiler-owned when it resolves to the exact
+  // allocator object captured at publication. Restrict this inference to the
+  // bounded core namespace so an arbitrary user alias cannot become a bridge
+  // export merely by targeting a compiler helper.
+  if (!isCoreVecHostBridgePublicName(entry.name)) return false;
+  const target = resolveVecHostBridgeExportTarget(ctx, entry);
+  return target !== undefined && published.some((candidate) => candidate.allocation.func === target);
 }
 
 function vecHostBridgeDefinition(kind: VecHostBridgeKind): VecHostBridgeDefinition {
@@ -320,8 +356,7 @@ export function finalizeVecHostBridgeExports(ctx: CodegenContext): void {
     if (currentPosition < 0) {
       throw new Error(`vec host bridge export descriptor ${name} resolves to a function import`);
     }
-    const currentAllocation =
-      entry.desc.index < STABLE_FUNC_BASE ? ctx.mod.functions[currentPosition] : definedFuncAt(ctx, entry.desc.index);
+    const currentAllocation = resolveVecHostBridgeExportTarget(ctx, entry);
     if (currentAllocation !== allocation.func) {
       throw new Error(`vec host bridge export descriptor ${name} resolves to a different allocator function`);
     }

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -3,21 +3,35 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { SINGLE_HOST_ENTRIES } from "../scripts/check-ir-only.js";
 import { analyzeSource } from "../src/checker/index.js";
 import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { stripHostBridgeExports } from "../src/codegen/host-bridge-exports.js";
 import { generateModule } from "../src/codegen/index.js";
+import {
+  finalizeCtorClosureHostBridgeExports,
+  isCompilerOwnedCtorClosureHostBridgeExport,
+  isCoreCtorClosureHostBridgePublicName,
+} from "../src/codegen/closure-exports.js";
 import {
   planProgramAbiEntrySourceSupportCallable,
   PROGRAM_ABI_CALLABLE_ROLE,
   resolveProgramAbiSupportCallableHandle,
 } from "../src/codegen/program-abi-planning.js";
+import { ProgramAbiCallableRegistry } from "../src/codegen/program-abi-callable-planning.js";
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
 import { emitBinary } from "../src/emit/binary.js";
+import { STABLE_FUNC_BASE } from "../src/emit/resolve-layout.js";
 import { buildIrUnitInventory, createIrBindingId } from "../src/ir/identity.js";
-import { createEmptyModule, type FuncTypeDef, type Import, type WasmFunction } from "../src/ir/types.js";
+import {
+  createEmptyModule,
+  type FuncTypeDef,
+  type Import,
+  type WasmExport,
+  type WasmFunction,
+} from "../src/ir/types.js";
 import { compile } from "../src/index.js";
 import { buildImports, wrapExports } from "../src/runtime.js";
 import { ts } from "../src/ts-api.js";
@@ -67,6 +81,60 @@ const CLOSURE_PHYSICAL_BASES = [
   "$ce",
   "$cf",
   "$cg",
+  "$ch",
+] as const;
+
+const CONSTRUCTIBLE_CLOSURE_SOURCE = `
+  const ctor = function (value: number): number { return value + 1; };
+  export function getCtor(): any { return ctor; }
+  export function invokeCtor(): number { return ctor(41); }
+`;
+
+const CLOSURE_COLLISION_SOURCE = `
+  export function __is_ctor_closure(): number { return 901; }
+  export function $ch(): number { return 902; }
+  export function $ch$$(): number { return 903; }
+  const ctor = function (value: number): number { return value + 1; };
+  export function getCtor(): any { return ctor; }
+  export function invokeCtor(): number { return ctor(41); }
+`;
+
+const CLOSURE_CROSS_NAMESPACE_COLLISION_SOURCE = `
+  export function $v0(): number { return 911; }
+  const ctor = function (value: number): number { return value + 1; };
+  export function getCtor(): any { return ctor; }
+  export function invokeCtor(): number { return ctor(41); }
+`;
+
+const CLOSURE_FREE_SPOOF_SOURCE = `
+  export function __is_ctor_closure(): number { return 801; }
+  export function $ch(): number { return 802; }
+  export function $ch$$(): number { return 803; }
+  export function $ch0(): number { return 804; }
+  export function $ch_extra(): number { return 805; }
+  export function __is_ctor_closure_extra(): number { return 806; }
+  export function add(): number { return 42; }
+`;
+
+const CLOSURE_STANDALONE_HELPER_EXPORTS = [
+  "__\0js2_call_fn_method_argc_1",
+  "__\0js2_call_fn_method_argc_2",
+  "__\0js2_call_fn_method_argc_3",
+  "__\0js2_call_fn_method_argc_4",
+  "__\0js2_call_fn_method_argc_5",
+  "__any_box_null",
+  "__any_box_undefined",
+  "__box_bigint",
+  "__box_boolean",
+  "__box_number",
+  "__dynamic_boundary_tag",
+  "__exn_tag",
+  "__to_bigint",
+  "__typeof_bigint",
+  "__typeof_boolean",
+  "__typeof_number",
+  "__unbox_boolean",
+  "__unbox_number",
 ] as const;
 
 const ZERO_ARITY_SOURCE = `
@@ -101,15 +169,55 @@ function hardErrors(result: ReturnType<typeof generateModule>) {
   return result.errors.filter((error) => error.severity !== "warning");
 }
 
-async function instantiate(source: string): Promise<{
+function generateWithCapturedRegistry(
+  source: string,
+  fileName: string,
+): {
+  readonly registry: ProgramAbiCallableRegistry;
+  readonly result: ReturnType<typeof generateModule>;
+} {
+  let registry: ProgramAbiCallableRegistry | undefined;
+  const originalObserve = ProgramAbiCallableRegistry.prototype.observeEntrySourceSupports;
+  const observe = vi
+    .spyOn(ProgramAbiCallableRegistry.prototype, "observeEntrySourceSupports")
+    .mockImplementation(function (observations) {
+      registry = this;
+      return originalObserve.call(this, observations);
+    });
+  let result: ReturnType<typeof generateModule>;
+  try {
+    // Keep a real vec support observation in this focused harness so the
+    // generated context is available for direct provenance mutation checks.
+    // The probe is unrelated to the constructor helper under test.
+    const sourceWithRegistryProbe = `${source}
+      export function __c38_registry_probe(): number {
+        const values: any = [1];
+        values.push(2);
+        values.pop();
+        return values[0];
+      }
+    `;
+    const ast = analyzeSource(sourceWithRegistryProbe, fileName);
+    result = generateModule(ast, { experimentalIR: true, trackIrOutcomes: true });
+  } finally {
+    observe.mockRestore();
+  }
+  if (!registry) throw new Error(`missing closure Program ABI session for ${fileName}`);
+  return { registry, result: result! };
+}
+
+async function instantiate(sourceOrResult: string | Awaited<ReturnType<typeof compile>>): Promise<{
   readonly exports: Record<string, unknown>;
   readonly result: Awaited<ReturnType<typeof compile>>;
 }> {
-  const result = await compile(source, {
-    fileName: "issue-3520-closure-host-runtime.ts",
-    experimentalIR: true,
-    trackIrOutcomes: true,
-  });
+  const result =
+    typeof sourceOrResult === "string"
+      ? await compile(sourceOrResult, {
+          fileName: "issue-3520-closure-host-runtime.ts",
+          experimentalIR: true,
+          trackIrOutcomes: true,
+        })
+      : sourceOrResult;
   expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
   const imports = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown> & {
     env?: Record<string, unknown>;
@@ -123,6 +231,230 @@ async function instantiate(source: string): Promise<{
 }
 
 describe("#3520 C31 closure host bridge Program ABI ownership", () => {
+  it("classifies only exact constructor-closure logical and physical names", () => {
+    expect(isCoreCtorClosureHostBridgePublicName("__is_ctor_closure")).toBe(true);
+    expect(["$ch", "$ch$", "$ch$$", "$ch$$$$"].every(isCoreCtorClosureHostBridgePublicName)).toBe(true);
+    expect(
+      ["$ch0", "$chi", "$ch_extra", "__is_ctor_closure_extra", "__is_ctor_closure$"].some(
+        isCoreCtorClosureHostBridgePublicName,
+      ),
+    ).toBe(false);
+  });
+
+  it("publishes the bit-17 classifier under ordinal 14 and binds its exact allocator", async () => {
+    const result = trackedModule(CONSTRUCTIBLE_CLOSURE_SOURCE);
+    expect(
+      hardErrors(result),
+      hardErrors(result)
+        .map((error) => error.message)
+        .join("\n"),
+    ).toEqual([]);
+    const entrySource = entrySourceRecord(CONSTRUCTIBLE_CLOSURE_SOURCE);
+    const expectedId = createIrBindingId({
+      ownerId: entrySource.id,
+      domain: "support",
+      role: CLOSURE_HOST_BRIDGE_ROLE,
+      ordinal: 14,
+    });
+    expect(result.programAbi!.abi.get(expectedId)).toMatchObject({
+      id: expectedId,
+      displayName: "__is_ctor_closure",
+      slotPolicy: "required",
+      slotSpace: "function",
+      intent: {
+        kind: "callable",
+        origin: "support",
+        sourceId: entrySource.id,
+      },
+    });
+
+    const exportsByName = new Map(result.module.exports.map((entry) => [entry.name, entry]));
+    const logical = exportsByName.get("__is_ctor_closure");
+    const physical = exportsByName.get("$ch");
+    expect(logical?.desc).toEqual(physical?.desc);
+    if (!logical || logical.desc.kind !== "func") throw new Error("missing logical constructor classifier");
+    const importCount = result.module.imports.filter((entry) => entry.desc.kind === "func").length;
+    expect(result.module.functions[logical.desc.index - importCount]?.name).toBe("__is_ctor_closure");
+    const finalSlot = result.programAbi!.abi.resolveFinalIndex(expectedId);
+    expect(finalSlot).toEqual({ space: "function", index: logical.desc.index });
+
+    for (const [label, options] of [
+      ["default", {}],
+      ["always", { hostBridge: "always" as const }],
+    ] as const) {
+      const compiled = await compile(CONSTRUCTIBLE_CLOSURE_SOURCE, {
+        fileName: `issue-3520-closure-ctor-${label}.ts`,
+        experimentalIR: true,
+        ...options,
+      });
+      const { exports: rawExports } = await instantiate(compiled);
+      expect(rawExports.__is_ctor_closure, label).toBe(rawExports.$ch);
+      expect(rawExports.__is_ctor_closure, label).toEqual(expect.any(Function));
+      const manifest = rawExports.$cm;
+      expect(manifest).toBeInstanceOf(WebAssembly.Global);
+      expect((manifest as WebAssembly.Global).value & (1 << 17), label).not.toBe(0);
+      const ctor = (rawExports.getCtor as () => unknown)();
+      expect((rawExports.__is_ctor_closure as (value: unknown) => number)(ctor), label).toBe(1);
+      expect((rawExports.invokeCtor as () => number)(), label).toBe(42);
+    }
+  });
+
+  it("strips compiler constructor-closure exports in standalone and WASI with exact parity", async () => {
+    const expectedNames = [...CLOSURE_STANDALONE_HELPER_EXPORTS, "getCtor", "invokeCtor"];
+    for (const target of ["standalone", "wasi"] as const) {
+      const options = {
+        fileName: `issue-3520-closure-ctor-${target}.ts`,
+        experimentalIR: true,
+        target,
+      } as const;
+      const untracked = await compile(CONSTRUCTIBLE_CLOSURE_SOURCE, options);
+      const tracked = await compile(CONSTRUCTIBLE_CLOSURE_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target} untracked`).toBe(true);
+      expect(tracked.success, `${target} tracked`).toBe(true);
+      expect(untracked.imports, `${target} untracked imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+
+      const targetExpectedNames = [...expectedNames, ...(target === "wasi" ? ["_start", "memory"] : [])].sort();
+      for (const [label, result] of [
+        ["untracked", untracked],
+        ["tracked", tracked],
+      ] as const) {
+        const { exports: rawExports } = await instantiate(result);
+        expect(Object.keys(rawExports).sort(), `${target} ${label} public names`).toEqual(targetExpectedNames);
+        expect(
+          Object.keys(rawExports).filter((name) => name.startsWith("$ch")),
+          `${target} ${label} constructor physical names`,
+        ).toEqual([]);
+        expect(rawExports.__is_ctor_closure, `${target} ${label} logical classifier`).toBeUndefined();
+        expect((rawExports.invokeCtor as () => number)(), `${target} ${label} runtime value`).toBe(42);
+      }
+    }
+  });
+
+  it("preserves exact constructor-closure collisions while publishing only free host aliases", async () => {
+    const userValues = [
+      ["__is_ctor_closure", 901],
+      ["$ch", 902],
+      ["$ch$$", 903],
+    ] as const;
+    const expectedNames = [
+      ...CLOSURE_STANDALONE_HELPER_EXPORTS,
+      ...userValues.map(([name]) => name),
+      "getCtor",
+      "invokeCtor",
+    ];
+    for (const target of ["standalone", "wasi"] as const) {
+      const options = {
+        fileName: `issue-3520-closure-collisions-${target}.ts`,
+        experimentalIR: true,
+        target,
+      } as const;
+      const untracked = await compile(CLOSURE_COLLISION_SOURCE, options);
+      const tracked = await compile(CLOSURE_COLLISION_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target} untracked`).toBe(true);
+      expect(tracked.success, `${target} tracked`).toBe(true);
+      expect(untracked.imports, `${target} untracked imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+      const targetExpectedNames = [...expectedNames, ...(target === "wasi" ? ["_start", "memory"] : [])].sort();
+      for (const [label, result] of [
+        ["untracked", untracked],
+        ["tracked", tracked],
+      ] as const) {
+        const { exports: rawExports } = await instantiate(result);
+        expect(Object.keys(rawExports).sort(), `${target} ${label} public names`).toEqual(targetExpectedNames);
+        expect(
+          Object.keys(rawExports).filter((name) => name.startsWith("$ch")),
+          `${target} ${label} physical names`,
+        ).toEqual(["$ch", "$ch$$"]);
+        for (const [name, value] of userValues) {
+          expect(rawExports[name], `${target} ${label} ${name}`).toEqual(expect.any(Function));
+          expect((rawExports[name] as () => number)(), `${target} ${label} ${name}`).toBe(value);
+        }
+        expect(rawExports["$ch$"], `${target} ${label} generated gap`).toBeUndefined();
+        expect(rawExports["$ch$$$"], `${target} ${label} generated terminal`).toBeUndefined();
+        expect((rawExports.invokeCtor as () => number)(), `${target} ${label} runtime value`).toBe(42);
+      }
+    }
+
+    for (const [label, options] of [
+      ["default", {}],
+      ["always", { hostBridge: "always" as const }],
+    ] as const) {
+      const compiled = await compile(CLOSURE_COLLISION_SOURCE, {
+        fileName: `issue-3520-closure-collisions-${label}.ts`,
+        experimentalIR: true,
+        ...options,
+      });
+      const { exports: rawExports } = await instantiate(compiled);
+      expect(
+        Object.keys(rawExports)
+          .filter((name) => name.startsWith("$ch"))
+          .sort(),
+        label,
+      ).toEqual(["$ch", "$ch$", "$ch$$", "$ch$$$"]);
+      expect(rawExports["$ch$"], label).toBe(rawExports["$ch$$$"]);
+      expect(rawExports["$ch$"], label).not.toBe(rawExports.$ch);
+      expect(rawExports["$ch$"], label).not.toBe(rawExports["$ch$$"]);
+      for (const [name, value] of userValues) {
+        expect((rawExports[name] as () => number)(), `${label} ${name}`).toBe(value);
+      }
+    }
+  });
+
+  it("keeps exact constructor-closure spoof names public without creating a classifier", async () => {
+    const spoofValues = [
+      ["__is_ctor_closure", 801],
+      ["$ch", 802],
+      ["$ch$$", 803],
+      ["$ch0", 804],
+      ["$ch_extra", 805],
+      ["__is_ctor_closure_extra", 806],
+    ] as const;
+    const generated = trackedModule(CLOSURE_FREE_SPOOF_SOURCE);
+    expect(
+      generated
+        .programAbi!.abi.entries()
+        .filter(
+          (entry) =>
+            entry.displayName === "__is_ctor_closure" &&
+            entry.slotPolicy === "required" &&
+            entry.intent.kind === "callable" &&
+            entry.intent.origin === "support",
+        ),
+    ).toEqual([]);
+    for (const target of ["standalone", "wasi"] as const) {
+      const options = {
+        fileName: `issue-3520-closure-spoof-${target}.ts`,
+        experimentalIR: true,
+        target,
+      } as const;
+      const untracked = await compile(CLOSURE_FREE_SPOOF_SOURCE, options);
+      const tracked = await compile(CLOSURE_FREE_SPOOF_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target} untracked`).toBe(true);
+      expect(tracked.success, `${target} tracked`).toBe(true);
+      expect(untracked.imports, `${target} imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+      const expectedNames = [
+        ...spoofValues.map(([name]) => name),
+        "add",
+        ...(target === "wasi" ? ["memory"] : []),
+      ].sort();
+      const { exports: rawExports } = await instantiate(tracked);
+      expect(Object.keys(rawExports).sort(), `${target} public names`).toEqual(expectedNames);
+      for (const [name, value] of spoofValues) {
+        expect((rawExports[name] as () => number)(), `${target} ${name}`).toBe(value);
+      }
+      expect(Object.keys(rawExports).filter((name) => name.startsWith("$ch"))).toEqual([
+        "$ch",
+        "$ch$$",
+        "$ch0",
+        "$ch_extra",
+      ]);
+    }
+  });
   it("plans fixed entry-source IDs and publishes each exact final helper slot", () => {
     const result = trackedModule();
     expect(
@@ -536,16 +868,16 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     assertBoxedObject(mutableManifest);
 
     const reservedBitManifest = clone();
-    reservedBitManifest["$cm$"] = new WebAssembly.Global({ value: "i32", mutable: false }, manifestValue | (1 << 17));
+    reservedBitManifest["$cm$"] = new WebAssembly.Global({ value: "i32", mutable: false }, manifestValue | (1 << 18));
     assertBoxedObject(reservedBitManifest);
 
     const f64Manifest = clone();
     f64Manifest["$cm$"] = new WebAssembly.Global({ value: "f64", mutable: false }, manifestValue);
     assertBoxedObject(f64Manifest);
 
-    const externrefBindings = new WebAssembly.Table({ element: "externref", initial: 17, maximum: 17 });
+    const externrefBindings = new WebAssembly.Table({ element: "externref", initial: 18, maximum: 18 });
     const externrefForge = clone();
-    const availabilityBits = manifestValue & 0x0001ffff;
+    const availabilityBits = manifestValue & 0x0003ffff;
     for (let bit = 0; bit < CLOSURE_PHYSICAL_BASES.length; bit++) {
       externrefBindings.set(bit, null);
     }
@@ -564,6 +896,171 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     }
     externrefForge["$cu$"] = externrefBindings;
     assertBoxedObject(externrefForge);
+  });
+
+  it("strips a copied descriptor only when it targets the exact classifier allocator", () => {
+    const { registry, result } = generateWithCapturedRegistry(
+      CONSTRUCTIBLE_CLOSURE_SOURCE,
+      "closure-ctor-cloned-descriptor.ts",
+    );
+    const entryIndex = result.module.exports.findIndex(
+      (candidate) => candidate.name === "__is_ctor_closure" && candidate.desc.kind === "func",
+    );
+    if (entryIndex < 0) throw new Error("missing compiler-owned constructor classifier descriptor");
+    const entry = result.module.exports[entryIndex]!;
+    if (entry.desc.kind !== "func") throw new Error("constructor classifier descriptor changed export kind");
+    const clone: WasmExport = { name: entry.name, desc: { kind: "func", index: entry.desc.index } };
+    result.module.exports[entryIndex] = clone;
+    const originalEmitHostBridge = registry.ctx.emitHostBridge;
+    try {
+      registry.ctx.emitHostBridge = false;
+      expect(isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, clone)).toBe(true);
+      expect(stripHostBridgeExports(registry.ctx)).toBeGreaterThan(0);
+      expect(result.module.exports).not.toContain(clone);
+    } finally {
+      registry.ctx.emitHostBridge = originalEmitHostBridge;
+    }
+  });
+
+  it("retains same-spelled user and near-prefix descriptors without constructor provenance", () => {
+    const collision = generateWithCapturedRegistry(CLOSURE_COLLISION_SOURCE, "closure-ctor-user-collision.ts");
+    const userLogical = collision.result.module.exports.find(
+      (candidate) => candidate.name === "__is_ctor_closure" && candidate.desc.kind === "func",
+    );
+    if (!userLogical) throw new Error("missing user constructor-classifier collision");
+    expect(isCompilerOwnedCtorClosureHostBridgeExport(collision.registry.ctx, userLogical)).toBe(false);
+
+    const compilerPhysical = collision.result.module.exports.find(
+      (candidate) => candidate.name === "$ch$" && candidate.desc.kind === "func",
+    );
+    if (!compilerPhysical || compilerPhysical.desc.kind !== "func") {
+      throw new Error("missing compiler constructor-classifier physical descriptor");
+    }
+    const nearPrefix: WasmExport = { name: "$ch0", desc: { kind: "func", index: compilerPhysical.desc.index } };
+    collision.result.module.exports.push(nearPrefix);
+    expect(isCompilerOwnedCtorClosureHostBridgeExport(collision.registry.ctx, nearPrefix)).toBe(false);
+
+    const originalEmitHostBridge = collision.registry.ctx.emitHostBridge;
+    try {
+      collision.registry.ctx.emitHostBridge = false;
+      stripHostBridgeExports(collision.registry.ctx);
+      expect(collision.result.module.exports).toContain(userLogical);
+      expect(collision.result.module.exports).toContain(nearPrefix);
+    } finally {
+      collision.registry.ctx.emitHostBridge = originalEmitHostBridge;
+    }
+  });
+
+  it("strips recorded constructor provenance before retaining a cross-namespace user collision", () => {
+    const { registry, result } = generateWithCapturedRegistry(
+      CLOSURE_CROSS_NAMESPACE_COLLISION_SOURCE,
+      "closure-ctor-cross-namespace-collision.ts",
+    );
+    const recorded = result.module.exports.find(
+      (candidate) =>
+        candidate.name === "__is_ctor_closure" && isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, candidate),
+    );
+    if (!recorded) throw new Error("missing recorded constructor classifier descriptor");
+    const user = result.module.exports.find((candidate) => candidate.name === "$v0" && candidate !== recorded);
+    if (!user) throw new Error("missing user vec-namespace collision descriptor");
+    expect(isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, user)).toBe(false);
+
+    recorded.name = "$v0";
+    expect(isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, recorded)).toBe(true);
+    const originalEmitHostBridge = registry.ctx.emitHostBridge;
+    try {
+      registry.ctx.emitHostBridge = false;
+      expect(stripHostBridgeExports(registry.ctx)).toBeGreaterThan(0);
+      expect(result.module.exports).toContain(user);
+      expect(result.module.exports).not.toContain(recorded);
+    } finally {
+      registry.ctx.emitHostBridge = originalEmitHostBridge;
+    }
+  });
+
+  it("fails closed for recorded constructor descriptor mutations before manifest publication", () => {
+    const cases: readonly {
+      readonly name: string;
+      readonly mutate: (
+        registry: ProgramAbiCallableRegistry,
+        result: ReturnType<typeof generateModule>,
+        entry: WasmExport,
+      ) => void;
+      readonly expected: RegExp;
+    }[] = [
+      {
+        name: "replaced",
+        mutate: (_registry, result, entry) => {
+          const index = result.module.exports.indexOf(entry);
+          result.module.exports[index] = { name: entry.name, desc: { ...entry.desc } };
+        },
+        expected: /disappeared before finalization/,
+      },
+      {
+        name: "duplicated",
+        mutate: (_registry, result, entry) => {
+          result.module.exports.push(entry);
+        },
+        expected: /appears more than once in the module/,
+      },
+      {
+        name: "name-changed",
+        mutate: (_registry, _result, entry) => {
+          entry.name = "$ch0";
+        },
+        expected: /changed its published name to \$ch0/,
+      },
+      {
+        name: "retargeted",
+        mutate: (_registry, result, entry) => {
+          const other = result.module.exports.find(
+            (candidate) => candidate.name === "__is_closure" && candidate.desc.kind === "func",
+          );
+          if (!other || other.desc.kind !== "func") throw new Error("missing alternate closure helper export");
+          entry.desc.index = other.desc.index;
+        },
+        expected: /resolves to a different allocator function/,
+      },
+      {
+        name: "one-past-defined-functions",
+        mutate: (_registry, result, entry) => {
+          const liveImportCount = result.module.imports.filter((candidate) => candidate.desc.kind === "func").length;
+          entry.desc.index = liveImportCount + result.module.functions.length;
+          expect(entry.desc.index).toBeLessThan(STABLE_FUNC_BASE);
+        },
+        expected: /resolves to a different allocator function/,
+      },
+      {
+        name: "kind-changed",
+        mutate: (_registry, _result, entry) => {
+          entry.desc = { kind: "global", index: entry.desc.index };
+        },
+        expected: /changed kind to global/,
+      },
+      {
+        name: "allocator-removed",
+        mutate: (_registry, result, entry) => {
+          if (entry.desc.kind !== "func") throw new Error("constructor classifier descriptor changed export kind");
+          const func = result.module.functions.find((candidate) => candidate.name === "__is_ctor_closure");
+          if (!func) throw new Error("missing constructor classifier allocator");
+          result.module.functions.splice(result.module.functions.indexOf(func), 1);
+        },
+        expected: /lost its allocator function/,
+      },
+    ];
+
+    for (const mutation of cases) {
+      const { registry, result } = generateWithCapturedRegistry(
+        CONSTRUCTIBLE_CLOSURE_SOURCE,
+        `closure-ctor-${mutation.name}.ts`,
+      );
+      const entry = result.module.exports.find(
+        (candidate) => candidate.name === "__is_ctor_closure" && candidate.desc.kind === "func",
+      );
+      if (!entry) throw new Error(`missing compiler-owned constructor classifier for ${mutation.name}`);
+      mutation.mutate(registry, result, entry);
+      expect(() => finalizeCtorClosureHostBridgeExports(registry.ctx), mutation.name).toThrow(mutation.expected);
+    }
   });
 
   it("owns closure_has_rest at ordinal 13 only when that helper is emitted", async () => {

--- a/tests/issue-3520-date-host-bridge-export-provenance.test.ts
+++ b/tests/issue-3520-date-host-bridge-export-provenance.test.ts
@@ -1,0 +1,579 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// C39 — Date carrier host-bridge export provenance. The Date helpers are
+// compiler-only inspection exports for the JavaScript host. Their names are
+// deliberately not broad namespace authority: removal is permitted only from
+// the exact three-entry descriptor/function census captured by the emitter.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeMultiSource, analyzeSource } from "../src/checker/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import {
+  emitDateHostBridge,
+  finalizeDateHostBridgeExports,
+  isCompilerOwnedDateHostBridgeExport,
+  isCoreDateHostBridgePublicName,
+} from "../src/codegen/date-host-bridge.js";
+import { stripHostBridgeExports } from "../src/codegen/host-bridge-exports.js";
+import { type GeneratedCodegenModule, generateModule, generateMultiModule } from "../src/codegen/index.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { STABLE_FUNC_BASE } from "../src/emit/resolve-layout.js";
+import { type CompileOptions, compile, compileMulti } from "../src/index.js";
+import { type WasmExport, type WasmFunction, createEmptyModule } from "../src/ir/types.js";
+import { buildImports, buildWasiPolyfill } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+
+const DATE_BRIDGE_NAMES = Object.freeze(["__\0js2_is_date", "__\0js2_date_value", "__\0js2_date_set_value"]);
+const DATE_ALWAYS_BRIDGE_NAMES = Object.freeze([
+  "__sget_length",
+  "__sget_data",
+  "__sget_byteOffset",
+  "__sget_timestamp",
+  "__sset_length",
+  ...DATE_BRIDGE_NAMES,
+  "__is_data_struct",
+  "$d0",
+  "__\0js2_data_struct_host_bridge_marker",
+  "$dt",
+  "__\0js2_data_struct_host_bridge_bindings",
+  "$du",
+  "__\0js2_data_struct_host_bridge",
+  "$dm",
+]);
+const DATE_MULTI_ALWAYS_BRIDGE_NAMES = Object.freeze([
+  "__sget_timestamp",
+  ...DATE_BRIDGE_NAMES,
+  "__is_data_struct",
+  "$d0",
+  "__\0js2_data_struct_host_bridge_marker",
+  "$dt",
+  "__\0js2_data_struct_host_bridge_bindings",
+  "$du",
+  "__\0js2_data_struct_host_bridge",
+  "$dm",
+]);
+
+const DATE_SOURCE = `
+  export function dateValue(): number {
+    return new Date(5).getTime();
+  }
+`;
+
+const DATE_MULTI_FILES = {
+  "./provider.ts": `
+    export function provideDate(): Date {
+      return new Date(5);
+    }
+  `,
+  "./entry.ts": `
+    import { provideDate } from "./provider.ts";
+    export function dateValue(): number {
+      const value: Date = provideDate();
+      return value.getTime();
+    }
+  `,
+} as const;
+
+type CompileResult = Awaited<ReturnType<typeof compile>>;
+type GeneratedResult = ReturnType<typeof generateModule>;
+type ErrorCarrier = {
+  readonly errors: readonly {
+    readonly severity: string;
+    readonly message: string;
+  }[];
+};
+
+function generatedOptions(options: Pick<CompileOptions, "target" | "hostBridge" | "trackIrOutcomes">) {
+  return {
+    experimentalIR: true,
+    trackIrOutcomes: options.trackIrOutcomes,
+    hostBridge: options.hostBridge,
+    standalone: options.target === "standalone",
+    wasi: options.target === "wasi",
+  };
+}
+
+function generateSingle(
+  source: string,
+  fileName: string,
+  options: Pick<CompileOptions, "target" | "hostBridge" | "trackIrOutcomes">,
+): GeneratedResult {
+  return generateModule(analyzeSource(source, fileName), generatedOptions(options));
+}
+
+function generateGraph(
+  files: Record<string, string>,
+  entryFile: string,
+  options: Pick<CompileOptions, "target" | "hostBridge" | "trackIrOutcomes">,
+): GeneratedCodegenModule {
+  return generateMultiModule(analyzeMultiSource(files, entryFile), generatedOptions(options));
+}
+
+function hardErrors(result: ErrorCarrier): string[] {
+  return result.errors.filter((error) => error.severity !== "warning").map((error) => error.message);
+}
+
+function dateEntries(result: GeneratedResult): WasmExport[] {
+  return result.module.exports.filter((entry) => DATE_BRIDGE_NAMES.includes(entry.name));
+}
+
+function importFunctionCount(result: GeneratedResult): number {
+  return result.module.imports.filter((entry) => entry.desc.kind === "func").length;
+}
+
+function expectedTargetExportNames(
+  target: "standalone" | "wasi",
+  hostBridge: "auto" | "off" | "always",
+  alwaysBridgeNames: readonly string[],
+) {
+  return [...(target === "wasi" ? ["memory"] : []), "dateValue", ...(hostBridge === "always" ? alwaysBridgeNames : [])];
+}
+
+function assertExactTargetSurface(
+  result: GeneratedCodegenModule,
+  target: "standalone" | "wasi",
+  hostBridge: "auto" | "off" | "always",
+  alwaysBridgeNames: readonly string[] = DATE_ALWAYS_BRIDGE_NAMES,
+): void {
+  expect(result.module.imports, `${target}/${hostBridge} imports`).toEqual([]);
+  expect(result.module.exports.map(({ name }) => name).sort(), `${target}/${hostBridge} exports`).toEqual(
+    expectedTargetExportNames(target, hostBridge, alwaysBridgeNames).sort(),
+  );
+}
+
+function functionForExport(result: GeneratedResult, entry: WasmExport): WasmFunction {
+  if (entry.desc.kind !== "func") throw new Error(`Date export ${entry.name} is not a function`);
+  const func = result.module.functions[entry.desc.index - importFunctionCount(result)];
+  if (!func) throw new Error(`Date export ${entry.name} has no defined function target`);
+  return func;
+}
+
+function assertExactDateCensus(result: GeneratedResult): void {
+  expect(hardErrors(result), hardErrors(result).join("\n")).toEqual([]);
+  const entries = dateEntries(result);
+  expect(entries.map((entry) => entry.name).sort()).toEqual([...DATE_BRIDGE_NAMES].sort());
+  expect(new Set(entries.map((entry) => (entry.desc.kind === "func" ? entry.desc.index : -1))).size).toBe(3);
+  const expectedTypes = [
+    { params: [{ kind: "externref" }], results: [{ kind: "i32" }] },
+    { params: [{ kind: "externref" }], results: [{ kind: "i64" }] },
+    {
+      params: [
+        {
+          kind: "ref",
+          typeIdx: result.module.types.findIndex((type) => type.kind === "struct" && type.name === "__Date"),
+        },
+        { kind: "i64" },
+      ],
+      results: [],
+    },
+  ];
+  for (const [index, name] of DATE_BRIDGE_NAMES.entries()) {
+    const entry = entries.find((candidate) => candidate.name === name);
+    if (!entry) throw new Error(`missing Date export ${name}`);
+    const func = functionForExport(result, entry);
+    expect(func.name, name).toBe(name);
+    const type = result.module.types[func.typeIdx];
+    expect(type?.kind, name).toBe("func");
+    if (type?.kind !== "func") continue;
+    expect(type.params, name).toEqual(expectedTypes[index]!.params);
+    expect(type.results, name).toEqual(expectedTypes[index]!.results);
+  }
+}
+
+async function instantiateGc(result: CompileResult): Promise<Record<string, unknown>> {
+  expect(result.success, hardErrors(result).join("\n")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  return instance.exports as Record<string, unknown>;
+}
+
+async function instantiateTarget(
+  result: CompileResult,
+  target: "standalone" | "wasi",
+): Promise<Record<string, unknown>> {
+  expect(result.success, hardErrors(result).join("\n")).toBe(true);
+  if (target === "wasi") {
+    const wasi = buildWasiPolyfill();
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), {
+      wasi_snapshot_preview1: wasi,
+    });
+    const memory = instance.exports.memory;
+    if (memory instanceof WebAssembly.Memory) wasi.setMemory(memory);
+    return instance.exports as Record<string, unknown>;
+  }
+  return instantiateGc(result);
+}
+
+function makeDateContext() {
+  const module = createEmptyModule();
+  const ctx = createCodegenContext(module, {} as ts.TypeChecker, {
+    target: "standalone",
+    hostBridge: "off",
+  });
+  const dateTypeIdx = module.types.length;
+  module.types.push({
+    kind: "struct",
+    name: "__Date",
+    fields: [{ name: "timestamp", type: { kind: "i64" }, mutable: true }],
+  });
+  ctx.structMap.set("__Date", dateTypeIdx);
+  ctx.typeIdxToStructName.set(dateTypeIdx, "__Date");
+  ctx.structFields.set("__Date", [{ name: "timestamp", type: { kind: "i64" }, mutable: true }]);
+  emitDateHostBridge(ctx);
+  return ctx;
+}
+
+function dateEntry(ctx: ReturnType<typeof makeDateContext>, name = DATE_BRIDGE_NAMES[0]): WasmExport {
+  const entry = ctx.mod.exports.find((candidate) => candidate.name === name);
+  if (!entry) throw new Error(`missing Date export ${name}`);
+  return entry;
+}
+
+function cloneExport(entry: WasmExport, name = entry.name): WasmExport {
+  return {
+    name,
+    desc: entry.desc.kind === "func" ? { kind: "func", index: entry.desc.index } : { ...entry.desc },
+  };
+}
+
+describe("#3520 C39 Date carrier export provenance", () => {
+  it("accepts only the exact three Date bridge names", () => {
+    expect(DATE_BRIDGE_NAMES.every(isCoreDateHostBridgePublicName)).toBe(true);
+    expect(
+      ["__\0js2_is_date$", "__\0js2_date_value_extra", "__\0js2_date_set_value0", "$d0", "$d0$"].some(
+        isCoreDateHostBridgePublicName,
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["auto", {}],
+    ["always", { hostBridge: "always" as const }],
+  ] as const)(
+    "captures exact names, types, targets, and runtime behavior for host policy %s",
+    async (_label, policy) => {
+      const options = {
+        fileName: `issue-3520-c39-date-${_label}.ts`,
+        experimentalIR: true,
+        ...policy,
+      } satisfies CompileOptions;
+      assertExactDateCensus(generateSingle(DATE_SOURCE, options.fileName, options));
+      const result = await compile(DATE_SOURCE, options);
+      const exports = await instantiateGc(result);
+      expect((exports.dateValue as () => number)()).toBe(5);
+    },
+  );
+
+  it.each(["standalone", "wasi"] as const)(
+    "removes all authenticated Date exports in %s auto/off policy with tracked parity",
+    async (target) => {
+      for (const hostBridge of ["auto", "off"] as const) {
+        const options: CompileOptions = {
+          fileName: `issue-3520-c39-date-${target}-${hostBridge}.ts`,
+          experimentalIR: true,
+          target,
+          hostBridge,
+        };
+        const generated = generateSingle(DATE_SOURCE, options.fileName!, options);
+        const generatedTracked = generateSingle(DATE_SOURCE, options.fileName!, {
+          ...options,
+          trackIrOutcomes: true,
+        });
+        expect(hardErrors(generated), `${target}/${hostBridge} generated untracked`).toEqual([]);
+        expect(hardErrors(generatedTracked), `${target}/${hostBridge} generated tracked`).toEqual([]);
+        assertExactTargetSurface(generated, target, hostBridge);
+        assertExactTargetSurface(generatedTracked, target, hostBridge);
+        expect(dateEntries(generated), `${target}/${hostBridge} untracked`).toEqual([]);
+        expect(dateEntries(generatedTracked), `${target}/${hostBridge} tracked`).toEqual([]);
+        expect(generatedTracked.module.imports, `${target}/${hostBridge} generated imports`).toEqual(
+          generated.module.imports,
+        );
+        expect(
+          generatedTracked.module.exports.map(({ name, desc }) => ({
+            name,
+            desc,
+          })),
+          `${target}/${hostBridge} generated exports`,
+        ).toEqual(generated.module.exports.map(({ name, desc }) => ({ name, desc })));
+        const untracked = await compile(DATE_SOURCE, options);
+        const tracked = await compile(DATE_SOURCE, {
+          ...options,
+          trackIrOutcomes: true,
+        });
+        expect(untracked.success, hardErrors(untracked).join("\n")).toBe(true);
+        expect(tracked.success, hardErrors(tracked).join("\n")).toBe(true);
+        expect(tracked.imports, `${target}/${hostBridge} imports`).toEqual(untracked.imports);
+        expect(tracked.binary, `${target}/${hostBridge} binary parity`).toEqual(untracked.binary);
+        const exports = await instantiateTarget(tracked, target);
+        expect((exports.dateValue as () => number)(), `${target}/${hostBridge} runtime`).toBe(5);
+      }
+    },
+  );
+
+  it.each(["standalone", "wasi"] as const)(
+    "retains all three exact Date helpers in %s hostBridge always",
+    async (target) => {
+      const options: CompileOptions = {
+        fileName: `issue-3520-c39-date-${target}-always.ts`,
+        experimentalIR: true,
+        target,
+        hostBridge: "always",
+      };
+      const generated = generateSingle(DATE_SOURCE, options.fileName!, options);
+      const generatedTracked = generateSingle(DATE_SOURCE, options.fileName!, {
+        ...options,
+        trackIrOutcomes: true,
+      });
+      assertExactDateCensus(generated);
+      assertExactDateCensus(generatedTracked);
+      assertExactTargetSurface(generated, target, "always");
+      assertExactTargetSurface(generatedTracked, target, "always");
+      expect(generatedTracked.module.imports).toEqual(generated.module.imports);
+      expect(emitBinary(generatedTracked.module)).toEqual(emitBinary(generated.module));
+      const untracked = await compile(DATE_SOURCE, options);
+      const tracked = await compile(DATE_SOURCE, {
+        ...options,
+        trackIrOutcomes: true,
+      });
+      expect(tracked.imports).toEqual(untracked.imports);
+      expect(tracked.binary).toEqual(untracked.binary);
+      const exports = await instantiateTarget(tracked, target);
+      expect((exports.dateValue as () => number)()).toBe(5);
+    },
+  );
+
+  it("keeps a Date-free control free of Date census and carrier exports", async () => {
+    const options = {
+      fileName: "issue-3520-c39-date-free.ts",
+      experimentalIR: true,
+      target: "standalone",
+      hostBridge: "always",
+      trackIrOutcomes: true,
+    } satisfies CompileOptions;
+    const result = generateSingle("export function dateValue(): number { return 5; }", options.fileName!, options);
+    expect(hardErrors(result), hardErrors(result).join("\n")).toEqual([]);
+    expect(dateEntries(result)).toEqual([]);
+    expect(result.module.functions.some((func) => DATE_BRIDGE_NAMES.includes(func.name))).toBe(false);
+  });
+
+  it("keeps Date provenance exact when Date is created in a non-entry provider", async () => {
+    for (const target of ["standalone", "wasi"] as const) {
+      for (const hostBridge of ["auto", "always"] as const) {
+        const options: CompileOptions = {
+          experimentalIR: true,
+          target,
+          hostBridge,
+        };
+        const generated = generateGraph(DATE_MULTI_FILES, "./entry.ts", options);
+        const generatedTracked = generateGraph(DATE_MULTI_FILES, "./entry.ts", {
+          ...options,
+          trackIrOutcomes: true,
+        });
+        expect(hardErrors(generated), `${target}/${hostBridge} generated untracked`).toEqual([]);
+        expect(hardErrors(generatedTracked), `${target}/${hostBridge} generated tracked`).toEqual([]);
+        assertExactTargetSurface(generated, target, hostBridge, DATE_MULTI_ALWAYS_BRIDGE_NAMES);
+        assertExactTargetSurface(generatedTracked, target, hostBridge, DATE_MULTI_ALWAYS_BRIDGE_NAMES);
+        if (hostBridge === "auto") {
+          expect(dateEntries(generated)).toEqual([]);
+          expect(dateEntries(generatedTracked)).toEqual([]);
+        } else {
+          assertExactDateCensus(generated);
+          assertExactDateCensus(generatedTracked);
+        }
+        expect(generatedTracked.module.imports, `${target}/${hostBridge} generated imports`).toEqual(
+          generated.module.imports,
+        );
+        expect(
+          generatedTracked.module.exports.map(({ name, desc }) => ({
+            name,
+            desc,
+          })),
+        ).toEqual(generated.module.exports.map(({ name, desc }) => ({ name, desc })));
+        const untracked = await compileMulti(DATE_MULTI_FILES, "./entry.ts", options);
+        const tracked = await compileMulti(DATE_MULTI_FILES, "./entry.ts", {
+          ...options,
+          trackIrOutcomes: true,
+        });
+        expect(untracked.success, `${target}/${hostBridge} untracked`).toBe(true);
+        expect(tracked.success, `${target}/${hostBridge} tracked`).toBe(true);
+        expect(tracked.binary, `${target}/${hostBridge} multi binary parity`).toEqual(untracked.binary);
+        const exports = await instantiateTarget(tracked, target);
+        expect((exports.dateValue as () => number)(), `${target}/${hostBridge} provider runtime`).toBe(5);
+      }
+    }
+  });
+
+  it("removes an exact-name copy only when its live target is the recorded allocator", () => {
+    const ctx = makeDateContext();
+    const recorded = dateEntry(ctx);
+    const copy = cloneExport(recorded);
+    ctx.mod.exports.push(copy);
+    expect(isCompilerOwnedDateHostBridgeExport(ctx, copy)).toBe(true);
+    ctx.emitHostBridge = false;
+    expect(stripHostBridgeExports(ctx)).toBe(4);
+    expect(ctx.mod.exports).not.toContain(copy);
+  });
+
+  it("keeps a same-spelled Date export that targets a distinct user allocator", () => {
+    const ctx = makeDateContext();
+    const recorded = dateEntry(ctx);
+    const recordedFunc = recorded.desc.kind === "func" ? ctx.mod.functions[recorded.desc.index] : undefined;
+    const userFunction: WasmFunction = {
+      name: "user-date-spelling",
+      typeIdx: recordedFunc?.typeIdx ?? 0,
+      locals: [],
+      body: [{ op: "i32.const", value: 7 }],
+      exported: true,
+    };
+    const userIndex = ctx.mod.functions.length;
+    ctx.mod.functions.push(userFunction);
+    const user = cloneExport(recorded);
+    user.desc = { kind: "func", index: userIndex };
+    ctx.mod.exports.push(user);
+    expect(isCompilerOwnedDateHostBridgeExport(ctx, user)).toBe(false);
+    ctx.emitHostBridge = false;
+    stripHostBridgeExports(ctx);
+    expect(ctx.mod.exports).toContain(user);
+    expect(ctx.mod.exports.filter((entry) => entry.name === recorded.name)).toEqual([user]);
+  });
+
+  it("keeps a near-spelled export even when it targets the compiler allocator", () => {
+    const ctx = makeDateContext();
+    const recorded = dateEntry(ctx);
+    const near = cloneExport(recorded, `${recorded.name}$`);
+    ctx.mod.exports.push(near);
+    expect(isCoreDateHostBridgePublicName(near.name)).toBe(false);
+    expect(isCompilerOwnedDateHostBridgeExport(ctx, near)).toBe(false);
+    ctx.emitHostBridge = false;
+    stripHostBridgeExports(ctx);
+    expect(ctx.mod.exports).toContain(near);
+  });
+
+  it("accepts a stable-regime copy but never falls through from an invalid live handle", () => {
+    const stableCtx = makeDateContext();
+    const stableRecorded = dateEntry(stableCtx);
+    if (stableRecorded.desc.kind !== "func") throw new Error("Date descriptor is not a function");
+    const stableFunc = stableCtx.mod.functions[stableRecorded.desc.index];
+    if (!stableFunc) throw new Error("missing Date allocator");
+    stableCtx.mod.funcOrdinalToPosition.push(stableCtx.mod.functions.indexOf(stableFunc));
+    const stableCopy = cloneExport(stableRecorded);
+    stableCopy.desc = { kind: "func", index: STABLE_FUNC_BASE };
+    stableCtx.mod.exports.push(stableCopy);
+    expect(isCompilerOwnedDateHostBridgeExport(stableCtx, stableCopy)).toBe(true);
+    stableCtx.emitHostBridge = false;
+    expect(stripHostBridgeExports(stableCtx)).toBe(4);
+    expect(stableCtx.mod.exports).not.toContain(stableCopy);
+
+    const invalidCtx = makeDateContext();
+    const invalidRecorded = dateEntry(invalidCtx);
+    if (invalidRecorded.desc.kind !== "func") throw new Error("Date descriptor is not a function");
+    const invalidStableFunc = invalidCtx.mod.functions[invalidRecorded.desc.index];
+    if (!invalidStableFunc) throw new Error("missing Date allocator");
+    finalizeDateHostBridgeExports(invalidCtx);
+    invalidCtx.indexSpaceFrozen = true;
+    expect(invalidCtx.numImportFuncs).toBe(0);
+    invalidCtx.mod.imports.push({
+      module: "env",
+      name: "late_date_import",
+      desc: { kind: "func", typeIdx: invalidStableFunc.typeIdx },
+    });
+    const invalidLive = cloneExport(invalidRecorded);
+    invalidLive.desc = { kind: "func", index: invalidRecorded.desc.index };
+    expect(invalidLive.desc.index).toBeLessThan(STABLE_FUNC_BASE);
+    invalidCtx.mod.exports.push(invalidLive);
+    expect(isCompilerOwnedDateHostBridgeExport(invalidCtx, invalidLive)).toBe(false);
+    invalidCtx.emitHostBridge = false;
+    stripHostBridgeExports(invalidCtx);
+    expect(invalidCtx.mod.exports).toContain(invalidLive);
+  });
+
+  it("removes a recorded Date descriptor renamed into the vec/closure namespace after finalization", () => {
+    for (const [name, userName] of [
+      ["$v0", "$v0"],
+      ["$ch", "$ch"],
+    ] as const) {
+      const ctx = makeDateContext();
+      const recorded = dateEntry(ctx);
+      const recordedFunc = recorded.desc.kind === "func" ? ctx.mod.functions[recorded.desc.index] : undefined;
+      const userFunction: WasmFunction = {
+        name: `user-${name}`,
+        typeIdx: recordedFunc?.typeIdx ?? 0,
+        locals: [],
+        body: [{ op: "i32.const", value: 7 }],
+        exported: true,
+      };
+      const userIndex = ctx.mod.functions.length;
+      ctx.mod.functions.push(userFunction);
+      const user: WasmExport = {
+        name: userName,
+        desc: { kind: "func", index: userIndex },
+      };
+      ctx.mod.exports.push(user);
+      finalizeDateHostBridgeExports(ctx);
+      ctx.indexSpaceFrozen = true;
+      recorded.name = name;
+      expect(isCompilerOwnedDateHostBridgeExport(ctx, recorded)).toBe(true);
+      ctx.emitHostBridge = false;
+      stripHostBridgeExports(ctx);
+      expect(ctx.mod.exports).toContain(user);
+      expect(ctx.mod.exports).not.toContain(recorded);
+    }
+  });
+
+  it.each([
+    [
+      "missing",
+      (ctx: ReturnType<typeof makeDateContext>, entry: WasmExport) =>
+        ctx.mod.exports.splice(ctx.mod.exports.indexOf(entry), 1),
+      /disappeared before finalization/,
+    ],
+    [
+      "duplicated",
+      (ctx: ReturnType<typeof makeDateContext>, entry: WasmExport) => ctx.mod.exports.push(entry),
+      /appears more than once/,
+    ],
+    [
+      "renamed",
+      (_ctx: ReturnType<typeof makeDateContext>, entry: WasmExport) => {
+        entry.name = "__\0js2_is_date$";
+      },
+      /changed its published name/,
+    ],
+    [
+      "kind-changed",
+      (_ctx: ReturnType<typeof makeDateContext>, entry: WasmExport) => {
+        entry.desc = { kind: "global", index: 0 };
+      },
+      /changed kind to global/,
+    ],
+    [
+      "retargeted",
+      (ctx: ReturnType<typeof makeDateContext>, entry: WasmExport) => {
+        entry.desc = { kind: "func", index: ctx.mod.functions.length - 1 };
+      },
+      /different allocator function/,
+    ],
+    [
+      "one-past",
+      (ctx: ReturnType<typeof makeDateContext>, entry: WasmExport) => {
+        entry.desc = { kind: "func", index: ctx.mod.functions.length };
+      },
+      /different allocator function/,
+    ],
+    [
+      "allocator-removed",
+      (ctx: ReturnType<typeof makeDateContext>, entry: WasmExport) => {
+        if (entry.desc.kind !== "func") throw new Error("not function");
+        ctx.mod.functions.splice(entry.desc.index, 1);
+      },
+      /lost its allocator function/,
+    ],
+  ] as const)("fails closed before policy publication for %s", (_name, mutate, expected) => {
+    const ctx = makeDateContext();
+    const entry = dateEntry(ctx);
+    mutate(ctx, entry);
+    expect(() => finalizeDateHostBridgeExports(ctx)).toThrow(expected);
+  });
+});

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -374,20 +374,33 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
   });
 
   it("strips exact compiler-owned suffixed aliases without deleting standalone or WASI user collisions", async () => {
+    const expectedNames = ["$v0$", "__exn_tag", "returnedValues"];
     for (const target of ["standalone", "wasi"] as const) {
-      const result = await compile(HOST_FREE_PHYSICAL_COLLISION_SOURCE, {
+      const options = {
         fileName: `vec-host-free-physical-collision-${target}.ts`,
         experimentalIR: true,
-        trackIrOutcomes: true,
         target,
-      });
-      expect(result.success, `${target}: ${result.errors.map((error) => error.message).join("\n")}`).toBe(true);
-      const module = await WebAssembly.compile(result.binary);
-      const exportNames = WebAssembly.Module.exports(module).map(({ name }) => name);
-      expect(exportNames, target).toContain("$v0$");
-      expect(exportNames, target).not.toContain("__vec_len");
-      expect(exportNames, target).not.toContain("$v0");
-      expect(exportNames, target).not.toContain("$v0$$");
+      } as const;
+      const untracked = await compile(HOST_FREE_PHYSICAL_COLLISION_SOURCE, options);
+      const tracked = await compile(HOST_FREE_PHYSICAL_COLLISION_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target}: ${untracked.errors.map((error) => error.message).join("\n")}`).toBe(true);
+      expect(tracked.success, `${target}: ${tracked.errors.map((error) => error.message).join("\n")}`).toBe(true);
+      expect(untracked.imports, `${target} untracked imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+
+      const targetExpectedNames = [...expectedNames, ...(target === "wasi" ? ["memory"] : [])].sort();
+      for (const [label, result] of [
+        ["untracked", untracked],
+        ["tracked", tracked],
+      ] as const) {
+        const exports = await instantiate(result);
+        expect(Object.keys(exports).sort(), `${target} ${label} public names`).toEqual(targetExpectedNames);
+        expect(Object.keys(exports).filter(isVecHostBridgePhysicalExport), `${target} ${label} physical names`).toEqual(
+          ["$v0$"],
+        );
+        expect((exports["$v0$"] as () => number)(), `${target} ${label} collision value`).toBe(811);
+      }
     }
   });
 
@@ -626,7 +639,7 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
     }
   });
 
-  it("fails closed when a compiler-owned export entry is replaced, duplicated, retargeted, or loses its function", () => {
+  it("fails closed when a compiler-owned export entry is replaced, duplicated, renamed, retargeted, or loses its function", () => {
     const cases: readonly {
       readonly name: string;
       readonly mutate: (
@@ -650,6 +663,13 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
           result.module.exports.push(entry);
         },
         expected: /appears more than once in the module/,
+      },
+      {
+        name: "name-changed",
+        mutate: (_registry, _result, entry) => {
+          entry.name = "__vec_get";
+        },
+        expected: /changed its published name to __vec_get/,
       },
       {
         name: "retargeted",

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -8,12 +8,14 @@ import { describe, expect, it, vi } from "vitest";
 import { SINGLE_HOST_ENTRIES } from "../scripts/check-ir-only.js";
 import { analyzeSource } from "../src/checker/index.js";
 import { definedFuncAt } from "../src/codegen/func-space.js";
+import { stripHostBridgeExports } from "../src/codegen/host-bridge-exports.js";
 import { generateModule } from "../src/codegen/index.js";
 import { ProgramAbiCallableRegistry } from "../src/codegen/program-abi-callable-planning.js";
 import {
   VEC_HOST_BRIDGE_ROLE,
   type VecHostBridgeKind,
   finalizeVecHostBridgeExports,
+  isCoreVecHostBridgePublicName,
   resolveVecHostBridgeHelper,
   vecHostBridgePhysicalExportBase,
 } from "../src/codegen/vec-access-exports.js";
@@ -148,6 +150,64 @@ const ARRAY_FREE_PHYSICAL_SPOOF_SOURCE = `
   }
 `;
 
+const ARRAY_FREE_LOGICAL_SPOOF_SOURCE = `
+  export function __vec_len(): number { return 702; }
+
+  class Empty {
+    m(): number { return 1; }
+  }
+
+  export function mkInstance(): Empty {
+    return new Empty();
+  }
+`;
+
+const ALL_PUBLIC_COLLISION_VALUES = [
+  ["__vec_len", 101],
+  ["__vec_get", 102],
+  ["__is_vec", 103],
+  ["__vec_mut_supported", 104],
+  ["__vec_push", 105],
+  ["__vec_pop", 106],
+  ["$v0", 901],
+  ["$v0$$", 902],
+] as const;
+
+const PREFIX_ONLY_COLLISION_VALUES = [
+  ["$v0", 201],
+  ["$v1", 202],
+  ["$v2", 203],
+  ["$v3", 204],
+  ["$v4", 205],
+  ["$v5", 206],
+] as const;
+
+const STANDALONE_VALUE_HELPER_EXPORTS = [
+  "__any_box_null",
+  "__any_box_undefined",
+  "__box_bigint",
+  "__box_boolean",
+  "__box_number",
+  "__dynamic_boundary_tag",
+  "__exn_tag",
+  "__to_bigint",
+  "__typeof_bigint",
+  "__typeof_boolean",
+  "__typeof_number",
+  "__unbox_boolean",
+  "__unbox_number",
+] as const;
+
+function assertFunctionValueCensus(
+  exports: Record<string, WebAssembly.ExportValue>,
+  expected: readonly (readonly [string, number])[],
+): void {
+  for (const [name, value] of expected) {
+    expect(exports[name], name).toEqual(expect.any(Function));
+    expect((exports[name] as () => number)(), name).toBe(value);
+  }
+}
+
 function generate(source: string, fileName: string, trackIrOutcomes = true) {
   const ast = analyzeSource(source, fileName);
   return {
@@ -198,6 +258,12 @@ async function instantiate(result: CompileResult): Promise<Record<string, WebAss
 }
 
 describe("#3520 vec host-bridge Program ABI ownership", () => {
+  it("classifies only exact core logical and physical vec names", () => {
+    expect(VEC_BRIDGES.every((bridge) => isCoreVecHostBridgePublicName(bridge.name))).toBe(true);
+    expect(["$v0", "$v0$", "$v0$$", "$v5$$$$"].every(isCoreVecHostBridgePublicName)).toBe(true);
+    expect(["$v00", "$v0x", "$v6", "__vec_len$", "__vec_custom"].some(isCoreVecHostBridgePublicName)).toBe(false);
+  });
+
   it("publishes all six bridges beneath the entry source with fixed ordinals and exact final slots", () => {
     const { ast, result } = generate(ARRAY_SOURCE, "vec-host-bridge.ts");
     const hardErrors = result.errors.filter((error) => error.severity !== "warning");
@@ -376,6 +442,47 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
     expect(wrapped.returnedValues()).toEqual([7, 8]);
   });
 
+  it("retains exact logical and physical user collisions in standalone and WASI", async () => {
+    const expectedNames = [
+      ...ALL_PUBLIC_COLLISION_VALUES.map(([name]) => name),
+      ...STANDALONE_VALUE_HELPER_EXPORTS,
+      "dynamicPush",
+      "dynamicPop",
+      "echo",
+      "returnedValues",
+    ];
+    for (const target of ["standalone", "wasi"] as const) {
+      const options = {
+        fileName: `vec-all-public-collisions-${target}.ts`,
+        experimentalIR: true,
+        target,
+      } as const;
+      const untracked = await compile(ALL_PUBLIC_COLLISION_SOURCE, options);
+      const tracked = await compile(ALL_PUBLIC_COLLISION_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target} untracked`).toBe(true);
+      expect(tracked.success, `${target} tracked`).toBe(true);
+      expect(untracked.imports, `${target} untracked imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+
+      const untrackedExports = await instantiate(untracked);
+      const trackedExports = await instantiate(tracked);
+      const targetExpectedNames = [...expectedNames, ...(target === "wasi" ? ["memory"] : [])].sort();
+      expect(Object.keys(untrackedExports).sort(), `${target} public names`).toEqual(targetExpectedNames);
+      expect(Object.keys(trackedExports).sort(), `${target} tracked public names`).toEqual(targetExpectedNames);
+      expect(
+        Object.keys(untrackedExports).filter(isVecHostBridgePhysicalExport).sort(),
+        `${target} physical collision names`,
+      ).toEqual(["$v0", "$v0$$"]);
+      expect(
+        Object.keys(trackedExports).filter(isVecHostBridgePhysicalExport).sort(),
+        `${target} tracked physical collision names`,
+      ).toEqual(["$v0", "$v0$$"]);
+      assertFunctionValueCensus(untrackedExports, ALL_PUBLIC_COLLISION_VALUES);
+      assertFunctionValueCensus(trackedExports, ALL_PUBLIC_COLLISION_VALUES);
+    }
+  });
+
   it("terminates all six prefix-only physical families with the structural helper", async () => {
     const runtime = await compile(PREFIX_ONLY_COLLISION_SOURCE, {
       fileName: "vec-helper-prefix-only-collisions.ts",
@@ -396,6 +503,47 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
     expect((rawExports.dynamicPush as (values: unknown, value: number) => number)(rawValues, 3)).toBe(3);
     expect(wrapped.echo(rawValues)).toEqual([7, 8, 3]);
     expect(wrapped.mkInstance()).toEqual({});
+  });
+
+  it("retains exact prefix-only user collisions in standalone and WASI", async () => {
+    const expectedNames = [
+      ...PREFIX_ONLY_COLLISION_VALUES.map(([name]) => name),
+      ...STANDALONE_VALUE_HELPER_EXPORTS,
+      "mkInstance",
+      "dynamicPush",
+      "echo",
+      "returnedValues",
+    ];
+    for (const target of ["standalone", "wasi"] as const) {
+      const options = {
+        fileName: `vec-prefix-only-collisions-${target}.ts`,
+        experimentalIR: true,
+        target,
+      } as const;
+      const untracked = await compile(PREFIX_ONLY_COLLISION_SOURCE, options);
+      const tracked = await compile(PREFIX_ONLY_COLLISION_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target} untracked`).toBe(true);
+      expect(tracked.success, `${target} tracked`).toBe(true);
+      expect(untracked.imports, `${target} untracked imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+
+      const untrackedExports = await instantiate(untracked);
+      const trackedExports = await instantiate(tracked);
+      const targetExpectedNames = [...expectedNames, ...(target === "wasi" ? ["memory"] : [])].sort();
+      expect(Object.keys(untrackedExports).sort(), `${target} public names`).toEqual(targetExpectedNames);
+      expect(Object.keys(trackedExports).sort(), `${target} tracked public names`).toEqual(targetExpectedNames);
+      expect(
+        Object.keys(untrackedExports).filter(isVecHostBridgePhysicalExport).sort(),
+        `${target} physical collision names`,
+      ).toEqual(PREFIX_ONLY_COLLISION_VALUES.map(([name]) => name).sort());
+      expect(
+        Object.keys(trackedExports).filter(isVecHostBridgePhysicalExport).sort(),
+        `${target} tracked physical collision names`,
+      ).toEqual(PREFIX_ONLY_COLLISION_VALUES.map(([name]) => name).sort());
+      assertFunctionValueCensus(untrackedExports, PREFIX_ONLY_COLLISION_VALUES);
+      assertFunctionValueCensus(trackedExports, PREFIX_ONLY_COLLISION_VALUES);
+    }
   });
 
   it("fills sparse physical gaps without rebasing any occupied user descriptor", async () => {
@@ -433,6 +581,33 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
 
     const wrapped = wrapExports(rawExports);
     expect(wrapped.mkInstance()).toEqual({});
+  });
+
+  it("keeps array-free logical and physical spoof exports public without a vec family", async () => {
+    for (const [target, source, name, value] of [
+      ["standalone", ARRAY_FREE_LOGICAL_SPOOF_SOURCE, "__vec_len", 702],
+      ["wasi", ARRAY_FREE_LOGICAL_SPOOF_SOURCE, "__vec_len", 702],
+      ["standalone", ARRAY_FREE_PHYSICAL_SPOOF_SOURCE, "$v0", 701],
+      ["wasi", ARRAY_FREE_PHYSICAL_SPOOF_SOURCE, "$v0", 701],
+    ] as const) {
+      const result = await compile(source, {
+        fileName: `vec-array-free-spoof-${target}-${name.replaceAll("$", "s")}.ts`,
+        experimentalIR: true,
+        target,
+        trackIrOutcomes: true,
+      });
+      expect(result.success, `${target} ${name}`).toBe(true);
+      expect(result.imports, `${target} ${name} imports`).toEqual([]);
+      expect(result.programAbi?.abi.entries().filter((entry) => entry.id.includes(VEC_HOST_BRIDGE_ROLE)) ?? []).toEqual(
+        [],
+      );
+      const rawExports = await instantiate(result);
+      expect(Object.keys(rawExports)).toContain(name);
+      expect((rawExports[name] as () => number)()).toBe(value);
+      expect(Object.keys(rawExports).filter(isVecHostBridgePhysicalExport)).toEqual(
+        name.startsWith("$v") ? [name] : [],
+      );
+    }
   });
 
   it("aborts compilation when structural vec ABI observation fails", () => {
@@ -538,6 +713,27 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
       registry.ctx.emitHostBridge = false;
       expect(result.module.exports).toContain(entry);
       expect(() => finalizeVecHostBridgeExports(registry.ctx)).toThrow(/survived disabled host-bridge policy/);
+    } finally {
+      registry.ctx.emitHostBridge = originalEmitHostBridge;
+    }
+  });
+
+  it("strips a cloned descriptor that still resolves to the exact compiler allocator", () => {
+    const { registry, result } = generateWithCapturedRegistry(ARRAY_SOURCE, "vec-export-cloned-descriptor.ts");
+    const entryIndex = result.module.exports.findIndex(
+      (candidate) => candidate.name === "__vec_len" && candidate.desc.kind === "func",
+    );
+    if (entryIndex < 0) throw new Error("missing compiler-owned vec export for cloned-descriptor");
+    const entry = result.module.exports[entryIndex]!;
+    if (entry.desc.kind !== "func") throw new Error("vec clone source changed export kind");
+    const clone: WasmExport = { name: entry.name, desc: { kind: "func", index: entry.desc.index } };
+    result.module.exports[entryIndex] = clone;
+    const originalEmitHostBridge = registry.ctx.emitHostBridge;
+    try {
+      registry.ctx.emitHostBridge = false;
+      expect(result.module.exports).toContain(clone);
+      expect(stripHostBridgeExports(registry.ctx)).toBeGreaterThan(0);
+      expect(result.module.exports).not.toContain(clone);
     } finally {
       registry.ctx.emitHostBridge = originalEmitHostBridge;
     }


### PR DESCRIPTION
## Summary

- record the exact three compiler-published Date carrier descriptors and allocator objects
- validate the complete census once and fail closed on descriptor or allocator drift
- strip authenticated Date helpers from standalone and WASI while preserving same-spelled user exports
- enforce live/stable handle regimes and Date-before-constructor/vec namespace ownership
- add exact single- and multi-source target, tracking, runtime, collision, and mutation coverage

## Stack note

This branch is built on exact C38 head d4a6c363539b885b82a8cccbb7317e4079569ee2. GitHub cannot use the fork-only C38 head as an upstream base, so this draft temporarily targets the same C36 base as PR #5298 and shows the already-reviewed C37 and C38 deltas cumulatively. Keep it draft until #5295 and #5298 land; then retarget to main, revalidate the C39-only diff, and repeat exact-SHA review.

## Validation

- C39 + C37 vec + C38 closure + #4616 Date controls: 62/62
- full changed-root precommit controls: 60/60
- TypeScript 7 and TypeScript 5 typechecks
- IR layering, dead exports, coercion sites, IR fallbacks, and host-import policy
- targeted Biome, Prettier, and diff checks
- LOC and function ratchets immediately before commit
- complete precommit and prepush hooks
- signed commit verified at 3ab607f311922f8f6a92e551ea456848ae57f8d2

## Known control

The byte-identical #4035 policy test remains 5/6: only the pre-existing 32,691-byte result exceeds its unchanged 20,000-byte ceiling. This PR does not edit or reclassify that ceiling.

## Review

Fresh independent Sol review of exact pushed SHA 3ab607f311922f8f6a92e551ea456848ae57f8d2 is pending.

Refs #3520