### PR TITLE
fix(playground): AST panel parses the user's TypeScript, not the usage-example tab

### DIFF
--- a/docs/playground-ast-explorer.md
+++ b/docs/playground-ast-explorer.md
@@ -44,18 +44,28 @@ The helper file itself is not shipped: its `from "js2wasm"` specifier cannot
 resolve from a statically-served file, and the playground already has the
 runtime loaded.
 
-## Editor source vs. compiled JS
+## TypeScript in, JavaScript AST out
 
-acorn parses JavaScript; the editor holds TypeScript. The panel tries the editor
-text first and falls back to the compiled JS output when annotations trip the
-parser. The header says which one is on screen — that distinction matters,
-because only the editor case can map a node's range back to what you typed
-(hover highlights it, click selects it).
+acorn parses JavaScript; the editor holds TypeScript. The panel erases the
+TS-only syntax by **blanking it with spaces** (`website/playground/ts-erase-types.ts`),
+so every surviving character keeps its original offset. `const x: number = 1`
+becomes `const x         = 1` — `x` and `1` are still exactly where the editor
+has them, which is what lets hovering a node highlight the right range and
+clicking it select the right text.
 
-While you type, the tree refreshes live **only** when it is already showing
-editor text. On a TypeScript source it waits for the next compile: the compiled
-output is cleared on every edit, so re-parsing there would replace a correct
-tree with a parse error on each keystroke.
+The eraser is deliberately partial. Constructs that need code **generation**
+rather than deletion — `enum`, `namespace`, constructor parameter properties,
+decorators — cannot be blanked, so it bails and the panel falls back to
+`ts.transpileModule`. That is correct JavaScript with shifted offsets, so the
+header says "transpiled (offsets shifted)" and hover mapping is off for it.
+
+The tree refreshes as you type: erasing and parsing costs a few milliseconds and
+needs no compile, so the panel follows the editor rather than the last build.
+
+An earlier cut parsed the playground's generated `example.js` tab instead. That
+tab is a *usage example* — a `createImports()` helper plus an inline adapter
+manifest — so the panel was rendering the AST of a JSON blob rather than of the
+user's program. If you touch this path, keep the input the user's own code.
 
 ## Known cosmetic differences
 

--- a/tests/playground-ts-erase-types.test.ts
+++ b/tests/playground-ts-erase-types.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+import { eraseTypesPreservingOffsets } from "../website/playground/ts-erase-types.js";
+import { setupAcorn } from "./dogfood/setup-acorn.mjs";
+
+// The playground's AST explorer parses with acorn (JavaScript only) while the
+// editor holds TypeScript. Rather than transpiling — which moves code and
+// breaks the panel's hover-to-highlight — the TS-only syntax is blanked with
+// spaces, so every surviving character keeps its original offset.
+//
+// Two properties matter and are checked here: the output is still parseable
+// JavaScript, and a node's range still points at the same text in the ORIGINAL
+// TypeScript.
+
+const PARSE_OPTIONS = { ecmaVersion: 2022, sourceType: "module" as const };
+
+const acorn = await import(setupAcorn().entryModulePath);
+
+function erase(source: string) {
+  const result = eraseTypesPreservingOffsets(ts, source, "input.ts");
+  if (!result) throw new Error("eraser returned null");
+  return result;
+}
+
+function eraseAndParse(source: string) {
+  const result = erase(source);
+  expect(result.unsupported, `bailed: ${result.unsupported}`).toBeUndefined();
+  // Blanking must never change the length, or every offset after the edit slides.
+  expect(result.code.length).toBe(source.length);
+  return { code: result.code, ast: acorn.parse(result.code, PARSE_OPTIONS) };
+}
+
+describe("playground TS type eraser", () => {
+  it("keeps offsets so a node's range still points at the original source", () => {
+    const source = `function el(tag: string, css: string): HTMLElement {
+  const e = document.createElement(tag);
+  return e;
+}
+`;
+    const { ast } = eraseAndParse(source);
+    const fn = ast.body[0];
+    expect(fn.type).toBe("FunctionDeclaration");
+    // The range is meaningful against the TypeScript the user typed, annotations included.
+    expect(source.slice(fn.start, fn.start + 11)).toBe("function el");
+    expect(source.slice(fn.id.start, fn.id.end)).toBe("el");
+    const param = fn.params[0];
+    expect(source.slice(param.start, param.end)).toBe("tag");
+  });
+
+  it.each([
+    ["type annotation", "const x: number = 1;\n"],
+    ["interface", "interface P { x: number }\nconst p = { x: 1 };\n"],
+    ["type alias", "type P = { x: number };\nconst p = { x: 1 };\n"],
+    ["as expression", 'const v = ("x" as string).length;\n'],
+    ["satisfies", "const v = { a: 1 } satisfies Record<string, number>;\n"],
+    ["non-null assertion", "const v = document.body!.tagName;\n"],
+    ["generic function", "function id<T>(v: T): T { return v; }\nid<number>(1);\n"],
+    ["type-only import", 'import type { A } from "./a.js";\nexport const x = 1;\n'],
+    ["inline type specifiers", 'import { a, type B, type C } from "./a.js";\nexport const x = a;\n'],
+    ["leading inline type specifier", 'import { type B, a } from "./a.js";\nexport const x = a;\n'],
+    ["definite assignment", "let v!: number;\nv = 1;\n"],
+    ["optional parameter", "function f(a?: number) { return a; }\n"],
+    ["this parameter", "function f(this: unknown, x: number) { return x; }\n"],
+    ["class members", "class C {\n  private readonly n: number = 0;\n  get v(): number { return this.n; }\n}\n"],
+    ["implements clause", "interface I { x: number }\nclass C implements I { x = 1; }\n"],
+    [
+      "overload signatures",
+      "function f(a: string): string;\nfunction f(a: number): number;\nfunction f(a: any) { return a; }\n",
+    ],
+  ])("erases %s into parseable JavaScript", (_name, source) => {
+    expect(() => eraseAndParse(source)).not.toThrow();
+  });
+
+  it.each([
+    ["enum", "enum E { A, B }\n"],
+    ["namespace", "namespace N { export const x = 1; }\n"],
+    ["parameter property", "class C { constructor(private readonly n: number) {} }\n"],
+  ])("bails on %s rather than blanking code that must be generated", (_name, source) => {
+    expect(erase(source).unsupported).toBeTruthy();
+  });
+
+  it("erases every playground example into parseable JavaScript", () => {
+    const dir = "website/playground/examples";
+    const files = (function walk(d: string): string[] {
+      return readdirSync(d).flatMap((n) => {
+        const p = join(d, n);
+        return statSync(p).isDirectory() ? walk(p) : p.endsWith(".ts") ? [p] : [];
+      });
+    })(dir);
+    expect(files.length).toBeGreaterThan(0);
+
+    const failures: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(file, "utf-8");
+      try {
+        const result = erase(source);
+        if (result.unsupported) {
+          failures.push(`${file}: bailed on ${result.unsupported}`);
+          continue;
+        }
+        acorn.parse(result.code, PARSE_OPTIONS);
+      } catch (error) {
+        failures.push(`${file}: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+    // Every shipped example is content the panel renders on load, so a
+    // regression here is visible to every visitor.
+    expect(failures).toEqual([]);
+  });
+});

--- a/website/playground/ast-explorer.ts
+++ b/website/playground/ast-explorer.ts
@@ -43,8 +43,12 @@ interface AcornMeta {
 
 type AstNode = Record<string, unknown>;
 
-/** Where a rendered subtree came from, so the header can say so honestly. */
-export type AstSourceKind = "editor" | "compiled-js";
+/**
+ * Whether the parsed text still lines up with the editor. True for the normal
+ * path (TS-only syntax blanked in place, offsets preserved); false when the
+ * host had to transpile, which moves code.
+ */
+export type AstSourceKind = "editor" | "transpiled";
 
 // Fields every node carries; shown as the range badge rather than as children.
 const RANGE_KEYS = new Set(["start", "end", "loc", "range", "sourceFile"]);
@@ -111,7 +115,7 @@ export class AstExplorer {
    */
   showsEditorSource = true;
 
-  private pendingSources: { editorCode: string; compiledJs: string } | null = null;
+  private pendingSource: { code: string; mapsToEditor: boolean } | null = null;
   private lastRendered: { code: string; kind: AstSourceKind; options: AcornOptions } | null = null;
 
   constructor() {
@@ -147,7 +151,7 @@ export class AstExplorer {
     this.sourceTypeSelect = this.element.querySelector(".ast-source-type")!;
 
     const reparse = () => {
-      if (this.pendingSources) return; // nothing parsed yet; load() will replay
+      if (this.pendingSource) return; // nothing parsed yet; load() will replay
       const last = this.lastRendered;
       if (!last) return;
       // Re-render THIS source under the new options, without re-running the
@@ -220,43 +224,28 @@ export class AstExplorer {
       this.loading = null;
     }
 
-    if (this.pendingSources) {
-      const { editorCode, compiledJs } = this.pendingSources;
-      this.pendingSources = null;
-      this.setSources(editorCode, compiledJs);
+    if (this.pendingSource) {
+      const { code, mapsToEditor } = this.pendingSource;
+      this.pendingSource = null;
+      this.setSource(code, mapsToEditor);
     }
   }
 
   /**
-   * Parse and render the current program.
+   * Parse and render `code`, which the host has already reduced to JavaScript.
    *
-   * acorn parses JavaScript and the editor holds TypeScript, so the editor text
-   * is tried first — most playground examples are annotation-free enough to
-   * parse, and only that case can map a node back to what the user typed. When
-   * the annotations trip it, fall back to the compiled JS output rather than
-   * showing a parse error for source that compiled fine. The header says which
-   * one is on screen.
-   *
-   * Both sources are taken together (rather than as two host calls) so a call
-   * that arrives before the parser has loaded can replay the same decision
-   * afterwards instead of replaying only the branch it happened to try first.
+   * `mapsToEditor` says whether its offsets still refer to the editor's own
+   * text — they do whenever the types were blanked in place, and do not when
+   * the host fell back to a transpile. The header states which, since only the
+   * first case can highlight a node back in the source.
    */
-  setSources(editorCode: string, compiledJs: string): void {
+  setSource(code: string, mapsToEditor: boolean): void {
     if (!this.parse) {
-      this.pendingSources = { editorCode, compiledJs };
+      this.pendingSource = { code, mapsToEditor };
       return;
     }
-    if (this.renderSource(editorCode, "editor")) {
-      this.showsEditorSource = true;
-      return;
-    }
-    if (compiledJs.trim() && this.renderSource(compiledJs, "compiled-js")) {
-      this.showsEditorSource = false;
-      return;
-    }
-    // Neither parsed: renderSource already put the editor error on screen, and
-    // that is the one the reader can act on.
-    this.showsEditorSource = true;
+    this.showsEditorSource = mapsToEditor;
+    this.renderSource(code, mapsToEditor ? "editor" : "transpiled");
   }
 
   /** Parse + render one candidate. Returns false (and shows why) on a parse error. */
@@ -318,7 +307,7 @@ export class AstExplorer {
     const parts = [`acorn ${this.meta.acornVersion} → wasm (${kb} KB)`];
     if (stats) {
       parts.push(`${stats.nodeCount} nodes in ${stats.parseMs.toFixed(1)} ms`);
-      parts.push(stats.kind === "editor" ? "from the editor" : "from the compiled JS output");
+      parts.push(stats.kind === "editor" ? "types erased in place" : "transpiled (offsets shifted)");
     }
     this.headerEl.textContent = parts.join(" · ");
     this.headerEl.title =

--- a/website/playground/main.ts
+++ b/website/playground/main.ts
@@ -20,6 +20,7 @@ import { WasmTreemap, parseWasm, parseWasmSpans, SECTION_COLORS } from "./wasm-t
 import type { WasmData, WasmSection, WasmFunctionBody, ByteSpan } from "./wasm-treemap.js";
 import { LayoutManager, clearSavedLayout, getDefaultLayout, getMobileDefaultLayout } from "./layout.js";
 import { AstExplorer } from "./ast-explorer.js";
+import { eraseTypesPreservingOffsets } from "./ts-erase-types.js";
 import DEFAULT_SOURCE from "./examples/dom/calendar.ts?raw";
 import BENCH_HELPERS_SOURCE from "./examples/benchmarks/helpers.ts?raw";
 
@@ -3005,28 +3006,52 @@ astExplorer.onNodeSelect = (range) => {
   });
 };
 
-/** Feed the explorer after a compile. Cheap when nothing changed. */
-function updateAstPanel(editorSource: string, compiledJs: string): void {
-  astExplorer.setSources(editorSource, compiledJs);
+/**
+ * The JavaScript the AST panel should parse.
+ *
+ * acorn parses JavaScript; the editor holds TypeScript. Erase the TS-only
+ * syntax by blanking it with spaces, which keeps every remaining character at
+ * its ORIGINAL offset — so a node's range still points at the editor text and
+ * hover/click keep working. Constructs that need code generation rather than
+ * deletion (enum, namespace, parameter properties) can't be blanked; those fall
+ * back to a real transpile, which is correct JS at shifted offsets.
+ */
+function javascriptForAst(editorSource: string): { code: string; mapsToEditor: boolean } {
+  try {
+    const erased = eraseTypesPreservingOffsets(ts, editorSource, "playground.ts");
+    if (erased && !erased.unsupported) return { code: erased.code, mapsToEditor: true };
+  } catch {
+    // A malformed source can trip the eraser's AST walk; transpile instead.
+  }
+  try {
+    const out = ts.transpileModule(editorSource, {
+      compilerOptions: { target: ts.ScriptTarget.ESNext, module: ts.ModuleKind.ESNext, removeComments: false },
+      reportDiagnostics: false,
+    });
+    return { code: out.outputText, mapsToEditor: false };
+  } catch {
+    // Give acorn the raw text and let it report the real syntax error.
+    return { code: editorSource, mapsToEditor: true };
+  }
+}
+
+/** Feed the explorer. Cheap when nothing changed. */
+function updateAstPanel(editorSource: string): void {
+  const { code, mapsToEditor } = javascriptForAst(editorSource);
+  astExplorer.setSource(code, mapsToEditor);
 }
 
 /**
- * Keep the tree live while typing — parsing costs milliseconds and needs no
- * compile.
- *
- * Only when the panel is already showing the EDITOR's text, though: a
- * TypeScript source is on screen as its compiled JS (acorn cannot parse the
- * annotations), and the compiled output is cleared the moment the source
- * changes. Re-parsing there would replace a correct tree with a parse error on
- * every keystroke, so that case waits for the next compile.
+ * Keep the tree live while typing. Erasing types and parsing costs milliseconds
+ * and needs no compile, so the panel follows the editor rather than the last
+ * build.
  */
 let astRefreshTimer: number | null = null;
 function scheduleAstRefreshFromEditor(): void {
-  if (!astExplorer.showsEditorSource) return;
   if (astRefreshTimer !== null) window.clearTimeout(astRefreshTimer);
   astRefreshTimer = window.setTimeout(() => {
     astRefreshTimer = null;
-    astExplorer.setSources(inputFile.model.getValue(), "");
+    updateAstPanel(inputFile.model.getValue());
   }, 250);
 }
 
@@ -4261,9 +4286,8 @@ async function compileOnly() {
     wasmFile.binaryData = new Uint8Array(bin);
     annotateHexEditor(bin, wasmData, lineLabels);
   }
-  const modularOutput = generateModularOutput(result);
-  fileMap.get("output/example.js")!.model.setValue(modularOutput);
-  updateAstPanel(source, modularOutput);
+  fileMap.get("output/example.js")!.model.setValue(generateModularOutput(result));
+  updateAstPanel(source);
 
   // Mark output files as compiled
   for (const f of files) {

--- a/website/playground/ts-erase-types.ts
+++ b/website/playground/ts-erase-types.ts
@@ -1,0 +1,322 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Erase TypeScript-only syntax by overwriting it with spaces, keeping every
+// remaining character at its original offset.
+//
+// Why not `ts.transpileModule`: it moves code. The AST explorer parses with
+// acorn (JavaScript only) but wants to point back into the TypeScript the user
+// typed — hover a node, highlight that range in the editor. Offsets survive
+// only if the erasure is a same-length blanking, so `const x: number = 1` keeps
+// `x` and `1` exactly where they were. This is the `ts-blank-space` idea,
+// implemented against the TypeScript AST the playground already loads.
+//
+// Deliberately partial. Constructs that need real code GENERATION rather than
+// deletion — enums, namespaces with values, parameter properties, decorator
+// emit — cannot be blanked, so this returns null for them and the caller falls
+// back to `ts.transpileModule` (correct JS, shifted offsets, no hover mapping).
+// A silent wrong answer would be worse than an honest fallback.
+
+import type * as TS from "typescript";
+
+/** Half-open [start, end) range in the original source. */
+type Span = [number, number];
+
+export interface EraseResult {
+  /** Source with TS-only syntax blanked out; same length as the input. */
+  code: string;
+  /** Constructs that forced a bail-out, when `code` is null. */
+  unsupported?: string;
+}
+
+/**
+ * @returns the blanked source, or null when the file uses a construct that
+ * cannot be erased by blanking alone (the caller should transpile instead).
+ */
+export function eraseTypesPreservingOffsets(ts: typeof TS, source: string, fileName = "input.ts"): EraseResult | null {
+  const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, /*setParentNodes*/ true, ts.ScriptKind.TS);
+  const spans: Span[] = [];
+  let unsupported: string | null = null;
+
+  const bail = (what: string) => {
+    unsupported ??= what;
+  };
+
+  // A node's full width includes leading trivia (comments); blanking that would
+  // delete comments the reader can see in the editor. Use the token start.
+  const spanOf = (node: TS.Node): Span => [node.getStart(sf), node.getEnd()];
+
+  const blankNode = (node: TS.Node | undefined) => {
+    if (node) spans.push(spanOf(node));
+  };
+
+  // For `x: T`, the colon sits between the name and the type and must go too.
+  const blankTypeAnnotation = (type: TS.TypeNode | undefined) => {
+    if (!type) return;
+    const end = type.getEnd();
+    let start = type.getStart(sf);
+    // Walk back over whitespace to the ':' that introduced it.
+    let i = start - 1;
+    while (i >= 0 && /\s/.test(source[i]!)) i--;
+    if (source[i] === ":") start = i;
+    spans.push([start, end]);
+  };
+
+  const blankTypeArguments = (args: TS.NodeArray<TS.TypeNode> | undefined) => {
+    if (!args || args.length === 0) return;
+    // `f<A, B>(…)` — blank from the '<' before the first argument through the
+    // '>' after the last. pos-1/end+1 are not reliable, so scan.
+    let start = args[0]!.getStart(sf);
+    while (start > 0 && source[start - 1] !== "<") start--;
+    if (start > 0) start -= 1; // include '<'
+    let end = args[args.length - 1]!.getEnd();
+    while (end < source.length && source[end] !== ">") end++;
+    if (end < source.length) end += 1; // include '>'
+    spans.push([start, end]);
+  };
+
+  const blankModifiers = (node: TS.Node) => {
+    const mods = (node as { modifiers?: TS.NodeArray<TS.ModifierLike> }).modifiers;
+    if (!mods) return;
+    for (const mod of mods) {
+      switch (mod.kind) {
+        case ts.SyntaxKind.PublicKeyword:
+        case ts.SyntaxKind.PrivateKeyword:
+        case ts.SyntaxKind.ProtectedKeyword:
+        case ts.SyntaxKind.ReadonlyKeyword:
+        case ts.SyntaxKind.AbstractKeyword:
+        case ts.SyntaxKind.OverrideKeyword:
+        case ts.SyntaxKind.DeclareKeyword:
+          spans.push(spanOf(mod));
+          break;
+        case ts.SyntaxKind.Decorator:
+          // Decorators are emit, not erasure.
+          bail("decorators");
+          break;
+        default:
+          break;
+      }
+    }
+  };
+
+  const visit = (node: TS.Node): void => {
+    if (unsupported) return;
+
+    switch (node.kind) {
+      // ── Whole-node erasures: type-only declarations ──────────────────────
+      case ts.SyntaxKind.InterfaceDeclaration:
+      case ts.SyntaxKind.TypeAliasDeclaration:
+        blankNode(node);
+        return;
+
+      case ts.SyntaxKind.ImportDeclaration: {
+        const decl = node as TS.ImportDeclaration;
+        if (decl.importClause?.isTypeOnly) {
+          blankNode(node);
+          return;
+        }
+        break;
+      }
+      case ts.SyntaxKind.ExportDeclaration: {
+        const decl = node as TS.ExportDeclaration;
+        if (decl.isTypeOnly) {
+          blankNode(node);
+          return;
+        }
+        break;
+      }
+
+      // `import { a, type B }` / `export { a, type B }` — the inline `type`
+      // specifier is erased on its own, and must take one adjacent comma with
+      // it: `{   , a }` is not legal JS while `{ a,   }` is.
+      //
+      // Take the FOLLOWING comma by preference, the preceding one only for the
+      // last specifier. Preferring the preceding comma breaks a run of type
+      // specifiers — `{ type A, type B, c }` would leave B's own trailing comma
+      // stranded in front of `c`.
+      case ts.SyntaxKind.ImportSpecifier:
+      case ts.SyntaxKind.ExportSpecifier: {
+        const spec = node as TS.ImportSpecifier | TS.ExportSpecifier;
+        if (spec.isTypeOnly) {
+          let [start, end] = spanOf(spec);
+          let j = end;
+          while (j < source.length && /\s/.test(source[j]!)) j++;
+          if (source[j] === ",") {
+            end = j + 1;
+          } else {
+            let i = start - 1;
+            while (i >= 0 && /\s/.test(source[i]!)) i--;
+            if (source[i] === ",") start = i;
+          }
+          spans.push([start, end]);
+        }
+        return;
+      }
+
+      // ── Constructs that need code generation, not deletion ───────────────
+      case ts.SyntaxKind.EnumDeclaration:
+        bail("enum");
+        return;
+      case ts.SyntaxKind.ModuleDeclaration:
+        bail("namespace/module");
+        return;
+      case ts.SyntaxKind.ImportEqualsDeclaration:
+        bail("import =");
+        return;
+
+      // ── Expression-level type syntax ─────────────────────────────────────
+      case ts.SyntaxKind.AsExpression:
+      case ts.SyntaxKind.SatisfiesExpression: {
+        const expr = node as TS.AsExpression | TS.SatisfiesExpression;
+        // Blank ` as T` / ` satisfies T`: from the end of the operand to the
+        // end of the type.
+        spans.push([expr.expression.getEnd(), expr.getEnd()]);
+        visit(expr.expression);
+        return;
+      }
+      case ts.SyntaxKind.TypeAssertionExpression: {
+        // `<T>value` — the angle-bracket form.
+        const expr = node as TS.TypeAssertion;
+        spans.push([expr.getStart(sf), expr.expression.getStart(sf)]);
+        visit(expr.expression);
+        return;
+      }
+      case ts.SyntaxKind.NonNullExpression: {
+        const expr = node as TS.NonNullExpression;
+        spans.push([expr.expression.getEnd(), expr.getEnd()]);
+        visit(expr.expression);
+        return;
+      }
+      default:
+        break;
+    }
+
+    // ── Per-node pieces ────────────────────────────────────────────────────
+    blankModifiers(node);
+
+    const anyNode = node as TS.Node & {
+      type?: TS.TypeNode;
+      typeParameters?: TS.NodeArray<TS.TypeParameterDeclaration>;
+      typeArguments?: TS.NodeArray<TS.TypeNode>;
+      questionToken?: TS.Node;
+      exclamationToken?: TS.Node;
+      body?: TS.Node;
+      heritageClauses?: TS.NodeArray<TS.HeritageClause>;
+    };
+
+    if (
+      ts.isVariableDeclaration(node) ||
+      ts.isParameter(node) ||
+      ts.isPropertyDeclaration(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isGetAccessor(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isFunctionExpression(node)
+    ) {
+      blankTypeAnnotation(anyNode.type);
+    }
+
+    if (anyNode.typeParameters) {
+      const first = anyNode.typeParameters[0]!;
+      let start = first.getStart(sf);
+      while (start > 0 && source[start - 1] !== "<") start--;
+      if (start > 0) start -= 1;
+      let end = anyNode.typeParameters[anyNode.typeParameters.length - 1]!.getEnd();
+      while (end < source.length && source[end] !== ">") end++;
+      if (end < source.length) end += 1;
+      spans.push([start, end]);
+    }
+
+    // `f<T>(x)` / `new C<T>()` — call-site type arguments.
+    if ((ts.isCallExpression(node) || ts.isNewExpression(node)) && anyNode.typeArguments) {
+      blankTypeArguments(anyNode.typeArguments);
+    }
+
+    // A `this` parameter is a type annotation wearing a parameter's clothes —
+    // it declares no binding and must not survive into the JS. Take one
+    // adjacent comma with it, same rule as a type-only import specifier.
+    if (ts.isParameter(node) && ts.isIdentifier(node.name) && node.name.text === "this") {
+      let [start, end] = spanOf(node);
+      let j = end;
+      while (j < source.length && /\s/.test(source[j]!)) j++;
+      if (source[j] === ",") {
+        end = j + 1;
+      } else {
+        let i = start - 1;
+        while (i >= 0 && /\s/.test(source[i]!)) i--;
+        if (source[i] === ",") start = i;
+      }
+      spans.push([start, end]);
+      return;
+    }
+
+    // Optional markers on parameters and properties are type-level.
+    if (
+      (ts.isParameter(node) || ts.isPropertyDeclaration(node) || ts.isMethodDeclaration(node)) &&
+      anyNode.questionToken
+    ) {
+      blankNode(anyNode.questionToken);
+    }
+    // Definite-assignment `!` on a property or a `let` binding.
+    if ((ts.isPropertyDeclaration(node) || ts.isVariableDeclaration(node)) && anyNode.exclamationToken) {
+      blankNode(anyNode.exclamationToken);
+    }
+
+    // `class C implements I` — the clause is type-only; `extends` is not.
+    if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+      for (const clause of anyNode.heritageClauses ?? []) {
+        if (clause.token === ts.SyntaxKind.ImplementsKeyword) blankNode(clause);
+      }
+    }
+
+    // A signature without a body is an overload declaration or an ambient
+    // declaration — nothing to emit.
+    if (
+      (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node) || ts.isConstructorDeclaration(node)) &&
+      !anyNode.body
+    ) {
+      blankNode(node);
+      return;
+    }
+
+    // A constructor parameter with an accessibility modifier declares a field:
+    // that is emit, not erasure.
+    if (ts.isParameter(node) && node.modifiers?.some((m) => m.kind !== ts.SyntaxKind.Decorator)) {
+      const parent = node.parent;
+      if (parent && ts.isConstructorDeclaration(parent)) {
+        bail("parameter property");
+        return;
+      }
+    }
+
+    // Index signatures and call/construct signatures inside a class body are
+    // type-only members.
+    if (ts.isIndexSignatureDeclaration(node) || ts.isPropertySignature(node) || ts.isMethodSignature(node)) {
+      blankNode(node);
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sf, visit);
+
+  if (unsupported) return { code: "", unsupported };
+
+  return { code: blankSpans(source, spans) };
+}
+
+/**
+ * Replace each span with spaces, keeping newlines so line/column numbers — and
+ * therefore acorn's error positions — still line up with the editor.
+ */
+function blankSpans(source: string, spans: Span[]): string {
+  if (spans.length === 0) return source;
+  const out = source.split("");
+  for (const [start, end] of spans) {
+    for (let i = Math.max(0, start); i < Math.min(end, out.length); i++) {
+      if (out[i] !== "\n" && out[i] !== "\r") out[i] = " ";
+    }
+  }
+  return out.join("");
+}


### PR DESCRIPTION
## Description

The AST panel fed acorn the generated `example.js` tab, on the theory that it was the compiled JavaScript of the program. **It is not.** That tab is a *usage example* — a `createImports()` helper wrapping a large inline adapter manifest — so the tree on screen was the AST of a JSON blob, and on the deployed build it failed outright with `Cannot read properties of null (reading 'replace')`.

acorn parses JavaScript and the editor holds TypeScript, so the input has to be the user's own code with the types removed.

### Why blanking, not transpiling

`ts.transpileModule` produces correct JS but **moves code**, which kills the panel's point: hovering a node highlights its range in the editor. So `website/playground/ts-erase-types.ts` erases TS-only syntax by **overwriting it with spaces**:

```
const x: number = 1     →     const x         = 1
```

Every surviving character keeps its original offset, so a node's range still points at the TypeScript the user typed — annotations included.

**Covered:** type annotations · interfaces and type aliases · `as` / `satisfies` · non-null `!` · definite-assignment `!` · type parameters and call-site type arguments · type-only imports/exports, whole-clause and inline specifiers · accessibility / `readonly` / `abstract` / `declare` modifiers · `implements` clauses · optional markers · `this` parameters · overload signatures · index and property signatures.

Measured over 444 TS files (playground examples, `tests/equivalence`, `src/ir`, `src/checker`):

| | files |
|---|---|
| erase + parse cleanly | 409 |
| bail (documented, falls back) | 31 |
| fail | 4 |

All 13 shipped playground examples pass — that is what a visitor actually sees.

**Deliberately partial.** Constructs needing code *generation* rather than deletion — `enum`, `namespace`, constructor parameter properties, decorators — cannot be blanked. The eraser bails on those by name and the panel falls back to `ts.transpileModule`: correct JS at shifted offsets, labelled "transpiled (offsets shifted)" with hover mapping off. A silent wrong tree would be worse than an honest fallback.

### Two consequences

- **Live refresh now applies to every source.** Erasing plus parsing is milliseconds and needs no compile. The old rule that limited live refresh to non-TS sources existed only because the fallback depended on a build.
- **The compiled parser is exonerated.** I checked directly: compiled-acorn raises the same `SyntaxError`s as node-acorn on TypeScript input (`Unexpected token (8:15)` on both, for `calendar.ts`). The `TypeError` came from feeding it the wrong text, not from acorn's error path.

### Verification

In a real browser against the built `dist/` (Playwright, headless Chromium):

- `calendar.ts` renders **1556 nodes in ~540 ms**, labelled "types erased in place" (previously: the imports-helper blob, or an error).
- Hovering `body[0]: FunctionDeclaration 328–460` highlights exactly `function el(tag: string, css: string): HTMLElement { … }` in the editor.
- No console errors.

`tests/playground-ts-erase-types.test.ts` (21 tests) covers the offset property directly, 16 per-construct cases, the three documented bail-outs, and every shipped example.

Gates green locally: LOC / function / coercion-sites budgets, `check:oracle-ratchet`, `check:dead-exports`, `check:issues`, `biome lint`, `build:playground`.

Docs updated: [`docs/playground-ast-explorer.md`](https://github.com/loopdive/js2/blob/claude/acorn-wasm-compile-6u450e/docs/playground-ast-explorer.md).

### Still open from the previous PR

No issue id (`claim-issue.mjs --allocate` refuses without the open-PR scan; `gh` unavailable here), and `build:acorn-wasm` is still not wired into `run-pages-build.mjs`, so the committed `acorn.wasm` drifts from the compiler until someone reruns it.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: agreeing to a legal document is the author's call, not the agent's. `cla-check` passes as "not required (allowlist)" on this branch. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tg5GRG1rv2KSSuTfddsXPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg5GRG1rv2KSSuTfddsXPZ)_