### PR TITLE
fix(#3729,#3958): restore acorn (3/3518 → 3518/3518) and React (0/180 → 144/180) npm-compat suites

### DIFF
--- a/plan/issues/3729-acorn-official-test-suite-harness.md
+++ b/plan/issues/3729-acorn-official-test-suite-harness.md
@@ -16,6 +16,12 @@ language_feature: n/a
 goal: core-semantics
 origin: "user asked whether the dogfood harness runs the packages' own bundled unit tests — it didn't (npm tarballs strip test/); this adds the real suite via source acquisition"
 related: [1710, 3717, 3730, 3728]
+# 2026-09-02 regression fix (3/3518 → 3518/3518): `__register_fnctor_instance`
+# must canonicalize a host-mirror constructor value (+1 line in resolveImport).
+loc-budget-allow:
+  - src/runtime.ts
+func-budget-allow:
+  - src/runtime.ts::resolveImport
 ---
 
 # #3729 — acorn official test-suite harness
@@ -109,3 +115,15 @@ here — this issue is the harness):
       existing #2962 mechanism, not a new one.
 - [x] Residual failures triaged into buckets and filed as separate,
       properly scoped issues (#3730, #3728).
+
+## 2026-09-02 regression: 3410 → 3 / 3518 ("curPosition is not a function")
+
+Bisected to 839225bc52 (`fix(codegen): preserve dynamic Proxy and class-expression
+values`, PR #5374): `_maybeWrapCallableUnknownArity` now hands a closure that
+carries user static props (`Parser.parse`, `Parser.extend`) to the host as its
+`_wrapCallableForHost` mirror. `Parser.parse = function (input) { return new
+this(input) }` then reaches `__register_fnctor_instance` with `this` = the
+mirror, whose sidecar has no `prototype`, so every `Parser.prototype.m` method
+was invisible on `new this(...)` instances. Fix: canonicalize the constructor
+via `_unwrapForHost` before linking (src/runtime.ts). Verified locally:
+3518/3518 (100%). Regression test: `tests/npm-compat-acorn-react-regressions.test.ts`.

--- a/plan/issues/3958-react-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3958-react-own-unit-tests-against-compiled-wasm.md
@@ -14,6 +14,13 @@ task_type: test
 area: dogfood
 language_feature: compiler-internals
 goal: dogfood
+# 2026-09-02 regression fix (0/180 → 144/180): a re-lifted sibling keeps its
+# phase-0 capture ABI across an intermediate transitive promotion (two helpers
+# + their doc comment; the lift function itself grows by the two call sites).
+loc-budget-allow:
+  - src/codegen/statements/nested-declarations.ts
+func-budget-allow:
+  - src/codegen/statements/nested-declarations.ts::compileNestedFunctionDeclarationInScope
 ---
 
 # Run React's own unit tests against compiled React
@@ -168,3 +175,17 @@ compile-quarantined. Two generic fixes account for the move:
 The other 200 admitted tests remain `harness-incompatible` because the native
 oracle also lacks their Jest/renderer infrastructure. They are still executed
 and counted, not filtered from the corpus.
+
+## 2026-09-02 regression: 144/180 → 0/180 (every batch INVALID)
+
+Bisected to 302443772e (`fix(standalone): deno-core bootstrap local-index
+remapping`, #4376, PR #5202): the lift-time transitive-capture promotion it
+added runs while an EARLIER sibling is lifted (`itRenders`) and moves
+`initModules` to a module global. The later real lift of `testMarkupMatch`
+then recomputed 4 captures, while `expectMarkupMatch` — compiled in between —
+still prepended the 5 pre-registered ones ("type error in fallthru[0]"). Fix: a
+re-lift honours the phase-0 pre-registered ABI (slot + order) for bindings
+promoted in the meantime (`collectPromotedPreRegisteredSlots` /
+`reorderToPreRegisteredAbi` in src/codegen/statements/nested-declarations.ts).
+Verified locally: 144/180 scored (80%), 0 invalid batches. Regression test:
+`tests/npm-compat-acorn-react-regressions.test.ts`.

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -1333,6 +1333,16 @@ function compileNestedFunctionDeclarationInScope(
      * lifted body's struct.get/set should produce/consume. */
     boxedValType?: ValType;
   }[] = [];
+  // A phase-0 pre-registration is the ABI earlier call sites already emit;
+  // keep it across an intermediate promotion (see collectPromotedPreRegisteredSlots).
+  const preRegisteredCaptures = opts.reuseReservedEntry ? ctx.nestedFuncCaptures.get(funcName) : undefined;
+  const promotedPreRegisteredSlots = collectPromotedPreRegisteredSlots(
+    ctx,
+    fctx,
+    preRegisteredCaptures,
+    referencedNames,
+    transitivelyRequiredNames,
+  );
   for (const name of referencedNames) {
     if (ownLocals.has(name) && !transitivelyRequiredNames.has(name)) continue;
     if (skipUnobservedHoistedCapture(fctx, stmt, name, directlyReferencedNames, transitivelyRequiredNames)) continue;
@@ -1359,7 +1369,7 @@ function compileNestedFunctionDeclarationInScope(
     // singleton — so `new Child()` inside the nested fn constructed from
     // null (react's ChildComponent family). Skip the value capture.
     if (ctx.classSet.has(name) && isSiblingClassDeclarationName(stmt, name)) continue;
-    const localIdx = fctx.localMap.get(name);
+    const localIdx = fctx.localMap.get(name) ?? promotedPreRegisteredSlots.get(name);
     if (localIdx === undefined) continue;
     // A real declaring-frame local wins over a same-named module funcMap entry.
     let type =
@@ -1454,6 +1464,7 @@ function compileNestedFunctionDeclarationInScope(
       boxedValType: outerBoxedEntry?.valType,
     });
   }
+  reorderToPreRegisteredAbi(captures, preRegisteredCaptures);
   if (shouldCaptureEnclosingDirectEvalState(ctx, fctx, stmt, reachesDirectEval)) {
     // Phase 0 only needs a stable slot/type so its reserved signature matches
     // the real compile. Runtime materialization belongs to the real hoist pass,
@@ -2670,6 +2681,62 @@ function emitEagerNestedCallCaptureBoxes(
 /** Publish a capturing sibling's lifted signature before any sibling body is
  * compiled. Returns true when the declaration must skip the capture-free
  * reservation path (including generators, whose state machine registers it). */
+type PreRegisteredCaptures = NonNullable<ReturnType<CodegenContext["nestedFuncCaptures"]["get"]>>;
+
+/**
+ * A sibling pre-registered in phase 0 (`preRegisterCapturingSibling`) has
+ * already published its capture list as the call-site ABI: every direct call
+ * and closure reification compiled before the real lift prepends EXACTLY that
+ * list. A lift-time transitive promotion run by an EARLIER sibling
+ * (`promoteAccessorCapturesToGlobals` transitive-only mode) can meanwhile move
+ * one of those bindings to a module global — deleting it from `localMap`,
+ * which silently dropped it from the recomputed signature while the earlier
+ * call sites still pushed it (React's ReactDOMServerIntegrationTestUtils shim:
+ * `itRenders` promoted `initModules`; `expectMarkupMatch` then called
+ * `testMarkupMatch` with one capture too many — "type error in fallthru").
+ * Returns the recorded declaring-frame slot of each such binding (promotion
+ * copies the local into the global, it never clears the slot) and re-marks it
+ * as required, so the lifted param list matches what callers already emit.
+ */
+function collectPromotedPreRegisteredSlots(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  preRegistered: PreRegisteredCaptures | undefined,
+  referencedNames: Set<string>,
+  transitivelyRequiredNames: Set<string>,
+): Map<string, number> {
+  const slots = new Map<string, number>();
+  if (!preRegistered) return slots;
+  for (const cap of preRegistered) {
+    if (fctx.localMap.has(cap.name) || !fctx.promotedCaptureNames?.has(cap.name)) continue;
+    if (!ctx.capturedGlobals.has(cap.name)) continue;
+    const slot =
+      cap.outerLocalIdx < fctx.params.length
+        ? fctx.params[cap.outerLocalIdx]
+        : fctx.locals[cap.outerLocalIdx - fctx.params.length];
+    if (slot?.name !== cap.name) continue;
+    slots.set(cap.name, cap.outerLocalIdx);
+    referencedNames.add(cap.name);
+    transitivelyRequiredNames.add(cap.name);
+  }
+  return slots;
+}
+
+/**
+ * Same ABI contract as above: callers prepend the pre-registered captures in
+ * the pre-registered ORDER, so a re-lift publishes that order (names the
+ * pre-registration did not know keep their relative order at the end).
+ */
+function reorderToPreRegisteredAbi(
+  captures: { name: string }[],
+  preRegistered: PreRegisteredCaptures | undefined,
+): void {
+  if (!preRegistered) return;
+  const order = new Map(preRegistered.map((c, i) => [c.name, i] as const));
+  if (!captures.every((c) => order.has(c.name))) return;
+  captures.sort((a, b) => order.get(a.name)! - order.get(b.name)!);
+}
+
 function preRegisterCapturingSibling(
   ctx: CodegenContext,
   fctx: FunctionContext,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -12014,7 +12014,8 @@ assert._isSameValue = isSameValue;
       // through the closure's vivified `.prototype` object.
       if (name === "__register_fnctor_instance")
         return (inst: any, ctor: any) => {
-          if (_canBeWeakKey(inst) && ctor != null) _fnctorInstanceCtor.set(inst, ctor);
+          // `ctor` may be the host-callable mirror of the closure (acorn's `new this(...)` in `Parser.parse`); link the RAW closure, whose sidecar holds `.prototype`.
+          if (_canBeWeakKey(inst) && ctor != null) _fnctorInstanceCtor.set(inst, _unwrapForHost(ctor) ?? ctor);
         };
       // (#2743 a) Mark a compiled `arguments` vec as an ordinary Object so the
       // MOP hooks (`__getPrototypeOf` / `__extern_get` / `__hasOwnProperty`)

--- a/tests/npm-compat-acorn-react-regressions.test.ts
+++ b/tests/npm-compat-acorn-react-regressions.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Two npm-compat regressions caught by the dashboard, not by any unit test:
+//
+// 1. acorn's official suite fell from 3518/3518 to 3/3518 ("curPosition is not
+//    a function"). `Parser.parse = function (input) { return new this(input) }`
+//    is dispatched through the host once `Parser` (a closure with user static
+//    props) crosses the boundary as its callable mirror; `new this(...)` then
+//    registered the MIRROR as the instance's constructor, so the prototype
+//    lookup never found `Parser.prototype.m`.
+//
+// 2. React's upstream shim stopped validating ("type error in fallthru[0]"):
+//    a lift-time transitive-capture promotion run by an earlier sibling moved
+//    `initModules` to a module global, so the later real lift of
+//    `testMarkupMatch` dropped it from its signature while the already-compiled
+//    `expectMarkupMatch` call site still prepended the pre-registered capture.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function compileAndInstantiate(source: string) {
+  const result = await compile(source, { fileName: "m.js", skipSemanticDiagnostics: true });
+  expect(result.success, result.errors?.map((e) => e.message).join("\n")).toBe(true);
+  await WebAssembly.compile(result.binary!);
+  const importObject = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary!, importObject);
+  importObject.__setInstance?.(instance);
+  return wrapExports(instance, { signatures: result.exportSignatures }) as Record<string, (...a: unknown[]) => unknown>;
+}
+
+describe("npm-compat regressions — acorn `new this` prototype link, React lift ABI", () => {
+  it("`new this(...)` in a host-dispatched static keeps `F.prototype` methods (acorn Parser.parse)", async () => {
+    const exp = await compileAndInstantiate(`
+      var Parser = function Parser(input) { this.input = input; this.x = this.curPosition(); };
+      Parser.prototype.curPosition = function () { return 1 };
+      Parser.parse = function parse(input) { return new this(input).x };
+      Parser.check = function check(input) {
+        var p = new this(input);
+        return Object.getPrototypeOf(p) === Parser.prototype && typeof p.curPosition === "function";
+      };
+      export function parse(input) { return Parser.parse(input) }
+      export function check(input) { return Parser.check(input) }
+    `);
+    expect(exp.parse!("abc")).toBe(1);
+    expect(exp.check!("abc")).toBeTruthy();
+  });
+
+  it("a re-lifted sibling keeps its pre-registered capture ABI after a transitive promotion", async () => {
+    // Shape of React's ReactDOMServerIntegrationTestUtils shim: `itRenders`
+    // reifies sibling function VALUES and promotes `initModules`; the later
+    // `expectMarkupMatch` → `testMarkupMatch` call must still type-check.
+    const exp = await compileAndInstantiate(`
+      function makeUtils(initModules) {
+        var A;
+        var B;
+        function resetModules() {
+          var modules = initModules();
+          A = modules.A;
+          B = modules.B;
+        }
+        function renderIntoDom(element, flag) {
+          return A(element) + (flag ? 1 : 0);
+        }
+        async function serverRender(element) {
+          resetModules();
+          return B(element);
+        }
+        async function clientCleanRender(element) {
+          resetModules();
+          return renderIntoDom(element, false);
+        }
+        function itRenders(desc, testFn) {
+          return testFn(serverRender) + testFn(clientCleanRender) + desc.length;
+        }
+        function expectMarkupMatch(serverElement, clientElement) {
+          return testMarkupMatch(serverElement, clientElement, true);
+        }
+        async function testMarkupMatch(serverElement, clientElement, shouldMatch) {
+          var domElement = await serverRender(serverElement);
+          resetModules();
+          return renderIntoDom(clientElement, shouldMatch) + domElement;
+        }
+        return { itRenders: itRenders, expectMarkupMatch: expectMarkupMatch };
+      }
+      export function run() {
+        var utils = makeUtils(function () {
+          return { A: function (x) { return x * 2; }, B: function (x) { return x + 1; } };
+        });
+        return utils.expectMarkupMatch(3, 4);
+      }
+    `);
+    // renderIntoDom(4, true) + await serverRender(3) = (8 + 1) + 4
+    await expect(exp.run!()).resolves.toBe(13);
+  });
+});


### PR DESCRIPTION
## Description

Two independent npm-compat regressions, each bisected to its introducing commit and fixed at the root:

**acorn official suite — 3/3518 on current main (dashboard still shows the stale 96.93%), now 3518/3518 (100%).**
Bisected to 839225bc52 (PR #5374). `_maybeWrapCallableUnknownArity` now hands a closure that carries user static props (`Parser.parse`, `Parser.extend`) to the host as its `_wrapCallableForHost` mirror. `Parser.parse = function (input) { return new this(input) }` then reached `__register_fnctor_instance` with `this` = that mirror, whose sidecar has no `prototype`, so every `Parser.prototype.m` method was invisible on `new this(...)` instances ("curPosition is not a function"). Fix (`src/runtime.ts`): canonicalize the constructor via `_unwrapForHost` before linking the instance.

**React upstream suite — 0/180 (every batch INVALID), now 144/180 (80%).**
Bisected to 302443772e (#4376, PR #5202). The lift-time transitive-capture promotion it added runs while an EARLIER sibling is lifted and moves a binding (`initModules`) to a module global; the later real lift of the pre-registered sibling `testMarkupMatch` then recomputed 4 captures while `expectMarkupMatch`, compiled in between, still prepended the 5 pre-registered ones ("type error in fallthru[0]"). Fix (`src/codegen/statements/nested-declarations.ts`): a re-lift honours the phase-0 pre-registered capture ABI (slot + order) for bindings promoted in the meantime.

Regression tests for both shapes: `tests/npm-compat-acorn-react-regressions.test.ts` (fail on main, pass here). Issue notes and budget grants in [#3729](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3729-acorn-official-test-suite-harness) and [#3958](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3958-react-own-unit-tests-against-compiled-wasm).

Verified locally: `pnpm run dogfood:acorn-official-suite` → 3518/3518; `pnpm run dogfood:react-upstream-suite` → 144/180 scored, 0 invalid batches; typecheck, biome, prettier, LOC/function/coercion/oracle/dead-export gates green (also against the origin/main base). Note: 3 cases in `tests/issue-2608-new-this-fnctor-static.test.ts` fail identically on unmodified main (pre-existing, not touched here).

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECD36tGCqAJofyLerMFaBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECD36tGCqAJofyLerMFaBG)_