### PR TITLE
fix(ir): restore nested callable brand guard

### DIFF
--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -4622,3 +4622,40 @@ is verified on main. Do not amend, reopen or push the merged PR's branch.
 Exclusive ownership is these two files and this issue record. Preserve active
 R5 initializer transactions, R8 body-handoff work and all other agents' changes.
 R2 and the full IR retirement epic remain open after this narrow repair.
+
+## Implementation Results — 2026-09-05 — R2-B1 missing brand guard repair
+
+**Status:** in-progress; the callable-boundary repair is complete on this
+forward branch, while the broader R2 work and the IR migration epic remain
+open.
+
+**Baseline:** current main plus the signed follow-up plan is
+`81e0d5d0e19f97466179fe14c603c70d4a44afeb`. The unchanged source was tested
+with the reviewed 13-test contract file in the worktree-local `.tmp` probe:
+8 controls passed and 5 controls failed. The five failures are the expected
+missing-guard negatives: nested `i32.boolean`, nested `i32.symbol`, nested
+`i64.bigint=false`, nested `i64.bigint=true` after candidate issuance, and
+nested `f64.undefSentinel` after certification. Each incorrectly certified or
+remained current while retaining the same outer physical signature and
+provider evidence; the other eight previously landed controls passed.
+
+**Repair:** restored only `semanticValTypeBrandKey` and its
+`valTypeBrands` contribution to the existing recursive `irTypeKey` receipt in
+`src/ir/prepared-callable-boundary.ts`, plus the five omitted mutation controls
+in `tests/issue-3521-prepared-callable-boundary.test.ts`. The fingerprint
+preserves absent/false/true states and leaves global `irTypeEquals` unchanged.
+The repaired contract suite is **13/13 passing**.
+
+**Validation:** the R2 withdrawal, scoped sealing, prepared dependency, and
+outside-caller controls are **73/73 passing**. Typecheck, IR layering, IR
+dialect, IR kind-neutrality, formatting, both hybrid and strict IR-only
+readiness checks, and the fallback ratchet pass. Both IR-only policies report
+5/5 entries, 41 terminal units, 38 IR-emitted units, 0 unsupported, 0
+invariants, 3 non-executable units, and 0 legacy body emissions in the GC and
+standalone lanes. No new residual was observed in these focused controls; the
+broader receipt-census residual recorded in the preceding R2 results remains
+outside this two-file repair.
+
+The signed implementation commit and issue-record update are published on the
+forward repair branch; the PR and exact final head are reported with the
+landing evidence. Full merge-group Test262 validation remains required.

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -4577,3 +4577,48 @@ controls pass (13/13, 6/6, and 9/9). The archived `origin/main` snapshot
 reproduces the wrapper-position failure, the imported-HOF failure, the
 receipt-census failure, and the 16 counted-string failures (19 baseline reds).
 Full merge-group Test262 validation remains a CI requirement.
+
+
+## Implementation Plan — 2026-09-05 — R2-B1 missing brand guard follow-up
+
+The merged callable-boundary PR #5600 is recorded at
+`45cc12dcbd9e02603e6648c19b43d6d4b8cb7939`, with refreshed source parent
+`ac4b1445562ebc9d26bed516dfb337b9ee4d204b`. Current main
+`e4ef2c3ef01cc04126203551240fe95b3513f92e` does not contain the final reviewed
+source head `2d8741c3332c0928b905bf4948c904e0ee112004` as an ancestor.
+A direct content comparison found seven integration, lowering, sealing and
+routing files unchanged from that reviewed head, but two specific omissions:
+`prepared-callable-boundary.ts` lacks the nested semantic ValType brand key,
+and its contract test lacks five corresponding mutation controls. This is a
+narrow incomplete landing, not evidence that all R2 work was lost or complete.
+
+Astra plans; the original Luna Max author implements the forward repair in
+`codex/3521-r2-b1-brands-luna-20260905`, based on the exact main above. Keep
+claim `3521:r2-b1-callable-boundary-contract` held until the repaired content
+is verified on main. Do not amend, reopen or push the merged PR's branch.
+
+1. Restore the already reviewed `semanticValTypeBrandKey` and its contribution
+   to `semanticSignatureKey` from final source head `2d8741c...` in
+   `src/ir/prepared-callable-boundary.ts`. Preserve boolean, symbol, bigint and
+   undefined-sentinel brands, including absent versus present false. Keep
+   recursive structural type equality and the separate physical ABI evidence
+   unchanged; no broad IR equality or transaction changes are needed.
+2. Restore the five omitted controls in
+   `tests/issue-3521-prepared-callable-boundary.test.ts`: boolean/symbol after
+   candidate issuance, bigint false/true after issuance, and undefined-sentinel
+   mutation after certification. Demonstrate these controls fail on the exact
+   current-main source before the repair and pass with it; retain all eight
+   previously landed controls. Report the actual denominator.
+3. Run the full focused callable-boundary suite, relevant R2 withdrawal and
+   transaction controls, typecheck and applicable normal gates. Attribute any
+   residual to an exact baseline comparison. Record final source refs and
+   validation results here; previous 13/13 reports do not prove the landed
+   main contained those tests.
+4. Open a ready fork PR containing only the two restored source/test changes
+   plus this issue record, after ordinary current-main integration. No force
+   push, queued-head update, direct main push or GitHub polling. Verify actual
+   final head/file set and later landed bytes before completing the claim.
+
+Exclusive ownership is these two files and this issue record. Preserve active
+R5 initializer transactions, R8 body-handoff work and all other agents' changes.
+R2 and the full IR retirement epic remain open after this narrow repair.

--- a/src/ir/prepared-callable-boundary.ts
+++ b/src/ir/prepared-callable-boundary.ts
@@ -167,12 +167,57 @@ function snapshotSemanticSignature(
   ) as PreparedCallableBoundarySemanticSignature;
 }
 
-/** Use the repository's canonical recursive serializer as an immutable receipt key. */
+/**
+ * Record the ValType brands nested in one semantic signature.
+ *
+ * `irTypeKey` is authoritative for the structural type shape but deliberately
+ * describes storage-equivalent values, so it omits `i32.boolean`, `i32.symbol`,
+ * `i64.bigint`, and `f64.undefSentinel`.  Keep its recursive handling for all
+ * other IR semantics and add this narrow supplementary walk for the brands.
+ * Physical attachments such as `typeRef`, `carrierRef`, and `layout` are
+ * intentionally not part of this fingerprint; they are checked through the
+ * separate prepared ABI evidence.
+ */
+function semanticValTypeBrandKey(signature: PreparedCallableBoundarySemanticSignature): string {
+  const brands: string[] = [];
+  const optionalFlagKey = (value: unknown): string =>
+    value === undefined ? "absent" : value === true ? "true" : value === false ? "false" : `other:${String(value)}`;
+  const active = new Set<object>();
+  const visit = (value: unknown): void => {
+    if (value === null || typeof value !== "object") return;
+    if (active.has(value)) throw new Error("IR semantic receipt cannot encode a recursive layout");
+    active.add(value);
+    try {
+      if (!Array.isArray(value)) {
+        const candidate = value as { readonly kind?: unknown; readonly val?: unknown };
+        if (candidate.kind === "val" && candidate.val !== null && typeof candidate.val === "object") {
+          const val = candidate.val as ValType;
+          if (val.kind === "i32")
+            brands.push(`i32:boolean=${optionalFlagKey(val.boolean)}:symbol=${optionalFlagKey(val.symbol)}`);
+          if (val.kind === "i64") brands.push(`i64:bigint=${optionalFlagKey(val.bigint)}`);
+          if (val.kind === "f64") brands.push(`f64:undefSentinel=${optionalFlagKey(val.undefSentinel)}`);
+        }
+      }
+      if (Array.isArray(value)) {
+        for (const item of value) visit(item);
+      } else {
+        for (const [, item] of Object.entries(value).sort(([left], [right]) => left.localeCompare(right))) visit(item);
+      }
+    } finally {
+      active.delete(value);
+    }
+  };
+  visit(signature.params);
+  visit(signature.returnType);
+  return brands.join("|");
+}
+
 function semanticSignatureKey(signature: PreparedCallableBoundarySemanticSignature): string | undefined {
   try {
     return JSON.stringify({
       params: signature.params.map((type) => irTypeKey(type)),
       returnType: signature.returnType === null ? null : irTypeKey(signature.returnType),
+      valTypeBrands: semanticValTypeBrandKey(signature),
     });
   } catch {
     // Recursive anonymous layouts have no canonical key.  They cannot cross

--- a/tests/issue-3521-prepared-callable-boundary.test.ts
+++ b/tests/issue-3521-prepared-callable-boundary.test.ts
@@ -230,6 +230,77 @@ describe("#3521 R2-B1 prepared callable boundary contract", () => {
     ).toEqual(f.numberType);
   });
 
+  it.each(["boolean", "symbol"] as const)("rejects an in-place nested callable i32.%s mutation", (flag) => {
+    const f = fixture();
+    const mutableCallable = f.callableType as unknown as {
+      signature: { params: IrType[]; returnType: IrType | null };
+    };
+    mutableCallable.signature.params[0] = { kind: "val", val: { kind: "i32" } };
+    const candidate = f.registry.issuePreparedCallableBoundary(f.unitId, {
+      params: [f.callableType, f.numberType],
+      returnType: f.numberType,
+    });
+    if (!candidate) throw new Error("callable-boundary fixture did not issue the flagged candidate");
+
+    const mutableParam = mutableCallable.signature.params[0] as unknown as {
+      val: { kind: "i32"; boolean?: true; symbol?: true };
+    };
+    mutableParam.val[flag] = true;
+    const invocation = invokeRef(createIrBindingId({ ownerId: f.unitId, domain: "support", role: "invoke" }));
+    expect(
+      candidate.certify({
+        fn: f.fn,
+        projectedSignature: projected(),
+        support: support(f, [invocation]),
+        scopeLookup: scope(f),
+      }),
+    ).toBeUndefined();
+    expect(candidate.contract).toBeUndefined();
+  });
+
+  it.each([false, true] as const)("rejects an in-place nested callable i64.bigint=%s mutation", (bigint) => {
+    const f = fixture();
+    const mutableCallable = f.callableType as unknown as {
+      signature: { params: IrType[]; returnType: IrType | null };
+    };
+    mutableCallable.signature.params[0] = { kind: "val", val: { kind: "i64" } };
+    const candidate = f.registry.issuePreparedCallableBoundary(f.unitId, {
+      params: [f.callableType, f.numberType],
+      returnType: f.numberType,
+    });
+    if (!candidate) throw new Error("callable-boundary fixture did not issue the bigint candidate");
+
+    const mutableParam = mutableCallable.signature.params[0] as unknown as {
+      val: { kind: "i64"; bigint?: boolean };
+    };
+    mutableParam.val.bigint = bigint;
+    const invocation = invokeRef(createIrBindingId({ ownerId: f.unitId, domain: "support", role: "invoke" }));
+    expect(
+      candidate.certify({
+        fn: f.fn,
+        projectedSignature: projected(),
+        support: support(f, [invocation]),
+        scopeLookup: scope(f),
+      }),
+    ).toBeUndefined();
+    expect(candidate.contract).toBeUndefined();
+  });
+
+  it("rejects an in-place nested callable f64.undefSentinel mutation after certification", () => {
+    const f = fixture();
+    const invocation = invokeRef(createIrBindingId({ ownerId: f.unitId, domain: "support", role: "invoke" }));
+    const contract = certify(f, [invocation]);
+    expect(contract).toBeDefined();
+
+    const mutableNumber = f.numberType as unknown as {
+      val: { kind: "f64"; undefSentinel?: true };
+    };
+    mutableNumber.val.undefSentinel = true;
+
+    expect(() => f.candidate.assertCurrent(f.fn)).toThrow(/semantic signature changed/);
+    expect(() => contract!.assertSupportCurrent(f.fn, support(f, [invocation]))).toThrow(/semantic signature changed/);
+  });
+
   it("does not collapse a multi-result function into the void signature", () => {
     const f = fixture();
     const voidCandidate = f.registry.issuePreparedCallableBoundary(f.unitId, {


### PR DESCRIPTION
## Problem

The merged callable-boundary change for issue 3521, IR-only R2: prepare-before-emit free-function ownership, lost its final semantic brand guard and five focused controls because the queued merge snapshot stopped at the earlier source parent. Current main therefore accepted nested ValType brand mutations while the outer externref ABI and provider evidence stayed unchanged.

## Result

Restore the reviewed `semanticValTypeBrandKey` in `prepared-callable-boundary.ts` and the five omitted controls in `issue-3521-prepared-callable-boundary.test.ts`. The receipt now preserves `i32.boolean`, `i32.symbol`, `i64.bigint` (including absent versus false), and `f64.undefSentinel` without changing global `irTypeEquals`, physical ABI checks, or transaction/routing seams.

The unchanged current-main source reproduced **8/13 passing and 5/13 failing** controls: boolean, symbol, bigint=false, bigint=true, and undef-sentinel mutation negatives. The repaired suite is **13/13 passing**. The issue record captures the exact baseline, repaired commit, and validation.

## Validation

- R2 withdrawal, scoped sealing, prepared dependency, and outside-caller controls: **73/73**.
- Typecheck, IR layering, dialect, kind-neutrality, format, LOC/function budgets, both hybrid and strict IR-only checks, and fallback ratchet: passing.
- Both IR-only policies report 5/5 entries, 41 terminal units, 38 IR-emitted units, 0 unsupported, 0 invariants, 3 non-executable units, and 0 legacy body emissions in GC and standalone lanes.
- Full merge-group Test262 validation remains required.
