### PR TITLE
docs(#5356, #5357): implementation plans — eager capture box for let/const; x === false on a nullish reference

### DIFF
--- a/plan/issues/5356-eager-capture-box-skips-let-const.md
+++ b/plan/issues/5356-eager-capture-box-skips-let-const.md
@@ -146,3 +146,84 @@ any analysis is written.
 2. The for-await-of / async-dstr family #2692 named stays green.
 3. A/B at one head over the 17 dogfood suites: prettier's
    `print-doc-to-string.js` improves, nothing else regresses.
+
+## Implementation Plan
+
+Everything the previous agent measured stands: deleting the
+`if (cap.hasTdzFlag) continue;` skip in `emitEagerCaptureBoxes`
+(`src/codegen/statements/nested-declarations.ts`) fixes every row of the
+table and then miscompiles prettier. The plan is to find out **which** of two
+candidate races the miscompile is, by the cheapest experiment first, and fix
+that race rather than the eligibility rule if it turns out to be fixable.
+
+1. **Capture the parent** (`.tmp/nested-declarations.orig.ts`) and reproduce
+   both ends before touching anything: the minimal `v=null` repro, and the
+   prettier miscompile with the skip deleted (array-valued doc →
+   non-terminating loop, first popped command's `doc` reads `[object Object]`
+   while `getDocType` says `"array"`). Reduce the miscompile to a standalone
+   two-file untyped `.js` project via `compileAndRunUpstreamModule` — the
+   skeleton is `printDocToString`'s shape: a parameter `doc`, a `const cmds =
+   [{ ind, mode, doc }]`, a `while (cmds.length > 0) { const { ind, mode, doc }
+   = cmds.pop(); switch (getDocType(doc)) { … } }`, a `let output = ""`
+   mutated by a hoisted `function trim() { output = "" }` declared after the
+   `return`. A reproduction that loops or reads the wrong `doc` in under 40
+   lines is the deliverable of this step; without it the rest is guesswork.
+2. **Name-scoped probe** (the previous agent's suggestion, ~20 lines, throw
+   away afterwards): allow eager boxing of a TDZ capture only when the
+   captured name is declared **exactly once** in the enclosing function's
+   scope tree — count `VariableDeclaration` / `Parameter` / `BindingElement`
+   / `FunctionDeclaration` / `ClassDeclaration` / catch-clause names with the
+   identifier text, walking the parent function but **not** descending into
+   nested function bodies (a nested function's own local is a different
+   binding). Run prettier's `print-doc-to-string` and the reduction.
+   - Miscompile gone, repro fixed ⇒ the race is **shadowing**: a box minted
+     at function top for the outer binding, then an inner block-scoped
+     declaration of the same name that the declaration path treats as "already
+     boxed" (`boxedForInitStore` #3396 / the #3534 boxed-before-declared arm)
+     and stores into the outer cell, or re-aims `localMap[name]` so reads in
+     the inner scope hit the cell. Fix at the declaration path: an inner
+     declaration that **shadows** a boxed outer name must allocate its own
+     slot (or its own cell, if it is itself captured by a hoisted function)
+     and must **not** consult the outer name's box. `dropStaleBindingBox` is
+     the closest existing hook — read it. Then drop the probe's eligibility
+     narrowing and re-run: the goal is the general mechanism with shadowing
+     handled, not a rule that silently keeps the shadowed shape on the lazy
+     path. If the general fix costs more than a day, ship the narrowed
+     eligibility with a test that pins the shadowed shape as *still lazy and
+     still correct*, and say so.
+   - Miscompile persists with unshadowed names only ⇒ the race is the
+     **declaration re-allocating the value slot** after the cell exists
+     (block scope, type reset, `let` re-declared in a loop body). Reduce to
+     that shape (a captured `let` whose declaration follows a differently
+     typed assignment, or lives inside a loop) and trace where the
+     declaration path allocates a fresh local while the hoisted callee still
+     writes the cell. The cell must be minted with the binding's **declared**
+     slot type, not the type of whatever value the name holds at function
+     top.
+3. **Per-iteration semantics**: a `let` captured by a hoisted function
+   declaration is not a per-iteration closure binding (the function is
+   hoisted once), so one cell per function invocation is correct. Confirm the
+   #2692 for-await-of / async-dstr family stays green — run
+   `tests/issue-2692*.test.ts` and `tests/issue-2669*.test.ts` and the
+   closure equivalence group in `tests/equivalence.test.ts`.
+4. **Regression test** per the acceptance criteria: dead-branch call,
+   never-called, number-valued counter, **and** the shadowed shape from step
+   1 (the miscompile must be pinned so it cannot return). Untyped `.js`
+   two-file fixtures, counts both ways, anti-vacuity control.
+5. **A/B at one HEAD**, 17 suites, per file. `print-doc-to-string` reaches
+   3/3 only together with #5357 — if #5357 has not landed, measure the file
+   with and without #5357's branch merged in and report both; do not claim
+   the bucket. Closure-heavy packages (jest, hono, prettier) are the ones to
+   watch for movement.
+
+Serial with nothing; independent of #5357 (disjoint files:
+`nested-declarations.ts` vs `binary-ops-typed-dispatch.ts`). Both must land
+for prettier's `print-doc-to-string`.
+
+## Dispatch
+
+Model: **fable** (`feasibility: hard`, `reasoning_effort: max`). The
+one-line fix is known and known to miscompile; the work is finding which
+race the declaration path has with an eager cell, on a mechanism (#2692,
+#3396, #3534) that has already been patched three times. Dispatch after PR
+#5665 lands (it carries this file).

--- a/plan/issues/5357-nullish-reference-strict-equals-false.md
+++ b/plan/issues/5357-nullish-reference-strict-equals-false.md
@@ -139,3 +139,74 @@ explicitly NOT wanted.
    `false`, `undefined == false` is `false`, `0 == false` is `true`) are
    unchanged.
 3. A/B at one head over the 17 dogfood suites.
+
+## Implementation Plan
+
+The previous agent located the emitter exactly and argued, correctly, that a
+static fold cannot fix prettier (`onEnter?.(doc) === false` has an `any`
+left operand). The fix is to stop the ToNumber collapse from ever seeing a
+pair it cannot decide, and route those pairs into the reference-equality arm
+that already implements JS `===` in both lanes.
+
+1. **Capture the parent** (`.tmp/binary-ops-typed-dispatch.orig.ts`) and
+   reproduce the whole nine-row matrix in one standalone probe
+   (`compileAndRunUpstreamModule`, untyped `.js`), plus `1 === true` (#4208)
+   and the three loose-equality rows, so every later run answers all of
+   them at once.
+2. **Read the two arms** in `src/codegen/binary-ops-typed-dispatch.ts`:
+   the reference-identity / `__host_eq` block (~L1330 on `01ce47aba7`; host
+   lane emits the `__host_eq` import, `semanticProviders === "native-first"`
+   emits the #1776 native tag dispatch) and the `__unbox_number` + `f64.eq`
+   tail (~L1545–1566). Also `strict-eq-type-disjoint.ts` (#4208) for how the
+   scalar regime folds disjoint types, and how a Boolean is boxed to
+   `externref` today (grep `type-coercion.ts` for the i32→externref boolean
+   arm used when a `true`/`false` is passed to a host function — reuse it,
+   do not invent a box).
+3. **Factor the reference arm's emission** into a helper
+   (`emitReferenceStrictEquality(ctx, fctx, isEqOp)` or similar, in a small
+   new module — `binary-ops-typed-dispatch.ts` is near its ceiling) that both
+   the existing ~L1330 site and the new call site use, so the host/native
+   lane split stays in one place. **A host-lane-only fix is explicitly not
+   wanted.**
+4. **Reroute the collapse.** In the tail, before `__unbox_number`:
+   - if the scalar side is **statically Boolean** → box it to `externref`
+     and call the helper. §7.2.16 step 1: `Type(x) ≠ Type(y)` is `false`,
+     and `__host_eq` / the native tag dispatch implement that. This also
+     fixes `x === true` for a reference holding `1` (the collapse answers
+     `true` there too — add that row to the matrix).
+   - if the scalar side is **statically Number** and the reference side is
+     not statically numeric → emit a `ref.is_null` guard first (nullish
+     reference ⇒ `false` for `===`, `true` for `!==`), then keep the
+     numeric fast path **only if** the unboxed value is genuinely a number;
+     otherwise route to the helper. Check what `__unbox_number` does with a
+     non-number (it is `Number()` semantics — a string `"0"` would compare
+     equal to `0`, also wrong for `===`; if the existing tests already pin
+     that, the fast path is unsound and the whole pair goes to the helper).
+   - leave the collapse untouched when the reference side is statically
+     numeric (`number`-typed externref, the case the fast path exists for).
+5. **test262 before pushing**: PR #272 cost −12 on a nearby fallback. Run
+   the scoped corpus locally — `test/language/expressions/strict-equals`,
+   `strict-does-not-equals`, `equals`, `does-not-equals` (find the path
+   filter in `tests/test262-runner.ts` / the vitest runner's env, e.g.
+   `TEST262_FILTER`) — on parent and fix; the numbers must not go down in
+   either lane. Note in the PR body what you ran.
+6. **Regression test** per the acceptance criteria, both lanes (find how
+   an existing test drives `semanticProviders: "native-first"` /
+   `--target wasi` and reuse it). Loose equality rows and #4208 rows as
+   no-change controls.
+7. **A/B at one HEAD**, 17 suites, per file. Expected: prettier
+   `is-empty-doc` 7/16 → ≥ 15/16 (with #5665's optional-call fix on your
+   base), and `=== false` / `=== 0` against `any`-typed values are common
+   library idioms — hono, jest, axios, redux may all move; report per file,
+   improvements welcome, no regressions. `print-doc-to-string` also needs
+   #5356; report its state without claiming it.
+
+Independent of #5356 (disjoint files); both needed for prettier's
+`print-doc-to-string`.
+
+## Dispatch
+
+Model: **fable** (`feasibility: hard`, `reasoning_effort: max`). Two
+lanes, a fast path whose soundness boundary has to be established by
+measurement, and a test262 history (#272) of a nearby change costing net
+conformance. Dispatch after PR #5665 lands (it carries this file).


### PR DESCRIPTION
Docs-only (+152 lines in two issue files, nothing else). Adds `## Implementation Plan` and `## Dispatch` to the two issues the #5346 agent filed with problem/evidence/acceptance but no plan. Both are the blockers for prettier's `print-doc-to-string` (0/3).

- [#5356](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5356-eager-capture-box-skips-let-const): find which race the declaration path has with an eager ref cell (shadowing vs slot re-allocation) by a name-scoped probe, then fix that race rather than the eligibility rule.
- [#5357](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5357-nullish-reference-strict-equals-false): reroute the ToNumber collapse for Boolean/Number-vs-reference pairs into the existing reference-equality arm in both lanes; scoped test262 before pushing (#272 precedent).

Dispatch: fable for both; they touch disjoint files and can run in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)