### PR TITLE
fix(ci): bisect the #3437 harness compile-budget drift, rebank it, warn at half margin ✓

### DIFF
--- a/plan/issues/5306-harness-compile-budget-ceiling-margin-exhausted.md
+++ b/plan/issues/5306-harness-compile-budget-ceiling-margin-exhausted.md
@@ -1,10 +1,11 @@
 ---
 id: 5306
 title: "check:harness-compile-budget sits 29 traversals under its ceiling on main (150,774 / 150,803) — the next harness-path PR trips a gate that measures drift since 2026-08-20, not its own change"
-status: ready
+status: done
 sprint: current
 created: 2026-09-03
-updated: 2026-09-03
+updated: 2026-09-04
+completed: 2026-09-04
 priority: medium
 horizon: s
 feasibility: easy
@@ -12,8 +13,9 @@ reasoning_effort: low
 task_type: infra
 area: ci
 goal: ir-full-coverage
-related: [3437, 3433, 3374, 5297]
+related: [3437, 3433, 3374, 5297, 5313]
 requested_by: ttraenkler/orchestrator
+assignee: "ttraenkler/opus-5306"
 ---
 
 # The pre-merge compile-work budget has silently used up its margin
@@ -77,3 +79,94 @@ thing to measure.
 - Raising `marginPct`. A wider band hides the same drift longer.
 - Rebanking from a PR branch. The budget is main's number; `--update` runs
   on `origin/main` and the result is reviewed.
+
+## Landed
+
+### Method
+
+`npx tsx scripts/check-harness-compile-budget.ts --json` at each of 100
+detached checkouts on the first-parent chain, ~7 s per measurement. The gate
+script and the `src/ts-api.ts` meter are **unchanged since they were
+introduced** (`bd20d07c11`), so every commit in the window was measured with
+the same fixture and the same counter — the numbers below are comparable
+without normalisation.
+
+The range is `d633020ab9..origin/main` (2026-08-20 rebank → 2026-09-04,
+`5240be0a10`). Of 956 first-parent commits only the **382 that touch `src/`**
+can move the count, so those were the search space: a 21-point sweep at every
+20th, then every commit inside each interval that showed a jump. Result: three
+single commits carry 99.7 % of the growth, and all three are pinned exactly
+(their immediate first-parent predecessor measures the pre-jump number).
+
+Attribution to a named scan was done by patching the meter to record the
+caller frame of every shared-`forEachChild` invocation and diffing the
+per-file profile across each jump commit and its first parent. One full pass
+over the fixture costs **3,919 traversals**, which is why the deltas are near
+multiples of it.
+
+### Bisection
+
+Total: **131,133 → 150,774 = +19,641** (+15.0 %) over 15 days.
+
+| # | commit | date | PR | before → after | delta | share |
+| - | ------ | ---- | -- | -------------- | ----: | ----: |
+| 1 | `523bd0428b` | 2026-08-29 | #5204 `feat(selfhost): compile TypeScript 5 parser graph to Wasm` | 139,016 → 146,863 | **+7,847** | 40.0 % |
+| 2 | `52b61990fe` | 2026-08-26 | #4922 `fix(es5): combine standalone conformance gains` | 131,169 → 139,007 | **+7,838** | 39.9 % |
+| 3 | `e285c0f29d` | 2026-08-31 | #5336 `feat(deno): complete linked runtime bootstrap` | 146,872 → 150,767 | **+3,895** | 19.8 % |
+| — | six others | — | — | — | +61 | 0.3 % |
+
+Named scans, from the per-file caller profile:
+
+- **#5204** — two new whole-program passes, both properly memoized:
+  `prepareIdentityPreservingStructuralParams` in `src/codegen/declarations.ts`
+  (+3,928, cached in `assertedStructuralParamsByContext`) and the new
+  `src/codegen/analysis/mixed-assignment-carrier.ts` (+3,919, cached per scope
+  in `byScope`). Linear, one pass, deliberate.
+- **#4922** — two **unconditional** whole-file walks in
+  `src/codegen/declarations/object-shape-widening.ts`
+  (15,661 → 23,499): `markRealmGlobalWithTargets` inside
+  `collectGrowableObjectLiterals`, and `visit` inside the new
+  `collectRedeclaredWithTargetObjects`. Both exist only to find `with`
+  statements and both run on sources that contain no `with`.
+- **#5336** — `sourceNodeWeight` in the new
+  `src/codegen/module-init-chunks.ts` (+3,895), a `WeakMap`-cached AST node
+  count for module-init chunk planning.
+
+Two commits (not one) cleared the "more than a third" bar in acceptance
+criterion 1. Only one of them is a defect, so only one follow-up was filed:
+**#5313** for #4922's unconditional `with` scans, which are ~7,838 traversals
+bought for a construct almost no source uses and which the existing
+`source-scan-predicates.ts` short-circuit pattern can gate away. #5204's and
+#5336's passes were assessed and deliberately accepted — memoized single
+passes that buy something on every source — and that assessment is recorded
+here rather than as a second issue nobody would action.
+
+None of the three is the #3433 quadratic class: every one is O(file), not
+O(call-sites × file). The gate did its job; the drift is additive cost, not a
+re-explosion.
+
+### Changes
+
+- **Rebanked** `scripts/harness-compile-budget.json` 131,133 → **150,774**,
+  measured on `origin/main` with the tree carrying no `src/` change. Ceiling
+  150,803 → **173,391**; margin 29 (0.02 %) → 22,617 (13.04 %).
+- **Soft-warning band** in `scripts/check-harness-compile-budget.ts`.
+  `evaluateBudget` gained `softCeiling` (= budget × (1 + marginPct/2 %)),
+  `nearCeiling`, `marginLeft` and `marginLeftPct`. Crossing the half-margin
+  line prints a `::warning::` on stderr naming the remaining margin in both
+  traversals and percent; the exit code is untouched and no new required check
+  was added. The warning is emitted **after** the hard checks so a real failure
+  is never softened into a warning, and on stderr so `--json` stdout stays
+  parseable. Every run — pass or warn — now also prints `margin-left=` on the
+  human-readable line, so the drift is visible in `quality` logs even before
+  the band trips.
+- **Provenance** — `--update` now writes a note carrying the rebank date, the
+  measured figure, the fixture call-site count and the margin, replacing the
+  figure-free "post-#3433 main".
+- Eight new cases in `tests/issue-3437-harness-compile-budget.test.ts` cover
+  the band's boundaries (no warn at the soft ceiling, warn one past it, warn at
+  the hard ceiling, **no** warn once over budget), the reported margin, and the
+  note's provenance. 18 tests pass.
+
+Against the pre-rebank budget the band reproduced this issue's own figures
+exactly — `margin-left=29 (0.02%)`, exit 0.

--- a/plan/issues/5313-unconditional-with-scans-object-shape-widening.md
+++ b/plan/issues/5313-unconditional-with-scans-object-shape-widening.md
@@ -1,0 +1,88 @@
+---
+id: 5313
+title: "Two unconditional whole-file `with`-statement walks in object-shape-widening.ts cost 7,838 traversals (40 % of the harness compile-budget drift) on sources containing no `with`"
+status: ready
+sprint: current
+created: 2026-09-04
+updated: 2026-09-04
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: fix
+area: codegen
+goal: ir-full-coverage
+related: [5306, 3437, 3433, 3374]
+requested_by: ttraenkler/opus-5306
+---
+
+# Two full-source walks look for `with` on every compile, `with` or not
+
+Bisecting the #3437 harness compile-work budget for
+[#5306](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5306-harness-compile-budget-ceiling-margin-exhausted)
+pinned 40 % of the 2026-08-20 → 2026-09-04 drift to a single merge:
+
+| | |
+| --- | --- |
+| commit | `52b61990fe` (2026-08-26) |
+| PR | #4922 `fix(es5): combine standalone conformance gains` |
+| measured | 131,169 → **139,007** (+7,838) |
+| share of total drift | **39.9 %** of +19,641 |
+
+Per-caller attribution (patch the `forEachChildMeter` in `src/ts-api.ts` to
+record caller frames; method in #5306's PR) puts **all** of it in one file:
+
+```
++7838   15661 -> 23499  src/codegen/declarations/object-shape-widening.ts
+```
+
+and exactly two new whole-source-file walks, each one full pass over the
+3,919-node fixture:
+
+1. `markRealmGlobalWithTargets` — an inner arrow inside
+   `collectGrowableObjectLiterals`. It recurses the entire source file, and its
+   only payload is `if (ts.isWithStatement(node)) { … }`.
+2. `visit` inside the new `collectRedeclaredWithTargetObjects`. It collects
+   variable declarations *and* `with` targets, and only ever produces a result
+   for symbols that are **both** redeclared and a `with` target
+   (`if (declarations.length < 2 || !withTargetSymbols.has(symbol)) continue;`).
+
+Both run unconditionally. The #3437 fixture contains no `with` statement, so
+both walks are pure cost on it — and `with` is rare in real input too, so this
+is pure cost on almost every compile, not just the fixture.
+
+## Why this is worth fixing rather than banking
+
+This is not the #3433 quadratic class (the walks are O(file), not
+O(call-sites × file)), so it will not blow up CI. It is worth fixing because it
+is ~7.8 k traversals of budget bought for a feature that fires on a construct
+almost no source uses, and because the guard already exists as a pattern:
+`src/codegen/source-scan-predicates.ts` has short-circuiting predicates of
+exactly this shape (`sourceContainsClass`, `sourceContainsBindingPattern`).
+
+For contrast, the other two commits in the same bisection were assessed and
+deliberately **not** filed: PR #5204's `prepareIdentityPreservingStructuralParams`
+and `mixedAssignmentFacts` are memoized single passes for genuinely new
+analysis, and PR #5336's `sourceNodeWeight` is a `WeakMap`-cached node count.
+They cost real budget but buy something on every source. These two buy nothing
+unless the source says `with`.
+
+## Acceptance criteria
+
+1. Both walks are gated on a **memoized** "does this source contain a `with`
+   statement" predicate, living with the other predicates in
+   `src/codegen/source-scan-predicates.ts` (memoized per `ts.SourceFile`, so a
+   second consumer is free). A cheap pre-filter on `sourceFile.text` before the
+   AST walk is acceptable as long as the AST walk remains the authority.
+2. `pnpm run check:harness-compile-budget` measures a drop of about 7,838
+   traversals from the #5306 budget of 150,774; bank it with `--update` in the
+   same PR (a decrease is the sanctioned write).
+3. No `with`-related behaviour changes: the equivalence suite and the
+   `with`-covering test262 buckets are unchanged. `with` sources must still get
+   both scans — the gate is a skip, not a semantic narrowing.
+
+## Non-goals
+
+- Reworking `collectGrowableObjectLiterals` or the redeclaration analysis
+  itself. This is a guard, not a redesign.
+- Touching PR #5204's or #5336's passes (see above — measured, accepted).

--- a/scripts/check-harness-compile-budget.ts
+++ b/scripts/check-harness-compile-budget.ts
@@ -101,7 +101,15 @@ export interface BudgetVerdict {
   budget: number;
   marginPct: number;
   ceiling: number;
+  /** Half-margin line (#5306): crossing it warns, it never fails. */
+  softCeiling: number;
   overBudget: boolean;
+  /** Past the half-margin line but still under the ceiling — advisory only. */
+  nearCeiling: boolean;
+  /** Traversals still available before `ceiling` (negative once over budget). */
+  marginLeft: number;
+  /** `marginLeft` as a share of the ceiling, so "how close" reads at a glance. */
+  marginLeftPct: number;
   vacuous: boolean;
   wellBelow: boolean;
 }
@@ -111,6 +119,13 @@ export interface BudgetVerdict {
  * fail (a real slowdown past the margin); `vacuous` is the safety fail (the
  * meter/fixture broke and the gate went blind); `wellBelow` is an advisory to
  * rebank an improvement.
+ *
+ * `nearCeiling` (#5306) is the SOFT band: the gate is a one-PR-regression
+ * detector, but the margin is consumed by every PR cumulatively, so a budget
+ * that is silently 99.98 % spent fails the NEXT harness-path PR for fourteen
+ * days of other people's drift. Warning at the half-margin line makes that
+ * drift visible in every `quality` log long before it fails. Exit code is
+ * deliberately unchanged — no new required check (issue #5306 non-goals).
  */
 export function evaluateBudget(
   measured: number,
@@ -119,12 +134,19 @@ export function evaluateBudget(
   vacuityFloor: number,
 ): BudgetVerdict {
   const ceiling = Math.ceil(budget * (1 + marginPct / 100));
+  const softCeiling = Math.ceil(budget * (1 + marginPct / 2 / 100));
+  const overBudget = measured > ceiling;
+  const marginLeft = ceiling - measured;
   return {
     measured,
     budget,
     marginPct,
     ceiling,
-    overBudget: measured > ceiling,
+    softCeiling,
+    overBudget,
+    nearCeiling: measured > softCeiling && !overBudget,
+    marginLeft,
+    marginLeftPct: ceiling === 0 ? 0 : (marginLeft / ceiling) * 100,
     vacuous: measured < vacuityFloor,
     wellBelow: measured < Math.floor(budget * (1 - marginPct / 100)),
   };
@@ -169,13 +191,19 @@ async function main(): Promise<void> {
   const measured = await measureCompileWork(callSites);
 
   if (isUpdate) {
+    const today = new Date().toISOString().slice(0, 10);
     const budget: Budget = {
       forEachChildCalls: measured,
       marginPct,
       fixtureCallSites: callSites,
-      updated: new Date().toISOString().slice(0, 10),
+      updated: today,
+      // #5306 acceptance #4: the note must carry the rebank DATE and the
+      // MEASURED figure it was banked from. The previous note said only
+      // "post-#3433 main", so a reader could not tell whether the committed
+      // number was measured or picked, nor when.
       note:
-        "Deterministic shared-forEachChild traversal count for the #3437 representative harness " +
+        `Rebanked ${today} from a measured ${measured} shared-forEachChild traversals ` +
+        `(fixtureCallSites=${callSites}, margin ${marginPct}%) for the #3437 representative harness ` +
         "assembly. Reseed with `npx tsx scripts/check-harness-compile-budget.ts --update` when a " +
         "slowdown is intentional and justified. See the script header.",
     };
@@ -200,7 +228,8 @@ async function main(): Promise<void> {
   } else {
     console.log(
       `#3437 harness compile-work: measured=${measured} budget=${existing.forEachChildCalls} ` +
-        `ceiling=${ceiling} (+${marginPct}%) callSites=${callSites}.`,
+        `ceiling=${ceiling} (+${marginPct}%) callSites=${callSites} ` +
+        `margin-left=${verdict.marginLeft} (${verdict.marginLeftPct.toFixed(2)}%).`,
     );
   }
 
@@ -222,6 +251,19 @@ async function main(): Promise<void> {
         `Otherwise fix the added/de-memoized per-file scan. See #3437.`,
     );
     process.exit(1);
+  }
+
+  // #5306 soft band. Emitted AFTER the hard checks so a real failure is never
+  // softened into a warning, and on stderr so `--json` stdout stays parseable.
+  // GitHub renders `::warning::` from either stream.
+  if (verdict.nearCeiling) {
+    console.error(
+      `::warning file=scripts/harness-compile-budget.json::#3437 harness compile work is past the ` +
+        `half-margin line: measured ${measured} vs budget ${existing.forEachChildCalls} ` +
+        `(soft ${verdict.softCeiling}, ceiling ${ceiling}). Margin left: ${verdict.marginLeft} traversals ` +
+        `(${verdict.marginLeftPct.toFixed(2)}% of the ceiling). Drift since the last rebank is cumulative — ` +
+        `bisect it and rebank on main (#5306) rather than letting the next harness-path PR absorb the failure.`,
+    );
   }
 
   if (verdict.wellBelow) {

--- a/scripts/harness-compile-budget.json
+++ b/scripts/harness-compile-budget.json
@@ -1,7 +1,7 @@
 {
-  "forEachChildCalls": 131133,
+  "forEachChildCalls": 150774,
   "marginPct": 15,
   "fixtureCallSites": 120,
-  "updated": "2026-08-20",
-  "note": "Deterministic shared-forEachChild traversal count for the #3437 representative harness assembly. Reseed with `npx tsx scripts/check-harness-compile-budget.ts --update` when a slowdown is intentional and justified. See the script header."
+  "updated": "2026-09-04",
+  "note": "Rebanked 2026-09-04 from a measured 150774 shared-forEachChild traversals (fixtureCallSites=120, margin 15%) for the #3437 representative harness assembly. Reseed with `npx tsx scripts/check-harness-compile-budget.ts --update` when a slowdown is intentional and justified. See the script header."
 }

--- a/tests/issue-3437-harness-compile-budget.test.ts
+++ b/tests/issue-3437-harness-compile-budget.test.ts
@@ -22,6 +22,8 @@ const BUDGET = JSON.parse(readFileSync(resolve(__dirname, "../scripts/harness-co
   forEachChildCalls: number;
   marginPct: number;
   fixtureCallSites: number;
+  updated: string;
+  note: string;
 };
 const VACUITY_FLOOR = 800;
 
@@ -55,6 +57,64 @@ describe("#3437 evaluateBudget — pure verdict", () => {
 
   it("rounds the ceiling up (Math.ceil), so a fractional margin never under-gates", () => {
     expect(evaluateBudget(0, 97, 15, VACUITY_FLOOR).ceiling).toBe(Math.ceil(97 * 1.15)); // 112
+  });
+});
+
+// #5306 — the soft band. The gate's margin is consumed CUMULATIVELY by every
+// PR, so a 99.98 %-spent budget makes the next harness-path PR fail for two
+// weeks of other people's drift. Warning at the half-margin line surfaces that
+// drift in every `quality` log; it must never change the exit status.
+describe("#5306 evaluateBudget — soft warning band", () => {
+  it("puts the soft ceiling at half the margin", () => {
+    const v = evaluateBudget(1000, 1000, 15, VACUITY_FLOOR);
+    expect(v.softCeiling).toBe(Math.ceil(1000 * 1.075)); // 1075
+    expect(v.ceiling).toBe(1150);
+  });
+
+  it("does not warn at or below the half-margin line", () => {
+    expect(evaluateBudget(1000, 1000, 15, VACUITY_FLOOR).nearCeiling).toBe(false);
+    expect(evaluateBudget(1075, 1000, 15, VACUITY_FLOOR).nearCeiling).toBe(false);
+  });
+
+  it("warns between the soft ceiling and the hard ceiling, without failing", () => {
+    const v = evaluateBudget(1076, 1000, 15, VACUITY_FLOOR);
+    expect(v.nearCeiling).toBe(true);
+    expect(v.overBudget).toBe(false);
+    const atCeiling = evaluateBudget(1150, 1000, 15, VACUITY_FLOOR);
+    expect(atCeiling.nearCeiling).toBe(true);
+    expect(atCeiling.overBudget).toBe(false);
+  });
+
+  it("stops warning once it is a hard failure (a fail is not softened into a warning)", () => {
+    const v = evaluateBudget(1151, 1000, 15, VACUITY_FLOOR);
+    expect(v.overBudget).toBe(true);
+    expect(v.nearCeiling).toBe(false);
+  });
+
+  it("reports the remaining margin in absolute traversals and as a share of the ceiling", () => {
+    // The state this issue was filed from: 150,774 measured against the
+    // 2026-08-20 budget of 131,133 — 29 traversals (0.02 %) of headroom left.
+    const v = evaluateBudget(150_774, 131_133, 15, VACUITY_FLOOR);
+    expect(v.nearCeiling).toBe(true);
+    expect(v.marginLeft).toBe(29);
+    expect(v.marginLeftPct.toFixed(2)).toBe("0.02");
+  });
+
+  it("reports a negative margin once over budget", () => {
+    const v = evaluateBudget(1200, 1000, 15, VACUITY_FLOOR);
+    expect(v.marginLeft).toBe(-50);
+  });
+});
+
+describe("#5306 committed budget carries its provenance", () => {
+  it("the note records the rebank date and the measured figure", () => {
+    expect(BUDGET.note).toContain(BUDGET.updated);
+    expect(BUDGET.note).toContain(String(BUDGET.forEachChildCalls));
+  });
+
+  it("main sits below the soft ceiling, so the band is not pre-tripped", () => {
+    const v = evaluateBudget(BUDGET.forEachChildCalls, BUDGET.forEachChildCalls, BUDGET.marginPct, VACUITY_FLOOR);
+    expect(v.nearCeiling).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes [#5306](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5306-harness-compile-budget-ceiling-margin-exhausted).

The [#3437](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3437-test262-harness-speed-gate) harness compile-budget gate sat **29 traversals (0.02 %)** under its ceiling on `main`. In that state it no longer does its job: the next PR touching the harness compile path fails `quality` for two weeks of *everyone else's* cumulative drift, with no local reproduction that isolates its own contribution. Bisected first, rebanked second — per the issue's acceptance criteria.

## 1. Bisection

**Method.** `npx tsx scripts/check-harness-compile-budget.ts --json` at 100 detached checkouts, ~7 s each. The gate script and the `src/ts-api.ts` meter are **unchanged since they were introduced** (`bd20d07c11`), so every commit was measured with the same fixture and the same counter — comparable without normalisation.

Range `d633020ab9..origin/main` (the 2026-08-20 rebank → 2026-09-04). Of 956 first-parent commits only the **382 that touch `src/`** can move the count, so those were the search space: a 21-point sweep at every 20th, then every commit inside each interval that jumped. Three single commits carry **99.7 %** of the growth and all three are pinned exactly — the immediate first parent of each measures the pre-jump number.

**Total: 131,133 → 150,774 = +19,641 (+15.0 %) over 15 days.**

| # | commit | date | PR | before → after | delta | share |
| - | ------ | ---- | -- | -------------- | ----: | ----: |
| 1 | `523bd0428b` | 2026-08-29 | PR #5204 `feat(selfhost): compile TypeScript 5 parser graph to Wasm` | 139,016 → 146,863 | **+7,847** | 40.0 % |
| 2 | `52b61990fe` | 2026-08-26 | PR #4922 `fix(es5): combine standalone conformance gains` | 131,169 → 139,007 | **+7,838** | 39.9 % |
| 3 | `e285c0f29d` | 2026-08-31 | PR #5336 `feat(deno): complete linked runtime bootstrap` | 146,872 → 150,767 | **+3,895** | 19.8 % |
| — | six others | — | — | — | +61 | 0.3 % |

**Naming the scans.** Attribution was done by patching the meter to record the caller frame of every shared-`forEachChild` invocation, then diffing the per-file profile across each jump commit and its first parent. One full pass over the fixture costs **3,919 traversals**, which is why every jump is one or two added whole-file walks:

| PR | file | delta | what was added |
| -- | ---- | ----: | -------------- |
| #5204 | `src/codegen/declarations.ts` | +3,928 | `prepareIdentityPreservingStructuralParams` — memoized in `assertedStructuralParamsByContext` |
| #5204 | `src/codegen/analysis/mixed-assignment-carrier.ts` (new) | +3,919 | `mixedAssignmentFacts` — memoized per scope in `byScope` |
| #4922 | `src/codegen/declarations/object-shape-widening.ts` | +7,838 | **two unconditional walks**: `markRealmGlobalWithTargets` and `collectRedeclaredWithTargetObjects` |
| #5336 | `src/codegen/module-init-chunks.ts` (new) | +3,895 | `sourceNodeWeight` — `WeakMap`-cached AST node count |

**None of the three is the [#3433](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3433-test262-prelude-compile-cache) quadratic class** — every one is O(file), not O(call-sites × file). The gate did its job; this is additive cost, not a re-explosion.

## 2. Follow-up filed

Two commits (not one) cleared the "more than a third" bar in acceptance criterion 1, but only one is a defect, so only one follow-up was filed:

- **[#5313](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5313-unconditional-with-scans-object-shape-widening)** — PR #4922's two walks recurse the whole source file and their entire payload is `if (ts.isWithStatement(node))`. They run on sources with no `with` at all, which is nearly all of them, for ~7,838 traversals. `src/codegen/source-scan-predicates.ts` already has the short-circuiting predicate pattern that would gate them.
- **PR #5204 and PR #5336 were assessed and deliberately accepted** — memoized single passes for genuinely new analysis that buy something on every source. That assessment is recorded in #5306's `## Landed` section rather than as a second issue nobody would action.

## 3. Rebank

`--update` run on a tree carrying no `src/` change, so the number is `main`'s. Re-measured after merging the newer `origin/main` in: still 150,774.

| | before | after |
| --- | --: | --: |
| budget | 131,133 | **150,774** |
| ceiling (+15 %) | 150,803 | **173,391** |
| margin left | 29 (0.02 %) | **22,617 (13.04 %)** |

`marginPct` is unchanged at 15 — widening the band was an explicit non-goal.

## 4. Soft-warning band

`evaluateBudget` gained `softCeiling` (budget × (1 + `marginPct`/2 %)), `nearCeiling`, `marginLeft` and `marginLeftPct`. Crossing the half-margin line prints a `::warning::` naming the remaining margin in both traversals and percent.

- **Exit code untouched, no new required check.**
- Emitted **after** the hard checks, so a real failure is never softened into a warning (`nearCeiling` is false once `overBudget`).
- Emitted on **stderr**, so `--json` stdout stays parseable; GitHub renders `::warning::` from either stream.
- Every run — pass or warn — now also prints `margin-left=` on the human-readable line, so the drift is visible in `quality` logs *before* the band trips.

Against the pre-rebank budget it reproduced this issue's own figures exactly:

```
$ npx tsx scripts/check-harness-compile-budget.ts     # budget still 131,133
#3437 harness compile-work: measured=150774 budget=131133 ceiling=150803 (+15%) callSites=120 margin-left=29 (0.02%).
  ✓ harness compile work within budget.
::warning file=scripts/harness-compile-budget.json::#3437 harness compile work is past the half-margin
line: measured 150774 vs budget 131133 (soft 140968, ceiling 150803). Margin left: 29 traversals (0.02%
of the ceiling). …
exit=0
```

After the rebank the band is not pre-tripped (150,774 vs soft ceiling 162,083) and the gate is silent again.

## 5. Note provenance

`--update` now writes the rebank date, the measured figure, the fixture call-site count and the margin, replacing the figure-free "post-#3433 main":

> `Rebanked 2026-09-04 from a measured 150774 shared-forEachChild traversals (fixtureCallSites=120, margin 15%) …`

## Validation

- `pnpm run check:harness-compile-budget` — green, `margin-left=22617 (13.04%)`.
- `tests/issue-3437-harness-compile-budget.test.ts` — **18 passed** (8 new: soft-ceiling placement, no-warn at the line, warn one past it, warn at the hard ceiling, **no** warn once over budget, the reported margin including this issue's own 29/0.02 % figures, negative margin, and the note's provenance).
- Ratchet chain green bare and with `LOC_GATE_BASE=$(git rev-parse origin/main)`: `check-loc-budget`, `check-func-budget`, `check-coercion-sites`, `check:oracle-ratchet`, `check:dead-exports`. **No `src/` file is touched by this PR.**
- `typecheck`, `biome lint`, `prettier --check` on every changed file. `check:issue-ids:against-main` green for #5313.

## Deviations

- **`gh` is not installed in this container**, so the open-PR scan for the id allocation degraded: `#5313` was reserved with `--allow-unscanned` and is recorded `pr_scan="degraded"` on `origin/issue-assignments`. The required `check:issue-ids:against-main` gate is the backstop and passes; the merge-group collision check is the real arbiter.
- **The issue estimated "~60 merges" in the window; there are 956 first-parent commits (382 touching `src/`).** The sweep was sized to the real number, not the estimate.
- **Two commits, not one, exceeded a third of the growth.** One follow-up issue was filed rather than two — see §2 for the reasoning.

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Namds9phYeHvpLKu735io3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_