### PR TITLE
fix(#5284): a namespace object survives an `export const`

### DIFF
--- a/plan/issues/5284-namespace-const-export-declines-object.md
+++ b/plan/issues/5284-namespace-const-export-declines-object.md
@@ -1,0 +1,81 @@
+---
+id: 5284
+title: "A single `export const` declines the whole module namespace object — `ns.CONSTANT` traps while `ns.fn()` works"
+status: done
+sprint: current
+created: 2026-09-03
+updated: 2026-09-03
+completed: 2026-09-03
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+`tryEmitCompiledModuleNamespaceObject` publishes a namespace object only when
+**every** runtime export of the imported module is an immutable top-level
+function declaration. `namespaceFunctionExports` declines the whole object
+otherwise:
+
+```ts
+// Mutable values require live-binding getters. Decline the entire object
+// rather than publishing a semantically-wrong snapshot.
+return undefined;
+```
+
+`export const` falls into that decline. The binding then goes through the
+identifier fallback and the member read traps:
+
+```ts
+// mod.ts
+export function f(s: string): number { return s.length; }
+export const N = 7;
+
+// entry.ts
+import * as m from "./mod.js";
+m.f("abc");   // → 3      (works)
+m.N;          // → [object WebAssembly.Exception]
+```
+
+Measured on `main` (e1285c756c) with `compileProject`, both when the exporting
+module is `.ts` and when it is `.js`; the named-import twin
+(`import { N } from "./mod.js"`) has always worked.
+
+## Fix
+
+`const` is the one binding form whose value is fixed once module
+initialization has run, so a snapshot of the exporting module's global is a
+correct namespace property — which is exactly the carve-out the
+"mutable values require live-binding getters" rule leaves open. The export
+scan now accepts a top-level `export const` whose binding name is an
+identifier backed by a `moduleGlobals` entry, and the namespace-object getter
+emits a `global.get` for it instead of a cached function-closure access.
+
+`let`, `var` and reassigned function declarations still decline the entire
+object, unchanged.
+
+The emitted `global.get` indices are re-resolved after the getter body is
+built, next to the existing cache-global recompute: reserving function-value
+caches and string constants adds import globals, which shifts the
+module-global range (`ctx.moduleGlobals` is shifted with it).
+
+## Acceptance criteria
+
+- [x] `ns.CONST` reads a numeric and a string `export const` on both `gc` and
+      `standalone`.
+- [x] A function export in the same namespace still calls.
+- [x] A module exporting `let` still declines the object (no snapshot).
+- [x] Regression test: `tests/module-namespace-const-export.test.ts` — 6 of
+      its 7 cases fail on the parent commit, all 7 pass with the fix.
+
+## Provenance
+
+Found while re-measuring the npm-compat upstream unit suites against current
+`main`. It is not itself a corpus blocker — the packages that were failing for
+this reason have since been fixed — but it is a live wrong-answer defect on a
+shape every ESM consumer writes.

--- a/src/codegen/module-namespace-value.ts
+++ b/src/codegen/module-namespace-value.ts
@@ -1,24 +1,50 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /** Runtime values for same-compilation ESM namespace imports. */
 
-import { ts } from "../ts-api.js";
 import type { GlobalDef, ValType, WasmFunction } from "../ir/types.js";
+import { ts } from "../ts-api.js";
 import { emitCachedFuncClosureAccess, ensureFuncClosureSingleton } from "./closures.js";
-import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { allocLocal } from "./context/locals.js";
 import { popBody, pushBody } from "./context/bodies.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
-import { coerceType } from "./shared.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
-import { stringConstantExternrefInstrs } from "./native-strings.js";
-import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
+import { coerceType } from "./shared.js";
 
 interface NamespaceFunctionExport {
+  readonly kind: "function";
   readonly key: string;
   readonly functionName: string;
   readonly funcIdx: number;
   readonly constructible: boolean;
+}
+
+/**
+ * A top-level `export const` of the imported module. `const` is the one binding
+ * form whose value is fixed once module initialization has run, so the snapshot
+ * this object publishes stays correct — which is exactly the carve-out the
+ * "mutable values require live-binding getters" rule below leaves open. `let`,
+ * `var` and reassigned function declarations still decline the whole object.
+ */
+interface NamespaceGlobalExport {
+  readonly kind: "global";
+  readonly key: string;
+  readonly globalName: string;
+}
+
+type NamespaceExport = NamespaceFunctionExport | NamespaceGlobalExport;
+
+/** `export const x = …` at the top level of the exporting module. */
+function immutableTopLevelConstName(ctx: CodegenContext, node: ts.Declaration): string | undefined {
+  if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name)) return undefined;
+  const list = node.parent;
+  if (!ts.isVariableDeclarationList(list) || (list.flags & ts.NodeFlags.Const) === 0) return undefined;
+  const statement = list.parent;
+  if (!ts.isVariableStatement(statement) || statement.parent !== statement.getSourceFile()) return undefined;
+  return ctx.moduleGlobals.has(node.name.text) ? node.name.text : undefined;
 }
 
 interface NamespaceObjectCache {
@@ -40,7 +66,7 @@ function cacheMap(ctx: CodegenContext): WeakMap<ts.NamespaceImport, NamespaceObj
 function namespaceFunctionExports(
   ctx: CodegenContext,
   declaration: ts.NamespaceImport,
-): readonly NamespaceFunctionExport[] | undefined {
+): readonly NamespaceExport[] | undefined {
   let moduleSymbol = ctx.checker.getSymbolAtLocation(declaration.name);
   if (!moduleSymbol) return undefined;
   if ((moduleSymbol.flags & ts.SymbolFlags.Alias) !== 0) {
@@ -51,7 +77,7 @@ function namespaceFunctionExports(
     }
   }
 
-  const exports: NamespaceFunctionExport[] = [];
+  const exports: NamespaceExport[] = [];
   for (const exportedSymbol of ctx.checker.getExportsOfModule(moduleSymbol)) {
     let target = exportedSymbol;
     if ((target.flags & ts.SymbolFlags.Alias) !== 0) {
@@ -65,6 +91,21 @@ function namespaceFunctionExports(
       target.valueDeclaration ?? target.declarations?.find((node) => !node.getSourceFile().isDeclarationFile);
     // Type-only exports do not exist on the runtime namespace object.
     if (declarationNode === undefined && (target.flags & ts.SymbolFlags.Value) === 0) continue;
+    if (declarationNode !== undefined) {
+      // `export const` is immutable after module init, so a snapshot of the
+      // exporting module's global is a correct namespace property. Without this
+      // arm a single `export const` in the module declined the WHOLE namespace
+      // object, and `ns.CONSTANT` trapped even though `ns.fn()` worked.
+      const constName = immutableTopLevelConstName(ctx, declarationNode);
+      if (constName !== undefined) {
+        exports.push({
+          kind: "global",
+          key: exportedSymbol.getName(),
+          globalName: constName,
+        });
+        continue;
+      }
+    }
     if (
       declarationNode === undefined ||
       !ts.isFunctionDeclaration(declarationNode) ||
@@ -96,7 +137,13 @@ function namespaceFunctionExports(
       declarationNode.asteriskToken === undefined &&
       !(declarationNode.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) ?? false);
     if (ensureFuncClosureSingleton(ctx, functionName, funcIdx, constructible) === null) return undefined;
-    exports.push({ key: exportedSymbol.getName(), functionName, funcIdx, constructible });
+    exports.push({
+      kind: "function",
+      key: exportedSymbol.getName(),
+      functionName,
+      funcIdx,
+      constructible,
+    });
   }
 
   // An empty module still has a real namespace object. In particular, a
@@ -180,14 +227,31 @@ export function tryEmitCompiledModuleNamespaceObject(
     kind: "externref",
   });
   getterFctx.body.push({ op: "local.set", index: objectLocal });
+  // `global.get` indices baked here can still move: reserving a function-value
+  // cache or a string constant adds import globals and shifts the module-global
+  // range. `ctx.moduleGlobals` is shifted with them, so remember each emitted
+  // read and re-resolve its index once the loop is done — the same treatment
+  // the cache global gets below.
+  const globalReads: {
+    instr: { op: "global.get"; index: number };
+    name: string;
+  }[] = [];
   for (const entry of exports) {
-    const valueType = emitCachedFuncClosureAccess(
-      ctx,
-      getterFctx,
-      entry.functionName,
-      entry.funcIdx,
-      entry.constructible,
-    );
+    let valueType: ValType | null;
+    if (entry.kind === "global") {
+      const globalIdx = ctx.moduleGlobals.get(entry.globalName);
+      const global = globalIdx === undefined ? undefined : ctx.mod.globals[globalIdx - ctx.numImportGlobals];
+      if (global === undefined) {
+        popBody(getterFctx, savedBody);
+        return undefined;
+      }
+      const instr = { op: "global.get" as const, index: globalIdx! };
+      getterFctx.body.push(instr);
+      globalReads.push({ instr, name: entry.globalName });
+      valueType = global.type;
+    } else {
+      valueType = emitCachedFuncClosureAccess(ctx, getterFctx, entry.functionName, entry.funcIdx, entry.constructible);
+    }
     if (valueType === null) {
       getterFctx.body.push({ op: "ref.null.extern" });
     } else if (valueType.kind !== "externref") {
@@ -203,6 +267,14 @@ export function tryEmitCompiledModuleNamespaceObject(
     getterFctx.body.push({ op: "call", funcIdx: finalSetIdx });
   }
   // Global indices may have moved while function-value caches were reserved.
+  for (const read of globalReads) {
+    const current = ctx.moduleGlobals.get(read.name);
+    if (current === undefined) {
+      popBody(getterFctx, savedBody);
+      return undefined;
+    }
+    read.instr.index = current;
+  }
   const finalCacheGlobalIdx = absoluteGlobalIndex(ctx, cacheGlobal);
   if (finalCacheGlobalIdx === undefined) {
     popBody(getterFctx, savedBody);
@@ -215,7 +287,12 @@ export function tryEmitCompiledModuleNamespaceObject(
 
   getterFctx.body.push({ op: "global.get", index: finalCacheGlobalIdx });
   getterFctx.body.push({ op: "ref.is_null" });
-  getterFctx.body.push({ op: "if", blockType: { kind: "empty" }, then: initBody, else: [] });
+  getterFctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: initBody,
+    else: [],
+  });
   getterFctx.body.push({ op: "global.get", index: finalCacheGlobalIdx });
   const getterTypeIdx = addFuncType(ctx, [], [{ kind: "externref" }]);
   const getterFuncIdx = mintDefinedFunc(ctx);

--- a/tests/module-namespace-const-export.test.ts
+++ b/tests/module-namespace-const-export.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5284 — a namespace object over a module that exports a `const`.
+//
+// `tryEmitCompiledModuleNamespaceObject` published an object only when EVERY
+// runtime export was an immutable top-level function; one `export const`
+// declined the whole object and sent the binding through the identifier
+// fallback, so `ns.CONSTANT` trapped at run time while `ns.fn()` in the very
+// same module worked. `const` is fixed after module init, which is exactly the
+// carve-out the "mutable values need live-binding getters" rule leaves open.
+
+import { describe, expect, it } from "vitest";
+import { compileMulti } from "../src/index.js";
+
+const MODULE = `
+  export const COUNT = 7;
+  export const LABEL = "hi";
+  export function twice(n) { return n * 2; }
+`;
+
+async function runEntry(entrySource: string, target: "gc" | "standalone"): Promise<unknown> {
+  const entry = "./entry.js";
+  const result = await compileMulti({ [entry]: entrySource, "./mod.js": MODULE }, entry, {
+    target,
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    deferTopLevelInit: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+
+  const imports = (result.importObject ?? {}) as Record<string, unknown>;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  const setExports = imports.__setExports ?? imports.setExports;
+  if (typeof setExports === "function") (setExports as (e: WebAssembly.Exports) => void)(instance.exports);
+  const setInstance = imports.__setInstance ?? imports.setInstance;
+  if (typeof setInstance === "function") (setInstance as (i: WebAssembly.Instance) => void)(instance);
+  const moduleInit = (instance.exports as Record<string, unknown>).__module_init;
+  if (typeof moduleInit === "function") (moduleInit as () => void)();
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#5284 module namespace over a const export", () => {
+  for (const target of ["gc", "standalone"] as const) {
+    it(`reads a numeric const through the namespace (${target})`, async () => {
+      expect(await runEntry(`import * as m from "./mod.js";\nexport function test() { return m.COUNT; }`, target)).toBe(
+        7,
+      );
+    });
+
+    it(`reads a string const through the namespace (${target})`, async () => {
+      // Standalone strings are WasmGC i16 arrays, so the value itself does not
+      // survive the boundary as a JS string — assert on it inside the module.
+      expect(
+        await runEntry(`import * as m from "./mod.js";\nexport function test() { return m.LABEL.length; }`, target),
+      ).toBe(2);
+    });
+
+    it(`still calls a function export from the same namespace (${target})`, async () => {
+      expect(
+        await runEntry(`import * as m from "./mod.js";\nexport function test() { return m.twice(m.COUNT); }`, target),
+      ).toBe(14);
+    });
+  }
+
+  it("declines the object for a mutable `let` export rather than snapshotting it", async () => {
+    // `let` can be reassigned after init, so a snapshot would be wrong. The
+    // binding keeps the pre-existing fallback behaviour: this asserts the gate
+    // still refuses, not that the read works.
+    const entry = "./entry.js";
+    const result = await compileMulti(
+      {
+        [entry]: `import * as m from "./mut.js";\nexport function test() { return typeof m; }`,
+        "./mut.js": `export let counter = 1;\nexport function bump() { counter += 1; }`,
+      },
+      entry,
+      {
+        target: "gc",
+        allowJs: true,
+        skipSemanticDiagnostics: true,
+        deferTopLevelInit: true,
+      },
+    );
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
`tryEmitCompiledModuleNamespaceObject` publishes a namespace object only when **every** runtime export of the imported module is an immutable top-level function declaration. A single `export const` makes `namespaceFunctionExports` decline the whole object; the binding then falls to the identifier fallback and the member read traps:

```ts
// mod.ts
export function f(s: string): number { return s.length; }
export const N = 7;

// entry.ts
import * as m from "./mod.js";
m.f("abc");   // → 3   (works)
m.N;          // → [object WebAssembly.Exception]
```

Measured on `main` (e1285c756c) via `compileProject`, with the exporting module written both as `.ts` and as `.js`. The named-import twin (`import { N } from "./mod.js"`) has always worked.

## Fix

`const` is the one binding form whose value is fixed once module initialization has run, so a snapshot of the exporting module's global is a correct namespace property — which is exactly the carve-out the existing comment leaves open:

> Mutable values require live-binding getters. Decline the entire object rather than publishing a semantically-wrong snapshot.

The export scan now accepts a top-level `export const` whose binding name is an identifier backed by a `moduleGlobals` entry, and the namespace-object getter emits a `global.get` for it instead of a cached function-closure access. `let`, `var` and reassigned function declarations still decline the entire object, unchanged.

The emitted `global.get` indices are re-resolved after the getter body is built, next to the existing cache-global recompute — reserving function-value caches and string constants adds import globals, which shifts the module-global range (`ctx.moduleGlobals` is shifted with it).

## Verification

- `tests/module-namespace-const-export.test.ts` (new): numeric const, string const, and a function export from the same namespace, on both `gc` and `standalone`, plus a case asserting a `let`-exporting module still declines. **6 of the 7 cases fail on the parent commit; all 7 pass here.**
- Neighbouring namespace suites (`#1058` ×3, `#4614`, `#5222`, `#4759`, consumer-driven barrels): 44 passing cases unchanged. The two `#4759` failures are the missing `test262` submodule in this environment — red before and after.

Issue: [#5284](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5284-namespace-const-export-declines-object)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
