### PR TITLE
docs(issues): file #5378 (ZonedDateTime ISO reads die in BalanceISODate) and #5379 (stale export map across provider instantiations)

### DIFF
--- a/plan/issues/5378-zoneddatetime-iso-reads-infinity-out-of-range.md
+++ b/plan/issues/5378-zoneddatetime-iso-reads-infinity-out-of-range.md
@@ -1,0 +1,128 @@
+---
+id: 5378
+title: "Every linked-Temporal `ZonedDateTime` field read (`year`, `month`, `day`, `daysInMonth`, `toPlainDate()`) throws `RangeError: infinity is out of range` — even ISO calendar, UTC — while `epochMilliseconds` reads correctly (the epoch→ISO-parts path hands `BalanceISODate` a non-finite)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-09-07
+---
+
+# #5378 — ZonedDateTime field reads die in `BalanceISODate` on a non-finite operand
+
+## Problem
+
+Measured through the test262 runner, provider linked, 2026-09-06/07
+(`probe-5365/zdt-*` rows in the dev-5364 worktree; re-confirmed after #5373 and
+#5377 by dev-5377's direct probe):
+
+```js
+const d = Temporal.ZonedDateTime.from({ year: 2024, month: 1, day: 1, hour: 12, minute: 34, timeZone: "UTC" });
+d.epochMilliseconds        // 1704112440000  (correct — the JSBI divide/toNumber path works)
+d.year                     // RangeError: infinity is out of range
+d.month / d.day / d.hour   // same
+d.daysInMonth, d.dayOfYear // same
+d.offsetNanoseconds        // NaN
+d.toPlainDate()            // same RangeError
+Temporal.ZonedDateTime.from("2024-01-01T12:34[UTC][u-ca=gregory]").year   // same
+```
+
+Nothing exotic is involved — ISO calendar, UTC — and the same fields read
+correctly on `PlainDateTime`. The throw sites are the polyfill's
+`BalanceISOYearMonth` / `BalanceISODate`:
+
+```js
+function Cr(e,t){ let n=e,r=t; if(!Number.isFinite(n)||!Number.isFinite(r)) throw new RangeError("infinity is out of range"); … }   // BalanceISOYearMonth
+function Or(e,t,n){ … if(!Number.isFinite(i)) throw new RangeError("infinity is out of range"); ({year:r,month:o}=Cr(r,o)); … }   // BalanceISODate
+```
+
+so a `year`/`month`/`day` operand reaching them is `NaN`/`±Infinity`. For a
+ZonedDateTime those operands come from `GetISODateTimeFor(timeZone, epochNs)`
+→ `GetISOPartsFromEpoch(epochNs)` (divmod by 1e6 → `new Date(ms)` →
+`getUTC{FullYear,Month,Date,Hours,…}`) plus the time-zone offset
+(`offsetNanoseconds` reads `NaN`, which is the same symptom one step earlier).
+`epochMilliseconds` takes the divmod-and-`toNumber` half of that path and is
+correct, so the non-finite is minted between the divmod and the `Date`
+getters — most likely in the compiled `new Date(ms)` / `getUTC*` inside the
+provider (a compiled `Date`, see #5208 for the compiled-Date ↔ host-Date
+boundary) or in `GetNamedTimeZoneOffsetNanoseconds("UTC", …)`.
+
+Blast radius: every `built-ins/Temporal/ZonedDateTime/**` row that reads a
+calendar/time field (hundreds), the 22 `infinity is out of range` rows of the
+123-row list, and the `intl402/Temporal/ZonedDateTime/**` calendar rows behind
+them.
+
+## Implementation Plan (Fable, 2026-09-07)
+
+**Step 1 — localise the non-finite, from the consumer side, no polyfill
+edits.** Through `tests/test262-runner.ts` as synthetic rows (the runner's
+compile options are the ones that matter — a bare `compile()` probe decodes
+literals differently), provider linked, fresh cache, log each of:
+1. `Temporal.Instant.from("2024-01-01T12:34:00Z").epochMilliseconds` and
+   `.toZonedDateTimeISO("UTC").epochMilliseconds` — expected 1704112440000.
+2. `.toZonedDateTimeISO("UTC").offsetNanoseconds` — expected 0; reads `NaN`
+   today. This isolates `GetOffsetNanosecondsFor("UTC", epochNs)`.
+3. `.toZonedDateTimeISO("UTC").year` — the `GetISOPartsFromEpoch` half.
+4. `Temporal.Instant.from(...).toString()` (uses the same epoch→ISO parts
+   path with offset 0) — if this works and 3 does not, the offset is the
+   culprit, not the parts.
+5. Consumer-only controls of the primitives the path uses, compiled with the
+   same options: `new Date(1704112440000).getUTCFullYear()`, `Math.floor(x/1e6)`
+   on a large number, `Number(bigint)`; then the SAME primitives inside a
+   throwaway linked provider (`tests/issue-5225-consumer-literal-seam.test.ts`
+   two-lane template) — `export function parts(ms) { const d = new Date(ms);
+   return [d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()]; }`. #5208's
+   bridge marshals a compiled Date at the extern-class ARGUMENT and JSON
+   boundaries; a `Date` minted and consumed inside the provider is a different
+   route.
+State which of 1–5 first goes non-finite, with the value.
+
+**Step 2 — fix the primitive, not the polyfill.** Expected shapes, by Step-1
+answer:
+- offset `NaN` → `GetNamedTimeZoneOffsetNanoseconds` uses
+  `Intl.DateTimeFormat(…, {timeZone}).formatToParts(date)` (#5355 bridge) or a
+  `Date` getter; find which value is `undefined`/`NaN` through the seam.
+- parts non-finite → the provider-internal `Date` (`new Date(ms)` in a linked
+  module, `getUTC*` on it): #5208 covered host-boundary marshalling; the
+  in-module getters may be reading a struct field that was never set when the
+  Date was constructed from a number that arrived as `f64` via a JSBI
+  `toNumber` result (check the `undefSentinel` branding from #5251 — a NaN
+  sentinel read as "absent" or vice versa).
+- divmod → `JSBI` arithmetic through the #5377 identity path — if `Number(x)`
+  on a JSBI still hits `__toPrimitive`, the digit array stringifies.
+One fix, in `src/runtime.ts` / the relevant codegen, gated as narrowly as the
+answer allows; consumer-only behaviour byte-identical.
+
+**Step 3 — tests.** `tests/issue-5378-zoneddatetime-iso-reads.test.ts`: the
+Step-1 ladder as assertions in the linked lane (base-failing on the first
+non-finite step), plus the consumer-only controls green on both sides.
+
+**Step 4 — measure.** Direct probe: `ZonedDateTime.from({…ISO…, timeZone:"UTC"}).year === 2024`
+and `.toPlainDate().toString() === "2024-01-01"`. Then
+`built-ins/Temporal/ZonedDateTime/prototype/{year,month,day,daysInMonth,offsetNanoseconds,toPlainDate}/**`
+(~250 rows) and the 123-row family, base vs fix per row, fresh cache per
+revision, 0 pass→fail. Never the full bucket.
+
+**Order-preservation constraints.** `epochMilliseconds` and `PlainDateTime`
+reads are correct today and must not change; the #5208 boundary marshalling
+tests (`tests/issue-5208-*`) are the guard.
+
+## Acceptance criteria
+
+1. Step 1 answered with the first non-finite value and where it was minted.
+2. ISO/UTC `ZonedDateTime.year/month/day/daysInMonth/offsetNanoseconds/toPlainDate()`
+   correct through the linked provider.
+3. ~250-row ZonedDateTime sample + 123-row family measured, 0 pass→fail,
+   counts with artifacts.
+
+## Notes
+
+- Filed after #5373/#5377 landed the dispatch and identity fixes without
+  moving this family; supersedes the "ISO `ZonedDateTime.year` still reads
+  `infinity is out of range`" residual of #5377 and the 22-row bound of #5373.
+- Id reserved via `claim-issue --allocate --allow-unscanned` (no `gh` in this
+  container); open PRs hand-checked 2026-09-07 — highest in-flight issue file
+  is #5377 (PR #5699).

--- a/plan/issues/5379-stale-export-map-across-instantiations.md
+++ b/plan/issues/5379-stale-export-map-across-instantiations.md
@@ -1,0 +1,125 @@
+---
+id: 5379
+title: "A value built by instantiation N of a linked provider is dispatched through instantiation N−1's export map — host mirrors keep the FIRST instantiation's exports, so every test262 strict rerun (and every later row in a fork) reads the wrong module (bounds #5377's +7; `Instant.epochNanoseconds` passes fresh, fails in-process)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+reasoning_effort: high
+requested_by: ttraenkler/fable-lead
+created: 2026-09-07
+---
+
+# #5379 — host mirrors dispatch through a stale instantiation's exports
+
+## Problem
+
+Measured by dev-5377 (PR #5699, `.tmp/dbgM5.log`, `.tmp/fix2-temporal.json`)
+with an instrumented runtime, provider linked:
+
+```
+[dbg5377reg]  name=JSBI classObj=object#1   exports=object#3     (instantiation 1)
+[dbg5377reg]  name=JSBI classObj=object#125 exports=object#127   (instantiation 2)
+[dbg5377read] inst=object#226 exports=object#127 classObj=object#125   → i.constructor === JSBI  true
+[dbg5377read] inst=object#226 exports=object#3   classObj=object#125   → FALSE
+```
+
+An instance minted by instantiation 2 reaches a read whose `exports` (the
+`callbackState.getExports()` an import closure captured) belong to
+instantiation 1. Consequences, all measured:
+
+- `Temporal.Instant.from("2024-01-01T00:00:00Z").epochNanoseconds` is a
+  correct `bigint` in a FRESH process and throws `Cannot convert
+  23396352,513294428,1 to a BigInt` in a process that has already run other
+  Temporal files (the test262 strict rerun of the same file is enough).
+- #5377 had to add `_classObjectOwnedBy` — both identity arms stand down when
+  the class object was minted by a different instantiation than the exports
+  the read arrived with — because landing them ungated regressed 5 rows with
+  `Error: Convert JSBI instances to native numbers using toNumber`. That gate
+  is what bounds #5377's +7 on the 481-row sample: a sharded worker runs
+  hundreds of files per fork, so most rows are "later rows".
+- This is the SECOND channel #5364 §4 named and could not close ("stale
+  exports also arrive directly as a `callbackState.getExports()` from an import
+  closure, traced through the Map/Set method bridge, `src/runtime.ts` ~L11361").
+  #5364's per-row registry + realm-global reset fixed the first channel
+  (the polyfill's `@@Temporal__GetSlots` store) and made batch == solo on the
+  123-row list; this channel is what still differs between "fresh process" and
+  "strict rerun in the same process".
+
+## Implementation Plan (Fable, 2026-09-07)
+
+**Step 1 — find the holder.** Which object outlives an instantiation and
+carries `exports`/`callbackState` of the old one? Candidates, in order:
+1. `_wrapForHost` mirror caches keyed on CLASS OBJECT or on class NAME
+   (`_hostConstructorForInstance`, the `_subclassCtors` bucket, the
+   `_instanceClassObject` WeakMap) — a mirror minted for instantiation 1's
+   class object handed to instantiation 2's instance through a name-keyed
+   lookup.
+2. Import closures created in `buildImports(...)` for instantiation 1 that a
+   host-side object (a Map/Set method bridge, `_wasmClosureDynamicWrapperCache`
+   entry, a `Proxy` trap) still references — reachable because the polyfill's
+   realm globals or the runtime's module-level singletons keep the object
+   alive across rows.
+3. The #5225 `_crossModuleStructs` registry: `resetLinkedProjectRegistry`
+   (#5364) retires the previous project, but `decoderFor`'s `owners` WeakMap
+   can still answer an old exports object for a struct that survived (a
+   struct cached in a module-level Map).
+Instrument `dbg5377read`-style: on every read where `exports !==` the
+receiver's owning exports, log the holder's construction site (a stack captured
+when the closure/mirror was created — a `WeakMap<object, string>` set in
+`buildImports` and `_wrapForHost` is enough). Quote the holder in the PR.
+
+**Step 2 — fix at the holder.** Two acceptable shapes; pick by Step 1:
+- (a) Mirrors and wrappers resolve `exports` from the RECEIVER at call time
+  (`_decoderExportsFor(raw, …)` / `_owningClassObject` → its instantiation's
+  exports), never from the closure that created them. This is the #5225 rule
+  applied to the dispatch side.
+- (b) The stale holder is dropped at instantiation boundary — extend
+  `resetLinkedProjectRegistry()` (#5364) to clear the module-level caches that
+  hold exports/callbackState (mirror cache, dynamic-wrapper cache, name-keyed
+  ctor buckets) when a NEW linked project starts, so nothing from instantiation
+  1 can answer for instantiation 2.
+(b) is cheaper and fixes the test262 lanes; (a) is the correct fix for
+embedders holding two projects at once (the #5364 (B) residual). Ship (b)
+first if (a) does not converge; state which.
+
+**Step 3 — remove the ownership gate once the channel is closed.** With no
+stale exports reachable, `_classObjectOwnedBy`'s `_MISS` arm (#5377) becomes
+dead; keep it but assert (test) that it never fires on the 481-row sample —
+that assertion is the proof the channel is closed.
+
+**Step 4 — tests.** `tests/issue-5379-stale-export-map.test.ts`: TWO
+instantiations of the same provider binary in one process (the
+`tests/issue-5364-linked-project-scope.test.ts` two-project harness), second
+project's instance read through a host mirror → `i.constructor === C` true and
+`Number(i)`/`String(i)` dispatch through the SECOND module's exports (assert on
+a module-identifying export, e.g. a counter export incremented per module).
+Base-failing.
+
+**Step 5 — measure.** `Instant.epochNanoseconds` in a fresh process AND after
+ten other Temporal rows in the same process (dev-5363's `probe-bisect`
+shape); the 481-row `Instant/**` + `ZonedDateTime/prototype/**` sample and the
+123-row family, batch driver (#5364's), base vs fix, fresh cache, 0 pass→fail
+— expect the +7 of #5377 to grow now that "later rows" are no longer bounded.
+Never the full bucket.
+
+**Order-preservation constraints.** #5364's `resetLinkedProjectRegistry` and
+`resetTemporalRealmGlobals` stay; #5377's identity arms stay; the single-module
+lane is unaffected (no linked project ⇒ no second instantiation of a provider).
+
+## Acceptance criteria
+
+1. Step 1 answered with the holder's construction site.
+2. `Instant.epochNanoseconds` is a `bigint` after ten other Temporal rows in the
+   same process; the #5377 ownership-gate `_MISS` count on the 481-row sample is
+   0.
+3. 481-row + 123-row samples measured, 0 pass→fail, counts with artifacts.
+
+## Notes
+
+- Filed from PR #5699's "reported, not fixed" #1 and #5364 §4's second
+  channel.
+- Id reserved via `claim-issue --allocate --allow-unscanned` (no `gh` in this
+  container); open PRs hand-checked 2026-09-07 — highest in-flight issue file
+  is #5377 (PR #5699).


### PR DESCRIPTION
Two issue files with implementation plans (docs-only; the other open docs PR, #5700, is already queue-locked so it could not take these commits).

- [#5378](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5378-zoneddatetime-iso-reads-infinity-out-of-range) — every linked-Temporal `ZonedDateTime` field read (`year`, `month`, `day`, `daysInMonth`, `toPlainDate()`) throws `RangeError: infinity is out of range`, even for ISO/UTC, while `epochMilliseconds` reads correctly: the epoch→ISO-parts path hands the polyfill's `BalanceISODate` a non-finite (`offsetNanoseconds` reads `NaN` one step earlier). The residual [#5373](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5373-array-subclass-tostring-dispatch) and [#5377](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5377-compiled-class-constructor-identity-any-receiver) left.
- [#5379](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5379-stale-export-map-across-instantiations) — a value built by instantiation N of a linked provider is dispatched through instantiation N−1's export map (host mirrors keep the first instantiation's exports), which is why `Instant.epochNanoseconds` passes in a fresh process and fails on the strict rerun, and why [#5377](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5377-compiled-class-constructor-identity-any-receiver) needed its ownership gate. The second channel [#5364](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5364-cross-module-registry-leaks-across-linked-projects) §4 named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_