### PR TITLE
test(#5259): rewrite the five stale issue-3517 map module-init routing pins to current truthful routing

### DIFF
--- a/plan/issues/5259-issue-3517-map-module-init-test-rot.md
+++ b/plan/issues/5259-issue-3517-map-module-init-test-rot.md
@@ -1,10 +1,11 @@
 ---
 id: 5259
 title: "issue-3517-map-module-init.test.ts is red 5/14 on main and invisible to CI"
-status: ready
+status: done
 sprint: current
 created: 2026-09-01
-updated: 2026-09-01
+updated: 2026-09-02
+completed: 2026-09-02
 priority: high
 horizon: s
 complexity: S
@@ -74,3 +75,100 @@ minimal repair, not a CI redesign.
   the rewrite: four of the five red lanes are unrelated to WASI, so bundling
   it would have widened that PR.
 - The file's other 9 tests are healthy and must stay untouched.
+
+## 2026-09-02 checkpoint note — Opus lane
+
+Branch `claude/issue-5259-map-module-init-test-rot`, based on `origin/main`
+`7f998ff873`. One test file changed (`tests/issue-3517-map-module-init.test.ts`);
+no `src/**`, no baseline JSON, no other test file.
+
+### Measured before-state (untouched base, `7f998ff873`)
+
+`npx vitest run tests/issue-3517-map-module-init.test.ts` → **5 failed | 9
+passed (14)**, every failure on the same line (`:155`,
+`expect(result.irCompiledFuncs ?? []).not.toContain("<module-init>")`):
+
+| # | Test | Message |
+| --- | --- | --- |
+| 1 | keeps the Map module initializer legacy-owned in **native strings** | `expected [ '<module-init>' ] to not include '<module-init>'` |
+| 2 | keeps the Map module initializer legacy-owned in **fast** | `expected [ '<module-init>' ] to not include '<module-init>'` |
+| 3 | keeps the Map module initializer legacy-owned in **standalone** | `expected [ 'memo', '<module-init>' ] to not include '<module-init>'` |
+| 4 | keeps the Map module initializer legacy-owned in **WASI** | `expected [ 'memo', '<module-init>' ] to not include '<module-init>'` |
+| 5 | keeps the Map module initializer legacy-owned in **strict no-host** | `expected [ 'memo', '<module-init>' ] to not include '<module-init>'` |
+
+The pins' *second* assertion (`irPostClaimErrors` empty) was never reached and
+is stale too: native strings and fast each report one post-claim demotion,
+`build / memo / "semantic intrinsic js.number.unbox has no provider under
+number-boundary policy box=unsupported/unbox=unsupported"`. Rewriting only the
+`irCompiledFuncs` line would have left those two lanes red.
+
+### Truthful routing, measured per lane
+
+Probe: `compile(MAP_SOURCE, { experimentalIR: true, trackFallbacks: true,
+trackIrOutcomes: true, skipSemanticDiagnostics: true, ...laneOptions })`, module-init
+row = the single `irOutcomes` entry with `unitKind === "module-init"`. Re-run
+with and without `trackIrOutcomes` — identical routing either way, so the flag
+observes rather than perturbs.
+
+| Lane | `irCompiledFuncs` | row kind | legacy · IR | post-claim | route |
+| --- | --- | --- | --- | --- | --- |
+| native strings | `["<module-init>"]` | `emitted@patch` | 1 · 1 | `["memo"]` | overlay |
+| fast | `["<module-init>"]` | `emitted@patch` | 1 · 1 | `["memo"]` | overlay |
+| standalone | `["memo","<module-init>"]` | `emitted@patch` | **0 · 1** | `[]` | prepared |
+| WASI | `["memo","<module-init>"]` | `emitted@patch` | **0 · 1** | `[]` | prepared |
+| strict no-host | `["memo","<module-init>"]` | `emitted@patch` | 1 · 1 | `[]` | overlay |
+
+No lane is legacy-*owned* any more — every one IR-compiles `<module-init>`. What
+still differs is which route claims the body, so the three overlay lanes keep a
+**positive** legacy assertion (`legacyBodyEmitted: true`), not a vacuous one.
+
+### The five rewrites and their citations
+
+Each row of the new `MODULE_INIT_LANES` table carries a one-line
+"Routing owner:" comment:
+
+1. **native strings** → #3142 slice 2 (PR #3168), the IR module-init overlay.
+   The prepared lane's host arm requires `!ctx.nativeStrings`
+   (`src/codegen/index.ts:4270`) and its standalone arm requires `ctx.standalone`
+   (`:4276`), so native strings on gc keeps the overlay's dual emission.
+2. **fast** → #3142 slice 2 (PR #3168). `ctx.fast` is refused outright by the
+   prepared lane (`index.ts:4292`), so fast mode can only reach `<module-init>`
+   through the overlay.
+3. **standalone** → #3523, `f58fdd279 feat(ir): retire standalone lexical
+   module-init bodies` in **PR #4662** — the prepared lane's standalone
+   native-first arm (`index.ts:4275-4280`). No legacy body at all.
+4. **WASI** → #3523 gap 3 (**PR #5425**, `5ba19f8fb` admission +
+   `bacf6a935` machinery) — the invocation-policy-driven `_start` guard
+   (`index.ts:4281-4290`). Prepared route, `legacy 0 · IR 1`, exactly the
+   success signature that slice's checkpoint note (probe P4) recorded.
+5. **strict no-host** → #3142 slice 2 (PR #3168). An EXPLICIT
+   `--no-host-imports` gc build stays refused by the prepared lane by design
+   (`index.ts:4293-4299`, comment added by #3523 gap 3), so this lane keeps a
+   legacy body alongside the overlay's IR body.
+
+Commits found with `git log -S` / `git log --diff-filter=A` after
+`git fetch --unshallow` (the session clone was shallow to 2026-08-31, which
+hides every pre-gap commit — worth knowing before trusting a `git log -S` here).
+
+After: **14 passed (14)**. The other 9 tests are byte-identical.
+
+### Criterion 4 — did `issue-tests`' `continue-on-error` swallow this?
+
+**No — the file was never selected, so the advisory step never had it in
+scope.** Evidence: PR #5450's CI run
+<https://github.com/loopdive/js2/actions/runs/33580595431/job/100094026969>
+(`issue-tests`, conclusion `success`). Its fatal step ran the pinned list —
+one file, `tests/issue-3529-selector-preclaim.test.ts` — and its advisory step
+logged `select-changed-issue-tests: base=3ba791164e changed=1 running=1` →
+`tests/issue-3523-module-init-single-pass.test.ts`. Neither list contains
+`tests/issue-3517-map-module-init.test.ts`, and `git log -- ` that file shows a
+single commit in its whole history (`16beee807 feat(ir): claim exact generic
+Map module init`), so no PR since creation has touched it.
+
+So of the three composing conditions in "Why CI never caught it" above, the
+load-bearing pair is (1) non-required job and (2) a one-file pinned list.
+`continue-on-error` (3) is a real hole but a **latent** one for this file: it
+only becomes the swallowing mechanism on the first PR that touches the file —
+which is this PR, where the advisory step now runs the file green. Gate
+redesign remains out of scope, and per the dispatch brief no separate CI-policy
+issue was filed here; the evidence above is left for that decision.

--- a/tests/issue-3517-map-module-init.test.ts
+++ b/tests/issue-3517-map-module-init.test.ts
@@ -143,17 +143,119 @@ describe("#3517 exact generic Map module initializer", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it.each([
-    ["native strings", { nativeStrings: true }],
-    ["fast", { fast: true }],
-    ["standalone", { target: "standalone" as const }],
-    ["WASI", { target: "wasi" as const }],
-    ["strict no-host", { strictNoHostImports: true }],
-  ])("keeps the Map module initializer legacy-owned in %s", async (_label, options) => {
-    const result = await tracked(MAP_SOURCE, options);
+  /**
+   * (#5259) The five lane pins below asserted `<module-init>` ∉ `irCompiledFuncs`
+   * — a "these lanes are legacy-owned" assumption that the IR module-init work
+   * has since retired lane by lane, leaving this file red 5/14 on main. Every
+   * lane here now IR-compiles the Map initializer; what still differs per lane
+   * is WHICH route claims it:
+   *
+   * - **overlay** — the #3142 slice-2 module-init lowering patches the IR body
+   *   into the `__module_init` slot while the legacy body dispatcher still
+   *   runs, so the outcome row reads `legacy 1 · IR 1`.
+   * - **prepared** — `preparedExactLexicalModuleInit`
+   *   (`src/codegen/index.ts:4269-4310`) owns the body outright and emits no
+   *   legacy body at all: `legacy 0 · IR 1`.
+   */
+  interface ModuleInitLaneRouting {
+    readonly label: string;
+    readonly route: "overlay" | "prepared";
+    readonly options: CompileOptions;
+    /** `irCompiledFuncs`, in order, exactly as this lane produces it. */
+    readonly irCompiledFuncs: readonly string[];
+    /** Module-init outcome row: the legacy body dispatcher emitted a body. */
+    readonly legacyBodyEmitted: boolean;
+    /** Module-init outcome row: the IR body dispatcher emitted a body. */
+    readonly irBodyEmitted: boolean;
+    /** Post-claim demotions this lane legitimately still reports, by unit. */
+    readonly postClaimErrorFuncs: readonly string[];
+  }
+
+  const MODULE_INIT_LANES: ModuleInitLaneRouting[] = [
+    {
+      // Routing owner: #3142 slice 2 (PR #3168) — the IR module-init overlay.
+      // The prepared lane's host arm requires `!ctx.nativeStrings` (index.ts:4270)
+      // and its standalone arm requires `ctx.standalone` (:4276), so native
+      // strings on gc keeps the overlay's dual emission. `memo` demotes
+      // post-claim under the gc number-boundary policy, which is a function-lane
+      // fact, not a module-init one.
+      label: "native strings",
+      route: "overlay",
+      options: { nativeStrings: true },
+      irCompiledFuncs: ["<module-init>"],
+      legacyBodyEmitted: true,
+      irBodyEmitted: true,
+      postClaimErrorFuncs: ["memo"],
+    },
+    {
+      // Routing owner: #3142 slice 2 (PR #3168) — the IR module-init overlay.
+      // `ctx.fast` is refused outright by the prepared lane (index.ts:4292), so
+      // fast mode can only ever reach `<module-init>` through the overlay.
+      label: "fast",
+      route: "overlay",
+      options: { fast: true },
+      irCompiledFuncs: ["<module-init>"],
+      legacyBodyEmitted: true,
+      irBodyEmitted: true,
+      postClaimErrorFuncs: ["memo"],
+    },
+    {
+      // Routing owner: #3523 "retire standalone lexical module-init bodies"
+      // (PR #4662) — the prepared lane's standalone native-first arm
+      // (index.ts:4275-4280). No legacy body is emitted on this lane.
+      label: "standalone",
+      route: "prepared",
+      options: { target: "standalone" as const },
+      irCompiledFuncs: ["memo", "<module-init>"],
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      postClaimErrorFuncs: [],
+    },
+    {
+      // Routing owner: #3523 gap 3 (PR #5425) — WASI joined the prepared lane
+      // via the invocation-policy-driven `_start` guard (index.ts:4281-4290),
+      // so the prepared route is `legacy 0 · IR 1` here too.
+      label: "WASI",
+      route: "prepared",
+      options: { target: "wasi" as const },
+      irCompiledFuncs: ["memo", "<module-init>"],
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      postClaimErrorFuncs: [],
+    },
+    {
+      // Routing owner: #3142 slice 2 (PR #3168) — the IR module-init overlay.
+      // An EXPLICIT `--no-host-imports` gc build stays refused by the prepared
+      // lane by design (index.ts:4293-4299, #3523 gap 3), so this lane keeps a
+      // legacy body alongside the overlay's IR body.
+      label: "strict no-host",
+      route: "overlay",
+      options: { strictNoHostImports: true },
+      irCompiledFuncs: ["memo", "<module-init>"],
+      legacyBodyEmitted: true,
+      irBodyEmitted: true,
+      postClaimErrorFuncs: [],
+    },
+  ];
+
+  it.each(MODULE_INIT_LANES)("routes the Map module initializer through the $route lane in $label", async (lane) => {
+    const result = await tracked(MAP_SOURCE, { ...lane.options, trackIrOutcomes: true });
     expectSuccess(result);
-    expect(result.irCompiledFuncs ?? []).not.toContain("<module-init>");
-    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? []).toEqual(lane.irCompiledFuncs);
+
+    const moduleInitRows = (result.irOutcomes ?? []).filter((outcome) => outcome.unitKind === "module-init");
+    expect(moduleInitRows).toHaveLength(1);
+    expect({
+      kind: moduleInitRows[0]!.kind,
+      legacyBodyEmitted: moduleInitRows[0]!.legacyBodyEmitted,
+      irBodyEmitted: moduleInitRows[0]!.irBodyEmitted,
+    }).toEqual({
+      kind: "emitted",
+      legacyBodyEmitted: lane.legacyBodyEmitted,
+      irBodyEmitted: lane.irBodyEmitted,
+    });
+
+    expect((result.irPostClaimErrors ?? []).map((error) => error.func)).toEqual(lane.postClaimErrorFuncs);
   });
 
   it("keeps module init legacy-owned in the M0 multi-source overlay", async () => {


### PR DESCRIPTION
Closes [#5259](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5259-issue-3517-map-module-init-test-rot).

`tests/issue-3517-map-module-init.test.ts` was **5/14 red on `main`** (measured on the untouched base `7f998ff873`, all five failing on `:155`):

| # | Test | Message |
| --- | --- | --- |
| 1 | keeps the Map module initializer legacy-owned in **native strings** | `expected [ '<module-init>' ] to not include '<module-init>'` |
| 2 | keeps the Map module initializer legacy-owned in **fast** | `expected [ '<module-init>' ] to not include '<module-init>'` |
| 3 | keeps the Map module initializer legacy-owned in **standalone** | `expected [ 'memo', '<module-init>' ] to not include '<module-init>'` |
| 4 | keeps the Map module initializer legacy-owned in **WASI** | `expected [ 'memo', '<module-init>' ] to not include '<module-init>'` |
| 5 | keeps the Map module initializer legacy-owned in **strict no-host** | `expected [ 'memo', '<module-init>' ] to not include '<module-init>'` |

The pins froze a "these lanes are legacy-owned" assumption the IR module-init work has since retired lane by lane. Their *second* assertion (`irPostClaimErrors` empty) was stale too and never reached: native strings and fast each report one `js.number.unbox` post-claim demotion for `memo`, so rewriting only the `irCompiledFuncs` line would have left those two lanes red.

## The five rewrites

Measured with `trackIrOutcomes: true` (routing identical with and without the flag, so it observes rather than perturbs) and pinned as a `MODULE_INIT_LANES` table asserting `irCompiledFuncs`, the module-init outcome row (`kind` + `legacyBodyEmitted`/`irBodyEmitted`) and each lane's legitimate post-claim demotions:

| Lane | `irCompiledFuncs` | row | legacy · IR | post-claim | routing owner (cited in-file) |
| --- | --- | --- | --- | --- | --- |
| native strings | `["<module-init>"]` | `emitted@patch` | 1 · 1 | `["memo"]` | #3142 slice 2 (PR #3168) overlay; prepared lane's host arm needs `!ctx.nativeStrings` (`index.ts:4270`) |
| fast | `["<module-init>"]` | `emitted@patch` | 1 · 1 | `["memo"]` | #3142 slice 2 (PR #3168) overlay; `ctx.fast` refused outright (`index.ts:4292`) |
| standalone | `["memo","<module-init>"]` | `emitted@patch` | **0 · 1** | `[]` | #3523 `f58fdd279` "retire standalone lexical module-init bodies" (PR #4662), standalone native-first arm (`index.ts:4275-4280`) |
| WASI | `["memo","<module-init>"]` | `emitted@patch` | **0 · 1** | `[]` | #3523 gap 3 (PR #5425), invocation-policy-driven `_start` guard (`index.ts:4281-4290`) — the prepared route that slice's probe P4 recorded |
| strict no-host | `["memo","<module-init>"]` | `emitted@patch` | 1 · 1 | `[]` | #3142 slice 2 (PR #3168) overlay; an explicit `--no-host-imports` gc build stays refused by design (`index.ts:4293-4299`) |

No lane is legacy-*owned* any more — every one IR-compiles `<module-init>`. What still differs is which route claims the body, so the three overlay lanes keep a **positive** legacy assertion (`legacyBodyEmitted: true`), not a vacuous one. Nothing was deleted; the file's other 9 tests are byte-identical.

Now **14/14 green**.

## CI evidence (acceptance criterion 4)

`issue-tests`' `continue-on-error` did **not** swallow these failures — the file was never selected at all. Run <https://github.com/loopdive/js2/actions/runs/33580595431/job/100094026969> (`issue-tests`, conclusion `success`): the fatal step ran the one-file pinned list (`tests/issue-3529-selector-preclaim.test.ts`) and the advisory step logged `select-changed-issue-tests: base=3ba791164e changed=1 running=1` → `tests/issue-3523-module-init-single-pass.test.ts`. Neither list contains this file, which has a single commit in its whole history (`16beee807`). So the load-bearing pair is the non-required job plus the one-file pinned list; `continue-on-error` is a real but *latent* hole for this file — it first applies on this PR, where the advisory step now runs the file green. Gate redesign stays out of scope and no separate CI-policy issue was filed.

## Validation

`node scripts/check-loc-budget.mjs`, `check-func-budget.mjs`, `check-coercion-sites.mjs`, `check:oracle-ratchet`, `check:dead-exports`, `check:test-vacuity-shapes`, `pnpm run typecheck`, `pnpm run lint`, `npx prettier --check` — all green (budget gates also re-run with `LOC_GATE_BASE=origin/main`). Only `tests/issue-3517-map-module-init.test.ts` and the issue file change; no `src/**`, no baseline JSON, no other test file.

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aFp8EAQaf21QYQU3yEFw1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LETvqD72EMVCpKh9dN4wRT)_