### PR TITLE
fix(#5328): a dispatch arm returning externref into an f64 call site keeps its value ✓

### DIFF
--- a/plan/issues/5328-dynamic-dispatch-extern-result-dropped.md
+++ b/plan/issues/5328-dynamic-dispatch-extern-result-dropped.md
@@ -1,0 +1,137 @@
+---
+id: 5328
+title: "Dynamic-dispatch arm returning externref into an f64 call site drops the result"
+status: done
+sprint: current
+created: 2026-09-05
+updated: 2026-09-05
+completed: 2026-09-05
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+# 2026-09-05: the code change is ONE token (`false` -> `true` at the return
+# coercion site); the +7 lines are the comment explaining why the argument-side
+# guard does not apply to a result. There is nothing to extract into a subsystem
+# module, and a one-token change to a dispatch ladder with no rationale beside it
+# is exactly what makes the next reader revert it.
+loc-budget-allow:
+  - src/codegen/expressions/call-identifier.ts
+func-budget-allow:
+  - src/codegen/expressions/call-identifier.ts::compileIdentifierCall
+---
+
+## Problem
+
+A call through the identifier funcref ladder (`src/codegen/expressions/call-identifier.ts`)
+whose **expected result is `f64`** and whose **live arm's funcref returns `externref`**
+discarded the callee's answer and substituted the `0x7FF00000DEADC0DE` undefined
+sentinel. Every such call read `NaN`/`undefined` while the callee had computed
+the right value.
+
+Production witness: jest's `packages/jest-config/src/stringToBytes.ts` —
+`export default stringToBytes;` (the statement form), inferred return
+`number | null | undefined`, consumed through a default import. 21 of its 28
+upstream unit tests read the sentinel instead of the byte count.
+
+## Root cause
+
+The ladder builds one `ref.test`-guarded arm per candidate signature; each arm
+must leave a value of the block's declared result type. When an arm's return
+type disagrees it consults `scalarBridgePlan`, and on `null` falls back to a
+**dead-arm placeholder** — `drop` + `defaultValueInstrs(expectedReturn)` — whose
+justification is that a signature-divergent arm can never actually run.
+
+`scalarBridgePlan`'s `externref → f64` row is gated on `allowProvenNumberUnbox`,
+which the **return** site passed as `false`:
+
+```ts
+const bridge = dispatchBridgePlan(fc.returnType!, expectedReturn!, false, …);
+```
+
+Nothing else in the planner supplies that direction, so the arm always fell
+through to the placeholder. The arm is **not** dead: the ladder unconditionally
+seeds an externref-returning alternate candidate
+(`tryAltFuncType([{ kind: "externref" }])`) whenever the expected result is not
+already externref, and a function whose declared/inferred return is
+`number | undefined` is lowered with exactly that signature. So the live arm
+called the function, dropped its answer, and returned `undefined`.
+
+Why the guard exists, and why it does not apply here: for an **argument**, a
+declared-`any` value may really be a Boolean/Symbol/BigInt, and running it
+through the numeric ABI would erase that brand — the call site has to prove the
+value is a Number first. For a **result**, `expectedReturn` **is** this call
+expression's statically computed result ValType, so the compiler has already
+committed to reading whatever comes back as `f64`. Refusing the unbox does not
+protect the value; it destroys it.
+
+## Fix
+
+Pass `allowProvenNumberUnbox = true` at the **return** coercion site only.
+`scalarBridgePlan` still returns `null` when `__unbox_number` is unregistered,
+so no late import is pulled and the dead-arm "no index shift" invariant
+(#2174) is preserved byte-for-byte. Argument bridges are untouched.
+
+## Falsified prior diagnosis (recorded so it is not re-derived)
+
+An earlier bisection attributed this bucket to *"an overload SET whose
+signatures disagree on the return type"*. That is refuted: deleting the overload
+signatures and keeping the identical implementation still reproduces. Measured
+ablations on this repo:
+
+| shape | wasm |
+| --- | --- |
+| `export default g;`, inferred/declared `number \| undefined` | **FAILS** (sentinel) |
+| `export default g;`, `number \| void` | **FAILS** |
+| `export default g;`, plain `number` | passes |
+| `export default g;`, `number \| null` | passes |
+| `export default g;`, `string \| undefined` | passes |
+| inline `export default function g(…)` | passes |
+| `export { g as default }` | passes |
+| named export | passes |
+
+The overloads are incidental. The trigger is: a declared/inferred return
+including `undefined`/`void` that lowers the callee's funcref to an `externref`
+result, reached through the dynamic identifier ladder with an `f64` expected
+result.
+
+## Evidence
+
+- jest dogfood suite: **299/356 → 320/356** (`stringToBytes.test.ts` 6/28 → 27/28);
+  no other file in the suite moved.
+- Regression test: `tests/issue-5328-dynamic-dispatch-extern-result.test.ts`
+  (untyped `.js`, two-file project — an annotated return routes to a different
+  arm and passes identically with and without the fix).
+
+## Blocked measurement on current `main` (#5332)
+
+Between the measurement head (`4946cf70fe`) and the PR base, an unrelated
+regression landed: `export default <identifier>;` in a multi-file project no
+longer COMPILES (`multi-prepared-module-init-census:terminal-join`, see #5332).
+That is the only shape which reproduces this defect — `export { g as default }`,
+an inline `export default function`, a named export, a factory return and a
+callback parameter were all measured and none of them reproduce — so the fix is
+correct but currently unobservable on `main`, and jest's own
+`stringToBytes.test.ts` is 0/28 there for the #5332 reason rather than 6/28.
+The regression test detects that compile error and SKIPS with a pointer to
+#5332; it starts enforcing the moment #5332 lifts.
+
+## Residuals (deliberately not in this change)
+
+- `g(0)` where the callee genuinely returns `undefined` still answers a NaN at an
+  `f64` call site: the carrier cannot represent `undefined`, and giving
+  `expectedReturn` the `undefSentinel` brand for a `T | undefined` return is a
+  much wider change. Before this fix the same site answered the *sentinel* NaN;
+  after, it answers `__unbox_number(undefined)`'s quiet NaN. Both read as
+  "not a number"; neither reads as `undefined`. The one remaining
+  `stringToBytes` failure (`expect(stringToBytes(undefined)).toBeUndefined()`)
+  is this residual and is unchanged by the fix.
+- A `boolean | undefined` return through the same ladder answers `false`
+  (`defaultValueInstrs({kind:"i32"})`), unchanged before and after — the
+  placeholder still owns the `externref → i32` row.
+- A dependency module that `throw`s inside the default-exported function
+  currently breaks the whole compiled module (measured identical before and
+  after); unrelated defect, not addressed here.

--- a/plan/issues/5332-module-init-census-export-default-identifier.md
+++ b/plan/issues/5332-module-init-census-export-default-identifier.md
@@ -1,0 +1,107 @@
+---
+id: 5332
+title: "REGRESSION on main: `export default <identifier>;` in a multi-file project fails to compile"
+status: ready
+sprint: current
+created: 2026-09-05
+updated: 2026-09-05
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Symptom (live on `main`, not introduced by any open PR)
+
+Any project of two or more files in which a **dependency** uses the
+`export default <identifier>;` statement form fails to compile outright:
+
+```
+Codegen error: multi-prepared-module-init-census:terminal-join:
+executable source ir-source:v1:0000000000000000:source:dep.js
+lost its exact module-init terminal
+```
+
+Minimal reproduction (`allowJs`, `target: "gc"`, `platform: "node"`, via
+`compileProject`):
+
+```js
+// dep.js
+function g(input) { return 42; }
+export default g;
+
+// main.js
+import g from './dep.js';
+export function a() { return g(5); }
+```
+
+Measured shapes (same harness, one run each):
+
+| shape | compiles |
+| --- | --- |
+| `export default g;` in a `.js` dep | **NO** |
+| `export default g;` in a `.ts` dep | **NO** |
+| `export default function g(…)` (inline) | yes |
+| `export function g(…)` (named) | yes |
+| `export { g as default }` | yes |
+
+The return type is irrelevant — a dep that never returns `undefined` fails
+identically.
+
+## Cost, measured
+
+jest dogfood suite, same machine, same day:
+
+- `4946cf70fe` — **299/356**; `packages/jest-config/src/__tests__/stringToBytes.test.ts` **6/28**
+- `6d0ae7531d` — **293/356**; `stringToBytes.test.ts` **0/28**, because
+  `packages/jest-config/src/stringToBytes.ts` ends in `export default stringToBytes;`
+  and the module no longer compiles at all.
+
+So this is a **−6 regression on the jest suite by itself**, and it additionally
+**masks** [#5328](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5328-dynamic-dispatch-extern-result-dropped)
+(worth a further +21 on the same file), whose only reproducing shape is exactly
+the one that now fails to compile.
+
+## Root cause — two sides disagree about what an `ExportAssignment` is
+
+- `src/ir/identity.ts` (~line 903): an `ExportAssignment` gets an
+  `addSupportUnit("export-assignment", …)` and is **NOT** pushed into
+  `modulePopulation`. A source whose only module-level work is
+  `export default g;` therefore gets **no `module-init` terminal unit**, so
+  `planning-identity.ts` never records it in `moduleInitUnitIdBySourceFile`.
+- `src/ir/module-init-plan.ts` (~line 453): every `ExportAssignment` **is**
+  pushed as an `evaluation` (`kind: "export-assignment"`), so
+  `executable = evaluations.length > 0` is **true**.
+- `src/codegen/multi-prepared-module-init-census.ts` (~line 448) then asserts
+  that an `executable` source has an exact module-init terminal, finds none, and
+  raises `terminal-join`.
+
+Introduced by the #3525 census work (`feat(ir): retain ordered multi-source
+module-init census`, commit `2c18cd7a6f`) — the invariant is new; the underlying
+disagreement between the two files is what it caught.
+
+## Two candidate fixes (not attempted here — this belongs to the #3525 lane)
+
+1. **Make the plan agree with identity.** Stop counting an `ExportAssignment` as
+   a module-init evaluation, keeping the `pushExportIntent` call that follows it.
+   Narrowest variant: only when the expression is a bare `Identifier`
+   (a hoisted-binding reference that performs no runtime work), leaving
+   `export default someCall()` alone. Risk to check: whether anything downstream
+   relies on that evaluation existing to emit the expression.
+2. **Make identity agree with the plan.** Push the `ExportAssignment` into
+   `modulePopulation` so a module-init terminal is minted. More conservative for
+   emission (it adds a unit rather than removing an evaluation), wider in its
+   effect on the unit inventory.
+
+The census's own re-check (`~line 626`) only compares `plan.unitId` against
+`moduleInitUnitIdBySourceFile` and the terminal denominator, so either
+reconciliation keeps it self-consistent; no evaluation COUNT is compared.
+
+## Related
+
+`tests/issue-5328-dynamic-dispatch-extern-result.test.ts` detects this exact
+compile error and **skips with a pointer to this issue**, so #5328's fix can
+land now and its assertions start enforcing the moment this is fixed.

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -3268,7 +3268,14 @@ export function compileIdentifierCall(
                   const bridge = dispatchBridgePlan(
                     fc.returnType!,
                     expectedReturn!,
-                    false,
+                    // (#5328) A RESULT is not an ARGUMENT: `expectedReturn` IS this
+                    // call's statically-computed result ValType, so the compiler has
+                    // already committed to reading whatever comes back as f64.
+                    // Refusing the unbox falls through to the dead-arm placeholder
+                    // below, which DROPS a live arm's result and answers the
+                    // undefined sentinel. Still null-safe: `scalarBridgePlan` gives
+                    // up when `__unbox_number` is unregistered, so no late import.
+                    true,
                     canExportCandidateReferenceResult(fc.funcTypeIdx),
                   );
                   if (bridge !== null) {

--- a/tests/issue-5328-dynamic-dispatch-extern-result.test.ts
+++ b/tests/issue-5328-dynamic-dispatch-extern-result.test.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5328 — a dynamic-dispatch arm whose funcref returns `externref` while the
+// call site expects `f64` must UNBOX the result, not discard it.
+//
+// `call-identifier.ts`'s funcref ladder gives every candidate signature its own
+// `ref.test`-guarded arm, and each arm has to leave a value of the block's
+// declared result type. When an arm's return type disagrees with that type it
+// asks `scalarBridgePlan` for a conversion; if none is available it falls back
+// to a "dead-arm placeholder" — `drop` + `defaultValueInstrs(expected)` — on the
+// theory that the arm can never actually run.
+//
+// The externref→f64 row of that planner is gated on `allowProvenNumberUnbox`,
+// which the RETURN site passed as `false`. Nothing else supplies that direction,
+// so the arm fell through to the placeholder, and for an `f64` block
+// `defaultValueInstrs` is the `0x7FF00000DEADC0DE` undefined sentinel. The arm
+// is not dead: the ladder always seeds an externref-returning ALTERNATE
+// candidate (`tryAltFuncType([{ kind: "externref" }])`), and a function whose
+// inferred return is `number | undefined` is lowered with exactly that
+// signature — so the LIVE arm called the function, threw its answer away, and
+// answered `undefined`.
+//
+// Production witness: jest's `packages/jest-config/src/stringToBytes.ts`
+// (`export default stringToBytes;`, returning `number | null | undefined`,
+// consumed through a default import). 21 of its 28 upstream unit tests read the
+// undefined sentinel instead of the computed byte count; the jest dogfood suite
+// went 299/356 → 320/356 on this change alone.
+//
+// The `allowProvenNumberUnbox` guard is right for an ARGUMENT — a declared-`any`
+// argument may really be a Boolean/Symbol/BigInt and must not be silently run
+// through the numeric ABI. It is wrong for a RESULT: `expectedReturn` IS the
+// call expression's own statically computed result ValType, so the compiler has
+// already committed to reading whatever comes back as `f64`. Refusing the unbox
+// does not protect the value, it destroys it.
+//
+// Fixtures are untyped `.js` in a two-file project on purpose. An explicit
+// return annotation, or a single-source graph, routes the call through a direct
+// arm and the test then passes identically with and without the fix.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject, type CompileResult } from "../src/index.js";
+import { buildCompiledImports } from "../src/runtime.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+async function compileFixture(files: Record<string, string>, entry: string): Promise<CompileResult> {
+  const root = mkdtempSync(join(tmpdir(), "js2-5328-"));
+  roots.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const target = join(root, name);
+    mkdirSync(join(target, ".."), { recursive: true });
+    writeFileSync(target, source);
+  }
+  return compileProject(join(root, entry), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+}
+
+async function instantiate(result: CompileResult): Promise<WebAssembly.Exports> {
+  const imports = buildCompiledImports(result, {}) as Record<string, unknown> & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports.setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (imports.__setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (instance.exports.__module_init as (() => void) | undefined)?.();
+  return instance.exports;
+}
+
+// `export default <identifier>` — the STATEMENT form, not the inline
+// `export default function` — is what puts the call site on the dynamic ladder:
+// the binding reaches the importer as a closure wrapper rather than a direct
+// call target. `export { g as default }` and a named export both keep the direct
+// lowering and never reproduced.
+const DEP_NUMBER = `
+function g(input) {
+  if (input === 0) return undefined;
+  return 42;
+}
+export default g;
+`;
+
+// Twin whose inferred return is \`string | undefined\`. The ladder's expected
+// result is then externref, the seeded alternate matches exactly, and no bridge
+// is consulted — a preserved-behaviour anchor for the arm this change touches.
+const DEP_STRING = `
+function label(input) {
+  if (input === undefined) return undefined;
+  return 'n' + input;
+}
+export default label;
+`;
+
+const ENTRY = `
+import g from './dep.js';
+import label from './dep-str.js';
+
+export function literalArg() { return g(5); }
+export function throughLocal() { const r = g(5); return r; }
+export function forwardedParam(v) { return g(v); }
+export function inArithmetic() { return g(5) + 1; }
+export function undefinedResult() { return g(0); }
+export function stringTwin() { return label(7); }
+`;
+
+// (#5332) `export default <identifier>;` in a two-file project does not COMPILE
+// on `main` right now — `buildIrModuleInitPlan` counts an `ExportAssignment` as
+// module-init work while `identity.ts` mints no module-init terminal for one, so
+// the census invariant hard-errors with
+// `multi-prepared-module-init-census:terminal-join`. That is a separate, live
+// regression (it also costs jest's `stringToBytes.test.ts` all 28 of its tests
+// on `main` today), and it MASKS the defect this file is about: the shape that
+// reproduces #5328 is exactly the shape #5332 refuses to compile. Every
+// alternative spelling measured — `export { g as default }`, an inline
+// `export default function`, a named export, a factory return, a callback
+// parameter — takes a different arm and never reproduced, so there is no
+// unblocked fixture to substitute.
+//
+// So: skip loudly while #5332 is live, and assert for real the moment it lifts.
+// A skip that names its blocker is honest; a green test that silently stopped
+// exercising anything is not.
+const CENSUS_BLOCKER = "multi-prepared-module-init-census";
+
+function blockedByCensusRegression(result: CompileResult): boolean {
+  return (
+    result.success === false && (result.errors ?? []).some((error) => String(error.message).includes(CENSUS_BLOCKER))
+  );
+}
+
+describe("#5328 dynamic-dispatch arm returning externref into an f64 call site", () => {
+  it("answers the callee's value instead of the undefined sentinel", async (ctx) => {
+    const result = await compileFixture(
+      { "dep.js": DEP_NUMBER, "dep-str.js": DEP_STRING, "main.js": ENTRY },
+      "main.js",
+    );
+    if (blockedByCensusRegression(result)) ctx.skip(`blocked by #5332 (${CENSUS_BLOCKER})`);
+    expect(result.success).toBe(true);
+    const exports = await instantiate(result);
+
+    // Every one of these answered the undefined sentinel before the fix.
+    expect((exports.literalArg as () => number)()).toBe(42);
+    expect((exports.throughLocal as () => number)()).toBe(42);
+    expect((exports.forwardedParam as (v: number) => number)(5)).toBe(42);
+    expect((exports.inArithmetic as () => number)()).toBe(43);
+  });
+
+  it("leaves the genuinely-undefined result and the externref twin unchanged", async (ctx) => {
+    const result = await compileFixture(
+      { "dep.js": DEP_NUMBER, "dep-str.js": DEP_STRING, "main.js": ENTRY },
+      "main.js",
+    );
+    if (blockedByCensusRegression(result)) ctx.skip(`blocked by #5332 (${CENSUS_BLOCKER})`);
+    expect(result.success).toBe(true);
+    const exports = await instantiate(result);
+
+    // DOCUMENTED RESIDUAL, asserted so it cannot move silently. The callee
+    // really returns `undefined` here, and the `f64` carrier at this call site
+    // cannot represent that. Measured NaN before the fix (the
+    // `0x7FF00000DEADC0DE` sentinel) and NaN after it
+    // (`__unbox_number(undefined)`'s quiet NaN) — both read as "not a number",
+    // neither reads as `undefined`. Giving `expectedReturn` the `undefSentinel`
+    // brand for a `T | undefined` return is the real fix and is much wider than
+    // this change.
+    expect((exports.undefinedResult as () => number)()).toBeNaN();
+    // Preserved: the `string | undefined` twin already took a matching arm.
+    expect((exports.stringTwin as () => string)()).toBe("n7");
+  });
+});


### PR DESCRIPTION
Closes [#5328](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5328-dynamic-dispatch-extern-result-dropped).

A call through the identifier funcref ladder whose **expected result is `f64`** and whose **live arm's funcref returns `externref`** discarded the callee's answer and substituted the `0x7FF00000DEADC0DE` undefined sentinel. Every such call read `NaN`/`undefined` while the callee had computed the right value.

Production witness: jest's `packages/jest-config/src/stringToBytes.ts` (`export default stringToBytes;`, inferred return `number | null | undefined`, consumed through a default import). 21 of its 28 upstream unit tests read the sentinel instead of the byte count.

## Root cause

The ladder builds one `ref.test`-guarded arm per candidate signature; each arm must leave a value of the block's declared result type. When an arm's return type disagrees it consults `scalarBridgePlan`, and on `null` falls back to a **dead-arm placeholder** — `drop` + `defaultValueInstrs(expectedReturn)` — justified by "a signature-divergent arm can never actually run".

`scalarBridgePlan`'s `externref → f64` row is gated on `allowProvenNumberUnbox`, which the **return** site passed as `false`, and nothing else supplies that direction. But the arm is **not** dead: the ladder unconditionally seeds an externref-returning alternate candidate whenever the expected result is not already externref, and a function whose inferred return is `number | undefined` is lowered with exactly that signature. So the live arm called the function, dropped its answer, and returned `undefined`.

The guard is right for an **argument** — a declared-`any` argument may really be a Boolean/Symbol/BigInt and must not be silently run through the numeric ABI. It is wrong for a **result**: `expectedReturn` *is* this call expression's statically computed result ValType, so the compiler has already committed to reading whatever comes back as `f64`. Refusing the unbox does not protect the value; it destroys it.

## Change

One token at the return coercion site (`false` → `true`), plus the comment explaining why the argument-side guard does not apply. `scalarBridgePlan` still returns `null` when `__unbox_number` is unregistered, so no late import is pulled and the dead-arm "no index shift" invariant (#2174) holds byte-for-byte. Argument bridges are untouched.

## A prior diagnosis this refutes

An earlier bisection attributed this bucket to "an overload SET whose signatures disagree on the return type". Deleting the overloads and keeping the identical implementation still reproduces, so that is not the trigger; the issue file records the full ablation table.

## Blocked measurement on current `main` — please read

Between the measurement head (`4946cf70fe`) and this PR's base an unrelated
regression landed: `export default <identifier>;` in a multi-file project no
longer COMPILES at all
(`multi-prepared-module-init-census:terminal-join`). Filed as
[#5332](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5332-module-init-census-export-default-identifier),
whose issue file is included here because this PR's test points at it. #5332
costs the jest suite 6 tests by itself (`stringToBytes.test.ts` 6/28 -> 0/28 on
current main) and MASKS this fix, because the shape that reproduces #5328 is
exactly the shape #5332 refuses to compile. Every alternative spelling was
measured — `export { g as default }`, inline `export default function`, a named
export, a factory return, a callback parameter — and none of them reproduce, so
there is no unblocked fixture to substitute.

The regression test therefore DETECTS that compile error and skips with a
pointer to #5332, and starts enforcing the moment #5332 lifts. Reviewers who
want to see the fix work can check out `4946cf70fe`, apply this diff, and run
`node --import tsx tests/dogfood/jest-upstream-suite.mjs` — 299/356 -> 320/356.

## Evidence

- jest dogfood suite **299/356 → 320/356**; `stringToBytes.test.ts` 6/28 → 27/28 and no other file in the suite moved.
- `tests/issue-5328-dynamic-dispatch-extern-result.test.ts` — **1 failed / 1 passed → 2 passed**. Untyped `.js` in a two-file project on purpose: an explicit return annotation routes the call through a direct arm and the test then passes identically with and without the fix.
- 17-package dogfood A/B at one head (webpack, three, clsx, cookie, lodash, redux, axios, stylelint, tailwindcss, jsdom, styled-components, uuid, marked, moment, prettier, jest, hono): see the PR comment — no package regressed.
- Budget/ratchet gates green. The +7 lines are the comment on a one-token change, granted in the issue file's frontmatter with a dated rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
