### PR TITLE
docs(#4444): 2026-09-03 ES2015 standalone census + six r3 implementation plans (563 rows, 54 steps)

### DIFF
--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -1166,6 +1166,68 @@ Source artifacts:
    pass/fail/compile-error counts, and integrate the checkpoint into the sole
    upstream draft PR #5010.
 
+## 2026-09-03 re-measurement of the 297-row checkpoint — now 233 rows, and the cross-cluster leverage
+
+Filed by the #4444 ES2015 closeout lane, not by this issue's owner: this lane
+is CLAIMED by `claude/es6-team-generators` (claim ref, since 2026-08-15) and is
+demonstrably live (`src/codegen/generators-native.ts` last moved on `main` at
+085ad75506 and 5890005e85, 2026-09-01), so nothing here is an attempt to take
+it over. It is a measurement handed to the owner, plus the reason it matters
+more than its own cluster suggests.
+
+**The 2026-08-26 checkpoint's 297 is now 233.** Same exact-text predicate (the
+sequential-numeric refusal, or a `__create_generator` / `__gen_*` token),
+re-run against the standalone baseline fetched 2026-09-03 08:13 UTC (rows
+stamped 09:07 UTC, `oracle_lane: "honest"`, so post-#5461 leak-checked) crossed
+with the ES2015 edition map. **64 rows cleared** since the checkpoint. All 233
+are still `compile_error`.
+
+| kind | rows | 08-26 | Δ |
+| --- | ---: | ---: | ---: |
+| carrier / import leak | 137 | 193 | −56 |
+| native-plan refusal (sequential numeric yields) | 95 | 104 | −9 |
+| `wasm_compile` naming `__gen_resume_g` | 1 | 1 | 0 |
+| **total** | **233** | **297** | **−64** |
+
+**The part that is easy to miss from inside this issue: only 46 of the 233 are
+in the generators cluster.** The rest sit in other clusters' residual lists,
+where the lane that owns the cluster cannot fix them:
+
+| cluster | generator-blocked rows | that cluster's total non-pass |
+| --- | ---: | ---: |
+| expressions | 91 | 244 |
+| generators | 46 | 121 |
+| class | 45 | 191 |
+| for-of + collections | 35 | 101 |
+| statements + lang | 13 | 75 |
+| module-code | 2 | 25 |
+| proxy + reflect | 1 | 157 |
+
+So this one lane gates **233 of the 1,756 remaining ES2015 standalone rows
+(13.3%), and 59% of all 391 compile_errors** — by a wide margin the largest
+single lever left toward the 100% goal, and larger than any whole cluster.
+Concretely: `language/expressions` cannot get past ~63% until this lands, no
+matter what the expressions lane does, because 91 of its 244 residual rows are
+this refusal.
+
+Two consequences for whoever picks this up:
+
+- **The cluster r3 plans being written today (typedarray, class, proxy+reflect,
+  array+object, promise, for-of) must EXCLUDE these rows from what they claim**,
+  or six plans will each promise rows only this lane can deliver. The
+  per-cluster path lists are in `.tmp/census0903/`; the 233 are isolated in
+  `.tmp/census0903/_gen.tsv`.
+- **The two biggest signature groups are still the two the checkpoint named.**
+  94 rows carry the canonical sequential-numeric refusal (the C01 group, which
+  the checkpoint already warned is a signature and not a bucket), and 137 carry
+  a carrier/import leak whose largest variants differ only in which `__gen_*`
+  helpers the module reached for. The `## S3 design note — yield POSITION
+  admission (measured, not implemented)` in this file is the piece that the
+  94-row group is waiting on.
+
+Reproduce: `.tmp/census0903/census.mjs`, then
+`grep -aE '__create_generator|__gen_|native generator lowering' .tmp/census0903/*.tsv`.
+
 ## ES2015 exact 297-row classification checkpoint (2026-08-26)
 
 This is the first closeout checkpoint from the authoritative ES2015 run. It is classification-only: no candidate gate was widened and no standalone result was credited without a host control. The next implementation checkpoint must start from the reduced groups below.

--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -64,6 +64,30 @@ for**: 948 in the six lanes planned on 09-03, 441 in the two waves in flight,
 to emit rather than a wrong answer, so it needs a feature, not a fix. Any plan
 that counts rows without splitting fail from CE is over-promising.
 
+### Cross-cutting blockers — 281 rows no cluster lane can fix
+
+Three defects are not clusters at all: they are single missing capabilities
+whose rows are scattered across other lanes' residual lists. A cluster plan
+that counts them is promising rows it cannot deliver.
+
+| blocker | issue | rows | where they sit |
+| --- | --- | ---: | --- |
+| standalone native generator lowering | #2864 (claimed, live) | 233 | expressions 91 · generators 46 · class 45 · for-of 35 · statements 13 · module-code 2 · proxy 1 |
+| `Reflect.construct` with a distinct NewTarget | #3371 (design checkpoint PR #5400) | 33 | proxy+reflect 11 · typedarray 11 · other built-ins 6 · expressions 2 · promise 2 · array+object 1 |
+| `Reflect.set` with an explicit receiver | #2046 (design checkpoint PR #5397) | 15 | proxy+reflect 7 · typedarray 6 · statements 2 |
+
+**281 rows, 16% of the residual.** Net of them, the six lanes planned today can
+claim at most: typedarray 227, class 146, proxy+reflect 138, array+object 136,
+promise 116, for-of+collections 66. Two caveats on that arithmetic — the 44
+`env::Promise_*` leaks inside the promise cluster and the 3 RegExp-engine
+refusals inside the regexp cluster are *those lanes' own scope*, so they are
+not subtracted; and #3371/#2046 are the proxy+reflect lane's own subject
+matter, held at design checkpoints rather than blocked elsewhere, so #5196's
+plan should treat its 18 as dependent-on-design rather than out of scope.
+
+Reproduce the split with the predicate in the commit that added this section;
+the generator rows are isolated in `.tmp/census0903/_gen.tsv`.
+
 ## 2026-09-02 post-wave census — 9,905 / 11,704 (84.6%), +232 rows in one day
 
 Source: `node scripts/fetch-baseline-jsonl.mjs --standalone --force` fetched

--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -18,6 +18,52 @@ related: [2860, 2864, 2865, 2867, 2906, 3032, 3178, 2161, 2175, 2158, 2159, 4445
 
 # #4444 — UMBRELLA: ES6 (ES2015) standalone edition close-out
 
+## 2026-09-03 census — 9,948 / 11,704 (85.0%), full residual coverage
+
+Source: `node scripts/fetch-baseline-jsonl.mjs --standalone --force` fetched
+2026-09-03 08:13 UTC (row timestamps 09:07 UTC, `oracle_lane: "honest"`, i.e.
+post-#5461 so every number is leak-checked), edition map
+`website/public/benchmarks/results/test262-file-editions.json` (`ES2015`).
+Reproduce with `.tmp/census0903/census.mjs`; per-cluster TSVs (path, status,
+truncated error) land in `.tmp/census0903/`.
+
+**ES2015 standalone: 9,948 pass / 11,704 (85.0%) — 1,756 non-pass**
+(1,364 fail · 391 compile_error · 1 compile_timeout), up from **9,905 / 11,704
+(84.6%)** at the 2026-09-02 census: **+43 rows**, from PR #5505 (statements +
+language semantics r2, #5271) and the other lanes that landed overnight.
+
+Note the clustering here is the one in `.tmp/census0903/census.mjs`, which
+differs from the 09-02 census: `class` and `generators` are pulled out of
+`language/expressions` and `language/statements` first, so `expressions` here
+collects what is left of `language/expressions/*`. Compare cluster *sizes*
+across censuses only via that script, not against the 09-02 table.
+
+| Cluster | rows | fail | CE | owner / state |
+| --- | ---: | ---: | ---: | --- |
+| expressions | 244 | 147 | 96 | #5270 — lane complete, in validation |
+| typedarray | 244 | 226 | 18 | #5194 — r2 landed (#5479), r3 planned 09-03 |
+| other built-ins | 197 | 178 | 19 | #5269 — lane complete, in round-3 review |
+| class | 191 | 135 | 56 | #5195 — r2 landed (#5489), r3 planned 09-03 |
+| proxy + reflect | 157 | 133 | 24 | #5196 — **never dispatched**, r3 planned 09-03 |
+| regexp | 140 | 130 | 10 | #5198 codex lane (checkpoint PR #5393) |
+| array + object | 137 | 127 | 10 | #5268 — r2 partial (#5494), r3 planned 09-03 |
+| generators | 121 | 75 | 46 | #680 / #2864 / #1691 codex lane (PR #5063 held) |
+| promise | 118 | 68 | 50 | #5197 — slices B–D landed (#5454), r3 planned 09-03 |
+| for-of + collections | 101 | 65 | 36 | #5267 — r2 landed (#5458), r3 planned 09-03 |
+| statements + lang | 75 | 55 | 20 | #5271 r2 landed (#5505) — residual unowned |
+| module-code | 25 | 19 | 6 | #4759 codex closeout lane |
+| rest | 6 | 6 | 0 | unowned |
+
+The cluster sizes sum to exactly 1,756, so **every non-pass row is accounted
+for**: 948 in the six lanes planned on 09-03, 441 in the two waves in flight,
+286 in codex lanes, and 81 (statements + lang residual, rest) still unowned.
+
+**The 391 compile_errors are the harder half.** They are not spread evenly —
+`expressions` (96), `class` (56), `promise` (50), `generators` (46) and
+`for-of + collections` (36) hold 71% of them, and a compile_error is a refusal
+to emit rather than a wrong answer, so it needs a feature, not a fix. Any plan
+that counts rows without splitting fail from CE is over-promising.
+
 ## 2026-09-02 post-wave census — 9,905 / 11,704 (84.6%), +232 rows in one day
 
 Source: `node scripts/fetch-baseline-jsonl.mjs --standalone --force` fetched

--- a/plan/issues/5194-es2015-standalone-typedarray-r2.md
+++ b/plan/issues/5194-es2015-standalone-typedarray-r2.md
@@ -5,7 +5,7 @@ status: in-progress
 pr: 5300
 sprint: current
 created: 2026-08-29
-updated: 2026-09-01
+updated: 2026-09-03
 priority: high
 horizon: l
 feasibility: medium
@@ -46,6 +46,15 @@ loc-budget-allow:
   - src/codegen/builtin-value-read.ts
   - src/codegen/native-proto-value-read.ts
   - src/codegen/ta-ctor-meta.ts
+  # 2026-09-03 r3 plan — dyn-view method resolution + per-method native
+  # helpers (see "Implementation Plan — r3 (2026-09-03)" → "Budget rationale").
+  # Two NEW files carry the mechanism so dataview-native.ts / call-receiver-
+  # method.ts do not absorb ~1,000 lines; the rest are splices into existing
+  # ladders (prototype walk, closure bodies, one finalize call, species /
+  # re-validate / ctor arms, 2-arg mapper, Symbol pre-test, $IterRec proto arm).
+  - src/codegen/ta-dyn-method-call.ts
+  - src/codegen/ta-dyn-proto-methods.ts
+  - src/codegen/index.ts
 func-budget-allow:
   - src/codegen/dataview-native.ts::ensureTaDynSetHelper
   - src/codegen/dataview-native.ts::emitTaDynCtorConstructFromLocals
@@ -73,6 +82,21 @@ func-budget-allow:
   # §23.2.6.2 `prototype` get_meta + gOPD arm pair (one splice ladder over one
   # native, so the arms belong in it rather than in a parallel filler).
   - src/codegen/ta-ctor-meta.ts::fillTaCtorGetMetaArm
+  # 2026-09-03 r3 plan — wasm-body emitters in the two new files exceed the
+  # 300-line ceiling the way ensureTaDynSetHelper does; the existing functions
+  # below gain one spliced arm each (rationale per step in the r3 section).
+  - src/codegen/ta-dyn-method-call.ts::unshiftExternMethodCallTaDynViewArm
+  - src/codegen/ta-dyn-proto-methods.ts::ensureTaDynSearchHelper
+  - src/codegen/ta-dyn-proto-methods.ts::ensureTaDynHofHelper
+  - src/codegen/ta-dyn-proto-methods.ts::ensureTaDynSortHelper
+  - src/codegen/ta-dyn-proto-methods.ts::ensureTaDynIteratorHelper
+  - src/codegen/ta-dyn-proto-methods.ts::ensureTaDynJoinHelper
+  - src/codegen/dataview-native.ts::emitTaDynSpeciesCreate
+  - src/codegen/dataview-native.ts::ensureTaDynFillHelper
+  - src/codegen/dataview-native.ts::ensureTaDynCopyWithinHelper
+  - src/codegen/dataview-native.ts::ensureTaFromArrayLikeHelper
+  - src/codegen/expressions/call-receiver-method.ts::tryEmitTaStaticOfFrom
+  - src/codegen/iterator-native.ts::ensureNativeArrayFromMapped
 ---
 
 # #5194 — typedarray r2: cluster and fix the 461 residual failures
@@ -1416,3 +1440,596 @@ than walk.
 The same row on the STANDALONE lane fails identically on the pre-#5479 base
 (`Expected a TypeError to be thrown but no exception was thrown at all`), so
 that lane is a pre-existing gap and not part of this park.
+
+## Implementation Plan — r3 (2026-09-03)
+
+Planner pass on `main` `bee5ddd535` (branch `claude/es6-test262-standalone-g10c7u`,
+identical to `origin/main`). Input: the 2026-09-03 09:07 UTC standalone
+baseline crossed with the ES2015 edition list — **244 non-pass rows** in
+`.tmp/census0903/typedarray.tsv` (226 `fail`, 18 `compile_error`). Nothing
+below restates the r2 sections; it starts from the r2 "Leftovers" and the
+2026-09-02 review findings F3/F4.
+
+### Step 0 — what changed since r2, and the one finding that reorders everything
+
+The r2 leftover 1 said the `any`-receiver rows never reach the
+`array-methods.ts` two-arm and must be wired through the `taFillIdx` block in
+`call-receiver-method.ts`. That is true but incomplete. Measured on this tree
+with WAT call-graph probes (`.tmp/census0903/probes/wat-fn-index.mts`, which
+resolves every `call N` inside one function to its name):
+
+- A local `var sample = new TA([...])` receiver compiles `sample.includes(42)`
+  to `__call_m_includes_1`, `sample.sort(cmp)` to `__call_m_sort_1`,
+  `sample.keys()` to `__call_m_keys_0`, `sample.every()` to `__call_m_every_0`,
+  `sample.map(cb)` to `__call_m_map_1` (`fillClosedMethodDispatch`). A
+  **parameter** receiver (`function g(a) { a.includes(42) }`) skips the closed
+  dispatcher and calls **`__extern_method_call`** directly. Every `__call_m_*`
+  bottoms out in `__extern_method_call` too. So the single convergence point
+  for dyn-view method calls is `__extern_method_call` (object-runtime.ts
+  L6444), not the `taFillIdx` two-arm.
+- **`__extern_get(view, "<method>")` answers `undefined`** — probe
+  `.tmp/census0903/probes/p9-shapes.js`:
+  `typeof sample.includes === "undefined"`, `typeof sample.sort`,
+  `typeof sample.keys` likewise, while `Object.getPrototypeOf(sample) ===
+  TA.prototype` is true. Root cause: `ta-dyn-mop.ts:buildStringKeyArm` (L532)
+  walks the prototype ONLY inside `constructorLookup` (L690, key
+  `"constructor"`); every other non-index string key that misses the expando
+  returns `missInstrs()` (L640 `legacyMiss` — `undefined` for get, `0` for has)
+  without consulting `__getPrototypeOf(recv)`. That is why the seeded
+  `%TypedArray%.prototype.<m>` closure singletons (r2 step 1/2) are unreachable
+  from an instance, why `HasProperty/inherited-property.js` fails, and why
+  `unshiftExternMethodCallProtoArm`-style dispatch cannot work for views yet.
+- With no method resolution, `__extern_method_call` falls to its generic
+  `$__vec_base` arms (the dyn view subtypes `$__vec_base`,
+  `registry/types.ts` L582): `includes` → the NUMBER `1`/`0` (probe p1/p8:
+  `includes(42)=number:1`; the SAME defect hits a plain any-array — an
+  arrays-cluster note, not claimed here), `indexOf()` → `0`, `join` works,
+  `at(1)` → `undefined`, `sort`/`keys` → `null`, `every()` → no throw, and
+  `map`'s callback never sees the view (`third=undefined`).
+
+Consequence: the r2 plan's per-call-site wiring (steps 3.2–3.5) is replaced by
+ONE runtime mechanism (step r3-1) plus per-method native helpers behind it. The
+helpers are the same ones r2 asked for; only the dispatch changes.
+
+### Step 0b — re-verification (15 rows, current main, fixed runner)
+
+```
+npx tsx scripts/run-test262-paths.mts .tmp/census0903/ta-r3-probe1.txt --standalone
+=== counts ===
+{ fail: 15 }
+```
+
+All 15 sampled rows (one per group below, list in
+`.tmp/census0903/ta-r3-probe1.txt`) fail with the baseline's error text, e.g.
+`includes/search-found-returns-true.js` → `Expected SameValue(«1», «true»)`,
+`sort/comparefn-calls.js` → `calls comparefn`, `keys/return-itor.js` →
+`Cannot read properties of undefined (reading 'next')`,
+`every/callbackfn-not-callable-throws.js` → `no args Expected a TypeError`,
+`join/return-abrupt-from-separator.js` → `illegal cast`,
+`fill/coerced-indexes.js` → `` `null` end coerced to 0 ``,
+`from/mapfn-arguments.js` → `SameValue(«3», «2»)`,
+`OwnPropertyKeys/integer-indexes.js` → `result1`,
+`map/speciesctor-get-ctor-inherited.js` → `SameValue(«true», «undefined»)`.
+Full output: `.tmp/census0903/ta-r3-probe1.out`. No group turned out to pass;
+nothing is dropped for staleness. The leak check (#5461) is active in this lane
+(`tests/issue-5272-runner-standalone-leak.test.ts` was 7/7 on the r2 tree and
+the runner is unchanged since).
+
+### Cluster table (244 rows, by root cause)
+
+Per-row: `.tmp/census0903/ta-sorted.txt` (`path|status|error`, sorted by error).
+
+| # | root cause | rows | fix step |
+|---|---|---:|---|
+| K1 | `ArrayBuffer/*` + `DataView/*` rows the census filed under "typedarray" (slice species ×13, isView ×5, prop-desc, proto, NewTarget CEs ×4, …) | 36 | **out of scope — #5150** (buffers lane; `tests/issue-5150-es2015-buffers.test.ts`). Do not touch `ArrayBuffer.prototype.slice`/`isView` here. |
+| K2 | `Reflect.construct` distinct NewTarget CE (`ctors/*/custom-proto-access-throws.js` ×5, `typedarray-arg/throw-type-error-before-custom-proto-access.js`) | 6 | out — #3371 |
+| K3 | `Reflect.set` explicit receiver CE (`internals/Set/*reflect-set.js`, `*receiver-is-*`) | 6 | out — #2046 |
+| K4 | `Function.prototype.call is not yet implemented` (`Symbol.species/result.js`, `Symbol.toStringTag/this-*` ×2, `from|of/custom-ctor-returns-other-instance.js`) | 5 | out — builtins lane cluster M (`.tmp/es2015/builtins-cl-M-function-call-value.txt`) |
+| K5 | native generator as ctor argument (`object-arg/as-generator-iterable-returns.js`) | 1 | out — #680/#2864 |
+| C0 | **dyn-view method resolution**: `__extern_get`/`__extern_has` never walk the prototype for ordinary string keys; `__extern_method_call` has no `$__ta_dyn_view` arm | — | r3-1 (foundation; every C/D row depends on it) |
+| C3 | `includes`/`indexOf`/`lastIndexOf` on dyn views: boolean-as-number, 0-arg → 0, fromIndex ToInteger/Symbol/abrupt/−0 not observed, detached not validated (14+7+7 minus 3 `invoked-as-method`) | 25 | r3-2 |
+| D | callback HOFs: IsCallable not checked (`*-not-callable*` ×7), callback's 3rd arg / `this` reads not the view, writes during iteration invisible, detach-inside-callback (×5) and on entry (×5), `filter` empty-result null deref (`every`/`some`/`forEach` ×3 each, `find`/`findIndex` ×2 each, `reduce`/`reduceRight` ×2 each, `map` ×3, `filter` ×4) | 24 | r3-3 |
+| C1 | `sort`: never runs (comparefn not called, `null` returned) | 12 | r3-4 |
+| C2 | `keys`/`values`/`entries`: `null` (return-itor ×3, iter-prototype ×3, detached-buffer ×3) | 9 | r3-4 |
+| C4 | `join`/`toLocaleString`/`toString`: separator reaches `__str_flatten` uncast (illegal cast ×5), per-element `toLocaleString`/`toString`/`valueOf` not invoked (×9), detached (×3) — minus `join/invoked-as-method` | 16 | r3-5 |
+| F | species residual: `get-ctor-inherited` ×4, `get-{ctor,species}-returns-throws` ×8, `custom-ctor-invocation` ×4, `custom-ctor-returns-another-instance` ×2, `slice` same-buffer offset, `map` empty-length, `subarray` instanceof | 21 | r3-6 |
+| E | ValidateTypedArray after argument coercion: `fill/coerced-*-detach` ×3, `copyWithin/coerced-values-*-detached*` ×3, `fill|copyWithin|reverse/detached-buffer` ×3, `subarray/{detached-buffer,byteoffset-with-detached-buffer}` | 11 | r3-7 |
+| G | index coercion: `null` end → 0 (`fill/coerced-indexes`, `copyWithin/coerced-values-end`), Symbol begin/end → TypeError (`slice`/`subarray` ×4), `set` reads past `src.length` | 7 | r3-7 |
+| H | constructor argument protocols (`object-arg` ×12, `typedarray-arg` ×4, `buffer-arg/toindex-*` ×2, `length-arg/toindex-length`, `no-species`) | 20 | r3-8 |
+| I | `from`/`of`: mapfn arity, IsCallable order, abrupt propagation as the original error (×8 `Expected a Test262Error but got a TypeError`), `invoked-as-func`/`not-a-constructor` ×4, `.call(customCtor)` ×4 (`Cannot read properties of undefined (reading 'call')`), `inherited` ×2, `mapper-detaches-result` ×2, `into-itself` (leak `env::__unwrap_for_wasm`, #2961) | 23 | r3-9 |
+| J | integer-indexed MOP: `OwnPropertyKeys` ×4, `DefineOwnProperty` ×5, `HasProperty` ×2 (fixed by r3-1's `has` walk), `Set/*prototype-chain-set` ×2 | 13 | r3-10 (+r3-1) |
+| C5 | `TypedArrayPrototype.<m>()` on the prototype for `includes`/`indexOf`/`lastIndexOf`/`join`/`slice` — probe p10: `sort()` throws (the `$NativeProto` arm reaches the seeded refusal closure) but these five route through `__extern_toString`/`__get_member_name` (a string-flavoured any-receiver lowering that claims the call before the `$NativeProto` arm) | 5 | DEFERRED (see r3-11) |
+| B | `%TypedArray%()` must throw; `length`/`byteLength` getters invoked through a var-held prototype; `Symbol.toStringTag/invoked-as-func` | 4 | DEFERRED (r3-11) |
+
+Out of scope: **54**. In scope: **190** (C3 25 + D 24 + C1 12 + C2 9 + C4 16 +
+F 21 + E 11 + G 7 + H 20 + I 23 + J 13 + C5 5 + B 4).
+
+### Common rules for every step
+
+- Standalone lane only (`noJsHost(ctx)` / `ctx.standalone` gates); no new
+  `env::*` import anywhere — the runner fails the whole module on a leak. The
+  host (gc) lane must stay byte-identical: assert it on the controls below.
+- Type questions through `ctx.oracle` (`src/checker/oracle.ts`); never
+  `ctx.checker.getTypeAtLocation` (oracle-ratchet gate). None of the steps below
+  needs a new type query — they are runtime-shape arms — so a new `checker.*`
+  call is a review flag, not a need.
+- Reserve-time minting only: every `ensureTaDyn*Helper` is a defined function
+  appended while the call site compiles (the same discipline as
+  `ensureTaDynFillHelper`); finalize passes only READ `funcMap` (#1719). Never
+  rebuild a native body at finalize; every throw sequence is a fresh `Instr[]`
+  per arm (#1058, #5194 F5).
+- `FunctionContext` literals: use `makeTaDynHelperFctx` (dataview-native.ts
+  L7407 — export it) so `labelMap: new Map()` and `savedBodies: []` are always
+  present.
+- Measurement: `npx tsx scripts/run-test262-paths.mts <list> --standalone`, one
+  process at a time, batches ≤ 15 paths on this box; `--isolate` for any list
+  with `$DETACHBUFFER` rows. Sub-lists: `.tmp/es2015/ta-cl-<X>.txt` still match
+  these clusters (C3/D/C1/C2/C4/F/E/G/H/I/J); regenerate from
+  `.tmp/census0903/ta-sorted.txt` if a fresh clone lacks them.
+- Controls after EVERY step, both lanes where the file is lane-agnostic:
+  `.tmp/es2015/ta-controls.txt` (21 rows, 21/21 on r2), `.tmp/es2015/ta-passing-all.txt`
+  (84 r2 flips, 84/84), `.tmp/es2015/arrobj-controls.txt` (20 array/object rows —
+  the `$__vec_base` arms the new dyn-view arm sits in front of), the 25-row
+  `set` cohort in `tests/issue-5194-es2015-typedarray-set-r2.test.ts`, and
+  `tests/issue-5194-es2015-typedarray-r2.test.ts` (11/11 incl. the F3
+  characterization control and the host `class extends null` pin).
+
+#### Step r3-1 — dyn-view method resolution and the `__extern_method_call` arm (foundation, 0 rows alone; C0)
+
+Root cause: C0 above. Two edits, both runtime-shape, both gated on
+`ctx.moduleUsesDynTaView` (set by the pre-scan, `dataview-native.ts` L3121) so a
+module without a dynamic view is **byte-identical**.
+
+1. `src/codegen/ta-dyn-mop.ts:buildStringKeyArm` (L532): factor the
+   prototype section of `constructorLookup` (L690–L760: `__getPrototypeOf(recv)`
+   → null ⇒ fallback; else `selfIdx(proto, key)`; for `get`, an `undefined`
+   result falls back) into `inheritedLookup(fallback: Instr[])` and call it from
+   `missInstrs()` for `mode === "get"` and `mode === "has"` on the
+   ordinary-key path (the `// get / has / delete: no expando → legacy miss`
+   branch at L672 and the expando-miss delegate right after it): expando own hit
+   → unchanged; expando miss (or no expando) → `inheritedLookup(legacyMiss)`.
+   `set`/`reflect_set`/`delete` keep their exact bodies (r3-10 owns `[[Set]]`
+   with a prototype-chain receiver). The `"constructor"` arm keeps its own
+   `constructorLookup` (its `namedValue` fallback differs) — do not merge them.
+   ORDER: expando own → prototype → legacy miss; the `@@toStringTag` symbol arm
+   (L770) and the intrinsic named props (`length`/`buffer`/…) stay BEFORE this
+   path exactly as today.
+2. New file `src/codegen/ta-dyn-method-call.ts` exporting
+   `unshiftExternMethodCallTaDynViewArm(ctx)`, a twin of
+   `native-proto-method-call.ts:unshiftExternMethodCallProtoArm` (read its
+   header — the "why FINALIZE" and "absent-not-wrong" rules apply verbatim):
+   `block { recv any.convert_extern ref.test $__ta_dyn_view; i32.eqz; br_if 0;
+   … }` unshifted onto `__extern_method_call` at finalize, called from
+   `src/codegen/index.ts` immediately after `unshiftExternMethodCallProtoArm(ctx)`
+   (L6354, and the profiled twin at L10961) and BEFORE `fillTaDynViewMopArms`
+   (L6438). Body, in order: (a) if the view's expando (`struct.get` field 4) is
+   non-null and `__hasOwnProperty(expando, name)` → `br_if 0` (an own
+   `view.includes = fn` shadows, §7.3.2); (b) a `ref.eq` ladder against the
+   INTERNED name globals (the #3673 round-9 pattern already inside
+   `__extern_method_call`, L6480–L6520 — `addStringConstantGlobal` +
+   `stringConstantExternrefInstrs`) for every method name whose helper exists
+   in `funcMap` at finalize (`__ta_dyn_<m>`); on a hit: unpack `argc`/`a0..a2`
+   from the `$ObjVec` args (the `loadArgs` shape at L6490) and
+   `return call __ta_dyn_<m>(recv, a0|null, a1|null, a2|null, argc)`;
+   (c) no hit → fall through to the untouched body. A rope/runtime-built name
+   misses the `ref.eq` and keeps today's behaviour — documented residual, not a
+   regression. The four existing helpers (`set`/`fill`/`copyWithin`/`reverse`)
+   join the ladder for free; the `taFillIdx` two-arm at
+   `call-receiver-method.ts` L4051 stays (it is a faster exit for the same
+   helpers and its bytes must not change).
+3. Helper registry: new file `src/codegen/ta-dyn-proto-methods.ts` with
+   `TA_DYN_PROTO_METHOD_HELPERS: ReadonlyMap<string, (ctx) => number | undefined>`
+   (name → ensure function; r3-2…r3-5 fill it) and
+   `ensureTaDynProtoMethodHelper(ctx, name)`. Reserve-time hook: in
+   `compileReceiverMethodCall`, where `taFillIdx` is computed (L4051–L4058),
+   add `else if (TA_DYN_PROTO_METHOD_HELPERS.has(methodName))
+   ensureTaDynProtoMethodHelper(ctx, methodName)` (mint only — the existing
+   two-arm keeps its four names), and call the same ensure at the two direct
+   `__extern_method_call` emit sites (L4400 and L4517) when
+   `ctx.moduleUsesDynTaView`. Also mint on `.call`/`.apply`-shaped reads of
+   `TypedArray.prototype.<m>` (`builtin-value-read.ts` value read) so the
+   closure body of step r3-1.4 has its helper.
+4. Seeded closure bodies (so `TypedArray.prototype.includes.call(view, 42)`
+   and `inherited.js`-style value reads dispatch too): in
+   `array-object-proto.ts:emitTypedArrayProtoMemberBody` (L1813), before the
+   refusal at L1829, `if (TA_DYN_PROTO_METHOD_HELPERS.has(member) &&
+   ctx.funcMap.has("__ta_dyn_<member>"))` emit: `local.get 1` (`this`)
+   `ref.test $__ta_dyn_view` → `call __ta_dyn_<member>(this, p2..p4 or null,
+   argc = paramSlots)` else `emitBrandCheckTypeError` (the existing cascade —
+   this is what keeps every `invoked-as-method.js` row green). Closure param
+   layout per `ensureStandaloneNativeMethodClosure` (native-proto.ts L1000–
+   L1040): 0 = self, 1 = `this`, 2… = `paramSlots` externrefs; treat an
+   `undefined` slot as absent (every §23.2.3 method defaults `undefined` the
+   same way an absent argument does — verified for fill/copyWithin/set/includes/
+   indexOf/lastIndexOf/join/sort/slice/subarray).
+
+Growth grant: `ta-dyn-mop.ts` +60 (`buildStringKeyArm` +40),
+`ta-dyn-method-call.ts` new ≈ 180, `ta-dyn-proto-methods.ts` new (registry
+≈ 60 now, grows in r3-2…r3-5), `index.ts` +6, `call-receiver-method.ts` +12
+(`compileReceiverMethodCall` +10), `array-object-proto.ts` +40
+(`emitTypedArrayProtoMemberBody` +30).
+
+Acceptance (this step ships alone, before any helper):
+- Probe `.tmp/census0903/probes/p9-shapes.js` must read
+  `typeof sample.includes=function sameAsProtoMember=true`, and
+  `internals/HasProperty/inherited-property.js` +
+  `internals/HasProperty/key-is-not-canonical-index.js` flip (2 rows).
+- **Passing shapes at risk**: (i) species `constructor` lookup —
+  `tests/issue-4449-species-controls.test.ts` 5/5 and
+  `tests/issue-2872-ta-dynview-reduce-includes.test.ts` 9/9 unchanged;
+  (ii) expando reads/writes — a control program `view.foo = 1; view.foo;
+  "foo" in view; view.nosuch === undefined; "nosuch" in view === false` on BOTH
+  lanes; (iii) `set`/`fill`/`copyWithin`/`reverse` on dyn views — the 25-row
+  `set` cohort and `tests/issue-2872-copywithin-reverse.test.ts` green, and the
+  `wasm_sha` of `built-ins/TypedArray/prototype/set/array-arg-set-values.js`
+  identical before/after (the `taFillIdx` two-arm must not move);
+  (iv) modules without a dynamic view — `wasm_sha` identical before/after on
+  three non-TA rows (`language/statements/class/subclass/class-definition-null-proto-super.js`,
+  one `built-ins/Array/prototype/map/*` row and one `built-ins/Map/*` row from
+  `ta-controls.txt`/`arrobj-controls.txt`), because every edit is gated on
+  `moduleUsesDynTaView` or on a `$__ta_dyn_view` type that such modules never
+  register; (v) `arrobj-controls.txt` 20/20 both lanes.
+
+#### Step r3-2 — search helpers: `__ta_dyn_includes` / `__ta_dyn_indexOf` / `__ta_dyn_lastIndexOf` (C3, 25 rows, expect ≥ 22)
+
+Root cause: C3. One `ensureTaDynSearchHelper(ctx, name)` in
+`ta-dyn-proto-methods.ts`, 5-slot ABI, body: `pushTaDynMethodPreamble`
+(export it, L7324) → `emitTaDynViewValidate` (detached/OOB → TypeError; the
+three `detached-buffer.js` rows) → `len` = `pushTaDynViewInBoundsLen` (the
+INTERNAL length, never the expando — `get-length-uses-internal-arraylength`) →
+`len == 0` → return boxed `false`/`-1` BEFORE reading `fromIndex`
+(§23.2.3.16 step 4; `length-zero-returns-false`) → `fromIndex` = `argc >= 2`
+? ToIntegerOrInfinity(a1) : default: reuse the Symbol pre-test +
+`coerceType(externref→f64)` + NaN→0 + `f64.trunc` sequence of
+`emitToIntegerI32FromArgLocal` (L5298 — factor its first 30 lines into an
+exported `emitToIntegerF64FromArgLocal` with no RangeError) so a Symbol throws
+TypeError (`*-fromindex-symbol` ×3) and an abrupt `valueOf` propagates
+(`return-abrupt-tointeger-fromindex` ×3; `__unbox_number`'s `@@toPrimitive`
+path throws through, as the set helper already relies on); `-0` → `+0`
+(`fromIndex-minus-zero` ×3); `+∞` → miss, `-∞` → 0 for forward /
+miss for backward (`fromIndex-infinity`); `lastIndexOf` default `len-1` and
+`n ≥ 0 ? min(n, len-1) : len+n`. Elements: `emitTaDynViewToVec` into a
+`$__vec_f64` (one decode pass; `searchelement-not-integer` reads the f64
+value), search target `ToNumber`-free: `includes` compares with SameValueZero
+on f64 (`f64.eq` OR both-NaN — `samevaluezero`); `indexOf`/`lastIndexOf` with
+strict `f64.eq` (NaN never matches). A non-number search element (object,
+string, undefined) can never match a numeric element → return the miss result
+without coercing it (`__unbox_number` must NOT be called on it — it would
+invoke `valueOf`). Results: `includes` → `__box_boolean`
+(`search-found-returns-true` ×3), index → `__box_number`.
+
+Rows: `ta-cl-C3-search.txt` minus the three `invoked-as-method.js`.
+Growth: `ta-dyn-proto-methods.ts` +220 (`ensureTaDynSearchHelper` ≈ 200 —
+grant), `dataview-native.ts` +10 (export of the factored ToInteger).
+Acceptance: the 22 rows; **at risk**: `Array.prototype.includes/indexOf` on
+`any` arrays keep the closed dispatcher's `$__vec_base` arm (the new arm is
+`ref.test $__ta_dyn_view`-gated and sits in `__extern_method_call`, not in
+`__call_m_*`) — `arrobj-controls.txt` 20/20 and a control program
+`var a: any = [1, NaN]; a.includes(NaN) === true; a.indexOf(1) === 0` on both
+lanes; `String.prototype.includes` on an `any` string
+(`"abc".includes("b")` through a parameter) unchanged on both lanes.
+
+#### Step r3-3 — callback HOFs on dyn views (D, 24 rows, expect ≥ 18)
+
+Root cause: D. `ensureTaDynHofHelper(ctx, name)` for `every`/`some`/`forEach`/
+`find`/`findIndex`/`reduce`/`reduceRight`/`map`/`filter`, 5-slot ABI, body:
+preamble → `emitTaDynViewValidate` (`detached-buffer` ×5 on entry) →
+`__typeof_function(a0)` else TypeError (`*-not-callable*` ×7 — this fixes r2
+leftover 3 for real: the guard lives in OUR helper, minted at reserve time with
+`ensureLateImport(ctx, "__typeof_function", …)` resolved BEFORE the body, so it
+is never compiled out) → then:
+- scalar family: `call __hof_<name>(recv = THE VIEW, cb, thisArg|init,
+  [hasInit = argc >= 2])` (`ensureNativeArrayHof`, hof-native.ts L83). Passing
+  the view itself (not a materialized vec) makes `__extern_length`/
+  `__extern_get_idx` go through the dyn-view MOP arms: live reads
+  (`callbackfn-set-value-during-*`), `this`/3rd argument = the view
+  (`callbackfn-arguments-*`), and a detach inside the callback reads `undefined`
+  from IntegerIndexedElementGet without throwing (`callbackfn-detachbuffer` ×5,
+  §23.2.3: "Let kValue be ! Get(O, Pk)") — verify the `__extern_get_idx`
+  dyn-view arm answers `undefined` (not a trap) on a negative buffer length;
+  if it traps, add the `buf.length < 0 → undefined` test to that arm in
+  `fillTaDynViewMopArms` (L341 index-key arm). `reduce`/`reduceRight` on empty
+  with no init already throw (r2).
+- `map`/`filter`: run `__hof_map`/`__hof_filter` over the view (same live
+  semantics) → `$ObjVec` result → `emitTaDynSpeciesCreate` with
+  `argLocals = [boxed count]` (`filter`: count = result length; `map`: len) →
+  `emitTaDynViewWriteF64Vec` from the `$ObjVec` (add an `$ObjVec` source arm:
+  `__unbox_number` per element — `map/callbackfn-return-*` rows already pass, so
+  keep the width conversion identical to `ta-hof-map-filter.ts`' store) —
+  count 0 must skip the copy loop (`filter/result-empty-callbackfn-returns-false`
+  null deref in `__any_unbox_bool`).
+Rows: `ta-cl-D-callback-hof.txt` (16) + the 8 `detached-buffer`/`callbackfn-detachbuffer`
+rows of `every`/`some`/`forEach`/`find`/`findIndex`/`reduce`/`reduceRight` (in
+`ta-cl-E-detach-validate.txt`) — `--isolate`.
+Growth: `ta-dyn-proto-methods.ts` +260 (`ensureTaDynHofHelper` ≈ 240 — grant),
+`ta-dyn-mop.ts` +15 if the detached `undefined` read is missing.
+Acceptance: the rows; **at risk**: `__hof_*` bodies are NOT edited (byte-identity
+of `__hof_map` in a plain-array module — hash one `built-ins/Array/prototype/map`
+row); static-carrier `map`/`filter` (`tests/issue-4449-species-producers.test.ts`,
+`tests/issue-2872-findlast-dynview.test.ts`) unchanged; the F3 characterization
+control still RED-by-design (unchanged verdict).
+
+#### Step r3-4 — `sort` and the three iterator factories (C1 12 + C2 9 = 21 rows, expect ≥ 17)
+
+- `ensureTaDynSortHelper`: preamble → validate → `a0` neither `undefined` nor
+  callable → TypeError BEFORE any read (`comparefn-nonfunction-call-throws`;
+  `null` is NOT undefined → TypeError, `comparefn-is-undefined` passes
+  `undefined`) → `emitTaDynViewToVec` → stable merge sort over the f64 array
+  (`merge-sort.ts:emitStableMergeSort(fctx, opts)` — read its
+  `MergeSortEmitOptions`; the comparator hook is an `Instr[]` producing an i32)
+  with comparator: default = numeric (`x < y`, `-0` before `+0` via
+  `i64.reinterpret` sign, NaN last — `sorted-values-nan`, `sort-tonumber`,
+  `sortcompare-with-no-tostring`), user = `__apply_closure(cb, undefined,
+  [box(x), box(y)])` → `__unbox_number` → NaN→0 → sign (`comparefn-calls`,
+  `stability`; abrupt propagates: `comparefn-call-throws`) → write back with
+  `emitTaDynViewWriteF64Vec(resultDv = recv)` → return `recv`
+  (`return-same-instance`). Ignore the expando `length`
+  (`arraylength-internal`). Do not call `compileArraySort` (string sort).
+- `ensureTaDynIteratorHelper(ctx, "keys"|"values"|"entries")`: preamble →
+  validate (`detached-buffer` ×3) → `emitTaDynViewToVec` → build the canonical
+  externref `$Vec` exactly as `compileNativeArrayIterator` does
+  (`array-methods.ts` L3090+: values box each f64, keys box the index, entries
+  build a 2-slot `$ObjVec` pair) → `struct.new $IterRec{ITER_KIND_VEC, vec, 0,
+  null}` (`iterator-native.ts` L3446 `iterRecAdoptArm` shape;
+  `getOrRegisterIterRecType`, `ensureNativeIteratorRuntime`) → externref. The
+  record's `next` must resolve (`return-itor` ×3) and
+  `Object.getPrototypeOf(it) === Object.getPrototypeOf([][Symbol.iterator]())`
+  (`iter-prototype` ×3): reuse `emitArrayIteratorPrototypeSingleton`
+  (array-object-proto.ts L3882) — check how `__getPrototypeOf` answers for an
+  `$IterRec` today (the #3013 arm in `call-builtin-static.ts` L2240) and make
+  the dyn-view records take the same arm; if `$IterRec` has no
+  `__getPrototypeOf` arm at all, that is the row's real defect — add it in
+  `object-runtime.ts:prependBuiltinFnObjectSemantics` next to the
+  `$NativeProto → $parent` arm (r2 step 1.1).
+Rows: `ta-cl-C1-sort.txt`, `ta-cl-C2-iterators.txt`.
+Growth: `ta-dyn-proto-methods.ts` +330 (`ensureTaDynSortHelper` ≈ 220,
+`ensureTaDynIteratorHelper` ≈ 110 — grant both), `object-runtime.ts` +20.
+Acceptance: the rows; **at risk**: plain-array `sort`/`keys` on `any` receivers
+(`arrobj-controls.txt`), `for (x of view)` (a currently-passing shape that goes
+through `iterRecAdoptArm`, not through `.values()` — control program on both
+lanes: `for (const v of new TA([1,2])) s += v`), and `[...view]`.
+
+#### Step r3-5 — `join` / `toLocaleString` / `toString` (C4, 16 rows, expect ≥ 12)
+
+`ensureTaDynJoinHelper(ctx, "join"|"toLocaleString")`: preamble → validate
+(`detached-buffer` ×3; `toString` aliases `Array.prototype.toString` per r2 —
+its detached row passes once `join` validates, because that alias calls
+`join`) → separator: `argc >= 1 && a0 !== undefined` ? `ToString(a0)` via the
+native `__extern_toString` (object-runtime.ts, standalone-registered) —
+Symbol → TypeError, abrupt `toString` → propagate (`return-abrupt-from-separator*`
+×2, and the two `custom-separator-*` illegal casts) — BEFORE the element loop
+(§23.2.3.15 step 5) : `","` → elements via `emitTaDynViewToVec` + the
+number→string path `compileArrayJoinNative` uses (array-methods.ts L5583; reuse
+its per-element formatter, do not reimplement `Number::toString`). For
+`toLocaleString`: per element `__extern_method_call(box(elem), "toLocaleString",
+[])` so a `Number.prototype.toLocaleString` override installed by the test is
+observed and its abrupt completion propagates (`calls-*-from-each-value` ×3,
+`return-abrupt-from-*` ×6) — this depends on `__extern_method_call`'s boxed-
+number receiver resolving `Number.prototype` members through the #4248 arm;
+probe `(5).toLocaleString()` with an override FIRST; if it does not resolve,
+scope this half to the 6 abrupt rows via `__extern_get(Number.prototype,
+"toLocaleString")` and record the 3 remaining as residual.
+Rows: `ta-cl-C4-join-tolocale.txt` minus `join/invoked-as-method.js`.
+Growth: `ta-dyn-proto-methods.ts` +180 (`ensureTaDynJoinHelper` ≈ 160 — grant).
+Acceptance: rows; **at risk**: `view.join()` and `String(view)` /
+`"" + view` on dyn views currently pass through the `$__vec_base` arm —
+control: `new TA([1,2]).join("-") === "1-2"` and `String(new TA([1]))` on both
+lanes; the arrays `join` rows in `arrobj-controls.txt`.
+
+#### Step r3-6 — species residual (F, 21 rows, expect ≥ 14)
+
+`dataview-native.ts:emitTaDynSpeciesCreate` (L6000): (a) the `constructor`
+read (L6097–L6110) already uses `__extern_get`; after r3-1 the read reaches
+the per-kind prototype's inherited getter, so `get-ctor-inherited` ×4 needs
+only: do NOT read `constructor` a second time anywhere in the producer (grep
+the callers: `emitDynViewSpeciesMethodTwoArm` L1522 and the r3-3 map/filter
+path) — re-measure first; (b) `false`/`42`/`"str"` constructor or species →
+the `typeErrorArm("TypedArray constructor is not an object")` at L6121 is
+reached only for `ref.is_null`; add `__typeof_object(C) == 0 && !isUndefined`
+→ TypeError (`get-ctor-returns-throws` ×4) and, after the species read,
+`species` non-nullish and `__reflect_is_constructor == 0` → TypeError
+(`get-species-returns-throws` ×4 — the L6169 check exists; verify it fires
+for `false`, which is a boxed boolean, not null); (c) the `@@species` getter
+must be invoked with `this` = C (`custom-ctor-invocation` ×4 asserts
+`this instanceof C`): the read at L6136 goes through `__extern_get(C,
+@@species)`, which invokes the accessor with `this` = C already — the failing
+half is the ARGUMENT tuple: `map`/`filter` `[count]`, `slice` `[count]`,
+`subarray` `[buffer, byteOffset, count]` — check `options.argLocals` at each
+caller; (d) a custom ctor returning ANOTHER dyn view: the result is that view
+(`custom-ctor-returns-another-instance` ×2 fail with "returned a
+non-TypedArray" → the driver's return is not the returned object; read
+`native-construct.ts:reserveNativeConstructDriver` L143 for how a closure
+constructor's explicit object return is surfaced, and pass it through);
+(e) `slice` same-buffer species result → snapshot the source before writing
+(`return-same-buffer-with-offset`); (f) `map` over length 0 still goes through
+species (`return-new-typedarray-from-empty-length`); (g) `subarray`
+`instanceof` — re-measure after r3-1 (prototype identity from r2 step 1.4).
+Rows: `ta-cl-F-species.txt`. Growth: `dataview-native.ts` +60
+(`emitTaDynSpeciesCreate` +50 — grant), `array-methods.ts` +20
+(`emitDynViewSpeciesMethodTwoArm` +15).
+Acceptance: rows; **at risk**: every currently-passing `speciesctor-*` row
+(`ta-passing-all.txt` holds them), `tests/issue-4449-species-{controls,producers}.test.ts`,
+`tests/issue-5385*`-era species identity (`result.constructor === TA` — probe
+P4 in the r2 section).
+
+#### Step r3-7 — validate-after-coercion and index coercion (E 11 + G 7 = 18 rows, expect ≥ 12)
+
+- `ensureTaDynFillHelper` (L6543) / `ensureTaDynCopyWithinHelper` (L7434):
+  keep `emitTaDynViewValidate` at entry (the `detached-buffer` rows) and add
+  a second `emitTaDynViewValidate` AFTER the last argument coercion and
+  BEFORE the write loop (§23.2.3.8 step 3 then IsDetachedBuffer re-check —
+  `coerced-*-detach` ×3, `coerced-values-*-detached*` ×3). Note the test
+  detaches from inside `valueOf`: the coercion must run through
+  `coerceType(externref→f64)`'s `@@toPrimitive`/`valueOf` route (it does —
+  `emitRelativeIndex` L6620). `reverse` validates at entry already; re-measure.
+  `subarray` must NOT throw when detached (§23.2.3.27); `byteOffset` reads 0
+  (`byteoffset-with-detached-buffer`) — that row fails with
+  `Cannot perform operation on a detached ArrayBuffer`: find the throw in
+  `emitTaViewDynamicByteOffset` (L4725) and return 0 for a detached buffer.
+- G: in both helpers the `end` (and copyWithin `start`) test
+  `argc >= 3 && !nullish(end)` treats `null` as absent; spec: only
+  `undefined` is absent, `null` → ToInteger → 0. Replace the
+  `__nullish_to_null` + `ref.is_null` test with `__extern_is_undefined` (a null
+  externref is JS `null` under the #2106 regime, so test `undefined` only
+  and let `null` coerce). Rows `fill/coerced-indexes`,
+  `copyWithin/coerced-values-end`. `slice`/`subarray` begin/end in
+  `emitDynViewSpeciesMethodTwoArm` go through `__unbox_number` (L1580+): add the
+  Symbol pre-test (`ctx.symbolTypeIdx` `ref.test` → TypeError, the
+  `emitToIntegerI32FromArgLocal` L5305 shape) — `return-abrupt-from-*-symbol`
+  ×4. `set/array-arg-set-values-in-order`: `ensureTaDynSetHelper`'s array-like
+  loop must stop at `ToLength(src.length)` read ONCE (L6960+).
+Growth: `dataview-native.ts` +70 (`ensureTaDynFillHelper` +20,
+`ensureTaDynCopyWithinHelper` +20 — grant both), `array-methods.ts` +25.
+Acceptance: rows (`--isolate`); **at risk**: the 25-row `set` cohort,
+`tests/issue-2872-copywithin-reverse.test.ts`, `tests/issue-3054-c-resizable.test.ts`
+(resizable-buffer OOB rows use the same validate), and `fill(v, s, undefined)`
+still meaning "to the end" — control program on both lanes.
+
+#### Step r3-8 — constructor argument protocols (H, 20 rows, expect ≥ 12)
+
+`emitTaDynCtorConstructFromLocals` (L5393) as r2 step 6.1 specified, with
+these corrections from reading the current arms: the plain-vec filter is at
+**L5773** (`carrierKey !== "f64" && … "i32_elem" && … "externref"`) — admit
+`i8_byte`/`i16_byte` and read signedness/width from the SOURCE carrier's
+storage entry (`typedarray-arg/returns-new-instance`,
+`other-ctor-returns-new-typedarray`); the `$Object` arm (L5560–L5700) already
+does `GetMethod(@@iterator)` with the non-callable TypeError — the failing rows
+are (i) `iterator-is-null-as-array-like` (`@@iterator` = `null` takes
+`arrayLikeArm` — check that `instanceof` fails because the result is built by
+a different carrier; measure `Object.getPrototypeOf(result)`), (ii)
+`iterator-throws`/`iterating-throws` (the abrupt completion is rewrapped:
+`__array_from_iter_n` L1779 drains and throws TypeError — propagate the
+original), (iii) `iterated-array-with-modified-array-iterator` (the `$ObjVec`
+fast arm L5726 skips the iterator protocol for a plain array whose
+`Array.prototype[@@iterator]` the test replaced — gate the fast arm on
+`!sourceOverridesBuiltinPrototypeMember(anchor, "Array", "@@iterator")`
+(`builtin-proto-member-override.ts` L111, a source scan, no checker), (iv)
+`throws-setting-obj-*` ×5 — element conversion in `emitTaExternrefElementToF64`
+(L3923) must propagate `valueOf`/`toString`/`@@toPrimitive` throws (it calls
+`coerceType`; verify the abrupt path is not swallowed by a `try`-less
+`__unbox_number` NaN default), (v) `length-excessive-throws`/`toindex-length`:
+check `n * es` against the allocation limit BEFORE `array.new_default`
+(`emitAllocViewFromN`, L5455) → RangeError instead of the trap, (vi)
+`buffer-arg/toindex-*`: ToIndex of an object `byteOffset`/`length` null-derefs
+in `__module_init` — coerce via `coerceType(externref→f64)` before the
+ArrayBuffer arm; **coordinate with #5150 F (windowed view)** — read
+`git log origin/main -- src/codegen/expressions/new-builtin-globals.ts` first.
+`no-species`/`same-ctor-buffer-ctor-species-*` ×3 need `view.buffer.constructor
+=== ArrayBuffer` — measure after #5150 lands; expect them to stay red here.
+Growth: `dataview-native.ts` +80 (`emitTaDynCtorConstructFromLocals` +60 —
+grant), `new-builtin-globals.ts` +20 (`tryCompileBuiltinGlobalNew` +15).
+Acceptance: rows; **at risk**: EVERY `makeCtorArg` harness row (the whole
+`ta-passing-all.txt`, 84/84), `tests/issue-3054-de-dynctor.test.ts`,
+`tests/issue-5150-es2015-buffers.test.ts` (the ArrayBuffer arm is shared),
+`tests/issue-3177.test.ts` at its pre-existing 3 failures and no more.
+
+#### Step r3-9 — `%TypedArray%.from` / `.of` (I, 23 rows, expect ≥ 14)
+
+`call-receiver-method.ts:tryEmitTaStaticOfFrom` (L330) + `dataview-native.ts:
+ensureTaFromArrayLikeHelper` (L6354) + `iterator-native.ts:ensureNativeArrayFromMapped`
+(L1875): (a) `mapfn` called with exactly `(kValue, k)` — `__array_from_mapped`
+composes `__hof_map`, which pushes 3 args; add a `__ta_from_mapped` twin whose
+loop builds a 2-slot `$ObjVec` (`mapfn-arguments`); (b) `IsCallable(mapfn)`
+BEFORE `source[@@iterator]` is read (`mapfn-is-not-callable`) — in the THEN
+arm at L390 test `__typeof_function(a1)` first when `argc >= 2 &&
+a1 !== undefined`; (c) `set-value-abrupt-completion`, `iterated-array-changed-
+by-tonumber`: values come from the DRAINED list; element ToNumber abrupt →
+propagate and stop; (d) `iter-*-error` ×4, `arylk-*-error` ×2, `custom-ctor`
+×2: the original error object must surface — `__array_from_iter_n`'s drain
+rewraps into a TypeError; find the wrap (iterator-native.ts L1906+
+`buildArrayFromIterNBody`) and rethrow the caught exception as-is;
+(e) `invoked-as-func` ×2 / `not-a-constructor` ×2: `var from = TA.from;
+from([])` — the value read mints the `from`/`of` closures (r2 step 2.1); their
+bodies must throw TypeError when `this` is not a `$__ta_ctor` / constructor
+(`__reflect_is_constructor`); (f) `.call(customCtor, src)` ×4 and
+`inherited` ×2 are the K4 `Function.prototype.call` family in disguise only
+when the receiver is read through `.call`; `inherited.js` compares
+`Int8Array.from === TypedArray.from` — a value-identity read: route the
+per-kind `$__ta_ctor` `__extern_get` arm (`ta-dyn-mop.ts` L1157) to the SAME
+intrinsic closures. `from-*-mapper-detaches-result` ×2: after the mapper
+detaches the result, the write must throw TypeError (validate before each
+element write). `from-typedarray-into-itself-mapper-detaches-result` leaks
+`env::__unwrap_for_wasm` (#2961) — do not chase it here; record it.
+Growth: `call-receiver-method.ts` +40 (`tryEmitTaStaticOfFrom` +30 — grant),
+`dataview-native.ts` +40 (`ensureTaFromArrayLikeHelper` +30 — grant),
+`iterator-native.ts` +60 (`ensureNativeArrayFromMapped` +40 — grant).
+Acceptance: rows; **at risk**: `harness/testTypedArray.js`'s `makeArray`
+(`Array.from({length:n}, fn)` — `__array_from_mapped` is on EVERY
+`makeCtorArg` row's path): `ta-passing-all.txt` 84/84 is the gate, plus
+`tests/issue-3177-fromof.test.ts` at its pre-existing failure and no more, and
+`Array.from` rows in `arrobj-controls.txt` on both lanes.
+
+#### Step r3-10 — integer-indexed MOP residual (J, 13 rows, expect ≥ 9; 2 come from r3-1)
+
+As r2 step 7 (a), (c), (d) — unchanged in substance: (a) the
+`__getOwnPropertyNames` (Reflect.ownKeys) `$__ta_dyn_view` arm mirroring the
+`__object_keys` arm at `ta-dyn-mop.ts` L957 — indices, then expando string
+keys, then symbols (`OwnPropertyKeys` ×4; `not-enumerable-keys` needs the
+expando's non-enumerable keys included); (c) `__defineProperty_value`/
+`_accessor` dyn-view arms (L1406–L1520): pass the caller's flag word through
+for expando keys (absent fields default to `false`, §10.1.6.3 —
+`key-is-not-numeric-index`, `key-is-symbol`, `non-extensible-redefine-key`),
+`ToNumber(Desc.[[Value]])` for a canonical index BEFORE the write
+(`desc-value-throws`), and `key-is-not-canonical-index` (null deref at 877:10
+— a `"1.0"`-style key reaching the index arm; route non-canonical numeric
+strings to the expando); (d) `[[Set]]` with the view on the RECEIVER's
+prototype chain (`prototype-chain-set` ×2): in `buildStringKeyArm` `set` mode
+the arm runs with `recv === O`; the ordinary `__extern_set` prototype walk
+must, on reaching a dyn view with `receiver !== O`, write the element for a
+valid index and do nothing for an invalid one (§10.4.5.5 step 1.b). Keep
+#2046's `Reflect.set` rows out.
+Growth: `ta-dyn-mop.ts` +120 (`fillTaDynViewMopArms` +80 — grant).
+Acceptance: rows; **at risk**: `Object.keys(view)`, `JSON.stringify(view)`,
+`for (k in view)` and `Object.defineProperty(view, "0", …)` — a control
+program on both lanes, and `tests/issue-3177.test.ts` `[[Delete]]` MOP case
+at its current verdict.
+
+#### Step r3-11 — DEFERRED: C5 (5 rows) and B (4 rows)
+
+- C5: probe `.tmp/census0903/probes/p10-protorecv.js` shows
+  `TypedArrayPrototype.includes()`/`.join()` do not throw while `.sort()` does:
+  the five names that are ALSO `String.prototype` members take a
+  string-flavoured any-receiver lowering (`__get_member_name` +
+  `__extern_toString` calls in the WAT of the caller) ahead of the
+  `$NativeProto` arm. Deferred because the site was not located by name in
+  this pass; find it with `npx tsx .tmp/census0903/probes/wat-fn-index.mts
+  <probe> '$h'` → the emitting function, then decline it when
+  `tracesToTypedArrayIntrinsicProto` holds. 5 rows, low value per risk.
+- B: `%TypedArray%()` must throw (r2 step 2.2 left undone — the callable
+  carrier's call body); `length`/`byteLength` getters through a var-held
+  prototype (`invoked-as-accessor` ×2 — needs the dynamic `__extern_get`
+  `$NativeProto` getter INVOCATION, not the value); `Symbol.toStringTag/
+  invoked-as-func` (gOPD `.get` symbol-key synthesis). All three are
+  builtin-surface mechanisms shared with other clusters; not worth a
+  TypedArray-local hack.
+
+### Order and honest expectations
+
+r3-1 (foundation, 2 rows, must ship first) → r3-2 (25) → r3-3 (24) → r3-4 (21)
+→ r3-5 (16) → r3-6 (21) → r3-7 (18) → r3-8 (20) → r3-9 (23) → r3-10 (13) →
+r3-11 deferred (9). Steps r3-1…r3-5 share one mechanism and one new file; ship
+them as one PR if the box allows, r3-6…r3-10 as one each. Floor for this pass:
+**≥ +110 of the 190 in-scope rows** (r3-1…r3-5 ≥ 71, r3-6…r3-10 ≥ 40 more);
+anything short of that per step is a residual to record, not a reason to widen
+a step. Do NOT touch `ArrayBuffer`/`DataView` rows (K1) even where the same
+function is edited — leave a note for #5150 instead.
+
+### Budget rationale (2026-09-03)
+
+The r3 mechanism is two NEW files (`ta-dyn-method-call.ts` — the
+`__extern_method_call` arm; `ta-dyn-proto-methods.ts` — the per-method
+helpers and their registry) so that `dataview-native.ts` (8,672 lines) and
+`call-receiver-method.ts` do not absorb another ~1,000 lines; the helper
+functions there (`ensureTaDynSortHelper`, `ensureTaDynSearchHelper`,
+`ensureTaDynHofHelper`, `ensureTaDynIteratorHelper`, `ensureTaDynJoinHelper`,
+`unshiftExternMethodCallTaDynViewArm`) are wasm-body emitters and will exceed
+the 300-line function ceiling the way `ensureTaDynSetHelper` does. Existing
+files grow only where an arm is spliced into an existing ladder: `ta-dyn-mop.ts`
+(prototype walk, MOP residual), `array-object-proto.ts` (closure bodies),
+`index.ts` (one finalize call), `call-receiver-method.ts` (reserve hook,
+`from`/`of`), `dataview-native.ts` (species, fill/copyWithin re-validate,
+ctor arms, from-arraylike), `iterator-native.ts` (2-arg mapper),
+`array-methods.ts` (Symbol pre-test in the species two-arm),
+`object-runtime.ts` (`$IterRec` prototype arm if missing). The frontmatter
+lists exactly these; r2's entries that r3 no longer touches are left in place
+(the gate only reads presence).

--- a/plan/issues/5195-es2015-standalone-class-r2.md
+++ b/plan/issues/5195-es2015-standalone-class-r2.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone class — r2 residual pass"
 status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-09-02
+updated: 2026-09-03
 priority: medium
 horizon: l
 feasibility: medium
@@ -39,6 +39,16 @@ loc-budget-allow:
   - src/codegen/expressions/call-tail-dispatch.ts
   - src/codegen/expressions/calls.ts
   - src/codegen/index.ts
+  - src/codegen/class-heritage-check.ts
+  - src/codegen/class-proto-lookup.ts
+  - src/codegen/closures/method-trampolines.ts
+  - src/codegen/property-access.ts
+  - src/codegen/literals.ts
+  - src/codegen/expressions/this-keyword.ts
+  - src/codegen/class-dynamic-keys.ts
+  - src/codegen/ast-modifiers.ts
+  - src/codegen/destructuring-params.ts
+  - src/codegen/statements/variables.ts
 coercion-sites-allow:
   - src/codegen/class-proto-lookup.ts
 func-budget-allow:
@@ -63,6 +73,21 @@ func-budget-allow:
   - src/codegen/typeof-delete.ts::compileTypeofComparison
   - src/codegen/property-access-dispatch.ts::finalizeStructAndDynamicMemberGet
   - src/codegen/expressions/call-builtin-static.ts::compileBuiltinStaticCall
+  - src/codegen/class-proto-lookup.ts::fillClassProtoLookupArm
+  - src/codegen/class-static-sidecar.ts::emitClassStaticSidecar
+  - src/codegen/class-static-sidecar.ts::classStaticSidecarApplies
+  - src/codegen/closures/method-trampolines.ts::finalizeMethodTrampolines
+  - src/codegen/closures/method-trampolines.ts::ensureMethodClosureSingleton
+  - src/codegen/property-access-dispatch.ts::emitClassStaticMemberRead
+  - src/codegen/property-access-dispatch.ts::tryIdentifierNamespaceAndStaticReceiverRead
+  - src/codegen/declarations.ts::collectDeclarations
+  - src/codegen/declarations.ts::collectPreparedTopLevelClassComputedNameEffects
+  - src/codegen/expressions/this-keyword.ts::compileThisKeyword
+  - src/codegen/literals.ts::resolveConstantExpression
+  - src/codegen/expressions/calls.ts::elemAccessReceiverClassName
+  - src/codegen/expressions/new-super.ts::compileClassExpression
+  - src/codegen/class-member-keys.ts::classMemberFuncKey
+  - src/compiler/early-errors/module-rules.ts::checkDuplicateConstructors
 ---
 
 # #5195 — class r2: cluster and fix the residual class-bucket failures
@@ -131,6 +156,41 @@ found the property: two answers about one object. The added arm is one
 predicate plus one clause on the existing "delegate to the runtime" condition
 the externref-receiver case already uses — the fold is declined, not
 reimplemented, and only for a prototype or constructor receiver of such a class.
+
+Growth allowance (2026-09-03, r3 planning pass — see "## Implementation Plan —
+r3 (2026-09-03)"): the r3 steps (1) widen the static sidecar to every class
+with a static method/accessor and install static ACCESSORS on it through a
+dummy-receiver trampoline (`class-static-sidecar.ts` +~120,
+`closures/method-trampolines.ts::ensureMethodClosureSingleton` /
+`::finalizeMethodTrampolines` +~70 for the `dummyReceiverClassName` variant,
+`property-access.ts` +10 to expose the dummy-struct instruction list), and
+redirect the reflective natives to it by class-object identity
+(`class-proto-lookup.ts::fillClassProtoLookupArm` +~90 — one more prepended
+arm per native, same mechanism as the F1/F4 arms already there); (2) split
+static/instance accessor funcMap keys on collision
+(`class-member-keys.ts::classMemberFuncKey` +8, `class-bodies.ts` +~40 for
+the pre-pass, the static-ctor-as-method arms and the derived-ctor `this` TDZ
+flag, `context/types.ts` +6 / `create-context.ts` +3 for the two new sets,
+`property-access-dispatch.ts::emitClassStaticMemberRead` /
+`::tryIdentifierNamespaceAndStaticReceiverRead` +~25 for the static key and the
+§10.2.4 `caller`/`arguments` throw, `assignment.ts::compilePropertyAssignment`
++~15 for the same two on the write side); (3) collect top-level class
+EXPRESSIONS with runtime-keyed members (`declarations.ts::collectDeclarations`
++~20, `expressions/calls.ts::elemAccessReceiverClassName` +8 for the
+`new C()` receiver of a class-expression binding); (4) a NEW leaf file
+`class-heritage-check.ts` (~150 LOC: the `__class_heritage_check` native and
+its emit) with +6/+4 call-site lines in `nested-declarations.ts` /
+`new-super.ts::compileClassExpression`, and the comma-heritage unwrapping in
+`class-bodies.ts::collectClassDeclaration`; (5) `literals.ts::resolveConstantExpression`
+(+5/−3) to stop folding an assignment-shaped key; (6)
+`expressions/this-keyword.ts::compileThisKeyword` +10 for the TDZ check;
+(7) `module-rules.ts::checkDuplicateConstructors` +2 and `ast-modifiers.ts`
++4 for the static-`constructor` skip; (8) `object-ops.ts::compilePropertyIntrospection`
++~15 and `call-builtin-static.ts::compileBuiltinStaticCall` +~12 for the fold
+declines that hand class-object receivers to the runtime; (9)
+`destructuring-params.ts` / `statements/variables.ts` +~15 for the nested
+array-pattern slot widening. Each is an arm at the decision point that already
+owns the case; no function is restructured.
 
 ## Problem
 
@@ -1140,3 +1200,792 @@ re-run alone; both are box-load artifacts.
 branch point `0f801557a` with this branch's sources removed, and the same 4
 (no more) with them restored. Worth its own issue; it is not in this issue's
 scope and nothing here touches it.
+
+## Implementation Plan — r3 (2026-09-03)
+
+Planner: Fable (this section); implementer: an Opus agent working from this
+text alone, in its own worktree. Nothing below was implemented here.
+
+### Census and root-cause groups (191 rows)
+
+Source: `.test262-cache/test262-standalone-current.jsonl` (rows stamped
+2026-09-03 09:07 UTC, `oracle_lane: honest`) × ES2015 edition list →
+`/home/user/js2/.tmp/census0903/class.tsv` (191 rows: 135 fail, 56
+compile_error). Grouped by ERROR STRING first, then by mechanism; the
+partition below is exact (191, no row in two groups — verified by
+`sort | uniq -d` on the union). Row lists live in
+`/home/user/js2/.tmp/census0903/r3/groups/<group>.txt` (this checkout only —
+the implementer's worktree must regenerate them from the regexes given per
+step; every regex is against the path column of `class.tsv`).
+
+| Group | Rows | Signature (error column) | Root cause |
+|---|---|---|---|
+| gen-owned | 67 | `env::__create_generator` leak ×37 · `native generator lowering currently supports only sequential…` ×8 · `Cannot destructure 'null'` ×8 (`gen-meth-*-ary-ptrn-elem-ary-empty-init`) · `yield-spread-arr-*` ×8 · `GeneratorFunction/*` ×5 · `methods-gen-yield-as-yield-operand` ×1 | native generator carrier (#680/#2864). OUT OF SCOPE, unchanged from r2. NB: the 8 `meth-*-iter-val-array-prototype` rows are plain methods, but the test replaces `Array.prototype[Symbol.iterator]` with a generator — same owner. |
+| S static surface | 31 | `Expected SameValue(«undefined», «1|2»)` ×18 (`cpn-*-accessors-*`) · `Cannot convert undefined or null to object` ×5 (`definition/{accessors,getters-prop-desc,methods,numeric-property-names,setters-prop-desc}`) · `Expected true but got false` ×4 (`grammar-static-ctor-{accessor,gen}-meth-valid`) · `C.eval is 3` / `x is 1` ×2 (`{getters,setters}-restricted-ids`) · `Cannot access property on null` ×2 (`fn-name-accessor-{get,set}`) | The class object has NO reflective static surface: `gOPD(C,'staticMethod')` is `undefined` (probe p1), static ACCESSORS are not on the sidecar at all (the module header of `class-static-sidecar.ts` says why — their compiled halves take the class STRUCT as `this`), and the sidecar only exists for classes with a runtime-keyed static. Plus the `C_get_<p>` funcMap key is shared by a static and an instance accessor of the same name (probe p6: `new C().eval` answers the STATIC body). |
+| B class-expression lane | 9 | `Expected SameValue(«null», «1|2»)` (`cpn-class-expr-computed-property-name-from-*`, methods only) | R3-2 as recorded: a top-level `let C = class { [k]() {} }` statement is never collected into `moduleInitStatements` (`declarations.ts:4076-4087` skips a variable statement whose only initializer is a class expression), so its keys are never evaluated, its prototype/sidecar never force-built, and `new C()[k]()` folds to `ref.null.extern` (probe p3: INSTANCE side fails too). The 9 `cpn-class-expr-accessors-*` rows in S need this step as well. |
+| K key side effects | 4 | `Expected SameValue(«0», «1»)` (`cpn-*-computed-property-name-from-assignment-expression-assignment`) | `literals.ts:2372 resolveConstantExpression` folds `x = 1` to its RHS, so the key is treated as the static string "1" and the WRITE is dropped (WAT of probe p2: no `global.set $__mod_x` anywhere; `__module_init` throws the assert unconditionally). |
+| C static constructor | 2 | `A class may only have one constructor` (CE) | `module-rules.ts:292 checkDuplicateConstructors` counts a `static constructor(){}` (TS parses it as a ConstructorDeclaration with a `static` modifier); `ast-modifiers.ts:40 findConstructorImplementation` would pick it as THE constructor. |
+| F heritage evaluation | 10 | `Expected a TypeError` ×8 · `calls is 1` ×1 · `indexed support unit … ir-source` (CE, `side-effects-in-extends`) | Standalone never evaluates a non-class heritage for IsConstructor / `Get(parent,'prototype')`: `collectClassDeclaration` (class-bodies.ts:974-1103) resolves identifiers and class expressions only, and the runtime registration `extern.ts:752 emitRegisterDynamicClassParent` returns at L758 under `ctx.standalone`. `class D extends (() => {}) {}` silently compiles as a base class (probe p5). |
+| D3 `this` TDZ | 3 | `Expected a ReferenceError` · `exn instanceof ReferenceError` · `b.prp is 3` | `_init` receives `__self` already allocated (class-bodies.ts:2396-2448), `this` reads are a bare `local.get` (this-keyword.ts:53-61), and `compileSuperCall` (class-bodies.ts:3899) has no "already initialized" check. `this-access-restriction-2.js` additionally needs a BASE ctor's return-override (`return o`) — see E, deferred. |
+| T restricted properties | 4 | `Expected a TypeError` ×3 · `Expected a TypeError` (`strict-mode/arguments-callee`) | `C.caller` / `C.arguments` read and write on a class object answer silently; `C.hasOwnProperty('caller')` is folded/undefined. |
+| O ctor `arguments` | 3 | `arguments.length is 2 … 0` · `args.length is 3 … 0` · `«undefined», «0»` | `nested-declarations.ts:3448 maybeSetArgcForKnownCall` publishes `__argc` only when the callee is in `funcUsesArguments`/`funcOptionalParams` AND the `new` site clamps to `paramCount`; the implicit derived ctor (`class-bodies.ts:452 computeImplicitDerivedCtorPrefix`) forwards the nearest ancestor's FORMALS only. |
+| N nested array pattern | 8 | `Expected SameValue(«NaN», «undefined»)` (`meth[-static]-dflt-obj-ptrn-prop-ary` ×4 + `gen-meth*` twins ×4) | The class-METHOD lane types the nested `[x, y, z]` element slots as f64. The object-literal twin `expressions/object/dstr/meth-dflt-obj-ptrn-prop-ary.js` PASSES and so does `expressions/function/dstr/dflt-obj-ptrn-prop-ary.js` (baseline), while `statements/function/dstr/dflt-obj-ptrn-prop-ary.js` fails — so the DECLARATION-style param typing (class-bodies.ts:1586 `resolveWasmType(ctx, paramType)` for a binding-pattern parameter) is the divergent lane, not the destructuring emitter. |
+| M falsy defaulted param | 8 | `Expected SameValue(«0», «false»)` | Cross-lane: `statements/function/`, `expressions/function/`, `arrow-function/`, `object/method-definition/` twins ALL fail in the baseline. The rule lives in `checker/type-mapper.ts:260 isUndefinedDefaultOnlyParam` (widens only an undefined-only initializer). DEFERRED — a shared param-typing rule, not a class defect. |
+| R Error `message` ownership | 7 | `message should be an own property` | `registry/error-types.ts:593 fieldArm("message", 1)` answers `message` as own unconditionally; an `Error` subclass has no `$Object` prototype (`standaloneClassProtoObjectApplies` builtin-parent exclusion) so `Err.prototype.message = …` has nowhere to land. DEFERRED — error-model goal (Lane A per `plan/method/lane-partition.md`). |
+| X class-expression identity | 3 | `«undefined», «"via get"»` ×2 (`accessor-name-*-computed-in`) · `name-binding/const` | Two class expressions assigned to ONE binding (`for (C = class {…}; ;)` twice) share `ctx.classExprNameMap[name]` — the second overwrites the first, so `C.prototype` resolves to the last class. Needs the binding to become a runtime VALUE with `prototype` reachable through the sidecar. DEFERRED. |
+| J method named `new` | 2 | `invalid Wasm binary … __module_init` (CE) | `${C}_new` is both the method's and the constructor's funcMap key (`class-member-keys.ts:46`). DEFERRED (needs the member NAME relocated at every dispatch site, not just the key). |
+| P bound class ctor | 2 | `s2prime.x is 3` · `Expected a TypeError` (`subclass/binding`) | `$__bound_fn` construct path drops the bound-args prefix. DEFERRED. |
+| E return override | 1 | `«"number"», «"undefined"»` (`derived-class-return-override-with-object`) | Probe p8: `return {}` in a derived ctor does not replace `this` — the struct-result lane (control-flow.ts:488-509) can only represent an override that IS the struct. DEFERRED (needs the externref-result lane). |
+| builtin-subclass | 13 | `called value is not a function` ×5 · misc | Array ×2, Boolean, Number, String ×2, DataView, ArrayBuffer, Date, Promise, TypedArray, `builtins.js`, `Symbol/new-symbol-with-super-throws`. OUT OF SCOPE (r2 cluster Q; `standalone-subclass-ctors.ts` identity-only carriers). |
+| env-owned | 8 | `Function/*` ×3 (QuickJS provider), `RegExp/*` ×2 (#5198), `definition/basics.js` + `class-definition-null-proto*` ×2 (`%Object.prototype%` rooting / `Object.prototype.toString` not implemented) | OUT OF SCOPE. |
+| decorators | 6 | `'yield' is a reserved word` (TS parser) | OUT OF SCOPE (not ES2015). |
+
+**In scope: 97 rows** (S 31 + B 9 + K 4 + C 2 + F 10 + D3 3 + T 4 + O 3 + N 8 + M 8 + R 7 + X 3 + J 2 + P 2 + E 1). **Out of scope: 94** (gen-owned 67, builtin-subclass 13, env-owned 8, decorators 6).
+
+### Verification on HEAD `dc98e78176` (2026-09-03, = origin/main)
+
+15-path sample across the biggest groups, in-process standalone runner
+(carries the #5461/#5272 host-import-leak check):
+
+```
+npx tsx scripts/run-test262-paths.mts /home/user/js2/.tmp/census0903/r3/sample1.txt --standalone
+=== counts ===
+{ fail: 14, compile_error: 1 }
+```
+
+Every row failed exactly as the baseline says (same error text, same line):
+`cpn-class-expr-accessors-…-logical-or` / `cpn-class-decl-accessors-…-logical-or`
+→ `«undefined», «2»` at L59 (the STATIC getter assert; the instance asserts
+before it pass) · `cpn-class-expr-computed-property-name-from-expression-logical-or`
+→ `«null», «2»` at L50 · `cpn-class-decl-…-assignment-expression-assignment`
+→ `«0», «1»` at L50 · `definition/methods.js` → `Cannot convert undefined or
+null to object` at L10 · `getters-prop-desc.js` → same at L18 ·
+`grammar-static-ctor-meth-valid` → CE `A class may only have one constructor`
+· `grammar-static-ctor-accessor-meth-valid` → false at L28
+(`C.hasOwnProperty('constructor')`) · `invalid-extends` / `heritage-arrow-function`
+→ no TypeError · `prototype-getter` → `calls is 1 … «0»` · `method/dflt-params-arg-val-not-undefined`
+→ `«0», «false»` · `dstr/meth-dflt-obj-ptrn-prop-ary` → `«NaN», «undefined»`
+· `getters-restricted-ids` → `C.eval is 3 … «1», «3»` · `this-access-restriction`
+→ no ReferenceError. No group has healed since the baseline; nothing to drop.
+
+Eight minimal probes (`/home/user/js2/.tmp/census0903/r3/probes/p1…p8.js`,
+run with `npx tsx .tmp/es2015/probe-one.mts <files>`; every one FAILS on
+HEAD, the assert message names the mechanism):
+
+| # | Shape | Observed |
+|---|---|---|
+| p1 | `gOPD(C.prototype,'method')` vs `gOPD(C,'staticMethod')` | proto: object ✓ · class object: `undefined` |
+| p2 | `let x = 0; class C { [x = 1]() {} }; x` | `0` (WAT: no store to `$__mod_x`; assert folded to an unconditional throw) |
+| p3 | `let C = class { [x\|\|1](){} static [x\|\|1](){} }` | `new C()[x\|\|1]()` → `null` (instance side fails, unlike the declaration form) |
+| p4 | `class C { static get constructor(){} }; C.hasOwnProperty('constructor')` | `null` |
+| p5 | `class D extends (() => {}) {}` | no throw |
+| p6 | `get eval(){return 1}` + `static get eval(){return 3}` | `new C().eval` → `3` |
+| p7 | `static get [x\|\|1](){return 2}` → `C[x\|\|1]` | `undefined` |
+| p8 | derived `return {other: 2}` | `this` not replaced |
+
+Function-twin baseline facts used above (grep of the same jsonl):
+`statements/function/dflt-params-arg-val-not-undefined.js` fail ·
+`expressions/object/method-definition/meth-dflt-params-arg-val-not-undefined.js`
+fail · `expressions/object/dstr/meth-dflt-obj-ptrn-prop-ary.js` **pass** ·
+`expressions/function/dstr/dflt-obj-ptrn-prop-ary.js` **pass** ·
+`statements/function/dstr/dflt-obj-ptrn-prop-ary.js` fail.
+
+### Standing rules for every step
+
+- **Every step is gated on `ctx.standalone`** unless the step says
+  otherwise; the host lane must stay byte-identical (compile any
+  `playground/examples/*.ts` with a class to `.wasm` with and without the
+  change, `cmp` — no `--target`).
+- **Byte-identity control (plain classes).** The three programs below must
+  compile to IDENTICAL `.wasm` before and after EVERY step marked
+  `[byte-inert]`, on `--target standalone` (`npx tsx src/cli.ts <f> --target
+  standalone --no-wat -o <dir>`; keep a second worktree of the base commit for
+  the "before" build — the file-copy A/B pattern from CLAUDE.md):
+  - `ctl-plain.js`: `class A { constructor(x){ this.x = x } m(){ return this.x } get g(){ return 1 } } class B extends A { m(){ return super.m() + 1 } } print(new B(2).m(), new B(1).g)`
+  - `ctl-static.js`: `class S { static sf = 1; static sm(){ return 2 } static get sg(){ return 3 } } print(S.sf, S.sm(), S.sg, S.hasOwnProperty('sf'), S.hasOwnProperty('sm'), Object.getOwnPropertyNames(S).join())` — NOTE: this one is byte-inert only for steps that do not touch the static surface (r3-3, r3-5, r3-6, r3-8, r3-9); for r3-1/r3-2/r3-4/r3-7 it is the VALUE control instead: its printed line must be identical on js (`node`) and standalone before and after.
+  - `ctl-fnctor.js`: `function F(a){ this.a = a } F.prototype.k = 9; class G extends F {} var g = new G(4); print(g.a, g.k, Object.getPrototypeOf(G.prototype) === F.prototype)`
+- **The 22-row order-preservation control list** must stay 22/22 after every
+  step (`npx tsx scripts/run-test262-paths.mts <list> --standalone`). The list
+  (recreate it in the worktree as `.tmp/r3/class-controls.txt`):
+
+  ```
+  language/computed-property-names/class/accessor/getter.js
+  language/computed-property-names/class/method/constructor-duplicate-1.js
+  language/expressions/class/accessor-name-static/computed-err-evaluation.js
+  language/expressions/class/accessor-name-static/computed-err-to-prop-key.js
+  language/expressions/class/method/array-destructuring-param-strict-body.js
+  language/expressions/class/method/dflt-params-abrupt.js
+  language/expressions/new.target/value-via-call.js
+  language/expressions/new.target/value-via-fpapply.js
+  language/expressions/super/call-arg-evaluation-err.js
+  language/expressions/super/call-construct-error.js
+  language/statements/class/accessor-name-inst/computed-err-evaluation.js
+  language/statements/class/definition/constructor-strict-by-default.js
+  language/statements/class/definition/fn-length-static-precedence-order.js
+  language/statements/class/dstr/meth-ary-init-iter-close.js
+  language/statements/class/dstr/meth-dflt-obj-init-null.js
+  language/statements/class/method-static/dflt-params-abrupt.js
+  language/statements/class/name-binding/in-extends-expression-assigned.js
+  language/statements/class/subclass/builtin-objects/Map/regular-subclassing.js
+  language/expressions/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js
+  language/statements/class/subclass/derived-class-return-override-with-this.js
+  language/statements/class/definition/methods-named-eval-arguments.js
+  language/statements/class/subclass/builtin-objects/Error/regular-subclassing.js
+  ```
+
+  plus, for THIS pass, the r2-landed rows that r3 touches the mechanism of
+  (must stay green): `statements/class/definition/constructor.js`,
+  `definition/constructor-property.js`, `computed-property-names/class/method/{number,string,symbol}.js`,
+  `computed-property-names/class/accessor/getter-duplicates.js`,
+  `statements/class/cpn-class-decl-computed-property-name-from-expression-logical-or.js`
+  (the declaration/method form that already passes — the sibling of every B row),
+  `statements/class/subclass/derived-class-return-override-with-{null,undefined}.js`.
+- **Probe batches ≤ 15 paths, one compile process at a time** (4-core box
+  shared with an equivalence gate); a `compilation timeout` under load is an
+  artifact — re-run alone before recording it.
+- **Type queries go through `ctx.oracle`** (`src/checker/oracle.ts`), never a
+  new `ctx.checker.*` call (oracle-ratchet gate). The raw calls already in the
+  touched functions are grandfathered; the new arms below never need a
+  `ts.Type` — every new predicate is syntactic or reads a `ctx.*` set.
+- `FunctionContext` literals (the mini trampoline fctx in r3-1.2) carry
+  `labelMap: new Map()` and `isGenerator?: boolean`.
+- No new host import anywhere (`env::*` = `host_import_leak` = the row fails
+  in CI); every new helper is a defined native minted with
+  `mintDefinedFunc`/`pushDefinedFunc` (`func-space.ts`), the way
+  `class-proto-lookup.ts` does it.
+- Gates before every commit, chained (CLAUDE.md), also with
+  `LOC_GATE_BASE=$(git rev-parse origin/main)`; `pnpm run typecheck`;
+  `pnpm run test:equivalence:gate`; `node scripts/update-issues.mjs --check`.
+  Add the landed shapes to `tests/issue-5195-es2015-class-r2.test.ts` (host +
+  standalone, zero-import assertion) — one pinned test262 row + the probe
+  shape per step.
+
+### Step r3-1 — Static surface: sidecar for every class with statics, static accessors via a dummy-receiver trampoline, reflective redirect (S: 29 of 31 rows; also the hasOwnProperty half of T and the sidecar half of C)
+
+**Root cause.** The class object is a `$ClassName` struct that cannot carry
+own properties; the r2 sidecar `$Object` exists only for classes with a
+runtime-keyed STATIC and holds static METHODS only. Nothing reflective
+(`gOPD`, `hasOwnProperty`, `propertyIsEnumerable`, `getOwnPropertyNames`)
+reaches it, and static accessors cannot be installed because their compiled
+halves take the class struct as `this` (`class-static-sidecar.ts` header).
+
+**Files / functions.**
+
+1. `src/codegen/class-bodies.ts::collectClassDeclaration` L1895-1908 — mint
+   the `__static_<C>` global when the class has ≥1 static METHOD or ACCESSOR
+   (non-private) OR a runtime-keyed static, not only the latter. Add the
+   predicate as `classHasStaticSurface(ctx, decl)` in
+   `src/codegen/class-dynamic-keys.ts` (syntactic: walks `decl.members` for
+   `hasStaticModifier` on a MethodDeclaration / accessor / the static
+   ConstructorDeclaration of r3-4, excluding `#private` names). Static FIELDS
+   alone do NOT create a sidecar (they keep the `staticProps` globals — one
+   source of truth per slot, as the r2 header says).
+2. `src/codegen/class-static-sidecar.ts::classStaticSidecarApplies` — drop the
+   "some member isStatic" narrowing (L81); apply whenever the global was
+   minted. `::emitClassStaticSidecar` — install, in this order: (a) `length`
+   (ctor arity: `functionNameMap`/the #4450 `class-static-metadata.ts` value —
+   reuse `classStaticOwnPropertyNames`'s source for the number), `name`
+   (`ctx.functionNameMap.get(className)`), `prototype` (`emitLazyProtoGet` +
+   `extern.convert_any`? — no: `emitLazyProtoGet` already yields externref),
+   with `__defineProperty_value` flags `0x04` (configurable only) for the
+   first two and `0x00` for `prototype`; a declared static member with one of
+   these names REPLACES it (skip the intrinsic when
+   `hasClassStaticMethod`/`staticAccessorSet`/`staticProps` has the name —
+   same predicate as `call-builtin-static.ts:3041 classIntrinsicOverridden`);
+   (b) then ONE walk over `decl.members` in source order: a static method →
+   `__defineProperty_value` (as today), a static get/set pair →
+   `__defineProperty_accessor` with `ACCESSOR_FLAGS` (import it from
+   `class-proto-accessors.ts`; merge a getter and a setter with the same
+   resolved name into ONE define, later half wins), a runtime-keyed static
+   accessor reads its `__cmkey_` global via `emitClassMemberKeyOperand`.
+   `collectStaticMethods` grows a sibling `collectStaticAccessors` returning
+   `{name, getterFuncIdx?, setterFuncIdx?}` resolved through the STATIC key
+   of r3-1.5.
+3. **The dummy-receiver trampoline.** `src/codegen/closures/method-trampolines.ts::ensureMethodClosureSingleton`
+   (L822) gains an optional trailing parameter `dummyReceiverClassName?:
+   string`. When set, the trampoline body REPLACES `buildTrampolineThisSlot` +
+   `coerceTrampolineThisSlot` (L862-868) with the dummy-struct instruction
+   list for that class, and the cache/trampoline names get a `_static` suffix
+   (`__obj_meth_tramp_${methodName}_static_cached`) so a static half never
+   shares a singleton with an instance half. Record
+   `dummyReceiverClassName` on the `pendingMethodTrampolines` entry and make
+   `::finalizeMethodTrampolines` (L574-603) emit the same dummy-struct list in
+   place of the `buildTrampolineThisSlot` branch when the entry carries it
+   (the rebuild path MUST agree with the first build or the module is invalid —
+   this is the #1669 lesson already documented there). Expose the instruction
+   list by splitting `src/codegen/property-access.ts::emitDummyStruct` (L1268)
+   into `export function dummyStructInstrs(ctx, className): Instr[] | null`
+   + the existing pusher. `emitClassStaticSidecar` calls a new thin wrapper
+   `emitCachedStaticAccessorHalfAccess(ctx, fctx, halfName, funcIdx,
+   className)` = `ensureMethodClosureSingleton(..., className)` +
+   `emitLazyClosureCacheAccess`, mirroring `emitCachedMethodClosureAccess`.
+   Why this shape: `__call_accessor_get` invokes the stored closure through
+   its trampoline with the RECEIVER in `__current_this`; a static getter must
+   ignore that receiver and take the struct-typed `this` the collection pass
+   gave it, which is exactly what `emitGetterCallWithDummy` (property-access.ts:1308)
+   does at the typed read site.
+4. **Reflective redirect.** `src/codegen/class-proto-lookup.ts::fillClassProtoLookupArm`:
+   mint a second native `__class_static_sidecar_of(externref) -> externref`
+   with one arm per sidecar class — the `classObjectArm` shape already at
+   L207-237 (identity test against `global.get __class_<C>`, `ref.eq`),
+   answering the sidecar global or null. Prepend, in each of
+   `__hasOwnProperty`, `__propertyIsEnumerable`, `__getOwnPropertyDescriptor`,
+   `__getOwnPropertyNames`, `__extern_get`, `__extern_set`,
+   `__extern_set_strict` (bodies found by name as at L189/L298/L331):
+   `local.get 0; call __class_static_sidecar_of; local.tee t; ref.is_null;
+   i32.eqz; if → (for the FIRST four) replace param 0 by `t` and re-enter the
+   native, return; (for the get/set three) only when
+   `__hasOwnProperty(t, key)` is 1 — otherwise fall through to the existing
+   body, so a static FIELD read/write keeps reaching its global and an
+   unknown key keeps today's miss`. `collectEntries` must now enumerate
+   sidecar classes independently of `classesNeedingLookup` (a class with
+   statics but no runtime key has no proto-lookup entry and must still get a
+   sidecar arm); keep the existing `__extern_get` proto arm untouched.
+   The lookup native must be minted whenever `ctx.classStaticSidecarGlobals.size > 0`
+   — move the `entries.length === 0` early return (L188) below the sidecar
+   minting.
+5. **Static/instance accessor key split** (`getters-restricted-ids`,
+   `setters-restricted-ids`). Pre-pass in `collectClassDeclaration` beside
+   the L1506-1513 method pre-pass: collect `C_get_<p>` / `C_set_<p>` names
+   declared BOTH static and non-static into a new
+   `ctx.staticAccessorKeyCollisions: Set<string>` (`context/types.ts` next to
+   `classStaticSidecarGlobals` L3885, `create-context.ts:382`). In
+   `src/codegen/class-member-keys.ts::classMemberFuncKey` add, beside the
+   L63 method rule: `if (kind === "static" && ctx.staticAccessorKeyCollisions.has(fullName)) key = "__cm$static$" + key`.
+   Then pass `"static"` at every STATIC accessor site: registration
+   (class-bodies.ts L1700/L1716/L1740/L1752 — pass the kind from
+   `hasStaticModifier(member)`), `property-access-dispatch.ts::tryIdentifierNamespaceAndStaticReceiverRead`
+   L2099, `::emitClassStaticMemberRead` L2305 (and gate that arm on
+   `ctx.staticAccessorSet.has(accessorKey)` — today it fires on
+   `classAccessorSet`, which is why the instance getter answers `C.eval`),
+   `assignment.ts::compilePropertyAssignment` L4513 (already "static") and
+   the element-target static-setter arm near L5564, the sidecar install of
+   r3-1.2, and `class-proto-accessors.ts::installableClassAccessors` L107-108
+   (instance: unchanged default). Also `compileClassBodiesInner`'s accessor
+   body loop must resolve the funcIdx with the same kind. Because the
+   relocation fires ONLY on a real collision, every program without one is
+   byte-identical.
+6. **Compile-time folds that must now decline.**
+   `src/codegen/object-ops.ts::compilePropertyIntrospection` L4594
+   `introspectionReceiverHasRuntimeKeys` → rename to
+   `introspectionReceiverDelegatesToRuntime`: additionally true for a bare
+   class-identifier receiver (`classIdentityFromExpression`-style resolution
+   through `classExprNameMap`) when the class has a sidecar AND the literal
+   key (if literal) is NOT already a known static name
+   (`hasClassStaticMethod` / `staticAccessorSet` / `staticProps` /
+   `classStaticOwnPropertyNames`). Known names keep the fold (this is what
+   keeps R2-2's `C.hasOwnProperty('sm'|'sf')` true and byte-identical);
+   unknown literals (`'caller'`, `'arguments'`, `'constructor'` with a static
+   accessor of that name — probe p4) and non-literal keys go to the runtime,
+   which the r3-1.4 arm answers from the sidecar.
+   `src/codegen/expressions/call-builtin-static.ts::compileBuiltinStaticCall`
+   L3008-3010 `isMethodLookup`: OR in `ctx.staticAccessorSet.has(\`${classIdentity}_${propLiteral}\`)`
+   so a static accessor descriptor falls to the dynamic native (which r3-1.4
+   redirects) instead of `emitUndefined`. The intrinsic synthesis at
+   L3031-3092 stays (same answer, fewer moving parts). Leave the
+   `getOwnPropertyNames(C)` fold (L3348-3365) as is.
+
+**Ordered edits:** 1.3 (trampoline, independent, testable alone with probe
+p7 after 1.2) → 1.1 + 1.2 → 1.4 → 1.6 → 1.5. Commit after 1.4 and after 1.6
+separately.
+
+**Rows claimed (29):** `grep -E 'cpn-class-(expr|decl)-accessors-computed-property-name-from-(arrow|async-arrow|function-declaration|function-expression|generator-function-declaration|assignment-expression-bitwise|expression-)|definition/(accessors|getters-prop-desc|methods|numeric-property-names|setters-prop-desc)\.js|grammar-static-ctor-(accessor|gen)|(getters|setters)-restricted-ids'`
+= 29 (the 9 `cpn-class-expr-accessors-*` rows also need r3-2; the 4
+`grammar-static-ctor-*` rows also need the r3-1.6 delegate). The 2
+`fn-name-accessor-{get,set}` rows are NOT claimed (SetFunctionName from a
+symbol key: `'get [test262]'` / `'get '` on the installed half — record as
+residual unless the `$fnmeta` name slot can be set from the key global at
+install time; do not chase).
+
+**Growth:** `class-static-sidecar.ts` +~120 · `class-proto-lookup.ts` +~90
+(`fillClassProtoLookupArm`) · `closures/method-trampolines.ts` +~70
+(`ensureMethodClosureSingleton`, `finalizeMethodTrampolines`) ·
+`property-access.ts` +10 · `class-dynamic-keys.ts` +12 ·
+`class-member-keys.ts::classMemberFuncKey` +5 · `class-bodies.ts::collectClassDeclaration`
++~20 · `context/types.ts` +3 / `create-context.ts` +1 ·
+`property-access-dispatch.ts` +6 · `object-ops.ts::compilePropertyIntrospection`
++~12 · `call-builtin-static.ts::compileBuiltinStaticCall` +2.
+
+**Order/evaluation constraints.** (i) Install order on the sidecar is
+`length, name, prototype`, then members in SOURCE order — `Object.getOwnPropertyNames(C)`
+is folded today from `classStaticOwnPropertyNames` in exactly that order,
+and the two must keep agreeing. (ii) The sidecar is force-built at
+ClassDefinitionEvaluation only where it is today (a runtime-keyed class);
+for a plain static class it stays LAZY (built on first redirect) — its
+installs have no observable side effects, so laziness is unobservable. (iii)
+The redirect is by IDENTITY of the class-object singleton; an instance of the
+class must never match (the `ref.eq` arm guarantees it — do NOT use
+`ref.test`, F2 explains why). (iv) `__extern_get`/`__extern_set` redirect only
+when the sidecar HAS the key, so static fields (globals) and unknown keys keep
+today's lanes.
+
+**Acceptance.**
+- Claimed rows: the 20 declaration-form rows pass after this step alone; the
+  9 expression-form rows after r3-2.
+- Probes p1, p4 (with r3-4), p6, p7 pass; the r2 probe
+  `probes5195/static-gopd.js` shape (inline in the test file) passes.
+- PASSING shapes at risk and how to check: **(a)** every typed static
+  accessor read/write (`C.staticX`, `C.staticX = v`, `this.g` in a static
+  method) — `getters-prop-desc.js`/`setters-prop-desc.js` assert those values
+  before the descriptors, and `ctl-static.js` must print the identical line
+  on js and standalone; **(b)** static/instance METHOD name collision
+  (`static m(){}` + `m(){}`) — `tests/` files `class-methods`,
+  `#3024` and `elements/syntax/valid/grammar-static-ctor-*` siblings; run
+  `npx vitest run tests/class-methods tests/issue-3024* tests/issue-4440* tests/issue-4450*`
+  (the `$fnmeta` / static `name`/`length` precedence tests — the sidecar's
+  intrinsic installs must not change what `C.name`/`C.length` READ, which
+  stay on the typed lane); **(c)** R2-2: `C.hasOwnProperty('sm')` and
+  `('sf')` stay `true` (probe in the test file); **(d)** `Object.getOwnPropertyNames(C)`
+  order unchanged (`fn-length-static-precedence-order.js` in the control
+  list); **(e)** byte-identity of `ctl-plain.js` and `ctl-fnctor.js` (no
+  statics → no sidecar → no arm; `fillClassProtoLookupArm` must return
+  before minting anything when both maps are empty); **(f)** the trampoline
+  finalize path: run `npx vitest run tests/issue-1669* tests/issue-2015* tests/issue-4466*`
+  (the rebuild-consistency tests named in `method-trampolines.ts`).
+
+### Step r3-2 — Top-level class EXPRESSIONS with runtime-keyed members reach ClassDefinitionEvaluation (B: 9 rows + the 9 expression-form rows of r3-1) `[byte-inert]`
+
+**Root cause.** `declarations.ts::collectDeclarations` L4071-4088 keeps the
+"historical skip" for a variable statement whose only initializer is a class
+expression, so `let C = class { [k]() {} }` never reaches
+`compileVariableStatement` → `tryCompileClassExpressionBindingValue` →
+`emitHandledClassExpressionBindingEffects` (variables.ts:98) →
+`emitUnresolvedComputedAccessorNameEffects` — no key evaluation, no proto
+force-init, no sidecar. R3-2 recorded this; probe p3 confirms the instance
+side fails too.
+
+**Files / functions.**
+1. `src/codegen/declarations.ts::collectDeclarations` L4079-4087: add
+   `hasRuntimeKeyedClassExpression` = some declaration whose initializer is a
+   `ts.ClassExpression` with `classHasUnresolvedComputedMemberName(ctx, init)`
+   or `classHierarchyHasDynamicMember(ctx, ctx.anonClassExprNames.get(init))`
+   (the R2-3 twin for descendants) and OR it into the collect condition.
+   Both predicates are already imported/used by
+   `collectPreparedTopLevelClassComputedNameEffects` (L2437) — reuse, do not
+   duplicate.
+2. `src/codegen/expressions/calls.ts::elemAccessReceiverClassName` L4324:
+   when `declaredNameOf` yields nothing for a `new C()` receiver (or yields a
+   name not in `classSet`), unwrap `ts.isNewExpression(expr.expression) &&
+   ts.isIdentifier(...)` and resolve that identifier through
+   `classExprNameMap`. Verify with probe p3 FIRST after edit 1 — if p3's
+   instance assert already passes, skip this edit (the oracle may already
+   resolve it).
+3. `src/codegen/expressions/new-super.ts::compileClassExpression` L2947:
+   unchanged — the effects emitter is already called there for the inline /
+   assignment forms; this step only fixes the DECLARATION-BOUND form.
+
+**Rows claimed (9):** `grep -E 'cpn-class-expr-computed-property-name-from-(arrow|async-arrow|function-declaration|function-expression|generator-function-declaration|assignment-expression-bitwise|expression-)'`;
+plus it is the missing half for the 9 `cpn-class-expr-accessors-*` rows in
+r3-1.
+
+**Growth:** `declarations.ts::collectDeclarations` +~12 · `calls.ts::elemAccessReceiverClassName` +8.
+
+**Order constraints.** The collected statement runs in SOURCE ORDER among
+the other module-init statements (it is pushed where the `let` sits, so a
+`let x = 0` before it initializes first — the K rows depend on that). The
+key expressions run exactly ONCE (`emitHandledClassExpressionBindingEffects`
+already splices effects before the materialization — keep that order).
+
+**Acceptance.**
+- 9 rows pass; with r3-1, the 9 expression accessor rows too. Probe p3 passes.
+- PASSING shapes at risk: **(a)** every top-level `const C = class {…}` with
+  FOLDING keys must stay un-collected — assert byte-identity of
+  `const K = class { m(){ return 1 } static s(){ return 2 } }; print(new K().m(), K.s())`
+  (the historical skip is load-bearing for the `#3045` identity shape);
+  **(b)** `#4618`-style `let Inner; Inner = class extends React.Component {}`
+  is the ASSIGNMENT form, untouched — run `npx vitest run tests/issue-4618* tests/issue-3045*`;
+  **(c)** the control list (contains `name-binding/in-extends-expression-assigned.js`).
+
+### Step r3-3 — An assignment-shaped computed key is a runtime key (K: 4 rows) `[byte-inert for keys without an assignment]`
+
+**Root cause.** `src/codegen/literals.ts::resolveConstantExpression` L2370-2374
+returns the RHS for `x = value`, i.e. the key folds to `"1"` and the write is
+silently dropped (the `&&=` arm two lines below already documents that the
+write-performing forms "must remain runtime expressions"). Probe p2 + its WAT:
+no store to `$__mod_x`.
+
+**Edits.** (1) Delete the L2372-2374 arm (return `undefined` for `=`, like
+`||=`/`??=`). The key then goes through the r2 Step-1 lane: the class is
+collected (`classHasUnresolvedComputedMemberName` is true), the key
+expression is compiled by `emitUnresolvedComputedAccessorNameEffects`
+(nested-declarations.ts:424) — a REAL assignment lowering that stores to
+`x` — and the member is installed under the runtime key. (2) Re-run probe
+p2. If `x` still reads 0, the remaining fold is on the READ side: the same
+function's L2359-2364 folds a `let`/`var` with a literal initializer to that
+literal for KEY resolution only, so it is not the culprit for a value read;
+find the read fold by compiling p2 with `--wat` and grepping the
+`$__mod_x` global — record what you find in this file before fixing it, and
+fix it only if it is a scan that skips `ComputedPropertyName` nodes (add the
+walk), never by disabling a fold wholesale.
+
+**Rows claimed (4):** `grep -E 'assignment-expression-assignment'`.
+
+**Growth:** `literals.ts::resolveConstantExpression` −3/+2.
+
+**Acceptance.**
+- 4 rows pass; probe p2 passes; `x` is 1 AFTER the class and the member is
+  reachable as `c[1]()` / `C[1]()` (the rows assert both).
+- PASSING shapes at risk: **(a)** object-literal computed keys with an
+  assignment (`{ [_ = 'str' + 'ing']: 1 }` — the comment at L2370 names this
+  shape): they now take `compileRuntimeComputedPropertyKey` (literals.ts:884,
+  the #2126 lane) — pin `var _; var o = { [_ = 'k']: 1 }; print(o.k, _)` in
+  the test file on both lanes; **(b)** class FIELDS with such a key
+  (`class C { [x = 1] = 2 }`) — the field lane (`class-bodies.ts`
+  PropertyDeclaration collection) must not start REJECTING the module: probe
+  `let x = 0; class C { [x = 1] = 2 }; print(new C()[1], x)` on js and
+  standalone before and after; if the field lane cannot take a runtime key
+  today, restrict edit (1) to keys of METHODS/ACCESSORS by moving the check
+  into `resolveComputedKeyExpression`'s callers for those member kinds only
+  (`resolveInstallableClassMemberName`), and say so here; **(c)** the
+  control row `computed-property-names/class/accessor/getter.js` and
+  `accessor-name-static/computed-err-evaluation.js`.
+
+### Step r3-4 — `static constructor(){}` is a static METHOD named `constructor` (C: 2 rows; unlocks the 4 `grammar-static-ctor-{accessor,gen}` rows with r3-1) `[byte-inert]`
+
+**Root cause.** TS parses `static constructor(){}` as a
+`ConstructorDeclaration` with a `static` modifier.
+`src/compiler/early-errors/module-rules.ts::checkDuplicateConstructors`
+L292 counts it; `src/codegen/ast-modifiers.ts::findConstructorImplementation`
+L40 would select it as the class's constructor; the method loops skip it
+(`ts.isMethodDeclaration`).
+
+**Edits.** (1) `checkDuplicateConstructors` L292: `&& !hasStaticModifier(member)`
+(import from `../../codegen/ast-modifiers.js` or duplicate the 2-line
+predicate locally to keep early-errors free of codegen imports — prefer the
+local twin). (2) `findConstructorImplementation`: `&& !hasStaticModifier(member)`.
+(3) `class-bodies.ts::collectClassDeclaration` L1506-1513 and L1514-1520
+method loops, `compileClassBodiesInner` L2958-2962 body loop, and
+`class-static-sidecar.ts::collectStaticMethods`: accept
+`isStaticCtorMethod(m) = ts.isConstructorDeclaration(m) && hasStaticModifier(m) && !!m.body`
+as a static method whose resolved name is the literal `"constructor"` (add
+the predicate to `ast-modifiers.ts`; `resolveInstallableClassMemberName`
+gets a one-line arm for it). The existing #3024 read arm
+(`property-access-dispatch.ts:2254`, `!ctx.staticMethodSet.has(fullName)`)
+then serves `C.constructor` as the static method, and r3-1's sidecar +
+hasOwnProperty delegate serve `C.hasOwnProperty('constructor')`.
+
+**Rows claimed (2):** `grep -E 'grammar-static-ctor-meth-valid'` (+4 via r3-1).
+
+**Growth:** `module-rules.ts::checkDuplicateConstructors` +2 · `ast-modifiers.ts` +6 · `class-bodies.ts` +8 · `class-static-sidecar.ts` +2.
+
+**Acceptance.**
+- 2 rows compile and pass (`C.hasOwnProperty('constructor')`,
+  `C.prototype.hasOwnProperty('constructor')`, `C.prototype.constructor !== C.constructor`).
+- PASSING shapes at risk: **(a)** the real duplicate-constructor early error
+  must still fire — `class C { constructor(){} constructor(){} }` must stay a
+  compile error (pin in the test file); **(b)** overload signatures
+  (`constructor(a: number); constructor(a: any) {}`) still select the bodied
+  one — `npx vitest run tests/classes tests/abstract-classes`; **(c)**
+  `computed-property-names/class/method/constructor-duplicate-1.js` in the
+  control list; **(d)** byte-identity of the three controls.
+
+### Step r3-5 — Heritage evaluation at ClassDefinitionEvaluation (F: 8 of 10 rows)
+
+**Root cause.** See the group table. Standalone has no `__register_class_parent`
+(host import) and no check at all.
+
+**Files / functions.**
+1. NEW leaf `src/codegen/class-heritage-check.ts` (template:
+   `class-proto-lookup.ts` for minting, `reflect-construct-native.ts:195
+   ensureReflectIsConstructor` for the IsConstructor query). Exports:
+   - `heritageNeedsRuntimeCheck(ctx, decl): ts.Expression | undefined` —
+     syntactic: unwrap parens; return the heritage expression when it is
+     NOT (a) an identifier in `ctx.classSet` / `classExprNameMap`, (b) an
+     identifier naming a builtin constructor (`isHostConstructibleBuiltin` /
+     the `standalone-subclass-ctors.ts` table), (c) an identifier whose
+     `ctx.oracle.valueDeclarationOf` is a plain (non-generator, non-async)
+     `FunctionDeclaration` or `FunctionExpression` — the fnctor parent lane
+     (`class-member-keys.ts:108 fnctorAncestorOfClass`), (d) a
+     `ClassExpression`, (e) a `PropertyAccessExpression` (react-style; not in
+     any row — leave its silent lane alone), (f) `null`. Everything else —
+     arrow, async arrow, generator function declaration, `42`, a call, an
+     identifier bound by `var/let/const` to an unknown value, the builtin
+     `Proxy` — is checked at runtime.
+   - `emitStandaloneHeritageCheck(ctx, fctx, decl, className)` — gated
+     `ctx.standalone`; compiles the heritage expression ONCE to externref and
+     calls the native `__class_heritage_check(parent: externref) -> void`:
+     `ref.is_null → return` (`extends null` is legal) · not an object
+     (`__typeof` ≠ "object"/"function", or the `$undefined`/number carriers)
+     → TypeError "Class extends value X is not a constructor or null" ·
+     `ensureReflectIsConstructor(parent) == 0` → same TypeError ·
+     `__extern_get(parent, "prototype")` neither object nor null →
+     TypeError "Class extends value does not have valid prototype property".
+     Throw via the standalone TypeError constructor the same way
+     `emitThrowTypeError` (`js-errors.ts`) does inside a native (mint the
+     message string constants with `addStringConstantGlobal`).
+2. Call sites: `nested-declarations.ts::compileNestedClassDeclaration`
+   immediately after L480 (`emitRegisterDynamicClassParent`, which is a no-op
+   in standalone) — before the early-return block at L497, so a re-compile
+   pass still emits it in order; `new-super.ts::compileClassExpression` right
+   before L2947; and the TOP-LEVEL declaration route: extend
+   `declarations.ts::shouldCollectTopLevelClassForRuntimeHeritage` (L2438
+   caller) so standalone collects a class whose `heritageNeedsRuntimeCheck`
+   is defined (today it is `!ctx.standalone && …`).
+3. Comma heritage (`side-effects-in-extends.js`, CE from
+   `ir/planning-identity.ts:412`): in `class-bodies.ts::collectClassDeclaration`
+   L977, unwrap `ParenthesizedExpression` and, for a `BinaryExpression` with
+   `CommaToken`, use the RIGHT operand as `baseExpr` for the static
+   resolution and push the LEFT operand onto a new
+   `ctx.classHeritagePrefixEffects: Map<string, ts.Expression[]>`
+   (`context/types.ts` + `create-context.ts`); `emitStandaloneHeritageCheck`
+   (and the host lane's `compileNestedClassDeclaration` L480 point) compiles
+   and drops those FIRST. The remaining asserts of that row
+   (`Object.getPrototypeOf(D) === C`, `C.prototype === Object.getPrototypeOf(D.prototype)`)
+   need a `classParentMap` arm in the `Object.getPrototypeOf(<class ident>)`
+   fold (`call-builtin-static.ts` L2102-2160 band) returning the parent's
+   class object via `emitLazyClassObjectGet` — add it; the prototype-chain
+   half is F1's link.
+
+**Rows claimed (8):** `grep -E 'heritage-(arrow|async-arrow)|constructable-but-no-prototype|invalid-extends|superclass-(arrow|generator)|Proxy/no-prototype|side-effects-in-extends'`.
+NOT claimed: `prototype-getter.js`, `prototype-setter.js` (an ACCESSOR
+`prototype` defined on a bound function must be invoked exactly once by the
+check — depends on `Object.defineProperty` on a function value honouring
+accessors in standalone; probe it, and if `__extern_get(bound,'prototype')`
+runs the getter the two rows come free — record either way).
+CONDITIONAL inside the 8: the two bound-function shapes in `superclass-*`
+and `constructable-but-no-prototype` depend on `__reflect_is_constructor`
+answering a `$__bound_fn` correctly (bound of an arrow/generator → 0, bound
+of a plain function → 1) and on `__extern_get(bound, 'prototype')` being
+`undefined`. Probe both on HEAD before edit 1; if the bound value is opaque
+to `fillReflectIsConstructor` (reflect-construct-native.ts:212 — it tests
+`constructibleClosureTypeIdxs`, `$Proxy`, builtin ctors), add a
+`$__bound_fn` arm there that reads the target's constructibility (the bind
+provider is `calls.ts:621 usesNativeFunctionBindProvider`) — or drop those 3
+rows from the claim and say so.
+
+**Growth:** new `class-heritage-check.ts` ~150 · `nested-declarations.ts::compileNestedClassDeclaration`
++6 · `new-super.ts::compileClassExpression` +4 · `declarations.ts` +6 ·
+`class-bodies.ts::collectClassDeclaration` +12 · `call-builtin-static.ts::compileBuiltinStaticCall`
++10 · `context/types.ts` +3 / `create-context.ts` +1 ·
+`reflect-construct-native.ts` +~15 only if the bound arm is needed.
+
+**Order constraints.** §15.7.14: heritage is evaluated (prefix effects, then
+the parent value, then IsConstructor, then `Get(prototype)`) BEFORE any
+computed key of the body and before the class object exists — so the check
+is emitted before `emitUnresolvedComputedAccessorNameEffects` at every site.
+The heritage expression is evaluated exactly ONCE (a getter that counts
+calls is the `prototype-getter.js` assert). A TDZ self-reference
+(`class x extends x`) keeps the existing L470 ReferenceError first.
+
+**Acceptance.**
+- 8 rows pass (or 5 with the bound-function residual recorded); probe p5
+  passes; `class D extends (calls++, C) {}` compiles and `calls === 1`.
+- PASSING shapes at risk: **(a)** fnctor parents — `ctl-fnctor.js`
+  byte-identical (excluded by predicate (c)) and
+  `expressions/super/call-construct-error.js` + `subclass/builtin-objects/{Map,Error}/regular-subclassing.js`
+  in the control list (builtin parents excluded by (b)); **(b)**
+  `extends null` — pin `class N extends null {}; print(typeof N)` (must not
+  throw); **(c)** `name-binding/in-extends-expression-assigned.js` (control
+  list) — the heritage is an assignment expression there and is now
+  runtime-checked: its value is a class object → IsConstructor must answer 1
+  for a `$ClassName` struct — verify `fillReflectIsConstructor` handles class
+  objects (the `tryEmitConstructorViaTag` family / `buildBuiltinConstructorTestArm`);
+  if it does not, add that arm BEFORE enabling the check, or the control
+  regresses; **(d)** `#4618` react shape stays on its host lane
+  (`npx vitest run tests/issue-4618*`); **(e)** `#1594B`
+  (`tests/issue-1594*`) self-reference TDZ ordering.
+
+### Step r3-6 — Derived-constructor `this` TDZ and double `super()` (D3: 2 of 3 rows)
+
+**Root cause.** See the group table (class-bodies.ts:2396-2448, this-keyword.ts:53, compileSuperCall).
+
+**Edits.**
+1. `class-bodies.ts::compileClassBodiesInner` at the `_init` build (after
+   L2498 `fctx.localMap.set("this", selfLocal)`): for a DERIVED ctor whose
+   body (a) references `this` or `super.<x>`/`super[<x>]` lexically before
+   its first statement-level `super(...)` (walk with `ts.forEachChild`,
+   stopping at nested non-arrow functions; arrows are walked), or (b) has ≥2
+   `super(...)` call sites anywhere, or (c) has a `super(...)` that is not a
+   direct statement (nested in a block/try/argument list), allocate an i32
+   local `__this_init` (0) and set `fctx.thisTdzFlagLocal = idx` (new
+   optional field on `FunctionContext`, `context/types.ts`). Otherwise
+   nothing changes (byte-identical for the straight-line ctor).
+2. `expressions/this-keyword.ts::compileThisKeyword` L53-61: when
+   `fctx.thisTdzFlagLocal !== undefined`, emit `local.get flag; i32.eqz; if →
+   emitThrowReferenceError("Must call super constructor in derived class
+   before accessing 'this' or returning from derived constructor")` before
+   the `local.get selfIdx`. Same check at the SuperKeyword entry of
+   `new-super.ts::compileSuperPropertyAccess` (L1275),
+   `::compileSuperElementAccess` (L1415) and `::compileSuperMethodCallCore`
+   (L1057) — one shared `emitThisTdzCheck(ctx, fctx)` helper in
+   `this-keyword.ts`.
+3. `class-bodies.ts::compileSuperCall`, user-parent arm (after the argument
+   compilation at L4224-4233 and BEFORE `call parentInit`): when the flag
+   exists — `if (flag) { <allocate a FRESH default instance: extract the
+   L2459-2487 default-field loop into emitDefaultStructAlloc(ctx, fctx,
+   className, fields)>; call parentInit; drop; throw ReferenceError("Super
+   constructor may only be called once") } else { call parentInit on
+   selfLocal; flag = 1 }`. Spec order (§13.3.7.1): arguments are evaluated,
+   the parent IS constructed (the test asserts `baseCalled === 1` and
+   `fCalled === 1` after the failing `super(f())`), THEN BindThisValue throws.
+   The fresh instance keeps the derived `this` untouched (`this === obj`).
+4. The `super(...)` inside an ARGUMENT list (`super(super(), f())`) is
+   reached through the #5153-F expression-position route already in the call
+   dispatcher; verify with `this-check-ordering.js` — the inner call must hit
+   edit 3 and throw before `f()` runs.
+
+**Rows claimed (2):** `this-access-restriction.js`, `this-check-ordering.js`.
+NOT claimed: `this-access-restriction-2.js` (needs a BASE ctor `return o` to
+override `this` — E, deferred).
+
+**Growth:** `class-bodies.ts` +~35 (`compileClassBodiesInner` +15,
+`compileSuperCall` +20) · `this-keyword.ts::compileThisKeyword` +10 ·
+`new-super.ts` +6 · `context/types.ts` +2.
+
+**Order constraints.** Straight-line ctors (one statement-level `super()`,
+no earlier `this`) MUST stay byte-identical — the predicate in edit 1 is the
+whole guarantee; `super(this.x)` evaluates `this.x` (throws) before anything
+else; nothing may reorder `emitOwnInstanceFieldInitializers()` (L2818),
+which runs after the parent init as today.
+
+**Acceptance.**
+- 2 rows pass; the r2 probes `probes5195/this-before-super.js` and
+  `super-twice.js` shapes (inline) throw ReferenceError.
+- PASSING shapes at risk: **(a)** every derived ctor with one `super()` —
+  `ctl-plain.js` byte-identical; `derived-class-return-override-with-this.js`
+  (control list) and `-with-{null,undefined}.js` still pass; **(b)** arrows
+  capturing `this` inside a derived ctor AFTER `super()` — pin
+  `class P{} class Q extends P { constructor(){ super(); this.f = () => this } }; print(typeof new Q().f())`;
+  **(c)** `tests/issue-1965-super-ctor-body.test.ts` — 4 of 13 fail on
+  main already (recorded above); it must not get WORSE; **(d)**
+  `expressions/super/call-arg-evaluation-err.js` (control list).
+
+### Step r3-7 — `caller` / `arguments` on class objects (T: 2 of 4 rows) `[byte-inert]`
+
+**Edits.** With r3-1.6 the `hasOwnProperty` halves are answered by the
+sidecar (false). For the READ: `property-access-dispatch.ts::emitClassStaticMemberRead`
+(the `ClassName.<prop>` band, before L2254): when `propName` is `caller` or
+`arguments` and the class declares no static member of that name, emit
+`emitThrowTypeError(ctx, fctx, "'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions…")`
+(same text `function-poison-pill.ts` uses) + `ref.null.extern`. For the
+WRITE: `assignment.ts::compilePropertyAssignment` L4500 arm, same predicate,
+same throw. Inherited: `SubClass.caller` resolves to the same band
+(`resolvedClass` = SubClass) — covered.
+
+**Rows claimed (2):** `restricted-properties.js` ×2 (statements + expressions).
+CONDITIONAL: `methods-restricted-properties.js` — `instance.method.hasOwnProperty('caller')`
+on a method CLOSURE and `accessor.get.caller`; probe after r3-1 and claim
+only if the closure bag already answers `false`/throws.
+NOT claimed: `strict-mode/arguments-callee.js` (fnctor `arguments.callee` +
+`Object.getPrototypeOf(D).arguments` — poison-pill on an fnctor VALUE).
+
+**Growth:** `property-access-dispatch.ts::emitClassStaticMemberRead` +10 · `assignment.ts::compilePropertyAssignment` +8.
+
+**Acceptance.** 2 rows; PASSING shape at risk: a class that DECLARES
+`static caller`/`static arguments` (or a static field of that name) keeps
+its value — pin `class W { static caller = 1 }; print(W.caller)`; byte-identity
+of the three controls.
+
+### Step r3-8 — Constructor `arguments` (O: 2 of 3 rows)
+
+**Root cause / edits.**
+1. `nested-declarations.ts::maybeSetArgcForKnownCall` L3448-3459 clamps to
+   `paramCount` and only publishes when the callee is in
+   `funcUsesArguments`/`funcOptionalParams`. The `new C(1, 2)` site for a
+   ZERO-formal ctor that reads `arguments` (`arguments/access.js`) must publish
+   the REAL count and the extras vector (`emitExtrasArgv`, the #1053 helper
+   right below at L3484) — find the `new` site's call to
+   `maybeSetArgcForKnownCall` in `new-super.ts` (grep `maybeSetArgcForKnownCall(`
+   there) and route extras when `ctx.funcUsesArguments.has(\`${C}_init\`)`
+   (the #5153 A.2 registration — verify which name it registered, `_new` or
+   `_init`, with a grep before editing).
+2. Implicit derived ctor (`class-bodies.ts::computeImplicitDerivedCtorPrefix`
+   L452 / the `_init` forwarding at L2521-2524): when the nearest ancestor
+   ctor reads `arguments`, the implicit `_init` must forward `__argc` and
+   `__extras_argv` unchanged — i.e. NOT re-clamp at its inner
+   `maybeSetArgcForKnownCall` — and the `new B(0,1,2)` site must publish the
+   extras beyond B's synthesized formals (0 here).
+
+**Rows claimed (2):** `arguments/access.js`,
+`subclass/class-definition-evaluation-empty-constructor-heritage-present.js`.
+CONDITIONAL: `arguments/default-constructor.js` also needs
+`Derived.apply(obj, arr)` → class-[[Call]] TypeError
+(`class-call-without-new.ts:66 tryEmitClassConstructorCallWithoutNew` extended
+to `.apply`/`.call` on a class identifier) — take it if it is a one-arm
+addition, else leave it.
+
+**Growth:** `nested-declarations.ts` +10 · `new-super.ts` +10 · `class-bodies.ts` +8.
+
+**Order constraints.** `__argc`/`__extras_argv` are GLOBALS: they must be set
+after the arguments are evaluated (an argument expression may itself call a
+function that resets them) and immediately before the call — the existing
+sites already do this; keep the placement.
+
+**Acceptance.** 2 rows; PASSING shapes at risk: **(a)** defaulted ctor params
+(`dflt-params-abrupt.js` ×2 in the control list; `#2082`/`#1965` tests —
+`npx vitest run tests/issue-1965* tests/issue-2082*`); **(b)** methods that
+read `arguments` (`methods-named-eval-arguments.js`, control list); **(c)**
+byte-identity of `ctl-plain.js` (no `arguments` read → no publish).
+
+### Step r3-9 — Nested array pattern inside an object-pattern parameter of a class method (N: 4 rows + 4 generator twins conditional)
+
+**Root cause.** Declaration-style param typing. The object-literal method and
+function-EXPRESSION twins pass; `statements/function/dstr/dflt-obj-ptrn-prop-ary.js`
+fails like the class method — so the divergent code is the typed
+binding-pattern PARAMETER slot, not the destructuring emitter.
+
+**Edits.** (1) Compile the two twins to WAT (`--wat`) and diff the parameter
+types + the `y` local of `m({ w: [x, y, z] = [4, 5, 6] } = { w: [7, undefined] })`
+— 10 minutes, do it before touching code; record the diff here. (2) Expected
+fix: `class-bodies.ts::collectClassDeclaration` L1586 (`resolveWasmType(ctx,
+paramType)` for a `param.name` that is an `ObjectBindingPattern` containing a
+nested `ArrayBindingPattern` whose element may be `undefined`) → `externref`
+slot, matching what the expression lane does; the same rule at the
+fctx-build phase (L3031 twin — the #5221 note says both phases must agree).
+Use `isUndefWidenedBindingElement` (`checker/type-mapper.ts:330`, already
+imported in `async-frame.ts:1475`) on the nested elements to decide, so a
+fully-typed pattern keeps its struct slot.
+
+**Rows claimed (4):** `grep -E 'class/dstr/meth(-static)?-dflt-obj-ptrn-prop-ary'`;
+the 4 `gen-meth*` twins flip only if the native generator lowering takes the
+widened slot through `$GenState` (`generators-native.ts`) — do NOT edit the
+generator emitter; if they do not flip, record it.
+
+**Growth:** `class-bodies.ts` +~12 · `destructuring-params.ts` +~10 if the
+element lane needs the widened source.
+
+**Acceptance.** 4 rows; PASSING shapes at risk: **(a)** typed destructuring
+params in class methods — `array-destructuring-param-strict-body.js` and
+`meth-dflt-obj-init-null.js` / `meth-ary-init-iter-close.js` (control
+list); **(b)** `npx vitest run tests/issue-3315* tests/issue-5154* tests/issue-821*`
+(the widening precedents named in `destructuring-params.ts:1453-1465`);
+**(c)** byte-identity of `ctl-plain.js`.
+
+### DEFERRED (with the reason; 35 in-scope rows)
+
+| Rows | Group | Why not this pass |
+|---|---|---|
+| 8 | M `dflt-params-arg-val-not-undefined` (4 + 4 gen) | Cross-lane rule (`type-mapper.ts:260 isUndefinedDefaultOnlyParam`): every function/arrow/object-method twin fails identically. r2 investigated and declined for the same reason (widening every scalar-initialized param changes typed code). Needs its own issue in the param-typing lane, with a rule such as "widen when the initializer is an ASSIGNMENT/CALL expression" measured across all twins. |
+| 7 | R NativeError `message` ownership | Error model (Lane A). Design sketch: presence bit or `$props`-bag storage for `message` at construction (`error-types.ts:291` stores it unconditionally; `:593 fieldArm` answers it unconditionally), an `$Object` prototype for Error subclasses (`standaloneClassProtoObjectApplies` excludes builtin parents), and a `__hasOwnProperty` arm for `$Error_struct` (none exists). Two sources of truth for `message` (field 1 vs bag) is the hazard. |
+| 3 | X class-expression identity (`accessor-name-*-computed-in` ×2, `name-binding/const`) | `classExprNameMap` is NAME-keyed; the second `C = class {}` overwrites the first. Fix = treat a multiply-assigned binding as a runtime VALUE with `prototype` served by the sidecar — which needs a sidecar for EVERY class (not byte-inert) or a per-binding gate. Not in one pass. |
+| 2 | fn-name-accessor-{get,set} | SetFunctionName from a symbol key on the installed half (`'get [test262]'`, `'get '`). Depends on r3-1; take only if the `$fnmeta` name slot can be written from the key global at install time. |
+| 2 | prototype-getter / prototype-setter | Accessor `prototype` on a bound function value; depends on `Object.defineProperty` honouring accessors on function objects in standalone. Probe after r3-5. |
+| 2 | J method named `new` | funcMap key collision with the ctor (`class-member-keys.ts:46`); the fix relocates the member NAME at every dispatch site. |
+| 2 | P bound class ctor | `$__bound_fn` construct path (`calls.ts:621`) drops bound args; separate provider work. |
+| 1 | E `derived-class-return-override-with-object` (+ `this-access-restriction-2`) | The struct-result lane cannot represent a foreign override object (control-flow.ts:488-509); needs the externref-result lane for derived ctors (`classExternrefBackedSet` opt-in) — a representation change, own issue. |
+| 1 | `strict-mode/arguments-callee.js` | fnctor value poison-pill (`arguments-callee-poison.ts`). |
+| 1 | `arguments/default-constructor.js` | conditional in r3-8. |
+| 1 | `methods-restricted-properties.js` | conditional in r3-7. |
+| 4 (counted in N) | N generator twins | conditional in r3-9. |
+
+### Expected yield
+
+| Step | Rows | Risk |
+|---|---|---|
+| r3-1 | 29 (20 alone, +9 with r3-2) | medium — touches every static accessor read and the trampoline finalize path |
+| r3-2 | 9 | low — one collector clause + one receiver resolver |
+| r3-3 | 4 | low — one fold arm; object-literal key shape to pin |
+| r3-4 | 2 (+4 in r3-1) | low |
+| r3-5 | 8 (5 firm + 3 bound-fn conditional) | medium — a NEW throw at class definition; the predicate list is the safety property |
+| r3-6 | 2 | medium — ctor lowering; gated to non-straight-line ctors |
+| r3-7 | 2 (+1 conditional) | low |
+| r3-8 | 2 (+1 conditional) | medium — `__argc` global protocol |
+| r3-9 | 4 (+4 conditional) | medium — param slot typing |
+
+**Firm total: 62 of the 97 in-scope rows** (conditional up to +13). After
+all steps the cluster should read ≈ 191 − 62 = 129 non-pass, of which 94 are
+out of scope. Whole-cluster re-run at the end (≤ 15 paths per batch, one at a
+time): `class.tsv` paths minus the four out-of-scope groups → expect ≥ 62
+new passes and **no row moving to a WORSE class** (a `fail` must not become
+`compile_error`/`timeout`), plus the 22 controls at 22/22 and the r2-landed
+rows listed under "Standing rules" still green.

--- a/plan/issues/5196-es2015-standalone-proxy-r2.md
+++ b/plan/issues/5196-es2015-standalone-proxy-r2.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone proxy — r2 residual pass"
 status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-09-01
+updated: 2026-09-03
 priority: medium
 horizon: m
 feasibility: medium
@@ -44,6 +44,15 @@ loc-budget-allow:
   - src/codegen/expressions/call-builtin-static.ts
   - src/codegen/expressions/new-super.ts
   - src/codegen/index.ts
+  # 2026-09-03 r3 plan (see "## Implementation Plan — r3 (2026-09-03)"):
+  # R3-5 opens the representation of a proxy-TARGET object literal at the
+  # variable-declaration compile sites (statements.ts / object-ops.ts, +~20
+  # each); R3-3's E-1 rebuilds a descriptor object inside the new
+  # `__defineProperty_value`/`_accessor` `$Proxy` front-guards; R3-2's C6 mints
+  # `__own_property_keys` beside `__getOwnPropertySymbols`. All growth, no
+  # refactor — every step adds an arm gated on the proxy runtime being present.
+  - src/codegen/statements.ts
+  - src/codegen/object-ops.ts
 func-budget-allow:
   # 2026-09-01 r2 plan: arm-ladder / dispatch-builder functions that gain one
   # more arm in the shape their existing arms already have (the step naming
@@ -61,6 +70,14 @@ func-budget-allow:
   - src/codegen/expressions/call-builtin-static.ts::compileBuiltinStaticCall
   - src/codegen/expressions/new-super.ts::emitDynamicNewFallback
   - src/codegen/index.ts::generateModule
+  # 2026-09-03 r3 plan: R3-4(c) adds a `ref.test __proxy_revoker` arm to
+  # `emitHasOwn` (a nested helper of ensureObjectRuntime, already >300 LOC);
+  # R3-5 may add an externref-slot decline to the `in` fold; R3-3 E-1 leaves
+  # the syntactic gate in compileObjectDefineProperty in place but the grant is
+  # here in case the implementer widens it via `tracesToProxyValue` (oracle).
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
+  - src/codegen/binary-ops-in.ts::compileInOperator
+  - src/codegen/object-ops.ts::compileObjectDefineProperty
 ---
 
 # #5196 — proxy r2: cluster and fix the residual proxy-bucket failures
@@ -893,3 +910,530 @@ Expected: +3 to +5.
   (already exists from #5389 — extend it) with one host+standalone control
   per step (p1, p4, p5, p6, p11, p12 shapes) and the exact test262 rows via
   `runTest262File`.
+
+## Implementation Plan — r3 (2026-09-03)
+
+Written by the Fable planning lane for an Opus implementer. The r2 residual
+plan above (2026-09-01) was **never dispatched**; this section re-verifies it
+against `origin/main` `bee5ddd535` (2026-09-03) and re-cuts it into steps that
+each carry a regression check on PASSING behaviour, per the six-wave lesson
+(five of six waves shipped regressions that a failing-row list cannot see).
+Where an r2 step is restated it is by reference — do not re-read r2 for the
+mechanics unless this section points there.
+
+### Census and re-verification (2026-09-03)
+
+- Input: `.tmp/census0903/proxy+reflect.tsv` — 157 non-pass rows
+  (`built-ins/Proxy/**` 125 + `built-ins/Reflect/**` 32; 141 `fail`, 16
+  `compile_error`), baseline stamped 2026-09-03 09:07 UTC, `oracle_lane:
+  honest`. The set is r2's 157 with one swap: `Reflect/apply/call-target.js`
+  now PASSES (dropped — the C4 `this`-threading question is closed) and
+  `Proxy/apply/trap-is-undefined-target-is-proxy.js` (generator host-import
+  compile error, #680/#2961) entered. Every other r2 cluster is unchanged.
+- Root-cause groups (from the error column crossed with the r2 probes; sizes
+  are exact, lists under `.tmp/census0903/probe5196/r3-*.txt`, partition
+  verified 157/157 against the TSV):
+
+  | group | rows | root cause (one line) |
+  |---|---:|---|
+  | R — `Proxy` read as a VALUE resolves to the namespace carrier, not a constructor | 27 | every `*-realm*` row does `new OProxy(t,h)` / `OProxy.revocable(t,h)` where `OProxy = $262.createRealm().global.Proxy` |
+  | A — §10.5 post-trap invariants not enforced (A1–A8) | 29 | dispatch builders return the trap result as-is ("Phase-F scope: NO result-invariants") |
+  | C — Reflect arm defects (C1–C6, C8a) | 22 | dropped booleans, missing non-object guards, string-only ownKeys, eager `#1472 Phase C` refusal |
+  | E — define/gOPD routing bypasses the proxy | 3 | syntactic `new Proxy` gate at `object-ops.ts:1000`; 1-arg gOPD compile error |
+  | D — revoker has no function metadata | 4 | `__proxy_revoker` is a 1-field struct known only to `fillApplyClosure` / `__typeof_function` |
+  | G — proxy TARGET literal keeps a closed representation | 5 | `delete p.attr` forwards onto a non-`$Object`, silently no-op |
+  | B — proxy as `[[Prototype]]` + receiver threading | 12 | DEFERRED (see below) |
+  | F — exotic targets under the trap-absent forward | 18 | DEFERRED — carrier-lane MOPs |
+  | C7 / C8b-d / E-3 | 5 | DEFERRED — wide blast radius for 1–2 rows each |
+  | X — owned elsewhere (#3371 14, #2046 7, realm harness 3, misc 7) | 31 | not this issue |
+
+- **Probe on `bee5ddd535`** (15 rows across R, A1, A2, A3, A7, B, C2, C4, C6,
+  D, E, G — `.tmp/census0903/probe5196/sample.txt`):
+
+  ```
+  npx tsx scripts/run-test262-paths.mts .tmp/census0903/probe5196/sample.txt --standalone
+  === counts ===
+  { fail: 15 }
+  ```
+
+  All 15 fail with the baseline's signature (`sample-run1.txt`), e.g.
+  `apply/null-handler-realm.js → TypeError: Proxy.revocable is not yet
+  implemented in --target standalone` (proves R's premise: the `OProxy` read is
+  the seeded namespace carrier whose `revocable` member is the
+  `builtin-value-read.ts:1717` refusal closure), `has/call-in-prototype.js →
+  handler is context Expected SameValue(«undefined», …)` (B: no trap fires
+  through `Object.create(proxy)`), `Reflect/ownKeys/return-on-corresponding-order.js
+  → Expected SameValue(«5», «7»)` (C6: symbols dropped). Nothing in the sample
+  has been fixed by the 09-01…09-03 merges (#5268 Steps 1/2-partial/3/6 landed
+  `object-integrity-proxy.ts`, `proxy-value-provenance.ts`,
+  `object-proto-proto-accessor.ts`; **#5268 Step 2.5 (gOPS proxy arm) and
+  2.7 (`__isPrototypeOf` hop) did NOT land** — `git show d21a768efa` touches
+  neither, and `object-runtime-prototype.ts:760-770` still seeds
+  `cur = candidate is $Object ? cast : null`).
+- Three micro-probes (`.tmp/census0903/probe5196/p{A,C,D}-*.js`, run one at a
+  time through `.tmp/probe-one.mts`, all `STATUS fail`):
+  - `pA` — `delete p.attr` on `new Proxy({attr:1}, {})` returns `true` but
+    `gOPD(target,"attr")` still answers the descriptor → G confirmed (forward
+    is a no-op on the target carrier).
+  - `pC` — `new OProxy({}, {get(){throw}})` throws `Cannot access property on
+    null or undefined at 321:11` from the `new` itself: the construct driver
+    takes the ordinary `callee.prototype` tail on the namespace carrier, never
+    `__proxy_create` → R confirmed.
+  - `pD` — `Object.defineProperty(r.proxy, "x", {value:1})` never fires the
+    `defineProperty` trap (`r = Proxy.revocable(…)`) → E confirmed; the
+    #5268 `tracesToProxyValue` predicate exists but `compileObjectDefineProperty`
+    does not use it.
+- Controls: `.tmp/census0903/probe5196/r3-controls.txt` — 70 rows, every one
+  `pass` in the 09-03 baseline (r2's 18 + 52 chosen from the directories each
+  step touches: Proxy/{construct,get,set,has,defineProperty,gOPD,ownKeys,
+  getPrototypeOf,setPrototypeOf,preventExtensions,apply,revocable},
+  Object/{setPrototypeOf,preventExtensions,freeze/proxy-*,getOwnPropertyNames,
+  prototype/__proto__,create}, Reflect/{set,setPrototypeOf,preventExtensions,
+  get,has,gOPD,defineProperty,ownKeys,apply}, language/expressions/{instanceof,
+  new,delete,in}, Function/prototype/bind). Baseline pass counts for the wider
+  directories, for the "N rows must stay green" checks below: Proxy 184/311,
+  Reflect/get 9/11, Reflect/has 9/10, Reflect/set 10/18, Reflect/setPrototypeOf
+  10/14, Reflect/preventExtensions 9/10, Reflect/ownKeys 10/13, Reflect/apply 7/9,
+  Reflect/defineProperty 10/12, Object/setPrototypeOf 11/12,
+  Object/preventExtensions 39/40, Object/freeze 51/53, Object/getOwnPropertyNames
+  42/45, Object/getOwnPropertyDescriptor 310/310, Object/defineProperty
+  1128/1131, Object/prototype/__proto__ 8/15, instanceof 37/43, new 56/59,
+  delete 62/69, in 28/36 (all editions; the standalone baseline).
+
+### Measurement protocol (every step)
+
+1. Before the first edit of a file: `git show HEAD:<path> > .tmp/base-<name>.ts`
+   (file-copy A/B; `git stash` is forbidden here — other agents share the
+   clone).
+2. After the step: `npx tsx scripts/run-test262-paths.mts .tmp/census0903/probe5196/r3-<X>.txt --standalone`
+   (claimed rows) AND `… r3-controls.txt --standalone` (must stay 70/70).
+   Batches ≤ 40 paths, one compile process at a time, `--isolate` only if a
+   row hangs; a compile timeout under load is an artifact — re-run alone.
+3. Byte-identity where a step promises it: compile the named control program
+   on base and branch with `compile(src, {target:"standalone"})` and compare
+   `sha256` of the bytes (`.tmp/es2015/probes5267/imports-of.mts` shows the
+   `compile` call; add a hash print). Where a step edits an emitted path for
+   ALL receivers (no byte-identity possible) it names the behavioural control
+   instead — run that control's rows on BOTH trees.
+4. Host-import check: `imports-of.mts` on one claimed row per step → `[]`.
+5. Gates, chained, before every commit (never piped):
+   `node scripts/check-loc-budget.mjs && node scripts/check-func-budget.mjs && node scripts/check-coercion-sites.mjs && npm run -s check:oracle-ratchet && npm run -s check:dead-exports`,
+   then `LOC_GATE_BASE=$(git rev-parse origin/main) node scripts/check-loc-budget.mjs`.
+   New type queries go through `ctx.oracle` (`variableInitializerOf`, the way
+   `proxy-value-provenance.ts` does) — never `ctx.checker.*` (oracle-ratchet).
+6. Every `Instr[]` template inside the proxy runtime is a FACTORY (fresh array
+   per use — `object-runtime-proxy.ts:96-104`); anything filled at finalize is
+   reserve-then-fill (`fillProxyDispatch`, `:2323`). Gate every new arm on the
+   proxy runtime being present (`ctx.funcMap.has("__proxy_get_dispatch")`) so
+   gc/host lanes and proxy-free standalone modules stay byte-identical.
+
+### Step R3-0 — `Proxy` as a first-class constructor value (R, 27 rows) — `r3-R.txt`
+
+**Root cause.** A bare `Proxy` identifier read materialises the namespace
+carrier (`builtin-static-globals.ts:40 ["Proxy", []]` →
+`emitBuiltinNamespaceObject` `:469`, a plain `$Object` whose `revocable`
+member is the `genericThrowBody` closure minted at `builtin-value-read.ts:1717`).
+`new <carrier>(t, h)` enters `fillNativeConstructDrivers`
+(`native-construct.ts:248`) whose only special arm is `ref.test $Proxy` (`:299-307`);
+a plain `$Object` callee falls to the ordinary tail.
+
+**Edits (in order).**
+1. `native-construct.ts` `fillNativeConstructDrivers`, inside the per-arity
+   loop, BEFORE the `canProxyConstruct` arm (`:299`): when
+   `ctx.builtinObjectGlobals.get("Proxy") !== undefined` AND
+   `ctx.funcMap.has("__proxy_create")`, push an arm: `local.get 0` /
+   `any.convert_extern`, `global.get <ProxyGlobal>` / `any.convert_extern`,
+   `ref.eq` (the global may still be `ref.null.extern` if never read — `ref.eq`
+   on null vs a non-null callee is simply 0, no extra guard needed) → `if`:
+   push arg0 / arg1 (`local.get 2` / `local.get 3`; for `arity < 2` push
+   `ref.null.extern` for the missing one — `__proxy_create`'s `requireObject`
+   (`object-runtime-proxy.ts:1494-1495`) turns that into the §28.2.1.1
+   TypeError), `call __proxy_create`, `return`. Arity > 2: extra args ignored.
+2. `builtin-value-read.ts` `ensureStandaloneBuiltinStaticMethodClosure`
+   (`:996`): add `case "Proxy.revocable"` beside `case "Reflect.get"` (`:1071`):
+   `paramTypes = [externref, externref]`, `returnType = externref`; then find
+   the body-emission block for the `Reflect.*` cases further down the same
+   function and add the twin: `ensureNativeProxyRuntime(ctx)` FIRST (it
+   registers natives — must precede any `closureFctx.body` push; the trailing
+   `flushLateImportShifts(ctx, closureFctx)` at `:1725` repairs the rest),
+   then `local.get 0`, `local.get 1`, `call __proxy_revocable`
+   (`object-runtime-proxy.ts:1658`). The namespace seed then carries a working
+   `revocable`; `r.revoke()` already routes through `fillApplyClosure`'s
+   revoker arm (#5389).
+3. Nothing else: `Proxy.length` / `Proxy.name` are not asserted by any R row.
+
+**Growth grant.** `native-construct.ts` (+~40 LOC, `fillNativeConstructDrivers`
+already in `func-budget-allow`), `builtin-value-read.ts` (+~25 LOC,
+`ensureStandaloneBuiltinStaticMethodClosure` already granted).
+
+**Order-preservation.** The new arm must sit BEFORE the `ref.test $Proxy` arm
+and AFTER nothing (it is the first test); it must not reorder the existing
+arms. The `Proxy` global is read, never written, here.
+
+**Acceptance.**
+- Claimed: +21 of `r3-R.txt` immediately (the rows whose non-realm twin passes
+  today), the remaining 6 (`defineProperty/targetdesc-*-realm` ×5,
+  `gopd/result-type-is-not-object-nor-undefined-realm`) after R3-1. Re-run the
+  list after BOTH steps.
+- Passing shapes at risk: every dynamic `new <externref callee>(…)` (class
+  values in `any` slots, `new F()` with `F` a closure, `Reflect.construct`
+  fallbacks) — the arm is gated on the `Proxy` carrier global existing, so a
+  module that never reads `Proxy` as a value must compile **byte-identical**:
+  hash-compare on base vs branch for (a) a class-in-`any` `new` program and
+  (b) `new Proxy({}, {})` + `Proxy.revocable({}, {})` (direct forms, which do
+  not materialise the carrier). Behavioural controls: `language/expressions/new/`
+  (56 pass), `built-ins/Proxy/construct/` (11 pass), `revocable/` (13 pass) on
+  both trees; `r3-controls.txt` 70/70.
+- `imports-of.mts` on `get/trap-is-not-callable-realm.js` → `[]`.
+
+### Step R3-1 — §10.5 descriptor-model invariants (A1–A8, 29 rows + 6 R twins) — `r3-A.txt`
+
+**Root cause.** `buildDispatch` (`object-runtime-proxy.ts:264`) trap arm,
+`buildDefineDispatch` (`:928`), `buildOwnKeysDispatch` (`:732`) and
+`buildProtoDispatch` (`:444`) return the trap result unvalidated (only #5140's
+target-independent checks exist, `:405-443` and `:463-530`).
+
+**Edits.** Implement r2 **Step 1** verbatim (its 1-a primitive table and 1-b
+per-operation table are still exact — the descriptor model, `$PropEntry.flags`
+and `__getOwnPropertyDescriptor` (`object-runtime-descriptors.ts:2909`) are
+unchanged), in the NEW module `src/codegen/object-runtime-proxy-invariants.ts`
+(export `registerProxyInvariantHelpers(ctx, deps)` + one `Instr[]` factory per
+operation, called from `ensureProxyRuntime` after `:83`), with these r3 deltas:
+
+1. `dispatchLocals()` (`:1001`) already reserves `res` at index `2 + arity`;
+   add `tdesc` (externref) and `ext` (i32) after it — FRESH array per use.
+2. A7 (`buildOwnKeysDispatch`): compute the TARGET's key set with
+   `__getOwnPropertyNames(target)` ++ `__getOwnPropertySymbols(target)`
+   (`object-runtime-descriptors.ts:3262` / `:3385`) — NOT
+   `__proxy_own_keys_all` (`object-integrity-proxy.ts:175`, which takes the
+   PROXY and would re-run the trap). Copy its `appendAll` loop idiom.
+3. A8b (`instanceof`): #5268 2.7 did not land, so this step owns the
+   `__isPrototypeOf` seed (`object-runtime-prototype.ts:760-770`): a `$Proxy`
+   candidate → `cur = __getPrototypeOf(candidate)` (front-guarded → gpo
+   dispatch, throws the §10.5.1 TypeError for
+   `instanceof-target-not-extensible-not-same-proto-throws`), cast when
+   `$Object` else answer 0. Leave the per-hop `struct.get` loop untouched.
+4. A8a: replace the `invStrictEqIdx` compare in the `!isSet` block
+   (`:504-526`) by the canonical proto-view compare r2 describes
+   (`__proxy_get_target_if_absent` → `__proto_from_function` on the trap
+   result vs the target `$Object`'s raw field 0, `ref.eq`, null-safe; keep the
+   SameValue fallback for non-`$Object` targets). Verify the `p10` probe flips.
+5. **Regression guard that r2 lacked:** a trap result that is a non-null,
+   non-primitive value the readers cannot decompose (a CLOSED literal struct
+   returned from a trap closure, a closure carrier, a `$Vec`) must be treated
+   as "an Object with no readable fields" — CompletePropertyDescriptor defaults
+   — and NEVER throw from a validator. Only a positive primitive/undefined
+   (`__typeof_number/string/boolean/bigint`, `__extern_is_undefined`,
+   `ref.is_null`) triggers the "not an Object" TypeError in A2. Probe this with
+   a trap `getOwnPropertyDescriptor(){ return {value:1, configurable:true,
+   enumerable:true, writable:true} }` over a configurable target prop —
+   must NOT throw before and after.
+
+**Growth grant.** New file `object-runtime-proxy-invariants.ts` (~450 LOC,
+already in `loc-budget-allow`), `object-runtime-proxy.ts` (+~120 wiring,
+`ensureProxyRuntime` already granted), `object-runtime-prototype.ts` (+~30,
+`buildObjectPrototypeHelpers` granted).
+
+**Order-preservation.** Validators run AFTER the driver call and BEFORE the
+result is pushed; the trap-ABSENT forward arms are not touched; a throwing
+trap propagates before any validator; `ToBoolean` is `__is_truthy` never
+`ref.is_null`; a revoked proxy still throws first. `__proxy_target_desc` must
+call the front-guarded `__getOwnPropertyDescriptor` (a proxy-of-proxy target
+recurses) — never read `ptarget`'s struct directly.
+
+**Acceptance.**
+- Claimed: `r3-A.txt` 29/29 (A1 6, A2 7, A3 4, A4 2, A5 2, A6 2, A7 3, A8 3)
+  plus the 6 R twins (re-run `r3-R.txt`).
+- Passing shapes at risk: EVERY trap that returns a VALID result now passes
+  through a validator — `built-ins/Proxy/` currently 184 pass: run all 311
+  rows (8 batches of ≤40) on the branch; **zero pass→non-pass**, listing any
+  by name. `language/expressions/instanceof/` (37 pass) and
+  `built-ins/Function/prototype/Symbol.hasInstance/` on both trees for the
+  `__isPrototypeOf` seed. The A8a compare touches `Object.getPrototypeOf` only
+  inside the proxy dispatch, but re-run `built-ins/Object/getPrototypeOf/` and
+  `Object/create/` (320 pass) anyway — the proto-view helpers are shared.
+- Byte-identity: a standalone program with no `Proxy` must hash-equal base
+  (the module is registered from `ensureProxyRuntime` only).
+
+### Step R3-2 — Reflect arms and call-site booleans (C1–C6, C8a; 22 rows) — `r3-C.txt`
+
+All arms live in `compileNamespaceStaticCall`
+(`src/codegen/expressions/call-namespace-static.ts`; line numbers below are
+current). The #2046 receiver refusal (`:887-920`) and the #3371 `construct`
+arms (`:1568-1740`) are NOT edited. Sub-steps ordered by rows/risk; each is
+independently shippable.
+
+- **C2 (5) — `setPrototypeOf` booleans.** (i) Reflect arm `:1221-1320`: after
+  `local.tee spoProtoLocal`, call `__object_setPrototypeOf_status`
+  (`object-runtime-prototype.ts:708`, `ensureLateImport` it BEFORE compiling
+  the operands — the `Object.setPrototypeOf` site `call-builtin-static.ts:1949-1962`
+  shows the reservation order) — status 0 → push `i32 0` without calling the
+  writer; else call `__object_setPrototypeOf`, `local.tee res`; if the target
+  is a `$Proxy` (`any.convert_extern` + `ref.test`) push `__is_truthy(res)`
+  else `drop; i32 1`. Keep the #5268 `immutable` branch as is. (ii)
+  `buildProtoDispatch` forward arm (`:534-544`): when `ptarget` is itself a
+  `$Proxy`, push the inner `__object_setPrototypeOf` result instead of
+  `drop; local.get 0` (the inner front-guard returns the inner dispatch's
+  booleanish), keep the token for ordinary targets. (iii)
+  `Object.setPrototypeOf` site `call-builtin-static.ts:2056-2058`: after
+  `call resolvedSpoIdx`, for a `$Proxy` receiver `__is_truthy` the result and
+  throw the existing `throwRefused` TypeError on 0, then push `objLocal` (the
+  spec return is `O`); ordinary receivers keep the current result push.
+  Rows: `Reflect/setPrototypeOf/return-false-if-target-is-not-extensible.js`,
+  `…-if-target-and-proto-are-the-same.js`, `…-if-target-is-prototype-of-proto.js`,
+  `Proxy/setPrototypeOf/toboolean-trap-result-false.js`,
+  `…/trap-is-missing-target-is-proxy.js`.
+- **C3 (3) — `preventExtensions` booleans.** Reflect arm `:1362-1414`: replace
+  `drop; i32.const 1` after `call nativeIdx` by `call __is_truthy` (an ordinary
+  `$Object` result is the object itself → truthy → 1, so the ordinary answer is
+  unchanged; a proxy answers the trap's booleanish). `buildExt1Dispatch`
+  forward arm for `TRAP_PREVEXT` (`:606+`): same "push inner result when the
+  target is a `$Proxy`" change as C2(ii). `Object.preventExtensions` site
+  (`call-builtin-static.ts:1786-1830`, `method === "preventExtensions"` ONLY —
+  the branch is shared with freeze/seal): for a `$Proxy` receiver
+  `__is_truthy` the `hostIdx` result, TypeError on 0 (§20.1.2.19 2.b), push
+  `objLocal`. Rows: `Reflect/preventExtensions/return-boolean-from-proxy-object.js`,
+  `Proxy/preventExtensions/return-false.js`, `…/trap-is-missing-target-is-proxy.js`.
+- **C1 (2) — `Reflect.set` bypasses the proxy.** In `ensureProxyRuntime`,
+  after the `setBody` patch (`:1760-1840`), `findBody("__reflect_set")`
+  (`object-runtime.ts:4226`) and `unshift` the same `ref.test $Proxy` guard
+  shape as `hasBody` (`:1845-1865`): `call __proxy_set_dispatch(p, key, value)`
+  → `__is_truthy` → `return`. Rows: `set/return-true-target-property-is-not-configurable.js`,
+  `set/trap-is-undefined-target-is-proxy.js` (the latter also needs its later
+  array assertions — F; count it only if it flips).
+- **C4 (4) — non-object / non-callable guards.** `get` (`:818`) and `has`
+  (`:934`) arms: after `emitReflectArgumentLocals()` call the existing local
+  `guardNativeReflectTarget(targetLocal, "Reflect.get called on non-object")`
+  (`:777`, the helper the ownKeys/isExtensible arms already use — it admits
+  closure carriers positively). `apply` arm (`:1416-1452`): (a) add to the
+  brand ladder a positive-`$Object`-non-callable rejection
+  (`__typeof_object(t) && !__typeof_function(t)`); (b) before `call applyIdx`,
+  reject an `argumentsList` that is missing (`argLocals[2] === undefined`) or
+  runtime null/undefined/primitive with the §7.3.19 TypeError. Rows:
+  `Reflect/get/target-is-not-object-throws.js`, `Reflect/has/target-is-not-object-throws.js`,
+  `Reflect/apply/target-is-not-callable-throws.js` (only the `{}` case fails
+  today), `Reflect/apply/arguments-list-is-not-array-like.js` — its FIRST
+  assertion needs `__extern_length` to invoke a `length` getter; probe
+  `Reflect.apply(fn, null, {get length(){throw new Test262Error()}})` first;
+  if it does not throw, leave the row open and say so in Results.
+- **C5 (4) — ToPropertyKey abrupt.** Insert `call __to_property_key`
+  (`object-runtime.ts:1533`) on the key local AFTER the target guard and
+  BEFORE the native call in the `get` (`:818`), `set` 3-arg non-receiver path
+  (`:887`), `getOwnPropertyDescriptor` (`:1049`) arms; `defineProperty`
+  (`:1101`): accept `arguments.length >= 2`, pad the missing descriptor with
+  the undefined singleton (`undefinedExternInstrs`, `any-helpers.ts:138`) so
+  the key coercion throws first and `__obj_define_from_desc` raises the
+  ToPropertyDescriptor TypeError otherwise. Rows: the four
+  `Reflect/*/return-abrupt-from-property-key.js`.
+- **C6 (3) — `Reflect.ownKeys` symbols + order.** Mint
+  `__own_property_keys(obj) -> externref($ObjVec)` in
+  `buildObjectDescriptorHelpers` right after `__getOwnPropertySymbols`
+  (`object-runtime-descriptors.ts:3385`), guarded by
+  `if (ctx.funcMap.has("__own_property_keys")) return` (the #5268 Step 2.5
+  twin name), = names ++ symbols in ONE vec (copy `appendAll` from
+  `object-integrity-proxy.ts:187`); route the arm (`:1008`) to it. FIRST
+  reproduce r2's p7 null-deref (`Reflect.ownKeys({p1:1, [Symbol()]:1, 2:1,
+  0:1})` in `__module_init`) — the suspect is the `__getOwnPropertyNames` walk
+  casting a `$Symbol` key to `$AnyString` (`:3262+`); the fix there is a
+  `ref.test` skip. Rows: `Reflect/ownKeys/return-on-corresponding-order.js`,
+  `…-large-index.js`, `order-after-define-property.js`.
+- **C8a (1) — `Reflect.hasOwnProperty("enumerate")`.** In the Phase-C refusal
+  branch (`:1738`), when `reflectMethod === "hasOwnProperty"` and
+  `expr.arguments.length === 1`: `emitBuiltinNamespaceObject(ctx, fctx, "Reflect")`,
+  compile the key, `call __hasOwnProperty`, return i32. Row:
+  `Reflect/enumerate/undefined.js` (its second assertion `Reflect.enumerate ===
+  undefined` is a member read of the carrier — verify it already answers
+  undefined; if it throws, the row stays open).
+
+**Growth grant.** `call-namespace-static.ts` (+~150, `compileNamespaceStaticCall`
+granted), `call-builtin-static.ts` (+~40, `compileBuiltinStaticCall` granted),
+`object-runtime-proxy.ts` (+~40), `object-runtime-descriptors.ts` (+~60,
+`buildObjectDescriptorHelpers` granted).
+
+**Order-preservation.** Spec order inside each arm is target-guard → key
+coercion → native call; `ArgumentListEvaluation` (all operands compiled by
+`emitReflectArgumentLocals`) stays BEFORE every guard. `__object_setPrototypeOf_status`
+must be consulted before the writer, and a 0 status must not call the writer
+(the writer is a silent no-op today, so double-calling is invisible — keep it
+single anyway). The `Object.preventExtensions` compile-away tracking
+(`:1724`) must not change.
+
+**Acceptance.**
+- Claimed: `r3-C.txt` 22 rows; expected floor 18 (C4's getter row and C8a
+  are conditional, `set/trap-is-undefined-target-is-proxy` needs F).
+- Passing shapes at risk: these arms are edited for ALL receivers, so no
+  byte-identity claim — behavioural controls on BOTH trees:
+  `built-ins/Reflect/{set,setPrototypeOf,preventExtensions,get,has,
+  getOwnPropertyDescriptor,defineProperty,ownKeys,apply}/` (current pass
+  10/10/9/9/9/12/10/10/7), `built-ins/Object/setPrototypeOf/` (11),
+  `Object/preventExtensions/` (39), `Object/freeze/` (51, incl. the #5268
+  `proxy-*` rows), `Object/prototype/__proto__/` (8, the #5268 Step 1 branch
+  in the same arm), `Object/getOwnPropertyNames/` (42) and
+  `Object/getOwnPropertySymbols/` (7) for C6. `r3-controls.txt` 70/70.
+- `imports-of.mts` on `Reflect/setPrototypeOf/return-false-if-target-is-not-extensible.js` → `[]`.
+
+### Step R3-3 — define/gOPD routing through the proxy (E, 3 rows) — `r3-E.txt`
+
+**Root cause.** `compileObjectDefineProperty` (`object-ops.ts:979-1010`)
+reroutes to `__obj_define_from_desc` only for a SYNTACTIC `new Proxy` binding
+(its own `isNewProxy` + `ctx.checker.getSymbolAtLocation`, `:1006`), so
+`r.proxy`, aliases and `any` receivers take the `__defineProperty_value` fast
+path that stores on the proxy externref. `Object.getOwnPropertyDescriptor(p)`
+with ONE argument falls past the `arguments.length >= 2` gate
+(`call-builtin-static.ts:2739`) into the `__get_builtin` compile error.
+
+**Edits.**
+1. **E-1 runtime guard (complete fix).** In `ensureProxyRuntime`, next to the
+   `objDefineBody` patch (`:2280`), `findBody("__defineProperty_value")`
+   (`object-runtime-descriptors.ts:717`, params `obj, key, value, f64 flags`;
+   flag word bits 0/1/2 = w/e/c, 3/4/5 = "specified", 7 = has value —
+   `object-ops.ts:777`) and `findBody("__defineProperty_accessor")` (`:1188`),
+   and `unshift` a `ref.test $Proxy` arm that rebuilds a descriptor `$Object`
+   holding ONLY the specified fields (`__new_plain_object` + `__extern_set`
+   per set bit; `call-parameters.js` counts the exact keys) and tail-calls
+   `__proxy_define_dispatch(p, key, desc)`, returning its result. The
+   syntactic gate at `object-ops.ts:1000` becomes redundant — leave it (its
+   emitted bytes are unchanged for non-proxies). Do NOT widen the gate with
+   `ctx.checker`; if a compile-time widening is wanted, use
+   `tracesToProxyValue` (`proxy-value-provenance.ts:69`, oracle-based).
+2. **E-2 1-arg gOPD.** `call-builtin-static.ts:2739`: under `ctx.standalone`
+   accept `arguments.length >= 1`; pad the key with `undefinedExternInstrs`
+   (the native coerces it to `"undefined"`; the revoked front-guard throws
+   first). Row: `getOwnPropertyDescriptor/null-handler.js`.
+
+**Growth grant.** `object-runtime-proxy.ts` (+~70), `call-builtin-static.ts`
+(+~10).
+
+**Order-preservation.** The guard is a FRONT test on param 0; the ordinary
+body's `ref.cast $Object` and every later arm keep their order. A revoked
+proxy must throw from the dispatch, not from the rebuild.
+
+**Acceptance.**
+- Claimed: `defineProperty/null-handler.js`, `defineProperty/call-parameters.js`,
+  `getOwnPropertyDescriptor/null-handler.js`; plus the `pD` probe must print
+  the trap firing.
+- Passing shapes at risk: `__defineProperty_value` is the store behind EVERY
+  `Object.defineProperty`, `Object.defineProperties`, `Object.create(p, descs)`
+  and the namespace seeding (`emitBuiltinNamespaceObject`): run
+  `built-ins/Object/defineProperty/` (1128 pass — 29 batches of 40; permitted
+  to sample 200 spread across `15.2.3.6-4-*` if time-boxed, and say so),
+  `Object/defineProperties/`, `Object/create/` (320), `Object/getOwnPropertyDescriptor/`
+  (310) on the branch: zero pass→non-pass. Byte-identity for a standalone
+  program that defines properties but never mentions `Proxy` (the guard is
+  installed only by `ensureProxyRuntime`).
+
+### Step R3-4 — first-class revoker (D, 4 rows) — `r3-D.txt`
+
+**Root cause.** `__proxy_revoker` (`object-runtime-proxy.ts:1638`) is a 1-field
+struct known only to `fillApplyClosure` (`object-runtime.ts:7694`) and
+`__typeof_function`; `gOPD(revoke,"length")` is undefined, `hasOwnProperty`
+false, `isConstructor(revoke)` throws "invoked with a non-function value".
+
+**Edits.** Each native below already has a NON-`$Object` head for builtin-
+function metadata (the #2896 `bfn…` arm — `buildNonObjectDeleteArms` in
+`__delete_property` shows the shape); add a `ref.test __proxy_revoker` arm
+IMMEDIATELY AFTER that existing arm in: (a) `__getOwnPropertyDescriptor`
+(`object-runtime-descriptors.ts:2909`): `"length"` → `__create_descriptor(box 0,
+FLAG_CONFIGURABLE)` (`:2998`), `"name"` → `{value:"", configurable}`, else
+undefined singleton; (b) `__getOwnPropertyNames` (`:3262`): `["length","name"]`
+in that order; (c) `emitHasOwn` (`object-runtime.ts:4545`): `length`/`name`
+only; (d) `fillReflectIsConstructor` (`reflect-construct-native.ts:212`):
+revoker → 0 — `isConstructor` in the harness is `Reflect.construct(function(){},
+[], f)` and the arm at `call-namespace-static.ts:1611-1617` already throws
+"newTarget is not a constructor" on 0; (e) `new revoke()`: check what the
+construct driver does with a callee that is neither `$Proxy` nor `$Object`
+(`native-construct.ts` ordinary tail) — add the revoker to its
+"not a constructor" TypeError arm. `__typeof_function` already answers 1.
+
+**Growth grant.** `object-runtime-descriptors.ts` (+~50), `object-runtime.ts`
+(+~15, `ensureObjectRuntime` — NEW grant below), `reflect-construct-native.ts`
+(+~10, `fillReflectIsConstructor` granted), `native-construct.ts` (+~15).
+
+**Order-preservation.** The arm goes AFTER the #2896 builtin-fn arm and BEFORE
+the `$Object` cast; it must not change what the builtin-fn arm answers for
+closures and bound functions. `property-order.js` needs `length` before
+`name`.
+
+**Acceptance.**
+- Claimed: `revocable/revocation-function-{length,name,property-order,
+  not-a-constructor}.js`.
+- Passing shapes at risk: `gOPD`/`getOwnPropertyNames`/`hasOwnProperty` on
+  functions, bound functions and builtins: run `built-ins/Function/prototype/bind/`
+  (93 pass), `built-ins/Function/length/`, `built-ins/Function/prototype/name*`,
+  `built-ins/Object/prototype/hasOwnProperty/` (62), `Proxy/revocable/` (13)
+  on both trees; `r3-controls.txt` 70/70. Byte-identity for a proxy-free
+  program (all arms gated on `ctx.structMap.get("__proxy_revoker")`).
+
+### Step R3-5 — open representation for a proxy TARGET literal (G, 5 rows) — `r3-G.txt`
+
+**Root cause.** `pA`: with `var target = {attr:1}; var p = new Proxy(target, {})`,
+`delete p.attr` forwards `__delete_property` onto a carrier that is not a
+`$Object` (silent `return 1`), so the target still owns `attr`;
+`gOPD(target,"attr")` and `"attr" in p` keep answering from the literal.
+`proxyBindingIsTarget` (`analysis/proxy-binding-escape.ts:284`) already marks
+the TARGET binding for externref storage (`proxyBindingNeedsExternref`,
+`:290`), but the INITIALIZER is still compiled as a closed struct and boxed.
+
+**Edits.** Find where `proxyBindingNeedsExternref` is consulted in the
+variable-declaration paths (grep; both the module-global and the function-local
+declaration compile) and, when it answers true AND the initializer is an
+object literal, compile the initializer with `compileObjectLiteralAsExternref`
+(the open `$Object` path the HANDLER already takes — `call-builtin-static.ts:3920`)
+instead of the closed-struct path. The `in` fold (`compileInOperator`,
+`binary-ops-in.ts:208-260`) already bypasses itself for externref-slot
+receivers — verify, do not edit unless `has/return-false-target-prop-exists.js`
+still folds. Verify with `pA` first, then the list.
+
+**Growth grant.** The declaration site file(s) the grep finds — expected
+`src/codegen/statements.ts` and/or `src/codegen/index.ts` (+~20 each; add the
+file to `loc-budget-allow` with a dated line if the gate names it —
+`index.ts::generateModule` is already granted), `binary-ops-in.ts` (+~10 if
+needed, `compileInOperator` — NEW grant below).
+
+**Order-preservation.** Only bindings for which `proxyBindingNeedsExternref`
+is ALREADY true change representation; every other literal keeps its closed
+struct. Static reads `target.attr` on such a binding already go through the
+externref accessor path (`ctx.externrefAccessorVars`).
+
+**Acceptance.**
+- Claimed: `deleteProperty/trap-is-undefined-{strict,not-strict}.js`,
+  `has/return-false-target-prop-exists.js`, `getOwnPropertyDescriptor/trap-is-undefined.js`,
+  `setPrototypeOf/not-extensible-target-same-target-prototype.js` (its second
+  half — `Object.setPrototypeOf(outro, p)` with `outro = {}` — also needs the
+  literal open; if it stays red, name the assertion).
+- Passing shapes at risk: every `var t = {…}; new Proxy(t, h)` row that passes
+  today because static reads of `t` fold (the 184 Proxy passes are the
+  population): run all `built-ins/Proxy/` again on the branch, zero
+  pass→non-pass; `language/expressions/delete/` (62), `language/expressions/in/`
+  (28), `r3-controls.txt` 70/70. Byte-identity for a program whose object
+  literals are never proxy targets.
+
+### DEFERRED (36 in-scope rows + 31 owned elsewhere) — do not start in this pass
+
+| id | rows | why deferred | pointer |
+|---|---:|---|---|
+| B — proxy as `[[Prototype]]` + receiver-threaded `[[Set]]` | 12 | needs a new `$Object` field or reserved key and a per-hop arm in `__extern_get` / `__extern_has` / `__extern_set_decide` / `__isPrototypeOf` / for-in — the hottest walkers in the runtime; the blast radius is every property read in every standalone module, which no control list can cover. Own issue, with `pnpm run test:equivalence:gate` + a full `built-ins/Object/` re-run as its floor. | r2 Step 4 (representation + walker arms + `__proxy_set_dispatch_recv` + `__ordinary_set_receiver`) is the design; the receiver primitive is also what #2046 (X2) needs — build it once, there. |
+| F — exotic targets under the trap-absent forward | 18 | each row's first failure is the carrier's MOP (array `length = 0`, String-wrapper deref, RegExp `lastIndex` brand check, bound-function `__apply_closure`), not the proxy layer; owners: array lane (#5268 N), #4491, #5198, `construct-bound.ts`. After R3-0…R3-5 re-run `proxy-cl-F.txt` and record the residue by carrier in Results; fix only a proxy-layer defect found (a dropped result, a `ref.cast $Object` on `ptarget`). | r2 Step 6 |
+| C7 `Reflect.defineProperty` → `false` | 1 | a mutable global threaded through nine throw sites of the #2042 S4 preflight, for one row | r2 C7 |
+| C8b `Object.getPrototypeOf(Reflect/Proxy)` | 2 | needs `%Object.prototype%` / `%Function.prototype%` as storable `$Object`s — measure first (`emitEs5IntrinsicPrototype` is not exported under that name; see `expressions/object-get-prototype-of.ts:177/259` `tryCompileEs5GetPrototypeOf{Early,Value}`); if either is a `$NativeProto`, it cannot be stored in `$Object.proto` | r2 C8(b) |
+| C8c `Reflect.getPrototypeOf({})` | 1 | reuse `tryCompileEs5GetPrototypeOfValue(ctx, fctx, expr)` (`object-get-prototype-of.ts:259`, inspects `arguments[0]` only) in the `getPrototypeOf` arm (`:1185`); cheap but untested against the arm's non-object guard order — do it only if R3-2 finishes under budget | r2 C8(c) |
+| C8d `defineProperty/desc-realm.js` | 1 | changes `__getPrototypeOf` for every ordinary object with a null `$proto` | r2 C8(0) |
+| E-3 lazy GetMethod (`setPrototypeOf/return-abrupt-from-get-trap.js`) | 1 | 13 eager read sites in `__proxy_create` become per-operation handler reads | r2 E-3 |
+| X1 #3371 (14), X2 #2046 (7), X3 realm harness (3), X4 misc (7: `Object.prototype.hasOwnProperty` value #5268-area, gOPS proxy arm = #5268 2.5, `enumerate` trap #1320, module-namespace exotic, two closed-struct Reflect receivers #2949/#2580, generator host imports #680/#2961) | 31 | owned elsewhere | r2 "Out of scope" table; `r3-owned-elsewhere.txt` |
+
+### r3 acceptance criteria (whole pass)
+
+- Floor **+80**, ceiling **+90** of the 126 in-scope rows: R 27, A 29, C 18–22,
+  E 3, D 4, G 3–5. Every row NOT flipped is named in Results with its first
+  failing assertion and owner.
+- `r3-controls.txt` 70/70 after every step; the per-step directory controls
+  above run on BOTH trees with zero pass→non-pass; the full `built-ins/Proxy/`
+  311 re-run after R3-1 and after R3-5.
+- Standalone modules host-import-free on one claimed row per step.
+- Gates chained (protocol §5); growth outside the frontmatter grants gets a
+  dated line in this file, never a baseline edit.
+- `tests/issue-5196-es2015-proxy-r2.test.ts` extended with one host +
+  standalone control per step (the `pA`/`pC`/`pD` shapes, r2's `p1`/`p4`/`p10`/
+  `p11`) asserting `WebAssembly.Module.imports(module).length === 0`, plus the
+  exact test262 rows via `runTest262File`; `node scripts/update-issues.mjs --check`,
+  `check-issue-ids.mjs`, `check-issue-spec-coverage.mjs` green.

--- a/plan/issues/5197-es2015-standalone-promise-r2.md
+++ b/plan/issues/5197-es2015-standalone-promise-r2.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone promise — r2 residual pass"
 status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-09-02
+updated: 2026-09-03
 loc-budget-allow:
   # 2026-09-01 (Slice B): the §27.2.1.3 settle closures gain the builtin-function
   # metadata carrier. Each grant lives in the module that already OWNS the
@@ -36,6 +36,23 @@ loc-budget-allow:
   # conditions from elsewhere.
   - src/codegen/promise-combinators.ts
   - src/codegen/expressions/call-namespace-static.ts
+  # 2026-09-03 (r3 plan, steps R3-1..R3-10): every r3 step extends a mechanism
+  # that already lives in one of these files, and the plan forbids forking a
+  # second protocol beside it. Expected growth per step is stated in the step
+  # itself; the totals are roughly:
+  #   promise-combinators   ~+420 (R3-2 generic element pipeline + resolve-element
+  #                          builtin-fn closures, R3-3 `.call(C, iter)` widening,
+  #                          R3-4 interleaved iterator drive, R3-1/R3-9 executor)
+  #   async-scheduler        ~+150 (R3-5 own-`then` capture in Resolve, R3-6
+  #                          SpeciesConstructor read in `then`, R3-8 boolean box)
+  #   call-namespace-static  ~+120 (R3-2 observable Get(C,"resolve") gate,
+  #                          R3-3 admission widening — the gate IS the dispatch)
+  #   closed-method-dispatch ~+60  (R3-5 bag-`then` arms in the two fills)
+  #   calls.ts               ~+30  (R3-2 f64-vec boxing arm in the dynamic path)
+  #   array-object-proto     ~+40  (R3-7 `p.then` value read → proto closure)
+  #   property-access-dispatch ~+30 (R3-7, if the read site is there instead)
+  - src/codegen/closed-method-dispatch.ts
+  - src/codegen/property-access-dispatch.ts
 func-budget-allow:
   # 2026-09-01 (Slice B): one extra `registerNative` call in the object-runtime
   # reservation block, and two three-line guard call sites on the `new` path.
@@ -48,6 +65,21 @@ func-budget-allow:
   # The conditions ARE the dispatch decision, so extracting them would move the
   # gate's own predicate out of the gate.
   - src/codegen/expressions/call-namespace-static.ts::compileNamespaceStaticCall
+  # 2026-09-03 (r3 plan): the four functions below are UNDER the 300-line
+  # threshold today (measured at bee5ddd535: emitStandalonePromiseThen 250,
+  # buildPromiseResolveValueBody 213, fillPromiseThenableHelpers 209,
+  # emitStandalonePromiseCombinatorRuntime 166) and the r3 steps that extend
+  # them (R3-6, R3-5, R3-5, R3-2/R3-4) may push each past it. The growth is one
+  # more arm inside the SAME decision ladder (an own-`then` / own-`constructor`
+  # bag consult before the native arm); pulling that arm out would split the
+  # ladder's predicate from the ladder. Prefer a helper for any new body >40
+  # lines (the plan names them: buildCombinatorElementStep,
+  # buildCombinatorElemFnClosureInstrs, emitPromiseSpeciesConstructorRead); the
+  # grant is for the residual in-place growth only.
+  - src/codegen/async-scheduler.ts::emitStandalonePromiseThen
+  - src/codegen/async-scheduler.ts::buildPromiseResolveValueBody
+  - src/codegen/closed-method-dispatch.ts::fillPromiseThenableHelpers
+  - src/codegen/promise-combinators.ts::emitStandalonePromiseCombinatorRuntime
 priority: high
 horizon: m
 feasibility: hard
@@ -631,3 +663,714 @@ capability half of their work is now done and shared.
   it the direct spelling `Promise.prototype.catch.call(t, f)` fell to the legacy
   `.call` tail that drops `thisArg`; a hand-probe with the value-erased spelling
   passed while test262 did not. Merge, never rebase.
+
+## Implementation Plan — r3 (2026-09-03)
+
+Base for every line number below: upstream `main` `bee5ddd535` (the census
+sha; HEAD `9c23347f57` adds only docs commits, `src/` is identical). Census:
+118 non-pass ES2015 rows in `.tmp/census0903/promise.tsv` — 50
+`compile_error` (all but 4 are `host_import_leak`), 68 `fail`, 0 timeout.
+Previous plan slices E–H map onto R3-2/R3-3/R3-4 (E, F1, F2), the deferred
+block (G, H); F3 (`allSettled`/`any`) has only the 4 class-`C` rows left and is
+deferred with them.
+
+### Root-cause groups (118 rows, by mechanism — not by path)
+
+| # | Root cause (one defect each) | Rows | Step |
+| --- | --- | ---: | --- |
+| G1 | The native combinators never do the observable `Get(C, "resolve")` / per-element `Call(resolve, C, v)` / `Invoke(next, "then", …)` — `Promise.resolve = f`, `defineProperty(Promise, "resolve", {get})` and an own `then` on a native element are all ignored. Includes the 4 `number[]`-argument rows that still leak `env::Promise_all` (the documented f64-vec gap). | 29 | R3-2 (23), R3-4 (6 `-close` rows) |
+| G2 | `Promise.all/race.call(C, iterable)` is admitted ONLY for `function C(){…}` declarations + an EMPTY `[]` (call-namespace-static.ts L2411-L2470); every other shape leaks `env::Promise_all`/`Promise_race` + `__js_array_new`. | 28 | R3-3 (27), R3-4 (1) |
+| G3 | Iterator abrupt completion / `IteratorClose` — the argument is drained to a vec BEFORE any element work, so `return()` is never called and a throwing `next()` surfaces as "argument is not iterable". | 6 (+1 in G2) | R3-4 (conditional — see the probe) |
+| G4 | `$__promise_custom_capability_executor` treats the canonical `undefined` singleton as "stored" (`ref.is_null` guard, promise-combinators.ts L186-L194), so `executor()` / `executor(undefined, undefined)` followed by `executor(f, g)` throws. | 4 | R3-1 |
+| G5 | `__promise_resolve_value` short-circuits on `ref.test $Promise` (async-scheduler.ts L1648-L1650) and never consults an own `then` written onto a native promise; the thenable job also re-reads `then` at job time instead of using the value captured at Resolve time. | 7 | R3-5 |
+| G6 | `then` never reads `constructor` / `@@species`; `Promise.resolve(x)` never reads `x.constructor`. | 5 (+2 subclass rows in G9) | R3-6 |
+| G7 | `p.then` / `p.catch` read as a VALUE off a `$Promise` instance answers `undefined` (probe C below). | 2 | R3-7 |
+| G8 | `.then` handler returning a `boolean` is boxed as a NUMBER (`coerceStackValueToExternref` L1828-L1835 ignores the i32 `boolean` brand). | 2 | R3-8 |
+| G9 | `class X extends Promise` used as `C` — standalone has no `Construct(C, «executor»)` for a compiled class and the host `__promise_subclass_ctor` leaks; 2 of these are the invalid-binary CEs. | 10 | DEFERRED |
+| G10 | `class C { static resolve(){throw} }` as `C` (needs G9's class construct) — the 8 `resolve-throws-iterator-return-*` rows across all four combinators. | 8 | DEFERRED |
+| G11 | GetCapabilitiesExecutor is minted on the bare funcref wrapper (L160-L176), not the builtin-fn metadata carrier Slice B gave the settle closures. | 3 | R3-9 |
+| G12 | `provablyNullishReceiver` (builtin-prototype-brand.ts L582-L587) takes TypeScript's control-flow narrowing of an initializer-less `var` as a PROOF of `undefined`, so `hasOwnProperty.call(resolveFunction, …)` compiles to a static TypeError. | 3 | R3-10 (2), 1 deferred |
+| G13 | #3371 arbitrary NewTarget (2), cross-realm prototype (1), global-object own `Promise` descriptor (1), `catch` on a primitive receiver / ToObject (1), `Promise.all("")` result-vec type mismatch (1), executor throw after `resolve(thenable)` (2), `Array.prototype.then` on the RESULT array (2), reaction FIFO order (1) | 11 | DEFERRED |
+
+29+28+6+4+7+5+2+2+10+8+3+3+11 = 118.
+
+### Verification on current main (do not skip — the baseline can be a day stale)
+
+15-row sample, one process, box load 1.2:
+
+```
+$ npx tsx scripts/run-test262-paths.mts .tmp/p5197r3/sample.txt --standalone
+=== counts ===
+{ compile_error: 3, fail: 12 }
+compile_error  built-ins/Promise/all/call-resolve-element.js
+                 standalone target emitted host imports: env::Promise_all, env::__js_array_new, env::__js_array_push (#2961)
+compile_error  built-ins/Promise/all/ctx-ctor-throws.js
+                 standalone target emitted host imports: env::Promise_all (#2961)
+compile_error  built-ins/Promise/all/invoke-resolve-on-promises-every-iteration-of-promise.js
+                 standalone target emitted host imports: env::Promise_all (#2961)
+fail  all/invoke-resolve.js            `resolve` invoked once for each iterated value Expected SameValue(«0», «3»)
+fail  all/invoke-then.js               `then` invoked once for every iterated value Expected SameValue(«0», «3»)
+fail  all/invoke-resolve-error-close.js  Expected SameValue(«0», «1»)
+fail  race/invoke-resolve-get-error.js   Expected SameValue(«TypeError: Promise.race argument is not iterable», «[object Object]»)
+fail  prototype/then/ctor-custom.js    The constructor is invoked exactly once Expected SameValue(«0», «1»)
+fail  prototype/then/ctor-null.js      Expected a TypeError to be thrown but no exception was thrown at all
+fail  prototype/catch/S25.4.5.1_A2.1_T1.js  The value of !!(p.catch instanceof Function) is expected to be true
+fail  resolve/arg-uniq-ctor.js         Expected SameValue(«true», «false»)
+fail  resolve/capability-executor-called-twice.js  TypeError | at L33
+fail  all/S25.4.4.1_A5.1_T1.js         reason … Expected SameValue(«TypeError: Promise.all argument is not iterable», «Test262Error: »)
+fail  race/resolve-self.js             async completion marker not observed
+fail  prototype/then/capability-executor-not-callable.js  CompileError: … extern.convert_any[0] expected type anyref, found call of type externref
+```
+
+All 15 reproduce the baseline status AND error string; nothing in the sample has
+been fixed by the merges since 09:07 UTC. Every group above has at least one
+member in the sample except G8/G9/G11/G12 (whose error strings are
+distinctive enough to trust).
+
+Mechanism probes (`.tmp/p5197r3/probe-carrier.mts`, three small standalone
+programs, `imports=[]` for all three):
+
+| probe | program | result | what it proves |
+| --- | --- | --- | --- |
+| A | `Promise.resolve = mine; Promise.resolve === mine; Promise.resolve(5) === 42` | `101` | the assignment lands on the `$Object` ctor carrier (`__builtin_ctor_Promise`, builtin-static-globals.ts L172) and a later `Promise.resolve(5)` CALL already dispatches to it — only the combinators ignore it |
+| B | `Object.defineProperty(Promise,'resolve',{get(){n++; return f}})`, two reads | `23` (2 gets, both return `f`) | accessor defines on the carrier work; `__extern_get(carrier, "resolve")` runs the getter |
+| C | `p.constructor = null; p.constructor === null` / `typeof Promise.resolve(2).then === "function"` | `1` (+0) | the `$Promise` bag round-trips `constructor` (R3-6 can read it); the instance member VALUE read of `then` is not a function (G7) |
+
+### Shared design constraints (apply to every step)
+
+- **Type info via `ctx.oracle` only** (`valueDeclarationOf`, `typeFactOf`,
+  `signatureOf`); no `ctx.checker.getTypeAtLocation` — the oracle-ratchet gate
+  fails otherwise. The only checker call already present in the touched region
+  (call-namespace-static.ts L2095, Set/Map probe) stays as it is.
+- **No new host import, anywhere.** Every arm is standalone-native
+  (`isStandalonePromiseActive`), and the host/gc lane must stay byte-identical:
+  the acceptance for every step includes a host-lane compile of the named
+  control programs and a `result.binary` byte comparison against the base tree.
+- **Registration-before-bake** (#2918/#2919): every `ensure*`/`reserve*` call
+  a step adds runs BEFORE any `ref.func`/`call` operand is pushed into a
+  detached buffer; and keep `fctx.savedBodies`/`ctx.liveBodies` discipline
+  exactly as the existing arms do (see the comment block at
+  call-namespace-static.ts L2056-L2068).
+- **`undefined` is not `ref.null.extern`** (#2864): any value that is
+  semantically `undefined` is `canonicalUndefinedExternInstrs(ctx)`
+  (any-helpers.ts L167), resolved BEFORE the body is swapped to a side buffer.
+- **`FunctionContext` literals** carry `labelMap: new Map()` and
+  `isGenerator?: boolean`; none of the steps should need a new one, but if a
+  helper function is minted through a fresh `FunctionContext`, include both.
+- **Every new callable that escapes to user code** (resolve-element functions,
+  GetCapabilitiesExecutor) is a subtype of the builtin-fn metadata carrier
+  (`ensureBuiltinFnMetaType`, builtin-fn-meta.ts L261) exactly like
+  `$__promise_settle_cap` (async-scheduler.ts L1044-L1075), never a second
+  representation.
+- **Probe command** for every row claim:
+  `npx tsx scripts/run-test262-paths.mts <list> --standalone` (≤15 paths per
+  batch, `--isolate` on a hang). Any single-row `compile_error (compilation
+  timeout …)` is re-run alone before it is believed. The in-process runner now
+  applies the host-import leak check (#5461); a row is claimed only when its
+  status is `pass`.
+
+### Steps, in execution order
+
+#### R3-1 — capability executor: `undefined` is "not yet stored" (4 rows, S, low risk)
+
+**Root cause.** `__promise_custom_capability_executor` (promise-combinators.ts
+L183-L215) decides "a slot was already stored" with `ref.is_null` on fields 0/1
+of `$__promise_custom_capability`. `executor(undefined, undefined)` and the
+zero-argument `executor()` (padded by `__apply_closure`) store the canonical
+`$AnyValue` `undefined` singleton, which is a NON-null externref, so the
+spec-legal second call `executor(f, g)` throws the TypeError meant for
+`(undefined, function)`.
+
+**Edits.**
+1. In `ensureCustomCapabilityRuntime` replace the two `ref.is_null` / `i32.eqz`
+   pairs (L186-L194) by "slot is nullish": `ref.is_null` OR the flagged
+   is-undefined predicate. Use the existing native the object runtime already
+   fills from `buildIsUndefinedExternBody` (any-helpers.ts, callers at
+   object-runtime.ts L2709 / L6404 and registry/imports.ts L1823 — read those
+   three to pick the registered `(externref) -> i32` name and call it; do NOT
+   inline a second copy of the predicate). If that native is not registered in
+   the module, fall back to `ref.is_null` (today's behaviour).
+2. The post-construction validation in `emitStandalonePromiseCustomCapabilityCheck`
+   (L311-L322) and `emitStandalonePromiseCustomSettle` (L410-L426) already
+   uses `ref.test wrapperRoot` (a stored `undefined` fails it) — unchanged.
+
+**Rows (4).** `built-ins/Promise/{all,race,resolve,reject}/capability-executor-called-twice.js`.
+Growth: promise-combinators.ts +15, no function crosses 300.
+
+**Order constraint.** The executor still stores BOTH arguments on every
+admitted call (spec GetCapabilitiesExecutor step 5-6 store, not merge).
+
+**Acceptance.** (a) the 4 rows `pass`; (b) PASSING shapes at risk — the six
+`capability-executor-not-callable` subcases (`tests/issue-4682.test.ts` "passes
+the six …" and `tests/issue-5197-promise-generic-capability.test.ts` 10/10) must
+still throw for `(undefined, function)` / `(function, undefined)` / a
+non-callable pair — run both files; (c) `reject/capability-executor-not-callable.js`,
+`reject/S25.4.4.4_A3.1_T1.js` (Slice-D rows) re-probed `pass`; (d) host lane:
+`tests/issue-4682.test.ts` "keeps the gc/host custom-constructor path unchanged"
+green.
+
+#### R3-2 — observable `resolve`/`then` pipeline on the intrinsic receiver over VEC arguments (23 rows, L, medium risk)
+
+**Root cause.** `emitStandalonePromiseCombinator` (L1199) and
+`emitStandalonePromiseCombinatorRuntime` (L1345) feed every element straight to
+`__combinator_subscribe` (L749), which normalizes through `__promise_resolve_value`
+and attaches raw microtask reaction FUNCS. Spec §27.2.4.1.1/§27.2.4.3.1 requires,
+per call: (1) `promiseResolve = Get(C, "resolve")` ONCE, before GetIterator,
+TypeError if not callable — IfAbruptRejectPromise; (2) per element
+`nextPromise = Call(promiseResolve, C, «value»)`; (3)
+`Invoke(nextPromise, "then", «resolveElement, capability.[[Reject]]»)` where
+`resolveElement` is a real built-in function object (`length` 1, `name` "",
+`[[AlreadyCalled]]`). Today `Promise.resolve = f` / a getter on the carrier /
+an own `then` on a native element promise are invisible, and an f64-backed
+`number[]` argument still falls through to the `env::Promise_all` host import
+(`resolveExternrefVecArg` L1297 returns null for f64 vecs; call-namespace-static.ts
+L2151-L2169).
+
+**Design — one generic step function, a fast path that stays byte-identical.**
+
+1. **Compile-time gate `promiseResolveObservable(ctx, node)`** (new, in
+   promise-combinators.ts, cached per source file like
+   `sourceHasMethodReassignment` at calls.ts L3131): true iff the source file
+   contains (a) an assignment whose LHS is `<X>.resolve` (reuse
+   `sourceHasMethodReassignment(ctx, node, "resolve")`), or (b) a call
+   `Object.defineProperty(<X>, "resolve"|…)` / `Object.defineProperties(<X>, …)`
+   whose first argument is the identifier `Promise`, or (c) any `.then` /
+   `"then"` assignment or defineProperty target (`sourceHasMethodReassignment(…, "then")`
+   plus the defineProperty scan). When FALSE the existing emitters run
+   unchanged — this is the byte-identity guarantee for every module that never
+   touches those properties (all of `tests/promise-combinators.test.ts`,
+   `deno-safe-promise-combinators.test.ts`, the async equivalence corpus).
+2. **`__combinator_get_resolve(C) -> externref`** (new defined func, registered
+   by `ensureCombinatorFunctions` only when the gate is true): `__extern_get(C,
+   "resolve")` on the carrier (`emitBuiltinConstructorIdentity(ctx, fctx,
+   "Promise")` pushes the carrier; getters run inside `__extern_get`), then
+   IsCallable via `buildClosureRefTestArms` (closed-method-dispatch.ts, the
+   #2175 classifier) → TypeError (`emitWasiErrorConstructor(ctx,"TypeError",1)`,
+   `__new_TypeError`) when not callable. The emit site wraps the call in
+   `buildTargetTaggedTry` and on catch rejects the result promise
+   (`rt.rejectFuncIdx`) and SKIPS the element loop — this is what
+   `invoke-resolve-get-error.js` observes (Get happens BEFORE GetIterator, so
+   emit it before the `__combinator_to_vec` call in `emitDynamicCombinatorArg`,
+   calls.ts L10480, and before the element buffers are spliced in the literal
+   arm).
+3. **Intrinsic fast path check.** Compare the fetched value with the intrinsic
+   singleton (`ensureStandaloneBuiltinStaticMethodClosure(ctx, "Promise",
+   "resolve")` + `pushBuiltinFnSingletonValueInstrs`, `ref.eq` after
+   `any.convert_extern`). Identical ⇒ the existing `__combinator_subscribe`
+   path (unchanged bytes, unchanged microtask count). Different ⇒ the generic
+   element step below.
+4. **`__combinator_element_step(next, state, index, C, fulfillFn, rejectFn)`**
+   (new, `buildCombinatorElementStep`): `next = __apply_closure(resolveFn, C,
+   [value])` is done by the CALLER (so the loop can catch and reject); this
+   helper implements `Invoke(next, "then", «resolveElem, rejectElem»)`:
+   - mint the two element functions as REAL closures (see 5) into an objvec
+     (`ensureObjVecBuilders`), then
+   - if `next` is a native `$Promise` AND (`__carrier_bag_has` is registered
+     AND `__carrier_bag_has(next, "then")` is 1) → `__apply_closure(
+     __extern_get(next, "then"), next, args)` — the same override branch
+     `emitStandalonePromiseThen` uses at async-scheduler.ts L4475-L4534;
+   - else if `next` is a native `$Promise` → the native subscribe (today's
+     `__combinator_subscribe` body) — but with the element closures' inner
+     funcs, so `[[AlreadyCalled]]` semantics are shared;
+   - else → `__call_m_then_vararg(next, args)` (the vararg dispatcher the
+     thenable job already uses, async-scheduler.ts L1205) preceded by
+     `__promise_has_callable_then(next)`; a 0 answer throws the §7.3.14 step-2
+     TypeError — same pairing Slice C used for `catch`.
+   Throws propagate to the caller's try, which rejects the aggregate.
+5. **Resolve-element / reject-element closures** (`buildCombinatorElemFnClosureInstrs`,
+   new): a struct `$__combinator_elem_fn` subtyping
+   `ensureBuiltinFnMetaType(ctx, wrapper.structTypeIdx, wrapper.closureInfo,
+   "promise:elem", "", 1)` (the `(externref)->()` wrapper, exactly as
+   `$__promise_settle_cap` at async-scheduler.ts L1044-L1075), adding fields
+   `caps: externref` (the `$CombinatorElemCaps`) and `called: mut i32`. Its
+   lifted trampoline: if `called` → return; set `called`; call the existing
+   reaction func (`reaction.fulfillIdx` / `reaction.rejectIdx` — the
+   `__combinator_all_fulfill` family, L889) with `(caps, value)`. Field order
+   is fixed by `ensureBuiltinFnMetaType`'s layout — copy
+   `buildPromiseSettleClosureInstrs` (L999) and NEVER hard-code the capture
+   index. `race`'s two functions are the capability's own resolve/reject (spec:
+   `Invoke(next, "then", «capability.[[Resolve]], capability.[[Reject]]»)`), so
+   for `race` reuse the Slice-B `$__promise_settle_cap` pair minted for the
+   RESULT promise (`ensurePromiseExecutorClosures` + `buildPromiseSettleClosureInstrs`)
+   — that is what `race/resolve-self.js` and `race/same-resolve-function.js`
+   assert (identity across elements).
+6. **f64-vec argument admission** (the 4 `every-iteration-of-promise` rows):
+   in `emitDynamicCombinatorArg` (calls.ts L10451) or a sibling arm at
+   call-namespace-static.ts L2151, when the probed argument type is a
+   `$Vec` whose element type is `f64`, loop it into a fresh externref `$Vec`
+   boxing each element with `__box_number` (late import registered BEFORE the
+   loop is built — `flushLateImportShifts`) and hand that vec to the runtime
+   emitter. Keep the `isDynamicCombinatorArgEligible` refusal for native
+   generators/strings as is.
+7. `emitStandalonePromiseCombinator` / `…Runtime` gain one parameter
+   `{ observable: { resolveLocal, ctorLocal } | undefined }`; when set they
+   emit the per-element `__apply_closure(resolve, C, [v])` + step-4 call
+   inside a `buildTargetTaggedTry` whose catch rejects `resultLocal` and
+   breaks the loop. `remaining` accounting stays in `$CombinatorState`
+   (the `all` fulfil still fires when the last element resolves; for the
+   spec's "resolve before loop exit" shape — elements settling synchronously
+   inside `then` — the state's `remaining` starts at n as today, which already
+   models step 4.h's +1/−1 bookkeeping for a fixed-length vec).
+
+**Order-preservation constraints (must not break).**
+- Element evaluation order: array-literal element expressions are compiled
+  into buffers FIRST (L2069-L2085) and only spliced after every `ensure*` —
+  keep that; the `Get(C,"resolve")` is emitted AFTER the element buffers are
+  evaluated (spec evaluates the argument expression before the call).
+- Microtask count for the intrinsic path must not change: a program with
+  `Promise.resolve = undefined`-free source must produce byte-identical wasm.
+- `Get(C, "resolve")` happens exactly ONCE per combinator call, before the
+  iterator is touched (`invoke-resolve-get-once-*`).
+- Rejection of the aggregate on a thrown `resolve`/`then` must use the
+  one-shot `rt.rejectFuncIdx` on `resultLocal`, never `__promise_reject` on a
+  fresh promise.
+
+**Rows (23).**
+`built-ins/Promise/all/{invoke-resolve,invoke-then,invoke-resolve-error-reject,invoke-resolve-get-error-reject,invoke-resolve-get-error,invoke-resolve-get-once-multiple-calls,invoke-resolve-get-once-no-calls,resolve-not-callable-reject-with-typeerror,invoke-resolve-on-promises-every-iteration-of-promise,invoke-resolve-on-values-every-iteration-of-promise,invoke-then-error-reject,invoke-then-get-error-reject}.js` (12),
+`built-ins/Promise/race/{invoke-resolve,invoke-then,invoke-resolve-get-error-reject,invoke-resolve-get-error,invoke-resolve-get-once-multiple-calls,invoke-resolve-get-once-no-calls,invoke-resolve-on-promises-every-iteration-of-promise,invoke-resolve-on-values-every-iteration-of-promise,invoke-then-error-reject,invoke-then-get-error-reject,resolve-self}.js` (11).
+
+**Growth grant.** promise-combinators.ts +300 (new helpers
+`promiseResolveObservable`, `buildCombinatorElementStep`,
+`buildCombinatorElemFnClosureInstrs`, `__combinator_get_resolve` body);
+call-namespace-static.ts +60 inside `compileNamespaceStaticCall` (granted);
+calls.ts +30 (`emitDynamicCombinatorArg` f64 arm); async-scheduler.ts +10
+(export `ensurePromiseExecutorClosures` is already exported; add
+`COMBINATOR_FUNC_IDX_KEYS` entries for every new funcIdx field — L5222, the
+late-import lockstep shift, or a `ref.func` baked from a stale index will
+silently target the wrong function).
+
+**Acceptance.**
+(a) the 23 rows `pass` with `imports=[]`;
+(b) PASSING shapes at risk — byte-identity: compile `tests/promise-combinators.test.ts`'s
+four sources and `tests/deno-safe-promise-combinators.test.ts` sources with
+`target:"standalone"` on base and on the branch and `Buffer.compare` the
+binaries (== 0, gate is false for them); run `tests/promise-combinators.test.ts`,
+`deno-safe-promise-combinators.test.ts`, `issue-2671-promise-capability.test.ts`
+(its one pre-existing failure stays exactly one), `issue-3125.test.ts`,
+`issue-3125-widen.test.ts` on BOTH lanes;
+(c) already-passing test262 controls re-probed: build the passing set with
+`ls test262/test/built-ins/Promise/{all,race}/*.js | grep -v -f <(cut -f1 .tmp/census0903/promise.tsv)`,
+probe 15 of them (all `S25.4.4.*` rows plus every `iter-arg-*` and `resolve-*`
+row in that set) and require every one still `pass`;
+(d) equivalence gate `pnpm run test:equivalence:gate` — 24 known failures, no
+new ones;
+(e) a NEW control in `tests/issue-5197-promise-generic-capability.test.ts`
+(or a new `tests/issue-5197-promise-observable-resolve.test.ts`, one fork):
+`Promise.resolve = spy; Promise.all([1,2])` counts 2 calls and
+`Promise.race([p])` on an own-`then` promise invokes that `then` — run on both
+lanes; the host lane compiles to the host `Promise` and must give the same
+observable counts.
+
+#### R3-3 — `Promise.{all,race}.call(C, iterable)` for ordinary-function `C` (27 rows, M, medium risk)
+
+**Root cause.** The `.call` arm (call-namespace-static.ts L2411-L2470) admits
+only `ts.isFunctionDeclaration(ctorDecl)` + `expr.arguments.length === 2` +
+an EMPTY array literal + `paramTypes.length === 1`. Slice D already widened the
+sibling `resolve/reject.call` arm (L2280-L2409) to function-EXPRESSION
+initializers (`ctorInit`), 1-or-2 arguments and a 0-parameter `C`; the
+combinator arm was left narrow because it had no per-element pipeline. R3-2
+supplies that pipeline.
+
+**Edits.**
+1. Lift the ctor-resolution block of the resolve/reject arm (L2299-L2312,
+   `unwrapReflectConstructExpr` → `ctx.oracle.valueDeclarationOf` →
+   `ctorInit` → `isOrdinaryCtorDecl`) into one helper
+   `resolveOrdinaryCapabilityCtor(ctx, arg): {ctorArg, isOrdinary}` and use it
+   in BOTH arms (do not duplicate the predicate; the two arms must admit the
+   same `C`). Also admit an inline `function(executor){…}` expression argument
+   (`race/capability-executor-not-callable.js` passes it directly).
+2. Admit `expr.arguments.length === 1` (`Promise.all.call(CustomPromise)`):
+   NewPromiseCapability runs first (C throws → propagates, `ctx-ctor-throws`);
+   then `GetIterator(undefined)` → TypeError → the result promise is
+   REJECTED (`rt.rejectFuncIdx`), not thrown — spec IfAbruptRejectPromise.
+   Admit `paramTypes.length === 0` (the `ZeroArgConstructor` rows expect the
+   steps 8-9 TypeError, which `emitStandalonePromiseCustomCapabilityCheck`
+   already raises once the executor is never invoked).
+3. Replace `emitStandalonePromiseCombinator(ctx, fctx, methodName, [])` at
+   L2464 by: capability check (unchanged) → `resolveFn = __combinator_get_resolve(C)`
+   (R3-2 step 2, with `C` = `ctorLocal` boxed via `extern.convert_any`, and the
+   IsCallable TypeError → REJECT via the capability's `[[Reject]]` slot, spec
+   step 6 IfAbruptRejectPromise — `all/capability-executor-called-twice.js`
+   fn3/fn4 expect a THROWN TypeError for the steps-8-9 failure, which happens
+   before the Get, so keep those two orders distinct) → for an array-literal
+   iterable, the R3-2 generic element loop with `observable` set and the
+   RESULT being the value returned by `C` (`resultLocal` of
+   `emitStandalonePromiseCustomSettle`'s pattern, L400-L404), settled through
+   the captured `[[Resolve]]`/`[[Reject]]` closures (`__apply_closure(slot,
+   undefined, [values])`) instead of `rt.fulfillFuncIdx`. The aggregate state
+   (`$CombinatorState`) still carries the results array; only the terminal
+   settle changes. Non-literal iterables (`Set`, vec vars, dynamic) reuse the
+   same R3-2 arms with `observable` set; custom iterables with `return` wait
+   for R3-4.
+4. `race` with custom `C`: the two element functions are the capability's
+   resolve/reject SLOTS (the closure values C stored), passed through unchanged
+   — identity is asserted by `race/same-{resolve,reject}-function.js`.
+
+**Rows (27).**
+`all/{call-resolve-element,call-resolve-element-after-return,call-resolve-element-items,capability-resolve-throws-reject,ctx-ctor-throws,invoke-resolve-return,new-resolve-function,resolve-before-loop-exit,resolve-before-loop-exit-from-same,resolve-element-function-extensible,resolve-element-function-length,resolve-element-function-name,resolve-element-function-nonconstructor,resolve-element-function-property-order,resolve-element-function-prototype,resolve-from-same-thenable,same-reject-function,S25.4.4.1_A4.1_T1}.js` (18),
+`race/{S25.4.4.3_A3.1_T1,capability-executor-not-callable,ctx-ctor-throws,invoke-resolve-error-reject,invoke-resolve-return,reject-from-same-thenable,resolve-from-same-thenable,same-reject-function,same-resolve-function}.js` (9).
+`resolve-element-function-nonconstructor.js` additionally needs `new fn()` on
+the element closure to throw — Slice B's `__builtinfn_is_builtin` `new`-site
+guard covers any builtin-fn-meta subtype, so it comes free with R3-2 step 5.
+
+**Growth grant.** call-namespace-static.ts +60 in `compileNamespaceStaticCall`
+(granted) — the admission conditions ARE the dispatch; promise-combinators.ts
++80 (`emitStandalonePromiseCustomCombinator` terminal-settle variant).
+
+**Order constraints.** Spec order for `Promise.all.call(C, iter)`: (1)
+NewPromiseCapability(C) — construct C, steps 8-9 TypeError THROWN; (2)
+`Get(C, "resolve")` — abrupt ⇒ REJECT the capability; (3) GetIterator —
+abrupt ⇒ REJECT; (4) per element. Today's empty-array arm skips (2) and (3)
+entirely; `all/capability-executor-called-twice.js` fn3 (`resolve` getter
+throws, expects the steps-8-9 TypeError, i.e. (1) wins) pins that (1) precedes
+(2).
+
+**Acceptance.** (a) the 27 rows `pass`, `imports=[]`; (b) PASSING shapes at
+risk — the 6 `capability-executor-not-callable` subcases and the empty-array
+`.call(fn, [])` rows (`tests/issue-4682.test.ts` all three tests, including
+"keeps the non-empty custom-constructor fallback unchanged" which must be
+REWRITTEN to assert the native result rather than the host fallback — say so
+in the test's comment), `tests/issue-4727.test.ts`, `tests/issue-5197-promise-generic-capability.test.ts`
+10/10; `all/{ctx-ctor-throws → already-passing twins} resolve/{ctx-ctor-throws,capability-invocation-error}`,
+`reject/{ctx-ctor-throws,capability-executor-not-callable,S25.4.4.4_A3.1_T1}`
+re-probed `pass`; (c) host lane: `tests/promise-combinators.test.ts`
+"compiled-fn capability constructor (#1694 A.i)" describe block green — those
+four tests run the host `Promise.all.call(fn, …)` path and must be
+byte-identical (compare binaries on base vs branch).
+
+#### R3-4 — interleaved iterator drive + IteratorClose (7 rows firm, 6 conditional, M, medium-high risk)
+
+**Root cause.** `emitDynamicCombinatorArg` drains the whole iterable into a
+`$Vec` via `__combinator_to_vec` (finalize-filled at promise-combinators.ts
+L1734-L1908) BEFORE any element work. Spec interleaves `IteratorStep` with
+`Call(promiseResolve)` and `Invoke(then)`, and on an abrupt element step
+performs `IteratorClose(iteratorRecord)` (calls `return`). The six `*-close`
+rows have a `next()` that NEVER reports `done` — the drain loops forever and
+the compile lane times out or the row fails on `callCount` — and
+`capability-resolve-throws-no-close.js` asserts `return` is NOT called when
+the abrupt step is the capability's own `resolve` throwing (spec: IfAbruptRejectPromise
+inside the loop only closes on `promiseResolve`/`then` abrupts, not on step
+4.h's `Call(capability.[[Resolve]])`).
+
+**Conditional rows — probe FIRST.** `all/{S25.4.4.1_A5.1_T1,iter-step-err-reject,iter-next-val-err-reject}.js`
+and the three `race/` twins reject with "argument is not iterable" today, which
+means `__combinator_to_vec` returned NULL, not that the throw escaped. Two
+hypotheses, different fixes: (H1) `__call_@@iterator` does not see a
+SYMBOL-keyed expando written as `obj[Symbol.iterator] = fn` on a `$Object`
+(for-of works on the same object only because it takes the compile-time #2162
+projection); (H2) the throw inside `__call_next` is caught and mapped to null
+somewhere in the `__call_*` dispatcher. Decide with a 3-line standalone probe
+that prints `typeof it[Symbol.iterator]` through `__extern_get` vs the
+dispatcher; fix H1 in `emitIteratorMethodExport`'s user arm, H2 in the
+dispatcher. Claim these 6 only if the fix is inside the combinator/iterator
+files named here; otherwise record them as a separate issue and leave them.
+
+**Edits.**
+1. Add `__combinator_drive(iterable, state, C, resolveFn, fulfillFn, rejectFn) -> i32`
+   (new, reserved at compile time beside `ensureCombinatorToVec`, filled at
+   finalize in `fillCombinatorToVec`'s slot right after it — same
+   `__call_@@iterator`/`__call_next`/`__sget_done`/`__sget_value` reads, same
+   bare-`next` fallback). Body: acquire iterator (null ⇒ return 0 = not
+   iterable); loop { `res = __call_next(it)` inside try → abrupt ⇒ reject
+   aggregate, return 1 (no close — spec 4.b/4.c set `[[Done]]` true); `done`
+   ⇒ break; `value` ⇒ `remaining++`; try { `next = __apply_closure(resolveFn, C,
+   [value])`; `__combinator_element_step(next, …)` (R3-2 step 4) } catch ⇒
+   `IteratorClose`: `__extern_get(it, "return")` — undefined/null ⇒ skip;
+   not callable ⇒ TypeError but the ORIGINAL throw wins (spec IteratorClose
+   step 5/6: a throw completion is returned as is); else call it and ignore
+   its result — then reject the aggregate with the original reason, return 1 }.
+   `$CombinatorState.remaining` becomes the spec's counter: start at 1, +1 per
+   element, −1 at loop end; when it reaches 0 at loop end the aggregate
+   fulfils with the results vec (which must be GROWABLE here — reuse the
+   `TOVEC_*` grow pattern L1781-L1797 on the state's `resultsArr`).
+2. `emitDynamicCombinatorArg` (calls.ts L10451): when `promiseResolveObservable`
+   OR the call is a custom-`C` `.call` (R3-3), emit `__combinator_drive`
+   instead of `__combinator_to_vec` + the runtime loop; otherwise unchanged
+   (byte-identity for every module without observable resolve — the six
+   `-close` rows all reassign `Promise.resolve` or define `then`, so they take
+   the new path).
+3. `remaining` starting at 1 changes `buildAllFulfillBody` (L889) only for
+   drive-mode states; add an `i32` `mode` field to `$CombinatorState`
+   (registerStruct L481) rather than branching on magic counts.
+
+**Rows (7 firm).** `all/{invoke-resolve-error-close,invoke-then-error-close,invoke-then-get-error-close,capability-resolve-throws-no-close}.js`,
+`race/{invoke-resolve-error-close,invoke-then-error-close,invoke-then-get-error-close}.js`.
+**Conditional (6).** `all/{S25.4.4.1_A5.1_T1,iter-step-err-reject,iter-next-val-err-reject}.js`,
+`race/{S25.4.4.3_A4.1_T1,iter-step-err-reject,iter-next-val-err-reject}.js`.
+
+**Growth grant.** promise-combinators.ts +150 (`buildCombinatorDriveBody`, the
+state `mode` field, grow helper); calls.ts +10.
+
+**Order constraints.** `Get(C,"resolve")` precedes GetIterator; `next()` is
+called at most once per element and NOT again after an abrupt step; `return`
+is called exactly once on an abrupt `resolve`/`then` step and never on an
+abrupt `next`/`done`/`value` read; the aggregate settles at most once.
+
+**Acceptance.** (a) firm rows `pass`; conditional rows `pass` or recorded as a
+separate issue with the probe result; (b) PASSING shapes at risk — every
+existing custom-iterable combinator row: `built-ins/Promise/all/iter-arg-is-*`,
+`race/iter-arg-is-*` (probe the full glob, ≤15 per batch), the async-generator
+`for await` corpus is untouched (no shared code), `tests/issue-2922*.test.ts`
+(if present) and `tests/promise-combinators.test.ts` on both lanes; byte-identity
+for a module with a custom iterable argument and NO resolve/then reassignment
+(compile `Promise.all(customIter)` on base and branch, compare binaries).
+
+#### R3-5 — own `then` on a native `$Promise` inside Resolve, captured at Resolve time (7 rows, S, low-medium risk)
+
+**Root cause.** `buildPromiseResolveValueBody` (async-scheduler.ts L1511)
+tests `ref.test $Promise` on the peeled value (L1648-L1650) and adopts the
+native state directly, so `thenable.then = f` on a native promise is never
+`Get`; spec §27.2.1.3.2 steps 8-13 `Get(resolution, "then")` runs for EVERY
+object. Additionally `__promise_thenable_job` (L1246-L1275) re-dispatches
+`__call_m_then_vararg(thenable, …)` at job time, whereas the spec captures
+`then` at Resolve time (`resolve-prms-cstm-then-immed.js` reassigns `then`
+after `resolve()` and asserts the LATE function is never called).
+
+**Edits.**
+1. In `buildPromiseResolveValueBody`'s `$Promise` arm (L1648-L1720), after
+   `selfCheck`, add: if `__carrier_bag_has` is registered in the module
+   (`ctx.funcMap.get(CARRIER_BAG_HAS)`, carrier-bag-visibility.ts L23) AND
+   `__carrier_bag_has(peeled, "then")` → `thenVal = __extern_get(peeled,
+   "then")`; if `thenVal` passes `buildClosureRefTestArms` → enqueue
+   `__promise_thenable_job` with caps `$__then_caps{callback: thenVal,
+   chained: promise}` (today `callback` is null for this job — L1274) and
+   return; else fall through to direct fulfil with `value` (a non-callable
+   own `then` ⇒ step 11). When the bag natives are not registered the arm is
+   absent — byte-identical for every module without promise expandos.
+2. In `__promise_thenable_job`'s try body (L1246-L1275): if `caps.callback`
+   is non-null → `__apply_closure(caps.callback, peeled thenable, argvec)`;
+   else the existing `__call_m_then_vararg` call. Nothing else changes.
+3. `fillPromiseThenableHelpers` (closed-method-dispatch.ts L1818): add a
+   `ref.test $Promise` + `__carrier_bag_has` arm BEFORE the `$Object` arm so a
+   `then`-bearing native promise answers 1 to `__promise_has_callable_then`
+   when reached through the non-promise path (an `$AnyValue`-boxed promise).
+   Gate it on `ctx.funcMap.get(CARRIER_BAG_HAS) !== undefined`.
+
+**Rows (7).** `prototype/then/resolve-{pending,settled}-{fulfilled,rejected}-prms-cstm-then.js` (4),
+`resolve-prms-cstm-then-{immed,deferred}.js` (2), `race/resolve-prms-cstm-then.js` (1).
+
+**Growth grant.** async-scheduler.ts +60 (the two functions, both granted
+above); closed-method-dispatch.ts +25.
+
+**Order constraints.** `Get(then)` runs synchronously inside Resolve (step 9),
+the CALL runs as a job (step 14); a throwing `then` getter on the native
+promise rejects synchronously via the existing `poisonedLocal` path — route the
+new Get through the same `buildTargetTaggedTry` (L1536-L1554) rather than a
+second try.
+
+**Acceptance.** (a) 7 rows `pass`; (b) PASSING shapes at risk — every
+native-promise adoption: `tests/issue-3125.test.ts` (all 6), `issue-3125-widen`,
+`promise-expando-standalone.test.ts` (which writes expandos onto promises and
+must NOT make plain adoption take the job path — assert its binaries only grow
+by the new arm, and that `Promise.resolve(p)` for an expando-free `p` still
+adopts synchronously), `issue-4167-test262.test.ts`, `issue-2623-promise-subclass-identity`,
+`issue-2867-gap4`; test262 controls `prototype/then/resolve-{pending,settled}-{fulfilled,rejected}-prms.js`
+(the non-custom twins — must stay `pass`) and `resolve-self`/`resolve-settled-*-self`;
+host lane byte-identical (the whole body is standalone/wasi-gated).
+
+#### R3-6 — `SpeciesConstructor` read in `then`; `x.constructor` check in `Promise.resolve` (5 rows, S, medium risk)
+
+**Root cause.** `emitStandalonePromiseThen` (L4286) never performs
+§27.2.5.4 step 3 `SpeciesConstructor(promise, %Promise%)`; `emitStandalonePromiseResolve`
+(L4164) skips §27.2.4.7.1 step 2.a `Get(x, "constructor")` and returns a
+native promise unchanged (`arg-uniq-ctor.js` sets `constructor = null` and
+expects a NEW promise).
+
+**Edits.**
+1. New `emitPromiseSpeciesConstructorRead(ctx, fctx, promiseLocal) -> {ctorLocal}`
+   (async-scheduler.ts, beside `emitStandalonePromiseThen`), emitted only when
+   `promiseSpeciesObservable(ctx, node)` — a per-file scan (same cache shape as
+   `sourceHasMethodReassignment`) for: an assignment/defineProperty whose key
+   is `constructor`, any `Symbol.species` token, or `defineProperty(Promise, …)`.
+   Body: `c = bag has "constructor" ? __extern_get(p, "constructor") : <Promise carrier>`
+   (`emitBuiltinConstructorIdentity(ctx, fctx, "Promise")`); `undefined` ⇒
+   default; not an object (null/primitive — use the object runtime's
+   is-object classifier, not `ref.is_null` alone) ⇒ TypeError; `s =
+   __extern_get(c, @@species)` (`ensureSymbolCarrier` + `__box_symbol` 5 as in
+   builtin-ctor-own-props.ts L307-L322); `s` undefined/null ⇒ default; `s`
+   `ref.eq` the Promise carrier ⇒ default (native path); anything else ⇒ if
+   IsConstructor fails ⇒ TypeError; if it IS a constructor, this pass has no
+   `Construct(S, «executor»)` for it (G9), so fall through to the native path
+   AFTER the Get/IsConstructor side effects ran, and say so in a code comment
+   naming G9 (`ctor-custom` / `deferred-is-resolved-value` are the rows that
+   need the real construct).
+2. Call it at the top of the `nativeBody` arm of `emitStandalonePromiseThen`
+   (after `promiseLocal` is set, L4363), so the override-`then` branch (an own
+   `then`) is unaffected. Throws propagate synchronously out of `then` — that
+   is what `ctor-null`/`ctor-poisoned`/`ctor-throws` assert.
+3. `emitStandalonePromiseResolve` L4182-L4187: in the `then` (native promise)
+   arm, when `__carrier_bag_has` is registered: if `bag has "constructor"` AND
+   `__extern_get(v, "constructor")` is not `ref.eq` the Promise carrier ⇒ take
+   the ELSE arm (new pending promise adopting `v`). Gate on the same
+   `promiseSpeciesObservable` scan for byte-identity.
+
+**Rows (5).** `prototype/then/{ctor-null,ctor-poisoned,ctor-throws,ctor-access-count}.js`,
+`resolve/arg-uniq-ctor.js`.
+
+**Growth grant.** async-scheduler.ts +80 (`emitPromiseSpeciesConstructorRead`
+new; `emitStandalonePromiseThen` +10, granted).
+
+**Order constraints.** `Get(constructor)` exactly once (`ctor-access-count`);
+it precedes the reaction attach; it is NOT performed on the own-`then`
+override branch (spec: `p.then` override means `Promise.prototype.then` was
+never entered).
+
+**Acceptance.** (a) 5 rows `pass`; (b) PASSING shapes at risk — every
+`p.then(...)` in a module that mentions `Symbol.species` or `constructor`:
+`tests/issue-2984-species.test.ts`, `issue-2984-ctor-carrier-own-props`,
+`issue-5197-es2015-promise-r2.test.ts` 8/8 (Slice A species rows), `issue-2623-promise-subclass-identity`,
+`issue-4746.test.ts` (Promise order rows); test262: every currently-passing
+`prototype/then/*.js` row (the glob minus the census rows, ≤15 per batch) and
+`Symbol.species/*.js`; byte-identity
+for a module with `then` but no `constructor`/species mention (compile
+`tests/issue-3125.test.ts` source 1 on base vs branch).
+
+#### R3-7 — `p.then` / `p.catch` / `p.finally` as VALUES on a `$Promise` instance (2 rows, S, low risk)
+
+**Root cause.** A member VALUE read of `then` off a `$Promise`-typed receiver
+answers `undefined` (probe C). The reflective closure for
+`Promise.prototype.then` exists (`ensurePromiseNativeProtoGlue`, brand
+registered by Slice C; value read of `Promise.prototype.<m>` goes through
+builtin-value-read.ts L616 / native-proto.ts `emitLazyNativeProtoGet`), but the
+instance read never consults the prototype.
+
+**Edits.** Find the site by compiling probe C with a breakpoint: the receiver
+is `ref $Promise` and the name is `then` — the read resolves in
+property-access-dispatch.ts (the struct-receiver member ladder) and falls to
+the bag miss ⇒ `undefined`. Add, in the standalone `$Promise` receiver arm:
+if the bag has no own `then`/`catch`/`finally` ⇒ push the SAME proto member
+closure the `Promise.prototype.<m>` read yields (call the glue's member
+closure getter; do not mint a second closure — identity `p.then ===
+Promise.prototype.then` is a spec fact and `S25.4.5.3_A1.1_T2` may compare).
+Reads of any OTHER member keep today's answer.
+
+**Rows (2).** `prototype/catch/S25.4.5.1_A2.1_T1.js`, `prototype/then/S25.4.5.3_A1.1_T2.js`.
+
+**Growth grant.** property-access-dispatch.ts +30 OR array-object-proto.ts
++40 (whichever owns the site; both granted).
+
+**Acceptance.** (a) 2 rows `pass`; (b) PASSING shapes at risk — the own-`then`
+override (`promise-expando-standalone.test.ts`: `p.then = f; p.then` must
+read `f`, and `emitStandalonePromiseThen`'s override branch must still fire);
+`then/context-check-on-entry.js`, `catch/{invokes-then,this-value-*}.js`
+(Slice C rows) re-probed `pass`; a compiled control `typeof p.then ===
+"function" && p.then === Promise.prototype.then` on both lanes.
+
+#### R3-8 — boolean results of `.then` handlers (2 rows, S, low risk)
+
+**Root cause.** `coerceStackValueToExternref` (async-scheduler.ts L1810) boxes
+every `i32` with `f64.convert_i32_s` + `__box_number` (L1828-L1835). The
+canonical i32→externref rule (type-coercion.ts L3396-L3407) honours the i32
+`boolean` brand (`from.boolean === true` ⇒ `__box_boolean`). `checkSequence`
+returns `boolean`, so `Promise.all([...]).then(r => compareArray(r, [true,true,true]))`
+sees `[1,1,1]`.
+
+**Edits.** In the `i32` case, if `from.boolean === true` and `__box_boolean`
+is registered (`addUnionImports` registers it in both modes; call
+`ensureUnionHelpersForThenWrapper`'s existing pre-registration path to make
+sure it is present BEFORE the wrapper body bakes the call), emit
+`call __box_boolean`; otherwise today's number box. Symbol-branded i32 is not
+reachable here (a handler returning a symbol is `externref` already) — assert
+that with a comment, not code.
+
+**Rows (2).** `race/resolved-sequence.js`, `race/resolved-sequence-with-rejections.js`.
+
+**Growth grant.** async-scheduler.ts +8.
+
+**Acceptance.** (a) 2 rows `pass`; (b) PASSING shapes at risk — handlers
+returning `number` (`tests/issue-2867*.test.ts`, `promise-combinators.test.ts`
+"Promise.all with resolved values"), handlers returning `boolean` consumed
+by `===` downstream; equivalence gate unchanged; host lane: the wrapper is
+standalone-only (`emitThenWrapperFunction` is reached only under
+`isStandaloneThenChainNativeActive`) — verify with a binary compare of
+`tests/promise-combinators.test.ts` source 1 on the host lane.
+
+#### R3-9 — GetCapabilitiesExecutor on the builtin-fn metadata carrier (3 rows, S, low risk)
+
+**Root cause.** `$__promise_custom_capability_executor` (promise-combinators.ts
+L160-L176) subtypes the bare `(externref, externref)->()` wrapper, so it has
+no `name`/`length`/prototype metadata; Slice B moved the settle closures onto
+`ensureBuiltinFnMetaType` for exactly this reason (`executor-function-length.js`
+passes only because `closureArityField()` happens to answer 2).
+
+**Edits.** Re-parent the struct onto
+`ensureBuiltinFnMetaType(ctx, wrapper.structTypeIdx, wrapper.closureInfo,
+"promise:capexec", "", 2)`; read the carrier's fields to place `$capability`
+AFTER them (`capMetaFields.length`, as L1055-L1058 does); factor the two
+`struct.new` mint sites (L262-L269 and L378-L387) into one
+`buildCustomCapabilityExecutorInstrs(runtime, stateLocal)` so the operand
+order lives in one place; the executor body's `ref.cast executorTypeIdx` +
+`struct.get CLOSURE_CAPTURE_FIELD_BASE` (L188-L190) must read the NEW
+capture index (`runtime.capabilityFieldIdx`), never the constant.
+
+**Rows (3).** `executor-function-{name,property-order,prototype}.js`.
+
+**Growth grant.** promise-combinators.ts +25 net.
+
+**Acceptance.** (a) 3 rows `pass`; (b) PASSING shapes at risk —
+`executor-function-{length,extensible}.js`, all Slice-D rows, `tests/issue-4682.test.ts`,
+`issue-4727.test.ts`, `issue-5197-promise-generic-capability.test.ts` (the
+executor is called from compiled `C` bodies through the wrapper `ref.test` —
+the subtype chain must still pass `getFuncRefWrapperRootTypeIdx`); the
+finalize `fillBuiltinFnMeta` arms must not double-register the
+`(name:"", length:2)` entry (it is keyed by identity — check the entry count
+in a compiled module before/after).
+
+#### R3-10 — an initializer-less `var` is not a proof of `undefined` (2 rows, S, low risk)
+
+**Root cause.** `provablyNullishReceiver` (builtin-prototype-brand.ts L582-L587)
+accepts `ctx.oracle.typeFactOf(e).kind === "undefined"`. For `var
+resolveFunction;` assigned only inside a nested function, TypeScript's
+control-flow analysis narrows the top-level use to `undefined` (an evolving
+`any`), which is a narrowing, not a proof; the borrowed-prototype arm then
+compiles `Object.prototype.hasOwnProperty.call(resolveFunction, "prototype")`
+to a static TypeError.
+
+**Edits.** Before trusting the fact, if `e` is an identifier whose
+`ctx.oracle.valueDeclarationOf(e)` is a `VariableDeclaration` with neither an
+initializer nor a type annotation (or a parameter), return false. Keep the
+`null` keyword and explicit `undefined`-typed declarations as proofs.
+
+**Rows (2).** `resolve-function-nonconstructor.js`, `reject-function-nonconstructor.js`
+(`hasOwnProperty.call(settleFn, "prototype")` then answers through the
+builtin-fn-meta gOPD arm — `false` — and Slice B's `new fn()` guard supplies the
+TypeError). `executor-function-not-a-constructor.js` also passes this gate but
+then needs `isConstructor()` = `Reflect.construct(function(){}, [], fn)` →
+#3371; record its new failure text, do not claim it.
+
+**Growth grant.** none needed (builtin-prototype-brand.ts is under threshold;
++10 lines).
+
+**Acceptance.** (a) 2 rows `pass`; (b) PASSING shapes at risk — every row that
+RELIES on the static nullish throw: probe `built-ins/Object/prototype/hasOwnProperty/*.js`,
+`built-ins/Object/prototype/isPrototypeOf/*.js`, `built-ins/Function/prototype/{call,apply}/*` (≤15 per
+batch, currently-passing set) and `tests/issue-4623*.test.ts` if present; the
+`null` literal and a `let x: undefined` receiver must still take the static
+throw (add a compiled control asserting the TypeError text).
+
+### DEFERRED (30 rows) — with the reason
+
+| rows | why not in this pass |
+| --- | --- |
+| G9 (10): `{all,race,resolve,reject}/ctx-ctor.js`, `then/ctor-custom.js`, `then/deferred-is-resolved-value.js`, `then/capability-executor-{called-twice,not-callable}.js`, `{all,race}/invoke-resolve-on-promises-every-iteration-of-custom.js` | need `Construct(C, «executor»)` for a compiled `class extends Promise` with a wasm-held executor argument — the `new`-site arms are AST-driven (`emitDynamicNewFallback`, new-super.ts L3290) and the host `__promise_subclass_ctor` is unsatisfiable (`class-bodies.ts` L175-L200). The two `then/capability-executor-*` CEs are an invalid-binary bug (`extern.convert_any` on an externref call result in `__module_init_chunk_0`) in the anonymous `new class extends Promise{…}(fn)` lowering — file it as its own issue; it blocks nothing here because the rows need G9 anyway. |
+| G10 (8): `{all,allSettled,any,race}/resolve-throws-iterator-return-{is-not-callable,null-or-undefined}.js` | `class BadPromise { static resolve(){throw} }` as `C` — same class-construct gap. |
+| #3371 (2): `get-prototype-abrupt{,-executor-not-callable}.js` | arbitrary NewTarget — Slice G, unchanged. |
+| `proto-from-ctor-realm.js` | Slice H (cross-realm), unchanged. |
+| `promise.js` | `verifyProperty(this, "Promise", …)` — global-object own-property reflection, cross-cutting (#4444's global-object blocker). |
+| `catch/this-value-obj-coercible.js` | §7.3.2 GetV ToObject for a primitive receiver (`Boolean.prototype.then`) — a wrapper-prototype expando lookup, separate mechanism. |
+| `all/iter-arg-is-string-resolve.js` | the handler's `v.length` is typed `string[]` by TS while the native result is an externref `$Vec` → illegal cast; a type-mapping fix in the combinator's RESULT typing, not a Promise-semantics fix. |
+| `exception-after-resolve-in-{executor,thenable-job}.js` | the executor-throw catch (promise-executor.ts L163-L205) rejects on PROMISE state, but `resolve(thenable)` leaves the promise pending; fixing it needs an `[[AlreadyResolved]]` record shared by the settle closures (or a new PENDING_RESOLVED state that the job's settle path is allowed to cross) — touches every settle path for 2 rows; own issue. |
+| `all/resolve-thenable.js`, `all/resolve-poisoned-then.js` | Resolve of the RESULT array must `Get(array, "then")` through `Array.prototype`'s expando; `__promise_has_callable_then` has no vec arm and the array-proto expando lookup is a different substrate. |
+| `then/S25.4.5.3_A5.1_T1.js` | reaction order: pending callbacks are PREPENDED (`emitStandalonePromiseThen` L4514-L4524, "FIFO append can be added later") so two `then`s on one pending promise fire LIFO. Real semantic bug worth its own issue; too much blast radius to bundle here. |
+| `executor-function-not-a-constructor.js` | after R3-10 it still needs the harness `isConstructor` (`Reflect.construct` with a NewTarget) — #3371. |
+
+### Expected yield
+
+Firm claims: R3-1 4 + R3-2 23 + R3-3 27 + R3-4 7 + R3-5 7 + R3-6 5 + R3-7 2 +
+R3-8 2 + R3-9 3 + R3-10 2 = **82 rows**; conditional +6 (R3-4 probe);
+deferred 30. Measure the WHOLE 118-row list before and after each step
+(file-copy A/B, refresh the "new" copy after every edit — see the Slice-D
+pitfall above), and re-probe the currently-passing `built-ins/Promise/**`
+ES2015 rows (the set `ls test262/test/built-ins/Promise -R` minus the census
+list, ~110 rows, ≤15 per batch) once after R3-4 and once at the end — that
+sweep, not the row list, is what catches a broken passing shape.

--- a/plan/issues/5267-es2015-standalone-forof-iterators-collections-r2.md
+++ b/plan/issues/5267-es2015-standalone-forof-iterators-collections-r2.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone: for-of + iterator prototypes + collections — r2 res
 status: in-progress
 sprint: current
 created: 2026-09-01
-updated: 2026-09-01
+updated: 2026-09-03
 priority: high
 horizon: l
 feasibility: medium
@@ -48,6 +48,17 @@ loc-budget-allow:
   - src/codegen/array-methods.ts
   - src/codegen/context/types.ts
   - src/codegen/index.ts
+  # 2026-09-03 r3 plan (files not already granted above): R3-8 adds a
+  # boxed-number arm to the standalone strict-eq helper; R3-2 seeds own `next`
+  # closures on the Map/Set iterator prototypes (new brands, own-props arms);
+  # R3-4(d) touches the finally re-inline; R3-6 exports the deleted-@@iterator
+  # guard for the for-of array path. Growth, not refactor — this change-set only.
+  - src/codegen/any-eq-helpers.ts
+  - src/codegen/native-proto-own-props.ts
+  - src/codegen/builtin-brands.ts
+  - src/codegen/statements/exceptions.ts
+  - src/codegen/statements/destructuring.ts
+  - src/codegen/set-runtime.ts
 func-budget-allow:
   # 2026-09-01: each is a kind-dispatch / arm-ladder function that gains one
   # more arm in the shape its existing arms already have (see the step that
@@ -68,6 +79,21 @@ func-budget-allow:
   - src/codegen/statements/for-of-destructuring.ts::compileForOfAssignDestructuringExternref
   - src/codegen/statements/for-of-destructuring.ts::compileForOfIteratorAssignDestructuring
   - src/codegen/index.ts::generateModule
+  # 2026-09-03 r3 plan: each gains one arm / one guard in the shape its existing
+  # arms already have (the R3 step that names it says which). `ensureMapHelpers`
+  # owns the `__map_iter_next` body (sticky exhaustion, R3-1c);
+  # `emitNativeCollectionCtorIterableDrive` gains the null→undefined normalize +
+  # the adder-branch move (R3-3); `compileForOfArray` gains the deleted-flag
+  # guard (R3-6); `getOrRegisterIterRecType` gains the `nextMethod` field
+  # (R3-4b); `registerAnyStrictEqAndComparisonHelpers` gains the boxed-number
+  # arm (R3-8); `makeCollectionGlue` gains the `@@1` alias (R3-7a).
+  - src/codegen/map-runtime.ts::ensureMapHelpers
+  - src/codegen/map-runtime.ts::tryCompileNativeMapMethodCall
+  - src/codegen/expressions/new-super.ts::emitNativeCollectionCtorIterableDrive
+  - src/codegen/statements/loops.ts::compileForOfArray
+  - src/codegen/iterator-native.ts::getOrRegisterIterRecType
+  - src/codegen/any-eq-helpers.ts::registerAnyStrictEqAndComparisonHelpers
+  - src/codegen/array-object-proto.ts::makeCollectionGlue
 ---
 
 # #5267 — ES2015 standalone: for-of + iterator prototypes + collections (r2)
@@ -930,3 +956,743 @@ keeping `Map/iterator-item-*-entry-returns-abrupt.js` from wedging a shard.
 
 **Steps C, D, E, F, G are untouched** — the plan above is unchanged and still
 accurate for them; only cluster B's residual count moved (17 → 5).
+
+## Implementation Plan — r3 (2026-09-03)
+
+Planner: Fable lane, read-only pass over main `bee5ddd535` (= origin/main at
+09:00 UTC). Implementer: an Opus agent in its own worktree, from this text.
+
+### Census and root-cause groups (101 residual rows)
+
+Source: `.tmp/census0903/for-of+collections.tsv` (standalone baseline rows
+stamped 2026-09-03 09:07 UTC × `test262-file-editions.json` ES2015). Grouped by
+the ERROR column, not by path:
+
+| # | Root cause | Rows | Error signature | Verdict |
+|---|---|---|---|---|
+| G1 | generator carrier: `env::__create_generator …` host imports | 23 | `standalone target emitted host imports: env::__create_generator, …` | OUT (#680 / #2864) |
+| G2 | generator carrier: native lowering refuses non-numeric yields | 12 | `native generator lowering currently supports only sequential numeric yields` | OUT (#680) |
+| G3 | `%Map/SetIteratorPrototype%.next` not materialised: `iterator.next` reads `undefined` | 10 | `Cannot read properties of undefined (reading 'call')` | **R3-2** |
+| G4 | same defect, metadata form (`MapIteratorProto.next` is `undefined` → gOPD of undefined) | 4 | `Cannot convert undefined or null to object` (`*IteratorPrototype/next/{name,length}.js`) | **R3-2** |
+| G5 | `map[Symbol.iterator]()` yields a record whose `.next()` is **null** (`map.keys()/entries()` work) | 4 | `Cannot access property on null or undefined at 33x:18` (`*IteratorPrototype/next/iteration{,-mutable}.js`) | **R3-1** |
+| G6 | exhausted `$MapIter` revived by a later `add` | 1 | `Exhausted result value (repeated request) … «4» … «undefined»` | **R3-1c** |
+| G7 | ctor drive: `Get(entry,"0")` on an entry without index `0` yields a NULL key → trap in the adder | 2 | `dereferencing a null pointer [in __closure_75() …]` | **R3-3a** |
+| G8 | ctor drive: CanBeHeldWeakly TypeError fires BEFORE a user-patched `set`/`add` | 2 | `Expected a Test262Error but got a TypeError` (`*-close-after-{set,add}-failure.js`) | **R3-3b** |
+| G9 | module-scope array loses identity when stored into a property → the accessor overlay is not seen → 4M-step ceiling TypeError (Map) / string-key TypeError (WeakMap) | 4 | `Expected a Test262Error but got a TypeError` (`iterator-item-{first,second}-entry-returns-abrupt.js` ×2 kinds) | DEFERRED (pre-existing identity gap, see r2 "Hang trap") |
+| G10 | for-of statement protocol (close on next/value abrupt; `next` re-read; non-Object result; finally re-inline; overlay accessor) | 6 | mixed (`Iterator is not closed`, `Should not access the next method after the iteration prologue`, `Expected a TypeError…no exception`, `«2» «1»`) | **R3-4** |
+| G11 | assignment-pattern head drive is eager (`__array_from_iter_n` up front) | 12 | `Expected SameValue(«1», «0»)` / `(«11», «0/1»)` (nextCount/returnCount), `«[object Object]», «12»`, elision/computed-key no-throw | **R3-5** |
+| G12 | `delete Array.prototype[Symbol.iterator]` not honoured by the for-of ARRAY fast path | 3 | `Expected a TypeError to be thrown but no exception was thrown at all` (`*-ary-init-iter-get-err-array-prototype.js`) | **R3-6** |
+| G13 | collection reflection: `@@iterator` own-ness on Map/Set proto (2), `size` gOPD (2), mixed-union `map.get` (1) | 5 | `Symbol() should be an own property` / `Cannot convert undefined or null to object` / `«NaN», «"valid"»` | **R3-7** |
+| G14 | `Ctor[Symbol.species]` write/delete/gOPD on a builtin ctor | 2 | `Expected obj[5] NOT to be writable, but was.` | DEFERRED (family: `Array/Symbol.species/symbol-species.js` fails identically — one owner for the species family) |
+| G15 | two boxed numbers from different producers are `!==` under `assert.sameValue` | 3 | `Expected SameValue(«0», «0») to be true` (`for-of/map{,-expand,-contract-expand}.js`) | **R3-8** |
+| G16 | anonymous `class` default in an OBJECT assignment pattern has no own `name` | 1 | `name should be an own property` (`dstr/obj-id-init-fn-name-class.js`) | **R3-9** |
+| G17 | realms (`$262.createRealm`) | 5 | `Cannot access property on null or undefined at 345:44` / `330:35` (4× `proto-from-ctor-realm.js`, `Symbol/iterator/cross-realm.js`) | OUT (#3371) |
+| G18 | parser: `[ x = 'x' in {} ]` in a for-of head | 1 | `',' expected.` | OUT (parser) |
+| G19 | well-known symbols are not own properties of the `Symbol` ctor | 1 | `iterator should be an own property` (`Symbol/iterator/prop-desc.js`) | OUT — the same defect fails all 12 `Symbol/*/prop-desc.js` rows in `.tmp/census0903/other-builtins.tsv`; one owner there |
+
+Totals: **53 claimed** (R3-1 5, R3-2 14, R3-3 4, R3-4 6 [4 firm + 2 stretch],
+R3-5 12, R3-6 3, R3-7 5, R3-8 3, R3-9 1) · **48 deferred / out of scope**
+(35 generator, 5 realm, 1 parser, 1 Symbol family, 2 species, 4 identity).
+
+### Verified on main (2026-09-03, load 1.2–3.1, in-process)
+
+```
+npx tsx scripts/run-test262-paths.mts .tmp/r3-5267/sample.txt --standalone
+=== counts ===  { fail: 14 }
+```
+
+14 rows, one per group (G3 `MapIteratorPrototype/next/this-not-object-throw-keys.js`,
+G4 `SetIteratorPrototype/next/length.js`, G5 `MapIteratorPrototype/next/iteration.js`,
+G7 `Map/iterator-items-are-not-object.js`, G8 `WeakMap/iterator-close-after-set-failure.js`,
+G10 `for-of/iterator-next-error.js` + `iterator-next-reference.js`, G11
+`dstr/array-elem-iter-thrw-close.js` + `array-rest-lref-err.js`, G13
+`Map/prototype/Symbol.iterator.js` + `Map/prototype/size/size.js`, G15
+`for-of/map.js`, G16 `dstr/obj-id-init-fn-name-class.js`, G19
+`Symbol/iterator/prop-desc.js`) — every one still fails with the baseline's
+error text (full output: `.tmp/r3-5267/sample.out`). Nothing in this cluster
+was fixed by what merged since the baseline; no group is dropped.
+
+Minimised repros, one compile each via `npx tsx .tmp/probe-one.mts <file>`
+(`.tmp/r3-5267/probes/`, results in `run1.out`):
+
+| probe | finding |
+|---|---|
+| `b1.js` | `map.keys().next()` → object; `map[Symbol.iterator]()` → non-null record; **its `.next()` → `null`** |
+| `b2.js` | `var f = map[Symbol.iterator]; f.call(map)` → **`null` record** (the `__mapset_symbol_iterator` closure route is broken too) |
+| `b3.js` | inline `map[Symbol.iterator]().next()` → `null` — so the STATIC `@@iterator` arm's product (`__iterator(map)`) is the bad producer, not the variable |
+| `a1.js` | `var z = [['a',1], 2]; z.length` OK; **`new Map([{}, 2])` traps** (`dereferencing a null pointer`) before the TypeError for `2` — an entry object WITHOUT index 0 yields a null key |
+| `f4.js` | **`[0,'a'][0] === a[0]` is FALSE at module scope** with `var a = [0,'a']` — G15 is not for-of specific; it is `===` on two `$BoxedNumber`s from different producers |
+| `f3.js` | array-pattern default `[ c2 = class {} ]` → `c2.name === 'c2'` OK; object-pattern default `{ cls = class {} }` → **`cls.name === undefined`** |
+| `g1.js` | `Object.getOwnPropertyDescriptor(Map.prototype,'size')` → object, `typeof d.get === 'function'` OK; **`typeof d.set` throws `Cannot convert undefined or null to object`** |
+
+### Method rules for every step
+
+- Type queries through `ctx.oracle` (`src/checker/oracle.ts`) — never
+  `ctx.checker.getTypeAtLocation` in NEW code (the oracle-ratchet gate). Where
+  a step needs the receiver's TS symbol name (Map/Set), use the oracle's
+  symbol/name query; where it needs the compiled `ValType` (a `$Map` struct
+  check), read the compiled result, not the checker.
+- Fresh `Instr` objects per arm (#2169b); reserve-then-fill for anything filled
+  at finalize (#1719/#2043); `ensureLateImport` + `flushLateImportShifts`
+  BEFORE resolving any funcIdx that will be baked.
+- Every step below is a separate commit, gates chained before each
+  (`node scripts/check-loc-budget.mjs && node scripts/check-func-budget.mjs && node scripts/check-coercion-sites.mjs && npm run -s check:oracle-ratchet && npm run -s check:dead-exports`,
+  also with `LOC_GATE_BASE=$(git rev-parse origin/main)`).
+- **Base-tree copies before the first edit** (`git show HEAD:<file> > .tmp/r3-5267/base/<file>`)
+  so every "byte-identical" acceptance below is a `cp` + recompile, not a claim.
+- Measurement: `npx tsx scripts/run-test262-paths.mts <list> --standalone`
+  (paths exactly as in the TSV, no `test/` prefix); `--isolate` for R3-6.
+  Row lists per step: write them to `.tmp/r3-5267/rows-R3-N.txt` from the
+  path globs given in each step. Controls (all currently passing, verify
+  before starting): `.tmp/es2015/forof-controls.txt` (28 rows; on the js-host
+  lane 5 of them fail on main already — `Map/map.js`,
+  `chunks/chunks-evenly-divisible.js`, `windows/windows-basic.js`,
+  `for-of/Array.prototype.Symbol.iterator.js`,
+  `for-of/dstr/array-elem-trlg-iter-list-nrml-close.js` — compare against
+  that baseline, not against 28) plus the per-step controls named below.
+- Box rules: one compile process at a time; probe batches ≤ 15 paths; never
+  a full sweep; a compile timeout under load is an artifact.
+
+### R3-1 — `map[Symbol.iterator]()` must yield the SAME live record `map.entries()` yields (5 rows)
+
+**Root cause.** `map.keys()/entries()` go through
+`compileNativeCollectionIterator` → `emitLiveCollectionIterRec`
+(`src/codegen/map-runtime.ts:2151-2166`), which builds the
+`$__IterRec{ITER_KIND_MAPSET}` inline. `map[Symbol.iterator]()` goes through
+the `@@iterator` arm of `compileTailDispatch`
+(`src/codegen/expressions/call-tail-dispatch.ts:754-815`): `resolveArrayInfo`
+is false for a Map, so it calls the dynamic ladder `__iterator(recv)`
+(`:807-810`). That ladder's `$Map` arm is SPLICED at finalize by
+`fillMapSetDynDispatchArms` (2) (`map-runtime.ts:2804-2856`) — and the probes
+show the product of `__iterator(map)` is a record whose `.next()` answers
+`null` (b3), and the closure route (`__mapset_symbol_iterator`,
+`map-runtime.ts:3070-3101`, body = `__iterator(this)`) answers a null RECORD
+(b2). Both point at `__iterator`'s `$Map` arm being absent or shadowed in the
+final body. Prime suspect: `fillNativeIteratorLateArms`
+(`src/codegen/iterator-native.ts:2389`) REBUILDS `__iterator`'s body
+(`index.ts:6030` / `:11110`), and `fillMapSetDynDispatchArms` (`index.ts:6480`
+/ `:11195`) refuses a second splice via the `__mapset_dyn_arms_filled` flag
+(`map-runtime.ts:2763`) — so any re-arm of the ladder after the first splice
+loses the `$Map` arm for good. Second suspect: the spliced arm sits AFTER
+`prependIterRecIdentityArm`'s rewrite (`iterator-native.ts:1692-1711`,
+`fn.body = [...]`) only by call order, which the two finalize paths do not
+guarantee identically.
+
+**Edits, in order.**
+
+1. **(a) static reroute — deterministic, independent of the root cause.** In
+   `compileTailDispatch`, inside the `methodName === "@@iterator"` arm and
+   BEFORE the `resolveArrayInfo` array arm (`call-tail-dispatch.ts:765`):
+   when `ctx.nativeStrings` and the receiver's TS symbol name (via
+   `ctx.oracle`) is `Map` or `Set`, snapshot-compile the receiver
+   (`snapshotSpeculative`/`rollbackSpeculative`, the `compileForOfNativeCollection`
+   pattern at `src/codegen/statements/loops.ts:1188-1192`) to confirm it lowers
+   to `ctx.mapTypeIdx`, then `return emitLiveCollectionIterRec(ctx, fctx, elemAccess.expression, isSet ? "values" : "entries", isSet)`
+   (export it from `map-runtime.ts` if it is module-private; it is the function
+   `compileNativeCollectionIterator` calls first). Extra call arguments:
+   evaluate + drop (spec ignores them). §24.1.3.12 / §24.2.3.11:
+   `Map.prototype[@@iterator]` IS `entries`, `Set.prototype[@@iterator]` IS
+   `values`, so the product is by definition the same record.
+2. **(b) dynamic ladder root cause.** Compile `.tmp/r3-5267/probes/b2.js` and
+   dump `__iterator`'s body (a WAT dump of the module — `scripts/` has no
+   flag for that on the runner path, so add a temporary `console.error` of
+   `definedFuncAt(ctx, ctx.funcMap.get("__iterator")).body.slice(0, 12)` at
+   the END of the second finalize path, or use `.tmp/es2015/probes5267/imports-of.mts`'
+   `compile()` call and `WebAssembly.Module` inspection). If the first arm is
+   NOT `ref.test $Map` (`mapTypeIdx`): make the `$Map` arm part of the
+   ladder's own build instead of a post-splice — in `buildIteratorBody`
+   (`iterator-native.ts:3473`) add the arm where `iterRecIdentityArm` is
+   applied (`:3431`), reading `ctx.mapTypeIdx` / `ctx.mapHelpers.get("__map_iter_new")`
+   at build time (they exist whenever a Map/Set was compiled before finalize;
+   when they do not, emit nothing — byte-identical for Map-free modules). Keep
+   the `fillMapSetDynDispatchArms` splice but make its idempotence key the
+   TARGET body (`iterFn.body` identity or a marker instr), not a global flag,
+   so a rebuilt ladder is re-armed. Then `b2.js` `closure-route-*` must pass.
+3. **(c) sticky exhaustion (`Set/prototype/values/values-iteration-mutable.js`).**
+   In `ensureMapHelpers`' `__map_iter_next` body (`map-runtime.ts:1115-1290`):
+   the done branch (`:1274-1277`, reached when `idx >= entryCount`) must first
+   `struct.set $MapIter.IT_INDEX := 0x7fffffff` (locals: `0` = it) so the
+   `i32.ge_s` test at `:1162` stays true after a later `add` grows
+   `M_ENTRYCOUNT`. `__map_iter_new` (`:1112`) starts at 0 — untouched.
+
+**Rows claimed (5).** `built-ins/MapIteratorPrototype/next/iteration.js`,
+`built-ins/MapIteratorPrototype/next/iteration-mutable.js`,
+`built-ins/SetIteratorPrototype/next/iteration.js`,
+`built-ins/SetIteratorPrototype/next/iteration-mutable.js`,
+`built-ins/Set/prototype/values/values-iteration-mutable.js`. Also unblocks
+the trailing `iterator.next.call(map[Symbol.iterator]())` line of 10 R3-2 rows.
+
+**Growth.** `call-tail-dispatch.ts` +30 (`compileTailDispatch`, one arm);
+`map-runtime.ts` +25 (`ensureMapHelpers` +6, `fillMapSetDynDispatchArms` re-key);
+`iterator-native.ts` +40 if (b) moves the arm into `buildIteratorBody`.
+
+**Order constraints.** (a) must evaluate the receiver exactly once and before
+the extra arguments; the record must be LIVE (no `emitCollectionIteratorVec`
+snapshot). (c) must not touch the non-done path (mutation rows depend on the
+tombstone-skipping walk exactly as it is).
+
+**Passing shapes at risk + how to check.**
+- `for (x of map)` / `for ([k, v] of map)` / `for (x of set)` /
+  `[...map]` / `Array.from(set)` / `new Set(map.keys())` — all consume the
+  MAPSET record or the vec projection: run the 6 Map/Set rows of
+  `forof-controls.txt` plus `built-ins/Map/prototype/entries/returns-iterator.js`,
+  `built-ins/Set/prototype/values/returns-iterator.js`,
+  `built-ins/Map/prototype/delete/does-not-break-iterators.js`,
+  `built-ins/SetIteratorPrototype/next/does-not-have-mapiterator-internal-slots-set.js`
+  (pass today).
+- Array receivers of `[Symbol.iterator]()` must be byte-identical: compile
+  `.tmp/es2015/probes5267/p2-array-symiter-next.js` on base and new tree and
+  `cmp` the `.wasm` (the reroute is gated on Map/Set symbol names).
+- js-host lane: the reroute is under `ctx.nativeStrings`; confirm with the
+  host-lane run of `forof-controls.txt` (23/28 baseline).
+- Any module with a Set-typed `values()` loop that exhausts and then `add`s
+  again expects `done` to stay true — the equivalence gate corpus is the
+  detector: `pnpm run test:equivalence:gate` must stay at its baseline.
+
+### R3-2 — own `next` on `%MapIteratorPrototype%` / `%SetIteratorPrototype%`, and `iterator.next` as a VALUE (14 rows)
+
+**Root cause.** `emitIteratorPrototypeSingleton`
+(`src/codegen/array-object-proto.ts:3799-3880`) seeds an own `next` only for
+`kind === "String"` (`:3856-3873`, a refusal body). For Map/Set the singleton
+has `@@toStringTag` only, so `MapIteratorProto.next` is `undefined` (G4), and a
+property READ `iterator.next` on an `$__IterRec` externref has no `__extern_get`
+arm at all — `fillMapSetDynDispatchArms` (4) only handles the CALL form via
+`__extern_method_call` (`map-runtime.ts:2992-3061`) — so `iterator.next` is
+`undefined` and `.call` on it throws (G3).
+
+**Edits, in order.**
+
+1. **Brands.** `src/codegen/builtin-brands.ts` `BUILTIN_BRAND_TABLE` has `Map`
+   (+25), `Iterator` (+32) but no iterator-kind brands: APPEND `MapIterator`,
+   `SetIterator`, `ArrayIterator` after the current last entry (append-only
+   contract stated in the file; never renumber).
+2. **Glues.** In `array-object-proto.ts` next to `ensureIteratorNativeProtoGlue`
+   (`:2676`): `ensureMapIteratorNativeProtoGlue` / `ensureSetIteratorNativeProtoGlue`
+   (and `ensureArrayIteratorNativeProtoGlue`, optional — see below) =
+   `registerNativeProtoBuiltin(ctx, { ...makeGlue(ctx, brand, "MapIterator", ["next"]), memberLength: () => 0, emitMemberBody: (c, f, m) => emitIterRecNextBody(c, f, "Map") })`.
+   `makeGlue` is at `:2348`; `emitMemberBody`'s closure ABI is local 0 = self,
+   local 1 = externref `this` (see `emitCollectionSizeGetterBody`, `:1893-1930`,
+   which is the model for a brand-checked body).
+3. **Body `emitIterRecNextBody(ctx, fctx, kind: "Map"|"Set"|"Array")`** (new,
+   `array-object-proto.ts`): `ensureNativeIteratorRuntime(ctx)`;
+   `ensureNativeIterResultObject(ctx)` (registers `__iter_next_result`,
+   `iterator-native.ts:1553-1590`); flush; then
+   `local.get 1; any.convert_extern; ref.test $__IterRec` → else
+   `emitBrandCheckTypeError(ctx, fctx.body, "…next called on incompatible receiver")`
+   (`native-proto.ts:1154`); then the kind test — Map/Set:
+   `struct.get $__IterRec.kind == ITER_KIND_MAPSET (9)` AND
+   `struct.get $__IterRec.userIter → any.convert_extern → ref.cast $MapIter → struct.get IT_MAP → struct.get $Map.M_KIND == 0 (Map) | 1 (Set)`
+   (`MAP_LAYOUT.M_KIND`, `map-runtime.ts:76`); Array: `kind == ITER_KIND_VEC (3)`
+   (or the LIVEVEC kind if D-1b ever lands) — mismatch → the same TypeError
+   (`does-not-have-mapiterator-internal-slots.js` throws in BOTH directions).
+   Then `local.get 1; call __iter_next_result; return externref`.
+4. **Seed on the singleton.** In `emitIteratorPrototypeSingleton`, generalise
+   the `kind === "String"` block (`:3856-3873`) to a per-kind table:
+   `{ String: [ensureStringNativeProtoGlue, refusalBodyFallback:true], Map: [ensureMapIteratorNativeProtoGlue], Set: […], Array: […] }`
+   — same `__defineProperty_value` recipe, bits `0x01|0x04`
+   (writable, non-enumerable, configurable). Mint the closure via
+   `ensureStandaloneNativeMethodClosure(ctx, brand, "next", "method")`
+   (`native-proto.ts:948`) WITHOUT `refusalBodyFallback` for the three
+   behavioural kinds. `name: "next"` / `length: 0` come from `nativeClosureMeta`
+   (the #5099 machinery the String branch already relies on).
+5. **`iterator.next` as a value.** Splice into `__extern_get` a `$__IterRec`
+   arm — the model is `fillMapSetDynDispatchArms` (1) (`map-runtime.ts:2930-2990`,
+   the `$Map` "size" / `@@iterator` arms; `keyEqualsStr("next", 1)` already
+   exists at `:2998`): `local.get 0; any.convert_extern; ref.test $__IterRec` →
+   key == "next" → select the closure by kind (MAPSET + M_KIND 0 → Map's
+   `next` singleton, M_KIND 1 → Set's, VEC → Array's if seeded) →
+   `pushBuiltinFnSingletonValueInstrs(ctx, closure); extern.convert_any; return`.
+   The closures must exist before this splice: mint them in the same fill
+   (`ensureStandaloneNativeMethodClosure` appends DEFINED funcs — allowed at
+   finalize, as `ensureMapSetIteratorClosureSingleton` does at `:3075`), but
+   only when `ctx.mapTypeIdx >= 0` (Map/Set) — for Array-only modules the
+   arm is emitted from the same place `emitArrayIteratorPrototypeSingleton`
+   is reached, or not at all (then the 3 `ArrayIteratorPrototype/next/*`
+   metadata rows in other-builtins stay as they are; they are NOT claimed
+   here).
+6. **`fn.call(recv)` on the closure.** `iterator.next.call(false)` reaches the
+   native method closure through the generic `__call_fn_method_*` path with
+   `this = false` (boxed). The body's `ref.test $__IterRec` on a boxed
+   primitive fails → TypeError — that is the whole `this-not-object-throw-*`
+   family. Verify once with the first row; if `.call` on a `__fn_wrap`-shaped
+   native closure declines (returns null instead of invoking), the fix is in
+   the `.call` arm of `closed-method-dispatch.ts` / `call-receiver-method.ts`
+   (grep `methodName === "call"`), not in the body.
+
+**Rows claimed (14).** `built-ins/MapIteratorPrototype/next/{length,name,this-not-object-throw-entries,this-not-object-throw-keys,this-not-object-throw-values,this-not-object-throw-prototype-iterator,does-not-have-mapiterator-internal-slots}.js`
+and the same 7 under `built-ins/SetIteratorPrototype/next/`. 10 of them end
+with `iterator.next.call(map[Symbol.iterator]())` ("does not throw") — R3-1(a)
+must land first.
+
+**Growth.** `array-object-proto.ts` +90 (`emitIteratorPrototypeSingleton` +25,
+new `emitIterRecNextBody` ~45, two glue registrars ~20); `map-runtime.ts` +45
+(`fillMapSetDynDispatchArms`, one more `__extern_get` arm);
+`builtin-brands.ts` +3; `native-proto-own-props.ts` +15 only if the new brands
+need an own-props arm for `hasOwnProperty(proto, "next")` (the
+`property-descriptor.js` rows are other-builtins; `name.js`/`length.js` read
+the value only).
+
+**Order constraints.** The prototype singleton's init order is observable only
+through `Object.getOwnPropertyNames` (`@@toStringTag` is a symbol, `next`
+must be the only string key). The `__extern_get` arm must come AFTER the
+`$Map` arm (a `$Map` is not an `$__IterRec`, so order is not semantic — keep
+`$Map` first for byte stability of Map-only modules).
+
+**Passing shapes at risk + how to check.**
+- `SetIteratorPrototype/next/does-not-have-mapiterator-internal-slots-set.js`
+  (passes today: `iterator.next.call(new Set()[...])`-style cross-kind throw)
+  and `Iterator/prototype/chunks/*` / `windows/*` rows (8 passing in
+  `forof-controls.txt`) — they read `.next` on `$LazyIterHelper` and
+  `$__IterRec` values; the new `__extern_get` arm must NOT intercept a
+  `$LazyIterHelper` (`ref.test` is exact).
+- `Object.getPrototypeOf([][Symbol.iterator]())` reflective rows
+  (`ArrayIteratorPrototype/Symbol.toStringTag.js`, `StringIteratorPrototype/next/{name,length}.js`
+  — the String branch stays byte-identical: `cmp` the `.wasm` of
+  `built-ins/StringIteratorPrototype/next/name.js` on base vs new).
+- Any program that reads `it.next` as a value on a generator (host `__gen_*`
+  records are not `$__IterRec`) — `tests/issue-5267-es2015-forof-iterators-r2.test.ts`
+  17/17 plus the 31-file collection/iterator vitest set the r2 record names.
+
+### R3-3 — constructor drive: null key normalisation + adder-branch CanBeHeldWeakly (4 rows)
+
+**Root cause.** `emitNativeCollectionCtorIterableDrive`
+(`src/codegen/expressions/new-super.ts:4338-4552`): (a) `Get(entry,"0")` /
+`Get(entry,"1")` via `__extern_get_idx` (`:4422-4434`) answer `ref.null.extern`
+for an absent index, and `any.convert_extern` turns that into a NULL anyref
+key that the native adder (`__map_set` → `__hash_anyref`,
+`map-runtime.ts:404-560`) dereferences (probe a1: `new Map([{}, 2])` traps
+before reaching `2`; the real rows trap on `[['a', 1], 2]` the same way once
+the nested literal's carrier is not indexable by `__extern_get_idx` — verify
+which of the two it is with a1 + `new Map([['a',1]])` alone). (b) the
+CanBeHeldWeakly test (`:4445-4462`) runs BEFORE the adder dispatch, so a
+user-patched `WeakMap.prototype.set` / `WeakSet.prototype.add` never gets the
+call it must observe (spec: the test lives INSIDE the intrinsic adder,
+§24.3.3.5 / §24.4.3.1).
+
+**Edits.**
+1. After each `call __extern_get_idx` in `entryBody` (`:4425`, `:4431`):
+   `local.tee kExt; ref.is_null; if → <canonicalUndefinedExternInstrs(ctx)> ; local.set kExt` (
+   `src/codegen/any-helpers.ts:167`), then the existing `any.convert_extern`.
+   Do the same for the value. Fresh instrs per site.
+2. Move the `isWeak` holdable block (`:4445-4462`) INTO `directAdd`
+   (`:4463-4469`) — i.e. the `else` branch of the `dispatch.modeLocal` `if`
+   (`:4470-4478`) and the no-dispatch fallback — so it runs only when the
+   INTRINSIC adder is about to be called. `modeLocal` = 1 means the proto
+   companion holds a user override (`prepareNativeSetAdderDispatch` doc).
+3. If a1's trap survives edit 1: the next suspect is `__hash_anyref` on a
+   null anyref — add a `ref.is_null → hash 0` arm there and note it in the PR.
+
+**Rows claimed (4).** `built-ins/Map/iterator-items-are-not-object.js`,
+`built-ins/WeakMap/iterator-items-keys-cannot-be-held-weakly.js`,
+`built-ins/WeakMap/iterator-close-after-set-failure.js`,
+`built-ins/WeakSet/iterator-close-after-add-failure.js`.
+
+**Deferred (4).** `Map/iterator-item-{first,second}-entry-returns-abrupt.js`,
+`WeakMap/iterator-item-{first,second}-entry-returns-abrupt.js` — module-scope
+array identity (`({v: a}).v === a` is false; r2 "Hang trap"). Do NOT lift the
+4M-step ceiling (`:4484-4520`) until that is fixed — it is what keeps the two
+Map rows from wedging a shard.
+
+**Growth.** `new-super.ts` +20 in `emitNativeCollectionCtorIterableDrive`.
+
+**Order constraints.** Spec order in the drive (adder Get → iterable →
+GetIterator → per step: next → Object test → Get 0 → Get 1 → Call adder) is
+unchanged; the holdable test now sits between "Get 1" and the intrinsic
+`__map_set`, exactly where §24.3.3.5 step 4 puts it. A throwing `get 0()` must
+still close the iterator (inside `wrapWithIteratorClose`).
+
+**Passing shapes at risk + how to check.** `new Map([[k, v], …])` literal
+pairs (the `seedablePairs` path, `:5504-5560`, untouched — `cmp` the `.wasm` of
+`built-ins/Map/iterable-calls-set.js` compiled on base vs new must be
+IDENTICAL only if that row uses the literal path; otherwise run it), plus the
+r2 lists `.tmp/es2015/forof-cl-A-ctor-iterable-drive.txt` and
+`forof-cl-A2-symbol-keys.txt` (19 rows flipped in r2 — every one must still
+pass), `built-ins/WeakMap/iterable-with-symbol-keys.js`,
+`built-ins/WeakSet/iterable-with-symbol-values.js`,
+`built-ins/Map/iterator-is-undefined-throws.js`.
+
+### R3-6 — `delete Array.prototype[Symbol.iterator]` honoured by the for-of ARRAY fast path (3 rows, `--isolate`)
+
+**Root cause.** The flag global exists (`__array_proto_iterator_deleted`,
+`src/codegen/expressions/proto-override.ts:132-159`, raised by
+`tryEmitArrayProtoIteratorDelete`, `:225-233`) and is read by ONE consumer —
+`emitArrayIteratorDeletedGuard` in `src/codegen/destructuring-params.ts:1664-1670`
+(binding patterns). `compileForOfArray` (`src/codegen/statements/loops.ts:1897`)
+never reads it, so `for (let [x, y, z] of [[1, 2, 3]])` after the delete
+iterates the OUTER array natively instead of throwing at GetIterator.
+
+**Edits.** Export `emitArrayIteratorDeletedGuard` (or move it to
+`proto-override.ts` next to `arrayIteratorDeletedGlobalIdx`) and call it in
+`compileForOfArray` right after the vec type is confirmed (`loops.ts:1953`,
+before the head-binding/loop emission) — it emits ZERO bytes when the source
+has no such delete (the global is only rooted by the pre-scan). Also
+`compileForOfArrayFromLocal` (`:1835`) if the `preVec` callers can be reached
+from a user array (they come from Map/Set projections — not arrays — so no).
+Check `maybeCaptureArrayProtoOverride` resets the flag to 0 when the source
+later ASSIGNS `Array.prototype[Symbol.iterator] = …` (no reader exists today,
+so this was never needed); add `i32.const 0; global.set` there if absent.
+
+**Rows claimed (3).** `language/statements/for-of/dstr/{let,const,var}-ary-init-iter-get-err-array-prototype.js`
+— measure with `--isolate` only (they poison the runner's realm).
+
+**Growth.** `loops.ts` +8 in `compileForOfArray`; `destructuring-params.ts` +2
+(export).
+
+**Passing shapes at risk + how to check.** Every for-of over an array in a
+module WITHOUT the delete is byte-identical (guard emits nothing): `cmp` the
+`.wasm` of `language/statements/for-of/array-key-get-error.js` (any array
+for-of row) on base vs new. Modules WITH the delete that later reinstall:
+`language/statements/for-of/dstr/*-ary-ptrn-elem-id-iter-val-array-prototype.js`
+are generator rows (out of scope) — but run the 3 `class/dstr/*-array-prototype.js`
+rows that pass today under `--isolate` (find them: `grep array-prototype .test262-cache/test262-standalone-current.jsonl | grep '"pass"'`).
+
+### R3-7 — collection reflection residue (5 rows; species DEFERRED)
+
+**(a) `Map.prototype[Symbol.iterator]` / `Set.prototype[Symbol.iterator]` own property (2).**
+Root cause: the value read already aliases the right closure (the test's
+`assert.sameValue(Map.prototype[Symbol.iterator], Map.prototype.entries)`
+passes; failure is `verifyProperty`'s `hasOwnProperty`). The own-props ladder
+only knows members listed in the glue CSV; `seededSymbolMembers`
+(`src/codegen/native-proto-own-props.ts:335-360`) already handles `@@<id>`
+CSV sentinels by symbol identity. Edit: add `"@@1"` to `MAP_PROTO_METHODS`
+and `SET_PROTO_METHODS` (`array-object-proto.ts:406-437`) and extend
+`makeCollectionGlue`'s `memberAliasOf` (`:1950`) with
+`member === "@@1" ? (name === "Map" ? "entries" : "values")` — exactly the
+Array pattern (`:138` + `:2400-2402`). The `@@` filter for string enumeration
+exists (`native-proto.ts:560`, `:604`). Descriptor: `{w:T, e:F, c:T}` as the
+Array `@@1` seeding. Rows: `built-ins/Map/prototype/Symbol.iterator.js`,
+`built-ins/Set/prototype/Symbol.iterator.js`. Risk check:
+`Object.getOwnPropertyNames(Map.prototype)` must not gain a `"@@1"` string;
+`Map.prototype[Symbol.iterator] === Map.prototype.entries` must stay true
+(identity through `memberAliasOf`, `native-proto.ts:989`); run
+`built-ins/Map/prototype/entries/{name,length}.js`,
+`built-ins/Set/prototype/keys/keys.js` (Set `keys`→`values` alias, same
+mechanism), `built-ins/Map/prototype/Symbol.toStringTag.js`.
+
+**(b) `size` gOPD (2).** Probe g1: the descriptor comes back with a working
+`get`; reading `d.set` throws `Cannot convert undefined or null to object`.
+`PropertyDescriptor.set` is a METHOD signature in lib.d.ts (`set?(v: any): void`),
+so `d.set` is compiled as a method-valued read on an externref receiver — find
+the site by bisecting `typeof d.set` / `d["set"]` / `var s = d.set` in
+`g1.js`; candidates are the method-reference read path in
+`src/codegen/property-access-dispatch.ts` (grep the `PropertyDescriptor` /
+method-signature branch) and the getter-descriptor synthesis for glue members
+of `memberKind: "getter"` (`native-proto-own-props.ts`, reached from
+`call-builtin-static.ts:3158`-area gOPD). Fix whichever it is so a synthesised
+accessor descriptor carries an explicit `set: undefined` data key AND a
+method-signature read on a plain `$Object` degrades to `__extern_get`. Rows:
+`built-ins/Map/prototype/size/size.js`, `built-ins/Set/prototype/size/size.js`.
+Risk check: `built-ins/Object/getOwnPropertyDescriptor/*` rows that pass today
+touching accessor descriptors (`15.2.3.3-4-{2,3}.js`-style; pick 5 from the
+baseline), `built-ins/Map/prototype/size/returns-count-of-present-values-*.js`.
+
+**(c) `append-new-values.js` (1).** `map.get(1)` answers `NaN` because
+`tryCompileNativeMapMethodCall`'s `get` arm (`map-runtime.ts:1699-1740`)
+returns `anyref` and the caller unboxes to the STATICALLY resolved value type
+(f64) although the map's value union is `number | string | symbol`. Edit: when
+the oracle's value type is not exactly number/boolean, return
+`extern.convert_any` → `{ kind: "externref" }` and let the dynamic reader
+unbox per tag. Row: `built-ins/Map/prototype/set/append-new-values.js`.
+Risk check: numeric maps stay unboxed (`built-ins/Map/prototype/get/returns-value.js`,
+the playground `map` examples via `pnpm run check:ir-fallbacks` unchanged,
+and the equivalence gate).
+
+**DEFERRED — species (2).** `Map/Set/Symbol.species/symbol-species.js` need
+the builtin-ctor `Ctor[Symbol.species] = v` write to be a silent no-op, the
+`delete` to flip a per-ctor flag that the static gOPD arm
+(`tryEmitStandaloneBuiltinSpeciesGopd`, `builtin-static-gopd.ts:444`) and
+`hasOwnProperty` consult; `Array/Symbol.species/symbol-species.js` fails
+identically on main, so this is the species FAMILY, not a collection row —
+one owner, not this pass.
+
+**Growth.** `array-object-proto.ts` +6; `map-runtime.ts` +15
+(`tryCompileNativeMapMethodCall`); the (b) site +25 wherever it lands
+(`property-access-dispatch.ts` or `native-proto-own-props.ts`).
+
+### R3-9 — anonymous `class` default in an OBJECT assignment pattern (1 row)
+
+Probe f3: the array-pattern default (`compileForOfAssignDestructuringExternref`,
+`for-of-destructuring.ts:2421-2440` → `emitDefaultValueCheck(ctx, fctx, externref, local, init, externref)`)
+yields a class value with an own `name`; the object-pattern identifier arm
+(`compileForOfIteratorAssignDestructuring`, `:2716-2735`) calls
+`emitDefaultValueCheck(…, targetTypeI ?? undefined, /* objectPropertySemantics */ true)`
+and the class value's `.name` reads `undefined`. The display name itself is
+right (`classObjectDisplayName` → `fnInstanceNameOf`,
+`function-instance-meta.ts:363` handles the shorthand's
+`objectAssignmentInitializer`), so the loss is in how the default VALUE is
+produced/coerced on that arm. Bisect by (i) passing `{ kind: "externref" }`
+as `targetType` for a class-expression initializer, (ii) the
+`objectPropertySemantics` flag. Whichever restores `cls.name === 'cls'` in
+`f3.js` is the fix; keep the `undefined`-only default trigger (§13.15.5.4
+step 4 — a `null` read must NOT take the default).
+Row: `language/statements/for-of/dstr/obj-id-init-fn-name-class.js`.
+Growth: `for-of-destructuring.ts` +10. Risk check: the 4 `dstr` binding rows
+in `forof-controls.txt`, `language/statements/for-of/dstr/obj-id-init-fn-name-{fn,arrow,cover,gen}.js`
+(pass today), and `f3.js` in full.
+
+### R3-4 — for-of statement protocol (6 rows: 4 firm, 2 stretch)
+
+All in `compileForOfIterator` (`src/codegen/statements/loops.ts:2988-3412`)
+and the OBJ step of `buildIteratorNextBody` (`src/codegen/iterator-native.ts:4372+`).
+
+**(a) IteratorStep/IteratorValue abrupt must NOT close (2 rows).** The #1347
+`try_table`/`try` wrapper (`loops.ts:3322-3392`) encloses
+`call __iterator_next` (`:3255-3258`), so a throwing `next()` or `value`
+getter runs `closeOnThrowBody` (`:3352-3361`). Edit: allocate an i32 local
+`__forof_in_next`; `i32.const 1; local.set` immediately before `:3255`,
+`i32.const 0; local.set` immediately after the done-check `if` (`:3272`);
+gate `closeOnThrowBody`'s condition to
+`doneFlag == 0 && in_next == 0` (fresh instrs; both lanes — the `try` and the
+`try_table` branch). The finallyStack entry (`:3212-3235`) handles
+return/break, never a throw — leave it. Apply the same gate to
+`compileForOfDirectIterator` (`:2514`-area) if it carries its own wrapper.
+Rows: `language/statements/for-of/iterator-next-error.js`,
+`language/statements/for-of/iterator-next-result-value-attr-error.js`.
+
+**(b) `next` read ONCE at GetIterator (1 row).** The OBJ step re-reads
+`Get(rec.userIter, "next")` every poll (`iterator-native.ts:4572-4598` and the
+strict twin `:4650-4674`). Edit: add a 5th field
+`nextMethod (mut externref)` to `$__IterRec` in `getOrRegisterIterRecType`
+(`:416-438`; field order is load-bearing, append at index 4); every
+`struct.new $__IterRec` site pushes one more `ref.null.extern` — **16 sites**
+(`grep -rn 'struct.new", typeIdx: iterRecTypeIdx\|struct.new", typeIdx: types.iterRecTypeIdx' src/codegen`),
+including `fillMapSetDynDispatchArms` (2) and `emitLiveCollectionIterRec`.
+In `buildIteratorBody`'s OBJ arm (the #3146 admission that already reads
+`next`, `:3699`), `struct.set` the read value; in both OBJ steps use
+`struct.get fieldIdx 4` when non-null, else the existing read (USER/closed
+records keep null and their `__sget_next` route). Row:
+`language/statements/for-of/iterator-next-reference.js`. This is the riskiest
+sub-step (every record producer changes); land it as its own commit and
+re-run the full R3 row set + controls after it.
+
+**(c) §7.4.2 non-Object `next()` result → TypeError (1 row).** In the OBJ
+step, a result that is neither an `$Object` (`objCarrierTest`, `:4620`) nor a
+closed struct with `__sget_done` is degraded to `done` (`readStructArm` /
+the falsy check at `:4605-4618`). Under `ctx.standalone || ctx.wasi` throw
+`notAnObjectThrowInstrs(ctx, scratch)` (`:2167`-area; deps
+`ensureNotAnObjectThrowDeps`, `:3391`) for a NON-NULL, non-object result of a
+REAL call; keep the degrade for a null/falsy `next` (ladder-internal
+carriers — the #5144 collision). Row:
+`language/statements/for-of/iterator-next-result-type.js`. Run
+`pnpm run test:equivalence:gate` — it is the consumer of the degrade.
+
+**(d) STRETCH `throw-from-finally.js` (1 row).** `i` increments twice: the
+`finally` body is inlined at its own inner `throw` on top of the for-of
+iterator-close finallyStack entry (`src/codegen/statements/exceptions.ts:440-470`,
+`cloneFinallyAtDepth`). Reproduce with `[1]` as the iterable first; a `throw`
+INSIDE a finally block must not re-inline that same finally. If it only
+reproduces with the `function*` source → it is G1/G2 territory, report and drop.
+
+**(e) STRETCH `array-key-get-error.js` (1 row).** An accessor installed by
+`Object.defineProperty(array, '0', {get})` is invisible to `compileForOfArray`
+(`loops.ts:1897`, reads `vec.data[i]`). `ctx.vecAccessorDescriptorDirty`
+(the #4159 pre-scan) is exactly the module-level signal: when it is true and
+the subject is a plain array, route through `compileForOfIterator` and check
+that `__iterator`'s VEC arm reads through the overlay. If the overlay is
+also invisible there, leave it un-root-caused in the PR body.
+
+**Growth.** `loops.ts` +30 (`compileForOfIterator`); `iterator-native.ts` +70
+(`getOrRegisterIterRecType` +3, `buildIteratorBody` +15, `buildIteratorNextBody` +25,
+plus 16 one-line operand additions); `exceptions.ts` +20 (stretch).
+
+**Order constraints.** §14.7.5.7 ForIn/OfBodyEvaluation: `next()` abrupt →
+return WITHOUT close; binding/body abrupt → IteratorClose (its own abrupt
+suppressed, the throw completion wins); `break` → IteratorClose (post-loop
+check, `:3399-3411`, untouched). The `next` read happens ONCE in GetIterator
+(step (b)) and must happen AFTER the `@@iterator` call and BEFORE the first
+`next()`.
+
+**Passing shapes at risk + how to check.**
+- Every for-of over a custom `{ next() }` iterable, a generator, a Map/Set
+  record, a lazy helper: `forof-controls.txt` (both lanes),
+  `language/statements/for-of/{break,break-from-catch,break-from-finally,break-label,continue,continue-from-catch,continue-label,return,return-from-catch,return-from-finally,throw,throw-from-catch}.js`
+  (all pass today — the close-on-abrupt matrix), `iterator-close-*` and
+  `iterator-next-result-*` rows that already pass, the 8 `chunks`/`windows`
+  rows, and `tests/issue-5267-es2015-forof-iterators-r2.test.ts` 17/17.
+- Host lane bytes: (a) changes the `try/catchAll` branch too — the host-lane
+  run of `forof-controls.txt` must equal its 23/28 baseline and the
+  equivalence gate its baseline.
+- (b) changes every producer: `cmp` is impossible; instead run the r2 lists
+  `forof-cl-B-live-collection-iterators.txt` and `forof-cl-A-ctor-iterable-drive.txt`
+  (their pass sets must not shrink) and the D/E rows in
+  `.tmp/census0903/other-builtins.tsv` that pass today (`ArrayIteratorPrototype/next/iteration.js`
+  is a fail; pick `built-ins/Array/from/iter-*.js` ×5 passing rows as the
+  spread/`Array.from` control).
+
+### R3-5 — interleaved assignment-pattern drive for `for ([…] of iter)` (12 rows)
+
+**Root cause.** `compileForOfAssignDestructuringExternref`
+(`src/codegen/statements/for-of-destructuring.ts:2239-2460`) materialises the
+whole source with `__array_from_iter_n(src, n | -1)` (`:2250-2267`) before any
+target is evaluated, so `nextCount`/`returnCount` are wrong, lref evaluation
+order is wrong, and no IteratorClose fires on a target/initializer abrupt.
+NOTE for the implementer: r2's suggestion to copy `destructureParamArray`'s
+stepping is WRONG — that path ALSO materialises through `__array_from_iter_n`
+(`src/codegen/destructuring-params.ts:1955-1992`); there is no interleaved
+drive on main to reuse. Write it here, gated on `ctx.standalone || ctx.wasi`
+so the js-host lane stays byte-identical (it keeps the import-based
+materialisation).
+
+**Emit, per §13.15.5.5 IteratorDestructuringAssignmentEvaluation** (locals:
+`iter` externref, `done` i32, `val` externref, `inNext` i32; the R3-4(a) gate
+applies here too):
+0. `GetIterator(elem)`: `local.get elemLocal; call __iterator` (native ladder,
+   `ensureNativeIteratorRuntime` first, flush) → `iter`; `done := 0`.
+1. For each element, in source order:
+   - **Elision** → step 2 only (no target). An elision-only pattern
+     `for ([,] of [Symbol()])` MUST still run step 0 (today the empty-pattern
+     shortcut `emitEmptyForOfArrayPatternRequirement`, `:257`, is the only
+     one that does): `array-elision-val-symbol.js`.
+   - **Non-pattern target**: evaluate the **lref FIRST** — for a member target
+     compile receiver + key into temps BEFORE step 2 (`[ {}[thrower()] ]`
+     throws here with `nextCount 0`); for an identifier target nothing to
+     evaluate.
+   - 2. if `!done`: `inNext := 1; call __iterator_next(iter)` → pop value then
+     done (`loops.ts:3252-3258` shape); `inNext := 0`; on `done` set
+     `val := undefined` (`canonicalUndefinedExternInstrs`).
+   - 3. initializer when `val === undefined` (NamedEvaluation for anonymous
+     fn/class — R3-9's arm) — `emitDefaultValueCheck` with the hole→undefined
+     mapping FIRST: an in-bounds hole in `[2, null, , undefined]` is the
+     #2001 S1 sentinel (`emitHoleSentinel` / `f64HoleTestInstrs`,
+     `src/codegen/array-holes.ts`, `vec-f64-hole-presence.ts`) —
+     `array-elem-init-assignment.js` expects the default for the hole and
+     for `undefined`, NOT for `null`.
+   - 4. PutValue to the temps (member) / local / global / boxed capture
+     (reuse the existing arms `:2369-2460` with the value in a temp instead of
+     `pushElemRead(i)`), or recurse into a nested pattern with
+     `destructureNestedExternrefPattern` (`:2359`).
+   - **Rest `[...t]`**: lref first (member target), then drain: loop
+     `__iterator_next` into a fresh `$Vec` (`__vec_externref` via the
+     `ensureNativeArrayFromIterN` geometry, `iterator-native.ts:1778`) until
+     `done`; then PutValue via `emitForOfRestAssignment` (`:2334`) over the
+     drained vec. `array-rest-lref-err.js`: `nextCount 0, returnCount 1`.
+2. Wrap steps 1.lref/3/4 (NOT step 2) in the close-on-throw shape of
+   `wrapWithIteratorClose` (`new-super.ts:4529`, reuse it) so a target /
+   initializer / nested-pattern abrupt calls `__iterator_return` once with its
+   own abrupt SUPPRESSED (`*-close-err.js` rows: the original throw wins),
+   then rethrows. `next()` abrupt propagates WITHOUT close (`done := 1` first).
+3. After the last element: `if (!done) call __iterator_return` (normal
+   completion; keep the #5144 C "close result must be an Object" check).
+4. **Object patterns** (`compileForOfIteratorAssignDestructuring`, `:2567+`):
+   a computed key (`{ [a.b]: x }`) is skipped today (`propName` undefined →
+   `continue`, `:2591-2598`). Evaluate the key expression (ToPropertyKey)
+   unconditionally BEFORE the Get, even when the key cannot be resolved
+   statically — then read via `__extern_get` with the runtime key.
+   `obj-prop-name-evaluation-error.js` expects the key's throw.
+
+**Rows claimed (12).** `language/statements/for-of/dstr/array-elem-iter-thrw-close.js`,
+`array-elem-iter-thrw-close-err.js`, `array-elem-trlg-iter-list-thrw-close.js`,
+`array-elem-trlg-iter-list-thrw-close-err.js`, `array-elem-trlg-iter-rest-thrw-close.js`,
+`array-elem-trlg-iter-rest-thrw-close-err.js`, `array-rest-iter-thrw-close.js`,
+`array-rest-iter-thrw-close-err.js`, `array-rest-lref-err.js`,
+`array-elem-init-assignment.js`, `array-elision-val-symbol.js`,
+`obj-prop-name-evaluation-error.js`.
+
+**Growth.** `for-of-destructuring.ts` +220 (a new
+`emitInterleavedArrayAssignmentDrive` ≤ 120 lines + per-target write helpers
+factored out of the existing arms; `compileForOfAssignDestructuringExternref`
+becomes a dispatcher); `statements/destructuring.ts` +15 if
+`emitDefaultValueCheck`'s hole mapping lands there.
+
+**Order constraints.** lref → next → default → PutValue per element; rest lref
+before its drain; no close on `next()` abrupt; exactly one `return()` on any
+other abrupt or on normal completion with `!done`; elision runs `next()`;
+the SOURCE's `@@iterator` is called exactly once per element of the OUTER loop.
+
+**Passing shapes at risk + how to check.**
+- Host lane: gated — `cmp` the `.wasm` of
+  `language/statements/for-of/dstr/array-elem-trlg-iter-list-nrml-close.js`
+  compiled WITHOUT `--standalone` on base vs new: must be identical.
+- Standalone: every `for ([a, b] of …)`, `for ([x, ...r] of …)`,
+  `for ([[x]] of …)`, `for ([x.y] of …)`, `for ([x = d] of …)` that passes
+  today — the 4 `dstr` rows in `forof-controls.txt` plus ALL currently-passing
+  `language/statements/for-of/dstr/array-*.js` rows (list them from the
+  baseline: `grep 'for-of/dstr/array-' .test262-cache/test262-standalone-current.jsonl | grep '"pass"'`
+  — ~120 rows; run in batches of 15, one process at a time) and the
+  `language/expressions/assignment/dstr/array-*.js` rows are NOT touched
+  (different lowering) — run 10 of them as a negative control.
+- `tests/issue-4447-*.test.ts` (for-of destructuring residual) and the
+  equivalence gate.
+
+### R3-8 — `===` between two `$BoxedNumber`s from different producers (3 rows) — LAST, own commit
+
+**Root cause.** Probe f4: `[0,'a'][0] === a[0]` is FALSE at module scope. The
+harness's `assert._isSameValue(a, b)` compiles to `__any_strict_eq` over two
+`$AnyValue`s; the operands reach it under different tags (one side tag-6
+`refval`, the other tag-5 `externval`, or tag-3 f64 vs a boxed ref — confirm
+with a WAT read of the `__any_box_*` calls at the `a === b` site in `f4.js`).
+The different-tag arm (`src/codegen/any-eq-helpers.ts:396-455`, #2175 V2-S3)
+recovers both payloads to `eqref` and answers `ref.eq` — two distinct
+`$BoxedNumber` structs holding `0` are unequal. The same-tag-5 arm already
+classifies Number×Number numerically (`tag5ValueEqThen`,
+`src/codegen/any-helpers.ts:1290+`, default-ON since 2026-07-16).
+
+**Edit.** In `registerAnyStrictEqAndComparisonHelpers`' different-tag arm,
+after `recoverRefPayload(0, 4)` / `(1, 5)` (`:434-435`) and BEFORE the
+`ref.eq` identity test: if both locals 4/5 `ref.test $BoxedNumber` (the type
+`addUnionImports` registers — find its typeIdx the way `__any_to_f64`'s #1888
+recovery arm does, `any-helpers.ts` grep `BoxedNumber`) → unbox both
+(`struct.get` the f64 field) → `f64.eq` (NaN self-unequal preserved). Also
+cover "tag ∈ {2,3} on one side, `$BoxedNumber` payload on the other": route
+through `__any_to_f64` on both and `f64.eq`. Keep the `ctx.standalone || ctx.wasi`
+gate — host bytes unchanged. Mirror in `__any_eq`'s different-tag arm ONLY if
+a probe shows `==` is affected too (do not touch otherwise).
+
+**Rows claimed (3).** `language/statements/for-of/map.js`,
+`language/statements/for-of/map-expand.js`,
+`language/statements/for-of/map-contract-expand.js`. Likely cross-cluster
+upside (every `«N» «N»` SameValue failure in the census) — report the delta,
+do not claim it.
+
+**Growth.** `any-eq-helpers.ts` +40 in `registerAnyStrictEqAndComparisonHelpers`.
+
+**Why last and why its own commit.** This helper is under every `===` on
+`any`-typed operands in standalone. #1888's first attempt at exactly this
+classifier ejected at −162 rows (`any-helpers.ts:1225-1250` history) —
+that mask has since been removed, but the blast radius has not. Ship it as
+the final commit so it can be reverted alone.
+
+**Passing shapes at risk + how to check.** `pnpm run test:equivalence:gate`
+at baseline; `forof-controls.txt` both lanes; a 15-row sample from the
+`class` and `dstr` families that pass today (the −162 victims were there:
+`language/statements/class/dstr/*-ary-ptrn-elem-id-init-undef.js` ×5,
+`*-ary-ptrn-elem-id-iter-val.js` ×5, `language/expressions/assignment/dstr/array-elem-init-undef.js`
+and 4 siblings); `built-ins/Object/is/*` ×3 and
+`language/expressions/strict-equals/*.js` ×5 (all pass today per the baseline).
+`undefined === undefined`, `NaN === NaN` (false), `0 === -0` (true) must be
+checked with a 6-line probe through `probe-one.mts` before and after.
+
+### Out of scope in r3 (48 rows) — do not touch
+
+- **Generator carrier (35):** every row whose error is
+  `standalone target emitted host imports: env::__create_generator …` (23,
+  incl. the 3 `*-ary-ptrn-elem-id-iter-val-array-prototype.js` rows that
+  override `Array.prototype[@@iterator]` with a `function*`) or `native
+  generator lowering currently supports only sequential numeric yields`
+  (12, the `*-rtrn-close*.js` family). Owner: #680 / #2864.
+- **Realms (5):** 4× `proto-from-ctor-realm.js`, `Symbol/iterator/cross-realm.js`
+  — #3371.
+- **Parser (1):** `dstr/array-elem-init-in.js`.
+- **`Symbol/iterator/prop-desc.js` (1):** the 12-row `Symbol/*/prop-desc.js`
+  family in `other-builtins.tsv` (well-known symbols are not own properties of
+  the `Symbol` ctor) — one fix, one owner, not here.
+- **Species (2), accessor identity (4):** see R3-7 / R3-3.
+
+### Acceptance (whole pass)
+
+- Row lists green per step (R3-6 with `--isolate`); expected flips
+  **53 max, ≥ 40 is the bar** (R3-4's 2 stretch singles, R3-7(b)'s
+  hypothesis-level 2, R3-8's 3 and R3-1(b)'s dynamic-route rows are the
+  uncertain part). Report every unflipped row with its residual error.
+- Every "passing shapes at risk" check above executed and quoted in the PR
+  body — the byte-identity ones as `cmp` results on the named files, the
+  control ones as pass counts against the stated baselines. A step whose
+  checks were not run is not shippable.
+- `imports-of.mts` on `Map/iterator-items-are-not-object.js`,
+  `WeakMap/iterator-close-after-set-failure.js`,
+  `MapIteratorPrototype/next/iteration.js` → `[]` (no `env::*` leak).
+- Gates chained before every commit (also with `LOC_GATE_BASE` = upstream
+  main tip); `pnpm run test:equivalence:gate` at baseline after R3-4(c),
+  R3-5 and R3-8; `tests/issue-5267-es2015-forof-iterators-r2.test.ts` 17/17.
+- No edits to `tests/test262-runner.ts`, skip lists, `scripts/*baseline*.json`;
+  no new host imports; no `--no-verify`.

--- a/plan/issues/5268-es2015-standalone-array-object-builtins-r2.md
+++ b/plan/issues/5268-es2015-standalone-array-object-builtins-r2.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone: Array + Object built-ins — r2 residual pass (136 ro
 status: in-progress
 sprint: current
 created: 2026-09-01
-updated: 2026-09-01
+updated: 2026-09-03
 priority: high
 horizon: l
 feasibility: medium
@@ -30,6 +30,23 @@ related: [5145, 5148, 4491, 4492, 4444]
 # provenance is a Proxy, which routes it to the native enumerator instead of the
 # closed-struct expansion. The predicate itself lives in the new
 # `proxy-value-provenance.ts`.
+# 2026-09-03 (fable-es6 r3 planning pass, "## Implementation Plan — r3"): the
+# r3 steps put every new algorithm in a NEW module — `array-from-native.ts`
+# (§23.1.2.1/§23.1.2.3), `object-assign-integrity.ts` (the fold-driven
+# integrity precheck), `array-unscopables-native.ts` (the @@unscopables
+# singleton) — and grow the files below by WIRING only: one call per arm
+# (`call-builtin-static.ts` Array.from/Object.assign arms, `builtin-value-read.ts`
+# two switch cases), one factory per trap-read site (`object-runtime-proxy.ts`
+# lazy trap fetch for a Proxy-typed handler), one carrier arm per native
+# (`object-runtime-descriptors.ts` gOPS `$Vec`/closure/Proxy arms,
+# `object-runtime.ts` index reads on closure/wrapper carriers,
+# `object-runtime-enumeration.ts` `$AnyStr` assign source), one guarded cast
+# (`index.ts` `__call_valueOf` closure-extern arm), one Get before the
+# classifier (`object-proto-tostring.ts`). `extern-declarations.ts` /
+# `global-environment.ts` are listed because ONE of them is the producer of the
+# `env::toString` getter import the r3 step R3-2.1 locates by stack trace; the
+# fix there is a single `sourceShadowsGlobalName` guard. Per-step budgets are in
+# the r3 section; `total` is deliberately not granted.
 loc-budget-allow:
   - src/codegen/object-ops.ts
   - src/codegen/expressions/call-namespace-static.ts
@@ -59,6 +76,19 @@ loc-budget-allow:
   - src/codegen/expressions/calls-guards.ts
   - src/codegen/expressions/calls.ts
   - src/codegen/declarations/import-collector.ts
+  # r3 (2026-09-03) — wiring-only growth, see the r3 section per step
+  - src/codegen/native-proto-instance-method-read.ts
+  - src/codegen/expressions/call-object-builtins.ts
+  - src/stdlib/object-runtime.ts
+  - src/codegen/index.ts
+  - src/codegen/carrier-bag-visibility.ts
+  - src/codegen/builtin-prototype-brand.ts
+  - src/codegen/array-methods.ts
+  - src/codegen/vec-length-set.ts
+  - src/codegen/vec-constructor-carrier.ts
+  - src/codegen/extern-declarations.ts
+  - src/codegen/global-environment.ts
+  - src/codegen/registry/imports.ts
 # 2026-09-02 (Opus implementation pass): the two step-1 wiring sites above are
 # each one arm inside an already-oversized dispatcher; splitting either is a
 # separate refactor with its own blast radius.
@@ -75,6 +105,12 @@ loc-budget-allow:
 # nothing here hand-rolls a ToString/ToNumber/equality matrix.
 coercion-sites-allow:
   - src/codegen/object-integrity-proxy.ts
+  # r3 (2026-09-03): `__array_from`'s GetMethod truthiness (`__is_truthy` on
+  # the `@@iterator` read, the same call `buildArrayFromIterNBody` makes) and
+  # the ToBoolean of a trap result in the lazy handler-proxy fetch; both are
+  # the coercion engine's own entry, never a hand-rolled matrix.
+  - src/codegen/array-from-native.ts
+  - src/codegen/object-runtime-proxy.ts
 func-budget-allow:
   - src/codegen/object-ops.ts::compileObjectKeysOrValues
   - src/codegen/object-runtime.ts::ensureObjectRuntime
@@ -91,6 +127,23 @@ func-budget-allow:
   - src/codegen/object-proto-tostring.ts::emitObjectProtoToStringClassifier
   - src/codegen/expressions/call-builtin-static.ts::compileBuiltinStaticCall
   - src/codegen/expressions/calls-guards.ts::emitObjectCoercion
+  # r3 (2026-09-03) — per-function growth named in the r3 section; if the
+  # gate reports a different qualified name for a nested builder (e.g. the
+  # `emitDispatchForMethod` arrow inside index.ts), replace the key with the
+  # gate's own spelling rather than widening the list.
+  - src/codegen/builtin-value-read.ts::ensureStandaloneBuiltinStaticMethodClosure
+  - src/codegen/object-proto-tostring.ts::emitObjectProtoOrRefusal
+  - src/codegen/object-proto-tostring.ts::emitObjectProtoToStringClassifier
+  - src/codegen/array-concat-spec.ts::compileArrayConcatNativeSpecFromExprs
+  - src/codegen/array-concat-spec.ts::emitConcatSource
+  - src/codegen/carrier-bag-visibility.ts::fillCarrierBagVisibility
+  - src/codegen/carrier-bag-visibility.ts::buildBuiltinFnSetRefusalArm
+  - src/codegen/array-like-native.ts::emitArrayLikeNativeMemberBody
+  - src/codegen/array-length-define.ts::maybeEmitVecLengthDefine
+  - src/codegen/vec-length-set.ts::fillVecLengthDynamicArms
+  - src/codegen/array-methods.ts::tryCompileArrayFlatNativeDepth1
+  - src/codegen/index.ts::emitDispatchForMethod
+  - src/codegen/object-runtime-proxy.ts::buildProxyRuntime
 ---
 
 # #5268 — ES2015 standalone: Array + Object built-ins, r2 residual pass
@@ -930,3 +983,899 @@ findings from reconnaissance that a follow-up should not re-derive:
 - **The four `Object.assign/Target-*` rows are one shared blocker**, described
   in the step-3 section above: a DYNAMIC `.valueOf()` on a wrapper `$Object`.
   Fixing that one seam flips all four at once.
+
+## Implementation Plan — r3 (2026-09-03)
+
+Written by the planning lane against `origin/main` `bee5ddd535` (the checkout
+branch `claude/es6-test262-standalone-g10c7u` is exactly that commit). The
+implementer works in its own worktree from this text; nothing below has been
+implemented.
+
+### Census and root-cause groups (137 rows, `.tmp/census0903/array+object.tsv`)
+
+Baseline: `.test262-cache/test262-standalone-current.jsonl` rows stamped
+2026-09-03 09:07 UTC (`oracle_lane: honest`), ES2015 bucket per
+`website/public/benchmarks/results/test262-file-editions.json`. 127 `fail` + 10
+`compile_error`. **23 rows are the r2 "Out of scope" set and stay out**: X0 11
+realm rows (`*proto-from-ctor-realm*` — note CI reaches the realm assertion,
+`Expected SameValue(«[object Array]», «[object Object]»)`, so `$262.createRealm`
+works in CI; the failure is the realm lane's `other.Array.prototype` identity,
+not ours), X1 `subclass-object-arg` (CE, #3371), X2 8 §10.5.11 invariant rows,
+X3 3 `revoke()`-inside-closure `illegal cast … __call_fn_method_3` rows. **114
+rows are in scope**, grouped by the error column (one defect per group, not per
+path prefix):
+
+| Group | Rows | Shared error signature | Root cause (one line) |
+|---|---:|---|---|
+| L `Array.from`/`Array.of` | 17 | `Array.from is not yet implemented` ×7, `Array.of …` ×2, `value is not iterable` ×2, `Expected a Test262Error but got a TypeError` ×3, `args[0].length … 3 vs 2`, `closeCount 0 vs 1`, `requested new array is too large`, `arr[0] undefined vs true`, `source-array-boundary` | No §23.1.2.1 native: the value/`.call` form hits the generic throw body (`builtin-value-read.ts:1717`), the 1-arg direct call drains through `__iterator` only (`call-builtin-static.ts:1416`, no array-like arm), the 2-arg call composes drain-THEN-map (`iterator-native.ts:1883`) so the mapper gets 3 args, never IteratorCloses, and drains an infinite iterator before mapping. |
+| C `Object.assign` + ToObject residual | 12 | `Return value should be …` ×4, `Expected a TypeError … no exception` ×3 (frozen/sealed/non-ext targets), `Cannot assign to read only property`, `Cannot convert undefined or null to object`, `length should be 4 … 0`, `NaN vs "c"`, `Object(symA)` identity | (a) wrapper `$Object`'s dynamic `.valueOf()` reaches `Object.prototype.valueOf` (r2 note); (b) compile-time integrity fold (`ctx.frozenVars`, `call-builtin-static.ts:1737`) is invisible to `__object_assign`; (c) no `$AnyStr` source arm, typed-field store on override, no standalone `Object(sym)` wrapper (`calls-guards.ts:773` is host-gated). |
+| J `concat` protocol | 12 | `[1,2,3,null,null,null] vs …undefined` ×3, `is-concat-spreadable-val-falsey`, `get-order`, `illegal cast in __call_valueOf`, `array-like-to-length-throws`, `arg-length-exceeding-integer-limit`, `uncaught Wasm-GC exception`, TA ×2, `is-concat-spreadable-proxy` illegal cast | `array-concat-spec.ts:204-228` treats `null` as absent; species prologue runs after the receiver's `@@isConcatSpreadable` Get; `__extern_has_idx` on an `arguments` carrier answers the length OVERRIDE; `index.ts:9194-9225` `closure-extern` arm `ref.cast`s a non-closure `valueOf`. |
+| E Proxy MOP in Object statics (r2 step 2 residual) | 11 | `Expected SameValue(«""», «"\|ownKeys\|…"»)` ×2, `Expected SameValue(«1», «0»)`, `Actual [ownKeys, getOwnPropertyDescriptor] and expected [get, set, has, …]`, `Cannot access property on null … 3xx:18` ×2, `[SITE-PROPS-BAG-NOT-AUTHORITATIVE]`, `illegal cast … __module_init_chunk_1`, `key is not present`, `Actual [0, foo] and expected [0, foo, Symbol()]`, `isPrototypeOf … false vs true` | Traps are read off the handler ONCE at `new Proxy` (`object-runtime-proxy.ts:1511-1537` `readTrap`), so a handler that is itself a Proxy (`new Proxy(handler, check)`) contributes NO traps — that is the "wrapTest mystery" of the r2 note (the hand probe used a plain handler); plus r2 steps 2.4-2.7 never started. |
+| D+D2 symbol keys on `$Vec`/closure carriers + intrinsic symbol props | 10 | `Actual [] and expected [Symbol(a), Symbol(b)]` ×2, `obj has 2 symbol-keyed descriptors … 0`, `first entry has value symValue`, `[a, length] vs [length, a]`, `[] vs [name, a]`, `[0, 1, length, a] vs [length, a]`, `Symbol() should be an own property`, `Cannot access property … 858:18`, `Expected obj[5] NOT to be writable` | `__getOwnPropertySymbols` has one `$Object` arm (`object-runtime-descriptors.ts:3323-3333`); the self-hosted gOPDs walks names only (`src/stdlib/object-runtime.ts:59-72`); `Array.prototype[@@unscopables]` never materialised; `Array[@@species]` write not refused. |
+| G reflective `Object.prototype.toString` + `env::toString` leak | 9 | `standalone target emitted host imports: env::toString` ×5 (CE), `Object.prototype.toString is not yet implemented` ×2, `get-symbol-tag-err`, `[object Boolean] vs [object test262]` | Leak: a script-level `var toString` registers a `(func (result externref))` import named `toString` (reproduced below); classifier (`object-proto-tostring.ts:236`) has no WeakSet/WeakMap/Promise/generator/Symbol/Math/JSON arms and the reflective body (`emitObjectProtoOrRefusal` L661) never does the `@@toStringTag` Get. |
+| F symbol/index expandos on function/wrapper/RegExp carriers + species via Proxy | 9 | `Actual [1,2,3] and expected []` (function), `[true] vs []`, `[y,u,c,k,…] vs []`, `[] vs []` (reg-exp), `[object Array] vs [object Object]` ×4 (`create-proxy`), `concat/create-proxy` | index reads (`__extern_has_idx`/`__extern_get_idx`/`__extern_length`) have no closure/wrapper/RegExp carrier arm; the 5 `create-proxy` rows need a repro (see F step). |
+| A/B `__proto__` residual | 6 | see r2 step-1 "NOT done" list | closed-struct literal has no runtime `%Object.prototype%` terminal; `Object.create(proxy)` canonicalises the link; `prop-desc` needs `__proto__` in `OBJECT_PROTOTYPE_OWN_NAMES`. |
+| H `toLocaleString` | 4 | `"true" vs "boolean"` ×2, `"true,false" vs "boolean,boolean"` ×2 | `x.toLocaleString()` folded statically; element Invoke must observe a patched `Boolean.prototype.toString` through the seeded companion (`__protoidx_get_r`). |
+| I/P reflective HOF on a Proxy receiver | 6 | `Expected a TypeError … no exception` ×3 (`create-revoked-proxy`), `Expected a RangeError` ×3 | `Array.prototype.{map,filter,splice}.call(proxy, cb)` goes `emitArrayProtoMemberBody` L896 → `__hof_<m>` with NO species prologue and no `ArrayCreate` RangeError (r2 step-6 "NOT done" finding). |
+| M/N/O/Q/R/S | 18 | as r2 table | unchanged from r2 step 10; O and M re-diagnosed below. |
+
+Sum: 17+12+12+11+10+9+9+6+4+6+18 = 114. ✓
+
+### Verification on current main (2026-09-03, load 0.4-2)
+
+`npx tsx scripts/run-test262-paths.mts .tmp/es2015/r3/sample.txt --standalone`
+(14 rows, one per big group; output `.tmp/es2015/r3/sample-run1.txt`):
+
+```
+=== counts ===
+{ fail: 13, compile_error: 1 }
+fail  Array/from/source-object-length.js            TypeError: value is not iterable
+fail  Array/of/construct-this-with-the-number-of-arguments.js  Array.of is not yet implemented in --target standalone
+compile_error  Object/prototype/toString/symbol-tag-weakset-builtin.js  standalone target emitted host imports: env::toString (#2961)
+fail  Object/prototype/toString/get-symbol-tag-err.js   Expected a Test262Error to be thrown but no exception was thrown at all
+fail  Object/entries/observable-operations.js       Expected SameValue(«""», «"|ownKeys|getOwnPropertyDescriptor:a|get:a|…"»)
+fail  Object/assign/Target-Boolean.js               Return value should be true … at L15: result.valueOf()
+fail  Object/assign/target-is-frozen-data-property-set-throws.js  Expected a TypeError … no exception
+fail  Array/prototype/concat/Array.prototype.concat_spreadable-function.js  Actual [1, 2, 3] and expected []
+fail  Array/prototype/concat/Array.prototype.concat_sloppy-arguments.js  Actual [1, 2, 3, null, null, null]
+fail  Array/prototype/concat/is-concat-spreadable-val-falsey.js  result.length … 2 vs 1
+fail  Object/getOwnPropertySymbols/order-after-define-property.js  Actual [] and expected [Symbol(a), Symbol(b)]
+fail  Object/prototype/toLocaleString/primitive_this_value.js  «"true"» vs «"boolean"»
+fail  Array/prototype/keys/returns-iterator-from-object.js  Array.prototype.keys is not yet callable as a value
+fail  Array/prototype/map/target-array-with-non-writable-property.js  0 value should be 2
+```
+
+Every sampled row fails exactly as the baseline records — nothing to drop.
+Controls: `.tmp/es2015/arrobj-controls.txt` re-run in two 10-row batches
+(`.tmp/es2015/r3/controls-run1.txt`): **20 / 20 pass** on `bee5ddd535`.
+
+Leak repro (CLI, one compile): `npx tsx src/cli.ts .tmp/es2015/probes/ts2.js
+--standalone -o .tmp/es2015/r3/out2` → `WebAssembly.Module.imports` =
+`[{"module":"env","name":"toString","kind":"function"}]`; the WAT carries
+`(import "env" "toString" (func $toString_import (type 17)))` with
+`(type $type17 (func (result externref)))` and a `$__mod_toString` module
+global — i.e. a ZERO-ARG externref GETTER import named after the identifier
+(not `global_toString`), never called from any body. The `global_<name>`
+family in `extern-declarations.ts:1459-1530,1594-1626` is already
+standalone-gated, so this comes from a different producer.
+
+### Ground rules for every step
+
+- Probe: `npx tsx scripts/run-test262-paths.mts <list> --standalone`, lists
+  ≤ 15 rows, one compile process at a time; `--isolate` only when a row hangs.
+  Compile timeouts under load are artifacts — re-run alone before believing one.
+- Type facts through `ctx.oracle` (`src/checker/oracle.ts`) only; a raw
+  `ctx.checker.getTypeAtLocation` trips `check:oracle-ratchet`. The steps below
+  name the oracle entry where a type question arises.
+- New mechanisms go in NEW modules (named per step); the god-files listed in
+  the frontmatter grow by WIRING only. Every `Instr[]` handed to two bodies is
+  a factory (#5188 followUp 4). `FunctionContext` literals carry
+  `labelMap: new Map()` (+ `isGenerator?`).
+- No new `env::*` import, no allowlist edit, no runner/skip-list/baseline edit.
+- **Every step's acceptance names PASSING shapes at risk and how they are
+  checked** — this is the r2 lesson (5 of 6 waves shipped regressions the row
+  list could not see). Two checks are used throughout: **byte-identity** (the
+  JS-host lane module for a named control program is sha-identical to base —
+  compile with `{ target: "gc" }` on both trees, compare `sha1(wasm)`) and
+  **control programs run on BOTH lanes** (standalone + host) and diffed
+  against base output. Capture `.tmp/base-<file>.ts` copies at the FIRST edit
+  (CLAUDE.md file-copy A/B) so every base run is one `cp` away.
+- Gates before every commit, bare and chained:
+  `node scripts/check-loc-budget.mjs && node scripts/check-func-budget.mjs && node scripts/check-coercion-sites.mjs && npm run -s check:oracle-ratchet && npm run -s check:dead-exports`,
+  plus once with `LOC_GATE_BASE=$(git rev-parse upstream/main)`.
+
+### Step R3-1 — native `Array.from` / `Array.of` (group L; 17 rows; risk: medium)
+
+**Root cause.** There is no §23.1.2.1/§23.1.2.3 algorithm in the module: the
+direct 1-arg call drains only iterables (`call-builtin-static.ts:1416-1447`
+calls `__iterator` → `value is not iterable` on `{length:4,…}`), the 2-arg
+call composes `__array_from_iter_n` THEN `__hof_map` (`iterator-native.ts:1873-1903`),
+which drains before mapping (infinite `{done:false}` → "requested new array is
+too large"), calls the mapper with `(v, i, recv)` (3 args), and never closes
+the iterator; the value/`.call` form takes the `default:` branch of
+`ensureStandaloneBuiltinStaticMethodClosure` (`builtin-value-read.ts:1280-1299`,
+throw body at L1717). `Array.of.call(T, …)` likewise.
+
+**Files / functions.**
+
+1. NEW `src/codegen/array-from-native.ts` (≈ 420 LOC): `ensureNativeArrayFrom(ctx)`
+   registers `__array_from(C, items, mapFn, thisArg) -> externref` and
+   `ensureNativeArrayOf(ctx)` registers `__array_of(C, argsVec) -> externref`
+   (both standalone-only, append-only defined funcs via `mintDefinedFunc` /
+   `pushDefinedFunc`, deps resolved BY NAME after `ensureObjectRuntime`,
+   `ensureNativeIteratorRuntime`, `addUnionImportsViaRegistry`,
+   `reserveApplyClosure`, and `reserveNativeConstructDriver(ctx, 0, …)` +
+   `(ctx, 1, …)` — `native-construct.ts:143`, driver name `__native_construct_<arity>`,
+   params `(C, newTarget, …args)`). Body of `__array_from`, in spec order:
+   - `C` null/undefined ⇒ the default lane (a fresh `$ObjVec` via `__objvec_new`);
+     else `usingCtor = __is_constructor(C)` (the predicate `array-species.ts`
+     already resolves as `deps.isConstructor`).
+   - `mapFn` undefined ⇒ `mapping = false`; else `__typeof_function(mapFn)`
+     false ⇒ `buildThrowJsErrorInstrs(ctx, "TypeError", "Array.from: mapFn is not callable")`.
+   - `usingIterator = GetMethod(items, @@iterator)`: `ref.test $Vec` OR
+     `__is_truthy(__extern_get(items, __box_symbol(1)))` (id 1 = `@@iterator`,
+     the same test `buildArrayFromIterNBody` makes at `iterator-native.ts:2033-2058`,
+     including the present-but-nullish arm that must reach `__iterator`'s
+     TypeError). Nullish `items` ⇒ TypeError "Cannot convert undefined or null
+     to object" (ToObject, step 7 of the array-like branch — but GetMethod on
+     nullish throws first, so ONE nullish guard at the top is spec-equivalent).
+   - Iterator branch: `A = usingCtor ? __native_construct_0(C, null) : $ObjVec`;
+     `iter = __iterator(items)`; loop `k`: `(done, v) = __iterator_next(iter)`;
+     done ⇒ `Set(A,"length",k)` (custom-C lane: `__extern_set_strict(A,"length",box(k))`;
+     `$ObjVec`: nothing) and return; `mapped = mapping ? __apply_closure(mapFn, thisArg, [v, box(k)]) : v`
+     — build the 2-slot `$ObjVec` with `__objvec_new`/`__objvec_push` so the
+     mapper observes `arguments.length === 2` (`iter-map-fn-args`);
+     `CreateDataPropertyOrThrow(A, k, mapped)`: `$ObjVec` lane ⇒ `__objvec_push`
+     (no prototype consult — `of/does-not-use-prototype-properties`); custom-C
+     lane ⇒ `__defineProperty_value(A, ToString(k), mapped, CREATE_DATA_PROPERTY_FLAGS)`
+     + the following plain `__extern_set` exactly as `emitArraySpeciesResultSwap`
+     does at `array-species.ts:423-451` (copy that comment's reason).
+     **IteratorClose on abrupt** (`iter-map-fn-err`, `iter-set-elem-prop-err`,
+     `iter-set-elem-prop-non-writable`): wrap the mapper call + define in a
+     `try_table` with a `catch_all_ref` clause (`src/ir/types.ts:592`; shape
+     precedent `named-this-call.ts:306-325` — EMPTY block type, result parked
+     in a local), handler = `__iterator_return(iter)` then `throw_ref`.
+   - Array-like branch: `len = __extern_length(items)` (ToLength incl. the
+     observable valueOf/toString walk); `A = usingCtor ? __native_construct_1(C, null, box(len)) : $ObjVec`;
+     loop `k < len`: `v = __extern_get_idx(items, k)` (an absent index reads
+     `undefined` — `source-object-length` expects an OWN `undefined`, not a
+     hole, so push the undefined singleton, never `$Hole`); same map/define as
+     above (no IteratorClose here); then `Set(A,"length",len)`.
+   - `__array_of(C, argsVec)`: `len = argsVec.len`; `A = usingCtor ? construct_1(C, box(len)) : $ObjVec`;
+     per k `CreateDataPropertyOrThrow` as above (custom-C lane must THROW when
+     the define is refused — `of/return-abrupt-from-data-property-using-proxy`
+     expects the Proxy `defineProperty` trap's Test262Error to escape, which
+     `__defineProperty_value` on a `$Proxy` already forwards); `Set(A,"length",len)`.
+2. `src/codegen/expressions/call-builtin-static.ts` — the `Array.from` arm
+   (L1188-1541): under `ctx.standalone`, REPLACE the #2169c drain block
+   (L1416-1447) and the #3206 mapped block (L1470-1513) with one emission:
+   `items` → externref, `mapFn` → externref (inline arrow/function via
+   `compileArrowAsClosure` exactly as L1482-1490, else `compileExpression`),
+   `thisArg` → externref or `ref.null.extern`, `ref.null.extern` for `C`, then
+   `call __array_from`. **Keep every arm above L1416 byte-for-byte**: the
+   native-string (#1470, L1225), native-generator (#2169, L1254), Set (L1288),
+   Map (L1322) and typed-vec `array.copy` (L1346-1409) fast paths return
+   before the new call, so `Array.from(typedVec)`, `Array.from("str")`,
+   `Array.from(set)` keep their carriers. The `Array.of` arm (L1543+): keep
+   the native `Array.of(a,b,c)` vec build; nothing changes for direct calls.
+   Type question here — none new (`argTsType` at L1195 is pre-existing;
+   do not add `ctx.checker` calls; `ctx.oracle.staticJsTypeOf` is the entry
+   if the implementer needs a primitive-vs-object fact).
+3. `src/codegen/builtin-value-read.ts` `ensureStandaloneBuiltinStaticMethodClosure`
+   (L996): add `case "Array.from"` (paramTypes = 3 × externref, returnType
+   externref, body = `call __array_from(<receiver>, arg1, arg2, arg3)`) and
+   `case "Array.of"` (variadic: mirror `String.fromCharCode` at L1183-1207 —
+   paramTypes = `[ref_null $argvVec]` from `ensureExtrasArgvGlobal`, body =
+   `call __array_of(<receiver>, vec)`; add `"Array.of"` to the variadic
+   publication test at L1742 so any-callee call sites emit the variadic arm).
+   **The receiver slot is the open question the implementer must settle with
+   a 5-line probe FIRST**: static value closures are minted with params
+   `[__self, arg0…]` (`makeBuiltinClosureFctx`, L524) — no `this` param — while
+   `__call_fn_method_N` installs the caller's `this` in the `__current_this`
+   module global before the `call_ref` (`closure-exports.ts:1338-1345`,
+   `context/types.ts:986`). Probe `var f = Array.from; f.call(C, [])` with a
+   body that returns `__current_this`; if the global carries `C`, read it
+   there; if not, mint these two closures with a leading receiver slot the
+   way proto-member closures do (`this` = param 1, `array-object-proto.ts:865`)
+   and route `.call` through the same wrapper type. `iter-cstm-ctor.js`
+   asserts `thisVal === result` and `args.length === 0`, which pins the answer.
+4. `iterator-native.ts`: leave `ensureNativeArrayFromMapped` in place for one
+   PR (it is still referenced from `call-builtin-static.ts` until step 2 lands);
+   after step 2 it is dead → `check:dead-exports` will flag it; delete it in
+   the same PR (−64 LOC) rather than leaving an unreferenced export.
+
+**Rows claimed (17):** all `built-ins/Array/from/*` and `built-ins/Array/of/*`
+rows in the TSV except the two X0 `proto-from-ctor-realm.js`.
+`source-array-boundary.js` (mapper receives `1.7976931348623157e+308`,
+expected `undefined` for `array[this.arrayIndex]`) is the mapper's `this`
+(`thisArg`) — verify after the 2-arg mapper exists; if it is a boxed-f64
+crossing defect, name it and defer.
+
+**Growth grant:** `src/codegen/array-from-native.ts` (new, no grant needed),
+`src/codegen/expressions/call-builtin-static.ts` +40 (wiring, net negative
+after the two removed arms), `src/codegen/builtin-value-read.ts` +45,
+`builtin-value-read.ts::ensureStandaloneBuiltinStaticMethodClosure` +30 lines.
+
+**Order-preservation constraints.** §23.1.2.1 order: mapFn callability check
+BEFORE `GetMethod(items,@@iterator)`; `Construct(C)` (iterator lane, zero
+args) BEFORE the first `next`; `Construct(C,«len»)` (array-like lane) AFTER
+`Get(items,"length")`; per element `Get`/`next` → map → define; `length`
+set LAST and through `[[Set]]`, not define (`iter-set-length-err`). The
+mapper receives exactly `(value, k)`.
+
+**Acceptance.**
+- The 17 rows above flip; `.tmp/es2015/r3/from-of.txt` (implementer writes
+  it from the TSV) 0 pass → ≥ 15 pass, every not-flipped row named with the
+  measured reason.
+- **Passing shapes at risk, checked on BOTH trees:** (i) the `#3206`
+  consumer — `Array.from({length: 3}, (_, i) => i * 2)` and
+  `Array.from(new Set([1,2]), x => x + 1)` print identically; run
+  `built-ins/TypedArray/prototype/map/` (any 10 rows — they go through
+  `harness/testTypedArray.js` `makeArray = Array.from({length:n}, fn)`) and
+  require an identical pass set; (ii) `Array.from("héllo")`,
+  `Array.from(gen())`, `Array.from(new Map([[1,2]]))`, `Array.from([1,2,3])`
+  (typed vec copy) — byte-identical standalone modules (the arms above the
+  new call must not move); (iii) host lane: `tests/issue-4492-builtin-as-value.test.ts`
+  style compile of `var f = Array.from; f([1])` with `{target:"gc"}` is
+  sha-identical to base (the new cases are inside `ctx.standalone`);
+  (iv) `built-ins/Array/from/iter-map-fn-this-arg.js`,
+  `get-iter-method-err.js`, `of/creates-a-new-array-from-arguments.js`
+  (controls) stay green.
+- Pin: `tests/issue-5268-r3-array-from.test.ts` — standalone compile of the
+  four shapes (array-like, iterable+mapFn+throw with `closeCount`,
+  `Array.from.call(C, iterable)`, `Array.of.call(C, 1, 2)`), `result.imports`
+  empty, verified to FAIL on the pre-change tree by file-copy A/B.
+
+### Step R3-2 — `env::toString` leak + reflective `Object.prototype.toString` (group G; 9 rows; risk: medium)
+
+**Root cause.** (a) A script-level `var toString = …` makes a
+`(func (result externref))` getter import named `toString` appear in the
+module (repro above) — the r2 note's diagnosis ("the collector registers the
+ambient function") is confirmed in effect but the producer is NOT any of the
+`global_<name>` loops (all standalone-gated). (b) The reflective body never
+performs the §20.1.3.6 step-14 `Get(O, @@toStringTag)`; steps 14/15 exist only
+in the compile-time `.call` fold (`object-proto-symbol-tag.ts:155
+emitObjectProtoToStringWithSymbolTag`).
+
+**Files / functions.**
+
+1. Locate the producer: add a TEMPORARY `if (name === "toString") throw new
+   Error(new Error().stack)` at the top of `addImport`
+   (`src/codegen/registry/imports.ts:51`) and compile
+   `.tmp/es2015/probes/ts2.js --standalone`; the stack names the site. Two
+   candidates by signature (zero params, externref result, bare name): a
+   declared-global getter thunk keyed by identifier text, or the
+   `emitRealmGlobalPrimitiveMethodWriteback` neighbourhood
+   (`global-environment.ts:61-95`, the ONLY code that special-cases a script
+   `toString`/`valueOf` binding). Fix at the producer: a name that
+   `sourceShadowsGlobalName(sourceFile, name)` (`source-function-members.ts:135`)
+   reports as rebound by THIS program must not register an ambient import
+   under `ctx.standalone`/`ctx.wasi`. Re-verify: 0 imports for `ts2.js`, AND
+   the module still prints `[object …]` (the `$__mod_toString` global path is
+   what the body actually uses). Remove the throw.
+2. `object-proto-tostring.ts:661 emitObjectProtoOrRefusal`: before the
+   classifier, emit `tag = __extern_get(recv, __box_symbol(4))` (id 4 =
+   `Symbol.toStringTag`, `array-object-proto.ts:3840`) — a real `[[Get]]`, so
+   a throwing getter propagates (`get-symbol-tag-err.js`) and a Proxy `get`
+   trap fires; if `tag` is a native string (`ref.test $AnyString`) → return
+   `"[object " + tag + "]"` (`__str_concat`), else fall into the classifier.
+   For a PRIMITIVE receiver (`symbol-tag-override-primitives.js`,
+   `toString.call(true)`), the Get must see the wrapper prototype: box first
+   through `__new_Boolean`/`__new_Number`/`__new_String`
+   (`object-runtime.ts:2952-2996`, the same natives `emitObjectCoercion` calls)
+   — only when `__typeof_boolean/number/string` says so; `null`/`undefined`
+   keep steps 1-2.
+3. Classifier arms (`emitObjectProtoToStringClassifier`, L236): add
+   brand-tested arms for WeakSet, WeakMap, Promise (`ref.test` on the
+   registered `$__WeakSet`/`$__WeakMap`/`$Promise` types), `$Symbol`
+   carrier/wrapper, and the `Math`/`JSON` namespace carriers → all answer
+   `[object Object]` ONLY as the step-13 default AFTER the @@toStringTag Get
+   above declined (their own tag was deleted/replaced, which is exactly why
+   the rows expect the default). Keep the loud refusal as the tail — the
+   module header forbids a blanket default.
+4. Proxy arm (`proxy-array.js`, `proxy-revoked-during-get-call.js`): replace
+   the explicit refusal at L493-502 with §20.1.3.6 step 4 `IsArray(O)` through
+   `__extern_is_array` (its `$Proxy` arm landed in r2 step 6: unwrap to target,
+   TypeError on revoked), then the step-14 Get through the proxy (the `get`
+   trap in `proxy-revoked-during-get-call` revokes the proxy DURING the Get —
+   the spec answer is still `[object Array]` because `builtinTag` was fixed in
+   step 4; do not re-run IsArray after the Get).
+
+**Rows claimed (8 of 9):** the 5 `symbol-tag-*-builtin.js` (must go CE → pass;
+`symbol-tag-generators-builtin.js` additionally wants `[object GeneratorFunction]`
+/ `[object Generator]` + a deletable generator-prototype tag — if that needs
+the generator carrier's own `@@toStringTag`, name it and DEFER that one row),
+`get-symbol-tag-err.js`, `symbol-tag-override-primitives.js`,
+`proxy-array.js`, `proxy-revoked-during-get-call.js`.
+
+**Growth grant:** `object-proto-tostring.ts` +90,
+`object-proto-tostring.ts::emitObjectProtoOrRefusal` +25,
+`object-proto-tostring.ts::emitObjectProtoToStringClassifier` +40; the
+producer file of the leak +10 (name it in the PR; if it is
+`extern-declarations.ts` or `global-environment.ts` the grant below covers
+it).
+
+**Order constraints.** Steps 1-2 (null/undefined) → 3 ToObject → 4 IsArray →
+5-13 builtinTag → 14 Get(@@toStringTag) → 15 string test. Do NOT move the
+Get before IsArray (revoked-proxy rows).
+
+**Acceptance.**
+- The 8 rows flip; the 5 CE rows are checked for `imports.length === 0` from
+  the CLI, not only for the runner verdict.
+- **Passing shapes at risk:** the compile-time `.call` fold is untouched —
+  `Object.prototype.toString.call([])`, `.call(null)`, `.call(new Date())`,
+  `.call(function(){})`, `.call(Object.prototype)`, `.call(Error.prototype)`
+  (the `NATIVE_PROTO_ORDINARY_BRANDS` rows) printed on both trees, standalone;
+  the stored-method idiom `arr.getClass = Object.prototype.toString; arr.getClass()`
+  for Array/Number/String/Boolean/Date/RegExp/Error/Map/Set receivers printed
+  on both trees; `built-ins/Object/prototype/toString/symbol-tag-non-str-proxy-function.js`
+  and `proxy-revoked.js` (controls) stay green; `built-ins/Object/prototype/toString/`
+  (≤ 15 rows sampled, including the 5 `S15.2.4.2_*`) identical pass set;
+  host lane sha-identical for a `toString.call(x)` program.
+- Pin: `tests/issue-5268-r3-proto-tostring.test.ts` asserts the import list
+  is EMPTY for the `var toString = Object.prototype.toString` shape and the
+  `@@toStringTag` getter throw propagates.
+
+### Step R3-3 — `Object.assign` integrity + wrapper `valueOf` + `Object(sym)` (group C; 12 rows; risk: medium)
+
+**Root cause.** Three seams: (a) a wrapper `$Object` created by
+`emitObjectCoercion` has no `$NativeProto` link, so the DYNAMIC
+`result.valueOf()` resolves to `Object.prototype.valueOf` (r2 step-3 note);
+`native-proto-instance-method-read.ts` answers the wrapper case on
+`__extern_get` only, and only for closures ALREADY minted (its demand gate,
+L27-40). (b) `Object.freeze/seal/preventExtensions(<literal>)` is a
+compile-time fold (`ctx.frozenVars`/`sealedVars`/`nonExtensibleVars`,
+`call-builtin-static.ts:1726-1737`; R2-5 in this file) invisible to
+`__object_assign`. (c) no `$AnyStr` source arm; a same-key override writes
+through a typed field (`ObjectOverride-sameproperty` → `NaN`); `Object(sym)`
+standalone is identity (`calls-guards.ts:773` arm is `!noJsHost`-gated).
+
+**Files / functions.**
+
+1. Wrapper method identity (4 rows `Target-{Boolean,Number,String,Symbol}`):
+   in `emitObjectCoercion` (`calls-guards.ts`, the four wrapper arms) and the
+   `Object.assign` primitive-target route (`call-builtin-static.ts:3629-3633`),
+   after emitting the wrapper, SEED the `valueOf` and `toString` closures for
+   that brand — `ensureStandaloneNativeMethodClosure(ctx, brand, "valueOf", "method", { refusalBodyFallback: true })`
+   (`native-proto.ts`; brand via `BUILTIN_BRAND_TABLE`), so
+   `unshiftExternGetProtoMethodArm` finds them; then give the METHOD-CALL
+   path the same answer: the `__extern_method_call` `$Object` arm's
+   proto-miss terminal (in `object-runtime.ts` — search the `registerNative("__extern_method_call"`
+   site) must consult a new `native-proto-instance-method-read.ts` export
+   `wrapperBrandMethodLookupInstrs(ctx, …)` (factor the `wrapperClassify`
+   ladder at L193-225 so both arms share ONE ladder) before answering
+   `Object.prototype.valueOf`. `Target-Symbol` needs 4 below.
+2. Integrity fold → runtime precheck (3 + 2 rows): NEW
+   `src/codegen/object-assign-integrity.ts` (≈ 140 LOC) exporting
+   `emitObjectAssignIntegrityPrecheck(ctx, fctx, targetLocal, sourcesLocal, level)`
+   where `level ∈ {frozen, sealed, nonExtensible}` comes from the call-site
+   fold (`integrityVarKey(ctx, targetIdentifier)` ∈ `ctx.frozenVars`/…, the
+   same test `assignment.ts:2898,4489` makes). Emitted at
+   `call-builtin-static.ts:3674` just before `call __object_assign`: for each
+   source (the `$ObjVec` built at L3666-3673) and each of
+   `__object_keys(src)` ++ `__getOwnPropertySymbols(src)`:
+   `d = __getOwnPropertyDescriptor(target, key)`; accessor `d` (has `set`) →
+   allowed (§10.1.5.3 calls the setter: `target-is-frozen-accessor-property-set-succeeds`,
+   `target-is-non-extensible-existing-accessor-property`); `frozen` and data
+   `d` → TypeError "Cannot assign to read only property"; `sealed`/`nonExtensible`
+   and `d` undefined → TypeError "Cannot add property, object is not extensible".
+   Only emitted when the fold KNOWS the level (a plain target keeps today's
+   bytes). `target-is-non-extensible-existing-accessor-property` currently
+   dies earlier with "Cannot convert undefined or null to object": probe
+   `var t = Object.preventExtensions({ set foo(v){} }); print(t == null)` —
+   `emitStoredObjectIntegrityCall` (`call-object-builtins.ts:80`) is returning
+   a null externref for an accessor-carrying literal; fix it to return its
+   argument (§20.1.2.17 step 3) before the precheck can help.
+3. `__object_assign` sources (`object-runtime-enumeration.ts:1107-1330`):
+   (a) `$AnyStr` source arm — copy index keys `"0"…"len-1"` via
+   `__extern_set_strict` (`Override-notstringtarget`: three string sources
+   onto a Number wrapper, later sources override); (b) `ObjectOverride-sameproperty`:
+   the `$Object` arm already writes through `__extern_set_strict` (L1318-1326),
+   so the `NaN` comes from the TARGET being a closed struct with a typed `a`
+   field — route a target whose `ctx.oracle` literal-shape fact has only
+   primitive-typed fields the way `compileObjectAssignArg` (`calls.ts:687`)
+   routes a literal (build as `$Object`); confirm with a 4-line probe before
+   editing (the fix may be in `compileObjectAssignArg`, not the native).
+4. `Object(sym)` standalone wrapper (`symbol_object-returns-fresh-symbol`,
+   half of `Target-Symbol`): in `calls-guards.ts:773` add the `noJsHost` arm —
+   `__new_plain_object()` + `__defineProperty_value(obj, WRAPPER_PRIMITIVE_KEY, extern(symbolCarrier), 0)`
+   (the `[[PrimitiveValue]]` slot convention `native-proto-instance-method-read.ts:70`
+   documents; the carrier from `ensureSymbolCarrier`/`__box_symbol`), typeof
+   answers `"object"` because it is a `$Object`.
+
+**Rows claimed (12):** all `built-ins/Object/assign/*` rows in the TSV +
+`built-ins/Object/symbol_object-returns-fresh-symbol.js`.
+
+**Growth grant:** `object-assign-integrity.ts` new; `call-builtin-static.ts`
++25 (wiring, shared with R3-1's grant); `calls-guards.ts` +35,
+`calls-guards.ts::emitObjectCoercion` +30; `native-proto-instance-method-read.ts`
++40; `object-runtime.ts` +25 (the one method-call consult);
+`object-runtime-enumeration.ts` +60 (string-source arm),
+`object-runtime-enumeration.ts::buildObjectEnumerationHelpers` +60;
+`call-object-builtins.ts` +8.
+
+**Order constraints.** §20.1.2.1: ToObject(target) first (already), then per
+source in order, per key in `[[OwnPropertyKeys]]` order (strings, then
+symbols), `Get` then `Set(…, true)`. The precheck of step 2 must observe the
+SAME key order and must run the source `Get` only once (do not read the
+value in the precheck — descriptors of the TARGET only).
+
+**Acceptance.**
+- The 12 rows flip.
+- **Passing shapes at risk, both trees:** `Object.assign({}, {a:1}, {b:2})`,
+  `Object.assign(target, null, undefined, {c:3})`, `Object.assign([], [1,2])`,
+  `Object.assign({}, "ab")` (host lane prints `{0:"a",1:"b"}` — after 3(a)
+  standalone must match), a frozen literal WITHOUT assign (`Object.freeze(o); o.x = 1`
+  strict throw, sloppy no-op) — byte-identical standalone modules (the
+  precheck is gated on `assign` + a fold hit); the wrapper seeding must not
+  change `(new Number(1)).toString()`/`Number.prototype.toString === (new Number()).toString`
+  (`tests/issue-4248*` suite green, A/B'd); `built-ins/Object/assign/Target-Undefined.js`
+  (control) stays green; host lane sha-identical for an `Object.assign(a, b)`
+  program (`{target:"gc"}`).
+- Pin `tests/issue-5268-r3-object-assign.test.ts`: frozen-data throw,
+  frozen-accessor setter called, `Object.assign(true, {}).valueOf() === true`,
+  `Object(sym) !== sym && typeof Object(sym) === "object"`.
+
+### Step R3-4 — Proxy MOP residual in the Object statics (group E; 9 of 11 rows; risk: high)
+
+**Root cause.** Traps are read off the handler ONCE, at `new Proxy` time
+(`object-runtime-proxy.ts:1511-1537`, the `readTrap("get")…readTrap("construct")`
+sequence into `$ProxyTraps`). §10.5.* does `GetMethod(handler, "<trap>")` at
+EVERY operation, so a handler that is itself a Proxy (`new Proxy(handler,
+check)` — `{values,entries}/observable-operations.js`,
+`keys/property-traps-order-with-proxied-array.js`, and R's
+`splice/property-traps-order-with-species.js`) contributes no traps today (the
+`$Proxy` handler fails `readTrap`'s `$Object` read → empty log). This is the
+r2 "wrapTest mystery": the hand probe used a plain handler. Plus r2 steps
+2.4-2.7 (never started).
+
+**Files / functions.**
+
+1. Lazy trap lookup for a Proxy-typed handler: in `object-runtime-proxy.ts`,
+   at `new Proxy` (L1511) record a `handlerIsProxy` i32 (append a field to
+   `$Proxy` or reuse a spare flag bit — the struct layout is minted in the
+   same file; pick the option that keeps `F_PTARGET`/`F_PHANDLER`/`F_REVOKED`
+   indices stable) and at every `trap = p.ptraps.<field>` read site
+   (L316, L565, L883, L966, L1194, L1315 and the ownKeys/gopd/gpo/spo/isext/
+   prevext/define sites that share the pattern) route through ONE new factory
+   `trapFetchInstrs(field, name)`: `handlerIsProxy ? GetMethod via __extern_get(handler, "<name>")` (which
+   dispatches the handler-proxy's own `get` trap) `: p.ptraps.<field>`. The
+   ordinary-handler path is byte-identical (the flag is 0). GetMethod: a
+   present non-callable trap is a TypeError, `undefined`/`null` is absent
+   (§7.3.9, the rule L129/L377 already document).
+2. r2 step 2.4 — `Object.keys(proxy)` post-trap enumerability
+   (`proxy-non-enumerable-prop-invariant-3`): in `buildOwnKeysDispatch`'s
+   `Object.keys` forward (L732; `forwardName === "__object_keys"`), after the
+   trap list is materialised, filter each STRING key through
+   `__proxy_gopd_dispatch(p, k)`, keeping only `enumerable === true`
+   (§7.3.25 step 4.a). `proxy-keys.js` (`illegal cast … __module_init_chunk_1`):
+   the ownKeys trap returns an array-LIKE `$Object` with numeric GETTERS; the
+   CreateListFromArrayLike loop at L768+ reads entries with `__extern_get_idx`
+   — confirm with a 6-line repro whether it is that read or the later
+   `__objvec` cast that traps, then read `length`/indices through
+   `__extern_get` with a string key (getter-aware) when the result is not a
+   `$ObjVec`.
+3. r2 step 2.5 — `__getOwnPropertySymbols` Proxy arm: ownKeys result filtered
+   to `$Symbol` carriers (`object-runtime-descriptors.ts:3305`, prepend the
+   arm with the `fillObjectIntegrityProxyArms` `install()` idempotence shape,
+   `object-integrity-proxy.ts:949-970`); and `__object_getOwnPropertyDescriptors`
+   (`src/stdlib/object-runtime.ts:59-72`, self-hosted TS): switch the key
+   source to names ++ `__getOwnPropertySymbols(obj)` and SKIP a key whose
+   `__getOwnPropertyDescriptor` answers `undefined` (`proxy-undefined-descriptor`);
+   this also serves D's `symbols-included` and
+   `getOwnPropertyDescriptors/order-after-define-property` once R3-6 gives
+   gOPS its `$Vec` arm. (`__getOwnPropertySymbols` must be added to the
+   `calleeTypes` map at L110-114.)
+4. r2 step 2.6 — `Object.defineProperties(o, proxy)`: at the
+   `[SITE-PROPS-BAG-NOT-AUTHORITATIVE]` refusal (`object-runtime-descriptors.ts:1326`)
+   add a `$Proxy` PROPS arm: keys = `__proxy_own_keys_all(props)`
+   (`object-integrity-proxy.ts:174`), per key `d = __proxy_gopd_dispatch`,
+   skip undefined, collect, then define in order. The row only asserts the
+   gopd trap ORDER `["0","foo",sym]`.
+5. r2 step 2.7 — `__isPrototypeOf` (`object-runtime-prototype.ts:777-781`):
+   replace the raw `struct.get $proto` hop with `__getPrototypeOf(cur)`
+   (Proxy `gpo` guard) — one call per hop, `ref.eq` unchanged.
+
+**Rows claimed (9):** `{values,entries}/observable-operations.js`,
+`keys/proxy-non-enumerable-prop-invariant-3.js`, `keys/proxy-keys.js`,
+`keys/property-traps-order-with-proxied-array.js`,
+`getOwnPropertyDescriptors/proxy-{no-ownkeys-returned-keys-order,undefined-descriptor}.js`,
+`defineProperties/proxy-no-ownkeys-returned-keys-order.js`,
+`isPrototypeOf/arg-is-proxy.js`. **DEFERRED (2):**
+`{freeze,seal}/proxy-with-defineProperty-handler.js` — r2 measured the trap
+sequence correct and the failure in a closed-struct capture
+(`seenDescriptors[key] = descriptor` not persisting into a captured empty
+literal); that is a value-representation defect outside this issue.
+
+**Growth grant:** `object-runtime-proxy.ts` +120,
+`object-runtime-proxy.ts::fillProxyDispatch` +60,
+`object-runtime-proxy.ts::buildProxyRuntime` (or whichever function owns
+L1500-1570 — name it in the PR) +20; `object-runtime-descriptors.ts` +70,
+`object-runtime-descriptors.ts::buildObjectDescriptorHelpers` +50;
+`src/stdlib/object-runtime.ts` +15; `object-runtime-prototype.ts` +10,
+`object-runtime-prototype.ts::buildObjectPrototypeHelpers` +10.
+
+**Order constraints.** Trap lookup order per operation is observable
+(`property-traps-order-with-proxied-array` expects exactly
+`["ownKeys","getOwnPropertyDescriptor"]` from the HANDLER proxy's `get`
+trap, in that order, and nothing else — so the lazy fetch must read only the
+trap the operation needs, never pre-fetch). EnumerableOwnProperties:
+`ownKeys`, then per key `gopd` → `get`.
+
+**Acceptance.**
+- The 9 rows flip.
+- **Passing shapes at risk, both trees:** `built-ins/Proxy/` — the largest
+  blast radius in this plan: run the 60-row sample
+  `built-ins/Proxy/{get,set,has,ownKeys,getOwnPropertyDescriptor,defineProperty}/`
+  (first 10 of each, in 15-row batches) and require an IDENTICAL pass set;
+  `built-ins/Object/seal/seal-proxy.js` (control) green; the 280-row
+  `Object/{freeze,seal,isFrozen,isSealed,values,entries}` set r2 measured
+  (253/26) must not lose a row (run in 15-row batches or the subset touched);
+  `tests/issue-5268*.test.ts` (r2's 23 pins) green; an ordinary-handler
+  program (`new Proxy({a:1}, { get(t,k){ return 42 } })`) compiles to a
+  byte-identical standalone module (the lazy path is flag-gated); host lane
+  sha-identical.
+- Pin `tests/issue-5268-r3-proxy-handler-proxy.test.ts`: the nested-handler
+  log for `Object.entries`, and `Object.keys` post-trap filtering.
+
+### Step R3-5 — concat residuals (group J; 10 of 12 rows; risk: low-medium)
+
+r2 step 8 is still exact; the sub-items below are re-anchored to today's code.
+
+1. (d) `is-concat-spreadable-val-falsey` (1 row, one line): `array-concat-spec.ts:212-216`
+   tests `ref.is_null ∨ __extern_is_undefined`; §23.1.3.1.1 step 3 is "if
+   `spreadable` is not undefined, return ToBoolean" — drop the `ref.is_null`
+   term (a present `null` is falsy, not absent). Risk: a receiver whose
+   reflective read returns `ref.null` for ABSENT — verify `__extern_get` on a
+   `$Vec`/closure/`$Object` miss returns the undefined singleton, not
+   `ref.null`, with a 3-line probe; if any carrier answers `ref.null` for a
+   miss, keep the null term for that carrier only.
+2. (e) `is-concat-spreadable-get-order` (1 row): in
+   `compileArrayConcatNativeSpecFromExprs` (L348-380) emit the species
+   prologue (`emitArraySpeciesCreate`, L375) BEFORE `emitConcatSource` runs
+   the receiver's `@@isConcatSpreadable` Get; the receiver is already stashed
+   in a local, so only the call order moves.
+3. (c) `concat_array-like-length-to-string-throws` / `-to-length-throws` /
+   `arg-length-exceeding-integer-limit` (3 rows): `index.ts:9194-9225`
+   (`closure-extern` arm of `emitDispatchForMethod`) `ref.cast`s the field to
+   `entry.closureTypeIdx` unguarded — a `valueOf: null` field traps. Add
+   `ref.test` and treat a non-closure slot as ABSENT (fall to the next
+   candidate / `toString`); when neither is callable `__to_primitive` must
+   throw TypeError (§7.1.1.1 step 6) — check `__class_to_primitive`'s tail
+   does, else add it. For the Proxy-backed `length` (`arg-length-exceeding…`)
+   the read at L232 is `__extern_length(src)` — confirm its `$Proxy` arm
+   reaches the `get` trap (it should via `__extern_get`); the L235-244
+   overflow check then fires.
+4. (a) `concat_{strict,sloppy,sloppy-with-dupes}-arguments` (3 rows):
+   `__extern_has_idx` on a `__arguments_vec` whose `length` was overridden to
+   6 answers true for 3..5 — in the `__extern_has_idx` arguments arm
+   (`object-runtime.ts`, the consumer of `ARGUMENTS_LENGTH_OVERRIDE_FIELD`
+   next to L11158-11190) compare the index against the PHYSICAL vec length
+   (field 0), not the override; the concat loop then pushes `$Hole` and the
+   patched output readers map it to `undefined` (`compareArray` reads through
+   `__extern_get_idx`).
+5. (b) `concat_spreadable-sparse-object` (1 row, "uncaught Wasm-GC exception"):
+   `[].concat({length: 5, [@@isConcatSpreadable]: true})` then
+   `compareArray(new Array(4000), [].concat(obj))` — repro the 5-element case
+   alone first; the exception is thrown, not a marker escape — suspect
+   `holeSentinelInstrs` (L285) reaching a reader that `throw`s on `$Hole`.
+   Name the reader in the PR.
+6. (g) `is-concat-spreadable-proxy` (1 row): the argument is a Proxy with a
+   `get` trap; the spreadable read at L208-211 already goes through
+   `__extern_get`; the `illegal cast in __module_init_chunk_0` is therefore
+   downstream — `__extern_length`/`__extern_get_idx` on the `$Proxy` — 6-line
+   repro, then add the `$Proxy` forward to whichever helper casts.
+7. (f) `concat_{large,small}-typed-array` (2 rows) — **DEFERRED** unless
+   `__extern_is_array` answering `false` for `$__ta_view` plus the TA expando
+   read needs no #4449-owned internals; check `collectStandaloneArrayCarrierTypeIdxs`
+   (`object-runtime.ts` ~L8162) first and say which in the PR.
+
+**Rows claimed (10)**, 2 deferred. **Growth grant:** `array-concat-spec.ts` +30,
+`array-concat-spec.ts::compileArrayConcatNativeSpecFromExprs` +15,
+`array-concat-spec.ts::emitConcatSource` +10; `index.ts` +25 (the guarded
+cast); `object-runtime.ts` +20 (shared with R3-3).
+
+**Order constraints.** §23.1.3.1: `ArraySpeciesCreate(O, 0)` (its
+`constructor` Get) FIRST, then per E: `Get(E,@@isConcatSpreadable)` →
+`IsArray(E)` only if undefined → `Get(E,"length")` → per index `HasProperty`
+then `Get`.
+
+**Acceptance.** The 10 rows flip; **passing shapes at risk:**
+`built-ins/Array/prototype/concat/` (≤ 45 rows, in 15-row batches) identical
+pass set on both trees — this file was the r2 control
+`concat_spreadable-number-wrapper.js`/`create-species-non-extensible-spreadable.js`/`concat_array-like.js`
+home; `[].concat([1,[2]], 3)`, `arr.concat()` on a typed vec, `Array.prototype.concat.call(obj, …)`
+printed on both trees; `"" + {valueOf(){return 1}}` / `+{toString(){return "2"}}` / `String({})`
+(the `__call_valueOf` dispatcher consumers) printed on both trees in BOTH
+lanes — the `index.ts` arm is not standalone-gated, so the host lane needs a
+sha or output diff too.
+
+### Step R3-6 — symbol keys on `$Vec`/closure carriers + intrinsic symbol props (groups D + D2; 9 of 10 rows; risk: medium)
+
+1. `__getOwnPropertySymbols` (`object-runtime-descriptors.ts:3305-3383`): add
+   BEFORE the `$Object` test a `$__vec_base` arm — `bag = __vec_bag_lookup(obj)`
+   (`vec-props.ts:64`, `VEC_BAG_LOOKUP`); non-null → run the SAME
+   `__obj_ordered_symbols` loop on the bag — and a closure arm via
+   `__closure_bag_lookup` (`closure-props.ts:85`, compose through
+   `ctx.funcMap.get`, do not edit that file). Rows:
+   `getOwnPropertySymbols/order-after-define-property.js` (array half),
+   with R3-4.3 also `getOwnPropertyDescriptors/{symbols-included,order-after-define-property}.js`.
+2. `Object.entries` omits symbol keys (`entries/symbols-omitted.js`): the
+   static-struct arm at `object-ops.ts:4360` enumerates literal fields
+   including a computed-symbol one; filter by the `ctx.oracle` literal-shape
+   fact's key kind (never `ctx.checker`). Also the `Object.defineProperty(obj, nonEnumSym, …)`
+   in that test forces the runtime path — check which path the row takes
+   before editing.
+3. Function receivers (`keys/entries/order-after-define-property-with-function.js`,
+   2 rows): `Object.defineProperty(fn, "length", {enumerable: true})` lands
+   `length` in the closure bag AFTER `a`; §10.1.11.1 order is creation order,
+   and `length`/`name` were created at function creation. In
+   `__carrier_bag_push_keys` (`carrier-bag-visibility.ts:250 buildBagPushKeys`
+   → the `CARRIER_BAG_PUSH_KEYS` native filled at L442
+   `fillCarrierBagVisibility`) for CLOSURE carriers emit the builtin own names
+   the bag marks enumerable (`length`, then `name`) FIRST, then the remaining
+   bag keys in insertion order.
+4. `getOwnPropertyNames(arr)` after `defineProperty(arr,"length",{value:2})`
+   fabricates `0,1` (`getOwnPropertyNames/order-after-define-property.js`):
+   `vec-overlay-keys.ts` (RC2 in its header) enumerates `0..length-1`; use
+   the hole-aware presence helper (`vec-overlay-presence.ts`) so an index
+   with no slot and no overlay entry is not listed.
+5. D2 `Array.prototype[@@unscopables]` (`Symbol.unscopables/{value,prop-desc}.js`):
+   NEW `src/codegen/array-unscopables-native.ts` (≈ 90 LOC) with
+   `emitArrayUnscopablesSingleton(ctx, fctx)` copying the lazy-global pattern
+   of `emitIteratorPrototypeSingleton` (`array-object-proto.ts:3799-3880`):
+   a null-prototype `$Object` (`__object_create(null)` or `__new_plain_object`
+   + `OBJ_FLAG_NULL_PROTO`) with the full modern name list the `value.js`
+   row asserts (read the file: `at, copyWithin, entries, fill, find, findIndex,
+   findLast, findLastIndex, flat, flatMap, includes, keys, toReversed, toSorted,
+   toSpliced, values`), each `{writable:true, enumerable:true, configurable:true}`
+   via `__defineProperty_value` flags `0b111`; wire the element-access read
+   `Array.prototype[Symbol.unscopables]` (the builtin-proto symbol-member read
+   in `builtin-value-read.ts` — `getWellKnownSymbolId("unscopables")` = 11 at
+   L182 already interns the id) and the gOPD arm in `builtin-static-gopd.ts`
+   beside `tryEmitStandaloneBuiltinSpeciesGopd` (L444) with
+   `{writable:false, enumerable:false, configurable:true}`.
+6. `Array[Symbol.species] = v` refusal (`Symbol.species/symbol-species.js`):
+   `verifyNotWritable` writes through `__extern_set` onto the ctor carrier;
+   extend `buildBuiltinFnSetRefusalArm` (`carrier-bag-visibility.ts:328`) to
+   refuse a `@@species` key (symbol id from `getWellKnownSymbolId("species")`)
+   on `SPECIES_OWNER_CTORS` carriers (`builtin-static-gopd.ts:384`) — sloppy
+   no-op, strict TypeError through the shared result channel
+   (`SET_RESULT_REFUSED`).
+
+**Rows claimed (9):** all group D/D2 rows except
+`getOwnPropertyDescriptors/order-after-define-property.js` IF R3-4.3's
+symbol source does not flip it — say so.
+
+**Growth grant:** `array-unscopables-native.ts` new;
+`object-runtime-descriptors.ts` (shared with R3-4) ;
+`carrier-bag-visibility.ts` +50, `carrier-bag-visibility.ts::fillCarrierBagVisibility` +30,
+`carrier-bag-visibility.ts::buildBuiltinFnSetRefusalArm` +15;
+`vec-overlay-keys.ts` +20; `object-ops.ts` +15,
+`object-ops.ts::compileObjectKeysOrValues` +15; `builtin-value-read.ts` +25
+(shared with R3-1); `builtin-static-gopd.ts` +30.
+
+**Acceptance.** The rows flip. **Passing shapes at risk, both trees:**
+`Object.getOwnPropertySymbols({[s]:1})`, `Object.keys(fn)` after `fn.a=1`
+(no `length` redefine → `["a"]` unchanged), `Object.getOwnPropertyNames([1,2])`
+→ `["0","1","length"]`, `Object.keys(arr)` on a sparse `[1,,3]`, `for-in`
+over an array with expandos — printed on both trees; the r2 pins
+`tests/issue-5268*.test.ts` and `built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-with-description.js`
++ `Object/entries/return-order.js` (controls) green; `with (arr) { … }` —
+`with-has-binding-native.ts` reads `@@unscopables` at runtime, so
+`language/statements/with/unscopables-*.js` (≤ 10 rows) must keep an
+identical pass set once the object is real (today they see `undefined`).
+
+### Step R3-7 — reflective HOF on a Proxy receiver: species prologue + `ArrayCreate` RangeError (groups I + P; 6 rows; risk: medium)
+
+**Root cause** (r2 step-6 "NOT done", confirmed by reading):
+`Array.prototype.{map,filter,splice,slice}.call(proxy, …)` is served by
+`emitArrayProtoMemberBody` (`array-object-proto.ts:871`) → the `__hof_<m>`
+route at L896-925 (map/filter) or the refusal (splice), which never runs
+`ArraySpeciesCreate`, so neither the revoked-proxy TypeError from `IsArray`
+(`create-revoked-proxy` ×3, `ctorCount === 0` asserted) nor the `len ≥ 2^32`
+RangeError (`create-species-undef-invalid-len` ×2, `create-proxied-array-invalid-len`)
+can fire.
+
+**Edits.** In `emitArrayProtoMemberBody` (map/filter branch, before the
+`call hofIdx` at L923): after the ToObject guard, `len = __extern_length(this)`
+(f64), then `emitArraySpeciesCreate(ctx, fctx, deps, [local.get 1], [local.get len])`
+(`array-species.ts:264`; `deps` via the same `prepareArraySpeciesDeps` the
+direct `map` lowering uses at `array-methods.ts:4999`) — a null result means
+the default lane: emit the §10.4.2.2 `ArrayCreate` check `len > 2^32-1 ⇒
+RangeError "Invalid array length"` (`buildThrowJsErrorInstrs(ctx, "RangeError", …)`)
+BEFORE the loop; a non-null species object → run the HOF into a `$ObjVec`
+then `emitArraySpeciesResultSwap` (L380). Give `splice` and `slice` the
+same prologue via a new arm in `array-like-native.ts emitArrayLikeNativeMemberBody`
+(L546; `splice` needs the §23.1.3.31 loop — if that is more than ~120 LOC,
+claim only the `slice` row and defer `splice/create-{revoked-proxy,species-undef-invalid-len}`
+with that reason).
+
+**Rows claimed (up to 6):** `{filter,map,splice}/create-revoked-proxy.js`,
+`{map,splice}/create-species-undef-invalid-len.js`,
+`slice/create-proxied-array-invalid-len.js`.
+
+**Growth grant:** `array-object-proto.ts` +60,
+`array-object-proto.ts::emitArrayProtoMemberBody` +45; `array-like-native.ts`
++80 (slice arm), `array-like-native.ts::emitArrayLikeNativeMemberBody` +10.
+
+**Order constraints.** §23.1.3.18 map: ToObject → `Get(O,"length")` →
+IsCallable(cb) → ArraySpeciesCreate → loop. IsArray(O) inside
+ArraySpeciesCreate must throw for a revoked proxy BEFORE `Get(O,"constructor")`
+(already the r2 step-6 shape) and BEFORE the first callback.
+
+**Acceptance.** The rows flip; **passing shapes at risk, both trees:**
+`Array.prototype.map.call(arguments, String)` (the #4394 harness idiom —
+`compareArray.format`), `Array.prototype.map.call({length:2,0:1,1:2}, x=>x*2)`,
+`Array.prototype.filter.call("abc", c => c > "a")`, `[1,2].map(x=>x)` (direct,
+must be byte-identical — the direct lowering is untouched); the 41-row
+`create-species*.js` + `Symbol.species*.js` set r2 measured at 38/3 must stay
+38/3 or better with the same 3 non-pass; controls `filter/create-non-array.js`,
+`slice/create-species-poisoned.js` green.
+
+### Step R3-8 — `toLocaleString` must `Invoke` (group H; 4 rows; risk: low)
+
+`Object.prototype.toLocaleString` (§20.1.3.5) is `Invoke(this,"toString")`;
+`Array.prototype.toLocaleString` (§23.1.3.32) per element
+`Invoke(elem,"toLocaleString")`. The Array side already has the `localized`
+arm (`array-methods.ts:5425 ensureElementToLocaleStringInvoke`, used at
+L5485/L5737); the failing rows patch `Boolean.prototype.toString` (or a
+GETTER for it) and expect the element's `toLocaleString` → `toString` chain to
+see the patch. Edits: (1) `builtin-prototype-brand.ts:536` — for
+`<primitive>.toLocaleString()` on a boolean/number/string receiver (static
+fold today), when the module has a dirty `Boolean/Number/String.prototype`
+companion (`seededNativeProtoOwnMembersByBrand(ctx)` non-empty for that brand,
+`native-proto.ts`), emit `__extern_method_call(box(x), "toString")` instead of
+the fold; (2) `ensureElementToLocaleStringInvoke` — confirm it dispatches
+`toLocaleString` through `__extern_method_call` (which reaches the seeded
+companion via `__protoidx_get_r`) and that the inherited
+`Object.prototype.toLocaleString` fallback in that native calls
+`Invoke(elem,"toString")` rather than `__extern_toString` — the GETTER row
+(`primitive_this_value_getter`) additionally needs the accessor to run with
+`this` = the boxed primitive (the `__reflect_get_receiver` route
+`closure-props.ts:850-857` describes).
+
+**Rows:** the 4 `toLocaleString/primitive_this_value*.js`. **Grant:**
+`builtin-prototype-brand.ts` +25, `builtin-prototype-brand.ts::tryBorrowedPrototypeNullishThisThrow` +0
+(new helper beside it), `array-methods.ts` +30. **At risk:** `[1,2].toLocaleString()`,
+`(1234.5).toLocaleString()`, `true.toLocaleString()` with NO patched proto —
+byte-identical (gated on a dirty companion); `built-ins/Array/prototype/toLocaleString/`
+(≤ 15 rows) identical pass set; host lane untouched (`!ctx.standalone && !ctx.wasi` return at L1989 stays).
+
+### Step R3-9 — small clusters, ordered (groups N, S, Q, R, M, A/B, F, O)
+
+- **S (1 row, low)** `hasOwnProperty/topropertykey_before_toobject.js`:
+  `tryBorrowedPrototypeNullishThisThrow` (`builtin-prototype-brand.ts:681`)
+  compiles+drops the args (L719-722) BEFORE throwing, but the key's
+  `ToPrimitive` (`hint === "string"` observed) never runs because the drop
+  is of the raw value: for `hasOwnProperty`/`propertyIsEnumerable` call
+  `__to_property_key` on argument 1 (dropping its result) before the throw;
+  `compilePropertyIntrospection` (`object-ops.ts:4644-4676`) already routes the
+  dynamic receiver to `__hasOwnProperty`, which must ToPropertyKey before its
+  own nullish throw — check that native's order too. At risk:
+  `hasOwnProperty.call("ab", "0") === true`, `({}).hasOwnProperty(sym)` — both trees.
+- **N (3 rows, medium)** ArraySetLength: `maybeEmitVecLengthDefine`
+  (`array-length-define.ts:111`) returns `false` for an object-valued `value`
+  (L199) and the dynamic `fillVecLengthDynamicArms` (`vec-length-set.ts:87`)
+  applies ONE `__to_primitive` (L118-125); §10.4.2.4 steps 3-4 call
+  `ToUint32(Desc.[[Value]])` AND `ToNumber(Desc.[[Value]])` — two ToPrimitive
+  hints `number` (`coercion-order-set` expects `["number","number"]`), then
+  RangeError on mismatch, then (step 12-13) if `length` is non-writable NOW
+  (it became so inside `valueOf`) → return false / strict TypeError. Add the
+  second coercion + the post-coercion writability re-check in both the
+  static arm (route object values to the dynamic native instead of `false`)
+  and the dynamic arm; `no-value-order`: a descriptor with no `value` must
+  not touch `enumerable` — `Object.defineProperty([], "length", {configurable:true})`
+  is a TypeError ("Cannot redefine") and `{enumerable:true}` via
+  `Reflect.defineProperty` is `false`, `{get(){}}` TypeError, `{writable:true}`
+  on a non-writable length TypeError — today the enumerable path throws the
+  wrong message. Grant: `array-length-define.ts` +40,
+  `array-length-define.ts::maybeEmitVecLengthDefine` +25; `vec-length-set.ts`
+  +40, `vec-length-set.ts::fillVecLengthDynamicArms` +40. At risk:
+  `arr.length = 0`, `arr.length = 2**32-1`, `Object.defineProperty(arr,"length",{value:2})`,
+  `arr.length = "3"`, `arr.length = new Number(1)` (S15.4.5.1_A1.3_T1/T2),
+  propertyHelper `verifyWritable(array,"length")` — printed on both trees;
+  `built-ins/Array/length/` (≤ 15 rows) identical pass set.
+- **Q (4 CE, medium)** `flat`/`flatMap` species targets: extend
+  `tryCompileArrayFlatNativeDepth1` (`array-methods.ts:10278`) to run
+  `emitArraySpeciesCreate` first and write through `emitArraySpeciesResultSwap`
+  when `ctx.arraySpeciesDirty` (the same gate the direct `map` lowering uses at
+  L4999), so the CE (the `#2717` refusal at L10404's fallthrough) becomes a
+  runtime path; never leave a CE that could become a wrong answer — if the
+  heterogeneous target cannot be handled, keep the refusal for THAT shape.
+  Grant: `array-methods.ts` +60 (shared with R3-8),
+  `array-methods.ts::tryCompileArrayFlatNativeDepth1` +30. At risk:
+  `[[1],[2]].flat()`, `[1,2].flatMap(x=>[x,x])`, `[[1,[2]]].flat(2)` (must
+  still refuse or answer identically) — both trees.
+- **R (2 of 3 rows, medium)** `copyWithin` reflective: `compileArrayCopyWithin`
+  (`array-methods.ts:9711`) is vec-only; the rows use
+  `Array.prototype.copyWithin.call(proxy, 0, 0)` and today hit the
+  "not yet callable as a value" refusal (that is the TypeError the rows
+  report). Add `copyWithin` to `emitArrayLikeNativeMemberBody`
+  (`array-like-native.ts:551`) with §23.1.3.4 steps 3-18 over
+  `__extern_length` / `__extern_has` / `__extern_get` / `__extern_set_strict` /
+  `__delete_property` (all Proxy-guarded). `splice/property-traps-order-with-species.js`
+  — **DEFERRED**: needs R3-4.1 (nested handler proxy) AND a full splice
+  trap sequence. Grant: `array-like-native.ts` +110 (shared with R3-7). At
+  risk: `[1,2,3,4,5].copyWithin(0,3)` direct (byte-identical) and control
+  `copyWithin/return-abrupt-from-target-as-symbol.js`.
+- **M (3 rows, medium)** `Array.prototype.{keys,values,entries}.call(obj)`:
+  give the three a body in `emitArrayProtoMemberBody` (L927 refusal): mint a
+  native `$__IterRec` over the array-like exactly as the direct `[].values()`
+  lowering does (`array-methods.ts:1296` region / `iterator-native.ts`), and
+  make `Object.getPrototypeOf(<that record>)` answer
+  `emitArrayIteratorPrototypeSingleton` (`array-object-proto.ts:3882`): the
+  routing is keyed on the STATIC type `ArrayIterator<T>` (header L3782-3785)
+  — `Array.prototype.keys.call(obj)` is typed `IterableIterator<number>`, so
+  the runtime `__getPrototypeOf` needs a `$__IterRec` arm answering the
+  Array singleton global (`ctx.builtinObjectGlobals.get("__native_array_iterator_prototype")`).
+  Grant: `array-object-proto.ts` (shared with R3-7) +40;
+  `object-runtime-prototype.ts` +20 (shared with R3-4). At risk:
+  `[].values()`, `Object.getPrototypeOf([].values()) === Object.getPrototypeOf([][Symbol.iterator]())`,
+  `getPrototypeOf(new Map().entries())` distinct — control
+  `values/returns-iterator.js` + `tests/issue-3013*` green on both trees.
+- **A/B residual (6 rows) — DEFERRED** with the r2 measured reasons: the
+  closed-struct literal's runtime `%Object.prototype%` terminal (3 rows +
+  `set-abrupt`) is a carrier change; `set-cycle-shadowed` needs
+  `canonicalizeProtoArg` to stop unwrapping a Proxy link (a `__object_create`
+  model change with a Proxy-lane owner, #5196); `prop-desc` needs
+  `__proto__` in `OBJECT_PROTOTYPE_OWN_NAMES` (changes every `in` answer) plus
+  `delete` on `Object.prototype`. Re-evaluate after R3-4.
+- **F (9 rows) — 4 claimed, 5 need a repro first.** The four
+  `concat_spreadable-{function,reg-exp,boolean-wrapper,string-wrapper}.js`
+  rows: `[].concat(fn)` with `fn[@@isConcatSpreadable]=true; fn[0..2]=…`
+  spreads to `[]` — `__extern_length(fn)` answers the arity 3 (correct), then
+  `__extern_has_idx`/`__extern_get_idx` on a closure carrier have no bag
+  consult. Add the closure/wrapper/RegExp carrier arms to those two natives
+  (`object-runtime.ts`, the `objArrayLikeArms` region — compose through
+  `buildClosurePropGetMissArm` (`closure-props.ts:157`) and the wrapper
+  `[[PrimitiveValue]]` string-exotic reader `string-exotic-own-props.ts`);
+  `Function.prototype[0] = 1` (inherited index) then also needs the
+  `__protoidx_get_r` consult that `__closure_prop_get` already has. The five
+  `create-proxy.js` rows (`array.constructor = function(){}; array.constructor[@@species] = Ctor;
+  Array.prototype.map.call(new Proxy(new Proxy(array,{}),{}), …)`): after
+  R3-7 the species prologue runs; `vecConstructorArmInstrs`
+  (`vec-constructor-carrier.ts:131-153`) DOES consult the bag for an own
+  `constructor`, and `__closure_prop_get` DOES read symbol keys from the bag
+  (`$Object`), so the r2 diagnosis ("string-keyed bags only") is not
+  supported by the code — run the 8-line repro (proxy → `Get("constructor")`
+  → `Get(@@species)`) through the proxy-of-proxy `get` forward and name the
+  failing hop before editing. Grant: `object-runtime.ts` +60 (total with
+  R3-3/R3-5), `object-runtime.ts::ensureObjectRuntime` +20. At risk:
+  `fn.length`, `fn[0]` (undefined), `"abc"[1]`, `new String("ab")[0]`,
+  `/x/[0]` — both trees; `built-ins/Function/prototype/` (≤ 10 rows) identical.
+- **O (4 rows) — DEFERRED.** `emitArraySpeciesResultSwap` already does
+  define + plain `[[Set]]` (L423-451, with the comment naming this exact
+  test); the read `r[0]` still answers the stale dense slot because the
+  overlay entry from the species constructor's `defineProperty(q, 0, {writable:false})`
+  shadows it and the later `[[Set]]` is refused by the (now writable, but
+  overlay-resident) entry — a `vec-overlay.ts` define-vs-slot coherence
+  question (#3251/#4491 territory). Reduce with the species-free repro from
+  #5145 and route to the overlay owner.
+
+### Step order and honest yield
+
+| Order | Step | Rows | Risk | Why here |
+|---|---|---:|---|---|
+| 1 | R3-1 Array.from/of | 17 | medium | new module, biggest yield, typed fast paths untouched |
+| 2 | R3-5 concat (10) | 10 | low-med | mostly one-line fixes in one 523-LOC file |
+| 3 | R3-2 toString + leak | 8 | medium | closes 5 CEs; leak fix is a gate on every later CE claim |
+| 4 | R3-3 assign/wrapper | 12 | medium | one new module + seeding; precheck is fold-gated |
+| 5 | R3-6 symbols/D2 | 9 | medium | additive arms |
+| 6 | R3-7 reflective HOF species | 6 | medium | contained in two files |
+| 7 | R3-8 toLocaleString | 4 | low | gated on a dirty companion |
+| 8 | R3-9 S, N, Q, R, M, F(4) | 4+3+4+2+3+4 = 20 | low-med | independent small edits |
+| 9 | R3-4 Proxy handler-proxy + 2.4-2.7 | 9 | **high** | last: widest blast radius (`built-ins/Proxy`), needs its own PR |
+| — | DEFERRED: E ×2, J(f) ×2, R ×1, A/B ×6, F ×5 (until repro), O ×4, G ×1 | 21 | | reasons above |
+
+Planned: 17+10+8+12+9+6+4+20+9 = 95 of 114 in-scope rows (target ≥ 80 for
+the wave); 19 deferred with named reasons (21 listed above minus the two
+F/G rows that are "claim after repro"). One PR per step (R3-9 may batch by
+file); R3-4 alone in its PR.
+
+### Frontmatter grants (r3)
+
+Added to the YAML below with a dated rationale: new files need no grant;
+the listed god-files grow by wiring only. `total` is NOT granted — if the
+change-set's net LOC exceeds the headroom, split the PR, do not widen the
+grant.

--- a/plan/issues/5296-to-primitive-null-hint-overload.md
+++ b/plan/issues/5296-to-primitive-null-hint-overload.md
@@ -1,0 +1,86 @@
+---
+id: 5296
+title: "`__to_primitive`'s null-hint convention is overloaded — \"default\" and \"number\" are indistinguishable"
+status: ready
+sprint: current
+created: 2026-09-03
+updated: 2026-09-03
+priority: medium
+horizon: s
+feasibility: medium
+goal: standalone-mode
+reasoning_effort: medium
+---
+
+## Problem
+
+The standalone `__to_primitive` runtime helper encodes the ES2015 §7.1.1
+`hint` as an externref, and uses `ref.null.extern` to mean "no explicit
+hint". But two different callers pass that same null for two DIFFERENT
+spec hints:
+
+- the `ToLength` / numeric-coercion path (`src/codegen/object-runtime.ts`
+  ~L11799) means **`"number"`**;
+- string concatenation (`"" + v`) means **`"default"`**.
+
+So the helper cannot tell them apart, and a user `[Symbol.toPrimitive]`
+handler — which receives the hint as its only argument and is entitled to
+branch on it — is handed the wrong string.
+
+## Observed
+
+Standalone, node as oracle:
+
+```js
+var w = { [Symbol.toPrimitive](h) { return "P<" + h + ">"; }, x: 41 };
+var v = w;
+"" + v        // node: P<default>   main (pre-#5269): [object Object]   after #5269: P<null>
+```
+
+`String(v)` is correct (`P<string>`) on both — only the hintless
+`default` path is affected.
+
+## Why it surfaced now
+
+Before #5269's round-3 fix the value never reached the handler at all on
+this path, so the wrong hint was invisible behind a wrong result. That
+fix (`src/codegen/to-primitive-open-object.ts`, carrying "open object" on
+the TYPE rather than on the syntactic position) makes the handler run,
+which is why the row moved from `[object Object]` to `P<null>`. Both are
+wrong against node; the fixed one is the only version that actually
+invokes the user's handler, and the wrong part is now the hint STRING
+rather than the value.
+
+This was recorded as the single "differently-wrong" row in that lane's
+round-3 report and deliberately left alone: it cannot be fixed at the
+`@@toPrimitive` call site without picking one of the two meanings and
+silently breaking the other caller.
+
+## Root cause
+
+One sentinel, two meanings. The fix is to stop overloading it — either
+pass the hint explicitly at every call site (three known: string, number,
+default), or split the null into two distinct sentinels so the numeric
+path and the default path are separable.
+
+## Acceptance criteria
+
+- `"" + v` answers `P<default>`, `String(v)` answers `P<string>`, and
+  `+v` / `v * 1` answer with hint `"number"`, all matching node, on
+  `--target standalone`.
+- The `ToLength` numeric path is unchanged — pin it, since it is the
+  caller that would silently break if the sentinel is reassigned rather
+  than split.
+- Host lane binaries byte-identical (this is a standalone-only helper).
+- No new `env::` import in a standalone module.
+- The passing `Symbol.toPrimitive` rows in the ES2015 standalone baseline
+  stay green: re-run `built-ins/Symbol/toPrimitive/**` and the
+  `@@toPrimitive` rows under `built-ins/Date/prototype/@@toPrimitive/**`
+  before and after, not just the rows this issue claims.
+
+## Related
+
+- #5269 — the round-3 fix that made this observable; its report names this
+  as the one row behind an otherwise unqualified "never worse than base".
+- #5102 — the earlier `@@toPrimitive` work whose gate #5269 R2-5 widened
+  and then reverted.


### PR DESCRIPTION
## Description

Docs-only. A fresh census of the ES2015 standalone residual, the three cross-cutting blockers it exposes, and six Fable-written r3 implementation plans for the clusters that are ready to be worked.

### Census — [#4444](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4444-es6-standalone-edition-closeout-umbrella)

**9,948 / 11,704 (85.0%)**, 1,756 non-pass, up from 84.6% on 09-02. Measured from the standalone baseline fetched today (rows stamped 09:07 UTC, `oracle_lane: "honest"`, so post-[#5461](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5461-test262-runner-standalone-leak-check) leak-checked) crossed with the ES2015 edition map. Reproduce with `.tmp/census0903/census.mjs`.

The cluster sizes now sum to exactly 1,756, so **every remaining row is accounted for**: 948 in the six lanes planned here, 441 in two waves in flight, 286 in codex lanes, 81 still unowned.

Two things earlier censuses left implicit are now recorded: this census clusters differently from 09-02 (class and generators are pulled out of `language/expressions` and `language/statements` first), so sizes are comparable only via that script; and the 391 compile_errors are concentrated — five clusters hold 71% of them — so a plan that counts rows without splitting fail from CE is over-promising.

### The three cross-cutting blockers — 281 rows (16%) no cluster lane can fix

| blocker | issue | rows | where they sit |
| --- | --- | ---: | --- |
| standalone native generator lowering | [#2864](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2864-standalone-generator-carrier) | 233 | expressions 91 · generators 46 · class 45 · for-of 35 · statements 13 · module-code 2 · proxy 1 |
| `Reflect.construct` with a distinct NewTarget | [#3371](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3371-reflect-construct-newtarget) | 33 | 6 clusters |
| `Reflect.set` with an explicit receiver | [#2046](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2046-reflect-set-receiver) | 15 | 3 clusters |

The generator finding is the consequential one and it is invisible from inside its own issue: **only 46 of those 233 rows are generator tests**. The rest sit in other clusters' residual lists where the owning lane cannot touch them, so `language/expressions` is capped near 63% until it lands, whatever the expressions lane does. This makes #2864 the largest single lever left toward 100% — larger than any whole cluster, and 59% of all compile_errors.

#2864 is claimed and its lane is live (`generators-native.ts` moved on main at 085ad75506 / 5890005e85 on 09-01), so nothing here touches it. What this PR adds to that issue is a measurement handed to its owner: re-running **their own** 297-row checkpoint predicate against today's baseline gives **233** — they have cleared 64 — plus the cross-cluster distribution and the note that the 94-row canonical-refusal group is waiting specifically on the S3 yield-position admission already designed in their file.

### Six r3 implementation plans — 563 rows, 54 steps

| Issue | Cluster | In scope | Planned | Deferred | Steps |
| --- | --- | ---: | ---: | ---: | ---: |
| [#5194](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5194-es2015-standalone-typedarray-r2) | typedarray | 190 | 181 | 63 | 11 |
| [#5268](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5268-es2015-standalone-array-object-builtins-r2) | array + object | 114 | 95 | 19 | 9 |
| [#5196](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5196-es2015-standalone-proxy-r2) | proxy + reflect | 126 | 90 | 67 | 6 |
| [#5197](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5197-es2015-standalone-promise-r2) | promise | 118 | 82 | 30 | 10 |
| [#5195](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5195-es2015-standalone-class-r2) | class | 97 | 62 | 35 | 9 |
| [#5267](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5267-es2015-standalone-forof-iterators-collections-r2) | for-of + collections | 101 | 53 | 48 | 9 |

Each plan re-verifies its cluster against current `main` rather than trusting the baseline, groups the residual by **root cause** rather than path prefix, names real functions and current line numbers, and carries its own LOC/function growth grants with dated rationale.

Every plan also **excludes the rows it cannot deliver instead of counting them** — for-of drops 35 generator-carrier rows to #680/#2864, class drops 67, typedarray carves out 36 to the buffers lane plus #3371/#2046, proxy carves out 31.

Findings the probes established rather than inferred:

- **class**: the class object has no reflective static surface at all — `gOPD(C,'m')` is `undefined`, static accessors are not on the sidecar, and a static and an instance accessor of the same name **share a `C_get_<p>` funcMap key**, so `new C().eval` runs the static body; a top-level `let C = class { [k](){} }` is never collected into `moduleInitStatements`, so its computed keys are never evaluated; standalone never evaluates a non-class heritage, so `class D extends (() => {}) {}` silently compiles as a base class.
- **array + object**: proxy traps are read off the handler once at `new Proxy`, so a handler that is itself a Proxy contributes none — which resolves the unexplained "wrapTest mystery" left in the r2 notes (its hand probe used a plain handler); a script-level `var toString` registers an `env::toString` import, the leak behind five compile errors.
- **promise**: the native combinators never perform the observable `Get(C,"resolve")`, per-element `Call(resolve, C, v)` or `Invoke(next,"then",…)`, so a reassigned `Promise.resolve` or an own `then` is silently ignored (29 rows).
- **proxy**: `new OProxy(t,h)` on a `Proxy` read as a *value* takes the ordinary `callee.prototype` construct tail because the read resolves to the namespace carrier; a forwarded `delete` no-ops on the target carrier. It also caught that two steps a neighbouring issue was believed to have landed (#5268 Steps 2.5/2.7) are in fact absent from `d21a768efa`.

### Why the acceptance criteria look the way they do

Every step names the **passing** shapes it endangers and how to check them, because a row list is drawn from *failing* rows and is therefore structurally blind to broken passing behaviour. That is not theoretical: of the seven waves that have reached an independent adversarial review, **six had a confirmed regression that the lane's own row list, its controls, all five ratchet gates and a full 8-shard equivalence run had all missed**. The Promise plan applies the lesson on its own initiative — it re-runs the ~110 Promise rows that currently pass and are absent from the census list, once mid-pass and once at the end.

### New issue

[#5296](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5296-to-primitive-null-hint-overload) — `__to_primitive` encodes a missing §7.1.1 hint as `ref.null.extern`, but the `ToLength` numeric path and string concatenation both pass it, meaning "number" and "default" respectively, so a user `[Symbol.toPrimitive]` handler gets the wrong hint string. Surfaced by the #5269 round-3 fix, and not fixable at the call site without silently breaking the other caller. Id reserved via `claim-issue.mjs --allocate`; the script's open-PR scan degrades in this container (no `gh` CLI), so #5296 was verified against open PRs by direct API search before reserving with `--allow-unscanned`.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs)_