### PR TITLE
fix(codegen): enforce Date bridge export provenance (#3520 C39)

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -3963,3 +3963,207 @@ precommit and prepush hooks run without bypass. No baseline, size, LOC,
 function, or hook exception is authorized. A Terra implementation remains draft
 until a separate Sol approves the exact pushed SHA; any later push invalidates
 that approval.
+
+## 2026-08-31 C39 implementation lock — Date carrier export provenance
+
+This Sol-authored checkpoint is stacked on the exact independently reviewed
+C38 commit `f8eefc6e9a7e379238bfe06d406f82de779cfd1f` (PR #5342), whose tree is
+`8dae802f55f37e5b932bef34f06905ce2f07e99a`. The current protected-main
+snapshot is `f6de3f79deabfc722368c3e3aaaa83bd8514c5d7`; it does not yet contain C38,
+so C39 is not eligible to leave draft. Develop on
+`codex/3520-c39-date-carrier-provenance-final`, then, after #5342 merges,
+re-anchor without rewriting the reviewed parent, rerun every gate on refreshed
+main, and obtain a new Sol review of the final pushed SHA. Any later push
+invalidates that review. The earlier draft PR #5301 and its allocator-authority
+design are superseded and must never be advanced or copied as an acceptance
+oracle.
+
+### Deterministic false-pass
+
+`emitDateHostBridge(...)` publishes three NUL-named compiler functions whenever
+the native `__Date` carrier exists:
+
+- `__\0js2_is_date`;
+- `__\0js2_date_value`; and
+- `__\0js2_date_set_value`.
+
+The #4035 policy sink does not recognize those spellings. They match neither
+the legacy bridge prefixes nor the `host_bridge` infix, so standalone and WASI
+retain all three exports even when `emitHostBridge` is false. Those exports are
+GC roots and keep the Date classifier/accessors, carrier type, and their
+dependency closure live. Adding these strings to the legacy strip table would
+create the same false ownership inference fixed by C37 and C38: an ordinary
+user can publish an exact same-spelled export, and spelling is not proof that
+the compiler produced its descriptor.
+
+The superseded C39 draft compounded that error by treating an unrecorded exact
+name plus a matching allocator target as compiler ownership. A copied
+descriptor, or a descriptor donated by an identically laid-out second context,
+can resolve to the recipient's allocator by numeric coincidence. Resolution is
+therefore validation evidence only. It must never authorize removal.
+
+### Exact ownership and file boundary
+
+The implementation owns only:
+
+- this issue record (Sol only);
+- `src/codegen/date-host-bridge.ts`;
+- `src/codegen/host-bridge-exports.ts`; and
+- `tests/issue-3520-date-host-bridge-export-provenance.test.ts`.
+
+The Terra implementer must not edit, stage, or restore C38's closure registry,
+C37's vec registry, Program ABI, #3525 publication files, #5092 selector work,
+compiler timing, runtime adapters, baselines, ratchet allowlists, or unrelated
+tests. Parallel Claude work is present; a newly observed path or semantic
+overlap is a stop-and-report condition, not permission to reconcile it.
+
+At Date publication, retain an immutable three-row context-local record. Each
+row binds the exact `WasmExport` descriptor object, its exact published name,
+and the exact `WasmFunction` allocator object. The descriptor identity issued
+by that `CodegenContext` is the sole capability that authorizes policy removal.
+The three names form one exact shared public namespace; there are no suffix or
+prefix members. Near spellings, compact `$d*` names, and any other NUL name are
+outside this C39 namespace.
+
+`isCompilerOwnedDateHostBridgeExport(ctx, entry)` must answer true only for a
+recorded descriptor object from that exact context. It must not consult the
+entry name, numeric index, function map, structural equality, another context,
+or a live/stable allocator match as a fallback. A recorded entry remains owned
+if it is renamed after the validated pre-freeze boundary; an unrecorded copy
+never becomes owned.
+
+### Pre-freeze namespace census
+
+Before the export-policy sink can return for either enabled or disabled host
+bridge policy, validate the current complete Date publication state. Do not
+memoize a successful validation in a way that lets a later pre-freeze mutation
+bypass a second check. The validation must fail closed, before rewriting the
+export array, unless all of the following are true:
+
+1. The context has either no Date publication at all or exactly three immutable
+   publication rows, one for each exact name.
+2. Every recorded descriptor and allocator object is unique; every exact name
+   appears exactly once in the record; and each recorded descriptor appears
+   exactly once in `ctx.mod.exports`.
+3. Every recorded descriptor retains its published name and `func` kind, its
+   allocator remains present exactly once in `ctx.mod.functions`, and its
+   descriptor resolves to that same allocator object.
+4. Live handles are interpreted only against the current function-import
+   prefix. A negative or out-of-range live position fails; it must not fall
+   through into stable resolution. Stable handles use `definedFuncAt(...)`.
+   No check may repair an index, consult `funcMap`, or reconstruct a target by
+   name.
+5. Every current export in the exact three-name Date namespace is examined.
+   For each unrecorded descriptor, resolution to any recorded Date allocator is
+   an invariant violation. This rejects same-context clones and a foreign
+   descriptor donated by an identically laid-out context. An unrecorded exact
+   name resolving to a distinct user allocator is legitimate and remains
+   user-owned.
+
+An entry outside the exact three-name namespace is not reclassified merely
+because it targets a Date allocator. In particular, a near spelling targeting
+the compiler function remains noncompiler. A post-freeze replacement copy of a
+recorded exact-name descriptor has no context-bound provenance and must be
+retained; no late validation or allocator fallback may silently strip it.
+
+### Shared policy-sink composition
+
+`stripHostBridgeExports(...)` must compose C39 with the exact reviewed C38/C37
+ordering. While the index space is still open, run the constructor-closure and
+Date pre-freeze validators before the `emitHostBridge` early return. When
+stripping is enabled, apply the predicates in this order:
+
+1. recorded Date descriptor identity;
+2. recorded constructor-closure descriptor identity;
+3. recorded vec descriptor identity;
+4. exact Date public-name retention for all remaining entries;
+5. exact vec public-name retention;
+6. exact constructor-closure public-name retention; and
+7. the unchanged legacy name policy.
+
+The first three identity checks intentionally precede every public-namespace
+retention rule. Thus a recorded Date descriptor renamed after validation into a
+vec or constructor spelling is still removed, while the genuine user entry at
+that spelling survives. Conversely, an unrecorded exact Date descriptor is
+retained even if its numeric target resembles compiler output; a pre-freeze
+allocator collision is rejected by the census, not converted into ownership.
+Do not add the Date names to `BRIDGE_PREFIXES`, `BRIDGE_ALIASES`, or the generic
+infix rule.
+
+### Required mutation and control matrix
+
+Build the focused test from production-shaped contexts and complete output
+censuses. It must cover all of the following without vacuous prefix checks:
+
+1. Exact namespace predicate: all three Date names are accepted; suffixes,
+   prefixes, `$d*` aliases, and near NUL spellings are rejected.
+2. Host `auto` and `always`: require the exact three descriptor names, distinct
+   exact function targets, expected parameter/result types and bodies, no hard
+   diagnostics, and runtime `dateValue() === 5`.
+3. Standalone and WASI, each with `auto` and `off`, each with IR-outcome
+   tracking disabled and enabled: all authenticated Date exports are absent,
+   host-import census is empty, complete public export census is exact,
+   tracked/untracked generated surfaces and binaries are byte-identical, and
+   runtime remains `5`.
+4. Standalone and WASI with `hostBridge: "always"`: all three authenticated
+   descriptors remain with exact targets/types; tracked/untracked binaries are
+   identical; runtime remains `5`.
+5. Date-free source: no Date publication record, functions, carrier census, or
+   Date exports. The finalizer and sink are true no-ops for this context.
+6. Multi-source provider/entry source order: Date may be materialized in a
+   non-entry provider, yet host/standalone/WASI and tracking matrices retain the
+   same exact policy, import, binary-parity, and runtime evidence.
+7. Genuine same-spelled user descriptor targeting a distinct user allocator is
+   retained. A near spelling targeting a recorded Date allocator is retained.
+8. A same-context exact-name clone targeting a recorded allocator is rejected
+   before any policy rewrite. A descriptor donated by a second, identically
+   laid-out context is likewise rejected in the recipient context. Assert the
+   export array remains byte/object-identical after each rejection.
+9. After one successful pre-freeze validation, a replacement copy inserted
+   only after `indexSpaceFrozen = true` remains unowned and retained. This is
+   the explicit no-fallback control and replaces the superseded draft's
+   copy-strip expectation.
+10. Recorded descriptor mutations fail closed before publication: missing,
+    duplicate object, renamed, kind-changed, retargeted, one-past live handle,
+    invalid live handle despite an available stable ordinal, allocator removed,
+    allocator duplicated, incomplete publication census, and duplicate/unknown
+    recorded names where a bounded test seam can express them.
+11. After a successful pre-freeze validation and freeze, a recorded Date
+    descriptor renamed into the vec namespace and one renamed into the
+    constructor-closure namespace are removed by Date identity, while genuine
+    user descriptors at those names remain. No other family registry changes.
+12. Preserve the full C38 constructor-closure suite, C37 vec suite, and #4035
+    policy suite as controls. The unchanged #4035 size ceiling is inherited
+    evidence, not a new C39 regression; do not change or relabel it.
+
+For every mutation, distinguish validation failure from policy removal and
+assert zero partial rewrite. For every target/tracking comparison, publish the
+complete export names/descriptors, import census, runtime value, and binary
+parity where specified. Counts without identities, prefix-only absence, and a
+successful compile without runtime evidence are not acceptance evidence.
+
+### Non-goals, validation, and publication
+
+C39 changes no Date helper body/type/order, `__Date` carrier layout, allocator
+order, stable-handle minting, late-import shifting, Program ABI, bridge
+manifest, runtime lookup, target selection, DCE algorithm, direct/IR routing,
+fallback behavior, or generic host-bridge spelling policy. It creates no
+compact Date alias family and no new test-only production authority.
+
+Validation requires the focused C39 suite plus the complete C38 closure, C37
+vec, and #4035 policy controls; TypeScript 7; targeted Biome and Prettier;
+`git diff --check`; issue integrity; IR fallback/layering/readiness; and all
+applicable oracle, coercion, dead-export, LOC, and function regrowth ratchets.
+Run every heavy command only after a finite, non-negative one-minute load
+sample is strictly below `logical cores - 2`. Immediately before the signed
+commit, rerun both LOC and function ratchets. Keep the complete precommit and
+prepush hooks enabled; no baseline, size, LOC, function, load, or hook exception
+is authorized.
+
+Commit and push a small checkpoint only after the exact owned diff is clean and
+all gates pass. The implementation PR remains draft while stacked or failing a
+gate. After #5342 merges, rebase/merge current protected main according to the
+repository workflow, rerun the entire matrix and hooks, push once, then obtain
+an independent Sol exact-byte/SHA review. Only that reviewed pushed head may be
+marked ready and entered into the protected merge queue. Close #5301 as
+superseded only after the replacement PR preserves its historical discussion.

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -3838,3 +3838,128 @@ strictly below `logical cores - 2`; keep complete precommit and prepush hooks
 enabled. No baseline, LOC, function-size, binary-size, size-ceiling, or hook
 exception is authorized. The stacked PR remains draft until an independent Sol
 approves its exact pushed SHA; any later push invalidates that approval.
+
+## 2026-08-30 C38 implementation lock — constructor-closure export provenance
+
+This Sol-authored checkpoint was prepared on exact signed C37 head
+`438017216a585f6a4d3ece1ec51d2a32224e4902`. That reviewed head is now an exact
+ancestor of refreshed main `adc071c4db5e0a70fedb0dc7d1b5ef0cedbff6f2`
+through merge commit `f6e86d09612581a4030d4d1635bf0773c39f615d`; the only
+later main commit is non-overlapping #5323 merge
+`adc071c4db5e0a70fedb0dc7d1b5ef0cedbff6f2`. Re-anchor the isolated
+`codex/5298-c38-prep-438017` preparation to that exact main before its signed
+commit. Never amend or push C37, C36, or a queued parent, and repeat the complete
+validation/review cycle after re-anchoring. The unchanged #4035 size ceiling
+remains a control, not a new regression claim.
+
+### Deterministic false-pass
+
+#4661 added closure-host-bridge availability bit 17 with logical export
+`__is_ctor_closure` and compact family `$ch`. `stripHostBridgeExports(...)`
+still recognizes only `$c0` through `$cg`; none of its prefixes matches
+`__is_ctor_closure`. When `constructibleClosureTypeIdxs` is populated, both
+compiler-owned exports therefore survive `emitHostBridge=false` in standalone
+and WASI, retaining the classifier and its types through DCE. The closure ABI
+test also stops its physical census at `$cg`, and #4035's marker list omits both
+names, so the leak currently passes every control.
+
+Do not repair this by adding the two spellings to the legacy strip table. That
+would delete genuine user exports and repeat the ownership bug C37 just closed.
+
+### Exact ownership and provenance contract
+
+Own only:
+
+- this issue record;
+- `src/codegen/closure-exports.ts`;
+- `src/codegen/host-bridge-exports.ts`; and
+- `tests/issue-3520-closure-host-bridge-abi.test.ts`.
+
+At bit 17 publication, retain each compiler-published `WasmExport` descriptor
+beside the exact `WasmFunction` already captured for the availability manifest.
+Export one predicate for the bounded shared namespace: exact
+`__is_ctor_closure`, or `$ch` followed by zero or more literal `$` characters.
+Near spellings such as `$ch0`, `$chi`, `$ch_extra`, and
+`__is_ctor_closure_extra` are not in this namespace.
+
+Authenticate an entry as compiler-owned only when it is one recorded bit-17
+descriptor from the same publishing `CodegenContext`, regardless of later
+spelling. Descriptor identity is the context-bound capability: an unrecorded
+replacement/copy has no authority to claim the classifier, including when it
+was donated from an identically laid-out module.
+
+Before the index-space freeze, finalization must census every entry in the exact
+constructor-closure namespace. Resolve each unrecorded function descriptor
+through the live or stable handle regime; if it resolves to any captured bit-17
+allocator, reject it rather than reinterpreting it as local compiler output.
+This catches cloned extras and foreign-context donations while retaining genuine
+user descriptors, including same-spelled entries targeting a different user
+allocator and near spellings. Never fall through from an invalid live lookup to
+the stable regime, repair an index, consult `funcMap`, or infer ownership from
+spelling alone.
+
+The normal policy sink runs before the freeze boundary. A direct post-freeze
+replacement copy cannot prove context ownership, so it remains a noncompiler
+exact-namespace entry rather than being silently stripped; this is intentionally
+fail-closed, not a second authentication path.
+
+`stripHostBridgeExports(...)` must remove authenticated bit-17 entries first,
+then retain noncompiler entries in the exact constructor-closure namespace,
+then apply the existing legacy host-bridge name policy unchanged. This order
+must coexist with C37's vec provenance branch without coupling the two
+registries. Do not change closure allocation, manifest bits/table layout,
+Program ABI role/ordinal 14, runtime lookup, collision suffix allocation, any
+other closure family, direct/IR routing, or fallback.
+
+### Required focused matrix
+
+1. In host mode and `hostBridge: "always"`, prove the logical and terminal
+   physical compiler descriptors resolve to the same exact allocator, the
+   availability manifest binds bit 17, and the Program ABI entry remains
+   closure-host-bridge derived ordinal 14.
+2. In standalone and WASI, with tracking disabled and enabled, compile a
+   constructible-closure fixture and require compiler `__is_ctor_closure` and
+   every `$ch` family member to be absent, host imports empty, tracked/untracked
+   binaries byte-identical, the complete public-name census exact, and the
+   fixture's runtime value unchanged.
+3. Add user collisions for `__is_ctor_closure`, `$ch`, and sparse `$ch$$`.
+   Standalone/WASI must preserve their exact values while removing generated
+   gap/terminal aliases. Host mode must preserve all user values and publish
+   the compiler classifier only at free suffixes, with exact allocator joins.
+4. In a fixture with no constructible closure, exact user logical/physical
+   spoof exports survive standalone/WASI and no ordinal-14 Program ABI row or
+   constructor-classifier family is created.
+5. Direct mutations must prove: an unrecorded extra clone and a descriptor
+   donated from an identically laid-out second context are both rejected before
+   final publication; a post-freeze replacement copy has no compiler
+   provenance and is retained; the same spelling targeting a different user
+   allocator survives; a near-prefix targeting the classifier is not
+   reclassified; and recorded name/kind/target/lost-function/duplicate
+   mutations still fail closed before final publication.
+6. Preserve the complete C31 closure suite, C37 vec suite, and #4035 policy
+   suite as controls. Update a marker/census only if required to make the
+   existing test truthful; do not change #4035's ceiling or characterize the
+   already-present leak as a new size regression.
+
+Every target/tracking comparison must publish exact names, descriptor targets,
+runtime values, import census, and binary parity where specified. Prefix-only
+absence and compact counts are not acceptance evidence.
+
+### Dependencies and acceptance
+
+The open-PR and worktree audit found no other owner of `closure-exports.ts` or
+the focused closure ABI test. The parallel Claude lane owns ProgramABI, #3525,
+and #5092 work and currently overlaps none of these four C38 paths. This
+intentional child overlaps only `host-bridge-exports.ts` in its C37 base. Any
+newly observed overlap is a stop-and-report condition.
+
+Acceptance requires the focused closure and vec suites, #4035 policy controls,
+TypeScript 7, Prettier/Biome and `git diff --check`, IR fallback and issue
+integrity, IR layering/readiness, and applicable oracle/coercion/dead-export
+ratchets. Run every heavy command only after a finite, non-negative one-minute
+load sample is strictly below `logical cores - 2`. Immediately before every
+signed commit run both LOC and function regrowth ratchets, then let all
+precommit and prepush hooks run without bypass. No baseline, size, LOC,
+function, or hook exception is authorized. A Terra implementation remains draft
+until a separate Sol approves the exact pushed SHA; any later push invalidates
+that approval.

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -8,7 +8,8 @@
 // (generateModule), which imports these back.
 
 import { ts } from "../ts-api.js";
-import type { FuncTypeDef, Instr, ValType, WasmFunction } from "../ir/types.js";
+import { STABLE_FUNC_BASE } from "../emit/resolve-layout.js";
+import type { FuncTypeDef, Instr, ValType, WasmExport, WasmFunction } from "../ir/types.js";
 import type { ClosureInfo, CodegenContext } from "./context/types.js";
 import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
 import { addUnionImports } from "./registry/imports.js";
@@ -36,7 +37,7 @@ import {
 } from "./program-abi-planning.js";
 import { recordClosureArgcDispatcher } from "./compiler-support-abi.js";
 import { DATA_STRUCT_HOST_BRIDGE_ORDINAL, publishDataStructHostBridge } from "./data-struct-host-bridge.js";
-import { definedFuncHandleOf } from "./func-space.js";
+import { definedFuncAt, definedFuncHandleOf } from "./func-space.js";
 import {
   STANDALONE_TIMER_CALLBACK_BINDINGS_EXPORT,
   STANDALONE_TIMER_CALLBACK_BINDINGS_PHYSICAL_BASE,
@@ -59,6 +60,15 @@ const CLOSURE_HOST_BRIDGE_BINDINGS_PHYSICAL_BASE = "$cu";
 const CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC = 0x5a200000;
 const publishedClosureHostBridgeBits = new WeakMap<CodegenContext, number>();
 const publishedClosureHostBridgeFuncs = new WeakMap<CodegenContext, Map<number, WasmFunction>>();
+interface PublishedCtorClosureHostBridgeExport {
+  readonly entry: WasmExport;
+  readonly name: string;
+  readonly func: WasmFunction;
+}
+const publishedCtorClosureHostBridgeExports = new WeakMap<
+  CodegenContext,
+  readonly PublishedCtorClosureHostBridgeExport[]
+>();
 const publishedClosureHostBridgeManifests = new WeakSet<CodegenContext>();
 const publishedStandaloneTimerCallbackManifests = new WeakSet<CodegenContext>();
 
@@ -133,6 +143,16 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
   const definition = closureHostBridgeDefinition(func.name);
   const occupied = new Set(ctx.mod.exports.map((entry) => entry.name));
   const physicalBase = definition.physicalBase;
+  const publishedCtorExports: PublishedCtorClosureHostBridgeExport[] | undefined =
+    definition.bit === 17 ? [] : undefined;
+  const publishExport = (name: string): void => {
+    const entry: WasmExport = {
+      name,
+      desc: { kind: "func", index: funcIdx },
+    };
+    ctx.mod.exports.push(entry);
+    publishedCtorExports?.push(Object.freeze({ entry, name, func }));
+  };
   let maxOccupiedSuffix = -1;
   for (const name of occupied) {
     if (!name.startsWith(physicalBase)) continue;
@@ -141,19 +161,13 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
   }
   const logicalNameOccupied = occupied.has(func.name);
   if (!logicalNameOccupied) {
-    ctx.mod.exports.push({
-      name: func.name,
-      desc: { kind: "func", index: funcIdx },
-    });
+    publishExport(func.name);
     occupied.add(func.name);
   }
   for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
     const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
     if (occupied.has(physicalName)) continue;
-    ctx.mod.exports.push({
-      name: physicalName,
-      desc: { kind: "func", index: funcIdx },
-    });
+    publishExport(physicalName);
     occupied.add(physicalName);
   }
   publishedClosureHostBridgeBits.set(ctx, (publishedClosureHostBridgeBits.get(ctx) ?? 0) | (1 << definition.bit));
@@ -163,7 +177,96 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
     publishedClosureHostBridgeFuncs.set(ctx, publishedFuncs);
   }
   publishedFuncs.set(definition.bit, func);
+  if (publishedCtorExports) {
+    if (publishedCtorClosureHostBridgeExports.has(ctx)) {
+      throw new Error("constructor-closure host bridge exports were published more than once");
+    }
+    publishedCtorClosureHostBridgeExports.set(ctx, Object.freeze(publishedCtorExports));
+  }
   return funcIdx;
+}
+
+/**
+ * Exact public names reserved by the bit-17 constructor-closure classifier.
+ *
+ * The logical spelling is one exact name. Its compact physical family is the
+ * base `$ch` followed only by literal `$` suffixes; near-prefix user exports
+ * such as `$ch0` and `$ch_extra` are deliberately outside this namespace.
+ */
+export function isCoreCtorClosureHostBridgePublicName(name: string): boolean {
+  return name === "__is_ctor_closure" || (name.startsWith("$ch") && /^\$*$/.test(name.slice("$ch".length)));
+}
+
+/** Resolve a constructor-closure descriptor under its exact handle regime. */
+function resolveCtorClosureHostBridgeExportTarget(ctx: CodegenContext, entry: WasmExport): WasmFunction | undefined {
+  if (entry.desc.kind !== "func") return undefined;
+  if (entry.desc.index < STABLE_FUNC_BASE) {
+    const currentImportCount = ctx.mod.imports.filter((candidate) => candidate.desc.kind === "func").length;
+    const currentPosition = entry.desc.index - currentImportCount;
+    return currentPosition < 0 ? undefined : ctx.mod.functions[currentPosition];
+  }
+  return definedFuncAt(ctx, entry.desc.index);
+}
+
+/**
+ * Authenticate a constructor-closure export by context-bound publication
+ * identity.
+ *
+ * The recorded descriptor object is the capability issued by this publishing
+ * context. A replacement or copy cannot prove that it belongs to this module;
+ * before the freeze boundary, finalization instead rejects any unrecorded
+ * exact-namespace descriptor that resolves to a recorded allocator.
+ */
+export function isCompilerOwnedCtorClosureHostBridgeExport(ctx: CodegenContext, entry: WasmExport): boolean {
+  const published = publishedCtorClosureHostBridgeExports.get(ctx);
+  if (!published) return false;
+  return published.some((candidate) => candidate.entry === entry);
+}
+
+/**
+ * Validate every recorded bit-17 descriptor before the availability manifest
+ * is frozen. This is the mutation boundary: replacing, duplicating, renaming,
+ * retargeting, changing kind, or removing the allocator cannot be repaired by
+ * the later export sink.
+ */
+export function finalizeCtorClosureHostBridgeExports(ctx: CodegenContext): void {
+  const published = publishedCtorClosureHostBridgeExports.get(ctx);
+  if (!published) return;
+  for (const { entry, name, func } of published) {
+    if (ctx.mod.exports.indexOf(entry) < 0) {
+      throw new Error(`constructor-closure host bridge export descriptor ${name} disappeared before finalization`);
+    }
+    if (ctx.mod.exports.indexOf(entry) !== ctx.mod.exports.lastIndexOf(entry)) {
+      throw new Error(`constructor-closure host bridge export descriptor ${name} appears more than once in the module`);
+    }
+    if (entry.name !== name) {
+      throw new Error(
+        `constructor-closure host bridge export descriptor ${name} changed its published name to ${entry.name}`,
+      );
+    }
+    if (entry.desc.kind !== "func") {
+      throw new Error(`constructor-closure host bridge export descriptor ${name} changed kind to ${entry.desc.kind}`);
+    }
+    if (!ctx.mod.functions.includes(func)) {
+      throw new Error(`constructor-closure host bridge export descriptor ${name} lost its allocator function`);
+    }
+    if (resolveCtorClosureHostBridgeExportTarget(ctx, entry) !== func) {
+      throw new Error(
+        `constructor-closure host bridge export descriptor ${name} resolves to a different allocator function`,
+      );
+    }
+  }
+  const recordedEntries = new Set(published.map((candidate) => candidate.entry));
+  const recordedFuncs = new Set(published.map((candidate) => candidate.func));
+  for (const entry of ctx.mod.exports) {
+    if (recordedEntries.has(entry) || !isCoreCtorClosureHostBridgePublicName(entry.name)) continue;
+    const target = resolveCtorClosureHostBridgeExportTarget(ctx, entry);
+    if (target !== undefined && recordedFuncs.has(target)) {
+      throw new Error(
+        `unrecorded constructor-closure host bridge export descriptor ${entry.name} resolves to a recorded allocator function`,
+      );
+    }
+  }
 }
 
 /**

--- a/src/codegen/date-host-bridge.ts
+++ b/src/codegen/date-host-bridge.ts
@@ -1,9 +1,141 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
+import { STABLE_FUNC_BASE } from "../emit/resolve-layout.js";
+import type { Instr, WasmExport, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt } from "./func-space.js";
 import { addFuncType } from "./registry/types.js";
 
-const emitted = new WeakSet<CodegenContext>();
+const DATE_HOST_BRIDGE_EXPORT_NAMES = Object.freeze([
+  "__\0js2_is_date",
+  "__\0js2_date_value",
+  "__\0js2_date_set_value",
+] as const);
+
+interface PublishedDateHostBridgeExport {
+  readonly entry: WasmExport;
+  readonly name: (typeof DATE_HOST_BRIDGE_EXPORT_NAMES)[number];
+  readonly func: WasmFunction;
+}
+
+/**
+ * Each CodegenContext issues its own immutable publication record. The record
+ * binds the exact descriptor object to its exact allocator object; neither a
+ * spelling nor a numeric target can substitute for that provenance.
+ */
+const publishedDateHostBridgeExports = new WeakMap<CodegenContext, readonly PublishedDateHostBridgeExport[]>();
+
+/** The complete public Date namespace consists of these three names only. */
+export function isCoreDateHostBridgePublicName(name: string): boolean {
+  return DATE_HOST_BRIDGE_EXPORT_NAMES.includes(name as (typeof DATE_HOST_BRIDGE_EXPORT_NAMES)[number]);
+}
+
+/**
+ * Resolve one Date export only as validation evidence.
+ *
+ * Live handles are interpreted against the current import prefix. An invalid
+ * live position must fail here rather than accidentally being reconsidered as
+ * a stable handle; stable handles are resolved solely through definedFuncAt.
+ */
+function resolveDateHostBridgeExportTarget(ctx: CodegenContext, entry: WasmExport): WasmFunction | undefined {
+  if (entry.desc.kind !== "func") return undefined;
+  if (entry.desc.index < STABLE_FUNC_BASE) {
+    const numImportFuncs = ctx.mod.imports.filter((candidate) => candidate.desc.kind === "func").length;
+    const position = entry.desc.index - numImportFuncs;
+    if (!Number.isInteger(position) || position < 0 || position >= ctx.mod.functions.length) return undefined;
+    return ctx.mod.functions[position];
+  }
+  return definedFuncAt(ctx, entry.desc.index);
+}
+
+/**
+ * The context-bound descriptor object is the sole removal authority.
+ *
+ * In particular, a same-spelled descriptor, a descriptor with a coincident
+ * numeric target, and a descriptor donated from a second context are all
+ * unowned. Resolution belongs only to the pre-freeze validation census.
+ */
+export function isCompilerOwnedDateHostBridgeExport(ctx: CodegenContext, entry: WasmExport): boolean {
+  return publishedDateHostBridgeExports.get(ctx)?.some((candidate) => candidate.entry === entry) ?? false;
+}
+
+/**
+ * Validate the full Date publication census before the index space freezes.
+ *
+ * This deliberately has no successful-validation cache: a second pre-freeze
+ * policy pass must see mutations made after the first one. The function is
+ * also directly useful to focused invariant tests; callers enforce the freeze
+ * boundary rather than this validator weakening its own checks.
+ */
+export function finalizeDateHostBridgeExports(ctx: CodegenContext): void {
+  const published = publishedDateHostBridgeExports.get(ctx);
+  if (!published) return;
+  if (published.length !== DATE_HOST_BRIDGE_EXPORT_NAMES.length) {
+    throw new Error(
+      `Date host bridge publication must contain exactly ${DATE_HOST_BRIDGE_EXPORT_NAMES.length} descriptors, got ${published.length}`,
+    );
+  }
+
+  const recordedEntries = new Set<WasmExport>();
+  const recordedFuncs = new Set<WasmFunction>();
+  const recordedNames = new Set<string>();
+  for (const { entry, name, func } of published) {
+    if (!isCoreDateHostBridgePublicName(name)) {
+      throw new Error(`Date host bridge publication recorded unknown name ${name}`);
+    }
+    if (recordedEntries.has(entry)) {
+      throw new Error(`Date host bridge export descriptor ${name} is recorded more than once`);
+    }
+    recordedEntries.add(entry);
+    if (recordedFuncs.has(func)) {
+      throw new Error(`Date host bridge allocator function for ${name} is recorded more than once`);
+    }
+    recordedFuncs.add(func);
+    if (recordedNames.has(name)) {
+      throw new Error(`Date host bridge publication records ${name} more than once`);
+    }
+    recordedNames.add(name);
+  }
+  for (const name of DATE_HOST_BRIDGE_EXPORT_NAMES) {
+    if (!recordedNames.has(name)) {
+      throw new Error(`Date host bridge publication is missing descriptor ${name}`);
+    }
+  }
+
+  for (const { entry, name, func } of published) {
+    if (ctx.mod.exports.indexOf(entry) < 0) {
+      throw new Error(`Date host bridge export descriptor ${name} disappeared before finalization`);
+    }
+    if (ctx.mod.exports.indexOf(entry) !== ctx.mod.exports.lastIndexOf(entry)) {
+      throw new Error(`Date host bridge export descriptor ${name} appears more than once in the module`);
+    }
+    if (entry.name !== name) {
+      throw new Error(`Date host bridge export descriptor ${name} changed its published name to ${entry.name}`);
+    }
+    if (entry.desc.kind !== "func") {
+      throw new Error(`Date host bridge export descriptor ${name} changed kind to ${entry.desc.kind}`);
+    }
+    if (ctx.mod.functions.indexOf(func) < 0) {
+      throw new Error(`Date host bridge export descriptor ${name} lost its allocator function`);
+    }
+    if (ctx.mod.functions.indexOf(func) !== ctx.mod.functions.lastIndexOf(func)) {
+      throw new Error(`Date host bridge allocator function for ${name} appears more than once in the module`);
+    }
+    if (resolveDateHostBridgeExportTarget(ctx, entry) !== func) {
+      throw new Error(`Date host bridge export descriptor ${name} resolves to a different allocator function`);
+    }
+  }
+
+  for (const entry of ctx.mod.exports) {
+    if (recordedEntries.has(entry) || !isCoreDateHostBridgePublicName(entry.name)) continue;
+    const target = resolveDateHostBridgeExportTarget(ctx, entry);
+    if (target !== undefined && recordedFuncs.has(target)) {
+      throw new Error(
+        `unrecorded Date host bridge export descriptor ${entry.name} resolves to a recorded allocator function`,
+      );
+    }
+  }
+}
 
 /**
  * Expose the native `$__Date` carrier to the JS host method bridge.
@@ -14,21 +146,30 @@ const emitted = new WeakSet<CodegenContext>();
  * carrier without mistaking an ordinary `{ timestamp }` object for a Date.
  */
 export function emitDateHostBridge(ctx: CodegenContext): void {
-  if (emitted.has(ctx)) return;
+  if (publishedDateHostBridgeExports.has(ctx)) return;
   const dateTypeIdx = ctx.structMap.get("__Date");
   if (dateTypeIdx === undefined) return;
-  emitted.add(ctx);
+  const published: PublishedDateHostBridgeExport[] = [];
 
   const publish = (
-    name: string,
+    name: (typeof DATE_HOST_BRIDGE_EXPORT_NAMES)[number],
     params: Parameters<typeof addFuncType>[1],
     results: Parameters<typeof addFuncType>[2],
-    body: import("../ir/types.js").Instr[],
+    body: Instr[],
   ): void => {
     const typeIdx = addFuncType(ctx, params, results, `$${name}_type`);
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({ name, typeIdx, locals: [], body, exported: true });
-    ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
+    const func: WasmFunction = {
+      name,
+      typeIdx,
+      locals: [],
+      body,
+      exported: true,
+    };
+    const entry: WasmExport = { name, desc: { kind: "func", index: funcIdx } };
+    ctx.mod.functions.push(func);
+    ctx.mod.exports.push(entry);
+    published.push(Object.freeze({ entry, name, func }));
   };
 
   publish(
@@ -58,4 +199,5 @@ export function emitDateHostBridge(ctx: CodegenContext): void {
       { op: "struct.set", typeIdx: dateTypeIdx, fieldIdx: 0 },
     ],
   );
+  publishedDateHostBridgeExports.set(ctx, Object.freeze(published));
 }

--- a/src/codegen/host-bridge-exports.ts
+++ b/src/codegen/host-bridge-exports.ts
@@ -25,6 +25,11 @@
 
 import type { WasmModule } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import {
+  finalizeCtorClosureHostBridgeExports,
+  isCompilerOwnedCtorClosureHostBridgeExport,
+  isCoreCtorClosureHostBridgePublicName,
+} from "./closure-exports.js";
 import { isCompilerOwnedVecHostBridgeExport, isCoreVecHostBridgePublicName } from "./vec-access-exports.js";
 
 /**
@@ -97,15 +102,30 @@ export function isHostBridgeExportName(name: string): boolean {
  * pure-Wasm host still needs to catch), and every user export.
  */
 export function stripHostBridgeExports(ctx: CodegenContext): number {
+  // The internal policy sink runs before index-space freeze. Validate the
+  // recorded constructor descriptors there; post-generation copies have no
+  // context-bound provenance and remain noncompiler entries.
+  if (!ctx.indexSpaceFrozen) finalizeCtorClosureHostBridgeExports(ctx);
   if (ctx.emitHostBridge) return 0;
   const mod: WasmModule = ctx.mod;
   const before = mod.exports.length;
   mod.exports = mod.exports.filter((ex) => {
+    // Authenticate the recorded, context-bound object identity before either
+    // shared public namespace. That same record remains authoritative if a
+    // late mutation renames it into the vec family, while copies and donors
+    // never authenticate. The ordering keeps the two sinks symmetric for
+    // cross-namespace descriptor mutations.
+    if (isCompilerOwnedCtorClosureHostBridgeExport(ctx, ex)) return false;
     if (isCompilerOwnedVecHostBridgeExport(ctx, ex)) return false;
     // Core vec names are a shared public namespace: only exact compiler
     // provenance authorizes removal. A user export with a matching spelling
     // must survive standalone/WASI stripping.
     if (isCoreVecHostBridgePublicName(ex.name)) return true;
+    // Constructor-closure names are a separate shared namespace: only the
+    // recorded bit-17 descriptor authorizes removal. An exact allocator join
+    // is rejected by pre-freeze finalization, not used for removal
+    // authorization; a same-spelled user export survives standalone/WASI.
+    if (isCoreCtorClosureHostBridgePublicName(ex.name)) return true;
     return !isHostBridgeExportName(ex.name);
   });
   return before - mod.exports.length;

--- a/src/codegen/host-bridge-exports.ts
+++ b/src/codegen/host-bridge-exports.ts
@@ -24,12 +24,17 @@
 // spread the policy across the codegen and risk a partially-built bridge.
 
 import type { WasmModule } from "../ir/types.js";
-import type { CodegenContext } from "./context/types.js";
 import {
   finalizeCtorClosureHostBridgeExports,
   isCompilerOwnedCtorClosureHostBridgeExport,
   isCoreCtorClosureHostBridgePublicName,
 } from "./closure-exports.js";
+import type { CodegenContext } from "./context/types.js";
+import {
+  finalizeDateHostBridgeExports,
+  isCompilerOwnedDateHostBridgeExport,
+  isCoreDateHostBridgePublicName,
+} from "./date-host-bridge.js";
 import { isCompilerOwnedVecHostBridgeExport, isCoreVecHostBridgePublicName } from "./vec-access-exports.js";
 
 /**
@@ -103,20 +108,28 @@ export function isHostBridgeExportName(name: string): boolean {
  */
 export function stripHostBridgeExports(ctx: CodegenContext): number {
   // The internal policy sink runs before index-space freeze. Validate the
-  // recorded constructor descriptors there; post-generation copies have no
-  // context-bound provenance and remain noncompiler entries.
-  if (!ctx.indexSpaceFrozen) finalizeCtorClosureHostBridgeExports(ctx);
+  // recorded Date and constructor descriptors before either policy outcome;
+  // post-generation copies have no context-bound provenance and remain
+  // noncompiler entries.
+  if (!ctx.indexSpaceFrozen) {
+    finalizeCtorClosureHostBridgeExports(ctx);
+    finalizeDateHostBridgeExports(ctx);
+  }
   if (ctx.emitHostBridge) return 0;
   const mod: WasmModule = ctx.mod;
   const before = mod.exports.length;
   mod.exports = mod.exports.filter((ex) => {
-    // Authenticate the recorded, context-bound object identity before either
-    // shared public namespace. That same record remains authoritative if a
-    // late mutation renames it into the vec family, while copies and donors
-    // never authenticate. The ordering keeps the two sinks symmetric for
-    // cross-namespace descriptor mutations.
+    // Authenticate the recorded, context-bound object identity before every
+    // shared public namespace. A recorded Date descriptor remains authoritative
+    // if a post-freeze mutation renames it into the vec or constructor family;
+    // copies and donors never authenticate.
+    if (isCompilerOwnedDateHostBridgeExport(ctx, ex)) return false;
     if (isCompilerOwnedCtorClosureHostBridgeExport(ctx, ex)) return false;
     if (isCompilerOwnedVecHostBridgeExport(ctx, ex)) return false;
+    // The three Date names are a shared public namespace. Only the exact
+    // recorded descriptor identity authorizes removal; a user descriptor with
+    // an exact spelling or a coincident numeric target survives.
+    if (isCoreDateHostBridgePublicName(ex.name)) return true;
     // Core vec names are a shared public namespace: only exact compiler
     // provenance authorizes removal. A user export with a matching spelling
     // must survive standalone/WASI stripping.

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -3,21 +3,35 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { SINGLE_HOST_ENTRIES } from "../scripts/check-ir-only.js";
 import { analyzeSource } from "../src/checker/index.js";
 import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { stripHostBridgeExports } from "../src/codegen/host-bridge-exports.js";
 import { generateModule } from "../src/codegen/index.js";
+import {
+  finalizeCtorClosureHostBridgeExports,
+  isCompilerOwnedCtorClosureHostBridgeExport,
+  isCoreCtorClosureHostBridgePublicName,
+} from "../src/codegen/closure-exports.js";
 import {
   planProgramAbiEntrySourceSupportCallable,
   PROGRAM_ABI_CALLABLE_ROLE,
   resolveProgramAbiSupportCallableHandle,
 } from "../src/codegen/program-abi-planning.js";
+import { ProgramAbiCallableRegistry } from "../src/codegen/program-abi-callable-planning.js";
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
 import { emitBinary } from "../src/emit/binary.js";
+import { STABLE_FUNC_BASE } from "../src/emit/resolve-layout.js";
 import { buildIrUnitInventory, createIrBindingId } from "../src/ir/identity.js";
-import { createEmptyModule, type FuncTypeDef, type Import, type WasmFunction } from "../src/ir/types.js";
+import {
+  createEmptyModule,
+  type FuncTypeDef,
+  type Import,
+  type WasmExport,
+  type WasmFunction,
+} from "../src/ir/types.js";
 import { compile } from "../src/index.js";
 import { buildImports, wrapExports } from "../src/runtime.js";
 import { ts } from "../src/ts-api.js";
@@ -67,6 +81,60 @@ const CLOSURE_PHYSICAL_BASES = [
   "$ce",
   "$cf",
   "$cg",
+  "$ch",
+] as const;
+
+const CONSTRUCTIBLE_CLOSURE_SOURCE = `
+  const ctor = function (value: number): number { return value + 1; };
+  export function getCtor(): any { return ctor; }
+  export function invokeCtor(): number { return ctor(41); }
+`;
+
+const CLOSURE_COLLISION_SOURCE = `
+  export function __is_ctor_closure(): number { return 901; }
+  export function $ch(): number { return 902; }
+  export function $ch$$(): number { return 903; }
+  const ctor = function (value: number): number { return value + 1; };
+  export function getCtor(): any { return ctor; }
+  export function invokeCtor(): number { return ctor(41); }
+`;
+
+const CLOSURE_CROSS_NAMESPACE_COLLISION_SOURCE = `
+  export function $v0(): number { return 911; }
+  const ctor = function (value: number): number { return value + 1; };
+  export function getCtor(): any { return ctor; }
+  export function invokeCtor(): number { return ctor(41); }
+`;
+
+const CLOSURE_FREE_SPOOF_SOURCE = `
+  export function __is_ctor_closure(): number { return 801; }
+  export function $ch(): number { return 802; }
+  export function $ch$$(): number { return 803; }
+  export function $ch0(): number { return 804; }
+  export function $ch_extra(): number { return 805; }
+  export function __is_ctor_closure_extra(): number { return 806; }
+  export function add(): number { return 42; }
+`;
+
+const CLOSURE_STANDALONE_HELPER_EXPORTS = [
+  "__\0js2_call_fn_method_argc_1",
+  "__\0js2_call_fn_method_argc_2",
+  "__\0js2_call_fn_method_argc_3",
+  "__\0js2_call_fn_method_argc_4",
+  "__\0js2_call_fn_method_argc_5",
+  "__any_box_null",
+  "__any_box_undefined",
+  "__box_bigint",
+  "__box_boolean",
+  "__box_number",
+  "__dynamic_boundary_tag",
+  "__exn_tag",
+  "__to_bigint",
+  "__typeof_bigint",
+  "__typeof_boolean",
+  "__typeof_number",
+  "__unbox_boolean",
+  "__unbox_number",
 ] as const;
 
 const ZERO_ARITY_SOURCE = `
@@ -101,15 +169,55 @@ function hardErrors(result: ReturnType<typeof generateModule>) {
   return result.errors.filter((error) => error.severity !== "warning");
 }
 
-async function instantiate(source: string): Promise<{
+function generateWithCapturedRegistry(
+  source: string,
+  fileName: string,
+): {
+  readonly registry: ProgramAbiCallableRegistry;
+  readonly result: ReturnType<typeof generateModule>;
+} {
+  let registry: ProgramAbiCallableRegistry | undefined;
+  const originalObserve = ProgramAbiCallableRegistry.prototype.observeEntrySourceSupports;
+  const observe = vi
+    .spyOn(ProgramAbiCallableRegistry.prototype, "observeEntrySourceSupports")
+    .mockImplementation(function (observations) {
+      registry = this;
+      return originalObserve.call(this, observations);
+    });
+  let result: ReturnType<typeof generateModule>;
+  try {
+    // Keep a real vec support observation in this focused harness so the
+    // generated context is available for direct provenance mutation checks.
+    // The probe is unrelated to the constructor helper under test.
+    const sourceWithRegistryProbe = `${source}
+      export function __c38_registry_probe(): number {
+        const values: any = [1];
+        values.push(2);
+        values.pop();
+        return values[0];
+      }
+    `;
+    const ast = analyzeSource(sourceWithRegistryProbe, fileName);
+    result = generateModule(ast, { experimentalIR: true, trackIrOutcomes: true });
+  } finally {
+    observe.mockRestore();
+  }
+  if (!registry) throw new Error(`missing closure Program ABI session for ${fileName}`);
+  return { registry, result: result! };
+}
+
+async function instantiate(sourceOrResult: string | Awaited<ReturnType<typeof compile>>): Promise<{
   readonly exports: Record<string, unknown>;
   readonly result: Awaited<ReturnType<typeof compile>>;
 }> {
-  const result = await compile(source, {
-    fileName: "issue-3520-closure-host-runtime.ts",
-    experimentalIR: true,
-    trackIrOutcomes: true,
-  });
+  const result =
+    typeof sourceOrResult === "string"
+      ? await compile(sourceOrResult, {
+          fileName: "issue-3520-closure-host-runtime.ts",
+          experimentalIR: true,
+          trackIrOutcomes: true,
+        })
+      : sourceOrResult;
   expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
   const imports = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown> & {
     env?: Record<string, unknown>;
@@ -123,6 +231,230 @@ async function instantiate(source: string): Promise<{
 }
 
 describe("#3520 C31 closure host bridge Program ABI ownership", () => {
+  it("classifies only exact constructor-closure logical and physical names", () => {
+    expect(isCoreCtorClosureHostBridgePublicName("__is_ctor_closure")).toBe(true);
+    expect(["$ch", "$ch$", "$ch$$", "$ch$$$$"].every(isCoreCtorClosureHostBridgePublicName)).toBe(true);
+    expect(
+      ["$ch0", "$chi", "$ch_extra", "__is_ctor_closure_extra", "__is_ctor_closure$"].some(
+        isCoreCtorClosureHostBridgePublicName,
+      ),
+    ).toBe(false);
+  });
+
+  it("publishes the bit-17 classifier under ordinal 14 and binds its exact allocator", async () => {
+    const result = trackedModule(CONSTRUCTIBLE_CLOSURE_SOURCE);
+    expect(
+      hardErrors(result),
+      hardErrors(result)
+        .map((error) => error.message)
+        .join("\n"),
+    ).toEqual([]);
+    const entrySource = entrySourceRecord(CONSTRUCTIBLE_CLOSURE_SOURCE);
+    const expectedId = createIrBindingId({
+      ownerId: entrySource.id,
+      domain: "support",
+      role: CLOSURE_HOST_BRIDGE_ROLE,
+      ordinal: 14,
+    });
+    expect(result.programAbi!.abi.get(expectedId)).toMatchObject({
+      id: expectedId,
+      displayName: "__is_ctor_closure",
+      slotPolicy: "required",
+      slotSpace: "function",
+      intent: {
+        kind: "callable",
+        origin: "support",
+        sourceId: entrySource.id,
+      },
+    });
+
+    const exportsByName = new Map(result.module.exports.map((entry) => [entry.name, entry]));
+    const logical = exportsByName.get("__is_ctor_closure");
+    const physical = exportsByName.get("$ch");
+    expect(logical?.desc).toEqual(physical?.desc);
+    if (!logical || logical.desc.kind !== "func") throw new Error("missing logical constructor classifier");
+    const importCount = result.module.imports.filter((entry) => entry.desc.kind === "func").length;
+    expect(result.module.functions[logical.desc.index - importCount]?.name).toBe("__is_ctor_closure");
+    const finalSlot = result.programAbi!.abi.resolveFinalIndex(expectedId);
+    expect(finalSlot).toEqual({ space: "function", index: logical.desc.index });
+
+    for (const [label, options] of [
+      ["default", {}],
+      ["always", { hostBridge: "always" as const }],
+    ] as const) {
+      const compiled = await compile(CONSTRUCTIBLE_CLOSURE_SOURCE, {
+        fileName: `issue-3520-closure-ctor-${label}.ts`,
+        experimentalIR: true,
+        ...options,
+      });
+      const { exports: rawExports } = await instantiate(compiled);
+      expect(rawExports.__is_ctor_closure, label).toBe(rawExports.$ch);
+      expect(rawExports.__is_ctor_closure, label).toEqual(expect.any(Function));
+      const manifest = rawExports.$cm;
+      expect(manifest).toBeInstanceOf(WebAssembly.Global);
+      expect((manifest as WebAssembly.Global).value & (1 << 17), label).not.toBe(0);
+      const ctor = (rawExports.getCtor as () => unknown)();
+      expect((rawExports.__is_ctor_closure as (value: unknown) => number)(ctor), label).toBe(1);
+      expect((rawExports.invokeCtor as () => number)(), label).toBe(42);
+    }
+  });
+
+  it("strips compiler constructor-closure exports in standalone and WASI with exact parity", async () => {
+    const expectedNames = [...CLOSURE_STANDALONE_HELPER_EXPORTS, "getCtor", "invokeCtor"];
+    for (const target of ["standalone", "wasi"] as const) {
+      const options = {
+        fileName: `issue-3520-closure-ctor-${target}.ts`,
+        experimentalIR: true,
+        target,
+      } as const;
+      const untracked = await compile(CONSTRUCTIBLE_CLOSURE_SOURCE, options);
+      const tracked = await compile(CONSTRUCTIBLE_CLOSURE_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target} untracked`).toBe(true);
+      expect(tracked.success, `${target} tracked`).toBe(true);
+      expect(untracked.imports, `${target} untracked imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+
+      const targetExpectedNames = [...expectedNames, ...(target === "wasi" ? ["_start", "memory"] : [])].sort();
+      for (const [label, result] of [
+        ["untracked", untracked],
+        ["tracked", tracked],
+      ] as const) {
+        const { exports: rawExports } = await instantiate(result);
+        expect(Object.keys(rawExports).sort(), `${target} ${label} public names`).toEqual(targetExpectedNames);
+        expect(
+          Object.keys(rawExports).filter((name) => name.startsWith("$ch")),
+          `${target} ${label} constructor physical names`,
+        ).toEqual([]);
+        expect(rawExports.__is_ctor_closure, `${target} ${label} logical classifier`).toBeUndefined();
+        expect((rawExports.invokeCtor as () => number)(), `${target} ${label} runtime value`).toBe(42);
+      }
+    }
+  });
+
+  it("preserves exact constructor-closure collisions while publishing only free host aliases", async () => {
+    const userValues = [
+      ["__is_ctor_closure", 901],
+      ["$ch", 902],
+      ["$ch$$", 903],
+    ] as const;
+    const expectedNames = [
+      ...CLOSURE_STANDALONE_HELPER_EXPORTS,
+      ...userValues.map(([name]) => name),
+      "getCtor",
+      "invokeCtor",
+    ];
+    for (const target of ["standalone", "wasi"] as const) {
+      const options = {
+        fileName: `issue-3520-closure-collisions-${target}.ts`,
+        experimentalIR: true,
+        target,
+      } as const;
+      const untracked = await compile(CLOSURE_COLLISION_SOURCE, options);
+      const tracked = await compile(CLOSURE_COLLISION_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target} untracked`).toBe(true);
+      expect(tracked.success, `${target} tracked`).toBe(true);
+      expect(untracked.imports, `${target} untracked imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+      const targetExpectedNames = [...expectedNames, ...(target === "wasi" ? ["_start", "memory"] : [])].sort();
+      for (const [label, result] of [
+        ["untracked", untracked],
+        ["tracked", tracked],
+      ] as const) {
+        const { exports: rawExports } = await instantiate(result);
+        expect(Object.keys(rawExports).sort(), `${target} ${label} public names`).toEqual(targetExpectedNames);
+        expect(
+          Object.keys(rawExports).filter((name) => name.startsWith("$ch")),
+          `${target} ${label} physical names`,
+        ).toEqual(["$ch", "$ch$$"]);
+        for (const [name, value] of userValues) {
+          expect(rawExports[name], `${target} ${label} ${name}`).toEqual(expect.any(Function));
+          expect((rawExports[name] as () => number)(), `${target} ${label} ${name}`).toBe(value);
+        }
+        expect(rawExports["$ch$"], `${target} ${label} generated gap`).toBeUndefined();
+        expect(rawExports["$ch$$$"], `${target} ${label} generated terminal`).toBeUndefined();
+        expect((rawExports.invokeCtor as () => number)(), `${target} ${label} runtime value`).toBe(42);
+      }
+    }
+
+    for (const [label, options] of [
+      ["default", {}],
+      ["always", { hostBridge: "always" as const }],
+    ] as const) {
+      const compiled = await compile(CLOSURE_COLLISION_SOURCE, {
+        fileName: `issue-3520-closure-collisions-${label}.ts`,
+        experimentalIR: true,
+        ...options,
+      });
+      const { exports: rawExports } = await instantiate(compiled);
+      expect(
+        Object.keys(rawExports)
+          .filter((name) => name.startsWith("$ch"))
+          .sort(),
+        label,
+      ).toEqual(["$ch", "$ch$", "$ch$$", "$ch$$$"]);
+      expect(rawExports["$ch$"], label).toBe(rawExports["$ch$$$"]);
+      expect(rawExports["$ch$"], label).not.toBe(rawExports.$ch);
+      expect(rawExports["$ch$"], label).not.toBe(rawExports["$ch$$"]);
+      for (const [name, value] of userValues) {
+        expect((rawExports[name] as () => number)(), `${label} ${name}`).toBe(value);
+      }
+    }
+  });
+
+  it("keeps exact constructor-closure spoof names public without creating a classifier", async () => {
+    const spoofValues = [
+      ["__is_ctor_closure", 801],
+      ["$ch", 802],
+      ["$ch$$", 803],
+      ["$ch0", 804],
+      ["$ch_extra", 805],
+      ["__is_ctor_closure_extra", 806],
+    ] as const;
+    const generated = trackedModule(CLOSURE_FREE_SPOOF_SOURCE);
+    expect(
+      generated
+        .programAbi!.abi.entries()
+        .filter(
+          (entry) =>
+            entry.displayName === "__is_ctor_closure" &&
+            entry.slotPolicy === "required" &&
+            entry.intent.kind === "callable" &&
+            entry.intent.origin === "support",
+        ),
+    ).toEqual([]);
+    for (const target of ["standalone", "wasi"] as const) {
+      const options = {
+        fileName: `issue-3520-closure-spoof-${target}.ts`,
+        experimentalIR: true,
+        target,
+      } as const;
+      const untracked = await compile(CLOSURE_FREE_SPOOF_SOURCE, options);
+      const tracked = await compile(CLOSURE_FREE_SPOOF_SOURCE, { ...options, trackIrOutcomes: true });
+      expect(untracked.success, `${target} untracked`).toBe(true);
+      expect(tracked.success, `${target} tracked`).toBe(true);
+      expect(untracked.imports, `${target} imports`).toEqual([]);
+      expect(tracked.imports, `${target} tracked imports`).toEqual([]);
+      expect(tracked.binary, `${target} tracked/untracked bytes`).toEqual(untracked.binary);
+      const expectedNames = [
+        ...spoofValues.map(([name]) => name),
+        "add",
+        ...(target === "wasi" ? ["memory"] : []),
+      ].sort();
+      const { exports: rawExports } = await instantiate(tracked);
+      expect(Object.keys(rawExports).sort(), `${target} public names`).toEqual(expectedNames);
+      for (const [name, value] of spoofValues) {
+        expect((rawExports[name] as () => number)(), `${target} ${name}`).toBe(value);
+      }
+      expect(Object.keys(rawExports).filter((name) => name.startsWith("$ch"))).toEqual([
+        "$ch",
+        "$ch$$",
+        "$ch0",
+        "$ch_extra",
+      ]);
+    }
+  });
   it("plans fixed entry-source IDs and publishes each exact final helper slot", () => {
     const result = trackedModule();
     expect(
@@ -536,16 +868,16 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     assertBoxedObject(mutableManifest);
 
     const reservedBitManifest = clone();
-    reservedBitManifest["$cm$"] = new WebAssembly.Global({ value: "i32", mutable: false }, manifestValue | (1 << 17));
+    reservedBitManifest["$cm$"] = new WebAssembly.Global({ value: "i32", mutable: false }, manifestValue | (1 << 18));
     assertBoxedObject(reservedBitManifest);
 
     const f64Manifest = clone();
     f64Manifest["$cm$"] = new WebAssembly.Global({ value: "f64", mutable: false }, manifestValue);
     assertBoxedObject(f64Manifest);
 
-    const externrefBindings = new WebAssembly.Table({ element: "externref", initial: 17, maximum: 17 });
+    const externrefBindings = new WebAssembly.Table({ element: "externref", initial: 18, maximum: 18 });
     const externrefForge = clone();
-    const availabilityBits = manifestValue & 0x0001ffff;
+    const availabilityBits = manifestValue & 0x0003ffff;
     for (let bit = 0; bit < CLOSURE_PHYSICAL_BASES.length; bit++) {
       externrefBindings.set(bit, null);
     }
@@ -564,6 +896,204 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     }
     externrefForge["$cu$"] = externrefBindings;
     assertBoxedObject(externrefForge);
+  });
+
+  it("does not grant post-freeze replacement copies constructor provenance", () => {
+    const { registry, result } = generateWithCapturedRegistry(
+      CONSTRUCTIBLE_CLOSURE_SOURCE,
+      "closure-ctor-cloned-descriptor.ts",
+    );
+    const entryIndex = result.module.exports.findIndex(
+      (candidate) => candidate.name === "__is_ctor_closure" && candidate.desc.kind === "func",
+    );
+    if (entryIndex < 0) throw new Error("missing compiler-owned constructor classifier descriptor");
+    const entry = result.module.exports[entryIndex]!;
+    if (entry.desc.kind !== "func") throw new Error("constructor classifier descriptor changed export kind");
+    expect(registry.ctx.indexSpaceFrozen).toBe(true);
+    const clone: WasmExport = { name: entry.name, desc: { kind: "func", index: entry.desc.index } };
+    result.module.exports[entryIndex] = clone;
+    const originalEmitHostBridge = registry.ctx.emitHostBridge;
+    try {
+      registry.ctx.emitHostBridge = false;
+      expect(isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, clone)).toBe(false);
+      expect(stripHostBridgeExports(registry.ctx)).toBeGreaterThan(0);
+      expect(result.module.exports).toContain(clone);
+    } finally {
+      registry.ctx.emitHostBridge = originalEmitHostBridge;
+    }
+  });
+
+  it("retains same-spelled user and near-prefix descriptors without constructor provenance", () => {
+    const collision = generateWithCapturedRegistry(CLOSURE_COLLISION_SOURCE, "closure-ctor-user-collision.ts");
+    const userLogical = collision.result.module.exports.find(
+      (candidate) => candidate.name === "__is_ctor_closure" && candidate.desc.kind === "func",
+    );
+    if (!userLogical) throw new Error("missing user constructor-classifier collision");
+    expect(isCompilerOwnedCtorClosureHostBridgeExport(collision.registry.ctx, userLogical)).toBe(false);
+
+    const compilerPhysical = collision.result.module.exports.find(
+      (candidate) => candidate.name === "$ch$" && candidate.desc.kind === "func",
+    );
+    if (!compilerPhysical || compilerPhysical.desc.kind !== "func") {
+      throw new Error("missing compiler constructor-classifier physical descriptor");
+    }
+    const nearPrefix: WasmExport = { name: "$ch0", desc: { kind: "func", index: compilerPhysical.desc.index } };
+    collision.result.module.exports.push(nearPrefix);
+    expect(isCompilerOwnedCtorClosureHostBridgeExport(collision.registry.ctx, nearPrefix)).toBe(false);
+
+    const originalEmitHostBridge = collision.registry.ctx.emitHostBridge;
+    try {
+      collision.registry.ctx.emitHostBridge = false;
+      stripHostBridgeExports(collision.registry.ctx);
+      expect(collision.result.module.exports).toContain(userLogical);
+      expect(collision.result.module.exports).toContain(nearPrefix);
+    } finally {
+      collision.registry.ctx.emitHostBridge = originalEmitHostBridge;
+    }
+  });
+
+  it("strips recorded constructor provenance before retaining a cross-namespace user collision", () => {
+    const { registry, result } = generateWithCapturedRegistry(
+      CLOSURE_CROSS_NAMESPACE_COLLISION_SOURCE,
+      "closure-ctor-cross-namespace-collision.ts",
+    );
+    const recorded = result.module.exports.find(
+      (candidate) =>
+        candidate.name === "__is_ctor_closure" && isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, candidate),
+    );
+    if (!recorded) throw new Error("missing recorded constructor classifier descriptor");
+    const user = result.module.exports.find((candidate) => candidate.name === "$v0" && candidate !== recorded);
+    if (!user) throw new Error("missing user vec-namespace collision descriptor");
+    expect(isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, user)).toBe(false);
+
+    recorded.name = "$v0";
+    expect(isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, recorded)).toBe(true);
+    const originalEmitHostBridge = registry.ctx.emitHostBridge;
+    try {
+      registry.ctx.emitHostBridge = false;
+      expect(stripHostBridgeExports(registry.ctx)).toBeGreaterThan(0);
+      expect(result.module.exports).toContain(user);
+      expect(result.module.exports).not.toContain(recorded);
+    } finally {
+      registry.ctx.emitHostBridge = originalEmitHostBridge;
+    }
+  });
+
+  it("fails closed for recorded constructor descriptor mutations before manifest publication", () => {
+    const cases: readonly {
+      readonly name: string;
+      readonly mutate: (
+        registry: ProgramAbiCallableRegistry,
+        result: ReturnType<typeof generateModule>,
+        entry: WasmExport,
+      ) => void;
+      readonly expected: RegExp;
+    }[] = [
+      {
+        name: "replaced",
+        mutate: (_registry, result, entry) => {
+          const index = result.module.exports.indexOf(entry);
+          result.module.exports[index] = { name: entry.name, desc: { ...entry.desc } };
+        },
+        expected: /disappeared before finalization/,
+      },
+      {
+        name: "duplicated",
+        mutate: (_registry, result, entry) => {
+          result.module.exports.push(entry);
+        },
+        expected: /appears more than once in the module/,
+      },
+      {
+        name: "cloned-extra",
+        mutate: (registry, result, entry) => {
+          const clone: WasmExport = { name: entry.name, desc: { ...entry.desc } };
+          result.module.exports.push(clone);
+          expect(isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, clone)).toBe(false);
+        },
+        expected:
+          /unrecorded constructor-closure host bridge export descriptor .* resolves to a recorded allocator function/,
+      },
+      {
+        name: "foreign-context-donor",
+        mutate: (registry, result, entry) => {
+          const donor = generateWithCapturedRegistry(
+            CONSTRUCTIBLE_CLOSURE_SOURCE,
+            "closure-ctor-identically-laid-out-donor.ts",
+          );
+          const donorEntry = donor.result.module.exports.find(
+            (candidate) => candidate.name === "__is_ctor_closure" && candidate.desc.kind === "func",
+          );
+          if (!donorEntry || donorEntry.desc.kind !== "func" || entry.desc.kind !== "func") {
+            throw new Error("missing function descriptor for constructor classifier donor mutation");
+          }
+          expect(donorEntry).not.toBe(entry);
+          expect(donorEntry.desc.index).toBe(entry.desc.index);
+          expect(isCompilerOwnedCtorClosureHostBridgeExport(donor.registry.ctx, donorEntry)).toBe(true);
+          expect(isCompilerOwnedCtorClosureHostBridgeExport(registry.ctx, donorEntry)).toBe(false);
+          result.module.exports.push(donorEntry);
+        },
+        expected:
+          /unrecorded constructor-closure host bridge export descriptor .* resolves to a recorded allocator function/,
+      },
+      {
+        name: "name-changed",
+        mutate: (_registry, _result, entry) => {
+          entry.name = "$ch0";
+        },
+        expected: /changed its published name to \$ch0/,
+      },
+      {
+        name: "retargeted",
+        mutate: (_registry, result, entry) => {
+          const other = result.module.exports.find(
+            (candidate) => candidate.name === "__is_closure" && candidate.desc.kind === "func",
+          );
+          if (!other || other.desc.kind !== "func") throw new Error("missing alternate closure helper export");
+          entry.desc.index = other.desc.index;
+        },
+        expected: /resolves to a different allocator function/,
+      },
+      {
+        name: "one-past-defined-functions",
+        mutate: (_registry, result, entry) => {
+          const liveImportCount = result.module.imports.filter((candidate) => candidate.desc.kind === "func").length;
+          entry.desc.index = liveImportCount + result.module.functions.length;
+          expect(entry.desc.index).toBeLessThan(STABLE_FUNC_BASE);
+        },
+        expected: /resolves to a different allocator function/,
+      },
+      {
+        name: "kind-changed",
+        mutate: (_registry, _result, entry) => {
+          entry.desc = { kind: "global", index: entry.desc.index };
+        },
+        expected: /changed kind to global/,
+      },
+      {
+        name: "allocator-removed",
+        mutate: (_registry, result, entry) => {
+          if (entry.desc.kind !== "func") throw new Error("constructor classifier descriptor changed export kind");
+          const func = result.module.functions.find((candidate) => candidate.name === "__is_ctor_closure");
+          if (!func) throw new Error("missing constructor classifier allocator");
+          result.module.functions.splice(result.module.functions.indexOf(func), 1);
+        },
+        expected: /lost its allocator function/,
+      },
+    ];
+
+    for (const mutation of cases) {
+      const { registry, result } = generateWithCapturedRegistry(
+        CONSTRUCTIBLE_CLOSURE_SOURCE,
+        `closure-ctor-${mutation.name}.ts`,
+      );
+      const entry = result.module.exports.find(
+        (candidate) => candidate.name === "__is_ctor_closure" && candidate.desc.kind === "func",
+      );
+      if (!entry) throw new Error(`missing compiler-owned constructor classifier for ${mutation.name}`);
+      mutation.mutate(registry, result, entry);
+      expect(() => finalizeCtorClosureHostBridgeExports(registry.ctx), mutation.name).toThrow(mutation.expected);
+    }
   });
 
   it("owns closure_has_rest at ordinal 13 only when that helper is emitted", async () => {

--- a/tests/issue-3520-date-host-bridge-export-provenance.test.ts
+++ b/tests/issue-3520-date-host-bridge-export-provenance.test.ts
@@ -1,0 +1,988 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// C39 — Date carrier host-bridge export provenance. Date bridge names are a
+// shared public namespace, not ownership authority: only the exact descriptor
+// object recorded by the publishing CodegenContext may be stripped.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeMultiSource, analyzeSource } from "../src/checker/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import {
+  emitDateHostBridge,
+  finalizeDateHostBridgeExports,
+  isCompilerOwnedDateHostBridgeExport,
+  isCoreDateHostBridgePublicName,
+} from "../src/codegen/date-host-bridge.js";
+import { definedFuncAt } from "../src/codegen/func-space.js";
+import { stripHostBridgeExports } from "../src/codegen/host-bridge-exports.js";
+import { type GeneratedCodegenModule, generateModule, generateMultiModule } from "../src/codegen/index.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { STABLE_FUNC_BASE } from "../src/emit/resolve-layout.js";
+import { type CompileOptions, compile, compileMulti } from "../src/index.js";
+import { type WasmExport, type WasmFunction, createEmptyModule } from "../src/ir/types.js";
+import { buildImports, buildWasiPolyfill } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+
+const DATE_BRIDGE_NAMES = Object.freeze(["__\0js2_is_date", "__\0js2_date_value", "__\0js2_date_set_value"] as const);
+
+const HOST_DATE_HOST_BRIDGE_EXPORTS = Object.freeze([
+  "__is_data_struct",
+  "__\0js2_data_struct_host_bridge",
+  "__\0js2_data_struct_host_bridge_bindings",
+  "__\0js2_data_struct_host_bridge_marker",
+  "__\0js2_data_struct_host_bridge_token",
+  ...DATE_BRIDGE_NAMES,
+  "__sget_timestamp",
+  "__struct_field_names",
+  "$d0",
+  "$d1",
+  "$dm",
+  "$dt",
+  "$du",
+  "$dv",
+] as const);
+
+const TARGET_DATE_HOST_BRIDGE_EXPORTS = Object.freeze([
+  "__is_data_struct",
+  "__\0js2_data_struct_host_bridge",
+  "__\0js2_data_struct_host_bridge_bindings",
+  "__\0js2_data_struct_host_bridge_marker",
+  ...DATE_BRIDGE_NAMES,
+  "__sget_byteOffset",
+  "__sget_data",
+  "__sget_length",
+  "__sget_timestamp",
+  "__sset_length",
+  "$d0",
+  "$dm",
+  "$dt",
+  "$du",
+] as const);
+
+const MULTI_TARGET_DATE_HOST_BRIDGE_EXPORTS = Object.freeze([
+  "__is_data_struct",
+  "__\0js2_data_struct_host_bridge",
+  "__\0js2_data_struct_host_bridge_bindings",
+  "__\0js2_data_struct_host_bridge_marker",
+  ...DATE_BRIDGE_NAMES,
+  "__sget_timestamp",
+  "$d0",
+  "$dm",
+  "$dt",
+  "$du",
+] as const);
+
+const DATE_FREE_TARGET_HOST_BRIDGE_EXPORTS = Object.freeze([
+  "__is_data_struct",
+  "__\0js2_data_struct_host_bridge",
+  "__\0js2_data_struct_host_bridge_bindings",
+  "__\0js2_data_struct_host_bridge_marker",
+  "__sget_byteOffset",
+  "__sget_data",
+  "__sget_length",
+  "__sset_length",
+  "$d0",
+  "$dm",
+  "$dt",
+  "$du",
+] as const);
+
+const MULTI_HOST_IMPORT_CENSUS = Object.freeze([
+  {
+    module: "string_constants",
+    name: "./provider.ts",
+    desc: { kind: "global", type: { kind: "externref" }, mutable: false },
+  },
+  {
+    module: "string_constants",
+    name: "dateValue",
+    desc: { kind: "global", type: { kind: "externref" }, mutable: false },
+  },
+  {
+    module: "string_constants",
+    name: "",
+    desc: { kind: "global", type: { kind: "externref" }, mutable: false },
+  },
+  {
+    module: "string_constants",
+    name: "timestamp",
+    desc: { kind: "global", type: { kind: "externref" }, mutable: false },
+  },
+  {
+    module: "string_constants",
+    name: "\0js2_data_struct_host_bridge_token",
+    desc: { kind: "global", type: { kind: "externref" }, mutable: false },
+  },
+] as const);
+
+const DATE_SOURCE = `
+  export function dateValue(): number {
+    return new Date(5).getTime();
+  }
+`;
+
+const DATE_FREE_SOURCE = `
+  export function dateValue(): number {
+    return 5;
+  }
+`;
+
+const DATE_PROVIDER_SOURCE = `
+  export const providedDateValue: number = new Date(5).getTime();
+`;
+
+const DATE_ENTRY_SOURCE = `
+  import { providedDateValue } from "./provider.ts";
+  export function dateValue(): number {
+    return providedDateValue;
+  }
+`;
+
+const DATE_MULTI_SOURCE_ORDERS = [
+  {
+    label: "provider-before-entry",
+    files: {
+      "./provider.ts": DATE_PROVIDER_SOURCE,
+      "./entry.ts": DATE_ENTRY_SOURCE,
+    },
+  },
+  {
+    label: "entry-before-provider",
+    files: {
+      "./entry.ts": DATE_ENTRY_SOURCE,
+      "./provider.ts": DATE_PROVIDER_SOURCE,
+    },
+  },
+] as const;
+
+type BridgePolicy = "auto" | "off" | "always";
+type OutputTarget = "host" | "standalone" | "wasi";
+type CompileResult = Awaited<ReturnType<typeof compile>>;
+type GeneratedResult = ReturnType<typeof generateModule>;
+type ErrorCarrier = {
+  readonly errors: readonly {
+    readonly severity: string;
+    readonly message: string;
+  }[];
+};
+type Context = ReturnType<typeof makeDateContext>;
+
+function generatedOptions({
+  target,
+  hostBridge,
+  trackIrOutcomes,
+}: {
+  readonly target: OutputTarget;
+  readonly hostBridge: BridgePolicy;
+  readonly trackIrOutcomes?: boolean;
+}) {
+  return {
+    experimentalIR: true,
+    hostBridge,
+    trackIrOutcomes,
+    standalone: target === "standalone",
+    wasi: target === "wasi",
+  };
+}
+
+function compileOptions(
+  fileName: string,
+  target: OutputTarget,
+  hostBridge: BridgePolicy,
+  trackIrOutcomes = false,
+): CompileOptions {
+  const common = {
+    fileName,
+    experimentalIR: true,
+    hostBridge,
+    trackIrOutcomes,
+  } as const;
+  if (target === "host") return common;
+  return { ...common, target };
+}
+
+function generateSingle(
+  source: string,
+  fileName: string,
+  target: OutputTarget,
+  hostBridge: BridgePolicy,
+  trackIrOutcomes = false,
+): GeneratedResult {
+  return generateModule(analyzeSource(source, fileName), generatedOptions({ target, hostBridge, trackIrOutcomes }));
+}
+
+function generateGraph(
+  files: Record<string, string>,
+  entryFile: string,
+  target: OutputTarget,
+  hostBridge: BridgePolicy,
+  trackIrOutcomes = false,
+): GeneratedCodegenModule {
+  return generateMultiModule(
+    analyzeMultiSource(files, entryFile),
+    generatedOptions({ target, hostBridge, trackIrOutcomes }),
+  );
+}
+
+function hardErrors(result: ErrorCarrier): string[] {
+  return result.errors.filter((error) => error.severity !== "warning").map((error) => error.message);
+}
+
+function isDateBridgeName(name: string): name is (typeof DATE_BRIDGE_NAMES)[number] {
+  return DATE_BRIDGE_NAMES.includes(name as (typeof DATE_BRIDGE_NAMES)[number]);
+}
+
+function dateEntries(result: GeneratedResult): WasmExport[] {
+  return result.module.exports.filter((entry) => isDateBridgeName(entry.name));
+}
+
+function importFunctionCount(result: Pick<GeneratedResult, "module">): number {
+  return result.module.imports.filter((entry) => entry.desc.kind === "func").length;
+}
+
+function functionForExport(result: Pick<GeneratedResult, "module">, entry: WasmExport): WasmFunction {
+  if (entry.desc.kind !== "func") throw new Error(`export ${entry.name} is not a function`);
+  const position =
+    entry.desc.index < STABLE_FUNC_BASE
+      ? entry.desc.index - importFunctionCount(result)
+      : result.module.funcOrdinalToPosition[entry.desc.index - STABLE_FUNC_BASE];
+  if (!Number.isInteger(position) || position < 0) {
+    throw new Error(`export ${entry.name} has no defined function target`);
+  }
+  const func = result.module.functions[position];
+  if (!func) throw new Error(`export ${entry.name} has no defined function target`);
+  return func;
+}
+
+function expectedPublicNames(
+  target: OutputTarget,
+  hostBridge: BridgePolicy,
+  hostBridgeExports: readonly string[],
+): string[] {
+  const emitsHostBridge = target === "host" ? hostBridge !== "off" : hostBridge === "always";
+  return [...(target === "wasi" ? ["memory"] : []), "dateValue", ...(emitsHostBridge ? hostBridgeExports : [])].sort();
+}
+
+function dateHostBridgeExportsFor(target: OutputTarget): readonly string[] {
+  return target === "host" ? HOST_DATE_HOST_BRIDGE_EXPORTS : TARGET_DATE_HOST_BRIDGE_EXPORTS;
+}
+
+function multiDateHostBridgeExportsFor(target: OutputTarget): readonly string[] {
+  return target === "host" ? HOST_DATE_HOST_BRIDGE_EXPORTS : MULTI_TARGET_DATE_HOST_BRIDGE_EXPORTS;
+}
+
+function importDescriptorCensus(result: Pick<GeneratedResult, "module">) {
+  return result.module.imports.map((entry) => ({ module: entry.module, name: entry.name, desc: entry.desc }));
+}
+
+function assertExactMultiImportCensus(result: GeneratedResult, target: OutputTarget, label: string): void {
+  expect(importDescriptorCensus(result), `${label} generated imports`).toEqual(
+    target === "host" ? MULTI_HOST_IMPORT_CENSUS : [],
+  );
+}
+
+function exportDescriptorCensus(result: Pick<GeneratedResult, "module">) {
+  return result.module.exports
+    .map((entry) => {
+      if (entry.desc.kind !== "func") return { name: entry.name, desc: entry.desc };
+      const func = functionForExport(result, entry);
+      return {
+        name: entry.name,
+        desc: entry.desc,
+        target: {
+          name: func.name,
+          typeIdx: func.typeIdx,
+          locals: func.locals,
+          body: func.body,
+        },
+      };
+    })
+    .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+}
+
+function assertExactPublicSurface(
+  result: GeneratedResult,
+  label: string,
+  target: OutputTarget,
+  hostBridge: BridgePolicy,
+  hostBridgeExports: readonly string[],
+  retainedNames: readonly string[] = [],
+): void {
+  expect(hardErrors(result), `${label} diagnostics`).toEqual([]);
+  const expectedNames = [...expectedPublicNames(target, hostBridge, hostBridgeExports), ...retainedNames].sort();
+  const census = exportDescriptorCensus(result);
+  expect(
+    census.map((entry) => entry.name),
+    `${label} complete export names`,
+  ).toEqual(expectedNames);
+  expect(new Set(census.map((entry) => entry.name)).size, `${label} duplicate export names`).toBe(census.length);
+  const dateValue = census.find((entry) => entry.name === "dateValue");
+  expect(dateValue, `${label} user export descriptor`).toMatchObject({
+    name: "dateValue",
+    target: { name: "dateValue" },
+  });
+}
+
+function assertExactDateCensus(result: GeneratedResult, label: string, allowInitializationPreamble = false): void {
+  expect(hardErrors(result), `${label} diagnostics`).toEqual([]);
+  const entries = dateEntries(result);
+  expect(entries.map((entry) => entry.name).sort(), `${label} Date names`).toEqual([...DATE_BRIDGE_NAMES].sort());
+  const handles = entries.map((entry) => {
+    if (entry.desc.kind !== "func") throw new Error(`${label} Date export ${entry.name} is not a function`);
+    return entry.desc.index;
+  });
+  expect(new Set(handles).size, `${label} distinct Date handles`).toBe(DATE_BRIDGE_NAMES.length);
+  const funcs = entries.map((entry) => functionForExport(result, entry));
+  expect(new Set(funcs).size, `${label} distinct Date allocator objects`).toBe(DATE_BRIDGE_NAMES.length);
+
+  const dateTypeIdx = result.module.types.findIndex((type) => type.kind === "struct" && type.name === "__Date");
+  expect(dateTypeIdx, `${label} Date carrier type`).toBeGreaterThanOrEqual(0);
+  const expected = new Map<
+    (typeof DATE_BRIDGE_NAMES)[number],
+    {
+      readonly params: readonly unknown[];
+      readonly results: readonly unknown[];
+      readonly body: readonly unknown[];
+    }
+  >([
+    [
+      "__\0js2_is_date",
+      {
+        params: [{ kind: "externref" }],
+        results: [{ kind: "i32" }],
+        body: [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "ref.test", typeIdx: dateTypeIdx }],
+      },
+    ],
+    [
+      "__\0js2_date_value",
+      {
+        params: [{ kind: "externref" }],
+        results: [{ kind: "i64" }],
+        body: [
+          { op: "local.get", index: 0 },
+          { op: "any.convert_extern" },
+          { op: "ref.cast", typeIdx: dateTypeIdx },
+          { op: "struct.get", typeIdx: dateTypeIdx, fieldIdx: 0 },
+        ],
+      },
+    ],
+    [
+      "__\0js2_date_set_value",
+      {
+        params: [{ kind: "ref", typeIdx: dateTypeIdx }, { kind: "i64" }],
+        results: [],
+        body: [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: 1 },
+          { op: "struct.set", typeIdx: dateTypeIdx, fieldIdx: 0 },
+        ],
+      },
+    ],
+  ]);
+
+  for (const name of DATE_BRIDGE_NAMES) {
+    const entry = entries.find((candidate) => candidate.name === name);
+    if (!entry) throw new Error(`${label} missing Date export ${name}`);
+    const func = functionForExport(result, entry);
+    const type = result.module.types[func.typeIdx];
+    expect(func.name, `${label} ${name} allocator name`).toBe(name);
+    expect(func.exported, `${label} ${name} allocator exported`).toBe(true);
+    expect(func.locals, `${label} ${name} locals`).toEqual([]);
+    expect(type?.kind, `${label} ${name} function type`).toBe("func");
+    if (type?.kind !== "func") continue;
+    const expectation = expected.get(name);
+    if (!expectation) throw new Error(`${label} missing Date expectation ${name}`);
+    expect(type.params, `${label} ${name} parameters`).toEqual(expectation.params);
+    expect(type.results, `${label} ${name} results`).toEqual(expectation.results);
+    if (!allowInitializationPreamble) {
+      expect(func.body, `${label} ${name} body`).toEqual(expectation.body);
+      continue;
+    }
+    const preambleLength = func.body.length - expectation.body.length;
+    expect(preambleLength, `${label} ${name} initialization preamble length`).toBeGreaterThanOrEqual(0);
+    const preamble = func.body.slice(0, preambleLength);
+    expect(func.body.slice(preambleLength), `${label} ${name} Date helper body suffix`).toEqual(expectation.body);
+    for (const instr of preamble) {
+      expect(instr, `${label} ${name} initialization preamble`).toMatchObject({ op: "call" });
+    }
+  }
+}
+
+function assertGeneratedParity(untracked: GeneratedResult, tracked: GeneratedResult, label: string): void {
+  expect(tracked.module.imports, `${label} generated import census`).toEqual(untracked.module.imports);
+  expect(exportDescriptorCensus(tracked), `${label} generated descriptor census`).toEqual(
+    exportDescriptorCensus(untracked),
+  );
+  expect(emitBinary(tracked.module), `${label} generated binary parity`).toEqual(emitBinary(untracked.module));
+}
+
+function assertCompiledParity(untracked: CompileResult, tracked: CompileResult, label: string): void {
+  expect(untracked.success, `${label} untracked diagnostics: ${hardErrors(untracked).join("\n")}`).toBe(true);
+  expect(tracked.success, `${label} tracked diagnostics: ${hardErrors(tracked).join("\n")}`).toBe(true);
+  expect(tracked.imports, `${label} compiled import census`).toEqual(untracked.imports);
+  expect(tracked.binary, `${label} compiled binary parity`).toEqual(untracked.binary);
+}
+
+async function instantiate(result: CompileResult, target: OutputTarget): Promise<Record<string, unknown>> {
+  expect(result.success, hardErrors(result).join("\n")).toBe(true);
+  if (target === "wasi") {
+    const wasi = buildWasiPolyfill();
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), {
+      wasi_snapshot_preview1: wasi,
+    });
+    const memory = instance.exports.memory;
+    if (memory instanceof WebAssembly.Memory) wasi.setMemory(memory);
+    return instance.exports as Record<string, unknown>;
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  return instance.exports as Record<string, unknown>;
+}
+
+async function assertDateRuntime(result: CompileResult, target: OutputTarget, label: string): Promise<void> {
+  const exports = await instantiate(result, target);
+  expect(exports.dateValue, `${label} dateValue export`).toEqual(expect.any(Function));
+  expect((exports.dateValue as () => number)(), `${label} runtime`).toBe(5);
+}
+
+function makeDateContext() {
+  const module = createEmptyModule();
+  const ctx = createCodegenContext(module, {} as ts.TypeChecker, {
+    target: "standalone",
+    hostBridge: "off",
+  });
+  const dateTypeIdx = module.types.length;
+  module.types.push({
+    kind: "struct",
+    name: "__Date",
+    fields: [{ name: "timestamp", type: { kind: "i64" }, mutable: true }],
+  });
+  ctx.structMap.set("__Date", dateTypeIdx);
+  ctx.typeIdxToStructName.set(dateTypeIdx, "__Date");
+  ctx.structFields.set("__Date", [{ name: "timestamp", type: { kind: "i64" }, mutable: true }]);
+  emitDateHostBridge(ctx);
+  return ctx;
+}
+
+function dateEntry(ctx: Context, name = DATE_BRIDGE_NAMES[0]): WasmExport {
+  const entry = ctx.mod.exports.find((candidate) => candidate.name === name);
+  if (!entry) throw new Error(`missing Date export ${name}`);
+  return entry;
+}
+
+function contextFunctionForExport(ctx: Context, entry: WasmExport): WasmFunction {
+  if (entry.desc.kind !== "func") throw new Error(`Date export ${entry.name} is not a function`);
+  const func =
+    entry.desc.index < STABLE_FUNC_BASE
+      ? ctx.mod.functions[
+          entry.desc.index - ctx.mod.imports.filter((candidate) => candidate.desc.kind === "func").length
+        ]
+      : definedFuncAt(ctx, entry.desc.index);
+  if (!func) throw new Error(`Date export ${entry.name} has no defined function target`);
+  return func;
+}
+
+function cloneExport(entry: WasmExport, name = entry.name): WasmExport {
+  return {
+    name,
+    desc: entry.desc.kind === "func" ? { kind: "func", index: entry.desc.index } : { ...entry.desc },
+  };
+}
+
+function appendDistinctUserExport(ctx: Context, name: string): WasmExport {
+  const dateFunc = contextFunctionForExport(ctx, dateEntry(ctx));
+  const index = ctx.mod.imports.filter((candidate) => candidate.desc.kind === "func").length + ctx.mod.functions.length;
+  const func: WasmFunction = {
+    name: `user-${name}`,
+    typeIdx: dateFunc.typeIdx,
+    locals: [],
+    body: [{ op: "i32.const", value: 7 }],
+    exported: true,
+  };
+  const entry: WasmExport = { name, desc: { kind: "func", index } };
+  ctx.mod.functions.push(func);
+  ctx.mod.exports.push(entry);
+  return entry;
+}
+
+type ExportSnapshot = {
+  readonly array: readonly WasmExport[];
+  readonly entries: readonly {
+    readonly entry: WasmExport;
+    readonly name: string;
+    readonly desc: WasmExport["desc"];
+    readonly descValue: WasmExport["desc"];
+  }[];
+};
+
+function snapshotExports(ctx: Context): ExportSnapshot {
+  return {
+    array: ctx.mod.exports,
+    entries: ctx.mod.exports.map((entry) => ({
+      entry,
+      name: entry.name,
+      desc: entry.desc,
+      descValue: { ...entry.desc },
+    })),
+  };
+}
+
+function expectExportsUnchanged(ctx: Context, snapshot: ExportSnapshot, label: string): void {
+  expect(ctx.mod.exports, `${label} export-array identity`).toBe(snapshot.array);
+  expect(ctx.mod.exports).toHaveLength(snapshot.entries.length);
+  snapshot.entries.forEach((before, index) => {
+    const after = ctx.mod.exports[index];
+    expect(after, `${label} export ${index} identity`).toBe(before.entry);
+    expect(after?.name, `${label} export ${index} name`).toBe(before.name);
+    expect(after?.desc, `${label} export ${index} descriptor identity`).toBe(before.desc);
+    expect(after?.desc, `${label} export ${index} descriptor value`).toEqual(before.descValue);
+  });
+}
+
+function expectPreFreezeRejection(ctx: Context, expected: RegExp, label: string): void {
+  ctx.emitHostBridge = false;
+  const before = snapshotExports(ctx);
+  expect(() => stripHostBridgeExports(ctx), label).toThrow(expected);
+  expectExportsUnchanged(ctx, before, label);
+}
+
+function multiSourcePolicySurvivors(target: OutputTarget, hostBridge: BridgePolicy): readonly string[] {
+  // `$dv` is the existing data-struct token alias, deliberately outside #4035's
+  // legacy alias table. It is not a Date export and remains public in host/off.
+  if (target === "wasi") return ["_start"];
+  return target === "host" && hostBridge === "off" ? ["$dv"] : [];
+}
+
+describe("#3520 C39 Date carrier host-bridge export provenance", () => {
+  it("accepts only the exact three Date public names", () => {
+    expect(DATE_BRIDGE_NAMES.every(isCoreDateHostBridgePublicName)).toBe(true);
+    expect(
+      [
+        "prefix__\0js2_is_date",
+        "__\0js2_is_date$",
+        "__\0js2_date_value_extra",
+        "__\0js2_date_set_value0",
+        "__\0js2_date-set-value",
+        "$d0",
+        "$d0$",
+      ].some(isCoreDateHostBridgePublicName),
+    ).toBe(false);
+  });
+
+  it.each(["auto", "always"] as const)(
+    "publishes exact Date descriptors, allocators, types, bodies, and runtime behavior for host %s",
+    async (hostBridge) => {
+      const fileName = `issue-3520-c39-date-host-${hostBridge}.ts`;
+      const generated = generateSingle(DATE_SOURCE, fileName, "host", hostBridge);
+      assertExactPublicSurface(generated, `host/${hostBridge}`, "host", hostBridge, dateHostBridgeExportsFor("host"));
+      assertExactDateCensus(generated, `host/${hostBridge}`);
+
+      const compiled = await compile(DATE_SOURCE, compileOptions(fileName, "host", hostBridge));
+      expect(compiled.success, hardErrors(compiled).join("\n")).toBe(true);
+      await assertDateRuntime(compiled, "host", `host/${hostBridge}`);
+    },
+  );
+
+  it.each(["standalone", "wasi"] as const)(
+    "strips Date bridge exports for %s auto/off with exact tracked parity",
+    async (target) => {
+      for (const hostBridge of ["auto", "off"] as const) {
+        const label = `${target}/${hostBridge}`;
+        const fileName = `issue-3520-c39-date-${target}-${hostBridge}.ts`;
+        const untrackedGenerated = generateSingle(DATE_SOURCE, fileName, target, hostBridge);
+        const trackedGenerated = generateSingle(DATE_SOURCE, fileName, target, hostBridge, true);
+        assertExactPublicSurface(
+          untrackedGenerated,
+          `${label}/untracked`,
+          target,
+          hostBridge,
+          dateHostBridgeExportsFor(target),
+        );
+        assertExactPublicSurface(
+          trackedGenerated,
+          `${label}/tracked`,
+          target,
+          hostBridge,
+          dateHostBridgeExportsFor(target),
+        );
+        expect(untrackedGenerated.module.imports, `${label} untracked generated imports`).toEqual([]);
+        expect(trackedGenerated.module.imports, `${label} tracked generated imports`).toEqual([]);
+        expect(dateEntries(untrackedGenerated), `${label} untracked Date exports`).toEqual([]);
+        expect(dateEntries(trackedGenerated), `${label} tracked Date exports`).toEqual([]);
+        assertGeneratedParity(untrackedGenerated, trackedGenerated, label);
+
+        const untracked = await compile(DATE_SOURCE, compileOptions(fileName, target, hostBridge));
+        const tracked = await compile(DATE_SOURCE, compileOptions(fileName, target, hostBridge, true));
+        assertCompiledParity(untracked, tracked, label);
+        expect(untracked.imports, `${label} untracked compiled imports`).toEqual([]);
+        expect(tracked.imports, `${label} tracked compiled imports`).toEqual([]);
+        await assertDateRuntime(tracked, target, label);
+      }
+    },
+  );
+
+  it.each(["standalone", "wasi"] as const)(
+    "retains all exact Date descriptors for %s hostBridge always with tracked parity",
+    async (target) => {
+      const label = `${target}/always`;
+      const fileName = `issue-3520-c39-date-${target}-always.ts`;
+      const untrackedGenerated = generateSingle(DATE_SOURCE, fileName, target, "always");
+      const trackedGenerated = generateSingle(DATE_SOURCE, fileName, target, "always", true);
+      assertExactPublicSurface(
+        untrackedGenerated,
+        `${label}/untracked`,
+        target,
+        "always",
+        dateHostBridgeExportsFor(target),
+      );
+      assertExactPublicSurface(
+        trackedGenerated,
+        `${label}/tracked`,
+        target,
+        "always",
+        dateHostBridgeExportsFor(target),
+      );
+      assertExactDateCensus(untrackedGenerated, `${label}/untracked`);
+      assertExactDateCensus(trackedGenerated, `${label}/tracked`);
+      assertGeneratedParity(untrackedGenerated, trackedGenerated, label);
+
+      const untracked = await compile(DATE_SOURCE, compileOptions(fileName, target, "always"));
+      const tracked = await compile(DATE_SOURCE, compileOptions(fileName, target, "always", true));
+      assertCompiledParity(untracked, tracked, label);
+      await assertDateRuntime(tracked, target, label);
+    },
+  );
+
+  it("keeps a Date-free source and context free of Date records, exports, functions, and carrier types", () => {
+    const generated = generateSingle(DATE_FREE_SOURCE, "issue-3520-c39-date-free.ts", "standalone", "always", true);
+    assertExactPublicSurface(
+      generated,
+      "Date-free standalone/always",
+      "standalone",
+      "always",
+      DATE_FREE_TARGET_HOST_BRIDGE_EXPORTS,
+    );
+    expect(dateEntries(generated), "Date-free exports").toEqual([]);
+    expect(
+      generated.module.functions.some((func) => isDateBridgeName(func.name)),
+      "Date-free functions",
+    ).toBe(false);
+    expect(
+      generated.module.types.some((type) => type.kind === "struct" && type.name === "__Date"),
+      "Date-free carrier type",
+    ).toBe(false);
+
+    for (const emitHostBridge of [true, false]) {
+      const module = createEmptyModule();
+      const ctx = createCodegenContext(module, {} as ts.TypeChecker, { target: "standalone", hostBridge: "off" });
+      emitDateHostBridge(ctx);
+      const probe: WasmExport = { name: DATE_BRIDGE_NAMES[0], desc: { kind: "func", index: 0 } };
+      expect(isCompilerOwnedDateHostBridgeExport(ctx, probe), `Date-free ownership ${emitHostBridge}`).toBe(false);
+      const before = snapshotExports(ctx as Context);
+      expect(() => finalizeDateHostBridgeExports(ctx), `Date-free finalizer ${emitHostBridge}`).not.toThrow();
+      ctx.emitHostBridge = emitHostBridge;
+      expect(stripHostBridgeExports(ctx), `Date-free policy ${emitHostBridge}`).toBe(0);
+      expect(ctx.mod.exports, `Date-free policy ${emitHostBridge} export contents`).toEqual(before.array);
+    }
+  });
+
+  it("keeps provider-created Date publication policy, descriptors, import census, binary parity, and runtime independent of source order", async () => {
+    const orderBaselines = new Map<
+      string,
+      {
+        readonly generated: ReturnType<typeof exportDescriptorCensus>;
+        readonly imports: ReturnType<typeof importDescriptorCensus>;
+        readonly binary: Uint8Array;
+      }
+    >();
+    for (const { label: order, files } of DATE_MULTI_SOURCE_ORDERS) {
+      for (const target of ["host", "standalone", "wasi"] as const) {
+        for (const hostBridge of ["auto", "off", "always"] as const) {
+          const label = `${order}/${target}/${hostBridge}`;
+          const fileName = `issue-3520-c39-date-provider-${order}-${target}-${hostBridge}.ts`;
+          const untrackedGenerated = generateGraph(files, "./entry.ts", target, hostBridge);
+          const trackedGenerated = generateGraph(files, "./entry.ts", target, hostBridge, true);
+          assertExactPublicSurface(
+            untrackedGenerated,
+            `${label}/untracked`,
+            target,
+            hostBridge,
+            multiDateHostBridgeExportsFor(target),
+            multiSourcePolicySurvivors(target, hostBridge),
+          );
+          assertExactPublicSurface(
+            trackedGenerated,
+            `${label}/tracked`,
+            target,
+            hostBridge,
+            multiDateHostBridgeExportsFor(target),
+            multiSourcePolicySurvivors(target, hostBridge),
+          );
+          const dateShouldRemain = target === "host" ? hostBridge !== "off" : hostBridge === "always";
+          if (dateShouldRemain) {
+            assertExactDateCensus(untrackedGenerated, `${label}/untracked`, true);
+            assertExactDateCensus(trackedGenerated, `${label}/tracked`, true);
+          } else {
+            expect(dateEntries(untrackedGenerated), `${label} untracked Date exports`).toEqual([]);
+            expect(dateEntries(trackedGenerated), `${label} tracked Date exports`).toEqual([]);
+          }
+          assertExactMultiImportCensus(untrackedGenerated, target, `${label}/untracked`);
+          assertExactMultiImportCensus(trackedGenerated, target, `${label}/tracked`);
+          assertGeneratedParity(untrackedGenerated, trackedGenerated, label);
+
+          const untracked = await compileMulti(files, "./entry.ts", compileOptions(fileName, target, hostBridge));
+          const tracked = await compileMulti(files, "./entry.ts", compileOptions(fileName, target, hostBridge, true));
+          assertCompiledParity(untracked, tracked, label);
+          if (target !== "host") {
+            expect(untracked.imports, `${label} untracked compiled imports`).toEqual([]);
+            expect(tracked.imports, `${label} tracked compiled imports`).toEqual([]);
+          }
+          await assertDateRuntime(tracked, target, label);
+
+          const key = `${target}/${hostBridge}`;
+          const baseline = orderBaselines.get(key);
+          const generated = exportDescriptorCensus(trackedGenerated);
+          const imports = importDescriptorCensus(trackedGenerated);
+          if (baseline) {
+            expect(generated, `${label} source-order descriptor parity`).toEqual(baseline.generated);
+            expect(imports, `${label} source-order import parity`).toEqual(baseline.imports);
+            expect(tracked.binary, `${label} source-order binary parity`).toEqual(baseline.binary);
+          } else {
+            orderBaselines.set(key, { generated, imports, binary: tracked.binary });
+          }
+        }
+      }
+    }
+  });
+
+  it("retains a genuine same-spelled user descriptor and a near spelling that targets a recorded Date allocator", () => {
+    const ctx = makeDateContext();
+    const recorded = dateEntry(ctx);
+    if (recorded.desc.kind !== "func") throw new Error("Date descriptor is not a function");
+    const user = appendDistinctUserExport(ctx, recorded.name);
+    const near = cloneExport(recorded, `${recorded.name}$`);
+    ctx.mod.exports.push(near);
+    expect(isCompilerOwnedDateHostBridgeExport(ctx, user)).toBe(false);
+    expect(isCompilerOwnedDateHostBridgeExport(ctx, near)).toBe(false);
+    expect(isCoreDateHostBridgePublicName(near.name)).toBe(false);
+
+    ctx.emitHostBridge = false;
+    expect(stripHostBridgeExports(ctx)).toBe(DATE_BRIDGE_NAMES.length);
+    expect(ctx.mod.exports).toContain(user);
+    expect(ctx.mod.exports).toContain(near);
+    expect(ctx.mod.exports).not.toContain(recorded);
+  });
+
+  it("validates and strips all recorded Date descriptors through distinct stable handles", () => {
+    const ctx = makeDateContext();
+    const entries = DATE_BRIDGE_NAMES.map((name) => dateEntry(ctx, name));
+    const funcs = entries.map((entry) => contextFunctionForExport(ctx, entry));
+    for (const [ordinal, entry] of entries.entries()) {
+      const func = funcs[ordinal]!;
+      const position = ctx.mod.functions.indexOf(func);
+      expect(position, `stable Date allocator ${entry.name}`).toBeGreaterThanOrEqual(0);
+      ctx.mod.funcOrdinalToPosition.push(position);
+      entry.desc = { kind: "func", index: STABLE_FUNC_BASE + ordinal };
+      expect(definedFuncAt(ctx, entry.desc.index), `stable Date handle ${entry.name}`).toBe(func);
+    }
+
+    finalizeDateHostBridgeExports(ctx);
+    ctx.emitHostBridge = false;
+    expect(stripHostBridgeExports(ctx)).toBe(DATE_BRIDGE_NAMES.length);
+    expect(ctx.mod.exports).toEqual([]);
+  });
+
+  it("validates and strips all recorded Date descriptors against the current function-import prefix", () => {
+    const ctx = makeDateContext();
+    const entries = DATE_BRIDGE_NAMES.map((name) => dateEntry(ctx, name));
+    const funcs = entries.map((entry) => contextFunctionForExport(ctx, entry));
+    ctx.mod.imports.push({
+      module: "env",
+      name: "late_date_import",
+      desc: { kind: "func", typeIdx: funcs[0]!.typeIdx },
+    });
+    expect(ctx.numImportFuncs, "stale creation-time import count").toBe(0);
+    for (const [index, entry] of entries.entries()) {
+      entry.desc = { kind: "func", index: index + 1 };
+      expect(contextFunctionForExport(ctx, entry), `rebased Date handle ${entry.name}`).toBe(funcs[index]);
+    }
+
+    finalizeDateHostBridgeExports(ctx);
+    ctx.emitHostBridge = false;
+    expect(stripHostBridgeExports(ctx)).toBe(DATE_BRIDGE_NAMES.length);
+    expect(ctx.mod.exports).toEqual([]);
+  });
+
+  it("rejects a same-context exact-name clone after a successful pre-freeze validation without a partial rewrite", () => {
+    const ctx = makeDateContext();
+    const recorded = dateEntry(ctx);
+    finalizeDateHostBridgeExports(ctx);
+    const clone = cloneExport(recorded);
+    ctx.mod.exports.push(clone);
+    expect(isCompilerOwnedDateHostBridgeExport(ctx, clone)).toBe(false);
+    expectPreFreezeRejection(
+      ctx,
+      /unrecorded Date host bridge export descriptor .* resolves to a recorded allocator function/,
+      "same-context clone",
+    );
+  });
+
+  it("rejects an identically laid-out foreign-context Date descriptor without a partial rewrite", () => {
+    const recipient = makeDateContext();
+    const donor = makeDateContext();
+    const recipientEntry = dateEntry(recipient);
+    const donorEntry = dateEntry(donor);
+    if (recipientEntry.desc.kind !== "func" || donorEntry.desc.kind !== "func") {
+      throw new Error("Date donor descriptors are not functions");
+    }
+    expect(donorEntry).not.toBe(recipientEntry);
+    expect(donorEntry.desc.index, "identical-layout handle").toBe(recipientEntry.desc.index);
+    expect(isCompilerOwnedDateHostBridgeExport(donor, donorEntry)).toBe(true);
+    expect(isCompilerOwnedDateHostBridgeExport(recipient, donorEntry)).toBe(false);
+    recipient.mod.exports.push(donorEntry);
+    expectPreFreezeRejection(
+      recipient,
+      /unrecorded Date host bridge export descriptor .* resolves to a recorded allocator function/,
+      "foreign-context donor",
+    );
+  });
+
+  it("keeps a post-freeze replacement copy unowned and retained without allocator fallback", () => {
+    const ctx = makeDateContext();
+    const recordedIndex = ctx.mod.exports.indexOf(dateEntry(ctx));
+    if (recordedIndex < 0) throw new Error("missing recorded Date descriptor");
+    const recorded = ctx.mod.exports[recordedIndex]!;
+    finalizeDateHostBridgeExports(ctx);
+    ctx.indexSpaceFrozen = true;
+    const replacement = cloneExport(recorded);
+    ctx.mod.exports[recordedIndex] = replacement;
+    expect(isCompilerOwnedDateHostBridgeExport(ctx, replacement)).toBe(false);
+
+    ctx.emitHostBridge = false;
+    expect(stripHostBridgeExports(ctx)).toBe(DATE_BRIDGE_NAMES.length - 1);
+    expect(ctx.mod.exports).toContain(replacement);
+    expect(ctx.mod.exports).not.toContain(recorded);
+  });
+
+  it.each([
+    ["vec", "$v0"],
+    ["constructor-closure", "$ch"],
+  ] as const)(
+    "strips a recorded Date descriptor renamed into the %s namespace before retaining a genuine user descriptor",
+    (family, name) => {
+      const ctx = makeDateContext();
+      const recorded = dateEntry(ctx);
+      const user = appendDistinctUserExport(ctx, name);
+      finalizeDateHostBridgeExports(ctx);
+      ctx.indexSpaceFrozen = true;
+      recorded.name = name;
+      expect(isCompilerOwnedDateHostBridgeExport(ctx, recorded)).toBe(true);
+      expect(isCompilerOwnedDateHostBridgeExport(ctx, user)).toBe(false);
+
+      ctx.emitHostBridge = false;
+      expect(stripHostBridgeExports(ctx), family).toBe(DATE_BRIDGE_NAMES.length);
+      expect(ctx.mod.exports).not.toContain(recorded);
+      expect(ctx.mod.exports).toContain(user);
+    },
+  );
+
+  it.each([
+    {
+      name: "missing descriptor",
+      mutate: (ctx: Context, entry: WasmExport) => {
+        ctx.mod.exports.splice(ctx.mod.exports.indexOf(entry), 1);
+      },
+      expected: /disappeared before finalization/,
+    },
+    {
+      name: "duplicate descriptor object",
+      mutate: (ctx: Context, entry: WasmExport) => {
+        ctx.mod.exports.push(entry);
+      },
+      expected: /appears more than once in the module/,
+    },
+    {
+      name: "renamed descriptor",
+      mutate: (_ctx: Context, entry: WasmExport) => {
+        entry.name = "__\0js2_is_date$";
+      },
+      expected: /changed its published name/,
+    },
+    {
+      name: "kind-changed descriptor",
+      mutate: (_ctx: Context, entry: WasmExport) => {
+        entry.desc = { kind: "global", index: 0 };
+      },
+      expected: /changed kind to global/,
+    },
+    {
+      name: "retargeted descriptor",
+      mutate: (ctx: Context, entry: WasmExport) => {
+        const other = dateEntry(ctx, DATE_BRIDGE_NAMES[1]);
+        if (other.desc.kind !== "func") throw new Error("alternate Date descriptor is not a function");
+        entry.desc = { kind: "func", index: other.desc.index };
+      },
+      expected: /resolves to a different allocator function/,
+    },
+    {
+      name: "one-past live handle",
+      mutate: (ctx: Context, entry: WasmExport) => {
+        entry.desc = {
+          kind: "func",
+          index:
+            ctx.mod.imports.filter((candidate) => candidate.desc.kind === "func").length + ctx.mod.functions.length,
+        };
+        if (entry.desc.kind !== "func" || entry.desc.index >= STABLE_FUNC_BASE) {
+          throw new Error("one-past Date handle did not stay in the live regime");
+        }
+      },
+      expected: /resolves to a different allocator function/,
+    },
+    {
+      name: "negative live handle",
+      mutate: (_ctx: Context, entry: WasmExport) => {
+        entry.desc = { kind: "func", index: -1 };
+      },
+      expected: /resolves to a different allocator function/,
+    },
+    {
+      name: "invalid live handle despite a stable ordinal",
+      mutate: (ctx: Context, entry: WasmExport) => {
+        const func = contextFunctionForExport(ctx, entry);
+        ctx.mod.funcOrdinalToPosition.push(ctx.mod.functions.indexOf(func));
+        expect(definedFuncAt(ctx, STABLE_FUNC_BASE), "available stable Date allocator").toBe(func);
+        ctx.mod.imports.push({
+          module: "env",
+          name: "late_date_import",
+          desc: { kind: "func", typeIdx: func.typeIdx },
+        });
+        if (entry.desc.kind !== "func" || entry.desc.index >= STABLE_FUNC_BASE) {
+          throw new Error("Date descriptor did not remain a live handle");
+        }
+      },
+      expected: /resolves to a different allocator function/,
+    },
+    {
+      name: "removed allocator",
+      mutate: (ctx: Context, entry: WasmExport) => {
+        const func = contextFunctionForExport(ctx, entry);
+        ctx.mod.functions.splice(ctx.mod.functions.indexOf(func), 1);
+      },
+      expected: /lost its allocator function/,
+    },
+    {
+      name: "duplicated allocator object",
+      mutate: (ctx: Context, entry: WasmExport) => {
+        ctx.mod.functions.push(contextFunctionForExport(ctx, entry));
+      },
+      expected: /allocator function .* appears more than once in the module/,
+    },
+  ] as const)("fails closed before policy rewrite for %s", ({ name, mutate, expected }) => {
+    const ctx = makeDateContext();
+    const entry = dateEntry(ctx);
+    mutate(ctx, entry);
+    expectPreFreezeRejection(ctx, expected, name);
+  });
+});


### PR DESCRIPTION
## Summary

- record the three Date carrier bridge export descriptors and allocator objects per `CodegenContext`
- validate the complete exact-name namespace before host-bridge policy runs
- make descriptor identity the sole removal authority while treating live/stable allocator resolution as validation-only evidence
- reject same-context descriptor clones and foreign-context allocator donations without rewriting the export array
- compose Date ownership ahead of the existing constructor and vector namespaces while preserving their policies
- add the complete C39 host, standalone, WASI, tracking, runtime, source-order, and fail-closed mutation matrix
- append the Sol-authored C39 implementation lock to the #3520 plan

## Publication state

Parent C38 PR #5342 has merged. Fresh independent Sol exact-byte/SHA review APPROVED unchanged C39 head `b39a839e5865af278336ea457bb4aa0e72d32719` against protected `main` `3193ca16685de143af1ae1d6066978b2590c687d`.

- merge-base: `f8eefc6e9a7e379238bfe06d406f82de779cfd1f`, the merged C38 head
- C38 merge commit: `d993a071e8259b6b3c9512abb2a07bdf98dd396f`, verified ancestor of current `main`
- canonical `git diff --binary main...head` SHA-256: `d2ab8c1675d1ecb9c0da1dd0662156ecd8759ca9d36d8ef95baa3ba279455d91`
- exact scope: four files, 1,363 insertions / 16 deletions; no C38 closure implementation/test delta remains
- no ProgramABI or #3525 whole-program publication source files are touched
- exact C39 commit tree: `c934071db0aa8e2bf26a823e1fb16004fc03ff59`
- GitHub verifies the Thomas-authored SSH signature; Codex co-author, model, and checklist trailers are present
- any later push invalidates the exact-byte/SHA approval

GitHub's displayed `baseRefOid` and file rollup are cached at the pre-C38 base `f08c7c62…`; the live current-main merge-base/diff identities above are authoritative. This supersedes older draft #5301. That draft's allocator-fallback ownership model is not carried forward; this implementation follows the descriptor-provenance contract recorded in the updated #3520 plan.

## Validation

- exact-head PR checks: 35 completed check runs = 25 success, 10 intentional skips, zero failed/cancelled/incomplete, plus successful `cla-check`
- full pre-commit hooks, including changed-root suites:
  - C38 constructor-closure provenance: 20/20
  - C39 Date carrier provenance: 27/27
- full pre-push hooks:
  - typecheck and lint
  - Prettier format check
  - oracle and coercion-site ratchets
  - issue integrity
  - numeric-local IR parity: 18/18
- focused closure checks:
  - C37 vector provenance: 19/19
  - TypeScript 7 typecheck
  - IR fallbacks, layering, adoption, dialect, kind-neutrality, optimization retirement ledger
  - host-import policy, dead exports, coercion sites, oracle ratchet
  - LOC and function regrowth ratchets
- fresh Sol static review found no defect: Date ownership is context-local descriptor identity only; allocator resolution remains validation-only; complete namespace census fails before rewriting; Date/C38/C37 policy order is preserved; mutation, target, tracking, source-order, and runtime coverage matches the lock

The existing #4035 size-ceiling test remains 5/6 with its unchanged `32691 < 20000` failure. This PR neither changes nor relabels that inherited ceiling.

Tracks #3520. This C39 checkpoint does not claim or close the parent issue. It is ready for the normal protected merge queue; no admin or direct-merge bypass.
