### PR TITLE
refactor(async): extract reserved native microtask queue builders

### DIFF
--- a/plan/issues/3527-ir-r7-ast-free-async-plan.md
+++ b/plan/issues/3527-ir-r7-ast-free-async-plan.md
@@ -1721,3 +1721,40 @@ fallback. Validate loaded-module census, two-await runtime behavior,
 source-qualified resume identity, tamper failures and the import removal
 control. Return the exact requirements C must materialize, without changing
 C's implementation or claiming its async acceptance has passed.
+
+### N queue physical extraction checkpoint — 2026-09-07
+
+The N continuation preserves the held semantic-runtime producer claim and
+changes only the approved queue portion of `async-scheduler.ts`: its real
+`ensureMicrotaskQueue` caller supplies a frozen typed reservation snapshot to
+`prepared-native-async-runtime.ts`. The leaf builds grow/enqueue/drain bodies
+and locals without importing the scheduler, codegen context, or a runtime
+registry. Type/global registration, grow → enqueue → drain function minting,
+the 8,192-slot initial capacity, stable handles, publication and startup remain
+owned by the existing caller.
+
+Baseline is upstream `6037ac8bcf07be4f71839cea33cf8c90ecc87f94`; candidate is
+this checkpoint's scoped diff on `codex/3527-native-async-closure`. The temporary
+`.tmp/compare-native-queue.ts` control compares all five extracted builder
+outputs with the exact baseline builders, using nonzero type/global indices
+and a stable function handle: **5/5 structurally identical**. The actual
+legacy-connected emitted Wasm tests in
+`tests/issue-3527-prepared-native-resource-closure.test.ts` passed **5/5**:
+unused/exhausted drain, FIFO growth beyond 8,192 entries with capture identity,
+enqueue-and-grow during drain, thrown callback/head advancement/resumption,
+and fresh-process leaf import with a forbidden-import positive control.
+
+Commands: `VITEST_MAX_FORKS=1 node_modules/.bin/vitest run tests/issue-3527-prepared-native-resource-closure.test.ts`
+(1/1 file, 5/5 tests, 14.56 s);
+`node --import tsx .tmp/compare-native-queue.ts` (5/5);
+`node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json`
+(exit 0). Logs are `.tmp/native-queue-vitest.log`,
+`.tmp/native-queue-baseline.log`, and `.tmp/native-queue-typecheck.log`.
+Prettier, LOC and function budget gates passed. The first Vitest attempt
+failed before collection because Vite could not write through the dependency
+symlink; the approved retry produced the reported execution results.
+
+This checkpoint does **not** complete the native Promise resource closure or
+admit native prepared-program emission. Promise settlement/assimilation,
+closure bridges, exception/rejection policy, optional hooks, value boundaries,
+and their resource declarations remain subsequent coordinated work.

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -49,6 +49,14 @@ import { CARRIER_BAG_HAS } from "./carrier-bag-visibility.js";
 import { ensureUnhandledRejectionTracking, buildNoteUnhandledRejection } from "./unhandled-rejection.js";
 import { buildTargetTaggedTry } from "../ir/try-table.js";
 import { canonicalUndefinedExternInstrs } from "./any-helpers.js";
+import {
+  buildGrowLocals,
+  buildGrowBody,
+  buildEnqueueBody,
+  buildDrainLocals,
+  buildDrainBody,
+  type PreparedNativeMicrotaskReservations,
+} from "./prepared-native-async-runtime.js";
 
 /**
  * #1326 — Sentinel state values for `$Promise.state`. Match the JS spec
@@ -528,11 +536,28 @@ export function ensureMicrotaskQueue(ctx: CodegenContext): void {
   //    the order grow → enqueue → drain so each later body can reference
   //    the prior ones.
   state.growFuncIdx = mintDefinedFunc(ctx);
+  const queueResources: PreparedNativeMicrotaskReservations = Object.freeze({
+    types: Object.freeze({
+      functions: Object.freeze({ kind: "type", index: funcArrIdx }),
+      arguments: Object.freeze({ kind: "type", index: argsArrIdx }),
+      callback: Object.freeze({ kind: "type", index: state.microtaskFuncTypeIdx }),
+    }),
+    globals: Object.freeze({
+      head: Object.freeze({ kind: "global", index: state.microtaskHeadGlobalIdx }),
+      tail: Object.freeze({ kind: "global", index: state.microtaskTailGlobalIdx }),
+      capacity: Object.freeze({ kind: "global", index: state.microtaskCapGlobalIdx }),
+      functions: Object.freeze({ kind: "global", index: state.microtaskFuncsGlobalIdx }),
+      captures: Object.freeze({ kind: "global", index: state.microtaskCapsGlobalIdx }),
+      arguments: Object.freeze({ kind: "global", index: state.microtaskArgsGlobalIdx }),
+    }),
+    grow: Object.freeze({ kind: "function", index: state.growFuncIdx }),
+    initialCapacity: MICROTASK_QUEUE_INITIAL_SLOTS,
+  });
   pushDefinedFunc(ctx, state.growFuncIdx, {
     name: "__microtask_grow",
     typeIdx: addFuncType(ctx, [{ kind: "i32" }], [], "$__mt_grow_type"),
-    locals: buildGrowLocals(funcArrIdx, argsArrIdx),
-    body: buildGrowBody(state, funcArrIdx, argsArrIdx),
+    locals: buildGrowLocals(queueResources),
+    body: buildGrowBody(queueResources),
     exported: false,
   });
   ctx.funcMap.set("__microtask_grow", state.growFuncIdx);
@@ -547,7 +572,7 @@ export function ensureMicrotaskQueue(ctx: CodegenContext): void {
       "$__mt_enqueue_type",
     ),
     locals: [],
-    body: buildEnqueueBody(state, funcArrIdx, argsArrIdx),
+    body: buildEnqueueBody(queueResources),
     exported: false,
   });
   ctx.funcMap.set("__microtask_enqueue", state.enqueueFuncIdx);
@@ -557,297 +582,10 @@ export function ensureMicrotaskQueue(ctx: CodegenContext): void {
     name: "__drain_microtasks",
     typeIdx: addFuncType(ctx, [], [], "$__mt_drain_type"),
     locals: buildDrainLocals(),
-    body: buildDrainBody(state, funcArrIdx, argsArrIdx),
+    body: buildDrainBody(queueResources),
     exported: false,
   });
   ctx.funcMap.set("__drain_microtasks", state.drainFuncIdx);
-}
-
-function buildGrowLocals(funcArrIdx: number, argsArrIdx: number): import("../ir/types.js").LocalDef[] {
-  // Param 0: $newCap (i32). Local slots start at 1.
-  return [
-    { name: "$oldFuncs", type: { kind: "ref_null", typeIdx: funcArrIdx } },
-    { name: "$oldCaps", type: { kind: "ref_null", typeIdx: argsArrIdx } },
-    { name: "$oldArgs", type: { kind: "ref_null", typeIdx: argsArrIdx } },
-    { name: "$oldHead", type: { kind: "i32" } },
-    { name: "$oldTail", type: { kind: "i32" } },
-    { name: "$i", type: { kind: "i32" } },
-    { name: "$dst", type: { kind: "i32" } },
-  ];
-}
-
-function buildGrowBody(state: AsyncSchedulerState, funcArrIdx: number, argsArrIdx: number): Instr[] {
-  const newCapLocal = 0;
-  const oldFuncs = 1;
-  const oldCaps = 2;
-  const oldArgs = 3;
-  const oldHead = 4;
-  const oldTail = 5;
-  const i = 6;
-  const dst = 7;
-
-  return [
-    // Snapshot the old state.
-    { op: "global.get", index: state.microtaskFuncsGlobalIdx },
-    { op: "local.set", index: oldFuncs },
-    { op: "global.get", index: state.microtaskCapsGlobalIdx },
-    { op: "local.set", index: oldCaps },
-    { op: "global.get", index: state.microtaskArgsGlobalIdx },
-    { op: "local.set", index: oldArgs },
-    { op: "global.get", index: state.microtaskHeadGlobalIdx },
-    { op: "local.set", index: oldHead },
-    { op: "global.get", index: state.microtaskTailGlobalIdx },
-    { op: "local.set", index: oldTail },
-
-    // Allocate the new arrays with init = ref.null.
-    // funcs: array.new (default=null funcref) of $newCap.
-    { op: "ref.null.func" },
-    { op: "local.get", index: newCapLocal },
-    { op: "array.new", typeIdx: funcArrIdx },
-    { op: "global.set", index: state.microtaskFuncsGlobalIdx },
-
-    { op: "ref.null.extern" },
-    { op: "local.get", index: newCapLocal },
-    { op: "array.new", typeIdx: argsArrIdx },
-    { op: "global.set", index: state.microtaskCapsGlobalIdx },
-
-    { op: "ref.null.extern" },
-    { op: "local.get", index: newCapLocal },
-    { op: "array.new", typeIdx: argsArrIdx },
-    { op: "global.set", index: state.microtaskArgsGlobalIdx },
-
-    // If oldFuncs is null, no live entries to copy. Just reset head/tail
-    // pointers and capacity, then return.
-    { op: "local.get", index: oldFuncs },
-    { op: "ref.is_null" },
-    {
-      op: "if",
-      blockType: { kind: "empty" } as any,
-      then: [
-        { op: "i32.const", value: 0 },
-        { op: "global.set", index: state.microtaskHeadGlobalIdx },
-        { op: "i32.const", value: 0 },
-        { op: "global.set", index: state.microtaskTailGlobalIdx },
-        { op: "local.get", index: newCapLocal },
-        { op: "global.set", index: state.microtaskCapGlobalIdx },
-        { op: "return" },
-      ],
-    },
-
-    // Copy live slice [oldHead, oldTail) into the new arrays starting at 0.
-    { op: "local.get", index: oldHead },
-    { op: "local.set", index: i },
-    { op: "i32.const", value: 0 },
-    { op: "local.set", index: dst },
-    {
-      op: "block",
-      blockType: { kind: "empty" },
-      body: [
-        {
-          op: "loop",
-          blockType: { kind: "empty" },
-          body: [
-            { op: "local.get", index: i },
-            { op: "local.get", index: oldTail },
-            { op: "i32.eq" },
-            // depth 1: exit the enclosing block (skip the loop label).
-            { op: "br_if", depth: 1 },
-
-            // funcs[dst] = oldFuncs[i]
-            { op: "global.get", index: state.microtaskFuncsGlobalIdx },
-            { op: "local.get", index: dst },
-            { op: "local.get", index: oldFuncs },
-            { op: "ref.as_non_null" },
-            { op: "local.get", index: i },
-            { op: "array.get", typeIdx: funcArrIdx },
-            { op: "array.set", typeIdx: funcArrIdx },
-
-            // caps[dst] = oldCaps[i]
-            { op: "global.get", index: state.microtaskCapsGlobalIdx },
-            { op: "local.get", index: dst },
-            { op: "local.get", index: oldCaps },
-            { op: "ref.as_non_null" },
-            { op: "local.get", index: i },
-            { op: "array.get", typeIdx: argsArrIdx },
-            { op: "array.set", typeIdx: argsArrIdx },
-
-            // args[dst] = oldArgs[i]
-            { op: "global.get", index: state.microtaskArgsGlobalIdx },
-            { op: "local.get", index: dst },
-            { op: "local.get", index: oldArgs },
-            { op: "ref.as_non_null" },
-            { op: "local.get", index: i },
-            { op: "array.get", typeIdx: argsArrIdx },
-            { op: "array.set", typeIdx: argsArrIdx },
-
-            // i++, dst++
-            { op: "local.get", index: i },
-            { op: "i32.const", value: 1 },
-            { op: "i32.add" },
-            { op: "local.set", index: i },
-            { op: "local.get", index: dst },
-            { op: "i32.const", value: 1 },
-            { op: "i32.add" },
-            { op: "local.set", index: dst },
-            // depth 0: re-enter the loop label.
-            { op: "br", depth: 0 },
-          ],
-        },
-      ],
-    },
-
-    // Finalise head/tail/cap.
-    { op: "i32.const", value: 0 },
-    { op: "global.set", index: state.microtaskHeadGlobalIdx },
-    { op: "local.get", index: dst },
-    { op: "global.set", index: state.microtaskTailGlobalIdx },
-    { op: "local.get", index: newCapLocal },
-    { op: "global.set", index: state.microtaskCapGlobalIdx },
-  ];
-}
-
-function buildEnqueueBody(state: AsyncSchedulerState, funcArrIdx: number, argsArrIdx: number): Instr[] {
-  const fnLocal = 0;
-  const capsLocal = 1;
-  const argLocal = 2;
-
-  return [
-    // Lazy first-allocate. Test `funcs` against null.
-    { op: "global.get", index: state.microtaskFuncsGlobalIdx },
-    { op: "ref.is_null" },
-    {
-      op: "if",
-      blockType: { kind: "empty" } as any,
-      then: [
-        { op: "i32.const", value: MICROTASK_QUEUE_INITIAL_SLOTS },
-        { op: "call", funcIdx: state.growFuncIdx },
-      ],
-    },
-
-    // If tail == cap, double the queue.
-    { op: "global.get", index: state.microtaskTailGlobalIdx },
-    { op: "global.get", index: state.microtaskCapGlobalIdx },
-    { op: "i32.eq" },
-    {
-      op: "if",
-      blockType: { kind: "empty" } as any,
-      then: [
-        { op: "global.get", index: state.microtaskCapGlobalIdx },
-        { op: "i32.const", value: 1 },
-        { op: "i32.shl" },
-        { op: "call", funcIdx: state.growFuncIdx },
-      ],
-    },
-
-    // Store fn, caps, arg at index `tail`.
-    { op: "global.get", index: state.microtaskFuncsGlobalIdx },
-    { op: "ref.as_non_null" },
-    { op: "global.get", index: state.microtaskTailGlobalIdx },
-    { op: "local.get", index: fnLocal },
-    { op: "array.set", typeIdx: funcArrIdx },
-
-    { op: "global.get", index: state.microtaskCapsGlobalIdx },
-    { op: "ref.as_non_null" },
-    { op: "global.get", index: state.microtaskTailGlobalIdx },
-    { op: "local.get", index: capsLocal },
-    { op: "array.set", typeIdx: argsArrIdx },
-
-    { op: "global.get", index: state.microtaskArgsGlobalIdx },
-    { op: "ref.as_non_null" },
-    { op: "global.get", index: state.microtaskTailGlobalIdx },
-    { op: "local.get", index: argLocal },
-    { op: "array.set", typeIdx: argsArrIdx },
-
-    // tail++
-    { op: "global.get", index: state.microtaskTailGlobalIdx },
-    { op: "i32.const", value: 1 },
-    { op: "i32.add" },
-    { op: "global.set", index: state.microtaskTailGlobalIdx },
-  ];
-}
-
-function buildDrainLocals(): import("../ir/types.js").LocalDef[] {
-  return [
-    { name: "$fn", type: { kind: "funcref" } as ValType },
-    { name: "$caps", type: { kind: "externref" } },
-    { name: "$arg", type: { kind: "externref" } },
-  ];
-}
-
-function buildDrainBody(state: AsyncSchedulerState, funcArrIdx: number, argsArrIdx: number): Instr[] {
-  const fnLocal = 0;
-  const capsLocal = 1;
-  const argLocal = 2;
-
-  return [
-    // If the queue was never used (`funcs` global null), there's nothing
-    // to drain. Early-return to avoid `ref.as_non_null` on a null ref.
-    { op: "global.get", index: state.microtaskFuncsGlobalIdx },
-    { op: "ref.is_null" },
-    {
-      op: "if",
-      blockType: { kind: "empty" } as any,
-      then: [{ op: "return" }],
-    },
-
-    {
-      op: "block",
-      blockType: { kind: "empty" },
-      body: [
-        {
-          op: "loop",
-          blockType: { kind: "empty" },
-          body: [
-            // Done when head == tail.
-            { op: "global.get", index: state.microtaskHeadGlobalIdx },
-            { op: "global.get", index: state.microtaskTailGlobalIdx },
-            { op: "i32.eq" },
-            // depth 1: exit the enclosing block (skip the loop label).
-            { op: "br_if", depth: 1 },
-
-            // Read fn, caps, arg at head.
-            { op: "global.get", index: state.microtaskFuncsGlobalIdx },
-            { op: "ref.as_non_null" },
-            { op: "global.get", index: state.microtaskHeadGlobalIdx },
-            { op: "array.get", typeIdx: funcArrIdx },
-            { op: "local.set", index: fnLocal },
-
-            { op: "global.get", index: state.microtaskCapsGlobalIdx },
-            { op: "ref.as_non_null" },
-            { op: "global.get", index: state.microtaskHeadGlobalIdx },
-            { op: "array.get", typeIdx: argsArrIdx },
-            { op: "local.set", index: capsLocal },
-
-            { op: "global.get", index: state.microtaskArgsGlobalIdx },
-            { op: "ref.as_non_null" },
-            { op: "global.get", index: state.microtaskHeadGlobalIdx },
-            { op: "array.get", typeIdx: argsArrIdx },
-            { op: "local.set", index: argLocal },
-
-            // head++ (advance BEFORE the call so a callback that enqueues
-            // more entries doesn't have to worry about an unconsumed slot).
-            { op: "global.get", index: state.microtaskHeadGlobalIdx },
-            { op: "i32.const", value: 1 },
-            { op: "i32.add" },
-            { op: "global.set", index: state.microtaskHeadGlobalIdx },
-
-            // call_ref fn(caps, arg) — push args then the funcref, then
-            // ref.cast to a non-null `(ref $__mt_func_type)` because
-            // call_ref requires a typed non-null funcref.
-            { op: "local.get", index: capsLocal },
-            { op: "local.get", index: argLocal },
-            { op: "local.get", index: fnLocal },
-            { op: "ref.cast", typeIdx: state.microtaskFuncTypeIdx },
-            { op: "call_ref", typeIdx: state.microtaskFuncTypeIdx },
-            { op: "drop" },
-
-            // depth 0: re-enter the loop label.
-            { op: "br", depth: 0 },
-          ],
-        },
-      ],
-    },
-  ];
 }
 
 export function ensurePromiseSettleFunctions(ctx: CodegenContext): void {

--- a/src/codegen/prepared-native-async-runtime.ts
+++ b/src/codegen/prepared-native-async-runtime.ts
@@ -1,0 +1,315 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr, LocalDef } from "../ir/types.js";
+
+/** Bound physical handles supplied by the owner after reservation, never allocated here. */
+export interface PreparedNativeQueueHandle<Kind extends "type" | "global" | "function"> {
+  readonly kind: Kind;
+  readonly index: number;
+}
+
+/** Exact queue dependency snapshot. Promise/value policy and publication belong to its caller. */
+export interface PreparedNativeMicrotaskReservations {
+  readonly types: {
+    readonly functions: PreparedNativeQueueHandle<"type">;
+    readonly arguments: PreparedNativeQueueHandle<"type">;
+    readonly callback: PreparedNativeQueueHandle<"type">;
+  };
+  readonly globals: {
+    readonly head: PreparedNativeQueueHandle<"global">;
+    readonly tail: PreparedNativeQueueHandle<"global">;
+    readonly capacity: PreparedNativeQueueHandle<"global">;
+    readonly functions: PreparedNativeQueueHandle<"global">;
+    readonly captures: PreparedNativeQueueHandle<"global">;
+    readonly arguments: PreparedNativeQueueHandle<"global">;
+  };
+  readonly grow: PreparedNativeQueueHandle<"function">;
+  readonly initialCapacity: number;
+}
+
+export function buildGrowLocals(resources: PreparedNativeMicrotaskReservations): LocalDef[] {
+  // Param 0: $newCap (i32). Local slots start at 1.
+  return [
+    { name: "$oldFuncs", type: { kind: "ref_null", typeIdx: resources.types.functions.index } },
+    { name: "$oldCaps", type: { kind: "ref_null", typeIdx: resources.types.arguments.index } },
+    { name: "$oldArgs", type: { kind: "ref_null", typeIdx: resources.types.arguments.index } },
+    { name: "$oldHead", type: { kind: "i32" } },
+    { name: "$oldTail", type: { kind: "i32" } },
+    { name: "$i", type: { kind: "i32" } },
+    { name: "$dst", type: { kind: "i32" } },
+  ];
+}
+
+export function buildGrowBody(resources: PreparedNativeMicrotaskReservations): Instr[] {
+  const newCapLocal = 0;
+  const oldFuncs = 1;
+  const oldCaps = 2;
+  const oldArgs = 3;
+  const oldHead = 4;
+  const oldTail = 5;
+  const i = 6;
+  const dst = 7;
+
+  return [
+    // Snapshot the old state.
+    { op: "global.get", index: resources.globals.functions.index },
+    { op: "local.set", index: oldFuncs },
+    { op: "global.get", index: resources.globals.captures.index },
+    { op: "local.set", index: oldCaps },
+    { op: "global.get", index: resources.globals.arguments.index },
+    { op: "local.set", index: oldArgs },
+    { op: "global.get", index: resources.globals.head.index },
+    { op: "local.set", index: oldHead },
+    { op: "global.get", index: resources.globals.tail.index },
+    { op: "local.set", index: oldTail },
+
+    // Allocate the new arrays with init = ref.null.
+    // funcs: array.new (default=null funcref) of $newCap.
+    { op: "ref.null.func" },
+    { op: "local.get", index: newCapLocal },
+    { op: "array.new", typeIdx: resources.types.functions.index },
+    { op: "global.set", index: resources.globals.functions.index },
+
+    { op: "ref.null.extern" },
+    { op: "local.get", index: newCapLocal },
+    { op: "array.new", typeIdx: resources.types.arguments.index },
+    { op: "global.set", index: resources.globals.captures.index },
+
+    { op: "ref.null.extern" },
+    { op: "local.get", index: newCapLocal },
+    { op: "array.new", typeIdx: resources.types.arguments.index },
+    { op: "global.set", index: resources.globals.arguments.index },
+
+    // If oldFuncs is null, no live entries to copy. Just reset head/tail
+    // pointers and capacity, then return.
+    { op: "local.get", index: oldFuncs },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "i32.const", value: 0 },
+        { op: "global.set", index: resources.globals.head.index },
+        { op: "i32.const", value: 0 },
+        { op: "global.set", index: resources.globals.tail.index },
+        { op: "local.get", index: newCapLocal },
+        { op: "global.set", index: resources.globals.capacity.index },
+        { op: "return" },
+      ],
+    },
+
+    // Copy live slice [oldHead, oldTail) into the new arrays starting at 0.
+    { op: "local.get", index: oldHead },
+    { op: "local.set", index: i },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: dst },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: i },
+            { op: "local.get", index: oldTail },
+            { op: "i32.eq" },
+            // depth 1: exit the enclosing block (skip the loop label).
+            { op: "br_if", depth: 1 },
+
+            // funcs[dst] = oldFuncs[i]
+            { op: "global.get", index: resources.globals.functions.index },
+            { op: "local.get", index: dst },
+            { op: "local.get", index: oldFuncs },
+            { op: "ref.as_non_null" },
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: resources.types.functions.index },
+            { op: "array.set", typeIdx: resources.types.functions.index },
+
+            // caps[dst] = oldCaps[i]
+            { op: "global.get", index: resources.globals.captures.index },
+            { op: "local.get", index: dst },
+            { op: "local.get", index: oldCaps },
+            { op: "ref.as_non_null" },
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: resources.types.arguments.index },
+            { op: "array.set", typeIdx: resources.types.arguments.index },
+
+            // args[dst] = oldArgs[i]
+            { op: "global.get", index: resources.globals.arguments.index },
+            { op: "local.get", index: dst },
+            { op: "local.get", index: oldArgs },
+            { op: "ref.as_non_null" },
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: resources.types.arguments.index },
+            { op: "array.set", typeIdx: resources.types.arguments.index },
+
+            // i++, dst++
+            { op: "local.get", index: i },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: i },
+            { op: "local.get", index: dst },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: dst },
+            // depth 0: re-enter the loop label.
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    // Finalise head/tail/cap.
+    { op: "i32.const", value: 0 },
+    { op: "global.set", index: resources.globals.head.index },
+    { op: "local.get", index: dst },
+    { op: "global.set", index: resources.globals.tail.index },
+    { op: "local.get", index: newCapLocal },
+    { op: "global.set", index: resources.globals.capacity.index },
+  ];
+}
+
+export function buildEnqueueBody(resources: PreparedNativeMicrotaskReservations): Instr[] {
+  const fnLocal = 0;
+  const capsLocal = 1;
+  const argLocal = 2;
+
+  return [
+    // Lazy first-allocate. Test `funcs` against null.
+    { op: "global.get", index: resources.globals.functions.index },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "i32.const", value: resources.initialCapacity },
+        { op: "call", funcIdx: resources.grow.index },
+      ],
+    },
+
+    // If tail == cap, double the queue.
+    { op: "global.get", index: resources.globals.tail.index },
+    { op: "global.get", index: resources.globals.capacity.index },
+    { op: "i32.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "global.get", index: resources.globals.capacity.index },
+        { op: "i32.const", value: 1 },
+        { op: "i32.shl" },
+        { op: "call", funcIdx: resources.grow.index },
+      ],
+    },
+
+    // Store fn, caps, arg at index `tail`.
+    { op: "global.get", index: resources.globals.functions.index },
+    { op: "ref.as_non_null" },
+    { op: "global.get", index: resources.globals.tail.index },
+    { op: "local.get", index: fnLocal },
+    { op: "array.set", typeIdx: resources.types.functions.index },
+
+    { op: "global.get", index: resources.globals.captures.index },
+    { op: "ref.as_non_null" },
+    { op: "global.get", index: resources.globals.tail.index },
+    { op: "local.get", index: capsLocal },
+    { op: "array.set", typeIdx: resources.types.arguments.index },
+
+    { op: "global.get", index: resources.globals.arguments.index },
+    { op: "ref.as_non_null" },
+    { op: "global.get", index: resources.globals.tail.index },
+    { op: "local.get", index: argLocal },
+    { op: "array.set", typeIdx: resources.types.arguments.index },
+
+    // tail++
+    { op: "global.get", index: resources.globals.tail.index },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "global.set", index: resources.globals.tail.index },
+  ];
+}
+
+export function buildDrainLocals(): LocalDef[] {
+  return [
+    { name: "$fn", type: { kind: "funcref" } },
+    { name: "$caps", type: { kind: "externref" } },
+    { name: "$arg", type: { kind: "externref" } },
+  ];
+}
+
+export function buildDrainBody(resources: PreparedNativeMicrotaskReservations): Instr[] {
+  const fnLocal = 0;
+  const capsLocal = 1;
+  const argLocal = 2;
+
+  return [
+    // If the queue was never used (`funcs` global null), there's nothing
+    // to drain. Early-return to avoid `ref.as_non_null` on a null ref.
+    { op: "global.get", index: resources.globals.functions.index },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "return" }],
+    },
+
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // Done when head == tail.
+            { op: "global.get", index: resources.globals.head.index },
+            { op: "global.get", index: resources.globals.tail.index },
+            { op: "i32.eq" },
+            // depth 1: exit the enclosing block (skip the loop label).
+            { op: "br_if", depth: 1 },
+
+            // Read fn, caps, arg at head.
+            { op: "global.get", index: resources.globals.functions.index },
+            { op: "ref.as_non_null" },
+            { op: "global.get", index: resources.globals.head.index },
+            { op: "array.get", typeIdx: resources.types.functions.index },
+            { op: "local.set", index: fnLocal },
+
+            { op: "global.get", index: resources.globals.captures.index },
+            { op: "ref.as_non_null" },
+            { op: "global.get", index: resources.globals.head.index },
+            { op: "array.get", typeIdx: resources.types.arguments.index },
+            { op: "local.set", index: capsLocal },
+
+            { op: "global.get", index: resources.globals.arguments.index },
+            { op: "ref.as_non_null" },
+            { op: "global.get", index: resources.globals.head.index },
+            { op: "array.get", typeIdx: resources.types.arguments.index },
+            { op: "local.set", index: argLocal },
+
+            // head++ (advance BEFORE the call so a callback that enqueues
+            // more entries doesn't have to worry about an unconsumed slot).
+            { op: "global.get", index: resources.globals.head.index },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "global.set", index: resources.globals.head.index },
+
+            // call_ref fn(caps, arg) — push args then the funcref, then
+            // ref.cast to a non-null `(ref $__mt_func_type)` because
+            // call_ref requires a typed non-null funcref.
+            { op: "local.get", index: capsLocal },
+            { op: "local.get", index: argLocal },
+            { op: "local.get", index: fnLocal },
+            { op: "ref.cast", typeIdx: resources.types.callback.index },
+            { op: "call_ref", typeIdx: resources.types.callback.index },
+            { op: "drop" },
+
+            // depth 0: re-enter the loop label.
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+  ];
+}

--- a/tests/issue-3527-prepared-native-resource-closure.test.ts
+++ b/tests/issue-3527-prepared-native-resource-closure.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import type ts from "typescript";
+import "../src/index.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { ensureMicrotaskQueue, getOrInitState, MICROTASK_QUEUE_INITIAL_SLOTS } from "../src/codegen/async-scheduler.js";
+import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
+import { addFuncType } from "../src/codegen/registry/types.js";
+import { addImport } from "../src/codegen/registry/imports.js";
+
+async function queue(visit: (captures: unknown, value: unknown) => unknown) {
+  const mod = createEmptyModule();
+  mod.types.push({
+    kind: "func",
+    params: [{ kind: "externref" }, { kind: "externref" }],
+    results: [{ kind: "externref" }],
+  });
+  const ctx = createCodegenContext(mod, {} as ts.TypeChecker);
+  addImport(ctx, "test", "visit", { kind: "func", typeIdx: 0 });
+  ensureMicrotaskQueue(ctx);
+  const state = getOrInitState(ctx);
+  const counts = [mod.types.length, mod.globals.length, mod.functions.length];
+  ensureMicrotaskQueue(ctx);
+  expect([mod.types.length, mod.globals.length, mod.functions.length]).toEqual(counts);
+  expect(mod.globals.map((global) => global.name)).toEqual([
+    "__mt_head",
+    "__mt_tail",
+    "__mt_cap",
+    "__mt_funcs",
+    "__mt_caps",
+    "__mt_args",
+  ]);
+  expect(mod.functions.map((fn) => fn.name)).toEqual(["__microtask_grow", "__microtask_enqueue", "__drain_microtasks"]);
+  const callback = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, callback, {
+    name: "callback",
+    typeIdx: state.microtaskFuncTypeIdx,
+    locals: [],
+    exported: false,
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: 0 },
+    ],
+  });
+  mod.declaredFuncRefs.push(callback);
+  const enqueue = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, enqueue, {
+    name: "enqueue",
+    typeIdx: addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], []),
+    locals: [],
+    exported: true,
+    body: [
+      { op: "ref.func", funcIdx: callback },
+      { op: "local.get", index: 0 },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: state.enqueueFuncIdx },
+    ],
+  });
+  mod.exports.push(
+    { name: "enqueue", desc: { kind: "func", index: enqueue } },
+    { name: "drain", desc: { kind: "func", index: state.drainFuncIdx } },
+    { name: "head", desc: { kind: "global", index: state.microtaskHeadGlobalIdx } },
+    { name: "tail", desc: { kind: "global", index: state.microtaskTailGlobalIdx } },
+    { name: "capacity", desc: { kind: "global", index: state.microtaskCapGlobalIdx } },
+  );
+  const binary = emitBinary(mod);
+  expect(WebAssembly.validate(binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(binary, { test: { visit } });
+  return instance.exports as {
+    enqueue: (captures: unknown, value: unknown) => void;
+    drain: () => void;
+    head: WebAssembly.Global;
+    tail: WebAssembly.Global;
+    capacity: WebAssembly.Global;
+  };
+}
+
+describe("prepared native queue physical closure", () => {
+  it("keeps unused and exhausted drains empty", async () => {
+    const seen: unknown[] = [];
+    const q = await queue((captures, value) => {
+      seen.push(captures, value);
+      return value;
+    });
+    q.drain();
+    expect(q.capacity.value).toBe(0);
+    const captures = {};
+    q.enqueue(captures, undefined);
+    q.drain();
+    q.drain();
+    expect(seen).toEqual([captures, undefined]);
+    expect(q.head.value).toBe(1);
+    expect(q.tail.value).toBe(1);
+  });
+
+  it("grows past the production initial capacity without losing FIFO values or captures", async () => {
+    const seen: unknown[] = [];
+    const captures = {};
+    const q = await queue((actualCaptures, value) => {
+      expect(actualCaptures).toBe(captures);
+      seen.push(value);
+      return null;
+    });
+    const count = MICROTASK_QUEUE_INITIAL_SLOTS + 3;
+    for (let i = 0; i < count; i++) q.enqueue(captures, i);
+    expect(q.capacity.value).toBe(MICROTASK_QUEUE_INITIAL_SLOTS * 2);
+    q.drain();
+    expect(seen).toEqual(Array.from({ length: count }, (_, i) => i));
+  });
+
+  it("copies only live entries when a callback grows the queue during drain", async () => {
+    const seen: unknown[] = [];
+    const q = await queue((_captures, value) => {
+      seen.push(value);
+      if (value === 0) q.enqueue(null, "appended");
+      return null;
+    });
+    for (let i = 0; i < MICROTASK_QUEUE_INITIAL_SLOTS; i++) q.enqueue(null, i);
+    q.drain();
+    expect(seen).toEqual([...Array.from({ length: MICROTASK_QUEUE_INITIAL_SLOTS }, (_, i) => i), "appended"]);
+    expect(q.capacity.value).toBe(MICROTASK_QUEUE_INITIAL_SLOTS * 2);
+    expect(q.head.value).toBe(MICROTASK_QUEUE_INITIAL_SLOTS);
+    expect(q.tail.value).toBe(MICROTASK_QUEUE_INITIAL_SLOTS);
+  });
+
+  it("propagates a thrown callback after advancing head and resumes remaining work", async () => {
+    const failure = new Error("callback failure");
+    const seen: unknown[] = [];
+    const q = await queue((_captures, value) => {
+      seen.push(value);
+      if (value === "throw") throw failure;
+      return null;
+    });
+    q.enqueue(null, "throw");
+    q.enqueue(null, "next");
+    expect(() => q.drain()).toThrow(failure);
+    expect(q.head.value).toBe(1);
+    q.drain();
+    expect(seen).toEqual(["throw", "next"]);
+  });
+
+  it("imports the physical leaf in a fresh process with legacy/frontend imports denied", () => {
+    const script = `
+      import { registerHooks } from "node:module";
+      const loaded = [];
+      registerHooks({ resolve(specifier, context, next) {
+        if (/async-scheduler|shared\\.js|context\\/|typescript|checker|from-ast/.test(specifier)) {
+          throw new Error("Forbidden import: " + specifier);
+        }
+        loaded.push(specifier);
+        return next(specifier, context);
+      }});
+      const leaf = await import("./src/codegen/prepared-native-async-runtime.ts");
+      if (typeof leaf.buildDrainBody !== "function") throw new Error("Missing builder");
+      let denied = false;
+      try { await import("./src/codegen/async-scheduler.ts"); }
+      catch (error) { denied = String(error).includes("Forbidden import:"); }
+      if (!denied) throw new Error("Import barrier failed its positive control");
+      console.log("physical-leaf-loaded");
+    `;
+    const child = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    expect(child.status, child.stderr).toBe(0);
+    expect(child.stdout).toContain("physical-leaf-loaded");
+  });
+});


### PR DESCRIPTION
The native microtask queue's physical builders currently require the legacy scheduler module. Extract grow, enqueue and drain bodies/locals into a pure leaf consumed by the real `ensureMicrotaskQueue` caller through frozen typed reservations.

The caller retains all type/global/function allocation, registration order, stable handles, initial capacity, export and startup policy. This checkpoint does not complete native Promise resource closure or admit native prepared-program emission.

Validation:
- 5/5 focused tests pass: emitted Wasm empty drain, >8,192 FIFO growth/captures, enqueue-and-grow during drain, thrown callback/head/resumption, and fresh-process import isolation with a forbidden-import control.
- All five builder outputs exactly match upstream `6037ac8bcf`, including nonzero resource indices and a stable function handle.
- TypeScript 7 typecheck, Prettier, LOC and function budget gates pass.

Related: issue 3527, “IR-only R7: AST-free async suspension plans and canonical Promise ABI.” Its blocked status and the remaining native closure work are preserved.
