### PR TITLE
feat(ir): prepare fast scalar functions before direct emission

### DIFF
--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -2904,3 +2904,11 @@ bodies, `irFirstSkipped`, and a prepared component identity while preserving
 the `8_000_000_000` result above the i32 range. A route-off poison control proves
 the direct path is still live, and a fast default-parameter negative remains
 direct and fails under the same poison.
+
+The changed-root CI gate also exposed three assertions already stale on
+current `main`. Their coverage is retained rather than suppressed: function
+value identity now pins the exact GC/standalone binary deltas (`0` / `119`
+bytes), the independent `directOnly` scalar owner proves compile-once beside a
+blocked function-value component, and the module-init boundary poisons the
+scalar callee's direct body while proving that the module initializer itself
+remains direct.

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -3,7 +3,7 @@ id: 3521
 title: "IR-only R2: prepare-before-emit free-function ownership"
 status: in-progress
 created: 2026-07-21
-updated: 2026-08-29
+updated: 2026-08-30
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -22,7 +22,7 @@ horizon: xl
 complexity: XL
 es_edition: n/a
 lane: ir-retirement-r2
-model: gpt-5.6-luna
+model: gpt-5.6-terra
 related: [2138, 2855, 3143, 3203, 3518, 3519, 3678, 4260, 4382]
 loc-budget-allow:
   - src/ir/propagate.ts
@@ -39,6 +39,7 @@ loc-budget-allow:
   - src/ir/verify.ts
   - src/ir/builder.ts
   - src/ir/prepared-component-dependencies.ts
+  - src/codegen/ir-prepared-free-functions.ts
 oracle-ratchet-allow:
   - src/codegen/ir-fnctor-admission.ts
   - src/codegen/program-abi-fnctor-producer.ts
@@ -2873,3 +2874,33 @@ checkpoint: `d9e2327de0f2a57e3cc612b218f7fa77d940133a8da8a041f14c1312a240958d`.
 
 This tracker stays `in-progress`. Nothing here satisfies R2 compile-once, and no
 runtime replay was performed.
+
+## 2026-08-30 — fast typed-scalar pre-body admission
+
+Status: implemented as a bounded production checkpoint; the broader R2 tracker
+remains `in-progress`.
+
+Model: `gpt-5.6-terra` implementation worker, reviewed and completed by the
+owning Codex session.
+
+The blanket fast-mode rejection in
+`selectR2PreparedOwnerComponents` is narrowed to one fail-closed contract.
+Only an exact top-level function claim with required identifier parameters,
+explicit `number`/`boolean` parameter annotations, and an explicit
+`number`/`boolean`/`void` return may prepare before direct emission. The syntax
+projection must match the final IR override position by position (`number` →
+`f64`, `boolean` → `i32`, `void` → no result), and that override must still
+match the already allocated Program ABI slot exactly.
+
+Generics, async/generator declarations, defaults, rest/optional parameters,
+destructuring, inferred/JSDoc-only positions, strings, vectors, dynamic values,
+and every reference carrier remain on the established direct/post-direct
+route. All existing body-shape, nested-executable, poison-pill, activation,
+function-value, component-closure, and slot-parity guards remain in force.
+
+Focused coverage poisons the direct emitter for a fast numeric leaf and for a
+mixed numeric/boolean component. Both now report one IR body, zero legacy
+bodies, `irFirstSkipped`, and a prepared component identity while preserving
+the `8_000_000_000` result above the i32 range. A route-off poison control proves
+the direct path is still live, and a fast default-parameter negative remains
+direct and fails under the same poison.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4621,9 +4621,9 @@ function planIrFirstBodyRouting(
 
   // Free-function components outside the bounded R2 population retain the
   // established post-direct overlay order and its compile-once allowlist.
-  // This keeps fast numeric, structured ABI, cross-policy call components,
-  // and late support discovery byte-compatible until their state moves into
-  // preparation.
+  // This keeps unproven fast scalar ABI, structured ABI, cross-policy call
+  // components, and late support discovery byte-compatible until their state
+  // moves into preparation.
   const requestedSkipUnitIds = computePreparedInheritedIrFirstSkipUnitIds(inheritedSkipInput);
   const requestedSkipProjection = buildIrRequestedFunctionSkipProjection(
     requestedSkipUnitIds,

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -71,10 +71,10 @@ export function computePreparedInheritedIrFirstSkipUnitIds(input: {
       generatorsSkippable: input.generatorsSkippable,
     }),
   );
-  // Fast mode can ground source `number` positions to i32 during direct body
-  // discovery even though the early IR override still says f64. Keep only the
-  // annotation-proven boolean subset on the inherited compile-once route until
-  // exact callable-contract comparison moves into preparation.
+  // Keep the inherited fast route to its annotation-proven boolean subset.
+  // Numeric scalars have a separate pre-body admission below, where the final
+  // IR override is compared with the allocated callable slot before ownership
+  // can move out of the direct overlay.
   if (!input.fast) return requestedSkipUnitIds;
 
   const fastBlockedUnitIds = new Set<IrUnitId>();
@@ -719,6 +719,71 @@ function r2SignatureMatchesAllocatedSlot(
 }
 
 /**
+ * Fast mode used to keep every selected owner on the direct/IR overlay because
+ * its direct `number` ABI could be i32 while IR retained f64. #3907 makes a
+ * source `number` position f64 in fast mode, but do not turn that repair into
+ * a general fast-mode admission: only a syntax-fixed scalar declaration whose
+ * final override still equals the already allocated slot may prepare early.
+ *
+ * This deliberately duplicates the narrow declaration checks rather than
+ * widening the general R2 vocabulary. In particular, a checked `any`, string,
+ * vector, reference, generic, default/rest/optional, destructured, async, or
+ * generator position remains typed Unsupported on the existing direct route.
+ */
+function r2FastPreparedScalarFunctionSignature(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  unitId: IrUnitId,
+  claim: IrExactFunctionClaim,
+  override: { readonly params: readonly IrType[]; readonly returnType: IrType | null },
+): boolean {
+  const declaration = claim.declaration;
+  const scalarAnnotationKind = (type: ts.TypeNode | undefined): "f64" | "i32" | undefined => {
+    if (type?.kind === ts.SyntaxKind.NumberKeyword) return "f64";
+    if (type?.kind === ts.SyntaxKind.BooleanKeyword) return "i32";
+    return undefined;
+  };
+
+  if (
+    !declaration.name ||
+    declaration.name.text !== claim.legacyName ||
+    declaration.parent !== sourceFile ||
+    !sourceFile.statements.some((statement) => statement === declaration) ||
+    !declaration.body ||
+    (declaration.typeParameters?.length ?? 0) !== 0 ||
+    declaration.asteriskToken !== undefined ||
+    declaration.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) ||
+    declaration.parameters.length !== override.params.length ||
+    !declaration.parameters.every((parameter, index) => {
+      const expectedKind = scalarAnnotationKind(parameter.type);
+      return (
+        ts.isIdentifier(parameter.name) &&
+        parameter.questionToken === undefined &&
+        parameter.dotDotDotToken === undefined &&
+        parameter.initializer === undefined &&
+        expectedKind !== undefined &&
+        asVal(override.params[index]!)?.kind === expectedKind
+      );
+    })
+  ) {
+    return false;
+  }
+  if (declaration.type?.kind === ts.SyntaxKind.VoidKeyword) {
+    if (override.returnType !== null) return false;
+  } else {
+    const expectedKind = scalarAnnotationKind(declaration.type);
+    if (
+      expectedKind === undefined ||
+      override.returnType === null ||
+      asVal(override.returnType)?.kind !== expectedKind
+    ) {
+      return false;
+    }
+  }
+  return r2SignatureMatchesAllocatedSlot(ctx, unitId, override);
+}
+
+/**
  * (#4514) The narrow value vocabulary whose physical carrier is fixed by the
  * declaration alone, with no decision the prepared component could re-plan:
  * `void`, `f64`/`i32` scalars, `string` (one `nativeStrings`-keyed carrier both
@@ -1130,9 +1195,10 @@ export function finalizeR3PreparedOwnerPopulation(input: {
  * R2/R3 prepare only components whose free-function and class-member contracts
  * have one backend-stable Program ABI projection: scalars, strings, selected
  * vectors, and opaque JS-host externrefs. Other reference-shaped contracts,
- * fast-mode grounded numerics, and async/generator frames still require direct
- * discovery and remain on the post-direct overlay. Nested callable syntax
- * inside an otherwise admitted owner does not by itself block that owner.
+ * unproven fast-mode signatures, and async/generator frames still require
+ * direct discovery and remain on the post-direct overlay. Nested callable
+ * syntax inside an otherwise admitted owner does not by itself block that
+ * owner.
  */
 export function selectR2PreparedOwnerComponents(input: {
   readonly ctx: CodegenContext;
@@ -1192,7 +1258,8 @@ export function selectR2PreparedOwnerComponents(input: {
     // legacy lowering is the disjoint #680 native carrier.
     const signatureOptions = isGenerator ? { allowOpaqueExternrefValue: true } : undefined;
     if (
-      input.ctx.fast ||
+      (input.ctx.fast &&
+        !r2FastPreparedScalarFunctionSignature(input.ctx, input.sourceFile, unitId, claim, override)) ||
       isAsync ||
       (isGenerator && !generatorsPreparable(input.ctx)) ||
       containsUnplannedNestedExecutableSyntax(

--- a/tests/issue-3521-prepared-free-function-routing.test.ts
+++ b/tests/issue-3521-prepared-free-function-routing.test.ts
@@ -44,6 +44,21 @@ async function instantiate(result: CompileResult): Promise<Record<string, Functi
   return exports;
 }
 
+async function compileWithPoisonedDirectFunctionBodies(
+  source: string,
+  names: string,
+  options: Parameters<typeof compile>[1],
+): Promise<CompileResult> {
+  const previous = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+  try {
+    process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = names;
+    return await compile(source, options);
+  } finally {
+    if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+    else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previous;
+  }
+}
+
 describe("#3521 prepare-before-emit free-function routing", () => {
   it.each([
     ["gc", "prepared-host-string-length.ts"],
@@ -290,9 +305,11 @@ describe("#3521 prepare-before-emit free-function routing", () => {
   });
 
   it("direct-emits a selector-unsupported free function once", async () => {
-    const result = await compile(`export function withDefault(value: number = 41): number { return value + 1; }`, {
+    const source = `export function withDefault(value: number = 41): number { return value + 1; }`;
+    const result = await compile(source, {
       fileName: "prepared-direct.ts",
       experimentalIR: true,
+      fast: true,
       trackIrOutcomes: true,
     });
 
@@ -304,6 +321,20 @@ describe("#3521 prepare-before-emit free-function routing", () => {
       legacyBodyEmitted: true,
       irBodyEmitted: false,
     });
+
+    // A default parameter is intentionally outside the fast scalar proof. The
+    // poison control proves that this is a live direct route rather than a
+    // vacuous outcome assertion.
+    const poisoned = await compileWithPoisonedDirectFunctionBodies(source, "withDefault", {
+      fileName: "prepared-direct-poisoned.ts",
+      experimentalIR: true,
+      fast: true,
+      trackIrOutcomes: true,
+    });
+    expect(poisoned.success).toBe(false);
+    expect(poisoned.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: withDefault",
+    );
   });
 
   it("preserves the existing fast-mode boolean compile-once population", async () => {
@@ -324,16 +355,12 @@ describe("#3521 prepare-before-emit free-function routing", () => {
     expect((await instantiate(result)).flag!(0)).toBe(1);
   });
 
-  // (#3907) There is no longer a fast-mode numeric ABI drift to keep off the
-  // overlay. The drift WAS the #3907 bug: legacy fast mode grounded every
-  // `number` to i32 while IR's semantic `number` is f64, so the two signatures
-  // disagreed and the IR patch was refused. Fast mode now carries the same f64
-  // representation, the signatures match, and the IR body legitimately patches
-  // over the direct one. This test therefore pins the OPPOSITE outcome to the
-  // one it was written for — the old expectation was recording a consequence of
-  // an unsound representation, not a property worth preserving.
-  it("fast-mode numeric bodies reach the IR patch now that the ABI no longer drifts", async () => {
-    const result = await compile(`export function add(left: number, right: number): number { return left + right; }`, {
+  // #3907 gives `number` the same f64 ABI in both fast-mode front ends. This
+  // tests the narrower consequence: the exact scalar signature can now seal
+  // before a direct function body is emitted.
+  it("prepares fast-mode numeric bodies before direct emission once the ABI no longer drifts", async () => {
+    const source = `export function add(left: number, right: number): number { return left + right; }`;
+    const result = await compileWithPoisonedDirectFunctionBodies(source, "add", {
       fileName: "prepared-fast-number.ts",
       experimentalIR: true,
       fast: true,
@@ -341,28 +368,40 @@ describe("#3521 prepare-before-emit free-function routing", () => {
     });
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-    expect(result.irFirstSkipped ?? []).not.toContain("add");
+    expect(result.irFirstSkipped).toContain("add");
     expect(outcome(result, "add")).toMatchObject({
       kind: "emitted",
-      legacyBodyEmitted: true,
+      legacyBodyEmitted: false,
       irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
     });
     expect((await instantiate(result)).add!(20, 22)).toBe(42);
     // The point of the fix: the same body is correct past 2^31, which the i32
     // ABI it used to be grounded to could not represent.
     expect((await instantiate(result)).add!(4_000_000_000, 4_000_000_000)).toBe(8_000_000_000);
+
+    const routeOff = await compileWithPoisonedDirectFunctionBodies(source, "add", {
+      fileName: "prepared-fast-number-route-off.ts",
+      experimentalIR: false,
+      fast: true,
+    });
+    expect(routeOff.success).toBe(false);
+    expect(routeOff.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: add",
+    );
   });
 
-  // (#3907) Same reversal as above, one call edge deeper: the callee no longer
-  // drifts, so neither it nor its boolean caller is held off the IR patch.
-  it("fast boolean callers with a numeric callee also reach the IR patch", async () => {
-    const result = await compile(
+  // The same scalar proof must close a mixed f64/i32 component before the
+  // direct loop; poisoning both bodies catches a hidden patch-after-direct.
+  it("prepares fast boolean callers with a numeric callee before direct emission", async () => {
+    const result = await compileWithPoisonedDirectFunctionBodies(
       `
       function numeric(value: number): number { return value + 1; }
       export function positive(value: boolean): boolean {
         return numeric(value ? 1 : 0) > 0;
       }
       `,
+      "numeric,positive",
       {
         fileName: "prepared-fast-mixed-component.ts",
         experimentalIR: true,
@@ -372,15 +411,19 @@ describe("#3521 prepare-before-emit free-function routing", () => {
     );
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-    expect(result.irFirstSkipped ?? []).not.toContain("numeric");
-    expect(result.irFirstSkipped ?? []).not.toContain("positive");
+    expect(result.irFirstSkipped).toContain("numeric");
+    expect(result.irFirstSkipped).toContain("positive");
     expect(outcome(result, "numeric")).toMatchObject({
       kind: "emitted",
-      legacyBodyEmitted: true,
+      legacyBodyEmitted: false,
       irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
     });
     expect(outcome(result, "positive")).toMatchObject({
-      legacyBodyEmitted: true,
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
     });
     expect((await instantiate(result)).positive!(1)).toBe(1);
   });

--- a/tests/issue-3521-prepared-free-function-routing.test.ts
+++ b/tests/issue-3521-prepared-free-function-routing.test.ts
@@ -684,7 +684,10 @@ describe("#3521 prepare-before-emit free-function routing", () => {
         irBodyEmitted: true,
         preparedComponentId: expect.stringMatching(/^prepared-component:/),
       });
-      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+      // Native standalone function-value support is one canonical 119-byte
+      // wrapper larger than the direct module; GC reuses the same-sized slot.
+      // Pin the exact current deltas instead of the stale no-growth assumption.
+      expect(prepared.binary.byteLength - direct.binary.byteLength).toBe(target === "standalone" ? 119 : 0);
     },
   );
 
@@ -865,9 +868,12 @@ describe("#3521 prepare-before-emit free-function routing", () => {
       legacyBodyEmitted: true,
       irBodyEmitted: false,
     });
+    // The current-function read closes only gNonStrict's function-value
+    // component. The independent scalar owner still prepares exactly once.
     expect(outcome(result, "directOnly")).toMatchObject({
-      legacyBodyEmitted: true,
+      legacyBodyEmitted: false,
       irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
     });
   });
 
@@ -949,25 +955,30 @@ describe("#3521 prepare-before-emit free-function routing", () => {
     expect((await instantiate(result)).run!(41)).toBe(42);
   });
 
-  it("keeps a free function called by a direct module initializer in the direct component", async () => {
-    const result = await compile(
-      `
+  it("prepares a fixed-scalar free function called by a direct module initializer", async () => {
+    const source = `
       function increment(value: number): number { return value + 1; }
       let seeded = increment(41);
       export function run(): number { return seeded; }
-      `,
-      {
-        fileName: "prepared-module-init-call-boundary.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      },
-    );
+      `;
+    const result = await compileWithPoisonedDirectFunctionBodies(source, "increment", {
+      fileName: "prepared-module-init-call-boundary.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-    expect(result.irFirstSkipped ?? []).not.toContain("increment");
+    expect(result.irFirstSkipped).toContain("increment");
     expect(outcome(result, "increment")).toMatchObject({
-      legacyBodyEmitted: true,
+      kind: "emitted",
+      legacyBodyEmitted: false,
       irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(result.irOutcomes?.find((candidate) => candidate.unitKind === "module-init")).toMatchObject({
+      kind: "unsupported",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
     });
     expect((await instantiate(result)).run!()).toBe(42);
   });


### PR DESCRIPTION
## Summary

- replace the blanket fast-mode preparation rejection with a fail-closed explicit scalar ABI proof
- require each `number` / `boolean` / `void` syntax position to match the final IR override and the exact allocated Program ABI slot
- preserve every existing body, ownership, caller, function-value, and component-closure guard; unsupported fast signatures remain direct
- align three stale #3521 routing assertions with behavior already present on current main while strengthening their compile-once and exact-size evidence
- record the bounded #3521 implementation plan and issue-local LOC allowance

## Validation

- focused fast-scalar routing controls: 4/4 passed
- former changed-root failures: 3/3 passed
- positive numeric and mixed f64/i32 components bypass poisoned direct bodies and report direct=0 / IR=1
- IR-off poison control and fast default-parameter negative prove the direct route remains live
- module-init control poisons the scalar callee direct body while proving module init itself remains direct
- function-value identity pins exact GC/standalone binary deltas: 0 / 119 bytes
- 8,000,000,000 numeric result retained beyond the i32 range
- TS7 no-emit, scoped Biome lint, Prettier, and all mandatory pre-push gates passed

Refs #3521