### PR TITLE
docs(issues): file #5237–#5238 — dev-5223's residual defects

### DIFF
--- a/plan/issues/5237-cross-module-class-member-resolution.md
+++ b/plan/issues/5237-cross-module-class-member-resolution.md
@@ -1,0 +1,63 @@
+---
+id: 5237
+title: "Compiled-class members resolve against the CALLING module's exports — every prototype member of a linked provider's class answers undefined in the consumer"
+status: ready
+sprint: current
+priority: high
+horizon: l
+goal: core-semantics
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-08-31
+---
+
+# #5237 — cross-module compiled-class member resolution
+
+## Problem
+
+Through the #4628 linked provider, every member read off a provider class's
+prototype answers `undefined` in the consumer:
+`typeof Temporal.PlainDate.prototype.toString` is `"undefined"`, `d.year` /
+`d.month` / `d.day` on a `.from()` result are `undefined`, and
+`Temporal.PlainDate.prototype.toString.call(d)` throws "Cannot read
+properties of null" — while `Object.getOwnPropertyNames(PlainDate.prototype)`
+correctly lists all 31 names. This is why the harness `staticFrom` row still
+prints `[object Object]` after the #5223 fix (PR #5339 re-measured:
+byte-identical before/after, so it is a distinct defect).
+
+Root cause (measured by dev-5223): the host boundary resolves compiled class
+members against the **calling module's** exports. The provider binary exports
+141 `__member_kind_*` / 41 `__call_get_*` / 137 `__class_call_*`; the
+consumer exports none, so nothing resolves. A `new`-built instance escapes
+because its host proxy carries the provider's export slot; a prototype-read
+or `Object.create(proto)` path does not.
+
+Control: the identical single-module shape answers `"function"`.
+
+## Direction
+
+Same family as #5222 (PR #5324's module-aware mirrors) and #5225: the member
+resolver needs to consult the exports of the module that OWNS the class (the
+minting module recorded on the mirror/prototype), not the reader's. Likely
+site: `_resolveClassMember` / `_safeGet` in `src/runtime.ts` and the linked
+provider export registry from #5324 — route resolution through the owner's
+registered export set when the receiver/prototype is foreign.
+
+## Acceptance criteria
+
+1. Non-Temporal linked reduction: prototype member reads and getter reads on
+   a provider class resolve in the consumer; new `tests/issue-5237-*.test.ts`
+   failing on base (linked lane), single-module control passing on base.
+2. Temporal: `Temporal.PlainDate.from("2020-03-04").toString()` answers
+   `"2020-03-04"` and `.year` answers `2020` through the provider; flip the
+   harness `staticFrom` knownGap.
+3. No regressions: issue-5222/5223/4628 test files + #2527 linker family.
+   Gates green.
+
+## Notes
+
+- Found by dev-5223 (PR #5339 "Found and NOT fixed" item 1) with counts and
+  controls. With #5225/#5226, this is the remaining provider-seam family
+  before the test262 runner can be wired to the provider (#4628 criterion 2).
+- Id reserved with a degraded PR scan; manually checked against open PR head
+  branches 2026-08-31.

--- a/plan/issues/5238-class-reflective-surface-gaps.md
+++ b/plan/issues/5238-class-reflective-surface-gaps.md
@@ -1,0 +1,59 @@
+---
+id: 5238
+title: "Host-lane reflective surface gaps on compiled classes: accessor descriptors lack get, Symbol.toStringTag is undefined, Object.create proto identity lost"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+goal: core-semantics
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-08-31
+---
+
+# #5238 — compiled-class reflective surface gaps (host lane)
+
+## Problem
+
+Three measured, pre-existing gaps in the host-lane reflective surface of
+compiled classes, all reproduced on plain user classes in one module
+(controls in `tests/issue-5223-instance-tostring-dispatch.test.ts` and the
+#4628 harness):
+
+1. `Object.getOwnPropertyDescriptor(P.prototype, "y")` for a class accessor
+   returns a descriptor with **no `get` slot** — the descriptor surface is
+   separate from the #5223 dispatch surface. Standalone answers correctly
+   via #4455.
+2. `Symbol.toStringTag` on a compiled instance answers `undefined`, so
+   `Object.prototype.toString.call(inst)` reports `[object Object]` even
+   when the class declares `get [Symbol.toStringTag]()`. Recorded as the
+   `instanceToStringTag` gap in `tests/dogfood/temporal-global-harness.mjs`.
+   test262 asserts toStringTag on every Temporal class.
+3. `Object.getPrototypeOf(Object.create(P.prototype)) === P.prototype` is
+   `false` in the host lane (`true` for `new P()`, and `true` in the
+   Temporal provider lane) — prototype identity is not preserved through
+   the host proxy.
+
+## Direction
+
+All three live in the host proxy / `wasm-struct-host-semantics.ts` surface,
+not codegen. (1) wire `__call_get_*` into the descriptor materialization;
+(2) support symbol-keyed accessors in the member-kind surface (the current
+`__member_kind_<key>` scheme is string-keyed — needs a well-known-symbol
+mapping); (3) make the proxy's `getPrototypeOf` trap answer the registered
+prototype object identity.
+
+## Acceptance criteria
+
+1. Each gap covered by tests failing on base, host lane, with the existing
+   base-pinned rows flipped rather than deleted.
+2. Flip the harness `instanceToStringTag` gap.
+3. No regressions in issue-5223/5221/4628 files. Gates green.
+
+## Notes
+
+- Found by dev-5223 (PR #5339 items 2–4), each with a control proving it
+  pre-existing. Split from #5237 (cross-module resolution) — these are
+  single-module host-lane gaps.
+- Id reserved with a degraded PR scan; manually checked against open PR head
+  branches 2026-08-31.


### PR DESCRIPTION
Files the two residual defect groups dev-5223 found and reported (not fixed) while validating PR #5339:

- [#5237](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5237-cross-module-class-member-resolution) — compiled-class members resolve against the **calling** module's exports, so every prototype member of a linked provider's class answers `undefined` in the consumer (the real cause of the harness `staticFrom` gap; provider exports 141 `__member_kind_*` / 41 `__call_get_*`, consumer exports none). With [#5225](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5225-consumer-object-literal-opaque-to-provider) and [#5226](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5226-provider-error-identity-not-crossing), the remaining provider-seam family before the test262 runner can be wired to the provider.
- [#5238](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5238-class-reflective-surface-gaps) — three single-module host-lane reflective gaps: class-accessor descriptors have no `get` slot, `Symbol.toStringTag` answers `undefined` (so `Object.prototype.toString` says `[object Object]`), and `Object.create(P.prototype)` loses prototype identity through the host proxy.

Docs-only: two new files under `plan/issues/`. Separate from docs PR #5335 only because that branch is locked in the in-flight merge group and declines pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_