### PR TITLE
docs(ir): plan next identity and class ownership slices

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -10,7 +10,7 @@ pr: 4733
 last_merged_pr: 4733
 sprint: current
 created: 2026-07-21
-updated: 2026-09-04
+updated: 2026-09-05
 priority: critical
 horizon: l
 complexity: L
@@ -5527,3 +5527,179 @@ transcript. Everything below is on `main` unless marked otherwise.
 - Plans live in issue files; implementers are Opus subagents (`senior-developer`, `isolation: worktree`), briefs list the full `quality` gate set, trailers `Model: Claude Opus 5 High`, and PR bodies go to the orchestrator's scratchpad because subagents cannot open PRs. The load gate blocks spawns at 1-min load ≥ 2 on this 4-core box.
 - A container restart on 2026-09-04 ~03:30Z killed two agents mid-validation; their worktrees survived and the W1-C implementation was salvaged by `git diff` from the dead worktree. Check `git -C .claude/worktrees/<agent> status` before re-running anything.
 - Claims: every landed slice's claim is completed on `origin/issue-assignments`; live claims at hand-over time are `5312` (opus-5312, running) and `5313` (PR #5572 in CI). `3520:w1h-…` is planned but **not** claimed.
+
+## Implementation Plan — 2026-09-05
+
+### W1-H execution lock: reject positively identified reference pairs before claim
+
+Planner: **Astra**. Source reviewed at `a53b1bd17338c01f4bffe2df6b3463d216990a6b`
+in the isolated `codex/ir-astra-plans-20260905` worktree. This section supersedes
+the September 4 W1-H implementation recipe, **not** the epic's acceptance
+criteria or its `in-progress` status. This is a source-grounded plan; the
+planner did not run compiler tests or repeat the historical corpus measurements.
+The implementer must produce fresh base/candidate evidence below.
+
+Lead-run preflight on this same base (September 5) independently reproduced
+the selected support-name collision test: one failed, one skipped, with a
+nonempty `irPostClaimErrors` assertion (`.tmp/ir-wave-20260905/equality-base.log`).
+The lead also reported typecheck and `check:ir-fallbacks` passing, and an
+IR-only report with five entries / 41 terminal units / 38 emitted / three
+non-executable / zero legacy bodies, Unsupported or Invariants **per lane**.
+These are attributed lead measurements, not runs performed by the planner;
+the implementer still needs its own focused base/candidate comparison.
+
+**Reserved slice:** `3520:w1h-equality-reference-operands`, owner
+`ttraenkler/luna-ir-equality-20260905`, branch
+`codex/3520-w1h-luna-20260905`. The lead verified the authoritative assignment
+record on September 5. Do not reclaim it under another owner. The older
+handover's "unclaimed" statement is historical.
+
+### Root cause and correction to the previous plan
+
+`selectorPrimitiveWrapperOrGenericBinary` (`src/ir/select.ts:7361`) still
+accepts generic equality after checking only each operand's syntax.
+`lowerBinary` (`src/ir/from-ast.ts:13027`, mismatch arm at `:13295`) still
+refuses closure/object carriers after claim. `checkerProvesBinarySourceCapabilityGap`
+(`:12625`) correctly distinguishes a source capability gap from a broken
+primitive producer; keep that distinction and its hard invariant backstop.
+
+The previous plan's second refusal condition is **not permitted**: two
+`undefined` results from `classifyDeclaredPrimitiveExpression` do not prove two
+references. `makeIrDeclaredPrimitiveExpressionClassifier`
+(`src/ir/module-bindings.ts:480-519`) also returns `undefined` for `any`,
+`unknown`, nonprimitive unions, and a failed checker query. There is real
+dynamic equality lowering at `from-ast.ts:13195` and `:13993`; a missing
+primitive classification must not suppress it or hide an invariant.
+
+No new checker hook is needed to fix the motivating callable pair:
+
+- `whyNotIrClaimable` (`select.ts:2003-2009`) records an expressible
+  `FunctionTypeNode` parameter through `recordCallableProjection` (`:7580`).
+- `knownCallableArity` (`:8329-8362`) consults that scoped evidence.
+- `obviousSelectorValueFamily` (`:9021-9061`) consequently returns
+  `"reference"` for **each** of `a` and `b` in the actual `hof.ts` fixture.
+  Scope snapshots, shadowing and mutation invalidation already belong to those
+  helpers; do not build another name table or alter their lifecycle.
+
+### Exact edits and boundary
+
+**Production ownership: `src/ir/select.ts`, only
+`selectorPrimitiveWrapperOrGenericBinary` and a small adjacent private helper
+if needed.** Leave `phase1MemberName` and class selection to the R3 lane.
+
+After the existing primitive-wrapper loose-equality special case and before
+the generic `isPhase1BinaryOp` tail:
+
+1. Match exactly `===`, `!==`, `==`, or `!=`.
+2. Ask `obviousSelectorValueFamily` for both operands in the current scope.
+3. If **both answers are positively `"reference"`**, return
+   `capabilityNo("operand-coercion-unsupported",
+   "expr-equality-reference-operands", expr)`.
+4. Otherwise retain the existing decision unchanged. In particular,
+   `undefined` evidence means **unproven**, not a reference and not a new
+   acceptance. This guard adds no admission path.
+
+The strict unshadowed-`undefined` arm (`select.ts:9562`) runs earlier.
+The new both-reference condition also excludes literal `null`; keep the
+existing strict-null lowering and module-extern guards unchanged. Do not use
+"either operand is a reference": reference/primitive and reference/nullish
+pairs have separate folds/coercion contracts this slice does not re-prove.
+
+The minimal deliverable is the callable-pair failure in
+`tests/issue-3520-support-callable-abi.test.ts:14-18,114-140`. Array and local
+class pairs qualify only through the existing positive family helper, and
+must be included in the fresh before/after matrix. A structural object
+parameter such as `a: { x: number }` may still have no positive family
+certificate; **do not add the old "undefined + undefined" heuristic to make
+that row pass**. Record its remaining outcome as a separate follow-up. A
+new exact reference classifier would be a separate scope with its own
+dynamic/unknown and carrier controls.
+
+**Wasm emission:** none is added. Unsupported owners retain the established
+direct fallback where policy allows it; they do not first allocate an IR body
+and then demote. Do not add `ref.eq`, a new IR node, a runtime import, boxing,
+or a representation conversion. `from-ast.ts`, the Program ABI resolver,
+`nodes.ts`, `lower.ts`, and all invariant/error classifiers are read-only.
+
+### Fresh verification required before widening the change
+
+Create `tests/issue-3520-equality-reference-operands.test.ts` using the
+`generateModule` / `generateMultiModule` and exact outcome patterns in
+`tests/issue-3529-selector-preclaim.test.ts` and the existing support-callable
+test. Run baseline cases before the production edit; use `target: "gc"` and
+`target: "standalone"`, never the ignored `standalone: true` spelling.
+
+| Case | Candidate contract |
+| --- | --- |
+| `a,b: () => number`, each of the four equality operators | Unsupported at **select**, exact code above, no post-claim build error |
+| The same strict comparison inside the original `try/catch` | Same; the callable scope evidence survives the nested body walk |
+| Existing multi-source support-name collision test | No support callable published, no post-claim equality error; retain every existing assertion |
+| Array and local-class reference pairs identified by the helper | Pre-claim refusal only where base actually reaches the unsupported reference lowerer; investigate any previously emitted row |
+| Structural-object params without positive family evidence | Record and preserve the base verdict; no invented reference proof |
+| Number/string/boolean equality, `x === undefined`, `x !== null` | Preserve base outcome, emitted bytes and executed value |
+| `any`/unknown operands, primitive unions, type assertions, omitted classifiers | Preserve base outcome; no new reference label merely because evidence is absent |
+| Inner primitive shadow of an outer callable, callable alias and mutation cases | Use existing scope/invalidation evidence; no text-only lookup |
+
+Enable `JS2WASM_IR_SHAPE_DIAG=1` **before module import** in a fresh test
+process to assert the arm `expr-equality-reference-operands:BinaryExpression`.
+Also assert a nonempty exact outcome population; an absent row is not a
+successful rejection. If base no longer demonstrates the motivating
+post-claim error, stop and report that evidence before changing selection.
+
+The production edit alone must be removable to make the new callable-pair
+assertions and original collision assertion fail again. Preserve and run the
+no-checker / same-primitive producer-invariant controls in
+`tests/issue-3529-*` and `tests/issue-4502.test.ts`; do not convert their hard
+failures into Unsupported to make this slice green.
+
+### Commands and evidence to hand back
+
+Run these from the implementer's isolated worktree, on both the captured base
+and candidate where a comparison is requested:
+
+```bash
+JS2WASM_IR_SHAPE_DIAG=1 pnpm exec vitest run tests/issue-3520-equality-reference-operands.test.ts tests/issue-3520-support-callable-abi.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+pnpm exec vitest run tests/issue-3529-selector-preclaim.test.ts tests/issue-3529-ir-producer-parity.test.ts tests/issue-3529-integration-preflight.test.ts tests/issue-4502.test.ts tests/issue-2949-direct-member-equality.test.ts tests/issue-4208-wrapper-loose-equality-ir.test.ts tests/issue-4208-strict-eq-type-disjoint.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+node --import tsx scripts/check-ir-fallbacks.ts
+node --import tsx scripts/check-ir-only.ts --policy=hybrid
+node --import tsx scripts/check-ir-only.ts --policy=ir-only
+pnpm run check:ir-dialect
+pnpm run check:ir-kind-neutrality
+pnpm run check:ir-layering
+pnpm run typecheck
+pnpm run lint
+node scripts/check-loc-budget.mjs && node scripts/check-func-budget.mjs && node scripts/check-coercion-sites.mjs && pnpm run check:oracle-ratchet && pnpm run check:dead-exports
+```
+
+Run the five ratchets again against the lead-verified main SHA using
+`LOC_GATE_BASE` for the LOC/function checks. Any grant belongs in this issue's
+frontmatter with the actual measured growth and reason; do not copy the old
+"approximately +25" estimate or edit main-owned budget baselines.
+
+Capture byte/diagnostic baselines before editing with
+`node --import tsx scripts/prove-emit-identity.mjs write --baseline .tmp/w1h-emit-base.json`,
+then the same command with `check --baseline .tmp/w1h-emit-base.json` on the
+candidate. Use `node --import tsx` here because this sandbox denies the CLI's
+IPC socket. This tool
+enumerates **`.ts` only**: it is not evidence for the dogfood `.js` corpus.
+For any additional `.js` cohort, record an explicit enumerated manifest,
+target, exact base/candidate SHA, per-row result and successful-compile floor.
+No historical 34/66/102-row count or "24 known failures" is a current result.
+Run the broader R1/R3 suites one file per invocation and report a fresh
+failing-name diff; the planned-support injection and Date/ambient-module-init
+failures are distinct residuals, not exemptions inferred from their names.
+Complete repository-required equivalence/quality checks before publication.
+
+### Luna max dispatch brief
+
+Implement only the reserved W1-H slice above, with **Luna / max**, in
+`codex/3520-w1h-luna-20260905`. You are not alone in the repository: preserve
+other edits, recheck the live claim/PR snapshot through the lead, and do not
+touch another lane's functions. Own the one selector function, the new
+focused test and this issue's measured landing record. First reproduce on the
+actual branch base, then add the positive-pair refusal and prove the
+before/after and removal controls. Source/test evidence outranks this plan.
+Return exact commands, base/head SHAs, moved outcome rows and any residual
+failures. Keep the epic open and do not claim reference-equality IR support:
+this slice removes a post-claim refusal, it does not implement reference
+identity lowering.

--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -4,7 +4,7 @@ title: "IR-only R3: compile-once classes, members, and closures"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-09-04
+updated: 2026-09-05
 assignee: ttraenkler/codex
 branch: codex/3522-f2-owner-aware-direct-calls
 priority: critical
@@ -5202,3 +5202,243 @@ The annotated `classes.js` twin now compiles every executable unit once
 - #5312 (uninitialised declared field reads as a null ref, not `undefined`) is
   being implemented by opus-5312 at hand-over time; its PR will carry the
   decision between read-site mapping and comparison folding.
+
+## Implementation Plan — 2026-09-05
+
+### W1-D: literal computed instance-method names, with exact body ownership
+
+Planner: **Astra**. Source review base:
+`a53b1bd17338c01f4bffe2df6b3463d216990a6b`. This is the next unimplemented
+class-member slice after the landed private-method and `super`-accessor work.
+It does not reopen those slices or mark R3 complete. No compiler tests were
+run by the planner; the current-source facts below are distinct from the
+historical September 3/4 measurements, which must be reproduced by the dev.
+
+**Dispatch identity:** `3522:w1d-computed-literal-method`, intended owner
+`ttraenkler/luna-ir-computed-method-20260905`, branch
+`codex/3522-w1d-luna-20260905`. The lead verified this reservation remotely
+after checking claims, remote branches and open PRs, and provisioned its
+isolated worktree. Recheck the record before editing. The old
+`3522:w1c-super-accessor` claim is not this slice.
+
+### Root cause on the reviewed source
+
+For `class Tagged { ["tagged"](): number { return 42; } }`:
+
+1. `identity.ts::classMemberLegacyName` (`:637`) obtains `<computed>` from
+   `memberBaseName` (`:631`) instead of the literal runtime key.
+2. `select.ts::phase1MemberName` (`:10696`) returns `null`; the identity
+   selector (`select-identity.ts:1285`) therefore refuses the method as
+   `class-method` before looking for its descriptor.
+3. `codegen/index.ts::buildIrClassShapes` (`:1526`, instance-method loop
+   `:1762-1815`) still skips every name except Identifier/PrivateIdentifier.
+   Opening the selector alone would merely move the refusal to
+   `class-member-unsupported` for the missing descriptor.
+4. `integration-identity.ts::classMemberLegacyName` (`:132-144`) must agree
+   with selection and inventory when it builds the exact selected owner map.
+
+The backend already knows the key: `class-bodies.ts::resolveClassMemberName`
+(`:757`) calls `resolveComputedKeyExpression` (`literals.ts:2792`), which
+resolves a string literal to its string value. This slice must use only that
+literal fact. Importing the backend's general constant evaluator into IR
+would also import mutable binding, enum and symbol assumptions this slice
+does not establish.
+
+### Bounded acceptance contract
+
+Add one syntax-only helper in **new `src/ir/class-method-names.ts`**, importing
+only `ts-api`. Suggested API:
+`literalComputedInstanceMethodKey(member: ts.MethodDeclaration): string | undefined`.
+It answers an exact decoded key or **unproven**, never a guessed name.
+
+For this first slice require all of the following:
+
+- The method name is a `ComputedPropertyName` whose expression is directly a
+  `StringLiteral`; `"tagged"` and `'tagged'` agree. No identifier lookup,
+  parentheses, assertion, template, arithmetic, comma, assignment, symbol,
+  numeric key, or runtime evaluation is added.
+- The containing declaration is a named, non-ambient top-level
+  `ClassDeclaration`, with no heritage or decorators. It contains only
+  body-bearing instance methods, an optional ordinary zero-parameter
+  constructor, and semicolons. Fields, accessors, statics, overload signatures,
+  private members and nested/class-expression ownership remain outside the
+  **new** family; existing admission for those forms stays unchanged.
+- Each method in that family has an Identifier or the same raw-string-literal
+  computed name, a body, no optional/async/generator/abstract form, no
+  decorators, and a fixed parameter list with explicit number/string/boolean
+  types. Return annotations are number/string/boolean/void. Parameter
+  defaults, rest, destructuring and callable/class/dynamic positions stay out.
+  Existing body selection still decides whether the body can lower.
+- The decoded keys are unique among the class's methods. Restrict the new
+  computed keys to ordinary ASCII identifier spellings for this slice, and
+  exclude `constructor`, `new`, and `init` (the latter two overlap constructor
+  support labels). The helper must reject an unresolved sibling or duplicate
+  rather than assuming it cannot collide. This restriction is deliberate
+  scope, not a claim that other legal JavaScript keys are unsupported forever.
+
+Keep name resolution and existing type/body/ABI proofs separate: the helper
+only certifies this narrow declaration family and its key. It does not mint
+an identity, reserve a slot, evaluate a key, or authorize emission by itself.
+The return type `undefined` is a refusal to extend the existing claim set.
+
+### Exact changes, in order
+
+1. **`src/ir/identity.ts`, `classMemberLegacyName` (`:637`).** For a method
+   accepted by the new helper, use its decoded key before the existing
+   `memberBaseName` fallback. Leave `memberBaseName` itself unchanged: it also
+   names object-literal members and field-initializer support. Keep
+   `InventoryBuilder.processClass`'s definition-expression scan (`:1191`) and
+   unit ordinal/lexical-owner construction (`:1257-1322`) unchanged. Thus the
+   exact declaration keeps its UnitId while its compatibility label becomes
+   `Tagged_tagged`; two different admitted keys get different labels.
+2. **`src/ir/select.ts`.** Add a method-specific wrapper, e.g.
+   `phase1MethodName(member)`, delegating to the new helper for computed names
+   and to `phase1MemberName` otherwise. Update only the method naming in
+   `planIrCompilation`'s static/instance collision collection (`:891-901`),
+   method branch (`:924`), and descriptor lookup (`:987`, branch by member
+   kind). The existing `phase1MemberName`, `phase1PropertyName`, accessor
+   paths and `classElementProjectionName` remain unchanged. In the
+   **no-sidecar** arm of `classMethodProjection` (`:7815-7852`), use the same
+   method-specific name for matching a method and counting an instance/static
+   collision. Its exact-shape arm (`:7776`) already reads descriptors by
+   semantic key and needs no new lookup. Leave the W1-H binary-expression
+   function at `:7361` alone.
+3. **`src/ir/select-identity.ts`, `planIrCompilationByIdentity` (`:909`) class loop.**
+   Use the method-specific name at the method-name refusal (`:1285`) and the
+   descriptor-name computation (`:1314`), preserving accessor behavior.
+   For a newly admitted computed method, require exactly one descriptor with
+   matching name/kind **and** exact `placement.classId`, `placement.unitId`,
+   unit-bound `target.binding.unitId`. Missing/ambiguous evidence refuses
+   before claim using the existing class-member capability path. Do not
+   weaken any `selectorIdentityInvariant`, replace exact ids with text, or
+   rewrite nested-class atom handling.
+4. **`src/codegen/index.ts`, `buildIrClassShapes` instance-method loop
+   (`:1762-1815`).** Keep the old Identifier/PrivateIdentifier arms, then add
+   only the new helper's successful computed-method arm. Preserve all
+   parameter/return projection checks, `callableTarget(member, ...)`,
+   `placementFor(member)` and descriptor shape. Do not admit every
+   StringLiteral/NumericLiteral property simply by calling the broader
+   `phase1MemberName`: those existing descriptor gaps are not this slice.
+   `planIrOverlay`, the TypeScript binder work and Reflect handlers are out
+   of the write scope.
+5. **`src/ir/integration-identity.ts`, `classMemberLegacyName` (`:132`).**
+   Use the same method-specific name for methods, preserving the accessor
+   branch and duplicate-owner invariants. Prove the producer declaration,
+   inventory terminal, descriptor target and final Program ABI callable all
+   point to the same exact unit.
+
+**Wasm pattern:** no new instruction or runtime helper. The existing
+`class.call`/method lowering continues to obtain its callee from the class
+descriptor, pass the existing receiver plus arguments, and emit the direct
+Wasm `call` to the exact resolved callable. The method body uses the existing
+IR operations for its scalar body. No `ref.cast`, ref-cell, `VOID_RESULT`,
+boxing or coercion rule changes are authorized here.
+
+### Direct-body routing and read-only checks
+
+`prepared-class-body-cutover.ts::hasResidualClassBodySyntax` (`:56`) rejects
+every computed member, but that is a **whole-walker cutover**, not evidence
+that a selected method must emit directly. The fallback
+`class-bodies.ts::compileClassBodies` calls `skipExactPreparedClassBody`
+(`:2996`) before resolving or emitting a method body; that helper (`:2188`)
+checks the exact declaration UnitId and allocator-owned callable. Use it.
+Do not widen the whole-class cutover or its kill switch.
+
+Read, do not edit, `class-bodies.ts`,
+`program-abi-class-callable-planning.ts::structuralClassMemberName` (`:178`),
+`class-callable-abi.ts::finalizeForwardClassCallableAbis` (`:106`, deliberately
+still identifier-only), and `integration.ts`'s compatibility-only method
+walk (`:3460`). The primitive-signature/top-level/identity-route limits avoid
+requiring their wider ABI surfaces. If a positive case needs a new callable
+provider or body-router change, report it and re-scope before broadening.
+
+### Tests and first-run decision
+
+New **`tests/issue-3522-computed-literal-method.test.ts`**, following
+`tests/issue-3522-private-method-admission.test.ts`'s per-target outcomes,
+runtime setup, exact body-poison controls and cleanup in `finally`.
+
+```ts
+class Tagged {
+  constructor() {}
+  ["tagged"](n: number): number { return n + 2; }
+  ["other"](n: number): number { return n + 7; }
+}
+export function run(): number {
+  const value = new Tagged();
+  return value.tagged(3) * 10 + value.other(4);
+}
+```
+
+Expected executed result is **61**. First run this source on the real branch
+base through `compile` and record the exact method and caller outcomes on
+`gc` and `standalone`. The new methods should reproduce the name/descriptor
+refusal; the planner does not claim a freshly measured failing-test count.
+If base already emits these methods or another earlier arm prevents reaching
+the intended boundary, resolve that finding before the production edit.
+
+The candidate must demonstrate all of the following:
+
+- One exact terminal per method, stable UnitIds versus base, decoded distinct
+  labels, exact descriptor/callable agreement, `irBodyEmitted: true` and
+  `legacyBodyEmitted: false`, with no post-claim errors or audit violations.
+- The positive source runs to 61 on both targets with each named direct
+  method body poisoned. A forced-direct control must trip the poison; a
+  no-poison direct baseline must return the same value. Do not equate a
+  successfully entered declaration walker with direct body emission.
+- Literal aliases (`const key = "tagged"; [key]()`), an effectful key,
+  numeric/template keys, duplicate decoded keys, reserved support names,
+  static/accessor/private/nested/derived/field-bearing classes and wider
+  signatures retain their previous admission. Existing ordinary methods in
+  a mixed class must not lose their prior ownership just because the new
+  computed candidate is refused.
+- The previously admitted private-method and `super`-accessor cases stay
+  unchanged. Object literal computed names and field/accessor key evaluation
+  also stay unchanged because their helpers were not widened.
+- Remove each load-bearing production seam in turn using worktree-local
+  file copies: the positive ownership/identity tests must fail. A branch
+  that changes only display names is not accepted as method admission.
+
+`tests/issue-3529-selector-preclaim.test.ts:114` currently lists a literal
+computed method as a refusal. Move that **exact** case to a positive runtime
+and ownership test; preserve a refusal control with a truly dynamic key.
+Do not delete the negative coverage or silently relax its assertions.
+
+### Validation, write ownership and dispatch
+
+```bash
+pnpm exec vitest run tests/issue-3522-computed-literal-method.test.ts tests/issue-3522-private-method-admission.test.ts tests/issue-3522-private-method-call-sites.test.ts tests/issue-3522-super-accessor.test.ts tests/issue-3529-selector-preclaim.test.ts tests/issue-3529-class-integration.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+node --import tsx scripts/check-ir-fallbacks.ts
+node --import tsx scripts/check-ir-only.ts --policy=hybrid
+node --import tsx scripts/check-ir-only.ts --policy=ir-only
+pnpm run check:ir-dialect
+pnpm run check:ir-kind-neutrality
+pnpm run check:ir-layering
+pnpm run typecheck
+pnpm run lint
+node scripts/check-loc-budget.mjs && node scripts/check-func-budget.mjs && node scripts/check-coercion-sites.mjs && pnpm run check:oracle-ratchet && pnpm run check:dead-exports
+```
+
+Run all affected R1 identity/R3/class-projection suites one file per invocation
+on base and candidate; report the fresh failing-name diff, not September's
+"23 pre-existing" count. Capture and compare emitted bytes with
+`node --import tsx scripts/prove-emit-identity.mjs write --baseline .tmp/w1d-emit-base.json`
+before edits and its `check` mode after. State its enumerated `.ts` manifest
+and successful-compile floor; it does not enumerate dogfood `.js`. No corpus
+coverage gain is predicted from the synthetic `r05` shape. Run required
+equivalence/quality checks, including the five ratchets against a freshly
+verified main SHA. Put only measured growth grants in this issue; never
+inflate main-owned baselines.
+
+**Luna / max brief:** own the new helper, the narrowly named functions in
+`identity.ts`, `select.ts`, `select-identity.ts`, `integration-identity.ts`,
+and `codegen/index.ts`, the new test, the one stale refusal case, and this
+issue's landing record. You are not alone; preserve peers' changes and use
+your assigned isolated branch. W1-H owns a different function in `select.ts`;
+coordinate imports and serialize main integration if both edit that file.
+No other shared function is assigned concurrently in this wave. Do not edit
+module-binding storage, R2 free-function ownership, class cutover switches,
+Reflect methods, or the binder. First measure the motivating row, then ship
+only this literal family with exact body evidence. Source and test results
+outrank this plan. Keep the epic `in-progress` and return base/head SHAs,
+commands, outcome changes, poison/removal controls, and remaining failures.

--- a/plan/issues/3523-ir-r4-module-init-compile-once.md
+++ b/plan/issues/3523-ir-r4-module-init-compile-once.md
@@ -4,7 +4,7 @@ title: "IR-only R4: typed ordered module-init compile-once ownership"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-09-02
+updated: 2026-09-05
 priority: critical
 horizon: xl
 complexity: XL
@@ -5380,3 +5380,92 @@ an entire syntactic form with no coverage in either corpus this slice is
 measured against. So the dogfood count neither establishes nor bounds the real
 weight of the `function` category; it establishes only that this slice's arm
 is exercised at all. Any figure quoted downstream must name its corpus.
+
+## Implementation Plan — 2026-09-05
+
+### Dispatch reconciliation and queued ambient-population slice
+
+Planner: **Astra**; source reviewed at
+`a53b1bd17338c01f4bffe2df6b3463d216990a6b`. No compiler tests were run by the
+planner. The R4-W2-B function-storage arm is absent from this source, but it is
+**not available for duplicate dispatch**: the lead read the authoritative
+`3523:w2b` assignment as `in-progress`, owner `ttraenkler/fable-3523-w2b`, and
+found remote branch `fable-3523-w2b` at
+`5d80d12343e23b73ac27bf338875c2aa00e5e406`. Reconcile that owner before
+dispatching function storage. The previous plan remains its design record.
+
+The completed #5283 receipt fix left a separate mechanism unimplemented:
+ambient declarations still enter the executable module-init population.
+Queue **`3523:ambient-module-init-scan-roots`**, unclaimed and **not part of
+the September 5 implementation wave**. It shares `identity.ts` with R3 W1-D;
+dispatch after that source is integrated and claims/PRs are rechecked. R4
+remains `in-progress`; this is not a reason to reopen the completed receipt fix.
+
+`collectModuleInitPopulation` (`src/ir/module-init.ts:9-28`) includes ambient
+namespaces and `declare const` statements. `InventoryBuilder.build`
+(`src/ir/identity.ts:845-929`) uses the list both to mint an executable terminal
+(`:907`) and to scan nested imported classes (`:925`). The #5283 landing record
+documents why simply filtering declarations lost those classes. The next
+bounded change must separate these jobs:
+
+1. **`src/ir/module-init.ts`**: preserve the old broad list as a distinct
+   scan-root collector, and narrow the runtime-population collector only for
+   explicit ambient statements/declaration-file context. Keep non-ambient
+   namespaces and real runtime statements conservative.
+2. **`identity.ts`, `InventoryBuilder.build`**: create a module-init terminal
+   only from the runtime population or existing static-class initialization
+   evidence. Independently scan every root exactly once, including ambient
+   wrappers when no runtime terminal exists. `scanNode` (`:1453`) currently
+   requires a non-null lexical owner; a source-root scan needs truthful null
+   ancestry passed to `processClass`/`addSupportUnit`, which already accept it.
+   Keep syntax placement separate from runtime ownership. Do not retain a fake
+   module-init UnitId just to preserve the old parent id.
+3. **Audit all consumers before editing** with
+   `rg -n 'collectModuleInitPopulation' src`. Selection, planning,
+   integration, multi-source orchestration and codegen all consume it; classify
+   each as runtime population or declaration discovery. Start at
+   `planning-identity.ts:487`, `integration-identity.ts:327`,
+   `integration.ts:559,2603,3691`, `select.ts:10796`, and
+   `select-identity.ts:811`. Extra edits need a named consumer requirement.
+4. **Preserve outcome refusals**: `buildNonExecutableModuleInitOutcome`
+   (`codegen/ir-overlay-outcomes.ts:871-913`) already requires no terminal,
+   empty runtime population, exact source identity and no duplicate row.
+   Keep those guards and the physical-body receipts. Add no Wasm instruction,
+   fallback body, import or representation conversion.
+
+The ambient classes' old phantom lexical parent disappears, so do not promise
+their ClassIds stay identical. Require truthful deterministic ancestry and
+exact layout/callable associations, retained class records, stable unrelated
+executable identities, and unchanged emitted bytes.
+
+**First proof before implementation:** reproduce
+`tests/fixtures/extern-demo.ts` and
+`tests/dogfood/corpus/import-attributes.module.js` through the real compiler
+on `gc` and `standalone`; inspect the transformed source seen by inventory,
+not a raw reparse of the JSON import. Add a namespace-wrapped imported-class
+positive control. Ambient-only sources must have one `non-executable` row,
+zero runtime init bodies, retained imported classes and no audit violations.
+Mixed ambient/runtime sources, non-ambient namespaces and static class
+initializers must retain execution and order. Removing the population filter
+must fail the outcome pin; removing the ambient scan must fail the class pin.
+
+Future Luna / max ownership: the collector/scanner split, only consumers whose
+need was established, a new
+`tests/issue-3523-ambient-module-init-population.test.ts`, and this issue's
+measured landing record. Run these existing files separately on base and
+candidate: `tests/issue-5283-legacy-body-receipt.test.ts`,
+`tests/issue-3520-ir-unit-identity.test.ts`,
+`tests/issue-3520-program-abi-unitless-class-order.test.ts`,
+`tests/issue-3520-module-init-callable-abi.test.ts`,
+`tests/issue-3523-module-init-discovery-static.test.ts`, and
+`tests/issue-3525-multi-prepared-module-init.test.ts`, using
+`pnpm exec vitest run <file> --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism`.
+Then run typecheck, current required IR/quality/equivalence gates and all five
+source ratchets against branch and verified main bases. Use `node --import tsx`
+for TypeScript scripts in this sandbox; enumerate fresh manifest/target/SHA
+evidence instead of copying historical corpus totals.
+
+This remains **queued** if any consumer's ownership contract is unclassified,
+class retention needs fabricated identity, or runtime order changes. The future
+implementer is not alone: preserve peers' edits, use a verified isolated
+worktree and do not take over W2-B's live storage claim.


### PR DESCRIPTION
The migration handover leaves the next selector and class-member tasks underspecified against current main. These plans define two bounded implementation slices with exact ownership, source anchors, refusal rules, and fresh validation requirements:

- #3520 — IR-only R1: source-qualified identity and Program ABI map: reject equality before claim only when both operands have positive reference evidence. Missing primitive classification remains unknown.
- #3522 — IR-only R3: compile-once classes, members, and closures: admit a narrow family of literal computed instance-method names using exact descriptor and body ownership.
- #3523 — IR-only R4: typed ordered module-init compile-once ownership: queue ambient declaration discovery separately from runtime initialization; preserve the existing function-storage claim.

The two ready slices have verified claims and are assigned to isolated Luna max agents. Parent issue acceptance and in-progress status remain open. This PR changes issue files only.

Validation on source base a53b1bd17338c01f4bffe2df6b3463d216990a6b: typecheck and the IR fallback gate pass. The bounded IR-only check passes in host and standalone lanes: 5/5 entries, 41 terminal units, 38 IR-emitted, 3 non-executable, zero legacy bodies, unsupported units or invariants per lane. The selected motivating equality collision test reproduces with 1 failure and 1 skipped test. Both plan commits pass whitespace and source-budget checks and contain SSH signatures.
