### PR TITLE
release: v0.71.0

### DIFF
--- a/docs/release-notes/v0.71.0.md
+++ b/docs/release-notes/v0.71.0.md
@@ -1,0 +1,83 @@
+# v0.71.0
+
+Lockstep release of `@loopdive/js2` and the `js2wasm` proxy: 0.70.0 → 0.71.0.
+
+A minor release with no declared breaking changes.
+
+## Conformance
+
+For a like-for-like comparison, the full test262 corpus stayed fixed at 48,735
+tests:
+
+| target | v0.70.0 | v0.71.0 snapshot | change |
+| --- | ---: | ---: | ---: |
+| JS-host (`gc`) | 33,432 / 48,735 (68.6%) | **35,244 / 48,735 (72.3%)** | **+1,812, +3.7 pp** |
+| standalone (pure Wasm) | 31,614 / 48,735 (64.9%) | **33,922 / 48,735 (69.6%)** | **+2,308, +4.7 pp** |
+
+The standalone edition snapshots show the main compatibility campaign directly:
+
+| edition | v0.70.0 | v0.71.0 snapshot | change |
+| --- | ---: | ---: | ---: |
+| ES5 | 8,506 / 9,029 (94.21%) | **8,940 / 9,029 (99.01%)** | **+434** |
+| ES2015 | 8,103 / 11,704 (69.23%) | **9,025 / 11,704 (77.11%)** | **+922** |
+
+The standard-plus-Annex-B view is now **35,008 / 48,232 (72.6%)** for
+JS-host and **33,687 / 48,232 (69.8%)** for standalone. Its v0.70.0
+denominator was 43,621: 4,611 Temporal tests moved from proposal scope into
+ES2026 standard scope, so that raw delta is not a like-for-like comparison.
+
+These figures come from the latest committed snapshots in the release range:
+the v0.70.0 artifact is anchored at `111a3794`, and the v0.71.0 snapshot at
+`35d7edf5`. The latter predates the final release head, so the numbers do not
+claim to measure changes after that snapshot.
+
+## Highlights
+
+**Standalone JavaScript semantics** — the ES5 and ES2015 campaigns advanced
+arrays, iterators and `for-of`, destructuring, classes and `super`,
+Proxy/Reflect, TypedArray/DataView, collections, Promise, RegExp,
+`eval`/`Function`/`with`, and Annex B behavior.
+
+**Static npm package linking** — `compileProject` can now compile supported bare
+package imports as content-addressed Wasm providers, follow export barrels and
+cross-package graphs, preserve value/class/namespace boundaries, cache
+providers, and optionally merge safe providers into a static bundle.
+Unsupported boundaries retain an explicit monolithic fallback. The same
+provider substrate supports a real `Temporal` global through a compile-once
+polyfill.
+
+**Deno integration** — a runnable compile-on-import loader now turns ordinary
+TypeScript modules into callable Wasm exports under Deno. The compatibility
+probe also boots the unchanged `deno_core` wrapper graph through linked runtime
+modules and real Rust callbacks; this is bounded bootstrap support, not a claim
+of complete Deno API compatibility.
+
+**Compiler core** — validated Prepared IR now owns more multi-source callable
+graphs, module initialization, typed fields, loops, conditional joins, and
+async runtime boundaries, with new ratchets preventing silent fallback to
+legacy paths.
+
+**Real-world validation** — the TypeScript 5.9.3 parser graph now compiles to
+valid Wasm, while runtime parity remains incomplete and tracked. Original
+upstream npm suites expanded across React/ReactDOM, Jest, ESLint, Redux, and
+TypeScript; the UUID suite moved from 10/75 to 75/75.
+
+**Experimental linear backend** — the boxed QuickJS tier gained
+ownership-aware handle cleanup and an optional coalescing `malloc-v1`
+allocator. The existing bump allocator remains the default. Binaryen was
+upgraded to 132.
+
+## Detail
+
+No `!:` subject or `BREAKING CHANGE` trailer appears in the release range.
+
+For the complete list, see the compare view:
+<https://github.com/loopdive/js2/compare/v0.70.0...v0.71.0>
+
+## Install
+
+```bash
+npm install @loopdive/js2@0.71.0
+# or the unscoped proxy
+npm install js2wasm@0.71.0
+```

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.70.0"
+    "@loopdive/js2": "0.71.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
## Description

Lockstep version bump from 0.70.0 to **0.71.0** across `@loopdive/js2`,
the `js2wasm` proxy and its canonical-package dependency, and `jsr.json`, plus
curated release notes. The release was cut with `node scripts/release.mjs
0.71.0` from a clean worktree at `origin/main`; the `v0.71.0` tag remains local
and deliberately unpushed until this PR merges.

### Why minor

This release includes substantial new capability without a declared breaking
change. No `!:` subject or `BREAKING CHANGE` trailer appears in the release
range.

### Conformance snapshot

On the stable 48,735-test full corpus:

- JS-host: 33,432 → 35,244 passing (**+1,812**)
- standalone: 31,614 → 33,922 passing (**+2,308**)
- standalone ES5: 8,506 / 9,029 → 8,940 / 9,029 (**+434**)
- standalone ES2015: 8,103 / 11,704 → 9,025 / 11,704 (**+922**)

The standard-plus-Annex-B denominator changed from 43,621 to 48,232 when 4,611
Temporal tests moved from proposal scope into ES2026 standard scope, so the
release notes do not present that raw delta as like-for-like. They also state
that the latest committed baseline (`35d7edf5`) predates the final release
head.

### What's in the diff

| file | change |
| --- | --- |
| `package.json` | 0.70.0 → 0.71.0 |
| `packages/js2wasm/package.json` | version and `@loopdive/js2` dependency pin → 0.71.0 |
| `jsr.json` | 0.70.0 → 0.71.0 |
| `docs/release-notes/v0.71.0.md` | curated release notes |

Full comparison:
<https://github.com/loopdive/js2/compare/v0.70.0...v0.71.0>

## Validation

- [x] `pnpm exec vitest run tests/manifest-version-only.test.ts tests/release-notes-summary.test.ts --reporter=dot` — 34 passed
- [x] `pnpm exec prettier --check package.json jsr.json packages/js2wasm/package.json docs/release-notes/v0.71.0.md`
- [x] `pnpm run check:loc-budget`
- [x] `pnpm run check:func-budget`
- [x] `git diff --check`
- [x] all four publish-version carriers equal exactly `0.71.0`

## Merging and publishing

This PR lands the versioned snapshot only. After merge, the release operator
will verify that the tag target is reachable from canonical `main`, push the
explicit `refs/tags/v0.71.0:refs/tags/v0.71.0` refspec, wait for the npm, JSR,
and GitHub Release jobs, replace generated notes with the curated file, and
verify the registry records.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unticked: this is a personal legal affirmation. Internal/org-member PRs skip the check automatically. -->
