### PR TITLE
fix(#5288): `typeof` on a numerically-used param no longer narrows to f64

### DIFF
--- a/plan/issues/5288-typeof-param-narrowed-to-f64.md
+++ b/plan/issues/5288-typeof-param-narrowed-to-f64.md
@@ -1,0 +1,90 @@
+---
+id: 5288
+title: "`typeof x` on a numerically-used parameter emits an INVALID module — f64 narrowing drops the undefined arm"
+status: done
+sprint: current
+created: 2026-09-03
+updated: 2026-09-03
+completed: 2026-09-03
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+loc-budget-allow:
+  - src/codegen/declarations/param-return-inference.ts
+---
+
+## Problem
+
+`inferParamTypeFromBody` narrows an implicit-`any` parameter to `f64` as soon
+as the body uses it numerically, and treats only `??` / `??=` as observing the
+distinction an f64 slot cannot carry:
+
+```ts
+// f64 cannot preserve the distinction this operation observes:
+// unboxing `undefined` yields NaN, but `undefined ?? fallback` must
+// select the fallback while `NaN ?? fallback` must not.
+```
+
+`typeof` observes exactly the same distinction, one operator over. An omitted
+argument pads the f64 slot with `0`, so `typeof size` answers `"number"` where
+the program requires `"undefined"`. And because the `typeof` lowering takes an
+**externref**, the narrowed parameter does not merely answer wrongly — it emits
+an **invalid module**:
+
+```
+WebAssembly.instantiate(): Compiling function "f" failed:
+  call[0] expected type externref, found local.get of type f64
+```
+
+Six-line repro (webpack's `formatSize` shape):
+
+```js
+// mod.js
+export function f(size) {
+  if (typeof size !== "number") return "unknown";
+  if (size <= 0) return "zero";      // ← the numeric use that narrowed it
+  return "n";
+}
+// entry.ts
+import { f } from "./mod.js";
+f();     // instantiation fails; before the numeric arm existed it answered "unknown"
+```
+
+The **arrow** spelling of the same body was already correct — it stays on the
+dynamic carrier — so the declaration form was the odd one out.
+
+## Fix
+
+Treat `typeof <param>` as a nullish-sensitive use, exactly as `??` already is.
+One arm in `inferParamTypeFromBody`'s visitor; the narrowing is unchanged for a
+parameter with no `typeof` use.
+
+## Measured
+
+- `tests/typeof-param-narrowing.test.ts`: 3 of its 5 cases fail on the parent
+  commit (two of them by failing to instantiate at all); all 5 pass with the
+  fix. The two that already passed are the guards — an argument that IS
+  supplied still takes the numeric arms, and a purely numeric parameter stays
+  narrowed.
+- Upstream npm suites re-run after the change: webpack 15/16, three 17/18,
+  clsx 32/32, cookie 63740/63740, lodash 50/62, redux 60/82 — all identical to
+  the pre-change baseline. No package moved, and none regressed.
+
+## Not fixed here (measured, adjacent)
+
+The same "optional parameter narrowed to a scalar" family has two more slices
+that this change does not reach, both reproduced in six lines:
+
+1. **`export default f` + JSDoc-optional param** answers `"zero"` for an
+   omitted argument. Exporting the identical function BY NAME is correct, and
+   so is the same default export without the JSDoc — so
+   `parameterMayBeOmitted` (which already names webpack's `formatSize` as its
+   witness) is not consulted on the default-export path. This is why webpack's
+   real `formatSize()` still answers `"0 bytes"`.
+2. **`@param {number} [size]`** (the bracketed JSDoc spelling) on an arrow that
+   is lifted to a closure emits the same invalid module in `__closure_0`; the
+   `{number=}` spelling of the same parameter is fine.

--- a/src/codegen/declarations/param-return-inference.ts
+++ b/src/codegen/declarations/param-return-inference.ts
@@ -959,6 +959,26 @@ export function inferParamTypeFromBody(
       }
     }
 
+    // (1b) `typeof x` — the same unrepresentable distinction as `??`, one
+    // operator over. An f64 slot cannot carry `undefined`: a call that omits
+    // the argument pads the slot with `0`, so `typeof size` answers `"number"`
+    // where the program requires `"undefined"`. Worse than a wrong answer, the
+    // `typeof` lowering takes an **externref**, so an f64-narrowed parameter
+    // emits an INVALID module — `call[0] expected type externref, found
+    // local.get of type f64`. Measured on webpack's `formatSize`:
+    //
+    //   function f(size) {
+    //     if (typeof size !== "number") return "unknown size";
+    //     if (size <= 0) return "0 bytes";   // ← the numeric use that narrowed
+    //     …
+    //   }
+    //
+    // The arrow-function spelling of the same body already stayed dynamic and
+    // answered correctly, so this only aligns the declaration form with it.
+    if (ts.isTypeOfExpression(node) && isReferenceTo(node.expression, param)) {
+      foundNullishSensitiveUse = true;
+    }
+
     // (2) param used in a numeric binary expression
     if (ts.isBinaryExpression(node)) {
       const op = node.operatorToken.kind;

--- a/tests/typeof-param-narrowing.test.ts
+++ b/tests/typeof-param-narrowing.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// `typeof x` on a parameter that is also used numerically.
+//
+// `inferParamTypeFromBody` narrowed an implicit-`any` parameter to `f64` on the
+// strength of one numeric use, treating only `??` / `??=` as observing the
+// difference an f64 slot cannot carry. `typeof` observes exactly the same
+// difference: an omitted argument pads the slot with `0`, so `typeof size`
+// answers `"number"` where the program requires `"undefined"`. And because the
+// `typeof` lowering takes an externref, the narrowed parameter did not merely
+// answer wrongly — it emitted an INVALID MODULE:
+//
+//   Compiling function "f" failed: call[0] expected type externref,
+//   found local.get of type f64
+//
+// The shape is webpack's `formatSize`; the arrow spelling of the same body was
+// already correct, so this only aligns the declaration form with it.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+/** The guard body: a `typeof` test followed by a numeric comparison. */
+const GUARD_BODY = `{ if (typeof size !== "number") return "unknown"; if (size <= 0) return "zero"; return "n"; }`;
+
+async function runProject(files: Record<string, string>, entry = "entry.ts"): Promise<unknown> {
+  const root = mkdtempSync(join(tmpdir(), "js2-typeof-param-"));
+  roots.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const target = join(root, name);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, source);
+  }
+  const result = await compileProject(join(root, entry), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  // The defect showed up here, not at compile time: instantiation is what
+  // rejects the invalid module.
+  const instance = await instantiateWithRuntime(result);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("typeof on a numerically-used parameter", () => {
+  it("keeps a same-file function declaration undefined-capable", async () => {
+    expect(
+      await runProject({
+        "entry.ts": `function f(size) ${GUARD_BODY}\nexport function test(): any { return (f as any)(); }`,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("keeps a cross-module ESM function declaration undefined-capable", async () => {
+    expect(
+      await runProject({
+        "mod.js": `export function f(size) ${GUARD_BODY}\n`,
+        "entry.ts": `import { f } from "./mod.js";\nexport function test(): any { return (f as any)(); }`,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("keeps a CommonJS `module.exports` function undefined-capable", async () => {
+    expect(
+      await runProject({
+        "mod.js": `function f(size) ${GUARD_BODY}\nmodule.exports = f;\n`,
+        "entry.ts": `import f from "./mod.js";\nexport function test(): any { return (f as any)(); }`,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("still takes the numeric arms when an argument IS supplied", async () => {
+    const files = {
+      "mod.js": `export function f(size) ${GUARD_BODY}\n`,
+      "entry.ts": `import { f } from "./mod.js";\nexport function test(): any { return [f(5), f(0), f(-1)]; }`,
+    };
+    expect(await runProject(files)).toEqual(["n", "zero", "zero"]);
+  });
+
+  it("leaves a purely numeric parameter narrowed", async () => {
+    // No `typeof`, so the f64 narrowing is still the right call — this asserts
+    // the gate did not widen every numerically-used parameter.
+    expect(
+      await runProject({
+        "entry.ts": `function g(n) { if (n <= 0) return "zero"; return "n"; }\nexport function test(): any { return [g(1), g(0)]; }`,
+      }),
+    ).toEqual(["n", "zero"]);
+  });
+});


### PR DESCRIPTION
`inferParamTypeFromBody` narrows an implicit-`any` parameter to `f64` on the strength of one numeric use, and treats only `??` / `??=` as observing the distinction an f64 slot cannot carry:

> f64 cannot preserve the distinction this operation observes: unboxing `undefined` yields NaN, but `undefined ?? fallback` must select the fallback while `NaN ?? fallback` must not.

`typeof` observes exactly the same distinction, one operator over. An omitted argument pads the f64 slot with `0`, so `typeof size` answers `"number"` where the program requires `"undefined"`. And because the `typeof` lowering takes an **externref**, the narrowed parameter does not merely answer wrongly — it emits an **invalid module**:

```
WebAssembly.instantiate(): Compiling function "f" failed:
  call[0] expected type externref, found local.get of type f64
```

Six-line repro, the shape of webpack's `formatSize`:

```js
// mod.js
export function f(size) {
  if (typeof size !== "number") return "unknown";
  if (size <= 0) return "zero";     // ← the numeric use that narrowed it
  return "n";
}
// entry.ts
import { f } from "./mod.js";
f();   // instantiation fails
```

The **arrow** spelling of the identical body already stayed on the dynamic carrier and answered correctly, so this only aligns the declaration form with it. One arm in the visitor; a parameter with no `typeof` use narrows exactly as before.

## Verification

- `tests/typeof-param-narrowing.test.ts` (new): same-file declaration, cross-module ESM, CommonJS `module.exports`, plus two guards. **3 of the 5 fail on the parent commit** — two of them by failing to instantiate at all — and all 5 pass here. The guards assert that a supplied argument still takes the numeric arms and that a parameter with no `typeof` use stays narrowed.
- Upstream npm suites re-run after the change: webpack 15/16, three 17/18, clsx 32/32, cookie 63740/63740, lodash 50/62, redux 60/82 — identical to the pre-change baseline. Nothing moved, nothing regressed.

## Adjacent, not fixed here

Two more slices of the same "optional parameter narrowed to a scalar" family, both reproduced in six lines and written up in the issue:

1. `export default f` + a JSDoc-optional param answers `"zero"` for an omitted argument, while exporting the same function *by name* is correct — so `parameterMayBeOmitted` (which already names `formatSize` as its witness) is not consulted on the default-export path. This is why webpack's real `formatSize()` still answers `"0 bytes"`.
2. `@param {number} [size]` on an arrow lifted to a closure emits the same invalid module in `__closure_0`; the `{number=}` spelling is fine.

Issue: [#5288](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5288-typeof-param-narrowed-to-f64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
