### PR TITLE
fix(#3781): give redux a standalone perf lane — no host imports from process.env or an any-receiver method

### DIFF
--- a/plan/issues/3781-npm-perf-standalone-js-host-lanes.md
+++ b/plan/issues/3781-npm-perf-standalone-js-host-lanes.md
@@ -16,6 +16,14 @@ goal: performance
 assignee: "ttraenkler/codex"
 depends_on: [3778, 3779, 3780]
 related: [1710, 3748, 3751, 3782]
+# 2026-09-02: standalone lanes for react/redux were host-import-error
+# (`__get_process_env`, lib.dom `NavigationHistoryEntry_getState` bound to an
+# `any` receiver). Two small host-free arms; growth granted here.
+loc-budget-allow:
+  - src/codegen/property-access-dispatch.ts
+  - src/codegen/expressions/calls-closures.ts
+func-budget-allow:
+  - src/codegen/expressions/calls-closures.ts::tryExternClassMethodOnAny
 files:
   - benchmarks/results/npm-compat-perf.json
   - benchmarks/results/npm-compat.json
@@ -128,3 +136,57 @@ The Acorn JS-host row still performs every parse after compilation and remains
 295.23x slower than Node. Its standalone runtime-dynamic counterpart performs
 the same class of work with no host imports and narrows the gap to 17.25x.
 Neither runtime result is combined with the static residual result.
+
+## 2026-09-02 — why four packages had a JS-host trend line but no standalone one
+
+The landing/dashboard perf-over-time graph plots `npm-compat-history.json`,
+which only records a lane whose `status` is `measured`. `uuid`, `react`,
+`hono` and `redux` were all `measured` on js-host and failed on standalone,
+so their standalone series was empty for their whole history (measured over
+343 recorded runs: acorn/clsx/cookie have both lanes; lit/react/hono/redux/uuid
+have js-host only).
+
+Two of the four causes were compiler defects and are fixed here:
+
+- **`process.env.<x>` kept a `__get_process_env` host import** (react, redux).
+  Standalone has no `process` to read, and the JS-host import itself answers
+  `{}` when none exists — so the host-free lane now materializes that empty
+  object directly (`src/codegen/property-access-dispatch.ts`).
+- **A method call on an `any` receiver bound the first extern class declaring
+  that name** (redux). `store.getState()` first-matched lib.dom's
+  `NavigationHistoryEntry.getState`, emitting an `env` import no standalone
+  instance can satisfy. Under `noJsHost` that whole first-match loop is now
+  skipped, so the call falls through to the native `__extern_method_call`
+  route (`src/codegen/expressions/calls-closures.ts`). Same defect family as
+  the `.join` (#3342) and DisposableStack (#3237) arms already sitting above
+  it, generalized instead of adding a fourth name-specific escape.
+
+Result: **redux now measures on all three lanes** (standalone static,
+standalone dynamic, js-host), so it gains a standalone trend line.
+
+The remaining two are NOT compiler bugs in this area and are deliberately left
+out of this change:
+
+- **hono** — `compile-error`: `String.prototype.replace()` with a RegExp search
+  value is unsupported under `--target standalone` (#1474). A feature gap with
+  its own issue, not a lane defect.
+- **uuid** — `host-import-error`: the binary retains `__crypto_get_random_values`
+  and `__crypto_random_uuid`. Needs a Wasm-native entropy source for standalone
+  (the dual-mode rule in CLAUDE.md), which is its own piece of work.
+- **react** — `host-import-error` is fixed by the `process.env` arm above, but
+  the lane then fails at `__module_init`: react's `index.js` is the classic
+  `if (process.env.NODE_ENV === "production") module.exports = require(
+  "./cjs/react.production.js") else … require("./cjs/react.development.js")`
+  gate. `src/cjs-rewrite.ts` only rewrites `require()` in DECLARATION
+  statements, so a `require` inside module-level control flow survives as a
+  bare call — fine with a JS host, a throw in a host-free module.
+  Hoisting both branches to eager imports was tried and abandoned: it makes the
+  dev AND prod builds share one module graph, and the two builds declare
+  same-named nested functions (`cloneAndReplaceKey`, `mapIntoArray`) which the
+  NAME-KEYED capture registry then mixes across frames —
+  `codegen invariant: 'cloneAndReplaceKey' references out-of-range local(s)
+  154, 198 after local dedup (params=2, locals=9, before=9)`. Each build
+  compiles cleanly on its own; only the two together fail. So react's standalone
+  lane needs either statically folding the NODE_ENV gate (so one branch is
+  dropped) or module-scoping the capture registry — both larger than this
+  change and worth their own issue.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -2584,6 +2584,15 @@ export function tryExternClassMethodOnAny(
     if (nativeJoin !== null) return nativeJoin;
   }
 
+  // Host-free targets: every `${Extern}_${method}` binding below is an `env`
+  // import no standalone/WASI instance can satisfy, so a first-match hit
+  // only turns a working dynamic dispatch into a retained host import
+  // (redux's `store.getState()` on an `any` receiver bound lib.dom's
+  // `NavigationHistoryEntry_getState`; the npm-compat standalone lane then
+  // failed with "retained 2 host import(s)"). Fall through to the native
+  // `__extern_method_call` route instead. JS-host lanes are untouched.
+  if (noJsHost(ctx)) return null;
+
   for (const [key, info] of ctx.externClasses) {
     if (key !== info.className) continue;
     const sig = info.methods.get(methodName);

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -1821,6 +1821,17 @@ export function tryGlobalThisAndProcessRead(
       // the standard EventEmitter surface (`stdout.on`/`removeListener`) too.
       else if (procProp === "stdout") hostImport = "__get_process_stdout";
       else if (procProp === "stderr") hostImport = "__get_process_stderr";
+      // Standalone has no process to read: `process.env` is the host-free
+      // empty object the JS-host import also answers when no `process` exists
+      // (react's / redux's `process.env.NODE_ENV === "production"` gate kept a
+      // `__get_process_env` import and failed the standalone npm-compat lane).
+      if (ctx.standalone && procProp === "env") {
+        const idx = ensureLateImport(ctx, "__new_plain_object", [], [{ kind: "externref" }]);
+        flushLateImportShifts(ctx, fctx);
+        if (idx !== undefined) fctx.body.push({ op: "call", funcIdx: idx });
+        else fctx.body.push({ op: "ref.null.extern" });
+        return { kind: "externref" };
+      }
       if (hostImport !== undefined) {
         const idx = ensureLateImport(ctx, hostImport, [], [{ kind: "externref" }]);
         flushLateImportShifts(ctx, fctx);

--- a/tests/npm-compat-standalone-host-imports.test.ts
+++ b/tests/npm-compat-standalone-host-imports.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#3781) The npm-compat standalone perf lane fails a package outright when its
+// binary retains ANY host import ("standalone binary retained N host import(s)"),
+// which is why react/redux had a JS-host trend line and no standalone one. Two
+// codegen arms leaked such imports from ordinary library code:
+//
+//   * `process.env.<x>` — a Node gate every published CJS bundle carries.
+//   * a method call on an `any` receiver whose name happens to be declared by
+//     some lib.dom interface (redux's `store.getState()` first-matched
+//     `NavigationHistoryEntry.getState`).
+//
+// Both are pinned here by compiling and asking the MODULE what it imports —
+// the same question the perf lane asks — rather than by inspecting codegen.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Every non-`string_constants` import the standalone binary retains. */
+async function standaloneHostImports(source: string): Promise<string[]> {
+  const result = await compile(source, {
+    fileName: "m.js",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+  });
+  expect(result.success, result.errors?.map((e) => e.message).join("\n")).toBe(true);
+  const module = await WebAssembly.compile(result.binary!);
+  return WebAssembly.Module.imports(module)
+    .filter((entry) => entry.module !== "string_constants")
+    .map((entry) => `${entry.module}.${entry.name}`);
+}
+
+describe("#3781 — a standalone binary keeps no host imports for ordinary library code", () => {
+  it("reads `process.env` without the `__get_process_env` host import", async () => {
+    expect(
+      await standaloneHostImports(`
+        export function f() { return process.env.NODE_ENV === "production" ? 1 : 2; }
+      `),
+    ).toEqual([]);
+  });
+
+  it("keeps the JS-host lane's `process.env` import (host mode is unchanged)", async () => {
+    const result = await compile(`export function f() { return process.env.NODE_ENV === "production" ? 1 : 2; }`, {
+      fileName: "m.js",
+      allowJs: true,
+      skipSemanticDiagnostics: true,
+    });
+    expect(result.success).toBe(true);
+    const imports = WebAssembly.Module.imports(await WebAssembly.compile(result.binary!)).map((e) => e.name);
+    expect(imports).toContain("__get_process_env");
+  });
+
+  it("dispatches an `any`-receiver method natively instead of binding a lib.dom extern", async () => {
+    // redux's shape: `createStore` returns an object literal, and the call site
+    // types the receiver as `any`. `getState` is also declared by lib.dom's
+    // NavigationHistoryEntry, whose `env` import no standalone instance can
+    // satisfy.
+    expect(
+      await standaloneHostImports(`
+        function createStore(reducer) {
+          var currentState = reducer(undefined, { type: "INIT" });
+          function getState() { return currentState; }
+          function dispatch(action) { currentState = reducer(currentState, action); return action; }
+          return { dispatch: dispatch, getState: getState };
+        }
+        export function g() {
+          var store = createStore(function (s, a) { return (s || 0) + 1; });
+          store.dispatch({ type: "x" });
+          return store.getState();
+        }
+      `),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

The npm-compat perf-over-time graph plots only lanes whose `status` is `measured`, and a standalone lane fails outright when its binary retains **any** host import. That is why `uuid`, `react`, `hono` and `redux` each had a JS-host trend line and an empty standalone one across their whole recorded history.

Two of the four causes were codegen defects leaking host imports from ordinary library code, and both are fixed here:

- **`process.env.<x>` emitted `__get_process_env` under `--target standalone`**, where there is no process to read. The JS-host import itself answers `{}` when no `process` exists, so the host-free lane now materializes that empty object directly. Every published CJS bundle carries this gate, so it affected react and redux alike.
- **A method call on an `any` receiver bound the FIRST extern class declaring that name.** redux's `store.getState()` first-matched lib.dom's `NavigationHistoryEntry.getState`, emitting an `env` import no standalone instance can satisfy. Under `noJsHost` that first-match loop is now skipped entirely and the call falls through to the native `__extern_method_call` route — generalizing the `.join` (#3342) and DisposableStack (#3237) escapes already sitting directly above it rather than adding a third name-specific one.

**Result: redux now measures on all three lanes** (standalone static, standalone dynamic, js-host), so it gains a standalone trend line. Verified with `generate-npm-compat-report.mjs --only redux --perf-only --inspect-imports`.

The other three are analysed and written up in [#3781](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3781-npm-perf-standalone-js-host-lanes), and deliberately left out of this change:

- **hono** — `compile-error`: standalone `String.prototype.replace()` with a RegExp is unsupported (#1474), a feature gap with its own issue.
- **uuid** — still retains `__crypto_get_random_values` / `__crypto_random_uuid`; needs a Wasm-native entropy source.
- **react** — the `process.env` fix clears its retained import, but the lane then throws at `__module_init`: react's `index.js` is the classic `if (process.env.NODE_ENV === "production") module.exports = require("./cjs/react.production.js") else … ` gate, and `cjs-rewrite.ts` only rewrites `require()` in *declaration* statements, so that call survives as a bare `require`. Hoisting both branches to eager imports was tried and abandoned — it puts the dev and prod builds in one module graph, and their same-named nested functions (`cloneAndReplaceKey`, `mapIntoArray`) then trip the name-keyed capture registry with `references out-of-range local(s) 154, 198 after local dedup`. Each build compiles cleanly alone; only the two together fail. That needs either folding the NODE_ENV gate or module-scoping the registry, both larger than this change.

Regression test: `tests/npm-compat-standalone-host-imports.test.ts` asks the compiled module what it imports, the same question the perf lane asks, and also pins that the JS-host lane keeps its `__get_process_env` import unchanged.

Verified locally: typecheck, biome, prettier, and the LOC/function/coercion/oracle/dead-export gates all green; the touched-area unit tests (#1490 process host imports, #3342 any-receiver join, #3237 DisposableStack, #2916, plus the acorn/React regression tests from the previous PR) pass — 52 tests.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECD36tGCqAJofyLerMFaBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECD36tGCqAJofyLerMFaBG)_