### PR TITLE
fix(#5294): widen a module reference slot that later receives a primitive

### DIFF
--- a/plan/issues/5294-reference-slot-module-global-drops-primitive.md
+++ b/plan/issues/5294-reference-slot-module-global-drops-primitive.md
@@ -1,0 +1,88 @@
+---
+id: 5294
+title: "A module `let` on a reference slot silently drops a primitive assignment and reads back `null`"
+status: done
+sprint: current
+created: 2026-09-03
+updated: 2026-09-03
+completed: 2026-09-03
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+func-budget-allow:
+  - src/codegen/declarations/heterogeneous-scalar-var-widening.ts::referenceSlotReceivesPrimitive
+---
+
+## Problem
+
+`moduleGlobalWasmType` commits a top-level binding's Wasm slot from its
+**initializer alone**, so `let x = { a: 1 }` becomes
+`(global $__mod_x (mut (ref null $obj)))`. A later `x = true` has nowhere to
+go, and `coerceType`'s terminal fallback is `drop` + `pushDefaultValue`:
+
+```wat
+(func $set
+  i32.const 1      ;; the boolean
+  drop             ;; ← discarded
+  ref.null 1       ;; ← stored instead
+  global.set 8
+```
+
+The module **validates** — this is a silent wrong answer, not a trap. Every
+read after the assignment answers `null`.
+
+This is #4204's defect in the opposite direction. That one widened a
+**primitive**-initialized slot that later received a reference
+(`var x = 2; x = {}` → `NaN`); this is a **reference**-initialized slot that
+later receives a primitive.
+
+## Extent (measured through `compileAndRunUpstreamModule`)
+
+| binding | later assignment | before |
+| --- | --- | --- |
+| `let x = { a: 1 }` | `x = true` / `5` / `"s"` / `undefined` | **`null`** |
+| `let x = [1, 2]` | `x = true` | **`null`** |
+| `let x = new C()` | `x = true` | **`null`** |
+| `var x = { a: 1 }` | `x = true` | **`null`** |
+| `let x = { a: 1 }` | `const v = 7; x = v` | **`null`** |
+| `let x = { a: 1 }` | `x = { b: 2 }` | ok |
+| `let x = { a: 1 }` | `x = null` | ok |
+| `let x = { a: 1 }` | (never reassigned) | ok |
+| function-local `let x = { a: 1 }` | `x = true` | ok |
+
+Only the module-global typer pins the slot from the initializer, which is why
+the function-local form is unaffected.
+
+## Fix
+
+Extend `heterogeneousWidenedModuleGlobalType` with the mirror predicate,
+`referenceSlotReceivesPrimitive`: a mutable, un-annotated, module-scoped
+binding whose initializer's static JS tag is `object`, and which some
+assignment in its own source file stores a value of a **provably** different
+tag into, is typed `externref`.
+
+Deliberately narrower than the primitive side's `assignmentWidens`, which
+widens on `mixed` (#4206):
+
+- **`mixed` does not widen here.** An object slot receiving an unconstrainable
+  value (`let cache = {}; cache = load()`) is the common shape in real module
+  code, it is already lowered correctly, and widening it would be a
+  representation change on a hot path bought with no evidence.
+- **`null` does not widen.** A nullable reference already carries it, and
+  `typeof null` is `"object"`, so the tag comparison excludes it on its own.
+- **A `function` initializer does not widen.** Closure-typed globals already
+  carry a later primitive correctly.
+- **An explicit annotation does not widen** — the same representation-contract
+  rule the primitive-side collector applies to its own initializer tag.
+- `||=` / `&&=` / `??=` are excluded from the compound-assignment table: they
+  store the right operand unchanged, which may well be a reference.
+
+## Measured
+
+- `tests/module-global-reference-slot-widening.test.ts`: 8 cases fail on the
+  parent commit and pass with the fix; 4 more are guards for the shapes the
+  widening deliberately leaves alone, and pass on both.

--- a/src/codegen/declarations/heterogeneous-scalar-var-widening.ts
+++ b/src/codegen/declarations/heterogeneous-scalar-var-widening.ts
@@ -73,10 +73,100 @@ export function heterogeneousWidenedModuleGlobalType(
   // same verdict so a conservatively demoted module initializer keeps the
   // representation chosen during selection.
   if (updateRetypesModuleBinding(ctx.oracle, decl)) return { kind: "externref" };
+  // The mirror image of the primitive-slot case below: a REFERENCE-initialized
+  // binding assigned a primitive. See {@link referenceSlotReceivesPrimitive}.
+  if (referenceSlotReceivesPrimitive(ctx.oracle, decl)) return { kind: "externref" };
   const widened = collectHeterogeneouslyAssignedModuleVarNames(ctx.oracle, sourceFile);
   // Deliberately does NOT tag `externrefAccessorVars`: this is a value-carrier
   // widening, not a host-property-access reroute.
   return widened.has(decl.name.text) ? { kind: "externref" } : undefined;
+}
+
+/** Compound assignments whose write-back is always a Number or a BigInt. */
+const NUMERIC_COMPOUND_ASSIGNMENTS: ReadonlySet<ts.SyntaxKind> = new Set<ts.SyntaxKind>([
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.MinusEqualsToken,
+  ts.SyntaxKind.AsteriskEqualsToken,
+  ts.SyntaxKind.AsteriskAsteriskEqualsToken,
+  ts.SyntaxKind.SlashEqualsToken,
+  ts.SyntaxKind.PercentEqualsToken,
+  ts.SyntaxKind.LessThanLessThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.AmpersandEqualsToken,
+  ts.SyntaxKind.BarEqualsToken,
+  ts.SyntaxKind.CaretEqualsToken,
+]);
+
+/**
+ * The mirror image of the primitive-slot widening above: a module `var`/`let`
+ * whose *reference* initializer pins a concrete struct/vec slot, and which some
+ * assignment stores a *primitive* into.
+ *
+ * `let x = { a: 1 }` types `__mod_x` as `(ref null $obj)` from the initializer,
+ * so a later `x = true` has nowhere to go. `coerceType`'s terminal fallback is
+ * `drop` + `pushDefaultValue`, and the module emits
+ *
+ *     i32.const 1     ;; the boolean
+ *     drop            ;; discarded
+ *     ref.null $obj   ;; stored instead
+ *
+ * which VALIDATES. Every read after the assignment silently answers `null` —
+ * the same class of loss #4204 fixed on the primitive side, in the other
+ * direction. Object, array and `new C()` initializers are all affected;
+ * function-local `let` is not, because only the module-global typer pins the
+ * slot from the initializer.
+ *
+ * Deliberately narrower than {@link assignmentWidens}: it fires only on a tag
+ * disagreement the compiler can PROVE, never on `mixed`. An object slot that
+ * receives an unconstrainable value is the overwhelmingly common shape in real
+ * module code (`let cache = {}; cache = load()`), it is already lowered
+ * correctly, and widening it would be a representation change on a hot path
+ * bought with no evidence. `null` is not a widening trigger either — a nullable
+ * reference already carries it, and `typeof null` is `"object"` so the tag
+ * comparison excludes it on its own.
+ */
+function referenceSlotReceivesPrimitive(ctx: CodegenContext["oracle"], decl: ts.VariableDeclaration): boolean {
+  // An explicit annotation is the representation contract (same rule the
+  // primitive-side collector applies to its own initializer tag).
+  if (decl.type !== undefined || decl.initializer === undefined) return false;
+  if (!ts.isIdentifier(decl.name) || !isModuleScoped(decl)) return false;
+  const list = decl.parent;
+  if (!ts.isVariableDeclarationList(list) || (list.flags & ts.NodeFlags.Const) !== 0) return false;
+  // Only a reference initializer pins a slot that cannot box a primitive. A
+  // `function` tag is excluded on purpose: closure-typed globals already carry
+  // the value correctly today, so widening them would move working code.
+  if (ctx.staticJsTypeOf(decl.initializer) !== "object") return false;
+
+  let receivesPrimitive = false;
+  const writesPrimitive = (assigned: ts.Expression): boolean => {
+    const tag = ctx.staticJsTypeOf(assigned);
+    return tag !== "mixed" && tag !== "object" && tag !== "function";
+  };
+  const targetsThisBinding = (target: ts.Expression): boolean =>
+    ts.isIdentifier(target) && ctx.variableDeclarationOf(target) === decl;
+
+  // The walk crosses nested functions: a callback body writes the same binding.
+  const visit = (node: ts.Node): void => {
+    if (receivesPrimitive) return;
+    if (ts.isBinaryExpression(node) && targetsThisBinding(node.left)) {
+      if (node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+        if (writesPrimitive(node.right)) {
+          receivesPrimitive = true;
+          return;
+        }
+      } else if (NUMERIC_COMPOUND_ASSIGNMENTS.has(node.operatorToken.kind)) {
+        // These write back the result of ToNumeric/ToBigInt by definition. The
+        // logical forms (`||=`, `&&=`, `??=`) are deliberately absent: they
+        // store the right operand unchanged, which may well be a reference.
+        receivesPrimitive = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(decl.getSourceFile());
+  return receivesPrimitive;
 }
 
 /**

--- a/tests/module-global-reference-slot-widening.test.ts
+++ b/tests/module-global-reference-slot-widening.test.ts
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// A module-scope `let`/`var` whose REFERENCE initializer pins a concrete
+// struct/vec slot, later assigned a PRIMITIVE.
+//
+// `moduleGlobalWasmType` commits the slot from the initializer, so
+// `let x = { a: 1 }` types `__mod_x` as `(ref null $obj)`. A later `x = true`
+// then has nowhere to go: `coerceType`'s terminal fallback is
+// `drop` + `pushDefaultValue`, and the module emits
+//
+//     i32.const 1     ;; the boolean
+//     drop            ;; discarded
+//     ref.null $obj   ;; stored instead
+//
+// The module VALIDATES — this is a silent wrong answer, not a trap. Every read
+// after the assignment answers `null`. This is #4204's defect in the opposite
+// direction: that one widened a PRIMITIVE-initialized slot that later received
+// a reference; this one widens a REFERENCE-initialized slot that later
+// receives a primitive.
+//
+// The fixtures are plain untyped `.js`, matching how the upstream npm suites
+// feed package code in. An explicit annotation (`let x: any = …`) selects the
+// externref slot up front and does NOT exercise this path at all.
+//
+// Function-local `let` is unaffected — only the module-global typer pins the
+// slot from the initializer — so the local case is included as a guard.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+const ENTRY = `import { run } from "./mod.js";\nexport function test(): number { return (run as unknown as () => number)(); }`;
+
+async function runModule(moduleSource: string): Promise<unknown> {
+  const root = mkdtempSync(join(tmpdir(), "js2-ref-slot-widen-"));
+  roots.push(root);
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, "mod.js"), moduleSource);
+  writeFileSync(join(root, "entry.ts"), ENTRY);
+  const result = await compileProject(join(root, "entry.ts"), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const instance = await instantiateWithRuntime(result);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("module global on a reference slot that later receives a primitive", () => {
+  it("stores a boolean into an object-literal-initialized `let`", async () => {
+    expect(
+      await runModule(`let x = { a: 1 };
+export function run() { x = true; return x === true ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("stores a number into an object-literal-initialized `let`", async () => {
+    expect(
+      await runModule(`let x = { a: 1 };
+export function run() { x = 5; return x === 5 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("stores a string into an array-literal-initialized `let`", async () => {
+    expect(
+      await runModule(`let x = [1, 2];
+export function run() { x = "s"; return x === "s" ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("stores a boolean into a `new C()`-initialized `let`", async () => {
+    expect(
+      await runModule(`class C { m() { return 1; } }
+let x = new C();
+export function run() { x = true; return x === true ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("stores a number into an object-initialized `var`", async () => {
+    expect(
+      await runModule(`var x = { a: 1 };
+export function run() { x = 7; return x === 7 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("distinguishes a stored `undefined` from the slot's null default", async () => {
+    expect(
+      await runModule(`let x = { a: 1 };
+export function run() { x = undefined; return x === undefined ? 1 : (x === null ? 2 : 0); }`),
+    ).toBe(1);
+  });
+
+  it("writes back a number through a compound assignment", async () => {
+    expect(
+      await runModule(`let x = { a: 1 };
+export function run() { x = 2; x += 3; return x === 5 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("stores a primitive assigned from a variable, not just a literal", async () => {
+    expect(
+      await runModule(`let x = { a: 1 };
+export function run() { const v = 9; x = v; return x === 9 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  // Guards — these already pass on the parent commit and must stay passing.
+  // Each one is a shape the widening deliberately does NOT fire on.
+
+  it("leaves an object-to-object reassignment on its concrete slot", async () => {
+    expect(
+      await runModule(`let x = { a: 1 };
+export function run() { x = { b: 2 }; return x.b === 2 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("leaves a never-reassigned binding alone", async () => {
+    expect(
+      await runModule(`let x = { a: 1 };
+export function run() { return x.a === 1 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("keeps a function-local `let` working", async () => {
+    expect(await runModule(`export function run() { let x = { a: 1 }; x = true; return x === true ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("does not widen a `const` binding", async () => {
+    expect(
+      await runModule(`const x = { a: 1 };
+export function run() { return x.a === 1 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
`moduleGlobalWasmType` commits a top-level binding's Wasm slot from its **initializer alone**, so `let x = { a: 1 }` becomes `(ref null $obj)`. A later `x = true` then has nowhere to go, and `coerceType`'s terminal fallback is `drop` + `pushDefaultValue`:

```wat
i32.const 1      ;; the boolean
drop             ;; ← discarded
ref.null 1       ;; ← stored instead
global.set 8
```

The module **validates** — this is a silent wrong answer, not a trap. Every read after the assignment answers `null`.

This is [#4204](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4204-heterogeneous-scalar-var-widening)'s defect in the opposite direction: that one widened a *primitive*-initialized slot that later received a reference; this widens a *reference*-initialized slot that later receives a primitive. Same module, same entry point.

## Extent (measured through `compileAndRunUpstreamModule`)

| binding | later assignment | before |
| --- | --- | --- |
| `let x = { a: 1 }` | `x = true` / `5` / `"s"` / `undefined` | **`null`** |
| `let x = [1, 2]` | `x = true` | **`null`** |
| `let x = new C()` | `x = true` | **`null`** |
| `var x = { a: 1 }` | `x = true` | **`null`** |
| `let x = { a: 1 }` | `const v = 7; x = v` | **`null`** |
| `let x = { a: 1 }` | `x = { b: 2 }` | ok |
| `let x = { a: 1 }` | `x = null` | ok |
| function-local `let x = { a: 1 }` | `x = true` | ok |

Only the module-global typer pins the slot from the initializer, which is why the function-local form is unaffected.

## Why the predicate is narrower than the primitive side's

`assignmentWidens` widens on `mixed` ([#4206](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4206-heterogeneous-mixed-rhs-widens)). This one does not:

- **`mixed` does not widen.** `let cache = {}; cache = load()` is the common shape in real module code, it is already lowered correctly, and widening it would be a representation change on a hot path bought with no evidence.
- **`null` does not widen** — a nullable reference already carries it, and `typeof null` is `"object"`, so the tag comparison excludes it on its own.
- **A `function` initializer does not widen**; those already carry a later primitive correctly.
- **An explicit annotation does not widen** — the representation contract, the same rule the primitive-side collector applies to its own initializer tag.
- `||=` / `&&=` / `??=` are excluded from the compound-assignment table: they store the right operand unchanged, which may well be a reference.

## Measured

- `tests/module-global-reference-slot-widening.test.ts`: **8 cases fail on the parent commit and pass with the fix**; 4 more are guards for the shapes the widening deliberately leaves alone, and pass on both.
- **A/B on 17 upstream npm suites at one HEAD** (webpack, three, clsx, cookie, lodash, redux, axios, stylelint, tailwindcss, jsdom, styled-components, uuid, marked, moment, prettier, jest, hono): every package number identical — no regressions.

Issue: [#5294](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5294-reference-slot-module-global-drops-primitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)