### PR TITLE
fix(ir): route prepared function bodies by exact unit ID

### DIFF
--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -2912,3 +2912,18 @@ bytes), the independent `directOnly` scalar owner proves compile-once beside a
 blocked function-value component, and the module-init boundary poisons the
 scalar callee's direct body while proving that the module initializer itself
 remains direct.
+
+## 2026-08-30 — exact function-body UnitId routing checkpoint
+
+This bounded checkpoint makes exact `IrUnitId` skip and preserve receipts the
+authority at the ordinary prepare-before-direct declaration seam, including the
+inherited compatibility route and already-installed prepared free bodies. The
+legacy name sets remain deterministic compatibility/telemetry projections and
+must agree with the exact receipts or fail closed. It changes neither selector
+population nor the legacy-body count.
+
+## Test Results
+
+- Focused exact-routing plus fast-scalar/route-off/direct-negative subset: 6 passed.
+- TypeScript 7 validation, changed-file lint/format, IR fallback/layering, and
+  LOC/function budget ratchets: passed.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3912,6 +3912,10 @@ interface IrFirstBodyRouting {
   readonly preparedImplicitConstructorUnitIds?: ReadonlySet<IrUnitId>;
   readonly preparedReport?: IrIntegrationReport;
   readonly preparedSelection?: Pick<IrSelection, "funcs" | "classMembers" | "classMemberUnitIds" | "moduleInit">;
+  /** Exact free-function body authority for the direct declaration seam. */
+  readonly skipBodyUnitIds?: ReadonlySet<IrUnitId>;
+  /** Exact prepared free-function bodies whose installed IR bodies survive direct traversal. */
+  readonly preserveBodyUnitIds?: ReadonlySet<IrUnitId>;
   readonly skipBodies?: ReadonlySet<string>;
   readonly preserveBodies?: ReadonlySet<string>;
 }
@@ -4496,6 +4500,7 @@ function planIrFirstBodyRouting(
         return {
           requestedSkipProjection,
           preparedSelection: plan.safeSelection,
+          skipBodyUnitIds: requestedSkipUnitIds,
           skipBodies: new Set(requestedSkipProjection.entries.map(({ legacyName }) => legacyName)),
         };
       }
@@ -4598,8 +4603,8 @@ function planIrFirstBodyRouting(
       const preparedImplicitConstructorUnitIds = preparedBodies.implicitConstructorUnitIds;
       const preparedReport = preparedBodies.report;
       const requestedSkipUnitIds = computePreparedInheritedIrFirstSkipUnitIds(inheritedSkipInput);
-      for (const entry of preparedFreeFunctions.requestedSkipProjection.entries) {
-        requestedSkipUnitIds.add(entry.unitId);
+      for (const unitId of preparedFreeFunctions.skipBodyUnitIds) {
+        requestedSkipUnitIds.add(unitId);
       }
       const requestedSkipProjection = buildIrRequestedFunctionSkipProjection(
         requestedSkipUnitIds,
@@ -4613,6 +4618,8 @@ function planIrFirstBodyRouting(
         ...(preparedImplicitConstructorUnitIds.size > 0 ? { preparedImplicitConstructorUnitIds } : {}),
         preparedReport,
         preparedSelection,
+        skipBodyUnitIds: requestedSkipUnitIds,
+        preserveBodyUnitIds: preparedFreeFunctions.preserveBodyUnitIds,
         skipBodies: new Set(requestedSkipProjection.entries.map(({ legacyName }) => legacyName)),
         preserveBodies: preparedFreeFunctions.preserveBodies,
       };
@@ -4631,6 +4638,7 @@ function planIrFirstBodyRouting(
   );
   return {
     requestedSkipProjection,
+    skipBodyUnitIds: requestedSkipUnitIds,
     skipBodies: new Set(requestedSkipProjection.entries.map(({ legacyName }) => legacyName)),
     ...(finalizedSelection ? { preparedSelection: finalizedSelection } : {}),
   };
@@ -4651,14 +4659,19 @@ function compileIrRoutedDeclarations(input: {
   /** (#3522 F4) The one proof-derived admitted-class marker; never recomputed. */
   readonly nestedClassFieldCallAdmission?: IrNestedClassFieldCallAdmission;
   readonly preparedModuleInit?: PreparedIrModuleInitBody;
+  /** Compatibility/audit-only names; exact UnitIds below decide direct suppression. */
   readonly irSkipBodies?: ReadonlySet<string>;
   readonly irPreserveBodies?: ReadonlySet<string>;
+  readonly irSkipBodyUnitIds?: ReadonlySet<IrUnitId>;
+  readonly irPreserveBodyUnitIds?: ReadonlySet<IrUnitId>;
 }): {
   readonly actuallySkipped?: string[];
+  readonly functionUnitIds: readonly IrUnitId[];
   readonly classMemberUnitIds: readonly IrUnitId[];
   readonly implicitConstructorUnitIds: readonly IrUnitId[];
   readonly moduleInitNames: readonly string[];
 } {
+  const functionUnitIds: IrUnitId[] = [];
   const classMemberNames: string[] = [];
   const classMemberUnitIds: IrUnitId[] = [];
   const implicitConstructorUnitIds: IrUnitId[] = [];
@@ -4686,6 +4699,22 @@ function compileIrRoutedDeclarations(input: {
         skippedNames: moduleInitNames,
       }
     : undefined;
+  const hasNameFunctionRouting = input.irSkipBodies !== undefined || input.irPreserveBodies !== undefined;
+  const hasExactFunctionRouting = input.irSkipBodyUnitIds !== undefined;
+  if (hasNameFunctionRouting !== hasExactFunctionRouting) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "IR-first declaration compilation must route function bodies by both exact UnitId and compatibility projection",
+    );
+  }
+  const functionBodyRouting = input.irSkipBodyUnitIds
+    ? {
+        skipBodyUnitIds: input.irSkipBodyUnitIds,
+        preserveSkippedBodyUnitIds: input.irPreserveBodyUnitIds ?? new Set<IrUnitId>(),
+        skippedUnitIds: functionUnitIds,
+      }
+    : undefined;
   const previousClassBodyRouting = input.ctx.irClassBodyRouting;
   try {
     input.ctx.irClassBodyRouting = classBodyRouting;
@@ -4698,7 +4727,9 @@ function compileIrRoutedDeclarations(input: {
         classBodyRouting,
         "full",
         moduleInitBodyRouting,
+        functionBodyRouting,
       ),
+      functionUnitIds,
       classMemberUnitIds,
       implicitConstructorUnitIds,
       moduleInitNames,
@@ -5427,6 +5458,8 @@ export function generateModule(
     let irSkippedModuleInitUnitIds: ReadonlySet<IrUnitId> = new Set();
     let irSkipBodies: ReadonlySet<string> | undefined;
     let irPreserveBodies: ReadonlySet<string> | undefined;
+    let irSkipBodyUnitIds: ReadonlySet<IrUnitId> | undefined;
+    let irPreserveBodyUnitIds: ReadonlySet<IrUnitId> | undefined;
     if (irFirst) {
       irPlan = planIrOverlay(ctx, ast, irPlanningIdentityContext!, { enableCountedStringAppendProof: true });
       const routing = planIrFirstBodyRouting(ctx, ast.sourceFile, irPlan, moduleInitPlanning);
@@ -5439,10 +5472,13 @@ export function generateModule(
       preparedSelection = routing.preparedSelection;
       irSkipBodies = routing.skipBodies;
       irPreserveBodies = routing.preserveBodies;
+      irSkipBodyUnitIds = routing.skipBodyUnitIds;
+      irPreserveBodyUnitIds = routing.preserveBodyUnitIds;
     }
     // Third pass: compile function bodies
     const {
       actuallySkipped,
+      functionUnitIds: actuallySkippedFunctionUnitIds,
       classMemberUnitIds: actuallySkippedClassMemberUnitIds,
       implicitConstructorUnitIds: actuallySkippedImplicitConstructorUnitIds,
       moduleInitNames: actuallySkippedModuleInit,
@@ -5460,6 +5496,8 @@ export function generateModule(
         preparedModuleInit,
         irSkipBodies,
         irPreserveBodies,
+        irSkipBodyUnitIds,
+        irPreserveBodyUnitIds,
       }),
     );
     if (irFirst) {
@@ -5471,9 +5509,36 @@ export function generateModule(
           "IR-first declaration compilation has no exact requested-skip projection",
         );
       }
-      const correlated = correlateIrSkippedFunctionNames(skipProjection, actuallySkipped ?? []);
-      irFirstSkipped = correlated.legacyNames;
-      irSkippedFunctionUnitIds = correlated.unitIds;
+      if (!irSkipBodyUnitIds) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "resolve",
+          "IR-first declaration compilation has no exact function-body skip population",
+        );
+      }
+      const correlatedNames = correlateIrSkippedFunctionNames(skipProjection, actuallySkipped ?? []);
+      const correlatedUnitIds = correlateIrSkippedBodyUnitIds(
+        irSkipBodyUnitIds,
+        actuallySkippedFunctionUnitIds,
+        "function",
+      );
+      const projectedNames = actuallySkippedFunctionUnitIds.map(
+        (unitId) => skipProjection.requireUnit(unitId).legacyName,
+      );
+      if (
+        projectedNames.length !== correlatedNames.legacyNames.length ||
+        projectedNames.some((legacyName, index) => legacyName !== correlatedNames.legacyNames[index])
+      ) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "resolve",
+          "IR-first exact function-body results disagree with the compatibility name projection",
+        );
+      }
+      // The exact direct-emitter receipt controls post-direct ownership. The
+      // public name list is only its deterministic, validated projection.
+      irFirstSkipped = Object.freeze(projectedNames);
+      irSkippedFunctionUnitIds = correlatedUnitIds;
       if (preparedClassMembers) {
         irSkippedClassMemberUnitIds = correlateIrSkippedBodyUnitIds(
           preparedClassMembers.skipBodyUnitIds,

--- a/src/codegen/ir-overlay-safety.ts
+++ b/src/codegen/ir-overlay-safety.ts
@@ -135,7 +135,7 @@ export function correlateIrSkippedBodyNames(
 export function correlateIrSkippedBodyUnitIds(
   requestedUnitIds: ReadonlySet<IrUnitId>,
   returnedUnitIds: readonly IrUnitId[],
-  kind: "class member" | "implicit constructor support",
+  kind: "function" | "class member" | "implicit constructor support",
 ): ReadonlySet<IrUnitId> {
   const completed = new Set<IrUnitId>();
   for (const unitId of returnedUnitIds) {

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -118,7 +118,16 @@ interface PreparedIrBodyFamily {
   readonly preserveBodies: ReadonlySet<string>;
 }
 
-export interface PreparedIrFreeFunctionBodies extends PreparedIrBodyFamily {}
+/**
+ * Prepared free-function bodies retain their exact ownership rows alongside
+ * the temporary declaration-name projection. The UnitId sets are the routing
+ * authority; names remain only for the legacy declaration seam and telemetry.
+ */
+export interface PreparedIrFreeFunctionBodies extends PreparedIrBodyFamily {
+  readonly completedBodyUnitIds: ReadonlySet<IrUnitId>;
+  readonly skipBodyUnitIds: ReadonlySet<IrUnitId>;
+  readonly preserveBodyUnitIds: ReadonlySet<IrUnitId>;
+}
 
 export interface PreparedIrClassMemberBodies extends PreparedIrBodyFamily {
   readonly completedBodyUnitIds: ReadonlySet<IrUnitId>;
@@ -1808,6 +1817,11 @@ export function prepareIrBodies(input: {
     completedBodies: new Set([...freeFunctionNames].filter((legacyName) => !freeDeferredBodies.has(legacyName))),
     skipBodies: new Set(freeRequestedSkipProjection.entries.map(({ legacyName }) => legacyName)),
     preserveBodies: new Set(freePreparedProjection.entries.map(({ legacyName }) => legacyName)),
+    completedBodyUnitIds: new Set(
+      [...freeFunctionClaimsByUnitId.keys()].filter((unitId) => !deferredPartition.freeFunctionUnitIds.has(unitId)),
+    ),
+    skipBodyUnitIds: irOwnedPartition.freeFunctionUnitIds,
+    preserveBodyUnitIds: preparedPartition.freeFunctionUnitIds,
   };
 
   const classRequestedSkipProjection = classPopulation

--- a/tests/issue-3521-prepared-free-function-routing.test.ts
+++ b/tests/issue-3521-prepared-free-function-routing.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from "vitest";
 import { analyzeSource } from "../src/checker/index.js";
 import { generateModule } from "../src/codegen/index.js";
 import { irFirstBodyIsProvenLowerable } from "../src/codegen/ir-first-gate.js";
+import { correlateIrSkippedBodyUnitIds } from "../src/codegen/ir-overlay-safety.js";
 import { compile, createIncrementalCompiler, type CompileResult, type IrObservedOutcome } from "../src/index.js";
 import { irSupportGlobalRef } from "../src/ir/abi-bindings.js";
 import { irSupportFuncRef } from "../src/ir/callable-bindings.js";
+import type { IrUnitId } from "../src/ir/identity.js";
 import { buildImports } from "../src/runtime.js";
 
 // Register the low-level codegen delegates used by generateModule.
@@ -60,6 +62,75 @@ async function compileWithPoisonedDirectFunctionBodies(
 }
 
 describe("#3521 prepare-before-emit free-function routing", () => {
+  it("routes inherited and prepared free functions by exact UnitId with names as audit mirrors", async () => {
+    const { resolvePreparedFunctionBodyRoute } = await import("../src/codegen/declarations.js");
+    const inheritedUnitId = "ir-unit:source:inherited" as IrUnitId;
+    const preparedUnitId = "ir-unit:source:prepared" as IrUnitId;
+    const sameSpelledForeignUnitId = "ir-unit:foreign:prepared" as IrUnitId;
+    const routing = {
+      skipBodyUnitIds: new Set<IrUnitId>([inheritedUnitId, preparedUnitId]),
+      preserveSkippedBodyUnitIds: new Set<IrUnitId>([preparedUnitId]),
+      skippedUnitIds: [],
+    };
+    const skipBodies = new Set(["inherited", "prepared"]);
+    const preserveSkippedBodies = new Set(["prepared"]);
+
+    // The inherited compatibility route remains skip-only, while the prepared
+    // body keeps the IR installation that already owns its callable slot.
+    expect(
+      resolvePreparedFunctionBodyRoute({
+        sourceFileName: "fixture.ts",
+        functionName: "inherited",
+        unitId: inheritedUnitId,
+        skipBodies,
+        preserveSkippedBodies,
+        routing,
+      }),
+    ).toEqual({ skip: true, preserve: false });
+    expect(
+      resolvePreparedFunctionBodyRoute({
+        sourceFileName: "fixture.ts",
+        functionName: "prepared",
+        unitId: preparedUnitId,
+        skipBodies,
+        preserveSkippedBodies,
+        routing,
+      }),
+    ).toEqual({ skip: true, preserve: true });
+
+    // A name match cannot suppress a foreign source-qualified body.
+    expect(() =>
+      resolvePreparedFunctionBodyRoute({
+        sourceFileName: "foreign.ts",
+        functionName: "prepared",
+        unitId: sameSpelledForeignUnitId,
+        skipBodies,
+        preserveSkippedBodies,
+        routing,
+      }),
+    ).toThrow(/routing disagrees/);
+  });
+
+  it("fails closed when exact free-function skip receipts are incomplete or untrusted", () => {
+    const inheritedUnitId = "ir-unit:source:inherited" as IrUnitId;
+    const preparedUnitId = "ir-unit:source:prepared" as IrUnitId;
+    const foreignUnitId = "ir-unit:foreign:prepared" as IrUnitId;
+    const requestedUnitIds = new Set<IrUnitId>([inheritedUnitId, preparedUnitId]);
+
+    expect(correlateIrSkippedBodyUnitIds(requestedUnitIds, [inheritedUnitId, preparedUnitId], "function")).toEqual(
+      new Set([inheritedUnitId, preparedUnitId]),
+    );
+    expect(() => correlateIrSkippedBodyUnitIds(requestedUnitIds, [inheritedUnitId], "function")).toThrow(
+      /omitted skipped function UnitIds/,
+    );
+    expect(() =>
+      correlateIrSkippedBodyUnitIds(requestedUnitIds, [inheritedUnitId, inheritedUnitId], "function"),
+    ).toThrow(/duplicate skipped function/);
+    expect(() =>
+      correlateIrSkippedBodyUnitIds(requestedUnitIds, [inheritedUnitId, preparedUnitId, foreignUnitId], "function"),
+    ).toThrow(/foreign skipped function/);
+  });
+
   it.each([
     ["gc", "prepared-host-string-length.ts"],
     ["standalone", "prepared-native-string-length.ts"],
@@ -369,7 +440,9 @@ describe("#3521 prepare-before-emit free-function routing", () => {
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
     expect(result.irFirstSkipped).toContain("add");
-    expect(outcome(result, "add")).toMatchObject({
+    const addOutcome = outcome(result, "add");
+    expect(addOutcome.unitId).toBeDefined();
+    expect(addOutcome).toMatchObject({
       kind: "emitted",
       legacyBodyEmitted: false,
       irBodyEmitted: true,


### PR DESCRIPTION
## Summary

- makes exact `IrUnitId` skip and preserve receipts authoritative at the ordinary prepare-before-direct declaration seam
- retains legacy names only as a deterministic compatibility and telemetry projection that must agree or fail closed
- reconciles exact returned UnitIds after direct traversal, rejecting missing, duplicate, or foreign receipts
- preserves inherited compatibility skips and already-installed prepared IR bodies without widening selector population

## Replacement

This signed current-main checkpoint supersedes closed PR #5311, whose public commits were unsigned. The five resulting file blobs are byte-identical to the previously reviewed implementation.

## Validation

- focused exact-routing suite: 39/39
- TypeScript 7 typecheck
- Prettier and Biome lint
- IR fallback and layering gates
- differential corpus delta gate: 0 new regressions
- LOC and function ratchets immediately before commit
- complete precommit and prepush hooks, both enabled
- signed commit authored and committed by Thomas Tränkler

## Review

Fresh independent Sol review approved exact signed head `f651aa523c33844d6f00cdb85ad36980232e0aeb`. It independently verified the five exact blobs, GitHub signature validity, the exact-UnitId fail-closed routing contract, 39/39 focused tests under the strict `cores - 2` load gate, TypeScript 7, and fully green CI. Any later push invalidates approval.

Refs #3521
