### PR TITLE
docs(issues): file #5218-#5220 (dev-5211 findings)

### DIFF
--- a/plan/issues/5218-standalone-dynamic-sort-comparator-noop.md
+++ b/plan/issues/5218-standalone-dynamic-sort-comparator-noop.md
@@ -1,0 +1,41 @@
+---
+id: 5218
+title: "Standalone: .sort(cmp) on a dynamic receiver is a silent no-op — array returned unsorted, no throw"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: standalone-gap
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5218 — standalone dynamic-receiver `.sort(cmp)` silently no-ops
+
+## Problem
+
+On the standalone lane, `t.sort((a,b) => …)` where `t` is an untyped/dynamic
+receiver returns the array UNSORTED with no error: `[3,1,2]` in, `[3,1,2]`
+out, at init and after init alike. A statically-typed receiver sorts
+correctly. Silent wrong values.
+
+Found by dev-5211 while validating PR #5314; verified PRE-EXISTING on
+pristine origin/main; host-lane-independent.
+
+## Acceptance criteria
+
+1. Reduced repro sorts correctly on standalone (dynamic + static receivers,
+   with and without comparator); new tests/issue-5218-*.test.ts failing on
+   base for the dynamic rows.
+2. No regressions in issue-5211 tests + array-method scoped runs (name
+   them). Gates green.
+
+## Notes
+
+- Sibling filings from the same report: #5219 (omitted optional arg lowers
+  to null), #5220 (init-marshal helper emission-condition gap).
+- Id reserved with a degraded PR scan; manually checked against open PR
+  head branches 2026-08-30. `check:issue-ids:against-main` arbitrates.
+  Note: PR number 5218 exists and is unrelated (ids and PR numbers are
+  independent sequences that collide numerically).

--- a/plan/issues/5219-omitted-optional-arg-null-not-undefined.md
+++ b/plan/issues/5219-omitted-optional-arg-null-not-undefined.md
@@ -1,0 +1,47 @@
+---
+id: 5219
+title: An omitted optional argument is lowered to null, not undefined — n.sort() reaches Array.prototype.sort as sort(null) and throws
+status: ready
+sprint: current
+priority: medium
+horizon: m
+goal: core-semantics
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5219 — omitted optional argument crosses as `null`
+
+## Problem
+
+Calling `n.sort()` (no comparator) on an `any` receiver reaches native
+`Array.prototype.sort` as `sort(null)`, which throws
+"The comparison function must be either a function or undefined: null".
+The omitted-argument lowering emits `null` where the spec (and the host
+API) require `undefined` / absent.
+
+Found by dev-5211 (PR #5314); pre-existing; pinned there by a
+`known-unfixed` test row in tests/issue-5211-invoke-method-callable-arg.test.ts
+so the eventual fix is noticed.
+
+## Direction
+
+Likely general beyond `.sort` — measure which call-lowering paths pad
+missing optional arguments with a null externref instead of an undefined
+sentinel, and fix at the lowering/coercion site, not per-method. Verify
+`fn(undefined)` vs `fn()` distinction where observable (e.g. default
+parameters see undefined for both).
+
+## Acceptance criteria
+
+1. `n.sort()` on an `any` receiver works host-lane; the #5211
+   known-unfixed row flips to passing (update it). Add coverage for a
+   user function with a default parameter called with the arg omitted.
+2. No regressions in call-lowering scoped runs + equivalence gate (name
+   them). Gates green.
+
+## Notes
+
+- Id reserved with a degraded PR scan; manually checked against open PR
+  head branches 2026-08-30.

--- a/plan/issues/5220-init-marshal-helper-emission-condition-gap.md
+++ b/plan/issues/5220-init-marshal-helper-emission-condition-gap.md
@@ -1,0 +1,49 @@
+---
+id: 5220
+title: "#5193 init-marshal helpers are emitted only when the module needs them elsewhere — a module without vec-producing calls still marshals vec args as [object Object] at init"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+goal: standalone-gap
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5220 — init-marshal helper registration has an emission-condition gap
+
+## Problem
+
+The #5193/#5209 start-export channel (`__register_init_export` family) is
+emitted only when the module's codegen decides it needs the helpers for
+some OTHER reason. A module with no vec-producing call registers none, so
+`marshalExports` is still undefined during that module's init and a vec
+argument crossing to the host still becomes the generic `[object Object]`
+proxy. Adding one unrelated `t.filter(...)` anywhere in the module flips
+the same row from wrong to right — proof the residue is an
+emission-condition gap in `src/codegen/init-marshal-helpers.ts`, not a
+runtime gap.
+
+Found by dev-5211 (PR #5314); pre-existing.
+
+## Direction
+
+Widen the emission condition: register the helper family whenever the
+module has a compiler-created module initializer AND any host-crossing
+import that can receive a struct (measure the import-list predicate the
+#5209 change already introduced — this is likely one more clause there).
+Keep byte-identity for modules with no top-level code.
+
+## Acceptance criteria
+
+1. Repro: a module whose ONLY vec-to-host crossing is a struct argument at
+   init (no .filter/.map anywhere) gets the array facade; new
+   tests/issue-5220-*.test.ts failing on base.
+2. Byte-identity check for modules without a module initializer.
+3. No regressions in issue-5193/5209/5211 test files. Gates green.
+
+## Notes
+
+- Id reserved with a degraded PR scan; manually checked against open PR
+  head branches 2026-08-30.


### PR DESCRIPTION
Docs-only PR — files three pre-existing defects surfaced while closing the last Temporal module-init blocker (PR #5314, issue [#5211](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5211-init-sort-comparator-opaque-struct)):

- [#5218](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5218-standalone-dynamic-sort-comparator-noop) — standalone: `.sort(cmp)` on a dynamic receiver is a **silent no-op** (array returned unsorted, no throw). Wrong values, high priority.
- [#5219](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5219-omitted-optional-arg-null-not-undefined) — an omitted optional argument is lowered to `null`, not `undefined` (`n.sort()` reaches `Array.prototype.sort` as `sort(null)` and throws); pinned by a known-unfixed row in the #5211 test file.
- [#5220](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5220-init-marshal-helper-emission-condition-gap) — the #5193 init-marshal helper family is emitted only when the module needs it elsewhere, so a module without vec-producing calls still marshals a vec argument as `[object Object]` at init.

All three reproduce on pristine main; none gates the [#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-runtime-object-spike) integration (moduleInitRuns is TRUE on the full stack).

No `src/`, `tests/`, `scripts/`, `.github/`, or `benchmarks/` files touched. Ids allocated via `claim-issue.mjs --allocate` (degraded PR scan, manually verified against open PR head branches; note PR numbers 5218-5220 exist and are unrelated — ids and PR numbers are independent sequences).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_