### PR TITLE
docs(ir): plan prepared boundaries and record retirement requirements

### DIFF
--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -3,7 +3,7 @@ id: 3518
 title: "IR-only default and direct front-end retirement"
 status: in-progress
 created: 2026-07-21
-updated: 2026-08-30
+updated: 2026-09-05
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -2896,3 +2896,119 @@ asked to compile (eslint's rule definitions, prettier's printers), so this is
 remains a proxy for shape coverage, not for IR representability — it can show a
 corpus is unlike the target, never that a like corpus would pass. Both
 measurements are re-runnable from `.tmp/`; neither is committed as a baseline.
+
+## Completion audit — 2026-09-05
+
+The user has requested completion of the **whole IR migration**. The product
+outcome and all acceptance criteria above remain the definition of completion.
+Landed selector improvements, bounded compile-once cohorts, and green sample
+readiness checks are progress toward that outcome; none closes this epic.
+
+This audit uses canonical upstream `main` commit
+`5da655f286fcd569203cd2012b23dc21bf1c626d`, source tree
+`3ede655c96c89083a65a3c7e96bca3329d29513f`. It is a source and retirement-ledger
+audit, **not a new conformance run**. Earlier measurements in this file retain
+their original commits, lanes, and denominators.
+
+### Acceptance status and required evidence
+
+| Requirement | Current evidence | What is still required |
+| --- | --- | --- |
+| Authoritative IR-only coverage gate | `scripts/check-ir-only.ts` still lists five playground entries and reuses those five for standalone. | Account for the complete declared application and conformance populations, with all terminal outcomes and positive denominator controls, across every required mode. |
+| Full host and standalone Test262 non-regression | No full merge-group outcome comparison was performed in this audit. | A complete final-candidate comparison, including skips, compile errors, runtime failures, timeouts, and fatal runner outcomes. Required checks that skip a shard do not supply its evidence. |
+| One prepared program before either backend | `src/ir/program.ts` declares `reconciliation: "pending-production-wiring"`; its sealed structural census still contains direct and invariant candidates. | Reconcile every supported unit into the production program before emission; remove remaining class, initializer, and multi-source ownership exceptions. |
+| Shared WasmGC and linear frontend/ABI | `src/codegen-linear/index.ts` still compiles declaration statements directly and exports an AST-taking `compileExpression`. `linear-integration.ts` still inspects declarations and the checker. | Both backends consume the same verified semantic bodies and ABI ledger without backend-specific frontend reconstruction. |
+| Lossless validated serialized handoff | A versioned `IrAsyncPlan` and its serializer exist. `PreparedIrProgram` remains a structural census; this audit did not establish a complete production serializer. | Connect the whole prepared semantic program, ABI, effects, and frozen runtime manifest to a lossless codec and reject malformed/incompatible input before artifact side effects. |
+| Differential backend-input proof | No fresh same-snapshot differential run was performed here; the direct linear path remains. | Feed the identical serialized prepared snapshot to both backends and verify equivalent supported behavior and typed incapability without reparsing or reselection. |
+| Explicit stable unsupported results | The equality reference-operand preclaim guard landed through PR 5584, but it addresses one selector boundary. | Account for every unsupported terminal unit, including source location/reason, and remove silent fallback, post-claim withdrawal, skipped slots, and legacy exception recovery. |
+| One production policy | Public `experimentalIR` / `disableIrFirst` options, `JS2WASM_IR_FIRST`, and `JS2WASM_LINEAR_IR` switches remain in production code. | Execute the live retirement inventory in **#4522 — Inventory and retirement plan for IR/direct env kill-switches** at R9, after all supported behavior is owned by IR. |
+| Delete the direct frontend graph | The unchanged reachability audit finds both real direct dispatch roots and substantial surviving graph overlap; details below. | Prove frontend-only survivors reach zero with a fresh **#3090 — Retire direct front-end after IR-only reachability gates close (~59,676 fn-lines)** audit, classify shared runtime separately, and delete the obsolete direct dispatch and handlers. |
+| Preserve behavior and optimizations | The current optimization-retirement ledger has 50 rows, of which 46 are not ready. | Map the full retirement surface and demonstrate behavior plus the required Wasm-shape/performance properties before deleting each implementation. The tracked 50 rows are not a complete handler census. |
+| Final merged validation | This audit is not the final merged candidate, and source blockers remain. | Complete the final equivalence, cross-backend, linear, typecheck, lint/format, LOC/dead-export, full Test262, standalone-floor, and artifact-validity checks against the landed implementation. |
+
+Specific live source evidence at the audited commit:
+
+- `src/ir/program.ts:190–203` describes unvalidated unit candidates and pending
+  production reconciliation. The type name and `sealed` field do not establish
+  the product handoff by themselves.
+- `src/ir/async-plan.ts:179` already owns semantic states, values, handlers,
+  spills, ABI, and runtime intents; `serializeIrAsyncPlan` exists. Async is not
+  starting from zero. Nevertheless, `src/codegen/async-cps.ts:1045` permits AST
+  expression operands, while `src/codegen/async-frame.ts:2093`, `:2117`,
+  `:2251`, `:2284`, and `:2517` still emit AST statements/expressions for resume,
+  await, conditions, and finalizers. These production edges must be replaced.
+- `src/ir/runtime-manifest.ts` already has a substantial fixed-point builder
+  and frozen runtime manifest, including boundaries, strings, callback
+  wrapping, and function-prototype calls. Earlier descriptions of a math-only
+  manifest must not be treated as current scope. Complete runtime ownership
+  still needs production and deletion evidence.
+- `src/codegen-linear/index.ts:665`, `:848`, and `:1781` retain the direct
+  statement/expression route. `src/ir/backend/linear-integration.ts:381`
+  retains its environment escape hatch.
+- `src/compiler.ts:881–887`, `src/index.ts:830–847`, and
+  `src/codegen/index.ts:5685` retain public or environment policy choices;
+  multi-source routing at `src/codegen/index.ts:10324` still has fast/policy
+  eligibility exits.
+
+### Fresh retirement measurements
+
+`node scripts/check-ir-optimization-retirement.mjs --require-ready` exited 1:
+**46 of 50 tracked optimization rows are not ready**. Ledger blob:
+`2310f1ad7037919585419b0bed9112fd404a07bb`. The failing rows include string
+operations, numeric switches/ABI, async frame spills and promises, class and
+closure behavior, regular expressions, parser paths, vector operations, and
+module TDZ. This count measures ledger readiness, not percentage of the
+compiler migrated.
+
+The unmodified `scripts/audit-legacy-reachability.mjs` (blob
+`7767986b14664e8aad58d8354ad7d3c803a1d46e`) reported **806 codegen files**.
+Its graph actually contained both configured dispatch nodes:
+`src/codegen/expressions.ts#compileExpression` (22 function lines) and
+`src/codegen/statements.ts#compileStatement` (24 function lines). This positive
+control checks the analyzed graph, rather than accepting the declared cut list
+as proof that the roots were found.
+
+| Asserted file bucket | Files | Legacy-only function lines | Shared function lines | Unreferenced function lines |
+| --- | ---: | ---: | ---: | ---: |
+| frontend | 109 | 87,121 | 16,141 | 0 |
+| runtime | 61 | 39,952 | 57,406 | 312 |
+| stays | 633 | 39,268 | 166,214 | 198 |
+| deferred | 3 | 2,543 | 2,958 | 0 |
+
+**These are not deletion permissions or an estimate of removable code.** Bucket
+membership is asserted by file-name/prefix rules; reachability is a separate,
+conservative static calculation. Twelve files labelled `frontend` contain more
+shared than legacy-only function lines. The tool roots functions outside
+`src/codegen`, cuts the two dispatchers, and reports codegen functions; it does
+not prove final runtime behavior or complete linear-backend retirement.
+
+The normal audit command currently fails in this checkout because its use of
+`new URL(import.meta.url).pathname` leaves the space in `/Volumes/Archiv Mini`
+encoded as `%20`. The measurement above ran the **same unchanged script and
+source** through a space-free symlink, with Node's
+`--preserve-symlinks-main`. This records a successful workaround, not a repaired
+default CLI. Local evidence is in
+`.tmp/ir-completion-20260905/{optimization-retirement.log,legacy-reachability.log,legacy-reachability.json,summary.json}`;
+the large graph JSON is not committed as a baseline.
+
+### Implementation sequence from the current state
+
+1. Complete and validate the already-dispatched computed-literal class-method
+   identity slice in **#3522 — IR-only R3: compile-once classes, members, and closures**.
+   Preserve the equality preclaim fix already merged through PR 5584.
+2. Implement the new Astra plan in **#3521 — IR-only R2: prepare-before-emit free-function ownership**: authenticate semantic and physical boundary
+   contracts against actual allocator/provider state before claiming bodies.
+   Remove declaration-kind certification as the correctness substitute only
+   where the replacement contract proves the complete boundary.
+3. In parallel, follow the independent prerequisite plan in **#3525 — IR-only R5: whole-program single- and multi-source Prepared ownership**: freeze ordered module-initializer
+   planning before routing/emission, joined by exact source and unit identity.
+   Mixed callable/initializer ownership remains dependent on coherent R2
+   preparation and must not be reported complete by this prerequisite alone.
+4. Continue whole-program ownership, async semantic emission, frozen runtime
+   support, shared linear consumption, and the full prepared-program codec.
+   Preserve existing live slice claims (including module function storage) and
+   ground subsequent implementation plans in current source and measurements.
+5. Retire policy escapes and direct handlers only after the supported-language
+   and optimization obligations are met. Then run the complete final merged
+   validation above. No bounded cohort or five-entry readiness check substitutes
+   for the epic's acceptance criteria.

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -3,7 +3,7 @@ id: 3521
 title: "IR-only R2: prepare-before-emit free-function ownership"
 status: in-progress
 created: 2026-07-21
-updated: 2026-09-02
+updated: 2026-09-05
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -4368,3 +4368,149 @@ plan's 10 + 4, and the flip counts follow from that.
   flagged so it gets an owner.
 - `tests/issue-3214-imported-hof.test.ts` was repaired by R2-T1 and is no
   longer red on this base.
+
+## Implementation Plan — 2026-09-05 — R2-B1 prepared callable-boundary contracts
+
+**Planning base:** `5da655f286fcd569203cd2012b23dc21bf1c626d`; implementation
+must rebase the evidence against its assigned current-main worktree. Astra
+plans, Luna `max` implements, per the user. Proposed slice claim:
+`3521:r2-b1-callable-boundary-contract` (the lead reserves it before dispatch).
+The issue and every remaining acceptance checkbox stay open.
+
+### Blocker and intended state movement
+
+`r2CertifiedAgainstOutsideCallers` in
+`src/codegen/ir-prepared-free-functions.ts:1028` uses a declaration-kind list
+that excludes reference contracts already admitted by `r2StableSignatureType`
+and mapped by `r2StableValType` (`:384`, `:685`). The fixed point (`:1545–1660`)
+therefore withdraws an otherwise supported callee when its caller stays direct.
+An allocated `externref` alone is insufficient evidence: callable invocation
+also depends on the exact signature and wrapper support.
+
+The missing structural proof has existing producers. The source-callable
+registry resolves exact allocator objects (`program-abi-source-callable-planning.ts:392`),
+and `prepareDependencyCompleteClosureSupport` (`prepared-closure-support.ts:244`)
+already records an explicit empty carrier proof for `callable` and nonempty
+invocation support for `closure.call` (`:427`, `:457`). Production sealing plans
+the allocated callable (`prepared-component-sealing.ts:536–560`), but the final
+lowered signature is currently checked only after body lowering
+(`integration.ts:5239`; `fillSealedPreparedCallable:2239`).
+
+Move that boundary proof into preparation and carry an authenticated immutable
+contract through sealing and emission. This removes a shared caller-direction
+barrier; it is not another function-name, fixture, annotation, or lane allowlist.
+It does **not** complete R2: `prepareIrBodies:1933` still combines preparation
+with emission, deferred free functions still enter the late overlay, and
+`src/ir/program.ts:201` correctly remains `pending-production-wiring`.
+
+**Fresh baseline evidence (Luna probe, same planning SHA):** the module-init
+`apply(f, v)` fixture and its observable `main() === 42` variant each report
+`(prepare, direct, IR) = (1, 1, 1)` with
+`fixed-point / outside-caller-uncertified` in both GC-host and standalone.
+The scalar outside-caller control and a callable export without an outside
+caller each report `(1, 0, 1)` in both lanes; the latter uses the real callable
+wrapper and `call_ref` support. A callable-identity variant reaches this R2
+barrier in GC-host but is rejected earlier by standalone call-graph closure.
+The object-return control is `return-signature-unstable`; the allocated-slot
+control reports `abi-signature-parity`. Imported callers remain the separate
+multi-source late-preparation route. These are baseline rows, not candidate
+gains or a population estimate. Probe records:
+`.tmp/issue-3521-outside-caller-results.jsonl` and
+`.tmp/issue-3521-callable-abi-results.jsonl` in the lead's Luna equality worktree.
+
+### Implementation sequence and exclusive write scope
+
+1. **Share signature projection with the emitter.** In `src/ir/lower.ts`,
+   extract the parameter/result conversion from `lowerIrFunctionBody:3945–3968`
+   into a reusable preparation helper; `lowerIrFunctionToWasm:546` must consume
+   the same projection. Preserve slot flattening, reference nullability,
+   `resolveParamPhysicalType`, counted-string physical-parameter evidence, and
+   backend-specific conversion. A preparation call emits no instructions and
+   interns/allocates no type. Use preplanned lookups; never duplicate the
+   `IrType`→carrier mapping in the R2 predicate.
+2. **Authenticate the allocated boundary.** Add a small R2-owned contract
+   module, with issuance through `ProgramAbiSourceCallableRegistry`. Bind the
+   contract to the session/inventory, exact `UnitId`, allocator object and
+   handle, and a defensive snapshot of the allocated physical parameter/result
+   types. Record the final IR semantic signature and its exact carrier/support
+   bindings when preparation completes. A plain object, same name, same type
+   index in a different module, or stale allocator is not authority. An empty
+   support set is valid only when its producer explicitly certified it.
+3. **Prepare support before certifying.** In `integration.ts:750`
+   (`prepareClosureTransaction`) and `prepared-component-sealing.ts:504`, use
+   final post-pass IR, the existing closure/ref-cell/runtime/type preparation,
+   and the scoped ABI lookup to reconcile the shared signature projection with
+   the allocated boundary **before the scope seals and before any body emits**.
+   Where scoped resolution is required, retain the existing open-scope form
+   until this check finishes; then seal every admitted scope. Preserve distinct
+   lookups for distinct components. Do not use the first component's scope as
+   authority for another component. No provider/helper discovery may be hidden
+   inside signature comparison. If a needed layout is currently lazy, move its
+   existing producer before this boundary and record it in the dependency
+   evidence; do not add another blanket reference rejection.
+4. **Route by the contract.** In `selectR2PreparedOwnerComponents`, replace the
+   declaration-kind-only outside-caller exemption with exact pending boundary
+   candidates; thread those candidates through `planIrFirstBodyRouting`
+   (`src/codegen/index.ts:4613`) and `prepareIrBodies`. A candidate is never a
+   `Prepared` outcome. Only successful final certification plus dependency
+   sealing authorizes the direct-body skip. Reconcile withdrawals before
+   publishing skips, and retain their typed reason. Leave the independent
+   admission, forward-call, construction, storage, direct-caller-activation,
+   nested executable and Annex B support exclusions intact. Keep the fast
+   admission proofs unchanged; this slice replaces the boundary proof shared
+   by their already-admitted owners.
+5. **Consume, do not re-decide.** Verify contract currentness immediately before
+   filling the exact prepared callable and at the existing final ABI
+   reconciliation. Emission uses the prepared signature and preplanned
+   support. A pre-seal unsupported contract stays direct-owned; forged, stale,
+   contradictory or post-seal changed evidence is an invariant and cannot
+   retry direct, patch a foreign slot, or ship an `unreachable` substitute.
+   Preserve the ordinary late route outside this slice; no global provider
+   latch or unrelated late-provider prohibition may be introduced.
+
+Owned production files are the new contract module, the source-callable
+registry, `ir-prepared-free-functions.ts`, and the named signature/preparation
+seams in `lower.ts`, `integration.ts`, `prepared-component-sealing.ts` and
+`index.ts`. A small typed options/plumbing addition is permitted in
+`integration-options.ts`; put reusable contract state in the new module rather
+than expanding the broad context. Do not edit R1 name/identity selection,
+computed method handling, binder/Reflect/runtime-prototype functions, R4 W2-B,
+or `multi-prepared-*`. The R5 ordered-initializer-census prerequisite is
+independent. Coordinate any other scope change with the lead before editing.
+
+### Validation and landing bar
+
+- Record baseline/candidate SHAs, target/options, the complete per-unit
+  attempted denominator, withdrawal stages, body counts and runtime values.
+  The incoming probe is evidence to refine this plan, not a forecasted gain.
+  Include a module-init caller of
+  `apply(f: (v: number) => number, v: number): number`, scalar and supported
+  reference controls, a direct caller withdrawn for its own storage dependency,
+  several callable signatures and spelling changes. Test host and standalone;
+  distinguish select-stage rejection from this R2 boundary. Do not broaden an
+  unrelated selector simply to make a matrix cell pass.
+- A newly certified owner must have one preparation attempt, direct body `0`,
+  IR body `1`, complete prepared dependency evidence, and the same runtime
+  result as `JS2WASM_IR_FIRST=0`. Poison its direct body to prove the skip.
+  Existing prepared scalar/string/vector controls must retain ownership.
+- Add contract tests for a missing/forged receipt, changed allocator object,
+  changed parameter/result type including nullability, foreign inventory,
+  missing callable invocation support and changed support after sealing.
+  Assert zero body publication before failed certification. Exercise a real
+  mismatched allocated signature; valid-input tests alone cannot prove this
+  guard. Revert the new contract routing once to prove the gain disappears.
+- Run `pnpm typecheck`, then
+  `VITEST_MAX_FORKS=1 node node_modules/vitest/dist/cli.js run` with the new
+  contract suite and `tests/issue-3521-prepared-free-function-routing.test.ts`,
+  `tests/issue-3521-scoped-prepared-abi-seal.test.ts`,
+  `tests/issue-3521-prepared-component-dependencies.test.ts`,
+  `tests/issue-3521-r2-withdrawal-shapes.test.ts`, and `tests/issue-4514.test.ts`.
+  Include existing closure/backend signature and counted-string parameter
+  tests selected from the changed conversion seams.
+- Run `node --import tsx scripts/check-ir-only.ts --json --policy=hybrid` and
+  `node --import tsx scripts/check-ir-only.ts --json --policy=ir-only`,
+  `node --import tsx scripts/check-ir-fallbacks.ts`, equivalence, and
+  normal layering/dialect/size/oracle/format gates. Attribute pre-existing reds
+  to a same-config baseline. No baseline weakening. Full merge-group Test262
+  validation remains required for these shared preparation/lowering changes;
+  a green small IR corpus is not migration completion.

--- a/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
+++ b/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
@@ -4,7 +4,7 @@ title: "IR-only R5: whole-program single- and multi-source Prepared ownership"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-30
+updated: 2026-09-05
 assignee: ttraenkler/codex
 branch: codex/3525-m1a3-same-spelling-callables
 priority: critical
@@ -2306,3 +2306,133 @@ providers. General AST→Wasm handler deletion remains #3090/R10 after R9.
 - **False zero:** deleting collision suppressors can lower the counted
   denominator. Reconcile source census, outcomes, and emitter counts by
   `IrUnitId` before and after every deletion.
+
+## Implementation Plan — 2026-09-05 — M2-P1 ordered initializer census before routing
+
+**Planning base:** `5da655f286fcd569203cd2012b23dc21bf1c626d`. Astra planning,
+Luna `max` implementation; proposed slice claim
+`3525:m2-p1-ordered-init-census`, reserved by the lead before dispatch. This is
+an independent production prerequisite. R5 remains in progress and none of
+its full acceptance checkboxes becomes complete from this phase alone.
+
+### Current blocker and bounded result
+
+M0 already coordinates all sources, M1A already stages exact cross-source
+callable components, and M2 already owns one executable initializer. The
+remaining problem is composition, not absence of these foundations.
+`planMultiPreparedModuleInit` (`src/codegen/multi-prepared-module-init.ts:163`)
+builds source initialization plans only after its optional M2 admission gate;
+`planMultiPreparedProgramEarlyRoutes:1270` separately rescans executable syntax
+to disable callable cutover. `MultiPreparedProgramOwner:694` sees detailed
+initialization evidence only after M2 has emitted its selected body. Most
+graphs therefore reach routing without one retained ordered semantic plan of
+all their initializers, although `IrModuleInitPlan` already provides the
+single-source immutable vocabulary (`src/ir/module-init-plan.ts:91`).
+
+Build and retain that whole-program plan once, before any early route can
+prepare or emit a body. Make both M2 and the owner consume it by exact source
+and unit identity. This moves semantic state to the whole-program preparation
+boundary and removes duplicate route-dependent discovery; it does not admit
+new initialization syntax or require an allocator change.
+
+Mixed callable/initializer emission is the next dependent phase and remains
+unimplemented here. It needs R2's prepared callable-boundary/support contract,
+detached initializer preparation, and one publication transaction. The current
+M2+callable refusals (`multi-prepared-program.ts:580`, `:701`), M2's singleton
+restriction, and `ProgramAbiModuleInitCallableRegistry`'s singleton prepared
+reservation (`program-abi-module-init-planning.ts:265`) must remain until that
+transaction is designed and verified. The per-source overlay and its unresolved
+module-binding route also remain; this census is not a `PreparedIrProgram` or
+a proof of successful IR emission.
+
+### Changes and independent write scope
+
+1. Add `src/codegen/multi-prepared-module-init-census.ts`. Produce a defensively
+   immutable collection from the exact existing identity inventory and
+   `multiAst.sourceFiles`, using `buildIrModuleInitPlan` for every source,
+   including empty, type-only, unsupported and multiple-contributor sources.
+   Retain each full semantic plan: bindings/TDZ, live seeds, evaluations,
+   exports, invocation policy and explicit gaps. Keep canonical source order
+   separate from the existing semantic source order; never sort evaluation
+   order by a name, path or binding ID. Preserve within-source evaluation
+   ordinals and the input graph's dependency/SCC order. No new module loader or
+   independent topological sort belongs here.
+2. Bind the collection to the same session/inventory as
+   `MultiPreparedProgramOwner` (`multi-prepared-program.ts:442`). Initialize
+   its pure semantic census before `planExistingRoutes`, with required
+   currentness checks for duplicate/missing/foreign sources, the reverse
+   `SourceId` join, `UnitId` ownership, source order and changed source syntax.
+   Owner construction is early enough for semantic planning; legacy queue
+   parity is a separate observation after declaration collection. Do not mint
+   an empty census when a required source or checker observation is unavailable.
+3. Move M2's legacy-queue reconciliation (`multi-prepared-module-init.ts:175–200`)
+   to one explicit boundary before route planning, after all sources have run
+   declaration collection. Attach its per-source observation to the retained
+   semantic plan, without rebuilding that plan. Preserve exact node provenance
+   when partitioning static entries/module statements. A name-only live-seed
+   join that cannot distinguish sources is unavailable evidence, not an empty
+   success. Semantic plan gaps or unavailable parity remain visible and keep
+   the existing route ineligible; they are not a reason to fail previously
+   supported direct compilation. Contradictory or stale identity evidence is
+   an invariant.
+4. In `planMultiPreparedProgramEarlyRoutes:1242`, require the finalized census
+   before `owner.planExistingRoutes`; use its executable population for the
+   existing callable/init policy decision. In `planMultiPreparedModuleInit`,
+   consume that same collection and reconciled observations instead of the
+   local `sourceFiles.map(buildIrModuleInitPlan)` and a second source census.
+   The unchanged M2 shape/target/selection gates select a contributor from the
+   complete population; rejected sources are never removed from it. Validate
+   M2's exact selected unit against the census before reserving its slot.
+5. In `sealBodyBoundary:789` and `registerPreparedModuleInit:694`, require the
+   same retained authority. Expose a versioned data projection of the complete
+   ordered census in the body-plan audit, including graphs where M2 is off or
+   declined. Keep semantic planning, parity and successful ownership as
+   distinct facts. Snapshot the full plan rather than only contributor counts;
+   any schema change must update its existing validators and tests together.
+   Recheck currentness before source-body routing and final audit publication.
+
+Own the new census module, `multi-prepared-module-init.ts`,
+`multi-prepared-callable-orchestration.ts` **only its early-route orchestration**,
+and `multi-prepared-program.ts` **only census lifecycle/body-plan consumers**.
+Use the existing shared `module-init-plan.ts` producer unchanged where possible.
+No R2 integration/lowering/source-callable-registry edits, no R1 computed-method
+or identity changes, no R4 W2-B storage admission, no registry reservation or
+startup behavior change, and no callable-component eligibility widening.
+Keep additional helpers outside the large orchestration/owner methods.
+
+### Validation and stop conditions
+
+- Freeze a complete census with M2 enabled and disabled. Cover no executable
+  sources, one and multiple contributors, type-only sources, dependency and
+  entry contributors, re-export chains, same-spelled bindings in different
+  sources, import cycles, and differing canonical versus semantic order.
+  Source membership comes from the inventory, not the selector. Demonstrate
+  that M2's existing admitted fixtures consume this authority and retain their
+  exact direct `0` / IR `1` receipts; other graphs preserve their measured
+  routing and runtime values. No population gain is asserted in advance.
+- Mutation tests must reject omitted/duplicated/reordered sources, foreign
+  inventory or unit, changed AST initializer after planning, changed queue
+  observation after reconciliation, and a forged M2 contributor. Exercise
+  unavailable parity with a real nonempty population. Assert no source-body
+  emission or ABI reservation happened before a failed pre-route check.
+- Run `pnpm typecheck` and
+  `VITEST_MAX_FORKS=1 node node_modules/vitest/dist/cli.js run` with the new
+  `tests/issue-3525-ordered-module-init-census.test.ts`,
+  `tests/issue-3525-multi-prepared-program-census.test.ts`,
+  `tests/issue-3525-multi-prepared-module-init.test.ts`,
+  `tests/issue-3525-multi-prepared-callable-bindings.test.ts`,
+  `tests/issue-3525-prepared-program-abi-aggregate.test.ts`, and
+  `tests/issue-3521-r2-withdrawal-multi-source.test.ts`. Run both
+  `node --import tsx scripts/check-ir-only.ts --json --policy=hybrid` and
+  `node --import tsx scripts/check-ir-only.ts --json --policy=ir-only`,
+  `node --import tsx scripts/check-ir-fallbacks.ts`, normal
+  layering/format/size gates, and same-config multi-source equivalence checks.
+  Record SHAs/options, actual source/unit denominators and runtime/event order;
+  the small IR-only corpus cannot demonstrate R5 completion.
+- If moving parity exposes declaration queues that are not complete at the
+  proposed boundary, retain the early semantic plan and move the parity
+  observation to the last point before any route emits; report the exact
+  producer and consumer. Do not fix that ordering by planning after a body,
+  silently omitting a source, or enabling mixed emission. Any need to modify
+  the shared R2 preparation transaction is a dependent follow-up requiring
+  coordination with its owner.


### PR DESCRIPTION
Callable parameters can already execute correctly through IR, but the current outside-caller gate still emits their direct bodies first. Add an implementation plan for authenticated callable boundary contracts before ABI sealing and body publication, grounded in the host/standalone probe.

Add an independent plan to freeze the complete ordered module-initializer census before routing and have M2 consume that same authority. Both plans specify exclusive implementation ownership, failure controls, and validation; the full migration acceptance criteria remain open.

The tracking epic now records an audit of current production gaps, source/instrument provenance, and the remaining retirement obligations. The reachability figures explicitly distinguish conservative graph evidence from permission to delete shared runtime code.

Validation: `git diff --check`; pre-commit issue/size checks; pre-push typecheck, lint, formatting, oracle/coercion ratchets, issue integrity, and numeric-local parity (18/18). The retirement ledger deliberately reports 46/50 tracked rows not ready. This documentation PR does not claim conformance or migration completion.

References: #3518, #3521, #3525.
