### PR TITLE
docs(issues): file #5225–#5228 — dev-5221's four residual defects

### DIFF
--- a/plan/issues/5225-consumer-object-literal-opaque-to-provider.md
+++ b/plan/issues/5225-consumer-object-literal-opaque-to-provider.md
@@ -1,0 +1,55 @@
+---
+id: 5225
+title: "Consumer-module object literals are opaque to a linked provider — Temporal.PlainDate.from({year,month,day}) throws 'year is required' while string and host-object forms work"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5225 — provider seam: consumer struct opaque to provider module
+
+## Problem
+
+Through the #4628 compile-once linked provider,
+`Temporal.PlainDate.from("2020-03-04")` and `.from(<host object>)` both work
+(after #5221/PR #5334), but `.from({ year: 2020, month: 3, day: 4 })` — an
+object literal built **in the consumer module** — throws
+`RangeError: year is required`. The consumer's WasmGC struct crosses the #2527
+linker seam as an opaque value the provider module cannot read properties
+from, so the polyfill's field extraction sees no `year`.
+
+This is the inbound twin of #5222 (PR #5324): #5222 made provider→consumer
+values module-aware at the exit boundary; this is consumer→provider — a value
+minted by module A, read by module B's `__extern_get`-equivalent path.
+
+## Direction
+
+Reduce with a non-Temporal linked pair: provider function
+`f(o) { return o.x }`, consumer passes `{ x: 7 }`. Likely the same
+module-aware mirror machinery from #5324 needs to run on the **argument**
+path: when a consumer value enters a registered linked provider, wrap it as a
+host mirror against the consumer's exports instead of handing over the raw
+struct.
+
+## Acceptance criteria
+
+1. Non-Temporal reduction: provider reads consumer-literal properties
+   correctly; new `tests/issue-5225-*.test.ts` failing on base (linked lane),
+   single-module control passing on base.
+2. `Temporal.PlainDate.from({year,month,day})` works through the provider;
+   flip the corresponding knownGap/reported row in
+   `tests/dogfood/temporal-global-harness.mjs` / issue-4628 tests.
+3. No regressions: issue-5222/4628 test files + #2527 linker family. Gates
+   green.
+
+## Notes
+
+- Found by dev-5221 validating PR #5334 (its PR body reports this defect
+  explicitly rather than claiming it fixed). Same family as #5222.
+- Id reserved with a degraded PR scan; manually checked against open PR head
+  branches 2026-08-30.

--- a/plan/issues/5226-provider-error-identity-not-crossing.md
+++ b/plan/issues/5226-provider-error-identity-not-crossing.md
@@ -1,0 +1,50 @@
+---
+id: 5226
+title: "Errors thrown inside a linked provider lose identity at the seam — e.pass through as generic objects, instanceof RangeError is false in the consumer"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+goal: core-semantics
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5226 — provider seam: error identity does not cross
+
+## Problem
+
+An error thrown inside the #4628 linked Temporal provider (e.g. the
+polyfill's `RangeError: year is required`) reaches the consumer as a value
+for which `e instanceof RangeError === false` (and `instanceof Error` is
+unreliable). The message survives; the identity does not. test262 Temporal
+rows assert error TYPES (`assert.throws(RangeError, …)`), so every
+negative-case row fails at the seam even when the polyfill throws correctly —
+this gates wiring the test262 runner to the provider as much as #5223 does.
+
+## Direction
+
+Reduce non-Temporal: provider function that `throw new RangeError("x")`,
+consumer catches and checks `instanceof`. Decide the crossing rule: re-mint
+the error host-side from name+message when a provider throw crosses the seam
+(cheap, loses custom subclass state), or mirror it module-aware like #5222's
+value path. Host-lane `Error` objects are host-native, so re-minting at the
+linker trampoline (`instantiateLinkedProviders` call wrapper) is likely
+sufficient and narrow.
+
+## Acceptance criteria
+
+1. Non-Temporal reduction: `instanceof RangeError` true in the consumer for a
+   provider throw; new `tests/issue-5226-*.test.ts` failing on base (linked
+   lane), single-module control passing.
+2. `assert.throws(RangeError, () => Temporal.PlainDate.from({}))`-shaped
+   probe passes through the provider.
+3. No regressions in issue-5222/4628 + linker family. Gates green.
+
+## Notes
+
+- Found by dev-5221 validating PR #5334. Blocks (with #5223) the test262
+  runner wiring for #4628 acceptance criterion 2.
+- Id reserved with a degraded PR scan; manually checked against open PR head
+  branches 2026-08-30.

--- a/plan/issues/5227-temporal-provider-cache-not-invalidated.md
+++ b/plan/issues/5227-temporal-provider-cache-not-invalidated.md
@@ -1,0 +1,51 @@
+---
+id: 5227
+title: "Temporal provider artifact cache is not invalidated by compiler changes — a stale artifact silently reproduces old bugs after a codegen fix"
+status: ready
+sprint: current
+priority: high
+horizon: s
+goal: dogfood
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5227 — provider cache keyed on inputs only, not compiler version
+
+## Problem
+
+The #4628 compile-once provider cache (`JS2WASM_TEMPORAL_CACHE`,
+`src/temporal-provider.ts`) keys the artifact on the polyfill source content
+hash — not on the **compiler** that produced it. After a codegen change, the
+first provider run reports `cacheHit=true` and serves an artifact built by
+the previous compiler. dev-5221 measured this directly: the cached artifact
+reproduced the already-fixed #5221 null deref; a fresh cache dir gave the
+correct result. This is a measurement hazard (a fix looks unlanded; a
+regression looks pre-existing) and will bite every future codegen PR that
+touches anything on the polyfill's compile path.
+
+## Direction
+
+Fold a compiler-version fingerprint into the cache key. Cheapest correct key:
+the package version plus a content hash of the compiled `dist/` (or, in
+from-source runs, a hash of `src/**` mtimes/contents is too slow — use the
+git HEAD sha of the compiler tree when available, falling back to version).
+Invalidation must be automatic; an env-var escape hatch to force rebuild
+(`JS2WASM_TEMPORAL_CACHE_REBUILD=1`) is a bonus, not the fix.
+
+## Acceptance criteria
+
+1. Changing the compiler (simulate: bump the fingerprint input) misses the
+   cache; unchanged compiler + unchanged polyfill still hits (warm-path cost
+   preserved, ~0.75 s).
+2. Test in `tests/issue-5227-*.test.ts` proving key sensitivity both ways.
+3. issue-4628 tests + harness green; gates green.
+
+## Notes
+
+- Found by dev-5221 (PR #5334 body carries the ⚠ warning); until fixed,
+  anyone measuring the provider after a codegen change must clear the cache
+  first.
+- Id reserved with a degraded PR scan; manually checked against open PR head
+  branches 2026-08-30.

--- a/plan/issues/5228-standalone-destructure-any-return-zero.md
+++ b/plan/issues/5228-standalone-destructure-any-return-zero.md
@@ -1,0 +1,48 @@
+---
+id: 5228
+title: "Standalone: destructuring the any-typed return of a call answers 0 for every property — const { year: n } = f() reads 0 regardless of shape"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+goal: standalone-gap
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-30
+---
+
+# #5228 — standalone destructure of an `any` call result reads 0
+
+## Problem
+
+In standalone mode, `const { year: n } = f()` where `f`'s return type
+resolves to `any` binds `n = 0` for **every** object shape — no shadowing or
+TDZ involved (distinct from #5221's defect 2/3, which this repro was reduced
+away from). The host lane answers correctly. Consistent with the #5221
+through-line: a slot/shape mismatch is silently coerced (here to a zero
+scalar) instead of being routed through a dynamic property read or rejected
+at compile time.
+
+## Direction
+
+Locate where standalone destructuring lowers the initializer when the source
+type is unresolvable — likely `src/codegen/destructuring*.ts` /
+`statements.ts` choosing a scalar slot for the bound name and defaulting the
+read to `0` when no struct type is known. Correct behavior: route through the
+standalone dynamic property-get path (the #2860 family machinery), or demote
+to a compile error if that path can't serve the shape — never a silent 0.
+
+## Acceptance criteria
+
+1. `const { year: n } = f()` (f returning `any`-typed object) answers the
+   real property value in standalone; several shapes covered.
+2. New `tests/issue-5228-*.test.ts` failing on base in the standalone lane,
+   host-lane control passing on base.
+3. No standalone floor/net regressions; gates green.
+
+## Notes
+
+- Found by dev-5221 (PR #5334 "Not fixed here" list) — it is why the
+  defect-3 repro in `tests/issue-5221-*.test.ts` has no standalone row.
+- Id reserved with a degraded PR scan; manually checked against open PR head
+  branches 2026-08-30.


### PR DESCRIPTION
Files the four defects dev-5221 found and reported (not fixed) while validating PR #5334:

- [#5225](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5225-consumer-object-literal-opaque-to-provider) — consumer-module object literals are opaque to a linked provider (`Temporal.PlainDate.from({year,month,day})` throws "year is required" while string/host-object forms work). Inbound twin of [#5222](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5222-temporal-now-methods-lost-provider-boundary).
- [#5226](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5226-provider-error-identity-not-crossing) — errors thrown inside a linked provider lose identity at the seam (`instanceof RangeError === false` in the consumer). With [#5223](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5223-compiled-class-instance-tostring-dispatch), gates wiring the test262 runner to the provider.
- [#5227](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5227-temporal-provider-cache-not-invalidated) — the provider artifact cache is not invalidated by compiler changes; a stale artifact reproduced the already-fixed #5221 null deref (`cacheHit=true`). Measurement hazard for every codegen PR.
- [#5228](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5228-standalone-destructure-any-return-zero) — standalone `const { year: n } = f()` on an `any`-typed return answers `0` for every shape.

Docs-only: four new files under `plan/issues/`, nothing else. Ids reserved via `claim-issue.mjs --allocate` (degraded PR scan; open-PR head branches manually checked 2026-08-30).

No open docs-only PR from this lane existed at creation time (#5249 is another session's final-handoff PR; the codex docs PRs are drafts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_