### PR TITLE
fix(ir): relock linked parser collector to production ABI

### DIFF
--- a/scripts/r2-linked-parser-ab-collection-v2/README.md
+++ b/scripts/r2-linked-parser-ab-collection-v2/README.md
@@ -16,10 +16,10 @@ relock; nothing here authorises that run.
 
 | file                 | role                                                                                                                                   |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `contract.mjs`       | the fail-closed oracle: canonical 16+8 matrix, pins, census states, declaration census, outcome joins, exact WAT ABI carriers, digests |
+| `contract.mjs`       | the fail-closed oracle: canonical 16+8 matrix, pins, census states, exact physical-row/outcome joins, host-scoped normalized ABI descriptors, digests |
 | `fixtures.mjs`       | canonical 24-child report fixture plus every mutation operator                                                                         |
 | `baseline-naive.mjs` | **reconstructed pre-repair baseline** — see caveat below                                                                               |
-| `selftest.mjs`       | static selftest and the five non-vacuity proofs                                                                                        |
+| `selftest.mjs`       | static selftest, five audit non-vacuity proofs, and four production-model relock proofs                                               |
 | `relock.mjs`         | manifest relock and `bundle/` byte-equality gate                                                                                       |
 | `manifest.json`      | relocked source digests, pins, expected census, root hash                                                                              |
 | `bundle/`            | byte-for-byte mirror of every source above                                                                                             |
@@ -35,9 +35,9 @@ fail-closed check with a runnable two-sided mutation in `selftest.mjs`:
 | #   | false pass                                                                  | repair                                                                                                           | failure code                            |
 | --- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
 | D1  | an arbitrary extra unitless `compileDeclarations` call passed               | the physical-row census is CLOSED: every row joins an inventory unit or is the one sanctioned unitless exception | `declaration/unsanctioned-unitless-row` |
-| D2  | a wrong-file prepared module-init outcome passed                            | outcomes join their inventory unit on every field, not by key presence                                           | `outcome/join-mismatch`                 |
+| D2  | a wrong-file direct-legacy module-init outcome passed                       | outcomes join their inventory unit on every field, not by key presence                                           | `outcome/join-mismatch`                 |
 | D3  | a duplicate outcome key passed                                              | the outcome index detects duplicates instead of `map.set` overwriting                                            | `outcome/duplicate-key`                 |
-| D4  | the parser's second WAT parameter `i32`→`f32` passed with hashes recomputed | the exact expected ABI is carried structurally, not only as a hash                                               | `wat/abi-mismatch`                      |
+| D4  | `stringToNumber`'s second WAT parameter `i32`→`f32` passed with hashes recomputed | the exact expected ABI is carried structurally, not only as a hash                                               | `wat/abi-mismatch`                      |
 | D5  | attempted/spawned/completed collapsed when a spawn threw                    | the three states are derived separately per child and cross-checked against the reported counters                | `census/state-collapse`                 |
 
 ## Caveat: `baseline-naive.mjs` is a RECONSTRUCTION
@@ -54,17 +54,24 @@ exactly one defect. This makes each mutation demonstrably non-vacuous — but
 evidence produced against it is evidence about the reconstruction, **not an
 observation of the original collector**, and must never be reported as one.
 
-## Open items for the independent auditor
+## Relocked production model
 
-1. **`EXPECTED_WAT_ABI` values are pinned placeholders.** The repair is that the
-   ABI is carried _exactly_ rather than by hash; the specific parameter and
-   result types must be confirmed against the landed L3 production ABI and
-   re-pinned under the approved relock before any collection.
-2. **The sole exception is enforced per child.** The issue says "each side must
-   retain exactly one copy" of the graph-global unitless `compileModuleInitBody`
-   row against `entry.mjs`. Each child is a separate compilation of the graph,
-   so the contract requires exactly one per child record. Confirm this reading.
-3. **The fixture is synthetic.** `fixtures.mjs` hand-builds a canonical report;
-   it is not a captured collection. The inventory shape (one owned module-init
-   unit in `empty.mjs`) follows the issue's description of the current bounded
-   multi-source exception and needs confirming against a real frozen inventory.
+The independent production readout closes the former placeholders:
+
+- `standalone` pins `stringToNumber(ref null $AnyString,i32)->f64`,
+  `readNumber(ref null $__fnctor_Parser)->f64`, and `run()->f64`.
+- `host` pins `stringToNumber(externref,i32)->f64`,
+  `readNumber(externref)->f64`, and `run()->f64`. The descriptors contain named
+  physical references, never numeric type indexes.
+- Every child contains exactly two physical rows: one owned
+  `empty.mjs::__module_init` direct-legacy row and exactly one immutable,
+  unitless graph-global `entry.mjs` exception. The outer `prepared` tuple does
+  not convert that module-init body into a Prepared terminal.
+- Every child records the owned module-init as direct legacy with the exact
+  `body-shape-rejected` terminal outcome. The fixture therefore reflects the
+  same physical row and outcome on both outer direct and prepared routes.
+
+`P1`–`P4` in the static selftest mutate the host ABI, module-init route,
+physical row, and terminal outcome. Each still passes the reconstructed
+hash/presence baseline but fails the repaired contract, proving the new checks
+are non-vacuous. No runtime collection is run by these scripts.

--- a/scripts/r2-linked-parser-ab-collection-v2/baseline-naive.mjs
+++ b/scripts/r2-linked-parser-ab-collection-v2/baseline-naive.mjs
@@ -108,7 +108,7 @@ function naiveWatCarriers(child, failures) {
     return;
   }
   for (const [name, observed] of Object.entries(carriers)) {
-    const recomputed = sha256(canonicalWatText(observed));
+    const recomputed = sha256(canonicalWatText(name, observed));
     if (observed.sha256 !== recomputed || manifest[name] !== recomputed) {
       failures.add("wat/hash-mismatch", key, `carrier ${name} hash is not self-consistent`);
     }

--- a/scripts/r2-linked-parser-ab-collection-v2/bundle/baseline-naive.mjs
+++ b/scripts/r2-linked-parser-ab-collection-v2/bundle/baseline-naive.mjs
@@ -108,7 +108,7 @@ function naiveWatCarriers(child, failures) {
     return;
   }
   for (const [name, observed] of Object.entries(carriers)) {
-    const recomputed = sha256(canonicalWatText(observed));
+    const recomputed = sha256(canonicalWatText(name, observed));
     if (observed.sha256 !== recomputed || manifest[name] !== recomputed) {
       failures.add("wat/hash-mismatch", key, `carrier ${name} hash is not self-consistent`);
     }

--- a/scripts/r2-linked-parser-ab-collection-v2/bundle/contract.mjs
+++ b/scripts/r2-linked-parser-ab-collection-v2/bundle/contract.mjs
@@ -75,30 +75,60 @@ export const SANCTIONED_EXCEPTION = Object.freeze({
   structurallyComplete: false,
 });
 
-// DEFECT 4 CARRIER. The exact expected WAT ABI, carried structurally rather
-// than as a hash. A hash-only carrier cannot see an i32 -> f32 parameter
-// change once the report's own manifest hash is recomputed alongside it.
-// These values are the committed contract; changing them requires an approved
-// relock, not a collector edit.
+// The frozen production inventory has one local module-init unit. It remains a
+// direct legacy body on BOTH outer collection routes: the outer "prepared"
+// route is the linked-parser overlay choice, not permission to invent a
+// Prepared module-init terminal.
+export const OWNED_MODULE_INIT = Object.freeze({
+  unit: "empty.mjs::__module_init",
+  source: "empty.mjs",
+  file: "empty.mjs",
+  kind: "module-init",
+  selfOwner: "inventory",
+  disposition: "legacy-ast-entry",
+});
+
+export const OWNED_MODULE_INIT_PHYSICAL = Object.freeze({
+  fn: "compileModuleInitBody",
+  structurallyComplete: true,
+  bodyRoute: "direct-legacy",
+  count: 1,
+});
+
+export const OWNED_MODULE_INIT_OUTCOME = Object.freeze({
+  bodyRoute: "direct-legacy",
+  outcome: "body-shape-rejected",
+  legacyBodyEmitted: true,
+  irBodyEmitted: false,
+});
+
+// DEFECT 4 CARRIER. These are normalized physical descriptors, keyed by the
+// host that produced the child. Named reference types deliberately replace raw
+// numeric type indexes: a compacted module must not make a type-index spelling
+// look like the same ABI.
 export const EXPECTED_WAT_ABI = Object.freeze({
-  parser: Object.freeze({
-    name: "$js2_linked_parser_parse",
-    params: Object.freeze(["i32", "i32"]),
-    results: Object.freeze(["i32"]),
+  standalone: Object.freeze({
+    stringToNumber: Object.freeze({
+      params: Object.freeze(["ref null $AnyString", "i32"]),
+      results: Object.freeze(["f64"]),
+    }),
+    readNumber: Object.freeze({
+      params: Object.freeze(["ref null $__fnctor_Parser"]),
+      results: Object.freeze(["f64"]),
+    }),
+    run: Object.freeze({ params: Object.freeze([]), results: Object.freeze(["f64"]) }),
   }),
-  caller: Object.freeze({
-    name: "$js2_linked_parser_call",
-    params: Object.freeze(["i32", "i32", "i32"]),
-    results: Object.freeze(["i32"]),
-  }),
-  run: Object.freeze({
-    name: "$js2_linked_parser_run",
-    params: Object.freeze(["i32"]),
-    results: Object.freeze(["i32"]),
+  host: Object.freeze({
+    stringToNumber: Object.freeze({
+      params: Object.freeze(["externref", "i32"]),
+      results: Object.freeze(["f64"]),
+    }),
+    readNumber: Object.freeze({ params: Object.freeze(["externref"]), results: Object.freeze(["f64"]) }),
+    run: Object.freeze({ params: Object.freeze([]), results: Object.freeze(["f64"]) }),
   }),
 });
 
-export const WAT_CARRIERS = Object.freeze(["parser", "caller", "run"]);
+export const WAT_CARRIERS = Object.freeze(["stringToNumber", "readNumber", "run"]);
 
 export const CENSUS_STATES = Object.freeze([
   "scheduled",
@@ -174,10 +204,25 @@ export function sha256(text) {
   return createHash("sha256").update(text, "utf8").digest("hex");
 }
 
-export function canonicalWatText(carrier) {
-  const params = (carrier?.params ?? []).map((p) => `(param ${p})`).join(" ");
-  const results = (carrier?.results ?? []).map((r) => `(result ${r})`).join(" ");
-  return `(func ${carrier?.name ?? ""} ${params} ${results})`.replace(/\s+/g, " ").trim();
+function normalizePhysicalType(type) {
+  if (typeof type !== "string") return null;
+  const compact = type.trim().replace(/\s+/g, " ");
+  const wrappedNullableRef = compact.match(/^\(ref null (\$[A-Za-z0-9_.$-]+)\)$/);
+  return wrappedNullableRef ? `ref null ${wrappedNullableRef[1]}` : compact;
+}
+
+function normalizePhysicalTypes(types) {
+  if (!Array.isArray(types)) return null;
+  const normalized = types.map(normalizePhysicalType);
+  return normalized.every((type) => type !== null) ? normalized : null;
+}
+
+// Hash the normalized descriptor, not a raw WAT declaration. This preserves
+// symbolic reference names while making inconsequential whitespace irrelevant.
+export function canonicalWatText(carrierName, carrier) {
+  const params = normalizePhysicalTypes(carrier?.params) ?? ["<malformed>"];
+  const results = normalizePhysicalTypes(carrier?.results) ?? ["<malformed>"];
+  return `${String(carrierName ?? "")}(${params.join(",")})->${results.join(",")}`;
 }
 
 // --- failure accumulator ----------------------------------------------------
@@ -273,6 +318,7 @@ function repairedCensusCheck(report, failures) {
 
 const EXCEPTION_FIELDS = Object.freeze([
   "fn",
+  "unit",
   "source",
   "file",
   "kind",
@@ -281,17 +327,65 @@ const EXCEPTION_FIELDS = Object.freeze([
   "structurallyComplete",
 ]);
 const JOIN_FIELDS = Object.freeze(["source", "file", "kind", "selfOwner", "disposition"]);
+const INVENTORY_FIELDS = Object.freeze(["unit", ...JOIN_FIELDS]);
+const OWNED_PHYSICAL_FIELDS = Object.freeze(["fn", "structurallyComplete", "bodyRoute", "count"]);
+const OWNED_OUTCOME_FIELDS = Object.freeze(["bodyRoute", "outcome", "legacyBodyEmitted", "irBodyEmitted"]);
 
 function indexInventory(child) {
   const byUnit = new Map();
-  for (const unit of child.record?.inventory?.units ?? []) byUnit.set(unit.unit, unit);
+  for (const unit of child.record?.inventory?.units ?? []) {
+    if (unit !== null && typeof unit === "object") byUnit.set(unit.unit, unit);
+  }
   return byUnit;
+}
+
+function checkCanonicalInventory(child, inventory, failures) {
+  const key = canonicalKey(child);
+  const units = child.record?.inventory?.units;
+  if (!Array.isArray(units)) {
+    failures.add("declaration/malformed-inventory", key, "inventory.units is not an array");
+    return;
+  }
+  if (units.length !== 1) {
+    failures.add(
+      "declaration/inventory-mismatch",
+      key,
+      `expected exactly one owned empty.mjs module-init unit, saw ${units.length}`,
+    );
+  }
+  if (inventory.size !== units.length) {
+    failures.add("declaration/inventory-mismatch", key, "inventory contains a malformed or duplicate unit key");
+  }
+  for (const unit of units) {
+    if (unit === null || typeof unit !== "object") {
+      failures.add("declaration/malformed-inventory", key, "inventory contains a non-object unit");
+      continue;
+    }
+    for (const field of INVENTORY_FIELDS) {
+      if (unit[field] !== OWNED_MODULE_INIT[field]) {
+        failures.add(
+          "declaration/inventory-mismatch",
+          key,
+          `inventory ${field}=${String(unit[field])} != expected ${String(OWNED_MODULE_INIT[field])}`,
+        );
+      }
+    }
+  }
+}
+
+function expectedOwnedPhysicalField(field) {
+  return OWNED_MODULE_INIT_PHYSICAL[field];
+}
+
+function expectedOwnedOutcomeField(field) {
+  return OWNED_MODULE_INIT_OUTCOME[field];
 }
 
 // DEFECT 1 REPAIR. The physical-row census is CLOSED: every row either joins an
 // inventory-owned unit on all join fields, or it is the one sanctioned unitless
-// exception. An arbitrary extra unitless row -- `compileDeclarations` or
-// anything else -- has nowhere to land and fails closed.
+// exception. The current one-unit inventory also has one exact direct legacy
+// physical row on EVERY outer route; a prepared tuple may not manufacture a
+// prepared module-init terminal.
 function repairedDeclarationCensus(child, failures) {
   const key = canonicalKey(child);
   const rows = child.record?.physicalRows;
@@ -300,9 +394,15 @@ function repairedDeclarationCensus(child, failures) {
     return;
   }
   const inventory = indexInventory(child);
+  checkCanonicalInventory(child, inventory, failures);
   const unitless = [];
+  const physicalByUnit = new Map();
 
   for (const row of rows) {
+    if (row === null || typeof row !== "object") {
+      failures.add("declaration/malformed-census", key, "physicalRows contains a non-object row");
+      continue;
+    }
     if (row.unit === null || row.unit === undefined) {
       unitless.push(row);
       continue;
@@ -321,13 +421,32 @@ function repairedDeclarationCensus(child, failures) {
         );
       }
     }
+    if (physicalByUnit.has(row.unit)) {
+      failures.add("declaration/duplicate-physical-row", key, `unit ${row.unit} has more than one physical row`);
+    } else {
+      physicalByUnit.set(row.unit, row);
+    }
+    for (const field of OWNED_PHYSICAL_FIELDS) {
+      const expected = expectedOwnedPhysicalField(field);
+      if (row[field] !== expected) {
+        failures.add(
+          "declaration/physical-row-mismatch",
+          key,
+          `physical row ${row.fn} ${field}=${String(row[field])} != expected ${String(expected)}`,
+        );
+      }
+    }
+  }
+
+  for (const unit of inventory.values()) {
+    if (!physicalByUnit.has(unit.unit)) {
+      failures.add("declaration/missing-physical-row", key, `inventory unit ${unit.unit} has no physical row`);
+    }
   }
 
   if (unitless.length === 0) {
     failures.add("declaration/missing-exception", key, "the graph-global module-init exception is absent");
-    return;
-  }
-  if (unitless.length > 1) {
+  } else if (unitless.length > 1) {
     failures.add(
       "declaration/unsanctioned-unitless-row",
       key,
@@ -357,8 +476,16 @@ function repairedDeclarationCensus(child, failures) {
 function repairedOutcomeIndex(child, failures) {
   const key = canonicalKey(child);
   const outcomes = child.record?.irOutcomes ?? [];
+  if (!Array.isArray(outcomes)) {
+    failures.add("outcome/malformed-census", key, "irOutcomes is not an array");
+    return new Map();
+  }
   const byKey = new Map();
   for (const outcome of outcomes) {
+    if (outcome === null || typeof outcome !== "object") {
+      failures.add("outcome/malformed-census", key, "irOutcomes contains a non-object row");
+      continue;
+    }
     if (byKey.has(outcome.key)) {
       failures.add(
         "outcome/duplicate-key",
@@ -375,8 +502,9 @@ function repairedOutcomeIndex(child, failures) {
 // --- strategy 2: full outcome joins -----------------------------------------
 
 // DEFECT 2 REPAIR. An outcome must join its inventory unit on EVERY field, not
-// merely exist under the right key. A prepared module-init outcome recorded
-// against the wrong file used to pass on key presence alone.
+// merely exist under the right key. Production records the owned module-init as
+// direct legacy / body-shape-rejected on both outer routes, so its exact route
+// and terminal code are part of the join rather than an invented prepared row.
 function repairedOutcomeJoin(child, byKey, failures) {
   const key = canonicalKey(child);
   const inventory = indexInventory(child);
@@ -399,25 +527,25 @@ function repairedOutcomeJoin(child, byKey, failures) {
         );
       }
     }
+    for (const field of OWNED_OUTCOME_FIELDS) {
+      const expected = expectedOwnedOutcomeField(field);
+      if (outcome[field] !== expected) {
+        failures.add(
+          "outcome/terminal-mismatch",
+          key,
+          `outcome ${outcome.key} ${field}=${String(outcome[field])} != expected ${String(expected)}`,
+        );
+      }
+    }
   }
 
-  if (child.route !== "prepared") return;
   for (const unit of inventory.values()) {
-    if (unit.kind !== "module-init") continue;
     const outcome = byKey.get(unit.unit);
     if (!outcome) {
       failures.add(
         "outcome/missing-terminal",
         key,
-        `prepared route has no terminal outcome for inventory unit ${unit.unit}`,
-      );
-      continue;
-    }
-    if (outcome.outcome !== "prepared-terminal") {
-      failures.add(
-        "outcome/missing-terminal",
-        key,
-        `prepared route outcome for ${unit.unit} is ${String(outcome.outcome)}, expected prepared-terminal`,
+        `direct legacy module-init has no terminal outcome for inventory unit ${unit.unit}`,
       );
     }
   }
@@ -434,37 +562,42 @@ function repairedWatCarriers(child, failures) {
   const key = canonicalKey(child);
   const carriers = child.record?.watCarriers;
   const manifest = child.record?.watManifest ?? {};
-  if (!carriers) {
+  const expectedByHost = EXPECTED_WAT_ABI[child.host];
+  if (!expectedByHost) {
+    failures.add("wat/unknown-host-mode", key, `no WAT ABI is pinned for host ${String(child.host)}`);
+    return;
+  }
+  if (carriers === null || typeof carriers !== "object" || Array.isArray(carriers)) {
     failures.add("wat/missing-carrier", key, "watCarriers is absent");
     return;
   }
+  for (const name of Object.keys(carriers)) {
+    if (!WAT_CARRIERS.includes(name)) failures.add("wat/unexpected-carrier", key, `unexpected carrier ${name}`);
+  }
   for (const name of WAT_CARRIERS) {
     const observed = carriers[name];
-    const expected = EXPECTED_WAT_ABI[name];
+    const expected = expectedByHost[name];
     if (!observed) {
       failures.add("wat/missing-carrier", key, `carrier ${name} is absent`);
       continue;
     }
-    if (observed.name !== expected.name) {
-      failures.add("wat/abi-mismatch", key, `carrier ${name} name ${String(observed.name)} != ${expected.name}`);
-    }
-    const observedParams = observed.params ?? [];
+    const observedParams = normalizePhysicalTypes(observed.params);
     if (stableStringify(observedParams) !== stableStringify(expected.params)) {
       failures.add(
         "wat/abi-mismatch",
         key,
-        `carrier ${name} params ${stableStringify(observedParams)} != expected ${stableStringify(expected.params)}`,
+        `carrier ${name} params ${stableStringify(observedParams)} != ${child.host} expected ${stableStringify(expected.params)}`,
       );
     }
-    const observedResults = observed.results ?? [];
+    const observedResults = normalizePhysicalTypes(observed.results);
     if (stableStringify(observedResults) !== stableStringify(expected.results)) {
       failures.add(
         "wat/abi-mismatch",
         key,
-        `carrier ${name} results ${stableStringify(observedResults)} != expected ${stableStringify(expected.results)}`,
+        `carrier ${name} results ${stableStringify(observedResults)} != ${child.host} expected ${stableStringify(expected.results)}`,
       );
     }
-    const recomputed = sha256(canonicalWatText(observed));
+    const recomputed = sha256(canonicalWatText(name, observed));
     if (observed.sha256 !== recomputed) {
       failures.add("wat/hash-mismatch", key, `carrier ${name} sha256 does not match its own WAT text`);
     }
@@ -579,7 +712,7 @@ function checkAccounting(child, failures) {
   if (!(child.side === "candidate" && child.host === "standalone" && child.route === "prepared")) return;
   const key = canonicalKey(child);
   const accounting = child.record?.accounting ?? {};
-  for (const carrier of ["parser", "caller"]) {
+  for (const carrier of ["stringToNumber", "readNumber"]) {
     const entry = accounting[carrier];
     if (entry?.direct !== 1 || entry?.ir !== 1) {
       failures.add(
@@ -589,6 +722,14 @@ function checkAccounting(child, failures) {
       );
     }
   }
+  const run = accounting.run;
+  if (run?.direct !== 1 || run?.ir !== 0) {
+    failures.add(
+      "accounting/mismatch",
+      key,
+      `landed candidate run accounting ${stableStringify(run ?? null)} != {direct:1, ir:0}`,
+    );
+  }
 }
 
 function checkDiagnostics(child, failures) {
@@ -597,15 +738,15 @@ function checkDiagnostics(child, failures) {
   const diagnostics = child.record?.diagnostics ?? [];
   const count = (kind, carrier) => diagnostics.filter((d) => d.kind === kind && d.carrier === carrier).length;
 
-  if (count("post-claim", "parser") !== 1 || count("compile-warning", "parser") !== 1) {
+  if (count("post-claim", "stringToNumber") !== 1 || count("compile-warning", "stringToNumber") !== 1) {
     failures.add(
       "diagnostics/parser-withdrawal",
       key,
-      "historical base standalone/prepared requires exactly one parser post-claim row and its matching compile warning",
+      "historical base standalone/prepared requires exactly one stringToNumber post-claim row and matching compile warning",
     );
   }
-  const callerClaim = count("post-claim", "caller");
-  const callerWarning = count("compile-warning", "caller");
+  const callerClaim = count("post-claim", "readNumber");
+  const callerWarning = count("compile-warning", "readNumber");
   if (callerClaim !== callerWarning || callerClaim > 1) {
     failures.add(
       "diagnostics/caller-cascade",
@@ -622,6 +763,14 @@ function projectChild(child) {
     key: canonicalKey(child),
     revision: child.revision ?? null,
     options: child.options ?? null,
+    inventory: (child.record?.inventory?.units ?? []).map((u) => ({
+      unit: u.unit,
+      source: u.source,
+      file: u.file,
+      kind: u.kind,
+      selfOwner: u.selfOwner,
+      disposition: u.disposition,
+    })),
     physicalRows: (child.record?.physicalRows ?? []).map((r) => ({
       fn: r.fn,
       unit: r.unit ?? null,
@@ -631,6 +780,8 @@ function projectChild(child) {
       selfOwner: r.selfOwner,
       disposition: r.disposition,
       structurallyComplete: r.structurallyComplete,
+      bodyRoute: r.bodyRoute,
+      count: r.count,
     })),
     irOutcomes: (child.record?.irOutcomes ?? []).map((o) => ({
       key: o.key,
@@ -640,9 +791,14 @@ function projectChild(child) {
       kind: o.kind,
       selfOwner: o.selfOwner,
       disposition: o.disposition,
+      bodyRoute: o.bodyRoute,
       outcome: o.outcome,
+      legacyBodyEmitted: o.legacyBodyEmitted,
+      irBodyEmitted: o.irBodyEmitted,
     })),
     watCarriers: child.record?.watCarriers ?? null,
+    diagnostics: child.record?.diagnostics ?? [],
+    accounting: child.record?.accounting ?? {},
   };
 }
 

--- a/scripts/r2-linked-parser-ab-collection-v2/bundle/fixtures.mjs
+++ b/scripts/r2-linked-parser-ab-collection-v2/bundle/fixtures.mjs
@@ -12,6 +12,9 @@
 import {
   EXPECTED_WAT_ABI,
   HOST_OPTIONS,
+  OWNED_MODULE_INIT,
+  OWNED_MODULE_INIT_OUTCOME,
+  OWNED_MODULE_INIT_PHYSICAL,
   PHASE_SIDES,
   PHASE_RANK,
   PINS,
@@ -26,21 +29,14 @@ import {
 // Frozen at relock time; a synthetic 40-hex stand-in for the static fixture.
 export const FIXTURE_LIVE_REVISION = "1111111111111111111111111111111111111111";
 
-const OWNED_UNIT = Object.freeze({
-  unit: "empty.mjs::__module_init",
-  source: "empty.mjs",
-  file: "empty.mjs",
-  kind: "module-init",
-  selfOwner: "inventory",
-  disposition: "owned-terminal",
-});
-
-function watCarriers() {
+function watCarriers(host) {
+  const abiByHost = EXPECTED_WAT_ABI[host];
+  if (!abiByHost) throw new Error(`fixture invariant broken: unknown host ${host}`);
   const out = {};
   for (const name of WAT_CARRIERS) {
-    const abi = EXPECTED_WAT_ABI[name];
-    const carrier = { name: abi.name, params: [...abi.params], results: [...abi.results] };
-    carrier.sha256 = sha256(canonicalWatText(carrier));
+    const abi = abiByHost[name];
+    const carrier = { params: [...abi.params], results: [...abi.results] };
+    carrier.sha256 = sha256(canonicalWatText(name, carrier));
     out[name] = carrier;
   }
   return out;
@@ -52,37 +48,19 @@ function watManifest(carriers) {
   return out;
 }
 
-function physicalRows(route) {
-  const rows = [];
-  if (route === "prepared") {
-    rows.push({
-      fn: "compileModuleInitBody",
-      unit: OWNED_UNIT.unit,
-      source: OWNED_UNIT.source,
-      file: OWNED_UNIT.file,
-      kind: OWNED_UNIT.kind,
-      selfOwner: OWNED_UNIT.selfOwner,
-      disposition: OWNED_UNIT.disposition,
-      structurallyComplete: true,
-    });
-  }
-  // The one immutable v1 graph-global exception, retained verbatim.
-  rows.push({ ...SANCTIONED_EXCEPTION });
-  return rows;
+function physicalRows() {
+  // The owned empty.mjs initializer remains a direct legacy physical root in
+  // BOTH tuple routes. The second row is the sole immutable graph-global
+  // exception, also once per child.
+  return [{ ...OWNED_MODULE_INIT, ...OWNED_MODULE_INIT_PHYSICAL }, { ...SANCTIONED_EXCEPTION }];
 }
 
-function irOutcomes(route) {
-  if (route !== "prepared") return [];
+function irOutcomes() {
   return [
     {
-      key: OWNED_UNIT.unit,
-      unit: OWNED_UNIT.unit,
-      source: OWNED_UNIT.source,
-      file: OWNED_UNIT.file,
-      kind: OWNED_UNIT.kind,
-      selfOwner: OWNED_UNIT.selfOwner,
-      disposition: OWNED_UNIT.disposition,
-      outcome: "prepared-terminal",
+      key: OWNED_MODULE_INIT.unit,
+      ...OWNED_MODULE_INIT,
+      ...OWNED_MODULE_INIT_OUTCOME,
     },
   ];
 }
@@ -93,18 +71,22 @@ function diagnostics(side, host, route) {
   // compile warning are mandatory; the caller cascade is absent here, which is
   // permitted only because BOTH of its rows are absent together.
   return [
-    { kind: "post-claim", carrier: "parser" },
-    { kind: "compile-warning", carrier: "parser" },
+    { kind: "post-claim", carrier: "stringToNumber" },
+    { kind: "compile-warning", carrier: "stringToNumber" },
   ];
 }
 
 function accounting(side, host, route) {
   if (!(side === "candidate" && host === "standalone" && route === "prepared")) return {};
-  return { parser: { direct: 1, ir: 1 }, caller: { direct: 1, ir: 1 } };
+  return {
+    stringToNumber: { direct: 1, ir: 1 },
+    readNumber: { direct: 1, ir: 1 },
+    run: { direct: 1, ir: 0 },
+  };
 }
 
 function buildChild(phase, side, tuple, ordinal) {
-  const carriers = watCarriers();
+  const carriers = watCarriers(tuple.host);
   return {
     ordinal,
     phase,
@@ -126,9 +108,9 @@ function buildChild(phase, side, tuple, ordinal) {
     signal: null,
     timedOut: false,
     record: {
-      inventory: { units: [{ ...OWNED_UNIT }] },
-      physicalRows: physicalRows(tuple.route),
-      irOutcomes: irOutcomes(tuple.route),
+      inventory: { units: [{ ...OWNED_MODULE_INIT }] },
+      physicalRows: physicalRows(),
+      irOutcomes: irOutcomes(),
       watCarriers: carriers,
       watManifest: watManifest(carriers),
       diagnostics: diagnostics(side, tuple.host, tuple.route),
@@ -197,7 +179,7 @@ export function mutateExtraUnitlessDeclaration(report) {
   return next;
 }
 
-// D2: a prepared module-init outcome recorded against the WRONG FILE.
+// D2: a direct-legacy module-init outcome recorded against the WRONG FILE.
 export function mutateWrongFileOutcome(report) {
   const next = clone(report);
   const child = findChild(next, preparedStandaloneCandidate);
@@ -210,19 +192,19 @@ export function mutateDuplicateOutcomeKey(report) {
   const next = clone(report);
   const child = findChild(next, preparedStandaloneCandidate);
   const first = child.record.irOutcomes[0];
-  child.record.irOutcomes.push({ ...first, outcome: "direct-legacy" });
+  child.record.irOutcomes.push({ ...first, outcome: "unexpected-terminal" });
   return next;
 }
 
-// D4: the parser's SECOND WAT PARAMETER changed i32 -> f32, with every hash
-// recomputed so the report stays self-consistent.
+// D4: stringToNumber's SECOND WAT PARAMETER changed i32 -> f32, with every
+// hash recomputed so the report stays self-consistent.
 export function mutateParserSecondParamType(report) {
   const next = clone(report);
   const child = findChild(next, preparedStandaloneCandidate);
-  const parser = child.record.watCarriers.parser;
-  parser.params[1] = "f32";
-  parser.sha256 = sha256(canonicalWatText(parser));
-  child.record.watManifest.parser = parser.sha256;
+  const stringToNumber = child.record.watCarriers.stringToNumber;
+  stringToNumber.params[1] = "f32";
+  stringToNumber.sha256 = sha256(canonicalWatText("stringToNumber", stringToNumber));
+  child.record.watManifest.stringToNumber = stringToNumber.sha256;
   return next;
 }
 
@@ -251,7 +233,7 @@ export const DEFECT_MUTATIONS = Object.freeze([
   },
   {
     id: "D2",
-    title: "wrong-file prepared module-init outcome",
+    title: "wrong-file direct-legacy module-init outcome",
     mutate: mutateWrongFileOutcome,
     repairedCode: "outcome/join-mismatch",
   },
@@ -263,7 +245,7 @@ export const DEFECT_MUTATIONS = Object.freeze([
   },
   {
     id: "D4",
-    title: "parser second WAT parameter i32 -> f32, hashes recomputed",
+    title: "stringToNumber second WAT parameter i32 -> f32, hashes recomputed",
     mutate: mutateParserSecondParamType,
     repairedCode: "wat/abi-mismatch",
   },
@@ -272,6 +254,70 @@ export const DEFECT_MUTATIONS = Object.freeze([
     title: "attempted/spawned/completed collapse when spawn throws",
     mutate: mutateCollapsedSpawnCensus,
     repairedCode: "census/state-collapse",
+  },
+]);
+
+// --- production-evidence relock mutations -----------------------------------
+// These records are not claims about the lost collector. They prove that the
+// reconstructed hash/presence baseline remains permissive while the relocked
+// production model rejects the host, route, physical-row, and terminal drift.
+
+export function mutateWrongHostAbi(report) {
+  const next = clone(report);
+  const child = findChild(next, preparedStandaloneCandidate);
+  const carriers = watCarriers("host");
+  child.record.watCarriers = carriers;
+  child.record.watManifest = watManifest(carriers);
+  return next;
+}
+
+export function mutateWrongModuleInitRoute(report) {
+  const next = clone(report);
+  const child = findChild(next, preparedStandaloneCandidate);
+  child.record.irOutcomes[0].bodyRoute = "prepared";
+  return next;
+}
+
+export function mutateWrongPhysicalRow(report) {
+  const next = clone(report);
+  const child = findChild(next, preparedStandaloneCandidate);
+  const row = child.record.physicalRows.find((candidate) => candidate.unit === OWNED_MODULE_INIT.unit);
+  if (!row) throw new Error("fixture invariant broken: owned physical row not found");
+  row.fn = "compileDeclarations";
+  return next;
+}
+
+export function mutateWrongModuleInitOutcome(report) {
+  const next = clone(report);
+  const child = findChild(next, preparedStandaloneCandidate);
+  child.record.irOutcomes[0].outcome = "prepared-terminal";
+  return next;
+}
+
+export const PRODUCTION_MUTATIONS = Object.freeze([
+  {
+    id: "P1",
+    title: "standalone child carrying the host physical ABI, hashes recomputed",
+    mutate: mutateWrongHostAbi,
+    repairedCode: "wat/abi-mismatch",
+  },
+  {
+    id: "P2",
+    title: "prepared outer tuple inventing a prepared module-init route",
+    mutate: mutateWrongModuleInitRoute,
+    repairedCode: "outcome/terminal-mismatch",
+  },
+  {
+    id: "P3",
+    title: "owned module-init physical row using compileDeclarations",
+    mutate: mutateWrongPhysicalRow,
+    repairedCode: "declaration/physical-row-mismatch",
+  },
+  {
+    id: "P4",
+    title: "owned module-init terminal outcome rewritten as prepared-terminal",
+    mutate: mutateWrongModuleInitOutcome,
+    repairedCode: "outcome/terminal-mismatch",
   },
 ]);
 
@@ -413,7 +459,7 @@ export const STRUCTURAL_MUTATIONS = Object.freeze([
   },
   {
     id: "S14",
-    title: "missing prepared terminal outcome",
+    title: "missing direct-legacy module-init terminal outcome",
     code: "outcome/missing-terminal",
     mutate: (r) => {
       const next = clone(r);
@@ -443,7 +489,7 @@ export const STRUCTURAL_MUTATIONS = Object.freeze([
         next,
         (c) => c.side === "base" && c.host === "standalone" && c.route === "prepared" && c.fixture === "decimal",
       );
-      child.record.diagnostics.push({ kind: "post-claim", carrier: "caller" });
+      child.record.diagnostics.push({ kind: "post-claim", carrier: "readNumber" });
       return next;
     },
   },

--- a/scripts/r2-linked-parser-ab-collection-v2/bundle/selftest.mjs
+++ b/scripts/r2-linked-parser-ab-collection-v2/bundle/selftest.mjs
@@ -11,7 +11,7 @@
 // PROOF OBLIGATION
 // ----------------
 // For each of the five defects the 2026-08-28 independent audit proved to be a
-// FALSE PASS, the mutation must:
+// FALSE PASS, and each production-evidence relock mutation, the mutation must:
 //   1. PASS the reconstructed pre-repair baseline (reproducing the false pass);
 //   2. FAIL the repaired collector with the specific expected failure code; and
 //   3. differ from the canonical report ONLY in that mutation -- established by
@@ -20,7 +20,13 @@
 
 import { computeDigests, validate } from "./contract.mjs";
 import { validateNaive } from "./baseline-naive.mjs";
-import { DEFECT_MUTATIONS, STRUCTURAL_MUTATIONS, buildCanonicalReport, reorderReport } from "./fixtures.mjs";
+import {
+  DEFECT_MUTATIONS,
+  PRODUCTION_MUTATIONS,
+  STRUCTURAL_MUTATIONS,
+  buildCanonicalReport,
+  reorderReport,
+} from "./fixtures.mjs";
 
 let failed = 0;
 const lines = [];
@@ -85,7 +91,32 @@ for (const defect of DEFECT_MUTATIONS) {
   });
 }
 
-// --- 2. structural selftests (repaired collector only) ---------------------
+// --- 2. production-evidence relock mutations, two-sided --------------------
+// The reconstructed baseline intentionally keeps the old hash/presence-only
+// shapes, so these mutations must still pass there. The relocked model must
+// reject each exact wrong host ABI, route, physical row, or terminal outcome.
+lines.push("");
+lines.push("production-evidence relock mutations (baseline must PASS, repaired must FAIL):");
+for (const mutation of PRODUCTION_MUTATIONS) {
+  const mutated = mutation.mutate(canonical);
+  const naive = validateNaive(mutated);
+  const repaired = validate(mutated);
+  const reproduced = naive.status === "PASS";
+  record(
+    reproduced,
+    `${mutation.id} remains permissive on the reconstructed baseline`,
+    `${mutation.title} → ${naive.status}`,
+  );
+  const rejected = repaired.status === "FAILED-DIAGNOSTIC-NOT-ACCEPTANCE";
+  const hasCode = codes(repaired).includes(mutation.repairedCode);
+  record(
+    rejected && hasCode,
+    `${mutation.id} fails closed on the relocked collector`,
+    `${repaired.status} [${codes(repaired).join(", ")}]`,
+  );
+}
+
+// --- 3. structural selftests (repaired collector only) ---------------------
 lines.push("");
 lines.push("structural selftests (repaired collector must FAIL each):");
 for (const mutation of STRUCTURAL_MUTATIONS) {
@@ -94,7 +125,7 @@ for (const mutation of STRUCTURAL_MUTATIONS) {
   record(ok, `${mutation.id} ${mutation.title}`, `${result.status} [${codes(result).join(", ")}]`);
 }
 
-// --- 3. multiple accumulated oracle failures --------------------------------
+// --- 4. multiple accumulated oracle failures --------------------------------
 // The plan requires a semantic failure to publish EVERY oracle failure, not the
 // first one. Compose four independent mutations and require all four codes.
 lines.push("");
@@ -119,7 +150,7 @@ record(
   `${composedResult.failures.length} failures`,
 );
 
-// --- 4. canonical reorder must not change the digest -----------------------
+// --- 5. canonical reorder must not change the digest -----------------------
 lines.push("");
 const reordered = reorderReport(canonical);
 const digestA = computeDigests(canonical.children);

--- a/scripts/r2-linked-parser-ab-collection-v2/contract.mjs
+++ b/scripts/r2-linked-parser-ab-collection-v2/contract.mjs
@@ -75,30 +75,60 @@ export const SANCTIONED_EXCEPTION = Object.freeze({
   structurallyComplete: false,
 });
 
-// DEFECT 4 CARRIER. The exact expected WAT ABI, carried structurally rather
-// than as a hash. A hash-only carrier cannot see an i32 -> f32 parameter
-// change once the report's own manifest hash is recomputed alongside it.
-// These values are the committed contract; changing them requires an approved
-// relock, not a collector edit.
+// The frozen production inventory has one local module-init unit. It remains a
+// direct legacy body on BOTH outer collection routes: the outer "prepared"
+// route is the linked-parser overlay choice, not permission to invent a
+// Prepared module-init terminal.
+export const OWNED_MODULE_INIT = Object.freeze({
+  unit: "empty.mjs::__module_init",
+  source: "empty.mjs",
+  file: "empty.mjs",
+  kind: "module-init",
+  selfOwner: "inventory",
+  disposition: "legacy-ast-entry",
+});
+
+export const OWNED_MODULE_INIT_PHYSICAL = Object.freeze({
+  fn: "compileModuleInitBody",
+  structurallyComplete: true,
+  bodyRoute: "direct-legacy",
+  count: 1,
+});
+
+export const OWNED_MODULE_INIT_OUTCOME = Object.freeze({
+  bodyRoute: "direct-legacy",
+  outcome: "body-shape-rejected",
+  legacyBodyEmitted: true,
+  irBodyEmitted: false,
+});
+
+// DEFECT 4 CARRIER. These are normalized physical descriptors, keyed by the
+// host that produced the child. Named reference types deliberately replace raw
+// numeric type indexes: a compacted module must not make a type-index spelling
+// look like the same ABI.
 export const EXPECTED_WAT_ABI = Object.freeze({
-  parser: Object.freeze({
-    name: "$js2_linked_parser_parse",
-    params: Object.freeze(["i32", "i32"]),
-    results: Object.freeze(["i32"]),
+  standalone: Object.freeze({
+    stringToNumber: Object.freeze({
+      params: Object.freeze(["ref null $AnyString", "i32"]),
+      results: Object.freeze(["f64"]),
+    }),
+    readNumber: Object.freeze({
+      params: Object.freeze(["ref null $__fnctor_Parser"]),
+      results: Object.freeze(["f64"]),
+    }),
+    run: Object.freeze({ params: Object.freeze([]), results: Object.freeze(["f64"]) }),
   }),
-  caller: Object.freeze({
-    name: "$js2_linked_parser_call",
-    params: Object.freeze(["i32", "i32", "i32"]),
-    results: Object.freeze(["i32"]),
-  }),
-  run: Object.freeze({
-    name: "$js2_linked_parser_run",
-    params: Object.freeze(["i32"]),
-    results: Object.freeze(["i32"]),
+  host: Object.freeze({
+    stringToNumber: Object.freeze({
+      params: Object.freeze(["externref", "i32"]),
+      results: Object.freeze(["f64"]),
+    }),
+    readNumber: Object.freeze({ params: Object.freeze(["externref"]), results: Object.freeze(["f64"]) }),
+    run: Object.freeze({ params: Object.freeze([]), results: Object.freeze(["f64"]) }),
   }),
 });
 
-export const WAT_CARRIERS = Object.freeze(["parser", "caller", "run"]);
+export const WAT_CARRIERS = Object.freeze(["stringToNumber", "readNumber", "run"]);
 
 export const CENSUS_STATES = Object.freeze([
   "scheduled",
@@ -174,10 +204,25 @@ export function sha256(text) {
   return createHash("sha256").update(text, "utf8").digest("hex");
 }
 
-export function canonicalWatText(carrier) {
-  const params = (carrier?.params ?? []).map((p) => `(param ${p})`).join(" ");
-  const results = (carrier?.results ?? []).map((r) => `(result ${r})`).join(" ");
-  return `(func ${carrier?.name ?? ""} ${params} ${results})`.replace(/\s+/g, " ").trim();
+function normalizePhysicalType(type) {
+  if (typeof type !== "string") return null;
+  const compact = type.trim().replace(/\s+/g, " ");
+  const wrappedNullableRef = compact.match(/^\(ref null (\$[A-Za-z0-9_.$-]+)\)$/);
+  return wrappedNullableRef ? `ref null ${wrappedNullableRef[1]}` : compact;
+}
+
+function normalizePhysicalTypes(types) {
+  if (!Array.isArray(types)) return null;
+  const normalized = types.map(normalizePhysicalType);
+  return normalized.every((type) => type !== null) ? normalized : null;
+}
+
+// Hash the normalized descriptor, not a raw WAT declaration. This preserves
+// symbolic reference names while making inconsequential whitespace irrelevant.
+export function canonicalWatText(carrierName, carrier) {
+  const params = normalizePhysicalTypes(carrier?.params) ?? ["<malformed>"];
+  const results = normalizePhysicalTypes(carrier?.results) ?? ["<malformed>"];
+  return `${String(carrierName ?? "")}(${params.join(",")})->${results.join(",")}`;
 }
 
 // --- failure accumulator ----------------------------------------------------
@@ -273,6 +318,7 @@ function repairedCensusCheck(report, failures) {
 
 const EXCEPTION_FIELDS = Object.freeze([
   "fn",
+  "unit",
   "source",
   "file",
   "kind",
@@ -281,17 +327,65 @@ const EXCEPTION_FIELDS = Object.freeze([
   "structurallyComplete",
 ]);
 const JOIN_FIELDS = Object.freeze(["source", "file", "kind", "selfOwner", "disposition"]);
+const INVENTORY_FIELDS = Object.freeze(["unit", ...JOIN_FIELDS]);
+const OWNED_PHYSICAL_FIELDS = Object.freeze(["fn", "structurallyComplete", "bodyRoute", "count"]);
+const OWNED_OUTCOME_FIELDS = Object.freeze(["bodyRoute", "outcome", "legacyBodyEmitted", "irBodyEmitted"]);
 
 function indexInventory(child) {
   const byUnit = new Map();
-  for (const unit of child.record?.inventory?.units ?? []) byUnit.set(unit.unit, unit);
+  for (const unit of child.record?.inventory?.units ?? []) {
+    if (unit !== null && typeof unit === "object") byUnit.set(unit.unit, unit);
+  }
   return byUnit;
+}
+
+function checkCanonicalInventory(child, inventory, failures) {
+  const key = canonicalKey(child);
+  const units = child.record?.inventory?.units;
+  if (!Array.isArray(units)) {
+    failures.add("declaration/malformed-inventory", key, "inventory.units is not an array");
+    return;
+  }
+  if (units.length !== 1) {
+    failures.add(
+      "declaration/inventory-mismatch",
+      key,
+      `expected exactly one owned empty.mjs module-init unit, saw ${units.length}`,
+    );
+  }
+  if (inventory.size !== units.length) {
+    failures.add("declaration/inventory-mismatch", key, "inventory contains a malformed or duplicate unit key");
+  }
+  for (const unit of units) {
+    if (unit === null || typeof unit !== "object") {
+      failures.add("declaration/malformed-inventory", key, "inventory contains a non-object unit");
+      continue;
+    }
+    for (const field of INVENTORY_FIELDS) {
+      if (unit[field] !== OWNED_MODULE_INIT[field]) {
+        failures.add(
+          "declaration/inventory-mismatch",
+          key,
+          `inventory ${field}=${String(unit[field])} != expected ${String(OWNED_MODULE_INIT[field])}`,
+        );
+      }
+    }
+  }
+}
+
+function expectedOwnedPhysicalField(field) {
+  return OWNED_MODULE_INIT_PHYSICAL[field];
+}
+
+function expectedOwnedOutcomeField(field) {
+  return OWNED_MODULE_INIT_OUTCOME[field];
 }
 
 // DEFECT 1 REPAIR. The physical-row census is CLOSED: every row either joins an
 // inventory-owned unit on all join fields, or it is the one sanctioned unitless
-// exception. An arbitrary extra unitless row -- `compileDeclarations` or
-// anything else -- has nowhere to land and fails closed.
+// exception. The current one-unit inventory also has one exact direct legacy
+// physical row on EVERY outer route; a prepared tuple may not manufacture a
+// prepared module-init terminal.
 function repairedDeclarationCensus(child, failures) {
   const key = canonicalKey(child);
   const rows = child.record?.physicalRows;
@@ -300,9 +394,15 @@ function repairedDeclarationCensus(child, failures) {
     return;
   }
   const inventory = indexInventory(child);
+  checkCanonicalInventory(child, inventory, failures);
   const unitless = [];
+  const physicalByUnit = new Map();
 
   for (const row of rows) {
+    if (row === null || typeof row !== "object") {
+      failures.add("declaration/malformed-census", key, "physicalRows contains a non-object row");
+      continue;
+    }
     if (row.unit === null || row.unit === undefined) {
       unitless.push(row);
       continue;
@@ -321,13 +421,32 @@ function repairedDeclarationCensus(child, failures) {
         );
       }
     }
+    if (physicalByUnit.has(row.unit)) {
+      failures.add("declaration/duplicate-physical-row", key, `unit ${row.unit} has more than one physical row`);
+    } else {
+      physicalByUnit.set(row.unit, row);
+    }
+    for (const field of OWNED_PHYSICAL_FIELDS) {
+      const expected = expectedOwnedPhysicalField(field);
+      if (row[field] !== expected) {
+        failures.add(
+          "declaration/physical-row-mismatch",
+          key,
+          `physical row ${row.fn} ${field}=${String(row[field])} != expected ${String(expected)}`,
+        );
+      }
+    }
+  }
+
+  for (const unit of inventory.values()) {
+    if (!physicalByUnit.has(unit.unit)) {
+      failures.add("declaration/missing-physical-row", key, `inventory unit ${unit.unit} has no physical row`);
+    }
   }
 
   if (unitless.length === 0) {
     failures.add("declaration/missing-exception", key, "the graph-global module-init exception is absent");
-    return;
-  }
-  if (unitless.length > 1) {
+  } else if (unitless.length > 1) {
     failures.add(
       "declaration/unsanctioned-unitless-row",
       key,
@@ -357,8 +476,16 @@ function repairedDeclarationCensus(child, failures) {
 function repairedOutcomeIndex(child, failures) {
   const key = canonicalKey(child);
   const outcomes = child.record?.irOutcomes ?? [];
+  if (!Array.isArray(outcomes)) {
+    failures.add("outcome/malformed-census", key, "irOutcomes is not an array");
+    return new Map();
+  }
   const byKey = new Map();
   for (const outcome of outcomes) {
+    if (outcome === null || typeof outcome !== "object") {
+      failures.add("outcome/malformed-census", key, "irOutcomes contains a non-object row");
+      continue;
+    }
     if (byKey.has(outcome.key)) {
       failures.add(
         "outcome/duplicate-key",
@@ -375,8 +502,9 @@ function repairedOutcomeIndex(child, failures) {
 // --- strategy 2: full outcome joins -----------------------------------------
 
 // DEFECT 2 REPAIR. An outcome must join its inventory unit on EVERY field, not
-// merely exist under the right key. A prepared module-init outcome recorded
-// against the wrong file used to pass on key presence alone.
+// merely exist under the right key. Production records the owned module-init as
+// direct legacy / body-shape-rejected on both outer routes, so its exact route
+// and terminal code are part of the join rather than an invented prepared row.
 function repairedOutcomeJoin(child, byKey, failures) {
   const key = canonicalKey(child);
   const inventory = indexInventory(child);
@@ -399,25 +527,25 @@ function repairedOutcomeJoin(child, byKey, failures) {
         );
       }
     }
+    for (const field of OWNED_OUTCOME_FIELDS) {
+      const expected = expectedOwnedOutcomeField(field);
+      if (outcome[field] !== expected) {
+        failures.add(
+          "outcome/terminal-mismatch",
+          key,
+          `outcome ${outcome.key} ${field}=${String(outcome[field])} != expected ${String(expected)}`,
+        );
+      }
+    }
   }
 
-  if (child.route !== "prepared") return;
   for (const unit of inventory.values()) {
-    if (unit.kind !== "module-init") continue;
     const outcome = byKey.get(unit.unit);
     if (!outcome) {
       failures.add(
         "outcome/missing-terminal",
         key,
-        `prepared route has no terminal outcome for inventory unit ${unit.unit}`,
-      );
-      continue;
-    }
-    if (outcome.outcome !== "prepared-terminal") {
-      failures.add(
-        "outcome/missing-terminal",
-        key,
-        `prepared route outcome for ${unit.unit} is ${String(outcome.outcome)}, expected prepared-terminal`,
+        `direct legacy module-init has no terminal outcome for inventory unit ${unit.unit}`,
       );
     }
   }
@@ -434,37 +562,42 @@ function repairedWatCarriers(child, failures) {
   const key = canonicalKey(child);
   const carriers = child.record?.watCarriers;
   const manifest = child.record?.watManifest ?? {};
-  if (!carriers) {
+  const expectedByHost = EXPECTED_WAT_ABI[child.host];
+  if (!expectedByHost) {
+    failures.add("wat/unknown-host-mode", key, `no WAT ABI is pinned for host ${String(child.host)}`);
+    return;
+  }
+  if (carriers === null || typeof carriers !== "object" || Array.isArray(carriers)) {
     failures.add("wat/missing-carrier", key, "watCarriers is absent");
     return;
   }
+  for (const name of Object.keys(carriers)) {
+    if (!WAT_CARRIERS.includes(name)) failures.add("wat/unexpected-carrier", key, `unexpected carrier ${name}`);
+  }
   for (const name of WAT_CARRIERS) {
     const observed = carriers[name];
-    const expected = EXPECTED_WAT_ABI[name];
+    const expected = expectedByHost[name];
     if (!observed) {
       failures.add("wat/missing-carrier", key, `carrier ${name} is absent`);
       continue;
     }
-    if (observed.name !== expected.name) {
-      failures.add("wat/abi-mismatch", key, `carrier ${name} name ${String(observed.name)} != ${expected.name}`);
-    }
-    const observedParams = observed.params ?? [];
+    const observedParams = normalizePhysicalTypes(observed.params);
     if (stableStringify(observedParams) !== stableStringify(expected.params)) {
       failures.add(
         "wat/abi-mismatch",
         key,
-        `carrier ${name} params ${stableStringify(observedParams)} != expected ${stableStringify(expected.params)}`,
+        `carrier ${name} params ${stableStringify(observedParams)} != ${child.host} expected ${stableStringify(expected.params)}`,
       );
     }
-    const observedResults = observed.results ?? [];
+    const observedResults = normalizePhysicalTypes(observed.results);
     if (stableStringify(observedResults) !== stableStringify(expected.results)) {
       failures.add(
         "wat/abi-mismatch",
         key,
-        `carrier ${name} results ${stableStringify(observedResults)} != expected ${stableStringify(expected.results)}`,
+        `carrier ${name} results ${stableStringify(observedResults)} != ${child.host} expected ${stableStringify(expected.results)}`,
       );
     }
-    const recomputed = sha256(canonicalWatText(observed));
+    const recomputed = sha256(canonicalWatText(name, observed));
     if (observed.sha256 !== recomputed) {
       failures.add("wat/hash-mismatch", key, `carrier ${name} sha256 does not match its own WAT text`);
     }
@@ -579,7 +712,7 @@ function checkAccounting(child, failures) {
   if (!(child.side === "candidate" && child.host === "standalone" && child.route === "prepared")) return;
   const key = canonicalKey(child);
   const accounting = child.record?.accounting ?? {};
-  for (const carrier of ["parser", "caller"]) {
+  for (const carrier of ["stringToNumber", "readNumber"]) {
     const entry = accounting[carrier];
     if (entry?.direct !== 1 || entry?.ir !== 1) {
       failures.add(
@@ -589,6 +722,14 @@ function checkAccounting(child, failures) {
       );
     }
   }
+  const run = accounting.run;
+  if (run?.direct !== 1 || run?.ir !== 0) {
+    failures.add(
+      "accounting/mismatch",
+      key,
+      `landed candidate run accounting ${stableStringify(run ?? null)} != {direct:1, ir:0}`,
+    );
+  }
 }
 
 function checkDiagnostics(child, failures) {
@@ -597,15 +738,15 @@ function checkDiagnostics(child, failures) {
   const diagnostics = child.record?.diagnostics ?? [];
   const count = (kind, carrier) => diagnostics.filter((d) => d.kind === kind && d.carrier === carrier).length;
 
-  if (count("post-claim", "parser") !== 1 || count("compile-warning", "parser") !== 1) {
+  if (count("post-claim", "stringToNumber") !== 1 || count("compile-warning", "stringToNumber") !== 1) {
     failures.add(
       "diagnostics/parser-withdrawal",
       key,
-      "historical base standalone/prepared requires exactly one parser post-claim row and its matching compile warning",
+      "historical base standalone/prepared requires exactly one stringToNumber post-claim row and matching compile warning",
     );
   }
-  const callerClaim = count("post-claim", "caller");
-  const callerWarning = count("compile-warning", "caller");
+  const callerClaim = count("post-claim", "readNumber");
+  const callerWarning = count("compile-warning", "readNumber");
   if (callerClaim !== callerWarning || callerClaim > 1) {
     failures.add(
       "diagnostics/caller-cascade",
@@ -622,6 +763,14 @@ function projectChild(child) {
     key: canonicalKey(child),
     revision: child.revision ?? null,
     options: child.options ?? null,
+    inventory: (child.record?.inventory?.units ?? []).map((u) => ({
+      unit: u.unit,
+      source: u.source,
+      file: u.file,
+      kind: u.kind,
+      selfOwner: u.selfOwner,
+      disposition: u.disposition,
+    })),
     physicalRows: (child.record?.physicalRows ?? []).map((r) => ({
       fn: r.fn,
       unit: r.unit ?? null,
@@ -631,6 +780,8 @@ function projectChild(child) {
       selfOwner: r.selfOwner,
       disposition: r.disposition,
       structurallyComplete: r.structurallyComplete,
+      bodyRoute: r.bodyRoute,
+      count: r.count,
     })),
     irOutcomes: (child.record?.irOutcomes ?? []).map((o) => ({
       key: o.key,
@@ -640,9 +791,14 @@ function projectChild(child) {
       kind: o.kind,
       selfOwner: o.selfOwner,
       disposition: o.disposition,
+      bodyRoute: o.bodyRoute,
       outcome: o.outcome,
+      legacyBodyEmitted: o.legacyBodyEmitted,
+      irBodyEmitted: o.irBodyEmitted,
     })),
     watCarriers: child.record?.watCarriers ?? null,
+    diagnostics: child.record?.diagnostics ?? [],
+    accounting: child.record?.accounting ?? {},
   };
 }
 

--- a/scripts/r2-linked-parser-ab-collection-v2/fixtures.mjs
+++ b/scripts/r2-linked-parser-ab-collection-v2/fixtures.mjs
@@ -12,6 +12,9 @@
 import {
   EXPECTED_WAT_ABI,
   HOST_OPTIONS,
+  OWNED_MODULE_INIT,
+  OWNED_MODULE_INIT_OUTCOME,
+  OWNED_MODULE_INIT_PHYSICAL,
   PHASE_SIDES,
   PHASE_RANK,
   PINS,
@@ -26,21 +29,14 @@ import {
 // Frozen at relock time; a synthetic 40-hex stand-in for the static fixture.
 export const FIXTURE_LIVE_REVISION = "1111111111111111111111111111111111111111";
 
-const OWNED_UNIT = Object.freeze({
-  unit: "empty.mjs::__module_init",
-  source: "empty.mjs",
-  file: "empty.mjs",
-  kind: "module-init",
-  selfOwner: "inventory",
-  disposition: "owned-terminal",
-});
-
-function watCarriers() {
+function watCarriers(host) {
+  const abiByHost = EXPECTED_WAT_ABI[host];
+  if (!abiByHost) throw new Error(`fixture invariant broken: unknown host ${host}`);
   const out = {};
   for (const name of WAT_CARRIERS) {
-    const abi = EXPECTED_WAT_ABI[name];
-    const carrier = { name: abi.name, params: [...abi.params], results: [...abi.results] };
-    carrier.sha256 = sha256(canonicalWatText(carrier));
+    const abi = abiByHost[name];
+    const carrier = { params: [...abi.params], results: [...abi.results] };
+    carrier.sha256 = sha256(canonicalWatText(name, carrier));
     out[name] = carrier;
   }
   return out;
@@ -52,37 +48,19 @@ function watManifest(carriers) {
   return out;
 }
 
-function physicalRows(route) {
-  const rows = [];
-  if (route === "prepared") {
-    rows.push({
-      fn: "compileModuleInitBody",
-      unit: OWNED_UNIT.unit,
-      source: OWNED_UNIT.source,
-      file: OWNED_UNIT.file,
-      kind: OWNED_UNIT.kind,
-      selfOwner: OWNED_UNIT.selfOwner,
-      disposition: OWNED_UNIT.disposition,
-      structurallyComplete: true,
-    });
-  }
-  // The one immutable v1 graph-global exception, retained verbatim.
-  rows.push({ ...SANCTIONED_EXCEPTION });
-  return rows;
+function physicalRows() {
+  // The owned empty.mjs initializer remains a direct legacy physical root in
+  // BOTH tuple routes. The second row is the sole immutable graph-global
+  // exception, also once per child.
+  return [{ ...OWNED_MODULE_INIT, ...OWNED_MODULE_INIT_PHYSICAL }, { ...SANCTIONED_EXCEPTION }];
 }
 
-function irOutcomes(route) {
-  if (route !== "prepared") return [];
+function irOutcomes() {
   return [
     {
-      key: OWNED_UNIT.unit,
-      unit: OWNED_UNIT.unit,
-      source: OWNED_UNIT.source,
-      file: OWNED_UNIT.file,
-      kind: OWNED_UNIT.kind,
-      selfOwner: OWNED_UNIT.selfOwner,
-      disposition: OWNED_UNIT.disposition,
-      outcome: "prepared-terminal",
+      key: OWNED_MODULE_INIT.unit,
+      ...OWNED_MODULE_INIT,
+      ...OWNED_MODULE_INIT_OUTCOME,
     },
   ];
 }
@@ -93,18 +71,22 @@ function diagnostics(side, host, route) {
   // compile warning are mandatory; the caller cascade is absent here, which is
   // permitted only because BOTH of its rows are absent together.
   return [
-    { kind: "post-claim", carrier: "parser" },
-    { kind: "compile-warning", carrier: "parser" },
+    { kind: "post-claim", carrier: "stringToNumber" },
+    { kind: "compile-warning", carrier: "stringToNumber" },
   ];
 }
 
 function accounting(side, host, route) {
   if (!(side === "candidate" && host === "standalone" && route === "prepared")) return {};
-  return { parser: { direct: 1, ir: 1 }, caller: { direct: 1, ir: 1 } };
+  return {
+    stringToNumber: { direct: 1, ir: 1 },
+    readNumber: { direct: 1, ir: 1 },
+    run: { direct: 1, ir: 0 },
+  };
 }
 
 function buildChild(phase, side, tuple, ordinal) {
-  const carriers = watCarriers();
+  const carriers = watCarriers(tuple.host);
   return {
     ordinal,
     phase,
@@ -126,9 +108,9 @@ function buildChild(phase, side, tuple, ordinal) {
     signal: null,
     timedOut: false,
     record: {
-      inventory: { units: [{ ...OWNED_UNIT }] },
-      physicalRows: physicalRows(tuple.route),
-      irOutcomes: irOutcomes(tuple.route),
+      inventory: { units: [{ ...OWNED_MODULE_INIT }] },
+      physicalRows: physicalRows(),
+      irOutcomes: irOutcomes(),
       watCarriers: carriers,
       watManifest: watManifest(carriers),
       diagnostics: diagnostics(side, tuple.host, tuple.route),
@@ -197,7 +179,7 @@ export function mutateExtraUnitlessDeclaration(report) {
   return next;
 }
 
-// D2: a prepared module-init outcome recorded against the WRONG FILE.
+// D2: a direct-legacy module-init outcome recorded against the WRONG FILE.
 export function mutateWrongFileOutcome(report) {
   const next = clone(report);
   const child = findChild(next, preparedStandaloneCandidate);
@@ -210,19 +192,19 @@ export function mutateDuplicateOutcomeKey(report) {
   const next = clone(report);
   const child = findChild(next, preparedStandaloneCandidate);
   const first = child.record.irOutcomes[0];
-  child.record.irOutcomes.push({ ...first, outcome: "direct-legacy" });
+  child.record.irOutcomes.push({ ...first, outcome: "unexpected-terminal" });
   return next;
 }
 
-// D4: the parser's SECOND WAT PARAMETER changed i32 -> f32, with every hash
-// recomputed so the report stays self-consistent.
+// D4: stringToNumber's SECOND WAT PARAMETER changed i32 -> f32, with every
+// hash recomputed so the report stays self-consistent.
 export function mutateParserSecondParamType(report) {
   const next = clone(report);
   const child = findChild(next, preparedStandaloneCandidate);
-  const parser = child.record.watCarriers.parser;
-  parser.params[1] = "f32";
-  parser.sha256 = sha256(canonicalWatText(parser));
-  child.record.watManifest.parser = parser.sha256;
+  const stringToNumber = child.record.watCarriers.stringToNumber;
+  stringToNumber.params[1] = "f32";
+  stringToNumber.sha256 = sha256(canonicalWatText("stringToNumber", stringToNumber));
+  child.record.watManifest.stringToNumber = stringToNumber.sha256;
   return next;
 }
 
@@ -251,7 +233,7 @@ export const DEFECT_MUTATIONS = Object.freeze([
   },
   {
     id: "D2",
-    title: "wrong-file prepared module-init outcome",
+    title: "wrong-file direct-legacy module-init outcome",
     mutate: mutateWrongFileOutcome,
     repairedCode: "outcome/join-mismatch",
   },
@@ -263,7 +245,7 @@ export const DEFECT_MUTATIONS = Object.freeze([
   },
   {
     id: "D4",
-    title: "parser second WAT parameter i32 -> f32, hashes recomputed",
+    title: "stringToNumber second WAT parameter i32 -> f32, hashes recomputed",
     mutate: mutateParserSecondParamType,
     repairedCode: "wat/abi-mismatch",
   },
@@ -272,6 +254,70 @@ export const DEFECT_MUTATIONS = Object.freeze([
     title: "attempted/spawned/completed collapse when spawn throws",
     mutate: mutateCollapsedSpawnCensus,
     repairedCode: "census/state-collapse",
+  },
+]);
+
+// --- production-evidence relock mutations -----------------------------------
+// These records are not claims about the lost collector. They prove that the
+// reconstructed hash/presence baseline remains permissive while the relocked
+// production model rejects the host, route, physical-row, and terminal drift.
+
+export function mutateWrongHostAbi(report) {
+  const next = clone(report);
+  const child = findChild(next, preparedStandaloneCandidate);
+  const carriers = watCarriers("host");
+  child.record.watCarriers = carriers;
+  child.record.watManifest = watManifest(carriers);
+  return next;
+}
+
+export function mutateWrongModuleInitRoute(report) {
+  const next = clone(report);
+  const child = findChild(next, preparedStandaloneCandidate);
+  child.record.irOutcomes[0].bodyRoute = "prepared";
+  return next;
+}
+
+export function mutateWrongPhysicalRow(report) {
+  const next = clone(report);
+  const child = findChild(next, preparedStandaloneCandidate);
+  const row = child.record.physicalRows.find((candidate) => candidate.unit === OWNED_MODULE_INIT.unit);
+  if (!row) throw new Error("fixture invariant broken: owned physical row not found");
+  row.fn = "compileDeclarations";
+  return next;
+}
+
+export function mutateWrongModuleInitOutcome(report) {
+  const next = clone(report);
+  const child = findChild(next, preparedStandaloneCandidate);
+  child.record.irOutcomes[0].outcome = "prepared-terminal";
+  return next;
+}
+
+export const PRODUCTION_MUTATIONS = Object.freeze([
+  {
+    id: "P1",
+    title: "standalone child carrying the host physical ABI, hashes recomputed",
+    mutate: mutateWrongHostAbi,
+    repairedCode: "wat/abi-mismatch",
+  },
+  {
+    id: "P2",
+    title: "prepared outer tuple inventing a prepared module-init route",
+    mutate: mutateWrongModuleInitRoute,
+    repairedCode: "outcome/terminal-mismatch",
+  },
+  {
+    id: "P3",
+    title: "owned module-init physical row using compileDeclarations",
+    mutate: mutateWrongPhysicalRow,
+    repairedCode: "declaration/physical-row-mismatch",
+  },
+  {
+    id: "P4",
+    title: "owned module-init terminal outcome rewritten as prepared-terminal",
+    mutate: mutateWrongModuleInitOutcome,
+    repairedCode: "outcome/terminal-mismatch",
   },
 ]);
 
@@ -413,7 +459,7 @@ export const STRUCTURAL_MUTATIONS = Object.freeze([
   },
   {
     id: "S14",
-    title: "missing prepared terminal outcome",
+    title: "missing direct-legacy module-init terminal outcome",
     code: "outcome/missing-terminal",
     mutate: (r) => {
       const next = clone(r);
@@ -443,7 +489,7 @@ export const STRUCTURAL_MUTATIONS = Object.freeze([
         next,
         (c) => c.side === "base" && c.host === "standalone" && c.route === "prepared" && c.fixture === "decimal",
       );
-      child.record.diagnostics.push({ kind: "post-claim", carrier: "caller" });
+      child.record.diagnostics.push({ kind: "post-claim", carrier: "readNumber" });
       return next;
     },
   },

--- a/scripts/r2-linked-parser-ab-collection-v2/manifest.json
+++ b/scripts/r2-linked-parser-ab-collection-v2/manifest.json
@@ -35,42 +35,62 @@
     "live": "frozen-at-relock"
   },
   "expectedWatAbi": {
-    "parser": {
-      "name": "$js2_linked_parser_parse",
-      "params": [
-        "i32",
-        "i32"
-      ],
-      "results": [
-        "i32"
-      ]
+    "standalone": {
+      "stringToNumber": {
+        "params": [
+          "ref null $AnyString",
+          "i32"
+        ],
+        "results": [
+          "f64"
+        ]
+      },
+      "readNumber": {
+        "params": [
+          "ref null $__fnctor_Parser"
+        ],
+        "results": [
+          "f64"
+        ]
+      },
+      "run": {
+        "params": [],
+        "results": [
+          "f64"
+        ]
+      }
     },
-    "caller": {
-      "name": "$js2_linked_parser_call",
-      "params": [
-        "i32",
-        "i32",
-        "i32"
-      ],
-      "results": [
-        "i32"
-      ]
-    },
-    "run": {
-      "name": "$js2_linked_parser_run",
-      "params": [
-        "i32"
-      ],
-      "results": [
-        "i32"
-      ]
+    "host": {
+      "stringToNumber": {
+        "params": [
+          "externref",
+          "i32"
+        ],
+        "results": [
+          "f64"
+        ]
+      },
+      "readNumber": {
+        "params": [
+          "externref"
+        ],
+        "results": [
+          "f64"
+        ]
+      },
+      "run": {
+        "params": [],
+        "results": [
+          "f64"
+        ]
+      }
     }
   },
   "sources": {
-    "contract.mjs": "86d12086c2e8b7ed8a8bc0888290b9dd8df545728aa3410ff3367509bde01403",
-    "fixtures.mjs": "ad7b2e185de349c27366a94be28080248b4273fee1a39189e803d378efaec607",
-    "baseline-naive.mjs": "cd7d19106904460fdc9ca5277266fd104775b9f9a924c3233c03ab7c6e7b7a0d",
-    "selftest.mjs": "23eebaca487a908cd9ce00f9c4b90b145a7584ea5b77a3eaa0e742310a14b31a",
+    "contract.mjs": "49b5e0bc4900a294fe86b148f02e853f4c8ccfd0b9113ad8c0c269b2823c87c8",
+    "fixtures.mjs": "ba58a253902e01deb60ad0708693571e04cd10a9afb36f0a48ed9c211a15173f",
+    "baseline-naive.mjs": "821c47d5b46d130112e0df1348dc3a2a715bd0a965ab646dbbf2ec686c760c77",
+    "selftest.mjs": "e8816bba728d3904824cdd89076b3fdb8349c2578668a971665e4d4720a0a9b8",
     "relock.mjs": "e166bf6c78f6fe3e6322ea06607539a18c367e61f567b58f437c2704239a1be3"
   },
   "bundleEqual": {
@@ -80,5 +100,5 @@
     "selftest.mjs": "EQUAL",
     "relock.mjs": "EQUAL"
   },
-  "rootHash": "d9e2327de0f2a57e3cc612b218f7fa77d940133a8da8a041f14c1312a240958d"
+  "rootHash": "7a0bf9be4def60b047144c7282e0bdd38f1bacb2fa956e046f34178785045eca"
 }

--- a/scripts/r2-linked-parser-ab-collection-v2/selftest.mjs
+++ b/scripts/r2-linked-parser-ab-collection-v2/selftest.mjs
@@ -11,7 +11,7 @@
 // PROOF OBLIGATION
 // ----------------
 // For each of the five defects the 2026-08-28 independent audit proved to be a
-// FALSE PASS, the mutation must:
+// FALSE PASS, and each production-evidence relock mutation, the mutation must:
 //   1. PASS the reconstructed pre-repair baseline (reproducing the false pass);
 //   2. FAIL the repaired collector with the specific expected failure code; and
 //   3. differ from the canonical report ONLY in that mutation -- established by
@@ -20,7 +20,13 @@
 
 import { computeDigests, validate } from "./contract.mjs";
 import { validateNaive } from "./baseline-naive.mjs";
-import { DEFECT_MUTATIONS, STRUCTURAL_MUTATIONS, buildCanonicalReport, reorderReport } from "./fixtures.mjs";
+import {
+  DEFECT_MUTATIONS,
+  PRODUCTION_MUTATIONS,
+  STRUCTURAL_MUTATIONS,
+  buildCanonicalReport,
+  reorderReport,
+} from "./fixtures.mjs";
 
 let failed = 0;
 const lines = [];
@@ -85,7 +91,32 @@ for (const defect of DEFECT_MUTATIONS) {
   });
 }
 
-// --- 2. structural selftests (repaired collector only) ---------------------
+// --- 2. production-evidence relock mutations, two-sided --------------------
+// The reconstructed baseline intentionally keeps the old hash/presence-only
+// shapes, so these mutations must still pass there. The relocked model must
+// reject each exact wrong host ABI, route, physical row, or terminal outcome.
+lines.push("");
+lines.push("production-evidence relock mutations (baseline must PASS, repaired must FAIL):");
+for (const mutation of PRODUCTION_MUTATIONS) {
+  const mutated = mutation.mutate(canonical);
+  const naive = validateNaive(mutated);
+  const repaired = validate(mutated);
+  const reproduced = naive.status === "PASS";
+  record(
+    reproduced,
+    `${mutation.id} remains permissive on the reconstructed baseline`,
+    `${mutation.title} → ${naive.status}`,
+  );
+  const rejected = repaired.status === "FAILED-DIAGNOSTIC-NOT-ACCEPTANCE";
+  const hasCode = codes(repaired).includes(mutation.repairedCode);
+  record(
+    rejected && hasCode,
+    `${mutation.id} fails closed on the relocked collector`,
+    `${repaired.status} [${codes(repaired).join(", ")}]`,
+  );
+}
+
+// --- 3. structural selftests (repaired collector only) ---------------------
 lines.push("");
 lines.push("structural selftests (repaired collector must FAIL each):");
 for (const mutation of STRUCTURAL_MUTATIONS) {
@@ -94,7 +125,7 @@ for (const mutation of STRUCTURAL_MUTATIONS) {
   record(ok, `${mutation.id} ${mutation.title}`, `${result.status} [${codes(result).join(", ")}]`);
 }
 
-// --- 3. multiple accumulated oracle failures --------------------------------
+// --- 4. multiple accumulated oracle failures --------------------------------
 // The plan requires a semantic failure to publish EVERY oracle failure, not the
 // first one. Compose four independent mutations and require all four codes.
 lines.push("");
@@ -119,7 +150,7 @@ record(
   `${composedResult.failures.length} failures`,
 );
 
-// --- 4. canonical reorder must not change the digest -----------------------
+// --- 5. canonical reorder must not change the digest -----------------------
 lines.push("");
 const reordered = reorderReport(canonical);
 const digestA = computeDigests(canonical.children);


### PR DESCRIPTION
## Summary

- replace placeholder all-i32 WAT contracts with host-scoped production ABI descriptors using symbolic reference carriers
- model the owned `empty.mjs` module initializer as direct legacy / body-shape-rejected on every outer route while retaining exactly one graph-global exception per child
- add non-vacuous host, route, physical-row, and terminal-outcome mutations and relock the byte-identical bundle manifest

## Validation

- R2-v2 static selftest: 46/46 assertions passed
- relock check passed; root hash `7a0bf9be4def60b047144c7282e0bdd38f1bacb2fa956e046f34178785045eca`
- source/bundle equality passed for all five mirrored modules
- Prettier, Biome, typecheck, lint, format, ratchets, numeric-local parity, and issue-integrity push gates passed

## Scope

No 24-child runtime collection was run. This closes the static adapter relock blockers; it does not claim R2 compile-once completion.

Refs #3521