### PR TITLE
docs(test262): record f841 ES2015 dispatch census

### DIFF
--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -23,7 +23,7 @@ related: [2860, 2864, 2865, 2867, 2906, 3032, 3178, 2161, 2175, 2158, 2159, 4445
 This is the latest immutable dispatch baseline for this umbrella. It replaces
 the older 2026-08-15/27/30 planning headline below, but it is not final
 acceptance evidence: upstream `main` advanced after the fetch from the measured
-`f841cddc` source to `b590669a`. A complete maintained-runner census on the
+`f841cddc` source to release head `7fffec53`. A complete maintained-runner census on the
 final integrated head is still required before any current pass-rate or
 completion claim.
 

--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -4,7 +4,7 @@ title: "UMBRELLA: ES6 (ES2015) standalone authoritative 11,704-row close-out →
 status: in-progress
 sprint: current
 created: 2026-08-15
-updated: 2026-08-30
+updated: 2026-09-01
 assignee: codex/es6-test262-closeout
 priority: high
 horizon: xl
@@ -18,7 +18,100 @@ related: [2860, 2864, 2865, 2867, 2906, 3032, 3178, 2161, 2175, 2158, 2159, 4445
 
 # #4444 — UMBRELLA: ES6 (ES2015) standalone edition close-out
 
-## Measurement (2026-08-15, this session)
+## Latest forced census (2026-09-01; replaces the stale dispatch headline below)
+
+This is the latest immutable dispatch baseline for this umbrella. It replaces
+the older 2026-08-15/27/30 planning headline below, but it is not final
+acceptance evidence: upstream `main` advanced after the fetch from the measured
+`f841cddc` source to `b590669a`. A complete maintained-runner census on the
+final integrated head is still required before any current pass-rate or
+completion claim.
+
+- **Compiler source:** detached `upstream/main`
+  `f841cddc0f0ea665b63700d9944a4372a34a8b57`.
+- **Baseline provenance:** a forced official fetch with
+  `node scripts/fetch-baseline-jsonl.mjs --standalone --force` retrieved
+  `test262-standalone-current.jsonl` from immutable
+  `loopdive/js2wasm-baselines` commit
+  `8a39bd1d4ddf200f8db3751c878ece02aa8688fe` (GitHub Actions commit time
+  `2026-09-01T00:28:18Z`).  The 22,858,445-byte cache has SHA-256
+  `4426cbf6f305ab4a092468b201cc5854d4470b5fe87edf2fe47ba0195a6e8cbf`.
+  Its row timestamps span `2026-09-01T02:02:14Z` through
+  `2026-09-01T02:24:30Z`. The baselines repository's `main` moved after this
+  fetch; cite the immutable commit above, not the moving branch tip.
+- **Schema/completeness check:** all 48,735 JSONL rows parse; every row has
+  the required string/number/boolean baseline fields, one of
+  `pass|fail|compile_error|compile_timeout|skip`, and a unique `(file,strict)`
+  identity.  Optional timing/error fields are absent only where the maintained
+  runner schema permits them.
+- **Edition authority:**
+  `website/public/benchmarks/results/test262-file-editions.json` maps every
+  fetched row.  Selecting entries whose exact label is `ES2015` produces
+  11,704 rows, all `scope_official: true` (11,536 standard and 168 Annex B).
+- **Measured result at `f841cddc`:** **9,616 pass / 11,704 total** (82.16%);
+  **1,644 fail, 444 compile_error, 0 compile_timeout, 0 skip** — **2,088
+  non-pass**. This
+  is progress, not completion; the umbrella remains `in-progress` until the
+  complete exact population is 11,704 pass with all other status counts zero.
+
+### Acceptance runner and positive control
+
+Do not infer acceptance from this fetched baseline.  A subsequent implementation
+must use the maintained runner, an exact 11,704-path filter derived from the
+authoritative edition map, and the runner's completion-manifest validator.  The
+shape is:
+
+```bash
+COMPILER_POOL_SIZE=1 VITEST_FORK_MAX_OLD_SPACE_SIZE=3072 \
+TEST262_TARGET=standalone JS2WASM_EVAL_ENGINE=quickjs \
+JS2WASM_QUICKJS_ARTIFACT_DIR=/absolute/prebuilt-quickjs-artifact-dir \
+TEST262_PATH_FILTER_FILE=/absolute/path/to/exact-es2015-paths.txt \
+TEST262_PUBLISH_HISTORY=0 TEST262_REPORTER=dot \
+pnpm run test:262 -- --official-scope-only
+```
+
+As a focused positive control for the free #2046 slice, the fetched baseline
+records `test/built-ins/Reflect/set/set-value-on-accessor-descriptor.js` as a
+standalone **pass** (the supported three-argument native `Reflect.set` path).
+Before and after any receiver implementation, it can be exercised without a
+full suite via:
+
+```bash
+printf '%s\n' \
+  'test/built-ins/Reflect/set/set-value-on-accessor-descriptor.js' \
+  > /absolute/path/to/reflect-set-positive-control.txt
+COMPILER_POOL_SIZE=1 TEST262_TARGET=standalone \
+JS2WASM_EVAL_ENGINE=quickjs \
+JS2WASM_QUICKJS_ARTIFACT_DIR=/absolute/prebuilt-quickjs-artifact-dir \
+TEST262_PATH_FILTER_FILE=/absolute/path/to/reflect-set-positive-control.txt \
+TEST262_PUBLISH_HISTORY=0 TEST262_REPORTER=dot \
+pnpm run test:262 -- --official-scope-only
+```
+
+### Current handoff: owned work versus free exact slices
+
+- **Do not duplicate:** the three ES2015 dynamic-`RegExp` `Symbol.match`
+  flag-refusal paths are isolated, but a live sibling worktree owns #5198
+  (`codex/5198-regexp-exec-r2-f841-20260901`).  Generator continuations are
+  covered by open PR #5383; TypedArray species work by #5385; and builtin
+  prototype/null-prototype work by #5384.
+- **Free, bounded implementation candidate:** #2046's explicit
+  `Reflect.set(target,key,value,receiver)` refusal has **15 exact
+  compile-error paths**, all with the same fail-loud diagnostic.  The single
+  gate is `src/codegen/expressions/call-namespace-static.ts:903-920`; #2046 is
+  in progress, no current GitHub PR matches it, and its visible remote branches
+  are June-era checkpoints.  The implementation must preserve the positive
+  control above and add receiver plumbing rather than drop the fourth argument.
+- **Unowned but not yet a safe parallel coding slice:** #3371's arbitrary
+  distinct-`Reflect.construct` NewTarget refusal remains on **33 exact
+  compile-error paths** at
+  `src/codegen/expressions/call-namespace-static.ts:1620-1627`, despite its
+  tracker being marked done.  It needs a reopened/new bounded owner before
+  implementation; it is not a substitute for the #2046 slice.  The apparent
+  three-row `Array.prototype.flat` refusal is already a tail of #5145's
+  in-review ArraySpecies/target-property wave, so do not duplicate it.
+
+## Historical measurement (2026-08-15, superseded as a headline)
 
 Source: fresh `test262-standalone-current.jsonl` (baselines repo, fetched
 `--force`, 48,735 entries, baseline_sha `734fab88`), classified per-test with


### PR DESCRIPTION
## Description

Problem: The ES2015 closeout umbrella still presented stale planning numerators and lacked immutable provenance for the latest forced 11,704-row standalone census. Behavior: Record the f841 dispatch result of 9,616 pass, 1,644 fail, and 444 compile errors; pin the baselines commit and artifact hash; document the authoritative maintained-runner contract; and identify collision-safe next slices while retaining in-progress status. Tests: Markdown Prettier and diff checks passed, and the branch was normally synchronized with release main `7fffec53`. Quality: Normal commit and pre-push hooks passed, including TS7/lint, repository formatting, oracle/coercion ratchets, 18/18 numeric-local parity, and issue integrity. Tracking: `plan/issues/4444-es6-standalone-edition-closeout-umbrella.md`; No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->