### PR TITLE
fix(test262): authenticate standalone high-water transition evidence

### DIFF
--- a/plan/issues/2097-standalone-pass-count-highwater-floor.md
+++ b/plan/issues/2097-standalone-pass-count-highwater-floor.md
@@ -1,17 +1,16 @@
 ---
 id: 2097
 title: "absolute standalone pass-count floor — high-water-mark backstop against compounding small regressions"
-status: done
+status: in-progress
 sprint: 62
 created: 2026-06-11
-updated: 2026-06-16
-completed: 2026-06-16
+updated: 2026-08-30
 assignee: ttraenkler/dv2
-priority: medium
-feasibility: easy
-reasoning_effort: low
-task_type: infrastructure
-area: testing
+priority: critical
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: testing, compiler, standalone
 language_feature: n/a
 goal: host-independence
 related: [2095]
@@ -90,3 +89,357 @@ standalone baseline (`pass: 21184`, full corpus). It only ever ratchets UP.
 - `tests/issue-2097-standalone-highwater.test.ts` — 7/7 pass.
 - Script smoke (within-tolerance pass, breach exit 1, ratchet raise/refuse) —
   all correct.
+
+## 2026-08-30 incident — recover the pre-existing 1,295-pass slide
+
+The #2097 backstop is working as designed. It blocked the protected IR merge
+queue after exposing a genuine standalone host-free regression that predates
+the queued IR branches. The repair must restore the lost behavior; it must not
+lower, re-seed, bypass, or reinterpret the high-water mark.
+
+### Frozen evidence
+
+All authoritative measurements use the same **48,735-test** denominator:
+
+| Revision / queue composition | Host-free pass | Delta from 33,876 mark | Evidence role |
+| --- | ---: | ---: | --- |
+| `fc6fd3b5f3df1fbce731bf74c391aca41fcd08c2` | 33,876 | 0 | committed high-water source |
+| `01fb67624e2f645b7e92dd9f8e47478e3face9ba` | 32,581 | −1,295 | exact later main ancestor, already bad |
+| #5297 atop `01fb676…` | 32,593 | −1,283 | first later complete queue measurement |
+| #5295 only, `60f3707751b86f5701a7f4e771924293e3b6f762` | 32,717 | −1,159 | C37 is not the cause |
+| #5295 + #5308, `8daa0d5be74e20cf9a01d7b1f5b779cdd7dfdeb0` | 32,719 | −1,157 | #5308 restores only two more passes |
+
+The endpoint and queue evidence is content-addressed as follows:
+
+| Evidence | Workflow run / attempt | Evidence locator / authority | Bytes | SHA-256 |
+| --- | --- | --- | ---: | --- |
+| `fc6fd3…` high-water source | Test262 Sharded `33228968210` | `js2wasm-baselines` commit `9657d806b1d6ed0f54256c74b390f232677bd8e4`, blob `f762926801f85f7bb630b53e9d727647ecc45d94` | 23,209,263 JSONL | `d3341cf6b6dbcc237f18f1461dc97dcddf1f2cbbfb944496d7ae73e8489adb87` |
+| `01fb676…` forced snapshot | Baseline Refresh `33308136754` | persistent baseline commit `f0d6b57da9362471decffeb6f3d98d650d477bd5`, blob `3b99ba94b2a1a8625f869a84464bd497eeb732c0`; ephemeral artifact `9731533771`, `emergency-merged-report`, expires `2026-08-31T11:40:26Z` | 5,220,517 ZIP / 23,482,700 JSONL | artifact `1953f7c82a2446d1c1aac8a9b04f8f66fbb3633bd671573221b85e016c3bb8b0`; JSONL `5d6cb6e5a39fbb6e20c9ac655a1cc6987d6555c222ad42aab9dbb70b0ec23ff3` |
+| #5297 first complete post-breach | Test262 Sharded `33306986588`, attempt 2 | ephemeral artifact `9731640668`, `test262-merged-report`, expires `2026-08-31T11:49:15Z` | 5,163,176 ZIP | `9c863f3a18531849f22d86c856f87a1b93f2e516689e2daa86f36422f1fcd4e7` |
+| #5295 only | Test262 Sharded `33315219028`, attempt 3 | ephemeral artifact `9734619149`, `test262-merged-report`, expires `2026-08-31T15:35:27Z` | 5,157,789 ZIP | `c2206cb1696fa3a4e40ba8b22a6e8a1805e5b1b6ccf1da629e59c3ceaf1ac7a1` |
+| #5295 + #5308 | Test262 Sharded `33317003311`, attempt 3 | ephemeral artifact `9734689995`, `test262-merged-report`, expires `2026-08-31T15:40:55Z` | 5,162,309 ZIP | `4d5c3f9b4f791a069c655b1a2a88170addef98212ac97b065483f03ab100e51e` |
+
+The `fc6fd3…` Actions artifact has expired. Its promoted baseline blob, exact
+byte length, and independently computed content digest are therefore the
+persistent endpoint authority; the plan must not invent a live artifact ID or
+claim recovery of streams GitHub no longer retains. The promoted `01fb676…`
+JSONL is the other persistent endpoint authority. All four Actions artifacts
+were authenticated through the API when recorded but expire on 2026-08-31;
+the three downstream queue artifacts are ephemeral confirmation only, not
+causal authority. Do not describe their IDs or archive digests as durable
+unless their raw bytes are first copied into a separately authenticated
+content-addressed store.
+
+The refreshed combined queue head
+`4f978ead0c022677f806c3c424f93fbe05e3a135` has the exact same tree,
+`c3228e27325a217e374401638570944c6da1ba01`, as `8daa0d5b…`; rerunning that
+tree cannot materially close the floor gap. Infrastructure cancellations may
+require a failed-job rerun for evidence completeness, but they are not a
+semantic repair.
+
+The later protected merge-group run `33322681387` supplies the clean rerun for
+the #5295-only composition: exact merge-group head `85f0925f…`, all 50
+standalone shards and the Test262 regression check passed, no job was
+cancelled, and the sole failure was the unchanged #2097 floor at 32,717 versus
+33,826 (−1,159). It confirms the earlier #5295-only measurement byte-for-byte
+at the aggregate-count level; it does not move either causal endpoint or
+justify changing #5295.
+
+The exact immutable `fc6fd3…` → `01fb676…` endpoint JSONLs contain **1,764 raw
+host-free pass regressions** and **469 raw improvements**, net −1,295. The
+fine-gate's post-quarantine view is a different population: **1,696 stable
+non-timeout regressions** and **461 improvements**, net −1,235. Never combine
+one side of the raw census with the other side of the filtered census.
+
+Observed raw regression groups include 683 `assertion_fail`, 681
+`other`-category outcomes (578 runtime failures plus 103 compile errors), 307
+`host_import_leak`, and 39 `compile_timeout` rows. Those named groups account
+for 1,710 paths; the remaining 54 regressions must stay explicit in the
+canonical manifest rather than being silently folded into “other.” The
+unchanged denominator rules out corpus growth as the explanation.
+
+The canonical sorted 1,764-path high-to-low regression manifest is **147,235
+bytes including its final LF**, SHA-256
+`ad2a2e1fcc59c86ef95cc9815c759322a70669be4cc81c42f7d2a68b147cddac`.
+It is a path-vector seed, not an acceptance summary. The operative predicate is
+standalone `host_free_pass` under the exact no-host-import contract, not raw
+`full_summary.pass` or an aggregate offset by unrelated improvements.
+
+Intervening queue runs contain cancelled or incomplete shards, so current
+evidence proves the bad interval but not one causal commit. Do not attribute
+the regression to the nearest completed PR, to #5295, or to #5308 without
+path-level replay.
+
+A fresh depth-500 public clone proves that `(fc6fd3…, 01fb676…]` contains
+**83 first-parent main transitions / 84 endpoint-inclusive snapshots** and
+**332 reachable DAG commits**. The shared development clone is shallow at
+`c882d1b…` and exposes only the final seven transitions; that truncated view
+must never bound the causal search or be recorded as the interval census.
+
+The `01fb676…` forced refresh is an authenticated measurement only: bypassing
+the gate to publish evidence did not accept the regression. #5297 is the first
+complete post-breach observation, not the first bad commit. #5295 and the
+#5295/#5308 composition are downstream confirmations, not origin anchors.
+
+### Non-goals and ownership boundary
+
+- Do not change PR #5295 or #5308, their branch histories, or their semantic
+  acceptance contracts.
+- Do not lower `benchmarks/results/test262-standalone-highwater.json`, increase
+  its tolerance, switch it from `host_free_pass`, skip the required job, or
+  mark known regressions as passes.
+- Do not weaken Test262 completeness, host-import leak classification,
+  timeout/error accounting, or the moving #1897 regression gate.
+- Do not treat runner cancellation, artifact absence, or a partial aggregate
+  as acceptance evidence.
+- Do not mix a speculative IR/legacy migration change into the diagnostic
+  checkpoint. Production ownership is assigned only after the first causal
+  boundary and exact path family are proven.
+
+The diagnosis may read any commit in `(fc6fd3…, 01fb676…]` and existing CI
+artifacts. Its first committed checkpoint is limited to this issue, a bounded
+path-transition manifest, and reusable verifier/test assets if they are needed.
+Once attribution is proven, amend this section with the exact production files
+before assigning implementation to Terra. Coordinate with the parallel Claude
+Program ABI/#3525 work and preserve every unrelated worktree change.
+
+### Phase A — preserve and authenticate the two endpoints
+
+1. Recover the full raw standalone JSONL/report evidence for `fc6fd3…` and
+   `01fb676…` from the persistent blobs above. Record run ID, available
+   artifact ID, exact compressed and JSONL byte lengths, SHA-256, Git blob,
+   compiler SHA, runtime-provider SHA, Node/pnpm versions, Test262 revision,
+   shard count, and exact command/environment contract. Mark the historical
+   `fc6fd3…` Actions artifact as expired; do not manufacture unavailable raw
+   stream evidence.
+2. Validate each endpoint before comparison:
+   - exactly 48,735 unique canonical test keys;
+   - no missing, duplicate, malformed, or foreign row;
+   - exact shard census and successful completeness validator;
+   - every comparison row retained in the durable content-addressed JSONL;
+   - available run stdout/stderr and artifact references retained without
+     treating their historical absence as row evidence;
+   - finite, non-negative load metadata where a local replay is used.
+3. Produce one deterministic, sorted transition manifest. Every row names the
+   test key, baseline/candidate statuses, host-import sets, compile/runtime
+   outcome, timeout duration, and error class. Retain any content hash the
+   authenticated historical row actually carries, but do not invent
+   compiler/runtime/source hash aliases absent from the producer schema;
+   endpoint and oracle provenance are authenticated separately. Canonical input
+   reordering must not change the semantic-row or transition digest.
+4. Add fail-closed manifest mutations for a dropped row, duplicate key,
+   unknown path, wrong endpoint SHA, status rewrite, missing import set,
+   malformed timing, and digest-preserving reorder control.
+
+Raw 48,735-row reports need not be committed, but the plan and verifier must
+make their content-addressed evidence recoverable. Compact totals without raw
+or referenced rows are diagnostic summaries, not acceptance evidence.
+
+#### Endpoint evidence schema correction (2026-08-30 Sol audit)
+
+The persistent endpoint bytes contradict a hypothetical schema in which every
+host-free row literally contains `imports: []`. Both the `fc6fd3…` stream at
+baseline commit `9657d806…` and the `01fb676…` stream at baseline commit
+`f0d6b57d…` are oracle-version 13, `oracle_lane: "honest"` producer rows. Their
+producer records `imports` and `host_import_leak_class` only when the import set
+is nonempty; an empty set is encoded by both fields being absent. This is the
+authenticated historical producer contract, not permission for a generic
+reader to guess that an omitted field means empty.
+
+The Phase A verifier must therefore enforce all of the following:
+
+1. Raw input authentication is mandatory and external to the report JSON. The
+   immutable production policy supplies the expected byte length, SHA-256, and
+   Git blob for each JSONL and each report JSON; the build API takes the raw
+   bytes, and the CLI takes only paths to those bytes, then validates them
+   against that policy before parsing. Neither production entry point accepts
+   caller-supplied descriptors as authority. Optional lookalike fields inside
+   mutable report metadata are not an authority. The frozen JSONL descriptors
+   remain those in the table above.
+   The newly recorded report descriptors are:
+   - `fc6fd3…`: 108,028 bytes, SHA-256
+     `e5626e5a57a37d9e29a051be0d5175e7771dd1cf5bf237065e43fbb586d82147`,
+     Git blob `3b34346a96caef48484f939a7ca6d0c030802ccb`;
+   - `01fb676…`: 110,636 bytes, SHA-256
+     `8738617eefa12fe0bc54ddfb7773d21635b9bb6b68850a1b09ed4e3cc5584b20`,
+     Git blob `7a033b31cb16947a1d1bfcbba2ddabe1a2734b62`.
+2. The real producer schema is the semantic-row authority. Retain and
+   canonicalize its timestamp, oracle version/lane/fast revision, file,
+   category, status, error fields/signature, reached-test flag, timing, scope,
+   official/strict/scope-reason fields, retry fields, import/leak evidence,
+   vacuity/hard-error fields, and any actual Wasm hash. Reject an unrecognized
+   key instead of silently dropping it from the endpoint digest. Every row's
+   oracle identity must match the authenticated report metadata.
+3. Only after the endpoint bytes, report bytes, endpoint SHA, oracle version,
+   honest lane, and exact producer schema all authenticate may the historical
+   absent pair (`imports`, `host_import_leak_class`) canonicalize to an empty
+   import set and null leak class. Explicit nonempty imports remain sorted and
+   deduplicated only in the semantic projection; inconsistent explicit fields
+   fail closed. A future or unknown producer with omitted import evidence is
+   refused.
+4. Publish two different digests. The mandatory raw-byte descriptors are
+   order-sensitive provenance. The full canonical semantic-row digest sorts by
+   canonical test key and is invariant to input-row order while binding every
+   recognized field. Reordering a stream must recompute its raw descriptors;
+   only the semantic-row and transition digests remain stable. Never claim the
+   entire manifest or raw endpoint digest is byte-identical after reorder.
+5. Mutations cover oracle version/lane, timestamp, scope/retry fields, an
+   unknown field, absent imports under an unauthenticated producer, wrong raw
+   JSONL/report bytes/hash/blob, and a non-transition semantic rewrite, in
+   addition to the Phase A mutations above. None may pass by recomputing only a
+   transition digest.
+
+6. Reconcile the authenticated report with the authenticated JSONL instead of
+   treating the two raw descriptors as unrelated provenance. The two preserved
+   report blobs have the exact top-level key set
+   `baseline_generated_at`, `baseline_sha`, `categories`,
+   `error_categories`, `full_summary`, `hard_errors`, `mode`,
+   `official_summary`, `oracle_version`, `root_cause_map`, `scope_summaries`,
+   `skip_reasons`, `strict_summary`, `summary`, and `timestamp`. Neither report
+   carries `oracle_lane` or `oracle_fast_rev`; require version 13 from the
+   report, bind honest lane and null fast revision through the externally
+   authenticated endpoint expectation plus every JSONL row, and reject any
+   contradictory optional report field if a future producer adds one. Derive
+   `total`, every verdict-status count, `compilable`, `host_free_pass`, and
+   `stale` from the complete parsed JSONL and require exact equality with the
+   report's `full_summary`; require `total` to equal the expected-key census.
+   Add mutations for a mismatched report total, status bucket,
+   `host_free_pass`, `compilable`, and stale count. A byte-authenticated report
+   paired with a different byte-authenticated JSONL is not a valid endpoint.
+
+The raw-free form of the manifest verifier is a structural/content-address
+validator only: it can validate canonical transition rows and the format of
+the endpoint digests, but it cannot recompute semantic endpoint evidence from
+bytes it was not given. Acceptance and CLI publication must always invoke the
+authenticated build/replay path with both raw streams and their immutable
+descriptors. Tests must prove that simultaneous edits to endpoint totals or a
+non-transition semantic digest are rejected when authenticated build options
+are supplied; documentation and call sites must not describe raw-free
+verification as provenance authentication.
+
+#### Pinned Phase A endpoint policy
+
+The issue-specific CLI and acceptance wrapper must not accept caller-invented
+descriptors as authority. Pin the following policy in source and require an
+exact match before parsing:
+
+| Endpoint | Tested commit | Baseline-store commit / tree | JSONL path / blob | Report path / blob | Report mode |
+| --- | --- | --- | --- | --- | --- |
+| baseline | `fc6fd3b5f3df1fbce731bf74c391aca41fcd08c2` | `9657d806b1d6ed0f54256c74b390f232677bd8e4` / `135a3c26544ea44409d93e8f3b9e7d6bfcc3326b` | `test262-standalone-current.jsonl` / `f762926801f85f7bb630b53e9d727647ecc45d94` | `test262-standalone-current.json` / `3b34346a96caef48484f939a7ca6d0c030802ccb` | `target=standalone`, `include_proposals=0`, `official test262 (default scope)` |
+| candidate | `01fb67624e2f645b7e92dd9f8e47478e3face9ba` | `f0d6b57da9362471decffeb6f3d98d650d477bd5` / `aa8f1f95b9d3da3c5ae60d3a71abe53d23733e50` | `test262-standalone-current.jsonl` / `3b99ba94b2a1a8625f869a84464bd497eeb732c0` | `test262-standalone-current.json` / `7a033b31cb16947a1d1bfcbba2ddabe1a2734b62` | `target=standalone`, `include_proposals=1`, `official test262 + proposals` |
+
+Both endpoints have exactly 48,735 canonical keys and the same sorted key-list
+SHA-256 `d5da0c8e80b17c9617275dd9d2feb84288b4ec9fd7d03578a763995648d85c6f`.
+The baseline full-summary vector is
+`pass=33876, fail=9506, compile_error=5227, compile_timeout=12, skip=114,
+compilable=43382, host_free_pass=33876, stale=0`; the candidate vector is
+`pass=32581, fail=10122, compile_error=5755, compile_timeout=163, skip=114,
+compilable=42703, host_free_pass=32581, stale=0`. The JSONL and report byte,
+SHA-256, and blob descriptors remain the values recorded above. The CLI may
+take file paths to those raw bytes but must source authority from this policy,
+not from user-supplied expected JSON. A generic fixture helper may accept a
+test-only policy, but it is not an acceptance API and the production CLI must
+never call it.
+
+### Phase B — locate every causal boundary
+
+This interval may contain several independent regressions and improvements;
+ordinary aggregate binary search is unsound because the count is not
+monotonic. Use path-vector segmentation:
+
+1. In a clone whose history is verified complete through both endpoints,
+   enumerate and assert exactly 83 first-parent transitions / 84 snapshots in
+   `(fc6fd3…, 01fb676…]`, while retaining all 332 reachable DAG commits for
+   provenance. Classify each transition's touched production, runtime,
+   harness, provider, workflow, and baseline files. Fail closed on a shallow
+   boundary or census drift. Do not exclude a commit merely because its title
+   says docs or CI.
+2. Start with the canonical 1,764-regression path set plus all 469 raw
+   improvements, not the full count alone. Replay that scoped union for all 84
+   first-parent snapshots in isolated detached worktrees, using each snapshot's
+   exact historical compiler/runtime/provider/harness/corpus/config dependency
+   closure and the same no-host-import predicate. At a dependency-changing
+   boundary, add a cross-pin replay only to distinguish compiler behavior from
+   provider/harness/corpus behavior; never replace the historical primary
+   observation with one endpoint-wide pin. Record each path's canonical
+   status, import set, error signature, and timing at every snapshot. Parallel
+   execution is allowed only when every child independently passes the strict
+   load gate.
+3. Coalesce adjacent snapshots only when the complete Test262-relevant
+   dependency hash (compiler, runtime, provider, harness, corpus, config, and
+   workflow inputs) is byte-identical. Otherwise every one of the 84 snapshots
+   must be observed. Midpoint/endpoint pruning is forbidden: equal half
+   endpoints can conceal pass→fail→pass or signature A→B→A excursions.
+4. Derive every adjacent pass→fail, fail→pass, and signature-change edge for
+   every path. Preserve multi-transition histories such as
+   pass→fail→pass→fail; do not report only the final or nearest loss. Cluster
+   first/final loss edges by exact failure signature, then refine each
+   implicated first-parent merge across that PR's unique commits.
+5. Replay deterministic parent/child boundaries twice. Rerun only timeout or
+   otherwise unstable paths a third time, serialized under the strict load
+   gate, before classifying them as semantic. Runner cancellation never
+   supplies a status vector. Run the complete 48,735-test lane after a bounded
+   repair candidate exists; scoped vectors locate causes, while the final full
+   lane proves aggregate recovery and detects collateral paths outside the
+   seed manifest.
+
+The output is a signed causal ledger mapping every one of the 1,764 endpoint
+regressions to a first causal commit or an explicit still-unattributed HOLD.
+Do not begin a broad production repair while any large path family remains
+unattributed.
+
+### Phase C — classify before repairing
+
+For each causal family, preserve the legacy optimization and standalone
+host-free contracts:
+
+- `host_import_leak`: compare exact import module/name/type projections and
+  locate the first newly required host capability. A test is not repaired by
+  relabeling the import, excluding the path, or loosening leak classification.
+- `assertion_fail` and other runtime outcomes: compare emitted Wasm/WAT,
+  exported ABI, instantiation/start protocol, and exact runtime value/error.
+  Separate compiler miscompile, runtime shim, test harness, and oracle changes.
+- `compile_timeout`: compare compilation phase timings and emitted artifact
+  census under serialized low load. A timeout may be accepted as runner noise
+  only when repeated evidence proves the same source/compiler result.
+- IR/direct ownership changes: compare source-qualified unit selection,
+  outcomes, imports/exports, fallback reasons, and optimized body shape. Fixing
+  the pass count must not restore a legacy route or drop an optimization that
+  the migration has already made IR-owned.
+
+Amend this issue with one bounded repair slice per independent cause. Each
+slice must name exact files, path set, expected pass recovery, mutation
+controls, and rollback behavior before code edits begin.
+
+### Acceptance matrix
+
+The final repair series is accepted only when all of the following hold:
+
+1. Apply the same bounded repair patch, without rewriting history, atop
+   isolated descendants of the immutable `01fb676…` endpoint, refreshed
+   current `main`, and the current #5295/#5308 combined tree. Each descendant
+   runs the complete 48,735-test standalone lane with
+   `host_free_pass >= 33,826` (the unchanged 33,876 mark minus 50).
+2. The canonical transition manifest reports zero unexplained baseline-pass
+   regressions. Any intentionally changed path has a separate reviewed
+   semantic acceptance record; aggregate offsetting improvements do not hide
+   it.
+3. No new host imports, hard compiler errors, completeness failures, or stable
+   compile-timeout growth are introduced. The host lane and moving #1897 gate
+   remain non-regressing.
+4. The high-water JSON and tolerance are unchanged during repair. After a
+   protected merge, normal `--update` behavior may ratchet the mark upward but
+   may never lower it.
+5. PR #5295 and #5308 are re-synthesized by the normal protected queue from
+   their unchanged reviewed heads and pass their own required checks. No admin
+   merge, direct merge, or queue bypass is permitted.
+
+Every heavy command samples a finite, non-negative one-minute load strictly
+below logical cores minus two immediately before execution and uses an
+archive-backed `TMPDIR`. Run the relevant focused tests, both TypeScript
+lanes, Test262 completeness/diff/hard-error/high-water validators, IR
+layering/fallback/kind-neutrality/IR-only gates, and optimization ledgers.
+Immediately before every commit run the LOC and function-growth ratchets.
+Keep all precommit and prepush hooks enabled, sign every commit, and require a
+fresh independent Sol review of the exact pushed SHA before readiness or queue
+entry.

--- a/scripts/standalone-highwater-transition-manifest.mjs
+++ b/scripts/standalone-highwater-transition-manifest.mjs
@@ -1,0 +1,1114 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2097 -- read-only, fail-closed standalone high-water transition evidence.
+// Production acceptance uses the immutable policy below. It receives raw
+// endpoint bytes and a raw expected-key census only; no caller-supplied
+// descriptor can replace the policy's commits, blobs, vector, or mode.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { TEST262_VERDICT_STATUSES } from "./validate-test262-completeness.mjs";
+
+export const TRANSITION_MANIFEST_SCHEMA = "standalone-highwater-transition-manifest-v3";
+export const PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST = "test262-record-result-v13-honest";
+
+const OWN = Object.prototype.hasOwnProperty;
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+const GIT_SHA = /^[0-9a-f]{40}$/;
+const STATUS_BUCKETS = Object.freeze(["pass", "fail", "compile_error", "compile_timeout", "skip"]);
+const STATUS_BUCKET_SET = new Set(STATUS_BUCKETS);
+const STRICT_VALUES = new Set(["only", "no", "both"]);
+const SCOPE_VALUES = new Set(["standard", "annex_b", "proposal"]);
+const BASELINE_ROW_FIELDS = Object.freeze([
+  "category",
+  "compile_ms",
+  "error",
+  "error_category",
+  "error_signature",
+  "exec_ms",
+  "file",
+  "host_import_leak_class",
+  "imports",
+  "oracle_lane",
+  "oracle_version",
+  "poison_healed",
+  "reached_test",
+  "retried",
+  "retry_count",
+  "scope",
+  "scope_official",
+  "scope_reason",
+  "status",
+  "strict",
+  "timestamp",
+]);
+const CANDIDATE_ROW_FIELDS = Object.freeze(BASELINE_ROW_FIELDS.filter((field) => field !== "poison_healed"));
+const ROW_FIELD_SETS = {
+  baseline: new Set(BASELINE_ROW_FIELDS),
+  candidate: new Set(CANDIDATE_ROW_FIELDS),
+};
+const REPORT_TOP_LEVEL_FIELDS = Object.freeze([
+  "baseline_generated_at",
+  "baseline_sha",
+  "categories",
+  "error_categories",
+  "full_summary",
+  "hard_errors",
+  "mode",
+  "official_summary",
+  "oracle_version",
+  "root_cause_map",
+  "scope_summaries",
+  "skip_reasons",
+  "strict_summary",
+  "summary",
+  "timestamp",
+]);
+const FULL_SUMMARY_FIELDS = Object.freeze([
+  "compilable",
+  "compile_error",
+  "compile_timeout",
+  "fail",
+  "host_free_pass",
+  "pass",
+  "skip",
+  "stale",
+  "total",
+]);
+const MODE_FIELDS = Object.freeze(["include_proposals", "label", "target"]);
+const MANIFEST_SUMMARY_FIELDS = Object.freeze([
+  "baseline_host_free_pass",
+  "candidate_host_free_pass",
+  "net_host_free_pass",
+  "raw_host_free_improvements",
+  "raw_host_free_regressions",
+]);
+
+function deepFreeze(value) {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const key of Object.keys(value)) deepFreeze(value[key]);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+// `baseline_sha` is the tested compiler commit. `baselineStore*` identifies
+// the immutable js2wasm-baselines object that supplied the raw endpoint.
+export const STANDALONE_HIGHWATER_TRANSITION_POLICY = deepFreeze({
+  id: "issue-2097-standalone-highwater-transition-v1",
+  expectedKeyCensus: {
+    count: 48735,
+    sortedKeysSha256: "d5da0c8e80b17c9617275dd9d2feb84288b4ec9fd7d03578a763995648d85c6f",
+  },
+  endpoints: {
+    baseline: {
+      testedCommitSha: "fc6fd3b5f3df1fbce731bf74c391aca41fcd08c2",
+      baselineStoreCommitSha: "9657d806b1d6ed0f54256c74b390f232677bd8e4",
+      baselineStoreTreeSha: "135a3c26544ea44409d93e8f3b9e7d6bfcc3326b",
+      paths: { jsonl: "test262-standalone-current.jsonl", report: "test262-standalone-current.json" },
+      jsonl: {
+        bytes: 23209263,
+        sha256: "d3341cf6b6dbcc237f18f1461dc97dcddf1f2cbbfb944496d7ae73e8489adb87",
+        gitBlob: "f762926801f85f7bb630b53e9d727647ecc45d94",
+      },
+      report: {
+        bytes: 108028,
+        sha256: "e5626e5a57a37d9e29a051be0d5175e7771dd1cf5bf237065e43fbb586d82147",
+        gitBlob: "3b34346a96caef48484f939a7ca6d0c030802ccb",
+      },
+      oracle: { version: 13, lane: "honest", fastRev: null },
+      producerSchema: PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST,
+      mode: { target: "standalone", include_proposals: 0, label: "official test262 (default scope)" },
+      fullSummary: {
+        total: 48735,
+        pass: 33876,
+        fail: 9506,
+        compile_error: 5227,
+        compile_timeout: 12,
+        skip: 114,
+        compilable: 43382,
+        host_free_pass: 33876,
+        stale: 0,
+      },
+    },
+    candidate: {
+      testedCommitSha: "01fb67624e2f645b7e92dd9f8e47478e3face9ba",
+      baselineStoreCommitSha: "f0d6b57da9362471decffeb6f3d98d650d477bd5",
+      baselineStoreTreeSha: "aa8f1f95b9d3da3c5ae60d3a71abe53d23733e50",
+      paths: { jsonl: "test262-standalone-current.jsonl", report: "test262-standalone-current.json" },
+      jsonl: {
+        bytes: 23482700,
+        sha256: "5d6cb6e5a39fbb6e20c9ac655a1cc6987d6555c222ad42aab9dbb70b0ec23ff3",
+        gitBlob: "3b99ba94b2a1a8625f869a84464bd497eeb732c0",
+      },
+      report: {
+        bytes: 110636,
+        sha256: "8738617eefa12fe0bc54ddfb7773d21635b9bb6b68850a1b09ed4e3cc5584b20",
+        gitBlob: "7a033b31cb16947a1d1bfcbba2ddabe1a2734b62",
+      },
+      oracle: { version: 13, lane: "honest", fastRev: null },
+      producerSchema: PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST,
+      mode: { target: "standalone", include_proposals: 1, label: "official test262 + proposals" },
+      fullSummary: {
+        total: 48735,
+        pass: 32581,
+        fail: 10122,
+        compile_error: 5755,
+        compile_timeout: 163,
+        skip: 114,
+        compilable: 42703,
+        host_free_pass: 32581,
+        stale: 0,
+      },
+    },
+  },
+});
+
+export class TransitionManifestError extends Error {
+  constructor(code, message, details = undefined) {
+    super(code + ": " + message);
+    this.name = "TransitionManifestError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function refuse(code, message, details = undefined) {
+  throw new TransitionManifestError(code, message, details);
+}
+
+function hasOwn(value, key) {
+  return OWN.call(value, key);
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sameList(left, right) {
+  return left.length === right.length && left.every((item, index) => item === right[index]);
+}
+
+function assertExactKeys(value, expectedKeys, code, label) {
+  if (!isPlainObject(value)) refuse(code, label + " must be a plain object");
+  const actual = Object.keys(value).sort(compareText);
+  const expected = [...expectedKeys].sort(compareText);
+  if (!sameList(actual, expected)) refuse(code, label + " has unexpected fields: " + actual.join(", "));
+}
+
+function canonicalJson(value, label) {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) refuse("malformed-metadata", label + " has a non-finite number");
+    return Object.is(value, -0) ? 0 : value;
+  }
+  if (Array.isArray(value)) return value.map((item, index) => canonicalJson(item, label + "[" + index + "]"));
+  if (!isPlainObject(value)) refuse("malformed-metadata", label + " must contain JSON values only");
+  const out = {};
+  // Assignment to an ordinary object's `__proto__` key changes its prototype
+  // instead of preserving the JSON member. Define each own member explicitly
+  // so canonicalization remains a lossless JSON round trip for every key.
+  for (const key of Object.keys(value).sort(compareText)) {
+    Object.defineProperty(out, key, {
+      configurable: true,
+      enumerable: true,
+      value: canonicalJson(value[key], label + "." + key),
+      writable: true,
+    });
+  }
+  return out;
+}
+
+export function stableStringify(value) {
+  if (value === null) return "null";
+  if (typeof value === "string" || typeof value === "boolean") return JSON.stringify(value);
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) refuse("noncanonical-json", "cannot serialize a non-finite number");
+    return JSON.stringify(Object.is(value, -0) ? 0 : value);
+  }
+  if (Array.isArray(value)) return "[" + value.map(stableStringify).join(",") + "]";
+  if (!isPlainObject(value)) refuse("noncanonical-json", "cannot serialize a non-JSON object");
+  return (
+    "{" +
+    Object.keys(value)
+      .sort(compareText)
+      .map((key) => JSON.stringify(key) + ":" + stableStringify(value[key]))
+      .join(",") +
+    "}"
+  );
+}
+
+function sameCanonical(left, right) {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function sha256Bytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function sha256Text(text) {
+  return sha256Bytes(Buffer.from(text, "utf8"));
+}
+
+function gitBlobSha1(bytes) {
+  return createHash("sha1")
+    .update(Buffer.from("blob " + bytes.byteLength + "\0", "utf8"))
+    .update(bytes)
+    .digest("hex");
+}
+
+function canonicalCommitSha(value, label) {
+  if (typeof value !== "string" || !GIT_SHA.test(value))
+    refuse("wrong-endpoint-sha", label + " must be a lowercase 40-hex SHA");
+  return value;
+}
+
+function canonicalRawDescriptor(value, label) {
+  assertExactKeys(value, ["bytes", "gitBlob", "sha256"], "malformed-raw-evidence", label);
+  if (!Number.isSafeInteger(value.bytes) || value.bytes < 0)
+    refuse("malformed-raw-evidence", label + " has invalid bytes");
+  if (typeof value.sha256 !== "string" || !SHA256_HEX.test(value.sha256))
+    refuse("malformed-raw-evidence", label + " has invalid SHA-256");
+  if (typeof value.gitBlob !== "string" || !GIT_SHA.test(value.gitBlob))
+    refuse("malformed-raw-evidence", label + " has invalid Git blob");
+  return { bytes: value.bytes, sha256: value.sha256, gitBlob: value.gitBlob };
+}
+
+function emittedRawDescriptor(value) {
+  return { bytes: value.bytes, git_blob: value.gitBlob, sha256: value.sha256 };
+}
+
+function canonicalEmittedRawDescriptor(value, label) {
+  assertExactKeys(value, ["bytes", "git_blob", "sha256"], "malformed-raw-evidence", label);
+  return canonicalRawDescriptor({ bytes: value.bytes, gitBlob: value.git_blob, sha256: value.sha256 }, label);
+}
+
+function canonicalOracle(value, label) {
+  assertExactKeys(value, ["fastRev", "lane", "version"], "malformed-oracle-provenance", label);
+  if (value.version !== 13 || value.lane !== "honest" || value.fastRev !== null) {
+    refuse("producer-schema-provenance", label + " must be v13/honest/null");
+  }
+  return { fastRev: null, lane: "honest", version: 13 };
+}
+
+function emittedOracle(value) {
+  return { fast_rev: value.fastRev, lane: value.lane, version: value.version };
+}
+
+function canonicalEmittedOracle(value, label) {
+  assertExactKeys(value, ["fast_rev", "lane", "version"], "malformed-oracle-provenance", label);
+  return canonicalOracle({ fastRev: value.fast_rev, lane: value.lane, version: value.version }, label);
+}
+
+function canonicalMode(value, label) {
+  assertExactKeys(value, MODE_FIELDS, "malformed-metadata", label);
+  if (value.target !== "standalone") refuse("malformed-metadata", label + " target must be standalone");
+  if (value.include_proposals !== 0 && value.include_proposals !== 1)
+    refuse("malformed-metadata", label + " include_proposals must be 0 or 1");
+  if (typeof value.label !== "string" || value.label.length === 0)
+    refuse("malformed-metadata", label + " label must be nonempty text");
+  return { include_proposals: value.include_proposals, label: value.label, target: value.target };
+}
+
+function canonicalFullSummary(value, label) {
+  assertExactKeys(value, FULL_SUMMARY_FIELDS, "malformed-report-summary", label);
+  const out = {};
+  for (const key of FULL_SUMMARY_FIELDS) {
+    if (!Number.isSafeInteger(value[key]) || value[key] < 0)
+      refuse("malformed-report-summary", label + " has invalid " + key);
+    out[key] = value[key];
+  }
+  if (out.total !== out.pass + out.fail + out.compile_error + out.compile_timeout + out.skip) {
+    refuse("malformed-report-summary", label + " total does not equal all status buckets");
+  }
+  if (out.compilable !== out.pass + out.fail)
+    refuse("malformed-report-summary", label + " compilable must equal pass + fail");
+  if (out.host_free_pass > out.pass) refuse("malformed-report-summary", label + " host_free_pass exceeds pass");
+  if (out.stale !== 0) refuse("malformed-report-summary", label + " stale must be zero");
+  return out;
+}
+
+export function canonicalFileIdentity(value, label) {
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim())
+    refuse("malformed-file", label + " has invalid file identity");
+  if (
+    /[\0\r\n]/.test(value) ||
+    value.startsWith("/") ||
+    value.endsWith("/") ||
+    value.includes("\\") ||
+    value.includes("//")
+  ) {
+    refuse("malformed-file", label + " is not canonical");
+  }
+  if (value.split("/").some((part) => part === "" || part === "." || part === ".."))
+    refuse("malformed-file", label + " is not canonical");
+  return value;
+}
+
+function canonicalPolicyEndpoint(value, endpoint, allowUnknownProducerSchema) {
+  assertExactKeys(
+    value,
+    [
+      "baselineStoreCommitSha",
+      "baselineStoreTreeSha",
+      "fullSummary",
+      "jsonl",
+      "mode",
+      "oracle",
+      "paths",
+      "producerSchema",
+      "report",
+      "testedCommitSha",
+    ],
+    "malformed-policy",
+    endpoint + " endpoint policy",
+  );
+  if (typeof value.producerSchema !== "string" || value.producerSchema.length === 0)
+    refuse("unknown-producer-schema", endpoint + " policy producer schema is unknown");
+  if (!allowUnknownProducerSchema && value.producerSchema !== PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST)
+    refuse("unknown-producer-schema", endpoint + " policy producer schema is unknown");
+  assertExactKeys(value.paths, ["jsonl", "report"], "malformed-policy", endpoint + " policy paths");
+  return {
+    baselineStoreCommitSha: canonicalCommitSha(value.baselineStoreCommitSha, endpoint + " store commit"),
+    baselineStoreTreeSha: canonicalCommitSha(value.baselineStoreTreeSha, endpoint + " store tree"),
+    fullSummary: canonicalFullSummary(value.fullSummary, endpoint + " policy full_summary"),
+    jsonl: canonicalRawDescriptor(value.jsonl, endpoint + " policy JSONL"),
+    mode: canonicalMode(value.mode, endpoint + " policy mode"),
+    oracle: canonicalOracle(value.oracle, endpoint + " policy oracle"),
+    paths: {
+      jsonl: canonicalFileIdentity(value.paths.jsonl, endpoint + " policy JSONL path"),
+      report: canonicalFileIdentity(value.paths.report, endpoint + " policy report path"),
+    },
+    producerSchema: value.producerSchema,
+    report: canonicalRawDescriptor(value.report, endpoint + " policy report"),
+    testedCommitSha: canonicalCommitSha(value.testedCommitSha, endpoint + " tested commit"),
+  };
+}
+
+function canonicalPolicy(value, allowUnknownProducerSchema = false) {
+  assertExactKeys(value, ["endpoints", "expectedKeyCensus", "id"], "malformed-policy", "transition policy");
+  assertExactKeys(value.endpoints, ["baseline", "candidate"], "malformed-policy", "policy endpoints");
+  assertExactKeys(value.expectedKeyCensus, ["count", "sortedKeysSha256"], "malformed-policy", "policy key census");
+  if (!Number.isSafeInteger(value.expectedKeyCensus.count) || value.expectedKeyCensus.count <= 0)
+    refuse("malformed-policy", "policy key count is invalid");
+  if (
+    typeof value.expectedKeyCensus.sortedKeysSha256 !== "string" ||
+    !SHA256_HEX.test(value.expectedKeyCensus.sortedKeysSha256)
+  )
+    refuse("malformed-policy", "policy key digest is invalid");
+  if (typeof value.id !== "string" || value.id.length === 0) refuse("malformed-policy", "policy id is invalid");
+  const out = {
+    id: value.id,
+    expectedKeyCensus: {
+      count: value.expectedKeyCensus.count,
+      sortedKeysSha256: value.expectedKeyCensus.sortedKeysSha256,
+    },
+    endpoints: {
+      baseline: canonicalPolicyEndpoint(value.endpoints.baseline, "baseline", allowUnknownProducerSchema),
+      candidate: canonicalPolicyEndpoint(value.endpoints.candidate, "candidate", allowUnknownProducerSchema),
+    },
+  };
+  for (const endpoint of ["baseline", "candidate"]) {
+    if (out.endpoints[endpoint].fullSummary.total !== out.expectedKeyCensus.count) {
+      refuse("malformed-policy", endpoint + " policy total does not match the key census");
+    }
+  }
+  return out;
+}
+
+function rawBytes(value, label) {
+  if (!Buffer.isBuffer(value)) refuse("missing-raw-build-input", label + " must be a raw Buffer");
+  return Buffer.from(value);
+}
+
+function decodeUtf8(bytes, label) {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch (error) {
+    refuse(
+      "malformed-raw-evidence",
+      label + " is not strict UTF-8: " + (error instanceof Error ? error.message : String(error)),
+    );
+  }
+}
+
+function rawDescriptor(bytes) {
+  return { bytes: bytes.byteLength, sha256: sha256Bytes(bytes), gitBlob: gitBlobSha1(bytes) };
+}
+
+function authenticateRaw(bytes, expected, endpoint, kind) {
+  const actual = rawDescriptor(bytes);
+  if (!sameCanonical(actual, expected)) {
+    refuse(
+      "raw-" + kind + "-evidence-mismatch",
+      endpoint + " " + kind + " does not match the immutable #2097 raw descriptor",
+      { actual, expected },
+    );
+  }
+}
+
+function canonicalBuildInputs(value) {
+  assertExactKeys(value, ["baseline", "candidate", "expectedKeys"], "missing-raw-build-input", "build inputs");
+  const endpoint = (item, label) => {
+    assertExactKeys(item, ["jsonl", "report"], "missing-raw-build-input", label + " input");
+    return { jsonl: rawBytes(item.jsonl, label + " JSONL"), report: rawBytes(item.report, label + " report") };
+  };
+  return {
+    baseline: endpoint(value.baseline, "baseline"),
+    candidate: endpoint(value.candidate, "candidate"),
+    expectedKeys: rawBytes(value.expectedKeys, "expected key census"),
+  };
+}
+
+function requiredText(value, field, label) {
+  if (typeof value !== "string" || value.length === 0) refuse("malformed-row", label + " has invalid " + field);
+  return value;
+}
+
+function optionalText(record, field, label) {
+  return hasOwn(record, field) ? requiredText(record[field], field, label) : null;
+}
+
+function requiredBoolean(record, field, label) {
+  if (typeof record[field] !== "boolean") refuse("malformed-row", label + " has invalid " + field);
+  return record[field];
+}
+
+function optionalBoolean(record, field, label) {
+  return hasOwn(record, field) ? requiredBoolean(record, field, label) : null;
+}
+
+function optionalNumber(record, field, label) {
+  if (!hasOwn(record, field)) return null;
+  if (!Number.isSafeInteger(record[field]) || record[field] < 0)
+    refuse("malformed-timing", label + " has invalid " + field);
+  return record[field];
+}
+
+function canonicalImports(record, expected, label) {
+  const hasImports = hasOwn(record, "imports");
+  const hasLeak = hasOwn(record, "host_import_leak_class");
+  if (!hasImports && !hasLeak) {
+    if (expected.producerSchema !== PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST)
+      refuse("unauthenticated-import-omission", label + " omitted imports under unknown producer");
+    return { imports: [], host_import_leak_class: null, imports_evidence: "authenticated_producer_omission" };
+  }
+  if (!hasImports || !hasLeak || !Array.isArray(record.imports) || record.imports.length === 0) {
+    refuse("inconsistent-import-evidence", label + " must provide a nonempty imports/leak pair");
+  }
+  if (typeof record.host_import_leak_class !== "string" || record.host_import_leak_class.length === 0) {
+    refuse("inconsistent-import-evidence", label + " has invalid host_import_leak_class");
+  }
+  const seen = new Set();
+  const imports = [];
+  for (let index = 0; index < record.imports.length; index++) {
+    const item = record.imports[index];
+    if (typeof item !== "string" || item.length === 0 || /[\0\r\n]/.test(item))
+      refuse("inconsistent-import-evidence", label + " has invalid imports[" + index + "]");
+    if (!seen.has(item)) {
+      seen.add(item);
+      imports.push(item);
+    }
+  }
+  return {
+    imports: imports.sort(compareText),
+    host_import_leak_class: record.host_import_leak_class,
+    imports_evidence: "explicit_nonempty",
+  };
+}
+
+export function isStandaloneHostFreePass(row) {
+  return (
+    row?.status === "pass" &&
+    Array.isArray(row.imports) &&
+    row.imports.length === 0 &&
+    row.host_import_leak_class === null
+  );
+}
+
+function canonicalRow(record, endpoint, expected, line, observedFields) {
+  const label = endpoint + " JSONL line " + line;
+  if (!isPlainObject(record)) refuse("malformed-row", label + " must be a plain object");
+  for (const field of Object.keys(record)) {
+    if (!ROW_FIELD_SETS[endpoint].has(field))
+      refuse("unrecognized-row-field", label + " contains unsupported field " + field);
+    observedFields.add(field);
+  }
+  if (record.oracle_version !== expected.oracle.version || record.oracle_lane !== expected.oracle.lane) {
+    refuse("oracle-provenance-mismatch", label + " contradicts the pinned v13 honest provenance");
+  }
+  if (
+    typeof record.status !== "string" ||
+    !TEST262_VERDICT_STATUSES.has(record.status) ||
+    !STATUS_BUCKET_SET.has(record.status)
+  ) {
+    refuse("malformed-status", label + " has unknown status " + JSON.stringify(record.status));
+  }
+  if (!SCOPE_VALUES.has(record.scope) || !STRICT_VALUES.has(record.strict))
+    refuse("malformed-row", label + " has invalid scope or strict mode");
+  const hasRetryCount = hasOwn(record, "retry_count");
+  const retryCount = hasRetryCount ? record.retry_count : null;
+  if (hasRetryCount && (!Number.isSafeInteger(retryCount) || retryCount <= 0))
+    refuse("malformed-row", label + " has invalid retry_count");
+  const retried = optionalBoolean(record, "retried", label);
+  if ((retried === null) !== (retryCount === null) || (retried !== null && retried !== true))
+    refuse("malformed-row", label + " has inconsistent retry evidence");
+  const imports = canonicalImports(record, expected, label);
+  // The report builder does not count an imported/leaky raw `pass` as a
+  // standalone pass. Current pinned streams contain none; reject one rather
+  // than silently letting it masquerade as a non-host-free pass here.
+  if (record.status === "pass" && imports.imports_evidence === "explicit_nonempty") {
+    refuse("non-host-free-pass", label + " is pass despite explicit host-import evidence");
+  }
+  const row = {
+    category: requiredText(record.category, "category", label),
+    error: optionalText(record, "error", label),
+    error_category: optionalText(record, "error_category", label),
+    error_signature: optionalText(record, "error_signature", label),
+    file: canonicalFileIdentity(record.file, label),
+    host_free_pass: false,
+    host_import_leak_class: imports.host_import_leak_class,
+    imports: imports.imports,
+    imports_evidence: imports.imports_evidence,
+    oracle_fast_rev: expected.oracle.fastRev,
+    oracle_lane: expected.oracle.lane,
+    oracle_version: expected.oracle.version,
+    poison_healed: endpoint === "baseline" ? optionalBoolean(record, "poison_healed", label) : null,
+    reached_test: requiredBoolean(record, "reached_test", label),
+    retried,
+    retry_count: retryCount,
+    scope: record.scope,
+    scope_official: requiredBoolean(record, "scope_official", label),
+    scope_reason: optionalText(record, "scope_reason", label),
+    status: record.status,
+    strict: record.strict,
+    timestamp: requiredText(record.timestamp, "timestamp", label),
+    timing: {
+      compile_ms: optionalNumber(record, "compile_ms", label),
+      exec_ms: optionalNumber(record, "exec_ms", label),
+    },
+  };
+  if (row.status === "compile_timeout" && row.timing.compile_ms === null)
+    refuse("malformed-timing", label + " timeout has no compile_ms");
+  row.host_free_pass = isStandaloneHostFreePass(row);
+  return row;
+}
+
+function expectedRowFields(endpoint) {
+  return endpoint === "baseline" ? BASELINE_ROW_FIELDS : CANDIDATE_ROW_FIELDS;
+}
+
+function fieldSetSha256(fields) {
+  return sha256Text([...fields].sort(compareText).join("\n") + "\n");
+}
+
+function parseJsonl(bytes, endpoint, expected) {
+  const rows = new Map();
+  const observedFields = new Set();
+  const lines = decodeUtf8(bytes, endpoint + " JSONL").split("\n");
+  for (let index = 0; index < lines.length; index++) {
+    const text = lines[index];
+    if (text === "" && index === lines.length - 1) continue;
+    if (text.trim() === "") refuse("blank-record", endpoint + " JSONL line " + (index + 1) + " is blank");
+    let record;
+    try {
+      record = JSON.parse(text);
+    } catch (error) {
+      refuse(
+        "malformed-json",
+        endpoint +
+          " JSONL line " +
+          (index + 1) +
+          " is invalid JSON: " +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    }
+    const row = canonicalRow(record, endpoint, expected, index + 1, observedFields);
+    if (rows.has(row.file)) refuse("duplicate-key", endpoint + " JSONL repeats " + row.file);
+    rows.set(row.file, { line: index + 1, row });
+  }
+  if (rows.size === 0) refuse("empty-endpoint", endpoint + " JSONL contains no rows");
+  if (!sameList([...observedFields].sort(compareText), expectedRowFields(endpoint).slice().sort(compareText))) {
+    refuse("field-universe-mismatch", endpoint + " JSONL does not have the authenticated v13 field universe");
+  }
+  return rows;
+}
+
+function parseReport(bytes, endpoint, expected) {
+  let metadata;
+  try {
+    metadata = JSON.parse(decodeUtf8(bytes, endpoint + " report"));
+  } catch (error) {
+    refuse(
+      "malformed-report-json",
+      endpoint + " report is invalid JSON: " + (error instanceof Error ? error.message : String(error)),
+    );
+  }
+  if (!isPlainObject(metadata)) refuse("malformed-metadata", endpoint + " report must be a plain object");
+  // Historical reports omit these fields. A contradiction gets its specific
+  // error before the exact historical key universe rejects the expansion.
+  if (hasOwn(metadata, "oracle_lane") && metadata.oracle_lane !== expected.oracle.lane)
+    refuse("oracle-provenance-mismatch", endpoint + " report oracle_lane contradicts policy");
+  if (hasOwn(metadata, "oracle_fast_rev") && metadata.oracle_fast_rev !== expected.oracle.fastRev)
+    refuse("oracle-provenance-mismatch", endpoint + " report oracle_fast_rev contradicts policy");
+  assertExactKeys(metadata, REPORT_TOP_LEVEL_FIELDS, "report-key-universe-mismatch", endpoint + " report");
+  if (metadata.baseline_sha !== expected.testedCommitSha)
+    refuse("wrong-endpoint-sha", endpoint + " report baseline_sha contradicts policy");
+  if (metadata.oracle_version !== expected.oracle.version)
+    refuse("oracle-provenance-mismatch", endpoint + " report oracle_version contradicts policy");
+  if (
+    typeof metadata.baseline_generated_at !== "string" ||
+    metadata.baseline_generated_at.length === 0 ||
+    typeof metadata.timestamp !== "string" ||
+    metadata.timestamp.length === 0
+  ) {
+    refuse("malformed-metadata", endpoint + " report timestamps must be nonempty text");
+  }
+  const mode = canonicalMode(metadata.mode, endpoint + " report mode");
+  if (!sameCanonical(mode, expected.mode)) refuse("report-mode-mismatch", endpoint + " report mode contradicts policy");
+  const fullSummary = canonicalFullSummary(metadata.full_summary, endpoint + " report full_summary");
+  if (!sameCanonical(fullSummary, expected.fullSummary))
+    refuse("pinned-summary-mismatch", endpoint + " report full_summary contradicts policy");
+  return canonicalJson(metadata, endpoint + " report");
+}
+
+function parseExpectedKeys(bytes) {
+  const lines = decodeUtf8(bytes, "expected key census").split(/\r?\n/);
+  const keys = [];
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (line === "" && index === lines.length - 1) continue;
+    if (line.trim() === "") refuse("missing-expected-census", "expected key census line " + (index + 1) + " is blank");
+    keys.push(canonicalFileIdentity(line, "expected key census line " + (index + 1)));
+  }
+  const sorted = [...new Set(keys)].sort(compareText);
+  if (keys.length === 0 || sorted.length !== keys.length)
+    refuse("duplicate-expected-key", "expected key census is empty or duplicates a path");
+  return sorted;
+}
+
+export function parseExpectedKeyCensus(text) {
+  if (typeof text !== "string") refuse("missing-expected-census", "expected key census must be text");
+  return parseExpectedKeys(Buffer.from(text, "utf8"));
+}
+
+function assertKeyPolicy(keys, policy) {
+  if (
+    keys.length !== policy.expectedKeyCensus.count ||
+    sha256Text(keys.join("\n") + "\n") !== policy.expectedKeyCensus.sortedKeysSha256
+  ) {
+    refuse("expected-key-census-mismatch", "expected key census does not match immutable #2097 policy");
+  }
+}
+
+function assertCensus(rows, keys, endpoint) {
+  const expected = new Set(keys);
+  for (const key of keys) if (!rows.has(key)) refuse("dropped-key", endpoint + " is missing " + key);
+  for (const key of rows.keys()) if (!expected.has(key)) refuse("foreign-key", endpoint + " has foreign " + key);
+}
+
+function summarizeRows(rows) {
+  const summary = {
+    total: rows.size,
+    pass: 0,
+    fail: 0,
+    compile_error: 0,
+    compile_timeout: 0,
+    skip: 0,
+    compilable: 0,
+    host_free_pass: 0,
+    stale: 0,
+  };
+  for (const { row } of rows.values()) {
+    summary[row.status]++;
+    if (row.host_free_pass) summary.host_free_pass++;
+  }
+  summary.compilable = summary.pass + summary.fail;
+  return summary;
+}
+
+function assertReportReconciles(metadata, rows, policy, endpoint) {
+  const actual = summarizeRows(rows);
+  for (const key of FULL_SUMMARY_FIELDS) {
+    if (metadata.full_summary[key] !== actual[key])
+      refuse("report-jsonl-summary-mismatch", endpoint + " report " + key + " does not match parsed JSONL");
+  }
+  if (
+    actual.total !== policy.expectedKeyCensus.count ||
+    !sameCanonical(actual, policy.endpoints[endpoint].fullSummary)
+  ) {
+    refuse("pinned-summary-mismatch", endpoint + " parsed JSONL does not match immutable endpoint vector");
+  }
+}
+
+function canonicalSemanticRowsJsonl(rows) {
+  return (
+    [...rows.values()]
+      .map((entry) => entry.row)
+      .sort((a, b) => compareText(a.file, b.file))
+      .map(stableStringify)
+      .join("\n") + "\n"
+  );
+}
+
+export function semanticRowsSha256(rows) {
+  if (!(rows instanceof Map)) refuse("malformed-manifest", "semantic rows must be a parsed map");
+  return sha256Text(canonicalSemanticRowsJsonl(rows));
+}
+
+// Structural-only compatibility digest. It never authenticates raw bytes and
+// is not used by public acceptance, render, or the fixed-policy CLI.
+export const endpointRowsSha256StructuralOnly = semanticRowsSha256;
+
+function buildEndpoint(raw, policyEndpoint, endpoint) {
+  authenticateRaw(raw.jsonl, policyEndpoint.jsonl, endpoint, "jsonl");
+  authenticateRaw(raw.report, policyEndpoint.report, endpoint, "report");
+  const metadata = parseReport(raw.report, endpoint, policyEndpoint);
+  const rows = parseJsonl(raw.jsonl, endpoint, policyEndpoint);
+  return { metadata, rows };
+}
+
+function endpointEvidence(policyEndpoint, endpointData, endpoint) {
+  const fields = expectedRowFields(endpoint);
+  return {
+    baseline_store_commit_sha: policyEndpoint.baselineStoreCommitSha,
+    baseline_store_tree_sha: policyEndpoint.baselineStoreTreeSha,
+    commit_sha: policyEndpoint.testedCommitSha,
+    oracle: emittedOracle(policyEndpoint.oracle),
+    paths: { ...policyEndpoint.paths },
+    pinned_full_summary: { ...policyEndpoint.fullSummary },
+    producer_schema: policyEndpoint.producerSchema,
+    raw_jsonl: emittedRawDescriptor(policyEndpoint.jsonl),
+    raw_report: emittedRawDescriptor(policyEndpoint.report),
+    row_field_count: fields.length,
+    row_fields_sha256: fieldSetSha256(fields),
+    semantic_row_count: endpointData.rows.size,
+    semantic_rows_sha256: semanticRowsSha256(endpointData.rows),
+  };
+}
+
+function transitionKind(baseline, candidate) {
+  if (baseline.host_free_pass && !candidate.host_free_pass) return "raw_host_free_regression";
+  if (!baseline.host_free_pass && candidate.host_free_pass) return "raw_host_free_improvement";
+  return null;
+}
+
+function transitionEvidence(row) {
+  const evidence = { ...row };
+  delete evidence.file;
+  return evidence;
+}
+
+export function canonicalTransitionRowsJsonl(rows) {
+  if (!Array.isArray(rows)) refuse("malformed-manifest", "transitions must be an array");
+  return rows.map(stableStringify).join("\n") + (rows.length ? "\n" : "");
+}
+
+export function transitionRowsSha256(rows) {
+  return sha256Text(canonicalTransitionRowsJsonl(rows));
+}
+
+function buildWithPolicy(rawBuildInputs, suppliedPolicy, allowUnknownProducerSchema = false) {
+  const policy = canonicalPolicy(suppliedPolicy, allowUnknownProducerSchema);
+  const raw = canonicalBuildInputs(rawBuildInputs);
+  // Authenticate both raw endpoint streams before parsing any untrusted census
+  // text. This keeps a byte mutation diagnostic independent of census shape.
+  const baseline = buildEndpoint(raw.baseline, policy.endpoints.baseline, "baseline");
+  const candidate = buildEndpoint(raw.candidate, policy.endpoints.candidate, "candidate");
+  const keys = parseExpectedKeys(raw.expectedKeys);
+  assertKeyPolicy(keys, policy);
+  assertCensus(baseline.rows, keys, "baseline");
+  assertCensus(candidate.rows, keys, "candidate");
+  assertReportReconciles(baseline.metadata, baseline.rows, policy, "baseline");
+  assertReportReconciles(candidate.metadata, candidate.rows, policy, "candidate");
+  const transitions = [];
+  for (const file of keys) {
+    const before = baseline.rows.get(file).row;
+    const after = candidate.rows.get(file).row;
+    const kind = transitionKind(before, after);
+    if (kind)
+      transitions.push({ baseline: transitionEvidence(before), candidate: transitionEvidence(after), file, kind });
+  }
+  transitions.sort((a, b) => compareText(a.file, b.file));
+  const regressions = transitions.filter((row) => row.kind === "raw_host_free_regression").length;
+  const improvements = transitions.filter((row) => row.kind === "raw_host_free_improvement").length;
+  const baselineHostFreePass = policy.endpoints.baseline.fullSummary.host_free_pass;
+  const candidateHostFreePass = policy.endpoints.candidate.fullSummary.host_free_pass;
+  return {
+    schema: TRANSITION_MANIFEST_SCHEMA,
+    policy_id: policy.id,
+    census: {
+      expected_key_count: policy.expectedKeyCensus.count,
+      expected_keys_sha256: policy.expectedKeyCensus.sortedKeysSha256,
+    },
+    endpoints: {
+      baseline: {
+        evidence: endpointEvidence(policy.endpoints.baseline, baseline, "baseline"),
+        metadata: baseline.metadata,
+      },
+      candidate: {
+        evidence: endpointEvidence(policy.endpoints.candidate, candidate, "candidate"),
+        metadata: candidate.metadata,
+      },
+    },
+    summary: {
+      baseline_host_free_pass: baselineHostFreePass,
+      candidate_host_free_pass: candidateHostFreePass,
+      net_host_free_pass: candidateHostFreePass - baselineHostFreePass,
+      raw_host_free_improvements: improvements,
+      raw_host_free_regressions: regressions,
+    },
+    transition_rows_sha256: transitionRowsSha256(transitions),
+    transitions,
+  };
+}
+
+export function buildStandaloneHighwaterTransitionManifest(rawBuildInputs) {
+  return buildWithPolicy(rawBuildInputs, STANDALONE_HIGHWATER_TRANSITION_POLICY);
+}
+
+// TEST-ONLY seam: small fixtures cannot reproduce the immutable 48,735-row
+// baseline. It also permits an explicitly unknown fixture producer so the
+// unauthenticated-import-omission refusal remains directly testable.
+// Production builder, renderer, verifier, and CLI never call this.
+export function buildStandaloneHighwaterTransitionManifestForTest(rawBuildInputs, testPolicy) {
+  return buildWithPolicy(rawBuildInputs, testPolicy, true);
+}
+
+function validateManifestEndpointEvidence(value, policyEndpoint, endpoint) {
+  assertExactKeys(
+    value,
+    [
+      "baseline_store_commit_sha",
+      "baseline_store_tree_sha",
+      "commit_sha",
+      "oracle",
+      "paths",
+      "pinned_full_summary",
+      "producer_schema",
+      "raw_jsonl",
+      "raw_report",
+      "row_field_count",
+      "row_fields_sha256",
+      "semantic_row_count",
+      "semantic_rows_sha256",
+    ],
+    "malformed-endpoint-evidence",
+    endpoint + " manifest evidence",
+  );
+  if (
+    value.baseline_store_commit_sha !== policyEndpoint.baselineStoreCommitSha ||
+    value.baseline_store_tree_sha !== policyEndpoint.baselineStoreTreeSha ||
+    value.commit_sha !== policyEndpoint.testedCommitSha ||
+    value.producer_schema !== policyEndpoint.producerSchema
+  ) {
+    refuse("policy-evidence-mismatch", endpoint + " manifest evidence contradicts policy");
+  }
+  if (!sameCanonical(canonicalEmittedOracle(value.oracle, endpoint + " manifest oracle"), policyEndpoint.oracle))
+    refuse("oracle-provenance-mismatch", endpoint + " manifest oracle contradicts policy");
+  if (!sameCanonical(canonicalJson(value.paths, endpoint + " manifest paths"), policyEndpoint.paths))
+    refuse("policy-evidence-mismatch", endpoint + " manifest paths contradict policy");
+  if (
+    !sameCanonical(
+      canonicalFullSummary(value.pinned_full_summary, endpoint + " manifest summary"),
+      policyEndpoint.fullSummary,
+    )
+  )
+    refuse("pinned-summary-mismatch", endpoint + " manifest pinned summary contradicts policy");
+  if (
+    !sameCanonical(canonicalEmittedRawDescriptor(value.raw_jsonl, endpoint + " manifest JSONL"), policyEndpoint.jsonl)
+  )
+    refuse("raw-jsonl-evidence-mismatch", endpoint + " manifest JSONL descriptor contradicts policy");
+  if (
+    !sameCanonical(
+      canonicalEmittedRawDescriptor(value.raw_report, endpoint + " manifest report"),
+      policyEndpoint.report,
+    )
+  )
+    refuse("raw-report-evidence-mismatch", endpoint + " manifest report descriptor contradicts policy");
+  const fields = expectedRowFields(endpoint);
+  if (
+    value.row_field_count !== fields.length ||
+    value.row_fields_sha256 !== fieldSetSha256(fields) ||
+    value.semantic_row_count !== policyEndpoint.fullSummary.total ||
+    typeof value.semantic_rows_sha256 !== "string" ||
+    !SHA256_HEX.test(value.semantic_rows_sha256)
+  ) {
+    refuse("malformed-endpoint-evidence", endpoint + " manifest evidence has an invalid field/semantic census");
+  }
+}
+
+// Structural-only canonicalization is intentionally private. It cannot see raw
+// inputs and must never be used for acceptance; verify/render always rebuild.
+function validateManifestStructureOnly(manifest, policy) {
+  if (!isPlainObject(manifest)) refuse("malformed-manifest", "manifest must be a plain object");
+  assertExactKeys(
+    manifest,
+    ["census", "endpoints", "policy_id", "schema", "summary", "transition_rows_sha256", "transitions"],
+    "malformed-manifest",
+    "manifest",
+  );
+  if (manifest.schema !== TRANSITION_MANIFEST_SCHEMA || manifest.policy_id !== policy.id)
+    refuse("policy-evidence-mismatch", "manifest schema or policy id is wrong");
+  assertExactKeys(
+    manifest.census,
+    ["expected_key_count", "expected_keys_sha256"],
+    "malformed-manifest",
+    "manifest census",
+  );
+  if (
+    manifest.census.expected_key_count !== policy.expectedKeyCensus.count ||
+    manifest.census.expected_keys_sha256 !== policy.expectedKeyCensus.sortedKeysSha256
+  )
+    refuse("expected-key-census-mismatch", "manifest census contradicts policy");
+  assertExactKeys(manifest.endpoints, ["baseline", "candidate"], "malformed-manifest", "manifest endpoints");
+  for (const endpoint of ["baseline", "candidate"]) {
+    const item = manifest.endpoints[endpoint];
+    assertExactKeys(item, ["evidence", "metadata"], "malformed-manifest", endpoint + " manifest endpoint");
+    validateManifestEndpointEvidence(item.evidence, policy.endpoints[endpoint], endpoint);
+    parseReport(Buffer.from(stableStringify(item.metadata), "utf8"), endpoint, policy.endpoints[endpoint]);
+  }
+  assertExactKeys(manifest.summary, MANIFEST_SUMMARY_FIELDS, "malformed-manifest", "manifest summary");
+  const baseline = policy.endpoints.baseline.fullSummary.host_free_pass;
+  const candidate = policy.endpoints.candidate.fullSummary.host_free_pass;
+  if (
+    manifest.summary.baseline_host_free_pass !== baseline ||
+    manifest.summary.candidate_host_free_pass !== candidate ||
+    manifest.summary.net_host_free_pass !== candidate - baseline ||
+    !Number.isSafeInteger(manifest.summary.raw_host_free_improvements) ||
+    manifest.summary.raw_host_free_improvements < 0 ||
+    !Number.isSafeInteger(manifest.summary.raw_host_free_regressions) ||
+    manifest.summary.raw_host_free_regressions < 0 ||
+    manifest.summary.net_host_free_pass !==
+      manifest.summary.raw_host_free_improvements - manifest.summary.raw_host_free_regressions
+  ) {
+    refuse("pinned-summary-mismatch", "manifest absolute or transition summary contradicts policy");
+  }
+  if (
+    !Array.isArray(manifest.transitions) ||
+    typeof manifest.transition_rows_sha256 !== "string" ||
+    !SHA256_HEX.test(manifest.transition_rows_sha256)
+  ) {
+    refuse("malformed-manifest", "manifest transitions are invalid");
+  }
+  return canonicalJson(manifest, "manifest");
+}
+
+function verifyWithPolicy(manifest, rawBuildInputs, suppliedPolicy, allowUnknownProducerSchema = false) {
+  if (rawBuildInputs === undefined)
+    refuse("missing-build-inputs", "acceptance verification requires authenticated raw build inputs");
+  const policy = canonicalPolicy(suppliedPolicy, allowUnknownProducerSchema);
+  const structural = validateManifestStructureOnly(manifest, policy);
+  const rebuilt = buildWithPolicy(rawBuildInputs, policy, allowUnknownProducerSchema);
+  if (!sameCanonical(structural, rebuilt))
+    refuse(
+      "manifest-authenticated-evidence-mismatch",
+      "manifest does not exactly reproduce authenticated raw endpoint evidence",
+    );
+  return rebuilt;
+}
+
+export function verifyStandaloneHighwaterTransitionManifest(manifest, rawBuildInputs) {
+  return verifyWithPolicy(manifest, rawBuildInputs, STANDALONE_HIGHWATER_TRANSITION_POLICY);
+}
+
+// TEST-ONLY companion to buildStandaloneHighwaterTransitionManifestForTest.
+export function verifyStandaloneHighwaterTransitionManifestForTest(manifest, rawBuildInputs, testPolicy) {
+  return verifyWithPolicy(manifest, rawBuildInputs, testPolicy, true);
+}
+
+export function renderStandaloneHighwaterTransitionManifest(manifest, rawBuildInputs) {
+  return stableStringify(verifyStandaloneHighwaterTransitionManifest(manifest, rawBuildInputs)) + "\n";
+}
+
+// TEST-ONLY companion to the generic fixture policy seam.
+export function renderStandaloneHighwaterTransitionManifestForTest(manifest, rawBuildInputs, testPolicy) {
+  return (
+    stableStringify(verifyStandaloneHighwaterTransitionManifestForTest(manifest, rawBuildInputs, testPolicy)) + "\n"
+  );
+}
+
+function cliUsage() {
+  return [
+    "Usage: node scripts/standalone-highwater-transition-manifest.mjs \\",
+    "  --baseline-jsonl <endpoint.jsonl> --candidate-jsonl <endpoint.jsonl> \\",
+    "  --baseline-report <endpoint-report.json> --candidate-report <endpoint-report.json> \\",
+    "  --expected-keys <canonical-test262-paths.txt>",
+    "",
+    "The immutable #2097 policy authenticates raw JSONL/report bytes before parsing.",
+  ].join("\n");
+}
+
+function parseCliArgs(argv) {
+  const values = {};
+  const allowed = new Set([
+    "--baseline-jsonl",
+    "--candidate-jsonl",
+    "--baseline-report",
+    "--candidate-report",
+    "--expected-keys",
+  ]);
+  for (let index = 0; index < argv.length; index++) {
+    const key = argv[index];
+    if (key === "--help" || key === "-h") return { help: true };
+    if (!allowed.has(key)) refuse("invalid-arguments", "unknown argument " + key);
+    const value = argv[++index];
+    if (value === undefined || value.startsWith("--")) refuse("invalid-arguments", key + " requires a value");
+    if (hasOwn(values, key)) refuse("invalid-arguments", key + " was supplied more than once");
+    values[key] = value;
+  }
+  for (const key of allowed) if (!hasOwn(values, key)) refuse("invalid-arguments", "missing required " + key);
+  return values;
+}
+
+function rawBuildInputsFromCli(argv) {
+  const args = parseCliArgs(argv);
+  if (args.help) return { help: true };
+  return {
+    baseline: {
+      jsonl: readFileSync(resolve(args["--baseline-jsonl"])),
+      report: readFileSync(resolve(args["--baseline-report"])),
+    },
+    candidate: {
+      jsonl: readFileSync(resolve(args["--candidate-jsonl"])),
+      report: readFileSync(resolve(args["--candidate-report"])),
+    },
+    expectedKeys: readFileSync(resolve(args["--expected-keys"])),
+  };
+}
+
+function runCliWithPolicy(argv, policy, allowUnknownProducerSchema = false) {
+  const rawBuildInputs = rawBuildInputsFromCli(argv);
+  if (rawBuildInputs.help) return cliUsage();
+  const manifest = buildWithPolicy(rawBuildInputs, policy, allowUnknownProducerSchema);
+  return stableStringify(verifyWithPolicy(manifest, rawBuildInputs, policy, allowUnknownProducerSchema)) + "\n";
+}
+
+export function runTransitionManifestCli(argv = process.argv.slice(2)) {
+  return runCliWithPolicy(argv, STANDALONE_HIGHWATER_TRANSITION_POLICY);
+}
+
+// TEST-ONLY: the executable entry point below never accepts this policy seam.
+export function runTransitionManifestCliForTest(argv, testPolicy) {
+  return runCliWithPolicy(argv, testPolicy, true);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(runTransitionManifestCli());
+  } catch (error) {
+    process.stderr.write(
+      "standalone-highwater-transition-manifest: " + (error instanceof Error ? error.message : String(error)) + "\n",
+    );
+    process.exitCode = 2;
+  }
+}

--- a/tests/issue-2097-standalone-highwater-transition.test.ts
+++ b/tests/issue-2097-standalone-highwater-transition.test.ts
@@ -1,0 +1,1086 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2097 -- authenticated raw endpoint transition manifest.
+ *
+ * The small policy is a test-only seam. The production builder and executable
+ * accept the immutable, audited 48,735-row policy from the implementation.
+ */
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST,
+  STANDALONE_HIGHWATER_TRANSITION_POLICY,
+  buildStandaloneHighwaterTransitionManifest,
+  buildStandaloneHighwaterTransitionManifestForTest,
+  isStandaloneHostFreePass,
+  renderStandaloneHighwaterTransitionManifestForTest,
+  runTransitionManifestCliForTest,
+  transitionRowsSha256,
+  verifyStandaloneHighwaterTransitionManifest,
+  verifyStandaloneHighwaterTransitionManifestForTest,
+} from "../scripts/standalone-highwater-transition-manifest.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CLI = resolve(ROOT, "scripts/standalone-highwater-transition-manifest.mjs");
+const HIGHWATER = resolve(ROOT, "benchmarks/results/test262-standalone-highwater.json");
+const BASE_SHA = "a".repeat(40);
+const CANDIDATE_SHA = "b".repeat(40);
+const KEYS = ["test/a.js", "test/b.js", "test/c.js"];
+
+type Status = "pass" | "fail" | "compile_error" | "compile_timeout" | "skip";
+type Row = {
+  category?: string;
+  compile_ms?: number;
+  error?: string;
+  error_category?: string;
+  error_signature?: string;
+  exec_ms?: number;
+  file: string;
+  host_import_leak_class?: string;
+  imports?: string[];
+  oracle_lane?: string;
+  oracle_version?: number;
+  poison_healed?: boolean;
+  reached_test?: boolean;
+  retried?: boolean;
+  retry_count?: number | null;
+  scope?: string;
+  scope_official?: boolean;
+  scope_reason?: string;
+  status: Status;
+  strict?: string;
+  timestamp?: string;
+};
+type Endpoint = {
+  commitSha: string;
+  jsonl: Buffer;
+  mode: { include_proposals: 0 | 1; label: string; target: "standalone" };
+  report: Buffer;
+  reportValue: Record<string, unknown>;
+};
+type Inputs = {
+  baseline: { jsonl: Buffer; report: Buffer };
+  candidate: { jsonl: Buffer; report: Buffer };
+  expectedKeys: Buffer;
+};
+
+function descriptor(bytes: Buffer) {
+  return {
+    bytes: bytes.byteLength,
+    gitBlob: createHash("sha1")
+      .update(Buffer.from("blob " + bytes.byteLength + "\0", "utf8"))
+      .update(bytes)
+      .digest("hex"),
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+  };
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function jsonRoundTrippedNullProtoMember(value: Record<string, unknown>) {
+  return JSON.parse(JSON.stringify({ ...value, ["__proto__"]: null })) as Record<string, unknown>;
+}
+
+function rawHostFreePass(row: Row) {
+  return row.status === "pass" && row.imports === undefined && row.host_import_leak_class === undefined;
+}
+
+function fullSummary(rows: readonly Row[]) {
+  const summary = {
+    total: rows.length,
+    pass: 0,
+    fail: 0,
+    compile_error: 0,
+    compile_timeout: 0,
+    skip: 0,
+    compilable: 0,
+    host_free_pass: 0,
+    stale: 0,
+  };
+  for (const entry of rows) {
+    summary[entry.status]++;
+    if (rawHostFreePass(entry)) summary.host_free_pass++;
+  }
+  summary.compilable = summary.pass + summary.fail;
+  return summary;
+}
+
+function report(commitSha: string, rows: readonly Row[], mode: Endpoint["mode"], timestamp = "2026-08-30T12:00:00Z") {
+  return {
+    baseline_generated_at: "2026-08-30T11:00:00Z",
+    baseline_sha: commitSha,
+    categories: {},
+    error_categories: {},
+    full_summary: fullSummary(rows),
+    hard_errors: [],
+    mode,
+    official_summary: {},
+    oracle_version: 13,
+    root_cause_map: {},
+    scope_summaries: {},
+    skip_reasons: {},
+    strict_summary: {},
+    summary: {},
+    timestamp,
+  };
+}
+
+function row(file: string, status: Status, extra: Partial<Row> = {}): Row {
+  const base: Row = {
+    category: "built-ins/Array",
+    compile_ms: 4,
+    exec_ms: 1,
+    file,
+    oracle_lane: "honest",
+    oracle_version: 13,
+    reached_test: status !== "compile_timeout",
+    scope: "standard",
+    scope_official: true,
+    status,
+    strict: "both",
+    timestamp: "30.8.2026, 13:09:50",
+  };
+  if (status !== "pass") {
+    base.error = status === "compile_timeout" ? "timeout after 30s" : "returned 2";
+    base.error_category = status === "compile_timeout" ? "timeout" : "assertion_fail";
+    base.error_signature = status + ":" + base.error_category;
+  }
+  return { ...base, ...extra };
+}
+
+function jsonl(rows: readonly Row[]) {
+  return Buffer.from(rows.map((entry) => JSON.stringify(entry)).join("\n") + "\n", "utf8");
+}
+
+function endpoint(
+  commitSha: string,
+  rows: readonly Row[],
+  mode: Endpoint["mode"],
+  reportValue = report(commitSha, rows, mode),
+): Endpoint {
+  return {
+    commitSha,
+    jsonl: jsonl(rows),
+    mode,
+    report: Buffer.from(JSON.stringify(reportValue) + "\n", "utf8"),
+    reportValue,
+  };
+}
+
+function withRows(value: Endpoint, rows: readonly Row[]) {
+  return { ...value, jsonl: jsonl(rows) };
+}
+
+function withReport(value: Endpoint, reportValue: Record<string, unknown>) {
+  return { ...value, report: Buffer.from(JSON.stringify(reportValue) + "\n", "utf8"), reportValue };
+}
+
+function makePolicy(
+  baseline: Endpoint,
+  candidate: Endpoint,
+  keys = KEYS,
+  options: {
+    pinned?: { baseline?: Record<string, unknown>; candidate?: Record<string, unknown> };
+    producerSchema?: { baseline?: string; candidate?: string };
+  } = {},
+) {
+  const keyText = [...keys].sort().join("\n") + "\n";
+  const endpointPolicy = (value: Endpoint, kind: "baseline" | "candidate") => ({
+    testedCommitSha: value.commitSha,
+    baselineStoreCommitSha: (kind === "baseline" ? "c" : "d").repeat(40),
+    baselineStoreTreeSha: (kind === "baseline" ? "e" : "f").repeat(40),
+    paths: { jsonl: "test262-standalone-current.jsonl", report: "test262-standalone-current.json" },
+    jsonl: descriptor(value.jsonl),
+    report: descriptor(value.report),
+    oracle: { version: 13, lane: "honest", fastRev: null },
+    producerSchema: options.producerSchema?.[kind] ?? PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST,
+    mode: value.mode,
+    fullSummary: options.pinned?.[kind] ?? value.reportValue.full_summary,
+  });
+  return {
+    id: "issue-2097-test-policy-v1",
+    expectedKeyCensus: {
+      count: keys.length,
+      sortedKeysSha256: createHash("sha256").update(keyText, "utf8").digest("hex"),
+    },
+    endpoints: {
+      baseline: endpointPolicy(baseline, "baseline"),
+      candidate: endpointPolicy(candidate, "candidate"),
+    },
+  };
+}
+
+function inputs(baseline: Endpoint, candidate: Endpoint, keys = KEYS): Inputs {
+  return {
+    baseline: { jsonl: baseline.jsonl, report: baseline.report },
+    candidate: { jsonl: candidate.jsonl, report: candidate.report },
+    expectedKeys: Buffer.from(keys.join("\n") + "\n", "utf8"),
+  };
+}
+
+function fixture() {
+  const baselineRows = [
+    row("test/a.js", "pass"),
+    row("test/b.js", "fail", { poison_healed: true, retried: true, retry_count: 1, scope_reason: "baseline retry" }),
+    row("test/c.js", "compile_error", {
+      imports: ["env::z", "env::a", "env::a"],
+      host_import_leak_class: "host_import",
+    }),
+  ];
+  const candidateRows = [
+    row("test/a.js", "compile_timeout", {
+      compile_ms: 30_000,
+      exec_ms: 0,
+      error: "timeout \ud800 after 30s",
+      error_category: "timeout",
+      error_signature: "compile_timeout:timeout",
+      imports: ["env::b", "env::a", "env::a"],
+      host_import_leak_class: "host_import",
+    }),
+    row("test/b.js", "pass", { retried: true, retry_count: 1, scope_reason: "candidate retry" }),
+    row("test/c.js", "fail", {
+      error: "non-transition detail",
+      error_category: "other",
+      error_signature: "fail:other",
+    }),
+  ];
+  const baseline = endpoint(BASE_SHA, baselineRows, {
+    target: "standalone",
+    include_proposals: 0,
+    label: "official test262 (default scope)",
+  });
+  const candidate = endpoint(CANDIDATE_SHA, candidateRows, {
+    target: "standalone",
+    include_proposals: 1,
+    label: "official test262 + proposals",
+  });
+  return {
+    baseline,
+    baselineRows,
+    candidate,
+    candidateRows,
+    policy: makePolicy(baseline, candidate),
+    raw: inputs(baseline, candidate),
+  };
+}
+
+function buildTest(raw: Inputs, policy: ReturnType<typeof makePolicy>) {
+  return buildStandaloneHighwaterTransitionManifestForTest(raw, policy);
+}
+
+describe("#2097 authenticated raw standalone transition manifest", () => {
+  it("uses the exact empty-import and null-leak host-free predicate", () => {
+    expect(isStandaloneHostFreePass({ status: "pass", imports: [], host_import_leak_class: null })).toBe(true);
+    expect(isStandaloneHostFreePass({ status: "pass", imports: ["env::x"], host_import_leak_class: null })).toBe(false);
+    expect(isStandaloneHostFreePass({ status: "pass", imports: [], host_import_leak_class: "host_import" })).toBe(
+      false,
+    );
+    expect(isStandaloneHostFreePass({ status: "pass", host_import_leak_class: null })).toBe(false);
+  });
+
+  it("pins every exact production-policy value and recursively freezes it", () => {
+    expect(STANDALONE_HIGHWATER_TRANSITION_POLICY).toEqual({
+      id: "issue-2097-standalone-highwater-transition-v1",
+      expectedKeyCensus: {
+        count: 48735,
+        sortedKeysSha256: "d5da0c8e80b17c9617275dd9d2feb84288b4ec9fd7d03578a763995648d85c6f",
+      },
+      endpoints: {
+        baseline: {
+          testedCommitSha: "fc6fd3b5f3df1fbce731bf74c391aca41fcd08c2",
+          baselineStoreCommitSha: "9657d806b1d6ed0f54256c74b390f232677bd8e4",
+          baselineStoreTreeSha: "135a3c26544ea44409d93e8f3b9e7d6bfcc3326b",
+          paths: { jsonl: "test262-standalone-current.jsonl", report: "test262-standalone-current.json" },
+          jsonl: {
+            bytes: 23209263,
+            sha256: "d3341cf6b6dbcc237f18f1461dc97dcddf1f2cbbfb944496d7ae73e8489adb87",
+            gitBlob: "f762926801f85f7bb630b53e9d727647ecc45d94",
+          },
+          report: {
+            bytes: 108028,
+            sha256: "e5626e5a57a37d9e29a051be0d5175e7771dd1cf5bf237065e43fbb586d82147",
+            gitBlob: "3b34346a96caef48484f939a7ca6d0c030802ccb",
+          },
+          oracle: { version: 13, lane: "honest", fastRev: null },
+          producerSchema: "test262-record-result-v13-honest",
+          mode: { target: "standalone", include_proposals: 0, label: "official test262 (default scope)" },
+          fullSummary: {
+            total: 48735,
+            pass: 33876,
+            fail: 9506,
+            compile_error: 5227,
+            compile_timeout: 12,
+            skip: 114,
+            compilable: 43382,
+            host_free_pass: 33876,
+            stale: 0,
+          },
+        },
+        candidate: {
+          testedCommitSha: "01fb67624e2f645b7e92dd9f8e47478e3face9ba",
+          baselineStoreCommitSha: "f0d6b57da9362471decffeb6f3d98d650d477bd5",
+          baselineStoreTreeSha: "aa8f1f95b9d3da3c5ae60d3a71abe53d23733e50",
+          paths: { jsonl: "test262-standalone-current.jsonl", report: "test262-standalone-current.json" },
+          jsonl: {
+            bytes: 23482700,
+            sha256: "5d6cb6e5a39fbb6e20c9ac655a1cc6987d6555c222ad42aab9dbb70b0ec23ff3",
+            gitBlob: "3b99ba94b2a1a8625f869a84464bd497eeb732c0",
+          },
+          report: {
+            bytes: 110636,
+            sha256: "8738617eefa12fe0bc54ddfb7773d21635b9bb6b68850a1b09ed4e3cc5584b20",
+            gitBlob: "7a033b31cb16947a1d1bfcbba2ddabe1a2734b62",
+          },
+          oracle: { version: 13, lane: "honest", fastRev: null },
+          producerSchema: "test262-record-result-v13-honest",
+          mode: { target: "standalone", include_proposals: 1, label: "official test262 + proposals" },
+          fullSummary: {
+            total: 48735,
+            pass: 32581,
+            fail: 10122,
+            compile_error: 5755,
+            compile_timeout: 163,
+            skip: 114,
+            compilable: 42703,
+            host_free_pass: 32581,
+            stale: 0,
+          },
+        },
+      },
+    });
+
+    const assertRecursivelyFrozen = (value: unknown): void => {
+      if (value === null || typeof value !== "object") return;
+      expect(Object.isFrozen(value)).toBe(true);
+      for (const child of Object.values(value)) assertRecursivelyFrozen(child);
+    };
+    assertRecursivelyFrozen(STANDALONE_HIGHWATER_TRANSITION_POLICY);
+  });
+
+  it("uses a fixed production policy and a clearly test-only generic seam", () => {
+    const { baseline, candidate, policy, raw } = fixture();
+    expect(() => buildStandaloneHighwaterTransitionManifest(raw)).toThrow(/raw-jsonl-evidence-mismatch/);
+    const manifest = buildTest(raw, policy);
+    expect(manifest).toMatchObject({
+      policy_id: "issue-2097-test-policy-v1",
+      schema: "standalone-highwater-transition-manifest-v3",
+      census: {
+        expected_key_count: 3,
+        expected_keys_sha256: "b777649a9cc531fb2a5317cb966d18829d52e577d41518639a54a5d4b69ac464",
+      },
+    });
+    expect(manifest.endpoints).toEqual({
+      baseline: {
+        evidence: {
+          baseline_store_commit_sha: "c".repeat(40),
+          baseline_store_tree_sha: "e".repeat(40),
+          commit_sha: BASE_SHA,
+          oracle: { fast_rev: null, lane: "honest", version: 13 },
+          paths: { jsonl: "test262-standalone-current.jsonl", report: "test262-standalone-current.json" },
+          pinned_full_summary: {
+            compilable: 2,
+            compile_error: 1,
+            compile_timeout: 0,
+            fail: 1,
+            host_free_pass: 1,
+            pass: 1,
+            skip: 0,
+            stale: 0,
+            total: 3,
+          },
+          producer_schema: PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST,
+          raw_jsonl: {
+            bytes: 1111,
+            git_blob: "c765b83a4e3eec5f35ac3fef395be5c2bed51aa6",
+            sha256: "7fa44a8342d56d44b58400a564e0ebc6026dc417f368178d98173f2499e42bb8",
+          },
+          raw_report: {
+            bytes: 563,
+            git_blob: "28c8ec7664799d760fed6c56b4d2ac6462945f21",
+            sha256: "9eaa9c0afbdba1f80edad3a6f372203b8a763c8570156087c6b59357a4fe9a18",
+          },
+          row_field_count: 21,
+          row_fields_sha256: "1247f0f0e7e247d395bdbc3e2d9bfd9bca032eee3cac8534a7c41de63856e607",
+          semantic_row_count: 3,
+          semantic_rows_sha256: "355ac27f327aef3948705d22f0c8961fc98183d7e31fb5a29f693a1dca685a65",
+        },
+        metadata: baseline.reportValue,
+      },
+      candidate: {
+        evidence: {
+          baseline_store_commit_sha: "d".repeat(40),
+          baseline_store_tree_sha: "f".repeat(40),
+          commit_sha: CANDIDATE_SHA,
+          oracle: { fast_rev: null, lane: "honest", version: 13 },
+          paths: { jsonl: "test262-standalone-current.jsonl", report: "test262-standalone-current.json" },
+          pinned_full_summary: {
+            compilable: 2,
+            compile_error: 0,
+            compile_timeout: 1,
+            fail: 1,
+            host_free_pass: 1,
+            pass: 1,
+            skip: 0,
+            stale: 0,
+            total: 3,
+          },
+          producer_schema: PRODUCER_SCHEMA_TEST262_RECORD_RESULT_V13_HONEST,
+          raw_jsonl: {
+            bytes: 1093,
+            git_blob: "17d51a91ed6686cccd7771598822f90847e80f48",
+            sha256: "29b2ae42e508396862cb93182e09a5cd309b8835d7bcae56616ab5ba629e9841",
+          },
+          raw_report: {
+            bytes: 559,
+            git_blob: "67d133d281b2ab81bf33f702f0267b9416b6a96f",
+            sha256: "732a19dac746312b0f3f6bb2838f650d3db235643451fda72c121acd78a57cbf",
+          },
+          row_field_count: 20,
+          row_fields_sha256: "cba9ae15f664144b4875938b3d2a85c4dff67d37e27246bafb474648649936bb",
+          semantic_row_count: 3,
+          semantic_rows_sha256: "39e73fa298afc3a2cda3da62d7d96ca2ddc21f82d8f6fbd4a5814566d4350237",
+        },
+        metadata: candidate.reportValue,
+      },
+    });
+    expect(manifest.summary).toEqual({
+      baseline_host_free_pass: 1,
+      candidate_host_free_pass: 1,
+      net_host_free_pass: 0,
+      raw_host_free_improvements: 1,
+      raw_host_free_regressions: 1,
+    });
+    expect(manifest.transitions).toEqual([
+      {
+        baseline: {
+          category: "built-ins/Array",
+          error: null,
+          error_category: null,
+          error_signature: null,
+          host_free_pass: true,
+          host_import_leak_class: null,
+          imports: [],
+          imports_evidence: "authenticated_producer_omission",
+          oracle_fast_rev: null,
+          oracle_lane: "honest",
+          oracle_version: 13,
+          poison_healed: null,
+          reached_test: true,
+          retried: null,
+          retry_count: null,
+          scope: "standard",
+          scope_official: true,
+          scope_reason: null,
+          status: "pass",
+          strict: "both",
+          timestamp: "30.8.2026, 13:09:50",
+          timing: { compile_ms: 4, exec_ms: 1 },
+        },
+        candidate: {
+          category: "built-ins/Array",
+          error: "timeout \ud800 after 30s",
+          error_category: "timeout",
+          error_signature: "compile_timeout:timeout",
+          host_free_pass: false,
+          host_import_leak_class: "host_import",
+          imports: ["env::a", "env::b"],
+          imports_evidence: "explicit_nonempty",
+          oracle_fast_rev: null,
+          oracle_lane: "honest",
+          oracle_version: 13,
+          poison_healed: null,
+          reached_test: false,
+          retried: null,
+          retry_count: null,
+          scope: "standard",
+          scope_official: true,
+          scope_reason: null,
+          status: "compile_timeout",
+          strict: "both",
+          timestamp: "30.8.2026, 13:09:50",
+          timing: { compile_ms: 30_000, exec_ms: 0 },
+        },
+        file: "test/a.js",
+        kind: "raw_host_free_regression",
+      },
+      {
+        baseline: {
+          category: "built-ins/Array",
+          error: "returned 2",
+          error_category: "assertion_fail",
+          error_signature: "fail:assertion_fail",
+          host_free_pass: false,
+          host_import_leak_class: null,
+          imports: [],
+          imports_evidence: "authenticated_producer_omission",
+          oracle_fast_rev: null,
+          oracle_lane: "honest",
+          oracle_version: 13,
+          poison_healed: true,
+          reached_test: true,
+          retried: true,
+          retry_count: 1,
+          scope: "standard",
+          scope_official: true,
+          scope_reason: "baseline retry",
+          status: "fail",
+          strict: "both",
+          timestamp: "30.8.2026, 13:09:50",
+          timing: { compile_ms: 4, exec_ms: 1 },
+        },
+        candidate: {
+          category: "built-ins/Array",
+          error: null,
+          error_category: null,
+          error_signature: null,
+          host_free_pass: true,
+          host_import_leak_class: null,
+          imports: [],
+          imports_evidence: "authenticated_producer_omission",
+          oracle_fast_rev: null,
+          oracle_lane: "honest",
+          oracle_version: 13,
+          poison_healed: null,
+          reached_test: true,
+          retried: true,
+          retry_count: 1,
+          scope: "standard",
+          scope_official: true,
+          scope_reason: "candidate retry",
+          status: "pass",
+          strict: "both",
+          timestamp: "30.8.2026, 13:09:50",
+          timing: { compile_ms: 4, exec_ms: 1 },
+        },
+        file: "test/b.js",
+        kind: "raw_host_free_improvement",
+      },
+    ]);
+    expect(manifest.transition_rows_sha256).toBe("12eea49dcdd52fa3a6da88a2188583482d722d6ad5521c8e2f7e7b210be39d88");
+  });
+
+  it("rejects raw byte changes before parse while retaining the original descriptor", () => {
+    const { policy, raw } = fixture();
+    const mutated: Inputs = {
+      ...raw,
+      baseline: { ...raw.baseline, jsonl: Buffer.concat([raw.baseline.jsonl, Buffer.from(" ")]) },
+    };
+    expect(() => buildTest(mutated, policy)).toThrow(
+      /raw-jsonl-evidence-mismatch: baseline jsonl does not match the immutable #2097 raw descriptor/,
+    );
+    const reportMutated: Inputs = {
+      ...raw,
+      candidate: { ...raw.candidate, report: Buffer.concat([raw.candidate.report, Buffer.from(" ")]) },
+    };
+    expect(() => buildTest(reportMutated, policy)).toThrow(
+      /raw-report-evidence-mismatch: candidate report does not match the immutable #2097 raw descriptor/,
+    );
+  });
+
+  it("authenticates each expected raw descriptor member independently", () => {
+    const { policy, raw } = fixture();
+    const corruptions: Array<["bytes" | "gitBlob" | "sha256", number | string]> = [
+      ["bytes", policy.endpoints.baseline.jsonl.bytes + 1],
+      ["sha256", "0".repeat(64)],
+      ["gitBlob", "0".repeat(40)],
+    ];
+
+    for (const [field, replacement] of corruptions) {
+      const corruptPolicy = clone(policy);
+      (corruptPolicy.endpoints.baseline.jsonl as Record<string, number | string>)[field] = replacement;
+      expect(() => buildTest(raw, corruptPolicy)).toThrow(
+        /raw-jsonl-evidence-mismatch: baseline jsonl does not match the immutable #2097 raw descriptor/,
+      );
+    }
+  });
+
+  it("enforces exact report keys, per-endpoint mode, and all full_summary constraints", () => {
+    const { baseline, candidate, policy, raw } = fixture();
+    const extra = clone(candidate.reportValue);
+    extra.unpinned = true;
+    const extraCandidate = withReport(candidate, extra);
+    expect(() => buildTest(inputs(baseline, extraCandidate), makePolicy(baseline, extraCandidate))).toThrow(
+      /report-key-universe-mismatch/,
+    );
+
+    const historicLane = clone(candidate.reportValue);
+    historicLane.oracle_lane = "honest";
+    const historicLaneCandidate = withReport(candidate, historicLane);
+    expect(() =>
+      buildTest(inputs(baseline, historicLaneCandidate), makePolicy(baseline, historicLaneCandidate)),
+    ).toThrow(/report-key-universe-mismatch/);
+
+    const contradictoryLane = clone(candidate.reportValue);
+    contradictoryLane.oracle_lane = "fast-nativeharness";
+    const contradictoryLaneCandidate = withReport(candidate, contradictoryLane);
+    expect(() =>
+      buildTest(inputs(baseline, contradictoryLaneCandidate), makePolicy(baseline, contradictoryLaneCandidate)),
+    ).toThrow(/oracle-provenance-mismatch/);
+
+    const contradictoryFastRevision = clone(candidate.reportValue);
+    contradictoryFastRevision.oracle_fast_rev = 1;
+    const contradictoryFastCandidate = withReport(candidate, contradictoryFastRevision);
+    expect(() =>
+      buildTest(inputs(baseline, contradictoryFastCandidate), makePolicy(baseline, contradictoryFastCandidate)),
+    ).toThrow(/oracle-provenance-mismatch/);
+
+    const wrongMode = clone(candidate.reportValue);
+    (wrongMode.mode as { include_proposals: number }).include_proposals = 0;
+    const wrongModeCandidate = withReport(candidate, wrongMode);
+    expect(() => buildTest(inputs(baseline, wrongModeCandidate), makePolicy(baseline, wrongModeCandidate))).toThrow(
+      /report-mode-mismatch/,
+    );
+
+    const extraMode = clone(candidate.reportValue);
+    (extraMode.mode as Record<string, unknown>).extra = true;
+    const extraModeCandidate = withReport(candidate, extraMode);
+    expect(() => buildTest(inputs(baseline, extraModeCandidate), makePolicy(baseline, extraModeCandidate))).toThrow(
+      /malformed-metadata/,
+    );
+
+    const missingMode = clone(candidate.reportValue);
+    (missingMode.mode as Record<string, unknown>).label = undefined;
+    const missingModeCandidate = withReport(candidate, missingMode);
+    expect(() => buildTest(inputs(baseline, missingModeCandidate), makePolicy(baseline, missingModeCandidate))).toThrow(
+      /malformed-metadata/,
+    );
+
+    const extraSummary = clone(candidate.reportValue);
+    (extraSummary.full_summary as Record<string, unknown>).extra = 0;
+    const extraSummaryCandidate = withReport(candidate, extraSummary);
+    expect(() =>
+      buildTest(inputs(baseline, extraSummaryCandidate), makePolicy(baseline, extraSummaryCandidate)),
+    ).toThrow(/malformed-report-summary/);
+
+    const inconsistentTotal = clone(candidate.reportValue);
+    (inconsistentTotal.full_summary as Record<string, number>).total = 4;
+    const inconsistentTotalCandidate = withReport(candidate, inconsistentTotal);
+    expect(() =>
+      buildTest(
+        inputs(baseline, inconsistentTotalCandidate),
+        makePolicy(baseline, inconsistentTotalCandidate, KEYS, {
+          pinned: { candidate: candidate.reportValue.full_summary as Record<string, unknown> },
+        }),
+      ),
+    ).toThrow(/malformed-report-summary: candidate report full_summary total does not equal all status buckets/);
+
+    const wrongHostField = clone(candidate.reportValue);
+    const changedSummary = wrongHostField.full_summary as Record<string, unknown>;
+    changedSummary.host_free = changedSummary.host_free_pass;
+    changedSummary.host_free_pass = undefined;
+    const wrongHostCandidate = withReport(candidate, wrongHostField);
+    expect(() => buildTest(inputs(baseline, wrongHostCandidate), makePolicy(baseline, wrongHostCandidate))).toThrow(
+      /malformed-report-summary/,
+    );
+
+    expect(() => buildTest(raw, policy)).not.toThrow();
+  });
+
+  it("rejects internally coherent report vectors that disagree with parsed JSONL", () => {
+    const { baseline, candidate } = fixture();
+    const vectors: Array<{
+      expected: RegExp;
+      name: string;
+      update: (summary: Record<string, number>) => void;
+    }> = [
+      {
+        name: "host-free count",
+        update(summary) {
+          summary.host_free_pass = 0;
+        },
+        expected: /report-jsonl-summary-mismatch: candidate report host_free_pass does not match parsed JSONL/,
+      },
+      {
+        name: "status counts",
+        update(summary) {
+          summary.pass = 0;
+          summary.fail = 2;
+          summary.host_free_pass = 0;
+          summary.compilable = 2;
+        },
+        expected: /report-jsonl-summary-mismatch: candidate report fail does not match parsed JSONL/,
+      },
+      {
+        name: "compilable count",
+        update(summary) {
+          summary.pass = 0;
+          summary.fail = 1;
+          summary.compile_error = 1;
+          summary.host_free_pass = 0;
+          summary.compilable = 1;
+        },
+        expected: /report-jsonl-summary-mismatch: candidate report compilable does not match parsed JSONL/,
+      },
+    ];
+
+    for (const vector of vectors) {
+      const reportValue = clone(candidate.reportValue);
+      vector.update(reportValue.full_summary as Record<string, number>);
+      const reportCandidate = withReport(candidate, reportValue);
+      expect(() => buildTest(inputs(baseline, reportCandidate), makePolicy(baseline, reportCandidate))).toThrow(
+        vector.expected,
+      );
+    }
+  });
+
+  it("reconciles full_summary against parsed rows, including status, compilable, host-free, and stale", () => {
+    const { baseline, candidate, candidateRows } = fixture();
+    const changedStatus = clone(candidateRows);
+    changedStatus[2].status = "compile_error";
+    const statusCandidate = withRows(candidate, changedStatus);
+    expect(() => buildTest(inputs(baseline, statusCandidate), makePolicy(baseline, statusCandidate))).toThrow(
+      /report-jsonl-summary-mismatch: candidate report compilable does not match parsed JSONL/,
+    );
+
+    const changedHostFree = clone(candidateRows);
+    changedHostFree[1].imports = ["env::leak"];
+    changedHostFree[1].host_import_leak_class = "host_import";
+    const hostCandidate = withRows(candidate, changedHostFree);
+    expect(() => buildTest(inputs(baseline, hostCandidate), makePolicy(baseline, hostCandidate))).toThrow(
+      /non-host-free-pass/,
+    );
+
+    const stale = clone(candidate.reportValue);
+    (stale.full_summary as Record<string, number>).stale = 1;
+    const staleCandidate = withReport(candidate, stale);
+    expect(() =>
+      buildTest(
+        inputs(baseline, staleCandidate),
+        makePolicy(baseline, staleCandidate, KEYS, {
+          pinned: { candidate: candidate.reportValue.full_summary as Record<string, unknown> },
+        }),
+      ),
+    ).toThrow(/malformed-report-summary/);
+  });
+
+  it("fails closed on provenance, field-universe, and key-census drift", () => {
+    const { baseline, baselineRows, candidate, candidateRows, policy, raw } = fixture();
+    const wrongOracle = clone(candidateRows);
+    wrongOracle[1].oracle_lane = "fast-nativeharness";
+    const oracleCandidate = withRows(candidate, wrongOracle);
+    expect(() => buildTest(inputs(baseline, oracleCandidate), makePolicy(baseline, oracleCandidate))).toThrow(
+      /oracle-provenance-mismatch/,
+    );
+
+    const wrongOracleVersion = clone(candidateRows);
+    wrongOracleVersion[1].oracle_version = 12;
+    const oracleVersionCandidate = withRows(candidate, wrongOracleVersion);
+    expect(() =>
+      buildTest(inputs(baseline, oracleVersionCandidate), makePolicy(baseline, oracleVersionCandidate)),
+    ).toThrow(/oracle-provenance-mismatch: candidate JSONL line 2 contradicts the pinned v13 honest provenance/);
+
+    const nullRetryCount = clone(candidateRows);
+    nullRetryCount[1].retry_count = null;
+    const nullRetryCandidate = withRows(candidate, nullRetryCount);
+    expect(() => buildTest(inputs(baseline, nullRetryCandidate), makePolicy(baseline, nullRetryCandidate))).toThrow(
+      /malformed-row: candidate JSONL line 2 has invalid retry_count/,
+    );
+
+    const missingPoisonField = clone(baselineRows);
+    missingPoisonField[1].poison_healed = undefined;
+    const missingPoisonBaseline = withRows(baseline, missingPoisonField);
+    expect(() =>
+      buildTest(inputs(missingPoisonBaseline, candidate), makePolicy(missingPoisonBaseline, candidate)),
+    ).toThrow(/field-universe-mismatch: baseline JSONL does not have the authenticated v13 field universe/);
+
+    const unknownProducerPolicy = makePolicy(baseline, candidate, KEYS, {
+      producerSchema: { candidate: "test-only-unknown-producer" },
+    });
+    expect(() => buildTest(raw, unknownProducerPolicy)).toThrow(
+      /unauthenticated-import-omission: candidate JSONL line 2 omitted imports under unknown producer/,
+    );
+
+    const unknown = clone(candidateRows) as Array<Row & { unknown_field?: string }>;
+    unknown[2].unknown_field = "must not be ignored";
+    const unknownCandidate = withRows(candidate, unknown);
+    expect(() => buildTest(inputs(baseline, unknownCandidate), makePolicy(baseline, unknownCandidate))).toThrow(
+      /unrecognized-row-field/,
+    );
+
+    const duplicateBaseline = withRows(baseline, [...baselineRows, baselineRows[0]]);
+    expect(() => buildTest(inputs(duplicateBaseline, candidate), makePolicy(duplicateBaseline, candidate))).toThrow(
+      /duplicate-key/,
+    );
+
+    const missingImportPair = clone(candidateRows);
+    missingImportPair[0].imports = undefined;
+    const partialCandidate = withRows(candidate, missingImportPair);
+    expect(() => buildTest(inputs(baseline, partialCandidate), makePolicy(baseline, partialCandidate))).toThrow(
+      /inconsistent-import-evidence/,
+    );
+
+    const wrongKeys: Inputs = { ...raw, expectedKeys: Buffer.from("test/a.js\ntest/b.js\n", "utf8") };
+    expect(() => buildTest(wrongKeys, policy)).toThrow(/expected-key-census-mismatch/);
+
+    const droppedCandidate = withRows(candidate, candidateRows.slice(0, 2));
+    expect(() => buildTest(inputs(baseline, droppedCandidate), makePolicy(baseline, droppedCandidate))).toThrow(
+      /dropped-key/,
+    );
+
+    const foreignCandidate = withRows(candidate, [...candidateRows, row("test/foreign.js", "compile_error")]);
+    expect(() => buildTest(inputs(baseline, foreignCandidate), makePolicy(baseline, foreignCandidate))).toThrow(
+      /foreign-key/,
+    );
+
+    const wrongReportSha = clone(baseline.reportValue);
+    wrongReportSha.baseline_sha = "9".repeat(40);
+    const wrongShaBaseline = withReport(baseline, wrongReportSha);
+    expect(() => buildTest(inputs(wrongShaBaseline, candidate), makePolicy(wrongShaBaseline, candidate))).toThrow(
+      /wrong-endpoint-sha/,
+    );
+
+    const negativeTiming = clone(candidateRows);
+    negativeTiming[0].compile_ms = -1;
+    const negativeCandidate = withRows(candidate, negativeTiming);
+    expect(() => buildTest(inputs(baseline, negativeCandidate), makePolicy(baseline, negativeCandidate))).toThrow(
+      /malformed-timing/,
+    );
+
+    const missingTimeoutTiming = clone(candidateRows);
+    missingTimeoutTiming[0].compile_ms = undefined;
+    const missingTimingCandidate = withRows(candidate, missingTimeoutTiming);
+    expect(() =>
+      buildTest(inputs(baseline, missingTimingCandidate), makePolicy(baseline, missingTimingCandidate)),
+    ).toThrow(/malformed-timing/);
+  });
+
+  it("binds an authenticated raw status rewrite instead of accepting a semantic alias", () => {
+    const { baseline, candidate, candidateRows, policy, raw } = fixture();
+    const original = buildTest(raw, policy);
+    const rewrittenRows = clone(candidateRows);
+    rewrittenRows[2].status = "compile_error";
+    const rewrittenCandidate = endpoint(CANDIDATE_SHA, rewrittenRows, candidate.mode);
+    const rewrittenPolicy = makePolicy(baseline, rewrittenCandidate);
+    const rewrittenRaw = inputs(baseline, rewrittenCandidate);
+    const rewritten = buildTest(rewrittenRaw, rewrittenPolicy);
+    expect(rewritten.endpoints.candidate.evidence.semantic_rows_sha256).not.toBe(
+      original.endpoints.candidate.evidence.semantic_rows_sha256,
+    );
+    const descriptorOnlyPolicy = clone(policy);
+    descriptorOnlyPolicy.endpoints.candidate.jsonl = descriptor(rewrittenCandidate.jsonl);
+    expect(() =>
+      verifyStandaloneHighwaterTransitionManifestForTest(original, rewrittenRaw, descriptorOnlyPolicy),
+    ).toThrow(/raw-jsonl-evidence-mismatch: candidate manifest JSONL descriptor contradicts policy/);
+  });
+
+  it("binds non-transition row timestamp, scope, and retry metadata through authenticated rebuild", () => {
+    const { baseline, candidate, candidateRows, policy, raw } = fixture();
+    const original = buildTest(raw, policy);
+    const mutations: Array<{ name: string; update: (entry: Row) => void }> = [
+      {
+        name: "timestamp",
+        update(entry) {
+          entry.timestamp = "30.8.2026, 13:09:51";
+        },
+      },
+      {
+        name: "scope",
+        update(entry) {
+          entry.scope = "proposal";
+        },
+      },
+      {
+        name: "retry",
+        update(entry) {
+          entry.retried = true;
+          entry.retry_count = 2;
+        },
+      },
+    ];
+
+    for (const mutation of mutations) {
+      const rewrittenRows = clone(candidateRows);
+      mutation.update(rewrittenRows[2]);
+      const rewrittenCandidate = withRows(candidate, rewrittenRows);
+      const rewrittenPolicy = makePolicy(baseline, rewrittenCandidate);
+      const rewrittenRaw = inputs(baseline, rewrittenCandidate);
+      const rewritten = buildTest(rewrittenRaw, rewrittenPolicy);
+      expect(rewritten.transitions).toEqual(original.transitions);
+      expect(rewritten.endpoints.candidate.evidence.semantic_rows_sha256).not.toBe(
+        original.endpoints.candidate.evidence.semantic_rows_sha256,
+      );
+
+      const descriptorBridged = clone(original);
+      descriptorBridged.endpoints.candidate.evidence.raw_jsonl = rewritten.endpoints.candidate.evidence.raw_jsonl;
+      expect(() =>
+        verifyStandaloneHighwaterTransitionManifestForTest(descriptorBridged, rewrittenRaw, rewrittenPolicy),
+      ).toThrow(
+        /manifest-authenticated-evidence-mismatch: manifest does not exactly reproduce authenticated raw endpoint evidence/,
+      );
+    }
+  });
+
+  it("keeps structural semantic digests order-stable while raw descriptors remain order-sensitive", () => {
+    const { baseline, baselineRows, candidate, candidateRows, policy, raw } = fixture();
+    const original = buildTest(raw, policy);
+    const reorderedBaseline = withRows(baseline, [...baselineRows].reverse());
+    const reorderedCandidate = withRows(candidate, [...candidateRows].reverse());
+    const reorderedPolicy = makePolicy(reorderedBaseline, reorderedCandidate);
+    const reordered = buildTest(inputs(reorderedBaseline, reorderedCandidate, [...KEYS].reverse()), reorderedPolicy);
+    expect(reordered.transition_rows_sha256).toBe(original.transition_rows_sha256);
+    expect(reordered.endpoints.baseline.evidence.semantic_rows_sha256).toBe(
+      original.endpoints.baseline.evidence.semantic_rows_sha256,
+    );
+    expect(reordered.endpoints.candidate.evidence.semantic_rows_sha256).toBe(
+      original.endpoints.candidate.evidence.semantic_rows_sha256,
+    );
+    expect(reordered.endpoints.baseline.evidence.raw_jsonl.sha256).not.toBe(
+      original.endpoints.baseline.evidence.raw_jsonl.sha256,
+    );
+    expect(
+      renderStandaloneHighwaterTransitionManifestForTest(
+        reordered,
+        inputs(reorderedBaseline, reorderedCandidate, [...KEYS].reverse()),
+        reorderedPolicy,
+      ),
+    ).not.toBe(renderStandaloneHighwaterTransitionManifestForTest(original, raw, policy));
+  });
+
+  it("requires raw inputs for verification and rejects semantic, metadata, and absolute-summary rewrites", () => {
+    const { policy, raw } = fixture();
+    const manifest = buildTest(raw, policy);
+    expect(verifyStandaloneHighwaterTransitionManifestForTest(manifest, raw, policy)).toEqual(manifest);
+    expect(() => verifyStandaloneHighwaterTransitionManifest(manifest)).toThrow(
+      /missing-build-inputs: acceptance verification requires authenticated raw build inputs/,
+    );
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(manifest, undefined, policy)).toThrow(
+      /missing-build-inputs: acceptance verification requires authenticated raw build inputs/,
+    );
+
+    const semantic = clone(manifest);
+    semantic.endpoints.candidate.evidence.semantic_rows_sha256 = "0".repeat(64);
+    const timestamp = clone(manifest);
+    timestamp.endpoints.candidate.metadata.timestamp = "2026-08-30T12:00:01Z";
+    const categories = clone(manifest);
+    categories.endpoints.candidate.metadata.categories = { rewritten: { source: "non-transition metadata" } };
+    const absolute = clone(manifest);
+    absolute.summary.baseline_host_free_pass++;
+    absolute.summary.candidate_host_free_pass++;
+
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(semantic, raw, policy)).toThrow(
+      /manifest-authenticated-evidence-mismatch: manifest does not exactly reproduce authenticated raw endpoint evidence/,
+    );
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(timestamp, raw, policy)).toThrow(
+      /manifest-authenticated-evidence-mismatch: manifest does not exactly reproduce authenticated raw endpoint evidence/,
+    );
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(categories, raw, policy)).toThrow(
+      /manifest-authenticated-evidence-mismatch: manifest does not exactly reproduce authenticated raw endpoint evidence/,
+    );
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(absolute, raw, policy)).toThrow(
+      /pinned-summary-mismatch: manifest absolute or transition summary contradicts policy/,
+    );
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(semantic, undefined, policy)).toThrow(
+      /missing-build-inputs: acceptance verification requires authenticated raw build inputs/,
+    );
+
+    const transitionRewrite = clone(manifest);
+    transitionRewrite.transitions[0].baseline.timestamp = "changed";
+    transitionRewrite.transition_rows_sha256 = transitionRowsSha256(transitionRewrite.transitions);
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(transitionRewrite, raw, policy)).toThrow(
+      /manifest-authenticated-evidence-mismatch/,
+    );
+  });
+
+  it("preserves JSON-round-tripped __proto__ members through authenticated verification", () => {
+    const { policy, raw } = fixture();
+    const manifest = buildTest(raw, policy);
+
+    const poisonedPaths = clone(manifest);
+    poisonedPaths.endpoints.baseline.evidence.paths = jsonRoundTrippedNullProtoMember(
+      poisonedPaths.endpoints.baseline.evidence.paths,
+    );
+    expect(Object.prototype.hasOwnProperty.call(poisonedPaths.endpoints.baseline.evidence.paths, "__proto__")).toBe(
+      true,
+    );
+    expect((poisonedPaths.endpoints.baseline.evidence.paths as Record<string, unknown>).__proto__).toBeNull();
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(poisonedPaths, raw, policy)).toThrow(
+      /policy-evidence-mismatch: baseline manifest paths contradict policy/,
+    );
+
+    const poisonedCategories = clone(manifest);
+    poisonedCategories.endpoints.candidate.metadata.categories = jsonRoundTrippedNullProtoMember(
+      poisonedCategories.endpoints.candidate.metadata.categories,
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(poisonedCategories.endpoints.candidate.metadata.categories, "__proto__"),
+    ).toBe(true);
+    expect(
+      (poisonedCategories.endpoints.candidate.metadata.categories as Record<string, unknown>).__proto__,
+    ).toBeNull();
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(poisonedCategories, raw, policy)).toThrow(
+      /manifest-authenticated-evidence-mismatch: manifest does not exactly reproduce authenticated raw endpoint evidence/,
+    );
+
+    const poisonedTransition = clone(manifest);
+    poisonedTransition.transitions[0].baseline = jsonRoundTrippedNullProtoMember(
+      poisonedTransition.transitions[0].baseline,
+    );
+    expect(Object.prototype.hasOwnProperty.call(poisonedTransition.transitions[0].baseline, "__proto__")).toBe(true);
+    expect((poisonedTransition.transitions[0].baseline as Record<string, unknown>).__proto__).toBeNull();
+    expect(() => verifyStandaloneHighwaterTransitionManifestForTest(poisonedTransition, raw, policy)).toThrow(
+      /manifest-authenticated-evidence-mismatch: manifest does not exactly reproduce authenticated raw endpoint evidence/,
+    );
+  });
+
+  it("uses raw-only CLI arguments, returns one JSON document on success, and frames errors on stderr", () => {
+    const { policy, raw } = fixture();
+    const directory = mkdtempSync(join(tmpdir(), "issue-2097-transition-"));
+    const highwaterBefore = readFileSync(HIGHWATER, "utf8");
+    const baselineJsonl = join(directory, "baseline.jsonl");
+    const candidateJsonl = join(directory, "candidate.jsonl");
+    const baselineReport = join(directory, "baseline-report.json");
+    const candidateReport = join(directory, "candidate-report.json");
+    const keys = join(directory, "keys.txt");
+    const argv = [
+      "--baseline-jsonl",
+      baselineJsonl,
+      "--candidate-jsonl",
+      candidateJsonl,
+      "--baseline-report",
+      baselineReport,
+      "--candidate-report",
+      candidateReport,
+      "--expected-keys",
+      keys,
+    ];
+    try {
+      writeFileSync(baselineJsonl, raw.baseline.jsonl);
+      writeFileSync(candidateJsonl, raw.candidate.jsonl);
+      writeFileSync(baselineReport, raw.baseline.report);
+      writeFileSync(candidateReport, raw.candidate.report);
+      writeFileSync(keys, raw.expectedKeys);
+      const output = runTransitionManifestCliForTest(argv, policy);
+      expect(output.endsWith("\n")).toBe(true);
+      expect(JSON.parse(output).policy_id).toBe("issue-2097-test-policy-v1");
+
+      const fixedPolicyProof = spawnSync(process.execPath, [CLI, ...argv], { encoding: "utf8" });
+      expect(fixedPolicyProof.status).toBe(2);
+      expect(fixedPolicyProof.stdout).toBe("");
+      expect(fixedPolicyProof.stderr).toMatch(
+        /^standalone-highwater-transition-manifest: raw-jsonl-evidence-mismatch: baseline jsonl does not match the immutable #2097 raw descriptor/,
+      );
+
+      writeFileSync(baselineJsonl, Buffer.concat([raw.baseline.jsonl, Buffer.from(" ")]));
+      expect(() => runTransitionManifestCliForTest(argv, policy)).toThrow(
+        /raw-jsonl-evidence-mismatch: baseline jsonl does not match the immutable #2097 raw descriptor/,
+      );
+
+      const rejectedArgument = spawnSync(process.execPath, [CLI, ...argv, "--baseline-expected", "forbidden.json"], {
+        encoding: "utf8",
+      });
+      expect(rejectedArgument.status).toBe(2);
+      expect(rejectedArgument.stdout).toBe("");
+      expect(rejectedArgument.stderr).toMatch(/^standalone-highwater-transition-manifest: invalid-arguments:/);
+      expect(readFileSync(HIGHWATER, "utf8")).toBe(highwaterBefore);
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- adds an immutable production policy for the two standalone endpoints, including tested commit, persistent baseline-store commit/tree, raw JSONL/report descriptors, exact modes, and the 48,735-key census
- authenticates raw bytes before parsing, reconciles each report with its JSONL rows, and publishes deterministic semantic and transition digests
- adds fail-closed coverage for producer shape, prototype keys, retry evidence, report vectors, byte drift, CLI framing, and canonical reorder behavior

This is a diagnostic recovery checkpoint only. It does not change compiler behavior, lower the standalone high-water floor, or bypass its merge-group gate.

## Measured transition

- baseline: `fc6fd3b5f3df1fbce731bf74c391aca41fcd08c2`, baseline-store `9657d806b1d6ed0f54256c74b390f232677bd8e4`
- candidate: `01fb67624e2f645b7e92dd9f8e47478e3face9ba`, baseline-store `f0d6b57da9362471decffeb6f3d98d650d477bd5`
- host-free passes: 33,876 → 32,581 (net -1,295)
- transitions: 1,764 regressions / 469 improvements
- transition digest: `90ebcd6ffe4e33a0e4e3c75e4e897acc9f7365e89537caca6be9fed48ef3f140`

## Validation

- authenticated production replay over all 48,735 rows
- focused test: 15/15
- TypeScript 7 and TypeScript 5 typechecks
- Prettier, Biome, syntax, diff, LOC, function, and oracle ratchets
- full precommit and prepush hooks, both enabled
- signed commit authored by Thomas Tränkler

## Follow-up

Use the authenticated path vector for Phase B attribution and fix-forward recovery. The existing floor remains authoritative until recovered by compiler changes.