### PR TITLE
test(#5340): pin the numeric round-trip through a tagged template's surplus arguments; file #5367

### DIFF
--- a/plan/issues/5340-hono-concurrent-invalid-array-length.md
+++ b/plan/issues/5340-hono-concurrent-invalid-array-length.md
@@ -1,10 +1,11 @@
 ---
 id: 5340
 title: "hono utils/concurrent: `RangeError: Invalid array length` on every test (0/6)"
-status: ready
+status: done
 sprint: current
 created: 2026-09-05
-updated: 2026-09-05
+updated: 2026-09-06
+completed: 2026-09-06
 priority: high
 horizon: s
 feasibility: medium
@@ -12,6 +13,8 @@ reasoning_effort: high
 task_type: bug
 area: compiler
 goal: correctness
+language_feature: tagged-template, arguments
+related: [5338, 5367]
 ---
 
 ## Problem
@@ -83,3 +86,122 @@ Measured on a clean detached worktree at main `c9a8b48616`.
 Model: **opus**. Small file, sharp symptom, but the fix likely lands in
 `call-identifier.ts` / `type-coercion.ts`, both of which have bitten this
 effort with "looks equivalent, isn't" hazards.
+
+## Resolution
+
+**Fixed by #5338, not by this issue's own PR.** The two issues were filed from
+different symptoms of one defect and worked in parallel; #5338 landed first
+(`src/codegen/tagged-template-arguments.ts` + `src/codegen/template-raw-dynamic.ts`,
+merged into main before `cbd2f11dff`). What this issue contributes is the
+diagnosis chain that connects the two, a value-level regression guard #5338's
+own test deliberately does not cover, and the identification of the residual.
+
+### The spec's mechanism was a hypothesis, and it was wrong
+
+The plan expected a number crossing a host boundary as the undefined sentinel or
+an unbridged `externref → f64` unbox, and pointed at `allowProvenNumberUnbox`
+(`call-identifier.ts`, #5328) and `type-coercion.ts`. None of that is involved.
+`concurrent.ts` contains no `new Array(`, `.length =` or `Array.from({length})`
+at all — the length operand lives in the *test* file, and two of the six failing
+tests pass a **literal** `10` to `new Array`, which no value-corruption story
+explains.
+
+### Root cause (the same one #5338 fixed)
+
+`compileTaggedTemplateExpression` marshalled at most one positional slot per
+DECLARED parameter and dropped every substitution past that, in four of its five
+lowering arms. The dogfood shim's table tag is the shape that breaks:
+
+```js
+function __upstreamEach(cases) {                                  // ONE parameter
+  const values = Array.prototype.slice.call(arguments, 1);        // reads the rest
+  const tableRows = Array.isArray(cases) && cases.raw && values.length > 0 ? … : null;
+```
+
+Measured inside the compiled module on the pre-fix parent: `arguments.length ===
+1`, `values.length === 0`, and `cases.raw` absent. So `tableRows` was `null`,
+`sourceCases` fell back to the **template strings array**, and the test body was
+invoked with `strings[0]` — the raw 25-character table header — instead of its
+row object. `Object.keys(row)` returned `[0,1,…,24]` (a string's indices) in
+Wasm versus `[concurrency,count]` natively; `row.count` was `undefined`; and
+`new Array(undefined)` reaches the host as `new Array(NaN)`, which is
+`RangeError: Invalid array length`.
+
+The literal-`10` tests failed for the same reason one level up: the whole row
+object was wrong, so the body diverged before the literal ever mattered. That is
+the observation that rules out every value-corruption explanation, and it is
+worth recording — it is what makes the tagged-template diagnosis the only one
+consistent with the evidence.
+
+Both halves of the harness gate had to be fixed, and #5338 fixed both: the
+missing substitutions (`__argc`/`__extras_argv`, the protocol an ordinary
+over-arity call already uses) **and** `cases.raw`, which fell through to
+`__extern_get` and answered `undefined` for any tag whose strings parameter
+lowered to `externref`.
+
+### Verified on main `cbd2f11dff`
+
+| file | pre-#5338 (`a1469a5454`) | main `cbd2f11dff` |
+| --- | --- | --- |
+| `src/utils/ipaddr.test.ts` | 4/16 | **13/16** |
+| `src/utils/concurrent.test.ts` | 0/6 | 0/6 (different failure) |
+| hono total | 220/324 | **229/324** |
+
+`RangeError: Invalid array length` is gone from all six concurrent tests; the
+per-test `wasmError` is now an ordinary assertion mismatch.
+
+### Residual — acceptance criterion 1 is NOT met
+
+`src/utils/concurrent.test.ts` is still **0/6**, blocked by an **independent**
+defect filed as **#5367**: `await Promise.all(…)` on a call expression yields a
+default-initialised tuple / empty array instead of the resolved values, and does
+not wait for the pending promises. All six of these tests end in
+`const results = await Promise.all(resultPromises)`; four then assert on state
+the un-awaited continuations were meant to mutate.
+
+Four-line repro, re-verified on `cbd2f11dff`:
+
+```js
+export async function run() {
+  const r = await Promise.all([Promise.resolve(1), Promise.resolve(2)])
+  return 'INLINE len=' + String(r.length) + ' json=' + JSON.stringify(r)
+}
+export async function probe() {
+  const p = Promise.all([Promise.resolve(1), Promise.resolve(2)])
+  const r = await p
+  return 'VIA-LOCAL len=' + String(r.length) + ' json=' + JSON.stringify(r)
+}
+// INLINE    len=NaN json={"_0":null,"_1":null}   ← wrong
+// VIA-LOCAL len=2   json=[1,2]                   ← correct
+```
+
+Binding the promise to a local first is correct, which is why this was invisible
+until the tagged-template defect was cleared. Full reproduction ladder in #5367.
+
+### What this PR adds
+
+`tests/issue-5340-tagged-template-extra-substitutions.test.ts` — the **value**
+guard that complements #5338's **arity** guard. #5338's regression test uses
+STRING substitutions on purpose (its own comment: "an untyped parameter lowers
+to f64 in this lane"), so the numeric round-trip — the thing that actually
+produced `RangeError: Invalid array length` — is unpinned by it. This test pins
+`new Array(n).fill(0).length === n` for a number that crossed the surplus path,
+in untyped `.js` two-file fixtures, with an anti-vacuity control on the plain
+over-arity CALL and an in-arity control. Measured: 2 of 3 cases fail on the
+pre-#5338 parent, all 3 pass from #5338 onward.
+
+### Superseded work
+
+An independent fix for the same root cause was implemented on
+`issue-5340-hono-concurrent-array-length` before #5338 was visible
+(`src/codegen/tagged-template-extras.ts`, same `__argc`/`__extras_argv`
+mechanism, same four arms) and measured green: 17-suite A/B at one HEAD, 16 of
+17 suites per-file identical, hono 220→229 with 9 flips all `failed → passed`.
+It was **discarded in favour of #5338's**, which is strictly better: it also
+fixes `strings.raw`, and it guards `userParamCount < 1`, which the superseded
+version did not — a zero-parameter tag with substitutions would have indexed
+`substitutions[-1]` there.
+
+The duplication is the known blind spot in `pre-dispatch-gate.mjs`: the two
+issues overlap by *idiom*, not by id, neither cites the other, and #5338 was
+in flight without a claim visible to this lane at dispatch time.

--- a/plan/issues/5367-await-promise-all-inline-loses-result.md
+++ b/plan/issues/5367-await-promise-all-inline-loses-result.md
@@ -1,0 +1,119 @@
+---
+id: 5367
+title: "`await Promise.all(...)` inline yields the wrong value (a default-initialised tuple / empty array)"
+status: ready
+sprint: current
+created: 2026-09-06
+updated: 2026-09-06
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: compiler
+goal: correctness
+language_feature: async, Promise.all
+related: [5340, 5338, 1042, 1373b, 4110, 1727]
+---
+
+## Problem
+
+Awaiting a `Promise.all(…)` **call expression directly** produces a value that
+is not the resolved array. Binding the promise to a local first and awaiting
+the local is correct. Measured on a clean detached worktree at upstream/main
+`cbd2f11dff` (and on `a1469a5454`), JS-host GC lane (`target: "gc"`, `platform: "web"`), with and
+without `experimentalIR` — both reproduce.
+
+Four-line repro (`compileProject`, untyped `.js`):
+
+```js
+export async function run() {
+  const r = await Promise.all([Promise.resolve(1), Promise.resolve(2)])
+  return 'INLINE len=' + String(r.length) + ' i0=' + String(r[0]) + ' json=' + JSON.stringify(r)
+}
+
+export async function probe() {
+  const p = Promise.all([Promise.resolve(1), Promise.resolve(2)])
+  const r = await p
+  return 'VIA-LOCAL len=' + String(r.length) + ' i0=' + String(r[0]) + ' json=' + JSON.stringify(r)
+}
+```
+
+```
+RUN   => INLINE    len=NaN i0=NaN json={"_0":null,"_1":null}   ← wrong
+PROBE => VIA-LOCAL len=2   i0=1   json=[1,2]                   ← correct
+```
+
+`{"_0":null,"_1":null}` is a **default-initialised wasm tuple struct** — the
+static awaited type of `Promise.all([Promise<number>, Promise<number>])` is the
+tuple `[number, number]`, and the resume binding appears to materialise that
+type instead of carrying the host array through. When the argument is a
+**variable** rather than an array literal (so the awaited type is `number[]`)
+the same shape produces an **empty array** instead:
+
+```
+const ps = [7, 8].map((i) => fn(i))
+const r  = await Promise.all(ps)     // len=0, json=[]
+```
+
+An explicit `const r: any = await Promise.all([…])` does **not** fix it (it
+yields `{}`), so this is not purely a tuple-type materialisation.
+
+Worse, in the array-of-pending-promises form the awaited continuations never
+run at all: with `fn = async (i) => { seen.push('s'+i); await gate; seen.push('e'+i); return i }`,
+`await Promise.all([fn(0), fn(1)])` returns `[]` and `seen` is `s0|s1` — the
+`e0|e1` half never executes. So `Promise.all` is not merely returning the wrong
+value, it is not waiting.
+
+`await Promise.resolve(1)` is correct, and sequential `await a; await b` on the
+same promises is correct — the defect is specific to the aggregator call in
+await position.
+
+## Impact
+
+This is the sole remaining blocker for hono `src/utils/concurrent.test.ts`
+(0/6 on main `cbd2f11dff`). All six of its tests end in
+`const results = await Promise.all(resultPromises)`, and four of them then assert
+on state the un-awaited continuations were meant to mutate. It surfaced while
+investigating #5340, whose own root cause — tagged-template substitutions
+dropped — #5338 fixed: with the `RangeError: Invalid array length` gone, every
+one of the six now fails here instead.
+
+Anything that fans out with `Promise.all` is affected, so the blast radius is
+much wider than one hono file.
+
+## Reproduction ladder (all measured, JS-host GC lane)
+
+| shape | result | native |
+| --- | --- | --- |
+| `await Promise.resolve(1)` | `1` ✅ | `1` |
+| `const p = Promise.all([…]); await p` | `[1,2]` ✅ | `[1,2]` |
+| `await Promise.all([Promise.resolve(1), Promise.resolve(2)])` | `{_0:null,_1:null}` ❌ | `[1,2]` |
+| `await Promise.all(psVariable)` | `[]` ❌ | `[1,2]` |
+| `await Promise.all([7,8].map(fn))` | `[]`, continuations skipped ❌ | `[7,8]` |
+| `const a = fn(7); const b = fn(8); await a; await b` | `7`, `8` ✅ | `7`, `8` |
+
+## Where to look
+
+- `src/codegen/expressions/call-namespace-static.ts` — the aggregator arm is
+  reached (verified by instrumentation); it emits the `Promise_all(thisArg,
+  iterable, directCall)` host import and returns `externref`. The host import
+  itself (`src/runtime.ts` ~15638 `Promise.all.call(C, _toIterable(arr))`) is a
+  faithful delegation, so the loss is on the consumer side.
+- `src/codegen/async-cps.ts` / `src/codegen/async-ir-planning.ts` — the resume
+  binding's wasm type and the coercion applied to the resumed externref.
+  `isAmbientPromiseAll` (async-ir-planning ~490) is a *specialised* path for
+  `await Promise.all(<identifier>)`; the array-literal form does not take it,
+  and both forms are wrong, so the defect is likely in the shared resume-binding
+  typing rather than in that specialisation.
+
+## Acceptance criteria
+
+1. The four-line repro above prints the same string for `run()` and `probe()`.
+2. hono `src/utils/concurrent.test.ts` ≥ 5/6 (its `RangeError` blocker is
+   already fixed on main by #5338).
+3. Regression test under `tests/`, untyped `.js` two-file fixtures, failing on
+   the parent and passing with the fix, pinning the resolved VALUES (not just
+   `length`), with an anti-vacuity control on the via-local form that already
+   works.
+4. A/B at one HEAD over all 17 dogfood suites, per test file.

--- a/tests/issue-5340-tagged-template-extra-substitutions.test.ts
+++ b/tests/issue-5340-tagged-template-extra-substitutions.test.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#5340) A NUMERIC tagged-template substitution must survive the surplus-
+// argument path as a usable number, all the way into a host `new Array(n)`.
+//
+// #5338 fixed the arity half of this: `compileTaggedTemplateExpression`
+// marshalled at most `declaredParams - 1` substitutions into positional slots
+// and dropped the rest, so a tag reading `arguments` (the vitest/jest
+// `test.each\`table\`` helper) saw `arguments.length === 1`. Its regression test
+// (`issue-5338-tagged-template-call-site-arity.test.ts`) pins that the
+// substitutions arrive at all, and that `strings.raw` is the raw parts.
+//
+// It deliberately uses STRING substitutions — its own comment explains why: "an
+// untyped parameter lowers to f64 in this lane, so a string substitution would
+// read NaN here for reasons that have nothing to do with this issue". That
+// leaves the numeric round-trip unpinned, and the numeric round-trip is exactly
+// what #5340 was reported as:
+//
+//   RangeError: Invalid array length
+//
+// hono's `src/utils/concurrent.test.ts` was 6/6 failing with that message.
+// Chain: the dropped substitutions made `test.each` treat the template STRINGS
+// array as its case list, so the test body got the raw 25-character table
+// header instead of its row object; `row.count` read `undefined`; and
+// `new Array(undefined)` reaches the host as `new Array(NaN)`.
+//
+// So this file is the value-level guard that complements #5338's arity guard:
+// a number crossing the extras path must arrive as a non-negative integer the
+// host will accept as a length, not as `undefined`/NaN. It fails on the
+// pre-#5338 parent (2 of 3 cases) and passes from #5338 onward.
+//
+// Fixtures are deliberately UNTYPED `.js` in a two-file project: a `: any`
+// annotation on the tag's parameter routes the call through a different arm and
+// hides the defect.
+//
+// Each case carries an anti-vacuity control that exercises the SAME tag through
+// a plain over-arity CALL, which already worked before #5338, so a fixture that
+// silently stopped running cannot read as a pass.
+//
+// A property-access tag (`tags.each\`…\``, hono's own spelling) is NOT covered
+// here: in a fixture this small it compiles to the `__tagged_template` host
+// bridge, which hands the raw closure carrier to JS and fails with "tag is not
+// a function" both before and after — a separate live defect. The hono suite
+// reaches the closure `call_ref` arm instead and is the measurement that covers
+// it.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject } from "../src/index.js";
+import { buildCompiledImports } from "../src/runtime.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+/**
+ * The tag module — untyped `.js`, imported by the entry.
+ *
+ * `summarize` is shared by both tags so the two arms assert the identical
+ * string, including the `new Array(n).length` readback of every substitution.
+ */
+const TAG_MODULE = `
+export function summarize(argCount, values) {
+  let out = 'n=' + argCount + ' vals=' + values.join(',');
+  // The operand that produced the RangeError: a length that must arrive as a
+  // real non-negative integer, not \`undefined\` (→ host NaN).
+  for (let i = 0; i < values.length; i++) {
+    out += ' len' + i + '=' + new Array(values[i]).fill(0).length;
+  }
+  return out;
+}
+
+export function namedTag(strings) {
+  return summarize(arguments.length, Array.prototype.slice.call(arguments, 1));
+}
+`;
+
+async function instantiate(entrySource: string): Promise<WebAssembly.Exports> {
+  const root = mkdtempSync(join(tmpdir(), "js2-5340-"));
+  roots.push(root);
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, "tag.js"), TAG_MODULE);
+  writeFileSync(join(root, "entry.js"), entrySource);
+  const result = await compileProject(join(root, "entry.js"), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const imports = buildCompiledImports(result, {}) as Record<string, unknown> & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports.setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (imports.__setInstance as ((i: WebAssembly.Instance) => void) | undefined)?.(instance);
+  (instance.exports.__module_init as (() => void) | undefined)?.();
+  return instance.exports;
+}
+
+describe("#5340 numeric tagged-template substitutions reach the host as lengths", () => {
+  it("carries numbers to a one-parameter named tag", async () => {
+    const exports = await instantiate(`
+      import { namedTag } from './tag.js';
+      export function probe() { return namedTag\`a\${3}b\${10}c\`; }
+      export function control() { return namedTag(['a', 'b', 'c'], 3, 10); }
+    `);
+    // Anti-vacuity: the plain over-arity CALL path already worked before #5338,
+    // so a fixture that silently stopped running cannot pass.
+    expect((exports.control as () => string)()).toBe("n=3 vals=3,10 len0=3 len1=10");
+    expect((exports.probe as () => string)()).toBe("n=3 vals=3,10 len0=3 len1=10");
+  });
+
+  it("carries numbers to a one-parameter function-expression tag", async () => {
+    const exports = await instantiate(`
+      import { summarize } from './tag.js';
+      const closureTag = function (strings) {
+        return summarize(arguments.length, Array.prototype.slice.call(arguments, 1));
+      };
+      export function probe() { return closureTag\`a\${4}b\${7}c\`; }
+      export function control() { return closureTag(['a', 'b', 'c'], 4, 7); }
+    `);
+    expect((exports.control as () => string)()).toBe("n=3 vals=4,7 len0=4 len1=7");
+    expect((exports.probe as () => string)()).toBe("n=3 vals=4,7 len0=4 len1=7");
+  });
+
+  it("leaves an in-arity tag alone", async () => {
+    // Every substitution fits a declared slot, so nothing rides the surplus
+    // path. Passes on the pre-#5338 parent too — it pins the arm that must not
+    // be disturbed.
+    const exports = await instantiate(`
+      function pair(strings, a, b) { return strings[0] + a + strings[1] + b + strings[2]; }
+      export function probe() { return pair\`<\${1}|\${2}>\`; }
+    `);
+    expect((exports.probe as () => string)()).toBe("<1|2>");
+  });
+});


### PR DESCRIPTION
## What this is

**#5340 was fixed by [#5338](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5338-hono-ipaddr-null-string-split), not by this PR.** The two issues were filed
from different symptoms of one root cause and worked in parallel; #5338 landed
first. This PR closes [#5340](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5340-hono-concurrent-invalid-array-length) with the diagnosis that connects them, adds the
one regression guard #5338's test deliberately does not cover, and files the
residual that still blocks the file.

No `src/` changes.

## The diagnosis (the issue's own spec was wrong)

The plan expected a number crossing a host boundary as the undefined sentinel or
an unbridged `externref → f64` unbox, around `allowProvenNumberUnbox`. None of
that is involved: hono's `concurrent.ts` contains no `new Array(` at all, and
**two of the six failing tests pass a literal `10`** to `new Array` — which no
value-corruption story explains.

The real chain: tagged templates dropped every substitution past the tag's
declared arity, so the vitest `test.each` table helper (`each(cases)` — one
parameter, reads the rest off `arguments`) saw `arguments.length === 1`. Its
`Array.isArray(cases) && cases.raw && values.length > 0` gate went false, the
template STRINGS array became the case list, and each test body was invoked with
the raw 25-character table header instead of its row object. Measured inside the
compiled module on the parent: `Object.keys(row)` = `[0,1,…,24]` in Wasm vs
`[concurrency,count]` natively → `row.count` `undefined` → `new Array(undefined)`
reaches the host as `new Array(NaN)` → `RangeError: Invalid array length`.

## What is added

**A value-level regression test.** #5338's test uses *string* substitutions on
purpose (its own comment: "an untyped parameter lowers to f64 in this lane"), so
the **numeric** round-trip — the thing that actually produced the RangeError — is
unpinned by it. `tests/issue-5340-tagged-template-extra-substitutions.test.ts`
pins `new Array(n).fill(0).length === n` for a number that crossed the surplus
path, using untyped `.js` two-file fixtures, with an anti-vacuity control on the
plain over-arity CALL and an in-arity control.

Measured both ways: **2 of 3 cases fail on the pre-#5338 parent, all 3 pass from
#5338 onward.**

**[#5367](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5367-await-promise-all-inline-loses-result)** — the residual. Verified on main `cbd2f11dff`: every `RangeError` is
gone (hono 220/324 → 229/324, `ipaddr.test.ts` 4/16 → 13/16), and all six
`concurrent.test.ts` tests now fail on an **independent** defect —
`await Promise.all(...)` on a call expression yields a default-initialised tuple
/ empty array and does not wait for the pending promises:

```
const r = await Promise.all([Promise.resolve(1), Promise.resolve(2)])  // len=NaN, {"_0":null,"_1":null}
const p = Promise.all([Promise.resolve(1), Promise.resolve(2)]); const r = await p  // len=2, [1,2]
```

Binding the promise to a local first is correct, which is why this was invisible
until the tagged-template defect was cleared. Six-row reproduction ladder in the
issue.

## Acceptance criteria

- ❌ **1. `concurrent.test.ts` ≥ 5/6** — NOT met, and cannot be until #5367 is
  fixed. It is 0/6 on main for a completely different reason than when the issue
  was filed.
- ✅ 2. Regression test: untyped `.js` two-file fixtures, pins the numeric value
  reaching the host, fails on the parent, anti-vacuity control included.
- ✅ 3. A/B at one HEAD over 17 suites, per test file (run against the superseded
  implementation, below).
- ✅ 4. Ratchet gates green: loc, func, coercion-sites, oracle-ratchet,
  dead-exports, dogfood-validation, tsgo typecheck, prettier.

## Superseded work — worth knowing about

An independent fix for the same root cause was implemented on this branch before
#5338 was visible (`src/codegen/tagged-template-extras.ts`, same
`__argc`/`__extras_argv` mechanism, same four lowering arms) and measured green:
17-suite A/B at one HEAD, **16 of 17 suites per-file identical** (including
styled-components 9/9, which is built entirely on tagged templates), hono
220→229, with a per-test diff showing **9 flips, all `failed → passed`, zero
`passed → failed`**.

It was **discarded in favour of #5338's**, which is strictly better: it also
fixes `strings.raw`, and it guards `userParamCount < 1` — the superseded version
would have indexed `substitutions[-1]` for a zero-parameter tag.

The duplication is the known blind spot in `pre-dispatch-gate.mjs`: the two
issues overlap by *idiom*, not by id, neither cites the other, and #5338 was in
flight with no claim visible to this lane at dispatch time.

## Note on the docs-only grouping rule

This PR touches `tests/`, so it is not docs-only. For the record, both open docs
PRs were unsafe to append to at the time: #5677 is already **in the merge queue**
(position 5 — pushing would eject it), and #5679 is a `loopdive`-owned branch
with required checks still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
