### PR TITLE
fix(proxy): return undefined from standalone revokers

### DIFF
--- a/plan/issues/5196-es2015-standalone-proxy-r2.md
+++ b/plan/issues/5196-es2015-standalone-proxy-r2.md
@@ -1,10 +1,10 @@
 ---
 id: 5196
 title: "ES2015 standalone proxy — r2 residual pass"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-08-29
+updated: 2026-09-01
 priority: medium
 horizon: m
 feasibility: medium
@@ -13,6 +13,8 @@ area: codegen
 es_edition: ES2015
 goal: standalone-mode
 requested_by: claude/fable-es2015
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
 ---
 
 # #5196 — proxy r2: cluster and fix the residual proxy-bucket failures
@@ -21,27 +23,179 @@ requested_by: claude/fable-es2015
 
 State after the 2026-08-29 session: wave 1 (#5140, part of PR #5173) plus the
 strongest second pass of the batch (+66, PR #5213 — evolved §7.3.9
-trap-callable guard, unified non-constructor meta-statics). Residual count on
-current main not re-measured; the wave-8 planning pass was stopped.
+trap-callable guard, unified non-constructor meta-statics). This r2 lane starts
+from the forced fresh `f841cddc0f0ea665b63700d9944a4372a34a8b57` baseline,
+not from the older planning snapshot.
+
+## Provenance and active-owner gate
+
+- Authoritative standalone snapshot:
+  `/private/tmp/js2-baseline-census-f841cddc-r1/.test262-cache/test262-standalone-current.jsonl`,
+  48,735 JSONL records, timestamped `1.9.2026, 02:03:18` onward and carrying
+  `oracle_version: 13`, `oracle_lane: honest`. The forced artifact is from
+  immutable `loopdive/js2wasm-baselines`
+  `8a39bd1d4ddf200f8db3751c878ece02aa8688fe` and has SHA-256
+  `4426cbf6f305ab4a092468b201cc5854d4470b5fe87edf2fe47ba0195a6e8cbf`.
+- Edition source: `website/public/benchmarks/results/test262-file-editions.json`.
+  Its `editions[6]` is `ES2015`; the query strips the baseline's `test/`
+  prefix before looking up `files[path] === 6`.
+- Fresh exact cohort: 310 `test/built-ins/Proxy/**` ES2015 records — 182 pass,
+  115 fail, and 13 compile errors. The exact non-pass path set is the 128
+  rows selected by the reproducible path/status query below; it excludes all
+  non-ES2015 rows and no `pass` row.
+- Active-owner check on 2026-09-01: `origin/issue-assignments` contains only
+  `81b48a9e830ed2b7350c32d3740dca699c7ef8b4` (`chore(assign): reserve #5196`)
+  with `status: "reserved"`, blank assignee, and blank branch; the local
+  `upstream/issue-assignments` ref has no #5196 record. This is an unassigned
+  reservation rather than a live conflicting owner.
+
+```sh
+rg '\"file\":\"test/built-ins/Proxy/' \
+  /private/tmp/js2-baseline-census-f841cddc-r1/.test262-cache/test262-standalone-current.jsonl \
+  | jq --slurpfile editions website/public/benchmarks/results/test262-file-editions.json \
+      -r '(.file | ltrimstr("test/")) as $path
+          | select($editions[0].files[$path] == 6 and .status != "pass")
+          | [.file, .status, (.error // "")] | @tsv'
+```
+
+## Exact status/error inventory
+
+The operation table is an exact partition of the 128 selected non-pass paths.
+All omitted Proxy subtrees have zero selected rows.
+
+| Proxy subtree | compile_error | fail |
+| --- | ---: | ---: |
+| apply | 1 | 5 |
+| construct | 8 | 10 |
+| defineProperty | 0 | 19 |
+| deleteProperty | 0 | 5 |
+| enumerate | 1 | 0 |
+| function-prototype.js | 0 | 1 |
+| get | 0 | 7 |
+| get-fn-realm*.js | 2 | 0 |
+| getOwnPropertyDescriptor | 1 | 13 |
+| getPrototypeOf | 0 | 4 |
+| has | 0 | 13 |
+| isExtensible | 0 | 1 |
+| ownKeys | 0 | 7 |
+| preventExtensions | 0 | 4 |
+| revocable | 0 | 7 |
+| set | 0 | 13 |
+| setPrototypeOf | 0 | 6 |
+| **Total** | **13** | **115** |
+
+The following is an exact first-stop-signature histogram, not a causal
+classification. Shared error text only identifies where a row stopped; it does
+not establish that those rows share a repair.
+
+| status | observed first-stop signature | rows | representative exact paths |
+| --- | --- | ---: | --- |
+| fail | `Expected a TypeError ... no exception was thrown` | 50 | `construct/return-not-object-throws-undefined-realm.js`; `ownKeys/trap-is-not-callable-realm.js` |
+| fail | `Expected true but got false` | 5 | `set/return-true-target-property-is-not-configurable.js`; `has/trap-is-undefined-target-is-proxy.js` |
+| fail | `Thrown value was not an object!` | 4 | `defineProperty/targetdesc-not-compatible-descriptor-realm.js` |
+| fail | handler receiver/context mismatch | 6 | `has/call-in-prototype.js`; `set/call-parameters-prototype.js` |
+| fail | `Proxy.revocable is not yet implemented ...` | 3 | `apply/null-handler-realm.js`; `construct/null-handler-realm.js` |
+| fail | `0 should be an own property` | 2 | `getOwnPropertyDescriptor/trap-is-undefined-target-is-proxy.js`; `.../trap-is-missing-target-is-proxy.js` |
+| fail | object-versus-`undefined` SameValue mismatch | 2 | `deleteProperty/trap-is-undefined-not-strict.js`; `...-strict.js` |
+| fail | `null` versus `undefined` SameValue mismatch | 2 | `revocable/revoke-returns-undefined.js`; `.../revoke-consecutive-call-returns-undefined.js` |
+| fail | remaining paired signatures (each distinct) | 6 | false-result invariants, `TypeError` versus `ReferenceError`, and nullish property reads |
+| fail | singleton first-stop signatures | 35 | descriptor, trap, target, realm, and carrier rows listed by the query above |
+| compile_error | distinct-NewTarget `Reflect.construct` refusal (#3371) | 10 | `construct/call-parameters-new-target.js`; `get-fn-realm.js` |
+| compile_error | dynamic-shape gOPD refusal (#1472) | 1 | `getOwnPropertyDescriptor/null-handler.js` |
+| compile_error | non-array `values()` refusal (#1320) | 1 | `enumerate/removed-does-not-trigger.js` |
+| compile_error | generated host imports (#2961) | 1 | `apply/trap-is-undefined-target-is-proxy.js` |
+
+The 35 singleton count plus the grouped rows above totals 115 fails. The
+signature table intentionally leaves the broad 50-row TypeError group
+unclaimed; it is not evidence for one Proxy implementation change.
+
+## Representative maintained-runner evidence
+
+`node --import tsx scripts/run-test262-paths.mts
+/private/tmp/issue-5196-proxy-representatives.txt --standalone --isolate`
+ran the repository's `runTest262File` path in fresh child processes. It
+reported `2 fail, 1 pass`:
+
+- `built-ins/Proxy/revocable/revoke-returns-undefined.js` — fail at
+  `assert.sameValue(r.revoke(), undefined)`, observed `null`.
+- `built-ins/Proxy/revocable/revoke-consecutive-call-returns-undefined.js` —
+  fail at its second `r.revoke()` assertion, observed `null`.
+- `built-ins/Proxy/revocable/revoke.js` — pass; the same result record exposes
+  a callable `revoke` field.
+
+This validates both a current failing pair and a current passing control through
+the maintained standalone runner, rather than inferring behavior from the
+baseline alone.
+
+## Narrow causal slice: revoker return value
+
+The two selected rows are independently causal, not selected because their
+error strings match. Both call the `__proxy_revoker` carrier through the one
+Proxy-specific branch in `fillApplyClosure` in
+`src/codegen/object-runtime.ts`. That branch successfully calls
+`__proxy_revoke`, then returns its local `undefinedSentinel()`, which is a bare
+`ref.null.extern`. In the default standalone undefined-singleton regime a bare
+null is JavaScript `null`; the repository's
+`canonicalUndefinedExternInstrs(ctx)` exists specifically to emit the exact
+standalone `undefined` carrier without a host import. The Test262 sources
+require `undefined` after both the first call (RevocableProxy step 7) and an
+already-cleared second call (step 2).
+
+No result-invariant, descriptor, target/handler, array, TypedArray, class,
+RegExp, Promise, generator, or global skip behavior is part of this slice.
 
 ## Implementation Plan
 
-Planning pass required before implementation (plan/implement split).
+1. In only the `$Proxy` revoker arm of `fillApplyClosure`, replace the bare
+   null sentinel returned after `__proxy_revoke` with
+   `canonicalUndefinedExternInstrs(ctx)`. Leave the generic not-callable and
+   arity-overflow fallback unchanged; those represent different semantics.
+2. Add a focused #5196 test that compiles a revocable Proxy in host and
+   standalone lanes, observes `revoke() === undefined` on first and second
+   calls, still observes revocation, and checks `null !== undefined`. The
+   standalone control must instantiate with zero host imports. Add the two
+   exact standalone Test262 rows through `runTest262File`, plus the existing
+   passing standalone `revoke.js` control.
+3. Re-run the maintained standalone path list after the change. A successful
+   slice must convert exactly the two claimed fail rows to `pass`, not merely
+   compile them into a different non-pass status. Run proportionate focused
+   quality checks without changing skips or importing a host provider.
 
-- Step 0 — regenerate the proxy residual list (`built-ins/Proxy/**`) on
-  current main via the standalone probe (see #5194 step 0 for probe shape and
-  the `.test262-cache` caveat).
-- Step 1 — cluster by error signature into file:function root causes; write
-  the cluster table into this file. Expect the remaining mass in traps whose
-  invariant checks are still partial.
-- Step 2 — implement per cluster; re-probe; spot-checks stay green.
-- Step 3 — five ratchet gates + equivalence gate.
+## Validation on the f841 worktree and b590 delivery head
+
+- One-worker focused Vitest lane:
+  `node node_modules/vitest/dist/cli.js run
+  tests/issue-5196-es2015-proxy-r2.test.ts --pool=forks
+  --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot` —
+  **5 passed**. This includes host and standalone compiler controls, the two
+  formerly failing exact standalone rows, and the maintained-runner
+  `revocable/revoke.js` passing control.
+- The standalone compiler control instantiated with `{}` and asserted an empty
+  `WebAssembly.Module.imports` list. It checks first and repeated revoker calls
+  return `undefined`, remain distinct from `null`, and still revoke the Proxy.
+- Focused Prettier check and Biome error-level lint passed for the changed
+  production and test files; `git diff --check` passed.
+- Before publication, this dirty checkpoint was fast-forwarded without conflict
+  to current upstream `b590669a7b0dd9537d9b9e703218d9cd6eec3106` (the only
+  intervening source change is disjoint #3521 prepared-free-function routing).
+  The same one-worker focused file passed **5/5** at that exact delivery base;
+  TS5 and TS7 typechecks also passed. Focused Prettier and Biome checks,
+  function budget, oracle ratchet, issue-spec coverage, and `git diff --check`
+  passed on that head. The LOC gate passed with this issue's explicit
+  `src/codegen/object-runtime.ts` allowance for the five-line import expansion.
+- No full 310-row re-census was run after the two exact rows passed: this lane
+  preserves the required two-global-compiler-lane cap. Relative to the fresh
+  snapshot, the unrerun residual is therefore 113 baseline `fail` rows plus 13
+  baseline `compile_error` rows; the two claimed rows are directly verified as
+  `pass` rather than inferred from compilation.
 
 ## Acceptance criteria
 
-- Cluster table with measured counts in this file before implementation.
-- Measurable net gain on the regenerated list; no spot-check or equivalence
-  regressions.
+- The exact 128-row inventory and first-stop histogram above are present before
+  production implementation.
+- The two claimed revocable-return rows pass in the maintained standalone lane,
+  while the passing control and focused host/standalone controls stay green.
+- Standalone output remains host-import-free; no global skip changes.
 
 ## References
 

--- a/plan/issues/5196-es2015-standalone-proxy-r2.md
+++ b/plan/issues/5196-es2015-standalone-proxy-r2.md
@@ -13,6 +13,7 @@ area: codegen
 es_edition: ES2015
 goal: standalone-mode
 requested_by: claude/fable-es2015
+pr: 5389
 loc-budget-allow:
   - src/codegen/object-runtime.ts
 ---
@@ -183,6 +184,12 @@ RegExp, Promise, generator, or global skip behavior is part of this slice.
   function budget, oracle ratchet, issue-spec coverage, and `git diff --check`
   passed on that head. The LOC gate passed with this issue's explicit
   `src/codegen/object-runtime.ts` allowance for the five-line import expansion.
+- Upstream then released v0.71.0. PR #5389 had no merge-queue entry, so the
+  branch was normally merged with release head
+  `7fffec534b44e344f9c2b2b310b346084eaa66b6`; its version-only delta is
+  disjoint. The focused one-worker matrix passed **5/5** again on the resulting
+  merge head before the checkpoint push. PR #5389 remains the single non-draft
+  upstream delivery for this completed two-row fix.
 - No full 310-row re-census was run after the two exact rows passed: this lane
   preserves the required two-global-compiler-lane cap. Relative to the fresh
   snapshot, the unrerun residual is therefore 113 baseline `fail` rows plus 13

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -165,7 +165,12 @@ import { UNDEF_F64_BITS } from "./value-tags.js";
 import { f64HolesActive, f64HoleTestInstrs } from "./vec-f64-hole-presence.js"; // (#4491 T11)
 // (#2106 S1) function-level-only cycle with any-helpers.ts (which imports
 // ensureObjectRuntime) — same tolerated shape as native-strings ↔ any-helpers.
-import { buildIsUndefinedExternBody, undefinedExternInstrs, undefinedSingletonActive } from "./any-helpers.js";
+import {
+  buildIsUndefinedExternBody,
+  canonicalUndefinedExternInstrs,
+  undefinedExternInstrs,
+  undefinedSingletonActive,
+} from "./any-helpers.js";
 import { reserveClassToPrimitive } from "./class-to-primitive.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 import { emitSelfHostedFunc } from "./stdlib-selfhost.js"; // (#3160) self-hosted object-runtime slice
@@ -7421,7 +7426,7 @@ export function fillApplyClosure(ctx: CodegenContext): void {
           { op: "ref.cast", typeIdx: proxyRevokerTypeIdx },
           { op: "struct.get", typeIdx: proxyRevokerTypeIdx, fieldIdx: 0 },
           { op: "call", funcIdx: proxyRevokeIdx },
-          ...undefinedSentinel(),
+          ...canonicalUndefinedExternInstrs(ctx),
           { op: "return" },
         ],
       },

--- a/tests/issue-5196-es2015-proxy-r2.test.ts
+++ b/tests/issue-5196-es2015-proxy-r2.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #5196 — Standalone Proxy revocation functions return the canonical
+ * `undefined` carrier, not the null externref sentinel.
+ */
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildImports, compile, instantiateWasm } from "../src/index.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+type Lane = "host" | "standalone";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TEST262_ROOT = join(REPO_ROOT, "test262");
+const TIMEOUT_MS = 180_000;
+const RUNNER_TIMEOUT_MS = 120_000;
+const TEST262_AVAILABLE = existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+const test262It = TEST262_AVAILABLE ? it : it.skip;
+
+const EXACT_RETURN_ROWS = [
+  "built-ins/Proxy/revocable/revoke-returns-undefined.js",
+  "built-ins/Proxy/revocable/revoke-consecutive-call-returns-undefined.js",
+] as const;
+const PASSING_CONTROL = "built-ins/Proxy/revocable/revoke.js";
+
+const CONTROL_SOURCE = `
+  export function test(): number {
+    const pair: any = Proxy.revocable({ value: 17 }, {});
+    if (pair.proxy.value !== 17) return 1;
+
+    const first: any = pair.revoke();
+    if (first !== undefined) return 2;
+    if (first === null) return 3;
+
+    const second: any = pair.revoke();
+    if (second !== undefined) return 4;
+    if (second === null) return 5;
+
+    try {
+      pair.proxy.value;
+      return 6;
+    } catch (error) {
+      if (!(error instanceof TypeError)) return 7;
+    }
+    return 0;
+  }
+`;
+
+async function runControl(lane: Lane): Promise<{ value: number; imports: string[] }> {
+  const result = await compile(CONTROL_SOURCE, {
+    allowJs: true,
+    fileName: "issue-5196-es2015-proxy-r2.ts",
+    skipSemanticDiagnostics: true,
+    ...(lane === "standalone" ? { target: "standalone" as const } : {}),
+  });
+  expect(
+    result.success,
+    `${lane} control compile failed:\n${result.errors?.map((error) => `L${error.line}: ${error.message}`).join("\n") ?? ""}`,
+  ).toBe(true);
+  if (!result.success) return { value: -1, imports: [] };
+
+  const module = await WebAssembly.compile(result.binary);
+  const imports = WebAssembly.Module.imports(module).map((entry) => `${entry.module}::${entry.name}`);
+  if (lane === "standalone") {
+    expect(imports, "standalone revocation controls must emit zero imports").toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    return { value: (instance.exports as { test: () => number }).test(), imports };
+  }
+
+  const built = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setInstance?.(instance);
+  return { value: (instance.exports as { test: () => number }).test(), imports };
+}
+
+describe("#5196 ES2015 standalone Proxy revoker return", () => {
+  for (const lane of ["host", "standalone"] as const) {
+    it(
+      `${lane}: revoker returns undefined twice, preserves null distinction, and revokes the proxy`,
+      { timeout: TIMEOUT_MS },
+      async () => {
+        const outcome = await runControl(lane);
+        expect(outcome.value).toBe(0);
+        if (lane === "standalone") expect(outcome.imports).toEqual([]);
+      },
+    );
+  }
+
+  for (const relativePath of [...EXACT_RETURN_ROWS, PASSING_CONTROL]) {
+    const filePath = join(TEST262_ROOT, "test", relativePath);
+    test262It(`standalone exact Test262 row: ${relativePath}`, { timeout: TIMEOUT_MS }, async () => {
+      try {
+        const result = await runTest262File(filePath, "issue-5196-standalone", RUNNER_TIMEOUT_MS, "standalone");
+        expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+      } finally {
+        restoreHostBuiltins();
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Description

Problem: Standalone `Proxy.revocable` revocation functions returned a bare null externref instead of JavaScript `undefined`, failing two ES2015 Test262 rows. Behavior: Emit the canonical standalone undefined carrier after revocation while preserving repeated revocation and the revoked-proxy TypeError. Tests: 5/5 focused host and standalone controls passed after the normal sync with release main `7fffec53`, including both formerly failing Test262 rows and the existing `revoke.js` control with zero standalone imports. Quality: TS5 and TS7 typechecks, focused Biome and Prettier, LOC/function budgets, oracle and coercion ratchets, 18/18 numeric-local parity, issue integrity, and normal commit/pre-push hooks passed. Tracking: `plan/issues/5196-es2015-standalone-proxy-r2.md`; No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->