### PR TITLE
docs(ir): plan generic async suspension and audit linear preparation

### DIFF
--- a/plan/issues/3527-ir-r7-ast-free-async-plan.md
+++ b/plan/issues/3527-ir-r7-ast-free-async-plan.md
@@ -3,7 +3,7 @@ id: 3527
 title: "IR-only R7: AST-free async suspension plans and canonical Promise ABI"
 status: blocked
 created: 2026-07-21
-updated: 2026-08-20
+updated: 2026-09-05
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -411,3 +411,186 @@ settlement provider behavior behind #3526 intents. General deletion is R10.
 - **Protocol/cross-file gaps:** iterator close, `yield*`, laziness, operation
   Promise identity, same-name units, and declaration order need dedicated
   anti-vacuity traces rather than corpus counts.
+
+## Implementation Plan — 2026-09-05 — B2 linear suspension chains and liveness
+
+**Planning source:** `5da655f286fcd569203cd2012b23dc21bf1c626d`; the lead
+verified no IR delta in the subsequently fetched `4946cf` main. Re-ground the
+implementation against its assigned current-main worktree. Proposed slice
+claim: `3527:r7-b2-linear-suspension-liveness`, reserved by the lead before
+dispatch. Astra plans and Luna `max` implements, per the user. This phase is
+ready independently of the remaining epic dependencies; it does not close R7
+or change its acceptance checkboxes.
+
+### Current production boundary
+
+The older “Current IR does not represent suspension” evidence above is
+superseded by production source. `IrAsyncPlan` already has a canonical Promise
+ABI, typed spills/updates, verifier and full semantic serialization.
+`src/codegen/ir-async-frame.ts:388` lowers it through the existing
+`emitPreparedAsyncFrameStateMachine`; its adapter restores typed spills
+(`:322`) and consumes multiple states. A new frame engine or plan schema is
+not required for linear chains.
+
+The producer still constrains the population. `async-prepare.ts:745` handles
+one await and rejects a slot used on both sides; its continuation receives
+only the resumed value. The separate loop and two-await producers test
+`fetchAllSequential`/`fetchUser` and `main` names (`:139`, `:373`). Source
+selection independently admits exact forms and rejects pre-await captures
+(`async-ir-planning.ts:445`, `:507`); native admission follows another named
+family (`:565–650`). None of those names is a semantic suspension proof.
+
+There is also an earlier blocker: the await arm in `from-ast.ts:4044` erases
+statically settled `Promise.resolve` and non-reference awaits. A general
+splitter cannot recover an erased microtask boundary. Exact prepared-owner
+await evidence must reach this arm before source admission widens.
+
+### Bounded structural result
+
+Prepare top-level ordinary async declarations with a linear sequence of
+awaits, ordinary intervening computation, and a final return/void completion.
+There is no fixed await count, statement count, identifier spelling, constant,
+or particular callee required. Use the existing callable/frame carrier and
+runtime-provider capabilities; this phase does not widen their representation
+vocabulary. At least the existing real-suspension population must be covered,
+and every await within an admitted chain survives, including settled operands.
+
+Branches/back-edges that cross suspension, try/catch/finally, nested executable
+containers, receivers/captured ref cells, `for await`, async generators, WASI
+and cross-source ownership remain separate phases. Existing specialized
+loop/main routes remain until the generic producer plus their runtime
+capabilities can replace them with measured parity. Their remaining name
+guards must be reported as unfinished work, not described as general R7
+coverage. Fully settled owners still using the old C-1 route are likewise
+outside this phase's completion claim.
+
+### Implementation and exclusive write scope
+
+1. **One exact source eligibility record.** Add
+   `src/codegen/async-linear-planning.ts` and consume it from `async-ir-planning.ts` in
+   `preparedIrAsyncSourceShape`, `prepareAsyncCallableAbi`, selector options,
+   thenable-call resolution and owner collection. Reuse `analyzeAsyncBody`
+   and `planLinearAwaits` (`async-cps.ts:659`) only as frontend structural
+   preflight; retain every exact await node in source evaluation order and
+   prove none is hidden in a nested scope/unsupported control region. Do not
+   copy their AST/callback plan into `IrAsyncPlan`. Source eligibility,
+   allocated canonical Promise result ABI, and final IR preparation must
+   agree; an unproved callable must not be changed to a Promise ABI and then
+   fall back to a raw-value emitter.
+2. **Preserve suspension at AST lowering.** Extend the prepared resolver in
+   `src/ir/async-from-ast.ts` with exact owner/await-site evidence and the
+   prepared resume type. Consume it only in `from-ast.ts`'s await arm, before
+   C-1 await elision. Evaluate the operand once, retaining an explicit `await`
+   even when an existing valid static substitution supplies its value. Use
+   the existing typed externref conversion when the operand needs the await
+   carrier; provider preparation must see that conversion. Do not add an
+   extra reaction or hand-written Promise wrapper: the existing frame engine
+   owns PromiseResolve/adoption and suspension. Reconcile the produced await
+   population with the exact source record; a missing, duplicate or foreign
+   site is an invariant, not a shorter successful plan.
+3. **General IR segmentation.** Add `src/ir/async-linear-prepare.ts`, called
+   from `prepareSuspendingIrFunction:678`. Consume one linear IR block with
+   no suspension hidden in nested buffers; split at every await, in order.
+   Retain the existing return-carrier optimization only after this general
+   analysis proves it valid. Do not use owner/callee/local names as admission.
+   Produce deterministic state IDs and `ir-async-state` derived `UnitId`s
+   anchored to the exact source owner and stable helper ordinal.
+4. **Compute values crossing boundaries.** Build a complete definition/use
+   and type table. Resolve ordinary linear `slot.write`/`slot.read` sequences
+   through reaching definitions before splitting; preserve explicit
+   conversions and logical types. A read without a proved reaching definition
+   or a refinement that cannot be preserved is a typed preparation refusal,
+   never an invented default. Compute live-in/live-out backwards over the
+   resulting state edges, excluding the successor-defined resume value.
+   Retain a value through intermediate states even when they do not use it;
+   omit dead values and overwritten slot versions. Populate exact typed
+   `spills` and each suspend's `live` set. Reuse the existing analysis
+   vocabulary and have `verifyIrAsyncPlan` (`async-plan.ts:1107–1171`)
+   independently recompute the result from the completed plan.
+5. **Outline computation into ordinary IR helpers.** The current frame
+   adapter intentionally accepts `const`/`call` state bodies
+   (`ir-async-frame.ts:230`); do not expand it into another instruction
+   lowerer. Partition non-suspending computation into deterministic ordinary
+   helper calls with explicit free-value parameters and zero/one result,
+   as the existing async producers do. A region with several values needed
+   later must expose each value through ordered helper boundaries; returning
+   only its final Promise loses the others. Never recompute effectful
+   prefixes to manufacture extra outputs. Preserve instruction order,
+   effects, allocation/site provenance, and exact symbolic call bindings.
+   Keep intermediate values inside helpers where their carrier is not a
+   valid frame boundary. Every helper and its final allocation provenance
+   must pass the ordinary IR verifier before component sealing.
+6. **Reuse canonical target preparation.** The semantic chain uses
+   `canonicalPromiseAbi`, `createIrAsyncPlan`, the existing runtime intents,
+   and rejection edges to the existing rejection sink. Numeric/reference
+   spills and helper interfaces must have exact preplanned carrier evidence.
+   For standalone, replace named-leaf certification for the new chain with a
+   structural call/provider closure: each awaited Promise producer is an
+   exact prepared async owner or an already-supported Promise-delay/provider
+   plan. Reconcile the whole candidate dependency component before reserving
+   ownership, independent of declaration order. Unknown producer/carrier
+   provenance remains a refusal. Do not enable the global native Promise
+   carrier gate, import host services into standalone, or let one unsupported
+   sibling poison unrelated prepared components.
+
+Own the new `src/ir/async-linear-prepare.ts` and `src/codegen/async-linear-planning.ts`,
+`src/ir/async-prepare.ts`, `src/codegen/async-ir-planning.ts`,
+`src/ir/async-from-ast.ts`, and only the named await arm/import in
+`src/ir/from-ast.ts`. A small pure liveness extraction from `async-plan.ts`
+is permitted if useful; do not weaken its verifier or change the codec/schema.
+Add `tests/issue-3527-linear-suspension-preparation.test.ts` and
+`tests/issue-3527-linear-suspension-runtime.test.ts`, updating old near-miss
+expectations only after their new route is measured.
+
+R2-B1 owns `lower.ts`, `integration.ts`, source-callable registry, and component
+sealing; this slice reuses those seams and does not edit them. R5 M2-P1 owns
+`multi-prepared-*`; this slice does not touch those files. Ordinary async
+callable allocation stays in `prepareAsyncCallableAbi`; any required shared
+boundary change must be coordinated with the R2 owner before editing. No
+changes to `async-frame.ts`, scheduler, runtime adapters or new providers are
+assumed: a missing capability is a concrete prerequisite to report, not a
+reason to bypass preparation or silently widen a backend.
+
+### Validation and landing bar
+
+- First measure baseline/candidate SHAs and explicit target/options. Include
+  two and three awaits with a parameter and a computed value live across
+  both, a mutable local updated between awaits, dead/overwritten values,
+  numeric-vector identity, an unused await result, and final `return await`.
+  Vary names, constants, helper declaration order and await count. Compare
+  exact attempted units, state/await counts, helpers, spill sets, direct/IR
+  body counts and runtime results. No gain is asserted from source inspection.
+- Use controlled pending fulfillment and rejection at each suspension. Assert
+  the event order before the first call returns, between resolutions, and
+  after final settlement; a rejected first await cannot run later effects or
+  evaluate the second operand. Test a synchronous throw while evaluating an
+  awaited expression and after a resume. Add a mixed pending/settled chain
+  containing `await Promise.resolve(value)` and a settled non-thenable; every
+  admitted await must still yield a microtask. Compare with native JavaScript
+  and the direct engine control, documenting any baseline ordering defect.
+- Corruption tests remove/add a live value, use an old slot version, drop or
+  duplicate an await, substitute a source owner, and remove a runtime/carrier
+  receipt. Missing liveness, invalid provenance or post-claim evidence must
+  fail before publication; deliberately unsupported control regions retain
+  a source-located refusal and do not emit a partial prepared body. Poison
+  the direct body of newly prepared owners and require direct `0` / IR `1`.
+  Revert the generic producer and prepared-await retention independently to
+  prove both ownership and ordering tests fail for the intended reason.
+- Run `pnpm typecheck` and
+  `VITEST_MAX_FORKS=1 node node_modules/vitest/dist/cli.js run` with the two
+  new suites, `tests/ir/issue-1373b-async-plan.test.ts`,
+  `tests/issue-4104-ir-async-plan-runtime-consumer.test.ts`,
+  `tests/issue-4106-ir-async-fetch-user.test.ts`,
+  `tests/issue-4124-ir-final-async.test.ts`,
+  `tests/issue-4573-standalone-native-promise-delay.test.ts`,
+  `tests/issue-4574-standalone-native-async-family.test.ts`, and
+  `tests/issue-2906-async-multiawait.test.ts`. Run native controls in fresh
+  processes; also retain host rejection/engine-convergence and existing WASI
+  controls as no-regression evidence, not newly prepared WASI coverage.
+- Run both `node --import tsx scripts/check-ir-only.ts --json --policy=hybrid`
+  and `node --import tsx scripts/check-ir-only.ts --json --policy=ir-only`,
+  `node --import tsx scripts/check-ir-fallbacks.ts`,
+  async equivalence, normal dialect/layering/format/size gates and full
+  merge-group Test262. Report remaining fixture producers, C-1 await elision,
+  unsupported containers/handlers and target gaps explicitly. A green
+  playground family or the small IR-only corpus cannot close this issue.

--- a/plan/issues/3528-ir-r8-shared-linear-prepared-program.md
+++ b/plan/issues/3528-ir-r8-shared-linear-prepared-program.md
@@ -4,7 +4,7 @@ title: "IR-only R8: linear consumes the shared Prepared IR program"
 status: blocked
 sprint: Backlog
 created: 2026-07-21
-updated: 2026-07-21
+updated: 2026-09-05
 priority: critical
 horizon: xl
 complexity: XL
@@ -295,3 +295,63 @@ general direct handlers persist until R9 makes IR-only sole policy and
 - **Gate denominator shrink:** removing a report can make counts appear green.
   Derive expected units from the Prepared census and fail on missing reports,
   compile catches, or unaccounted source/support units.
+
+## Source re-grounding — 2026-09-05
+
+Audited source: `5da655f286fcd569203cd2012b23dc21bf1c626d`. The later fetched
+upstream `4946cf70fe82def4bb4ec3e55092153b90b9506b` changes runtime prototype
+support but none of the IR or linear files cited here. This is source evidence,
+not a new corpus or conformance measurement. All acceptance criteria remain open.
+The subsequently verified `0a5a3e87df074982cc3022a95899fc62ad69b036` includes
+computed-method selection and the merged retirement plans; it also leaves the
+cited linear preparation and ratchet files unchanged.
+
+The July narrative about `check-linear-ir.ts` swallowing a compilation crash
+as an empty success is now stale. The current script has an authenticated
+complete source/owner census, explicit compile-error evidence, instrumentation
+failures, and a failing top-level exception outcome. Preserve those controls.
+Its corpus remains the fixed playground population and its acceptance predicate
+remains a compiled-count/rejection-threshold ratchet. It still does not prove
+zero direct emissions or the shared prepared-program product contract. The
+next gate change must extend the existing complete-accounting instrument rather
+than replace it with a bare count or reimplement its already-landed safeguards.
+
+Likewise, linear already has early structural identity/selection preparation:
+`prepareLinearIrOverlay` (`linear-integration.ts:514`) freezes and authenticates
+an exact context/source/oracle record before user slots. However,
+`PreparedLinearIrOverlay` (`:501`) retains `LinearContext`, `ts.SourceFile`,
+the oracle, and AST-keyed selection evidence. It is neither the neutral
+`PreparedIrProgram` handoff nor a complete semantic body snapshot.
+
+The remaining independent frontend rebuild is concrete:
+
+- `planLinearIrOverlay:384` builds its own propagated types, recursive evidence,
+  checker overlay and selection. Selection still depends on existing runtime
+  functions and linear-specific capability choices.
+- `compileLinearIrFunctions:954–1095` derives callable signatures from
+  declarations, projects them into legacy names, and retries
+  `lowerFunctionAstToIr` in a separate fixed point. Ordinary build failures can
+  still demote to the direct route; exact counted-string reservations have
+  stronger invariant behavior and must retain it.
+- `prepareLinearIntrinsicFunctions:666` prepares a target-specific runtime
+  manifest after this rebuild. Sharing the vocabulary or the from-AST helper
+  is not evidence that both backends consume the same prepared semantic input.
+
+Before dispatching L0, reconcile the shared frontend boundary with **#4617 —
+Frontend-neutral semantic IR snapshot for TypeScript 7 and Acorn**, the active
+R2 callable-boundary work, and R5 whole-program ownership. Preserve the existing
+unfinished D1a worktree recorded in #4617; do not duplicate it or overwrite it.
+The next implementation plan must name the immutable semantic artifact and
+its exact production producer/consumers, then prove preparation and semantic
+hash equality before permitting linear to bypass its independent builder.
+Wrapping `PreparedLinearIrOverlay` in a differently named type, serializing
+AST/checker state, or accepting two independently rebuilt hashes as one shared
+preparation does not advance the required boundary.
+
+The recorded `/private/tmp/js2-4617-d1a-function-value-baseline` directory is
+not visible in this filesystem. Its worktree/branch registration remains, so
+absence here is not proof that the unpublished bytes were deleted on every
+host. Preserve the registration and the recorded checkpoint; do not prune or
+recreate that path as a cleanup step. Any D1a continuation must first establish
+which recorded changes are available and compare them with current production
+source, rather than treating the historical dirty worktree as a ready artifact.


### PR DESCRIPTION
The async producer still admits narrow suspension forms and can erase settled awaits before a general IR plan sees them. Specify a generic straight-line suspension producer with exact await-site evidence, SSA/slot liveness, deterministic existing IR helpers, and event-order validation. The plan preserves every await in an admitted chain and reuses the existing frame engine.

Re-ground the linear migration issue against its current complete-accounting ratchet and the remaining independent AST-to-IR build. Record the historical D1a worktree visibility limit so its registration is not mistaken for available, validated compiler changes.

The two issue files retain their full acceptance requirements. No compiler code or baselines change in this PR.

Validation: `git diff --check`, normal pre-commit size checks, and pre-push typecheck, lint, formatting, oracle/coercion ratchets, issue integrity, and numeric-local parity (18/18).

References: #3527, #3528; migration epic #3518.
