### PR TITLE
fix(#5342): the module-scope capability-probe idiom no longer binds null ✓

### DIFF
--- a/src/codegen/expressions/misc.ts
+++ b/src/codegen/expressions/misc.ts
@@ -91,8 +91,24 @@ function compileConditionalExpression(
   fctx.savedBodies.push(elseInstrs);
   fctx.body = savedBody;
 
-  const thenType: ValType = thenResultType ?? { kind: "f64" };
-  const elseType: ValType = elseResultType ?? { kind: "f64" };
+  // (#5342) Re-attach the symbol BRAND to an arm that produced a bare `i32`
+  // symbol id. `compileSymbolCall` deliberately returns the js-host id
+  // UNbranded (#4626: branding it globally routed mid-emission coercions
+  // through a late `__box_symbol` import whose index shift corrupted already
+  // baked `ref.func` operands). The join below is the one place that must know
+  // anyway, and it is already prepared for a coercion-time late import — both
+  // arms are parked in `fctx.savedBodies` precisely so the shift walker sees
+  // them. Without the brand `cond ? Symbol("a") : undefined` boxed the id with
+  // `__box_number` while the `symbol`-typed sink unboxed it with
+  // `__unbox_symbol`, which answers 0 for a JS number — so lodash's
+  // `var symbol = Symbol ? Symbol("a") : undefined` fixture produced
+  // `Symbol(wasm_0)` in place of `Symbol(a)`.
+  const brandSymbolCarrier = (type: ValType, branch: ts.Expression): ValType =>
+    type.kind === "i32" && type.symbol !== true && ctx.oracle.staticJsTypeOf(branch) === "symbol"
+      ? { ...type, symbol: true }
+      : type;
+  const thenType: ValType = brandSymbolCarrier(thenResultType ?? { kind: "f64" }, expr.whenTrue);
+  const elseType: ValType = brandSymbolCarrier(elseResultType ?? { kind: "f64" }, expr.whenFalse);
 
   // Determine the common result type for both branches
   let resultValType: ValType = thenType;

--- a/src/codegen/helpers/is-strict-function.ts
+++ b/src/codegen/helpers/is-strict-function.ts
@@ -161,7 +161,7 @@ export function isSimpleParameterList(params: readonly ts.ParameterDeclaration[]
  * sloppy `.js` source compiled under a `.ts` filename has `scriptKind: TS` but
  * no module markers, and must stay sloppy.
  */
-function isModuleSourceFile(sf: ts.SourceFile): boolean {
+export function isModuleSourceFile(sf: ts.SourceFile): boolean {
   const internal = sf as ts.SourceFile & { externalModuleIndicator?: ts.Node };
   if (internal.externalModuleIndicator !== undefined) return true;
   if (sf.impliedNodeFormat === ts.ModuleKind.ESNext) return true;

--- a/src/codegen/helpers/sloppy-this-global.ts
+++ b/src/codegen/helpers/sloppy-this-global.ts
@@ -40,7 +40,7 @@ import { compileIdentifier } from "../expressions/identifiers.js";
 import { inlinedCalleeHasBoundReceiver } from "../expressions/inlined-call-receiver.js"; // (#4555)
 import { emitUndefined, ensureLateImport, flushLateImportShifts } from "../expressions/late-imports.js";
 import { coerceType } from "../shared.js";
-import { isStrictContext, isStrictFunction } from "./is-strict-function.js";
+import { isModuleSourceFile, isStrictContext, isStrictFunction } from "./is-strict-function.js";
 
 /**
  * True when an unbound `this` at `expr` must evaluate to the global object
@@ -284,6 +284,50 @@ export function receiverIsRealmGlobalObject(
   if (cur.kind === ts.SyntaxKind.ThisKeyword) return thisReceiverIsGlobalObject(ctx, fctx, cur);
   if (!ts.isIdentifier(cur) || cur.text !== "globalThis") return false;
   return fctx.localMap.get("globalThis") === undefined && !ctx.moduleGlobals.has("globalThis");
+}
+
+/**
+ * (#5342) True when `receiver` is the realm global object AND `name`'s wasm
+ * module global IS that object's property of that name — the full precondition
+ * every #4500 Slice A arm needs before it may answer a `globalThis.<name>` /
+ * `this.<name>` access from the module global. Supersedes the bare
+ * `receiverIsRealmGlobalObject` test at those four sites.
+ *
+ * It holds for SCRIPT goal only. §9.1.1.4.18 CreateGlobalVarBinding makes a
+ * script's top-level `var` a property of the global object, which is the whole
+ * reason Slice A exists. §16.2.1.6.4 InitializeEnvironment puts a MODULE's
+ * top-level `var` in the module environment record instead, where it creates
+ * NO global-object property — so in module code the two are different storage
+ * and the access must consult the real object.
+ *
+ * Getting this wrong does not merely lose precision, it INVERTS the program.
+ * The published capability-probe idiom
+ *
+ *     var Symbol = typeof globalThis.Symbol === "function" ? globalThis.Symbol : undefined;
+ *
+ * compiled `globalThis.Symbol` into a read of the not-yet-initialised global
+ * the same statement is defining, so the true arm stored `null`, the shadow
+ * stayed falsy for the rest of the module, and every later `Symbol(...)` /
+ * `Symbol.iterator` read off it was dead. lodash's fixture is exactly this
+ * shape (#5342); jQuery/underscore-era `var Map = ... globalThis.Map ...`
+ * probes are the same idiom.
+ *
+ * Module-ness is read from the RECEIVER's own source file rather than
+ * `ctx.sourceIsModule`, which multi-file linking sets unconditionally, and it
+ * honours `inferModuleStrictArguments === false` — the test262 harness's
+ * synthetic `export function test()` wrapper marks genuinely script-goal
+ * sources as modules, and Slice A's own witnesses (`var p1 = 7; this.p1`) are
+ * script-goal tests that must keep the module-global answer.
+ */
+export function realmGlobalObjectCarriesModuleGlobal(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiver: ts.Expression,
+  name: string,
+): boolean {
+  if (!ctx.moduleGlobals.has(name)) return false;
+  if (ctx.inferModuleStrictArguments !== false && isModuleSourceFile(receiver.getSourceFile())) return false;
+  return receiverIsRealmGlobalObject(ctx, fctx, receiver);
 }
 
 /**

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -163,7 +163,7 @@ import {
   recordInModuleInitFlagRead,
 } from "./registry/imports.js";
 import { tryCompileArrayMethodValue } from "./array-method-value.js";
-import { receiverIsRealmGlobalObject } from "./helpers/sloppy-this-global.js"; // (#4500 Slice A) realm-global receiver
+import { realmGlobalObjectCarriesModuleGlobal } from "./helpers/sloppy-this-global.js"; // (#4500 Slice A) realm-global receiver; (#5342) script-goal gate
 import { dvDetachedThrowInstrs, getOrRegisterDvWindowType } from "./dataview-native.js"; // (#2159/#38) DataView windowing; (#3173) detached TypeError
 import {
   getArrTypeIdxFromVec,
@@ -3699,7 +3699,7 @@ function tryEmitRealmGlobalModuleGlobalRead(
 ): ValType | undefined {
   const globalIdx = ctx.moduleGlobals.get(propName);
   if (globalIdx === undefined) return undefined;
-  if (!receiverIsRealmGlobalObject(ctx, fctx, expr.expression)) return undefined;
+  if (!realmGlobalObjectCarriesModuleGlobal(ctx, fctx, expr.expression, propName)) return undefined;
   fctx.body.push({ op: "global.get", index: globalIdx });
   return ctx.mod.globals[localGlobalIdx(ctx, globalIdx)]?.type ?? { kind: "externref" };
 }
@@ -3725,11 +3725,11 @@ function tryEmitRealmGlobalModuleGlobalElementRead(
   fctx: FunctionContext,
   expr: ts.ElementAccessExpression,
 ): ValType | undefined {
-  if (!receiverIsRealmGlobalObject(ctx, fctx, expr.expression)) return undefined;
   const key = resolveComputedKeyExpression(ctx, expr.argumentExpression);
   if (key === undefined) return undefined;
   const globalIdx = ctx.moduleGlobals.get(key);
   if (globalIdx === undefined) return undefined;
+  if (!realmGlobalObjectCarriesModuleGlobal(ctx, fctx, expr.expression, key)) return undefined;
   fctx.body.push({ op: "global.get", index: globalIdx });
   return ctx.mod.globals[localGlobalIdx(ctx, globalIdx)]?.type ?? { kind: "externref" };
 }

--- a/src/codegen/property-nullish-read.ts
+++ b/src/codegen/property-nullish-read.ts
@@ -8,7 +8,7 @@ import { tryEmitFnctorPrototypeRead } from "./expressions/fnctor-prototype.js";
 import { ensureExternIsUndefinedImport, ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
 import { reserveMemberGetDispatch } from "./member-get-dispatch.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
-import { receiverIsRealmGlobalObject } from "./helpers/sloppy-this-global.js"; // (#4500 Slice A)
+import { realmGlobalObjectCarriesModuleGlobal } from "./helpers/sloppy-this-global.js"; // (#4500 Slice A); (#5342) script-goal gate
 import { compilePropertyAccess, typeErrorThrowInstrs } from "./property-access.js";
 import { coerceType, compileExpression } from "./shared.js";
 import { readsUninitialisedFieldSlot } from "./uninitialised-field-undefined.js"; // (#5312)
@@ -58,7 +58,8 @@ export function compilePropertyAccessForNullishObservation(
   // Both were live in one program. Delegate so the module-global arm decides.
   // (Disjoint from the #4480 fnctor arm below: this one fires only for the
   // realm-global receiver, that one only for a user-function receiver.)
-  if (ctx.moduleGlobals.has(propName) && receiverIsRealmGlobalObject(ctx, fctx, expr.expression)) {
+  // (#5342) Script goal only — a module-scoped `var` is not a global-object property.
+  if (realmGlobalObjectCarriesModuleGlobal(ctx, fctx, expr.expression, propName)) {
     return compilePropertyAccess(ctx, fctx, expr);
   }
 

--- a/src/codegen/realm-global-element-write.ts
+++ b/src/codegen/realm-global-element-write.ts
@@ -42,7 +42,7 @@ import type { ts } from "../ts-api.js";
 import type { InnerResult } from "./shared.js";
 import { allocLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { receiverIsRealmGlobalObject } from "./helpers/sloppy-this-global.js";
+import { realmGlobalObjectCarriesModuleGlobal } from "./helpers/sloppy-this-global.js";
 import { localGlobalIdx } from "./registry/imports.js";
 import { coerceType, compileExpression, resolveComputedKeyExpression } from "./shared.js";
 
@@ -56,11 +56,13 @@ export function tryEmitRealmGlobalElementWrite(
   target: ts.ElementAccessExpression,
   value: ts.Expression,
 ): InnerResult | undefined {
-  if (!receiverIsRealmGlobalObject(ctx, fctx, target.expression)) return undefined;
   const key = resolveComputedKeyExpression(ctx, target.argumentExpression);
   if (key === undefined) return undefined;
   const globalIdx = ctx.moduleGlobals.get(key);
   if (globalIdx === undefined) return undefined;
+  // (#5342) Script goal only — the read twin declines in module code, and a
+  // half-fixed pair is worse than neither half (see this file's header).
+  if (!realmGlobalObjectCarriesModuleGlobal(ctx, fctx, target.expression, key)) return undefined;
 
   const globalType = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)]?.type;
   const rhsType = compileExpression(ctx, fctx, value, globalType);

--- a/tests/issue-5342-module-global-capability-probe.test.ts
+++ b/tests/issue-5342-module-global-capability-probe.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5342 cause C — the published capability-probe idiom bound `null`:
+//
+//   var Symbol = typeof globalThis.Symbol === 'function' ? globalThis.Symbol : undefined;
+//   var symbol = Symbol ? Symbol('a') : undefined;
+//
+// Two independent defects compose here, and BOTH are needed for the idiom to
+// work; either alone leaves it wrong in a different way.
+//
+// C1 — `globalThis.Symbol` was compiled as a read of the module global that
+// this very statement is defining. The #4500 Slice A arm answers
+// `globalThis.<name>` / `this.<name>` from `<name>`'s wasm module global,
+// which is right for SCRIPT goal (§9.1.1.4.18 CreateGlobalVarBinding makes a
+// script's top-level `var` a property of the global object) and wrong for a
+// MODULE (§16.2.1.6.4 puts it in the module environment record, creating no
+// global-object property). In module code the arm therefore read a global that
+// was still `null`, the true arm stored that null, and the shadow stayed falsy
+// for the rest of the module — so every later `Symbol(...)` / `Symbol.iterator`
+// read off it was dead. The gate is now script-goal only, on the RECEIVER's own
+// source file, honouring `inferModuleStrictArguments === false` so the test262
+// harness's synthetic `export function test()` wrapper does not reclassify a
+// genuinely script-goal source (Slice A's own witnesses are script tests).
+//
+// C2 — the ternary join dropped the symbol BRAND. `compileSymbolCall` returns
+// the js-host symbol id as a bare `i32` on purpose (#4626: branding it globally
+// routed mid-emission coercions through a late `__box_symbol` import whose index
+// shift corrupted baked `ref.func` operands). Joining `symbol` with `undefined`
+// coerces that `i32` to `externref` — and unbranded it took `__box_number`,
+// while the `symbol`-typed sink unboxed with `__unbox_symbol`, which answers 0
+// for a JS number. So the fixture produced `Symbol(wasm_0)` instead of
+// `Symbol(a)`. The brand is re-attached at the join, which is already prepared
+// for a coercion-time late import (both arms are parked in `fctx.savedBodies`).
+//
+// The script-goal control at the bottom is not decoration: it is the half of
+// #4500 this change must NOT take away.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as joinPath } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compile, compileProject, type CompileResult } from "../src/index.js";
+import { buildCompiledImports } from "../src/runtime.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+async function compileFixture(files: Record<string, string>, entry: string): Promise<CompileResult> {
+  const root = mkdtempSync(joinPath(tmpdir(), "js2-5342c-"));
+  roots.push(root);
+  for (const [name, source] of Object.entries(files)) {
+    const target = joinPath(root, name);
+    mkdirSync(joinPath(target, ".."), { recursive: true });
+    writeFileSync(target, source);
+  }
+  return compileProject(joinPath(root, entry), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+}
+
+async function instantiate(result: CompileResult): Promise<WebAssembly.Exports> {
+  const imports = buildCompiledImports(result, {}) as Record<string, unknown> & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports.setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (imports.__setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (instance.exports.__module_init as (() => void) | undefined)?.();
+  return instance.exports;
+}
+
+const DEP = `
+export function text(v) { return String(v); }
+export function truthy(v) { return v ? 1 : 0; }
+`;
+
+const MAIN = `
+import { text, truthy } from './dep.js';
+
+var Symbol = typeof globalThis.Symbol === 'function' ? globalThis.Symbol : undefined;
+var Map = typeof globalThis.Map === 'function' ? globalThis.Map : undefined;
+var symbol = Symbol ? Symbol('a') : undefined;
+
+export function shadowedSymbolIsLive() { return truthy(Symbol); }
+export function shadowedMapIsLive() { return truthy(Map); }
+export function shadowedSymbolTypeof() { return typeof Symbol; }
+export function probedSymbolText() { return text(symbol); }
+export function moduleVarIsNotAGlobalProperty() { return typeof globalThis.symbol; }
+export function unshadowedGlobalStillReads() { return truthy(globalThis.Array); }
+export function ternarySymbolText(flag) { return text(flag ? Symbol('b') : undefined); }
+`;
+
+describe("#5342 module-scope capability probe over globalThis", () => {
+  it("binds the real builtin and keeps the symbol's description", async () => {
+    const result = await compileFixture({ "dep.js": DEP, "main.js": MAIN }, "main.js");
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    const exports = await instantiate(result);
+
+    // C1. Before the fix both answered 0 — the shadow read its own
+    // uninitialised module global.
+    expect((exports.shadowedSymbolIsLive as () => number)()).toBe(1);
+    expect((exports.shadowedMapIsLive as () => number)()).toBe(1);
+    expect((exports.shadowedSymbolTypeof as () => string)()).toBe("function");
+
+    // C2. Before the fix this was 'Symbol(wasm_0)' (brand lost at the join, so
+    // the id was boxed as a number and unboxed as a symbol → 0).
+    expect((exports.probedSymbolText as () => string)()).toBe("Symbol(a)");
+
+    // Anti-vacuity for C1: the arm must not simply be inverted. A MODULE's
+    // top-level `var` is not a property of the global object, so the read has
+    // to answer `undefined` — proving we route to the real object rather than
+    // to the module global in either direction.
+    expect((exports.moduleVarIsNotAGlobalProperty as () => string)()).toBe("undefined");
+    expect((exports.unshadowedGlobalStillReads as () => number)()).toBe(1);
+
+    // Anti-vacuity for C2: the same join with a runtime-false condition must
+    // still yield `undefined`, not a symbol.
+    expect((exports.ternarySymbolText as (flag: number) => string)(1)).toBe("Symbol(b)");
+    expect((exports.ternarySymbolText as (flag: number) => string)(0)).toBe("undefined");
+  });
+
+  it("keeps the #4500 script-goal answer: a script's top-level var IS a global property", async () => {
+    // Script goal — no import/export, so `externalModuleIndicator` is unset and
+    // the Slice A arm must still fire. The script throws iff an assertion
+    // fails, so "ran to completion" is the assertion.
+    const src = `
+var p1 = 7;
+var p2;
+if (globalThis.p1 !== 7) { throw new Error('globalThis.p1'); }
+if (globalThis['p1'] !== 7) { throw new Error('globalThis["p1"]'); }
+if ((globalThis.p1 === undefined)) { throw new Error('globalThis.p1 nullish read'); }
+globalThis['p2'] = 5;
+if (p2 !== 5) { throw new Error('globalThis["p2"] write'); }
+`;
+    const result = await compile(src, {
+      fileName: "script.js",
+      allowJs: true,
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+    });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    (instance.exports as { __module_init?: () => void }).__module_init?.();
+  });
+});


### PR DESCRIPTION
Cause **C** of three for [#5342](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5342-lodash-residual-nine). Siblings: #5654 (host builtin in a callable property) and #5655 (`eqref` carrier). Each is independently correct and independently revertable; **lodash reaches 58/62 only when all three land**.

```js
var Symbol = typeof globalThis.Symbol === 'function' ? globalThis.Symbol : undefined;
var symbol = Symbol ? Symbol('a') : undefined;
```

Two independent defects compose here, and **either one alone leaves the idiom wrong in a different way**, which is why they ship together.

## C1 — `globalThis.Symbol` read the module global it was defining

The #4500 Slice A arm answers `globalThis.<name>` / `this.<name>` from `<name>`'s wasm module global. That is right for **script** goal (§9.1.1.4.18 CreateGlobalVarBinding makes a script's top-level `var` a property of the global object — the whole reason Slice A exists) and wrong for a **module** (§16.2.1.6.4 InitializeEnvironment puts it in the module environment record, creating no global-object property). `receiverIsRealmGlobalObject` refuses a shadowed `globalThis` but never checked module-ness, so `__module_init` emitted, literally:

```wat
i32.const 1                 ;; typeof globalThis.Symbol === "function" — folded TRUE
(if (result externref)
  (then global.get 10)      ;; the not-yet-initialised `Symbol` global ITSELF
  (else call $__get_undefined))
global.set 10               ;; Symbol = null
```

The shadow bound `null`, stayed falsy for the rest of the module, and poisoned every later read off it — including a sibling `var Sym2 = globalThis.Symbol` in the same file, which is how the blast radius shows.

The gate is now script-goal only, judged on the **receiver's own source file** (not `ctx.sourceIsModule`, which multi-file linking sets unconditionally) and honouring `inferModuleStrictArguments === false`, because the test262 harness's synthetic `export function test()` wrapper marks genuinely script-goal sources as modules and Slice A's own witnesses (`var p1 = 7; this.p1`) are script tests.

Applied to **all four** Slice A arms — dot read, bracket read, nullish-comparison read, and the bracket **write** — because `realm-global-element-write.ts`'s own header records that a half-fixed read/write pair is worse than neither half. Every call site is a 1:1 line replacement, so `property-access.ts` (a god file at its LOC ceiling) does not grow and no `loc-budget-allow` grant is needed.

## C2 — the ternary join dropped the symbol brand

`compileSymbolCall` returns the js-host symbol id as a bare `i32` **on purpose** (#4626: branding it globally routed mid-emission coercions through a late `__box_symbol` import whose index shift corrupted already-baked `ref.func` operands — 216 regressions). Joining `symbol` with `undefined` coerces that `i32` to `externref`, and unbranded it took `__box_number` while the `symbol`-typed sink unboxed with `__unbox_symbol`, which answers 0 for a JS number — hence `Symbol(wasm_0)` in place of `Symbol(a)`.

The brand is re-attached **at the join only**. That site is already prepared for a coercion-time late import: both arms are parked in `fctx.savedBodies` precisely so the shift walker sees them, and the file says so.

## Evidence

- Regression test — untyped `.js` two-file fixture. Fails on the parent with `expected +0 to be 1` (the shadow is not live); passes here.
- Anti-vacuity for C1 is a spec point, not decoration: a **module's** top-level `var` must still read `undefined` through `globalThis`, proving the arm was not merely inverted. For C2: the same join with a runtime-false condition must still be `undefined`.
- The second `it()` is the **#4500 preservation control** — a sloppy script asserting `globalThis.p1 === 7`, `globalThis['p1'] === 7` and the bracket write. It passes on **both** lanes by design; it is the behaviour this change must not take away.
- **lodash 56/62 → 58/62** from this PR (on top of #5654 and #5655).
- **A/B at one head over 17 dogfood suites**, one suite at a time, per test file: net **+5**, **0** individually regressed tests, both lanes exit 0, every anchor reproduced.
- Gates: LOC · func · coercion-sites · oracle-ratchet · dead-exports all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
