### PR TITLE
feat(ir): materialize native vector resources in the prepared consumer

### DIFF
--- a/plan/agent-context/3518-native-vector-checkpoint-handoff-2026-09-08.md
+++ b/plan/agent-context/3518-native-vector-checkpoint-handoff-2026-09-08.md
@@ -1,0 +1,73 @@
+# Physical vector checkpoint
+
+Base: PR #5763, commit `6ed68535323e0756c3a0b15dde18fd480ad7fc9f`.
+
+The isolated checkpoint composes twelve physical-vector implementation and
+test files from the earlier native-vector-consumer worktree. An independent
+byte comparison reported twelve matches and zero mismatches. The published
+logical and historical-reconstruction changes are inherited from the base,
+not replaced by older snapshots. Existing worktrees remain untouched.
+
+## Implementation
+
+The checked physical-plan entry authenticates prepared input before deriving
+vector resource requirements. Backend resources use the same physical module
+reservation ledger, shared array/carrier identities, exact provider bindings,
+and per-use nullability. The consumer reserves and binds the canonical
+grow/store helper before filling its body. Legacy adapters call the same
+extracted body and descriptor builders.
+
+Three compiler-boundary modules are activated without widening allowed edges.
+The async physical refusal remains: this checkpoint does not materialize the
+Promise/frame/timer/string family or establish direct-codegen retirement.
+
+## Evidence carried forward and pending checks
+
+The prior combined tree passed TS7 and all31 vector-resource tests. Inventory
+reported73 modules and259 edges (174 type-only,85 runtime), with zero errors.
+Its boundary run passed152/153; one negative mutation was a no-op because it
+assigned the already-existing layer. The corrected control now changes the
+layer and proves the digest changes before expecting rejection. Its focused
+rerun passed5/5 controls; the complete corrected153-test rerun is still pending.
+
+The extraction worker passed42/42 body/donor tests. Those test files were
+copied exactly. Public compiler comparison is still being validated: a sparse
+fixture did not exercise the grow/store helper, so that run cannot establish
+complete path coverage. The worker retains it and adds a positive fixture.
+
+Fresh composed-tree TS7, resource/boundary tests, the worker's final comparison,
+and High review are required before this checkpoint is published. No new
+composed-tree test pass is claimed by this handoff.
+
+## Subsequent measured results
+
+Public comparison revision2 controller82714 and both children exited0.
+The record reports14/14 equal pairs,28 compilation rows,56 expected calls,
+and zero raw differences across bytes, WAT and resource order. Emitted-path
+checks cover dense externref/f64, both hole-fill arms and packed branding;
+both populations report no coverage gaps. Five negative controls reject
+dropped rows, wrong roots, altered bytes, altered values and changed outcomes.
+The baseline is the unchanged explicit-recursive-group checkpoint2b9cb408c1;
+the candidate is the frozen grow/store extraction worker, not this composed
+consumer. These results prove donor preservation, not full async execution.
+
+Composed checkpoint session10660 passed TS7 and entered the four-suite run
+(resource, complete boundary, body and donor tests). The suite is still live;
+no terminal verdict is claimed yet.
+
+Session10660 subsequently exited0: TS7 passed, then226/226 tests across4/4
+files passed in100.20s. This includes the complete corrected153-test boundary
+suite,31 vector-resource tests,22 body tests and20 donor tests. No skipped
+tests or unhandled errors were reported. This supersedes the pending suite
+status above, not the limits on full async execution or retirement.
+
+High review approved the unchanged twelve implementation/test files after
+these results, finding no remaining blocker within physical-vector scope.
+
+The public-comparison worker identified a further instrumentation limit:
+WAT omits some type declarations, so its positional type lookup is incorrect
+for some non-core helpers. The raw equality of fourteen pairs and56 values
+remains measured; the lookup is not general type-provenance proof. A tracked
+reproducibility handoff is being prepared. Resource identity evidence comes
+from the explicit reservation implementation and focused resource tests,
+not from extrapolating that positional lookup.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6268,3 +6268,24 @@ conflicts, unresolved review threads, or reported failing/pending checks.
 Stacked PRs5752 and5754–5760 lack required checks because CI targets main;
 their mergeability is not evidence of complete CI coverage. Existing holds
 remain, and neither this checkpoint nor those checks establish retirement.
+
+## Physical vector checkpoint after PR #5763
+
+The physical vector checkpoint is based on6ed68535323e0756c3a0b15dde18fd480ad7fc9f.
+It composes same-ledger vector layouts, the canonical grow/store body, checked
+resource planning and consumer binding while retaining the async physical
+refusal. All12 transferred implementation/test files matched their reviewed
+source tree exactly. No existing worktree was reset or replaced.
+
+Fresh composed-tree session10660 exited0: TS7 and226/226 tests across4/4 files
+passed (153 boundary,31 resources,22 body,20 donor). Public compiler comparison
+revision2 controller82714 and both children exited0:14/14 pairs,28 rows,
+56 expected calls, zero raw differences and five rejecting negative controls.
+The comparison covers both hole-fill arms, dense carriers and packed branding;
+it is extraction preservation, not execution of the full prepared async family.
+
+Detailed limits and provenance are in
+`plan/agent-context/3518-native-vector-checkpoint-handoff-2026-09-08.md`.
+Promise resolution and same-ledger Promise resources are the next active
+implementation slices. Full frame/timer/string execution, public IR-only
+cutover, strict closure and the ABI30 witness remain outstanding.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -159,9 +159,10 @@
         "src/ir/program/prepared-contracts.ts",
         "src/ir/program/errors.ts",
         "src/ir/program/data.ts",
-        "src/ir/program/input.ts"
+        "src/ir/program/input.ts",
+        "src/ir/program/native-vector-resources.ts"
       ],
-      "minModules": 12
+      "minModules": 13
     },
     {
       "id": "runtime-contracts",
@@ -178,10 +179,10 @@
     },
     {
       "id": "backend-wasmgc",
-      "status": "planned",
+      "status": "active",
       "roots": ["src/backend/wasmgc"],
       "required": true,
-      "entries": ["src/backend/wasmgc/program/index.ts"],
+      "entries": ["src/backend/wasmgc/resources/native-vectors.ts"],
       "minModules": 1
     },
     {
@@ -195,9 +196,10 @@
         "src/runtime/wasmgc/async/frame-engine.ts",
         "src/runtime/wasmgc/async/native-await.ts",
         "src/runtime/wasmgc/promise/delay-bodies.ts",
-        "src/runtime/wasmgc/promise/combinator-bodies.ts"
+        "src/runtime/wasmgc/promise/combinator-bodies.ts",
+        "src/runtime/wasmgc/values/vector-grow-store.ts"
       ],
-      "minModules": 6
+      "minModules": 7
     },
     {
       "id": "standalone-platform",
@@ -436,6 +438,43 @@
     }
   ],
   "activationHistory": [
+    {
+      "layer": "ir-program",
+      "entries": [
+        "src/ir/program/abi-inventory.ts",
+        "src/ir/program/abi.ts",
+        "src/ir/program/startup.ts",
+        "src/ir/program/abi-lookup.ts",
+        "src/ir/program/callable-bindings.ts",
+        "src/ir/program/controls.ts",
+        "src/ir/program/index.ts",
+        "src/ir/program/input-contracts.ts",
+        "src/ir/program/prepared-contracts.ts",
+        "src/ir/program/errors.ts",
+        "src/ir/program/data.ts",
+        "src/ir/program/input.ts",
+        "src/ir/program/native-vector-resources.ts"
+      ],
+      "minModules": 13
+    },
+    {
+      "layer": "native-runtime",
+      "entries": [
+        "src/runtime/wasmgc/async/microtask-queue-bodies.ts",
+        "src/runtime/wasmgc/promise/settlement-bodies.ts",
+        "src/runtime/wasmgc/async/frame-engine.ts",
+        "src/runtime/wasmgc/async/native-await.ts",
+        "src/runtime/wasmgc/promise/delay-bodies.ts",
+        "src/runtime/wasmgc/promise/combinator-bodies.ts",
+        "src/runtime/wasmgc/values/vector-grow-store.ts"
+      ],
+      "minModules": 7
+    },
+    {
+      "layer": "backend-wasmgc",
+      "entries": ["src/backend/wasmgc/resources/native-vectors.ts"],
+      "minModules": 1
+    },
     {
       "layer": "ir-core",
       "entries": [
@@ -868,6 +907,9 @@
     }
   ],
   "files": [
+    { "path": "src/ir/program/native-vector-resources.ts", "state": "clean", "layer": "ir-program" },
+    { "path": "src/backend/wasmgc/resources/native-vectors.ts", "state": "clean", "layer": "backend-wasmgc" },
+    { "path": "src/runtime/wasmgc/values/vector-grow-store.ts", "state": "clean", "layer": "native-runtime" },
     { "path": "src/shared/contracts/ir-preparation-failure.ts", "state": "clean", "layer": "foundation" },
     { "path": "src/shared/contracts/ir-unit-inventory.ts", "state": "clean", "layer": "foundation" },
     { "path": "src/ir/analysis/contracts/allocations.ts", "state": "clean", "layer": "ir-analysis" },

--- a/src/backend/wasmgc/resources/native-vectors.ts
+++ b/src/backend/wasmgc/resources/native-vectors.ts
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrType } from "../../../ir/core/types.js";
+import type { NativeVectorElement, NativeVectorResourcePlan } from "../../../ir/program/native-vector-resources.js";
+import { VECTOR_CALLABLE_DECLARATION } from "../../../ir/runtime/vector-callables.js";
+import { irCallableBindingKey } from "../../../ir/core/callable-bindings.js";
+import { preparedIrDataMismatch } from "../../../ir/program/data.js";
+import type { ValType } from "../../../wasm/model/instructions.js";
+import {
+  type PhysicalModuleReservations,
+  type PhysicalFunctionSignature,
+  type TypeReservation,
+  type FunctionReservation,
+  type TagReservation,
+  type TagImportReservation,
+} from "../../../wasm/physical/module-reservations.js";
+import {
+  buildVectorGrowStoreBody,
+  createVectorBaseType,
+  createVectorBackingArrayType,
+  createVectorCarrierType,
+} from "../../../runtime/wasmgc/values/vector-grow-store.js";
+
+export interface NativeVectorLayout {
+  readonly vecStructTypeIdx: number;
+  readonly arrayTypeIdx: number;
+  readonly elementValType: ValType;
+  // Deliberately no valueType: each logical use owns its nullability.
+}
+export interface NativeVectorReservedLayout {
+  readonly element: NativeVectorElement;
+  readonly array: TypeReservation;
+  readonly carrier: TypeReservation;
+  readonly layout: NativeVectorLayout;
+}
+export interface NativeVectorTypeReservations {
+  readonly base?: TypeReservation;
+  readonly layouts: readonly NativeVectorReservedLayout[];
+}
+export interface NativeVectorHelperReservation {
+  readonly function: FunctionReservation;
+}
+
+// Provenance/completion checks only; physical allocation and resource identity remain
+// exclusively owned by the caller's PhysicalModuleReservations transaction.
+const typeOwners = new WeakMap<
+  NativeVectorTypeReservations,
+  { transaction: PhysicalModuleReservations; plan: NativeVectorResourcePlan }
+>();
+const helperOwners = new WeakMap<
+  NativeVectorHelperReservation,
+  {
+    transaction: PhysicalModuleReservations;
+    types: NativeVectorTypeReservations;
+    tag: TagReservation | TagImportReservation;
+    signature: PhysicalFunctionSignature;
+    tagTypeIndex: number;
+  }
+>();
+
+function fail(detail: string): never {
+  throw new Error(`native vector resources: ${detail}`);
+}
+function equal(actual: unknown, expected: unknown, detail: string): void {
+  if (preparedIrDataMismatch(actual, expected) !== undefined) fail(detail);
+}
+function validateTypes(types: NativeVectorTypeReservations, transaction?: PhysicalModuleReservations): void {
+  const owner = typeOwners.get(types);
+  if (!owner || (transaction && owner.transaction !== transaction)) fail("foreign vector type reservations");
+  if (types.layouts.length === 0) {
+    if (types.base) fail("unexpected vector base");
+    return;
+  }
+  if (!types.base) fail("missing shared vector base");
+  equal(types.base.object, createVectorBaseType(), "vector base descriptor mismatch");
+  for (const row of types.layouts) {
+    equal(
+      row.array.object,
+      createVectorBackingArrayType(`__arr_${row.element}`, { kind: row.element }),
+      "vector backing array descriptor mismatch",
+    );
+    equal(
+      row.carrier.object,
+      createVectorCarrierType({
+        name: `__vec_${row.element}`,
+        baseTypeIndex: types.base.typeIndex,
+        arrayTypeIndex: row.array.typeIndex,
+      }),
+      "vector carrier descriptor mismatch",
+    );
+    equal(
+      row.layout,
+      {
+        vecStructTypeIdx: row.carrier.typeIndex,
+        arrayTypeIdx: row.array.typeIndex,
+        elementValType: { kind: row.element },
+      },
+      "vector lookup descriptor mismatch",
+    );
+  }
+}
+
+/** Reserve on the caller's empty-origin transaction; never adopt legacy caches. */
+export function reserveNativeVectorTypes(
+  transaction: PhysicalModuleReservations,
+  plan: NativeVectorResourcePlan,
+): NativeVectorTypeReservations {
+  if (!plan.anchor) fail("missing entry-source anchor");
+  equal(
+    plan.layouts,
+    (["f64", "externref"] as const).filter((element) => plan.layouts.includes(element)),
+    "noncanonical vector layout order/population",
+  );
+  const key = (role: string): string => `physical:vector:${JSON.stringify(plan.anchor)}:${role}`;
+  const base = plan.layouts.length ? transaction.reserveType(key("base"), createVectorBaseType()) : undefined;
+  const layouts = plan.layouts.map((element): NativeVectorReservedLayout => {
+    const array = transaction.reserveType(
+      key(`array:${element}`),
+      createVectorBackingArrayType(`__arr_${element}`, { kind: element }),
+    );
+    const carrier = transaction.reserveType(
+      key(`carrier:${element}`),
+      createVectorCarrierType({
+        name: `__vec_${element}`,
+        baseTypeIndex: base!.typeIndex,
+        arrayTypeIndex: array.typeIndex,
+      }),
+    );
+    return Object.freeze({
+      element,
+      array,
+      carrier,
+      layout: Object.freeze({
+        vecStructTypeIdx: carrier.typeIndex,
+        arrayTypeIdx: array.typeIndex,
+        elementValType: Object.freeze({ kind: element }),
+      }),
+    });
+  });
+  const result = Object.freeze({ ...(base ? { base } : {}), layouts: Object.freeze(layouts) });
+  typeOwners.set(result, { transaction, plan });
+  return result;
+}
+
+export function resolveNativeVectorForElement(
+  types: NativeVectorTypeReservations,
+  element: ValType,
+): NativeVectorLayout | undefined {
+  validateTypes(types);
+  return types.layouts.find((row) => preparedIrDataMismatch(row.layout.elementValType, element) === undefined)?.layout;
+}
+export function resolveNativeVector(
+  types: NativeVectorTypeReservations,
+  value: ValType,
+): NativeVectorLayout | undefined {
+  validateTypes(types);
+  return value.kind === "ref" || value.kind === "ref_null"
+    ? types.layouts.find((row) => row.carrier.typeIndex === value.typeIdx)?.layout
+    : undefined;
+}
+export function nativeVectorPhysicalType(types: NativeVectorTypeReservations, type: IrType): ValType | undefined {
+  validateTypes(types);
+  if (type.kind === "val") return type.typeRef ? undefined : type.val;
+  if (type.kind !== "vec" || type.layout || type.elementType.kind !== "val" || type.elementType.typeRef)
+    return undefined;
+  const layout = resolveNativeVectorForElement(types, type.elementType.val);
+  return layout ? { kind: type.nullable ? "ref_null" : "ref", typeIdx: layout.vecStructTypeIdx } : undefined;
+}
+export function nativeVectorPhysicalSignature(
+  types: NativeVectorTypeReservations,
+  signature: { readonly params: readonly IrType[]; readonly results: readonly IrType[] },
+): PhysicalFunctionSignature | undefined {
+  const params = signature.params.map((type) => nativeVectorPhysicalType(types, type));
+  const results = signature.results.map((type) => nativeVectorPhysicalType(types, type));
+  return params.every((type): type is ValType => type !== undefined) &&
+    results.every((type): type is ValType => type !== undefined)
+    ? { params, results }
+    : undefined;
+}
+
+/** Call after imports and original unit functions, before startup support/freeze. */
+export function reserveNativeVectorHelper(
+  transaction: PhysicalModuleReservations,
+  plan: NativeVectorResourcePlan,
+  types: NativeVectorTypeReservations,
+  tag: TagReservation | TagImportReservation | undefined,
+): NativeVectorHelperReservation | undefined {
+  validateTypes(types, transaction);
+  equal(typeOwners.get(types)!.plan, plan, "vector plan changed between reservations");
+  if (!plan.helper) return undefined;
+  if (!plan.exceptionRequired || !tag) fail("vector helper requires the reserved exception tag");
+  const declaration = VECTOR_CALLABLE_DECLARATION;
+  if (
+    plan.helper.referenceKey !== irCallableBindingKey(declaration.ref.binding) ||
+    plan.helper.name !== declaration.ref.name
+  )
+    fail("noncanonical vector helper binding");
+  const signature = nativeVectorPhysicalSignature(types, declaration);
+  if (!signature) fail("vector helper signature lacks its exact carrier");
+  const tagTypeIndex = transaction.internFunctionType([{ kind: "externref" }], []);
+  if (tag.kind === "tag")
+    equal(tag.object, { name: "__exn", typeIdx: tagTypeIndex }, "exception tag descriptor mismatch");
+  else
+    equal(
+      tag.object,
+      { module: "env", name: "__exn", desc: { kind: "tag", typeIdx: tagTypeIndex } },
+      "shared exception tag descriptor mismatch",
+    );
+  const fn = transaction.reserveFunction(plan.helper.bindingId, plan.helper.name, signature);
+  const result = Object.freeze({ function: fn });
+  helperOwners.set(result, { transaction, types, tag, signature, tagTypeIndex });
+  return result;
+}
+
+/** Fill exactly the reserved helper after the caller freezes; never freeze or seal here. */
+export function fillNativeVectorHelper(
+  transaction: PhysicalModuleReservations,
+  helper: NativeVectorHelperReservation,
+): void {
+  const owner = helperOwners.get(helper);
+  if (!owner || owner.transaction !== transaction) fail("foreign vector helper reservation");
+  validateTypes(owner.types, transaction);
+  for (const token of [owner.types.base!, ...owner.types.layouts.flatMap((row) => [row.array, row.carrier])])
+    if (transaction.physicalIndex(token) !== token.typeIndex) fail("vector type coordinate mismatch");
+  transaction.physicalIndex(helper.function);
+  const tagIndex = transaction.physicalIndex(owner.tag);
+  const layout = resolveNativeVectorForElement(owner.types, { kind: "externref" });
+  if (!layout) fail("missing externref vector carrier");
+  transaction.fillFunction(
+    helper.function,
+    buildVectorGrowStoreBody({
+      carrierTypeIndex: layout.vecStructTypeIdx,
+      arrayTypeIndex: layout.arrayTypeIdx,
+      exceptionTagIndex: tagIndex,
+      gapFill: { kind: "default" },
+    }),
+  );
+}

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -5,7 +5,12 @@
  * This module owns function-type caches plus reusable GC array/vec/ref-cell
  * registrations so leaf modules can depend on a narrow type-registry surface.
  */
-import type { ArrayTypeDef, FieldDef, FuncTypeDef, StructTypeDef, ValType } from "../../ir/types.js";
+import type { FieldDef, FuncTypeDef, StructTypeDef, ValType } from "../../ir/types.js";
+import {
+  createVectorBaseType,
+  createVectorBackingArrayType,
+  createVectorCarrierType,
+} from "../../runtime/wasmgc/values/vector-grow-store.js";
 import type { CodegenContext } from "../context/types.js";
 import { internFunctionType } from "../../wasm/physical/function-types.js";
 import { getArgumentsVecTypeIdx } from "../arguments-carrier-brand.js";
@@ -61,12 +66,7 @@ export function getOrRegisterArrayType(ctx: CodegenContext, elemKind: string, el
     elemType = { kind: "ref_null", typeIdx: (elemType as { typeIdx: number }).typeIdx };
   }
   const idx = ctx.mod.types.length;
-  ctx.mod.types.push({
-    kind: "array",
-    name: `__arr_${cacheKey}`,
-    element: elemType,
-    mutable: true,
-  } as ArrayTypeDef);
+  ctx.mod.types.push(createVectorBackingArrayType(`__arr_${cacheKey}`, elemType));
   ctx.arrayTypeMap.set(cacheKey, idx);
   return idx;
 }
@@ -82,12 +82,7 @@ export function getOrRegisterArrayType(ctx: CodegenContext, elemKind: string, el
 export function getOrRegisterVecBaseType(ctx: CodegenContext): number {
   if (ctx.vecBaseTypeIdx >= 0) return ctx.vecBaseTypeIdx;
   const idx = ctx.mod.types.length;
-  ctx.mod.types.push({
-    kind: "struct",
-    name: "__vec_base",
-    superTypeIdx: -1, // open / non-final — concrete vecs subtype this
-    fields: [{ name: "length", type: { kind: "i32" }, mutable: true }],
-  });
+  ctx.mod.types.push(createVectorBaseType());
   ctx.vecBaseTypeIdx = idx;
   ctx.structMap.set("__vec_base", idx);
   ctx.typeIdxToStructName.set(idx, "__vec_base");
@@ -185,32 +180,26 @@ export function getOrRegisterVecType(ctx: CodegenContext, elemKind: string, elem
 
   const arrTypeIdx = getOrRegisterArrayType(ctx, elemKind, elemTypeOverride);
   const vecIdx = ctx.mod.types.length;
-  ctx.mod.types.push({
-    kind: "struct",
-    name: `__vec_${cacheKey}`,
-    superTypeIdx: vecBaseIdx,
-    // (#5349) Brand the packed-byte TypedArray carrier. `$__vec_i8_byte` and
-    // the ArrayBuffer's `$__vec_i32_byte` declare the same two fields over
-    // structurally identical `(array (mut i8))` data, so once BOTH are marked
-    // `final` by `markLeafStructsFinal` Wasm GC canonicalizes them to ONE
-    // runtime type and no `ref.test` can separate a `Uint8Array` from an
-    // ArrayBuffer (the §25.1.5.3 step-16 slot check). Declaring `final` here,
-    // while `finalizeLeafStructTypes` keeps `i32_byte` open, makes the two
-    // distinct canonical types. Sound because the packed-byte vec has no
-    // subtype anywhere: every `superTypeIdx` in `src/codegen` names
-    // `$__vec_base`, the externref vec, `$__vec_i32_byte` (`$__resizable_ab`)
-    // or a class/brand struct. Declared, not post-seal mutated, so
-    // `programAbiSession.recordLeafTypeFinalization` is not involved.
-    ...(cacheKey === "i8_byte" ? { final: true } : {}),
-    fields: [
-      { name: "length", type: { kind: "i32" }, mutable: true },
-      {
-        name: "data",
-        type: { kind: "ref", typeIdx: arrTypeIdx },
-        mutable: true,
-      },
-    ],
-  });
+  ctx.mod.types.push(
+    createVectorCarrierType({
+      name: `__vec_${cacheKey}`,
+      baseTypeIndex: vecBaseIdx,
+      arrayTypeIndex: arrTypeIdx,
+      // (#5349) Brand the packed-byte TypedArray carrier. `$__vec_i8_byte` and
+      // the ArrayBuffer's `$__vec_i32_byte` declare the same two fields over
+      // structurally identical `(array (mut i8))` data, so once BOTH are marked
+      // `final` by `markLeafStructsFinal` Wasm GC canonicalizes them to ONE
+      // runtime type and no `ref.test` can separate a `Uint8Array` from an
+      // ArrayBuffer (the §25.1.5.3 step-16 slot check). Declaring `final` here,
+      // while `finalizeLeafStructTypes` keeps `i32_byte` open, makes the two
+      // distinct canonical types. Sound because the packed-byte vec has no
+      // subtype anywhere: every `superTypeIdx` in `src/codegen` names
+      // `$__vec_base`, the externref vec, `$__vec_i32_byte` (`$__resizable_ab`)
+      // or a class/brand struct. Declared, not post-seal mutated, so
+      // `programAbiSession.recordLeafTypeFinalization` is not involved.
+      ...(cacheKey === "i8_byte" ? { final: true } : {}),
+    }),
+  );
   ctx.vecTypeMap.set(cacheKey, vecIdx);
 
   const vecStructName = `__vec_${cacheKey}`;

--- a/src/codegen/vec-elem-set.ts
+++ b/src/codegen/vec-elem-set.ts
@@ -21,12 +21,13 @@
 //
 // The helper is pure WasmGC — no host import — so it works identically in
 // JS-host and standalone modes (the dual-mode rule).
-import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import type { ValType, WasmFunction } from "../ir/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType, getOrRegisterHoleyArrayType, getOrRegisterVecType, isHoleyArrayType } from "./registry/types.js";
 import { ensureExnTag } from "./registry/imports.js";
-import { holeSentinelInstrs } from "./array-holes.js";
+import { ensureHoleType, holeSentinelInstrs } from "./array-holes.js";
+import { buildVectorGrowStoreBody, type VectorGrowStoreGapFill } from "../runtime/wasmgc/values/vector-grow-store.js";
 import { f64HolesActive } from "./vec-f64-hole-presence.js";
 import { HOLE_F64_BITS } from "./value-tags.js";
 
@@ -176,11 +177,11 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
   // encounter a sparse indexed write before it emits a f64 literal marker.
   const f64HoleCarrier = ctx.standalone && elem.kind === "f64" && f64HolesActive(ctx);
   if (f64HoleCarrier) ctx.f64HoleMarkerEmitted = true;
-  const gapFillInit: Instr[] = holeyCarrier
-    ? holeSentinelInstrs(ctx)
+  const gapFill: VectorGrowStoreGapFill = holeyCarrier
+    ? { kind: "hole-global", globalIndex: ensureHoleType(ctx) }
     : f64HoleCarrier
-      ? [{ op: "i64.const", value: HOLE_F64_BITS }, { op: "f64.reinterpret_i64" }]
-      : [];
+      ? { kind: "f64-hole", bits: HOLE_F64_BITS }
+      : { kind: "default" };
   // (#4430) The branded sparse carrier is a FINAL subtype of the ordinary
   // externref vec, and BOTH fields this helper touches (`length`, `data`) are
   // declared on that parent. The IR path types the receiving binding from the
@@ -201,163 +202,17 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
   const sigIdx = addFuncType(ctx, [vecParam, { kind: "i32" }, elem], [], `$${name}_type`);
   const funcIdx = mintDefinedFunc(ctx);
 
-  // Params: 0=vec, 1=idx, 2=val. Locals: 3=data, 4=newCap, 5=newData, 6=oldCap.
-  const VEC = 0;
-  const IDX = 1;
-  const VAL = 2;
-  const DATA = 3;
-  const NCAP = 4;
-  const NDATA = 5;
-  const OCAP = 6;
-  const OLEN = 7;
-
-  const body: Instr[] = [
-    // ── Null guard (#441 parity): if (vec == null) throw TypeError ─────────
-    { op: "local.get", index: VEC },
-    { op: "ref.is_null" },
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [{ op: "ref.null.extern" }, { op: "throw", tagIdx }],
-      else: [],
-    },
-    // ── data = vec.data ─────────────────────────────────────────────────────
-    { op: "local.get", index: VEC },
-    { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 1 },
-    { op: "local.set", index: DATA },
-    // ── Grow when idx >= capacity (legacy sequence) ─────────────────────────
-    { op: "local.get", index: IDX },
-    { op: "local.get", index: DATA },
-    { op: "array.len" },
-    { op: "i32.ge_s" },
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        // oldCap = array.len(data)
-        { op: "local.get", index: DATA },
-        { op: "array.len" },
-        { op: "local.set", index: OCAP },
-        // newCap = idx + 1
-        { op: "local.get", index: IDX },
-        { op: "i32.const", value: 1 },
-        { op: "i32.add" },
-        { op: "local.set", index: NCAP },
-        // if (oldCap * 2 > newCap) newCap = oldCap * 2
-        { op: "local.get", index: OCAP },
-        { op: "i32.const", value: 1 },
-        { op: "i32.shl" },
-        { op: "local.get", index: NCAP },
-        { op: "i32.gt_s" },
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [
-            { op: "local.get", index: OCAP },
-            { op: "i32.const", value: 1 },
-            { op: "i32.shl" },
-            { op: "local.set", index: NCAP },
-          ],
-        },
-        // if (4 > newCap) newCap = 4
-        { op: "i32.const", value: 4 },
-        { op: "local.get", index: NCAP },
-        { op: "i32.gt_s" },
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [
-            { op: "i32.const", value: 4 },
-            { op: "local.set", index: NCAP },
-          ],
-        },
-        // Branded externref sparse carriers and standalone f64 sparse carriers
-        // fill new capacity with their respective absence markers. Dense
-        // carriers retain the ordinary zero/null default.
-        ...gapFillInit,
-        { op: "local.get", index: NCAP },
-        ...(holeyCarrier || f64HoleCarrier
-          ? ([{ op: "array.new", typeIdx: arrTypeIdx }] satisfies Instr[])
-          : ([{ op: "array.new_default", typeIdx: arrTypeIdx }] satisfies Instr[])),
-        { op: "local.set", index: NDATA },
-        // array.copy newData[0..oldCap] = data[0..oldCap]
-        { op: "local.get", index: NDATA },
-        { op: "i32.const", value: 0 },
-        { op: "local.get", index: DATA },
-        { op: "i32.const", value: 0 },
-        { op: "local.get", index: OCAP },
-        { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx },
-        // vec.data = newData
-        { op: "local.get", index: VEC },
-        { op: "local.get", index: NDATA },
-        { op: "ref.as_non_null" },
-        { op: "struct.set", typeIdx: carrierTypeIdx, fieldIdx: 1 },
-        // data = newData
-        { op: "local.get", index: NDATA },
-        { op: "local.set", index: DATA },
-      ],
-    },
-    ...(holeyCarrier || f64HoleCarrier
-      ? ([
-          // A write beyond logical length can land in already-allocated spare
-          // capacity. Preserve absence in the full [oldLength, idx) gap for
-          // both branded externref and standalone f64 sparse carriers.
-          { op: "local.get", index: VEC },
-          { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 0 },
-          { op: "local.set", index: OLEN },
-          { op: "local.get", index: IDX },
-          { op: "local.get", index: OLEN },
-          { op: "i32.gt_u" },
-          {
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [
-              { op: "local.get", index: DATA },
-              { op: "local.get", index: OLEN },
-              ...gapFillInit,
-              { op: "local.get", index: IDX },
-              { op: "local.get", index: OLEN },
-              { op: "i32.sub" },
-              { op: "array.fill", typeIdx: arrTypeIdx },
-            ],
-          },
-        ] satisfies Instr[])
-      : []),
-    // ── data[idx] = val ─────────────────────────────────────────────────────
-    { op: "local.get", index: DATA },
-    { op: "local.get", index: IDX },
-    { op: "local.get", index: VAL },
-    { op: "array.set", typeIdx: arrTypeIdx },
-    // ── if (idx + 1 > vec.length) vec.length = idx + 1 ─────────────────────
-    { op: "local.get", index: IDX },
-    { op: "i32.const", value: 1 },
-    { op: "i32.add" },
-    { op: "local.get", index: VEC },
-    { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 0 },
-    { op: "i32.gt_u" },
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        { op: "local.get", index: VEC },
-        { op: "local.get", index: IDX },
-        { op: "i32.const", value: 1 },
-        { op: "i32.add" },
-        { op: "struct.set", typeIdx: carrierTypeIdx, fieldIdx: 0 },
-      ],
-    },
-  ];
+  const { locals, body } = buildVectorGrowStoreBody({
+    carrierTypeIndex: carrierTypeIdx,
+    arrayTypeIndex: arrTypeIdx,
+    exceptionTagIndex: tagIdx,
+    gapFill,
+  });
 
   const fn: WasmFunction = {
     name,
     typeIdx: sigIdx,
-    locals: [
-      { name: "$data", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
-      { name: "$ncap", type: { kind: "i32" } },
-      { name: "$ndata", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
-      { name: "$ocap", type: { kind: "i32" } },
-      ...(holeyCarrier || f64HoleCarrier ? [{ name: "$oldlen", type: { kind: "i32" } as ValType }] : []),
-    ],
+    locals,
     body,
     exported: false,
   };

--- a/src/ir/program-consumer.ts
+++ b/src/ir/program-consumer.ts
@@ -28,6 +28,14 @@
 
 import { sameValTypes } from "../wasm/physical/function-types.js";
 import {
+  reserveNativeVectorTypes,
+  reserveNativeVectorHelper,
+  fillNativeVectorHelper,
+  nativeVectorPhysicalType,
+  resolveNativeVector,
+  resolveNativeVectorForElement,
+} from "../backend/wasmgc/resources/native-vectors.js";
+import {
   PhysicalModuleReservations,
   type CallableReservation,
   type FunctionReservation,
@@ -45,7 +53,7 @@ import { forEachInstrDeep, type IrFuncRef, type IrFunction, type IrGlobalRef } f
 import type { IrPreparationFailure } from "./outcomes.js";
 import { ProgramAbiMap } from "./program-abi.js";
 import { observePreparedIrProgram } from "./program-observation.js";
-import { planPhysicalSetup, type PhysicalSetupPlan } from "./program-physical-plan.js";
+import { planPhysicalSetup, type PhysicalSetupPlan, type PhysicalSignatureType } from "./program-physical-plan.js";
 import { assertPreparedIrProgram } from "./program-validation.js";
 import {
   preparedIrProgramOwner,
@@ -289,8 +297,27 @@ function materializePhysicalProgram(
       )
     : undefined;
 
+  const vectorTypes = reserveNativeVectorTypes(reservations, plan.vectors);
+  const physicalSignature = (signature: {
+    readonly params: readonly PhysicalSignatureType[];
+    readonly results: readonly PhysicalSignatureType[];
+  }) => {
+    const convert = (types: readonly PhysicalSignatureType[]): ValType[] =>
+      types.map((type) => {
+        const value = nativeVectorPhysicalType(vectorTypes, type.kind === "vec" ? type : { kind: "val", val: type });
+        if (!value) emissionFailed("accepted signature has no reserved physical carrier");
+        return value;
+      });
+    return { params: convert(signature.params), results: convert(signature.results) };
+  };
+
   for (const imported of plan.importedFunctions) {
-    const reserved = reservations.reserveFunctionImport(imported.bindingId, imported.module, imported.field, imported);
+    const reserved = reservations.reserveFunctionImport(
+      imported.bindingId,
+      imported.module,
+      imported.field,
+      physicalSignature(imported),
+    );
     functionsByKey.set(imported.referenceKey, reserved);
     resourcesByBinding.set(imported.bindingId, reserved);
   }
@@ -314,11 +341,19 @@ function materializePhysicalProgram(
   const slots = new Map<IrUnitId, FunctionReservation>();
   const slotOwners = new Map<WasmFunction, IrUnitId>();
   for (const declared of plan.functions) {
-    const reserved = reservations.reserveFunction(declared.bindingId, declared.name, declared);
+    const reserved = reservations.reserveFunction(declared.bindingId, declared.name, physicalSignature(declared));
     slots.set(declared.unitId, reserved);
     slotOwners.set(reserved.object, declared.unitId);
     functionsByKey.set(irCallableBindingKey({ kind: "unit", unitId: declared.unitId }), reserved);
     resourcesByBinding.set(declared.bindingId, reserved);
+  }
+  const vectorHelper = reserveNativeVectorHelper(reservations, plan.vectors, vectorTypes, exceptionTag);
+  if (vectorHelper) {
+    if (!plan.vectors.helper) emissionFailed("vector helper has no authenticated binding plan");
+    functionsByKey.set(plan.vectors.helper.referenceKey, vectorHelper.function);
+    resourcesByBinding.set(plan.vectors.helper.bindingId, vectorHelper.function);
+  } else if (plan.vectors.helper) {
+    emissionFailed("planned vector helper was not reserved");
   }
   let startAdapter: FunctionReservation | undefined;
   if (plan.startup.units.length > 0) {
@@ -353,6 +388,12 @@ function materializePhysicalProgram(
       index: reservations.physicalIndex(slots.get(declared.unitId)!),
     });
   }
+  if (vectorHelper && plan.vectors.helper) {
+    abi.bindFinalIndex(plan.vectors.helper.bindingId, {
+      space: "function",
+      index: reservations.physicalIndex(vectorHelper.function),
+    });
+  }
   for (const global of [...plan.importedGlobals, ...plan.definedGlobals]) {
     abi.bindFinalIndex(global.bindingId, {
       space: "global",
@@ -360,8 +401,12 @@ function materializePhysicalProgram(
     });
   }
   abi.finishBinding();
+  if (vectorHelper) fillNativeVectorHelper(reservations, vectorHelper);
 
   // 4. Lower every physical body into its reserved slot.
+  // Resource validation authenticates this exact shared two-field layout.
+  const vectorLowering = (layout: ReturnType<typeof resolveNativeVector>) =>
+    layout ? { ...layout, lengthFieldIdx: 0, dataFieldIdx: 1 } : null;
   const resolver: IrLowerResolver = {
     resolveFunc: (ref: IrFuncRef) => {
       const reserved = functionsByKey.get(irCallableBindingKey(ref.binding));
@@ -374,6 +419,8 @@ function materializePhysicalProgram(
       return reservations.physicalIndex(reserved);
     },
     resolveType: (ref) => emissionFailed(`type ${ref.name} was not reserved`),
+    resolveVec: (type) => vectorLowering(resolveNativeVector(vectorTypes, type)),
+    resolveVecForElement: (element) => vectorLowering(resolveNativeVectorForElement(vectorTypes, element)),
     internFuncType: (type) => reservations.internFunctionType(type.params, type.results),
     ensureExnTag: () => {
       if (exnTagIdx === undefined) emissionFailed("a body requires the __exn tag but the plan reserved none");
@@ -403,7 +450,8 @@ function materializePhysicalProgram(
     }
     const params = lowered.params.flatMap((param) => [...param.slots]);
     const results = lowered.results.flatMap((result) => [...result]);
-    if (!sameValTypes(params, declared.params) || !sameValTypes(results, declared.results)) {
+    const signature = physicalSignature(declared);
+    if (!sameValTypes(params, signature.params) || !sameValTypes(results, signature.results)) {
       emissionFailed(`body ${declared.unitId} lowered to a signature that contradicts its reserved ABI slot`);
     }
     reservations.fillFunction(reserved, {
@@ -453,7 +501,9 @@ function materializePhysicalProgram(
   for (const fn of module.functions) {
     const unitId = slotOwners.get(fn);
     if (unitId === undefined) {
-      if (fn !== startAdapter?.object) emissionFailed(`module carries an unowned function ${fn.name}`);
+      if (fn !== startAdapter?.object && fn !== vectorHelper?.function.object) {
+        emissionFailed(`module carries an unowned function ${fn.name}`);
+      }
       continue;
     }
     emittedUnitIds.push(unitId);

--- a/src/ir/program-physical-plan.ts
+++ b/src/ir/program-physical-plan.ts
@@ -28,13 +28,18 @@ import {
   type PreparedIrProgramRuntimeProjection,
 } from "./program.js";
 import type { ValType } from "./types.js";
+import { deriveNativeVectorResourcePlan, type NativeVectorResourcePlan } from "./program/native-vector-resources.js";
+import { assertPreparedIrProgram } from "./program-validation.js";
+
+/** Vector carriers stay logical until the consumer reserves their shared types. */
+export type PhysicalSignatureType = ValType | Extract<IrType, { kind: "vec" }>;
 
 export interface PhysicalFunctionSlot {
   readonly unitId: IrUnitId;
   readonly bindingId: IrBindingId;
   readonly name: string;
-  readonly params: readonly ValType[];
-  readonly results: readonly ValType[];
+  readonly params: readonly PhysicalSignatureType[];
+  readonly results: readonly PhysicalSignatureType[];
 }
 
 export interface PhysicalImportedFunction {
@@ -42,8 +47,8 @@ export interface PhysicalImportedFunction {
   readonly referenceKey: string;
   readonly module: string;
   readonly field: string;
-  readonly params: readonly ValType[];
-  readonly results: readonly ValType[];
+  readonly params: readonly PhysicalSignatureType[];
+  readonly results: readonly PhysicalSignatureType[];
 }
 
 export interface PhysicalDefinedGlobal {
@@ -84,6 +89,7 @@ export interface PhysicalSetupPlan {
   readonly backend: PreparedIrBackendOptions["backend"];
   readonly target: PreparedIrBackendOptions["target"];
   readonly exceptionTag: PhysicalExceptionTag;
+  readonly vectors: NativeVectorResourcePlan;
   readonly importedFunctions: readonly PhysicalImportedFunction[];
   readonly importedGlobals: readonly PhysicalImportedGlobal[];
   readonly definedGlobals: readonly PhysicalDefinedGlobal[];
@@ -96,6 +102,41 @@ export interface PhysicalSetupPlan {
 export type PhysicalSetupOutcome =
   | { readonly kind: "planned"; readonly plan: PhysicalSetupPlan }
   | PreparedIrProgramFailure;
+
+/** Checked program entry; the canonical calculation has no acceptance authority. */
+export function planNativeVectorResources(
+  program: PreparedIrProgram,
+  options: PreparedIrBackendOptions,
+  projection: PreparedIrProgramRuntimeProjection,
+): NativeVectorResourcePlan {
+  assertPreparedIrProgram(program);
+  if (
+    !program.runtime.includes(projection) ||
+    projection.backend !== options.backend ||
+    projection.target !== options.target
+  ) {
+    throw new PreparedIrProgramInvariantError(
+      "invalid-prepared-data",
+      "native vector resources: selected projection does not belong to the requested program/backend/target",
+    );
+  }
+  const entry = program.inventory.sources.find((source) => source.kind === "entry");
+  if (!entry) {
+    throw new PreparedIrProgramInvariantError(
+      "invalid-prepared-data",
+      "native vector resources: missing entry-source anchor",
+    );
+  }
+  return deriveNativeVectorResourcePlan({
+    anchor: entry.id,
+    functions: program.ir.functions,
+    abiEntries: program.abi.entries,
+    policy: projection.prepared.manifest.policy,
+    providers: projection.prepared.manifest.providers,
+    backend: options.backend,
+    target: options.target,
+  });
+}
 
 function scalar(type: IrType): ValType | undefined {
   return type.kind === "val" ? type.val : undefined;
@@ -146,11 +187,23 @@ export function planPhysicalSetup(
   const physical = projection.prepared.functions;
   const bodies = new Map<IrUnitId, IrFunction>(physical.map((fn) => [fn.unitId, fn] as const));
   const entries = new Map<IrBindingId, PreparedIrAbiEntry>(program.abi.entries.map((entry) => [entry.plan.id, entry]));
+  const vectors = planNativeVectorResources(program, options, projection);
 
-  const convert = (types: readonly IrType[], where: string, unitId?: IrUnitId): ValType[] => {
-    const out: ValType[] = [];
+  const convert = (types: readonly IrType[], where: string, unitId?: IrUnitId): PhysicalSignatureType[] => {
+    const out: PhysicalSignatureType[] = [];
     for (const type of types) {
       const value = scalar(type);
+      if (
+        type.kind === "vec" &&
+        !type.layout &&
+        type.elementType.kind === "val" &&
+        !type.elementType.typeRef &&
+        (type.elementType.val.kind === "f64" || type.elementType.val.kind === "externref") &&
+        vectors.layouts.includes(type.elementType.val.kind)
+      ) {
+        out.push(type);
+        continue;
+      }
       if (!value) {
         gaps.add(
           `${where} carries non-scalar IR type ${typeLabel(type)}; physical carrier materialization is not available`,
@@ -229,6 +282,9 @@ export function planPhysicalSetup(
         });
         continue;
       }
+      if (vectors.helper?.bindingId === plan.id && vectors.helper.referenceKey === irCallableBindingKey(binding)) {
+        continue;
+      }
       gaps.add(`${binding.kind} callable ${contract.ref.name} needs runtime function materialization`);
       continue;
     }
@@ -272,9 +328,10 @@ export function planPhysicalSetup(
   const reserved = new Set<string>([
     ...functions.map((slot) => irCallableBindingKey({ kind: "unit", unitId: slot.unitId })),
     ...importedFunctions.map((fn) => fn.referenceKey),
+    ...(vectors.helper ? [vectors.helper.referenceKey] : []),
   ]);
   const reservedGlobals = new Set<string>([...importedGlobals, ...definedGlobals].map((global) => global.referenceKey));
-  let exceptionRequired = false;
+  let exceptionRequired = vectors.exceptionRequired;
   for (const fn of physical) {
     for (const buffer of [
       ...fn.blocks.map((block) => block.instrs),
@@ -369,6 +426,7 @@ export function planPhysicalSetup(
     backend: options.backend,
     target: options.target,
     exceptionTag: { required: exceptionRequired || options.sharedExceptionTag, shared: options.sharedExceptionTag },
+    vectors,
     importedFunctions,
     importedGlobals,
     definedGlobals,

--- a/src/ir/program/native-vector-resources.ts
+++ b/src/ir/program/native-vector-resources.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrBindingId } from "../../shared/contracts/ir-identity.js";
+import { irCallableBindingKey } from "../core/callable-bindings.js";
+import { forEachInstrDeep, type IrFunction } from "../core/nodes.js";
+import type { IrType } from "../core/types.js";
+import {
+  VECTOR_CALLABLE_DECLARATION,
+  VECTOR_CALLABLE_RUNTIME_PROVIDERS,
+  collectVectorCallableDemands,
+  vectorProviderMismatch,
+  vectorCallablePolicyMismatch,
+  type IrVectorCallableDemand,
+} from "../runtime/vector-callables.js";
+import { freezePreparedIrValue, preparedIrDataMismatch } from "./data.js";
+import { PreparedIrProgramInvariantError } from "./errors.js";
+import type { PreparedIrAbiEntry } from "./prepared-contracts.js";
+import type { RuntimeManifestPolicy } from "../../runtime/contracts/provider-policy.js";
+import type { RuntimeProviderDefinition } from "../runtime/contracts/manifest.js";
+
+export type NativeVectorElement = "f64" | "externref";
+export interface NativeVectorResourcePlan {
+  readonly anchor: string;
+  readonly layouts: readonly NativeVectorElement[];
+  /** Complete semantic owner population, including owners with no vector calls. */
+  readonly demands: readonly IrVectorCallableDemand[];
+  readonly helper?: {
+    readonly bindingId: IrBindingId;
+    readonly referenceKey: string;
+    readonly name: string;
+  };
+  readonly exceptionRequired: boolean;
+}
+
+function fail(detail: string): never {
+  throw new PreparedIrProgramInvariantError("invalid-prepared-data", `native vector resources: ${detail}`);
+}
+
+export interface NativeVectorResourceInput {
+  readonly anchor: string;
+  readonly functions: readonly IrFunction[];
+  readonly abiEntries: readonly PreparedIrAbiEntry[];
+  readonly policy: RuntimeManifestPolicy;
+  readonly providers: readonly RuntimeProviderDefinition[];
+  readonly backend: RuntimeManifestPolicy["backend"];
+  readonly target: RuntimeManifestPolicy["target"];
+}
+
+/** Pure bounded discovery, not program authentication or an emission acceptance capability. */
+export function deriveNativeVectorResourcePlan(input: NativeVectorResourceInput): NativeVectorResourcePlan {
+  if (!input.anchor) fail("missing entry-source anchor");
+  const demands = collectVectorCallableDemands(input.functions);
+  const layouts = new Set<NativeVectorElement>();
+  const supported = input.backend === "wasmgc" && input.target === "standalone";
+  const note = (type: IrType): void => {
+    if (!supported || type.kind !== "vec" || type.layout || type.elementType.kind !== "val" || type.elementType.typeRef)
+      return;
+    const kind = type.elementType.val.kind;
+    if (kind === "f64" || kind === "externref") layouts.add(kind);
+  };
+  for (const fn of input.functions) {
+    fn.params.forEach((param) => note(param.type));
+    fn.resultTypes.forEach(note);
+    fn.asyncPlan?.values.forEach((value) => note(value.type));
+    for (const block of fn.blocks) block.blockArgTypes.forEach(note);
+    for (const buffer of [
+      ...fn.blocks.map((block) => block.instrs),
+      ...(fn.asyncPlan?.states.map((state) => state.body) ?? []),
+    ])
+      for (const instr of buffer)
+        forEachInstrDeep(instr, (item) => {
+          if (item.resultType) note(item.resultType);
+        });
+  }
+  for (const abi of input.abiEntries) {
+    if (abi.contract.kind === "callable") {
+      abi.contract.params.forEach(note);
+      abi.contract.results.forEach(note);
+    }
+  }
+  let helper: NativeVectorResourcePlan["helper"];
+  if (supported && demands.some((owner) => owner.uses.length > 0)) {
+    const declaration = VECTOR_CALLABLE_DECLARATION;
+    const policyError = vectorCallablePolicyMismatch(declaration.feature, input.policy);
+    if (policyError) fail(policyError);
+    const canonical = VECTOR_CALLABLE_RUNTIME_PROVIDERS[0]!;
+    const providers = input.providers.filter(
+      (provider) =>
+        provider.feature === canonical.feature ||
+        provider.id === canonical.id ||
+        (provider.implementation.kind === "runtime-callable" &&
+          canonical.implementation.kind === "runtime-callable" &&
+          provider.implementation.symbol === canonical.implementation.symbol),
+    );
+    if (
+      providers.length !== 1 ||
+      providers[0]!.id !== canonical.id ||
+      providers[0]!.feature !== canonical.feature ||
+      vectorProviderMismatch(providers[0]!) !== undefined
+    )
+      fail("noncanonical selected vector provider");
+    const referenceKey = irCallableBindingKey(declaration.ref.binding);
+    const entries = input.abiEntries.filter(
+      (abi) => abi.contract.kind === "callable" && irCallableBindingKey(abi.contract.ref.binding) === referenceKey,
+    );
+    const abi = entries[0];
+    if (
+      entries.length !== 1 ||
+      !abi ||
+      abi.contract.kind !== "callable" ||
+      abi.plan.slotPolicy !== "required" ||
+      abi.plan.slotSpace !== "function" ||
+      preparedIrDataMismatch(declaration.params, abi.contract.params) !== undefined ||
+      preparedIrDataMismatch(declaration.results, abi.contract.results) !== undefined
+    )
+      fail("noncanonical vector callable ABI declaration");
+    helper = { bindingId: abi.plan.id, referenceKey, name: declaration.ref.name };
+    layouts.add("externref");
+  }
+  return freezePreparedIrValue({
+    anchor: input.anchor,
+    layouts: (["f64", "externref"] as const).filter((element) => layouts.has(element)),
+    demands,
+    ...(helper ? { helper } : {}),
+    exceptionRequired: helper !== undefined,
+  }) as NativeVectorResourcePlan;
+}

--- a/src/runtime/wasmgc/values/vector-grow-store.ts
+++ b/src/runtime/wasmgc/values/vector-grow-store.ts
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr, LocalDef, ValType } from "../../../wasm/model/instructions.js";
+import type { ArrayTypeDef, StructTypeDef } from "../../../wasm/model/module-records.js";
+
+/** Closed legacy gap initialization choices; no allocating context or callbacks. */
+export type VectorGrowStoreGapFill =
+  | { readonly kind: "default" }
+  | { readonly kind: "hole-global"; readonly globalIndex: number }
+  | { readonly kind: "f64-hole"; readonly bits: bigint };
+
+export interface VectorGrowStoreResources {
+  readonly carrierTypeIndex: number;
+  readonly arrayTypeIndex: number;
+  readonly exceptionTagIndex: number;
+  readonly gapFill: VectorGrowStoreGapFill;
+}
+
+function gapFillInstructions(fill: VectorGrowStoreGapFill): Instr[] {
+  switch (fill.kind) {
+    case "default":
+      return [];
+    case "hole-global":
+      return [{ op: "global.get", index: fill.globalIndex }, { op: "extern.convert_any" }];
+    case "f64-hole":
+      return [{ op: "i64.const", value: fill.bits }, { op: "f64.reinterpret_i64" }];
+    default:
+      throw new Error("unknown vector grow/store gap fill");
+  }
+}
+
+/** Exact existing grow/copy/store sequence; allocation and publication stay with the caller. */
+export function buildVectorGrowStoreBody(resources: VectorGrowStoreResources): { locals: LocalDef[]; body: Instr[] } {
+  const {
+    carrierTypeIndex: carrierTypeIdx,
+    arrayTypeIndex: arrTypeIdx,
+    exceptionTagIndex: tagIdx,
+    gapFill,
+  } = resources;
+  const hasGapFill = gapFill.kind !== "default";
+  const gapFillInit = gapFillInstructions(gapFill);
+  // Params: 0=vec, 1=idx, 2=val. Locals: 3=data, 4=newCap, 5=newData, 6=oldCap.
+  const VEC = 0;
+  const IDX = 1;
+  const VAL = 2;
+  const DATA = 3;
+  const NCAP = 4;
+  const NDATA = 5;
+  const OCAP = 6;
+  const OLEN = 7;
+
+  const body: Instr[] = [
+    // ── Null guard (#441 parity): if (vec == null) throw TypeError ─────────
+    { op: "local.get", index: VEC },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "ref.null.extern" }, { op: "throw", tagIdx }],
+      else: [],
+    },
+    // ── data = vec.data ─────────────────────────────────────────────────────
+    { op: "local.get", index: VEC },
+    { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 1 },
+    { op: "local.set", index: DATA },
+    // ── Grow when idx >= capacity (legacy sequence) ─────────────────────────
+    { op: "local.get", index: IDX },
+    { op: "local.get", index: DATA },
+    { op: "array.len" },
+    { op: "i32.ge_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        // oldCap = array.len(data)
+        { op: "local.get", index: DATA },
+        { op: "array.len" },
+        { op: "local.set", index: OCAP },
+        // newCap = idx + 1
+        { op: "local.get", index: IDX },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.set", index: NCAP },
+        // if (oldCap * 2 > newCap) newCap = oldCap * 2
+        { op: "local.get", index: OCAP },
+        { op: "i32.const", value: 1 },
+        { op: "i32.shl" },
+        { op: "local.get", index: NCAP },
+        { op: "i32.gt_s" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: OCAP },
+            { op: "i32.const", value: 1 },
+            { op: "i32.shl" },
+            { op: "local.set", index: NCAP },
+          ],
+        },
+        // if (4 > newCap) newCap = 4
+        { op: "i32.const", value: 4 },
+        { op: "local.get", index: NCAP },
+        { op: "i32.gt_s" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "i32.const", value: 4 },
+            { op: "local.set", index: NCAP },
+          ],
+        },
+        // Branded externref sparse carriers and standalone f64 sparse carriers
+        // fill new capacity with their respective absence markers. Dense
+        // carriers retain the ordinary zero/null default.
+        ...gapFillInit,
+        { op: "local.get", index: NCAP },
+        ...(hasGapFill
+          ? ([{ op: "array.new", typeIdx: arrTypeIdx }] satisfies Instr[])
+          : ([{ op: "array.new_default", typeIdx: arrTypeIdx }] satisfies Instr[])),
+        { op: "local.set", index: NDATA },
+        // array.copy newData[0..oldCap] = data[0..oldCap]
+        { op: "local.get", index: NDATA },
+        { op: "i32.const", value: 0 },
+        { op: "local.get", index: DATA },
+        { op: "i32.const", value: 0 },
+        { op: "local.get", index: OCAP },
+        { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx },
+        // vec.data = newData
+        { op: "local.get", index: VEC },
+        { op: "local.get", index: NDATA },
+        { op: "ref.as_non_null" },
+        { op: "struct.set", typeIdx: carrierTypeIdx, fieldIdx: 1 },
+        // data = newData
+        { op: "local.get", index: NDATA },
+        { op: "local.set", index: DATA },
+      ],
+    },
+    ...(hasGapFill
+      ? ([
+          // A write beyond logical length can land in already-allocated spare
+          // capacity. Preserve absence in the full [oldLength, idx) gap for
+          // both branded externref and standalone f64 sparse carriers.
+          { op: "local.get", index: VEC },
+          { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 0 },
+          { op: "local.set", index: OLEN },
+          { op: "local.get", index: IDX },
+          { op: "local.get", index: OLEN },
+          { op: "i32.gt_u" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: DATA },
+              { op: "local.get", index: OLEN },
+              ...gapFillInit,
+              { op: "local.get", index: IDX },
+              { op: "local.get", index: OLEN },
+              { op: "i32.sub" },
+              { op: "array.fill", typeIdx: arrTypeIdx },
+            ],
+          },
+        ] satisfies Instr[])
+      : []),
+    // ── data[idx] = val ─────────────────────────────────────────────────────
+    { op: "local.get", index: DATA },
+    { op: "local.get", index: IDX },
+    { op: "local.get", index: VAL },
+    { op: "array.set", typeIdx: arrTypeIdx },
+    // ── if (idx + 1 > vec.length) vec.length = idx + 1 ─────────────────────
+    { op: "local.get", index: IDX },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.get", index: VEC },
+    { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 0 },
+    { op: "i32.gt_u" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: VEC },
+        { op: "local.get", index: IDX },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "struct.set", typeIdx: carrierTypeIdx, fieldIdx: 0 },
+      ],
+    },
+  ];
+
+  return {
+    locals: [
+      { name: "$data", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
+      { name: "$ncap", type: { kind: "i32" } },
+      { name: "$ndata", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
+      { name: "$ocap", type: { kind: "i32" } },
+      ...(hasGapFill ? [{ name: "$oldlen", type: { kind: "i32" } as ValType }] : []),
+    ],
+    body,
+  };
+}
+
+/** Shared open length-prefix carrier; never register or cache from this constructor. */
+export function createVectorBaseType(): StructTypeDef {
+  return {
+    kind: "struct",
+    name: "__vec_base",
+    superTypeIdx: -1, // open / non-final — concrete vecs subtype this
+    fields: [{ name: "length", type: { kind: "i32" }, mutable: true }],
+  };
+}
+
+/** The legacy registry resolves reference nullability before passing the element type. */
+export function createVectorBackingArrayType(name: string, element: ValType): ArrayTypeDef {
+  return { kind: "array", name, element, mutable: true };
+}
+
+export interface VectorCarrierTypeResources {
+  readonly name: string;
+  readonly baseTypeIndex: number;
+  readonly arrayTypeIndex: number;
+  readonly final?: boolean;
+}
+
+/** Exact field order, mutability, supertype and optional-final metadata shared by both callers. */
+export function createVectorCarrierType(resources: VectorCarrierTypeResources): StructTypeDef {
+  return {
+    kind: "struct",
+    name: resources.name,
+    superTypeIdx: resources.baseTypeIndex,
+    ...(resources.final === undefined ? {} : { final: resources.final }),
+    fields: [
+      { name: "length", type: { kind: "i32" }, mutable: true },
+      { name: "data", type: { kind: "ref", typeIdx: resources.arrayTypeIndex }, mutable: true },
+    ],
+  };
+}

--- a/tests/issue-3518-native-vector-resources.test.ts
+++ b/tests/issue-3518-native-vector-resources.test.ts
@@ -1,0 +1,442 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { createEmptyModule, type Instr, type ValType } from "../src/ir/types.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import { prepareIrProgramSources, captureTypedIrProgramInput } from "../src/ir/program-source.js";
+import { prepareTypedIrProgram } from "../src/ir/program-prepare-ir.js";
+import { encodePreparedIrProgram, decodePreparedIrProgram } from "../src/ir/program-codec.js";
+import { forEachInstrDeep, type IrFunction } from "../src/ir/core/nodes.js";
+import {
+  deriveNativeVectorResourcePlan,
+  type NativeVectorResourceInput,
+} from "../src/ir/program/native-vector-resources.js";
+import { collectVectorCallableDemands } from "../src/ir/runtime/vector-callables.js";
+import { planPhysicalSetup, planNativeVectorResources } from "../src/ir/program-physical-plan.js";
+import {
+  reserveNativeVectorTypes,
+  reserveNativeVectorHelper,
+  fillNativeVectorHelper,
+  resolveNativeVector,
+  resolveNativeVectorForElement,
+  nativeVectorPhysicalType,
+  nativeVectorPhysicalSignature,
+} from "../src/backend/wasmgc/resources/native-vectors.js";
+import { sourceInput, typedOptions, requireProgram } from "./helpers/typed-program-fixtures.js";
+import { encodeTypedPacket, decodeTypedPacket } from "./helpers/typed-program-transport.mjs";
+
+const policy = {
+  backend: "wasmgc",
+  target: "standalone",
+  stringConst: { storage: "native" },
+  stringConcat: { concat: "native" },
+} as const;
+const options = {
+  ...policy,
+  sharedExceptionTag: false,
+  utf8Storage: false,
+  sourceMap: false,
+  moduleName: "vector-resource-proof",
+};
+const sourceText = readFileSync(new URL("../website/playground/examples/js/async.ts", import.meta.url), "utf8");
+function census(functions: readonly IrFunction[]) {
+  let calls = 0;
+  for (const fn of functions)
+    for (const buffer of [
+      ...fn.blocks.map((block) => block.instrs),
+      ...(fn.asyncPlan?.states.map((state) => state.body) ?? []),
+    ])
+      for (const root of buffer)
+        forEachInstrDeep(root, (instr) => {
+          if (instr.kind === "call") calls++;
+        });
+  return { owners: functions.length, calls };
+}
+function prepare(gvnMode: "off" | "on", replay: boolean) {
+  const source = prepareIrProgramSources({
+    ...sourceInput({ "./entry.ts": sourceText }),
+    policy,
+    promiseDelayProjection: "standalone-native",
+    asyncFamilyProjection: "standalone-native",
+  });
+  if (source.kind !== "prepared") throw new Error(source.detail);
+  expect(census(source.ir.functions)).toEqual({ owners: 5, calls: 22 });
+  const packet = captureTypedIrProgramInput(source);
+  const input = replay ? decodeTypedPacket(encodeTypedPacket(packet)) : packet;
+  expect(input.allocations).toEqual(packet.allocations);
+  const program = requireProgram(
+    prepareTypedIrProgram(input, {
+      ...typedOptions,
+      policy,
+      runtimePolicies: [policy],
+      controls: { ...typedOptions.controls, gvnMode },
+    }),
+  );
+  expect(census(program.ir.functions)).toEqual({ owners: 16, calls: 33 });
+  const selected = replay ? decodePreparedIrProgram(encodePreparedIrProgram(program)) : program;
+  const encoded = encodePreparedIrProgram(selected);
+  const plan = planNativeVectorResources(selected, options, selected.runtime[0]!);
+  expect(encodePreparedIrProgram(selected)).toBe(encoded);
+  return { program: selected, plan };
+}
+let cached: ReturnType<typeof prepare> | undefined;
+const prepared = () => (cached ??= prepare("off", false));
+
+/** Isolated resource harness driven by the real complete-family plan, NOT whole-family execution. */
+function reserve(shared = false, importOffset = false) {
+  const { plan } = prepared();
+  const module = createEmptyModule();
+  const tx = new PhysicalModuleReservations(module);
+  const tag = tx.reserveTag(
+    "exception",
+    { params: [{ kind: "externref" }], results: [] },
+    shared ? { kind: "import", module: "env", name: "__exn" } : { kind: "defined", name: "__exn" },
+  );
+  const types = reserveNativeVectorTypes(tx, plan);
+  if (importOffset) tx.reserveFunctionImport("kernel-offset", "control", "noop", { params: [], results: [] });
+  const layout = resolveNativeVectorForElement(types, { kind: "externref" })!;
+  const ref: ValType = { kind: "ref_null", typeIdx: layout.vecStructTypeIdx };
+  const i32: ValType = { kind: "i32" },
+    extern: ValType = { kind: "externref" };
+  const make = tx.reserveFunction("harness:make", "make", { params: [i32], results: [ref] });
+  const get = tx.reserveFunction("harness:get", "get", { params: [ref, i32], results: [extern] });
+  const length = tx.reserveFunction("harness:length", "length", { params: [ref], results: [i32] });
+  const capacity = tx.reserveFunction("harness:capacity", "capacity", { params: [ref], results: [i32] });
+  const store = tx.reserveFunction("harness:store", "store", { params: [ref, i32, extern], results: [] });
+  const helper = reserveNativeVectorHelper(tx, plan, types, tag)!;
+  return { module, tx, tag, types, layout, make, get, length, capacity, store, helper };
+}
+function execute(shared = false, importOffset = false) {
+  const state = reserve(shared, importOffset);
+  const { module, tx, tag, layout, make, get, length, capacity, store, helper } = state;
+  tx.freezeReservations();
+  fillNativeVectorHelper(tx, helper);
+  const data: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "struct.get", typeIdx: layout.vecStructTypeIdx, fieldIdx: 1 },
+  ];
+  tx.fillFunction(make, {
+    locals: [],
+    body: [
+      { op: "i32.const", value: 0 },
+      { op: "local.get", index: 0 },
+      { op: "array.new_default", typeIdx: layout.arrayTypeIdx },
+      { op: "struct.new", typeIdx: layout.vecStructTypeIdx },
+    ],
+  });
+  tx.fillFunction(get, {
+    locals: [],
+    body: [...data, { op: "local.get", index: 1 }, { op: "array.get", typeIdx: layout.arrayTypeIdx }],
+  });
+  tx.fillFunction(length, {
+    locals: [],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: layout.vecStructTypeIdx, fieldIdx: 0 },
+    ],
+  });
+  tx.fillFunction(capacity, { locals: [], body: [...data, { op: "array.len" }] });
+  tx.fillFunction(store, {
+    locals: [],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "local.get", index: 1 },
+      { op: "local.get", index: 2 },
+      { op: "call", funcIdx: helper.function.handle },
+    ],
+  });
+  for (const fn of [make, get, length, capacity, store])
+    tx.defineExport(`export:${fn.object.name}`, fn.object.name, fn);
+  tx.defineExport("export:exception", "exception", tag);
+  tx.seal();
+  const binary = emitBinary(module);
+  expect(WebAssembly.validate(binary)).toBe(true);
+  const externalTag = new WebAssembly.Tag({ parameters: ["externref"] });
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    env: { __exn: externalTag },
+    control: { noop() {} },
+  });
+  const api = instance.exports as unknown as {
+    make(capacity: number): unknown;
+    get(vec: unknown, index: number): unknown;
+    store(vec: unknown, index: number, value: unknown): void;
+    length(vec: unknown): number;
+    capacity(vec: unknown): number;
+    exception: WebAssembly.Tag;
+  };
+  return { ...state, api, externalTag };
+}
+
+describe("native vector physical resource planning from the complete source family", () => {
+  for (const mutation of ["foreign-id-and-feature", "missing-provider", "duplicate-provider"] as const)
+    it(`pure derivation rejects ${mutation} independently of whole-program authentication`, () => {
+      const { program, plan } = prepared();
+      const manifest = program.runtime[0]!.prepared.manifest;
+      const input: NativeVectorResourceInput = {
+        anchor: plan.anchor,
+        functions: program.ir.functions,
+        abiEntries: program.abi.entries,
+        policy: manifest.policy,
+        providers: manifest.providers,
+        backend: options.backend,
+        target: options.target,
+      };
+      // Positive first: identical genuine inputs work through the pure boundary.
+      expect(deriveNativeVectorResourcePlan(input)).toEqual(plan);
+      const canonical = input.providers.find((provider) => provider.feature === "js.vector.elem-set.externref")!;
+      expect(canonical.implementation).toMatchObject({
+        kind: "runtime-callable",
+        symbol: "__ir_vec_elem_set_externref",
+      });
+      const others = input.providers.filter((provider) => provider !== canonical);
+      const providers =
+        mutation === "missing-provider"
+          ? others
+          : mutation === "duplicate-provider"
+            ? [...input.providers, canonical]
+            : [...others, { ...canonical, id: "foreign.vector", feature: "async.native.delay" as const }];
+      expect(() => deriveNativeVectorResourcePlan({ ...input, providers })).toThrow(
+        "native vector resources: noncanonical selected vector provider",
+      );
+    });
+  for (const gvn of ["off", "on"] as const)
+    for (const replay of [false, true])
+      it(`retains the complete population and located physical gaps, GVN=${gvn} replay=${replay}`, () => {
+        const { program, plan } = prepare(gvn, replay);
+        expect(plan.layouts).toEqual(["f64", "externref"]);
+        expect(plan.demands).toEqual(collectVectorCallableDemands(program.ir.functions));
+        expect(plan.demands.map((owner) => owner.unitId)).toEqual(program.ir.functions.map((fn) => fn.unitId));
+        expect(plan.demands).toHaveLength(16);
+        expect(plan.demands.some((owner) => owner.uses.length === 0)).toBe(true);
+        expect(plan.demands.flatMap((owner) => owner.uses)).toHaveLength(1);
+        expect(plan.exceptionRequired).toBe(true);
+        expect(Object.isFrozen(plan)).toBe(true);
+        expect(Object.isFrozen(plan.demands)).toBe(true);
+        const refusal = planPhysicalSetup(program, options, program.runtime[0]!);
+        expect(refusal.kind).toBe("unsupported");
+        if (refusal.kind === "planned") throw new Error("whole-family physical execution unexpectedly admitted");
+        expect(refusal.detail).toContain("scheduler/promise runtime materialization");
+        expect(refusal.location.sourceId).toBeDefined();
+        expect(program.allocations.size).toBeGreaterThan(0);
+      });
+});
+
+describe("real reserved provider execution, separately from full-family acceptance", () => {
+  for (const shared of [false, true])
+    for (const offset of [false, true])
+      it(`grows, preserves identities/nulls, and repeats stores; shared=${shared}, kernel import offset=${offset}`, () => {
+        const { api, helper, tx, externalTag } = execute(shared, offset);
+        const vec = api.make(0),
+          first = { first: true },
+          second = { second: true };
+        expect(api.capacity(vec)).toBe(0);
+        api.store(vec, 0, first);
+        expect(api.capacity(vec)).toBe(4);
+        expect(api.length(vec)).toBe(1);
+        expect(api.get(vec, 0)).toBe(first);
+        api.store(vec, 7, second);
+        expect(api.capacity(vec)).toBe(8);
+        expect(api.length(vec)).toBe(8);
+        expect(api.get(vec, 0)).toBe(first);
+        expect(api.get(vec, 7)).toBe(second);
+        expect(api.get(vec, 3)).toBeNull();
+        api.store(vec, 0, null);
+        api.store(vec, 7, first);
+        expect(api.get(vec, 0)).toBeNull();
+        expect(api.get(vec, 7)).toBe(first);
+        expect(api.length(vec)).toBe(8);
+        expect(api.capacity(vec)).toBe(8);
+        api.store(vec, 8, second);
+        expect(api.capacity(vec)).toBe(16);
+        expect(api.length(vec)).toBe(9);
+        const other = api.make(10);
+        api.store(other, 2, second);
+        expect(api.length(other)).toBe(3);
+        expect(api.capacity(other)).toBe(10);
+        expect(api.get(other, 2)).toBe(second);
+        expect(tx.physicalIndex(helper.function)).toBe(5 + Number(offset));
+        expect(helper.function.handle).not.toBe(tx.physicalIndex(helper.function));
+        if (shared) expect(api.exception).toBe(externalTag);
+        let thrown: unknown;
+        try {
+          api.store(null, 0, first);
+        } catch (error) {
+          thrown = error;
+        }
+        expect(thrown).toBeInstanceOf(WebAssembly.Exception);
+        expect((thrown as WebAssembly.Exception).is(api.exception)).toBe(true);
+        expect((thrown as WebAssembly.Exception).getArg(api.exception, 0)).toBeNull();
+      });
+});
+
+describe("exact reservation descriptors, provenance and lifecycle", () => {
+  it("shares one base and keeps nullable/non-null views without allocating lookup", () => {
+    const { types, tx } = reserve();
+    expect(types.layouts).toHaveLength(2);
+    for (const row of types.layouts) {
+      expect(row.carrier.object).toMatchObject({ superTypeIdx: types.base!.typeIndex });
+      expect(Object.hasOwn(row.layout, "valueType")).toBe(false);
+      for (const nullable of [false, true]) {
+        const logical = { kind: "vec", elementType: { kind: "val", val: { kind: row.element } }, nullable } as const;
+        const physical = nativeVectorPhysicalType(types, logical)!;
+        expect(physical).toEqual({ kind: nullable ? "ref_null" : "ref", typeIdx: row.carrier.typeIndex });
+        expect(resolveNativeVector(types, physical)).toBe(row.layout);
+      }
+    }
+    expect(resolveNativeVectorForElement(types, { kind: "i32" })).toBeUndefined();
+    expect(
+      nativeVectorPhysicalSignature(types, {
+        params: [{ kind: "vec", elementType: { kind: "val", val: { kind: "i32" } }, nullable: true }],
+        results: [],
+      }),
+    ).toBeUndefined();
+    expect(tx.state).toBe("reserving");
+  });
+  for (const mutation of [
+    "element",
+    "array-mutability",
+    "field-mutability",
+    "field-type",
+    "supertype",
+    "base",
+  ] as const)
+    it(`rejects exact ${mutation} descriptor corruption before building`, () => {
+      const state = reserve(),
+        row = state.types.layouts.find((row) => row.element === "externref")!;
+      if (
+        row.array.object.kind !== "array" ||
+        row.carrier.object.kind !== "struct" ||
+        state.types.base!.object.kind !== "struct"
+      )
+        throw new Error("missing descriptors");
+      if (mutation === "element") row.array.object.element = { kind: "f64" };
+      if (mutation === "array-mutability") row.array.object.mutable = false;
+      if (mutation === "field-mutability") row.carrier.object.fields[1]!.mutable = false;
+      if (mutation === "field-type") row.carrier.object.fields[1]!.type = { kind: "externref" };
+      if (mutation === "supertype") row.carrier.object.superTypeIdx = row.array.typeIndex;
+      if (mutation === "base") state.types.base!.object.fields[0]!.type = { kind: "f64" };
+      expect(() => resolveNativeVectorForElement(state.types, { kind: "externref" })).toThrow(
+        /native vector resources: .*descriptor mismatch/,
+      );
+    });
+  it("rejects substituted type/helper wrapper objects", () => {
+    const { types, helper, tx } = reserve();
+    expect(() => resolveNativeVectorForElement({ ...types }, { kind: "externref" })).toThrow(
+      "foreign vector type reservations",
+    );
+    tx.freezeReservations();
+    expect(() => fillNativeVectorHelper(tx, { ...helper })).toThrow("foreign vector helper reservation");
+  });
+  it("rejects foreign transactions", () => {
+    const left = reserve(),
+      right = reserve();
+    expect(() => reserveNativeVectorHelper(right.tx, prepared().plan, left.types, right.tag)).toThrow(
+      "foreign vector type reservations",
+    );
+    right.tx.freezeReservations();
+    expect(() => fillNativeVectorHelper(right.tx, left.helper)).toThrow("foreign vector helper reservation");
+  });
+  it("rejects duplicate reservation", () => {
+    const { tx, types, tag } = reserve();
+    expect(() => reserveNativeVectorHelper(tx, prepared().plan, types, tag)).toThrow(/duplicate/);
+  });
+  it("rejects duplicate fill", () => {
+    const { tx, helper } = reserve();
+    tx.freezeReservations();
+    fillNativeVectorHelper(tx, helper);
+    expect(() => fillNativeVectorHelper(tx, helper)).toThrow("duplicate function fill");
+  });
+  it("rejects missing fills and late allocation", () => {
+    const tx = new PhysicalModuleReservations(createEmptyModule());
+    const tag = tx.reserveTag(
+      "exception",
+      { params: [{ kind: "externref" }], results: [] },
+      { kind: "defined", name: "__exn" },
+    );
+    const types = reserveNativeVectorTypes(tx, prepared().plan);
+    const helper = reserveNativeVectorHelper(tx, prepared().plan, types, tag)!;
+    tx.freezeReservations();
+    expect(() => tx.seal()).toThrow(`missing function fill ${helper.function.key}`);
+    const late = reserve();
+    late.tx.freezeReservations();
+    expect(() => reserveNativeVectorTypes(late.tx, prepared().plan)).toThrow(/requires reserving/);
+  });
+  it("rejects post-fill mutation", () => {
+    const { tx, helper } = reserve();
+    tx.freezeReservations();
+    fillNativeVectorHelper(tx, helper);
+    helper.function.object.body.push({ op: "nop" });
+    expect(() => tx.seal()).toThrow("altered completed function");
+  });
+  for (const kind of ["missing", "wrong-signature", "wrong-linkage", "foreign", "substituted"] as const)
+    it(`rejects ${kind} exception resource`, () => {
+      const tx = new PhysicalModuleReservations(createEmptyModule());
+      const signature = {
+        params: [{ kind: kind === "wrong-signature" ? "i32" : "externref" } as ValType],
+        results: [],
+      };
+      const tag =
+        kind === "missing"
+          ? undefined
+          : tx.reserveTag(
+              "exception",
+              signature,
+              kind === "wrong-linkage"
+                ? { kind: "import", module: "foreign", name: "__exn" }
+                : { kind: "defined", name: "__exn" },
+            );
+      const types = reserveNativeVectorTypes(tx, prepared().plan);
+      if (kind === "missing" || kind === "wrong-signature" || kind === "wrong-linkage") {
+        expect(() => reserveNativeVectorHelper(tx, prepared().plan, types, tag)).toThrow(/exception tag/);
+      } else {
+        const foreign = new PhysicalModuleReservations(createEmptyModule());
+        const foreignTag = foreign.reserveTag(
+          "exception",
+          { params: [{ kind: "externref" }], results: [] },
+          { kind: "defined", name: "__exn" },
+        );
+        const token = kind === "foreign" ? foreignTag : { ...tag! };
+        const helper = reserveNativeVectorHelper(tx, prepared().plan, types, token)!;
+        tx.freezeReservations();
+        expect(() => fillNativeVectorHelper(tx, helper)).toThrow(/foreign|substitut|owned/);
+      }
+    });
+  it("rejects substituted exact helper token even when its descriptor is copied", () => {
+    const { tx, helper, module } = reserve();
+    module.functions[module.functions.indexOf(helper.function.object)] = { ...helper.function.object };
+    expect(() => tx.freezeReservations()).toThrow(/substitut|population|order/);
+  });
+  it("does not admit a second provider or fabricated canonical declaration", () => {
+    const { program } = prepared();
+    const projection = program.runtime[0]!;
+    const row = projection.prepared.manifest.providers.find(
+      (provider) => provider.feature === "js.vector.elem-set.externref",
+    )!;
+    expect(row).toBeDefined();
+    const duplicate = {
+      ...projection,
+      prepared: {
+        ...projection.prepared,
+        manifest: {
+          ...projection.prepared.manifest,
+          providers: [...projection.prepared.manifest.providers, row],
+        },
+      },
+    };
+    const forged = { ...program, runtime: [duplicate] };
+    expect(() => planNativeVectorResources(forged, options, duplicate)).toThrow();
+    const changed = {
+      ...program,
+      abi: {
+        entries: program.abi.entries.map((entry) =>
+          entry.plan.id === prepared().plan.helper!.bindingId && entry.contract.kind === "callable"
+            ? { ...entry, contract: { ...entry.contract, results: [{ kind: "val", val: { kind: "i32" } }] } }
+            : entry,
+        ),
+      },
+    };
+    expect(() => planNativeVectorResources(changed as typeof program, options, projection)).toThrow();
+  });
+});

--- a/tests/issue-3518-semantic-provider-boundary.test.ts
+++ b/tests/issue-3518-semantic-provider-boundary.test.ts
@@ -10,7 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const repository = resolve(import.meta.dirname, "..");
 // Fixed specification population, independent of discovered imports and policy.
-const groups = {
+const historicalGroups = {
   foundation: [
     "source-origin",
     "ir-identity",
@@ -90,6 +90,17 @@ const groups = {
     (x) => `src/runtime/contracts/${x}.ts`,
   ),
 };
+const physicalVectorAdditions = [
+  "src/ir/program/native-vector-resources.ts",
+  "src/runtime/wasmgc/values/vector-grow-store.ts",
+  "src/backend/wasmgc/resources/native-vectors.ts",
+];
+const groups = {
+  ...historicalGroups,
+  "ir-program": [...historicalGroups["ir-program"], physicalVectorAdditions[0]!],
+  "native-runtime": [...historicalGroups["native-runtime"], physicalVectorAdditions[1]!],
+  "backend-wasmgc": [physicalVectorAdditions[2]!],
+};
 const required = Object.values(groups).flat();
 const callableAdditions = ["src/ir/core/async-callables.ts", "src/ir/runtime/native-async-callables.ts"];
 const vectorAdditions = ["src/ir/core/vector-runtime.ts", "src/ir/runtime/vector-callables.ts"];
@@ -126,34 +137,42 @@ const additions = [
 const policy = () => JSON.parse(readFileSync(resolve(repository, "scripts/compiler-boundaries.json"), "utf8"));
 const digest = (value: unknown) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
 function assertNewActivations(history: unknown[]) {
-  expect(history.slice(0, 2)).toEqual(
-    (["ir-core", "ir-runtime"] as const).map((layer) => ({
+  expect(history.slice(0, 3)).toEqual(
+    (["ir-program", "native-runtime", "backend-wasmgc"] as const).map((layer) => ({
       layer,
       entries: groups[layer],
       minModules: groups[layer].length,
     })),
   );
+  history = history.slice(3);
+  expect(history.slice(0, 2)).toEqual(
+    (["ir-core", "ir-runtime"] as const).map((layer) => ({
+      layer,
+      entries: historicalGroups[layer],
+      minModules: historicalGroups[layer].length,
+    })),
+  );
   history = history.slice(2);
   expect(history.slice(0, 2)).toEqual(
     (["ir-core", "ir-runtime"] as const).map((layer) => ({
       layer,
-      entries: groups[layer].filter((path) => !vectorAdditions.includes(path)),
-      minModules: groups[layer].length - 1,
+      entries: historicalGroups[layer].filter((path) => !vectorAdditions.includes(path)),
+      minModules: historicalGroups[layer].length - 1,
     })),
   );
   history = history.slice(2);
-  expect(history[0]).toEqual({ layer: "wasm-physical", entries: groups["wasm-physical"], minModules: 5 });
-  expect(history[1]).toEqual({ layer: "native-runtime", entries: groups["native-runtime"], minModules: 6 });
+  expect(history[0]).toEqual({ layer: "wasm-physical", entries: historicalGroups["wasm-physical"], minModules: 5 });
+  expect(history[1]).toEqual({ layer: "native-runtime", entries: historicalGroups["native-runtime"], minModules: 6 });
   expect(history.slice(2, 4)).toEqual(
     (["native-runtime", "wasm-physical"] as const).map((layer) => ({
       layer,
-      entries: groups[layer].filter(
+      entries: historicalGroups[layer].filter(
         (path) =>
           ![...delayCombinatorAdditions, ...typeLayoutAdditions, ...callableAdditions, ...vectorAdditions].includes(
             path,
           ),
       ),
-      minModules: groups[layer].filter(
+      minModules: historicalGroups[layer].filter(
         (path) =>
           ![...delayCombinatorAdditions, ...typeLayoutAdditions, ...callableAdditions, ...vectorAdditions].includes(
             path,
@@ -165,7 +184,7 @@ function assertNewActivations(history: unknown[]) {
     (["native-runtime", "wasm-model", "wasm-physical", "ir-core", "ir-analysis", "ir-runtime"] as const).map(
       (layer) => ({
         layer,
-        entries: groups[layer].filter(
+        entries: historicalGroups[layer].filter(
           (path) =>
             ![
               ...frameAdditions,
@@ -175,7 +194,7 @@ function assertNewActivations(history: unknown[]) {
               ...vectorAdditions,
             ].includes(path),
         ),
-        minModules: groups[layer].filter(
+        minModules: historicalGroups[layer].filter(
           (path) =>
             ![
               ...frameAdditions,
@@ -261,9 +280,9 @@ function fixture() {
 }
 
 describe("semantic verification and provider ownership boundary", () => {
-  it("pins the original 68 modules plus two canonical vector owners without relaxing historical policy", () => {
-    expect(required).toHaveLength(70);
-    expect(new Set(required).size).toBe(70);
+  it("pins the original 70 modules plus three physical vector owners without relaxing historical policy", () => {
+    expect(required).toHaveLength(73);
+    expect(new Set(required).size).toBe(73);
     expect(callableAdditions).toHaveLength(2);
     expect(vectorAdditions).toHaveLength(2);
     expect(typeLayoutAdditions).toHaveLength(1);
@@ -282,6 +301,7 @@ describe("semantic verification and provider ownership boundary", () => {
             ...typeLayoutAdditions,
             ...callableAdditions,
             ...vectorAdditions,
+            ...physicalVectorAdditions,
           ].includes(path),
       ),
     ).toHaveLength(56);
@@ -296,17 +316,18 @@ describe("semantic verification and provider ownership boundary", () => {
       ...typeLayoutAdditions,
       ...callableAdditions,
       ...vectorAdditions,
+      ...physicalVectorAdditions,
     ])
       expect(required).toContain(path);
     const p = policy();
     assertNewActivations(p.activationHistory);
-    expect(p.activationHistory).toHaveLength(32);
-    expect(digest(p.activationHistory.slice(8))).toBe(
+    expect(p.activationHistory).toHaveLength(35);
+    expect(digest(p.activationHistory.slice(11))).toBe(
       "3437a59aacf39df9dffcafa8099ac9f47c0f43a7a0ecc423df4c1fe3e638f002",
     );
     expect(digest(p.allowedEdges)).toBe("efe7e7ed8dee1a009d2bef3ff36dba80df1a805cd3f5b7b472e62ec6dcff64c7");
     // Exact full activation history at b4c116639a, not a selected subset.
-    expect(digest(p.activationHistory.slice(14))).toBe(
+    expect(digest(p.activationHistory.slice(17))).toBe(
       "a6d07b900b0837832707ce083202ab6ffa40f0bbe6bfce25f3062270882b26da",
     );
     for (const [id, entries] of Object.entries(groups)) {
@@ -323,23 +344,26 @@ describe("semantic verification and provider ownership boundary", () => {
   it("loads the complete actual canonical type-and-value closure", () => {
     const r = fixture().run();
     expect(r.status, JSON.stringify(r.report.errors)).toBe(0);
-    expect(r.report.counts.total).toBe(70);
+    expect(r.report.counts.total).toBe(73);
     expect(r.report.errors).toEqual([]);
     for (const field of ["unknownEdges", "unresolvedEdges", "forbiddenEdges", "transitiveViolations"])
       expect(r.report[field]).toEqual([]);
-    expect(r.report.resolvedEdgeCount).toBe(239);
-    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 163, runtime: 76 });
+    expect(r.report.resolvedEdgeCount).toBe(259);
+    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 174, runtime: 85 });
   });
 
   it.each(["delete", "reorder", "layer", "entries", "minimum"] as const)(
     "rejects %s corruption of the new activation records",
     (mutation) => {
       const history = policy().activationHistory;
+      assertNewActivations(history);
+      const before = digest(history);
       if (mutation === "delete") history.splice(0, 1);
       if (mutation === "reorder") [history[0], history[1]] = [history[1], history[0]];
-      if (mutation === "layer") history[0].layer = "ir-program";
+      if (mutation === "layer") history[0].layer = "ir-core";
       if (mutation === "entries") history[0].entries.pop();
       if (mutation === "minimum") history[0].minModules--;
+      expect(digest(history), "mutation must alter the accepted activation records").not.toBe(before);
       expect(() => assertNewActivations(history)).toThrow();
     },
   );
@@ -353,6 +377,7 @@ describe("semantic verification and provider ownership boundary", () => {
     ...typeLayoutAdditions,
     ...callableAdditions,
     ...vectorAdditions,
+    ...physicalVectorAdditions,
   ])("rejects deleting %s and its classification", (path) => {
     const f = fixture();
     rmSync(resolve(f.root, path));
@@ -373,6 +398,7 @@ describe("semantic verification and provider ownership boundary", () => {
     ...typeLayoutAdditions,
     ...callableAdditions,
     ...vectorAdditions,
+    ...physicalVectorAdditions,
   ])("rejects an aliased frontend type dependency from %s", (path) => {
     const f = fixture();
     f.put("src/forbidden.ts", "export interface Hidden { value: number }");
@@ -398,6 +424,7 @@ describe("semantic verification and provider ownership boundary", () => {
       ...typeLayoutAdditions,
       ...callableAdditions,
       ...vectorAdditions,
+      ...physicalVectorAdditions,
     ])(`reports ${field} from %s instead of treating it as closed`, (path) => {
       const f = fixture();
       f.append(path, source);

--- a/tests/issue-3518-vector-grow-store-body.test.ts
+++ b/tests/issue-3518-vector-grow-store-body.test.ts
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import {
+  buildVectorGrowStoreBody,
+  createVectorBaseType,
+  createVectorBackingArrayType,
+  createVectorCarrierType,
+  type VectorGrowStoreGapFill,
+} from "../src/runtime/wasmgc/values/vector-grow-store.js";
+import type { Instr, LocalDef } from "../src/wasm/model/instructions.js";
+
+const read = () => readFileSync(new URL("../src/runtime/wasmgc/values/vector-grow-store.ts", import.meta.url), "utf8");
+const sha = (text: string) => createHash("sha256").update(text).digest("hex");
+const parse = (text: string) => ts.createSourceFile("vector.ts", text, ts.ScriptTarget.Latest, true);
+
+/** Recover the exact old expression, then authenticate against pre-extraction receipts.
+ * No historical Git object, legacy context, or hand-maintained duplicate builder is required.
+ */
+function donorExpressions(text = read()) {
+  const sf = parse(text);
+  const functions = sf.statements.filter(ts.isFunctionDeclaration);
+  expect(functions.map((fn) => fn.name!.text)).toEqual([
+    "gapFillInstructions",
+    "buildVectorGrowStoreBody",
+    "createVectorBaseType",
+    "createVectorBackingArrayType",
+    "createVectorCarrierType",
+  ]);
+  const fn = functions.find((fn) => fn.name!.text === "buildVectorGrowStoreBody")!;
+  expect(fn.asteriskToken).toBeUndefined();
+  expect(fn.modifiers?.map((m) => m.kind)).toEqual([ts.SyntaxKind.ExportKeyword]);
+  expect(fn.parameters.map((p) => p.getText(sf))).toEqual(["resources: VectorGrowStoreResources"]);
+  expect(fn.type?.getText(sf)).toBe("{ locals: LocalDef[]; body: Instr[] }");
+  const statements = fn.body!.statements;
+  const name = (s: ts.Statement) =>
+    ts.isVariableStatement(s) ? s.declarationList.declarations[0]!.name.getText(sf) : undefined;
+  const first = statements.findIndex((s) => name(s) === "VEC"),
+    last = statements.findIndex((s) => name(s) === "body");
+  expect(statements.slice(first, last + 1).map(name)).toEqual([
+    "VEC",
+    "IDX",
+    "VAL",
+    "DATA",
+    "NCAP",
+    "NDATA",
+    "OCAP",
+    "OLEN",
+    "body",
+  ]);
+  const movedConstruction = statements
+    .slice(first, last + 1)
+    .map((s) => s.getFullText(sf))
+    .join("")
+    .replaceAll("hasGapFill", "holeyCarrier || f64HoleCarrier");
+  // The donor had one additional blank line after function reservation.
+  // Restore only that extraction-boundary byte, not arbitrary whitespace.
+  const construction = "\n" + movedConstruction;
+  expect(sha(construction)).toBe("68501b8e4599a28a8be525081a0a892a007f7eda34dc5c672054fd900f9b8cf4");
+  const returns = statements.filter(ts.isReturnStatement);
+  expect(returns).toHaveLength(1);
+  const result = returns[0]!.expression!;
+  if (!ts.isObjectLiteralExpression(result)) throw new Error("expected exact local/body record");
+  expect(result.properties.map((p) => p.name?.getText(sf))).toEqual(["locals", "body"]);
+  const property = result.properties[0]!;
+  if (!ts.isPropertyAssignment(property)) throw new Error("expected explicit locals");
+  const locals = property.initializer.getText(sf).replaceAll("hasGapFill", "holeyCarrier || f64HoleCarrier");
+  expect(sha(locals)).toBe("28423084cec961f57ece3591ea8f431141e68083162b2e5d354dc3be1522a883");
+  return { construction, locals };
+}
+
+function originalBody(fill: VectorGrowStoreGapFill, indices: readonly [number, number, number]) {
+  const { construction, locals } = donorExpressions();
+  const js = ts.transpileModule(`${construction}\nreturn {locals: ${locals}, body};`, {
+    compilerOptions: { target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+  const original = new Function(
+    "carrierTypeIdx",
+    "arrTypeIdx",
+    "tagIdx",
+    "holeyCarrier",
+    "f64HoleCarrier",
+    "gapFillInit",
+    js,
+  );
+  const gap: Instr[] =
+    fill.kind === "default"
+      ? []
+      : fill.kind === "hole-global"
+        ? [{ op: "global.get", index: fill.globalIndex }, { op: "extern.convert_any" }]
+        : [{ op: "i64.const", value: fill.bits }, { op: "f64.reinterpret_i64" }];
+  return original(...indices, fill.kind === "hole-global", fill.kind === "f64-hole", gap) as {
+    locals: LocalDef[];
+    body: Instr[];
+  };
+}
+
+const fills: readonly VectorGrowStoreGapFill[] = [
+  { kind: "default" },
+  { kind: "hole-global", globalIndex: 17 },
+  { kind: "f64-hole", bits: 0x7ff8000000000001n },
+];
+
+describe("exact vector donor body and local construction", () => {
+  it("pins complete expression/local receipts and declaration headers", () => {
+    donorExpressions();
+  });
+  it.each(["async function buildVectorGrowStoreBody", "function* buildVectorGrowStoreBody"])(
+    "rejects changed canonical header %s",
+    (header) => {
+      expect(() => donorExpressions(read().replace("function buildVectorGrowStoreBody", header))).toThrow();
+    },
+  );
+  it.each(["i32.ge_s", "array.copy", "$ocap"])("rejects live donor mutation %s", (token) => {
+    expect(() => donorExpressions(read().replace(token, token + "_changed"))).toThrow();
+  });
+  it.each(
+    fills.flatMap((fill) =>
+      [
+        [4, 8, 3],
+        [41, 22, 0],
+      ].map((indices) => ({ fill, indices })),
+    ),
+  )("matches the old complete body for $fill.kind at $indices", ({ fill, indices }) => {
+    const coordinates = indices as [number, number, number];
+    const current = buildVectorGrowStoreBody({
+      carrierTypeIndex: coordinates[0],
+      arrayTypeIndex: coordinates[1],
+      exceptionTagIndex: coordinates[2],
+      gapFill: fill,
+    });
+    expect(current).toEqual(originalBody(fill, coordinates));
+    expect(current.locals.map((l) => l.name)).toEqual(
+      fill.kind === "default"
+        ? ["$data", "$ncap", "$ndata", "$ocap"]
+        : ["$data", "$ncap", "$ndata", "$ocap", "$oldlen"],
+    );
+  });
+  it("returns independent fresh output without mutating frozen resource data", () => {
+    const resources = Object.freeze({
+      carrierTypeIndex: 5,
+      arrayTypeIndex: 7,
+      exceptionTagIndex: 2,
+      gapFill: Object.freeze({ kind: "default" as const }),
+    });
+    const first = buildVectorGrowStoreBody(resources),
+      second = buildVectorGrowStoreBody(resources);
+    expect(first).toEqual(second);
+    expect(first.body).not.toBe(second.body);
+    expect(first.locals).not.toBe(second.locals);
+    first.body.pop();
+    first.locals.pop();
+    expect(second).toEqual(originalBody(resources.gapFill, [5, 7, 2]));
+  });
+  it("has only type imports from the physical model and no context/runtime dependency", () => {
+    const imports = parse(read()).statements.filter(ts.isImportDeclaration);
+    expect(imports.map((i) => [i.importClause?.isTypeOnly, i.moduleSpecifier.getText()])).toEqual([
+      [true, '"../../../wasm/model/instructions.js"'],
+      [true, '"../../../wasm/model/module-records.js"'],
+    ]);
+    expect(read()).not.toMatch(/CodegenContext|currentFunc|process\.|globalThis\./);
+  });
+});
+
+describe("shared vector type descriptors", () => {
+  it("preserves the one open mutable length-prefix base", () => {
+    expect(createVectorBaseType()).toEqual({
+      kind: "struct",
+      name: "__vec_base",
+      superTypeIdx: -1,
+      fields: [{ name: "length", type: { kind: "i32" }, mutable: true }],
+    });
+    expect(createVectorBaseType()).not.toBe(createVectorBaseType());
+  });
+  it.each(["externref", "f64", "i32", "i8"] as const)("preserves exact backing-array element %s", (kind) => {
+    const element = { kind };
+    const descriptor = createVectorBackingArrayType(`__arr_${kind}`, element);
+    expect(descriptor).toEqual({ kind: "array", name: `__arr_${kind}`, element, mutable: true });
+    expect(descriptor.element).toBe(element);
+  });
+  it.each([undefined, false, true])(
+    "preserves carrier metadata final=%s without inventing missing properties",
+    (final) => {
+      const descriptor = createVectorCarrierType({
+        name: "__vec_test",
+        baseTypeIndex: 2,
+        arrayTypeIndex: 6,
+        ...(final === undefined ? {} : { final }),
+      });
+      expect(descriptor).toEqual({
+        kind: "struct",
+        name: "__vec_test",
+        superTypeIdx: 2,
+        ...(final === undefined ? {} : { final }),
+        fields: [
+          { name: "length", type: { kind: "i32" }, mutable: true },
+          { name: "data", type: { kind: "ref", typeIdx: 6 }, mutable: true },
+        ],
+      });
+      expect(Object.hasOwn(descriptor, "final")).toBe(final !== undefined);
+    },
+  );
+});

--- a/tests/issue-3518-vector-grow-store-donor.test.ts
+++ b/tests/issue-3518-vector-grow-store-donor.test.ts
@@ -1,0 +1,515 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+// Established bootstrap: the legacy registry graph needs the public entry first.
+import "../src/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { ensureVecElemSet, ensureVecNewSized, ensureHoleyArrayNew } from "../src/codegen/vec-elem-set.js";
+import {
+  getOrRegisterArrayType,
+  getOrRegisterVecBaseType,
+  getOrRegisterVecType,
+  getOrRegisterHoleyArrayType,
+} from "../src/codegen/registry/types.js";
+import { HOLE_F64_BITS } from "../src/codegen/value-tags.js";
+import {
+  buildVectorGrowStoreBody,
+  createVectorBackingArrayType,
+  createVectorBaseType,
+  createVectorCarrierType,
+} from "../src/runtime/wasmgc/values/vector-grow-store.js";
+
+const paths = { donor: "../src/codegen/vec-elem-set.ts", registry: "../src/codegen/registry/types.ts" } as const;
+const read = (key: keyof typeof paths) => readFileSync(new URL(paths[key], import.meta.url), "utf8");
+const parse = (text: string) => ts.createSourceFile("donor.ts", text, ts.ScriptTarget.Latest, true);
+const sha = (text: string) => createHash("sha256").update(text).digest("hex");
+const printer = ts.createPrinter({ removeComments: true });
+
+function normalizedFunction(text: string, name: string): string {
+  const sf = parse(text),
+    fn = sf.statements.find((s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === name);
+  if (!fn?.body) throw new Error("missing exact donor function");
+  const transform = ts.transform(fn, [
+    (context) => (root) => {
+      const visit: ts.Visitor = (node) => {
+        if (name === "ensureVecElemSet" && ts.isVariableStatement(node)) {
+          const declaration = node.declarationList.declarations[0]!;
+          const variable = declaration.name.getText(sf);
+          if (["VEC", "IDX", "VAL", "DATA", "NCAP", "NDATA", "OCAP", "OLEN", "body"].includes(variable))
+            return undefined;
+          if (
+            declaration.initializer &&
+            ts.isCallExpression(declaration.initializer) &&
+            declaration.initializer.expression.getText(sf) === "buildVectorGrowStoreBody"
+          )
+            return undefined;
+          if (variable === "gapFill" || variable === "gapFillInit")
+            return ts.factory.createVariableStatement(
+              undefined,
+              ts.factory.createVariableDeclarationList(
+                [
+                  ts.factory.createVariableDeclaration(
+                    "GAP_FILL_RECEIPT",
+                    undefined,
+                    undefined,
+                    ts.factory.createNumericLiteral(0),
+                  ),
+                ],
+                ts.NodeFlags.Const,
+              ),
+            );
+        }
+        if (
+          name === "ensureVecElemSet" &&
+          node.parent &&
+          ts.isObjectLiteralExpression(node.parent) &&
+          (ts.isShorthandPropertyAssignment(node) || ts.isPropertyAssignment(node)) &&
+          node.name.getText(sf) === "locals"
+        )
+          return ts.factory.createPropertyAssignment("locals", ts.factory.createIdentifier("LOCALS_RECEIPT"));
+        if (
+          name !== "ensureVecElemSet" &&
+          ts.isCallExpression(node) &&
+          node.expression.getText(sf) === "ctx.mod.types.push"
+        )
+          return ts.factory.updateCallExpression(node, node.expression, node.typeArguments, [
+            ts.factory.createIdentifier("DESCRIPTOR_RECEIPT"),
+          ]);
+        return ts.visitEachChild(node, visit, context);
+      };
+      return ts.visitNode(root, visit) as ts.FunctionDeclaration;
+    },
+  ]);
+  try {
+    return printer.printNode(ts.EmitHint.Unspecified, transform.transformed[0]!, sf);
+  } finally {
+    transform.dispose();
+  }
+}
+
+const ORIGINAL_DECLARATIONS = {
+  donor: [
+    {
+      name: "VEC_ELEM_SET_PREFIX",
+      sha256: "63da7e9e1db98ac675fa523288fccdf343a12820aa56c9ad6d05014de037ba19",
+      retained: true,
+    },
+    {
+      name: "VEC_NEW_SIZED_PREFIX",
+      sha256: "bde93877ee17967c1cfdeb1585fde4e669d71c466e81644ddf83e2be02209187",
+      retained: true,
+    },
+    {
+      name: "HOLEY_ARRAY_NEW",
+      sha256: "ce594f8d66edced31796aa6046bfc93feb2b000e161854ad9dbc6581da1e2c88",
+      retained: true,
+    },
+    {
+      name: "ensureHoleyArrayNew",
+      sha256: "dc44540f5f166faf8f66f324f520b3048410723a96151a5b7489562dff13d3fa",
+      retained: true,
+    },
+    {
+      name: "vecTypeIndexForElement",
+      sha256: "83ce8899fdee86879c3e44559e7a4dd5d67e15924be645ce601c0f26a289af8c",
+      retained: true,
+    },
+    {
+      name: "ensureVecNewSizedForElement",
+      sha256: "84c614bafd3a5e0decfb9094feb8077805da5b239c88c1a4cd5f9aa24c67a5d1",
+      retained: true,
+    },
+    {
+      name: "ensureVecElemSetForElement",
+      sha256: "ceb27e66bbb4e4603ad24f522fb313c3d424b6db96deefc2afb3db26184327ed",
+      retained: true,
+    },
+    {
+      name: "ensureVecNewSized",
+      sha256: "08bdd2ca285cbabfc5e0ccce7bbc02976b7917b9b95969146b43e46feb30ad29",
+      retained: true,
+    },
+    {
+      name: "ensureVecElemSet",
+      sha256: "241349f47b3dce9705c3c62878bc0b4607a7146d25937570bb43e0b3b6a2787b",
+      retained: false,
+    },
+  ],
+  registry: [
+    {
+      name: "registerStructType",
+      sha256: "f61916d65496bd57304cdb8f5dff9e4ce5f0f623c23fa966169f3f9dde605311",
+      retained: true,
+    },
+    {
+      name: "addFuncType",
+      sha256: "a309d38e966a5d1673c6dcec320eed5377b517fb93306e72fdd3773f9c3ff4aa",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterArrayType",
+      sha256: "58f890ac3c21f18978308c9d2860e50b60cd07943ab8f6ddd0b9886efddf869a",
+      retained: false,
+    },
+    {
+      name: "getOrRegisterVecBaseType",
+      sha256: "84a8ef3b660721feea565ba3f1fe41b3802b3e5e6f7407b51d174cc69b390b83",
+      retained: false,
+    },
+    {
+      name: "isVecBaseSubtype",
+      sha256: "731a40aa43c528f2a3206f69e8f75c33e4bced61de9403c3623e3fd94931755a",
+      retained: true,
+    },
+    {
+      name: "withSuppressedVecUsage",
+      sha256: "b735b4d4c0d313b49eb530231d2e13958e069b5717448ffa053d69d10c1fad7d",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterVecType",
+      sha256: "04ce4c10ec816b7a13ca4224a4848f4b4546314a3ed6c62209bce0bdfe80d1b9",
+      retained: false,
+    },
+    {
+      name: "getOrRegisterHoleyArrayType",
+      sha256: "a67da23cdd4122372771fc71f3a830ac45236f6e0611e25623b05891cbdda1c6",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterArgumentsVecType",
+      sha256: "0e0bc367bef202bd9424f287442e843708e8db64fb7ea52800525f6c5565a85d",
+      retained: true,
+    },
+    {
+      name: "isHoleyArrayType",
+      sha256: "1a53d6aefb740bfa7095b97eb90d00e32927fcd38515df4b396b82af9d62be1d",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterSubviewType",
+      sha256: "19cd01d9ecb9fbff104d466a8bc26012771470e2fad2f334a6cbd9bb43eb1c5d",
+      retained: true,
+    },
+    {
+      name: "getSubviewArrTypeIdx",
+      sha256: "36cdc948e28b0c2af703e026e5ae31f2d0013a76c92e32ed1041e72a96f2ac5f",
+      retained: true,
+    },
+    {
+      name: "isSubviewTypeIdx",
+      sha256: "6c652ffae30ca70f41a4cd5412b3fd799401463a7704b230610db335e0829d87",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterTaViewType",
+      sha256: "76ef1f6cdb6f743246c05163489ea9e766dc71cb66bf9985800e1814b07e81c1",
+      retained: true,
+    },
+    {
+      name: "isTaViewTypeIdx",
+      sha256: "f5d0799c265543e5bbf266c5955a587c1d06d7dcb4439a091fcb71f69cbad1f2",
+      retained: true,
+    },
+    {
+      name: "getTaViewName",
+      sha256: "69b5092526080087e0b2f24bd0b1d7883efe86a9aa4188e41a2ae6ed85d66b3e",
+      retained: true,
+    },
+    {
+      name: "TA_CTOR_KINDS",
+      sha256: "e463d8c77082b4209454419e80f4f6e6e5de0e9ef6bd0867271a9111cd1467aa",
+      retained: true,
+    },
+    {
+      name: "TA_CTOR_BYTES",
+      sha256: "10aa617f7e4d5e4fb1a88e0e3055af6af31525e27a1c8bb414b6c3b8fd29b6e7",
+      retained: true,
+    },
+    {
+      name: "taCtorKindOf",
+      sha256: "0ed36bb3795fe4b0e668b8a4d3a2b1e43e4f7137162d7551d1835f8cbf188c3d",
+      retained: true,
+    },
+    {
+      name: "TA_CTOR_BRAND",
+      sha256: "e00e3c3de260d8d73d6e49c85fb013df9a1800ddeff3d56925f2fabd42452a29",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterTaCtorType",
+      sha256: "27e08f0a72b4cddd3b2b0e165aded9b16f95184dc3043705c5d117552c884e29",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterTaDynViewType",
+      sha256: "50710f4c16f23b4e1aba77720b84613e501b7977174e8d9f5da6fe336c844bd9",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterBoundFnType",
+      sha256: "ecbc1fb0a77ebf742cd1cbe3fdb96f5b1c201a67573a50bbab88c61ba0b2d6e4",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterResizableAbType",
+      sha256: "9518a66e28e9ad013dd078fbefda0fc9eeb3b87006ac58fb44e591f9387b6d23",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterTemplateVecType",
+      sha256: "c6612aa945819bf098b0ac1f220a62e5daa13189d00d3d1d70d759653d5e39a4",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterRefCellType",
+      sha256: "0976446f07ccdc56f52edf370d3dd0d29b0ed782ed1e55f9779e38a20c71fe44",
+      retained: true,
+    },
+    {
+      name: "refCellValueType",
+      sha256: "5cb7fa2f270729d36a996af22b7f7640020a06b6641496ce1f1c2572de2366b9",
+      retained: true,
+    },
+    {
+      name: "getArrTypeIdxFromVec",
+      sha256: "d5de6b418d7c5670a928e119021e315441ecbe541e5b9ee42db5e65f5a239a54",
+      retained: true,
+    },
+    {
+      name: "getOrRegisterErrorStructType",
+      sha256: "5e029463531f6b7b65d119b2f6fe7b19c01bf01ea2589f9d40c8ca59c89f4c9e",
+      retained: true,
+    },
+    {
+      name: "registerNativeStringTypes",
+      sha256: "e6de2fc9648203849e20fe402b07af90a03283b36decd583284253ae70b0aadb",
+      retained: true,
+    },
+  ],
+} as const;
+
+const ADAPTER_SHAPES = [
+  ["donor", "ensureVecElemSet", "781a2474556a4b472851f6c92325d560549d2572272e08e713e5e44fa5940df2"],
+  ["registry", "getOrRegisterArrayType", "ef19d0d5b623d517dff2b5e517dcae50ca866a6215133b35ae8722ab460d8b22"],
+  ["registry", "getOrRegisterVecBaseType", "8da164e7abf6ca79052b8d96e4e30149440d9b6d853c3aae464048511015319f"],
+  ["registry", "getOrRegisterVecType", "c5a11ee88d8c7c7d341146708fbf5d9b212f05a0501af93381cb74f2e6282f47"],
+] as const;
+
+describe("complete donor/registry preservation", () => {
+  it.each(["donor", "registry"] as const)("retains every declaration and original order in %s", (key) => {
+    const sf = parse(read(key)),
+      declarations = sf.statements.filter((s) => !ts.isImportDeclaration(s));
+    const name = (s: ts.Statement) =>
+      ts.isVariableStatement(s)
+        ? s.declarationList.declarations[0]!.name.getText(sf)
+        : ts.isFunctionDeclaration(s)
+          ? s.name?.text
+          : undefined;
+    expect(declarations.map(name)).toEqual(ORIGINAL_DECLARATIONS[key].map((r) => r.name));
+    for (const receipt of ORIGINAL_DECLARATIONS[key])
+      if (receipt.retained) {
+        const declaration = declarations.find((s) => name(s) === receipt.name)!;
+        expect(sha(declaration.getFullText(sf)), receipt.name).toBe(receipt.sha256);
+      }
+    expect(ORIGINAL_DECLARATIONS[key].filter((r) => r.retained)).toHaveLength(key === "donor" ? 8 : 27);
+  });
+  it.each(ADAPTER_SHAPES)("preserves %s %s allocation/cache/publication control flow", (key, name, expected) => {
+    expect(sha(normalizedFunction(read(key), name))).toBe(expected);
+  });
+  it("pins exact closed-data selection and builder resource forwarding before normalization", () => {
+    const sf = parse(read("donor")),
+      fn = sf.statements.find(
+        (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === "ensureVecElemSet",
+      )!;
+    const statements = fn.body!.statements.filter(ts.isVariableStatement);
+    const rows = statements.filter((s) =>
+      ["gapFill", "{ locals, body }"].includes(s.declarationList.declarations[0]!.name.getText(sf)),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.map((s) => sha(s.getText(sf)))).toEqual([
+      "41a7364246c28fb754a95e6b3f203a32209be89a64e18460d19551d8f71b8d93",
+      "23960d6e026071292017b91ab91979116cfcddc0ffd6b09185f471a76675dd06",
+    ]);
+    expect(read("donor")).not.toContain("currentFunc");
+  });
+  it.each([
+    ["donor", "ensureVecElemSet", "ctx.funcMap.set(name, funcIdx);", "ctx.funcMap.set(name, sigIdx);"],
+    ["donor", "ensureVecElemSet", "if (existing !== undefined) return existing;", "if (existing) return existing;"],
+    ["registry", "getOrRegisterVecType", "if (!ctx.suppressVecUsageFlag)", "if (ctx.suppressVecUsageFlag)"],
+    [
+      "registry",
+      "getOrRegisterArrayType",
+      "ctx.arrayTypeMap.set(cacheKey, idx);",
+      "ctx.arrayTypeMap.set(elemKind, idx);",
+    ],
+  ] as const)("detects live adapter mutation in %s/%s", (key, name, before, after) => {
+    const source = read(key);
+    // Restrict the mutation to the named declaration, not an earlier sibling cache check.
+    const sf = parse(source),
+      fn = sf.statements.find(
+        (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === name,
+      )!;
+    const changed =
+      source.slice(0, fn.pos) + source.slice(fn.pos, fn.end).replace(before, after) + source.slice(fn.end);
+    expect(changed).not.toBe(source);
+    expect(normalizedFunction(changed, name)).not.toBe(normalizedFunction(source, name));
+  });
+});
+
+function context(standalone = true) {
+  return createCodegenContext(createEmptyModule(), ts.createProgram([], {}).getTypeChecker(), { standalone });
+}
+
+describe("real legacy adapters retain dense and hole behavior", () => {
+  it.each(["dense-externref", "dense-f64", "hole-global", "f64-hole"] as const)(
+    "publishes the exact pure body and preserves cache hits: %s",
+    (kind) => {
+      const ctx = context();
+      ctx.usesArrayHoles = kind === "hole-global" || kind === "f64-hole";
+      const index =
+        kind === "hole-global"
+          ? getOrRegisterHoleyArrayType(ctx)
+          : getOrRegisterVecType(ctx, kind === "dense-externref" ? "externref" : "f64");
+      const carrier = ctx.mod.types[index]!;
+      if (carrier.kind !== "struct") throw new Error("fixture carrier");
+      const data = carrier.fields[1]!.type;
+      if (data.kind !== "ref" && data.kind !== "ref_null") throw new Error("fixture backing array");
+      const counts = { functions: ctx.mod.functions.length, globals: ctx.mod.globals.length };
+      const id = ensureVecElemSet(ctx, index);
+      expect(id).not.toBeNull();
+      const fn = ctx.mod.functions.find((f) => f.name === "__vec_elem_set_" + index)!;
+      expect(fn).toBeDefined();
+      expect(ctx.mod.functions).toHaveLength(counts.functions + 1);
+      const gapFill =
+        kind === "hole-global"
+          ? { kind: "hole-global" as const, globalIndex: ctx.holeGlobalIdx! }
+          : kind === "f64-hole"
+            ? { kind: "f64-hole" as const, bits: HOLE_F64_BITS }
+            : { kind: "default" as const };
+      expect({ body: fn.body, locals: fn.locals }).toEqual(
+        buildVectorGrowStoreBody({
+          carrierTypeIndex: kind === "hole-global" ? carrier.superTypeIdx! : index,
+          arrayTypeIndex: data.typeIdx,
+          exceptionTagIndex: ctx.exnTagIdx,
+          gapFill,
+        }),
+      );
+      expect(ctx.mod.globals.length - counts.globals).toBe(kind === "hole-global" ? 1 : 0);
+      if (kind === "f64-hole") expect(ctx.f64HoleMarkerEmitted).toBe(true);
+      const types = ctx.mod.types.length,
+        tags = ctx.mod.tags.length,
+        globals = ctx.mod.globals.length;
+      expect(ensureVecElemSet(ctx, index)).toBe(id);
+      expect(ctx.mod.types).toHaveLength(types);
+      expect(ctx.mod.tags).toHaveLength(tags);
+      expect(ctx.mod.globals).toHaveLength(globals);
+      expect(ctx.mod.functions).toHaveLength(counts.functions + 1);
+      expect(ctx.mod.functions.find((f) => f.name === fn.name)).toBe(fn);
+    },
+  );
+  it("keeps hole allocation before tag/signature and publishes function before cache", () => {
+    const ctx = context(),
+      index = getOrRegisterHoleyArrayType(ctx),
+      events: string[] = [];
+    const typesPush = ctx.mod.types.push.bind(ctx.mod.types),
+      globalsPush = ctx.mod.globals.push.bind(ctx.mod.globals);
+    const tagsPush = ctx.mod.tags.push.bind(ctx.mod.tags),
+      functionsPush = ctx.mod.functions.push.bind(ctx.mod.functions);
+    const mapSet = ctx.funcMap.set.bind(ctx.funcMap);
+    ctx.mod.types.push = (...items) => {
+      events.push(...items.map((t) => "type:" + t.kind));
+      return typesPush(...items);
+    };
+    ctx.mod.globals.push = (...items) => {
+      events.push("hole-global");
+      return globalsPush(...items);
+    };
+    ctx.mod.tags.push = (...items) => {
+      events.push("tag");
+      return tagsPush(...items);
+    };
+    ctx.mod.functions.push = (...items) => {
+      events.push("function");
+      return functionsPush(...items);
+    };
+    ctx.funcMap.set = (key, value) => {
+      events.push("func-cache:" + key);
+      return mapSet(key, value);
+    };
+    ensureVecElemSet(ctx, index);
+    expect(events).toEqual([
+      "type:struct",
+      "hole-global",
+      "type:func",
+      "tag",
+      "type:func",
+      "function",
+      "func-cache:__vec_elem_set_" + index,
+    ]);
+    events.length = 0;
+    ensureVecElemSet(ctx, index);
+    expect(events).toEqual([]);
+  });
+  it("preserves base/array/carrier descriptor and bookkeeping object ownership", () => {
+    const ctx = context();
+    const base = getOrRegisterVecBaseType(ctx);
+    expect(ctx.mod.types[base]).toEqual(createVectorBaseType());
+    for (const kind of ["f64", "externref", "i8_byte"] as const) {
+      const element = kind === "i8_byte" ? { kind: "i8" as const } : { kind };
+      const index = getOrRegisterVecType(ctx, kind, element),
+        array = getOrRegisterArrayType(ctx, kind, element);
+      expect(ctx.mod.types[array]).toEqual(createVectorBackingArrayType("__arr_" + kind, element));
+      const expected = createVectorCarrierType({
+        name: "__vec_" + kind,
+        baseTypeIndex: base,
+        arrayTypeIndex: array,
+        ...(kind === "i8_byte" ? { final: true } : {}),
+      });
+      expect(ctx.mod.types[index]).toEqual(expected);
+      expect(ctx.structMap.get(expected.name)).toBe(index);
+      expect(ctx.typeIdxToStructName.get(index)).toBe(expected.name);
+      expect(ctx.structFields.get(expected.name)).toEqual(expected.fields);
+      const carrier = ctx.mod.types[index]!;
+      if (carrier.kind !== "struct") throw new Error("fixture carrier");
+      expect(ctx.structFields.get(expected.name)).not.toBe(carrier.fields);
+    }
+    expect(ctx.usesVecValue).toBe(true);
+  });
+  it("retains reference element normalization and distinct reference caches", () => {
+    const ctx = context(),
+      before = ctx.mod.types.length;
+    const a = getOrRegisterArrayType(ctx, "ref", { kind: "ref", typeIdx: 901 });
+    const b = getOrRegisterArrayType(ctx, "ref", { kind: "ref", typeIdx: 902 });
+    expect(ctx.mod.types).toHaveLength(before + 2);
+    expect(a).not.toBe(b);
+    expect(ctx.mod.types[a]).toEqual(createVectorBackingArrayType("__arr_ref_901", { kind: "ref_null", typeIdx: 901 }));
+    expect(getOrRegisterArrayType(ctx, "ref_null", { kind: "ref_null", typeIdx: 901 })).toBe(a);
+  });
+  it("retains invalid-carrier and packed-element refusals without allocation", () => {
+    const ctx = context(),
+      packed = getOrRegisterVecType(ctx, "i8_byte", { kind: "i8" });
+    const types = ctx.mod.types.length,
+      funcs = ctx.mod.functions.length;
+    expect(ensureVecElemSet(ctx, -1)).toBeNull();
+    expect(ensureVecElemSet(ctx, packed)).toBeNull();
+    expect(ctx.mod.types).toHaveLength(types);
+    expect(ctx.mod.functions).toHaveLength(funcs);
+  });
+  it("retains both untouched sized allocators and their caches", () => {
+    const ctx = context(),
+      dense = getOrRegisterVecType(ctx, "f64");
+    const first = ensureVecNewSized(ctx, dense),
+      holey = ensureHoleyArrayNew(ctx);
+    expect(first).not.toBeNull();
+    expect(holey).not.toBe(first);
+    const count = ctx.mod.functions.length;
+    expect(ensureVecNewSized(ctx, dense)).toBe(first);
+    expect(ensureHoleyArrayNew(ctx)).toBe(holey);
+    expect(ctx.mod.functions).toHaveLength(count);
+  });
+});


### PR DESCRIPTION
## Summary

Materialize vector layouts and the canonical grow/store helper through the prepared consumer's existing physical reservation ledger. Preserve checked provider identity, same-module bindings and per-use nullability. Legacy adapters reuse the extracted body and descriptor builders.

Stacked on #5763. Activates three compiler-boundary modules without widening allowed edges. The async physical refusal remains in place.

## Validation

- Composed TS7 typecheck passed.
- 226/226 tests across 4/4 files passed: 153 boundary, 31 resource, 22 body and 20 donor tests (session 10660).
- Public extraction comparison: 14/14 equal pairs, 28 compilation rows, 56 expected calls, zero raw differences; five negative controls rejected tampering. Both child processes and controller exited 0.
- High review approved the exact twelve implementation/test files.

The public comparison proves donor preservation, not full prepared-family execution. Its positional WAT type lookup is not general type-provenance evidence; explicit reservation checks and resource tests provide that scoped evidence. Detailed provenance and limitations are recorded in the included handoff.

## Remaining work

Promise/frame/timer/string materialization, full async-family execution, public IR-only cutover, strict graph closure and the ABI30 witness remain incomplete. Existing holds remain; no auto-merge requested. Stacked-base CI coverage must be checked separately from local validation.

Refs #3518.
