### PR TITLE
fix(release): validate JSR declaration graph

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -86,8 +86,11 @@ tags only `sprint/N` (+ `sprint-N/begin`); see `CLAUDE.md` and
    leading `v`, reads both `package.json` versions, and **fails the publish if
    either differs** from the tag. Only when they match does it publish
    `@loopdive/js2`, the `js2wasm` proxy, and JSR. The JSR job builds a
-   name-preserving minified `dist/` package and refuses to publish at 18 MiB,
-   leaving 2 MiB of headroom below JSR's aggregate package limit.
+   name-preserving minified `dist/` package, retains only the declarations
+   reachable from its three public entries, and rejects declaration syntax
+   that the registry forbids (including global/module augmentation). It also
+   refuses to publish at 18 MiB, leaving 2 MiB of headroom below JSR's
+   aggregate package limit.
 
 ## Why the tag travels with the branch (and the merge-method dependency)
 
@@ -115,3 +118,5 @@ For an isolated JSR recovery after a partial release, select `target=jsr` and
 `dry-run=false`. This skips both npm jobs and publishes JSR from the selected
 ref. Use it only after confirming the exact version is absent from JSR and all
 version carriers on that ref match; manual dispatch bypasses the tag verifier.
+The compact-build declaration gate is load-bearing: `jsr publish --dry-run`
+does not exercise every registry-side syntax policy.

--- a/scripts/ir-kind-neutrality-baseline.json
+++ b/scripts/ir-kind-neutrality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-31",
+  "generated": "2026-09-01",
   "populationRule": "A kind is in scope iff it is the `readonly kind` discriminant of a top-level `export interface` that is an arm of the `IrInstr` or `IrTerminator` union in src/ir/nodes.ts. Excluded: the symbolic-reference types IrFuncRef/IrGlobalRef/IrTypeRef (kinds func/global/type) and every inline union member of a payload type. See scripts/check-ir-kind-neutrality.mjs.",
   "ratchet": {
     "unresolved": 3,
@@ -284,7 +284,7 @@
       "where": "dialect",
       "declaredAt": "src/ir/dialect/js.ts:713",
       "why": "This is `%String.prototype%[@@iterator]` inlined as a statement form. The per-iteration element is a CODE POINT rendered as a one-element string — the intent field resolves to `__str_charAt_cp`, deliberately not the code-unit `string.char_at` next door. Its general sibling `forof.iter` is already in the dialect, so keeping the string specialization in core splits one protocol across the boundary.",
-      "evidence": ["src/ir/dialect/js.ts:722", "src/ir/integration.ts:6058"]
+      "evidence": ["src/ir/dialect/js.ts:722", "src/ir/integration.ts:6051"]
     },
     "forof.vec": {
       "verdict": "neutral",

--- a/scripts/prepare-jsr-dist.mjs
+++ b/scripts/prepare-jsr-dist.mjs
@@ -1,17 +1,161 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// JSR's registry validates forbidden declaration syntax after upload, while
+// `jsr publish --dry-run` stops before that server-side analysis. Retain only
+// the public declaration graph and mirror the registry checks locally so a
+// release cannot discover an augmentation failure after its tag is public.
 
+import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import ts from "typescript";
+
+const distRoot = resolve("dist");
 const entries = ["index", "runtime", "optimize"];
+const declarationEntries = entries.map((entry) => resolve(distRoot, `${entry}.d.ts`));
+const declarationResolutionOptions = {
+  allowJs: true,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+};
+
+function listDeclarationFiles(directory) {
+  const files = [];
+  const directories = [directory];
+  while (directories.length > 0) {
+    const current = directories.pop();
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const path = resolve(current, entry.name);
+      if (entry.isDirectory()) directories.push(path);
+      else if (entry.isFile() && path.endsWith(".d.ts")) files.push(path);
+    }
+  }
+  return files.sort();
+}
+
+function isInsideDist(path) {
+  const fromDist = relative(distRoot, path);
+  return fromDist !== "" && fromDist !== ".." && !fromDist.startsWith(`..${sep}`) && !isAbsolute(fromDist);
+}
+
+function resolveDeclaration(from, specifier) {
+  const resolved = ts.resolveModuleName(specifier, from, declarationResolutionOptions, ts.sys).resolvedModule;
+  if (!resolved || resolved.isExternalLibraryImport || !isInsideDist(resolved.resolvedFileName)) return undefined;
+  if (!resolved.resolvedFileName.endsWith(".d.ts")) {
+    throw new Error(
+      `JSR declaration ${relative(distRoot, from)} resolves ${specifier} to non-declaration ${relative(distRoot, resolved.resolvedFileName)}`,
+    );
+  }
+  return resolve(resolved.resolvedFileName);
+}
+
+function collectDeclarationClosure() {
+  const retained = new Set();
+  const queue = [...declarationEntries];
+  while (queue.length > 0) {
+    const path = queue.shift();
+    if (retained.has(path)) continue;
+    if (!existsSync(path)) throw new Error(`JSR declaration closure is missing ${relative(distRoot, path)}`);
+    retained.add(path);
+
+    const source = readFileSync(path, "utf8");
+    const imports = ts.preProcessFile(source, true, true);
+    if (imports.libReferenceDirectives.length > 0 || imports.isLibFile) {
+      throw new Error(`JSR declaration ${relative(distRoot, path)} contains a forbidden triple-slash lib directive`);
+    }
+    for (const imported of imports.importedFiles) {
+      const target = resolveDeclaration(path, imported.fileName);
+      if (imported.fileName.startsWith(".") && !target) {
+        throw new Error(
+          `JSR declaration ${relative(distRoot, path)} has an unresolved relative import ${imported.fileName}`,
+        );
+      }
+      if (target && !retained.has(target)) queue.push(target);
+    }
+    for (const referenced of imports.referencedFiles) {
+      const target = resolve(dirname(path), referenced.fileName);
+      if (!existsSync(target) || !target.endsWith(".d.ts") || !isInsideDist(target)) {
+        throw new Error(
+          `JSR declaration ${relative(distRoot, path)} has an invalid triple-slash path ${referenced.fileName}`,
+        );
+      }
+      if (!retained.has(target)) queue.push(target);
+    }
+    for (const typeReference of imports.typeReferenceDirectives) {
+      const resolved = ts.resolveTypeReferenceDirective(
+        typeReference.fileName,
+        path,
+        declarationResolutionOptions,
+        ts.sys,
+      ).resolvedTypeReferenceDirective;
+      if (!resolved || resolved.isExternalLibraryImport || !isInsideDist(resolved.resolvedFileName)) continue;
+      const target = resolve(resolved.resolvedFileName);
+      if (!target.endsWith(".d.ts")) {
+        throw new Error(
+          `JSR declaration ${relative(distRoot, path)} resolves type reference ${typeReference.fileName} to a non-declaration file`,
+        );
+      }
+      if (!retained.has(target)) queue.push(target);
+    }
+  }
+  return retained;
+}
+
+function assertRegistrySafeDeclarations(paths) {
+  const violations = [];
+  for (const path of paths) {
+    const sourceFile = ts.createSourceFile(path, readFileSync(path, "utf8"), ts.ScriptTarget.Latest, true);
+    const visit = (node) => {
+      let reason;
+      if (
+        ts.isModuleDeclaration(node) &&
+        ((node.flags & ts.NodeFlags.GlobalAugmentation) !== 0 || ts.isStringLiteral(node.name))
+      ) {
+        reason = "global/module augmentation";
+      } else if (ts.isNamespaceExportDeclaration(node)) {
+        reason = "namespace export";
+      } else if (ts.isExportAssignment(node) && node.isExportEquals) {
+        reason = "CommonJS export assignment";
+      } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+        reason = "CommonJS import assignment";
+      }
+      if (reason) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        violations.push(`${relative(distRoot, path)}:${line + 1}:${character + 1} (${reason})`);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+  if (violations.length > 0) {
+    throw new Error(`JSR declarations contain registry-forbidden syntax:\n${violations.join("\n")}`);
+  }
+}
 
 for (const entry of entries) {
-  const javascriptPath = `dist/${entry}.js`;
-  const declarationPath = `dist/${entry}.d.ts`;
+  const javascriptPath = resolve(distRoot, `${entry}.js`);
+  const declarationPath = resolve(distRoot, `${entry}.d.ts`);
   if (!existsSync(javascriptPath) || !existsSync(declarationPath)) {
-    throw new Error(`JSR build is missing ${javascriptPath} or ${declarationPath}`);
+    throw new Error(`JSR build is missing dist/${entry}.js or dist/${entry}.d.ts`);
   }
+}
 
+const allDeclarations = listDeclarationFiles(distRoot);
+const retainedDeclarations = collectDeclarationClosure();
+for (const path of allDeclarations) {
+  if (!retainedDeclarations.has(path)) unlinkSync(path);
+}
+
+const rebuiltClosure = collectDeclarationClosure();
+assertRegistrySafeDeclarations(rebuiltClosure);
+console.log(
+  `JSR declaration closure: retained ${rebuiltClosure.size.toLocaleString()} / ${allDeclarations.length.toLocaleString()} files; registry-forbidden syntax: none`,
+);
+
+for (const entry of entries) {
+  const javascriptPath = resolve(distRoot, `${entry}.js`);
   const source = readFileSync(javascriptPath, "utf8");
   if (source.includes("@ts-self-types")) {
-    throw new Error(`JSR build already contains an unexpected @ts-self-types directive in ${javascriptPath}`);
+    throw new Error(`JSR build already contains an unexpected @ts-self-types directive in dist/${entry}.js`);
   }
 
   const directive = `/* @ts-self-types="./${entry}.d.ts" */`;

--- a/src/codegen/multi-source-ir-integration.ts
+++ b/src/codegen/multi-source-ir-integration.ts
@@ -1,12 +1,10 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import type { IrBindingId, IrUnitId } from "../ir/identity.js";
 import type { IrFnctorParameterPreselectionPlan } from "../ir/ast-lowering-plans.js";
 import type { IrTypeOverrideMap } from "../ir/integration.js";
 import type {
   PreparedComponentPublicationDraft,
   PreparedComponentPublicationToken,
-  PendingPreparedProgramComponentReceipt,
 } from "../ir/prepared-component-publication.js";
 import { asVal, irVal, type IrType } from "../ir/nodes.js";
 import { IrInvariantError } from "../ir/outcomes.js";
@@ -14,28 +12,7 @@ import type { IrLegacyUnitProjection, IrPlanningIdentityContext } from "../ir/pl
 import { isExactDynamicStringReplaceNumberParser } from "../ir/dynamic-string-parser-shape.js";
 import { ts } from "../ts-api.js";
 import type { CodegenContext } from "./context/types.js";
-import type { PreparedModuleCallableAliasDescriptor } from "./program-abi-module-callable-alias-planning.js";
 import type { PreparedProgramAbiPendingScope } from "./program-abi-prepared-transaction.js";
-
-declare module "../ir/integration.js" {
-  interface IrIntegrationOptions {
-    /** Source files participating in one aggregate IR integration. */
-    readonly integrationSourceFiles?: readonly ts.SourceFile[];
-    /** Seal and withdraw the exact aggregate as one component. */
-    readonly atomicComponent?: boolean;
-    /** Exact non-source bindings included in the component seal. */
-    readonly preparedBindingIdsByTerminalUnitId?: ReadonlyMap<IrUnitId, ReadonlySet<IrBindingId>>;
-    /** Keep the exact aggregate scope open and return detached body patches. */
-    readonly deferPreparedPublication?: boolean;
-    /** Sink used by the aggregate-only integration entry to receive a receipt. */
-    readonly preparedComponentPublicationSink?: {
-      readonly publish: (draft: PreparedComponentPublicationDraft) => PendingPreparedProgramComponentReceipt;
-      readonly abort?: () => void;
-    };
-    /** Opaque module-callable-alias descriptor staged with the open scope. */
-    readonly preparedModuleCallableAliasDescriptor?: PreparedModuleCallableAliasDescriptor;
-  }
-}
 
 /** The narrow owner-facing aggregate publication boundary for IR integration. */
 export type PreparedComponentPublicationDraftForOwner = PreparedComponentPublicationDraft;

--- a/src/ir/integration-options.ts
+++ b/src/ir/integration-options.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { ts } from "../ts-api.js";
+import type { IrBindingId, IrUnitId } from "./identity.js";
+import type {
+  PendingPreparedProgramComponentReceipt,
+  PreparedComponentModuleCallableAliasDescriptor,
+  PreparedComponentPublicationDraft,
+} from "./prepared-component-publication.js";
+
+/** Configuration shared by single-source and aggregate IR integration. */
+export interface IrIntegrationOptions {
+  /**
+   * Derive post-pass R2 components and seal every dependency-complete ABI
+   * component before lowering. Components with still-implicit runtime/layout
+   * support retain the established transitional route.
+   */
+  readonly sealPreparedComponents?: boolean;
+  /** Source files participating in one aggregate IR integration. */
+  readonly integrationSourceFiles?: readonly ts.SourceFile[];
+  /** Seal and withdraw the exact aggregate as one component. */
+  readonly atomicComponent?: boolean;
+  /** Exact non-source bindings included in the component seal. */
+  readonly preparedBindingIdsByTerminalUnitId?: ReadonlyMap<IrUnitId, ReadonlySet<IrBindingId>>;
+  /** Keep the exact aggregate scope open and return detached body patches. */
+  readonly deferPreparedPublication?: boolean;
+  /** Sink used by the aggregate-only integration entry to receive a receipt. */
+  readonly preparedComponentPublicationSink?: {
+    readonly publish: (draft: PreparedComponentPublicationDraft) => PendingPreparedProgramComponentReceipt;
+    readonly abort?: () => void;
+  };
+  /** Opaque module-callable-alias descriptor staged with the open scope. */
+  readonly preparedModuleCallableAliasDescriptor?: PreparedComponentModuleCallableAliasDescriptor;
+}

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -23,6 +23,8 @@
 // That's the whole point of the symbolic-ref design — spec #1131 §1.2.
 
 import { ts } from "../ts-api.js";
+import type { IrIntegrationOptions } from "./integration-options.js";
+export type { IrIntegrationOptions } from "./integration-options.js";
 import { acceptsStaticNumericArrayParam, staticNumericArrayGlobalMatches } from "./select-vector-slots.js";
 import { makeIrHostDateSnapshotResolver } from "./host-date.js";
 import { ClosureStructRegistry } from "./closure-struct-registry.js";
@@ -529,15 +531,6 @@ export interface IrTypeOverrideMap {
   // void-returning function (zero Wasm result types). Plumbs through to
   // `from-ast.ts` so the IR builder can be constructed with `[]` results.
   get(name: string): { readonly params: readonly IrType[]; readonly returnType: IrType | null } | undefined;
-}
-
-export interface IrIntegrationOptions {
-  /**
-   * Derive post-pass R2 components and seal every dependency-complete ABI
-   * component before lowering. Components with still-implicit runtime/layout
-   * support retain the established transitional route.
-   */
-  readonly sealPreparedComponents?: boolean;
 }
 
 interface BuiltFn {


### PR DESCRIPTION
## Summary

- replace the one public-graph module augmentation with the same structural `IrIntegrationOptions` interface in a dedicated type module
- prune the JSR declaration payload to the exact closure of `index`, `runtime`, and `optimize`
- fail the build on registry-forbidden declaration syntax, unresolved relative type edges, and forbidden triple-slash library directives

## Failure being repaired

The isolated JSR recovery run correctly skipped both npm jobs, built the compact package, and passed the 18 MiB gate. JSR then rejected the upload because `dist/codegen/multi-source-ir-integration.d.ts` contained a string-literal `declare module` augmentation.

This is a registry-side check: Deno 2.6.7 returns from `publish --dry-run` before the registry analysis request, so the previous strict dry run could not expose it. JSR 0.71.0 remains unpublished.

## Fix

- The reachable augmentation's six fields now live on the same exported structural options type; no runtime or assignability behavior changes.
- The declaration union is 136 of 1,143 generated files. The two other generated augmentations are outside all three public entrypoint graphs and are omitted.
- The post-build AST scan mirrors the applicable JSR bans for global/module augmentation, namespace exports, CommonJS export/import assignments, and library directives.

## Validation

- `pnpm run build:jsr` — retained 136 / 1,143 declarations; forbidden syntax: none
- `pnpm run check:jsr-package-budget` — 14,379,192 / 18,874,368 bytes
- all nine generated JavaScript file hashes are unchanged from the npm-equivalent compact artifact
- clean-tree `npx jsr publish --dry-run` passed without `--allow-slow-types`
- Deno 2.6.7 checked a consumer of all three JavaScript entrypoints, including negative type sentinels
- default and standalone compile/instantiate smokes returned the expected values; emitted Wasm validated
- 112 prepared-component tests passed (6 skipped by design)
- TypeScript, formatting, LOC/function, coercion, oracle, and dead-export gates passed
- pre-commit and pre-push hooks passed

The two remaining CLI warnings are the existing intentional runtime-configurable dynamic imports (`binaryen` and arbitrary program dynamic import).

References: [JSR global augmentation policy](https://jsr.io/docs/about-slow-types#global-augmentation), [registry syntax analysis](https://github.com/jsr-io/jsr/blob/888163ad7c119bb82692a1397b0fe83771166700/api/src/analysis.rs#L954-L1070), [Deno dry-run return path](https://github.com/denoland/deno/blob/d155af667f0e57277dc992d1b9609d5e6712908d/cli/tools/publish/mod.rs#L181-L203).
