### PR TITLE
fix(#5310): for-in over a closed-struct receiver enumerated nothing in JS-host mode

### DIFF
--- a/plan/issues/5310-forin-closed-struct-host-enumerates-nothing.md
+++ b/plan/issues/5310-forin-closed-struct-host-enumerates-nothing.md
@@ -1,0 +1,97 @@
+---
+id: 5310
+title: "for-in over a closed-struct receiver enumerates nothing in JS-host mode"
+status: done
+created: 2026-09-03
+updated: 2026-09-03
+completed: 2026-09-03
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: for-in, enumeration
+goal: npm-library-support
+sprint: current
+horizon: s
+related: [1243, 1271, 2572, 2575, 5311]
+---
+
+# #5310 — for-in over a closed-struct receiver enumerates nothing in JS-host mode
+
+## Problem
+
+```ts
+export function keys(): string {
+  const o = { a: 1, b: 2 };
+  let out = "";
+  for (const k in o) out += k + ",";
+  return out;
+}
+```
+
+Host mode returned `""`. Standalone returned `"a,b,"`. Same source, same
+compiler, opposite answers — and the host answer is the wrong one.
+
+## Root cause
+
+`compileForInStatement` chose its enumeration strategy by asking whether the
+`__for_in_*` host imports were **registered**, not by asking what the receiver
+actually **lowers to**.
+
+The standalone branch already carried the correct reasoning in a comment: a
+closed WasmGC struct "does NOT lower to `$Object`", so `__object_keys` would
+return empty, and such a receiver must keep the static-unroll path, "which is
+exact for a non-mutated closed shape". But that reasoning only ever ran where
+the host imports were absent. In JS-host mode they exist, so control never
+reached it: the struct was wrapped with `extern.convert_any` and handed to a JS
+function that receives an opaque WasmGC value and enumerates zero keys.
+
+Emitted host WAT for the snippet above — `struct.new 6`, then straight into the
+dynamic enumerators:
+
+```wat
+(local $o (ref null 6))
+f64.const 1
+f64.const 2
+struct.new 6
+local.set 0
+...
+local.get 0
+extern.convert_any   ;; opaque to JS from here on
+call 1               ;; __for_in_keys -> 0 keys
+```
+
+Standalone, same source, unrolls both keys inline.
+
+The failure is silent: zero iterations is indistinguishable from "the object had
+no keys", so the loop body simply never runs and the program carries on with a
+default.
+
+## Fix
+
+Choose the strategy from the lowered representation. The two predicates that the
+standalone branch already used — `isOpenForInReceiver` and
+`forInReceiverIsDynamic` — are now evaluated for every target; a receiver that
+is neither open nor dynamic clears the primitive indices so the existing
+static-unroll fallback runs. Host and standalone now agree, with standalone as
+the reference.
+
+## Tests
+
+`tests/issue-5310-forin-closed-struct-host.test.ts` — 5 cases (data properties,
+string values, method values, mixed source order, and an iteration count that
+distinguishes "zero iterations" from a formatting difference). **All five fail
+on the parent commit and pass with the fix.**
+
+No regressions across the 5 existing for-in suites (32 tests) or the 9
+enumeration/object-literal suites (74 tests).
+
+## Measured package impact: none yet
+
+jest is 299/356 both before and after. This is a correctness fix that removes a
+host/standalone divergence; it did not move any curated package on its own,
+because the packages that walk an options bag reach it through an `any`
+parameter, and a struct crossing that boundary is opaque for a separate reason —
+see [#5311](5311-closed-struct-crossing-into-any-is-opaque.md), which is what
+actually blocks marked.

--- a/plan/issues/5311-closed-struct-crossing-into-any-is-opaque.md
+++ b/plan/issues/5311-closed-struct-crossing-into-any-is-opaque.md
@@ -1,0 +1,109 @@
+---
+id: 5311
+title: "A closed struct crossing into an `any` position is opaque — no property read, no enumeration"
+status: ready
+created: 2026-09-03
+updated: 2026-09-03
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: object-representation, for-in, Object.keys, property-access
+goal: npm-library-support
+sprint: current
+horizon: l
+related: [1243, 1271, 2584, 2837, 2992, 5310]
+---
+
+# #5311 — a closed struct crossing into an `any` position is opaque
+
+## Problem
+
+An object literal that lowers to a closed WasmGC struct becomes **completely
+unreadable** once it is passed into a parameter typed `any`. Not just
+enumeration — an ordinary property read returns `NaN`.
+
+```ts
+function get(o: any): number { return o.a; }
+export function n(): number { const o = { a: 7, b: 2 }; return get(o); }
+// host mode: NaN   (expected 7)
+```
+
+```ts
+function count(o: any): number { return Object.keys(o).length; }
+export function n(): number { const o = { a: 1, b: 2 }; return count(o); }
+// host mode: 0     (expected 2)
+```
+
+```ts
+function names(o: any): string { let out = ""; for (const k in o) out += k + ","; return out; }
+export function keys(): string { const o = { a: 1, b: 2 }; return names(o); }
+// host mode: ""    (expected "a,b,")
+```
+
+`const o: any = { a: 1, b: 2 }` at the declaration site behaves the same way.
+The value is a `struct.new`; `extern.convert_any` hands it to the callee, and
+every dynamic accessor — property get, `Object.keys`, `for...in`, `in` — sees an
+opaque WasmGC reference.
+
+## Why this matters right now
+
+It is what holds **marked at 0/30**. `Marked.use()` installs hooks with
+
+```js
+if (n.hooks) {
+  let r = this.defaults.hooks || new P();
+  for (let i in n.hooks) { /* wrap and install */ }
+  s.hooks = r;
+}
+```
+
+`n.hooks` arrives through a rest parameter, so the enumeration is over an `any`.
+It yields nothing, no hook is installed, and the default pipeline runs — which is
+exactly the observed failure shape: every test asserts a hook's effect and gets
+the un-hooked output (`actual=<p>text</p> expected=<h1>text</h1>`), or reads a
+property the hook should have set and gets `undefined`. All 30 upstream Hooks
+tests fail this way, and none of them crash.
+
+## Not the same defect as #5310
+
+[#5310](5310-forin-closed-struct-host-enumerates-nothing.md) is a *strategy
+selection* bug at the for-in site: the receiver's closed type was visible and
+was ignored. It is fixed. This issue is a *representation* bug at the call
+boundary: by the time the callee runs, the closed type is gone, so no
+site-local decision can recover it. Fixing #5310 does not move any of the three
+snippets above.
+
+## Note on #1271
+
+[#1271](1271-for-in-object-keys-enumeration.md) was closed in sprint 47 with a
+smoke test reporting "for-in over any-typed object: OK". That result is not
+reproducible in the form above, and the distinction is the point: what works is
+a value whose representation was **open from the start**; what fails is a
+**closed struct widened at a boundary**. A re-check should use the snippets in
+this issue rather than the ones in that note.
+
+## Direction (not yet chosen)
+
+Two candidates, both with real costs — neither should be picked without an
+A/B across all 24 curated packages:
+
+1. **Widen at the boundary.** Have the object-shape-widening pre-pass
+   (`src/codegen/declarations/object-shape-widening.ts`) treat "flows into an
+   `any`/externref parameter" as an escape that forces the open `$Object`
+   carrier, the way it already treats `o[k]`, `k in o`, `Object.keys(o)` and
+   `for (k in o)`. Contained and reuses existing machinery, but it will widen a
+   great many objects that are currently closed structs — a size and speed
+   regression that has to be measured, not assumed.
+
+2. **Make the dynamic accessors struct-aware.** Emit a per-struct-type shape
+   descriptor and teach the `$Object` accessors and enumerators to consult it.
+   Keeps the closed representation (and its performance), but adds metadata to
+   every struct type and a branch to every dynamic access.
+
+## Repro
+
+The three snippets above, compiled with `compileAndRunHost`. Standalone shares
+the defect for the `any`-parameter cases; only the direct-receiver case (#5310)
+differed between targets.

--- a/src/codegen/for-in-open-object.ts
+++ b/src/codegen/for-in-open-object.ts
@@ -1,7 +1,9 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /** Selection of the live open-object representation for standalone for-in. */
 import { ts } from "../ts-api.js";
+import { forInReceiverIsDynamic } from "./builtin-instance-key-presence.js";
 import type { CodegenContext } from "./context/types.js";
+import type { ValType } from "../ir/types.js";
 import { resolveWidenedVarKey } from "./widened-var-key.js";
 
 /**
@@ -18,4 +20,27 @@ export function isOpenForInReceiver(ctx: CodegenContext, expression: ts.Expressi
   return (
     ctx.growableObjectLiteralVars.has(receiver.text) || (key !== undefined && ctx.irWithOpenObjectTargetKeys.has(key))
   );
+}
+
+/**
+ * (#5310) Whether a for-in receiver needs the DYNAMIC key enumerators
+ * (`__for_in_*` in JS-host mode, the `$Object` runtime helpers in a no-JS-host
+ * target) rather than the static unroll.
+ *
+ * This has to be answered from the receiver's lowered REPRESENTATION. The
+ * enumeration site used to answer it from whether the host imports happened to
+ * be REGISTERED, which made the two targets disagree: a closed WasmGC struct
+ * does not lower to `$Object`, so the dynamic enumerators cannot see its
+ * fields, and standalone therefore fell through to the static unroll — exact
+ * for a non-mutated closed shape. In host mode the imports exist, so the struct
+ * was wrapped with `extern.convert_any` and handed to a JS function that sees
+ * an opaque WasmGC value and returns zero keys. `for (const k in { a: 1 })`
+ * silently ran its body zero times.
+ */
+export function forInReceiverNeedsDynamicKeys(
+  ctx: CodegenContext,
+  expression: ts.Expression,
+  receiverWasmType: ValType,
+): boolean {
+  return isOpenForInReceiver(ctx, expression) || forInReceiverIsDynamic(ctx, receiverWasmType);
 }

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -66,7 +66,6 @@ import { emitForInStaticUnroll } from "./for-in-static-unroll.js"; // (#4561)
 // (#4491 T9) a `new Date()` / `new RegExp()` receiver is a closed STRUCT but not a
 // closed SHAPE — it carries own properties in the #4008 bag, so it must enumerate
 // dynamically rather than unroll its declared (inherited, non-enumerable) members.
-import { forInReceiverIsDynamic } from "../builtin-instance-key-presence.js";
 import { blockLoop, restoreBlockScopedShadows, saveBlockScopedShadows, shiftLoopDepths } from "./shared.js";
 import {
   bodyHasMatchingCharRead,
@@ -95,7 +94,7 @@ import { tryCompileCountedStringAppend } from "./counted-string-append.js";
 import { emitHoleToUndefined } from "../array-holes.js"; // (#2001 S1)
 import { emitF64HoleToUndef, f64HolesActive } from "../vec-f64-hole-presence.js"; // (#4491 T11)
 import { definedFuncAt, nativeStrHelperHandle } from "../func-space.js"; // (#1916 S2) positional-read chokepoint
-import { isOpenForInReceiver } from "../for-in-open-object.js";
+import { forInReceiverNeedsDynamicKeys } from "../for-in-open-object.js";
 
 /** Strip the transparent parentheses used by CoverParenthesizedExpression in a
  * for-of assignment head. The declaration/destructuring paths intentionally
@@ -4086,12 +4085,16 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
   // old static-unroll fallback, which enumerated the receiver's *static* shape
   // and was therefore wrong for a runtime-mutated dynamic object (a key added
   // or deleted at runtime was invisible / stale).
-  let keysIdx = ctx.funcMap.get("__for_in_keys");
-  let lenIdx = ctx.funcMap.get("__for_in_len");
-  let getIdx = ctx.funcMap.get("__for_in_get");
-  let hasIdx = ctx.funcMap.get("__for_in_has");
+  // (#5310) Only a dynamic receiver gets the primitives — see the predicate.
+  const recvWasm = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(stmt.expression));
+  const needsDynamic = forInReceiverNeedsDynamicKeys(ctx, stmt.expression, recvWasm);
+  let keysIdx = needsDynamic ? ctx.funcMap.get("__for_in_keys") : undefined;
+  let lenIdx = needsDynamic ? ctx.funcMap.get("__for_in_len") : undefined;
+  let getIdx = needsDynamic ? ctx.funcMap.get("__for_in_get") : undefined;
+  let hasIdx = needsDynamic ? ctx.funcMap.get("__for_in_has") : undefined;
 
   if (
+    needsDynamic &&
     (keysIdx === undefined || lenIdx === undefined || getIdx === undefined) &&
     (ctx.standalone || ctx.wasi || ctx.targetProfile.semanticProviders === "native-first")
   ) {
@@ -4105,21 +4108,17 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
     // below is shared. A closed WasmGC struct or an array does NOT lower to
     // `$Object` (so `__object_keys` would return empty) — those keep the
     // static-unroll path below, which is exact for a non-mutated closed shape.
-    const recvWasmType = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(stmt.expression));
-    const isDynamicReceiver = isOpenForInReceiver(ctx, stmt.expression) || forInReceiverIsDynamic(ctx, recvWasmType);
-    if (isDynamicReceiver) {
-      ensureObjectRuntime(ctx);
-      // #2964 — for-in must enumerate inherited enumerable keys too, so route
-      // through `__object_keys_forin` (own ordered keys per level + `$proto`
-      // walk with shadow-skip), NOT the OWN-only `__object_keys` (which powers
-      // Object.keys). Same `$ObjVec` return shape, so the loop scaffolding and
-      // the `__extern_length`/`__extern_get_idx`/`__extern_has` accessors below
-      // are unchanged.
-      keysIdx = ctx.funcMap.get("__object_keys_forin");
-      lenIdx = ctx.funcMap.get("__extern_length");
-      getIdx = ctx.funcMap.get("__extern_get_idx");
-      hasIdx = ctx.funcMap.get("__extern_has");
-    }
+    ensureObjectRuntime(ctx);
+    // #2964 — for-in must enumerate inherited enumerable keys too, so route
+    // through `__object_keys_forin` (own ordered keys per level + `$proto`
+    // walk with shadow-skip), NOT the OWN-only `__object_keys` (which powers
+    // Object.keys). Same `$ObjVec` return shape, so the loop scaffolding and
+    // the `__extern_length`/`__extern_get_idx`/`__extern_has` accessors below
+    // are unchanged.
+    keysIdx = ctx.funcMap.get("__object_keys_forin");
+    lenIdx = ctx.funcMap.get("__extern_length");
+    getIdx = ctx.funcMap.get("__extern_get_idx");
+    hasIdx = ctx.funcMap.get("__extern_has");
   }
 
   if (keysIdx === undefined || lenIdx === undefined || getIdx === undefined) {

--- a/tests/issue-5310-forin-closed-struct-host.test.ts
+++ b/tests/issue-5310-forin-closed-struct-host.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #5310 — a for-in receiver that lowers to a closed WasmGC struct enumerated
+ * NOTHING in JS-host mode, while standalone enumerated it correctly.
+ *
+ * WHY the two targets disagreed: `compileForInStatement` picks its enumeration
+ * strategy by asking whether the `__for_in_*` host imports are REGISTERED, not
+ * by asking what the receiver actually lowers to. In standalone those imports
+ * are deliberately absent, so control fell through to the static-unroll path —
+ * which is exact for a closed shape, and whose own comment says a closed struct
+ * "does NOT lower to `$Object`" and therefore must not be handed to the dynamic
+ * enumerators. In host mode the imports exist, so that reasoning never ran: the
+ * struct was wrapped with `extern.convert_any` and passed to a JS function that
+ * sees an opaque WasmGC value and returns zero keys. The loop body never ran.
+ *
+ * These cases pin the AGREEMENT, not one target's answer: the strategy is now
+ * chosen from the lowered representation, so both targets unroll a closed shape.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compileAndRunHost as compileAndRun } from "./helpers/compile.js";
+
+async function keysOf(literal: string): Promise<string> {
+  const exports = await compileAndRun(`
+    export function keys(): string {
+      const o = ${literal};
+      let out = "";
+      for (const k in o) out += k + ",";
+      return out;
+    }
+  `);
+  return (exports.keys as () => string)();
+}
+
+describe("#5310 for-in over a closed-struct receiver (JS-host mode)", () => {
+  it("enumerates data properties", async () => {
+    expect(await keysOf(`{ a: 1, b: 2 }`)).toBe("a,b,");
+  });
+
+  it("enumerates string-valued properties", async () => {
+    expect(await keysOf(`{ a: "x", b: "y" }`)).toBe("a,b,");
+  });
+
+  it("enumerates method-valued properties", async () => {
+    // The shape that matters to real packages: an options bag of callbacks.
+    // marked's `use({ hooks: { preprocess() {…} } })` walks exactly this with
+    // `for (const i in n.hooks)`.
+    expect(
+      await keysOf(`{ preprocess(m: string): string { return m; }, postprocess(h: string): string { return h; } }`),
+    ).toBe("preprocess,postprocess,");
+  });
+
+  it("enumerates a mix of data and method properties in source order", async () => {
+    expect(await keysOf(`{ flag: 1, run(m: string): string { return m; }, name: "n" }`)).toBe("flag,run,name,");
+  });
+
+  it("runs the loop body once per key, not zero times", async () => {
+    // The original bug was silent: zero iterations reads as "the object had no
+    // keys", so a count is what distinguishes it from a formatting difference.
+    const exports = await compileAndRun(`
+      export function count(): number {
+        const o = { a: 1, b: 2, c: 3 };
+        let n = 0;
+        for (const k in o) n++;
+        return n;
+      }
+    `);
+    expect((exports.count as () => number)()).toBe(3);
+  });
+});


### PR DESCRIPTION
## The bug

```ts
export function keys(): string {
  const o = { a: 1, b: 2 };
  let out = "";
  for (const k in o) out += k + ",";
  return out;
}
```

Host mode returned `""`. Standalone returned `"a,b,"`. Same source, same compiler, opposite answers — and the host answer is the wrong one.

## Root cause

`compileForInStatement` chose its enumeration strategy by asking whether the `__for_in_*` host imports were **registered**, not by asking what the receiver actually **lowers to**.

The standalone branch already carried the correct reasoning in a comment: a closed WasmGC struct "does NOT lower to `$Object`", so the dynamic enumerators cannot see its fields, and such a receiver must keep the static-unroll path, "which is exact for a non-mutated closed shape". That reasoning only ever ran where the host imports were absent. In host mode they exist, so control never reached it:

```wat
(local $o (ref null 6))
f64.const 1
f64.const 2
struct.new 6          ;; closed struct
local.set 0
...
local.get 0
extern.convert_any    ;; opaque to JS from here on
call 1                ;; __for_in_keys -> 0 keys
```

The failure is silent: zero iterations is indistinguishable from "the object had no keys", so the body never runs and the program carries on with a default.

## The change

The decision moves into the for-in subsystem module as `forInReceiverNeedsDynamicKeys`, built from the two predicates the standalone branch already used (`isOpenForInReceiver`, `forInReceiverIsDynamic`), and is consulted by **every** target. A receiver that is neither open nor dynamic never resolves the primitives and falls through to the existing static unroll. Standalone is the reference.

## Tests

`tests/issue-5310-forin-closed-struct-host.test.ts` — 5 cases (data properties, string values, method values, mixed source order, and an iteration **count** that distinguishes "zero iterations" from a formatting difference). **All five fail on the parent commit; all five pass with the fix.**

| suite group | result |
|---|---|
| 5 existing for-in suites + 9 enumeration/object-literal suites + this one | **111 passed** |
| LOC budget gate | OK, no allowance needed |
| function budget gate | OK, no allowance needed |

## Measured package impact: none yet — stated plainly

jest is **299/356 before and after**. This removes a real host/standalone divergence but did not move any curated package on its own.

The reason is worth reading, and is filed as [#5311](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5311-closed-struct-crossing-into-any-is-opaque): a closed struct that crosses into an **`any` position** is opaque for a *different* reason, one no site-local decision can fix. Through an `any` parameter even a plain property read fails:

```ts
function get(o: any): number { return o.a; }
export function n(): number { const o = { a: 7, b: 2 }; return get(o); }
// host mode: NaN   (expected 7)
```

That is what actually holds **marked at 0/30**: `Marked.use()` installs hooks with `for (let i in n.hooks)` over a rest parameter, the loop yields nothing, no hook is installed, and every one of the 30 upstream Hooks tests silently gets the un-hooked output. #5311 records the repro, the two candidate directions, and why neither should be picked without an A/B across all 24 packages.

Also noted there: [#1271](https://js2wasm.loopdive.com/dashboard/issue.html?slug=1271-for-in-object-keys-enumeration) was closed in sprint 47 on a smoke test reporting "for-in over any-typed object: OK". That is not reproducible in the form above — what works is a value whose representation was open *from the start*; what fails is a closed struct widened *at a boundary*.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ)_