### PR TITLE
refactor(codegen): prepare function metadata before name materialization

### DIFF
--- a/plan/issues/4617-frontend-neutral-semantic-ir.md
+++ b/plan/issues/4617-frontend-neutral-semantic-ir.md
@@ -3,7 +3,7 @@ id: 4617
 title: "Frontend-neutral semantic IR snapshot for TypeScript 7 and Acorn"
 status: in-progress
 created: 2026-08-22
-updated: 2026-09-01
+updated: 2026-09-05
 assignee: ttraenkler/codex
 branch: codex/4617-frontend-neutral-semantic-ir
 priority: critical
@@ -32,6 +32,7 @@ files:
   - src/ir/program.ts
   - src/ir/prepared-component-sealing.ts
   - src/codegen/certified-function-value-authority.ts
+  - src/codegen/certified-function-value-bindings.ts
   - src/codegen/certified-function-value-evidence.ts
   - src/codegen/certified-function-value-materialization.ts
   - src/codegen/closures.ts
@@ -57,6 +58,8 @@ files:
   - tests/issue-4591-fib-pair-prepared-cutover.test.ts
   - tests/issue-4617-declaration-replay-mutations.test.ts
   - tests/issue-4617-certified-function-value-materialization.test.ts
+  - tests/issue-4617-function-value-evidence.test.ts
+  - tests/issue-4617-metadata-preparation.test.ts
   - tests/issue-4617-semantic-declaration-snapshot.test.ts
   - tests/issue-4617-semantic-function-value-source-projection.test.ts
   - tests/dogfood/acorn-harness.mjs
@@ -3811,6 +3814,182 @@ protected merge queue, D1a-before-D1b order, and full #4590 artifact/runtime
 parity remain mandatory.
 
 ### Frozen implementation handoff
+
+#### 2026-09-05 resumption audit
+
+Resumption starts from protected main `470ceba797a2822ead2a4060fc65fb78c0b52887`
+in an isolated worktree. The former temporary implementation worktree is no
+longer present, and neither core leaf appears in reachable Git history. The
+frozen hashes below remain recovery targets, not available validated source.
+Recover task-specific patch records before reconstructing the draft; do not
+represent the prior static checks as checks of newly reconstructed bytes.
+
+The focused existing C1 control, “routes the exact reduction from replayed facts
+with both live declaration methods poisoned,” passes on this main: one test
+passed, 25 excluded by the explicit filter. This is a baseline check only.
+The subsequent unfiltered suite exited with a V8 heap exhaustion at its
+configured 512 MB worker limit and an IPC channel-closed error; it provides no
+full-suite acceptance result. Resume that measurement with an appropriate
+worker-memory budget or isolated test processes after resource availability
+permits it. A subsequent strict-gated run using the supported
+`VITEST_FORK_MAX_OLD_SPACE_SIZE=2048 VITEST_MAX_FORKS=1` configuration completed:
+23/26 passed. Three pre-existing main failures remain: the raw Prepared binary
+is 137,618 bytes where the direct-relative assertion expects 137,304; optimized
+Prepared is 60,324 bytes versus direct 60,219; and the Prepared cache binding
+resolves to global index 12 versus the pinned 10. These failures predate any
+resumed compiler edits. Preserve the assertions while tracing allocation and
+layout differences; they do not authorize a baseline relaxation or establish
+optimization parity.
+
+Independent current-main review additionally measured the direct ABI slots as
+source/trampoline/cache = 76/300/144, against the old 76/291/139 pins; Prepared
+is 76/78/12. The absolute-index failure therefore includes allocation drift in
+both lanes. The early false-constructibility defect also predates the current
+binary failures, so attributing all three failures to that defect would be
+unsupported. Reconstructed D1a must prove the exact constructible metadata
+family, a single materialization, and the late provider's zero-write behavior,
+then compare complete artifacts against both current controls. Preserve the
+optimizer and investigate any remaining size difference independently.
+
+PR #5600 (certify callable R2 boundaries before emit) changes integration,
+prepared free functions, and the codegen entry point. PR #5598 (retain ordered
+multi-source module-init census) changes the shared multi-prepared owner and
+callable orchestration. Reconcile their merged boundaries before applying D1a
+wiring in those paths. Recovery and the isolated bottom evidence leaf can
+proceed without editing the concurrently owned integration paths.
+
+The evidence extraction owns focused tests in
+`tests/issue-4617-function-value-evidence.test.ts`. These isolate physical
+identity, canonical projection, alias-edge multiplicity, cycle rejection,
+native-name side-space deltas, and identity-preserving remapping from the
+larger lifecycle test. They do not replace the full materialization or #4590
+acceptance suites. A physical reprojection helper checks an independently
+constructed expected recipe and retains all original object/array identities;
+its caller must first authenticate the one-shot settlement authority. The
+evidence leaf neither accepts a caller-supplied lifecycle phase nor changes
+that phase itself.
+
+The metadata support seam was recovered from the recorded successful patch
+lineage: `function-instance-meta.ts` matches its reviewed SHA-256
+`6e41de6649258f47e13897c52846bd8ad854833d002b6c47d478e1b3e8a3f300`
+at 552 lines. It exposes the allocation-only recipe and materializes the name
+before resolving the retained metadata-global object. The current import
+fixup now shifts both metadata and native-string maps, preserving intervening
+main changes; the existing prototype-map loop uses the same shared shift
+helper to keep that oversized file non-growing. The function-metadata suite
+passes all 19 tests, and TS7 typechecking passed after restoring the seam.
+The complete #4590 rerun after this support restoration remains 23/26 with
+exactly the same three failing assertions and numeric values as current main.
+Both LOC and function regrowth gates pass for the two modified source files.
+Full lifecycle and optimization acceptance remains outstanding.
+
+The metadata prerequisite additionally owns
+`tests/issue-4617-metadata-preparation.test.ts`: exercise the real context,
+prepare a metadata slot without materializing its name, insert a real imported
+global, and prove the initializer resolves the same retained object at its new
+absolute index. Cover the native-name cache across a later import as well, and
+reject structural replacement of the prepared metadata global. These controls
+make the two side-table shifts non-vacuous before lifecycle integration.
+
+Use the actual late-import fixup owner (`addHostStringConstantGlobal` in a
+host/native-string context) for positive relocation controls. Raw `addImport`
+does not itself run module-global fixups; treating it as a complete relocation
+operation would invent a broader contract. Keep standalone preparation and
+immediate-materialization equivalence controls separate. No general import
+registration behavior changes are authorized by this prerequisite.
+
+The focused metadata prerequisite tests pass 5/5 (one file, 127 lines,
+SHA-256 `3afc03e9c9f310d777baf99bd06682bb4874791f7afb11804c204cbf6c1317c3`).
+Both native-map relocation controls use the real host-string import owner;
+standalone no-name-allocation and immediate-helper equivalence remain separate
+positive controls. This does not validate the unfinished receipt lifecycle.
+
+The six retained physical arrays are specifically target locals/body,
+trampoline locals/body, cache-global initializer, and metadata-global
+initializer. They are not six emitted instruction sequences. Publication
+evidence follows the real emitted initializer recipe and its exact owner-body
+occurrences, retaining the six physical arrays independently during settlement.
+
+Recovery reached a hash-exact 1,649-line materialization artifact
+(`c853e9ef6946cfd4ec248bdbe1d0cd4b17ac7e51b5559fa9ab99f9406e2bbaa5`).
+The best verified-event authority reconstruction is 1,725 lines but hashes to
+`521448ab1297d5c41525fc51307d80a30b1d3422cf20df8796bec4438448c458`,
+not the frozen authority hash below. Conflicting transcript lineage prevents
+claiming exact recovery. Treat that artifact as a new implementation candidate:
+retain its authority contracts, extract only physical canonical/array helpers
+to the bottom evidence leaf, and require fresh semantic and mutation review.
+Do not inherit historical approval. The old lifecycle test is not recovered;
+its required negative matrix must be reconstructed from the signed plan rather
+than guessed from incomplete patch history.
+
+### Resumption implementation sequence
+
+1. Restore the authority candidate as new source, not as previously approved
+   bytes. Import/re-export the physical canonical, array, and six-array
+   projection helpers from the evidence leaf; keep every Program-ABI join,
+   type-lineage label resolution, active receipt census, owner transition,
+   layout revision, and settlement brand in authority. Repair the missing
+   `assertPhysicalArrayIdentities` definition from the earlier complete
+   snapshot: settlement must compare the six original array identities before
+   accepting remapped canonicals. It must not replace that check with equality
+   of newly captured values. Preserve original API contracts while measuring
+   the remaining source budget; do not compress code or grant an allowance.
+2. Restore the hash-exact materialization source, replacing its independent
+   physical occurrence/native-name walkers with the evidence leaf. Keep the
+   actual metadata/cache publication recipe and current ABI-derived expected
+   operands in materialization. Capture one pushed instruction sequence and
+   its nested initializer, not an invented fixed sequence count. Authenticate
+   the uncommitted settlement token before asking evidence to reproject, then
+   perform the sole layout revision commit after every currentness check.
+3. Rebuild the lifecycle mutation tests from this issue's required matrix,
+   including physical clone replacement, duplicate occurrence, failed native
+   callback/consume replay, second active receipt, stale transition, and
+   post-DCE revision-one terminal checks. Then adapt method-trampoline and
+   source-owner wiring against current main's R2 boundary hooks, preserving
+   their ownership and withdrawal evidence. No route is enabled before the
+   standalone control matrix and fresh Sol review pass.
+
+### Measured authority-query split
+
+The three-leaf estimate did not survive reconstruction: extracting the actual
+physical helpers leaves authority at 1,673 lines, while the evidence leaf's
+required identity, occurrence, native-witness, and remapping checks occupy
+about 1,450. Do not erase invariants, hide lines in dense expressions, or
+increase the 1,500-line ceiling. Separate the existing read-only binding query
+responsibility into `src/codegen/certified-function-value-bindings.ts`:
+
+- It owns `programAbiSession`, required-draft/role joins, target/support
+  binding absence/currentness queries, exact current function/global object
+  and stable-handle joins, and target signature/physical-ABI checks. It may
+  share the deterministic invariant and scalar-validation helpers used by
+  these queries. It reads Program-ABI/context/Wasm state but performs no
+  allocation, body write, brand minting, registry mutation, or transition.
+- Authority retains all prewrite/support/receipt/owner/layout/settlement brands
+  and all lifecycle state. Query success alone must never mint or consume
+  those authorities. Existing public authority exports remain compatible
+  through re-exports; this is not a new route or a generic validation framework.
+- Runtime imports are `materialization -> authority -> bindings -> evidence`,
+  with direct evidence imports where needed. Bindings must not runtime-import
+  authority/materialization or a frontend; type-only receipt projections are
+  permissible. This supersedes the earlier exact three-leaf dependency sketch,
+  not its safety boundary. Every leaf remains at or below 1,500 lines and
+  needs exact-byte Sol review before the D1a implementation PR is ready.
+
+The isolated resumption branch subsequently fast-forwarded to upstream main
+`e4ef2c3ef01cc04126203551240fe95b3513f92e`, incorporating PR #5600
+(`feat(ir): certify callable R2 boundaries before emit`) and PR #5598
+(`feat(ir): retain ordered multi-source module-init census`). Upstream changed
+no metadata/evidence-owned path, and the three reviewed metadata source/test
+hashes remained unchanged after sync. Re-evaluate integration against these
+new boundaries; do not replay the historical index/integration diff blindly.
+The 5/5 and 19/19 measurements above were made before this fast-forward and
+must be rerun on the updated composition before publication.
+The new metadata preparation file has since passed again on `e4ef2c3e`
+(one file, 5/5 tests). The separate existing `tests/issue-4437.test.ts`
+also passed 19/19 on that composition after a fresh load sample of 7.851
+(10 cores, required strictly below 8). An earlier attempt was blocked by
+load 8.615 before spawning a runner. Sol approved the three exact metadata
+source/test hashes above; this approval is limited to the metadata prerequisite.
 
 The 2026-09-01 repair session stopped before publication and left no staged,
 committed, or pushed compiler/test bytes. Its reproducible local checkpoint is

--- a/src/codegen/function-instance-meta.ts
+++ b/src/codegen/function-instance-meta.ts
@@ -65,7 +65,7 @@
  * reflective property path, so the extra field would be pure cost; every entry
  * point here is a no-op unless `ctx.standalone`.
  */
-import type { FieldDef, Instr, ValType } from "../ir/types.js";
+import type { FieldDef, GlobalDef, Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { ts } from "../ts-api.js";
 import { expectedArgumentCountOfParams } from "./function-expected-argument-count.js";
@@ -84,6 +84,29 @@ export const FN_META_LENGTH_FIELD_IDX = 1;
 export interface FnInstanceMeta {
   readonly name: string;
   readonly length: number;
+}
+
+/**
+ * Allocation-only recipe for one `$fnmeta` slot.
+ *
+ * D1a's certified function-value path prepares the structural field and its
+ * singleton global during the early support phase, then materializes a fresh
+ * initializer only when the one direct consumer takes its receipt.  Retaining
+ * the `GlobalDef` object instead of an absolute index is deliberate: late
+ * imported globals shift every module-global index, while this object remains
+ * the exact physical allocation the recipe certified.
+ */
+export interface PreparedFnMetaSlot {
+  readonly kind: "prepared-fn-meta-slot";
+  readonly field: FieldDef;
+  readonly meta: FnInstanceMeta;
+  readonly key: string;
+  readonly structTypeIdx: number;
+  readonly global: GlobalDef;
+}
+
+function moduleGlobalAt(ctx: CodegenContext, absIdx: number): GlobalDef | undefined {
+  return ctx.mod.globals[absIdx - ctx.numImportGlobals];
 }
 
 /**
@@ -135,40 +158,108 @@ export function fnMetaField(ctx: CodegenContext): FieldDef {
  * function bodies, never `ctx.mod.globals[].init`. Keeping the sequence in a
  * shift-covered array makes the choice of materialization irrelevant here.
  */
-function pushFnInstanceMetaValueInstrs(ctx: CodegenContext, meta: FnInstanceMeta): Instr[] {
-  const structTypeIdx = ensureFnInstanceMetaStructType(ctx);
+function fnInstanceMetaKey(meta: FnInstanceMeta): string {
   // `<length>:<name>` — unambiguous for ANY name, because `length` is
   // digits-only, so the first `:` is always the separator even when the name
   // itself contains one (a computed key like `{ "a:b": function () {} }`).
-  const key = `${meta.length}:${meta.name}`;
+  return `${meta.length}:${meta.name}`;
+}
+
+/**
+ * Prepare the physical `$fnmeta` field and singleton global without emitting
+ * the lazy value initializer.  This is intentionally allocation-only.
+ */
+export function prepareFnMetaSlotOfMeta(ctx: CodegenContext, meta: FnInstanceMeta): PreparedFnMetaSlot {
+  if (typeof meta.name !== "string" || !Number.isSafeInteger(meta.length) || meta.length < 0) {
+    throw new Error("invalid fn metadata recipe");
+  }
+  const canonicalMeta = Object.freeze({ name: meta.name, length: meta.length });
+  const structTypeIdx = ensureFnInstanceMetaStructType(ctx);
+  const field = fnMetaField(ctx);
+  const key = fnInstanceMetaKey(canonicalMeta);
   const cache = (ctx.fnInstanceMetaGlobalByKey ??= new Map<string, number>());
   let globalIdx = cache.get(key);
+  let global: GlobalDef | undefined;
   if (globalIdx === undefined) {
     globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
-    ctx.mod.globals.push({
+    global = {
       name: `__fn_instance_meta_${cache.size}`,
       type: { kind: "ref_null", typeIdx: structTypeIdx },
       mutable: true,
       init: [{ op: "ref.null", typeIdx: structTypeIdx }],
-    });
+    };
+    ctx.mod.globals.push(global);
     cache.set(key, globalIdx);
+  } else {
+    global = moduleGlobalAt(ctx, globalIdx);
   }
-  return [
-    { op: "global.get", index: globalIdx },
-    { op: "ref.is_null" },
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        ...nativeStringLiteralInstrs(ctx, meta.name),
-        { op: "extern.convert_any" },
-        { op: "i32.const", value: meta.length },
-        { op: "struct.new", typeIdx: structTypeIdx },
-        { op: "global.set", index: globalIdx },
-      ],
-    },
-    { op: "global.get", index: globalIdx },
-  ];
+  if (
+    global === undefined ||
+    global.type.kind !== "ref_null" ||
+    global.type.typeIdx !== structTypeIdx ||
+    !global.mutable
+  ) {
+    throw new Error(`prepared fn metadata global '${key}' no longer has its certified layout`);
+  }
+
+  return Object.freeze({
+    kind: "prepared-fn-meta-slot" as const,
+    field,
+    meta: canonicalMeta,
+    key,
+    structTypeIdx,
+    global,
+  });
+}
+
+/**
+ * Materialize fresh lazy-initializer instructions for a prepared metadata
+ * recipe.  The current map value is re-read after all import shifts and then
+ * proven to name the exact global object prepared above.
+ */
+export function materializePreparedFnMetaSlot(
+  ctx: CodegenContext,
+  prepared: PreparedFnMetaSlot,
+): { field: FieldDef; init: Instr[]; meta: FnInstanceMeta } {
+  if (prepared.kind !== "prepared-fn-meta-slot") {
+    throw new Error("invalid prepared fn metadata slot");
+  }
+  // Native string materialization may add an imported global and shift every
+  // module-global absolute index.  It therefore has to happen before reading
+  // the metadata side-table; the map shift below is the authoritative current
+  // location of the retained `GlobalDef` object.
+  const nameInit = nativeStringLiteralInstrs(ctx, prepared.meta.name);
+  const globalIdx = ctx.fnInstanceMetaGlobalByKey?.get(prepared.key);
+  if (globalIdx === undefined || moduleGlobalAt(ctx, globalIdx) !== prepared.global) {
+    throw new Error(`prepared fn metadata global '${prepared.key}' is no longer current`);
+  }
+  if (
+    prepared.global.type.kind !== "ref_null" ||
+    prepared.global.type.typeIdx !== prepared.structTypeIdx ||
+    !prepared.global.mutable
+  ) {
+    throw new Error(`prepared fn metadata global '${prepared.key}' no longer has its certified layout`);
+  }
+  return {
+    field: prepared.field,
+    meta: prepared.meta,
+    init: [
+      { op: "global.get", index: globalIdx },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          ...nameInit,
+          { op: "extern.convert_any" },
+          { op: "i32.const", value: prepared.meta.length },
+          { op: "struct.new", typeIdx: prepared.structTypeIdx },
+          { op: "global.set", index: globalIdx },
+        ],
+      },
+      { op: "global.get", index: globalIdx },
+    ],
+  };
 }
 
 /**
@@ -457,9 +548,5 @@ export function fnMetaSlotOfMeta(
   ctx: CodegenContext,
   meta: FnInstanceMeta,
 ): { field: FieldDef; init: Instr[]; meta: FnInstanceMeta } {
-  return {
-    field: fnMetaField(ctx),
-    init: pushFnInstanceMetaValueInstrs(ctx, meta),
-    meta,
-  };
+  return materializePreparedFnMetaSlot(ctx, prepareFnMetaSlotOfMeta(ctx, meta));
 }

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -519,14 +519,13 @@ function fixupModuleGlobalIndices(ctx: CodegenContext, threshold: number, delta:
   }
   shiftMap(ctx.staticProps);
   shiftMap(ctx.protoGlobals);
-  if (ctx.nativeProtoGlobals !== undefined) {
-    for (const [brand, idx] of ctx.nativeProtoGlobals) {
-      if (idx >= threshold) ctx.nativeProtoGlobals.set(brand, idx + delta);
-    }
-  }
+  shiftMap(ctx.nativeProtoGlobals);
   shiftMap(ctx.classObjectGlobals); // (#1395) — same shift discipline as protoGlobals
   shiftMap(ctx.methodClosureGlobals); // (#1394) — cached per-method closure globals
   shiftMap(ctx.funcClosureGlobals); // (#1340) — cached per-function closure globals
+  // (#4617) Prepared metadata and native names retain absolute global slots.
+  shiftMap(ctx.fnInstanceMetaGlobalByKey);
+  shiftMap(ctx.nativeStrLiteralGlobals);
   shiftMap(ctx.tdzGlobals);
   shiftMap(ctx.modulePatternTdzGlobals);
   shiftMap(ctx.builtinFnSingletonGlobalByTypeIdx);

--- a/tests/issue-4617-metadata-preparation.test.ts
+++ b/tests/issue-4617-metadata-preparation.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import {
+  fnMetaSlotOfMeta,
+  materializePreparedFnMetaSlot,
+  prepareFnMetaSlotOfMeta,
+} from "../src/codegen/function-instance-meta.js";
+import { nativeStringLiteralInstrs } from "../src/codegen/native-string-literals.js";
+import { addHostStringConstantGlobal } from "../src/codegen/registry/imports.js";
+import { type GlobalDef, createEmptyModule } from "../src/ir/types.js";
+
+const META = { name: "prepared metadata", length: 2 };
+
+function fixture(
+  options: Parameters<typeof createCodegenContext>[2] = { standalone: true, strictNoHostImports: false },
+) {
+  const ast = analyzeSource("export const value = 0;", "/repo/issue-4617-metadata-preparation.ts");
+  const module = createEmptyModule();
+  const ctx = createCodegenContext(module, ast.checker, options);
+  return { ctx, module };
+}
+
+function addLateHostStringGlobal(ctx: ReturnType<typeof fixture>["ctx"]): number {
+  const importsBefore = ctx.mod.imports.length;
+  const globalsBefore = ctx.numImportGlobals;
+  const globalIdx = addHostStringConstantGlobal(ctx, "late host global");
+  expect(globalIdx).toBe(globalsBefore);
+  expect(ctx.mod.imports).toHaveLength(importsBefore + 1);
+  expect(ctx.numImportGlobals).toBe(globalsBefore + 1);
+  expect(ctx.mod.imports.at(-1)).toMatchObject({
+    module: "string_constants",
+    name: "late host global",
+    desc: { kind: "global", type: { kind: "externref" } },
+  });
+  return globalIdx!;
+}
+
+describe("#4617 prepared function metadata slots", () => {
+  it("prepares only its retained global and type before standalone materialization", () => {
+    const { ctx, module } = fixture();
+    const typesBefore = module.types.length;
+    const globalsBefore = module.globals.length;
+    const prepared = prepareFnMetaSlotOfMeta(ctx, META);
+
+    expect(module.types).toHaveLength(typesBefore + 1);
+    expect(module.globals).toHaveLength(globalsBefore + 1);
+    expect(module.globals.at(-1)).toBe(prepared.global);
+    expect(ctx.nativeStrLiteralGlobals).toEqual(new Map());
+
+    const materialized = materializePreparedFnMetaSlot(ctx, prepared);
+    const globalIdx = ctx.fnInstanceMetaGlobalByKey!.get(prepared.key);
+    if (globalIdx === undefined) throw new Error("missing prepared metadata global");
+    expect(globalIdx).toBe(ctx.numImportGlobals + module.globals.indexOf(prepared.global));
+    expect(module.globals[globalIdx - ctx.numImportGlobals]).toBe(prepared.global);
+    expect(materialized.field).toEqual(prepared.field);
+    expect(materialized.meta).toEqual(META);
+    expect(materialized.init[0]).toEqual({ op: "global.get", index: globalIdx });
+    expect(materialized.init.at(-1)).toEqual({ op: "global.get", index: globalIdx });
+    const initialize = materialized.init[2];
+    if (!initialize || initialize.op !== "if") throw new Error("missing metadata initializer");
+    const nameGlobalIdx = [...ctx.nativeStrLiteralGlobals.values()][0];
+    if (nameGlobalIdx === undefined) throw new Error("missing metadata name literal");
+    expect(initialize.then[0]).toEqual({ op: "global.get", index: nameGlobalIdx });
+    expect(initialize.then.at(-1)).toEqual({ op: "global.set", index: globalIdx });
+  });
+
+  it("materializes prepared metadata against its retained slot after a real host global fixup", () => {
+    const { ctx, module } = fixture({ standalone: false, nativeStrings: true, strictNoHostImports: false });
+    const prepared = prepareFnMetaSlotOfMeta(ctx, META);
+    const originalIdx = ctx.fnInstanceMetaGlobalByKey!.get(prepared.key);
+    if (originalIdx === undefined) throw new Error("missing prepared metadata global");
+
+    addLateHostStringGlobal(ctx);
+    const shiftedIdx = ctx.fnInstanceMetaGlobalByKey!.get(prepared.key);
+    expect(shiftedIdx).toBe(originalIdx + 1);
+    expect(module.globals[shiftedIdx! - ctx.numImportGlobals]).toBe(prepared.global);
+    const materialized = materializePreparedFnMetaSlot(ctx, prepared);
+    expect(materialized.init[0]).toEqual({ op: "global.get", index: shiftedIdx });
+    expect(materialized.init.at(-1)).toEqual({ op: "global.get", index: shiftedIdx });
+  });
+
+  it("keeps a materialized native name bound to its same global after a real host global fixup", () => {
+    const { ctx, module } = fixture({ standalone: false, nativeStrings: true, strictNoHostImports: false });
+    const prepared = prepareFnMetaSlotOfMeta(ctx, META);
+    materializePreparedFnMetaSlot(ctx, prepared);
+    const [nativeKey, nativeIdx] = [...ctx.nativeStrLiteralGlobals.entries()][0] ?? [];
+    if (nativeKey === undefined || nativeIdx === undefined) throw new Error("missing native name literal");
+    const nativeGlobal = module.globals[nativeIdx - ctx.numImportGlobals];
+
+    addLateHostStringGlobal(ctx);
+    const shiftedNativeIdx = ctx.nativeStrLiteralGlobals.get(nativeKey);
+    expect(shiftedNativeIdx).toBe(nativeIdx + 1);
+    expect(module.globals[shiftedNativeIdx! - ctx.numImportGlobals]).toBe(nativeGlobal);
+    const globalsBeforeReuse = module.globals.length;
+    expect(nativeStringLiteralInstrs(ctx, META.name)).toEqual([{ op: "global.get", index: shiftedNativeIdx }]);
+    expect(module.globals).toHaveLength(globalsBeforeReuse);
+  });
+
+  it("rejects a structural clone that replaces its retained metadata global", () => {
+    const { ctx, module } = fixture();
+    const prepared = prepareFnMetaSlotOfMeta(ctx, META);
+    const clone: GlobalDef = {
+      ...prepared.global,
+      type: { ...prepared.global.type },
+      init: [...prepared.global.init],
+    };
+    module.globals[module.globals.indexOf(prepared.global)] = clone;
+
+    expect(() => materializePreparedFnMetaSlot(ctx, prepared)).toThrow(/no longer current/);
+  });
+
+  it("keeps the immediate helper's type, global, and initializer sequence canonical", () => {
+    const immediate = fixture();
+    const split = fixture();
+    const direct = fnMetaSlotOfMeta(immediate.ctx, META);
+    const prepared = prepareFnMetaSlotOfMeta(split.ctx, META);
+    const materialized = materializePreparedFnMetaSlot(split.ctx, prepared);
+
+    expect(split.module.types).toEqual(immediate.module.types);
+    expect(split.module.globals).toEqual(immediate.module.globals);
+    expect(materialized).toEqual(direct);
+  });
+});


### PR DESCRIPTION
## Summary

- Split function metadata slot preparation from native-name materialization while preserving the existing immediate helper.
- Rejoin the retained metadata global at its current index after name materialization; include metadata and native-string caches in the existing late-import fixup.
- Add five real-context mutation/control tests and update the implementation plan for #4617 — Frontend-neutral semantic IR snapshot for TypeScript 7 and Acorn.

This is the reviewed metadata prerequisite only. It does not enable the unfinished certified function-value lifecycle or claim completion of the IR migration. That ongoing work has been handed to the other IR migration session.

## Validation

- Metadata preparation tests: 5/5 passed.
- Existing `tests/issue-4437.test.ts`: 19/19 passed.
- TS7 source typecheck passed; targeted formatting and diff checks passed.
- LOC and function ratchets passed immediately before commit; all precommit hooks passed.
- Independent Sol review approved the exact metadata source/import-fixup/test bytes.
- Push is performed with all prepush hooks enabled and the finite/nonnegative load gate strictly below logical cores minus two.

The host-name callback cannot currently introduce an import itself; lookup-after-callback ordering is statically reviewed. The late-import fixture exercises the real host-string import fixup, not raw caller-managed `addImport` behavior.

No legacy optimization or route is removed by this prerequisite, and no existing size ceiling is relaxed.
