### PR TITLE
fix(#5299): prepared-callable rows carry their (1, 0, 1) receipt triple ✓

### DIFF
--- a/plan/issues/5299-prepared-callable-rows-missing-receipt-triple.md
+++ b/plan/issues/5299-prepared-callable-rows-missing-receipt-triple.md
@@ -285,6 +285,24 @@ Both budget gates pass **without a grant**: `check-loc-budget` reports net
 `check-func-budget` reports no unallowed growth on either base. No
 `loc-budget-allow:` entry is therefore needed or added.
 
+### Validation, re-run after merging `origin/main` at `744203f3c7`
+
+Every number above was re-measured on the merged tree; none moved. In addition:
+
+- **Equivalence**, 8 shards, `EQUIVALENCE_FORK_HEAP_MB=4096`: 24 failing /
+  1,718 passing, all 24 in `scripts/equivalence-baseline.json` — zero new
+  regressions on every shard.
+- **62 `issue-3520-*` suites**, base vs branch, run in three chunks: failing-name
+  sets **identical** (11 failures, all pre-existing on merged main).
+- `issue-3525-*` (4 files), `issue-3519-*` (2), `issue-5262`, `issue-5283`,
+  `issue-5300`, `issue-5297`: failing-name sets identical — the two known
+  `#3525 M2 prepared multi-source module-init` reds are unchanged, everything
+  else green.
+- Ratchet chain green on both bases (`merge-base(origin)` and
+  `LOC_GATE_BASE=origin/main`); every `quality` gate green, including
+  `check:harness-compile-budget` at measured 150,774 / ceiling 150,803 — **29
+  units of margin**, unchanged by this PR.
+
 ### Open, deliberately not done
 
 `PreparedIrEmissionLedgerEntry` (`src/ir/program.ts:167`) carries the same

--- a/plan/issues/5299-prepared-callable-rows-missing-receipt-triple.md
+++ b/plan/issues/5299-prepared-callable-rows-missing-receipt-triple.md
@@ -1,10 +1,12 @@
 ---
 id: 5299
 title: "Published prepared-callable outcome rows carry NO (prepareAttempts, directBodyEmissions, irBodyEmissions) triple — absent, not zero — so every R9 ratio over the R2 population silently omits them"
-status: ready
+status: done
 sprint: current
 created: 2026-09-03
 updated: 2026-09-03
+completed: 2026-09-03
+assignee: ttraenkler/opus-5299
 priority: high
 horizon: s
 feasibility: medium
@@ -190,3 +192,101 @@ onto it), #5297 (`prepared-component-sealing.ts`, `prepared-dynamic-support.ts`,
 `compiler-timer-shim-preparation.ts`), #3520 W1-D (`program-abi-*.ts`),
 #3522 W1-A (`select.ts` class arms, `class-bodies.ts`). Branch after #5283
 lands if it touches `legacy-body-audit.ts`'s index shape; otherwise now.
+
+## Implementation notes (2026-09-03, ttraenkler/opus-5299)
+
+Implemented as planned. Three deviations, each forced by a measurement.
+
+### 1. The 34-case corpus contains ZERO rows from this publication path
+
+Acceptance criterion 1 assumed the dogfood/ratchet corpus would show a
+non-zero N for this row set. It does not, and the plan's own construction
+explains why: `MultiPreparedCallablePublication` only ever stages **cross-source
+`top-level-function` terminals**, and all 34 corpus cases are compiled
+single-source through `compile()`.
+
+Measured on `origin/main` (`986bbf7705`) with a probe over the exact 34 cases,
+both lanes:
+
+| | gc | standalone |
+| --- | --- | --- |
+| outcome rows | 105 | 105 |
+| rows with a `preparedComponentId` | 48 | 45 |
+| of those, **absent triple** | **13** | **13** |
+| of the 13, built by `multi-prepared-callable-publication.ts` | **0** | **0** |
+
+The 13 are 10 `class-member` rows (`classes.ts`), 2 `module-init` rows
+(`calendar.ts`, `algorithms.ts`) and 1 derived timer-shim `setTimeout` row
+(`async.ts`) — R3/R4 populations that the R2 reconciler does not cover and that
+this slice deliberately does not touch. **They are unchanged after the fix**
+(13 → 13, both lanes), which is the correct outcome, not a miss: fabricating a
+triple for a population whose counters nothing measures is the exact defect
+this issue exists to remove. They are the natural follow-up for the R9
+denominator work.
+
+So the affected population needed its own corpus (below), and the corpus sweep
+served only as the byte-identity and no-collateral check.
+
+### 2. The affected population is standalone-only
+
+Measured across seven `compileMulti` option lanes on the same cross-source
+program: `gc/default`, `gc/experimentalIR`, `gc/experimentalIR+nativeStrings`,
+`gc/nativeStrings` and `wasi/default` all produce **0** prepared-callable rows;
+only `standalone/default` and `standalone/experimentalIR+nativeStrings` reach
+the route (2 rows each). Every measurement of the fixed population is therefore
+standalone; the gc lane is reported as a byte-identity control.
+
+Eight-program prepared corpus (multi-source, both lanes, 16 compiles):
+
+| | base | branch |
+| --- | --- | --- |
+| prepared rows | 22 | 22 |
+| absent triple | **21** | **0** |
+| exact `(1, 0, 1)` | 1 | **22** |
+| sha256 of the binary, per case | — | **16/16 identical** |
+
+The one row already exact on base comes from the overlay reconciler
+(`ir-overlay-outcomes.ts`), not from this publication — it is the control that
+shows the two producers now agree.
+
+### 3. A row states no counters when the direct-body ledger does not exist
+
+`ctx.irBodyRouteAuditSession` requires `trackIrOutcomes` **and** an
+`irCutoverRoute` (`context/body-route-audit.ts:29`). Every production entry
+point supplies one (`compiler.ts:838` defaults it to `compileSourceSync`), but
+a direct `generateMultiModule(ast, { trackIrOutcomes: true })` call does not —
+and that spelling is used by existing `issue-3525` tests.
+
+Failing closed there would break a public entry point; writing
+`directBodyEmissions: 0` would be an unmeasured claim of exactly the kind this
+issue removes. So the row keeps its pre-#5299 booleans and states **no**
+counters, which `hasMalformedBodyEmissionAccounting` already treats as
+well-formed. A pinned test covers this boundary so a later change cannot
+quietly start guessing zeros.
+
+### Ordering, and why the reorder is load-bearing
+
+`prepareCommit` now claims the component tokens **before** building the rows.
+Reverting only that reorder (rows built first, `tokens` still empty) makes every
+prepared unit read 0 own-body patches, the fail-closed arm fires, and the whole
+compile errors — 3 of the 8 new tests go red, including the end-to-end one.
+The counts genuinely are unavailable at the old construction point.
+
+Abort semantics are unchanged: nothing between the token loop and the row build
+writes, so a rejected row still reaches the owner's `publication.abort()` with
+every receipt claimed-but-unpublished — the same state a failing `take` already
+produced. A pinned test asserts that abort still succeeds after a post-claim
+rejection.
+
+### Budgets
+
+Both budget gates pass **without a grant**: `check-loc-budget` reports net
++130 LOC against `merge-base(origin)` and net −86 against `origin/main`, and
+`check-func-budget` reports no unallowed growth on either base. No
+`loc-budget-allow:` entry is therefore needed or added.
+
+### Open, deliberately not done
+
+`PreparedIrEmissionLedgerEntry` (`src/ir/program.ts:167`) carries the same
+triple for the #3525 owner lifecycle and is still not wired to this path.
+Unifying the two is R5 M1B, not this slice.

--- a/src/codegen/multi-prepared-callable-publication.ts
+++ b/src/codegen/multi-prepared-callable-publication.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { IrSourceId, IrTerminalUnitRecord, IrUnitId } from "../ir/identity.js";
-import type { IrObservedOutcome } from "../ir/outcomes.js";
+import { hasMalformedBodyEmissionAccounting, type IrObservedOutcome } from "../ir/outcomes.js";
 import {
   takePendingPreparedProgramComponentReceipt,
   type PendingPreparedProgramComponentReceipt,
@@ -9,6 +9,7 @@ import {
 } from "../ir/prepared-component-publication.js";
 import type { ts } from "../ts-api.js";
 import type { CodegenContext } from "./context/types.js";
+import type { IrDirectFunctionBodyReceiptAudit } from "./legacy-body-audit.js";
 import type { PreparedComponentPendingScope } from "./multi-source-ir-integration.js";
 
 type SourceFile = ts.SourceFile;
@@ -105,6 +106,21 @@ function sameSet<T>(actual: ReadonlySet<T>, expected: ReadonlySet<T>): boolean {
 
 function publicationError(detail: string): Error {
   return new Error(`multi-prepared callable publication: ${detail}`);
+}
+
+/**
+ * (#5299) The body-emission evidence a published prepared row carries.
+ *
+ * The counters are optional in exactly one situation, spelled out on
+ * `#bodyEmissionAccounting`: the direct-body receipt ledger was never
+ * allocated, so there is nothing to reconcile the IR patch count against.
+ */
+interface PreparedRowBodyEmissionAccounting {
+  readonly legacyBodyEmitted: boolean;
+  readonly irBodyEmitted: boolean;
+  readonly prepareAttempts?: number;
+  readonly directBodyEmissions?: number;
+  readonly irBodyEmissions?: number;
 }
 
 function serializeOutcome(outcome: IrObservedOutcome): string {
@@ -306,49 +322,6 @@ export class MultiPreparedCallablePublication<BodyPlan extends object> {
     this.#assertPreflightCurrent();
     this.#assertContextPrefixes();
 
-    const existingUnitIds = new Set(
-      this.#outcomePrefix.flatMap((outcome) => (outcome.unitId === undefined ? [] : [outcome.unitId])),
-    );
-    const existingKeys = new Set(this.#outcomePrefix.map(({ key }) => key));
-    if (publicationMutation() === "existing-outcome") {
-      existingUnitIds.add(this.#components[0]!.units[0]!.unitId);
-    }
-    const target: IrObservedOutcome["target"] = this.#ctx.wasi ? "wasi" : this.#ctx.standalone ? "standalone" : "gc";
-    const finalOutcomes =
-      this.#outcomePrefixObject === undefined
-        ? undefined
-        : [
-            ...this.#outcomePrefix,
-            ...this.#components.flatMap((component) =>
-              component.units.map((unit): IrObservedOutcome => {
-                const terminal = this.#terminalByUnitId.get(unit.unitId)!;
-                if (existingUnitIds.has(unit.unitId) || existingKeys.has(terminal.legacyKey)) {
-                  throw publicationError(`terminal outcome prefix already owns ${unit.unitId}`);
-                }
-                existingUnitIds.add(unit.unitId);
-                existingKeys.add(terminal.legacyKey);
-                return Object.freeze({
-                  key: terminal.legacyKey,
-                  sourceId: terminal.sourceId,
-                  unitId: terminal.id,
-                  file: unit.sourceFile.fileName,
-                  unitKind: terminal.observedKind,
-                  displayName: terminal.displayName,
-                  ordinal: terminal.legacyOrdinal,
-                  line: terminal.line,
-                  column: terminal.column,
-                  backend: "wasmgc",
-                  target,
-                  legacyBodyEmitted: false,
-                  irBodyEmitted: true,
-                  preparedComponentId: component.preparedComponentId,
-                  kind: "emitted",
-                  stage: "patch",
-                });
-              }),
-            ),
-          ];
-
     const tokens: PreparedComponentPublicationToken[] = [];
     try {
       const staleScopeMutation = publicationMutation();
@@ -388,6 +361,15 @@ export class MultiPreparedCallablePublication<BodyPlan extends object> {
       }
       throw error;
     }
+
+    // (#5299) The rows are built only now, from the CLAIMED tokens. Before the
+    // claim this transaction holds no patch count to cite, which is exactly why
+    // the rows used to carry no
+    // `(prepareAttempts, directBodyEmissions, irBodyEmissions)` triple and
+    // dropped out of every R9 ratio. Nothing between here and the token loop
+    // writes, so a rejection still reaches the owner's `abort()` with every
+    // receipt claimed-but-unpublished, as a failing take already did.
+    const finalOutcomes = this.#buildFinalOutcomes(tokens);
 
     const skippedUnitIds = new Set<IrUnitId>();
     for (const unitIds of this.#skippedUnitIdsBySourceFile.values()) {
@@ -438,6 +420,123 @@ export class MultiPreparedCallablePublication<BodyPlan extends object> {
       }
     }
     this.#state = "aborted";
+  }
+
+  /** Build the terminal rows from the claimed tokens; no value here writes. */
+  #buildFinalOutcomes(tokens: readonly PreparedComponentPublicationToken[]): IrObservedOutcome[] | undefined {
+    if (this.#outcomePrefixObject === undefined) return undefined;
+    const existingUnitIds = new Set(
+      this.#outcomePrefix.flatMap((outcome) => (outcome.unitId === undefined ? [] : [outcome.unitId])),
+    );
+    const existingKeys = new Set(this.#outcomePrefix.map(({ key }) => key));
+    if (publicationMutation() === "existing-outcome") {
+      existingUnitIds.add(this.#components[0]!.units[0]!.unitId);
+    }
+    const target: IrObservedOutcome["target"] = this.#ctx.wasi ? "wasi" : this.#ctx.standalone ? "standalone" : "gc";
+    // One claim per component, counted rather than assumed: the constructor
+    // already rejects a repeated component id, so anything but `1` here is a
+    // broken claim loop and `hasMalformedBodyEmissionAccounting` rejects it.
+    const claimsByComponentId = new Map<string, number>();
+    const patchCountsByComponentId = new Map<string, ReadonlyMap<IrUnitId, number>>();
+    for (const token of tokens) {
+      const claimed = claimsByComponentId.get(token.preparedComponentId) ?? 0;
+      claimsByComponentId.set(token.preparedComponentId, claimed + 1);
+      patchCountsByComponentId.set(token.preparedComponentId, token.irPatchCountByUnitId);
+    }
+    const directAudits = new Map<SourceFile, IrDirectFunctionBodyReceiptAudit>();
+    return [
+      ...this.#outcomePrefix,
+      ...this.#components.flatMap((component) =>
+        component.units.map((unit): IrObservedOutcome => {
+          const terminal = this.#terminalByUnitId.get(unit.unitId)!;
+          if (existingUnitIds.has(unit.unitId) || existingKeys.has(terminal.legacyKey)) {
+            throw publicationError(`terminal outcome prefix already owns ${unit.unitId}`);
+          }
+          existingUnitIds.add(unit.unitId);
+          existingKeys.add(terminal.legacyKey);
+          const outcome: IrObservedOutcome = Object.freeze({
+            key: terminal.legacyKey,
+            sourceId: terminal.sourceId,
+            unitId: terminal.id,
+            file: unit.sourceFile.fileName,
+            unitKind: terminal.observedKind,
+            displayName: terminal.displayName,
+            ordinal: terminal.legacyOrdinal,
+            line: terminal.line,
+            column: terminal.column,
+            backend: "wasmgc",
+            target,
+            ...this.#bodyEmissionAccounting(
+              unit,
+              claimsByComponentId.get(component.preparedComponentId) ?? 0,
+              patchCountsByComponentId.get(component.preparedComponentId)?.get(unit.unitId) ?? 0,
+              directAudits,
+            ),
+            preparedComponentId: component.preparedComponentId,
+            kind: "emitted",
+            stage: "patch",
+          });
+          if (hasMalformedBodyEmissionAccounting(outcome)) {
+            throw publicationError(`prepared terminal ${unit.unitId} has malformed body-emission accounting`);
+          }
+          return outcome;
+        }),
+      ),
+    ];
+  }
+
+  /**
+   * (#5299) Exact body evidence for one prepared terminal.
+   *
+   * `directBodyEmissions` comes from the physical direct-body receipt ledger —
+   * the same `countsByUnitId` index the R2 reconciler reads — and MUST be zero:
+   * this transaction publishes an IR body for a unit whose direct body it made
+   * every source skip, so a direct receipt means both emitters ran and the row
+   * would be claiming sole IR ownership of a body the direct compiler also
+   * wrote. That fails closed rather than publishing.
+   *
+   * When the ledger was never allocated (`trackIrOutcomes` without an
+   * `irCutoverRoute`, reachable only by calling `generateMultiModule`
+   * directly) the row keeps the pre-#5299 booleans and states no counters.
+   * `directBodyEmissions: 0` would be an unmeasured claim of exactly the kind
+   * this row set exists to stop making, and `hasMalformedBodyEmissionAccounting`
+   * deliberately treats a wholly absent triple as well-formed.
+   */
+  #bodyEmissionAccounting(
+    unit: MultiPreparedProgramCallableUnit,
+    prepareAttempts: number,
+    irBodyEmissions: number,
+    directAudits: Map<SourceFile, IrDirectFunctionBodyReceiptAudit>,
+  ): PreparedRowBodyEmissionAccounting {
+    const session = this.#ctx.irBodyRouteAuditSession;
+    if (!session) return { legacyBodyEmitted: false, irBodyEmitted: true };
+    let audit = directAudits.get(unit.sourceFile);
+    if (!audit) {
+      audit = session.directFunctionBodyReceiptAudit(unit.sourceFile);
+      directAudits.set(unit.sourceFile, audit);
+    }
+    const directBodyEmissions = audit.countsByUnitId.get(unit.unitId) ?? 0;
+    // Derive first, then reject: the booleans stay the counters' projection
+    // (as in `reconcileR2FunctionBodyEmissionAccounting`) instead of literals
+    // that a later guard happens to agree with.
+    const accounting: PreparedRowBodyEmissionAccounting = {
+      legacyBodyEmitted: directBodyEmissions === 1,
+      irBodyEmitted: irBodyEmissions === 1,
+      prepareAttempts,
+      directBodyEmissions,
+      irBodyEmissions,
+    };
+    if (accounting.legacyBodyEmitted || directBodyEmissions !== 0) {
+      throw publicationError(
+        `prepared terminal ${unit.unitId} recorded ${directBodyEmissions} direct body receipts after an exact skip`,
+      );
+    }
+    if (!accounting.irBodyEmitted) {
+      throw publicationError(
+        `prepared terminal ${unit.unitId} claims emission with ${irBodyEmissions} exact IR body patches`,
+      );
+    }
+    return accounting;
   }
 
   #assertContextPrefixes(): void {

--- a/src/ir/outcomes.ts
+++ b/src/ir/outcomes.ts
@@ -350,8 +350,17 @@ export interface IrOutcomePolicyVerdict {
   readonly blockers: readonly IrObservedOutcome[];
 }
 
-/** Reject partial, impossible, or boolean-inconsistent exact body accounting. */
-function hasMalformedBodyEmissionAccounting(outcome: IrObservedOutcome): boolean {
+/**
+ * Reject partial, impossible, or boolean-inconsistent exact body accounting.
+ *
+ * (#5299) Exported so a producer can reject a malformed triple at the point it
+ * builds the row, instead of publishing it and letting the policy pass report
+ * it as a blocker one whole compile later. An absent triple is deliberately
+ * still well-formed here: a row whose emitter cannot measure the counters
+ * states nothing rather than guessing, and the R9 denominator work tracks that
+ * omission separately.
+ */
+export function hasMalformedBodyEmissionAccounting(outcome: IrObservedOutcome): boolean {
   const values = [outcome.prepareAttempts, outcome.directBodyEmissions, outcome.irBodyEmissions];
   if (values.every((value) => value === undefined)) return false;
   if (values.some((value) => value === undefined)) return true;

--- a/src/ir/prepared-component-publication.ts
+++ b/src/ir/prepared-component-publication.ts
@@ -78,6 +78,21 @@ export interface PreparedComponentPublicationToken<Entry = unknown> {
   readonly preparedComponentId: string;
   readonly terminalUnitIds: readonly IrUnitId[];
   readonly pendingScope: PreparedComponentPendingScope;
+  /**
+   * (#5299) Exact own-body patch count per terminal, snapshotted at claim time
+   * so an owner can state `irBodyEmissions` from the bodies this token is
+   * about to publish rather than from a name or selector projection.
+   *
+   * Only patches whose artifact IS the terminal (`artifactUnitId ===
+   * terminalOwnerUnitId`) count — the same restriction `buildIrIntegrationReport`
+   * uses to mint `kind: "patched"` terminal evidence, so a lifted helper
+   * artifact belonging to the terminal never inflates its body count past one.
+   *
+   * The snapshot is taken here, not exposed as a live view, because
+   * `publishBodies()` empties the queue: a count read afterwards would be zero
+   * for every unit whose body was in fact published.
+   */
+  readonly irPatchCountByUnitId: ReadonlyMap<IrUnitId, number>;
   readonly publishBodies: () => void;
 }
 
@@ -297,11 +312,18 @@ export function takePendingPreparedProgramComponentReceipt<Entry>(
       throw error;
     }
   }
+  const irPatchCountByUnitId = new Map<IrUnitId, number>();
+  for (const patch of state.publicationPatches) {
+    if (patch.artifactUnitId !== patch.terminalOwnerUnitId) continue;
+    const owner = patch.terminalOwnerUnitId;
+    irPatchCountByUnitId.set(owner, (irPatchCountByUnitId.get(owner) ?? 0) + 1);
+  }
   state.state = "claimed";
   return Object.freeze({
     preparedComponentId: state.draft.preparedComponentId,
     terminalUnitIds: state.draft.terminalUnitIds,
     pendingScope,
+    irPatchCountByUnitId,
     publishBodies: () => {
       // This function is intentionally only the detached body assignment
       // phase.  Every identity/type/currentness check belongs before the

--- a/tests/issue-5299-prepared-callable-receipt-triple.test.ts
+++ b/tests/issue-5299-prepared-callable-receipt-triple.test.ts
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #5299 — a published prepared-callable row must CARRY its
+ * `(prepareAttempts, directBodyEmissions, irBodyEmissions)` triple.
+ *
+ * Before this slice the rows built by `MultiPreparedCallablePublication`
+ * carried none of the three fields. `hasMalformedBodyEmissionAccounting`
+ * treats a wholly absent triple as well-formed, so the rows passed every
+ * invariant and then dropped out of every ratio computed over the R2
+ * population — the R9 denominator problem, on the population most certain to
+ * be IR-emitted.
+ *
+ * Two things are worth knowing about the shape of this file:
+ *
+ * 1. The affected population is **multi-source and standalone-only**. Measured
+ *    2026-09-03 across seven option lanes: `compileMulti` reaches the prepared
+ *    callable route under `target: "standalone"` and under no gc or wasi
+ *    spelling, and single-source `compile()` never reaches it at all (the
+ *    publication only ever stages cross-source `top-level-function` terminals).
+ *    That is why the end-to-end arm below is a `compileMulti` standalone case
+ *    and not a corpus sweep.
+ * 2. There is **no `JS2WASM_TEST_*` poison that forces a direct body receipt
+ *    for a prepared unit** — the direct census is recorded by physically
+ *    entering `compileFunctionBody`, which a prepared unit is skipped out of by
+ *    construction, and `JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY` proves the
+ *    opposite property (it THROWS if the direct route is entered). The
+ *    fail-closed arms therefore drive the transaction directly and inject the
+ *    receipt through `ctx.irBodyRouteAuditSession`, which is the exact field
+ *    the production path reads.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { analyzeMultiSource } from "../src/checker/index.js";
+import type { CodegenContext } from "../src/codegen/context/types.js";
+import type { IrDirectFunctionBodyReceiptAudit } from "../src/codegen/legacy-body-audit.js";
+import {
+  MultiPreparedCallablePublication,
+  type MultiPreparedProgramCallableComponent,
+} from "../src/codegen/multi-prepared-callable-publication.js";
+import { compileMulti } from "../src/index.js";
+import { buildIrUnitInventory, type IrUnitId } from "../src/ir/identity.js";
+import type { IrIntegrationReport } from "../src/ir/integration-report.js";
+import type { IrObservedOutcome } from "../src/ir/outcomes.js";
+import { buildIrPlanningIdentityContext } from "../src/ir/planning-identity.js";
+import { createPendingPreparedProgramComponentReceipt } from "../src/ir/prepared-component-publication.js";
+import type { WasmFunction } from "../src/ir/types.js";
+import { ts } from "../src/ts-api.js";
+
+const CROSS_SOURCE_FILES = {
+  "./dep.ts": `
+    export function add(left: number, right: number): number {
+      return left + right;
+    }
+  `,
+  "./entry.ts": `
+    import { add as plus } from "./dep";
+    export function run(value: number): number {
+      return plus(value, 2);
+    }
+  `,
+};
+
+const STANDALONE_OPTIONS = {
+  experimentalIR: true,
+  nativeStrings: true,
+  target: "standalone" as const,
+  trackIrOutcomes: true,
+};
+
+function preparedRows(outcomes: readonly IrObservedOutcome[] | undefined): readonly IrObservedOutcome[] {
+  return (outcomes ?? []).filter((outcome) => outcome.preparedComponentId !== undefined);
+}
+
+/** One source, one terminal, one component: the smallest publishable transaction. */
+function stageSingleTerminalPublication(input: {
+  readonly directBodyReceipts: number;
+  readonly ownBodyPatches: number;
+  readonly withAuditSession: boolean;
+}): {
+  readonly publication: MultiPreparedCallablePublication<Record<string, never>>;
+  readonly ctx: CodegenContext;
+  readonly unitId: IrUnitId;
+} {
+  const ast = analyzeMultiSource(CROSS_SOURCE_FILES, "./entry.ts");
+  const identity = buildIrPlanningIdentityContext(
+    buildIrUnitInventory(ast.sourceFiles, { checker: ast.checker, entrySource: ast.entryFile }),
+  );
+  const sourceFile = ast.sourceFiles.find((candidate) => candidate.fileName.endsWith("dep.ts"))!;
+  const declaration = sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === "add",
+  )!;
+  const unitId = identity.unitIdByDeclaration.get(declaration)! as IrUnitId;
+  const sourceId = identity.sourceIdBySourceFile.get(sourceFile)!;
+  const preparedComponentId = "prepared-component:issue-5299";
+  const existing: WasmFunction = { name: "add", typeIdx: 0, locals: [], body: [], exported: false };
+  const replacement: WasmFunction = { name: "add", typeIdx: 0, locals: [], body: [], exported: false };
+  const receipt = createPendingPreparedProgramComponentReceipt({
+    preparedComponentId,
+    terminalUnitIds: [unitId],
+    report: { compiled: [], errors: [] } satisfies IrIntegrationReport,
+    patches: Array.from({ length: input.ownBodyPatches }, () => ({
+      entry: {},
+      artifactUnitId: unitId,
+      terminalOwnerUnitId: unitId,
+      funcIdx: 0,
+      existing,
+      replacement,
+      finalBody: [],
+    })),
+    assertCurrent: () => {},
+    prepareSeal: () => ({
+      kind: "prepared-program-abi-pending-scope" as const,
+      scopeId: preparedComponentId,
+      terminalUnitIds: [unitId],
+    }),
+    scopePublicationState: () => "prepared" as const,
+    abortScope: () => {},
+  });
+  const component: MultiPreparedProgramCallableComponent = {
+    preparedComponentId,
+    units: [{ sourceFile, sourceId, unitId, legacyName: "add", declaration }],
+    pendingReceipt: receipt,
+    assertPreflightCurrent: () => {},
+  };
+  const audit: IrDirectFunctionBodyReceiptAudit = Object.freeze({
+    sourceId,
+    countsByUnitId: new Map(input.directBodyReceipts === 0 ? [] : [[unitId, input.directBodyReceipts]]),
+    violations: [],
+    physicalRootUnitIds: new Set<IrUnitId>(),
+  });
+  const ctx = {
+    irCompiledFuncs: [],
+    irOutcomes: [],
+    irProgramCallablePreparedUnitIds: undefined,
+    standalone: true,
+    wasi: false,
+    ...(input.withAuditSession ? { irBodyRouteAuditSession: { directFunctionBodyReceiptAudit: () => audit } } : {}),
+  } as unknown as CodegenContext;
+  const publication = new MultiPreparedCallablePublication<Record<string, never>>({
+    ctx,
+    sourceFiles: [sourceFile],
+    terminalByUnitId: identity.terminalByUnitId,
+    components: [component],
+  });
+  publication.sealBodyBoundary({});
+  publication.recordSkippedUnitIds(sourceFile, [unitId]);
+  return { publication, ctx, unitId };
+}
+
+describe("#5299 prepared-callable rows carry the receipt triple", () => {
+  it("publishes (1, 0, 1) on every prepared row of a cross-source standalone program", async () => {
+    const result = await compileMulti(CROSS_SOURCE_FILES, "./entry.ts", STANDALONE_OPTIONS);
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    const rows = preparedRows(result.irOutcomes);
+    // Anti-vacuity: the assertions below say nothing if the route never ran.
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(
+        {
+          unitId: row.unitId,
+          prepareAttempts: row.prepareAttempts,
+          directBodyEmissions: row.directBodyEmissions,
+          irBodyEmissions: row.irBodyEmissions,
+          legacyBodyEmitted: row.legacyBodyEmitted,
+          irBodyEmitted: row.irBodyEmitted,
+        },
+        `prepared row ${row.unitId} must carry an exact (1, 0, 1) triple`,
+      ).toEqual({
+        unitId: row.unitId,
+        prepareAttempts: 1,
+        directBodyEmissions: 0,
+        irBodyEmissions: 1,
+        // The booleans are the counters' projection, not independent literals.
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+    }
+  }, 120_000);
+
+  it("keeps the row identity and kind it published before the triple existed", async () => {
+    const result = await compileMulti(CROSS_SOURCE_FILES, "./entry.ts", STANDALONE_OPTIONS);
+
+    const rows = preparedRows(result.irOutcomes);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((row) => row.kind === "emitted" && row.stage === "patch" && row.backend === "wasmgc")).toBe(true);
+    expect(rows.every((row) => row.target === "standalone" && row.unitKind === "function")).toBe(true);
+  }, 120_000);
+
+  it("derives the triple from the claimed token and the direct receipt ledger", () => {
+    const { publication, unitId } = stageSingleTerminalPublication({
+      directBodyReceipts: 0,
+      ownBodyPatches: 1,
+      withAuditSession: true,
+    });
+
+    const prepared = publication.prepareCommit();
+
+    expect(prepared.finalOutcomes).toEqual([
+      expect.objectContaining({
+        unitId,
+        prepareAttempts: 1,
+        directBodyEmissions: 0,
+        irBodyEmissions: 1,
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      }),
+    ]);
+  });
+
+  it("fails closed, publishing nothing, when a prepared unit also has a direct body receipt", () => {
+    const { publication, ctx, unitId } = stageSingleTerminalPublication({
+      directBodyReceipts: 1,
+      ownBodyPatches: 1,
+      withAuditSession: true,
+    });
+
+    expect(() => publication.prepareCommit()).toThrow(
+      new RegExp(`${unitId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} recorded 1 direct body receipts`),
+    );
+    expect(ctx.irOutcomes).toEqual([]);
+    expect(ctx.irCompiledFuncs).toEqual([]);
+    expect(ctx.irProgramCallablePreparedUnitIds).toBeUndefined();
+  });
+
+  it("fails closed when the claimed token holds no own-body patch for the terminal", () => {
+    const { publication, ctx } = stageSingleTerminalPublication({
+      directBodyReceipts: 0,
+      ownBodyPatches: 0,
+      withAuditSession: true,
+    });
+
+    expect(() => publication.prepareCommit()).toThrow(/claims emission with 0 exact IR body patches/);
+    expect(ctx.irOutcomes).toEqual([]);
+  });
+
+  it("states no counters at all when the direct-body receipt ledger was never allocated", () => {
+    // The deliberate boundary: no ledger means no measurement, and a fabricated
+    // `directBodyEmissions: 0` would be exactly the unmeasured claim this row
+    // set exists to stop making. A future change that guesses zeros here — or
+    // that starts publishing a partial triple — turns this red.
+    const { publication } = stageSingleTerminalPublication({
+      directBodyReceipts: 0,
+      ownBodyPatches: 1,
+      withAuditSession: false,
+    });
+
+    const row = publication.prepareCommit().finalOutcomes?.[0];
+
+    expect(row?.legacyBodyEmitted).toBe(false);
+    expect(row?.irBodyEmitted).toBe(true);
+    expect(row?.prepareAttempts).toBeUndefined();
+    expect(row?.directBodyEmissions).toBeUndefined();
+    expect(row?.irBodyEmissions).toBeUndefined();
+  });
+
+  it("still aborts every receipt when a row is rejected after the tokens are claimed", () => {
+    const { publication, ctx } = stageSingleTerminalPublication({
+      directBodyReceipts: 1,
+      ownBodyPatches: 1,
+      withAuditSession: true,
+    });
+    // The rows are now built AFTER the token loop, so this is the ordering the
+    // reorder had to preserve: a rejection there must still leave the owner a
+    // transaction it can abort, exactly as a failing take already did.
+    expect(() => publication.prepareCommit()).toThrow(/direct body receipts/);
+
+    expect(() => publication.abort()).not.toThrow();
+    expect(ctx.irOutcomes).toEqual([]);
+  });
+
+  it("publishes no callable prefix when the outcome prefix already owns a prepared unit", () => {
+    const { publication, ctx } = stageSingleTerminalPublication({
+      directBodyReceipts: 0,
+      ownBodyPatches: 1,
+      withAuditSession: true,
+    });
+    vi.stubEnv("JS2WASM_TEST_MUTATE_MULTI_PREPARED_CALLABLE_PUBLICATION", "existing-outcome");
+
+    expect(() => publication.prepareCommit()).toThrow(/terminal outcome prefix already owns/);
+    expect(ctx.irOutcomes).toEqual([]);
+    vi.unstubAllEnvs();
+  });
+});


### PR DESCRIPTION
Closes [#5299](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5299-prepared-callable-rows-missing-receipt-triple).

## What was wrong

The outcome rows published by `src/codegen/multi-prepared-callable-publication.ts`
for cross-source prepared callables carried **no** `prepareAttempts`,
`directBodyEmissions` or `irBodyEmissions` fields — absent, not zero.
`hasMalformedBodyEmissionAccounting` treats a wholly absent triple as
well-formed, so those rows passed every invariant and then **dropped out of
every ratio computed over the R2 population**. That is the R9 denominator
problem from [#3518](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3518-ir-only-default-and-direct-frontend-retirement),
landing on the population most certain to be IR-emitted. Flagged in
[#5263](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5263-multi-prepared-callables-zero-direct-body-receipts)'s
plan and confirmed by measurement in its implementation.

## Why the rows were empty — and why the fix is a reorder

The rows were built **before** the component tokens were claimed. At that point
the transaction holds no patch count to cite, so there was nothing truthful to
put in the triple. `prepareCommit` now claims the tokens first and builds the
rows from them.

That ordering is load-bearing, not cosmetic. Reverting **only** the reorder
(rows built first, `tokens` still empty) makes every prepared unit read zero
own-body patches, the fail-closed arm fires, and the whole compile errors —
3 of the 8 new tests go red, including the end-to-end one.

Abort semantics are unchanged: nothing between the token loop and the row build
writes, so a rejected row still reaches the owner's `publication.abort()` with
every receipt claimed-but-unpublished — the same state a failing `take` already
produced. A pinned test asserts abort still succeeds after a post-claim
rejection.

## How each counter is derived (none is hard-coded)

| counter | source | fail-closed rule |
| --- | --- | --- |
| `prepareAttempts` | claims counted per component id (the constructor already rejects a repeated id) | anything but `1` is rejected by the accounting checker |
| `irBodyEmissions` | new `irPatchCountByUnitId` snapshot on `PreparedComponentPublicationToken`, counting only patches whose artifact **is** the terminal (`artifactUnitId === terminalOwnerUnitId`) — the same restriction `buildIrIntegrationReport` uses to mint `kind: "patched"` evidence, so a lifted helper cannot push a terminal past one | `!== 1` throws `publicationError` |
| `directBodyEmissions` | the physical direct-body receipt ledger the R2 reconciler already reads (`legacy-body-audit.ts` `countsByUnitId`) | `!== 0` throws — a direct receipt for a unit whose body every source was made to skip means both emitters ran |

`legacyBodyEmitted` / `irBodyEmitted` become the counters' projection rather
than literals, and the finished row is validated with the now-exported
`hasMalformedBodyEmissionAccounting` before it is frozen.

**One deliberate boundary.** When the direct-body ledger was never allocated —
`trackIrOutcomes` without an `irCutoverRoute`, reachable only by calling
`generateMultiModule` directly — the row keeps its previous booleans and states
**no** counters. Writing `directBodyEmissions: 0` there would be an unmeasured
claim of exactly the kind this change removes. A pinned test covers it so a
later change cannot quietly start guessing zeros.

## Measurements

All numbers re-measured on the tree merged with `origin/main` at `744203f3c7`.
The "base" column is that same tree with only the three changed source files
reverted to their `origin/main` contents (file-copy A/B, no `git stash`).

### 1. The 34-case corpus does not contain this row set — measured, not assumed

Acceptance criterion 1 assumed the dogfood/ratchet corpus would show a non-zero
N here. It does not: `MultiPreparedCallablePublication` only ever stages
**cross-source `top-level-function` terminals**, and all 34 cases are compiled
single-source through `compile()`.

| 34-case corpus (20 dogfood + 12 playground + `extern-demo.ts` + `add.ts`) | gc base → branch | standalone base → branch |
| --- | --- | --- |
| outcome rows | 105 → 105 | 105 → 105 |
| rows with a `preparedComponentId` | 48 → 48 | 45 → 45 |
| of those, **absent triple** | **13 → 13** | **13 → 13** |
| of the 13, built by this publication | **0** | **0** |

The 13 are 10 `class-member` rows (`js/classes.ts`), 2 `module-init` rows
(`dom/calendar.ts`, `js/algorithms.ts`) and 1 derived timer-shim `setTimeout`
row (`js/async.ts`) — R3/R4 populations the R2 reconciler does not cover and
this slice deliberately does not touch. Leaving them at 13 is the correct
outcome, not a miss: fabricating counters for a population nothing measures is
the defect being removed. They are the natural follow-up for the R9 denominator
work.

### 2. The affected population — 8 multi-source programs, both lanes

Measured across seven `compileMulti` option lanes: `gc/default`,
`gc/experimentalIR`, `gc/experimentalIR+nativeStrings`, `gc/nativeStrings` and
`wasi/default` produce **0** prepared-callable rows; only
`standalone/default` and `standalone/experimentalIR+nativeStrings` reach the
route. **The route is standalone-only today**, so every measurement of the
fixed population is standalone and the gc lane is a byte-identity control.

Programs: `simple-cross-source`, `same-spelling`, `two-disjoint-components`,
`named-default-alias`, `helper-bearing`, `array-bearing`,
`unanchored-sibling`, `dedicated-route-with-callable` (shapes taken from
`tests/issue-3525-multi-prepared-callable-bindings.test.ts`).

| 8 programs × 2 lanes = 16 compiles | base | branch |
| --- | --- | --- |
| prepared rows | 22 | 22 |
| **absent triple** | **21** | **0** |
| exact `(1, 0, 1)` | 1 | **22** |
| sha256 of the emitted binary | — | **16/16 identical** |

The single row already exact on base comes from the overlay reconciler
(`ir-overlay-outcomes.ts`), not from this publication — it is the control
showing the two producers now agree.

### 3. Byte identity

| corpus | lanes | result |
| --- | --- | --- |
| 34 single-source cases | gc + standalone | **68/68 sha256 identical** |
| 8 multi-source programs | gc + standalone | **16/16 sha256 identical** |

Zero moving rows. This is a publication-only change; no codegen path is touched.

### 4. Gates

| gate | base | branch |
| --- | --- | --- |
| `check:ir-only` | READY — 41 terminal units, 38 emitted, 0 unsupported, 0 invariants, **0 legacy bodies**, 38 IR bodies (both lanes) | **byte-identical output**, READY |
| `check:ir-only -- --policy=hybrid` | — | READY |
| `check:ir-fallbacks` | — | OK, no bucket growth |
| `check:ir-dialect` | — | OK, 27 dialect declarations |
| `check:ir-kind-neutrality` | — | OK (quote-hash baseline untouched) |
| `check:ir-layering` | — | OK, 86 import lines / 15 files, baseline 86 |
| `check:standalone-ir-cutover-corpus` | — | PASS, sources 5/5, units 47/47 |
| `check:harness-compile-budget` | — | measured 150,774 / ceiling 150,803 — **29 units of margin, unchanged by this PR** |
| `check:jstag-seam`, `check:host-import-policy`, `check:pushraw`, `check:stack-balance`, `check:codegen-fallbacks`, `check:any-box-sites`, `check:speculative-rollback`, `check:ir-adoption` | — | all exit 0 |

`check:ir-only` is unaffected because its lanes are single-source, which never
reach this publication — the same reason the 34-case corpus shows no rows from
it.

### 5. Ratchet chain

Run bare (never piped), on both bases:

| gate | `merge-base(origin)` | `LOC_GATE_BASE=origin/main` |
| --- | --- | --- |
| `check-loc-budget` | OK, net **+130** LOC, 3 changed src files | OK, net **+130** LOC |
| `check-func-budget` | OK, no unallowed growth | OK |
| `check-coercion-sites` | OK, no net vocabulary growth | — |
| `check:oracle-ratchet` | OK, `getTypeAtLocation +0`, `ctx.checker +0` | — |
| `check:dead-exports` | OK, 25 known entries, 0 new | — |

Both budget gates pass **without a grant**, so no `loc-budget-allow:` entry was
added and no `scripts/*-baseline.json` was touched.

### 6. Test suites — failing-name-set diff, base vs branch

| suite set | base failures | branch failures | diff |
| --- | --- | --- | --- |
| 62 `issue-3520-*` files (437 tests) | 11 | 11 | **empty** |
| `issue-3525-*` (4 files) | 2 | 2 | **empty** |
| `issue-3519-*`, `issue-5262`, `issue-5283`, `issue-5300`, `issue-5297` | 0 | 0 | **empty** |

The 2 `issue-3525` reds are the known
`#3525 M2 prepared multi-source module-init` pair (`owns the contributor's
exact unit and never enters compileModuleInitBody`, `preserves deferred-host
TDZ timing and one exact startup export`) — already red on `main`. The 11
`issue-3520` reds are likewise pre-existing on merged main (C35
compiler-support, C39 Date provenance, module-init callable, two
lifted-callable planning, monomorphized-callable planning, structural IR
identity, type remapping, type/class-layout planning, two support-callable
planning).

### 7. Equivalence — 8 shards, `EQUIVALENCE_FORK_HEAP_MB=4096`

| shard | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | total |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| failing | 5 | 4 | 3 | 0 | 2 | 7 | 2 | 1 | **24** |
| passing | 181 | 212 | 294 | 166 | 196 | 213 | 271 | 185 | **1,718** |

All 24 are in `scripts/equivalence-baseline.json` (24 known failures);
every shard reports **"No new equivalence regressions"**. Zero name-set diff.

Note: the gate reads `EQUIVALENCE_FORK_HEAP_MB` (default 1024), not
`VITEST_FORK_MAX_OLD_SPACE_SIZE`; shard 7 was SIGKILLed twice at the default
and completed cleanly at 4096.

## Tests

`tests/issue-5299-prepared-callable-receipt-triple.test.ts` — 8 tests,
**5 red on `origin/main`**:

1. every prepared row of a cross-source standalone program carries
   `(1, 0, 1)` and the booleans agree — red on base (fields absent);
2. those rows keep the identity/`kind`/`stage`/`target` they published before —
   green on base, a protective pin;
3. the triple is derived from the claimed token and the direct receipt ledger —
   red on base;
4. fail-closed on a direct body receipt for a prepared unit, publishing nothing —
   red on base (no throw);
5. fail-closed when the claimed token holds no own-body patch — red on base;
6. **no counters at all** when the ledger was never allocated — green on base,
   pins the deliberate boundary against a future change guessing zeros;
7. abort still succeeds after a post-claim rejection — red on base (no throw);
8. the `existing-outcome` mutation still publishes no callable prefix — green on
   base, pins the ordering change against a regression.

**Non-vacuity by revert:** with only the reorder reverted, 3 of the 8 go red
(1, 2, 3) with `claims emission with 0 exact IR body patches` — the counts
genuinely are unavailable at the old construction point.

There is **no `JS2WASM_TEST_*` poison that forces a direct body receipt for a
prepared unit**: the direct census is recorded by physically entering
`compileFunctionBody`, which a prepared unit is skipped out of by construction,
and `JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY` proves the opposite property (it
throws if the direct route is entered). The fail-closed arms therefore drive
the transaction directly and inject the receipt through
`ctx.irBodyRouteAuditSession` — the exact field the production path reads.

## R5 M1B: should this be unified with `PreparedIrEmissionLedgerEntry`?

**Yes, but not here.** `src/ir/program.ts:167` defines
`PreparedIrEmissionLedgerEntry` with the identical triple (`prepareAttempts: 1`,
`directBodyEmissions`, `irBodyEmissions`) for the
[#3525](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3525-ir-r5-whole-program-multi-source-ownership)
owner lifecycle, and it is still not wired to this publication path. There are
now **three** producers of the same triple — that ledger,
`reconcileR2FunctionBodyEmissionAccounting` in `ir-overlay-outcomes.ts`, and
(as of this PR) the publication — each with its own copy of the "one prepare,
at most one body per emitter" rule.

Unifying them is worth doing and is R5 M1B territory, not this slice: it would
mean routing the publication's rows through the ledger's owner lifecycle, which
touches `module-init.ts` and `ir-overlay-outcomes.ts` and would have made this
diff unreviewable against the six red `issue-3525` tests — the same reason
[#5263](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5263-multi-prepared-callables-zero-direct-body-receipts)
deliberately left this gap open. The three producers now at least agree on the
values, which is the precondition for merging them.

## Files

- `src/codegen/multi-prepared-callable-publication.ts` — reorder + `#buildFinalOutcomes` / `#bodyEmissionAccounting`
- `src/ir/prepared-component-publication.ts` — `irPatchCountByUnitId` on the token
- `src/ir/outcomes.ts` — export `hasMalformedBodyEmissionAccounting`
- `tests/issue-5299-prepared-callable-receipt-triple.test.ts` — new
- `plan/issues/5299-prepared-callable-rows-missing-receipt-triple.md` — `status: done`, implementation notes

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Namds9phYeHvpLKu735io3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_