### PR TITLE
fix(codegen): #5383 S1 — the standalone @js-temporal/polyfill compiles to a valid, import-free module (anyref ToBoolean row; host-free optional method call)

### DIFF
--- a/plan/issues/5383-standalone-temporal-provider.md
+++ b/plan/issues/5383-standalone-temporal-provider.md
@@ -1,7 +1,8 @@
 ---
 id: 5383
 title: "standalone: a real `Temporal` global for `--target standalone` — link the compiled polyfill provider into the standalone lane (baseline 170 / 4,603 Temporal rows pass; 1,506 `Temporal is not defined`, 454 `__temporal_*` host-import leaks); first blocker measured: the polyfill compiles under standalone but emits INVALID Wasm (`WeakMap.get(x)` as an `if` condition leaves an anyref where i32 is required)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-5383
 sprint: current
 priority: high
 horizon: l
@@ -9,6 +10,23 @@ goal: standalone
 reasoning_effort: high
 requested_by: ttraenkler/fable-lead
 created: 2026-09-07
+loc-budget-allow:
+  # 2026-09-07 (S1) — two codegen fixes that make the compiled
+  # @js-temporal/polyfill a VALID, import-free standalone module. Both are
+  # net-new arms plus the rationale comments that keep the next reader from
+  # re-deriving why the host lane is byte-identical; neither replaces existing
+  # lines, so the growth is real and intended.
+  - path: src/codegen/coercion-engine.ts
+    lines: 40
+    reason: "#5383 S1 R1 — the missing `anyref` row in the #1917 ToBoolean cascade (WeakMap/Map `get` used as a condition emitted an anyref where the `if` needs i32 -> invalid Wasm)."
+  - path: src/codegen/expressions/calls-optional.ts
+    lines: 60
+    reason: "#5383 S1 R2 — `recv.m?.(args)` host/native split so the standalone lane uses __objvec_new/__objvec_push/__apply_closure instead of leaking env::__js_array_new/__js_array_push/__call_function/__get_undefined (#2961)."
+func-budget-allow:
+  - path: src/codegen/coercion-engine.ts
+    reason: "#5383 S1 — no new functions; allowance restated here so the grant is not stranded in a file this PR does not touch."
+  - path: src/codegen/expressions/calls-optional.ts
+    reason: "#5383 S1 — no new functions; allowance restated here so the grant is not stranded in a file this PR does not touch."
 ---
 
 # #5383 — `Temporal` in standalone mode
@@ -180,3 +198,101 @@ alone, unless measured as neutral).
   #5381; fork PRs #5715-#5717 are #3518/#3527 slices.
 - Probes: `/home/user/js2/.tmp/sa-temporal/{probe2,probe3,red1,red2}.mts`,
   `polyfill.mjs` (linked source), `polyfill-sa.wasm` (the invalid binary).
+
+## Implementation notes — S1 (dev-5383, Opus 5 High, 2026-09-07)
+
+**S1 is DONE and S2's structural half is DONE. What remains for S2 is a runtime
+defect that has nothing to do with the provider seam — see "Where S2 stops".**
+
+### R1 — the missing `anyref` row in the ToBoolean cascade
+
+`src/codegen/coercion-engine.ts`, `emitToBoolean`. The plan offered two options;
+**option (b) is vacuous** and that is worth recording, because it is the obvious
+first move: `tryCompileNativeMapMethodCall` (`map-runtime.ts` L1744) returns
+`{ kind: "anyref" }` for `get` too — *exactly* what the WeakMap arm returns. The
+`map_get_if` row in `red1.mts` was valid only because it binds through a local
+(`const t = m.get(k); t && 1`), which coerces on the way in. A bare
+`if (m.get(k))` on a native **Map** is the same invalid Wasm, and is now a test.
+
+So the fix is (a): an `anyref`/`eqref` row that does `extern.convert_any` and
+calls `__is_truthy` — the same ToBoolean provider the `externref` row already
+uses, so the two agree by construction rather than by coincidence. In standalone
+that helper is a Wasm-native body (`registry/imports.ts` §7) that classifies the
+#2106 tag-0/1 null/undefined singletons, i31, boxed number/bool/bigint and
+`$AnyString`; a plain `ref.is_null` test would have made a `get` MISS, `0` and
+`""` all truthy.
+
+**Why this cannot perturb existing bytes in either lane:** before the row, an
+`anyref` fell through to the i32 no-op tail, leaving an `anyref` where the
+consumer requires i32. No module that reaches that tail can validate. So every
+byte this changes belonged to a module that did not exist as a valid artifact.
+Measured, not argued — see the A/B below.
+
+### R2 — `recv.m?.(args)` leaked four host imports (#2961)
+
+`src/codegen/expressions/calls-optional.ts`, `compileOptionalPropertyValueCall`.
+It registered `__js_array_new` / `__js_array_push` / `__call_function` /
+`__get_undefined` unconditionally. Attribution was measured, not guessed: a
+temporary print at the `addImport` fallthrough in `ensureLateImport` named **one
+call site** (the polyfill's `hr`) as the source of the compiled polyfill's entire
+`env` import set.
+
+Fixed with the host/native split `tryCompileCallableStaticField` already uses:
+native lane takes `__objvec_new` / `__objvec_push` / `__apply_closure` (same
+`(callee, thisArg, args) -> result` signature as `__call_function`) and
+`canonicalUndefinedExternInstrs` for the short-circuit result. The host lane
+keeps its four registrations, in the same order, emitting the same instructions.
+
+The short-circuit value matters and is asserted: `ref.null.extern` surfaces as
+JS **null**, so `o.missing?.(1) === undefined` needs the #2106 singleton.
+
+### Measurements
+
+| check | result |
+| --- | --- |
+| whole linked polyfill, `{target:"standalone", hostBridge:"off"}` | compiles in 60 s, **`WebAssembly.Module` ACCEPTS**, 2,956,918 B |
+| its import list | **EMPTY** — no `env`, no `wasm:js-string`, no `string_constants` (S1 step 3: zero #2961 leaks) |
+| host (gc) Temporal provider, before vs after | `temporalProviderCacheKey` `372a41be…` and artifact sha256 `baff93a9…` **identical**, 2,090,802 B both sides |
+| standalone modules with no WeakMap / no optional-call (arith, classes, Map) | **byte-identical** before/after, on BOTH `standalone` and `gc` |
+| the `o.f?.(a,b)` shape | standalone bytes change (that IS the fix); **`gc` bytes identical** |
+| `equivalence-gate` | 0 new regressions; **2 baseline failures now PASS** (`fn?.()` on a closure — R2 collateral), baseline ratcheted |
+
+Only ONE compiler defect stood between the polyfill and a valid binary; R2 was
+found by the import audit, not by a further `CompileError`.
+
+### Where S2 stops (precisely)
+
+S2's link half is **already satisfied**, and `buildTemporalProvider` proves it
+rather than reporting it: it *throws* unless the plan is `separate` with a
+`Temporal` **getter** boundary (`src/temporal-provider.ts` L202-215). With
+`compileOptions: {target:"standalone", hostBridge:"off"}` it now returns OK in
+53 s — namespace `js2wasm:npm:@js-temporal/polyfill:3de2aca05e190a7f`, getter
+`__js2wasm_get_Temporal_ba822575`, **`__module_init` exported**, artifact imports
+**empty**. A consumer compiled with `compileWithTemporalGlobal(..., standalone)`
+imports exactly one namespace — the provider — and nothing else.
+
+**The remaining failure is not in the seam.** `instantiateLinkedProject(result,
+{})` throws a WasmGC exception from the provider's `__module_init`, i.e. the
+polyfill's own top-level init, *before* any consumer code runs — and it throws
+**identically with no linker at all**, from a plain
+`compileMulti(polyfill, {standalone, hostBridge:"off", deferTopLevelInit:true})`
+whose `__module_init` is called directly (`.tmp/s2c.mts`). So it is a standalone
+runtime defect in the polyfill's module init, not a provider-linking defect, and
+it is the next slice.
+
+**Naming it is blocked by a second, separate gap worth its own issue:**
+`emitExceptionRenderExports` (#2962) does not put `__exn_render_prepare` /
+`__exn_render_char` in the export list for an ordinary standalone compile — a
+two-line `throw new TypeError("boom")` module exports only `run,__exn_tag`, even
+though every documented gate passes (`standalone` ✓, `nativeStrings` ✓,
+`exnTagIdx` 0, and the four prerequisites inside the emitter all resolve). Without
+them the thrown payload is host-opaque and `renderHarnessThrownText` can only say
+"non-stringifiable payload". Until that is fixed, the S2 throw cannot be attributed
+to a line of the polyfill.
+
+### Probes (this worktree's `.tmp/`)
+
+`probe3.mts` (whole-polyfill compile + import audit) · `s2.mts` (provider +
+host-free consumer link) · `s2b.mts` / `s2c.mts` (provider vs no-linker
+`__module_init`) · `s2d.mts` (the render-export gap) · `ab.mts` (small-module
+byte A/B) · `host-ab.mts` (host-lane provider key + sha A/B).

--- a/plan/issues/5384-standalone-exn-render-exports-missing.md
+++ b/plan/issues/5384-standalone-exn-render-exports-missing.md
@@ -1,0 +1,90 @@
+---
+id: 5384
+title: "standalone: a throwing module does NOT export `__exn_render_prepare` / `__exn_render_char`, so every host-free WasmGC throw renders as \"non-stringifiable payload\" — the #2962 renderer is unreachable outside the test262 lane"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+goal: standalone
+reasoning_effort: high
+requested_by: ttraenkler/dev-5383
+created: 2026-09-07
+---
+
+# #5384 — the standalone exception renderer is not reachable
+
+## Problem
+
+#2962 added `__exn_render_prepare` / `__exn_render_char` so a natively-thrown
+WasmGC payload can be rendered ("TypeError: boom") with **zero host imports** —
+the module runs the payload through its own `__any_to_string` chain and exposes
+the flat string one code unit at a time. `scripts/lib/wasm-exn-render.mjs`
+(`tryNativeExnRender`) is the only consumer, and when the exports are absent it
+returns `null` and the caller falls back to the opaque
+`"uncaught Wasm-GC exception (non-stringifiable payload)"`.
+
+**Measured 2026-09-07, on clean main + the #5383 S1 branch:** an ordinary
+standalone compile does not get those exports at all.
+
+```js
+// .tmp/s2d.mts
+const src = `throw new TypeError("boom from top level");\nexport function run() { return 1; }`;
+await compileMulti({ "t.js": src }, "t.js",
+  { target: "standalone", hostBridge: "off", allowJs: true, deferTopLevelInit: false });
+```
+
+→ export list is exactly **`run,__exn_tag`**. `__exn_render_prepare` is not
+there, with or without `deferTopLevelInit`.
+
+This is not an unmet precondition. Every gate `emitExceptionRenderExports`
+documents PASSES (instrumented, then reverted):
+
+| gate | value |
+| --- | --- |
+| `ctx.standalone` | `true` |
+| `ctx.nativeStrings` | `true` |
+| `ctx.exnTagIdx` | `0` (≥ 0 — the module can throw) |
+| `funcMap.has("__exn_render_prepare")` | `false` (not already emitted) |
+| `anyToStrIdx` / `flattenIdx` / `flatTypeIdx` / `dataTypeIdx` | `2097220` / `2097153` / `7` / `5` — all resolved |
+
+So the emitter runs past all four early returns and reaches its
+`mod.exports.push({ name: "__exn_render_prepare", … })`
+(`src/codegen/native-strings.ts` ~L2367), yet the export is not in the finished
+binary. Something after this point drops it, or the export list the emitter
+writes to is not the one that gets encoded. **That is the thing to find** — the
+functions themselves are almost certainly present.
+
+Note there are TWO finalize call sites for it (`src/codegen/index.ts` L6156 and
+L11456); the probe above goes through `compileMulti`. Check whether both paths
+reach the same `mod`.
+
+## Why it matters
+
+Without a renderer, a host-free standalone throw is **unattributable**. This
+blocked #5383 S2 concretely: the standalone `@js-temporal/polyfill` provider
+instantiates cleanly with an empty import object and then throws from its own
+`__module_init`, and there is no way to learn which error it is — the payload is
+host-opaque and the renderer that exists precisely for this is not exported.
+Every host-free debugging session on the standalone lane pays this cost.
+
+## Acceptance criteria
+
+1. A standalone (`hostBridge: "off"`) module that throws exports
+   `__exn_render_prepare` and `__exn_render_char`.
+2. `renderHarnessThrownText(error, instance)` returns `"TypeError: boom from top
+   level"` for the two-line reduction above — a test, not a manual check.
+3. The JS-host / `gc` lane is byte-identical (the emitter is already gated on
+   `standalone || wasi`).
+4. Re-run the #5383 S2 probe (`.tmp/s2c.mts` in the S1 worktree, or recreate it:
+   compile the linked polyfill standalone with `deferTopLevelInit: true` and call
+   `__module_init`) and record what the polyfill's init actually throws.
+
+## Notes
+
+- Found while implementing #5383 S1; the fix is not on that PR's critical path
+  (S1 landed without it) but S2 cannot be diagnosed without it.
+- Predecessors: #2962 (the renderer), #3469 (the sibling `__stdout_prepare` /
+  `__stdout_char` sink, same export-at-finalize pattern — compare how it lands),
+  #2870 (the opaque fallback this leaves in place).
+- Id reserved via `claim-issue.mjs --allocate --allow-unscanned`; the open-PR
+  scan was degraded (no `gh`), so re-check for collision before merge.

--- a/scripts/equivalence-baseline.json
+++ b/scripts/equivalence-baseline.json
@@ -14,8 +14,6 @@
     "tests/equivalence/null-dereference-guards.test.ts :: null dereference guards (#396) method call on null class instance returns default instead of trapping",
     "tests/equivalence/null-dereference-guards.test.ts :: null dereference guards (#396) property access on null struct returns NaN instead of trapping",
     "tests/equivalence/null-dereference-guards.test.ts :: null dereference guards (#396) uninitialized class variable property access returns default",
-    "tests/equivalence/optional-direct-closure-call.test.ts :: optional direct closure call (call_ref funcref fix) fn?.() on a closure that captures a variable",
-    "tests/equivalence/optional-direct-closure-call.test.ts :: optional direct closure call (call_ref funcref fix) fn?.() on a locally-defined closure",
     "tests/equivalence/reflect-api.test.ts :: Reflect API compile-time rewrites Reflect.construct creates a new instance",
     "tests/equivalence/tdz-reference-error.test.ts :: Temporal Dead Zone (TDZ) detection (#428) TDZ in block scope",
     "tests/equivalence/tdz-reference-error.test.ts :: Temporal Dead Zone (TDZ) detection (#428) assignment to let before declaration",

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -555,6 +555,7 @@ export function getStringToNumberProvider(ctx: CodegenContext): number | undefin
  *   f64          → |x| > 0       (NaN, +0, -0 all falsy)
  *   externref    → __is_truthy   (0/NaN/null/undefined/"" → falsy); ref.is_null fallback
  *   any-boxed ref→ __any_unbox_bool (proper JS truthiness on the boxed value)
+ *   anyref/eqref → extern.convert_any → __is_truthy (#5383; untyped GC ref)
  *   native str ref→ flatten → len > 0 (empty string falsy)
  *   other ref    → non-null (ref.is_null; i32.eqz)
  *   i64          → nonzero
@@ -623,6 +624,34 @@ export function emitToBoolean(ctx: CodegenContext, valType: ValType | null, sink
       }
     }
     // Opaque struct ref — non-null is truthy.
+    sink.push({ op: "ref.is_null" }, { op: "i32.eqz" });
+    return sink;
+  }
+  if (kind === "anyref" || kind === "eqref") {
+    // (#5383) An UNTYPED GC reference — the shape `__map_get` / `WeakMap.get`
+    // hand back in standalone (`{ kind: "anyref" }`, weak-collections-runtime.ts
+    // / map-runtime.ts). Before this row the cascade fell through to the i32
+    // no-op tail and left an `anyref` where the consuming `if`/`select` needs
+    // i32, i.e. INVALID Wasm — that is the `@js-temporal/polyfill`
+    // `OneObjectCache_setObject` failure ("if[0] expected type i32, found ...
+    // anyref"). No validating module can have reached this tail, so adding the
+    // row cannot perturb existing bytes in either lane.
+    //
+    // `extern.convert_any` is total (no trap, no null special case) and
+    // `__is_truthy` is the SAME ToBoolean provider the `externref` row above
+    // uses, so the answer agrees with the boxed-value lane by construction:
+    // standalone's native body classifies the `$AnyValue` tag-0/1 null/
+    // undefined singletons, i31, boxed number/bool/bigint and `$AnyString`
+    // (empty string falsy); the host lane keeps its import.
+    addUnionImports(ctx);
+    const anyTruthyIdx = ensureLateImport(ctx, "__is_truthy", [{ kind: "externref" }], [{ kind: "i32" }]);
+    if (anyTruthyIdx !== undefined) {
+      // Re-read the canonical index: registering a late helper shifts function
+      // indices (same hazard the externref row documents).
+      sink.push({ op: "extern.convert_any" }, { op: "call", funcIdx: ctx.funcMap.get("__is_truthy") ?? anyTruthyIdx });
+      return sink;
+    }
+    // Fallback: non-null → true.
     sink.push({ op: "ref.is_null" }, { op: "i32.eqz" });
     return sink;
   }

--- a/src/codegen/expressions/calls-optional.ts
+++ b/src/codegen/expressions/calls-optional.ts
@@ -12,6 +12,8 @@ import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { addStringImports, resolveWasmType } from "../index.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, ensureLateImport, valTypesMatch, VOID_RESULT } from "../shared.js";
+import { canonicalUndefinedExternInstrs } from "../any-helpers.js";
+import { ensureObjVecBuilders, reserveApplyClosure } from "../object-runtime.js";
 import { compileNativeStringMethodCall } from "../string-ops.js";
 import { defaultValueInstrs, pushDefaultValue } from "../type-coercion.js";
 import { addStringConstantGlobal } from "../registry/imports.js";
@@ -348,18 +350,40 @@ function compileOptionalPropertyValueCall(
   fctx.body.push({ op: "local.set", index: receiverLocal });
 
   const methodName = ts.isPrivateIdentifier(propAccess.name) ? propAccess.name.text.slice(1) : propAccess.name.text;
+  // (#5383 / #2961) `recv.m?.(args)` used to build its argument list and invoke
+  // the callee through the JS-host trio `__js_array_new` / `__js_array_push` /
+  // `__call_function` (plus `__get_undefined` for the short-circuit result)
+  // unconditionally. Under `--target standalone` those four have no provider,
+  // so the shape leaked FOUR unsatisfiable `env::*` imports — the entire `env`
+  // import set of the compiled `@js-temporal/polyfill` (one call site, the
+  // polyfill's `hr`). The native lane owns exact equivalents already:
+  // `__objvec_new` / `__objvec_push` (object-runtime vec builders) and
+  // `__apply_closure`, which has the SAME `(callee, thisArg, args) -> result`
+  // signature as `__call_function`; `canonicalUndefinedExternInstrs` supplies
+  // the lane's real `undefined` (the #2106 tag-1 singleton standalone, the host
+  // `__get_undefined` otherwise). Split exactly the way
+  // `tryCompileCallableStaticField` already does. The HOST lane keeps its four
+  // `ensureLateImport` registrations in the same order and emits the same
+  // instructions, so its bytes are unchanged.
+  const hostLane = !ctx.standalone && !ctx.wasi;
   const getIdx = ensureLateImport(ctx, "__extern_get", [externref, externref], [externref]);
   const isUndefinedIdx = ensureExternIsUndefinedImport(ctx);
-  const arrayNewIdx = ensureLateImport(ctx, "__js_array_new", [], [externref]);
-  const arrayPushIdx = ensureLateImport(ctx, "__js_array_push", [externref, externref], []);
-  const callIdx = ensureLateImport(ctx, "__call_function", [externref, externref, externref], [externref]);
-  const getUndefinedIdx = ensureLateImport(ctx, "__get_undefined", [], [externref]);
+  const applyIdx = hostLane ? undefined : reserveApplyClosure(ctx);
+  const vecBuilders = hostLane ? undefined : ensureObjVecBuilders(ctx);
+  const arrayNewIdx = hostLane ? ensureLateImport(ctx, "__js_array_new", [], [externref]) : vecBuilders?.newIdx;
+  const arrayPushIdx = hostLane
+    ? ensureLateImport(ctx, "__js_array_push", [externref, externref], [])
+    : vecBuilders?.pushIdx;
+  const callIdx = hostLane
+    ? ensureLateImport(ctx, "__call_function", [externref, externref, externref], [externref])
+    : applyIdx;
+  if (hostLane) ensureLateImport(ctx, "__get_undefined", [], [externref]);
   addStringConstantGlobal(ctx, methodName);
   flushLateImportShifts(ctx, fctx);
   const resolvedGetIdx = ctx.funcMap.get("__extern_get") ?? getIdx;
-  const resolvedNewIdx = ctx.funcMap.get("__js_array_new") ?? arrayNewIdx;
-  const resolvedPushIdx = ctx.funcMap.get("__js_array_push") ?? arrayPushIdx;
-  const resolvedCallIdx = ctx.funcMap.get("__call_function") ?? callIdx;
+  const resolvedNewIdx = ctx.funcMap.get(hostLane ? "__js_array_new" : "__objvec_new") ?? arrayNewIdx;
+  const resolvedPushIdx = ctx.funcMap.get(hostLane ? "__js_array_push" : "__objvec_push") ?? arrayPushIdx;
+  const resolvedCallIdx = ctx.funcMap.get(hostLane ? "__call_function" : "__apply_closure") ?? callIdx;
   if (
     resolvedGetIdx === undefined ||
     resolvedNewIdx === undefined ||
@@ -400,14 +424,10 @@ function compileOptionalPropertyValueCall(
   const elseInstrs = fctx.body;
   popBody(fctx, savedBody);
 
-  const resolvedUndefinedIdx = ctx.funcMap.get("__get_undefined") ?? getUndefinedIdx;
   fctx.body.push({
     op: "if",
     blockType: { kind: "val", type: externref },
-    then:
-      resolvedUndefinedIdx === undefined
-        ? [{ op: "ref.null.extern" }]
-        : [{ op: "call", funcIdx: resolvedUndefinedIdx }],
+    then: canonicalUndefinedExternInstrs(ctx),
     else: elseInstrs,
   });
   return externref;

--- a/tests/issue-5383-standalone-temporal-provider.test.ts
+++ b/tests/issue-5383-standalone-temporal-provider.test.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5383 S1 — the compiled `@js-temporal/polyfill` must produce a VALID,
+// import-free module under `--target standalone` (`hostBridge: "off"`), so a
+// standalone `Temporal` provider can be linked at all.
+//
+// Two independent defects blocked that, each reduced here to a few lines. Both
+// are regression-guarded by `WebAssembly.Module` acceptance / the import list,
+// not by a runtime value alone: the failure mode is a module that never gets
+// as far as running.
+//
+//  R1  ToBoolean of an `anyref` (`src/codegen/coercion-engine.ts`,
+//      `emitToBoolean`). `WeakMap.prototype.get` / `Map.prototype.get` hand
+//      back `{ kind: "anyref" }` (weak-collections-runtime.ts L191-197,
+//      map-runtime.ts). The #1917 ToBoolean cascade had rows for f64 /
+//      externref / typed struct refs / i64 / i32 but NONE for a bare `anyref`,
+//      so the value fell through to the i32 no-op tail and an `anyref` was left
+//      where the consuming `if` needs i32:
+//        `Compiling function #225:"OneObjectCache_setObject" failed:
+//         if[0] expected type i32, found call of type anyref`
+//      Note the `Map` twin is the same defect — it merely happened not to be
+//      exercised as a bare condition in the original reduction (a `const t =
+//      m.get(k)` binding coerces on the way into the local).
+//
+//  R2  `recv.m?.(args)` (`src/codegen/expressions/calls-optional.ts`,
+//      `compileOptionalPropertyValueCall`) built its argument list and invoked
+//      the callee through the JS-host `__js_array_new` / `__js_array_push` /
+//      `__call_function` / `__get_undefined` unconditionally. Under standalone
+//      those have no provider — a #2961 leak. This ONE call site accounted for
+//      the entire `env` import set of the compiled polyfill.
+//
+// The whole polyfill is not compiled here (~60 s, 2.9 MB): `.tmp/sa-temporal/`
+// carries that probe. These are the reductions.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface StandaloneModule {
+  binary: Uint8Array;
+  imports: string[];
+  instance: WebAssembly.Instance;
+}
+
+/**
+ * Compile `source` for `--target standalone` with the JS host bridge OFF,
+ * assert it validates, assert it imports nothing, and instantiate it with an
+ * EMPTY import object — the host-free contract the standalone Temporal
+ * provider has to satisfy.
+ */
+async function compileStandalone(source: string): Promise<StandaloneModule> {
+  const result = await compile(source, {
+    fileName: "issue-5383.js",
+    target: "standalone",
+    hostBridge: "off",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+  } as never);
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  // `new WebAssembly.Module` (not `validate`) so a failure names the offending
+  // function and the type mismatch, which is the whole diagnostic value here.
+  const wasmModule = new WebAssembly.Module(result.binary);
+  const imports = WebAssembly.Module.imports(wasmModule).map((entry) => `${entry.module}::${entry.name}`);
+  expect(imports, "standalone module leaked host imports (#2961)").toEqual([]);
+  const instance = await WebAssembly.instantiate(wasmModule, {});
+  return { binary: result.binary, imports, instance };
+}
+
+function callExport(mod: StandaloneModule, name = "test"): unknown {
+  return (mod.instance.exports as Record<string, () => unknown>)[name]!();
+}
+
+describe("#5383 S1 R1 — ToBoolean of an anyref (WeakMap/Map `get` as a condition)", () => {
+  it("WeakMap.get on a static field, used as an `if` condition (the polyfill's OneObjectCache_setObject)", async () => {
+    // The literal shape of `OneObjectCache.setObject` in @js-temporal/polyfill.
+    // Pre-fix: `C_setObject` failed to compile — if[0] expected i32, found anyref.
+    const mod = await compileStandalone(`
+      class C {
+        setObject(e) {
+          if (C.objectMap.get(e)) throw new RangeError("dup");
+          C.objectMap.set(e, this);
+        }
+      }
+      C.objectMap = new WeakMap();
+      export function test() {
+        var c = new C(); var o = {};
+        c.setObject(o);
+        try { c.setObject(o); } catch (e) { return e instanceof RangeError ? 1 : 2; }
+        return 0;
+      }
+    `);
+    // 1 = the second setObject threw the RangeError, i.e. `get` answered TRUTHY
+    // for a present key. 0 would mean the condition read falsy.
+    expect(callExport(mod)).toBe(1);
+  });
+
+  it("WeakMap.get as a ternary condition — hit and miss", async () => {
+    const mod = await compileStandalone(`
+      const m = new WeakMap(); const o = {}; const other = {};
+      m.set(o, 1);
+      export function test() {
+        return (m.get(o) ? 10 : 0) + (m.get(other) ? 5 : 1);
+      }
+    `);
+    // hit → 10, miss → 1. A miss answers the `$undefined` singleton (#2106),
+    // which `__is_truthy` must classify FALSY — 11, not 15.
+    expect(callExport(mod)).toBe(11);
+  });
+
+  it("Map.get as a bare `if` condition — the same cascade row, and empty string / 0 stay falsy", async () => {
+    const mod = await compileStandalone(`
+      const m = new Map();
+      m.set("t", 1); m.set("zero", 0); m.set("empty", "");
+      export function test() {
+        var n = 0;
+        if (m.get("t")) n += 1;
+        if (m.get("zero")) n += 100;
+        if (m.get("empty")) n += 1000;
+        if (m.get("absent")) n += 10000;
+        return n;
+      }
+    `);
+    // Only the truthy entry counts: routing through `__is_truthy` (rather than
+    // a bare non-null test) is what keeps 0 / "" / a miss falsy.
+    expect(callExport(mod)).toBe(1);
+  });
+
+  it("WeakMap.get on the left of `&&` and inside `!`", async () => {
+    const mod = await compileStandalone(`
+      const m = new WeakMap(); const k = {}; const k2 = {};
+      m.set(k, { v: 3 });
+      export function test() {
+        var a = m.get(k) && 1;
+        var b = !m.get(k2);
+        return (a === 1 ? 1 : 0) + (b ? 2 : 0);
+      }
+    `);
+    expect(callExport(mod)).toBe(3);
+  });
+});
+
+describe("#5383 S1 R2 — `recv.m?.(args)` must not leak JS-host imports (#2961)", () => {
+  it("optional method-value call on a dynamic receiver links host-free and calls through", async () => {
+    // `compileStandalone` already asserts the import list is EMPTY; pre-fix this
+    // shape emitted env::__js_array_new, __js_array_push, __call_function and
+    // __get_undefined and could not be instantiated at all.
+    const mod = await compileStandalone(`
+      export function test() {
+        var o = { add: function (a, b) { return a + b; } };
+        return o.add?.(2, 3);
+      }
+    `);
+    expect(callExport(mod)).toBe(5);
+  });
+
+  it("optional method-value call short-circuits to `undefined`, not `null`", async () => {
+    const mod = await compileStandalone(`
+      export function test() {
+        var o = {};
+        var r = o.missing?.(1);
+        // The short-circuit result must be the lane's real undefined (#2106
+        // tag-1 singleton), NOT a null externref -- r === undefined is the
+        // whole point of the shape.
+        return (r === undefined ? 1 : 0) + (r === null ? 10 : 0) + (typeof r === "undefined" ? 100 : 0);
+      }
+    `);
+    expect(callExport(mod)).toBe(101);
+  });
+
+  it("receiver and arguments are evaluated exactly once, in order", async () => {
+    const mod = await compileStandalone(`
+      export function test() {
+        var log = "";
+        var o = { f: function (a, b) { log += "f"; return a + b; } };
+        function recv() { log += "r"; return o; }
+        function arg(n) { return function () { log += "a" + n; return n; }; }
+        recv().f?.(arg(1)(), arg(2)());
+        return log === "ra1a2f" ? 1 : 0;
+      }
+    `);
+    expect(callExport(mod)).toBe(1);
+  });
+});


### PR DESCRIPTION
## What this is

S1 of [#5383](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5383-standalone-temporal-provider) — a real `Temporal` for `--target standalone`. Two codegen fixes turn the compiled `@js-temporal/polyfill` from **a binary `WebAssembly.Module` rejects** into **a valid module that imports nothing at all**.

Standalone only. The JS-host lane is byte-identical, measured (below), not asserted.

S1 does not close [#5383](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5383-standalone-temporal-provider) — the issue stays `in-progress`. Where S2 stops is stated precisely at the end.

## The two defects

**R1 — the `anyref` row missing from the #1917 ToBoolean cascade** (`src/codegen/coercion-engine.ts`, `emitToBoolean`).

`WeakMap.prototype.get` returns `{ kind: "anyref" }` (`weak-collections-runtime.ts` L191-197). The cascade had rows for f64 / externref / typed struct refs / i64 / i32 and none for a bare `anyref`, so the value fell through to the i32 no-op tail and left an `anyref` where the consuming `if` needs i32:

```
Compiling function #225:"OneObjectCache_setObject" failed:
if[0] expected type i32, found call of type anyref
```

The plan offered a second option — return whatever ValType the native `Map.get` arm returns. **That option is vacuous:** `map-runtime.ts` L1744 returns `{ kind: "anyref" }` too. The `Map` twin looked healthy only because the original reduction bound through a local (`const t = m.get(k); t && 1`), which coerces on the way in. A bare `if (m.get(k))` on a native `Map` is the same invalid Wasm — it is now a test.

So: an `anyref`/`eqref` row that does `extern.convert_any` and calls `__is_truthy` — the **same** ToBoolean provider the `externref` row already uses, so the two agree by construction. In standalone that helper is a Wasm-native body classifying the #2106 tag-0/1 null/undefined singletons, i31, boxed number/bool/bigint and `$AnyString`. A plain `ref.is_null` test would have made a `get` MISS, `0` and `""` all truthy.

*Why it cannot perturb existing bytes:* before the row, an `anyref` here left an `anyref` where i32 was required. **No module that reaches that tail can validate.** Every byte this changes belonged to a module that did not exist as a valid artifact.

**R2 — `recv.m?.(args)` leaked four host imports (#2961)** (`src/codegen/expressions/calls-optional.ts`, `compileOptionalPropertyValueCall`).

It registered `__js_array_new` / `__js_array_push` / `__call_function` / `__get_undefined` unconditionally, none of which has a standalone provider. Attribution was measured, not guessed: a temporary print at `ensureLateImport`'s `addImport` fallthrough named **one call site** — the polyfill's `hr` — as the source of the polyfill's *entire* `env` import set.

Fixed with the host/native split `tryCompileCallableStaticField` already uses: the native lane takes `__objvec_new` / `__objvec_push` / `__apply_closure` (identical `(callee, thisArg, args) -> result` signature to `__call_function`) plus `canonicalUndefinedExternInstrs` for the short-circuit value. The host lane keeps its four registrations in the same order emitting the same instructions.

The short-circuit value is load-bearing and asserted: `ref.null.extern` surfaces as JS **null**, so `o.missing?.(1) === undefined` needs the #2106 singleton.

## Measurements

| check | result |
| --- | --- |
| whole linked polyfill, `{target:"standalone", hostBridge:"off"}` | compiles in 60 s, **`WebAssembly.Module` ACCEPTS**, 2,956,918 B |
| its import list | **EMPTY** — no `env`, no `wasm:js-string`, no `string_constants`. Zero #2961 leaks |
| host (`gc`) Temporal provider, before vs after | `temporalProviderCacheKey` `372a41be…` **and** artifact sha256 `baff93a9…` identical; 2,090,802 B both sides |
| standalone modules with no WeakMap / no optional-call (arith+strings, classes+closures+try, Map) | **byte-identical** before/after, on **both** `standalone` and `gc` |
| the `o.f?.(a,b)` shape | standalone bytes change (that is the fix); **`gc` bytes identical** |
| `equivalence-gate` | **0 new regressions**; 2 baseline failures now PASS (`fn?.()` on a closure — R2 collateral), baseline ratcheted with the gate's own `--update` |

Only **one** compiler defect stood between the polyfill and a valid binary. R2 was found by the S1 import audit, not by a further `CompileError`.

## Where S2 stops (precisely)

S2's link half is **already satisfied**, and `buildTemporalProvider` proves it rather than reporting it — it *throws* unless the plan is `separate` with a `Temporal` **getter** boundary (`src/temporal-provider.ts` L202-215). With standalone compile options it now returns OK in 53 s: namespace `js2wasm:npm:@js-temporal/polyfill:3de2aca05e190a7f`, getter `__js2wasm_get_Temporal_ba822575`, **`__module_init` exported**, artifact imports **empty**. A consumer built with `compileWithTemporalGlobal(..., standalone)` imports exactly one namespace — the provider — and nothing else.

The remaining failure is **not in the seam**: `instantiateLinkedProject(result, {})` throws a WasmGC exception out of the provider's `__module_init`, before any consumer code runs — and it throws **identically with no linker at all**, from a plain `compileMulti(polyfill, {standalone, hostBridge:"off", deferTopLevelInit:true})` whose `__module_init` is called directly. So it is a standalone runtime defect in the polyfill's own module init, and it is the next slice. The two smoke assertions (`PlainDate.from("2024-01-01").day === 1`, `Duration.from({hours:1}).total("minutes") === 60`) are therefore **not** in this PR.

Naming that throw is blocked by a separate gap this PR files as [#5384](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5384-standalone-exn-render-exports-missing): a standalone module does not export `__exn_render_prepare` / `__exn_render_char`, so every host-free WasmGC throw renders as "non-stringifiable payload" — even though all five documented gates in `emitExceptionRenderExports` pass (instrumented, then reverted; the values are in the issue).

## Tests

`tests/issue-5383-standalone-temporal-provider.test.ts`, 7 cases. Each compiles standalone with `hostBridge: "off"`, asserts `new WebAssembly.Module` accepts it, asserts the import list is **empty**, instantiates with `{}`, and asserts a value:

- R1: the literal `OneObjectCache.setObject` shape; `WeakMap.get` as a ternary (hit **and** miss — a miss must be falsy); `Map.get` as a bare `if` with `0` / `""` / miss all staying falsy; `WeakMap.get` under `&&` and `!`
- R2: an optional method-value call that links host-free and returns `5`; the short-circuit answering `undefined` and not `null`; receiver and arguments evaluated once, in order

## Gates

`typecheck` · `check-loc-budget` (also with `LOC_GATE_BASE=origin/main`) · `check-func-budget` · `check-coercion-sites` · `check:oracle-ratchet` · `check:dead-exports` · `biome lint src tests` · `check:host-import-policy` · `equivalence-gate` (0 new regressions) — all pass. Growth allowances are in the #5383 issue frontmatter with dated rationale; no budget baseline file was touched (the equivalence baseline ratchet-down is the gate's own sanctioned `--update`).

Guard suites run green: `issue-2162-standalone-weak`, `issue-2162-weak-mapHelpers-shift`, `weakmap-weakset-weakref`, `issue-1917-coercion-plan`, `issue-2915-standalone-toboolean-descriptor`, `issue-4157-is-truthy-inline-ic`, `issue-3172`. `issue-4781-weakmap-constructor-prototype` OOMs its vitest worker at 6 GB — **verified pre-existing**: it OOMs identically with both source files reverted to `HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_