### PR TITLE
docs(ir): #3522 W1-A class-member family — 2026-09-03 arm census + implementation plan ✓

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -3971,3 +3971,431 @@ So the release decision rests where it already did — on the merged PR, the
 on this listing, which cannot distinguish a dead lane from a subagent. The one
 thing worth checking before releasing that I could not: whether the
 still-RUNNING `IR migration` seat considers F4 unfinished work of its own.
+
+## Measurement 2026-09-03 — class-arm census
+
+Run on `origin/main` **`42a0adf7d47579e4632c7ddd4b82f6e5732cb7bf`** ("Merge pull
+request #5535"), through the production `compile` seam with
+`experimentalIR: true, trackIrOutcomes: true` and `JS2WASM_IR_SHAPE_DIAG=1`,
+sequentially in one process, over the full census population the #5285 survey
+used: **`tests/dogfood/corpus` (20 `.js`) + `website/playground/examples` (13
+`.ts`) = 33 entries × 2 lanes = 66 compiles**. No source was edited; the probe
+harness is `.tmp/` only.
+
+### Instrument validation
+
+The run reproduces #3518's 2026-09-03 dogfood census: 35 terminal units per
+lane, 33 unsupported / 1 emitted / 1 non-executable on single-host, 31
+unsupported on standalone, and the class family at exactly
+`class-member-unsupported ×4`, `class-projection-unsupported ×2`,
+`class-method ×1`, `static-class-initialization ×1` — **identical on both
+lanes**. Two non-class buckets have drifted since that census as main advanced
+(`body-shape-rejected` 19→18 sh / 16→14 sa; `template-substitution-unsupported`
+and, on standalone, `string-method-unsupported` are now split out). The class
+family has not moved.
+
+| corpus | lane | units | emitted | unsupported | non-exec |
+| --- | --- | --: | --: | --: | --: |
+| dogfood (20) | single-host | 35 | 1 | 33 | 1 |
+| dogfood (20) | standalone | 35 | 0 | 31 | 4 |
+| playground (13) | single-host | 73 | 54 | 8 | 11 |
+| playground (13) | standalone | 73 | 48 | 14 | 11 |
+
+**Finding 0 — the class family is ONE FILE.** All 16 class-family refusal rows
+(8 units × 2 lanes) come from `tests/dogfood/corpus/classes.js`. Every one of
+the **20 playground `class-member` rows is `emitted`** on both lanes: classes
+already compile once on that corpus. There is no second file to generalise
+from.
+
+**Finding 1 — the `detail` string does not name the arm for these codes.** The
+brief assumed `detail` could be mapped to a source line. It cannot here:
+`src/codegen/ir-overlay-outcomes.ts:827` composes
+`` `${unit.matchName} rejected by IR selection (${fallback.reason})` `` whenever
+the identity fallback carries no detail, so every class row reads
+`Animal_get_label rejected by IR selection (class-member-unsupported)` — the
+code restated, zero arm information. `JS2WASM_IR_SHAPE_DIAG=1` adds arm detail
+for `body-shape-rejected` and for #5285's module-binding refusals, **not** for
+the class reasons. The arms below were therefore established by source reading
+plus **fixture bisection**, which is the only instrument that currently answers
+this question.
+
+### Raw class rows (both lanes identical; single-host shown)
+
+| unit | file:line | unitKind | code | stage |
+| --- | --- | --- | --- | --- |
+| `<module-init>` | classes.js:2 | module-init | `static-class-initialization` | select |
+| `Animal_new` | classes.js:5 | class-member | `class-projection-unsupported` | select |
+| `Animal_get_label` | classes.js:6 | class-member | `class-member-unsupported` | select |
+| `Animal_set_label` | classes.js:7 | class-member | `class-member-unsupported` | select |
+| `Animal_<computed>` | classes.js:8 | class-member | `class-method` | select |
+| `Animal_make` | classes.js:9 | class-member | `class-member-unsupported` | select |
+| `Dog_new` | classes.js:12 | class-member | `class-projection-unsupported` | select |
+| `Dog_speak` | classes.js:13 | class-member | `class-member-unsupported` | select |
+
+### Arm map — arm (file:line) → units → lanes
+
+| # | arm | file:line | units firing | lanes |
+| --- | --- | --- | --- | --- |
+| **A1** | **root: class position type is `any`** → `ctorOk = false`, class never enters the shape sidecar | `src/codegen/index.ts:1633` (predicate `tsTypeToClassPositionIr` `:2032`), gate `:1646`. Same-cause twin for fields: `:1747`, gate `:1752` (via `valTypeToIrField` `:2059`, which returns null for string/externref with no AST evidence) | `Animal`, `Dog` (⇒ **6 units**) | gc + sa |
+| A1a | downstream stamp, constructors: `projectionGap && !isStaticMethod` | `src/ir/select-identity.ts:1334` (`localClassHasKnownProjectionGap` `src/ir/select.ts:8039`, which is `!projectedClassShapes.has(className)`) | `Animal_new`, `Dog_new` | gc + sa |
+| A1b | downstream stamp, non-constructors: no exact member descriptor | `src/ir/select-identity.ts:1329` | `Animal_get_label`, `Animal_set_label`, `Animal_make`, `Dog_speak` | gc + sa |
+| **A2** | **member NAME not phase-1 representable** (`PrivateIdentifier` / `ComputedPropertyName`) | `src/ir/select-identity.ts:1286`; predicate `phase1MemberName` `src/ir/select.ts:10495`; the `<computed>` display name is minted at `src/ir/identity.ts:602-605` (`memberBaseName`) and composed at `:607` | `Animal_<computed>` (`#privateMethod`) | gc + sa |
+| A3 | static class initialization on the module-init unit | `src/ir/identity.ts:890` | `<module-init>` | gc + sa |
+
+A1a and A1b are **not independent arms** — they are two stamps of one fact
+(`Animal`/`Dog` absent from the projected class-shape map). The census's
+`class-member-unsupported ×4` and `class-projection-unsupported ×2` are the same
+root cause seen from the member side and the constructor side.
+
+### Bisection — the measurement that establishes A1
+
+Additive probes, each compiled on both lanes (`.tmp/probes`, results identical
+gc/standalone unless noted):
+
+| probe | shape | outcome |
+| --- | --- | --- |
+| `p01` | **untyped `.js`** class: ctor + one method | `Animal_new=class-projection-unsupported`, `Animal_speak=class-member-unsupported` |
+| `p02` | **the same class, annotated `.ts`** | **all units claim (IR)** |
+| `q01` | untyped, but `.ts` | refused, identically to `p01` — **the `.js` extension is not the discriminant** |
+| `q02` | field declared, ctor param untyped | refused ⇒ the **ctor-position** arm (`:1633`) |
+| `q03` | ctor param typed, field not declared | refused ⇒ the **field** arm (`:1747`) |
+| `p03`/`p04`/`p05`/`p06`/`p08` | annotated getter+setter / static method / static field / private FIELD / extra field | **all claim** |
+| `q06` | annotated twin of `classes.js` minus `#privateMethod` and minus `extends` | **every class unit claims**; only `<module-init>` still refuses (`static-class-initialization`) |
+| `q05` | full annotated twin of `classes.js` | accessors claim; `Animal_<computed>=class-method`; ctors `late-preparation-unsupported`; `Dog_speak=body-shape-rejected` |
+
+Checker probe on the arm inputs (`.tmp/arm-probe.ts`, TypeScript API,
+`tests/dogfood/corpus/classes.js`): `Animal`'s and `Dog`'s constructor parameter
+`name` both have type **`any`** (flags `0x1`), and `this.name` / `this.legs`
+are `any` as well. `tsTypeToClassPositionIr` returns null for `any` (it admits
+only NumberLike / BooleanLike / StringLike / a projected class / an object IR
+type), so `ctorOk` is false at `:1633` for both classes, and the gate at `:1646`
+drops them before the field and method loops are ever reached.
+
+**Consequence, stated plainly: 6 of the 8 class units in the census are not a
+class-coverage gap. They are unannotated-`any` class positions.** The identical
+class shapes — implicit-ctor, getter, setter, static method, static field,
+private field, extra instance field — all compile once today when annotated
+(`q06`). Reading this cluster as "R3 class members" would repeat exactly the
+error #3518 recorded twice: a reason label names a demote path, not a feature
+area.
+
+### Cost of the A2 (private-method) arm, measured
+
+| probe | shape | units lost |
+| --- | --- | --- |
+| `r01` | private method **declared, never called** | **1** (`Animal_<computed>`); ctor, sibling method and `run` all claim |
+| `r03` | private method called from the constructor | 2 (`Animal_new` → `body-shape-rejected`) |
+| `r02` | private method called from a sibling method | 3 (ctor → `late-preparation-unsupported`, sibling → `body-shape-rejected`) |
+| `r04` | private **field** only, read from a method | **0 — already claims** |
+| `r05` | computed-name method `["tagged"]()` | 1, same arm (`class-method`) |
+| `r06` | generator method `*gen()` | 1, but a **different** arm — `class-member-unsupported` via the descriptor drop at `src/codegen/index.ts:1763` (`asteriskToken`) |
+
+`classes.js:8` is the `r01` shape: `#privateMethod` is never called, so on the
+census this arm costs exactly one unit per lane and produces **no cascade**.
+
+**Latent naming defect found while measuring (`s01`/`s02`).** Two private
+methods in one class both take the display/legacy-match name
+`Animal_<computed>` — `memberBaseName` (`src/ir/identity.ts:602-605`) returns
+the same literal for every `PrivateIdentifier` and every
+`ComputedPropertyName`. Today this is inert because both members are refused
+and never mint a callable slot. It becomes load-bearing the moment either is
+admitted: a second private method would overwrite the first's exact UnitId in
+the legacy callable slot — the same hazard the accessor slice guarded with
+`occupiedAccessorSlots`. Any admission of this arm must introduce a distinct
+name **before** claiming.
+
+## Implementation Plan — W1-A class-member family (2026-09-03)
+
+### What the census changed about this slice
+
+W1-A was briefed as "one PR over the `class-member-unsupported` ×4 cluster,
+after an arm-level census says all four fire on the same arm." The census says
+they **do** fire on one arm — and that arm is **A1, an `any`-typed class
+position**, not a class-member shape. So the briefed slice does not exist as
+briefed. This plan therefore does two things: it disqualifies A1 with reasons,
+and it dispatches the largest arm that is genuinely class-shaped, in-scope, and
+test262-representative.
+
+**Why A1 is not this slice**, three measured reasons:
+
+1. **It is a type-resolution arm.** `q06` proves the identical class shapes
+   claim once annotated. Fixing A1 means deciding how an `any` class position
+   is carried (boxed / dynamic), not widening class-member admission.
+2. **It belongs to another lane.** The `any`-carrier decision is #5289 /
+   #3523 territory (module-binding `any` ABI landed in PR #5525); duplicating
+   it here is the cross-lane duplication CLAUDE.md documents at length.
+3. **Blast radius.** It changes the class-shape sidecar for *every* class in
+   *every* unannotated file, on both lanes — the opposite of a bounded slice.
+
+Record it as R3's largest measured cluster and hand the mechanism to the `any`
+lane; do not implement it under W1-A.
+
+### Chosen cluster — A2, PrivateIdentifier instance-method declarations
+
+Scope: **admit a `PrivateIdentifier`-named, non-static, non-generator,
+body-bearing instance METHOD DECLARATION into the ordinary bounded class-member
+family.** Computed names stay refused. Private-method **call sites** (`r02`/`r03`,
+2–3 units, an `src/ir/from-ast.ts` lowering question) are explicitly the *next*
+slice, not this one.
+
+Why this one:
+
+- It is the largest **class-shaped** arm on the census (1 unit × 2 lanes) once
+  A1 is removed, and the only one whose fix is a member-admission change.
+- **It is the single most test262-representative class shape we have.** #3518
+  measures `PrivateIdentifier` at **4.58 % of test262 nodes vs 0.21 %
+  (playground) / 0.23 % (dogfood)** — the largest blind spot in both denominators
+  by an order of magnitude.
+- Measured cost is bounded and cascade-free in the census shape (`r01`).
+- The legacy substrate already exists and agrees:
+  `resolveClassMemberName` (`src/codegen/class-bodies.ts:752-761`) already maps
+  `#x` → `__priv_x`, and the field path in `buildIrClassShapes`
+  (`src/codegen/index.ts:1682`) already uses the identical mangling. This slice
+  makes the IR member path agree with two conventions that are already in the
+  tree; it invents no naming.
+
+### Root cause
+
+A `PrivateIdentifier`-named method fails `phase1MemberName`
+(`src/ir/select.ts:10495`, which returns `null` for `PrivateIdentifier` and
+`ComputedPropertyName` alike), so `src/ir/select-identity.ts:1286` stamps
+`class-method` before any descriptor is consulted. Independently, the descriptor
+loop in `buildIrClassShapes` skips the member at `src/codegen/index.ts:1762`
+(`if (!ts.isIdentifier(member.name)) continue`), so no descriptor exists for it
+either. And `memberBaseName` (`src/ir/identity.ts:602-605`) gives every such
+member the same name, `<computed>`.
+
+**All three must move together.** Relaxing only the name predicate moves the
+row from `class-method` (A2) to `class-member-unsupported` (A1b, the
+missing-descriptor arm) and claims nothing — the exact trap recorded in the
+2026-08-15 accessor measurement ("Relaxing gate 1 alone moved every fixture from
+`body-shape-rejected` to `class-member-unsupported` and claimed nothing").
+Relaxing the name without the mangling re-admits the `s01` collision.
+
+### Changes, in this order
+
+**Step 0 (measurement, before any edit).** Re-run the probe set at the branch
+base and record the current rows for `r01`, `r02`, `s01`, `s02` and
+`tests/dogfood/corpus/classes.js` on **both** lanes. Capture the base copies of
+every file this slice touches (`cp src/… .tmp/base-….ts`) at the *first* edit,
+per CLAUDE.md's A/B rule — the acceptance criteria below require a base run.
+
+**1. `src/ir/identity.ts` — `memberBaseName` (`:602-605`).**
+Return `"__priv_" + name.text.slice(1)` for a `PrivateIdentifier`; leave
+`ComputedPropertyName` returning `"<computed>"` unchanged. This is the naming
+substrate for both the display name and the legacy match name composed at
+`classMemberLegacyName` (`:607-616`), so `#first` becomes `Animal___priv_first`
+— byte-agreeing with what `resolveClassMemberName`
+(`src/codegen/class-bodies.ts:754`) already produces on the legacy side.
+`memberBaseName` is also read by `objectMemberDisplayName` (`:620-627`); an
+object literal cannot carry a private name, so that call site is unaffected —
+assert it with a test rather than assuming it.
+
+**2. `src/ir/select.ts` — `phase1MemberName` (`:10495-10501`).**
+Return the same mangled name for a `PrivateIdentifier`; keep `null` for
+`ComputedPropertyName`. Use one shared helper so steps 1 and 2 cannot drift —
+put it beside `phase1MemberName` and have `memberBaseName` call it. Do **not**
+touch the accessor arm at `select-identity.ts:1294`; private accessors are out
+of scope for this slice and must stay refused (negative test).
+
+**3. `src/codegen/index.ts` — the method-descriptor loop (`:1756-1800`).**
+Widen `:1762` from `!ts.isIdentifier(member.name)` to also admit a
+`PrivateIdentifier`, using the same helper, and mint `methodName` from it. The
+static defer (`:1760`), the abstract defer, and the generator defer (`:1763`)
+are unchanged. **This function is `buildIrClassShapes` (`:1519`), ~1,300 lines
+above `planIrOverlay`; the standing instruction to stay out of `planIrOverlay`
+is respected.** PR #5530, which held this file, **merged** (`54bfb99c90`, on
+main at the base sha) — verified, so the file is free. Re-verify at branch time.
+
+**4. `src/codegen/class-bodies.ts` — verify only, edit only if measured.**
+`resolveClassMemberName` (`:752`) already yields `__priv_x`. Confirm the
+prepared class-body route emits and dispatches the admitted member under that
+name on both lanes; if it does, this file is audit-only and the slice does not
+edit it. Do not "fix" it speculatively.
+
+**5. Do NOT touch** `src/codegen/prepared-class-body-cutover.ts` unless a
+measured failure requires it (it is the `JS2WASM_PREPARED_CLASS_ROUTE_CUTOVER`
+hatch, R9 inventory row 12 — changing it moves a retirement denominator).
+
+### What this must NOT change
+
+- **Order preservation.** Field initialization must still precede constructor
+  body reads, and member declaration order must be unchanged. Reuse the F4
+  ordering control (`40100`, where every wrong ordering yields `0` or `NaN`).
+- **Byte identity for programs without a private method.** Every entry in the
+  census cohort that carries no `PrivateIdentifier` member must be
+  byte-identical to base, on both lanes. This is the primary safety property:
+  step 1 edits a naming helper on a shared path.
+- **Computed names stay refused** (`r05` keeps its `class-method` row), private
+  **accessors** stay refused, **generator** methods keep their `class-member-unsupported`
+  row via `:1763` (`r06`), **static** private methods stay deferred via `:1760`.
+- **The `s01`/`s02` collision must be closed, not inherited.** Two private
+  methods, and a private method beside a computed-name method, must resolve to
+  distinct names and must not overwrite each other's UnitId.
+- **A1 must not move.** `tests/dogfood/corpus/classes.js` keeps its 6 A1 rows
+  after this slice; only `Animal_<computed>` changes. A run that "improves"
+  A1 means step 3 widened something it should not have.
+- **No new import, runtime representation, ABI, or lowering surface.** If one
+  appears to be needed, the slice is wrong — stop and re-measure.
+
+### Tests to add (must be RED on base)
+
+`tests/issue-3522-private-method-admission.test.ts`, both lanes, direct class
+and function emitters poisoned (`JS2WASM_TEST_POISON_DIRECT_CLASS_BODY`), with a
+positive control proving the poison seam is live so no assertion can pass
+vacuously:
+
+1. `r01` — private method declared, never called: the member claims (IR) and
+   the class's other units stay claimed. **Red on base** (`class-method` today).
+2. Runtime equality legacy↔IR for that fixture, both lanes.
+3. `s01` — two private methods: distinct unit names, both admitted, no UnitId
+   overwrite; assert the two rows carry different `displayName`s. **Red on base**
+   (both read `Animal_<computed>`).
+4. `s02` — private method beside a computed-name method: the private one
+   claims, the computed one keeps `class-method`.
+5. Negatives, each asserted identical to base: private **accessor**, **static**
+   private method, **generator** method (`r06` keeps `class-member-unsupported`),
+   computed name (`r05`).
+6. Call-site controls pinning the deferral: `r02` and `r03` keep their exact
+   current rows (3 and 2 units lost). These are the next slice's boundary and
+   must not silently move.
+7. A1 control: `tests/dogfood/corpus/classes.js` keeps 6 A1 rows on both lanes.
+8. WAT proof on the admitted fixture: no `call_ref`, `call_indirect`,
+   `ref.test`, ambient `this`, boxing, or `__call_m_*` in the prepared owner.
+
+### Byte-identity cohort
+
+Per-row **sha256** over the emitted binary for **all 33 entries × 2 lanes**
+(dogfood 20 + playground 13; gc and standalone), base vs branch, with the
+diagnostic OFF. Expected: **65 of 66 identical**; the sole permitted mover is
+`tests/dogfood/corpus/classes.js`, whose two rows change because
+`Animal_<computed>` is admitted. Publish the full table, and publish the two
+changed digests explicitly with the claimed-unit set before and after. A second
+mover is a stop-and-diagnose, not a rebaseline. Reuse `.tmp/census-3522.ts`
+(add a `sha256` over `result.wasm`); it is a `.tmp` instrument, not a shipped
+script.
+
+### Gates
+
+Run bare (never piped — a piped gate reports the pipe's status), chained so a
+failure blocks, before the commit:
+
+```bash
+node scripts/check-loc-budget.mjs && node scripts/check-func-budget.mjs \
+  && node scripts/check-coercion-sites.mjs && npm run -s check:oracle-ratchet \
+  && npm run -s check:dead-exports
+```
+
+plus, and each named because this slice can move it:
+
+- `LOC_GATE_BASE=$(git rev-parse origin/main) node scripts/check-loc-budget.mjs`
+  and the same for `check-func-budget` — CI diffs the merge preview, not the
+  fork point. Any growth allowance goes in **this issue file's** frontmatter
+  with a dated rationale; never edit `scripts/*-baseline.json`.
+- `npm run -s check:ir-dialect`.
+- `npm run -s check:ir-kind-neutrality` — steps 2 and 3 add lines to
+  `src/ir/select.ts` and `src/codegen/index.ts`, which is exactly what has
+  relocated evidence line anchors on the last two checkpoints (F2, F4). Expect
+  an evidence-location-only diff; **re-lock the baseline sha256 and state in the
+  commit that no row, verdict, placement, rationale or phase-two move changed.**
+- `pnpm run check:ir-fallbacks` — name the class buckets in the result:
+  `class-member-unsupported`, `class-projection-unsupported`, `class-method`,
+  `static-class-initialization`. `class-method` should **decrease**; the other
+  three must not move. Use `--update-on-decrease` only for a real decrease.
+- `npm run -s check:ir-only` — must stay **READY**, single-host and standalone.
+  The five gate entries contain no private members, so this is a no-move check.
+- `gen-ir-adoption --check` byte-clean, TypeScript 7 and 5 no-emit, Prettier,
+  Biome, IR layering.
+- `scripts/hooks/changed-root-tests.sh` against the branch base, reproducing
+  CI's `test:changed-root` selection — and read the 2026-08-29 F4 correction
+  above before dismissing any failure in a file this branch touches: touching a
+  root test file arms the fix-on-touch ratchet against pre-existing rot.
+
+Never `--no-verify`.
+
+### Acceptance criteria
+
+1. On `tests/dogfood/corpus/classes.js`, `Animal_<computed>` becomes an admitted
+   IR-emitted unit named `Animal___priv_first`-style (mangled, not `<computed>`),
+   on **both** lanes, with `legacyBodyEmitted: false`.
+2. The other 7 class rows of that file are **unchanged**, including all 6 A1
+   rows and the `<module-init>` `static-class-initialization` row.
+3. The byte-identity cohort is 65/66 identical with the one documented mover.
+4. All 8 test groups above pass on both lanes; groups 1 and 3 are demonstrably
+   RED on the branch base (show the base failure output).
+5. Every gate above passes, including the `LOC_GATE_BASE` simulation, with the
+   kind-neutrality baseline re-locked and its diff characterised.
+6. `check:ir-fallbacks` shows `class-method` decreased and no other bucket —
+   class or otherwise — increased.
+7. No new import, ABI, runtime representation, or lowering surface, evidenced by
+   the WAT assertion in test group 8.
+
+### Blast radius and conflict check
+
+Files this slice owns: `src/ir/identity.ts`, `src/ir/select.ts`,
+`src/codegen/index.ts` (`buildIrClassShapes` only), optionally
+`src/codegen/class-bodies.ts`, and `tests/issue-3522-*`.
+
+Verified against the in-flight set at base sha `42a0adf7d4`:
+
+| constraint | state today | verdict |
+| --- | --- | --- |
+| `src/codegen/index.ts` / `planIrOverlay`, `src/codegen/ir-overlay-outcomes.ts` (#5530) | **PR #5530 MERGED** (`54bfb99c90`) — the takeover doc's "draft, in flight" is stale | file free; still stay out of `planIrOverlay` |
+| #5283 — `ir-overlay-outcomes.ts`, `src/ir/module-init.ts`, `legacy-body-audit.ts` | `status: ready` (queued) | untouched by this slice |
+| #5297 — `prepared-dynamic-support.ts`, `prepared-component-sealing.ts`, `compiler-timer-shim-preparation.ts`, `src/ir/integration.ts` | `status: ready` | untouched. **Note:** `late-preparation-unsupported` is raised in `prepared-component-sealing.ts:648/698` — this is why the slice fixes the *cause* (admit the member) and never the cascade |
+| #5300 — `src/ir/from-ast.ts` direct-call lowering | `status: done` (PR #5535, at the base sha) | free — but the private-method **call-site** slice will land there, so keep this slice out of `from-ast.ts` entirely |
+| #3520 W1-D — `src/codegen/program-abi-*.ts` | untouched | clear |
+| `src/ir/integration.ts`, `src/ir/module-bindings.ts` | untouched | clear |
+
+Residual risk, highest first: (a) step 1 edits a naming helper on a shared
+path — the byte-identity cohort is the control that catches over-reach; (b)
+`check:ir-kind-neutrality` evidence anchors will move; (c) the legacy match name
+must agree exactly with `resolveClassMemberName`, so a mismatch surfaces as an
+invariant, not a demote — assert the emitted legacy name directly.
+
+### Representativeness
+
+**This arm is the test262-representative one**, which is unusual for this issue
+and is the main reason to prefer it over A1's larger count. #3518's 2026-09-03
+node-frequency measurement puts `PrivateIdentifier` at **4.58 % of test262 nodes
+against 0.21 % (playground) / 0.23 % (dogfood)**, and `PrivateIdentifier` +
+`PropertyDeclaration` together at **8.9 % vs 0.4 %** — class bodies are the
+single largest blind spot in both denominators, by an order of magnitude. The
+`PropertyDeclaration` half is already covered (annotated fields, including
+private fields, claim today — `r04`, `p06`), so this slice attacks precisely the
+half that is both uncovered and heavily represented upstream. A1, by contrast,
+is a shape test262 barely contains at all: test262 is not an unannotated-`.js`
+application corpus, so A1's 6 units are close to the maximum that arm will ever
+be worth on this census, while A2's 1 unit is close to the minimum it is worth
+on the real target population. **Fixture to add to the census** so the arm stops
+being invisible: a single file
+`tests/dogfood/corpus/class-private-members.js` — one class with a private
+field, an uncalled private method, and a private method called from a sibling —
+which covers `r01`, `r02` and `r04` in one entry and gives the next slice its
+denominator. Adding it changes census counts, so add it in the **same** PR as
+this slice or in a dedicated corpus PR, never silently.
+
+### Next cluster, in order
+
+1. **Private-method call sites** (`r02`/`r03`) — 2–3 units per occurrence,
+   `src/ir/from-ast.ts` lowering; sequence after #5300's file settles.
+2. **`super.<accessor>` in a derived method** (`p09`/`q05`) — the remaining
+   genuine class gap in the annotated twin: both ctors
+   `late-preparation-unsupported`, `Dog_speak` `body-shape-rejected`.
+3. **Computed-name methods** (`r05`) — same A2 arm, but needs a compile-time
+   constant-key contract; deliberately excluded here.
+4. **A1, the `any` class position** — hand to the `any`-carrier lane (#5289 /
+   #3523), not to R3.
+5. `static-class-initialization` on `<module-init>` — R4 (#3523), not R3.
+
+### Claim
+
+Claim the **slice**, never the bare id — the bare-id claim is what froze this
+issue for five days:
+
+```bash
+node scripts/claim-issue.mjs 3522:w1a-private-method ttraenkler/<agent> --branch <branch>
+```
+
+Release it on merge. `#3522` itself is `horizon: xl` and remains open after this
+slice.


### PR DESCRIPTION
Docs-only. [#3522](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3522-ir-r3-classes-closures-compile-once) (spine row R3) gains `## Measurement 2026-09-03 — class-arm census` and `## Implementation Plan — W1-A class-member family`, from the arm-level census the spine-takeover audit required before any R3 dispatch (66 compiles: dogfood 20 + playground 13, gc + standalone, base `42a0adf7d4`).

**Three findings that changed the brief.** (1) All 16 class refusal rows come from one file, `tests/dogfood/corpus/classes.js`; every playground class-member row is `emitted`. (2) `detail` does not name the arm for class codes (`ir-overlay-outcomes.ts:827` restates the code), so arms were attributed by source reading plus fixture bisection. (3) The largest cluster — 6 of 8 units — is **not a class gap**: unannotated-`any` class positions (`src/codegen/index.ts:1633/1747`) that claim once annotated; it is handed to the `any`-carrier lane ([#5297](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5297-r4-compat-dynamic-support-symbolization) / [#3523](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3523-ir-r4-module-init-compile-once)) rather than mislabelled R3.

**Chosen cluster: PrivateIdentifier instance-method declarations** (arm `select-identity.ts:1286`, predicate `select.ts:10495`, naming `identity.ts:602`) — the single most test262-representative class shape (PrivateIdentifier 4.58% of test262 nodes vs ~0.2% of our corpora). The legacy substrate already mangles `#x` → `__priv_x` in both `class-bodies.ts:754` and `index.ts:1682`. Three sites must move together or the row only shifts arm. A latent UnitId-overwrite hazard (two private methods in one class both named `Animal_<computed>`) is pinned as a required red-on-base test. Claim slug `3522:w1a-private-method`.

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Namds9phYeHvpLKu735io3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_