### PR TITLE
fix(temporal): atomically publish immutable provider source projects

### DIFF
--- a/plan/issues/5382-temporal-synthetic-project-atomic-publication.md
+++ b/plan/issues/5382-temporal-synthetic-project-atomic-publication.md
@@ -1,0 +1,318 @@
+---
+id: 5382
+title: "Publish Temporal synthetic projects atomically and keep published source trees immutable"
+status: ready
+sprint: current
+created: 2026-09-07
+updated: 2026-09-07
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: low
+task_type: bug
+area: compiler
+language_feature: Temporal
+goal: correctness
+---
+
+# Publish Temporal synthetic projects atomically and keep published source trees immutable
+
+## Ownership and scope
+
+This is the Astra High repair specification for an Astra Low implementer.
+The identifier was reserved by `claim-issue.mjs --allocate --by
+ttraenkler/astra-temporal-publication-spec --json`; the allocator reported an
+upstream-verified reservation and successful open-PR scan. No implementation
+claim is implied. The existing claim on issue 5353, **Wire the SHARDED test262 CI
+lane to the compile-once Temporal provider so the published conformance number
+includes Temporal**, remains its owner's responsibility.
+
+Source inspected at `6a6eb9a8ac40035cd965ddff48d4fa52d6c2d597` on
+`upstream/main`. This specification is an independent documentation change,
+not a stack containing either diagnostic snapshot or an implementation.
+
+Own the synthetic source materialization in `src/temporal-provider.ts` and
+focused tests in `tests/issue-5382-temporal-project-publication.test.ts` plus
+an issue-specific child-process fixture if required. Keep helpers private to
+the provider module unless a test seam is demonstrably necessary. Do not edit
+the package linker, compiled-provider cache, worker gate, prewarm stamp,
+baseline, workflows, runtime Temporal semantics, or another owner's files.
+Do not reopen 5353 to hide this separate materialization defect.
+
+## Evidence and limits
+
+Popper's complete evidence is the local report
+`/tmp/js2-5683-diagnosis.Vrp0Rw/init-interleaving.qbyW0T/report.md` and its
+referenced per-arm logs. The architect read that report; these measurements
+are Popper's, not a newly executed architecture-spec test run.
+
+The experiment used saved original bundles, Node 25.9.0 on Darwin arm64,
+at most two processes with 768 MB heaps, and warm per-snapshot provider
+caches. It rebuilt no bundle and ran no Test262 corpus. Both snapshots were
+tested: baseline `24681afc1ee2146e2317f81df2404a710f884e52` and merge-group
+candidate `2babfc21ec5b97a54e7f399d5c7ee232e77fdde5`.
+
+Each reader completed all three synthetic writes, then paused before its
+first real source read. A second initializer opened either the entry or
+polyfill file with `w`, genuinely truncating it, and paused before writing.
+The first process resumed and read zero bytes through the production reader.
+After it failed, the second process resumed the original write and succeeded.
+
+- Entry truncation: 0 of 121 expected bytes, followed by
+  `Temporal provider was not linked separately (plan=none)`.
+- Polyfill truncation: 0 of 157546 expected bytes, followed by
+  `Temporal provider was not linked separately (plan=bundled, reason=@js-temporal/polyfill does not expose Temporal)`.
+- Across both snapshots: sequential and all-writes-complete controls succeeded
+  8/8; forced-interleaving readers failed 4/4; resumed writers succeeded 4/4.
+  All 16 initializer processes exited normally after reporting their result.
+- All 12 successes reported `cacheHit: true` and the same 2,072,630-byte
+  provider, SHA-256
+  `dc7b1f20d88af74531635c0e793328151130b1d89c88049f4f10bf21995d3630`.
+
+Expected evidence-file SHA-256 values: entry
+`e47a1e52f675fd6a8dbbd69944ac941d07a4c424aa50012ae6754e86ddddbdd9`,
+polyfill `68b811af28240d9ac917c7c26628d7794190e0e367e791b150b5a527cda9e7be`,
+75-byte package metadata
+`06282976de72920b850c57b0e444532b4256614a1e56cefb83d4f255dcd38d1d`.
+
+This proves a possible initialization failure mechanism in both snapshots.
+It does not establish the cause of the original PR 5683 CI run, attribute
+every affected row to the race, or establish a candidate-only regression.
+The experiment did not exercise downstream worker error memoization or
+ambient fallback. Keep those boundaries in the implementation PR report.
+
+## Existing failure mechanism
+
+`buildTemporalProvider` checks its process-local memory cache, computes
+`temporal-project-${key.slice(0, 16)}`, then writes package metadata, polyfill,
+and entry directly into that shared directory on every disk-backed call.
+Only afterwards does `compileProject` traverse it. A warm binary cache does
+not avoid that module-graph read. Another process can truncate a source file
+while the first compiler is reading the shared tree.
+
+Writing temporary files and renaming each file individually is insufficient:
+the project is the publication unit. `existsSync` followed by the old writes
+also races. A process-local pending-promise map cannot serialize independent
+workers. None of these is the accepted repair.
+
+## Implementation plan
+
+### Identity, bytes, and migration
+
+Leave `temporalProviderCacheKey`, its length-prefixed hashing, and
+`providerOptionFingerprint` unchanged. Preserve every forwarded compile
+option and the existing forced `allowJs`, `emitWat`, and semantic-diagnostic
+settings. Preserve `packageCacheDir = path.join(cacheDir, "providers")`.
+The synthetic layout version must not enter the provider/prewarm identity.
+
+Use a distinct deterministic final path, for example
+`temporal-project-v2-${key}` under the same caller-supplied cache directory.
+Use the complete existing key. Never reuse the legacy mutable
+`temporal-project-${key.slice(0, 16)}` path: a concurrently running old bundle
+can continue rewriting it. Do not rename, repair, or delete legacy trees.
+
+Build the expected three-file map once per call from the current inputs:
+`__js2wasm_temporal_entry.js`,
+`node_modules/@js-temporal/polyfill/package.json`, and
+`node_modules/@js-temporal/polyfill/index.js`. Preserve their current exact
+UTF-8 bytes, including metadata formatting and the two entry newlines.
+Do not normalize source text or add a generated file inside the package
+that changes its discovered source set. No source text belongs in errors.
+
+The linker currently computes `packageFileKey` relative to the package root
+and hashes those keys with source contents, dependency identities, ABI
+versions, and compiler options. Moving the synthetic parent therefore
+should not invalidate provider fingerprints. Verify this with the migration
+control below; do not alter the linker if that expectation fails without a
+new scoped investigation.
+
+### Complete verification and atomic publication
+
+Introduce a private materialization helper returning only a verified final
+entry path. It must complete before calling `compileProject`.
+
+1. Ensure only the caller's cache directory exists. If a final project is
+   present, verify the directory structure and all three expected files as
+   regular files with exactly the expected bytes. Reject symlink substitutions
+   for the project, package path, or files. A matching key in a filename,
+   entry existence, nonzero length, or a marker alone is insufficient.
+   On a valid warm tree, perform no writes to that tree. Missing files within
+   an existing tree and byte mismatches are corruption errors, not cache
+   misses to repair in place. Other filesystem errors retain their causes.
+2. When the final root is absent, allocate a uniquely named private staging
+   directory with `mkdtempSync` under that same cache directory, e.g.
+   `.temporal-project-v2-${key}.staging-...`. Create and write all three files
+   only there. Close writes and verify the complete staged tree. No compiler
+   or other initializer may consume this private path.
+3. Publish with one directory `renameSync(stagingRoot, finalRoot)`. Never copy
+   on `EXDEV`, remove the destination to make rename succeed, or fall back to
+   writing destination files. Same-parent staging is required, not an OS
+   temporary directory that might reside on another filesystem.
+4. A complete published tree is nonempty. Concurrent directory rename cannot
+   replace that valid nonempty winner. A losing initializer may reuse the
+   winner only after full verification against its own expected bytes.
+   Recognize directory-collision errors (`EEXIST`/`ENOTEMPTY`, with a tested
+   platform-specific equivalent if necessary); do not catch every filesystem
+   exception and report a cache hit. If collision verification fails, reject
+   before compilation and preserve useful original error/cause information.
+5. After a successful rename, verify the final path as well, then pass only
+   its entry path to `compileProject`. The precheck in step 1 is an
+   optimization; the rename and winner verification establish correctness.
+   There is no exists-before-write window on published source files.
+
+Be precise about directory rename semantics: some platforms can atomically
+replace a concurrently created *empty* destination. Such a directory is not
+a valid published winner. This outcome may publish the entire verified tree
+atomically; it must never result in partial source reads. An invalid tree
+observed during warm verification is rejected. The contract does not claim
+that ordinary Node rename provides a general no-replace primitive for every
+invalid filesystem object. Test the empty-destination race explicitly; do
+not implement locks, lock stealing, or a pointer protocol merely to claim
+stronger semantics than this repair requires.
+
+### Errors, lifetime, and cleanup
+
+Only delete the unique staging directory created by the current invocation,
+and only if it was not successfully renamed. Track that ownership directly;
+do not derive cleanup targets by scanning prefixes. Leave published winners,
+legacy paths, another initializer's staging tree, and the provider cache
+untouched. An abandoned staging tree after process death is harmless because
+no reader discovers it. Automated stale-tree scavenging is out of scope.
+
+Cleanup after write/verification/rename failure must not mask the primary
+failure. If cleanup itself fails, preserve that information without treating
+the build as successful. Cleanup failure after losing to a valid winner is
+still an operational failure; do not silently discard it. A compile failure
+after successful publication leaves the complete immutable tree for a retry.
+
+Preserve the existing compilation/link-plan/artifact/getter errors and
+successful memory-cache behavior. Do not insert a failed build or partially
+constructed provider into memoryCache. No new retries, swallowed errors,
+bundled fallback, or change to `cacheHit` semantics: `cacheHit` describes the
+compiled provider, not whether synthetic sources already existed.
+
+## Deterministic verification contract
+
+Implement controlled filesystem barriers in a child fixture or an injected
+environment filesystem. Use explicit acknowledgements and bounded timeouts,
+not timing sleeps or a high-concurrency stress run as the proof. Record
+whether each barrier was actually reached; a missing observation must fail.
+Keep per-test paths private and avoid running expensive compiler suites in
+parallel with another owner's pre-push checks.
+
+- **Cold private writes:** pause initializer A after each of the three
+  staging writes, in separate cases. B must publish a complete project and
+  proceed; A resumes, verifies that same winner, and proceeds. The compiler
+  seam records every consumed path and all three observed file bytes. No
+  consumed path contains the staging prefix, and no observed file is partial.
+- **Two completed contenders:** pause both after staged verification, allow
+  B to rename, then A. Both consume B's complete final tree; only A's private
+  stage is cleaned. Repeat with A winning. These are independent processes,
+  not calls serialized by one memory cache.
+- **Warm reader versus initializer:** publish a valid tree; pause A at the
+  real entry/polyfill read, run B's warm initialization, then resume A.
+  Instrument write-open/truncate/rename/remove calls on the final tree and
+  require zero. Both initializers see the exact original bytes. Cover entry
+  and polyfill separately, reproducing the old failing schedule's boundary.
+- **Partial/corrupt winner:** independently seed missing entry, missing
+  polyfill, truncated entry, truncated polyfill, wrong package metadata,
+  same-length wrong content, an empty project root, and a symlink replacement.
+  Each observed warm invalid tree is rejected before compile and is preserved.
+  For a nonempty invalid tree inserted just before A's rename, collision
+  verification must reject and clean only A's stage. Also insert an empty
+  destination at that boundary: accept only whole-tree atomic publication
+  followed by complete verification, or an explicit failure before compile.
+- **Error ownership:** inject staging mkdir/write/read failure, rename
+  `EXDEV`/permission failure, verification read failure, and cleanup failure.
+  Assert original failure/cause, no compiler call on materialization failure,
+  and no deletion outside the invocation's stage. A sibling stage survives.
+  Simulated process death during staging leaves a tree that a later process
+  ignores while independently publishing successfully.
+- **Migration/cache compatibility:** using one pinned source and fixed
+  compile options, prewarm with the old layout/bundle, then run the repaired
+  initializer against the same `cacheDir`. Require the unchanged
+  `temporalProviderCacheKey` and prewarm-stamp key, provider source fingerprint,
+  artifact cache key, namespace, export/getter contract, and binary SHA-256;
+  require a real provider cache hit. The new project path is versioned and
+  the old path's bytes and metadata are untouched. Run an old initializer
+  while the new reader is paused to prove the old path cannot truncate the
+  new tree. Do not make the historical binary hash above a permanent compiler
+  golden; compare baseline and candidate with identical compiler inputs.
+- **Identity separation:** changed source and each existing fingerprinted
+  option select the corresponding unchanged key and independent new-layout
+  path. Unchanged input reuses the immutable tree. Exercise an attached
+  provider-memory-cache hit separately from a disk hit in a fresh process.
+
+The cheap barrier tests may stub `compileProject` to inspect consumed bytes,
+but report them separately from at least one real linked-provider migration
+and interleaving control. That real control must assert a separate link plan,
+artifact/getter availability, nonempty binary and exact cache provenance;
+process exit zero alone is not success. Reuse existing Temporal test helpers
+and pinned source acquisition without adding network access to production.
+
+Run the focused new tests, existing issue-5353 sharded-lane tests, and the
+relevant existing Temporal wiring/provider controls plus normal required
+hooks. Report exact denominators, compiler/runtime version, input hashes,
+baseline/candidate SHAs, and any unexecuted heavy controls. No Test262 score
+or resolution of PR 5683 is claimed from these tests alone.
+
+## Acceptance and handoff
+
+The implementation is complete only when no initializer writes published
+synthetic source, both cold contenders and warm readers observe complete
+trees, corrupt winners fail before compilation, old/new processes use
+disjoint synthetic layouts, and compiled-provider identity/cache reuse is
+unchanged. The PR must contain only the scoped source/test repair and this
+issue's measured completion record, pass normal hooks, and retain other
+owners' claims and worktrees. The current change is specification only;
+none of the proposed repair controls has yet been run on an implementation.
+
+
+## Implementation checkpoint — Astra Low, 2026-09-07
+
+Implementation worktree: `/private/tmp/js2-5382-temporal-publication-impl`.
+Branch: `codex/5382-temporal-atomic-publication`.
+Fresh upstream baseline verified with `git ls-remote upstream refs/heads/main`:
+`ec6d2efc3241e8698b0755983491a85ebcbca5eb`.
+The upstream claim for 5382 is verified for
+`ttraenkler/astra-low-temporal-publication`; issue 5353 is not claimed or changed.
+
+The source change is confined to `src/temporal-provider.ts`: private complete
+staging, full-key versioned publication, directory and exact-byte verification,
+collision verification, and invocation-owned cleanup with original error causes.
+The provider fingerprint function, compile options, binary-cache location,
+linker, worker, prewarm contract, workflows and baselines are unchanged.
+
+Focused tests live in `tests/issue-5382-temporal-project-publication.test.ts`;
+the independent-process fixture is
+`tests/fixtures/issue-5382-temporal-publication-child.mjs`.
+Cheap tests use a stubbed compiler observer, real filesystem operations and at
+most two 192 MB children inside one 512 MB Vitest fork. Barriers acknowledge
+their arrival and block on parent input with a bounded parent deadline.
+These tests do not claim real provider compilation or conformance results.
+
+Measured on Node 22.23.2 / Darwin arm64, TypeScript 5.9.3, Vitest 3.2.4:
+50/50 executed tests pass (32 publication, 14 issue5353 sharded-lane,
+4 issue5248 wiring); 1 real-provider test is explicitly skipped. The focused
+command uses one Vitest fork and no file parallelism. LOC and function budget
+checks pass for the scoped source change. These are local, not CI results.
+
+Verification is in progress. The real linked-provider migration/interleaving
+test is explicitly opt-in via `ISSUE5382_BASELINE_BUNDLE` (the old builder and
+environment exports) and requires the parent-coordinated heavy-test slot.
+It compiles the current provider bundle itself, acquires the pinned polyfill
+through the existing helper, compares source-ref metadata, provider cache key,
+namespace, getter/binary exports, byte/hash identity, prewarm stamp and legacy
+source metadata, and requires real cache hits. Both entry and polyfill reads
+are paused at the actual compiler resolver while the old initializer runs.
+A successful process exit alone is not accepted.
+
+Pending: execute that real control and existing heavy provider controls after
+coordination; full typecheck/pre-push after D's typecheck and B's next pre-push
+slots; normal commit hooks; publication of a ready non-draft PR only when the
+remaining acceptance checks are resolved. No hook bypass is authorized.
+
+Original issue5683 diagnostic snapshots and reports remain untouched. Neither
+this implementation nor the prior forced schedule proves the original CI cause.
+The initial fresh checkout reported an unrelated Acorn LFS-pointer anomaly at
+`website/public/acorn/acorn.wasm`; it is not part of this change.

--- a/plan/issues/5382-temporal-synthetic-project-atomic-publication.md
+++ b/plan/issues/5382-temporal-synthetic-project-atomic-publication.md
@@ -264,11 +264,12 @@ trees, corrupt winners fail before compilation, old/new processes use
 disjoint synthetic layouts, and compiled-provider identity/cache reuse is
 unchanged. The PR must contain only the scoped source/test repair and this
 issue's measured completion record, pass normal hooks, and retain other
-owners' claims and worktrees. The current change is specification only;
-none of the proposed repair controls has yet been run on an implementation.
+owners' claims and worktrees. At specification authorship, none of the proposed
+repair controls had run; the implementation measurements below supersede that
+specification-only state.
 
 
-## Implementation checkpoint — Astra Low, 2026-09-07
+## Measured implementation handoff — Astra Low, 2026-09-07
 
 Implementation worktree: `/private/tmp/js2-5382-temporal-publication-impl`.
 Branch: `codex/5382-temporal-atomic-publication`.
@@ -291,26 +292,77 @@ most two 192 MB children inside one 512 MB Vitest fork. Barriers acknowledge
 their arrival and block on parent input with a bounded parent deadline.
 These tests do not claim real provider compilation or conformance results.
 
-Measured on Node 22.23.2 / Darwin arm64, TypeScript 5.9.3, Vitest 3.2.4:
-50/50 executed tests pass (32 publication, 14 issue5353 sharded-lane,
-4 issue5248 wiring); 1 real-provider test is explicitly skipped. The focused
-command uses one Vitest fork and no file parallelism. LOC and function budget
-checks pass for the scoped source change. These are local, not CI results.
+The initial checkpoint was `8c3629d4f13231ad142958efe062373cb8593432`.
+Its Node 22.23.2 run had 50 passes and one required real control skipped; that
+was explicitly not acceptance. The parent subsequently released the heavy slot.
+The following Node 25.9.0 / Darwin arm64 measurements supersede that skip:
 
-Verification is in progress. The real linked-provider migration/interleaving
-test is explicitly opt-in via `ISSUE5382_BASELINE_BUNDLE` (the old builder and
-environment exports) and requires the parent-coordinated heavy-test slot.
-It compiles the current provider bundle itself, acquires the pinned polyfill
-through the existing helper, compares source-ref metadata, provider cache key,
-namespace, getter/binary exports, byte/hash identity, prewarm stamp and legacy
-source metadata, and requires real cache hits. Both entry and polyfill reads
-are paused at the actual compiler resolver while the old initializer runs.
-A successful process exit alone is not accepted.
+- Publication file: **33/33 pass, none skipped**, including the real linked
+  migration and both old/new compiler-read interleavings (32.29 s total).
+- Existing controls: **29/29 pass**, comprising issue4628 provider/global
+  controls (11), issue5353 sharded-lane controls (14), and issue5248 wiring (4).
+  The issue4628 heavy child built a fresh provider (`cacheHit: false`), then
+  all **25/25 supported runtime probes** passed. Its three existing known-gap
+  observations remain reported, not silently promoted to supported tests.
+- Total: **62/62 distinct tests**, none skipped in these verification runs.
+  TypeScript compiler dependency 5.9.3; Vitest 3.2.4. One Vitest fork, no file
+  parallelism; real initializer heaps 768 MB, at most two initializer processes.
+  These are local host-lane checks, not CI or a Test262 corpus measurement.
 
-Pending: execute that real control and existing heavy provider controls after
-coordination; full typecheck/pre-push after D's typecheck and B's next pre-push
-slots; normal commit hooks; publication of a ready non-draft PR only when the
-remaining acceptance checks are resolved. No hook bypass is authorized.
+The old builder was read directly from git blob
+`ec6d2efc3241e8698b0755983491a85ebcbca5eb:src/temporal-provider.ts`, source SHA-256
+`674d7c12e519d92c802362cc722cb7559ada3b8e575fd02def780f0df17f6fea`.
+Every other compiler source and dependency was identical to the implementation
+worktree. The test bundles use the same esbuild options, environment exports,
+and require shim; no historical compiler revision was mixed into this A/B.
+The preserved original bundle (`4ba1c719…`) had a duplicate `createRequire`
+banner declaration and could not load. The corrected old bundle is
+`.tmp/issue5382-baseline-provider-v2.mjs`, SHA-256
+`bfdf8cfa2b093579285367f43661c299850853b3c81f4161160816af8375104e`.
+The first executable run also correctly refused acceptance when a noncanonical
+macOS temporary path prevented its compiler-read barrier from being reached.
+Canonicalizing the test root fixed the instrumentation, not production code.
+
+Exact real-control provenance:
+
+- Polyfill source: 157546 bytes, SHA-256
+  `68b811af28240d9ac917c7c26628d7794190e0e367e791b150b5a527cda9e7be`.
+- Unchanged provider/prewarm input key:
+  `372a41be9bdeb22ade63a811b4b26afce75694ee0d9b7cf928c24ddad739020b`.
+- Unchanged linker source fingerprint:
+  `3fac10330db10667fdc54b9f775538cf546827af564bb6efea22e05b2f377ceb`.
+- Provider: **2090802 bytes**, binary SHA-256 and artifact cache key
+  `2d1e8f3deda3fbdab06bcdf204113dc99793d3abeec27507723c23aa25cf5e37`.
+- Namespace: `js2wasm:npm:@js-temporal/polyfill:2d1e8f3deda3fbda`;
+  getter: `__js2wasm_get_Temporal_ba822575`; 901 binary exports agree exactly.
+- Old cold build: cache miss. Repaired migration: real cache hit. Both resumed
+  repaired readers and both old warm initializers: real cache hits. All six
+  builds succeeded with the same artifact identity.
+- Entry and polyfill compiler-read barriers were both acknowledged. Each
+  repaired reader recorded 10 actual reads, all matching complete expected
+  bytes (entry 121, package metadata 75, polyfill 157546). Old initializers
+  performed their production legacy writes while each new reader was paused.
+  New readers performed zero mutations of the published tree. Initial
+  migration preserved all legacy file bytes, inode/mtime/ctime, provider ref
+  contents and prewarm stamp bytes.
+
+Reproduction: set `ISSUE5382_BASELINE_BUNDLE` to that exact old bundle and
+`ISSUE5382_REPORT` to a private report path, then run the focused publication
+file under Node 25.9.0 with `VITEST_MAX_FORKS=1`,
+`VITEST_FORK_MAX_OLD_SPACE_SIZE=512` and `--no-file-parallelism`.
+The report is `.tmp/issue5382-real-migration.json`; the existing end-to-end
+report is `tests/dogfood/report/temporal-global.json`. They are local evidence,
+not committed generated artifacts. Default CI invocation leaves the explicitly
+opt-in migration test skipped; the manual required acceptance run above did not.
+
+Normal checkpoint hooks passed: prettier, lint, LOC/function budgets,
+changed-root publication tests and oracle ratchet. The first commit-message
+attempt rejected shorthand `Model: Astra Low`; inspecting its rule and using
+`Model: Codex Astra Low` passed without bypass. Full `pnpm run typecheck`
+(the repository's TypeScript 7 lane) exited 0. Full `pnpm run lint` exited 0
+at its configured error threshold. `pnpm run sync:conformance:check` passed
+with 0 updates / 5 unchanged files. Normal pre-push/publication results remain
+to be reported; no hook bypass or signing-configuration change is authorized.
 
 Original issue5683 diagnostic snapshots and reports remain untouched. Neither
 this implementation nor the prior forced schedule proves the original CI cause.

--- a/src/temporal-provider.ts
+++ b/src/temporal-provider.ts
@@ -135,6 +135,96 @@ function providerOptionFingerprint(options: CompileOptions | undefined): string 
   });
 }
 
+type ProjectFilesystem = NonNullable<ReturnType<typeof getDefaultEnvironment>["fs"]>;
+
+function verifyTemporalProject(fs: ProjectFilesystem, root: string, files: ReadonlyMap<string, Buffer>): void {
+  for (const relative of ["", "node_modules", "node_modules/@js-temporal", "node_modules/@js-temporal/polyfill"]) {
+    if (!fs.lstatSync(path.join(root, relative)).isDirectory()) {
+      throw new Error(`Invalid Temporal synthetic project directory: ${relative || "."}`);
+    }
+  }
+  for (const [relative, expected] of files) {
+    const file = path.join(root, relative);
+    if (!fs.lstatSync(file).isFile() || !fs.readFileSync(file).equals(expected)) {
+      throw new Error(`Invalid Temporal synthetic project file: ${relative}`);
+    }
+  }
+}
+
+function materializeTemporalProject(fs: ProjectFilesystem, cacheDir: string, key: string, source: string): string {
+  // Versioned separately from provider identity: old bundles may still mutate
+  // the legacy directory. Only complete, immutable trees live in this layout.
+  const root = path.join(cacheDir, `temporal-project-v2-${key}`);
+  const entry = "__js2wasm_temporal_entry.js";
+  const packagePath = "node_modules/@js-temporal/polyfill";
+  const files = new Map([
+    [
+      `${packagePath}/package.json`,
+      Buffer.from(JSON.stringify({ name: TEMPORAL_PACKAGE_NAME, version: "0.0.0-linked", main: "index.js" })),
+    ],
+    [`${packagePath}/index.js`, Buffer.from(source)],
+    [
+      entry,
+      Buffer.from(
+        `import { ${TEMPORAL_EXPORT_NAME} } from "${TEMPORAL_PACKAGE_NAME}";\n` +
+          `export function __js2wasm_temporal_probe() { return typeof ${TEMPORAL_EXPORT_NAME}; }\n`,
+      ),
+    ],
+  ]);
+  fs.mkdirSync(cacheDir, { recursive: true });
+  let present = true;
+  try {
+    fs.lstatSync(root);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    present = false;
+  }
+  if (present) {
+    verifyTemporalProject(fs, root, files);
+    return path.join(root, entry);
+  }
+
+  const stage = fs.mkdtempSync(path.join(cacheDir, `.temporal-project-v2-${key}.staging-`));
+  let owned = true;
+  let failed = false;
+  let failure: unknown;
+  try {
+    fs.mkdirSync(path.join(stage, packagePath), { recursive: true });
+    for (const [relative, bytes] of files) fs.writeFileSync(path.join(stage, relative), bytes);
+    verifyTemporalProject(fs, stage, files);
+    try {
+      fs.renameSync(stage, root);
+      owned = false;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST" && code !== "ENOTEMPTY") throw error;
+      try {
+        verifyTemporalProject(fs, root, files);
+      } catch (verificationError) {
+        throw new AggregateError([error, verificationError], "Temporal synthetic project publication collision", {
+          cause: error,
+        });
+      }
+    }
+    verifyTemporalProject(fs, root, files);
+  } catch (error) {
+    failed = true;
+    failure = error;
+  }
+  if (owned) {
+    try {
+      fs.rmSync(stage, { recursive: true, force: true });
+    } catch (cleanupError) {
+      if (!failed) throw cleanupError;
+      throw new AggregateError([failure, cleanupError], "Temporal synthetic project publication and cleanup failed", {
+        cause: failure,
+      });
+    }
+  }
+  if (failed) throw failure;
+  return path.join(root, entry);
+}
+
 /**
  * Compile the polyfill once into a linked provider artifact.
  *
@@ -164,22 +254,7 @@ export async function buildTemporalProvider(options: BuildTemporalProviderOption
   // The linker consumes a real module graph, so the bundle is materialized as
   // a one-file npm package next to its own provider cache. The directory is
   // keyed by the source fingerprint, so a bundle bump never reuses stale text.
-  const projectRoot = path.join(options.cacheDir, `temporal-project-${key.slice(0, 16)}`);
-  const packageRoot = path.join(projectRoot, "node_modules", "@js-temporal", "polyfill");
-  fs.mkdirSync(packageRoot, { recursive: true });
-  fs.writeFileSync(
-    path.join(packageRoot, "package.json"),
-    JSON.stringify({ name: TEMPORAL_PACKAGE_NAME, version: "0.0.0-linked", main: "index.js" }),
-  );
-  fs.writeFileSync(path.join(packageRoot, "index.js"), options.polyfillSource);
-  const entryPath = path.join(projectRoot, "__js2wasm_temporal_entry.js");
-  // The root exists only to make `Temporal` an external package edge the
-  // linker must plan; its own binary is discarded.
-  fs.writeFileSync(
-    entryPath,
-    `import { ${TEMPORAL_EXPORT_NAME} } from "${TEMPORAL_PACKAGE_NAME}";\n` +
-      `export function __js2wasm_temporal_probe() { return typeof ${TEMPORAL_EXPORT_NAME}; }\n`,
-  );
+  const entryPath = materializeTemporalProject(fs, options.cacheDir, key, options.polyfillSource);
 
   const result = await compileProject(entryPath, {
     ...options.compileOptions,

--- a/tests/fixtures/issue-5382-temporal-publication-child.mjs
+++ b/tests/fixtures/issue-5382-temporal-publication-child.mjs
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// Independent initializer with acknowledged, parent-controlled filesystem barriers.
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { createHash } from "node:crypto";
+
+const config = JSON.parse(process.argv[2]);
+if (config.sourceFile) config.polyfillSource = fs.readFileSync(config.sourceFile, "utf8");
+const events = [];
+const reads = [];
+const consumed = [];
+let stage;
+let paused = false;
+let injected = false;
+let compiling = false;
+const send = (value) => fs.writeSync(1, `${JSON.stringify(value)}\n`);
+function barrier(label) {
+  if (paused || config.barrier !== label) return;
+  paused = true;
+  send({ barrier: label, stage });
+  process.stdin._handle.setBlocking(true);
+  const byte = Buffer.alloc(1);
+  if (fs.readSync(0, byte, 0, 1, null) !== 1) throw new Error("Barrier was not released");
+}
+function encodedError(error) {
+  return {
+    message: error?.message,
+    code: error?.code,
+    cause: error?.cause ? encodedError(error.cause) : undefined,
+    errors: error?.errors?.map(encodedError),
+  };
+}
+const module = await import(pathToFileURL(config.bundle).href);
+const key = module.temporalProviderCacheKey(config);
+const finalRoot = path.join(
+  config.cacheDir,
+  config.legacy ? `temporal-project-${key.slice(0, 16)}` : `temporal-project-v2-${key}`,
+);
+const adapter = new Proxy(fs, {
+  get(target, property) {
+    const original = target[property];
+    if (typeof original !== "function") return original;
+    return (...args) => {
+      const file = typeof args[0] === "string" ? args[0] : "";
+      const local = file.startsWith(config.cacheDir);
+      if (local)
+        events.push({ op: property, path: file, destination: property === "renameSync" ? args[1] : undefined });
+      if (property === "renameSync") barrier("rename");
+      if (
+        property === "readFileSync" &&
+        file.startsWith(finalRoot) &&
+        (!config.compilerRead || compiling || new Error().stack?.includes("resolveAllImports"))
+      ) {
+        barrier(`read:${path.basename(file)}`);
+      }
+      const fault = config.fault;
+      if (
+        fault &&
+        property === fault.op &&
+        (!fault.where || file.includes(fault.where)) &&
+        (!injected || property === "rmSync")
+      ) {
+        injected = true;
+        throw Object.assign(new Error(`injected ${property}`), { code: fault.code ?? "EACCES" });
+      }
+      if (property === "rmSync" && config.cleanupFailure) {
+        throw Object.assign(new Error("injected cleanup"), { code: "EACCES" });
+      }
+      const result = original.apply(target, args);
+      if (property === "mkdtempSync") stage = result;
+      if (property === "readFileSync" && (file.startsWith(finalRoot) || file.includes(".staging-")))
+        reads.push({ path: file, hex: Buffer.from(result).toString("hex") });
+      if (property === "writeFileSync" && file.includes(".staging-")) {
+        if (config.abandonStage) {
+          send({ ok: false, abandoned: true, stage, consumed, events, finalRoot });
+          process.exit(0); // Simulate death: no stack unwinding or materializer cleanup.
+        }
+        barrier(`write:${path.basename(file)}`);
+      }
+      return result;
+    };
+  },
+});
+module.setDefaultEnvironment({ ...module.getDefaultEnvironment(), fs: adapter });
+globalThis.__issue5382Compile = async (entry, options) => {
+  compiling = true;
+  const root = path.dirname(entry);
+  const files = Object.fromEntries(
+    [
+      "__js2wasm_temporal_entry.js",
+      "node_modules/@js-temporal/polyfill/package.json",
+      "node_modules/@js-temporal/polyfill/index.js",
+    ].map((relative) => [relative, adapter.readFileSync(path.join(root, relative)).toString("hex")]),
+  );
+  consumed.push({ entry, files, options });
+  if (config.compileFailure) throw new Error("injected compile failure");
+  return {
+    success: true,
+    linkPlan: { mode: "separate" },
+    linkedModules: [
+      {
+        packageName: "@js-temporal/polyfill",
+        namespace: "test:provider",
+        cacheHit: false,
+        exportBoundaries: { Temporal: { kind: "getter", field: "getTemporal" } },
+      },
+    ],
+  };
+};
+try {
+  if (config.retryCompile) {
+    config.compileFailure = true;
+    try {
+      await module.buildTemporalProvider(config);
+      throw new Error("Expected first compile to fail");
+    } catch (error) {
+      if (error.message !== "injected compile failure") throw error;
+    }
+    config.compileFailure = false;
+  }
+  const provider = await module.buildTemporalProvider(config);
+  if (config.real) {
+    const artifact = provider.artifact;
+    const binary = Buffer.from(artifact.binary);
+    const wasm = new WebAssembly.Module(binary);
+    const exports = WebAssembly.Module.exports(wasm).map((item) => item.name);
+    if (!binary.length || !exports.includes(provider.getterField))
+      throw new Error("Real provider getter missing from binary");
+    send({
+      ok: true,
+      key,
+      finalRoot,
+      stage,
+      events,
+      reads,
+      paused,
+      provider: {
+        cacheHit: provider.cacheHit,
+        namespace: provider.namespace,
+        getterField: provider.getterField,
+        cacheKey: artifact.cacheKey,
+        exportBoundaries: artifact.exportBoundaries,
+        bytes: binary.length,
+        sha256: createHash("sha256").update(binary).digest("hex"),
+        exports,
+      },
+    });
+    process.exit(0);
+  }
+  const count = events.length;
+  const memory = config.memory ? await module.buildTemporalProvider(config) : undefined;
+  send({
+    ok: true,
+    provider,
+    memory,
+    memoryEvents: events.length - count,
+    finalRoot,
+    stage,
+    events,
+    reads,
+    consumed,
+    paused,
+  });
+} catch (error) {
+  send({ ok: false, error: encodedError(error), finalRoot, stage, events, reads, consumed, paused });
+}

--- a/tests/issue-5382-temporal-project-publication.test.ts
+++ b/tests/issue-5382-temporal-project-publication.test.ts
@@ -1,0 +1,505 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { createHash } from "node:crypto";
+import { build } from "esbuild";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const source = "export const Temporal = { marker: 'π' };\n";
+const entry = "__js2wasm_temporal_entry.js";
+const pkg = "node_modules/@js-temporal/polyfill";
+const expected = {
+  [`${pkg}/package.json`]: Buffer.from(
+    JSON.stringify({ name: "@js-temporal/polyfill", version: "0.0.0-linked", main: "index.js" }),
+  ).toString("hex"),
+  [`${pkg}/index.js`]: Buffer.from(source).toString("hex"),
+  [entry]: Buffer.from(
+    'import { Temporal } from "@js-temporal/polyfill";\nexport function __js2wasm_temporal_probe() { return typeof Temporal; }\n',
+  ).toString("hex"),
+};
+const root = fs.mkdtempSync(path.join(tmpdir(), "issue-5382-"));
+const bundle = path.join(root, "provider.mjs");
+const fixture = path.join(import.meta.dirname, "fixtures/issue-5382-temporal-publication-child.mjs");
+type Outcome = {
+  ok: boolean;
+  finalRoot: string;
+  stage?: string;
+  paused: boolean;
+  error?: { message: string; code?: string; cause?: unknown; errors?: unknown[] };
+  events: Array<{ op: string; path: string; destination?: string }>;
+  consumed: Array<{ entry: string; files: Record<string, string>; options: Record<string, unknown> }>;
+  reads: Array<{ path: string; hex: string }>;
+  memoryEvents: number;
+  memory?: { cacheHit: boolean };
+  key?: string;
+  provider?: {
+    cacheHit: boolean;
+    namespace: string;
+    getterField: string;
+    cacheKey: string;
+    bytes: number;
+    sha256: string;
+    exportBoundaries: unknown;
+    exports: string[];
+  };
+};
+let serial = 0;
+const cache = () => path.join(root, `cache-${serial++}`);
+
+function child(cacheDir: string, extra: Record<string, unknown> = {}) {
+  const process = spawn(
+    globalThis.process.execPath,
+    [
+      `--max-old-space-size=${extra.real ? 768 : 192}`,
+      fixture,
+      JSON.stringify({ bundle, cacheDir, polyfillSource: source, ...extra }),
+    ],
+    { stdio: ["pipe", "pipe", "pipe"] },
+  );
+  let stderr = "";
+  let outcome: Outcome | undefined;
+  let reached = false;
+  let acknowledge!: (value: { stage: string }) => void;
+  let rejectBarrier!: (error: Error) => void;
+  const ready = new Promise<{ stage: string }>((resolve, reject) => {
+    acknowledge = resolve;
+    rejectBarrier = reject;
+  });
+  // Tests without a barrier only await completion; retain rejection visibility there.
+  void ready.catch(() => {});
+  const timer = setTimeout(() => process.stdin.end(), extra.real ? 120000 : 15000);
+  process.stderr.on("data", (data) => {
+    stderr += data;
+  });
+  createInterface({ input: process.stdout }).on("line", (line) => {
+    if (!line.startsWith("{")) {
+      stderr += `${line}\n`;
+      return;
+    }
+    const message = JSON.parse(line);
+    if (message.barrier) {
+      reached = true;
+      acknowledge(message);
+    } else outcome = message;
+  });
+  const done = new Promise<Outcome>((resolve, reject) => {
+    process.on("error", reject);
+    process.on("close", (code) => {
+      clearTimeout(timer);
+      if (!reached) rejectBarrier(new Error(`Barrier not reached: ${stderr} ${JSON.stringify(outcome)}`));
+      if (code !== 0 || !outcome) reject(new Error(`child exit=${code}: ${stderr}`));
+      else resolve(outcome);
+    });
+  });
+  return { ready, done, release: () => process.stdin.end("x"), abandon: () => process.stdin.end() };
+}
+
+function complete(out: Outcome) {
+  expect(out.ok, JSON.stringify(out.error)).toBe(true);
+  expect(out.consumed).toHaveLength(1);
+  expect(out.consumed[0].entry).toBe(path.join(out.finalRoot, entry));
+  expect(out.consumed[0].entry).not.toContain(".staging-");
+  expect(out.consumed[0].files).toEqual(expected);
+}
+function untouched(out: Outcome) {
+  expect(
+    out.events.filter(
+      (event) =>
+        ["writeFileSync", "openSync", "truncateSync", "renameSync", "rmSync", "mkdirSync"].includes(event.op) &&
+        (event.path.startsWith(out.finalRoot) || event.destination?.startsWith(out.finalRoot)),
+    ),
+  ).toEqual([]);
+}
+beforeAll(async () => {
+  await build({
+    stdin: {
+      contents:
+        'export * from "./src/temporal-provider.ts"; export { getDefaultEnvironment, setDefaultEnvironment } from "./src/env.ts";',
+      resolveDir: path.join(import.meta.dirname, ".."),
+      loader: "ts",
+    },
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile: bundle,
+    plugins: [
+      {
+        name: "issue5382-compile-observer",
+        setup(builder) {
+          builder.onResolve({ filter: /^\.\/index\.js$/ }, (args) =>
+            args.importer.endsWith("temporal-provider.ts")
+              ? { path: "compile-observer", namespace: "issue5382" }
+              : undefined,
+          );
+          builder.onLoad({ filter: /.*/, namespace: "issue5382" }, () => ({
+            contents:
+              "export const compileProject = (...args) => globalThis.__issue5382Compile(...args); export const compileMulti = () => { throw Error('unused'); };",
+          }));
+        },
+      },
+    ],
+  });
+});
+afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+
+// Opt-in because the pinned polyfill cold compile needs the team's heavy-test
+// slot. The baseline must export the unchanged builder and environment seam.
+it.skipIf(!process.env.ISSUE5382_BASELINE_BUNDLE)(
+  "#5382 real linked-provider migration and old/new interleaving",
+  { timeout: 300000 },
+  async () => {
+    const realBundle = path.join(root, "real-provider.mjs");
+    const repo = path.join(import.meta.dirname, "..");
+    await build({
+      stdin: {
+        contents:
+          'export * from "./src/temporal-provider.ts"; export { getDefaultEnvironment, setDefaultEnvironment } from "./src/env.ts";',
+        resolveDir: repo,
+        loader: "ts",
+      },
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      packages: "external",
+      outfile: realBundle,
+      banner: { js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);' },
+    });
+    fs.symlinkSync(path.join(repo, "node_modules"), path.join(root, "node_modules"));
+    const { loadTemporalPolyfillSource, writeTemporalPrewarmStamp, readTemporalPrewarmStamp } =
+      await import("../scripts/test262-temporal.mjs");
+    const polyfillSource = await loadTemporalPolyfillSource();
+    const sourceFile = path.join(root, "polyfill.js");
+    fs.writeFileSync(sourceFile, polyfillSource);
+    const dir = cache();
+    const oldConfig = { real: true, sourceFile, legacy: true, bundle: process.env.ISSUE5382_BASELINE_BUNDLE };
+    const newConfig = { real: true, sourceFile, bundle: realBundle };
+    const before = await child(dir, oldConfig).done;
+    expect(before.ok, JSON.stringify(before.error)).toBe(true);
+    expect(before.provider?.cacheHit).toBe(false);
+    const metadata = () =>
+      Object.fromEntries(
+        Object.keys(expected).map((relative) => {
+          const file = path.join(before.finalRoot, relative);
+          const stat = fs.statSync(file);
+          return [
+            relative,
+            { hex: fs.readFileSync(file).toString("hex"), mtime: stat.mtimeMs, ctime: stat.ctimeMs, ino: stat.ino },
+          ];
+        }),
+      );
+    const legacyBefore = metadata();
+    const refs = () =>
+      Object.fromEntries(
+        fs
+          .readdirSync(path.join(dir, "providers"))
+          .filter((name) => name.endsWith(".ref.json"))
+          .map((name) => [name, fs.readFileSync(path.join(dir, "providers", name), "utf8")]),
+      );
+    const refBefore = refs();
+    expect(Object.keys(refBefore).length).toBeGreaterThan(0);
+    writeTemporalPrewarmStamp(dir, {
+      key: before.key,
+      namespace: before.provider!.namespace,
+      bytes: before.provider!.bytes,
+    });
+    const stampBefore = fs.readFileSync(path.join(dir, "prewarm.json"));
+    const after = await child(dir, newConfig).done;
+    expect(after.ok, JSON.stringify(after.error)).toBe(true);
+    expect(after.provider?.cacheHit).toBe(true);
+    expect(after.key).toBe(before.key);
+    expect(readTemporalPrewarmStamp(dir)?.key).toBe(after.key);
+    expect(fs.readFileSync(path.join(dir, "prewarm.json"))).toEqual(stampBefore);
+    expect(after.provider).toEqual({ ...before.provider, cacheHit: true });
+    expect(metadata()).toEqual(legacyBefore);
+    expect(refs()).toEqual(refBefore);
+    expect(after.finalRoot).not.toBe(before.finalRoot);
+    const interleavings = [];
+    for (const file of [entry, "index.js"]) {
+      const reader = child(dir, { ...newConfig, barrier: `read:${file}`, compilerRead: true });
+      await reader.ready;
+      const old = await child(dir, oldConfig).done;
+      expect(old.ok, JSON.stringify(old.error)).toBe(true);
+      expect(old.provider?.cacheHit).toBe(true);
+      expect(old.events.some((event) => event.op === "writeFileSync" && event.path.startsWith(before.finalRoot))).toBe(
+        true,
+      );
+      reader.release();
+      const result = await reader.done;
+      expect(result.ok, JSON.stringify(result.error)).toBe(true);
+      expect(result.paused).toBe(true);
+      expect(result.provider).toEqual(after.provider);
+      untouched(result);
+      for (const read of result.reads.filter((read) => read.path.startsWith(result.finalRoot))) {
+        expect(read.hex).toBe(fs.readFileSync(read.path).toString("hex"));
+      }
+      expect(result.reads.length).toBeGreaterThanOrEqual(3);
+      interleavings.push({
+        file,
+        provider: result.provider,
+        reads: result.reads.map((read) => ({
+          path: read.path,
+          bytes: read.hex.length / 2,
+          sha256: createHash("sha256").update(Buffer.from(read.hex, "hex")).digest("hex"),
+        })),
+      });
+    }
+    const report = {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      baselineBundle: process.env.ISSUE5382_BASELINE_BUNDLE,
+      sourceSha256: createHash("sha256").update(polyfillSource).digest("hex"),
+      key: after.key,
+      before: before.provider,
+      after: after.provider,
+      sourceRefs: refBefore,
+      interleavings,
+    };
+    console.log("issue5382 real migration:", JSON.stringify(report));
+    if (process.env.ISSUE5382_REPORT) fs.writeFileSync(process.env.ISSUE5382_REPORT, JSON.stringify(report, null, 2));
+  },
+);
+
+describe("#5382 complete immutable source publication (stubbed compiler, real filesystem and processes)", () => {
+  for (const file of ["package.json", "index.js", entry])
+    it(`cold writer paused after ${file} loses to a complete winner`, async () => {
+      const dir = cache();
+      const a = child(dir, { barrier: `write:${file}` });
+      const { stage } = await a.ready;
+      const b = await child(dir).done;
+      complete(b);
+      a.release();
+      const loser = await a.done;
+      complete(loser);
+      expect(loser.paused).toBe(true);
+      expect(loser.finalRoot).toBe(b.finalRoot);
+      expect(fs.existsSync(stage)).toBe(false);
+      expect(loser.events.filter((e) => e.op === "rmSync").map((e) => e.path)).toEqual([stage]);
+    });
+
+  for (const winner of ["a", "b"])
+    it(`two verified contenders, ${winner} publishes first`, async () => {
+      const dir = cache();
+      const a = child(dir, { barrier: "rename" });
+      const b = child(dir, { barrier: "rename" });
+      const [sa, sb] = await Promise.all([a.ready, b.ready]);
+      const first = winner === "a" ? a : b;
+      const second = winner === "a" ? b : a;
+      first.release();
+      const won = await first.done;
+      complete(won);
+      second.release();
+      const lost = await second.done;
+      complete(lost);
+      expect(won.events.filter((e) => e.op === "rmSync")).toEqual([]);
+      expect(lost.events.filter((e) => e.op === "rmSync").map((e) => e.path)).toEqual([
+        winner === "a" ? sb.stage : sa.stage,
+      ]);
+    });
+
+  for (const file of [entry, "index.js"])
+    it(`warm reader at ${file} cannot be truncated by a warm initializer`, async () => {
+      const dir = cache();
+      complete(await child(dir).done);
+      const a = child(dir, { barrier: `read:${file}`, compilerRead: true });
+      await a.ready;
+      const b = await child(dir).done;
+      complete(b);
+      untouched(b);
+      a.release();
+      const reader = await a.done;
+      complete(reader);
+      untouched(reader);
+      expect(reader.paused).toBe(true);
+    });
+
+  const corruptions: Record<string, (directory: string) => void> = {
+    "missing entry": (d) => fs.unlinkSync(path.join(d, entry)),
+    "missing polyfill": (d) => fs.unlinkSync(path.join(d, pkg, "index.js")),
+    "truncated entry": (d) => fs.truncateSync(path.join(d, entry)),
+    "truncated polyfill": (d) => fs.truncateSync(path.join(d, pkg, "index.js")),
+    "wrong metadata": (d) => fs.writeFileSync(path.join(d, pkg, "package.json"), "{}"),
+    "same length wrong bytes": (d) =>
+      fs.writeFileSync(path.join(d, entry), Buffer.alloc(Buffer.from(expected[entry], "hex").length, 120)),
+    "empty root": (d) => {
+      fs.rmSync(d, { recursive: true });
+      fs.mkdirSync(d);
+    },
+    "symlink file": (d) => {
+      fs.unlinkSync(path.join(d, entry));
+      fs.symlinkSync(path.join(d, pkg, "index.js"), path.join(d, entry));
+    },
+    "symlink package": (d) => {
+      fs.renameSync(path.join(d, pkg), path.join(d, "saved"));
+      fs.symlinkSync(path.join(d, "saved"), path.join(d, pkg));
+    },
+    "symlink root": (d) => {
+      fs.renameSync(d, `${d}-saved`);
+      fs.symlinkSync(`${d}-saved`, d);
+    },
+  };
+  for (const [name, corrupt] of Object.entries(corruptions))
+    it(`rejects and preserves observed ${name}`, async () => {
+      const dir = cache();
+      const initial = await child(dir).done;
+      complete(initial);
+      corrupt(initial.finalRoot);
+      const result = await child(dir).done;
+      expect(result.ok).toBe(false);
+      expect(result.consumed).toEqual([]);
+      untouched(result);
+      expect(fs.lstatSync(initial.finalRoot)).toBeDefined();
+    });
+
+  for (const empty of [false, true])
+    it(`handles ${empty ? "empty" : "corrupt nonempty"} destination inserted before rename`, async () => {
+      const dir = cache();
+      const a = child(dir, { barrier: "rename" });
+      const { stage } = await a.ready;
+      const final = path.join(dir, path.basename(stage).slice(1).split(".staging-")[0]);
+      fs.mkdirSync(final);
+      if (!empty) fs.writeFileSync(path.join(final, "foreign"), "preserve");
+      a.release();
+      const result = await a.done;
+      if (empty && result.ok) complete(result);
+      else {
+        expect(result.ok).toBe(false);
+        expect(result.consumed).toEqual([]);
+        expect(result.error).toBeDefined();
+      }
+      if (!empty) expect(fs.readFileSync(path.join(final, "foreign"), "utf8")).toBe("preserve");
+      expect(fs.existsSync(stage)).toBe(false);
+    });
+
+  for (const fault of [
+    { op: "mkdtempSync" },
+    { op: "mkdirSync", where: ".staging-" },
+    { op: "writeFileSync", where: ".staging-" },
+    { op: "readFileSync", where: ".staging-" },
+    { op: "renameSync", code: "EXDEV" },
+    { op: "renameSync", code: "EACCES" },
+  ])
+    it(`preserves ${fault.op}/${fault.code ?? "EACCES"} and cleans only owned stage`, async () => {
+      const dir = cache();
+      fs.mkdirSync(dir);
+      const sibling = fs.mkdtempSync(path.join(dir, ".temporal-project-v2-sibling.staging-"));
+      const result = await child(dir, { fault }).done;
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe(fault.code ?? "EACCES");
+      expect(result.consumed).toEqual([]);
+      expect(fs.existsSync(sibling)).toBe(true);
+      expect(result.events.filter((e) => e.op === "rmSync").every((e) => e.path === result.stage)).toBe(true);
+      if (result.stage) expect(fs.existsSync(result.stage)).toBe(false);
+    });
+
+  it("preserves primary and cleanup errors together", async () => {
+    const result = await child(cache(), { fault: { op: "writeFileSync" }, cleanupFailure: true }).done;
+    expect(result.ok).toBe(false);
+    expect(result.error?.cause).toMatchObject({ message: "injected writeFileSync" });
+    expect(result.error?.errors).toHaveLength(2);
+    expect(result.consumed).toEqual([]);
+    expect(fs.existsSync(result.stage!)).toBe(true);
+  });
+
+  it("cleanup failure after a valid winner remains a failure", async () => {
+    const dir = cache();
+    const a = child(dir, { barrier: "rename", cleanupFailure: true });
+    await a.ready;
+    complete(await child(dir).done);
+    a.release();
+    const result = await a.done;
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toBe("injected cleanup");
+    expect(result.consumed).toEqual([]);
+    expect(fs.existsSync(result.stage!)).toBe(true);
+  });
+
+  it("warm verification read failure is not a miss", async () => {
+    const dir = cache();
+    complete(await child(dir).done);
+    const result = await child(dir, { fault: { op: "readFileSync" } }).done;
+    expect(result.error?.code).toBe("EACCES");
+    expect(result.consumed).toEqual([]);
+    untouched(result);
+  });
+
+  it("compile failure leaves the published tree reusable in a fresh process", async () => {
+    const dir = cache();
+    const failed = await child(dir, { compileFailure: true }).done;
+    expect(failed.error?.message).toBe("injected compile failure");
+    expect(fs.existsSync(failed.finalRoot)).toBe(true);
+    const retry = await child(dir, { memory: true }).done;
+    complete(retry);
+    untouched(retry);
+    expect(retry.memoryEvents).toBe(0);
+    expect(retry.memory?.cacheHit).toBe(true);
+  });
+
+  it("failed compilation does not poison the attached process memory cache", async () => {
+    const result = await child(cache(), { retryCompile: true, memory: true }).done;
+    expect(result.ok, JSON.stringify(result.error)).toBe(true);
+    expect(result.consumed).toHaveLength(2);
+    expect(result.consumed[0]).toEqual(result.consumed[1]);
+    expect(result.memoryEvents).toBe(0);
+    expect(result.memory?.cacheHit).toBe(true);
+  });
+
+  it("ignores abandoned private staging trees", async () => {
+    const dir = cache();
+    const dead = await child(dir, { abandonStage: true }).done;
+    expect(dead.ok).toBe(false);
+    expect(dead.consumed).toEqual([]);
+    const abandoned = dead.stage!;
+    const before = fs.readFileSync(path.join(abandoned, pkg, "package.json"));
+    complete(await child(dir).done);
+    expect(fs.readFileSync(path.join(abandoned, pkg, "package.json"))).toEqual(before);
+    expect(fs.existsSync(path.join(abandoned, entry))).toBe(false);
+  });
+
+  it("preserves the existing length-prefixed identity and separates every fingerprinted option", async () => {
+    const dir = cache();
+    const cases = [
+      {},
+      { target: "wasi" },
+      { fast: true },
+      { nativeStrings: true },
+      { utf8Storage: true },
+      { semanticProviders: "native-first" },
+      { hostBridge: "off" },
+      { platform: "node" },
+    ];
+    const roots = new Set<string>();
+    for (const compileOptions of cases) {
+      const result = await child(dir, { compileOptions }).done;
+      complete(result);
+      const options = {
+        target: "gc",
+        fast: false,
+        nativeStrings: false,
+        utf8Storage: false,
+        semanticProviders: "auto",
+        hostBridge: "auto",
+        platform: "web",
+        ...compileOptions,
+      };
+      const hash = createHash("sha256");
+      for (const part of [source, JSON.stringify(options)]) hash.update(`${part.length}:${part}\n`);
+      expect(path.basename(result.finalRoot)).toBe(`temporal-project-v2-${hash.digest("hex")}`);
+      expect(result.consumed[0].options).toMatchObject({
+        ...compileOptions,
+        allowJs: true,
+        emitWat: false,
+        skipSemanticDiagnostics: true,
+        packageCacheDir: path.join(dir, "providers"),
+      });
+      roots.add(result.finalRoot);
+    }
+    expect(roots.size).toBe(cases.length);
+    const changed = await child(dir, { polyfillSource: `${source}\n` }).done;
+    expect(changed.ok).toBe(true);
+    expect(roots.has(changed.finalRoot)).toBe(false);
+  });
+});

--- a/tests/issue-5382-temporal-project-publication.test.ts
+++ b/tests/issue-5382-temporal-project-publication.test.ts
@@ -20,7 +20,7 @@ const expected = {
     'import { Temporal } from "@js-temporal/polyfill";\nexport function __js2wasm_temporal_probe() { return typeof Temporal; }\n',
   ).toString("hex"),
 };
-const root = fs.mkdtempSync(path.join(tmpdir(), "issue-5382-"));
+const root = fs.realpathSync(fs.mkdtempSync(path.join(tmpdir(), "issue-5382-")));
 const bundle = path.join(root, "provider.mjs");
 const fixture = path.join(import.meta.dirname, "fixtures/issue-5382-temporal-publication-child.mjs");
 type Outcome = {
@@ -89,7 +89,12 @@ function child(cacheDir: string, extra: Record<string, unknown> = {}) {
     process.on("error", reject);
     process.on("close", (code) => {
       clearTimeout(timer);
-      if (!reached) rejectBarrier(new Error(`Barrier not reached: ${stderr} ${JSON.stringify(outcome)}`));
+      if (!reached)
+        rejectBarrier(
+          new Error(
+            `Barrier not reached: ${stderr} ${JSON.stringify({ ok: outcome?.ok, error: outcome?.error, readPaths: outcome?.reads?.map((read) => read.path) })}`,
+          ),
+        );
       if (code !== 0 || !outcome) reject(new Error(`child exit=${code}: ${stderr}`));
       else resolve(outcome);
     });
@@ -165,7 +170,9 @@ it.skipIf(!process.env.ISSUE5382_BASELINE_BUNDLE)(
       format: "esm",
       packages: "external",
       outfile: realBundle,
-      banner: { js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);' },
+      banner: {
+        js: 'import { createRequire as issue5382Require } from "node:module"; const require = issue5382Require(import.meta.url);',
+      },
     });
     fs.symlinkSync(path.join(repo, "node_modules"), path.join(root, "node_modules"));
     const { loadTemporalPolyfillSource, writeTemporalPrewarmStamp, readTemporalPrewarmStamp } =


### PR DESCRIPTION
## Summary

Implements local plan issue 5382: publish complete Temporal synthetic source projects with one atomic directory rename, then keep published trees immutable. Uses a versioned full-key path disjoint from legacy writers; verifies directory/file types and exact bytes; handles competing publishers and owned-staging cleanup without masking failures.

Scope is four files only: `src/temporal-provider.ts`, the focused publication test, its child fixture, and the issue5382 measured handoff. No linker, compiled-provider cache, worker, workflow, baseline, gate, or hold changes.

## Verification

- Node 25.9.0, Darwin arm64, TypeScript compiler dependency 5.9.3, Vitest 3.2.4; one test fork and bounded independent initializer processes.
- **62/62 distinct tests passed**: publication 33/33 (including required real migration/interleavings, none skipped), existing provider/global controls 11/11, sharded-lane controls 14/14, wiring controls 4/4. The heavy provider control built a fresh cache and passed all 25 supported runtime probes; existing known-gap observations remain reported separately.
- Exact old builder from base `ec6d2efc3241e8698b0755983491a85ebcbca5eb`; all other compiler inputs and dependencies identical. Both old cold and repaired warm providers are 2,090,802 bytes, SHA-256/cache key `2d1e8f3deda3fbdab06bcdf204113dc99793d3abeec27507723c23aa25cf5e37`.
- Source fingerprint, provider/prewarm key, namespace, getter and all 901 binary exports matched. Repaired migration was a real cache hit and preserved legacy file bytes/metadata and prewarm bytes.
- Both entry and polyfill compiler-read barriers were acknowledged while old initializers performed legacy writes; each repaired reader recorded 10 exact-byte reads and zero published-tree mutations.
- Full repository typecheck and lint passed locally. Normal commit hooks passed. The real migration test is opt-in in default CI/hook invocation; the required explicit local invocation above ran it successfully rather than counting a skip as acceptance.
- Normal pre-push passed without bypass: typecheck/lint, formatting, oracle and coercion checks, 18/18 numeric-local parity tests, and issue integrity. Conformance preflight reported 0 updates / 5 unchanged. The branch was pushed through that hook path; no out-of-scope files were committed.

The first real-control attempts exposed test-harness defects (duplicate require-shim import, then noncanonical macOS path matching). Both were corrected in the scoped test; barrier non-observation failed loudly. Complete hashes and reproduction details are in the issue handoff.

## Limits

This proves the publication repair under the measured schedules. It does **not** establish the cause of PR 5683's original CI failures, attribute its regression rows, or claim a Test262 score improvement. The original diagnostic snapshots remain untouched. Parent owns PR shepherding.
