### PR TITLE
fix(standalone): ES2015 Promise r2 — Slices B, C, D (#5197): built-in settle callables, generic catch/then, generic NewPromiseCapability for resolve/reject

### DIFF
--- a/plan/issues/5197-es2015-standalone-promise-r2.md
+++ b/plan/issues/5197-es2015-standalone-promise-r2.md
@@ -538,6 +538,49 @@ is believed.
 | `exception-after-resolve-in-{executor,thenable-job}.js`, `resolve-prms-cstm-then-{immed,deferred}.js` | settlement-core rows that fail in the async drive, unrelated to the capability protocol. |
 | Slices E/F (combinators), G (#3371), H (realm) | untouched by this pass. |
 
+### Validation for both commits
+
+| check | result |
+| --- | --- |
+| TS7 `pnpm run typecheck` | clean |
+| TS5 `pnpm run typecheck:ts5` | one PRE-EXISTING error in `src/linked-provider-runtime.ts` (`WebAssembly.Tag`); that file is untouched by this lane |
+| `tests/issue-5197-es2015-promise-r2.test.ts` | 8/8 |
+| `tests/issue-5197-promise-generic-catch.test.ts` | 4/4 |
+| `tests/issue-5197-promise-generic-capability.test.ts` | 10/10 |
+| loc / func / coercion / oracle-ratchet / dead-exports | all exit 0 |
+| prettier + biome on every changed file | clean |
+| `pnpm run test:equivalence:gate` | **24 failing, 1718 passing, 24 known-failures in baseline — no new regressions** |
+| `npm run check:issues`, `check:done-status-integrity` | exit 0 |
+
+**On the equivalence gate's scope.** The green run above was taken on the
+Slice C + Slice D tree before the `undefined` fix; a re-run on the exact
+committed tree was killed by the harness at ~55 min under box load 12-14 and
+produced no verdict. That gap is closed by inspection rather than by a third
+run: `grep -rn "resolve\.call\|reject\.call" tests/equivalence/` returns **zero
+matches**, so no equivalence test can reach the changed arm at all, in either
+version. The suite is byte-identical across the whole of Slice D; the green run
+is therefore evidence for the committed tree, and specifically for Slice C.
+
+**Two control failures were checked and are PRE-EXISTING, not this lane's.**
+Both were A/B'd by restoring all eight lane-modified `src/codegen` files to
+`813b828b6` and re-running:
+
+- `tests/issue-2671-promise-capability.test.ts` — "wasm thenable element's then
+  is invoked with the native resolve-element fn": `'C.resolve|'` vs
+  `'C.resolve|p1.then:function|'`, identical at base. (The other 30 tests across
+  `promise-combinators`, `issue-2671-promise-executor` and
+  `issue-28-promise-executor-invocation` pass, including both
+  `Promise.reject.call(NotPromise)` executor-metadata rows.)
+- `tests/reflected-symbol-promise-statics.test.ts` — BOTH tests fail, including
+  the `Symbol.for`/`Symbol.keyFor` one that this lane cannot touch; identical at
+  base. Worth a look by whoever owns it: the previous implementer recorded this
+  file green on 2026-09-01, so something between then and `813b828b6` (or an
+  environment difference) took it out.
+
+`promise-expando-standalone`, `issue-4167-async-rejection-identity`,
+`issue-2623-promise-subclass-identity` and `issue-2867-gap4` are all green
+(45 passing in that batch).
+
 A pointer for whoever takes Slice E/F: `all/` and `race/` carry the exact twins
 of the rows just fixed — `{all,race}/ctx-ctor{,-throws}.js`,
 `{all,race}/capability-executor-{called-twice,not-callable}.js`. They fail for a

--- a/plan/issues/5197-es2015-standalone-promise-r2.md
+++ b/plan/issues/5197-es2015-standalone-promise-r2.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone promise — r2 residual pass"
 status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-09-01
+updated: 2026-09-02
 loc-budget-allow:
   # 2026-09-01 (Slice B): the §27.2.1.3 settle closures gain the builtin-function
   # metadata carrier. Each grant lives in the module that already OWNS the
@@ -25,12 +25,29 @@ loc-budget-allow:
   # one enumerated brand arm beside the existing Number/Boolean twins.
   - src/codegen/array-object-proto.ts
   - src/codegen/expressions/calls.ts
+  # 2026-09-02 (Slice D): the NewPromiseCapability protocol is generalized in
+  # place rather than forked. `promise-combinators.ts` already owns the #4682
+  # capability record, its GetCapabilitiesExecutor and the construct-then-
+  # validate sequence; selecting `[[Resolve]]` vs `[[Reject]]` is one field
+  # index inside that same emitter. `call-namespace-static.ts` already owns the
+  # `Promise.METHOD.call(C, …)` admission gate; `reject`, the one-argument
+  # spelling and a zero-parameter `C` are three widenings of that one gate, and
+  # splitting them into a new module would leave the gate reading half its own
+  # conditions from elsewhere.
+  - src/codegen/promise-combinators.ts
+  - src/codegen/expressions/call-namespace-static.ts
 func-budget-allow:
   # 2026-09-01 (Slice B): one extra `registerNative` call in the object-runtime
   # reservation block, and two three-line guard call sites on the `new` path.
   - src/codegen/object-runtime.ts::ensureObjectRuntime
   - src/codegen/expressions/new-super.ts::compileNewExpression
   - src/codegen/expressions/new-super.ts::emitDynamicNewFallback
+  # 2026-09-02 (Slice D): the widened `Promise.resolve/reject.call(C, …)`
+  # admission is three extra conditions plus a missing-argument default inside
+  # the ONE dispatcher that decides every `Namespace.static(...)` lowering.
+  # The conditions ARE the dispatch decision, so extracting them would move the
+  # gate's own predicate out of the gate.
+  - src/codegen/expressions/call-namespace-static.ts::compileNamespaceStaticCall
 priority: high
 horizon: m
 feasibility: hard
@@ -402,6 +419,132 @@ the same reason: they reach GetCapabilitiesExecutor only via
 | `then/ctor-*`, `then/*-prms-cstm-then.js`, `then/capability-*` | SpeciesConstructor + NewPromiseCapability — Slice D/C's `then` half. |
 | Slice E/F combinators (`all`/`race`/`allSettled`/`any`, 83 rows) | out of scope for this pass; still leak `env::Promise_all` / `Promise_race` / `__js_array_new`. |
 | Slice G (#3371 NewTarget), Slice H (realm) | out of scope by the plan. |
+
+## 2026-09-01 resumed implementation (Opus)
+
+Resumes the suspension handoff below (patches applied with `git am --3way` onto
+`813b828b6`; the only conflict was this file's own References block, resolved by
+keeping both sides). Slice C was committed properly; Slice D was then
+implemented and measured. Worktree
+`/home/user/js2/.claude/worktrees/agent-adaa0534580f31c70`, branch
+`worktree-agent-adaa0534580f31c70`.
+
+### Slice C — committed as landed (no code change)
+
+The suspended snapshot's uncommitted Slice C edits were validated as a commit
+rather than re-derived: TS7 typecheck clean; both focused files green
+(`issue-5197-es2015-promise-r2.test.ts` 8/8, `issue-5197-promise-generic-catch.test.ts`
+4/4, run one file per fork); all five ratchet gates exit 0
+(loc, func, coercion, oracle-ratchet "no net checker-usage growth", dead-exports
+"25 known entries, 0 new"). Commit `6fe2aad08`.
+
+The pre-existing TS5 failure `src/linked-provider-runtime.ts(41,37) TS2694:
+Namespace 'WebAssembly' has no exported member 'Tag'` is **not** from this work —
+that file is untouched by every patch in this lane (`git diff 813b828b6 --stat --
+src/linked-provider-runtime.ts` is empty). TS7 is clean.
+
+### Slice D — generic NewPromiseCapability(C) (LANDED, partial)
+
+The two gaps the previous implementer named were real but narrower than the
+"no receiver slot / no generic Construct" framing suggested. The blocker was
+**not** the reified `Promise.resolve` closure's missing receiver: a syntactic
+`Promise.resolve.call(C, v)` never reaches that closure at all — it is decided
+by `compileNamespaceStaticCall`, which already had a #4682/#4727
+NewPromiseCapability arm (`emitStandalonePromiseCustom{CapabilityCheck,Resolve}`
+in `promise-combinators.ts`: mint the capability record, mint a
+GetCapabilitiesExecutor on the funcref-wrapper carrier, call `C`, apply
+§27.2.1.5 steps 8-9, then `Call` the resolve slot). That arm was simply admitted
+too narrowly. Three widenings, no second protocol:
+
+1. **`reject` joins `resolve`.** §27.2.4.6 and §27.2.4.7 differ only in which
+   capability slot the value is handed to, so the emitter takes a
+   `settle: "resolve" | "reject"` argument and picks field 0 or 1 of the same
+   record. It is now `emitStandalonePromiseCustomSettle`.
+2. **One argument is admitted** (`Promise.resolve.call(C)`), not just two. The
+   protocol reads only `C`; the settled value is `undefined`.
+3. **A zero-parameter `C` is admitted.** The executor then never reaches a
+   formal, both slots stay undefined, and steps 8-9 throw the TypeError the spec
+   requires — which is the whole point of `reject/S25.4.4.4_A3.1_T1.js`.
+
+**The undefined-vs-null trap (#2864), caught by the control, not by the corpus.**
+The absent second argument was first emitted as `ref.null.extern`. Every exact
+row still passed and the host lane passed, because none of them inspects the
+settled value — but in standalone a null externref IS JS `null`, not
+`undefined`, so `Promise.resolve.call(C)` settled with the wrong value. The fix
+is `canonicalUndefinedExternInstrs`, resolved BEFORE the value side-buffer is
+detached (it reserves the `$AnyValue` substrate on first use, and doing that with
+`fctx.body` swapped away would register under a body already being written).
+
+**Measurement** — the WHOLE 140-row corpus, standalone, in process, base =
+Slice C commit `6fe2aad08` (file-copy A/B; both runs executed by this
+implementer, ~10 min each):
+
+| | pass | fail | compile_error |
+| --- | ---: | ---: | ---: |
+| before (Slices B + C) | 11 | 127 | 2 |
+| after Slice D | **19** | 119 | 2 |
+
+Set-differenced: **8 fail → pass, 0 regressions.** The `before` figure
+reproduces the previous implementer's 11/127/2 exactly, which also confirms the
+two surviving compile errors are still only the #3371 pair. All eight rows were
+re-compiled through `wrapTest` + `compile({target:"standalone"})` and checked
+with the runner's own `standaloneHostImportError`: every one reports an empty
+import list, so no row is claimed on a module that still leaks
+`env::Promise_resolve` / `Promise_reject` (#5272 — the in-process probe does not
+apply that check itself).
+
+- `built-ins/Promise/resolve/capability-invocation-error.js`
+- `built-ins/Promise/resolve/ctx-ctor-throws.js`
+- `built-ins/Promise/reject/capability-invocation-error.js`
+- `built-ins/Promise/reject/ctx-ctor-throws.js`
+- `built-ins/Promise/reject/capability-executor-not-callable.js`
+- `built-ins/Promise/reject/S25.4.4.4_A3.1_T1.js`
+- `built-ins/Promise/executor-function-extensible.js`
+- `built-ins/Promise/executor-function-length.js`
+
+The last two were **not** predicted from the 17-row resolve/reject/settlement
+sub-corpus (which moved 0 → 6) and are the reason the full sweep was worth its
+ten minutes. They are downstream of the same admission: both observe the
+GetCapabilitiesExecutor's own `length` / extensibility, and the only way either
+reaches one is `Promise.resolve.call(NotPromise)` — a ONE-argument call on a
+custom `C`. Slice B had already made that executor a real built-in function
+object; Slice D is what lets the rows reach it. That closes two of the six
+`executor-function-*` rows the previous implementer listed as Slice-D-blocked.
+
+**A file-copy A/B pitfall worth naming**, because it silently reverted a fix
+that had already been validated. The revert copies were captured at the FIRST
+edit (per the CLAUDE.md pattern) and then the `undefined` fix landed on top —
+so `.tmp/new.ts` was stale. Restoring from it after the base measurement put a
+tree back that was *not* the tree the measurement had been taken on, and the
+only thing that caught it was the compiled control returning 5 again. **Refresh
+the "new" copy after every edit that follows it, and re-run the focused control
+after any restore** — a restore is a code change, not a bookkeeping step.
+
+One measurement artifact worth recording: in the first after-run
+`resolve/capability-executor-called-twice.js` scored `compile_error
+(compilation timeout, 15445 ms)` at box load ~13 on 4 cores. Re-run alone it is
+`fail`, the same status it had at baseline — a load artifact, not a regression.
+Any single-row `compile_error` in this corpus should be re-run alone before it
+is believed.
+
+### Slice D — what is still open
+
+| row(s) | why |
+| --- | --- |
+| `{resolve,reject}/capability-executor-called-twice.js` | the arm IS taken, and both throw the capability TypeError: after `executor()` / `executor(undefined, undefined)` the follow-up `executor(fn, fn)` does not leave two callables in the record, so steps 8-9 refuse. The GetCapabilitiesExecutor is reached through the dynamic apply path with a 0-argument call; that padding/store interaction is the next thing to look at. |
+| `{resolve,reject}/ctx-ctor.js` | `class SubPromise extends Promise` — needs a real `Construct(C, «executor»)` with subclass prototype and `instance.constructor`, not the plain call this arm performs. |
+| `reject/capability-invocation.js`, `resolve/resolve-from-promise-capability.js` | need the settle call's `this` (sloppy-mode global) and a real `arguments` object inside the user-supplied resolve/reject function. |
+| `resolve/arg-uniq-ctor.js` | §27.2.4.7 step 3 — `Promise.resolve(x)` must `Get(x, "constructor")` and compare with `C` before the passthrough; today a native `$Promise` is returned unchanged without that read. Self-contained and reachable, just not done here. |
+| `exception-after-resolve-in-{executor,thenable-job}.js`, `resolve-prms-cstm-then-{immed,deferred}.js` | settlement-core rows that fail in the async drive, unrelated to the capability protocol. |
+| Slices E/F (combinators), G (#3371), H (realm) | untouched by this pass. |
+
+A pointer for whoever takes Slice E/F: `all/` and `race/` carry the exact twins
+of the rows just fixed — `{all,race}/ctx-ctor{,-throws}.js`,
+`{all,race}/capability-executor-{called-twice,not-callable}.js`. They fail for a
+different reason (the `.call(C, iter)` arm still admits only an EMPTY array via
+`emitStandalonePromiseCustomCapabilityCheck`, and a non-empty iterable needs the
+per-element pipeline), so the same widening does not simply transfer — but the
+capability half of their work is now done and shared.
 
 ## References
 

--- a/plan/issues/5197-es2015-standalone-promise-r2.md
+++ b/plan/issues/5197-es2015-standalone-promise-r2.md
@@ -19,6 +19,12 @@ loc-budget-allow:
   - src/codegen/async-scheduler.ts
   - src/codegen/object-runtime.ts
   - src/codegen/expressions/new-super.ts
+  # 2026-09-01 (Slice C): `Promise.prototype.catch`'s two-arm body and the
+  # §27.2.5.4 IsPromise guard belong next to `emitPromiseProtoMemberBody`, the
+  # only place that owns Promise-prototype member bodies; the calls.ts entry is
+  # one enumerated brand arm beside the existing Number/Boolean twins.
+  - src/codegen/array-object-proto.ts
+  - src/codegen/expressions/calls.ts
 func-budget-allow:
   # 2026-09-01 (Slice B): one extra `registerNative` call in the object-runtime
   # reservation block, and two three-line guard call sites on the `new` path.
@@ -282,9 +288,125 @@ the validated Promise behavior.
 - Exact isolated sweeps, focused tests, async/equivalence controls, ratchets,
   issue integrity, and complete repository hooks are green for every fix.
 
+## 2026-09-01 r2 Slices B–D implementation (Opus)
+
+### Corpus and baseline
+
+Exact corpus: the 140 ES2015 `built-ins/Promise/**` rows that were not passing
+standalone at sha `d39779cb` (`.tmp/es2015/promise-paths.txt`). Measured on this
+branch's base with `npx tsx scripts/run-test262-paths.mts … --standalone`:
+
+| | pass | fail | compile_error |
+| --- | ---: | ---: | ---: |
+| before (140 rows) | 0 | 134 | 6 |
+| after Slices B + C | **11** | 127 | 2 |
+
+Set-differencing the two non-pass lists: **11 rows flipped fail → pass, 0 rows
+regressed**. Because nothing in the corpus passed at baseline, no row inside it
+*could* regress; regression cover for everything OUTSIDE the corpus is the
+focused vitest file plus the equivalence gate.
+
+The two surviving compile errors are the pair the plan already assigns to Slice
+G — `get-prototype-abrupt.js` and `get-prototype-abrupt-executor-not-callable.js`,
+both refused by the documented #3371 arbitrary-NewTarget boundary. They are the
+only two of the six that were real compiler refusals.
+
+Three environment notes that change how the numbers read:
+
+- The other **four** baseline `compile_error`s were **compilation timeouts**
+  (~16 s each) under a 4-core box shared with five other agents, not compiler
+  refusals: `{resolve,reject,executor}-function-prototype.js` and
+  `then/S25.4.5.3_A1.1_T2.js`. Two of those four are among the eleven rows that
+  now pass; the other two are ordinary failures in the after-run.
+- `proto-from-ctor-realm.js` and the two `*-function-prototype.js` rows need the
+  prebuilt QuickJS runtime-eval provider. Its adapter cache key changes with the
+  compiler bundle, so it had to be rebuilt
+  (`node --import tsx scripts/build-quickjs-eval-provider.mjs`, ~14 s) before
+  those rows could be scored at all.
+- **The in-process probe does NOT apply the standalone host-import leak check
+  CI's sharded lane applies** (#5272) — `runTest262File`'s original-harness path
+  bypasses `standaloneHostImportError`. Every row claimed below was therefore
+  re-checked by compiling its exact original-harness module with
+  `target: "standalone"` and asserting `result.imports` is empty.
+
+### Slice B — synthesized promise callables (LANDED)
+
+`$__promise_settle_cap` now subtypes the repository's builtin-function metadata
+type (`ensureBuiltinFnMetaType`, `{name: "", length: 1}`) instead of the bare
+signature wrapper, so the finalize-time arms that already answer
+`name`/`length`/gOPD/delete/`getOwnPropertyNames` and
+isExtensible/isFrozen/isSealed/`getPrototypeOf` cover the escaped `resolve` /
+`reject` for free. One factory (`buildPromiseSettleClosureInstrs`) owns the
+`struct.new` operand order for all three mint sites; the capture index moved
+from 3 to 5 and is carried as `capPromiseFieldIdx`, never a literal.
+
+§7.2.4 IsConstructor at a dynamic `new` site: a new `__builtinfn_is_builtin`
+native, filled from the SAME finalized predicate as the integrity helpers, lets
+the two standalone unknown-ctor bases throw the spec TypeError for a built-in
+function value.
+
+**+6 rows** (all fail → pass, all host-import clean):
+`{resolve,reject}-function-name.js`,
+`{resolve,reject}-function-property-order.js`,
+`{resolve,reject}-function-prototype.js`.
+
+### Slice C — generic `catch`, brand-checked `then` (LANDED, partial)
+
+`Promise.prototype.catch` is §27.2.5.1 `Invoke(this, "then", «undefined,
+onRejected»)` and nothing more. Its body now `ref.test`s the receiver: a native
+`$Promise` keeps the intrinsic fast path verbatim, anything else goes through
+`__call_m_then_vararg` — the same dispatcher the thenable-assimilation job uses
+— with an `__promise_has_callable_then` pre-check supplying the §7.3.14 step-2
+TypeError the dispatcher does not raise. `Promise.prototype.then` gained the
+§27.2.5.4 step-2 IsPromise guard, which it needs before it can be reached
+reflectively at all (its `ref.cast` previously trapped on a foreign `this`).
+
+`nativeProtoBrandForInterface` learned the `Promise` brand. Without it the
+DIRECT syntactic spelling `Promise.prototype.catch.call(target, f)` fell to the
+legacy `.call` tail, which drops `thisArg` — so the object's own `then` was
+never invoked. The value-erased spelling (`var m = Promise.prototype.catch`)
+already worked; that difference is why a hand-probe passed while the test262
+rows did not.
+
+**+5 rows**: `catch/{invokes-then,this-value-then-not-callable,
+this-value-then-throws,this-value-then-poisoned}.js`,
+`then/context-check-on-entry.js`.
+
+### Slice D — NOT done, and what it needs
+
+Slice D was not attempted, on evidence rather than time alone: every one of its
+rows bottoms out in the same missing mechanism, a generic
+**NewPromiseCapability(C)** — mint a GetCapabilitiesExecutor built-in function
+(the Slice-B carrier is the right one), `Construct(C, «executor»)` for an
+arbitrary runtime `C`, then apply steps 8–9's IsCallable checks to whatever the
+executor stored. Two concrete gaps block it:
+
+1. `Promise.resolve` / `Promise.reject` reify with `paramTypes = [externref]`
+   and **no receiver slot** (`ensureStandaloneBuiltinStaticMethodClosure`), so
+   `Promise.resolve.call(C, v)` cannot see `C` at all.
+2. Standalone has no general "construct this runtime closure value" primitive —
+   the `new`-site arms cover `$__ta_ctor`, bound functions and runtime-eval
+   carriers, and the host lane's `__construct_closure` is not available.
+
+The six `executor-function-*` rows in the Slice-B corpus are Slice-D-blocked for
+the same reason: they reach GetCapabilitiesExecutor only via
+`Promise.resolve.call(NotPromise)`.
+
+### Rows deliberately not fixed
+
+| row(s) | why |
+| --- | --- |
+| `exec-args.js`, `{resolve,reject}-function-nonconstructor.js` | fail EARLIER than any of this work, in the harness-level `var` binding: the receiver reads null before `hasOwnProperty` is consulted. Same error text as baseline. A hand-written probe of the identical shape passes in both lanes, so the defect is in how the original-harness module binds that `var`, not in the settle-closure object model. |
+| `catch/this-value-obj-coercible.js` | needs §7.3.2 GetV's `ToObject` step for a PRIMITIVE receiver (`Boolean.prototype.then`), a separate mechanism from the generic Invoke. |
+| `catch/S25.4.5.1_A2.1_T1.js`, `then/S25.4.5.3_A1.1_T2.js` | `p.then` / `p.catch` read off a native `$Promise` INSTANCE answer `undefined` — the prototype-chain member read from a `$Promise` receiver is not wired (only `Promise.prototype.<m>` is). Independent of Slice C. |
+| `then/ctor-*`, `then/*-prms-cstm-then.js`, `then/capability-*` | SpeciesConstructor + NewPromiseCapability — Slice D/C's `then` half. |
+| Slice E/F combinators (`all`/`race`/`allSettled`/`any`, 83 rows) | out of scope for this pass; still leak `env::Promise_all` / `Promise_race` / `__js_array_new`. |
+| Slice G (#3371 NewTarget), Slice H (realm) | out of scope by the plan. |
+
 ## References
 
 - #5143 (wave-1 plan), PRs #5179, #5213.
+- #5272 (the in-process probe does not apply the host-import leak check).
 
 ## Suspended Work (2026-09-01T21:56Z — user-requested 2-hour pause)
 

--- a/plan/issues/5197-es2015-standalone-promise-r2.md
+++ b/plan/issues/5197-es2015-standalone-promise-r2.md
@@ -4,7 +4,27 @@ title: "ES2015 standalone promise — r2 residual pass"
 status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-08-30
+updated: 2026-09-01
+loc-budget-allow:
+  # 2026-09-01 (Slice B): the §27.2.1.3 settle closures gain the builtin-function
+  # metadata carrier. Each grant lives in the module that already OWNS the
+  # mechanism being extended, so there is no smaller home for it:
+  #   async-scheduler — mints `$__promise_settle_cap`; the metadata supertype and
+  #     the one `struct.new` factory the three mint sites share belong beside it.
+  #   object-runtime  — owns the `__builtinfn_*` native family; the new
+  #     `__builtinfn_is_builtin` is one more member, filled from the SAME
+  #     finalized predicate as isExtensible/getPrototypeOf.
+  #   new-super       — owns every `new`-site arm; §7.2.4 IsConstructor for a
+  #     built-in function is a `new`-site refusal, not a Promise concern.
+  - src/codegen/async-scheduler.ts
+  - src/codegen/object-runtime.ts
+  - src/codegen/expressions/new-super.ts
+func-budget-allow:
+  # 2026-09-01 (Slice B): one extra `registerNative` call in the object-runtime
+  # reservation block, and two three-line guard call sites on the `new` path.
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
+  - src/codegen/expressions/new-super.ts::compileNewExpression
+  - src/codegen/expressions/new-super.ts::emitDynamicNewFallback
 priority: high
 horizon: m
 feasibility: hard

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -116,8 +116,13 @@ import { ensureSymbolCarrier, usesNativeSymbolProvider } from "./symbol-native.j
 import {
   emitStandalonePromiseFinally,
   emitStandalonePromiseThen,
+  getOrRegisterPromiseType,
   type StandalonePromiseThenCallback,
 } from "./async-scheduler.js";
+// (#5197 Slice C) `Promise.prototype.catch` is specified as an observable
+// `Invoke(this, "then", …)`, so its non-Promise receiver arm reuses the same
+// vararg `then` dispatcher the thenable-assimilation job already uses.
+import { reserveClosedMethodDispatchVararg } from "./closed-method-dispatch.js";
 
 /**
  * `Array.prototype`'s own enumerable+non-enumerable method names (ES2024
@@ -2061,6 +2066,150 @@ function dynamicPromiseHandler(localIndex: number): StandalonePromiseThenCallbac
   };
 }
 
+/**
+ * (#5197 Slice C) §27.2.5.4 step 2 — `IsPromise(this)`.
+ *
+ * Emits `if (!(this is a native $Promise)) throw TypeError` at the head of a
+ * reflective `Promise.prototype.then` body. `catch` deliberately does NOT get
+ * this: §27.2.5.1 is defined purely as `Invoke(this, "then", …)` and works on
+ * any thenable. `finally` does not get it either — its body still `ref.cast`s
+ * the receiver and no reflective spelling routes to it (see the enumerated
+ * brand arm in `tryEmitNativeProtoReflectiveCall`).
+ */
+function emitPromiseReceiverIsPromiseGuard(ctx: CodegenContext, fctx: FunctionContext): void {
+  const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+  const throwBody: Instr[] = [];
+  const saved = fctx.body;
+  fctx.body = throwBody;
+  try {
+    emitThrowTypeError(ctx, fctx, "Method Promise.prototype.then called on incompatible receiver");
+  } finally {
+    fctx.body = saved;
+  }
+  if (throwBody.length === 0) return;
+  fctx.body.push(
+    { op: "local.get", index: 1 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: promiseTypeIdx },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: throwBody },
+  );
+}
+
+/**
+ * (#5197 Slice C) §27.2.5.1 `Promise.prototype.catch ( onRejected )`
+ *
+ *   1. Let promise be the this value.
+ *   2. Return ? Invoke(promise, "then", «undefined, onRejected»).
+ *
+ * `catch` has NO IsPromise check and NO Promise-specific behaviour of its own —
+ * it is defined entirely in terms of an OBSERVABLE `then` invocation on whatever
+ * `this` is. The previous body went straight to the native `$Promise` `.then`,
+ * which `ref.cast`s the receiver, so `Promise.prototype.catch.call({then(){}})`
+ * trapped with an illegal cast instead of calling the object's own `then`.
+ *
+ * Two arms, chosen by a `ref.test` on the receiver:
+ *
+ *  - a native `$Promise` receiver keeps the intrinsic fast path verbatim. That
+ *    is observationally equivalent while `Promise.prototype.then` is unpatched,
+ *    and it is what every ordinary `p.catch(f)` in a compiled program takes;
+ *  - anything else goes through `__call_m_then_vararg(receiver, «undefined,
+ *    onRejected»)` — the same dispatcher the thenable-assimilation job uses, so
+ *    closed-struct `then` methods, closure-valued `then` fields and open
+ *    `$Object` receivers are all covered by one mechanism, with `this` = the
+ *    receiver and the invocation's own result returned.
+ *
+ * Returns `null` (emitting nothing) when the dispatcher or the arg-vector
+ * builders are unavailable, so the caller falls back to the previous body.
+ */
+function emitPromiseProtoCatchBody(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
+  const thenDispatchIdx = ctx.funcMap.get("__call_m_then_vararg");
+  const objVecNewIdx = ctx.funcMap.get("__objvec_new");
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push");
+  const undefinedInstrs = undefinedExternInstrs(ctx);
+  if (
+    thenDispatchIdx === undefined ||
+    objVecNewIdx === undefined ||
+    objVecPushIdx === undefined ||
+    undefinedInstrs === undefined
+  ) {
+    return null;
+  }
+  const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+  const argsLocal = allocLocal(fctx, `__pcatch_args_${fctx.locals.length}`, { kind: "externref" });
+
+  // §7.3.20 Invoke → §7.3.14 Call step 2: `IsCallable(func)` false is a
+  // TypeError, and the vararg dispatcher does not raise one — a non-callable
+  // `then` field reaches `__apply_closure`, which no-ops and answers undefined.
+  // `__promise_has_callable_then` is the module's existing IsCallable(Get(v,
+  // "then")) predicate (built from the SAME collectors as the dispatcher, so
+  // the two agree on what is callable by construction), and it RUNS a stored
+  // accessor — which is exactly right here: a poisoned `then` getter must throw
+  // out of `catch`. Skipped when the predicate was never reserved, leaving the
+  // pre-existing silent-undefined outcome rather than a new hard failure.
+  //
+  // Built BEFORE the native arm on purpose: `emitThrowTypeError` can register
+  // the `__new_TypeError` late import, which shifts already-baked defined-function
+  // indices. Doing it first means nothing is baked yet (#1839/#608).
+  const hasCallableThenIdx = ctx.funcMap.get("__promise_has_callable_then");
+  const notCallableThrow: Instr[] = [];
+  if (hasCallableThenIdx !== undefined) {
+    const savedForThrow = fctx.body;
+    fctx.body = notCallableThrow;
+    try {
+      emitThrowTypeError(ctx, fctx, "is not a function");
+    } finally {
+      fctx.body = savedForThrow;
+    }
+  }
+
+  const nativeArm: Instr[] = [];
+  ctx.liveBodies.add(nativeArm);
+  const saved = fctx.body;
+  fctx.body = nativeArm;
+  try {
+    emitStandalonePromiseThen(ctx, fctx, [{ op: "local.get", index: 1 }], null, dynamicPromiseHandler(2));
+  } finally {
+    fctx.body = saved;
+  }
+
+  const genericArm: Instr[] = [
+    ...(hasCallableThenIdx !== undefined && notCallableThrow.length > 0
+      ? ([
+          { op: "local.get", index: 1 },
+          { op: "call", funcIdx: hasCallableThenIdx },
+          { op: "i32.eqz" },
+          { op: "if", blockType: { kind: "empty" }, then: notCallableThrow },
+        ] satisfies Instr[])
+      : []),
+    { op: "call", funcIdx: objVecNewIdx },
+    { op: "local.set", index: argsLocal },
+    { op: "local.get", index: argsLocal },
+    ...undefinedInstrs, // «undefined» — the onFulfilled slot, always present
+    { op: "call", funcIdx: objVecPushIdx },
+    { op: "local.get", index: argsLocal },
+    { op: "local.get", index: 2 },
+    { op: "call", funcIdx: objVecPushIdx },
+    { op: "local.get", index: 1 },
+    { op: "local.get", index: argsLocal },
+    { op: "call", funcIdx: thenDispatchIdx },
+  ];
+
+  ctx.liveBodies.delete(nativeArm);
+  fctx.body.push(
+    { op: "local.get", index: 1 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: promiseTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: nativeArm,
+      else: genericArm,
+    },
+  );
+  return { kind: "externref" };
+}
+
 /** Emit a callable reflected Promise.prototype method body.
  *
  * Native-prototype closure ABI: local 0 is the wrapper, local 1 is `this`, and
@@ -2072,11 +2221,22 @@ function emitPromiseProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, 
   const receiver: Instr[] = [{ op: "local.get", index: 1 }];
   switch (member) {
     case "then":
+      // (#5197 Slice C) §27.2.5.4 step 2 — "If IsPromise(promise) is false,
+      // throw a TypeError exception", BEFORE `Get(promise, "constructor")`.
+      // This body is reached only through a REFLECTIVE spelling
+      // (`Promise.prototype.then.call(x, …)`, `const m = Promise.prototype.then`),
+      // never through an ordinary `p.then(f)`, so the guard's whole blast radius
+      // is receivers the spec already rejects. Without it `emitStandalonePromiseThen`'s
+      // `ref.cast` trapped on a foreign `this` instead of throwing.
+      emitPromiseReceiverIsPromiseGuard(ctx, fctx);
       emitStandalonePromiseThen(ctx, fctx, receiver, dynamicPromiseHandler(2), dynamicPromiseHandler(3));
       return { kind: "externref" };
-    case "catch":
+    case "catch": {
+      const generic = emitPromiseProtoCatchBody(ctx, fctx);
+      if (generic !== null) return generic;
       emitStandalonePromiseThen(ctx, fctx, receiver, null, dynamicPromiseHandler(2));
       return { kind: "externref" };
+    }
     case "finally":
       emitStandalonePromiseFinally(ctx, fctx, receiver, dynamicPromiseHandler(2));
       return { kind: "externref" };
@@ -2381,6 +2541,12 @@ export function ensurePromiseNativeProtoGlue(ctx: CodegenContext): number | unde
   const brand = getBuiltinBrand(ctx, "Promise");
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    // (#5197 Slice C) `catch`'s generic arm calls `__call_m_then_vararg`.
+    // RESERVE it here, before the glue exists: the member-closure factory emits
+    // each body TWICE (a probe for the result type, then the committed
+    // emission), and minting a function inside either would shift funcidxs
+    // under a body already being written.
+    if (ctx.standalone === true || ctx.wasi === true) reserveClosedMethodDispatchVararg(ctx, "then");
     registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Promise", PROMISE_PROTO_METHODS, "Promise"));
   }
   return brand;

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -17,7 +17,7 @@
 //                   wrappers, chained-resolution machinery, rejection
 //                   propagation.
 
-import type { Instr, LocalDef, ValType } from "../ir/types.js";
+import type { FieldDef, Instr, LocalDef, ValType } from "../ir/types.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import { allocLocal } from "./context/locals.js";
 import { addFuncType, getOrRegisterArrayType } from "./registry/types.js";
@@ -31,12 +31,12 @@ import { inLiveShiftRange } from "../emit/resolve-layout.js"; // (#1916 S3) stab
 // never at module evaluation). The other three are cycle-free leaves relative
 // to this module.
 import { getClosureFuncSelfTypeIdx, getOrCreateFuncRefWrapperTypes } from "./closures.js";
-import {
-  CLOSURE_CAPTURE_FIELD_BASE,
-  closureArityField,
-  closureBagField,
-  closureBagInitInstr,
-} from "./closures/funcref-wrapper-types.js";
+import { closureBagField, closureBagInitInstr } from "./closures/funcref-wrapper-types.js";
+// (#5197 Slice B) The settle closures escape to user code as real function
+// objects, so they carry the standard builtin-function metadata subtype rather
+// than a Promise-local imitation. Cycle-free: builtin-fn-meta.ts imports only
+// the closure-header leaf and func-space.
+import { ensureBuiltinFnMetaType } from "./builtin-fn-meta.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { reserveClosedMethodDispatchVararg } from "./closed-method-dispatch.js";
@@ -965,10 +965,55 @@ export interface PromiseExecutorClosures {
   rejectClFuncIdx: number;
   /** The `$__promise_settle_cap` struct typeIdx (subtype of the canonical `(externref)->()` wrapper). */
   capTypeIdx: number;
+  /**
+   * (#5197 Slice B) Field index of the captured `$Promise` inside
+   * `$__promise_settle_cap`. NOT `CLOSURE_CAPTURE_FIELD_BASE`: the cap struct
+   * subtypes the §27.2.1.3 builtin-function METADATA type, whose two extra
+   * header slots (`bfnstate`, `bfnid`) sit between the closure header and the
+   * capture. Every read/write of the capture derives from this, never a literal.
+   */
+  capPromiseFieldIdx: number;
+  /**
+   * (#5197 Slice B) The `$__promise_settle_meta` typeIdx — the shared
+   * builtin-function metadata subtype (`{name: "", length: 1}`) both settle
+   * closures carry, so `resolve`/`reject` escape as real function objects.
+   */
+  capMetaTypeIdx: number;
   /** `$Promise` struct typeIdx. */
   promiseTypeIdx: number;
   /** `__promise_reject(promise, reason) -> reason` funcIdx (used by the executor-throw catch). */
   rejectFuncIdx: number;
+}
+
+/**
+ * (#5197 Slice B) The `struct.new` sequence for one settle closure VALUE
+ * (`resolve` / `reject`), leaving `(ref $__promise_settle_cap)` on the stack.
+ *
+ * A FACTORY, not a shared constant: the three mint sites splice the result into
+ * three different function bodies, and aliasing one `Instr[]` across them would
+ * be double-remapped by the late-import index walks (the `ref.func` operand is
+ * a DEFINED-function index).
+ *
+ * `promiseInstrs` must leave the captured `(ref $Promise)` on the stack.
+ */
+export function buildPromiseSettleClosureInstrs(
+  closures: PromiseExecutorClosures,
+  clFuncIdx: number,
+  promiseInstrs: readonly Instr[],
+): Instr[] {
+  return [
+    { op: "ref.func", funcIdx: clFuncIdx },
+    { op: "i32.const", value: 1 }, // (#3673) $arity — settle fns take 1 arg
+    closureBagInitInstr(), // (#4241) $bag
+    // (#5197) `bfnstate` delete-bits + the `bfnid` metadata anchor, in the
+    // layout `ensureBuiltinFnMetaType` fixed. Both settle functions share ONE
+    // metadata entry because §27.2.1.3.1/.2 give them identical `{name: "",
+    // length: 1}`; the id therefore selects that single entry for both.
+    { op: "i32.const", value: 0 },
+    { op: "i32.const", value: closures.capMetaTypeIdx },
+    ...promiseInstrs,
+    { op: "struct.new", typeIdx: closures.capTypeIdx },
+  ];
 }
 
 /**
@@ -1003,19 +1048,38 @@ export function ensurePromiseExecutorClosures(ctx: CodegenContext): PromiseExecu
   const wrapper = getOrCreateFuncRefWrapperTypes(ctx, [{ kind: "externref" }], []);
   if (!wrapper) return null;
 
+  // (#5197 Slice B) §27.2.1.3.1/.2 — a promise resolve/reject function is an
+  // anonymous BUILT-IN function object: `typeof === "function"`,
+  // `[[Prototype]] === %Function.prototype%`, extensible, own `length` (1) then
+  // `name` ("") with `{writable:F, enumerable:F, configurable:T}`, and no
+  // [[Construct]]. All of that is exactly what the repository's builtin-function
+  // metadata carrier already answers (`builtin-fn-meta.ts` + the finalize-time
+  // arms in `fillBuiltinFnMeta` / `prependBuiltinFnObjectSemantics`), so the cap
+  // struct SUBTYPES that carrier instead of introducing a second function-object
+  // representation. Both settle functions share ONE metadata entry: the spec
+  // gives them identical `{name, length}`, and the entry is keyed by
+  // (name,length) identity, not by which of the two is being materialized.
+  const capMetaTypeIdx = ensureBuiltinFnMetaType(
+    ctx,
+    wrapper.structTypeIdx,
+    wrapper.closureInfo,
+    "promise:settle",
+    "",
+    1,
+  );
+  const capMetaFields = (ctx.mod.types[capMetaTypeIdx] as { fields: FieldDef[] }).fields;
+  const capPromiseFieldIdx = capMetaFields.length;
   const capTypeIdx = ctx.mod.types.length;
   ctx.mod.types.push({
     kind: "struct",
     name: "$__promise_settle_cap",
     fields: [
-      // Field 0 is inherited from the wrapper root (funcref); it MUST be
-      // redeclared identically in the subtype — as must the #3673 $arity slot.
-      { name: "func", type: { kind: "funcref" }, mutable: false },
-      closureArityField(),
-      closureBagField(),
+      // The metadata supertype's fields MUST be redeclared verbatim (closure
+      // header + `bfnstate` + `bfnid`); the capture is appended after them.
+      ...capMetaFields.map((f) => ({ ...f })),
       { name: "cap_promise", type: { kind: "ref", typeIdx: promiseTypeIdx }, mutable: false },
     ],
-    superTypeIdx: wrapper.structTypeIdx,
+    superTypeIdx: capMetaTypeIdx,
   });
 
   // Mint both trampolines UP-FRONT (stable-regime handles) before any code
@@ -1032,7 +1096,7 @@ export function ensurePromiseExecutorClosures(ctx: CodegenContext): PromiseExecu
   const makeBody = (settleFuncIdx: number): Instr[] => [
     { op: "local.get", index: 0 }, // self: (ref $wrapperRoot)
     { op: "ref.cast", typeIdx: capTypeIdx }, // downcast to the cap subtype (non-null)
-    { op: "struct.get", typeIdx: capTypeIdx, fieldIdx: CLOSURE_CAPTURE_FIELD_BASE }, // captured (ref $Promise)
+    { op: "struct.get", typeIdx: capTypeIdx, fieldIdx: capPromiseFieldIdx }, // captured (ref $Promise)
     { op: "local.get", index: 1 }, // value: externref
     { op: "call", funcIdx: settleFuncIdx }, // settle -> externref
     { op: "drop" }, // trampoline result type is () — discard the settled value
@@ -1060,6 +1124,8 @@ export function ensurePromiseExecutorClosures(ctx: CodegenContext): PromiseExecu
     resolveClFuncIdx,
     rejectClFuncIdx,
     capTypeIdx,
+    capPromiseFieldIdx,
+    capMetaTypeIdx,
     promiseTypeIdx,
     rejectFuncIdx,
   };
@@ -1193,12 +1259,10 @@ function ensurePromiseThenableSubstrate(
     { name: "$argvec", type: { kind: "externref" } },
   ];
   const emitSettleCap = (clFuncIdx: number): Instr[] => [
-    { op: "ref.func", funcIdx: clFuncIdx },
-    { op: "i32.const", value: 1 }, // (#3673) $arity — settle callbacks take 1 arg
-    closureBagInitInstr(), // (#4241) $bag
-    { op: "local.get", index: promiseLocal },
-    { op: "ref.as_non_null" },
-    { op: "struct.new", typeIdx: execClosures.capTypeIdx },
+    ...buildPromiseSettleClosureInstrs(execClosures, clFuncIdx, [
+      { op: "local.get", index: promiseLocal },
+      { op: "ref.as_non_null" },
+    ]),
     { op: "extern.convert_any" },
   ];
   const jobTryBody: Instr[] = [

--- a/src/codegen/expressions/call-namespace-static.ts
+++ b/src/codegen/expressions/call-namespace-static.ts
@@ -60,6 +60,7 @@ import {
   tryEmitJsonParseLiteral,
   tryEmitJsonStringifyStatic,
 } from "../json-standalone.js";
+import { canonicalUndefinedExternInstrs } from "../any-helpers.js";
 import { compileObjectLiteralAsExternref } from "../literals.js";
 import { compileInternalCallArgument } from "./internal-call-argument.js";
 import { emitCollectionIteratorVec } from "../map-runtime.js";
@@ -70,7 +71,7 @@ import { ensureObjectRuntime, ensureObjVecBuilders, reserveApplyClosure } from "
 import {
   emitStandalonePromiseCombinator,
   emitStandalonePromiseCustomCapabilityCheck,
-  emitStandalonePromiseCustomResolve,
+  emitStandalonePromiseCustomSettle,
   emitStandalonePromiseCombinatorRuntime,
   isNativeCombinatorMethod,
   resolveExternrefVecArg,
@@ -2264,10 +2265,20 @@ export function compileNamespaceStaticCall(
     ts.isPropertyAccessExpression(propAccess.expression) &&
     ts.isIdentifier(propAccess.expression.expression) &&
     propAccess.expression.expression.text === "Promise" &&
-    propAccess.expression.name.text === "resolve" &&
+    // (#5197 Slice D) `reject` joins `resolve` here: §27.2.4.6 and §27.2.4.7 are
+    // the SAME protocol — `NewPromiseCapability(C)` then `Call` on one settle
+    // slot — so admitting only one of them left the other on the unsatisfiable
+    // `Promise_reject` host import for every custom `C`.
+    (propAccess.expression.name.text === "resolve" || propAccess.expression.name.text === "reject") &&
     isStandalonePromiseActive(ctx) &&
-    expr.arguments.length === 2
+    // (#5197 Slice D) One argument is the ordinary `Promise.resolve.call(C)`
+    // spelling: NewPromiseCapability still runs, and the settled value is
+    // `undefined`. Requiring two arguments sent that whole family to the host
+    // import even though `C` is the only operand the capability protocol reads.
+    expr.arguments.length >= 1 &&
+    expr.arguments.length <= 2
   ) {
+    const settleKind = propAccess.expression.name.text === "reject" ? "reject" : "resolve";
     const ctorArg = unwrapReflectConstructExpr(expr.arguments[0]!);
     const ctorDecl = ts.isIdentifier(ctorArg) ? ctx.oracle.valueDeclarationOf(ctorArg) : ctorArg;
     const ctorInit = ctorDecl && ts.isVariableDeclaration(ctorDecl) ? ctorDecl.initializer : undefined;
@@ -2282,6 +2293,13 @@ export function compileNamespaceStaticCall(
       const snap = snapshotSpeculative(ctx, fctx);
       ensurePromiseSettleFunctions(ctx);
       ensureObjectRuntime(ctx);
+      // (#5197 Slice D) The missing-second-argument value, resolved HERE — the
+      // canonical `undefined` reserves the `$AnyValue` substrate on first use,
+      // and doing that later would land inside the detached `valueInstrs`
+      // buffer with `fctx.body` swapped away. In standalone a null externref is
+      // JS `null`, NOT `undefined`, so `Promise.resolve.call(C)` must settle
+      // with this singleton or the capability sees the wrong value (#2864).
+      const absentValueInstrs = canonicalUndefinedExternInstrs(ctx);
       const ctorType = compileExpression(ctx, fctx, expr.arguments[0]!);
       const ctorInfo =
         ctorType && (ctorType.kind === "ref" || ctorType.kind === "ref_null")
@@ -2291,8 +2309,13 @@ export function compileNamespaceStaticCall(
             : undefined;
       const supportsCapabilityCtor =
         ctorInfo !== undefined &&
-        ctorInfo.paramTypes.length === 1 &&
-        ctorInfo.paramTypes[0]?.kind === "externref" &&
+        // (#5197 Slice D) A ZERO-parameter `C` is admitted too. NewPromiseCapability
+        // still constructs it — the executor simply never reaches a formal, both
+        // capability slots stay undefined, and §27.2.1.5 steps 8-9 then throw the
+        // TypeError the spec requires. Refusing it here made that observable
+        // outcome a host-import compile failure instead.
+        ctorInfo.paramTypes.length <= 1 &&
+        (ctorInfo.paramTypes.length === 0 || ctorInfo.paramTypes[0]?.kind === "externref") &&
         (ctorInfo.returnType === null ||
           ctorInfo.returnType.kind === "externref" ||
           ctorInfo.returnType.kind === "ref" ||
@@ -2317,14 +2340,21 @@ export function compileNamespaceStaticCall(
         const savedBody = fctx.body;
         fctx.body = valueInstrs;
         try {
-          const valueType = compileExpression(ctx, fctx, expr.arguments[1]!, { kind: "externref" });
-          if (valueType === null) fctx.body.push({ op: "ref.null.extern" });
-          else if (valueType.kind !== "externref") coerceType(ctx, fctx, valueType, { kind: "externref" });
+          const valueArg = expr.arguments[1];
+          // No second argument → the settled value is `undefined`.
+          if (valueArg === undefined) fctx.body.push(...absentValueInstrs);
+          else {
+            const valueType = compileExpression(ctx, fctx, valueArg, { kind: "externref" });
+            if (valueType === null) fctx.body.push({ op: "ref.null.extern" });
+            else if (valueType.kind !== "externref") coerceType(ctx, fctx, valueType, { kind: "externref" });
+          }
         } finally {
           fctx.body = savedBody;
         }
         try {
-          if (emitStandalonePromiseCustomResolve(ctx, fctx, ctorLocal, ctorInfo, ctorSelfTypeIdx, valueInstrs)) {
+          if (
+            emitStandalonePromiseCustomSettle(ctx, fctx, ctorLocal, ctorInfo, ctorSelfTypeIdx, valueInstrs, settleKind)
+          ) {
             return { kind: "externref" };
           }
         } finally {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -310,6 +310,7 @@ import {
   ensureNumberNativeProtoGlue,
   ensureBooleanNativeProtoGlue,
   ensureObjectNativeProtoGlue,
+  ensurePromiseNativeProtoGlue,
   ensureStringNativeProtoGlue,
   ensureGeneratorPrototypeNativeProtoGlue,
   emitTypedArrayIntrinsicCtorObject,
@@ -1328,6 +1329,18 @@ function tryEmitNativeProtoReflectiveCall(
   if (brand === undefined && wrapperWiredMember && ifaceName === "Number") brand = ensureNumberNativeProtoGlue(ctx);
   else if (brand === undefined && wrapperWiredMember && ifaceName === "Boolean")
     brand = ensureBooleanNativeProtoGlue(ctx);
+  // (#5197 Slice C) The same one-member-at-a-time discipline for `Promise`.
+  // `Promise.prototype.catch.call(target, f)` in its DIRECT syntactic form fell
+  // to the legacy `.call` tail, which drops `thisArg` — so the object's own
+  // `then` was never invoked, though §27.2.5.1 is defined as nothing but that
+  // invocation. (The value-erased spelling `var m = Promise.prototype.catch`
+  // already routed here, which is why a hand-probe of the same shape passed.)
+  // Enumerated rather than opening the family: `then` and `catch` now decide
+  // the receiver at runtime, but `finally` still `ref.cast`s it, so routing
+  // `finally` here would turn today's wrong-but-non-throwing answer into a trap.
+  else if (brand === undefined && ifaceName === "Promise" && (member === "then" || member === "catch")) {
+    brand = ensurePromiseNativeProtoGlue(ctx);
+  }
   if (brand === undefined) return undefined;
 
   const glue = getNativeProtoBuiltinGlue(ctx, brand);

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -3247,6 +3247,44 @@ function tryCompileNativeConstructFromValue(
  * fallback is new, so there is no perf or shape change for statically-resolved
  * construction.
  */
+/**
+ * (#5197 Slice B) §7.2.4 IsConstructor for a runtime callee that turned out to
+ * be one of the compiler's own §17 built-in function objects — a promise
+ * `resolve`/`reject`, a GetCapabilitiesExecutor, a reified `Array.isArray`, …
+ *
+ * "Built-in function objects that are not identified as constructors do not
+ * implement the [[Construct]] internal method", so `new resolveFn()` is a
+ * TypeError. Without this the standalone unknown-ctor base evaluated to a bare
+ * null externref and the `assert.throws(TypeError, …)` rows silently passed
+ * through (`built-ins/Promise/{resolve,reject}-function-nonconstructor.js`).
+ *
+ * Deliberately narrow: it fires ONLY for a value that `ref.test`s as a
+ * registered builtin-function metadata family. A user `function f(){}` reaching
+ * this base is untouched, so this cannot convert a working construction into a
+ * throw. Emits NOTHING when the object runtime is absent (host/gc mode, or a
+ * standalone module with no reified builtin function), keeping those byte-identical.
+ *
+ * `descLocal` is the `anyref` slot already holding the evaluated callee.
+ */
+function emitBuiltinFnNotAConstructorGuard(ctx: CodegenContext, fctx: FunctionContext, descLocal: number): void {
+  const isBuiltinIdx = ctx.funcMap.get("__builtinfn_is_builtin");
+  if (isBuiltinIdx === undefined) return;
+  const guardBody: Instr[] = [];
+  const savedBody = fctx.body;
+  fctx.body = guardBody;
+  try {
+    emitThrowTypeError(ctx, fctx, "is not a constructor");
+  } finally {
+    fctx.body = savedBody;
+  }
+  fctx.body.push(
+    { op: "local.get", index: descLocal },
+    { op: "extern.convert_any" },
+    { op: "call", funcIdx: isBuiltinIdx },
+    { op: "if", blockType: { kind: "empty" }, then: guardBody },
+  );
+}
+
 function emitDynamicNewFallback(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -3875,6 +3913,7 @@ function emitDynamicNewFallback(
     const base: Instr[] = [];
     const savedBase = fctx.body;
     fctx.body = base;
+    emitBuiltinFnNotAConstructorGuard(ctx, fctx, descLocal);
     emitTaDynCtorConstructFromLocals(ctx, fctx, descLocal, argLocals);
     fctx.body = savedBase;
     noMatchBase = base;
@@ -6389,6 +6428,9 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
             fctx.body.push({ op: "local.set", index: aLocal });
             taArgLocals.push(aLocal);
           }
+          // (#5197) §13.3.5.1 step 3 runs AFTER ArgumentListEvaluation, so the
+          // IsConstructor refusal is emitted here rather than beside the callee.
+          emitBuiltinFnNotAConstructorGuard(ctx, fctx, taDescLocal);
           emitTaDynCtorConstructFromLocals(ctx, fctx, taDescLocal, taArgLocals);
           // (#4196) A `$__bound_fn` is not a `$__ta_ctor`, so the arm above
           // yields null for it. Retry as §10.4.1.2 [[Construct]] on null.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1420,6 +1420,23 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       ],
       [{ op: "i32.const", value: 0 }],
     );
+    // (#5197) `__builtinfn_is_builtin(v) -> i32` — 1 iff v is one of the §17
+    // built-in function objects this module materializes (a registered
+    // `ctx.builtinFnMetaByTypeIdx` family). Filled from the SAME finalized
+    // predicate `prependBuiltinFnObjectSemantics` uses for
+    // `isExtensible`/`getPrototypeOf`, so the three answers cannot disagree
+    // about what counts as a builtin function object.
+    //
+    // Its consumer is §7.2.4 IsConstructor at a dynamic `new` site: a built-in
+    // function that is not identified as a constructor has no [[Construct]], so
+    // `new resolveFn()` must throw a TypeError rather than evaluate to null.
+    registerNative(
+      "__builtinfn_is_builtin",
+      [{ kind: "externref" }],
+      [{ kind: "i32" }],
+      [],
+      [{ op: "i32.const", value: 0 }],
+    );
   }
   const bfnGetMetaIdx = ctx.standalone ? ctx.funcMap.get("__builtinfn_get_meta") : undefined;
   const bfnGopdIdx = ctx.standalone ? ctx.funcMap.get("__builtinfn_gopd") : undefined;
@@ -11942,6 +11959,10 @@ function prependBuiltinFnObjectSemantics(ctx: CodegenContext, typeIdxs: readonly
     ["__object_isExtensible", 1],
     ["__object_isFrozen", 0],
     ["__object_isSealed", 0],
+    // (#5197) `__builtinfn_is_builtin` answers the same question the three
+    // integrity predicates are being taught, so it is filled from the same
+    // predicate rather than a second `ref.test` chain that could drift.
+    ["__builtinfn_is_builtin", 1],
   ] as const) {
     const integrityFn = findFn(name);
     if (!integrityFn) continue;

--- a/src/codegen/promise-combinators.ts
+++ b/src/codegen/promise-combinators.ts
@@ -333,14 +333,24 @@ export function emitStandalonePromiseCustomCapabilityCheck(
   return true;
 }
 
-/** (#4727) Invoke C with a native capability, then call its resolve slot. */
-export function emitStandalonePromiseCustomResolve(
+/**
+ * (#4727) Invoke C with a native capability, then call one of its settle slots.
+ *
+ * (#5197 Slice D) `settle` selects which slot the value is handed to, because
+ * §27.2.4.7 `Promise.resolve` and §27.2.4.6 `Promise.reject` differ ONLY in
+ * that step — both are `NewPromiseCapability(C)` followed by
+ * `Call(capability.[[Resolve|Reject]], undefined, «x»)`. The capability record's
+ * field 0 is `[[Resolve]]` and field 1 is `[[Reject]]`, so the slot index is the
+ * whole difference and no second protocol is needed.
+ */
+export function emitStandalonePromiseCustomSettle(
   ctx: CodegenContext,
   fctx: FunctionContext,
   constructorLocal: number,
   constructorInfo: ClosureInfo,
   constructorSelfTypeIdx: number,
   valueInstrs: Instr[],
+  settle: "resolve" | "reject",
 ): boolean {
   if (!isStandalonePromiseActive(ctx)) return false;
   const runtime = ensureCustomCapabilityRuntime(ctx);
@@ -418,7 +428,10 @@ export function emitStandalonePromiseCustomResolve(
     { op: "local.get", index: valueLocal },
     { op: "call", funcIdx: vec.pushIdx },
     { op: "local.get", index: stateLocal },
-    { op: "struct.get", typeIdx: runtime.stateTypeIdx, fieldIdx: 0 },
+    // §27.2.4.7 step 5 / §27.2.4.6 step 4 — `Call(capability.[[Resolve]] or
+    // [[Reject]], undefined, «x»)`. `undefined` for the receiver is the null
+    // externref the apply helper already treats as "no thisArg".
+    { op: "struct.get", typeIdx: runtime.stateTypeIdx, fieldIdx: settle === "reject" ? 1 : 0 },
     { op: "ref.null.extern" },
     { op: "local.get", index: argsLocal },
     { op: "call", funcIdx: applyIdx },

--- a/src/codegen/promise-executor.ts
+++ b/src/codegen/promise-executor.ts
@@ -52,6 +52,9 @@ import {
   // module already imports from async-scheduler (the reverse import would be
   // an eval-time cycle).
   ensurePromiseExecutorClosures,
+  // (#5197 Slice B) One factory for the settle-closure `struct.new` sequence —
+  // the metadata slots must agree byte-for-byte across all three mint sites.
+  buildPromiseSettleClosureInstrs,
   isStandalonePromiseActive,
 } from "./async-scheduler.js";
 
@@ -120,7 +123,7 @@ export function emitStandalonePromiseFromExecutor(
     ctx.liveBodies.delete(execInstrs);
     return false;
   }
-  const { resolveClFuncIdx, rejectClFuncIdx, capTypeIdx, promiseTypeIdx, rejectFuncIdx } = closures;
+  const { resolveClFuncIdx, rejectClFuncIdx, promiseTypeIdx, rejectFuncIdx } = closures;
 
   // 2. Allocate the pending $Promise: {state: PENDING, value: null, callbacks: null}.
   const pLocal = allocLocal(fctx, `__pexec_p_${fctx.locals.length}`, { kind: "ref", typeIdx: promiseTypeIdx });
@@ -133,13 +136,11 @@ export function emitStandalonePromiseFromExecutor(
   fctx.body.push(...buildDenoPromiseHookCall(ctx, DENO_PROMISE_HOOK_INIT, [{ op: "local.get", index: pLocal }]));
 
   // 3. Materialise resolve / reject as capturing closure VALUES (externref):
-  //    struct{ func: ref.func $cl, cap_promise: p } upcast to externref.
+  //    struct{ func: ref.func $cl, …builtin-fn metadata…, cap_promise: p }
+  //    upcast to externref. (#5197) The metadata slots make the escaped
+  //    `resolve`/`reject` real §27.2.1.3 function objects.
   const emitSettleValue = (clFuncIdx: number, dst: number): void => {
-    fctx.body.push({ op: "ref.func", funcIdx: clFuncIdx });
-    fctx.body.push({ op: "i32.const", value: 1 }); // (#3673) $arity — settle fns take 1 arg
-    fctx.body.push(closureBagInitInstr()); // (#4241) $bag
-    fctx.body.push({ op: "local.get", index: pLocal });
-    fctx.body.push({ op: "struct.new", typeIdx: capTypeIdx });
+    fctx.body.push(...buildPromiseSettleClosureInstrs(closures, clFuncIdx, [{ op: "local.get", index: pLocal }]));
     fctx.body.push({ op: "extern.convert_any" });
     fctx.body.push({ op: "local.set", index: dst });
   };
@@ -248,7 +249,7 @@ export function emitStandalonePromiseFromExecutorValue(
   const exnTag = ensureExnTag(ctx);
   const closures = ensurePromiseExecutorClosures(ctx);
   if (!closures) return false;
-  const { resolveClFuncIdx, rejectClFuncIdx, capTypeIdx, promiseTypeIdx, rejectFuncIdx } = closures;
+  const { resolveClFuncIdx, rejectClFuncIdx, promiseTypeIdx, rejectFuncIdx } = closures;
 
   // Open-`any` closure bridge + the boxed-any args vec builders.
   ensureObjectRuntime(ctx);
@@ -276,11 +277,7 @@ export function emitStandalonePromiseFromExecutorValue(
 
   // 3. resolve / reject as capturing closure VALUES (externref), capturing p.
   const emitSettleValue = (clFuncIdx: number, dst: number): void => {
-    fctx.body.push({ op: "ref.func", funcIdx: clFuncIdx });
-    fctx.body.push({ op: "i32.const", value: 1 }); // (#3673) $arity — settle fns take 1 arg
-    fctx.body.push(closureBagInitInstr()); // (#4241) $bag
-    fctx.body.push({ op: "local.get", index: pLocal });
-    fctx.body.push({ op: "struct.new", typeIdx: capTypeIdx });
+    fctx.body.push(...buildPromiseSettleClosureInstrs(closures, clFuncIdx, [{ op: "local.get", index: pLocal }]));
     fctx.body.push({ op: "extern.convert_any" });
     fctx.body.push({ op: "local.set", index: dst });
   };

--- a/tests/issue-5197-es2015-promise-r2.test.ts
+++ b/tests/issue-5197-es2015-promise-r2.test.ts
@@ -21,18 +21,28 @@ const EXACT_ROWS = [
   "built-ins/Promise/Symbol.species/symbol-species.js",
   "built-ins/Promise/prototype/Symbol.toStringTag.js",
   // Slice B — the escaped `resolve`/`reject` are §27.2.1.3 built-in function
-  // objects. These four rows were `fail` in BOTH lanes at the 2026-09-01
-  // standalone baseline (0 pass / 134 fail / 6 CE over the 140-row corpus).
+  // objects.
   "built-ins/Promise/resolve-function-name.js",
-  "built-ins/Promise/reject-function-name.js",
-  "built-ins/Promise/resolve-function-property-order.js",
-  "built-ins/Promise/reject-function-property-order.js",
-  // `{resolve,reject}-function-prototype.js` also flipped fail -> pass, but
-  // reading `%Function.prototype%` pulls the native-prototype glue, which makes
-  // the runner instantiate the runtime-eval provider. That provider is a
-  // prebuilt artifact, absent in a bare checkout, so those two rows are covered
-  // by the compiled control below (which needs no runner) instead of here.
 ] as const;
+// Eleven rows of the 140-row ES2015 `built-ins/Promise/**` corpus flipped
+// `fail` -> `pass` on this change (0 -> 11 pass, 0 regressions; the full
+// before/after is recorded on the issue). Only ONE Slice-B row is re-run here,
+// and Slice C's lives in its own file — that split is a MEMORY budget, not a
+// style choice. `vitest.config.ts` gives every fork
+// `--max-old-space-size=512` (`VITEST_FORK_MAX_OLD_SPACE_SIZE`) and runs ONE
+// fork per FILE, so every exact row in a file shares one 512 MB heap while
+// paying a full harness compile + instantiate in BOTH lanes. Adding Slice C's
+// row and control to this file reproducibly OOMs the worker; splitting the
+// file gives each half a fresh heap.
+//
+// Everything the other rows assert is also asserted by the compiled controls,
+// which cost one small compile each and carry the standalone zero-host-import
+// check besides.
+//
+// Two of the eleven (`{resolve,reject}-function-prototype.js`) are additionally
+// unrunnable here: reading `%Function.prototype%` pulls the native-prototype
+// glue, which makes the runner instantiate the runtime-eval provider — a
+// prebuilt artifact that is absent in a bare checkout.
 
 // The species checks intentionally use both the syntactic constructor and an
 // any-typed alias. The former exercises the canonical static gOPD/direct-key

--- a/tests/issue-5197-es2015-promise-r2.test.ts
+++ b/tests/issue-5197-es2015-promise-r2.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
-// #5197 — ES2015 Promise Symbol.species / Symbol.toStringTag object model.
+// #5197 — ES2015 Promise Symbol.species / Symbol.toStringTag object model
+// (Slice A) and the synthesized promise callables (Slice B).
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -19,6 +20,18 @@ const EXACT_ROWS = [
   "built-ins/Promise/Symbol.species/prop-desc.js",
   "built-ins/Promise/Symbol.species/symbol-species.js",
   "built-ins/Promise/prototype/Symbol.toStringTag.js",
+  // Slice B — the escaped `resolve`/`reject` are §27.2.1.3 built-in function
+  // objects. These four rows were `fail` in BOTH lanes at the 2026-09-01
+  // standalone baseline (0 pass / 134 fail / 6 CE over the 140-row corpus).
+  "built-ins/Promise/resolve-function-name.js",
+  "built-ins/Promise/reject-function-name.js",
+  "built-ins/Promise/resolve-function-property-order.js",
+  "built-ins/Promise/reject-function-property-order.js",
+  // `{resolve,reject}-function-prototype.js` also flipped fail -> pass, but
+  // reading `%Function.prototype%` pulls the native-prototype glue, which makes
+  // the runner instantiate the runtime-eval provider. That provider is a
+  // prebuilt artifact, absent in a bare checkout, so those two rows are covered
+  // by the compiled control below (which needs no runner) instead of here.
 ] as const;
 
 // The species checks intentionally use both the syntactic constructor and an
@@ -85,9 +98,80 @@ async function runExactRow(relativePath: (typeof EXACT_ROWS)[number], lane: Lane
   }
 }
 
-async function runControl(lane: Lane): Promise<number> {
+// Slice B — §27.2.1.3.1/.2 promise resolve/reject functions are anonymous
+// BUILT-IN function objects. The escaped `resolve` must therefore answer every
+// §10.2 function-object surface, not merely be callable: `typeof`, an own
+// `length` (1) BEFORE an own `name` (""), both `{writable:F, enumerable:F,
+// configurable:T}`, `%Function.prototype%` as [[Prototype]], extensible, no own
+// `prototype`, and no [[Construct]].
+//
+// The reads are deliberately DYNAMIC (runtime keys through `getOwnPropertyNames`
+// / `getOwnPropertyDescriptor` / `hasOwnProperty.call`) because that is what
+// test262's propertyHelper does and what a compile-time direct-access fold would
+// silently paper over.
+const SETTLE_CALLABLE_SOURCE = `
+  export function test(): number {
+    let resolveFn: any = undefined;
+    let rejectFn: any = undefined;
+    new Promise(function (resolve: any, reject: any) {
+      resolveFn = resolve;
+      rejectFn = reject;
+    });
+
+    if (typeof resolveFn !== "function") return 1;
+    if (typeof rejectFn !== "function") return 2;
+    if (resolveFn === rejectFn) return 3;
+
+    const names: any = Object.getOwnPropertyNames(resolveFn);
+    if (names.length !== 2) return 4;
+    if (names[0] !== "length") return 5;
+    if (names[1] !== "name") return 6;
+
+    const nameDesc: any = Object.getOwnPropertyDescriptor(resolveFn, "name");
+    if (
+      nameDesc === undefined ||
+      nameDesc.value !== "" ||
+      nameDesc.writable !== false ||
+      nameDesc.enumerable !== false ||
+      nameDesc.configurable !== true
+    ) return 7;
+    const lengthDesc: any = Object.getOwnPropertyDescriptor(rejectFn, "length");
+    if (
+      lengthDesc === undefined ||
+      lengthDesc.value !== 1 ||
+      lengthDesc.writable !== false ||
+      lengthDesc.enumerable !== false ||
+      lengthDesc.configurable !== true
+    ) return 8;
+
+    if (Object.getPrototypeOf(resolveFn) !== Function.prototype) return 9;
+    if (Object.getPrototypeOf(rejectFn) !== Function.prototype) return 10;
+    if (!Object.isExtensible(resolveFn)) return 11;
+    if (Object.prototype.hasOwnProperty.call(resolveFn, "prototype")) return 12;
+
+    let threw: any = 0;
+    try {
+      new resolveFn();
+    } catch (e) {
+      threw = e instanceof TypeError ? 1 : 2;
+    }
+    if (threw !== 1) return 13;
+
+    // The metadata must not cost the settle functions their actual job.
+    let settled: any = 0;
+    const p: any = new Promise(function (resolve: any) {
+      resolve(42);
+    });
+    p.then(function (v: any) {
+      settled = v;
+    });
+    return 0;
+  }
+`;
+
+async function runControl(lane: Lane, source: string = CONTROL_SOURCE): Promise<number> {
   try {
-    const result = await compile(CONTROL_SOURCE, {
+    const result = await compile(source, {
       fileName: "issue-5197-es2015-promise-r2-control.ts",
       ...(lane === "standalone" ? { target: "standalone" as const, nativeStrings: true } : {}),
     });
@@ -138,6 +222,12 @@ describe("#5197 ES2015 Promise Symbol.species and Symbol.toStringTag", () => {
   for (const lane of ["host", "standalone"] as const) {
     it(`${lane}: keeps species and prototype tag descriptors aligned`, async () => {
       await expect(runControl(lane)).resolves.toBe(0);
+    });
+  }
+
+  for (const lane of ["host", "standalone"] as const) {
+    it(`${lane}: escapes promise resolve/reject as real built-in function objects`, async () => {
+      await expect(runControl(lane, SETTLE_CALLABLE_SOURCE)).resolves.toBe(0);
     });
   }
 });

--- a/tests/issue-5197-promise-generic-capability.test.ts
+++ b/tests/issue-5197-promise-generic-capability.test.ts
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5197 Slice D — a generic NewPromiseCapability(C) behind
+// `Promise.resolve.call(C, x)` and `Promise.reject.call(C, r)`.
+//
+// §27.2.4.7 and §27.2.4.6 are the same three steps — `NewPromiseCapability(C)`,
+// `Call(capability.[[Resolve]] or [[Reject]], undefined, «x»)`, return
+// `[[Promise]]` — so the two methods share one emitter and differ only in which
+// capability slot the value is handed to.
+//
+// A SEPARATE file for the same reason the Slice C file is separate: one Vitest
+// fork per file with `--max-old-space-size=512`, and every exact row compiles a
+// full harness module.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile, instantiateWasm } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+type Lane = "host" | "standalone";
+
+const TEST262_ROOT = join(import.meta.dirname ?? ".", "..", "test262");
+const TEST262_AVAILABLE =
+  process.env.JS2_TEST262_AVAILABLE !== "0" && existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+
+// Standalone only, deliberately: the whole arm is gated on
+// `isStandalonePromiseActive`, so the JS-host lane reaches these rows through
+// the host `Promise` and is byte-identical before and after. The compiled
+// control below still runs in BOTH lanes, which is what pins that claim.
+//
+// The exact rows this slice flipped, standalone, measured with
+// `scripts/run-test262-paths.mts` over the whole 140-row ES2015
+// `built-ins/Promise/**` corpus: 11 pass → 19 pass, 0 regressions.
+//
+// The last two are downstream, not direct: they observe the
+// GetCapabilitiesExecutor's own `length` and extensibility, and the ONLY way
+// they reach one is `Promise.resolve.call(NotPromise)` — a one-argument call
+// on a custom `C`, which is exactly what this slice admits. They pass because
+// Slice B already made that executor a real built-in function object.
+const EXACT_ROWS = [
+  "built-ins/Promise/resolve/capability-invocation-error.js",
+  "built-ins/Promise/resolve/ctx-ctor-throws.js",
+  "built-ins/Promise/reject/capability-invocation-error.js",
+  "built-ins/Promise/reject/ctx-ctor-throws.js",
+  "built-ins/Promise/reject/capability-executor-not-callable.js",
+  "built-ins/Promise/reject/S25.4.4.4_A3.1_T1.js",
+  "built-ins/Promise/executor-function-extensible.js",
+  "built-ins/Promise/executor-function-length.js",
+] as const;
+
+// Every observable step of NewPromiseCapability, in one compiled module so the
+// mechanism is covered without paying six more harness compiles.
+const CAPABILITY_SOURCE = `
+  export function test(): number {
+    // §27.2.4.7 steps 4-5 — construct C with a GetCapabilitiesExecutor, then
+    // call the captured [[Resolve]] with «x».
+    let seen: any = null;
+    let calls = 0;
+    let resolvedWith: any = null;
+    const Capturing = function (executor: any) {
+      calls += 1;
+      seen = executor;
+      executor(
+        function (v: any) {
+          resolvedWith = v;
+        },
+        function () {},
+      );
+    };
+    Promise.resolve.call(Capturing, 41);
+    if (calls !== 1) return 1;
+    if (typeof seen !== "function") return 2;
+    if (resolvedWith !== 41) return 3;
+
+    // The ONE-argument spelling still runs the whole protocol; the settled
+    // value is undefined.
+    resolvedWith = 7;
+    Promise.resolve.call(Capturing);
+    if (calls !== 2) return 4;
+    if (resolvedWith !== undefined) return 5;
+
+    // §27.2.4.6 step 4 — reject reaches the OTHER slot, and only that one.
+    let rejectedWith: any = null;
+    let resolveSlotCalls = 0;
+    const RejCapturing = function (executor: any) {
+      executor(
+        function () {
+          resolveSlotCalls += 1;
+        },
+        function (r: any) {
+          rejectedWith = r;
+        },
+      );
+    };
+    Promise.reject.call(RejCapturing, 24601);
+    if (rejectedWith !== 24601) return 6;
+    if (resolveSlotCalls !== 0) return 7;
+
+    // §27.2.1.5 steps 8-9 — IsCallable on both captured slots, checked AFTER C
+    // returns. A C that never reaches its formal supplies neither.
+    const ZeroArg = function () {};
+    let threw = 0;
+    try {
+      Promise.reject.call(ZeroArg, 4);
+    } catch (e) {
+      threw = e instanceof TypeError ? 1 : 2;
+    }
+    if (threw !== 1) return 8;
+
+    // …and a C that supplies non-callables fails the same check.
+    const NotCallable = function (executor: any) {
+      executor(1, "x");
+    };
+    threw = 0;
+    try {
+      Promise.resolve.call(NotCallable, 1);
+    } catch (e) {
+      threw = e instanceof TypeError ? 1 : 2;
+    }
+    if (threw !== 1) return 9;
+
+    // §27.2.1.5 step 7 — an abrupt completion out of Construct(C) propagates
+    // unchanged, so it is NOT swallowed into a rejected promise.
+    const Throwing = function () {
+      throw new RangeError("boom");
+    };
+    threw = 0;
+    try {
+      Promise.resolve.call(Throwing);
+    } catch (e) {
+      threw = e instanceof RangeError ? 1 : 2;
+    }
+    if (threw !== 1) return 10;
+
+    // …and so does one out of the settle call itself (§27.2.4.7 step 6).
+    const PoisonResolve = function (executor: any) {
+      executor(
+        function () {
+          throw new RangeError("resolve");
+        },
+        function () {},
+      );
+    };
+    threw = 0;
+    try {
+      Promise.resolve.call(PoisonResolve, 1);
+    } catch (e) {
+      threw = e instanceof RangeError ? 1 : 2;
+    }
+    if (threw !== 1) return 11;
+
+    // The intrinsic receiver is untouched by all of the above.
+    let observed = 0;
+    Promise.resolve(3).then(function (v: any) {
+      observed = v;
+    });
+    if (observed !== 0 && observed !== 3) return 12;
+    return 0;
+  }
+`;
+
+async function runExactRow(relativePath: (typeof EXACT_ROWS)[number], lane: Lane) {
+  try {
+    return await runTest262File(
+      join(TEST262_ROOT, "test", relativePath),
+      "issue-5197",
+      120_000,
+      lane === "standalone" ? lane : undefined,
+    );
+  } finally {
+    restoreHostBuiltins();
+  }
+}
+
+async function runControl(lane: Lane): Promise<number> {
+  try {
+    const result = await compile(CAPABILITY_SOURCE, {
+      fileName: "issue-5197-promise-generic-capability-control.ts",
+      ...(lane === "standalone" ? { target: "standalone" as const, nativeStrings: true } : {}),
+    });
+    expect(
+      result.success,
+      result.success ? "" : result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n"),
+    ).toBe(true);
+    if (!result.success) return -1;
+
+    // (#5272) The in-process test262 probe does NOT apply the standalone
+    // host-import leak check CI's sharded lane applies, so assert it here —
+    // the whole point of this slice is that a custom `C` no longer reaches
+    // `env::Promise_resolve` / `env::Promise_reject`.
+    if (lane === "standalone") {
+      expect(result.imports?.length ?? 0, "standalone control must remain host-free").toBe(0);
+    }
+    const built = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await instantiateWasm(
+      result.binary,
+      built.env,
+      built.string_constants,
+      built.string_constants16,
+    );
+    built.setInstance?.(instance);
+    return (instance.exports as { test: () => number }).test();
+  } finally {
+    restoreHostBuiltins();
+  }
+}
+
+describe("#5197 Slice D — generic NewPromiseCapability(C)", () => {
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_ROWS)(
+    "passes the exact standalone Test262 row %s",
+    async (relativePath) => {
+      const result = await runExactRow(relativePath, "standalone");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    },
+    180_000,
+  );
+
+  for (const lane of ["host", "standalone"] as const) {
+    it(`${lane}: runs NewPromiseCapability(C) for an arbitrary constructor`, async () => {
+      await expect(runControl(lane)).resolves.toBe(0);
+    });
+  }
+});

--- a/tests/issue-5197-promise-generic-catch.test.ts
+++ b/tests/issue-5197-promise-generic-catch.test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5197 Slice C — `Promise.prototype.catch` as an observable
+// `Invoke(this, "then", …)`, and the §27.2.5.4 IsPromise brand check on a
+// reflective `then`.
+//
+// Deliberately a SEPARATE file from `issue-5197-es2015-promise-r2.test.ts`.
+// `vitest.config.ts` gives every fork `--max-old-space-size=512` and runs one
+// fork per FILE, so all the tests in a file share one 512 MB heap. Slice A + B's
+// exact rows and controls already fill most of it; adding this row and control
+// to that file reproducibly OOMs the worker. Splitting gives each half a fresh
+// heap and costs nothing else.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile, instantiateWasm } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+type Lane = "host" | "standalone";
+
+const TEST262_ROOT = join(import.meta.dirname ?? ".", "..", "test262");
+const TEST262_AVAILABLE =
+  process.env.JS2_TEST262_AVAILABLE !== "0" && existsSync(join(TEST262_ROOT, "harness", "assert.js"));
+
+// One exact row for the mechanism. Four more flipped with it —
+// `catch/this-value-then-{not-callable,throws,poisoned}.js` and
+// `then/context-check-on-entry.js` — and every assertion they make is also made
+// by the compiled control below, which costs one small compile per lane instead
+// of a full harness compile.
+const EXACT_ROWS = ["built-ins/Promise/prototype/catch/invokes-then.js"] as const;
+
+// §27.2.5.1 `Promise.prototype.catch` is `Invoke(this, "then", «undefined,
+// onRejected»)` and nothing else: no IsPromise check, no Promise-specific
+// behaviour, so an arbitrary object's own `then` is what runs. §27.2.5.4 `then`
+// is the opposite — step 2 brand-checks `this` BEFORE reading `constructor`, so
+// a reflective call on a foreign receiver is a TypeError.
+//
+// Both the direct syntactic spelling (`Promise.prototype.catch.call(o, f)`) and
+// the value-erased one (`var m = Promise.prototype.catch; m.call(o, f)`) are
+// exercised: they take different lowerings, and only the second one worked
+// before the resolver learned the Promise brand.
+const GENERIC_CATCH_SOURCE = `
+  export function test(): number {
+    const target: any = {};
+    const returnValue: any = {};
+    let callCount = 0;
+    let thisValue: any = null;
+    let argCount: any = null;
+    let firstArg: any = null;
+    let secondArg: any = null;
+    target.then = function (a: any, b: any) {
+      callCount += 1;
+      thisValue = this;
+      argCount = arguments.length;
+      firstArg = a;
+      secondArg = b;
+      return returnValue;
+    };
+
+    // Extra arguments are dropped: exactly «undefined, onRejected» is forwarded.
+    const direct: any = Promise.prototype.catch.call(target, 1, 2, 3);
+    if (callCount !== 1) return 1;
+    if (thisValue !== target) return 2;
+    if (argCount !== 2) return 3;
+    if (firstArg !== undefined) return 4;
+    if (secondArg !== 1) return 5;
+    if (direct !== returnValue) return 6;
+
+    const erased: any = Promise.prototype.catch;
+    if (erased.call(target, 9) !== returnValue) return 7;
+    if (callCount !== 2) return 8;
+
+    // §7.3.14 Call step 2 — a non-callable \`then\` is a TypeError, including
+    // the ordinary-object case that a plain "is it a closure" test would miss.
+    const notCallable: any = [{}, { then: null }, { then: 1 }, { then: "" }, { then: true }, { then: {} }];
+    for (let i = 0; i < notCallable.length; i++) {
+      let threw: any = 0;
+      try {
+        Promise.prototype.catch.call(notCallable[i]);
+      } catch (e) {
+        threw = e instanceof TypeError ? 1 : 2;
+      }
+      if (threw !== 1) return 10 + i;
+    }
+
+    // An abrupt completion out of \`then\` propagates unchanged.
+    const thrower: any = {};
+    thrower.then = function () {
+      throw new RangeError("boom");
+    };
+    let propagated: any = 0;
+    try {
+      Promise.prototype.catch.call(thrower);
+    } catch (e) {
+      propagated = e instanceof RangeError ? 1 : 2;
+    }
+    if (propagated !== 1) return 20;
+
+    // §27.2.5.4 step 2 — IsPromise(this) is checked before anything observable.
+    const poisoned: any = {};
+    Object.defineProperty(poisoned, "constructor", {
+      get: function () {
+        throw new RangeError("constructor must not be read");
+      },
+    });
+    let brandThrew: any = 0;
+    try {
+      Promise.prototype.then.call(poisoned);
+    } catch (e) {
+      brandThrew = e instanceof TypeError ? 1 : 2;
+    }
+    if (brandThrew !== 1) return 21;
+
+    // The intrinsic fast path is untouched: a native promise still chains.
+    let observed: any = 0;
+    Promise.resolve(7).catch(function () {}).then(function (v: any) {
+      observed = v;
+    });
+    return 0;
+  }
+`;
+
+async function runExactRow(relativePath: (typeof EXACT_ROWS)[number], lane: Lane) {
+  try {
+    return await runTest262File(
+      join(TEST262_ROOT, "test", relativePath),
+      "issue-5197",
+      120_000,
+      lane === "standalone" ? lane : undefined,
+    );
+  } finally {
+    // The host runner executes in-process; restore the shared host realm before
+    // the next row (and before Vitest's strict rerun).
+    restoreHostBuiltins();
+  }
+}
+
+async function runControl(lane: Lane): Promise<number> {
+  try {
+    const result = await compile(GENERIC_CATCH_SOURCE, {
+      fileName: "issue-5197-promise-generic-catch-control.ts",
+      ...(lane === "standalone" ? { target: "standalone" as const, nativeStrings: true } : {}),
+    });
+    expect(
+      result.success,
+      result.success ? "" : result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n"),
+    ).toBe(true);
+    if (!result.success) return -1;
+
+    // (#5272) The in-process test262 probe does NOT apply the standalone
+    // host-import leak check CI's sharded lane applies, so assert it here.
+    if (lane === "standalone") {
+      expect(result.imports?.length ?? 0, "standalone control must remain host-free").toBe(0);
+    }
+    const built = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await instantiateWasm(
+      result.binary,
+      built.env,
+      built.string_constants,
+      built.string_constants16,
+    );
+    built.setInstance?.(instance);
+    return (instance.exports as { test: () => number }).test();
+  } finally {
+    restoreHostBuiltins();
+  }
+}
+
+describe("#5197 Slice C — generic Promise.prototype.catch", () => {
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_ROWS)(
+    "passes the exact host Test262 row %s",
+    async (relativePath) => {
+      const result = await runExactRow(relativePath, "host");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    },
+    180_000,
+  );
+
+  it.skipIf(!TEST262_AVAILABLE).each(EXACT_ROWS)(
+    "passes the exact standalone Test262 row %s",
+    async (relativePath) => {
+      const result = await runExactRow(relativePath, "standalone");
+      expect(result.status, `${relativePath}: ${result.error ?? result.reason ?? ""}`).toBe("pass");
+    },
+    180_000,
+  );
+
+  for (const lane of ["host", "standalone"] as const) {
+    it(`${lane}: runs catch as a generic Invoke(this, "then") and brand-checks then`, async () => {
+      await expect(runControl(lane)).resolves.toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Description

Wave 1 of the ES2015 standalone close-out (umbrella [#4444](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4444-es6-standalone-edition-closeout-umbrella)): the Promise r2 lane ([#5197](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5197-es2015-standalone-promise-r2)), Opus-implemented per the Fable plan, integrated into the session branch.

- **Slice B** — the §27.2.1.3 settle closures (`resolve`/`reject`, executor) escape as the repository's builtin-function metadata carrier: `typeof "function"`, `Function.prototype`, own `length` then `name`, extensible, and a §7.2.4 IsConstructor TypeError at dynamic `new` sites (`__builtinfn_is_builtin`).
- **Slice C** — `Promise.prototype.catch` is §27.2.5.1 `Invoke(this, "then", «undefined, onRejected»)` on any receiver (native `$Promise` keeps the intrinsic fast path); `Promise.prototype.then` gains the §27.2.5.4 IsPromise brand check; `nativeProtoBrandForInterface` learns the `Promise` brand so the direct `Promise.prototype.catch.call(t, f)` spelling no longer drops `thisArg`.
- **Slice D** — generic `NewPromiseCapability(C)` for `Promise.resolve.call(C, v)` / `Promise.reject.call(C, v)`: the existing `compileNamespaceStaticCall` capability arm is widened (reject joins resolve via `emitStandalonePromiseCustomSettle`, one-argument calls, zero-parameter `C`).

**Measured** (140-row ES2015 `built-ins/Promise/**` corpus that failed standalone at baseline sha `d39779cb`, in-process runner): 0 pass / 134 fail / 6 CE → **19 pass / 119 fail / 2 CE** (+19 fail→pass, 0 regressions; the two surviving CEs are the [#3371](``https://js2wasm.loopdive.com/dashboard/issue.html?slug=3371-standalone-reflect-construct-arbitrary-distinct-newtarget-still-refuses-33-es2015-rows``) Reflect.construct NewTarget pair). Every flipped row re-compiled with `target: "standalone"` and checked with the runner's own `standaloneHostImportError`: empty import lists.

**Validation**: TS7 typecheck clean; LOC/func budget, coercion-sites, oracle-ratchet, dead-exports gates green (allowances in the issue frontmatter with rationale); focused tests `tests/issue-5197-es2015-promise-r2.test.ts` 8/8, `issue-5197-promise-generic-catch.test.ts` 4/4, `issue-5197-promise-generic-capability.test.ts` 10/10 (host + standalone lanes, zero-host-import assertions); equivalence gate green on the B+C tree (24 failing / 1718 passing, all 24 in the known baseline) — Slice D's changed arm has no `resolve.call`/`reject.call` site in `tests/equivalence/`, and the gate re-runs in CI here.

Two **pre-existing** control failures were A/B-confirmed against `813b828b6` (unmodified main) and are recorded in the issue file, not caused here: `issue-2671-promise-capability.test.ts` (one thenable-element case) and `reflected-symbol-promise-statics.test.ts` (both tests). TS5 typecheck fails pre-existing on `src/linked-provider-runtime.ts` (`WebAssembly.Tag`), untouched.

Not in this wave (recorded in the issue): `capability-executor-called-twice`, `ctx-ctor` (needs a real `Construct` for `class extends Promise`), settle functions needing `this`/`arguments`, `arg-uniq-ctor`, and Slices E/F/G/H (combinators still leak `env::Promise_all`/`Promise_race`).

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs)_