### PR TITLE
fix(codegen): retain guaranteed top-level TDZ reads

### DIFF
--- a/plan/issues/5253-es2015-top-level-tdz-read-retention.md
+++ b/plan/issues/5253-es2015-top-level-tdz-read-retention.md
@@ -1,0 +1,86 @@
+---
+id: 5253
+title: "ES2015 standalone: retain guaranteed top-level TDZ reads"
+status: in-progress
+sprint: current
+created: 2026-09-01
+updated: 2026-09-01
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: max
+task_type: conformance
+area: codegen, conformance
+es_edition: ES2015
+goal: standalone-mode
+assignee: ttraenkler/codex-tdz-prior-stmt-terra-20260901
+related: [3623, 4433, 4672, 5154]
+origin: "Current-main ES2015 census: direct top-level reads before a later let/const are silently dropped before TDZ lowering."
+loc-budget-allow:
+  - src/codegen/declarations.ts
+  - src/codegen/expressions/identifier-module-storage.ts
+  - tests/issue-5253.test.ts
+func-budget-allow:
+  - src/codegen/declarations.ts::collectDeclarations
+---
+
+# #5253 — Retain guaranteed top-level TDZ reads
+
+## Problem and locked evidence
+
+On `upstream/main` at
+`83b173d8ded5d10ea7d9986f62290334982fdee9`, the authoritative isolated
+standalone runner reports **0 pass / 2 fail** for these ES2015 rows:
+
+- `language/statements/const/global-use-before-initialization-in-prior-statement.js`
+- `language/statements/let/global-use-before-initialization-in-prior-statement.js`
+
+Both are runtime-negative tests expecting `ReferenceError`; both instead
+succeed. The sources reduce to `x; const x = 1;` and `x; let x;`. The command
+was `node --import tsx scripts/run-test262-paths.mts <two-path-list> --isolate
+--standalone`; no compiler/test process was active before the lane. The locked
+f841 census has the same two outcomes.
+
+This is not the closure/loop work completed under #4672 and not #5154's
+block/closure TDZ slice. The bare identifier never reaches TDZ lowering:
+`collectDeclarations` keeps a special CaseBlock lexical read but sends a
+generic top-level `x;` to the module-init classifier, where a non-effectful atom
+is recorded and dropped. Existing identifier lowering already knows how to
+emit the static in-module `ReferenceError` once the statement is retained.
+
+No GitHub issue was created. ID 5253 was allocated and claimed atomically in
+the repository's `issue-assignments` ref.
+
+## Implementation plan
+
+1. Add a focused red regression proving that a source-owned top-level lexical
+   read before its declaration is currently dropped. Cover `let` and `const`,
+   real `ReferenceError` identity, standalone zero-import instantiation, and a
+   host/GC target-neutral control.
+2. Add a collector predicate beside the existing CaseBlock exception. Retain a
+   bare identifier statement only when symbol ownership proves it resolves to
+   an exact top-level lexical declaration in the same source and static TDZ
+   analysis proves the access is before initialization. Reuse the existing
+   symbol-aware helpers when import topology permits; otherwise extract only a
+   cycle-safe ownership predicate into `identifier-module-storage.ts`.
+3. Quantify every statement selected by the new predicate before landing. Do
+   not change the general `expressionRunsUserCode`/atom classifier and do not
+   broadly collect unbound identifiers, `var` reads, block-local future
+   bindings, or post-initialization reads. Broad module-init vacuity remains
+   owned by #3623/#4433.
+4. Run controls for post-init `let`/`const`, `var`, block-local future binding,
+   and unbound `x;`, plus existing TDZ/error substrate suites
+   `issue-1597`, `issue-1473`, `issue-723-tdz`, and `issue-906`.
+5. Rerun the exact two official rows through the authoritative isolated
+   standalone runner and record before/after counts and zero-loss evidence in
+   this file.
+
+## Acceptance criteria
+
+- The exact two ES2015 rows pass in standalone and throw an actual
+  `ReferenceError` object.
+- The generated standalone modules remain host-free with zero new imports.
+- The predicate selects only proven forward reads of their own direct
+  top-level lexical binding; all listed controls retain their prior behavior.
+- Focused tests, TDZ/error controls, typecheck, lint/format, and repository
+  ratchets pass.

--- a/plan/issues/5253-es2015-top-level-tdz-read-retention.md
+++ b/plan/issues/5253-es2015-top-level-tdz-read-retention.md
@@ -1,10 +1,11 @@
 ---
 id: 5253
 title: "ES2015 standalone: retain guaranteed top-level TDZ reads"
-status: in-progress
+status: done
 sprint: current
 created: 2026-09-01
 updated: 2026-09-01
+completed: 2026-09-01
 priority: high
 horizon: s
 feasibility: medium
@@ -22,6 +23,7 @@ loc-budget-allow:
   - tests/issue-5253.test.ts
 func-budget-allow:
   - src/codegen/declarations.ts::collectDeclarations
+commit: 0b60ac4c9db6b21cd10d743a7e7a8103ab11d933
 ---
 
 # #5253 — Retain guaranteed top-level TDZ reads
@@ -84,3 +86,62 @@ the repository's `issue-assignments` ref.
   top-level lexical binding; all listed controls retain their prior behavior.
 - Focused tests, TDZ/error controls, typecheck, lint/format, and repository
   ratchets pass.
+
+## Root cause
+
+`collectDeclarations` already retained a CaseBlock lexical exception, but sent
+a direct source-level `x;` to the generic module-init expression classifier.
+That classifier correctly treats ordinary bare atoms as inert for its broad
+scope, so the read never reached existing TDZ lowering and the required
+`ReferenceError` was silently omitted.
+
+## Implementation summary
+
+The collector now builds a source-local map of unambiguous direct runtime
+`let`/`const` declarations. It retains a direct bare identifier statement only
+when the declaration is from that exact source, the oracle resolves the
+identifier to that exact declaration node, and the source position proves the
+read occurs before the declaration completes. At a direct `SourceFile` child
+there is no closure or loop deferral, so this is the static TDZ analyser's
+guaranteed-throw case.
+
+Each retained statement increments
+`module-init-direct-top-level-tdz-forward-read-statements`; no generic atom
+collection or identifier storage behavior changed. The implementation is
+`0b60ac4c9db6b21cd10d743a7e7a8103ab11d933`; this closeout also removes an
+unreachable test-control branch only.
+
+## Test Results (2026-09-01)
+
+- Red baseline: the authoritative isolated standalone runner reported **0
+  pass / 2 fail** for the exact `const` and `let`
+  `global-use-before-initialization-in-prior-statement.js` rows; both completed
+  instead of throwing `ReferenceError`.
+- After the fix, the same command,
+  `node --import tsx scripts/run-test262-paths.mts .tmp/issue-5253-test262-paths.txt --isolate --standalone`,
+  reported **2 pass / 0 non-pass**.
+- `tests/issue-5253.test.ts`: **13/13 pass**. It covers both exact Test262
+  rows, `let`/`const` direct standalone reads, actual in-module
+  `error instanceof ReferenceError` identity, zero compiler/Wasm/host imports,
+  and the host/GC control.
+- Combined substrate sweep: **44/44 pass** across #5253, #1597, #1473, #723,
+  and #906 in one single-fork run.
+- Profiled direct standalone `let` and `const` probes each reported
+  `module-init-direct-top-level-tdz-forward-read-statements=1`.
+- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check`,
+  `check:loc-budget`, `check:func-budget`, `check:oracle-ratchet`, and
+  `check:coercion-sites` all passed.
+- Differential harness: **115/120 match** (the expected five pre-existing
+  non-matches make the harness exit nonzero); `pnpm run test:diff:gate` passed
+  with **0 new regressions** and **3 improvements**.
+
+## Residuals
+
+- `{ x; let x = 1; }` remains the existing block-local bare-read gap owned by
+  #5154; this change deliberately does not collect it through the new direct
+  top-level predicate.
+- An unbound top-level `x;` remains generic atom-collection work owned by
+  #3623/#4433. `var` and post-initialization lexical reads likewise retain
+  their prior inert collector behavior.
+
+No GitHub issue was created.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -3652,13 +3652,19 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
   }
 
   // A bare identifier expression is normally inert at module-init collection
-  // time, but a reference to a direct CaseBlock lexical name is observable:
-  // outside the switch it must perform the ordinary unresolved-binding lookup
-  // and throw ReferenceError. Keep this narrow to top-level switches with no
-  // same-named top-level binding; an outer `let x` legitimately shadows a
-  // switch-local `let x` after the switch.
+  // time, but two source-local lexical cases are observable:
+  //
+  // - a reference to a direct CaseBlock lexical name outside its switch must
+  //   perform the ordinary unresolved-binding lookup and throw ReferenceError;
+  // - a direct script-level `x; let/const x` read is a statically guaranteed
+  //   TDZ violation once exact binding ownership is proven.
+  //
+  // Keep both exceptions narrow. In particular, an outer `let x` legitimately
+  // shadows a switch-local `let x` after the switch, and ordinary atom
+  // collection remains owned by #3623/#4433.
   const topLevelBoundNames = new Set<string>();
   const topLevelSwitchLexicalNames = new Set<string>();
+  const directTopLevelLexicalDeclarations = new Map<string, ts.VariableDeclaration | null>();
   const addBindingNames = (name: ts.BindingName): void => {
     if (ts.isIdentifier(name)) {
       topLevelBoundNames.add(name.text);
@@ -3671,6 +3677,24 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
   for (const stmt of sourceFile.statements) {
     if (ts.isVariableStatement(stmt)) {
       for (const decl of stmt.declarationList.declarations) addBindingNames(decl.name);
+      // #5253 — record only unambiguous direct runtime `let` / `const`
+      // declarations. The later predicate also requires the checker/oracle to
+      // resolve the read to this exact AST node, so same-spelled bindings from
+      // another source, `var`, patterns, ambient declarations, and duplicate
+      // syntax cannot enter the narrow TDZ-read route.
+      if (
+        !sourceFile.isDeclarationFile &&
+        !hasDeclareModifier(stmt) &&
+        (stmt.declarationList.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0
+      ) {
+        for (const decl of stmt.declarationList.declarations) {
+          if (!ts.isIdentifier(decl.name)) continue;
+          directTopLevelLexicalDeclarations.set(
+            decl.name.text,
+            directTopLevelLexicalDeclarations.has(decl.name.text) ? null : decl,
+          );
+        }
+      }
     } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
       topLevelBoundNames.add(stmt.name.text);
     } else if (ts.isClassDeclaration(stmt) && stmt.name) {
@@ -3714,6 +3738,20 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       }
     }
   }
+  const isDirectTopLevelLexicalForwardRead = (identifier: ts.Identifier): boolean => {
+    const declaration = directTopLevelLexicalDeclarations.get(identifier.text);
+    // The expression statement is itself a direct SourceFile child, so this
+    // positional proof is the static TDZ analyser's guaranteed-throw case:
+    // no closure or loop can defer/re-enter the read before initialization.
+    return (
+      declaration !== undefined &&
+      declaration !== null &&
+      identifier.getSourceFile() === sourceFile &&
+      ctx.oracle.valueDeclarationOf(identifier) === declaration &&
+      identifier.getStart(sourceFile) < declaration.getEnd()
+    );
+  };
+  let directTopLevelLexicalForwardReadStatements = 0;
 
   // Var declarations are function-scoped, so a declaration nested in a later
   // top-level `try`/loop/branch is already in scope for earlier statements.
@@ -3881,6 +3919,15 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       }
       if (ts.isIdentifier(expr) && topLevelSwitchLexicalNames.has(expr.text) && !topLevelBoundNames.has(expr.text)) {
         ctx.moduleInitStatements.push(stmt);
+        continue;
+      }
+      // #5253 — retain only the exact source-owned direct lexical shape whose
+      // forward source position proves a TDZ throw. Do not generalize the
+      // `expressionRunsUserCode` atom route: unbound/var/post-init/block-local
+      // reads remain outside this collector exception.
+      if (ts.isIdentifier(stmt.expression) && isDirectTopLevelLexicalForwardRead(stmt.expression)) {
+        ctx.moduleInitStatements.push(stmt);
+        directTopLevelLexicalForwardReadStatements += 1;
         continue;
       }
       if (
@@ -4280,6 +4327,10 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       collectOrRecordUnnamedExpressionStatement(ctx, stmt);
     }
   }
+
+  // #5253 — every source statement retained by the narrow TDZ proof is
+  // reported independently from the aggregate module-init count below.
+  profileCount("module-init-direct-top-level-tdz-forward-read-statements", directTopLevelLexicalForwardReadStatements);
 
   // Export default for module globals (#1108): `export default <variable>` where
   // the variable is a module-level global (e.g. `var add = createMathOperation(fn, 0)`)

--- a/tests/issue-5253.test.ts
+++ b/tests/issue-5253.test.ts
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5253 — direct top-level lexical reads before their own declaration.
+//
+// A bare `x;` normally has no observable work, so module-init collection may
+// record and omit it.  This is only sound when `x` is not a same-source lexical
+// binding whose declaration comes later: in that narrow case GetValue is a
+// guaranteed TDZ ReferenceError.
+import { describe, expect, it } from "vitest";
+import { resolve } from "node:path";
+import { compile, type CompileResult } from "../src/index.js";
+import { renderHarnessThrownText } from "../scripts/lib/wasm-exn-render.mjs";
+import { runTest262File } from "./test262-runner.js";
+
+type LexicalKind = "let" | "const";
+
+const TEST262_FORWARD_READ_ROWS = [
+  "language/statements/const/global-use-before-initialization-in-prior-statement.js",
+  "language/statements/let/global-use-before-initialization-in-prior-statement.js",
+] as const;
+
+function directForwardReadSource(kind: LexicalKind): string {
+  return kind === "const" ? "x; const x = 1;" : "x; let x;";
+}
+
+function caughtForwardReadSource(kind: LexicalKind): string {
+  return `
+    let verdict = 0;
+    try {
+      x;
+    } catch (error: any) {
+      verdict = error instanceof ReferenceError ? 1 : 2;
+    }
+    ${kind} x: number = 1;
+    export function test(): number { return verdict; }
+  `;
+}
+
+const NON_MATCHING_TOP_LEVEL_CONTROLS = [
+  {
+    label: "post-initialization let read",
+    source: "let x = 1; x;",
+    outcome: "complete",
+  },
+  {
+    label: "post-initialization const read",
+    source: "const x = 1; x;",
+    outcome: "complete",
+  },
+  {
+    label: "forward var read",
+    source: "x; var x = 1;",
+    outcome: "complete",
+  },
+  {
+    label: "block-local forward lexical read (#5154)",
+    source: "{ x; let x = 1; }",
+    outcome: "complete",
+  },
+  {
+    label: "unbound bare identifier",
+    source: "x;",
+    outcome: "complete",
+  },
+] as const;
+
+function importNames(result: CompileResult): string[] {
+  return WebAssembly.Module.imports(new WebAssembly.Module(result.binary))
+    .map((entry) => `${entry.module}.${entry.name}`)
+    .sort();
+}
+
+function expectStandaloneHostFree(result: CompileResult): void {
+  expect(result.imports, "standalone compiler import descriptors").toEqual([]);
+  expect(importNames(result), "standalone Wasm import section").toEqual([]);
+  expect(result.hostImportSummary?.total ?? 0, "standalone host-import inventory").toBe(0);
+}
+
+function runModuleInit(instance: WebAssembly.Instance): unknown {
+  try {
+    const init = instance.exports.__module_init;
+    if (typeof init === "function") init();
+  } catch (error) {
+    return error;
+  }
+  return undefined;
+}
+
+describe("#5253 — retain guaranteed top-level TDZ reads", () => {
+  it.each(TEST262_FORWARD_READ_ROWS)("passes the exact standalone Test262 row %s", async (relativePath) => {
+    const result = await runTest262File(
+      resolve("test262/test", relativePath),
+      "language/statements",
+      undefined,
+      "standalone",
+    );
+    expect(result.status, result.reason ?? result.error).toBe("pass");
+  });
+
+  it.each(["let", "const"] as const)(
+    "retains the direct script-level forward %s read in standalone without host imports",
+    async (kind) => {
+      const result = await compile(directForwardReadSource(kind), {
+        allowJs: true,
+        deferTopLevelInit: true,
+        fileName: `issue-5253-direct-${kind}.js`,
+        hostBridge: "always",
+        inferModuleStrictArguments: false,
+        skipSemanticDiagnostics: true,
+        target: "standalone",
+      });
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expectStandaloneHostFree(result);
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), {});
+      const thrown = runModuleInit(instance);
+      expect(thrown, "module init must observe the TDZ read").toBeDefined();
+      expect(renderHarnessThrownText(thrown, instance)).toContain("ReferenceError");
+    },
+  );
+
+  it.each(["let", "const"] as const)(
+    "retains the same direct script-level forward %s read in the host/GC control",
+    async (kind) => {
+      const result = await compile(directForwardReadSource(kind), {
+        allowJs: true,
+        deferTopLevelInit: true,
+        fileName: `issue-5253-host-${kind}.js`,
+        hostBridge: "always",
+        inferModuleStrictArguments: false,
+        skipSemanticDiagnostics: true,
+        target: "gc",
+      });
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), result.importObject);
+      const thrown = runModuleInit(instance);
+      expect(thrown, "module init must observe the TDZ read").toBeDefined();
+      expect(renderHarnessThrownText(thrown, instance)).toContain("ReferenceError");
+    },
+  );
+
+  it.each(["let", "const"] as const)(
+    "builds a real in-module ReferenceError for a caught top-level forward %s read",
+    async (kind) => {
+      const result = await compile(caughtForwardReadSource(kind), {
+        deferTopLevelInit: true,
+        fileName: `issue-5253-caught-${kind}.ts`,
+        skipSemanticDiagnostics: true,
+        target: "standalone",
+      });
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expectStandaloneHostFree(result);
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), {});
+      expect(runModuleInit(instance)).toBeUndefined();
+      expect((instance.exports.test as () => number)()).toBe(1);
+    },
+  );
+
+  it.each(NON_MATCHING_TOP_LEVEL_CONTROLS)(
+    "leaves the $label control outside the direct top-level lexical proof",
+    async ({ label, source, outcome }) => {
+      const result = await compile(source, {
+        allowJs: true,
+        deferTopLevelInit: true,
+        fileName: `issue-5253-control-${label}.js`,
+        hostBridge: "always",
+        inferModuleStrictArguments: false,
+        skipSemanticDiagnostics: true,
+        target: "standalone",
+      });
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expectStandaloneHostFree(result);
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), {});
+      const thrown = runModuleInit(instance);
+      if (outcome === "reference-error") {
+        expect(thrown, `${label} must retain its existing TDZ behavior`).toBeDefined();
+        expect(renderHarnessThrownText(thrown, instance)).toContain("ReferenceError");
+      } else {
+        // The generic atom collector remains intentionally unchanged here:
+        // post-init and var reads are inert; the block-local gap is #5154;
+        // and unbound reads stay #3623 work rather than being misclassified
+        // as a lexical TDZ proof.
+        expect(thrown, `${label} must not enter #5253's TDZ exception`).toBeUndefined();
+      }
+    },
+  );
+});

--- a/tests/issue-5253.test.ts
+++ b/tests/issue-5253.test.ts
@@ -40,27 +40,22 @@ const NON_MATCHING_TOP_LEVEL_CONTROLS = [
   {
     label: "post-initialization let read",
     source: "let x = 1; x;",
-    outcome: "complete",
   },
   {
     label: "post-initialization const read",
     source: "const x = 1; x;",
-    outcome: "complete",
   },
   {
     label: "forward var read",
     source: "x; var x = 1;",
-    outcome: "complete",
   },
   {
     label: "block-local forward lexical read (#5154)",
     source: "{ x; let x = 1; }",
-    outcome: "complete",
   },
   {
     label: "unbound bare identifier",
     source: "x;",
-    outcome: "complete",
   },
 ] as const;
 
@@ -157,7 +152,7 @@ describe("#5253 — retain guaranteed top-level TDZ reads", () => {
 
   it.each(NON_MATCHING_TOP_LEVEL_CONTROLS)(
     "leaves the $label control outside the direct top-level lexical proof",
-    async ({ label, source, outcome }) => {
+    async ({ label, source }) => {
       const result = await compile(source, {
         allowJs: true,
         deferTopLevelInit: true,
@@ -171,16 +166,11 @@ describe("#5253 — retain guaranteed top-level TDZ reads", () => {
       expectStandaloneHostFree(result);
       const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), {});
       const thrown = runModuleInit(instance);
-      if (outcome === "reference-error") {
-        expect(thrown, `${label} must retain its existing TDZ behavior`).toBeDefined();
-        expect(renderHarnessThrownText(thrown, instance)).toContain("ReferenceError");
-      } else {
-        // The generic atom collector remains intentionally unchanged here:
-        // post-init and var reads are inert; the block-local gap is #5154;
-        // and unbound reads stay #3623 work rather than being misclassified
-        // as a lexical TDZ proof.
-        expect(thrown, `${label} must not enter #5253's TDZ exception`).toBeUndefined();
-      }
+      // The generic atom collector remains intentionally unchanged here:
+      // post-init and var reads are inert; the block-local gap is #5154;
+      // and unbound reads stay #3623 work rather than being misclassified as
+      // a lexical TDZ proof.
+      expect(thrown, `${label} must not enter #5253's TDZ exception`).toBeUndefined();
     },
   );
 });


### PR DESCRIPTION
## Description

Problem: Two ES2015 runtime-negative rows succeeded because a guaranteed top-level read before its own `let` or `const` declaration was dropped before TDZ lowering.
Behavior: Retain only oracle-exact, same-source direct top-level lexical forward reads so existing identifier lowering emits the required `ReferenceError`; generic atoms, unbound names, `var`, block-local, and post-initialization reads remain unchanged.
Tests: Exact isolated standalone Test262 rows: 2/2 passed; focused [#5253](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5253-es2015-top-level-tdz-read-retention): 13/13 passed; combined TDZ/error controls: 44/44 passed; differential gate: 0 regressions and 3 improvements.
Quality: Post-sync typecheck, lint, formatting, LOC/function/oracle/coercion ratchets, diff check, issue integrity, and normal pre-push gates passed.
Tracking: [`plan/issues/5253-es2015-top-level-tdz-read-retention.md`](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5253-es2015-top-level-tdz-read-retention); No GitHub issue was created.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

<!-- The `cla-check` CI gate reads the checkbox above and turns green automatically when it is checked. -->