### PR TITLE
docs(issues): file #5373 (Array-subclass toString bypassed — every linked Instant/ZonedDateTime read) and #5374 (valueOf never called across the seam)

### DIFF
--- a/plan/issues/5373-array-subclass-tostring-dispatch.md
+++ b/plan/issues/5373-array-subclass-tostring-dispatch.md
@@ -1,0 +1,154 @@
+---
+id: 5373
+title: "`String(x)` / `${x}` / any-typed `x.toString()` on a `class extends Array` instance run the built-in array join instead of the subclass override — every linked-Temporal `Instant`/`ZonedDateTime` read fails (JSBI is `class JSBI extends Array`)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-09-06
+---
+
+# #5373 — Array-subclass `toString` override is bypassed by the coercion paths
+
+## Problem
+
+Reduction, no Temporal, measured through the test262 runner (provider linked,
+same compile options as a conformance row — `.tmp/probe-5365/array-subclass.js`
+in the dev-5364 worktree, 2026-09-06):
+
+```js
+class B extends Array {
+  constructor(n, s) { super(n); this.sign = s; }
+  toString() { return "B(" + this.length + ")"; }
+  dig(i) { return this[i]; }
+}
+const b = new B(3, false); b[0] = 1; b[1] = 2; b[2] = 3;
+function anyStr(x) { return String(x) + "|" + x.toString() + "|" + ("" + x); }
+```
+
+| expression        | compiled       | node     |
+| ----------------- | -------------- | -------- |
+| `b.toString()`    | `B(3)`         | `B(3)`   |
+| `"" + b`          | `B(3)`         | `B(3)`   |
+| `String(b)`       | **`1,2,3`**    | `B(3)`   |
+| `` `${b}` ``      | **`1,2,3`**    | `B(3)`   |
+| `anyStr(b)`       | **`1,2,3\|1,2,3\|B(3)`** | `B(3)\|B(3)\|B(3)` |
+
+`b.length`, `b.dig(1)`, `Array.isArray(b)`, `b instanceof B`, `b.sign`,
+`new B(4).length`, `push`, `map` are all correct. Only the **string-coercion
+paths and the any-typed method call** resolve `toString` to the built-in array
+join instead of the subclass's own override.
+
+### Why it matters — every `Instant` / `ZonedDateTime` read
+
+`jsbi@4.3.0` is `class JSBI extends Array { constructor(i,_) { super(i);
+this.sign=_; Object.setPrototypeOf(this, JSBI.prototype); … } }` with its own
+`toString(radix)`. The polyfill exposes every BigInt through
+`ko(e){const t=Lo(e);return void 0!==globalThis.BigInt?globalThis.BigInt(t.toString(10)):t}` —
+`t` is any-typed, so the compiled `t.toString(10)` joins the digit array:
+
+```
+Temporal.Instant.from("2024-01-01T00:00:00Z").epochNanoseconds
+  → SyntaxError: Cannot convert 23396352,513294428,1 to a BigInt
+Temporal.ZonedDateTime.from({year:2024,month:1,day:1,hour:12,minute:34,timeZone:"UTC"}).year
+  → RangeError: infinity is out of range        (ISO calendar, UTC — nothing exotic)
+new Temporal.ZonedDateTime(1704067200000000000n, "UTC")
+  → ctor ok, .epochMilliseconds = 1704067200000 (number path fine),
+    .year / .daysInMonth → "infinity is out of range", .offsetNanoseconds → NaN,
+    .epochNanoseconds → the comma-joined carrier above
+```
+
+(`.tmp/probe-5365/{instant-epoch,zdt-ctor,zdt-iso,zdt-gregory-steps}.js`.)
+The `infinity is out of range` arm is the same defect one step later: a JSBI
+value stringified as `"a,b,c"` then re-parsed is `NaN`/`Infinity` inside
+`JSBI.toNumber` / `ToIntegerWithTruncation`. This is the whole "9–22 ×
+`infinity is out of range`, ZonedDateTime only" residual that #5251, #5354,
+#5208 and #5360 each reported and left, and the `Cannot convert … to a BigInt`
+row family of #5245 (Duration `total`/`round`).
+
+On the 123-row #5249 list (batch-fixed.tsv, after #5364): 22 rows
+`infinity is out of range`, of which the node control passes 8
+(`daysInMonth/basic-{ethioaa,japanese}`, `monthsInYear/basic-islamic-civil`,
+`since/{basic-buddhist,leap-year-japanese}`, `subtract/constrain-day-japanese`,
+`until/leap-year-japanese`); the other 14 also fail under node on the pinned
+polyfill (era-code version gap, #5360) and are unblocked only for their next
+layer. Beyond that list, every `built-ins/Temporal/Instant/*` and
+`ZonedDateTime/*` row that reads a BigInt-backed field is in this family —
+expect the bucket to be hundreds of rows in the merge-group report.
+
+## Implementation Plan (Fable, 2026-09-06)
+
+**Step 1 — find the three dispatch sites.** Which runtime/codegen path serves
+each wrong cell:
+
+- `String(x)` and `` `${x}` `` — `emitToString` in
+  `src/codegen/coercion-engine.ts` (~L211): the struct/externref arm goes to
+  `tryStructToString` / `__extern_toString` / `__extern_to_string_default`. Find
+  where the RUNTIME side (`src/runtime.ts`: the ToPrimitive helpers around
+  L3620–3700 — `tryMethod("toString")`, the `methodNames` order at L3691/L4169 —
+  and the `_wrapForHost` proxy trap at ~L8490 that special-cases
+  `toString`/`valueOf`) decides "this is an array → join". The likely shape is
+  an `Array.isArray(mirror)` / vec check that runs BEFORE the struct's own
+  method lookup. Log which branch fires for `B` and for a plain array.
+- Any-typed `x.toString()` — the dynamic method-call path
+  (`__call_method`/`invokeMethod` family in `src/runtime.ts`, and
+  `src/runtime/class-method-host-bridge.ts` `resolveClassMemberOnInstance`):
+  same question, an array fast path that pre-empts the class's own method table.
+
+State all three in the PR with the line numbers.
+
+**Step 2 — fix: subclass override first, built-in second.** For a receiver
+whose struct IS a class instance (it has a class object / `__tag` — the
+#5354 `__class_object_of` answers this, and the pre-existing
+`_prototypeMethodNames` / class method tables do too), look up the method on
+the class chain BEFORE the array/vec built-in. Plain arrays (no class) keep the
+fast path byte-for-byte. Do not special-case `toString`: the same ordering bug
+affects any built-in name a subclass overrides (`join`, `slice`, `valueOf`,
+`Symbol.toPrimitive`), so fix the ORDER, then verify `join` and `valueOf`
+overrides in the test.
+
+**Step 3 — `toString(radix)` with an argument** through the any-typed path
+(the polyfill's exact call). Include it in the reduction; the arg must reach the
+override.
+
+**Step 4 — tests.** `tests/issue-5373-array-subclass-tostring.test.ts`: the
+table above (all five expressions + `join`/`valueOf` overrides + `toString(10)`
+with an argument), base-failing on the three wrong cells, plus a plain-array
+control that must not change. Single-module AND linked-provider lanes (the JSBI
+class lives in the PROVIDER — use the two-lane template of
+`tests/issue-5225-consumer-literal-seam.test.ts`).
+
+**Step 5 — measure.** (a) The direct probes: `Instant.from(...).epochNanoseconds`
+must be a `bigint`, `ZonedDateTime.from({…ISO…, timeZone:"UTC"}).year` must be
+2024. (b) The 123-row list, batch (post-#5364 driver, fresh
+`JS2WASM_TEMPORAL_CACHE`): expect the 22 `infinity is out of range` rows to
+move (8 to pass or a next layer; 14 to the #5360 era layer). (c) A bounded
+Temporal sample that does not overlap the 123: `built-ins/Temporal/Instant/**`
+(~700 rows) and `built-ins/Temporal/ZonedDateTime/prototype/{year,month,day,epochNanoseconds,epochMilliseconds}/**`
+— base vs fix, per row, 0 pass→fail. Never the full 838/6,600-row bucket.
+
+**Order-preservation constraints.** The array fast path for plain arrays is a
+hot path (`__extern_get` / `join` on `mixed`/`csv-parse` benchmarks, #3903) —
+the class-chain lookup must be gated on "receiver is a class instance", not on
+"receiver looks like an array", so a plain array never pays for it. Equivalence
+gate at baseline.
+
+## Acceptance criteria
+
+1. Step 1 answered with the three sites.
+2. Table above all-green in both lanes; plain-array control unchanged.
+3. `Instant.epochNanoseconds` is a `bigint`; ISO `ZonedDateTime.year` reads.
+4. 123-row and Instant/ZonedDateTime samples measured, 0 pass→fail, counts
+   stated with the artifact they came from.
+
+## Notes
+
+- Found while planning the next Temporal slice after #5364; supersedes the
+  "infinity is out of range, ZonedDateTime only — not probed" rows of #5251,
+  #5354, #5208 and #5360, and the `Cannot convert … to a BigInt` half of #5245.
+- Id reserved via `claim-issue --allocate --allow-unscanned` (no `gh` in this
+  container); open PRs hand-checked 2026-09-06 — highest in-flight issue file
+  is #5364.

--- a/plan/issues/5374-valueof-object-across-linked-seam.md
+++ b/plan/issues/5374-valueof-object-across-linked-seam.md
@@ -1,0 +1,114 @@
+---
+id: 5374
+title: "A consumer object with `valueOf` handed to a linked provider coerces to 0 / no throw — `valueOf` is never called across the seam (`toPrimitiveObserver` rows; `infinity-throws-rangeerror` ×3)"
+status: ready
+sprint: current
+priority: high
+horizon: s
+goal: core-semantics
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-09-06
+---
+
+# #5374 — ToNumber on a consumer-minted `{ valueOf() {…} }` inside the provider
+
+## Problem
+
+Measured through the test262 runner, provider linked
+(`.tmp/probe-5365/{valueof-consumer,valueof-seam,pym-observer}.js` in the
+dev-5364 worktree, 2026-09-06):
+
+| where the coercion runs | expression | compiled | node |
+| --- | --- | --- | --- |
+| consumer only | `Number({ valueOf(){ return 7 } })`, `+o`, `o*1`, via `function(x){return Number(x)}` | 7 | 7 |
+| consumer only | observer `{valueOf(){calls.push(…); return Infinity}}` | `Infinity`, calls=`valueOf` | same |
+| **provider** | `Temporal.PlainDate.from({ year: 2000, month: obs, day: 1 })` | `RangeError: Cannot convert a number less than one to a positive integer`, **calls = []** | month 3 |
+| **provider** | `PlainDate.from({ year:2000, month:1, day: { valueOf(){ return Infinity } } })` | same RangeError (read as 0), no valueOf call | RangeError `invalid number value` |
+| **provider** | `Duration.from({ hours: { valueOf(){ return 2 } } })` | `hours === 0` | 2 |
+| **provider** | `PlainYearMonth.from({ era:"ad", month:5, calendar:"gregory", eraYear: obj })` (obj = `TemporalHelpers.toPrimitiveObserver(calls, Infinity, "eraYear")`) | no throw, calls = [] | RangeError |
+
+So the consumer's own coercion is correct, and the plain-number half of the
+same rows is correct (`eraYear: Infinity` → `RangeError: invalid number value`,
+as node). What fails is: a consumer-minted object whose `valueOf` is a compiled
+closure, read by the PROVIDER through the #5225 cross-module decoder, then
+coerced with the provider's `ToNumber`. The value arrives as `0` (or an
+"absent" that the polyfill's `ToIntegerWithTruncation` reads as 0), and the
+closure is never invoked.
+
+This is exactly the second half of every `TemporalHelpers.toPrimitiveObserver`
+row and the whole of the 3 `infinity-throws-rangeerror` rows on the 123-row
+list (`PlainDateTime/prototype/since`, `PlainMonthDay/prototype/toPlainDate`,
+`PlainYearMonth/from`) — the node control passes all three. Beyond that list
+the helper is used by `checkStringOptionWrongType`, `checkRoundingIncrement…`
+and the `*-wrong-type` / `*-non-integer` families across every Temporal type,
+so the bucket is wide.
+
+## Implementation Plan (Fable, 2026-09-06)
+
+**Step 1 — which coercion runs, and what it sees.** Reduce with the two-lane
+template of `tests/issue-5225-consumer-literal-seam.test.ts`: provider
+`export function num(o) { return Number(o.v); }`, `plus(o) { return +o.v; }`,
+`trunc(o) { return Math.trunc(Number(o.v)); }`, `direct(x) { return Number(x); }`;
+consumer passes `{ v: { valueOf() { return 7; } } }` and the bare observer.
+Expected 7 in both lanes. Then instrument the provider-side path in
+`src/runtime.ts`: the ToPrimitive helpers (L3620–3700 — `tryMethod("valueOf")`,
+the `methodNames` order, the `__call_fn_0` / `__call_@@toPrimitive` arms at
+~L3486) and whichever `_decoderExportsFor` (#5225, ~L6178) call sits in front
+of them. Hypotheses, most likely first:
+
+1. The provider's ToPrimitive resolves `valueOf` through the PROVIDER's own
+   exports (`callbackState.getExports()`), which cannot name a consumer closure
+   → treated as "no valueOf" → `+{}`-style NaN → the polyfill's
+   `ToIntegerWithTruncation` maps a non-number to 0. Fix: route the closure
+   lookup and the `__call_fn_0` invocation through `_decoderExportsFor(obj,
+   exports)` the way #5225 did for field reads.
+2. The consumer literal is decoded field-wise into a plain host object whose
+   `valueOf` slot is a raw closure struct (not callable) → `typeof !== "function"`
+   → skipped. Fix: wrap via `_wrapWasmClosure` with the OWNING module's state
+   before the primitive lookup.
+
+State which one with the instrumented log line in the PR.
+
+**Step 2 — fix at the seam, not in the polyfill.** Whatever Step 1 says, the
+fix belongs in the runtime's ToPrimitive / closure-call path with the owning
+module's exports; no new host import, no change to consumer-only coercion (keep
+the consumer table byte-identical).
+
+**Step 3 — `toString` and `Symbol.toPrimitive` too.** The same lookup serves
+`hint: "string"` (`toString` first) and `@@toPrimitive`; cover both in the
+test — the string-option `checkStringOptionWrongType` rows depend on the
+`toString` arm.
+
+**Step 4 — tests.** `tests/issue-5374-valueof-across-seam.test.ts`: the
+provider/consumer reduction above for `valueOf`, `toString`,
+`Symbol.toPrimitive`, an `Infinity`-returning `valueOf` that must reach a
+provider-side `if (!Number.isFinite(n)) throw new RangeError(...)`, and the
+call-order observer (`calls` must contain `valueOf` exactly once). Base-failing
+on the linked lane, green on the single-module control.
+
+**Step 5 — measure.** The 3 `infinity-throws-rangeerror` rows + the 123-row
+list (batch, post-#5364 driver, fresh cache) — 0 pass→fail; and a bounded
+sample of `built-ins/Temporal/**/argument-object-tostring.js` /
+`*-wrong-type.js` / `*-non-integer.js` (`find test262/test/built-ins/Temporal
+-name "*wrong-type*"` ≈ 400 rows) base vs fix, per row.
+
+**Order-preservation constraint.** Single-module ToPrimitive is unchanged; the
+extra decoder lookup is on the miss path only (the `enabled` boolean of the
+#5225 registry short-circuits it when no linked project is live).
+
+## Acceptance criteria
+
+1. Step 1 answered with the log line.
+2. Reduction green in both lanes for `valueOf` / `toString` / `@@toPrimitive`
+   and the observer call order.
+3. 3 `infinity-throws-rangeerror` rows pass; samples measured, 0 pass→fail,
+   counts stated with artifacts.
+
+## Notes
+
+- Found while planning the next Temporal slice after #5364. Independent of
+  #5373 (Array-subclass dispatch) — the two can run in parallel.
+- Id reserved via `claim-issue --allocate --allow-unscanned` (no `gh` in this
+  container); open PRs hand-checked 2026-09-06 — highest in-flight issue file
+  is #5364.


### PR DESCRIPTION
Two issue files with implementation plans, measured through the test262 runner on the post-#5364 driver (batch now equals solo), fresh provider cache.

- [#5373](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5373-array-subclass-tostring-dispatch) — `String(x)`, `` `${x}` `` and any-typed `x.toString()` on a `class extends Array` instance run the built-in array join instead of the subclass override (`b.toString()` and `"" + b` are correct). `jsbi` is `class JSBI extends Array`, and the polyfill exposes every BigInt via `globalThis.BigInt(t.toString(10))`, so `Instant.epochNanoseconds` throws `Cannot convert 23396352,513294428,1 to a BigInt` and every ISO/UTC `ZonedDateTime.year`-style read fails `infinity is out of range`. This is the residual that [#5251](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5251-temporal-numeric-calendar-seam-families), [#5354](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5354-linked-class-instanceof-prototype-identity), [#5208](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5208-compiled-date-host-date-bridge) and [#5360](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5360-temporal-era-arithmetic-seam) each reported and left.
- [#5374](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5374-valueof-object-across-linked-seam) — a consumer object with `valueOf` handed to the linked provider coerces to 0 and `valueOf` is never called (consumer-only coercion is correct; the plain-number half of the same rows is correct). The `TemporalHelpers.toPrimitiveObserver` half of the `*-wrong-type` families and the 3 `infinity-throws-rangeerror` rows.

Docs-only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_