### PR TITLE
fix(#5342): admit the eqref carrier so an own toString/valueOf property is actually called ✓

### DIFF
--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -1800,8 +1800,8 @@ export function compileCallablePropertyCall(
     }
   }
 
-  // Field is externref — try to find or create matching closure wrapper types
-  if (fieldType.kind === "externref") {
+  // Field is externref, or the `eqref` own-`valueOf`/`toString` carrier (#4394/#5342 cause B).
+  if (fieldType.kind === "externref" || fieldType.kind === "eqref") {
     const resultTypes = sigRetWasm ? [sigRetWasm] : [];
     const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, sigParamWasmTypes, resultTypes);
 
@@ -1870,7 +1870,7 @@ export function compileCallablePropertyCall(
           typeIdx: selfTypeIdx,
         };
         const closureLocal = allocLocal(fctx, `__cprop_ext_${fctx.locals.length}`, closureRefType);
-        fctx.body.push({ op: "any.convert_extern" });
+        if (fieldType.kind === "externref") fctx.body.push({ op: "any.convert_extern" });
         emitGuardedRefCast(fctx, selfTypeIdx);
         fctx.body.push({ op: "local.set", index: closureLocal });
 
@@ -1926,7 +1926,7 @@ export function compileCallablePropertyCall(
       // intact (mirrors calls.ts #2174).
       const rootRefType: ValType = { kind: "ref_null", typeIdx: rootIdx };
       const closureLocal = allocLocal(fctx, `__cprop_ext_${fctx.locals.length}`, rootRefType);
-      fctx.body.push({ op: "any.convert_extern" });
+      if (fieldType.kind === "externref") fctx.body.push({ op: "any.convert_extern" });
       emitGuardedRefCast(fctx, rootIdx);
       fctx.body.push({ op: "local.set", index: closureLocal });
 

--- a/tests/issue-5342-own-toprimitive-name-property-call.test.ts
+++ b/tests/issue-5342-own-toprimitive-name-property-call.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5342 cause B — calling an object literal's OWN `toString` / `valueOf`
+// property answered `null`, silently:
+//
+//   const _ = { toString: fn };
+//   _.toString('x');            // null   (want fn('x'))
+//
+// Not the Object.prototype fallback it looks like. `{ toString: fn }` types
+// that one field `eqref` on purpose (#4394) so the ToPrimitive dispatchers can
+// `ref.test` the stored closure without an externref round-trip. The
+// callable-property dispatcher admitted only `externref`, `ref` and `ref_null`
+// carriers, so for an `eqref` field EVERY arm of the method-call ladder
+// declined and the call fell through to calls.ts's graceful tail — compile the
+// callee, `drop`, push `ref.null.extern`. Green compile, no diagnostic, wrong
+// answer.
+//
+// lodash's `_.toString(value)` is exactly this shape and every one of its
+// direct method calls returned `null`, including `_.toString('x')`.
+//
+// The fix admits the `eqref` carrier into the same wrapper-dispatch branch,
+// skipping only the `any.convert_extern` that the externref carrier needs.
+//
+// Untyped `.js` two-file fixtures: the property name has to come from a real
+// import so the field keeps its published shape rather than a test-local one.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as joinPath } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject, type CompileResult } from "../src/index.js";
+import { buildCompiledImports } from "../src/runtime.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+async function compileFixture(files: Record<string, string>, entry: string): Promise<CompileResult> {
+  const root = mkdtempSync(joinPath(tmpdir(), "js2-5342b-"));
+  roots.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const target = joinPath(root, name);
+    mkdirSync(joinPath(target, ".."), { recursive: true });
+    writeFileSync(target, source);
+  }
+  return compileProject(joinPath(root, entry), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+}
+
+async function instantiate(result: CompileResult): Promise<WebAssembly.Exports> {
+  const imports = buildCompiledImports(result, {}) as Record<string, unknown> & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports.setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (imports.__setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (instance.exports.__module_init as (() => void) | undefined)?.();
+  return instance.exports;
+}
+
+const DEP = `
+export function conv(value) { return value === undefined ? 'undef' : 'v:' + value; }
+`;
+
+const MAIN = `
+import { conv } from './dep.js';
+
+const own = { toString: conv, valueOf: conv, plain: conv };
+const bare = { n: 1 };
+const local = { valueOf: function () { return 41; } };
+
+export function ownToString() { return own.toString('x'); }
+export function ownValueOf() { return own.valueOf('y'); }
+export function ownPlain() { return own.plain('z'); }
+export function inheritedToString() { return bare.toString(); }
+export function implicitToPrimitive() { return local + 1; }
+export function localValueOfCalled() { return local.valueOf(); }
+`;
+
+describe("#5342 own toString/valueOf callable property", () => {
+  it("calls the own property instead of answering null", async () => {
+    const result = await compileFixture({ "dep.js": DEP, "main.js": MAIN }, "main.js");
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    const exports = await instantiate(result);
+
+    // Before the fix both of these answered `null`.
+    expect((exports.ownToString as () => string)()).toBe("v:x");
+    expect((exports.ownValueOf as () => string)()).toBe("v:y");
+
+    // Control: a property whose name is NOT an Object.prototype member keeps
+    // the `externref` carrier and always worked — it proves the fixture and
+    // the harness, so a null from the two above is the defect, not the setup.
+    expect((exports.ownPlain as () => string)()).toBe("v:z");
+
+    // Anti-vacuity, both directions: an object with NO own `toString` must
+    // still reach Object.prototype, and an own `valueOf` must still be the one
+    // ToPrimitive picks — that implicit dispatch is the whole reason the field
+    // is `eqref` (#4394), and admitting the carrier to the EXPLICIT call path
+    // must not disturb it.
+    expect((exports.inheritedToString as () => string)()).toBe("[object Object]");
+    expect((exports.localValueOfCalled as () => number)()).toBe(41);
+    expect((exports.implicitToPrimitive as () => number)()).toBe(42);
+  });
+});


### PR DESCRIPTION
Cause **B** of three for [#5342](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5342-lodash-residual-nine). Siblings: #5654 (cause A, host builtin in a callable property) and cause C (module-scope capability probe). Each is independently correct and independently revertable; **lodash reaches 58/62 only when all three land**.

## The defect

```js
const _ = { toString: fn };
_.toString('x');       // null, silently
```

Not the Object.prototype interception it looks like. `{ toString: fn }` types that one field **`eqref`** on purpose (#4394), so the ToPrimitive dispatchers can `ref.test` the stored closure without an externref round-trip. `compileCallablePropertyCall` admitted `externref`, `ref` and `ref_null` — not `eqref` — so every arm of the method-call ladder declined and the call fell through to `calls.ts`'s graceful tail: compile the callee, `drop`, push `ref.null.extern`. Green compile, no diagnostic, wrong answer.

The tell is name-dependence, measured on the parent: `toString` and `valueOf` answered `null` while `toStr` and `toLocaleString` — the same function value, a different property name — were correct. That is the field **carrier**, not the prototype.

lodash's `_.toString(value)` is exactly this shape, so every direct method call answered `null`, including `_.toString('x')`. That null is also what made #5342's spec misread three of its nine failures: the `-0`-in-an-array row and one of the `deepEqual` rows were this defect, not `-0` handling and not "a Symbol reaching a string-typed slot".

## The fix

Admit the `eqref` carrier into the same wrapper-dispatch branch, skipping only the `any.convert_extern` that the externref carrier needs — an `eqref` already *is* a WasmGC ref, so `emitGuardedRefCast` takes it directly.

Written to be **line-neutral inside `compileCallablePropertyCall`** (671 lines, sitting exactly at its function-budget ceiling) rather than taking a `func-budget-allow` grant. The full rationale lives in the test header and the issue file instead of a long in-function comment.

## Evidence

- Regression test — untyped `.js` two-file fixture. Fails on the parent with `expected null to be 'v:x'`; passes here.
- Anti-vacuity in both directions: a property whose name is **not** an Object.prototype member (which always worked) proves the fixture and harness; an object with no own `toString` must still reach `[object Object]`; and an own `valueOf` must still be the one ToPrimitive picks implicitly — that implicit dispatch is the whole reason the field is `eqref`, and admitting the carrier to the *explicit* call path must not disturb it.
- **lodash 54/62 → 56/62** from this PR (on top of #5654); 58/62 with all three.
- **A/B at one head over 17 dogfood suites**, one suite at a time, per test file: net **+5**, **0** individually regressed tests, both lanes exit 0, every anchor reproduced.
- Gates: LOC · func · coercion-sites · oracle-ratchet · dead-exports all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
