### PR TITLE
refactor(ir): retire Math rollback switches

### DIFF
--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -3,7 +3,7 @@ id: 3518
 title: "IR-only default and direct front-end retirement"
 status: in-progress
 created: 2026-07-21
-updated: 2026-08-25
+updated: 2026-08-30
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -193,6 +193,27 @@ R3 because its ordered plan consumes the class/static-intent census owned by
 parallel deletion opportunities. R9 also requires the explicit dynamic-value,
 control-flow, async, adoption-owner, and broader-corpus coverage closure named
 above.
+
+### 2026-08-30 #4522 Math rollback checkpoint
+
+This is a bounded pre-R9 retirement, not an IR-only policy claim. The temporary
+per-method Math withdrawals used during the initial rollout are removed while
+the exact ambient recognizer and target-capability boundary remain unchanged.
+The production registry remains a 33-method contract, and the shared linear
+legality boundary remains exactly 10/33.
+
+The closed #4522 proof adds a literal 21-row method/arity/provider census with
+42 host/standalone positive cells, 21 shadowed cells, 21 alias cells, 42
+wrong-arity cells, and 21 provider mutations. It joins the independently
+literal retirement population to the production registry and rejects missing,
+duplicate, and synthetic foreign rows. Each positive cell uses the retained
+global `experimentalIR: false` compile of the same source as an observational
+direct oracle for runtime and public Wasm surface parity; it is not a production
+fallback. The current #4522 R9 environment denominator is fifteen readers:
+the four global controls, the separately owned exact mixed-primitive selector
+rollback, nine named Prepared cutovers, and the default-on linear direct-backend
+escape hatch. Diagnostics, self-checks, and codegen-only tuning remain separately
+classified. This full inventory stays owned by #4522 until the R9 policy flip.
 
 ## Program rules
 

--- a/plan/issues/4522-ir-kill-switch-inventory-r9.md
+++ b/plan/issues/4522-ir-kill-switch-inventory-r9.md
@@ -1,11 +1,10 @@
 ---
 id: 4522
 title: "Inventory and retirement plan for IR/direct env kill-switches"
-status: done
+status: in-progress
 sprint: current
 created: 2026-08-16
-updated: 2026-08-24
-completed: 2026-08-21
+updated: 2026-08-30
 priority: medium
 horizon: s
 feasibility: easy
@@ -61,26 +60,33 @@ kind of last-minute audit R9 should not depend on.
 
 ## The inventory (measured 2026-08-21)
 
-**14 vars now, not 13** — `JS2WASM_IR_CUTOVER_AUDIT` was added after this
-issue was filed; the truncated `JS2WASM_IR_I…` in the problem statement is
-`JS2WASM_IR_I32_DOMAIN`. The classification key: a var is **R9 debt exactly
-when flipping it selects the legacy/direct path or a legacy representation**
-("IR/legacy escape hatches and compile-twice switches", #3518 R9). A toggle
-over an IR-internal pass, experiment, or log never resurrects the direct
-front-end and survives the flip — the problem statement's blanket "pass
-toggles are the R9 debt" is corrected accordingly, per-var below.
+**15 vars now, not 14** — the current source census includes the earlier
+`JS2WASM_IR_CUTOVER_AUDIT` addition and the live exact mixed-primitive
+conditional reader omitted by the prior table; the truncated `JS2WASM_IR_I…`
+in the problem statement is `JS2WASM_IR_I32_DOMAIN`. The classification key: a
+var is **R9 debt exactly when flipping it selects the legacy/direct path or a
+legacy representation** ("IR/legacy escape hatches and compile-twice switches",
+#3518 R9). A toggle over an IR-internal pass, experiment, or log never
+resurrects the direct front-end and survives the flip — the problem statement's
+blanket "pass toggles are the R9 debt" is corrected accordingly, per-var below.
 
 | Var | Default | What flipping does | Classification | Retired by |
 | --- | --- | --- | --- | --- |
 | `JS2WASM_IR_FIRST` | on | `=0` disables IR-first legacy-body skipping — forces compile-twice | **retire-at-R9** (named in the R9 row of #3518 itself) | R9 |
 | `JS2WASM_IR_STRING_BUILDER` | on | `=0` forces builder loops to legacy (`string-builder-candidate`) | **retire-at-R9** — legacy escape hatch; its always-deferred sibling arm (`containsCountedLiteralStringAppend`, the #1004 repeat-fold) is a selector gap #3518's coverage closure must own, not an env var | R9 |
 | `JS2WASM_IR_ASYNC` | on | `=0` clears `supportsAsyncIr` — async bodies route to legacy | **retire-at-R9** | R7 (#3527/#1373b) then R9 |
+| `JS2WASM_IR_MIXED_PRIMITIVE_CONDITIONAL` | on | `=0` rejects the exact mixed primitive conditional/wrapper route before claim, leaving the function direct-owned | **retire-at-R9** — separately owned exact selector rollback | #5092 then R9 |
 | `JS2WASM_IR_OBJECT_SHAPES` | on | `=0` reverts to the legacy boxed-externref object representation | **retire-at-R9** — legacy-representation escape hatch | R9 |
 | `JS2WASM_MULTI_PREPARED_SCALAR_LEAF_CUTOVER` | on | `=0` restores direct-first ownership for the bounded scalar leaf | **retire-at-R9** — bounded direct-route escape hatch | #3518 R9 |
 | `JS2WASM_MULTI_PREPARED_ARRAY_CUTOVER` | on | `=0` restores direct-first ownership for the bounded array leaf | **retire-at-R9** — bounded direct-route escape hatch | #3518 R9 |
 | `JS2WASM_MULTI_PREPARED_STRING_CUTOVER` | on | `=0` restores direct-first ownership for the exact counted-string benchmark leaf while retaining its late IR overlay | **retire-at-R9** — bounded direct-route escape hatch | #3518 R9 |
 | `JS2WASM_MULTI_PREPARED_BENCH_LOOP_CUTOVER` | on | `=0` restores direct-first ownership for the bounded benchmark loop leaf | **retire-at-R9** — bounded direct-route escape hatch | #3518 R9 |
 | `JS2WASM_MULTI_PREPARED_FIB_PAIR_CUTOVER` | on | `=0` restores direct-first ownership for the bounded Fibonacci pair | **retire-at-R9** — bounded direct-route escape hatch | #3518 R9 |
+| `JS2WASM_MULTI_PREPARED_CALLABLE_COMPONENT_CUTOVER` | on | `=0`/`false` prevents eligible standalone multi-source callable components from becoming Prepared, leaving their direct-body route available | **retire-at-R9** — bounded direct-route escape hatch | #3518 R9 |
+| `JS2WASM_MULTI_PREPARED_MODULE_INIT_CUTOVER` | off | `=1` enables the exact multi-source Prepared module-init route; unset retains the direct module-init owner | **retire-at-R9** — bounded pre-default direct-route gate | #3518 R9 |
+| `JS2WASM_PREPARED_CLASS_ROUTE_CUTOVER` | on | `=0` restores the legacy standalone class-body correlation route | **retire-at-R9** — bounded direct-route escape hatch | #3518 R9 |
+| `JS2WASM_PREPARED_TIMER_SHIM_CUTOVER` | on | `=0`/`false` restores the direct injected timer-shim body route | **retire-at-R9** — bounded direct-route escape hatch | #3518 R9 |
+| `JS2WASM_LINEAR_IR` | on | `=0` restores byte-identical direct-backend ownership for linear IR candidates | **retire-at-R9** — default-on direct-backend escape hatch | #3528 then R9 |
 | `JS2WASM_IR_INLINE` | on | `=0`/tuned sets control the IR-level inliner (#4157) | keep-as-tuning — IR pass config, no legacy involvement (a `-O`-style knob) | — |
 | `JS2WASM_IR_GVN` | off | `1` enables the GVN pass; `poison` runs the liveness self-check | keep-as-experiment + self-check — IR pass, no legacy; its owner decides the default flip | — |
 | `JS2WASM_IR_GVN_DEBUG` | off | debug prints for GVN | keep-as-diagnostic | — |
@@ -95,10 +101,171 @@ toggles are the R9 debt" is corrected accordingly, per-var below.
 Nothing is retire-now-already-dead: every var has a live reader under `src/`
 (verified by the per-var grep above the table's compilation, 2026-08-21).
 
-The original four `JS2WASM_IR_*` retire-at-R9 vars remain exactly
+The original four global `JS2WASM_IR_*` retire-at-R9 vars remain
 `JS2WASM_IR_FIRST`, `JS2WASM_IR_STRING_BUILDER`, `JS2WASM_IR_ASYNC`, and
-`JS2WASM_IR_OBJECT_SHAPES`. The five current
-`JS2WASM_MULTI_PREPARED_*_CUTOVER` vars are additional bounded direct-route
-escape hatches introduced after the 2026-08-21 census. R9 consumes the complete
-live retire-at-R9 table, not the historical cardinality. Every new bounded
-route switch must update this table in the same landing PR.
+`JS2WASM_IR_OBJECT_SHAPES`; the exact mixed-primitive conditional rollback is a
+fifth selector-route row, separately owned by #5092. The complete 2026-08-30
+source census finds fifteen `JS2WASM_IR_*` readers and nine non-test named
+Prepared cutover readers: the five earlier multi-source leaves plus callable
+component, module-init, standalone class, and timer-shim routes, plus the
+default-on `JS2WASM_LINEAR_IR` direct-backend reader. These fifteen
+route/representation readers are the complete current `retire-at-R9` env
+denominator. `JS2WASM_LINEAR_IR_COVERAGE` and `JS2WASM_LINEAR_IR_DEBUG` are
+opt-in observation/debug siblings, while `JS2WASM_DIRECT_CALLS` only tunes
+direct-codegen devirtualization and `JS2WASM_ASYNC_CLOSURE_PROMISE` only selects
+a host async-wrapper ABI; none of those select a source unit between IR and a
+direct body. R9 consumes the complete live table, not a stale historical
+cardinality. Every new bounded route switch must update this table in the same
+landing PR.
+
+## 2026-08-30 Sol implementation plan — retire the exact Math rollback family
+
+### Grounded scope
+
+Ground this slice on `origin/main` at
+`01fb67624e2f645b7e92dd9f8e47478e3face9ba`. Current production contains
+exactly 21 per-intrinsic Math rollback readers, contiguous in
+`src/ir/select.ts`'s Math-plan gate. Every one is default-on and withdraws only
+when its environment value is exactly `"0"`. The family covers inverse trig,
+derived logarithms, hyperbolic and inverse-hyperbolic functions, cube root,
+single-precision rounding, leading-zero count, integer multiply, min/max,
+round, sign, and exponential-minus-one.
+
+This is a bounded R9 debt-removal checkpoint, not the R9 policy flip. The live
+mixed-primitive conditional rollback is separately owned by #5092 and the
+parallel semantic-selector work; global IR-first, string-builder, async,
+object-shape, and multi-prepared cutover switches remain. Do not edit those
+readers or claim that the complete inventory is retired.
+
+### Exact change contract
+
+1. Remove all 21 Math-specific environment branches from the selector. Keep
+   the target-capability decision and the exact ambient-binding/source-shape
+   recognizer unchanged; removal makes an already-default claim unconditional,
+   it does not admit a new syntax shape.
+2. Update the 14 focused Math test files. Delete only the narrow environment-
+   withdrawal controls and their save/restore plumbing. Preserve every exact
+   positive route, direct-body poison, IR outcome/WAT/provider assertion, and
+   shadowed, aliased, reassigned, optional, wrong-arity, or otherwise non-
+   ambient near miss.
+3. Where a narrow rollback was the only A/B oracle, replace it with the public
+   global `experimentalIR: false` control for the same exact source and lane.
+   The default build must remain IR-owned with `legacyBodyEmitted: false`; the
+   direct control must preserve runtime value, exports/imports, and Wasm
+   validity. The global oracle is retained only for comparison and is not
+   retired by this slice.
+4. Update this inventory, the R9 record in
+   `plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md`, and the
+   14 originating Math issue records append-only. Historical statements may
+   say “the per-intrinsic rollback used during initial rollout”; the retired
+   environment identifiers themselves must disappear from active plans and
+   documentation.
+5. Repository grep for the Math rollback prefix must be exactly zero across
+   source, tests, scripts, and plans. The broader IR environment inventory must
+   still enumerate the separately owned mixed-primitive rollback and all other
+   surviving R9 debt; an empty or stale inventory is a failure.
+
+### Mutation and acceptance matrix
+
+- Map all 21 intrinsics one-to-one to the existing 14 focused suites; no
+  intrinsic may disappear behind a family-level representative. The closed
+  inventory is `atan`, `tan`, `asin`, `acos`, `log10`, `log1p`, `sinh`,
+  `cosh`, `tanh`, `cbrt`, `expm1`, `clz32`, `imul`, `min`, `max`, `asinh`,
+  `acosh`, `atanh`, `sign`, `round`, and `fround`.
+- Add `tests/issue-3518-ir-math-switch-retirement.test.ts` with a literal,
+  checked 21-row method/arity/provider table. Its positive matrix is exactly
+  42 cells: every method in host and standalone must be `emitted`, use an
+  IR-only body, and have no legacy body. The table and the production Math
+  intrinsic registry must join one-to-one; missing, duplicate, and foreign
+  rows fail closed.
+- Run 21 shadowed-`Math` cells and 21 extracted/aliased-method cells. Every one
+  remains pre-claim `unsupported`, absent from `irCompiledFuncs`, with no
+  post-claim error or invariant and body flags `legacy=true`, `IR=false` under
+  the current hybrid policy.
+- Run 42 wrong-arity cells: one argument too few and one too many for every
+  method. Apply the same exact pre-claim/no-prefix/body assertions.
+- Run 21 provider mutations: wrong intrinsic binding for each of the sixteen
+  callable-backed methods, one malformed `fround` sequence, and four
+  wrong/unknown composite operations for `clz32`, `imul`, `min`, and `max`,
+  including crossed `min`/`max`. Provider mutation evidence must be exact and
+  may not be replaced by a representative family row.
+- Retain every stronger originating-suite negative: reassigned bindings,
+  computed or optional access/call, spread, unsupported operands, poison/WAT,
+  and special numeric values (`NaN`, infinities, signed zero, and 32-bit
+  coercion edges) where applicable. `max` must gain its own shadow, alias, and
+  wrong-arity evidence if the shared retirement matrix is the first place it
+  becomes non-vacuous.
+- Run at least one exact global-direct A/B control per originating suite and
+  assert the same runtime result and public artifact surface. The direct arm is
+  an observational oracle only; it must not become a production fallback.
+- Prove census non-vacuity without an ad-hoc script: the grounded pre-removal
+  record is exactly 21 production readers, and the candidate repository grep
+  is exactly zero. The new table must reject a missing, duplicate, or synthetic
+  foreign legacy entry so a zero caused by an empty/disabled census cannot
+  pass.
+
+### Four-arm A/B contract
+
+1. On the grounded current-main bytes, run the fourteen focused suites and
+   three shared #3526 Math suites with all 21 names unset.
+2. On those same current-main bytes, preserve the existing 21 independent
+   withdrawal records: setting exactly one name to `"0"` withdraws only its
+   named method while the sibling denominator remains emitted.
+3. On candidate bytes with all former names unset, require the same canonical
+   source/outcome/import/manifest/runtime projection as arm 1.
+4. On candidate bytes with all former names externally set to `"0"`, require
+   byte/projection identity with arm 3 and run the complete positive, semantic
+   negative, arity, and provider matrices. This is the authoritative proof
+   that no hidden reader survived.
+
+### Files and parallel-work lock
+
+Production ownership is limited to `src/ir/select.ts`. Test and record
+ownership is limited to the 14 `tests/issue-5101*` through
+`tests/issue-5135*` Math files, the new closed-matrix
+`tests/issue-3518-ir-math-switch-retirement.test.ts`, their 14 matching issue
+records, this inventory, and the #3518 R9 record. The open nested-vec work also
+edits `select.ts`, but at a distant hunk; merge current main normally before
+publication and re-run a fresh exact-SHA review. Do not touch ProgramABI,
+prepared publication, multi-source callable ownership, module-init, or
+export-provenance files.
+
+### Validation and landing
+
+Run all 14 focused suites, the new retirement matrix, and
+`tests/issue-3526-ir-math-intrinsic-integration.test.ts`,
+`tests/issue-3526-ir-runtime-manifest.test.ts`, and
+`tests/issue-3526-ir-linear-math-intrinsics.test.ts` together; report
+files/tests passed over total and preserve the shared 33-method denominator
+and exact 10/33 linear legality boundary. Then run TS7 and TS5 typechecks,
+targeted lint/Prettier/diff-check, IR layering, IR fallback/IR-only policy
+gates, and the relevant host/standalone equivalence controls. Every heavy
+command requires a finite, non-negative one-minute load strictly below logical
+cores minus two and an archive-backed `TMPDIR`.
+Immediately before committing, run both LOC and function-growth ratchets.
+Commit and push through the complete hooks with no bypass. Terra implements;
+a fresh independent Sol reviewer must approve the exact pushed SHA before the
+regular pull request is marked ready or enqueued. No admin or direct merge is
+permitted.
+
+### Candidate implementation record (2026-08-30)
+
+The candidate removes the exact 21 default-on per-method readers from the
+shared Math selector while leaving its ambient-binding recognizer and
+target-capability condition intact. It removes only the matching withdrawal and
+save/restore test plumbing from the fourteen originating suites. The 33-method
+production registry and the shared 10/33 linear legality denominator remain
+unchanged.
+
+`tests/issue-3518-ir-math-switch-retirement.test.ts` is the closed proof: a
+literal 21-row table independently projects the retired subset from the
+production registry, rejects missing/duplicate/foreign rows, and runs the
+host/standalone, shadow, alias, wrong-arity, and deep provider-mutation cells.
+Its global-direct comparison compiles the same combined source with
+`experimentalIR: false`, preserving signed-zero and NaN observations through
+`Object.is` while comparing runtime and public Wasm surface. Candidate source,
+tests, scripts, and plans have a zero census for the retired Math family.
+
+This checkpoint does not retire the mixed-primitive rollback or any global,
+string-builder, async, object-shape, or multi-prepared R9 switch. Those remain
+live inventory entries until their separately owned policy work lands.

--- a/plan/issues/5101-ir-exact-ambient-math-atan.md
+++ b/plan/issues/5101-ir-exact-ambient-math-atan.md
@@ -31,8 +31,9 @@ loc-budget-allow:
   - src/ir/runtime-manifest.ts
   - src/ir/select.ts
 func-budget-allow:
-  # The narrow rollback predicate belongs at the shared provider-capability
-  # check read by every selector/call-graph Math admission site.
+  # During initial rollout, the narrow rollback predicate belonged at the
+  # shared provider-capability check read by every selector/call-graph Math
+  # admission site.
   - src/ir/select.ts::selectorSupportsMathPlan
 ---
 
@@ -100,7 +101,7 @@ selection/build contract. No parallel `atan` recognizer is added.
    `IR_MATH_METHOD_TABLE`. The existing selector, number proof, call-graph
    walker, builder, manifest preparation, and backend provider resolution then
    consume the same row.
-3. Add a narrow `JS2WASM_IR_MATH_ATAN=0` selector control at
+3. Initial rollout retained a narrow per-method selector withdrawal at
    `selectorSupportsMathPlan`; it prevents only this new claim and leaves the
    direct implementation reachable. Keep `JS2WASM_IR_FIRST=0` as the global
    repository control.
@@ -125,7 +126,7 @@ selection/build contract. No parallel `atan` recognizer is added.
   legacy body.
 - Host and standalone binaries execute with direct-path parity; standalone has
   zero imports.
-- `JS2WASM_IR_MATH_ATAN=0` keeps the same valid source on the direct path.
+- The rollout-only per-method withdrawal kept the same valid source on the direct path.
 - Every excluded shape declines before claim with no post-claim error or
   invariant.
 - Existing #3526 runtime-manifest, integration, and linear-backend tests pass.
@@ -135,7 +136,7 @@ selection/build contract. No parallel `atan` recognizer is added.
 
 - `math.atan` is now the thirteenth closed source-level Math intrinsic, with
   the existing unary f64 definition and self-hosted `Math_atan` provider. The
-  only selection change is one shared table row plus the narrow rollback in
+  only selection change was one shared table row plus the narrow rollback in
   `selectorSupportsMathPlan`; from-AST lowering remains completely generic.
 - The #3526 closed-vocabulary, manifest, all-method integration, and neutrality
   evidence now describe thirteen intrinsic entry points. `math.reduce-trig`
@@ -145,7 +146,7 @@ selection/build contract. No parallel `atan` recognizer is added.
   zero-import standalone execution, provider-free semantic IR before manifest
   attachment, exact existing-provider resolution, IR/direct parity across
   finite values, infinities, NaN and signed zero, pre-claim exclusions, and a
-  compile-level `JS2WASM_IR_MATH_ATAN=0` rollback without withdrawing
+  compile-level per-method rollback without withdrawing
   `Math.atan2`.
 - TypeScript 7 typecheck, targeted Prettier/Biome, the IR kind-neutrality gate,
   and scoped LOC/function budgets pass. Independent Luna Max review returned
@@ -174,3 +175,10 @@ inside the same table used by expression selection, call-graph scanning, and
 from-AST lowering preserves one source of truth. Any provider/signature drift
 after claim remains a runtime-manifest invariant; unsupported source shapes
 must never reach that boundary.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5103-ir-exact-ambient-math-tan.md
+++ b/plan/issues/5103-ir-exact-ambient-math-tan.md
@@ -79,8 +79,8 @@ the direct path.
 3. Add `tan` to `IR_MATH_METHOD_TABLE`; reuse the generic selector,
    call-graph walker, from-AST intrinsic emitter, manifest preparation, and
    provider materializer.
-4. Add narrow rollback `JS2WASM_IR_MATH_TAN=0` without withdrawing any other
-   Math intrinsic.
+4. Initial rollout added a temporary per-method withdrawal without withdrawing
+   any other Math intrinsic.
 5. Widen #3526 exhaustive vocabulary, dependency, integration, and neutrality
    evidence from thirteen to fourteen source-level Math intrinsics.
 6. Add focused tests for host and zero-import standalone ownership, semantic
@@ -98,7 +98,7 @@ the direct path.
   capabilities.
 - Host and standalone execution match the direct path, and standalone imports
   remain empty.
-- `JS2WASM_IR_MATH_TAN=0` keeps only `Math.tan` on the direct path.
+- The temporary per-method withdrawal kept only `Math.tan` on the direct path.
 - Every excluded form declines before claim with no invariant or post-claim
   failure.
 - Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
@@ -113,7 +113,7 @@ the direct path.
   `math.tan -> [math.cos, math.sin]`, and deduplicates the transitive
   `math.reduce-trig` dependency. The existing provider materializer emits the
   established helper family; no algorithm or direct-codegen file changed.
-- `JS2WASM_IR_MATH_TAN=0` withdraws only the new claim. Shadowed, aliased,
+- The temporary per-method withdrawal withdrew only the new claim. Shadowed, aliased,
   wrong-arity, spread, and non-number forms all decline before claim.
 - Four focused/affected suites pass 23/23, including host and zero-import
   standalone execution, exact semantic/provider evidence, dependency closure,
@@ -138,5 +138,12 @@ the direct path.
 The principal risk is manifest/provider drift: `Math_tan` requires both
 `Math_sin` and `Math_cos`, which share `math.reduce-trig`. The frozen manifest
 must express that graph and prove deterministic deduplication. The shared Math
-table remains the sole source grammar contract. `JS2WASM_IR_MATH_TAN=0` is the
+table remains the sole source grammar contract. The per-method withdrawal was the
 checkpoint rollback; `JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5105-ir-exact-ambient-math-inverse-trig.md
+++ b/plan/issues/5105-ir-exact-ambient-math-inverse-trig.md
@@ -72,8 +72,8 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
    each provider.
 3. Add both methods to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
    call-graph walker, from-AST emitter, manifest, and provider materializer.
-4. Add independent `JS2WASM_IR_MATH_ASIN=0` and
-   `JS2WASM_IR_MATH_ACOS=0` rollbacks so either claim can be withdrawn alone.
+4. Initial rollout added independent per-method rollbacks so either claim could
+   be withdrawn alone.
 5. Widen #3526 exhaustive vocabulary, dependency, integration, linear-legality,
    and neutrality evidence from fourteen to sixteen source Math intrinsics.
 6. Add focused host/standalone, provider-closure, numerical-parity, rollback,
@@ -89,7 +89,7 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
   provider and requests no host capability.
 - Host and zero-import standalone execution match the direct path across
   domain boundaries, finite values, NaN, infinities, and signed zero.
-- Each rollback withdraws only its corresponding method.
+- During initial rollout, each per-method rollback withdrew only its corresponding method.
 - Excluded shapes decline before claim without invariants or post-claim errors.
 - Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
 
@@ -102,8 +102,7 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
   callables, declares `math.atan` as each provider's sole dependency, and
   materializes that dependency once. No Math algorithm or direct-codegen file
   changed.
-- Independent `JS2WASM_IR_MATH_ASIN=0` and
-  `JS2WASM_IR_MATH_ACOS=0` controls withdraw only their corresponding claim.
+- Independent per-method controls withdrew only their corresponding claim.
   Shadowed, aliased, wrong-arity, spread, and non-number forms decline before
   claim for both methods.
 - Four focused/affected suites pass 30/30. They cover host and zero-import
@@ -130,6 +129,13 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
 
 The principal risk is dependency or source-identity drift. Both semantic
 features must depend on `math.atan` without duplicating its provider, while the
-shared table remains the sole grammar contract. Independent environment flags
-provide narrow checkpoint rollback; `JS2WASM_IR_FIRST=0` remains the global
-control.
+shared table remains the sole grammar contract. During initial rollout,
+independent per-method withdrawals provided narrow rollback;
+`JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawals are retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5106-ir-exact-ambient-math-derived-log.md
+++ b/plan/issues/5106-ir-exact-ambient-math-derived-log.md
@@ -72,8 +72,8 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
    each provider.
 3. Add both methods to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
    call-graph walker, from-AST emitter, manifest, and provider materializer.
-4. Add independent `JS2WASM_IR_MATH_LOG10=0` and
-   `JS2WASM_IR_MATH_LOG1P=0` rollbacks so either claim can be withdrawn alone.
+4. Initial rollout added independent per-method rollbacks so either claim could
+   be withdrawn alone.
 5. Widen #3526 exhaustive vocabulary, dependency, integration,
    linear-legality, and neutrality evidence from sixteen to eighteen source
    Math intrinsics.
@@ -90,7 +90,7 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
   provider and requests no host capability.
 - Host and zero-import standalone execution preserve direct-path behavior and
   stay inside explicit native-Math absolute/ULP regression bounds.
-- Each rollback withdraws only its corresponding method.
+- During initial rollout, each per-method rollback withdrew only its corresponding method.
 - Excluded shapes decline before claim without invariants or post-claim errors.
 - Affected #3526 suites, TypeScript 7, and all pre-push gates pass.
 
@@ -103,8 +103,7 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
   callables, declares `math.log` as each provider's sole dependency, and
   materializes that dependency once. No Math algorithm or direct-codegen file
   changed.
-- Independent `JS2WASM_IR_MATH_LOG10=0` and
-  `JS2WASM_IR_MATH_LOG1P=0` controls withdraw only their corresponding claim.
+- Independent per-method controls withdrew only their corresponding claim.
   Shadowed, aliased, computed, optional-invocation, optional-receiver,
   wrong-arity, spread, and non-number forms all decline before claim.
 - Four focused/affected suites pass 36/36. They cover host and zero-import
@@ -133,6 +132,13 @@ computed, shadowed, coercive, spread, and wrong-arity forms remain direct.
 
 The principal risk is dependency or numerical-evidence drift. Both semantic
 features must depend on `math.log` without duplicating its provider, and the
-shared table must remain the sole grammar contract. Independent environment
-flags provide narrow checkpoint rollback; `JS2WASM_IR_FIRST=0` remains the
-global control.
+shared table must remain the sole grammar contract. During initial rollout,
+independent per-method withdrawals provided narrow rollback;
+`JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawals are retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5110-ir-exact-ambient-math-hyperbolic.md
+++ b/plan/issues/5110-ir-exact-ambient-math-hyperbolic.md
@@ -76,8 +76,7 @@ remain direct.
 3. Add all three methods to `IR_MATH_METHOD_TABLE` and reuse the generic
    selector, call-graph walker, from-AST emitter, manifest, and provider
    materializer.
-4. Add independent `JS2WASM_IR_MATH_SINH=0`,
-   `JS2WASM_IR_MATH_COSH=0`, and `JS2WASM_IR_MATH_TANH=0` rollbacks.
+4. Initial rollout added independent per-method rollbacks.
 5. Widen #3526 exhaustive vocabulary, dependency, integration,
    linear-legality, and neutrality evidence from eighteen to twenty-one source
    Math intrinsics.
@@ -98,7 +97,8 @@ remain direct.
   NaN, and infinities.
 - Native-Math sanity checks use explicit method-specific bounds that preserve
   the known approximation envelope without pretending to be libm conformance.
-- Each rollback withdraws only its corresponding method, and excluded shapes
+- During initial rollout, each per-method rollback withdrew only its corresponding
+  method, and excluded shapes
   decline before claim without invariants or post-claim errors.
 - Affected regressions, TypeScript 7, and all pre-push gates pass.
 
@@ -111,8 +111,7 @@ remain direct.
   `Math_tanh` callables, declares `math.exp` as each provider's sole
   dependency, and materializes that dependency once. No Math algorithm or
   direct-codegen file changed.
-- Independent `JS2WASM_IR_MATH_SINH=0`, `JS2WASM_IR_MATH_COSH=0`, and
-  `JS2WASM_IR_MATH_TANH=0` controls withdraw only their corresponding claim.
+- Independent per-method controls withdrew only their corresponding claim.
   Shadowed, aliased, computed, optional-invocation, optional-receiver,
   wrong-arity, spread, and non-number forms all decline before claim.
 - Four focused/affected contract suites pass 45/45. They cover host and
@@ -144,5 +143,13 @@ remain direct.
 The principal risks are dependency deduplication and inherited cancellation or
 overflow behavior. The semantic features must share one `math.exp` provider,
 while direct-path bit identity remains the hard migration invariant and native
-Math only supplies a coarse numerical sanity bound. Independent environment
-flags provide narrow rollback; `JS2WASM_IR_FIRST=0` remains the global control.
+Math only supplies a coarse numerical sanity bound. During initial rollout,
+independent per-method withdrawals provided narrow rollback;
+`JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawals are retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5111-ir-exact-ambient-math-cbrt.md
+++ b/plan/issues/5111-ir-exact-ambient-math-cbrt.md
@@ -69,7 +69,7 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
 2. Add the dependency-free `selfhost.math.cbrt -> Math_cbrt` provider.
 3. Add `cbrt` to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
    call-graph walker, from-AST emitter, manifest, and provider materializer.
-4. Add an independent `JS2WASM_IR_MATH_CBRT=0` rollback.
+4. Initial rollout added an independent per-method rollback.
 5. Widen #3526 exhaustive vocabulary, integration, linear-legality, and
    neutrality evidence from twenty-one to twenty-two source Math intrinsics.
 6. Add focused host/standalone ownership, dependency-free provider closure,
@@ -89,7 +89,8 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
   infinities.
 - A native-Math oracle pins an explicit absolute/relative accuracy envelope
   while separately proving the oracle ran on an IR-only body.
-- The narrow rollback and all excluded shapes decline before claim without
+- The former narrow rollback was validated alongside excluded shapes, which
+  decline before claim without
   invariants or post-claim errors.
 - Affected regressions, TypeScript 7, and all pre-push gates pass.
 
@@ -101,7 +102,7 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
 - The frozen manifest attaches the existing, dependency-free `Math_cbrt`
   callable and requests no host capability. No Math algorithm or
   direct-codegen file changed.
-- `JS2WASM_IR_MATH_CBRT=0` withdraws only this claim. Shadowed, aliased,
+- The per-method rollback withdrew only this claim. Shadowed, aliased,
   computed, optional-invocation, optional-receiver, wrong-arity, spread, and
   non-number forms all decline before claim.
 - Four focused/affected contract suites pass 27/27. They cover host and
@@ -137,5 +138,12 @@ Luna's numerical audit measured large pre-existing relative error at
 values in standalone mode, pins direct/IR identity at both range edges, and
 limits the native oracle to the helper's established moderate-value envelope.
 Changing the eight-step algorithm remains a separate correctness change. The
-method-specific environment flag provides narrow rollback;
+rollout-only per-method withdrawal provided narrow rollback;
 `JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5114-ir-exact-ambient-math-expm1.md
+++ b/plan/issues/5114-ir-exact-ambient-math-expm1.md
@@ -71,7 +71,7 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
    dependency.
 3. Add `expm1` to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
    call-graph walker, from-AST emitter, manifest, and provider materializer.
-4. Add an independent `JS2WASM_IR_MATH_EXPM1=0` rollback.
+4. Initial rollout added an independent per-method rollback.
 5. Widen #3526 exhaustive vocabulary, dependency, integration,
    linear-legality, and neutrality evidence from twenty-two to twenty-three
    source Math intrinsics.
@@ -92,7 +92,8 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
   infinities.
 - A native-Math oracle pins explicit Taylor/general accuracy bounds while
   separately proving the oracle ran on an IR-only body.
-- The narrow rollback and all excluded shapes decline before claim without
+- The former narrow rollback was validated alongside excluded shapes, which
+  decline before claim without
   invariants or post-claim errors.
 - Affected regressions, TypeScript 7, and all pre-push gates pass.
 
@@ -104,7 +105,7 @@ shadowed, coercive, spread, and wrong-arity forms remain direct.
 - The frozen manifest attaches the existing host-free `Math_expm1` callable,
   closes it over exactly one shared `math.exp` dependency, and requests no
   host capability. No Math algorithm or direct-codegen file changed.
-- `JS2WASM_IR_MATH_EXPM1=0` withdraws only this claim. Shadowed, aliased,
+- The per-method rollback withdrew only this claim. Shadowed, aliased,
   computed, optional-invocation, optional-receiver, wrong-arity, spread, and
   non-number forms all decline before claim without invariants or post-claim
   errors.
@@ -156,5 +157,12 @@ the shared numerical algorithm remains separate from this ownership-only PR.
 The principal risks are cancellation near zero and behavior at the strict
 `|x| < 1e-5` Taylor boundary. Direct-path bit identity remains the hard
 migration invariant and native Math supplies method-specific independent
-accuracy bounds. The method-specific environment flag provides narrow
+accuracy bounds. The rollout-only per-method withdrawal provided narrow
 rollback; `JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5125-ir-exact-ambient-math-clz32.md
+++ b/plan/issues/5125-ir-exact-ambient-math-clz32.md
@@ -113,8 +113,8 @@ The provider must:
    catalogues with the existing f64-unary signature. Add one
    `backend.math.clz32` composite provider for all targets and both Wasm
    backends, with no dependencies or host capabilities.
-3. Add a composite-marked `clz32` method plan and narrow
-   `JS2WASM_IR_MATH_CLZ32=0` rollback. Preserve the generic ambient binding,
+3. Initial rollout added a composite-marked `clz32` method plan and narrow
+   per-method rollback. Preserve the generic ambient binding,
    exact arity, non-spread, and primitive-number selector/from-AST path.
 4. Extend the closed composite operation union and lower `math.clz32` by
    reusing `emitWasmInt32Coercion` with the existing lazy i64 scratch pool,
@@ -144,8 +144,8 @@ The provider must:
   both Wasm backends.
 - Missing/malformed providers and unsupported bytecode/Porffor policies fail
   before emission; no saturation or callable fallback is introduced.
-- Coercive and excluded call shapes keep direct ownership, and rollback causes
-  a clean pre-claim decline with no post-claim errors.
+- Coercive and excluded call shapes keep direct ownership; the former rollback
+  caused a clean pre-claim decline with no post-claim errors.
 
 ## Non-goals
 
@@ -160,8 +160,8 @@ The provider must:
 The primary risk is losing unsigned-result evidence at an IR or export
 boundary. Focused result-type/provider assertions and runtime checks at 32-bit
 high-bit inputs guard that seam. The second risk is selector overreach into
-coercive or optional calls; exclusion and rollback tests keep those shapes
-legacy-owned. `JS2WASM_IR_MATH_CLZ32=0` provides narrow rollback, while
+coercive or optional calls; exclusion tests keep those shapes legacy-owned.
+During initial rollout, the per-method control provided narrow rollback, while
 `JS2WASM_IR_FIRST=0` remains the global control.
 
 ## Outcome
@@ -170,10 +170,17 @@ Implemented in PR #5141. Exact ambient one-number `Math.clz32` calls now enter
 semantic IR as `f64 -> f64`, freeze a dependency-free `backend.math.clz32`
 composite, and lower through the shared exact IEEE-754 ToUint32 expansion plus
 `i32.clz`/`f64.convert_i32_s` on both WasmGC and production linear. Bytecode and
-Porffor remain fail-closed, excluded/coercive shapes remain direct, and
-`JS2WASM_IR_MATH_CLZ32=0` withdraws only this claim.
+Porffor remain fail-closed, excluded/coercive shapes remain direct, and the
+per-method control withdrew only this claim during initial rollout.
 
 Validation covers 23 focused ownership/catalogue/provider cases, native and
 direct parity through huge finite values, zero-import standalone, composed
 Number semantics, TypeScript 7, LOC/function/oracle/coercion ratchets, issue
 integrity, and the mechanically refreshed no-growth neutrality baseline.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5126-ir-exact-ambient-math-imul.md
+++ b/plan/issues/5126-ir-exact-ambient-math-imul.md
@@ -95,8 +95,8 @@ Porffor remain rejected by legality before emission.
 1. Add `math.imul` to the certified Math ID/runtime-feature catalogues with the
    existing f64-binary signature and add dependency-free
    `backend.math.imul` composite provider metadata.
-2. Add a binary composite-marked selector plan and the narrow
-   `JS2WASM_IR_MATH_IMUL=0` rollback while retaining the shared ambient-binding,
+2. Initial rollout added a binary composite-marked selector plan and narrow
+   per-method rollback while retaining the shared ambient-binding,
    exact-arity, non-spread, and primitive-number admission gates.
 3. Extend the closed composite union and add an exact binary Wasm wrapper that
    uses one i32 rhs local plus #5136's reusable i64 coercion scratch.
@@ -124,7 +124,8 @@ Porffor remain rejected by legality before emission.
 - The provider is frozen, dependency-free, host-free, and emits right coercion,
   one i32 stash, left coercion, `i32.mul`, and `f64.convert_i32_s` in that order.
 - Missing/malformed providers and unsupported bytecode/Porffor consumers fail
-  closed; excluded/coercive shapes and rollback cleanly retain direct ownership.
+  closed; excluded/coercive shapes retain direct ownership, and the former
+  rollback was pre-claim only.
 
 ## Non-goals
 
@@ -142,7 +143,8 @@ The primary risk is reversing operands or destroying the left f64 while the
 right operand is coerced. Stack-shape assertions, non-commutative coercion edge
 vectors, and side-effect-order tests guard that seam. The second risk is using
 saturating conversion for huge values; #5136 regression vectors remain in the
-focused bundle. `JS2WASM_IR_MATH_IMUL=0` withdraws only this claim, while
+focused bundle. During initial rollout, the per-method control withdrew only
+this claim, while
 `JS2WASM_IR_FIRST=0` remains the global control.
 
 ## Outcome
@@ -152,8 +154,8 @@ semantic intrinsic backed by one dependency-free, host-free Wasm composite.
 The shared exact ToUint32 expansion coerces right then left, reuses the existing
 i64 scratch pool plus one lazy i32 rhs local, multiplies with `i32.mul`, and
 returns the signed Int32 result as f64. WasmGC and production linear emit the
-same closed body; bytecode and Porffor remain fail-closed, and
-`JS2WASM_IR_MATH_IMUL=0` provides the narrow rollback.
+same closed body; bytecode and Porffor remain fail-closed, and the per-method
+control provided the narrow rollback during initial rollout.
 
 Validation passed for the 14 focused #5126 cases, the #3526 linear,
 integration, and manifest suites, the #5136 exact-coercion prerequisite (30/30
@@ -161,3 +163,10 @@ tests total), TypeScript 7, lint, formatting, IR kind-neutrality, LOC/function
 budgets, oracle/coercion ratchets, and issue integrity. Luna Max architecture
 and test audits confirmed the stack discipline, provider boundary, and focused
 coverage with no checkpoint-scoped blockers.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5130-ir-exact-ambient-math-minmax.md
+++ b/plan/issues/5130-ir-exact-ambient-math-minmax.md
@@ -98,9 +98,9 @@ Bytecode and Porffor remain rejected by legality before emission.
 1. Add `math.min` and `math.max` to the certified Math ID/runtime-feature
    catalogues with the existing f64-binary signature and add dependency-free
    `backend.math.min` / `backend.math.max` composite provider metadata.
-2. Add exact-binary composite selector plans plus narrow
-   `JS2WASM_IR_MATH_MIN=0` and `JS2WASM_IR_MATH_MAX=0` rollbacks while
-   retaining ambient-binding, exact-arity, non-spread, and primitive-number
+2. Initial rollout added exact-binary composite selector plans plus narrow
+   per-method rollbacks while retaining ambient-binding, exact-arity,
+   non-spread, and primitive-number
    admission gates.
 3. Extend the closed composite union and add one shared Wasm min/max emitter
    using two lazily allocated f64 locals, explicit ordered NaN guards, and the
@@ -130,8 +130,8 @@ Bytecode and Porffor remain rejected by legality before emission.
 - Each provider is frozen, dependency-free, host-free, and emits two stores,
   ordered NaN guards, then exactly one `f64.min` or `f64.max`.
 - Missing/malformed providers and unsupported bytecode/Porffor consumers fail
-  closed; excluded/coercive/variadic shapes and rollback retain direct
-  ownership.
+  closed; excluded/coercive/variadic shapes retain direct ownership and the
+  former rollback was pre-claim only.
 
 ## Non-goals
 
@@ -148,8 +148,9 @@ signed-zero differences. Ordered local-based guards and reciprocal-zero tests
 pin those semantics independently for each method. The second risk is
 short-circuiting right-argument evaluation when left is NaN; argument-order
 fixtures require both effects before the composite executes.
-`JS2WASM_IR_MATH_MIN=0` and `JS2WASM_IR_MATH_MAX=0` independently withdraw
-the claims, while `JS2WASM_IR_FIRST=0` remains the global control.
+During initial rollout, the per-method controls independently withdrew the
+claims, while
+`JS2WASM_IR_FIRST=0` remains the global control.
 
 ## Outcome
 
@@ -158,8 +159,8 @@ typed binary semantic intrinsics backed by dependency-free, host-free Wasm
 composites. Each composite stores both already-evaluated operands, propagates
 left then right NaN explicitly, and uses regular `f64.min` / `f64.max` for
 the required signed-zero ordering. WasmGC and production linear emit identical
-closed bodies; bytecode and Porffor remain fail-closed, and each method has an
-independent narrow rollback.
+closed bodies; bytecode and Porffor remain fail-closed, and each method had an
+independent narrow rollback during initial rollout.
 
 Validation passed for all 19 focused #5130 cases, the #3526 linear,
 integration, and manifest suites plus the #5126 prerequisite (27/27), and the
@@ -168,3 +169,10 @@ lint, formatting, IR kind-neutrality, LOC/function budgets, oracle/coercion
 ratchets, and issue integrity passed. Three Luna Max architecture and priority
 audits independently selected this exact checkpoint and found no
 checkpoint-scoped semantic blocker.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawals are retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5132-ir-exact-ambient-math-inverse-hyperbolic.md
+++ b/plan/issues/5132-ir-exact-ambient-math-inverse-hyperbolic.md
@@ -76,8 +76,7 @@ spread, and wrong-arity forms remain direct.
 3. Add all three methods to `IR_MATH_METHOD_TABLE` and reuse the generic
    selector, call-graph walker, from-AST emitter, manifest, and provider
    materializer.
-4. Add independent `JS2WASM_IR_MATH_ASINH=0`,
-   `JS2WASM_IR_MATH_ACOSH=0`, and `JS2WASM_IR_MATH_ATANH=0` rollbacks.
+4. Initial rollout added independent per-method rollbacks.
 5. Widen #3526 exhaustive vocabulary, dependency, integration,
    linear-legality, and neutrality evidence from twenty-three to twenty-six
    source Math intrinsics.
@@ -100,8 +99,9 @@ spread, and wrong-arity forms remain direct.
   inherited range edges, NaN, and infinities.
 - Native-Math checks pin explicit method-specific safe-range envelopes while
   separately proving every oracle ran on an IR-only body.
-- Each narrow rollback withdraws only its corresponding method, and excluded
-  shapes decline before claim without invariants or post-claim errors.
+- During initial rollout, each narrow rollback withdrew only its corresponding
+  method; excluded shapes decline before claim without invariants or post-claim
+  errors.
 - Affected regressions, TypeScript 7, and all pre-push gates pass.
 
 ## Implementation outcome and validation
@@ -114,8 +114,7 @@ spread, and wrong-arity forms remain direct.
   `Math_acosh`, and `Math_atanh` callables, closes each over `math.log`,
   materializes that dependency once, and requests no host capability. No Math
   algorithm or direct-codegen file changed.
-- Independent `JS2WASM_IR_MATH_ASINH=0`, `JS2WASM_IR_MATH_ACOSH=0`, and
-  `JS2WASM_IR_MATH_ATANH=0` controls withdraw only their corresponding claim.
+- Independent per-method controls withdrew only their corresponding claim.
   Shadowed, aliased, computed, optional-invocation, optional-receiver,
   wrong-arity, spread, and non-number forms all decline before claim.
 - Four focused/affected contract suites pass 45/45. They cover host and
@@ -168,5 +167,13 @@ The principal risks are inherited cancellation near zero, domain endpoints,
 and multiplication overflow in the existing `x * x` formulas for large finite
 inputs. Direct-path bit identity remains the hard migration invariant; native
 Math evidence will use separately measured safe ranges rather than disguise
-known approximation limits. Independent environment flags provide narrow
-rollback; `JS2WASM_IR_FIRST=0` remains the global control.
+known approximation limits. During initial rollout, independent per-method
+withdrawals provided narrow rollback; `JS2WASM_IR_FIRST=0` remains the global
+control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawals are retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5133-ir-exact-ambient-math-sign.md
+++ b/plan/issues/5133-ir-exact-ambient-math-sign.md
@@ -86,7 +86,7 @@ shadowed, coercive, Symbol, spread, and wrong-arity forms remain direct.
    unary-f64 signature and a dependency-free `selfhost.math.sign` provider.
 3. Add `sign` to `IR_MATH_METHOD_TABLE` and reuse the generic selector,
    call-graph walker, from-AST emitter, manifest, and provider materializer.
-4. Add an independent `JS2WASM_IR_MATH_SIGN=0` rollback.
+4. Initial rollout added an independent per-method rollback.
 5. Widen #3526 exhaustive vocabulary, integration, linear-deferral, and
    neutrality evidence from twenty-six to twenty-seven source Math intrinsics.
 6. Add focused host/standalone ownership, dependency-free provider closure,
@@ -108,8 +108,8 @@ shadowed, coercive, Symbol, spread, and wrong-arity forms remain direct.
   support is not mistaken for backend support.
 - Symbol/coercive and all other excluded shapes preserve direct behavior and
   decline before claim without invariants or post-claim errors.
-- The narrow rollback, affected regressions, TypeScript 7, and all pre-push
-  gates pass.
+- The former narrow rollback was validated alongside the affected regressions,
+  TypeScript 7, and all pre-push gates.
 
 ## Implementation outcome and validation
 
@@ -157,5 +157,12 @@ shadowed, coercive, Symbol, spread, and wrong-arity forms remain direct.
 The primary semantic risk is changing evaluation or bit identity for NaN and
 negative zero while adding the IR-owned self-hosted path. Exact direct/IR
 parity and existing Symbol-coercion tests are the hard boundaries.
-`JS2WASM_IR_MATH_SIGN=0` provides narrow rollback;
+The rollout-only per-method withdrawal provided narrow rollback;
 `JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5134-ir-exact-ambient-math-round.md
+++ b/plan/issues/5134-ir-exact-ambient-math-round.md
@@ -111,8 +111,8 @@ instructions inside the helper; they are not callable provider dependencies.
    with a unary-f64 signature and dependency-free `selfhost.math.round`
    provider.
 3. Add `round` to `IR_MATH_METHOD_TABLE`, reuse the generic selection,
-   from-AST, manifest, and materialization path, and add the independent
-   `JS2WASM_IR_MATH_ROUND=0` rollback.
+   from-AST, manifest, and materialization path; initial rollout added the
+   independent per-method rollback.
 4. Widen #3526 exhaustive vocabulary, integration, linear-legality, and
    neutrality evidence from twenty-seven to twenty-eight source Math
    intrinsics. Refresh stale tests that still describe `round` as a legacy
@@ -140,8 +140,8 @@ instructions inside the helper; they are not callable provider dependencies.
   native linear Math intrinsics.
 - Coercive and all other excluded shapes preserve direct behavior and decline
   before claim without invariants or post-claim errors.
-- The narrow rollback, affected regressions, TypeScript 7, and all pre-push
-  gates pass.
+- The former narrow rollback was validated alongside the affected regressions,
+  TypeScript 7, and all pre-push gates.
 
 ## Implementation outcome and validation
 
@@ -185,5 +185,12 @@ instructions inside the helper; they are not callable provider dependencies.
 The primary risks are accidentally canonicalizing NaN, losing negative zero,
 or using the wrong tie rule while moving the established direct schedule into
 source. Raw-bit direct/IR parity is the migration invariant.
-`JS2WASM_IR_MATH_ROUND=0` provides narrow rollback;
+The rollout-only per-method withdrawal provided narrow rollback;
 `JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/plan/issues/5135-ir-exact-ambient-math-fround.md
+++ b/plan/issues/5135-ir-exact-ambient-math-fround.md
@@ -133,8 +133,8 @@ than silently dropping the popped value.
 3. Add `math.fround` and `backend.f64.fround` to the intrinsic, feature,
    provider, and signature catalogues with no dependencies/capabilities.
 4. Add a sequence-marked `fround` method plan so both the WasmGC symbolic path
-   and linear selector admit it, and add independent
-   `JS2WASM_IR_MATH_FROUND=0` rollback. Keep generic from-AST emission.
+   and linear selector admit it; initial rollout added the independent
+   per-method rollback. Keep generic from-AST emission.
 5. Widen linear legality from five to six native Math semantics only for the
    closed fround sequence. Unknown/malformed sequence values, missing
    providers, unsupported adapters, and provider-shape drift must fail closed.
@@ -163,8 +163,8 @@ than silently dropping the popped value.
   missing providers/adapters, and unsupported non-Wasm sinks fail loudly.
 - Coercive and all other excluded shapes preserve direct behavior and decline
   before claim without invariants or post-claim errors.
-- The narrow rollback, affected regressions, TypeScript 7, and all pre-push
-  gates pass.
+- The former narrow rollback was validated alongside the affected regressions,
+  TypeScript 7, and all pre-push gates.
 
 ## Outcome
 
@@ -179,8 +179,8 @@ Completed on 2026-08-28 in non-draft PR
   Bytecode remains fail-loud and Porffor now rejects both conversions
   explicitly.
 - Exact ambient one-number calls are IR-owned on WasmGC and production linear;
-  excluded/coercive forms still decline before claim, and
-  `JS2WASM_IR_MATH_FROUND=0` provides narrow rollback.
+  excluded/coercive forms still decline before claim, and the per-method
+  control provided narrow rollback during initial rollout.
 - Focused validation passed 15/15 cases, including production-linear ownership,
   malformed-sequence rejection, zero-import standalone execution, and raw-bit
   parity across custom NaNs, signed zero, f32 midpoint ties, subnormal/normal
@@ -207,5 +207,12 @@ The main architectural risk is turning one exact closed sequence into an
 untyped raw-instruction escape hatch; the one-member vocabulary and exhaustive
 switch prevent that. Numeric risk is conversion order or hidden re-evaluation,
 guarded by raw-bit direct parity and exact WAT assertions.
-`JS2WASM_IR_MATH_FROUND=0` provides narrow rollback;
+The rollout-only per-method withdrawal provided narrow rollback;
 `JS2WASM_IR_FIRST=0` remains the global control.
+
+## 2026-08-30 retirement update
+
+The rollout-only per-method withdrawal is retired by the #4522 Math checkpoint.
+Exact ambient, global-direct parity, and all existing numeric and near-miss
+coverage remain. The shared #3518 matrix provides the literal closed cross-method
+census; `experimentalIR: false` is the retained observational oracle.

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -7329,27 +7329,6 @@ function selectorSupportsMathPlan(plan: IrMathMethodPlan, call: ts.CallExpressio
 }
 
 function selectorMathPlanEnabled(plan: IrMathMethodPlan): boolean {
-  if (plan.intrinsic === "math.asin" && process.env.JS2WASM_IR_MATH_ASIN === "0") return false;
-  if (plan.intrinsic === "math.acos" && process.env.JS2WASM_IR_MATH_ACOS === "0") return false;
-  if (plan.intrinsic === "math.atan" && process.env.JS2WASM_IR_MATH_ATAN === "0") return false;
-  if (plan.intrinsic === "math.tan" && process.env.JS2WASM_IR_MATH_TAN === "0") return false;
-  if (plan.intrinsic === "math.log10" && process.env.JS2WASM_IR_MATH_LOG10 === "0") return false;
-  if (plan.intrinsic === "math.log1p" && process.env.JS2WASM_IR_MATH_LOG1P === "0") return false;
-  if (plan.intrinsic === "math.sinh" && process.env.JS2WASM_IR_MATH_SINH === "0") return false;
-  if (plan.intrinsic === "math.cosh" && process.env.JS2WASM_IR_MATH_COSH === "0") return false;
-  if (plan.intrinsic === "math.tanh" && process.env.JS2WASM_IR_MATH_TANH === "0") return false;
-  if (plan.intrinsic === "math.cbrt" && process.env.JS2WASM_IR_MATH_CBRT === "0") return false;
-  if (plan.intrinsic === "math.fround" && process.env.JS2WASM_IR_MATH_FROUND === "0") return false;
-  if (plan.intrinsic === "math.clz32" && process.env.JS2WASM_IR_MATH_CLZ32 === "0") return false;
-  if (plan.intrinsic === "math.imul" && process.env.JS2WASM_IR_MATH_IMUL === "0") return false;
-  if (plan.intrinsic === "math.max" && process.env.JS2WASM_IR_MATH_MAX === "0") return false;
-  if (plan.intrinsic === "math.min" && process.env.JS2WASM_IR_MATH_MIN === "0") return false;
-  if (plan.intrinsic === "math.round" && process.env.JS2WASM_IR_MATH_ROUND === "0") return false;
-  if (plan.intrinsic === "math.sign" && process.env.JS2WASM_IR_MATH_SIGN === "0") return false;
-  if (plan.intrinsic === "math.expm1" && process.env.JS2WASM_IR_MATH_EXPM1 === "0") return false;
-  if (plan.intrinsic === "math.asinh" && process.env.JS2WASM_IR_MATH_ASINH === "0") return false;
-  if (plan.intrinsic === "math.acosh" && process.env.JS2WASM_IR_MATH_ACOSH === "0") return false;
-  if (plan.intrinsic === "math.atanh" && process.env.JS2WASM_IR_MATH_ATANH === "0") return false;
   return (
     "op" in plan ||
     "sequence" in plan ||

--- a/tests/issue-3518-ir-math-switch-retirement.test.ts
+++ b/tests/issue-3518-ir-math-switch-retirement.test.ts
@@ -1,0 +1,484 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+import {
+  forEachInstrDeep,
+  mapNestedBuffers,
+  type IrFunction,
+  type IrInstr,
+  type IrInstrIntrinsic,
+} from "../src/ir/nodes.js";
+import { IR_MATH_METHOD_TABLE, type IrMathMethodPlan } from "../src/ir/select.js";
+import { verifyIrFunction } from "../src/ir/verify.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-3518-ir-math-switch-retirement");
+
+type ProviderKind = "callable" | "backend-sequence" | "backend-composite";
+
+type RetirementRow = {
+  readonly method: string;
+  readonly arity: 1 | 2;
+  readonly provider: ProviderKind;
+  readonly suite: number;
+};
+
+// This is deliberately independent of the production registry projection below.
+// It is the complete 21-method retirement population, in its rollout order.
+const EXPECTED_RETIRED_METHODS = [
+  "atan",
+  "tan",
+  "asin",
+  "acos",
+  "log10",
+  "log1p",
+  "sinh",
+  "cosh",
+  "tanh",
+  "cbrt",
+  "expm1",
+  "clz32",
+  "imul",
+  "min",
+  "max",
+  "asinh",
+  "acosh",
+  "atanh",
+  "sign",
+  "round",
+  "fround",
+] as const;
+
+// Literal method/arity/provider ownership table. The suite field makes the
+// fourteen focused origin suites part of the closed census rather than implied.
+const RETIRED_MATH_METHODS = [
+  { method: "atan", arity: 1, provider: "callable", suite: 5101 },
+  { method: "tan", arity: 1, provider: "callable", suite: 5103 },
+  { method: "asin", arity: 1, provider: "callable", suite: 5105 },
+  { method: "acos", arity: 1, provider: "callable", suite: 5105 },
+  { method: "log10", arity: 1, provider: "callable", suite: 5106 },
+  { method: "log1p", arity: 1, provider: "callable", suite: 5106 },
+  { method: "sinh", arity: 1, provider: "callable", suite: 5110 },
+  { method: "cosh", arity: 1, provider: "callable", suite: 5110 },
+  { method: "tanh", arity: 1, provider: "callable", suite: 5110 },
+  { method: "cbrt", arity: 1, provider: "callable", suite: 5111 },
+  { method: "expm1", arity: 1, provider: "callable", suite: 5114 },
+  { method: "clz32", arity: 1, provider: "backend-composite", suite: 5125 },
+  { method: "imul", arity: 2, provider: "backend-composite", suite: 5126 },
+  { method: "min", arity: 2, provider: "backend-composite", suite: 5130 },
+  { method: "max", arity: 2, provider: "backend-composite", suite: 5130 },
+  { method: "asinh", arity: 1, provider: "callable", suite: 5132 },
+  { method: "acosh", arity: 1, provider: "callable", suite: 5132 },
+  { method: "atanh", arity: 1, provider: "callable", suite: 5132 },
+  { method: "sign", arity: 1, provider: "callable", suite: 5133 },
+  { method: "round", arity: 1, provider: "callable", suite: 5134 },
+  { method: "fround", arity: 1, provider: "backend-sequence", suite: 5135 },
+] as const satisfies readonly RetirementRow[];
+
+const FOCUSED_SUITES = [5101, 5103, 5105, 5106, 5110, 5111, 5114, 5125, 5126, 5130, 5132, 5133, 5134, 5135];
+
+function paramsFor(row: RetirementRow): string {
+  return row.arity === 1 ? "value: number" : "left: number, right: number";
+}
+
+function argumentNamesFor(row: RetirementRow): readonly string[] {
+  return row.arity === 1 ? ["value"] : ["left", "right"];
+}
+
+function argumentsFor(row: RetirementRow): string {
+  return argumentNamesFor(row).join(", ");
+}
+
+function exactSource(row: RetirementRow, name: string): string {
+  return `export function ${name}(${paramsFor(row)}): number { return Math.${row.method}(${argumentsFor(row)}); }`;
+}
+
+function shadowedSource(row: RetirementRow): string {
+  const replacement =
+    row.arity === 1
+      ? `const Math = { ${row.method}: (value: number): number => value };`
+      : `const Math = { ${row.method}: (left: number, right: number): number => left + right };`;
+  return `
+    export function shadow_${row.method}(${paramsFor(row)}): number {
+      ${replacement}
+      return Math.${row.method}(${argumentsFor(row)});
+    }
+  `;
+}
+
+function aliasedSource(row: RetirementRow): string {
+  const alias = `bound_${row.method}`;
+  return `
+    const ${alias} = Math.${row.method};
+    export function alias_${row.method}(${paramsFor(row)}): number {
+      return ${alias}(${argumentsFor(row)});
+    }
+  `;
+}
+
+type ArityVariant = "too-few" | "too-many";
+
+function arityDisplayName(row: RetirementRow, variant: ArityVariant): string {
+  return `arity_${row.method}_${variant.replaceAll("-", "_")}`;
+}
+
+function wrongAritySource(row: RetirementRow, variant: ArityVariant): string {
+  const args = argumentNamesFor(row);
+  const supplied = variant === "too-few" ? args.slice(0, -1) : [...args, args[0]!];
+  const typeErrorSuppression =
+    row.method === "min" || row.method === "max" ? "" : "      // @ts-expect-error exact arity is intentional here.\n";
+  return `
+    export function ${arityDisplayName(row, variant)}(${paramsFor(row)}): number {
+${typeErrorSuppression}      return Math.${row.method}(${supplied.join(", ")});
+    }
+  `;
+}
+
+const POSITIVE_SOURCE = RETIRED_MATH_METHODS.map((row) => exactSource(row, row.method)).join("\n");
+const SHADOWED_SOURCE = RETIRED_MATH_METHODS.map(shadowedSource).join("\n");
+const ALIASED_SOURCE = RETIRED_MATH_METHODS.map(aliasedSource).join("\n");
+const ARITY_CASES = RETIRED_MATH_METHODS.flatMap((row) =>
+  (["too-few", "too-many"] as const).map((variant) => ({ row, variant })),
+);
+const WRONG_ARITY_SOURCE = ARITY_CASES.map(({ row, variant }) => wrongAritySource(row, variant)).join("\n");
+
+function outcomeFor(result: CompileResult, displayName: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find((candidate) => candidate.displayName === displayName);
+  expect(outcome, `missing IR outcome for ${displayName}`).toBeDefined();
+  if (!outcome) throw new Error(`missing IR outcome for ${displayName}`);
+  return outcome;
+}
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, unknown>> {
+  const imports = result.importObject ?? buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, unknown>;
+  (imports as { setExports?: (value: Record<string, unknown>) => void }).setExports?.(exports);
+  return exports;
+}
+
+function expectPreclaimUnsupported(result: CompileResult, displayName: string): void {
+  expect(outcomeFor(result, displayName)).toMatchObject({
+    kind: "unsupported",
+    stage: "select",
+    legacyBodyEmitted: true,
+    irBodyEmitted: false,
+  });
+  expect(result.irCompiledFuncs ?? []).not.toContain(displayName);
+  expect(result.irPostClaimErrors ?? []).toEqual([]);
+  expect((result.irOutcomes ?? []).filter((outcome) => outcome.kind === "invariant")).toEqual([]);
+}
+
+function assertProviderClass(row: RetirementRow, plan: IrMathMethodPlan): void {
+  if (row.provider === "callable") {
+    if ("op" in plan || "sequence" in plan || "composite" in plan) {
+      throw new Error(`Math.${row.method} is not callable-backed in the production registry`);
+    }
+    return;
+  }
+  if (row.provider === "backend-sequence") {
+    if (!("sequence" in plan) || plan.sequence !== "f64.fround") {
+      throw new Error(`Math.${row.method} is not bound to the fround backend sequence`);
+    }
+    return;
+  }
+  if (!("composite" in plan) || plan.composite !== `math.${row.method}`) {
+    throw new Error(`Math.${row.method} is not bound to its exact backend composite`);
+  }
+}
+
+function assertClosedRetirementTable(rows: readonly RetirementRow[]): void {
+  const expected = new Set<string>(EXPECTED_RETIRED_METHODS);
+  if (expected.size !== 21) throw new Error("the independent retirement expectation must contain exactly 21 methods");
+  if (rows.length !== expected.size) throw new Error(`expected exactly 21 retirement rows, got ${rows.length}`);
+
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (!expected.has(row.method)) throw new Error(`foreign retirement row: ${row.method}`);
+    if (seen.has(row.method)) throw new Error(`duplicate retirement row: ${row.method}`);
+    seen.add(row.method);
+  }
+  for (const method of expected) {
+    if (!seen.has(method)) throw new Error(`missing retirement row: ${method}`);
+  }
+
+  const projection = Object.entries(IR_MATH_METHOD_TABLE).filter(([method]) => expected.has(method));
+  if (projection.length !== expected.size) {
+    throw new Error(`production registry projected ${projection.length} retired methods, expected ${expected.size}`);
+  }
+  const projectedNames = new Set(projection.map(([method]) => method));
+  for (const method of expected) {
+    if (!projectedNames.has(method)) throw new Error(`production registry is missing Math.${method}`);
+  }
+
+  for (const row of rows) {
+    const plan = IR_MATH_METHOD_TABLE[row.method];
+    if (!plan) throw new Error(`missing production Math plan for ${row.method}`);
+    if (plan.arity !== row.arity) {
+      throw new Error(`Math.${row.method} has arity ${plan.arity}, expected ${row.arity}`);
+    }
+    if (plan.intrinsic !== `math.${row.method}`) {
+      throw new Error(`Math.${row.method} maps to ${plan.intrinsic}, not its own semantic intrinsic`);
+    }
+    assertProviderClass(row, plan);
+  }
+}
+
+function sampleArguments(row: RetirementRow): readonly number[] {
+  switch (row.method) {
+    case "clz32":
+      return [0x100];
+    case "imul":
+      return [0x7fff_ffff, -3];
+    case "min":
+    case "max":
+      return [-3, 7];
+    case "acosh":
+      return [2];
+    case "atanh":
+      return [0.5];
+    default:
+      return [0.5];
+  }
+}
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function preparedFunctionFor(row: RetirementRow): IrFunction {
+  const analysis = analyzeSource(exactSource(row, `provider_${row.method}`));
+  const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+  if (!declaration) throw new Error(`missing Math.${row.method} declaration`);
+  const lowered = lowerFunctionAstToIr(declaration, {
+    ownerUnitId: identities.next(`provider_${row.method}`).unitId,
+    exported: true,
+  }).main;
+  const prepared = prepareIrRuntimeManifest({
+    functions: [lowered],
+    sourceFile: analysis.sourceFile.fileName,
+    policy: { target: "host", backend: "wasmgc" },
+  });
+  if (!prepared) throw new Error(`missing prepared Math.${row.method} manifest`);
+  const matching = intrinsicInstructions(prepared.functions[0]!).filter((instr) => instr.id === `math.${row.method}`);
+  if (matching.length !== 1)
+    throw new Error(`expected one prepared Math.${row.method} intrinsic, got ${matching.length}`);
+  if (matching[0]!.provider?.kind !== row.provider) {
+    throw new Error(`Math.${row.method} prepared as ${matching[0]!.provider?.kind}, expected ${row.provider}`);
+  }
+  return prepared.functions[0]!;
+}
+
+function rewritePreparedIntrinsic(
+  fn: IrFunction,
+  row: RetirementRow,
+  rewrite: (instr: IrInstrIntrinsic) => IrInstrIntrinsic,
+): IrFunction {
+  let rewrittenCount = 0;
+  const mapBuffer = (buffer: readonly IrInstr[]): readonly IrInstr[] => buffer.map(mapInstr);
+  const mapInstr = (instr: IrInstr): IrInstr => {
+    const nested = mapNestedBuffers(instr, mapBuffer);
+    if (nested.kind !== "intrinsic" || nested.id !== `math.${row.method}`) return nested;
+    rewrittenCount++;
+    return rewrite(nested);
+  };
+  const rewritten: IrFunction = {
+    ...fn,
+    blocks: fn.blocks.map((block) => ({ ...block, instrs: mapBuffer(block.instrs) })),
+  };
+  if (rewrittenCount !== 1) {
+    throw new Error(`rewrote ${rewrittenCount} nested Math.${row.method} providers instead of exactly one`);
+  }
+  return rewritten;
+}
+
+function minimalResolver(): IrLowerResolver {
+  let nextType = 0;
+  return {
+    resolveFunc: () => 0,
+    resolveGlobal: () => {
+      throw new Error("resolveGlobal is not used by this provider mutation");
+    },
+    resolveType: () => {
+      throw new Error("resolveType is not used by this provider mutation");
+    },
+    internFuncType: () => nextType++,
+  };
+}
+
+const COMPOSITE_MUTATIONS: Readonly<Record<string, string>> = {
+  clz32: "math.unknown",
+  imul: "math.unknown",
+  min: "math.max",
+  max: "math.min",
+};
+
+describe("#3518 per-intrinsic Math rollback retirement", () => {
+  it("joins the literal 21-row retirement table to the independently projected 33-row production registry", () => {
+    expect(Object.keys(IR_MATH_METHOD_TABLE)).toHaveLength(33);
+    expect(new Set(RETIRED_MATH_METHODS.map((row) => row.suite))).toEqual(new Set(FOCUSED_SUITES));
+    assertClosedRetirementTable(RETIRED_MATH_METHODS);
+
+    const expectedProjection = Object.keys(IR_MATH_METHOD_TABLE)
+      .filter((method) => EXPECTED_RETIRED_METHODS.includes(method as (typeof EXPECTED_RETIRED_METHODS)[number]))
+      .sort();
+    expect(expectedProjection).toEqual([...EXPECTED_RETIRED_METHODS].sort());
+
+    expect(() => assertClosedRetirementTable(RETIRED_MATH_METHODS.slice(1))).toThrow(/exactly 21 retirement rows/);
+    const duplicate = [...RETIRED_MATH_METHODS.slice(0, -1), RETIRED_MATH_METHODS[0]!];
+    expect(() => assertClosedRetirementTable(duplicate)).toThrow(/duplicate retirement row/);
+    const foreign = [...RETIRED_MATH_METHODS];
+    foreign[0] = { ...foreign[0]!, method: "synthetic" };
+    expect(() => assertClosedRetirementTable(foreign)).toThrow(/foreign retirement row/);
+  });
+
+  it.each([
+    ["host", undefined],
+    ["standalone", "standalone" as const],
+  ])("emits every retirement-table method as an IR-only body on %s", async (label, target) => {
+    const options = {
+      fileName: `issue-3518-math-retirement-${label}.ts`,
+      ...(target === undefined ? {} : { target }),
+    };
+    const [result, direct] = await Promise.all([
+      compile(POSITIVE_SOURCE, { ...options, experimentalIR: true, trackIrOutcomes: true }),
+      compile(POSITIVE_SOURCE, { ...options, experimentalIR: false }),
+    ]);
+    expectSuccess(result);
+    expectSuccess(direct);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(WebAssembly.validate(direct.binary)).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    for (const row of RETIRED_MATH_METHODS) {
+      expect(outcomeFor(result, row.method)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(result.irCompiledFuncs ?? []).toContain(row.method);
+    }
+
+    const module = new WebAssembly.Module(result.binary);
+    const directModule = new WebAssembly.Module(direct.binary);
+    expect(WebAssembly.Module.imports(module)).toEqual(WebAssembly.Module.imports(directModule));
+    expect(WebAssembly.Module.exports(module)).toEqual(WebAssembly.Module.exports(directModule));
+    expect(result.imports).toEqual(direct.imports);
+    if (target === "standalone") {
+      expect(WebAssembly.Module.imports(module)).toEqual([]);
+      expect(result.imports).toEqual([]);
+    } else {
+      expect(result.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    }
+
+    const [exports, directExports] = await Promise.all([instantiate(result), instantiate(direct)]);
+    for (const row of RETIRED_MATH_METHODS) {
+      const compiled = exports[row.method] as (...args: number[]) => number;
+      const directCompiled = directExports[row.method] as (...args: number[]) => number;
+      const args = sampleArguments(row);
+      expect(Object.is(compiled(...args), directCompiled(...args)), `Math.${row.method} direct runtime parity`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("keeps all 21 shadowed Math cells pre-claim and legacy-owned", async () => {
+    const result = await compile(SHADOWED_SOURCE, {
+      fileName: "issue-3518-math-shadowed.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    for (const row of RETIRED_MATH_METHODS) expectPreclaimUnsupported(result, `shadow_${row.method}`);
+  });
+
+  it("keeps all 21 extracted aliases pre-claim and legacy-owned", async () => {
+    const result = await compile(ALIASED_SOURCE, {
+      fileName: "issue-3518-math-aliased.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    for (const row of RETIRED_MATH_METHODS) expectPreclaimUnsupported(result, `alias_${row.method}`);
+  });
+
+  it("keeps all 42 exact-arity misses pre-claim and legacy-owned", async () => {
+    const result = await compile(WRONG_ARITY_SOURCE, {
+      fileName: "issue-3518-math-wrong-arity.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    for (const { row, variant } of ARITY_CASES) {
+      expectPreclaimUnsupported(result, arityDisplayName(row, variant));
+    }
+  });
+
+  it("rejects all 21 row-specific malformed provider mutations", () => {
+    for (const row of RETIRED_MATH_METHODS) {
+      const prepared = preparedFunctionFor(row);
+      if (row.provider === "callable") {
+        const malformed = rewritePreparedIntrinsic(prepared, row, (instr) => {
+          if (instr.provider?.kind !== "callable") throw new Error(`missing callable provider for Math.${row.method}`);
+          return {
+            ...instr,
+            provider: {
+              kind: "callable",
+              target: {
+                ...instr.provider.target,
+                binding: { kind: "intrinsic", symbol: "math.abs" },
+              },
+            },
+          };
+        });
+        expect(
+          verifyIrFunction(malformed).map((error) => error.message),
+          row.method,
+        ).toContain(`math.${row.method} callable provider must retain the semantic intrinsic binding`);
+        continue;
+      }
+
+      if (row.provider === "backend-sequence") {
+        const malformed = rewritePreparedIntrinsic(prepared, row, (instr) => ({
+          ...instr,
+          provider: { kind: "backend-sequence", sequence: "f64.unknown" },
+        })) as unknown as IrFunction;
+        expect(() => lowerIrFunctionToWasm(malformed, minimalResolver()), row.method).toThrowError(
+          /unsupported backend sequence/,
+        );
+        continue;
+      }
+
+      const operation = COMPOSITE_MUTATIONS[row.method];
+      if (!operation) throw new Error(`missing composite mutation for Math.${row.method}`);
+      const malformed = rewritePreparedIntrinsic(prepared, row, (instr) => ({
+        ...instr,
+        provider: { kind: "backend-composite", operation },
+      })) as unknown as IrFunction;
+      expect(
+        verifyIrFunction(malformed).map((error) => error.message),
+        row.method,
+      ).toContain(`math.${row.method} backend composite provider must use math.${row.method}, got ${operation}`);
+    }
+  });
+});

--- a/tests/issue-5101-ir-math-atan.test.ts
+++ b/tests/issue-5101-ir-math-atan.test.ts
@@ -156,38 +156,6 @@ describe("#5101 exact ambient Math.atan IR ownership", () => {
     }
   });
 
-  it("uses the narrow env rollback for atan without withdrawing atan2", async () => {
-    const previous = process.env.JS2WASM_IR_MATH_ATAN;
-    process.env.JS2WASM_IR_MATH_ATAN = "0";
-    try {
-      const result = await compile(
-        `
-          export function atan(value: number): number { return Math.atan(value); }
-          export function atan2(left: number, right: number): number { return Math.atan2(left, right); }
-        `,
-        { fileName: "issue-5101-rollback.ts", experimentalIR: true, trackIrOutcomes: true, emitWat: true },
-      );
-      expectSuccess(result);
-      expect(outcomeFor(result, "atan")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(outcomeFor(result, "atan2")).toMatchObject({
-        kind: "emitted",
-        legacyBodyEmitted: false,
-        irBodyEmitted: true,
-      });
-      expect(result.irCompiledFuncs ?? []).not.toContain("atan");
-      expect(result.irCompiledFuncs ?? []).toContain("atan2");
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_IR_MATH_ATAN");
-      else process.env.JS2WASM_IR_MATH_ATAN = previous;
-    }
-  });
-
   it.each([
     [
       "shadowed Math",

--- a/tests/issue-5103-ir-math-tan.test.ts
+++ b/tests/issue-5103-ir-math-tan.test.ts
@@ -161,39 +161,6 @@ describe("#5103 exact ambient Math.tan IR ownership", () => {
     }
   });
 
-  it("uses the narrow env rollback for tan without withdrawing sin or cos", async () => {
-    const previous = process.env.JS2WASM_IR_MATH_TAN;
-    process.env.JS2WASM_IR_MATH_TAN = "0";
-    try {
-      const result = await compile(
-        `
-          export function tan(value: number): number { return Math.tan(value); }
-          export function sin(value: number): number { return Math.sin(value); }
-          export function cos(value: number): number { return Math.cos(value); }
-        `,
-        { fileName: "issue-5103-rollback.ts", experimentalIR: true, trackIrOutcomes: true },
-      );
-      expectSuccess(result);
-      expect(outcomeFor(result, "tan")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      for (const name of ["sin", "cos"]) {
-        expect(outcomeFor(result, name)).toMatchObject({
-          kind: "emitted",
-          legacyBodyEmitted: false,
-          irBodyEmitted: true,
-        });
-      }
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_IR_MATH_TAN");
-      else process.env.JS2WASM_IR_MATH_TAN = previous;
-    }
-  });
-
   it.each([
     [
       "shadowed Math",

--- a/tests/issue-5105-ir-math-inverse-trig.test.ts
+++ b/tests/issue-5105-ir-math-inverse-trig.test.ts
@@ -248,39 +248,6 @@ describe("#5105 exact ambient Math.asin/Math.acos IR ownership", () => {
     }
   });
 
-  it.each([
-    ["asin", "JS2WASM_IR_MATH_ASIN", "acos"],
-    ["acos", "JS2WASM_IR_MATH_ACOS", "asin"],
-  ] as const)("withdraws only %s through its narrow rollback", async (disabled, flag, retained) => {
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(
-        `
-          export function asin(value: number): number { return Math.asin(value); }
-          export function acos(value: number): number { return Math.acos(value); }
-        `,
-        { fileName: `issue-5105-${disabled}-rollback.ts`, experimentalIR: true, trackIrOutcomes: true },
-      );
-      expectSuccess(result);
-      expect(outcomeFor(result, disabled)).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(outcomeFor(result, retained)).toMatchObject({
-        kind: "emitted",
-        legacyBodyEmitted: false,
-        irBodyEmitted: true,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
     const result = await compile(source, {
       fileName: `issue-5105-${_label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5106-ir-math-derived-log.test.ts
+++ b/tests/issue-5106-ir-math-derived-log.test.ts
@@ -299,39 +299,6 @@ describe("#5106 exact ambient Math.log10/Math.log1p IR ownership", () => {
     }
   });
 
-  it.each([
-    ["log10", "JS2WASM_IR_MATH_LOG10", "log1p"],
-    ["log1p", "JS2WASM_IR_MATH_LOG1P", "log10"],
-  ] as const)("withdraws only %s through its narrow rollback", async (disabled, flag, retained) => {
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(
-        `
-          export function log10(value: number): number { return Math.log10(value); }
-          export function log1p(value: number): number { return Math.log1p(value); }
-        `,
-        { fileName: `issue-5106-${disabled}-rollback.ts`, experimentalIR: true, trackIrOutcomes: true },
-      );
-      expectSuccess(result);
-      expect(outcomeFor(result, disabled)).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(outcomeFor(result, retained)).toMatchObject({
-        kind: "emitted",
-        legacyBodyEmitted: false,
-        irBodyEmitted: true,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
     const result = await compile(source, {
       fileName: `issue-5106-${_label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5110-ir-math-hyperbolic.test.ts
+++ b/tests/issue-5110-ir-math-hyperbolic.test.ts
@@ -262,43 +262,6 @@ describe("#5110 exact ambient hyperbolic Math IR ownership", () => {
     }
   });
 
-  it.each([
-    ["sinh", "JS2WASM_IR_MATH_SINH", ["cosh", "tanh"]],
-    ["cosh", "JS2WASM_IR_MATH_COSH", ["sinh", "tanh"]],
-    ["tanh", "JS2WASM_IR_MATH_TANH", ["sinh", "cosh"]],
-  ] as const)("withdraws only %s through its narrow rollback", async (disabled, flag, retained) => {
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(
-        `
-          export function sinh(value: number): number { return Math.sinh(value); }
-          export function cosh(value: number): number { return Math.cosh(value); }
-          export function tanh(value: number): number { return Math.tanh(value); }
-        `,
-        { fileName: `issue-5110-${disabled}-rollback.ts`, experimentalIR: true, trackIrOutcomes: true },
-      );
-      expectSuccess(result);
-      expect(outcomeFor(result, disabled)).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      for (const method of retained) {
-        expect(outcomeFor(result, method)).toMatchObject({
-          kind: "emitted",
-          legacyBodyEmitted: false,
-          irBodyEmitted: true,
-        });
-      }
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
     const result = await compile(source, {
       fileName: `issue-5110-${_label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5111-ir-math-cbrt.test.ts
+++ b/tests/issue-5111-ir-math-cbrt.test.ts
@@ -211,30 +211,6 @@ describe("#5111 exact ambient Math.cbrt IR ownership", () => {
     }
   });
 
-  it("withdraws only cbrt through its narrow rollback", async () => {
-    const flag = "JS2WASM_IR_MATH_CBRT";
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(`export function cbrt(value: number): number { return Math.cbrt(value); }`, {
-        fileName: "issue-5111-rollback.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      });
-      expectSuccess(result);
-      expect(outcomeFor(result, "cbrt")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
     const result = await compile(source, {
       fileName: `issue-5111-${_label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5114-ir-math-expm1.test.ts
+++ b/tests/issue-5114-ir-math-expm1.test.ts
@@ -281,30 +281,6 @@ describe("#5114 exact ambient Math.expm1 IR ownership", () => {
     }
   });
 
-  it("withdraws only expm1 through its narrow rollback", async () => {
-    const flag = "JS2WASM_IR_MATH_EXPM1";
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(`export function expm1(value: number): number { return Math.expm1(value); }`, {
-        fileName: "issue-5114-rollback.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      });
-      expectSuccess(result);
-      expect(outcomeFor(result, "expm1")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
     const result = await compile(source, {
       fileName: `issue-5114-${_label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5125-ir-math-clz32.test.ts
+++ b/tests/issue-5125-ir-math-clz32.test.ts
@@ -298,30 +298,6 @@ describe("#5125 exact ambient Math.clz32 IR ownership", () => {
     expect(() => lowerIrFunctionToWasm(malformed, minimalResolver())).toThrowError(/unsupported backend composite/);
   });
 
-  it("withdraws only clz32 through its narrow rollback", async () => {
-    const flag = "JS2WASM_IR_MATH_CLZ32";
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(SOURCE, {
-        fileName: "issue-5125-rollback.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      });
-      expectSuccess(result);
-      expect(outcomeFor(result, "clz32")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
     const result = await compile(source, {
       fileName: `issue-5125-${label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5126-ir-math-imul.test.ts
+++ b/tests/issue-5126-ir-math-imul.test.ts
@@ -320,30 +320,6 @@ describe("#5126 exact ambient Math.imul IR ownership", () => {
     expect(() => lowerIrFunctionToWasm(malformed, minimalResolver())).toThrowError(/unsupported backend composite/);
   });
 
-  it("withdraws only imul through its narrow rollback", async () => {
-    const flag = "JS2WASM_IR_MATH_IMUL";
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(SOURCE, {
-        fileName: "issue-5126-rollback.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      });
-      expectSuccess(result);
-      expect(outcomeFor(result, "imul")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
     const result = await compile(source, {
       fileName: `issue-5126-${label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5130-ir-math-minmax.test.ts
+++ b/tests/issue-5130-ir-math-minmax.test.ts
@@ -344,37 +344,6 @@ describe("#5130 exact ambient binary Math.min/max IR ownership", () => {
     );
   });
 
-  it.each([
-    ["MIN", "min2", "max2"],
-    ["MAX", "max2", "min2"],
-  ] as const)("withdraws only Math.%s through its narrow rollback", async (suffix, withdrawn, retained) => {
-    const flag = `JS2WASM_IR_MATH_${suffix}`;
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(SOURCE, {
-        fileName: `issue-5130-${suffix.toLowerCase()}-rollback.ts`,
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      });
-      expectSuccess(result);
-      expect(outcomeFor(result, withdrawn)).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(outcomeFor(result, retained)).toMatchObject({
-        kind: "emitted",
-        legacyBodyEmitted: false,
-        irBodyEmitted: true,
-      });
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (label, body) => {
     const source = `export function f(x: number, y: number): number { ${body} }`;
     const result = await compile(source, {

--- a/tests/issue-5132-ir-math-inverse-hyperbolic.test.ts
+++ b/tests/issue-5132-ir-math-inverse-hyperbolic.test.ts
@@ -366,43 +366,6 @@ describe("#5132 exact ambient inverse-hyperbolic Math IR ownership", () => {
     }
   });
 
-  it.each([
-    ["asinh", "JS2WASM_IR_MATH_ASINH", ["acosh", "atanh"]],
-    ["acosh", "JS2WASM_IR_MATH_ACOSH", ["asinh", "atanh"]],
-    ["atanh", "JS2WASM_IR_MATH_ATANH", ["asinh", "acosh"]],
-  ] as const)("withdraws only %s through its narrow rollback", async (disabled, flag, retained) => {
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(
-        `
-          export function asinh(value: number): number { return Math.asinh(value); }
-          export function acosh(value: number): number { return Math.acosh(value); }
-          export function atanh(value: number): number { return Math.atanh(value); }
-        `,
-        { fileName: `issue-5132-${disabled}-rollback.ts`, experimentalIR: true, trackIrOutcomes: true },
-      );
-      expectSuccess(result);
-      expect(outcomeFor(result, disabled)).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      for (const method of retained) {
-        expect(outcomeFor(result, method)).toMatchObject({
-          kind: "emitted",
-          legacyBodyEmitted: false,
-          irBodyEmitted: true,
-        });
-      }
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (_label, source) => {
     const result = await compile(source, {
       fileName: `issue-5132-${_label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5133-ir-math-sign.test.ts
+++ b/tests/issue-5133-ir-math-sign.test.ts
@@ -228,30 +228,6 @@ describe("#5133 exact ambient Math.sign IR ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("withdraws only sign through its narrow rollback", async () => {
-    const flag = "JS2WASM_IR_MATH_SIGN";
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(`export function sign(value: number): number { return Math.sign(value); }`, {
-        fileName: "issue-5133-rollback.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      });
-      expectSuccess(result);
-      expect(outcomeFor(result, "sign")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
     const result = await compile(source, {
       fileName: `issue-5133-${label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5134-ir-math-round.test.ts
+++ b/tests/issue-5134-ir-math-round.test.ts
@@ -237,30 +237,6 @@ describe("#5134 exact ambient Math.round IR ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("withdraws only round through its narrow rollback", async () => {
-    const flag = "JS2WASM_IR_MATH_ROUND";
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(`export function round(value: number): number { return Math.round(value); }`, {
-        fileName: "issue-5134-rollback.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      });
-      expectSuccess(result);
-      expect(outcomeFor(result, "round")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
     const result = await compile(source, {
       fileName: `issue-5134-${label.replaceAll(" ", "-")}.ts`,

--- a/tests/issue-5135-ir-math-fround.test.ts
+++ b/tests/issue-5135-ir-math-fround.test.ts
@@ -335,30 +335,6 @@ describe("#5135 exact ambient Math.fround IR ownership", () => {
     expect(() => lowerIrFunctionToWasm(malformed, minimalResolver())).toThrowError(/unsupported backend sequence/);
   });
 
-  it("withdraws only fround through its narrow rollback", async () => {
-    const flag = "JS2WASM_IR_MATH_FROUND";
-    const previous = process.env[flag];
-    process.env[flag] = "0";
-    try {
-      const result = await compile(SOURCE, {
-        fileName: "issue-5135-rollback.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      });
-      expectSuccess(result);
-      expect(outcomeFor(result, "fround")).toMatchObject({
-        kind: "unsupported",
-        stage: "select",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
-      });
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    } finally {
-      if (previous === undefined) Reflect.deleteProperty(process.env, flag);
-      else process.env[flag] = previous;
-    }
-  });
-
   it.each(exclusionCases)("rejects %s before claim", async (label, source) => {
     const result = await compile(source, {
       fileName: `issue-5135-${label.replaceAll(" ", "-")}.ts`,


### PR DESCRIPTION
## Summary

- removes all 21 per-intrinsic `JS2WASM_IR_MATH_*` rollback readers so exact ambient Math plans stay on their established IR providers
- replaces duplicated switch-off assertions across fourteen suites with one closed 21-method ownership/provider/runtime/mutation oracle
- refreshes #3518, #4522, and the fourteen method records with the exact retirement evidence and next serialized rollback denominator

## Invariants preserved

- exact ambient checker identity, arity, and provider-kind admission remain unchanged
- shadowed, aliased, optional, and wrong-arity calls remain pre-claim Unsupported
- host/standalone behavior, IEEE edge semantics, optimized artifacts, and callable/backend provider mappings remain pinned
- no Math optimization or intrinsic implementation is removed; only the direct-route rollback readers retire

## Validation

- changed-root precommit census: 15 files, 230/230 tests passed
- independent Sol review: 18 files, 244/244 tests with all 21 former rollback variables externally forced to `0`
- TypeScript 7 and 5 typechecks
- Prettier and Biome
- IR dialect, kind-neutrality, layering, fallback, host-import, hybrid IR-only, linear-IR, and optimization-retirement gates
- differential corpus: 0 new regressions
- retired identifier grep: zero tracked `JS2WASM_IR_MATH_*` occurrences
- LOC/function ratchets immediately before commit; full precommit and prepush hooks enabled and passing
- strict load gate: 10 logical cores, every heavy command below exact limit `< 8`
- signed Thomas Tränkler-authored commit

## Review

Fresh independent Sol review approved exact signed head `d5dbef0ddf85f54236a753e07c3a7bc00aa68fab`. It verified the exact 32-path scope, one-parent signed history, 21-reader deletion, closed provider/negative/mutation census, plan accuracy, and 244/244 tests. All GitHub checks are green and the PR is enrolled in the normal protected merge queue. Any later push invalidates approval.

Refs #3518
Refs #4522
