### PR TITLE
docs(quality): audit main and file verified findings

### DIFF
--- a/plan/issues/1616-flatten-issue-files-stable-location.md
+++ b/plan/issues/1616-flatten-issue-files-stable-location.md
@@ -1,10 +1,9 @@
 ---
 id: 1616
 title: "Flatten issue files into a stable location; sprint membership via frontmatter only"
-status: done
+status: ready
 created: 2026-05-24
-updated: 2026-05-24
-completed: 2026-05-24
+updated: 2026-08-31
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -12,7 +11,7 @@ task_type: infrastructure
 area: tooling
 language_feature: n/a
 goal: process
-sprint: 55
+sprint: current
 ---
 # Issue #1616 — Flatten issue files into a stable location; sprint membership via frontmatter only
 
@@ -361,3 +360,36 @@ dashboard build on every push.
 - [ ] All 10 tools/workflows updated or confirmed-unaffected per the table.
 - [ ] Validation plan steps 1–8 all pass; CI green.
 - [ ] Rename-safety lint in place (broken-link check wired into `quality`).
+
+## 2026-08-31 — reopened: canonical-set and flatten acceptance remain unmet
+
+The migration mostly landed, but a current-source audit found concrete
+residuals against the unchecked acceptance list above:
+
+1. Three numbered issue files remain nested under `plan/issues/backlog/`:
+   #1446, #1447, and #1449. No flat counterparts exist.
+2. The generated backlog index links them as `../<basename>`, which resolves to
+   nonexistent flat paths.
+3. Tool populations disagree: `check-issue-ids.mjs` scans **4,259** flat IDs,
+   while committed integrity and `update-issues` see **4,260** canonical issue
+   records recursively.
+4. `website/dashboard/build-data.js:53-55,136-146` accepts any digit-prefixed
+   Markdown basename instead of the canonical predicate. A fresh build admits
+   three planning/non-issue documents as ready issues: `sprints/0.md`,
+   `sprints/73-plan.md`, and `1578-test262-analysis.md`. It produces **4,263**
+   dashboard entries for **4,260** canonical issues.
+
+Move the three legacy records to flat paths, then share one canonical issue
+predicate (or require valid, matching `id:` frontmatter) across integrity,
+index, and dashboard tooling. #5234 separately owns the freshness/ownership of
+the tracked dashboard snapshots; this issue owns which files count as issues.
+
+### Reopened acceptance criteria
+
+- [ ] Zero numbered issue records remain below backlog/wont-fix/sprint
+      subdirectories.
+- [ ] Every generated issue link resolves to a canonical flat record.
+- [ ] Workspace, committed-integrity, update, and dashboard scanners return the
+      same identity set and count.
+- [ ] `sprints/0.md`, `sprints/73-plan.md`, and
+      `1578-test262-analysis.md` are negative regression fixtures, not cards.

--- a/plan/issues/3103-split-runtime-ts-host-runtime-by-concern.md
+++ b/plan/issues/3103-split-runtime-ts-host-runtime-by-concern.md
@@ -1,10 +1,10 @@
 ---
 id: 3103
-title: "Split src/runtime.ts (15,032 LOC) host runtime by concern; decompose resolveImport (6,517-line function)"
+title: "Split src/runtime.ts (18,786 LOC) host runtime by concern and remove duplicate helper implementations"
 status: ready
 sprint: current
 created: 2026-07-09
-updated: 2026-07-17
+updated: 2026-08-31
 priority: high
 horizon: l
 feasibility: medium
@@ -229,3 +229,35 @@ confirmed **0** stray references to the four privatized symbols remain in
 lines: license header, one `export` keyword, one import block). `tsc --noEmit`:
 clean. `check:loc-budget`: green. `runtime.ts` is host-side JS, not in the Wasm
 emit path, so the split cannot change an emitted byte by construction.
+
+## 2026-08-31 — audit update: the public helpers now have divergent copies
+
+`src/runtime.ts` has grown to **18,786 lines**. The audit also found that the
+partial extraction created parallel implementations rather than a canonical
+module boundary:
+
+- `src/runtime-instantiate.ts` is 99 lines and is imported by **40** source/test
+  files, yet it duplicates `instantiateWasm`, `instantiateWasmStreaming`, and
+  `compileAndInstantiate` from the production `src/runtime.ts` entry point.
+  The two copies already differ: the production helper preserves the
+  data-struct association capability and uses `buildCompiledImports`; the
+  sibling does neither. Both retain the catch-all retry defect filed as #5231.
+- `src/runtime-containment.ts` is a 129-line copy of
+  `wrapWithContainment` with **zero importers**. Production continues to use
+  the private copy in `src/runtime.ts`; fixing the apparently extracted file
+  would change no behavior. The live copy currently violates reopened #68.
+
+This is not just file size. Two sources of truth make correctness fixes land in
+the wrong copy or drift by caller. The decomposition must make each concern
+canonical before shrinking the barrel.
+
+### Added acceptance criteria
+
+- [ ] Exactly one implementation owns each public instantiation helper; all 40
+      helper consumers and the package export route through it.
+- [ ] Exactly one implementation owns DOM containment; no zero-import duplicate
+      remains.
+- [ ] The canonicalization preserves data-struct association and compiled-import
+      construction behavior, with differential tests before deletion.
+- [ ] #5231 and #68 regression tests execute through the canonical production
+      entry point and any supported subpath.

--- a/plan/issues/3603-verifyproperty-vacuous-both-lanes.md
+++ b/plan/issues/3603-verifyproperty-vacuous-both-lanes.md
@@ -4,7 +4,7 @@ title: "verifyProperty is vacuous on BOTH lanes — two distinct root causes (st
 status: in-progress
 sprint: current
 created: 2026-07-25
-updated: 2026-07-25
+updated: 2026-08-31
 assignee: ttraenkler/opus-loop-a
 loc-budget-allow:
   - src/runtime.ts
@@ -877,3 +877,28 @@ is touched, and there is no committed force-disable switch.**
 obj[name]`, `isWritable` writes) and the host lane shares real host builtins
    across in-process runs. Probing `Math.abs` twice in one process without
    `{restore:true}` contaminates the second probe. Use a fresh subject per case.
+
+## 2026-08-31 — residual: vector mirror writeback is skipped on abrupt calls
+
+The fixed-arity host call bridge still brackets mirror writeback only on normal
+completion. `src/runtime/host-call-abi.ts:43-46` snapshots vector mirrors,
+calls `Reflect.apply`, and reconciles afterwards without `finally`. The live
+`__proto_method_call` path in `src/runtime.ts:14077-14079` has the same shape.
+
+A direct probe mutating the host mirror and then throwing leaves the mirror
+changed while the compiled vector remains unchanged. This violates the abrupt
+completion rule already implemented correctly by the sibling prototype-method
+path at `src/runtime.ts:14293-14304`, whose comment explicitly says committed
+writes must be reconciled before rethrow.
+
+This remains within #3603 because the affected bridges are the same host
+uncurried-call/vector-mirror surface the issue owns.
+
+### Added acceptance criteria
+
+- [ ] Every bridge that calls host code after `snapshotVecMirrors` reconciles in
+      `finally` before an abrupt completion is rethrown.
+- [ ] A host callback that mutates a mirrored vector and then throws leaves the
+      compiled vector observing the committed mutation.
+- [ ] Normal return, failed assertion, and non-vector controls preserve their
+      current identity/exception behavior.

--- a/plan/issues/3987-test262-baseline-node-version-bound.md
+++ b/plan/issues/3987-test262-baseline-node-version-bound.md
@@ -3,7 +3,7 @@ id: 3987
 title: "test262 shards are stranded on the absent Node 25 manifest pin — moving them to 24 needs the baseline regenerated first, because conformance results are Node-version-bound"
 status: ready
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-31
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -138,3 +138,22 @@ conservative on purpose and narrowing it deserves its own judgement.
 The unfinished half of #3963, split out so the deferral is tracked rather than
 buried in a merged issue's prose. #3963 shipped 7 workflows and recorded its own
 criterion 2 as not met specifically so this could be picked up deliberately.
+
+## 2026-08-31 — blast-radius refresh
+
+The shared `setup-node-pnpm` action still defaults to Node 25, and its absent-
+manifest fallback now reaches **seven unique workflows** (multiple jobs in
+several of them):
+
+- `ci.yml`;
+- `eval-interpreter-lane.yml`;
+- `npm-compat-promote.yml`;
+- `npm-compat-refresh.yml`;
+- `quickjs-wasi-artifact.yml`;
+- `refresh-baseline.yml`; and
+- `test262-sharded.yml`.
+
+The issue should no longer be read as a two-workflow residual. The baseline
+coordination requirement still applies to conformance jobs, but consumers such
+as ordinary `ci.yml` and artifact lanes need to be classified individually so
+unrelated work does not inherit a per-run fallback download without reason.

--- a/plan/issues/4063-check-godfiles-red-on-main-gates-nothing.md
+++ b/plan/issues/4063-check-godfiles-red-on-main-gates-nothing.md
@@ -1,11 +1,11 @@
 ---
 id: 4063
-title: "`check:godfiles` is RED on main (2 regressions in src/codegen/index.ts) but gates nothing — wire it in or retire it"
+title: "`check:godfiles` is RED on main with 39 regressions but gates nothing — wire it in or retire it"
 status: ready
 sprint: current
 created: 2026-08-02
-updated: 2026-08-02
-priority: low
+updated: 2026-08-31
+priority: medium
 horizon: s
 feasibility: medium
 reasoning_effort: high
@@ -14,7 +14,7 @@ area: ci
 language_feature: n/a
 goal: dogfood
 ---
-# `check:godfiles` is RED on main (2 regressions in src/codegen/index.ts) but gates nothing — wire it in or retire it
+# `check:godfiles` is RED on main with 39 regressions but gates nothing — wire it in or retire it
 
 > Filed 2026-08-02 from a TaskList entry that had been carrying the full
 > analysis but no issue file. The body below is the original measurement
@@ -56,3 +56,40 @@ banked that improvement automatically.
 
 LOW PRIORITY — nothing is blocked on it. Do not let it displace ES5/standalone lever
 work.
+
+## 2026-08-31 — current measurement: 2 regressions became 39
+
+The original evidence remains valid but its scale and priority are stale.
+`node scripts/profile-godfiles.mjs --check` now exits 1 with **39**
+regressions across five files, while no workflow under `.github/` invokes the
+profiler.
+
+Largest measured growth:
+
+- `ensureObjectRuntime`: **4,234 → 5,669 LOC** (+1,435);
+- `compileCallExpression`: **1,811 → 2,307** (+496);
+- `emitIteratorMethodExport`: **169 → 595** (+426);
+- `generateModule`: **1,269 → 1,718** (+449);
+- `generateMultiModule`: **768 → 1,155** (+387);
+- `ensureAnyToStringHelper`: **467 → 660** (+193).
+
+The result includes numerous new 150+ LOC mega-functions in `calls.ts`,
+`index.ts`, `object-runtime.ts`, `array-methods.ts`, and `native-strings.ts`.
+Thirty-seven additional violations accumulated while the red check remained
+decorative. Raising this issue to medium reflects that demonstrated ratchet
+failure; it still should not displace correctness work.
+
+PR preflight against `upstream/main` at
+`c39de6dac8c376482b4f2cd628e445c6d8441728` re-ran the gate after 22 upstream
+commits beyond the audit base. It remains at **39** regressions; intervening
+codegen work increased `generateModule` from the audit's measured 1,684 LOC to
+1,718 LOC, which is reflected above.
+
+### Updated acceptance criteria
+
+- [ ] Pristine main is green because violations were reduced/reconciled, not
+      because the current 39 were blindly banked.
+- [ ] An intentional function growth above the configured margin is a red
+      positive control.
+- [ ] A required workflow invokes the meaningful ratchet, or the profiler and
+      package scripts are explicitly retired.

--- a/plan/issues/5229-node20-supported-runtime-quality-gates.md
+++ b/plan/issues/5229-node20-supported-runtime-quality-gates.md
@@ -1,0 +1,87 @@
+---
+id: 5229
+title: "Published Node 20 support floor has no package-level compatibility proof"
+status: ready
+sprint: current
+created: 2026-08-31
+updated: 2026-08-31
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: max
+task_type: infrastructure
+area: runtime, ci, tooling
+language_feature: n/a
+goal: dogfood
+related: [1449, 3490, 3552, 3613, 3746]
+requested_by: ttraenkler/codex-sol-ultra
+---
+
+# #5229 — prove the published package at its declared Node 20 floor
+
+## Problem
+
+The published package declares `engines.node: ">=20"` and ships `dist/`, its
+CLI entry points, examples, and documentation. Required CI exercises Node 25,
+but no required job packs the publication, installs it under Node 20, and runs
+a bounded public API/CLI compatibility smoke. The oldest accepted package
+runtime is therefore metadata without an executable regression proof.
+
+This contract is intentionally narrower than repository development and
+authoritative conformance work:
+
+- `docs/methodology.md` requires Node 22+ for contributors;
+- `docs/getting-started.md` recommends Node 22+ and documents that older hosts
+  may need `--experimental-wasm-gc`; and
+- #3490 and #3746 explicitly keep published-package support separate from the
+  Node 25 Test262/FYI environment.
+
+Fresh observations on audited commit
+`dfd3ae92da8186d1b77c9781cb8bf40c4ef62d0f` show why a package-level smoke must
+be selected deliberately, but they do **not** prove the published package is
+broken:
+
+- repository-only `scripts/check-test-vacuity-shapes.ts` imports
+  `node:fs.globSync`, which is absent on official Node 20.19.5; and
+- the repository's 20-file guard manifest, run without the documented Wasm
+  feature flags, reports **101 failed, 149 passed, 4 skipped**, while Node
+  24.19.0 reports **250 passed, 4 skipped**.
+
+Neither repository script is included in the published `files` set, and the
+unflagged guard run is outside the documented older-host command. They are
+tooling-boundary evidence, not a finding against `engines.node`.
+
+## Impact
+
+`npm` accepts installation on Node 20, but a change that breaks the packed
+entry points only at that floor cannot block a PR. Conversely, repository-only
+tooling failures can be mistaken for package incompatibility when the two
+contracts are not tested and named separately.
+
+## Direction
+
+Build or pack the exact publishable artifact, install it in an isolated Node 20
+consumer fixture, and smoke the documented public surfaces: module import,
+one bounded compile, the relevant instantiate/runtime path with documented
+flags, and CLI startup/one minimal compilation. Keep contributor checks and
+the Node 25 authoritative conformance lane separate.
+
+If that bounded package contract cannot be supported, raise `engines.node` and
+align consumer-facing documentation. Repository-only checks may independently
+raise their contributor runtime or replace newer APIs, but that is not a
+precondition for proving the package.
+
+## Acceptance criteria
+
+- [ ] Required CI builds or packs the same files that publication exposes and
+      installs them into an isolated consumer fixture.
+- [ ] The lowest `engines.node` major imports the public package and runs a
+      minimal documented API compile/instantiate path.
+- [ ] The published CLI entry points start, and the primary CLI completes one
+      bounded compilation under that Node major.
+- [ ] Any Wasm feature flags needed by that consumer path are applied through a
+      documented command and covered by a negative control.
+- [ ] Contributor-tooling and authoritative Test262 runtime requirements stay
+      separately named and do not silently redefine package support.
+- [ ] If the smoke cannot pass, `engines.node` and consumer-facing docs are
+      raised together.

--- a/plan/issues/5230-issue-check-generated-drift-fail-open.md
+++ b/plan/issues/5230-issue-check-generated-drift-fail-open.md
@@ -1,0 +1,91 @@
+---
+id: 5230
+title: "`check:issues` reports semantic generated drift but has no freshness verdict"
+status: ready
+sprint: current
+created: 2026-08-31
+updated: 2026-08-31
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: max
+task_type: infrastructure
+area: tooling, planning, ci
+language_feature: n/a
+goal: process
+related: [1616]
+requested_by: ttraenkler/codex-sol-ultra
+---
+
+# #5230 — give generated issue drift an enforceable, deterministic verdict
+
+## Problem
+
+The required `check:issues` step runs
+`node scripts/update-issues.mjs --check`. On current upstream main it reports:
+
+```text
+update-issues — 4260 issues indexed
+  would update 0 issue files
+  would update plan/log/sprints/index.md: true
+  would update plan/issues/backlog/index.md: true
+  would update plan/issues/wont-fix/index.md: true
+```
+
+and exits **0**.
+
+The three booleans are calculated correctly at
+`scripts/update-issues.mjs:695-697` and printed at lines 699-705, but the check
+failure list at lines 758-767 includes only duplicate IDs, ID mismatches,
+dangling dependencies, and broken links. It never includes generated drift.
+Issue-file normalization drift is even misreported: `issueFilesUpdated` is
+incremented only inside `if (!CHECK && nextText !== originalText)` at lines
+414-417, so check mode necessarily prints zero.
+
+The current `--check` header calls the mode "audit only, no writes", and CI's
+comments name the four structural failures. That makes this an underspecified
+contract rather than evidence that every byte difference was intended to be
+fatal. The quality problem is that no other required check owns freshness even
+when this command positively detects meaningful drift.
+
+## Semantic drift reproduced
+
+Regeneration in an isolated worktree changed the planning data, not just a
+date header:
+
+- the sprint index advances beyond the committed Sprint 77 view;
+- backlog summary changes from **191 ready / 45 blocked / 71 backlog** to
+  **186 / 41 / 77**;
+- wont-fix count changes from **55** to **58**.
+
+The full normalization pass also changes thousands of tracked issue records,
+yet check mode reports zero issue files by construction. Required CI therefore
+confirms structural referential integrity while allowing its generated views
+and normalized source records to drift indefinitely.
+
+There is a second fail-open at lines 733-737: failure of `git ls-files` is
+swallowed, turning the broken-link population into an empty successful scan.
+
+## Direction
+
+Define two explicit, separately named contracts if both are useful:
+
+- structural integrity (duplicates, identity, dependencies, links); and
+- deterministic freshness (normalization and generated artifacts).
+
+Compute proposed issue-file changes even when writes are disabled. Stabilize
+the generated date from source/revision metadata, or compare normalized content
+that excludes a date-only header, before making freshness required.
+
+## Acceptance criteria
+
+- [ ] A pristine committed tree exits 0 without writes.
+- [ ] A fixture issue that needs normalization exits non-zero and names the
+      file while leaving it untouched.
+- [ ] Independently perturbing each of the three generated indexes exits
+      non-zero and names that path.
+- [ ] Crossing a UTC date with unchanged source does not create drift.
+- [ ] A simulated `git ls-files` failure is non-zero or explicitly marks the
+      check degraded and non-successful.
+- [ ] Required CI calls the deterministic freshness contract; the narrower
+      structural audit, if retained, has a name that cannot be mistaken for it.

--- a/plan/issues/5231-instantiation-fallback-replays-start.md
+++ b/plan/issues/5231-instantiation-fallback-replays-start.md
@@ -1,0 +1,81 @@
+---
+id: 5231
+title: "Instantiation fallback retries modules after start-section failure, replaying initialization"
+status: ready
+sprint: current
+created: 2026-08-31
+updated: 2026-08-31
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: max
+task_type: bugfix
+area: runtime
+language_feature: wasm-instantiation
+goal: core-semantics
+related: [66, 907, 1155, 1619]
+requested_by: ttraenkler/codex-sol-ultra
+---
+
+# #5231 — do not replay a failed Wasm start section as feature fallback
+
+## Problem
+
+`instantiateWasm` is intended to try native `wasm:js-string` built-ins and
+fall back to the JS polyfill only when the native option is unsupported.
+Instead, `src/runtime.ts:18708-18717` catches **every** rejection from
+`WebAssembly.instantiate` and retries at lines 18719-18724.
+
+Instantiation is not side-effect-free: a Wasm start section can call host
+imports and then throw. The catch-all cannot distinguish an unsupported
+built-in option from a compile error, link error, import exception, or
+start-section runtime failure. It therefore repeats user-visible
+initialization before propagating the second error.
+
+The streaming path is worse. `instantiateWasmStreaming` first catches the
+streaming rejection at `src/runtime.ts:18744-18755`, reads the cloned response,
+then calls the same two-attempt helper at lines 18771-18772.
+
+## Reproduction
+
+A minimized module whose start function calls `env.hit()` once and then traps
+produced these counts on current upstream main:
+
+- `instantiateWasm`: `hit` called **2** times, final error
+  `WebAssembly.RuntimeError: unreachable`;
+- `instantiateWasmStreaming`: `hit` called **3** times, same final error;
+- duplicate helper `src/runtime-instantiate.ts`: **2** calls.
+
+A positive control confirmed that top-level module initialization happens
+inside the awaited instantiation operation. No active issue owns this retry
+classification; #66 merely recorded that the fallback stayed as-is.
+
+## Impact
+
+Any start-time host effect can be duplicated or triplicated: registration,
+logging, counters, DOM writes, callbacks, or mutations in an imported service.
+The caller sees only the final failure and cannot know that initialization was
+replayed. The same broad catch also obscures the original error if the retry
+fails differently.
+
+## Direction
+
+Separate compile/feature negotiation from instantiation. Prefer compiling with
+the native options first, or classify only the precise unsupported-option
+failure before a start section can execute. Once instantiation begins, propagate
+compile/link/start/import failures unchanged and never retry the module.
+
+Keep one canonical implementation; `src/runtime-instantiate.ts` duplicates
+the public helpers and must not retain a second fallback policy (see #3103).
+
+## Acceptance criteria
+
+- [ ] A start-section or imported-function failure is propagated unchanged
+      after exactly one instantiation attempt.
+- [ ] Throwing byte and streaming fixtures each observe exactly **1** `hit`.
+- [ ] An engine that genuinely rejects native string built-in options still
+      reaches the JS polyfill and instantiates successfully.
+- [ ] MIME/streaming compilation fallback remains supported without retrying a
+      module after instantiation has begun.
+- [ ] Production and any retained helper entry point share the same tested
+      classification policy.

--- a/plan/issues/5232-issue-test-gate-population-loss.md
+++ b/plan/issues/5232-issue-test-gate-population-loss.md
@@ -1,0 +1,99 @@
+---
+id: 5232
+title: "Issue-test regression gate lets files and assertions disappear without a verdict"
+status: ready
+sprint: current
+created: 2026-08-31
+updated: 2026-08-31
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: max
+task_type: infrastructure
+area: testing, ci
+language_feature: n/a
+goal: dogfood
+related: [3008, 3340, 3552, 4253]
+requested_by: ttraenkler/codex-sol-ultra
+---
+
+# #5232 — make regression-test population loss a failing event
+
+## Problem
+
+The post-merge issue-test gate protects only observed failures. Its IDs encode
+the observed file and assertion name, but it has no expected population or
+explicit shard identity:
+
+- `scripts/issue-tests-gate.mjs:60-73` enumerates only files that exist now;
+- reporter parsing at lines 154-170 records only `failed` and `passed`
+  assertions;
+- shard artifacts at lines 191-201 contain three observed ID sets but no shard
+  number, enumerated file list, expected assertion denominator, or skip/todo
+  population;
+- the baseline at lines 204-205 stores only `knownFailures`;
+- comparison at lines 253-255 asks only whether a current failure is new or a
+  known current assertion now passes.
+
+The required PR selector compounds this: `scripts/hooks/changed-root-tests.sh`
+uses `git diff --diff-filter=AM`, so deletion is outside the per-PR gate.
+
+Consequently, deleting or renaming a green regression file, changing an
+assertion to `.skip`/`.todo`, or losing part of collection simply removes
+identities from observation. `runVitest()` also ignores the subprocess status
+whenever a JSON report exists, so a non-zero run that emits a partial report can
+still produce a successful shard artifact. A missing identity is neither
+failing nor passing, so the merge verdict can remain green.
+
+The normal matrix does **not** hide a failed or missing shard job:
+`.github/workflows/issue-tests.yml:79-80` makes `gate` depend on the complete
+`shard` matrix. The unchecked case is a matrix whose jobs report success but
+whose downloaded artifacts are incomplete, duplicated, mislabeled, or empty;
+the merge has no expected artifact count or identity against which to compare.
+
+## Deterministic reproduction
+
+Given a baseline:
+
+```json
+{"knownFailures":["tests/deleted.test.ts :: previously known broken assertion"]}
+```
+
+and a successfully downloaded partial set containing empty `failing`,
+`passing`, and `unexpectedPasses` arrays, the normal `--update-on-decrease`
+command reports:
+
+```text
+0 failing, 0 passing, 1 known in baseline.
+No new root-suite regressions.
+```
+
+and exits **0** without changing the baseline. Previously green assertions are
+even less visible because their identities were never recorded.
+
+Positive controls remain sound: an unexpected pass exits 1, an ordinary known
+failure exits 0, and a new observed regression exits 1. This issue is the
+unprotected *loss of observation*, not those verdict paths.
+
+## Direction
+
+Carry a reviewed population contract through every shard: shard identity,
+enumerated files, assertion IDs/counts, and skipped/todo counts. Store at least
+the expected file/assertion identity set, including known-green assertions.
+Require explicit rename/removal metadata for intentional shrinkage and reject
+missing, duplicate, or wrong-identity artifacts before merging verdicts. Treat
+a non-zero Vitest subprocess as failed even if it managed to write JSON.
+
+## Acceptance criteria
+
+- [ ] Deleting or renaming a registered assertion exits non-zero and names the
+      lost identity.
+- [ ] Converting a registered assertion to `.skip` or `.todo` exits non-zero.
+- [ ] An intentional removal/rename needs explicit, reviewed metadata and
+      cannot silently broaden to unrelated tests.
+- [ ] Missing, duplicate, or wrong-identity shard artifacts are rejected.
+- [ ] A shard process that exits non-zero cannot emit a successful partial even
+      when a JSON report exists.
+- [ ] Existing positive controls for new regression, known failure, and
+      unexpected pass keep their current verdicts.
+- [ ] An unchanged full population across all expected shards exits 0.

--- a/plan/issues/5233-test262-report-mirror-missing-lane.md
+++ b/plan/issues/5233-test262-report-mirror-missing-lane.md
@@ -1,0 +1,103 @@
+---
+id: 5233
+title: "Pages deploy can silently fall back to a checkout Test262 snapshot"
+status: ready
+sprint: current
+created: 2026-08-31
+updated: 2026-08-31
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: max
+task_type: infrastructure
+area: ci, website, test262
+language_feature: n/a
+goal: conformance
+related: [1778, 2911]
+requested_by: ttraenkler/codex-sol-ultra
+---
+
+# #5233 — materialize a coherent pair of Test262 report lanes
+
+## Problem
+
+The Pages workflow tolerates a partially materialized external baseline while
+the checkout already contains committed canonical snapshots. In
+`.github/workflows/deploy-pages.yml:81-86`, baseline clone/checkout failure is
+swallowed. If the external host JSON exists, lines 87-118 enter the refresh
+block; the standalone copy at lines 113-115 is independently optional.
+
+When that standalone download is absent, the committed
+`benchmarks/results/test262-standalone-current.json` remains present. The
+synchronizer sees both of its source paths, emits no missing-lane warning, and
+copies the committed standalone snapshot beside the newly downloaded host
+snapshot. It does not prove that both inputs came from this deployment's
+external baseline materialization.
+
+The synchronizer also warns and continues when a source path is genuinely
+absent (`scripts/sync-test262-report-mirrors.mjs:29-45`), but merely requiring
+both paths to exist would not fix the Pages path because the pre-existing
+checkout file satisfies that predicate.
+
+## Reproduction and controls
+
+The direct synchronizer fixture established the underlying fail-open behavior:
+host-only input copied three host targets, left a deliberately stale standalone
+target untouched, and exited **0**.
+
+The deployment-shaped reproduction started from a checkout containing an old
+standalone canonical snapshot, materialized a fresh host snapshot while leaving
+the external standalone snapshot absent, then ran the workflow's copy/sync
+sequence. Both canonical paths existed, so all six targets were copied and the
+command exited 0; host targets came from the external baseline while standalone
+targets retained the checkout copy.
+
+Controls behaved as expected:
+
+- neither source present: non-zero;
+- both sources present: zero and all six targets byte-identical to their own
+  lane source;
+- current upstream checkout: each checked-in lane family is internally
+  byte-identical, so this is a latent provenance defect, not a claim that
+  today's mirrors are stale.
+
+The existing seven freshness tests compare present files and grep workflow
+wiring; none proves that both inputs were materialized from the external
+baseline source for the current deployment.
+
+## Impact
+
+An incomplete Pages baseline materialization can refresh one public pass-rate
+lane while silently sourcing the other from the repository checkout instead of
+the baselines repository's current lane snapshot. The synchronizer reports
+success and erases the provenance distinction.
+
+Host and standalone lanes are intentionally allowed to advance independently;
+their `baseline_sha` values need not match. The defect is fallback to the wrong
+source, not valid cross-lane epoch skew.
+
+## Direction
+
+Stage both externally sourced snapshots away from the checkout, require both to
+materialize successfully, and validate each lane's non-empty provenance before
+overwriting either canonical source or any mirror. Pass the staged paths or
+validated provenance into the synchronizer so committed fallback files cannot
+masquerade as this deployment's downloaded inputs. Preserve the workflows'
+intentional independent-lane advancement policy.
+
+If a caller intentionally supports one lane, require an explicit mode that
+removes or labels the other lane unavailable; never present an older committed
+snapshot as current.
+
+## Acceptance criteria
+
+- [ ] Pages stages and validates both external current snapshots before
+      replacing either checkout source.
+- [ ] Missing host or standalone materialization exits non-zero even when an old
+      committed canonical file remains present.
+- [ ] Absent or invalid per-lane provenance exits non-zero before copying.
+- [ ] Valid external lane snapshots may carry different `baseline_sha` values;
+      six targets are produced, each byte-identical to its own lane source.
+- [ ] A failure cannot leave a stale target described as synchronized.
+- [ ] Focused deployment-shaped tests cover missing-host, missing-standalone,
+      invalid provenance, and valid equal/different lane epochs.

--- a/plan/issues/5234-dashboard-snapshots-stale-ungated.md
+++ b/plan/issues/5234-dashboard-snapshots-stale-ungated.md
@@ -1,0 +1,84 @@
+---
+id: 5234
+title: "Checked-in dashboard issue snapshots are thousands of records stale and no required check notices"
+status: ready
+sprint: current
+created: 2026-08-31
+updated: 2026-08-31
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: max
+task_type: infrastructure
+area: dashboard, ci, planning
+language_feature: n/a
+goal: process
+related: [1616, 1656]
+requested_by: ttraenkler/codex-sol-ultra
+---
+
+# #5234 — make dashboard snapshots deterministic and enforce their ownership
+
+## Problem
+
+The tracked `website/dashboard/data/issues.json` contains **2,157** entries:
+
+```text
+43 backlog / 26 blocked / 179 ready / 23 in-progress / 0 review / 1886 done
+```
+
+Running the current generator from the same upstream source produces **4,263**
+entries:
+
+```text
+78 backlog / 52 blocked / 610 ready / 177 in-progress / 49 review / 3297 done
+```
+
+The gross drift is **+2,106 records**. Three fresh records are non-issue
+phantoms owned by reopened #1616, so even after excluding them the checked-in
+snapshot is more than two thousand canonical records behind.
+
+The generator is part of `scripts/build-planning-artifacts.mjs`. CI runs it
+only in a push-only step inside the `quality` job at
+`.github/workflows/ci.yml:599-606`, then does not compare the worktree or fail.
+The commit-back block at lines 608-625 is disabled and still names obsolete
+paths. `docs/ci-policy.md` repeats those obsolete paths and describes
+enforcement that is not active.
+
+Public Pages is partly protected because `scripts/run-pages-build.mjs`
+regenerates before deployment. The stale tracked file still affects clones,
+offline use, reviews, and any consumer that reads repository snapshots rather
+than the Pages build.
+
+## Controls
+
+The generator comparison is not universally noisy: regenerated `runs.json`
+was byte-identical at 137 entries. `sprints.json`, `issues.json`, and `data.js`
+changed. This makes ownership/determinism a per-artifact problem that can be
+tested, not a reason to leave every snapshot unenforced.
+
+## Direction
+
+Choose one explicit model:
+
+1. Track deterministic snapshots and add a required temp-output comparison;
+   source changes make it red until a reviewed regeneration lands.
+2. Stop tracking generated dashboard payloads, make every local/Pages consumer
+   generate them, and document that source files—not stale JSON—are canonical.
+
+Do not retain tracked outputs with neither a freshness gate nor a declared
+deploy-only status. Coordinate the canonical issue predicate with #1616 so the
+new check does not bank phantom records.
+
+## Acceptance criteria
+
+- [ ] The repository declares whether each dashboard payload is tracked source
+      or generated-only output.
+- [ ] For tracked outputs, a source issue add/status/remove makes a required
+      check fail and regeneration restores green.
+- [ ] Volatile timestamps are deterministic or normalized for comparison.
+- [ ] Local/offline dashboard and Pages consume the same canonical payload.
+- [ ] Documentation names current `website/dashboard/...` paths and does not
+      cite the disabled commit-back step as enforcement.
+- [ ] After #1616, dashboard issue identities equal the canonical issue scanner
+      exactly.

--- a/plan/issues/5235-changed-root-masks-unhandled-errors.md
+++ b/plan/issues/5235-changed-root-masks-unhandled-errors.md
@@ -1,0 +1,78 @@
+---
+id: 5235
+title: "Required changed-root test gate masks real unhandled rejections"
+status: ready
+sprint: current
+created: 2026-08-31
+updated: 2026-08-31
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: max
+task_type: infrastructure
+area: testing, ci
+language_feature: n/a
+goal: dogfood
+related: [3008, 3552, 4003]
+requested_by: ttraenkler/codex-sol-ultra
+---
+
+# #5235 — stop suppressing the changed-root gate's entire async-error channel
+
+## Problem
+
+`scripts/hooks/changed-root-tests.sh:74-79` documents one infrastructure
+failure it wants to tolerate: a spurious Vitest worker RPC timeout while all
+assertions pass under load (#4003). The implementation at lines 80-85 applies
+`--dangerouslyIgnoreUnhandledErrors` to every changed root test file.
+
+That flag does not classify the one RPC timeout. It disables Vitest's complete
+unhandled-rejection/uncaught-exception failure channel, including real
+application/test faults. This script is the required PR gate wired at
+`.github/workflows/ci.yml:523-540`.
+
+## Deterministic reproduction
+
+A temporary test with one green assertion plus:
+
+```js
+Promise.reject(new Error("AUDIT_SENTINEL_UNHANDLED_REJECTION"));
+```
+
+was run with the gate's pool and single-fork settings:
+
+- without the dangerous flag: 1 assertion passed, 1 unhandled rejection,
+  exit **1**;
+- with the flag: the identical rejection was printed, 1 assertion passed,
+  exit **0**.
+
+Vitest itself warns that ignored unhandled errors can make tests false-positive.
+This is the unsafe workaround for #4003, not a duplicate of #4003's RPC-timeout
+root cause.
+
+## Impact
+
+A PR can add or modify a regression test that appears green while asynchronous
+work throws after/beside its assertions. For a newly added or otherwise
+unpinned root test, this is the only required generic gate that runs that file;
+guard and explicitly pinned files can have additional owners. The log may show
+a warning, but this required-check consumer receives success.
+
+## Direction
+
+Remove the blanket flag. Fix the birpc starvation/timeout or classify only the
+exact infrastructure-only `onTaskUpdate` condition after proving that the test
+process completed faithfully. A narrow wrapper must preserve all unrelated
+unhandled errors as fatal.
+
+## Acceptance criteria
+
+- [ ] A green assertion plus a sentinel unhandled rejection exits non-zero.
+- [ ] An ordinary green file exits 0 and an ordinary failed assertion exits
+      non-zero under the changed-root command.
+- [ ] Any special treatment for the exact worker RPC timeout is narrowly
+      matched, observable, and has a positive/negative subprocess test.
+- [ ] An unrelated unhandled rejection can never satisfy required CI even when
+      its assertions are green.
+- [ ] The #4003 under-load scenario has an explicit operational resolution so
+      contributors are not pushed back toward bypassing hooks.

--- a/plan/issues/5236-jsr-tag-gate-version-lockstep.md
+++ b/plan/issues/5236-jsr-tag-gate-version-lockstep.md
@@ -1,0 +1,68 @@
+---
+id: 5236
+title: "JSR tag gate omits jsr.json version and can authorize a stale publish"
+status: ready
+sprint: current
+created: 2026-08-31
+updated: 2026-08-31
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: max
+task_type: infrastructure
+area: ci, release
+language_feature: n/a
+goal: release-pipeline
+related: [3453, 3454, 3455]
+requested_by: ttraenkler/codex-sol-ultra
+---
+
+# #5236 — verify the JSR manifest before tag-triggered publication
+
+## Problem
+
+PR #3384 completed #3454's contract: `scripts/release.mjs` now bumps and stages
+`jsr.json` with the two package manifests. The independent tag-publish gate has
+a narrower proof. In `.github/workflows/publish-npm.yml:39-60`,
+`verify-version` compares the tag with:
+
+1. root `package.json` version;
+2. proxy `package.json` version; and
+3. the proxy dependency on `@loopdive/js2`.
+
+It never reads `jsr.json.version`, although the JSR job at lines 154-190 is
+authorized by the shared gate and `deno publish` derives its version from that
+file. Current committed values match at 0.70.0. A read-only simulation with the
+first three values and tag at 0.70.0 but `jsr.json.version` at 0.69.0 passed the
+workflow's exact comparisons.
+
+The release script's post-write assertion at `scripts/release.mjs:404-414`
+likewise checks the two package versions plus the dependency but not the JSR
+manifest. The normal scripted release path is correct; this follow-up owns the
+missing independent proof before publication.
+
+## Impact
+
+A manual or partial release commit can carry a new tag while leaving only
+`jsr.json` stale. Both npm packages remain eligible to publish, and the JSR job
+can run against the old version. Because an already-published JSR version can
+exit successfully, the workflow can finish without publishing the tagged JSR
+release—the same external symptom that originally exposed #3454, through a
+different control path.
+
+## Direction
+
+Include `jsr.json.version` in the release invariant and verify it before the
+JSR job. Preserve independent-registry operation deliberately: if a JSR-only
+mismatch should not block npm, use a JSR-specific prerequisite rather than
+weakening either registry's check.
+
+## Acceptance criteria
+
+- [ ] Tag verification compares `jsr.json.version` with the tag before JSR
+      publication.
+- [ ] Root/proxy/dependency matching while only JSR differs is a failing
+      regression fixture.
+- [ ] The release script's post-write assertion proves all four version values.
+- [ ] A normal four-value lockstep fixture remains green.
+- [ ] Registry-specific gating behavior is explicit and tested.

--- a/plan/issues/68-dom-containment-scope-wasm-module.md
+++ b/plan/issues/68-dom-containment-scope-wasm-module.md
@@ -1,16 +1,23 @@
 ---
 id: 68
 title: "Issue 68: DOM containment — scope wasm module access to a subtree"
-status: done
+status: ready
 created: 2026-03-03
-updated: 2026-04-14
-completed: 2026-03-03
+updated: 2026-08-31
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: max
+task_type: bugfix
+area: runtime, host-interop
 goal: compiler-architecture
-sprint: 0
+sprint: current
+related: [593]
 ---
 # Issue 68: DOM containment — scope wasm module access to a subtree
 
-Depends on: [#67](67.md) — Closed import objects
+Depends on: [#67](67-closed-import-objects-replace-proxy.md) — Closed import
+objects
 
 ## Summary
 
@@ -102,3 +109,42 @@ capabilities outside the policy (e.g., `Document.cookie`, `Window.fetch`).
 ## Complexity
 
 M — ~250 lines in runtime.ts + new containment module
+
+## 2026-08-31 — reopened: the implemented containment contract is incomplete
+
+The Sol Ultra whole-project audit re-ran `tests/dom-containment.test.ts` on
+upstream `main`: **15/19 passed, 4/19 failed**. The failing cases are both
+above-root traversal checks plus outside-receiver mutation and property-set
+checks. That directly violates this issue's original test contract.
+
+Three implementation defects explain the result:
+
+1. `src/runtime.ts:17878-17883` uses current-realm `instanceof Node`
+   exclusively whenever global `Node` exists. Cross-realm nodes therefore
+   become "not node-like"; the structural `nodeType` fallback is never tried.
+   The current Node-less test mocks also omit `nodeType`, so receiver checks do
+   not run for them.
+2. Method wrappers at lines 17941-17955 call `self[member]` instead of the
+   already-resolved `fn`, discarding resolver behavior and creating a second,
+   divergent dispatch policy.
+3. Root-relative outward mutation is exempted by `self !== domRoot`. Methods
+   such as `remove`, `before`, `after`, `replaceWith`, and `insertAdjacent*`
+   can therefore act on the containment root itself and alter its ancestors or
+   siblings. `getRootNode` is blocked only in the property-get branch, not when
+   represented as a method.
+
+The same 123-line implementation is duplicated in
+`src/runtime-containment.ts` with zero importers. Fix the production copy and
+remove the unused duplicate under #3103 so the policy cannot drift again.
+This is a host API containment/correctness contract, not a security boundary.
+
+### Reopened acceptance criteria
+
+- [ ] The existing containment suite passes 19/19 with positive controls.
+- [ ] Same-realm, cross-realm, and structural test nodes receive identical
+      containment decisions.
+- [ ] `parentElement`/`parentNode` cannot expose an ancestor above `domRoot`.
+- [ ] Outside receivers cannot be read, written, or mutated.
+- [ ] Inward operations on the root remain allowed, while root-relative
+      outward operations cannot alter ancestors or siblings.
+- [ ] Allowed methods delegate through the resolved import function.

--- a/plan/quality-review-2026-08-31.md
+++ b/plan/quality-review-2026-08-31.md
@@ -1,0 +1,235 @@
+# Whole-project quality review — 2026-08-31
+
+Base: `upstream/main` as audited at
+`dfd3ae92da8186d1b77c9781cb8bf40c4ef62d0f`, verified as the remote tip when
+the review began. Upstream advanced by six commits during final documentation
+QA; none touched the audited findings' paths. Before PR publication, a second
+preflight at `c39de6dac8c376482b4f2cd628e445c6d8441728` (22 commits beyond the
+audit base) rechecked the changed god-file input: the total remained 39, while
+`generateModule` grew further as recorded below. The review ran from a clean,
+isolated checkout; the user's dirty development tree was not modified.
+
+Model/process: delegated **GPT-5.6 Sol, ultra-effort** lanes audited runtime
+correctness, CI/release tooling, test/harness integrity, finding
+reproduction/deduplication, and the corrected final patch. The coordinating
+lane reconciled their evidence, ran cross-checks, and filed only reproduced
+findings or measured stale debt.
+
+## Outcome
+
+Eight new issue records were reserved atomically and filed:
+
+- [#5229 — Published Node 20 support floor has no package-level compatibility proof](issues/5229-node20-supported-runtime-quality-gates.md)
+  (**medium**, compatibility/CI).
+- [#5230 — `check:issues` reports semantic generated drift but has no freshness verdict](issues/5230-issue-check-generated-drift-fail-open.md)
+  (**medium**, planning integrity).
+- [#5231 — Instantiation fallback retries modules after start-section failure, replaying initialization](issues/5231-instantiation-fallback-replays-start.md)
+  (**high**, runtime correctness).
+- [#5232 — Issue-test regression gate lets files and assertions disappear without a verdict](issues/5232-issue-test-gate-population-loss.md)
+  (**high**, regression-memory integrity).
+- [#5233 — Pages deploy can silently fall back to a checkout Test262 snapshot](issues/5233-test262-report-mirror-missing-lane.md)
+  (**medium**, published conformance data).
+- [#5234 — Checked-in dashboard issue snapshots are thousands of records stale and no required check notices](issues/5234-dashboard-snapshots-stale-ungated.md)
+  (**medium**, dashboard/planning data).
+- [#5235 — Required changed-root test gate masks real unhandled rejections](issues/5235-changed-root-masks-unhandled-errors.md)
+  (**high**, required-CI false positives).
+- [#5236 — JSR tag gate omits `jsr.json` version and can authorize a stale publish](issues/5236-jsr-tag-gate-version-lockstep.md)
+  (**high**, release integrity).
+
+Two completed issues were reopened because their own acceptance contracts are
+currently violated:
+
+- [#68 — Issue 68: DOM containment — scope wasm module access to a subtree](issues/68-dom-containment-scope-wasm-module.md):
+  containment tests are 15/19 and multiple receiver/root cases remain incorrect.
+- [#1616 — Flatten issue files into a stable location; sprint membership via frontmatter only](issues/1616-flatten-issue-files-stable-location.md):
+  three numbered records remain nested, links break, scanners disagree, and
+  dashboard discovery admits non-issues.
+
+Four existing active owners were updated rather than duplicated:
+
+- [#3103 — split the host runtime by concern](issues/3103-split-runtime-ts-host-runtime-by-concern.md):
+  `runtime.ts` is now 18,786 lines; instantiation and containment have divergent
+  sibling implementations, one unused and one imported by 40 files.
+- [#3603 — verifyProperty vacuity on both lanes](issues/3603-verifyproperty-vacuous-both-lanes.md):
+  two vector-mirror host-call paths still skip writeback when a callback throws.
+- [#3987 — Node-version-bound Test262 baseline](issues/3987-test262-baseline-node-version-bound.md):
+  the Node-25 composite default now reaches seven unique workflows.
+- [#4063 — `check:godfiles` is red but gates nothing](issues/4063-check-godfiles-red-on-main-gates-nothing.md):
+  its stale count of two regressions is now 39, so priority was raised from low
+  to medium.
+
+## Highest-risk correctness findings
+
+### Instantiation replays start-time effects — #5231
+
+`src/runtime.ts:18708-18724` catches every failure from a native-options
+instantiation and retries with the polyfill imports. A Wasm start section that
+calls a host import and then traps therefore executes twice. The streaming path
+at lines 18744-18772 can execute it three times. A minimized start-function
+probe measured exactly **2** and **3** calls; the duplicate helper in
+`src/runtime-instantiate.ts` also measured **2**.
+
+This is not a harmless compatibility retry: start sections and imports can
+mutate host state before the error. The fix must distinguish unsupported feature
+negotiation before instantiation from compile/link/start/import failures after
+execution can begin.
+
+### DOM containment contract has four failing cases — reopened #68
+
+The production wrapper at `src/runtime.ts:17838-17960` treats cross-realm nodes
+as non-nodes because it stops at current-realm `instanceof Node`; the structural
+fallback is never tried. Method wrappers do not use the resolved function and
+invoke `self[member]` directly. Root-relative outward mutation is exempted, and
+`getRootNode` is blocked only in property-get form.
+
+The committed suite currently fails four cases: both above-root traversal
+checks, outside mutation, and outside property set. Independent cross-realm and
+root-removal probes reproduced the same mechanism. This violates the host API's
+documented containment/correctness contract; it is not framed as a security
+boundary.
+
+### Abrupt host calls lose vector writes — updated #3603
+
+`src/runtime/host-call-abi.ts:43-46` and `src/runtime.ts:14077-14079` reconcile
+vector mirrors only after a normal `Reflect.apply` return. If host code mutates
+the mirror and then throws, the host view changes while the compiled vector
+does not. A sibling path already uses `finally` and documents the required
+abrupt-completion behavior, so the inconsistency and direction are concrete.
+
+## Required-gate and regression-memory findings
+
+### The required changed-root gate accepts real async faults — #5235
+
+The workaround for #4003 applies Vitest's
+`--dangerouslyIgnoreUnhandledErrors` to every changed root test. A deterministic
+fixture with one green assertion plus an unhandled rejected promise exits **1**
+under the strict runner and **0** under the required gate's flag. The log still
+prints the rejection, but CI receives success.
+
+### Root-test identities can disappear silently — #5232
+
+The post-merge gate stores only known failing assertion IDs. Observed IDs encode
+their file and assertion, but there is no expected file/assertion/skip
+population or shard identity, and the PR selector excludes deletions. A Vitest
+subprocess status is also ignored whenever JSON exists. Deleting, renaming,
+skipping, or partially collecting a previously green regression test removes it
+from both `passing` and `failing`; absence is accepted. An empty successful
+partial set against a one-entry known-failure baseline exited **0** and left the
+stale baseline unchanged. Failed matrix jobs remain red through `needs`; the
+gap is successful but incomplete/mislabeled artifact population.
+
+### Generated planning drift is observable but unenforced — #5230
+
+`update-issues --check` detects all three generated indexes as different and
+prints `would update: true`, then exits 0 because generated drift is not in its
+four structural failure classes. The semantic changes include backlog counts
+**191/45/71 → 186/41/77** and wont-fix **55 → 58**, not only a date header.
+Check mode also reports zero issue-file changes by construction, and broken-link
+discovery swallows `git ls-files` failure.
+
+The script calls `--check` an audit-only no-write mode, so #5230 explicitly asks
+the project to define separate structural and deterministic-freshness contracts
+rather than blindly failing on today's wall-clock-stamped output.
+
+### The god-file ratchet deteriorated while decorative — updated #4063
+
+`profile-godfiles --check` now reports **39** regressions. The largest is
+`ensureObjectRuntime`, **4,234 → 5,669 LOC** (+1,435). Other large growth
+includes `compileCallExpression` (+496), `emitIteratorMethodExport` (+426),
+`generateModule` (+449 at the PR preflight), and `generateMultiModule` (+387).
+No GitHub workflow invokes this check. Its original issue documented two
+violations; 37 more accumulated while main stayed permanently red and CI
+ignored it.
+
+## Release, compatibility, and published-data findings
+
+### JSR tag verification omits the JSR version — #5236
+
+`publish-npm.yml` verifies the tag against root version, proxy version, and
+proxy dependency, then authorizes JSR without reading `jsr.json.version`.
+Simulating only JSR at 0.69.0 while the other three values and tag are 0.70.0
+passes the exact comparisons. #3454 remains correctly done because the normal
+release script satisfies its acceptance contract; #5236 owns this independent
+tag-gate proof.
+
+### Published Node 20 support is not exercised as a package contract — #5229
+
+The package says Node `>=20`, while required CI uses Node 25 and has no cell that
+packs, installs, and smokes the published API/CLI at the floor. Contributor docs
+requiring Node 22+ and authoritative conformance using Node 25 are deliberately
+separate contracts under #3490/#3746. Repository-only Node 20 failures in the
+vacuity checker and unflagged guard corpus therefore motivate careful boundary
+selection but do not establish a package defect. #5229 asks for a packed-package
+smoke or an honestly raised consumer floor.
+
+### Pages can silently use a checkout Test262 fallback — #5233
+
+The Pages workflow optionally overwrites each external lane, but the checkout
+already contains both canonical files. With a fresh external host snapshot and
+the standalone download absent, the committed standalone canonical remains;
+the synchronizer sees both paths, copies all six targets, and exits 0 without
+proving both came from the external baseline materialization. A
+deployment-shaped fixture reproduced external-host plus checkout-standalone
+provenance. Host and standalone lanes may intentionally advance independently;
+the defect is the silent checkout fallback, not unequal lane epochs. Current
+checked-in mirrors match their sources, so this is not a claim that today's
+numbers are stale.
+
+### Dashboard source and snapshots disagree — #5234 and reopened #1616
+
+Tracked `website/dashboard/data/issues.json` has 2,157 entries; fresh generation
+has 4,263, a gross difference of 2,106. Public Pages regenerates and is
+mitigated, but required CI never compares or commits tracked output. Separately,
+the fresh generator's broad filename predicate admits three non-issue planning
+documents, while three real issue files remain in the legacy nested layout.
+The freshness problem and canonical-set problem have distinct issue owners.
+
+## Checks and controls
+
+Passing baseline checks on the clean audit checkout included:
+
+- Prettier format checks over `src/**/*.ts`, `tests/**/*.ts`, and
+  `scripts/**/*.ts`;
+- TypeScript 7 `typecheck`;
+- Biome at the configured error threshold;
+- the dead-export/legacy-reachability ratchet, IR-retirement, issue-ID, and
+  committed-issue-integrity checks;
+- IR dialect/kind-neutrality/layering, JsTag seam, pushRaw, LOC budget,
+  IR adoption, any-box, rollback, coercion-site, conformance-number, and
+  feature-badge checks;
+- the complete Node-24 guard manifest: 20 files, 250 passed, 4 skipped;
+- 81 focused harness/CI assertions across benchmark lifecycle, Test262 lane
+  gating, verdict completeness, report freshness, unexpected-pass protection,
+  quality fail-fast, and report building.
+
+Expected red reproductions tied to filed/updated issues:
+
+- `tests/dom-containment.test.ts`: 4 failed / 15 passed (#68);
+- `profile-godfiles --check`: 39 regressions (#4063);
+- generated issue indexes: all three differ while check exits 0 (#5230).
+
+Ancillary compatibility observations, not treated as published-package
+failures, were the official Node-20 vacuity-checker import error and the
+unflagged guard manifest's **101 failed / 149 passed / 4 skipped** result. Those
+repository-only commands define separate contracts from #5229's proposed
+packed-package smoke.
+
+Whole-tree `func-budget --all` and `oracle-ratchet --all` also report old
+baseline debt (208 function entries and 97 oracle failures respectively), but
+their required CI modes are change-scoped and existing #3400/#3273 already own
+the semantics. No duplicate issues were filed from those raw all-tree modes.
+
+## Scope and limitations
+
+The repository contains 11,729 tracked files, including roughly 5,105
+TypeScript files, 4,200 files under `tests`, 285 scripts, and 4,260 canonical
+issue records. The audit sampled every major source/tooling surface through
+parallel sweeps and ran broad static gates, but it is not a mathematical proof
+that no other defect exists.
+
+Full Test262 execution was unavailable because the audit checkout's submodules
+were intentionally uninitialized (`test262/test` contained no corpus). This is
+an environment limitation, not a filed repository defect. Release/registry
+behavior was inspected and simulated read-only; no packages were published.
+No product-code fix was attempted because the requested deliverable was a
+review, summary, and issue records.


### PR DESCRIPTION
## Summary

- add a Sol Ultra whole-project quality review
- file 8 verified issues: #5229–#5236
- reopen #68 and #1616 because their acceptance contracts remain violated
- update existing owners #3103, #3603, #3987, and #4063 instead of filing duplicates
- make no product-code changes

## Highest-risk findings

- Wasm instantiation fallback can replay start-section effects twice, or three times through the streaming path
- DOM containment still fails 4 of 19 committed tests
- the required changed-root gate accepts real unhandled rejections
- the post-merge issue-test gate cannot detect lost files/assertions or incomplete successful shard populations
- JSR tag verification omits `jsr.json.version`
- generated planning indexes, dashboard snapshots, and Test262 Pages inputs have unenforced freshness/provenance gaps
- `check:godfiles` has deteriorated from 2 to 39 regressions while remaining outside CI

## Validation

Passing audit and publication checks included:

- Prettier over source, tests, scripts, and all changed Markdown
- TypeScript 7 typecheck and Biome at the configured error threshold
- issue-ID collision checks and committed-tree integrity over 4,269 issue records
- dead-export/legacy-reachability, IR, LOC, oracle, coercion, conformance-number, and feature-badge gates
- complete Node 24 guard manifest: 250 passed, 4 skipped
- 81 focused harness/CI assertions
- pre-push numeric-local IR parity: 18 passed
- `git diff --check`

Expected red reproductions retained as evidence:

- DOM containment: 4 failed / 15 passed
- god-file ratchet: 39 regressions
- all three generated issue indexes drift while `--check` exits 0

## Audit provenance

The audit began from clean `upstream/main` at `dfd3ae92da8186d1b77c9781cb8bf40c4ef62d0f`. Before publication, the branch was rebased onto current main at `c39de6dac8c376482b4f2cd628e445c6d8441728` and the changed god-file input was rechecked: the total remains 39 regressions, with `generateModule` now measured at +449 LOC over its baseline.

## Limitation

Full Test262 execution was unavailable because the isolated audit checkout intentionally left the Test262 submodules uninitialized. Release behavior was inspected and simulated read-only; no packages were published.
