### PR TITLE
docs(#5334): the "jest.fn() callback" illegal cast is a rest-param metadata gap ✓

### DIFF
--- a/plan/issues/5334-rest-param-wrapper-metadata-illegal-cast.md
+++ b/plan/issues/5334-rest-param-wrapper-metadata-illegal-cast.md
@@ -1,0 +1,132 @@
+---
+id: 5334
+title: "Rest-param function value reached through a fixed-arity callable param casts arg0 to the rest vec (illegal cast)"
+status: ready
+sprint: current
+created: 2026-09-05
+updated: 2026-09-05
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Symptom
+
+`RuntimeError: illegal cast` at runtime. In the jest dogfood suite this is
+`jest-watcher/src/lib/__tests__/prompt.test.ts` (0/4) and two of
+`jest-matcher-utils/src/__tests__/Replaceable.test.ts` — **6 tests**. The
+original triage described it as "a `jest.fn()` mock passed as a callback into
+compiled library code"; that is a symptom, not the mechanism. `jest.fn()` is not
+a host object here — the dogfood shim's `vi.fn()` returns a **compiled**
+`function spy(...args) { … }`, and the rest parameter is the whole story.
+
+## Reduction (no jest, no mocks)
+
+```ts
+function spy(...args: any[]): void {}
+
+class Box {
+  private _v = "x";
+  private _n = -1;
+  private _cb: () => void;
+  constructor() { this._cb = () => {}; }
+  enter(onChange: (pattern: string, options: { max: number; offset: number }) => void): void {
+    this._v = "";
+    this._cb = () => onChange(this._v, { max: 10, offset: this._n });
+    this._cb();
+  }
+}
+new Box().enter(spy);        // RuntimeError: illegal cast
+```
+
+Controls, measured on the same harness: an arity-2 arrow, an arity-0 arrow and a
+plain non-rest function expression in the same slot are all clean. Only the
+callback slot whose value is a REST function traps, and only that slot (a rest
+function in `onSuccess`/`onCancel` — never invoked with 2 args — is clean).
+
+## Mechanism
+
+From the emitted WAT, the arm that runs is:
+
+```wat
+local.get <self>
+local.get <arg0-as-externref>     ;; this._v — a STRING
+any.convert_extern
+ref.cast null (ref null $__vec_externref)   ;; <-- traps
+local.get <funcref>
+ref.cast (ref $spyType)
+call_ref $spyType
+```
+
+so the single trailing **vec** formal of `spy` is being marshalled as an
+ordinary positional parameter, and argument 0 is cast straight to it.
+
+Why: the ladder in `src/codegen/expressions/call-identifier.ts` decides
+rest-ness from `info.hasRestParam` (falling back to
+`ctx.__restFuncTypeIdxs`). An instrumented dump of the candidate scan for this
+fixture shows `spy`'s record as
+
+```
+info.funcTypeIdx=27 struct=26 params=[{"kind":"ref_null","typeIdx":2}] rest=false infoRest=undefined
+```
+
+— `hasRestParam` is **absent**. `src/codegen/closures/funcref-as-closure.ts`
+does set it (it reads the source declaration), but that path does not run for a
+top-level function used as a value: the wrapper comes from
+`ensureFuncValueWrappersRegistered` via `getOrCreateFuncRefWrapperTypes` /
+`getOrCreateConstructibleFuncRefWrapperTypes`
+(`src/codegen/closures/funcref-wrapper-types.ts`), and **neither constructs
+`hasRestParam`**.
+
+With `hasRestParam` false, `fixedParamCount` becomes 1, the scan compares
+`sigParamWasmTypes[0]` (`externref`, because `pattern: string` lowers to
+externref) against the vec formal, and `scalarBridgePlan`'s "erased generic ref
+carrier" row admits it with `any.convert_extern` + `ref.cast`. That row exists
+for a genuinely erased type parameter whose runtime value IS the carrier; here
+the value is a string and the cast is a guaranteed trap on a LIVE arm.
+
+`ctx.__restFuncTypeIdxs` — the registry the ladder reads at
+`call-identifier.ts:2352` to recover rest-ness — has **no writer anywhere in the
+tree**. The escape hatch exists but was never wired.
+
+## Why this is not a two-line fix
+
+Marking rest-ness on the wrapper is ambiguous, and the ambiguity is real:
+`function spy(...args: any[])` and `function g(xs: any[])` lower to the SAME
+funcref type, and when both are captureless declarations they share the same
+wrapper struct too. A `funcTypeIdx`-level "this is rest" flag would make the
+dispatcher pack arguments into a fresh vec for the genuine array-parameter
+callee as well — silently wrong in the other direction. #4616 met the same
+ambiguity in `calls.ts` and answered it by keeping a separate rest arm guarded
+on the CONCRETE struct type; that guard does not separate these two.
+
+## Proposed design (runtime disambiguation, no metadata needed)
+
+Make the argument bridge decide at runtime instead of guessing at compile time:
+`ref.test` the incoming value against the vec carrier and
+
+- on a **hit**, pass it through — the fixed reading, which is what a real
+  `g(xs)` call site produces;
+- on a **miss**, pack every call argument into a fresh vec — the rest reading.
+
+Both readings then get their correct answer, and no arm can trap. The cost is a
+guarded branch on an arm that today is one unconditional `ref.cast`.
+
+## Notes for whoever takes this
+
+- The whole bridge family is HOST-lane only (`scalarBridgePlan` returns null
+  under `standalone`/`wasi`), so the change cannot affect standalone.
+- Two adjacent shapes fail differently and are probably the same root cause seen
+  through a different arm: a rest function expression, and a nested function
+  returned from a factory, both answer
+  `TypeError: Cannot access property on null or undefined` rather than trapping.
+- `jest-jasmine2/src/__tests__/queueRunner.test.ts` (6 more tests) is blocked
+  behind a **host-callback** failure of the same family —
+  `TypeError: Cannot convert object to primitive value` out of
+  `invokeNativeFunctionCallback` — after
+  [#5329](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5329-tuple-rest-carrier)
+  made its module valid. Worth re-checking once this lands.


### PR DESCRIPTION
Files [#5334](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5334-rest-param-wrapper-metadata-illegal-cast). **Diagnosis only — no code change.**

This is the jest bucket that was described as *"a `jest.fn()` mock passed as a callback into compiled library code"* (`prompt.test.ts` 0/4 plus two `Replaceable` tests — 6 tests). That description is a symptom. `jest.fn()` is not a host object in the dogfood harness: the shim's `vi.fn()` returns a **compiled** `function spy(...args) { … }`, and the **rest parameter** is the whole story.

Reduced to no jest and no mocks:

```ts
function spy(...args: any[]): void {}
// …a class field arrow that calls a `(pattern: string, options: {…}) => void`
// parameter with two arguments, given `spy` as that parameter.
new Box().enter(spy);   // RuntimeError: illegal cast
```

An arity-2 arrow, an arity-0 arrow and a plain non-rest function expression in the same slot are all clean.

**Mechanism**, from the WAT plus an instrumented dump of the candidate scan: `spy`'s `ClosureInfo` reaches the identifier ladder with `hasRestParam` **absent**, because `ensureFuncValueWrappersRegistered` builds the wrapper through `getOrCreate(Constructible)FuncRefWrapperTypes` and neither of those carries the flag (only `funcref-as-closure.ts` sets it, and that path does not run for a top-level function used as a value). The ladder therefore treats the single trailing **vec** formal as an ordinary parameter, and `scalarBridgePlan`'s "erased generic ref carrier" row emits `any.convert_extern` + `ref.cast null (ref null $__vec_externref)` on argument 0 — a string. That is a guaranteed trap on a live arm.

`ctx.__restFuncTypeIdxs`, the registry the ladder reads at `call-identifier.ts:2352` to recover rest-ness, has **no writer anywhere in the tree**. The escape hatch exists but was never wired.

**Why I did not fix it here.** Rest-ness is genuinely ambiguous on a signature-SHARED wrapper: `function spy(...args: any[])` and `function g(xs: any[])` lower to the same funcref type, and for captureless declarations to the same struct type too, so a `funcTypeIdx`-level flag would make the dispatcher pack arguments for the real array-parameter callee as well — wrong in the other direction. #4616 met the same ambiguity in `calls.ts` and answered it with a rest arm guarded on the concrete struct type; that guard does not separate these two. The issue proposes a **runtime-disambiguating bridge** instead — `ref.test` the value against the vec carrier, pass it through on a hit, pack every argument into a fresh vec on a miss — which needs no metadata and cannot trap either way.

Worth 6 jest tests directly, and worth re-checking `queueRunner.test.ts`'s remaining 6 afterwards: with [#5329](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5329-tuple-rest-carrier) making its module valid, its failure moved to a host-callback `TypeError: Cannot convert object to primitive value` out of `invokeNativeFunctionCallback` — plausibly the same family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
