### PR TITLE
fix(ir): capture Promise thenables before queued invocation

### DIFF
--- a/plan/agent-context/3518-promise-getter-capture-2026-09-08.md
+++ b/plan/agent-context/3518-promise-getter-capture-2026-09-08.md
@@ -1,0 +1,27 @@
+# Bounded Promise getter capture
+
+Approved specification recorded before production edits. Base: a7fbc6eb6fa8ebcde29529d67e55408592672fee (PR 5765). Worktree: /private/tmp/js2-3518-promise-getter-capture-20260908; branch: codex/3518-promise-getter-capture-20260908. Preserve the old resolution candidate and its receipts unchanged.
+
+Reserve/fill __promise_lookup_then(externref) -> (i32 callable, externref capturedThen). Accessor, field and open-object arms read then once and return that exact callable using function-local multi-results. Compiled methods return callable=1 with null capturedThen as the existing compiled-method dispatch sentinel. Noncallable values return 0/null.
+
+Resolve consumes the second result into a function local and stores it in the existing continuation caps.callback. The queued job uses the actual applyClosure binding with the captured function and original peeled receiver. No global scratch, second Get, or extra capture allocation. Getter exceptions continue to reject with their original reason. Get remains synchronous and invocation remains queued. Native Promise adoption and compiled-method dispatch stay intact.
+
+Owned production files: src/runtime/wasmgc/promise/thenable-bodies.ts, resolution-bodies.ts; src/codegen/async-scheduler.ts, closed-method-dispatch.ts. Focused tests and this handoff are also owned. Resource files and Hilbert signature integration belong to the parent.
+
+Preserve authenticated donor fixture hashes and all 49 preservation controls. Check intentional deltas explicitly rather than rebaselining donor text. Add capture/replacement, poisoned and noncallable getters, receiver identity, two pending resolutions, and reentrant getter controls. Immutable public baseline controller: 76198. Required new trace: getter=1, original=1, replacement=0, value=42, trace=1324.
+
+Heavy tests require the parent's explicit slot grant (parent running 19123 at dispatch). Freeze source manifest for High review before publication. Use normal hooks and user author with Codex coauthor. Final publication is a non-draft PR to loopdive/js2; no merge, cutover or retirement claim.
+
+## Validated candidate
+
+After parent checkpoint push 30254 completed, the parent granted an exclusive validation slot. TS7 session 28466 exited 0. Serial single-fork preservation/runtime session 9166 exited 0: 56/56 tests across 2/2 files in 15.28s (49 original preservation controls with checked intentional deltas, 7 standalone runtime cases). Both used a 2048 MiB heap. Heavy slot released after terminal.
+
+The repaired runtime asserts getter=1, original=1, replacement=0, value=42, trace=1324 and original receiver identity. Additional runtime cases cover thrown reason identity, noncallable getter fulfillment, field replacement, two pending captures, reentrancy, native adoption and compiled-method dispatch.
+
+Donor receipt SHA256 remains da7c7a907726732488dec5e80a8a06c8bb0ed88c644fea32e0da15abef70a646. The immutable controller76198 baseline and old candidate tree were not modified. Exact commands/output are recorded in .tmp/promise-getter-capture-validation-9166.json; source identities are in .tmp/promise-getter-capture-manifest.json. Parent High review and resource signature integration remain pending.
+
+### Explicit migration lanes
+
+The initial 9166 receipt exercised only the default lane and is retained independently. All seven cases now run with experimentalIR=false and true, skipSemanticDiagnostics=false, and the six compiler controls from public controller76198 fixed to zero before compiler import.
+
+TS7 40200 exited 0. First explicit-lane run 85556 failed the 10-second import hook (49 preservation passed, 14 runtime skipped due to failed setup); its failure receipt is retained. After bounding that import hook to 60 seconds, full rerun 6839 exited 0: 63/63 passed in 18.53s, comprising all 49 preservation controls and all 14 runtime tests, no skips. No source algorithm changed during this validation extension. Exact commands/output are in .tmp/promise-getter-capture-validation-6839.json. Heavy slot released; High review precedes PR publication.

--- a/plan/agent-context/3518-promise-getter-explicit-lanes-validation-2026-09-08.json
+++ b/plan/agent-context/3518-promise-getter-explicit-lanes-validation-2026-09-08.json
@@ -1,0 +1,43 @@
+{
+  "revision": "getter-capture-v2-explicit-lanes",
+  "base": "a7fbc6eb6fa8ebcde29529d67e55408592672fee",
+  "typecheck": {
+    "session": 40200,
+    "exitCode": 0,
+    "command": "NODE_OPTIONS=--max-old-space-size=2048 node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json",
+    "output": ""
+  },
+  "test": {
+    "session": 6839,
+    "exitCode": 0,
+    "command": "NODE_OPTIONS=--max-old-space-size=2048 VITEST_FORK_MAX_OLD_SPACE_SIZE=2048 VITEST_MAX_FORKS=1 pnpm exec vitest run tests/issue-3518-promise-resolution-preservation.test.ts tests/issue-3518-promise-getter-capture.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot",
+    "output": "\n RUN  v3.2.4 /private/tmp/js2-3518-promise-getter-capture-20260908\n\n·······························································\n\n Test Files  2 passed (2)\n      Tests  63 passed (63)\n   Start at  20:20:44\n   Duration  18.53s (transform 7.60s, setup 0ms, collect 57ms, tests 18.15s, environment 0ms, prepare 48ms)\n\n",
+    "passed": 63,
+    "total": 63,
+    "preservation": 49,
+    "runtime": {
+      "experimentalIRFalse": 7,
+      "experimentalIRTrue": 7,
+      "skipped": 0,
+      "skipSemanticDiagnostics": false
+    },
+    "durationSeconds": 18.53
+  },
+  "controls": {
+    "JS2WASM_IR_GVN": "0",
+    "JS2WASM_IR_OWNERSHIP": "0",
+    "JS2WASM_IR_ESCAPE": "0",
+    "IR_VERIFY_ALLOC": "0",
+    "JS2WASM_IR_VERIFY_DOMINANCE_NAIVE": "0",
+    "JS2WASM_IR_INLINE": "0"
+  },
+  "earlierReceipts": [
+    ".tmp/promise-getter-capture-validation-9166.json",
+    ".tmp/promise-getter-capture-failed-85556.json"
+  ],
+  "heavySlotReleased": true,
+  "serial": true,
+  "singleFork": true,
+  "heapMiB": 2048,
+  "limits": "Both explicit compile modes passed scoped runtime expectations; not source-free prepared consumer, whole-family cutover or retirement acceptance."
+}

--- a/plan/agent-context/3518-promise-getter-integration-2026-09-08.md
+++ b/plan/agent-context/3518-promise-getter-integration-2026-09-08.md
@@ -1,0 +1,108 @@
+# Promise getter capture integration
+
+Base: PR #5766, `5118637e0e9b34291465230428447e511958faa1`.
+
+Parent inspected and applied Hilbert's two-file resource adaptation from
+`/private/tmp/js2-3518-promise-lookup-resources-20260908`.
+It reserves and fills the new two-result lookup separately from the existing
+one-result classifier, joins the captured-then binding into resolution, and
+asserts the full ordered14-function reservation population. Existing24 resource
+tests remain; the worker's initial21-control report was stale, not a deletion.
+
+This integration is intentionally incomplete until Pauli's canonical/codegen
+getter fix is copied after review. No composed typecheck or execution is
+claimed. The resource adaptation requires the new canonical lookup export.
+No tests should be launched against this partial composition.
+
+Pauli's first isolated run passed TS7 and56/56 tests (49 preservation controls,
+7 default-mode runtime cases). Parent requested the same7 cases explicitly in
+both direct and experimental-IR modes, with semantic diagnostics enabled.
+Those results, the final source manifest, High review and an independent public
+comparison are still required. The historical public baseline remains intact.
+
+The resource pack still requires actual primitive, string/error, closure and
+object materializers. Primitive and string/error implementation now run in
+disjoint Astra Low worktrees under the persisted High plan. This checkpoint
+does not authorize removing async admission, strict closure or retirement gates.
+
+Parent subsequently integrated all six Pauli TS files with exact final-manifest
+SHA256 matches and the handoff. Worker6839 passed63/63 (49 preservation plus
+14 runtime, seven in each explicit IR mode); composed parent38918 passed TS7
+and87/87 across3 files in23.82s, including24 resource controls.
+
+High approved the production getter behavior but requested additional historical
+signature and actual-object-finalization negatives. Pauli owns those test-only
+additions. No complete proof-suite approval is claimed before that repair.
+
+The composed function-budget gate rejected two newly oversized functions:
+resolve303 and resource fill302 lines. Parent extracted the resolution peel
+prelude and microtask reservation projection into private helpers, preserving
+instruction/order semantics without an allowance. The size gate now passes.
+Session96871 is the post-refactor TS7 and87-test rerun; no terminal result yet.
+
+Session96871 subsequently exited0: composed TS7 and87/87 tests passed in22.78s.
+The two helper extractions therefore retain the exercised behavior. Pauli has
+since frozen two additional signature/fill proof cases (51 preservation controls
+total), not yet integrated or executed here. Those are the next validation step.
+
+Worker49086 subsequently passed TS7 and65/65 tests (51 preservation and14
+runtime) in17.61s. Parent integrated its exact test hash and retained raw
+receipts under plan/agent-context. High approved all nine adapter/signature
+mutants, but identified that expected lookup bodies still come from the same
+builder. Pauli is adding independent capture-body expectations and mutations
+for capture, null returns and getter/field targets. That final proof condition
+remains before publication; no production correction was requested.
+
+The final independent whole-body oracle is integrated at test SHA256
+`a241f8bab9e21d1e80aa8a2d538a016010af9041b90b78385941553880e8ab7a`.
+High reviewed and approved its literal result pairs, capture-before-conversion,
+exact reads, accessor/field ordering and null-getter fallthrough, plus four
+positive-first live builder mutants. No scoped review blocker remains.
+Final composed session31410 (TS7 plus259 tests) is live, not yet a pass.
+
+Session31410 subsequently exited0: TS7 and259/259 tests across4 files passed
+in117.47s (52 preservation,14 runtime,24 resource,169 boundary). No skips were
+reported. This closes the requested scoped tests and boundary regression;
+the separately pinned public comparison has now been launched.
+
+Public controller94830 exited0. Both children exited0; candidate24/24 rows
+met independent semantics with zero gaps, and baseline retained the exact20
+known discrepancies. All14 controls passed; repair acceptance is true, raw
+preservation and both-arm semantic equality false. All48 compiles,96 instances
+and184 observations completed. The compact result with hashes and terminals
+is retained in3518-promise-repair-public-result-2026-09-08.json. This public
+measurement covers Pauli's frozen source, not the later parent helper/resource
+composition; the259 composed tests provide that separate scoped evidence.
+
+Normal commit86944 exited1 before creating a commit: formatting/lint passed,
+but the file-size gate rejected async-scheduler4682 versus4665 and
+closed-method-dispatch2066 versus2054. No hook bypass or allowance was used.
+Staged work remains intact. Parent requested a focused legacy adapter-module
+extraction for reservation/finalization, preserving canonical ownership and
+the frozen public candidate. That refactor and its scoped validation remain
+before committing/opening this checkpoint. The prior execution evidence is
+retained rather than relabeled as a pass for future source changes.
+
+Parent extracted the ordered peel/lookup reservation and predicate/lookup
+finalization into `src/codegen/promise-thenable-lookup.ts`. The scheduler
+retains classifier reservation before the helper and publishes its flag after;
+the dispatch driver retains early guards, peel filling and inventory collection.
+The new adapter imports canonical bodies, never the reverse. Both file and
+function budget gates now pass, without allowances. Pauli owns test adaptation
+to the extracted functions; post-extraction execution is still pending.
+
+Pauli returned the adapted test at SHA25672c10f112b76cbd7beed1812b11182e80eacd0e3fad2bf5822f2385d44382e30.
+It evaluates authentic driver/helper declarations together while retaining52
+controls and13 mutants. The wrong-type mutation uses the valid in-scope peel
+type rather than an undefined variable. Original donor and public candidate
+remain unchanged. New legacy module classification is explicitly unmigrated,
+not clean; full inventory now reports1244 unmigrated,77 clean,5 adapters and
+zero errors. No dependency allowance or activation history was relaxed.
+Session12541 is the post-adapter TS7,90-test and focused-closure validation;
+its terminal remains pending.
+
+Session12541 subsequently exited0: TS7 and90/90 affected tests passed in25.46s;
+the focused closure test then passed1/1 (168 unrelated controls deliberately
+filtered, not claimed rerun). The earlier full169 boundary population remains
+recorded separately. Parent inspected the actual adapter/test diff; final High
+review of this size-only extraction is requested while publication proceeds.

--- a/plan/agent-context/3518-promise-lookup-proof-validation-2026-09-08.json
+++ b/plan/agent-context/3518-promise-lookup-proof-validation-2026-09-08.json
@@ -1,0 +1,74 @@
+{
+  "revision": "getter-lookup-proof-v1-validated",
+  "worktree": "/private/tmp/js2-3518-promise-getter-capture-20260908",
+  "typecheck": {
+    "session": 99136,
+    "exitCode": 0,
+    "command": "NODE_OPTIONS=--max-old-space-size=2048 node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json",
+    "output": ""
+  },
+  "suite": {
+    "session": 49086,
+    "exitCode": 0,
+    "command": "NODE_OPTIONS=--max-old-space-size=2048 VITEST_FORK_MAX_OLD_SPACE_SIZE=2048 VITEST_MAX_FORKS=1 pnpm exec vitest run tests/issue-3518-promise-resolution-preservation.test.ts tests/issue-3518-promise-getter-capture.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot",
+    "passed": 65,
+    "total": 65,
+    "filesPassed": 2,
+    "filesTotal": 2,
+    "preservation": 51,
+    "runtime": 14,
+    "skipped": 0,
+    "durationSeconds": 17.61,
+    "output": "\n RUN  v3.2.4 /private/tmp/js2-3518-promise-getter-capture-20260908\n\n·································································\n\n Test Files  2 passed (2)\n      Tests  65 passed (65)\n   Start at  20:28:14\n   Duration  17.61s (transform 7.49s, setup 0ms, collect 63ms, tests 17.25s, environment 0ms, prepare 45ms)\n\n"
+  },
+  "proofControls": {
+    "signaturePositive": "passed",
+    "actualRegisteredObjectFillPositive": "passed",
+    "positiveBeforeMutants": true,
+    "executedMutants": [
+      {
+        "name": "wrong parameter type",
+        "rejected": true
+      },
+      {
+        "name": "missing captured-function result",
+        "rejected": true
+      },
+      {
+        "name": "reversed result order",
+        "rejected": true
+      },
+      {
+        "name": "wrong reserved function type binding",
+        "rejected": true
+      },
+      {
+        "name": "omitted lookup fill",
+        "rejected": true
+      },
+      {
+        "name": "classifier substituted for lookup",
+        "rejected": true
+      },
+      {
+        "name": "unreachable placeholder retained",
+        "rejected": true
+      },
+      {
+        "name": "fill written to predicate instead",
+        "rejected": true
+      },
+      {
+        "name": "lookup locals omitted",
+        "rejected": true
+      }
+    ]
+  },
+  "heavySlotReleased": true,
+  "exclusive": true,
+  "serial": true,
+  "heapMiB": 2048,
+  "singleFork": true,
+  "productionChanged": false,
+  "limits": "Worker proof additions and explicit-lane runtime coverage only; parent composed integration and High review remain separate."
+}

--- a/plan/agent-context/3518-promise-repair-public-admission-2026-09-08.md
+++ b/plan/agent-context/3518-promise-repair-public-admission-2026-09-08.md
@@ -1,0 +1,26 @@
+# Public repair comparison admission
+
+Parent read the complete784-line repair runner, complete source-manifest helper
+and worker handoff before preparing execution. The original extraction runner
+and12-recipe fixture remain immutable. The new runner separately reports raw
+preservation, candidate semantics and the exact previously measured baseline
+defect; its24 pairs/48 compiles/96 instances/184 observations are not reduced.
+
+Manifest capture completed successfully in the instrument worktree:
+`/private/tmp/js2-3518-promise-repair-public-20260908/.tmp/promise-repair-candidate-manifest-r1.json`.
+Pinned SHA256: `1af3a55b5224af8dc4e1ed26231a2205ea5e7f99409ecfd2290da3a9eb44cbe1`.
+Producer receipt SHA256:
+`aa7ca4a4af949eb438497162b5ad923939f7d4ccb222734ec862a876f782cec0`.
+
+Parent reviewed all27 differing source paths. They include the published
+callable/vector/extraction prerequisites plus the four repaired production
+files; not all differences can be attributed to getter capture alone.
+Baseline is2b9cb408c18446361fcf9837045067d1fd97c642,1316 source files,
+census SHA25648f52a45be1b9b37622d146297ec630dd4a2e3d8458852e804f30d57951bff18.
+Candidate is Pauli's frozen source on a7fbc6eb6fa8ebcde29529d67e55408592672fee,
+1325 files, census SHA2566d302fbcbefe8845ddf5974d3582a2ccf433e303bf4811ac0809f7dd714aa9d9.
+It is not the parent's later resource/helper composition.
+
+No compiler comparison has run yet. The pinned manifest must be revalidated
+by the runner, and all14 comparator/provenance controls must actually execute.
+Manifest capture and syntax checks are not acceptance or retirement evidence.

--- a/plan/agent-context/3518-promise-repair-public-pair-handoff-2026-09-08.md
+++ b/plan/agent-context/3518-promise-repair-public-pair-handoff-2026-09-08.md
@@ -1,0 +1,159 @@
+# Promise getter repair: separate public comparison instrument
+
+Static handoff; no compiler, test suite, typecheck or claim hook was run.
+The parent owns execution scheduling and non-draft held PR publication.
+
+## Frozen scope
+
+Instrument checkout: `/private/tmp/js2-3518-promise-repair-public-20260908`.
+Branch: `codex/3518-promise-repair-public-20260908`.
+Base: `5118637e0e9b34291465230428447e511958faa1` (PR #5766).
+Only two new scripts and this handoff are changed. No production, old runner,
+fixture, historical expectation or previous receipt is modified.
+
+- `scripts/verify-promise-resolution-repair-public-pair.mts`
+  SHA256 `760b072fe1288f428cfbd786da8ac5d4a0673c7191b6ff9a43fab075f183869d`.
+- `scripts/lib/promise-repair-source-manifest.mjs`
+  SHA256 `7843ccc549c1eacb31d4252cda4e0e619ead2133e329c401fafacb37fcbe8b87`.
+
+The original extraction runner remains byte-identical, SHA256
+`13f3ef003d15cecdee9c9f8fc2263f2c2f7170ae63a3fc7fd49b31a41d62ba40`.
+The reused, unchanged 12-recipe JSON remains SHA256
+`fb38fbd8180ba54b029b5ec8034929b301d9ab5831f4879385aaebcb417fa0b8`.
+The repair runner authenticates both rather than importing/executing the old
+runner or changing its four-path extraction-candidate admission.
+
+## Exact experiment and separate verdicts
+
+Lane: actual public `src/index.ts` compile, standalone WasmGC, native strings,
+IR false and true. Existing options retain semantic diagnostics, exact source
+strings and required real module-init/drain/export actions. No host fallback,
+synthetic subscription, source instrumentation or positional WAT classifier.
+
+Original baseline is the clean read-only checkout
+`/private/tmp/js2-3518-explicit-rec-integration-20260908`, exact
+`2b9cb408c18446361fcf9837045067d1fd97c642`. Its complete `src` census is pinned:
+1,316 regular files, SHA256
+`48f52a45be1b9b37622d146297ec630dd4a2e3d8458852e804f30d57951bff18`.
+
+Repaired candidate is read-only Pauli checkout
+`/private/tmp/js2-3518-promise-getter-capture-20260908`, currently based at
+`a7fbc6eb6fa8ebcde29529d67e55408592672fee`. **Its final producer freeze and
+independently reviewed cumulative manifest SHA are still required.** No current
+draft hash is silently selected by the compiler run. This is not the older
+four-file extraction candidate, nor the instrument checkout's compiler.
+
+Denominator is unchanged: **12 recipes × 2 modes = 24 pairs / 48 compiles /
+96 fresh instances / 184 external action observations**. Failed/refused rows
+remain in the fixed matrix with full errors and phase. Every successful compile
+is instantiated twice using exactly its recorded full binary. Full WAT, resource
+order, import/export order, IR outcomes, string pool and values are retained.
+
+`preservationOK` requires raw deep equality of all rows. Nothing is normalized,
+including intended binary/WAT changes or checkout prefixes in errors.
+`semanticOK` still means both arms meet the unchanged fixture oracle, so the
+expected baseline defect makes it false. `candidateSemanticsOK` is independent
+of baseline values. `repairAcceptanceOK` requires all candidate semantics,
+the exact expected baseline defect, every comparator control and no provenance
+drift. A successful repair may (and likely will) report `preservationOK:false`.
+It never constitutes general physical acceptance, cutover or retirement proof.
+
+The independently read old baseline report SHA256 is
+`0021d12520b0ae0b1e0c8da639a4a655dc1047cd1bcbd79bd27d5b0e89329744` at
+`/private/tmp/js2-3518-vector-grow-store-20260908/.tmp/promise-resolution-public-parent-r1/baseline.json`.
+The original comparison report SHA256 is
+`880909fc1e0f89f2cdb5ff98913c597f6649ef5c0228b8d5e8d6f4f46361cbb3`.
+Both getter-trace modes, both repetitions, actually observed action values
+`[1, 0, undefined, 2, 0, 1, 99, 13184]`. The unchanged correct oracle is
+`[1, 0, undefined, 1, 1, 0, 42, 1324]`. Exactly those 20 value discrepancies
+are required from the baseline; the other 22 baseline rows must meet semantics.
+Historical defects are labeled as defects, not converted to correct expectations.
+
+## Source manifest protocol
+
+The plain-Node helper never imports the compiler. After Pauli's final freeze,
+the parent supplies its independently verified producer receipt path and SHA.
+The current producer shape is `{worktree, base, sha256: {path: digest}}`, with
+exact four production owner paths: scheduler, closed-method-dispatch, resolution
+bodies and thenable bodies. The helper verifies their hashes, root and current
+HEAD against that receipt. A committed/moved candidate needs an updated explicit
+producer receipt; there is no fallback to an old base or another checkout.
+
+Capture records the *entire* baseline/candidate `src` inventories and every
+added/removed/modified source path with both hashes. The cumulative difference
+can exceed four because the repaired candidate has published prerequisites.
+The parent must review this census before pinning its SHA; it does not imply
+all differences are attributable to the four-file repair.
+
+The compiler runner requires both `--candidate-manifest` and an explicit
+`--candidate-manifest-sha256`. It never regenerates admission during execution.
+Both arms' HEAD/status/source censuses, producer receipt, runtime binary,
+tsx/esbuild implementations/native binary, configuration, helper and runner
+identities are rechecked before/after. Baseline and candidate use identical
+runtime/loader/configuration identities, distinct selected-root dynamic imports,
+and explicit scrubbed launch environments. Each actual child launch/terminal
+is bound to its positional root, arguments, report hash and clean exit.
+
+## Exact proposed commands (UNRUN)
+
+Run from `/private/tmp/js2-3518-promise-repair-public-20260908`. The parent must
+first provide `REPAIR_PRODUCER_SHA256` from the final Pauli freeze and explicitly
+grant the heavy slot before the second command. No install is required; the
+controller below uses the already provisioned baseline tsx loader. Each child
+resolves its own selected-root loader independently.
+
+```sh
+mkdir -p .tmp
+node scripts/lib/promise-repair-source-manifest.mjs \
+  --baseline /private/tmp/js2-3518-explicit-rec-integration-20260908 \
+  --candidate /private/tmp/js2-3518-promise-getter-capture-20260908 \
+  --producer-receipt /private/tmp/js2-3518-promise-getter-capture-20260908/.tmp/promise-getter-capture-manifest.json \
+  --producer-receipt-sha256 "${REPAIR_PRODUCER_SHA256:?supply independently verified final freeze SHA256}" \
+  --output /private/tmp/js2-3518-promise-repair-public-20260908/.tmp/promise-repair-candidate-manifest-r1.json
+```
+
+Read/review the generated complete census, then independently pin its SHA in
+`REPAIR_MANIFEST_SHA256`. A fresh output directory is required; preserve all old
+reports. Capture does not grant a heavy slot or execute any compiler.
+
+```sh
+NODE_OPTIONS=--max-old-space-size=2048 \
+TSX_TSCONFIG_PATH=/private/tmp/js2-3518-promise-repair-public-20260908/tsconfig.json \
+TSX_DISABLE_CACHE=1 \
+node --import /private/tmp/js2-3518-explicit-rec-integration-20260908/node_modules/tsx/dist/esm/index.mjs \
+  scripts/verify-promise-resolution-repair-public-pair.mts \
+  --baseline /private/tmp/js2-3518-explicit-rec-integration-20260908 \
+  --candidate /private/tmp/js2-3518-promise-getter-capture-20260908 \
+  --candidate-manifest /private/tmp/js2-3518-promise-repair-public-20260908/.tmp/promise-repair-candidate-manifest-r1.json \
+  --candidate-manifest-sha256 "${REPAIR_MANIFEST_SHA256:?supply independently reviewed census SHA256}" \
+  --output /private/tmp/js2-3518-promise-repair-public-20260908/.tmp/promise-repair-public-r1 \
+  > .tmp/promise-repair-public-r1-controller.log 2>&1
+```
+
+The controller records a fresh finite nonnegative load check, then runs baseline
+and candidate sequentially with 2 GiB heaps. No deadline kill or retry exists.
+Expected outputs: `expected.json`, per-arm progress/full/launch/terminal reports,
+stdout/stderr logs and `comparison.json`, containing raw differences, row
+transitions, actual denominators, all semantic gaps and separate verdicts.
+
+## Controls and static checks
+
+All six original comparator negatives remain: dropped row, wrong root, stale
+provenance, substituted instantiation bytes, wrong value and changed outcome.
+The last two now compare mutated candidate to the unmutated candidate rather
+than relying on the already-different baseline; intended changes cannot make
+these controls vacuous. Eight additional controls cover stale manifest digest,
+changed census, missing source difference, changed producer freeze, missing /
+nonzero / signalled terminal, and a baseline with its defect removed.
+
+Static checks only: both new scripts parse, all 12 unchanged source fixtures
+parse, and the fixed denominator is 184 actions. Ten retained function
+declarations (including actual `measure`, artifact capture and serialization)
+are identical after applying the same normal formatter to both versions.
+An initial raw TS-printer comparison stopped on formatting-only multiline
+`observation`; the formatter-normalized comparison then passed 10/10. No receipt
+was reseeded. Normal formatting and `git diff --check` pass.
+
+All 14 comparator controls, manifest capture and the complete compiler comparison
+remain **unrun**. No final candidate hash/acceptance is claimed. Wait for parent
+freeze review and explicit execution grant; do not duplicate its running jobs.

--- a/plan/agent-context/3518-promise-repair-public-result-2026-09-08.json
+++ b/plan/agent-context/3518-promise-repair-public-result-2026-09-08.json
@@ -1,0 +1,285 @@
+{
+  "controller": 94830,
+  "exitCode": 0,
+  "reportPath": ".tmp/promise-repair-public-r1/comparison.json",
+  "reportSha256": "a3882321c170416f581e2e076831737a922749114ea45f437db6bc08c7d49ea7",
+  "preservationOK": false,
+  "semanticOK": false,
+  "candidateSemanticsOK": true,
+  "baselineDefectObserved": true,
+  "repairAcceptanceOK": true,
+  "denominator": {
+    "recipes": 12,
+    "modes": 2,
+    "pairs": 24,
+    "rows": 48,
+    "compiles": 48,
+    "instances": 96,
+    "exportObservations": 184
+  },
+  "baseline": {
+    "executed": 24,
+    "requiredRows": 24,
+    "compileAttempts": 24,
+    "completedCompilationRecords": 24,
+    "instances": 48,
+    "observations": 92,
+    "gaps": [
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 0,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-legacy",
+        "repetition": 1,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 0,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getGets",
+        "ordinal": 3,
+        "actual": 2,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getCalls",
+        "ordinal": 4,
+        "actual": 0,
+        "expected": 1
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getWrongCalls",
+        "ordinal": 5,
+        "actual": 1,
+        "expected": 0
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getValue",
+        "ordinal": 6,
+        "actual": 99,
+        "expected": 42
+      },
+      {
+        "id": "callable-getter-capture-trace-ir",
+        "repetition": 1,
+        "export": "getTrace",
+        "ordinal": 7,
+        "actual": 13184,
+        "expected": 1324
+      }
+    ],
+    "ok": false
+  },
+  "candidate": {
+    "executed": 24,
+    "requiredRows": 24,
+    "compileAttempts": 24,
+    "completedCompilationRecords": 24,
+    "instances": 48,
+    "observations": 92,
+    "gaps": [],
+    "ok": true
+  },
+  "negativeControls": [
+    {
+      "name": "drop-row",
+      "rejected": true
+    },
+    {
+      "name": "wrong-root",
+      "rejected": true
+    },
+    {
+      "name": "changed-provenance",
+      "rejected": true
+    },
+    {
+      "name": "changed-instantiation-byte",
+      "rejected": true
+    },
+    {
+      "name": "wrong-value-cannot-pass-semantic-acceptance",
+      "rejected": true
+    },
+    {
+      "name": "changed-outcome-not-equal",
+      "rejected": true
+    },
+    {
+      "name": "stale-manifest-digest",
+      "rejected": true
+    },
+    {
+      "name": "changed-candidate-census",
+      "rejected": true
+    },
+    {
+      "name": "missing-source-difference",
+      "rejected": true
+    },
+    {
+      "name": "changed-producer-freeze",
+      "rejected": true
+    },
+    {
+      "name": "missing-terminal",
+      "rejected": true
+    },
+    {
+      "name": "nonzero-terminal",
+      "rejected": true
+    },
+    {
+      "name": "signalled-terminal",
+      "rejected": true
+    },
+    {
+      "name": "missing-historical-defect-not-repair-evidence",
+      "rejected": true
+    }
+  ],
+  "negativeControlsComplete": true,
+  "rawDifferenceCount": 4790,
+  "terminals": [
+    {
+      "code": 0,
+      "signal": null,
+      "error": null,
+      "pid": 20322,
+      "root": "/private/tmp/js2-3518-explicit-rec-integration-20260908",
+      "label": "baseline",
+      "output": "/private/tmp/js2-3518-promise-repair-public-20260908/.tmp/promise-repair-public-r1/baseline.json",
+      "reportSha256": "1b5637685f789d8d1385f6a704b12a68ac81ff35d0937f97d25e370352cea51e",
+      "launchSha256": "ce6787fa0a64776b5f3728cc53d619897c3581bee0ae512e026299d7cacc7d24"
+    },
+    {
+      "code": 0,
+      "signal": null,
+      "error": null,
+      "pid": 20505,
+      "root": "/private/tmp/js2-3518-promise-getter-capture-20260908",
+      "label": "candidate",
+      "output": "/private/tmp/js2-3518-promise-repair-public-20260908/.tmp/promise-repair-public-r1/candidate.json",
+      "reportSha256": "332964cfffb4824dd6647e9d89450caf9fe5e41db7181ac424243dccf34c0e42",
+      "launchSha256": "b71d567288d8f2b8354d4bff0e61780d087682bc2d615ff30d54c3f882c418bb"
+    }
+  ]
+}

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6368,3 +6368,34 @@ and `plan/agent-context/3518-native-promise-resource-checkpoint-handoff-2026-09-
 
 The requested unsealed-program control subsequently passed with all24/24
 resource tests in13.76s; session2053 also passed composed TS7 and exited0.
+
+## Capture-once Promise integration (2026-09-08)
+
+The ordinary then getter defect is repaired in canonical runtime bodies and
+their legacy callers: resolution returns callability plus the first captured
+function, stores that function in the existing callback field, and the queued
+job invokes it with the original receiver. Compiled-method dispatch retains
+its existing null-capture path. The native resource pack reserves and fills
+the matching two-result lookup without replacing the legacy classifier.
+
+Pauli's isolated explicit-mode suite passed63/63 (49 historical preservation
+controls plus7 runtime cases in each of direct and experimental-IR modes).
+Parent composed TS7 and87/87 tests passed twice:38918 before budget helpers,
+96871 after them. The second run took22.78s. No size allowance was added.
+High approved production changes, resource adaptation and private helpers.
+
+The requested two additional historical signature/fill cases are integrated
+with exact worker hash03091b33df320d43edd63b64fbebc293b5b2fb81a93388ef6b19c35244a8b271.
+Their positive-first4 signature and5 actual-fill mutants still need a terminal
+composed result. Boundary regression and the independent public comparison
+also remain pending. Original donor hashes and failing baseline receipts are
+preserved; this is not full native resource execution or retirement.
+
+Final proof and boundary run31410 passed TS7 and259/259 tests in117.47s.
+High approved the added independent body oracle and all scoped changes.
+Public repair comparison94830 exited0: all24 candidate cases passed their
+semantic expectations, all14 comparator controls passed, and the baseline
+reproduced its exact20 known gaps. Both arms completed48 compiles,96 instances
+and184 observations. Raw outputs differ; baseline/candidate equality is not
+the criterion for correcting the defect. Exact frozen-source scope, hashes
+and limitations are retained in the adjacent agent-context result/handoff.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -6284,6 +6284,14 @@
       "nextBoundary": "Separate AST/context-driven generation, physical resources and generated native runtime."
     },
     {
+      "path": "src/codegen/promise-thenable-lookup.ts",
+      "state": "unmigrated",
+      "layer": "mixed-needs-split",
+      "destination": "backend-wasmgc",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Retire context-owned reservation and finalization after native Promise resource admission; executable bodies already have canonical owners."
+    },
+    {
       "path": "src/codegen/property-access-dispatch.ts",
       "state": "unmigrated",
       "layer": "mixed-needs-split",

--- a/scripts/lib/promise-repair-source-manifest.mjs
+++ b/scripts/lib/promise-repair-source-manifest.mjs
@@ -1,0 +1,155 @@
+// Independent, explicitly pinned source admission for the repair-only runner.
+// This helper never imports the compiler or modifies either measured checkout.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const BASELINE = "2b9cb408c18446361fcf9837045067d1fd97c642";
+const BASELINE_SOURCE_SHA = "48f52a45be1b9b37622d146297ec630dd4a2e3d8458852e804f30d57951bff18";
+const REPAIR_PATHS = [
+  "src/codegen/async-scheduler.ts",
+  "src/codegen/closed-method-dispatch.ts",
+  "src/runtime/wasmgc/promise/resolution-bodies.ts",
+  "src/runtime/wasmgc/promise/thenable-bodies.ts",
+];
+export const sha = (value) => createHash("sha256").update(value).digest("hex");
+
+export function sourceSnapshot(root) {
+  const files = [];
+  function walk(directory) {
+    for (const entry of readdirSync(join(root, directory), { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else {
+        assert(entry.isFile(), "source census rejects nonregular entry: " + path);
+        files.push([path, sha(readFileSync(join(root, path)))]);
+      }
+    }
+  }
+  walk("src");
+  return {
+    root,
+    head: execFileSync("git", ["-C", root, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+    dirty: execFileSync("git", ["-C", root, "status", "--porcelain", "--untracked-files=all", "--", "src"], {
+      encoding: "utf8",
+    }),
+    files,
+    sha256: sha(JSON.stringify(files)),
+  };
+}
+
+export function sourceDifference(baseline, candidate) {
+  const old = new Map(baseline.files),
+    current = new Map(candidate.files);
+  return [...new Set([...old.keys(), ...current.keys()])]
+    .sort()
+    .filter((path) => old.get(path) !== current.get(path))
+    .map((path) => ({ path, baseline: old.get(path) ?? null, candidate: current.get(path) ?? null }));
+}
+
+function cleanBaseline(root) {
+  const baseline = sourceSnapshot(root);
+  assert.equal(baseline.head, BASELINE, "original baseline commit");
+  assert.equal(baseline.files.length, 1316, "original baseline census denominator");
+  assert.equal(baseline.sha256, BASELINE_SOURCE_SHA, "original complete source census");
+  assert.equal(
+    execFileSync("git", ["-C", root, "status", "--porcelain", "--untracked-files=all"], { encoding: "utf8" }),
+    "",
+    "baseline must remain clean",
+  );
+  return baseline;
+}
+
+function producerReceipt(path, expectedSha256, candidate) {
+  assert.match(expectedSha256, /^[0-9a-f]{64}$/, "explicit producer receipt SHA256");
+  const bytes = readFileSync(path);
+  assert.equal(sha(bytes), expectedSha256, "stale producer freeze receipt");
+  const producer = JSON.parse(bytes.toString("utf8"));
+  assert.equal(realpathSync(producer.worktree), candidate.root, "producer candidate root");
+  assert.equal(producer.base, candidate.head, "producer candidate HEAD");
+  const production = Object.keys(producer.sha256)
+    .filter((path) => path.startsWith("src/"))
+    .sort();
+  assert.deepEqual(production, REPAIR_PATHS, "exact four repair owner paths; cumulative census is separate");
+  const current = new Map(candidate.files);
+  for (const path of production)
+    assert.equal(current.get(path), producer.sha256[path], "stale producer source: " + path);
+  return {
+    path: realpathSync(path),
+    sha256: expectedSha256,
+    repairSourceFiles: production.map((path) => [path, producer.sha256[path]]),
+  };
+}
+
+export function captureManifest(roots, producerPath, producerSha256) {
+  const baseline = cleanBaseline(roots.baseline),
+    candidate = sourceSnapshot(roots.candidate);
+  assert.notEqual(baseline.root, candidate.root);
+  const producer = producerReceipt(producerPath, producerSha256, candidate);
+  const difference = sourceDifference(baseline, candidate);
+  assert(difference.length >= REPAIR_PATHS.length, "nonempty complete repair/prerequisite source difference");
+  for (const path of REPAIR_PATHS)
+    assert(
+      difference.some((entry) => entry.path === path),
+      "missing repair source difference: " + path,
+    );
+  return { schema: "promise-repair-source-manifest-v1", roots, baseline, candidate, difference, producer };
+}
+
+export function readPinnedManifest(path, expectedSha256, roots) {
+  assert.match(expectedSha256, /^[0-9a-f]{64}$/, "explicit independently reviewed manifest SHA256 required");
+  const bytes = readFileSync(path);
+  assert.equal(sha(bytes), expectedSha256, "stale candidate source manifest");
+  const manifest = JSON.parse(bytes.toString("utf8"));
+  assert.equal(manifest.schema, "promise-repair-source-manifest-v1");
+  assert.deepEqual(manifest.roots, roots, "positional baseline/candidate manifest roots");
+  return manifest;
+}
+
+export function assertManifestCurrent(manifest, roots) {
+  assert.deepEqual(manifest.roots, roots);
+  assert.deepEqual(
+    captureManifest(roots, manifest.producer.path, manifest.producer.sha256),
+    manifest,
+    "source/HEAD/status/census/producer drift since independent manifest capture",
+  );
+  return { baseline: manifest.baseline, candidate: manifest.candidate, changed: manifest.difference };
+}
+
+function main(argv) {
+  const values = {};
+  const required = ["--baseline", "--candidate", "--producer-receipt", "--producer-receipt-sha256", "--output"];
+  for (let i = 0; i < argv.length; i += 2) {
+    assert(required.includes(argv[i]) && argv[i + 1] && !argv[i + 1].startsWith("--"), "unknown/missing option");
+    assert.equal(values[argv[i]], undefined, "duplicate option");
+    values[argv[i]] = argv[i + 1];
+  }
+  for (const key of required) assert(values[key], "required: " + key);
+  const roots = { baseline: realpathSync(values["--baseline"]), candidate: realpathSync(values["--candidate"]) };
+  const output = resolve(values["--output"]);
+  const ownRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+  assert(
+    realpathSync(dirname(output)) === join(ownRoot, ".tmp") && output.startsWith(join(ownRoot, ".tmp/")),
+    "manifest writes restricted to instrument scratch",
+  );
+  const manifest = captureManifest(roots, values["--producer-receipt"], values["--producer-receipt-sha256"]);
+  const text = JSON.stringify(manifest, null, 2) + "\n";
+  writeFileSync(output, text, { flag: "wx" });
+  console.log(
+    JSON.stringify({
+      output,
+      sha256: sha(text),
+      candidateHead: manifest.candidate.head,
+      sourceFiles: manifest.candidate.files.length,
+      differingPaths: manifest.difference.length,
+      instruction: "Independently review and pin this manifest before the compiler run; capture is not acceptance.",
+    }),
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main(process.argv.slice(2));

--- a/scripts/verify-promise-resolution-repair-public-pair.mts
+++ b/scripts/verify-promise-resolution-repair-public-pair.mts
@@ -1,0 +1,784 @@
+// Separate repair comparison; the historical extraction runner/fixtures stay unchanged.
+// Measurement recipes and compile/instantiate/action code are retained from that runner.
+// Candidate admission is an externally SHA-pinned complete source/producer manifest.
+// A successful repair is NOT byte preservation, baseline correctness or IR retirement.
+import assert from "node:assert/strict";
+import { loadavg } from "node:os";
+import { sourceSnapshot, readPinnedManifest, assertManifestCurrent } from "./lib/promise-repair-source-manifest.mjs";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  mkdirSync,
+  writeFileSync,
+  appendFileSync,
+  openSync,
+  closeSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { CompileResult } from "../src/index.js";
+const instrument = fileURLToPath(import.meta.url);
+const instrumentRoot = resolve(dirname(instrument), "..");
+const fixturePath = join(dirname(instrument), "fixtures/3518-promise-resolution-public-pair.json");
+const BASE = "2b9cb408c18446361fcf9837045067d1fd97c642";
+const ORIGINAL_INSTRUMENT_SHA = "13f3ef003d15cecdee9c9f8fc2263f2c2f7170ae63a3fc7fd49b31a41d62ba40";
+const originalInstrument = join(instrumentRoot, "scripts/verify-promise-resolution-public-pair.mts");
+const manifestHelper = join(instrumentRoot, "scripts/lib/promise-repair-source-manifest.mjs");
+assert.equal(
+  createHash("sha256").update(readFileSync(originalInstrument)).digest("hex"),
+  ORIGINAL_INSTRUMENT_SHA,
+  "historical instrument must remain unchanged",
+);
+
+// Receipt primitives reused from issue-3518-promise-settlement-source-preservation.test.ts.
+const sha = (value: string | Uint8Array) => createHash("sha256").update(value).digest("hex");
+
+const read = (root: string, path: string) => readFileSync(join(root, path), "utf8");
+
+const controls = {
+  JS2WASM_IR_GVN: "0",
+  JS2WASM_IR_OWNERSHIP: "0",
+  JS2WASM_IR_ESCAPE: "0",
+  IR_VERIFY_ALLOC: "0",
+  JS2WASM_IR_VERIFY_DOMINANCE_NAIVE: "0",
+  JS2WASM_IR_INLINE: "0",
+};
+
+function envFor(root: string) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env))
+    if (/^(JS2WASM_|IR_VERIFY_|TSX_|ESBUILD_BINARY_PATH$|NODE_OPTIONS$|NODE_V8_COVERAGE$)/.test(key))
+      Reflect.deleteProperty(env, key);
+  return {
+    ...env,
+    ...controls,
+    NODE_OPTIONS: "--max-old-space-size=2048",
+    TSX_TSCONFIG_PATH: join(root, "tsconfig.json"),
+    TSX_DISABLE_CACHE: "1",
+  };
+}
+
+function launch() {
+  return {
+    argv: process.execArgv,
+    env: Object.fromEntries(
+      Object.entries(process.env)
+        .filter(([key]) => /^(JS2WASM_|IR_VERIFY_|TSX_|ESBUILD_BINARY_PATH$|NODE_OPTIONS$|NODE_V8_COVERAGE$)/.test(key))
+        .sort(),
+    ),
+  };
+}
+
+function tree(root: string, directory: string): [string, string][] {
+  const result: [string, string][] = [];
+  for (const entry of readdirSync(join(root, directory), { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) result.push(...tree(root, path));
+    else if (entry.isFile()) result.push([path, sha(readFileSync(join(root, path)))]);
+  }
+  return result;
+}
+
+function snapshot(root: string) {
+  return sourceSnapshot(root);
+}
+
+function runtime(root: string) {
+  const req = createRequire(join(root, "package.json"));
+  const tsx = dirname(req.resolve("tsx/package.json"));
+  const esbuild = dirname(req.resolve("esbuild/package.json"));
+  const binaryPackage = dirname(
+    createRequire(join(esbuild, "package.json")).resolve(`@esbuild/${process.platform}-${process.arch}/package.json`),
+  );
+  return {
+    node: process.version,
+    versions: process.versions,
+    exec: realpathSync(process.execPath),
+    execSha256: sha(readFileSync(process.execPath)),
+    tsx: tree(tsx, "dist"),
+    tsxPackage: sha(readFileSync(join(tsx, "package.json"))),
+    esbuild: tree(esbuild, "lib"),
+    esbuildPackage: sha(readFileSync(join(esbuild, "package.json"))),
+    binary: tree(binaryPackage, "bin"),
+    typescript: sha(readFileSync(req.resolve("typescript"))),
+    config: sha(read(root, "tsconfig.json")),
+    instrument: sha(readFileSync(instrument)),
+    manifestHelper: sha(readFileSync(manifestHelper)),
+    originalInstrument: sha(readFileSync(originalInstrument)),
+  };
+}
+
+function data(value: unknown): unknown {
+  const seen = new Map<object, number>();
+  function visit(v: any): any {
+    if (v === undefined) return { $undefined: true };
+    if (typeof v === "number" && !Number.isFinite(v)) return { $number: String(v) };
+    if (typeof v === "bigint") return { $bigint: String(v) };
+    if (v === null || typeof v !== "object") return v;
+    if (seen.has(v)) return { $ref: seen.get(v) };
+    seen.set(v, seen.size);
+    if (v instanceof Error)
+      return Object.fromEntries(
+        [...new Set(["name", "message", "stack", "cause", ...Object.getOwnPropertyNames(v)])].map((k) => [
+          k,
+          visit((v as Error & Record<string, unknown>)[k]),
+        ]),
+      );
+    if (Array.isArray(v)) return v.map(visit);
+    if (v instanceof Map) return { $map: [...v].map(([k, w]) => [visit(k), visit(w)]) };
+    if (v instanceof Set) return { $set: [...v].map(visit) };
+    return Object.fromEntries(Object.keys(v).map((k) => [k, visit(v[k])]));
+  }
+  return visit(value);
+}
+
+async function settle<T>(promise: Promise<T>, phase: string): Promise<T> {
+  let rejectIdle!: (error: Error) => void;
+  const idle = new Promise<never>((_, reject) => {
+    rejectIdle = reject;
+  });
+  const onIdle = () => {
+    const error = Object.assign(new Error("unsettled recorder await: " + phase), {
+      code: "ERR_RECORDER_UNSETTLED_AWAIT",
+      phase,
+    });
+    rejectIdle(error);
+  };
+  process.once("beforeExit", onIdle);
+  try {
+    return await Promise.race([promise, idle]);
+  } finally {
+    process.removeListener("beforeExit", onIdle);
+  }
+}
+
+function artifact(result: CompileResult) {
+  const bytes = result.binary;
+  const module = new WebAssembly.Module(bytes);
+  return {
+    binary: Buffer.from(bytes).toString("base64"),
+    wat: result.wat,
+    imports: WebAssembly.Module.imports(module),
+    exports: WebAssembly.Module.exports(module),
+    resourceOrder: result.wat
+      .split("\n")
+      .filter((line) => /^ {2}\((?:type|import|global|func|export|elem|data)\b/.test(line)),
+    units: data({
+      compiled: result.irCompiledFuncs,
+      outcomes: result.irOutcomes,
+      postClaimErrors: result.irPostClaimErrors,
+    }),
+    stringPool: data(result.stringPool),
+  };
+}
+
+const FIXTURE_SHA = "fb38fbd8180ba54b029b5ec8034929b301d9ab5831f4879385aaebcb417fa0b8";
+assert.equal(sha(readFileSync(fixturePath)), FIXTURE_SHA, "fixed recipe receipt");
+const fixtureFile = JSON.parse(readFileSync(fixturePath, "utf8"));
+assert.equal(fixtureFile.schema, "promise-resolution-public-fixtures-v1");
+assert.equal(fixtureFile.base, BASE);
+assert.equal(fixtureFile.recipes.length, 12);
+const matrix = fixtureFile.recipes.flatMap((recipe: any) =>
+  [false, true].map((experimentalIR) => ({
+    ...recipe,
+    id: recipe.id + (experimentalIR ? "-ir" : "-legacy"),
+    options: {
+      target: "standalone",
+      nativeStrings: true,
+      experimentalIR,
+      emitWat: true,
+      skipSemanticDiagnostics: false,
+      trackFallbacks: true,
+      trackIrOutcomes: true,
+      fileName: "promise-resolution-" + recipe.id + ".ts",
+      ...recipe.options,
+    },
+  })),
+);
+assert.equal(matrix.length, 24);
+assert.equal(new Set(matrix.map((x: any) => x.id)).size, 24);
+const plannedActions = matrix.reduce((n: number, f: any) => n + f.actions.length, 0) * 4;
+assert.equal(plannedActions, 184);
+
+function argumentsOf(argv: string[]) {
+  const values: Record<string, string> = {};
+  const required = ["--baseline", "--candidate", "--output", "--candidate-manifest", "--candidate-manifest-sha256"];
+  for (let i = 0; i < argv.length; i += 2) {
+    assert([...required, "--arm"].includes(argv[i]), "unknown option");
+    assert(argv[i + 1] && !argv[i + 1].startsWith("--"), "missing option value");
+    assert.equal(values[argv[i]], undefined, "duplicate option");
+    values[argv[i]] = argv[i + 1];
+  }
+  for (const key of required) assert(values[key], "required explicit argument: " + key);
+  const baseline = realpathSync(values["--baseline"]),
+    candidate = realpathSync(values["--candidate"]);
+  assert.notEqual(baseline, candidate);
+  const output = resolve(values["--output"]);
+  assert(output.startsWith(join(instrumentRoot, ".tmp/")), "writes restricted to instrument worktree scratch");
+  assert.equal(
+    realpathSync(dirname(output)),
+    join(instrumentRoot, ".tmp"),
+    "fresh output directly inside real instrument scratch",
+  );
+  const arm = values["--arm"];
+  assert(arm === undefined || arm === "baseline" || arm === "candidate");
+  const manifestPath = realpathSync(values["--candidate-manifest"]),
+    manifestSha256 = values["--candidate-manifest-sha256"];
+  const roots = { baseline, candidate };
+  readPinnedManifest(manifestPath, manifestSha256, roots);
+  return { roots, output, manifestPath, manifestSha256, arm: arm as "baseline" | "candidate" | undefined };
+}
+function preflight(config: ReturnType<typeof argumentsOf>) {
+  const manifest = readPinnedManifest(config.manifestPath, config.manifestSha256, config.roots);
+  const sources = assertManifestCurrent(manifest, config.roots);
+  const identities = { baseline: runtime(config.roots.baseline), candidate: runtime(config.roots.candidate) };
+  assert.deepEqual(
+    identities.candidate,
+    identities.baseline,
+    "same runtime/loader implementations/config/harness in both arms",
+  );
+  assert.equal(identities.baseline.originalInstrument, ORIGINAL_INSTRUMENT_SHA);
+  return {
+    ...sources,
+    identities,
+    manifest: { path: config.manifestPath, sha256: config.manifestSha256, producer: manifest.producer },
+  };
+}
+function observation(value: any) {
+  return data(value);
+}
+async function measure(api: any, fixture: any) {
+  const row: any = { id: fixture.id, fixture, compilations: [], executions: [], kind: "pending", expectedOK: false };
+  let phase = "compile";
+  try {
+    const result = await settle(api.compile(fixture.source, fixture.options), "compile:" + fixture.id);
+    const compilation: any = {
+      source: fixture.source,
+      options: fixture.options,
+      success: result.success,
+      errors: data(result.errors),
+      artifact: { binary: Buffer.from(result.binary).toString("base64"), wat: result.wat },
+    };
+    row.compilations.push(compilation);
+    if (!result.success) {
+      row.kind = "refused";
+      row.phase = phase;
+      return row;
+    }
+    phase = "artifact";
+    compilation.artifact = artifact(result);
+    compilation.artifact.completeResourceOrder = result.wat
+      .split("\n")
+      .filter((line: string) =>
+        /^\s+\((?:rec|type|import|global|func|tag|table|memory|export|elem|data)(?:\s|\))/.test(line),
+      );
+    assert(result.binary.length > 8 && result.wat.length > 0);
+    assert.deepEqual(compilation.artifact.imports, [], "no host/WASI/synthetic fallback");
+    assert.deepEqual(result.imports, [], "declared imports");
+    // Each repetition starts a fresh real module instance: old fixtures contain
+    // module-local result cells and must not inherit the first repetition's state.
+    for (let repetition = 0; repetition < 2; repetition++) {
+      phase = "instantiate";
+      const bytes = Buffer.from(result.binary),
+        input = bytes.toString("base64");
+      assert.equal(input, compilation.artifact.binary);
+      const execution: any = { repetition, instantiationInputBinary: input, instantiatedBinary: null, actions: [] };
+      row.executions.push(execution);
+      const { instance } = await settle(WebAssembly.instantiate(bytes, {}), "instantiate:" + fixture.id);
+      execution.instantiatedBinary = input;
+      phase = "execute";
+      for (let ordinal = 0; ordinal < fixture.actions.length; ordinal++) {
+        const action = fixture.actions[ordinal],
+          fn = instance.exports[action.export];
+        assert.equal(typeof fn, "function", "required real export " + action.export);
+        const actual = observation((fn as Function)(...action.args));
+        // Retain every later trace observation even if this value is wrong.
+        execution.actions.push({ ordinal, export: action.export, args: action.args, value: actual });
+      }
+    }
+    row.kind = "executed";
+    row.phase = "completed";
+    row.expectedOK = row.executions.every((e: any) =>
+      e.actions.every((a: any, i: number) => JSON.stringify(a.value) === JSON.stringify(fixture.actions[i].expected)),
+    );
+  } catch (error) {
+    row.kind = "threw";
+    row.phase = phase;
+    row.error = data(error);
+  }
+  return row;
+}
+async function arm(config: ReturnType<typeof argumentsOf>) {
+  const label = config.arm!,
+    root = config.roots[label],
+    output = join(config.output, label + ".json");
+  assert.equal(process.cwd(), root);
+  assert.equal(process.env.TSX_TSCONFIG_PATH, join(root, "tsconfig.json"));
+  assert.equal(process.env.TSX_DISABLE_CACHE, "1");
+  assert.equal(process.env.ESBUILD_BINARY_PATH, undefined);
+  for (const [key, value] of Object.entries(controls)) assert.equal(process.env[key], value);
+  const expected = preflight(config),
+    before = snapshot(root),
+    identity = runtime(root);
+  const urls = { compile: pathToFileURL(join(root, "src/index.ts")).href };
+  const api = await settle(import(urls.compile), "selected-public-root");
+  const rows = [];
+  for (const fixture of matrix) {
+    appendFileSync(output + ".progress.jsonl", JSON.stringify({ stage: "start", id: fixture.id }) + "\n");
+    const row = await measure(api, fixture);
+    rows.push(row);
+    appendFileSync(output + ".progress.jsonl", JSON.stringify({ stage: "completed", row }) + "\n");
+  }
+  const after = snapshot(root);
+  assert.deepEqual(after, before);
+  assert.deepEqual(preflight(config), expected);
+  assert.deepEqual(runtime(root), identity);
+  assert.equal(sha(readFileSync(fixturePath)), FIXTURE_SHA);
+  writeFileSync(
+    output,
+    JSON.stringify(
+      {
+        schema: "promise-resolution-repair-public-v1",
+        provenance: {
+          label,
+          before,
+          after,
+          identity,
+          urls,
+          launch: launch(),
+          manifest: expected.manifest,
+          fixtureSha256: FIXTURE_SHA,
+          matrixSha256: sha(JSON.stringify(matrix)),
+        },
+        rows,
+      },
+      null,
+      2,
+    ),
+  );
+}
+function environmentReceipt(env: NodeJS.ProcessEnv) {
+  return Object.fromEntries(
+    Object.entries(env)
+      .filter(([key]) => /^(JS2WASM_|IR_VERIFY_|TSX_|ESBUILD_BINARY_PATH$|NODE_OPTIONS$|NODE_V8_COVERAGE$)/.test(key))
+      .sort(),
+  );
+}
+async function child(config: ReturnType<typeof argumentsOf>, label: "baseline" | "candidate") {
+  const root = config.roots[label],
+    output = join(config.output, label + ".json");
+  const loader = createRequire(join(root, "package.json")).resolve("tsx/esm");
+  const args = [
+    "--import",
+    loader,
+    instrument,
+    "--baseline",
+    config.roots.baseline,
+    "--candidate",
+    config.roots.candidate,
+    "--output",
+    config.output,
+    "--candidate-manifest",
+    config.manifestPath,
+    "--candidate-manifest-sha256",
+    config.manifestSha256,
+    "--arm",
+    label,
+  ];
+  const env = envFor(root),
+    launchReceipt = { root, label, exec: process.execPath, args, env: environmentReceipt(env), output };
+  const launchFile = join(config.output, label + ".launch.json");
+  writeFileSync(launchFile, JSON.stringify(launchReceipt, null, 2));
+  const stdout = openSync(join(config.output, label + ".stdout.log"), "wx"),
+    stderr = openSync(join(config.output, label + ".stderr.log"), "wx");
+  let terminal: any;
+  try {
+    terminal = await new Promise((resolveTerminal) => {
+      const processChild = spawn(process.execPath, args, { cwd: root, env, stdio: ["ignore", stdout, stderr] });
+      console.log(JSON.stringify({ stage: "child-start", label, pid: processChild.pid, output }));
+      let error: any = null;
+      processChild.once("error", (e) => {
+        error = data(e);
+      });
+      processChild.once("close", (code, signal) => resolveTerminal({ code, signal, error, pid: processChild.pid }));
+    });
+  } finally {
+    closeSync(stdout);
+    closeSync(stderr);
+  }
+  let reportSha256: string | null = null;
+  try {
+    reportSha256 = sha(readFileSync(output));
+  } catch {}
+  const receipt = { ...terminal, root, label, output, reportSha256, launchSha256: sha(readFileSync(launchFile)) };
+  writeFileSync(join(config.output, label + ".terminal.json"), JSON.stringify(receipt, null, 2));
+  console.log(JSON.stringify({ stage: "child-terminal", ...receipt }));
+  return receipt;
+}
+function differences(a: any, b: any, path = "$", out: any[] = []): any[] {
+  if (Object.is(a, b)) return out;
+  if (!a || !b || typeof a !== "object" || typeof b !== "object" || Array.isArray(a) !== Array.isArray(b)) {
+    out.push({ path, baseline: a, candidate: b });
+    return out;
+  }
+  for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) differences(a[key], b[key], path + "." + key, out);
+  return out;
+}
+function validate(
+  report: any,
+  label: "baseline" | "candidate",
+  expected: any,
+  roots: { baseline: string; candidate: string },
+) {
+  const p = report.provenance,
+    root = roots[label],
+    gaps: any[] = [];
+  assert.equal(report.schema, "promise-resolution-repair-public-v1");
+  assert.equal(p.label, label);
+  assert.deepEqual(p.before, expected[label]);
+  assert.deepEqual(p.after, p.before);
+  assert.deepEqual(p.identity, expected.identities[label]);
+  assert.deepEqual(p.identity, runtime(root));
+  assert.deepEqual(p.manifest, expected.manifest);
+  assert.equal(p.fixtureSha256, FIXTURE_SHA);
+  assert.equal(p.matrixSha256, sha(JSON.stringify(matrix)));
+  assert.deepEqual(p.urls, { compile: pathToFileURL(join(root, "src/index.ts")).href });
+  assert.deepEqual(p.launch.env, environmentReceipt(envFor(root)));
+  assert.deepEqual(p.launch.argv, ["--import", createRequire(join(root, "package.json")).resolve("tsx/esm")]);
+  assert.equal(report.rows.length, 24);
+  let observations = 0,
+    instances = 0,
+    executed = 0;
+  for (let i = 0; i < matrix.length; i++) {
+    const row = report.rows[i],
+      fixture = matrix[i];
+    assert.equal(row.id, fixture.id);
+    assert.deepEqual(row.fixture, fixture);
+    if (row.kind !== "executed") {
+      gaps.push({ id: row.id, kind: row.kind, phase: row.phase });
+      continue;
+    }
+    executed++;
+    assert.equal(row.compilations.length, 1);
+    const c = row.compilations[0],
+      e = c.artifact;
+    assert.equal(c.source, fixture.source);
+    assert.deepEqual(c.options, fixture.options);
+    assert.equal(c.success, true);
+    const mod = new WebAssembly.Module(Buffer.from(e.binary, "base64"));
+    assert.deepEqual(e.imports, WebAssembly.Module.imports(mod));
+    assert.deepEqual(e.imports, []);
+    assert.deepEqual(e.exports, WebAssembly.Module.exports(mod));
+    assert(e.wat.length > 0);
+    assert.equal(row.executions.length, 2);
+    let expectedOK = true;
+    for (let rep = 0; rep < 2; rep++) {
+      const execution = row.executions[rep];
+      assert.equal(execution.repetition, rep);
+      assert.equal(execution.instantiationInputBinary, e.binary);
+      assert.equal(execution.instantiatedBinary, e.binary);
+      instances++;
+      assert.equal(execution.actions.length, fixture.actions.length);
+      for (let n = 0; n < fixture.actions.length; n++) {
+        const a = execution.actions[n],
+          wanted = fixture.actions[n];
+        assert.equal(a.ordinal, n);
+        assert.equal(a.export, wanted.export);
+        assert.deepEqual(a.args, wanted.args);
+        observations++;
+        if (differences(a.value, wanted.expected).length) {
+          expectedOK = false;
+          gaps.push({
+            id: row.id,
+            repetition: rep,
+            export: a.export,
+            ordinal: n,
+            actual: a.value,
+            expected: wanted.expected,
+          });
+        }
+      }
+    }
+    assert.equal(row.expectedOK, expectedOK, "independently recomputed expectation verdict");
+  }
+  return {
+    executed,
+    requiredRows: 24,
+    compileAttempts: report.rows.length,
+    completedCompilationRecords: report.rows.reduce((n: number, row: any) => n + row.compilations.length, 0),
+    instances,
+    observations,
+    gaps,
+    ok: gaps.length === 0,
+  };
+}
+function historicalBaseline(report: any, measured: ReturnType<typeof validate>) {
+  // These are observed defects, NOT edits to the fixed semantic recipe.
+  // Parent baseline receipt SHA256 0021d12520b0ae0b1e0c8da639a4a655dc1047cd1bcbd79bd27d5b0e89329744.
+  const values = [1, 0, { $undefined: true }, 2, 0, 1, 99, 13184];
+  const gaps: any[] = [],
+    observations: any[] = [];
+  for (const mode of ["legacy", "ir"]) {
+    const id = "callable-getter-capture-trace-" + mode,
+      fixture = matrix.find((f: any) => f.id === id)!;
+    const row = report.rows.find((r: any) => r.id === id);
+    observations.push({ id, kind: row?.kind, actions: row?.executions?.map((e: any) => e.actions) });
+    for (let repetition = 0; repetition < 2; repetition++)
+      for (let ordinal = 0; ordinal < values.length; ordinal++) {
+        if (differences(values[ordinal], fixture.actions[ordinal].expected).length)
+          gaps.push({
+            id,
+            repetition,
+            export: fixture.actions[ordinal].export,
+            ordinal,
+            actual: values[ordinal],
+            expected: fixture.actions[ordinal].expected,
+          });
+      }
+  }
+  return {
+    ok:
+      measured.executed === 24 &&
+      measured.instances === 48 &&
+      measured.observations === 92 &&
+      differences(measured.gaps, gaps).length === 0,
+    expectedHistoricalValues: values,
+    expectedGaps: gaps,
+    observations,
+  };
+}
+function terminalValid(terminal: any, label: "baseline" | "candidate", config: ReturnType<typeof argumentsOf>) {
+  assert(terminal && Number.isInteger(terminal.pid) && terminal.pid > 0, "actual terminal PID");
+  assert.equal(terminal.label, label);
+  assert.equal(terminal.root, config.roots[label]);
+  assert.equal(terminal.output, join(config.output, label + ".json"));
+  assert.equal(terminal.code, 0);
+  assert.equal(terminal.signal, null);
+  assert.equal(terminal.error, null);
+  assert.equal(terminal.reportSha256, sha(readFileSync(terminal.output)));
+  const launchFile = join(config.output, label + ".launch.json");
+  assert.equal(terminal.launchSha256, sha(readFileSync(launchFile)));
+  const receipt = JSON.parse(readFileSync(launchFile, "utf8"));
+  const root = config.roots[label],
+    loader = createRequire(join(root, "package.json")).resolve("tsx/esm");
+  assert.deepEqual(receipt, {
+    root,
+    label,
+    exec: process.execPath,
+    args: [
+      "--import",
+      loader,
+      instrument,
+      "--baseline",
+      config.roots.baseline,
+      "--candidate",
+      config.roots.candidate,
+      "--output",
+      config.output,
+      "--candidate-manifest",
+      config.manifestPath,
+      "--candidate-manifest-sha256",
+      config.manifestSha256,
+      "--arm",
+      label,
+    ],
+    env: environmentReceipt(envFor(root)),
+    output: terminal.output,
+  });
+}
+function negativeControls(a: any, b: any, expected: any, config: ReturnType<typeof argumentsOf>, terminals: any[]) {
+  const negatives: any[] = [];
+  const mustReject = (name: string, operation: () => unknown) => {
+    assert.throws(operation);
+    negatives.push({ name, rejected: true });
+  };
+  const clone = (mutate: (x: any) => void) => {
+    const x = structuredClone(b);
+    mutate(x);
+    return x;
+  };
+  mustReject("drop-row", () =>
+    validate(
+      clone((x) => x.rows.pop()),
+      "candidate",
+      expected,
+      config.roots,
+    ),
+  );
+  mustReject("wrong-root", () => validate(a, "candidate", expected, config.roots));
+  mustReject("changed-provenance", () =>
+    validate(
+      clone((x) => (x.provenance.identity.node = "stale")),
+      "candidate",
+      expected,
+      config.roots,
+    ),
+  );
+  const index = b.rows.findIndex((r: any) => r.kind === "executed");
+  assert(index >= 0, "nonempty comparator positive");
+  mustReject("changed-instantiation-byte", () =>
+    validate(
+      clone((x) => (x.rows[index].executions[0].instantiatedBinary += "AA")),
+      "candidate",
+      expected,
+      config.roots,
+    ),
+  );
+  const wrong = clone((x) => {
+    x.rows[index].executions[0].actions[0].value = { $wrong: true };
+    x.rows[index].expectedOK = false;
+  });
+  assert.equal(validate(wrong, "candidate", expected, config.roots).ok, false);
+  assert(differences(b.rows, wrong.rows).length > 0);
+  negatives.push({ name: "wrong-value-cannot-pass-semantic-acceptance", rejected: true });
+  const changed = clone((x) => x.rows[index].compilations[0].errors.push({ message: "changed outcome" }));
+  // Compare against the unmutated same arm, not already-different baseline bytes.
+  assert(differences(b.rows, changed.rows).length > 0);
+  negatives.push({ name: "changed-outcome-not-equal", rejected: true });
+  const manifest = readPinnedManifest(config.manifestPath, config.manifestSha256, config.roots);
+  mustReject("stale-manifest-digest", () => readPinnedManifest(config.manifestPath, "0".repeat(64), config.roots));
+  for (const [name, mutate] of [
+    [
+      "changed-candidate-census",
+      (m: any) => {
+        m.candidate.files.pop();
+      },
+    ],
+    [
+      "missing-source-difference",
+      (m: any) => {
+        m.difference.pop();
+      },
+    ],
+    [
+      "changed-producer-freeze",
+      (m: any) => {
+        m.producer.sha256 = "0".repeat(64);
+      },
+    ],
+  ] as const) {
+    const altered = structuredClone(manifest);
+    mutate(altered);
+    mustReject(name, () => assertManifestCurrent(altered, config.roots));
+  }
+  for (const [name, altered] of [
+    ["missing-terminal", null],
+    ["nonzero-terminal", { ...terminals[1], code: 13 }],
+    ["signalled-terminal", { ...terminals[1], signal: "SIGTERM" }],
+  ] as const)
+    mustReject(name, () => terminalValid(altered, "candidate", config));
+  const baselinePassed = structuredClone(a);
+  for (const row of baselinePassed.rows)
+    if (row.id.startsWith("callable-getter-capture-trace-")) {
+      for (const execution of row.executions)
+        for (let i = 0; i < execution.actions.length; i++) execution.actions[i].value = row.fixture.actions[i].expected;
+      row.expectedOK = true;
+    }
+  assert.equal(
+    historicalBaseline(baselinePassed, validate(baselinePassed, "baseline", expected, config.roots)).ok,
+    false,
+  );
+  negatives.push({ name: "missing-historical-defect-not-repair-evidence", rejected: true });
+  return negatives;
+}
+async function pair(config: ReturnType<typeof argumentsOf>) {
+  const load = loadavg();
+  assert.equal(load.length, 3);
+  assert(
+    load.every((n) => Number.isFinite(n) && n >= 0),
+    "fresh finite nonnegative load check",
+  );
+  const expected = preflight(config);
+  mkdirSync(config.output, { recursive: false });
+  writeFileSync(
+    join(config.output, "expected.json"),
+    JSON.stringify(
+      {
+        roots: config.roots,
+        expected,
+        matrix,
+        fixtureSha256: FIXTURE_SHA,
+        harnessSha256: sha(readFileSync(instrument)),
+        load,
+      },
+      null,
+      2,
+    ),
+  );
+  const terminals = [];
+  for (const label of ["baseline", "candidate"] as const) terminals.push(await child(config, label));
+  for (const [i, label] of (["baseline", "candidate"] as const).entries()) terminalValid(terminals[i], label, config);
+  const a = JSON.parse(readFileSync(terminals[0].output, "utf8")),
+    b = JSON.parse(readFileSync(terminals[1].output, "utf8"));
+  const baseline = validate(a, "baseline", expected, config.roots),
+    candidate = validate(b, "candidate", expected, config.roots);
+  const rawDifferences = differences(a.rows, b.rows);
+  const preservationOK = rawDifferences.length === 0,
+    semanticOK = baseline.ok && candidate.ok;
+  const historical = historicalBaseline(a, baseline);
+  const comparison: any = {
+    schema: "promise-resolution-repair-public-pair-v1",
+    preservationOK,
+    semanticOK,
+    candidateSemanticsOK: candidate.ok,
+    baselineDefectObserved: historical.ok,
+    repairAcceptanceOK: false,
+    denominator: { recipes: 12, modes: 2, pairs: 24, rows: 48, compiles: 48, instances: 96, exportObservations: 184 },
+    baseline,
+    candidate,
+    historical,
+    rawDifferences,
+    rowTransitions: a.rows.map((row: any, i: number) => ({
+      id: row.id,
+      baseline: { kind: row.kind, expectedOK: row.expectedOK },
+      candidate: { kind: b.rows[i].kind, expectedOK: b.rows[i].expectedOK },
+      rawEqual: differences(row, b.rows[i]).length === 0,
+    })),
+    negativeControls: [],
+    negativeControlsComplete: false,
+    terminals,
+  };
+  const reportPath = join(config.output, "comparison.json");
+  // Preserve all real rows/deltas even if a comparator control itself fails.
+  writeFileSync(reportPath, JSON.stringify(comparison, null, 2));
+  try {
+    comparison.negativeControls = negativeControls(a, b, expected, config, terminals);
+    comparison.negativeControlsComplete = true;
+    assert.deepEqual(preflight(config), expected);
+    comparison.repairAcceptanceOK = candidate.ok && historical.ok;
+  } catch (error) {
+    comparison.repairAcceptanceOK = false;
+    comparison.instrumentFailure = data(error);
+  }
+  writeFileSync(reportPath, JSON.stringify(comparison, null, 2));
+  console.log(
+    JSON.stringify({
+      stage: "comparison",
+      preservationOK,
+      semanticOK,
+      candidateSemanticsOK: candidate.ok,
+      baselineDefectObserved: historical.ok,
+      repairAcceptanceOK: comparison.repairAcceptanceOK,
+      negativeControlsComplete: comparison.negativeControlsComplete,
+      baseline,
+      candidate,
+      rawDifferenceCount: rawDifferences.length,
+    }),
+  );
+  if (!comparison.repairAcceptanceOK) process.exitCode = 1;
+}
+const config = argumentsOf(process.argv.slice(2));
+try {
+  if (config.arm) await arm(config);
+  else await pair(config);
+} catch (error) {
+  if (config.arm) writeFileSync(join(config.output, config.arm + ".fatal.json"), JSON.stringify(data(error), null, 2));
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/src/backend/wasmgc/resources/native-promises.ts
+++ b/src/backend/wasmgc/resources/native-promises.ts
@@ -41,6 +41,8 @@ import {
 import {
   buildPromisePeelValue,
   buildPromiseThenableClassifier,
+  buildPromiseThenableLookup,
+  type PromiseThenableInventory,
 } from "../../../runtime/wasmgc/promise/thenable-bodies.js";
 
 type Tag = TagReservation | TagImportReservation;
@@ -84,6 +86,7 @@ export interface NativePromiseReservations {
     readonly resolveValue: FunctionReservation;
     readonly peel: FunctionReservation;
     readonly classifier: FunctionReservation;
+    readonly lookupThen: FunctionReservation;
     readonly thenableJob: FunctionReservation;
     readonly resolveClosure: FunctionReservation;
     readonly rejectClosure: FunctionReservation;
@@ -290,6 +293,7 @@ export function reserveNativePromiseResources(
   const rejectClosure = reserve("reject-closure", "__promise_reject_cl", trampoline);
   const peel = reserve("peel", "__promise_peel_value", { params: [EXTERN], results: [EXTERN] });
   const classifier = reserve("classifier", "__promise_has_callable_then", { params: [EXTERN], results: [I32] });
+  const lookupThen = reserve("lookup-then", "__promise_lookup_then", { params: [EXTERN], results: [I32, EXTERN] });
   const thenableJob = reserve("thenable-job", "__promise_thenable_job", callbackSignature);
   const result: NativePromiseReservations = Object.freeze({
     types: Object.freeze({
@@ -320,6 +324,7 @@ export function reserveNativePromiseResources(
       resolveValue,
       peel,
       classifier,
+      lookupThen,
       thenableJob,
       resolveClosure,
       rejectClosure,
@@ -343,6 +348,25 @@ export function reserveNativePromiseResources(
     filled: false,
   });
   return result;
+}
+
+function promiseQueueReservations(
+  tx: PhysicalModuleReservations,
+  pack: NativePromiseReservations,
+): PreparedNativeMicrotaskReservations {
+  const t = pack.types;
+  return {
+    types: {
+      functions: { kind: "type", index: t.functions.typeIndex },
+      arguments: { kind: "type", index: t.arguments.typeIndex },
+      callback: { kind: "type", index: t.callbackSignature },
+    },
+    globals: Object.fromEntries(
+      Object.entries(pack.globals).map(([name, token]) => [name, { kind: "global", index: tx.physicalIndex(token) }]),
+    ) as PreparedNativeMicrotaskReservations["globals"],
+    grow: { kind: "function", index: pack.functions.grow.handle },
+    initialCapacity: 8192,
+  };
 }
 
 /** No fallback: resolution/classification/value dependencies must all be real same-ledger reservations. */
@@ -519,18 +543,7 @@ export function fillNativePromiseResources(
   }
   const f = pack.functions,
     t = pack.types;
-  const queue: PreparedNativeMicrotaskReservations = {
-    types: {
-      functions: { kind: "type", index: t.functions.typeIndex },
-      arguments: { kind: "type", index: t.arguments.typeIndex },
-      callback: { kind: "type", index: t.callbackSignature },
-    },
-    globals: Object.fromEntries(
-      Object.entries(pack.globals).map(([name, token]) => [name, { kind: "global", index: tx.physicalIndex(token) }]),
-    ) as PreparedNativeMicrotaskReservations["globals"],
-    grow: { kind: "function", index: f.grow.handle },
-    initialCapacity: 8192,
-  };
+  const queue = promiseQueueReservations(tx, pack);
   const cap = {
     capTypeIdx: t.settleCapture.typeIndex,
     capMetaTypeIdx: owner.dependencies.settleMetadata.typeIndex,
@@ -554,6 +567,7 @@ export function fillNativePromiseResources(
     capsFields: { callback: 0, chained: 1 },
     thenable: {
       hasCallableThenFuncIdx: f.classifier.handle,
+      lookupThenFuncIdx: f.lookupThen.handle,
       thenableJobFuncIdx: f.thenableJob.handle,
       peelValueFuncIdx: f.peel.handle,
       newTypeErrorFuncIdx: newTypeError,
@@ -567,7 +581,7 @@ export function fillNativePromiseResources(
     typeofFunctionIdx: typeofFunction,
     callableRootTypeIdx: owner.dependencies.closureRoot.typeIndex,
   });
-  const classifier = buildPromiseThenableClassifier({
+  const thenableInventory: PromiseThenableInventory = {
     finalized: true,
     peelFuncIdx: f.peel.handle,
     methodTypeIdxs: methods,
@@ -576,7 +590,9 @@ export function fillNativePromiseResources(
     fields,
     closureWrapperTypeIdxs: closures,
     openObject: { typeIdx: objectType, externGetFuncIdx: objectGet, thenStringInstrs: thenString },
-  });
+  };
+  const classifier = buildPromiseThenableClassifier(thenableInventory);
+  const lookupThen = buildPromiseThenableLookup(thenableInventory);
   const job = buildPromiseThenableJob({
     target,
     promiseTypeIdx: t.promise.typeIndex,
@@ -637,6 +653,7 @@ export function fillNativePromiseResources(
     buildPromisePeelValue({ typeIdx: anyType, tagFieldIdx: av.tag, refFieldIdx: av.ref, externFieldIdx: av.extern }),
   );
   tx.fillFunction(f.classifier, classifier);
+  tx.fillFunction(f.lookupThen, lookupThen);
   tx.fillFunction(f.thenableJob, job);
   tx.fillFunction(f.resolveClosure, { locals: [], body: buildPromiseSettleClosureBody(cap, f.resolveValue.handle) });
   tx.fillFunction(f.rejectClosure, { locals: [], body: buildPromiseSettleClosureBody(cap, f.reject.handle) });

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -44,6 +44,7 @@ import { ensureBuiltinFnMetaType } from "./builtin-fn-meta.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { reserveClosedMethodDispatchVararg } from "./closed-method-dispatch.js";
+import { reservePromiseThenableValueHelpers } from "./promise-thenable-lookup.js";
 // (#4394) Dynamic `.then` handler wrappers invoke a runtime-held callback via
 // the `__apply_closure` arity bridge; the args carrier is the runtime's own
 // $ObjVec. Cycle-safe: object-runtime.ts does not import this module.
@@ -937,6 +938,7 @@ export function ensurePromiseExecutorClosures(ctx: CodegenContext): PromiseExecu
  */
 interface PromiseThenableSubstrate {
   hasCallableThenFuncIdx: number;
+  lookupThenFuncIdx: number;
   thenableJobFuncIdx: number;
   /**
    * `__promise_peel_value(value) -> externref` — unwraps a `$AnyValue`-boxed
@@ -1007,19 +1009,7 @@ function ensurePromiseThenableSubstrate(
   });
   ctx.funcMap.set("__promise_has_callable_then", hasCallableThenFuncIdx);
 
-  // __promise_peel_value(value: externref) -> externref — reserved; filled at
-  // finalize (needs `$AnyValue`, whose typeIdx may not exist yet). IDENTITY
-  // placeholder: raw (unboxed) values are classified/dispatched unchanged.
-  const peelTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }], "$__promise_peel_type");
-  const peelValueFuncIdx = mintDefinedFunc(ctx);
-  pushDefinedFunc(ctx, peelValueFuncIdx, {
-    name: "__promise_peel_value",
-    typeIdx: peelTypeIdx,
-    locals: [],
-    body: [{ op: "local.get", index: 0 }],
-    exported: false,
-  });
-  ctx.funcMap.set("__promise_peel_value", peelValueFuncIdx);
+  const { peelValueFuncIdx, lookupThenFuncIdx } = reservePromiseThenableValueHelpers(ctx);
   ctx.promiseThenableReserved = true;
 
   // __promise_thenable_job(capsRaw: externref, thenable: externref) -> externref
@@ -1053,6 +1043,7 @@ function ensurePromiseThenableSubstrate(
 
   const result: PromiseThenableSubstrate = {
     hasCallableThenFuncIdx,
+    lookupThenFuncIdx,
     thenableJobFuncIdx,
     peelValueFuncIdx,
     newTypeErrorFuncIdx,

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -1,4 +1,5 @@
-import { buildPromisePeelValue, buildPromiseThenableClassifier } from "../runtime/wasmgc/promise/thenable-bodies.js";
+import { buildPromisePeelValue } from "../runtime/wasmgc/promise/thenable-bodies.js";
+import { finalizePromiseThenableLookup } from "./promise-thenable-lookup.js";
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
  * #2151 — standalone any-receiver method dispatch over CLOSED object-literal
@@ -2032,8 +2033,8 @@ export function fillPromiseThenableHelpers(ctx: CodegenContext): void {
   const fields = collectFieldEntries(ctx, "then");
   const externGetIdx = ctx.funcMap.get("__extern_get");
   const objectTypeIdx = ctx.objectRuntimeTypes?.objectTypeIdx;
-  const result = buildPromiseThenableClassifier({
-    finalized: true,
+  const inventory = {
+    finalized: true as const,
     peelFuncIdx: peelIdx,
     methodTypeIdxs,
     accessors,
@@ -2048,7 +2049,6 @@ export function fillPromiseThenableHelpers(ctx: CodegenContext): void {
             thenStringInstrs: stringConstantExternrefInstrs(ctx, "then"),
           }
         : null,
-  });
-  predFn.locals = result.locals;
-  predFn.body = result.body;
+  };
+  finalizePromiseThenableLookup(ctx, predFn, inventory);
 }

--- a/src/codegen/promise-thenable-lookup.ts
+++ b/src/codegen/promise-thenable-lookup.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// Legacy registration adapter only; executable bodies remain canonical runtime code.
+import type { WasmFunction } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { addFuncType } from "./registry/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import {
+  buildPromiseThenableClassifier,
+  buildPromiseThenableLookup,
+  type PromiseThenableInventory,
+} from "../runtime/wasmgc/promise/thenable-bodies.js";
+
+/** Reserve in the scheduler's original order, before publishing the substrate. */
+export function reservePromiseThenableValueHelpers(ctx: CodegenContext): {
+  peelValueFuncIdx: number;
+  lookupThenFuncIdx: number;
+} {
+  // __promise_peel_value(value: externref) -> externref — reserved; filled at
+  // finalize (needs `$AnyValue`, whose typeIdx may not exist yet). IDENTITY
+  // placeholder: raw (unboxed) values are classified/dispatched unchanged.
+  const peelTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }], "$__promise_peel_type");
+  const peelValueFuncIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, peelValueFuncIdx, {
+    name: "__promise_peel_value",
+    typeIdx: peelTypeIdx,
+    locals: [],
+    body: [{ op: "local.get", index: 0 }],
+    exported: false,
+  });
+  ctx.funcMap.set("__promise_peel_value", peelValueFuncIdx);
+  const lookupTypeIdx = addFuncType(
+    ctx,
+    [{ kind: "externref" }],
+    [{ kind: "i32" }, { kind: "externref" }],
+    "$__promise_lookup_then_type",
+  );
+  const lookupThenFuncIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, lookupThenFuncIdx, {
+    name: "__promise_lookup_then",
+    typeIdx: lookupTypeIdx,
+    locals: [],
+    body: [{ op: "unreachable" }],
+    exported: false,
+  });
+  ctx.funcMap.set("__promise_lookup_then", lookupThenFuncIdx);
+  return { peelValueFuncIdx, lookupThenFuncIdx };
+}
+
+/** Inventory collection and the original early guards remain in the driver. */
+export function finalizePromiseThenableLookup(
+  ctx: CodegenContext,
+  predFn: WasmFunction,
+  inventory: PromiseThenableInventory,
+): void {
+  const result = buildPromiseThenableClassifier(inventory);
+  predFn.locals = result.locals;
+  predFn.body = result.body;
+  const lookupIdx = ctx.funcMap.get("__promise_lookup_then");
+  const lookupFn = lookupIdx === undefined ? undefined : definedFuncAt(ctx, lookupIdx);
+  if (lookupFn) {
+    const lookup = buildPromiseThenableLookup(inventory);
+    lookupFn.locals = lookup.locals;
+    lookupFn.body = lookup.body;
+  }
+}

--- a/src/runtime/wasmgc/promise/resolution-bodies.ts
+++ b/src/runtime/wasmgc/promise/resolution-bodies.ts
@@ -5,6 +5,7 @@ import { PROMISE_STATE_FULFILLED, PROMISE_STATE_REJECTED } from "./settlement-bo
 
 export interface PromiseResolutionBindings {
   readonly hasCallableThenFuncIdx: FuncHandle;
+  readonly lookupThenFuncIdx: FuncHandle;
   readonly thenableJobFuncIdx: FuncHandle;
   readonly peelValueFuncIdx: FuncHandle;
   readonly newTypeErrorFuncIdx: FuncHandle;
@@ -44,6 +45,7 @@ export function buildNativePromiseResolveValueBody(
     throw new Error("Native Promise resolution requires complete thenable and TypeError bindings");
   for (const handle of [
     resources.thenable.hasCallableThenFuncIdx,
+    resources.thenable.lookupThenFuncIdx,
     resources.thenable.thenableJobFuncIdx,
     resources.thenable.peelValueFuncIdx,
     resources.thenable.newTypeErrorFuncIdx,
@@ -65,6 +67,18 @@ export function buildPromiseResolveValueLocals(promiseTypeIdx: TypeHandle): Loca
     { name: "$peeled", type: { kind: "externref" } },
     // (#5197 R3-5) The own `then` read off a native `$Promise` resolution.
     { name: "$bagThen", type: { kind: "externref" } },
+  ];
+}
+
+function buildResolutionPeelPrelude(
+  thenable: PromiseResolutionBindings | null,
+  valueLocal: number,
+  peeledLocal: number,
+): Instr[] {
+  return [
+    { op: "local.get", index: valueLocal },
+    ...(thenable === null ? [] : [{ op: "call", funcIdx: thenable.peelValueFuncIdx } as Instr]),
+    { op: "local.set", index: peeledLocal },
   ];
 }
 
@@ -114,6 +128,8 @@ export function buildPromiseResolveValueBody(resources: PromiseResolveValueResou
   const hasThenLocal = 4;
   const reasonLocal = 5;
   const poisonedLocal = 6;
+  // Reuse the existing own-then scratch local; each invocation has its own frame.
+  const capturedThenLocal = 8;
 
   // (#3125) The non-$Promise arm: thenable check + job enqueue, or direct
   // fulfil. Falls back to the pre-#3125 direct fulfil when the substrate is
@@ -127,7 +143,7 @@ export function buildPromiseResolveValueBody(resources: PromiseResolveValueResou
           { op: "call", funcIdx: state.promiseFulfillFuncIdx },
         ]
       : [
-          // hasThen = __promise_has_callable_then(value) — the Get("then") runs
+          // (hasThen, capturedThen) = __promise_lookup_then(value). Get("then") runs
           // accessors, so a poisoned getter THROWS here (§27.2.1.3.2 step 9):
           // catch → reject(promise, thrown).
           buildTargetTaggedTry(
@@ -135,7 +151,8 @@ export function buildPromiseResolveValueBody(resources: PromiseResolveValueResou
             { kind: "empty" },
             [
               { op: "local.get", index: valueLocal },
-              { op: "call", funcIdx: thenable.hasCallableThenFuncIdx },
+              { op: "call", funcIdx: thenable.lookupThenFuncIdx },
+              { op: "local.set", index: capturedThenLocal },
               { op: "local.set", index: hasThenLocal },
             ],
             [
@@ -166,11 +183,11 @@ export function buildPromiseResolveValueBody(resources: PromiseResolveValueResou
                 blockType: { kind: "val", type: { kind: "externref" } },
                 then: [
                   // Callable then: enqueue PromiseResolveThenableJob(promise,
-                  // value, then). caps = $__then_caps{callback: null, chained:
+                  // value, then). caps = $__then_caps{callback: capturedThen, chained:
                   // promise}; the thenable rides the job's value slot (step 14
                   // — the then CALL happens as a job, never inline).
                   { op: "ref.func", funcIdx: thenable.thenableJobFuncIdx },
-                  { op: "ref.null.extern" },
+                  { op: "local.get", index: capturedThenLocal },
                   { op: "local.get", index: promiseLocal },
                   { op: "struct.new", typeIdx: capsTypeIdx },
                   { op: "extern.convert_any" },
@@ -222,17 +239,7 @@ export function buildPromiseResolveValueBody(resources: PromiseResolveValueResou
   // deliver the ORIGINAL `value`, preserving identity across the promise.
   // (Placeholder peel = identity, so pre-fill behaviour is unchanged.)
   const peeledLocal = 7;
-  const peelPrelude: Instr[] =
-    thenable === null
-      ? [
-          { op: "local.get", index: valueLocal },
-          { op: "local.set", index: peeledLocal },
-        ]
-      : [
-          { op: "local.get", index: valueLocal },
-          { op: "call", funcIdx: thenable.peelValueFuncIdx },
-          { op: "local.set", index: peeledLocal },
-        ];
+  const peelPrelude = buildResolutionPeelPrelude(thenable, valueLocal, peeledLocal);
 
   // (#5197 R3-5) §27.2.1.3.2 steps 8-13 run `Get(resolution, "then")` for EVERY
   // object, including a native promise. The `$Promise` arm below adopts the
@@ -505,8 +512,8 @@ export function buildPromiseThenableJob(resources: PromiseThenableJobResources):
     // res, rej)`. The peel unwraps an `$AnyValue`-boxed resolution so the
     // dispatcher's `ref.test` arms (closed structs / `$Object`) see the RAW
     // object as the receiver.
-    // (#5197 R3-5) When Resolve captured the `then` FUNCTION (an own `then` on
-    // a native promise), call THAT value — the spec captures `then` at Resolve
+    // When Resolve captured the `then` FUNCTION (ordinary lookup or own `then`
+    // on a native promise), call THAT value — the spec captures `then` at Resolve
     // time (step 9) and calls it as a job (step 14), so a reassignment between
     // the two must not change which function runs. Otherwise re-dispatch
     // through the vararg `then` method dispatcher exactly as before.

--- a/src/runtime/wasmgc/promise/thenable-bodies.ts
+++ b/src/runtime/wasmgc/promise/thenable-bodies.ts
@@ -97,6 +97,24 @@ export function buildPromiseThenableClassifier(resources: PromiseThenableInvento
   locals: LocalDef[];
   body: Instr[];
 } {
+  return buildThenableLookup(resources, false);
+}
+
+/** Return (callable, capturedThen); null captures denote compiled-method dispatch. */
+export function buildPromiseThenableLookup(resources: PromiseThenableInventory): {
+  locals: LocalDef[];
+  body: Instr[];
+} {
+  return buildThenableLookup(resources, true);
+}
+
+function buildThenableLookup(
+  resources: PromiseThenableInventory,
+  capture: boolean,
+): {
+  locals: LocalDef[];
+  body: Instr[];
+} {
   if (
     resources.finalized !== true ||
     !Array.isArray(resources.methodTypeIdxs) ||
@@ -120,6 +138,14 @@ export function buildPromiseThenableClassifier(resources: PromiseThenableInvento
   const peeledLocalIdx = 1; // param 0 = value externref
   const anyLocalIdx = 2;
   const thenAnyLocalIdx = 3;
+  const capturedThenLocalIdx = 4;
+  const verdict = (callable: 0 | 1, captured = false): Instr[] => [
+    { op: "i32.const", value: callable },
+    ...(capture
+      ? [captured ? ({ op: "local.get", index: capturedThenLocalIdx } as Instr) : ({ op: "ref.null.extern" } as Instr)]
+      : []),
+    { op: "return" },
+  ];
   const body: Instr[] = [
     // peeled = __promise_peel_value(value) — classify the RAW payload.
     { op: "local.get", index: 0 },
@@ -131,7 +157,7 @@ export function buildPromiseThenableClassifier(resources: PromiseThenableInvento
     {
       op: "if",
       blockType: { kind: "empty" },
-      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      then: verdict(0),
     },
     { op: "local.get", index: peeledLocalIdx },
     { op: "any.convert_extern" },
@@ -142,15 +168,15 @@ export function buildPromiseThenableClassifier(resources: PromiseThenableInvento
   // base wrappers; 1 on a hit, else 0.
   const closureTest = (loadThen: Instr[]): Instr[] => [
     ...loadThen,
+    ...(capture ? [{ op: "local.tee", index: capturedThenLocalIdx } as Instr] : []),
     { op: "any.convert_extern" },
     { op: "local.set", index: thenAnyLocalIdx },
     ...closureWrapperTypeIdxs.flatMap((typeIdx): Instr[] => [
       { op: "local.get", index: thenAnyLocalIdx },
       { op: "ref.test", typeIdx },
-      { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 1 }, { op: "return" }] },
+      { op: "if", blockType: { kind: "empty" }, then: verdict(1, true) },
     ]),
-    { op: "i32.const", value: 0 },
-    { op: "return" },
+    ...verdict(0),
   ];
 
   // Closed-struct METHOD arms — a compiled `then` method is always callable.
@@ -163,7 +189,7 @@ export function buildPromiseThenableClassifier(resources: PromiseThenableInvento
     body.push({
       op: "if",
       blockType: { kind: "empty" },
-      then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+      then: verdict(1),
     });
   }
 
@@ -239,10 +265,12 @@ export function buildPromiseThenableClassifier(resources: PromiseThenableInvento
   }
 
   body.push({ op: "i32.const", value: 0 });
+  if (capture) body.push({ op: "ref.null.extern" });
   const locals: LocalDef[] = [
     { name: "__peeled", type: { kind: "externref" } },
     { name: "__any", type: { kind: "anyref" } },
     { name: "__thenAny", type: { kind: "anyref" } },
   ];
+  if (capture) locals.push({ name: "__capturedThen", type: { kind: "externref" } });
   return { locals, body };
 }

--- a/tests/issue-3518-native-promise-resources.test.ts
+++ b/tests/issue-3518-native-promise-resources.test.ts
@@ -250,7 +250,7 @@ describe("reservation-only Promise pack controls; missing native dependencies re
       "__mt_caps",
       "__mt_args",
     ]);
-    expect(module.functions.slice(0, 8).map((fn) => fn.name)).toEqual([
+    expect(module.functions.map((fn) => fn.name)).toEqual([
       "__microtask_grow",
       "__microtask_enqueue",
       "__drain_microtasks",
@@ -259,8 +259,33 @@ describe("reservation-only Promise pack controls; missing native dependencies re
       "__then_identity_fulfill",
       "__then_identity_reject",
       "__promise_resolve_value",
+      "__promise_resolve_cl",
+      "__promise_reject_cl",
+      "__promise_peel_value",
+      "__promise_has_callable_then",
+      "__promise_lookup_then",
+      "__promise_thenable_job",
     ]);
-    expect(new Set(Object.values(pack.functions).map((fn) => fn.object)).size).toBe(13);
+    expect(new Set(Object.values(pack.functions).map((fn) => fn.object)).size).toBe(14);
+    expect(pack.functions.lookupThen.object).toMatchObject({
+      name: "__promise_lookup_then",
+      body: [],
+    });
+    expect(module.types[pack.functions.lookupThen.object.typeIdx]).toMatchObject({
+      kind: "func",
+      params: [{ kind: "externref" }],
+      results: [{ kind: "i32" }, { kind: "externref" }],
+    });
+    expect(pack.functions.classifier.object).toMatchObject({
+      name: "__promise_has_callable_then",
+      body: [],
+    });
+    expect(module.types[pack.functions.classifier.object.typeIdx]).toMatchObject({
+      kind: "func",
+      params: [{ kind: "externref" }],
+      results: [{ kind: "i32" }],
+    });
+    expect(pack.functions.lookupThen.object).not.toBe(pack.functions.classifier.object);
     expect(tx.state).toBe("reserving");
     tx.freezeReservations();
     expect(() => tx.seal()).toThrow("missing global fill");

--- a/tests/issue-3518-promise-getter-capture.test.ts
+++ b/tests/issue-3518-promise-getter-capture.test.ts
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Same compiler controls as immutable public comparison controller 76198.
+const controls = {
+  JS2WASM_IR_GVN: "0",
+  JS2WASM_IR_OWNERSHIP: "0",
+  JS2WASM_IR_ESCAPE: "0",
+  IR_VERIFY_ALLOC: "0",
+  JS2WASM_IR_VERIFY_DOMINANCE_NAIVE: "0",
+  JS2WASM_IR_INLINE: "0",
+};
+let compile: typeof import("../src/index.js").compile;
+beforeAll(async () => {
+  for (const key of Object.keys(process.env)) if (/^(JS2WASM_|IR_VERIFY_)/.test(key)) vi.stubEnv(key, undefined);
+  for (const [key, value] of Object.entries(controls)) vi.stubEnv(key, value);
+  ({ compile } = await import("../src/index.js"));
+}, 60_000);
+afterAll(() => vi.unstubAllEnvs());
+
+const prelude = `
+declare function __drain_microtasks(): void;
+const s: any = { getter: 0, original: 0, replacement: 0, value: 0, trace: 0, receiver: 0 };
+export function getter(): number { return s.getter; }
+export function original(): number { return s.original; }
+export function replacement(): number { return s.replacement; }
+export function value(): number { return s.value; }
+export function trace(): number { return s.trace; }
+export function receiver(): number { return s.receiver; }
+`;
+
+async function runStandalone(body: string, experimentalIR: boolean) {
+  for (const [key, value] of Object.entries(controls)) expect(process.env[key], key).toBe(value);
+  const result = await compile(prelude + "\nexport function test(): void {\n" + body + "\n}", {
+    fileName: "issue-3518-promise-getter-capture.ts",
+    target: "standalone",
+    nativeStrings: true,
+    experimentalIR,
+    skipSemanticDiagnostics: false,
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  const module = await WebAssembly.compile(result.binary);
+  expect(WebAssembly.Module.imports(module), "native regression must not call host helpers").toEqual([]);
+  const instance = await WebAssembly.instantiate(module, {});
+  const exports = instance.exports as Record<string, () => number>;
+  exports.test!();
+  return Object.fromEntries(
+    ["getter", "original", "replacement", "value", "trace", "receiver"].map((name) => [name, exports[name]!()]),
+  );
+}
+
+describe.each([false, true])("ordinary Promise then is captured once (experimentalIR=%s)", (experimentalIR) => {
+  const run = (body: string) => runStandalone(body, experimentalIR);
+  it("reads synchronously and invokes the original getter result later with its receiver", async () => {
+    expect(
+      await run(`
+      const o: any = { tag: 42 };
+      const first: any = function (this: any, resolve: any) {
+        s.original++; s.trace = s.trace * 10 + 2;
+        s.receiver = this === o ? 1 : 0; resolve(this.tag);
+      };
+      const replacement: any = function (resolve: any) { s.replacement++; resolve(99); };
+      Object.defineProperty(o, "then", { configurable: true, get: function () {
+        s.getter++; s.trace = s.trace * 10 + 1; return first;
+      } });
+      new Promise(function (resolve: any) { resolve(o); }).then(function (v: any) {
+        s.value = v; s.trace = s.trace * 10 + 4;
+      });
+      Object.defineProperty(o, "then", { configurable: true, get: function () {
+        s.getter++; return replacement;
+      } });
+      s.trace = s.trace * 10 + 3;
+      __drain_microtasks();
+    `),
+    ).toEqual({ getter: 1, original: 1, replacement: 0, value: 42, trace: 1324, receiver: 1 });
+  });
+
+  it("keeps a poisoned getter's exact reason and does not invoke a replacement", async () => {
+    expect(
+      await run(`
+      const reason: any = { marker: 71 };
+      const o: any = {};
+      Object.defineProperty(o, "then", { configurable: true, get: function () {
+        s.getter++; throw reason;
+      } });
+      new Promise(function (resolve: any) { resolve(o); }).then(
+        function () { s.value = -1; },
+        function (caught: any) { s.value = caught === reason ? 42 : -2; });
+      Object.defineProperty(o, "then", { value: function (resolve: any) {
+        s.replacement++; resolve(99);
+      } });
+      __drain_microtasks();
+    `),
+    ).toMatchObject({ getter: 1, replacement: 0, value: 42 });
+  });
+
+  it("fulfills with the original object when the first getter result is not callable", async () => {
+    expect(
+      await run(`
+      const o: any = {};
+      Object.defineProperty(o, "then", { configurable: true, get: function () { s.getter++; return 7; } });
+      new Promise(function (resolve: any) { resolve(o); }).then(function (v: any) {
+        s.value = v === o ? 42 : -1;
+      });
+      Object.defineProperty(o, "then", { value: function (resolve: any) { s.replacement++; resolve(99); } });
+      __drain_microtasks();
+    `),
+    ).toMatchObject({ getter: 1, replacement: 0, value: 42 });
+  });
+
+  it("captures a field value before that field is replaced", async () => {
+    expect(
+      await run(`
+      const o: any = { tag: 42, then: function (this: any, resolve: any) {
+        s.original++; s.receiver = this.tag === 42 ? 1 : 0; resolve(42);
+      } };
+      new Promise(function (resolve: any) { resolve(o); }).then(function (v: any) { s.value = v; });
+      o.then = function (resolve: any) { s.replacement++; resolve(99); };
+      __drain_microtasks();
+    `),
+    ).toMatchObject({ original: 1, replacement: 0, value: 42, receiver: 1 });
+  });
+
+  it("retains separate captures for two pending resolutions", async () => {
+    expect(
+      await run(`
+      const a: any = { left: 11 };
+      const b: any = { right: 31 };
+      Object.defineProperty(a, "then", { configurable: true, get: function () {
+        s.getter++; return function (resolve: any) { s.original++; resolve(11); };
+      } });
+      Object.defineProperty(b, "then", { configurable: true, get: function () {
+        s.getter++; return function (resolve: any) { s.original++; resolve(31); };
+      } });
+      new Promise(function (resolve: any) { resolve(a); }).then(function (v: any) { s.value += v; });
+      new Promise(function (resolve: any) { resolve(b); }).then(function (v: any) { s.value += v; });
+      __drain_microtasks();
+    `),
+    ).toMatchObject({ getter: 2, original: 2, value: 42 });
+  });
+
+  it("does not overwrite an outer capture during a reentrant getter", async () => {
+    expect(
+      await run(`
+      const inner: any = { then: function (resolve: any) { s.original++; resolve(11); } };
+      const outer: any = {};
+      Object.defineProperty(outer, "then", { get: function () {
+        s.getter++;
+        new Promise(function (resolve: any) { resolve(inner); }).then(function (v: any) { s.value += v; });
+        return function (resolve: any) { s.original++; resolve(31); };
+      } });
+      new Promise(function (resolve: any) { resolve(outer); }).then(function (v: any) { s.value += v; });
+      __drain_microtasks();
+    `),
+    ).toMatchObject({ getter: 1, original: 2, value: 42 });
+  });
+
+  it("preserves native adoption and compiled-method dispatch", async () => {
+    expect(
+      await run(`
+      class Thenable {
+        then(resolve: any): void { s.original++; resolve(31); }
+      }
+      const native: any = Promise.resolve(11);
+      new Promise(function (resolve: any) { resolve(native); }).then(function (v: any) { s.value += v; });
+      new Promise(function (resolve: any) { resolve(new Thenable()); }).then(function (v: any) { s.value += v; });
+      __drain_microtasks();
+    `),
+    ).toMatchObject({ original: 1, value: 42 });
+  });
+});

--- a/tests/issue-3518-promise-resolution-preservation.test.ts
+++ b/tests/issue-3518-promise-resolution-preservation.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   buildPromisePeelValue,
   buildPromiseThenableClassifier,
+  buildPromiseThenableLookup,
   type PromiseThenableInventory,
 } from "../src/runtime/wasmgc/promise/thenable-bodies.js";
 
@@ -78,6 +79,7 @@ const oldAsync = donors.get(asyncPath)!;
 const oldClosed = donors.get(closedPath)!;
 const newAsync = current(asyncPath);
 const newClosed = current(closedPath);
+const newLookupAdapter = current("src/codegen/promise-thenable-lookup.ts");
 const plain = (value: unknown) => JSON.parse(JSON.stringify(value));
 
 function declaration(source: string, name: string): string {
@@ -160,6 +162,7 @@ function resolutionFixture(source: string, native: boolean, ownThen: boolean, ca
   const thenable = native
     ? {
         hasCallableThenFuncIdx: 20,
+        lookupThenFuncIdx: 24,
         thenableJobFuncIdx: 21,
         peelValueFuncIdx: 22,
         newTypeErrorFuncIdx: 23,
@@ -219,6 +222,7 @@ function classifierFixture(source: string, variant: "full" | "empty" | "no-any" 
   const bindings = {
     buildPromisePeelValue,
     buildPromiseThenableClassifier,
+    buildPromiseThenableLookup,
     definedFuncAt: (_ctx: unknown, idx: number) => funcs.get(idx),
     collectMethodEntries: () => {
       calls.push("methods");
@@ -240,12 +244,26 @@ function classifierFixture(source: string, variant: "full" | "empty" | "no-any" 
       return [{ op: "global.get", index: 60 }];
     },
   };
-  evaluate(source, ["fillPromiseThenableHelpers"], bindings).fillPromiseThenableHelpers(ctx);
+  // Evaluate the real driver and helper together; historical donors stay standalone.
+  const names = ["fillPromiseThenableHelpers"];
+  if (source !== oldClosed) names.push("finalizePromiseThenableLookup");
+  evaluate(
+    source === oldClosed ? source : source + "\n" + newLookupAdapter,
+    names,
+    bindings,
+  ).fillPromiseThenableHelpers(ctx);
   return plain({ funcs: [...funcs], calls });
 }
 
-function jobFixture(source: string, native: boolean, apply: boolean) {
+function jobFixture(
+  source: string,
+  native: boolean,
+  apply: boolean,
+  observe?: (types: Map<number, { params: unknown; results: unknown; name: unknown }>, funcs: unknown[]) => void,
+  lookupSource = newLookupAdapter,
+) {
   const funcs: unknown[] = [];
+  const types = new Map<number, { params: unknown; results: unknown; name: unknown }>();
   const calls: string[] = [];
   let next = 100;
   const ctx = {
@@ -278,9 +296,11 @@ function jobFixture(source: string, native: boolean, apply: boolean) {
       calls.push("closures");
       return caps;
     },
-    addFuncType: () => {
+    addFuncType: (_ctx: unknown, params: unknown, results: unknown, name: unknown) => {
       calls.push("type");
-      return next++;
+      const index = next++;
+      types.set(index, plain({ params, results, name }));
+      return index;
     },
     mintDefinedFunc: () => {
       calls.push("mint");
@@ -300,11 +320,338 @@ function jobFixture(source: string, native: boolean, apply: boolean) {
     },
     closureBagInitInstr: () => ({ op: "ref.null.extern" }),
   };
-  const fns = evaluate(source, ["buildPromiseSettleClosureInstrs", "ensurePromiseThenableSubstrate"], bindings);
+  const names = ["buildPromiseSettleClosureInstrs", "ensurePromiseThenableSubstrate"];
+  if (source !== oldAsync) names.push("reservePromiseThenableValueHelpers");
+  const fns = evaluate(source === oldAsync ? source : source + "\n" + lookupSource, names, bindings);
   const result = fns.ensurePromiseThenableSubstrate(ctx, state);
   const repeated = fns.ensurePromiseThenableSubstrate(ctx, state);
   expect(repeated).toBe(result);
+  observe?.(types, funcs);
   return plain({ funcs, calls, result, registrations: [...ctx.funcMap] });
+}
+
+function replaceOnce(source: string, before: string, after: string): string {
+  expect(source.split(before)).toHaveLength(2);
+  return source.replace(before, after);
+}
+
+function changeLookupSignature(source: string, argument: 1 | 2, replacement: unknown): string {
+  const file = ts.createSourceFile("lookup-reservation.ts", source, ts.ScriptTarget.Latest, true);
+  const sites: ts.CallExpression[] = [];
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText(file) === "addFuncType" &&
+      node.arguments[3] &&
+      ts.isStringLiteral(node.arguments[3]) &&
+      node.arguments[3].text === "$__promise_lookup_then_type"
+    )
+      sites.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(file);
+  expect(sites).toHaveLength(1);
+  const target = sites[0]!.arguments[argument]!;
+  return source.slice(0, target.getStart(file)) + JSON.stringify(replacement) + source.slice(target.end);
+}
+
+function verifyLookupReservation(source: string): void {
+  jobFixture(
+    newAsync,
+    true,
+    true,
+    (types, funcs) => {
+      const lookups = funcs.filter((entry: any) => entry[1].name === "__promise_lookup_then") as [
+        number,
+        { typeIdx: number; locals: unknown[]; body: unknown[] },
+      ][];
+      expect(lookups).toHaveLength(1);
+      const [index, fn] = lookups[0]!;
+      expect(index).toBe(105);
+      expect(types.get(fn.typeIdx)).toEqual({
+        params: [{ kind: "externref" }],
+        results: [{ kind: "i32" }, { kind: "externref" }],
+        name: "$__promise_lookup_then_type",
+      });
+      expect(plain(fn.locals)).toEqual([]);
+      expect(plain(fn.body)).toEqual([{ op: "unreachable" }]);
+    },
+    source,
+  );
+}
+
+function verifyActualLookupFill(source: string): void {
+  const lookup = { typeIdx: 104, locals: [] as unknown[], body: [{ op: "unreachable" }] as unknown[] };
+  const predicate = { typeIdx: 100, locals: [] as unknown[], body: [{ op: "i32.const", value: 0 }] as unknown[] };
+  const funcs = new Map([
+    [40, predicate],
+    [44, lookup],
+  ]);
+  const inventory: PromiseThenableInventory = {
+    finalized: true,
+    peelFuncIdx: 41,
+    methodTypeIdxs: [8],
+    accessors: [{ typeIdx: 9, getGlobal: 55 }],
+    callAccessorGetIdx: 42,
+    fields: [{ typeIdx: 10, fieldIdx: 2 }],
+    closureWrapperTypeIdxs: [11, 12],
+    openObject: { typeIdx: 13, externGetFuncIdx: 43, thenStringInstrs: [{ op: "global.get", index: 60 }] },
+  };
+  const ctx = {
+    promiseThenableReserved: true,
+    anyValueTypeIdx: -1,
+    funcMap: new Map([
+      ["__promise_has_callable_then", 40],
+      ["__promise_peel_value", 41],
+      ["__promise_lookup_then", 44],
+      ["__call_accessor_get", 42],
+      ["__extern_get", 43],
+    ]),
+    structAccessorClosure: new Map([["Getter_then", { getGlobal: 55 }]]),
+    structMap: new Map([["Getter", 9]]),
+    objectRuntimeTypes: { objectTypeIdx: 13 },
+  };
+  expect(funcs.get(44)).toBe(lookup);
+  expect(lookup.body).toEqual([{ op: "unreachable" }]);
+  evaluate(newClosed + "\n" + source, ["fillPromiseThenableHelpers", "finalizePromiseThenableLookup"], {
+    buildPromisePeelValue,
+    buildPromiseThenableClassifier,
+    buildPromiseThenableLookup,
+    definedFuncAt: (_ctx: unknown, index: number) => funcs.get(index),
+    collectMethodEntries: () => [{ typeIdx: 8 }],
+    collectFieldEntries: () => [{ typeIdx: 10, fieldIdx: 2 }],
+    collectClosureBaseWrapperTypeIdxs: () => [11, 12],
+    stringConstantExternrefInstrs: () => [{ op: "global.get", index: 60 }],
+  }).fillPromiseThenableHelpers(ctx);
+  expect(funcs.get(44)).toBe(lookup); // the reserved object, not a detached replacement
+  expect(lookup.typeIdx).toBe(104);
+  expect(plain({ locals: lookup.locals, body: lookup.body })).toEqual(plain(buildPromiseThenableLookup(inventory)));
+  expect(plain({ locals: predicate.locals, body: predicate.body })).toEqual(
+    plain(buildPromiseThenableClassifier(inventory)),
+  );
+}
+
+// Hand-authored instruction oracle. Expected instructions never call the builder,
+// nor are they reconstructed from its output or its source text.
+function verifyIndependentLookupBody(builder: typeof buildPromiseThenableLookup): void {
+  const actual = plain(
+    builder({
+      finalized: true,
+      peelFuncIdx: 41,
+      methodTypeIdxs: [8],
+      accessors: [{ typeIdx: 9, getGlobal: 55 }],
+      callAccessorGetIdx: 42,
+      fields: [{ typeIdx: 9, fieldIdx: 2 }],
+      closureWrapperTypeIdxs: [11],
+      openObject: { typeIdx: 13, externGetFuncIdx: 43, thenStringInstrs: [{ op: "global.get", index: 60 }] },
+    }),
+  );
+  const failure = [{ op: "i32.const", value: 0 }, { op: "ref.null.extern" }, { op: "return" }];
+  const callable = [{ op: "i32.const", value: 1 }, { op: "local.get", index: 4 }, { op: "return" }];
+  const afterRead = [
+    { op: "local.tee", index: 4 }, // preserve externref BEFORE any conversion
+    { op: "any.convert_extern" },
+    { op: "local.set", index: 3 },
+    { op: "local.get", index: 3 },
+    { op: "ref.test", typeIdx: 11 },
+    { op: "if", blockType: { kind: "empty" }, then: callable },
+    ...failure,
+  ];
+  expect(actual).toEqual({
+    locals: [
+      { name: "__peeled", type: { kind: "externref" } },
+      { name: "__any", type: { kind: "anyref" } },
+      { name: "__thenAny", type: { kind: "anyref" } },
+      { name: "__capturedThen", type: { kind: "externref" } },
+    ],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: 41 },
+      { op: "local.set", index: 1 },
+      { op: "local.get", index: 1 },
+      { op: "ref.is_null" },
+      { op: "if", blockType: { kind: "empty" }, then: failure },
+      { op: "local.get", index: 1 },
+      { op: "any.convert_extern" },
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 2 },
+      { op: "ref.test", typeIdx: 8 },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 1 }, { op: "ref.null.extern" }, { op: "return" }],
+      },
+      // Same type9 has accessor AND field. The guarded accessor precedes field.
+      { op: "local.get", index: 2 },
+      { op: "ref.test", typeIdx: 9 },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "global.get", index: 55 },
+          { op: "ref.is_null" },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 1 },
+              { op: "global.get", index: 55 },
+              { op: "call", funcIdx: 42 },
+              ...afterRead,
+            ],
+          },
+          // No return here: a null getter falls through to the field arm.
+        ],
+      },
+      { op: "local.get", index: 2 },
+      { op: "ref.test", typeIdx: 9 },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx: 9 },
+          { op: "struct.get", typeIdx: 9, fieldIdx: 2 },
+          ...afterRead,
+        ],
+      },
+      { op: "local.get", index: 2 },
+      { op: "ref.test", typeIdx: 13 },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "global.get", index: 60 },
+          { op: "call", funcIdx: 43 },
+          ...afterRead,
+        ],
+      },
+      { op: "i32.const", value: 0 },
+      { op: "ref.null.extern" },
+    ],
+  });
+  // Explicit denominators, independent of the shape equality assertion.
+  const flat: any[] = [];
+  function walk(body: any[]): void {
+    for (const instruction of body) {
+      flat.push(instruction);
+      if (instruction.then) walk(instruction.then);
+      if (instruction.else) walk(instruction.else);
+    }
+  }
+  walk(actual.body);
+  expect(flat.filter((i) => i.op === "call" && i.funcIdx === 42)).toHaveLength(1);
+  expect(flat.filter((i) => i.op === "struct.get")).toEqual([{ op: "struct.get", typeIdx: 9, fieldIdx: 2 }]);
+  expect(flat.filter((i) => i.op === "call" && i.funcIdx === 43)).toHaveLength(1);
+  expect(flat.filter((i) => i.op === "local.tee" && i.index === 4)).toHaveLength(3);
+}
+
+describe("Promise lookup independent instruction contract", () => {
+  it("checks independent result pairs and read ordering before four live builder mutants", () => {
+    verifyIndependentLookupBody(buildPromiseThenableLookup);
+    const source = current("src/runtime/wasmgc/promise/thenable-bodies.ts");
+    const mutations = [
+      replaceOnce(source, '{ op: "local.tee", index: capturedThenLocalIdx }', '{ op: "nop" }'),
+      replaceOnce(source, '{ op: "local.get", index: capturedThenLocalIdx }', '{ op: "ref.null.extern" }'),
+      replaceOnce(source, "funcIdx: callAccessorGetIdx", "funcIdx: callAccessorGetIdx + 1"),
+      replaceOnce(source, "fieldIdx: fe.fieldIdx", "fieldIdx: fe.fieldIdx + 1"),
+    ];
+    for (const mutated of mutations) {
+      const builder = evaluate(mutated, ["buildThenableLookup", "buildPromiseThenableLookup"], {})
+        .buildPromiseThenableLookup as typeof buildPromiseThenableLookup;
+      expect(() => verifyIndependentLookupBody(builder)).toThrow();
+    }
+  });
+});
+
+describe("Promise lookup reservation and actual-object finalization", () => {
+  it("checks parameter/result order and type wiring before live signature mutations", () => {
+    verifyLookupReservation(newLookupAdapter);
+    for (const mutated of [
+      changeLookupSignature(newLookupAdapter, 1, [{ kind: "i32" }]),
+      changeLookupSignature(newLookupAdapter, 2, [{ kind: "i32" }]),
+      changeLookupSignature(newLookupAdapter, 2, [{ kind: "externref" }, { kind: "i32" }]),
+      replaceOnce(newLookupAdapter, "typeIdx: lookupTypeIdx,", "typeIdx: peelTypeIdx,"),
+    ])
+      expect(() => verifyLookupReservation(mutated)).toThrow();
+  });
+  it("fills the registered lookup object before live omitted/wrong-fill mutations", () => {
+    verifyActualLookupFill(newLookupAdapter);
+    for (const mutated of [
+      replaceOnce(newLookupAdapter, "if (lookupFn) {", "if (false && lookupFn) {"),
+      replaceOnce(
+        newLookupAdapter,
+        "const lookup = buildPromiseThenableLookup(inventory);",
+        "const lookup = buildPromiseThenableClassifier(inventory);",
+      ),
+      replaceOnce(newLookupAdapter, "lookupFn.body = lookup.body;", 'lookupFn.body = [{ op: "unreachable" }];'),
+      replaceOnce(newLookupAdapter, "lookupFn.body = lookup.body;", "predFn.body = lookup.body;"),
+      replaceOnce(newLookupAdapter, "lookupFn.locals = lookup.locals;", "void lookup.locals;"),
+    ])
+      expect(() => verifyActualLookupFill(mutated)).toThrow();
+  });
+});
+
+// Checked intentional deltas; the authenticated donor itself remains immutable.
+function expectedCaptureDelta(receipt: ReturnType<typeof resolutionFixture>, native: boolean) {
+  let calls = 0;
+  let captures = 0;
+  function visit(value: any): void {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const instr = value[i];
+        if (instr?.op === "call" && instr.funcIdx === 20) {
+          expect(value[i + 1]).toEqual({ op: "local.set", index: 4 });
+          instr.funcIdx = 24;
+          value.splice(i + 1, 0, { op: "local.set", index: 8 });
+          calls++;
+        }
+        if (instr?.op === "ref.func" && instr.funcIdx === 21 && value[i + 1]?.op === "ref.null.extern") {
+          expect(value[i + 2]).toEqual({ op: "local.get", index: 0 });
+          value[i + 1] = { op: "local.get", index: 8 };
+          captures++;
+        }
+        visit(instr);
+      }
+    } else if (value && typeof value === "object") {
+      for (const child of Object.values(value)) visit(child);
+    }
+  }
+  visit(receipt.body);
+  expect([calls, captures]).toEqual(native ? [1, 1] : [0, 0]);
+  return receipt;
+}
+
+function expectedLookupReservation(receipt: ReturnType<typeof jobFixture>, native: boolean) {
+  if (!native) return receipt;
+  expect(receipt.funcs.map((entry: any) => [entry[0], entry[1].name])).toEqual([
+    [101, "__promise_has_callable_then"],
+    [103, "__promise_peel_value"],
+    [104, "__promise_thenable_job"],
+  ]);
+  receipt.funcs[2][0] = 106;
+  receipt.funcs.splice(2, 0, [
+    105,
+    {
+      name: "__promise_lookup_then",
+      typeIdx: 104,
+      locals: [],
+      body: [{ op: "unreachable" }],
+      exported: false,
+    },
+  ]);
+  const caps = receipt.calls.indexOf("caps");
+  expect(caps).toBeGreaterThan(0);
+  receipt.calls.splice(caps, 0, "type", "mint", "push");
+  expect(receipt.result.thenableJobFuncIdx).toBe(104);
+  receipt.result.thenableJobFuncIdx = 106;
+  receipt.result.lookupThenFuncIdx = 105;
+  const last = receipt.registrations.pop();
+  expect(last).toEqual(["__promise_thenable_job", 104]);
+  receipt.registrations.push(["__promise_lookup_then", 105], ["__promise_thenable_job", 106]);
+  return receipt;
 }
 
 describe("Promise resolution exact-base body preservation", () => {
@@ -320,7 +667,7 @@ describe("Promise resolution exact-base body preservation", () => {
       for (const callable of ["predicate", "root", "none"] as const)
         it("resolution resources " + JSON.stringify({ native, ownThen, callable }), () => {
           expect(resolutionFixture(newAsync, native, ownThen, callable)).toEqual(
-            resolutionFixture(oldAsync, native, ownThen, callable),
+            expectedCaptureDelta(resolutionFixture(oldAsync, native, ownThen, callable), native),
           );
         });
   it("preserves all seven resolution locals", () => {
@@ -336,7 +683,9 @@ describe("Promise resolution exact-base body preservation", () => {
   for (const native of [false, true])
     for (const apply of [false, true])
       it("job reservations, cache, bodies and locals " + JSON.stringify({ native, apply }), () => {
-        expect(jobFixture(newAsync, native, apply)).toEqual(jobFixture(oldAsync, native, apply));
+        expect(jobFixture(newAsync, native, apply)).toEqual(
+          expectedLookupReservation(jobFixture(oldAsync, native, apply), native),
+        );
       });
   it("rejects missing or unfinished classification inventory", () => {
     expect(() => buildPromiseThenableClassifier({} as PromiseThenableInventory)).toThrow("not finalized");


### PR DESCRIPTION
## Summary

- Capture ordinary callable `then` during Promise resolution and invoke that
  same function later with the original receiver; do not reread its getter.
- Reserve/fill the matching two-result lookup in the native Promise resource
  pack, preserving the legacy classifier and compiled-method fallback.
- Add positive-first signature, registered-object fill and independent body
  controls without changing original donor hashes or49 historical cases.
- Extract two private helpers to satisfy function budgets without allowances.

Stacked on #5766; refs #3518, not a migration completion claim.

## Validation

- Prior composition: TS7 and87/87 tests passed before and after helper extraction.
- Isolated getter:65/65 tests including both explicit compiler modes passed
  before the final independent-body control was added.
- Final composed TS7 and259/259 tests passed across4 files in117.47s.
- Public comparison94830 exited0:24/24 candidate cases executed correctly;
  both arms completed48 compiles,96 instances,184 observations. All14 negative
  controls passed. The baseline reproduced its exact20 known getter gaps.
  Raw preservation is false (4790 differences), as expected for this repair.
  Public comparison targets Pauli's frozen candidate; composed unit/runtime
  tests separately cover the resource join and budget helpers in this PR.
- High review approved production, resource adaptation, helpers and final
  independent proof controls. Formatting and function budgets pass.
- The normal commit hook identified driver-file growth. A focused legacy adapter
  extraction now passes file/function budgets; post-extraction TS7,90/90 affected
  tests and1/1 focused closure test pass. The other168 boundary tests were not
  rerun after this extraction. Final High review approved the exact adapter/test
  hashes with no findings; both driver ASTs reconstruct to the frozen candidate.
- Normal commit hooks passed. The changed-root hook skipped its65-file population
  (>20); this is explicitly not claimed as an additional test pass.

## Limits

The async consumer refusal remains. Actual primitive/string/error/closure/object
dependencies and full native Promise filling, frames/timers, public IR-only
cutover, strict closure and retirement remain incomplete. Existing holds remain;
no merge, auto-merge or bypass requested. Stacked CI is not full main-based CI.
