### PR TITLE
docs(plans): implementation plan for #5299 — receipt triple on prepared-callable rows ✓

### DIFF
--- a/plan/issues/5299-prepared-callable-rows-missing-receipt-triple.md
+++ b/plan/issues/5299-prepared-callable-rows-missing-receipt-triple.md
@@ -71,3 +71,122 @@ prepared unit — assert, do not assume).
 `src/codegen/multi-prepared-callable-publication.ts`, `src/ir/outcomes.ts`
 (only if the optional-triple validation needs tightening). Do not branch until
 PR #5530 has merged; it reshapes the reconciler this row set flows through.
+
+## Implementation Plan
+
+Written 2026-09-03 by the Fable lane from a read of
+`src/codegen/multi-prepared-callable-publication.ts`, `src/ir/outcomes.ts`,
+`src/codegen/ir-overlay-outcomes.ts`, `src/codegen/legacy-body-audit.ts`,
+`src/ir/prepared-component-publication.ts` and `src/ir/program.ts` at
+`origin/main` after PR #5535 (#5300). Line numbers are from that revision.
+
+### Where the triple is dropped (reasoned from source; confirm in step 1)
+
+The prepared row is built in `prepareCommit`
+(`multi-prepared-callable-publication.ts:317-350`): a literal with
+`legacyBodyEmitted: false`, `irBodyEmitted: true`, `kind: "emitted"`,
+`stage: "patch"` and **no** `prepareAttempts` / `directBodyEmissions` /
+`irBodyEmissions`. `hasMalformedBodyEmissionAccounting`
+(`src/ir/outcomes.ts:353-370`) returns `false` when all three are `undefined`,
+so the row passes every invariant while contributing nothing to any ratio.
+The rows land in `ctx.irOutcomes` at `multi-prepared-program.ts:1015`.
+
+The row is built **before** the component tokens are taken (`tokens` loop
+starts at `:353`), so at construction time the publication has no patch
+count to cite. That ordering is why the triple was never filled, not an
+oversight in the literal.
+
+### Sources of truth (do not hard-code `(1, 0, 1)`)
+
+| counter | source | expected for a prepared unit |
+| --- | --- | --- |
+| `prepareAttempts` | one `pendingReceipt` per component, one `take` per commit — by construction `1`; assert the receipt `kind` and single take, do not count | `1` |
+| `irBodyEmissions` | the token's `publicationPatches` (`prepared-component-publication.ts` `ReceiptState.publicationPatches`, one `PreparedComponentDetachedPatch` per terminal unit) — count the patches whose unit is this `unitId` | `1` |
+| `directBodyEmissions` | `legacy-body-audit.ts` indexed `countsByUnitId` (`:96`, incremented only on entering `compileFunctionBody`, `:354-364`) — a prepared unit is skipped, so the count must be `0` | `0` |
+
+`src/ir/program.ts`'s `PreparedIrEmissionLedgerEntry` (`:167-175`) is the
+#3525 owner-lifecycle ledger with the same triple; it is **not** wired to
+this publication path today. Do not route through it in this slice — note
+in the PR body whether the two should be unified (R5 M1B territory).
+
+### Change (one file, plus a small export)
+
+1. **Reorder `prepareCommit`**: take the component tokens first (the
+   existing `try { … }` at `:353`), then build `finalOutcomes` from the
+   taken tokens. The rows are frozen literals either way; only the order of
+   the two blocks moves. Abort semantics stay: a failing take still aborts
+   every receipt before any row exists.
+2. **Expose per-unit patch counts on the token**: add
+   `readonly irPatchCountByUnitId: ReadonlyMap<IrUnitId, number>` to
+   `PreparedComponentPublicationToken` (`prepared-component-publication.ts:77-82`),
+   computed from `publicationPatches` at token creation (read-only
+   projection; no behaviour change to `publishBodies`).
+3. **Read the direct count** from the audit index the reconciler already
+   uses (`legacy-body-audit.ts` — the same `countsByUnitId` that
+   `reconcileR2FunctionBodyEmissionAccounting` reads at
+   `ir-overlay-outcomes.ts:297`). If it is not `0` for a prepared unit,
+   throw `publicationError(...)` — **fail closed**, never publish a row that
+   claims IR ownership of a body the direct compiler also emitted.
+4. **Emit the triple** on each row and validate it with the existing
+   checker before freezing: export `hasMalformedBodyEmissionAccounting`
+   from `src/ir/outcomes.ts` (or a thin
+   `assertExactBodyEmissionAccounting(outcome)` wrapper) and call it; a
+   malformed triple is a `publicationError`.
+5. Leave `legacyBodyEmitted` / `irBodyEmitted` as derived booleans
+   (`directBodyEmissions === 1`, `irBodyEmissions === 1`), matching
+   `ir-overlay-outcomes.ts:308-309`, instead of literals.
+
+Do not touch `reconcileIrOverlayOutcomes` or `ownedElsewhereUnitIds`
+(#5263) — the reconciler still skips these units; the publication path now
+owns their accounting end-to-end.
+
+### Measurement order
+
+1. **Probe on base** (`.tmp/probe-5299.ts`): compile a two-source program
+   with a cross-source prepared callable (reuse the fixture from
+   `tests/issue-3525-multi-prepared-callable-bindings.test.ts`) with
+   `trackIrOutcomes: true`; print every published row with
+   `preparedComponentId` and its three counters. Expected on base: all three
+   `undefined` on every prepared row. Count N = rows with an absent triple on
+   the 34-case dogfood/ratchet corpus (gc + standalone) — record N.
+2. Capture base copies at first edit (`.tmp/base-*.ts`).
+3. Implement 1–5. Re-run the probe: every prepared row carries `(1, 0, 1)`;
+   N → 0.
+4. Byte identity: publication-only change — per-row sha256 over the 34-case
+   corpus, gc + standalone, all rows identical (zero moving rows is the
+   acceptance bar; any moved row is a defect).
+5. `check:ir-only` before/after: report the numbers it prints; READY must
+   hold and the emitted share may only rise. `check:ir-fallbacks`,
+   `check:ir-dialect`, `check:ir-kind-neutrality` (quote-hash baseline since
+   PR #5533, never hand-edited): unchanged.
+6. Keep green: `tests/issue-3525-*`, `issue-3519-*`, `issue-3520-*`,
+   `issue-5262-*`, `issue-5300-*`.
+7. Equivalence, 8 shards by name, `VITEST_FORK_MAX_OLD_SPACE_SIZE=4096`, zero
+   name-set diff; full ratchet chain + `LOC_GATE_BASE`.
+
+### Tests
+
+`tests/issue-5299-prepared-callable-receipt-triple.test.ts`:
+
+- (a) every published row with a `preparedComponentId` carries
+  `prepareAttempts === 1`, `directBodyEmissions === 0`,
+  `irBodyEmissions === 1`, and the derived booleans agree — **red on base**
+  (fields absent).
+- (b) fail-closed: inject a direct receipt for a prepared unit (the audit's
+  test seam, or `JS2WASM_TEST_*` poison if one exists for this path — name
+  it) → `prepareCommit` throws `publicationError`, no row is published.
+- (c) non-vacuity by revert: with the reorder reverted, (a) is red again
+  (the counts are unavailable at the old construction point).
+
+### Budget and conflict surface
+
+`src/codegen/multi-prepared-callable-publication.ts` (+~30 LOC, grant in
+this issue's frontmatter with a dated rationale),
+`src/ir/prepared-component-publication.ts` (+~8 LOC),
+`src/ir/outcomes.ts` (one export). Disjoint from #5283
+(`ir-overlay-outcomes.ts`, `module-init.ts`, `legacy-body-audit.ts` —
+this slice only READS the audit index; if #5283 changes its shape, rebase
+onto it), #5297 (`prepared-component-sealing.ts`, `prepared-dynamic-support.ts`,
+`compiler-timer-shim-preparation.ts`), #3520 W1-D (`program-abi-*.ts`),
+#3522 W1-A (`select.ts` class arms, `class-bodies.ts`). Branch after #5283
+lands if it touches `legacy-body-audit.ts`'s index shape; otherwise now.


### PR DESCRIPTION
Docs-only. [#5299](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5299-prepared-callable-rows-missing-receipt-triple) gains an `## Implementation Plan`.

Mechanism located in source: `prepareCommit` in `src/codegen/multi-prepared-callable-publication.ts` builds the prepared-callable rows **before** the component tokens are taken, so no patch count exists at construction time and the `(prepareAttempts, directBodyEmissions, irBodyEmissions)` triple was never filled — `hasMalformedBodyEmissionAccounting` accepts an all-absent triple, so the rows pass every invariant while dropping out of every R9 ratio.

The plan reorders the two blocks, projects per-unit IR patch counts onto the publication token, reads the direct-body count from the legacy-body audit index (fail-closed on non-zero for a prepared unit), validates with the existing checker before freezing, and derives the booleans from the counters. It deliberately does not route through `PreparedIrProgram`'s owner-lifecycle ledger (a separate #3525 mechanism) and names that as a possible later unification.

The W1-A ([#3522](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3522-ir-r3-classes-closures-compile-once)) and W1-D ([#3520](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3520-ir-r1-source-qualified-identity-program-abi)) planning architects are still measuring; their plans follow in the next docs PR.

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Namds9phYeHvpLKu735io3