### PR TITLE
fix(#5329): tuple-typed rest parameters get a carrier instead of an invalid module ✓

### DIFF
--- a/plan/issues/5329-tuple-rest-carrier.md
+++ b/plan/issues/5329-tuple-rest-carrier.md
@@ -1,0 +1,95 @@
+---
+id: 5329
+title: "Tuple-typed rest parameter has no carrier: invalid module + null-deref on every call"
+status: done
+sprint: current
+created: 2026-09-05
+updated: 2026-09-05
+completed: 2026-09-05
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+A tuple-typed rest parameter — `function (...args: [Error])` — is a carrier
+neither rest builder recognised, and both of their "anything else" fallbacks
+were wrong:
+
+- **`compileRestClosureArguments`** (`src/codegen/expressions/calls-closures.ts`)
+  fell through to `pushDefaultValue(ref …)`, i.e. `ref.null` + `ref.as_non_null`.
+  Every direct call to such a closure trapped with **"dereferencing a null
+  pointer"** before its body ran.
+- **`classifyClosureDispatchRest`** (`src/codegen/closure-exports.ts`) answered
+  `undefined`, which the caller could not distinguish from *"there is no rest
+  formal"*. The closure was therefore admitted as an ordinary arity-N entry with
+  the formal dropped, so the arm's `call_ref` was one operand short and the
+  **whole module** failed validation:
+  `Compiling function #N:"__call_fn_0" failed: not enough arguments on the stack
+  for call_ref (need 2, got 1)`.
+
+Production witness: jest's `packages/jest-jasmine2/src/queueRunner.ts` —
+`const next = function (...args: [Error]) {…}` plus a `next.fail` twin. It was
+the **only** module of the 34 in the jest dogfood suite that failed Wasm
+validation.
+
+## Root cause
+
+Rest parameters have three carriers in this compiler and the classifier knew two
+and a half of them:
+
+| source | lowered carrier |
+| --- | --- |
+| `...args: number[]` / `...args` | `{ length, data }` vec |
+| `...args: T` (generic) | `externref` |
+| `...args: []` | zero-field struct |
+| **`...args: [Error]`** | **`__tuple_N` struct, one field per element** |
+
+The last row hit neither `getArrTypeIdxFromVec` (not a vec) nor the
+`fields.length === 0` branch.
+
+Two independent things were wrong, and only fixing both is safe:
+
+1. **No recipe for the carrier.** Added — the tuple struct is built
+   positionally, one field per element, padded with that field type's
+   missing-argument default.
+2. **`undefined` was overloaded.** "No rest formal" and "a rest formal I cannot
+   build" are different facts and the callers must treat them differently. The
+   classifier now answers `{ kind: "unsupported" }` for the second, and both
+   dispatch builders SKIP such an entry. An unbuildable carrier can no longer
+   cost the module its validity — the worst case is a closure that is not
+   offered on the host dispatcher.
+
+The recognizer lives in one place — `src/codegen/closures/tuple-rest-carrier.ts`
+— so the two builders agree by construction rather than by coincidence.
+
+## Evidence
+
+- Minimal repro (dogfood harness, `compileAndRunUpstreamModule`):
+  `const f = function (...a: [number]) { return a[0]; }; f(7)` — invalid module
+  before, `7` after. `[Error, Error]` likewise.
+- Controls that were already clean and stay clean: `...a: number[]`,
+  `...a: any[]`, `...a: []`, a top-level `function f(...a: [number])`.
+- `tests/issue-5329-tuple-rest-carrier.test.ts`: **3 failed → 3 passed**. On the
+  base arm the compile reports `success: true` and then
+  `WebAssembly.instantiate` rejects the module.
+- jest dogfood: `queueRunner.test.ts` stops failing validation. Its 6 tests do
+  **not** yet pass — see the residual below — so the suite headline does not
+  move on this change alone.
+
+## Residuals (measured, deliberately not in this change)
+
+- **`queueRunner.test.ts` is still 0/6.** With the module valid, the failure
+  moves to a host-callback `TypeError: Cannot convert object to primitive value`
+  raised from `invokeNativeFunctionCallback` while running the test's
+  `jest.fn()` mocks. That is the same family as the `prompt`/`Replaceable`
+  "illegal cast" bucket, not a rest-carrier problem.
+- **`args.length` on a tuple reads NaN.** This is a property-access gap on tuple
+  structs generally, not something the carrier introduced: a plain
+  `const t: [number, number] = [1, 2]; t.length` reads NaN too, identically
+  before and after. Asserted in the regression test so it cannot move silently.

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -31,7 +31,7 @@ import {
   classifyClosureDispatchRest,
   closureDispatchSelfTypeIdx,
   materializeClosureDispatchRest,
-  type ClosureDispatchRestInfo,
+  type ClosureDispatchRestCarrier,
 } from "./closures/closure-dispatch-rest.js";
 import { buildMethodDispatchPrologue } from "./closures/method-dispatch-prologue.js";
 import { isSyntheticStructName } from "./emit-helpers.js";
@@ -626,7 +626,7 @@ interface ClosureDispatchEntry {
   returnType: ValType | null;
   selfTypeIdx: number;
   closureArity: number;
-  rest?: ClosureDispatchRestInfo;
+  rest?: ClosureDispatchRestCarrier;
 }
 
 /**

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -27,6 +27,12 @@ import { ensureAnyToExternHelper, isAnyValue, undefinedExternInstrs } from "./an
 import { ensureObjVecBuilders } from "./object-runtime.js";
 import { buildVecFromExternMaterializer } from "./type-coercion.js";
 import { buildClosureResultBoxing } from "./closures/result-boxing.js";
+import {
+  classifyClosureDispatchRest,
+  closureDispatchSelfTypeIdx,
+  materializeClosureDispatchRest,
+  type ClosureDispatchRestInfo,
+} from "./closures/closure-dispatch-rest.js";
 import { buildMethodDispatchPrologue } from "./closures/method-dispatch-prologue.js";
 import { isSyntheticStructName } from "./emit-helpers.js";
 export { buildTransferredCharAtApplyArm } from "./char-at-transfer.js";
@@ -615,96 +621,12 @@ function closureHostArity(info: {
   return info.hasRestParam === true ? Math.max(0, info.paramTypes.length - 1) : info.paramTypes.length;
 }
 
-type ClosureDispatchRestInfo =
-  | {
-      kind: "vec";
-      matchTypeIdx: number;
-      vecTypeIdx: number;
-      arrTypeIdx: number;
-      elemType: ValType;
-    }
-  | {
-      kind: "empty-struct";
-      matchTypeIdx: number;
-      vecTypeIdx: number;
-    }
-  | {
-      kind: "externref";
-      matchTypeIdx: number;
-    };
-
 interface ClosureDispatchEntry {
   funcTypeIdx: number;
   returnType: ValType | null;
   selfTypeIdx: number;
   closureArity: number;
   rest?: ClosureDispatchRestInfo;
-}
-
-/**
- * Recover the concrete carrier needed for a source rest parameter.
- *
- * Most rest parameters lower to the canonical `{ length, data }` vec. A
- * generic rest (`...args: T`, where `T extends unknown[]`) instead resolves to
- * `externref`: the lifted function still has one Wasm rest formal, but the
- * host dispatcher must build the array value that formal represents. Treating
- * that signature as an ordinary arity-0 closure omitted the formal entirely
- * and made every `__call_fn_N`/`__call_fn_method_N` containing it invalid.
- */
-function classifyClosureDispatchRest(
-  ctx: CodegenContext,
-  matchTypeIdx: number,
-  info: ClosureInfo,
-  funcTypeDef: FuncTypeDef | undefined,
-  hostArity: number,
-): ClosureDispatchRestInfo | undefined {
-  if (info.hasRestParam !== true || funcTypeDef === undefined) return undefined;
-  const restParam = funcTypeDef.params[hostArity + 1]; // +1 for closure self
-  if (!restParam) return undefined;
-
-  if (restParam.kind === "externref" || restParam.kind === "ref_extern") {
-    return { kind: "externref", matchTypeIdx };
-  }
-  if (restParam.kind !== "ref" && restParam.kind !== "ref_null") return undefined;
-
-  const vecTypeIdx = restParam.typeIdx;
-  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
-  const arrDef = ctx.mod.types[arrTypeIdx];
-  if (arrDef?.kind === "array") {
-    return { kind: "vec", matchTypeIdx, vecTypeIdx, arrTypeIdx, elemType: arrDef.element };
-  }
-  const vecDef = ctx.mod.types[vecTypeIdx];
-  if (vecDef?.kind === "struct" && vecDef.fields.length === 0) {
-    return { kind: "empty-struct", matchTypeIdx, vecTypeIdx };
-  }
-  return undefined;
-}
-
-/** Build the single hidden Wasm argument that implements a source rest array. */
-function materializeClosureDispatchRest(
-  rest: ClosureDispatchRestInfo,
-  dispatcherArity: number,
-  fixedArity: number,
-  externVecTypeIdx: number,
-  externArrTypeIdx: number,
-  emitElement: (argumentIndex: number, elemType: ValType) => Instr[],
-): Instr[] {
-  if (rest.kind === "empty-struct") return [{ op: "struct.new", typeIdx: rest.vecTypeIdx }];
-
-  const restCount = Math.max(0, dispatcherArity - fixedArity);
-  const elemType: ValType = rest.kind === "externref" ? { kind: "externref" } : rest.elemType;
-  const arrTypeIdx = rest.kind === "externref" ? externArrTypeIdx : rest.arrTypeIdx;
-  const vecTypeIdx = rest.kind === "externref" ? externVecTypeIdx : rest.vecTypeIdx;
-  const instrs: Instr[] = [{ op: "i32.const", value: restCount }];
-  for (let i = fixedArity; i < dispatcherArity; i++) {
-    instrs.push(...emitElement(i, elemType));
-  }
-  instrs.push(
-    { op: "array.new_fixed", typeIdx: arrTypeIdx, length: restCount },
-    { op: "struct.new", typeIdx: vecTypeIdx },
-  );
-  if (rest.kind === "externref") instrs.push({ op: "extern.convert_any" });
-  return instrs;
 }
 
 /**
@@ -814,19 +736,11 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
     }
 
     const funcTypeDef = mod.types[info.funcTypeIdx];
-    const selfParam = funcTypeDef?.kind === "func" ? funcTypeDef.params[0] : undefined;
-    const selfTypeIdx =
-      selfParam && (selfParam.kind === "ref" || selfParam.kind === "ref_null")
-        ? (selfParam as { typeIdx: number }).typeIdx
-        : typeIdx;
+    const selfTypeIdx = closureDispatchSelfTypeIdx(funcTypeDef?.kind === "func" ? funcTypeDef : undefined, typeIdx);
 
-    const rest = classifyClosureDispatchRest(
-      ctx,
-      typeIdx,
-      info,
-      funcTypeDef?.kind === "func" ? funcTypeDef : undefined,
-      hostArity,
-    );
+    const funcType = funcTypeDef?.kind === "func" ? funcTypeDef : undefined;
+    const rest = classifyClosureDispatchRest(ctx, typeIdx, info, funcType, hostArity);
+    if (rest?.kind === "unsupported") continue; // (#5329) never emit a short call_ref
     if (rest) {
       restEntries.push({
         funcTypeIdx: info.funcTypeIdx,
@@ -1386,19 +1300,11 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
       baseWrapperIdx = typeIdx;
     }
     const funcTypeDef = mod.types[info.funcTypeIdx];
-    const selfParam = funcTypeDef?.kind === "func" ? funcTypeDef.params[0] : undefined;
-    const selfTypeIdx =
-      selfParam && (selfParam.kind === "ref" || selfParam.kind === "ref_null")
-        ? (selfParam as { typeIdx: number }).typeIdx
-        : typeIdx;
+    const selfTypeIdx = closureDispatchSelfTypeIdx(funcTypeDef?.kind === "func" ? funcTypeDef : undefined, typeIdx);
 
-    const rest = classifyClosureDispatchRest(
-      ctx,
-      typeIdx,
-      info,
-      funcTypeDef?.kind === "func" ? funcTypeDef : undefined,
-      hostArity,
-    );
+    const funcType = funcTypeDef?.kind === "func" ? funcTypeDef : undefined;
+    const rest = classifyClosureDispatchRest(ctx, typeIdx, info, funcType, hostArity);
+    if (rest?.kind === "unsupported") continue; // (#5329) never emit a short call_ref
     if (rest) {
       restEntries.push({
         funcTypeIdx: info.funcTypeIdx,
@@ -2023,11 +1929,7 @@ function collectClosureArityEntries(
     if (seenFuncTypeIdx.has(info.funcTypeIdx)) continue;
     seenFuncTypeIdx.add(info.funcTypeIdx);
     const funcTypeDef = mod.types[info.funcTypeIdx];
-    const selfParam = funcTypeDef?.kind === "func" ? funcTypeDef.params[0] : undefined;
-    const selfTypeIdx =
-      selfParam && (selfParam.kind === "ref" || selfParam.kind === "ref_null")
-        ? (selfParam as { typeIdx: number }).typeIdx
-        : typeIdx;
+    const selfTypeIdx = closureDispatchSelfTypeIdx(funcTypeDef?.kind === "func" ? funcTypeDef : undefined, typeIdx);
     entries.push({ funcTypeIdx: info.funcTypeIdx, selfTypeIdx, closureArity: closureHostArity(info) });
   }
   return entries;

--- a/src/codegen/closures/closure-dispatch-rest.ts
+++ b/src/codegen/closures/closure-dispatch-rest.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Rest-parameter carriers for the host closure dispatchers (#5329).
+ *
+ * `__call_fn_N` / `__call_fn_method_N` take every user argument as
+ * `externref`, but a closure with a source rest parameter declares ONE hidden
+ * Wasm formal for it, whose shape depends on how the rest type lowered. This
+ * module owns the classification of that formal and the instruction sequence
+ * that builds it, so the two dispatcher emitters in `closure-exports.ts` cannot
+ * disagree about it. Extracted from that file, which is over its LOC budget.
+ */
+
+import type { FuncTypeDef, Instr, ValType } from "../../ir/types.js";
+import type { ClosureInfo, CodegenContext } from "../context/types.js";
+import { getArrTypeIdxFromVec } from "../registry/types.js";
+import { defaultValueInstrs } from "../type-coercion.js";
+import { classifyTupleRestCarrier } from "./tuple-rest-carrier.js";
+
+export type ClosureDispatchRestInfo =
+  | {
+      kind: "vec";
+      matchTypeIdx: number;
+      vecTypeIdx: number;
+      arrTypeIdx: number;
+      elemType: ValType;
+    }
+  | {
+      kind: "empty-struct";
+      matchTypeIdx: number;
+      vecTypeIdx: number;
+    }
+  | {
+      kind: "externref";
+      matchTypeIdx: number;
+    }
+  | {
+      /**
+       * (#5329) A TUPLE-typed rest (`...args: [Error]`) lowers to a fixed-field
+       * `__tuple_N` struct, one field per element — not to the canonical
+       * `{ length, data }` vec. Materialize it positionally.
+       */
+      kind: "tuple";
+      matchTypeIdx: number;
+      tupleTypeIdx: number;
+      fieldTypes: ValType[];
+    }
+  | {
+      /**
+       * (#5329) A rest FORMAL exists on the funcref but this dispatcher has no
+       * recipe for its carrier. The caller MUST skip the entry entirely: the
+       * only alternative — treating the closure as an ordinary arity-`hostArity`
+       * one — omits the formal and emits a `call_ref` one operand short, which
+       * fails module validation. See `classifyClosureDispatchRest`.
+       */
+      kind: "unsupported";
+    };
+
+/**
+ * Recover the concrete carrier needed for a source rest parameter.
+ *
+ * Most rest parameters lower to the canonical `{ length, data }` vec. A
+ * generic rest (`...args: T`, where `T extends unknown[]`) instead resolves to
+ * `externref`: the lifted function still has one Wasm rest formal, but the
+ * host dispatcher must build the array value that formal represents. Treating
+ * that signature as an ordinary arity-0 closure omitted the formal entirely
+ * and made every `__call_fn_N`/`__call_fn_method_N` containing it invalid.
+ *
+ * (#5329) Returns `undefined` only when there is NO rest formal to build. A
+ * formal that exists but has no known carrier answers `{ kind: "unsupported" }`,
+ * which the caller must translate into "skip this entry" — falling through to
+ * the plain-arity push is what produced the invalid module above, and a bare
+ * `undefined` could not tell the two cases apart. jest's `queueRunner.ts`
+ * (`const next = function (...args: [Error]) {…}`) is the witness: a TUPLE-typed
+ * rest lowers to a `__tuple_N` struct with one field per element, matching none
+ * of the vec / empty-struct / externref carriers, so the whole module failed to
+ * validate with "not enough arguments on the stack for call_ref (need 2, got 1)".
+ */
+export function classifyClosureDispatchRest(
+  ctx: CodegenContext,
+  matchTypeIdx: number,
+  info: ClosureInfo,
+  funcTypeDef: FuncTypeDef | undefined,
+  hostArity: number,
+): ClosureDispatchRestInfo | undefined {
+  if (info.hasRestParam !== true || funcTypeDef === undefined) return undefined;
+  const restParam = funcTypeDef.params[hostArity + 1]; // +1 for closure self
+  if (!restParam) return undefined;
+
+  if (restParam.kind === "externref" || restParam.kind === "ref_extern") {
+    return { kind: "externref", matchTypeIdx };
+  }
+  if (restParam.kind !== "ref" && restParam.kind !== "ref_null") return { kind: "unsupported" };
+
+  const vecTypeIdx = restParam.typeIdx;
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  const arrDef = ctx.mod.types[arrTypeIdx];
+  if (arrDef?.kind === "array") {
+    return { kind: "vec", matchTypeIdx, vecTypeIdx, arrTypeIdx, elemType: arrDef.element };
+  }
+  const vecDef = ctx.mod.types[vecTypeIdx];
+  if (vecDef?.kind === "struct" && vecDef.fields.length === 0) {
+    return { kind: "empty-struct", matchTypeIdx, vecTypeIdx };
+  }
+  // (#5329) A tuple-typed rest lowers to a `__tuple_N` struct, one field per
+  // element — see closures/tuple-rest-carrier.ts for the shared recognizer.
+  const tuple = classifyTupleRestCarrier(ctx, vecTypeIdx);
+  if (tuple !== null) {
+    return { kind: "tuple", matchTypeIdx, tupleTypeIdx: tuple.tupleTypeIdx, fieldTypes: tuple.fieldTypes };
+  }
+  return { kind: "unsupported" };
+}
+
+/** Build the single hidden Wasm argument that implements a source rest array. */
+export function materializeClosureDispatchRest(
+  rest: ClosureDispatchRestInfo,
+  dispatcherArity: number,
+  fixedArity: number,
+  externVecTypeIdx: number,
+  externArrTypeIdx: number,
+  emitElement: (argumentIndex: number, elemType: ValType) => Instr[],
+): Instr[] {
+  if (rest.kind === "empty-struct") return [{ op: "struct.new", typeIdx: rest.vecTypeIdx }];
+  // (#5329) A tuple carrier has one FIELD per element, not a length + array. Push
+  // the positional argument for each field it covers and pad the rest with that
+  // field type's missing-argument default (the f64 `undefined` sentinel, typed
+  // null, 0 — `defaultValueInstrs`), then build the struct.
+  if (rest.kind === "tuple") {
+    const instrs: Instr[] = [];
+    for (let i = 0; i < rest.fieldTypes.length; i++) {
+      const fieldType = rest.fieldTypes[i]!;
+      const argumentIndex = fixedArity + i;
+      instrs.push(
+        ...(argumentIndex < dispatcherArity ? emitElement(argumentIndex, fieldType) : defaultValueInstrs(fieldType)),
+      );
+    }
+    instrs.push({ op: "struct.new", typeIdx: rest.tupleTypeIdx });
+    return instrs;
+  }
+  if (rest.kind === "unsupported") {
+    // Unreachable: callers skip an `unsupported` entry before it can reach a
+    // dispatch arm (see `emitClosureCallExportN`). Keep the exhaustive tail so a
+    // future carrier kind cannot silently fall through to the vec path.
+    return [];
+  }
+
+  const restCount = Math.max(0, dispatcherArity - fixedArity);
+  const elemType: ValType = rest.kind === "externref" ? { kind: "externref" } : rest.elemType;
+  const arrTypeIdx = rest.kind === "externref" ? externArrTypeIdx : rest.arrTypeIdx;
+  const vecTypeIdx = rest.kind === "externref" ? externVecTypeIdx : rest.vecTypeIdx;
+  const instrs: Instr[] = [{ op: "i32.const", value: restCount }];
+  for (let i = fixedArity; i < dispatcherArity; i++) {
+    instrs.push(...emitElement(i, elemType));
+  }
+  instrs.push(
+    { op: "array.new_fixed", typeIdx: arrTypeIdx, length: restCount },
+    { op: "struct.new", typeIdx: vecTypeIdx },
+  );
+  if (rest.kind === "externref") instrs.push({ op: "extern.convert_any" });
+  return instrs;
+}
+
+/**
+ * (#5329) The struct type a lifted funcref expects as its `self` operand: the
+ * declared param-0 type when it is a reference, else the closure's own struct.
+ * Three dispatcher loops in `closure-exports.ts` had this open-coded.
+ */
+export function closureDispatchSelfTypeIdx(funcTypeDef: FuncTypeDef | undefined, structTypeIdx: number): number {
+  const selfParam = funcTypeDef?.kind === "func" ? funcTypeDef.params[0] : undefined;
+  return selfParam && (selfParam.kind === "ref" || selfParam.kind === "ref_null") ? selfParam.typeIdx : structTypeIdx;
+}

--- a/src/codegen/closures/closure-dispatch-rest.ts
+++ b/src/codegen/closures/closure-dispatch-rest.ts
@@ -56,6 +56,13 @@ export type ClosureDispatchRestInfo =
     };
 
 /**
+ * (#5329) The subset a dispatch ARM can actually be built from. Callers skip an
+ * `unsupported` classification before an entry is created, so the entry's
+ * carrier is statically one of the buildable kinds.
+ */
+export type ClosureDispatchRestCarrier = Exclude<ClosureDispatchRestInfo, { kind: "unsupported" }>;
+
+/**
  * Recover the concrete carrier needed for a source rest parameter.
  *
  * Most rest parameters lower to the canonical `{ length, data }` vec. A
@@ -112,7 +119,7 @@ export function classifyClosureDispatchRest(
 
 /** Build the single hidden Wasm argument that implements a source rest array. */
 export function materializeClosureDispatchRest(
-  rest: ClosureDispatchRestInfo,
+  rest: ClosureDispatchRestCarrier,
   dispatcherArity: number,
   fixedArity: number,
   externVecTypeIdx: number,
@@ -135,12 +142,6 @@ export function materializeClosureDispatchRest(
     }
     instrs.push({ op: "struct.new", typeIdx: rest.tupleTypeIdx });
     return instrs;
-  }
-  if (rest.kind === "unsupported") {
-    // Unreachable: callers skip an `unsupported` entry before it can reach a
-    // dispatch arm (see `emitClosureCallExportN`). Keep the exhaustive tail so a
-    // future carrier kind cannot silently fall through to the vec path.
-    return [];
   }
 
   const restCount = Math.max(0, dispatcherArity - fixedArity);

--- a/src/codegen/closures/tuple-rest-carrier.ts
+++ b/src/codegen/closures/tuple-rest-carrier.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#5329) Tuple-typed rest parameters (`function (...args: [Error])`).
+ *
+ * Most rest parameters lower to the canonical `{ length, data }` vec, and an
+ * empty tuple rest (`...args: []`) lowers to a zero-field struct. A NON-EMPTY
+ * tuple rest lowers to neither: it becomes a `__tuple_N` struct with one field
+ * per tuple element. Every consumer that builds a rest argument had a recipe
+ * for the two known carriers and a fallback for "anything else", and both
+ * fallbacks were wrong for this shape:
+ *
+ *  - `calls-closures.ts` padded the formal with `pushDefaultValue(ref …)`,
+ *    i.e. `ref.null` + `ref.as_non_null` — a guaranteed "dereferencing a null
+ *    pointer" trap on every call;
+ *  - `closure-exports.ts` dropped the formal from the host dispatch arm, so the
+ *    emitted `call_ref` was one operand short and the WHOLE module failed
+ *    validation ("not enough arguments on the stack for call_ref (need 2,
+ *    got 1)").
+ *
+ * jest's `packages/jest-jasmine2/src/queueRunner.ts` is the production witness
+ * (`const next = function (...args: [Error]) {…}` plus a `next.fail` twin); it
+ * was the only module of the 34 in the jest dogfood suite that failed to
+ * validate.
+ *
+ * This module is the single place that recognizes the carrier and names its
+ * field types, so the two builders agree by construction.
+ */
+
+import type { ts } from "../../ts-api.js";
+import type { ValType } from "../../ir/types.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { allocLocal } from "../context/locals.js";
+import { coerceType, compileExpression, valTypesMatch } from "../shared.js";
+import { defaultValueInstrs, pushDefaultValue } from "../type-coercion.js";
+
+export interface TupleRestCarrier {
+  /** The `__tuple_N` struct type index the lifted formal declares. */
+  tupleTypeIdx: number;
+  /** One entry per tuple element, in field order. */
+  fieldTypes: ValType[];
+}
+
+/**
+ * Recognize a non-empty tuple rest carrier, or `null` when `typeIdx` is not one
+ * (or cannot be built safely).
+ *
+ * Two conditions beyond "struct with fields":
+ *
+ *  - it must be a REGISTERED tuple type. An arbitrary struct that happens to sit
+ *    in a rest formal is not something a positional builder may invent a value
+ *    for.
+ *  - every field must have a valid missing-argument pad. `defaultValueInstrs`
+ *    answers `ref.null` for a `ref`/`ref_null` field, which types as
+ *    `(ref null T)` — fine for `ref_null`, ill-typed for a NON-NULL `ref`. A
+ *    carrier with such a field is declined rather than built badly.
+ */
+export function classifyTupleRestCarrier(ctx: CodegenContext, typeIdx: number): TupleRestCarrier | null {
+  const def = ctx.mod.types[typeIdx];
+  if (def?.kind !== "struct" || def.fields.length === 0) return null;
+  let registered = false;
+  for (const candidate of ctx.tupleTypeMap.values()) {
+    if (candidate === typeIdx) {
+      registered = true;
+      break;
+    }
+  }
+  if (!registered) return null;
+  if (def.fields.some((field) => field.type.kind === "ref")) return null;
+  return { tupleTypeIdx: typeIdx, fieldTypes: def.fields.map((field) => field.type) };
+}
+
+/**
+ * (#5329) Build a struct-shaped rest formal from positional arguments, or
+ * answer `null` when `restTypeIdx` is not one — leaving the caller on the vec
+ * path.
+ *
+ * Covers both struct carriers. An EMPTY tuple (`...args: []`) lowers to a
+ * zero-field struct and just needs `struct.new`; TypeScript also uses that
+ * shape for an unused `...rest`. A NON-EMPTY tuple gets one field per element,
+ * in field order: the corresponding call argument when there is one, else that
+ * field type's missing-argument default (the f64 `undefined` sentinel / typed
+ * null / 0). Arguments past the tuple's width are still EVALUATED — JavaScript
+ * ignores surplus arguments but not their side effects — and returned as
+ * externref copies so the caller can populate `__extras_argv` for the callee's
+ * `arguments` object, exactly as the vec carrier does.
+ */
+export function compileTupleRestClosureArgument(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  callArgs: ts.Expression[],
+  fixedParamCount: number,
+  restTypeIdx: number,
+): { fixedParamCount: number; restExternLocals: number[] } | null {
+  const restDef = ctx.mod.types[restTypeIdx];
+  if (restDef?.kind === "struct" && restDef.fields.length === 0) {
+    fctx.body.push({ op: "struct.new", typeIdx: restTypeIdx });
+    return { fixedParamCount, restExternLocals: [] };
+  }
+  const carrier = classifyTupleRestCarrier(ctx, restTypeIdx);
+  if (carrier === null) return null;
+  const { tupleTypeIdx, fieldTypes } = carrier;
+  const fieldLocals: number[] = [];
+  const restExternLocals: number[] = [];
+  const captureExtern = (valueLocal: number, valueType: ValType): void => {
+    fctx.body.push({ op: "local.get", index: valueLocal });
+    coerceType(ctx, fctx, valueType, { kind: "externref" });
+    const externLocal = allocLocal(fctx, `__cc_trest_extern_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: externLocal });
+    restExternLocals.push(externLocal);
+  };
+
+  for (let i = 0; i < fieldTypes.length; i++) {
+    const fieldType = fieldTypes[i]!;
+    const argIndex = fixedParamCount + i;
+    const fieldLocal = allocLocal(fctx, `__cc_trest_${fctx.locals.length}`, fieldType);
+    const argument = callArgs[argIndex];
+    if (argument === undefined) {
+      fctx.body.push(...defaultValueInstrs(fieldType));
+    } else {
+      const actualType = compileExpression(ctx, fctx, argument, fieldType);
+      if (actualType === null) pushDefaultValue(fctx, fieldType, ctx);
+      else if (!valTypesMatch(actualType, fieldType)) coerceType(ctx, fctx, actualType, fieldType);
+    }
+    fctx.body.push({ op: "local.set", index: fieldLocal });
+    fieldLocals.push(fieldLocal);
+    if (argument !== undefined) captureExtern(fieldLocal, fieldType);
+  }
+
+  // Surplus arguments: evaluate for side effects, keep them visible to
+  // `arguments`, and do not let them reach the struct.
+  for (let argIndex = fixedParamCount + fieldTypes.length; argIndex < callArgs.length; argIndex++) {
+    const surplusType = compileExpression(ctx, fctx, callArgs[argIndex]!, { kind: "externref" });
+    if (surplusType === null) {
+      fctx.body.push({ op: "ref.null.extern" });
+    } else if (!valTypesMatch(surplusType, { kind: "externref" })) {
+      coerceType(ctx, fctx, surplusType, { kind: "externref" });
+    }
+    const externLocal = allocLocal(fctx, `__cc_trest_extra_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: externLocal });
+    restExternLocals.push(externLocal);
+  }
+
+  for (const fieldLocal of fieldLocals) fctx.body.push({ op: "local.get", index: fieldLocal });
+  fctx.body.push({ op: "struct.new", typeIdx: tupleTypeIdx });
+  return { fixedParamCount, restExternLocals };
+}

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -24,6 +24,7 @@ import { ensureObjVecBuilders, reserveApplyClosure } from "../object-runtime.js"
 import { emitRuntimeEvalCarrierUnwrapAny } from "../runtime-eval-callable.js";
 import { expressionDescendsFromRealmStructuralBinding } from "../analysis/realm-global-structural-carrier.js";
 import { allocLocal } from "../context/locals.js";
+import { compileTupleRestClosureArgument } from "../closures/tuple-rest-carrier.js";
 import type {
   ClosureInfo,
   CodegenContext,
@@ -825,17 +826,13 @@ function compileRestClosureArguments(
     pushDefaultValue(fctx, restType, ctx);
     return { fixedParamCount, restExternLocals: [] };
   }
-  // TypeScript represents an unused `...rest` parameter as an empty tuple
-  // struct rather than the ordinary `(length, data)` vec.  It is still a
-  // non-null lifted formal, so padding it with `pushDefaultValue(ref)` emits
-  // `ref.null; ref.as_non_null` and traps before the callee can materialize its
-  // `arguments` object.  Construct the canonical empty tuple instead; the
-  // arguments-object builder treats the parameter as a normal boxed formal.
-  const restDef = ctx.mod.types[restType.typeIdx];
-  if (restDef?.kind === "struct" && restDef.fields.length === 0) {
-    fctx.body.push({ op: "struct.new", typeIdx: restType.typeIdx });
-    return { fixedParamCount, restExternLocals: [] };
-  }
+  // (#5329) A struct-shaped rest carrier — the empty tuple (`...a: []`) and the
+  // fixed-width tuple (`...a: [Error]`) alike — has one FIELD per element, not a
+  // `(length, data)` vec. Both used to reach a `pushDefaultValue(ref …)` tail
+  // that emits `ref.null; ref.as_non_null` and traps before the callee runs.
+  // See closures/tuple-rest-carrier.ts.
+  const tupleRest = compileTupleRestClosureArgument(ctx, fctx, callArgs, fixedParamCount, restType.typeIdx);
+  if (tupleRest !== null) return tupleRest;
   const vecInfo = getVecInfo(ctx, restType.typeIdx);
   if (vecInfo === null) {
     pushDefaultValue(fctx, restType, ctx);

--- a/tests/issue-5329-tuple-rest-carrier.test.ts
+++ b/tests/issue-5329-tuple-rest-carrier.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5329 — a TUPLE-typed rest parameter (`function (...args: [Error])`) is a
+// carrier neither rest builder knew about, and both of their fallbacks were
+// wrong in a way that could not be seen from the source.
+//
+// Most rest parameters lower to the canonical `{ length, data }` vec; an empty
+// tuple rest (`...args: []`) lowers to a zero-field struct. A NON-EMPTY tuple
+// rest lowers to a `__tuple_N` struct with one field per element, so:
+//
+//  - `compileRestClosureArguments` (calls-closures.ts) fell through to
+//    `pushDefaultValue(ref …)` = `ref.null` + `ref.as_non_null`, and every
+//    direct call trapped with "dereferencing a null pointer" before the body
+//    ran;
+//  - `classifyClosureDispatchRest` (closure-exports.ts) returned `undefined`,
+//    which the caller could not distinguish from "there is no rest formal", so
+//    the closure was admitted as an ordinary arity-N entry with the formal
+//    dropped. The emitted `call_ref` was then one operand short and the WHOLE
+//    module failed to validate:
+//      `Compiling function #N:"__call_fn_0" failed: not enough arguments on the
+//       stack for call_ref (need 2, got 1)`
+//
+// Production witness: jest's `packages/jest-jasmine2/src/queueRunner.ts`
+// (`const next = function (...args: [Error]) {…}` plus a `next.fail` twin). It
+// was the ONLY module of the 34 in the jest dogfood suite that failed Wasm
+// validation, taking all 6 of its tests with it.
+//
+// The fix adds the carrier to the shared recognizer
+// (`src/codegen/closures/tuple-rest-carrier.ts`) so both builders agree, and
+// gives `classifyClosureDispatchRest` an explicit `"unsupported"` answer so a
+// formal it cannot build is SKIPPED rather than silently dropped — an
+// unbuildable carrier must never again cost the whole module its validity.
+//
+// WHY `.ts` AND NOT UNTYPED `.js`: the trigger IS the type annotation. There is
+// no untyped spelling of a tuple rest, so the usual "untyped `.js` fixture"
+// rule cannot apply here; an unannotated `...args` lowers to the vec carrier and
+// was always correct. The two-file project shape is kept.
+//
+// DOCUMENTED RESIDUAL, asserted below: `.length` on a tuple reads NaN. That is
+// a property-access gap on tuple structs generally — a plain
+// `const t: [number, number] = [1, 2]; t.length` reads NaN too, with and
+// without this change — not something this carrier introduced.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject, type CompileResult } from "../src/index.js";
+import { buildCompiledImports } from "../src/runtime.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+async function compileFixture(files: Record<string, string>, entry: string): Promise<CompileResult> {
+  const root = mkdtempSync(join(tmpdir(), "js2-5329-"));
+  roots.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const target = join(root, name);
+    mkdirSync(join(target, ".."), { recursive: true });
+    writeFileSync(target, source);
+  }
+  return compileProject(join(root, entry), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+}
+
+async function instantiate(result: CompileResult): Promise<WebAssembly.Exports> {
+  const imports = buildCompiledImports(result, {}) as Record<string, unknown> & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports.setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (imports.__setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (instance.exports.__module_init as (() => void) | undefined)?.();
+  return instance.exports;
+}
+
+const DEP = `
+export function record(sink: number[], value: number): number {
+  sink.push(value);
+  return sink.length;
+}
+`;
+
+// `queueRunner.ts`'s shape: a function EXPRESSION (so it is lifted into a
+// closure and lands in the host dispatch table) with a tuple rest, a property
+// assigned onto it that is a second tuple-rest function expression, and
+// \`.apply(null, args)\` forwarding the whole tuple.
+const ENTRY = `
+import { record } from './dep.js';
+
+const sink: number[] = [];
+
+const next = function (...args: [number]) {
+  const first = args[0];
+  return record(sink, first);
+};
+(next as any).fail = function (...args: [number]) {
+  return record(sink, args[0] * 10);
+};
+
+const twoWide = function (...args: [number, number]) {
+  return args[0] * 100 + args[1];
+};
+
+const forwarder = function (...args: [number]) {
+  return next.apply(null, args);
+};
+
+export function callDirect(): number { return next(7); }
+export function callProperty(): number { return (next as any).fail(3); }
+export function callTwoWide(): number { return twoWide(4, 5); }
+export function callThroughApply(): number { return forwarder(9); }
+export function callAsCallback(): number {
+  const out = [1, 2, 3].map(next);
+  return out[out.length - 1] as number;
+}
+export function sinkLength(): number { return sink.length; }
+// Residual: \`.length\` on a tuple reads NaN, before and after this change.
+export function restLength(): number {
+  const widthOf = function (...args: [number]) { return args.length; };
+  return widthOf(1);
+}
+`;
+
+describe("#5329 tuple-typed rest parameter carrier", () => {
+  it("produces a module that validates and calls the closure with its tuple", async () => {
+    const result = await compileFixture({ "dep.ts": DEP, "main.ts": ENTRY }, "main.ts");
+    // Before the fix this compile FAILED outright: `__call_fn_0` was emitted one
+    // operand short and the emitted module was rejected by validation.
+    expect(result.success).toBe(true);
+    const exports = await instantiate(result);
+
+    expect((exports.callDirect as () => number)()).toBe(1);
+    expect((exports.callProperty as () => number)()).toBe(2);
+    expect((exports.callTwoWide as () => number)()).toBe(405);
+    expect((exports.callThroughApply as () => number)()).toBe(3);
+  });
+
+  it("keeps the closure reachable through the host dispatcher", async () => {
+    const result = await compileFixture({ "dep.ts": DEP, "main.ts": ENTRY }, "main.ts");
+    expect(result.success).toBe(true);
+    const exports = await instantiate(result);
+
+    // `Array.prototype.map` routes the closure through `__call_fn_N` — the
+    // dispatcher whose arm used to be dropped. The last element is the third
+    // `record` call in this instance, so it observes the growing sink.
+    expect((exports.callAsCallback as () => number)()).toBe(3);
+    expect((exports.sinkLength as () => number)()).toBe(3);
+  });
+
+  it("still reads NaN for a tuple's .length (documented residual)", async () => {
+    const result = await compileFixture({ "dep.ts": DEP, "main.ts": ENTRY }, "main.ts");
+    expect(result.success).toBe(true);
+    const exports = await instantiate(result);
+    // Not introduced here: a plain `const t: [number, number] = [1, 2]` reads
+    // `t.length` as NaN too, unchanged by this fix. Asserted so the day the
+    // tuple property-access gap is closed, this test says so.
+    expect((exports.restLength as () => number)()).toBeNaN();
+  });
+});


### PR DESCRIPTION
Closes [#5329](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5329-tuple-rest-carrier).

A tuple-typed rest parameter — `function (...args: [Error])` — is a carrier neither rest builder recognised, and both of their "anything else" fallbacks were wrong:

- `compileRestClosureArguments` fell through to `pushDefaultValue(ref …)`, i.e. `ref.null` + `ref.as_non_null`. Every direct call to such a closure trapped with **"dereferencing a null pointer"** before its body ran.
- `classifyClosureDispatchRest` answered `undefined`, which the caller could not tell apart from *"there is no rest formal"*. The closure was admitted as an ordinary arity-N entry with the formal dropped, so the arm's `call_ref` was one operand short and the **whole module** failed validation: `Compiling function #N:"__call_fn_0" failed: not enough arguments on the stack for call_ref (need 2, got 1)`.

Production witness: jest's `packages/jest-jasmine2/src/queueRunner.ts` (`const next = function (...args: [Error]) {…}` plus a `next.fail` twin) — the only module of the 34 in the jest dogfood suite that failed Wasm validation.

## Root cause

Rest parameters have several carriers and the classifier knew two and a half:

| source | lowered carrier |
| --- | --- |
| `...args: number[]` / `...args` | `{ length, data }` vec |
| `...args: T` (generic) | `externref` |
| `...args: []` | zero-field struct |
| **`...args: [Error]`** | **`__tuple_N` struct, one field per element** |

Two independent things were wrong and only fixing both is safe:

1. **No recipe for the carrier.** The tuple struct is now built positionally, one field per element, padded with that field type's missing-argument default.
2. **`undefined` was overloaded.** "No rest formal" and "a rest formal I cannot build" are different facts. The classifier now answers `{ kind: "unsupported" }` for the second, and both dispatch builders SKIP such an entry — an unbuildable carrier can no longer cost the module its validity; the worst case is a closure that is not offered on the host dispatcher.

## Change shape

The recognizer and both builders live in two new leaf modules — `src/codegen/closures/tuple-rest-carrier.ts` and `src/codegen/closures/closure-dispatch-rest.ts` — so the dispatcher-side and call-site builders agree by construction. Moving the existing classify/materialize pair out of `closure-exports.ts` takes that god-file **below** its LOC budget; the empty-tuple special case in `calls-closures.ts` folds into the same shared entry point, and three open-coded copies of the `self` type-index computation collapse into one helper. Net: no budget allowance needed for this PR.

## Evidence

- `tests/issue-5329-tuple-rest-carrier.test.ts` — **3 failed → 3 passed**. On the base arm the compile reports `success: true` and then `WebAssembly.instantiate` rejects the module.
- Probe matrix: `[number]`, `[Error, Error]`, `.apply(null, args)`, use as an `Array.prototype.map` callback, and the full queueRunner shape all go from broken to correct. Controls that were already clean stay clean: `...a: number[]`, `...a: any[]`, `...a: []`, a top-level `function f(...a: [number])`.
- 17-package dogfood A/B at one head — see the PR comment; no package regressed.

## Residuals, measured and deliberately out of scope

- **`queueRunner.test.ts` is still 0/6**, so the jest headline does not move on this change alone. With the module valid, the failure moves to a host-callback `TypeError: Cannot convert object to primitive value` raised while running the test's `jest.fn()` mocks — the same family as the `prompt`/`Replaceable` "illegal cast" bucket, not a rest-carrier problem.
- **`args.length` on a tuple reads NaN.** A property-access gap on tuple structs generally: a plain `const t: [number, number] = [1, 2]; t.length` reads NaN too, identically before and after. Asserted in the regression test so it cannot move silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
