### PR TITLE
fix(#5342): a host builtin in an object-literal callable property no longer traps ✓

### DIFF
--- a/plan/issues/5342-lodash-residual-nine.md
+++ b/plan/issues/5342-lodash-residual-nine.md
@@ -1,10 +1,11 @@
 ---
 id: 5342
 title: "lodash residual: the last 9 of 62 — two traps, two Symbol-keyed nulls, two deepEqual misses — never investigated"
-status: ready
+status: done
+completed: 2026-09-06
 sprint: current
 created: 2026-09-05
-updated: 2026-09-05
+updated: 2026-09-06
 priority: medium
 horizon: m
 feasibility: medium
@@ -75,3 +76,229 @@ Two of these are recognisable on sight:
 
 Model: **opus**. Nine unexamined failures with at least four distinct
 mechanisms; needs diagnosis before any fix.
+
+## Outcome
+
+**lodash 53/62 → 58/62** on `upstream/main` `01ce47aba7`. Four residuals
+remain, all newly diagnosed and all distinct from the six fixed here (see
+"Residuals" below).
+
+The spec's grouping was WRONG on two of its three named mechanisms, and the
+correction is the useful part of this write-up:
+
+| spec said | actually was |
+| --- | --- |
+| 2 × trap: "check the #5320/#5323/#5333 capture-cell family" | Not capture cells at all. A **host builtin stored in an object-literal callable property**; the dispatcher guard-casts it to the closure-wrapper root, the cast nulls, and `struct.get` on that null traps. |
+| 2 × `object:null !== string:Symbol(a)`: "a Symbol reaching a string-typed slot and dropping to null" | The `null` had nothing to do with symbols. EVERY `_.toString(x)` answered `null`, including `_.toString('x')` — the property is named `toString`, whose field carries `eqref`, a carrier the callable-property dispatcher did not admit. The Symbol part is a SEPARATE defect that only became visible once the null was gone. |
+| 1 × `object:null != string:-0,-0,0,0`: "`-0` in `f64 → string` / `join` / `Object.is`" | Same `eqref` defect. `-0` handling is fine: with the carrier admitted, `_.toString([-0, Object(-0), 0, Object(0)])` returns `'-0,-0,0,0'` with no `-0`-specific change. |
+| 2 × `deepEqual object != object` | One (`_.toString` nullish values) was the same `eqref` defect. The other (`_.toArray` iterables) is unrelated and still open. |
+
+Reduction harness: `.tmp/l5342/probe.mjs` + per-cause case files, each run with
+a deliberately-false control test that must fail in BOTH lanes (it did, in
+every run quoted below).
+
+## Cause A — host builtin in an object-literal callable property (2 tests)
+
+`_.isArray([1,2,3])` where `isArray` is lodash's published
+`var isArray = Array.isArray; module.exports = isArray` trapped with
+`RuntimeError: dereferencing a null pointer`. Minimal repro, no lodash:
+
+```js
+var o = { f: Array.isArray };
+o.f([1, 2, 3]);        // trap
+```
+
+`compileCallablePropertyCall`'s externref branch does
+`any.convert_extern` + `emitGuardedRefCast(root)`. For a genuine host function
+the `ref.test` fails, so the cast yields `ref.null`, and `emitNullCheckThrow`
+deliberately rethrows ONLY when the PRE-cast value was nullish (#789 — a wrong
+struct type is meant to fall through to a multi-struct dispatch). A live host
+function is not nullish, so the null cast reached `struct.get` and trapped.
+Because a wasm trap is not catchable, the whole lodash test file died at that
+point.
+
+The remedy already existed: `callablePropertyIsExtractedHostBuiltin` routes
+such values to the host method bridge, and its own comment describes exactly
+this trap. It proved only one shape — a shorthand whose value is a binding
+element of `const { isArray } = Array`. It could not see lodash's shape because
+`valueDeclarationOf` stops at the import clause. The predicate now follows
+import aliases (new oracle query `aliasedValueDeclarationOf`) and
+single-initializer hops, admits a plain `PropertyAssignment` initializer, and
+accepts an ambient (`.d.ts`) binding, which covers `parseInt` / `isNaN` /
+`Math.max` / `Object.keys` as well. The whole proof moved out of
+`calls-closures.ts` into the subsystem module
+`src/codegen/expressions/callable-property-host-value.ts` — a god-file
+allowance was available and deliberately not taken; the move leaves
+`calls-closures.ts` 83 lines SMALLER than before this change.
+
+Probe `.tmp/l5342/c2-hostfn.mjs`, 11 rows + control: **4/12 → 11/12 wasm**
+(the 12th is the control, which fails in both lanes by construction).
+
+**Why static and not a runtime fallback.** The general question ("is this
+externref a wasm closure?") is a runtime one, and #4618 established the runtime
+answer for the `__call_fn_N` dispatchers. Doing the same here means wrapping
+the whole dispatch — inline ladder AND the shared `__call_cprop_deferred_N`
+helper, whose ABI passes only the already-cast root and so has no access to the
+raw externref — in a runtime branch, on the hottest object-literal call path in
+the compiler. The declaration-proven route is byte-identical for every shape it
+does not claim, and it reuses a bridge that was already proven for
+`Array.isArray`. The residual (a host function that arrives dynamically, e.g.
+through a parameter) is recorded below.
+
+## Cause B — own `toString` / `valueOf` property answered `null` (4 tests)
+
+```js
+const _ = { toString: fn };
+_.toString('x');       // null, silently
+```
+
+`{ toString: fn }` types that one field **`eqref`** on purpose (#4394) so the
+ToPrimitive dispatchers can `ref.test` the stored closure without an externref
+round-trip. `compileCallablePropertyCall` admitted `externref`, `ref` and
+`ref_null` — not `eqref` — so every arm of the method-call ladder declined and
+the call fell through to `calls.ts`'s graceful tail: compile the callee, `drop`,
+push `ref.null.extern`. Green compile, no diagnostic, wrong answer.
+
+Measured (`.tmp/l5342/c5-namecheck.mjs`): `toString` and `valueOf` answered
+`null`; `toStr` and `toLocaleString` — same function value, different name —
+were correct. That name-dependence is the tell, and it is the field CARRIER,
+not an Object.prototype interception.
+
+The fix admits `eqref` into the same branch and skips only the
+`any.convert_extern` the externref carrier needs (an `eqref` already IS a
+WasmGC ref, so `emitGuardedRefCast` takes it directly).
+
+lodash effect: 54 → 56, and it is what made the two symbol failures legible —
+they had been masked by the same `null`.
+
+## Cause C — the capability-probe idiom bound `null` (2 tests)
+
+```js
+var Symbol = typeof globalThis.Symbol === 'function' ? globalThis.Symbol : undefined;
+var symbol = Symbol ? Symbol('a') : undefined;
+```
+
+Two independent defects compose; **either one alone leaves the idiom wrong**,
+which is why they ship together.
+
+**C1 — `globalThis.Symbol` read the module global it was defining.** The #4500
+Slice A arm answers `globalThis.<name>` / `this.<name>` from `<name>`'s wasm
+module global. That is right for SCRIPT goal (§9.1.1.4.18 CreateGlobalVarBinding
+makes a script's top-level `var` a property of the global object) and wrong for
+a MODULE (§16.2.1.6.4 puts it in the module environment record, creating no
+global-object property). `receiverIsRealmGlobalObject` refuses a shadowed
+`globalThis` but never checked module-ness. The emitted `__module_init` was
+literally:
+
+```wat
+i32.const 1                 ;; typeof globalThis.Symbol === "function" — folded TRUE
+(if (result externref)
+  (then global.get 10)      ;; <-- the not-yet-initialised `Symbol` global itself
+  (else call $__get_undefined))
+global.set 10               ;; Symbol = null
+```
+
+so the shadow bound `null`, stayed falsy for the rest of the module, and
+poisoned every later read off it. The gate is now script-goal only, judged on
+the RECEIVER's own source file (not `ctx.sourceIsModule`, which multi-file
+linking sets unconditionally) and honouring `inferModuleStrictArguments ===
+false`, because the test262 harness's synthetic `export function test()` wrapper
+marks genuinely script-goal sources as modules and Slice A's own witnesses
+(`var p1 = 7; this.p1`) are script tests. Applied to all four Slice A arms — dot
+read, bracket read, nullish-comparison read, and the bracket WRITE — because
+that file's own header records that a half-fixed read/write pair is worse than
+neither half.
+
+**C2 — the ternary join dropped the symbol brand.** `compileSymbolCall` returns
+the js-host symbol id as a bare `i32` on purpose (#4626: branding it globally
+routed mid-emission coercions through a late `__box_symbol` import whose index
+shift corrupted baked `ref.func` operands — 216 regressions). Joining `symbol`
+with `undefined` coerces that `i32` to `externref`, and unbranded it took
+`__box_number` while the `symbol`-typed sink unboxed with `__unbox_symbol`,
+which answers 0 for a JS number — hence `Symbol(wasm_0)`. The brand is
+re-attached at the JOIN only. That site is already prepared for a
+coercion-time late import: both arms are parked in `fctx.savedBodies` precisely
+so the shift walker sees them, and the file says so.
+
+lodash effect: 56 → 58.
+
+## Residuals (not fixed here, each a distinct new cause)
+
+1. **`_.constant`** — `expected truthy; got false`. `constant.call({})` /
+   identity of the captured object across `lodashStable.map` over a sparse
+   `Array(2).concat(...)`.
+2. **`_.isArray(args)`** — the `arguments` object answers `true`. The compiled
+   `arguments` carrier is materialised as a real array at the host boundary.
+   (Newly visible: this test used to trap before cause A.)
+3. **`_.isBoolean(_)`** — assertion 6 answers `true` for a plain object.
+   lodash's `baseGetTag` goes through `getRawTag`, which writes and deletes
+   `Symbol.toStringTag` on the receiver.
+4. **`_.toArray(object)`** with `object[Symbol.iterator] = arrayProto[Symbol.iterator]`.
+5. **Own `hasOwnProperty` property** — `{ hasOwnProperty: fn }` then
+   `o.hasOwnProperty('x')` still reaches the Object.prototype host import and
+   answers `false` instead of calling the own function. Same family as cause B
+   but a different mechanism (interception, not carrier); no lodash test needs
+   it.
+6. **Host function reaching a callable property dynamically** (via a parameter
+   or a later write) still traps — cause A's declaration-proven route cannot
+   see it. The runtime fallback sketched above is the fix when a case appears.
+7. **`symbol | undefined` has no `undefined` in the `i32` symbol carrier.** A
+   local of that declared type round-trips `externref → __unbox_symbol → i32`,
+   and the false arm lands on id 0. Pre-existing; cause C2 changes how it
+   RENDERS (`"0"` → `"Symbol(wasm_0)"`), not whether it is wrong. Not reached by
+   lodash, which only takes the true arm.
+
+## Evidence
+
+Base: `upstream/main` `01ce47aba75222b98484d4beea3ebde0d93577ca`
+(`git merge-base --is-ancestor 68e1c0c2cb HEAD` → yes; tree clean at every
+measurement).
+
+**Regression tests** — untyped `.js` two-file fixtures, each with an
+anti-vacuity control, run at one head both ways:
+
+| lane | result |
+| --- | --- |
+| parent (`01ce47ab`, all fixes reverted by file copy) | **3 failed / 1 passed** — cause A `dereferencing a null pointer`; cause B `expected null to be 'v:x'`; cause C `expected +0 to be 1` |
+| with the fixes | **3 files / 4 tests passed** |
+
+The one test that passes on BOTH lanes is deliberate: it is the #4500
+script-goal preservation control (`var p1 = 7; globalThis.p1 === 7` in a
+sloppy script), i.e. the behaviour cause C must NOT take away.
+
+**A/B, one head, 17 suites, one suite at a time, per test file:**
+
+```
+  webpack            base 16/16       new 16/16        delta 0
+  three              base 17/18       new 17/18        delta 0
+  clsx               base 32/32       new 32/32        delta 0
+  cookie             base 63740/63740 new 63740/63740  delta 0
++ lodash             base 53/62       new 58/62        delta +5
+  redux              base 64/82       new 64/82        delta 0
+  axios              base 200/231     new 200/231      delta 0
+  stylelint          base 108/108     new 108/108      delta 0
+  tailwindcss        base 13/13       new 13/13        delta 0
+  jsdom              base 6/6         new 6/6          delta 0
+  styled-components  base 9/9         new 9/9          delta 0
+  uuid               base 75/75       new 75/75        delta 0
+  marked             base 9/30        new 9/30         delta 0
+  moment             base 10/10       new 10/10        delta 0
+  prettier           base 101/151     new 101/151      delta 0
+  jest               base 329/356     new 329/356      delta 0
+  hono               base 244/324     new 244/324      delta 0
+
+net wasmPassed delta = +5; individually REGRESSED tests = 0
+test files that moved: lodash/test.js  (pass 53→58, fail 9→4)
+```
+
+Every anchor in #5338 reproduced exactly. Both lanes exited 0 on all 17.
+
+The god-file extraction (cause A's proof into its own module) happened AFTER
+that A/B, so it was separately proven byte-neutral: four repro inputs covering
+all three causes compile to byte-identical wasm before and after the move
+(`4/4` sha256 match), and lodash re-measured 58/62 at the shipped head.
+
+Gates at the shipped head: `check-loc-budget` OK · `check-func-budget` OK ·
+`check-coercion-sites` OK · `check:oracle-ratchet` OK (+0/+0) ·
+`check:dead-exports` OK · `check:dogfood-validation` OK (6/6 compiled,
+6/6 validated).

--- a/src/checker/inhouse-oracle.ts
+++ b/src/checker/inhouse-oracle.ts
@@ -125,6 +125,14 @@ export class InHouseOracle implements TypeOracle {
     return binding.valueDeclaration ?? binding.declarations[0];
   }
 
+  aliasedValueDeclarationOf(id: ts.Node): ts.Declaration | undefined {
+    // The in-house binder resolves within a file and has no cross-module alias
+    // graph, so an imported name answers with its own import declaration. That
+    // is the same answer `valueDeclarationOf` gives; callers must treat a
+    // non-followed alias as "unknown", never as "not a host value".
+    return this.valueDeclarationOf(id);
+  }
+
   variableDeclarationOf(id: ts.Node): ts.VariableDeclaration | undefined {
     const decl = this.valueDeclarationOf(id);
     if (!decl || !ts.isVariableDeclaration(decl) || !ts.isIdentifier(decl.name)) return undefined;

--- a/src/checker/oracle-backend.ts
+++ b/src/checker/oracle-backend.ts
@@ -322,6 +322,10 @@ export class DifferentialOracle implements TypeOracle {
     return this.compare("valueDeclarationOf", id, (o) => o.valueDeclarationOf(id), describeOptionalNode);
   }
 
+  aliasedValueDeclarationOf(id: ts.Node): ts.Declaration | undefined {
+    return this.compare("aliasedValueDeclarationOf", id, (o) => o.aliasedValueDeclarationOf(id), describeOptionalNode);
+  }
+
   declarationsOf(node: ts.Node): readonly ts.Declaration[] {
     return this.compare(
       "declarationsOf",

--- a/src/checker/oracle.ts
+++ b/src/checker/oracle.ts
@@ -149,6 +149,16 @@ export interface TypeOracle {
    * boundary without exposing the checker Symbol.
    */
   valueDeclarationOf(id: ts.Node): ts.Declaration | undefined;
+  /**
+   * Value declaration for an identifier binding, resolved THROUGH import
+   * aliases. `valueDeclarationOf` stops at the `import` clause/specifier that
+   * introduced the name, which hides what the imported module actually binds;
+   * this variant follows the alias to the declaration the exporting module
+   * wrote (`var isArray = Array.isArray` behind `import isArray from
+   * "lodash/isArray.js"`). Non-alias bindings answer exactly as
+   * `valueDeclarationOf` does.
+   */
+  aliasedValueDeclarationOf(id: ts.Node): ts.Declaration | undefined;
   /** All declarations for an exact binding, without exposing its Symbol. */
   declarationsOf(node: ts.Node): readonly ts.Declaration[];
   /**
@@ -434,6 +444,25 @@ export class TsCheckerOracle implements TypeOracle {
             ).getShorthandAssignmentValueSymbol?.(id.parent)
           : this.checker.getSymbolAtLocation(id);
       return sym?.valueDeclaration ?? sym?.declarations?.[0];
+    } catch {
+      return undefined;
+    }
+  }
+
+  aliasedValueDeclarationOf(id: ts.Node): ts.Declaration | undefined {
+    try {
+      if (!ts.isIdentifier(id)) return undefined;
+      const sym =
+        id.parent && ts.isShorthandPropertyAssignment(id.parent) && id.parent.name === id
+          ? (
+              this.checker as unknown as {
+                getShorthandAssignmentValueSymbol?: (node: ts.Node) => ts.Symbol | undefined;
+              }
+            ).getShorthandAssignmentValueSymbol?.(id.parent)
+          : this.checker.getSymbolAtLocation(id);
+      if (sym === undefined) return undefined;
+      const resolved = (sym.flags & ts.SymbolFlags.Alias) !== 0 ? this.checker.getAliasedSymbol(sym) : sym;
+      return resolved?.valueDeclaration ?? resolved?.declarations?.[0];
     } catch {
       return undefined;
     }

--- a/src/codegen/expressions/callable-property-host-value.ts
+++ b/src/codegen/expressions/callable-property-host-value.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Declaration-proof that a closed object's callable property holds a HOST
+ * function value rather than a compiled Wasm closure.
+ *
+ * Why this proof has to exist at all: the field's runtime carrier is
+ * `externref` either way, and `compileCallablePropertyCall` reads a callable
+ * `externref` field by `any.convert_extern` + a guarded cast to the closure
+ * wrapper root. For a genuine host function that `ref.test` fails, so the cast
+ * yields `ref.null` — and `emitNullCheckThrow` deliberately rethrows ONLY when
+ * the value was nullish BEFORE the cast (#789: a wrong struct type is meant to
+ * fall through to a multi-struct dispatch). A live host function is not
+ * nullish, so the null cast reaches `struct.get` and the module TRAPS with
+ * "dereferencing a null pointer". A wasm trap is not catchable by wasm
+ * exception handling, so it takes the whole calling program with it.
+ *
+ * A proven host value is therefore routed to the ordinary host method bridge
+ * (`emitWrapperDynamicMethodCall`) instead, which also materializes Wasm array
+ * arguments for native observers such as `Array.isArray`.
+ *
+ * (#5342) The proof used to admit exactly ONE shape — a shorthand whose value
+ * is a binding element of `const { isArray } = Array`. Published packages
+ * mostly do not look like that. lodash ships
+ * `var isArray = Array.isArray; module.exports = isArray`, the consumer writes
+ * `import isArray from 'lodash/isArray.js'` and `const _ = { …, isArray, … }`,
+ * and `valueDeclarationOf` stops at the import clause — so `_.isArray([1,2,3])`
+ * trapped and killed lodash's whole test file. The walk below follows import
+ * aliases and single-initializer hops, accepts a plain `PropertyAssignment`
+ * initializer, and accepts an ambient (`.d.ts`) binding, which additionally
+ * covers `{ f: parseInt }`, `{ f: isNaN }`, `{ f: Math.max }` and
+ * `{ f: Object.keys }` — every one of which trapped identically.
+ *
+ * Deliberately NOT a runtime test. "Is this externref a wasm closure?" is a
+ * runtime question and #4618 answers it that way for the `__call_fn_N`
+ * dispatchers, but doing so here means wrapping the entire callable-property
+ * dispatch — the inline funcref ladder AND the shared
+ * `__call_cprop_deferred_N` helper, whose ABI passes only the already-cast
+ * root and so cannot see the raw externref — in a runtime branch on the
+ * hottest object-literal call path. A declaration proof is byte-identical for
+ * every shape it does not claim. A host function that arrives dynamically
+ * (through a parameter, or a later write) is the residual, recorded in #5342.
+ */
+import { ts } from "../../ts-api.js";
+import type { CodegenContext } from "../context/types.js";
+import { BUILTIN_CLASS_NAMES } from "./builtin-class-names.js";
+
+/** Alias/initializer hops walked before the proof gives up. */
+const HOST_VALUE_ALIAS_DEPTH = 8;
+
+function stripParens(expr: ts.Expression): ts.Expression {
+  let node = expr;
+  while (ts.isParenthesizedExpression(node)) node = node.expression;
+  return node;
+}
+
+/** A name whose every declaration is ambient (`lib.d.ts`) is a host binding. */
+function bindingIsAmbient(ctx: CodegenContext, id: ts.Identifier): boolean {
+  const decls = ctx.oracle.declarationsOf(id);
+  return decls.length > 0 && decls.every((decl) => decl.getSourceFile().isDeclarationFile);
+}
+
+/**
+ * True when `expr` provably evaluates to a host function value — a member of a
+ * builtin class (`Array.isArray`, `Math.max`) or an ambient global binding
+ * (`parseInt`) — rather than to a compiled Wasm closure.
+ */
+function resolvesToHostFunctionValue(ctx: CodegenContext, expr: ts.Expression, depth = 0): boolean {
+  if (depth > HOST_VALUE_ALIAS_DEPTH) return false;
+  const node = stripParens(expr);
+
+  if (ts.isPropertyAccessExpression(node)) {
+    let root = stripParens(node.expression);
+    while (ts.isPropertyAccessExpression(root)) root = stripParens(root.expression);
+    if (ts.isIdentifier(root) && (BUILTIN_CLASS_NAMES.has(root.text) || ctx.declaredGlobals.has(root.text)))
+      return true;
+    return !ts.isPrivateIdentifier(node.name) && bindingIsAmbient(ctx, node.name);
+  }
+  if (!ts.isIdentifier(node)) return false;
+  // A shorthand's own name resolves to the object-literal property, so only a
+  // non-shorthand position can answer "ambient" here.
+  const shorthand =
+    node.parent !== undefined && ts.isShorthandPropertyAssignment(node.parent) && node.parent.name === node;
+  if (!shorthand && bindingIsAmbient(ctx, node)) return true;
+
+  const valueDecl = ctx.oracle.aliasedValueDeclarationOf(node) ?? ctx.oracle.valueDeclarationOf(node);
+  if (!valueDecl) return false;
+
+  // `const { isArray } = Array;`
+  if (ts.isBindingElement(valueDecl) && ts.isObjectBindingPattern(valueDecl.parent)) {
+    const variableDecl = valueDecl.parent.parent;
+    if (!ts.isVariableDeclaration(variableDecl) || !variableDecl.initializer) return false;
+    const source = stripParens(variableDecl.initializer);
+    return ts.isIdentifier(source) && (BUILTIN_CLASS_NAMES.has(source.text) || ctx.declaredGlobals.has(source.text));
+  }
+  // `var isArray = Array.isArray;` — including the alias target of an import.
+  if (ts.isVariableDeclaration(valueDecl) && valueDecl.initializer !== undefined) {
+    return resolvesToHostFunctionValue(ctx, valueDecl.initializer, depth + 1);
+  }
+  return valueDecl.getSourceFile().isDeclarationFile && !ts.isVariableDeclaration(valueDecl);
+}
+
+/**
+ * True when the callable property named by `propAccess` is declaration-proven
+ * to hold a host builtin, so the caller must route the call through the host
+ * method bridge instead of the typed closure-wrapper path.
+ */
+export function callablePropertyIsExtractedHostBuiltin(
+  ctx: CodegenContext,
+  propAccess: ts.PropertyAccessExpression,
+): boolean {
+  for (const decl of ctx.oracle.declarationsOf(propAccess.name)) {
+    if (ts.isShorthandPropertyAssignment(decl)) {
+      if (resolvesToHostFunctionValue(ctx, decl.name)) return true;
+    } else if (ts.isPropertyAssignment(decl) && !ts.isPrivateIdentifier(decl.name)) {
+      if (resolvesToHostFunctionValue(ctx, decl.initializer)) return true;
+    }
+  }
+  return false;
+}

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -10,7 +10,7 @@
 import { ts } from "../../ts-api.js";
 import { isVoidType, isPromiseType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
-import { BUILTIN_CLASS_NAMES } from "./builtin-class-names.js";
+import { callablePropertyIsExtractedHostBuiltin } from "./callable-property-host-value.js"; // (#5342)
 import {
   getClosureFuncSelfTypeIdx,
   getFuncRefWrapperRootTypeIdx,
@@ -167,33 +167,6 @@ function callablePropertyRefBridge(ctx: CodegenContext, from: ValType, to: ValTy
 
 /** `fillApplyClosure` only emits dynamic method dispatchers for arities 0..8. */
 const REALM_DYNAMIC_CALL_MAX_ARITY = 8;
-
-/**
- * True when a closed object's callable property is a shorthand reference to a
- * function extracted from a host builtin, for example:
- *
- *   const { isArray } = Array;
- *   export default { isArray };
- *
- * The field contains a genuine host function externref, not a compiled Wasm
- * closure. Calling it through the typed closure-wrapper path null-casts the
- * value and traps. Keep these declaration-proven values on the ordinary host
- * method bridge, which also materializes Wasm array arguments for native
- * `Array.isArray` and similar observers.
- */
-function callablePropertyIsExtractedHostBuiltin(ctx: CodegenContext, propAccess: ts.PropertyAccessExpression): boolean {
-  const propertyDecl = ctx.oracle.declarationsOf(propAccess.name).find(ts.isShorthandPropertyAssignment);
-  if (!propertyDecl || !ts.isShorthandPropertyAssignment(propertyDecl)) return false;
-
-  const valueDecl = ctx.oracle.valueDeclarationOf(propertyDecl.name);
-  if (!valueDecl || !ts.isBindingElement(valueDecl) || !ts.isObjectBindingPattern(valueDecl.parent)) return false;
-
-  const variableDecl = valueDecl.parent.parent;
-  if (!ts.isVariableDeclaration(variableDecl) || !variableDecl.initializer) return false;
-  let source = variableDecl.initializer;
-  while (ts.isParenthesizedExpression(source)) source = source.expression;
-  return ts.isIdentifier(source) && (BUILTIN_CLASS_NAMES.has(source.text) || ctx.declaredGlobals.has(source.text));
-}
 
 /**
  * True when a callable property comes from a function-declaration shorthand

--- a/tests/issue-5342-object-literal-host-builtin-property.test.ts
+++ b/tests/issue-5342-object-literal-host-builtin-property.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5342 cause A — a HOST builtin stored in an object literal's callable
+// property trapped when called as a method:
+//
+//   const _ = { isArray };          // isArray === Array.isArray
+//   _.isArray([1, 2, 3]);           // RuntimeError: dereferencing a null pointer
+//
+// The field's carrier is `externref` and the callable-property dispatcher
+// guard-casts it to the closure-wrapper root. For a genuine host function that
+// cast yields null, and `emitNullCheckThrow` deliberately rethrows ONLY when
+// the PRE-cast value was nullish (#789 — a wrong struct type is meant to fall
+// through to a multi-struct dispatch). A live host function is not nullish, so
+// the null cast reached `struct.get` and trapped. A wasm trap is not catchable,
+// so the whole test file died.
+//
+// `callablePropertyIsExtractedHostBuiltin` already existed for exactly this
+// defect but proved only ONE shape — a shorthand whose value is a binding
+// element of `const { isArray } = Array`. lodash publishes
+// `var isArray = Array.isArray; module.exports = isArray` and the adapter
+// imports it, which that predicate could not see: it stops at the import
+// clause. The proof now follows import aliases and single-initializer hops,
+// and admits a plain `PropertyAssignment` initializer as well.
+//
+// Fixtures are untyped `.js` in a two-file project because that is the shape
+// the defect arrives in — a published CommonJS/ESM re-export of a builtin,
+// consumed through an object literal in another file.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as joinPath } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject, type CompileResult } from "../src/index.js";
+import { buildCompiledImports } from "../src/runtime.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+async function compileFixture(files: Record<string, string>, entry: string): Promise<CompileResult> {
+  const root = mkdtempSync(joinPath(tmpdir(), "js2-5342a-"));
+  roots.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const target = joinPath(root, name);
+    mkdirSync(joinPath(target, ".."), { recursive: true });
+    writeFileSync(target, source);
+  }
+  return compileProject(joinPath(root, entry), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+}
+
+async function instantiate(result: CompileResult): Promise<WebAssembly.Exports> {
+  const imports = buildCompiledImports(result, {}) as Record<string, unknown> & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports.setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (imports.__setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (instance.exports.__module_init as (() => void) | undefined)?.();
+  return instance.exports;
+}
+
+const DEP = `
+var isArray = Array.isArray;
+var keys = Object.keys;
+export { isArray, keys };
+export function measure(v) { return v.length; }
+`;
+
+const MAIN = `
+import { isArray, keys, measure } from './dep.js';
+
+const _ = { isArray, keys, measure, max: Math.max, direct: Array.isArray };
+
+export function shorthandHostBuiltin() { return _.isArray([1, 2, 3]) ? 1 : 0; }
+export function shorthandHostBuiltinNegative() { return _.isArray({ 0: 1, length: 1 }) ? 1 : 0; }
+export function shorthandHostBuiltinNoArgs() { return _.isArray() ? 1 : 0; }
+export function literalHostBuiltin() { return _.direct([7]) ? 1 : 0; }
+export function namespaceMember() { return _.max(3, 9); }
+export function objectKeysCount() { return _.keys({ a: 1, b: 2 }).length; }
+export function compiledClosureStillDispatches() { return _.measure([1, 2, 3, 4]); }
+`;
+
+describe("#5342 host builtin in an object-literal callable property", () => {
+  it("calls the real host function instead of trapping on a null cast", async () => {
+    const result = await compileFixture({ "dep.js": DEP, "main.js": MAIN }, "main.js");
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    const exports = await instantiate(result);
+
+    // Before the fix each of these four threw
+    // "RuntimeError: dereferencing a null pointer".
+    expect((exports.shorthandHostBuiltin as () => number)()).toBe(1);
+    expect((exports.literalHostBuiltin as () => number)()).toBe(1);
+    expect((exports.namespaceMember as () => number)()).toBe(9);
+    expect((exports.objectKeysCount as () => number)()).toBe(2);
+
+    // Anti-vacuity: the routed call must still compute a real answer, not a
+    // constant truth. An array-like object and a missing argument are both
+    // `false` for `Array.isArray`.
+    expect((exports.shorthandHostBuiltinNegative as () => number)()).toBe(0);
+    expect((exports.shorthandHostBuiltinNoArgs as () => number)()).toBe(0);
+
+    // Control: a COMPILED closure in the same literal keeps the typed
+    // call_ref path — the routing is scoped to declaration-proven host values.
+    expect((exports.compiledClosureStillDispatches as () => number)()).toBe(4);
+  });
+});


### PR DESCRIPTION
Cause **A** of three for [#5342](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5342-lodash-residual-nine). Siblings: cause B (`eqref` carrier) and cause C (module-scope capability probe). Each is independently correct and independently revertable; **lodash reaches 58/62 only when all three land**.

## The defect

```js
var o = { f: Array.isArray };
o.f([1, 2, 3]);        // RuntimeError: dereferencing a null pointer
```

`compileCallablePropertyCall`'s externref branch reads the field, does `any.convert_extern`, and guard-casts to the closure-wrapper root. For a genuine host function that `ref.test` fails, so the cast yields `ref.null` — and `emitNullCheckThrow` deliberately rethrows **only** when the value was nullish *before* the cast (#789: a wrong struct type is meant to fall through to a multi-struct dispatch). A live host function is not nullish, so the null cast reached `struct.get` and trapped. A wasm trap is not catchable by wasm exception handling, so this killed lodash's whole single test file.

lodash publishes `var isArray = Array.isArray; module.exports = isArray`, the adapter does `import isArray from 'lodash/isArray.js'` and `const _ = { …, isArray, … }`, and `_.isArray([1,2,3])` is the trap.

## The fix

`callablePropertyIsExtractedHostBuiltin` already existed for exactly this trap — its own comment describes it — but proved one shape only: a shorthand whose value is a binding element of `const { isArray } = Array`. `valueDeclarationOf` stops at the import clause, so lodash's shape was invisible.

The proof now follows import aliases (new oracle query `aliasedValueDeclarationOf`) and single-initializer hops, accepts a plain `PropertyAssignment` initializer, and accepts an ambient `.d.ts` binding — which also covers `{ f: parseInt }`, `{ f: isNaN }`, `{ f: Math.max }` and `{ f: Object.keys }`, every one of which trapped identically.

It moved into the subsystem module `src/codegen/expressions/callable-property-host-value.ts` rather than growing the god file: a `loc-budget-allow` grant was available and deliberately not taken, and `calls-closures.ts` ends up 25 lines **smaller**.

**Deliberately a declaration proof, not a runtime test.** "Is this externref a wasm closure?" is a runtime question, and #4618 answers it that way for the `__call_fn_N` dispatchers — but doing so here means wrapping the whole callable-property dispatch, including the shared `__call_cprop_deferred_N` helper whose ABI passes only the already-cast root, in a runtime branch on the hottest object-literal call path. A host function that arrives dynamically (through a parameter, or a later write) is the recorded residual.

## Evidence

- Reduction probe, 11 rows + a deliberately-false control: **4/12 → 11/12** in Wasm; the control fails in both lanes by construction.
- Regression test — untyped `.js` two-file fixture. Fails on the parent with `dereferencing a null pointer`; passes here. Anti-vacuity: an array-like object and a missing argument must still answer `false`, and a compiled closure in the same literal must keep the typed `call_ref` path.
- **lodash 53/62 → 54/62** from this PR alone (58/62 with both siblings).
- **A/B at one head over 17 dogfood suites**, one suite at a time, per test file: net **+5**, **0** individually regressed tests, both lanes exit 0, every anchor reproduced (webpack 16/16 · three 17/18 · clsx 32/32 · cookie 63740/63740 · redux 64/82 · axios 200/231 · stylelint 108/108 · tailwindcss 13/13 · jsdom 6/6 · styled-components 9/9 · uuid 75/75 · marked 9/30 · moment 10/10 · prettier 101/151 · jest 329/356 · hono 244/324). The god-file extraction happened after that A/B and was separately proven byte-neutral (4/4 repro inputs compile to identical wasm sha256).
- Gates: LOC · func · coercion-sites · oracle-ratchet (+0/+0) · dead-exports · dogfood-validation (6/6) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
