### PR TITLE
fix(optimizer): keep Binaryen 132 output engine-compatible

### DIFF
--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -4,7 +4,7 @@ title: "umbrella: close the acorn-vs-Node performance gap — representation fir
 status: ready
 sprint: current
 created: 2026-08-04
-updated: 2026-08-12
+updated: 2026-08-30
 priority: high
 horizon: xl
 feasibility: hard
@@ -5042,3 +5042,27 @@ benchmark artifact is refreshed on merge to `main` and read by humans. A
 per-program regression gate on `wasm-host-wasmtime-hot-runtime.json` — comparing
 within a runner class, keyed on the JS lane as the machine fingerprint — is the
 missing check. Filed as a follow-up rather than bundled here.
+
+## 2026-08-30 (50) — Binaryen 132 made `--all-features` emit unsupported compact imports
+
+The first post-upgrade `Refresh Benchmarks` run failed while optimizing the
+landing `fib` module. Binaryen was installed and `wasm-opt` completed; the
+reported “wasm-opt not available” warning was the fallback's misleading final
+diagnostic after the optimized output failed `WebAssembly.validate`.
+
+Binaryen 132 added the proposed `compact-imports` encoding to
+`--all-features`. It rewrote ordinary imports to kind byte `0x7e`, which Node
+25.7 and the current Wasmtime lane do not accept. Exact reproduction:
+
+- raw `fib`: 9,779 bytes, valid;
+- previous Binaryen 132 flags: 6,358 bytes, invalid (`unknown import kind 0x7e`);
+- plus `--disable-compact-imports`: 6,779 bytes, valid.
+
+The portable feature set now keeps `--all-features` for parsing js2wasm's
+post-MVP instructions while excluding both proposal encodings Binaryen can
+introduce during rewriting: custom descriptors/exact references and compact
+imports. The same flags cover the compiler optimizer, static npm-package
+bundler, and landing Wasmtime normalization. A focused optimizer test forces
+the bundled Binaryen CLI path and requires the previously failing class-union
+module to remain optimized and loadable. Rejected CLI output also retains the
+runtime validator's detail instead of degrading to “wasm-opt not available”.

--- a/scripts/lib/landing-wasmtime-runtime.mjs
+++ b/scripts/lib/landing-wasmtime-runtime.mjs
@@ -17,7 +17,12 @@ export const LANDING_WASMTIME_COMPILE_OPTIONS = Object.freeze({
   optimize: 3,
 });
 
-export const LANDING_WASM_OPT_ARGS = Object.freeze(["--all-features", "--disable-custom-descriptors", "-O3"]);
+export const LANDING_WASM_OPT_ARGS = Object.freeze([
+  "--all-features",
+  "--disable-custom-descriptors",
+  "--disable-compact-imports",
+  "-O3",
+]);
 export const LANDING_WASMTIME_WARM_VALIDATION_EXPORT = "landing_validate";
 export const LANDING_FOUR_LANE_INNER_WARMUP_CALLS = 6;
 export const LANDING_FOUR_LANE_INNER_MEASURED_CALLS = 9;

--- a/src/binaryen-features.ts
+++ b/src/binaryen-features.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * Binaryen feature flags for Wasm that remains loadable by the engines js2
+ * targets. `--all-features` is needed to read our post-MVP instructions, but
+ * it also enables proposal encodings that Binaryen may introduce while
+ * rewriting an otherwise portable module.
+ */
+export const BINARYEN_BASE_FEATURE_FLAGS = [
+  "--all-features",
+  // Binaryen can refine ordinary GC references into exact references.
+  "--disable-custom-descriptors",
+] as const;
+
+export const BINARYEN_COMPACT_IMPORTS_DISABLE_FLAG = "--disable-compact-imports" as const;
+
+export const BINARYEN_PORTABLE_FEATURE_FLAGS = [
+  ...BINARYEN_BASE_FEATURE_FLAGS,
+  // Binaryen 132 can rewrite ordinary imports into proposal kind 0x7e, which
+  // Node 25 and current Wasmtime do not accept.
+  BINARYEN_COMPACT_IMPORTS_DISABLE_FLAG,
+] as const;

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -16,6 +16,11 @@
  */
 
 import { inlineHintArgs } from "./inline-hints.js";
+import {
+  BINARYEN_BASE_FEATURE_FLAGS,
+  BINARYEN_COMPACT_IMPORTS_DISABLE_FLAG,
+  BINARYEN_PORTABLE_FEATURE_FLAGS,
+} from "./binaryen-features.js";
 
 // Dynamic imports to avoid vite bundling node-only modules for the browser.
 // These are only used by optimizeWithSystemBinary which only runs in Node.js.
@@ -29,6 +34,8 @@ let _nodeImports: {
   join: typeof import("node:path").join;
   tmpdir: typeof import("node:os").tmpdir;
 } | null = null;
+
+const _wasmOptCompactImportsSupport = new Map<string, boolean>();
 
 async function getNodeImports() {
   if (_nodeImports) return _nodeImports;
@@ -116,6 +123,27 @@ function getNodeImportsSync() {
   }
 }
 
+function wasmOptSupportsCompactImports(n: NonNullable<typeof _nodeImports>, wasmOptPath: string): boolean {
+  const cached = _wasmOptCompactImportsSupport.get(wasmOptPath);
+  if (cached !== undefined) return cached;
+
+  let supported = false;
+  try {
+    const help = n.execFileSync(wasmOptPath, ["--help"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    });
+    supported = help.includes(BINARYEN_COMPACT_IMPORTS_DISABLE_FLAG);
+  } catch {
+    // Older Binaryen versions do not advertise compact imports and must not
+    // receive a flag they cannot parse. The real optimization call below
+    // remains responsible for surfacing an unusable executable.
+  }
+  _wasmOptCompactImportsSupport.set(wasmOptPath, supported);
+  return supported;
+}
+
 /** Settings for {@link optimizeBinaryAsync} (Binaryen wasm-opt configuration). */
 export interface OptimizeOptions {
   /** Optimization level: 1 (-O1), 2 (-O2), 3 (-O3), 4 (-O4). Default: 3 */
@@ -164,7 +192,7 @@ export interface EmittedBinaryValidation {
  * failed: struct.get[0] expected type (ref null 2), found local.tee of type
  * f64`) that makes a miscompile diagnosable. Callers: the compiler's opt-in
  * `validate` gate (src/compiler.ts), the CLI's refuse-to-publish check
- * (src/cli.ts, #3338), {@link optimizedBinaryValidates} (#1941), and the
+ * (src/cli.ts, #3338), {@link optimizeBinaryAsync} (#1941), and the
  * dogfood/npm-compat compile probe.
  *
  * Reports `valid: true` when validation cannot be performed at all (no
@@ -211,17 +239,16 @@ export function validateEmittedBinary(binary: Uint8Array): EmittedBinaryValidati
 /**
  * Validate optimizer output before trusting it (#1941).
  *
- * `WebAssembly.validate` is available in every runtime that can host a
- * compiled module (Node, browsers, Deno, Bun). We use it as a fail-loud
- * gate on whatever the optimizer hands back: if the bytes don't validate,
- * the optimization MISCOMPILED the module and we must NOT ship it. Returns
- * `true` when validation can't be performed (no `WebAssembly` global — an
- * exotic embedding); in that case we conservatively trust the optimizer,
- * because refusing to optimize everywhere `WebAssembly` is absent would be
- * worse than the status quo.
+ * Preserve the engine's validation detail while applying the fail-loud gate
+ * to optimizer output. If validation cannot be performed, the shared helper
+ * deliberately returns `valid: true` and we conservatively trust the result.
  */
-function optimizedBinaryValidates(binary: Uint8Array): boolean {
-  return validateEmittedBinary(binary).valid;
+function invalidCliBinaryWarning(validation: EmittedBinaryValidation): string {
+  const detail = validation.detail ? ` Runtime validation: ${validation.detail.slice(0, 500)}` : "";
+  return (
+    "wasm-opt produced an invalid binary (it failed WebAssembly.validate); shipping unoptimized output instead." +
+    detail
+  );
 }
 
 /**
@@ -264,13 +291,18 @@ export async function optimizeBinaryAsync(binary: Uint8Array, options: OptimizeO
   // not fix a pre-existing codegen bug, and a broken-input warning would be
   // noise. The optimize gate below only judges the optimizer's *delta*.
 
+  let cliValidationWarning: string | undefined;
+
   // 1. System / bundled wasm-opt CLI — the correct backend (#1941).
   try {
     const result = optimizeWithSystemBinary(binary, level, gc, referenceTypes, exceptionHandling, preserveNames);
     if (result && result.optimized) {
-      if (optimizedBinaryValidates(result.binary)) return result;
+      const validation = validateEmittedBinary(result.binary);
+      if (validation.valid) return result;
       // CLI produced an invalid binary — do not ship it. Fall through to the
-      // module backend in case a different encoder produces valid output.
+      // module backend in case a different encoder produces valid output, but
+      // retain the actual validation failure if that fallback is unavailable.
+      cliValidationWarning = invalidCliBinaryWarning(validation);
     } else if (result) {
       // CLI resolved but reported a wasm-opt error (warning, optimized:false)
       // — surface it; don't silently fall through to the module path, which
@@ -296,7 +328,8 @@ export async function optimizeBinaryAsync(binary: Uint8Array, options: OptimizeO
         preserveNames,
       );
       if (result && result.optimized) {
-        if (optimizedBinaryValidates(result.binary)) return result;
+        const validation = validateEmittedBinary(result.binary);
+        if (validation.valid) return result;
         // Module miscompiled (the #1941 case). Discard — return the original
         // binary with a fail-loud warning so the miscompile is visible and we
         // never emit a module that doesn't validate.
@@ -318,6 +351,7 @@ export async function optimizeBinaryAsync(binary: Uint8Array, options: OptimizeO
     binary,
     optimized: false,
     warning:
+      cliValidationWarning ??
       "wasm-opt not available: install the 'binaryen' npm package or add wasm-opt to PATH. Skipping optimization.",
   };
 }
@@ -530,6 +564,13 @@ function optimizeWithSystemBinary(
   }
   if (!wasmOptPath) return null;
 
+  // Binaryen 132 added compact imports to --all-features. Capability-probe
+  // rather than version-check because callers may provide an older system
+  // wasm-opt or a downstream build with a backported feature set.
+  const featureFlags = wasmOptSupportsCompactImports(n, wasmOptPath)
+    ? BINARYEN_PORTABLE_FEATURE_FLAGS
+    : BINARYEN_BASE_FEATURE_FLAGS;
+
   // Write to temp file, run wasm-opt, read result
   const tmpDir = n.mkdtempSync(n.join(n.tmpdir(), "js2wasm-opt-"));
   const inputPath = n.join(tmpDir, "input.wasm");
@@ -547,28 +588,16 @@ function optimizeWithSystemBinary(
     // surfaced as the misleading "wasm-opt not available" warning at the
     // outer try/catch). Use `--all-features` rather than enumerating; it's
     // the same set wasm-opt uses for `wasm-opt --all-features`.
-    // `--disable-custom-descriptors` excludes the unfinished
-    // custom-descriptors / exact-ref proposal from `--all-features`.
-    // Without this, wasm-opt's GC optimization passes will introduce
-    // `(ref (exact $T))` types that wasmtime ≤ 44 (and most other engines)
-    // refuse to parse. The cost of the disable is zero — js2wasm doesn't
-    // emit exact refs itself, so the only effect is preventing wasm-opt
-    // from inserting them as a width refinement.
+    // The shared portable-feature flags exclude proposal encodings Binaryen
+    // may otherwise introduce while rewriting the module: exact references
+    // from custom-descriptors, and (since Binaryen 132) compact import kind
+    // 0x7e. js2wasm emits neither, and Node 25/current Wasmtime reject them.
     // (#4157) `JS2WASM_INLINE_HINTS` — binaryen's inlining knobs. Both lists
     // are empty (and the argv byte-identical) unless the flag is set. `pre`
     // must precede `-O<level>`: `--no-inline` is a PASS and binaryen runs
     // passes in command order.
     const hints = inlineHintArgs();
-    const args: string[] = [
-      inputPath,
-      ...hints.pre,
-      `-O${level}`,
-      "-o",
-      outputPath,
-      "--all-features",
-      "--disable-custom-descriptors",
-      ...hints.post,
-    ];
+    const args: string[] = [inputPath, ...hints.pre, `-O${level}`, "-o", outputPath, ...featureFlags, ...hints.post];
     if (preserveNames) args.push("-g");
     void gc;
     void referenceTypes;

--- a/src/package-bundler.ts
+++ b/src/package-bundler.ts
@@ -10,6 +10,7 @@ import { dirname, join } from "node:path";
 import type { CompileResult, LinkedModuleArtifact } from "./index.js";
 import { RUNTIME_RECGROUP_ABI_VERSION } from "./emit/canonical-recgroup.js";
 import { appendBundleManifest, bundleArtifactHash, type BundleManifestV1 } from "./bundle-manifest.js";
+import { BINARYEN_PORTABLE_FEATURE_FLAGS } from "./binaryen-features.js";
 import {
   decodeProviderManifest,
   providerArtifactHash,
@@ -175,7 +176,7 @@ export function mergePackageProviders(
       writeFileSync(providerPath, artifact.binary);
       mergeArgs.push(providerPath, artifact.namespace);
     });
-    mergeArgs.push("--all-features", "--disable-custom-descriptors", "--rename-export-conflicts", "-o", mergedPath);
+    mergeArgs.push(...BINARYEN_PORTABLE_FEATURE_FLAGS, "--rename-export-conflicts", "-o", mergedPath);
     runBinaryenTool("wasm-merge", mergeArgs);
 
     const graph = manifest.rootExports.map((name, index) => ({
@@ -186,8 +187,7 @@ export function mergePackageProviders(
     writeFileSync(graphPath, JSON.stringify(graph));
     runBinaryenTool("wasm-metadce", [
       mergedPath,
-      "--all-features",
-      "--disable-custom-descriptors",
+      ...BINARYEN_PORTABLE_FEATURE_FLAGS,
       "--graph-file",
       graphPath,
       "-o",
@@ -197,14 +197,7 @@ export function mergePackageProviders(
     let finalPath = dcePath;
     if (options.optimize) {
       const level = options.optimize === true ? 3 : options.optimize;
-      runBinaryenTool("wasm-opt", [
-        dcePath,
-        `-O${level}`,
-        "--all-features",
-        "--disable-custom-descriptors",
-        "-o",
-        optimizedPath,
-      ]);
+      runBinaryenTool("wasm-opt", [dcePath, `-O${level}`, ...BINARYEN_PORTABLE_FEATURE_FLAGS, "-o", optimizedPath]);
       finalPath = optimizedPath;
     }
 

--- a/tests/issue-3498-landing-four-lane-backend-benchmark.test.ts
+++ b/tests/issue-3498-landing-four-lane-backend-benchmark.test.ts
@@ -28,6 +28,7 @@ import {
 import {
   LANDING_FOUR_LANE_INNER_MEASURED_CALLS,
   LANDING_FOUR_LANE_INNER_WARMUP_CALLS,
+  LANDING_WASM_OPT_ARGS,
   landingFourLaneWasmtimeMedianWarmDriverSource,
 } from "../scripts/lib/landing-wasmtime-runtime.mjs";
 
@@ -54,6 +55,15 @@ afterAll(() => {
 });
 
 describe("#3498 landing four-lane backend benchmark", () => {
+  it("keeps Binaryen output on engine-supported import encodings", () => {
+    expect(LANDING_WASM_OPT_ARGS).toEqual([
+      "--all-features",
+      "--disable-custom-descriptors",
+      "--disable-compact-imports",
+      "-O3",
+    ]);
+  });
+
   it("pins and oracles the four exact landing source files without object-ops", async () => {
     expect(LANDING_BENCHMARK_PROGRAMS.map((program) => program.id)).toEqual([
       "fib",

--- a/tests/package-linking.test.ts
+++ b/tests/package-linking.test.ts
@@ -244,6 +244,30 @@ export async function run(): Promise<number> {
     expect(cached.bundleCacheKey).toBe(result.bundleCacheKey);
   });
 
+  it("keeps host imports in an optimized static package bundle engine-loadable", async () => {
+    const root = project("package-link-merge-host-import");
+    writePackage(root, "merge-inc", "export function inc(x: number): number { return x + 1; }\n");
+    writeFileSync(
+      join(root, "main.ts"),
+      'import { inc } from "merge-inc"; export function run(x: number): number { console.log(x); console.log("hello"); console.error(x); return inc(x); }\n',
+    );
+    const result = await compileProject(join(root, "main.ts"), {
+      emitWat: false,
+      optimize: 1,
+      packageCacheDir: join(root, ".cache"),
+      packageLinking: "merge",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.linkPlan?.mergeFallbackReason).toBeUndefined();
+    expect(result.linkPlan?.mode).toBe("merged");
+    const module = new WebAssembly.Module(result.binary);
+    const imports = WebAssembly.Module.imports(module);
+    expect(imports.length).toBeGreaterThan(0);
+    expect(imports.some((entry) => entry.module.startsWith("js2wasm:npm:"))).toBe(false);
+    await expect(WebAssembly.instantiate(module, result.importObject)).resolves.toBeDefined();
+  });
+
   it("reports an explicit separate-module fallback for merge-unsafe JavaScript values", async () => {
     const root = project("package-link-merge-value-fallback");
     writePackage(root, "merge-value", "export const answer = 42;\n");

--- a/tests/wasm-opt-optimize.test.ts
+++ b/tests/wasm-opt-optimize.test.ts
@@ -1,5 +1,9 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
+import { optimizeBinaryAsync } from "../src/optimize.js";
 
 describe("wasm-opt optimization pass", () => {
   const source = `
@@ -10,6 +14,11 @@ describe("wasm-opt optimization pass", () => {
       if (n <= 1) return n;
       return fib(n - 1) + fib(n - 2);
     }
+  `;
+  const compactImportSource = `
+    class A { x = 1; }
+    class B { y = "a"; }
+    export function f(n: number): any { return n ? new A() : new B(); }
   `;
 
   it("compiles successfully without optimize flag", async () => {
@@ -68,5 +77,109 @@ describe("wasm-opt optimization pass", () => {
     // WAT should be the same regardless of optimize flag,
     // because WAT is emitted from the IR, not from the binary
     expect(withOpt.wat).toBe(withoutOpt.wat);
+  });
+
+  it("keeps Binaryen 132 compact-import rewrites loadable by Node", async () => {
+    const raw = await compile(compactImportSource);
+    expect(raw.success).toBe(true);
+    expect(WebAssembly.validate(raw.binary)).toBe(true);
+
+    // Exclude any system wasm-opt so this exercises the binaryen package path
+    // used by clean benchmark runners. Keep Node on PATH for Binaryen's
+    // /usr/bin/env node launcher.
+    const previousPath = process.env.PATH;
+    process.env.PATH = [resolve(process.cwd(), "node_modules", ".bin"), dirname(process.execPath)].join(delimiter);
+    try {
+      const optimized = await optimizeBinaryAsync(raw.binary, { level: 4 });
+      expect(optimized.optimized, optimized.warning).toBe(true);
+      expect(WebAssembly.validate(optimized.binary)).toBe(true);
+    } finally {
+      if (previousPath === undefined) Reflect.deleteProperty(process.env, "PATH");
+      else process.env.PATH = previousPath;
+    }
+  });
+
+  it("does not pass compact-import flags to an older system wasm-opt", async () => {
+    const raw = await compile(compactImportSource);
+    expect(raw.success).toBe(true);
+
+    const fakeRoot = mkdtempSync(join(tmpdir(), "js2-wasm-opt-old-"));
+    const fakeWasmOpt = join(fakeRoot, "wasm-opt");
+    const capturedArgs = join(fakeRoot, "args.json");
+    writeFileSync(
+      fakeWasmOpt,
+      `#!/usr/bin/env node
+const { copyFileSync, writeFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+if (args.includes("--help")) {
+  console.log("old wasm-opt help");
+  process.exit(0);
+}
+writeFileSync(process.env.JS2WASM_FAKE_WASM_OPT_ARGS, JSON.stringify(args));
+copyFileSync(args[0], args[args.indexOf("-o") + 1]);
+`,
+    );
+    chmodSync(fakeWasmOpt, 0o755);
+
+    const previousPath = process.env.PATH;
+    const previousCapture = process.env.JS2WASM_FAKE_WASM_OPT_ARGS;
+    process.env.PATH = [fakeRoot, dirname(process.execPath), "/usr/bin", "/bin"].join(delimiter);
+    process.env.JS2WASM_FAKE_WASM_OPT_ARGS = capturedArgs;
+    try {
+      const optimized = await optimizeBinaryAsync(raw.binary, { level: 4 });
+      expect(optimized.optimized, optimized.warning).toBe(true);
+      const args = JSON.parse(readFileSync(capturedArgs, "utf8")) as string[];
+      expect(args).toContain("--all-features");
+      expect(args).toContain("--disable-custom-descriptors");
+      expect(args).not.toContain("--disable-compact-imports");
+    } finally {
+      if (previousPath === undefined) Reflect.deleteProperty(process.env, "PATH");
+      else process.env.PATH = previousPath;
+      if (previousCapture === undefined) Reflect.deleteProperty(process.env, "JS2WASM_FAKE_WASM_OPT_ARGS");
+      else process.env.JS2WASM_FAKE_WASM_OPT_ARGS = previousCapture;
+      rmSync(fakeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("reports rejected optimizer output instead of claiming wasm-opt is missing", async () => {
+    const raw = await compile(compactImportSource);
+    expect(raw.success).toBe(true);
+
+    const fakeRoot = mkdtempSync(join(tmpdir(), "js2-wasm-opt-invalid-"));
+    const fakeWasmOpt = join(fakeRoot, "wasm-opt");
+    writeFileSync(
+      fakeWasmOpt,
+      `#!/usr/bin/env node
+const { writeFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+if (args.includes("--help")) {
+  console.log("--disable-compact-imports");
+  process.exit(0);
+}
+writeFileSync(args[args.indexOf("-o") + 1], Buffer.from([0]));
+`,
+    );
+    chmodSync(fakeWasmOpt, 0o755);
+
+    const previousPath = process.env.PATH;
+    const binaryenSpecifierKey = "__js2wasmBinaryenModuleSpecifier";
+    const globalObject = globalThis as Record<string, unknown>;
+    const previousBinaryenSpecifier = globalObject[binaryenSpecifierKey];
+    process.env.PATH = [fakeRoot, dirname(process.execPath), "/usr/bin", "/bin"].join(delimiter);
+    globalObject[binaryenSpecifierKey] = `file://${join(fakeRoot, "missing-binaryen.mjs")}`;
+    try {
+      const optimized = await optimizeBinaryAsync(raw.binary, { level: 4 });
+      expect(optimized.optimized).toBe(false);
+      expect(optimized.binary).toEqual(raw.binary);
+      expect(optimized.warning).toContain("wasm-opt produced an invalid binary");
+      expect(optimized.warning).toContain("Runtime validation:");
+      expect(optimized.warning).not.toContain("wasm-opt not available");
+    } finally {
+      if (previousPath === undefined) Reflect.deleteProperty(process.env, "PATH");
+      else process.env.PATH = previousPath;
+      if (previousBinaryenSpecifier === undefined) Reflect.deleteProperty(globalObject, binaryenSpecifierKey);
+      else globalObject[binaryenSpecifierKey] = previousBinaryenSpecifier;
+      rmSync(fakeRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- keep Binaryen 132 from rewriting imports to the unsupported compact-import proposal in compiler, static package-bundle, and landing benchmark output
- capability-probe system `wasm-opt` so older Binaryen releases do not receive an unknown flag
- retain the actual runtime validation diagnostic when optimizer output is rejected
- cover the optimizer, merged npm-package host imports, and landing normalization paths

## Root cause

Binaryen 132 added compact imports to `--all-features`. It rewrote ordinary imports to kind byte `0x7e`; Node 25 and the current Wasmtime lane reject that encoding. The benchmark refresh therefore discarded O4 output and misleadingly reported `wasm-opt not available`.

## Validation

- 39 focused tests passed; 5 platform-gated tests skipped
- TypeScript 7 typecheck passed
- Biome lint and Prettier checks passed
- LOC/function, oracle, and coercion ratchets passed
- 18 numeric-local IR parity tests passed in the pre-push gate
- exact Binaryen 132 probe: raw 9,779-byte module valid; optimized 6,779-byte module valid

## Acorn

This unblocks a fresh JS-host measurement. The separate `standaloneDynamic` 0.0007× regression was the hot-`arguments` vec retention bug already fixed by #4873; the latest committed standalone result is back to 0.1266× (7.9× slower than Node).