### PR TITLE
ci(auto-enqueue): trust the Claude GitHub App (claude, claude[bot]) in the author gate

### DIFF
--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -143,5 +143,16 @@ jobs:
           # which had been CLEAN and unenqueued for three hours while the
           # npm-compat dashboard stayed frozen. Naming both forms grants no new
           # trust: it is the same app, spelled the way each API returns it.
-          TRUSTED_AUTHOR_LOGINS: ttraenkler,${{ steps.app-token.outputs.app-slug }},${{ steps.app-token.outputs.app-slug }}[bot]
+          #
+          # `claude` / `claude[bot]` — the Claude GitHub App (project-lead order,
+          # 2026-09-01). Implementation PRs opened by Claude Code sessions the
+          # maintainer dispatches are authored by this app with
+          # `authorAssociation: NONE`, so they matched none of the three layers
+          # and stranded fully green + CLEAN: #5364/#5367 (manual enqueue),
+          # then #5424 (skipped `untrusted-author:NONE (login=claude)` on four
+          # consecutive sweeps and replaced by the hand-reopened #5425). Both
+          # spellings for the same GraphQL-vs-REST reason as above. The trust
+          # delta: only sessions the maintainer runs can make this app author a
+          # PR, and `cla-check` stays the deeper merge gate.
+          TRUSTED_AUTHOR_LOGINS: ttraenkler,${{ steps.app-token.outputs.app-slug }},${{ steps.app-token.outputs.app-slug }}[bot],claude,claude[bot]
         run: node scripts/enqueue-green-prs.mjs


### PR DESCRIPTION
Adds `claude,claude[bot]` to `TRUSTED_AUTHOR_LOGINS` in `auto-enqueue.yml` (project-lead order, 2026-09-01).

**Why.** Implementation PRs opened by maintainer-dispatched Claude Code sessions are authored by the Claude GitHub App with `authorAssociation: NONE`, so they match none of the gate's three layers and strand fully green + CLEAN: #5364/#5367 needed a manual enqueue, and #5424 was skipped `untrusted-author:NONE (login=claude)` on four consecutive sweeps before being hand-reopened as #5425. Both spellings are listed for the same reason the enqueue app carries both: GraphQL reports a Bot author as the bare slug (`claude`, which is what the skip log showed), REST as `<slug>[bot]`.

**Trust delta.** Only sessions the maintainer runs can make this app author a PR; `cla-check` stays the deeper merge gate. One-line env change plus a rationale comment; `scripts/enqueue-green-prs.mjs` untouched.

**Verified.** The line keeps the pinned shape (starts with `ttraenkler,`, both app-slug forms, no hardcoded queue-bot slug): `tests/issue-2550-trust-gate-fork-allowlist.test.ts` and `tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts` pass (38/38); all five ratchet gates green.

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aFp8EAQaf21QYQU3yEFw1

---
_Generated by [Claude Code](https://claude.ai/code/session_019aFp8EAQaf21QYQU3yEFw1)_