### PR TITLE
docs(issues): file #5221-#5223 (Temporal provider follow-ups)

### DIFF
--- a/plan/issues/5221-temporal-plaindate-from-null-deref.md
+++ b/plan/issues/5221-temporal-plaindate-from-null-deref.md
@@ -1,0 +1,49 @@
+---
+id: 5221
+title: "Temporal.PlainDate.from(…) traps with a null-pointer deref — polyfill intrinsic / Object.create(proto) machinery, single-module too"
+status: ready
+sprint: current
+priority: high
+horizon: l
+goal: core-semantics
+feasibility: hard
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5221 — `Temporal.PlainDate.from(…)` null-pointer deref
+
+## Problem
+
+With the #4628 provider wired (PR #5318), `Temporal.PlainDate.from("2020-03-04")`
+traps with `RuntimeError: dereferencing a null pointer`. Measured by
+dev-temporal-wire to fail IDENTICALLY when the polyfill is compiled as one
+module with no provider and no linking — a pre-existing gap in the compiled
+polyfill's intrinsic / `Object.create(proto)` machinery, not the provider
+seam. This is the biggest conformance blocker left on the Temporal bucket:
+`.from(...)` is the entry point most test262 rows use, which is why the
+runner was deliberately NOT wired to the provider yet (rows would move from
+"not defined" to a null deref with no net gain).
+
+## Direction
+
+Reduce inside the single-module polyfill compile (harness ESM lane):
+instrument where the null flows from — likely `Object.create(proto)` /
+%Intrinsic% table population in the compiled polyfill. Reduce to a minimal
+compiled program before touching codegen/runtime.
+
+## Acceptance criteria
+
+1. `Temporal.PlainDate.from("2020-03-04")` returns a working object,
+   single-module AND through the provider; new tests failing on base.
+2. Temporal 256-row slice (dev-temporal-wire's deterministic sample) measured
+   before/after; report deltas.
+3. No regressions in issue-4628 test files + equivalence gate. Gates green.
+
+## Notes
+
+- Found by dev-temporal-wire validating PR #5318. Siblings: #5222 (Now.*
+  lost across provider boundary), #5223 (instance toString dispatch).
+- Id reserved with a degraded PR scan; manually checked against open PR
+  head branches 2026-08-30.

--- a/plan/issues/5222-temporal-now-methods-lost-provider-boundary.md
+++ b/plan/issues/5222-temporal-now-methods-lost-provider-boundary.md
@@ -1,0 +1,41 @@
+---
+id: 5222
+title: "Temporal.Now.* methods are lost across the provider boundary — \"function\" single-module, undefined through the linked provider"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5222 — `Temporal.Now.*` lost across the provider boundary
+
+## Problem
+
+`typeof Temporal.Now.instant` is `"function"` when the polyfill is compiled
+as a single module, but `undefined` when reached through the #4628
+compile-once linked provider (PR #5318). Linking-specific: `Now`'s methods
+do not survive the cross-module value crossing. dev-temporal-wire called
+this the strongest next follow-up — `Now` is a plain namespace object of
+functions, so whatever drops its members likely affects other
+object-of-functions exports crossing module boundaries.
+
+## Acceptance criteria
+
+1. `Temporal.Now.instant()` / `Temporal.Now.plainDateISO()` callable through
+   the provider; new tests failing on base (provider lane) with the
+   single-module control passing on base.
+2. Identify and state the general rule (which value shapes lose members at
+   the link boundary) — if broader than Now, file it, don't widen the fix
+   silently.
+3. No regressions in issue-4628 + package-linker (#2527-family) tests.
+   Gates green.
+
+## Notes
+
+- Found by dev-temporal-wire validating PR #5318. Siblings #5221/#5223.
+- Id reserved with a degraded PR scan; manually checked against open PR
+  head branches 2026-08-30.

--- a/plan/issues/5223-compiled-class-instance-tostring-dispatch.md
+++ b/plan/issues/5223-compiled-class-instance-tostring-dispatch.md
@@ -1,0 +1,43 @@
+---
+id: 5223
+title: "Compiled-class instance toString / Symbol.toStringTag dispatch not wired — new Temporal.PlainDate(…).toString() returns \"[object Object]\""
+status: ready
+sprint: current
+priority: medium
+horizon: m
+goal: core-semantics
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5223 — compiled-class instance `toString` dispatch
+
+## Problem
+
+`new Temporal.PlainDate(2020,3,4).toString()` returns `"[object Object]"`
+instead of `"2020-03-04"` — the compiled class's prototype `toString` (and
+`Symbol.toStringTag`) is not consulted when the instance crosses to the
+host / is stringified. Found by dev-temporal-wire validating PR #5318.
+
+## Direction
+
+Related family: #5201/#5202 dispatch exports and the #5318 `.prototype`
+dynamic-lane fix. Measure whether the miss is (a) host-side `toString`
+resolution on the wrapped instance, or (b) string-coercion paths bypassing
+the class dispatch surface. Reduce with a plain user class first
+(`class P { toString(){ return "x"; } }` via a dynamic receiver) — if that
+also fails, this is general, not Temporal-specific; say so in the PR.
+
+## Acceptance criteria
+
+1. Reduced repro (plain class + Temporal shape) returns the prototype's
+   toString result, host lane; new tests failing on base.
+2. `String(inst)`, template-literal interpolation, and `"" + inst` measured.
+3. No regressions in class-dispatch scoped runs (#5201/#5202 files).
+   Gates green.
+
+## Notes
+
+- Siblings #5221/#5222. Id reserved with a degraded PR scan; manually
+  checked against open PR head branches 2026-08-30.


### PR DESCRIPTION
Docs-only PR — files the three defects found by dev-temporal-wire while wiring the [#4628](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4628-temporal-runtime-object-spike) `Temporal` global (PR #5318):

- [#5221](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5221-temporal-plaindate-from-null-deref) — `Temporal.PlainDate.from(…)` traps with a null-pointer deref, **single-module too** (polyfill intrinsic / `Object.create(proto)` machinery). The main remaining Temporal conformance blocker — it's why the test262 runner isn't wired to the provider yet.
- [#5222](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5222-temporal-now-methods-lost-provider-boundary) — `Temporal.Now.*` methods are lost across the provider link boundary (`"function"` single-module, `undefined` linked). Strongest next follow-up.
- [#5223](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5223-compiled-class-instance-tostring-dispatch) — compiled-class instance `toString` / `Symbol.toStringTag` dispatch not wired (`.toString()` → `"[object Object]"`).

No `src/`, `tests/`, `scripts/`, `.github/`, or `benchmarks/` files touched. Ids allocated via `claim-issue.mjs --allocate` (degraded PR scan, manually verified against open PR head branches).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_