### PR TITLE
test(#5274): rewrite the 17 standing-red pins across five string/#3529 suites to current truthful behaviour

### DIFF
--- a/plan/issues/5274-standing-red-tests-string-and-3529-suites.md
+++ b/plan/issues/5274-standing-red-tests-string-and-3529-suites.md
@@ -1,10 +1,11 @@
 ---
 id: 5274
 title: "17 tests across 5 string/#3529 suites are red on main and invisible to CI"
-status: ready
+status: done
 sprint: current
 created: 2026-09-02
 updated: 2026-09-02
+completed: 2026-09-02
 priority: high
 horizon: s
 complexity: S
@@ -72,3 +73,165 @@ non-vacuity counts honest.
 - Together with #5259 this is the second standing red found in one session by
   lanes that measure base before editing; a required, changed-files-driven
   issue-tests gate would make both classes impossible to accumulate.
+
+## 2026-09-02 checkpoint note — Opus lane
+
+Branch `claude/issue-5274-string-test-rot`, base `origin/main` `7f998ff873`.
+
+### Measured before-state (untouched base, `npx vitest run <file>` per file)
+
+`7f998ff873`, one file per invocation. **17 failures, matching the issue exactly** —
+1 + 4 + 8 + 2 + 2:
+
+| file | result | failing test → message |
+| --- | --- | --- |
+| `tests/issue-320.test.ts` | 1 failed / 7 passed (8) | "handles programs with no dead imports (no-op)" → `expected '(module\n  (import "string_constants"…' not to contain '(import'` |
+| `tests/imported-string-constants.test.ts` | 4 failed / 17 passed (21) | "multiple distinct string literals produce multiple global imports" → `expected 5 to be 3`; "no string_constants section when source has no string literals" → `expected 2 to be +0`; "string array literal access works" → `LinkError: Import #5 module="env" function="__get_undefined": function import requires a callable`; "module with no strings needs no string_constants import" → `TypeError: Import #0 module="string_constants": module is not an object or function` |
+| `tests/issue-3529-equivalence-error-imports.test.ts` | 8 failed / 1 passed (9) | all eight `provides the production <E> constructor for manual instantiation` rows (Error, TypeError, RangeError, SyntaxError, URIError, EvalError, ReferenceError, AggregateError) → `expected [ { module: 'env', …(4) } ] to deep equally contain { module: 'env', …(3) }` at `:47` |
+| `tests/issue-3529-dataflow-outcomes.test.ts` | 2 failed / 21 passed (23) | "records unary ! coercion as unsupported" → got `{kind:"emitted", stage:"patch", irBodyEmitted:true, legacyBodyEmitted:false}`; "keeps unary ! with a checker-boolean carrier contradiction invariant" → `expected undefined to be an instance of Error` |
+| `tests/issue-3529-ir-producer-parity.test.ts` | 2 failed / 1 passed (3) | "preserves inferred boolean identity across an externref console boundary" → got `{kind:"unsupported", irBodyEmitted:false}`; "types array-literal widening as an unsupported representation" → extra `<module-init>` `non-executable` row |
+
+**After:** all five files green — `Test Files 5 passed (5)`, `Tests 64 passed (64)`.
+
+### The 17 rewrites and their citations
+
+Every citation was found by `git log -S` / `git bisect` on the **unshallowed**
+clone (the session's clone was shallow to 2026-08-26, which hides every one of
+these commits — worth knowing for the next lane that tries this).
+
+1–3. **`.name` metadata now interns string constants** — `8d17e2d8e0`
+   *feat: add function/class .name property infrastructure (#731)*, 2026-03-25.
+   `collectFunctionClassNames` (`src/codegen/declarations/import-collector.ts:1455-1495`)
+   pre-registers every function/class name, and `finalizeUnifiedCollector:1647`
+   adds the implicit `""` once the pool is non-empty. Confirmed by stack-trace
+   probe: `export function add(a,b){…}` yields pool `["add",""]` and two
+   `string_constants` global imports.
+   - `issue-320` "handles programs with no dead imports (no-op)": the #320 intent
+     is *dead-import elimination*, so it now pins that directly — no
+     `wasm:js-string` import, no `env` import, and the surviving import list is
+     exactly the two `.name` globals.
+   - `imported-string-constants` "multiple distinct string literals…": keeps the
+     three `toContain` literal checks and pins the exact sorted pool
+     `["", "bar", "baz", "foo", "test"]` instead of `length === 3`.
+   - `imported-string-constants` "no string_constants section…": pins the pool to
+     exactly `["", "add"]` — i.e. **no user literal is interned**, the claim that
+     was actually worth keeping — plus the `.name` import that now exists.
+
+4. **`imported-string-constants` "module with no strings needs no
+   string_constants import"** — same #731 fact from the instantiation side. Now
+   asserts `result.imports` is empty (no `env` import needed) and supplies only
+   `string_constants` built from the pool.
+
+5. **`imported-string-constants` "string array literal access works"** —
+   `56d1211acc` *fix(#2773): S7 — externref plain-array OOB reads undefined;
+   length-bounded vec reads; grow-write gap-fill*, 2026-07-09. Verified clean at
+   its parent (`RESULT NONE`) and dirty at it (`RESULT HAS`): `days[1]` now pulls
+   `env.__get_undefined` plus `__box_number`/`__unbox_number`, none of which the
+   file's hand-rolled `env` stub supplied. The `run()` helper now routes through
+   `instantiateWithRuntime` (the production runtime import builder) so it tracks
+   the current host surface instead of re-pinning a 2026-03 snapshot.
+
+6–13. **The eight Error-family rows** — `a41115bc78` *perf(#4150): kill
+   per-crossing arg-array allocation in host imports*, 2026-08-04, added
+   `paramCount` to every `ImportDescriptor`, so the exact-shape `toContainEqual`
+   at `:47` stopped matching. Rewritten to pin the arity too (`1`, and `3` for
+   `AggregateError`) rather than relaxing to a partial match — #4150 made the ABI
+   width load-bearing, so it belongs in the assertion.
+
+14–15. **The two unary-`!` dataflow pins** — `c171454d11` *feat(#4512): ref-typed
+   ToBoolean in condition/ternary/! position*.
+   - "records unary ! coercion as unsupported": the `!` row is split out of the
+     `+`/`-` table (which still demotes correctly) into its own test asserting the
+     measured `{kind:"emitted", stage:"patch", legacyBodyEmitted:false,
+     irBodyEmitted:true}` plus both policy verdicts — a silent fall back to the
+     legacy body would still fail it.
+   - "keeps unary ! … contradiction invariant": ToBoolean now *converts* a
+     mismatched carrier instead of throwing, so the `!`/boolean/F64 row is split
+     out and asserts lowering succeeds. The `+`/`-` rows keep asserting
+     `invariant`. A `lowerWithCallees` helper was factored out for this.
+
+16. **producer-parity "preserves inferred boolean identity…"** — `100543f4e7`
+    *refactor(#4514): directional reverse-callers edge restores compile-once for
+    ABI-certified callees*, 2026-08-16 (git-bisected over 10,052 commits;
+    parent good, commit bad). The untyped `isEven`/`isOdd` pair now demotes at IR
+    **selection** with `operand-coercion-unsupported`, cascading
+    `call-graph-closure` onto `<module-init>`. See the criterion-3 note below.
+
+17. **producer-parity "types array-literal widening…"** — `22a72e500a`
+    *feat(3523): record a truthful non-executable module-init outcome row*,
+    2026-08-31 (R4 gap 4). A source with an empty module-init population is no
+    longer silent, so the ledger carries a second row. The exhaustive `toEqual`
+    is **kept** (the point of the pin is that `test` is the only unit that
+    demotes) and the new row added, rather than relaxing to containment.
+
+### Criterion 3 — intent check against #320 and #3529
+
+Every rewrite was checked against the originating issue's intent; **none was
+weakened to a superset**, and no assertion was deleted.
+
+- **#320 (dead-import elimination):** strictly *stronger*. The old
+  `not.toContain("(import")` was a blunt any-import check; the rewrite pins the
+  exact surviving import list, so a regressed `wasm:js-string` or `env` import —
+  the actual #320 failure mode — still fails, and now so does an unexpected
+  *extra* string-constant global.
+- **String-pool intent:** the two `length`-based pins became exact sorted-pool
+  equalities. A literal that stops being interned, or one that starts being
+  interned spuriously, still fails. `toBe(3)` would not have caught the latter.
+- **#3529 P5 (Error-family import surface):** unchanged in kind and now pins
+  arity as well. The e2e half of each row (constructor identity, `errors`/`cause`
+  ABI, instantiation, `test()` returning 1) was never red and is untouched.
+- **#3529 P2 (dataflow outcomes):** splitting the `!` case is what *preserves*
+  the intent — the surviving `+`/`-` rows still pin the demote and the invariant
+  respectively, and `!` gains a positive pin on its new lowering. Collapsing the
+  tables to something both cases satisfy is what would have lost the gate.
+- **#3529 producer parity, item 16 — the one place worth flagging.** The claim
+  this test is named for, boolean identity across the externref boundary, is
+  **still true and still asserted**: `expect(result.wat).toContain("__box_boolean")`
+  passes unchanged. What moved is the *routing*, so the outcome pin is now the
+  truthful demote, with `legacyBodyEmitted: true` retained (nothing emitted at all
+  still fails) and the two callee rows added so the cascade is pinned at its
+  source rather than only at `<module-init>`. **This is an IR-coverage narrowing,
+  not a semantic regression** — the program compiles and boxes correctly via the
+  legacy body. It is nonetheless a real capability loss for the untyped
+  mutual-recursion shape under #4514 and deserves its own issue against the
+  ir-full-coverage goal; it is out of scope here, where the mandate is pins, not
+  compiler behaviour. Recorded rather than papered over.
+
+### Criterion 4 — would `issue-tests` have surfaced any of the 17?
+
+**No — zero of the 17, and four of the five files are structurally unreachable.**
+
+Evidence: run <https://github.com/loopdive/js2/actions/runs/33580595431>, job
+`issue-tests` <https://github.com/loopdive/js2/actions/runs/33580595431/job/100094026969>
+(PR head `cecb06f989`, `perf(codegen): skip module-init pass 2 …` (#3523 gap-1b),
+2026-09-02T01:46Z, conclusion **success**). The job ran exactly two files:
+
+- *pinned (fatal)* — `tests/issue-3529-selector-preclaim.test.ts`, the sole entry
+  of `PINNED` in `scripts/select-changed-issue-tests.mjs:39-45`;
+- *changed (advisory)* — `tests/issue-3523-module-init-single-pass.test.ts`
+  (log: `select-changed-issue-tests: base=3ba791164e changed=1 running=1`).
+
+Neither is one of the five. Three structural reasons, all still true:
+
+1. `imported-string-constants.test.ts` can **never** be selected — the selector's
+   `ISSUE_TEST` regex is `^tests/issue-[^/]*\.test\.ts$` and the filename does not
+   match, so no change to any file could make this job run it.
+2. The other four match the regex but are not pinned, so they run **only** when the
+   PR itself touches them — which is exactly the case that cannot exist for a
+   standing red nobody is editing.
+3. The changed-files step is `continue-on-error: true` (`ci.yml:741-745`), and
+   `issue-tests` is not a required check, so even a hit would not have blocked.
+
+Per the issue, gate redesign is out of scope; this row feeds the decision #5259
+already asks for.
+
+### Deviations
+
+- The clone was **shallow** to `362b8297` (2026-08-26); `git fetch --unshallow`
+  was required before any citation could be found. Not a scope change, but it is
+  the reason this took a full-history fetch.
+- Two throwaway worktrees under `.claude/worktrees/` were used for the bisects and
+  removed afterwards (`git worktree list` clean).
+- Nothing under `src/**`, `scripts/*-baseline.json`, or any test file outside the
+  five was modified. `tests/equivalence/helpers.ts` is *imported* by the rewritten
+  `run()` helper, not edited.

--- a/tests/imported-string-constants.test.ts
+++ b/tests/imported-string-constants.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
 import { buildStringConstants } from "../src/runtime.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
 
 /**
  * Helper: compile TS source and instantiate with string_constants + polyfill.
@@ -14,26 +15,14 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
     );
   }
 
-  const env: Record<string, Function> = {
-    console_log_number: () => {},
-    console_log_bool: () => {},
-    console_log_string: () => {},
-    number_toString: (v: number) => String(v),
-  };
-
-  const jsStringPolyfill = {
-    concat: (a: string, b: string) => a + b,
-    length: (s: string) => s.length,
-    equals: (a: string, b: string) => (a === b ? 1 : 0),
-    substring: (s: string, start: number, end: number) => s.substring(start, end),
-    charCodeAt: (s: string, i: number) => s.charCodeAt(i),
-  };
-
-  const { instance } = await WebAssembly.instantiate(result.binary, {
-    env,
-    "wasm:js-string": jsStringPolyfill,
-    string_constants: buildStringConstants(result.stringPool),
-  } as WebAssembly.Imports);
+  // The hand-rolled `env` stub this helper used to carry froze the host-import
+  // surface of 2026-03. `56d1211acc` (#2773 S7, 2026-07-09, "externref
+  // plain-array OOB reads undefined") made `days[1]` pull in
+  // `env.__get_undefined` plus the boxing pair, which the stub could not supply
+  // — the e2e cases below died on LinkError, not on anything about string
+  // constants. Route through the production runtime's import builder so this
+  // file tracks the current surface instead of re-pinning a snapshot of it.
+  const instance = await instantiateWithRuntime(result);
   return (instance.exports as any)[fn](...args);
 }
 
@@ -69,7 +58,10 @@ describe("importedStringConstants", () => {
       expect(result.stringPool).toContain("foo");
       expect(result.stringPool).toContain("bar");
       expect(result.stringPool).toContain("baz");
-      expect(result.stringPool.length).toBe(3);
+      // (#731, 8d17e2d8e0) also pre-registers the enclosing function's `.name`
+      // and the implicit "" alongside the user literals. Pin the exact pool so
+      // a literal that stops being interned is still caught.
+      expect([...result.stringPool].sort()).toEqual(["", "bar", "baz", "foo", "test"]);
     });
 
     it("duplicate string literals share the same global import", async () => {
@@ -92,9 +84,12 @@ describe("importedStringConstants", () => {
         }
       `);
       expect(result.success).toBe(true);
-      expect(result.stringPool.length).toBe(0);
-      // WAT should not mention string_constants
-      expect(result.wat).not.toContain("string_constants");
+      // (#731, 8d17e2d8e0) makes the pool non-empty for any named declaration:
+      // the `.name` metadata for `add`, plus the implicit "". The claim worth
+      // keeping is that no *user* string literal is interned, so pin the pool to
+      // exactly that metadata — a stray literal import would still fail here.
+      expect([...result.stringPool].sort()).toEqual(["", "add"]);
+      expect(result.wat).toContain('(import "string_constants" "add"');
     });
   });
 
@@ -261,10 +256,16 @@ describe("importedStringConstants", () => {
         }
       `);
       expect(result.success).toBe(true);
-      // Should instantiate fine without string_constants
+      // Same (#731, 8d17e2d8e0) fact from the instantiation side: the module now
+      // imports `string_constants` for its `.name` metadata, so a bare `env: {}`
+      // no longer links. The intent — a string-free module runs correctly — is
+      // kept by supplying only what the pool actually asks for and still
+      // asserting no `env` import is required.
+      expect(result.imports).toEqual([]);
       const { instance } = await WebAssembly.instantiate(result.binary, {
         env: {},
-      });
+        string_constants: buildStringConstants(result.stringPool),
+      } as WebAssembly.Imports);
       expect((instance.exports as any).add(2, 3)).toBe(5);
     });
 

--- a/tests/issue-320.test.ts
+++ b/tests/issue-320.test.ts
@@ -79,8 +79,22 @@ describe("Dead import and type elimination (#320)", () => {
     `);
     expect(result.success).toBe(true);
 
-    // Pure arithmetic - no imports at all
-    expect(result.wat).not.toContain("(import");
+    // (#731, 8d17e2d8e0 "add function/class .name property infrastructure")
+    // pre-registers every function/class name — and, once the pool is non-empty,
+    // the implicit "" — as a `string_constants` global, so even pure arithmetic
+    // now carries imports. The #320 intent is *dead-import elimination*, so pin
+    // that instead: no `wasm:js-string` and no `env` import survive, and the only
+    // imports left are exactly the two `.name` metadata globals.
+    expect(result.wat).not.toContain('(import "wasm:js-string"');
+    expect(result.wat).not.toContain('(import "env"');
+    const importLines = result.wat
+      .split("\n")
+      .map((l: string) => l.trim())
+      .filter((l: string) => l.startsWith("(import"));
+    expect(importLines).toEqual([
+      '(import "string_constants" "add" (global $add externref))',
+      '(import "string_constants" "" (global $ externref))',
+    ]);
 
     const mod = new WebAssembly.Module(result.binary);
     expect(mod).toBeDefined();

--- a/tests/issue-3529-dataflow-outcomes.test.ts
+++ b/tests/issue-3529-dataflow-outcomes.test.ts
@@ -55,6 +55,42 @@ function lowerDirect(source: string): void {
   });
 }
 
+/**
+ * Lower `test` with typed direct-call plans for its callees, returning nothing
+ * and letting any producer throw escape. Shared setup for the invariant and
+ * demote expectations below, and for the #4512 case where lowering now succeeds.
+ */
+function lowerWithCallees(
+  source: string,
+  calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>,
+  resolver?: IrFromAstResolver,
+): void {
+  const ast = analyzeSource(source, "producer-seam-invariant.ts");
+  const declaration = ast.sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === "test",
+  );
+  expect(declaration).toBeDefined();
+  const ownerIdentity = irIdentities.next("test");
+  const directCalls = collectIrDirectCallLoweringPlans(
+    declaration!,
+    ownerIdentity.unitId,
+    new Map(
+      [...calleeTypes].map(([calleeName, signature]) => [
+        calleeName,
+        { target: irUnitFuncRef(irIdentities.next(`callee:${calleeName}`)), signature },
+      ]),
+    ),
+  );
+  lowerFunctionAstToIr(declaration!, {
+    ownerUnitId: ownerIdentity.unitId,
+    exported: true,
+    checker: ast.checker,
+    directCalls,
+    resolver,
+  });
+}
+
 function expectLowerInvariant(
   source: string,
   calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>,
@@ -231,7 +267,6 @@ describe("#3529 P2 — typed dataflow outcomes", () => {
   it.each([
     ["+", `return +new Box();`],
     ["-", `return -new Box();`],
-    ["!", `return !new Box() ? 1 : 0;`],
   ])("records unary %s coercion as unsupported", async (_operator, body) => {
     await expectBuildUnsupported(
       `
@@ -240,6 +275,31 @@ describe("#3529 P2 — typed dataflow outcomes", () => {
       `,
       "operand-coercion-unsupported",
     );
+  });
+
+  // `c171454d11` (feat(#4512), "ref-typed ToBoolean in condition/ternary/!
+  // position") gave `!` a real lowering for a ref operand, so it no longer
+  // demotes with the arithmetic `+`/`-` siblings above — it is emitted, and at
+  // stage `patch` rather than `build`. Asserting the emitted shape (not just
+  // "not unsupported") keeps the gate: if `!` ever silently falls back to the
+  // legacy body again, `irBodyEmitted`/`legacyBodyEmitted` flip and this fails.
+  it("emits unary ! on a ref operand via the #4512 ToBoolean patch", async () => {
+    const result = await compile(
+      `
+        class Box { valueOf(): number { return 1; } }
+        export function test(): number { return !new Box() ? 1 : 0; }
+      `,
+      { fileName: "unary-not-toboolean.ts", trackIrOutcomes: true },
+    );
+    const outcome = terminalFor(result);
+    expect(outcome).toMatchObject({
+      kind: "emitted",
+      stage: "patch",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(evaluateIrOutcomePolicy([outcome], "hybrid").ready).toBe(true);
+    expect(evaluateIrOutcomePolicy([outcome], "ir-only").ready).toBe(true);
   });
 
   it.each([
@@ -310,7 +370,6 @@ describe("#3529 P2 — typed dataflow outcomes", () => {
   it.each([
     ["-", "number", EXTERNREF],
     ["+", "number", EXTERNREF],
-    ["!", "boolean", F64],
   ] as const)("keeps unary %s with a checker-%s carrier contradiction invariant", (operator, sourceType, carrier) => {
     expectLowerInvariant(
       `
@@ -319,6 +378,23 @@ describe("#3529 P2 — typed dataflow outcomes", () => {
       `,
       new Map([["value", { params: [], returnType: carrier }]]),
     );
+  });
+
+  // The `!` row of the table above asserted the same invariant backstop until
+  // `c171454d11` (feat(#4512)) made ToBoolean *convert* a mismatched carrier
+  // instead of throwing: a checker-`boolean` source over an `f64` carrier is now
+  // a lowerable contradiction, not an internal-throw one. The `+`/`-` rows are
+  // still genuine producer-contract cases and keep asserting `invariant`.
+  it("resolves a checker-boolean carrier contradiction under unary ! instead of throwing", () => {
+    expect(() =>
+      lowerWithCallees(
+        `
+        function value(): boolean { return true; }
+        export function test(): number { return !value() ? 1 : 0; }
+      `,
+        new Map([["value", { params: [], returnType: F64 }]]),
+      ),
+    ).not.toThrow();
   });
 
   it("keeps a checker-string RHS carrier contradiction invariant at string +=", () => {

--- a/tests/issue-3529-equivalence-error-imports.test.ts
+++ b/tests/issue-3529-equivalence-error-imports.test.ts
@@ -44,7 +44,18 @@ describe("#3529 P5 — equivalence Error-family imports", () => {
       name === "AggregateError"
         ? { type: "builtin" as const, name: importName }
         : { type: "extern_class" as const, className: name, action: "new" as const };
-    expect(result.imports).toContainEqual({ module: "env", name: importName, kind: "func", intent: expectedIntent });
+    // `a41115bc78` (perf(#4150), 2026-08-04, "kill per-crossing arg-array
+    // allocation in host imports") added `paramCount` to every ImportDescriptor,
+    // so this exact-shape `toContainEqual` stopped matching for all eight cases.
+    // Pin the arity too rather than loosening to a partial match — the ABI width
+    // is exactly what #4150 made load-bearing.
+    expect(result.imports).toContainEqual({
+      module: "env",
+      name: importName,
+      kind: "func",
+      intent: expectedIntent,
+      paramCount: name === "AggregateError" ? 3 : 1,
+    });
 
     const imports = buildImports(result);
     const constructorImport = (imports.env as Record<string, Function>)[importName];

--- a/tests/issue-3529-ir-producer-parity.test.ts
+++ b/tests/issue-3529-ir-producer-parity.test.ts
@@ -29,11 +29,32 @@ describe("#3529 — typed AST-to-IR producer capability gaps", () => {
     );
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    // The *identity* claim this test exists for is unchanged and still asserted
+    // below: the inferred boolean survives the externref console boundary as a
+    // boxed boolean, not a number. What rotted is the routing pin. Since
+    // `100543f4e7` (refactor(#4514), 2026-08-16, "directional reverse-callers
+    // edge restores compile-once for ABI-certified callees") the untyped
+    // `isEven`/`isOdd` pair demotes at IR *selection* with
+    // `operand-coercion-unsupported`, which cascades `call-graph-closure` onto
+    // `<module-init>`; the legacy body carries the program instead. Pin that
+    // truthfully — `legacyBodyEmitted: true` still fails if nothing is emitted
+    // at all, and a return to IR emission will fail here and be re-examined.
     expect(terminal(result).find((outcome) => outcome.displayName === "<module-init>")).toMatchObject({
-      kind: "emitted",
+      kind: "unsupported",
+      code: "call-graph-closure",
+      stage: "select",
       legacyBodyEmitted: true,
-      irBodyEmitted: true,
+      irBodyEmitted: false,
     });
+    for (const name of ["isEven", "isOdd"]) {
+      expect(terminal(result).find((outcome) => outcome.displayName === name)).toMatchObject({
+        kind: "unsupported",
+        code: "operand-coercion-unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+    }
     expect(result.wat).toContain("__box_boolean");
   });
 
@@ -47,6 +68,12 @@ describe("#3529 — typed AST-to-IR producer capability gaps", () => {
     );
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    // `22a72e500a` (feat(3523) R4 gap 4, 2026-08-31, "record a truthful
+    // non-executable module-init outcome row") stopped leaving a source with an
+    // empty module-init population silent, so the ledger now carries a second
+    // row. Keep the exhaustive `toEqual` — the point of this pin is that `test`
+    // is the *only* unit that demotes — and add the new row rather than relaxing
+    // to a containment check that would hide an unexpected third outcome.
     expect(terminal(result)).toEqual([
       expect.objectContaining({
         displayName: "test",
@@ -54,6 +81,14 @@ describe("#3529 — typed AST-to-IR producer capability gaps", () => {
         code: "array-representation-unsupported",
         stage: "build",
         legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      }),
+      expect.objectContaining({
+        displayName: "<module-init>",
+        unitKind: "module-init",
+        kind: "non-executable",
+        stage: "select",
+        legacyBodyEmitted: false,
         irBodyEmitted: false,
       }),
     ]);


### PR DESCRIPTION
Closes [#5274](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5274-standing-red-tests-string-and-3529-suites).

## Before-state (measured on the untouched base)

`origin/main` `7f998ff873`, `npx vitest run <file>` once per file. **17 failures across five files** — 1 + 4 + 8 + 2 + 2, matching the issue exactly:

| file | before | after |
| --- | --- | --- |
| `tests/issue-320.test.ts` | 1 failed / 7 passed | 8 passed |
| `tests/imported-string-constants.test.ts` | 4 failed / 17 passed | 21 passed |
| `tests/issue-3529-equivalence-error-imports.test.ts` | 8 failed / 1 passed | 9 passed |
| `tests/issue-3529-dataflow-outcomes.test.ts` | 2 failed / 21 passed | 23 passed |
| `tests/issue-3529-ir-producer-parity.test.ts` | 2 failed / 1 passed | 3 passed |

All five together: `Test Files 5 passed (5)`, `Tests 64 passed (64)`.

## The 17 rewrites

Each pin is rewritten to the current truthful behaviour with a one-line comment citing the slice that moved the fact. **Nothing deleted, nothing loosened to a superset.** Citations came from `git log -S` / `git bisect` on the *unshallowed* clone — the session clone was shallow to 2026-08-26, which hides every one of these commits.

1–3. **`.name` metadata now interns string constants** — `8d17e2d8e0` *feat: add function/class .name property infrastructure (#731)*, 2026-03-25. `collectFunctionClassNames` pre-registers every function/class name, and `finalizeUnifiedCollector` adds the implicit `""` once the pool is non-empty; `export function add(a,b){…}` yields pool `["add",""]` and two `string_constants` globals.
   - `issue-320` "handles programs with no dead imports (no-op)" — the #320 intent is *dead-import elimination*, so it now pins that directly: no `wasm:js-string` import, no `env` import, exact surviving import list.
   - `imported-string-constants` "multiple distinct string literals…" — keeps the three literal `toContain` checks, pins the exact sorted pool instead of `length === 3`.
   - `imported-string-constants` "no string_constants section…" — pins the pool to exactly `["", "add"]`, i.e. no *user* literal is interned.

4. **"module with no strings needs no string_constants import"** — same #731 fact from the instantiation side; now asserts `result.imports` is empty and supplies only `string_constants` from the pool.

5. **"string array literal access works"** — `56d1211acc` *fix(#2773): S7 — externref plain-array OOB reads undefined*, 2026-07-09 (verified clean at its parent, dirty at it). `days[1]` now pulls `env.__get_undefined` plus the boxing pair, which the file's hand-rolled `env` stub could not supply. `run()` now routes through `instantiateWithRuntime` so it tracks the current host surface instead of a 2026-03 snapshot.

6–13. **The eight Error-family rows** — `a41115bc78` *perf(#4150): kill per-crossing arg-array allocation in host imports*, 2026-08-04, added `paramCount` to every `ImportDescriptor`. Pinned the arity too (`1`, `3` for `AggregateError`) rather than relaxing to a partial match — #4150 is what made the ABI width load-bearing.

14–15. **The two unary-`!` dataflow pins** — `c171454d11` *feat(#4512): ref-typed ToBoolean in condition/ternary/! position*. `!` is now emitted at stage `patch`, and ToBoolean *converts* a mismatched carrier instead of throwing. Both `!` cases are split out of their tables; the `+`/`-` rows keep asserting demote and invariant respectively.

16. **producer-parity "preserves inferred boolean identity…"** — `100543f4e7` *refactor(#4514): directional reverse-callers edge…*, 2026-08-16, git-bisected over 10,052 commits (parent good, commit bad). The untyped `isEven`/`isOdd` pair demotes at IR **selection** with `operand-coercion-unsupported`, cascading `call-graph-closure` onto `<module-init>`.

17. **producer-parity "types array-literal widening…"** — `22a72e500a` *feat(3523): record a truthful non-executable module-init outcome row*, 2026-08-31 (R4 gap 4). The exhaustive `toEqual` is kept and the new row added, not relaxed to containment.

## Criterion 3 — intent check against #320 and #3529

- **#320** is strictly *stronger*: the old `not.toContain("(import")` was a blunt any-import check; the rewrite pins the exact surviving import list, so a regressed `wasm:js-string`/`env` import still fails and so does an unexpected extra global.
- **String-pool pins** became exact sorted equalities — a literal that stops being interned *or* starts being interned spuriously still fails; `toBe(3)` would not have caught the latter.
- **#3529 P5** is unchanged in kind and now pins arity as well; the e2e half of each row was never red and is untouched.
- **#3529 P2** — splitting the `!` case is what *preserves* the intent: `+`/`-` keep their demote/invariant gates and `!` gains a positive pin on its new lowering. Collapsing the tables to something both satisfy is what would have lost the gate.
- **#3529 producer parity, item 16 — flagged, not papered over.** The claim the test is named for is **still true and still asserted** (`expect(result.wat).toContain("__box_boolean")` passes unchanged); only the *routing* pin moved. `legacyBodyEmitted: true` is retained so "nothing emitted at all" still fails, and the two callee rows are added so the cascade is pinned at its source. This is an **IR-coverage narrowing, not a semantic regression** — the program compiles and boxes correctly via the legacy body — but it is a real capability loss for the untyped mutual-recursion shape under #4514 and deserves its own issue against the ir-full-coverage goal. Out of scope here, where the mandate is pins rather than compiler behaviour.

## Criterion 4 — would `issue-tests` have surfaced any of the 17?

**No — zero of the 17, and four of the five files are structurally unreachable.**

Evidence: run <https://github.com/loopdive/js2/actions/runs/33580595431>, job [`issue-tests`](https://github.com/loopdive/js2/actions/runs/33580595431/job/100094026969) (PR head `cecb06f989`, 2026-09-02T01:46Z, conclusion **success**). It ran exactly two files — the pinned `tests/issue-3529-selector-preclaim.test.ts` and the changed `tests/issue-3523-module-init-single-pass.test.ts`. Neither is one of the five. Three structural reasons:

1. `imported-string-constants.test.ts` can **never** be selected — the selector regex is `^tests/issue-[^/]*\.test\.ts$` and the filename does not match.
2. The other four match but are not pinned, so they run only when the PR itself touches them — exactly the case that cannot exist for a standing red nobody is editing.
3. The changed-files step is `continue-on-error: true` and `issue-tests` is not required, so even a hit would not have blocked.

Gate redesign stays out of scope per the issue; this row feeds the decision #5259 already asks for.

## Validation

Ratchet chain run bare (no pipes), all exit 0: `check-loc-budget`, `check-func-budget`, `check-coercion-sites`, `check:oracle-ratchet`, `check:dead-exports`. Plus `pnpm run typecheck` (0), `pnpm run lint` (0), `npx prettier --check` on all six changed files (clean), and the five suites green.

Scope: no `src/**`, no `scripts/*-baseline.json`, no test file outside the five. `tests/equivalence/helpers.ts` is *imported* by the rewritten `run()` helper, not edited.

Note: `npx prettier --check tests plan` also reports 8 pre-existing warnings under `plan/probes/` (`3603/*`, `3976/synt2.mts`) that this branch does not touch and did not introduce.

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aFp8EAQaf21QYQU3yEFw1

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyufTZ85uuzkUEciXJaebG)_