### PR TITLE
feat(ir): prepare fast host string signatures

### DIFF
--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -3,7 +3,7 @@ id: 3521
 title: "IR-only R2: prepare-before-emit free-function ownership"
 status: in-progress
 created: 2026-07-21
-updated: 2026-08-30
+updated: 2026-09-01
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -3010,3 +3010,31 @@ per-terminal reconciliation.
   - TypeScript 7, changed-file Biome lint and Prettier check, `git diff --check`,
     IR layering/dialect/kind-neutrality/fallback/IR-only readiness, adoption,
     optimization-retirement, oracle, and LOC/function budget gates: passed.
+
+## 2026-09-01 — fast JS-host pass-through string-signature checkpoint
+
+Status: bounded production checkpoint only; this tracker remains in-progress.
+
+The separate r2FastJsHostPassThroughStringSignature admission adds only the
+normalized JS-host lane: !ctx.nativeStrings && !ctx.standalone && !ctx.wasi &&
+!ctx.strictNoHostImports. It requires one top-level named function with
+required identifier parameters, explicit string annotations at every parameter
+and result position, no generic/async/generator/default/rest/optional/
+destructured form, and a constructed all-IrType.string override that still
+equals the exact allocated Program ABI slot. The existing fast scalar admission
+is unchanged. Native strings, standalone, WASI, strict no-host imports, and
+defaulted string parameters retain their direct or existing post-direct route.
+
+Focused evidence: tests/issue-3521-prepared-free-function-routing.test.ts
+passed 46/46 with VITEST_FORK_MAX_OLD_SPACE_SIZE=4096. The poisoned fast
+JS-host echo(value: string): string route returned its original string with
+irFirstSkipped, a UnitId and prepared-component identity, and exact post-#5313
+accounting (prepareAttempts, directBodyEmissions, irBodyEmissions) = (1, 0, 1).
+Four isolated excluded-lane controls reached the poisoned direct emitter. The
+unpoisoned native-string control records directBodyEmissions=1 without
+pre-body skip ownership (its established late-overlay patch remains (1,1,1)),
+and the defaulted-string boundary remains direct. Existing standalone and
+native-string routing coverage ran in the same focused suite.
+
+This does not broaden general string admission or complete the overall R2
+prepare-before-emit migration.

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -793,6 +793,56 @@ function r2FastPreparedScalarFunctionSignature(
 }
 
 /**
+ * Fast mode normally selects native strings, but an explicit nativeStrings:
+ * false keeps the JS-host externref string ABI. Its only added
+ * prepare-before-direct admission is an annotation-fixed pass-through
+ * signature whose constructed IR string contract still equals the allocated
+ * callable slot.
+ */
+function r2FastJsHostPassThroughStringSignature(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  unitId: IrUnitId,
+  claim: IrExactFunctionClaim,
+  override: { readonly params: readonly IrType[]; readonly returnType: IrType | null },
+): boolean {
+  const declaration = claim.declaration;
+  const preparedOverride: { readonly params: readonly IrType[]; readonly returnType: IrType } = {
+    params: declaration.parameters.map(() => ({ kind: "string" })),
+    returnType: { kind: "string" },
+  };
+  const exactJsHostLane = !ctx.nativeStrings && !ctx.standalone && !ctx.wasi && !ctx.strictNoHostImports;
+
+  if (
+    !exactJsHostLane ||
+    !declaration.name ||
+    !ts.isIdentifier(declaration.name) ||
+    declaration.name.text !== claim.legacyName ||
+    declaration.parent !== sourceFile ||
+    !sourceFile.statements.some((statement) => statement === declaration) ||
+    !declaration.body ||
+    (declaration.typeParameters?.length ?? 0) !== 0 ||
+    declaration.asteriskToken !== undefined ||
+    declaration.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) ||
+    declaration.type?.kind !== ts.SyntaxKind.StringKeyword ||
+    declaration.parameters.length !== override.params.length ||
+    !declaration.parameters.every(
+      (parameter) =>
+        ts.isIdentifier(parameter.name) &&
+        parameter.questionToken === undefined &&
+        parameter.dotDotDotToken === undefined &&
+        parameter.initializer === undefined &&
+        parameter.type?.kind === ts.SyntaxKind.StringKeyword,
+    ) ||
+    !override.params.every((type) => type.kind === "string") ||
+    override.returnType?.kind !== "string"
+  ) {
+    return false;
+  }
+  return r2SignatureMatchesAllocatedSlot(ctx, unitId, preparedOverride);
+}
+
+/**
  * (#4514) The narrow value vocabulary whose physical carrier is fixed by the
  * declaration alone, with no decision the prepared component could re-plan:
  * `void`, `f64`/`i32` scalars, `string` (one `nativeStrings`-keyed carrier both
@@ -1268,7 +1318,10 @@ export function selectR2PreparedOwnerComponents(input: {
     const signatureOptions = isGenerator ? { allowOpaqueExternrefValue: true } : undefined;
     if (
       (input.ctx.fast &&
-        !r2FastPreparedScalarFunctionSignature(input.ctx, input.sourceFile, unitId, claim, override)) ||
+        !(
+          r2FastPreparedScalarFunctionSignature(input.ctx, input.sourceFile, unitId, claim, override) ||
+          r2FastJsHostPassThroughStringSignature(input.ctx, input.sourceFile, unitId, claim, override)
+        )) ||
       isAsync ||
       (isGenerator && !generatorsPreparable(input.ctx)) ||
       containsUnplannedNestedExecutableSyntax(

--- a/tests/issue-3521-prepared-free-function-routing.test.ts
+++ b/tests/issue-3521-prepared-free-function-routing.test.ts
@@ -603,6 +603,116 @@ describe("#3521 prepare-before-emit free-function routing", () => {
     );
   });
 
+  it("prepares a fast JS-host string pass-through before direct emission", async () => {
+    const source = "export function echo(value: string): string { return value; }";
+    const result = await compileWithPoisonedDirectFunctionBodies(source, "echo", {
+      fileName: "prepared-fast-host-string.ts",
+      experimentalIR: true,
+      fast: true,
+      nativeStrings: false,
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irFirstSkipped).toContain("echo");
+    const echoOutcome = outcome(result, "echo");
+    expect(echoOutcome.unitId).toBeDefined();
+    expect(echoOutcome).toMatchObject({
+      kind: "emitted",
+      prepareAttempts: 1,
+      directBodyEmissions: 0,
+      irBodyEmissions: 1,
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect((await instantiate(result)).echo!("prepared host string")).toBe("prepared host string");
+  });
+
+  it("keeps fast string pass-through signatures direct in every excluded lane", async () => {
+    const source = "export function echo(value: string): string { return value; }";
+    const excludedLanes = [
+      ["nativeStrings", { nativeStrings: true }],
+      ["standalone", { target: "standalone", nativeStrings: false }],
+      ["wasi", { target: "wasi", nativeStrings: false, strictNoHostImports: false }],
+      ["strictNoHostImports", { strictNoHostImports: true, nativeStrings: false }],
+    ] as const;
+
+    for (const [lane, laneOptions] of excludedLanes) {
+      const result = await compileWithPoisonedDirectFunctionBodies(source, "echo", {
+        fileName: "prepared-fast-host-string-excluded-" + lane + ".ts",
+        experimentalIR: true,
+        fast: true,
+        trackIrOutcomes: true,
+        ...laneOptions,
+      });
+      expect(result.success, lane).toBe(false);
+      expect(result.errors.map((error) => error.message).join("\n"), lane).toContain(
+        "injected direct function-body poison: echo",
+      );
+    }
+  });
+
+  it("accounts an unpoisoned fast native-string pass-through as direct with no prepared owner", async () => {
+    const result = await compile("export function echo(value: string): string { return value; }", {
+      fileName: "prepared-fast-native-string-direct.ts",
+      experimentalIR: true,
+      fast: true,
+      nativeStrings: true,
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irFirstSkipped ?? []).not.toContain("echo");
+    const echoOutcome = outcome(result, "echo");
+    expect(echoOutcome).toMatchObject({
+      kind: "emitted",
+      stage: "patch",
+      prepareAttempts: 1,
+      directBodyEmissions: 1,
+      irBodyEmissions: 1,
+      legacyBodyEmitted: true,
+      irBodyEmitted: true,
+    });
+  });
+
+  it("keeps a defaulted fast JS-host string parameter on the direct route", async () => {
+    const source = 'export function defaultEcho(value: string = "fallback"): string { return value; }';
+    const result = await compile(source, {
+      fileName: "prepared-fast-host-string-default.ts",
+      experimentalIR: true,
+      fast: true,
+      nativeStrings: false,
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irFirstSkipped ?? []).not.toContain("defaultEcho");
+    const defaultOutcome = outcome(result, "defaultEcho");
+    expect(defaultOutcome).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      prepareAttempts: 1,
+      directBodyEmissions: 1,
+      irBodyEmissions: 0,
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(defaultOutcome.preparedComponentId).toBeUndefined();
+
+    const poisoned = await compileWithPoisonedDirectFunctionBodies(source, "defaultEcho", {
+      fileName: "prepared-fast-host-string-default-poisoned.ts",
+      experimentalIR: true,
+      fast: true,
+      nativeStrings: false,
+      trackIrOutcomes: true,
+    });
+    expect(poisoned.success).toBe(false);
+    expect(poisoned.errors.map((error) => error.message).join("\n")).toContain(
+      "injected direct function-body poison: defaultEcho",
+    );
+  });
+
   // The same scalar proof must close a mixed f64/i32 component before the
   // direct loop; poisoning both bodies catches a hidden patch-after-direct.
   it("prepares fast boolean callers with a numeric callee before direct emission", async () => {


### PR DESCRIPTION
## Summary

- admit exact all-string fast JS-host signatures into prepare-before-direct routing
- preserve direct/post-direct routing for native strings and every host-free lane
- prove exact `(1,0,1)` body accounting plus conservative boundary controls

## Validation

- 46/46 focused #3521 routing tests
- TypeScript 7, Biome, and Prettier
- IR layering, dialect, kind-neutrality, fallback, IR-only, adoption, and optimization-retirement gates
- LOC/function budgets, ratchets, and issue integrity
