### PR TITLE
feat(#5279): classify every npm-compat package by the ECMAScript edition it requires

### DIFF
--- a/plan/issues/5279-npm-compat-es-edition-classification.md
+++ b/plan/issues/5279-npm-compat-es-edition-classification.md
@@ -1,0 +1,132 @@
+---
+id: 5279
+title: "Classify each npm-compat package by the ECMAScript edition it requires"
+status: done
+sprint: current
+created: 2026-09-02
+updated: 2026-09-02
+completed: 2026-09-02
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: high
+task_type: tooling
+area: tooling, dogfood, website
+language_feature: n/a
+goal: dogfood
+related: [1710, 3781, 3958]
+files:
+  - scripts/lib/es-edition.mjs
+  - scripts/lib/npm-compat-es-edition.mjs
+  - scripts/generate-npm-compat-report.mjs
+  - website/components/npm-compat-chart.js
+  - tests/es-edition-classifier.test.ts
+origin: "user: we should classify the npm packages by the ES edition they require"
+---
+
+# #5279 — classify each npm-compat package by the ECMAScript edition it requires
+
+## Problem
+
+The npm-compat dashboard said whether each package compiles, validates and
+passes its tests, but not what the package actually asks of the compiler. So
+"acorn passes, tailwindcss does not" carried no signal about _why_, and the
+corpus could not answer the one question that orders the work: **which
+ECMAScript edition must the compiler support to run real npm code?**
+
+Without it, a failure and a feature gap look the same on the card.
+
+## What it does
+
+Every package row now carries an `esEdition` classification: the newest edition
+required by the package's **own module graph**, walked from its published entry
+module and stopping at the package boundary.
+
+Two axes are reported separately, because they cost different work and fail
+differently:
+
+| Axis         | Means                                        | Example                           |
+| ------------ | -------------------------------------------- | --------------------------------- |
+| **syntax**   | grammar the parser and codegen must accept   | `a?.b` is ES2020 — unpolyfillable |
+| **builtins** | library surface the runtime must provide     | `Object.entries` is ES2017        |
+
+The split is not academic: react's grammar is **ES5** (it ships transpiled)
+while its runtime needs **ES2021** `AggregateError`. A compiler that "supports
+ES5" does not run react.
+
+### The library map is derived, not hand-written
+
+TypeScript ships one `lib.es<year>.<area>.d.ts` per edition per area — the
+authoritative, maintained statement of which edition introduced which global,
+static and prototype member. The classifier reads those files and builds the
+map from them, so a new edition lands without anyone editing a table, and every
+classification is traceable to a lib file. `lib.es*.intl.d.ts` is excluded:
+Intl is ECMA-402, a separate standard, and counting it would report a package
+as needing ES2020 for `Intl.DisplayNames`.
+
+### What it refuses to claim
+
+The number is only worth reading if it never over-reports, so three cases
+deliberately do **not** raise the edition:
+
+- **A bare prototype-method read.** `x.flat()` is only `Array.prototype.flat`
+  if `x` is an Array, which needs type information this classifier does not
+  use. Recorded as evidence in a separate `heuristic` bucket, never counted.
+- **A shadowed global.** A file with its own `Promise` binding is not using the
+  ES2015 global.
+- **An unextracted tarball.** Reports `unavailable` rather than reading an
+  absent package as ES5.
+
+Following the module graph rather than the entry file alone is what makes the
+answer honest for a gate module: react's `index.js` is five lines that `require`
+one of two real builds, and classifying those five lines would report ES5 for a
+package whose implementation is not. External dependencies are counted, not
+followed, so a barrel package (lit) shows a visible `externalDependencies`
+count instead of a silent "ES5".
+
+## Result — the corpus as a timeline
+
+| Edition | Packages                                                                 |
+| ------- | ------------------------------------------------------------------------ |
+| ES2015  | clsx, jest, lit, lodash, lodash-es, moment, react-dom, styled-components |
+| ES2018  | redux                                                                    |
+| ES2020  | axios, cookie, typescript, webpack                                       |
+| ES2021  | react, uuid                                                              |
+| ES2022  | acorn, eslint, hono, jsdom, marked, prettier, tailwindcss                |
+| ES2025  | stylelint (`import … with { type: "json" }`)                             |
+| ESNext  | three (`Float16Array`)                                                   |
+
+Two things fall out of that table immediately:
+
+1. **Every package that currently runs needs ES2022 or below** — and the whole
+   ES2025/ESNext tail fails. The edition is a usable predictor of support.
+2. **Seven packages need ES2022**, the largest cluster above ES2015, so class
+   fields and private members are the highest-leverage grammar remaining rather
+   than a long-tail nicety.
+
+## Acceptance criteria
+
+- [x] Each package row carries `esEdition` with `required`, `syntax`,
+      `builtins`, per-axis evidence (feature, file, line) and the scanned-file
+      count.
+- [x] The library map is derived from TypeScript's `lib.es*.d.ts`, not
+      hand-curated, and excludes ECMA-402.
+- [x] A prototype-method read, a shadowed global, and an unextracted package
+      never raise the reported edition.
+- [x] The report summary carries an `esEditions` rollup ordered oldest first,
+      naming the packages behind each count and stating its own method.
+- [x] The dashboard shows a per-card `needs ES####` badge (with the evidence in
+      its tooltip) and a corpus-wide edition strip.
+- [x] Tests pin the derivation, the syntax table, the refusals, and the
+      evidence-trimming behaviour.
+
+## Notes
+
+- Evidence is trimmed **after** sorting by edition. Trimming during collection
+  dropped whichever feature was encountered last — including the one that set
+  the headline edition, which then had no evidence behind it at all (stylelint
+  read "ES2025" with nothing above ES2020 listed).
+- `NodeFlags.AwaitUsing` is `Const | Using`, so a naive bit test reads every
+  `const` as an ES2025 `using` declaration. `Using` is the discriminating bit.
+- The graph walk stops at 400 files and sets `graphTruncated`; jsdom, webpack
+  and lodash-es reach it. Their reported edition is a floor, not a ceiling.

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -41,6 +41,7 @@ import { runHarness as runClsxUpstreamSuite } from "../tests/dogfood/clsx-upstre
 import { runHarness as runCookie } from "../tests/dogfood/cookie-harness.mjs";
 import { runHarness as runCookieUpstreamSuite } from "../tests/dogfood/cookie-upstream-suite.mjs";
 import { correctnessRollup, correctnessVerdict } from "./lib/npm-compat-correctness.mjs"; // (#4127)
+import { classifyPackageRow, esEditionRollup } from "./lib/npm-compat-es-edition.mjs";
 import { runHarness as runEslint } from "../tests/dogfood/eslint-harness.mjs";
 import { runHarness as runEslintWorkload } from "../tests/dogfood/eslint-workload-harness.mjs";
 import { runHarness as runEslintUpstreamSuite } from "../tests/dogfood/eslint-upstream-suite.mjs";
@@ -3030,6 +3031,7 @@ for (const entry of NPM_COMPAT_CATALOG) {
 }
 
 for (const pkg of packages) {
+  pkg.esEdition = classifyPackageRow(pkg, ROOT);
   pkg.weeklyDownloads = NPM_DOWNLOADS_SNAPSHOT.packages[pkg.name] ?? null;
   pkg.playground ??= {
     kind: "unavailable",
@@ -3061,6 +3063,10 @@ const summary = {
   // `unverified` list is named, not just counted, so the size of the blind spot
   // is legible rather than implied.
   correctness: correctnessRollup(packages),
+  // Which ECMAScript edition each package actually needs — the corpus
+  // ordered as a timeline, so "what must the compiler support to run real npm
+  // code" is answerable from the artifact rather than by reading bundles.
+  esEditions: esEditionRollup(packages),
   note: "Only packages with a committed, reproducible tests/dogfood harness are listed. Original upstream tests are preferred; when npm omits them, the card says so instead of substituting harness-authored tests.",
   popularity: {
     metric: "weekly npm downloads",

--- a/scripts/lib/es-edition.mjs
+++ b/scripts/lib/es-edition.mjs
@@ -1,0 +1,680 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Classify a JavaScript source (or a package's intra-package module graph) by
+// the ECMAScript edition it REQUIRES — the newest edition whose features it
+// actually uses. Two independent axes, because they cost the compiler
+// different work and fail differently:
+//
+//   * SYNTAX  — what the parser and codegen must understand (`?.` is ES2020
+//     grammar; no runtime can polyfill it).
+//   * BUILTINS — what the runtime library must provide (`Object.entries` is
+//     ES2017 library surface; the grammar is ES5).
+//
+// A published bundle is usually transpiled, so the two diverge routinely:
+// lodash's syntax is ES5 while it feature-detects ES2015 builtins.
+//
+// The builtin map is DERIVED, not hand-written: TypeScript ships one
+// `lib.es<year>.<area>.d.ts` per edition per area, which is the authoritative,
+// maintained statement of which edition introduced which global, static and
+// prototype member. Hand-curating that list would drift the moment a new
+// edition lands; reading it from the installed TypeScript keeps it correct by
+// construction and makes every classification traceable to a lib file.
+//
+// ECMA-402 (`lib.es*.intl.d.ts`) is deliberately excluded — Intl is a separate
+// standard, not an ECMA-262 edition, and counting it would report a package as
+// needing ES2020 for `Intl.DisplayNames`.
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+
+import { ts } from "../../src/ts-api.js";
+
+/** The edition every script is allowed to assume; nothing below this is evidence. */
+export const BASELINE_EDITION = 5;
+
+/** `lib.esnext.*` members are draft — reported separately, never as a year. */
+export const ESNEXT = "ESNext";
+
+/** Files the graph walk will read before it stops, so one huge package cannot stall a report. */
+const MAX_GRAPH_FILES = 400;
+
+/** Evidence entries kept per feature bucket — enough to explain, not enough to bloat the artifact. */
+const MAX_EVIDENCE_PER_KIND = 12;
+
+// ---------------------------------------------------------------------------
+// Syntax → edition
+// ---------------------------------------------------------------------------
+//
+// Keyed by what a reader would call the feature, valued by the edition that
+// introduced it. Grammar is stable and small enough to state directly; unlike
+// the library surface it does not grow every year in dozens of places.
+
+const SYNTAX_EDITION = {
+  // ES2015
+  "arrow function": 2015,
+  class: 2015,
+  "template literal": 2015,
+  "tagged template": 2015,
+  "for-of": 2015,
+  "let/const": 2015,
+  destructuring: 2015,
+  "default parameter": 2015,
+  "rest parameter": 2015,
+  spread: 2015,
+  "shorthand property": 2015,
+  "computed property name": 2015,
+  "shorthand method": 2015,
+  generator: 2015,
+  "new.target": 2015,
+  "ES module": 2015,
+  // ES2016
+  exponentiation: 2016,
+  // ES2017
+  async: 2017,
+  await: 2017,
+  // ES2018
+  "object spread": 2018,
+  "object rest": 2018,
+  "for await": 2018,
+  "async generator": 2018,
+  "regexp dotAll flag": 2018,
+  "regexp named capture group": 2018,
+  "regexp lookbehind": 2018,
+  "regexp unicode property escape": 2018,
+  // ES2019
+  "optional catch binding": 2019,
+  // ES2020
+  "optional chaining": 2020,
+  "nullish coalescing": 2020,
+  "dynamic import": 2020,
+  "import.meta": 2020,
+  "bigint literal": 2020,
+  "export * as ns": 2020,
+  // ES2021
+  "logical assignment": 2021,
+  "numeric separator": 2021,
+  // ES2022
+  "class field": 2022,
+  "private class member": 2022,
+  "static block": 2022,
+  "top-level await": 2022,
+  "regexp hasIndices flag": 2022,
+  // ES2024
+  "regexp unicodeSets flag": 2024,
+  // ES2025
+  "import attributes": 2025,
+  "using declaration": 2025,
+  "regexp modifiers": 2025,
+};
+
+// ---------------------------------------------------------------------------
+// Builtin map, derived from the installed TypeScript lib files
+// ---------------------------------------------------------------------------
+
+/** `lib.<name>.d.ts` files that do not describe an ECMA-262 edition surface. */
+function isEcma262Lib(fileName) {
+  if (!/^lib\.es(\d{4}|next|5)\./.test(fileName) && fileName !== "lib.es5.d.ts") return false;
+  // Aggregators (`lib.es2017.d.ts`, `lib.es2017.full.d.ts`) only `/// <reference>`
+  // the real files, so reading them would double-count nothing but cost time.
+  if (/\.(full|d)\.ts$/.test(fileName) && /^lib\.es(\d{4}|next)\.d\.ts$/.test(fileName)) return false;
+  if (/^lib\.es\d{4}\.full\.d\.ts$/.test(fileName)) return false;
+  if (/\.intl\.d\.ts$/.test(fileName)) return false; // ECMA-402, not ECMA-262
+  return true;
+}
+
+function editionOfLib(fileName) {
+  if (fileName === "lib.es5.d.ts") return BASELINE_EDITION;
+  const next = /^lib\.esnext\./.test(fileName);
+  if (next) return ESNEXT;
+  const year = /^lib\.es(\d{4})\./.exec(fileName);
+  return year ? Number(year[1]) : null;
+}
+
+/** An edition is "newer" than another when it would raise the reported requirement. */
+function isNewer(candidate, current) {
+  if (candidate === null || candidate === undefined) return false;
+  if (current === null || current === undefined) return true;
+  if (current === ESNEXT) return false;
+  if (candidate === ESNEXT) return true;
+  return candidate > current;
+}
+
+/** Keep the EARLIEST edition that declares a name — later libs only add overloads. */
+function recordEarliest(map, key, edition) {
+  const seen = map.get(key);
+  if (seen === undefined || isNewer(seen, edition)) map.set(key, edition);
+}
+
+let cachedBuiltins = null;
+
+/**
+ * Read TypeScript's `lib.es*.d.ts` files into three lookups:
+ *
+ *   globals         `WeakRef` → 2021              (a `declare var` that did not exist before)
+ *   statics         `Object.entries` → 2017       (a member of a `…Constructor` interface)
+ *   instanceMembers `flat` → 2019                 (a member of an instance interface)
+ *
+ * `instanceMembers` is bare-named on purpose: `x.flat()` cannot be attributed
+ * to `Array` without type information, so it is reported as a heuristic and
+ * never raises the required edition on its own.
+ */
+export function loadBuiltinEditionMap(libDir = defaultLibDir()) {
+  if (cachedBuiltins && cachedBuiltins.libDir === libDir) return cachedBuiltins;
+
+  const globals = new Map();
+  const statics = new Map();
+  const instanceMembers = new Map();
+  // `interface ObjectConstructor` is only reachable as `Object.…` because
+  // `declare var Object: ObjectConstructor` says so. Collect that binding
+  // first, then attribute each constructor interface's members to the global.
+  const constructorInterfaceToGlobal = new Map();
+  const pendingStatics = [];
+  const libFiles = existsSync(libDir)
+    ? readdirSync(libDir)
+        .filter((name) => name.endsWith(".d.ts") && isEcma262Lib(name))
+        .sort()
+    : [];
+
+  for (const fileName of libFiles) {
+    const edition = editionOfLib(fileName);
+    if (edition === null) continue;
+    const source = ts.createSourceFile(
+      fileName,
+      readFileSync(join(libDir, fileName), "utf-8"),
+      ts.ScriptTarget.Latest,
+      false,
+      ts.ScriptKind.TS,
+    );
+
+    for (const statement of source.statements) {
+      if (ts.isVariableStatement(statement)) {
+        for (const declaration of statement.declarationList.declarations) {
+          if (!ts.isIdentifier(declaration.name)) continue;
+          recordEarliest(globals, declaration.name.text, edition);
+          const typeNode = declaration.type;
+          if (typeNode && ts.isTypeReferenceNode(typeNode) && ts.isIdentifier(typeNode.typeName)) {
+            constructorInterfaceToGlobal.set(typeNode.typeName.text, declaration.name.text);
+          }
+        }
+        continue;
+      }
+      if (!ts.isInterfaceDeclaration(statement)) continue;
+      const interfaceName = statement.name.text;
+      const memberNames = [];
+      for (const member of statement.members) {
+        const name = member.name;
+        if (!name) continue;
+        if (ts.isIdentifier(name) || ts.isStringLiteral(name)) memberNames.push(name.text);
+      }
+      if (memberNames.length === 0) continue;
+      // Resolved after the whole sweep: a constructor interface can be
+      // declared in an earlier lib file than its `declare var`.
+      pendingStatics.push({ interfaceName, memberNames, edition });
+    }
+  }
+
+  for (const { interfaceName, memberNames, edition } of pendingStatics) {
+    const globalName = constructorInterfaceToGlobal.get(interfaceName);
+    for (const memberName of memberNames) {
+      if (globalName) recordEarliest(statics, `${globalName}.${memberName}`, edition);
+      else recordEarliest(instanceMembers, memberName, edition);
+    }
+  }
+
+  // A name that already exists in ES5 is never evidence, whichever interface
+  // re-declares it later (`Array.prototype.includes` is ES2016, but `length`
+  // must not be attributed to whatever lib file mentions it last).
+  for (const map of [globals, statics, instanceMembers]) {
+    for (const [key, edition] of map) if (edition === BASELINE_EDITION) map.delete(key);
+  }
+
+  // TypeScript models `globalThis` intrinsically rather than as a `declare var`
+  // in any lib file, so the sweep above cannot see it. It is ES2020 surface and
+  // common in published bundles, so state it explicitly rather than miss it.
+  recordEarliest(globals, "globalThis", 2020);
+
+  cachedBuiltins = { libDir, globals, statics, instanceMembers, libFiles: libFiles.length };
+  return cachedBuiltins;
+}
+
+function defaultLibDir() {
+  try {
+    const require = createRequire(import.meta.url);
+    return dirname(require.resolve("typescript"));
+  } catch {
+    return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single-source classification
+// ---------------------------------------------------------------------------
+
+/** RegExp flags introduced after ES5, and the edition that introduced each. */
+const REGEXP_FLAG_FEATURES = { s: "regexp dotAll flag", d: "regexp hasIndices flag", v: "regexp unicodeSets flag" };
+
+function classifyRegExpLiteral(text, hit) {
+  const lastSlash = text.lastIndexOf("/");
+  if (lastSlash <= 0) return;
+  const flags = text.slice(lastSlash + 1);
+  const body = text.slice(1, lastSlash);
+  for (const flag of flags) {
+    const feature = REGEXP_FLAG_FEATURES[flag];
+    if (feature) hit(feature);
+  }
+  if (/\(\?<[=!]/.test(body)) hit("regexp lookbehind");
+  else if (/\(\?<[A-Za-z_$]/.test(body)) hit("regexp named capture group");
+  if (/\\[pP]\{/.test(body)) hit("regexp unicode property escape");
+  // `(?i:…)` / `(?-i:…)` — ES2025 inline modifiers. Requiring at least one
+  // modifier letter (or a `-`) is what separates them from a plain `(?:…)`
+  // non-capturing group, which every regex-heavy bundle uses constantly.
+  if (/\(\?[ims]*-[ims]*:/.test(body) || /\(\?[ims]+:/.test(body)) hit("regexp modifiers");
+}
+
+/**
+ * Walk one parsed source file, reporting every post-ES5 feature it uses.
+ * `report(feature, kind, node)` is called once per occurrence; the caller
+ * decides how much evidence to keep.
+ */
+/**
+ * Every name the file binds itself. Used to suppress a global-builtin hit when
+ * the source declares its own `Promise`/`Symbol` — deliberately a whole-file
+ * over-approximation (any same-named binding anywhere suppresses the global),
+ * because under-reporting an edition is honest while over-reporting is not.
+ */
+function collectBoundNames(sourceFile) {
+  const bound = new Set();
+  const addName = (name) => {
+    if (!name) return;
+    if (ts.isIdentifier(name)) bound.add(name.text);
+    else if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name)) {
+      for (const element of name.elements) if (!ts.isOmittedExpression(element)) addName(element.name);
+    }
+  };
+  const visit = (node) => {
+    if (ts.isVariableDeclaration(node) || ts.isParameter(node) || ts.isBindingElement(node)) addName(node.name);
+    else if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) addName(node.name);
+    else if (ts.isImportClause(node)) addName(node.name);
+    else if (ts.isImportSpecifier(node) || ts.isNamespaceImport(node)) addName(node.name);
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return bound;
+}
+
+function walkSource(sourceFile, builtins, report) {
+  const hit = (feature, node) => report(feature, "syntax", node);
+  const boundNames = collectBoundNames(sourceFile);
+
+  /** True when this identifier is a READ of a free variable, not a name in a declaration or member position. */
+  const isFreeVariableRead = (node) => {
+    const parent = node.parent;
+    if (!parent) return true;
+    if (ts.isPropertyAccessExpression(parent) && parent.name === node) return false;
+    if (ts.isQualifiedName(parent) && parent.right === node) return false;
+    if (ts.isPropertyAssignment(parent) && parent.name === node) return false;
+    if (ts.isBindingElement(parent) && parent.propertyName === node) return false;
+    if (ts.isMethodDeclaration(parent) || ts.isPropertyDeclaration(parent)) return parent.name !== node;
+    if (ts.isVariableDeclaration(parent) || ts.isParameter(parent)) return parent.name !== node;
+    if (ts.isFunctionDeclaration(parent) || ts.isClassDeclaration(parent) || ts.isFunctionExpression(parent)) {
+      return parent.name !== node;
+    }
+    if (ts.isLabeledStatement(parent) || ts.isBreakOrContinueStatement(parent)) return false;
+    return true;
+  };
+
+  const visit = (node) => {
+    switch (node.kind) {
+      case ts.SyntaxKind.ArrowFunction:
+        hit("arrow function", node);
+        break;
+      case ts.SyntaxKind.ClassDeclaration:
+      case ts.SyntaxKind.ClassExpression:
+        hit("class", node);
+        break;
+      case ts.SyntaxKind.TemplateExpression:
+      case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+        hit("template literal", node);
+        break;
+      case ts.SyntaxKind.TaggedTemplateExpression:
+        hit("tagged template", node);
+        break;
+      case ts.SyntaxKind.ForOfStatement:
+        hit(node.awaitModifier ? "for await" : "for-of", node);
+        break;
+      case ts.SyntaxKind.ObjectBindingPattern:
+      case ts.SyntaxKind.ArrayBindingPattern:
+        hit("destructuring", node);
+        break;
+      case ts.SyntaxKind.SpreadElement:
+        hit("spread", node);
+        break;
+      case ts.SyntaxKind.SpreadAssignment:
+        hit("object spread", node);
+        break;
+      case ts.SyntaxKind.ShorthandPropertyAssignment:
+        hit("shorthand property", node);
+        break;
+      case ts.SyntaxKind.ComputedPropertyName:
+        hit("computed property name", node);
+        break;
+      case ts.SyntaxKind.MethodDeclaration:
+        hit("shorthand method", node);
+        break;
+      case ts.SyntaxKind.MetaProperty:
+        hit(node.keywordToken === ts.SyntaxKind.ImportKeyword ? "import.meta" : "new.target", node);
+        break;
+      case ts.SyntaxKind.ImportDeclaration:
+      case ts.SyntaxKind.ExportDeclaration:
+      case ts.SyntaxKind.ExportAssignment:
+      case ts.SyntaxKind.ImportEqualsDeclaration:
+        hit("ES module", node);
+        if (node.attributes ?? node.assertClause) hit("import attributes", node);
+        if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamespaceExport(node.exportClause)) {
+          hit("export * as ns", node);
+        }
+        break;
+      case ts.SyntaxKind.PropertyDeclaration:
+        hit("class field", node);
+        break;
+      case ts.SyntaxKind.ClassStaticBlockDeclaration:
+        hit("static block", node);
+        break;
+      case ts.SyntaxKind.PrivateIdentifier:
+        hit("private class member", node);
+        break;
+      case ts.SyntaxKind.BigIntLiteral:
+        hit("bigint literal", node);
+        break;
+      case ts.SyntaxKind.RegularExpressionLiteral:
+        classifyRegExpLiteral(node.getText(sourceFile), (feature) => hit(feature, node));
+        break;
+      case ts.SyntaxKind.AwaitExpression:
+        hit("await", node);
+        break;
+      case ts.SyntaxKind.PropertyAccessExpression:
+      case ts.SyntaxKind.ElementAccessExpression:
+      case ts.SyntaxKind.CallExpression:
+        if (node.questionDotToken) hit("optional chaining", node);
+        break;
+      default:
+        break;
+    }
+
+    if (ts.isVariableDeclarationList(node)) {
+      // `AwaitUsing` is `Const | Using`, so testing it directly matches every
+      // plain `const`. `Using` is the discriminating bit and covers both forms.
+      if ((node.flags & ts.NodeFlags.Using) !== 0) hit("using declaration", node);
+      else if ((node.flags & ts.NodeFlags.BlockScoped) !== 0) hit("let/const", node);
+    }
+    if (ts.isCatchClause(node) && !node.variableDeclaration) hit("optional catch binding", node);
+    if (ts.isBinaryExpression(node)) {
+      const op = node.operatorToken.kind;
+      if (op === ts.SyntaxKind.AsteriskAsteriskToken || op === ts.SyntaxKind.AsteriskAsteriskEqualsToken) {
+        hit("exponentiation", node);
+      } else if (op === ts.SyntaxKind.QuestionQuestionToken) {
+        hit("nullish coalescing", node);
+      } else if (
+        op === ts.SyntaxKind.QuestionQuestionEqualsToken ||
+        op === ts.SyntaxKind.BarBarEqualsToken ||
+        op === ts.SyntaxKind.AmpersandAmpersandEqualsToken
+      ) {
+        hit("logical assignment", node);
+      }
+    }
+    if (ts.isNumericLiteral(node) && node.getText(sourceFile).includes("_")) hit("numeric separator", node);
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) hit("dynamic import", node);
+    if (ts.isFunctionLike(node)) {
+      const modifiers = ts.canHaveModifiers(node) ? (ts.getModifiers(node) ?? []) : [];
+      const isAsync = modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword);
+      if (isAsync && node.asteriskToken) hit("async generator", node);
+      else if (isAsync) hit("async", node);
+      else if (node.asteriskToken) hit("generator", node);
+      for (const parameter of node.parameters ?? []) {
+        if (parameter.dotDotDotToken) hit("rest parameter", parameter);
+        else if (parameter.initializer) hit("default parameter", parameter);
+      }
+    }
+    if (ts.isObjectBindingPattern(node)) {
+      for (const element of node.elements) if (element.dotDotDotToken) hit("object rest", element);
+    }
+
+    // Builtins. Only unambiguous forms raise the requirement: `Object.entries`
+    // names the global it reads, and a bare `WeakRef` is a global unless the
+    // file shadows it. A bare `.flat()` could be any user object, so it is
+    // recorded as a heuristic instead.
+    if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && ts.isIdentifier(node.name)) {
+      const qualified = `${node.expression.text}.${node.name.text}`;
+      const staticEdition = builtins.statics.get(qualified);
+      if (staticEdition !== undefined) report(qualified, "builtin", node, staticEdition);
+      else {
+        const memberEdition = builtins.instanceMembers.get(node.name.text);
+        if (memberEdition !== undefined) report(`.${node.name.text}`, "builtin-heuristic", node, memberEdition);
+      }
+    } else if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.name)) {
+      const memberEdition = builtins.instanceMembers.get(node.name.text);
+      if (memberEdition !== undefined) report(`.${node.name.text}`, "builtin-heuristic", node, memberEdition);
+    } else if (ts.isIdentifier(node) && !boundNames.has(node.text) && isFreeVariableRead(node)) {
+      // A global the file neither declares nor imports: `new WeakRef(…)` needs
+      // ES2021 from the runtime however old the surrounding grammar is.
+      const globalEdition = builtins.globals.get(node.text);
+      if (globalEdition !== undefined) report(node.text, "builtin", node, globalEdition);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  // A module's own top level is the one place `await` means ES2022, so classify
+  // it before the generic walk reaches the AwaitExpression above.
+  const markTopLevelAwait = (statements) => {
+    const scan = (node) => {
+      if (ts.isFunctionLike(node) || ts.isClassLike(node)) return;
+      if (ts.isAwaitExpression(node) || (ts.isForOfStatement(node) && node.awaitModifier)) {
+        report("top-level await", "syntax", node);
+      }
+      ts.forEachChild(node, scan);
+    };
+    for (const statement of statements) scan(statement);
+  };
+  if (ts.isExternalModule(sourceFile)) markTopLevelAwait(sourceFile.statements);
+
+  for (const statement of sourceFile.statements) visit(statement);
+}
+
+/**
+ * Classify a single source text. `fileName` only labels the evidence.
+ */
+export function classifySource(source, fileName = "input.js", options = {}) {
+  return classifySources([{ fileName, source }], options);
+}
+
+/**
+ * Classify a set of already-read sources as ONE unit — a package's own module
+ * graph, for example. The reported edition is the newest any file requires.
+ */
+export function classifySources(files, options = {}) {
+  const builtins = options.builtins ?? loadBuiltinEditionMap();
+  const featureEditions = new Map();
+  const evidence = { syntax: [], builtin: [], "builtin-heuristic": [] };
+  const counts = { syntax: 0, builtin: 0, "builtin-heuristic": 0 };
+  let syntaxEdition = null;
+  let builtinEdition = null;
+  const parseErrors = [];
+
+  for (const { fileName, source } of files) {
+    let sourceFile;
+    try {
+      sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+    } catch (error) {
+      parseErrors.push({ fileName, message: error instanceof Error ? error.message : String(error) });
+      continue;
+    }
+
+    walkSource(sourceFile, builtins, (feature, kind, node, editionOverride) => {
+      const edition = editionOverride ?? SYNTAX_EDITION[feature];
+      if (edition === undefined || edition === null) return;
+      counts[kind] += 1;
+      if (!featureEditions.has(feature)) {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        featureEditions.set(feature, edition);
+        // Collect every DISTINCT feature (bounded by the feature maps, not by
+        // file size) and trim only after sorting by edition. Trimming during
+        // collection dropped whichever feature happened to be encountered late
+        // — including the one that set the headline edition, which then had no
+        // evidence behind it at all (stylelint read "ES2025" with nothing above
+        // ES2020 listed).
+        evidence[kind].push({ feature, edition, file: fileName, line: line + 1 });
+      }
+      if (kind === "syntax" && isNewer(edition, syntaxEdition)) syntaxEdition = edition;
+      if (kind === "builtin" && isNewer(edition, builtinEdition)) builtinEdition = edition;
+    });
+  }
+
+  const required = isNewer(builtinEdition, syntaxEdition) ? builtinEdition : (syntaxEdition ?? builtinEdition);
+  // Newest first, so the entries that justify the headline edition survive the
+  // trim and read first.
+  const sortEvidence = (list) =>
+    list.sort((a, b) => editionRank(b.edition) - editionRank(a.edition)).slice(0, MAX_EVIDENCE_PER_KIND);
+
+  return {
+    required: required ?? BASELINE_EDITION,
+    syntax: syntaxEdition ?? BASELINE_EDITION,
+    builtins: builtinEdition ?? BASELINE_EDITION,
+    evidence: {
+      syntax: sortEvidence(evidence.syntax),
+      builtins: sortEvidence(evidence.builtin),
+      // Kept apart because it never raises `required`: a bare `.flat()` may
+      // well be a user method, and saying so is the difference between a
+      // classification and a guess.
+      heuristic: sortEvidence(evidence["builtin-heuristic"]),
+    },
+    featureCounts: counts,
+    scannedFiles: files.length,
+    parseErrors,
+  };
+}
+
+function editionRank(edition) {
+  return edition === ESNEXT ? Number.MAX_SAFE_INTEGER : Number(edition) || 0;
+}
+
+/** `2020` → `"ES2020"`, `5` → `"ES5"`, `"ESNext"` → `"ESNext"`. */
+export function formatEdition(edition) {
+  if (edition === ESNEXT) return ESNEXT;
+  if (edition === BASELINE_EDITION) return "ES5";
+  return `ES${edition}`;
+}
+
+// ---------------------------------------------------------------------------
+// Package module graph
+// ---------------------------------------------------------------------------
+
+const SCRIPT_EXTENSIONS = [".js", ".mjs", ".cjs"];
+
+function resolveWithinPackage(specifier, fromFile, packageRoot) {
+  if (!specifier.startsWith(".")) return null; // a dependency, not this package's code
+  const base = resolve(dirname(fromFile), specifier);
+  const candidates = [base, ...SCRIPT_EXTENSIONS.map((ext) => base + ext)];
+  for (const ext of SCRIPT_EXTENSIONS) candidates.push(join(base, `index${ext}`));
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    if (extname(candidate) === "") continue; // a directory that matched `base`
+    const inside = relative(packageRoot, candidate);
+    if (inside.startsWith("..") || isAbsolute(inside)) return null;
+    return candidate;
+  }
+  return null;
+}
+
+/** Every `import`/`export … from`/`require()`/`import()` specifier in a source. */
+function collectSpecifiers(sourceFile) {
+  const specifiers = [];
+  const visit = (node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const isRequire = ts.isIdentifier(callee) && callee.text === "require";
+      const isDynamicImport = callee.kind === ts.SyntaxKind.ImportKeyword;
+      const first = node.arguments[0];
+      if ((isRequire || isDynamicImport) && first && ts.isStringLiteral(first)) specifiers.push(first.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return specifiers;
+}
+
+/**
+ * Read the package's own module graph starting at `entryPath`, following only
+ * relative specifiers so the walk stops at the package boundary.
+ *
+ * Following the graph rather than reading the entry alone is what makes the
+ * answer honest for a gate module: react's `index.js` is five lines that
+ * `require` one of two real builds, and classifying those five lines would
+ * report ES5 for a package whose implementation is not ES5 at all. External
+ * dependencies are counted, not followed — a barrel package that re-exports
+ * siblings gets a visible `externalDependencies` number instead of a silent
+ * "ES5".
+ */
+export function readPackageGraph(entryPath, packageRoot, options = {}) {
+  const limit = options.maxFiles ?? MAX_GRAPH_FILES;
+  const files = [];
+  const seen = new Set();
+  const external = new Set();
+  const queue = [resolve(entryPath)];
+  let truncated = false;
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (seen.has(current)) continue;
+    seen.add(current);
+    if (files.length >= limit) {
+      truncated = true;
+      break;
+    }
+    let source;
+    try {
+      source = readFileSync(current, "utf-8");
+    } catch {
+      continue;
+    }
+    files.push({ fileName: relative(packageRoot, current) || current, source, path: current });
+    let sourceFile;
+    try {
+      sourceFile = ts.createSourceFile(current, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+    } catch {
+      continue;
+    }
+    for (const specifier of collectSpecifiers(sourceFile)) {
+      const resolved = resolveWithinPackage(specifier, current, packageRoot);
+      if (resolved) queue.push(resolved);
+      else if (!specifier.startsWith(".")) external.add(specifier);
+    }
+  }
+
+  return { files, externalDependencies: [...external].sort(), truncated };
+}
+
+/**
+ * Classify a package: read its graph from `entryPath`, then classify every file
+ * in it as one unit.
+ */
+export function classifyPackage(entryPath, packageRoot, options = {}) {
+  const graph = readPackageGraph(entryPath, packageRoot, options);
+  if (graph.files.length === 0) {
+    return { required: null, syntax: null, builtins: null, unavailable: "entry module could not be read" };
+  }
+  const classification = classifySources(graph.files, options);
+  return {
+    ...classification,
+    externalDependencies: graph.externalDependencies,
+    graphTruncated: graph.truncated,
+  };
+}

--- a/scripts/lib/npm-compat-es-edition.mjs
+++ b/scripts/lib/npm-compat-es-edition.mjs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Attach an ES-edition classification to each npm-compat package row.
+//
+// This is the layout-aware half of the classifier: `es-edition.mjs` knows how
+// to read JavaScript, this file knows where the dogfood harnesses extract each
+// pinned tarball. Every package lands at `<dir>/package/<entryFile>` where
+// `<dir>` is either `tests/dogfood/.npm-compat/<name>` (catalog packages) or
+// `tests/dogfood/.<name>` (packages with a bespoke harness), so both are tried
+// and a package whose tarball is not extracted in this run reports
+// `unavailable` rather than silently reading as ES5.
+
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { BASELINE_EDITION, classifyPackage, ESNEXT, formatEdition } from "./es-edition.mjs";
+
+const DOGFOOD = "tests/dogfood";
+
+/** Where `<name>`'s pinned tarball may have been extracted, most specific first. */
+export function packageRootCandidates(name, repoRoot) {
+  return [join(repoRoot, DOGFOOD, ".npm-compat", name, "package"), join(repoRoot, DOGFOOD, `.${name}`, "package")];
+}
+
+/**
+ * Classify one report row. Returns the classification, or a row carrying
+ * `unavailable` with the reason — never throws, because an edition label is
+ * metadata on a report whose real subject is compile/test results.
+ */
+export function classifyPackageRow(pkg, repoRoot, options = {}) {
+  const entryFile = pkg?.entryFile;
+  if (!entryFile) return { unavailable: "package row carries no entry file" };
+
+  for (const root of packageRootCandidates(pkg.name, repoRoot)) {
+    const entryPath = join(root, entryFile);
+    if (!existsSync(entryPath)) continue;
+    try {
+      const classification = classifyPackage(entryPath, root, options);
+      if (classification.unavailable) return classification;
+      return {
+        required: classification.required,
+        requiredLabel: formatEdition(classification.required),
+        syntax: classification.syntax,
+        syntaxLabel: formatEdition(classification.syntax),
+        builtins: classification.builtins,
+        builtinsLabel: formatEdition(classification.builtins),
+        evidence: classification.evidence,
+        scannedFiles: classification.scannedFiles,
+        externalDependencies: classification.externalDependencies,
+        ...(classification.graphTruncated ? { graphTruncated: true } : {}),
+        ...(classification.parseErrors.length > 0 ? { parseErrors: classification.parseErrors } : {}),
+      };
+    } catch (error) {
+      return { unavailable: error instanceof Error ? error.message : String(error) };
+    }
+  }
+  return { unavailable: "package tarball is not extracted in this run" };
+}
+
+/**
+ * Corpus-level rollup: how many packages each edition accounts for, and which.
+ * Ordered oldest edition first so the list reads as a timeline.
+ */
+export function esEditionRollup(packages) {
+  const byEdition = new Map();
+  const unclassified = [];
+  for (const pkg of packages) {
+    const edition = pkg.esEdition?.required;
+    if (edition === undefined || edition === null) {
+      unclassified.push(pkg.name);
+      continue;
+    }
+    const key = formatEdition(edition);
+    if (!byEdition.has(key)) byEdition.set(key, { edition, label: key, packages: [] });
+    byEdition.get(key).packages.push(pkg.name);
+  }
+
+  const rank = (edition) => (edition === ESNEXT ? Number.MAX_SAFE_INTEGER : Number(edition) || 0);
+  const editions = [...byEdition.values()]
+    .sort((left, right) => rank(left.edition) - rank(right.edition))
+    .map((entry) => ({ ...entry, count: entry.packages.length, packages: entry.packages.sort() }));
+
+  return {
+    // What the number means, stated where the number lives: the newest edition
+    // any file in the package's own module graph requires — syntax the parser
+    // must accept, or library surface the runtime must provide.
+    method:
+      "Newest ECMAScript edition required by the package's own module graph, from its published entry module. " +
+      "Syntax is classified from the grammar; library surface is derived from TypeScript's lib.es<year>.*.d.ts declarations. " +
+      "Bare prototype-method reads (`x.flat()`) cannot be attributed without types, so they are reported as evidence but never raise the edition.",
+    baseline: formatEdition(BASELINE_EDITION),
+    editions,
+    unclassified: unclassified.sort(),
+  };
+}

--- a/scripts/lib/npm-compat-partials.mjs
+++ b/scripts/lib/npm-compat-partials.mjs
@@ -1,4 +1,5 @@
 import { correctnessRollup } from "./npm-compat-correctness.mjs";
+import { esEditionRollup } from "./npm-compat-es-edition.mjs";
 import { mergeNpmPerfHistory, npmPerfHistoryPoint, npmPerfRows } from "./npm-compat-perf.mjs";
 import { NPM_COMPAT_CATALOG_NAMES } from "../../tests/dogfood/npm-compat-catalog.mjs";
 
@@ -154,6 +155,12 @@ export function mergeNpmCompatPartials(
           }
         : null,
     correctness: correctnessRollup(sortedPackages),
+    // Rebuilt here, not copied from a partial: the sharded path assembles the
+    // shipped artifact from worker reports and constructs this summary itself,
+    // so a rollup added only to the single-process generator would be present
+    // locally and absent from every artifact CI actually publishes. The rows
+    // carry `esEdition`, so the corpus-level view is derivable from them.
+    esEditions: esEditionRollup(sortedPackages),
     note: firstMeta.note ?? "Only packages with a committed, reproducible tests/dogfood harness are listed.",
     popularity: firstMeta.popularity ?? null,
     performanceMethodology: firstMeta.performanceMethodology ?? null,

--- a/tests/es-edition-classifier.test.ts
+++ b/tests/es-edition-classifier.test.ts
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// The npm-compat corpus is classified by the ECMAScript edition each package
+// requires. Two properties keep that number worth reading, and both are pinned
+// here:
+//
+//   1. It is DERIVED, not asserted. The library half comes from TypeScript's
+//      own `lib.es<year>.*.d.ts` declarations, so a new edition lands without
+//      anyone editing a table.
+//   2. It never over-reports. A bare `x.flat()` cannot be attributed to Array
+//      without types, and a file that declares its own `Promise` is not using
+//      the global — both must leave the edition where it was.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — .mjs script library has no declaration file
+import {
+  BASELINE_EDITION,
+  classifySource,
+  ESNEXT,
+  formatEdition,
+  loadBuiltinEditionMap,
+} from "../scripts/lib/es-edition.mjs";
+// @ts-expect-error — .mjs script library has no declaration file
+import { esEditionRollup } from "../scripts/lib/npm-compat-es-edition.mjs";
+
+type Classification = {
+  required: number | string;
+  syntax: number | string;
+  builtins: number | string;
+  evidence: { syntax: Evidence[]; builtins: Evidence[]; heuristic: Evidence[] };
+};
+type Evidence = { feature: string; edition: number | string; file: string; line: number };
+
+const classify = (source: string): Classification => classifySource(source, "case.js") as Classification;
+const features = (list: Evidence[]) => list.map((item) => item.feature);
+
+describe("ES-edition classifier — builtin map derived from TypeScript's lib files", () => {
+  it("reads every ECMA-262 lib file and attributes statics to their global", () => {
+    const map = loadBuiltinEditionMap();
+    expect(map.libFiles).toBeGreaterThan(20);
+    expect(map.statics.get("Object.entries")).toBe(2017);
+    expect(map.statics.get("Object.fromEntries")).toBe(2019);
+    expect(map.statics.get("Object.hasOwn")).toBe(2022);
+    expect(map.statics.get("Promise.allSettled")).toBe(2020);
+    expect(map.globals.get("WeakRef")).toBe(2021);
+    expect(map.globals.get("Symbol")).toBe(2015);
+  });
+
+  it("never attributes an ES5 name to a later lib file that re-declares it", () => {
+    const map = loadBuiltinEditionMap();
+    // `Object.keys`/`Array.isArray` are ES5; later libs mention `ObjectConstructor`
+    // again for new members, which must not drag the old ones forward.
+    expect(map.statics.has("Object.keys")).toBe(false);
+    expect(map.statics.has("Array.isArray")).toBe(false);
+    expect(map.instanceMembers.has("map")).toBe(false);
+  });
+
+  it("excludes ECMA-402 (Intl), which is a separate standard from ECMA-262", () => {
+    expect(classify("var f = new Intl.DisplayNames();").required).toBe(BASELINE_EDITION);
+  });
+});
+
+describe("ES-edition classifier — syntax", () => {
+  it.each([
+    ["var x = 1; function f(a) { return a; }", BASELINE_EDITION],
+    ["const f = (a) => a * 2;", 2015],
+    ["var y = 2 ** 8;", 2016],
+    ["async function g() { return 1; }", 2017],
+    ["var merged = { ...a, b: 1 };", 2018],
+    ["try { f(); } catch { g(); }", 2019],
+    ["var v = a?.b ?? c;", 2020],
+    ["let n = 0; n ||= 1;", 2021],
+    ["class A { #p = 1; static { } }", 2022],
+    ['import x from "./x.js" with { type: "json" };', 2025],
+  ])("classifies %j as ES%s", (source, edition) => {
+    expect(classify(source as string).syntax).toBe(edition);
+  });
+
+  it("separates a `using` declaration from an ordinary `const`", () => {
+    // `NodeFlags.AwaitUsing` is `Const | Using`, so a naive bit test reads every
+    // `const` as an ES2025 `using` declaration.
+    expect(features(classify("const a = 1;").evidence.syntax)).toContain("let/const");
+    expect(features(classify("const a = 1;").evidence.syntax)).not.toContain("using declaration");
+    expect(features(classify("using handle = open();").evidence.syntax)).toContain("using declaration");
+  });
+
+  it("does not read a plain non-capturing group as an ES2025 regexp modifier", () => {
+    expect(classify("var re = /(?:abc)+/;").required).toBe(BASELINE_EDITION);
+    expect(features(classify("var re = /(?i:abc)/;").evidence.syntax)).toContain("regexp modifiers");
+    expect(features(classify("var re = /(?<y>\\d{4})/;").evidence.syntax)).toContain("regexp named capture group");
+  });
+
+  it("counts module top-level await as ES2022, not ES2017", () => {
+    const topLevel = classify('import "./x.js";\nawait ready();');
+    expect(features(topLevel.evidence.syntax)).toContain("top-level await");
+    expect(topLevel.syntax).toBe(2022);
+    expect(classify("async function f() { await ready(); }").syntax).toBe(2017);
+  });
+});
+
+describe("ES-edition classifier — library surface, and what it refuses to claim", () => {
+  it("reports a static call and a global read at their introducing edition", () => {
+    expect(classify("var e = Object.entries(o);").builtins).toBe(2017);
+    expect(classify("var r = new WeakRef(o);").builtins).toBe(2021);
+    expect(classify("var g = globalThis;").builtins).toBe(2020);
+  });
+
+  it("keeps syntax and library separate, because a transpiled bundle splits them", () => {
+    // react's exact shape: ES5 grammar, ES2021 runtime requirement.
+    const result = classify("var x = new AggregateError([], 'e');");
+    expect(result.syntax).toBe(BASELINE_EDITION);
+    expect(result.builtins).toBe(2021);
+    expect(result.required).toBe(2021);
+  });
+
+  it("does not raise the edition for a bare prototype-method read", () => {
+    // `x.flat()` is only `Array.prototype.flat` if `x` is an Array, which needs
+    // type information this classifier deliberately does not use.
+    const result = classify("var y = x.flat();");
+    expect(result.required).toBe(BASELINE_EDITION);
+    expect(features(result.evidence.heuristic)).toContain(".flat");
+  });
+
+  it("does not treat a locally declared name as the global builtin", () => {
+    expect(classify("function f(Promise) { return new Promise(); }").builtins).toBe(BASELINE_EDITION);
+    expect(classify("var p = Promise.resolve(1);").builtins).toBe(2015);
+  });
+
+  it("keeps the evidence that set the headline edition, however late it appears", () => {
+    // Trimming evidence during collection dropped whichever feature came last,
+    // which could be the one that set the number — a headline with nothing
+    // behind it.
+    const filler = Array.from({ length: 40 }, (_, i) => `const v${i} = (a) => a + ${i};`).join("\n");
+    const result = classify(`${filler}\nclass Late { #hidden = 1; }`);
+    expect(result.required).toBe(2022);
+    expect(features(result.evidence.syntax)).toContain("private class member");
+  });
+});
+
+describe("ES-edition rollup", () => {
+  it("orders editions oldest first and names the packages behind each count", () => {
+    const rollup = esEditionRollup([
+      { name: "b", esEdition: { required: 2022 } },
+      { name: "a", esEdition: { required: 2015 } },
+      { name: "c", esEdition: { required: 2022 } },
+      { name: "d", esEdition: { required: ESNEXT } },
+      { name: "e", esEdition: { unavailable: "not extracted" } },
+    ]);
+    expect(rollup.editions.map((entry: { label: string }) => entry.label)).toEqual(["ES2015", "ES2022", "ESNext"]);
+    expect(rollup.editions[1].packages).toEqual(["b", "c"]);
+    expect(rollup.editions[1].count).toBe(2);
+    expect(rollup.unclassified).toEqual(["e"]);
+  });
+
+  it("formats editions the way the spec names them", () => {
+    expect(formatEdition(BASELINE_EDITION)).toBe("ES5");
+    expect(formatEdition(2020)).toBe("ES2020");
+    expect(formatEdition(ESNEXT)).toBe("ESNext");
+  });
+});

--- a/tests/npm-compat-partials.test.ts
+++ b/tests/npm-compat-partials.test.ts
@@ -36,6 +36,29 @@ describe("npm-compat partial aggregation", () => {
     expect(result.perfHistory.runs).toHaveLength(1);
   });
 
+  it("rebuilds the ES-edition rollup, which the sharded path would otherwise drop (#5279)", () => {
+    // The partial report carries a trimmed `summaryMeta`, and this merge builds
+    // the shipped summary itself — so a rollup added only to the single-process
+    // generator is present locally and absent from every artifact CI publishes.
+    const withEditions = {
+      ...partial(["acorn", "react"]),
+      packages: [
+        { name: "acorn", compile: { success: true }, esEdition: { required: 2022 } },
+        { name: "react", compile: { success: true }, esEdition: { required: 2021 } },
+      ],
+    };
+    const result = mergeNpmCompatPartials([withEditions], {
+      expectedNames: ["acorn", "react"],
+      sourceRevision: "source",
+    });
+
+    expect(result.summary.esEditions.editions.map((entry: { label: string }) => entry.label)).toEqual([
+      "ES2021",
+      "ES2022",
+    ]);
+    expect(result.summary.esEditions.unclassified).toEqual([]);
+  });
+
   it("rejects duplicate or missing package rows instead of publishing a partial dashboard", () => {
     expect(() =>
       mergeNpmCompatPartials([partial(["acorn"]), partial(["acorn"])], {

--- a/website/components/npm-compat-chart.js
+++ b/website/components/npm-compat-chart.js
@@ -136,6 +136,67 @@ class NpmCompatChart extends HTMLElement {
     };
   }
 
+  /**
+   * The newest ECMAScript edition the package's own module graph requires.
+   *
+   * Syntax and library surface are shown separately when they differ, because
+   * the difference is the actionable part: react's grammar is ES5 (it ships
+   * transpiled) while its runtime needs ES2021 `AggregateError`, so "supports
+   * ES5" would not run it. The tooltip carries the evidence that set the
+   * number so a reader never has to take the badge on faith.
+   */
+  _editionBadge(pkg) {
+    const edition = pkg.esEdition;
+    if (!edition || !edition.requiredLabel) return "";
+    const split =
+      edition.syntaxLabel !== edition.requiredLabel || edition.builtinsLabel !== edition.requiredLabel
+        ? ` (syntax ${edition.syntaxLabel}, library ${edition.builtinsLabel})`
+        : "";
+    const top = [...(edition.evidence?.syntax ?? []), ...(edition.evidence?.builtins ?? [])]
+      .slice(0, 6)
+      .map((item) => `${item.feature} — ${item.file}:${item.line}`)
+      .join("\n");
+    const title = `Requires ${edition.requiredLabel}${split}. Classified from ${edition.scannedFiles} file${
+      edition.scannedFiles === 1 ? "" : "s"
+    } of this package's own module graph.${top ? `\n\n${top}` : ""}`;
+    return `<span class="badge edition" title="${this._esc(title)}">needs ${this._esc(edition.requiredLabel)}</span>`;
+  }
+
+  /**
+   * The corpus as an edition timeline: how many packages need each edition,
+   * oldest first. This is the "what must the compiler support to run real npm
+   * code" view — a single ES2022 package is a different piece of work from
+   * half the corpus needing it.
+   */
+  _editionStrip(data, pkgs) {
+    const rollup = data?.esEditions;
+    const editions = rollup?.editions ?? [];
+    if (editions.length === 0) return "";
+    const classified = editions.reduce((sum, entry) => sum + entry.count, 0);
+    const cells = editions
+      .map(
+        (entry) =>
+          `<span class="edition-cell" title="${this._esc(entry.packages.join(", "))}">
+            <span class="edition-label">${this._esc(entry.label)}</span>
+            <span class="edition-count">${entry.count}</span>
+          </span>`,
+      )
+      .join("");
+    const unclassified = rollup?.unclassified?.length
+      ? `<span class="edition-unclassified" title="${this._esc(rollup.unclassified.join(", "))}">${
+          rollup.unclassified.length
+        } unclassified</span>`
+      : "";
+    return `
+      <div class="edition-strip" title="${this._esc(rollup?.method ?? "")}">
+        <span class="edition-strip-title">Required ECMAScript edition</span>
+        <span class="edition-cells">${cells}</span>
+        <span class="edition-note">${classified} of ${pkgs.length} classified${
+          unclassified ? " · " : ""
+        }</span>${unclassified}
+      </div>`;
+  }
+
   _row(label, valueHtml, cls) {
     return `<div class="row"><span class="k">${this._esc(label)}</span><span class="v ${cls || ""}">${valueHtml}</span></div>`;
   }
@@ -612,7 +673,7 @@ class NpmCompatChart extends HTMLElement {
           pkg.capabilities?.nodeFs
             ? '<span class="badge" title="This compatibility lane explicitly grants the compiled package Node filesystem access.">fs enabled</span>'
             : ""
-        }${
+        }${this._editionBadge(pkg)}${
           // The entry is a re-export barrel with no implementation in it, so
           // the two badges above describe the barrel, not the package. Saying
           // so on the badge line is the point — a green "compiles" next to a
@@ -679,6 +740,7 @@ class NpmCompatChart extends HTMLElement {
         ${metric(`${compiling}/${pkgs.length}`, "compile")}
         ${metric(`${validating}/${pkgs.length}`, "validate")}
       </div>
+      ${this._editionStrip(data, pkgs)}
       <div class="chart-dashboard" data-target="standalone" data-precompilation="off">
         <div class="benchmark-toolbar">
           <div>
@@ -1040,6 +1102,27 @@ class NpmCompatChart extends HTMLElement {
           text-decoration: none;
         }
         .entry:hover { color: var(--text-muted, rgba(255,255,255,0.46)); text-decoration: underline; }
+        .edition-strip {
+          display: flex; align-items: baseline; flex-wrap: wrap; gap: 10px;
+          margin: 0 0 18px; padding: 10px 12px;
+          border: 1px solid var(--border, rgba(255,255,255,0.12)); border-radius: 8px;
+        }
+        .edition-strip-title { font-size: 12px; color: var(--text-muted, rgba(255,255,255,0.46)); }
+        .edition-cells { display: flex; flex-wrap: wrap; gap: 6px; }
+        .edition-cell {
+          display: inline-flex; align-items: baseline; gap: 5px;
+          padding: 2px 8px; border-radius: 999px;
+          border: 1px solid color-mix(in srgb, var(--accent, #7aa2f7) 40%, transparent);
+        }
+        .edition-label { font-size: 11px; color: var(--accent, #7aa2f7); }
+        .edition-count { font-size: 12px; font-weight: 600; }
+        .edition-note, .edition-unclassified {
+          font-size: 11px; color: var(--text-muted, rgba(255,255,255,0.46));
+        }
+        .badge.edition {
+          border-color: color-mix(in srgb, var(--accent, #7aa2f7) 45%, transparent);
+          color: var(--accent, #7aa2f7);
+        }
         .card-links {
           display: flex;
           flex-wrap: wrap;


### PR DESCRIPTION
## Description

The npm-compat dashboard said whether each package compiles, validates and passes its tests, but not what the package actually asks of the compiler — so a failure and a feature gap looked the same on the card, and the corpus could not answer the question that orders the work: **which ECMAScript edition must the compiler support to run real npm code?**

Every package row now carries an `esEdition` classification: the newest edition required by the package's **own module graph**, walked from its published entry module and stopping at the package boundary.

**Syntax and library surface are reported separately**, because they cost different work and fail differently — `a?.b` is ES2020 grammar no runtime can polyfill, while `Object.entries` is ES2017 library surface on ES5 grammar. The split is not academic: react's grammar is **ES5** (it ships transpiled) while its runtime needs **ES2021** `AggregateError`, so a compiler that "supports ES5" does not run react.

**The library map is derived, not hand-written.** TypeScript ships one `lib.es<year>.<area>.d.ts` per edition per area — the authoritative, maintained statement of which edition introduced which global, static and prototype member. The classifier reads those files and builds the map from them, so a new edition lands without anyone editing a table and every classification is traceable to a lib file. `lib.es*.intl.d.ts` is excluded: Intl is ECMA-402, a separate standard, and counting it would report a package as needing ES2020 for `Intl.DisplayNames`.

**What it refuses to claim** — a number that over-reports is not worth reading, so three cases deliberately never raise the edition: a bare prototype-method read (`x.flat()` is only `Array.prototype.flat` if `x` is an Array, which needs type information this classifier does not use — recorded as `heuristic` evidence instead), a shadowed global, and a package whose tarball is not extracted (reports `unavailable` rather than reading as ES5).

Following the module graph rather than the entry file alone is what makes the answer honest for a gate module: react's `index.js` is five lines that `require` one of two real builds, and classifying those five lines would report ES5 for a package whose implementation is not. External dependencies are counted, not followed, so a barrel package (lit) shows a visible `externalDependencies` count instead of a silent "ES5".

### Result — the corpus as a timeline

| Edition | Packages |
| --- | --- |
| ES2015 | clsx, jest, lit, lodash, lodash-es, moment, react-dom, styled-components |
| ES2018 | redux |
| ES2020 | axios, cookie, typescript, webpack |
| ES2021 | react, uuid |
| ES2022 | acorn, eslint, hono, jsdom, marked, prettier, tailwindcss |
| ES2025 | stylelint (`import … with { type: "json" }`) |
| ESNext | three (`Float16Array`) |

Two things fall out immediately: **every package that currently runs needs ES2022 or below** and the whole ES2025/ESNext tail fails, so the edition is a usable predictor of support; and **seven packages need ES2022**, the largest cluster above ES2015, making class fields and private members the highest-leverage grammar remaining.

The dashboard gains a per-card `needs ES####` badge (evidence in the tooltip) and a corpus-wide edition strip.

### Caught while wiring it

The sharded merge path (`mergeNpmCompatPartials`) **builds the shipped summary itself** rather than copying the generator's, so a rollup added only to the single-process generator would have been present in a local run and absent from every artifact CI publishes. It is rebuilt in both, with a regression test pinning it.

Verified locally: 37 tests across `tests/es-edition-classifier.test.ts` (new) and `tests/npm-compat-partials.test.ts`; a focused `generate-npm-compat-report.mjs --only clsx` run confirms `esEdition` lands in the artifact; typecheck, prettier and the LOC/function/coercion/oracle/dead-export gates green. The classifications above are from running the classifier over all 24 extracted packages, not from a table.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECD36tGCqAJofyLerMFaBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECD36tGCqAJofyLerMFaBG)_