### PR TITLE
fix(capabilities): reject duplicate provider imports

### DIFF
--- a/plan/issues/4398-target-neutral-explicit-platform-capability-providers.md
+++ b/plan/issues/4398-target-neutral-explicit-platform-capability-providers.md
@@ -3,7 +3,7 @@ id: 4398
 title: "Target-neutral explicit platform capabilities with swappable providers"
 status: done
 created: 2026-08-13
-updated: 2026-08-18
+updated: 2026-08-30
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -97,3 +97,91 @@ This issue is about platform authority, not ECMAScript semantic fallback.
 
 Follow-up: source-site provenance and rewrite hints remain broader #4382
 explanation work; they do not change the completed capability/provider ABI.
+
+## 2026-08-30 follow-up lock — duplicate import authentication
+
+This Sol-authored repair is based on refreshed exact `main`
+`01fb67624e2f645b7e92dd9f8e47478e3face9ba` and belongs to #4398 rather than
+the #3520 C36–C39 export-provenance stack. Implement it on
+`codex/4398-capability-duplicate-auth`. The open-PR/worktree audit found no
+owner for `src/capability-registry.ts` or the focused #4398 test; do not touch
+the callable/publication, Program-ABI, `from-ast`, propagation, selection,
+host-bridge, or C36–C39 files being changed by parallel sessions.
+
+### Deterministic false-pass
+
+The emit-time standalone/WASI leak backstop intentionally collapses duplicate
+imports to one `(module,name)` diagnostic. Its timer, DOM, and DOM-interaction
+exemptions then search the module for *any* same-named entry for which
+`isValidatedPlatformCapabilityImport(...)` returns true. A finished module
+containing one exact `env.__timer_set_timeout` import beside a malformed import
+with the same module and name therefore produces one leak row, but the exact
+sibling authenticates the row and removes it. The malformed duplicate reaches
+the binary without a leak diagnostic. Direct mutation is in scope for this
+backstop: it exists specifically to catch imports that bypass normal registry
+insertion or retain stale bookkeeping.
+
+Clock already closes this boundary by requiring exactly one `env.__date_now`
+entry. Timer, DOM, and DOM-interaction imports must have the same exact
+cardinality property without changing leak diagnostic deduplication.
+
+### Authorized implementation
+
+Own only:
+
+- this issue record;
+- `src/capability-registry.ts`; and
+- `tests/issue-4398-capability-registry.test.ts`.
+
+Strengthen `isValidatedPlatformCapabilityImport(...)` itself. Before accepting
+the candidate import contract, require the module to contain exactly one import
+whose module and name equal the selected entry, and require that sole occurrence
+to be the entry at `importIndex`. Count every descriptor kind and signature in
+that same-name census: one exact function plus one malformed function, global,
+or other descriptor is ambiguous and must reject. Keep the existing provider,
+environment, namespace, kind, parameter, and result validation byte-for-byte
+after the uniqueness guard.
+
+Do not scan only registry-matching entries, choose a preferred occurrence,
+deduplicate before validation, repair or remove imports, add provenance, change
+`scanForLeakedHostImports(...)`, or edit the `.some(...)` callers in
+`src/codegen/index.ts`. Their existing search becomes safe because every
+same-name candidate returns false when the census is not exactly one. Imports
+with a different module or different name remain independent.
+
+### Required focused matrix
+
+Use real `WasmModule` import/type descriptors and the exported registry
+validator. For the timer, one base DOM contract, and one DOM-interaction
+contract, prove:
+
+1. one exact import authenticates;
+2. exact plus malformed same-name import authenticates neither occurrence;
+3. two exact same-name imports authenticate neither occurrence; and
+4. a malformed-only import remains rejected.
+
+For at least the timer mutation, combine the existing leak scanner with the
+same `.some(...)` predicate used by the production exemption: require the
+deduplicated leak row to remain present because no occurrence authenticates.
+Add a different-name sibling control proving uniqueness is scoped to the exact
+`(module,name)` pair. Keep the #4577 unique/duplicate clock controls unchanged,
+and preserve the existing compiled timer/provider/runtime tests in this file.
+No synthetic success based only on counts is acceptance evidence: assert the
+candidate indices, exact names, signatures, per-occurrence validator results,
+and final leak row.
+
+### Acceptance and workflow
+
+Run the focused #4398 and #4577 suites, TypeScript 7 and 5, targeted
+Prettier/Biome, `git diff --check`, host-import policy, issue integrity, and
+applicable layering/oracle ratchets. Before every heavy command, require a
+finite, non-negative one-minute load strictly below `logical cores - 2`.
+Immediately before the signed commit run both LOC and function regrowth
+ratchets, then run complete precommit and prepush hooks without bypass. No
+baseline or hook exception is authorized.
+
+A bounded implementation may be delegated only after this lock. Before the PR
+is marked ready, a fresh independent Sol must review the exact pushed SHA for
+the three capability families, the exact-cardinality boundary, non-vacuous leak
+retention, different-name control, unchanged clock behavior, and non-overlap
+with active migration lanes. Any later push invalidates that approval.

--- a/src/capability-registry.ts
+++ b/src/capability-registry.ts
@@ -315,6 +315,15 @@ export function isValidatedPlatformCapabilityImport(
   ) {
     return false;
   }
+  // A public module import name is not authority: a malformed or repeated
+  // descriptor can share the same `(module, name)` spelling as the
+  // compiler-owned provider entry.  Count every descriptor kind in the
+  // finished import section before authenticating the candidate, and require
+  // the sole occurrence to be the exact index under review.
+  const matchingImportIndexes = mod.imports.flatMap((candidate, index) =>
+    candidate.module === entry.module && candidate.name === entry.name ? [index] : [],
+  );
+  if (matchingImportIndexes.length !== 1 || matchingImportIndexes[0] !== importIndex) return false;
   const actual: CapabilityImportRequirement = {
     module: entry.module,
     name: entry.name,

--- a/tests/issue-4398-capability-registry.test.ts
+++ b/tests/issue-4398-capability-registry.test.ts
@@ -1,8 +1,162 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { describe, expect, it } from "vitest";
+import { isValidatedPlatformCapabilityImport, type CapabilityProviderId } from "../src/capability-registry.js";
+import { scanForLeakedHostImports } from "../src/codegen/host-import-allowlist.js";
 import { compile, formatCompileExplanation, validatePlatformCapabilityRequirements } from "../src/index.js";
+import { createEmptyModule, type ValType, type WasmModule } from "../src/ir/types.js";
 import { buildCompiledAdapterImports, buildCompiledImports } from "../src/runtime.js";
+
+const AUTHENTICATION_CASES = [
+  {
+    capabilityId: "timers",
+    name: "__timer_set_timeout",
+    params: ["externref", "externref"],
+    results: ["externref"],
+  },
+  {
+    capabilityId: "dom",
+    name: "global_document",
+    params: [],
+    results: ["externref"],
+  },
+  {
+    capabilityId: "dom-interaction",
+    name: "CSSStyleDeclaration_set_background",
+    params: ["externref", "externref"],
+    results: [],
+  },
+] as const satisfies ReadonlyArray<{
+  capabilityId: "timers" | "dom" | "dom-interaction";
+  name: string;
+  params: readonly string[];
+  results: readonly string[];
+}>;
+
+function wasmValType(name: string): ValType {
+  if (name === "externref") return { kind: "externref" };
+  if (name === "i32") return { kind: "i32" };
+  throw new Error(`unsupported test value type: ${name}`);
+}
+
+function moduleWithCapabilityImports(
+  capabilityCase: (typeof AUTHENTICATION_CASES)[number],
+  occurrences: ReadonlyArray<"exact" | "malformed">,
+  siblingName?: string,
+): WasmModule {
+  const module = createEmptyModule();
+  module.types.push({
+    kind: "func",
+    params: capabilityCase.params.map(wasmValType),
+    results: capabilityCase.results.map(wasmValType),
+  });
+  module.imports.push(
+    ...occurrences.map((occurrence) => ({
+      module: "env",
+      name: capabilityCase.name,
+      desc:
+        occurrence === "exact"
+          ? ({ kind: "func", typeIdx: 0 } as const)
+          : ({ kind: "global", type: { kind: "i32" } as const, mutable: false } as const),
+    })),
+  );
+  if (siblingName) {
+    module.imports.push({
+      module: "env",
+      name: siblingName,
+      desc: { kind: "func", typeIdx: 0 },
+    });
+  }
+  return module;
+}
+
+function importShape(module: WasmModule): unknown[] {
+  return module.imports.map((entry, index) => ({
+    index,
+    module: entry.module,
+    name: entry.name,
+    kind: entry.desc.kind,
+    ...(entry.desc.kind === "func" ? { typeIdx: entry.desc.typeIdx } : { type: entry.desc.type }),
+  }));
+}
+
+describe("#4398 duplicate platform-capability import authentication", () => {
+  for (const capabilityCase of AUTHENTICATION_CASES) {
+    const providerId: CapabilityProviderId = "embedder";
+    const validate = (module: WasmModule, importIndex: number): boolean =>
+      isValidatedPlatformCapabilityImport(module, importIndex, capabilityCase.capabilityId, providerId, "none");
+
+    it(`${capabilityCase.capabilityId}: authenticates one exact Wasm import and its ABI`, () => {
+      const module = moduleWithCapabilityImports(capabilityCase, ["exact"]);
+      expect(importShape(module)).toEqual([
+        { index: 0, module: "env", name: capabilityCase.name, kind: "func", typeIdx: 0 },
+      ]);
+      expect(module.types).toEqual([
+        {
+          kind: "func",
+          params: capabilityCase.params.map(wasmValType),
+          results: capabilityCase.results.map(wasmValType),
+        },
+      ]);
+      expect(validate(module, 0)).toBe(true);
+    });
+
+    it(`${capabilityCase.capabilityId}: rejects exact plus malformed same-name imports`, () => {
+      const module = moduleWithCapabilityImports(capabilityCase, ["exact", "malformed"]);
+      expect(importShape(module)).toEqual([
+        { index: 0, module: "env", name: capabilityCase.name, kind: "func", typeIdx: 0 },
+        { index: 1, module: "env", name: capabilityCase.name, kind: "global", type: { kind: "i32" } },
+      ]);
+      expect([0, 1].map((index) => validate(module, index))).toEqual([false, false]);
+    });
+
+    it(`${capabilityCase.capabilityId}: rejects two exact same-name imports`, () => {
+      const module = moduleWithCapabilityImports(capabilityCase, ["exact", "exact"]);
+      expect(importShape(module)).toEqual([
+        { index: 0, module: "env", name: capabilityCase.name, kind: "func", typeIdx: 0 },
+        { index: 1, module: "env", name: capabilityCase.name, kind: "func", typeIdx: 0 },
+      ]);
+      expect([0, 1].map((index) => validate(module, index))).toEqual([false, false]);
+    });
+
+    it(`${capabilityCase.capabilityId}: rejects a malformed-only import`, () => {
+      const module = moduleWithCapabilityImports(capabilityCase, ["malformed"]);
+      expect(importShape(module)).toEqual([
+        { index: 0, module: "env", name: capabilityCase.name, kind: "global", type: { kind: "i32" } },
+      ]);
+      expect(validate(module, 0)).toBe(false);
+    });
+
+    it(`${capabilityCase.capabilityId}: scopes uniqueness to the exact module/name pair`, () => {
+      const siblingName = `${capabilityCase.name}_different`;
+      const module = moduleWithCapabilityImports(capabilityCase, ["exact"], siblingName);
+      expect(importShape(module)).toEqual([
+        { index: 0, module: "env", name: capabilityCase.name, kind: "func", typeIdx: 0 },
+        { index: 1, module: "env", name: siblingName, kind: "func", typeIdx: 0 },
+      ]);
+      expect(validate(module, 0)).toBe(true);
+      expect(validate(module, 1)).toBe(false);
+    });
+  }
+
+  it("retains a deduplicated timer leak when exact-name authentication is ambiguous", () => {
+    const timer = AUTHENTICATION_CASES[0]!;
+    const module = moduleWithCapabilityImports(timer, ["exact", "malformed"]);
+    const leaks = scanForLeakedHostImports(module.imports);
+    expect(leaks).toEqual([{ module: "env", name: timer.name, reason: "env-not-on-allowlist" }]);
+
+    const retainedLeaks = leaks.filter(
+      ({ module: leakModule, name: leakName }) =>
+        !module.imports.some(
+          (entry, index) =>
+            entry.module === leakModule &&
+            entry.name === leakName &&
+            isValidatedPlatformCapabilityImport(module, index, timer.capabilityId, "embedder", "none"),
+        ),
+    );
+    expect(retainedLeaks).toEqual(leaks);
+  });
+});
 
 describe("#4398 explicit platform capability requirements", () => {
   it("selects the target-specific timer provider and records its exact ABI", async () => {


### PR DESCRIPTION
## Summary

- require a platform-capability import to be the sole exact module/name occurrence before its ABI can authorize a standalone leak exemption
- keep timer, DOM, and DOM-interaction leak authentication fail closed when malformed or duplicate same-name siblings exist
- cover real WasmModule descriptor matrices and production-shaped deduplicated leak retention

## Validation

- focused issue #4398 and #4577 suites: 45/45 passed
- TS7 and TS5 typechecks passed
- targeted Biome, Prettier, diff check, IR layering, host-import policy, LOC ratchet, and function ratchet passed
- full precommit and prepush hooks passed
- independent Sol exact-SHA review approved 68319efa3dbc7926f85eacf865943da05ec0c68f

Refs #4398