### PR TITLE
docs(ir): specify owner continuations for full frontend retirement

### DIFF
--- a/plan/agent-context/3518-owner-claims-20260907.json
+++ b/plan/agent-context/3518-owner-claims-20260907.json
@@ -1,0 +1,426 @@
+{
+  "ref_read": "ok",
+  "ref": "issue-assignments",
+  "tip": "a49968cdd47872a5221ef97367214e9f7072e2db",
+  "total_records": 2120,
+  "held_count": 800,
+  "held": [
+    {
+      "id": "3090",
+      "slice": "",
+      "assignee": "ttraenkler/opus-dead",
+      "status": "in-progress",
+      "branch": "issue-3090-delete-dead-handlers",
+      "claimed_at": "2026-07-13T07:53:23Z"
+    },
+    {
+      "id": "3518",
+      "slice": "application-evidence",
+      "assignee": "ttraenkler/luna-ir-evidence-d-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-whole-program-d-20260905",
+      "claimed_at": "2026-09-05T21:20:26Z"
+    },
+    {
+      "id": "3518",
+      "slice": "async-iife-return-scope",
+      "assignee": "ttraenkler/astra-ir-producers-b-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-async-iife-return-scope-20260906",
+      "claimed_at": "2026-09-06T22:12:01Z"
+    },
+    {
+      "id": "3518",
+      "slice": "authoritative-preparation",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-whole-program-a-20260905",
+      "claimed_at": "2026-09-05T21:20:15Z"
+    },
+    {
+      "id": "3518",
+      "slice": "backend-consumption-replay",
+      "assignee": "ttraenkler/claude-fable-ir-backend-c-20260906",
+      "status": "in-progress",
+      "branch": "claude/3518-whole-program-c-20260906",
+      "claimed_at": "2026-09-05T22:10:50Z"
+    },
+    {
+      "id": "3518",
+      "slice": "bench-string-c2",
+      "assignee": "ttraenkler/codex-3518-bench-string-prepared-cutover",
+      "status": "in-progress",
+      "branch": "codex/3518-bench-string-prepared-cutover",
+      "claimed_at": "2026-08-27T04:32:09Z"
+    },
+    {
+      "id": "3518",
+      "slice": "call-arg-ref-nullability",
+      "assignee": "ttraenkler/astra-ir-producers-b-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-call-arg-ref-nullability-20260906",
+      "claimed_at": "2026-09-06T19:16:00Z"
+    },
+    {
+      "id": "3518",
+      "slice": "compiler-result-finalizer",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-result-finalizer-20260906",
+      "claimed_at": "2026-09-06T15:53:55Z"
+    },
+    {
+      "id": "3518",
+      "slice": "driver-output-planning",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-driver-output-plan-20260906",
+      "claimed_at": "2026-09-06T14:37:15Z"
+    },
+    {
+      "id": "3518",
+      "slice": "error-message-bridge-leaves",
+      "assignee": "ttraenkler/astra-reference-error-runtime-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-error-message-bridge-20260906",
+      "claimed_at": "2026-09-06T15:17:38Z"
+    },
+    {
+      "id": "3518",
+      "slice": "evidence-runner-acceptance",
+      "assignee": "ttraenkler/astra-evidence-acceptance-b-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-evidence-acceptance-b-20260906",
+      "claimed_at": "2026-09-06T01:44:35Z"
+    },
+    {
+      "id": "3518",
+      "slice": "export-marshalling",
+      "assignee": "ttraenkler/astra-reference-error-runtime-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-export-marshalling-20260907",
+      "claimed_at": "2026-09-07T01:45:38Z"
+    },
+    {
+      "id": "3518",
+      "slice": "host-js-string-provider",
+      "assignee": "ttraenkler/astra-reference-error-runtime-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-host-js-string-provider-20260907",
+      "claimed_at": "2026-09-07T00:38:42Z"
+    },
+    {
+      "id": "3518",
+      "slice": "host-value-service",
+      "assignee": "ttraenkler/astra-reference-error-runtime-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-host-value-service-20260906",
+      "claimed_at": "2026-09-06T16:44:59Z"
+    },
+    {
+      "id": "3518",
+      "slice": "initializer-evidence-consumer",
+      "assignee": "ttraenkler/astra-evidence-acceptance-b-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-evidence-acceptance-b-20260906",
+      "claimed_at": "2026-09-06T14:05:32Z"
+    },
+    {
+      "id": "3518",
+      "slice": "integration-consolidation",
+      "assignee": "ttraenkler/astra-ir-integration-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-ir-integration-20260905",
+      "claimed_at": "2026-09-05T17:37:34Z"
+    },
+    {
+      "id": "3518",
+      "slice": "ir-source-positions",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/44-ir-source-positions-20260906",
+      "claimed_at": "2026-09-06T18:00:51Z"
+    },
+    {
+      "id": "3518",
+      "slice": "module-init-source-audit",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-module-init-source-audit-20260906",
+      "claimed_at": "2026-09-06T13:33:13Z"
+    },
+    {
+      "id": "3518",
+      "slice": "object-emitter-function-layout",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/33-object-function-layout-20260906",
+      "claimed_at": "2026-09-06T21:39:56Z"
+    },
+    {
+      "id": "3518",
+      "slice": "object-link-function-indices",
+      "assignee": "ttraenkler/astra-reference-error-runtime-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-object-link-function-indices-20260906",
+      "claimed_at": "2026-09-06T21:31:05Z"
+    },
+    {
+      "id": "3518",
+      "slice": "object-result-finalizer",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-object-result-finalizer-20260906",
+      "claimed_at": "2026-09-06T20:03:20Z"
+    },
+    {
+      "id": "3518",
+      "slice": "prepared-async-frame-engine",
+      "assignee": "ttraenkler/astra-ir-producers-b-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-prepared-async-frame-reconciled-20260907",
+      "claimed_at": "2026-09-07T00:49:54Z"
+    },
+    {
+      "id": "3518",
+      "slice": "presentation-output-split",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-presentation-output-20260906",
+      "claimed_at": "2026-09-06T15:06:06Z"
+    },
+    {
+      "id": "3518",
+      "slice": "private-observation-collector",
+      "assignee": "ttraenkler/astra-evidence-acceptance-b-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-evidence-acceptance-b-20260906",
+      "claimed_at": "2026-09-06T13:31:08Z"
+    },
+    {
+      "id": "3518",
+      "slice": "program-observation-authority",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-whole-program-a-20260905",
+      "claimed_at": "2026-09-06T13:19:20Z"
+    },
+    {
+      "id": "3518",
+      "slice": "reference-error-host-adapter",
+      "assignee": "ttraenkler/astra-reference-error-runtime-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-reference-error-runtime-20260906",
+      "claimed_at": "2026-09-06T14:08:10Z"
+    },
+    {
+      "id": "3518",
+      "slice": "reference-error-materialization",
+      "assignee": "ttraenkler/astra-reference-error-runtime-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-reference-error-runtime-20260906",
+      "claimed_at": "2026-09-06T13:08:53Z"
+    },
+    {
+      "id": "3518",
+      "slice": "reference-error-runtime",
+      "assignee": "ttraenkler/astra-reference-error-runtime-20260906",
+      "status": "in-progress",
+      "branch": "codex/3518-reference-error-runtime-20260906",
+      "claimed_at": "2026-09-06T10:11:43Z"
+    },
+    {
+      "id": "3518",
+      "slice": "runtime-callable-abi",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-whole-program-a-20260905",
+      "claimed_at": "2026-09-06T10:13:42Z"
+    },
+    {
+      "id": "3518",
+      "slice": "semantic-runtime-producers",
+      "assignee": "ttraenkler/astra-ir-producers-b-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-whole-program-b-20260905",
+      "claimed_at": "2026-09-05T21:20:20Z"
+    },
+    {
+      "id": "3518",
+      "slice": "wasi-startup-handoff",
+      "assignee": "ttraenkler/astra-ir-program-a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3518-wasi-startup-handoff-20260907",
+      "claimed_at": "2026-09-07T01:43:35Z"
+    },
+    {
+      "id": "3520",
+      "slice": "c30-vec-host-bridge",
+      "assignee": "ttraenkler/codex-r1-c30",
+      "status": "in-progress",
+      "branch": "codex/3520-c30-vec-host-bridge",
+      "claimed_at": "2026-07-30T04:44:42Z"
+    },
+    {
+      "id": "3520",
+      "slice": "c31-closure-host-bridge",
+      "assignee": "ttraenkler/codex-r1-c31",
+      "status": "in-progress",
+      "branch": "codex/3520-c31-closure-host-bridge",
+      "claimed_at": "2026-07-30T06:03:22Z"
+    },
+    {
+      "id": "3520",
+      "slice": "c32-date-civil-support",
+      "assignee": "ttraenkler/codex-c32-date-civil-019f7cb9",
+      "status": "in-progress",
+      "branch": "codex/3520-c32-date-civil-support",
+      "claimed_at": "2026-07-30T06:34:53Z"
+    },
+    {
+      "id": "3520",
+      "slice": "c33-data-struct-host-bridge",
+      "assignee": "ttraenkler/codex-c33-data-struct-host-bridge",
+      "status": "in-progress",
+      "branch": "codex/3520-c33-data-struct-host-bridge",
+      "claimed_at": "2026-07-30T08:57:36Z"
+    },
+    {
+      "id": "3520",
+      "slice": "w1g-implicit-ctor-param",
+      "assignee": "ttraenkler/opus-3520-w1g",
+      "status": "in-progress",
+      "branch": "claude/issue-3520-w1g-implicit-ctor-param",
+      "claimed_at": "2026-09-04T03:26:41Z"
+    },
+    {
+      "id": "3521",
+      "slice": "prepared-program-core",
+      "assignee": "ttraenkler/codex-3521-prepared-core-019f7cb9",
+      "status": "in-progress",
+      "branch": "codex/3521-r2-prepared-program-core",
+      "claimed_at": "2026-07-30T07:33:48Z"
+    },
+    {
+      "id": "3521",
+      "slice": "production-routing",
+      "assignee": "ttraenkler/codex-lead",
+      "status": "in-progress",
+      "branch": "codex/3521-r2-production-routing",
+      "claimed_at": "2026-07-30T12:52:02Z"
+    },
+    {
+      "id": "3521",
+      "slice": "program-abi-session-seal",
+      "assignee": "ttraenkler/codex-r2-session",
+      "status": "in-progress",
+      "branch": "codex/3521-r2-program-abi-session-seal",
+      "claimed_at": "2026-07-30T05:22:50Z"
+    },
+    {
+      "id": "3521",
+      "slice": "r2f1",
+      "assignee": "ttraenkler/opus-3521-r2f1",
+      "status": "in-progress",
+      "branch": "claude/issue-3521-r2f1-fast-mixed-signature",
+      "claimed_at": "2026-09-02T21:54:38Z"
+    },
+    {
+      "id": "3521",
+      "slice": "scoped-prepared-abi-seal",
+      "assignee": "codex-3521-scoped-abi",
+      "status": "in-progress",
+      "branch": "",
+      "claimed_at": "2026-07-30T08:54:39Z"
+    },
+    {
+      "id": "3522",
+      "slice": "w1c-super-accessor",
+      "assignee": "ttraenkler/opus-3522-w1c",
+      "status": "in-progress",
+      "branch": "claude/issue-3522-w1c-super-accessor",
+      "claimed_at": "2026-09-04T02:49:03Z"
+    },
+    {
+      "id": "3523",
+      "slice": "r4m1",
+      "assignee": "ttraenkler/opus-3523-r4m1",
+      "status": "in-progress",
+      "branch": "claude/issue-3523-r4m1-string-module-storage",
+      "claimed_at": "2026-09-03T00:05:13Z"
+    },
+    {
+      "id": "3523",
+      "slice": "w2b",
+      "assignee": "ttraenkler/fable-3523-w2b",
+      "status": "in-progress",
+      "branch": "fable-3523-w2b",
+      "claimed_at": "2026-09-03T17:15:28Z"
+    },
+    {
+      "id": "3525",
+      "slice": "m2-p2a-atomic-init-batch",
+      "assignee": "ttraenkler/luna-ir-r5-m2p2a-20260905",
+      "status": "in-progress",
+      "branch": "codex/3525-m2-p2a-luna-20260905",
+      "claimed_at": "2026-09-05T11:16:23Z"
+    },
+    {
+      "id": "3526",
+      "slice": "a1",
+      "assignee": "ttraenkler/codex",
+      "status": "in-progress",
+      "branch": "codex/3526-async-capability-catalog-plan",
+      "claimed_at": "2026-08-26T03:53:45Z"
+    },
+    {
+      "id": "3526",
+      "slice": "f3s1",
+      "assignee": "ttraenkler/opus-3526-f3s1",
+      "status": "in-progress",
+      "branch": "claude/issue-3526-f3s1-host-callback-maker",
+      "claimed_at": "2026-09-02T14:26:54Z"
+    },
+    {
+      "id": "3526",
+      "slice": "f3s2",
+      "assignee": "ttraenkler/opus-3526-f3s2",
+      "status": "in-progress",
+      "branch": "claude/issue-3526-f3s2-callable-schema",
+      "claimed_at": "2026-09-02T21:09:40Z"
+    },
+    {
+      "id": "3526",
+      "slice": "f3s3",
+      "assignee": "ttraenkler/opus-3526-f3s3",
+      "status": "in-progress",
+      "branch": "claude/issue-3526-f3s3-function-prototype-call",
+      "claimed_at": "2026-09-03T17:12:33Z"
+    },
+    {
+      "id": "3527",
+      "slice": "r7-b2-linear-suspension-liveness",
+      "assignee": "ttraenkler/luna-ir-r7-b2-20260905",
+      "status": "in-progress",
+      "branch": "codex/3527-b2-luna-20260905",
+      "claimed_at": "2026-09-05T09:49:15Z"
+    },
+    {
+      "id": "3527",
+      "slice": "r7-b3-settled-nonthenable-owners",
+      "assignee": "ttraenkler/luna-ir-r7-b3-20260905",
+      "status": "in-progress",
+      "branch": "codex/3527-b3-luna-20260905",
+      "claimed_at": "2026-09-05T12:15:45Z"
+    },
+    {
+      "id": "3528",
+      "slice": "l0-p1-frozen-body-batch",
+      "assignee": "ttraenkler/luna-ir-r8-l0p1-20260905",
+      "status": "in-progress",
+      "branch": "codex/3528-l0-p1-luna-20260905",
+      "claimed_at": "2026-09-05T11:52:00Z"
+    }
+  ],
+  "scope": "Filtered migration claims; original held_count is ledger-wide. Claims do not prove process liveness. No process/session IDs are recorded by this ledger."
+}

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -3012,3 +3012,287 @@ the large graph JSON is not committed as a baseline.
    and optimization obligations are met. Then run the complete final merged
    validation above. No bounded cohort or five-entry readiness check substitutes
    for the epic's acceptance criteria.
+
+## Astra High continuation specification — 2026-09-07
+
+This is a specification checkpoint for the full migration. It changes no
+compiler code and closes no acceptance criterion. Implementation is assigned
+to **Astra Low**, by continuation of the existing owners or a recorded handoff.
+No new parallel replacement of a claimed owner is authorized by this plan.
+
+### Provenance and claim reconciliation
+
+Source base: upstream `loopdive/js2` main
+`b3133d1d4da1151d82ef45b58db9566565097c57`, fetched in the isolated
+`codex/3518-ir-retirement-spec-astra-high` worktree. The fork's main is not the
+base. All source locations below refer to that SHA unless explicitly labelled
+package C. Historical R1/R2 results above remain historical measurements.
+
+The full live claim read returned `read upstream/issue-assignments`, tip
+`a49968cdd47872a5221ef97367214e9f7072e2db`, with 800 held records. Relevant
+records, including exact handles and branch names, are preserved in
+[the filtered owner snapshot](../agent-context/3518-owner-claims-20260907.json).
+The ordinary `--check 3518` and `--check 3520` report no active **bare** claim;
+they do not establish that the issues' slices are free. The pre-dispatch gate
+for this epic returns **STOP**, citing package C and overlapping child issues.
+This documentation-only continuation is the explicit response to that STOP;
+it is not permission to dispatch duplicate implementation. Its own claim is
+`3518:astra-high-continuation-spec`,
+`ttraenkler/astra-high-spec-20260907`.
+
+Owner handles and next actions:
+
+- **A:** `ttraenkler/astra-ir-program-a-20260905`, original branch
+  `codex/3518-whole-program-a-20260905`. Holds authoritative preparation,
+  runtime-callable ABI, observation authority, and the subsequent driver,
+  result-finalizer, object-output, source-position and WASI slices. Continue
+  **lane A** below after recovering the owner's actual latest commits.
+- **B:** `ttraenkler/astra-ir-producers-b-20260905`, original branch
+  `codex/3518-whole-program-b-20260905`; latest relevant ledger branch
+  `codex/3518-prepared-async-frame-reconciled-20260907`. Holds semantic runtime
+  producers and async-frame work. Continue **lane B** below, preserving the
+  separately claimed IIFE return-scope and call-argument nullability work.
+- **D:** `ttraenkler/luna-ir-evidence-d-20260905`, branch
+  `codex/3518-whole-program-d-20260905`, holds application evidence.
+  `ttraenkler/astra-evidence-acceptance-b-20260906`, branch
+  `codex/3518-evidence-acceptance-b-20260906`, holds evidence acceptance,
+  private observation collection and initializer evidence. The lead must
+  reconcile these two evidence owners before **lane D** has one writer.
+- **C, excluded:** `ttraenkler/claude-fable-ir-backend-c-20260906`, branch
+  `claude/3518-whole-program-c-20260906`, active PR **5692 — package C:
+  PreparedIrProgram codec, backend acceptance/emission, fresh-process replay**.
+  Published head inspected: `643ed8ab8dfcee6ec836c71bedd5ddfdb0392435`.
+  The coordinating task subsequently confirmed C's live repair at
+  `a1bf929730a10c262749df31c22a6c093e99f76f`; local worktree enumeration finds
+  that HEAD in `/private/tmp/js2-5692-repair`. It is not treated as merged or
+  as the published PR head. C continues its own layering/acceptance repair.
+- **Runtime host boundary owner, also excluded:**
+  `ttraenkler/astra-reference-error-runtime-20260906`, including
+  `codex/3518-export-marshalling-20260907`,
+  `codex/3518-host-js-string-provider-20260907`, and
+  `codex/3518-reference-error-runtime-20260906`. A consumes its output
+  contracts; B consumes its provider contracts. Neither replaces them.
+
+The ledger contains no process ID or Codex session ID. No A/B/D process was
+identified in this checkout, and their recorded branch names did not appear
+in the queried upstream/fork `codex/3518-*2026090*` remote heads. This is an
+**unresolved location/liveness question**, not proof the work was abandoned.
+The parent coordination task is `01a03e4f-6022-7c10-90a6-f79349570326`; the
+known C shepherd task is `01a035b2-ddc5-79f3-86af-c53857925523`. Do not delete,
+release, override or recreate a claim because its branch is not visible here.
+The A/B implementation present in C's stack is a recoverable checkpoint, not
+proof it is their newest work. Preserve attribution when adopting it.
+
+### Current source and fresh probes
+
+The following remaining dependencies are verified in current source:
+
+1. `src/compiler.ts::runPipeline` calls `generateLinearModule` /
+   `generateLinearMultiModule` or `generateModule` / `generateMultiModule`
+   (`:1089–1104`). All public source/file drivers converge here, but
+   `src/compiler/output.ts::compileToObjectSource` separately calls
+   `generateModule(ast)` at `:355`. Changing just the main driver leaves a
+   public direct route.
+2. `src/codegen/index.ts::generateModule` prepares selected bodies, then calls
+   legacy declaration walking and an overlay. Its policy at `:5741` reads
+   `experimentalIR`, `disableIrFirst` and `JS2WASM_IR_FIRST`. The multi overlay
+   at `:10398` returns early for `ctx.fast`. These are executable routes, not
+   dead compatibility type declarations.
+3. Upstream `src/ir/program.ts` still permits `direct-candidate`,
+   `emitDirect`, and `reconciliation: "pending-production-wiring"`.
+   In C's **unmerged stack**, `program-preparation.ts::prepareWholeIrProgram`
+   instead builds `prepared-ir-program-v1` with complete reconciliation before
+   acceptance. Do not recreate this producer. Its `program-source.ts` still
+   refuses non-function declaration producers and unresolved typed storage;
+   a codec passing does not close classes, closures or the source population.
+4. `src/codegen/ir-async-frame.ts::lowerPreparedIrAsyncFunction` consumes a
+   prepared plan but calls `emitPreparedAsyncFrameStateMachine` imported from
+   `async-frame.ts`. That shared module retains AST statement/expression arms
+   at `:2093`, `:2117`, `:2251`, `:2284`, `:2326`, `:2361`, `:2517` and a
+   name-based resume lookup near `:2926`. `AsyncCfgOperand` in `async-cps.ts`
+   is an AST-or-callback union. Therefore an AST-free input alone does not
+   prove an AST-free reachable emitter graph.
+5. `src/ir/backend/linear-integration.ts::compileLinearIrFunctions` derives
+   signatures and lowers declarations with the checker. The direct linear
+   statement root remains at `src/codegen-linear/index.ts:848`. The legacy
+   reachability script cuts only the two WasmGC dispatchers; it cannot by
+   itself prove linear retirement.
+6. R1 retains both symbolic ABI authority and legacy projections. The new
+   R1 continuation note in the source-qualified identity issue specifies the
+   exact boundary that A/B/C must preserve. A display-name scan or a final
+   numeric slot is not the source of semantic identity.
+
+Fresh commands on the pinned upstream base, with no compiler edits:
+
+- `node --import tsx scripts/check-ir-only.ts --policy=ir-only`: **READY**;
+  single-host and standalone each enumerate **5/5 entries, 41 terminals,
+  38 emitted IR bodies, 3 non-executable, 0 unsupported, 0 invariants,
+  0 legacy bodies**. This is exactly this small corpus, not all applications.
+- `node scripts/check-ir-optimization-retirement.mjs --require-ready`:
+  **exit 1, 46/50 tracked rows not ready**. The ledger is a required
+  optimization obligation list, not a compiler-migration percentage.
+- `node scripts/audit-legacy-reachability.mjs --json <scratch-file>`:
+  **833 codegen files**. The asserted frontend bucket has 115 files,
+  88,395 legacy-only and 17,330 shared function lines. Both actual dispatcher
+  graph nodes are present (22 and 24 lines respectively), supplying a positive
+  detector control. Bucket membership is asserted; these are not deletion
+  permissions. The audit also roots every non-codegen node, including linear,
+  as a survivor, and must be supplemented for final retirement.
+
+- Existing `tests/issue-3519-ir-only-gate.test.ts`: **14/14 pass**.
+- A fresh public `compile` probe of
+  `namespace N { export const x = 1; } export function h(): number { return N.x; }`
+  with `trackIrOutcomes: true` succeeds in gc and standalone, each with **two
+  terminal Unsupported outcomes and two legacy-body receipts** (`h` and module
+  init), zero IR bodies. This is a working direct-route compilation control
+  alongside the five-entry READY result; this probe did not execute its binary.
+
+Scratch outputs are under `.tmp/ir-retirement-spec/` in this worktree. No full
+Test262 run, backend replay run of C, or baseline/candidate performance
+comparison is claimed by this specification.
+
+### Parallel ownership and dependency order
+
+There is no verified unclaimed compiler prerequisite in the overlapping
+preparation/runtime/acceptance surfaces. Use these **three owner continuations**
+after liveness/handoff reconciliation. They may proceed concurrently because
+only one lane writes each named file. Existing owner changes take precedence
+until their exact head is captured and reviewed.
+
+- **A — one public preparation/emission driver:** compiler entry and output
+  orchestration. Exact design and tests are appended to
+  [R5: whole-program ownership](3525-ir-r5-whole-program-multi-source-ownership.md).
+  A owns `src/compiler.ts`, `src/compiler/output.ts`, `src/index.ts`,
+  `src/compiler/ir-program-driver.ts` (new unless recovered),
+  `src/compiler/ir-program-result.ts` (new unless recovered), and its new
+  `tests/issue-3525-public-prepared-driver.test.ts`. Existing A output splits
+  must be reused instead of creating parallel modules. No backend emission,
+  runtime provider, or package C file belongs to A's next slice.
+- **B — detach prepared async emission from AST walkers:** exact design and
+  tests are appended to [R7: AST-free async plan](3527-ir-r7-ast-free-async-plan.md).
+  B owns `src/codegen/ir-async-frame.ts`, the new/recovered
+  `src/codegen/prepared-async-frame-engine.ts`, new
+  `src/codegen/prepared-async-frame-types.ts`, and
+  `tests/issue-3527-prepared-frame-import-boundary.test.ts` plus
+  `tests/issue-3527-prepared-frame-runtime.test.ts`. Existing AST frame modules
+  are read-only in this extraction checkpoint; deletion is a later R10 step.
+- **D — public-route completion gate:** owns new
+  `scripts/check-ir-retirement.ts`,
+  `tests/issue-3518-public-retirement-gate.test.ts`, and
+  `tests/fixtures/ir-retirement/manifest.json` with fixtures beneath that
+  directory. Reuse the recovered evidence collector before adding any new
+  one. Production observation authority belongs to A/C and is read-only.
+  `scripts/check-ir-only.ts`, its baseline, the existing reachability script,
+  C's codec/replay tests and helpers remain read-only for this slice. Wire the
+  new command into CI only after the existing CI owner grants that file scope.
+
+**C-exclusive write set:** `src/ir/program-codec.ts`,
+`src/ir/program-physical-plan.ts`, `src/ir/program-consumer.ts`,
+`scripts/ir-whole-program-replay.mjs`,
+`tests/issue-3518-program-codec-replay.test.ts`, and C's codec/replay helpers.
+A/B/D can import approved APIs or submit a located failing fixture to C; none
+edits or mocks away C's acceptance rules. The remaining preparation, ABI,
+source-population and runtime-producer modules in C's PR are stacked A/B
+history, not free files. This checkpoint gives no new writer those files.
+
+Order: recover/pin A/B/D heads and C's current repair; run each continuation's
+before controls; A builds orchestration against C's real API while B extracts
+the frame engine and D builds the gate against existing observations; compose
+normal merges in an isolated integration branch; C consumes B's prepared
+runtime through its own acceptance work; A then completes the single production
+cutover; D proves it through public APIs. C currently refuses async physical
+materialization and non-scalar layouts, so A cannot truthfully merge a full
+cutover until those dependencies and source coverage close. An intermediate
+non-draft checkpoint may land internal infrastructure that has no public flag;
+it must not advertise a second supported compiler mode or claim migration done.
+
+### D implementation contract: completion evidence through public APIs
+
+Manifest rows are exact input files, entry API, source graph, target, options,
+expected semantic oracle and expected terminal inventory. Hash source contents
+and preserve the same corpus on base and candidate. Include every API from A's
+matrix; fast is a representation option, not permission to omit an IR census.
+Do not infer runtime expectations from the candidate's generated output.
+
+The first checked-in fixture graph is deliberately small but heterogeneous:
+`state.ts` initializes a numeric live binding and exports a mutator;
+`math.ts` imports it and exports a loop/branch helper; `entry.ts` re-exports
+both and contains a two-await async export. Same-spelling helpers in separate
+files, an imported alias, an empty type-only source and a source function named
+`__module_init` provide identity controls. Pin explicit startup order and
+numeric values. Keep the async row separate from the scalar subset so C's
+current typed async refusal cannot erase the working positive control. Add
+runtime namespace, class+closure, dynamic-code, and CJS fixtures as explicit
+coverage obligations; preserve a located refusal while unsupported, but **no
+new refusal of previously supported behavior counts as final success**.
+
+Build the gate with these rules:
+
+1. Establish a bijection between expected sources/units and terminal
+   observations. Reconcile pass-derived units through original owners; list
+   compiler support bodies separately. Empty/type-only units need explicit
+   non-executable evidence. A missing collector, source, row, phase or process
+   result is an error, never zero direct emission.
+2. Require prepare-before-accept-before-emit ordering and exactly one owned
+   final body per executable unit. Count every entry into direct dispatch,
+   including discovery passes whose output is discarded; a boolean
+   `legacyBodyEmitted` cannot certify that no direct work occurred.
+3. Unsupported is a typed source-qualified failure before artifact publication.
+   Invariants and failures after acceptance remain fatal. Refusal rows retain
+   the complete original denominator; a refused program cannot publish a
+   smaller module or masquerade as a successful all-IR compile.
+4. Execute outputs and compare startup, state, throws, exported values and
+   async scheduling to the pinned JavaScript oracle. Use C's fresh-process
+   replay unchanged for the same serialized snapshot on both backends. Treat
+   missing runner output, timeout and skipped execution as failed evidence.
+5. Negative controls: delete a unit row; duplicate another; swap two same-name
+   source IDs; inject a direct-entry receipt; reorder phases; skip an entry;
+   remove a runtime provider; replay a donor projection; zero the corpus;
+   substitute an always-green result. Every mutation must fail for its intended
+   reason while the scalar positive control still executes. An unsupported
+   async fixture must not make the whole gate pass vacuously.
+
+**Astra Low lane D prompt:** Continue the existing D/evidence-acceptance work
+only after its two owner handles are reconciled. Implement the gate and
+fixtures above in the listed files; you are not alone in the repository and
+must preserve peer edits. Do not edit compiler, codec, replay, observer authority,
+CI or baseline files. First reproduce the pinned upstream five-entry READY
+result beside a namespace direct-path control. Then exercise the public A
+adapter and C consumer on the recovered integration head. Return exact
+base/head SHAs, manifest hash, per-unit rows, negative-control failures and
+runtime values. This gate is complete only when it distinguishes unavailable,
+unsupported, corrupt and fully validated evidence. It does not close the epic.
+
+### Final completion audit, required after these continuations
+
+- [ ] A single production route serves async/sync compile, multi-source,
+  file compilation, object/linking output and all CLI/selfhost entry wrappers.
+  No public option or environment switch can select direct codegen. Execute
+  the inventory in [IR/direct policy retirement](4522-ir-kill-switch-inventory-r9.md).
+- [ ] Every accepted source and pass-derived unit has one semantic producer
+  and one emission receipt. Classes, closures, nested/CJS/IIFE bodies,
+  ordered initialization, async/generator state machines and dynamic code
+  are included; they cannot be excluded by naming the census a subset.
+- [ ] A single validated semantic snapshot and ABI feed both backends.
+  Frontend/checker/AST and legacy body modules are absent from backend replay's
+  transitive runtime import graph. Runtime and carrier refusals occur before
+  resource publication. Backend capability gaps remain visible until fixed.
+- [ ] Native/host runtime support and all demanded layouts have authenticated
+  providers. Preserve shared runtime/backends; remove direct source walkers.
+- [ ] All optimization-retirement obligations have executable preservation
+  and removal controls, including Wasm shape and performance where required.
+  Re-enumerate untracked handlers rather than treating 50 rows as exhaustive.
+- [ ] Reachability is checked from actual public roots for **both** backends,
+  including async/eval/object paths and dynamic imports. Require detector
+  positive controls and zero unknown edges before using it as deletion proof.
+  Run the existing [direct frontend deletion issue](3090-shrink-codegen-delete-dormant-legacy-handlers.md)
+  through its owner; do not transfer its still-held bare claim implicitly.
+- [ ] Full host/standalone Test262 and application comparisons use the same
+  corpus/configuration on explicit base/candidate SHAs. Account for skips,
+  fatal runner outcomes, timeouts and missing shards. Required equivalence,
+  linear, typecheck, lint/format, budgets, oracle, dead-export and standalone
+  floor checks pass on the actual merged candidate.
+
+A new typed refusal protects correctness while a migration checkpoint is
+incomplete. It is **not** a license to replace working direct coverage with
+errors and declare the user's full migration complete.

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -5751,3 +5751,52 @@ preclaim (67), producer parity (3), issue-4502 (29), direct-member equality
 preflight remains 10/13: two module-init expectation rows now observe the
 existing `module-init-legacy-coupling` fallback, and the Date provider collision
 row now emits; these are unrelated drift from the scoped equality change.
+
+## Astra High R1 boundary audit for the full cutover (2026-09-07)
+
+Pinned source and owner records are in the
+[epic continuation specification](3518-ir-only-default-and-direct-frontend-retirement.md).
+This is an architecture contract for the continuing A/B/C owners, not a new
+R1 implementation claim. C30–C33 and the implicit-constructor slice remain
+held in the ledger; their source and acceptance evidence must be verified
+before any ownership reassignment. A merged PR title or completed sub-slice
+never closes the complete R1 contract.
+
+At upstream `b3133d1d4da1151d82ef45b58db9566565097c57`, prepared async entry
+still has a downstream name-based resume lookup in `async-frame.ts`, and
+`program.ts` retains direct candidates and pending production reconciliation.
+The unmerged package C stack instead binds a `ProgramAbiMap` from the prepared
+entries inside `program-consumer.ts`. It resolves function/global references
+by binding key and builds a slot-to-unit ownership map before deriving final
+receipts. That is existing implementation to preserve, not a second ABI map
+for a new implementer to invent. Its unresolved type materialization and
+runtime support are C dependencies, not permission for source-name fallback.
+
+Required boundary invariants for the three continuation lanes:
+
+1. A creates one inventory and identity context for the complete input graph
+   before handing it to the existing producer. No output finalizer rebuilds
+   identities by reparsing source or joining display names. Diagnostics retain
+   original source/owner identity through transforms and output conversion.
+2. B requests entry/resume/callback/frame resources by original or derived
+   owner plus stable role/ordinal. Name collisions cannot alter the binding.
+   Backend-local numeric indices are final locators over those handles and
+   never become persisted semantic identity.
+3. C remains sole owner of backend binding/reservation, codec authentication
+   and emission receipts. A accepts its output without reconstructing
+   authority from module-array order; D observes the authentic evidence
+   without synthesizing it from its expected test population.
+4. A/B enumerate readers, mutators and late-remap consumers before moving any
+   shared ABI data. Reserve/fill object identity must survive imports and DCE.
+   Missing, duplicate, foreign or contradictory bindings are fatal; they
+   cannot be converted to a warning or a lowerer name scan.
+
+Acceptance joins equal-name functions across two sources, an imported alias,
+re-export, a source function named `__module_init`, a colliding async resume
+label, and a late import/remap control. Assert distinct semantic owners,
+correct runtime values, exact final object ownership, and correctly located
+failures. Swap donor bindings/projections or omit a source and require failure.
+These controls apply to tracked and untracked public compilation; telemetry
+must not change compiler decisions or bytes. The final R1 audit additionally
+must enumerate remaining display-name and module-array consumers across both
+backends; this bounded continuation is not that exhaustive census.

--- a/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
+++ b/plan/issues/3525-ir-r5-whole-program-multi-source-ownership.md
@@ -2882,3 +2882,126 @@ P2B still owns mixed callable/init graphs, imported-global and re-export
 storage proofs, and noncommuting initializer-to-callable effects. Full R5
 acceptance and merge-group CI remain open; no full local Test262 run is claimed
 by this landing.
+
+## Astra High lane A — public prepared-program driver (2026-09-07)
+
+This is an **owner continuation**, under the ownership and pinned-source
+snapshot in [the epic's September 7 specification](3518-ir-only-default-and-direct-frontend-retirement.md).
+The recorded A owner is `ttraenkler/astra-ir-program-a-20260905`; its liveness
+and newest output-split commits remain unverified. Resume that work or obtain
+a scope handoff. Implementation model: **Astra Low**. Do not rebuild the
+preparation driver already carried by package C's stack.
+
+### Verified trigger and desired behavior
+
+On upstream `b3133d1d4da1151d82ef45b58db9566565097c57`,
+`src/compiler.ts::runPipeline` chooses legacy generators at `:1089–1104`.
+`src/compiler/output.ts::compileToObjectSource` separately calls
+`generateModule(ast)` at `:355`. A normal source compile and an object compile
+can therefore select different frontend policy even for identical options.
+The public `compileToObject` wrapper in `src/index.ts:1289` reaches that second
+root. A switch in only `runPipeline` cannot complete the migration.
+
+Desired production sequence: input normalization and source validation → one
+whole-program preparation → backend acceptance → one emission → shared output
+finalization. Keep parsing and original-source diagnostics on the frontend
+side. No backend is allowed to discover missing source bodies by calling the
+legacy generator, and no failure path retries through direct compilation.
+
+### Exclusive file ownership and API design
+
+A owns `src/compiler.ts`, `src/compiler/output.ts`, `src/index.ts`, new or
+recovered `src/compiler/ir-program-driver.ts`, new or recovered
+`src/compiler/ir-program-result.ts`, and new
+`tests/issue-3525-public-prepared-driver.test.ts`. If the recovered owner
+already split finalization/presentation into other files, use those files and
+record the exact substitution before editing; do not create duplicate output
+implementations. B's async engine, C's codec/consumer, host export marshalling,
+linker emission, and source-preparation producers are read-only in this slice.
+
+1. Define one internal synchronous driver over the complete analyzed source
+   graph, canonical entry source, checker/oracle, normalized target profile,
+   and output policy. Async APIs may await resolution/optimization, but
+   synchronous compile and object output cannot acquire an async-only semantic
+   preparation dependency. Reuse A's existing `prepareWholeIrProgram` from
+   `src/ir/program-preparation.ts` once the dependency is available.
+2. The driver returns an explicit discriminated result: emitted module with
+   authentic ownership/diagnostic evidence, or a located preparation/acceptance
+   refusal. Invariant exceptions remain fatal. No result variant contains a
+   retry callback, direct candidate or AST-taking backend closure. Catching an
+   arbitrary exception must not convert it to preclaim Unsupported.
+3. Call C's `acceptPreparedIrProgram` and `emitAcceptedIrProgram` exactly as
+   their recovered definitions require. Freeze target/runtime options before
+   acceptance. Do not manufacture acceptance receipts or plan materialization
+   in the wrapper. `emitAcceptedIrProgram` receives only C's accepted token.
+4. Separate module generation from binary/WAT/object/presentation finalization.
+   Feed the emitted module to the same established binary optimizer,
+   source-map, import helper, DTS, string-pool, export metadata and linker
+   paths that consume it today. Inventory every `mod` field read below
+   `runPipeline`'s generation block and by `compileToObjectSource` before
+   moving code; missing metadata must be a named contract gap, never silently
+   filled with an empty object. Preserve diagnostics and target options.
+5. Use the same driver for single, multi, files and object outputs; preserve
+   module evaluation order from the prepared startup plan. Sync/async API
+   wrappers may differ in I/O, not in source identity or semantic ownership.
+   Source IDs are minted once for the graph and remain unchanged through
+   finalization. Export names remain labels over binding IDs.
+6. Integrate the production call-site replacement only when coverage and
+   runtime dependencies pass the epic's final bar. Before that, publish
+   internal driver/finalizer checkpoints with explicit incomplete status;
+   do not add an optional `wholeProgramIR` mode or catch-and-direct fallback.
+   The eventual cutover removes direct imports from compiler orchestration
+   and routes all target profiles through preparation. Flag retirement in
+   #4522 remains owner-coordinated; disabling an optimization must never
+   select another frontend.
+
+### Required acceptance and negative controls
+
+Run the following cases through public `compile`, `compileFiles`,
+`compileMulti`, `compileToObject`, `compileToWat` and `compileProject` wrappers
+in `src/index.ts`, using each real signature. Also exercise the synchronous
+`compileSourceSync` entry in `src/compiler.ts` used by runtime eval; there is
+no public `compileSync` export. Never substitute a private generator for a
+public-route test. Include CLI/selfhost wrappers in the final closure audit.
+
+- One numeric function returns a nonconstant result; two sources with aliased
+  calls and equal helper names preserve distinct results; an exported live
+  global updates after startup; type-only/ambient sources preserve the census
+  without invented executable bodies. Ordinary and `fast: true` use the same
+  semantic ownership on gc and standalone. Linear/WASI report exact current
+  capability rather than producing a reduced module.
+- Object output is linked and executed, not merely nonempty. Check public
+  function/global export binding and startup behavior, and preserve relocation
+  index spaces. Missing C object/WASI capability is a dependency, not permission
+  to route object output through `generateModule` again.
+- Poison the four legacy generators before calling each public entry on the
+  candidate. Accepted cases still execute. The same test on the captured base
+  must hit poison for at least the direct namespace/object control; otherwise
+  it has not proved the detector is attached.
+- Inject a preparation Unsupported, a producer invariant, acceptance failure,
+  and emission failure independently. Each gives no artifact/exports; only
+  the actual Unsupported keeps that classification; none enters a direct
+  generator. A late failure cannot publish a partially filled module.
+- Same-name modules and a source function named `__module_init` cannot receive
+  each other's diagnostics, startup slot or exports. Reordering input map
+  insertion alone must not alter module dependency order or unit ownership.
+- Preserve target-specific result metadata and source-map locations on the
+  ordinary positive control. Remove the shared-driver call from object output
+  only: its poison test must fail again. Restore it and rerun the focused test.
+
+Use C's existing scalar two-source fixture as an initial dependency control;
+add the D application graph when runtime materialization becomes available.
+Run focused tests, typecheck, IR layering/dialect/kind checks, equivalence and
+required output/linker tests. Record exact base/candidate source hashes and
+per-entry phase/ownership evidence. Do not report full migration from scalar
+success while C still refuses async, reference layouts, linear plans or WASI.
+
+**Astra Low lane A prompt:** Continue A's recovered public driver/output work
+in its isolated worktree after ownership confirmation. You are not alone in
+the repository: preserve all peer changes and use only the file set above.
+First capture existing public-route results and metadata, then implement the
+shared driver and finalizers against the real A preparation and C consumer.
+Publish a non-draft checkpoint with exact moved call sites and poison/runtime
+controls. Do not add a public alternative compiler mode, edit package C, or
+silently narrow supported behavior. Hand back any missing provider/layout or
+source producer as a located failing fixture to its existing owner.

--- a/plan/issues/3527-ir-r7-ast-free-async-plan.md
+++ b/plan/issues/3527-ir-r7-ast-free-async-plan.md
@@ -972,3 +972,133 @@ These are recorded gate/environment residuals, not B3 acceptance evidence.
 The scoped B3 source, tests, and measured record are committed in
 `7c60d5c5873d0b164f1aa99b85b2995897fe8233` on top of the signed current-main
 merge above.
+
+## Astra High lane B — prepared frame engine without AST reachability (2026-09-07)
+
+Continue `ttraenkler/astra-ir-producers-b-20260905`'s held
+`prepared-async-frame-engine` scope, branch
+`codex/3518-prepared-async-frame-reconciled-20260907`; liveness and latest
+commits must be recovered by the lead. Implementation model: **Astra Low**.
+The [epic continuation specification](3518-ir-only-default-and-direct-frontend-retirement.md)
+records all peer claims and package C's exclusive files. This plan is not a
+replacement dispatch and does not authorize rewriting C's consumer.
+
+### Why the current prepared input does not retire the direct graph
+
+At upstream `b3133d1d4da1151d82ef45b58db9566565097c57`,
+`src/codegen/ir-async-frame.ts` imports
+`emitPreparedAsyncFrameStateMachine` from `src/codegen/async-frame.ts`.
+`lowerPreparedIrAsyncFunction` verifies current runtime identity, builds a
+frame layout and passes a callback CFG to that shared engine. The wrapper
+calls `emitAsyncFrameEntry(..., null, cfg)`; the shared engine still imports
+AST expression/statement dispatch and the checker-backed CPS machinery.
+`AsyncCfgOperand` in `async-cps.ts` accepts either a `ts.Expression` or an
+emit callback. The runtime path's type surface therefore permits AST fallback,
+and its transitive import graph retains the direct walkers even when one
+particular function supplies only callbacks.
+
+`buildFrameInfo` also allocates types immediately, and the shared entry code
+recovers a resume index from `ctx.funcMap` by a sanitized function name. The
+next slice must separate pure physical requirements from allocation and
+preserve exact allocated object identity across index changes. Copying the
+AST-bearing union into a differently named file does not achieve this.
+
+### Ownership, design and invariants
+
+Write only `src/codegen/ir-async-frame.ts`, new/recovered
+`src/codegen/prepared-async-frame-engine.ts`, new
+`src/codegen/prepared-async-frame-types.ts`,
+`tests/issue-3527-prepared-frame-import-boundary.test.ts`, and
+`tests/issue-3527-prepared-frame-runtime.test.ts`. Reuse already implemented
+B extraction modules if recovery finds them. Treat `async-frame.ts`,
+`async-cps.ts`, A's program contracts, C's consumer/physical plan and the
+separate runtime host-adapter owner as read-only. If a required shared API is
+absent, report the exact contract change to its owner rather than silently
+widening this lock.
+
+1. Define prepared-only local emission types. State leads are emission
+   operations derived from validated IR, terminators reference typed value
+   IDs or local emission operations, and handler/finalizer state comes from
+   the semantic plan. No `ts.Node`, checker, AST-or-emit union, source text or
+   parser callback belongs to these types. Process-local emission callbacks
+   are permitted only **after** backend acceptance; they are never serialized
+   as part of `PreparedIrProgram` or its runtime projection.
+2. Move only the prepared entry/resume algorithm into the new engine. Consume
+   a complete preaccepted frame layout, spill mapping, Promise carrier,
+   callback adapters, type/function/global handles and exception contract.
+   Preflight proves all required resources and supported state/handler shapes
+   before allocation. Unknown materialization remains C's located Unsupported;
+   malformed plans are invariants. No lazy `ensure*` discovery in accepted
+   emission, and no emitter-internal frontend selection.
+3. Replace the import from `async-frame.ts` and the dependency on
+   `AsyncCfgPlan` from `async-cps.ts` in `ir-async-frame.ts`. Reuse physical
+   helpers only when their runtime import closure excludes AST/checker/direct
+   dispatch. Type-only imports are erased and should be distinguished by the
+   boundary test. Avoid the broad `shared.ts` barrel when it pulls legacy
+   dispatchers; name the actual primitive module for required coercion/locals.
+4. Bind entry/resume/callback references by existing symbolic binding IDs and
+   allocator objects, never `fn.name`, sanitized stems or suffix search.
+   Resolve the current physical index from that handle. Preserve import
+   shifting, DCE remapping and recurrence group rules; failing handle
+   resolution cannot fall back to a saved number or name lookup.
+5. Preserve the existing semantic graph and state order. Entry runs once to
+   the first suspension; continuation resumes the planned state; live values
+   survive repeated awaits; fulfillment/rejection/throw keep Promise identity
+   and microtask behavior. This extraction does not widen supported handlers:
+   upstream `preparedCfg` rejects nonempty handlers, so adding full finally
+   support requires separately validated lowering and is not an incidental
+   part of moving the engine.
+6. C adopts the new physical engine through its own acceptance/materialization
+   implementation after B supplies requirements and tests. B demonstrates a
+   real lowerer/runtime positive control; it does not patch C to make a missing
+   runtime provider appear available. Leave legacy AST engine deletion for the
+   final whole-program reachability cut, after all users have migrated.
+
+### Acceptance with load-bearing controls
+
+- Fresh-process runtime import census for the prepared engine and its actual
+  entry adapter must contain no `typescript`, `ts-api`, checker,
+  `codegen/expressions`, `codegen/statements`, `async-cps`, or `async-frame`
+  runtime module. Use actual loaded modules, not only an import-text grep.
+  Inject a forbidden import in a temporary fixture and prove the census fails;
+  absence of events/unsupported instrumentation fails rather than returning
+  an empty successful census.
+- Execute an input-dependent async function with two numeric awaits and a live
+  value carried across both; assert exact result, stable returned Promise and
+  callback/microtask ordering against JavaScript. Exercise host and supported
+  standalone native Promise runtime. C's linear runtime refusal is recorded
+  as a dependency until its owner supplies physical support.
+- Two same-named async functions in different sources must have distinct
+  frames/resume targets. Add a user export matching the old sanitized resume
+  name. Both results remain correct. Inject a late import/remap through an
+  approved allocator test seam and assert handle resolution selects the same
+  object; an unbound handle is fatal, never name-resolved.
+- A stale plan/current-runtime pair, foreign-owner projection, missing spill,
+  missing callback capability, unsupported handler, duplicate state, and wrong
+  Promise result carrier each fail before emission with the appropriate
+  invariant or supported capability classification. After acceptance, remove
+  a bound resource via a test seam: emission fails without publishing output
+  or retrying through AST. Keep a passing scalar control in the same harness.
+- Poison legacy AST body entry on a previously supported prepared async
+  fixture; prepared execution passes. Restore only the legacy-engine import
+  in an isolated removal control and require the module-boundary test to fail.
+  The original body must remain input-dependent so constant folding cannot
+  erase the evidence.
+
+Run the existing prepared async/currentness/frame suites identified in the
+recovered B branch, the two new tests, async equivalence, typecheck, IR
+layering/dialect/kind checks and resource/LOC/function ratchets. Compare base
+and candidate outputs on the same runtime configuration. Record final
+functions/imports/frame fields, executed values, phase and failure rows.
+Do not describe an AST-free parameter type or a mocked engine as completed
+AST-free backend emission.
+
+**Astra Low lane B prompt:** Resume the existing prepared-frame extraction
+with the exact ownership above, after the lead confirms its recovered head.
+You are not alone in the repository; preserve other edits, including C and the
+host-provider owner. Reproduce the actual prepared-to-legacy import path,
+then remove it by a prepared-only physical engine with no semantic AST
+fallback. Validate loaded-module census, two-await runtime behavior,
+source-qualified resume identity, tamper failures and the import removal
+control. Return the exact requirements C must materialize, without changing
+C's implementation or claiming its async acceptance has passed.


### PR DESCRIPTION
Current public compiler entry points still reach direct AST codegen even though the bounded IR-only gate is READY. This specification defines three disjoint owner continuations: one public prepared-program driver, a prepared async frame engine without AST reachability, and a public-route completion gate with runtime and mutation controls.

Updates the existing plans for #3518 (IR-only default and direct frontend retirement), #3520 (source-qualified identity and Program ABI), #3525 (whole-program ownership), and #3527 (AST-free async plans). Includes a pinned ownership snapshot, exact file scopes, dependency ordering, Astra Low implementation prompts, and the final completion audit. Claims are held records, not proof of live writers. Package C PR #5692 remains excluded; no claims are transferred and no compiler code changes.

Validation on upstream b3133d1d4da1151d82ef45b58db9566565097c57:
- Existing IR-only gate tests: 14/14 pass.
- IR-only corpus: both lanes READY, each 5/5 entries, 41 terminals, 38 IR bodies, 3 non-executable, zero legacy bodies.
- Public namespace control: gc and standalone each compile successfully with two legacy terminal bodies and zero IR bodies. Binary execution was not measured for this probe.
- Optimization retirement intentionally remains red: 46/50 obligations not ready. Current static reachability audit covers 833 codegen files and observes both configured dispatch roots.
- Issue/link check, JSON formatting, whitespace, LOC/function and oracle gates pass. Commit hooks ran without bypass. No full Test262 or package C replay run is claimed.

This is a non-draft specification checkpoint, not completion of the migration.
