### PR TITLE
fix(test262-runner): apply the standalone host-import leak check on the in-process original-harness path (#5272)

### DIFF
--- a/plan/issues/5272-test262-runner-original-harness-standalone-leak-check.md
+++ b/plan/issues/5272-test262-runner-original-harness-standalone-leak-check.md
@@ -1,10 +1,10 @@
 ---
 id: 5272
 title: "test262 runner: the in-process original-harness path (runTest262File) never applies the standalone host-import leak check — local probes disagree with the sharded lane"
-status: ready
+status: in-review
 sprint: current
 created: 2026-09-01
-updated: 2026-09-01
+updated: 2026-09-02
 priority: high
 horizon: s
 feasibility: easy
@@ -87,3 +87,107 @@ number the merge_group will see.
 - #2961 (strict leak scan for `--target standalone`), #4444 (ES2015 umbrella),
   #5267 (planning pass that surfaced the gap; its Step A closes the
   `Set_new`/`WeakMap_new` leaks themselves).
+
+## 2026-09-02 implementation (Opus)
+
+`runOriginalHarnessVariant` (`tests/test262-runner.ts`) now calls the existing
+`standaloneHostImportError` right after `computeWasmSha` and **before**
+`buildImports`, returning `{ pass: false, phase: "compile", detail, timing,
+wasm_sha }`. No second classifier was written. `runTest262File` maps
+`phase: "compile"` → `status: "compile_error"` and `classifyErrorCategory`
+already maps the message → `host_import_leak`, so the record shape needed no
+other change. The strict rerun goes through the same function, so step 2 is
+covered; `runSyntheticTest262File` keeps its own call.
+
+**Fixture correction to the plan.** The plan named `new Set(customIterable)` /
+`new WeakMap([[k, v]])`; the for-of lane (PR #5458) has since closed both, and
+`Promise.all` / `Promise.race` / `RegExp` / `Proxy` no longer leak either
+(measured 2026-09-02 with the runner's own compile options — `target:
+"standalone"`, `deferTopLevelInit`, `hostBridge: "always"` — all report
+`imports: []`). `new SharedArrayBuffer(8)` still emits
+`env::SharedArrayBuffer_new` (296 rows in the committed standalone baseline
+carry exactly that leak), so it is the fixture.
+
+**One negative-test refinement.** The check is skipped for `parse`/`early`/
+`resolution` negatives. That is not leniency: the sharded worker's own
+compile-phase-negative arm (`scripts/test262-worker.mjs:1788`) returns
+`negativeCompileSucceededVerdict` → `status: "fail"` **before** it reaches its
+leak check at `:1797`. Applying the leak check unconditionally here would have
+scored those rows `compile_error` while the baseline says `fail` — a new
+disagreement in the opposite direction, in the very lane this issue exists to
+align. Runtime negatives are unaffected and do reach the check, exactly as in
+the worker.
+
+### Before / after — `npx tsx scripts/run-test262-paths.mts .tmp/5272.txt --standalone`
+
+The plan's suggested probe rows (`Promise/all`, `Promise/race`) no longer leak,
+so the slice is two rows the committed baseline scores `host_import_leak` plus
+the `Proxy` control.
+
+| row | before (HEAD `4ae25b8d6c`) | after |
+| --- | --- | --- |
+| `built-ins/SharedArrayBuffer/prototype/slice/nonconstructor.js` | **pass** (pseudo-pass — `buildImports` satisfied `env::SharedArrayBuffer_new` from the host) | `compile_error` — `standalone target emitted host imports: env::SharedArrayBuffer_new (#2961)` |
+| `built-ins/Atomics/notify/bad-range.js` | `fail` — `RuntimeError: illegal cast in __module_init()` | `compile_error` — same leak message |
+| `built-ins/Proxy/revocable/revoke.js` (control) | pass | pass |
+
+Counts: `{ pass: 2, fail: 1 }` → `{ compile_error: 2, pass: 1 }`.
+
+**JS-host lane is byte-identical before and after** (same slice without
+`--standalone`, both runs executed here): `{ pass: 2, fail: 1 }`, same failure
+text on `Atomics/notify/bad-range.js`. Expected — `standaloneHostImportError`
+returns `undefined` unless `target === "standalone"`.
+
+### Parity with the sharded lane (acceptance criterion 3)
+
+`TEST262_TARGET=standalone
+TEST262_PATH_FILTER="built-ins/SharedArrayBuffer/prototype/slice/nonconstructor.js"
+TEST262_REPORTER=dot pnpm run test:262 --official-scope-only`, run 2026-09-02.
+The wrapper exits 2 with `missing-shard-manifest: Expected 16 shard manifests
+but found 1` — the documented consequence of filtering to a single row (15
+shards match nothing), **not** a verdict failure. The one shard that ran wrote
+`benchmarks/results/test262-standalone-results-20260902-044838.jsonl`:
+
+```
+"status":"compile_error"
+"error":"standalone target emitted host imports: env::SharedArrayBuffer_new (#2961)"
+"error_category":"host_import_leak"
+"imports":["env::SharedArrayBuffer_new"]
+```
+
+Identical status, error text and `error_category` to what the in-process runner
+now returns for that row. The committed baseline
+(`.test262-cache/test262-standalone-current.jsonl`, promoted 2026-09-01 20:21)
+carries the same three fields for both leaky rows, so the two lanes agreed on
+this row's verdict in both a fresh run and the published artifact.
+
+### Regression test
+
+`tests/issue-5272-runner-standalone-leak.test.ts` — 7 tests, all pass
+(`npx vitest run`, 124 s). It guards the fixture first (fails loudly with
+"pick a construct that does" if `SharedArrayBuffer` ever stops leaking, so the
+row assertions can never vacuate silently), then asserts `compile_error` +
+`/standalone target emitted host imports/` on both leaky rows, that the same
+rows are untouched on the JS-host lane, that a host-free standalone row still
+passes, and that `standaloneHostImportError` is the single classifier.
+
+### Gates
+
+`pnpm run typecheck` exit 0. All five ratchet gates exit 0, run bare:
+`check-loc-budget`, `check-func-budget`, `check-coercion-sites`,
+`check:oracle-ratchet` (`no net checker-usage growth`), `check:dead-exports`
+(`OK (25 known entries, 0 new)`).
+
+### Pre-existing failures in neighbouring runner tests (NOT caused by this change)
+
+Each was re-run on the unmodified HEAD copy of `tests/test262-runner.ts` and
+fails identically there:
+
+| file | base | with the change |
+| --- | --- | --- |
+| `tests/test262-runner-static-gen-yield.test.ts` | 10 pass | 10 pass |
+| `tests/issue-542-negative-skip.test.ts` | 3 fail | 3 fail — stale `shouldSkip` assertions; `eval`/`with` are no longer skipped |
+| `tests/issue-3369-project-runner.test.ts` | 1 fail | 1 fail — hits its own 600 s timeout; the box was at load ~12 on 4 cores |
+| `tests/test262-fyi-runner.test.ts` | 8 fail / 2 pass | 8 fail / 2 pass — `Test262 worker exited before ready (code 1)`, a child-spawn failure in this container |
+
+The last three are all host-lane or non-runner paths, so a
+`target === "standalone"`-gated check cannot reach them.

--- a/tests/issue-5272-runner-standalone-leak.test.ts
+++ b/tests/issue-5272-runner-standalone-leak.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5272 — the in-process original-harness path must apply the SAME standalone
+// host-import leak check the sharded worker applies (#2961).
+//
+// Before this landed, `runTest262File(…, "standalone")` handed a leaked `env::*`
+// import to `buildImports`, satisfied it from the JS host and reported whatever
+// the test then did — sometimes a pass. So a local before/after measured with
+// `scripts/run-test262-paths.mts --standalone` was not the number the
+// merge_group would see.
+//
+// FIXTURE CHOICE — `new SharedArrayBuffer(...)` still emits
+// `env::SharedArrayBuffer_new` on `--target standalone` (verified 2026-09-02
+// against the committed standalone baseline: 296 rows carry exactly that leak).
+// `Promise.all` / `Set` / `WeakMap` used to leak too and no longer do, so if
+// this construct ever gains a Wasm-native lowering, the `leaks on standalone
+// today` guard below fails FIRST and tells you to move the fixture rather than
+// silently vacuating the assertion.
+
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { runTest262File, standaloneHostImportError } from "./test262-runner.js";
+
+/** Rows the sharded baseline scores `compile_error` / `host_import_leak`. */
+const LEAKY_ROWS = [
+  "built-ins/SharedArrayBuffer/prototype/slice/nonconstructor.js",
+  "built-ins/Atomics/notify/bad-range.js",
+] as const;
+
+/** Control: a standalone row that needs no host import and passes. */
+const HOST_FREE_ROW = "built-ins/Proxy/revocable/revoke.js";
+
+const category = (relativePath: string) => relativePath.split("/").slice(0, 2).join("/");
+
+describe("#5272 — runTest262File applies the standalone host-import leak check", () => {
+  it("still emits a host import for the fixture construct (guards the rows below)", async () => {
+    const result = await compile("const b = new SharedArrayBuffer(8);\n", {
+      allowJs: true,
+      fileName: "test.js",
+      target: "standalone",
+    });
+    const names = (result.imports ?? []).map((entry) => `${entry.module}::${entry.name}`);
+    expect(
+      names,
+      "SharedArrayBuffer no longer leaks on standalone — pick a construct that does, or stub result.imports",
+    ).toContain("env::SharedArrayBuffer_new");
+  });
+
+  it.each(LEAKY_ROWS)("scores %s as a host_import_leak compile_error on standalone", async (relativePath) => {
+    const result = await runTest262File(
+      resolve("test262/test", relativePath),
+      category(relativePath),
+      undefined,
+      "standalone",
+    );
+    expect(result.status, result.error ?? result.reason).toBe("compile_error");
+    expect(result.error).toMatch(/standalone target emitted host imports/);
+    expect(result.error).toContain("env::SharedArrayBuffer_new");
+  });
+
+  it.each(LEAKY_ROWS)("leaves %s alone on the JS-host lane", async (relativePath) => {
+    const result = await runTest262File(resolve("test262/test", relativePath), category(relativePath));
+    expect(result.status).not.toBe("compile_error");
+    expect(result.error ?? "").not.toMatch(/standalone target emitted host imports/);
+  });
+
+  it("still passes a host-free standalone row", async () => {
+    const result = await runTest262File(
+      resolve("test262/test", HOST_FREE_ROW),
+      category(HOST_FREE_ROW),
+      undefined,
+      "standalone",
+    );
+    expect(result.status, result.error ?? result.reason).toBe("pass");
+  });
+
+  it("reuses the one leak classifier rather than a second copy", () => {
+    expect(standaloneHostImportError("standalone", [{ module: "env", name: "SharedArrayBuffer_new" }])).toMatch(
+      /standalone target emitted host imports: env::SharedArrayBuffer_new \(#2961\)/,
+    );
+    expect(standaloneHostImportError(undefined, [{ module: "env", name: "SharedArrayBuffer_new" }])).toBeUndefined();
+    expect(standaloneHostImportError("standalone", [])).toBeUndefined();
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -4429,6 +4429,10 @@ async function runOriginalHarnessVariant(
     // FIRST, so a parse/early/resolution negative keeps its own verdict here
     // too. A leak is never a valid negative outcome either, so it is likewise
     // never routed through `negativeCompileErrorMatches`.
+    // oracle-version-exempt: flips ZERO baseline rows — the sharded worker that
+    // produces the published baseline already scores every leaked-import row
+    // as compile_error/host_import_leak (scripts/test262-worker.mjs, #2961);
+    // this only brings the in-process probe lane into agreement (#5272).
     const compileNegative =
       meta.negative?.phase === "parse" || meta.negative?.phase === "early" || meta.negative?.phase === "resolution";
     const standaloneImportError = compileNegative ? undefined : standaloneHostImportError(target, result.imports);

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -4419,6 +4419,23 @@ async function runOriginalHarnessVariant(
     }
 
     const wasm_sha = computeWasmSha(result.binary);
+
+    // (#5272) A standalone verdict must describe a binary that runs without the
+    // JS harness. `buildImports` below would satisfy a leaked `env::*` import
+    // from the host and turn the row into a pseudo-pass, which is exactly what
+    // the sharded worker refuses (`scripts/test262-worker.mjs`, #2961) — so the
+    // in-process runner scored the same row differently from the baseline.
+    // Ordering mirrors that worker: its compile-phase-negative arm returns
+    // FIRST, so a parse/early/resolution negative keeps its own verdict here
+    // too. A leak is never a valid negative outcome either, so it is likewise
+    // never routed through `negativeCompileErrorMatches`.
+    const compileNegative =
+      meta.negative?.phase === "parse" || meta.negative?.phase === "early" || meta.negative?.phase === "resolution";
+    const standaloneImportError = compileNegative ? undefined : standaloneHostImportError(target, result.imports);
+    if (standaloneImportError) {
+      return { pass: false, phase: "compile", detail: standaloneImportError, timing: timing(), wasm_sha };
+    }
+
     const output: string[] = [];
     const appendOutput = (line: string): void => {
       Reflect.defineProperty(output, output.length, {


### PR DESCRIPTION
## Description

Fixes [#5272](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5272-test262-runner-original-harness-standalone-leak-check) (umbrella [#4444](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4444-es6-standalone-edition-closeout-umbrella)): `runTest262File`'s original-harness path — the in-process runner behind `scripts/run-test262-paths.mts`, `tests/test262.test.ts` and the ESM worker — never applied the `--target standalone` host-import leak check that the sharded CI lane applies, so local before/after measurements could report a pseudo-pass (the import satisfied from the JS host) or an unrelated runtime error where CI scores `compile_error` / `host_import_leak`.

- `runOriginalHarnessVariant` now calls the existing `standaloneHostImportError` after `computeWasmSha` and before `buildImports`, returning the same `phase: "compile"` shape as the compile-failure arm; `runTest262File` already maps that to `compile_error` and `classifyErrorCategory` to `host_import_leak`, so the record matches the sharded lane. The strict rerun shares the function; `runSyntheticTest262File` keeps its own call. No second classifier.
- The check is skipped for `parse`/`early`/`resolution` negatives, mirroring the sharded worker, whose compile-phase-negative arm returns `fail` before its own leak check — applying it unconditionally would have created a new disagreement in the opposite direction.
- Regression test `tests/issue-5272-runner-standalone-leak.test.ts` (7/7): `new SharedArrayBuffer(8)` still leaks `env::SharedArrayBuffer_new` (296 baseline rows) and is the fixture; a host-free control still passes; the JS-host lane is byte-identical before/after.

**Before → after** (`run-test262-paths.mts --standalone`): `SharedArrayBuffer/prototype/slice/nonconstructor.js` pseudo-**pass** → `compile_error` (`standalone target emitted host imports: env::SharedArrayBuffer_new (#2961)`); `Atomics/notify/bad-range.js` `fail` (illegal cast) → the same `compile_error`; `Proxy/revocable/revoke.js` control pass → pass. **Parity**: a single-row sharded run (`pnpm run test:262` with `TEST262_PATH_FILTER`) wrote `status: compile_error`, identical error text and `error_category: host_import_leak` — matching the in-process result and the committed baseline.

**Validation**: TS7 typecheck clean; five ratchet gates green; focused test 7/7. Three neighbouring runner test files fail identically on unmodified `main` (stale `shouldSkip` assertions in `issue-542-negative-skip`, a 600 s timeout in `issue-3369-project-runner` under load, and a child-spawn failure in `test262-fyi-runner` in this container) — pre-existing, recorded in the issue.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs)_