### PR TITLE
fix(#5337): reproduce the iOS AST-panel failure, and make the boundary state visible

### DIFF
--- a/plan/issues/5337-jsc-host-callback-export-wiring.md
+++ b/plan/issues/5337-jsc-host-callback-export-wiring.md
@@ -1,0 +1,123 @@
+---
+id: 5337
+title: "Compiled modules break on JavaScriptCore: host-callback dispatch finds no exports"
+status: in-progress
+sprint: current
+created: 2026-09-05
+updated: 2026-09-05
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: runtime
+goal: correctness
+---
+
+## Problem
+
+On iOS Safari (JavaScriptCore) the playground's AST panel fails where Chrome and
+Node succeed. Two console lines, from the deployed build:
+
+```
+[Error]   TypeError: wasm closure dispatcher __call_fn_0 is not available
+[Warning] Since Acorn 8.0.0, options.ecmaVersion is required.
+          Defaulting to 2020, but this will stop working in the future.
+```
+
+Both come from inside the compiled module's host boundary, and together they say
+the same thing twice:
+
+1. **The warning is acorn's own.** Compiled acorn could not read `ecmaVersion`
+   off the options object the host passed to `parse(src, opts)` — the object
+   crossed the boundary, but its properties read as absent. Everything after
+   that runs on default options, which is how the user-visible
+   `Cannot read properties of null (reading 'replace')` arises: that message is
+   **ours**, thrown by `src/runtime.ts:14068` in `__extern_method_call` when a
+   compiled method call has a null receiver. The most likely site is acorn's
+   `keywordRegexp(words)` (`dist/acorn.mjs:279`), whose keyword-table lookup is
+   indexed by `options.ecmaVersion` / `options.sourceType`.
+2. **`__call_fn_0 is not available`** is thrown by `src/runtime.ts:2365` when
+   `callbackState.getExports()?.__call_fn_0` is not a function.
+
+So a compiled module that takes a host object or host callback misbehaves under
+JSC. The AST panel is the first consumer to surface it; it is not a panel bug.
+
+## What is already ruled out
+
+- **The export is present.** `website/public/acorn/acorn.wasm` exports 611
+  symbols including `__call_fn_0..4` and `__call_fn_method_0..8`. The dispatcher
+  exists; the *lookup* failed, i.e. `getExports()` returned undefined or a
+  partial set at call time.
+- **Not the js-string-builtins fallback.** Safari has no `js-string` builtins, so
+  `instantiateWasm` takes its polyfill branch. Simulated exactly (rejecting the
+  3-argument `WebAssembly.instantiate` so the real `instantiateWasm` falls back):
+  `nativeBuiltins: false`, and `parse` returned a correct 18-node Program. The
+  branch itself is sound under V8.
+- **Not the parse input.** Fixed separately (PR #5603): the panel used to feed
+  acorn the generated `example.js` usage-example tab. It now feeds the user's own
+  source with TS syntax blanked in place, verified in Chrome.
+- **Not a stale deployment.** Pages deploys #7880/#7881 (2026-09-05 17:55 and
+  18:50 UTC) succeeded on revisions containing the fix.
+
+## Reproduced under V8 — the symptom class is "export set never published"
+
+An instance whose exports are never published (`setInstance` not called) does
+**not** fail loudly. It parses anyway, wrongly:
+
+```
+Since Acorn 8.0.0, options.ecmaVersion is required.
+Defaulting to 2020, but this will stop working in the future.
+unwired instance: THREW — Cannot read properties of null (reading 'replace')
+second wired instance: parse OK — 18 nodes
+```
+
+That is both iOS symptoms, verbatim, on Node/V8 — no WebKit needed. So the
+mechanism is established: **the module could not see its own export set at call
+time.** Property reads on a host object and closure dispatch both route through
+exports-backed marshalling, which is why the options object reads as empty AND
+`__call_fn_0` is unavailable.
+
+What is *not* yet established is why publishing fails on JSC specifically.
+`setInstance` throws on a non-instance rather than no-opping
+(`src/runtime/instance-lifecycle-adapter.ts:67`), and the panel would have
+surfaced that, so the plausible remainder is `prepareExports` establishing only
+a partial set under JSC, or a second instantiation attempt (Safari's failed
+native-`js-string` attempt precedes the polyfill fallback) leaving the runtime's
+per-closure caches bound to the first, dead instance.
+
+No WebKit engine is reachable from the dev container: Playwright's webkit
+download fails and `js2wasm.loopdive.com` is proxy-blocked (403). Fixing the
+wiring blind would touch a path every compiled-module consumer depends on, so
+the next step is one iOS screenshot with the diagnostics below, not a patch.
+
+## Acceptance criteria
+
+1. The failing call is identified: which value reaches `__extern_method_call`
+   as null, and why `getExports()` is empty at the `__call_fn_0` dispatch.
+2. Reading a property off a host-supplied plain object from inside a compiled
+   module returns the same value on JSC as on V8.
+3. A regression test covers the host-object property read and the zero-arg
+   callback dispatch, at a level that would have caught this without a browser
+   (see "Open question" below — a V8-only test did not catch it, so a test that
+   only runs under V8 may not be sufficient).
+
+## Plan
+
+1. **Done — canary + diagnostics.** The panel now proves the boundary at load
+   with a one-token parse (`parse("0")` must round-trip `0`). When it fails, the
+   status says the boundary is not live and the error is a symptom, not the
+   user's source; any non-syntax parse error also reports which instantiation
+   branch ran, whether `setInstance` was wired, and the export count.
+   `tests/playground-acorn-artifact.test.ts` pins the unwired reproduction.
+2. **Next — one iOS screenshot** of the AST tab with the new build. Its status
+   line distinguishes: boundary not live (wiring) vs. live-but-throwing
+   (something else), plus branch/export facts.
+3. Root-cause from that report; fix in `src/runtime.ts`; regression test.
+
+## Open question
+
+Whether other compiled-module consumers are affected on JSC — the playground's
+own compile-and-run path passes DOM callbacks across the same boundary, so the
+`calendar.ts` preview may fail on iOS for the same reason. Worth checking once
+the mechanism is known.

--- a/tests/playground-acorn-artifact.test.ts
+++ b/tests/playground-acorn-artifact.test.ts
@@ -105,3 +105,47 @@ describe("playground AST explorer — committed acorn.wasm artifact", () => {
     expect(() => compiled.parse("function (", PARSE_OPTIONS)).toThrow(/./);
   }, 120_000);
 });
+
+// (#5337) The failure reported from iOS Safari, reproduced under V8.
+//
+// An instance whose export set was never published (`setInstance` not called)
+// does NOT fail loudly. It parses anyway — wrongly: the module cannot read the
+// host options object, acorn falls back to its defaults (warning "Since Acorn
+// 8.0.0, options.ecmaVersion is required"), and then dies inside its keyword
+// table with "Cannot read properties of null (reading 'replace')" — thrown by
+// the runtime's own `__extern_method_call` guard, which is why the message
+// carries V8 wording on every engine.
+//
+// This is what the panel's load-time canary detects. The test pins the symptom
+// so a future fix that makes the unwired case loud is recognised as a change,
+// not a surprise.
+describe("#5337 — unwired host boundary degrades silently", () => {
+  it("parses with default options and then throws deep inside, instead of failing loudly", async () => {
+    const bytes = readFileSync(WASM_PATH);
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf-8"));
+
+    const imports = buildCompiledAdapterImports(manifest);
+    const { instance } = await instantiateWasm(
+      bytes,
+      imports.env,
+      imports.string_constants,
+      imports.string_constants16,
+    );
+    // Deliberately NOT calling imports.setInstance(instance).
+    const exports = wrapExports(instance, {
+      signatures: manifest.exportSignatures,
+      boundaryPolicies: manifest.exportBoundaries,
+    }) as { parse: (src: string, opts: typeof PARSE_OPTIONS) => any };
+
+    expect(typeof exports.parse).toBe("function");
+    expect(() => exports.parse(SAMPLE, PARSE_OPTIONS)).toThrow(/Cannot read properties of null/);
+  }, 120_000);
+
+  it("a wired instance parses the same input correctly", async () => {
+    const compiled = await loadCompiledAcorn();
+    // The canary the panel runs at load: a one-token parse must round-trip.
+    const canary = compiled.parse("0", PARSE_OPTIONS);
+    expect(canary.body[0].expression.value).toBe(0);
+    expect(compiled.parse(SAMPLE, PARSE_OPTIONS).type).toBe("Program");
+  }, 120_000);
+});

--- a/website/playground/ast-explorer.ts
+++ b/website/playground/ast-explorer.ts
@@ -115,6 +115,11 @@ export class AstExplorer {
    */
   showsEditorSource = true;
 
+  /** Host-boundary facts captured at load; surfaced only on a parse failure. */
+  private boundary: { nativeBuiltins: boolean; setInstance: boolean; exportCount: number } | null = null;
+  /** Did a known-good one-token parse round-trip at load? See the canary in `load`. */
+  private boundaryLive = true;
+
   private pendingSource: { code: string; mapsToEditor: boolean } | null = null;
   private lastRendered: { code: string; kind: AstSourceKind; options: AcornOptions } | null = null;
 
@@ -196,7 +201,7 @@ export class AstExplorer {
       ]);
 
       const imports = buildCompiledAdapterImports(manifest);
-      const { instance } = await instantiateWasm(
+      const { instance, nativeBuiltins } = await instantiateWasm(
         bytes,
         imports.env,
         imports.string_constants,
@@ -204,7 +209,22 @@ export class AstExplorer {
       );
       // Exports-backed capabilities (closure wrapping, struct reads) need the
       // instance handed back before anything is called.
+      const wired = typeof imports.setInstance === "function";
       imports.setInstance?.(instance);
+
+      // (#5337) Keep what the host boundary was actually given. On
+      // JavaScriptCore a parse fails with `__call_fn_0 is not available` and
+      // acorn's own "ecmaVersion is required" warning — i.e. the module could
+      // read neither the options object nor its own exports — while the same
+      // build is fine under V8. These three facts separate the candidate
+      // mechanisms (which instantiation branch ran, whether the export set was
+      // published, how large it is), and they are the ones no stack trace
+      // carries. Reported only when a parse throws.
+      this.boundary = {
+        nativeBuiltins,
+        setInstance: wired,
+        exportCount: Object.keys(instance.exports).length,
+      };
 
       const exports = wrapExports(instance, {
         signatures: manifest.exportSignatures,
@@ -215,6 +235,25 @@ export class AstExplorer {
       }
       this.parse = exports.parse as (src: string, opts: AcornOptions) => AstNode;
       this.meta = meta;
+
+      // (#5337) Canary: prove the host boundary is live before the panel trusts
+      // it. An instance whose export set was never published parses ANYWAY, but
+      // wrongly — it cannot read the options object, so acorn falls back to its
+      // defaults and then dies deep inside on a null keyword table. Reproduced
+      // under V8 by skipping `setInstance`: acorn warns "ecmaVersion is
+      // required" and throws "Cannot read properties of null (reading
+      // 'replace')" — the exact pair reported from iOS Safari. Checking a
+      // one-token parse here turns that into a statement about the boundary
+      // instead of a confusing error about the user's source.
+      try {
+        const canary = this.parse("0", { ecmaVersion: 2022, sourceType: "module" }) as {
+          body?: { expression?: { value?: unknown } }[];
+        };
+        this.boundaryLive = canary.body?.[0]?.expression?.value === 0;
+      } catch {
+        this.boundaryLive = false;
+      }
+
       this.setStatus("", "info");
     })();
 
@@ -270,7 +309,23 @@ export class AstExplorer {
       this.lastRendered = null;
       this.treeEl.replaceChildren();
       const message = error instanceof Error ? error.message : String(error);
-      this.setStatus(`Parse error: ${message}`, "error");
+      // A genuine SyntaxError from acorn is about the SOURCE and needs no
+      // machine details; anything else came out of the host boundary, and there
+      // the boundary facts are the whole diagnosis (#5337).
+      const isSyntax = error instanceof Error && error.name === "SyntaxError";
+      const b = this.boundary;
+      const detail =
+        isSyntax || !b
+          ? ""
+          : ` — [${b.nativeBuiltins ? "native js-string" : "js-string polyfill"}, ` +
+            `setInstance ${b.setInstance ? "ok" : "MISSING"}, ${b.exportCount} exports]`;
+      this.setStatus(
+        this.boundaryLive
+          ? `Parse error: ${message}${detail}`
+          : `The compiled parser loaded but its host boundary is not live, so it cannot read ` +
+              `parse options — the error below is a symptom, not your source. ${message}${detail}`,
+        "error",
+      );
       this.renderHeader(null);
       return false;
     }


### PR DESCRIPTION
## Description

Issue: [#5337](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5337-jsc-host-callback-export-wiring)

iOS Safari reported two console lines the AST panel could not explain:

```
TypeError: wasm closure dispatcher __call_fn_0 is not available
Since Acorn 8.0.0, options.ecmaVersion is required. Defaulting to 2020…
```

The second is **acorn's own** warning: compiled acorn could not read `ecmaVersion` off the options object the host passed it. The first is **ours** (`src/runtime.ts:2365`), thrown when `callbackState.getExports()?.__call_fn_0` is not a function. So is the user-visible `Cannot read properties of null (reading 'replace')` (`src/runtime.ts:14068`) — which is why it carries V8 wording on every engine, and why it was never evidence of a stale bundle.

### Reproduced under V8 — no WebKit needed

An instance whose export set is never published (`setInstance` not called) does **not** fail loudly. It parses anyway, wrongly:

```
Since Acorn 8.0.0, options.ecmaVersion is required.
Defaulting to 2020, but this will stop working in the future.
unwired instance: THREW — Cannot read properties of null (reading 'replace')
second wired instance: parse OK — 18 nodes
```

Both iOS symptoms, verbatim. The mechanism is therefore established: **the module could not see its own export set at call time.** Host-object property reads and closure dispatch both route through exports-backed marshalling, which is why the options object read as empty *and* `__call_fn_0` was unavailable.

### What this PR deliberately does not do

It does not patch the wiring. What remains unknown is why publishing fails on JavaScriptCore specifically, and no WebKit is reachable from the dev container (Playwright's webkit download fails; the site is proxy-blocked with 403). This path is one every compiled-module consumer depends on — a blind fix there is the expensive kind.

### What it does

- **Load-time canary** in the panel: `parse("0")` must round-trip `0`. When it does not, the status says the boundary is not live and the error shown is a symptom rather than the user's source — instead of a null-deref that reads like a parser bug.
- **Non-syntax parse errors** now also report which instantiation branch ran (native js-string vs polyfill), whether `setInstance` was wired, and the export count. Those three facts separate the remaining candidate mechanisms and are what no stack trace carries. Syntax errors stay clean.
- `tests/playground-acorn-artifact.test.ts` pins the unwired reproduction *and* the canary, so a future fix that makes this case loud registers as a change rather than a surprise.

### Also ruled out (recorded in the issue)

| Hypothesis | Verdict |
|---|---|
| `__call_fn_0` missing from the artifact | No — 611 exports incl. `__call_fn_0..4`, `__call_fn_method_0..8`. The *lookup* failed. |
| js-string polyfill branch broken | No — simulated by rejecting the builtins form of `WebAssembly.instantiate`: `nativeBuiltins: false`, 18-node parse. |
| Stale deployment | No — Pages deploys #7880/#7881 succeeded on revisions containing the earlier fix. |
| The parse input (fixed in #5603) | Separate bug, already fixed and verified in Chrome. |

### Verification

Chrome path unchanged: `calendar.ts` still renders 1556 nodes in ~450 ms as "types erased in place", hover still highlights `body[0]: FunctionDeclaration 328–460` in the editor. 5 tests green. Gates green locally: LOC / function / coercion-sites, `check:oracle-ratchet`, `check:dead-exports`, `check:issues`, `biome lint`, `build:playground`.

### Next step

One iOS screenshot of the AST tab on this build. Its status line distinguishes *boundary not live* (wiring) from *live but throwing* (something else), with the branch and export facts attached.

### Note on the issue id

`#5337` was reserved via `claim-issue.mjs --allocate --allow-unscanned`; `gh` is unavailable in this container so the open-PR scan degraded. The id is verified against `origin/issue-assignments` and `main`, but not against in-flight PRs — the `check:issue-ids:against-main` gate is the backstop.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: agreeing to a legal document is the author's call, not the agent's. `cla-check` passes as "not required (allowlist)" on this branch. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tg5GRG1rv2KSSuTfddsXPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg5GRG1rv2KSSuTfddsXPZ)_