### PR TITLE
fix(standalone): a method on a `class B extends Array` instance is reachable through a dynamic receiver, and its constructor's own-field write lands (#5383 S2b)

### DIFF
--- a/plan/issues/5383-standalone-temporal-provider.md
+++ b/plan/issues/5383-standalone-temporal-provider.md
@@ -11,6 +11,19 @@ reasoning_effort: high
 requested_by: ttraenkler/fable-lead
 created: 2026-09-07
 loc-budget-allow:
+  # 2026-09-08 (S2b) — the externref-backed-subclass family fix (own-field
+  # write/read + dynamic method dispatch on `class B extends Array`). Every
+  # entry is a net-new guarded arm plus the measurement that justifies it; the
+  # dispatch machinery itself lives in the new module
+  # src/codegen/standalone-subclass-method-install.ts, not in these files.
+  #   assignment.ts             +29  the unknown-backing write redirect (R6)
+  #   property-access-dispatch  +20  its READ twin (R6)
+  #   property-access.ts         +3  the backing-override parameter (R6)
+  #   class-bodies.ts            +8  the one call into the new module (R7)
+  - src/codegen/expressions/assignment.ts
+  - src/codegen/property-access-dispatch.ts
+  - src/codegen/property-access.ts
+  - src/codegen/class-bodies.ts
   # 2026-09-07 (S2) — three more codegen fixes, each reduced from the exact
   # statement in the linked polyfill bundle that hit it (see "S2 findings"
   # below for the measurement behind each). Plain-path spelling: the gate's
@@ -42,6 +55,15 @@ loc-budget-allow:
     lines: 20
     reason: "#5383 S2 R4 — pre-register the `Math.<fn>` value-read substrate before the closure is built (#2704 forbids a first registration mid-body), which is why every Math value read kept the refusal body."
 func-budget-allow:
+  # 2026-09-08 (S2b) — both grants are a guarded ARM added to an existing
+  # dispatch cascade, in the one place the cascade's order is load-bearing: the
+  # write redirect must sit between the externref-backed check and the struct
+  # path, and the read twin must sit between the own-field read and the struct
+  # ladder. Lifting either into a helper would move the arm away from the
+  # ordering constraint its comment exists to document, and would not shrink
+  # the cascade — the call would still be a line in the same place.
+  - src/codegen/expressions/assignment.ts::compilePropertyAssignment
+  - src/codegen/property-access-dispatch.ts::finalizeStructAndDynamicMemberGet
   - src/codegen/builtin-value-read.ts::ensureStandaloneBuiltinStaticMethodClosure
   - path: src/codegen/builtin-value-read.ts::ensureStandaloneBuiltinStaticMethodClosure
     reason: "#5383 S2 R4 — the 8-line pre-registration hook plus its rationale; splitting a single call out of this dispatcher would hide the ordering constraint it exists to document."
@@ -374,3 +396,140 @@ The S2 smoke test from the plan (`buildTemporalProvider` +
 `Temporal.Duration.from({hours:1}).total("minutes") === 60`) is NOT written:
 it cannot pass while `__module_init` throws, and a skipped assertion would be
 worse than an honest gap.
+
+## S2b findings (2026-09-08) — the externref-backed subclass family, and the new stop
+
+The handover's suspect was right and INCOMPLETE. A property write on a
+`class … extends Array` instance does throw — that is R6 below — but fixing it
+alone changed nothing at the module level, because a second, larger defect sat
+behind it: **a user METHOD on such an instance is unreachable through any
+dynamic receiver**, and it fails SILENTLY, answering `null`. That silence is
+why `JSBI.subtract` was reached with a null: it is not where the null was made.
+
+Probe used throughout: the jsbi PREFIX of the linked bundle (28,942 B, up to
+`l=e.multiply(h,i);`) plus a handful of exported one-liners. It compiles in
+**5 s** against the whole file's ~45 s, exercises the same class, and is what
+made the iteration loop usable — the whole-file probe was only re-run to
+confirm each step.
+
+### R6 — own-field write/read on an externref-backed subclass instance
+
+`class B extends Array { constructor(n, s) { super(n); this.sign = s; } }`
+threw `TypeError: Cannot access property on null or undefined` at the write.
+
+Root cause: `compilePropertyAssignment` (`src/codegen/expressions/assignment.ts`)
+consults `externrefBackedOwnFieldBacking`, which knows two carriers —
+`$Error_struct` and a native `$Object` — and answers `undefined` for every
+other parent. On `undefined` the code FELL THROUGH to the struct.set path, and
+that path is unreachable-by-design here: the instance is a `$__vec_externref`
+and never a `$B`, so `ref.test $B` always misses, the receiver narrows to
+`ref.null $B`, and the #2084 null guard throws.
+
+The field only reaches that path because the constructor's own assignment
+FLOW-GROWS a `sign` slot onto the vestigial `$B` struct. The identical write
+from outside the class (`b.sign = 1`) finds no slot, takes the #4149
+`fieldIdx === -1` dynamic-store arm, and has always worked — so the class's own
+constructor was the one place the write failed. Fix: route the unknown-backing
+case to that SAME dynamic store, plus its read twin in
+`property-access-dispatch.ts` (scoped to keys that actually have a flow-grown
+slot, so a builtin member like `length` still reaches the array paths).
+
+### R7 — a method is unreachable through a dynamic receiver (the real blocker)
+
+| receiver spelling | `o.d(0)` before | after |
+| --- | --- | --- |
+| `var x = new B(1); x.d(0)` | 5 | 5 |
+| `function f(o) { return o.d(0); } f(b)` | **null** | 5 |
+| `new B(1).d(0)` | **null** | null (unchanged, see below) |
+
+A statically-typed receiver compiles to `call $B_d`. Anything the checker
+cannot pin — and jsbi's statics take UNANNOTATED parameters
+(`static toNumber(i) { … i.__unsignedDigit(0) … }`) — goes out through the
+dynamic terminal, which resolves a method by `ref.test`ing instance identity
+against each closed struct plus the open `$Object`. The carrier is none of
+those. The host lane's answer is `__set_subclass_proto`, a JS host import, so
+`emitSetSubclassProto` is a documented NO-OP standalone: nothing on the
+instance says "B".
+
+Measured consequence on the jsbi prefix, before the fix:
+`JSBI.toNumber(JSBI.BigInt(5))` → `null`, `JSBI.add(5,3)` → `null`,
+`JSBI.unaryMinus(x)` → `null`, `x.__copy()` → `null`. After: `5`, `8`,
+non-null, non-null. The polyfill's `Ne = xo(ke), xe = e.unaryMinus(Ne),
+Le = e.add(e.subtract(xe, l), n)` is one top-level statement; `unaryMinus`
+returned null and `subtract` reported it, five frames later.
+
+Two halves, both in the fix:
+
+1. **`standalone-subclass-method-install.ts` (new).** At construction, install
+   each declared instance method on the instance as an own data property at §17
+   attributes — the same closure singleton, `__defineProperty_value` and flags
+   `class-proto-object.ts` (#3976) uses for `C.prototype`. The dynamic
+   terminals already consult the carrier's own-property side table (#3537 vec
+   bag / #3468 closure bag).
+2. **The method trampoline's `this` slot** (`closures/method-trampolines.ts`).
+   Installing alone was not enough: the trampoline builds `this` by
+   `ref.test`ing `__current_this` against the method's object struct, so the
+   carrier failed that test too and every method ran with `this === null`
+   (`this[0]` threw, `this.sign` answered null). For a method whose declared
+   `this` is `externref` AND whose owner is externref-backed, the carrier is now
+   passed straight through. The #2025 absent-receiver TypeError is preserved and
+   tested.
+
+**Alternatives measured and rejected** (each would put the methods where the
+spec puts them, and each is a dead end today): `Object.setPrototypeOf(inst,
+B.prototype)` → the standalone dynamic member path does not consult an explicit
+prototype link on a non-`$Object` carrier, so the call still answers `null`;
+`inst.__proto__ = B.prototype` → same; leaning on `B.prototype` itself →
+`emitStandaloneClassProtoObject` explicitly DECLINES for a builtin-parent class,
+so it is still the legacy defaulted struct. The deviation shipped instead is
+that the methods are OWN rather than inherited (`hasOwnProperty("d")` answers
+`true`); they are non-enumerable, so `Object.keys` / `for-in` are unchanged.
+
+`extends Error` is EXCLUDED by measurement, not by policy: `__defineProperty_value`
+does not reach an `$Error_struct`'s `$props` side-slot, so such a class got
+5.8 kB of machinery and still answered "called value is not a function".
+Deleting that one line is the whole fix once the Error carrier's dynamic member
+path reads `$props`.
+
+### Byte A/B (`.tmp/ab-base.txt` vs `.tmp/ab-new2.txt`, sha256, 6 modules × 2 targets)
+
+**gc lane: all six byte-identical** (arith, plain class, `extends Array`,
+`extends Error`, object-literal method, Map/WeakMap). Standalone: **only the
+`extends Array` module changes**; arith, plain class, object-literal method,
+Map/WeakMap and — after the Error exclusion — `extends Error` are byte-identical.
+
+### Where `__module_init` stops NOW
+
+Not in jsbi any more. `TypeError: Cannot access property on null or undefined`
+at **4:94864**, which is
+`"formatToParts" in ai.prototype || delete DateTimeFormatImpl.prototype.formatToParts`
+— `ai` is `Intl.DateTimeFormat`, and standalone deliberately leaves the `Intl`
+identifier `ref.null.extern` (#5206: "a compiled shim for it is a separate, much
+larger gap"). The polyfill reads that namespace at top level in two places: the
+cache `ct = Intl.DateTimeFormat` at 4:10198 and this `.prototype` probe.
+
+An `Intl.<member>` → `undefined` arm was written and **reverted**: it clears the
+first read and the second one then throws on `.prototype`, so it moved the
+failure without removing it while changing standalone `Intl` semantics. Getting
+past this needs one of, in increasing order of honesty:
+
+1. the provider builder strips/stubs the Intl-dependent section of the polyfill
+   for standalone (a provider-side decision — the 66 Intl-dependent Temporal
+   rows are already out of scope per this issue's own plan);
+2. a standalone `Intl` namespace whose members are constructible refusal
+   closures carrying a real `.prototype` (the #5206 gap, properly);
+3. ICU in Wasm (out of scope, permanently, for this issue).
+
+Recommendation: **(1)**, as the S2 continuation — it is the only one that does
+not require deciding the `Intl` shim question to link Temporal.
+
+### Not reached (unchanged from S2)
+
+The S2 smoke test (`buildTemporalProvider` + `compileWithTemporalGlobal` +
+host-free `instantiateLinkedProject`) is still NOT written: `__module_init`
+still throws, and a skipped assertion is worse than an honest gap. Everything
+else in this slice is a test in
+`tests/issue-5383-standalone-temporal-provider.test.ts` (S2b R6 / S2b R7,
+9 cases, including the non-enumerability of the installed methods, the
+untouched element/length surface, an unaffected plain class, and the preserved
+absent-receiver TypeError).

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -6325,6 +6325,14 @@
       "nextBoundary": "Separate AST/context-driven generation, physical resources and generated native runtime."
     },
     {
+      "path": "src/codegen/standalone-subclass-method-install.ts",
+      "state": "unmigrated",
+      "layer": "mixed-needs-split",
+      "destination": "backend-wasmgc",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate AST/context-driven generation, physical resources and generated native runtime."
+    },
+    {
       "path": "src/codegen/standalone-wrapper-instanceof.ts",
       "state": "unmigrated",
       "layer": "mixed-needs-split",

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -76,6 +76,7 @@ import { compileStringLiteral } from "./string-ops.js";
 import { emitUndefined } from "./expressions/late-imports.js";
 import { emitLazyClassObjectGet } from "./expressions/extern.js"; // (#5377)
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
+import { emitStandaloneSubclassMethodInstall } from "./standalone-subclass-method-install.js";
 import { buildTargetTaggedTry } from "../ir/try-table.js";
 import { UNDEF_F64_BITS } from "./value-tags.js";
 import { emitWasiErrorConstructor, getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
@@ -604,6 +605,13 @@ function emitSetSubclassProto(
   subName: string,
   parentName: string,
 ): void {
+  // (#5383 S2b) Standalone/WASI has no `__set_subclass_proto` host import, so
+  // this function is a documented no-op there — and a method on an
+  // externref-backed subclass is consequently unreachable through any dynamic
+  // receiver. Install the methods on the instance instead; the helper emits
+  // nothing for every other shape. Runs BEFORE the host path below so the two
+  // lanes stay independent (the helper is standalone/WASI-gated).
+  emitStandaloneSubclassMethodInstall(ctx, fctx, selfLocal, subName);
   const setProtoIdx = ensureLateImport(
     ctx,
     "__set_subclass_proto",

--- a/src/codegen/class-proto-object.ts
+++ b/src/codegen/class-proto-object.ts
@@ -107,7 +107,7 @@ import {
  * VALUES (bit 1 left clear ⇒ non-enumerable). Same constant the generator
  * prototype singleton uses (`array-object-proto.ts`).
  */
-const METHOD_FLAGS = 0x01 | 0x04;
+export const METHOD_FLAGS = 0x01 | 0x04;
 
 /** The `__priv_` prefix `resolveClassMemberName` gives `#private` element names. */
 const PRIVATE_NAME_PREFIX = "__priv_";
@@ -125,7 +125,7 @@ const protoObjectsInProgress = new Set<string>();
  * not abstract), excluding private elements, and only those whose canonical
  * closure singleton is actually resolvable.
  */
-function installableMethodNames(ctx: CodegenContext, className: string): string[] {
+export function installableInstanceMethodNames(ctx: CodegenContext, className: string): string[] {
   const declared = ctx.classMethodNames.get(className);
   if (!declared || declared.length === 0) return [];
   const out: string[] = [];
@@ -207,7 +207,7 @@ export function emitStandaloneClassProtoObject(
   if (newObjectIdx === undefined || defineIdx === undefined) return false;
 
   const structTypeIdx = ctx.structMap.get(className)!;
-  const methodNames = installableMethodNames(ctx, className);
+  const methodNames = installableInstanceMethodNames(ctx, className);
   const accessors = installableClassAccessors(ctx, className);
   // (#4455) The accessor store is a separate native from the data-property one;
   // a class that has accessors and cannot reach it must keep the legacy struct

--- a/src/codegen/closures/method-trampolines.ts
+++ b/src/codegen/closures/method-trampolines.ts
@@ -163,14 +163,86 @@ export function compiledBodyReadsThis(ctx: CodegenContext, methodFuncIdx: number
   return methodBodyReadsThis(ctx, methodFuncIdx);
 }
 
+/**
+ * (#5383 S2b) Is `objStructTypeIdx` the vestigial `$ClassName` struct of an
+ * EXTERNREF-BACKED class (`class B extends Array`)?
+ *
+ * Such a class has a registered struct type but never a struct INSTANCE — its
+ * objects are the parent's native carrier (a `$__vec_externref` for `extends
+ * Array`), reached as `externref` (`externref-backed-class-rep.ts`, #5201). So
+ * the `ref.test $B` the ordinary `this`-slot performs on `__current_this` can
+ * NEVER match, and the receiver silently degrades to `ref.null` — the #2025
+ * "foreign receiver" passthrough firing on the class's OWN instances.
+ *
+ * Reverse-mapped from `ctx.structMap` rather than threaded through the call
+ * chain: the trampoline is a per-method-NAME singleton built by whichever site
+ * touches the method first, so the owning class is not otherwise in scope here.
+ * Runs once per trampoline.
+ */
+function structTypeIdxIsExternrefBackedClass(ctx: CodegenContext, objStructTypeIdx: number): boolean {
+  for (const [name, idx] of ctx.structMap) {
+    if (idx === objStructTypeIdx) return ctx.classExternrefBackedSet.has(name);
+  }
+  return false;
+}
+
+/**
+ * (#5383 S2b) True when {@link buildTrampolineThisSlot} takes its
+ * externref-carrier arm, i.e. the receiver it leaves on the stack is ALREADY
+ * the method's declared `externref` `this`. The caller then skips
+ * {@link coerceTrampolineThisSlot}, whose whole job is bridging the struct
+ * receiver to that carrier.
+ */
+function externrefCarrierThisSlot(
+  ctx: CodegenContext,
+  objStructTypeIdx: number,
+  methodThisType: ValType | undefined,
+): boolean {
+  return (
+    methodThisType?.kind === "externref" &&
+    structTypeIdxIsExternrefBackedClass(ctx, objStructTypeIdx) &&
+    ensureCurrentThisGlobal(ctx) >= 0
+  );
+}
+
 function buildTrampolineThisSlot(
   ctx: CodegenContext,
   objStructTypeIdx: number,
   anyTempLocalIdx: number,
   methodUsesThis: boolean,
+  // (#5383 S2b) The method's declared `this` parameter, when known. Only an
+  // `externref` one on an externref-backed class takes the carrier arm below;
+  // every other method keeps the struct arm and its exact previous bytes.
+  methodThisType?: ValType,
 ): Instr[] {
   const currentThisGlobalIdx = ensureCurrentThisGlobal(ctx);
   const nullThis: Instr[] = [{ op: "ref.null", typeIdx: objStructTypeIdx }];
+  if (
+    methodThisType?.kind === "externref" &&
+    structTypeIdxIsExternrefBackedClass(ctx, objStructTypeIdx) &&
+    currentThisGlobalIdx >= 0
+  ) {
+    // The carrier IS the receiver — hand `__current_this` straight to the
+    // method. `coerceTrampolineThisSlot` must not run after this (the value is
+    // already the method's declared carrier); the caller skips it.
+    const externThrow = methodUsesThis ? buildNullThisTypeErrorThrow(ctx) : null;
+    if (!externThrow) return [{ op: "global.get", index: currentThisGlobalIdx }];
+    return [
+      { op: "global.get", index: currentThisGlobalIdx },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: anyTempLocalIdx },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        // A genuinely absent receiver is the same catchable TypeError the
+        // struct arm raises; a present one is passed through unconditionally,
+        // because no `ref.test` can recognise it.
+        then: externThrow,
+        else: [{ op: "local.get", index: anyTempLocalIdx }, { op: "extern.convert_any" }],
+      },
+    ];
+  }
   if (currentThisGlobalIdx < 0) return nullThis;
   // (#2025) When the resolved `this` isn't the method's struct, distinguish a
   // GENUINELY-ABSENT receiver (`__current_this` null — the unbound extraction
@@ -388,8 +460,16 @@ export function emitObjectMethodAsClosure(
   ensureNullThisTypeError(ctx, fctx);
   const ntShift = ctx.numImportFuncs - importsBeforeNT;
   if (ntShift > 0 && inLiveShiftRange(methodFuncIdx, importsBeforeNT)) methodFuncIdx += ntShift;
-  const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx, methodUsesThis);
-  coerceTrampolineThisSlot(ctx, trampolineBody, objStructTypeIdx, sig.params[0], methodUsesThis, fctx);
+  const trampolineBody: Instr[] = buildTrampolineThisSlot(
+    ctx,
+    objStructTypeIdx,
+    anyTempLocalIdx,
+    methodUsesThis,
+    sig.params[0],
+  );
+  if (!externrefCarrierThisSlot(ctx, objStructTypeIdx, sig.params[0])) {
+    coerceTrampolineThisSlot(ctx, trampolineBody, objStructTypeIdx, sig.params[0], methodUsesThis, fctx);
+  }
   for (let i = 0; i < userParams.length; i++) {
     // Skip closure_self at param 0; user params start at index 1
     trampolineBody.push({ op: "local.get", index: i + 1 });
@@ -607,7 +687,7 @@ export function finalizeMethodTrampolines(ctx: CodegenContext): void {
       // here where `t.methodFuncIdx` may be stale). Fall back to a fresh body
       // scan only when it wasn't recorded.
       const usesThis = t.methodUsesThis ?? methodBodyReadsThis(ctx, t.methodFuncIdx);
-      newBody = buildTrampolineThisSlot(ctx, t.objStructTypeIdx, anyTempLocalIdx, usesThis);
+      newBody = buildTrampolineThisSlot(ctx, t.objStructTypeIdx, anyTempLocalIdx, usesThis, sig.params[0]);
       // (#4466) Do NOT re-coerce the receiver here, and do NOT alias
       // `tFctx.body` to `newBody` to make that possible. The emit-time call
       // sites (`emitObjectMethodAsClosure`, `ensureMethodClosureSingleton`)
@@ -882,8 +962,11 @@ export function ensureMethodClosureSingleton(
       objStructTypeIdx,
       anyTempLocalIdx,
       methodUsesThisCached,
+      sig.params[0],
     );
-    coerceTrampolineThisSlot(ctx, trampolineBody, objStructTypeIdx, sig.params[0], methodUsesThisCached, fctx);
+    if (!externrefCarrierThisSlot(ctx, objStructTypeIdx, sig.params[0])) {
+      coerceTrampolineThisSlot(ctx, trampolineBody, objStructTypeIdx, sig.params[0], methodUsesThisCached, fctx);
+    }
     for (let i = 0; i < userParams.length; i++) {
       trampolineBody.push({ op: "local.get", index: i + 1 });
     }

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -5001,7 +5001,36 @@ function compilePropertyAssignment(
     if (ctx.standalone) {
       const ownWrite = emitExternrefBackedOwnFieldWrite(ctx, fctx, target, value, fieldName, typeName);
       if (ownWrite !== undefined) return ownWrite;
-      // undefined → not applicable (e.g. helper unavailable); fall through.
+      // (#5383 S2b) `undefined` means the class has NO known native backing —
+      // an Array/TypedArray/String/… carrier rather than an `$Error_struct` or
+      // a native `$Object` (`externrefBackedOwnFieldBacking`). The struct path
+      // below is not merely unhelpful there, it is UNREACHABLE-BY-DESIGN: the
+      // instance is an externref carrier and never a `$typeName` WasmGC struct,
+      // so its `ref.test $typeName` always misses. The receiver then narrows to
+      // `ref.null $typeName` and the #2084 null guard throws
+      // `TypeError: Cannot access property on null or undefined` — which is
+      // exactly what `class B extends Array { constructor(n, s) { super(n);
+      // this.sign = s; } }` did on this lane, and (via jsbi's `class JSBI
+      // extends Array`) what stopped the standalone @js-temporal/polyfill's
+      // `__module_init`.
+      //
+      // The field only reaches the struct path at all because the constructor's
+      // own `this.sign = …` FLOW-GROWS a `sign` slot onto the vestigial `$B`
+      // struct; an assignment from outside the class (`b.sign = 1`) finds no
+      // slot, takes the #4149 `fieldIdx === -1` arm below, and has always
+      // worked. So route the unknown-backing case to the SAME dynamic store the
+      // outside write already uses — one behaviour for both, instead of a slot
+      // that decides which of the two throws.
+      //
+      // Nothing that works today changes: every write this redirects previously
+      // threw or trapped, so there is no valid artifact to perturb. The
+      // JS-host/`gc` lane never enters this branch (it is `ctx.standalone`-only
+      // and the `!ctx.wasi` arm below is untouched).
+      const backing = externrefBackedOwnFieldBacking(ctx, typeName);
+      if (backing === undefined) {
+        return compilePropertyAssignmentExternSet(ctx, fctx, target, value, fieldName);
+      }
+      // A known backing whose helper was unavailable — fall through unchanged.
     } else if (!ctx.wasi) {
       return compilePropertyAssignmentExternSet(ctx, fctx, target, value, fieldName, true);
     }

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -169,7 +169,11 @@ import { isSealedNominalStructParent } from "./struct-hierarchy-layout.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { receiverIsPrimitiveWrapper } from "./object-ctor-primitive-receiver.js";
 import { tryObjectCoercionFnctorPrototypeIdentity } from "./object-coercion-fnctor-prototype.js";
-import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
+import {
+  externrefBackedOwnFieldBacking,
+  getOrRegisterErrorStructType,
+  isWasiErrorName,
+} from "./registry/error-types.js";
 import {
   classExpressionDefinesOwnName,
   classifyPlainCtorReceiverNamespace,
@@ -4384,6 +4388,26 @@ export function finalizeStructAndDynamicMemberGet(
     if (ctx.standalone && ctx.classExternrefBackedSet.has(typeName)) {
       const ownRead = emitExternrefBackedOwnFieldRead(ctx, fctx, expr, propName, typeName);
       if (ownRead !== undefined) return ownRead;
+      // (#5383 S2b) The READ twin of the write fix in `assignment.ts`. When the
+      // class has no known native backing (an Array/TypedArray/… carrier), the
+      // own-field WRITE now stores through `__extern_set` on the carrier
+      // itself, so the read has to look in the same place — otherwise the
+      // struct.get path below reads the vestigial `$typeName` slot the write no
+      // longer fills, and (the carrier never being a `$typeName`) throws
+      // `TypeError: Cannot access property on null or undefined`.
+      //
+      // Scoped to properties that actually HAVE such a flow-grown slot, which
+      // is exactly the set the doomed struct path would have claimed. A builtin
+      // member of the parent (`length`, `push`, an index) has no slot, so it
+      // still reaches the array/builtin member paths below unchanged — that
+      // scoping is why this cannot swallow inherited behaviour.
+      if (
+        externrefBackedOwnFieldBacking(ctx, typeName) === undefined &&
+        (ctx.structFields.get(typeName)?.some((field) => field.name === propName) ?? false)
+      ) {
+        const selfStoreRead = emitExternrefBackedOwnFieldRead(ctx, fctx, expr, propName, typeName, "plain-object");
+        if (selfStoreRead !== undefined) return selfStoreRead;
+      }
       // undefined → helper unavailable; fall through to the legacy path.
     }
 

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -153,6 +153,7 @@ import {
 } from "./array-object-proto.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import {
+  type ExternrefBackedOwnFieldBacking,
   externrefBackedOwnFieldBacking,
   getOrRegisterErrorStructType,
   isWasiErrorName,
@@ -2052,8 +2053,10 @@ export function emitExternrefBackedOwnFieldRead(
   expr: ts.PropertyAccessExpression,
   propName: string,
   className?: string,
+  backingOverride?: ExternrefBackedOwnFieldBacking,
 ): ValType | null | undefined {
-  const backing = className === undefined ? "error-struct" : externrefBackedOwnFieldBacking(ctx, className);
+  const backing =
+    backingOverride ?? (className === undefined ? "error-struct" : externrefBackedOwnFieldBacking(ctx, className));
   if (backing === undefined) return undefined;
   ensureObjectRuntime(ctx);
   const externGetIdx = ensureLateImport(

--- a/src/codegen/standalone-subclass-method-install.ts
+++ b/src/codegen/standalone-subclass-method-install.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#5383 S2b) Make a user METHOD reachable on a standalone externref-backed
+ * subclass instance through a DYNAMIC receiver.
+ *
+ * ## The gap (measured, 2026-09-08)
+ *
+ * `class B extends Array { d(i) { return this[i]; } }` under `--target
+ * standalone`, `hostBridge: "off"`:
+ *
+ * | receiver spelling                        | `o.d(0)` |
+ * | ---------------------------------------- | -------- |
+ * | `var x = new B(1); x.d(0)`               | 5 — statically dispatched to `$B_d` |
+ * | `function f(o) { return o.d(0); } f(b)`  | **null** |
+ * | `new B(1).d(0)`                          | **null** |
+ *
+ * A statically-typed receiver compiles to a direct `call $B_d`. Anything the
+ * checker cannot pin — a bare parameter, a call result of a union type — goes
+ * out through the dynamic terminal (`__extern_method_call` / the
+ * `__call_m_<name>` closed dispatcher), and those resolve a method by
+ * INSTANCE IDENTITY: `ref.test` against each closed struct type, plus the open
+ * `$Object` hash map. An externref-backed subclass instance is neither. Its
+ * carrier is the parent's native value — a `$__vec_externref` for `extends
+ * Array` — indistinguishable from a plain array, and the host lane's answer to
+ * this (`__set_subclass_proto`, which installs `B.prototype` on the instance)
+ * is a JS host import, so `emitSetSubclassProto` is a documented NO-OP on this
+ * lane. There is nothing on the instance that says "B".
+ *
+ * The miss is SILENT — `null`, not a TypeError — which is why it survived: it
+ * reads as a method that returned nothing. It is what stopped the standalone
+ * `@js-temporal/polyfill` provider's `__module_init`: jsbi is
+ * `class JSBI extends Array`, and its statics call methods on their
+ * PARAMETERS (`static toNumber(i) { … i.__unsignedDigit(0) … }`). Every such
+ * call answered `null`, so `JSBI.unaryMinus(x)` handed back `null` and the
+ * next `JSBI.subtract(null, l)` threw `TypeError: Cannot access property on
+ * null or undefined` — one null, five frames from where it was made.
+ *
+ * ## The fix, and why own properties rather than a prototype link
+ *
+ * At construction, install each declared instance method on the INSTANCE as an
+ * own data property at §17 attributes (`{writable: true, enumerable: false,
+ * configurable: true}`) — the same closure singleton, the same
+ * `__defineProperty_value` native, and the same flags `class-proto-object.ts`
+ * (#3976) uses for `C.prototype`. The dynamic terminals already consult the
+ * carrier's own-property side table (#3537 vec bag / #3468 closure bag), so
+ * every dynamic spelling starts resolving with `this` correctly bound.
+ *
+ * Three alternatives were MEASURED first, and each is a dead end today:
+ *
+ *   - **`Object.setPrototypeOf(instance, B.prototype)`** — one call per
+ *     instance instead of N, and it would put the methods where the spec puts
+ *     them. Probed: `Object.setPrototypeOf(a, p); a.m()` through a dynamic
+ *     receiver answers `null` for a vec carrier. Standalone's dynamic member
+ *     path does not consult an explicit `setPrototypeOf` link on a non-`$Object`
+ *     carrier at all, so this fixes nothing until that link is honoured.
+ *   - **`instance.__proto__ = B.prototype`** — same probe, same `null`.
+ *   - **Leaning on `B.prototype` itself** — `emitStandaloneClassProtoObject`
+ *     explicitly DECLINES for a class with a builtin parent, so `B.prototype`
+ *     is still the legacy defaulted `$ClassName` struct here, not a real
+ *     `$Object` the bag could inherit from.
+ *
+ * ## What this deliberately does NOT claim
+ *
+ * The methods become OWN properties of the instance, not inherited ones. So
+ * `b.hasOwnProperty("d")` answers `true` where the spec says `false`, and
+ * `delete b.d` removes it for that instance only. That is a real deviation and
+ * it is the price of the carrier having no prototype channel; it is strictly
+ * better than the status quo, where the method is not reachable at all. The
+ * non-enumerable flag keeps the visible surface right for the two questions
+ * that are actually asked — `Object.keys(b)` and `for (k in b)` still see only
+ * the elements/fields (probed: `Object.keys` length unchanged). When the
+ * standalone dynamic path learns to honour a carrier's prototype link, this
+ * should be replaced by that link, not extended.
+ *
+ * ## Byte-neutrality
+ *
+ * Gated on `ctx.standalone || ctx.wasi` AND on the class being externref-backed
+ * AND on it declaring at least one installable instance method. The JS-host /
+ * `gc` lane never reaches here — it keeps `__set_subclass_proto`, which does
+ * the equivalent job through the real prototype — and any standalone module
+ * without such a class emits exactly its previous bytes.
+ */
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { classMemberFuncKey } from "./class-member-keys.js";
+import { emitClassMemberKeyOperand } from "./class-proto-accessors.js";
+import { installableInstanceMethodNames, METHOD_FLAGS } from "./class-proto-object.js";
+import { emitCachedMethodClosureAccess } from "./closures.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
+import { externrefBackedOwnFieldBacking } from "./registry/error-types.js";
+
+/**
+ * Install `subName`'s declared instance methods as own data properties of the
+ * instance held in `selfLocal` (an `externref` local). No-op — emitting
+ * nothing at all — unless the standalone/WASI externref-backed shape above
+ * applies.
+ */
+export function emitStandaloneSubclassMethodInstall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  selfLocal: number,
+  subName: string,
+): void {
+  if (!(ctx.standalone || ctx.wasi)) return;
+  if (!ctx.classExternrefBackedSet.has(subName)) return;
+  // MEASURED exclusion, not a policy one: `__defineProperty_value` lands in the
+  // #3537 vec bag / #3468 closure bag and on a native `$Object`, but NOT in an
+  // `$Error_struct`'s `$props` side-slot, so an `extends Error` subclass gets
+  // the installs and still answers "called value is not a function" on a
+  // dynamic method call — 5.8 kB of machinery pulled into every such standalone
+  // binary for no behaviour change. Skip it until the Error carrier's dynamic
+  // member path reads `$props`, at which point deleting this line is the whole
+  // fix.
+  if (externrefBackedOwnFieldBacking(ctx, subName) === "error-struct") return;
+  const methodNames = installableInstanceMethodNames(ctx, subName);
+  if (methodNames.length === 0) return;
+  const structTypeIdx = ctx.structMap.get(subName);
+  if (structTypeIdx === undefined) return;
+  ensureObjectRuntime(ctx);
+  const defineIdx = ctx.funcMap.get("__defineProperty_value");
+  if (defineIdx === undefined) return;
+
+  // Everything below appends to `fctx.body` in receiver/key/value/flags order,
+  // exactly as `emitStandaloneClassProtoObject` does for the prototype object.
+  // A member whose key or closure singleton fails to materialize stops the
+  // loop rather than leaving operands stranded on the stack.
+  for (const name of methodNames) {
+    const fullName = `${subName}_${name}`;
+    const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
+    if (funcIdx === undefined) break;
+    fctx.body.push({ op: "local.get", index: selfLocal });
+    if (!emitClassMemberKeyOperand(ctx, fctx, subName, name)) {
+      fctx.body.push({ op: "drop" });
+      break;
+    }
+    if (!emitCachedMethodClosureAccess(ctx, fctx, fullName, funcIdx, structTypeIdx)) {
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "drop" });
+      break;
+    }
+    fctx.body.push({ op: "f64.const", value: METHOD_FLAGS });
+    // `__defineProperty_value` returns the target; the install is for effect.
+    fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__defineProperty_value") ?? defineIdx });
+    fctx.body.push({ op: "drop" });
+  }
+}

--- a/tests/issue-5383-standalone-temporal-provider.test.ts
+++ b/tests/issue-5383-standalone-temporal-provider.test.ts
@@ -277,3 +277,167 @@ describe("#5383 S2 R4 — `Math.<fn>` read as a VALUE, host-free", () => {
     expect(callExport(mod)).toBe(101.5);
   });
 });
+
+// ── S2b ──────────────────────────────────────────────────────────────────────
+//
+// Two defects in the EXTERNREF-BACKED subclass family (`class B extends Array`
+// — jsbi's `class JSBI extends Array`), both reduced from the standalone
+// polyfill's `__module_init` throw and both invisible in the JS-host lane,
+// where the real host prototype does this work.
+//
+//  R6  An own-field WRITE inside the constructor (`this.sign = s`). The
+//      constructor's own assignment flow-grows a `sign` slot onto the vestigial
+//      `$B` struct, and the write then took the struct.set path — but the
+//      instance is the parent's native carrier, never a `$B`, so the receiver
+//      narrowed to `ref.null $B` and the #2084 guard threw
+//      `TypeError: Cannot access property on null or undefined`. The same write
+//      from OUTSIDE the class always worked (no slot ⇒ the #4149 dynamic-store
+//      arm), so the class's own constructor was the one place it failed.
+//
+//  R7  A method call through a DYNAMIC receiver. Nothing on the carrier says
+//      "B", so the dynamic terminals (`__extern_method_call` /
+//      `__call_m_<name>`, which resolve by `ref.test`ing instance identity)
+//      missed and answered `null` — SILENTLY, which is why it survived. The
+//      host lane's answer, `__set_subclass_proto`, is a JS host import, so
+//      `emitSetSubclassProto` is a no-op standalone. Methods are now installed
+//      on the instance at §17 attributes, and the method trampoline binds
+//      `__current_this` as the carrier instead of `ref.null $B`.
+//
+// This is what stopped the compiled @js-temporal/polyfill: jsbi statics call
+// methods on their PARAMETERS (`static toNumber(i) { … i.__unsignedDigit(0) … }`),
+// every such call answered null, and the null surfaced five frames later as
+// `JSBI.subtract(null, …)`.
+
+describe("#5383 S2b R6 — own-field write/read on an externref-backed subclass instance", () => {
+  it("`this.<field> = v` in the constructor of a `class … extends Array`", async () => {
+    const mod = await compileStandalone(`
+      class B extends Array { constructor(n, s) { super(n); this.sign = s; } }
+      export function test() { var b = new B(2, true); return b.sign === true ? 1 : 0; }
+    `);
+    expect(callExport(mod)).toBe(1);
+  });
+
+  it("the jsbi shape — an instance minted by one static, read by another", async () => {
+    // `JSBI.subtract(i, _) { const t = i.sign; … }` with `i` from `JSBI.BigInt`.
+    const mod = await compileStandalone(`
+      class B extends Array {
+        constructor(n, s) { super(n); this.sign = s; }
+        static make(s) { return new B(2, s); }
+        static subtract(i, _) { const t = i.sign; return t === true ? 7 : 8; }
+      }
+      export function test() { return B.subtract(B.make(true), B.make(false)); }
+    `);
+    expect(callExport(mod)).toBe(7);
+  });
+
+  it("the element/length surface of the Array carrier is untouched", async () => {
+    // The write must land in the expando side table, never over the vec's own
+    // element storage or its length.
+    const mod = await compileStandalone(`
+      class B extends Array { constructor(n, s) { super(n); this.sign = s; } }
+      export function test() {
+        var b = new B(3, true);
+        b[0] = 9;
+        return b.length * 10 + b[0] + (b.sign === true ? 100 : 0);
+      }
+    `);
+    expect(callExport(mod)).toBe(139);
+  });
+
+  it("a plain class and an `extends Error` subclass are unaffected", async () => {
+    const mod = await compileStandalone(`
+      class P { constructor(n, s) { this.length = n; this.sign = s; } }
+      class E extends Error { constructor(m) { super(m); this.sign = true; } }
+      export function test() {
+        return (new P(2, true).sign === true ? 1 : 0) + (new E("m").sign === true ? 2 : 0);
+      }
+    `);
+    expect(callExport(mod)).toBe(3);
+  });
+});
+
+describe("#5383 S2b R7 — dynamic method dispatch on an externref-backed subclass instance", () => {
+  it("a method called through an untyped parameter runs, with `this` bound", async () => {
+    const mod = await compileStandalone(`
+      class B extends Array {
+        constructor(n, s) { super(n); this.sign = s; }
+        d(i) { return this[i]; }
+        static mk(n) { var b = new B(1, false); b[0] = n; return b; }
+      }
+      function callD(o) { return o.d(0); }
+      export function test() { return callD(B.mk(5)); }
+    `);
+    // Pre-fix: `null` — the dispatch missed entirely and nothing reported it.
+    expect(callExport(mod)).toBe(5);
+  });
+
+  it("`this` reaches elements, an own field, `.length` and a sibling method", async () => {
+    // Each is a separate `this` consumer inside the method body; the trampoline
+    // used to hand all four a null receiver (`ref.null $B`), so the element read
+    // threw and the field read answered null.
+    const mod = await compileStandalone(`
+      class B extends Array {
+        constructor(n, s) { super(n); this[0] = 4; this.sign = s; }
+        elem() { return this[0]; }
+        field() { return this.sign; }
+        len() { return this.length; }
+        sib() { return this.elem(); }
+      }
+      function call(o, which) {
+        return which === 0 ? o.elem() : which === 1 ? o.field() : which === 2 ? o.len() : o.sib();
+      }
+      export function test() {
+        var b = new B(2, 3);
+        return call(b, 0) + call(b, 1) + call(b, 2) + call(b, 3);
+      }
+    `);
+    // 4 + 3 + 2 + 4
+    expect(callExport(mod)).toBe(13);
+  });
+
+  it("the installed methods are NOT enumerable — `Object.keys` still sees only the elements", async () => {
+    // The install uses §17 method attributes (`{writable, !enumerable,
+    // configurable}`), the same flags `C.prototype` gets, so the method name
+    // must not appear in the enumerable own-key surface. Asserted as ABSENCE of
+    // the key rather than as a key COUNT: a standalone Array-subclass carrier
+    // answers `Object.keys(b).length === 0` for its elements too (measured on
+    // `origin/main`, unchanged by this PR and out of scope here), so a count
+    // would be asserting that unrelated gap rather than this property.
+    const mod = await compileStandalone(`
+      class B extends Array { constructor(n) { super(n); this[0] = 1; this[1] = 2; } d() { return 7; } }
+      function call(o) { return o.d(); }
+      export function test() {
+        var b = new B(2);
+        var keys = Object.keys(b);
+        var sawMethod = 0;
+        for (var i = 0; i < keys.length; i++) if (keys[i] === "d") sawMethod = 1;
+        return call(b) + 100 * sawMethod;
+      }
+    `);
+    expect(callExport(mod)).toBe(7);
+  });
+
+  it("a plain class's dynamic dispatch keeps working (the struct arm is untouched)", async () => {
+    const mod = await compileStandalone(`
+      class P { constructor(v) { this.v = v; } d() { return this.v; } }
+      function callD(o) { return o.d(); }
+      export function test() { return callD(new P(5)); }
+    `);
+    expect(callExport(mod)).toBe(5);
+  });
+
+  it("an extracted method still sees an absent receiver — the #2025 TypeError is preserved", async () => {
+    const mod = await compileStandalone(`
+      class B extends Array { constructor(n) { super(n); this[0] = 4; } d() { return this[0]; } }
+      export function test() {
+        var b = new B(1);
+        var f = b.d;
+        try { f(); } catch (e) { return e instanceof TypeError ? 1 : 2; }
+        return 0;
+      }
+    `);
+    // 1 = calling the extracted method with no receiver threw a CATCHABLE
+    // TypeError rather than trapping or silently answering.
+    expect(callExport(mod)).toBe(1);
+  });
+});


### PR DESCRIPTION
# standalone: make a method on a `class B extends Array` instance reachable

Slice **S2b** of [#5383](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5383-standalone-temporal-provider) — the standalone `Temporal` provider. Two defects in the **externref-backed subclass** family (`class B extends Array`, i.e. jsbi's `class JSBI extends Array`), both reduced from the compiled `@js-temporal/polyfill`'s `__module_init` throw, both invisible in the JS-host lane where the real prototype does this work.

## R6 — an own-field write inside the constructor threw

`class B extends Array { constructor(n, s) { super(n); this.sign = s; } }` threw `TypeError: Cannot access property on null or undefined`.

`compilePropertyAssignment` consults `externrefBackedOwnFieldBacking`, which knows two carriers (`$Error_struct`, native `$Object`) and answers `undefined` for every other parent — and on `undefined` it fell through to the `struct.set` path. That path is unreachable by design here: the instance is a `$__vec_externref`, never a `$B`, so `ref.test $B` always misses, the receiver narrows to `ref.null $B`, and the #2084 guard throws.

The field only reaches that path because the constructor's own assignment flow-grows a `sign` slot onto the vestigial `$B` struct. The identical write from *outside* the class finds no slot, takes the #4149 dynamic-store arm, and has always worked — so the class's own constructor was the one place it failed. Fixed by routing the unknown-backing case to that same dynamic store, plus its read twin (scoped to keys that actually have a flow-grown slot, so `length` still reaches the array paths).

## R7 — a method was unreachable through a dynamic receiver, silently

| receiver | `o.d(0)` before | after |
| --- | --- | --- |
| `var x = new B(1); x.d(0)` | 5 | 5 |
| `function f(o) { return o.d(0); } f(b)` | **null** | 5 |

A statically-typed receiver compiles to `call $B_d`. Anything the checker cannot pin — and jsbi's statics take unannotated parameters (`static toNumber(i) { … i.__unsignedDigit(0) … }`) — goes out through the dynamic terminal, which resolves a method by `ref.test`ing instance identity. The carrier is not any of those types, and the host lane's answer (`__set_subclass_proto`) is a JS host import, so `emitSetSubclassProto` is a documented no-op standalone. The miss answered `null`, not a TypeError, which is why it survived.

Measured on the jsbi prefix before the fix: `JSBI.toNumber(JSBI.BigInt(5))` → `null`, `JSBI.add(5,3)` → `null`, `JSBI.unaryMinus(x)` → `null`. That null is what surfaced five frames later as `JSBI.subtract(null, …)`.

Two halves:

1. **`src/codegen/standalone-subclass-method-install.ts` (new)** — at construction, install each declared instance method on the instance as an own data property at §17 attributes (`{writable, !enumerable, configurable}`), using the same closure singleton and `__defineProperty_value` that `class-proto-object.ts` (#3976) uses for `C.prototype`. The dynamic terminals already consult the carrier's own-property side table (#3537 vec bag).
2. **The method trampoline's `this` slot** — installing alone was not enough: the trampoline built `this` by `ref.test`ing `__current_this` against the object struct, so every method still ran with `this === null`. For a method whose declared `this` is `externref` **and** whose owner is externref-backed, the carrier is now passed through. The #2025 absent-receiver TypeError is preserved and tested.

Alternatives measured and rejected (each would put the methods where the spec puts them): `Object.setPrototypeOf(inst, B.prototype)` and `inst.__proto__ = …` both still answer `null` — the standalone dynamic member path does not consult an explicit prototype link on a non-`$Object` carrier; and `emitStandaloneClassProtoObject` explicitly declines for a builtin-parent class, so `B.prototype` is still the legacy defaulted struct. The deviation shipped instead: the methods are OWN rather than inherited. They are non-enumerable, so `Object.keys` / `for-in` are unchanged.

`extends Error` is excluded **by measurement**: `__defineProperty_value` does not reach an `$Error_struct`'s `$props` side-slot, so such a class got 5.8 kB of machinery and still answered "called value is not a function". Deleting that one line is the whole fix once the Error carrier's dynamic member path reads `$props`.

## Order preservation

sha256 A/B over 6 modules × 2 targets (arith, plain class, `extends Array`, `extends Error`, object-literal method, Map/WeakMap):

- **`gc` lane: all six byte-identical.**
- standalone: **only the `extends Array` module changes**; the other five, including `extends Error`, are byte-identical.

## Where `__module_init` stops now

Not in jsbi any more. It stops in the polyfill's `Intl` section — `"formatToParts" in Intl.DateTimeFormat.prototype` at top level — because standalone deliberately leaves the `Intl` identifier null ([#5206](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5206-intl-global): "a compiled shim for it is a separate, much larger gap"). An `Intl.<member>` → `undefined` arm was written and **reverted**: it clears the first read and the next one throws on `.prototype`, so it moved the failure without removing it while changing standalone `Intl` semantics. The recommended continuation is for the provider builder to strip/stub the Intl-dependent section for standalone — the 66 Intl-dependent Temporal rows are already out of scope per #5383's own plan.

The S2 smoke test is therefore still **not** written; a skipped assertion would be worse than an honest gap. #5383 stays `in-progress`.

## Tests / gates

`tests/issue-5383-standalone-temporal-provider.test.ts` — 9 new cases (S2b R6 / S2b R7): the constructor write, the jsbi mint-then-read shape, the untouched element/length surface, an unaffected plain class and `extends Error`, dynamic dispatch through an untyped parameter, `this` reaching elements / an own field / `.length` / a sibling method, non-enumerability of the installed methods, and the preserved absent-receiver TypeError. 22/22 pass.

Green: `typecheck`, `check-loc-budget` (also with `LOC_GATE_BASE=origin/main`), `check-func-budget` (same), `check-coercion-sites`, `check:oracle-ratchet`, `check:dead-exports`, `check:host-import-policy`, `biome lint`, `equivalence-gate`, and the standalone subclass / class-family guard suites (#2620, #2917, #5384, #4455, #5191, #5195 ×3, #5201, #5204 — 178 + 43 passing).

Growth allowances (`loc-budget-allow` / `func-budget-allow`) are in #5383's frontmatter with a dated rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_