### PR TITLE
fix(#5301): a self-recursive arrow must not box its recursion inside a branch

### DIFF
--- a/plan/issues/5301-self-recursive-arrow-conditional-box.md
+++ b/plan/issues/5301-self-recursive-arrow-conditional-box.md
@@ -1,0 +1,105 @@
+---
+id: 5301
+title: "A self-recursive arrow boxes its own recursion inside a conditional arm, so the other arm reads null"
+status: done
+sprint: current
+created: 2026-09-03
+updated: 2026-09-03
+completed: 2026-09-03
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+`arrow-phases.ts` already documents this hazard, at the eager-box site:
+
+> A construction site in a conditional arm cannot own the canonical box for a
+> captured parameter: compilation re-aims all later reads to that box even when
+> the arm is skipped at runtime.
+
+Its guard, `canBoxBindingInDominatingParent`, admits two safe sources — a
+declared parameter of the owner function, and a local initialised before the
+region. **The self-recursive arrow binding is neither.** Inside the lifted body
+that name resolves to `__self`, lifted param 0; its NAME belongs to the outer
+binding and appears in no `owner.parameters` entry, so the parameter test cannot
+see it, and the local test rejects it for being a param.
+
+So the box is created inside whichever conditional arm first constructs a nested
+closure over the recursion, and every later recursive reference is re-aimed at
+that box. On any path that skipped the arm the box is null:
+
+```js
+const visit = (s) => {
+  if (Array.isArray(s)) { const r = []; s.forEach((v, i) => { r[i] = visit(v); }); return r; }
+  const t = {}; for (const k in s) t[k] = visit(s[k]); return t;   // ← reads the null box
+};
+visit({ a: [{ b: 7 }] });   // RuntimeError: dereferencing a null pointer
+```
+
+The emitted body makes it plain — `local.get 9` is `$__boxed_visit`, assigned
+only inside the `Array.isArray` arm:
+
+```wat
+(if  ;; Array.isArray(s)
+  (then
+  …
+  local.get 0        ;; __self
+  struct.new 16      ;; $__boxed_visit  ← created HERE, inside the arm
+  local.tee 9
+  struct.new 19      ;; the forEach callback's env
+  …))
+…
+local.get 9          ;; the object arm's recursive call
+struct.get 16 0      ;; ← traps: local 9 is null on this path
+```
+
+**Source order alone decided whether the function trapped.** Putting the object
+arm first made the identical program work, because the direct recursive call was
+then compiled before the box existed and resolved through `__self`.
+
+Three ingredients are all required — a recursive call inside a nested closure, a
+recursive call outside it, and a first call that takes the arm without the
+closure. Any two of the three run correctly, which is why this survived.
+
+## Fix
+
+Admit the self-recursive binding as a third safe source in
+`canBoxBindingInDominatingParent`. `__self` is lifted param 0: always live at
+entry and never written, so it is eligible for the eager dominating box the
+file's own rule already prescribes. The predicate matching the binding is the
+same one `collectArrowCaptures` uses to route the recursive call (#2118).
+
+**`localIdx === 0` alone is not proof, and assuming it was cost a regression.**
+In a body that was NOT lifted, slot 0 is the arrow's own first PARAMETER, so a
+first cut boxed the parameter instead of the recursion and jest's
+`packages/jest-jasmine2/src/__tests__/concurrent.test.ts` went 3/3 → 0/3. The
+guard therefore requires the synthetic self param by name
+(`fctx.params[0]?.name === "__self"`). The regression was invisible in the
+first sweep because that suite crashed on an unrelated harness
+fixture-resolution error and was never scored — a missing number read as
+"unchanged" until it was re-run alone.
+
+## Measured
+
+- `tests/self-recursive-arrow-conditional-capture.test.ts`: **4 of 6 cases fail
+  on the parent commit; all 6 pass with the fix.** The two that already passed
+  are the guards — the object-arm-first ordering, and a recursion with no nested
+  closure at all.
+- **axios 190/231 → 191/231**, and the `dereferencing a null pointer` bucket
+  goes from **12 failures to 1**. The eleven `AxiosError.test.js` redaction
+  tests stop trapping; they still fail, now on ordinary assertion mismatches, so
+  a second defect sits behind this one.
+- axios' `redactConfig` and `toJSONObject` are exactly this shape: an array arm
+  using `forEach` plus an object arm walking entries.
+- **A/B over 17 upstream npm suites at one HEAD**: axios is the only package
+  that moves (108/231 → 109/231). webpack, three, clsx, cookie, lodash, redux,
+  stylelint, tailwindcss, jsdom, styled-components, uuid, marked, moment,
+  prettier, jest and hono are byte-identical per test file — jest and prettier
+  each re-run alone after being killed/crashed under load rather than being
+  reported as unchanged.

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -171,6 +171,26 @@ function directInitializedLocalBeforeRegion(
   return undefined;
 }
 
+/**
+ * (#2118 mirror) The binding name a `const f = (…) => …` / `let f = …` arrow
+ * refers to itself by. Inside the lifted body that name resolves to `__self`
+ * (lifted param 0), not to any declared parameter — the same predicate
+ * `collectArrowCaptures` uses to route the recursive call.
+ */
+function selfRecursiveArrowBindingName(owner: ts.Node): string | undefined {
+  if (!ts.isArrowFunction(owner) && !(ts.isFunctionExpression(owner) && !owner.name)) return undefined;
+  const declaration = owner.parent;
+  if (
+    declaration &&
+    ts.isVariableDeclaration(declaration) &&
+    declaration.initializer === owner &&
+    ts.isIdentifier(declaration.name)
+  ) {
+    return declaration.name.text;
+  }
+  return undefined;
+}
+
 function canBoxBindingInDominatingParent(
   fctx: FunctionContext,
   closure: ts.ArrowFunction | ts.FunctionExpression,
@@ -204,7 +224,22 @@ function canBoxBindingInDominatingParent(
     localIdx < fctx.params.length && sourceParameter !== undefined && sourceParameter.initializer === undefined;
   const safeInitializedLocal =
     localIdx >= fctx.params.length && directInitializedLocalBeforeRegion(ownerBody, region, name) !== undefined;
-  if (!safeSourceParameter && !safeInitializedLocal) return false;
+  // (#2118) The self-recursive arrow binding resolves to `__self`, lifted param
+  // 0 — always live at entry and never written. It has no entry in
+  // `owner.parameters` (the name belongs to the OUTER binding), so the
+  // parameter test cannot see it, and the local test rejects it for being a
+  // param. Without this a nested closure that captures the recursion boxes it
+  // inside whichever conditional arm happens to construct that closure first,
+  // and every LATER recursive reference is re-aimed at that box — reading null
+  // on any path that skipped the arm. Source order alone then decides whether
+  // the function traps.
+  // `localIdx === 0` alone is NOT proof: in a body that was not lifted, slot 0
+  // is the arrow's own FIRST PARAMETER, and boxing that instead of the
+  // recursion is a miscompile (measured: jest's `test.concurrent.each` fixture
+  // went 3/3 → 0/3). Require the synthetic self param by NAME.
+  const safeSelfBinding =
+    localIdx === 0 && fctx.params[0]?.name === "__self" && selfRecursiveArrowBindingName(owner) === name;
+  if (!safeSourceParameter && !safeInitializedLocal && !safeSelfBinding) return false;
 
   // The parent buffer already contains every preceding top-level statement,
   // so writes before `region` are reflected in the value we box there. Refuse

--- a/tests/self-recursive-arrow-conditional-capture.test.ts
+++ b/tests/self-recursive-arrow-conditional-capture.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// A self-recursive `const` arrow whose recursion is ALSO captured by a nested
+// closure, where that nested closure is constructed inside a conditional arm.
+//
+// `arrow-phases.ts` already documents the hazard at the eager-box site: "A
+// construction site in a conditional arm cannot own the canonical box for a
+// captured parameter: compilation re-aims all later reads to that box even when
+// the arm is skipped at runtime." Its guard, `canBoxBindingInDominatingParent`,
+// admits two safe sources — a declared parameter of the owner, and a local
+// initialised before the region. The self-recursive binding is NEITHER: inside
+// the lifted body it resolves to `__self`, lifted param 0, whose NAME belongs to
+// the outer binding and appears in no `owner.parameters` entry.
+//
+// So the box was created inside whichever conditional arm first constructed a
+// nested closure over the recursion, and every LATER recursive reference was
+// re-aimed at that box. On any path that skipped the arm the box is null:
+//
+//     const visit = (s) => {
+//       if (Array.isArray(s)) { const r = []; s.forEach((v, i) => { r[i] = visit(v); }); return r; }
+//       const t = {}; for (const k in s) t[k] = visit(s[k]); return t;   // ← reads the null box
+//     };
+//     visit({ a: [{ b: 7 }] });   // RuntimeError: dereferencing a null pointer
+//
+// **Source order alone decided whether the function trapped.** Putting the
+// object branch first made the same program work, because the direct recursive
+// call was then compiled before the box existed and resolved through `__self`.
+// Both orders are pinned below.
+//
+// Reached by axios' `redactConfig` and `toJSONObject`, which are exactly this
+// shape — an array arm using `forEach` plus an object arm walking entries.
+// Eleven of `AxiosError.test.js`'s redaction tests trapped here.
+//
+// The fixtures are plain untyped `.js`, matching how the upstream npm suites
+// feed package code in.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+const ENTRY = `import { run } from "./mod.js";\nexport function test(): any { return (run as unknown as () => unknown)(); }`;
+
+async function runModule(moduleSource: string): Promise<unknown> {
+  const root = mkdtempSync(join(tmpdir(), "js2-self-rec-arrow-"));
+  roots.push(root);
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, "mod.js"), moduleSource);
+  writeFileSync(join(root, "entry.ts"), ENTRY);
+  const result = await compileProject(join(root, "entry.ts"), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const instance = await instantiateWithRuntime(result);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+const ARRAY_ARM = `if (Array.isArray(s)) { const r = []; s.forEach((v, i) => { r[i] = visit(v); }); return r; }`;
+const OBJECT_ARM = `const t = {}; for (const k in s) t[k] = visit(s[k]); return t;`;
+
+describe("self-recursive arrow captured by a closure in a conditional arm", () => {
+  it("recurses on the object path when the array arm is compiled first", async () => {
+    expect(
+      await runModule(`export function run() {
+  const visit = (s) => {
+    if (s === null || typeof s !== "object") return s;
+    ${ARRAY_ARM}
+    ${OBJECT_ARM}
+  };
+  return visit({ a: [{ b: 7 }] }).a[0].b;
+}`),
+    ).toBe(7);
+  });
+
+  it("still recurses when the object arm is compiled first", async () => {
+    // This order already worked — it pins that the fix did not move it.
+    expect(
+      await runModule(`export function run() {
+  const visit = (s) => {
+    if (s === null || typeof s !== "object") return s;
+    if (!Array.isArray(s)) { ${OBJECT_ARM} }
+    ${ARRAY_ARM}
+    return s;
+  };
+  return visit({ a: [{ b: 7 }] }).a[0].b;
+}`),
+    ).toBe(7);
+  });
+
+  it("recurses on the array path too", async () => {
+    expect(
+      await runModule(`export function run() {
+  const visit = (s) => {
+    if (s === null || typeof s !== "object") return s;
+    ${ARRAY_ARM}
+    ${OBJECT_ARM}
+  };
+  return visit([{ b: 1 }, { b: 2 }])[1].b;
+}`),
+    ).toBe(2);
+  });
+
+  it("recurses through `map` as well as `forEach`", async () => {
+    expect(
+      await runModule(`export function run() {
+  const visit = (s) => {
+    if (s === null || typeof s !== "object") return s;
+    if (Array.isArray(s)) return s.map((v) => visit(v));
+    const t = {};
+    for (const [k, v] of Object.entries(s)) t[k] = visit(v);
+    return t;
+  };
+  return visit({ a: [{ b: 3 }] }).a[0].b;
+}`),
+    ).toBe(3);
+  });
+
+  it("survives three arms where only the middle one captures the recursion", async () => {
+    expect(
+      await runModule(`export function run() {
+  const visit = (s) => {
+    if (typeof s === "number") return s + 1;
+    if (Array.isArray(s)) { const r = []; s.forEach((v, i) => { r[i] = visit(v); }); return r; }
+    if (s && typeof s === "object") { const t = {}; for (const k in s) t[k] = visit(s[k]); return t; }
+    return s;
+  };
+  return visit({ a: { b: 4 } }).a.b;
+}`),
+    ).toBe(5);
+  });
+
+  // Guard — a recursion with no nested-closure capture never boxed at all.
+  it("keeps a purely direct recursion working", async () => {
+    expect(
+      await runModule(`export function run() {
+  const visit = (s) => {
+    if (s === null || typeof s !== "object") return s;
+    if (Array.isArray(s)) { const r = []; for (let i = 0; i < s.length; i++) r[i] = visit(s[i]); return r; }
+    const t = {};
+    for (const k in s) t[k] = visit(s[k]);
+    return t;
+  };
+  return visit({ a: [{ b: 6 }] }).a[0].b;
+}`),
+    ).toBe(6);
+  });
+});


### PR DESCRIPTION
`arrow-phases.ts` already documents this hazard, at the eager-box site:

> A construction site in a conditional arm cannot own the canonical box for a captured parameter: compilation re-aims all later reads to that box even when the arm is skipped at runtime.

Its guard, `canBoxBindingInDominatingParent`, admits two safe sources — a declared parameter of the owner, and a local initialised before the region. **The self-recursive arrow binding is neither.** Inside the lifted body it resolves to `__self`, lifted param 0; its *name* belongs to the outer binding and appears in no `owner.parameters` entry, so the parameter test cannot see it and the local test rejects it for being a param.

So the box was created inside whichever conditional arm first constructed a nested closure over the recursion, and every later recursive reference was re-aimed at that box. On any path that skipped the arm the box is null:

```js
const visit = (s) => {
  if (Array.isArray(s)) { const r = []; s.forEach((v, i) => { r[i] = visit(v); }); return r; }
  const t = {}; for (const k in s) t[k] = visit(s[k]); return t;   // ← reads the null box
};
visit({ a: [{ b: 7 }] });   // RuntimeError: dereferencing a null pointer
```

The emitted body makes it plain — `local.get 9` is `$__boxed_visit`, assigned only inside the `Array.isArray` arm:

```wat
(if  ;; Array.isArray(s)
  (then
  …
  local.get 0        ;; __self
  struct.new 16      ;; $__boxed_visit  ← created HERE, inside the arm
  local.tee 9
  struct.new 19      ;; the forEach callback's env
  …))
…
local.get 9          ;; the object arm's recursive call
struct.get 16 0      ;; ← traps: local 9 is null on this path
```

**Source order alone decided whether the function trapped.** Putting the object arm first made the identical program work, because the direct recursive call was then compiled before the box existed and resolved through `__self`. Three ingredients are all required — a recursive call inside a nested closure, one outside it, and a first call that takes the arm without the closure. Any two of the three run correctly, which is why this survived.

## Fix

Admit the self-recursive binding as a third safe source. `__self` is lifted param 0: always live at entry and never written, so it is eligible for the eager dominating box the file's own rule already prescribes. The predicate matching the binding is the same one `collectArrowCaptures` uses to route the recursive call ([#2118](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2118-self-recursive-const-arrow)).

**`localIdx === 0` alone is not proof, and assuming it was cost a regression.** In a body that was *not* lifted, slot 0 is the arrow's own first **parameter**, so a first cut boxed the parameter instead of the recursion and jest's `packages/jest-jasmine2/src/__tests__/concurrent.test.ts` went 3/3 → 0/3. The guard now requires the synthetic self param by name (`fctx.params[0]?.name === "__self"`). That regression was invisible in the first sweep because the jest suite crashed on an unrelated harness fixture-resolution error and was never scored — a missing number read as "unchanged" until it was re-run alone.

## Measured

- `tests/self-recursive-arrow-conditional-capture.test.ts`: **4 of 6 cases fail on the parent, all 6 pass with the fix** (re-verified after merging main). The two already-passing cases are the guards — the object-arm-first ordering, and a recursion with no nested closure at all.
- **axios 108/231 → 109/231**, and its `dereferencing a null pointer` bucket goes from **12 failures to 1**. The eleven `AxiosError.test.js` redaction tests stop trapping; they still fail on ordinary assertion mismatches, so a second defect sits behind this one. axios' `redactConfig` and `toJSONObject` are exactly this shape — an array arm using `forEach` plus an object arm walking entries.
- **A/B over 17 upstream npm suites at one HEAD**: axios is the only package that moves. webpack, three, clsx, cookie, lodash, redux, stylelint, tailwindcss, jsdom, styled-components, uuid, marked, moment, prettier, jest and hono are byte-identical per test file — jest and prettier were each re-run alone after being killed/crashed under load, rather than reported as unchanged.

Issue: [#5301](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5301-self-recursive-arrow-conditional-box)

🤖 Generated with [Claude Code](https://claude.com/claude-code)