### PR TITLE
docs(issues): plan authoritative ES2015 census

### DIFF
--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -1,6 +1,6 @@
 ---
 id: 4444
-title: "UMBRELLA: ES6 (ES2015) standalone edition close-out — 8,681/11,704 (74%) → 100%"
+title: "UMBRELLA: ES6 (ES2015) standalone authoritative 11,704-row close-out → 100%"
 status: in-progress
 sprint: current
 created: 2026-08-15
@@ -214,3 +214,61 @@ PR from `ttraenkler/js2` to `loopdive/js2`; only an incomplete or genuinely
 non-mergeable checkpoint may remain draft. A separate shepherd agent verifies
 the required PR body, mergeability, reviews, CI, exact tested head, and
 ready/queue state before landing.
+
+## 2026-08-30 current integrated-head census implementation plan
+
+The numeric title no longer repeats the stale 2026-08-28 snapshot. Historical
+measurements above remain useful dispatch evidence, but none is the acceptance
+numerator. The next headline will be written only from a complete maintained-
+runner census on one exact integrated upstream commit.
+
+At this checkpoint, freshly fetched `loopdive/js2` main is
+`01fb67624e2f645b7e92dd9f8e47478e3face9ba`. RegExp Slice A PR #5296 is merged
+there. TypedArray `set` Slice A PR #5300 is non-draft at exact tested head
+`a6bd6301007e37d289e9378a97891a44846e33f9` and is already in the upstream
+merge queue; the census must not start until that exact change lands and this
+worktree is fast-forwarded or merged to the resulting current main. The
+documentation-only ES2018 tracker PR #5304 does not affect the ES2015
+denominator. #5131's two fixed empty-spread rows are unclassified, and #5216's
+object-spread rows classify as ES2018, so neither may be added to the ES2015
+numerator.
+
+The selection authority is the frozen 11,704-path artifact
+`/private/tmp/js2-es2015-11704-pr5008.txt`, whose LF-normalized SHA-256 is
+`45de809c6bfce7371cee1d20e327758246b0524ecd75481a08b8c03344fced8a`.
+Every entry has a leading `test/`; removing only that prefix produces 11,704
+unique `test262/test`-relative paths with SHA-256
+`90d5e85a13e3721c8e53734e21c01ec894f736412048cf4d8b15ca7ecc47c2cd`.
+Before execution, regenerate that normalized file in this worktree's temporary
+area, require exact set equality and 11,704 existing files, and record the
+Test262 gitlink/checkout `b363f29d3c43c626dc852744ad64a0b48a003693`.
+
+Execution uses the maintained `scripts/run-test262-vitest.sh` path, not a
+hand-written verdict approximation: `TEST262_TARGET=standalone`,
+`TEST262_PATH_FILTER_FILE=<normalized exact map>`, official scope only,
+`TEST262_WORKERS=1`, `COMPILER_POOL_SIZE=1`, `VITEST_MAX_FORKS=1`, and the
+pinned QuickJS artifact
+`/private/tmp/js2-quickjs-artifact-2e2d7736713beeda`. Keep one compiler/test
+worker for this lane and at most two globally. Disable history publication for
+the scoped run. Preserve the timestamped JSONL, report, per-shard completion
+manifests, source commit, filter hashes, command, and elapsed time in this
+tracker before making any claim.
+
+Completeness is a hard gate, not an inference from Vitest's console summary.
+The final report must reconcile exactly 11,704 registered tests, 11,704 started
+callbacks, 11,704 settled callbacks, 11,704 physical canonical rows, and
+11,704 unique selected paths, with no duplicate, malformed, outside-filter, or
+missing row. The acceptance result is exactly **11,704 pass / 11,704 total, 0
+fail, 0 compile_error, 0 compile_timeout, 0 skip**, with every passing module
+host-import free. Any other result keeps this umbrella in progress.
+
+If non-pass rows remain, cluster only this fresh integrated-head artifact by
+stable error signature and provider boundary. Root first updates or allocates
+one repository-local `plan/issues/*.md` tracker per bounded cluster (new IDs
+only through `node scripts/claim-issue.mjs --allocate`), records its exact path
+set and implementation plan, and only then fans implementation to Luna Max
+agents in separate provisioned worktrees. Each completed fix gets one
+mergeable non-draft upstream PR from `ttraenkler/js2`; a genuinely incomplete
+or non-mergeable checkpoint alone may remain draft. The dedicated PR shepherd
+owns exact head/body/repository/readiness/check/conflict/queue verification.
+No GitHub issue is created.

--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -236,12 +236,16 @@ numerator.
 The selection authority is the frozen 11,704-path artifact
 `/private/tmp/js2-es2015-11704-pr5008.txt`, whose LF-normalized SHA-256 is
 `45de809c6bfce7371cee1d20e327758246b0524ecd75481a08b8c03344fced8a`.
-Every entry has a leading `test/`; removing only that prefix produces 11,704
-unique `test262/test`-relative paths with SHA-256
-`90d5e85a13e3721c8e53734e21c01ec894f736412048cf4d8b15ca7ecc47c2cd`.
-Before execution, regenerate that normalized file in this worktree's temporary
-area, require exact set equality and 11,704 existing files, and record the
-Test262 gitlink/checkout `b363f29d3c43c626dc852744ad64a0b48a003693`.
+Every entry intentionally retains the leading `test/`: the maintained shard
+runner computes each filter key with `relative(TEST262_ROOT, filePath)`, where
+`TEST262_ROOT` is the Test262 checkout rather than its `test/` child. Removing
+the prefix would therefore register zero selected rows. Before execution, copy
+the authoritative bytes unchanged into this worktree's temporary area,
+require the same hash, 11,704 physical and unique entries, exact set equality,
+and 11,704 files existing below the Test262 checkout. Record the Test262
+gitlink/checkout `b363f29d3c43c626dc852744ad64a0b48a003693`. A no-prefix
+derivative is valid only for helpers that explicitly resolve relative to
+`test262/test`; it is not the maintained sharded-runner filter.
 
 Execution uses the maintained `scripts/run-test262-vitest.sh` path, not a
 hand-written verdict approximation: `TEST262_TARGET=standalone`,


### PR DESCRIPTION
## Description

Problem: The ES2015 umbrella headline still repeated a stale pre-integration pass count, while final acceptance requires one complete 11,704-row standalone census on the exact integrated upstream head.

Behavior: Replace the stale numeric title with a commit-bound implementation plan that freezes the exact path/filter hashes, maintained runner configuration, completeness reconciliation, zero-non-pass acceptance gate, and issue-first Luna Max fanout policy. This checkpoint changes no compiler or runtime behavior.

Tests: Normal commit and pre-push hooks passed, including TypeScript 7, lint, Prettier, LOC/function budgets, oracle/coercion ratchets, issue integrity, and 18/18 numeric-local parity. The frozen map was independently verified as 11,704 unique `test/...` runner keys at Test262 gitlink `b363f29d3c43c626dc852744ad64a0b48a003693`; the maintained filter retains that prefix.

Quality: The branch is based on current upstream `01fb67624e2f645b7e92dd9f8e47478e3face9ba`; it records #5300 as a queue dependency and makes no fresh pass-rate claim before that integrated-head census runs.

Tracking: `plan/issues/4444-es6-standalone-edition-closeout-umbrella.md` is the sole umbrella issue record and contains the implementation and handoff plan. No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->
