### PR TITLE
ES2015 standalone close-out: dispatch census + r2 plans/fixes (session branch)

### DIFF
--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -18,6 +18,52 @@ related: [2860, 2864, 2865, 2867, 2906, 3032, 3178, 2161, 2175, 2158, 2159, 4445
 
 # #4444 — UMBRELLA: ES6 (ES2015) standalone edition close-out
 
+## 2026-09-01 evening dispatch census at d39779cb — cluster ownership + Fable/Opus fan-out
+
+Source: `node scripts/fetch-baseline-jsonl.mjs --standalone --force` (baselines
+repo, compiler sha `d39779cbfdd5a9b5fdb54569923fd9810637d495`, generated
+2026-09-01T18:33Z — an ancestor of the session branch
+`claude/es6-test262-standalone-g10c7u`, which is `origin/main` @ `0d9bfede`),
+edition map `website/public/benchmarks/results/test262-file-editions.json`
+(`ES2015` label; 11,778 labelled, 11,704 in the official runner scope).
+
+**ES2015 standalone: 9,673 pass / 11,704 (82.6%) — 2,031 non-pass**
+(1,644 fail · 386 compile_error · 1 compile_timeout). Status/error class:
+1,122 `assertion_fail`, 367 `type_error`, 248 `host_import_leak` CE,
+151 other CE, 34 runtime_error CE, 21 promise_error, 15 illegal_cast,
+10 null_deref, 10 range_error.
+
+Cluster split (path-disjoint; lists under `.tmp/es2015/<cluster>-{paths.txt,errors.tsv}`,
+regenerable from the JSONL + edition map):
+
+| Cluster | Rows | Owner / tracker | Dispatch (this session) |
+| --- | ---: | --- | --- |
+| generators (`language/*/generators`, `yield`, GeneratorFunction/Prototype, `__create_generator` leaks, "sequential numeric yields" refusal) | 318 | #680 / #2864 codex lane (PR #5383 merged; #5406/#5407 drafts) | **not re-dispatched** |
+| typedarray (`built-ins/TypedArray*`, excl. buffers) | 300 | #5194 (Slice A merged #5300; #5385 species merged) | Fable planner → r2 plan in #5194 → Opus |
+| class (`language/*/class`, `computed-property-names/class`, `super`, `new.target`) | 209 | #5195 (stub) | Fable planner → plan → Opus |
+| array + object built-ins | 159 | new **#5268** | Fable planner → plan → Opus |
+| proxy + Reflect | 157 | #5196 (2-row revoker slice merged #5389); #3371 (33 CE, blocked design PR #5400); #2046 (15 CE, design PR #5397) | Fable planner on the unowned trap-invariant residual → Opus |
+| for-of + Iterator/*IteratorPrototype + Map/Set/Weak* | 155 | new **#5267** (wave-1 #5144/#5147/#5151; draft PR #5225 mined, not merged) | Fable planner → plan → Opus |
+| function/error/symbol/string/JSON/number built-ins | 150 | new **#5269** (wave-1 #5156/#5152) | Fable planner → plan → Opus |
+| regexp (`built-ins/RegExp`, annexB RegExp, `Symbol.{match,replace,search,split}`) | 148 | #5198 codex lane (Slice A merged #5296; Slice B draft #5393) | **not re-dispatched** |
+| promise | 140 | #5197 (Slice A merged #5292; slices B–H planned) | Opus implementer on Slices B–D directly |
+| expressions (object literal, assignment, arrow, call, template, instanceof, …) | 117 | new **#5270** (wave-1 #5149/#5146) | Fable planner → plan → Opus |
+| statements + lang semantics (for-in/for/let/const/with/try, global/eval code, arguments, rest, dstr) | 84 | new **#5271** (wave-1 #5154/#5158/#5157) | Fable planner → plan → Opus |
+| buffers (ArrayBuffer/DataView) | 53 | #5150 (full plan; WIP draft PR #5224 unvalidated) | Opus implementer directly (mines the WIP) |
+| module-code | 23 | #4759 codex closeout lane | not re-dispatched |
+| rest (misc singletons) | 18 | — | folded into the nearest cluster plan |
+
+Ids #5267–#5271 were reserved via `claim-issue.mjs --allocate`
+(`--no-pr-scan --allow-unscanned`: no `gh` in this container, so the open-PR
+scan could not run; the `check:issue-ids:against-main` gate backstops).
+
+Method (unchanged from the 08-28/29 session): Fable planners re-verify each
+list on HEAD with `scripts/run-test262-paths.mts --standalone`, cluster by
+root cause with file:function sites, and write the `## Implementation Plan`
+into the issue; Opus implementers work each plan in an isolated worktree and
+commit validated slices; this lane integrates them into the session branch,
+runs the ratchet + equivalence gates, and lands batches through PRs.
+
 ## Latest forced census (2026-09-01; replaces the stale dispatch headline below)
 
 This is the latest immutable dispatch baseline for this umbrella. It replaces


### PR DESCRIPTION
## Description

Session branch for the goal "100% ES2015 test262 pass rate in standalone mode" (umbrella [#4444](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4444-es6-standalone-edition-closeout-umbrella)).

First commit: the 2026-09-01 evening dispatch census at compiler sha `d39779cb` — ES2015 standalone 9,673 / 11,704 pass (82.6%), 2,031 non-pass — with the path-disjoint cluster split, which clusters are owned by active codex lanes and are not re-dispatched (generators, RegExp, module-code), the five reserved r2 issue ids (#5267–#5271 via `claim-issue.mjs --allocate`), and the plan/implement fan-out for this session.

Follow-up commits on this branch will carry the r2 implementation plans (Fable) and the validated implementation slices (Opus, per plan) for the unowned clusters: class ([#5195](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5195-es2015-standalone-class-r2)), TypedArray ([#5194](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5194-es2015-standalone-typedarray-r2)), Proxy ([#5196](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5196-es2015-standalone-proxy-r2)), Promise ([#5197](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5197-es2015-standalone-promise-r2)), buffers ([#5150](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5150-es2015-standalone-buffers-wave1)), and the new r2 issues for for-of/iterators/collections, Array/Object built-ins, function/error/symbol built-ins, expressions, and statements.

No `src/` change in this first commit; gates (LOC/func budget, coercion sites, oracle ratchet, dead exports) green.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs)_