### PR TITLE
feat(standalone): a provider-minted object is readable across the host-free linked boundary — pure-wasm link facade (#5383 S2d)

### DIFF
--- a/plan/issues/5383-standalone-temporal-provider.md
+++ b/plan/issues/5383-standalone-temporal-provider.md
@@ -11,6 +11,20 @@ reasoning_effort: high
 requested_by: ttraenkler/fable-lead
 created: 2026-09-07
 loc-budget-allow:
+  # 2026-09-08 (S2d) — the standalone cross-module OBJECT boundary. The whole
+  # mechanism lives in the new module src/codegen/standalone-link-boundary.ts;
+  # what lands in object-runtime.ts is the two places the mechanism has to be
+  # WIRED, and both are wired next to their JS-host twin on purpose:
+  #   object-runtime.ts  +24  the peer-terminal registration (beside the
+  #                           `__boundary_object_*` late imports, which must all
+  #                           exist before the #1984 index-space freeze), the
+  #                           `??`-fallback on the two arms that already ask
+  #                           "this carrier is not mine, who can decode it?",
+  #                           and the one call that emits the provider-side
+  #                           terminals. Moving any of it away from the arm it
+  #                           guards would hide the ordering constraint its
+  #                           comment exists to document.
+  - src/codegen/object-runtime.ts
   # 2026-09-08 (S2b) — the externref-backed-subclass family fix (own-field
   # write/read + dynamic method dispatch on `class B extends Array`). Every
   # entry is a net-new guarded arm plus the measurement that justifies it; the
@@ -55,6 +69,11 @@ loc-budget-allow:
     lines: 20
     reason: "#5383 S2 R4 — pre-register the `Math.<fn>` value-read substrate before the closure is built (#2704 forbids a first registration mid-body), which is why every Math value read kept the refusal body."
 func-budget-allow:
+  # 2026-09-08 (S2d) — same wiring, same argument: `ensureObjectRuntime` is
+  # where every dynamic terminal is registered and where the late-import freeze
+  # point is, so the peer registration and the terminal emission cannot move out
+  # of it without moving away from the constraint they depend on.
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
   # 2026-09-08 (S2b) — both grants are a guarded ARM added to an existing
   # dispatch cascade, in the one place the cascade's order is load-bearing: the
   # write redirect must sit between the externref-backed check and the struct
@@ -645,3 +664,115 @@ its `--target standalone` text, a prototype-method refusal, the `gc` cache key
 recomputed from the raw bundle (the host-lane no-change guard), standalone/wasi
 keys distinct from `gc`, and the shim's own shape (one `const Intl`, prefixed
 binding).
+
+## S2d findings (2026-09-08) — the getter boundary, root-caused and fixed; the stop moves INSIDE the provider
+
+The S2 smoke test is still **not** written, and the reason moved again. What is
+fixed: the cross-module object boundary, end to end, on a reduction. What now
+stops Temporal is a provider-INTERNAL read, measured from both sides.
+
+### R9 — why a provider-minted object arrived empty (two causes, not one)
+
+**Cause 1 — the linker handed the consumer a JS host MIRROR.**
+`instantiateLinkedProviders` wrapped every non-function boundary value in
+`wrapLinkedProviderValue` → `_wrapForHost`, unconditionally. That mirror is
+bound to the provider's `__struct_field_names` / `__sget_*` exports, which a
+standalone binary does not have (#4035 strips the host bridge), and it is handed
+to a consumer that is **wasm** and cannot read a JS proxy at all. Fixed by
+skipping the mirror when the provider's own `targetProfile.environment` is not
+`"javascript"` — the raw struct now crosses.
+
+**Cause 2 — nothing on a standalone value says what it is.** With the raw struct
+crossing, every read still answered `undefined`: standalone has no
+self-describing property bag. `__extern_get` / `__object_keys` are module-local
+`ref.test` ladders over the struct types THAT module declared (filled at
+finalize), so a provider-minted struct misses every arm. The JS lane hides this
+because #5225's `_crossModuleStructs` registry re-points a read at the module
+that can decode it; there is no standalone twin.
+
+Fixed by building that twin in pure wasm (`src/codegen/standalone-link-boundary.ts`):
+a standalone provider whose consumer is wasm (`exportsConsumedByWasm`) publishes
+`__js2wasm_link_member_get` / `__js2wasm_link_object_keys` / `__js2wasm_link_apply`,
+and the consumer calls them on the arms where its own ladder has ALREADY missed
+— the same two arms the host lane's `__boundary_object_get` /
+`__boundary_object_keys` occupy, so neither lane grows an arm and the
+single-module lane is untouched.
+
+The two published reads are **wrappers, not re-exports**: each normalises "I do
+not know this value" to `ref.null.extern`. Without that the consumer would have
+to trust another module's `undefined` singleton, and the peer's empty key-vec
+would out-rank the consumer's own carrier bags. Both normalisations are
+answer-preserving (a genuinely-`undefined` property and a genuinely-empty object
+fall back to the consumer's local miss, which answers the same).
+
+**Measured** (`.tmp/s2d/probe3`, host-free `instantiateLinkedProject(result, {})`,
+three carrier shapes — object literal, assigned own props, `defineProperty`):
+
+| probe | base | after |
+| --- | --- | --- |
+| `Object.keys(NS).length` | 0 | **3** |
+| `NS.a` | `undefined` | **1** |
+| `NS.zzz === undefined` | true | true |
+| gc control | 3 / 1 | unchanged |
+
+Four cases in `tests/issue-5383-standalone-temporal-provider.test.ts`.
+
+Two things the facade does NOT yet cover, both measured: **calling a
+provider-minted closure** (`keysOf(NS)` → `null`) and `hasOwnProperty` / `in` /
+`for-in` for the non-`defineProperty` carriers — those terminals have their own
+miss arms and were left for a follow-up rather than guessed at.
+
+### Where it stops NOW — inside the provider, not at the boundary
+
+Through the real provider the consumer still reads nothing, and the reason is no
+longer the boundary. Measured with the terminals called directly from JS on the
+EXACT value the consumer holds (identity checked, `.tmp/s2d/temporal-probe`):
+
+- `__js2wasm_link_object_keys(Temporal)` → **non-null** (the provider enumerates
+  its own namespace fine — 9 keys);
+- `__js2wasm_link_member_get(Temporal, <consumer-minted "PlainDate">)` → **null**,
+  and with the normalisation disabled it is the provider's own `undefined`
+  singleton (the consumer agrees — `x === undefined` answers true for it, so the
+  singleton itself crosses correctly).
+
+So the provider's own `__extern_get` answers `undefined` for `qi.PlainDate`
+while its own `__object_keys` lists all nine. That asymmetry is provider-local:
+driving the polyfill from INSIDE its own module (`compileMulti` of shim+bundle,
+`.tmp/s2d/in-provider`, referencing the bundle's real binding `qi` — a bare
+`Temporal` identifier is intercepted by the #661 compile-time lowering and tests
+nothing) answers `Object.keys(qi).length === 9`, `typeof qi.PlainDate ===
+"function"`, `qi["Plain"+"Date"]` resolvable, `"PlainDate" in qi` true. **Next
+lane's target: find which terminal serves the in-module read and why
+`__extern_get` — the one the boundary can call — does not.** A first reduction
+attempt (`.tmp/s2d/probe13`, an object literal whose values are classes) does
+NOT reproduce it: there `__extern_get` returns the right class by identity, it
+only mis-reports `typeof` as `"object"` instead of `"function"` (a separate,
+smaller defect worth its own reduction).
+
+### The other three stops, re-measured in-module (`.tmp/s2d/in-provider`)
+
+Messages read back through the #5384 renderer (`__exn_render_prepare` /
+`__exn_render_char`), host-free, zero imports:
+
+| probe | answer |
+| --- | --- |
+| `Object.keys(qi).length` | **9** |
+| `new qi.PlainDate(2024,1,1).day` | throws `invalid calendar identifier` |
+| `qi.Duration.from({hours:1}).total("minutes")` | throws `invalid receiver: method called with the wrong type of this-object` |
+| `qi.PlainDate.from("2024-01-01")` | throws `Unsupported dynamic regular expression pattern` → filed as **#5404** |
+| `qi.Now.timeZoneId()` | **no-throw** (must raise the shim's RangeError) |
+
+The last one is NOT a boundary artifact and NOT the "discarded result" shape the
+S2c note guessed at — ten isolated spellings of that guess (bare `new`, no-paren
+`new`, two-step, result used, result returned, result discarded, via a namespace
+object, on both lanes) all propagate the constructor's throw correctly
+(`.tmp/s2d/probe14`, `probe15`, `probe16`). The real trigger is narrower and
+worse, and it reproduces in ten lines on BOTH lanes: **a property read on the
+result of a `never`-returning call elides the entire receiver expression**, so
+`(new Intl.DateTimeFormat).resolvedOptions().timeZone` never runs the
+constructor at all (`ctorHits === 0`). Filed as **#5405** with the reduction and
+the shape of the fix. Every shim method has a `throw`-only body, which is why
+the shim is where it surfaced.
+
+`invalid calendar identifier` and `invalid receiver` remain unreduced — S2d
+spent its budget on the boundary and on root-causing the two above.

--- a/plan/issues/5383-standalone-temporal-provider.md
+++ b/plan/issues/5383-standalone-temporal-provider.md
@@ -533,3 +533,115 @@ else in this slice is a test in
 9 cases, including the non-enumerability of the installed methods, the
 untouched element/length surface, an unaffected plain class, and the preserved
 absent-receiver TypeError).
+
+## S2c findings (2026-09-08) — the Intl shim; `__module_init` RETURNS; the stop moves to the getter boundary
+
+`__module_init` now **returns** under `--target standalone`, both as a plain
+`compileMulti` of the bundle and through `buildTemporalProvider`'s real link
+path. The S2 smoke test is still **not** written, and the reason is new and
+elsewhere: the `Temporal` object does not survive the linked-provider **getter
+boundary** on this lane.
+
+### R8 — the `Intl` refusal shim (`src/temporal-intl-shim.ts`, provider-local)
+
+S2b stopped at `"formatToParts" in ai.prototype`, because standalone leaves the
+`Intl` identifier null by decision (#5206). The fix is **lexical and
+provider-local**, not a codegen change: `buildTemporalProvider` writes the
+synthetic package's `index.js` as `<shim>\n<bundle>` when
+`compileOptions.target` is `standalone` or `wasi`, and verbatim otherwise.
+
+The shape is dictated by the polyfill's own EAGER uses, each measured:
+
+| polyfill line (top level) | what the shim must provide |
+| --- | --- |
+| `ct = Intl.DateTimeFormat`, `const ai = Intl.DateTimeFormat` | a constructor VALUE (`typeof === "function"`) |
+| `"formatToParts" in ai.prototype \|\| delete DateTimeFormatImpl.prototype.formatToParts` (and the `formatRangeToParts` twin) | a real `.prototype` carrying both names, so the answer is TRUE and the polyfill does **not** delete its own methods |
+| `di.supportedLocalesOf = ai.supportedLocalesOf` | any value; a static is fine (measured: a class static read as a VALUE answers `undefined` on this lane — harmless here, noted below) |
+| `const {format,formatToParts} = Intl.DurationFormat?.prototype ?? …` and `Intl.DurationFormat?.prototype && (…)` | `DurationFormat: undefined`, so both short-circuit |
+| `Intl.supportedValuesOf?.("timeZone")` (lazy, `hr`) | `supportedValuesOf: undefined` → the polyfill's own fallback, not a throw |
+
+Everything else — the constructor and every method on the prototype — throws a
+`RangeError` naming `--target standalone`. `DurationFormat`/`supportedValuesOf`
+are deliberately `undefined` rather than throwing bodies: every use of them is
+behind `?.` or `typeof … === "function"`, so a body would convert a graceful
+degradation (`Duration.prototype.toLocaleString` falls back to the ISO string)
+into a throw.
+
+**A module-scoped `const Intl` DOES shadow the builtin on this lane** — measured
+first, because the whole design depends on it: with the shim prepended,
+`typeof ct === "function"`, `"formatToParts" in ai.prototype` is `true`, and
+`new Intl.DateTimeFormat()` throws the shim's RangeError rather than reaching
+`tryCompileIntlHostOnlyNew` (#5355). Standalone `Intl` semantics for user code
+are unchanged: the binding lives in ONE compilation unit.
+
+The shim text is part of the provider's identity: `temporalProviderCacheKey`
+now fingerprints the EFFECTIVE source, so editing the shim re-keys the
+standalone artifact and a stale binary cannot be served. **Host lane A/B, run
+both ways in this worktree** (`.tmp/gc-ab.mts`, fresh cache per side):
+key `372a41be…`, artifact sha256 `acd6ff4d…`, 1,701,105 B — **identical** before
+and after.
+
+Whole-bundle measurement with the shim (`--target standalone`,
+`hostBridge: "off"`, `deferTopLevelInit: true`): 158,585 B of source (shim
+1,043 B + bundle 157,541 B) compiles in **44 s**; through `buildTemporalProvider`
+the artifact is **3,167,456 B** with an **empty** import list, and
+`__module_init` **RETURNS**.
+
+### Where it stops now — the getter boundary, not the polyfill
+
+Measured two ways, which is what localises it:
+
+| probe | `Object.keys(Temporal).length` |
+| --- | --- |
+| inside the standalone module itself (`Object.keys(qi)` appended to the bundle, after `__module_init`) | **9** |
+| through `compileWithTemporalGlobal` + `instantiateLinkedProject(result, {})`, standalone | **0** |
+| the same consumer probe on the host `gc` lane (control) | **9** (`Duration,Instant,Now,PlainDate,…`) |
+
+So the standalone consumer receives an object (`typeof` `"object"`,
+`String(...)` `[object Object]`, not null) with no own properties, and
+`Temporal.PlainDate` is `undefined` — hence
+`TypeError: Cannot read properties of undefined (reading 'from')` for both smoke
+assertions. `__module_init` ran (the linker calls it in `wireProviderInstance`)
+and the namespace IS populated inside the provider. **This is a standalone
+cross-module object-boundary defect and it is the next slice (S2d).**
+
+Two further stops sit BEHIND that one, found by driving the polyfill from
+inside its own module (so they are real, not boundary artifacts):
+
+- `Temporal.PlainDate.from("2024-01-01")` → `TypeError: Unsupported dynamic
+  regular expression pattern` — the polyfill parses ISO strings with a
+  dynamically-built RegExp, which the standalone RegExp backend refuses.
+- `Temporal.Duration.from({hours:1}).total("minutes")` and the
+  `new Temporal.Duration(…)` spelling → `TypeError: invalid receiver: method
+  called with the wrong type of this-object`.
+- `new Temporal.PlainDate(2024,1,1)` → `RangeError: invalid calendar identifier`.
+
+Fixing the boundary alone therefore will NOT make the two smoke assertions pass;
+S2d needs all three. Recording them now so the next lane does not re-derive them
+at 45 s per compile.
+
+### Two small measured facts worth not re-deriving
+
+- **A class STATIC read as a value answers `undefined`** on this lane
+  (`ai.supportedLocalesOf` where `ai` is a class with `static
+  supportedLocalesOf(){…}`). Harmless for the polyfill (it just copies the
+  value onto its own object), but it is not what the spec says.
+- **`Temporal.Now.timeZoneId()` answers `null` instead of throwing the shim's
+  RangeError.** The polyfill's `Uo()` is
+  `(new Intl.DateTimeFormat).resolvedOptions().timeZone`, and an isolated
+  reduction of that exact spelling — a `new`-expression chain whose result is
+  discarded by the caller — also swallowed the constructor's throw. The
+  direct spellings (`new Intl.DateTimeFormat()`, `const f = new …; f.m()`,
+  via an alias, with arguments) all throw correctly and are tests. The
+  swallowing shape is NOT fixed here; it is filed with the S2d work above,
+  and it is why the smoke test's "`Now.timeZoneId()` throws" assertion is not
+  written either.
+
+### Tests
+
+`tests/issue-5383-standalone-temporal-provider.test.ts` gains six S2c cases:
+the eager-use bitmask (all five shapes in one module), the lazy RangeError with
+its `--target standalone` text, a prototype-method refusal, the `gc` cache key
+recomputed from the raw bundle (the host-lane no-change guard), standalone/wasi
+keys distinct from `gc`, and the shim's own shape (one `const Intl`, prefixed
+binding).

--- a/plan/issues/5404-standalone-dynamic-regexp-pattern.md
+++ b/plan/issues/5404-standalone-dynamic-regexp-pattern.md
@@ -1,0 +1,99 @@
+---
+id: 5404
+title: "standalone: the RegExp backend refuses every RUNTIME-BUILT pattern (`Unsupported dynamic regular expression pattern`), which is how the Temporal polyfill parses ISO strings — 13 `new RegExp(<template>)` sites composed at module init"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+goal: standalone
+feasibility: hard
+reasoning_effort: high
+requested_by: ttraenkler/dev-5383-s2d
+created: 2026-09-08
+---
+
+# #5404 — a runtime-built RegExp pattern is refused under `--target standalone`
+
+## Problem
+
+`--target standalone` compiles a regular expression whose pattern is a
+**literal** (`/[0-9]+/`) to the #682 native backtracking VM at COMPILE time. A
+pattern that is only known at RUNTIME goes through
+`__regex_compile_dynamic_simple`, whose grammar is a small subset; anything
+outside it produces a **poisoned** `$NativeRegExp` that raises
+`TypeError: Unsupported dynamic regular expression pattern` on first use
+(`REGEX_UNSUPPORTED_DYNAMIC_PATTERN`, `src/codegen/native-regex.ts` L54; the
+poisoned-value design is #4439).
+
+That is the wall `Temporal.PlainDate.from("2024-01-01")` hits on the standalone
+lane (measured 2026-09-08 while driving the compiled `@js-temporal/polyfill`
+from inside its own module — #5383 S2c/S2d). It is NOT a linked-provider or
+boundary problem: the same throw happens single-module.
+
+### What the polyfill actually builds (measured, `.tmp/s2d/regexp-scan`)
+
+The bundle contains **13** `new RegExp(...)` call sites and **1** literal used
+with `.test`/`.exec`. Every one of the 13 is a template literal that splices the
+`.source` of previously built expressions — i.e. a **finite, closed set fixed at
+module-initialisation time**, with no user input anywhere:
+
+```
+new RegExp(`(?:${/(?:[+-](?:[01][0-9]|2[0-3]) … `)      // UTC offset
+new RegExp(`(${ye.source} …`)                            // date
+new RegExp(`([zZ] …`)                                    // Z designator
+new RegExp([`^${we.source}`, `(?:(?:[tT]|\\s+ …`)        // date-time
+new RegExp([`^[tT]?${ve.source}`, `(?:${De.source} …`)   // time
+new RegExp(`^(${ye.source} …`)
+new RegExp(`^(?:-- …`)                                   // month-day
+new RegExp(`(?:${Oe.source}H …`)                         // duration
+new RegExp(`^([+-] …`)
+new RegExp(`^${fe.source}$`, "i")                         // (case-insensitive)
+new RegExp(`^${/([+-] …`)
+new RegExp(`^${be.source}$`)
+```
+
+`String.raw` is not used; there are no `\d{n}`-style constructions. The
+composition happens once, at init, into module-level bindings the ISO parsers
+then reuse.
+
+## Why this matters
+
+Every `Temporal.*.from("<ISO string>")` row in test262 goes through these
+parsers, and string parsing is the single largest Temporal entry point. It also
+blocks the same shape anywhere else: a library that composes its grammar from
+fragments (a very common idiom) is unusable on the standalone lane even though
+every fragment is a compile-time constant.
+
+## Plan (two candidate fixes, pick by measurement)
+
+1. **Precompile the closed set at provider/compile time.** The 13 patterns are
+   fixed once the bundle's own initialisation has run, so a build-time pass
+   could evaluate the composition and lower each result through the SAME
+   compile-time path a literal takes. Cheapest at runtime, but it needs a
+   defensible answer to "when is a template-composed pattern provably constant?"
+   — const-folded `.source` reads of already-const regexes is the narrow rule
+   that covers all 13.
+2. **Grow the runtime compiler** (`__regex_compile_dynamic_simple`) toward the
+   feature set the literal path already implements, so a runtime pattern is
+   compiled by the native engine rather than poisoned. Strictly more general,
+   pays a runtime cost, and is the honest fix for arbitrary user input.
+
+Either way, keep #4439's poisoned-value contract for what remains outside the
+grammar: refuse on first USE with a catchable `TypeError`, never at construction
+and never as a Wasm trap.
+
+## Acceptance criteria
+
+- A standalone module that builds a pattern by composing `.source` of literal
+  regexes at init can `.test`/`.exec` with it, host-free.
+- The exact 13 polyfill spellings above are covered (a fixture test, not a
+  Temporal end-to-end).
+- `Temporal.PlainDate.from("2024-01-01").day === 1` through the standalone
+  provider — as a follow-on measurement in #5383, once its boundary work lands.
+- No change to the JS-host (`gc`) lane: byte-identical artifacts.
+
+## Notes
+
+Filed out of #5383 S2d, which deliberately used the OBJECT-form spellings
+(`Temporal.Duration.from({hours: 1})`, `new Temporal.PlainDate(2024, 1, 1)`) to
+keep its smoke test off this gap.

--- a/plan/issues/5405-never-call-chain-elides-receiver.md
+++ b/plan/issues/5405-never-call-chain-elides-receiver.md
@@ -1,0 +1,95 @@
+---
+id: 5405
+title: "codegen (BOTH lanes): a property read on the result of a `never`-returning call ELIDES the whole receiver expression — `(new C).m().p` never runs `C`'s constructor, so its throw is silently lost and the read answers a non-`undefined` placeholder"
+status: ready
+sprint: current
+priority: high
+horizon: m
+goal: core-semantics
+feasibility: hard
+reasoning_effort: high
+requested_by: ttraenkler/dev-5383-s2d
+created: 2026-09-08
+---
+
+# #5405 — a `never`-returning call in a member chain drops its receiver's side effects
+
+## Problem
+
+When the RESULT of a call is read as a property, and that call's declared return
+type is `never` (its body is only a `throw`), the compiler emits **nothing for
+the receiver expression at all**. Constructor side effects do not happen, a
+constructor throw is lost, and the read answers a value that is not `undefined`.
+
+Measured 2026-09-08 (`.tmp/s2d/probe18`), on **both** lanes — `--target
+standalone --hostBridge off` AND the default `gc` lane, byte-for-byte the same
+answers:
+
+| spelling | throws? | constructor ran? |
+| --- | --- | --- |
+| `(new NS.C).m().p` — `m()` returns `never` | **NO** | **0 times** |
+| `(new C).m().p` — same, direct binding | **NO** | **0 times** |
+| `(new NS.C).m()` — no trailing property read | yes | 1 |
+| `new NS.C()` | yes | 1 |
+| `const x = new NS.C; x.m();` | yes | 1 |
+| `(new NS.V).m().p` — `m()` RETURNS A VALUE | yes | 1 |
+
+So the trigger is precisely: **a property read on a call whose return type is
+`never`**. Drop the trailing `.p`, or give `m()` a value-returning body, and the
+receiver is compiled normally.
+
+### Reduction (10 lines, no Temporal, no linking)
+
+```js
+let hits = 0;
+class C {
+  constructor() { hits++; throw new RangeError("ctor"); }
+  m() { throw new RangeError("m"); }        // returns `never`
+}
+const NS = { C: C };
+export function chain() {
+  try { const v = (new NS.C).m().p; return v === undefined ? 0 : -1; }
+  catch (e) { return 1; }
+}
+export function ctorHits() { return hits; }   // → 0, must be 1
+```
+
+`chain()` answers `-1` (no throw, a non-`undefined` value); it must answer `1`.
+`ctorHits()` answers `0`; it must answer `1`.
+
+## Why this matters
+
+This is a **silent wrong answer with a lost side effect**, not a missing
+feature: the program observes neither the exception nor the construction. It is
+the general form of a real failure — `Temporal.Now.timeZoneId()` on the
+standalone lane answers a value instead of the refusal its
+`(new Intl.DateTimeFormat).resolvedOptions().timeZone` body must raise (#5383
+S2c/S2d), because the shim's methods all have `throw`-only bodies. Any refusal
+shim, assertion helper, or `assertUnreachable()`-style API has `never`-returning
+methods, so the pattern is not exotic.
+
+## Where to look
+
+The receiver is dropped, so the fault is on the READ side, not in `new`: the
+property-access lowering resolves the receiver's type to `never`, finds no shape
+to read from, and takes a "cannot type this receiver → answer the placeholder"
+path **without first compiling the receiver for effect**. Everything that
+type-checks the member (`src/codegen/property-access.ts`,
+`property-access-dispatch.ts`, `property-access-exact-shapes.ts` — the last one
+already filters `TypeFlags.Never` out of its member set) is the neighbourhood.
+
+The fix shape is the standard one for an unusable-value path: still compile the
+receiver, then `drop` it, and only then answer the placeholder — the same
+discipline the `VOID_RESULT` sentinel enforces elsewhere. Better still, a call
+whose static type is `never` should be emitted followed by `unreachable`, since
+control cannot continue past it.
+
+## Acceptance criteria
+
+- The reduction above answers `chain() === 1` and `ctorHits() === 1` on the
+  `gc` lane and host-free `--target standalone`.
+- The five non-triggering spellings in the table keep their current answers
+  (they are already correct; a test pins them so a fix cannot regress them).
+- `Temporal.Now.timeZoneId()` raises the shim's `RangeError` in a standalone
+  build of the polyfill (measured in #5383 as `no-throw` today).
+- No change to any module that has no `never`-returning member call: byte A/B.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -10085,6 +10085,14 @@
       "nextBoundary": "Review the frontend, orchestration, runtime and shared-contract split before migration."
     },
     {
+      "path": "src/temporal-intl-shim.ts",
+      "state": "unmigrated",
+      "layer": "mixed-needs-split",
+      "destination": "compiler",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Review the frontend, orchestration, runtime and shared-contract split before migration."
+    },
+    {
       "path": "src/temporal-provider.ts",
       "state": "unmigrated",
       "layer": "mixed-needs-split",

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -6317,6 +6317,14 @@
       "nextBoundary": "Separate AST/context-driven generation, physical resources and generated native runtime."
     },
     {
+      "path": "src/codegen/standalone-link-boundary.ts",
+      "state": "unmigrated",
+      "layer": "mixed-needs-split",
+      "destination": "backend-wasmgc",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate AST/context-driven generation, physical resources and generated native runtime."
+    },
+    {
       "path": "src/codegen/standalone-subclass-ctors.ts",
       "state": "unmigrated",
       "layer": "mixed-needs-split",

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -178,6 +178,7 @@ import { expressionHasWidenedPropertyType, markIndexedPropertyStale } from "./st
 import { ProgramAbiSession, type PublishedProgramAbi } from "./program-abi-session.js";
 import { sourceFunctionHandleForDeclaration } from "./program-abi-source-callable-planning.js";
 import { stripHostBridgeExports } from "./host-bridge-exports.js";
+import { publishStandaloneLinkBoundaryExports } from "./standalone-link-boundary.js"; // (#5383 S2d)
 import { eliminateDeadLayoutAndPlanProgramAbi } from "./program-abi-finalization.js";
 import { emitDataStructHostBridgeManifest } from "./data-struct-host-bridge.js";
 import { planProgramAbiFunctionValue, planProgramAbiGlobal, PROGRAM_ABI_GLOBAL_ROLE } from "./program-abi-planning.js";
@@ -7012,6 +7013,11 @@ function assertNoLeakedHostImports(ctx: CodegenContext, mod: WasmModule): void {
 function finalizeStandaloneTimerCallbackExports(ctx: CodegenContext): void {
   publishStandaloneTimerCallbackDispatch(ctx);
   stripHostBridgeExports(ctx);
+  // (#5383 S2d) AFTER the host-bridge strip, deliberately: the strip is what
+  // removes the JS-facing decoder family from a standalone binary, and these
+  // wasm-facing terminals are its replacement for a linked consumer. Publishing
+  // before it would leave the export to be stripped again.
+  publishStandaloneLinkBoundaryExports(ctx);
 }
 
 /**

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -240,6 +240,7 @@ import { overlayRouteActive } from "./typed-lane-overlay-route.js"; // (#4222) o
 import { backedBoundsGuard, canonicalIndexDigitStep } from "./vec-index-domain.js"; // (#4434) index domain + sparse tail
 import { buildVecIndexKeyPush, reserveVecIndexEnumerable } from "./vec-index-enumerable.js"; // (#4491) overlay-aware key flags
 import { fillHostArrayCarrierPredicate } from "./host-array-carrier.js"; // (#4649) js-host late-bound carrier test
+import { emitStandaloneLinkBoundaryTerminals, standaloneLinkBoundaryPeerIndices } from "./standalone-link-boundary.js"; // (#5383 S2d) wasm→wasm peer terminals
 import {
   buildOwnToPrimitiveOverridePresent,
   buildWrapperSlotShortCircuit,
@@ -1014,6 +1015,12 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   const boundaryObjectSetPrototypeIdx = boundaryObjectInterop
     ? ctx.funcMap.get("__boundary_object_set_prototype")
     : undefined;
+  // (#5383 S2d) The standalone twin of the two host-lane boundary reads above.
+  // Registered HERE, next to them, because both must exist before the index
+  // space freezes (#1984) and because they answer the same question — "this
+  // carrier is not mine; who can decode it?". On the host lane these stay
+  // undefined and every arm below is byte-identical.
+  const { memberGet: peerMemberGetIdx, objectKeys: peerObjectKeysIdx } = standaloneLinkBoundaryPeerIndices(ctx);
   const boundaryObjectGetOwnPropertyDescriptorIdx = boundaryObjectInterop
     ? ctx.funcMap.get("__boundary_object_get_own_property_descriptor")
     : undefined;
@@ -2393,11 +2400,17 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
           // fallback below. A present JS property whose value is `undefined`
           // returns the non-null native undefined carrier, so miss and value do
           // not alias.
-          ...(boundaryObjectGetIdx !== undefined
+          // (#5383 S2d) The standalone lane reaches the SAME arm with the peer
+          // provider's normalising terminal: "not a `$Object` of mine" is
+          // exactly the question, and the wrapper's null-for-a-miss contract is
+          // the same one this arm was written against. The closed-struct field
+          // ladder is unshifted onto the FRONT of this body at finalize, so a
+          // receiver this module can decode never gets here.
+          ...((boundaryObjectGetIdx ?? peerMemberGetIdx) !== undefined
             ? ([
                 { op: "local.get", index: 0 },
                 { op: "local.get", index: 1 },
-                { op: "call", funcIdx: boundaryObjectGetIdx },
+                { op: "call", funcIdx: (boundaryObjectGetIdx ?? peerMemberGetIdx)! },
                 { op: "local.tee", index: 6 },
                 { op: "ref.is_null" },
                 { op: "i32.eqz" },
@@ -6340,8 +6353,13 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     objVecPushIdx,
     objOrderedIdx,
     objOrderedAllIdx,
-    boundaryObjectKeysIdx,
-    boundaryObjectForInKeysIdx,
+    // (#5383 S2d) On the standalone lane the peer terminal takes the SAME arm:
+    // the arm's contract is "ask, and use the answer only when it is non-null",
+    // which is exactly what the provider's normalising wrapper guarantees. The
+    // two are mutually exclusive by construction (one needs a JS host, the
+    // other needs there not to be one), so neither lane grows an arm.
+    boundaryObjectKeysIdx: boundaryObjectKeysIdx ?? peerObjectKeysIdx,
+    boundaryObjectForInKeysIdx: boundaryObjectForInKeysIdx ?? peerObjectKeysIdx,
     FLAG_ENUMERABLE,
     FLAG_TOMBSTONE,
   });
@@ -6841,6 +6859,12 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       }
     }
   }
+
+  // (#5383 S2d) A standalone provider publishes the same two reads to its WASM
+  // consumer that the block above publishes to a JS host. Emitted here, at the
+  // end of the object runtime, because both wrappers call terminals the block
+  // above has only just finished registering.
+  emitStandaloneLinkBoundaryTerminals(ctx, registerNative);
 
   // (#2175 V2-S3b-1) Build any `$NativeProto` companion seeders that were parked
   // because their proto materialized before `__defineProperty_value` existed

--- a/src/codegen/standalone-link-boundary.ts
+++ b/src/codegen/standalone-link-boundary.ts
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// standalone-link-boundary.ts — (#5383 S2d) the wasm→wasm twin of the #5225
+// cross-module struct-owner registry.
+//
+// THE DEFECT THIS EXISTS FOR (measured 2026-09-08, `.tmp/s2d/probe4`):
+// a value minted by a linked PROVIDER and read by the CONSUMER answers nothing
+// under `--target standalone` — `Object.keys(NS).length` is 0 where the same
+// read inside the provider answers 3, and `NS.a` is `undefined`.
+//
+// Root cause: standalone puts NO self-describing property bag on a value. Every
+// dynamic read is a module-local `ref.test` ladder over the struct types THAT
+// module declared, filled at finalize (`__extern_get`, `__object_keys`). A
+// provider-minted struct is in the provider's ladder and in no other, so the
+// consumer's ladder misses on every arm and falls through to its terminal.
+// (Verified from the other side: a module's own generic terminals DO decode its
+// own static-shape structs — `.tmp/s2d/probe11`, keys 3 / get 1 / call 1.)
+//
+// The JS-host lane never sees this because the linker replaces the boundary
+// value with a host mirror bound to the provider's `__struct_field_names` /
+// `__sget_*` exports, and #5225's `_crossModuleStructs` registry re-points a
+// read at the module that can decode it. Neither exists without a JS host.
+//
+// The fix mirrors that design in pure wasm: the provider EXPORTS its generic
+// terminals under stable names, and the consumer calls them when its own ladder
+// has already missed. This is deliberately a MISS-PATH mechanism — a receiver
+// the consumer can decode never reaches the peer call, so the single-module
+// lane and every local read stay byte-identical.
+//
+// Scope: `--target standalone` only, and only between modules of one linked
+// project. The JS-host lane keeps the host mirror and is untouched (byte A/B in
+// #5383's S2d notes).
+
+import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+import type { CodegenContext } from "./context/types.js";
+import type { Instr, ValType } from "../ir/types.js";
+
+const EXTERNREF: ValType = { kind: "externref" };
+
+/** `registerNative` as `ensureObjectRuntime` defines it (structural, not imported). */
+type RegisterNative = (
+  name: string,
+  paramTypes: ValType[],
+  resultTypes: ValType[],
+  locals: { name: string; type: ValType }[],
+  body: Instr[],
+) => number;
+
+/** Provider-exported generic terminals. The name is the wasm→wasm ABI. */
+export const LINK_BOUNDARY_EXPORTS = Object.freeze({
+  memberGet: "__js2wasm_link_member_get",
+  objectKeys: "__js2wasm_link_object_keys",
+  apply: "__js2wasm_link_apply",
+} as const);
+
+/** The internal terminal each boundary name wraps, and its signature. */
+const TERMINALS: ReadonlyArray<{ export: string; internal: string; params: ValType[] }> = [
+  { export: LINK_BOUNDARY_EXPORTS.memberGet, internal: "__extern_get", params: [EXTERNREF, EXTERNREF] },
+  { export: LINK_BOUNDARY_EXPORTS.objectKeys, internal: "__object_keys", params: [EXTERNREF] },
+  { export: LINK_BOUNDARY_EXPORTS.apply, internal: "__apply_closure", params: [EXTERNREF, EXTERNREF, EXTERNREF] },
+];
+
+/** A module compiled as a linked provider whose consumer is wasm, not JS. */
+function isWasmConsumedStandaloneProvider(ctx: CodegenContext): boolean {
+  return ctx.standalone && ctx.exportsConsumedByWasm === true;
+}
+
+/** The provider namespaces this module may route a missed read to. */
+function peerNamespaces(ctx: CodegenContext): string[] {
+  if (!ctx.standalone || isWasmConsumedStandaloneProvider(ctx)) return [];
+  return [...ctx.linkedNamespaces].filter((name) => name.startsWith("js2wasm:npm:")).sort();
+}
+
+/**
+ * Emit the provider-side boundary terminals.
+ *
+ * NOT raw re-exports of `__extern_get` / `__object_keys`, and the difference is
+ * the whole correctness argument: each wrapper normalises "I do not know this
+ * value" to `ref.null.extern`, so the consumer can tell a real answer from a
+ * miss and keep its own local answer otherwise. Without that the consumer would
+ * have to trust the peer's `undefined` singleton (a DIFFERENT module's global —
+ * its `x === undefined` identity is not the consumer's) and the peer's empty
+ * key vec would out-rank the consumer's own carrier-bag keys.
+ *
+ * Both normalisations are answer-preserving: a property that is genuinely
+ * `undefined` on a foreign object, and an object with genuinely zero own keys,
+ * fall back to the consumer's local miss — which answers `undefined` / empty.
+ *
+ * `__apply_closure` needs no wrapper: calling a closure the peer does not own
+ * cannot be confused with a value, and the consumer only reaches it after its
+ * own closure test has already failed.
+ */
+export function emitStandaloneLinkBoundaryTerminals(ctx: CodegenContext, registerNative: RegisterNative): void {
+  if (!isWasmConsumedStandaloneProvider(ctx)) return;
+  const externGet = ctx.funcMap.get("__extern_get");
+  const isUndefined = ctx.funcMap.get("__extern_is_undefined");
+  if (externGet !== undefined && isUndefined !== undefined && !ctx.funcMap.has(LINK_BOUNDARY_EXPORTS.memberGet)) {
+    registerNative(
+      LINK_BOUNDARY_EXPORTS.memberGet,
+      [EXTERNREF, EXTERNREF],
+      [EXTERNREF],
+      [{ name: "v", type: EXTERNREF }],
+      [
+        { op: "local.get", index: 0 },
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: externGet },
+        { op: "local.tee", index: 2 },
+        { op: "call", funcIdx: isUndefined },
+        {
+          op: "if",
+          blockType: { kind: "val", type: EXTERNREF },
+          then: [{ op: "ref.null.extern" }],
+          else: [{ op: "local.get", index: 2 }],
+        },
+      ],
+    );
+  }
+  const objectKeys = ctx.funcMap.get("__object_keys");
+  const externLength = ctx.funcMap.get("__extern_length");
+  if (objectKeys !== undefined && externLength !== undefined && !ctx.funcMap.has(LINK_BOUNDARY_EXPORTS.objectKeys)) {
+    registerNative(
+      LINK_BOUNDARY_EXPORTS.objectKeys,
+      [EXTERNREF],
+      [EXTERNREF],
+      [{ name: "v", type: EXTERNREF }],
+      [
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: objectKeys },
+        { op: "local.tee", index: 1 },
+        { op: "call", funcIdx: externLength },
+        { op: "f64.const", value: 0 },
+        { op: "f64.eq" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: EXTERNREF },
+          then: [{ op: "ref.null.extern" }],
+          else: [{ op: "local.get", index: 1 }],
+        },
+      ],
+    );
+  }
+}
+
+/**
+ * Publish the generic terminals of a standalone provider.
+ *
+ * Called at finalize, when every terminal has been filled. A terminal the
+ * module never needed is simply not published: the consumer's import is added
+ * only for a namespace it links, and a provider that has no object runtime at
+ * all cannot own a value the consumer could ask about.
+ */
+export function publishStandaloneLinkBoundaryExports(ctx: CodegenContext): void {
+  if (!isWasmConsumedStandaloneProvider(ctx)) return;
+  const published = new Set(ctx.mod.exports.map((entry) => entry.name));
+  for (const terminal of TERMINALS) {
+    if (published.has(terminal.export)) continue;
+    // The wrapper (when one was emitted) is registered UNDER the export name;
+    // `__apply_closure` is published directly.
+    const index = ctx.funcMap.get(terminal.export) ?? ctx.funcMap.get(terminal.internal);
+    if (index === undefined) continue;
+    ctx.mod.exports.push({ name: terminal.export, desc: { kind: "func", index } });
+  }
+}
+
+/**
+ * The imported peer terminal, or undefined when this module has no standalone
+ * provider to ask.
+ *
+ * ONE peer, deliberately: the export name IS the ABI, and `ensureLateImport`
+ * keys `funcMap` by that name, so a second namespace publishing the same name
+ * cannot be told apart without a per-namespace alias. #5383's graph is one
+ * provider; a multi-provider standalone graph keeps today's behaviour for the
+ * namespaces after the first (nothing decodes, exactly as before this module),
+ * rather than silently asking the wrong module.
+ *
+ * MUST be called before the index-space freeze (#1984) — `ensureObjectRuntime`
+ * is the caller, alongside the host lane's `__boundary_object_*` twins.
+ */
+export function standaloneLinkBoundaryPeerIndices(ctx: CodegenContext): {
+  memberGet?: number;
+  objectKeys?: number;
+} {
+  const namespace = peerNamespaces(ctx)[0];
+  if (namespace === undefined) return {};
+  // Register BOTH, then flush, then read the indices back. Each late import
+  // SHIFTS the function index space, so an index captured from the first
+  // `ensureLateImport` return names a different function once the second lands
+  // (measured: the consumer called the 3-parameter apply terminal with 2
+  // arguments and the module failed to validate). This is the same
+  // register-all-then-flush-then-look-up discipline the `__boundary_object_*`
+  // block above follows, and for the same reason.
+  for (const terminal of TERMINALS) {
+    ensureLateImport(ctx, terminal.export, [...terminal.params], [EXTERNREF], namespace);
+  }
+  flushLateImportShifts(ctx, null);
+  return {
+    memberGet: ctx.funcMap.get(LINK_BOUNDARY_EXPORTS.memberGet),
+    objectKeys: ctx.funcMap.get(LINK_BOUNDARY_EXPORTS.objectKeys),
+  };
+}

--- a/src/linked-provider-runtime.ts
+++ b/src/linked-provider-runtime.ts
@@ -252,8 +252,19 @@ export function instantiateLinkedProviders(
     // consumer-minted argument arrives undecodable.
     registerLinkedProviderModule(rawExports);
     const exposedExports: Record<string, any> = { ...rawExports };
+    // (#5383 S2d) A provider compiled for a NON-JavaScript environment
+    // (`--target standalone`) hands its values to a WASM consumer, not to a
+    // host. `wrapLinkedProviderValue` replaces the value with a JS host mirror
+    // bound to this provider's `__struct_field_names` / `__sget_*` exports —
+    // exactly right for the JS lane, and a dead end for the standalone one:
+    // those exports do not exist in a standalone binary (#4035 strips the host
+    // bridge), and the consumer is wasm, which cannot read a JS proxy at all.
+    // Measured: with the mirror in place the consumer sees an object with zero
+    // own keys and every read `undefined`. Passing the raw struct through is
+    // what lets the #5383 S2d boundary terminals decode it.
+    const noHostMirror = manifest.providerMetadata.targetProfile?.environment !== "javascript";
     for (const boundary of Object.values(manifest.exportBoundaries)) {
-      if (boundary.kind === "function") continue;
+      if (boundary.kind === "function" || noHostMirror) continue;
       const getter = rawExports[boundary.field];
       if (typeof getter !== "function") {
         throw new Error(`Linked provider ${artifact.namespace} has no getter ${boundary.field}`);

--- a/src/temporal-intl-shim.ts
+++ b/src/temporal-intl-shim.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// temporal-intl-shim.ts (#5383 S2c) — the module-scoped `Intl` binding that is
+// prepended to the @js-temporal/polyfill provider SOURCE for the standalone /
+// WASI lanes, and to nothing else.
+//
+// Why this exists. The polyfill reads the `Intl` namespace at MODULE TOP LEVEL
+// in three places, so its `__module_init` cannot return without them:
+//
+//   ct = Intl.DateTimeFormat                     (a cache of the constructor)
+//   const ai = Intl.DateTimeFormat
+//   "formatToParts" in ai.prototype || delete DateTimeFormatImpl.prototype.formatToParts
+//   "formatRangeToParts" in ai.prototype || delete …
+//   di.supportedLocalesOf = ai.supportedLocalesOf
+//   const { format: Ri, formatToParts: Si } = Intl.DurationFormat?.prototype ?? …
+//
+// Standalone deliberately leaves the `Intl` IDENTIFIER null (#5206: "a compiled
+// shim for it is a separate, much larger gap" — there is no ICU in pure Wasm),
+// so `Intl.DateTimeFormat` reads a property of null and init throws at the
+// first of those lines.
+//
+// Two things this is NOT, both measured before choosing this shape (#5383 S2b):
+//
+//  - It is NOT a change to standalone `Intl` semantics for user code. An
+//    `Intl.<member>` → `undefined` codegen arm was written and REVERTED: it
+//    cleared the first read and the `.prototype` probe then threw on
+//    `undefined`, so it moved the failure rather than removing it, while
+//    changing what every standalone program sees. This binding is lexical and
+//    lives in ONE compilation unit — the provider's `index.js`.
+//  - It is NOT an Intl implementation. Every member is a refusal that names the
+//    target. The 66 of 4,603 Temporal rows that touch `Intl.`/`toLocaleString`
+//    are out of scope for #5383 by its own plan and stay red; they now fail
+//    with a RangeError that says why, instead of a null dereference.
+//
+// The shape is dictated by the eager uses above, not by taste:
+//   * `Intl.DateTimeFormat` must be a CONSTRUCTOR VALUE with a real
+//     `.prototype`, because `"formatToParts" in ai.prototype` is evaluated
+//     eagerly. Answering `true` there is also what keeps the polyfill from
+//     running the `delete DateTimeFormatImpl.prototype.formatToParts` branch,
+//     so its own implementation surface stays intact.
+//   * `DurationFormat` and `supportedValuesOf` are `undefined`, because every
+//     use of them is behind `?.` or a `typeof … === "function"` test. Giving
+//     them bodies would turn those graceful degradations into throws
+//     (`Duration.prototype.toLocaleString` falls back to the ISO string).
+//   * Every remaining member throws a `RangeError` naming the target, so a
+//     lazy path (`Temporal.Now.timeZoneId()`, a non-ISO calendar) fails with a
+//     nameable error instead of a trap or a wrong answer.
+
+/** The message every refusal in the shim throws, with the member spelled out. */
+function refusal(member: string): string {
+  return `Intl.${member} is unavailable under --target standalone (no ICU data in pure Wasm)`;
+}
+
+function throwingMethod(name: string, member: string): string {
+  return `  ${name}() { throw new RangeError(${JSON.stringify(refusal(member))}); }`;
+}
+
+/**
+ * The `Intl` shim prepended to the provider source under `--target standalone`
+ * / `--target wasi`. Deterministic: the text is part of the provider's cache
+ * key (`temporalProviderCacheKey` fingerprints the EFFECTIVE source), so a
+ * change here re-keys the standalone artifact and cannot serve a stale one.
+ *
+ * The binding names are `__js2wasm_`-prefixed so they cannot collide with any
+ * of the bundle's 340 top-level bindings.
+ */
+export function standaloneIntlShimSource(): string {
+  const methods = ["format", "formatToParts", "formatRange", "formatRangeToParts", "resolvedOptions"]
+    .map((name) => throwingMethod(name, "DateTimeFormat"))
+    .join("\n");
+  return [
+    "// #5383 S2c — standalone Intl refusal shim (js2wasm, provider-local).",
+    "class __js2wasm_IntlDateTimeFormat {",
+    `  constructor() { throw new RangeError(${JSON.stringify(refusal("DateTimeFormat"))}); }`,
+    methods,
+    "}",
+    "const Intl = {",
+    "  DateTimeFormat: __js2wasm_IntlDateTimeFormat,",
+    "  DurationFormat: undefined,",
+    "  supportedValuesOf: undefined,",
+    "};",
+    "",
+  ].join("\n");
+}

--- a/src/temporal-provider.ts
+++ b/src/temporal-provider.ts
@@ -40,6 +40,7 @@ import * as nodeCrypto from "node:crypto";
 
 import type { CompileOptions, CompileResult, LinkedModuleArtifact } from "./index.js";
 import { compileMulti, compileProject } from "./index.js";
+import { standaloneIntlShimSource } from "./temporal-intl-shim.js";
 import { getDefaultEnvironment } from "./env.js";
 
 /** npm package name the polyfill bundle is presented to the linker under. */
@@ -120,7 +121,26 @@ function fingerprint(parts: readonly string[]): string {
  * `scripts/prewarm-temporal-provider.mjs` carries this exact key.
  */
 export function temporalProviderCacheKey(options: { polyfillSource: string; compileOptions?: CompileOptions }): string {
-  return fingerprint([options.polyfillSource, providerOptionFingerprint(options.compileOptions)]);
+  return fingerprint([providerSource(options), providerOptionFingerprint(options.compileOptions)]);
+}
+
+/**
+ * The text actually written to the synthetic package's `index.js`.
+ *
+ * On the JS-host lane (`--target gc`, the default) this is the bundle verbatim,
+ * so the host provider's cache key and artifact bytes are unchanged by this
+ * function's existence — proven by an A/B of both in #5383 S2c.
+ *
+ * On the standalone / WASI lanes the #5383 S2c `Intl` refusal shim is prepended
+ * (see `temporal-intl-shim.ts` for why the polyfill cannot initialise without a
+ * module-scoped `Intl` there). Because the KEY is computed from this same text,
+ * editing the shim re-keys the standalone artifact: a stale binary can never be
+ * served for a changed shim.
+ */
+function providerSource(options: { polyfillSource: string; compileOptions?: CompileOptions }): string {
+  const target = options.compileOptions?.target ?? "gc";
+  if (target !== "standalone" && target !== "wasi") return options.polyfillSource;
+  return `${standaloneIntlShimSource()}\n${options.polyfillSource}`;
 }
 
 function providerOptionFingerprint(options: CompileOptions | undefined): string {
@@ -228,19 +248,28 @@ function materializeTemporalProject(fs: ProjectFilesystem, cacheDir: string, key
 /**
  * Compile the polyfill once into a linked provider artifact.
  *
- * STANDALONE MODE IS OUT OF SCOPE HERE, and that is a real gap, not an
- * oversight: this lane is `--target gc` with the JS host adapter. The polyfill
- * reaches the host through the ordinary compiled-object bridge — no NEW host
- * import is introduced by this module (it adds none; the provider's import set
- * is whatever the polyfill's own compile needs, and the linker refuses any
- * namespace outside `env` / the string namespaces / declared `link:` targets).
- * So the dual-mode principle is not violated by a new host dependency, but a
- * standalone (`--target wasi` / `--no-host-imports`) Temporal global does NOT
- * exist yet: the provider deferred-init export the linker requires is
- * documented as unavailable for WASI (`src/package-linker.ts`, "the deferred
- * export is unavailable for WASI, whose startup contract is `_start`"). Wiring
- * standalone needs that provider-startup lifecycle first and is deliberately
- * left to a follow-up.
+ * The DEFAULT lane is `--target gc` with the JS host adapter: the polyfill
+ * reaches the host through the ordinary compiled-object bridge, and this module
+ * introduces no host import of its own (the provider's import set is whatever
+ * the polyfill's compile needs, and the linker refuses any namespace outside
+ * `env` / the string namespaces / declared `link:` targets).
+ *
+ * STANDALONE (#5383) is now BUILDABLE, not yet usable end to end. With
+ * `compileOptions: { target: "standalone", hostBridge: "off" }` this returns a
+ * `separate` plan whose artifact imports NOTHING and whose `__module_init`
+ * RETURNS (measured 2026-09-08: 44 s, 3.17 MB, import list empty) — the
+ * `Intl` refusal shim in `temporal-intl-shim.ts` is what got init that far.
+ * What does NOT work yet is the value that crosses the getter boundary: a
+ * consumer compiled with `compileWithTemporalGlobal(..., standalone)` sees
+ * `typeof Temporal === "object"` with ZERO own keys, while the SAME module
+ * read from inside itself has all nine (`Object.keys(qi).length === 9`). So
+ * the remaining gap is the standalone cross-module object boundary, not the
+ * polyfill and not this module's plumbing. Details in #5383's "S2c findings".
+ *
+ * The historical claim that the deferred-init export is unavailable for
+ * standalone is FALSE and was retired in S1: it is a `--target wasi` statement
+ * (`src/package-linker.ts`, "the deferred export is unavailable for WASI,
+ * whose startup contract is `_start`"), and standalone exports `__module_init`.
  */
 export async function buildTemporalProvider(options: BuildTemporalProviderOptions): Promise<TemporalProvider> {
   const key = temporalProviderCacheKey(options);
@@ -254,7 +283,7 @@ export async function buildTemporalProvider(options: BuildTemporalProviderOption
   // The linker consumes a real module graph, so the bundle is materialized as
   // a one-file npm package next to its own provider cache. The directory is
   // keyed by the source fingerprint, so a bundle bump never reuses stale text.
-  const entryPath = materializeTemporalProject(fs, options.cacheDir, key, options.polyfillSource);
+  const entryPath = materializeTemporalProject(fs, options.cacheDir, key, providerSource(options));
 
   const result = await compileProject(entryPath, {
     ...options.compileOptions,

--- a/tests/issue-5383-standalone-temporal-provider.test.ts
+++ b/tests/issue-5383-standalone-temporal-provider.test.ts
@@ -34,7 +34,10 @@
 
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { compile } from "../src/index.js";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { compile, compileMulti, compileProject, instantiateLinkedProject } from "../src/index.js";
 import { standaloneIntlShimSource } from "../src/temporal-intl-shim.js";
 import { temporalProviderCacheKey } from "../src/temporal-provider.js";
 
@@ -590,5 +593,105 @@ describe("#5383 S2c — the shim re-keys the standalone provider and leaves the 
     // Collision safety against the bundle's 340 top-level bindings.
     expect(shim).toContain("__js2wasm_IntlDateTimeFormat");
     expect(shim).toContain("--target standalone");
+  });
+});
+
+// ── S2d — the standalone cross-module OBJECT boundary ───────────────────────
+//
+// The stop S2c measured: a value the provider mints reaches the consumer with
+// ZERO own keys and every read `undefined`, while the SAME read inside the
+// provider answers correctly. Two causes, both fixed here and both asserted
+// below on a throwaway package (nothing Temporal-specific about either):
+//
+//   1. the linker replaced the boundary value with a JS host MIRROR even for a
+//      provider compiled for a non-JavaScript environment — a mirror bound to
+//      `__struct_field_names` / `__sget_*` exports that a standalone binary does
+//      not have, handed to a consumer that is wasm and cannot read a JS proxy;
+//   2. with the raw struct passing through, the consumer's dynamic terminals
+//      are module-local `ref.test` ladders over the struct types THAT module
+//      declared, so a provider-minted struct misses every arm. The provider now
+//      publishes its own terminals (`standalone-link-boundary.ts`) and the
+//      consumer asks them on the paths where its own ladder has already missed.
+//
+// Base measurements for the assertions (this branch's merge base, host-free
+// standalone, `.tmp/s2d/probe3`): keys 0 / read `undefined` for ALL THREE
+// carrier shapes below. The `gc` control answered the post-fix values on base
+// already — that is what makes this standalone-specific.
+describe("#5383 S2d — a provider-minted object survives the standalone getter boundary", () => {
+  /** Three ways to build the same three-property object, three carriers. */
+  const CARRIERS: Record<string, string> = {
+    literal: `export const NS = { a: 1, b: 2, c: 3 };`,
+    "assigned own props": `const o = {}; o.a = 1; o.b = 2; o.c = 3; export const NS = o;`,
+    defineProperty: `const o = {};
+      Object.defineProperty(o, "a", { value: 1, enumerable: true, writable: true, configurable: true });
+      o.b = 2; o.c = 3; export const NS = o;`,
+  };
+
+  const CONSUMER = `
+    export function keysHere() { return Object.keys(NS).length; }
+    export function readA() { return NS.a === 1 ? 1 : (NS.a === undefined ? -1 : -2); }
+    export function readMissing() { return NS.zzz === undefined ? 1 : 0; }
+  `;
+
+  async function linkAndRun(providerSource: string, target: "standalone" | "gc") {
+    const root = mkdtempSync(join(tmpdir(), "issue-5383-s2d-"));
+    const packageRoot = join(root, "node_modules", "ns5383");
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      JSON.stringify({ name: "ns5383", version: "0.0.0", main: "index.js" }),
+    );
+    writeFileSync(join(packageRoot, "index.js"), providerSource);
+    const entry = join(root, "entry.js");
+    writeFileSync(entry, `import { NS } from "ns5383";\nexport function __probe() { return typeof NS; }\n`);
+    const standalone = target === "standalone" ? { target: "standalone" as const, hostBridge: "off" as const } : {};
+    const built = await compileProject(entry, {
+      allowJs: true,
+      skipSemanticDiagnostics: true,
+      packageCacheDir: join(root, "providers"),
+      ...standalone,
+    });
+    expect(built.success).toBe(true);
+    // Load-bearing: a `bundled` plan would inline the package and test nothing.
+    expect(built.linkPlan?.mode).toBe("separate");
+    const artifact = (built.linkedModules ?? []).find((entry) => entry.packageName === "ns5383")!;
+    const boundary = artifact.exportBoundaries?.NS;
+    expect(boundary?.kind).toBe("getter");
+    const field = boundary!.field;
+    const stub = "/__ns_stub.ts";
+    const consumerEntry = "/__main.js";
+    const result = await compileMulti(
+      {
+        [stub]: `export declare function ${field}(): any;\n`,
+        [consumerEntry]: `import { ${field} } from "/__ns_stub";\nconst NS = ${field}();\n${CONSUMER}`,
+      },
+      consumerEntry,
+      {
+        allowJs: true,
+        skipSemanticDiagnostics: true,
+        canonicalRuntimeTypes: true,
+        sharedExceptionTag: true,
+        link: [artifact.namespace],
+        linkedPackageBindings: new Map([[field, { module: artifact.namespace, field }]]),
+        ...standalone,
+      },
+    );
+    (result as { linkedModules?: unknown[] }).linkedModules = [artifact];
+    expect(result.success).toBe(true);
+    // The EMPTY import object is the host-free contract: nothing below may
+    // depend on a JS host being present.
+    const { instance } = await instantiateLinkedProject(result, target === "standalone" ? {} : undefined);
+    const exports = instance.exports as unknown as Record<string, () => unknown>;
+    return { keysHere: exports.keysHere(), readA: exports.readA(), readMissing: exports.readMissing() };
+  }
+
+  for (const [name, source] of Object.entries(CARRIERS)) {
+    it(`host-free standalone: a ${name} carrier keeps its keys and values`, { timeout: 300_000 }, async () => {
+      expect(await linkAndRun(source, "standalone")).toEqual({ keysHere: 3, readA: 1, readMissing: 1 });
+    });
+  }
+
+  it("the gc control answers identically — the host mirror path is untouched", { timeout: 300_000 }, async () => {
+    expect(await linkAndRun(CARRIERS.literal, "gc")).toEqual({ keysHere: 3, readA: 1, readMissing: 1 });
   });
 });

--- a/tests/issue-5383-standalone-temporal-provider.test.ts
+++ b/tests/issue-5383-standalone-temporal-provider.test.ts
@@ -32,8 +32,11 @@
 // The whole polyfill is not compiled here (~60 s, 2.9 MB): `.tmp/sa-temporal/`
 // carries that probe. These are the reductions.
 
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
+import { standaloneIntlShimSource } from "../src/temporal-intl-shim.js";
+import { temporalProviderCacheKey } from "../src/temporal-provider.js";
 
 interface StandaloneModule {
   binary: Uint8Array;
@@ -67,6 +70,16 @@ async function compileStandalone(source: string): Promise<StandaloneModule> {
 
 function callExport(mod: StandaloneModule, name = "test"): unknown {
   return (mod.instance.exports as Record<string, () => unknown>)[name]!();
+}
+
+/**
+ * (#5383 S2c) Compile with the standalone provider's `Intl` shim ahead of the
+ * source — the exact text `buildTemporalProvider` prepends for
+ * `target: "standalone" | "wasi"`, so these cases exercise the shipped shim
+ * rather than a copy of it.
+ */
+function withIntlShim(source: string): string {
+  return `${standaloneIntlShimSource()}\n${source}`;
 }
 
 describe("#5383 S1 R1 — ToBoolean of an anyref (WeakMap/Map `get` as a condition)", () => {
@@ -439,5 +452,143 @@ describe("#5383 S2b R7 — dynamic method dispatch on an externref-backed subcla
     // 1 = calling the extracted method with no receiver threw a CATCHABLE
     // TypeError rather than trapping or silently answering.
     expect(callExport(mod)).toBe(1);
+  });
+});
+
+// ── S2c ──────────────────────────────────────────────────────────────────────
+//
+// With S2b's subclass family fixed, the standalone `__module_init` stopped in
+// the polyfill's `Intl` section: standalone deliberately leaves the `Intl`
+// IDENTIFIER null (#5206 — there is no ICU in pure Wasm), and the polyfill
+// reads that namespace at MODULE TOP LEVEL, so init threw at
+// `"formatToParts" in ai.prototype` before any Temporal object existed.
+//
+// The fix is provider-local and lexical, not a codegen change: the #5383 S2c
+// shim (`src/temporal-intl-shim.ts`) is prepended to the polyfill SOURCE for
+// the standalone / WASI provider builds only. An `Intl.<member>` → `undefined`
+// codegen arm was written and REVERTED in S2b — it moved the failure to the
+// next line and changed what every standalone program sees.
+//
+// These cases pin the contract the shim has to meet, which is dictated by the
+// polyfill's own eager uses:
+//   * every EAGER use evaluates without throwing (init must RETURN), and
+//   * every LAZY use throws a RangeError that NAMES the target.
+//
+// Measured with the shim in place (whole linked bundle, `--target standalone`,
+// `hostBridge: "off"`, 2026-09-08): compiles in 44 s to 2.96 MB with ZERO
+// imports, and `__module_init` RETURNS. Where it stops next is recorded in the
+// issue file (S2c findings) — the `Temporal` namespace does not survive the
+// linked-provider getter boundary, so the S2 smoke test is still not written.
+
+describe("#5383 S2c — the standalone provider's `Intl` refusal shim", () => {
+  it("every EAGER use the polyfill makes at module top level evaluates", async () => {
+    // The shapes, verbatim in structure from the bundle:
+    //   ct = Intl.DateTimeFormat                                  (cache)
+    //   const ai = Intl.DateTimeFormat
+    //   "formatToParts" in ai.prototype || delete Impl.prototype.formatToParts
+    //   di.supportedLocalesOf = ai.supportedLocalesOf
+    //   const {format,formatToParts} = Intl.DurationFormat?.prototype ?? {}
+    const mod = await compileStandalone(
+      withIntlShim(`
+        const ct = Intl.DateTimeFormat;
+        const ai = Intl.DateTimeFormat;
+        class DateTimeFormatImpl { formatToParts() { return 1; } }
+        "formatToParts" in ai.prototype || delete DateTimeFormatImpl.prototype.formatToParts;
+        const di = {};
+        di.supportedLocalesOf = ai.supportedLocalesOf;
+        const durationProto = Intl.DurationFormat?.prototype;
+        const tz = Intl.supportedValuesOf?.("timeZone");
+        export function test() {
+          var bits = 0;
+          if (typeof ct === "function") bits += 1;
+          // TRUE keeps the polyfill's own formatToParts — the delete branch
+          // must not run, or its DateTimeFormat surface loses a method.
+          if ("formatToParts" in ai.prototype) bits += 2;
+          if (durationProto === undefined) bits += 4;
+          if (tz === undefined) bits += 8;
+          if (new DateTimeFormatImpl().formatToParts() === 1) bits += 16;
+          return bits;
+        }
+      `),
+    );
+    expect(callExport(mod)).toBe(31);
+  });
+
+  it("a LAZY use throws a catchable RangeError that names the target", async () => {
+    // `Temporal.Now.timeZoneId()` is `(new Intl.DateTimeFormat).resolvedOptions().timeZone`
+    // in the bundle. The refusal has to be nameable — not a trap, not a wrong
+    // answer. The 66 Intl-dependent Temporal rows are out of scope for #5383
+    // and this is what they will report.
+    const mod = await compileStandalone(
+      withIntlShim(`
+        export function test() {
+          try {
+            const f = new Intl.DateTimeFormat("en-US-u-ca-gregory", { day: "numeric" });
+            return 0;
+          } catch (e) {
+            if (!(e instanceof RangeError)) return 1;
+            return e.message.indexOf("--target standalone") >= 0 ? 2 : 3;
+          }
+        }
+      `),
+    );
+    expect(callExport(mod)).toBe(2);
+  });
+
+  it("a method on the refusal class throws the same way, so `in`-probing it is safe", async () => {
+    const mod = await compileStandalone(
+      withIntlShim(`
+        const ai = Intl.DateTimeFormat;
+        export function test() {
+          const proto = ai.prototype;
+          try { proto.formatToParts(); } catch (e) { return e instanceof RangeError ? 1 : 2; }
+          return 0;
+        }
+      `),
+    );
+    expect(callExport(mod)).toBe(1);
+  });
+});
+
+describe("#5383 S2c — the shim re-keys the standalone provider and leaves the host lane alone", () => {
+  const polyfillSource = "export const Temporal = { PlainDate: 1 };\n";
+
+  it("the `gc` key is the fingerprint of the BUNDLE — the host provider is unaffected", () => {
+    // The same two-part fingerprint `temporalProviderCacheKey` computes, with
+    // the source NOT wrapped. If a future edit ever prepends anything on the
+    // host lane this is what fails, and the host artifact sha would move with
+    // it (measured identical across S2c: key 372a41be…, sha baff93a9…).
+    const optionFingerprint = JSON.stringify({
+      target: "gc",
+      fast: false,
+      nativeStrings: false,
+      utf8Storage: false,
+      semanticProviders: "auto",
+      hostBridge: "auto",
+      platform: "web",
+    });
+    const hash = createHash("sha256");
+    for (const part of [polyfillSource, optionFingerprint]) {
+      hash.update(String(part.length));
+      hash.update(":");
+      hash.update(part);
+      hash.update("\n");
+    }
+    expect(temporalProviderCacheKey({ polyfillSource })).toBe(hash.digest("hex"));
+  });
+
+  it("standalone and wasi keys differ from `gc` and from each other", () => {
+    const gc = temporalProviderCacheKey({ polyfillSource });
+    const standalone = temporalProviderCacheKey({ polyfillSource, compileOptions: { target: "standalone" } as never });
+    const wasi = temporalProviderCacheKey({ polyfillSource, compileOptions: { target: "wasi" } as never });
+    expect(new Set([gc, standalone, wasi]).size).toBe(3);
+  });
+
+  it("the shim declares `Intl` once and prefixes its own binding", () => {
+    const shim = standaloneIntlShimSource();
+    expect(shim.match(/\bconst Intl\b/g)).toHaveLength(1);
+    // Collision safety against the bundle's 340 top-level bindings.
+    expect(shim).toContain("__js2wasm_IntlDateTimeFormat");
+    expect(shim).toContain("--target standalone");
   });
 });


### PR DESCRIPTION
Land order: after PR #5762 (S2c).

Slice **S2d** of [#5383](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5383-standalone-temporal-provider): the standalone cross-module OBJECT boundary. S2c measured the stop — a value the linked provider mints reaches the consumer with `Object.keys(...).length === 0` and every read `undefined`, while the identical read inside the provider answers correctly, and the `gc` control answers correctly. This roots that out and fixes it.

## Two causes, not one

**1. The linker handed the consumer a JS host mirror.** `instantiateLinkedProviders` wrapped every non-function boundary value in `wrapLinkedProviderValue` → `_wrapForHost`, unconditionally. That mirror is bound to the provider's `__struct_field_names` / `__sget_*` exports — which a standalone binary does not have (#4035 strips the host bridge) — and it is handed to a consumer that is **wasm** and cannot read a JS proxy at all. Now skipped when the provider's own `targetProfile.environment` is not `"javascript"`, so the raw struct crosses.

**2. Nothing on a standalone value says what it is.** With the raw struct crossing, every read still answered `undefined`: `__extern_get` / `__object_keys` are module-local `ref.test` ladders over the struct types **that** module declared (filled at finalize), so a provider-minted struct misses every arm. The JS lane hides this behind #5225's `_crossModuleStructs` registry, which re-points a read at the module that can decode it; there is no standalone twin.

New `src/codegen/standalone-link-boundary.ts` builds that twin in pure wasm. A standalone provider whose consumer is wasm publishes `__js2wasm_link_member_get` / `__js2wasm_link_object_keys` / `__js2wasm_link_apply`, and the consumer calls them on the two arms where its own ladder has **already** missed — the arms the host lane's `__boundary_object_get` / `__boundary_object_keys` already occupy, so neither lane grows an arm and the single-module lane is untouched.

The two published reads are **wrappers, not re-exports**: each normalises "I do not know this value" to `ref.null.extern`, so the consumer can tell a miss from an answer instead of trusting another module's `undefined` singleton or letting the peer's empty key-vec out-rank its own carrier bags. Both normalisations are answer-preserving.

## Measured

Host-free `instantiateLinkedProject(result, {})`, three carrier shapes (object literal, assigned own props, `Object.defineProperty`):

| probe | base | after |
| --- | --- | --- |
| `Object.keys(NS).length` | 0 | **3** |
| `NS.a` | `undefined` | **1** |
| `NS.zzz === undefined` | true | true |
| `gc` control | 3 / 1 | unchanged |

Four cases added to `tests/issue-5383-standalone-temporal-provider.test.ts` (32 pass).

## What this does NOT yet do

Temporal end to end still does not work, and **the stop is no longer the boundary**: the provider's own `__extern_get` answers `undefined` for `qi.PlainDate` while its own `__object_keys` lists all nine keys — verified by calling the published terminals directly on the exact value the consumer holds (identity checked). Driving the polyfill from inside its own module answers all four reads correctly, so the next lane's target is which terminal serves the in-module read and why `__extern_get` — the one the boundary can call — does not. Full measurements in the issue's "S2d findings", including the in-module status of the remaining stops read back through the #5384 exception renderer.

Also not covered, both measured rather than assumed: calling a provider-minted **closure** across the boundary, and `hasOwnProperty` / `in` / `for-in` for the non-`defineProperty` carriers — those terminals have their own miss arms.

## Two issues filed while measuring, each with a reduction

- [#5404](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5404-standalone-dynamic-regexp-pattern) — the standalone RegExp backend refuses runtime-built patterns, which is exactly how the polyfill assembles its 13 ISO grammars at init.
- [#5405](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5405-never-call-chain-elides-receiver) — **both lanes**: a property read on the result of a `never`-returning call elides the entire receiver expression, so `(new C).m().p` never runs `C`'s constructor and its throw is silently lost. That, not the "discarded result" shape S2c guessed at (ten spellings of that guess all propagate correctly), is why `Temporal.Now.timeZoneId()` does not raise the shim's `RangeError`.

## Gates

typecheck · loc-budget (also with `LOC_GATE_BASE=origin/main`) · func-budget · coercion-sites · oracle-ratchet · dead-exports · host-import-policy · compiler-boundaries inventory · issue-ids:against-main · biome lint · equivalence-gate (**0 new regressions**) · #5383/#5384 suites · 12 linker/provider suites. Three failures in those suites are pre-existing on this branch's merge base (binaryen `wasm-merge --disable-compact-imports` CLI mismatch ×2, #5226 host identity ×1) — measured on base with the change reverted.

Growth allowances for `src/codegen/object-runtime.ts` (+24) and `ensureObjectRuntime` (+23) are in the #5383 frontmatter with dated rationale: both are the wiring that must sit beside the arm it guards and before the #1984 index-space freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6r5kd3zWKXZrhsqALWVdk)_