### PR TITLE
refactor(ir): isolate capability record schema

### DIFF
--- a/plan/agent-context/3518-capability-schema-checkpoint-plan-2026-09-08.md
+++ b/plan/agent-context/3518-capability-schema-checkpoint-plan-2026-09-08.md
@@ -1,0 +1,184 @@
+# Capability schema checkpoint — Astra High implementation plan
+
+Issue #3518, IR-only default and direct front-end retirement. This is a
+dependency-cohesive extraction toward the approved standalone WasmGC folder
+separation, not a new host implementation or retirement claim.
+
+## Base, ownership and publication
+
+Independent base: `16498efb481cb022ee5c4dcc9bb137b6d4c91a50` on
+`loopdive/js2/main`. It does not incorporate held PRs #5738, #5739, #5741 or
+#5742. Astra High reviewed the exact source map below; Astra Low native
+workers implement the source and disjoint tests. The parent integrates,
+validates and publishes a non-draft checkpoint PR with the inherited merge
+hold. Green PR-head checks alone do not clear the N1/queue-safety hold.
+
+Live ledger before dispatch: `abf49cbd1413db5be1ad5f13af0f570f85cb974b`,
+814 held records. Historical capability claims remain recorded, not released:
+`3526:a1` has merged PR #4983; `3526:f3s2` has merged PR #5504. The inspected
+source includes their work. No open capability-schema PR was found. The
+coordinator's suspended-session recovery authority applies; no old worktree
+is resumed, modified, reset, or pruned by this extraction.
+
+Fresh preserved drafts: P at `6037ac8bcf07be4f71839cea33cf8c90ecc87f94`
+retains eight modified plus four untracked paths; C at
+`9feb7bf8fc0f8fddccf87235c7664651eb338e92` retains two modified plus three
+untracked paths. Neither set intersects the source/test paths below. Other
+held runtime/producer claims retain their scope; no provider-selection or
+resource-planning edits are included. Root main remains untouched.
+
+Scoped dirty-content fingerprints (SHA-256 of the sorted JSON `{path,blob}`
+list, where `blob` is Git's file-content hash) are
+`ecb33cddf6a6d0049b5c6d4b8440a2d95415ae60bf7a108172c396dc62816494`
+for P's twelve files and
+`73665f99262a0bae9dac0b48e21c1cbd0c1ec247b39885fc087e826c2047e73f`
+for C's five files. These are preservation receipts, not implementation
+validation of those drafts.
+
+## Exact source map
+
+Old implementation: `src/ir/runtime-host-capabilities.ts`.
+New canonical leaf: `src/runtime/contracts/host-capability-schema.ts`.
+Move exactly **25 types/interfaces and 14 constants**, with zero imports
+(including type imports) in the destination. Preserve declaration text and
+attached documentation. The old path explicitly imports what it uses and
+re-exports every moved public binding, without wrappers or copied tuples.
+
+Types/interfaces prefixed `RuntimeHostCapability`:
+
+```text
+FuncId FuncFamilyId GlobalId ExportId Id ValueType
+FuncModule GlobalModule Kind FieldScheme GlobalField FuncFamilyFieldScheme
+ExportPublication HostSelectionEnvVar HostSelectionCondition HostSelection
+FuncFamilyField FuncFamilyParams FuncRecord GlobalRecord FuncFamilyRecord
+ExportRecord Record
+```
+
+Also move `HostCallbackExceptionPolicy` and
+`ResolvedRuntimeHostCapabilityFuncFamilyRow`.
+
+Constants prefixed `RUNTIME_HOST_CAPABILITY_`:
+
+```text
+FUNC_IDS FUNC_FAMILY_IDS GLOBAL_IDS EXPORT_IDS IDS
+FUNC_MODULES GLOBAL_MODULES KINDS FIELD_SCHEMES FUNC_FAMILY_FIELD_SCHEMES
+EXPORT_PUBLICATIONS HOST_SELECTION_ENV_VARS HOST_SELECTIONS
+```
+
+Also move `HOST_CALLBACK_EXCEPTION_POLICY`. Preserve all literal tuples,
+ordering, aggregate-ID sorting, generic constraints/defaults, optional fields
+and all four discriminated record arms. A synthesized family row remains
+distinct from a canonical catalog record. Async-facing types remain narrowed
+to `externref | i32`; no widening or new host/linear support is allowed.
+
+**Stay unchanged in the old module:** every function; every private
+constant/set/map; private factory options; `RUNTIME_HOST_CAPABILITY_RECORDS`;
+`HOST_CALLBACK_WRAP_CAPABILITY_RECORD`. In particular, catalog construction,
+guards, validators, canonicalizers, resolvers and authentication sets retain
+one authority and the same object identities. No functions move, so existing
+function-liveness populations cannot drop through this extraction.
+
+## Worker split and parent acceptance
+
+- Source worker owns only the two source paths and
+  `tests/issue-3518-capability-schema-seam.test.ts` in its isolated worktree.
+  Prove 25/14 census, old/new runtime identity, exact declaration preservation,
+  generic/discriminant type compatibility and canonical-record rejection.
+- Evidence worker owns only
+  `tests/issue-3518-capability-schema-boundary.test.ts` in its isolated
+  worktree. Use the existing compiler-boundary instrument with positive
+  controls, required-file failure, type/runtime/re-export/transitive back
+  edges, missing/nonliteral loading and malformed source controls.
+- Parent owns `scripts/compiler-boundaries.json`, this plan and the issue
+  handoff. Activate only this leaf in `runtime-contracts`, keeping its
+  unfinished index/dependent contracts explicit. No allowed-edge widening,
+  policy exemption, LOC/function budget baseline edit or denominator change.
+  The old mixed implementation stays migration debt, not a clean facade.
+- Serialize bounded tests at 2 GiB. Run the new controls and existing callable,
+  string-schema, concat-family and async-provider controls; typecheck and
+  normal commit/push hooks. Do not run local Test262 or a broad suite.
+- Compare explicit base/candidate source revisions using actual public
+  standalone WasmGC compilation, emitted bytes/imports/order and execution.
+  Keep exact provider/catalog identity and no-host checks. Report measured
+  denominators; do not extrapolate a bounded probe to full retirement.
+
+## Next architectural obligation
+
+This leaf lets subsequent manifest schemas name capability records without
+importing catalog implementation. It does **not** permit IR core to import
+runtime contracts. `IrFunction.asyncRuntime` still carries selected providers,
+layouts and authenticated manifests; the semantic-function/prepared-attachment
+split requires its own complete reader/mutator/pass/codec map. Preserve
+`preparedManifestByPlan`, currentness, provider object/order identity and codec
+reauthentication. Do not erase them with `unknown`, weaker attachments or
+generic defaults that silently lose information. Full `core/nodes.ts`, pure
+program preparation, standalone backend integration and direct retirement
+remain open. Strict closure unknowns and all existing held evidence survive.
+
+High's next connected map places semantic bodies/identities/`asyncPlan` in
+core and the full prepared-function extension in program/runtime. Audit
+verifier, program/runtime validation, component dependencies, body receipts,
+physical planner and backend readers before that change. Preserve the
+prepared-state provenance refusal guards in `inline-small`/`monomorphize`,
+including nested functions and module copies. Runtime attachment creation,
+`extern-support` body rewriting and vector-layout attachment are the writers.
+Codec reauthentication must continue regenerating and checking runtime
+projections while retaining persisted semantic IR; decoded clones are not
+authenticated attachments. Attachment-preserving copies, stale/cloned/donor
+rejection and codec parity are required. This map is not a dispatch of the
+preserved P/C contracts.
+
+## Validated implementation and frozen handoff
+
+Astra Low's source blobs are
+`22dcbfe8f87bfc8b1c58010feb67edcc264505a9` (old implementation),
+`b6806719418d8e17e3b0498070502e231549eb05` (canonical schema) and
+`85909364a5e6dfd4d560e59dc716e153dcd49336` (seam test). Parent copied
+these exactly. The evidence worker supplied 49 controls; parent amended
+only the core-edge assertion to accommodate #5742's separately approved
+pure Wasm-model edge, never runtime-contracts. Final boundary-test blob:
+`8d2892cf713b283531ec05326d24dda28b3776b7`.
+
+Independent base/candidate AST comparison accounts for every declaration:
+39 moved plus 48 retained, including all 28 functions; declaration text and
+attached documentation match. Old source 1,237 -> 961 lines, new source
+376 lines, net **+100 LOC** for the real canonical import/re-export seam.
+No budget baseline or function allowance changed.
+
+Validation on Node 22.23.2 with the serialized 2 GiB settings:
+
+- Low seam 27/27 and typecheck pass. Parent final seam + boundary + existing
+  D0 regression controls: 118/118. The six-file broader focused run was
+  174/175; total distinct focused population is 217, with 216 passing and
+  one pre-existing local failure, not 217/217.
+- The existing concat-many async website fixture fails its old 10,021-byte
+  pin on both untouched main and the candidate. Base file run: 32/33.
+  Exact paired fixture outputs are equal: 10,122 bytes, SHA-256
+  `9cc61132c3cea9c609e93fc3ec5fa85af99e7d17bca888eb457373d3c9fa3450`,
+  28 function imports with `__concat_5` at index 22, seven IR outcomes and
+  14 pool entries. The old test expects 27 imports/index 21. Its expectations
+  remain unchanged; this proves no extraction delta, not a passing fixture
+  or host execution. The original cause of the prior mismatch is not resolved.
+- Three public standalone WasmGC programs (scalar/vector/closure) preserve
+  complete bytes, WAT, descriptors/order, pool, IR outcomes and twice-executed
+  values; all validate and instantiate with zero Wasm imports. Scalar yields
+  85, vector/closure 42. Both complete async manifests (standalone/host)
+  retain seven providers; their canonical host-record counts remain 0/7.
+  All 32 catalog records match. The host comparison is preservation only.
+- The complete 1,245-module inventory passes: seven clean, two compatibility
+  adapters, 1,236 unmigrated; 9,751 resolved edges (2,485 type / 7,266 runtime),
+  four recorded unknowns and zero inventory errors. Full architecture mode
+  still exits 1. N1 preservation exits 0 with all six full/cut witnesses and
+  the original 25-entry legacy baseline unchanged; strict mode still exits 1
+  on the same two dynamic-import receipts. Retirement remains false.
+
+Local reproduction receipts are in the parent's isolated `.tmp/` directory:
+`capability-tests.json`, `capability-boundary-final-tests.json`,
+`capability-concat-base-tests.json`, `capability-paired-{base,candidate}.json`,
+`capability-host-async-{base,candidate}.json`, `capability-inventory.json`,
+`capability-complete.json`, `capability-preservation-v1.json` and
+`capability-strict.json`. Public probes use unoptimized `compile`,
+`target: standalone`, `experimentalIR: true`, `trackIrOutcomes: true`.
+The exact host failure uses the existing unit test's source/options.
+No local Test262 or broad conformance run. Astra High reviewed source,
+controls and both exact failing-fixture receipts and approved held publication.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -4117,3 +4117,63 @@ integration. It also sequences native and linear resource materialization,
 public metadata/cutover, original-population evidence and eventual deletion.
 This is specification only: no source implementation, gate relaxation,
 claim release or migration-complete declaration is included.
+
+### Capability contract extraction checkpoint (2026-09-08)
+
+The [Astra High capability-schema plan](../agent-context/3518-capability-schema-checkpoint-plan-2026-09-08.md)
+specifies an independent checkpoint from canonical main
+`16498efb481cb022ee5c4dcc9bb137b6d4c91a50`. It extracts the complete closed
+capability-record data schema (25 types/interfaces, 14 constants) into
+`src/runtime/contracts/host-capability-schema.ts`, without changing provider
+selection, host/linear behavior, catalog construction or authentication.
+The old module imports/re-exports the same bindings and retains every
+function, private set/map and canonical record object. This removes an
+implementation dependency needed by the subsequent manifest contract split;
+it is not new host-backend work.
+
+Reconciled claim `3518:capability-schema-separation` is held by
+`ttraenkler/codex-astra-capability-schema-20260908`, branch
+`codex/3518-capability-schema-worker-20260908`, verified in ledger
+`d31c011bfbdca1f743d8102f82c9404ce743e15b` (815 held records). Historical
+claims and P/C's twelve/five dirty files remain preserved. Astra Low source
+and evidence workers have disjoint worktrees; the parent owns shared policy,
+integration and non-draft PR publication. No main push or force push.
+
+The boundary policy activates only the canonical schema leaf with zero new
+allowed edges. The old catalog implementation and the planned full runtime
+contracts index remain explicit debt. Core may not import this upward
+contract: full semantic-function/prepared-function separation still needs
+the reader, writer, generic-pass and codec obligations in the linked plan.
+
+PR #5742 (core type construction/equality) was independently observed at
+`acfd3e37b8765c4c4788c1fa94718d62c60e473c` with 29 successful and 13 skipped
+PR-head checks, mergeable/CLEAN, no unresolved review threads and `hold`
+retained. That is not merge-group or full-conformance proof. This checkpoint
+does not stack its source. PRs #5738/#5739/#5741/#5742 retain the inherited
+N1 host-regression/merge-queue-safety hold; the separate ABI caller decision
+also remains open. No CI/ruleset change, hold removal, enqueue or retirement
+claim is authorized by this checkpoint.
+
+Validated handoff: 39/39 moved declarations and 48/48 retained declarations
+(all 28 functions) are text/documentation-identical; source net +100 LOC,
+no budget exemption. All 76 new controls pass, plus all 42 existing D0
+controls. The full distinct focused population is **216/217 passing**: the
+one existing host-async concat fixture fails on untouched main too. Exact
+base/candidate byte, WAT, import-order, pool and outcome comparison matches
+at 10,122 bytes, SHA `9cc61132c3cea9c609e93fc3ec5fa85af99e7d17bca888eb457373d3c9fa3450`,
+28 function imports and concat5 index 22. Its old 10,021-byte/27-import/index-21
+expectations are not changed or waived. No claim that the fixture passes or
+that its prior mismatch is fixed.
+
+Three original public standalone scalar/vector/closure programs execute
+twice each with zero Wasm imports and full baseline/candidate equality
+(bytes/WAT/descriptors/pools/IR outcomes/results). Two complete async manifests
+retain seven providers each and 0/7 standalone/host capability records;
+all 32 catalog objects remain canonical. Typecheck passed. Inventory:
+1,245 tracked modules, seven clean, two compatibility adapters, 1,236 debt,
+9,751 resolved edges, four unknowns, zero inventory errors. Complete mode
+fails honestly; N1 preservation retains all six witnesses and its original
+25-entry legacy baseline, while strict closure still fails on the same two
+dynamic imports. No retirement credit. The linked plan records exact frozen
+hashes, test commands/receipts, next prepared-function obligations and
+Astra High's held-publication review.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -1,6 +1,6 @@
 {
   "schema": "compiler-boundaries-v1",
-  "description": "Exact compiler inventory with shared contracts and the bounded Wasm instruction, handle-primitive and native queue modules activated. Remaining model, allocator, runtime-value and compiler concerns stay migration debt.",
+  "description": "Exact compiler inventory with shared contracts, bounded Wasm instruction and handle-primitive leaves, the native microtask queue and the complete capability-record schema activated. Remaining IR, model, allocator, runtime/provider and compiler concerns stay migration debt.",
   "sourceRoot": "src",
   "tsconfig": "tsconfig.json",
   "requireGitProvenance": true,
@@ -100,10 +100,10 @@
     },
     {
       "id": "runtime-contracts",
-      "status": "planned",
+      "status": "active",
       "roots": ["src/runtime/contracts"],
       "required": true,
-      "entries": ["src/runtime/contracts/index.ts"],
+      "entries": ["src/runtime/contracts/host-capability-schema.ts"],
       "minModules": 1
     },
     {
@@ -381,6 +381,11 @@
     {
       "layer": "native-runtime",
       "entries": ["src/runtime/wasmgc/async/microtask-queue-bodies.ts"],
+      "minModules": 1
+    },
+    {
+      "layer": "runtime-contracts",
+      "entries": ["src/runtime/contracts/host-capability-schema.ts"],
       "minModules": 1
     }
   ],
@@ -9352,9 +9357,9 @@
       "path": "src/ir/runtime-host-capabilities.ts",
       "state": "unmigrated",
       "layer": "mixed-needs-split",
-      "destination": "ir-core",
+      "destination": "runtime-contracts",
       "owner": "3518-coordinator",
-      "nextBoundary": "Separate pure IR contracts from frontend inventory and physical/backend dependencies."
+      "nextBoundary": "The complete 25-type/14-constant record schema lives in runtime/contracts/host-capability-schema.ts. Catalog construction, validators, resolvers and compatibility exports remain here. Complete remaining runtime contracts and the originally planned runtime/contracts/index.ts boundary without moving selected provider attachments into IR core."
     },
     {
       "path": "src/ir/runtime-manifest.ts",
@@ -9788,6 +9793,11 @@
       "path": "src/runtime/boundary-value-adapter.ts",
       "state": "unmigrated",
       "layer": "legacy-host"
+    },
+    {
+      "path": "src/runtime/contracts/host-capability-schema.ts",
+      "state": "clean",
+      "layer": "runtime-contracts"
     },
     {
       "path": "src/runtime/builtins.ts",

--- a/src/ir/runtime-host-capabilities.ts
+++ b/src/ir/runtime-host-capabilities.ts
@@ -42,108 +42,85 @@
  * and every frozen manifest, import and emitted body is byte-identical.
  */
 
-/**
- * (#3526 F2-S2) The two id tuples are the CLOSED source of truth for which
- * kind a capability is. `RuntimeHostCapabilityId` is their union, so a
- * `host-callable` provider row can be typed on the func half alone and a
- * global id in that position is a compile error rather than a runtime
- * surprise.
- */
-export const RUNTIME_HOST_CAPABILITY_FUNC_IDS = Object.freeze([
-  "async.callback.wrap",
-  "async.exception.caught",
-  "async.promise.capability.create",
-  "async.promise.react",
-  "async.promise.resolve",
-  "async.promise.settle.fulfill",
-  "async.promise.settle.reject",
-  "async.value.undefined",
-  "boolean.box",
-  "callable.host_call.array",
-  "callback.wrap.ctor",
-  "callback.wrap.getter",
-  "error.reference.construct",
-  "extern.is_undefined",
-  "number.box",
-  "number.unbox",
-  "string.char_code_at",
-  "string.compare",
-  "string.concat",
-  "string.eq",
-  "string.len",
-] as const);
-
-/**
- * (#3526 F2-S6) The FAMILY half of the func side: one id standing for an
- * unbounded SET of physical imports that differ only in arity.
- *
- * `env.__concat_3` … `env.__concat_9` (and, on the host lane, any N — the JS
- * provider matches by prefix) are one semantic crossing whose field name is
- * DERIVED from the operand count, so a closed catalogue cannot enumerate them
- * any more than it could enumerate `string_constants.<literal>`. The record
- * therefore fixes the derivation rule, not a name.
- *
- * This is a THIRD list rather than a member of
- * {@link RUNTIME_HOST_CAPABILITY_FUNC_IDS}, and that separation is the whole
- * point: a family id in the func list would make `RuntimeHostCapabilityFuncId`
- * admit it, so a plain `host-callable { capability: "string.concat.many" }`
- * would type-check and be caught only by the runtime throw in
- * {@link asCallableRuntimeHostCapabilityRecord} at module init — exactly the
- * typed-half hole F2-S2 closed for globals. With the third list the family id
- * is spellable only where a family is expected.
- */
-export const RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS = Object.freeze([
-  "callable.boundary_callback.call",
-  "callable.host_call.fixed",
-  "string.concat.many",
-] as const);
-
-export const RUNTIME_HOST_CAPABILITY_GLOBAL_IDS = Object.freeze(["string.const", "string.const.utf16"] as const);
-
-/**
- * (#3526 F3-S2) The EXPORT half — the first ids whose direction is host→module.
- *
- * Every id above names something this module CALLS or READS. These name what
- * the module PUBLISHES for the host to call: the direct closure dispatchers
- * `__call_fn_0..4` and the arity probe `__closure_arity`. Direction is carried
- * by the kind, which is why an export record has no `module` key at all — an
- * export has no import namespace, and giving it one would invite a lane to
- * resolve it as an import.
- *
- * ENUMERATED rather than schematised, unlike the family half. The F2-S2/F2-S6
- * criterion is closedness: string-literal fields and `__concat_N` are unbounded
- * so they got schemes, but the direct dispatchers are bounded at 0..4
- * (`directClosureHostBridgeOrdinal`, `closure-exports.ts:352-353`, and the
- * `/^__call_fn_([0-4])$/` alias regex at `:101`), so they can be spelled.
- */
-export const RUNTIME_HOST_CAPABILITY_EXPORT_IDS = Object.freeze([
-  "callable.export.arity",
-  "callable.export.call_fn.0",
-  "callable.export.call_fn.1",
-  "callable.export.call_fn.2",
-  "callable.export.call_fn.3",
-  "callable.export.call_fn.4",
-] as const);
-
-export type RuntimeHostCapabilityFuncId = (typeof RUNTIME_HOST_CAPABILITY_FUNC_IDS)[number];
-export type RuntimeHostCapabilityFuncFamilyId = (typeof RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS)[number];
-export type RuntimeHostCapabilityGlobalId = (typeof RUNTIME_HOST_CAPABILITY_GLOBAL_IDS)[number];
-export type RuntimeHostCapabilityExportId = (typeof RUNTIME_HOST_CAPABILITY_EXPORT_IDS)[number];
-export type RuntimeHostCapabilityId =
-  | RuntimeHostCapabilityFuncId
-  | RuntimeHostCapabilityFuncFamilyId
-  | RuntimeHostCapabilityGlobalId
-  | RuntimeHostCapabilityExportId;
-
-/** Every id, sorted — the completeness axis the catalogue is checked against. */
-export const RUNTIME_HOST_CAPABILITY_IDS: readonly RuntimeHostCapabilityId[] = Object.freeze(
-  [
-    ...RUNTIME_HOST_CAPABILITY_FUNC_IDS,
-    ...RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS,
-    ...RUNTIME_HOST_CAPABILITY_GLOBAL_IDS,
-    ...RUNTIME_HOST_CAPABILITY_EXPORT_IDS,
-  ].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0)),
-);
+import {
+  RUNTIME_HOST_CAPABILITY_FUNC_IDS,
+  RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS,
+  RUNTIME_HOST_CAPABILITY_GLOBAL_IDS,
+  RUNTIME_HOST_CAPABILITY_EXPORT_IDS,
+  RUNTIME_HOST_CAPABILITY_IDS,
+  RUNTIME_HOST_CAPABILITY_FUNC_MODULES,
+  RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES,
+  RUNTIME_HOST_CAPABILITY_KINDS,
+  RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES,
+  RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES,
+  RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS,
+  RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS,
+  RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS,
+  HOST_CALLBACK_EXCEPTION_POLICY,
+  type RuntimeHostCapabilityFuncId,
+  type RuntimeHostCapabilityFuncFamilyId,
+  type RuntimeHostCapabilityGlobalId,
+  type RuntimeHostCapabilityExportId,
+  type RuntimeHostCapabilityId,
+  type RuntimeHostCapabilityValueType,
+  type RuntimeHostCapabilityFuncModule,
+  type RuntimeHostCapabilityGlobalModule,
+  type RuntimeHostCapabilityGlobalField,
+  type RuntimeHostCapabilityExportPublication,
+  type RuntimeHostCapabilityHostSelection,
+  type RuntimeHostCapabilityFuncFamilyField,
+  type RuntimeHostCapabilityFuncFamilyParams,
+  type RuntimeHostCapabilityFuncRecord,
+  type RuntimeHostCapabilityGlobalRecord,
+  type RuntimeHostCapabilityFuncFamilyRecord,
+  type RuntimeHostCapabilityExportRecord,
+  type RuntimeHostCapabilityRecord,
+  type HostCallbackExceptionPolicy,
+  type ResolvedRuntimeHostCapabilityFuncFamilyRow,
+} from "../runtime/contracts/host-capability-schema.js";
+export {
+  RUNTIME_HOST_CAPABILITY_FUNC_IDS,
+  RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS,
+  RUNTIME_HOST_CAPABILITY_GLOBAL_IDS,
+  RUNTIME_HOST_CAPABILITY_EXPORT_IDS,
+  RUNTIME_HOST_CAPABILITY_IDS,
+  RUNTIME_HOST_CAPABILITY_FUNC_MODULES,
+  RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES,
+  RUNTIME_HOST_CAPABILITY_KINDS,
+  RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES,
+  RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES,
+  RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS,
+  RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS,
+  RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS,
+  HOST_CALLBACK_EXCEPTION_POLICY,
+} from "../runtime/contracts/host-capability-schema.js";
+export type {
+  RuntimeHostCapabilityFuncId,
+  RuntimeHostCapabilityFuncFamilyId,
+  RuntimeHostCapabilityGlobalId,
+  RuntimeHostCapabilityExportId,
+  RuntimeHostCapabilityId,
+  RuntimeHostCapabilityValueType,
+  RuntimeHostCapabilityFuncModule,
+  RuntimeHostCapabilityGlobalModule,
+  RuntimeHostCapabilityKind,
+  RuntimeHostCapabilityFieldScheme,
+  RuntimeHostCapabilityGlobalField,
+  RuntimeHostCapabilityFuncFamilyFieldScheme,
+  RuntimeHostCapabilityExportPublication,
+  RuntimeHostCapabilityHostSelectionEnvVar,
+  RuntimeHostCapabilityHostSelectionCondition,
+  RuntimeHostCapabilityHostSelection,
+  RuntimeHostCapabilityFuncFamilyField,
+  RuntimeHostCapabilityFuncFamilyParams,
+  RuntimeHostCapabilityFuncRecord,
+  RuntimeHostCapabilityGlobalRecord,
+  RuntimeHostCapabilityFuncFamilyRecord,
+  RuntimeHostCapabilityExportRecord,
+  RuntimeHostCapabilityRecord,
+  HostCallbackExceptionPolicy,
+  ResolvedRuntimeHostCapabilityFuncFamilyRow,
+} from "../runtime/contracts/host-capability-schema.js";
 
 const RUNTIME_HOST_CAPABILITY_ID_SET: ReadonlySet<string> = new Set(RUNTIME_HOST_CAPABILITY_IDS);
 const RUNTIME_HOST_CAPABILITY_FUNC_ID_SET: ReadonlySet<string> = new Set(RUNTIME_HOST_CAPABILITY_FUNC_IDS);
@@ -182,14 +159,6 @@ export function isRuntimeHostCapabilityExportId(value: string): value is Runtime
   return RUNTIME_HOST_CAPABILITY_EXPORT_ID_SET.has(value);
 }
 
-/**
- * Value types an R6 host capability may carry. `f64` was added by F1-S1 for
- * the number boundary; `ref_extern` by F2-S2, because `wasm:js-string.concat`
- * returns `(ref extern)` and not `externref` (`registry/imports.ts`
- * `addStringImports`). The async projection stays on `externref | i32`.
- */
-export type RuntimeHostCapabilityValueType = "externref" | "i32" | "f64" | "ref_extern";
-
 const RUNTIME_HOST_CAPABILITY_VALUE_TYPES: ReadonlySet<string> = new Set<RuntimeHostCapabilityValueType>([
   "externref",
   "i32",
@@ -197,123 +166,28 @@ const RUNTIME_HOST_CAPABILITY_VALUE_TYPES: ReadonlySet<string> = new Set<Runtime
   "ref_extern",
 ]);
 
-/**
- * (#3526 F2-S2) Closed module namespaces, per kind. Keeping them on the kind
- * arm is what makes `env.<global>` and `wasm:js-string.<global>` — and
- * `string_constants.<func>` — unrepresentable rather than merely unused.
- */
-export const RUNTIME_HOST_CAPABILITY_FUNC_MODULES = Object.freeze(["env", "wasm:js-string"] as const);
-export const RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES = Object.freeze([
-  "string_constants",
-  "string_constants16",
-] as const);
-
-export type RuntimeHostCapabilityFuncModule = (typeof RUNTIME_HOST_CAPABILITY_FUNC_MODULES)[number];
-export type RuntimeHostCapabilityGlobalModule = (typeof RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES)[number];
-
 const RUNTIME_HOST_CAPABILITY_FUNC_MODULE_SET: ReadonlySet<string> = new Set(RUNTIME_HOST_CAPABILITY_FUNC_MODULES);
 const RUNTIME_HOST_CAPABILITY_GLOBAL_MODULE_SET: ReadonlySet<string> = new Set(RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES);
 
-export const RUNTIME_HOST_CAPABILITY_KINDS = Object.freeze(["export", "func", "func-family", "global"] as const);
-export type RuntimeHostCapabilityKind = (typeof RUNTIME_HOST_CAPABILITY_KINDS)[number];
 const RUNTIME_HOST_CAPABILITY_KIND_SET: ReadonlySet<string> = new Set(RUNTIME_HOST_CAPABILITY_KINDS);
 
-/**
- * (#3526 F2-S2) How a global capability's import FIELD is derived from the
- * literal it carries — not a field name, because the field IS the literal.
- *
- *  * `literal` — the surrogate-free case: `string_constants."f"`, `""`, `"ab"`.
- *  * `literal-utf16-hex` — the lone-surrogate case (#2880): a literal that is
- *    not valid UTF-8 cannot be its own field name, so `string_constants16` is
- *    keyed by `hexCodeUnits(value)` (ASCII).
- */
-export const RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES = Object.freeze(["literal", "literal-utf16-hex"] as const);
-export type RuntimeHostCapabilityFieldScheme = (typeof RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES)[number];
 const RUNTIME_HOST_CAPABILITY_FIELD_SCHEME_SET: ReadonlySet<string> = new Set(RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES);
 
-export interface RuntimeHostCapabilityGlobalField {
-  readonly scheme: RuntimeHostCapabilityFieldScheme;
-}
-
-/**
- * (#3526 F2-S6) How a func FAMILY's import field is derived from the arity.
- *
- * `arity-suffix` — the field is `prefix + arity`: `env.__concat_3`,
- * `env.__concat_9`. Deliberately its OWN list rather than a member of
- * {@link RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES}: a global's schemes derive a
- * field from a string LITERAL, a family's from a NUMBER, and nothing may read
- * one where the other is meant.
- */
-export const RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES = Object.freeze(["arity-suffix"] as const);
-export type RuntimeHostCapabilityFuncFamilyFieldScheme =
-  (typeof RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES)[number];
 const RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEME_SET: ReadonlySet<string> = new Set(
   RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES,
 );
 
-/**
- * (#3526 F3-S2) Why an export NAME may be absent from a module that otherwise
- * contains the capability.
- *
- * `host-bridge-gated` — the whole closure host bridge is published only when
- * `ctx.emitHostBridge` is true (`create-context.ts:189`,
- * `emitHostBridge: targetProfile.hostValueInterop !== "off"`), and
- * `stripHostBridgeExports` (`host-bridge-exports.ts:118`) removes the set
- * otherwise. Measured (P2, `.tmp/f3s2-plan/p2-strip.md`): on `standalone` and
- * `wasi` all six names and all six `$c*` aliases are absent, on gc-host and
- * gc-strict-no-host they are present. ONE member because the measurement found
- * exactly one gate; a second arm must be declared from a measurement, not
- * anticipated.
- */
-export const RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS = Object.freeze(["host-bridge-gated"] as const);
-export type RuntimeHostCapabilityExportPublication = (typeof RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS)[number];
 const RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATION_SET: ReadonlySet<string> = new Set(
   RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS,
 );
 
-/**
- * (#3526 F3-S2) The one environment variable that picks between two sibling
- * spellings of the same crossing, DECLARED rather than read.
- *
- * No record ever reads `process.env`. This axis only records WHICH condition
- * selects a row, so the `__call_function_N` / `__call_function` pair is a
- * declared sibling choice instead of a fact hidden inside `planHostCallFallback`.
- */
-export const RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS = Object.freeze([
-  "JS2WASM_FIXED_ARITY_HOST_CALLS",
-] as const);
-export type RuntimeHostCapabilityHostSelectionEnvVar = (typeof RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS)[number];
 const RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VAR_SET: ReadonlySet<string> = new Set(
   RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS,
 );
 
-/**
- * The two conditions, mirroring `host-call-fallback.ts:20` EXACTLY:
- *
- * ```ts
- * nativeBoundary || (process.env.JS2WASM_FIXED_ARITY_HOST_CALLS !== "0" && arity <= 4)
- * ```
- *
- * so the array ABI is selected when the knob is `"0"` **OR** the arity exceeds
- * the family's `max` — not on the knob alone. A two-member `"zero" | "not-zero"`
- * axis would therefore be a FALSE contract: measured (P3,
- * `.tmp/f3s2-plan/p3-family-abi.json`) the gc-host cell for CB7/12 imports
- * `env.__call_function` ALONGSIDE `__call_function_0..4` with the knob unset.
- */
-export const RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS = Object.freeze([
-  "knob-not-zero-within-arity",
-  "knob-zero-or-arity-above-max",
-] as const);
-export type RuntimeHostCapabilityHostSelectionCondition = (typeof RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS)[number];
 const RUNTIME_HOST_CAPABILITY_HOST_SELECTION_SET: ReadonlySet<string> = new Set(
   RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS,
 );
-
-/** A declared selection axis: which env var, and which of its conditions picks this spelling. */
-export interface RuntimeHostCapabilityHostSelection {
-  readonly envVar: RuntimeHostCapabilityHostSelectionEnvVar;
-  readonly selectsWhen: RuntimeHostCapabilityHostSelectionCondition;
-}
 
 /**
  * The smallest arity ANY capability family may admit.
@@ -335,137 +209,6 @@ export interface RuntimeHostCapabilityHostSelection {
  * arity, which no derivation rule can ever mean.
  */
 const RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_MIN_ARITY = 0;
-
-export interface RuntimeHostCapabilityFuncFamilyField {
-  readonly scheme: RuntimeHostCapabilityFuncFamilyFieldScheme;
-  /** Literal prefix the arity is appended to; `__concat_` for the concat family. */
-  readonly prefix: string;
-}
-
-/**
- * A family's parameter list as a SCHEME: `repeat` × arity, bounded by
- * `[min, max]`. `max: null` is unbounded — the measured host fact (the JS
- * provider matches `__concat_` by prefix and answers any N; the census
- * observed `__concat_9`).
- */
-export interface RuntimeHostCapabilityFuncFamilyParams<
-  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
-> {
-  readonly repeat: Value;
-  readonly min: number;
-  readonly max: number | null;
-  /**
-   * (#3526 F3-S2) The FIXED prefix ahead of the repeated tail, when the family
-   * has one. `env.__call_function_3` takes five params — callee, this, and
-   * three arguments — so `repeat × arity` alone cannot describe it.
-   *
-   * OPTIONAL, on the `exceptionPolicy?` precedent, so `string.concat.many`'s
-   * frozen shape and its whole-shape pins do not move: a row that declares no
-   * `leading` is byte-identical to a pre-F3-S2 one.
-   */
-  readonly leading?: readonly Value[];
-}
-
-/**
- * Exception policy at the host reaction boundary. A compiled throw crosses
- * that boundary as a WebAssembly.Exception carrying the original JS value in
- * this module's exception tag. The host Promise must observe that value, not
- * the Wasm carrier. Foreign tags and runtime traps are deliberately excluded.
- */
-export const HOST_CALLBACK_EXCEPTION_POLICY = "module-tag-payload" as const;
-export type HostCallbackExceptionPolicy = typeof HOST_CALLBACK_EXCEPTION_POLICY;
-
-/** Exact concrete FUNC capability record selected by the frozen manifest. */
-export interface RuntimeHostCapabilityFuncRecord<
-  Id extends RuntimeHostCapabilityFuncId = RuntimeHostCapabilityFuncId,
-  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
-> {
-  readonly capability: Id;
-  readonly module: RuntimeHostCapabilityFuncModule;
-  readonly field: string;
-  readonly kind: "func";
-  readonly params: readonly Value[];
-  readonly results: readonly Value[];
-  readonly exceptionPolicy?: HostCallbackExceptionPolicy;
-  readonly hostSelection?: RuntimeHostCapabilityHostSelection;
-}
-
-/** Exact concrete GLOBAL capability record selected by the frozen manifest. */
-export interface RuntimeHostCapabilityGlobalRecord<
-  Id extends RuntimeHostCapabilityGlobalId = RuntimeHostCapabilityGlobalId,
-  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
-> {
-  readonly capability: Id;
-  readonly module: RuntimeHostCapabilityGlobalModule;
-  readonly field: RuntimeHostCapabilityGlobalField;
-  readonly kind: "global";
-  readonly valueType: Value;
-  readonly mutable: boolean;
-}
-
-/**
- * (#3526 F2-S6) Exact FAMILY capability record — a rule for deriving an
- * unbounded set of concrete func rows, not a concrete row itself.
- *
- * Deliberately a separate kind rather than a widening of
- * {@link RuntimeHostCapabilityFuncRecord}'s `field: string` /
- * `params: readonly Value[]`: widening those would make every existing
- * `resolveRuntimeHostCapabilityFuncRecord` consumer handle a scheme it can
- * never receive. {@link resolveRuntimeHostCapabilityFuncFamilyRecord} is the
- * one place a concrete row is synthesized, and it takes the arity.
- */
-export interface RuntimeHostCapabilityFuncFamilyRecord<
-  Id extends RuntimeHostCapabilityFuncFamilyId = RuntimeHostCapabilityFuncFamilyId,
-  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
-> {
-  readonly capability: Id;
-  readonly module: RuntimeHostCapabilityFuncModule;
-  readonly field: RuntimeHostCapabilityFuncFamilyField;
-  readonly kind: "func-family";
-  readonly params: RuntimeHostCapabilityFuncFamilyParams<Value>;
-  readonly results: readonly Value[];
-  readonly hostSelection?: RuntimeHostCapabilityHostSelection;
-}
-
-/**
- * (#3526 F3-S2) Exact concrete EXPORT capability record — a name this module
- * PUBLISHES for the host to call, not one it imports.
- *
- * Deliberately has **no `module` key**, and the exact-key check enforces its
- * absence: an export has no import namespace, so a `module` slot would only
- * invite a consumer to resolve the row as an import. Direction is carried by
- * `kind` alone, which is why `asCallableRuntimeHostCapabilityRecord` refuses an
- * export record exactly as it refuses a global one.
- *
- * An export publishes TWO names. `publishClosureHostBridge`
- * (`closure-exports.ts:162-166`) emits the logical label AND the reserved
- * compact base `$c<bit36>` (`:156-172`), so the row carries both. It does NOT
- * carry the `$`-suffix collision walk, which depends on user exports observed
- * at emit time and is F3-S5's.
- */
-export interface RuntimeHostCapabilityExportRecord<
-  Id extends RuntimeHostCapabilityExportId = RuntimeHostCapabilityExportId,
-  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
-> {
-  readonly capability: Id;
-  /** The logical export label, e.g. `__call_fn_2`. */
-  readonly name: string;
-  /** The reserved compact alias base, e.g. `$c2`. */
-  readonly alias: string;
-  readonly kind: "export";
-  readonly params: readonly Value[];
-  readonly results: readonly Value[];
-  readonly publication: RuntimeHostCapabilityExportPublication;
-}
-
-export type RuntimeHostCapabilityRecord<
-  Id extends RuntimeHostCapabilityId = RuntimeHostCapabilityId,
-  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
-> =
-  | RuntimeHostCapabilityFuncRecord<Extract<Id, RuntimeHostCapabilityFuncId>, Value>
-  | RuntimeHostCapabilityFuncFamilyRecord<Extract<Id, RuntimeHostCapabilityFuncFamilyId>, Value>
-  | RuntimeHostCapabilityGlobalRecord<Extract<Id, RuntimeHostCapabilityGlobalId>, Value>
-  | RuntimeHostCapabilityExportRecord<Extract<Id, RuntimeHostCapabilityExportId>, Value>;
 
 /**
  * (#3526 F3-S2) Optional trailing options, deliberately an OBJECT rather than a
@@ -1105,25 +848,6 @@ export function resolveRuntimeHostCapabilityRecord(
   if (!found) throw new Error(`host capability catalog does not define ${capability}`);
   assertCanonicalRuntimeHostCapabilityRecord(found);
   return found;
-}
-
-/**
- * (#3526 F2-S6) One CONCRETE row synthesized from a family record and an arity.
- *
- * Structurally the `module` / `field` / `params` / `results` a caller would
- * have gotten from a plain func record — deliberately NOT a
- * {@link RuntimeHostCapabilityFuncRecord}, because it is not a catalogue
- * object: `assertCanonicalRuntimeHostCapabilityRecord` would (correctly)
- * refuse it, and nothing may pass a synthesized row where a canonical one is
- * required.
- */
-export interface ResolvedRuntimeHostCapabilityFuncFamilyRow<
-  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
-> {
-  readonly module: RuntimeHostCapabilityFuncModule;
-  readonly field: string;
-  readonly params: readonly Value[];
-  readonly results: readonly Value[];
 }
 
 /**

--- a/src/runtime/contracts/host-capability-schema.ts
+++ b/src/runtime/contracts/host-capability-schema.ts
@@ -1,0 +1,376 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * (#3526 F2-S2) The two id tuples are the CLOSED source of truth for which
+ * kind a capability is. `RuntimeHostCapabilityId` is their union, so a
+ * `host-callable` provider row can be typed on the func half alone and a
+ * global id in that position is a compile error rather than a runtime
+ * surprise.
+ */
+export const RUNTIME_HOST_CAPABILITY_FUNC_IDS = Object.freeze([
+  "async.callback.wrap",
+  "async.exception.caught",
+  "async.promise.capability.create",
+  "async.promise.react",
+  "async.promise.resolve",
+  "async.promise.settle.fulfill",
+  "async.promise.settle.reject",
+  "async.value.undefined",
+  "boolean.box",
+  "callable.host_call.array",
+  "callback.wrap.ctor",
+  "callback.wrap.getter",
+  "error.reference.construct",
+  "extern.is_undefined",
+  "number.box",
+  "number.unbox",
+  "string.char_code_at",
+  "string.compare",
+  "string.concat",
+  "string.eq",
+  "string.len",
+] as const);
+
+/**
+ * (#3526 F2-S6) The FAMILY half of the func side: one id standing for an
+ * unbounded SET of physical imports that differ only in arity.
+ *
+ * `env.__concat_3` … `env.__concat_9` (and, on the host lane, any N — the JS
+ * provider matches by prefix) are one semantic crossing whose field name is
+ * DERIVED from the operand count, so a closed catalogue cannot enumerate them
+ * any more than it could enumerate `string_constants.<literal>`. The record
+ * therefore fixes the derivation rule, not a name.
+ *
+ * This is a THIRD list rather than a member of
+ * {@link RUNTIME_HOST_CAPABILITY_FUNC_IDS}, and that separation is the whole
+ * point: a family id in the func list would make `RuntimeHostCapabilityFuncId`
+ * admit it, so a plain `host-callable { capability: "string.concat.many" }`
+ * would type-check and be caught only by the runtime throw in
+ * {@link asCallableRuntimeHostCapabilityRecord} at module init — exactly the
+ * typed-half hole F2-S2 closed for globals. With the third list the family id
+ * is spellable only where a family is expected.
+ */
+export const RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS = Object.freeze([
+  "callable.boundary_callback.call",
+  "callable.host_call.fixed",
+  "string.concat.many",
+] as const);
+
+export const RUNTIME_HOST_CAPABILITY_GLOBAL_IDS = Object.freeze(["string.const", "string.const.utf16"] as const);
+
+/**
+ * (#3526 F3-S2) The EXPORT half — the first ids whose direction is host→module.
+ *
+ * Every id above names something this module CALLS or READS. These name what
+ * the module PUBLISHES for the host to call: the direct closure dispatchers
+ * `__call_fn_0..4` and the arity probe `__closure_arity`. Direction is carried
+ * by the kind, which is why an export record has no `module` key at all — an
+ * export has no import namespace, and giving it one would invite a lane to
+ * resolve it as an import.
+ *
+ * ENUMERATED rather than schematised, unlike the family half. The F2-S2/F2-S6
+ * criterion is closedness: string-literal fields and `__concat_N` are unbounded
+ * so they got schemes, but the direct dispatchers are bounded at 0..4
+ * (`directClosureHostBridgeOrdinal`, `closure-exports.ts:352-353`, and the
+ * `/^__call_fn_([0-4])$/` alias regex at `:101`), so they can be spelled.
+ */
+export const RUNTIME_HOST_CAPABILITY_EXPORT_IDS = Object.freeze([
+  "callable.export.arity",
+  "callable.export.call_fn.0",
+  "callable.export.call_fn.1",
+  "callable.export.call_fn.2",
+  "callable.export.call_fn.3",
+  "callable.export.call_fn.4",
+] as const);
+
+export type RuntimeHostCapabilityFuncId = (typeof RUNTIME_HOST_CAPABILITY_FUNC_IDS)[number];
+
+export type RuntimeHostCapabilityFuncFamilyId = (typeof RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS)[number];
+
+export type RuntimeHostCapabilityGlobalId = (typeof RUNTIME_HOST_CAPABILITY_GLOBAL_IDS)[number];
+
+export type RuntimeHostCapabilityExportId = (typeof RUNTIME_HOST_CAPABILITY_EXPORT_IDS)[number];
+
+export type RuntimeHostCapabilityId =
+  | RuntimeHostCapabilityFuncId
+  | RuntimeHostCapabilityFuncFamilyId
+  | RuntimeHostCapabilityGlobalId
+  | RuntimeHostCapabilityExportId;
+
+/** Every id, sorted — the completeness axis the catalogue is checked against. */
+export const RUNTIME_HOST_CAPABILITY_IDS: readonly RuntimeHostCapabilityId[] = Object.freeze(
+  [
+    ...RUNTIME_HOST_CAPABILITY_FUNC_IDS,
+    ...RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS,
+    ...RUNTIME_HOST_CAPABILITY_GLOBAL_IDS,
+    ...RUNTIME_HOST_CAPABILITY_EXPORT_IDS,
+  ].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0)),
+);
+
+/**
+ * Value types an R6 host capability may carry. `f64` was added by F1-S1 for
+ * the number boundary; `ref_extern` by F2-S2, because `wasm:js-string.concat`
+ * returns `(ref extern)` and not `externref` (`registry/imports.ts`
+ * `addStringImports`). The async projection stays on `externref | i32`.
+ */
+export type RuntimeHostCapabilityValueType = "externref" | "i32" | "f64" | "ref_extern";
+
+/**
+ * (#3526 F2-S2) Closed module namespaces, per kind. Keeping them on the kind
+ * arm is what makes `env.<global>` and `wasm:js-string.<global>` — and
+ * `string_constants.<func>` — unrepresentable rather than merely unused.
+ */
+export const RUNTIME_HOST_CAPABILITY_FUNC_MODULES = Object.freeze(["env", "wasm:js-string"] as const);
+
+export const RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES = Object.freeze([
+  "string_constants",
+  "string_constants16",
+] as const);
+
+export type RuntimeHostCapabilityFuncModule = (typeof RUNTIME_HOST_CAPABILITY_FUNC_MODULES)[number];
+
+export type RuntimeHostCapabilityGlobalModule = (typeof RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES)[number];
+
+export const RUNTIME_HOST_CAPABILITY_KINDS = Object.freeze(["export", "func", "func-family", "global"] as const);
+
+export type RuntimeHostCapabilityKind = (typeof RUNTIME_HOST_CAPABILITY_KINDS)[number];
+
+/**
+ * (#3526 F2-S2) How a global capability's import FIELD is derived from the
+ * literal it carries — not a field name, because the field IS the literal.
+ *
+ *  * `literal` — the surrogate-free case: `string_constants."f"`, `""`, `"ab"`.
+ *  * `literal-utf16-hex` — the lone-surrogate case (#2880): a literal that is
+ *    not valid UTF-8 cannot be its own field name, so `string_constants16` is
+ *    keyed by `hexCodeUnits(value)` (ASCII).
+ */
+export const RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES = Object.freeze(["literal", "literal-utf16-hex"] as const);
+
+export type RuntimeHostCapabilityFieldScheme = (typeof RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES)[number];
+
+export interface RuntimeHostCapabilityGlobalField {
+  readonly scheme: RuntimeHostCapabilityFieldScheme;
+}
+
+/**
+ * (#3526 F2-S6) How a func FAMILY's import field is derived from the arity.
+ *
+ * `arity-suffix` — the field is `prefix + arity`: `env.__concat_3`,
+ * `env.__concat_9`. Deliberately its OWN list rather than a member of
+ * {@link RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES}: a global's schemes derive a
+ * field from a string LITERAL, a family's from a NUMBER, and nothing may read
+ * one where the other is meant.
+ */
+export const RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES = Object.freeze(["arity-suffix"] as const);
+
+export type RuntimeHostCapabilityFuncFamilyFieldScheme =
+  (typeof RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES)[number];
+
+/**
+ * (#3526 F3-S2) Why an export NAME may be absent from a module that otherwise
+ * contains the capability.
+ *
+ * `host-bridge-gated` — the whole closure host bridge is published only when
+ * `ctx.emitHostBridge` is true (`create-context.ts:189`,
+ * `emitHostBridge: targetProfile.hostValueInterop !== "off"`), and
+ * `stripHostBridgeExports` (`host-bridge-exports.ts:118`) removes the set
+ * otherwise. Measured (P2, `.tmp/f3s2-plan/p2-strip.md`): on `standalone` and
+ * `wasi` all six names and all six `$c*` aliases are absent, on gc-host and
+ * gc-strict-no-host they are present. ONE member because the measurement found
+ * exactly one gate; a second arm must be declared from a measurement, not
+ * anticipated.
+ */
+export const RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS = Object.freeze(["host-bridge-gated"] as const);
+
+export type RuntimeHostCapabilityExportPublication = (typeof RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS)[number];
+
+/**
+ * (#3526 F3-S2) The one environment variable that picks between two sibling
+ * spellings of the same crossing, DECLARED rather than read.
+ *
+ * No record ever reads `process.env`. This axis only records WHICH condition
+ * selects a row, so the `__call_function_N` / `__call_function` pair is a
+ * declared sibling choice instead of a fact hidden inside `planHostCallFallback`.
+ */
+export const RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS = Object.freeze([
+  "JS2WASM_FIXED_ARITY_HOST_CALLS",
+] as const);
+
+export type RuntimeHostCapabilityHostSelectionEnvVar = (typeof RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS)[number];
+
+/**
+ * The two conditions, mirroring `host-call-fallback.ts:20` EXACTLY:
+ *
+ * ```ts
+ * nativeBoundary || (process.env.JS2WASM_FIXED_ARITY_HOST_CALLS !== "0" && arity <= 4)
+ * ```
+ *
+ * so the array ABI is selected when the knob is `"0"` **OR** the arity exceeds
+ * the family's `max` — not on the knob alone. A two-member `"zero" | "not-zero"`
+ * axis would therefore be a FALSE contract: measured (P3,
+ * `.tmp/f3s2-plan/p3-family-abi.json`) the gc-host cell for CB7/12 imports
+ * `env.__call_function` ALONGSIDE `__call_function_0..4` with the knob unset.
+ */
+export const RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS = Object.freeze([
+  "knob-not-zero-within-arity",
+  "knob-zero-or-arity-above-max",
+] as const);
+
+export type RuntimeHostCapabilityHostSelectionCondition = (typeof RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS)[number];
+
+/** A declared selection axis: which env var, and which of its conditions picks this spelling. */
+export interface RuntimeHostCapabilityHostSelection {
+  readonly envVar: RuntimeHostCapabilityHostSelectionEnvVar;
+  readonly selectsWhen: RuntimeHostCapabilityHostSelectionCondition;
+}
+
+export interface RuntimeHostCapabilityFuncFamilyField {
+  readonly scheme: RuntimeHostCapabilityFuncFamilyFieldScheme;
+  /** Literal prefix the arity is appended to; `__concat_` for the concat family. */
+  readonly prefix: string;
+}
+
+/**
+ * A family's parameter list as a SCHEME: `repeat` × arity, bounded by
+ * `[min, max]`. `max: null` is unbounded — the measured host fact (the JS
+ * provider matches `__concat_` by prefix and answers any N; the census
+ * observed `__concat_9`).
+ */
+export interface RuntimeHostCapabilityFuncFamilyParams<
+  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
+> {
+  readonly repeat: Value;
+  readonly min: number;
+  readonly max: number | null;
+  /**
+   * (#3526 F3-S2) The FIXED prefix ahead of the repeated tail, when the family
+   * has one. `env.__call_function_3` takes five params — callee, this, and
+   * three arguments — so `repeat × arity` alone cannot describe it.
+   *
+   * OPTIONAL, on the `exceptionPolicy?` precedent, so `string.concat.many`'s
+   * frozen shape and its whole-shape pins do not move: a row that declares no
+   * `leading` is byte-identical to a pre-F3-S2 one.
+   */
+  readonly leading?: readonly Value[];
+}
+
+/**
+ * Exception policy at the host reaction boundary. A compiled throw crosses
+ * that boundary as a WebAssembly.Exception carrying the original JS value in
+ * this module's exception tag. The host Promise must observe that value, not
+ * the Wasm carrier. Foreign tags and runtime traps are deliberately excluded.
+ */
+export const HOST_CALLBACK_EXCEPTION_POLICY = "module-tag-payload" as const;
+
+export type HostCallbackExceptionPolicy = typeof HOST_CALLBACK_EXCEPTION_POLICY;
+
+/** Exact concrete FUNC capability record selected by the frozen manifest. */
+export interface RuntimeHostCapabilityFuncRecord<
+  Id extends RuntimeHostCapabilityFuncId = RuntimeHostCapabilityFuncId,
+  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
+> {
+  readonly capability: Id;
+  readonly module: RuntimeHostCapabilityFuncModule;
+  readonly field: string;
+  readonly kind: "func";
+  readonly params: readonly Value[];
+  readonly results: readonly Value[];
+  readonly exceptionPolicy?: HostCallbackExceptionPolicy;
+  readonly hostSelection?: RuntimeHostCapabilityHostSelection;
+}
+
+/** Exact concrete GLOBAL capability record selected by the frozen manifest. */
+export interface RuntimeHostCapabilityGlobalRecord<
+  Id extends RuntimeHostCapabilityGlobalId = RuntimeHostCapabilityGlobalId,
+  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
+> {
+  readonly capability: Id;
+  readonly module: RuntimeHostCapabilityGlobalModule;
+  readonly field: RuntimeHostCapabilityGlobalField;
+  readonly kind: "global";
+  readonly valueType: Value;
+  readonly mutable: boolean;
+}
+
+/**
+ * (#3526 F2-S6) Exact FAMILY capability record — a rule for deriving an
+ * unbounded set of concrete func rows, not a concrete row itself.
+ *
+ * Deliberately a separate kind rather than a widening of
+ * {@link RuntimeHostCapabilityFuncRecord}'s `field: string` /
+ * `params: readonly Value[]`: widening those would make every existing
+ * `resolveRuntimeHostCapabilityFuncRecord` consumer handle a scheme it can
+ * never receive. {@link resolveRuntimeHostCapabilityFuncFamilyRecord} is the
+ * one place a concrete row is synthesized, and it takes the arity.
+ */
+export interface RuntimeHostCapabilityFuncFamilyRecord<
+  Id extends RuntimeHostCapabilityFuncFamilyId = RuntimeHostCapabilityFuncFamilyId,
+  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
+> {
+  readonly capability: Id;
+  readonly module: RuntimeHostCapabilityFuncModule;
+  readonly field: RuntimeHostCapabilityFuncFamilyField;
+  readonly kind: "func-family";
+  readonly params: RuntimeHostCapabilityFuncFamilyParams<Value>;
+  readonly results: readonly Value[];
+  readonly hostSelection?: RuntimeHostCapabilityHostSelection;
+}
+
+/**
+ * (#3526 F3-S2) Exact concrete EXPORT capability record — a name this module
+ * PUBLISHES for the host to call, not one it imports.
+ *
+ * Deliberately has **no `module` key**, and the exact-key check enforces its
+ * absence: an export has no import namespace, so a `module` slot would only
+ * invite a consumer to resolve the row as an import. Direction is carried by
+ * `kind` alone, which is why `asCallableRuntimeHostCapabilityRecord` refuses an
+ * export record exactly as it refuses a global one.
+ *
+ * An export publishes TWO names. `publishClosureHostBridge`
+ * (`closure-exports.ts:162-166`) emits the logical label AND the reserved
+ * compact base `$c<bit36>` (`:156-172`), so the row carries both. It does NOT
+ * carry the `$`-suffix collision walk, which depends on user exports observed
+ * at emit time and is F3-S5's.
+ */
+export interface RuntimeHostCapabilityExportRecord<
+  Id extends RuntimeHostCapabilityExportId = RuntimeHostCapabilityExportId,
+  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
+> {
+  readonly capability: Id;
+  /** The logical export label, e.g. `__call_fn_2`. */
+  readonly name: string;
+  /** The reserved compact alias base, e.g. `$c2`. */
+  readonly alias: string;
+  readonly kind: "export";
+  readonly params: readonly Value[];
+  readonly results: readonly Value[];
+  readonly publication: RuntimeHostCapabilityExportPublication;
+}
+
+export type RuntimeHostCapabilityRecord<
+  Id extends RuntimeHostCapabilityId = RuntimeHostCapabilityId,
+  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
+> =
+  | RuntimeHostCapabilityFuncRecord<Extract<Id, RuntimeHostCapabilityFuncId>, Value>
+  | RuntimeHostCapabilityFuncFamilyRecord<Extract<Id, RuntimeHostCapabilityFuncFamilyId>, Value>
+  | RuntimeHostCapabilityGlobalRecord<Extract<Id, RuntimeHostCapabilityGlobalId>, Value>
+  | RuntimeHostCapabilityExportRecord<Extract<Id, RuntimeHostCapabilityExportId>, Value>;
+
+/**
+ * (#3526 F2-S6) One CONCRETE row synthesized from a family record and an arity.
+ *
+ * Structurally the `module` / `field` / `params` / `results` a caller would
+ * have gotten from a plain func record — deliberately NOT a
+ * {@link RuntimeHostCapabilityFuncRecord}, because it is not a catalogue
+ * object: `assertCanonicalRuntimeHostCapabilityRecord` would (correctly)
+ * refuse it, and nothing may pass a synthesized row where a canonical one is
+ * required.
+ */
+export interface ResolvedRuntimeHostCapabilityFuncFamilyRow<
+  Value extends RuntimeHostCapabilityValueType = RuntimeHostCapabilityValueType,
+> {
+  readonly module: RuntimeHostCapabilityFuncModule;
+  readonly field: string;
+  readonly params: readonly Value[];
+  readonly results: readonly Value[];
+}

--- a/tests/issue-3518-capability-schema-boundary.test.ts
+++ b/tests/issue-3518-capability-schema-boundary.test.ts
@@ -1,0 +1,390 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import ts from "typescript";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const repository = resolve(import.meta.dirname, "..");
+const checker = resolve(repository, "scripts/check-compiler-boundaries.mjs");
+const schema = "src/runtime/contracts/host-capability-schema.ts";
+const oldCatalog = "src/ir/runtime-host-capabilities.ts";
+const foundation = "src/shared/contracts/boundary-probe.ts";
+const wasmModel = "src/wasm/model/boundary-probe.ts";
+const core = "src/ir/core/boundary-probe.ts";
+const frontend = "src/frontend/ts/boundary-probe.ts";
+const barrel = "src/runtime/contracts/boundary-probe.ts";
+const runtimeEdges = ["runtime-contracts", "foundation", "wasm-model"];
+// #5742 independently activates the already-approved pure Wasm-model edge.
+// Neither base admits runtime contracts or implementation layers from core.
+const permittedCoreEdges = ["ir-core", "foundation", "wasm-model"];
+const probe = "export type Probe = number; export const probe = 1;";
+const scratchRoots: string[] = [];
+
+type Layer = {
+  id: string;
+  status: string;
+  roots: string[];
+  required?: boolean;
+  entries?: string[];
+  minModules?: number;
+};
+type Classification = { path: string; state: string; layer: string };
+type Policy = {
+  moduleExtensions: string[];
+  layers: Layer[];
+  allowedEdges: Record<string, string[]>;
+  files: Classification[];
+};
+type Edge = { from: string; to?: string; specifier: string | null; syntax: string; typeOnly: boolean };
+type Report = {
+  inventoryValid: boolean;
+  graphComplete: boolean;
+  architectureComplete: boolean;
+  errors: { code: string; detail: string }[];
+  edges: Edge[];
+  forbiddenEdges: Edge[];
+  unknownEdges: Edge[];
+  unresolvedEdges: Edge[];
+  transitiveViolations: { from: string; path: string[]; typeOnly: boolean }[];
+  activatedRoots: { layer: string; entries: string[]; visitedEntries: string[]; modules: number; minModules: number }[];
+  modules: (Classification & { hash: string })[];
+  counts: { total: number; byState: Record<string, number> };
+  resolvedEdgeCount: number;
+  debt: Classification[];
+};
+
+let source: string;
+let productionPolicy: Policy;
+beforeAll(() => {
+  // Deliberately requires the composed source and policy. There is no old-path,
+  // source-worker, exists/skip or synthetic-schema fallback for this suite.
+  source = readFileSync(resolve(repository, schema), "utf8");
+  productionPolicy = JSON.parse(readFileSync(resolve(repository, "scripts/compiler-boundaries.json"), "utf8"));
+});
+
+function fixture() {
+  const scratch = resolve(repository, ".tmp");
+  mkdirSync(scratch, { recursive: true });
+  const root = mkdtempSync(resolve(scratch, "issue-3518-capability-schema-boundary-"));
+  scratchRoots.push(root);
+  const put = (path: string, text: string) => {
+    mkdirSync(dirname(resolve(root, path)), { recursive: true });
+    writeFileSync(resolve(root, path), text);
+  };
+  const active = new Map([
+    ["runtime-contracts", schema],
+    ["foundation", foundation],
+    ["wasm-model", wasmModel],
+    ["ir-core", core],
+    ["frontend-ts", frontend],
+  ]);
+  const policy = {
+    schema: "compiler-boundaries-v1",
+    sourceRoot: "src",
+    tsconfig: "tsconfig.json",
+    requireGitProvenance: false,
+    moduleExtensions: productionPolicy.moduleExtensions,
+    layers: productionPolicy.layers.map((layer): Layer => {
+      const entry = active.get(layer.id);
+      return entry
+        ? {
+            id: layer.id,
+            status: "active",
+            roots: layer.id === "runtime-contracts" ? [...layer.roots] : [entry],
+            required: true,
+            entries: [entry],
+            minModules: 1,
+          }
+        : { id: layer.id, status: "debt", roots: layer.roots };
+    }),
+    // All production allowed-edge rules are retained, not widened for fixtures.
+    allowedEdges: structuredClone(productionPolicy.allowedEdges),
+    files: [
+      ...Array.from(active, ([layer, path]) => ({ path, layer, state: "clean" })),
+      { ...productionPolicy.files.find((file) => file.path === oldCatalog)! },
+    ],
+    nonModules: [],
+    externalPackages: [],
+    moves: [],
+    evidence: [],
+    activationHistory: [{ layer: "runtime-contracts", entries: [schema], minModules: 1 }],
+  };
+  put(schema, source);
+  for (const path of [foundation, wasmModel, core, frontend, oldCatalog]) put(path, probe);
+  put(
+    "tsconfig.json",
+    JSON.stringify({
+      compilerOptions: { target: "ES2022", module: "ESNext", moduleResolution: "Bundler" },
+      include: ["src/**/*"],
+    }),
+  );
+  const addBarrel = (text: string) => {
+    put(barrel, text);
+    // Classify only this synthetic helper inside the existing directory root.
+    // The required entry remains the canonical schema, never the helper.
+    policy.files.push({ path: barrel, layer: "runtime-contracts", state: "clean" });
+  };
+  const append = (text: string) => put(schema, source + "\n" + text + "\n");
+  const run = (mode = "inventory") => {
+    put("policy.json", JSON.stringify(policy));
+    const child = spawnSync(
+      process.execPath,
+      ["--max-old-space-size=2048", checker, "--root", root, "--config", "policy.json", "--mode", mode, "--json"],
+      { encoding: "utf8", maxBuffer: 8 * 1024 * 1024, env: process.env },
+    );
+    expect(child.error).toBeUndefined();
+    expect(child.signal).toBeNull();
+    expect([0, 1], child.stderr + child.stdout).toContain(child.status);
+    return { exit: child.status, report: JSON.parse(child.stdout) as Report };
+  };
+  return { root, policy, put, append, addBarrel, run };
+}
+
+afterEach(() => {
+  for (const root of scratchRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function rejected(result: ReturnType<ReturnType<typeof fixture>["run"]>, code: string) {
+  expect(result.exit).toBe(1);
+  expect(result.report.inventoryValid).toBe(false);
+  expect(result.report.architectureComplete).toBe(false);
+  expect(result.report.errors.map((error) => error.code)).toContain(code);
+}
+
+const forbiddenTargets = [
+  { target: oldCatalog, specifier: "../../ir/runtime-host-capabilities.js" },
+  { target: core, specifier: "../../ir/core/boundary-probe.js" },
+  { target: frontend, specifier: "../../frontend/ts/boundary-probe.js" },
+];
+const backEdges = [
+  { text: 'import { probe } from "TARGET";', syntax: "import", typeOnly: false },
+  { text: 'import type { Probe } from "TARGET";', syntax: "import", typeOnly: true },
+  { text: 'type BackEdge = import("TARGET").Probe;', syntax: "import-type", typeOnly: true },
+  { text: 'export type { Probe } from "TARGET";', syntax: "export-from", typeOnly: true },
+  { text: 'export * from "TARGET";', syntax: "export-star", typeOnly: false },
+  { text: 'void import("TARGET");', syntax: "dynamic-import", typeOnly: false },
+  { text: 'const back = require("TARGET");', syntax: "require", typeOnly: false },
+  { text: 'import back = require("TARGET");', syntax: "import-equals", typeOnly: false },
+];
+
+describe("#3518 capability schema compiler boundaries", () => {
+  it("requires the one real leaf activation without widening policy or cleaning the old catalog", () => {
+    expect(productionPolicy.layers.find((layer) => layer.id === "runtime-contracts")).toMatchObject({
+      status: "active",
+      roots: ["src/runtime/contracts"],
+      required: true,
+      entries: [schema],
+      minModules: 1,
+    });
+    expect(productionPolicy.files.filter((file) => file.path === schema)).toEqual([
+      expect.objectContaining({ state: "clean", layer: "runtime-contracts" }),
+    ]);
+    expect(productionPolicy.files.filter((file) => file.path === oldCatalog)).toEqual([
+      expect.objectContaining({ state: "unmigrated", layer: "mixed-needs-split" }),
+    ]);
+    expect(productionPolicy.allowedEdges["runtime-contracts"]).toEqual(runtimeEdges);
+    expect(productionPolicy.allowedEdges["ir-core"]).toEqual(expect.arrayContaining(["ir-core", "foundation"]));
+    expect(productionPolicy.allowedEdges["ir-core"].filter((edge) => !permittedCoreEdges.includes(edge))).toEqual([]);
+  });
+
+  it("binds a nonempty 25-type/14-constant schema, with immutable constant initializers", () => {
+    const tree = ts.createSourceFile(schema, source, ts.ScriptTarget.Latest, true);
+    const types = tree.statements.filter((node) => ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node));
+    const variables = tree.statements.filter(ts.isVariableStatement);
+    expect(types).toHaveLength(25);
+    expect(variables).toHaveLength(14);
+    expect(tree.statements).toHaveLength(39);
+    for (const statement of variables) {
+      expect(statement.declarationList.flags & ts.NodeFlags.Const).not.toBe(0);
+      expect(statement.declarationList.declarations).toHaveLength(1);
+      const declaration = statement.declarationList.declarations[0]!;
+      const initializer = declaration.initializer!;
+      if (declaration.name.getText(tree) === "HOST_CALLBACK_EXCEPTION_POLICY") {
+        expect(initializer.getText(tree)).toBe('"module-tag-payload" as const');
+      } else {
+        expect(ts.isCallExpression(initializer)).toBe(true);
+        if (ts.isCallExpression(initializer)) expect(initializer.expression.getText(tree)).toBe("Object.freeze");
+      }
+    }
+  });
+
+  it("visits the actual import-free schema and retains catalog debt, not a retirement verdict", () => {
+    const f = fixture();
+    const result = f.run();
+    expect(result.exit).toBe(0);
+    expect(result.report.errors).toEqual([]);
+    expect(result.report.counts).toMatchObject({ total: 6, byState: { clean: 5, unmigrated: 1 } });
+    expect(result.report.activatedRoots).toContainEqual({
+      layer: "runtime-contracts",
+      entries: [schema],
+      visitedEntries: [schema],
+      modules: 1,
+      minModules: 1,
+    });
+    expect(result.report.modules).toContainEqual(
+      expect.objectContaining({ path: schema, hash: createHash("sha256").update(source).digest("hex") }),
+    );
+    expect(result.report.edges).toEqual([]);
+    expect(result.report.resolvedEdgeCount).toBe(0);
+    expect(result.report.unknownEdges).toEqual([]);
+    expect(result.report.unresolvedEdges).toEqual([]);
+    expect(result.report.graphComplete).toBe(true);
+    expect(result.report.architectureComplete).toBe(false);
+    expect(result.report.debt).toEqual([expect.objectContaining({ path: oldCatalog, state: "unmigrated" })]);
+    const complete = f.run("complete");
+    expect(complete.exit).toBe(1);
+    expect(complete.report.inventoryValid).toBe(true);
+    expect(complete.report.architectureComplete).toBe(false);
+  });
+
+  it.each([
+    { target: foundation, specifier: "../../shared/contracts/boundary-probe.js" },
+    { target: wasmModel, specifier: "../../wasm/model/boundary-probe.js" },
+    { target: barrel, specifier: "./boundary-probe.js" },
+  ])("resolves allowed policy edges to $target without changing the real import-free leaf", ({ target, specifier }) => {
+    const f = fixture();
+    if (target === barrel) f.addBarrel(probe);
+    f.append(`import type { Probe } from "${specifier}";`);
+    const result = f.run();
+    expect(result.exit).toBe(0);
+    expect(result.report.errors).toEqual([]);
+    expect(result.report.resolvedEdgeCount).toBe(1);
+    expect(result.report.edges).toContainEqual(expect.objectContaining({ from: schema, to: target, typeOnly: true }));
+  });
+
+  it.each(forbiddenTargets.flatMap((target) => backEdges.map((edge) => ({ ...target, ...edge }))))(
+    "rejects $syntax typeOnly=$typeOnly from the schema to $target",
+    ({ target, specifier, text, syntax, typeOnly }) => {
+      const f = fixture();
+      f.append(text.replace("TARGET", specifier));
+      const result = f.run();
+      rejected(result, "forbidden-clean-edge");
+      expect(result.report.unresolvedEdges).toEqual([]);
+      expect(result.report.unknownEdges).toEqual([]);
+      expect(result.report.forbiddenEdges).toContainEqual(
+        expect.objectContaining({ from: schema, to: target, syntax, typeOnly }),
+      );
+    },
+  );
+
+  it.each(backEdges.filter((edge) => ["import", "export-from"].includes(edge.syntax) && edge.typeOnly))(
+    "also forbids IR core $syntax from depending on the runtime schema",
+    ({ text, syntax }) => {
+      const f = fixture();
+      f.put(
+        core,
+        text
+          .replace("TARGET", "../../runtime/contracts/host-capability-schema.js")
+          .replace("Probe", "RuntimeHostCapabilityId"),
+      );
+      const result = f.run();
+      rejected(result, "forbidden-clean-edge");
+      expect(result.report.forbiddenEdges).toContainEqual(
+        expect.objectContaining({ from: core, to: schema, syntax, typeOnly: true }),
+      );
+    },
+  );
+
+  it.each(["dynamic-import", "require"])("reports a nonliteral %s as unknown, never an empty graph", (syntax) => {
+    const f = fixture();
+    f.append(`declare const target: string; void ${syntax === "dynamic-import" ? "import" : "require"}(target);`);
+    const result = f.run();
+    rejected(result, "unknown-clean-edge");
+    expect(result.report.graphComplete).toBe(false);
+    expect(result.report.unknownEdges).toEqual([
+      expect.objectContaining({ from: schema, specifier: null, syntax, typeOnly: false }),
+    ]);
+  });
+
+  it.each(backEdges.filter((edge) => edge.syntax !== "import" && edge.syntax !== "export-from"))(
+    "fails closed for a missing literal $syntax target",
+    ({ text, syntax, typeOnly }) => {
+      const f = fixture();
+      f.append(text.replace("TARGET", "./missing.js"));
+      const result = f.run();
+      rejected(result, "unresolved-module");
+      expect(result.report.graphComplete).toBe(false);
+      expect(result.report.unresolvedEdges).toEqual([
+        expect.objectContaining({ from: schema, specifier: "./missing.js", syntax, typeOnly }),
+      ]);
+    },
+  );
+
+  it.each(["delete", "delete-and-unclassify", "rename"])("cannot satisfy the required leaf after %s", (operation) => {
+    const f = fixture();
+    if (operation === "rename") {
+      const renamed = schema.replace("host-capability-schema.ts", "renamed-schema.ts");
+      renameSync(resolve(f.root, schema), resolve(f.root, renamed));
+      f.policy.files.find((file) => file.path === schema)!.path = renamed;
+    } else {
+      rmSync(resolve(f.root, schema));
+      if (operation === "delete-and-unclassify") f.policy.files = f.policy.files.filter((file) => file.path !== schema);
+    }
+    const result = f.run();
+    rejected(result, "missing-activated-root");
+    expect(result.report.activatedRoots).toContainEqual(
+      expect.objectContaining({
+        layer: "runtime-contracts",
+        visitedEntries: [],
+        modules: operation === "rename" ? 1 : 0,
+      }),
+    );
+  });
+
+  it("rejects malformed canonical source instead of accepting a partial AST", () => {
+    const f = fixture();
+    f.append("export interface Broken { value: ;");
+    const result = f.run();
+    rejected(result, "parse-error");
+    expect(result.report.errors).toContainEqual(
+      expect.objectContaining({ code: "parse-error", detail: expect.stringContaining(schema) }),
+    );
+  });
+
+  it.each([
+    {
+      text: 'export type { Probe } from "../../ir/runtime-host-capabilities.js";',
+      terminal: oldCatalog,
+      code: "forbidden-clean-edge",
+    },
+    {
+      text: 'import type { Probe } from "../../ir/core/boundary-probe.js";',
+      terminal: core,
+      code: "forbidden-clean-edge",
+    },
+    { text: 'void import("../../frontend/ts/boundary-probe.js");', terminal: frontend, code: "forbidden-clean-edge" },
+    {
+      text: "declare const target: string; void import(target);",
+      terminal: "<unknown dependency>",
+      code: "unknown-clean-edge",
+    },
+    { text: 'const missing = require("./missing.js");', terminal: "./missing.js", code: "unresolved-module" },
+  ])("follows a permitted peer barrel to forbidden or incomplete dependency $terminal", ({ text, terminal, code }) => {
+    const f = fixture();
+    f.append('export * from "./boundary-probe.js";');
+    f.addBarrel(text);
+    const result = f.run();
+    rejected(result, code);
+    expect(result.report.edges).toContainEqual(expect.objectContaining({ from: schema, to: barrel }));
+    expect(result.report.transitiveViolations).toContainEqual(
+      expect.objectContaining({ from: schema, path: [schema, barrel, terminal] }),
+    );
+  });
+
+  it("does not let IR core reach runtime contracts through an otherwise allowed foundation barrel", () => {
+    const f = fixture();
+    f.put(core, 'export * from "../../shared/contracts/boundary-probe.js";');
+    f.put(
+      foundation,
+      'export type { RuntimeHostCapabilityId } from "../../runtime/contracts/host-capability-schema.js";',
+    );
+    const result = f.run();
+    rejected(result, "forbidden-transitive-path");
+    expect(result.report.transitiveViolations).toContainEqual(
+      expect.objectContaining({ from: core, path: [core, foundation, schema], typeOnly: true }),
+    );
+  });
+});

--- a/tests/issue-3518-capability-schema-seam.test.ts
+++ b/tests/issue-3518-capability-schema-seam.test.ts
@@ -1,0 +1,403 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import * as schema from "../src/runtime/contracts/host-capability-schema.js";
+import * as catalog from "../src/ir/runtime-host-capabilities.js";
+import { ASYNC_HOST_CAPABILITY_RECORDS, asAsyncHostAdapter } from "../src/ir/async-runtime-providers.js";
+
+const root = resolve(import.meta.dirname, "..");
+const schemaPath = "src/runtime/contracts/host-capability-schema.ts";
+const oldPath = "src/ir/runtime-host-capabilities.ts";
+const read = (path: string) => readFileSync(resolve(root, path), "utf8");
+const digest = (text: string) => createHash("sha256").update(text).digest("hex");
+
+// Exact declaration + attached documentation receipts measured from
+// 16498efb481cb022ee5c4dcc9bb137b6d4c91a50, source blob
+// a6e1ddb276407b25677b3a69a006f6470d89589c. No historical git object is needed
+// at test time. Deliberate future schema changes must review these receipts.
+const declarationHashes = {
+  RUNTIME_HOST_CAPABILITY_FUNC_IDS: "e306259b714b4c39b829dc697d28f42b14801f123ee62d038b9dd0a06729a2f9",
+  RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS: "aae1710f5cfdf266b5d2c3d3b9daddc2d3da20e7949c7fc5aa6c3c723526a181",
+  RUNTIME_HOST_CAPABILITY_GLOBAL_IDS: "05a13450c6caa7c600202a1ab1ac7e36ff248f32e657d03dbd30f47a340835bf",
+  RUNTIME_HOST_CAPABILITY_EXPORT_IDS: "640d5cd0bd3926c3df7b2b6f67d03723f030338159d44bfd5c91d6e0236880e1",
+  RuntimeHostCapabilityFuncId: "48db2d2c4af7a4f7102f7cb18149bb27d174367b4557a8d6039651116183cd5d",
+  RuntimeHostCapabilityFuncFamilyId: "a5c782c60bb3f65a96534c47f47513b80eb7d8c176317879b07d01b160836a17",
+  RuntimeHostCapabilityGlobalId: "1ce1a0ef94bffd77a54015d6a95eded60101541f6854daf6db2a4f97fb97a671",
+  RuntimeHostCapabilityExportId: "87d786f538c0fcf39a098f0ccd66292d79b7edfaef94231db33eb6f666220947",
+  RuntimeHostCapabilityId: "a8089d35683016485af2a6e31a38914545fa1a2f4ecf4820c5ff9399ee905dd6",
+  RUNTIME_HOST_CAPABILITY_IDS: "cdc4d7e0897336ae642b720f90ab33c1dc9c5cd125f63c8a5883644218fe88ae",
+  RuntimeHostCapabilityValueType: "97523d5901898db97cc21824dd0b129b8a1c2ecf0ba3b6b9f692f4e000386cb8",
+  RUNTIME_HOST_CAPABILITY_FUNC_MODULES: "2a34df0165f7271e686eedeb9a61138e53817dec5737278e6017d2e0ad82d53c",
+  RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES: "0689f54dfdb29eed6a5c8b270163aa853e1494094d750a26ae13865839f740cf",
+  RuntimeHostCapabilityFuncModule: "8332b654be7750990d3f496ec2ab1f3b6c7aff92cca05acbfbf0f1b709feb2fe",
+  RuntimeHostCapabilityGlobalModule: "9e8d7706526f45bfb1a3117b5a096b6c3f870a428cc9927493dcb74e7e357a5d",
+  RUNTIME_HOST_CAPABILITY_KINDS: "9b5c1784abe1923af34f589cf188d8b36528428face91df25b7043e1d21e39d9",
+  RuntimeHostCapabilityKind: "74ae7c6d67e7f37f3a11b37e3abf4e5d62c55d34ef7f99e1b5cf7725364bd031",
+  RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES: "7fda2f265e09d4e2a5e94a52b922ca53a829ee4ffd049a8018cef9ebf18aa582",
+  RuntimeHostCapabilityFieldScheme: "cd73f2faf966a8daa86151d4368739932ab6bb959b50443252bd9a8fda953b6d",
+  RuntimeHostCapabilityGlobalField: "1c34ffadfe56163e28d1e208752b940f63f82279000aa60e6cb8aa96417e166a",
+  RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES: "a86918d09fe7240bf3b391cdcde4bebefd01b82ac018b0f5e1c4ae62645b62c0",
+  RuntimeHostCapabilityFuncFamilyFieldScheme: "73c2bf844bf571e7168fc089254f92f3ee9e6625dca06f7a2d05d5a1e12b6076",
+  RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS: "ec316299abf542507c0b72e027abe1b429a67d574c609e06d3e3daeb12f1dd45",
+  RuntimeHostCapabilityExportPublication: "1e4f1c9efa0421b177680cbcae8010976e1a3db9019f9c5880412a4dcf5e2a1a",
+  RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS: "bb2ad1f116576f77e807e575c97ec7fa42fb2eaa65349a3a77948a55e3e96a01",
+  RuntimeHostCapabilityHostSelectionEnvVar: "4d20d24c468bfd250bfe31c0ecdab0291c1a646563838a818f28a82022e7ba1f",
+  RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS: "45b30bbc520fb7d1c3b2342a9a673a6e9a3c9ee42ce6abd5a5409ef30a1981cb",
+  RuntimeHostCapabilityHostSelectionCondition: "b7f9a283196976bbb35c7074088203f948c797f9584dfab0aef98c22445a4fa2",
+  RuntimeHostCapabilityHostSelection: "5c3dc2789cc8d2745c7ee94082cf81e8c3bc87c01998186d91a02d29f191f547",
+  RuntimeHostCapabilityFuncFamilyField: "4c6981f6f8257ae9a705af1be15402d5fcd4cbd240f561cc840aff78f7350c51",
+  RuntimeHostCapabilityFuncFamilyParams: "9286d7dfef0383cf51e007b1c9a700907866ddb798c56a1148678bce82ffa978",
+  HOST_CALLBACK_EXCEPTION_POLICY: "b6ba839ae9332d763dce717df72b5b5c73eafc0d24e951b607d1950251e83bac",
+  HostCallbackExceptionPolicy: "d9de2f8e8440a1938fb034d72d709a9110dcfb2ac98c9eab7426e6bf4d157ded",
+  RuntimeHostCapabilityFuncRecord: "6b854fa968280a81b1c0510f0544d2081ff20e910f6ccecda8d073d3de01a90c",
+  RuntimeHostCapabilityGlobalRecord: "3cf65a1e352c9c554b9bcbc7543375b456a07b46a31049dcd7eea486e9d94394",
+  RuntimeHostCapabilityFuncFamilyRecord: "f7a66a84124df67619e7752211251103d17a6ff9a76d3e67caee6509ca960923",
+  RuntimeHostCapabilityExportRecord: "56bcb96599e24427cc080066039216b0dabfd42400a5e680b408e80ce48f042c",
+  RuntimeHostCapabilityRecord: "62877aa9d1f465377294246678e44ec550bb58c9a078cd0d699dd06e0a315c09",
+  ResolvedRuntimeHostCapabilityFuncFamilyRow: "ab6c9212fc12c9641855229ffd7b7451b8ac86afe8f9d47338e753418b40af64",
+} as const;
+const typeNames = [
+  "RuntimeHostCapabilityFuncId",
+  "RuntimeHostCapabilityFuncFamilyId",
+  "RuntimeHostCapabilityGlobalId",
+  "RuntimeHostCapabilityExportId",
+  "RuntimeHostCapabilityId",
+  "RuntimeHostCapabilityValueType",
+  "RuntimeHostCapabilityFuncModule",
+  "RuntimeHostCapabilityGlobalModule",
+  "RuntimeHostCapabilityKind",
+  "RuntimeHostCapabilityFieldScheme",
+  "RuntimeHostCapabilityGlobalField",
+  "RuntimeHostCapabilityFuncFamilyFieldScheme",
+  "RuntimeHostCapabilityExportPublication",
+  "RuntimeHostCapabilityHostSelectionEnvVar",
+  "RuntimeHostCapabilityHostSelectionCondition",
+  "RuntimeHostCapabilityHostSelection",
+  "RuntimeHostCapabilityFuncFamilyField",
+  "RuntimeHostCapabilityFuncFamilyParams",
+  "RuntimeHostCapabilityFuncRecord",
+  "RuntimeHostCapabilityGlobalRecord",
+  "RuntimeHostCapabilityFuncFamilyRecord",
+  "RuntimeHostCapabilityExportRecord",
+  "RuntimeHostCapabilityRecord",
+  "HostCallbackExceptionPolicy",
+  "ResolvedRuntimeHostCapabilityFuncFamilyRow",
+] as const;
+const constantNames = [
+  "RUNTIME_HOST_CAPABILITY_FUNC_IDS",
+  "RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS",
+  "RUNTIME_HOST_CAPABILITY_GLOBAL_IDS",
+  "RUNTIME_HOST_CAPABILITY_EXPORT_IDS",
+  "RUNTIME_HOST_CAPABILITY_IDS",
+  "RUNTIME_HOST_CAPABILITY_FUNC_MODULES",
+  "RUNTIME_HOST_CAPABILITY_GLOBAL_MODULES",
+  "RUNTIME_HOST_CAPABILITY_KINDS",
+  "RUNTIME_HOST_CAPABILITY_FIELD_SCHEMES",
+  "RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_FIELD_SCHEMES",
+  "RUNTIME_HOST_CAPABILITY_EXPORT_PUBLICATIONS",
+  "RUNTIME_HOST_CAPABILITY_HOST_SELECTION_ENV_VARS",
+  "RUNTIME_HOST_CAPABILITY_HOST_SELECTIONS",
+  "HOST_CALLBACK_EXCEPTION_POLICY",
+] as const;
+
+function parse(path: string, text = read(path)) {
+  const file = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true);
+  if ((file as ts.SourceFile & { parseDiagnostics: readonly ts.Diagnostic[] }).parseDiagnostics.length) {
+    throw new Error("malformed source: " + path);
+  }
+  return file;
+}
+
+function declarationName(node: ts.Statement): string | undefined {
+  if (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node) || ts.isFunctionDeclaration(node)) {
+    return node.name?.text;
+  }
+  if (ts.isVariableStatement(node)) return node.declarationList.declarations[0]?.name.getText();
+  return undefined;
+}
+
+function attachedDoc(node: ts.Statement) {
+  return (node as ts.Statement & { jsDoc?: readonly ts.JSDoc[] }).jsDoc?.at(-1);
+}
+
+function declarationText(node: ts.Statement, file: ts.SourceFile) {
+  return file.text.slice(attachedDoc(node)?.pos ?? node.getStart(), node.end);
+}
+
+function verifySchema(text = read(schemaPath)) {
+  const file = parse(schemaPath, text);
+  const types = file.statements.filter((node) => ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node));
+  const constants = file.statements.filter(ts.isVariableStatement);
+  expect(types.map(declarationName).sort()).toEqual([...typeNames].sort());
+  expect(constants.map(declarationName).sort()).toEqual([...constantNames].sort());
+  expect(file.statements).toHaveLength(39);
+  expect(types).toHaveLength(25);
+  expect(constants).toHaveLength(14);
+  for (const node of file.statements) {
+    const name = declarationName(node) as keyof typeof declarationHashes;
+    expect(digest(declarationText(node, file)), name).toBe(declarationHashes[name]);
+  }
+  return file;
+}
+
+function typeDiagnostics(source: string) {
+  const fileName = resolve(root, ".tmp/capability-schema-contract.ts");
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    types: [],
+    lib: ["lib.es2022.d.ts"],
+  };
+  const host = ts.createCompilerHost(options);
+  const original = host.getSourceFile.bind(host);
+  host.getSourceFile = (path, languageVersion, onError, shouldCreateNewSourceFile) =>
+    path === fileName
+      ? ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true)
+      : original(path, languageVersion, onError, shouldCreateNewSourceFile);
+  return ts.getPreEmitDiagnostics(ts.createProgram([fileName], options, host));
+}
+
+describe("capability schema relocation", () => {
+  it.each(constantNames)("retains the exact old-path %s binding", (name) => {
+    expect(catalog[name]).toBe(schema[name]);
+    if (Array.isArray(schema[name])) expect(Object.isFrozen(schema[name])).toBe(true);
+  });
+
+  it("contains exactly the original 25 types and 14 constants, without imports or implementation declarations", () => {
+    verifySchema();
+    expect(Object.keys(schema).sort()).toEqual([...constantNames].sort());
+  });
+
+  it.each([
+    [
+      "removed declaration",
+      (text: string) =>
+        text.replace("export type HostCallbackExceptionPolicy = typeof HOST_CALLBACK_EXCEPTION_POLICY;", ""),
+    ],
+    ["changed literal", (text: string) => text.replace('"async.callback.wrap"', '"async.callback.changed"')],
+    ["changed documentation", (text: string) => text.replace("CLOSED source of truth", "different source of truth")],
+    ["extra declaration", (text: string) => text + "\nexport type Extra = string;\n"],
+    ["malformed declaration", (text: string) => text + "\nexport {\n"],
+  ] as const)("rejects a %s in the declaration receipt control", (_name, perturb) => {
+    verifySchema(); // The detector must accept the populated, unmodified source first.
+    expect(() => verifySchema(perturb(read(schemaPath)))).toThrow();
+  });
+
+  it("leaves all 48 catalog/private/function declarations and their documentation unchanged", () => {
+    const file = parse(oldPath);
+    const declarations = file.statements.filter((node) => declarationName(node) !== undefined);
+    expect(declarations).toHaveLength(48);
+    expect(declarations.filter(ts.isFunctionDeclaration)).toHaveLength(28);
+    const rows = declarations.map((node) => [
+      declarationName(node),
+      attachedDoc(node)?.getText() ?? "",
+      node.getText(),
+    ]);
+    expect(digest(JSON.stringify(rows))).toBe("46aa565f9b3ee7ea0c807768e5210d8012d04df69d69cb7a3ffe0e22d18fd724");
+    expect(declarations.map(declarationName)).toContain("RUNTIME_HOST_CAPABILITY_RECORDS");
+    expect(declarations.map(declarationName)).toContain("HOST_CALLBACK_WRAP_CAPABILITY_RECORD");
+    for (const name of [...typeNames, ...constantNames]) {
+      expect(declarations.map(declarationName)).not.toContain(name);
+    }
+    const exports = file.statements.filter(ts.isExportDeclaration);
+    expect(exports).toHaveLength(2);
+    for (const node of exports) {
+      expect(node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier) && node.moduleSpecifier.text).toBe(
+        "../runtime/contracts/host-capability-schema.js",
+      );
+      expect(node.exportClause && ts.isNamedExports(node.exportClause)).toBe(true);
+    }
+  });
+
+  it("loads the import-free schema alone in a fresh process", () => {
+    const script = [
+      "import assert from 'node:assert/strict';",
+      "import { registerHooks } from 'node:module';",
+      "import { realpathSync } from 'node:fs';",
+      "import { relative } from 'node:path';",
+      "import { fileURLToPath } from 'node:url';",
+      "const root = realpathSync(process.cwd()), visited = new Set();",
+      "registerHooks({ resolve(specifier, context, next) {",
+      "  const result = next(specifier, context);",
+      "  if (!result.url.startsWith('file:')) throw Error('forbidden dependency: ' + result.url);",
+      "  const path = relative(root, realpathSync(fileURLToPath(result.url)));",
+      "  if (path !== 'src/runtime/contracts/host-capability-schema.ts') throw Error('forbidden dependency: ' + path);",
+      "  visited.add(path); return result;",
+      "}});",
+      "const schema = await import('./src/runtime/contracts/host-capability-schema.ts');",
+      "assert.equal(schema.RUNTIME_HOST_CAPABILITY_IDS.length, 32);",
+      "assert.equal(Object.isFrozen(schema.RUNTIME_HOST_CAPABILITY_IDS), true);",
+      "await assert.rejects(import('./src/ir/runtime-host-capabilities.ts'), /forbidden dependency:/);",
+      "console.log(JSON.stringify([...visited]));",
+    ].join("\n");
+    const child = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+      cwd: root,
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    expect(child.error).toBeUndefined();
+    expect(child.signal).toBeNull();
+    expect(child.status, child.stderr + child.stdout).toBe(0);
+    expect(JSON.parse(child.stdout)).toEqual([schemaPath]);
+  });
+
+  it("preserves all 32 IDs, their ordering, and the mutually exclusive runtime kind guards", () => {
+    const parts = [
+      [schema.RUNTIME_HOST_CAPABILITY_FUNC_IDS, catalog.isRuntimeHostCapabilityFuncId],
+      [schema.RUNTIME_HOST_CAPABILITY_FUNC_FAMILY_IDS, catalog.isRuntimeHostCapabilityFuncFamilyId],
+      [schema.RUNTIME_HOST_CAPABILITY_GLOBAL_IDS, catalog.isRuntimeHostCapabilityGlobalId],
+      [schema.RUNTIME_HOST_CAPABILITY_EXPORT_IDS, catalog.isRuntimeHostCapabilityExportId],
+    ] as const;
+    expect(parts.map(([ids]) => ids.length)).toEqual([21, 3, 2, 6]);
+    const all = parts.flatMap(([ids]) => [...ids]);
+    expect(new Set(all).size).toBe(32);
+    expect(schema.RUNTIME_HOST_CAPABILITY_IDS).toEqual([...all].sort());
+    for (const id of schema.RUNTIME_HOST_CAPABILITY_IDS) {
+      expect(catalog.isRuntimeHostCapabilityId(id)).toBe(true);
+      expect(parts.filter(([ids]) => (ids as readonly string[]).includes(id))).toHaveLength(1);
+      for (const [ids, guard] of parts) expect(guard(id)).toBe((ids as readonly string[]).includes(id));
+    }
+    expect(catalog.isRuntimeHostCapabilityId("unregistered.capability")).toBe(false);
+    for (const [, guard] of parts) expect(guard("unregistered.capability")).toBe(false);
+  });
+
+  it("keeps the full catalog canonical and rejects structurally exact reconstructed records", () => {
+    const original = catalog.RUNTIME_HOST_CAPABILITY_RECORDS;
+    expect(original).toHaveLength(32);
+    expect(original.map((row) => row.capability)).toEqual(schema.RUNTIME_HOST_CAPABILITY_IDS);
+    expect(Object.isFrozen(original)).toBe(true);
+    const reordered = catalog.canonicalizeRuntimeHostCapabilityCatalog([...original].reverse());
+    expect(Object.isFrozen(reordered)).toBe(true);
+    for (const [index, row] of original.entries()) {
+      expect(Object.isFrozen(row)).toBe(true);
+      expect(reordered[index]).toBe(row);
+      expect(catalog.resolveRuntimeHostCapabilityRecord(original, row.capability)).toBe(row);
+      expect(() => catalog.assertCanonicalRuntimeHostCapabilityRecord(row)).not.toThrow();
+      const rebuilt = { ...row };
+      expect(() => catalog.assertRuntimeHostCapabilityRecord(rebuilt)).not.toThrow();
+      expect(() => catalog.assertCanonicalRuntimeHostCapabilityRecord(rebuilt)).toThrow(
+        "not the canonical catalog record",
+      );
+      expect(() => catalog.resolveRuntimeHostCapabilityRecord([rebuilt], row.capability)).toThrow(
+        "not the canonical catalog record",
+      );
+    }
+    expect(() => catalog.canonicalizeRuntimeHostCapabilityCatalog(original.slice(1))).toThrow("incomplete");
+    expect(() => catalog.canonicalizeRuntimeHostCapabilityCatalog([...original, original[0]])).toThrow("duplicates");
+    expect(catalog.HOST_CALLBACK_WRAP_CAPABILITY_RECORD).toBe(
+      catalog.resolveRuntimeHostCapabilityFuncRecord(original, "async.callback.wrap"),
+    );
+    expect(catalog.HOST_CALLBACK_WRAP_CAPABILITY_RECORD.exceptionPolicy).toBe(schema.HOST_CALLBACK_EXCEPTION_POLICY);
+  });
+
+  it("keeps synthesized family rows distinct and preserves leading parameters, shared results, and arity guards", () => {
+    const records = catalog.RUNTIME_HOST_CAPABILITY_RECORDS;
+    const family = catalog.resolveRuntimeHostCapabilityRecord(records, "callable.host_call.fixed");
+    const concrete = catalog.resolveRuntimeHostCapabilityFuncFamilyRecord(records, "callable.host_call.fixed", 2);
+    expect(concrete).toEqual({
+      module: "env",
+      field: "__call_function_2",
+      params: ["externref", "externref", "externref", "externref"],
+      results: ["externref"],
+    });
+    expect(concrete).not.toHaveProperty("capability");
+    expect(concrete).not.toHaveProperty("kind");
+    expect(family.kind === "func-family" && concrete.results === family.results).toBe(true);
+    expect(Object.isFrozen(concrete)).toBe(true);
+    expect(Object.isFrozen(concrete.params)).toBe(true);
+    expect(() => catalog.assertCanonicalRuntimeHostCapabilityRecord(concrete)).toThrow();
+    expect(() => catalog.resolveRuntimeHostCapabilityFuncFamilyRecord(records, "callable.host_call.fixed", 5)).toThrow(
+      "does not cover arity",
+    );
+    expect(() => catalog.resolveRuntimeHostCapabilityFuncFamilyRecord(records, "string.concat.many", 2)).toThrow(
+      "does not cover arity",
+    );
+    expect(catalog.resolveRuntimeHostCapabilityFuncFamilyRecord(records, "string.concat.many", 9).params).toHaveLength(
+      9,
+    );
+    for (const invalid of [-1, 0.5, NaN, Infinity]) {
+      expect(() =>
+        catalog.resolveRuntimeHostCapabilityFuncFamilyRecord(records, "callable.host_call.fixed", invalid),
+      ).toThrow("does not cover arity");
+    }
+  });
+
+  it("preserves the async projection's eight exact catalog objects and rejects every non-async record", () => {
+    expect(ASYNC_HOST_CAPABILITY_RECORDS).toHaveLength(8);
+    for (const row of catalog.RUNTIME_HOST_CAPABILITY_RECORDS) {
+      if (row.capability.startsWith("async.")) {
+        expect(asAsyncHostAdapter(row)).toBe(row);
+        expect(ASYNC_HOST_CAPABILITY_RECORDS.find((entry) => entry.capability === row.capability)).toBe(row);
+        expect(
+          row.kind === "func" &&
+            [...row.params, ...row.results].every((value) => value === "externref" || value === "i32"),
+        ).toBe(true);
+      } else {
+        expect(() => asAsyncHostAdapter(row)).toThrow("not an async capability");
+      }
+    }
+    expect(() => asAsyncHostAdapter({ ...catalog.HOST_CALLBACK_WRAP_CAPABILITY_RECORD, params: ["f64"] })).toThrow(
+      "cannot carry value type f64",
+    );
+  });
+
+  it("compiles old/new generic compatibility and all four record discriminants, with real negative controls", () => {
+    const source = [
+      "import type * as New from '../src/runtime/contracts/host-capability-schema.js';",
+      "import type * as Old from '../src/ir/runtime-host-capabilities.js';",
+      ...typeNames.map((name) => "{ let old!: Old." + name + "; let next: New." + name + " = old; old = next; }"),
+      "type Narrow = New.RuntimeHostCapabilityFuncRecord<'async.callback.wrap', 'externref' | 'i32'>;",
+      "let narrow!: Narrow; let oldNarrow: Old.RuntimeHostCapabilityFuncRecord<'async.callback.wrap', 'externref' | 'i32'> = narrow; narrow = oldNarrow;",
+      "let all!: New.RuntimeHostCapabilityRecord;",
+      "let func!: New.RuntimeHostCapabilityFuncRecord; all = func;",
+      "let global!: New.RuntimeHostCapabilityGlobalRecord; all = global;",
+      "let family!: New.RuntimeHostCapabilityFuncFamilyRecord; all = family;",
+      "let exported!: New.RuntimeHostCapabilityExportRecord; all = exported;",
+      "let resolved!: New.ResolvedRuntimeHostCapabilityFuncFamilyRow<'externref'>;",
+      "let narrowed!: New.RuntimeHostCapabilityRecord<'number.box', 'f64' | 'externref'>;",
+      "if (narrowed.kind === 'func') { const id: 'number.box' = narrowed.capability; }",
+      "function discriminate(row: New.RuntimeHostCapabilityRecord): string {",
+      " switch (row.kind) {",
+      " case 'func': return row.module + row.field + row.params.length;",
+      " case 'func-family': return row.module + row.field.prefix + row.params.repeat;",
+      " case 'global': return row.module + row.field.scheme + row.valueType;",
+      " case 'export': return row.name + row.alias + row.publication;",
+      " default: { const unreachable: never = row; return unreachable; }",
+      " }}",
+      "// @ts-expect-error a family is not a concrete callable ID",
+      "type BadFamily = New.RuntimeHostCapabilityFuncRecord<'string.concat.many'>;",
+      "// @ts-expect-error global IDs cannot be callables",
+      "type BadGlobal = New.RuntimeHostCapabilityFuncRecord<'string.const'>;",
+      "// @ts-expect-error export IDs cannot be callables",
+      "type BadExport = New.RuntimeHostCapabilityFuncRecord<'callable.export.arity'>;",
+      "// @ts-expect-error value generic stays closed",
+      "type BadValue = New.RuntimeHostCapabilityFuncFamilyParams<'i64'>;",
+      "// @ts-expect-error narrowed async ABI cannot carry f64",
+      "const invalidParams: Narrow['params'] = ['f64'];",
+      "// @ts-expect-error synthesized rows lack canonical identity and kind",
+      "all = resolved;",
+      "// @ts-expect-error export direction has no module namespace",
+      "exported.module;",
+      "// @ts-expect-error the global namespace is not a func namespace",
+      "const moduleName: New.RuntimeHostCapabilityFuncModule = 'string_constants';",
+      "// @ts-expect-error literal field derivation is not an arity derivation",
+      "const fieldScheme: New.RuntimeHostCapabilityFuncFamilyFieldScheme = 'literal';",
+      "// @ts-expect-error host selection is a closed declared condition",
+      "const selection: New.RuntimeHostCapabilityHostSelectionCondition = 'zero';",
+    ].join("\n");
+    const valid = typeDiagnostics(source);
+    expect(valid.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, "\n"))).toEqual([]);
+    const invalid = typeDiagnostics(source.replaceAll("@ts-expect-error", "negative control"));
+    expect(invalid).toHaveLength(10);
+    expect(invalid.every((entry) => entry.category === ts.DiagnosticCategory.Error)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Checkpoint for #3518: extract the complete capability-record schema into `src/runtime/contracts/host-capability-schema.ts`. All 25 types/interfaces and 14 constants retain their exact declarations and documentation. The old module imports/re-exports the same bindings; every function, private lookup, catalog object, validator, resolver and provider choice remains unchanged.

This is an independent checkpoint from `loopdive/js2/main` at `16498efb481cb022ee5c4dcc9bb137b6d4c91a50`, not a stack of the held core/lowering/ABI/startup PRs. Astra High specified/reviewed; Astra Low native subagents implemented disjoint source and tests. The committed implementation plan and issue handoff preserve the other sessions' drafts and describe the next semantic-function/prepared-function boundary.

## Validation

- All 76 new controls pass. The final new-seam/boundary plus existing compiler-boundary run passes 118/118; typecheck passes.
- Across the distinct focused population, 216/217 pass. One existing host-async concat fixture fails identically on untouched main: both sides emit 10,122 bytes, SHA-256 `9cc61132c3cea9c609e93fc3ec5fa85af99e7d17bca888eb457373d3c9fa3450`, 28 function imports with concat5 at index 22. Full binary/WAT/import-order/pool/outcome comparison is equal. Its old 10,021-byte/27-import/index-21 expectations are unchanged. This is not a passing fixture or a fix of its prior mismatch.
- All 39 moved plus 48 retained declarations (including all 28 functions) are text-identical. Net source +100 LOC; no budget allowance or baseline changes.
- Three public standalone WasmGC programs preserve full bytes, WAT, descriptors/order, pools, IR outcomes and twice-executed results, with zero Wasm imports. Two complete async manifests and all 32 canonical catalog records also match.
- Compiler inventory passes: 1,245 modules, seven clean, two compatibility adapters, 1,236 still unmigrated; 9,751 resolved edges, four explicit unknowns. Only the exact new leaf is activated; no allowed-edge changes.
- Existing N1 preservation retains six full/cut witnesses and the unchanged 25-entry legacy baseline. Strict closure still fails on the same two dynamic imports; full architecture completion still fails. No local Test262 or broad conformance run.

## Merge hold and handoff

Non-draft, deliberately `hold`. Do not enqueue or remove the hold on green PR-head CI alone. The inherited N1 host-regression/merge-queue-safety decision remains open, along with the separate ABI caller decision. The pre-existing local async fixture mismatch remains documented and unmodified.

No new host/linear implementation, provider-selection change, CI/workflow/ruleset change, direct-codegen retirement, public cutover, force push or direct-main push. The full prepared-function/semantic-function split still requires its reader/mutator/pass/codec map; this schema extraction does not allow core to import upward into runtime contracts.

Implementation plan: `plan/agent-context/3518-capability-schema-checkpoint-plan-2026-09-08.md`.
Handoff: `plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md`.
