### PR TITLE
test(3520): pin the private member's mangled legacy name instead of the old <computed> collision ✓

### DIFF
--- a/tests/issue-3520-ir-unit-identity.test.ts
+++ b/tests/issue-3520-ir-unit-identity.test.ts
@@ -919,7 +919,12 @@ describe("#3520 structural IR identity", () => {
       "class-instance-method",
     ]);
     expect(new Set(members.map((unit) => unit.id)).size).toBe(members.length);
-    expect(members.filter((unit) => unit.legacyMatchName === "Shape_<computed>")).toHaveLength(2);
+    // #3522 W1-A (PR #5545): a private member carries its mangled name, so only
+    // the genuinely computed member is `<computed>`. Before that fix every
+    // private member collapsed onto `<computed>` and two members shared one
+    // legacy match name — the collision this pin used to encode.
+    expect(members.filter((unit) => unit.legacyMatchName === "Shape_<computed>")).toHaveLength(1);
+    expect(members.filter((unit) => unit.legacyMatchName === "Shape___priv_secret")).toHaveLength(1);
     expect(new Set(members.map((unit) => unit.legacyKey)).size).toBe(members.length);
   });
 


### PR DESCRIPTION
Test-only, one assertion. No `src/` change.

## What went red, and why it is a stale pin

`tests/issue-3520-ir-unit-identity.test.ts` › *encodes static, instance, accessor, private, and computed members as distinct units* has been red on `main` since [#3522](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3522-ir-r3-classes-closures-compile-once) W1-A (PR #5545) landed. The W1-F implementer flagged it as a red row in no cluster table.

The assertion expected **two** `Shape_<computed>` legacy match names. That was the pre-W1-A collision: `memberBaseName` returned `<computed>` for every private member, so `#secret()` and `[computed]()` shared one legacy name and one selection-set entry — the exact defect the W1-A commit message and the `privateMemberMangledName` comment in `src/ir/identity.ts` describe. The fix gave private members `__priv_<name>`, and the test kept pinning the collision.

Measured on `main` `be9de98af4` (`.tmp/probe-iui.mts`): the eight class-member units carry legacy names `Shape_m`, `Shape_m`, `Shape_get_x`, `Shape_set_x`, `Shape_get_x`, `Shape_set_x`, **`Shape___priv_secret`**, **`Shape_<computed>`** — eight distinct `legacyKey`s, one `<computed>`.

## Change

The pin now expects one `Shape_<computed>` (the computed member) and one `Shape___priv_secret`, with a comment naming the W1-A change. The distinct-id and distinct-legacyKey assertions are untouched.

| | result |
| --- | --- |
| before, on `main` | `expected [ {…} ] to have a length of 2 but got 1` |
| after | 32/32 pass |

Part of the [#3520](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3520-ir-r1-source-qualified-identity-program-abi) red-set cleanup; status stays `in-progress`.

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Namds9phYeHvpLKu735io3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_