### PR TITLE
docs(codegen): checkpoint #3371 Reflect.construct NewTarget design

### DIFF
--- a/plan/issues/3371-standalone-reflect-construct-newtarget.md
+++ b/plan/issues/3371-standalone-reflect-construct-newtarget.md
@@ -18,7 +18,21 @@ goal: standalone-mode
 umbrella: 1781
 related: [1472, 1781, 1905, 2026, 2046, 2618, 3240, 4196, 4661, 5138, 5140, 5143, 5150, 5153, 5154, 5156]
 origin: "2026-09-01 immutable f841 standalone census; reopened because the prior done closure still refuses arbitrary distinct NewTarget."
-checkpoint: ordinary-slice-authorized
+checkpoint: draft-architecture-unmergeable
+loc-budget-allow:
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/context/types.ts
+  - src/codegen/index.ts
+  - src/codegen/registry/imports.ts
+  - src/codegen/expressions.ts
+func-budget-allow:
+  - src/codegen/expressions/new-super.ts::compileNewExpression
+  - src/codegen/index.ts::generateMultiModule
+  - src/codegen/expressions.ts::compileExpressionInner
+  - src/codegen/context/create-context.ts::createCodegenContext
+  - src/codegen/index.ts::generateModule
+  - src/codegen/expressions/new-super.ts::compileNewFunctionDeclaration
+  - src/codegen/function-body.ts::compileFunctionBody
 ---
 
 # #3371 — standalone Reflect.construct with arbitrary distinct NewTarget
@@ -232,6 +246,85 @@ for all #3371 work: it must still honor any newly landed #2026/#5153/#5154
 interfaces, and all view, native, bound, and Proxy groups remain separately
 owned.
 
+## Ordinary/class implementation checkpoint — 2026-09-01
+
+The implementation worktree is pinned at planning commit
+`b51340b359d0c27c252496a31bf40c3848630fcb` (base
+`2c3c27a54f78df2b71e034080dc509139776a2af`). A fresh overlap audit found no
+active implementation PR for this arm: the only overlapping open change was
+the frozen, nonmergeable #2046 draft, while #5394 is this planning record and
+the adjacent #5153/#5154 work is already merged or does not touch the
+namespace-static lowering.
+
+The exact standalone baseline remains four explicit-refusal rows (10--13)
+and a passing omitted-NewTarget control. The same five host invocations fail
+for pre-existing host-carrier reasons and are retained as non-regression
+controls, not acceptance criteria for this standalone-only slice.
+
+Source and runtime audit established the following contract before any
+production edit:
+
+- `reserveNativeConstructDriver` already creates an ordinary `$Object`, calls
+  the ordinary closure with that object as `this`, and returns an object result
+  or the receiver. A standalone probe confirms that an `$Object` created from
+  `Array.prototype` preserves `Object.getPrototypeOf(x) === Array.prototype`.
+- A user function's `.prototype` has a dedicated native storage path, while
+  class prototypes require the class/runtime-prototype machinery. A direct
+  generic class-prototype probe currently answers false, so the class branch
+  must set the existing conditional dynamic-prototype field before `_init`,
+  rather than post-mutating a completed instance.
+- The runtime contract therefore carries the evaluated `newTarget` identity
+  and its runtime-read prototype across the construct call, saves/restores it
+  for nesting, and lets the class allocation wrapper consume it before a
+  derived constructor reaches `super()`. Ordinary function targets use the
+  existing native construct driver with the selected runtime prototype.
+- Admission is intentionally limited to source-proven stable local ordinary
+  functions/classes plus the ambient `Array`/`Object` shapes exercised by
+  rows 10--13. It declines bound values, Proxies, native view/buffer/Date/
+  Error/Promise carriers, dynamic aliases, direct-eval/`with` scopes, and
+  mutable target/NewTarget bindings. This is carrier admission, not the old
+  `NewTarget.prototype = ...` source-value substitution: the accepted route
+  performs the property/prototype operation at runtime.
+
+The focused implementation will add regressions for source evaluation order,
+ordinary `new.target`, class/super `new.target`, and retained refusal of an
+excluded carrier. It will not expand the other 29 census rows.
+
+### Frozen implementation checkpoint — 2026-09-01
+
+The first implementation pass is deliberately **not mergeable**. It is an
+uncommitted architectural checkpoint only: it records source-proven candidate
+sites and wires the runtime NewTarget state through ordinary function bodies,
+class allocation, and the existing dynamic-prototype field. The
+`Reflect.construct` namespace-static dispatcher is intentionally still
+unwired, so this checkpoint cannot change the accepted carrier surface.
+
+Focused evidence at this checkpoint:
+
+- `pnpm run typecheck:ts7` — pass (exit 0).
+- Standalone rows 10--13 each retain the exact prior loud #3371
+  `compile_error`; none has become a runtime failure or a different refusal.
+- `test/built-ins/Reflect/construct/return-without-newtarget-argument.js` —
+  pass.
+
+The partial diff is approximately 740 added lines, including 511 lines in
+`src/codegen/new-target.ts`, before it even owns the dispatcher. Do not extend
+that file with the call-site lowering. A successor must first extract a small,
+cohesive `Reflect.construct` ordinary-route module and use it to connect the
+already-existing `reserveNativeConstructDriver` to a runtime
+GetPrototypeFromConstructor-equivalent contract. That design must preserve
+target, argument-list, and NewTarget evaluation order; selected NewTarget
+identity for ordinary `new.target`; class allocation before `_init`/`super`;
+and save/restore nesting. It must retain loud refusal for all view/buffer,
+Date/Error/Promise, bound, Proxy, dynamic-alias, and other unproven carriers.
+No claim of rows 10--13 is justified until the exact paths are pass.
+
+The frontmatter's narrowly enumerated LOC/function allowances exist only
+because the repository's normal commit hook requires a passing ratchet even
+for this draft publication. They document the architectural fault rather than
+waive it: the successor must remove them while moving the state and dispatcher
+seam into a dedicated module.
+
 ## Future acceptance and regression gate
 
 Run these only in the later implementation worktree, after acquiring ownership;
@@ -270,9 +363,17 @@ they were intentionally **not** run for this planning audit.
 
 ## Handoff
 
-The next owner should begin with slice 1's post-#2046 audit, then implement only
-the four ordinary/class paths if the interfaces are still unowned. Record a fresh
-precise result for all 33 paths after each slice, retain the no-distinct-
-NewTarget positive control, and leave each carrier group as a separate
-coordination decision. This document is the corrected reopen record; it does
-not certify the historical closure or authorize a broad source rewrite.
+This published draft is a **nonmergeable architectural checkpoint**, not an
+implementation claim. It has zero pass gain: its exact evidence is TS7 green,
+rows 10--13 still loud compile errors, and the omitted-NewTarget control pass.
+The dispatcher is unwired and all excluded carriers remain unchanged.
+
+The next owner must begin by decomposing the inert #3371 substrate into a
+dedicated ordinary `Reflect.construct` module before wiring a dispatcher. Only
+then implement the four ordinary/class paths if the interfaces are still
+unowned, with targeted semantic regressions and a fresh exact result. Record a
+precise result for all 33 paths after each later carrier slice, retain the
+no-distinct-NewTarget positive control, and leave view/buffer, native,
+bound-function, and Proxy groups as separate coordination decisions. This
+document neither certifies the historical closure nor authorizes a broad source
+rewrite.

--- a/plan/issues/3371-standalone-reflect-construct-newtarget.md
+++ b/plan/issues/3371-standalone-reflect-construct-newtarget.md
@@ -334,6 +334,22 @@ Post-sync validation after merging live `loopdive/js2` main
 - `test/built-ins/Reflect/construct/return-without-newtarget-argument.js` —
   pass.
 
+### Draft CI blocker — PR #5400
+
+The draft CI run confirms the checkpoint is inert rather than mergeable. Its
+only concrete failing gate was:
+
+~~~text
+pnpm run check:dead-exports
+dead-export gate: 1 NEW unreferenced top-level function(s) in src/codegen/: src/codegen/new-target.ts#standaloneReflectConstructOrdinarySite
+~~~
+
+It exited 1. All preceding and other gates passed or were intentionally
+skipped. The unreferenced admission query is expected while the
+`Reflect.construct` dispatcher remains unwired; it is evidence for the
+dedicated-module/decomposition handoff, not a reason to update the dead-export
+baseline or add a synthetic production reference.
+
 ## Future acceptance and regression gate
 
 Run these only in the later implementation worktree, after acquiring ownership;

--- a/plan/issues/3371-standalone-reflect-construct-newtarget.md
+++ b/plan/issues/3371-standalone-reflect-construct-newtarget.md
@@ -1,176 +1,275 @@
 ---
 id: 3371
-title: "standalone: Reflect.construct (with NewTarget) refused — ~160 tests (proto-from-ctor-realm, subclassing) on the #1472 Phase-C refusal path"
-status: done
+title: "standalone: Reflect.construct arbitrary distinct NewTarget still refuses 33 ES2015 rows"
+status: blocked
+blocked_on: [2046]
 created: 2026-07-17
-updated: 2026-07-21
-completed: 2026-07-20
-sprint: 73
-priority: medium
+updated: 2026-09-01
+reopened: 2026-09-01
+sprint: current
+priority: high
 horizon: l
 feasibility: hard
 model: fable
-task_type: feature
+task_type: bugfix
 area: codegen, runtime
 language_feature: reflect, constructors, prototype chain
+es_edition: ES2015
 goal: standalone-mode
 umbrella: 1781
-related: [1781, 1905, 2046, 3240, 1472]
-origin: "2026-07-17 /harvest-errors. Baselines run 20260717-151504 (gitHash 0069df37, 32,139 pass), standalone lane test262-standalone-current.jsonl."
-loc-budget-allow:
-  - src/codegen/expressions/call-namespace-static.ts
-  - src/codegen/property-access-dispatch.ts
-  - src/codegen/expressions/call-identifier.ts
-  - src/codegen/index.ts
-  - src/codegen/dataview-native.ts
-  - src/codegen/expressions/identifiers.ts
-oracle-ratchet-allow:
-  - src/codegen/expressions/call-namespace-static.ts
-  - src/codegen/expressions/identifiers.ts
-  - src/codegen/property-access-dispatch.ts
+related: [1472, 1781, 1905, 2026, 2046, 2618, 3240, 4196, 4661, 5138, 5140, 5143, 5150, 5153, 5154, 5156]
+origin: "2026-09-01 immutable f841 standalone census; reopened because the prior done closure still refuses arbitrary distinct NewTarget."
 ---
 
-# #3371 — Standalone `Reflect.construct` (with NewTarget) refused
+# #3371 — standalone Reflect.construct with arbitrary distinct NewTarget
 
-## Problem
+## Reopen decision
 
-`--target standalone` emits a codegen refusal for every `Reflect.construct`
-call:
+The prior implementation and closure are stale. On the fresh immutable census
+below, 33 ES2015 paths end in the same compile error; this issue is therefore
+**reopened** and must not be treated as done. This planning-only audit makes no
+production or Test262-source change, creates no GitHub issue, and does not run a
+compiler lane.
 
-```text
-Codegen error: Reflect.construct not supported in standalone mode (#1472 Phase C).
-```
+The blocking state is an ownership gate, not a claim that #2046 is the semantic
+prerequisite: active local #2046 currently owns
+src/codegen/expressions/call-namespace-static.ts. Rebase and audit after it
+lands before taking any source edit in that file.
 
-The original `20260717-151504` bucketing attributed **~160 direct failures** to
-this refusal (0 in the default/JS-host lane — the host path handles it, so this
-is a pure standalone gap). The 2026-07-20 preliminary original-harness run
-showed the larger dependency blast: **813 standalone failures**, of which
-**637 corpus tests include `isConstructor.js`**. That helper performs an honest
-three-argument `Reflect.construct(function () {}, [], value)` probe, so the
-single refusal blocks far more tests once the untouched Test262 harness runs.
+## Immutable evidence
 
-The refusal was left deliberately out of scope by **#1905** (native
-`Reflect.get/set/has/deleteProperty`), which states:
+| Item | Value |
+| --- | --- |
+| Source baseline | f841cddc0f0ea665b63700d9944a4372a34a8b57 |
+| Baselines commit | 8a39bd1d4ddf200f8db3751c878ece02aa8688fe |
+| Census artifact | /private/tmp/js2-baseline-census-f841cddc-r1/.test262-cache/test262-standalone-current.jsonl |
+| Artifact SHA-256 | 4426cbf6f305ab4a092468b201cc5854d4470b5fe87edf2fe47ba0195a6e8cbf |
+| Edition mapping | /private/tmp/js2-baseline-census-f841cddc-r1/.test262-cache/es2015-per-file-editions.json |
+| Exact result | 33 ES2015 paths, all compile_error |
 
-> `Reflect.apply` and `Reflect.construct` remain separate call/constructor
-> machinery and are **out of scope here** … `Reflect.construct` remain on the
-> standalone refusal path with the existing `#1472 Phase C` cite.
+The raw signature occurs in 64 all-edition census rows. This issue deliberately
+uses only the 33 rows whose path is explicitly in the ES2015 mapping; the other
+31 are not silently folded into this scope.
 
-Since #1472 is `done`, the refusal self-cites a closed issue and there is **no
-dedicated tracking issue** for actually implementing `Reflect.construct` in
-standalone — this issue fills that gap.
+Every listed row reports:
 
-## Affected tests (by category, 160 total)
+~~~
+Codegen error: standalone Reflect.construct cannot preserve an arbitrary distinct NewTarget without a statically-resolved NewTarget.prototype assignment (#3371).
+~~~
 
-| Count | Category                                                                                 |
-| ----- | ---------------------------------------------------------------------------------------- |
-| 47    | built-ins/TypedArrayConstructors (`proto-from-ctor-realm`, `use-custom-proto-if-object`) |
-| 14    | built-ins/DataView                                                                       |
-| 11    | built-ins/Proxy                                                                          |
-| 8     | built-ins/Function                                                                       |
-| 6     | built-ins/NativeErrors (`proto-from-ctor-realm`)                                         |
-| 6     | built-ins/Reflect                                                                        |
-| 6     | built-ins/ArrayBuffer                                                                    |
-| 6     | built-ins/SharedArrayBuffer                                                              |
-| 4     | built-ins/Date (`subclassing`)                                                           |
-| 4     | built-ins/AsyncDisposableStack                                                           |
-| …     | (Boolean/Number/String/Promise/Map/Set proto-from-ctor tails)                            |
+The refusal is in src/codegen/expressions/call-namespace-static.ts:1620-1627.
+The positive control remains healthy in the same census:
+test/built-ins/Reflect/construct/return-without-newtarget-argument.js
+(pass, reached and executed). Preserve that control while repairing the
+distinct-NewTarget cases.
 
-Sample files:
+## Current mechanism and defect boundary
 
-- `built-ins/TypedArrayConstructors/ctors/buffer-arg/proto-from-ctor-realm.js`
-- `built-ins/TypedArrayConstructors/ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js`
-- `built-ins/DataView/custom-proto-access-throws.js`
-- `built-ins/Date/subclassing.js`
-- `built-ins/NativeErrors/URIError/proto-from-ctor-realm.js`
+The Reflect.construct namespace-static lowering currently recognizes an
+array-literal argument list, builds a NewExpression, and asks
+assignedNewTargetPrototype() to find a syntactic prior
+Identifier.prototype = … assignment. If the scan cannot statically resolve one,
+it emits the refusal above. It is not a runtime Get(newTarget, "prototype"), so
+it cannot faithfully cover ordinary functions/classes, implicit prototypes,
+built-ins, bound functions, proxies, accessors, abrupt completion, realm
+behavior, or target-specific ordering.
 
-## Root cause
+There are already narrow native-view hooks (constructProto for DataView and
+dynamic typed arrays) and the constructor classifier from completed #4661.
+They are inputs to the eventual fix, not evidence that generic arbitrary
+NewTarget is implemented. Do not replace the runtime contract with a broader
+source-text scan.
 
-The dominant pattern is `Reflect.construct(Target, argsList, newTarget)` used to
-exercise §10.1.13 (`GetPrototypeFromConstructor` / `OrdinaryCreateFromConstructor`)
-— the instance's `[[Prototype]]` must come from `newTarget.prototype`, not
-`Target.prototype`. Standalone codegen has no lowering for:
+## Exact ES2015 refusal cluster (33)
 
-1. The `Reflect.construct` call site itself
-   (`src/codegen/expressions/call-namespace-static.ts`, the refusal gate that
-   #1905/#2046 kept fail-loud for construct).
-2. Threading a distinct `newTarget` through native `__new_<Parent>` construction
-   so the prototype is selected from `newTarget.prototype`.
+The paths below are the complete immutable ES2015 intersection. They are grouped
+by the target / NewTarget carrier that determines the prerequisite; the list is
+also the future isolated acceptance set.
 
-## Relationship to existing work
+### View target and accessor ordering — 9
 
-- **#3240** (ready) — native `__new_<Parent>` subclass constructors. That gives
-  the construction substrate but is driven by the `class X extends Parent`/`super()`
-  path, not the explicit `Reflect.construct(...)` API with an arbitrary NewTarget.
-  This issue should build on #3240's native ctors and add the NewTarget-driven
-  prototype-selection path plus the `Reflect.construct` call lowering.
-- **#2046** (in-progress) — Reflect get/set/deleteProperty spec fixes; keeps
-  construct fail-loud. This issue removes that refusal.
-- **#1472 Phase C** (done) — the umbrella whose cite the refusal string still
-  carries; update the cite to this issue when the refusal is retired.
+DataView target with a bound-function accessor NewTarget.prototype:
 
-## Implementation notes
+1. test/built-ins/DataView/byteOffset-validated-against-initial-buffer-length.js
+2. test/built-ins/DataView/custom-proto-access-detaches-buffer.js
+3. test/built-ins/DataView/custom-proto-access-throws.js
 
-The implementation deliberately reuses `compileNewExpression` for construction
-instead of duplicating constructor argument and native carrier semantics. Array
-literal argument lists are synthesized into a `new Target(...args)` expression;
-unresolved array-like and arbitrary carrier shapes remain fail-loud under
-**#3371**.
+Dynamic typed-array target with a bound-function accessor NewTarget:
 
-Ordinary functions use a nominal constructible closure subtype only in
-host-free targets, while arrows and method closures keep the existing
-callable-only wrapper. This gives the host-free `__reflect_is_constructor`
-helper a real runtime discriminator and keeps the Test262 probe honest:
-ordinary functions return true, arrows and `Date.prototype.getYear` return
-false. The JS-host lane keeps its established wrapper ABI; applying the marker
-there changed closure nominal types unnecessarily and caused 29 illegal-cast
-transitions in the merge-group Test262 run.
+4. test/built-ins/TypedArrayConstructors/ctors/length-arg/custom-proto-access-throws.js
+5. test/built-ins/TypedArrayConstructors/ctors/object-arg/custom-proto-access-throws.js
+6. test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/custom-proto-access-throws.js
+7. test/built-ins/TypedArrayConstructors/ctors/no-args/custom-proto-access-throws.js
+8. test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js
+9. test/built-ins/TypedArrayConstructors/ctors/buffer-arg/custom-proto-access-throws.js
 
-DataView and runtime-kinded TypedArray views gained an append-only
-`constructProto` carrier slot. A distinct object-valued `NewTarget.prototype`
-is stored there; a primitive/null prototype leaves the slot null and selects the
-target's intrinsic prototype. Their existing `Object.getPrototypeOf` native MOP
-arms read this override before the intrinsic singleton. The original realm shim
-aliases the current global, so `other[TA.name].prototype` is lowered by the
-TypedArray constructor kind to the same per-kind intrinsic singleton.
+These require real getter/abrupt and detachment ordering; row 8 additionally
+requires the argument TypeError before custom-prototype access. Coordinate with
+#5138 (in review) and #5150 / draft PR #5224 before touching the view carriers.
 
-Unblocking the untouched TypedArray representative exposed a separate call-ABI
-fault: its JSDoc callback typedef has two formals while the actual callback has
-one. Callable-parameter dispatch now pre-registers later callback wrappers,
-accepts shorter runtime signatures, and marshals only that signature's formal
-prefix, matching JavaScript's ignored-surplus-arguments rule.
+### Ordinary / class target — 4
 
-## Verification (2026-07-20)
+10. test/built-ins/Reflect/construct/return-with-newtarget-argument.js
+11. test/language/expressions/new.target/value-via-reflect-construct.js
+12. test/language/expressions/super/call-construct-invocation.js
+13. test/built-ins/Object/subclass-object-arg.js
 
-- Untouched original-harness representatives pass in standalone mode:
-  `annexB/built-ins/Date/prototype/getYear/not-a-constructor.js`,
-  `built-ins/TypedArrayConstructors/ctors/buffer-arg/proto-from-ctor-realm.js`,
-  and `built-ins/DataView/custom-proto-if-object-is-used.js`.
-- Focused tests cover two-argument construction, the honest IsConstructor
-  result matrix, DataView custom prototype selection, all nine dynamic
-  TypedArray intrinsic prototypes, the realm `Function` NewTarget, and the
-  shorter-formal harness callback.
-- Every successful standalone probe validates as Wasm and has zero imports.
-- Unsupported args-list shapes refuse with **#3371** and no `#1472` cite.
+This group covers a function with Array as NewTarget, ordinary custom NewTarget,
+a class/super invocation, and Object with a class NewTarget. Its immediate
+dependencies are the ownership/status audits for #2026 (dynamic class-as-value),
+#5153 (super), and #5154 (new.target).
 
-## Merge-queue follow-up (2026-07-21)
+### Native constructor carrier and ordering — 6
 
-- Bisected the 29 host `illegal_cast` transitions to the constructible-wrapper
-  change in this implementation: 26 existing async/dynamic-import failures had
-  become uncatchable traps and three Annex B function-block-scoping tests had
-  regressed from pass to trap.
-- Scoped constructor-marker wrappers to host-free targets. The exact 29-path
-  cluster now has zero `illegal_cast` rows; all three Annex B regressions pass,
-  while the existing non-pass rows return to ordinary runtime-error categories.
-- The complete focused #3371 suite remains green (15/15), including the three
-  standalone original-harness representatives and host ABI regression probes.
+14. test/built-ins/Date/subclassing.js
+15. test/built-ins/Error/prototype/stack/getter-foreign-new-target.js
+16. test/built-ins/ArrayBuffer/data-allocation-after-object-creation.js
+17. test/built-ins/ArrayBuffer/prototype-from-newtarget.js
+18. test/built-ins/Promise/get-prototype-abrupt.js
+19. test/built-ins/Promise/get-prototype-abrupt-executor-not-callable.js
 
-## Acceptance Criteria
+These cover Date, native Error, ArrayBuffer, and Promise. They must preserve
+each constructor's own allocation / validation order, including the
+non-callable-executor-before-prototype-getter requirement in row 19. Coordinate
+with #3240 (faithful native constructors), #5143 (Promise), #5150 (buffers),
+and #5156 (function/error); do not assume the ordinary slice can implement
+them.
 
-- [x] Representative `proto-from-ctor-realm` / custom-prototype TypedArray and
-      DataView tests compile and run under `target: "standalone"`.
-- [x] A distinct object-valued `NewTarget.prototype` is selected for supported
-      native carriers; primitive prototypes fall back to the target intrinsic.
-- [x] The original-harness Annex B IsConstructor probe observes ordinary versus
-      non-constructible callable values honestly.
-- [x] Any residual refusal cites **#3371**, not the closed #1472.
+### Proxy target or Proxy NewTarget — 10
+
+20. test/built-ins/Proxy/construct/call-parameters-new-target.js
+21. test/built-ins/Proxy/get-fn-realm.js
+22. test/built-ins/Proxy/construct/trap-is-undefined.js
+23. test/built-ins/Proxy/construct/trap-is-null.js
+24. test/built-ins/Proxy/get-fn-realm-recursive.js
+25. test/built-ins/Proxy/construct/trap-is-null-target-is-proxy.js
+26. test/built-ins/Proxy/construct/trap-is-undefined-proto-from-cross-realm-newtarget.js
+27. test/built-ins/Proxy/construct/trap-is-undefined-target-is-proxy.js
+28. test/built-ins/Proxy/construct/trap-is-missing-target-is-proxy.js
+29. test/built-ins/Proxy/construct/trap-is-undefined-no-property.js
+
+Keep this as a separate carrier slice. It needs proxy [[Construct]], trap result
+and forwarding semantics, recursive / cross-realm fallback behavior. #5140 (in
+review) identifies its residual Proxy cluster as out of scope, while #2618 is
+the host Proxy construct-path issue and is blocked on #56. Do not claim these as
+a generic Reflect.construct follow-up without coordinating those owners.
+
+### Bound-function carrier — 4
+
+30. test/built-ins/Function/prototype/bind/instance-construct-newtarget-boundtarget-bound.js
+31. test/built-ins/Function/prototype/bind/get-fn-realm-recursive.js
+32. test/built-ins/Function/prototype/bind/instance-construct-newtarget-boundtarget.js
+33. test/built-ins/Function/prototype/bind/get-fn-realm.js
+
+Completed #4196 supplies the bound [[Construct]] carrier (construct-bound.ts).
+This slice must compose its actual NewTarget forwarding and realm fallback; it
+must not reimplement or bypass that carrier.
+
+## Ownership and overlap audit
+
+| Scope | State at audit | Required treatment |
+| --- | --- | --- |
+| Local #3371 worktrees | This planning worktree only | No implementation has been started here. |
+| Local #2046 worktree | Active and dirty on codex/2046-reflect-set-receiver-f841-20260901 | It edits call-namespace-static.ts; wait for its landing and re-audit before source edits. |
+| #2046 source overlap | Its current diff is an import plus the Reflect.set arm around lines 896-935; #3371 refusal is around lines 1620-1627 | Semantically separate today, but a shared-file lease remains a merge/conflict risk. |
+| Open remote PR mentioning #3371 | None found | This does not reopen the issue automatically; the local plan is the authoritative handoff. |
+| Open remote PR touching call-namespace-static.ts | None found | Re-check immediately before implementation. |
+| Draft PR #5224 | WIP ES2015 buffers wave 1; changes DataView/buffer support but not call-namespace-static.ts | It does not block the ordinary carrier directly, but it owns adjacent view/buffer substrate for rows 1-9 and 16-17. |
+
+Relevant issue states at this audit: #4661 done; #2026 in progress; #4196 and
+#3240 ready; #5138, #5140, #5143, #5153, #5154, and #5156 in review; #5150 is
+ready with its adjacent WIP #5224. Re-check both issue and worktree ownership,
+not only labels, at the start of each implementation slice.
+
+## Implementation slices and sequencing
+
+Do not make a single patch for all 33 paths.
+
+1. **Release the shared-file gate.** Wait for #2046 to land. Rebase from the
+   then-current upstream, inspect the current ownership of
+   call-namespace-static.ts, and verify whether #2026/#5153/#5154 changed the
+   ordinary construction interfaces. This plan authorizes no source edit until
+   that check succeeds.
+
+2. **Ordinary/class runtime-NewTarget contract (rows 10-13).** This is the
+   first candidate post-#2046 slice. For the narrow ordinary function, class,
+   and Object paths, evaluate target, arguments, and NewTarget once in source
+   order; reuse #4661's IsConstructor machinery; perform the real prototype
+   operation rather than source scanning; and preserve returned objects, fallback
+   behavior, new.target, and super semantics. Exclude native views/buffers,
+   native Promise/Error/Date, bound functions, and proxies from this patch.
+
+3. **View getter / abrupt-order slice (rows 1-9).** Extend the existing
+   DataView and dynamic-typed-array construction-prototype hooks only after
+   coordination with #5138 and #5150/#5224. Preserve each constructor's
+   target-specific validation, detachment, and getter order; a static prototype
+   assignment is not an acceptable substitute.
+
+4. **Native constructor slice (rows 14-19).** Implement per-target
+   GetPrototypeFromConstructor-equivalent ordering only with the owners of
+   #3240, #5143, #5150, and #5156. Keep executor/argument validation and
+   allocation ordering observable before/after the prototype operation exactly
+   as required by each constructor.
+
+5. **Bound carrier slice (rows 30-33).** Integrate with #4196's bound construct
+   path, preserving forwarding and realm behavior instead of adding a second
+   bound-function model.
+
+6. **Proxy carrier slice (rows 20-29).** Wait for a coordinated #5140 and
+   #2618/#56 direction. Preserve trap behavior, recursive/cross-realm fallback,
+   target/newTarget forwarding, and invariant checking in the Proxy construct
+   implementation rather than papering over it in the namespace-static caller.
+
+### Safe first slice after #2046?
+
+**Yes, conditionally.** After #2046 lands and the prescribed fresh ownership
+audit succeeds, the four-row ordinary/class slice is non-overlapping with the
+active #2046 Reflect.set change and does not require the #5224 view/buffer
+files. It is not blanket authorization for all #3371 work: it must still honor
+any newly landed #2026/#5153/#5154 interfaces, and all view, native, bound, and
+Proxy groups remain separately owned.
+
+## Future acceptance and regression gate
+
+Run these only in the later implementation worktree, after acquiring ownership;
+they were intentionally **not** run for this planning audit.
+
+1. Re-fetch the current standalone baseline with the normal project workflow
+   (do not reuse a stale cache) and confirm all 33 paths above are pass, not
+   merely free of this one error signature. Confirm the positive control
+   test/built-ins/Reflect/construct/return-without-newtarget-argument.js
+   remains pass.
+
+2. Put the exact 33 paths above, with the leading test/ removed, in
+   .tmp/3371-es2015-paths.txt, then run the isolated corpus bucket:
+
+   ~~~sh
+   pnpm exec tsx scripts/run-test262-paths.mts \
+     --isolate .tmp/3371-es2015-paths.txt --standalone
+   ~~~
+
+   The isolate is required so a failure cannot be hidden by realm contamination.
+
+3. Run focused unit/host guards (using the repository's root-installed
+   dependencies, not a fresh worktree install):
+
+   ~~~sh
+   PATH="/Users/thomas/Code/js2/node_modules/.bin:$PATH" \
+     pnpm exec vitest run \
+       tests/issue-3371.test.ts \
+       tests/issue-4394-reflect-construct-newtarget.test.ts
+   ~~~
+
+4. Preserve the unit suite's zero-import / valid-Wasm and host ABI assertions.
+   Add focused regressions for any newly implemented carrier, including
+   evaluation order and abrupt completion; do not rebaseline until the true
+   result is understood.
+
+## Handoff
+
+The next owner should begin with slice 1's post-#2046 audit, then implement only
+the four ordinary/class paths if the interfaces are still unowned. Record a fresh
+precise result for all 33 paths after each slice, retain the no-distinct-
+NewTarget positive control, and leave each carrier group as a separate
+coordination decision. This document is the corrected reopen record; it does
+not certify the historical closure or authorize a broad source rewrite.

--- a/plan/issues/3371-standalone-reflect-construct-newtarget.md
+++ b/plan/issues/3371-standalone-reflect-construct-newtarget.md
@@ -1,8 +1,7 @@
 ---
 id: 3371
 title: "standalone: Reflect.construct arbitrary distinct NewTarget still refuses 33 ES2015 rows"
-status: blocked
-blocked_on: [2046]
+status: in-progress
 created: 2026-07-17
 updated: 2026-09-01
 reopened: 2026-09-01
@@ -10,7 +9,7 @@ sprint: current
 priority: high
 horizon: l
 feasibility: hard
-model: fable
+model: terra
 task_type: bugfix
 area: codegen, runtime
 language_feature: reflect, constructors, prototype chain
@@ -19,6 +18,7 @@ goal: standalone-mode
 umbrella: 1781
 related: [1472, 1781, 1905, 2026, 2046, 2618, 3240, 4196, 4661, 5138, 5140, 5143, 5150, 5153, 5154, 5156]
 origin: "2026-09-01 immutable f841 standalone census; reopened because the prior done closure still refuses arbitrary distinct NewTarget."
+checkpoint: ordinary-slice-authorized
 ---
 
 # #3371 — standalone Reflect.construct with arbitrary distinct NewTarget
@@ -31,10 +31,13 @@ below, 33 ES2015 paths end in the same compile error; this issue is therefore
 production or Test262-source change, creates no GitHub issue, and does not run a
 compiler lane.
 
-The blocking state is an ownership gate, not a claim that #2046 is the semantic
-prerequisite: active local #2046 currently owns
-src/codegen/expressions/call-namespace-static.ts. Rebase and audit after it
-lands before taking any source edit in that file.
+The former #2046 shared-file ownership gate is now released. Its implementation
+was frozen and published only as nonmergeable draft PR #5397; no further source
+work is active in that worktree and it is not a prerequisite for this issue.
+This implementation branch starts from current upstream main
+`2c3c27a54f78df2b71e034080dc509139776a2af`. The ordinary/class four-row slice
+below is authorized after a fresh overlap audit, while every view, native,
+bound-function, and Proxy carrier remains excluded.
 
 ## Immutable evidence
 
@@ -169,10 +172,10 @@ must not reimplement or bypass that carrier.
 
 | Scope | State at audit | Required treatment |
 | --- | --- | --- |
-| Local #3371 worktrees | This planning worktree only | No implementation has been started here. |
-| Local #2046 worktree | Active and dirty on codex/2046-reflect-set-receiver-f841-20260901 | It edits call-namespace-static.ts; wait for its landing and re-audit before source edits. |
-| #2046 source overlap | Its current diff is an import plus the Reflect.set arm around lines 896-935; #3371 refusal is around lines 1620-1627 | Semantically separate today, but a shared-file lease remains a merge/conflict risk. |
-| Open remote PR mentioning #3371 | None found | This does not reopen the issue automatically; the local plan is the authoritative handoff. |
+| Local #3371 worktrees | `issue-3371-reflect-construct-ordinary-20260901`, current-main branch | Terra owns only rows 10-13 after this plan checkpoint commits. |
+| Local #2046 worktree | Frozen at draft PR #5397; shepherded as nonmergeable and unqueued | No active file lease remains. Do not copy its unvalidated production diff. |
+| #2046 source overlap | Draft #5397 edits the Reflect.set arm; #3371 owns the distinct Reflect.construct refusal | Keep this slice based on current main and avoid depending on the draft helper. |
+| Open remote PR mentioning #3371 | Planning PR #5394, non-draft and queued before this branch was created | This branch carries that plan commit; do not open the implementation PR until its diff against current main is reviewed. |
 | Open remote PR touching call-namespace-static.ts | None found | Re-check immediately before implementation. |
 | Draft PR #5224 | WIP ES2015 buffers wave 1; changes DataView/buffer support but not call-namespace-static.ts | It does not block the ordinary carrier directly, but it owns adjacent view/buffer substrate for rows 1-9 and 16-17. |
 
@@ -185,11 +188,11 @@ not only labels, at the start of each implementation slice.
 
 Do not make a single patch for all 33 paths.
 
-1. **Release the shared-file gate.** Wait for #2046 to land. Rebase from the
-   then-current upstream, inspect the current ownership of
-   call-namespace-static.ts, and verify whether #2026/#5153/#5154 changed the
-   ordinary construction interfaces. This plan authorizes no source edit until
-   that check succeeds.
+1. **Release the shared-file gate — complete 2026-09-01.** #2046 stopped as
+   nonmergeable draft #5397, this branch was created from current upstream
+   `2c3c27a54f`, and no active worktree now leases the Reflect.construct arm.
+   Re-audit #2026/#5153/#5154 interfaces before editing and keep the ordinary
+   carrier independent of #2046's draft helper.
 
 2. **Ordinary/class runtime-NewTarget contract (rows 10-13).** This is the
    first candidate post-#2046 slice. For the narrow ordinary function, class,
@@ -220,14 +223,14 @@ Do not make a single patch for all 33 paths.
    target/newTarget forwarding, and invariant checking in the Proxy construct
    implementation rather than papering over it in the namespace-static caller.
 
-### Safe first slice after #2046?
+### Safe first slice after the #2046 freeze?
 
-**Yes, conditionally.** After #2046 lands and the prescribed fresh ownership
-audit succeeds, the four-row ordinary/class slice is non-overlapping with the
-active #2046 Reflect.set change and does not require the #5224 view/buffer
-files. It is not blanket authorization for all #3371 work: it must still honor
-any newly landed #2026/#5153/#5154 interfaces, and all view, native, bound, and
-Proxy groups remain separately owned.
+**Yes, conditionally.** With #2046 frozen rather than landing, the four-row
+ordinary/class slice is non-overlapping with its parked Reflect.set change and
+does not require the #5224 view/buffer files. It is not blanket authorization
+for all #3371 work: it must still honor any newly landed #2026/#5153/#5154
+interfaces, and all view, native, bound, and Proxy groups remain separately
+owned.
 
 ## Future acceptance and regression gate
 

--- a/plan/issues/3371-standalone-reflect-construct-newtarget.md
+++ b/plan/issues/3371-standalone-reflect-construct-newtarget.md
@@ -325,6 +325,15 @@ for this draft publication. They document the architectural fault rather than
 waive it: the successor must remove them while moving the state and dispatcher
 seam into a dedicated module.
 
+Post-sync validation after merging live `loopdive/js2` main
+`ca4b31eb12d4bae3275d02a17ca6b42f745932a6` into this checkpoint:
+
+- `pnpm run typecheck:ts7` — pass (exit 0).
+- Rows 10--13 — each retains the same explicit #3371 `compile_error` quoted
+  above; zero rows became pass and no row changed to a runtime failure.
+- `test/built-ins/Reflect/construct/return-without-newtarget-argument.js` —
+  pass.
+
 ## Future acceptance and regression gate
 
 Run these only in the later implementation worktree, after acquiring ownership;

--- a/src/codegen/class-constructor-wrapper.ts
+++ b/src/codegen/class-constructor-wrapper.ts
@@ -4,6 +4,8 @@ import type { FieldDef, FuncHandle, Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { definedFuncAt } from "./func-space.js";
 import { UNDEF_F64_BITS } from "./value-tags.js";
+import { dynamicProtoFieldIdx, dynamicProtoRootFor } from "./dynamic-proto.js";
+import { reflectConstructClassTargetId } from "./new-target.js";
 
 export interface AstFreeClassConstructorNewWrapperInput {
   readonly className: string;
@@ -100,6 +102,41 @@ function astFreeClassConstructorNewWrapperPlan(
   body.push({ op: "struct.new", typeIdx: structTypeIdx });
   const selfLocal = newSignature.params.length;
   body.push({ op: "local.set", index: selfLocal });
+  // (#3371) A marked Reflect.construct class target installs its selected
+  // NewTarget prototype BEFORE `_init` begins, so a derived constructor's
+  // `super()` sees the same allocated receiver and live new.target contract.
+  // The separate proto-owner slot is consumed here: nested ordinary `new C()`
+  // calls made by the constructor body must not inherit the outer override.
+  const protoOwnerGlobal = ctx.reflectConstructNewTargetProtoOwnerGlobalIdx;
+  const protoValueGlobal = ctx.reflectConstructNewTargetProtoGlobalIdx;
+  const reflectOwnerId = reflectConstructClassTargetId(ctx, className);
+  const protoRoot = dynamicProtoRootFor(ctx, className);
+  const protoFieldIdx = protoRoot === undefined ? undefined : dynamicProtoFieldIdx(ctx, protoRoot);
+  const protoRootTypeIdx = protoRoot === undefined ? undefined : ctx.structMap.get(protoRoot);
+  if (
+    protoOwnerGlobal !== undefined &&
+    protoValueGlobal !== undefined &&
+    reflectOwnerId !== undefined &&
+    protoFieldIdx !== undefined &&
+    protoRootTypeIdx !== undefined
+  ) {
+    body.push(
+      { op: "global.get", index: protoOwnerGlobal },
+      { op: "i32.const", value: reflectOwnerId },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: selfLocal },
+          { op: "global.get", index: protoValueGlobal },
+          { op: "struct.set", typeIdx: protoRootTypeIdx, fieldIdx: protoFieldIdx },
+          { op: "i32.const", value: 0 },
+          { op: "global.set", index: protoOwnerGlobal },
+        ],
+      },
+    );
+  }
   for (let index = 0; index < newSignature.params.length; index++) {
     body.push({ op: "local.get", index });
   }

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -163,6 +163,10 @@ export function createCodegenContext(
     usesNewTarget: false, // (#2023) set by the pre-scan in generateModule
     newTargetGlobalIdx: undefined, // (#2023)
     classNewTargetIds: new Map(), // (#2023) className → stable 1-based i32 id
+    reflectConstructNewTargetOwnerGlobalIdx: undefined, // (#3371)
+    reflectConstructNewTargetValueGlobalIdx: undefined, // (#3371)
+    reflectConstructNewTargetProtoOwnerGlobalIdx: undefined, // (#3371)
+    reflectConstructNewTargetProtoGlobalIdx: undefined, // (#3371)
     usesDynamicProto: false, // (#802) set by the scanForDynamicProto pre-scan
     dynamicProtoClasses: new Set(), // (#802) hierarchy-ROOT class names receiving proto mutation (Slice B)
     dynamicProtoLiteralNodes: new WeakSet(), // (#802) object-literal proto receivers (Slice A)

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -799,6 +799,18 @@ export interface FunctionContext {
    */
   isFnctorConstructor?: boolean;
   /**
+   * (#3371) A source function admitted as the stable target of the narrow
+   * standalone `Reflect.construct` route. Its ordinary body reads the runtime
+   * NewTarget only while the matching owner id is active.
+   */
+  reflectConstructNewTargetId?: number;
+  /**
+   * (#3371) A synthesized ordinary-function constructor reached from a marked
+   * class's `super()` chain. It inherits the active Reflect.construct
+   * NewTarget without claiming a new owner id of its own.
+   */
+  reflectConstructNewTargetPassThrough?: boolean;
+  /**
    * (#4464) Local index of the constructed `this` receiver when the
    * construction result is an EXTERNREF object rather than a nominal struct —
    * the `new function(){…}` FunctionExpression lowering. Set ⇒
@@ -1602,6 +1614,18 @@ export interface CodegenContext extends StandaloneCapabilityDemandState, BodyRou
   usesNewTarget: boolean;
   newTargetGlobalIdx: number | undefined;
   classNewTargetIds: Map<string, number>;
+  /**
+   * (#3371) Runtime state for the narrow standalone `Reflect.construct`
+   * ordinary/class route. The owner/value pair is visible to a source function
+   * body that is statically known to be the construct target; the separate
+   * prototype-owner/value pair is consumed once by a marked class allocation
+   * wrapper before its `_init` body (and therefore `super()`) runs. All four
+   * are cached absolute global indices and must follow imported-global shifts.
+   */
+  reflectConstructNewTargetOwnerGlobalIdx: number | undefined;
+  reflectConstructNewTargetValueGlobalIdx: number | undefined;
+  reflectConstructNewTargetProtoOwnerGlobalIdx: number | undefined;
+  reflectConstructNewTargetProtoGlobalIdx: number | undefined;
   /**
    * (#802) Dynamic prototype support. Set by the `scanForDynamicProto` pre-scan
    * when the program mutates an object's [[Prototype]] at runtime

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -79,7 +79,7 @@ import { compileCallExpression } from "./expressions/calls.js";
 import { isForeignEvalNode } from "./expressions/eval-source.js";
 
 import { compileClassExpression, compileNewExpression } from "./expressions/new-super.js";
-import { emitNewTargetClassId } from "./new-target.js"; // (#2023)
+import { emitNewTargetClassId, emitReflectConstructNewTargetRead } from "./new-target.js"; // (#2023 / #3371)
 
 import { compileConditionalExpression, compileYieldExpression } from "./expressions/misc.js";
 
@@ -1583,6 +1583,12 @@ function compileExpressionInner(
   }
 
   if (ts.isMetaProperty(expr) && expr.keywordToken === ts.SyntaxKind.NewKeyword && expr.name.text === "target") {
+    // (#3371) An admitted ordinary Reflect.construct target keeps its source
+    // function body on the normal closure path, so it needs the explicit
+    // runtime NewTarget value rather than the class-only i32 id. Synthesized
+    // fnctor bodies in an admitted class's super chain use the pass-through
+    // variant. Every other function retains the existing undefined result.
+    if (emitReflectConstructNewTargetRead(ctx, fctx)) return { kind: "externref" };
     if (fctx.isConstructor) {
       // (#2023) Read the live new.target class-id (set at the outermost `new`
       // site, preserved through super()). Non-zero inside a construction, so

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -58,7 +58,15 @@ import { emitBoundsCheckedArrayGet } from "../array-methods.js";
 import { emitObjectCoercion } from "./calls-guards.js"; // (#3118) shared Object(...) / new Object(...) ToObject coercion
 import { COLLECTION_KIND, ensureMapHelpers, coerceMapKeyToAnyref } from "../map-runtime.js";
 import { ensureDisposableStackNew } from "../disposable-runtime.js";
-import { emitSetNewTargetBeforeCall, ensureNewTargetGlobal } from "../new-target.js"; // (#2023)
+import {
+  activateReflectConstructNewTarget,
+  emitSetNewTargetBeforeCall,
+  ensureNewTargetGlobal,
+  reflectConstructFnctorPassesNewTarget,
+  restoreReflectConstructNewTargetState,
+  saveReflectConstructNewTargetState,
+  type SavedReflectConstructNewTargetState,
+} from "../new-target.js"; // (#2023 / #3371)
 import {
   ensureNativeProxyRuntime,
   ensureObjectRuntime,
@@ -75,6 +83,7 @@ import {
   resolveComputedKeyExpression,
 } from "../literals.js";
 import { stringConstantExternrefInstrs, ensureAnyToStringHelper } from "../native-strings.js";
+import { emitLazyProtoGet } from "./extern.js";
 import {
   MAX_NATIVE_CONSTRUCT_ARITY,
   reserveNativeConstructDriver,
@@ -2085,6 +2094,7 @@ function compileNewFunctionDeclaration(
     });
   }
   appendFnctorConstructorParam(ctx, paramDefs);
+  const reflectConstructPassThrough = reflectConstructFnctorPassesNewTarget(ctx, funcDecl);
 
   const ctorFctx: FunctionContext = {
     name: ctorName,
@@ -2105,6 +2115,7 @@ function compileNewFunctionDeclaration(
     // return type — i.e. pushed `ref.null $__fnctor_<F>` — and the `new` site
     // trapped on the first property read. See `isFnctorConstructor`.
     isFnctorConstructor: true,
+    ...(reflectConstructPassThrough ? { reflectConstructNewTargetPassThrough: true } : {}),
     // The JS-host constructor executes with a concrete fnctor receiver, which
     // lets constructor-time prototype calls use the in-Wasm driver before
     // exports are available. Standalone keeps the historical dynamic `this`
@@ -4959,7 +4970,23 @@ function usesHostConstructClosureBase(ctx: CodegenContext, expression: ts.Expres
   );
 }
 
-function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: ts.NewExpression): ValType | null {
+export interface ReflectConstructClassNewTarget {
+  readonly expression: ts.Expression;
+  readonly ownerId: number;
+  /** A local class uses its prototype singleton rather than a generic carrier read. */
+  readonly className?: string;
+}
+
+export interface CompileNewExpressionOptions {
+  readonly reflectConstructNewTarget?: ReflectConstructClassNewTarget;
+}
+
+function compileNewExpression(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.NewExpression,
+  options?: CompileNewExpressionOptions,
+): ValType | null {
   // (#3927 per-type layouts) Publish the allocation-label hint when this `new`
   // is a recorded label site of a split family. BEFORE the arguments compile —
   // a labelled allocation nested in them consumes and resets the hint, so the
@@ -6574,6 +6601,52 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       }
     }
 
+    // (#3371) Reflect.construct evaluates NewTarget after the argument list,
+    // then makes both its identity and GetPrototypeFromConstructor result live
+    // for this one allocation. The class wrapper consumes the proto owner
+    // before `_init`/`super`; the owner/value pair stays live for an admitted
+    // ordinary-function parent that reads `new.target`.
+    let reflectConstructSaved: SavedReflectConstructNewTargetState | undefined;
+    const reflectConstructNewTarget = options?.reflectConstructNewTarget;
+    if (reflectConstructNewTarget) {
+      const newTargetType = compileExpression(ctx, fctx, reflectConstructNewTarget.expression, { kind: "externref" });
+      if (newTargetType && newTargetType.kind !== "externref") {
+        coerceType(ctx, fctx, newTargetType, { kind: "externref" });
+      } else if (newTargetType === null) {
+        fctx.body.push({ op: "ref.null.extern" });
+      }
+      const newTargetLocal = allocLocal(fctx, `__reflect_construct_nt_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: newTargetLocal });
+
+      if (reflectConstructNewTarget.className && emitLazyProtoGet(ctx, fctx, reflectConstructNewTarget.className)) {
+        // The class prototype singleton is the compiler's authoritative
+        // representation; generic `__extern_get` cannot recover it reliably.
+      } else {
+        ensureObjectRuntime(ctx);
+        addStringConstantGlobal(ctx, "prototype");
+        const getPrototypeIdx = ctx.funcMap.get("__extern_get");
+        if (getPrototypeIdx !== undefined) {
+          fctx.body.push(
+            { op: "local.get", index: newTargetLocal },
+            ...stringConstantExternrefInstrs(ctx, "prototype"),
+            { op: "call", funcIdx: getPrototypeIdx },
+          );
+        } else {
+          fctx.body.push({ op: "ref.null.extern" });
+        }
+      }
+      const prototypeLocal = allocLocal(fctx, `__reflect_construct_proto_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: prototypeLocal });
+      reflectConstructSaved = saveReflectConstructNewTargetState(ctx, fctx);
+      activateReflectConstructNewTarget(
+        ctx,
+        fctx.body,
+        reflectConstructNewTarget.ownerId,
+        newTargetLocal,
+        prototypeLocal,
+      );
+    }
+
     // (#2023) With args on the stack, set new.target to THIS class's id right
     // before the call. The ctor body (and the super() chain it drives, which
     // calls `_init` and never touches the global) reads this id.
@@ -6602,6 +6675,13 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       fctx.body.push({ op: "local.get", index: resultLocal });
       releaseTempLocal(fctx, resultLocal);
       releaseTempLocal(fctx, ntPrevLocal);
+    }
+    if (reflectConstructSaved !== undefined) {
+      const resultLocal = allocTempLocal(fctx, { kind: "ref", typeIdx: structTypeIdx });
+      fctx.body.push({ op: "local.set", index: resultLocal });
+      restoreReflectConstructNewTargetState(ctx, fctx.body, reflectConstructSaved);
+      fctx.body.push({ op: "local.get", index: resultLocal });
+      releaseTempLocal(fctx, resultLocal);
     }
     return { kind: "ref", typeIdx: structTypeIdx };
   }

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -81,6 +81,7 @@ import {
   functionMayReachDirectEval,
   reifyCurrentDirectEvalBindings,
 } from "./direct-eval-environment.js";
+import { reflectConstructFunctionTargetId } from "./new-target.js"; // (#3371)
 
 /** Maximum number of instructions for a function body to be considered inlinable */
 export const INLINE_MAX_INSTRS = 10;
@@ -358,6 +359,7 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
   // ordinary calls and only changes the value when a receiver was actually
   // installed by an enclosing dispatch.
   const readsThis = decl.body ? bodyReferencesOwnThis(decl.body) : false;
+  const reflectConstructTargetId = reflectConstructFunctionTargetId(ctx, decl);
 
   const fctx: FunctionContext = {
     name: func.name,
@@ -373,6 +375,7 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
     savedBodies: [],
     isGenerator,
     readsCurrentThis: readsThis,
+    ...(reflectConstructTargetId !== undefined ? { reflectConstructNewTargetId: reflectConstructTargetId } : {}),
     i32CoercedLocals: i32CoercedLocals.size > 0 ? i32CoercedLocals : undefined,
     i32SpecializedArrays: i32SpecializedArrays.size > 0 ? i32SpecializedArrays : undefined,
   };

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -272,7 +272,7 @@ import type {
 } from "./context/types.js";
 import type { NodeBuiltinImport } from "../import-resolver.js";
 import { ensureMapRuntimeTypes } from "./map-runtime.js";
-import { scanForNewTarget } from "./new-target.js"; // (#2023)
+import { scanForNewTarget, scanForStandaloneReflectConstructNewTarget } from "./new-target.js"; // (#2023 / #3371)
 import { scanForDynamicProto, fillDynamicProtoHelpers } from "./dynamic-proto.js"; // (#802)
 import { scanForArrayHoles, ensureHoleType } from "./array-holes.js"; // (#2001 S1)
 import {
@@ -5421,6 +5421,10 @@ export function generateModule(
     // Off by default — programs without holes are byte-identical.
     scanForArrayHoles(ctx, ast.sourceFile);
 
+    // (#3371) This must run after scanForArrayHoles populates dynamicCodeDirty
+    // and before collectDeclarations fixes the marked class-root layout.
+    scanForStandaloneReflectConstructNewTarget(ctx, ast.sourceFile);
+
     if (
       options?.experimentalIR &&
       ctx.standalone &&
@@ -10362,6 +10366,15 @@ export function generateMultiModule(multiAst: MultiTypedAST, options?: CodegenOp
     profilePhase("array-hole-scan", () => {
       for (const sf of multiAst.sourceFiles) {
         scanForArrayHoles(ctx, sf);
+      }
+    });
+
+    // (#3371) Admit only stable ordinary/class Reflect.construct sites after
+    // the direct-eval scan, but before declaration collection fixes class
+    // layouts. A direct eval makes an otherwise lexical binding unsafe here.
+    profilePhase("reflect-construct-newtarget-scan", () => {
+      for (const sf of multiAst.sourceFiles) {
+        scanForStandaloneReflectConstructNewTarget(ctx, sf);
       }
     });
 

--- a/src/codegen/new-target.ts
+++ b/src/codegen/new-target.ts
@@ -25,7 +25,13 @@
 
 import { ts, forEachChild } from "../ts-api.js";
 import type { CodegenContext } from "./context/types.js";
+import type { FunctionContext } from "./context/types.js";
 import type { Instr } from "../ir/types.js";
+import { allocLocal } from "./context/locals.js";
+import { nextModuleGlobalIdx } from "./registry/imports.js";
+import { resolvesToAmbientGlobal } from "./expressions/non-constructable.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
+import { undefinedExternInstrs } from "./any-helpers.js";
 
 /**
  * Pre-scan the source for any `new.target` meta-property. Sets
@@ -94,4 +100,515 @@ export function emitSetNewTargetBeforeCall(ctx: CodegenContext, body: Instr[], c
   const classId = getOrAssignClassNewTargetId(ctx, className);
   body.push({ op: "i32.const", value: classId });
   body.push({ op: "global.set", index: globalIdx });
+}
+
+// ── #3371: standalone Reflect.construct ordinary/class admission ──────────
+
+export interface StandaloneReflectConstructOrdinarySite {
+  readonly targetKind: "function" | "class" | "object";
+  /** Source name of the direct ordinary-function or class allocation target. */
+  readonly targetName: string;
+  /** Non-zero only for an ordinary function target whose body may read new.target. */
+  readonly ownerId: number;
+  readonly newTargetKind: "same" | "function" | "class" | "array";
+  /** Present for a class NewTarget so codegen can use the class-prototype source of truth. */
+  readonly newTargetClassName?: string;
+}
+
+interface ReflectConstructOrdinaryScanState {
+  readonly sites: WeakMap<ts.CallExpression, StandaloneReflectConstructOrdinarySite>;
+  readonly functionTargetIds: WeakMap<ts.Node, number>;
+  readonly fnctorPassThrough: WeakSet<ts.Node>;
+  readonly classTargetIds: Map<string, number>;
+  nextOwnerId: number;
+}
+
+const reflectConstructOrdinaryStates = new WeakMap<CodegenContext, ReflectConstructOrdinaryScanState>();
+
+function reflectConstructOrdinaryState(ctx: CodegenContext): ReflectConstructOrdinaryScanState {
+  let state = reflectConstructOrdinaryStates.get(ctx);
+  if (!state) {
+    state = {
+      sites: new WeakMap(),
+      functionTargetIds: new WeakMap(),
+      fnctorPassThrough: new WeakSet(),
+      classTargetIds: new Map(),
+      nextOwnerId: 1,
+    };
+    reflectConstructOrdinaryStates.set(ctx, state);
+  }
+  return state;
+}
+
+function unwrapReflectConstructOperand(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+}
+
+function eachBindingIdentifier(node: ts.Node, visit: (identifier: ts.Identifier) => void): void {
+  if (ts.isIdentifier(node)) {
+    visit(node);
+    return;
+  }
+  if (ts.isParenthesizedExpression(node) || ts.isAsExpression(node) || ts.isNonNullExpression(node)) {
+    eachBindingIdentifier(node.expression, visit);
+    return;
+  }
+  if (ts.isArrayBindingPattern(node) || ts.isObjectBindingPattern(node)) {
+    for (const element of node.elements) {
+      if (ts.isOmittedExpression(element)) continue;
+      eachBindingIdentifier(element.name, visit);
+    }
+    return;
+  }
+  if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+    eachBindingIdentifier(node.left, visit);
+  }
+}
+
+function hasNewTarget(node: ts.Node): boolean {
+  let found = false;
+  const visit = (child: ts.Node): void => {
+    if (found) return;
+    if (ts.isMetaProperty(child) && child.keywordToken === ts.SyntaxKind.NewKeyword && child.name.text === "target") {
+      found = true;
+      return;
+    }
+    forEachChild(child, visit);
+  };
+  visit(node);
+  return found;
+}
+
+function isWithinWith(node: ts.Node): boolean {
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    if (ts.isWithStatement(current)) return true;
+  }
+  return false;
+}
+
+function bindingIsStableInSource(ctx: CodegenContext, identifier: ts.Identifier, declaration: ts.Declaration): boolean {
+  if (identifier.getSourceFile() !== declaration.getSourceFile()) return false;
+  const sourceFile = identifier.getSourceFile();
+  let stable = true;
+  const isBinding = (candidate: ts.Identifier): boolean => ctx.oracle.valueDeclarationOf(candidate) === declaration;
+  const hasPrototypeWrite = (left: ts.Expression): boolean =>
+    ts.isPropertyAccessExpression(left) &&
+    left.name.text === "prototype" &&
+    ts.isIdentifier(unwrapReflectConstructOperand(left.expression)) &&
+    isBinding(unwrapReflectConstructOperand(left.expression) as ts.Identifier);
+  const visit = (node: ts.Node): void => {
+    if (!stable) return;
+    if (ts.isBinaryExpression(node) && isAssignmentOperator(node.operatorToken.kind)) {
+      eachBindingIdentifier(node.left, (candidate) => {
+        if (isBinding(candidate)) stable = false;
+      });
+      if (hasPrototypeWrite(node.left)) stable = false;
+    }
+    if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)
+    ) {
+      eachBindingIdentifier(node.operand, (candidate) => {
+        if (isBinding(candidate)) stable = false;
+      });
+    }
+    if (ts.isVariableDeclaration(node) && node !== declaration && node.initializer) {
+      eachBindingIdentifier(node.name, (candidate) => {
+        if (isBinding(candidate)) stable = false;
+      });
+    }
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === "Object" &&
+      (node.expression.name.text === "defineProperty" || node.expression.name.text === "defineProperties") &&
+      node.arguments[0] &&
+      ts.isIdentifier(unwrapReflectConstructOperand(node.arguments[0]!)) &&
+      isBinding(unwrapReflectConstructOperand(node.arguments[0]!) as ts.Identifier)
+    ) {
+      stable = false;
+    }
+    forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return stable;
+}
+
+interface OrdinaryCarrier {
+  readonly kind: "function" | "class" | "object" | "array";
+  readonly name: string;
+  readonly declaration?: ts.Declaration;
+  readonly classDeclaration?: ts.ClassDeclaration;
+}
+
+function ordinaryCarrier(ctx: CodegenContext, expression: ts.Expression): OrdinaryCarrier | undefined {
+  const unwrapped = unwrapReflectConstructOperand(expression);
+  if (!ts.isIdentifier(unwrapped)) return undefined;
+  if (unwrapped.text === "Object" && resolvesToAmbientGlobal(ctx, unwrapped)) {
+    return { kind: "object", name: "Object" };
+  }
+  if (unwrapped.text === "Array" && resolvesToAmbientGlobal(ctx, unwrapped)) {
+    return { kind: "array", name: "Array" };
+  }
+  const declaration = ctx.oracle.valueDeclarationOf(unwrapped);
+  if (!declaration || !bindingIsStableInSource(ctx, unwrapped, declaration)) return undefined;
+  if (ts.isFunctionDeclaration(declaration)) return { kind: "function", name: unwrapped.text, declaration };
+  if (ts.isClassDeclaration(declaration) && declaration.name) {
+    return { kind: "class", name: declaration.name.text, declaration, classDeclaration: declaration };
+  }
+  if (ts.isVariableDeclaration(declaration)) {
+    const initializer = declaration.initializer && unwrapReflectConstructOperand(declaration.initializer);
+    if (initializer && ts.isFunctionExpression(initializer)) {
+      return { kind: "function", name: unwrapped.text, declaration };
+    }
+  }
+  return undefined;
+}
+
+function hasExplicitConstructor(declaration: ts.ClassDeclaration): boolean {
+  return declaration.members.some((member) => ts.isConstructorDeclaration(member));
+}
+
+function isSimpleObjectSubclass(ctx: CodegenContext, carrier: OrdinaryCarrier): boolean {
+  if (carrier.kind !== "class" || !carrier.classDeclaration || hasExplicitConstructor(carrier.classDeclaration))
+    return false;
+  const parent = carrier.classDeclaration.heritageClauses?.find(
+    (clause) => clause.token === ts.SyntaxKind.ExtendsKeyword,
+  )?.types[0]?.expression;
+  return !!parent && ts.isIdentifier(parent) && parent.text === "Object" && resolvesToAmbientGlobal(ctx, parent);
+}
+
+/**
+ * Record only source-proven ordinary/class Reflect.construct sites before
+ * declaration collection. This is a carrier admission scan, not a substitute
+ * for GetPrototypeFromConstructor: accepted call sites still read the selected
+ * NewTarget prototype at runtime.
+ */
+export function scanForStandaloneReflectConstructNewTarget(ctx: CodegenContext, root: ts.Node): void {
+  if (!ctx.standalone || ctx.dynamicCodeDirty) return;
+  const state = reflectConstructOrdinaryState(ctx);
+  const declaredClasses = new Set<string>();
+  const classParents = new Map<string, string>();
+  const classByName = new Map<string, ts.ClassDeclaration>();
+  const collectClasses = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node) && node.name) {
+      declaredClasses.add(node.name.text);
+      classByName.set(node.name.text, node);
+      const parent = node.heritageClauses?.find((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)?.types[0]
+        ?.expression;
+      if (parent && ts.isIdentifier(parent)) classParents.set(node.name.text, parent.text);
+    }
+    forEachChild(node, collectClasses);
+  };
+  collectClasses(root);
+
+  const ownerIdForFunction = (declaration: ts.Declaration): number => {
+    const existing = state.functionTargetIds.get(declaration);
+    if (existing !== undefined) return existing;
+    const id = state.nextOwnerId++;
+    state.functionTargetIds.set(declaration, id);
+    return id;
+  };
+  const ownerIdForClass = (name: string): number => {
+    const existing = state.classTargetIds.get(name);
+    if (existing !== undefined) return existing;
+    const id = state.nextOwnerId++;
+    state.classTargetIds.set(name, id);
+    return id;
+  };
+  const markClassAllocation = (name: string): number | undefined => {
+    if (!classByName.has(name)) return undefined;
+    let rootName = name;
+    const seen = new Set([name]);
+    for (;;) {
+      const parent = classParents.get(rootName);
+      if (!parent || !declaredClasses.has(parent) || seen.has(parent)) break;
+      seen.add(parent);
+      rootName = parent;
+    }
+    ctx.usesDynamicProto = true;
+    ctx.dynamicProtoClasses.add(rootName);
+    ensureReflectConstructNewTargetGlobals(ctx);
+    return ownerIdForClass(name);
+  };
+  const markFunctionSuperConsumer = (classDeclaration: ts.ClassDeclaration): void => {
+    const parent = classDeclaration.heritageClauses?.find((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
+      ?.types[0]?.expression;
+    if (!parent) return;
+    const carrier = ordinaryCarrier(ctx, parent);
+    if (carrier?.kind === "function" && carrier.declaration && hasNewTarget(carrier.declaration)) {
+      state.fnctorPassThrough.add(carrier.declaration);
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === "Reflect" &&
+      resolvesToAmbientGlobal(ctx, node.expression.expression) &&
+      node.expression.name.text === "construct" &&
+      node.arguments.length >= 2 &&
+      node.arguments.length <= 3 &&
+      !isWithinWith(node)
+    ) {
+      const target = ordinaryCarrier(ctx, node.arguments[0]!);
+      const list = unwrapReflectConstructOperand(node.arguments[1]!);
+      const explicitNewTarget = node.arguments[2];
+      const newTarget = explicitNewTarget ? ordinaryCarrier(ctx, explicitNewTarget) : target;
+      const validList =
+        ts.isArrayLiteralExpression(list) &&
+        !list.elements.some((element) => ts.isOmittedExpression(element) || ts.isSpreadElement(element));
+      if (target && newTarget && validList) {
+        if (target.kind === "function" && target.declaration && list.elements.length <= 8) {
+          const ownerId = ownerIdForFunction(target.declaration);
+          const newTargetKind =
+            explicitNewTarget === undefined
+              ? "same"
+              : newTarget.kind === "function"
+                ? "function"
+                : newTarget.kind === "class"
+                  ? "class"
+                  : newTarget.kind === "array"
+                    ? "array"
+                    : undefined;
+          if (newTargetKind) {
+            ensureReflectConstructNewTargetGlobals(ctx);
+            state.sites.set(node, {
+              targetKind: "function",
+              targetName: target.name,
+              ownerId,
+              newTargetKind,
+              ...(newTarget.kind === "class" ? { newTargetClassName: newTarget.name } : {}),
+            });
+          }
+        } else if (
+          target.kind === "class" &&
+          target.classDeclaration &&
+          explicitNewTarget &&
+          !hasNewTarget(target.classDeclaration)
+        ) {
+          const ownerId = markClassAllocation(target.name);
+          if (ownerId !== undefined) {
+            markFunctionSuperConsumer(target.classDeclaration);
+            const newTargetKind =
+              newTarget.kind === "function"
+                ? "function"
+                : newTarget.kind === "class"
+                  ? "class"
+                  : newTarget.kind === "array"
+                    ? "array"
+                    : undefined;
+            if (newTargetKind) {
+              state.sites.set(node, {
+                targetKind: "class",
+                targetName: target.name,
+                ownerId,
+                newTargetKind,
+                ...(newTarget.kind === "class" ? { newTargetClassName: newTarget.name } : {}),
+              });
+            }
+          }
+        } else if (target.kind === "object" && explicitNewTarget && isSimpleObjectSubclass(ctx, newTarget)) {
+          const ownerId = markClassAllocation(newTarget.name);
+          if (ownerId !== undefined) {
+            state.sites.set(node, {
+              targetKind: "object",
+              targetName: newTarget.name,
+              ownerId,
+              newTargetKind: "class",
+              newTargetClassName: newTarget.name,
+            });
+          }
+        }
+      }
+    }
+    forEachChild(node, visit);
+  };
+  visit(root);
+}
+
+export function standaloneReflectConstructOrdinarySite(
+  ctx: CodegenContext,
+  call: ts.CallExpression,
+): StandaloneReflectConstructOrdinarySite | undefined {
+  return reflectConstructOrdinaryStates.get(ctx)?.sites.get(call);
+}
+
+export function reflectConstructFunctionTargetId(ctx: CodegenContext, declaration: ts.Node): number | undefined {
+  return reflectConstructOrdinaryStates.get(ctx)?.functionTargetIds.get(declaration);
+}
+
+export function reflectConstructFnctorPassesNewTarget(ctx: CodegenContext, declaration: ts.Node): boolean {
+  return reflectConstructOrdinaryStates.get(ctx)?.fnctorPassThrough.has(declaration) === true;
+}
+
+export function reflectConstructClassTargetId(ctx: CodegenContext, className: string): number | undefined {
+  return reflectConstructOrdinaryStates.get(ctx)?.classTargetIds.get(className);
+}
+
+export interface ReflectConstructNewTargetGlobals {
+  readonly owner: number;
+  readonly value: number;
+  readonly prototypeOwner: number;
+  readonly prototypeValue: number;
+}
+
+export function ensureReflectConstructNewTargetGlobals(ctx: CodegenContext): ReflectConstructNewTargetGlobals {
+  const existingOwner = ctx.reflectConstructNewTargetOwnerGlobalIdx;
+  const existingValue = ctx.reflectConstructNewTargetValueGlobalIdx;
+  const existingPrototypeOwner = ctx.reflectConstructNewTargetProtoOwnerGlobalIdx;
+  const existingPrototypeValue = ctx.reflectConstructNewTargetProtoGlobalIdx;
+  if (
+    existingOwner !== undefined &&
+    existingValue !== undefined &&
+    existingPrototypeOwner !== undefined &&
+    existingPrototypeValue !== undefined
+  ) {
+    return {
+      owner: existingOwner,
+      value: existingValue,
+      prototypeOwner: existingPrototypeOwner,
+      prototypeValue: existingPrototypeValue,
+    };
+  }
+  const owner = nextModuleGlobalIdx(ctx);
+  ctx.mod.globals.push({
+    name: "__reflect_construct_newtarget_owner",
+    type: { kind: "i32" },
+    mutable: true,
+    init: [{ op: "i32.const", value: 0 }],
+  });
+  const value = nextModuleGlobalIdx(ctx);
+  ctx.mod.globals.push({
+    name: "__reflect_construct_newtarget_value",
+    type: { kind: "externref" },
+    mutable: true,
+    init: [{ op: "ref.null.extern" }],
+  });
+  const prototypeOwner = nextModuleGlobalIdx(ctx);
+  ctx.mod.globals.push({
+    name: "__reflect_construct_newtarget_proto_owner",
+    type: { kind: "i32" },
+    mutable: true,
+    init: [{ op: "i32.const", value: 0 }],
+  });
+  const prototypeValue = nextModuleGlobalIdx(ctx);
+  ctx.mod.globals.push({
+    name: "__reflect_construct_newtarget_proto",
+    type: { kind: "externref" },
+    mutable: true,
+    init: [{ op: "ref.null.extern" }],
+  });
+  ctx.reflectConstructNewTargetOwnerGlobalIdx = owner;
+  ctx.reflectConstructNewTargetValueGlobalIdx = value;
+  ctx.reflectConstructNewTargetProtoOwnerGlobalIdx = prototypeOwner;
+  ctx.reflectConstructNewTargetProtoGlobalIdx = prototypeValue;
+  return { owner, value, prototypeOwner, prototypeValue };
+}
+
+export interface SavedReflectConstructNewTargetState {
+  readonly ownerLocal: number;
+  readonly valueLocal: number;
+  readonly prototypeOwnerLocal: number;
+  readonly prototypeValueLocal: number;
+}
+
+export function saveReflectConstructNewTargetState(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+): SavedReflectConstructNewTargetState {
+  const globals = ensureReflectConstructNewTargetGlobals(ctx);
+  const ownerLocal = allocLocal(fctx, `__reflect_nt_owner_${fctx.locals.length}`, { kind: "i32" });
+  const valueLocal = allocLocal(fctx, `__reflect_nt_value_${fctx.locals.length}`, { kind: "externref" });
+  const prototypeOwnerLocal = allocLocal(fctx, `__reflect_nt_proto_owner_${fctx.locals.length}`, { kind: "i32" });
+  const prototypeValueLocal = allocLocal(fctx, `__reflect_nt_proto_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push(
+    { op: "global.get", index: globals.owner },
+    { op: "local.set", index: ownerLocal },
+    { op: "global.get", index: globals.value },
+    { op: "local.set", index: valueLocal },
+    { op: "global.get", index: globals.prototypeOwner },
+    { op: "local.set", index: prototypeOwnerLocal },
+    { op: "global.get", index: globals.prototypeValue },
+    { op: "local.set", index: prototypeValueLocal },
+  );
+  return { ownerLocal, valueLocal, prototypeOwnerLocal, prototypeValueLocal };
+}
+
+export function activateReflectConstructNewTarget(
+  ctx: CodegenContext,
+  body: Instr[],
+  ownerId: number,
+  valueLocal: number,
+  prototypeLocal: number,
+): void {
+  const globals = ensureReflectConstructNewTargetGlobals(ctx);
+  body.push(
+    { op: "local.get", index: valueLocal },
+    { op: "global.set", index: globals.value },
+    { op: "local.get", index: prototypeLocal },
+    { op: "global.set", index: globals.prototypeValue },
+    { op: "i32.const", value: ownerId },
+    { op: "global.set", index: globals.owner },
+    { op: "i32.const", value: ownerId },
+    { op: "global.set", index: globals.prototypeOwner },
+  );
+}
+
+export function restoreReflectConstructNewTargetState(
+  ctx: CodegenContext,
+  body: Instr[],
+  saved: SavedReflectConstructNewTargetState,
+): void {
+  const globals = ensureReflectConstructNewTargetGlobals(ctx);
+  body.push(
+    { op: "local.get", index: saved.ownerLocal },
+    { op: "global.set", index: globals.owner },
+    { op: "local.get", index: saved.valueLocal },
+    { op: "global.set", index: globals.value },
+    { op: "local.get", index: saved.prototypeOwnerLocal },
+    { op: "global.set", index: globals.prototypeOwner },
+    { op: "local.get", index: saved.prototypeValueLocal },
+    { op: "global.set", index: globals.prototypeValue },
+  );
+}
+
+/** Emit an admitted ordinary-function constructor body's runtime new.target read. */
+export function emitReflectConstructNewTargetRead(ctx: CodegenContext, fctx: FunctionContext): boolean {
+  const owner = ctx.reflectConstructNewTargetOwnerGlobalIdx;
+  const value = ctx.reflectConstructNewTargetValueGlobalIdx;
+  if (owner === undefined || value === undefined) return false;
+  const targetId = fctx.reflectConstructNewTargetId;
+  const passThrough = fctx.reflectConstructNewTargetPassThrough === true;
+  if (targetId === undefined && !passThrough) return false;
+  ensureObjectRuntime(ctx);
+  const undefinedValue = undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
+  const active: Instr[] =
+    targetId === undefined
+      ? [{ op: "global.get", index: owner }, { op: "i32.eqz" }, { op: "i32.eqz" }]
+      : [{ op: "global.get", index: owner }, { op: "i32.const", value: targetId }, { op: "i32.eq" }];
+  fctx.body.push(...active, {
+    op: "if",
+    blockType: { kind: "val", type: { kind: "externref" } },
+    then: [{ op: "global.get", index: value }],
+    else: undefinedValue,
+  });
+  return true;
 }

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -305,6 +305,19 @@ function fixupModuleGlobalIndices(ctx: CodegenContext, threshold: number, delta:
   if (ctx.newTargetGlobalIdx !== undefined && ctx.newTargetGlobalIdx >= threshold) {
     ctx.newTargetGlobalIdx += delta;
   }
+  // (#3371) The ordinary/class Reflect.construct NewTarget contract keeps four
+  // cached module-global indices. They are emitted before arbitrary later
+  // string/global imports, so every cached value must follow the same absolute
+  // index shift as the established class-id new.target global above.
+  for (const key of [
+    "reflectConstructNewTargetOwnerGlobalIdx",
+    "reflectConstructNewTargetValueGlobalIdx",
+    "reflectConstructNewTargetProtoOwnerGlobalIdx",
+    "reflectConstructNewTargetProtoGlobalIdx",
+  ] as const) {
+    const index = ctx[key];
+    if (index !== undefined && index >= threshold) ctx[key] = index + delta;
+  }
   // (#2001 S1 regress) Same hazard for the `$__hole` singleton global. When a
   // string-constant import is inserted after `$Hole` was registered,
   // `shiftGlobalIndices` correctly bumps the already-emitted `global.get


### PR DESCRIPTION
## Description

Problem: Four ordinary/class ES2015 Reflect.construct rows still refuse an arbitrary distinct NewTarget, and the existing lowering has no runtime contract for preserving NewTarget identity and prototype selection.
Behavior: Publish an intentionally inert architectural substrate for carrying runtime NewTarget state through ordinary function and class construction. The namespace-static dispatcher remains unwired, so this checkpoint makes no conformance claim and is not mergeable.
Tests: TypeScript 7 passes; the exact four owned standalone rows retain their prior #3371 compile errors; the omitted-NewTarget control still passes; the normal pre-push suite passes, including 18/18 numeric-local parity tests.
Quality: Formatting, lint, typecheck, oracle and coercion ratchets, issue integrity, LOC/function probes, and post-sync validation are recorded in the issue handoff. The semantic acceptance gate remains intentionally unmet.
Tracking: `plan/issues/3371-standalone-reflect-construct-newtarget.md`; No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->