### PR TITLE
fix(typescript): harden parser callback and generic carriers

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "dogfood:uuid": "node --import tsx tests/dogfood/npm-compat-catalog-harness.mjs --package uuid",
     "dogfood:uuid-upstream-suite": "node --import tsx tests/dogfood/uuid-upstream-suite.mjs",
     "dogfood:typescript": "node --import tsx tests/dogfood/npm-compat-catalog-harness.mjs --package typescript",
-    "dogfood:typescript-parser-source": "node tests/dogfood/typescript-upstream-build-probe.mjs --root tests/dogfood/.npm-upstream-suites/typescript --prepare-pinned-typescript --mode source --entry ../../fixtures/typescript-parser-workload.ts --consumer-driven-barrels --invoke-export runCase --require-invocations 3 --invoke-case src/compiler/builderStatePublic.ts=13386537220945 --invoke-case src/compiler/corePublic.ts=40098163538143 --invoke-case src/compiler/performanceCore.ts=49645738923599 --timeout-ms 420000 --heap-mb 4096 --json",
+    "dogfood:typescript-parser-source": "node tests/dogfood/typescript-upstream-build-probe.mjs --root tests/dogfood/.npm-upstream-suites/typescript --prepare-pinned-typescript --mode source --entry ../../fixtures/typescript-parser-workload.ts --consumer-driven-barrels --invoke-export runCase --require-invocations 3 --invoke-case src/compiler/builderStatePublic.ts=13386537220945 --invoke-case src/compiler/corePublic.ts=40098163538143 --invoke-case src/compiler/performanceCore.ts=49645738923599 --timeout-ms 600000 --heap-mb 4096 --json",
     "dogfood:redux": "node --import tsx tests/dogfood/npm-compat-catalog-harness.mjs --package redux",
     "dogfood:redux-workload": "node --import tsx tests/dogfood/redux-workload-harness.mjs",
     "dogfood:redux-upstream-suite": "node --import tsx tests/dogfood/redux-upstream-suite.mjs",

--- a/plan/issues/1058-compile-the-typescript-compiler-itself.md
+++ b/plan/issues/1058-compile-the-typescript-compiler-itself.md
@@ -119,6 +119,10 @@ oracle-ratchet-allow:
   - src/codegen/property-access-dispatch.ts
   - src/codegen/property-access.ts
   - src/codegen/generic-struct-factory.ts
+  # 2026-08-30: distinguishing a compiled Scanner implementation from an
+  # ambient object requires checker-backed declaration and initializer
+  # provenance. This is deliberately local to callback classification.
+  - src/codegen/closures/callback-classification.ts
 ---
 # #1058 — Compile the TypeScript compiler to Wasm (self-hosting stress test)
 
@@ -518,29 +522,31 @@ does not claim it is resolved.
 ## Runtime parser handoff (2026-08-30)
 
 Branch: `codex/1058-typescript5-runtime`, synchronized to `origin/main` at
-`3e89b5f95318b45fd69c9cf8209da84a7a06351a`.
+`275216c74c7299ea07a72c8d5479f7e1a477000c`.
 
-The canonical consumer-driven TypeScript 5.9.3 scanner/parser graph now
-**compiles and validates**. The latest authoritative run produced an
-**83,543,849-byte** Wasm module from 30 input files / 34 program files and 4,284
-functions. It completed in 361,235 ms worker time / 362,442 ms wall time, used
-359,130 ms CPU, and peaked at **3,719.4 MiB RSS**, below the 4 GiB gate.
-`compileSuccess` and `WebAssembly.validate` are both true.
+The canonical consumer-driven TypeScript 5.9.3 scanner/parser graph **compiles
+and validates** after the sync. The authoritative diagnostic run on this tree
+finished in 467,608 ms worker time / 468,686 ms wall time and produced an
+**84,817,448-byte** Wasm module from 30 input/source files, 34 program files,
+and 4,284 functions. Peak RSS was **3,848.6 MiB**, below the 4 GiB gate, and the
+result contained 16 non-fatal IR/projection warnings. `compileSuccess` and
+`WebAssembly.validate` are both true.
 
-Tier 3 runtime equivalence remains open. All three real-source invocations now
-pass compilation, instantiation, constructor dispatch, literal materialization,
-and Wasm null-cast execution, then stop at the same later host-boundary error:
-
-```text
-TypeError: Cannot access property on null or undefined
-```
-
-The probe currently has no Wasm offset or source-map location for that host
-exception. The required values are still:
+Runtime parser equivalence remains open. The same fresh build invoked all three
+canonical inputs; none returned its required fingerprint:
 
 - `builderStatePublic.ts = 13386537220945`
 - `corePublic.ts = 40098163538143`
 - `performanceCore.ts = 49645738923599`
+
+`builderStatePublic.ts` and `performanceCore.ts` both reach semicolon recovery
+with a missing Identifier whose `escapedText` is `undefined`, then fail in
+`unescapeLeadingUnderscores` / `utilitiesPublic.ts:851`. `corePublic.ts` reaches
+an `illegal cast` in `__call_fn_method_2` from
+`parseBinaryExpressionRest`. The diagnostic Wasm and source map were preserved
+at `/private/tmp/ts2wasm-typescript-parser-latest.wasm{,.map}` for the next
+investigation; they match this exact source tree and must not be confused with
+the earlier 83.6 MB artifact used for the size audit.
 
 ### Compiler fixes in this follow-up
 
@@ -565,32 +571,91 @@ exception. The required values are still:
   rejection, prepared multi-module factories, concrete nullable `Symbol`
   fields, sibling loop layouts, and the exact four-module literal/parser
   diamond that previously trapped.
+- Callable-property invocation now bridges erased generic reference ABIs in
+  both directions. In particular, a generic `(externref) -> externref`
+  identity stored as `Rules.apply(Box): Box` no longer freezes or miscasts its
+  argument/result carrier. The focused regressions in
+  `issue-1058-generic-identity-return.test.ts` and
+  `issue-1058-generic-base-node-factory.test.ts` compile, validate, and return
+  their expected values.
+- Callback ownership and registration now span the whole prepared source
+  graph. Later-source named callbacks are discovered before an earlier generic
+  dispatcher is compiled, while an inline arrow passed to a method declared by
+  a compiled interface stays on the Wasm-closure path instead of being wrapped
+  as a host callback. This is the exact TypeScript parser shape
+  `scanner.tryScan(() => scanner.reScanInvalidIdentifier() === Identifier)`;
+  before the fix `speculationHelper<T>` cast the host wrapper to a null Wasm
+  closure root. All five focused cases in
+  `issue-1058-multifile-generic-callback-registration.test.ts` now pass,
+  including the inline-arrow case returning `42` and the later-source
+  boolean/node/enum callback case returning `14243`.
+- Cross-source callback discovery is cached graph-wide. Registration still
+  runs per source so a later exact ABI can replace a conservative entry, but
+  the compiler no longer walks the roughly 10 MB TypeScript graph once for
+  every source.
+- Body-proven generic identity helpers can recover the concrete input carrier
+  after an erased `externref -> externref` call. The proof fails closed: every
+  outer value return must name the same generic parameter symbol and the
+  binding may not be assigned, updated, rebound, or used as a loop write
+  target. Property writes remain valid for TypeScript's `finishNode<T>`.
+  Negative regressions cover returning a fresh asserted value and rebinding
+  the parameter before return.
 
-Post-sync validation on `3e89b5f95318b45fd69c9cf8209da84a7a06351a`
-is green: all **52** `tests/issue-1058-*.test.ts` files pass (**175 tests**),
-TS5 and TS7 typechecks pass, repository Biome lint checks 4,994 files with a
-zero exit status, and `check:ir-fallbacks` reports no gated increase.
+Current-main validation is green for all **53** `tests/issue-1058-*.test.ts`
+files (**183/183 tests**), including all **6/6** multi-file callback cases and
+the new generic-identity safety controls. TS5 and TS7 typechecks, repository
+lint/format, the IR fallback ratchet, the oracle ratchet, and
+`git diff --check` pass. The strict upstream callback suite is intentionally
+not claimed: its prerequisite parser fingerprints still fail as documented
+above.
 
 ### Artifact size note
 
-The 83.5 MB output is not a 100 KB hand-written parser translated directly.
-It contains the selected TypeScript compiler runtime graph: scanner, parser,
-node factories, utilities, diagnostics, module initialization, 4,284 compiled
-functions, WasmGC type/layout metadata, and generated property/call adapters.
-One erased generic memoized-closure dispatch alone renders to roughly 4.9
-million WAT characters. QuickJS's often-quoted parser size excludes much of
-that shared runtime and is compiled by a mature native optimizer; size work is
-a separate follow-up from this correctness-first compile milestone.
+The roughly **84 MB** output is not an intrinsic cost of TypeScript's parser;
+it exposes a js2wasm code-generation pathology. A measured 83,585,611-byte
+diagnostic artifact has an **81,488,148-byte code section (97.49%)** and no
+embedded source/data payload. Of that code, 1,176 generated `__closure_*`
+bodies occupy 76,499,060 bytes. TypeScript's 88 KB `visitorPublic.ts` accounts
+for **75,571,430 bytes** of closure code because its visitor callback cohort is
+emitted during discovery and then twice during the final two-pass compile. The
+two final cohorts include an exact byte-for-byte duplicated
+**36,791,280-byte** block.
+
+This is why comparison with an approximately 100 KB QuickJS parser is only
+partly apples-to-apples: this gate links about 6.82 MB across 28 TypeScript
+frontend modules, factories, utilities, diagnostics, and initialization, and
+emits raw unoptimized WasmGC. Even so, the current size is not acceptable as a
+normal parser baseline. Binaryen's `--remove-unused-module-elements` alone
+reduces the measured artifact from 83,585,611 to **41,141,284 bytes**, proving
+that almost half is removable duplicate/dead module code rather than required
+runtime behavior.
+
+Size follow-up priorities, in order, are:
+
+1. Make callback discovery transactional/analyze-only, or prune the functions
+   it emits, so the final pass does not retain the discovery cohort.
+2. Reuse the final two-pass closure bodies instead of minting a second identical
+   function for the same AST node and capture ABI.
+3. Replace per-call expansion over roughly 1,034 closure candidates with shared
+   or ABI-narrowed dispatch helpers.
+4. Reduce exports and run unused-module elimination/optimization before
+   delivery; pool the 12,057 imported string globals separately.
 
 ### Exact remaining work
 
-1. Add a host-boundary diagnostic around `runCase` traversal to locate the
-   common null property read now reached by all three sources.
-2. Make all three invocations return the expected fingerprints above.
-3. After the runtime fix, rerun the canonical fingerprints, the strict
-   11-callback upstream suite, and the oracle ratchet before claiming runtime
-   parser equivalence. The focused suite, typechecks, lint, and IR ratchet are
-   already green at this handoff.
+1. Add the missing focused Identifier witness: a multi-file, two-activation
+   `createNodeFactory` graph with typed ObjectAllocator constructors, generic
+   `countNode<T>`, the five BaseNodeFactory arrows, destructured
+   `factoryCreateIdentifier`, and `factoryCreateIdentifier("")`. Individual
+   allocator and structural-extension shapes already pass; their combined
+   per-activation/candidate shape is the narrow untested frontier.
+2. Use that witness to determine whether the callable BaseNodeFactory resolves
+   to the wrong carrier or whether Node-to-Identifier structural extension is
+   skipped. Make it fail before changing compiler code.
+3. Reduce the `corePublic.ts` two-argument method-cast separately; do not fold
+   it into the Identifier fix without a shared root-cause proof.
+4. Make all three invocations return the expected fingerprints above, then run
+   the strict 3-file / 11-callback upstream suite.
 
 This is a real-package compile/validation milestone, not a claim that the
 three AST fingerprints or the whole TypeScript unit suite pass yet.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -4527,7 +4527,7 @@ export function compileArrowAsCallback(
       // callback snapshots it; this is also required for a capture-free
       // declaration that is referenced only from inside the callback.
       // The materializer is a no-op for ordinary captured locals.
-      materializeHoistedFunctionValueBinding(ctx, fctx, cap.name);
+      materializeHoistedFunctionValueBinding(ctx, fctx, cap.name, cap.mutable !== true);
       if (cap.mutable && !cap.alreadyBoxed) {
         const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.type);
         // (#2128) Reuse the literal's shared cell when a sibling callback

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -1391,7 +1391,7 @@ export function emitClosureConstruction(
     // Function value even when this closure never names it directly. Fill the
     // hoisted binding before the closure snapshots/passes its slot; otherwise
     // the lifted caller receives the preallocated null value.
-    materializeHoistedFunctionValueBinding(ctx, fctx, cap.name);
+    materializeHoistedFunctionValueBinding(ctx, fctx, cap.name, cap.mutable !== true);
     if (cap.mutable) {
       // Check if the outer scope already has this variable boxed (nested closure case)
       if (fctx.boxedCaptures?.has(cap.name)) {

--- a/src/codegen/closures/callback-classification.ts
+++ b/src/codegen/closures/callback-classification.ts
@@ -138,6 +138,99 @@ export function isVecOrArrayRefType(ctx: CodegenContext, wt: ValType): boolean {
   return name.startsWith("__vec_") || name.startsWith("__arr_") || name === "__vec_base";
 }
 
+function sourceBelongsToCompiledProgram(ctx: CodegenContext, sourceFile: ts.SourceFile): boolean {
+  return (
+    !sourceFile.isDeclarationFile &&
+    ctx.callableSourceFiles?.some(
+      (candidate) => candidate === sourceFile || candidate.fileName === sourceFile.fileName,
+    ) === true
+  );
+}
+
+function unwrapReceiverOriginExpression(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/**
+ * Prove that an interface-typed receiver was produced by compiled code.
+ *
+ * A source MethodSignature alone is not implementation provenance: a local
+ * interface can describe an ambient/host object. The Scanner case that needs
+ * the Wasm-closure path has a stronger fact: its receiver local is initialized
+ * by the compiled `createScanner()` implementation. Follow only that narrow
+ * initializer/callee chain; parameters and uninitialized/ambient declarations
+ * deliberately remain host boundaries. (TypeScript intentionally declares its
+ * singleton scanner with `var` to avoid a TDZ check, so declaration kind cannot
+ * be used as the provenance proof.)
+ */
+function receiverHasCompiledImplementationOrigin(
+  ctx: CodegenContext,
+  expression: ts.Expression,
+  seen = new Set<ts.Node>(),
+): boolean {
+  const current = unwrapReceiverOriginExpression(expression);
+  if (seen.has(current)) return false;
+  seen.add(current);
+
+  if (ts.isObjectLiteralExpression(current) || ts.isClassExpression(current)) return true;
+
+  if (ts.isIdentifier(current)) {
+    let symbol = ctx.checker.getSymbolAtLocation(current);
+    if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+      try {
+        symbol = ctx.checker.getAliasedSymbol(symbol);
+      } catch {
+        return false;
+      }
+    }
+    return (
+      symbol?.declarations?.some(
+        (declaration) =>
+          ts.isVariableDeclaration(declaration) &&
+          declaration.initializer !== undefined &&
+          receiverHasCompiledImplementationOrigin(ctx, declaration.initializer, seen),
+      ) === true
+    );
+  }
+
+  if (ts.isCallExpression(current) || ts.isNewExpression(current)) {
+    let callee: ts.Expression = current.expression;
+    callee = unwrapReceiverOriginExpression(callee);
+    if (ts.isFunctionExpression(callee) || ts.isArrowFunction(callee) || ts.isClassExpression(callee)) return true;
+    const symbolNode = ts.isPropertyAccessExpression(callee) ? callee.name : callee;
+    let symbol = ctx.checker.getSymbolAtLocation(symbolNode);
+    if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+      try {
+        symbol = ctx.checker.getAliasedSymbol(symbol);
+      } catch {
+        return false;
+      }
+    }
+    return (
+      symbol?.declarations?.some((declaration) => {
+        if (!sourceBelongsToCompiledProgram(ctx, declaration.getSourceFile())) return false;
+        if (ts.isFunctionDeclaration(declaration) || ts.isMethodDeclaration(declaration)) {
+          return declaration.body !== undefined;
+        }
+        if (ts.isVariableDeclaration(declaration)) return declaration.initializer !== undefined;
+        if (ts.isClassDeclaration(declaration)) return true;
+        return false;
+      }) === true
+    );
+  }
+
+  return false;
+}
+
 /** Check if an arrow/function expression is used as a callback argument to a call
  *  that targets a HOST import (not a user-defined function). User-defined functions
  *  should receive closures via the GC struct path, not the __make_callback host path. */
@@ -219,6 +312,27 @@ export function isHostCallbackArgument(node: ts.Node, ctx: CodegenContext): bool
       }
       try {
         const receiverType = ctx.checker.getTypeAtLocation(propAccess.expression);
+        // A method declared by one of the source files being compiled is an
+        // in-module callable boundary even when its receiver is described by
+        // an interface rather than a class. TypeScript's Scanner is the
+        // production witness: `scanner.tryScan(() => ...)` resolves through a
+        // source `Scanner.tryScan<T>` signature and the object-literal method
+        // invokes the callback as a Wasm closure. Sending that inline arrow
+        // through `__make_callback` creates a host JS function; the compiled
+        // generic dispatcher then guard-casts it to the closure wrapper root
+        // and dereferences null.
+        //
+        // Keep ambient/library methods on the host path. Requiring the method
+        // declaration itself to belong to `callableSourceFiles` also avoids
+        // reclassifying an imported host API merely because its receiver has a
+        // callable-looking structural type.
+        const methodSymbol = ctx.checker.getSymbolAtLocation(propAccess.name) ?? receiverType.getProperty(methodName);
+        const isCompiledSourceMethod = methodSymbol?.declarations?.some((declaration) => {
+          const sourceFile = declaration.getSourceFile();
+          return sourceBelongsToCompiledProgram(ctx, sourceFile);
+        });
+        if (isCompiledSourceMethod && receiverHasCompiledImplementationOrigin(ctx, propAccess.expression)) return false;
+
         // Search the receiver type's symbol chain for a class name that
         // matches a user-defined method `${ClassName}_${methodName}`. We
         // check both the receiver's own symbol (instance methods) and the

--- a/src/codegen/closures/funcref-as-closure.ts
+++ b/src/codegen/closures/funcref-as-closure.ts
@@ -135,7 +135,7 @@ function emitMemoizedNestedFnClosure(
     // local directly would otherwise snapshot its initial null value. Keep the
     // lazy timing (important when the function captures later initializers),
     // but fill the binding immediately before this closure copies it.
-    materializeHoistedFunctionValueBinding(ctx, fctx, cap.name);
+    materializeHoistedFunctionValueBinding(ctx, fctx, cap.name, cap.mutable !== true);
     // (#2029 family A) Cross-fctx capture sourcing. `cap.outerLocalIdx` is a
     // slot in the function that DECLARED the nested fn; when this
     // materialization runs inside a DIFFERENT function (an object-literal
@@ -638,19 +638,25 @@ export function materializeHoistedFunctionValueBinding(
   ctx: CodegenContext,
   fctx: FunctionContext,
   name: string,
+  reemitForImmutableCapture = false,
 ): boolean {
+  const alreadyMaterialized = fctx.materializedHoistedFunctionValueBindings?.has(name) === true;
   if (
     !fctx.hoistedFunctionValueBindings?.has(name) ||
     fctx.liftedCaptureNames?.has(name) ||
-    fctx.materializedHoistedFunctionValueBindings?.has(name) ||
+    (alreadyMaterialized && !reemitForImmutableCapture) ||
     fctx.materializingHoistedFunctionValueBindings?.has(name)
   ) {
-    return (
-      fctx.materializedHoistedFunctionValueBindings?.has(name) ||
-      fctx.materializingHoistedFunctionValueBindings?.has(name) ||
-      false
-    );
+    return alreadyMaterialized || fctx.materializingHoistedFunctionValueBindings?.has(name) || false;
   }
+
+  // Compilation visits both conditional arms, while only one arm runs. A
+  // sibling Function value emitted in the first arm therefore does not
+  // dominate a closure constructed in the second arm. Immutable captures may
+  // safely re-emit the materializer here: capture-carrying declarations reuse
+  // their per-activation memo and capture-free declarations reuse their module
+  // singleton, so this publishes the same Function object without changing
+  // assignment semantics. Mutable captures keep the one-site behavior above.
 
   const localIdx = fctx.localMap.get(name);
   const funcIdx = ctx.funcMap.get(name);

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -68,7 +68,7 @@ import { resolveVariadicBuiltinStaticPlainAlias } from "../builtin-static-plain-
 import { bindingMayReceiveHostCallable } from "../analysis/mixed-assignment-carrier.js";
 import { ensureStandaloneBuiltinStaticMethodClosure } from "../builtin-value-read.js";
 import { localBindingShadowsCapturingFunction } from "../function-declaration-observation.js";
-import { genericStructFactoryCall } from "../generic-struct-factory.js";
+import { genericIdentityReturnParamIndex, genericStructFactoryCall } from "../generic-struct-factory.js";
 import { isUnaliasedNodeFsImportBinding } from "../node-fs-binding-identity.js";
 import {
   canEmitAssertedStructExtension,
@@ -174,6 +174,44 @@ function tryEmitGenericStructFactoryResult(
   }
 
   return emitAssertedStructExtension(ctx, fctx, carried, target) ? target : null;
+}
+
+/**
+ * Recover the concrete carrier hidden by an externref `T -> T` implementation
+ * ABI before applying the instantiated result type.
+ *
+ * TypeScript's `finishNode<T>(node: T): T` intentionally accepts every AST
+ * node layout through externref. In `parseTokenNode<TypeNode>()`, its argument
+ * is still statically a `Token`, while the surrounding assertion asks for the
+ * sibling `TypeNode` interface. Casting the opaque externref straight to
+ * TypeNode loses the valid Token and produces null. Decode the value through
+ * the proven identity parameter first; the ordinary typed-ref coercion can
+ * then perform its field-preserving structural projection (including erased
+ * `_...Brand` defaults).
+ */
+function tryEmitGenericIdentityResult(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  call: ts.CallExpression,
+  actualReturn: ValType,
+  instantiatedReturn: ts.Type,
+): ValType | null {
+  const parameterIndex = genericIdentityReturnParamIndex(ctx, call);
+  const argument = parameterIndex === undefined ? undefined : call.arguments[parameterIndex];
+  if (!argument || (actualReturn.kind !== "externref" && actualReturn.kind !== "ref_extern")) return null;
+
+  const source = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(argument));
+  const target = resolveWasmType(ctx, instantiatedReturn);
+  if ((source.kind !== "ref" && source.kind !== "ref_null") || (target.kind !== "ref" && target.kind !== "ref_null")) {
+    return null;
+  }
+
+  const sourceCarrier: ValType = { kind: "ref_null", typeIdx: source.typeIdx };
+  if (source.typeIdx !== target.typeIdx && !canStructurallyProjectRef(ctx, sourceCarrier, target)) return null;
+
+  coerceType(ctx, fctx, { kind: "externref" }, sourceCarrier);
+  if (!valTypesMatch(sourceCarrier, target)) coerceType(ctx, fctx, sourceCarrier, target);
+  return target;
 }
 
 /**
@@ -2015,6 +2053,7 @@ export function compileIdentifierCall(
               unboxNumberIdx: number | null;
             },
             allowProvenNumberUnbox: boolean,
+            allowGeneralRefExport: boolean,
           ): Instr[] | null => {
             if (scalarAbiTypesMatch(from, to)) return [];
             if (ctx.standalone || ctx.wasi) return null;
@@ -2053,9 +2092,23 @@ export function compileIdentifierCall(
             }
             if (
               (from.kind === "ref" || from.kind === "ref_null") &&
-              (isErasedGenericRefCarrier(from.typeIdx) || sigParamWasmTypes.length === 0) &&
+              ((allowGeneralRefExport && from.typeIdx !== ctx.anyValueTypeIdx) ||
+                isErasedGenericRefCarrier(from.typeIdx) ||
+                sigParamWasmTypes.length === 0) &&
               isHostExtern(to)
             ) {
+              // `$AnyValue` is deliberately excluded from the new general
+              // argument widening: its tagged GC struct needs semantic
+              // projection rather than raw reference export.
+              // Widening a concrete WasmGC reference to externref is always
+              // lossless.  Keep the tuple/vec restriction on the reverse
+              // direction above, where an erased value would need a guarded
+              // downcast, but do not apply it here.  TypeScript's parent-fixup
+              // traversal is the production witness: visitNode supplies a
+              // concrete Node while its captured addWorkItem callback accepts
+              // Node | NodeArray<Node>.  The latter lowers to externref, and
+              // excluding that wrapper type made the callable dispatch end in
+              // its TypeError arm even though the callback was present.
               return [{ op: "extern.convert_any" }];
             }
 
@@ -2086,7 +2139,11 @@ export function compileIdentifierCall(
           };
           const argumentHasNumberBridgeProof = (index: number): boolean =>
             index >= expr.arguments.length || ctx.oracle.staticJsTypeOf(expr.arguments[index]!) === "number";
-          const theoreticalHelpers = { boxNumberIdx: 0, boxBooleanIdx: 0, unboxNumberIdx: 0 };
+          const theoreticalHelpers = {
+            boxNumberIdx: 0,
+            boxBooleanIdx: 0,
+            unboxNumberIdx: 0,
+          };
           let needsScalarBridge = false;
           for (const [, info] of ctx.closureInfoByTypeIdx) {
             const hasRest = info.hasRestParam === true;
@@ -2101,7 +2158,7 @@ export function compileIdentifierCall(
               const to = info.paramTypes[pi]!;
               if (scalarAbiTypesMatch(from, to)) continue;
               differs = true;
-              if (scalarBridgePlan(from, to, theoreticalHelpers, argumentHasNumberBridgeProof(pi)) === null) {
+              if (scalarBridgePlan(from, to, theoreticalHelpers, argumentHasNumberBridgeProof(pi), true) === null) {
                 compatible = false;
                 break;
               }
@@ -2111,7 +2168,7 @@ export function compileIdentifierCall(
               expectedReturn !== null &&
               info.returnType !== null &&
               !scalarAbiTypesMatch(info.returnType, expectedReturn) &&
-              scalarBridgePlan(info.returnType, expectedReturn, theoreticalHelpers, false) !== null;
+              scalarBridgePlan(info.returnType, expectedReturn, theoreticalHelpers, false, false) !== null;
             if (differs || returnDiffers) {
               needsScalarBridge = true;
               break;
@@ -2121,7 +2178,12 @@ export function compileIdentifierCall(
             addUnionImports(ctx);
             flushLateImportShifts(ctx, fctx);
           }
-          const dispatchBridgePlan = (from: ValType, to: ValType, allowProvenNumberUnbox: boolean): Instr[] | null =>
+          const dispatchBridgePlan = (
+            from: ValType,
+            to: ValType,
+            allowProvenNumberUnbox: boolean,
+            allowGeneralRefExport: boolean,
+          ): Instr[] | null =>
             scalarBridgePlan(
               from,
               to,
@@ -2131,6 +2193,7 @@ export function compileIdentifierCall(
                 unboxNumberIdx: ctx.funcMap.get("__unbox_number") ?? null,
               },
               allowProvenNumberUnbox,
+              allowGeneralRefExport,
             );
 
           const funcCandidates: FuncCandidate[] = [
@@ -2186,6 +2249,7 @@ export function compileIdentifierCall(
                   sigParamWasmTypes[pi]!,
                   candidateParamTypes[pi]!,
                   argumentHasNumberBridgeProof(pi),
+                  true,
                 );
                 if (bridge === null) {
                   paramsMatch = false;
@@ -2203,7 +2267,7 @@ export function compileIdentifierCall(
               expectedReturn !== null &&
               info.returnType !== null &&
               !scalarAbiTypesMatch(info.returnType, expectedReturn) &&
-              dispatchBridgePlan(info.returnType, expectedReturn, false) === null &&
+              dispatchBridgePlan(info.returnType, expectedReturn, false, false) === null &&
               !declaredRefSubtypeOf(info.returnType, expectedReturn) &&
               !canProjectImplementationReturn(info.returnType, expectedReturn)
             ) {
@@ -2762,7 +2826,7 @@ export function compileIdentifierCall(
                 }
                 fcCallBody.push({ op: "local.get", index: argLocals[ai]! });
                 if (!scalarAbiTypesMatch(fromType, toType)) {
-                  const bridge = dispatchBridgePlan(fromType, toType, argumentHasNumberBridgeProof(ai));
+                  const bridge = dispatchBridgePlan(fromType, toType, argumentHasNumberBridgeProof(ai), true);
                   if (bridge === null) {
                     candidateArgsCoercible = false;
                     break;
@@ -2828,7 +2892,7 @@ export function compileIdentifierCall(
                 } else if (canProjectImplementationReturn(fc.returnType!, expectedReturn!)) {
                   fcCallBody.push(...coercionInstrs(ctx, fc.returnType!, expectedReturn!, fctx));
                 } else {
-                  const bridge = dispatchBridgePlan(fc.returnType!, expectedReturn!, false);
+                  const bridge = dispatchBridgePlan(fc.returnType!, expectedReturn!, false, false);
                   if (bridge !== null) {
                     fcCallBody.push(...bridge);
                   } else {
@@ -3154,7 +3218,7 @@ export function compileIdentifierCall(
         // live cell still contains null until the lazy materializer fills it.
         // Publish the value before passing the cell to the callee, matching
         // emitClosureConstruction's capture path.
-        materializeHoistedFunctionValueBinding(ctx, fctx, cap.name);
+        materializeHoistedFunctionValueBinding(ctx, fctx, cap.name, cap.mutable !== true);
         // #1177: TDZ check for captured let/const/using variables — fires
         // BEFORE the cap-prepend so we throw ReferenceError before the callee
         // observes an uninitialized value. Apply to BOTH the mutable and
@@ -3735,6 +3799,8 @@ export function compileIdentifierCall(
       const actualReturn = getWasmFuncReturnType(ctx, finalFuncIdx) ?? resolveWasmType(ctx, retType);
       const factoryResult = tryEmitGenericStructFactoryResult(ctx, fctx, expr, actualReturn);
       if (factoryResult !== null) return factoryResult;
+      const identityResult = tryEmitGenericIdentityResult(ctx, fctx, expr, actualReturn, retType);
+      if (identityResult !== null) return identityResult;
       return brandExternMethodResult(ctx, retType, actualReturn);
     }
     return getWasmFuncReturnType(ctx, finalFuncIdx) ?? { kind: "f64" };

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -81,7 +81,39 @@ import { isDeclaredStructRefSubtypeAssignable } from "../struct-hierarchy-layout
  * element call: the concrete closure struct type, its lifted funcref type, and
  * the wasm return type that funcref yields.
  */
-type FuncCandidate = { funcTypeIdx: number; structTypeIdx: number; returnType: ValType | null };
+type FuncCandidate = {
+  funcTypeIdx: number;
+  structTypeIdx: number;
+  returnType: ValType | null;
+  paramTypes: ValType[];
+};
+
+/**
+ * Import-free ABI bridge for a callable property's erased generic reference.
+ *
+ * A generic implementation such as `identity<T>(value: T): T` lowers to
+ * `(externref) -> externref`, while a concrete interface field holding it can
+ * be called as `(ref Box) -> ref Box`. Both crossings preserve the same GC
+ * reference: export the concrete argument and narrow the declared concrete
+ * result at the field boundary. `$AnyValue` is a tagged carrier rather than a
+ * raw object reference, so it must keep its semantic projection path.
+ */
+function callablePropertyRefBridge(ctx: CodegenContext, from: ValType, to: ValType): Instr[] | null {
+  const isHostExtern = (type: ValType): boolean => type.kind === "externref" || type.kind === "ref_extern";
+  if (valTypesMatch(from, to) || (isHostExtern(from) && isHostExtern(to))) return [];
+  if (ctx.standalone || ctx.wasi) return null;
+
+  if ((from.kind === "ref" || from.kind === "ref_null") && from.typeIdx !== ctx.anyValueTypeIdx && isHostExtern(to)) {
+    return [{ op: "extern.convert_any" }];
+  }
+  if (isHostExtern(from) && (to.kind === "ref" || to.kind === "ref_null")) {
+    return [
+      { op: "any.convert_extern" },
+      { op: to.kind === "ref_null" ? "ref.cast_null" : "ref.cast", typeIdx: to.typeIdx },
+    ];
+  }
+  return null;
+}
 
 /** `fillApplyClosure` only emits dynamic method dispatchers for arities 0..8. */
 const REALM_DYNAMIC_CALL_MAX_ARITY = 8;
@@ -214,6 +246,7 @@ function buildClosureFuncCandidates(
         funcTypeIdx: alt.closureInfo.funcTypeIdx,
         structTypeIdx: alt.closureInfo.structTypeIdx,
         returnType: alt.closureInfo.returnType,
+        paramTypes: alt.closureInfo.paramTypes,
       });
     }
   };
@@ -233,7 +266,7 @@ function buildClosureFuncCandidates(
     if (seen.has(info.funcTypeIdx)) continue;
     let paramsMatch = true;
     for (let pi = 0; pi < sigParamCount; pi++) {
-      if (!valTypesMatch(info.paramTypes[pi]!, sigParamWasmTypes[pi]!)) {
+      if (callablePropertyRefBridge(ctx, sigParamWasmTypes[pi]!, info.paramTypes[pi]!) === null) {
         paramsMatch = false;
         break;
       }
@@ -244,6 +277,7 @@ function buildClosureFuncCandidates(
         funcTypeIdx: info.funcTypeIdx,
         structTypeIdx: info.structTypeIdx,
         returnType: info.returnType,
+        paramTypes: info.paramTypes,
       });
     }
   }
@@ -312,6 +346,7 @@ function emitRootFuncrefDispatch(
   rootIdx: number,
   funcCandidates: FuncCandidate[],
   argLocals: number[],
+  argTypes: ValType[],
   expectedReturn: ValType | null,
 ): void {
   // Fetch the funcref off the ROOT (field 0 is the root's own field, present on
@@ -338,7 +373,14 @@ function emitRootFuncrefDispatch(
     if (candidateSelfTypeIdx !== rootIdx) {
       fcCallBody.push({ op: "ref.cast", typeIdx: candidateSelfTypeIdx });
     }
-    for (const al of argLocals) fcCallBody.push({ op: "local.get", index: al });
+    for (let index = 0; index < argLocals.length; index++) {
+      fcCallBody.push({ op: "local.get", index: argLocals[index]! });
+      const bridge = callablePropertyRefBridge(ctx, argTypes[index]!, fc.paramTypes[index]!);
+      if (bridge === null) {
+        throw new Error("callable-property candidate admitted without an argument ABI bridge");
+      }
+      fcCallBody.push(...bridge);
+    }
     fcCallBody.push({ op: "local.get", index: funcrefLocal });
     fcCallBody.push({ op: "ref.cast", typeIdx: fc.funcTypeIdx });
     fcCallBody.push({ op: "call_ref", typeIdx: fc.funcTypeIdx });
@@ -348,6 +390,10 @@ function emitRootFuncrefDispatch(
     // padding, so the coercion MUST be import-free (a late import would shift
     // indices and corrupt already-baked ref.func operands — the #2174 hazard).
     const matchedDispatch = expectedReturn !== null && fc.returnType !== null;
+    const referenceReturnBridge =
+      matchedDispatch && !valTypesMatch(fc.returnType!, expectedReturn!)
+        ? callablePropertyRefBridge(ctx, fc.returnType!, expectedReturn!)
+        : null;
     if (expectedReturn === null && fc.returnType !== null) {
       fcCallBody.push({ op: "drop" });
     } else if (expectedReturn !== null && fc.returnType === null) {
@@ -362,6 +408,8 @@ function emitRootFuncrefDispatch(
       // defaulting here would turn a SourceFile-returning NodeFactory closure
       // into null before its caller can narrow the same object back to
       // SourceFile.
+    } else if (referenceReturnBridge !== null) {
+      fcCallBody.push(...referenceReturnBridge);
     } else if (
       matchedDispatch &&
       !valTypesMatch(fc.returnType!, expectedReturn!) &&
@@ -1438,6 +1486,7 @@ export function compileCallablePropertyCall(
           funcTypeIdx: matchedClosureInfo.funcTypeIdx,
           structTypeIdx: wrapperStructIdx,
           returnType: matchedClosureInfo.returnType,
+          paramTypes: matchedClosureInfo.paramTypes,
         },
         sigParamCount,
         sigParamWasmTypes,
@@ -1549,7 +1598,16 @@ export function compileCallablePropertyCall(
 
       // After the args (they may read the caller's `this`), before the ladder.
       if (bind) emitObjectLiteralMethodThisInstall(ctx, fctx, bind);
-      emitRootFuncrefDispatch(ctx, fctx, closureLocal, rootIdx, funcCandidates, argLocals, expectedReturn);
+      emitRootFuncrefDispatch(
+        ctx,
+        fctx,
+        closureLocal,
+        rootIdx,
+        funcCandidates,
+        argLocals,
+        matchedClosureInfo.paramTypes,
+        expectedReturn,
+      );
 
       // A target that does not itself read `arguments` leaves the module
       // globals untouched. Clear them after the indirect call while preserving
@@ -1802,7 +1860,12 @@ export function compileCallableElementAccessCall(
   // externref). See buildClosureFuncCandidates + compileCallablePropertyCall.
   const funcCandidates = buildClosureFuncCandidates(
     ctx,
-    { funcTypeIdx: closureInfo.funcTypeIdx, structTypeIdx: wrapperStructIdx, returnType: closureInfo.returnType },
+    {
+      funcTypeIdx: closureInfo.funcTypeIdx,
+      structTypeIdx: wrapperStructIdx,
+      returnType: closureInfo.returnType,
+      paramTypes: closureInfo.paramTypes,
+    },
     sigParamCount,
     sigParamWasmTypes,
   );
@@ -1901,7 +1964,16 @@ export function compileCallableElementAccessCall(
 
   const argLocals = collectPropertyCallArgLocals(ctx, fctx, expr, closureInfo.paramTypes);
   if (bind) emitObjectLiteralMethodThisInstall(ctx, fctx, bind);
-  emitRootFuncrefDispatch(ctx, fctx, closureLocal, rootIdx, funcCandidates, argLocals, expectedReturn);
+  emitRootFuncrefDispatch(
+    ctx,
+    fctx,
+    closureLocal,
+    rootIdx,
+    funcCandidates,
+    argLocals,
+    closureInfo.paramTypes,
+    expectedReturn,
+  );
   return finishObjectLiteralMethodCall(ctx, fctx, bind, expectedReturn ?? VOID_RESULT);
 }
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3798,14 +3798,33 @@ export function isGlobalBuiltinIdentifier(ctx: CodegenContext, fctx: FunctionCon
  * function-valued declarations.
  */
 export function ensureFuncValueWrappersRegistered(ctx: CodegenContext, sf: ts.SourceFile): void {
-  const registrationState = ctx as unknown as { __funcValueWrapperSourcesRegistered?: Set<string> };
+  const registrationState = ctx as unknown as {
+    __funcValueWrapperSourcesRegistered?: Set<string>;
+    __funcValueWrapperDiscoverySources?: Set<string>;
+    __funcValueWrapperNamedDeclarations?: Set<ts.FunctionDeclaration>;
+    __funcValueWrapperFunctionExpressions?: Set<ts.FunctionExpression | ts.ArrowFunction>;
+  };
   const registeredSources =
     registrationState.__funcValueWrapperSourcesRegistered ??
     (registrationState.__funcValueWrapperSourcesRegistered = new Set<string>());
   if (registeredSources.has(sf.fileName)) return;
   registeredSources.add(sf.fileName);
 
-  const usedAsValue = new Set<ts.FunctionDeclaration>();
+  // Cross-source discovery is graph-global and purely syntactic. Cache its
+  // result instead of walking the complete TypeScript compiler graph once per
+  // source file. Registration below intentionally still runs per source: a
+  // declaration can acquire its exact funcMap/capture ABI after an earlier
+  // source's conservative registration, and getOrCreate is idempotent.
+  const discoverySources =
+    registrationState.__funcValueWrapperDiscoverySources ??
+    (registrationState.__funcValueWrapperDiscoverySources = new Set<string>());
+  const usedAsValue =
+    registrationState.__funcValueWrapperNamedDeclarations ??
+    (registrationState.__funcValueWrapperNamedDeclarations = new Set<ts.FunctionDeclaration>());
+  const usedAsValueFunctions =
+    registrationState.__funcValueWrapperFunctionExpressions ??
+    (registrationState.__funcValueWrapperFunctionExpressions = new Set<ts.FunctionExpression | ts.ArrowFunction>());
+
   const visit = (node: ts.Node): void => {
     if (ts.isIdentifier(node)) {
       const p = node.parent;
@@ -3825,7 +3844,37 @@ export function ensureFuncValueWrappersRegistered(ctx: CodegenContext, sf: ts.So
     }
     ts.forEachChild(node, visit);
   };
-  visit(sf);
+  const visitFns = (node: ts.Node): void => {
+    if (ts.isFunctionExpression(node) || ts.isArrowFunction(node)) {
+      const p = node.parent;
+      const isCallArg = p && ts.isCallExpression(p) && p.arguments.some((a) => a === node);
+      const isVarInit = p && ts.isVariableDeclaration(p) && p.initializer === node;
+      // A reassigned mutable callable is another dynamic-dispatch value
+      // producer. Its call site may compile before the assignment RHS's
+      // wrapper is materialized, so pre-register the same conservative
+      // all-reference wrapper shape used for callback values.
+      const isAssignmentValue =
+        p && ts.isBinaryExpression(p) && p.operatorToken.kind === ts.SyntaxKind.EqualsToken && p.right === node;
+      // A generator function-expression's value is a Generator object, not a
+      // plain closure the inline dispatcher marshals; skip (its wrapper type
+      // is externref-returning and harmless, but leave it to the value site).
+      const isGen = ts.isFunctionExpression(node) && node.asteriskToken !== undefined;
+      if ((isCallArg || isVarInit || isAssignmentValue) && !isGen) usedAsValueFunctions.add(node);
+    }
+    ts.forEachChild(node, visitFns);
+  };
+  // The generic dispatcher can be compiled in an EARLIER source file than the
+  // named callback values passed to it. TypeScript's scanner is the production
+  // witness: scanner.ts emits `speculationHelper<T>(callback: () => T)` before
+  // parser.ts passes nested `nextToken*`/`parse*` declarations through it.
+  // Arrow pre-registration below already scans the complete callable program;
+  // named declarations need the same order-independent visibility.
+  for (const sourceFile of ctx.callableSourceFiles ?? [sf]) {
+    if (discoverySources.has(sourceFile.fileName)) continue;
+    discoverySources.add(sourceFile.fileName);
+    visit(sourceFile);
+    visitFns(sourceFile);
+  }
 
   for (const declaration of usedAsValue) {
     const name = declaration.name!.text;
@@ -3866,6 +3915,7 @@ export function ensureFuncValueWrappersRegistered(ctx: CodegenContext, sf: ts.So
       params.length === 0 &&
       returnType !== null &&
       ((returnType.kind === "i32" && returnType.boolean === true) ||
+        (returnType.kind === "f64" && returnType.undefSentinel !== true) ||
         returnType.kind === "ref" ||
         returnType.kind === "ref_null");
     if (!allExternref || (!externrefOrVoidReturn && !safeZeroArgErasedReturn)) continue;
@@ -3916,10 +3966,7 @@ export function ensureFuncValueWrappersRegistered(ctx: CodegenContext, sf: ts.So
   //     is signature-cached, so the value site reuses the same funcTypeIdx —
   //     no index inconsistency (the declaration loop already relies on this).
   {
-    const seenFnNodes = new Set<ts.Node>();
     const usedAsValueFn = (node: ts.FunctionExpression | ts.ArrowFunction): void => {
-      if (seenFnNodes.has(node)) return;
-      seenFnNodes.add(node);
       const { params, returnType } = computeClosureWrapperSig(ctx, node);
       // (#2939) Restrict pre-registration to the ALL-EXTERNREF callback shape
       // (externref params + externref/void return). This is exactly the harness
@@ -3940,31 +3987,13 @@ export function ensureFuncValueWrappersRegistered(ctx: CodegenContext, sf: ts.So
         params.length === 0 &&
         returnType !== null &&
         ((returnType.kind === "i32" && returnType.boolean === true) ||
+          (returnType.kind === "f64" && returnType.undefSentinel !== true) ||
           returnType.kind === "ref" ||
           returnType.kind === "ref_null");
       if (!allExternref || (!externrefOrVoidReturn && !safeZeroArgErasedReturn)) return;
       getOrCreateFuncRefWrapperTypes(ctx, params, returnType ? [returnType] : []);
     };
-    const visitFns = (node: ts.Node): void => {
-      if (ts.isFunctionExpression(node) || ts.isArrowFunction(node)) {
-        const p = node.parent;
-        const isCallArg = p && ts.isCallExpression(p) && p.arguments.some((a) => a === node);
-        const isVarInit = p && ts.isVariableDeclaration(p) && p.initializer === node;
-        // A reassigned mutable callable is another dynamic-dispatch value
-        // producer. Its call site may compile before the assignment RHS's
-        // wrapper is materialized, so pre-register the same conservative
-        // all-reference wrapper shape used for callback values.
-        const isAssignmentValue =
-          p && ts.isBinaryExpression(p) && p.operatorToken.kind === ts.SyntaxKind.EqualsToken && p.right === node;
-        // A generator function-expression's value is a Generator object, not a
-        // plain closure the inline dispatcher marshals; skip (its wrapper type
-        // is externref-returning and harmless, but leave it to the value site).
-        const isGen = ts.isFunctionExpression(node) && node.asteriskToken !== undefined;
-        if ((isCallArg || isVarInit || isAssignmentValue) && !isGen) usedAsValueFn(node);
-      }
-      ts.forEachChild(node, visitFns);
-    };
-    for (const sourceFile of ctx.callableSourceFiles ?? [sf]) visitFns(sourceFile);
+    for (const node of usedAsValueFunctions) usedAsValueFn(node);
   }
 }
 

--- a/src/codegen/generic-struct-factory.ts
+++ b/src/codegen/generic-struct-factory.ts
@@ -29,6 +29,7 @@ export interface StructFactoryExpression {
 type FactoryMemoEntry = GenericStructFactoryDeclaration | null | "visiting";
 
 const factoryMemo = new WeakMap<CodegenContext, WeakMap<ts.FunctionDeclaration, FactoryMemoEntry>>();
+const identityReturnParamMemo = new WeakMap<CodegenContext, WeakMap<ts.FunctionDeclaration, number | null>>();
 
 function eraseReadonlyView(type: ts.Type): ts.Type {
   return readonlyErasureMappedAliasTarget(type) ?? type;
@@ -371,6 +372,156 @@ export function genericStructFactoryCall(
   }
 
   return { declaration, sourceConstraint: factory.sourceConstraint, target };
+}
+
+/**
+ * Parameter index for a direct generic identity result (`value: T` -> `T`).
+ *
+ * Some identity-preserving structural helpers deliberately use an externref
+ * implementation ABI so one body can carry every concrete object layout.
+ * Their call sites still know the instantiated input carrier. Recovery is
+ * admitted only when every outer value-return names that exact parameter and
+ * its binding is never replaced (writes through its properties are harmless).
+ * This narrow value-flow fact lets identifier-call lowering recover the
+ * carrier after the opaque call instead of immediately casting the result to
+ * an unrelated nominal sibling.
+ */
+export function genericIdentityReturnParamIndex(ctx: CodegenContext, call: ts.CallExpression): number | undefined {
+  const declaration = functionDeclarationForCall(ctx, call);
+  if (!declaration?.typeParameters?.length) return undefined;
+
+  let memo = identityReturnParamMemo.get(ctx);
+  if (!memo) {
+    memo = new WeakMap();
+    identityReturnParamMemo.set(ctx, memo);
+  }
+  const cached = memo.get(declaration);
+  if (cached !== undefined) return cached === null ? undefined : cached;
+
+  const signature = ctx.checker.getSignatureFromDeclaration(declaration);
+  if (!signature || !declaration.body) {
+    memo.set(declaration, null);
+    return undefined;
+  }
+  const result = eraseReadonlyView(ctx.checker.getReturnTypeOfSignature(signature));
+  if (!ownedTypeParameter(ctx, declaration, result)) {
+    memo.set(declaration, null);
+    return undefined;
+  }
+
+  const candidateIndices: number[] = [];
+  declaration.parameters.forEach((parameter, index) => {
+    const parameterType = eraseReadonlyView(ctx.checker.getTypeAtLocation(parameter));
+    if (sameTypeParameter(parameterType, result)) candidateIndices.push(index);
+  });
+
+  const bindingContainsSymbol = (name: ts.BindingName, symbol: ts.Symbol): boolean => {
+    if (ts.isIdentifier(name)) return ctx.checker.getSymbolAtLocation(name) === symbol;
+    return name.elements.some(
+      (element) => !ts.isOmittedExpression(element) && bindingContainsSymbol(element.name, symbol),
+    );
+  };
+
+  const writeTargetContainsSymbol = (target: ts.Node, symbol: ts.Symbol): boolean => {
+    if (ts.isIdentifier(target)) return ctx.checker.getSymbolAtLocation(target) === symbol;
+    // Writing through the parameter is compatible with identity: `node.pos =`
+    // mutates the object but does not replace the parameter binding.
+    if (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) return false;
+    if (
+      ts.isParenthesizedExpression(target) ||
+      ts.isNonNullExpression(target) ||
+      ts.isAsExpression(target) ||
+      ts.isTypeAssertionExpression(target)
+    ) {
+      return writeTargetContainsSymbol(target.expression, symbol);
+    }
+    if (ts.isBinaryExpression(target) && target.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      return writeTargetContainsSymbol(target.left, symbol);
+    }
+
+    let found = false;
+    ts.forEachChild(target, (child) => {
+      if (!found && writeTargetContainsSymbol(child, symbol)) found = true;
+    });
+    return found;
+  };
+
+  const provesExactIdentityReturn = (parameterIndex: number): boolean => {
+    const parameter = declaration.parameters[parameterIndex];
+    if (!parameter || !ts.isIdentifier(parameter.name)) return false;
+    const parameterSymbol = ctx.checker.getSymbolAtLocation(parameter.name);
+    if (!parameterSymbol) return false;
+
+    let sawValueReturn = false;
+    let valid = true;
+    const visit = (node: ts.Node, checkReturns: boolean): void => {
+      if (!valid) return;
+
+      if (ts.isVariableDeclaration(node) && bindingContainsSymbol(node.name, parameterSymbol)) {
+        valid = false;
+        return;
+      }
+      if (
+        (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) &&
+        node.name &&
+        ctx.checker.getSymbolAtLocation(node.name) === parameterSymbol
+      ) {
+        valid = false;
+        return;
+      }
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+        node.operatorToken.kind <= ts.SyntaxKind.LastAssignment &&
+        writeTargetContainsSymbol(node.left, parameterSymbol)
+      ) {
+        valid = false;
+        return;
+      }
+      if (
+        (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+        (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) &&
+        writeTargetContainsSymbol(node.operand, parameterSymbol)
+      ) {
+        valid = false;
+        return;
+      }
+      if (
+        (ts.isForInStatement(node) || ts.isForOfStatement(node)) &&
+        !ts.isVariableDeclarationList(node.initializer) &&
+        writeTargetContainsSymbol(node.initializer, parameterSymbol)
+      ) {
+        valid = false;
+        return;
+      }
+      if (ts.isReturnStatement(node)) {
+        if (checkReturns) {
+          sawValueReturn = true;
+          const returned = node.expression ? unwrapExpression(node.expression) : undefined;
+          if (
+            !returned ||
+            !ts.isIdentifier(returned) ||
+            ctx.checker.getSymbolAtLocation(returned) !== parameterSymbol
+          ) {
+            valid = false;
+          }
+        } else if (node.expression) {
+          visit(node.expression, false);
+        }
+        return;
+      }
+
+      const nestedScope = ts.isFunctionLike(node) || ts.isClassLike(node);
+      ts.forEachChild(node, (child) => visit(child, nestedScope ? false : checkReturns));
+    };
+
+    visit(declaration.body!, true);
+    return valid && sawValueReturn;
+  };
+
+  const index = candidateIndices.find(provesExactIdentityReturn);
+  memo.set(declaration, index ?? null);
+  return index;
 }
 
 /**

--- a/tests/issue-1058-generic-base-node-factory.test.ts
+++ b/tests/issue-1058-generic-base-node-factory.test.ts
@@ -20,6 +20,48 @@ async function instantiate(result: Awaited<ReturnType<typeof compile>>) {
 }
 
 describe("#1058 generic base-node factories", () => {
+  it("keeps a memoized callback's later factory capture live", async () => {
+    const result = await compileMulti(
+      {
+        "./core.ts": `
+          export function memoize<T>(callback: () => T): () => T {
+            let value: T;
+            return () => {
+              if (callback) {
+                value = callback();
+                callback = undefined!;
+              }
+              return value;
+            };
+          }
+        `,
+        "./factory.ts": `
+          import { memoize } from "./core.js";
+
+          interface Rules { value: number; }
+
+          export function createFactory() {
+            const rules = memoize((): Rules => ({ value: factory.seed }));
+            const factory = {
+              seed: 41,
+              create(): number { return rules().value + 1; },
+            };
+            return factory;
+          }
+        `,
+        "./entry.ts": `
+          import { createFactory } from "./factory.js";
+          const factory = createFactory();
+          export function test(): number { return factory.create(); }
+        `,
+      },
+      "./entry.ts",
+      { target: "gc", platform: "node", skipSemanticDiagnostics: true },
+    );
+
+    expect((await instantiate(result)).test()).toBe(42);
+  });
+
   it("dispatches a captured callable returned by a cross-module generic memoizer", async () => {
     const result = await compileMulti(
       {

--- a/tests/issue-1058-generic-identity-return.test.ts
+++ b/tests/issue-1058-generic-identity-return.test.ts
@@ -14,6 +14,25 @@ async function instantiate(result: Awaited<ReturnType<typeof compile>>) {
 }
 
 describe("#1058 generic identity returns", () => {
+  it("bridges an erased generic identity through a concrete callable property", async () => {
+    const result = await compile(`
+      interface Box { value: number; }
+      interface Rules { apply(value: Box): Box; }
+
+      function identity<T>(value: T): T {
+        return value;
+      }
+
+      const rules: Rules = { apply: identity };
+
+      export function test(): number {
+        return rules.apply({ value: 42 }).value;
+      }
+    `);
+
+    expect((await instantiate(result)).test()).toBe(42);
+  });
+
   it("does not freeze a T-to-T result to the first sibling layout", async () => {
     const result = await compile(`
       type Mutable<T> = { -readonly [P in keyof T]: T[P] };

--- a/tests/issue-1058-multifile-generic-callback-registration.test.ts
+++ b/tests/issue-1058-multifile-generic-callback-registration.test.ts
@@ -5,6 +5,322 @@ import { describe, expect, it } from "vitest";
 import { compileMulti, wrapExports } from "../src/index.js";
 
 describe("#1058 multi-file generic callback registration", () => {
+  it("keeps an inline arrow on the Wasm closure path for a compiled interface method", async () => {
+    const result = await compileMulti(
+      {
+        "./scanner.ts": `
+export interface Scanner {
+  tryScan<T>(callback: () => T): T;
+}
+
+export function createScanner(): Scanner {
+  function speculationHelper<T>(callback: () => T): T {
+    return callback();
+  }
+  function tryScan<T>(callback: () => T): T {
+    return speculationHelper(callback);
+  }
+  return { tryScan };
+}
+`,
+        "./parser.ts": `
+import { createScanner } from "./scanner.js";
+
+const scanner = createScanner();
+
+function reScanInvalidIdentifier(): number {
+  return 80;
+}
+
+export function test(): number {
+  return scanner.tryScan(() => reScanInvalidIdentifier() === 80) ? 42 : 0;
+}
+`,
+        "./main.ts": `
+import { test as parserTest } from "./parser.js";
+export function test(): number { return parserTest(); }
+`,
+      },
+      "./main.ts",
+      { target: "gc", platform: "node", skipSemanticDiagnostics: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const imports = result.importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    (imports as { __setInstance?: (value: WebAssembly.Instance) => void }).__setInstance?.(instance);
+    const exports = wrapExports(instance, { signatures: result.exportSignatures }) as unknown as { test(): number };
+    expect(exports.test()).toBe(42);
+  });
+
+  it("keeps a local interface describing an ambient receiver on the host callback path", async () => {
+    const result = await compileMulti(
+      {
+        "./main.ts": `
+interface HostInterface {
+  invoke(callback: () => number): number;
+}
+export function test(host: any): number {
+  return (host as HostInterface).invoke(() => 42);
+}
+`,
+      },
+      "./main.ts",
+      { target: "gc", platform: "node", skipSemanticDiagnostics: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).map((entry) => entry.name)).toContain(
+      "__make_callback",
+    );
+  });
+
+  it("registers later-source named callbacks for an earlier generic dispatcher", async () => {
+    const result = await compileMulti(
+      {
+        "./scanner.ts": `
+export interface Scanner {
+  scan(): number;
+  lookAhead<T>(callback: () => T): T;
+  tryScan<T>(callback: () => T): T;
+}
+
+export function createScanner(): Scanner {
+  let pos = 0;
+  function scan(): number {
+    pos++;
+    return 19;
+  }
+  function speculationHelper<T>(callback: () => T, isLookahead: boolean): T {
+    const savePos = pos;
+    const result = callback();
+    if (!result || isLookahead) pos = savePos;
+    return result;
+  }
+  function lookAhead<T>(callback: () => T): T {
+    return speculationHelper(callback, true);
+  }
+  function tryScan<T>(callback: () => T): T {
+    return speculationHelper(callback, false);
+  }
+  return { scan, lookAhead, tryScan };
+}
+`,
+        "./parser.ts": `
+import { createScanner } from "./scanner.js";
+
+interface NodeLike { kind: number; }
+enum Kind { OpenBraceToken = 19, Node = 42, Next = 43, ExportKeyword = 95, ImportKeyword = 102 }
+
+export function createParser() {
+  // TypeScript's Parser singleton intentionally uses var here to avoid a TDZ
+  // check. Keep that declaration shape in the regression witness.
+  var scanner = createScanner();
+  let currentToken = Kind.ImportKeyword;
+
+  function parserSpeculationHelper<T>(callback: () => T): T {
+    const saveToken = currentToken;
+    const result = scanner.lookAhead(callback);
+    currentToken = saveToken;
+    return result;
+  }
+  function lookAhead<T>(callback: () => T): T {
+    return parserSpeculationHelper(callback);
+  }
+  function token(): Kind {
+    return currentToken;
+  }
+  function nextToken(): Kind {
+    return currentToken = scanner.scan() as Kind;
+  }
+  function isDeclaration(): boolean {
+    switch (token()) {
+      case Kind.ImportKeyword:
+        nextToken();
+        return token() === Kind.OpenBraceToken;
+      case Kind.ExportKeyword: {
+        // Upstream has this same-name block shadow. The callback still needs
+        // the namespace currentToken transitively through token/nextToken.
+        let currentToken = nextToken();
+        return currentToken === Kind.OpenBraceToken;
+      }
+      default:
+        return false;
+    }
+  }
+  function parseNode(): NodeLike {
+    return { kind: Kind.Node };
+  }
+  function nextValue(): Kind {
+    return Kind.Next;
+  }
+
+  return function run(): number {
+    // Mirrors Parser.lookAhead(isDeclaration), including the second generic
+    // callback dispatcher between parser.ts and scanner.ts.
+    const predicate = lookAhead(isDeclaration);
+    const node = scanner.tryScan(parseNode);
+    const value = scanner.tryScan(nextValue);
+    return (predicate ? 10000 : 0) + node.kind * 100 + value;
+  };
+}
+`,
+        "./main.ts": `
+import { createParser } from "./parser.js";
+const run = createParser();
+export function test(): number { return run(); }
+`,
+      },
+      "./main.ts",
+      { target: "gc", platform: "node", skipSemanticDiagnostics: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const imports = result.importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    (imports as { __setInstance?: (value: WebAssembly.Instance) => void }).__setInstance?.(instance);
+    const exports = wrapExports(instance, { signatures: result.exportSignatures }) as unknown as { test(): number };
+    expect(exports.test()).toBe(14243);
+  });
+
+  it("materializes an immutable sibling captured from the non-dominating ternary arm", async () => {
+    const result = await compileMulti(
+      {
+        "./visitor.ts": `
+function invoke(callback: () => number): number {
+  return callback();
+}
+
+export function run(useFirst: boolean): number {
+  return invoke(useFirst ? first : second);
+
+  function first(): number {
+    return 1;
+  }
+
+  function second(): number {
+    return first ? 42 : 0;
+  }
+}
+`,
+        "./main.ts": `
+import { run } from "./visitor.js";
+export function test(): number { return run(false); }
+`,
+      },
+      "./main.ts",
+      { target: "gc", platform: "node", skipSemanticDiagnostics: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const imports = result.importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    (imports as { __setInstance?: (value: WebAssembly.Instance) => void }).__setInstance?.(instance);
+    const exports = wrapExports(instance, { signatures: result.exportSignatures }) as unknown as { test(): number };
+    expect(exports.test()).toBe(42);
+  });
+
+  it("preserves both callbacks through a generic object-table handler", async () => {
+    const result = await compileMulti(
+      {
+        "./visitor.ts": `
+interface NodeLike {
+  kind: number;
+  value: number;
+  children?: NodeLike[];
+  tail?: NodeLike;
+}
+
+type ChildCallback<T> = (node: NodeLike) => T | undefined;
+type ChildrenCallback<T> = (nodes: NodeLike[]) => T | undefined;
+type Handler = <T>(
+  node: NodeLike,
+  cbNode: ChildCallback<T>,
+  cbNodes?: ChildrenCallback<T>,
+) => T | undefined;
+
+function visitNode<T>(cbNode: ChildCallback<T>, node: NodeLike | undefined): T | undefined {
+  return node && cbNode(node);
+}
+
+function visitNodes<T>(
+  cbNode: ChildCallback<T>,
+  cbNodes: ChildrenCallback<T> | undefined,
+  nodes: NodeLike[] | undefined,
+): T | undefined {
+  if (nodes) {
+    if (cbNodes) return cbNodes(nodes);
+    for (const node of nodes) {
+      const result = cbNode(node);
+      if (result) return result;
+    }
+  }
+}
+
+const table: Record<number, Handler> = {
+  1: function visitRoot<T>(
+    node: NodeLike,
+    cbNode: ChildCallback<T>,
+    cbNodes?: ChildrenCallback<T>,
+  ): T | undefined {
+    return visitNodes(cbNode, cbNodes, node.children) || visitNode(cbNode, node.tail);
+  },
+};
+
+function forEachChild<T>(
+  node: NodeLike,
+  cbNode: ChildCallback<T>,
+  cbNodes?: ChildrenCallback<T>,
+): T | undefined {
+  const handler = table[node.kind];
+  return handler === undefined ? undefined : handler(node, cbNode, cbNodes);
+}
+
+export function test(): number {
+  const gathered: NodeLike[] = [];
+  let arrayCalls = 0;
+  let scalarCalls = 0;
+  const root: NodeLike = {
+    kind: 1,
+    value: 0,
+    children: [],
+    tail: { kind: 0, value: 7 },
+  };
+  function addWorkItem(node: NodeLike | NodeLike[]): void {
+    if (Array.isArray(node)) {
+      arrayCalls++;
+      for (const child of node) gathered.push(child);
+    } else {
+      scalarCalls++;
+      gathered.push(node);
+    }
+  }
+  forEachChild(root, addWorkItem, addWorkItem);
+  return arrayCalls * 1000 + scalarCalls * 100 + gathered[0].value;
+}
+`,
+        "./main.ts": `
+import { test as visitTest } from "./visitor.js";
+export function test(): number { return visitTest(); }
+`,
+      },
+      "./main.ts",
+      { target: "gc", platform: "node", skipSemanticDiagnostics: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const imports = result.importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    (imports as { __setInstance?: (value: WebAssembly.Instance) => void }).__setInstance?.(instance);
+    const exports = wrapExports(instance, { signatures: result.exportSignatures }) as unknown as { test(): number };
+    expect(exports.test()).toBe(1107);
+  });
+
   it("registers a later source file's concrete callback return ABI", async () => {
     const result = await compileMulti(
       {

--- a/tests/issue-1058-nullable-method-cast.test.ts
+++ b/tests/issue-1058-nullable-method-cast.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, wrapExports } from "../src/index.js";
+
+const SOURCE = `
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+interface NodeLike {
+  readonly kind: number;
+  readonly pos: number;
+  readonly end: number;
+}
+
+interface TypeNodeLike extends NodeLike {
+  _typeNodeBrand: any;
+}
+
+interface Token<TKind extends number = number> extends NodeLike {
+  readonly kind: TKind;
+}
+
+interface NodeFactory {
+  createToken(token: 1): Token<1>;
+  createToken<TKind extends number>(token: TKind): Token<TKind>;
+  createAs(expression: NodeLike, type: TypeNodeLike): NodeLike;
+}
+
+function createNodeFactory(): NodeFactory {
+  function createToken(token: 1): Token<1>;
+  function createToken<TKind extends number>(token: TKind): Token<TKind>;
+  function createToken<TKind extends number>(token: TKind) {
+    return { kind: token, pos: -1, end: -1 };
+  }
+
+  function createAs(expression: NodeLike, type: TypeNodeLike): NodeLike {
+    return { kind: expression.kind * 10 + type.kind, pos: 0, end: 0 };
+  }
+
+  return { createToken, createAs };
+}
+
+const factory = createNodeFactory();
+const { createToken: factoryCreateToken } = factory;
+
+function finishNode<T extends NodeLike>(node: T, pos: number): T {
+  (node as Mutable<NodeLike>).pos = pos;
+  (node as Mutable<NodeLike>).end = pos + 1;
+  return node;
+}
+
+function replaceNode<T extends NodeLike>(node: T): T {
+  (node as Mutable<NodeLike>).pos += 0;
+  return { kind: 99, pos: 3, end: 4 } as T;
+}
+
+function rebindNode<T extends NodeLike>(node: T): T {
+  (node as Mutable<NodeLike>).pos += 0;
+  node = { kind: 77, pos: 5, end: 6 } as T;
+  return node;
+}
+
+function parseTokenNode<T extends NodeLike>(): T {
+  return finishNode(factoryCreateToken(2), 10) as T;
+}
+
+function parseKeywordAndNoDot(): TypeNodeLike | undefined {
+  return parseTokenNode<TypeNodeLike>();
+}
+
+export function tokenKind(): number {
+  return parseKeywordAndNoDot()!.kind;
+}
+
+export function test(): number {
+  const expression: NodeLike = { kind: 4, pos: 0, end: 0 };
+  return factory.createAs(expression, parseKeywordAndNoDot()!).kind;
+}
+
+export function replacementKind(): number {
+  return replaceNode(factoryCreateToken(2)).kind;
+}
+
+export function reboundKind(): number {
+  return rebindNode(factoryCreateToken(2)).kind;
+}
+`;
+
+describe("#1058 generic identity structural projection", () => {
+  it("recovers only a body-proven identity parameter carrier", async () => {
+    const result = await compile(SOURCE, {
+      fileName: "issue-1058-nullable-method-cast.ts",
+      target: "gc",
+      platform: "node",
+      skipSemanticDiagnostics: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const imports = result.importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    (imports as { __setInstance?: (value: WebAssembly.Instance) => void }).__setInstance?.(instance);
+    const exports = wrapExports(instance, { signatures: result.exportSignatures }) as unknown as {
+      test(): number;
+      tokenKind(): number;
+      replacementKind(): number;
+      reboundKind(): number;
+    };
+    // Positive: finishNode mutates only properties and returns the exact node
+    // binding, so its opaque T result can recover the Token carrier before the
+    // sibling TypeNode projection.
+    expect(exports.tokenKind()).toBe(2);
+    expect(exports.test()).toBe(42);
+    // Negative: replaceNode has the same T -> T signature but returns a fresh
+    // asserted object. Recovering its argument carrier would null-cast that
+    // distinct result; the body-level proof must decline and preserve kind 99.
+    expect(exports.replacementKind()).toBe(99);
+    // Returning the parameter identifier is insufficient after rebinding it.
+    expect(exports.reboundKind()).toBe(77);
+  });
+});


### PR DESCRIPTION
## Summary

- register named and inline callback wrappers across the prepared source graph while keeping compiled Scanner interface methods on the Wasm-closure path
- bridge concrete references through erased generic callable ABIs and recover only body-proven generic identity results
- rematerialize immutable hoisted sibling functions across non-dominating branches and add production-shaped regressions
- update the #1058 issue handoff with the fresh compile metrics, artifact-size analysis, and exact remaining runtime frontier

## Validation

- `pnpm run dogfood:typescript-parser-source`: TypeScript 5.9.3 parser graph compiles and emits valid Wasm; 84,817,448 bytes; 4,284 functions; 468,686 ms wall time; 3,848.6 MiB peak RSS
- all 53 `tests/issue-1058-*.test.ts` files pass (183/183 tests)
- TS5 and TS7 typechecks pass
- repository lint and format checks pass
- LOC/function, IR fallback, oracle, coercion-site, issue-integrity, and numeric-local pre-push gates pass

## Runtime status

This is a compile/validation and regression-hardening milestone, not the final AST-equivalence claim. The fresh canonical build still misses all three parser fingerprints: builder/performance reach recovery with an Identifier whose `escapedText` is undefined, while core reaches an `__call_fn_method_2` illegal cast from `parseBinaryExpressionRest`. The exact reduced next witness and separate core frontier are recorded in the updated issue file; the strict upstream callback suite is not claimed until those fingerprints pass.

Advances #1058. Follow-up to merged #5293 and #5183.
