### PR TITLE
docs(issues): file #5249–#5251 — Temporal residual families from the #5248 sample census

### DIFF
--- a/plan/issues/5249-temporal-adjustcalendardate-unreachable.md
+++ b/plan/issues/5249-temporal-adjustcalendardate-unreachable.md
@@ -1,0 +1,63 @@
+---
+id: 5249
+title: "Compiled Temporal polyfill traps `RuntimeError: unreachable` in HelperBase_adjustCalendarDate — largest residual family after provider wiring (123 of 838 sampled rows)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-08-31
+---
+
+# #5249 — `unreachable` in `HelperBase_adjustCalendarDate()` (Temporal residual, top family)
+
+## Problem
+
+With the test262 runner wired to the compile-once Temporal provider (#5248 /
+PR #5375), the single largest residual failure family in the 838-row sampled
+Temporal bucket is **123 rows** failing with
+`RuntimeError: unreachable in HelperBase_adjustCalendarDate()`.
+
+The polyfill's calendar arithmetic (`@js-temporal/polyfill@0.5.1`,
+`HelperBase.adjustCalendarDate` and its callers) hits a compiled `unreachable`
+trap — i.e. js2wasm lowered some reachable path in that function to an
+`unreachable` instruction (typical causes: an unhandled expression/statement
+shape demoted to a trap, an exhaustiveness fallthrough, or a cast ladder with
+no fallback arm). The trap fires on non-ISO calendar operations broadly, so
+the family spans `intl402/Temporal/**` (calendar-sensitive `from`, `add`,
+`until`, `with` rows).
+
+## Evidence and bounds
+
+- Counts come from dev-5248b's sample census (838 rows, two agreeing runs,
+  provider built cold in-tree — see PR #5375's measurement section and
+  `.tmp/` artifacts in worktree `agent-a316c90e14c5ca605`).
+- **Sample census only — no bucket-wide count is claimed**; the sample is not
+  proportional. The family is the top residual by a wide margin (next:
+  74× ZonedDateTime_init destructure-null, #5221/#5243 family).
+
+## Direction
+
+1. Reduce: compile the polyfill, call a non-ISO calendar op
+   (e.g. `Temporal.PlainDate.from({calendar:"hebrew", ...})` or an ISO row
+   that routes through `adjustCalendarDate`) and capture the trap.
+2. Find which construct inside `adjustCalendarDate` lowers to `unreachable`
+   (disassemble the provider around the trap, or bisect the function's source
+   shapes in a probe compile).
+3. Fix the codegen gap; a hard compile error is acceptable over a silent
+   trap if the shape is genuinely unsupported — but the goal is to run it.
+
+## Acceptance criteria
+
+1. A base-failing reduction pinning the trap; fixed to spec behaviour.
+2. Measured on the same sampled bucket: the 123-row family shrinks
+   substantially (state the new count); no regressions in the
+   issue-5221…5248 provider family; gates green.
+
+## Notes
+
+- Filed from PR #5375's residual worklist (dev-5248b census).
+- Id reserved with a degraded open-PR scan (gh unreachable from the
+  container); manually checked against open PR head branches 2026-08-31.

--- a/plan/issues/5250-temporal-error-semantics-mismatches.md
+++ b/plan/issues/5250-temporal-error-semantics-mismatches.md
@@ -1,0 +1,55 @@
+---
+id: 5250
+title: "Compiled Temporal throws the wrong error where node's polyfill matches spec: PlainYearMonth.until missing-args RangeError (spec: TypeError) and non-ISO yearOfWeek RangeError (spec: undefined)"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+goal: error-model
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-08-31
+---
+
+# #5250 — Temporal error-semantics mismatches vs the same polyfill in node
+
+## Problem
+
+Two small families where the COMPILED `@js-temporal/polyfill@0.5.1` diverges
+from the SAME pinned polyfill running natively in node — so the defect is
+ours, by measurement (dev-5248b probed both against node during #5248 triage):
+
+1. **`Temporal.PlainYearMonth.prototype.until()` with missing arguments**
+   throws **RangeError** compiled; node throws
+   `TypeError: Either month or monthCode are required`. Test262
+   `…/PlainYearMonth/prototype/until/arguments-missing-throws` asserts
+   TypeError.
+2. **`yearOfWeek`/week-of-year on non-ISO calendars** throws
+   `RangeError: Invalid ISO date` compiled; node returns **`undefined`** for
+   every non-ISO calendar (`intl402/…/yearOfWeek/non-iso-week-of-year`).
+
+Both surfaced as "regressions" in PR #5375's 838-row sample — they were
+wrong-reason passes before the provider existed (a bogus object's method call
+happened to satisfy `assert.throws`), and are now honest failures.
+
+## Direction
+
+Likely one root each: (1) an error-construction path where the compiled
+polyfill's argument-shape check falls into a range-check branch — probe which
+check misfires (plausibly the same undefined-vs-missing-property distinction
+as the #5221/#5243 record-nulling family); (2) a calendar-dispatch path where
+the non-ISO branch is not taken compiled, so the ISO validator runs instead.
+
+## Acceptance criteria
+
+1. Base-failing reductions for both (compiled vs node on the pinned
+   polyfill); fixed so compiled matches node.
+2. The two named test262 rows pass with the provider linked
+   (`JS2WASM_TEST262_TEMPORAL` lane); no provider-family regressions; gates
+   green.
+
+## Notes
+
+- Filed from PR #5375's regression-triage table (dev-5248b).
+- Id reserved with a degraded open-PR scan; manually checked against open PR
+  head branches 2026-08-31.

--- a/plan/issues/5251-temporal-numeric-calendar-seam-families.md
+++ b/plan/issues/5251-temporal-numeric-calendar-seam-families.md
@@ -1,0 +1,56 @@
+---
+id: 5251
+title: "Temporal residual numeric/calendar seam families: 'invalid number value' (43), HebrewHelper illegal cast (29), JSBI toNumber seam (11), year/eraYear-required (10) — sampled census"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+goal: core-semantics
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-08-31
+---
+
+# #5251 — Temporal residual numeric/calendar seam families (sampled census)
+
+## Problem
+
+After the #5248 runner wiring (PR #5375), dev-5248b's 838-row sample census
+leaves four mid-size failure families beyond #5249 (adjustCalendarDate trap)
+and the already-filed #5221/#5243 (destructure-null, 74) and #5223-adjacent
+`invalid receiver` (51) families:
+
+| sampled rows | error shape | first suspicion |
+| --- | --- | --- |
+| 43 | `invalid number value` | a numeric coercion at a provider seam produces a value the polyfill's own validator rejects (NaN/undefined where an integer is expected) |
+| 29 | `HebrewHelper` illegal cast (`ref.cast` failure) | non-ISO calendar helper subclass object crosses a seam and loses its concrete struct type |
+| 11 | JSBI `toNumber` seam | the compiled polyfill's BigInt shim (`jsbi@4.3.0`) mis-converts at a linked-module boundary |
+| 10 | `year/eraYear is required` | era/eraYear property reads return undefined on objects that carry them — likely the #5225 decoder-provenance family's write/read twin (#5246 covers write paths) |
+
+## Bounds
+
+- **Sample census only** (838 rows, not proportional to the full ~1,589-row
+  bucket) — counts order the work, they are not bucket-wide claims.
+- The four families may collapse into fewer roots (all four smell like
+  provider-seam value/type fidelity, the #5225/#5243/#5246 lineage). Probe
+  before splitting: a fix PR should re-measure the sampled bucket and report
+  which families moved.
+
+## Direction
+
+Start with one probe per family (3-line compiled repro against the linked
+provider, node-on-polyfill as control, per the #5226/#5248 method). If a
+family reduces to an already-filed issue, note it there and drop it here.
+
+## Acceptance criteria
+
+1. Each family either (a) reduced + fixed with a base-failing test, or
+   (b) attributed to an existing filed issue with the probe as evidence.
+2. Sampled-bucket re-measurement reporting per-family deltas; no
+   provider-family regressions; gates green.
+
+## Notes
+
+- Filed from PR #5375's residual worklist (dev-5248b census).
+- Id reserved with a degraded open-PR scan; manually checked against open PR
+  head branches 2026-08-31.


### PR DESCRIPTION
Files three follow-up issues from dev-5248b's 838-row sampled Temporal bucket, measured after the test262 runner wiring (PR #5375):

- [#5249](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5249-temporal-adjustcalendardate-unreachable) — `RuntimeError: unreachable in HelperBase_adjustCalendarDate()`, the top residual family (123 sampled rows).
- [#5250](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5250-temporal-error-semantics-mismatches) — compiled polyfill throws the wrong error where node on the same pinned polyfill matches spec (`PlainYearMonth.until` missing-args, non-ISO `yearOfWeek`). Both were wrong-reason passes before the provider existed.
- [#5251](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5251-temporal-numeric-calendar-seam-families) — four mid-size numeric/calendar seam families (invalid number value 43, HebrewHelper cast 29, JSBI toNumber 11, year/eraYear-required 10), with the probe-first, may-collapse-into-existing-issues caveat.

All counts are from a **sample census** (838 rows, not proportional) — the files state that bound explicitly; no bucket-wide totals are claimed. Ids 5249–5251 were reserved via `claim-issue.mjs --allocate` with a degraded open-PR scan (gh unreachable from the container); each file records the manual open-PR check.

Docs-only: three new files under `plan/issues/`, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_