### PR TITLE
docs(#5365, #5366, #5368–#5371): plans for the hono dev/index residuals; four follow-ups from #5362/#5339

### DIFF
--- a/plan/issues/5365-host-closure-bridge-loses-length-and-name.md
+++ b/plan/issues/5365-host-closure-bridge-loses-length-and-name.md
@@ -1,0 +1,156 @@
+---
+id: 5365
+title: "JS-host closure bridge loses Function.prototype.length and .name once a compiled closure crosses a call boundary as a value"
+status: ready
+sprint: current
+created: 2026-09-06
+updated: 2026-09-06
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+In `gc`/JS-host mode, a compiled closure that is **passed as an argument** and
+then reflected on inside the callee reports `length === 0` and
+`name === undefined`. Measured (hono harness, `platform: web`, `target: gc`):
+
+```js
+const f = (a, b) => a + b;
+const o = { h: f };
+const arr = [f];
+function viaParam(x) { return x.length + " / " + x.name + " / " + typeof x; }
+```
+
+| read                | native            | wasm (JS host)                    |
+| ------------------- | ----------------- | --------------------------------- |
+| `f.length` / `.name`| `2` / `"f"`       | `2` / `"f"`            ✓          |
+| `o.h.length`/`.name`| `2` / `"f"`       | `2` / **`"h"`**        ✗ (name)    |
+| `arr[0].length`/`.name` | `2` / `"f"`   | `2` / **`""`**         ✗ (name)    |
+| `viaParam(f)`       | `2` / `"f"` / fn  | **`0`** / **`undefined`** / fn ✗   |
+| `String(f)`         | `"(a, b) => a + b"` | `"function () { [native code] }"` |
+
+The `String(f)` row names the mechanism: at the parameter boundary the value
+the callee sees is the **host bridge wrapper**, not the closure. The wrapper is
+minted in `src/runtime.ts` `_wrapWasmClosure` as
+
+```ts
+const wrapped = function wasmClosureBridge(this: any, ...args: any[]) { … };
+```
+
+so its own `length` is `0` (rest parameter) and its `name` is whatever
+`installNativeFunctionSourceFacade` leaves. The direct/object/array reads above
+are answered statically from the declaration, which is why only the boundary
+crossing is wrong.
+
+Static answers are also only *approximately* right: `o.h.name` returns the
+property key `"h"` and `arr[0].name` returns `""`, where the spec's
+NamedEvaluation gives `"f"` in both cases (the function was named at its own
+declaration, not at the storage site).
+
+`length` is recoverable — the module already exports `__closure_arity`
+(`src/codegen/closure-exports.ts`), and `_wrapWasmClosure` is handed the arity
+it dispatches at. `name` has **no host-mode carrier at all**: #4437's
+`$__fn_instance_meta` slot (`src/codegen/function-instance-meta.ts`) is
+explicitly *standalone only* — "In gc/host mode the `env::__extern_*` imports
+own the reflective property path". Closing `name` therefore means either
+extending that carrier to host mode or teaching the bridge to read a
+per-declaration name table.
+
+## Impact
+
+Found while fixing [#5339](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5339-hono-dev-index-whole-module-failure).
+Once hono's `src/helper/dev/index.test.ts` compiles and validates, **6 of its 7
+remaining failures are this bug**: hono classifies routes with
+
+```js
+const isMiddleware = (handler) => handler.length > 1;
+const handlerName = (handler) => handler.name || (isMiddleware(handler) ? "[middleware]" : "[handler]");
+```
+
+Handlers reach `inspectRoutes` through `#addRoute(method, path, handler)`, i.e.
+across a call boundary, so every one of them reports arity `0` and no name. The
+Wasm lane therefore labels every route `[handler]` / `isMiddleware: false`,
+which breaks `inspectRoutes()` (1 test) and all four `showRoutes()` variants
+plus the verbose form (5 tests).
+
+`length` alone lifts the file from 1/8 to 5/8; `length` + `name` reaches 7/8.
+
+## Acceptance criteria
+
+1. `viaParam(f)` above reports the declared arity and the declaration's name in
+   `gc`/host mode, matching Node.
+2. `o.h.name` / `arr[0].name` answer the *declaration's* name, not the storage
+   key.
+3. Regression test under `tests/` with untyped `.js` two-file fixtures, failing
+   on the parent and passing with the fix, plus an anti-vacuity control.
+4. A/B over the 17 dogfood suites: `hono src/helper/dev/index.test.ts` improves;
+   the change touches a hot global runtime path (`_wrapWasmClosure` is on every
+   host callback), so a full per-file A/B is mandatory, not optional.
+
+## Notes
+
+`length` and `name` are separable and should probably land as two slices —
+`length` is a small, well-understood change against an export that already
+exists; `name` needs new per-declaration metadata in host mode.
+
+## Implementation Plan
+
+Two slices, two PRs, in this order. The filer's split is right: `length` is a
+small change against an export that already exists; `name` needs a host-mode
+carrier that does not exist yet.
+
+### Slice 1 — `length` (small)
+
+1. Read `_wrapWasmClosure` in `src/runtime.ts` and `__closure_arity` in
+   `src/codegen/closure-exports.ts`. The wrapper is minted as
+   `function wasmClosureBridge(...args)`, so its own `length` is `0`; the arity
+   it dispatches at is already in hand. Set it at wrap time with
+   `Object.defineProperty(wrapped, "length", { value: arity, configurable: true })`
+   (spec attributes: non-writable, non-enumerable, configurable). Confirm the
+   wrapper cache keeps identity across crossings (`f === f` after two trips) so
+   the property is set once.
+2. Check what `__closure_arity` encodes for `(a, b = 1)` and `(a, ...r)` — the
+   spec value is the number of formals before the first default or rest (1 in
+   both). If the export counts all formals, fix the export, not the bridge.
+3. Regression test: `viaParam(f).length` for plain, default-param and
+   rest-param closures; control: direct `f.length` unchanged. Untyped `.js`
+   two-file fixtures, counts both ways.
+4. A/B all 17 suites per file — `_wrapWasmClosure` is on every host callback.
+   jest (mock arity checks), hono, axios are the ones to watch.
+
+### Slice 2 — `name`
+
+5. Host mode has no per-declaration name carrier (`$__fn_instance_meta`,
+   #4437, is standalone-only). Prefer the **twin of the arity export**: a
+   per-module `__closure_name(idx)` (or a string table indexed by closure
+   declaration index) that the bridge reads once at wrap time and installs
+   with `defineProperty(wrapped, "name", …)`. Names are per *declaration*, not
+   per instance, so the table is the declaration count — cheap. Measure the
+   module-size delta on a closure-heavy hono module and quote it. Extending
+   `$__fn_instance_meta` to host mode (a field per instance) is the fallback
+   if the table cannot be indexed from what the bridge is handed.
+6. NamedEvaluation for the **static** reads: `o.h.name` answers `"h"` and
+   `arr[0].name` answers `""` today. Find where `.name` on a statically known
+   closure is folded (grep `"name"` in `src/codegen/property-access*.ts` /
+   `member-get-dispatch.ts`) and make it use the declaration's own name when
+   the function had one; only an *anonymous* function expression takes the
+   storage key, and only for the NamedEvaluation sites (variable declaration,
+   property assignment) — never for an array element.
+7. Regression test: `viaParam(f).name`, `o.h.name`, `arr[0].name`, anonymous
+   arrow assigned to a const (`"g"`), anonymous in an array (`""`); A/B as in
+   step 4.
+
+## Dispatch
+
+Model: **opus** for slice 1 (well-understood, one export already exists).
+Slice 2 also **opus**, with the instruction to stop and record if the carrier
+cannot be a declaration-indexed table — that design question is the only
+hard part, and it should be decided by measurement (size delta, wrap-time
+cost) before any per-instance field is added. Dispatch after PR #5676 lands
+(it carries this file); not blocked on anything else.

--- a/plan/issues/5366-class-instance-field-from-constructor-option-reads-null.md
+++ b/plan/issues/5366-class-instance-field-from-constructor-option-reads-null.md
@@ -1,0 +1,126 @@
+---
+id: 5366
+title: "A class instance field assigned from a constructor-option object reads back null (hono `new Hono({ router })`)"
+status: ready
+sprint: current
+created: 2026-09-06
+updated: 2026-09-06
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+```js
+const app = new Hono({ router: new RegExpRouter() });
+app.router;        // native: the RegExpRouter instance   wasm: null
+app.router.name;   // native: "RegExpRouter"              wasm: TypeError
+```
+
+Measured through the hono upstream harness (`target: gc`, `platform: web`,
+`allowJs`), hono v4.12.16 published dist. The relevant source is two lines:
+
+```js
+// dist/hono-base.js — HonoBase declares the field with NO initializer
+router;
+// …and copies the constructor options onto the instance
+const { strict, ...optionsWithoutStrict } = options;
+Object.assign(this, optionsWithoutStrict);
+
+// dist/hono.js — the subclass then assigns it
+class Hono extends HonoBase {
+  constructor(options = {}) {
+    super(options);
+    this.router = options.router ?? new SmartRouter({ routers: [new RegExpRouter(), new TrieRouter()] });
+  }
+}
+```
+
+The **default** path is fine: `new Hono()` produces a working `SmartRouter`
+(routes register, `this.router.add(...)` runs, 11 routes recorded). Only the
+path where the value comes from the *options object* yields `null`. Which of
+the three candidate mechanisms is responsible is not yet bisected:
+
+- the uninitialized `router;` field declaration re-nulling the slot after the
+  subclass assignment (field-init ordering across `extends`);
+- the field's inferred struct type being narrowed to the default
+  `SmartRouter` shape so storing a `RegExpRouter` fails a `ref.cast`-style guard
+  and writes null;
+- `options.router` reading null out of the constructor-argument object literal
+  (or through the `Object.assign(this, {...rest})` object-rest copy).
+
+A short bisect of those three is the first step — each has a two-line repro.
+
+## Impact
+
+Found while fixing [#5339](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5339-hono-dev-index-whole-module-failure).
+It is the last of hono `src/helper/dev/index.test.ts`'s 8 tests
+(`getRouterName()` → `Cannot read properties of null (reading 'match')`); the
+other six residual failures are
+[#5365](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5365-host-closure-bridge-loses-length-and-name).
+A constructor that copies options onto `this` is an extremely common library
+shape, so the blast radius is likely wider than this one test.
+
+## Acceptance criteria
+
+1. The repro above returns the assigned instance in Wasm.
+2. The responsible mechanism is named in the issue before the fix lands (the
+   three candidates above are hypotheses, not a diagnosis).
+3. Regression test under `tests/` with untyped `.js` two-file fixtures, failing
+   on the parent and passing with the fix, plus an anti-vacuity control.
+4. A/B over the 17 dogfood suites, per test file.
+
+## Implementation Plan
+
+1. **Bisect the three candidates with one probe file** (standalone `.mjs`,
+   `compileAndRunUpstreamModule`, untyped `.js` two-file project, harness
+   sanity-checked). Base shape, then one variant per candidate:
+
+   ```js
+   class B { r; constructor(o) { const { strict, ...rest } = o; Object.assign(this, rest); } }
+   class H extends B { constructor(o = {}) { super(o); this.r = o.r ?? new Y(); } }
+   export function probe() { return String(new H({ r: new X() }).r instanceof X); }
+   ```
+
+   - A1: delete the `r;` field declaration → flips? ⇒ field-init ordering
+     re-nulls the slot after the subclass store.
+   - A2: replace the default `new Y()` with `null` → flips? ⇒ the field's
+     slot type was inferred from the default branch (`$Y`) and storing an `$X`
+     fails a guarded cast and writes null.
+   - A3: replace `o.r ?? …` with `o.r` → flips? ⇒ the `??` lowering narrows
+     to the right operand's type.
+   - A4: delete `Object.assign(this, rest)` → flips? ⇒ the object-rest copy
+     is writing the field.
+   Exactly one variant should flip; if none does, the literal `{ r: new X() }`
+   is the suspect (its anonymous struct's field typed by `X`'s shape — cf.
+   #5348 `shapeless-object-type.ts`), and `o.r` alone in a probe settles it.
+2. **Fix at the mechanism named by step 1.** The likely one is A2: a class
+   field assigned from a value whose static type is not a subtype of the
+   inferred slot (a parameter-property read, `any`) must widen the slot to the
+   common carrier at class-shape inference time — precedent
+   `heterogeneous-scalar-var-widening.ts` (#2011/#4204) for scalars and the
+   struct-carrier decision in `struct-carrier-inhabits.ts` (#5327). If A3, the
+   `??` lowering's result type must be the union of both operands, never the
+   right operand alone. If A1, the field initializer for a declared-but-
+   uninitialised field must run *before* the derived constructor's body, at
+   the base constructor's start — where JS runs it — not after `super()`
+   returns to the subclass.
+3. **Regression test**: the repro, the default path as the anti-vacuity
+   control (`new H()` works today), and the `Object.assign(this, rest)`
+   shape; untyped `.js` two-file fixtures; fails on parent, passes with fix,
+   exact counts both ways.
+4. **A/B at one HEAD**, 17 suites, per file. hono `helper/dev` +1
+   (`getRouterName`). Option-copying constructors are everywhere (axios's
+   `Axios` copies `instanceConfig`, jest's config objects) — improvements
+   welcome, regressions not.
+
+## Dispatch
+
+Model: **opus**. One probe file names the mechanism; the fix lands in an
+existing widening or ordering arm. Dispatch after PR #5676 lands (it carries
+this file).

--- a/plan/issues/5368-dogfood-validation-gate-declared-entry-only.md
+++ b/plan/issues/5368-dogfood-validation-gate-declared-entry-only.md
@@ -1,0 +1,68 @@
+---
+id: 5368
+title: "`check:dogfood-validation` compiles only each package's declared entry module — a subpath that emits invalid Wasm (`hono/dist/utils/color.js`, #5339) passes the gate green"
+status: ready
+sprint: current
+created: 2026-09-06
+updated: 2026-09-06
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: infra
+area: ci
+goal: correctness
+---
+
+## Problem
+
+`scripts/check-dogfood-validation.mjs` (#5336, required inside `quality`)
+asserts `compile.success ⇒ validates` — but only for each package's
+**declared entry module** (`<pkg>/dist/index.js`). A module the dogfood suite
+admits through a subpath is never compiled by the gate.
+
+#5339 is the measured miss: hono's `dist/utils/color.js` compiled to a module
+that failed `WebAssembly.compile` (`type error in return[0] (expected i32,
+got externref)` in `getColorEnabledAsync` — an inlined IIFE's `return`
+inside a `catch` clause left as a Wasm `return`), and **with that source
+restored the gate exits 0**. The invalid module was live on `main` with the
+gate green; it surfaced only as a whole-file `0/8` in the hono suite, where
+four agents had already misread the null `wasmError`.
+
+## Acceptance criteria
+
+1. The gate is **red** on the parent of #5339's fix (PR #5676) and green
+   after it — demonstrate both runs.
+2. It covers every module the dogfood suites admit, not just the declared
+   entry: the union of modules the suite runner compiles for each package
+   (the generated trees `.<pkg>-upstream-suite-generated/` enumerate exactly
+   that), or the package's exported subpath map — whichever the runner
+   already knows how to enumerate.
+3. Wall-clock stays inside the `quality` budget: ≤ 2× today's ~26 s, or
+   packages run in a worker pool (`cores − 1`). Quote before/after timings.
+4. On failure the message names the package, the module path, and the
+   validation error verbatim.
+
+## Implementation Plan
+
+1. Read the gate script and `tests/dogfood/upstream-suite-runner.mjs`'s
+   module enumeration (`UPSTREAM_TEST_EXPORTS`, the generated-tree layout).
+   Reuse the runner's enumeration rather than re-deriving `exports`
+   conditions from `package.json`.
+2. Compile every enumerated module with the same options the suite uses;
+   fail on any `success && !validates`. Keep compile-error modules out of the
+   verdict (they are a different gate's business) but count them in the
+   summary line.
+3. Parallelise per package if the budget needs it; keep output deterministic
+   (sorted by package, then path).
+4. Verify AC 1 by checking out #5676's parent in a detached worktree under
+   `<repo>/.claude/worktrees/`, running the gate there (red), then on main
+   (green). Record both in the PR body.
+5. `.github/workflows/**` is untouched (the gate is already wired); if a
+   workflow change is needed after all, expect the `needs-manual-enqueue`
+   label (#3584) — a lead action, not a hold.
+
+## Dispatch
+
+Model: **opus** (small CI change; opus rather than sonnet because the
+mandatory step-0 base recipe on this box has stalled two sonnet agents).

--- a/plan/issues/5369-unhandled-host-rejection-zeroes-test-module.md
+++ b/plan/issues/5369-unhandled-host-rejection-zeroes-test-module.md
@@ -1,0 +1,73 @@
+---
+id: 5369
+title: "One unobserved host-promise rejection inside a compiled module kills the dogfood worker and zeroes the whole test file — a single failing call reads as a 24-test cliff"
+status: ready
+sprint: current
+created: 2026-09-06
+updated: 2026-09-06
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: infra
+area: testing
+goal: correctness
+---
+
+## Problem
+
+#5362's bisect found that hono's `src/utils/cookie.test.ts` went 24/35 →
+0/35 on `main` because **one** `crypto.subtle.importKey` call (the
+binary-secret case) rejected and nobody observed the rejection: Node's
+default `unhandledRejection` behaviour terminated the suite worker, and every
+test in the file — including the 24 that had already passed — was recorded
+as failed with `wasmError: null`. Decisive control: with
+`process.on("unhandledRejection", …)` installed and nothing else changed,
+`main` scored exactly 24/35, the parent's number.
+
+So the harness turns any single host-API rejection into a whole-file zero,
+with a null per-test error and no reason in `compile.details` either. That is
+how a one-test defect looked like a 244 → 220 regression, cost a bisect, and
+would have been mis-attributed to whichever PR measured next.
+
+## Acceptance criteria
+
+1. An unhandled rejection raised while test N runs is attributed to test N
+   (its `wasmError` carries the rejection reason) and the remaining tests in
+   the file still run.
+2. A rejection outside any test (module init, `beforeAll`) is recorded on the
+   module: `compile.details[N].runtimeError = "unhandled rejection: <reason>"`
+   — never a silent null.
+3. The native lane is left symmetric (its own unhandled rejections are
+   attributed the same way), so a lane difference is still visible.
+4. A/B at one HEAD over all 17 suites: no count changes on current `main`
+   (#5362 already removed the trigger), demonstrated; plus a probe that
+   re-creates the parent's condition (a compiled call whose host promise
+   rejects, unobserved) showing the file no longer zeroes.
+5. The compiler-side sibling found in the same probe — `await getCryptoKey(…)`
+   handing back the Promise itself — is **not** fixed here; it is #5371.
+
+## Implementation Plan
+
+1. Read the worker in `tests/dogfood/upstream-suite-runner.mjs`
+   (`compileAndRunUpstreamModule`, `UPSTREAM_TEST_SHIM`): how tests are run
+   sequentially, where per-test results are written, and what happens on a
+   worker crash (today: every test of the file marked failed, `wasmError:
+   null`).
+2. Track the "current test" in the shim's `it` runner; install
+   `process.on("unhandledRejection")` in the worker that (a) records the
+   reason on the current test and resolves that test as failed, or (b) with no
+   current test, records it on the module. Do not swallow the reason; print it
+   once to the worker log too.
+3. Keep the worker alive: continue with the next test. If the rejection
+   arrives *after* the test settled (late), attribute it to the last test and
+   mark the attribution as late in the message.
+4. Regression: a fixture module whose one test calls a compiled function that
+   returns an unobserved rejecting host promise, followed by two passing
+   tests — must read 2/3 with the reason on test 1 (today 0/3, null).
+5. A/B; one PR. Touches `tests/dogfood/` only.
+
+## Dispatch
+
+Model: **opus**. Harness change with a clear contract; the only judgement is
+the attribution rule for late rejections.

--- a/plan/issues/5370-typed-array-carrier-host-boundary-fidelity.md
+++ b/plan/issues/5370-typed-array-carrier-host-boundary-fidelity.md
@@ -1,0 +1,77 @@
+---
+id: 5370
+title: "Typed-array carriers are not faithful at the host boundary: `ArrayBuffer.isView()` answers false for a compiled carrier, a host-built typed array loses its brand crossing in, and `new Uint8Array(<host typed array>)` builds an EMPTY carrier"
+status: ready
+sprint: current
+created: 2026-09-06
+updated: 2026-09-06
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+Three defects found while writing #5362's regression test, all pre-existing
+on `main` and none fixed there (#5362 only made `_wrapForHost` honour the
+`__register_typed_array` brand on the way *out*):
+
+1. `ArrayBuffer.isView(u8)` from compiled code answers `false` for a compiled
+   typed-array carrier (Node: `true`).
+2. A host-built typed array **loses its brand crossing in** through
+   `__vec_from_extern_<N>`: it arrives as a plain vec, so a later crossing
+   out re-emits a plain `Array` — the exact shape that made
+   `SubtleCrypto.importKey` reject in #5362.
+3. `new Uint8Array(<host typed array>)` builds an **empty** carrier
+   (`DataError: Zero-length key is not supported` from the next host call).
+
+hono's remaining `cookie.test.ts` failures (11/35 after #5362) and every
+WebCrypto / `TextEncoder` / `Buffer`-adjacent library path cross this
+boundary in both directions.
+
+## Acceptance criteria
+
+1. Three probes match Node: `ArrayBuffer.isView(new Uint8Array(3)) === true`
+   in compiled code; `f(hostU8)` where `f` is compiled and returns its
+   argument to a host `ArrayBuffer.isView` check answers `true` with the
+   contents intact; `new Uint8Array(hostU8).length === hostU8.length` with
+   equal contents.
+2. Regression test under `tests/`, untyped `.js` two-file fixtures, one case
+   per defect, failing on the parent and passing with the fix, exact counts
+   both ways, anti-vacuity control (a plain array literal is still a plain
+   `Array` on both sides).
+3. A/B at one HEAD over all 17 suites, per file — hono `cookie.test.ts` is
+   expected to move; nothing regresses.
+4. Standalone lane status recorded (these are host-boundary defects; the
+   standalone lane should be byte-identical).
+
+## Implementation Plan
+
+1. **Measure first, post-#5362.** Run the three probes on current `main`
+   (standalone `.mjs`, `compileAndRunUpstreamModule`, untyped `.js`): the
+   #5362 fix may already have flipped (1). Record exact results.
+2. **(1) `isView`**: find how the call is lowered — a static builtin arm
+   answering `false` for a struct (grep `isView` in `src/codegen` and
+   `src/runtime.ts`), or a host call whose argument crossed without the
+   brand. Fix at the arm that answers.
+3. **(2) crossing in**: in `__vec_from_extern_<N>` (host side, `src/runtime.ts`)
+   the host knows `ArrayBuffer.isView(src)` and the constructor name → typed
+   kind; register the brand (`__register_typed_array`, the kind #5362's
+   instrumentation showed as `taKind`) on the produced carrier. Check the
+   element copy keeps the element type (Uint8 vs Float64).
+4. **(3) `new Uint8Array(hostTA)`**: find the TypedArray constructor lowering
+   (grep `Uint8Array` in `src/codegen/typed-array*.ts` / `builtins`) and its
+   host-object arm — it likely reads `length` through a route that answers
+   `0` for a host typed array. Route it through the crossing-in path from
+   step 3 (copy + brand).
+5. Regression tests; A/B; one PR. Growth allowances for `src/runtime.ts` in
+   this issue's frontmatter with the reason, as #5362 did.
+
+## Dispatch
+
+Model: **opus**. Three located defects in known arms; the only design point
+is where the brand is registered on the way in.

--- a/plan/issues/5371-await-compiled-async-returning-host-promise.md
+++ b/plan/issues/5371-await-compiled-async-returning-host-promise.md
@@ -1,0 +1,62 @@
+---
+id: 5371
+title: "`await` of a compiled async function that returns a HOST promise hands back the Promise itself — hono `verifySignature` passes a pending Promise where `getCryptoKey` should have resolved to a CryptoKey"
+status: ready
+sprint: current
+created: 2026-09-06
+updated: 2026-09-06
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+Found by #5362's instrumentation of hono's signed-cookie path and left
+unfixed there. hono does
+
+```js
+const getCryptoKey = async (secret) => {
+  const secretBuf = typeof secret === "string" ? new TextEncoder().encode(secret) : secret;
+  return await crypto.subtle.importKey("raw", secretBuf, { name: "HMAC", hash: "SHA-256" }, false, ["sign", "verify"]);
+};
+const verifySignature = async (base64Signature, value, secret) => {
+  const secretKey = await getCryptoKey(secret);
+  return await crypto.subtle.verify({ name: "HMAC" }, secretKey, signatureBinary, dataBinary);
+};
+```
+
+and the probe shows `crypto.subtle.verify` receiving a **`Promise`** as
+`secretKey`: `await getCryptoKey(secret)` hands back the promise instead of
+the `CryptoKey` it resolves to. The compiled async function's return value is
+a host promise (from `importKey`); the promise the compiled function itself
+returns must **adopt** it (§27.2.1.3.2 Promise Resolve Functions: a thenable
+result schedules a PromiseResolveThenableJob), and/or the `await` must
+unwrap a host thenable. One of those two steps is not happening for a host
+promise flowing through a compiled async function.
+
+This is what keeps hono's `cookie.test.ts` at 24/35 after #5362 (the signed
+`getSignedCookie` / `verifySignature` tests), and the shape — an async
+wrapper around a host async API — is universal in library code.
+
+## Acceptance criteria
+
+1. Probe matches Node: `async function gk() { return crypto.subtle.importKey(...) }` (with and without the inner `await`) followed by `const k = await gk(); return k.type` returns `"secret"`, in an untyped `.js` two-file project. Also `async function w() { return Promise.resolve(7) }` → `await w()` is `7`, and `async function w2() { return hostAsyncFn() }` for a host function that returns a promise.
+2. Regression test under `tests/` for those shapes, failing on the parent, passing with the fix, exact counts both ways, anti-vacuity control (an async function returning a plain value already works).
+3. A/B at one HEAD, 17 suites, per file — hono `cookie.test.ts` expected up; jest/axios (promise-heavy) watched; no regressions.
+4. Both lanes: the host lane's promise resolution and the standalone/native-first promise implementation must both adopt thenables; record the standalone status explicitly.
+
+## Implementation Plan
+
+1. **Reduce** with the four shapes in AC 1 (standalone `.mjs`, `compileAndRunUpstreamModule`). Determine which step fails: (a) the async function's *return* — does the compiled promise resolve with the host promise as a plain value? (b) the *await* — does `await <host promise>` unwrap? Shape `await w2()` vs `await hostAsyncFn()` directly separates them.
+2. **Read the async lowering's return path** (grep `async` in `src/codegen/statements/` and `src/codegen/async*.ts`; the resolve import — `__promise_resolve` / `__async_return` — in `src/runtime.ts`) and the `await` lowering. In the host lane the resolve function should be `Promise.resolve`-adopting (`resolve(value)` on a real Promise capability adopts thenables for free — if the runtime resolves via a hand-rolled settle that stores the value, that is the defect). In the standalone/native-first lane, the promise implementation's resolve must check `typeof value?.then === "function"` and adopt.
+3. Fix at the resolve function (or the await unwrap), not at call sites. Do not special-case host promises: the rule is "a thenable result adopts".
+4. Regression tests, both lanes; A/B; one PR.
+
+## Dispatch
+
+Model: **opus**. One reduction separates the two candidate steps; the fix is at a single resolve/await site per lane.


### PR DESCRIPTION
Docs-only (six issue files, +562 lines, nothing else).

Plans added to two issues the #5339 agent filed without one:
- [#5365](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5365-host-closure-bridge-loses-length-and-name) — closure `length`/`name` across the host bridge, two slices (`length` from the existing arity export; `name` from a declaration-indexed table).
- [#5366](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5366-class-instance-field-from-constructor-option-reads-null) — `new Hono({ router })` field reads null; one probe with four variants names the mechanism.

New, from #5362's and #5339's reports:
- [#5368](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5368-dogfood-validation-gate-declared-entry-only) — `check:dogfood-validation` compiles only the declared entry module; #5339's invalid Wasm passed it green.
- [#5369](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5369-unhandled-host-rejection-zeroes-test-module) — one unobserved host-promise rejection zeroes a whole test file (how a one-test defect read as hono 244 → 220).
- [#5370](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5370-typed-array-carrier-host-boundary-fidelity) — `ArrayBuffer.isView` false for a carrier; brand lost crossing in; `new Uint8Array(hostTA)` empty.
- [#5371](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5371-await-compiled-async-returning-host-promise) — `await` of a compiled async function returning a host promise hands back the promise.

#5365/#5366 are also added by PR #5676 (without the plan sections); whichever lands second keeps the version with the plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)