### PR TITLE
fix(ci): npm-compat refresh resolves src/ts-api under plain node

### DIFF
--- a/scripts/lib/es-edition.mjs
+++ b/scripts/lib/es-edition.mjs
@@ -28,7 +28,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 
-import { ts } from "../../src/ts-api.js";
+import { ts } from "../../src/ts-api.ts";
 
 /** The edition every script is allowed to assume; nothing below this is evidence. */
 export const BASELINE_EDITION = 5;

--- a/tests/es-edition-plain-node-import.test.ts
+++ b/tests/es-edition-plain-node-import.test.ts
@@ -1,0 +1,23 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// `npm-compat-refresh.yml` runs `node scripts/merge-npm-compat-partials.mjs`
+// under PLAIN node — no tsx, no vitest resolver — and that script imports
+// scripts/lib/es-edition.mjs. A `.js` specifier pointing into src/ resolves
+// only under tsx/vitest (which map `.js` to the `.ts` source); plain node
+// throws ERR_MODULE_NOT_FOUND. That is exactly how every refresh run failed
+// from 2026-09-03 (#5279 landed `../../src/ts-api.js`) until the specifier was
+// corrected to `.ts`, leaving the bot's artifact PR two days stale with green
+// CI everywhere else. This pin loads the module the way the workflow does.
+describe("scripts/lib/es-edition.mjs loads under plain node", () => {
+  it("imports without tsx or vitest resolution", () => {
+    const mod = fileURLToPath(new URL("../scripts/lib/es-edition.mjs", import.meta.url));
+    const out = execFileSync(
+      process.execPath,
+      ["--input-type=module", "-e", `await import(${JSON.stringify(mod)}); console.log("ok");`],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    expect(out.trim()).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Description

Every `Refresh npm-compat` run since 2026-09-03 has failed at the merge step, so the bot's artifact PR ([#5503](https://github.com/loopdive/js2/pull/5503)) still carries the 2026-09-03 measurement while main's own checks stay green.

Root cause: `scripts/lib/es-edition.mjs` (landed with [#5279](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5279-npm-compat-es-edition-classification)) imports `../../src/ts-api.js`. That specifier resolves only under tsx / vitest, which map `.js` to the `.ts` source. `npm-compat-refresh.yml` runs `node scripts/merge-npm-compat-partials.mjs` under plain node 25, where it is `ERR_MODULE_NOT_FOUND` (see run 33952635501, jobs `refresh-fast / refresh` and `refresh-slow / refresh`). The sibling scripts already import `../src/ts-api.ts` directly; this PR does the same here.

**Reproduced** on node v25.9.0 and v22.22.2: `node scripts/merge-npm-compat-partials.mjs <dir>` fails on main and writes all five artifacts with this change.

**Pin:** `tests/es-edition-plain-node-import.test.ts` loads the module through `process.execPath` with no resolver in the way, so this specifier class cannot regress silently again.

Diff: one specifier in `scripts/lib/es-edition.mjs` plus the test. No `src/` changes, no artifact files.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEGi3DmyPRPD5dx4kWU8hs)_