### PR TITLE
docs(test262): harvest 2026-09-03 — Temporal now counts as official; 2 new issues, 2 regression flags

### DIFF
--- a/plan/issues/1524-test262-harness-resizable-buffer-ctors-fixture.md
+++ b/plan/issues/1524-test262-harness-resizable-buffer-ctors-fixture.md
@@ -190,3 +190,41 @@ matches this issue's family: `built-ins/TypedArray/prototype` (91),
 `built-ins/Array/prototype` (68).
 
 Original scope was 202 tests; the successor bucket is 224. Filed as **#4364**.
+
+## ⚠ Harvest re-measurement 2026-09-03 — NOT actually fixed (status `done` is wrong)
+
+Source: baselines-repo `test262-current.jsonl`, sha `998a110a`, run `20260903-155044`.
+
+The original symptom is gone, but the tests still fail — the error merely
+changed shape:
+
+| Signature | Count today | Note |
+| --- | ---: | --- |
+| `ctors is not defined` | **0** | the symptom this issue was closed on |
+| `No dependency provided for extern class "ctor"` | **239** | same tests, new message |
+
+Recorded `test262_count` at closure was 259; 239 of those rows are still
+failing. Failing directories are the same resizable-ArrayBuffer family:
+
+| Count | Directory |
+| ---: | --- |
+| 92 | `built-ins/TypedArray/prototype` |
+| 69 | `built-ins/Array/prototype` |
+| 15 | `built-ins/FinalizationRegistry/prototype` |
+| 7 | `built-ins/Proxy/construct` |
+| 5 | `built-ins/Proxy/defineProperty` |
+| 5 | `language/statements/for-of` |
+
+Samples: `test/built-ins/TypedArray/prototype/reverse/resizable-buffer.js`,
+`test/built-ins/Array/prototype/findLastIndex/resizable-buffer.js`,
+`test/built-ins/TypedArray/prototype/reduceRight/resizable-buffer-grow-mid-iteration.js`.
+
+Note the singular `"ctor"` in the new message vs the harness's `var ctors` —
+the fix appears to have made the helper resolvable as a *dependency name*
+while leaving the binding unresolved at the codegen boundary.
+
+The same test family is also the top standalone-lane `illegal cast` bucket
+(244 rows, 105 `TypedArray/prototype` + 80 `Array/prototype`), so this is a
+cross-lane cluster, not a host-lane harness quirk.
+
+**Suggested action:** reopen (`status: ready`) or open a successor issue.

--- a/plan/issues/3601-dynamic-import-fixture-base-dir-144-false-fails.md
+++ b/plan/issues/3601-dynamic-import-fixture-base-dir-144-false-fails.md
@@ -108,3 +108,25 @@ directory in as the resolution base.
   (byte-identical verdicts).
 - Regression test `tests/issue-3601.test.ts`: compile+run a tiny
   `import('./fixture.js')` pair from a temp directory far from `scripts/`.
+
+## Harvest re-measurement 2026-09-03 — bucket has GROWN
+
+Source: baselines-repo `test262-current.jsonl`, sha `998a110a`, run `20260903-155044`.
+
+| Date | Rows matching `Cannot find module … _FIXTURE.js` |
+| --- | ---: |
+| 2026-07-24 (this issue's measurement) | 144 |
+| 2026-09-03 | **173** (+29) |
+
+Of those, 64 are the `module-code_FIXTURE.js` specifier specifically, all in
+`language/expressions/dynamic-import/**`. The baked-in absolute path is
+unchanged and still points at the CI worker bundle directory:
+
+```
+Cannot find module '/home/runner/work/js2/js2/scripts/module-code_FIXTURE.js'
+  imported from /home/runner/work/js2/js2/scripts/runtime-bundle.mjs
+```
+
+These remain false FAILs — the compiled dynamic-import machinery never runs.
+Still `status: ready` / `sprint: current`; the growth suggests newly-enabled
+dynamic-import tests are landing straight into this bucket.

--- a/plan/issues/5304-yield-star-thrown-typeerror-not-intrinsic.md
+++ b/plan/issues/5304-yield-star-thrown-typeerror-not-intrinsic.md
@@ -1,0 +1,101 @@
+---
+id: 5304
+title: "yield*: the TypeError rejecting a bad iterator protocol is not the %TypeError% intrinsic — v.constructor mismatch, 364 tests"
+status: ready
+sprint: current
+created: 2026-09-03
+priority: high
+feasibility: medium
+reasoning_effort: medium
+horizon: m
+task_type: bugfix
+area: codegen, runtime
+language_feature: generators, async-iteration, error-objects
+goal: test262-conformance
+test262_bucket: yield-star-error-identity
+test262_count: 364
+related: [1691, 1639, 3227]
+origin: "2026-09-03 harvest of baselines-repo test262-current.jsonl (sha 998a110a, run 20260903-155044): 364 official-scope default-lane rows share one signature."
+---
+
+# #5304 — `yield*` protocol errors reject with a non-intrinsic TypeError
+
+## Problem (measured 2026-09-03)
+
+364 official-scope rows in the **default (JS-host) lane** fail with exactly:
+
+```
+Test262:AsyncTestFailure:Test262Error: TypeError Expected SameValue(
+  «function () { [native code] }», «function TypeError() { [native code] }») to be true
+```
+
+The tests are the procedurally-generated `yield-star-*-throw` family:
+
+| Count | Directory |
+| ---: | --- |
+| 120 | `language/expressions/class` (async-gen methods / private methods) |
+| 120 | `language/statements/class` |
+| 60 | `language/expressions/async-generator` |
+| 30 | `language/statements/async-generator` |
+| 30 | `language/expressions/object` |
+| 3 | `language/expressions/dynamic-import` |
+
+Samples:
+
+- `test/language/expressions/async-generator/yield-star-getiter-sync-not-callable-number-throw.js`
+- `test/language/statements/class/async-gen-method-static/yield-star-getiter-sync-returns-null-throw.js`
+- `test/language/expressions/class/elements/async-gen-private-method-static/yield-star-next-not-callable-symbol-throw.js`
+
+## Root cause (exact)
+
+These tests do **not** check that a rejection happens — we already get that
+right. They check the *identity* of the rejecting error's constructor:
+
+```js
+iter.next().then(() => {
+  throw new Test262Error('Promise incorrectly fulfilled.');
+}, v => {
+  assert.sameValue(v.constructor, TypeError, "TypeError");   // <-- fails here
+  ...
+});
+```
+
+The rejection arrives with correct *timing* and correct *kind* (the
+`Promise incorrectly fulfilled` branch never fires), so `GetIterator` /
+`GetMethod` abrupt completion is being detected and propagated correctly.
+What is wrong is that `v.constructor` resolves to an anonymous
+`function () { [native code] }` rather than the global `%TypeError%`
+intrinsic. The error object we construct on the `yield*` protocol failure
+path is not linked to the realm's `TypeError` — either its prototype is a
+freshly-minted native error prototype, or `.constructor` is left pointing at
+an unnamed host shim.
+
+Note the diagnostic detail that pins this down: the *expected* side prints as
+`function TypeError() { [native code] }` (the real intrinsic is reachable from
+the test's scope), while the *actual* side prints unnamed. So the intrinsic
+exists — the throw site simply is not using it.
+
+## Why this is worth fixing
+
+It is a single shared throw path behind 364 tests, and the surrounding
+semantics already pass. This is an error-object wiring fix, not a generator
+redesign — distinct from #1691 (`yield*` does not delegate `throw()`/`return()`
+to the inner iterator, in progress on PR #5063), which is about delegation
+behaviour rather than error identity.
+
+## Cross-lane note
+
+The standalone lane shows 116 rows of `TypeError: Cannot read properties of
+undefined (reading a class field)` on the *same* `yield-star-getiter-*` test
+family (58 `language/expressions/class`, 58 `language/statements/class`). That
+is a different, harder failure on the same tests — fixing #5304 will not fix
+those, but they should be re-measured after this lands.
+
+## Acceptance criteria
+
+1. On a `yield*` protocol failure (non-callable `@@iterator`/`@@asyncIterator`,
+   non-object iterator, non-callable `next`/`then`), the thrown/rejected value
+   satisfies `v.constructor === TypeError` and
+   `Object.getPrototypeOf(v) === TypeError.prototype`.
+2. The 364 rows above flip to `pass` in the default lane.
+3. No regression in the `yield-star-*` rows that pass today.

--- a/plan/issues/5305-standalone-static-class-method-not-own-property.md
+++ b/plan/issues/5305-standalone-static-class-method-not-own-property.md
@@ -1,0 +1,84 @@
+---
+id: 5305
+title: "standalone: a class's static/instance method is callable but is NOT an own property of the class object — verifyProperty fails on 218 class-elements tests"
+status: ready
+sprint: current
+created: 2026-09-03
+priority: high
+feasibility: medium
+reasoning_effort: medium
+horizon: m
+task_type: bugfix
+area: codegen, runtime
+language_feature: class-elements, property-descriptors
+goal: standalone-mode
+test262_bucket: standalone-class-elements-own-property
+test262_count: 218
+related: [1781, 1888, 2963, 2860]
+origin: "2026-09-03 harvest of baselines-repo test262-standalone-current.jsonl (sha 998a110a): 218 official-scope standalone rows, 0 in the default lane."
+---
+
+# #5305 — standalone class methods are callable but not own properties
+
+## Problem (measured 2026-09-03)
+
+218 official-scope rows in the **standalone lane** fail with exactly:
+
+```
+Test262Error: m should be an own property
+```
+
+The default (JS-host) lane passes all of them — this is a pure
+standalone-only gap.
+
+| Count | Directory |
+| ---: | --- |
+| 108 | `language/expressions/class/elements/**` |
+| 108 | `language/statements/class/elements/**` |
+| 1 | `built-ins/Iterator/from` |
+| 1 | `built-ins/ShadowRealm/descriptor.js` |
+
+Samples:
+
+- `test/language/statements/class/elements/after-same-line-static-method-static-private-fields.js`
+- `test/language/expressions/class/elements/after-same-line-static-gen-grammar-privatename-identifier-semantics-stringvalue.js`
+- `test/language/statements/class/elements/after-same-line-static-async-method-rs-private-setter-alt.js`
+
+## Root cause (exact)
+
+The message text comes from `verifyProperty` in the test262
+`propertyHelper.js` harness, which fails its very first check when
+`Object.prototype.hasOwnProperty.call(obj, name)` is false.
+
+In the representative test the assertions run in this order:
+
+```js
+assert.sameValue(C.m(), 42);                                    // line 41 — PASSES
+assert(!Object.prototype.hasOwnProperty.call(c, "m"), ...);     // line 42 — PASSES
+assert(!Object.prototype.hasOwnProperty.call(C.prototype,"m")); // line 46 — PASSES
+verifyProperty(C, "m", {                                        // line 51 — FAILS
+  enumerable: false, writable: true, configurable: true
+});
+```
+
+So the static method **is reachable and returns the right value**
+(`C.m() === 42`), but the class constructor object does not report `m` as an
+own property. In standalone lowering the method is dispatched through the
+static/vtable path rather than being installed as a real own property with a
+descriptor on the class object. The host lane installs it, which is why the
+gap is standalone-only.
+
+This is the class-object face of the same reification gap tracked by #1888
+(open-any method dispatch + built-ins-as-static-globals) and #2963 (reify
+builtins as first-class values), but it is distinguishable by signature and
+by the fact that dispatch already works — only descriptor materialisation is
+missing.
+
+## Acceptance criteria
+
+1. For a class `C` with a static method `m`, `Object.getOwnPropertyDescriptor(C, "m")`
+   in standalone returns `{ value: <fn>, writable: true, enumerable: false, configurable: true }`.
+2. The same holds for prototype methods on `C.prototype`, and private elements
+   (`#x`) remain *absent* from `hasOwnProperty` on `C`, `C.prototype` and instances.
+3. The 218 rows above flip to `pass` in the standalone lane, with no default-lane
+   regression.

--- a/plan/log/test262-harvest-2026-09-03.md
+++ b/plan/log/test262-harvest-2026-09-03.md
@@ -1,0 +1,125 @@
+# test262 error harvest — 2026-09-03
+
+Source: `loopdive/js2wasm-baselines` @ run **`20260903-155044`**, baseline sha
+**`998a110a`** (= main `986bbf77`, "refresh sharded baseline — 35495/48232").
+Both lanes fetched fresh from the baselines repo; the main-repo
+`benchmarks/results/*.jsonl` mirror is trimmed/stale and must not be used.
+
+**The two lanes are independent conformance metrics on different targets. Never sum them.**
+
+| Lane | Official total | pass | fail | compile_error | timeout | rate |
+| --- | --- | --- | --- | --- | --- | --- |
+| Default (JS-host) | 48,232 | **35,495** | 12,361 | 343 | 15 | **73.6 %** |
+| Standalone (`--target standalone`, no host imports) | 48,232 | **34,598** | 9,869 | 3,738 | 9 | **71.7 %** |
+
+> **Metric caution.** The default lane's summary carries `host_free_pass: 4,314`
+> and `leaky_pass: 31,181`. `host_free_pass` is NOT the standalone result — the
+> authoritative standalone number is the standalone lane's own summary,
+> **34,598**. Do not quote 4,314 as "standalone".
+
+---
+
+## ⚠ Scope correction — Temporal now COUNTS (supersedes the harvest skill doc)
+
+The `/harvest-errors` skill doc still says Temporal tests are `official: false`,
+excluded by design, and that we should not file issues for them. **That is no
+longer true and it materially distorts the picture.**
+
+`#5173` removed the `built-ins/Temporal/` → `proposal` rule from
+`classifyTestScope` because **Temporal shipped in ECMA-262 17th edition
+(ES2026, approved 2026-06-30)** and upstream test262 lists `Temporal` under
+standard language features. Temporal rows now classify as `scope: "standard"`,
+`scope_official: true` and count toward the official denominator.
+
+Measured today: **4,611 Temporal rows in official scope, 4,017 failing** — i.e.
+**31.6 % of all default-lane official failures are Temporal**, the single
+largest addressable bucket. `test/staging/Temporal/**` is still excluded by the
+staging rule.
+
+Temporal is **not** unowned: it is an active campaign (#4628 spike → #5169,
+#5180, #5191–#5251). Residual owners today: #5224, #5227, #5245, #5249, #5250,
+#5251 (`ready`), #4352 (`in-progress`). The `Temporal is not defined` signature
+still dominates (1,592 default / 1,498 standalone), i.e. the compiled provider
+is not yet reaching these runs despite #5248.
+
+---
+
+## Default (JS-host) lane — top signatures (non-Temporal: 8,702 of 12,719)
+
+| Pattern | Count | Cross-reference |
+| --- | ---: | --- |
+| `TypeError Expected SameValue(«function () { [native code] }», «function TypeError() …»)` | **364** | **NEW → #5304** |
+| `Expected a TypeError to be thrown but no exception was thrown at all` | 245 | #3430 family |
+| `No dependency provided for extern class "ctor"` | **239** | **#1524 is `done` but NOT fixed — see below** |
+| `Expected SameValue(«#», «#») to be true` | 229 | heterogeneous, no single owner |
+| `Cannot find module … _FIXTURE.js` (all specifiers) | **173** | #3601 `ready` — **grew from 144** |
+| `Cannot read properties of null (reading 'bind')` | 112 | #4365 (`$262.agent` is null — count matches exactly) |
+| `Cannot convert undefined or null to object [in verifyProperty()]` | 83 | descriptor-fidelity family |
+| `async completion marker not observed` | 75 | #3421 / #3574 / #3417 |
+| `Cannot set property # of [object Array] which has only a getter` | 64 | #2017, #2614 |
+| `ShadowRealm is not defined` | 61 | #1356 (`backlog`) |
+
+Negative-test failures are negligible this run: **4** total
+(3 × `expected runtime ReferenceError but succeeded`, 1 × early SyntaxError
+not detected).
+
+---
+
+## Standalone lane — top signatures (non-Temporal: 9,167 of 13,616)
+
+Leading with the embedded `#NNNN` citation counts, which are the highest-signal
+cross-reference on this lane:
+
+| Cited issue | Records | Status | Feature |
+| --- | ---: | --- | --- |
+| #2961 | 2,538 | done | strict leak guard firing — names the leaked imports |
+| #680 | 320 | ready | native generators (sequential-numeric-yield limit) |
+| #1472 | 116 | ready | host-independent object/property ops |
+| #3371 | 65 | blocked | `Reflect.construct` with distinct NewTarget |
+| #1539 | 29 | done | RegExp dynamic flags residual |
+| #2046 | 19 | in-progress | `Reflect.set` explicit receiver |
+| #2717 | 19 | done | `Array.prototype.flatMap` residual |
+| #1474 | 19 | done | `matchAll` with RegExp/symbol protocol |
+| #3494 | 14 | blocked | standalone dynamic import |
+
+By signature:
+
+| Pattern | Count | Cross-reference |
+| --- | ---: | --- |
+| leak: `env::__gen_next` (+ generator family ≈ 1,044 total) | 515 | #680, #3178 umbrella |
+| `Standalone dynamic import is unsupported…` | 436 | #3494 (`blocked`) |
+| leak: `env::SharedArrayBuffer_new` (+ `__timer_set_timeout` variant) | 405 | #674 (`ready`), #1354 (`backlog`) |
+| `Expected a TypeError to be thrown but no exception was thrown at all` | 350 | #3430 family |
+| native generator lowering — sequential numeric yields only | 318 | #680 |
+| `Cannot access property on null or undefined` | 283 | heterogeneous |
+| `illegal cast [in __module_init_chunk_0()]` | **244** | resizable-buffer family — same cluster as #1524 |
+| `m should be an own property` | **218** | **NEW → #5305** (0 in default lane) |
+| `Cannot read properties of undefined (reading a class field)` | 116 | `yield-star-getiter-*` — same tests as #5304, harder failure |
+| `Cannot convert undefined or null to object` | 106 | iterator/descriptor family |
+| `__get_builtin` dynamic-shape refusal | 94 | #2963 (`ready`) |
+| `ShadowRealm is not defined` | 61 | #1356 (`backlog`) |
+
+Leak classes this run: `iterator_protocol` 1,300, `host_import` 1,238,
+`dynamic_object_property` 3. (Per the doc's own caution: do **not** use
+`host_import_leak_class` to tell the lanes apart — the default lane carries
+12,541 `dynamic_object_property` rows.)
+
+---
+
+## Issues filed / updated by this harvest
+
+| Issue | Action | Rows |
+| --- | --- | ---: |
+| **#5304** | NEW — `yield*` protocol TypeError is not the `%TypeError%` intrinsic | 364 |
+| **#5305** | NEW — standalone class method callable but not an own property | 218 |
+| #1524 | **Regression flag** — closed `done`, but 239 rows still fail; symptom migrated from `ctors is not defined` (now 0) to `No dependency provided for extern class "ctor"` (239). Reopen candidate. | 239 |
+| #3601 | **Growth flag** — 144 (2026-07-24) → 173 (+29) | 173 |
+
+## Method notes for the next harvest
+
+- **Do not extract `#NNNN` citations from the default lane without filtering.**
+  Wasm validation errors embed function indices (`Compiling function #104:"__closure_33"`),
+  which the naive regex reads as issue citations. Only #1387/#1472/#3587 were
+  real citations this run; every other default-lane "citation" was an index.
+- Sub-bucketing `other` remains essential: it held 6,536 of 8,702 non-Temporal
+  default-lane failures, including the 364-row #5304 pattern.


### PR DESCRIPTION
Harvest of both test262 lanes from `loopdive/js2wasm-baselines` @ `998a110a`
(run `20260903-155044`, = main `986bbf77`). Docs-only: no `src/`, `tests/`,
`scripts/`, `.github/` or `benchmarks/` changes.

| Lane | Official total | pass | rate |
| --- | ---: | ---: | ---: |
| Default (JS-host) | 48,232 | 35,495 | 73.6 % |
| Standalone | 48,232 | 34,598 | 71.7 % |

## Scope correction — Temporal now counts

[#5173](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5173-runner-temporal-proposal-scope)
removed the `built-ins/Temporal/` → `proposal` rule from `classifyTestScope`
because Temporal shipped in **ECMA-262 17th edition (ES2026, approved
2026-06-30)**. Temporal rows now classify `scope: standard` /
`scope_official: true`.

Measured: **4,611 Temporal rows in official scope, 4,017 failing — 31.6 % of
all default-lane official failures**, the single largest addressable bucket.

The `/harvest-errors` skill doc still states Temporal is `official: false`,
excluded by design, and that we should not file issues for it. That guidance is
stale and actively misleading; this PR records the correction in the harvest log
since the skill file lives outside the repo. Temporal itself is **not** unowned —
it is the active #4628 → #5169/#5191–#5251 campaign.

## New issues

- **#5304** — `yield*` protocol errors reject with a TypeError whose
  `.constructor` is an anonymous native function rather than the `%TypeError%`
  intrinsic. **364** default-lane rows. The surrounding semantics already pass
  (rejection timing and kind are correct); only error-object identity is wrong.
  Distinct from #1691 / PR #5063, which is about `throw()`/`return()` delegation.
- **#5305** — standalone: a class's static method is callable (`C.m() === 42`)
  but is not an own property of the class object, so `verifyProperty(C, "m", …)`
  fails at its `hasOwnProperty` check. **218** standalone rows, **0** in the
  default lane.

## Regression / growth flags on existing issues

- **#1524** is `status: done`, but **239 rows still fail**. The symptom migrated:
  `ctors is not defined` is now **0**, replaced by `No dependency provided for
  extern class "ctor"` at **239**, on the same resizable-ArrayBuffer tests.
  Reopen candidate. The same family is also the top standalone `illegal cast`
  bucket (244 rows), so it is a cross-lane cluster.
- **#3601** grew from **144** (2026-07-24) to **173** (+29). Still false FAILs
  from the CI-absolute fixture path baked into the runtime bundle.

Method note recorded in the log: do **not** extract `#NNNN` citations from the
default lane unfiltered — Wasm validation errors embed function indices
(`Compiling function #104:"__closure_33"`) that a naive regex reads as issue
citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)