### PR TITLE
fix(dogfood): bound React DOM consumer compiles

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,7 @@
       "tests/dogfood/.prettier/**",
       "tests/dogfood/.react/**",
       "tests/dogfood/.react-dom-upstream-suite-impl/**",
+      "tests/dogfood/.react-dom-upstream-suite-project/**",
       "tests/dogfood/.react-upstream-suite/**",
       "tests/dogfood/.lit-upstream-suite/**",
       "tests/dogfood/.hono-upstream-suite/**",

--- a/plan/issues/2527-core-wasm-linking-host-shims-and-runtime.md
+++ b/plan/issues/2527-core-wasm-linking-host-shims-and-runtime.md
@@ -340,11 +340,38 @@ such as package cycles, type-position identity, ambiguous boundaries, and
 signature validation continue to fall back explicitly in both modes.
 
 The React DOM dogfood worker opts into strict separate mode. Its client adapter
-batches are also bounded to 400,000 lifted-source characters and 32 tests. This
-is separate from provider caching: two historical ~870 KB consumers still
+batches are bounded to the exact generated `entry.ts` length (220,000 characters
+by default) and 32 tests; the same entry builder sizes the batch and writes the
+artifact, so generated setup and export scaffolding cannot escape the limit.
+This is separate from provider caching: two historical ~870 KB consumers still
 needed 308–478 seconds and one emitted a 462 MB invalid module even with four
-warm provider hits. Splitting those consumers keeps the provider modules cached
-and independently linked while bounding the remaining root-codegen work.
+warm provider hits.
+
+A remaining compile-stage watchdog timeout is subdivided as a stable binary
+tree, to at most six levels/127 attempts per original batch. Only a timeout
+reported specifically during compilation triggers this recovery; diagnostics,
+invalid Wasm, execution timeouts, and singleton timeouts remain terminal. The
+terminal leaves alone own tests and native-oracle rows, while every attempted
+parent and child remains in `compile.attempts` so recovered timeout cost and
+provider-cache telemetry stay visible. Each retry links the same cached provider
+modules from a unique consumer root rather than recompiling package sources.
+
+The cold end-to-end control on 2026-08-30 took 9,584.84 seconds. Its 400,000
+raw-character estimate produced four `ReactDOMFizzServer` entries between
+453,639 and 466,648 generated characters; all four exhausted the 300-second
+compile watchdog. The other 120 client batches recorded seven provider compiles
+and 473 cache hits, and the legacy-server/browser-Fizz/node-Fizz/edge-Fizz lanes
+recorded no timeout, isolating the remaining failure to oversized client roots.
+
+With exact 220,000-character partitioning, a real focused rerun admitted all
+166 client-side `ReactDOMFizzServer` tests as 18 batches and completed in 168.01
+seconds. No attempt timed out or split; the largest entry was 219,029
+characters, the slowest compile was 21.418 seconds, and all 72 provider
+resolutions were cache hits in strict separate mode. Summed compiler work for
+that file fell from 1,722.203 seconds in the 400,000-character control to
+283.283 seconds, a 6.1x reduction. Ordinary async-shape/codegen diagnostics and
+the existing emitted-Wasm validation failures remain visible as separate
+correctness work rather than being mislabeled as timeouts.
 
 ## Measurement rule for whoever packages the runtime-eval provider (#2928 E7)
 

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -134,17 +134,24 @@ export function installNativeHostErrorBoundary(nativeHostErrors) {
 }
 
 // Upstream's `suite` scaffolding is replicated into every lifted test, so a
-// whole file's tests can generate megabytes. Split up front by generated size —
-// a separate lever from the validation-failure subdivision below, which exists
-// to bound #3775's blast radius rather than to keep a unit compilable at all.
+// whole file's tests can generate megabytes. Server/legacy batches retain their
+// historical raw-fragment bound; client project batches below use the exact
+// generated entry.ts length instead.
 const MAX_BATCH_CHARS = 120_000;
 // Linked providers remove the 566 KB implementation floor from each client
 // adapter, but generated test bodies can still be super-linear in codegen and
-// binary emission. Two former ~870 KB entries exceeded the 300 s watchdog even
-// without a bundled retry; 400 KB keeps the largest warm-provider adapter well
-// below that boundary while preserving per-file lifecycle isolation.
-export const DEFAULT_PROJECT_BATCH_CHARS = 400_000;
+// binary emission. The first cold compile-once run still timed out on a client
+// adapter whose exact generated entry was larger than the raw-fragment estimate.
+// Bound the artifact the compiler actually sees, and retain the test-count cap
+// as an independent guard against unusually expensive small tests.
+export const DEFAULT_PROJECT_BATCH_CHARS = 220_000;
 export const DEFAULT_PROJECT_BATCH_TESTS = 32;
+// A compile-stage timeout may hide one pathological test in an otherwise useful
+// batch. Retry only that narrow signal as a stable binary tree. Six levels mean
+// at most 127 attempts per top-level batch; with the default 32-test input cap,
+// every test can reach a singleton before the bound is exhausted.
+export const MAX_PROJECT_SPLIT_DEPTH = 6;
+export const MAX_PROJECT_SPLIT_ATTEMPTS = 2 ** (MAX_PROJECT_SPLIT_DEPTH + 1) - 1;
 
 function decodeVlq(segment) {
   const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -489,15 +496,11 @@ function providerPackageFiles(packageName, source) {
   };
 }
 
-// Keep each published CJS implementation file in its own project module.
-// Concatenating the 560 KB client graph into every test batch both repeats
-// compilation work and makes a single compiler watchdog unable to distinguish
-// a slow implementation from a pathological test body.
-// Exported like its sibling `buildServerProjectFiles`: the implementation
-// probe's cost is a property of this shape, so it has to be measurable
-// without running the 3-4 hour suite.
-export function buildProjectFiles({ reactSource, sharedSource, clientSource, tests }) {
-  const entry = [
+// Build the client consumer once and reuse this exact string for both partition
+// sizing and the entry.ts written to disk. This avoids under-counting generated
+// setup, assertion shims, exports, and escaped test names.
+export function buildClientProjectEntry(tests) {
+  return [
     'import { __reactExports } from "react";',
     'import { __sharedExports } from "react-dom-shared";',
     'import { __clientExports } from "react-dom-client";',
@@ -514,6 +517,17 @@ export function buildProjectFiles({ reactSource, sharedSource, clientSource, tes
     `export function upstreamTestNames() { return [${tests.map((test) => JSON.stringify(test.id)).join(", ")}]; }`,
     `export function upstreamTestCount() { return ${tests.length}; }`,
   ].join("\n");
+}
+
+// Keep each published CJS implementation file in its own project module.
+// Concatenating the 560 KB client graph into every test batch both repeats
+// compilation work and makes a single compiler watchdog unable to distinguish
+// a slow implementation from a pathological test body.
+// Exported like its sibling `buildServerProjectFiles`: the implementation
+// probe's cost is a property of this shape, so it has to be measurable
+// without running the 3-4 hour suite.
+export function buildProjectFiles({ reactSource, sharedSource, clientSource, tests }) {
+  const entry = buildClientProjectEntry(tests);
   return {
     ...providerPackageFiles(
       "react",
@@ -668,16 +682,37 @@ export function partitionProjectTests(
   maxTests = DEFAULT_PROJECT_BATCH_TESTS,
 ) {
   const batches = [];
-  const byFile = new Map();
+  let file = null;
+  let current = [];
+  const flush = () => {
+    if (current.length === 0) return;
+    const entryChars = buildClientProjectEntry(current).length;
+    batches.push({ file, tests: current, entryChars });
+    current = [];
+  };
   for (const test of tests) {
-    const fileTests = byFile.get(test.file) ?? [];
-    fileTests.push(test);
-    byFile.set(test.file, fileTests);
+    if (current.length > 0 && test.file !== file) flush();
+    file = test.file;
+    const candidate = [...current, test];
+    if (current.length > 0 && (current.length >= maxTests || buildClientProjectEntry(candidate).length > maxChars)) {
+      flush();
+      file = test.file;
+    }
+    // A single generated test may itself exceed maxChars. Keep it as one
+    // explicit oversize leaf: dropping it would corrupt the denominator, while
+    // splitting inside an extracted test would change upstream semantics.
+    current.push(test);
   }
-  for (const [file, fileTests] of byFile) {
-    for (const chunk of splitBySize(fileTests, maxChars, maxTests)) batches.push({ file, tests: chunk });
-  }
+  flush();
   return batches;
+}
+
+// Programmatic focus for a bounded diagnostic run. This is intentionally not
+// environment-driven: scheduled npm-compat runs must continue to measure the
+// full client corpus unless their caller explicitly requests an exact file.
+export function selectClientProjectTests(tests, { clientFile = null, limit = 0 } = {}) {
+  const focused = clientFile === null ? tests : tests.filter((test) => test.file === clientFile);
+  return Number.isInteger(limit) && limit > 0 ? focused.slice(0, limit) : [...focused];
 }
 
 // Project batches are independent compile jobs, but the native oracle must
@@ -691,6 +726,164 @@ export function projectCompileConcurrency(batchCount, configured = process.env.D
   const requested = Number(configured ?? 2);
   if (!Number.isFinite(requested) || requested < 1) return Math.min(2, batchCount);
   return Math.max(1, Math.min(Math.floor(requested), batchCount));
+}
+
+function projectCompileError(compile) {
+  return (
+    compile.errors?.[0]?.message ??
+    compile.validationError ??
+    (compile.timedOut ? `${compile.timeoutStage ?? "worker"} timeout` : compile.success ? null : "no binary emitted")
+  );
+}
+
+/**
+ * Compile top-level client batches with bounded, compile-timeout-only splitting.
+ *
+ * Top-level batches share one fixed-size worker pool. A worker that encounters
+ * a genuine compile-stage timeout recursively compiles its left then right half
+ * in the same slot, so retries cannot multiply concurrency. Results are emitted
+ * in original top-level and test order even when workers finish out of order.
+ */
+export async function compileProjectBatchTrees({
+  batches,
+  compileAttempt,
+  concurrency = projectCompileConcurrency(batches.length),
+  maxSplitDepth = MAX_PROJECT_SPLIT_DEPTH,
+  onAttempt = null,
+  consumeTopLevel = null,
+}) {
+  if (batches.length === 0) return { attempts: [], leaves: [], splitTimeouts: 0 };
+  const depthLimit = Math.max(0, Math.min(Math.floor(maxSplitDepth), MAX_PROJECT_SPLIT_DEPTH));
+  const workerCount = Math.max(1, Math.min(Math.floor(concurrency) || 1, batches.length));
+  const ready = Array.from({ length: batches.length }, () => {
+    let settleResolve;
+    let settleReject;
+    const slot = { settled: false, promise: null, resolve: null, reject: null };
+    const promise = new Promise((resolve, reject) => {
+      settleResolve = resolve;
+      settleReject = reject;
+    });
+    // A later top-level slot can fail while the ordered consumer is still
+    // awaiting an earlier one. Attach a handler immediately so that rejection
+    // is observed without changing the promise the consumer eventually awaits.
+    promise.catch(() => {});
+    slot.promise = promise;
+    slot.resolve = (value) => {
+      if (slot.settled) return;
+      slot.settled = true;
+      settleResolve(value);
+    };
+    slot.reject = (error) => {
+      if (slot.settled) return;
+      slot.settled = true;
+      settleReject(error);
+    };
+    return slot;
+  });
+
+  const compileTree = async (topLevelBatch, file, batchTests, path, depth) => {
+    const rootName =
+      depth === 0 ? `batch-${topLevelBatch}` : `batch-${topLevelBatch}-split-${path.split(".").slice(1).join("-")}`;
+    const entryChars = buildClientProjectEntry(batchTests).length;
+    const started = performance.now();
+    let isolated;
+    try {
+      isolated = await compileAttempt({
+        topLevelBatch,
+        file,
+        tests: batchTests,
+        path,
+        depth,
+        rootName,
+        entryChars,
+      });
+    } catch (error) {
+      isolated = {
+        compile: {
+          success: false,
+          validates: false,
+          durationMs: Math.round(performance.now() - started),
+          binaryBytes: 0,
+          errors: [{ message: error instanceof Error ? error.message : String(error) }],
+        },
+        wasm: null,
+      };
+    }
+    const compile = isolated?.compile ?? {
+      success: false,
+      validates: false,
+      durationMs: Math.round(performance.now() - started),
+      binaryBytes: 0,
+      errors: [{ message: "compile worker returned no result" }],
+    };
+    const shouldSplit =
+      compile.timedOut === true && compile.timeoutStage === "compile" && batchTests.length > 1 && depth < depthLimit;
+    const attempt = {
+      topLevelBatch,
+      path,
+      depth,
+      rootName,
+      file,
+      batchTests,
+      entryChars,
+      compile,
+      wasm: isolated?.wasm ?? null,
+      compileError: projectCompileError(compile),
+      split: shouldSplit,
+      terminal: !shouldSplit,
+    };
+    if (onAttempt) await onAttempt(attempt);
+    if (!shouldSplit) return { attempts: [attempt], leaves: [attempt], splitTimeouts: 0 };
+
+    const middle = Math.ceil(batchTests.length / 2);
+    const left = await compileTree(topLevelBatch, file, batchTests.slice(0, middle), `${path}.0`, depth + 1);
+    const right = await compileTree(topLevelBatch, file, batchTests.slice(middle), `${path}.1`, depth + 1);
+    return {
+      attempts: [attempt, ...left.attempts, ...right.attempts],
+      leaves: [...left.leaves, ...right.leaves],
+      splitTimeouts: 1 + left.splitTimeouts + right.splitTimeouts,
+    };
+  };
+
+  let nextBatchIndex = 0;
+  let workerFailure = null;
+  const rejectPending = (error) => {
+    if (workerFailure === null) workerFailure = error;
+    for (const item of ready) item.reject(workerFailure);
+  };
+  const compileWorker = async () => {
+    while (workerFailure === null) {
+      const batchIndex = nextBatchIndex++;
+      if (batchIndex >= batches.length) return;
+      const batch = batches[batchIndex];
+      try {
+        const tree = await compileTree(batchIndex, batch.file, batch.tests, String(batchIndex), 0);
+        ready[batchIndex].resolve(tree);
+      } catch (error) {
+        // Reject every ordered slot, including ones not yet claimed. Otherwise
+        // a callback failure in one worker can leave the consumer permanently
+        // blocked on a promise that no worker will ever resolve.
+        rejectPending(error);
+        return;
+      }
+    }
+  };
+  const workers = Promise.all(Array.from({ length: workerCount }, () => compileWorker()));
+  const topLevelResults = [];
+  try {
+    for (const item of ready) {
+      const tree = await item.promise;
+      topLevelResults.push(tree);
+      if (consumeTopLevel) await consumeTopLevel(tree);
+    }
+  } finally {
+    await workers;
+  }
+  return {
+    attempts: topLevelResults.flatMap((tree) => tree.attempts),
+    leaves: topLevelResults.flatMap((tree) => tree.leaves),
+    splitTimeouts: topLevelResults.reduce((total, tree) => total + tree.splitTimeouts, 0),
+  };
 }
 
 function buildNativeRunners(implementation, tests, options = {}) {
@@ -1148,6 +1341,7 @@ async function compileImplementationOnly({ reactSource, sharedSource, clientSour
 
 async function runProjectHarness({
   report,
+  reportPath,
   log,
   implementation,
   reactSource,
@@ -1174,118 +1368,122 @@ async function runProjectHarness({
   const runResults = new Map();
   let totalCompileMs = 0;
   let totalBytes = 0;
+  let attemptReports = [];
+  let splitTimeouts = 0;
 
   try {
-    const batchReady = Array.from({ length: projectBatches.length }, () => {
-      let resolve;
-      const promise = new Promise((done) => {
-        resolve = done;
-      });
-      return { promise, resolve };
-    });
     const workerCount = projectCompileConcurrency(projectBatches.length);
     log(`[dogfood]   client project: ${projectBatches.length} batches, ${workerCount} compile workers`);
-    let nextBatchIndex = 0;
-    const compileBatch = async () => {
-      while (true) {
-        const batchIndex = nextBatchIndex++;
-        if (batchIndex >= projectBatches.length) return;
-        const { file, tests: batchTests } = projectBatches[batchIndex];
-        const generatedRoot = join(PROJECT_ROOT, `batch-${batchIndex}`);
-        const started = performance.now();
-        let isolated;
-        try {
-          const files = buildProjectFiles({ reactSource, sharedSource, clientSource, tests: batchTests });
-          isolated = await compileProjectInWorker({
-            generatedRoot,
-            entryFile: "entry.ts",
-            files,
-            timeoutMs,
-            workerEnv: {
-              DOGFOOD_PACKAGE_CACHE_DIR: PROVIDER_CACHE_DIR,
-              DOGFOOD_INSTALL_JSDOM: "1",
-              DOGFOOD_NAMED_TEST_EXPORTS: "1",
-              DOGFOOD_UPSTREAM_TEST_TIMEOUT_MS: String(testTimeoutMs()),
-              DOGFOOD_REACT_DOM_ACT: "1",
-            },
-          });
-        } catch (error) {
-          isolated = {
-            compile: {
-              success: false,
-              validates: false,
-              durationMs: Math.round(performance.now() - started),
-              binaryBytes: 0,
-              errors: [{ message: error instanceof Error ? error.message : String(error) }],
-            },
-            wasm: null,
-          };
-        }
-        const compile = isolated?.compile ?? {
-          success: false,
-          validates: false,
-          durationMs: Math.round(performance.now() - started),
-          binaryBytes: 0,
-          errors: [{ message: "compile worker returned no result" }],
-        };
-        const wasm = isolated?.wasm ?? null;
-        const compileError =
-          compile.errors?.[0]?.message ??
-          compile.validationError ??
-          (compile.timedOut ? `compile timeout after ${timeoutMs}ms` : compile.success ? null : "no binary emitted");
-        const batch = { file, batchTests, compile, wasm, compileError };
-        batchReady[batchIndex].resolve(batch);
+    const compiled = await compileProjectBatchTrees({
+      batches: projectBatches,
+      concurrency: workerCount,
+      compileAttempt: ({ tests: attemptTests, rootName }) =>
+        compileProjectInWorker({
+          generatedRoot: join(PROJECT_ROOT, rootName),
+          entryFile: "entry.ts",
+          files: buildProjectFiles({ reactSource, sharedSource, clientSource, tests: attemptTests }),
+          timeoutMs,
+          workerEnv: {
+            DOGFOOD_PACKAGE_CACHE_DIR: PROVIDER_CACHE_DIR,
+            DOGFOOD_INSTALL_JSDOM: "1",
+            DOGFOOD_NAMED_TEST_EXPORTS: "1",
+            DOGFOOD_UPSTREAM_TEST_TIMEOUT_MS: String(testTimeoutMs()),
+            DOGFOOD_REACT_DOM_ACT: "1",
+          },
+        }),
+      onAttempt: ({ file, batchTests: attemptTests, depth, compile, compileError, split }) => {
         log(
-          `[dogfood]   client project ${file.replace(/^.*\//, "")}: ${batchTests.length} tests, ` +
-            `${compile.validates === true ? "valid" : `INVALID — ${String(compileError).slice(0, 70)}`}`,
+          `[dogfood]   client project ${file.replace(/^.*\//, "")}: ${attemptTests.length} tests` +
+            `${depth > 0 ? ` (split depth ${depth})` : ""}, ` +
+            `${compile.validates === true ? "valid" : `INVALID — ${String(compileError).slice(0, 70)}`}` +
+            (split ? " — splitting timed-out compile" : ""),
         );
-      }
-    };
-    const compileWorkers = Promise.all(Array.from({ length: workerCount }, () => compileBatch()));
+      },
+      // Compilation and the native oracle are pipelined: later independent
+      // top-level batches keep compiling while the shared host consumes the
+      // current tree's terminal leaves. The oracle itself remains strictly
+      // source-ordered, including leaves recovered by timeout splitting.
+      consumeTopLevel: async ({ leaves }) => {
+        for (const { file, batchTests, entryChars, path, depth, compile, wasm, compileError } of leaves) {
+          const validates = compile.validates === true;
 
-    // Compilation and the native oracle are pipelined: later independent
-    // batches keep compiling while the shared host consumes the next batch.
-    // The oracle itself remains strictly source-ordered, so scheduler
-    // callbacks and late host errors stay deterministic.
-    try {
-      for (const { promise } of batchReady) {
-        const { file, batchTests, compile, wasm, compileError } = await promise;
-        const validates = compile.validates === true;
-        totalCompileMs += compile.durationMs ?? 0;
-        totalBytes += compile.binaryBytes ?? 0;
-
-        nativeContextFile = file;
-        const nativeResults = new Map((await runNative(implementation, batchTests)).map((entry) => [entry.id, entry]));
-        const statuses = wasm?.statuses ?? [];
-        const wasmErrors = wasm?.errors ?? [];
-        for (let index = 0; index < batchTests.length; index++) {
-          const test = batchTests[index];
-          const native = nativeResults.get(test.id) ?? {};
-          runResults.set(test.id, {
-            native,
+          nativeContextFile = file;
+          const nativeResults = new Map(
+            (await runNative(implementation, batchTests)).map((entry) => [entry.id, entry]),
+          );
+          const statuses = wasm?.statuses ?? [];
+          const wasmErrors = wasm?.errors ?? [];
+          for (let index = 0; index < batchTests.length; index++) {
+            const test = batchTests[index];
+            const native = nativeResults.get(test.id) ?? {};
+            runResults.set(test.id, {
+              native,
+              validates,
+              compileError,
+              wasmFatal: wasm?.fatal ?? null,
+              wasmStatus: statuses[index] === true,
+              wasmError: wasmErrors[index] ?? "",
+            });
+          }
+          batchReports.push({
+            file,
+            tests: batchTests.length,
+            entryChars,
+            path,
+            depth,
+            compileMs: compile.durationMs ?? 0,
+            workerMs: compile.workerDurationMs ?? compile.durationMs ?? 0,
+            binaryBytes: compile.binaryBytes ?? 0,
+            imports: compile.imports ?? [],
+            linkPlan: compile.linkPlan ?? null,
+            compileSuccess: compile.success === true,
             validates,
-            compileError,
-            wasmFatal: wasm?.fatal ?? null,
-            wasmStatus: statuses[index] === true,
-            wasmError: wasmErrors[index] ?? "",
+            timedOut: compile.timedOut === true,
+            timeoutStage: compile.timeoutStage ?? null,
+            firstError: compileError,
           });
         }
-        batchReports.push({
-          file,
-          tests: batchTests.length,
-          compileMs: compile.durationMs ?? 0,
-          binaryBytes: compile.binaryBytes ?? 0,
-          imports: compile.imports ?? [],
-          linkPlan: compile.linkPlan ?? null,
-          compileSuccess: compile.success === true,
-          validates,
-          firstError: compileError,
-        });
-      }
-    } finally {
-      // Do not leave compiler workers behind if the shared native oracle throws.
-      await compileWorkers;
-    }
+      },
+    });
+    totalCompileMs = compiled.attempts.reduce((total, attempt) => total + (attempt.compile.durationMs ?? 0), 0);
+    totalBytes = compiled.attempts.reduce((total, attempt) => total + (attempt.compile.binaryBytes ?? 0), 0);
+    splitTimeouts = compiled.splitTimeouts;
+    attemptReports = compiled.attempts.map(
+      ({
+        topLevelBatch,
+        path,
+        depth,
+        rootName,
+        file,
+        batchTests,
+        entryChars,
+        compile,
+        compileError,
+        split,
+        terminal,
+      }) => ({
+        topLevelBatch,
+        path,
+        depth,
+        rootName,
+        file,
+        tests: batchTests.length,
+        testIds: batchTests.map((test) => test.id),
+        entryChars,
+        compileMs: compile.durationMs ?? 0,
+        workerMs: compile.workerDurationMs ?? compile.durationMs ?? 0,
+        binaryBytes: compile.binaryBytes ?? 0,
+        imports: compile.imports ?? [],
+        linkPlan: compile.linkPlan ?? null,
+        compileSuccess: compile.success === true,
+        validates: compile.validates === true,
+        timedOut: compile.timedOut === true,
+        timeoutStage: compile.timeoutStage ?? null,
+        split,
+        terminal,
+        firstError: compileError,
+      }),
+    );
   } finally {
     // A scheduler callback can outlive the final test body. Keep the host error
     // boundary installed until all project batches have had one macrotask.
@@ -1338,6 +1536,8 @@ async function runProjectHarness({
     success: batchReports.length > 0 && batchReports.every((batch) => batch.compileSuccess),
     durationMs: totalCompileMs,
     binaryBytes: totalBytes,
+    attempts: attemptReports,
+    splitTimeouts,
     batches: batchReports,
     invalidBatches: invalidBatches.length,
     implementationInvalid,
@@ -1374,16 +1574,18 @@ async function runProjectHarness({
     nativeHostErrors: nativeHostErrors.length,
     compileMs: totalCompileMs,
     binaryBytes: totalBytes,
+    compileAttempts: attemptReports.length,
+    splitTimeouts,
     batches: batchReports.length,
     invalidBatches: invalidBatches.length,
     implementationInvalid: implementationInvalid !== null,
     implementationError: implementationInvalid?.error ?? null,
     binaryValidates: report.validation.validates,
   };
-  mkdirSync(dirname(REPORT_PATH), { recursive: true });
-  writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+  mkdirSync(dirname(reportPath), { recursive: true });
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   log(`[dogfood] ${report.summary.headline}`);
-  log(`[dogfood] full report → ${REPORT_PATH}`);
+  log(`[dogfood] full report → ${reportPath}`);
   return report;
 }
 
@@ -1405,9 +1607,13 @@ function splitBySize(tests, maxChars = MAX_BATCH_CHARS, maxTests = Number.POSITI
   return chunks;
 }
 
-export async function runHarness({ quiet = false } = {}) {
+export async function runHarness({
+  quiet = false,
+  clientFile = null,
+  reportPath = REPORT_PATH,
+  skipServerLanes = false,
+} = {}) {
   const log = quiet ? () => {} : (...values) => console.log(...values);
-  installReactTestEnvironment();
 
   // --- 1. ACQUIRE ----------------------------------------------------------
   const { root: reactRoot, version: reactVersion } = setupReact();
@@ -1419,11 +1625,6 @@ export async function runHarness({ quiet = false } = {}) {
   const reactSource = readFileSync(reactModulePath, "utf-8");
   const implementationPin = setupReactDomImplementation({ build });
   const localRequire = createRequire(import.meta.url);
-  const hostInfrastructure = installReactUpstreamInfrastructure({
-    react: localRequire(reactModulePath),
-    build,
-    preferReactDomAct: true,
-  });
   const installedReactDom = localRequire("react-dom/package.json");
   if (installedReactDom.version !== implementationPin.version) {
     throw new Error(
@@ -1570,22 +1771,42 @@ export async function runHarness({ quiet = false } = {}) {
     edgeFizzAdmitted: edgeFizzTests.length,
   };
   const requestedLimit = Number(process.env.DOGFOOD_REACT_DOM_TEST_LIMIT ?? 0);
-  const selectedTests =
-    Number.isInteger(requestedLimit) && requestedLimit > 0 ? clientTests.slice(0, requestedLimit) : clientTests;
+  const selectedTests = selectClientProjectTests(clientTests, { clientFile, limit: requestedLimit });
+  if (clientFile !== null) {
+    report.extraction.clientFileFocus = clientFile;
+    if (selectedTests.length === 0)
+      throw new Error(`No admitted React DOM client tests matched exact file ${clientFile}`);
+  }
   report.extraction.selected = selectedTests.length;
   report.extraction.clientSelected = selectedTests.length;
-  report.extraction.serverSelected = Number(process.env.DOGFOOD_REACT_DOM_SERVER_TEST_LIMIT ?? 0) || serverTests.length;
-  report.extraction.fizzSelected = Number(process.env.DOGFOOD_REACT_DOM_FIZZ_TEST_LIMIT ?? 0) || fizzTests.length;
-  report.extraction.nodeFizzSelected =
-    Number(process.env.DOGFOOD_REACT_DOM_NODE_FIZZ_TEST_LIMIT ?? 0) || nodeFizzTests.length;
-  report.extraction.edgeFizzSelected =
-    Number(process.env.DOGFOOD_REACT_DOM_EDGE_FIZZ_TEST_LIMIT ?? 0) || edgeFizzTests.length;
+  report.extraction.serverSelected = skipServerLanes
+    ? 0
+    : Number(process.env.DOGFOOD_REACT_DOM_SERVER_TEST_LIMIT ?? 0) || serverTests.length;
+  report.extraction.fizzSelected = skipServerLanes
+    ? 0
+    : Number(process.env.DOGFOOD_REACT_DOM_FIZZ_TEST_LIMIT ?? 0) || fizzTests.length;
+  report.extraction.nodeFizzSelected = skipServerLanes
+    ? 0
+    : Number(process.env.DOGFOOD_REACT_DOM_NODE_FIZZ_TEST_LIMIT ?? 0) || nodeFizzTests.length;
+  report.extraction.edgeFizzSelected = skipServerLanes
+    ? 0
+    : Number(process.env.DOGFOOD_REACT_DOM_EDGE_FIZZ_TEST_LIMIT ?? 0) || edgeFizzTests.length;
   log(
     `[dogfood] react-dom@${implementationPin.version} upstream @ ${suitePin.tag}: ` +
       `${admittedTests.length} of ${admittedTests.length + rejectedTests.length} upstream tests admitted ` +
       `(${clientTests.length} client, ${serverTests.length} legacy server, ${fizzTests.length} browser Fizz, ` +
       `${nodeFizzTests.length} node Fizz, ${edgeFizzTests.length} edge Fizz)`,
   );
+
+  // Exact-file diagnostics are validated before installing process-global
+  // React/Jest infrastructure. A miss therefore exits without leaving globals
+  // behind or requiring cleanup from a run that never started.
+  installReactTestEnvironment();
+  const hostInfrastructure = installReactUpstreamInfrastructure({
+    react: localRequire(reactModulePath),
+    build,
+    preferReactDomAct: true,
+  });
 
   const runFizzLane = async ({ source, tests, lane, moduleName, testLimitEnv, fizzPlatform }) => {
     try {
@@ -1627,6 +1848,7 @@ export async function runHarness({ quiet = false } = {}) {
   if (process.env.DOGFOOD_REACT_DOM_PROJECT !== "0") {
     const result = await runProjectHarness({
       report,
+      reportPath,
       log,
       implementation,
       reactSource,
@@ -1634,65 +1856,69 @@ export async function runHarness({ quiet = false } = {}) {
       clientSource,
       selectedTests,
     });
-    try {
-      result.server = await runServerHarness({
-        log,
-        reactSource,
-        sharedSource,
-        serverSource,
-        suitePin,
-        serverTests,
-        lane: "legacy server",
-        moduleName: implementationPin.moduleNames.server,
+    if (!skipServerLanes) {
+      try {
+        result.server = await runServerHarness({
+          log,
+          reactSource,
+          sharedSource,
+          serverSource,
+          suitePin,
+          serverTests,
+          lane: "legacy server",
+          moduleName: implementationPin.moduleNames.server,
+        });
+      } catch (error) {
+        result.server = {
+          summary: {
+            headline:
+              "0/0 executed upstream react-dom server tests pass against compiled Wasm (server lane failed before execution)",
+            passRatePct: 0,
+            upstreamTestsSeen: serverTests.length,
+            admitted: serverTests.length,
+            selected: 0,
+            scored: 0,
+            passed: 0,
+            failed: 0,
+            harnessIncompatible: 0,
+            implementationInvalidTests: serverTests.length,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        };
+      }
+      result.fizz = await runFizzLane({
+        source: fizzSource,
+        tests: fizzTests,
+        lane: "browser Fizz",
+        moduleName: implementationPin.moduleNames.fizzServer,
+        testLimitEnv: "DOGFOOD_REACT_DOM_FIZZ_TEST_LIMIT",
+        fizzPlatform: "browser",
       });
-    } catch (error) {
-      result.server = {
-        summary: {
-          headline:
-            "0/0 executed upstream react-dom server tests pass against compiled Wasm (server lane failed before execution)",
-          passRatePct: 0,
-          upstreamTestsSeen: serverTests.length,
-          admitted: serverTests.length,
-          selected: 0,
-          scored: 0,
-          passed: 0,
-          failed: 0,
-          harnessIncompatible: 0,
-          implementationInvalidTests: serverTests.length,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      };
+      result.nodeFizz = await runFizzLane({
+        source: nodeFizzSource,
+        tests: nodeFizzTests,
+        lane: "node Fizz",
+        moduleName: implementationPin.moduleNames.nodeFizzServer,
+        testLimitEnv: "DOGFOOD_REACT_DOM_NODE_FIZZ_TEST_LIMIT",
+        fizzPlatform: "node",
+      });
+      result.edgeFizz = await runFizzLane({
+        source: edgeFizzSource,
+        tests: edgeFizzTests,
+        lane: "edge Fizz",
+        moduleName: implementationPin.moduleNames.edgeFizzServer,
+        testLimitEnv: "DOGFOOD_REACT_DOM_EDGE_FIZZ_TEST_LIMIT",
+        fizzPlatform: "edge",
+      });
+      report.server = result.server;
+      report.fizz = result.fizz;
+      report.nodeFizz = result.nodeFizz;
+      report.edgeFizz = result.edgeFizz;
+    } else {
+      report.skippedLanes = ["legacy server", "browser Fizz", "node Fizz", "edge Fizz"];
     }
-    result.fizz = await runFizzLane({
-      source: fizzSource,
-      tests: fizzTests,
-      lane: "browser Fizz",
-      moduleName: implementationPin.moduleNames.fizzServer,
-      testLimitEnv: "DOGFOOD_REACT_DOM_FIZZ_TEST_LIMIT",
-      fizzPlatform: "browser",
-    });
-    result.nodeFizz = await runFizzLane({
-      source: nodeFizzSource,
-      tests: nodeFizzTests,
-      lane: "node Fizz",
-      moduleName: implementationPin.moduleNames.nodeFizzServer,
-      testLimitEnv: "DOGFOOD_REACT_DOM_NODE_FIZZ_TEST_LIMIT",
-      fizzPlatform: "node",
-    });
-    result.edgeFizz = await runFizzLane({
-      source: edgeFizzSource,
-      tests: edgeFizzTests,
-      lane: "edge Fizz",
-      moduleName: implementationPin.moduleNames.edgeFizzServer,
-      testLimitEnv: "DOGFOOD_REACT_DOM_EDGE_FIZZ_TEST_LIMIT",
-      fizzPlatform: "edge",
-    });
-    report.server = result.server;
-    report.fizz = result.fizz;
-    report.nodeFizz = result.nodeFizz;
-    report.edgeFizz = result.edgeFizz;
-    mkdirSync(dirname(REPORT_PATH), { recursive: true });
-    writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+    mkdirSync(dirname(reportPath), { recursive: true });
+    writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
     hostInfrastructure.cleanup();
     return result;
   }
@@ -1950,66 +2176,70 @@ export async function runHarness({ quiet = false } = {}) {
     binaryValidates: report.validation.validates,
   };
 
-  mkdirSync(dirname(REPORT_PATH), { recursive: true });
-  writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+  mkdirSync(dirname(reportPath), { recursive: true });
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   log(`[dogfood] ${report.summary.headline}`);
   if (nativeHostErrors.length > 0) {
     log(`[dogfood] native oracle recorded ${nativeHostErrors.length} expected late jsdom host error(s)`);
   }
-  log(`[dogfood] full report → ${REPORT_PATH}`);
-  try {
-    report.server = await runServerHarness({
-      log,
-      reactSource,
-      sharedSource,
-      serverSource,
-      suitePin,
-      serverTests,
+  log(`[dogfood] full report → ${reportPath}`);
+  if (!skipServerLanes) {
+    try {
+      report.server = await runServerHarness({
+        log,
+        reactSource,
+        sharedSource,
+        serverSource,
+        suitePin,
+        serverTests,
+      });
+    } catch (error) {
+      report.server = {
+        summary: {
+          headline:
+            "0/0 executed upstream react-dom server tests pass against compiled Wasm (server lane failed before execution)",
+          passRatePct: 0,
+          upstreamTestsSeen: serverTests.length,
+          admitted: serverTests.length,
+          selected: 0,
+          scored: 0,
+          passed: 0,
+          failed: 0,
+          harnessIncompatible: 0,
+          implementationInvalidTests: serverTests.length,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+    report.fizz = await runFizzLane({
+      source: fizzSource,
+      tests: fizzTests,
+      lane: "browser Fizz",
+      moduleName: implementationPin.moduleNames.fizzServer,
+      testLimitEnv: "DOGFOOD_REACT_DOM_FIZZ_TEST_LIMIT",
+      fizzPlatform: "browser",
     });
-  } catch (error) {
-    report.server = {
-      summary: {
-        headline:
-          "0/0 executed upstream react-dom server tests pass against compiled Wasm (server lane failed before execution)",
-        passRatePct: 0,
-        upstreamTestsSeen: serverTests.length,
-        admitted: serverTests.length,
-        selected: 0,
-        scored: 0,
-        passed: 0,
-        failed: 0,
-        harnessIncompatible: 0,
-        implementationInvalidTests: serverTests.length,
-        error: error instanceof Error ? error.message : String(error),
-      },
-    };
+    report.nodeFizz = await runFizzLane({
+      source: nodeFizzSource,
+      tests: nodeFizzTests,
+      lane: "node Fizz",
+      moduleName: implementationPin.moduleNames.nodeFizzServer,
+      testLimitEnv: "DOGFOOD_REACT_DOM_NODE_FIZZ_TEST_LIMIT",
+      fizzPlatform: "node",
+    });
+    report.edgeFizz = await runFizzLane({
+      source: edgeFizzSource,
+      tests: edgeFizzTests,
+      lane: "edge Fizz",
+      moduleName: implementationPin.moduleNames.edgeFizzServer,
+      testLimitEnv: "DOGFOOD_REACT_DOM_EDGE_FIZZ_TEST_LIMIT",
+      fizzPlatform: "edge",
+    });
+  } else {
+    report.skippedLanes = ["legacy server", "browser Fizz", "node Fizz", "edge Fizz"];
   }
-  report.fizz = await runFizzLane({
-    source: fizzSource,
-    tests: fizzTests,
-    lane: "browser Fizz",
-    moduleName: implementationPin.moduleNames.fizzServer,
-    testLimitEnv: "DOGFOOD_REACT_DOM_FIZZ_TEST_LIMIT",
-    fizzPlatform: "browser",
-  });
-  report.nodeFizz = await runFizzLane({
-    source: nodeFizzSource,
-    tests: nodeFizzTests,
-    lane: "node Fizz",
-    moduleName: implementationPin.moduleNames.nodeFizzServer,
-    testLimitEnv: "DOGFOOD_REACT_DOM_NODE_FIZZ_TEST_LIMIT",
-    fizzPlatform: "node",
-  });
-  report.edgeFizz = await runFizzLane({
-    source: edgeFizzSource,
-    tests: edgeFizzTests,
-    lane: "edge Fizz",
-    moduleName: implementationPin.moduleNames.edgeFizzServer,
-    testLimitEnv: "DOGFOOD_REACT_DOM_EDGE_FIZZ_TEST_LIMIT",
-    fizzPlatform: "edge",
-  });
-  mkdirSync(dirname(REPORT_PATH), { recursive: true });
-  writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+  mkdirSync(dirname(reportPath), { recursive: true });
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   hostInfrastructure.cleanup();
   return report;
 }

--- a/tests/dogfood/react-dom-upstream-suite.test.ts
+++ b/tests/dogfood/react-dom-upstream-suite.test.ts
@@ -1,34 +1,38 @@
 import { execFile } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { existsSync } from "node:fs";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 import { compileProject, instantiateLinkedProject } from "../../src/index.ts";
 
-// @ts-expect-error — .mjs dogfood setup has no declaration file
-import { loadReactDomUpstreamSuitePin, setupReactDomImplementation } from "./setup-react-dom-upstream-suite.mjs";
-// @ts-expect-error — .mjs dogfood setup has no declaration file
-import { loadReactUpstreamSuitePin } from "./setup-react-upstream-suite.mjs";
 // @ts-expect-error — .mjs dogfood harness has no declaration file
 import {
   DEFAULT_PROJECT_BATCH_CHARS,
   DEFAULT_PROJECT_BATCH_TESTS,
-  createNativeRequire,
+  MAX_PROJECT_SPLIT_ATTEMPTS,
+  MAX_PROJECT_SPLIT_DEPTH,
+  buildClientProjectEntry,
   buildProjectFiles,
   buildServerProjectFiles,
+  compileProjectBatchTrees,
+  createNativeRequire,
   installNativeHostErrorBoundary,
   isExpectedLateJsdomHostError,
   partitionProjectTests,
   partitionReactDomTestsForBuild,
   projectCompileConcurrency,
   reactDomTestSetup,
+  selectClientProjectTests,
 } from "./react-dom-upstream-suite.mjs";
 // @ts-expect-error — .mjs dogfood extractor has no declaration file
 import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
+// @ts-expect-error — .mjs dogfood setup has no declaration file
+import { loadReactDomUpstreamSuitePin, setupReactDomImplementation } from "./setup-react-dom-upstream-suite.mjs";
+// @ts-expect-error — .mjs dogfood setup has no declaration file
+import { loadReactUpstreamSuitePin } from "./setup-react-upstream-suite.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const execFileAsync = promisify(execFile);
@@ -171,44 +175,236 @@ describe("react-dom upstream suite", () => {
     }
   });
 
-  it("partitions project entries without dropping tests or mixing files", () => {
-    const make = (file: string, index: number, size: number) => ({
+  it("partitions by exact generated entry length without dropping or reordering file runs", () => {
+    const make = (file: string, index: number, size = 0) => ({
       file,
       id: `${file}-${index}`,
-      prelude: "p".repeat(size),
-      body: "",
+      fullName: `${file} test ${index}`,
+      prelude: "",
+      body: `void 0;${" ".repeat(size)}`,
+      isAsync: false,
     });
-    const input = [make("a.js", 0, 7), make("a.js", 1, 7), make("b.js", 0, 7)];
-    const batches = partitionProjectTests(input, 15);
+    const first = make("a.js", 0, 20);
+    const second = make("a.js", 1, 20);
+    const exactPairChars = buildClientProjectEntry([first, second]).length;
+
+    const exact = partitionProjectTests([first, second], exactPairChars);
+    expect(exact).toHaveLength(1);
+    expect(exact[0].entryChars).toBe(exactPairChars);
+    expect(
+      buildProjectFiles({ reactSource: "", sharedSource: "", clientSource: "", tests: exact[0].tests })["entry.ts"],
+    ).toHaveLength(exact[0].entryChars);
+
+    const split = partitionProjectTests([first, second], exactPairChars - 1);
+    expect(split.map(({ tests }) => tests.map(({ id }) => id))).toEqual([[first.id], [second.id]]);
+    expect(split.every((batch) => batch.entryChars === buildClientProjectEntry(batch.tests).length)).toBe(true);
+
+    // A repeated filename is not pulled backward across an intervening file;
+    // source order and each contiguous file lifecycle remain intact.
+    const input = [first, make("b.js", 0), second];
+    const batches = partitionProjectTests(input, Number.POSITIVE_INFINITY);
 
     expect(batches.map(({ file, tests }) => [file, tests.map(({ id }) => id)])).toEqual([
       ["a.js", ["a.js-0"]],
-      ["a.js", ["a.js-1"]],
       ["b.js", ["b.js-0"]],
+      ["a.js", ["a.js-1"]],
     ]);
     expect(batches.flatMap(({ tests }) => tests).map(({ id }) => id)).toEqual(input.map(({ id }) => id));
   });
 
-  it("keeps default linked-root adapters below the measured watchdog-safe size", () => {
+  it("keeps oversize singletons and independently enforces the default test cap", () => {
     const make = (index: number) => ({
       file: "large.js",
       id: `large-${index}`,
-      prelude: "p".repeat(210_000),
-      body: "",
+      fullName: `large ${index}`,
+      prelude: "",
+      body: `void 0;${" ".repeat(230_000)}`,
+      isAsync: false,
     });
-    const batches = partitionProjectTests([make(0), make(1)]);
+    const singleton = make(0);
+    const singletonChars = buildClientProjectEntry([singleton]).length;
+    const batches = partitionProjectTests([singleton], singletonChars - 1);
 
-    expect(DEFAULT_PROJECT_BATCH_CHARS).toBe(400_000);
-    expect(batches.map(({ tests }) => tests.map(({ id }) => id))).toEqual([["large-0"], ["large-1"]]);
+    expect(DEFAULT_PROJECT_BATCH_CHARS).toBe(220_000);
+    expect(batches).toHaveLength(1);
+    expect(batches[0].tests.map(({ id }) => id)).toEqual(["large-0"]);
+    expect(batches[0].entryChars).toBe(singletonChars);
+    expect(batches[0].entryChars).toBeGreaterThan(singletonChars - 1);
 
     const many = Array.from({ length: 33 }, (_, index) => ({
       file: "many.js",
       id: `many-${index}`,
+      fullName: `many ${index}`,
       prelude: "",
-      body: "",
+      body: "void 0;",
+      isAsync: false,
     }));
     expect(DEFAULT_PROJECT_BATCH_TESTS).toBe(32);
-    expect(partitionProjectTests(many).map(({ tests }) => tests.length)).toEqual([32, 1]);
+    expect(partitionProjectTests(many, Number.POSITIVE_INFINITY).map(({ tests }) => tests.length)).toEqual([32, 1]);
+  });
+
+  it("recursively splits only compile-timeout parents and retains every attempt in stable order", async () => {
+    const tests = Array.from({ length: 4 }, (_, index) => ({
+      file: "timeout.js",
+      id: `timeout-${index}`,
+      fullName: `timeout ${index}`,
+      prelude: "",
+      body: "void 0;",
+      isAsync: false,
+    }));
+    const invoked: Array<{ path: string; ids: string[]; rootName: string }> = [];
+    const timeout = {
+      compile: {
+        success: false,
+        validates: false,
+        durationMs: 10,
+        binaryBytes: 0,
+        timedOut: true,
+        timeoutStage: "compile",
+        errors: [{ message: "compile timeout" }],
+      },
+      wasm: null,
+    };
+    const valid = (count: number) => ({
+      compile: { success: true, validates: true, durationMs: 2, binaryBytes: 10, linkPlan: { cachedProviders: 4 } },
+      wasm: { statuses: Array.from({ length: count }, () => true), errors: [] },
+    });
+    const result = await compileProjectBatchTrees({
+      batches: [{ file: "timeout.js", tests }],
+      concurrency: 1,
+      compileAttempt: async ({ path, tests: attemptTests, rootName }) => {
+        invoked.push({ path, ids: attemptTests.map(({ id }: { id: string }) => id), rootName });
+        return path === "0" || path === "0.0" ? timeout : valid(attemptTests.length);
+      },
+    });
+
+    expect(result.attempts.map(({ path }) => path)).toEqual(["0", "0.0", "0.0.0", "0.0.1", "0.1"]);
+    expect(result.leaves.map(({ batchTests }) => batchTests.map(({ id }) => id))).toEqual([
+      ["timeout-0"],
+      ["timeout-1"],
+      ["timeout-2", "timeout-3"],
+    ]);
+    expect(result.leaves.flatMap(({ batchTests }) => batchTests.map(({ id }) => id))).toEqual(
+      tests.map(({ id }) => id),
+    );
+    expect(result.splitTimeouts).toBe(2);
+    expect(result.attempts.reduce((total, attempt) => total + attempt.compile.durationMs, 0)).toBe(26);
+    expect(new Set(invoked.map(({ rootName }) => rootName)).size).toBe(invoked.length);
+    expect(MAX_PROJECT_SPLIT_DEPTH).toBe(6);
+    expect(MAX_PROJECT_SPLIT_ATTEMPTS).toBe(127);
+
+    const bounded = await compileProjectBatchTrees({
+      batches: [{ file: "timeout.js", tests }],
+      concurrency: 1,
+      maxSplitDepth: 1,
+      compileAttempt: async () => timeout,
+    });
+    expect(bounded.attempts.map(({ path }) => path)).toEqual(["0", "0.0", "0.1"]);
+    expect(bounded.leaves.map(({ batchTests }) => batchTests.length)).toEqual([2, 2]);
+    expect(bounded.splitTimeouts).toBe(1);
+  });
+
+  it("does not split diagnostics, validation failures, execution timeouts, or singleton compile timeouts", async () => {
+    const make = (file: string, index: number) => ({
+      file,
+      id: `${file}-${index}`,
+      fullName: `${file} ${index}`,
+      prelude: "",
+      body: "void 0;",
+      isAsync: false,
+    });
+    const pair = (file: string) => [make(file, 0), make(file, 1)];
+    const batches = [
+      { file: "diagnostic.js", tests: pair("diagnostic.js") },
+      { file: "validation.js", tests: pair("validation.js") },
+      { file: "execution.js", tests: pair("execution.js") },
+      { file: "singleton.js", tests: [make("singleton.js", 0)] },
+    ];
+    const result = await compileProjectBatchTrees({
+      batches,
+      concurrency: 2,
+      compileAttempt: async ({ topLevelBatch }) => {
+        if (topLevelBatch === 0) {
+          return {
+            compile: {
+              success: false,
+              validates: false,
+              durationMs: 1,
+              binaryBytes: 0,
+              errors: [{ message: "ordinary compiler diagnostic" }],
+            },
+          };
+        }
+        if (topLevelBatch === 1) {
+          return {
+            compile: {
+              success: true,
+              validates: false,
+              durationMs: 1,
+              binaryBytes: 10,
+              validationError: "invalid Wasm",
+            },
+          };
+        }
+        return {
+          compile: {
+            success: false,
+            validates: false,
+            durationMs: 1,
+            binaryBytes: 0,
+            timedOut: true,
+            timeoutStage: topLevelBatch === 2 ? "execution" : "compile",
+            errors: [{ message: "timeout" }],
+          },
+        };
+      },
+    });
+
+    expect(result.splitTimeouts).toBe(0);
+    expect(result.attempts).toHaveLength(4);
+    expect(result.leaves).toHaveLength(4);
+    expect(result.attempts.every(({ terminal }) => terminal)).toBe(true);
+    expect(result.leaves.flatMap(({ batchTests }) => batchTests.map(({ id }) => id))).toEqual(
+      batches.flatMap(({ tests }) => tests.map(({ id }) => id)),
+    );
+  });
+
+  it("rejects the ordered compile consumer when an attempt callback throws", async () => {
+    const make = (file: string) => ({
+      file,
+      id: file,
+      fullName: file,
+      prelude: "",
+      body: "void 0;",
+      isAsync: false,
+    });
+    const valid = {
+      compile: { success: true, validates: true, durationMs: 1, binaryBytes: 1 },
+      wasm: { statuses: [true], errors: [] },
+    };
+    const compilation = compileProjectBatchTrees({
+      batches: [
+        { file: "first.js", tests: [make("first.js")] },
+        { file: "second.js", tests: [make("second.js")] },
+      ],
+      concurrency: 2,
+      compileAttempt: async ({ topLevelBatch }) => {
+        if (topLevelBatch === 0) await new Promise((resolve) => setTimeout(resolve, 20));
+        return valid;
+      },
+      onAttempt: ({ topLevelBatch }) => {
+        if (topLevelBatch === 1) throw new Error("attempt observer failed");
+      },
+    });
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    const didNotSettle = new Promise((_, reject) => {
+      deadline = setTimeout(() => reject(new Error("ordered compile helper hung")), 250);
+    });
+    try {
+      await expect(Promise.race([compilation, didNotSettle])).rejects.toThrow("attempt observer failed");
+    } finally {
+      if (deadline !== undefined) clearTimeout(deadline);
+    }
   });
 
   it("keeps the project compile pool bounded and deterministic", () => {
@@ -216,6 +412,19 @@ describe("react-dom upstream suite", () => {
     expect(projectCompileConcurrency(3, "1")).toBe(1);
     expect(projectCompileConcurrency(3, "4")).toBe(3);
     expect(projectCompileConcurrency(3, "not-a-number")).toBe(2);
+  });
+
+  it("focuses a diagnostic client run by exact file without changing default selection", () => {
+    const tests = [
+      { file: "a.js", id: "a-0" },
+      { file: "b.js", id: "b-0" },
+      { file: "a.js", id: "a-1" },
+    ];
+
+    expect(selectClientProjectTests(tests)).toEqual(tests);
+    expect(selectClientProjectTests(tests, { clientFile: "a.js" }).map(({ id }) => id)).toEqual(["a-0", "a-1"]);
+    expect(selectClientProjectTests(tests, { clientFile: "a.js", limit: 1 }).map(({ id }) => id)).toEqual(["a-0"]);
+    expect(selectClientProjectTests(tests, { clientFile: "A.js" })).toEqual([]);
   });
 
   it("does not shadow upstream act functions or read a test-owned document early", () => {


### PR DESCRIPTION
## Summary

- partition React DOM client consumers by the exact generated `entry.ts` length, capped at 220,000 characters or 32 tests while preserving source order
- retry only true compiler-timeout batches as bounded deterministic binary splits
- retain every compile attempt in report telemetry while scoring only terminal leaves and preserving the shared provider cache across retries
- add exact-file diagnostic runs and reject callback/worker failures without leaving ordered consumers hanging
- ignore the generated React DOM project workspace in Biome so benchmark runs cannot pollute repository lint

## Context

PR #5312 merged the strict separate-module linking fix and the original 400k estimated-size cap. Its merge-queue entry raced with the already-pushed follow-up commit, so this PR carries only the validated timeout follow-up on top of current `main`.

The old partitioner estimated lifted test-body size rather than measuring the generated adapter, imports, and per-test wrappers. Nominally 400 KB batches became 454–467 KB compiler entries. Code generation grows super-linearly at that size, and four `ReactDOMFizzServer-test.js` batches reached the fixed 300-second compiler timeout.

## Measurement

Cold full-suite control before the tighter cap:

- 1,923 admitted tests, 124 client batches, concurrency 2
- 2h 39m 44.84s wall time; 5,266,761 ms summed client compile work
- four 300-second compiler timeouts, all in `ReactDOMFizzServer-test.js` (98 tests total)
- timed-out generated entries were 453,639–466,648 characters

Corrected real-script focused run after this change:

- all 166 admitted client tests from `ReactDOMFizzServer-test.js`
- 18 exact-size batches in 2m 48.01s wall time
- 283,283 ms summed compile work; maximum batch compile 21.418s
- generated entries ranged from 151,652 to 219,029 characters
- zero compiler timeouts and zero adaptive splits
- all 18 link plans stayed separate and reused providers through 72 cache hits
- 6.08x less summed compiler work than the same file's prior seven batches (1,722,203 ms)

The split fallback remains available for genuine outliers, but the exact entry cap alone kept every measured batch below the timeout.

## Validation

- adaptive partitioning/splitting: 6/6 focused tests passed after the latest `main` sync
- package linking and worker protocol: 23/23 tests passed after the latest `main` sync
- TypeScript typecheck passed
- repository pre-commit and pre-push gates passed, including formatting, lint, LOC/function budgets, oracle/coercion ratchets, issue integrity, and 18/18 numeric-local IR parity tests
- the previous pushed head completed GitHub quality, Test262 PR gates, cross-backend parity, and the Porffor source canary successfully; this synchronized follow-up reruns those checks

The existing React DOM provider integration still emits invalid Wasm in `expectMarkupMatch`. The identical selected failure reproduces on exact upstream `main`, so that correctness issue is not introduced or hidden by this performance change.

## Terminology

- A **provider module** is a separately compiled and cached package Wasm module, such as React, Scheduler, or React DOM.
- A **consumer adapter** is the smaller root Wasm module containing the lifted tests/application entry and imports that connect it to provider modules. This PR bounds the size of those consumer adapters.
- A **provider adapter manifest** is metadata embedded in a provider Wasm module. It records identity, dependency/export contracts, value-boundary adapters, and host/string metadata so the linker can validate, cache, and instantiate the provider without reconstructing information from its original source tree.
