### PR TITLE
feat(ir): reserve native Promise resources from checked programs

### DIFF
--- a/plan/agent-context/3518-native-promise-resource-checkpoint-handoff-2026-09-08.md
+++ b/plan/agent-context/3518-native-promise-resource-checkpoint-handoff-2026-09-08.md
@@ -1,0 +1,91 @@
+# Native Promise resource integration
+
+Base: PR #5765, `a7fbc6eb6fa8ebcde29529d67e55408592672fee`.
+
+Parent copied the frozen three-file resource snapshot with SHA256 verification
+into an isolated integration tree. Composed TS7 session39187 exited0.
+Focused test session68968 is live and has reported a failure; no passing
+suite result is claimed yet.
+
+This snapshot derives complete semantic/selected owner requirements and
+reserves Promise/scheduler resources in the existing physical ledger. Its
+tests deliberately distinguish reservation/layout controls from full execution.
+Type-only closure metadata in the kernel harness is not proof of actual native
+closure materialization. The complete fill path remains dependent on real
+value, object, string, TypeError and closure resources plus checked parent
+inventory authentication. Affirmatively absent carriers are currently rejected,
+not implemented. The async consumer refusal remains in place.
+
+Do not report this resource snapshot as full Promise-family execution or
+direct-codegen retirement. Required next steps include terminal diagnosis,
+High review, checked parent integration and actual native dependencies.
+
+Focused session68968 subsequently exited1: all16 tests failed during their
+shared positive source preparation, before reservation controls ran. The
+planner rejected the selected async attachment at line124. This is not16
+independent resource failures, nor evidence that the negative controls work.
+Hilbert owns diagnosis and repair of the exact attachment comparison, with
+the original refusal preserved until the real selected representation is
+understood. No tests were killed or rerun merely because observation timed out.
+
+Static worker repair now distinguishes cross-stage plan value equality from
+attachment ownership. Projection preparation recreates the semantic plan;
+the old cross-stage reference comparison was too strict. The working repair
+compares semantic plan contents, then calls the existing current-attachment
+validator against the selected owner's own plan and requires native kind.
+It also rejects an attachment without a semantic owner. This is not yet a
+frozen or executed repair; parent has not copied it or claimed a passing test.
+
+Parent launched the approved public Promise comparison directly after a fresh
+process census showed no delegated compiler run. Controller76198 started
+baseline child96719 with fresh output under the instrument worktree at
+`.tmp/promise-resolution-public-parent-r1`. Maxwell was instructed not to
+launch a duplicate. The fixed proposed denominator is24 pairs,48 compiles,
+96 instances and184 export observations, including the additional getter
+capture trace. No terminal or correctness result is claimed yet.
+
+Attachment repair r2 was integrated after source/target SHA checks. Composed
+session21281 passed TS7 and19/21 tests. All source-preparation positives now
+pass; the remaining two assertions expected missing function fill, but the
+ledger reports its earlier missing global fill at queue head. Parent changed
+only those two error expectations to the actual first unresolved resource.
+No materializer or rejection behavior changed. Rerun11858 is live.
+
+Rerun11858 exited0:21/21 tests passed in12.32s, with no reported skips or
+unhandled errors. This validates the scoped requirements/reservation controls,
+not complete filling or physical execution of the native Promise family.
+
+The checked parent planning entry now authenticates the whole prepared program
+and exact selected projection before deriving Promise requirements. Runtime
+configuration remains explicit; it is not inferred from missing bindings.
+Source-positive tests use this entry, with foreign-projection and backend
+mismatch controls. Session61703 passed TS7 and23/23 tests in13.40s. Boundary
+activation and full resource review remain before publication; no execution
+guard was removed.
+
+Boundary activation now includes both native Promise resource modules without
+changing the prior activation history or allowed edges. The measured closure
+is77 modules and286 resolved edges (187 type-only,99 runtime), with no unknown,
+unresolved, forbidden or transitive violations. Focused session53817 exited1
+only on the obsolete edge split; parent updated it to the measured counts.
+An earlier incorrectly named test filter selected zero tests and is not a pass.
+The pre-compaction66849 handle was missing when checked, so its terminal
+result is not claimed.
+
+Full session19123 exited0:192/192 tests across2 files in111.70s, comprising
+169 boundary controls and23 native resource tests. Scoped formatting also
+passed. Final composed TS7 session42272 also exited0. This still does not exercise complete native Promise filling or
+remove the async consumer refusal. High review remains pending.
+
+Public comparison76198 subsequently exited1: both child runs completed, all
+24 pairs matched, but both arms violated the independent ordinary getter
+capture expectation. See the public result JSON and retained preflight for
+the exact instrument and source identities. A separate High-reviewed repair
+plan is recorded alongside this handoff and delegated to Pauli in a fresh
+worktree, preserving the historical baseline and frozen extraction candidate.
+
+High review found no source/boundary blocker and requested one additional
+positive-paired rejection with only `sealed: false` changed on the genuine
+program. Parent added it. Session2053 passed24/24 resource tests in13.76s
+and the subsequent composed TS7 check, exiting0. This satisfies that review
+condition without modifying production code or weakening a refusal.

--- a/plan/agent-context/3518-promise-getter-capture-implementation-plan-2026-09-08.md
+++ b/plan/agent-context/3518-promise-getter-capture-implementation-plan-2026-09-08.md
@@ -1,0 +1,52 @@
+# Capture ordinary then once during Promise resolution
+
+High-reviewed implementation contract; implementation delegated to Pauli
+(native Astra Low), in a fresh worktree on PR #5765,
+`a7fbc6eb6fa8ebcde29529d67e55408592672fee`.
+
+## Evidence and intended behavior
+
+Public comparison controller76198 completed both arms and all24 pairs.
+Preservation passed, but semantic acceptance failed on both arms: an ordinary
+then getter was read twice and its replacement invoked. The recorded source
+baseline and frozen extraction candidate remain immutable. See the adjacent
+public result JSON and preflight document for exact identities and scope.
+
+Resolution must synchronously capture the first callable then, enqueue it,
+and later invoke that same callable with the original peeled receiver.
+Expected trace: getter1, original invocation1, replacement invocation0,
+delivered value42, trace1324. Matching the previous wrong result is not success.
+
+## Implementation ownership
+
+Pauli owns `src/runtime/wasmgc/promise/thenable-bodies.ts`,
+`src/runtime/wasmgc/promise/resolution-bodies.ts`,
+`src/codegen/async-scheduler.ts`, `src/codegen/closed-method-dispatch.ts`,
+and focused regression/preservation tests. Parent coordinates the separate
+native resource lookup-signature adaptation; no concurrent shared-file edits.
+
+1. Reserve and fill `__promise_lookup_then(externref)` with two results:
+   an i32 callability indicator and the captured externref callable.
+2. Return the exact callable from the first accessor, field or open-object
+   read. Use function-local multi-results, never global scratch, a second Get,
+   or an extra capture allocation.
+3. Store the captured callable in the existing capability callback field.
+   The queued job invokes it through the real applyClosure path with the
+   original peeled receiver.
+4. Preserve thrown-getter reason identity, synchronous Get versus queued
+   invocation timing, native Promise adoption and compiled-method dispatch.
+
+## Verification and landing
+
+- Test capture/replacement, poisoned and noncallable getters, receiver identity,
+  two pending resolutions and reentrancy.
+- Preserve original donor hashes and the49-control population. Explicitly
+  assert intentional behavior deltas rather than silently reseeding history.
+- Keep the original public comparison receipts; verify the repaired candidate
+  against independently stated semantic expectations, not raw parity alone.
+- Freeze changed source identities for parent High review. Serialize heavy
+  tests with parent; use normal commit/push hooks and a non-draft upstream PR.
+
+This fix does not establish full native resource filling, prepared-consumer
+cutover, strict compiler closure, or direct-codegen retirement. Those remain
+separate required migration work.

--- a/plan/agent-context/3518-promise-resolution-public-pair-preflight-2026-09-08.md
+++ b/plan/agent-context/3518-promise-resolution-public-pair-preflight-2026-09-08.md
@@ -1,0 +1,175 @@
+# Promise resolution public-source comparison: preflight
+
+Astra Low sidecar, prepared without running a compiler, suite or typecheck.
+Parent owns the heavy slot. No production/test-owner file was changed and
+nothing was written to Pauli's worktree, the baseline or the parent checkout.
+
+## Candidate binding
+
+Read-only candidate:
+ /private/tmp/js2-3518-promise-resolution-20260908
+ on codex/3518-promise-resolution-20260908.
+
+Baseline:
+ /private/tmp/js2-3518-explicit-rec-integration-20260908.
+
+Both HEADs are 2b9cb408c18446361fcf9837045067d1fd97c642. Pauli's
+.tmp/promise-resolution-v2-checkpoint.json was read in full. All four source
+SHA256s match; a complete recursive src comparison finds exactly these changes:
+
+- src/codegen/async-scheduler.ts:
+  159c7eba9ed415784307a460aa8617fd31a65850b621966d1e3f22fedc4d1723
+- src/codegen/closed-method-dispatch.ts:
+  9379464bd8386f5b203bdfc2d21d4dbb2a9584529b9a8cac53441f5124e02dfc
+- src/runtime/wasmgc/promise/resolution-bodies.ts:
+  a68e90829a719de5a83898e0df10eee61aed10cc1f6355391f7212bc9e52fe91
+- src/runtime/wasmgc/promise/thenable-bodies.ts:
+  9a802504e895b011a9e3b7a2a5cf975046fd679a1a14ce5af37ca410f88ff3ec
+
+Baseline src census: 1,316 files,
+48f52a45be1b9b37622d146297ec630dd4a2e3d8458852e804f30d57951bff18.
+Candidate: 1,318 files,
+25ba254acc6a4ba8434456302fa222245b0a65460630e76b9f16151c8e6e2afa.
+
+The runner rechecks both commits, a clean baseline, candidate four hashes,
+and the complete source-difference set before/after every child. The candidate
+is Pauli's four-file slice, not this worker's unrelated vector draft or the
+parent's larger integration.
+
+## Proposed fixed denominator
+
+Twelve recipes, each with experimentalIR=false and true:
+
+1. Native promise adoption through the executor resolve, with no own then.
+2. Pending native promise returned by a reaction and recursively adopted.
+3. Executor self-resolution, preserving the original truthy-reason control.
+4. Ordinary user thenable invocation.
+5. Recursively resolving thenables.
+6. Ordinary numeric resolution.
+7. Non-thenable object resolution.
+8. Real thrown-reason identity delivered through native rejection.
+9. Throwing then getter on the closed Object.defineProperty target.
+10. Throwing then getter on the open any-typed object.
+11. Captured native promise own then, replaced before the queued call.
+12. Callable-getter capture/order trace described below.
+
+This means **24 pairs / 48 compiles / 96 fresh module instances / 184 external
+export observations** if all actions are supported. No rows may be skipped.
+Compile, artifact, instantiate and execute failures remain separate located
+records; all baseline/candidate rows must still be compared.
+
+Eleven source recipes are extracted from existing tests:
+
+- issue-3125.test.ts
+- issue-3125-widen.test.ts
+- issue-2867.test.ts
+- issue-5197-own-then-indirection.test.ts
+- issue-4167-async-rejection-identity.test.ts
+
+Their exact source strings, originating test titles/full-file hashes, source
+wrapper adaptations, required exports, call order and expected values are in
+scripts/fixtures/3518-promise-resolution-public-pair.json. The old WASI-oriented
+source recipes deliberately run on the active standalone target here. This
+does not invoke a Test262 runner or create host/linear work.
+
+## Execution mechanism and positive observations
+
+Only selected-root src/index.ts public compile is dynamically imported. Native
+Promise settlement is observed through the actual module's microtask drain,
+either called inside the original source fixture or as an explicit required
+export action. There is no optional-drain fallback, host Promise substitution,
+synthetic subscription or await of an opaque native Promise carrier.
+
+Each compile is instantiated twice with its exact recorded bytes and empty
+imports. The fresh-instance repetitions avoid reusing old fixture globals.
+Every source expectation is independent of the other arm. Wrong values are
+recorded without stopping later trace reads, then fail semantic acceptance
+even if baseline/candidate agree.
+
+Most existing positives return distinct sentinels for fulfilment, rejection,
+identity failure and non-delivery. The pending-adoption row preserves explicit
+run/drain/getResult actions. The rejection-identity row preserves explicit
+module-init/drain/identityOk actions. These are observations, not helper-name
+or WAT-position coverage claims.
+
+Recipe 12 is explicitly a **new source observation**, not an unchanged known
+passing repository test. It combines the existing open-object getter shape
+with the resolve-before-job replacement test. Expected exported observations:
+
+- start reads the getter once; getter call count is 1.
+- Before drain, then invocation count is 0.
+- After drain, getter count remains 1, original then invocation count is 1,
+  replacement invocation count is 0, delivered value is 42, and trace is 1324
+  (get, return from resolve, call captured then, fulfil reaction).
+
+This addition needs parent/reviewer acceptance before execution if the desired
+denominator is restricted to byte-unchanged existing test source strings.
+
+## Concrete feasibility risk retained
+
+The moved non-Promise resolution arm currently enqueues a null callback after
+the callability predicate. The thenable job redispatches through the vararg
+then method when that callback is null. The native-Promise own-then arm instead
+captures the function into the callback field before queuing it.
+
+Consequently, an ordinary object's callable getter may be read again at job
+time and select the replacement. This is a source-reading prediction, not a
+measured regression. The new trace row will expose it without changing the
+compiler or its checker. If it fails on both arms, preservation can remain true
+while semantic acceptance is false. Do not replace it with a native-promise
+capture row and claim ordinary-getter capture has passed.
+
+The old JS2WASM_ASYNC_CARRIER_WIDEN switch is retired in the actual baseline
+scheduler. This sidecar does not use that obsolete switch or the old getter
+test's throwing host stubs. Binary and declared imports must both be empty.
+A resulting refusal remains in the denominator.
+
+## Reproducible runner and unrun command
+
+Prepared repository-path files:
+
+- scripts/verify-promise-resolution-public-pair.mts
+- scripts/fixtures/3518-promise-resolution-public-pair.json
+- this handoff.
+
+Runner SHA256:
+13f3ef003d15cecdee9c9f8fc2263f2c2f7170ae63a3fc7fd49b31a41d62ba40.
+
+Fixture SHA256:
+fb38fbd8180ba54b029b5ec8034929b301d9ab5831f4879385aaebcb417fa0b8.
+
+The runner is root-parameterized; no absolute host roots are embedded.
+Outputs are restricted to the invoking instrument worktree's .tmp directory.
+The output directory must be fresh. Do not delete prior receipts to rerun.
+
+From /private/tmp/js2-3518-vector-grow-store-20260908, only after a new grant:
+
+~~~sh
+NODE_OPTIONS=--max-old-space-size=2048 \
+TSX_TSCONFIG_PATH=/private/tmp/js2-3518-vector-grow-store-20260908/tsconfig.json \
+TSX_DISABLE_CACHE=1 \
+node --import tsx scripts/verify-promise-resolution-public-pair.mts \
+  --baseline /private/tmp/js2-3518-explicit-rec-integration-20260908 \
+  --candidate /private/tmp/js2-3518-promise-resolution-20260908 \
+  --output /private/tmp/js2-3518-vector-grow-store-20260908/.tmp/promise-resolution-public-r1 \
+  > .tmp/promise-resolution-public-r1-controller.log 2>&1
+~~~
+
+The controller spawns baseline then candidate, never parallel. Each child uses
+its selected tsx loader/config, disabled tsx cache, a 2 GiB heap and scrubbed
+compiler/loader overrides. GVN/ownership/escape/allocation/dominance/inline
+controls are explicitly off; the two IR modes are distinct compile options.
+skipSemanticDiagnostics is explicitly false: no checker waiver is added.
+
+Retained evidence includes source census before/after, runtime/loader/harness
+identities, fixture digest, launch and clean terminal receipts, exact binary
+inputs, full WAT/resource ordering, imports/exports, IR outcomes, full errors,
+and actual per-action values/traces. No difference normalization is allowed.
+
+Authored comparator negatives cover missing row, wrong root, stale provenance,
+substituted instantiation bytes, wrong expected value, and changed outcome.
+They are **unrun**, as is the entire compiler pair. Static TS parsing passed
+for the runner and all 12 recipe strings; this is not a typecheck.
+
+Source-free prepared-consumer execution remains separate. This sidecar does
+not establish resource closure, native-family acceptance or retirement.

--- a/plan/agent-context/3518-promise-resolution-public-result-2026-09-08.json
+++ b/plan/agent-context/3518-promise-resolution-public-result-2026-09-08.json
@@ -1,0 +1,405 @@
+{
+  "schema": "promise-resolution-public-summary-v1",
+  "controller": {
+    "session": 76198,
+    "exitCode": 1
+  },
+  "comparisonSha256": "880909fc1e0f89f2cdb5ff98913c597f6649ef5c0228b8d5e8d6f4f46361cbb3",
+  "preservationOK": true,
+  "semanticOK": false,
+  "denominator": {
+    "pairs": 24,
+    "rows": 48,
+    "instances": 96,
+    "exportObservations": 184
+  },
+  "negativeControls": [
+    {
+      "name": "drop-row",
+      "rejected": true
+    },
+    {
+      "name": "wrong-root",
+      "rejected": true
+    },
+    {
+      "name": "changed-provenance",
+      "rejected": true
+    },
+    {
+      "name": "changed-instantiation-byte",
+      "rejected": true
+    },
+    {
+      "name": "wrong-value-cannot-pass-semantic-acceptance",
+      "rejected": true
+    },
+    {
+      "name": "changed-outcome-not-equal",
+      "rejected": true
+    }
+  ],
+  "baseline": {
+    "executed": 24,
+    "requiredRows": 24,
+    "instances": 48,
+    "observations": 92,
+    "gaps": [
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      }
+    ],
+    "ok": false
+  },
+  "candidate": {
+    "executed": 24,
+    "requiredRows": 24,
+    "instances": 48,
+    "observations": 92,
+    "gaps": [
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      }
+    ],
+    "ok": false
+  },
+  "rawDifferences": [],
+  "terminals": [
+    {
+      "code": 0,
+      "signal": null,
+      "error": null,
+      "pid": 96719,
+      "root": "/private/tmp/js2-3518-explicit-rec-integration-20260908",
+      "label": "baseline",
+      "output": "/private/tmp/js2-3518-vector-grow-store-20260908/.tmp/promise-resolution-public-parent-r1/baseline.json",
+      "reportSha256": "0021d12520b0ae0b1e0c8da639a4a655dc1047cd1bcbd79bd27d5b0e89329744",
+      "launchSha256": "f7af88ff4a0ab51b806a479fa02f0ae3a51946a18979a1b1563bf396c51632ac"
+    },
+    {
+      "code": 0,
+      "signal": null,
+      "error": null,
+      "pid": 96812,
+      "root": "/private/tmp/js2-3518-promise-resolution-20260908",
+      "label": "candidate",
+      "output": "/private/tmp/js2-3518-vector-grow-store-20260908/.tmp/promise-resolution-public-parent-r1/candidate.json",
+      "reportSha256": "7adb84d303355b82f51dc0a39cfd9ba6910a43ba2a02b9ab5d41fb2f1c8cf582",
+      "launchSha256": "32547fdd8e40f95b2d8407e350dc55fb6d73d723dd9e3178dceb3e78ab0ca4ee"
+    }
+  ]
+}

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6322,3 +6322,49 @@ Promise resource materialization is a separate concurrent implementation.
 
 Composed rerun5973 subsequently exited0:210/210 tests across2/2 files passed
 in96.37s. This supersedes its pending status, not the execution limitations.
+
+## Confirmed ordinary-thenable capture defect
+
+Public comparison controller76198 exited1 although both compiler children
+exited0. All24 baseline/candidate pairs were raw-equal: the extraction
+preserves existing behavior. All48 compilation rows,96 instances and184
+export observations were attempted. Semantic acceptance is false.
+
+The additional ordinary-object getter-capture recipe fails identically in
+both IR modes and both fresh instances on both arms: getter count2 instead
+of1; original callback calls0 instead of1; replacement calls1 instead of0;
+delivered value99 instead of42; trace13184 instead of1324. The queued job
+therefore does not preserve the original captured then method for this case.
+Keep the failing row and original receipts. This is an existing correctness
+defect, not an extraction regression, and cannot count as native completion.
+
+High is specifying the bounded canonical resolution/job repair before Low
+implementation. Acceptance must retain once-only getter access, original
+callback capture, poisoned-getter rejection, recursive adoption and the full
+comparison denominator. Do not replace the expected values or normalize the
+failure away. The original report lives in the instrument worktree under
+`.tmp/promise-resolution-public-parent-r1/comparison.json`.
+
+## Native Promise resource checkpoint (2026-09-08)
+
+The isolated checkpoint on #5765 now derives authenticated selected-program
+requirements and reserves native Promise resources in the existing physical
+ledger. It activates two resource modules without relaxing historical
+boundary rules. Session19123 passed192/192 controls (169 boundary,23 resource),
+and composed TS7 session42272 exited0. The77-module closure has286 edges:
+187 type-only and99 runtime, with no reported closure violations.
+
+High review found no source or boundary-policy blocker but requested a
+positive-paired unsealed-program rejection test. That test is added and awaits
+its scoped run; it protects the checked wrapper's leading authentication.
+Full filling and execution remain unproven: actual value, object, string,
+TypeError and closure dependencies are still required. The consumer's async
+refusal remains, as do strict closure and retirement gates.
+
+The getter-capture fix is now High-specified and delegated to native Astra Low
+in a separate worktree on #5765. The implementation contract and checkpoint
+handoff are in `plan/agent-context/3518-promise-getter-capture-implementation-plan-2026-09-08.md`
+and `plan/agent-context/3518-native-promise-resource-checkpoint-handoff-2026-09-08.md`.
+
+The requested unsealed-program control subsequently passed with all24/24
+resource tests in13.76s; session2053 also passed composed TS7 and exited0.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -160,9 +160,10 @@
         "src/ir/program/errors.ts",
         "src/ir/program/data.ts",
         "src/ir/program/input.ts",
-        "src/ir/program/native-vector-resources.ts"
+        "src/ir/program/native-vector-resources.ts",
+        "src/ir/program/native-promise-resources.ts"
       ],
-      "minModules": 13
+      "minModules": 14
     },
     {
       "id": "runtime-contracts",
@@ -182,8 +183,8 @@
       "status": "active",
       "roots": ["src/backend/wasmgc"],
       "required": true,
-      "entries": ["src/backend/wasmgc/resources/native-vectors.ts"],
-      "minModules": 1
+      "entries": ["src/backend/wasmgc/resources/native-vectors.ts", "src/backend/wasmgc/resources/native-promises.ts"],
+      "minModules": 2
     },
     {
       "id": "native-runtime",
@@ -440,6 +441,31 @@
     }
   ],
   "activationHistory": [
+    {
+      "layer": "ir-program",
+      "entries": [
+        "src/ir/program/abi-inventory.ts",
+        "src/ir/program/abi.ts",
+        "src/ir/program/startup.ts",
+        "src/ir/program/abi-lookup.ts",
+        "src/ir/program/callable-bindings.ts",
+        "src/ir/program/controls.ts",
+        "src/ir/program/index.ts",
+        "src/ir/program/input-contracts.ts",
+        "src/ir/program/prepared-contracts.ts",
+        "src/ir/program/errors.ts",
+        "src/ir/program/data.ts",
+        "src/ir/program/input.ts",
+        "src/ir/program/native-vector-resources.ts",
+        "src/ir/program/native-promise-resources.ts"
+      ],
+      "minModules": 14
+    },
+    {
+      "layer": "backend-wasmgc",
+      "entries": ["src/backend/wasmgc/resources/native-vectors.ts", "src/backend/wasmgc/resources/native-promises.ts"],
+      "minModules": 2
+    },
     {
       "layer": "native-runtime",
       "entries": [
@@ -924,6 +950,8 @@
     }
   ],
   "files": [
+    { "path": "src/ir/program/native-promise-resources.ts", "state": "clean", "layer": "ir-program" },
+    { "path": "src/backend/wasmgc/resources/native-promises.ts", "state": "clean", "layer": "backend-wasmgc" },
     { "path": "src/runtime/wasmgc/promise/resolution-bodies.ts", "state": "clean", "layer": "native-runtime" },
     { "path": "src/runtime/wasmgc/promise/thenable-bodies.ts", "state": "clean", "layer": "native-runtime" },
     { "path": "src/ir/program/native-vector-resources.ts", "state": "clean", "layer": "ir-program" },

--- a/scripts/fixtures/3518-promise-resolution-public-pair.json
+++ b/scripts/fixtures/3518-promise-resolution-public-pair.json
@@ -1,0 +1,299 @@
+{
+  "schema": "promise-resolution-public-fixtures-v1",
+  "base": "2b9cb408c18446361fcf9837045067d1fd97c642",
+  "recipes": [
+    {
+      "id": "native-adoption",
+      "source": "declare function __drain_microtasks(): void;\nexport function test(): number {\n  const holder: any = { last: 0 };\n  const inner: any = Promise.resolve(42);\n  const alias: any = inner;\n  new Promise(function (res: any) { res(alias); }).then(function (val: any) { holder.last = (val === 42) ? 1 : 2; }, function () { holder.last = 3; });\n  __drain_microtasks();\n  return holder.last;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-5197-own-then-indirection.test.ts",
+        "title": "standalone: a promise with no own then still adopts",
+        "sha256": "511fe70dbdaf65328bc302317c1bdc0b8717cf4a6afe0457bb31c8addcd8a1bd",
+        "originalHarness": "runStandalone",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "pending-adoption",
+      "source": "\nlet result = 0;\nexport function run(): void { Promise.resolve(1)\n           .then((v: number) => Promise.resolve(v).then((w: number) => w + 10))\n           .then((v: number) => { result = v; }); }\nexport function getResult(): number { return result; }\n",
+      "actions": [
+        {
+          "export": "run",
+          "args": [],
+          "expected": {
+            "$undefined": true
+          }
+        },
+        {
+          "export": "__drain_microtasks",
+          "args": [],
+          "expected": {
+            "$undefined": true
+          }
+        },
+        {
+          "export": "getResult",
+          "args": [],
+          "expected": 11
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-2867.test.ts",
+        "title": "assimilation recurses through a pending inner promise",
+        "sha256": "7c846273064fbdd28ab82e12775a9eb34bf370baeaf9bbf531c5c185e6be8c03",
+        "originalHarness": "runWasi",
+        "adaptation": "original runWasi source wrapper; target changed to standalone"
+      }
+    },
+    {
+      "id": "self-resolution",
+      "source": "declare function __drain_microtasks(): void;\n\nexport function test(): number {\n  let result = 0;\n  let cap: any = null;\n  const p = new Promise(function(resolve) { cap = resolve; });\n  cap(p); // resolve p with ITSELF -> §27.2.1.3.2 step 6 rejects with TypeError\n  p.then(function() { result = 2; }, function(reason: any) {\n    result = reason ? 1 : 4;\n  });\n  __drain_microtasks();\n  return result;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-3125.test.ts",
+        "title": "rejects self-resolution with a truthy TypeError (executor resolve)",
+        "sha256": "d81689064e2d572f624fc4532c6ef997fcb44f920e0d2064ea7e236865fd3ed0",
+        "originalHarness": "runWasi",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "thenable-invocation",
+      "source": "declare function __drain_microtasks(): void;\n\nexport function test(): number {\n  let result = 0;\n  const thenable = { then: function(resolve: any) { resolve(42); } };\n  Promise.resolve(thenable).then(function(val: any) {\n    result = (val === 42) ? 1 : 2;\n  }, function() { result = 3; });\n  __drain_microtasks();\n  return result;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-3125.test.ts",
+        "title": "assimilates a user thenable ({then: function(resolve){...}})",
+        "sha256": "d81689064e2d572f624fc4532c6ef997fcb44f920e0d2064ea7e236865fd3ed0",
+        "originalHarness": "runWasi",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "thenable-recursion",
+      "source": "declare function __drain_microtasks(): void;\n\nexport function test(): number {\n  let result = 0;\n  const inner = { then: function(resolve: any) { resolve(7); } };\n  const outer = { then: function(resolve: any) { resolve(inner); } };\n  Promise.resolve(outer).then(function(val: any) {\n    result = (val === 7) ? 1 : 2;\n  }, function() { result = 3; });\n  __drain_microtasks();\n  return result;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-3125.test.ts",
+        "title": "assimilates recursively (thenable resolving with a thenable)",
+        "sha256": "d81689064e2d572f624fc4532c6ef997fcb44f920e0d2064ea7e236865fd3ed0",
+        "originalHarness": "runWasi",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "ordinary-number",
+      "source": "declare function __drain_microtasks(): void;\n\nexport function test(): number {\n  let result = 0;\n  Promise.resolve(42).then(function(val: any) {\n    result = (val === 42) ? 1 : 2;\n  }, function() { result = 3; });\n  __drain_microtasks();\n  return result;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-3125.test.ts",
+        "title": "non-object resolutions still fulfil directly (numbers)",
+        "sha256": "d81689064e2d572f624fc4532c6ef997fcb44f920e0d2064ea7e236865fd3ed0",
+        "originalHarness": "runWasi",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "ordinary-object",
+      "source": "declare function __drain_microtasks(): void;\n\nexport function test(): number {\n  let result = 0;\n  const plain = { marker: 5 };\n  Promise.resolve(plain).then(function(val: any) {\n    result = (val.marker === 5) ? 1 : 2;\n  }, function() { result = 3; });\n  __drain_microtasks();\n  return result;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-3125.test.ts",
+        "title": "non-thenable objects still fulfil directly (regression guard)",
+        "sha256": "d81689064e2d572f624fc4532c6ef997fcb44f920e0d2064ea7e236865fd3ed0",
+        "originalHarness": "runWasi",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "ordinary-rejection-identity",
+      "source": "\n        let identity = false;\n        const reason: any = { marker: 4167 };\n        Promise.resolve(0)\n          .then(function() { throw reason; })\n          .catch(function(caught) { identity = caught === reason; });\n        export function identityOk(): boolean { return identity; }\n      ",
+      "actions": [
+        {
+          "export": "__module_init",
+          "args": [],
+          "expected": {
+            "$undefined": true
+          }
+        },
+        {
+          "export": "__drain_microtasks",
+          "args": [],
+          "expected": {
+            "$undefined": true
+          }
+        },
+        {
+          "export": "identityOk",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {
+        "deferTopLevelInit": true
+      },
+      "origin": {
+        "path": "tests/issue-4167-async-rejection-identity.test.ts",
+        "title": "keeps standalone Promise rejection payload identity on the native scheduler",
+        "sha256": "ca948318cd5c5670858a362bb4cf2b8120ebc8ae2d89a78accfed4a87ea7086f",
+        "originalHarness": "compile",
+        "adaptation": "unchanged compile source and required explicit init/drain"
+      }
+    },
+    {
+      "id": "getter-throw-closed",
+      "source": "declare function __drain_microtasks(): void;\n\nexport function test(): number {\n  let result = 0;\n  const value = { marker: 7 };\n  const poisoned = Object.defineProperty({}, 'then', { get: function() { throw value; } });\n  Promise.resolve(poisoned).then(function() { result = 2; }, function(val: any) {\n    result = (val === value) ? 1 : 4;\n  });\n  __drain_microtasks();\n  return result;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-3125-widen.test.ts",
+        "title": "rejects on a poisoned `then` getter (inline defineProperty target)",
+        "sha256": "36f16450807eacab5f22a91827541e80b8192329717b57170e05aba74861cef3",
+        "originalHarness": "runWidenStandalone",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "getter-throw-open",
+      "source": "declare function __drain_microtasks(): void;\n\nexport function test(): number {\n  let result = 0;\n  const value = { marker: 7 };\n  const o: any = {};\n  Object.defineProperty(o, 'then', { get: function() { throw value; } });\n  Promise.resolve(o).then(function() { result = 2; }, function(val: any) {\n    result = (val === value) ? 1 : 4;\n  });\n  __drain_microtasks();\n  return result;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-3125-widen.test.ts",
+        "title": "rejects on a poisoned `then` getter (any-typed $Object target)",
+        "sha256": "36f16450807eacab5f22a91827541e80b8192329717b57170e05aba74861cef3",
+        "originalHarness": "runWidenStandalone",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "native-then-capture",
+      "source": "declare function __drain_microtasks(): void;\nexport function test(): number {\n  const holder: any = { last: 0 };\n  const p: any = Promise.resolve(1);\n  p.then = function (res: any) { res(11); };\n  const alias: any = p;\n  const outer: any = new Promise(function (res: any) { res(alias); });\n  p.then = function (res: any) { res(22); };\n  outer.then(function (val: any) { holder.last = (val === 11) ? 1 : (val === 22 ? 2 : 4); }, function () { holder.last = 3; });\n  __drain_microtasks();\n  return holder.last;\n}",
+      "actions": [
+        {
+          "export": "test",
+          "args": [],
+          "expected": 1
+        }
+      ],
+      "options": {},
+      "origin": {
+        "path": "tests/issue-5197-own-then-indirection.test.ts",
+        "title": "standalone: `then` is captured at Resolve time, not at job time",
+        "sha256": "511fe70dbdaf65328bc302317c1bdc0b8717cf4a6afe0457bb31c8addcd8a1bd",
+        "originalHarness": "runStandalone",
+        "adaptation": "original source/PRELUDE; standalone-only target"
+      }
+    },
+    {
+      "id": "callable-getter-capture-trace",
+      "origin": {
+        "path": "tests/issue-3125-widen.test.ts + tests/issue-5197-own-then-indirection.test.ts",
+        "title": "proposed callable-getter counter/temporal control",
+        "adaptation": "new bounded source observation combining the existing open-object getter site and resolve-before-job replacement; not an unchanged existing passing fixture"
+      },
+      "source": "let gets = 0;\nlet calls = 0;\nlet wrongCalls = 0;\nlet value = 0;\nlet trace = 0;\nlet version = 0;\nexport function start(): number {\n  const o: any = {};\n  Object.defineProperty(o, \"then\", { get: function() {\n    gets += 1;\n    trace = trace * 10 + 1;\n    if (version === 0) return function(res: any) {\n      calls += 1;\n      trace = trace * 10 + 2;\n      res(42);\n    };\n    return function(res: any) {\n      wrongCalls += 1;\n      trace = trace * 10 + 8;\n      res(99);\n    };\n  } });\n  Promise.resolve(o).then(function(v: any) {\n    value = v;\n    trace = trace * 10 + 4;\n  });\n  trace = trace * 10 + 3;\n  version = 1;\n  return gets;\n}\nexport function getGets(): number { return gets; }\nexport function getCalls(): number { return calls; }\nexport function getWrongCalls(): number { return wrongCalls; }\nexport function getValue(): number { return value; }\nexport function getTrace(): number { return trace; }",
+      "options": {},
+      "actions": [
+        {
+          "export": "start",
+          "args": [],
+          "expected": 1
+        },
+        {
+          "export": "getCalls",
+          "args": [],
+          "expected": 0
+        },
+        {
+          "export": "__drain_microtasks",
+          "args": [],
+          "expected": {
+            "$undefined": true
+          }
+        },
+        {
+          "export": "getGets",
+          "args": [],
+          "expected": 1
+        },
+        {
+          "export": "getCalls",
+          "args": [],
+          "expected": 1
+        },
+        {
+          "export": "getWrongCalls",
+          "args": [],
+          "expected": 0
+        },
+        {
+          "export": "getValue",
+          "args": [],
+          "expected": 42
+        },
+        {
+          "export": "getTrace",
+          "args": [],
+          "expected": 1324
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/verify-promise-resolution-public-pair.mts
+++ b/scripts/verify-promise-resolution-public-pair.mts
@@ -1,0 +1,397 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// Standalone public-source preservation only. Not a prepared-consumer witness.
+// No WAT positional type classification, source instrumentation, or host fallback.
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, realpathSync, mkdirSync, writeFileSync, appendFileSync, openSync, closeSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { CompileResult } from "../src/index.js";
+const instrument=fileURLToPath(import.meta.url);
+const instrumentRoot=resolve(dirname(instrument),"..");
+const fixturePath=join(dirname(instrument),"fixtures/3518-promise-resolution-public-pair.json");
+const BASE="2b9cb408c18446361fcf9837045067d1fd97c642";
+const SOURCE_HASHES={
+  "src/codegen/async-scheduler.ts":"159c7eba9ed415784307a460aa8617fd31a65850b621966d1e3f22fedc4d1723",
+  "src/codegen/closed-method-dispatch.ts":"9379464bd8386f5b203bdfc2d21d4dbb2a9584529b9a8cac53441f5124e02dfc",
+  "src/runtime/wasmgc/promise/resolution-bodies.ts":"a68e90829a719de5a83898e0df10eee61aed10cc1f6355391f7212bc9e52fe91",
+  "src/runtime/wasmgc/promise/thenable-bodies.ts":"9a802504e895b011a9e3b7a2a5cf975046fd679a1a14ce5af37ca410f88ff3ec",
+};
+
+// Receipt primitives reused from issue-3518-promise-settlement-source-preservation.test.ts.
+const sha = (value: string | Uint8Array) => createHash("sha256").update(value).digest("hex");
+
+const read = (root: string, path: string) => readFileSync(join(root, path), "utf8");
+
+const controls = {
+  JS2WASM_IR_GVN: "0",
+  JS2WASM_IR_OWNERSHIP: "0",
+  JS2WASM_IR_ESCAPE: "0",
+  IR_VERIFY_ALLOC: "0",
+  JS2WASM_IR_VERIFY_DOMINANCE_NAIVE: "0",
+  JS2WASM_IR_INLINE: "0",
+};
+
+function envFor(root: string) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env))
+    if (/^(JS2WASM_|IR_VERIFY_|TSX_|ESBUILD_BINARY_PATH$|NODE_OPTIONS$|NODE_V8_COVERAGE$)/.test(key))
+      Reflect.deleteProperty(env, key);
+  return {
+    ...env,
+    ...controls,
+    NODE_OPTIONS: "--max-old-space-size=2048",
+    TSX_TSCONFIG_PATH: join(root, "tsconfig.json"),
+    TSX_DISABLE_CACHE: "1",
+  };
+}
+
+function launch() {
+  return {
+    argv: process.execArgv,
+    env: Object.fromEntries(
+      Object.entries(process.env)
+        .filter(([key]) => /^(JS2WASM_|IR_VERIFY_|TSX_|ESBUILD_BINARY_PATH$|NODE_OPTIONS$|NODE_V8_COVERAGE$)/.test(key))
+        .sort(),
+    ),
+  };
+}
+
+function tree(root: string, directory: string): [string, string][] {
+  const result: [string, string][] = [];
+  for (const entry of readdirSync(join(root, directory), { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) result.push(...tree(root, path));
+    else if (entry.isFile()) result.push([path, sha(readFileSync(join(root, path)))]);
+  }
+  return result;
+}
+
+function snapshot(root: string) {
+  const files = tree(root, "src");
+  return {
+    root,
+    head: execFileSync("git", ["-C", root, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+    dirty: execFileSync("git", ["-C", root, "status", "--porcelain", "--untracked-files=all", "--", "src"], {
+      encoding: "utf8",
+    }),
+    files,
+    sha256: sha(JSON.stringify(files)),
+  };
+}
+
+function runtime(root: string) {
+  const req = createRequire(join(root, "package.json"));
+  const tsx = dirname(req.resolve("tsx/package.json"));
+  const esbuild = dirname(req.resolve("esbuild/package.json"));
+  const binaryPackage = dirname(
+    createRequire(join(esbuild, "package.json")).resolve(`@esbuild/${process.platform}-${process.arch}/package.json`),
+  );
+  return {
+    node: process.version,
+    versions: process.versions,
+    exec: realpathSync(process.execPath),
+    execSha256: sha(readFileSync(process.execPath)),
+    tsx: tree(tsx, "dist"),
+    tsxPackage: sha(readFileSync(join(tsx, "package.json"))),
+    esbuild: tree(esbuild, "lib"),
+    esbuildPackage: sha(readFileSync(join(esbuild, "package.json"))),
+    binary: tree(binaryPackage, "bin"),
+    typescript: sha(readFileSync(req.resolve("typescript"))),
+    config: sha(read(root, "tsconfig.json")),
+    instrument: sha(readFileSync(instrument)),
+  };
+}
+
+function data(value: unknown): unknown {
+  const seen = new Map<object, number>();
+  function visit(v: any): any {
+    if (v === undefined) return { $undefined: true };
+    if (typeof v === "number" && !Number.isFinite(v)) return { $number: String(v) };
+    if (typeof v === "bigint") return { $bigint: String(v) };
+    if (v === null || typeof v !== "object") return v;
+    if (seen.has(v)) return { $ref: seen.get(v) };
+    seen.set(v, seen.size);
+    if (v instanceof Error)
+      return Object.fromEntries(
+        [...new Set(["name", "message", "stack", "cause", ...Object.getOwnPropertyNames(v)])].map((k) => [
+          k,
+          visit((v as Error & Record<string, unknown>)[k]),
+        ]),
+      );
+    if (Array.isArray(v)) return v.map(visit);
+    if (v instanceof Map) return { $map: [...v].map(([k, w]) => [visit(k), visit(w)]) };
+    if (v instanceof Set) return { $set: [...v].map(visit) };
+    return Object.fromEntries(Object.keys(v).map((k) => [k, visit(v[k])]));
+  }
+  return visit(value);
+}
+
+async function settle<T>(promise: Promise<T>, phase: string): Promise<T> {
+  let rejectIdle!: (error: Error) => void;
+  const idle = new Promise<never>((_, reject) => {
+    rejectIdle = reject;
+  });
+  const onIdle = () => {
+    const error = Object.assign(new Error("unsettled recorder await: " + phase), {
+      code: "ERR_RECORDER_UNSETTLED_AWAIT",
+      phase,
+    });
+    rejectIdle(error);
+  };
+  process.once("beforeExit", onIdle);
+  try {
+    return await Promise.race([promise, idle]);
+  } finally {
+    process.removeListener("beforeExit", onIdle);
+  }
+}
+
+function artifact(result: CompileResult) {
+  const bytes = result.binary;
+  const module = new WebAssembly.Module(bytes);
+  return {
+    binary: Buffer.from(bytes).toString("base64"),
+    wat: result.wat,
+    imports: WebAssembly.Module.imports(module),
+    exports: WebAssembly.Module.exports(module),
+    resourceOrder: result.wat
+      .split("\n")
+      .filter((line) => /^ {2}\((?:type|import|global|func|export|elem|data)\b/.test(line)),
+    units: data({
+      compiled: result.irCompiledFuncs,
+      outcomes: result.irOutcomes,
+      postClaimErrors: result.irPostClaimErrors,
+    }),
+    stringPool: data(result.stringPool),
+  };
+}
+
+const FIXTURE_SHA="fb38fbd8180ba54b029b5ec8034929b301d9ab5831f4879385aaebcb417fa0b8";
+assert.equal(sha(readFileSync(fixturePath)),FIXTURE_SHA,"fixed recipe receipt");
+const fixtureFile=JSON.parse(readFileSync(fixturePath,"utf8"));
+assert.equal(fixtureFile.schema,"promise-resolution-public-fixtures-v1");
+assert.equal(fixtureFile.base,BASE);
+assert.equal(fixtureFile.recipes.length,12);
+const matrix=fixtureFile.recipes.flatMap((recipe:any)=>[false,true].map(experimentalIR=>({
+  ...recipe,id:recipe.id+(experimentalIR?"-ir":"-legacy"),
+  options:{target:"standalone",nativeStrings:true,experimentalIR,emitWat:true,
+    skipSemanticDiagnostics:false,trackFallbacks:true,trackIrOutcomes:true,
+    fileName:"promise-resolution-"+recipe.id+".ts",...recipe.options},
+})));
+assert.equal(matrix.length,24);
+assert.equal(new Set(matrix.map((x:any)=>x.id)).size,24);
+const plannedActions=matrix.reduce((n:number,f:any)=>n+f.actions.length,0)*4;
+assert.equal(plannedActions,184);
+
+function argumentsOf(argv:string[]) {
+  const values:Record<string,string>={};
+  for(let i=0;i<argv.length;i+=2) {
+    assert(["--baseline","--candidate","--output","--arm"].includes(argv[i]),"unknown option");
+    assert(argv[i+1] && !argv[i+1].startsWith("--"),"missing option value");
+    assert.equal(values[argv[i]],undefined,"duplicate option");
+    values[argv[i]]=argv[i+1];
+  }
+  assert(values["--baseline"] && values["--candidate"] && values["--output"],"required explicit roots/output");
+  const baseline=realpathSync(values["--baseline"]),candidate=realpathSync(values["--candidate"]);
+  assert.notEqual(baseline,candidate);
+  const output=resolve(values["--output"]);
+  assert(output.startsWith(join(instrumentRoot,".tmp/")),"writes restricted to instrument worktree scratch");
+  const arm=values["--arm"];
+  assert(arm===undefined || arm==="baseline" || arm==="candidate");
+  return {roots:{baseline,candidate},output,arm:arm as "baseline"|"candidate"|undefined};
+}
+function preflight(roots:{baseline:string;candidate:string}) {
+  for(const root of Object.values(roots))assert.equal(execFileSync("git",["-C",root,"rev-parse","HEAD"],{encoding:"utf8"}).trim(),BASE);
+  assert.equal(execFileSync("git",["-C",roots.baseline,"status","--porcelain","--untracked-files=all"],{encoding:"utf8"}),"","baseline must remain clean");
+  for(const [path,hash] of Object.entries(SOURCE_HASHES))assert.equal(sha(readFileSync(join(roots.candidate,path))),hash,path);
+  const baseline=snapshot(roots.baseline),candidate=snapshot(roots.candidate);
+  const old=new Map(baseline.files),now=new Map(candidate.files);
+  const changed=[...new Set([...old.keys(),...now.keys()])].filter(p=>old.get(p)!==now.get(p)).sort();
+  assert.deepEqual(changed,Object.keys(SOURCE_HASHES).sort(),"exact four production paths, no unrelated seeded source");
+  return {baseline,candidate,changed};
+}
+function observation(value:any) { return data(value); }
+async function measure(api:any,fixture:any) {
+  const row:any={id:fixture.id,fixture,compilations:[],executions:[],kind:"pending",expectedOK:false};
+  let phase="compile";
+  try {
+    const result=await settle(api.compile(fixture.source,fixture.options),"compile:"+fixture.id);
+    const compilation:any={source:fixture.source,options:fixture.options,success:result.success,
+      errors:data(result.errors),artifact:{binary:Buffer.from(result.binary).toString("base64"),wat:result.wat}};
+    row.compilations.push(compilation);
+    if(!result.success){row.kind="refused";row.phase=phase;return row;}
+    phase="artifact";
+    compilation.artifact=artifact(result);
+    compilation.artifact.completeResourceOrder=result.wat.split("\n").filter((line:string)=>
+      /^\s+\((?:rec|type|import|global|func|tag|table|memory|export|elem|data)(?:\s|\))/.test(line));
+    assert(result.binary.length>8 && result.wat.length>0);
+    assert.deepEqual(compilation.artifact.imports,[],"no host/WASI/synthetic fallback");
+    assert.deepEqual(result.imports,[],"declared imports");
+    // Each repetition starts a fresh real module instance: old fixtures contain
+    // module-local result cells and must not inherit the first repetition's state.
+    for(let repetition=0;repetition<2;repetition++) {
+      phase="instantiate";
+      const bytes=Buffer.from(result.binary),input=bytes.toString("base64");
+      assert.equal(input,compilation.artifact.binary);
+      const execution:any={repetition,instantiationInputBinary:input,instantiatedBinary:null,actions:[]};
+      row.executions.push(execution);
+      const {instance}=await settle(WebAssembly.instantiate(bytes,{}),"instantiate:"+fixture.id);
+      execution.instantiatedBinary=input;
+      phase="execute";
+      for(let ordinal=0;ordinal<fixture.actions.length;ordinal++) {
+        const action=fixture.actions[ordinal],fn=instance.exports[action.export];
+        assert.equal(typeof fn,"function","required real export "+action.export);
+        const actual=observation((fn as Function)(...action.args));
+        // Retain every later trace observation even if this value is wrong.
+        execution.actions.push({ordinal,export:action.export,args:action.args,value:actual});
+      }
+    }
+    row.kind="executed";row.phase="completed";
+    row.expectedOK=row.executions.every((e:any)=>e.actions.every((a:any,i:number)=>
+      JSON.stringify(a.value)===JSON.stringify(fixture.actions[i].expected)));
+  } catch(error) {row.kind="threw";row.phase=phase;row.error=data(error);}
+  return row;
+}
+async function arm(config:ReturnType<typeof argumentsOf>) {
+  const label=config.arm!,root=config.roots[label],output=join(config.output,label+".json");
+  assert.equal(process.cwd(),root);
+  assert.equal(process.env.TSX_TSCONFIG_PATH,join(root,"tsconfig.json"));
+  assert.equal(process.env.TSX_DISABLE_CACHE,"1");
+  assert.equal(process.env.ESBUILD_BINARY_PATH,undefined);
+  for(const [key,value] of Object.entries(controls))assert.equal(process.env[key],value);
+  const expected=preflight(config.roots),before=snapshot(root),identity=runtime(root);
+  const urls={compile:pathToFileURL(join(root,"src/index.ts")).href};
+  const api=await settle(import(urls.compile),"selected-public-root");
+  const rows=[];
+  for(const fixture of matrix) {
+    appendFileSync(output+".progress.jsonl",JSON.stringify({stage:"start",id:fixture.id})+"\n");
+    const row=await measure(api,fixture);rows.push(row);
+    appendFileSync(output+".progress.jsonl",JSON.stringify({stage:"completed",row})+"\n");
+  }
+  const after=snapshot(root);assert.deepEqual(after,before);
+  assert.deepEqual(preflight(config.roots),expected);
+  assert.deepEqual(runtime(root),identity);assert.equal(sha(readFileSync(fixturePath)),FIXTURE_SHA);
+  writeFileSync(output,JSON.stringify({schema:"promise-resolution-public-v1",
+    provenance:{label,before,after,identity,urls,launch:launch(),fixtureSha256:FIXTURE_SHA,matrixSha256:sha(JSON.stringify(matrix))},rows},null,2));
+}
+function environmentReceipt(env:NodeJS.ProcessEnv) {
+  return Object.fromEntries(Object.entries(env).filter(([key])=>
+    /^(JS2WASM_|IR_VERIFY_|TSX_|ESBUILD_BINARY_PATH$|NODE_OPTIONS$|NODE_V8_COVERAGE$)/.test(key)).sort());
+}
+async function child(config:ReturnType<typeof argumentsOf>,label:"baseline"|"candidate") {
+  const root=config.roots[label],output=join(config.output,label+".json");
+  const loader=createRequire(join(root,"package.json")).resolve("tsx/esm");
+  const args=["--import",loader,instrument,"--baseline",config.roots.baseline,
+    "--candidate",config.roots.candidate,"--output",config.output,"--arm",label];
+  const env=envFor(root),launchReceipt={root,label,exec:process.execPath,args,env:environmentReceipt(env),output};
+  const launchFile=join(config.output,label+".launch.json");
+  writeFileSync(launchFile,JSON.stringify(launchReceipt,null,2));
+  const stdout=openSync(join(config.output,label+".stdout.log"),"wx"),stderr=openSync(join(config.output,label+".stderr.log"),"wx");
+  let terminal:any;
+  try {
+    terminal=await new Promise(resolveTerminal=>{
+      const processChild=spawn(process.execPath,args,{cwd:root,env,stdio:["ignore",stdout,stderr]});
+      console.log(JSON.stringify({stage:"child-start",label,pid:processChild.pid,output}));
+      let error:any=null;
+      processChild.once("error",e=>{error=data(e)});
+      processChild.once("close",(code,signal)=>resolveTerminal({code,signal,error,pid:processChild.pid}));
+    });
+  } finally {closeSync(stdout);closeSync(stderr);}
+  let reportSha256:string|null=null;try{reportSha256=sha(readFileSync(output))}catch{}
+  const receipt={...terminal,root,label,output,reportSha256,launchSha256:sha(readFileSync(launchFile))};
+  writeFileSync(join(config.output,label+".terminal.json"),JSON.stringify(receipt,null,2));
+  console.log(JSON.stringify({stage:"child-terminal",...receipt}));
+  return receipt;
+}
+function differences(a:any,b:any,path="$",out:any[]=[]):any[] {
+  if(Object.is(a,b))return out;
+  if(!a || !b || typeof a!=="object" || typeof b!=="object" || Array.isArray(a)!==Array.isArray(b)) {
+    out.push({path,baseline:a,candidate:b});return out;
+  }
+  for(const key of new Set([...Object.keys(a),...Object.keys(b)]))differences(a[key],b[key],path+"."+key,out);
+  return out;
+}
+function validate(report:any,label:"baseline"|"candidate",expected:any,roots:{baseline:string;candidate:string}) {
+  const p=report.provenance,root=roots[label],gaps:any[]=[];
+  assert.equal(report.schema,"promise-resolution-public-v1");assert.equal(p.label,label);
+  assert.deepEqual(p.before,expected[label]);assert.deepEqual(p.after,p.before);
+  assert.deepEqual(p.identity,runtime(root));assert.equal(p.fixtureSha256,FIXTURE_SHA);
+  assert.equal(p.matrixSha256,sha(JSON.stringify(matrix)));
+  assert.deepEqual(p.urls,{compile:pathToFileURL(join(root,"src/index.ts")).href});
+  assert.deepEqual(p.launch.env,environmentReceipt(envFor(root)));
+  assert.deepEqual(p.launch.argv,["--import",createRequire(join(root,"package.json")).resolve("tsx/esm")]);
+  assert.equal(report.rows.length,24);
+  let observations=0,instances=0,executed=0;
+  for(let i=0;i<matrix.length;i++){
+    const row=report.rows[i],fixture=matrix[i];assert.equal(row.id,fixture.id);assert.deepEqual(row.fixture,fixture);
+    if(row.kind!=="executed"){gaps.push({id:row.id,kind:row.kind,phase:row.phase});continue;}
+    executed++;
+    assert.equal(row.compilations.length,1);
+    const c=row.compilations[0],e=c.artifact;
+    assert.equal(c.source,fixture.source);assert.deepEqual(c.options,fixture.options);assert.equal(c.success,true);
+    const mod=new WebAssembly.Module(Buffer.from(e.binary,"base64"));
+    assert.deepEqual(e.imports,WebAssembly.Module.imports(mod));assert.deepEqual(e.imports,[]);
+    assert.deepEqual(e.exports,WebAssembly.Module.exports(mod));assert(e.wat.length>0);
+    assert.equal(row.executions.length,2);
+    let expectedOK=true;
+    for(let rep=0;rep<2;rep++){
+      const execution=row.executions[rep];assert.equal(execution.repetition,rep);
+      assert.equal(execution.instantiationInputBinary,e.binary);assert.equal(execution.instantiatedBinary,e.binary);
+      instances++;
+      assert.equal(execution.actions.length,fixture.actions.length);
+      for(let n=0;n<fixture.actions.length;n++){
+        const a=execution.actions[n],wanted=fixture.actions[n];
+        assert.equal(a.ordinal,n);assert.equal(a.export,wanted.export);assert.deepEqual(a.args,wanted.args);
+        observations++;
+        if(differences(a.value,wanted.expected).length) {
+          expectedOK=false;gaps.push({id:row.id,repetition:rep,export:a.export,ordinal:n,actual:a.value,expected:wanted.expected});
+        }
+      }
+    }
+    assert.equal(row.expectedOK,expectedOK,"independently recomputed expectation verdict");
+  }
+  return {executed,requiredRows:24,instances,observations,gaps,ok:gaps.length===0};
+}
+async function pair(config:ReturnType<typeof argumentsOf>) {
+  const expected=preflight(config.roots);
+  mkdirSync(config.output,{recursive:false});
+  writeFileSync(join(config.output,"expected.json"),JSON.stringify({roots:config.roots,expected,matrix,fixtureSha256:FIXTURE_SHA,harnessSha256:sha(readFileSync(instrument)),identity:runtime(config.roots.baseline)},null,2));
+  const terminals=[];
+  for(const label of ["baseline","candidate"] as const)terminals.push(await child(config,label));
+  for(const t of terminals){assert.equal(t.code,0);assert.equal(t.signal,null);assert.equal(t.error,null);assert.equal(t.reportSha256,sha(readFileSync(t.output)));}
+  const a=JSON.parse(readFileSync(terminals[0].output,"utf8")),b=JSON.parse(readFileSync(terminals[1].output,"utf8"));
+  const baseline=validate(a,"baseline",expected,config.roots),candidate=validate(b,"candidate",expected,config.roots);
+  const rawDifferences=differences(a.rows,b.rows);
+  const preservationOK=rawDifferences.length===0,semanticOK=baseline.ok&&candidate.ok;
+  const negatives:any[]=[];
+  const mustReject=(name:string,operation:()=>unknown)=>{assert.throws(operation);negatives.push({name,rejected:true});};
+  const clone=(mutate:(x:any)=>void)=>{const x=structuredClone(b);mutate(x);return x;};
+  mustReject("drop-row",()=>validate(clone(x=>x.rows.pop()),"candidate",expected,config.roots));
+  mustReject("wrong-root",()=>validate(a,"candidate",expected,config.roots));
+  mustReject("changed-provenance",()=>validate(clone(x=>x.provenance.identity.node="stale"),"candidate",expected,config.roots));
+  const index=b.rows.findIndex((r:any)=>r.kind==="executed");assert(index>=0,"nonempty comparator positive");
+  mustReject("changed-instantiation-byte",()=>validate(clone(x=>x.rows[index].executions[0].instantiatedBinary+="AA"),"candidate",expected,config.roots));
+  const wrong=clone(x=>{x.rows[index].executions[0].actions[0].value={$wrong:true};x.rows[index].expectedOK=false;});
+  assert.equal(validate(wrong,"candidate",expected,config.roots).ok,false);
+  assert(differences(a.rows,wrong.rows).length>0);negatives.push({name:"wrong-value-cannot-pass-semantic-acceptance",rejected:true});
+  const changed=clone(x=>x.rows[index].compilations[0].errors.push({message:"changed outcome"}));
+  assert(differences(a.rows,changed.rows).length>0);negatives.push({name:"changed-outcome-not-equal",rejected:true});
+  const comparison={schema:"promise-resolution-public-pair-v1",preservationOK,semanticOK,
+    acceptanceOK:preservationOK&&semanticOK,denominator:{pairs:24,rows:48,instances:96,exportObservations:184},
+    baseline,candidate,rawDifferences,negativeControls:negatives,terminals};
+  writeFileSync(join(config.output,"comparison.json"),JSON.stringify(comparison,null,2));
+  assert.deepEqual(preflight(config.roots),expected);
+  console.log(JSON.stringify({stage:"comparison",preservationOK,semanticOK,baseline,candidate,rawDifferenceCount:rawDifferences.length}));
+  if(!comparison.acceptanceOK)process.exitCode=1;
+}
+const config=argumentsOf(process.argv.slice(2));
+try{if(config.arm)await arm(config);else await pair(config);}
+catch(error){
+  if(config.arm)writeFileSync(join(config.output,config.arm+".fatal.json"),JSON.stringify(data(error),null,2));
+  console.error(error);process.exitCode=1;
+}

--- a/src/backend/wasmgc/resources/native-promises.ts
+++ b/src/backend/wasmgc/resources/native-promises.ts
@@ -1,0 +1,646 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr, ValType } from "../../../wasm/model/instructions.js";
+import type { TypeDef } from "../../../wasm/model/module-records.js";
+import type {
+  PhysicalModuleReservations,
+  TypeReservation,
+  GlobalReservation,
+  CallableReservation,
+  FunctionReservation,
+  TagReservation,
+  TagImportReservation,
+  PhysicalFunctionSignature,
+} from "../../../wasm/physical/module-reservations.js";
+import { preparedIrDataMismatch, freezePreparedIrValue } from "../../../ir/program/data.js";
+import type { NativePromiseResourcePlan, NativePromiseOwner } from "../../../ir/program/native-promise-resources.js";
+import { resolveNativeVectorForElement, type NativeVectorTypeReservations } from "./native-vectors.js";
+import {
+  buildGrowLocals,
+  buildGrowBody,
+  buildEnqueueBody,
+  buildDrainLocals,
+  buildDrainBody,
+  type PreparedNativeMicrotaskReservations,
+} from "../../../runtime/wasmgc/async/microtask-queue-bodies.js";
+import {
+  buildPromiseSettleLocals,
+  buildPromiseSettleBody,
+  buildIdentityWrapperLocals,
+  buildIdentityWrapperBody,
+  PROMISE_STATE_FULFILLED,
+  PROMISE_STATE_REJECTED,
+  type PromiseHookResources,
+} from "../../../runtime/wasmgc/promise/settlement-bodies.js";
+import {
+  buildNativePromiseResolveValueBody,
+  buildPromiseResolveValueLocals,
+  buildPromiseThenableJob,
+  buildPromiseSettleClosureBody,
+} from "../../../runtime/wasmgc/promise/resolution-bodies.js";
+import {
+  buildPromisePeelValue,
+  buildPromiseThenableClassifier,
+} from "../../../runtime/wasmgc/promise/thenable-bodies.js";
+
+type Tag = TagReservation | TagImportReservation;
+const EXTERN: ValType = { kind: "externref" },
+  I32: ValType = { kind: "i32" },
+  F64: ValType = { kind: "f64" };
+const callbackSignature = { params: [EXTERN, EXTERN], results: [EXTERN] };
+export interface NativePromiseReservationDependencies {
+  readonly vectors: NativeVectorTypeReservations;
+  readonly exceptionTag: Tag;
+  /** Actual canonical closure root and builtin metadata reservation from the value materializer. */
+  readonly closureRoot: TypeReservation;
+  readonly settleMetadata: TypeReservation;
+}
+export interface NativePromiseReservations {
+  readonly types: {
+    readonly arguments: TypeReservation;
+    readonly functions: TypeReservation;
+    readonly callbackSignature: number;
+    readonly promise: TypeReservation;
+    readonly callback: TypeReservation;
+    readonly captures: TypeReservation;
+    readonly settleCapture: TypeReservation;
+  };
+  readonly globals: {
+    readonly head: GlobalReservation;
+    readonly tail: GlobalReservation;
+    readonly capacity: GlobalReservation;
+    readonly functions: GlobalReservation;
+    readonly captures: GlobalReservation;
+    readonly arguments: GlobalReservation;
+  };
+  readonly functions: {
+    readonly grow: FunctionReservation;
+    readonly enqueue: FunctionReservation;
+    readonly drain: FunctionReservation;
+    readonly fulfill: FunctionReservation;
+    readonly reject: FunctionReservation;
+    readonly identityFulfill: FunctionReservation;
+    readonly identityReject: FunctionReservation;
+    readonly resolveValue: FunctionReservation;
+    readonly peel: FunctionReservation;
+    readonly classifier: FunctionReservation;
+    readonly thenableJob: FunctionReservation;
+    readonly resolveClosure: FunctionReservation;
+    readonly rejectClosure: FunctionReservation;
+  };
+}
+export interface NativePromiseStringBinding {
+  readonly text: "then" | "Chaining cycle detected for promise";
+  readonly global: GlobalReservation;
+  readonly representation: "externref" | "gc";
+}
+export interface NativePromiseInventory {
+  /** Checked boundary must account for every selected owner, including empty owners. */
+  readonly owners: readonly NativePromiseOwner[];
+  readonly selectedOwners: readonly NativePromiseOwner[];
+  readonly derivedUnits: NativePromiseResourcePlan["derivedUnits"];
+  /** Exact carrier population derived by the checked parent resource plan, not a classifier assertion. */
+  readonly requiredCarriers: readonly TypeReservation[];
+  /** Every object/closure carrier supplied by the checked resource plan, in canonical order. */
+  readonly carriers: readonly {
+    readonly type: TypeReservation;
+    readonly role: "method" | "accessor" | "field" | "closure" | "other";
+    readonly getterGlobal?: GlobalReservation;
+    readonly fieldIndex?: number;
+  }[];
+  readonly anyValue: {
+    readonly type: TypeReservation;
+    readonly tag: number;
+    readonly ref: number;
+    readonly extern: number;
+  };
+  readonly openObject: { readonly type: TypeReservation; readonly get: CallableReservation };
+  readonly accessorGet: CallableReservation;
+}
+export interface NativePromiseFillDependencies {
+  readonly inventory: NativePromiseInventory;
+  readonly values: {
+    readonly boxNumber: CallableReservation;
+    readonly unboxNumber: CallableReservation;
+    readonly isNumber: CallableReservation;
+    readonly undefined: GlobalReservation;
+  };
+  readonly resolution: {
+    readonly newTypeError: CallableReservation;
+    readonly selfResolution: NativePromiseStringBinding;
+    readonly then: NativePromiseStringBinding;
+    readonly argumentVectorNew: CallableReservation;
+    readonly argumentVectorPush: CallableReservation;
+    readonly applyClosure: CallableReservation;
+    readonly thenDispatch: CallableReservation;
+    readonly bagHas: CallableReservation;
+    readonly externGet: CallableReservation;
+    readonly typeofFunction: CallableReservation;
+  };
+  readonly hooks:
+    | { readonly kind: "disabled" }
+    | { readonly kind: "dispatch"; readonly dispatch: CallableReservation; readonly parent: GlobalReservation };
+  readonly unhandledRejections:
+    | { readonly kind: "disabled" }
+    | { readonly kind: "track"; readonly head: GlobalReservation; readonly node: TypeReservation };
+}
+
+const owners = new WeakMap<
+  NativePromiseReservations,
+  {
+    tx: PhysicalModuleReservations;
+    plan: NativePromiseResourcePlan;
+    dependencies: NativePromiseReservationDependencies;
+    snapshots: readonly { token: TypeReservation; descriptor: TypeDef }[];
+    filled: boolean;
+  }
+>();
+function fail(detail: string): never {
+  throw new Error(`native Promise resources: ${detail}`);
+}
+function same(actual: unknown, expected: unknown, detail: string): void {
+  if (preparedIrDataMismatch(actual, expected) !== undefined) fail(detail);
+}
+function structFields(token: TypeReservation) {
+  if (token.object.kind !== "struct") fail("expected concrete struct reservation");
+  return token.object.fields;
+}
+const closureFields = () => [
+  { name: "func", type: { kind: "funcref" } as ValType, mutable: false },
+  { name: "$arity", type: I32, mutable: false },
+  { name: "$bag", type: EXTERN, mutable: true },
+];
+
+/** Reserve only: empty bodies are ledger obligations, never accepted fallback implementations. */
+export function reserveNativePromiseResources(
+  tx: PhysicalModuleReservations,
+  plan: NativePromiseResourcePlan,
+  dependencies: NativePromiseReservationDependencies,
+): NativePromiseReservations {
+  if (!plan.required || !plan.anchor) fail("missing required native Promise plan");
+  const layout = resolveNativeVectorForElement(dependencies.vectors, EXTERN);
+  const argumentArray = dependencies.vectors.layouts.find((row) => row.element === "externref")?.array;
+  if (!layout || !argumentArray || argumentArray.typeIndex !== layout.arrayTypeIdx)
+    fail("missing exact shared externref array");
+  same(
+    argumentArray.object,
+    { kind: "array", name: "__arr_externref", element: EXTERN, mutable: true },
+    "shared array descriptor mismatch",
+  );
+  same(structFields(dependencies.closureRoot), closureFields(), "noncanonical closure root");
+  const metadataFields = [
+    ...closureFields(),
+    { name: "bfnstate", type: I32, mutable: true },
+    { name: "bfnid", type: I32, mutable: false },
+  ];
+  same(structFields(dependencies.settleMetadata), metadataFields, "noncanonical settle metadata fields");
+  // The actual metadata subtype may sit below a signature wrapper; ancestry is checked by the ledger.
+  const key = (role: string) => `physical:promise:${JSON.stringify(plan.anchor)}:${role}`;
+  const functionsType = tx.reserveType(key("queue:function-array"), {
+    kind: "array",
+    name: "__arr_mt_func",
+    element: { kind: "funcref" },
+    mutable: true,
+  });
+  const callbackType = tx.internFunctionType(callbackSignature.params, callbackSignature.results, "$__mt_func_type");
+  const head = tx.reserveGlobal(key("queue:head"), "__mt_head", I32, true);
+  const tail = tx.reserveGlobal(key("queue:tail"), "__mt_tail", I32, true);
+  const capacity = tx.reserveGlobal(key("queue:capacity"), "__mt_cap", I32, true);
+  const functionsGlobal = tx.reserveGlobal(
+    key("queue:functions"),
+    "__mt_funcs",
+    { kind: "ref_null", typeIdx: functionsType.typeIndex },
+    true,
+  );
+  const capturesGlobal = tx.reserveGlobal(
+    key("queue:captures"),
+    "__mt_caps",
+    { kind: "ref_null", typeIdx: argumentArray.typeIndex },
+    true,
+  );
+  const argumentsGlobal = tx.reserveGlobal(
+    key("queue:arguments"),
+    "__mt_args",
+    { kind: "ref_null", typeIdx: argumentArray.typeIndex },
+    true,
+  );
+  const reserve = (role: string, name: string, signature: PhysicalFunctionSignature) => {
+    const bindings = plan.callableBindings.filter(
+      (entry) =>
+        entry.contract.kind === "callable" &&
+        (entry.contract.ref.binding.kind === "runtime" || entry.contract.ref.binding.kind === "intrinsic") &&
+        entry.contract.ref.binding.symbol === name,
+    );
+    if (bindings.length > 1) fail("duplicate canonical helper binding");
+    return tx.reserveFunction(bindings[0]?.plan.id ?? key(role), name, signature);
+  };
+  const grow = reserve("queue:grow", "__microtask_grow", { params: [I32], results: [] });
+  const enqueue = reserve("queue:enqueue", "__microtask_enqueue", {
+    params: [{ kind: "funcref" }, EXTERN, EXTERN],
+    results: [],
+  });
+  const drain = reserve("queue:drain", "__drain_microtasks", { params: [], results: [] });
+  const promise = tx.reserveType(key("carrier"), {
+    kind: "struct",
+    name: "$Promise",
+    fields: [
+      { name: "state", type: I32, mutable: true },
+      { name: "value", type: EXTERN, mutable: true },
+      { name: "callbacks", type: EXTERN, mutable: true },
+      { name: "$bag", type: EXTERN, mutable: true },
+    ],
+  });
+  const callback = tx.reserveType(key("callback"), {
+    kind: "struct",
+    name: "$PromiseCallback",
+    fields: [
+      { name: "onFulfilledFn", type: { kind: "funcref" }, mutable: false },
+      { name: "onFulfilledCaps", type: EXTERN, mutable: false },
+      { name: "onRejectedFn", type: { kind: "funcref" }, mutable: false },
+      { name: "onRejectedCaps", type: EXTERN, mutable: false },
+      { name: "next", type: EXTERN, mutable: false },
+    ],
+  });
+  const promiseRef: ValType = { kind: "ref", typeIdx: promise.typeIndex };
+  const captures = tx.reserveType(key("captures"), {
+    kind: "struct",
+    name: "$__then_caps",
+    fields: [
+      { name: "callback", type: EXTERN, mutable: false },
+      { name: "chained", type: promiseRef, mutable: false },
+    ],
+  });
+  const settle = { params: [promiseRef, EXTERN], results: [EXTERN] };
+  const fulfill = reserve("fulfill", "__promise_fulfill", settle);
+  const reject = reserve("reject", "__promise_reject", settle);
+  const identityFulfill = reserve("identity-fulfill", "__then_identity_fulfill", callbackSignature);
+  const identityReject = reserve("identity-reject", "__then_identity_reject", callbackSignature);
+  const resolveValue = reserve("resolve-value", "__promise_resolve_value", settle);
+  const settleCapture = tx.reserveType(key("settle-capture"), {
+    kind: "struct",
+    name: "$__promise_settle_cap",
+    superTypeIdx: dependencies.settleMetadata.typeIndex,
+    fields: [...metadataFields, { name: "cap_promise", type: promiseRef, mutable: false }],
+  });
+  const trampoline = {
+    params: [{ kind: "ref", typeIdx: dependencies.closureRoot.typeIndex } as ValType, EXTERN],
+    results: [],
+  };
+  const resolveClosure = reserve("resolve-closure", "__promise_resolve_cl", trampoline);
+  const rejectClosure = reserve("reject-closure", "__promise_reject_cl", trampoline);
+  const peel = reserve("peel", "__promise_peel_value", { params: [EXTERN], results: [EXTERN] });
+  const classifier = reserve("classifier", "__promise_has_callable_then", { params: [EXTERN], results: [I32] });
+  const thenableJob = reserve("thenable-job", "__promise_thenable_job", callbackSignature);
+  const result: NativePromiseReservations = Object.freeze({
+    types: Object.freeze({
+      arguments: argumentArray,
+      functions: functionsType,
+      callbackSignature: callbackType,
+      promise,
+      callback,
+      captures,
+      settleCapture,
+    }),
+    globals: Object.freeze({
+      head,
+      tail,
+      capacity,
+      functions: functionsGlobal,
+      captures: capturesGlobal,
+      arguments: argumentsGlobal,
+    }),
+    functions: Object.freeze({
+      grow,
+      enqueue,
+      drain,
+      fulfill,
+      reject,
+      identityFulfill,
+      identityReject,
+      resolveValue,
+      peel,
+      classifier,
+      thenableJob,
+      resolveClosure,
+      rejectClosure,
+    }),
+  });
+  const snapshots = [
+    argumentArray,
+    functionsType,
+    promise,
+    callback,
+    captures,
+    settleCapture,
+    dependencies.closureRoot,
+    dependencies.settleMetadata,
+  ].map((token) => ({ token, descriptor: freezePreparedIrValue(token.object) as TypeDef }));
+  owners.set(result, {
+    tx,
+    plan: freezePreparedIrValue(plan) as NativePromiseResourcePlan,
+    dependencies: Object.freeze({ ...dependencies }),
+    snapshots,
+    filled: false,
+  });
+  return result;
+}
+
+/** No fallback: resolution/classification/value dependencies must all be real same-ledger reservations. */
+export function fillNativePromiseResources(
+  tx: PhysicalModuleReservations,
+  pack: NativePromiseReservations,
+  dependencies: NativePromiseFillDependencies,
+): void {
+  const owner = owners.get(pack);
+  if (!owner || owner.tx !== tx) fail("foreign Promise pack");
+  if (owner.filled) fail("duplicate Promise pack fill");
+  if (!dependencies?.inventory || !dependencies.values || !dependencies.resolution)
+    fail("complete native dependencies are missing");
+  same(dependencies.inventory.owners, owner.plan.owners, "classification owner population differs");
+  same(dependencies.inventory.selectedOwners, owner.plan.selectedOwners, "classification selected population differs");
+  same(dependencies.inventory.derivedUnits, owner.plan.derivedUnits, "classification derived population differs");
+  // Do not infer an empty AnyValue/open-object inventory from absent registrations.
+  if (!dependencies.inventory.anyValue || !dependencies.inventory.openObject || !dependencies.inventory.accessorGet)
+    fail("complete native classification materialization is missing");
+  if (!Array.isArray(dependencies.inventory.requiredCarriers) || !Array.isArray(dependencies.inventory.carriers))
+    fail("checked carrier population is missing");
+  if (
+    dependencies.inventory.requiredCarriers.length !== dependencies.inventory.carriers.length ||
+    dependencies.inventory.requiredCarriers.some(
+      (token, index) => dependencies.inventory.carriers[index]?.type !== token,
+    )
+  )
+    fail("classifier inventory differs from checked carrier population");
+  if (
+    dependencies.hooks?.kind !== owner.plan.configuration.hooks ||
+    dependencies.unhandledRejections?.kind !== owner.plan.configuration.unhandledRejections
+  )
+    fail("hook/unhandled configuration differs from selected runtime");
+  for (const { token, descriptor } of owner.snapshots) {
+    same(token.object, descriptor, "reserved Promise layout changed");
+    if (tx.physicalIndex(token) !== token.typeIndex) fail("type coordinate differs");
+  }
+  for (const fn of Object.values(pack.functions)) tx.physicalIndex(fn);
+  const tag = owner.dependencies.exceptionTag;
+  const tagType = tx.internFunctionType([EXTERN], []);
+  if (tag.kind === "tag") same(tag.object, { name: "__exn", typeIdx: tagType }, "wrong exception tag");
+  else
+    same(
+      tag.object,
+      { module: "env", name: "__exn", desc: { kind: "tag", typeIdx: tagType } },
+      "wrong shared exception tag",
+    );
+  const exn = tx.physicalIndex(tag);
+  const bind = (token: CallableReservation, params: ValType[], results: ValType[]): number => {
+    if (!token) fail("missing callable dependency");
+    tx.physicalIndex(token);
+    const actual =
+      token.kind === "function"
+        ? token.object.typeIdx
+        : token.object.desc.kind === "func"
+          ? token.object.desc.typeIdx
+          : -1;
+    if (actual !== tx.internFunctionType(params, results)) fail(`dependency signature mismatch: ${token.key}`);
+    return token.handle;
+  };
+  const string = (binding: NativePromiseStringBinding, text: NativePromiseStringBinding["text"]): Instr[] => {
+    if (!binding || binding.text !== text) fail("missing exact native string operand");
+    const index = tx.physicalIndex(binding.global);
+    if (binding.representation === "externref") {
+      same(binding.global.object.type, EXTERN, "wrong extern string global");
+      return [{ op: "global.get", index }];
+    }
+    if (binding.global.object.type.kind !== "ref") fail("wrong GC string global");
+    return [{ op: "global.get", index }, { op: "extern.convert_any" }];
+  };
+  const r = dependencies.resolution,
+    v = dependencies.values,
+    inventory = dependencies.inventory;
+  bind(v.boxNumber, [F64], [EXTERN]);
+  bind(v.unboxNumber, [EXTERN], [F64]);
+  bind(v.isNumber, [EXTERN], [I32]);
+  tx.physicalIndex(v.undefined);
+  const newTypeError = bind(r.newTypeError, [EXTERN], [EXTERN]);
+  const argumentNew = bind(r.argumentVectorNew, [], [EXTERN]);
+  const argumentPush = bind(r.argumentVectorPush, [EXTERN, EXTERN], []);
+  const apply = bind(r.applyClosure, [EXTERN, EXTERN, EXTERN], [EXTERN]);
+  const thenDispatch = bind(r.thenDispatch, [EXTERN, EXTERN], [EXTERN]);
+  const bagHas = bind(r.bagHas, [EXTERN, EXTERN], [I32]);
+  const externGet = bind(r.externGet, [EXTERN, EXTERN], [EXTERN]);
+  const typeofFunction = bind(r.typeofFunction, [EXTERN], [I32]);
+  const selfString = string(r.selfResolution, "Chaining cycle detected for promise"),
+    thenString = string(r.then, "then");
+  const methods: number[] = [],
+    accessors: { typeIdx: number; getGlobal: number }[] = [],
+    fields: { typeIdx: number; fieldIdx: number }[] = [],
+    closures: number[] = [];
+  const seenTypes = new Set<TypeReservation>();
+  for (const row of inventory.carriers) {
+    if (seenTypes.has(row.type)) fail("duplicate inventory carrier");
+    seenTypes.add(row.type);
+    const index = tx.physicalIndex(row.type);
+    if (row.role === "method") methods.push(index);
+    if (row.role === "closure") closures.push(index);
+    if (row.role === "accessor") {
+      if (!row.getterGlobal) fail("missing accessor global");
+      accessors.push({ typeIdx: index, getGlobal: tx.physicalIndex(row.getterGlobal) });
+    }
+    if (row.role === "field") {
+      if (row.fieldIndex === undefined || structFields(row.type)[row.fieldIndex]?.type.kind !== "externref")
+        fail("invalid then field");
+      fields.push({ typeIdx: index, fieldIdx: row.fieldIndex });
+    }
+  }
+  if (!seenTypes.has(owner.dependencies.closureRoot)) fail("closure root absent from finalized inventory");
+  const av = inventory.anyValue;
+  const avFields = structFields(av.type);
+  if (av.tag !== 0 || av.ref !== 3 || av.extern !== 4) fail("invalid AnyValue peel descriptor");
+  same(
+    avFields,
+    [
+      { name: "tag", type: I32, mutable: false },
+      { name: "i32val", type: I32, mutable: false },
+      { name: "f64val", type: F64, mutable: false },
+      { name: "refval", type: { kind: "eqref" }, mutable: false },
+      { name: "externval", type: EXTERN, mutable: false },
+    ],
+    "invalid AnyValue peel descriptor",
+  );
+  const anyType = tx.physicalIndex(av.type),
+    objectType = tx.physicalIndex(inventory.openObject.type);
+  same(
+    v.undefined.object,
+    {
+      name: "__undefined",
+      type: { kind: "ref", typeIdx: anyType },
+      mutable: false,
+      init: [
+        { op: "i32.const", value: 1 },
+        { op: "i32.const", value: 0 },
+        { op: "f64.const", value: NaN },
+        { op: "ref.null", typeIdx: -19 },
+        { op: "ref.null.extern" },
+        { op: "struct.new", typeIdx: anyType },
+      ],
+    },
+    "canonical tag-1 undefined initializer is missing",
+  );
+  const objectGet = bind(inventory.openObject.get, [EXTERN, EXTERN], [EXTERN]);
+  const accessorGet = bind(inventory.accessorGet, [EXTERN, EXTERN], [EXTERN]);
+  let hook: PromiseHookResources;
+  if (dependencies.hooks.kind === "dispatch")
+    hook = {
+      dispatchFuncIdx: bind(dependencies.hooks.dispatch, [F64, EXTERN, EXTERN], []),
+      parentExternInstrs: [{ op: "global.get", index: tx.physicalIndex(dependencies.hooks.parent) }],
+    };
+  let unhandledHead = -1,
+    unhandledNode = -1;
+  if (dependencies.unhandledRejections.kind === "track") {
+    same(
+      dependencies.unhandledRejections.node.object,
+      {
+        kind: "struct",
+        name: "$__unhandled_node",
+        fields: [
+          { name: "promise", type: { kind: "eqref" }, mutable: false },
+          { name: "next", type: EXTERN, mutable: false },
+          { name: "handled", type: I32, mutable: true },
+        ],
+      },
+      "invalid unhandled-rejection node",
+    );
+    same(
+      dependencies.unhandledRejections.head.object,
+      { name: "__unhandled_head", type: EXTERN, mutable: true, init: [{ op: "ref.null.extern" }] },
+      "invalid unhandled-rejection head",
+    );
+    unhandledHead = tx.physicalIndex(dependencies.unhandledRejections.head);
+    unhandledNode = tx.physicalIndex(dependencies.unhandledRejections.node);
+  }
+  const f = pack.functions,
+    t = pack.types;
+  const queue: PreparedNativeMicrotaskReservations = {
+    types: {
+      functions: { kind: "type", index: t.functions.typeIndex },
+      arguments: { kind: "type", index: t.arguments.typeIndex },
+      callback: { kind: "type", index: t.callbackSignature },
+    },
+    globals: Object.fromEntries(
+      Object.entries(pack.globals).map(([name, token]) => [name, { kind: "global", index: tx.physicalIndex(token) }]),
+    ) as PreparedNativeMicrotaskReservations["globals"],
+    grow: { kind: "function", index: f.grow.handle },
+    initialCapacity: 8192,
+  };
+  const cap = {
+    capTypeIdx: t.settleCapture.typeIndex,
+    capMetaTypeIdx: owner.dependencies.settleMetadata.typeIndex,
+    capPromiseFieldIdx: 5,
+  };
+  const target = { wasi: false, standalone: true };
+  const resolution = buildNativePromiseResolveValueBody({
+    target,
+    state: {
+      promiseFulfillFuncIdx: f.fulfill.handle,
+      promiseRejectFuncIdx: f.reject.handle,
+      enqueueFuncIdx: f.enqueue.handle,
+      identityFulfillWrapperFuncIdx: f.identityFulfill.handle,
+      identityRejectWrapperFuncIdx: f.identityReject.handle,
+    },
+    promiseTypeIdx: t.promise.typeIndex,
+    callbackTypeIdx: t.callback.typeIndex,
+    capsTypeIdx: t.captures.typeIndex,
+    promiseFields: { state: 0, value: 1, callbacks: 2 },
+    callbackFields: [0, 1, 2, 3, 4],
+    capsFields: { callback: 0, chained: 1 },
+    thenable: {
+      hasCallableThenFuncIdx: f.classifier.handle,
+      thenableJobFuncIdx: f.thenableJob.handle,
+      peelValueFuncIdx: f.peel.handle,
+      newTypeErrorFuncIdx: newTypeError,
+    },
+    exnTagIdx: exn,
+    selfResolutionStringInstrs: selfString,
+    thenStringInstrs: thenString,
+    thenGetStringInstrs: thenString,
+    bagHasIdx: bagHas,
+    externGetIdx: externGet,
+    typeofFunctionIdx: typeofFunction,
+    callableRootTypeIdx: owner.dependencies.closureRoot.typeIndex,
+  });
+  const classifier = buildPromiseThenableClassifier({
+    finalized: true,
+    peelFuncIdx: f.peel.handle,
+    methodTypeIdxs: methods,
+    accessors,
+    callAccessorGetIdx: accessorGet,
+    fields,
+    closureWrapperTypeIdxs: closures,
+    openObject: { typeIdx: objectType, externGetFuncIdx: objectGet, thenStringInstrs: thenString },
+  });
+  const job = buildPromiseThenableJob({
+    target,
+    promiseTypeIdx: t.promise.typeIndex,
+    promiseRejectFuncIdx: f.reject.handle,
+    capsTypeIdx: t.captures.typeIndex,
+    capsFields: { callback: 0, chained: 1 },
+    objVecNewIdx: argumentNew,
+    objVecPushIdx: argumentPush,
+    execClosures: { ...cap, resolveClFuncIdx: f.resolveClosure.handle, rejectClFuncIdx: f.rejectClosure.handle },
+    applyClosureIdx: apply,
+    peelValueFuncIdx: f.peel.handle,
+    varargThenFuncIdx: thenDispatch,
+    exnTag: exn,
+  });
+  for (const token of [pack.globals.head, pack.globals.tail, pack.globals.capacity])
+    tx.fillGlobal(token, [{ op: "i32.const", value: 0 }]);
+  for (const token of [pack.globals.functions, pack.globals.captures, pack.globals.arguments]) {
+    if (token.object.type.kind !== "ref_null") fail("wrong queue storage type");
+    tx.fillGlobal(token, [{ op: "ref.null", typeIdx: token.object.type.typeIdx }]);
+  }
+  tx.fillFunction(f.grow, { locals: buildGrowLocals(queue), body: buildGrowBody(queue) });
+  tx.fillFunction(f.enqueue, { locals: [], body: buildEnqueueBody(queue) });
+  tx.fillFunction(f.drain, { locals: buildDrainLocals(), body: buildDrainBody(queue) });
+  for (const [fn, state] of [
+    [f.fulfill, PROMISE_STATE_FULFILLED],
+    [f.reject, PROMISE_STATE_REJECTED],
+  ] as const)
+    tx.fillFunction(fn, {
+      locals: buildPromiseSettleLocals(t.callback.typeIndex),
+      body: buildPromiseSettleBody(
+        {
+          promiseTypeIdx: t.promise.typeIndex,
+          callbackTypeIdx: t.callback.typeIndex,
+          enqueueFuncIdx: f.enqueue.handle,
+          resolveHook: hook,
+          unhandledHeadGlobalIdx: unhandledHead,
+          unhandledNodeTypeIdx: unhandledNode,
+        },
+        state,
+      ),
+    });
+  for (const [fn, settle] of [
+    [f.identityFulfill, f.resolveValue],
+    [f.identityReject, f.reject],
+  ])
+    tx.fillFunction(fn!, {
+      locals: buildIdentityWrapperLocals(t.captures.typeIndex),
+      body: buildIdentityWrapperBody({
+        capsTypeIdx: t.captures.typeIndex,
+        settleFuncIdx: settle!.handle,
+        beforeHook: hook,
+        afterHook: hook,
+      }),
+    });
+  tx.fillFunction(f.resolveValue, { locals: buildPromiseResolveValueLocals(t.promise.typeIndex), body: resolution });
+  tx.fillFunction(
+    f.peel,
+    buildPromisePeelValue({ typeIdx: anyType, tagFieldIdx: av.tag, refFieldIdx: av.ref, externFieldIdx: av.extern }),
+  );
+  tx.fillFunction(f.classifier, classifier);
+  tx.fillFunction(f.thenableJob, job);
+  tx.fillFunction(f.resolveClosure, { locals: [], body: buildPromiseSettleClosureBody(cap, f.resolveValue.handle) });
+  tx.fillFunction(f.rejectClosure, { locals: [], body: buildPromiseSettleClosureBody(cap, f.reject.handle) });
+  for (const fn of [f.identityFulfill, f.identityReject, f.thenableJob, f.resolveClosure, f.rejectClosure])
+    tx.declareFunctionReference(fn);
+  owner.filled = true;
+}

--- a/src/ir/program-physical-plan.ts
+++ b/src/ir/program-physical-plan.ts
@@ -30,6 +30,11 @@ import {
 import type { ValType } from "./types.js";
 import { deriveNativeVectorResourcePlan, type NativeVectorResourcePlan } from "./program/native-vector-resources.js";
 import { assertPreparedIrProgram } from "./program-validation.js";
+import {
+  deriveNativePromiseResourcePlan,
+  type NativePromiseConfiguration,
+  type NativePromiseResourcePlan,
+} from "./program/native-promise-resources.js";
 
 /** Vector carriers stay logical until the consumer reserves their shared types. */
 export type PhysicalSignatureType = ValType | Extract<IrType, { kind: "vec" }>;
@@ -135,6 +140,45 @@ export function planNativeVectorResources(
     providers: projection.prepared.manifest.providers,
     backend: options.backend,
     target: options.target,
+  });
+}
+
+/** Authenticate the program and projection; runtime configuration remains an explicit caller choice. */
+export function planNativePromiseResources(
+  program: PreparedIrProgram,
+  options: PreparedIrBackendOptions,
+  projection: PreparedIrProgramRuntimeProjection,
+  configuration: NativePromiseConfiguration,
+): NativePromiseResourcePlan {
+  assertPreparedIrProgram(program);
+  if (
+    !program.runtime.includes(projection) ||
+    projection.backend !== options.backend ||
+    projection.target !== options.target
+  ) {
+    throw new PreparedIrProgramInvariantError(
+      "invalid-prepared-data",
+      "native Promise resources: selected projection does not belong to the requested program/backend/target",
+    );
+  }
+  const entry = program.inventory.sources.find((source) => source.kind === "entry");
+  if (!entry) {
+    throw new PreparedIrProgramInvariantError(
+      "invalid-prepared-data",
+      "native Promise resources: missing entry-source anchor",
+    );
+  }
+  return deriveNativePromiseResourcePlan({
+    anchor: entry.id,
+    functions: program.ir.functions,
+    selectedFunctions: projection.prepared.functions,
+    derivedUnits: program.derivedUnits,
+    abiEntries: program.abi.entries,
+    policy: projection.prepared.manifest.policy,
+    providers: projection.prepared.manifest.providers,
+    backend: options.backend,
+    target: options.target,
+    configuration,
   });
 }
 

--- a/src/ir/program/native-promise-resources.ts
+++ b/src/ir/program/native-promise-resources.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrFunction } from "../core/nodes.js";
+import { forEachInstrDeep } from "../core/nodes.js";
+import { irCallableBindingKey } from "../core/callable-bindings.js";
+import type { IrUnitId } from "../../shared/contracts/ir-identity.js";
+import type { RuntimeManifestPolicy } from "../../runtime/contracts/provider-policy.js";
+import type { RuntimeProviderDefinition } from "../runtime/contracts/manifest.js";
+import { ASYNC_RUNTIME_PROVIDERS } from "../runtime/async-providers.js";
+import { assertPreparedIrAsyncRuntimeCurrent } from "../runtime/async-attachment.js";
+import type { PreparedIrAbiEntry } from "./prepared-contracts.js";
+import type { PreparedIrFunction } from "../runtime/contracts/prepared.js";
+import type { ProgramAbiDerivedUnitRecord } from "./abi.js";
+import { freezePreparedIrValue, preparedIrDataMismatch } from "./data.js";
+import { PreparedIrProgramInvariantError } from "./errors.js";
+
+export interface NativePromiseOwner {
+  readonly unitId: IrUnitId;
+  readonly calls: readonly { readonly region: string; readonly ordinal: number; readonly bindingKey: string }[];
+}
+export interface NativePromiseConfiguration {
+  readonly hooks: "disabled" | "dispatch";
+  readonly unhandledRejections: "disabled" | "track";
+}
+export interface NativePromiseResourceInput {
+  readonly anchor: string;
+  readonly functions: readonly IrFunction[];
+  readonly selectedFunctions: readonly PreparedIrFunction[];
+  readonly derivedUnits: readonly ProgramAbiDerivedUnitRecord[];
+  readonly abiEntries: readonly PreparedIrAbiEntry[];
+  readonly policy: RuntimeManifestPolicy;
+  readonly providers: readonly RuntimeProviderDefinition[];
+  readonly backend: RuntimeManifestPolicy["backend"];
+  readonly target: RuntimeManifestPolicy["target"];
+  /** Supplied from selected runtime configuration, never inferred from missing bindings. */
+  readonly configuration: NativePromiseConfiguration;
+}
+export interface NativePromiseResourcePlan {
+  readonly anchor: string;
+  readonly owners: readonly NativePromiseOwner[];
+  readonly selectedOwners: readonly NativePromiseOwner[];
+  readonly derivedUnits: readonly ProgramAbiDerivedUnitRecord[];
+  readonly required: boolean;
+  readonly configuration: NativePromiseConfiguration;
+  readonly providers: readonly RuntimeProviderDefinition[];
+  readonly callableBindings: readonly PreparedIrAbiEntry[];
+  readonly dependencies: readonly string[];
+}
+export const NATIVE_PROMISE_DEPENDENCIES = Object.freeze([
+  "shared-externref-vector-array",
+  "exception-tag",
+  "number-box",
+  "number-unbox",
+  "number-classification",
+  "canonical-tag-1-undefined",
+  "type-error-constructor",
+  "self-resolution-string",
+  "then-string",
+  "argument-vector-new",
+  "argument-vector-push",
+  "apply-closure",
+  "then-vararg-dispatch",
+  "settle-closure-root",
+  "settle-closure-metadata",
+  "finalized-object-closure-inventory",
+] as const);
+
+function fail(message: string): never {
+  throw new PreparedIrProgramInvariantError("invalid-prepared-data", `native Promise resources: ${message}`);
+}
+
+/** Derives requirements only. Whole-program/current-attachment authentication belongs to the checked parent wrapper. */
+export function deriveNativePromiseResourcePlan(input: NativePromiseResourceInput): NativePromiseResourcePlan {
+  if (!input.anchor) fail("missing source anchor");
+  if (
+    !input.configuration ||
+    !["disabled", "dispatch"].includes(input.configuration.hooks) ||
+    !["disabled", "track"].includes(input.configuration.unhandledRejections)
+  )
+    fail("missing explicit runtime configuration");
+  const census = (functions: readonly PreparedIrFunction[], selected: boolean): NativePromiseOwner[] => {
+    const seen = new Set<IrUnitId>();
+    return functions.map((fn): NativePromiseOwner => {
+      if (seen.has(fn.unitId)) fail("duplicate owner");
+      seen.add(fn.unitId);
+      const calls: NativePromiseOwner["calls"][number][] = [];
+      const buffers = [
+        ...fn.blocks.map((block, i) => ({ region: `block:${i}`, body: block.instrs })),
+        ...((selected ? fn.asyncRuntime?.states : fn.asyncPlan?.states)?.map((state) => ({
+          region: `state:${state.id}`,
+          body: state.body,
+        })) ?? []),
+      ];
+      for (const { region, body } of buffers) {
+        let ordinal = 0;
+        for (const root of body)
+          forEachInstrDeep(root, (instr) => {
+            const position = ordinal++;
+            if (instr.kind === "call")
+              calls.push({ region, ordinal: position, bindingKey: irCallableBindingKey(instr.target.binding) });
+          });
+      }
+      return { unitId: fn.unitId, calls };
+    });
+  };
+  if (!Array.isArray(input.selectedFunctions) || !Array.isArray(input.derivedUnits))
+    fail("missing selected/derived population");
+  const owners = census(input.functions, false),
+    selectedOwners = census(input.selectedFunctions, true);
+  if (
+    preparedIrDataMismatch(
+      owners.map((owner) => owner.unitId),
+      selectedOwners.map((owner) => owner.unitId),
+    ) !== undefined
+  )
+    fail("selected owner population/order differs");
+  for (const [index, fn] of input.functions.entries()) {
+    const selected = input.selectedFunctions[index]!;
+    if (fn.asyncPlan) {
+      // Projection preparation recreates the semantic plan. Compare those two
+      // values, but authenticate identity against the selected owner's own plan.
+      if (!selected.asyncPlan || preparedIrDataMismatch(selected.asyncPlan, fn.asyncPlan) !== undefined)
+        fail("selected semantic async plan differs");
+      const current = assertPreparedIrAsyncRuntimeCurrent(
+        selected.unitId,
+        selected.name,
+        selected.asyncPlan,
+        selected.asyncRuntime,
+      );
+      if (current.kind !== "standalone-native-wasmgc") fail("selected async attachment is not native");
+    } else if (selected.asyncPlan || selected.asyncRuntime) {
+      fail("selected async attachment has no semantic owner");
+    }
+  }
+  const derived = new Set<IrUnitId>();
+  for (const unit of input.derivedUnits) {
+    if (derived.has(unit.id) || !owners.some((owner) => owner.unitId === unit.id))
+      fail("derived owner is duplicate or absent");
+    derived.add(unit.id);
+  }
+  const required =
+    input.functions.some((fn) => fn.asyncPlan !== undefined) ||
+    input.providers.some(
+      (provider) => provider.feature.startsWith("promise.") || provider.feature.startsWith("scheduler."),
+    );
+  const providers: RuntimeProviderDefinition[] = [];
+  if (required) {
+    if (
+      input.backend !== "wasmgc" ||
+      input.target !== "standalone" ||
+      input.policy.backend !== "wasmgc" ||
+      input.policy.target !== "standalone"
+    )
+      fail("Promise pack requires selected standalone WasmGC policy");
+    const demanded = new Set<string>([
+      "promise.resolve",
+      "promise.settle.fulfill",
+      "promise.settle.reject",
+      "scheduler.enqueue",
+      "scheduler.drain",
+    ]);
+    for (const fn of input.functions) for (const feature of fn.asyncPlan?.runtimeIntents ?? []) demanded.add(feature);
+    for (const provider of input.providers) {
+      demanded.add(provider.feature);
+      for (const feature of provider.dependencies) demanded.add(feature);
+    }
+    for (const canonical of ASYNC_RUNTIME_PROVIDERS.filter(
+      (provider) => provider.id.startsWith("native.") && demanded.has(provider.feature),
+    )) {
+      const feature = canonical.feature;
+      const rows = input.providers.filter((provider) => provider.feature === feature || provider.id === canonical.id);
+      if (rows.length !== 1 || preparedIrDataMismatch(rows[0], canonical) !== undefined)
+        fail(`noncanonical ${feature} provider`);
+      providers.push(rows[0]!);
+    }
+  }
+  const keys = new Set(owners.flatMap((owner) => owner.calls.map((call) => call.bindingKey)));
+  const callableBindings = input.abiEntries.filter(
+    (entry) => entry.contract.kind === "callable" && keys.has(irCallableBindingKey(entry.contract.ref.binding)),
+  );
+  return freezePreparedIrValue({
+    anchor: input.anchor,
+    owners,
+    selectedOwners,
+    derivedUnits: input.derivedUnits,
+    required,
+    configuration: input.configuration,
+    providers,
+    callableBindings,
+    dependencies: required ? NATIVE_PROMISE_DEPENDENCIES : [],
+  }) as NativePromiseResourcePlan;
+}

--- a/tests/issue-3518-native-promise-resources.test.ts
+++ b/tests/issue-3518-native-promise-resources.test.ts
@@ -1,0 +1,354 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { createEmptyModule } from "../src/ir/types.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import { prepareIrProgramSources, captureTypedIrProgramInput } from "../src/ir/program-source.js";
+import { prepareTypedIrProgram } from "../src/ir/program-prepare-ir.js";
+import { sourceInput, typedOptions, requireProgram } from "./helpers/typed-program-fixtures.js";
+import { encodeTypedPacket, decodeTypedPacket } from "./helpers/typed-program-transport.mjs";
+import { deriveNativePromiseResourcePlan } from "../src/ir/program/native-promise-resources.js";
+import { planNativePromiseResources } from "../src/ir/program-physical-plan.js";
+import { deriveNativeVectorResourcePlan } from "../src/ir/program/native-vector-resources.js";
+import { reserveNativeVectorTypes } from "../src/backend/wasmgc/resources/native-vectors.js";
+import {
+  reserveNativePromiseResources,
+  fillNativePromiseResources,
+  type NativePromiseFillDependencies,
+} from "../src/backend/wasmgc/resources/native-promises.js";
+
+const policy = {
+  backend: "wasmgc",
+  target: "standalone",
+  stringConst: { storage: "native" },
+  stringConcat: { concat: "native" },
+} as const;
+const configuration = { hooks: "disabled", unhandledRejections: "disabled" } as const;
+const backendOptions = {
+  backend: "wasmgc",
+  target: "standalone",
+  sharedExceptionTag: false,
+  utf8Storage: false,
+  sourceMap: false,
+  moduleName: "native-promise-resources",
+} as const;
+function prepare(gvnMode: "off" | "on" = "off", replay = false) {
+  const text = readFileSync(new URL("../website/playground/examples/js/async.ts", import.meta.url), "utf8");
+  const source = prepareIrProgramSources({
+    ...sourceInput({ "./entry.ts": text }),
+    policy,
+    promiseDelayProjection: "standalone-native",
+    asyncFamilyProjection: "standalone-native",
+  });
+  if (source.kind !== "prepared") throw new Error(source.detail);
+  const packet = captureTypedIrProgramInput(source);
+  const input = replay ? decodeTypedPacket(encodeTypedPacket(packet)) : packet;
+  const program = requireProgram(
+    prepareTypedIrProgram(input, {
+      ...typedOptions,
+      policy,
+      runtimePolicies: [policy],
+      controls: { ...typedOptions.controls, gvnMode },
+    }),
+  );
+  const requirements = {
+    anchor: program.inventory.sources.find((row) => row.kind === "entry")!.id,
+    functions: program.ir.functions,
+    selectedFunctions: program.runtime[0]!.prepared.functions,
+    derivedUnits: program.derivedUnits,
+    abiEntries: program.abi.entries,
+    policy,
+    providers: program.runtime[0]!.prepared.manifest.providers,
+    backend: policy.backend,
+    target: policy.target,
+  };
+  return {
+    program,
+    requirements,
+    plan: planNativePromiseResources(program, backendOptions, program.runtime[0]!, configuration),
+    vectorPlan: deriveNativeVectorResourcePlan(requirements),
+  };
+}
+let cached: ReturnType<typeof prepare> | undefined;
+const actual = () => (cached ??= prepare());
+
+/** Type-only kernel harness. No fabricated native value/classifier/function dependency. */
+function reserve() {
+  const { plan, vectorPlan } = actual();
+  const module = createEmptyModule(),
+    tx = new PhysicalModuleReservations(module);
+  const tag = tx.reserveTag(
+    "tag",
+    { params: [{ kind: "externref" }], results: [] },
+    { kind: "defined", name: "__exn" },
+  );
+  const vectors = reserveNativeVectorTypes(tx, vectorPlan);
+  const fields = [
+    { name: "func", type: { kind: "funcref" } as const, mutable: false },
+    { name: "$arity", type: { kind: "i32" } as const, mutable: false },
+    { name: "$bag", type: { kind: "externref" } as const, mutable: true },
+  ];
+  const closureRoot = tx.reserveType("kernel:closure-root", {
+    kind: "struct",
+    name: "kernel-root",
+    superTypeIdx: -1,
+    fields,
+  });
+  const settleMetadata = tx.reserveType("kernel:metadata", {
+    kind: "struct",
+    name: "kernel-metadata",
+    superTypeIdx: closureRoot.typeIndex,
+    fields: [
+      ...fields,
+      { name: "bfnstate", type: { kind: "i32" }, mutable: true },
+      { name: "bfnid", type: { kind: "i32" }, mutable: false },
+    ],
+  });
+  const dependencies = { vectors, exceptionTag: tag, closureRoot, settleMetadata };
+  const pack = reserveNativePromiseResources(tx, plan, dependencies);
+  return { module, tx, pack, dependencies, plan };
+}
+
+describe("native Promise resource requirements, not whole-family materialization", () => {
+  it("rejects an unsealed program after accepting the genuine complete program", () => {
+    const { program, plan } = actual();
+    const projection = program.runtime[0]!;
+    expect(planNativePromiseResources(program, backendOptions, projection, configuration)).toEqual(plan);
+    const unsealed = { ...program, sealed: false } as unknown as typeof program;
+    expect(() => planNativePromiseResources(unsealed, backendOptions, projection, configuration)).toThrow(
+      "program is not a complete prepared program",
+    );
+  });
+  it("rejects a detached projection after accepting its owning program", () => {
+    const { program, plan } = actual();
+    const projection = program.runtime[0]!;
+    expect(planNativePromiseResources(program, backendOptions, projection, configuration)).toEqual(plan);
+    expect(() => planNativePromiseResources(program, backendOptions, { ...projection }, configuration)).toThrow(
+      "selected projection does not belong",
+    );
+  });
+  it("rejects a mismatched backend after an accepted positive", () => {
+    const { program, plan } = actual();
+    const projection = program.runtime[0]!;
+    expect(planNativePromiseResources(program, backendOptions, projection, configuration)).toEqual(plan);
+    expect(() =>
+      planNativePromiseResources(program, { ...backendOptions, backend: "linear" }, projection, configuration),
+    ).toThrow("selected projection does not belong");
+  });
+  for (const mode of ["off", "on"] as const)
+    for (const replay of [false, true])
+      it(`retains all 16 owners and 33 calls, GVN=${mode}, decoded=${replay}`, () => {
+        const { plan, program } = prepare(mode, replay);
+        expect(plan.owners).toHaveLength(16);
+        expect(plan.owners.flatMap((owner) => owner.calls)).toHaveLength(33);
+        expect(plan.owners.map((owner) => owner.unitId)).toEqual(program.ir.functions.map((fn) => fn.unitId));
+        expect(plan.dependencies).toContain("finalized-object-closure-inventory");
+        expect(plan.dependencies).toContain("canonical-tag-1-undefined");
+        expect(plan.dependencies).toContain("type-error-constructor");
+        expect(plan.configuration).toEqual(configuration);
+        for (const feature of [
+          "promise.capability.create",
+          "promise.react",
+          "value.undefined",
+          "promise.number.bridge",
+        ])
+          expect(plan.providers.some((provider) => provider.feature === feature)).toBe(true);
+        expect(plan.selectedOwners.map((owner) => owner.unitId)).toEqual(plan.owners.map((owner) => owner.unitId));
+        expect(plan.derivedUnits).toEqual(program.derivedUnits);
+        expect(Object.isFrozen(plan)).toBe(true);
+        expect(program.allocations.size).toBeGreaterThan(0);
+      });
+  it("rejects missing explicit configuration", () => {
+    const { requirements } = actual();
+    expect(() => deriveNativePromiseResourcePlan({ ...requirements, configuration: undefined! })).toThrow(
+      "explicit runtime configuration",
+    );
+  });
+  it("accepts the recreated selected plan but rejects a detached attachment plan", () => {
+    const { requirements, plan } = actual();
+    expect(deriveNativePromiseResourcePlan({ ...requirements, configuration })).toEqual(plan);
+    const index = requirements.functions.findIndex((fn) => fn.asyncPlan !== undefined);
+    expect(index).toBeGreaterThanOrEqual(0);
+    const semantic = requirements.functions[index]!,
+      selected = requirements.selectedFunctions[index]!;
+    expect(selected.asyncPlan).not.toBe(semantic.asyncPlan);
+    expect(selected.asyncPlan).toEqual(semantic.asyncPlan);
+    expect(selected.asyncRuntime!.plan).toBe(selected.asyncPlan);
+    const selectedFunctions = requirements.selectedFunctions.map((fn, i) =>
+      i === index ? { ...fn, asyncRuntime: { ...fn.asyncRuntime!, plan: semantic.asyncPlan! } } : fn,
+    );
+    expect(() => deriveNativePromiseResourcePlan({ ...requirements, selectedFunctions, configuration })).toThrow(
+      "does not retain its exact semantic plan owner",
+    );
+  });
+  for (const mutation of [
+    "wrong-semantic-plan",
+    "missing-selected-plan",
+    "foreign-attachment",
+    "attachment-without-owner",
+  ] as const)
+    it(`rejects ${mutation} after genuine selected-attachment positive`, () => {
+      const { requirements, plan } = actual();
+      expect(deriveNativePromiseResourcePlan({ ...requirements, configuration })).toEqual(plan);
+      const index = requirements.functions.findIndex((fn) => fn.asyncPlan !== undefined);
+      const other = requirements.selectedFunctions.find((fn, i) => i !== index && fn.asyncRuntime !== undefined)!;
+      expect(index).toBeGreaterThanOrEqual(0);
+      expect(other.asyncRuntime).toBeDefined();
+      const functions = requirements.functions.map((fn, i) => {
+        if (i !== index) return fn;
+        const semanticPlan = fn.asyncPlan!;
+        if (mutation === "wrong-semantic-plan")
+          return { ...fn, asyncPlan: { ...semanticPlan, entry: 999 as typeof semanticPlan.entry } };
+        if (mutation === "attachment-without-owner") return { ...fn, asyncPlan: undefined };
+        return fn;
+      });
+      const selectedFunctions = requirements.selectedFunctions.map((fn, i) => {
+        if (i !== index) return fn;
+        if (mutation === "missing-selected-plan") return { ...fn, asyncPlan: undefined };
+        if (mutation === "foreign-attachment") return { ...fn, asyncRuntime: other.asyncRuntime };
+        return fn;
+      });
+      const error =
+        mutation === "foreign-attachment"
+          ? "does not retain its exact semantic plan owner"
+          : mutation === "attachment-without-owner"
+            ? "selected async attachment has no semantic owner"
+            : "selected semantic async plan differs";
+      expect(() =>
+        deriveNativePromiseResourcePlan({ ...requirements, functions, selectedFunctions, configuration }),
+      ).toThrow(error);
+    });
+  for (const mutation of ["missing", "duplicate", "foreign"] as const)
+    it(`rejects ${mutation} native resolve provider after positive control`, () => {
+      const { requirements, plan } = actual();
+      expect(deriveNativePromiseResourcePlan({ ...requirements, configuration })).toEqual(plan);
+      const row = requirements.providers.find((provider) => provider.feature === "promise.resolve")!;
+      const others = requirements.providers.filter((provider) => provider !== row);
+      const providers =
+        mutation === "missing"
+          ? others
+          : mutation === "duplicate"
+            ? [...requirements.providers, row]
+            : [...others, { ...row, id: "foreign.resolve" }];
+      expect(() => deriveNativePromiseResourcePlan({ ...requirements, providers, configuration })).toThrow(
+        "noncanonical promise.resolve provider",
+      );
+    });
+});
+
+describe("reservation-only Promise pack controls; missing native dependencies remain a gap", () => {
+  it("reuses the exact vector array and preserves queue order and lazy storage obligations", () => {
+    const { module, pack, dependencies, tx } = reserve();
+    expect(pack.types.arguments).toBe(dependencies.vectors.layouts.find((row) => row.element === "externref")!.array);
+    expect(module.types.filter((type) => type.kind === "array" && type.name === "__arr_externref")).toHaveLength(1);
+    expect(module.globals.map((global) => global.name)).toEqual([
+      "__mt_head",
+      "__mt_tail",
+      "__mt_cap",
+      "__mt_funcs",
+      "__mt_caps",
+      "__mt_args",
+    ]);
+    expect(module.functions.slice(0, 8).map((fn) => fn.name)).toEqual([
+      "__microtask_grow",
+      "__microtask_enqueue",
+      "__drain_microtasks",
+      "__promise_fulfill",
+      "__promise_reject",
+      "__then_identity_fulfill",
+      "__then_identity_reject",
+      "__promise_resolve_value",
+    ]);
+    expect(new Set(Object.values(pack.functions).map((fn) => fn.object)).size).toBe(13);
+    expect(tx.state).toBe("reserving");
+    tx.freezeReservations();
+    expect(() => tx.seal()).toThrow("missing global fill");
+  });
+  it("preserves Promise, callback and continuation field order/mutability", () => {
+    const { pack } = reserve();
+    expect(pack.types.promise.object).toMatchObject({
+      fields: [
+        { name: "state", mutable: true },
+        { name: "value", mutable: true },
+        { name: "callbacks", mutable: true },
+        { name: "$bag", mutable: true },
+      ],
+    });
+    expect(pack.types.callback.object).toMatchObject({
+      fields: [
+        { name: "onFulfilledFn", mutable: false },
+        { name: "onFulfilledCaps", mutable: false },
+        { name: "onRejectedFn", mutable: false },
+        { name: "onRejectedCaps", mutable: false },
+        { name: "next", mutable: false },
+      ],
+    });
+    expect(pack.types.captures.object).toMatchObject({
+      fields: [
+        { name: "callback", mutable: false },
+        { name: "chained", mutable: false },
+      ],
+    });
+    expect(pack.types.settleCapture.object).toMatchObject({
+      fields: [
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        { name: "cap_promise", mutable: false },
+      ],
+    });
+  });
+  it("does not complete missing resolution/value/classifier bindings", () => {
+    const { tx, pack, module } = reserve();
+    tx.freezeReservations();
+    expect(() => fillNativePromiseResources(tx, pack, undefined!)).toThrow("complete native dependencies are missing");
+    expect(module.functions.every((fn) => fn.body.length === 0)).toBe(true);
+    expect(() => tx.seal()).toThrow("missing global fill");
+  });
+  it("rejects wrapper substitution and another ledger", () => {
+    const a = reserve(),
+      b = reserve();
+    expect(() => fillNativePromiseResources(a.tx, { ...a.pack }, undefined!)).toThrow("foreign Promise pack");
+    expect(() => fillNativePromiseResources(b.tx, a.pack, undefined!)).toThrow("foreign Promise pack");
+  });
+  it("rejects changed complete-owner census before using builder flags", () => {
+    const { tx, pack } = reserve();
+    const missing = {
+      inventory: { owners: [] },
+      values: {},
+      resolution: {},
+    } as unknown as NativePromiseFillDependencies;
+    expect(() => fillNativePromiseResources(tx, pack, missing)).toThrow("classification owner population differs");
+  });
+  it("rejects empty/null classifier flags as materialization evidence", () => {
+    const { tx, pack, plan } = reserve();
+    const absent = {
+      inventory: {
+        owners: plan.owners,
+        selectedOwners: plan.selectedOwners,
+        derivedUnits: plan.derivedUnits,
+        finalized: true,
+        carriers: [],
+        anyValue: null,
+        openObject: null,
+      },
+      values: {},
+      resolution: {},
+    } as unknown as NativePromiseFillDependencies;
+    expect(() => fillNativePromiseResources(tx, pack, absent)).toThrow(
+      "complete native classification materialization is missing",
+    );
+  });
+  it("rejects duplicate pack reservation", () => {
+    const { tx, plan, dependencies } = reserve();
+    expect(() => reserveNativePromiseResources(tx, plan, dependencies)).toThrow("duplicate resource key");
+  });
+  it("rejects late reservation", () => {
+    const { tx, plan, dependencies } = reserve();
+    tx.freezeReservations();
+    expect(() => reserveNativePromiseResources(tx, plan, dependencies)).toThrow("requires reserving");
+  });
+});

--- a/tests/issue-3518-semantic-provider-boundary.test.ts
+++ b/tests/issue-3518-semantic-provider-boundary.test.ts
@@ -105,9 +105,18 @@ const resolutionAdditions = [
   "src/runtime/wasmgc/promise/resolution-bodies.ts",
   "src/runtime/wasmgc/promise/thenable-bodies.ts",
 ];
-const groups = {
+const resolutionGroups = {
   ...vectorGroups,
   "native-runtime": [...vectorGroups["native-runtime"], ...resolutionAdditions],
+};
+const promiseResourceAdditions = [
+  "src/ir/program/native-promise-resources.ts",
+  "src/backend/wasmgc/resources/native-promises.ts",
+];
+const groups = {
+  ...resolutionGroups,
+  "ir-program": [...resolutionGroups["ir-program"], promiseResourceAdditions[0]!],
+  "backend-wasmgc": [...resolutionGroups["backend-wasmgc"], promiseResourceAdditions[1]!],
 };
 const required = Object.values(groups).flat();
 const callableAdditions = ["src/ir/core/async-callables.ts", "src/ir/runtime/native-async-callables.ts"];
@@ -145,6 +154,14 @@ const additions = [
 const policy = () => JSON.parse(readFileSync(resolve(repository, "scripts/compiler-boundaries.json"), "utf8"));
 const digest = (value: unknown) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
 function assertNewActivations(history: unknown[]) {
+  expect(history.slice(0, 2)).toEqual(
+    (["ir-program", "backend-wasmgc"] as const).map((layer) => ({
+      layer,
+      entries: groups[layer],
+      minModules: groups[layer].length,
+    })),
+  );
+  history = history.slice(2);
   expect(history[0]).toEqual({
     layer: "native-runtime",
     entries: groups["native-runtime"],
@@ -294,9 +311,9 @@ function fixture() {
 }
 
 describe("semantic verification and provider ownership boundary", () => {
-  it("pins the original 70 modules plus three vector and two Promise owners without relaxing historical policy", () => {
-    expect(required).toHaveLength(75);
-    expect(new Set(required).size).toBe(75);
+  it("pins the original 70 modules plus three vector, two Promise body and two resource owners without relaxing historical policy", () => {
+    expect(required).toHaveLength(77);
+    expect(new Set(required).size).toBe(77);
     expect(callableAdditions).toHaveLength(2);
     expect(vectorAdditions).toHaveLength(2);
     expect(typeLayoutAdditions).toHaveLength(1);
@@ -317,6 +334,7 @@ describe("semantic verification and provider ownership boundary", () => {
             ...vectorAdditions,
             ...physicalVectorAdditions,
             ...resolutionAdditions,
+            ...promiseResourceAdditions,
           ].includes(path),
       ),
     ).toHaveLength(56);
@@ -333,17 +351,18 @@ describe("semantic verification and provider ownership boundary", () => {
       ...vectorAdditions,
       ...physicalVectorAdditions,
       ...resolutionAdditions,
+      ...promiseResourceAdditions,
     ])
       expect(required).toContain(path);
     const p = policy();
     assertNewActivations(p.activationHistory);
-    expect(p.activationHistory).toHaveLength(36);
-    expect(digest(p.activationHistory.slice(12))).toBe(
+    expect(p.activationHistory).toHaveLength(38);
+    expect(digest(p.activationHistory.slice(14))).toBe(
       "3437a59aacf39df9dffcafa8099ac9f47c0f43a7a0ecc423df4c1fe3e638f002",
     );
     expect(digest(p.allowedEdges)).toBe("efe7e7ed8dee1a009d2bef3ff36dba80df1a805cd3f5b7b472e62ec6dcff64c7");
     // Exact full activation history at b4c116639a, not a selected subset.
-    expect(digest(p.activationHistory.slice(18))).toBe(
+    expect(digest(p.activationHistory.slice(20))).toBe(
       "a6d07b900b0837832707ce083202ab6ffa40f0bbe6bfce25f3062270882b26da",
     );
     for (const [id, entries] of Object.entries(groups)) {
@@ -360,12 +379,12 @@ describe("semantic verification and provider ownership boundary", () => {
   it("loads the complete actual canonical type-and-value closure", () => {
     const r = fixture().run();
     expect(r.status, JSON.stringify(r.report.errors)).toBe(0);
-    expect(r.report.counts.total).toBe(75);
+    expect(r.report.counts.total).toBe(77);
     expect(r.report.errors).toEqual([]);
     for (const field of ["unknownEdges", "unresolvedEdges", "forbiddenEdges", "transitiveViolations"])
       expect(r.report[field]).toEqual([]);
-    expect(r.report.resolvedEdgeCount).toBe(263);
-    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 176, runtime: 87 });
+    expect(r.report.resolvedEdgeCount).toBe(286);
+    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 187, runtime: 99 });
   });
 
   it.each(["delete", "reorder", "layer", "entries", "minimum"] as const)(
@@ -395,6 +414,7 @@ describe("semantic verification and provider ownership boundary", () => {
     ...vectorAdditions,
     ...physicalVectorAdditions,
     ...resolutionAdditions,
+    ...promiseResourceAdditions,
   ])("rejects deleting %s and its classification", (path) => {
     const f = fixture();
     rmSync(resolve(f.root, path));
@@ -417,6 +437,7 @@ describe("semantic verification and provider ownership boundary", () => {
     ...vectorAdditions,
     ...physicalVectorAdditions,
     ...resolutionAdditions,
+    ...promiseResourceAdditions,
   ])("rejects an aliased frontend type dependency from %s", (path) => {
     const f = fixture();
     f.put("src/forbidden.ts", "export interface Hidden { value: number }");
@@ -444,6 +465,7 @@ describe("semantic verification and provider ownership boundary", () => {
       ...vectorAdditions,
       ...physicalVectorAdditions,
       ...resolutionAdditions,
+      ...promiseResourceAdditions,
     ])(`reports ${field} from %s instead of treating it as closed`, (path) => {
       const f = fixture();
       f.append(path, source);


### PR DESCRIPTION
## Summary

- Derive native Promise requirements from the checked prepared program and
  selected projection, retaining complete semantic/selected owner inventories.
- Reserve Promise and scheduler resources in the existing physical ledger;
  require real dependencies for filling rather than fabricated bindings.
- Activate two boundary modules while preserving prior policy and history.
- Retain the public extraction comparison and independently failing ordinary
  getter-capture observation, plus the High-reviewed separate repair plan.

Stacked on #5765. Refs #3518; does not close the migration issue.

## Validation

- 192/192 boundary/resource controls passed; after adding the High-requested
  unsealed-program control, all24/24 resource tests passed in13.76s.
- Composed TS7, scoped formatting/lint, function and file budgets passed.
- Normal commit hooks passed; changed-root test hook explicitly skipped its
  64-file population (>20), so that hook is not claimed as a test pass.
- Public extraction comparison:24/24 pairs preserved; semantic acceptance
  failed on both arms for the existing ordinary getter-capture defect.

## Limits

Requirements/reservation checkpoint only, not full native Promise filling or
execution. Actual value/object/string/TypeError/closure resources remain needed.
The async consumer refusal, strict compiler-closure and direct retirement
gates remain. Existing merge holds remain; no auto-merge or bypass requested.
Stacked-base checks do not establish main-based required CI readiness.
