### PR TITLE
fix(codegen): preserve conditional alias property writes (#5386)

### DIFF
--- a/plan/issues/5386-conditional-alias-property-write-widening.md
+++ b/plan/issues/5386-conditional-alias-property-write-widening.md
@@ -1,0 +1,107 @@
+---
+id: 5386
+title: "Preserve property type changes through conditional object aliases"
+status: in-review
+sprint: current
+created: 2026-09-08
+updated: 2026-09-08
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: compiler
+language_feature: objects
+goal: correctness
+assignee: "ttraenkler/codex-alias"
+# 2026-09-08: small hooks in existing collectors, local registration, console,
+# addition, and identifier reads propagate one declaration-scoped property
+# widening fact. The traversal lives in strict-eq-stale-type.ts and the new
+# widened-property-return.ts helper; a broader driver split is outside this fix.
+loc-budget-allow:
+  - src/codegen/declarations/object-shape-widening.ts
+  - src/codegen/index.ts
+  - src/codegen/binary-ops.ts
+  - src/codegen/declarations.ts
+  - src/codegen/expressions/builtins.ts
+  - src/codegen/statements/variables.ts
+  - src/codegen/declarations/import-collector.ts
+  - src/codegen/expressions/identifiers.ts
+func-budget-allow:
+  - src/codegen/binary-ops.ts::compileBinaryExpression
+  - src/codegen/declarations.ts::collectDeclarations
+  - src/codegen/declarations/import-collector.ts::unifiedVisitNode
+  - src/codegen/expressions/identifiers.ts::compileIdentifierCore
+---
+
+## Problem
+
+A property write through an alias selected by a conditional must update the
+original object, including when the write changes the property's runtime type.
+The locally built js2wasm compiler accepts this program but prints `NaN`:
+
+```js
+const a = { x: 1 };
+const b = true ? a : { x: "" };
+b.x = "x";
+console.log(a.x + 1); // Must print: x1
+```
+
+Node.js 24.4.1 prints `x1`. The local js2wasm `dist` build, compiled with
+`target: "node"` and run under Node, prints `NaN`. This initial observation is
+from the existing build; source-level baseline and fix evidence will be recorded
+below. The isolated fix starts at `16498efb481cb0`.
+
+For comparison, scriptc 0.0.36 refuses line 3 with SC1090,
+`assignment to non-variables are not supported yet`. Fixing that separate
+compiler is outside this issue.
+
+## Acceptance criteria
+
+- [x] The exact program compiles and prints `x1` using the current source compiler.
+- [x] Regression tests verify reads through the original binding after writes
+      through conditional aliases, including a runtime-selected condition.
+- [x] Numeric-only object writes retain correct arithmetic behavior.
+- [x] Relevant existing property-widening and alias tests show no new failures
+      against the clean baseline (see the pre-existing failure below).
+
+## Implementation and validation
+
+The property-write prepass records writes to each declaration behind a union
+receiver. Incompatible primitive writes invalidate the old numeric/string field
+type without widening unrelated objects that happen to use the same property
+name. Existing field registration selects the dynamic storage carrier.
+
+A shared expression predicate preserves that fact through property reads,
+addition, and unannotated initializer aliases. Addition, local/global storage,
+identifier reads, inferred function return slots, equality, and console imports
+use it to avoid coercing the live value back to the old checker type. Both console
+import collection and emission choose the same existing dynamic-value import.
+The standalone path uses its existing native addition and output sink.
+
+This is declaration-scoped propagation, not general escape/interprocedural
+analysis. Indirect call-result inference and arbitrary reassignment/destructuring
+flows are not newly covered.
+
+### Validation
+
+- Clean source baseline `16498efb481cb0`: the exact top-level program prints
+  `NaN`; candidate prints `x1` with default JS-host options on Node 24.4.1.
+- Candidate standalone compiles the exact program with zero imports and its
+  output sink contains `x1\n`.
+- Existing suites: `issue-2953-unions-boxing`, `issue-2984-alias-receivers`,
+  `union-narrowing`, and `equivalence/empty-object-widening`: 25/26 pass.
+  The nested-scope shadow guard in `issue-2984-alias-receivers` returns 3 where
+  it expects 1, identically on candidate and clean baseline (6/7 in that suite).
+- New regression suites: 12/12 pass on the candidate. On clean baseline,
+  the first 11 cases have 8 failures and 3 passing controls; the subsequently
+  added same-instance true/false case also fails (`[NaN, 2]` vs `["x1", 2]`).
+- Type checking and lint pass. LOC/function budgets pass with the scoped
+  integration allowances above; oracle and coercion checks report zero growth.
+- `check:dead-exports` exits 0 but reports the same pre-existing open graph on
+  clean baseline and candidate: nonliteral dynamic imports in `optimize.ts`
+  and `runtime/platform-capability-adapter.ts`. No deletion is certified.
+- The coercion gate was invoked through a space-free symlink with Node's
+  preserve-symlinks flags so it actually inspected this worktree; its direct
+  invocation misreads the URL-encoded space in the checkout path and falls back
+  to an unscoped baseline check.

--- a/plan/issues/5386-conditional-alias-property-write-widening.md
+++ b/plan/issues/5386-conditional-alias-property-write-widening.md
@@ -105,3 +105,17 @@ flows are not newly covered.
   preserve-symlinks flags so it actually inspected this worktree; its direct
   invocation misreads the URL-encoded space in the checkout path and falls back
   to an unscoped baseline check.
+
+### PR #5746 CI follow-up
+
+The first CI run passed all eight equivalence shards and the equivalence gate,
+issue tests, linear tests, and smoke tests. Its quality job stopped at compiler
+inventory validation: the new `widened-property-return.ts` helper was absent
+from the compiler boundary inventory.
+
+Registered that helper as `unmigrated` / `mixed-needs-split`, destined for
+`backend-wasmgc`. The remaining separation is AST-based alias evidence versus
+physical return-carrier selection; this entry does not claim an activated
+architecture boundary. The inventory check against the preceding commit now
+reports `inventory-valid-architecture-incomplete` with zero errors. No runtime
+code, conformance baseline, or equivalence baseline changed.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -2429,6 +2429,14 @@
       "nextBoundary": "Separate AST/context-driven generation, physical resources and generated native runtime."
     },
     {
+      "path": "src/codegen/declarations/widened-property-return.ts",
+      "state": "unmigrated",
+      "layer": "mixed-needs-split",
+      "destination": "backend-wasmgc",
+      "owner": "5386-alias-property-writes",
+      "nextBoundary": "Separate AST-based alias evidence from physical return-carrier selection."
+    },
+    {
       "path": "src/codegen/declarations/with-body-var-hoisting.ts",
       "state": "unmigrated",
       "layer": "mixed-needs-split",

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -4,6 +4,7 @@
  * Handles binary expression compilation including numeric, i32, i64,
  * bitwise, modulo, boolean, and any-typed binary operations.
  */
+import { expressionHasWidenedPropertyType } from "./strict-eq-stale-type.js";
 import { ts } from "../ts-api.js";
 import type { TypeFact } from "../checker/oracle.js";
 import {
@@ -668,10 +669,14 @@ export function compileBinaryExpression(
   // ToPrimitive; sending that operand through the ordinary numeric hint would
   // eagerly apply ToNumber and turn `(function (x) { return x + arguments[1] })
   // (1, "1")` into `2` instead of `"11"`.
+  // The same rule applies to properties widened after writes through an
+  // object alias: their checker type still describes the original value.
   if (
     op === ts.SyntaxKind.PlusToken &&
     [expr.left, expr.right].some(
-      (operand) => ts.isIdentifier(operand) && fctx.rawArgumentsParamNames?.has(operand.text),
+      (operand) =>
+        (ts.isIdentifier(operand) && fctx.rawArgumentsParamNames?.has(operand.text)) ||
+        expressionHasWidenedPropertyType(ctx, operand),
     )
   ) {
     return emitAnyAdd(ctx, fctx, expr);

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2352,7 +2352,7 @@ export interface CodegenContext extends StandaloneCapabilityDemandState, BodyRou
   objectLiteralAssignedPropertyNames: Set<string>;
   /** Concrete RHS types observed for those property writes. */
   objectLiteralAssignedPropertyTypes: Map<string, ts.Type[]>;
-  /** Concrete RHS types observed for statically-resolved indexed properties. */
+  /** Concrete RHS types for indexed properties and union-receiver property declarations. */
   objectLiteralIndexedAssignedPropertyTypes: Map<ts.Declaration, ts.Type[]>;
   /**
    * (#2674) Property names that need a deferred-fill member-READ dispatcher

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -5,6 +5,8 @@
  *
  * Extracted from codegen/index.ts (#1013).
  */
+import { expressionHasWidenedPropertyType } from "./strict-eq-stale-type.js";
+import { functionReturnsWidenedProperty } from "./declarations/widened-property-return.js";
 import { ts, forEachChild } from "../ts-api.js";
 import {
   isBigIntType,
@@ -1829,15 +1831,15 @@ function registerBodylessFunctionDeclaration(
     }
     const rUnwrapped = isAsync ? unwrapPromiseType(retType, ctx.checker) : retType;
     const isImplicitAnyReturn = (rUnwrapped.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
-    const withScopedReturn = functionReturnsThroughWithScope(ctx, stmt);
-    const inferredNumericRet = withScopedReturn
+    const dynamicReturn = functionReturnsThroughWithScope(ctx, stmt) || functionReturnsWidenedProperty(ctx, stmt);
+    const inferredNumericRet = dynamicReturn
       ? null
       : inferredNumericResultType(ctx, name, isAsync, isImplicitAnyReturn, params);
     if (inferredNumericRet) {
       results = [inferredNumericRet];
-    } else if (withScopedReturn) {
-      // The checker's return type came from the SHADOWED outer binding; the real
-      // value is whatever the `with` receiver holds. Carry it as `any`.
+    } else if (dynamicReturn) {
+      // A routed or alias-mutated value can differ from the checker's
+      // inferred return type. Preserve its runtime tag.
       results = [{ kind: "externref" }];
     } else {
       results = isVoidType(rUnwrapped)
@@ -2956,19 +2958,18 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
         // return type if every param is numeric and the body is a pure
         // numeric kernel (catches e.g. recursive `function fib(n) {...}`).
         const isImplicitAnyReturn = (rUnwrapped.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
-        const withScopedReturn = functionReturnsThroughWithScope(ctx, stmt);
+        const dynamicReturn = functionReturnsThroughWithScope(ctx, stmt) || functionReturnsWidenedProperty(ctx, stmt);
         const preInitVarReturn = functionReturnsPreInitVarValue(ctx, stmt);
-        const inferredNumericRet = withScopedReturn
+        const inferredNumericRet = dynamicReturn
           ? null
           : inferredNumericResultType(ctx, name, isAsync, isImplicitAnyReturn, params);
         if (nativeTaViewReturn !== null) {
           results = [nativeTaViewReturn];
         } else if (inferredNumericRet) {
           results = [inferredNumericRet];
-        } else if (withScopedReturn || preInitVarReturn) {
-          // See `functionReturnsThroughWithScope`: the checker resolved the
-          // returned name against the SHADOWED outer binding, so the inferred
-          // type describes the wrong value. Carry it as `any`.
+        } else if (dynamicReturn || preInitVarReturn) {
+          // Routed, pre-init and alias-mutated values can disagree with the
+          // checker's inferred return type. Preserve the runtime value.
           results = [{ kind: "externref" }];
         } else {
           results = isVoidType(rUnwrapped)
@@ -3477,6 +3478,9 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
    * let/const pass so both scopes register the same type.
    */
   function moduleGlobalWasmType(decl: ts.VariableDeclaration, varType: ts.Type): ValType {
+    if (decl.initializer && !decl.type && expressionHasWidenedPropertyType(ctx, decl.initializer)) {
+      return { kind: "externref" };
+    }
     if (proxyOrTransferredResultNeedsExternref(ctx, decl)) return { kind: "externref" };
     // A host builtin static read (`Date.now`, `Object.hasOwn`, …) is a genuine
     // JS function, not a Wasm closure struct.  Conditional/short-circuit

--- a/src/codegen/declarations/import-collector.ts
+++ b/src/codegen/declarations/import-collector.ts
@@ -59,6 +59,7 @@ import { emitNativeUriDecode, emitNativeUriEncode } from "../uri-encoding-native
 import type { ValType } from "../../ir/types.js";
 import type { CodegenContext } from "../context/types.js";
 import { registerImportCollectorDelegates } from "../registry/import-collector-delegates.js";
+import { expressionHasWidenedPropertyType } from "../strict-eq-stale-type.js";
 
 /** Accumulated state for the single-pass collector */
 export interface UnifiedCollectorState {
@@ -471,7 +472,9 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
       const needed = state.consoleNeededByMethod.get(method)!;
       for (const arg of node.arguments) {
         const argType = ctx.checker.getTypeAtLocation(arg);
-        if (isStringType(argType)) {
+        if (expressionHasWidenedPropertyType(ctx, arg)) {
+          needed.add("externref");
+        } else if (isStringType(argType)) {
           needed.add("string");
         } else if (isBooleanType(argType)) {
           needed.add("bool");

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -4,6 +4,7 @@
  * Runs before collectDeclarations so struct/vec types register with the right
  * fields. Extracted verbatim from codegen/declarations.ts (#3268).
  */
+import { markIndexedPropertyStale } from "../strict-eq-stale-type.js";
 import { collectShapes } from "../../shape-inference.js";
 import { forEachChild, getTypeAtLocationBounded, ts } from "../../ts-api.js";
 import { resolveWasmType } from "../index.js";
@@ -185,7 +186,25 @@ export function collectObjectLiteralAssignedPropertyNames(ctx: CodegenContext, s
           writes.push(rhsType);
           ctx.objectLiteralIndexedAssignedPropertyTypes.set(indexedProperty, writes);
         }
-      } else if (mayCarryObject && ts.isPropertyAccessExpression(node.left)) {
+      }
+      if (ts.isPropertyAccessExpression(node.left)) {
+        // A union receiver can alias an object whose own property type is
+        // narrower than the union. Preserve writes on each constituent's
+        // declaration, rather than trusting that narrower checker type.
+        if (ctx.oracle.unionPartsOf(node.left.expression)) {
+          for (const declaration of ctx.oracle.declarationsOf(node.left.name)) {
+            const writes = ctx.objectLiteralIndexedAssignedPropertyTypes.get(declaration) ?? [];
+            writes.push(rhsType);
+            ctx.objectLiteralIndexedAssignedPropertyTypes.set(declaration, writes);
+            const seed = ctx.oracle.typeFactOf(declaration).kind;
+            const written = ctx.oracle.typeFactOf(rhs).kind;
+            if (["number", "string", "boolean", "bigint", "symbol"].includes(seed) && seed !== written) {
+              markIndexedPropertyStale(ctx, declaration);
+            }
+          }
+        }
+      }
+      if (mayCarryObject && ts.isPropertyAccessExpression(node.left)) {
         const name = node.left.name.text;
         ctx.objectLiteralAssignedPropertyNames.add(name);
         const writes = ctx.objectLiteralAssignedPropertyTypes.get(name) ?? [];

--- a/src/codegen/declarations/widened-property-return.ts
+++ b/src/codegen/declarations/widened-property-return.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts, forEachChild } from "../../ts-api.js";
+import type { CodegenContext } from "../context/types.js";
+import { expressionHasWidenedPropertyType } from "../strict-eq-stale-type.js";
+
+/** A return inferred from an alias-mutated property needs its runtime carrier. */
+export function functionReturnsWidenedProperty(ctx: CodegenContext, fn: ts.FunctionDeclaration): boolean {
+  if (!fn.body || fn.type || ctx.objectLiteralIndexedAssignedPropertyTypes.size === 0) return false;
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found || ts.isFunctionLike(node)) return;
+    if (ts.isReturnStatement(node) && node.expression && expressionHasWidenedPropertyType(ctx, node.expression)) {
+      found = true;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  visit(fn.body);
+  return found;
+}

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -26,6 +26,7 @@ import { emitThrowRangeError, emitThrowTypeError } from "./helpers.js";
 import { isStaticNaN, tryStaticToNumber } from "./misc.js";
 import { sourceOverridesMethodOnReceiver } from "./member-override-scan.js";
 import { objectCoercionPreservesDate } from "../object-ctor-primitive-receiver.js";
+import { expressionHasWidenedPropertyType } from "../strict-eq-stale-type.js";
 
 // ── Builtins ─────────────────────────────────────────────────────────
 
@@ -83,8 +84,11 @@ function compileConsoleCall(
 
   for (const arg of expr.arguments) {
     const argType = ctx.checker.getTypeAtLocation(arg);
+    // An alias write can invalidate the checker type; match the collector
+    // and preserve the runtime value through the externref console import.
+    const stale = expressionHasWidenedPropertyType(ctx, arg);
 
-    if (isStringType(argType)) {
+    if (!stale && isStringType(argType)) {
       compileExpression(ctx, fctx, arg);
       // Fast mode: flatten + marshal native string to externref before passing to host
       if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
@@ -103,7 +107,7 @@ function compileConsoleCall(
       if (funcIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx });
       }
-    } else if (isBooleanType(argType)) {
+    } else if (!stale && isBooleanType(argType)) {
       // (#2788) Coerce the argument to the console import's param ValType (i32).
       // The static-type-selected variant fixes the import signature; passing the
       // expected ValType makes compileExpression reconcile any mismatch (e.g. a
@@ -113,7 +117,7 @@ function compileConsoleCall(
       if (funcIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx });
       }
-    } else if (isNumberType(argType)) {
+    } else if (!stale && isNumberType(argType)) {
       // (#2788) Coerce to f64 — fixes `console.log(a[i])` where the bounds-checked
       // element read (#2760) widened a `number[]` element to an `externref`
       // (OOB→undefined) but the `console_${method}_number` import expects f64.

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -2,6 +2,7 @@
 /**
  * Identifier resolution, TDZ analysis, and instanceof handling.
  */
+import { expressionHasWidenedPropertyType } from "../strict-eq-stale-type.js";
 import { ts, forEachChild } from "../../ts-api.js";
 import {
   getNullablePrimitiveInfo,
@@ -1325,7 +1326,8 @@ function compileIdentifierCore(
       !fctx.undefWidenedLocals?.has(name) &&
       !fctx.forInIdentifierVars?.has(name) &&
       !fctx.mixedAssignmentCarrierVars?.has(name) &&
-      !mappedExternrefParam
+      !mappedExternrefParam &&
+      !expressionHasWidenedPropertyType(ctx, id)
     ) {
       const narrowedType = ctx.checker.getTypeAtLocation(id);
       const narrowed = narrowTypeToUnbox(ctx, fctx, narrowedType);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -174,7 +174,7 @@ import {
   removeMultiIrAttemptedCallableUnits,
 } from "./multi-prepared-callable-orchestration.js";
 import { createCodegenContext } from "./context/create-context.js";
-import { markIndexedPropertyStale } from "./strict-eq-stale-type.js";
+import { expressionHasWidenedPropertyType, markIndexedPropertyStale } from "./strict-eq-stale-type.js";
 import { ProgramAbiSession, type PublishedProgramAbi } from "./program-abi-session.js";
 import { sourceFunctionHandleForDeclaration } from "./program-abi-source-callable-planning.js";
 import { stripHostBridgeExports } from "./host-bridge-exports.js";
@@ -13932,7 +13932,11 @@ function hoistVarDecl(
     // mixed-assignment demotion does not — a positive unboxing proof outranks
     // it (see `numericProofOverridesMixedCarrier`).
     const hardForcesExternref =
-      initForcesExternref || realmStructuralCarrier || forInTargetForcesExternref || transferredArrayLikeResult;
+      initForcesExternref ||
+      realmStructuralCarrier ||
+      forInTargetForcesExternref ||
+      transferredArrayLikeResult ||
+      (!!decl.initializer && !decl.type && expressionHasWidenedPropertyType(ctx, decl.initializer));
     const usageF64 = hardForcesExternref
       ? null
       : mixedAssignmentCarrier
@@ -14740,7 +14744,10 @@ function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: t
           ? numericProofOverridesMixedCarrier(usageInferredLocalType(ctx, decl))
           : null;
         const carrierForcesExternref =
-          initForcesExternref || realmStructuralCarrier || (mixedAssignmentCarrier && !mixedCarrierProvenF64);
+          initForcesExternref ||
+          realmStructuralCarrier ||
+          (mixedAssignmentCarrier && !mixedCarrierProvenF64) ||
+          (!!decl.initializer && !decl.type && expressionHasWidenedPropertyType(ctx, decl.initializer));
         // (#4616) Empty-array (or Array<any>) initializer: use the SAME
         // usage-based vec inference `compileVariableStatement` applies
         // (`inferArrayVecType`, mirroring the var hoister above). Without it

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -2,6 +2,7 @@
 /**
  * Variable declaration statement lowering.
  */
+import { expressionHasWidenedPropertyType } from "../strict-eq-stale-type.js";
 import { ts, forEachChild } from "../../ts-api.js";
 import { isNullablePrimitiveType, isStringType, isVoidType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
@@ -875,6 +876,9 @@ export function usageInferredLocalType(ctx: CodegenContext, decl: ts.VariableDec
 }
 
 function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type, decl?: ts.VariableDeclaration): ValType {
+  if (decl?.initializer && !decl.type && expressionHasWidenedPropertyType(ctx, decl.initializer)) {
+    return { kind: "externref" };
+  }
   // (#3673) Explicit native type annotation — `let x: i32` where
   // `type i32 = number`; the annotation node is the only surviving evidence.
   // It is a user assertion and outranks every inference below it.

--- a/src/codegen/strict-eq-stale-type.ts
+++ b/src/codegen/strict-eq-stale-type.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * Runtime-carrier guards for strict equality operands whose checker type is
- * stale after an indexed object-literal write.
+ * Runtime-carrier guards for expressions whose checker type is stale after
+ * an indexed or union-alias object property write. Arithmetic, storage and
+ * output consumers must preserve that value until the actual JS operation.
  */
 import { ts } from "../ts-api.js";
 import { moduleGlobalIsDynamicButStaticallyPrimitive } from "./declarations/heterogeneous-scalar-var-widening.js";
@@ -18,17 +19,30 @@ export function markIndexedPropertyStale(ctx: CodegenContext, property: ts.Decla
   stale.add(property);
 }
 
-/** Whether equality must inspect the runtime carrier instead of checker type. */
-export function equalityOperandHasStaleStaticType(
+/** Whether a value derives from a property whose carrier was widened. */
+export function expressionHasWidenedPropertyType(
   ctx: CodegenContext,
-  fctx: FunctionContext,
   expr: ts.Expression,
+  seen?: Set<ts.Node>,
 ): boolean {
-  if (
-    ts.isIdentifier(expr) &&
-    (fctx.forInIdentifierVars?.has(expr.text) === true || moduleGlobalIsDynamicButStaticallyPrimitive(ctx, expr))
-  ) {
-    return true;
+  if (!indexedStaleProperties.get(ctx)?.size) return false;
+  seen ??= new Set<ts.Node>();
+  if (seen.has(expr)) return false;
+  seen.add(expr);
+  while (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || ts.isNonNullExpression(expr)) {
+    expr = expr.expression;
+  }
+  if (ts.isBinaryExpression(expr) && expr.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    return (
+      expressionHasWidenedPropertyType(ctx, expr.left, seen) || expressionHasWidenedPropertyType(ctx, expr.right, seen)
+    );
+  }
+
+  if (ts.isIdentifier(expr) && ctx.objectLiteralIndexedAssignedPropertyTypes.size > 0) {
+    const declaration = ctx.oracle.valueDeclarationOf(expr);
+    if (declaration && ts.isVariableDeclaration(declaration) && !declaration.type && declaration.initializer) {
+      return expressionHasWidenedPropertyType(ctx, declaration.initializer, seen);
+    }
   }
 
   let key: string | undefined;
@@ -68,5 +82,18 @@ export function equalityOperandHasStaleStaticType(
   return (
     ctx.oracle.typeFactOf(propertyReceiver).kind === "object" &&
     ctx.oracle.propertyFactOf(propertyReceiver, propertyKey).kind !== "unresolvable"
+  );
+}
+
+/** Equality also observes pre-existing dynamic module/for-in carriers. */
+export function equalityOperandHasStaleStaticType(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.Expression,
+): boolean {
+  return (
+    (ts.isIdentifier(expr) &&
+      (fctx.forInIdentifierVars?.has(expr.text) === true || moduleGlobalIsDynamicButStaticallyPrimitive(ctx, expr))) ||
+    expressionHasWidenedPropertyType(ctx, expr)
   );
 }

--- a/tests/issue-5386-console.test.ts
+++ b/tests/issue-5386-console.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it, vi } from "vitest";
+import { compile } from "../src/index.js";
+
+async function consoleOutput(source: string): Promise<unknown[][]> {
+  const result = await compile(source);
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  const output: unknown[][] = [];
+  const log = vi.spyOn(console, "log").mockImplementation((...args) => output.push(args));
+  try {
+    // Exercise the default start-section path, before host exports are wired.
+    await WebAssembly.instantiate(result.binary, result.importObject!);
+    return output;
+  } finally {
+    log.mockRestore();
+  }
+}
+
+describe("#5386: console preserves values from conditional object aliases", () => {
+  it("prints x1 for the exact top-level reproduction", async () => {
+    expect(
+      await consoleOutput(`
+      const a = { x: 1 };
+      const b = true ? a : { x: "" };
+      b.x = "x";
+      console.log(a.x + 1);
+    `),
+    ).toEqual([["x1"]]);
+  });
+
+  it("preserves an intermediate module variable", async () => {
+    expect(
+      await consoleOutput(`
+      const a = { x: 1 };
+      const b = true ? a : { x: "" };
+      b.x = "x";
+      const result = a.x + 1;
+      console.log(result);
+    `),
+    ).toEqual([["x1"]]);
+  });
+
+  it("keeps an unselected numeric object and ordinary console arguments intact", async () => {
+    expect(
+      await consoleOutput(`
+      const a = { x: 1 };
+      const b = false ? a : { x: "" };
+      b.x = "x";
+      console.log(a.x + 1);
+      console.log(true);
+      console.log("ok");
+    `),
+    ).toEqual([[2], [true], ["ok"]]);
+  });
+
+  it("prints x1 through the host-free standalone output sink", async () => {
+    const result = await compile(
+      `
+      const a = { x: 1 };
+      const b = true ? a : { x: "" };
+      b.x = "x";
+      console.log(a.x + 1);
+    `,
+      { target: "standalone", hostBridge: "always" },
+    );
+    expect(result.success, JSON.stringify(result.errors)).toBe(true);
+    const module = await WebAssembly.compile(result.binary);
+    expect(WebAssembly.Module.imports(module)).toEqual([]);
+    const instance = await WebAssembly.instantiate(module, {});
+    const prepare = instance.exports.__stdout_prepare as () => number;
+    const char = instance.exports.__stdout_char as (index: number) => number;
+    expect(typeof prepare).toBe("function");
+    expect(typeof char).toBe("function");
+    const length = prepare();
+    let output = "";
+    for (let i = 0; i < length; i++) output += String.fromCharCode(char(i));
+    expect(output).toBe("x1\n");
+  });
+});

--- a/tests/issue-5386.test.ts
+++ b/tests/issue-5386.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(body: string, flag: boolean | boolean[] = false, standalone = false): Promise<unknown> {
+  const result = await compile(
+    `export function test(flag: boolean) { ${body} }`,
+    standalone ? { target: "standalone" } : {},
+  );
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const imports = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(instance);
+  const test = instance.exports.test as (flag: boolean) => unknown;
+  return Array.isArray(flag) ? flag.map((value) => test(value)) : test(flag);
+}
+
+describe("#5386 — conditional object aliases preserve property writes", () => {
+  it("uses the live property value for addition through the original object", async () => {
+    expect(await run(`const a = { x: 1 }; const b = true ? a : { x: "" }; b.x = "x"; return a.x + 1;`)).toBe("x1");
+  });
+
+  it("selects both branches in the same compiled module", async () => {
+    expect(
+      await run(`const a = { x: 1 }; const b = flag ? a : { x: "" }; b.x = "x"; return a.x + 1;`, [true, false]),
+    ).toEqual(["x1", 2]);
+  });
+
+  for (const flag of [true, false]) {
+    it(`preserves runtime selection (${flag}) and unrelated same-named properties`, async () => {
+      expect(
+        await run(
+          `
+        const a = { x: 1 }; const other = { x: "" }; const unrelated = { x: 4 };
+        const b = flag ? a : other;
+        b.x = "x";
+        return (a.x + 1 === ${flag ? '"x1"' : "2"}) &&
+          (other.x === ${flag ? '""' : '"x"'}) && unrelated.x + 1 === 5 && b === ${flag ? "a" : "other"};
+      `,
+          flag,
+        ),
+      ).toBe(1);
+    });
+  }
+
+  it("preserves widened addition under standalone runtime equality", async () => {
+    expect(
+      await run(`const a = { x: 1 }; const b = flag ? a : { x: "" }; b.x = "x"; return a.x + 1 === "x1";`, true, true),
+    ).toBe(1);
+  });
+
+  it("keeps numeric-only conditional aliases numeric", async () => {
+    expect(await run(`const a = { x: 1 }; const b = flag ? a : { x: 3 }; b.x = 7; return a.x + 1;`, true)).toBe(8);
+  });
+
+  it("preserves an inferred intermediate local", async () => {
+    expect(
+      await run(
+        `const a = { x: 1 }; const b = true ? a : { x: "" }; b.x = "x"; const result = a.x + 1; return result;`,
+      ),
+    ).toBe("x1");
+  });
+
+  it("preserves a numeric write and reversed addition through a chained alias", async () => {
+    expect(
+      await run(`
+      const a = { x: "initial" }; const b = true ? a : { x: 1 }; const c = b;
+      c.x = 2; return 1 + a.x;
+    `),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
Type-changing writes through conditional object aliases left the original property's numeric type in place. The reported `b.x = "x"; console.log(a.x + 1)` program compiled but printed `NaN`; it now prints `x1` in JS-host and standalone execution.

The fix tracks union-receiver writes by property declaration and preserves the runtime value through addition, inferred variables/returns, equality, and console output. Unrelated same-named properties and numeric-only writes retain their behavior.

Tracks repository issue **#5386 — Preserve property type changes through conditional object aliases**, included in `plan/issues/5386-conditional-alias-property-write-widening.md`.

Validation:
- 12/12 new regression cases pass; 9 fail on clean baseline `16498efb481cb0`, with 3 passing controls.
- Focused existing suites: 25/26 pass. The `issue-2984-alias-receivers` nested-shadow guard fails identically on clean baseline (expected 1, received 3).
- Typecheck, lint, LOC/function budgets, oracle ratchet and change-scoped coercion gate pass.
- `check:dead-exports` exits 0 with the same pre-existing open-graph diagnostics on baseline and candidate.

This change does not add general interprocedural or escape analysis. Scoped integration budget allowances and the full validation evidence are recorded in the issue.
