### PR TITLE
docs(issues): file #5352/#5353 + implementation plans for #5250/#5251 — Temporal completion fan-out

### DIFF
--- a/plan/issues/5250-temporal-error-semantics-mismatches.md
+++ b/plan/issues/5250-temporal-error-semantics-mismatches.md
@@ -40,6 +40,25 @@ check misfires (plausibly the same undefined-vs-missing-property distinction
 as the #5221/#5243 record-nulling family); (2) a calendar-dispatch path where
 the non-ISO branch is not taken compiled, so the ISO validator runs instead.
 
+## Implementation Plan (Fable, 2026-09-05)
+
+1. `PlainYearMonth.prototype.until()` missing args: node throws
+   `TypeError: Either month or monthCode are required`; the compiled build
+   throws RangeError first. Probe `Temporal.PlainYearMonth.from({year:2000,
+   month:1}).until()` compiled vs node; capture the compiled stack. Likely
+   root: the polyfill's argument-shape check reads `undefined` vs
+   missing-property differently through a bridged record (#5243 lineage —
+   `buildRecordFromExternref` may materialise absent fields as present
+   `undefined`, so `"month" in obj` answers true). Fix at the record bridge
+   (presence must survive), not in the polyfill.
+2. Non-ISO `yearOfWeek` returns `undefined` in node; compiled throws
+   `RangeError: Invalid ISO date`. Probe which branch runs: the polyfill
+   dispatches on calendar id; if the ISO validator runs for a non-ISO
+   calendar, an open-receiver call may be statically bound (#5352) — check
+   after #5352 lands before fixing anything here.
+3. Reductions in `tests/issue-5250-*.test.ts`, base-failing; both named
+   test262 rows pass with the provider linked.
+
 ## Acceptance criteria
 
 1. Base-failing reductions for both (compiled vs node on the pinned

--- a/plan/issues/5251-temporal-numeric-calendar-seam-families.md
+++ b/plan/issues/5251-temporal-numeric-calendar-seam-families.md
@@ -23,9 +23,11 @@ and the already-filed #5221/#5243 (destructure-null, 74) and #5223-adjacent
 | sampled rows | error shape | first suspicion |
 | --- | --- | --- |
 | 43 | `invalid number value` | a numeric coercion at a provider seam produces a value the polyfill's own validator rejects (NaN/undefined where an integer is expected) |
-| 29 | `HebrewHelper` illegal cast (`ref.cast` failure) | non-ISO calendar helper subclass object crosses a seam and loses its concrete struct type |
+| 29 → 120 | `HebrewHelper` illegal cast | **SUPERSEDED by #5352** (2026-09-05): measured on all 123 #5249 rows, every non-Hebrew calendar is statically bound into `HebrewHelper_maximumMonthLength` — a dispatch defect, not a seam one |
 | 11 | JSBI `toNumber` seam | the compiled polyfill's BigInt shim (`jsbi@4.3.0`) mis-converts at a linked-module boundary |
 | 10 | `year/eraYear is required` | era/eraYear property reads return undefined on objects that carry them — likely the #5225 decoder-provenance family's write/read twin (#5246 covers write paths) |
+
+| 3 | `RangeError: Invalid monthCode: M13 in ti()` | (added 2026-09-05, PR #5577 measurement) 13-month calendars (Ethiopic/Coptic) — a month-code seam; probe after #5352 lands, it may be the same static-bind route |
 
 ## Bounds
 
@@ -35,6 +37,19 @@ and the already-filed #5221/#5243 (destructure-null, 74) and #5223-adjacent
   provider-seam value/type fidelity, the #5225/#5243/#5246 lineage). Probe
   before splitting: a fix PR should re-measure the sampled bucket and report
   which families moved.
+
+## Implementation Plan (Fable, 2026-09-05)
+
+Blocked on #5352 for the calendar rows. Sequence: (1) after #5352 lands,
+re-run the #5249 `family-123.txt` list and the 838-row census sample; (2) for
+each surviving family write ONE 3-line compiled probe with node-on-polyfill as
+control; (3) `invalid number value` — capture the exact value crossing the
+seam (`typeof`, `Number.isInteger`) at the provider boundary, expect an
+externref-boxed f64 read back as NaN/undefined; (4) JSBI `toNumber` — check
+`jsbi@4.3.0`'s `toNumber` on a linked-module BigInt (i64 vs boxed) crossing;
+(5) `year/eraYear is required` — read-path twin of #5246, verify the
+`__struct_field_names` provenance from the MINTING module. Each family: fix
+with base-failing test, or attribute to a filed issue with the probe.
 
 ## Direction
 

--- a/plan/issues/5352-open-receiver-static-bind-on-cascade-bailout.md
+++ b/plan/issues/5352-open-receiver-static-bind-on-cascade-bailout.md
@@ -1,0 +1,104 @@
+---
+id: 5352
+title: "Open-receiver `this.m()` statically binds to candidates[0] when the tag-cascade emitter bails — routes every non-Hebrew Temporal calendar into HebrewHelper (120 of 123 rows)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+reasoning_effort: max
+requested_by: ttraenkler/fable-lead
+created: 2026-09-05
+---
+
+# #5352 — open-receiver dispatch binds statically to `candidates[0]` on cascade bail-out
+
+## Problem
+
+For an OPEN-receiver call — `this.m(...)` where the receiver's class declares no
+`m`, so every implementation lives below it — `call-receiver-method.ts` collects
+the descendant candidates (#5249 widened this to the full descendant set) and,
+when there is more than one, asks `emitVirtualMethodDispatchByTag`
+(`src/codegen/expressions/virtual-dispatch.ts`) for a `__tag` cascade. That
+emitter has NINE transactional bail-outs (`return undefined`). When any fires,
+the caller falls through with `funcIdx = candidates[0].funcIdx` and emits a
+**direct static call to the first declarer** — for every receiver, whatever its
+runtime type.
+
+Measured (PR #5577, all 123 rows of the #5249 family, provider linked): **120 of
+123 rows** share ONE chain —
+`HelperBase_calendarToIsoDate → HelperBase_regulateMonthDayNaive →
+HebrewHelper_maximumMonthLength → HebrewHelper_minMaxMonthLength` — for
+Japanese, Gregory, Roc, Coptic, Ethiopic, Buddhist and Islamic calendar rows
+alike. `HebrewHelper` is `candidates[0]` (first declarer in `classParentMap`
+order); its body then reads `this.months` on a non-Hebrew receiver and traps
+`illegal cast`. The `illegal cast` is the symptom; the static bind is the
+defect. This supersedes the "HebrewHelper illegal cast" row of #5251.
+
+## Implementation Plan (Fable, 2026-09-05)
+
+**Step 1 — identify WHICH bail-out fires for `this.maximumMonthLength(e)`.**
+Instrument (a `.tmp/` probe, or a temporary `JS2WASM_DEBUG_VDISPATCH` env log)
+the nine `return undefined` sites in `emitVirtualMethodDispatchByTag`, build
+the provider, and record the site. Candidates, most to least likely:
+- L152 `unified === undefined` — result-type unification across candidates
+  fails. The polyfill's `maximumMonthLength` bodies return `30` (numeric),
+  `12===t?29:t<=6?31:30` (numeric), `this.getMonthInfo(e).length` (any) and
+  Hebrew's `this.minMaxMonthLength(e,"max")` (any) — mixed f64 / externref.
+- L39 receiver not `ref`/`ref_null`; L216 `!recvIsClassStruct`.
+- L18 first candidate has no param types; L82/L99 param-type gaps.
+State the answer with the probe output in the PR.
+
+**Step 2 — make the fallback SOUND.** Whatever the bail-out, a static bind to
+`candidates[0]` is wrong for `candidates.length > 1`. Two acceptable shapes,
+pick by what Step 1 says and measure both if cheap:
+- (a) *Fix the bail-out* so the cascade emits — for L152, unify to `externref`
+  (box numerics) when candidate result types disagree; the cascade's arms each
+  box on their own path. This keeps the dispatch in-Wasm.
+- (b) *Route the bail-out to the dynamic method path* — when
+  `virtualCandidates.length > 1 && vresult === undefined`, do NOT keep
+  `funcIdx = candidates[0]`; clear it so the call falls to the existing
+  dynamic/host method-call path (`__extern_method_call` family), which resolves
+  by runtime type. Verify that path actually handles a compiled-class receiver
+  here (it does for #5243's `dateAdd` route) and does not just re-trap.
+Either way: the `candidates.length === 1` collapse to a direct call stays ONLY
+when the receiver's static class has no other descendants (a single declarer
+with sibling subtrees is the same unsoundness); otherwise it needs a 1-arm
+cascade with a sound terminal.
+
+**Step 3 — terminal `else`.** The cascade's terminal is `unreachable`. With
+#5249 every descendant has an arm, so it is reachable only for an instance of
+the abstract base itself; leave it, but if (b) is chosen, the terminal for a
+1-arm cascade must be the dynamic path, not `unreachable`.
+
+**Step 4 — reduce + test.** `tests/issue-5352-*.test.ts`: a hierarchy whose
+declarers return DIFFERENT types (numeric vs object) so the cascade bails
+today; assert each subclass dispatches to its own body and a non-declaring
+sibling does not reach a declarer's body. Base-failing on main.
+
+**Step 5 — measure.** Re-run the #5249 `family-123.txt` list (worktree
+`issue-5249-fix/.tmp/family-123.txt`, or regenerate from the census) with the
+provider linked: report pass/fail and the new top reasons. Expect the 120
+`HebrewHelper_minMaxMonthLength` rows to move; state how many turn green and
+what the next layer is. Also re-run `tests/issue-5249-*`, the 8 dispatch
+suites and the 9 provider suites (list in PR #5577), equivalence gate at
+24/1718.
+
+**Order-preservation constraint.** `candidates[0]` is the emitter's result
+schema; changing candidate ORDER is out of scope — change what happens when
+the emitter declines.
+
+## Acceptance criteria
+
+1. Step 1 answered with evidence (which bail-out, why).
+2. Base-failing reduction; no static bind to `candidates[0]` for any open
+   receiver with >1 candidate.
+3. 123-row family re-measured; the 120-row Hebrew chain gone; new counts and
+   next-layer reasons stated. Gates + suites green; equivalence at baseline.
+
+## Notes
+
+- Filed from PR #5577's "follow-up this exposes"; supersedes the Hebrew
+  illegal-cast row of #5251.
+- Id reserved via `claim-issue --allocate` with a degraded open-PR scan;
+  open PRs checked by hand 2026-09-05.

--- a/plan/issues/5353-test262-sharded-lane-temporal-provider.md
+++ b/plan/issues/5353-test262-sharded-lane-temporal-provider.md
@@ -1,0 +1,63 @@
+---
+id: 5353
+title: "Wire the SHARDED test262 CI lane to the compile-once Temporal provider so the published conformance number includes Temporal"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+goal: dogfood
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-09-05
+---
+
+# #5353 — Temporal provider in the sharded CI lane
+
+## Problem
+
+#5248 (PR #5375) wired the IN-PROCESS test262 runner to the provider; the
+sampled Temporal bucket went 81 → 262 pass. It deliberately left the SHARDED
+CI lane (`scripts/test262-worker.mjs`, `test262-sharded.yml`) unwired, so the
+published number (`benchmarks/results/test262-current.json`, ~35,497 today)
+does not include a single Temporal gain, and no merge-group regression gate
+sees Temporal rows. Two blockers were named:
+1. the compiler bundle the shards run does not re-export
+   `buildTemporalProvider`;
+2. the cold provider build (~52–65 s) exceeds the vitest fork pool's 30 s
+   kill, so a SHARD cannot build it — the shard PARENT must pre-warm the cache.
+
+## Implementation Plan (Fable, 2026-09-05)
+
+1. **Bundle export.** Add `buildTemporalProvider` (and whatever
+   `scripts/test262-import-object.mjs`'s `linkedModules` path needs) to the
+   compiler bundle's public surface; confirm `dist/` carries it.
+2. **Pre-warm in the shard parent.** In `test262-sharded.yml` (and the local
+   `test:262` path), build the provider ONCE before the fork pool starts —
+   `JS2WASM_TEMPORAL_CACHE` pointed at a workspace dir — so every shard hits
+   `cacheHit=true` (~1 s). Cache the artifact across CI runs keyed on
+   compiler ABI + polyfill source (the existing content-addressed key).
+3. **Worker wiring.** `scripts/test262-worker.mjs` passes `linkedModules` to
+   `instantiateTest262Module` under the same path-OR-`features:` gate the
+   in-process runner uses; default ON in CI, `JS2WASM_TEST262_TEMPORAL=0`
+   opt-out kept.
+4. **Baseline validator parity.** `scripts/validate-test262-baseline.ts`
+   currently defaults the provider OFF to avoid phantom drift; once the
+   sharded baseline is produced WITH the provider, flip its default to match
+   (same PR, or the validator strands PRs UNSTABLE — #3878/#3904).
+5. **Land order + measurement.** This PR's merge group will show the Temporal
+   bucket's flips against the current baseline: expect large gains and the
+   10 wrong-reason-pass regressions #5375 triaged. Cite that triage; do NOT
+   add an accepted-regressions mechanism. Report the new published number.
+
+## Acceptance criteria
+
+1. Merge-group shards run Temporal rows with the provider; `Temporal is not
+   defined` = 0 in the merged report.
+2. Published conformance number moves; the delta is stated with the #5375
+   triage cited for the known 10.
+3. Per-shard cost measured (instantiate ms) and stated; no shard timeouts.
+
+## Notes
+
+- Filed from #5248's "Not done" bounds (PR #5375). Lane A (CI/infra).
+- Id reserved via `claim-issue --allocate` with a degraded open-PR scan.


### PR DESCRIPTION
Specs and plans for the remaining Temporal work, grounded in PR #5577's full 123-row measurement.

- [#5352](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5352-open-receiver-static-bind-on-cascade-bailout) — **new, the single root behind 120 of 123 rows.** When `emitVirtualMethodDispatchByTag` takes one of its nine bail-outs, an open-receiver `this.m()` falls through to a direct static call to `candidates[0]` — so every non-Hebrew calendar (Japanese, Gregory, Roc, Coptic, Islamic…) is routed into `HebrewHelper_maximumMonthLength`, whose body then traps `illegal cast` on `this.months`. Plan: identify the bail-out with evidence, then either unify result types so the cascade emits or route the bail-out to the dynamic method path — never a static bind for >1 candidate. Supersedes #5251's Hebrew row.
- [#5353](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5353-test262-sharded-lane-temporal-provider) — **new.** Wire the SHARDED CI lane to the provider (bundle re-export + shard-parent cache pre-warm + worker `linkedModules` + validator parity), so the published conformance number finally includes Temporal. From #5248's not-done bounds.
- [#5250](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5250-temporal-error-semantics-mismatches) — implementation plan added (record-bridge presence for the `until()` TypeError; `yearOfWeek` gated on #5352).
- [#5251](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5251-temporal-numeric-calendar-seam-families) — Hebrew row marked superseded, `monthCode: M13` (3 rows) added, per-family probe plan added; blocked on #5352 for the calendar rows.

Ids 5352/5353 reserved via `claim-issue --allocate` (degraded open-PR scan; open PRs checked by hand). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_