### PR TITLE
perf(codegen): gate the two `with`-statement scans on a memoized predicate (#5313) ✓

### DIFF
--- a/plan/issues/5313-unconditional-with-scans-object-shape-widening.md
+++ b/plan/issues/5313-unconditional-with-scans-object-shape-widening.md
@@ -1,7 +1,8 @@
 ---
 id: 5313
 title: "Two unconditional whole-file `with`-statement walks in object-shape-widening.ts cost 7,838 traversals (40 % of the harness compile-budget drift) on sources containing no `with`"
-status: ready
+status: done
+completed: 2026-09-04
 sprint: current
 created: 2026-09-04
 updated: 2026-09-04
@@ -14,6 +15,16 @@ area: codegen
 goal: ir-full-coverage
 related: [5306, 3437, 3433, 3374]
 requested_by: ttraenkler/opus-5306
+# 2026-09-04 (#5313): +8 lines in the god-file — one import, one early-return
+# gate, one call-site gate, and the four comment lines carrying the soundness
+# argument for each skip (why a `with`-free source provably marks nothing).
+# Both budgets sit at ZERO headroom, so any gate at all needs a grant. The
+# change REFUNDS 7,838 traversals of the #3437 harness compile-work budget —
+# a net reduction in compiler work bought for 8 lines of guard.
+loc-budget-allow:
+  - src/codegen/declarations/object-shape-widening.ts
+func-budget-allow:
+  - src/codegen/declarations/object-shape-widening.ts::collectGrowableObjectLiterals
 ---
 
 # Two full-source walks look for `with` on every compile, `with` or not
@@ -86,3 +97,123 @@ unless the source says `with`.
 - Reworking `collectGrowableObjectLiterals` or the redeclaration analysis
   itself. This is a guard, not a redesign.
 - Touching PR #5204's or #5336's passes (see above — measured, accepted).
+
+## Landed
+
+### Result
+
+`pnpm run check:harness-compile-budget`, measured on this branch against the
+same fixture (`fixtureCallSites=120`) #5306 rebanked from:
+
+| | before | after | delta |
+| --- | ---: | ---: | ---: |
+| measured traversals | 150,774 | **142,936** | **−7,838** (−5.20 %) |
+| banked budget | 150,774 | 142,936 | rebanked with `--update` |
+| ceiling (+15 %) | 173,391 | 164,377 | |
+| margin left | 22,617 (13.04 %) | 21,441 (13.04 %) | |
+
+−7,838 is the issue's predicted figure to the traversal, and it lands the file
+back on its exact pre-#4922 number.
+
+### Attribution
+
+Reproduced #5306's method — the `forEachChildMeter` in `src/ts-api.ts`
+temporarily patched to record the caller frame (file:line) of every
+shared-`forEachChild` invocation, run over the #3437 fixture, then reverted.
+One full pass over the fixture is 3,919 traversals.
+
+Per file:
+
+| file | before | after | delta |
+| ---- | -----: | ----: | ----: |
+| `src/codegen/declarations/object-shape-widening.ts` | 23,499 | **15,661** | **−7,838** |
+| `src/codegen/source-scan-predicates.ts` | 11,804 | 11,804 | **+0** |
+| everything else | 115,471 | 115,471 | +0 |
+
+Per call site inside `object-shape-widening.ts`:
+
+| call site | before | after |
+| --------- | -----: | ----: |
+| `markRealmGlobalWithTargets` (in `collectGrowableObjectLiterals`) | 3,919 | **0** |
+| `visit` in `collectRedeclaredWithTargetObjects` | 3,919 | **0** |
+| `visit` in `collectRedeclaredObjectIdentityLiterals` | 3,919 | 3,919 |
+| `visit` in `collectRepeatedOrdinaryToPrimitiveObjects` | 3,918 | 3,918 |
+| the two `scanNestedFunctionExpressions` / `scanStatements` pairs | 7,814 | 7,814 |
+| `sourceContainsWithStatement` (new) | — | **0** |
+
+The new predicate costing **0** is the whole design, not a rounding artefact.
+A NEGATIVE answer to "does this source contain a `with`" is only knowable after
+visiting every node — the walk cannot short-circuit the way `sourceContainsClass`
+does. Gating two full passes on an unconditional AST walk would therefore have
+refunded 3,919, not 7,838. The `sourceFile.text.includes("with")` pre-filter is
+what makes it the full amount, and it is sound in the one direction it is used:
+a `with` statement's source text necessarily contains the keyword, and a
+reserved word may not be spelled with a unicode escape, so absence of the
+substring is definite absence of the statement. It can never answer "yes" —
+`withDefaults()`, `{ writable: … }` and the word in a comment all match the
+substring, and there the AST walk remains the authority. The same idiom is
+already load-bearing in `collectGlobalObjectPropertyNames` (`this`/`globalThis`)
+and `collectHeterogeneouslyAssignedModuleVarNames` (which pre-filters on the
+identical `"with"` substring).
+
+### Why the skip is sound
+
+Neither walk can mark anything on a `with`-free source, so the gate is a pure
+skip and not a narrowing:
+
+- `markRealmGlobalWithTargets` — every effect it has is inside its
+  `if (ts.isWithStatement(node))` branch.
+- `collectRedeclaredWithTargetObjects` — its result loop `continue`s on
+  `!withTargetSymbols.has(symbol)`, and only a `ts.WithStatement` can populate
+  that set. The declaration half it also collects is then discarded unread.
+
+### Byte identity (base vs branch)
+
+`npx tsx scripts/prove-emit-identity.mjs`, golden baseline captured with the two
+files reverted to `origin/main` (file-copy A/B), then `check` on the branch:
+
+```
+[prove-emit-identity] IDENTICAL — all 84 (file,target) emits match baseline. ✓
+```
+
+84 = 21 files × 4 targets (`gc`, `standalone`, `wasi`, `linear`) — the 15-file
+default corpus (`website/playground/examples` + `scripts/emit-identity-corpus`),
+plus a 6-file `with` corpus written for this issue and passed via `--root`,
+because the default corpus contains no `with` statement at all and so proves
+nothing about the half of criterion 3 that matters. The `with` corpus covers
+the redeclared-`with`-target shape `collectRedeclaredWithTargetObjects` exists
+for, a realm-global `this.x = {…}` target, a top-level static + dynamic `with`,
+`with` inside a `for…in`, a `withDefaults`/`writable` lookalike with no `with`
+statement, and a plain `with`-free redeclaration.
+
+### Suites
+
+- **`with`-covering suites** — all 18 `tests/*with*` files, run on base and on
+  branch: **6 failed / 139 passed (145) on both**, failing-name diff **empty**.
+  The 6 are pre-existing on `origin/main` (#1387 ×2, #3521 telemetry, #4206
+  closure-IR ×2, #671 W1).
+- **Equivalence** — 8 shards sequential, `EQUIVALENCE_FORK_HEAP_MB=4096`,
+  24 known failures in the baseline, no new regressions on any shard.
+- **New** `tests/issue-5313-with-scan-gating.test.ts` — 13 tests: the
+  pre-filter's one-directional soundness (`withDefaults` reads false), a real
+  `with` in four positions reads true, zero traversals when the substring is
+  absent, memoization proved on the lookalike (first call really walks, second
+  costs 0) and on the positive answer, deterministic bytes for `with` and
+  `with`-free programs on gc/standalone/wasi, the redeclared-`with`-target
+  widening still producing 20, and the budget drop plus the fact that a
+  `with`-bearing fixture still pays for both scans (measured +20,267).
+- The three behavioural assertions were run against **base** first and give the
+  same answers there, so they lock a preserved invariant rather than new
+  behaviour.
+- Gates: `check:harness-compile-budget`, LOC/func (with the grants above, also
+  under `LOC_GATE_BASE=origin/main`), `check-coercion-sites`,
+  `check:oracle-ratchet`, `check:dead-exports`, `check:ir-dialect`,
+  `check:ir-kind-neutrality`, `check:jstag-seam`, `check:ir-layering`,
+  `check:ir-fallbacks`, `check:host-import-policy`,
+  `check:ir-only --policy=hybrid` (READY), `check:standalone-ir-cutover-corpus`,
+  `check:pushraw`, `check:stack-balance`, `check:codegen-fallbacks`,
+  `check:any-box-sites`, `check:speculative-rollback`, `check:ir-adoption`,
+  `check:linear-ir`, `typecheck`, `lint`, `prettier --check` — all pass.
+  `check:oracle-ratchet` and `check-coercion-sites` watch `src/codegen` and
+  report +0, as expected for a change that adds no checker query and no
+  coercion site.

--- a/scripts/harness-compile-budget.json
+++ b/scripts/harness-compile-budget.json
@@ -1,7 +1,7 @@
 {
-  "forEachChildCalls": 150774,
+  "forEachChildCalls": 142936,
   "marginPct": 15,
   "fixtureCallSites": 120,
   "updated": "2026-09-04",
-  "note": "Rebanked 2026-09-04 from a measured 150774 shared-forEachChild traversals (fixtureCallSites=120, margin 15%) for the #3437 representative harness assembly. Reseed with `npx tsx scripts/check-harness-compile-budget.ts --update` when a slowdown is intentional and justified. See the script header."
+  "note": "Rebanked 2026-09-04 from a measured 142936 shared-forEachChild traversals (fixtureCallSites=120, margin 15%) for the #3437 representative harness assembly. Reseed with `npx tsx scripts/check-harness-compile-budget.ts --update` when a slowdown is intentional and justified. See the script header."
 }

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -21,6 +21,7 @@ import {
   bindingUsesOnlyIrPlannedOpenObjectOperations,
 } from "./dynamic-with-shape.js";
 import { collectRedeclarationWidenedModuleVarNames } from "./redeclared-var-widening.js";
+import { sourceContainsWithStatement } from "../source-scan-predicates.js"; // (#5313)
 
 function isUnboxedPrimitiveCarrier(type: ValType): boolean {
   return ["f64", "f32", "i64", "i32", "i16", "i8"].includes(type.kind);
@@ -1102,6 +1103,12 @@ function collectRedeclaredWithTargetObjects(
   checker: ts.TypeChecker,
   sourceFile: ts.SourceFile,
 ): void {
+  // (#5313) A pure skip, not a narrowing: the result loop below `continue`s on
+  // `!withTargetSymbols.has(symbol)`, and only a `ts.WithStatement` can populate
+  // that set — so on a `with`-free source this walk provably marks nothing and
+  // the declaration half it also collects is discarded unread. It ran
+  // unconditionally, at a full pass (3,919 traversals on the #3437 fixture).
+  if (!sourceContainsWithStatement(sourceFile)) return;
   const declarationsBySymbol = new Map<ts.Symbol, ts.VariableDeclaration[]>();
   const withTargetSymbols = new Set<ts.Symbol>();
   const visit = (node: ts.Node): void => {
@@ -1224,7 +1231,8 @@ export function collectGrowableObjectLiterals(
     }
     forEachChild(node, markRealmGlobalWithTargets);
   };
-  markRealmGlobalWithTargets(sourceFile);
+  // (#5313) Same pure skip: every effect above is inside the `isWithStatement` test.
+  if (sourceContainsWithStatement(sourceFile)) markRealmGlobalWithTargets(sourceFile);
   collectRepeatedOrdinaryToPrimitiveObjects(ctx, checker, sourceFile);
   collectRedeclaredObjectIdentityLiterals(ctx, checker, sourceFile);
   collectRedeclaredShapeDivergentObjects(ctx, checker, sourceFile); // (#5270 step 3, cluster M)

--- a/src/codegen/source-scan-predicates.ts
+++ b/src/codegen/source-scan-predicates.ts
@@ -668,6 +668,53 @@ export function sourceContainsBindingPattern(sourceFile: ts.SourceFile): boolean
   return found;
 }
 
+/** Per-file memo for {@link sourceContainsWithStatement}. */
+const withStatementCache = new WeakMap<ts.SourceFile, boolean>();
+
+/**
+ * (#5313) True iff the source contains a `with` statement anywhere.
+ *
+ * Unlike the short-circuiting predicates above, a NEGATIVE answer here costs a
+ * FULL pass — "no `with` anywhere" is only knowable after visiting every node.
+ * That makes the memo and the text pre-filter load-bearing rather than
+ * decorative: the two `with`-target scans in
+ * `declarations/object-shape-widening.ts` that this gates cost 7,838 of the
+ * #3437 harness compile-work budget (two full passes over the 3,919-node
+ * fixture), and gating them on an *unconditional* AST walk would have refunded
+ * only half of that.
+ *
+ * The `text` pre-filter is sound in the one direction it is used: a `with`
+ * statement's source text necessarily contains the keyword, and a reserved word
+ * may not be spelled with a unicode escape (escaping any letter of the keyword
+ * is a SyntaxError, so there is no spelling of the statement that hides from
+ * the substring test). So absence of the substring is DEFINITE absence of the
+ * statement, and the filter can never say "yes" — `withDefaults()`,
+ * `{ writable: true }` in a member name, or the word in a comment all match the
+ * substring, and for those the AST walk remains the authority and answers
+ * false. Same idiom as `collectGlobalObjectPropertyNames`'s `this`/`globalThis`
+ * precondition and `collectHeterogeneouslyAssignedModuleVarNames`.
+ *
+ * Memoized per `ts.SourceFile` so the second and later consumers are free.
+ */
+export function sourceContainsWithStatement(sourceFile: ts.SourceFile): boolean {
+  const cached = withStatementCache.get(sourceFile);
+  if (cached !== undefined) return cached;
+  let found = false;
+  if (sourceFile.text.includes("with")) {
+    const walk = (node: ts.Node): void => {
+      if (found) return;
+      if (ts.isWithStatement(node)) {
+        found = true;
+        return;
+      }
+      forEachChild(node, walk);
+    };
+    walk(sourceFile);
+  }
+  withStatementCache.set(sourceFile, found);
+  return found;
+}
+
 /**
  * (#1719 S1) Whole-program pre-scan for the `ITER_OVERRIDDEN` brand of the
  * array object-value representation track. Returns true iff the source may

--- a/tests/issue-5313-with-scan-gating.test.ts
+++ b/tests/issue-5313-with-scan-gating.test.ts
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5313 — the two `with`-target scans in
+// `src/codegen/declarations/object-shape-widening.ts` ran UNCONDITIONALLY:
+// `markRealmGlobalWithTargets` inside `collectGrowableObjectLiterals`, and the
+// `visit` inside `collectRedeclaredWithTargetObjects`. Both exist only to find
+// `ts.WithStatement` nodes, and each cost a full pass over the source — 7,838
+// of the #3437 harness compile-work budget on a fixture containing no `with`,
+// which is ~40 % of the 2026-08-20 → 2026-09-04 drift bisected in #5306.
+//
+// Both are now gated on the memoized `sourceContainsWithStatement` predicate.
+// These tests lock in the three things that can break:
+//   • the predicate's soundness — the `sourceFile.text` pre-filter may only
+//     ever say "no", never "yes" (`withDefaults()` must NOT read as a `with`),
+//   • that the gate is a pure SKIP, not a semantic narrowing — a `with` source
+//     still gets both scans and still emits/behaves identically,
+//   • that the traversal saving is real and still there.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+import { ts, enableForEachChildMeter, disableForEachChildMeter, readForEachChildCalls } from "../src/ts-api.js";
+import { sourceContainsWithStatement } from "../src/codegen/source-scan-predicates.js";
+import { buildRepresentativeAssembly } from "../scripts/check-harness-compile-budget.js";
+
+/** The figure measured on `origin/main` immediately before this change (#5306's rebank). */
+const PRE_5313_MEASURED = 150_774;
+/** One full pass over the #3437 fixture, per #5306's per-caller attribution. */
+const ONE_FIXTURE_PASS = 3_919;
+
+const BUDGET = JSON.parse(readFileSync(resolve(__dirname, "../scripts/harness-compile-budget.json"), "utf-8")) as {
+  forEachChildCalls: number;
+  marginPct: number;
+  fixtureCallSites: number;
+};
+
+function parse(text: string): ts.SourceFile {
+  return ts.createSourceFile("t.ts", text, ts.ScriptTarget.Latest, true);
+}
+
+/** Shared-`forEachChild` invocations performed by `fn`. */
+function traversals(fn: () => void): number {
+  enableForEachChildMeter();
+  try {
+    fn();
+    return readForEachChildCalls();
+  } finally {
+    disableForEachChildMeter();
+  }
+}
+
+async function meterCompile(source: string): Promise<number> {
+  enableForEachChildMeter();
+  try {
+    // The assembly need not compile cleanly — the WORK is what is measured.
+    await compile(source, { fileName: "harness-budget-fixture.ts" });
+    return readForEachChildCalls();
+  } finally {
+    disableForEachChildMeter();
+  }
+}
+
+async function runModule(pre: string, ret: string, target?: "standalone"): Promise<any> {
+  const src = `${pre}\nexport function test(): any { return ${ret}; }`;
+  const result: any = await compile(src, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+    ...(target ? { target } : {}),
+  } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  (instance.exports as any).__module_init?.();
+  const exp = wrapExports(instance.exports, { signatures: result.exportSignatures });
+  return exp.test();
+}
+
+describe("#5313 sourceContainsWithStatement — the AST walk is the authority", () => {
+  it("answers false for `with`-shaped identifiers and property names", () => {
+    const sf = parse(
+      [
+        "function withDefaults(o) { return o; }",
+        "const withering = { writable: true, withCredentials: false };",
+        "const bandwidth = withDefaults(withering);",
+        "// a comment mentioning with (o) { } that is not a with statement",
+        'const s = "with (o) { }";',
+      ].join("\n"),
+    );
+    expect(sf.text.includes("with")).toBe(true); // the pre-filter says "maybe"
+    expect(sourceContainsWithStatement(sf)).toBe(false); // the AST walk says no
+  });
+
+  it("answers true for a real `with`, wherever it sits", () => {
+    expect(sourceContainsWithStatement(parse("var o = { z: 1 };\nwith (o) { z = 2; }"))).toBe(true);
+    expect(sourceContainsWithStatement(parse("function f(o) { with (o) { return z; } }"))).toBe(true);
+    expect(sourceContainsWithStatement(parse("var o = {};\nfor (var k in o) { with (o) { p = 1; } }"))).toBe(true);
+    expect(sourceContainsWithStatement(parse("var o = {};\nwith ((o) || null) { p = 1; }"))).toBe(true);
+  });
+
+  it("costs ZERO traversals when the source has no `with` substring at all", () => {
+    const sf = parse("var obj = { a: 1 };\nvar obj = { b: 2 };\nobj.b = 3;");
+    expect(sf.text.includes("with")).toBe(false);
+    expect(traversals(() => expect(sourceContainsWithStatement(sf)).toBe(false))).toBe(0);
+  });
+
+  it("memoizes per source file — a second call re-walks nothing", () => {
+    // Deliberately the lookalike: the pre-filter cannot short-circuit it, so
+    // the FIRST call must really walk. That is what makes the second call's
+    // zero meaningful rather than an artefact of the pre-filter.
+    const sf = parse("function withDefaults(o) { return o; }\nconst x = withDefaults({ a: 1 });");
+    const first = traversals(() => expect(sourceContainsWithStatement(sf)).toBe(false));
+    expect(first).toBeGreaterThan(0);
+    const second = traversals(() => expect(sourceContainsWithStatement(sf)).toBe(false));
+    expect(second).toBe(0);
+  });
+
+  it("memoizes the positive answer too, and short-circuits on the first hit", () => {
+    const sf = parse("var o = { z: 1 };\nwith (o) { z = 2; }\n" + "var pad = 1;\n".repeat(200));
+    const first = traversals(() => expect(sourceContainsWithStatement(sf)).toBe(true));
+    expect(first).toBeGreaterThan(0);
+    // Short-circuit: finding the `with` early must not cost a full walk of the
+    // 200 trailing statements.
+    expect(first).toBeLessThan(50);
+    expect(traversals(() => expect(sourceContainsWithStatement(sf)).toBe(true))).toBe(0);
+  });
+});
+
+describe("#5313 the gate is a pure skip, not a semantic narrowing", () => {
+  // The two shapes the gated scans exist for, plus their `with`-free twins.
+  const REDECLARED_WITH_TARGET = [
+    "var obj: any = { a: 1 };",
+    "with (obj) { a = 10; }",
+    "var obj: any = { b: 2 };",
+    "with (obj) { b = 20; }",
+  ].join("\n");
+  const WITH_FREE_LOOKALIKE = [
+    "function withDefaults(o: any): any { return o; }",
+    "const withering = { writable: true };",
+    "const bandwidth: any = withDefaults(withering);",
+  ].join("\n");
+
+  it.each(["gc", "standalone", "wasi"] as const)("emits deterministic bytes on %s", async (target) => {
+    for (const src of [REDECLARED_WITH_TARGET, WITH_FREE_LOOKALIKE]) {
+      const a: any = await compile(src + "\nexport function test(): any { return 1; }", {
+        fileName: "test.ts",
+        skipSemanticDiagnostics: true,
+        inferModuleStrictArguments: false,
+        target,
+      } as any);
+      const b: any = await compile(src + "\nexport function test(): any { return 1; }", {
+        fileName: "test.ts",
+        skipSemanticDiagnostics: true,
+        inferModuleStrictArguments: false,
+        target,
+      } as any);
+      expect(a.binary?.length).toBeGreaterThan(0);
+      // The predicate memo is keyed on `ts.SourceFile` identity, so a second
+      // compile builds a fresh AST and re-answers from scratch. Identical bytes
+      // prove the memo introduces no cross-compile order dependence.
+      expect(Buffer.from(b.binary).equals(Buffer.from(a.binary))).toBe(true);
+    }
+  });
+
+  it("still widens a redeclared `with`-target object (standalone)", async () => {
+    // The exact shape `collectRedeclaredWithTargetObjects` exists for: one
+    // binding, two differently shaped literals, each used as a `with` target.
+    // The later literal's key must survive — a skipped scan here would lose it.
+    expect(await runModule(REDECLARED_WITH_TARGET, "obj.b", "standalone")).toBe(20);
+  });
+
+  it("still executes an ordinary top-level `with` (standalone)", async () => {
+    expect(await runModule("var s: any = { z: 9 };\nwith (s) { z = 44; }", "(s as any).z", "standalone")).toBe(44);
+  });
+
+  it("does not confuse a `withDefaults` call for a `with` statement", async () => {
+    expect(await runModule(WITH_FREE_LOOKALIKE, "bandwidth.writable ? 1 : 0")).toBe(1);
+  });
+});
+
+describe("#5313 harness compile-work budget", () => {
+  it("drops below the pre-#5313 figure and holds the banked budget", async () => {
+    const measured = await meterCompile(buildRepresentativeAssembly(BUDGET.fixtureCallSites));
+    expect(measured).toBeLessThan(PRE_5313_MEASURED);
+    // Two full fixture passes are what the gate refunds.
+    expect(PRE_5313_MEASURED - measured).toBeGreaterThanOrEqual(2 * ONE_FIXTURE_PASS);
+    expect(measured).toBeLessThanOrEqual(Math.ceil(BUDGET.forEachChildCalls * (1 + BUDGET.marginPct / 100)));
+  });
+
+  it("still pays for both scans when the source DOES contain `with`", async () => {
+    const free = buildRepresentativeAssembly(BUDGET.fixtureCallSites);
+    const withed = free + "var wt = { q: 1 };\nwith (wt) { q = 2; }\n";
+    const freeCount = await meterCompile(free);
+    const withCount = await meterCompile(withed);
+    // Adding one `with` re-admits both gated walks (2 × 3,919) plus the
+    // `with`-only analysis downstream. Measured delta 2026-09-04: +20,267.
+    expect(withCount - freeCount).toBeGreaterThan(2 * ONE_FIXTURE_PASS);
+  });
+});


### PR DESCRIPTION
Gates the two `with`-statement scans in `src/codegen/declarations/object-shape-widening.ts` on a new memoized predicate, refunding **7,838 traversals** — 5.2 % — of the [#3437](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3437-test262-harness-speed-gate) harness compile-work budget.

Closes [#5313](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5313-unconditional-with-scans-object-shape-widening).

## The problem

[#5306](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5306-harness-compile-budget-ceiling-margin-exhausted) bisected 40 % of the 2026-08-20 → 2026-09-04 budget drift to two **unconditional** whole-file walks whose only payload is finding a `ts.WithStatement`:

- `markRealmGlobalWithTargets`, an inner arrow inside `collectGrowableObjectLiterals`;
- the `visit` inside `collectRedeclaredWithTargetObjects`.

Both ran on every compile. Neither can mark anything on a source with no `with` in it, and `with` is rare in real input — so this was ~7.8 k traversals of pure cost on almost every compile.

## The fix

A memoized `sourceContainsWithStatement(sourceFile)` in `src/codegen/source-scan-predicates.ts`, alongside `sourceContainsClass` / `sourceContainsBindingPattern`, gating both walks.

**The `sourceFile.text` pre-filter is load-bearing, not an optimisation.** A *negative* answer to "does this contain a `with`" is only knowable after visiting every node — the walk cannot short-circuit the way `sourceContainsClass` does. Gating two full passes on an unconditional AST walk would have refunded 3,919, not 7,838. The pre-filter is sound in the one direction it is used: a `with` statement's text necessarily contains the keyword, and a reserved word may not be spelled with a unicode escape, so absence of the substring is *definite* absence of the statement. It can never answer "yes" — `withDefaults()`, `{ writable: … }` and the word in a comment all match, and there the AST walk remains the authority. The same idiom already backs `collectGlobalObjectPropertyNames` and `collectHeterogeneouslyAssignedModuleVarNames`.

The gate is a **pure skip, not a semantic narrowing**: `markRealmGlobalWithTargets` has every effect inside its `isWithStatement` branch, and `collectRedeclaredWithTargetObjects`' result loop `continue`s on `!withTargetSymbols.has(symbol)`, a set only a `ts.WithStatement` can populate. `with` sources still get both scans, unchanged.

## Measured

| | before | after | delta |
| --- | ---: | ---: | ---: |
| harness compile work | 150,774 | **142,936** | **−7,838** (−5.20 %) |
| `object-shape-widening.ts` | 23,499 | **15,661** | −7,838 |
| `source-scan-predicates.ts` | 11,804 | 11,804 | +0 |
| everything else | 115,471 | 115,471 | +0 |

Per call site, from #5306's method (the `forEachChildMeter` in `src/ts-api.ts` temporarily patched to record caller frames, then reverted). One full fixture pass = 3,919:

| call site | before | after |
| --------- | -----: | ----: |
| `markRealmGlobalWithTargets` | 3,919 | **0** |
| `visit` in `collectRedeclaredWithTargetObjects` | 3,919 | **0** |
| `sourceContainsWithStatement` (new) | — | **0** |

`scripts/harness-compile-budget.json` rebanked with `--update` (a decrease is the sanctioned write): budget 150,774 → 142,936, ceiling 173,391 → 164,377, margin left 21,441 (13.04 %). The file lands back on its exact pre-#4922 number.

## Validation

- **Byte identity, base vs branch** — `scripts/prove-emit-identity.mjs`, golden baseline captured with the two files reverted to `origin/main` (file-copy A/B): `IDENTICAL — all 84 (file,target) emits match baseline`. 84 = 21 files × 4 targets (gc/standalone/wasi/linear). The default corpus contains no `with` at all, so a 6-file `with` corpus was written and passed via `--root`, covering the redeclared-`with`-target shape, a realm-global target, static + dynamic top-level `with`, `with` in a `for…in`, a `withDefaults` lookalike, and a `with`-free redeclaration.
- **`with`-covering suites** — all 18 `tests/*with*` files run on base and branch: 6 failed / 139 passed (145) on **both**, failing-name diff empty. The 6 are pre-existing on `origin/main`.
- **Equivalence** — 8 shards sequential, `EQUIVALENCE_FORK_HEAP_MB=4096`, 24 known baseline failures, no new regressions.
- **New** `tests/issue-5313-with-scan-gating.test.ts` (13 tests) — pre-filter soundness, memoization proved on the lookalike (first call really walks, second costs 0), deterministic bytes on gc/standalone/wasi, the redeclared-`with`-target widening still producing 20, and that a `with`-bearing fixture still pays for both scans (+20,267). The behavioural assertions were run against base first, so they lock a preserved invariant rather than new behaviour.
- Gates: LOC/func (also under `LOC_GATE_BASE=origin/main`), coercion-sites, oracle-ratchet, dead-exports, ir-dialect, ir-kind-neutrality, jstag-seam, ir-layering, ir-fallbacks, host-import-policy, `ir-only --policy=hybrid` (READY), standalone-ir-cutover-corpus, pushraw, stack-balance, codegen-fallbacks, any-box-sites, speculative-rollback, ir-adoption, linear-ir, typecheck, lint, prettier — all pass.

## LOC / func grants

Both budgets sit at **zero headroom** for this god-file, so any guard at all needs a grant. `loc-budget-allow` (+8) and `func-budget-allow` (+1) are in the issue's own frontmatter with a dated rationale: one import, two gate lines, and the comment lines carrying the soundness argument for each skip. The change is a net *reduction* in compiler work bought for 8 lines of guard.

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Namds9phYeHvpLKu735io3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Namds9phYeHvpLKu735io3)_