### PR TITLE
fix(#5330): a namespace import of a bare Node builtin binds the real module ✓

### DIFF
--- a/plan/issues/5330-bare-builtin-namespace-import.md
+++ b/plan/issues/5330-bare-builtin-namespace-import.md
@@ -1,0 +1,83 @@
+---
+id: 5330
+title: "Namespace import of a bare Node builtin binds an empty object"
+status: done
+sprint: current
+created: 2026-09-05
+updated: 2026-09-05
+completed: 2026-09-05
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+`import * as path from 'path'` (bare builtin specifier, **namespace** form)
+bound an **empty object**: `typeof path.join === 'undefined'`,
+`path.sep === undefined`, `String(path) === '[object Object]'`. Calls surfaced
+as `TypeError: join is not a function`. The same import written
+`from 'node:path'` worked, as did the bare **default** form
+`import path from 'path'`.
+
+Production witness: jest's `jest-haste-map` `fast_path.test.js` (0/5) and
+`get_mock_name.test.js` (0/1), plus `jest-util` `isError.test.ts` (3 tests using
+`import * as vm from 'vm'`).
+
+## Root cause — NOT the specifier normalisation it looks like
+
+The obvious suspect is `src/checker/index.ts`, whose Node-emulation scan gates
+on `spec.startsWith("node:")` while `src/cjs-rewrite.ts` normalises bare
+builtins for `require()`. **Measured: extending that gate to bare specifiers
+changes nothing** — every one of the failing probes still failed. Recorded here
+so it is not re-tried.
+
+The real site is `tryEmitCompiledModuleNamespaceObject`
+(`src/codegen/module-namespace-value.ts`), the optimizer that materializes a
+namespace object out of a module's compiled exports. It asks the **checker** for
+those exports. With no `@types/node` in the program, a **bare** builtin
+specifier resolves to nothing at all, so `getExportsOfModule` answers `[]` — an
+empty array, which is **truthy**. The optimizer therefore built
+`__new_plain_object()` with no properties and published it as the namespace,
+shadowing the `__node_path` host module thunk the module was still importing.
+(The compiled module's import list is the tell: the bare row imports
+`__new_plain_object` where the `node:` row imports `__node_path`.)
+
+`node:path` escaped only by **accident**: the injected ambient
+`declare module "node:path"` gives it one export whose only declaration lives in
+a `.d.ts`, which trips the optimizer's "mutable value → decline the whole
+object" arm and falls through to the host binding.
+
+## Fix
+
+Decline up front, for the real reason: a namespace import **of** a Node builtin
+is served by the host module object and must never be synthesized. One guard at
+the top of `namespaceFunctionExports`.
+
+Scope: this does not touch a user module that **re-exports** builtin members
+(`export { join } from 'node:path'`) — that namespace belongs to the user
+module and keeps its `host-member` lowering. Asserted in the regression test.
+
+## Evidence
+
+- jest dogfood: **320/356 → 329/356** (+9). `fast_path.test.js` 0/5 → 5/5,
+  `get_mock_name.test.js` 0/1 → 1/1, and — not predicted by the original triage,
+  which had filed it as a missing host builtin — `isError.test.ts` 17/20 → 20/20,
+  because `import * as vm from 'vm'` was binding `{}` the same way.
+- `tests/issue-5330-bare-builtin-namespace-import.test.ts`: **1 failed / 2 passed
+  → 3 passed**.
+- Probe matrix (dogfood harness), before → after:
+  `import * as path from 'path'` join/sep/relative/resolve: all broken → all
+  correct; `node:path` namespace, bare default import: correct → correct
+  (unchanged).
+
+## Residual (measured, out of scope)
+
+`import { join } from 'path'` — and `from 'node:path'` — still answers `null`.
+That is a defect in the #1791 path shim's NAMED bindings
+(`buildPathNamedBinding` emits a rest-forwarding stub that returns null), it
+affects both spellings equally, and no jest test uses that form.

--- a/src/codegen/module-namespace-value.ts
+++ b/src/codegen/module-namespace-value.ts
@@ -141,10 +141,41 @@ function cacheMap(ctx: CodegenContext): WeakMap<object, NamespaceObjectCache> {
   return caches;
 }
 
+/**
+ * (#5330) The module specifier a namespace import names, or `undefined` when it
+ * is not a plain string literal.
+ */
+function namespaceImportSpecifier(declaration: ts.NamespaceImport): string | undefined {
+  const importDeclaration = declaration.parent.parent;
+  if (!ts.isImportDeclaration(importDeclaration)) return undefined;
+  const specifier = importDeclaration.moduleSpecifier;
+  return ts.isStringLiteral(specifier) ? specifier.text : undefined;
+}
+
 function namespaceFunctionExports(
   ctx: CodegenContext,
   declaration: ts.NamespaceImport,
 ): readonly NamespaceExport[] | undefined {
+  // (#5330) `import * as path from 'path'` — a namespace import OF a Node
+  // builtin is served by the host module thunk (`__node_<mod>`), never by a
+  // synthesized object. This optimizer asks the CHECKER for the module's
+  // exports, and with no `@types/node` in the program a BARE builtin specifier
+  // resolves to nothing at all: `getExportsOfModule` answers `[]`, which is an
+  // empty-but-truthy list, so the namespace was materialized as
+  // `__new_plain_object()` with no properties. `path.join` was then genuinely
+  // undefined ("join is not a function"), `path.sep` undefined, and
+  // `String(path)` `[object Object]` — while the module still imported
+  // `__node_path` for nothing. The `node:`-prefixed spelling escaped only by
+  // accident: the injected ambient `declare module "node:path"` gives it ONE
+  // export whose sole declaration lives in a `.d.ts`, which trips the
+  // mutable-value decline below and falls through to the host binding.
+  // Decline for the whole family, up front, for the actual reason.
+  //
+  // This does NOT affect a user module that RE-EXPORTS builtin members
+  // (`export { join } from 'node:path'`): that namespace belongs to the user
+  // module, and its entries keep the `host-member` lowering below.
+  const specifier = namespaceImportSpecifier(declaration);
+  if (specifier !== undefined && isNodeBuiltin(specifier)) return undefined;
   let moduleSymbol = ctx.checker.getSymbolAtLocation(declaration.name);
   if (!moduleSymbol) return undefined;
   if ((moduleSymbol.flags & ts.SymbolFlags.Alias) !== 0) {

--- a/tests/issue-5330-bare-builtin-namespace-import.test.ts
+++ b/tests/issue-5330-bare-builtin-namespace-import.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5330 — `import * as path from 'path'` (BARE builtin specifier, namespace
+// form) bound an empty object: `path.join` was `undefined`, `path.sep` was
+// `undefined`, `String(path)` was `[object Object]`. The `node:`-prefixed
+// spelling of the same import worked.
+//
+// Root cause is NOT the specifier normalisation it looks like. It is
+// `tryEmitCompiledModuleNamespaceObject` (src/codegen/module-namespace-value.ts),
+// the optimizer that materializes a namespace object out of a module's compiled
+// exports. It asks the CHECKER for those exports, and with no `@types/node` in
+// the program a bare builtin specifier resolves to nothing at all —
+// `getExportsOfModule` answers `[]`. An empty array is truthy, so the optimizer
+// happily built `__new_plain_object()` with no properties and published it as
+// the namespace, shadowing the `__node_path` host module thunk the module was
+// still importing.
+//
+// `node:path` escaped only by ACCIDENT: the injected ambient
+// `declare module "node:path"` gives it one export whose sole declaration lives
+// in a `.d.ts`, which trips the optimizer's "mutable value, decline the whole
+// object" arm and falls through to the host binding. The right answer for the
+// whole family is to decline up front: a namespace import OF a Node builtin is
+// served by the host module object, never by a synthesized one.
+//
+// Two things this deliberately does NOT change, both asserted below:
+//  - a user module that RE-EXPORTS builtin members keeps the `host-member`
+//    lowering (its namespace belongs to the user module, not to `node:path`);
+//  - named imports from the path shim (`import { join } from 'path'`) still
+//    answer `null`. That is a separate defect in the #1791 shim's named
+//    bindings, present for the `node:` spelling too, and out of scope here.
+//
+// Fixtures are untyped `.js` in a two-file project: that is the shape real
+// packages present (jest's `jest-haste-map` `fast_path.test.js` and
+// `get_mock_name.test.js` are exactly this), and it keeps the test on the
+// multi-source lane where the defect lives.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as joinPath } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject, type CompileResult } from "../src/index.js";
+import { buildCompiledImports } from "../src/runtime.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+async function compileFixture(files: Record<string, string>, entry: string): Promise<CompileResult> {
+  const root = mkdtempSync(joinPath(tmpdir(), "js2-5330-"));
+  roots.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const target = joinPath(root, name);
+    mkdirSync(joinPath(target, ".."), { recursive: true });
+    writeFileSync(target, source);
+  }
+  return compileProject(joinPath(root, entry), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+}
+
+async function instantiate(result: CompileResult): Promise<WebAssembly.Exports> {
+  const imports = buildCompiledImports(result, {}) as Record<string, unknown> & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports.setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (imports.__setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (instance.exports.__module_init as (() => void) | undefined)?.();
+  return instance.exports;
+}
+
+const DEP = `
+export function identity(v) { return v; }
+`;
+
+function entryFor(specifier: string): string {
+  return `
+import * as path from '${specifier}';
+import { identity } from './dep.js';
+
+export function joined() { return identity(path.join('a', 'b')); }
+export function separator() { return String(path.sep); }
+export function joinIsFunction() { return typeof path.join === 'function' ? 1 : 0; }
+export function relativeOf() { return path.relative('/a/b', '/a/b/c'); }
+export function resolveIsString() { return typeof path.resolve('/a', 'b') === 'string' ? 1 : 0; }
+`;
+}
+
+describe("#5330 namespace import of a bare Node builtin specifier", () => {
+  for (const specifier of ["path", "node:path"]) {
+    it(`binds the real host module for '${specifier}'`, async () => {
+      const result = await compileFixture({ "dep.js": DEP, "main.js": entryFor(specifier) }, "main.js");
+      expect(result.success).toBe(true);
+      const exports = await instantiate(result);
+
+      // Before the fix the bare row answered: joinIsFunction 0, separator
+      // "undefined", and `joined()`/`relativeOf()` threw
+      // "join is not a function" / "relative is not a function".
+      expect((exports.joinIsFunction as () => number)()).toBe(1);
+      expect((exports.joined as () => string)()).toBe("a/b");
+      expect((exports.separator as () => string)()).toBe("/");
+      expect((exports.relativeOf as () => string)()).toBe("c");
+      expect((exports.resolveIsString as () => number)()).toBe(1);
+    });
+  }
+
+  it("still synthesizes a namespace for a user module that re-exports builtin members", async () => {
+    // The decline is scoped to a namespace import OF a builtin. A user module's
+    // own namespace keeps the compiled-object lowering, with builtin re-exports
+    // served through `__extern_get(__node_<mod>(), prop)`.
+    const files = {
+      "dep.js": DEP,
+      "reexport.js": `
+export { join } from 'node:path';
+export function twice(v) { return v * 2; }
+`,
+      "main.js": `
+import * as helpers from './reexport.js';
+import { identity } from './dep.js';
+export function joined() { return identity(helpers.join('a', 'b')); }
+export function doubled() { return helpers.twice(21); }
+`,
+    };
+    const result = await compileFixture(files, "main.js");
+    expect(result.success).toBe(true);
+    const exports = await instantiate(result);
+    expect((exports.joined as () => string)()).toBe("a/b");
+    expect((exports.doubled as () => number)()).toBe(42);
+  });
+});


### PR DESCRIPTION
Closes [#5330](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5330-bare-builtin-namespace-import).

`import * as path from 'path'` — bare builtin specifier, **namespace** form — bound an **empty object**: `typeof path.join === 'undefined'`, `path.sep === undefined`, `String(path) === '[object Object]'`. Calls surfaced as `TypeError: join is not a function`. The same import written `from 'node:path'` worked, as did the bare **default** form `import path from 'path'`.

## Root cause — not the specifier normalisation it looks like

The obvious suspect is `src/checker/index.ts`, whose Node-emulation scan gates on `spec.startsWith("node:")` while `src/cjs-rewrite.ts` normalises bare builtins for `require()`. **Measured: extending that gate to bare specifiers changes nothing** — every failing probe still failed. Recorded in the issue file so it is not re-tried.

The real site is `tryEmitCompiledModuleNamespaceObject` (`src/codegen/module-namespace-value.ts`), the optimizer that materializes a namespace object out of a module's compiled exports. It asks the **checker** for those exports. With no `@types/node` in the program a bare builtin specifier resolves to nothing at all, so `getExportsOfModule` answers `[]` — an empty array, which is **truthy**. The optimizer built `__new_plain_object()` with no properties and published it as the namespace, shadowing the `__node_path` host module thunk the module was still importing. The compiled module's import list is the tell: the bare row imports `__new_plain_object` where the `node:` row imports `__node_path`.

`node:path` escaped only by **accident** — the injected ambient `declare module "node:path"` gives it one export whose only declaration lives in a `.d.ts`, which trips the optimizer's "mutable value → decline the whole object" arm and falls through to the host binding.

## Change

Decline up front, for the real reason: a namespace import **of** a Node builtin is served by the host module object and must never be synthesized. One guard at the top of `namespaceFunctionExports`.

Scope: a user module that **re-exports** builtin members (`export { join } from 'node:path'`) is untouched — that namespace belongs to the user module and keeps its `host-member` lowering. Asserted in the regression test.

## Evidence

- jest dogfood suite **320/356 → 329/356** (+9): `fast_path.test.js` 0/5 → 5/5, `get_mock_name.test.js` 0/1 → 1/1, and — not predicted by the original triage, which had filed it as a missing host builtin — `isError.test.ts` 17/20 → 20/20, because `import * as vm from 'vm'` was binding `{}` the same way.
- `tests/issue-5330-bare-builtin-namespace-import.test.ts` — **1 failed / 2 passed → 3 passed**. Untyped `.js` in a two-file project: the shape real packages present.
- 17-package dogfood A/B at one head — see the PR comment; no package regressed.

## Residual, measured and out of scope

`import { join } from 'path'` — and `from 'node:path'` — still answers `null`. That is a defect in the #1791 path shim's NAMED bindings, it affects both spellings equally, and no jest test uses that form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
