### PR TITLE
feat(ir): materialize checked native primitive values

### DIFF
--- a/plan/agent-context/3518-native-value-integration-2026-09-08.md
+++ b/plan/agent-context/3518-native-value-integration-2026-09-08.md
@@ -1,0 +1,63 @@
+# Native primitive-value integration
+
+Base: PR #5770, edfb6f4b6bf884cc69eceddb8713eab04370b2c9.
+Branch: codex/3518-native-value-integration-20260908.
+
+Six production files from the native-value worker retain their frozen blobs.
+Canonical AnyValue, undefined, boxed-number/boolean layouts and numeric bodies
+are consumed by both existing legacy callers and same-ledger resource fills.
+Legacy registration/cache/import reconciliation remains at its original sites.
+The checked planNativeValueResources entry validates the whole program and
+current selected projection before deriving requirements. Pure derivation
+alone is not whole-program admission.
+
+Worker repair preserved all60 cases and four original receipt hashes. An
+additional complete comment collector visits punctuation-attached trivia;
+this fixes the retained failing mutation without weakening its assertion.
+Original run79553 passed59/60; repaired run14552 passed60/60 in19.53s.
+Repaired test blob: fbeb86a33bee4f3c789d65cd783ac51c6a806037.
+Parent independently verified all seven worker blobs after recovery.
+
+Integration TS7 session77587 exited0. Focused session57269 exited0 with70/70
+tests (60 resource/preservation plus10 checked-entry controls),20.27s.
+Tests cover genuine and serialized/decoded typed input, unsealed programs,
+detached/foreign projections, backend/target mismatch, altered selected
+instructions with retained owner IDs, missing ABI and missing unit receipts.
+Decoded input is not a fresh-process frontend-import-denial witness.
+
+Boundary activation adds four files across ir-program, native-runtime and
+backend-wasmgc. All historical activation records and allowed edges remain
+unchanged. The fixed population now contains86 modules. Focused probes44529
+and67210 exited1 only on stale edge counts; observed313 edges comprise203
+type-only and110 runtime, with no unknown/unresolved/forbidden/transitive
+violations. Expectations now reflect those measured counts. Full205-test
+boundary suite86860 is running; no terminal success claimed yet.
+
+Final boundary terminal86860 exited0:205/205 tests passed in132.76s.
+This supersedes the preceding running status. All four new modules retain
+deletion, frontend-type, unknown-import and unresolved-import controls.
+Parent copied the full historical High implementation plan into this PR's
+handoff population so subsequent work does not depend on an uncommitted
+worker-only document.
+
+Pre-publication formatting of both parent boundary files reported unchanged;
+scoped diff whitespace check passed. Budget session36024 exited0: file and
+function gates passed against the upstream merge base across163 changed
+source files, with existing inherited grants and no new allowances.
+
+Final High review approved all nine implementation/test files, including
+checked wrapper a2af438b, admission controls ded53f69 and repaired receipt
+fbeb86a3. No remaining scoped findings. Scanner/full-family/retirement
+remain unproved; normal publication hooks are the next step.
+
+High review of the checked entry and repaired comment receipt remains pending.
+Normal commit/push hooks and checkpoint PR remain pending.
+
+## Remaining implementation
+
+Native-string selection still requires the actual scanner and flattening,
+exponent and power-table resource producers. Signature/name/nonempty-body
+checks do not certify scanner implementation. Primitive-only absence is a
+bounded scalar-leaf proof, not the final migration state. Closure/argument
+vectors, object/callable joins, full Promise/frame/timer execution, prepared
+replay, IR-only cutover, strict closure and direct retirement remain open.

--- a/plan/agent-context/3518-native-value-materialization-high-plan-2026-09-08.md
+++ b/plan/agent-context/3518-native-value-materialization-high-plan-2026-09-08.md
@@ -1,0 +1,196 @@
+The authentication condition is closed: I inspected the genuine-positive/`sealed:false` negative; parent now reports **24/24 and TS7 exit0**. Resource approval remains limited to requirements and reservation—not full fill or execution.
+
+# Native value materialization implementation plan
+
+Source grounding: `a7fbc6eb6fa8ebcde29529d67e55408592672fee` plus the reviewed resource delta, now reported committed as `5118637e0e9b34291465230428447e511958faa1`. Getter capture is a separate prerequisite under Pauli; this plan must consume its corrected interface.
+
+## 1. Next checkpoint and shared contract
+
+Implement **real primitive-value and native literal/error materializers first**, with two disjoint Low lanes. Follow with callable/argument-vector and object-dispatch materialization. Do not attempt to complete the Promise pack by supplying signature-compatible placeholder functions.
+
+The current [Promise dependency interface](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/backend/wasmgc/resources/native-promises.ts:121) requires:
+
+- Number boxing, unboxing and classification.
+- The canonical tag-1 undefined global.
+- Real TypeError construction and exact native strings.
+- Closure root and settlement metadata.
+- Argument-vector creation/push and actual closure invocation.
+- Complete object/accessor/callable classification.
+
+Important distinction: the current pack **validates** the three number bindings but does not itself exercise their bodies. Execution proof must include actual number consumers—ultimately delay/frame await conversion—not count dependency admission as execution.
+
+Use the existing `PhysicalModuleReservations` exclusively. New APIs should follow its existing reserve/fill model:
+
+- `reserveNativeValueResources(tx, requirements, dependencies)`
+- `fillNativeValueResources(tx, reservations, dependencies)`
+- Corresponding string/error and callable resource operations.
+
+These are proposed additions, not existing APIs. Return owned type/global/function reservations; bodies receive explicit layouts and stable function handles. No `CodegenContext`, allocator callbacks, arbitrary instruction callbacks or name-only lookup.
+
+## 2. First parallel lane A: undefined and number bodies
+
+**Existing write scope**
+
+- [any-helpers.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/any-helpers.ts:28)
+- [registry/imports.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/registry/imports.ts:1199)
+
+**Proposed new files**
+
+- `/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/runtime/wasmgc/values/primitive-layouts.ts`
+- `/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/runtime/wasmgc/values/number-bodies.ts`
+- `/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/ir/program/native-value-resources.ts`
+- `/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/backend/wasmgc/resources/native-values.ts`
+- `/private/tmp/js2-3518-native-promise-checkpoint-20260908/tests/issue-3518-native-value-resources.test.ts`
+
+Extract executable descriptor/initializer builders from `ensureAnyValueType`, and body/locals builders for `__box_number`, `__unbox_number`, `__typeof_number` from `addUnionImportsAsNativeFuncs`. Existing adapters call these builders at their original allocation/registration points.
+
+Preserve exactly:
+
+- `AnyValue` fields: immutable `tag:i32`, `i32val:i32`, `f64val:f64`, `refval:eqref`, `externval:externref`.
+- Undefined initializer: **tag1, 0, NaN, null-eq, null-extern**, then `struct.new`; one immutable, non-null global. Null is not its substitute.
+- Number/boolean carrier layouts and identity.
+- Signed-i31 fast path `[-2³⁰, 2³⁰−1]`; exclude negative zero, nonintegral values, nonfinite values and out-of-range integers.
+- Boxed-f64 path for `3e9`, `-0`, NaN and infinities.
+- Unbox order: null→0; i31; boxed number; boxed boolean; selected native-string scanner; opaque fallback→NaN.
+- `__typeof_number` recognizes both i31 and boxed f64.
+
+The scanner dependency must be explicit: either an actual native-string conversion binding with its exact layout, or affirmative evidence that the selected representation does not include that branch. Missing binding is not permission to omit it.
+
+Keep legacy import-shift reconciliation, signature interning, function registration order, context caches and all unrelated union helpers—including BigInt—unchanged. Do not turn the canonical builder into another registry.
+
+## 3. First parallel lane B: native strings and TypeError
+
+**Existing write scope**
+
+- [registry/types.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/registry/types.ts:765): Error and native-string layout production only.
+- [native-string-literals.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/native-string-literals.ts:33)
+- [registry/error-types.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/registry/error-types.ts:271)
+
+**Proposed canonical owners**
+
+Under `/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/runtime/wasmgc/values/`:
+
+- `string-layouts.ts`
+- `string-literal-bodies.ts`
+- `error-bodies.ts`
+
+Under `/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/backend/wasmgc/resources/`:
+
+- `native-string-literals.ts`
+- `native-errors.ts`
+
+Focused tests: `issue-3518-native-string-error-resources.test.ts` under the same checkout’s `tests/`.
+
+Required implementation:
+
+- Reuse the actual `AnyString`, flat, cons and hashed-string hierarchy; preserve all mutable hash/cache fields and selected UTF-8 layout.
+- Move literal instruction production, hash calculation and chunking together. Preserve interning keys, allocation order, UTF-16 code-unit semantics and oversized-literal behavior.
+- Materialize `"then"`, `"Chaining cycle detected for promise"` and `"TypeError"` through that owner. A text label attached to an arbitrary global is insufficient authentication.
+- Reuse the six-field Error layout: tag, message, name, stack, userClassId, props.
+- Build actual one-argument `__new_TypeError`: tag−11, supplied message, real name string, existing stack initialization, userClassId−1 and null props.
+- Preserve Error constructor caching and name-string registration **before** body construction. No eager property-bag allocation.
+
+Do not duplicate the builtin tag catalog. If its canonical placement is required, relocate that existing authority with compatibility exports, as a separately explicit parent-reviewed map amendment.
+
+**Required dependent string work:** number unboxing with native strings needs the real scanner from [parse-number-native.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/parse-number-native.ts:582), including flattening, exponent helpers and power-table resources. Literal-only completion does not close this dependency. Number formatting, concat and stdout remain further full-family obligations.
+
+## 4. Next executable slice: closure identities and argument vectors
+
+Start after the first interfaces freeze; do not overlap Pauli’s scheduler/dispatch edits.
+
+Existing donors:
+
+- [closure-header-layout.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/closures/closure-header-layout.ts)
+- [funcref-wrapper-types.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/closures/funcref-wrapper-types.ts:73)
+- [builtin-fn-meta.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/builtin-fn-meta.ts:261)
+- [object-runtime.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/object-runtime.ts:4375): `__objvec_new`/`__objvec_push` bodies and their layouts.
+
+Canonical destinations: `runtime/wasmgc/values/closure-layouts.ts`, `argument-vector-bodies.ts`, and `backend/wasmgc/resources/native-callables.ts` under the reviewed checkout.
+
+Required contracts:
+
+- One canonical closure root: `[func, $arity, $bag]`.
+- Lifted functions take that root as `self`, not whichever signature wrapper was allocated first.
+- Settlement metadata retains `[func,$arity,$bag,bfnstate,bfnid]`; genuine `"promise:settle"` metadata, name `""`, length1, followed by the Promise capture field.
+- Preserve metadata identity independently of structurally equivalent Wasm types.
+- `$ObjVecArr`/`$ObjVec` remain distinct from the prepared vector’s backing/carrier. Reuse the existing vector-base identity where the donor does.
+- `__objvec_new`: actual empty vector with capacity8.
+- `__objvec_push`: original copy/grow/store/length-update order and existing non-vector behavior.
+
+Legacy mutations that must remain accounted for include wrapper caches, root assignment, closure counter, minimum argument counts, allocation-mode flags, `closureInfoByTypeIdx`, builtin metadata maps and adopted early argument-array reservations.
+
+This slice creates genuine closure values and argument storage. It does **not** complete `applyClosure`.
+
+## 5. Then complete object lookup and callable invocation
+
+This is the necessary connected join—not an optional convenience layer.
+
+Serialize ownership of `object-runtime.ts` after argument-vector extraction. The dependent donor scope is:
+
+- `reserveApplyClosure` / `fillApplyClosure` in [object-runtime.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/object-runtime.ts:7357).
+- Arity/widening and actual method-call bridges in [closure-exports.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/closure-exports.ts:1940).
+- [accessor-driver.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/accessor-driver.ts:338).
+- [closure-classifier.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/closure-classifier.ts:43).
+- [typeof-natives-finalize.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/typeof-natives-finalize.ts:57).
+- [carrier-bag-visibility.ts](/private/tmp/js2-3518-native-promise-checkpoint-20260908/src/codegen/carrier-bag-visibility.ts:442).
+- Pauli’s completed capture-once lookup and existing closed-method fallback.
+
+Canonical bodies belong under `runtime/wasmgc/values/`; IR-to-resource selection belongs under `backend/wasmgc/resources/`.
+
+Preserve:
+
+- Real `$PropEntry`, `$PropMap`, self-referencing `$Object`, flags, tombstones, insertion ordering and getter/setter slots.
+- Lookup/hash/equality/prototype behavior and relevant native-string caches.
+- Nonallocating bag reads; lookup must not create a bag.
+- Actual argument count before dispatcher widening; omitted arguments, extras, receiver and closure-self.
+- Existing runtime receiver/argc handling and exception behavior—do not silently add restoration semantics during extraction.
+- Finalization after the complete callable population exists.
+
+The initial `__typeof_function` zero body and `__apply_closure` unreachable body are reservations, never implementations. No missing dispatcher may become an accepted zero/null/identity fallback.
+
+Pauli’s captured ordinary `then` must travel to the queued job and invoke through real closure application; do not restore the second getter read.
+
+## 6. Authenticate population before selecting classifier arms
+
+The existing single-role `carriers` array is inadequate as the final classification contract: one carrier can contribute both accessor and field behavior.
+
+Use one authenticated carrier inventory with **separate ordered projections** for methods, accessors, fields, closure roots and other callable carriers. Preserve original precedence and fallback behavior. Do not duplicate the underlying authority.
+
+The checked parent must join three populations:
+
+1. Complete semantic/selected prepared owners, state bodies, globals and startup—retain the original family’s **16 owners /33 calls**.
+2. Allocation/type/capture records, preserving aliases, metadata and provenance losslessly.
+3. Runtime-created Promise, callback, settle-capture, frame, timer, combinator, error, string and argument-vector allocations.
+
+The third population is not recoverable merely by counting source IR allocations.
+
+Reconcile these records with actual reserved layouts, allocation instructions and callable targets. Two copies of a caller-supplied list are not independent evidence. Unknown metadata or missing required implementation produces a located refusal; no empty-inventory inference.
+
+## 7. Parent integration and acceptance
+
+Parent retains `program-consumer.ts`, `program-physical-plan.ts`, Promise-pack interface joins and boundary-policy activation.
+
+One transaction:
+
+1. Authenticate program, projection, providers and current attachments.
+2. Reserve all prerequisite resources and forward function handles.
+3. Complete the carrier/dispatch population.
+4. Freeze reservations; resolve physical publication indices.
+5. Fill actual globals and bodies exactly once.
+6. Publish refs, timer/export/start metadata; seal.
+
+Keep recursive layout ownership and the existing shared vector identity. No late allocation, second ABI map or new completion authority.
+
+Each slice needs:
+
+- Live donor body/locals/initializer/order receipts; preserve existing hashes and denominators through checked reconstruction.
+- Same-module, stale-layout, wrong-target, missing-fill, altered numeric initializer and omitted-carrier negatives.
+- Actual legacy callers using the canonical builders, with paired bytes/WAT/resource ordering.
+- Direct execution of owned implementations: i31 boundaries, `3e9`, `-0`, NaN/infinities; undefined versus null; strings and real TypeError; vector growth; closure invocation and captured-getter behavior.
+- Fresh-process prepared replay forbidding frontend/legacy imports. Resource unit tests alone do not prove this route.
+
+The confirmed getter defect remains a correctness failure even where baseline/candidate bytes match. Its corrected candidate needs independent semantic evidence.
+
+**Dispatch recommendation:** start the two disjoint primitive and literal/error lanes; follow with closure/argument-vector and then object/invocation joins. No new user architectural choice is needed. Complete Promise fill, frames, timers, full-family strings/output, public IR-only cutover, strict closure and the unresolved ABI30 witness remain explicit obligations.
+
+No files or tests changed. Pauli’s frozen getter revision is the next review, not assessed in this plan.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6429,3 +6429,27 @@ open. This checkpoint does not satisfy those acceptance requirements.
 Final scoped approval and execution: High approved the five live-constructor
 controls; parent67641 exited0 with29/29 tests passing in10.08s. All eight
 production hashes and the authenticated fixture remain unchanged.
+
+## Native primitive-value checkpoint — 2026-09-08
+
+On #5770, canonical primitive layouts and number bodies now back legacy
+callers and same-ledger native resource fills. The checked value-plan entry
+authenticates the whole program and selected projection. Integrated TS7
+passed;70/70 focused tests passed (60 resource/preservation and10 admission
+controls). Repaired comment receipts preserve the original tests and hashes;
+the preceding59/60 failure remains recorded rather than discarded.
+
+Four new boundary owners produce a measured86-module,313-edge graph
+(203 type-only,110 runtime), without unknown/unresolved/forbidden edges.
+Historical activation records and allowed edges are unchanged. Expanded205
+boundary controls are still running; final review and publication pending.
+See agent-context/3518-native-value-integration-2026-09-08.md for receipts.
+
+This does not complete native strings: the genuine scanner, flattening and
+exponent/power resources remain next, followed by closure metadata/ObjVec
+and complete object/callable dispatch. Existing Promise pack ownership of
+settle captures/trampolines must not be duplicated. Full-family execution,
+fresh-process replay, cutover, strict closure and retirement remain open.
+
+Expanded boundary suite86860 subsequently exited0:205/205 passed in132.76s.
+The full High native-value implementation plan is included in agent-context.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -161,9 +161,10 @@
         "src/ir/program/data.ts",
         "src/ir/program/input.ts",
         "src/ir/program/native-vector-resources.ts",
-        "src/ir/program/native-promise-resources.ts"
+        "src/ir/program/native-promise-resources.ts",
+        "src/ir/program/native-value-resources.ts"
       ],
-      "minModules": 14
+      "minModules": 15
     },
     {
       "id": "runtime-contracts",
@@ -187,9 +188,10 @@
         "src/backend/wasmgc/resources/native-vectors.ts",
         "src/backend/wasmgc/resources/native-promises.ts",
         "src/backend/wasmgc/resources/native-string-literals.ts",
-        "src/backend/wasmgc/resources/native-errors.ts"
+        "src/backend/wasmgc/resources/native-errors.ts",
+        "src/backend/wasmgc/resources/native-values.ts"
       ],
-      "minModules": 4
+      "minModules": 5
     },
     {
       "id": "native-runtime",
@@ -208,9 +210,11 @@
         "src/runtime/wasmgc/promise/thenable-bodies.ts",
         "src/runtime/wasmgc/values/string-layouts.ts",
         "src/runtime/wasmgc/values/string-literal-bodies.ts",
-        "src/runtime/wasmgc/values/error-bodies.ts"
+        "src/runtime/wasmgc/values/error-bodies.ts",
+        "src/runtime/wasmgc/values/primitive-layouts.ts",
+        "src/runtime/wasmgc/values/number-bodies.ts"
       ],
-      "minModules": 12
+      "minModules": 14
     },
     {
       "id": "standalone-platform",
@@ -449,6 +453,58 @@
     }
   ],
   "activationHistory": [
+    {
+      "layer": "ir-program",
+      "entries": [
+        "src/ir/program/abi-inventory.ts",
+        "src/ir/program/abi.ts",
+        "src/ir/program/startup.ts",
+        "src/ir/program/abi-lookup.ts",
+        "src/ir/program/callable-bindings.ts",
+        "src/ir/program/controls.ts",
+        "src/ir/program/index.ts",
+        "src/ir/program/input-contracts.ts",
+        "src/ir/program/prepared-contracts.ts",
+        "src/ir/program/errors.ts",
+        "src/ir/program/data.ts",
+        "src/ir/program/input.ts",
+        "src/ir/program/native-vector-resources.ts",
+        "src/ir/program/native-promise-resources.ts",
+        "src/ir/program/native-value-resources.ts"
+      ],
+      "minModules": 15
+    },
+    {
+      "layer": "native-runtime",
+      "entries": [
+        "src/runtime/wasmgc/async/microtask-queue-bodies.ts",
+        "src/runtime/wasmgc/promise/settlement-bodies.ts",
+        "src/runtime/wasmgc/async/frame-engine.ts",
+        "src/runtime/wasmgc/async/native-await.ts",
+        "src/runtime/wasmgc/promise/delay-bodies.ts",
+        "src/runtime/wasmgc/promise/combinator-bodies.ts",
+        "src/runtime/wasmgc/values/vector-grow-store.ts",
+        "src/runtime/wasmgc/promise/resolution-bodies.ts",
+        "src/runtime/wasmgc/promise/thenable-bodies.ts",
+        "src/runtime/wasmgc/values/string-layouts.ts",
+        "src/runtime/wasmgc/values/string-literal-bodies.ts",
+        "src/runtime/wasmgc/values/error-bodies.ts",
+        "src/runtime/wasmgc/values/primitive-layouts.ts",
+        "src/runtime/wasmgc/values/number-bodies.ts"
+      ],
+      "minModules": 14
+    },
+    {
+      "layer": "backend-wasmgc",
+      "entries": [
+        "src/backend/wasmgc/resources/native-vectors.ts",
+        "src/backend/wasmgc/resources/native-promises.ts",
+        "src/backend/wasmgc/resources/native-string-literals.ts",
+        "src/backend/wasmgc/resources/native-errors.ts",
+        "src/backend/wasmgc/resources/native-values.ts"
+      ],
+      "minModules": 5
+    },
     {
       "layer": "native-runtime",
       "entries": [
@@ -986,6 +1042,10 @@
     }
   ],
   "files": [
+    { "path": "src/ir/program/native-value-resources.ts", "state": "clean", "layer": "ir-program" },
+    { "path": "src/runtime/wasmgc/values/primitive-layouts.ts", "state": "clean", "layer": "native-runtime" },
+    { "path": "src/runtime/wasmgc/values/number-bodies.ts", "state": "clean", "layer": "native-runtime" },
+    { "path": "src/backend/wasmgc/resources/native-values.ts", "state": "clean", "layer": "backend-wasmgc" },
     { "path": "src/runtime/wasmgc/values/string-layouts.ts", "state": "clean", "layer": "native-runtime" },
     { "path": "src/runtime/wasmgc/values/string-literal-bodies.ts", "state": "clean", "layer": "native-runtime" },
     { "path": "src/runtime/wasmgc/values/error-bodies.ts", "state": "clean", "layer": "native-runtime" },

--- a/src/backend/wasmgc/resources/native-values.ts
+++ b/src/backend/wasmgc/resources/native-values.ts
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { ValType } from "../../../wasm/model/instructions.js";
+import type {
+  PhysicalModuleReservations,
+  TypeReservation,
+  GlobalReservation,
+  FunctionReservation,
+} from "../../../wasm/physical/module-reservations.js";
+import {
+  assertNativeValueResourcePlan,
+  type NativeValueResourcePlan,
+} from "../../../ir/program/native-value-resources.js";
+import { preparedIrDataMismatch } from "../../../ir/program/data.js";
+import {
+  buildAnyValueType,
+  buildUndefinedInitializer,
+  buildBoxNumberType,
+  buildBoxBooleanType,
+} from "../../../runtime/wasmgc/values/primitive-layouts.js";
+import {
+  buildBoxNumberBody,
+  buildBoxNumberLocals,
+  buildUnboxNumberBody,
+  buildUnboxNumberLocals,
+  buildTypeofNumberBody,
+  type NativeNumberStringConversion,
+} from "../../../runtime/wasmgc/values/number-bodies.js";
+
+export type NativeValueStringDependency =
+  | { readonly kind: "native-string"; readonly anyString: TypeReservation; readonly toNumber: FunctionReservation }
+  | { readonly kind: "absent" };
+export interface NativeValueDependencies {
+  readonly strings: NativeValueStringDependency;
+}
+export interface NativeValueReservations {
+  readonly types: {
+    readonly anyValue: TypeReservation;
+    readonly boxedNumber: TypeReservation;
+    readonly boxedBoolean: TypeReservation;
+  };
+  readonly globals: { readonly undefined: GlobalReservation };
+  readonly functions: {
+    readonly boxNumber: FunctionReservation;
+    readonly unboxNumber: FunctionReservation;
+    readonly isNumber: FunctionReservation;
+  };
+}
+const EXTERN: ValType = { kind: "externref" },
+  F64: ValType = { kind: "f64" },
+  I32: ValType = { kind: "i32" };
+interface Owner {
+  readonly tx: PhysicalModuleReservations;
+  readonly requirements: NativeValueResourcePlan;
+  readonly dependency: NativeValueStringDependency;
+}
+const owners = new WeakMap<NativeValueReservations, Owner>();
+function fail(detail: string): never {
+  throw new Error("native value resources: " + detail);
+}
+function same(actual: unknown, expected: unknown, detail: string): void {
+  if (preparedIrDataMismatch(actual, expected) !== undefined) fail(detail);
+}
+
+function requireDependency(
+  requirements: NativeValueResourcePlan,
+  dependencies: NativeValueDependencies,
+): NativeValueStringDependency {
+  const strings = dependencies?.strings;
+  if (requirements.strings === "primitive-only") {
+    if (strings?.kind !== "absent") fail("primitive-only requirements contradict the scanner dependency");
+  } else if (strings?.kind !== "native-string") {
+    fail("selected native strings require the actual StringToNumber dependency");
+  }
+  if (strings.kind === "native-string") {
+    if (
+      !strings.anyString ||
+      !strings.toNumber ||
+      strings.anyString.kind !== "type" ||
+      strings.toNumber.kind !== "function"
+    )
+      fail("missing actual native scanner reservations");
+    same(
+      strings.anyString.object,
+      {
+        kind: "struct",
+        name: "AnyString",
+        fields: [{ name: "len", type: I32, mutable: false }],
+        superTypeIdx: -1,
+      },
+      "noncanonical native string scanner layout",
+    );
+    if (strings.toNumber.object.name !== "__str_to_number") fail("wrong native StringToNumber target");
+  }
+  return strings;
+}
+
+/** Reserve on the existing transaction only; no freezes, fills or publication here. */
+export function reserveNativeValueResources(
+  tx: PhysicalModuleReservations,
+  requirements: NativeValueResourcePlan,
+  dependencies: NativeValueDependencies,
+): NativeValueReservations {
+  assertNativeValueResourcePlan(requirements);
+  const strings = requireDependency(requirements, dependencies);
+  const key = (role: string) => "physical:values:" + JSON.stringify(requirements.anchor) + ":" + role;
+  const anyValue = tx.reserveType(key("any"), buildAnyValueType());
+  const undefinedValue = tx.reserveGlobal(
+    key("undefined"),
+    "__undefined",
+    { kind: "ref", typeIdx: anyValue.typeIndex },
+    false,
+  );
+  const boxedNumber = tx.reserveType(key("number"), buildBoxNumberType());
+  const boxedBoolean = tx.reserveType(key("boolean"), buildBoxBooleanType());
+  // Preserve the union donor's number-related signature order. The legacy
+  // adapter still interns ALL its unrelated signatures at the original sites.
+  tx.internFunctionType([EXTERN], [I32]);
+  tx.internFunctionType([EXTERN], [F64]);
+  tx.internFunctionType([F64], [EXTERN]);
+  const boxNumber = tx.reserveFunction(key("box-number"), "__box_number", { params: [F64], results: [EXTERN] });
+  const unboxNumber = tx.reserveFunction(key("unbox-number"), "__unbox_number", { params: [EXTERN], results: [F64] });
+  const isNumber = tx.reserveFunction(key("typeof-number"), "__typeof_number", { params: [EXTERN], results: [I32] });
+  const result = Object.freeze({
+    types: Object.freeze({ anyValue, boxedNumber, boxedBoolean }),
+    globals: Object.freeze({ undefined: undefinedValue }),
+    functions: Object.freeze({ boxNumber, unboxNumber, isNumber }),
+  });
+  owners.set(result, {
+    tx,
+    requirements,
+    dependency:
+      strings.kind === "absent"
+        ? Object.freeze({ kind: "absent" })
+        : Object.freeze({ kind: "native-string", anyString: strings.anyString, toNumber: strings.toNumber }),
+  });
+  return result;
+}
+
+/** Fill the exact reserved objects after freeze. The ledger remains completion authority. */
+export function fillNativeValueResources(
+  tx: PhysicalModuleReservations,
+  reservations: NativeValueReservations,
+  dependencies: NativeValueDependencies,
+): void {
+  const owner = owners.get(reservations);
+  if (!owner || owner.tx !== tx) fail("foreign native value reservations");
+  assertNativeValueResourcePlan(owner.requirements);
+  const strings = requireDependency(owner.requirements, dependencies);
+  if (
+    strings.kind !== owner.dependency.kind ||
+    (strings.kind === "native-string" &&
+      (owner.dependency.kind !== "native-string" ||
+        strings.anyString !== owner.dependency.anyString ||
+        strings.toNumber !== owner.dependency.toNumber))
+  )
+    fail("substituted native string conversion dependency");
+  const { anyValue, boxedNumber, boxedBoolean } = reservations.types;
+  for (const [token, expected] of [
+    [anyValue, buildAnyValueType()],
+    [boxedNumber, buildBoxNumberType()],
+    [boxedBoolean, buildBoxBooleanType()],
+  ] as const) {
+    if (tx.physicalIndex(token) !== token.typeIndex) fail("stale primitive layout coordinate");
+    same(token.object, expected, "altered primitive layout");
+  }
+  for (const token of Object.values(reservations.functions)) tx.physicalIndex(token);
+  tx.physicalIndex(reservations.globals.undefined);
+  let conversion: NativeNumberStringConversion;
+  if (strings.kind === "native-string") {
+    if (tx.physicalIndex(strings.anyString) !== strings.anyString.typeIndex) fail("stale native string layout");
+    tx.physicalIndex(strings.toNumber);
+    // Cache-only after freeze, so this can never synthesize a missing signature.
+    if (strings.toNumber.object.typeIdx !== tx.internFunctionType([EXTERN], [F64]))
+      fail("native scanner signature differs");
+    if (
+      !strings.toNumber.object.body.length ||
+      strings.toNumber.object.body.every((instr) => instr.op === "unreachable")
+    )
+      fail("native scanner body is still a reservation, not an implementation");
+    conversion = {
+      kind: "native-string",
+      anyStringTypeIdx: strings.anyString.typeIndex,
+      toNumber: strings.toNumber.handle,
+    };
+  } else {
+    conversion = { kind: "absent", evidence: "selected-primitive-only" };
+  }
+  tx.fillGlobal(reservations.globals.undefined, buildUndefinedInitializer(anyValue.typeIndex));
+  tx.fillFunction(reservations.functions.boxNumber, {
+    locals: buildBoxNumberLocals(),
+    body: buildBoxNumberBody(boxedNumber.typeIndex),
+  });
+  tx.fillFunction(reservations.functions.unboxNumber, {
+    locals: buildUnboxNumberLocals(),
+    body: buildUnboxNumberBody(boxedNumber.typeIndex, boxedBoolean.typeIndex, conversion),
+  });
+  tx.fillFunction(reservations.functions.isNumber, { locals: [], body: buildTypeofNumberBody(boxedNumber.typeIndex) });
+}

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -6,6 +6,7 @@
  * Extracted from codegen/index.ts (#1013).
  */
 import type { Instr, StructTypeDef, ValType } from "../ir/types.js";
+import { buildAnyValueType, buildUndefinedInitializer } from "../runtime/wasmgc/values/primitive-layouts.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 import { ensureAnyToStringHelper, ensureNativeStringHelpers, nativeStringType } from "./native-strings.js";
@@ -28,17 +29,7 @@ export const NATIVE_PROMISE_NUMBER_BOUNDARY_HELPERS = ["__typeof_number", "__unb
 export function ensureAnyValueType(ctx: CodegenContext): void {
   if (ctx.anyValueTypeIdx >= 0) return; // already registered
   ctx.anyValueTypeIdx = ctx.mod.types.length;
-  ctx.mod.types.push({
-    kind: "struct",
-    name: "AnyValue",
-    fields: [
-      { name: "tag", type: { kind: "i32" }, mutable: false },
-      { name: "i32val", type: { kind: "i32" }, mutable: false },
-      { name: "f64val", type: { kind: "f64" }, mutable: false },
-      { name: "refval", type: { kind: "eqref" }, mutable: false },
-      { name: "externval", type: { kind: "externref" }, mutable: false },
-    ],
-  });
+  ctx.mod.types.push(buildAnyValueType());
 
   // (#2106 S1.0) Reserve the standalone `$undefined` singleton up-front, in the
   // same call that registers `$AnyValue`. It is an immutable tag-1 `$AnyValue`
@@ -54,21 +45,13 @@ export function ensureAnyValueType(ctx: CodegenContext): void {
   // this global. The tag-1 shape mirrors `__any_from_extern`'s `nullAny`
   // ({tag:1, i32val:0, f64val:NaN, refval:null, externval:null}).
   if ((ctx.standalone || ctx.nativeStrings) && ctx.undefinedGlobalIdx === undefined) {
-    const EQ_HEAP_TYPE = -19; // WasmGC `eq` abstract heap type
     const anyTypeIdx = ctx.anyValueTypeIdx;
     const globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
     ctx.mod.globals.push({
       name: "__undefined",
       type: { kind: "ref", typeIdx: anyTypeIdx },
       mutable: false,
-      init: [
-        { op: "i32.const", value: 1 }, // tag = 1 (Undefined)
-        { op: "i32.const", value: 0 }, // i32val
-        { op: "f64.const", value: NaN }, // f64val
-        { op: "ref.null", typeIdx: EQ_HEAP_TYPE }, // refval
-        { op: "ref.null.extern" }, // externval
-        { op: "struct.new", typeIdx: anyTypeIdx },
-      ],
+      init: buildUndefinedInitializer(anyTypeIdx),
     });
     ctx.undefinedGlobalIdx = globalIdx;
   }

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -1,6 +1,14 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /** Import/global registration and late index-space fixups. */
 import type { Import, Instr, ValType } from "../../ir/types.js";
+import { buildBoxNumberType, buildBoxBooleanType } from "../../runtime/wasmgc/values/primitive-layouts.js";
+import {
+  buildBoxNumberBody,
+  buildBoxNumberLocals,
+  buildUnboxNumberBody,
+  buildUnboxNumberLocals,
+  buildTypeofNumberBody,
+} from "../../runtime/wasmgc/values/number-bodies.js";
 import type { CodegenContext, ExternClassInfo } from "../context/types.js";
 import { resolveWidenedVarKey } from "../widened-var-key.js";
 import { hasLoneSurrogate, hexCodeUnits, STRING_CONSTANTS16_NS } from "../../string-surrogate.js";
@@ -1228,18 +1236,10 @@ export function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
 
   // 1. Register the boxed-value struct types. Both are immutable singletons.
   const boxNumStructIdx = ctx.mod.types.length;
-  ctx.mod.types.push({
-    kind: "struct",
-    name: "__box_number_struct",
-    fields: [{ name: "value", type: { kind: "f64" }, mutable: false }],
-  });
+  ctx.mod.types.push(buildBoxNumberType());
 
   const boxBoolStructIdx = ctx.mod.types.length;
-  ctx.mod.types.push({
-    kind: "struct",
-    name: "__box_boolean_struct",
-    fields: [{ name: "value", type: { kind: "i32" }, mutable: false }],
-  });
+  ctx.mod.types.push(buildBoxBooleanType());
 
   const bigIntStructIdx = ctx.mod.types.length;
   ctx.mod.types.push({
@@ -1307,47 +1307,7 @@ export function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
   // (i31 cannot carry the sign — `1/x` and Object.is would lose it), NaN and
   // infinities (fail the trunc round-trip), and values outside [-2^30, 2^30-1]
   // (fail the shl/shr round-trip).
-  registerNative(
-    "__box_number",
-    f64ToExternref,
-    [
-      { op: "local.get", index: 0 },
-      { op: "i32.trunc_sat_f64_s" },
-      { op: "local.tee", index: 1 },
-      { op: "f64.convert_i32_s" },
-      { op: "local.get", index: 0 },
-      { op: "f64.eq" }, // integral (and clamp-free) round-trip
-      { op: "local.get", index: 1 },
-      { op: "i32.const", value: 1 },
-      { op: "i32.shl" },
-      { op: "i32.const", value: 1 },
-      { op: "i32.shr_s" },
-      { op: "local.get", index: 1 },
-      { op: "i32.eq" }, // fits signed 31 bits
-      { op: "i32.and" },
-      { op: "local.get", index: 1 },
-      { op: "i32.const", value: 0 },
-      { op: "i32.ne" },
-      { op: "local.get", index: 0 },
-      { op: "i64.reinterpret_f64" },
-      { op: "i64.const", value: 0n },
-      { op: "i64.lt_s" },
-      { op: "i32.eqz" },
-      { op: "i32.or" }, // t != 0 || sign bit clear (rejects -0 only)
-      { op: "i32.and" },
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "externref" } },
-        then: [{ op: "local.get", index: 1 }, { op: "ref.i31" }, { op: "extern.convert_any" }],
-        else: [
-          { op: "local.get", index: 0 },
-          { op: "struct.new", typeIdx: boxNumStructIdx },
-          { op: "extern.convert_any" },
-        ],
-      },
-    ],
-    [{ name: "$i31_temp", type: { kind: "i32" } as ValType }],
-  );
+  registerNative("__box_number", f64ToExternref, buildBoxNumberBody(boxNumStructIdx), buildBoxNumberLocals());
 
   // 4. __unbox_number(externref) -> f64
   //    Local 1 is an anyref temp used to ref.test then ref.cast without
@@ -1356,82 +1316,14 @@ export function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
   registerNative(
     "__unbox_number",
     externrefToF64,
-    [
-      // if (ref.is_null param) return 0   // Number(null) === 0
-      { op: "local.get", index: 0 },
-      { op: "ref.is_null" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [{ op: "f64.const", value: 0 }, { op: "return" }],
-      },
-      // any = any.convert_extern(param)
-      { op: "local.get", index: 0 },
-      { op: "any.convert_extern" },
-      { op: "local.set", index: 1 },
-      // (#3673) i31-boxed small int → its value.
-      { op: "local.get", index: 1 },
-      { op: "ref.test", typeIdx: -20 },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          { op: "local.get", index: 1 },
-          { op: "ref.cast", typeIdx: -20 },
-          { op: "i31.get_s" },
-          { op: "f64.convert_i32_s" },
-          { op: "return" },
-        ],
-      },
-      { op: "local.get", index: 1 },
-      // if (ref.test $box_number_struct any) return any.value
-      { op: "ref.test", typeIdx: boxNumStructIdx },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          { op: "local.get", index: 1 },
-          { op: "ref.cast", typeIdx: boxNumStructIdx },
-          { op: "struct.get", typeIdx: boxNumStructIdx, fieldIdx: 0 },
-          { op: "return" },
-        ],
-      },
-      // #1910 R3 — a boxed boolean (the [[BooleanData]] slot of a
-      // `new Boolean(x)` wrapper, recovered by `__to_primitive`) coerces per
-      // §7.1.4 ToNumber(true)=1, ToNumber(false)=0. Without this arm a boxed
-      // boolean fell through to the opaque-ref NaN fallback, so
-      // `Number(new Boolean(true))` returned NaN instead of 1.
-      { op: "local.get", index: 1 },
-      { op: "ref.test", typeIdx: boxBoolStructIdx },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          { op: "local.get", index: 1 },
-          { op: "ref.cast", typeIdx: boxBoolStructIdx },
-          { op: "struct.get", typeIdx: boxBoolStructIdx, fieldIdx: 0 },
-          { op: "f64.convert_i32_s" },
-          { op: "return" },
-        ],
-      },
-      ...(strToNumberIdx !== undefined && ctx.anyStrTypeIdx >= 0
-        ? ([
-            // StringToNumber (§7.1.4.1): object ToPrimitive can yield a native
-            // string; parse it with the existing pure-Wasm scanner before the
-            // opaque-ref NaN fallback.
-            { op: "local.get", index: 1 },
-            { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [{ op: "local.get", index: 0 }, { op: "call", funcIdx: strToNumberIdx }, { op: "return" }],
-            },
-          ] satisfies Instr[])
-        : []),
-      // not a recognized boxed number → NaN (matches Number(opaque))
-      { op: "f64.const", value: NaN },
-    ],
-    [{ name: "$any_temp", type: { kind: "anyref" } as ValType }],
+    buildUnboxNumberBody(
+      boxNumStructIdx,
+      boxBoolStructIdx,
+      strToNumberIdx !== undefined && ctx.anyStrTypeIdx >= 0
+        ? { kind: "native-string", anyStringTypeIdx: ctx.anyStrTypeIdx, toNumber: strToNumberIdx }
+        : { kind: "absent", evidence: "selected-primitive-only" },
+    ),
+    buildUnboxNumberLocals(),
   );
 
   // 5. __box_boolean(i32) -> externref — interned carriers (#3780).
@@ -1784,23 +1676,7 @@ export function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
   );
 
   // 8. __typeof_number(externref) -> i32 — `ref.test $box_number_struct`.
-  registerNative("__typeof_number", externrefToI32, [
-    { op: "local.get", index: 0 },
-    { op: "ref.is_null" },
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
-    },
-    { op: "local.get", index: 0 },
-    { op: "any.convert_extern" },
-    { op: "ref.test", typeIdx: boxNumStructIdx },
-    // (#3673) …or an i31-boxed small int.
-    { op: "local.get", index: 0 },
-    { op: "any.convert_extern" },
-    { op: "ref.test", typeIdx: -20 },
-    { op: "i32.or" },
-  ]);
+  registerNative("__typeof_number", externrefToI32, buildTypeofNumberBody(boxNumStructIdx));
 
   // 9. __typeof_boolean(externref) -> i32 — `ref.test $box_boolean_struct`.
   registerNative("__typeof_boolean", externrefToI32, [

--- a/src/ir/program-physical-plan.ts
+++ b/src/ir/program-physical-plan.ts
@@ -31,6 +31,11 @@ import type { ValType } from "./types.js";
 import { deriveNativeVectorResourcePlan, type NativeVectorResourcePlan } from "./program/native-vector-resources.js";
 import { assertPreparedIrProgram } from "./program-validation.js";
 import {
+  deriveNativeValueResourcePlan,
+  type NativeValueResourcePlan,
+  type NativeValueStringRepresentation,
+} from "./program/native-value-resources.js";
+import {
   deriveNativePromiseResourcePlan,
   type NativePromiseConfiguration,
   type NativePromiseResourcePlan,
@@ -180,6 +185,27 @@ export function planNativePromiseResources(
     target: options.target,
     configuration,
   });
+}
+
+/** Authenticate the complete program and current projection before deriving value requirements. */
+export function planNativeValueResources(
+  program: PreparedIrProgram,
+  options: PreparedIrBackendOptions,
+  projection: PreparedIrProgramRuntimeProjection,
+  strings: NativeValueStringRepresentation,
+): NativeValueResourcePlan {
+  assertPreparedIrProgram(program);
+  if (
+    !program.runtime.includes(projection) ||
+    projection.backend !== options.backend ||
+    projection.target !== options.target
+  ) {
+    throw new PreparedIrProgramInvariantError(
+      "invalid-prepared-data",
+      "native value resources: selected projection does not belong to the requested program/backend/target",
+    );
+  }
+  return deriveNativeValueResourcePlan(program, projection, strings);
 }
 
 function scalar(type: IrType): ValType | undefined {

--- a/src/ir/program/native-value-resources.ts
+++ b/src/ir/program/native-value-resources.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrType } from "../core/types.js";
+import type { PreparedIrFunction } from "../runtime/contracts/prepared.js";
+import type { PreparedIrProgram, PreparedIrProgramRuntimeProjection } from "./prepared-contracts.js";
+import type { IrUnitId } from "../../shared/contracts/ir-identity.js";
+import { freezePreparedIrValue, preparedIrDataMismatch } from "./data.js";
+import { PreparedIrProgramInvariantError } from "./errors.js";
+
+export type NativeValueStringRepresentation = "native-string" | "primitive-only";
+export interface NativeValueResourcePlan {
+  readonly anchor: string;
+  readonly owners: readonly IrUnitId[];
+  readonly strings: NativeValueStringRepresentation;
+}
+interface Source {
+  readonly program: PreparedIrProgram;
+  readonly projection: PreparedIrProgramRuntimeProjection;
+  readonly strings: NativeValueStringRepresentation;
+}
+const sources = new WeakMap<NativeValueResourcePlan, Source>();
+
+function fail(detail: string): never {
+  throw new PreparedIrProgramInvariantError("invalid-prepared-data", "native value resources: " + detail);
+}
+
+function primitive(type: IrType): boolean {
+  return (
+    type.kind === "val" &&
+    !type.typeRef &&
+    (type.val.kind === "f64" || type.val.kind === "f32" || (type.val.kind === "i32" && !type.val.symbol))
+  );
+}
+
+/** Deliberately narrow affirmative absence proof, not a no-binding fallback. */
+function assertPrimitiveOwner(fn: PreparedIrFunction): void {
+  if (fn.asyncPlan || fn.asyncRuntime || fn.closureSubtype || (fn.funcKind !== undefined && fn.funcKind !== "regular"))
+    fail("primitive-only representation has a runtime-created carrier in " + fn.name);
+  if (![...fn.params.map((p) => p.type), ...fn.resultTypes].every(primitive))
+    fail("primitive-only representation has a reference/unknown signature in " + fn.name);
+  if (fn.slots?.length) fail("primitive-only absence proof does not cover local slots in " + fn.name);
+  if (!fn.blocks.length) fail("empty owner body in " + fn.name);
+  for (const block of fn.blocks) {
+    if (!block.blockArgTypes.every(primitive)) fail("nonprimitive block argument in " + fn.name);
+    for (const instr of block.instrs) {
+      // This proof covers only scalar leaves. Calls, raw Wasm, allocations,
+      // globals, nested buffers and future instruction kinds require a scanner.
+      if (
+        !["const", "binary", "unary", "select"].includes(instr.kind) ||
+        !instr.resultType ||
+        !primitive(instr.resultType) ||
+        Object.hasOwn(instr, "alloc")
+      )
+        fail("primitive-only absence proof does not cover " + instr.kind + " in " + fn.name);
+    }
+  }
+}
+
+function calculate({ program, projection, strings }: Source): NativeValueResourcePlan {
+  if (program.schema !== "prepared-ir-program-v1" || program.sealed !== true || program.reconciliation !== "complete")
+    fail("program is not a complete prepared program");
+  if (
+    !program.runtime.includes(projection) ||
+    projection.backend !== "wasmgc" ||
+    projection.target !== "standalone" ||
+    projection.prepared.manifest.policy.backend !== "wasmgc" ||
+    projection.prepared.manifest.policy.target !== "standalone"
+  )
+    fail("selected projection does not belong to standalone WasmGC");
+  if (strings !== "native-string" && strings !== "primitive-only")
+    fail("missing explicit native string representation");
+  const entry = program.inventory.sources.find((source) => source.kind === "entry");
+  if (!entry || !program.ir.functions.length) fail("missing source anchor or complete owner population");
+  const owners = program.ir.functions.map((fn) => fn.unitId);
+  if (
+    new Set(owners).size !== owners.length ||
+    preparedIrDataMismatch(
+      owners,
+      projection.prepared.functions.map((fn) => fn.unitId),
+    ) !== undefined
+  )
+    fail("selected owner population/order differs");
+  if (strings === "primitive-only") {
+    if (projection.prepared.manifest.providers.length || program.allocations.size)
+      fail("primitive-only absence proof has runtime providers or allocations");
+    for (const init of program.startup) {
+      if (init.bindings.length || init.liveSeeds.length || init.gaps.length)
+        fail("primitive-only absence proof does not cover startup bindings, live seeds or gaps");
+      if (init.executable && !owners.includes(init.unitId!)) fail("primitive-only startup owner is absent");
+    }
+    program.ir.functions.forEach(assertPrimitiveOwner);
+    projection.prepared.functions.forEach(assertPrimitiveOwner);
+    for (const entry of program.abi.entries) {
+      if (entry.contract.kind === "callable") {
+        if (![...entry.contract.params, ...entry.contract.results].every(primitive))
+          fail("primitive-only ABI includes a reference/unknown callable");
+      } else if (entry.contract.kind !== "export" && entry.contract.kind !== "support") {
+        fail("primitive-only absence proof does not cover ABI " + entry.contract.kind);
+      }
+    }
+  }
+  return { anchor: entry.id, owners, strings };
+}
+
+/**
+ * Derive selected resources from the actual complete program/projection.
+ * Full program/current-attachment authentication remains in the parent's checked
+ * wrapper. Primitive-only absence is bounded; it cannot admit the async family.
+ */
+export function deriveNativeValueResourcePlan(
+  program: PreparedIrProgram,
+  projection: PreparedIrProgramRuntimeProjection,
+  strings: NativeValueStringRepresentation,
+): NativeValueResourcePlan {
+  const source = { program, projection, strings };
+  const plan = freezePreparedIrValue(calculate(source)) as NativeValueResourcePlan;
+  sources.set(plan, source);
+  return plan;
+}
+
+/** Require the issued plan and recheck its live selected source; never accept a copied absence flag. */
+export function assertNativeValueResourcePlan(plan: NativeValueResourcePlan): void {
+  const source = sources.get(plan);
+  if (!source || preparedIrDataMismatch(plan, calculate(source)) !== undefined)
+    fail("unissued or stale selected native value requirements");
+}

--- a/src/runtime/wasmgc/values/number-bodies.ts
+++ b/src/runtime/wasmgc/values/number-bodies.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { FuncHandle, Instr, LocalDef } from "../../../wasm/model/instructions.js";
+
+/** Selected conversion arm; omission is never a request to drop native strings. */
+export type NativeNumberStringConversion =
+  | { readonly kind: "native-string"; readonly anyStringTypeIdx: number; readonly toNumber: FuncHandle }
+  | { readonly kind: "absent"; readonly evidence: "selected-primitive-only" };
+
+/** Parameter 0 is f64; local 1 retains the donor's signed-i31 candidate. */
+export function buildBoxNumberLocals(): LocalDef[] {
+  return [{ name: "$i31_temp", type: { kind: "i32" } }];
+}
+
+// 3. __box_number(f64) -> externref
+// (#3673) i31 fast path: an integral value in the signed-31-bit range is
+// encoded as an UNBOXED `(ref i31)` — no allocation. Every consumer that
+// discriminates boxed numbers carries a matching i31 arm. Excluded: -0
+// (i31 cannot carry the sign — `1/x` and Object.is would lose it), NaN and
+// infinities (fail the trunc round-trip), and values outside [-2^30, 2^30-1]
+// (fail the shl/shr round-trip).
+export function buildBoxNumberBody(boxNumStructIdx: number): Instr[] {
+  return [
+    { op: "local.get", index: 0 },
+    { op: "i32.trunc_sat_f64_s" },
+    { op: "local.tee", index: 1 },
+    { op: "f64.convert_i32_s" },
+    { op: "local.get", index: 0 },
+    { op: "f64.eq" }, // integral (and clamp-free) round-trip
+    { op: "local.get", index: 1 },
+    { op: "i32.const", value: 1 },
+    { op: "i32.shl" },
+    { op: "i32.const", value: 1 },
+    { op: "i32.shr_s" },
+    { op: "local.get", index: 1 },
+    { op: "i32.eq" }, // fits signed 31 bits
+    { op: "i32.and" },
+    { op: "local.get", index: 1 },
+    { op: "i32.const", value: 0 },
+    { op: "i32.ne" },
+    { op: "local.get", index: 0 },
+    { op: "i64.reinterpret_f64" },
+    { op: "i64.const", value: 0n },
+    { op: "i64.lt_s" },
+    { op: "i32.eqz" },
+    { op: "i32.or" }, // t != 0 || sign bit clear (rejects -0 only)
+    { op: "i32.and" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [{ op: "local.get", index: 1 }, { op: "ref.i31" }, { op: "extern.convert_any" }],
+      else: [
+        { op: "local.get", index: 0 },
+        { op: "struct.new", typeIdx: boxNumStructIdx },
+        { op: "extern.convert_any" },
+      ],
+    },
+  ];
+}
+
+export function buildUnboxNumberLocals(): LocalDef[] {
+  return [{ name: "$any_temp", type: { kind: "anyref" } }];
+}
+
+// 4. __unbox_number(externref) -> f64
+//    Local 1 is an anyref temp used to ref.test then ref.cast without
+//    re-evaluating the parameter (which is fine — it's a local.get —
+//    but the temp shape mirrors the spec'd structure for symmetry).
+export function buildUnboxNumberBody(
+  boxNumStructIdx: number,
+  boxBoolStructIdx: number,
+  strings: NativeNumberStringConversion,
+): Instr[] {
+  if (!strings || (strings.kind !== "native-string" && strings.kind !== "absent"))
+    throw new Error("native number bodies: missing explicit string conversion");
+  if (strings.kind === "absent" && strings.evidence !== "selected-primitive-only")
+    throw new Error("native number bodies: missing string absence evidence");
+  if (
+    strings.kind === "native-string" &&
+    (!Number.isInteger(strings.anyStringTypeIdx) ||
+      strings.anyStringTypeIdx < 0 ||
+      !Number.isInteger(strings.toNumber) ||
+      strings.toNumber < 0)
+  )
+    throw new Error("native number bodies: unresolved string conversion binding");
+  return [
+    // if (ref.is_null param) return 0   // Number(null) === 0
+    { op: "local.get", index: 0 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "f64.const", value: 0 }, { op: "return" }],
+    },
+    // any = any.convert_extern(param)
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: 1 },
+    // (#3673) i31-boxed small int → its value.
+    { op: "local.get", index: 1 },
+    { op: "ref.test", typeIdx: -20 },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 1 },
+        { op: "ref.cast", typeIdx: -20 },
+        { op: "i31.get_s" },
+        { op: "f64.convert_i32_s" },
+        { op: "return" },
+      ],
+    },
+    { op: "local.get", index: 1 },
+    // if (ref.test $box_number_struct any) return any.value
+    { op: "ref.test", typeIdx: boxNumStructIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 1 },
+        { op: "ref.cast", typeIdx: boxNumStructIdx },
+        { op: "struct.get", typeIdx: boxNumStructIdx, fieldIdx: 0 },
+        { op: "return" },
+      ],
+    },
+    // #1910 R3 — a boxed boolean (the [[BooleanData]] slot of a
+    // `new Boolean(x)` wrapper, recovered by `__to_primitive`) coerces per
+    // §7.1.4 ToNumber(true)=1, ToNumber(false)=0. Without this arm a boxed
+    // boolean fell through to the opaque-ref NaN fallback, so
+    // `Number(new Boolean(true))` returned NaN instead of 1.
+    { op: "local.get", index: 1 },
+    { op: "ref.test", typeIdx: boxBoolStructIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 1 },
+        { op: "ref.cast", typeIdx: boxBoolStructIdx },
+        { op: "struct.get", typeIdx: boxBoolStructIdx, fieldIdx: 0 },
+        { op: "f64.convert_i32_s" },
+        { op: "return" },
+      ],
+    },
+    ...(strings.kind === "native-string"
+      ? ([
+          // StringToNumber (§7.1.4.1): object ToPrimitive can yield a native
+          // string; parse it with the existing pure-Wasm scanner before the
+          // opaque-ref NaN fallback.
+          { op: "local.get", index: 1 },
+          { op: "ref.test", typeIdx: strings.anyStringTypeIdx },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "local.get", index: 0 }, { op: "call", funcIdx: strings.toNumber }, { op: "return" }],
+          },
+        ] satisfies Instr[])
+      : []),
+    // not a recognized boxed number → NaN (matches Number(opaque))
+    { op: "f64.const", value: NaN },
+  ];
+}
+
+// 8. __typeof_number(externref) -> i32 — `ref.test $box_number_struct`.
+export function buildTypeofNumberBody(boxNumStructIdx: number): Instr[] {
+  return [
+    { op: "local.get", index: 0 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+    },
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: boxNumStructIdx },
+    // (#3673) …or an i31-boxed small int.
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: -20 },
+    { op: "i32.or" },
+  ];
+}

--- a/src/runtime/wasmgc/values/primitive-layouts.ts
+++ b/src/runtime/wasmgc/values/primitive-layouts.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr } from "../../../wasm/model/instructions.js";
+import type { StructTypeDef } from "../../../wasm/model/module-records.js";
+
+/** Exact five-field carrier shared by legacy and prepared native values. */
+export function buildAnyValueType(): StructTypeDef {
+  return {
+    kind: "struct",
+    name: "AnyValue",
+    fields: [
+      { name: "tag", type: { kind: "i32" }, mutable: false },
+      { name: "i32val", type: { kind: "i32" }, mutable: false },
+      { name: "f64val", type: { kind: "f64" }, mutable: false },
+      { name: "refval", type: { kind: "eqref" }, mutable: false },
+      { name: "externval", type: { kind: "externref" }, mutable: false },
+    ],
+  };
+}
+
+/** Canonical non-null undefined: tag 1, zero, NaN, null eq, null extern. */
+export function buildUndefinedInitializer(anyTypeIdx: number): Instr[] {
+  const EQ_HEAP_TYPE = -19; // WasmGC `eq` abstract heap type
+  return [
+    { op: "i32.const", value: 1 }, // tag = 1 (Undefined)
+    { op: "i32.const", value: 0 }, // i32val
+    { op: "f64.const", value: NaN }, // f64val
+    { op: "ref.null", typeIdx: EQ_HEAP_TYPE }, // refval
+    { op: "ref.null.extern" }, // externval
+    { op: "struct.new", typeIdx: anyTypeIdx },
+  ];
+}
+
+export function buildBoxNumberType(): StructTypeDef {
+  return {
+    kind: "struct",
+    name: "__box_number_struct",
+    fields: [{ name: "value", type: { kind: "f64" }, mutable: false }],
+  };
+}
+
+export function buildBoxBooleanType(): StructTypeDef {
+  return {
+    kind: "struct",
+    name: "__box_boolean_struct",
+    fields: [{ name: "value", type: { kind: "i32" }, mutable: false }],
+  };
+}

--- a/tests/issue-3518-native-value-boundary.test.ts
+++ b/tests/issue-3518-native-value-boundary.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import { prepareTypedIrProgram } from "../src/ir/program-prepare-ir.js";
+import { planNativeValueResources } from "../src/ir/program-physical-plan.js";
+import { PreparedIrProgramInvariantError } from "../src/ir/program/errors.js";
+import { sourcePacket, typedOptions, requireProgram } from "./helpers/typed-program-fixtures.js";
+import { encodeTypedPacket, decodeTypedPacket } from "./helpers/typed-program-transport.mjs";
+
+const options = { backend: "wasmgc", target: "standalone" } as const;
+function prepare(replay = false) {
+  const { packet } = sourcePacket({ "./entry.ts": "export function main(): number { return 42; }" });
+  const input = replay ? decodeTypedPacket(encodeTypedPacket(packet)) : packet;
+  if (replay) expect(input).not.toBe(packet);
+  return requireProgram(prepareTypedIrProgram(input, typedOptions));
+}
+type Program = ReturnType<typeof prepare>;
+function positive(program: Program) {
+  const projection = program.runtime[0]!;
+  const plan = planNativeValueResources(program, options, projection, "primitive-only");
+  expect(plan.owners).toEqual(program.ir.functions.map((fn) => fn.unitId));
+  expect(plan.owners.length).toBeGreaterThan(0);
+  expect(plan.strings).toBe("primitive-only");
+  return projection;
+}
+
+describe("checked native value whole-program/current-projection boundary", () => {
+  it("accepts the genuine complete program", () => {
+    positive(prepare());
+  });
+  it("accepts preparation from actual serialized and decoded typed input", () => {
+    positive(prepare(true));
+  });
+  it("rejects an unsealed program after a real positive", () => {
+    const program = prepare(),
+      projection = positive(program);
+    expect(() =>
+      planNativeValueResources(
+        { ...program, sealed: false } as unknown as Program,
+        options,
+        projection,
+        "primitive-only",
+      ),
+    ).toThrow("program is not a complete prepared program");
+  });
+  it("rejects a detached selected projection after a real positive", () => {
+    const program = prepare(),
+      projection = positive(program);
+    expect(() => planNativeValueResources(program, options, { ...projection }, "primitive-only")).toThrow(
+      "native value resources: selected projection does not belong",
+    );
+  });
+  it("rejects another genuinely prepared program's projection", () => {
+    const program = prepare(),
+      foreign = prepare(true);
+    positive(program);
+    const projection = positive(foreign);
+    expect(() => planNativeValueResources(program, options, projection, "primitive-only")).toThrow(
+      "native value resources: selected projection does not belong",
+    );
+  });
+  it("rejects a backend mismatch after a real positive", () => {
+    const program = prepare(),
+      projection = positive(program);
+    expect(() =>
+      planNativeValueResources(program, { ...options, backend: "linear" }, projection, "primitive-only"),
+    ).toThrow("native value resources: selected projection does not belong");
+  });
+  it("rejects a target mismatch after a real positive", () => {
+    const program = prepare(),
+      projection = positive(program);
+    expect(() =>
+      planNativeValueResources(
+        program,
+        { ...options, target: "host" } as unknown as typeof options,
+        projection,
+        "primitive-only",
+      ),
+    ).toThrow("native value resources: selected projection does not belong");
+  });
+  it("rejects changed selected instructions despite identical owner coordinates", () => {
+    const program = prepare(),
+      original = positive(program);
+    let changed = 0;
+    const functions = original.prepared.functions.map((fn) => ({
+      ...fn,
+      blocks: fn.blocks.map((block) => ({
+        ...block,
+        instrs: block.instrs.map((instr) => {
+          if (instr.kind !== "const") return instr;
+          changed++;
+          return { ...instr, value: 43 };
+        }),
+      })),
+    }));
+    expect(changed).toBeGreaterThan(0);
+    expect(functions).not.toEqual(original.prepared.functions);
+    const projection = { ...original, prepared: { ...original.prepared, functions } };
+    const mutated = {
+      ...program,
+      runtime: program.runtime.map((row) => (row === original ? projection : row)),
+    } as Program;
+    expect(projection.prepared.functions.map((fn) => fn.unitId)).toEqual(program.ir.functions.map((fn) => fn.unitId));
+    expect(() => planNativeValueResources(mutated, options, projection, "native-string")).toThrow(
+      "contradicts complete semantic/provider data",
+    );
+  });
+  it("rejects a missing ABI entry after a real positive", () => {
+    const program = prepare(),
+      projection = positive(program);
+    expect(program.abi.entries.length).toBeGreaterThan(0);
+    const mutated = { ...program, abi: { ...program.abi, entries: [] } };
+    expect(() => planNativeValueResources(mutated, options, projection, "native-string")).toThrow(
+      PreparedIrProgramInvariantError,
+    );
+  });
+  it("rejects a missing unit receipt despite retained sealed flags", () => {
+    const program = prepare(),
+      projection = positive(program);
+    expect(program.units.size).toBeGreaterThan(0);
+    const mutated = { ...program, units: new Map() };
+    expect(() => planNativeValueResources(mutated, options, projection, "native-string")).toThrow(
+      PreparedIrProgramInvariantError,
+    );
+  });
+});

--- a/tests/issue-3518-native-value-resources.test.ts
+++ b/tests/issue-3518-native-value-resources.test.ts
@@ -1,0 +1,609 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import { setImmediate } from "node:timers/promises";
+import ts from "typescript";
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyModule } from "../src/ir/types.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import { prepareIrProgramSources, captureTypedIrProgramInput } from "../src/ir/program-source.js";
+import { prepareTypedIrProgram } from "../src/ir/program-prepare-ir.js";
+import { sourceInput, typedOptions, requireProgram } from "./helpers/typed-program-fixtures.js";
+import { encodeTypedPacket, decodeTypedPacket } from "./helpers/typed-program-transport.mjs";
+import {
+  deriveNativeValueResourcePlan,
+  assertNativeValueResourcePlan,
+} from "../src/ir/program/native-value-resources.js";
+import {
+  reserveNativeValueResources,
+  fillNativeValueResources,
+  type NativeValueDependencies,
+} from "../src/backend/wasmgc/resources/native-values.js";
+import { buildUnboxNumberBody } from "../src/runtime/wasmgc/values/number-bodies.js";
+
+afterEach(async () => {
+  await setImmediate();
+});
+const policy = { backend: "wasmgc", target: "standalone" } as const;
+const primitiveSource = "export function main(value: number): number { return value; }";
+function prepare(replay = false, text = primitiveSource) {
+  const source = prepareIrProgramSources({ ...sourceInput({ "./entry.ts": text }), policy });
+  if (source.kind !== "prepared") throw Error(source.detail);
+  const packet = captureTypedIrProgramInput(source);
+  const program = requireProgram(
+    prepareTypedIrProgram(replay ? decodeTypedPacket(encodeTypedPacket(packet)) : packet, {
+      ...typedOptions,
+      policy,
+      runtimePolicies: [policy],
+    }),
+  );
+  const projection = program.runtime[0]!;
+  return { program, projection, plan: deriveNativeValueResourcePlan(program, projection, "primitive-only") };
+}
+let cached: ReturnType<typeof prepare> | undefined;
+const actual = () => (cached ??= prepare());
+const absent = (): NativeValueDependencies => ({ strings: { kind: "absent" } });
+
+function reserve() {
+  const module = createEmptyModule(),
+    tx = new PhysicalModuleReservations(module);
+  const dependencies = absent(),
+    plan = actual().plan;
+  const pack = reserveNativeValueResources(tx, plan, dependencies);
+  const f64 = { kind: "f64" } as const,
+    i32 = { kind: "i32" } as const,
+    extern = { kind: "externref" } as const;
+  const roundtrip = tx.reserveFunction("control:roundtrip", "roundtrip", { params: [f64], results: [f64] });
+  const small = tx.reserveFunction("control:small", "small", { params: [f64], results: [i32] });
+  const boolean = tx.reserveFunction("control:boolean", "boolean", { params: [i32], results: [extern] });
+  const undefinedValue = tx.reserveFunction("control:undefined", "undefinedValue", { params: [], results: [extern] });
+  const tag = tx.reserveFunction("control:tag", "tag", { params: [], results: [i32] });
+  return { module, tx, dependencies, pack, roundtrip, small, boolean, undefinedValue, tag };
+}
+
+function filled() {
+  const state = reserve();
+  const { tx, pack, dependencies, roundtrip, small, boolean, undefinedValue, tag } = state;
+  tx.freezeReservations();
+  fillNativeValueResources(tx, pack, dependencies);
+  tx.fillFunction(roundtrip, {
+    locals: [],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: pack.functions.boxNumber.handle },
+      { op: "call", funcIdx: pack.functions.unboxNumber.handle },
+    ],
+  });
+  tx.fillFunction(small, {
+    locals: [],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: pack.functions.boxNumber.handle },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: -20 },
+    ],
+  });
+  tx.fillFunction(boolean, {
+    locals: [],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "struct.new", typeIdx: pack.types.boxedBoolean.typeIndex },
+      { op: "extern.convert_any" },
+    ],
+  });
+  tx.fillFunction(undefinedValue, {
+    locals: [],
+    body: [{ op: "global.get", index: tx.physicalIndex(pack.globals.undefined) }, { op: "extern.convert_any" }],
+  });
+  tx.fillFunction(tag, {
+    locals: [],
+    body: [
+      { op: "global.get", index: tx.physicalIndex(pack.globals.undefined) },
+      { op: "struct.get", typeIdx: pack.types.anyValue.typeIndex, fieldIdx: 0 },
+    ],
+  });
+  for (const [name, fn] of Object.entries({
+    box: pack.functions.boxNumber,
+    unbox: pack.functions.unboxNumber,
+    isNumber: pack.functions.isNumber,
+    roundtrip,
+    small,
+    boolean,
+    undefinedValue,
+    tag,
+  }))
+    tx.defineExport("export:" + name, name, fn);
+  return state;
+}
+interface Exports {
+  box(value: number): unknown;
+  unbox(value: unknown): number;
+  isNumber(value: unknown): number;
+  roundtrip(value: number): number;
+  small(value: number): number;
+  boolean(value: number): unknown;
+  undefinedValue(): unknown;
+  tag(): number;
+}
+function execute() {
+  const { module, tx } = filled();
+  const census = tx.seal();
+  const binary = emitBinary(module);
+  const compiled = new WebAssembly.Module(binary as BufferSource);
+  expect(WebAssembly.Module.imports(compiled)).toEqual([]);
+  return { exports: new WebAssembly.Instance(compiled, {}).exports as unknown as Exports, census };
+}
+let execution: ReturnType<typeof execute> | undefined;
+const executed = () => (execution ??= execute());
+
+describe("native primitive resources: executed bodies, not signature-only admission", () => {
+  it("uses actual source-produced requirements and the complete single-ledger fill census", () => {
+    const { program, plan } = actual();
+    expect(plan.owners).toEqual(program.ir.functions.map((fn) => fn.unitId));
+    expect(plan.owners.length).toBeGreaterThan(0);
+    expect(executed().census.completedFunctions).toBe(8);
+    expect(executed().census.completedGlobals).toBe(1);
+    expect(executed().census.types).toBeGreaterThanOrEqual(6);
+  });
+  it.each([-1073741824, -1073741823, -1, 0, 1, 1073741822, 1073741823])(
+    "executes signed-i31 boxing and numeric recovery for %s",
+    (value) => {
+      const x = executed().exports;
+      expect(x.small(value)).toBe(1);
+      expect(x.isNumber(x.box(value))).toBe(1);
+      expect(Object.is(x.roundtrip(value), value)).toBe(true);
+    },
+  );
+  it.each([-1073741825, 1073741824, 3e9, -0, 1.5, -1.5, NaN, Infinity, -Infinity])(
+    "executes boxed-f64 preservation for %s",
+    (value) => {
+      const x = executed().exports;
+      expect(x.small(value)).toBe(0);
+      expect(x.isNumber(x.box(value))).toBe(1);
+      expect(Object.is(x.roundtrip(value), value)).toBe(true);
+    },
+  );
+  it("executes boolean conversion before the opaque fallback", () => {
+    const x = executed().exports;
+    expect(x.unbox(x.boolean(0))).toBe(0);
+    expect(x.unbox(x.boolean(1))).toBe(1);
+    expect(x.isNumber(x.boolean(1))).toBe(0);
+  });
+  it("executes distinct canonical undefined and null behavior", () => {
+    const x = executed().exports,
+      undefinedValue = x.undefinedValue();
+    expect(undefinedValue).not.toBeNull();
+    expect(x.undefinedValue()).toBe(undefinedValue);
+    expect(x.tag()).toBe(1);
+    expect(x.unbox(null)).toBe(0);
+    expect(x.unbox(undefinedValue)).toBeNaN();
+    expect(x.isNumber(null)).toBe(0);
+    expect(x.isNumber(undefinedValue)).toBe(0);
+  });
+  it("keeps primitive-only absence source-bound across codec replay", () => {
+    const direct = actual(),
+      replay = prepare(true);
+    expect(replay.plan).toEqual(direct.plan);
+    expect(() => assertNativeValueResourcePlan(replay.plan)).not.toThrow();
+    expect(() => assertNativeValueResourcePlan({ ...replay.plan })).toThrow("unissued");
+  });
+  it("rejects an unsealed program only after its real positive", () => {
+    const { program, projection, plan } = actual();
+    expect(() => assertNativeValueResourcePlan(plan)).not.toThrow();
+    expect(() =>
+      deriveNativeValueResourcePlan(
+        { ...program, sealed: false } as unknown as typeof program,
+        projection,
+        "primitive-only",
+      ),
+    ).toThrow("complete prepared program");
+  });
+  it("rejects an omitted selected owner after authentic scalar preparation", () => {
+    const { program, projection, plan } = actual();
+    assertNativeValueResourcePlan(plan);
+    const missing = { ...projection, prepared: { ...projection.prepared, functions: [] } };
+    const changed = { ...program, runtime: [missing] };
+    expect(() => deriveNativeValueResourcePlan(changed, missing, "primitive-only")).toThrow("owner population");
+  });
+  it("does not infer scanner absence from a source owner with an unaccounted carrier", () => {
+    const { program, projection, plan } = actual();
+    assertNativeValueResourcePlan(plan);
+    const first = program.ir.functions[0]!;
+    const functions = [
+      { ...first, resultTypes: [{ kind: "val", val: { kind: "externref" } } as const] },
+      ...program.ir.functions.slice(1),
+    ];
+    const changed = { ...program, ir: { ...program.ir, functions } };
+    expect(() => deriveNativeValueResourcePlan(changed, projection, "primitive-only")).toThrow(
+      "reference/unknown signature",
+    );
+  });
+  it("does not turn a missing scanner into absence in the native-string representation", () => {
+    const { program, projection } = actual();
+    expect(() => reserve()).not.toThrow();
+    const plan = deriveNativeValueResourcePlan(program, projection, "native-string");
+    const tx = new PhysicalModuleReservations(createEmptyModule());
+    expect(() => reserveNativeValueResources(tx, plan, absent())).toThrow("actual StringToNumber");
+  });
+  it("requires explicit builder-side string selection", () => {
+    expect(buildUnboxNumberBody(0, 1, { kind: "absent", evidence: "selected-primitive-only" })).not.toHaveLength(0);
+    expect(() => buildUnboxNumberBody(0, 1, undefined!)).toThrow("explicit string conversion");
+    expect(() =>
+      buildUnboxNumberBody(0, 1, { kind: "native-string", anyStringTypeIdx: 2, toNumber: undefined! }),
+    ).toThrow("unresolved string conversion");
+  });
+  it("rejects fills before freeze and duplicate fills", () => {
+    const first = reserve();
+    expect(() => fillNativeValueResources(first.tx, first.pack, first.dependencies)).toThrow(
+      "physical index requested in reserving",
+    );
+    const second = filled();
+    expect(() => fillNativeValueResources(second.tx, second.pack, second.dependencies)).toThrow("duplicate");
+  });
+  it("rejects a foreign transaction and copied resource wrapper", () => {
+    const state = filled();
+    expect(() =>
+      fillNativeValueResources(new PhysicalModuleReservations(createEmptyModule()), state.pack, state.dependencies),
+    ).toThrow("foreign");
+    expect(() => fillNativeValueResources(state.tx, { ...state.pack }, state.dependencies)).toThrow("foreign");
+  });
+  it("retains missing-fill failure for real reserved resources", () => {
+    expect(executed().census.completedGlobals).toBe(1);
+    const state = reserve();
+    state.tx.freezeReservations();
+    expect(() => state.tx.seal()).toThrow(/missing .* fill/);
+  });
+  it("rejects stale/altered primitive layout after a real positive", () => {
+    expect(executed().exports.roundtrip(3e9)).toBe(3e9);
+    const state = reserve();
+    const type = state.pack.types.boxedNumber.object;
+    if (type.kind !== "struct") throw Error("missing actual number struct");
+    type.fields[0]!.mutable = true;
+    expect(() => state.tx.freezeReservations()).toThrow("altered");
+  });
+  it("rejects a wrong callable signature at the original ledger boundary", () => {
+    expect(executed().exports.roundtrip(-0)).toBe(-0);
+    const state = reserve();
+    state.pack.functions.unboxNumber.object.typeIdx = state.pack.functions.boxNumber.object.typeIdx;
+    expect(() => state.tx.freezeReservations()).toThrow();
+  });
+  it.each([0, 1, 2, 3, 4, 5])("rejects a changed undefined initializer instruction %s", (index) => {
+    expect(executed().exports.tag()).toBe(1);
+    const state = filled();
+    state.pack.globals.undefined.object.init[index] = { op: "i32.const", value: 42 };
+    expect(() => state.tx.seal()).toThrow("altered");
+  });
+});
+
+// Fixed 5118637 donor receipts. Tests read mandatory LIVE files only. Whitespace
+// and optional separators are irrelevant; the complete parsed tree, lexical
+// operators/declaration keywords and comments are not. This also covers every
+// retained union helper, nested callback, cache write and registration position.
+const sourcePaths = {
+  any: "src/codegen/any-helpers.ts",
+  union: "src/codegen/registry/imports.ts",
+  layouts: "src/runtime/wasmgc/values/primitive-layouts.ts",
+  numbers: "src/runtime/wasmgc/values/number-bodies.ts",
+} as const;
+type Sources = Record<keyof typeof sourcePaths, string>;
+function liveSources(): Sources {
+  return Object.fromEntries(
+    Object.entries(sourcePaths).map(([key, path]) => [
+      key,
+      readFileSync(resolve(import.meta.dirname, "..", path), "utf8"),
+    ]),
+  ) as Sources;
+}
+function parsed(text: string): ts.SourceFile {
+  const file = ts.createSourceFile("receipt.ts", text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  if ((file as ts.SourceFile & { parseDiagnostics: readonly unknown[] }).parseDiagnostics.length)
+    throw Error("native value receipt: invalid syntax");
+  return file;
+}
+function sourceHash(text: string): string {
+  const file = parsed(text);
+  const comments = new Map<number, ts.CommentRange>();
+  function tree(node: ts.Node): unknown {
+    for (const range of [
+      ...(ts.getLeadingCommentRanges(text, node.getFullStart()) ?? []),
+      ...(ts.getTrailingCommentRanges(text, node.end) ?? []),
+    ])
+      comments.set(range.pos, range);
+    const children = node
+      .getChildren(file)
+      .filter(
+        (child) =>
+          ![ts.SyntaxKind.CommaToken, ts.SyntaxKind.SemicolonToken, ts.SyntaxKind.EndOfFileToken].includes(
+            child.kind,
+          ) && !(child.kind >= ts.SyntaxKind.FirstJSDocNode && child.kind <= ts.SyntaxKind.LastJSDocNode),
+      );
+    return [node.kind, children.length ? children.map(tree) : node.getText(file)];
+  }
+  const syntax = tree(file);
+  const docs = [...comments.values()]
+    .sort((a, b) => a.pos - b.pos)
+    .map((range) => [
+      range.kind,
+      text
+        .slice(range.pos, range.end)
+        .split("\n")
+        .map((line) => line.trim())
+        .join("\n"),
+    ]);
+  return createHash("sha256")
+    .update(JSON.stringify([syntax, docs]))
+    .digest("hex");
+}
+/** Supplemental receipt: visit punctuation/EOF before any syntax filtering. */
+function completeCommentReceipt(text: string): { count: number; sha256: string } {
+  const file = parsed(text);
+  const comments = new Map<number, ts.CommentRange>();
+  function visit(node: ts.Node): void {
+    for (const range of [
+      ...(ts.getLeadingCommentRanges(text, node.getFullStart()) ?? []),
+      ...(ts.getTrailingCommentRanges(text, node.end) ?? []),
+    ])
+      comments.set(range.pos, range);
+    // The entire JSDoc range is captured as trivia. Its interior is prose, not
+    // a second JavaScript token stream. All actual tokens, including commas,
+    // semicolons and EOF, are otherwise visited without omission.
+    if (node.kind >= ts.SyntaxKind.FirstJSDocNode && node.kind <= ts.SyntaxKind.LastJSDocNode) return;
+    for (const child of node.getChildren(file)) visit(child);
+  }
+  visit(file);
+  const rows = [...comments.values()]
+    .sort((a, b) => a.pos - b.pos)
+    .map((range) => [
+      range.kind,
+      text
+        .slice(range.pos, range.end)
+        .split("\n")
+        .map((line) => line.trim())
+        .join("\n"),
+    ]);
+  return { count: rows.length, sha256: createHash("sha256").update(JSON.stringify(rows)).digest("hex") };
+}
+function replaceOnce(text: string, before: string, after: string): string {
+  const start = text.indexOf(before);
+  if (start < 0 || text.indexOf(before, start + before.length) >= 0)
+    throw Error("missing/duplicate mapped edit: " + before);
+  return text.slice(0, start) + after + text.slice(start + before.length);
+}
+function returned(text: string, name: string): string {
+  const matches = parsed(text).statements.filter(
+    (node): node is ts.FunctionDeclaration => ts.isFunctionDeclaration(node) && node.name?.text === name,
+  );
+  if (matches.length !== 1 || !matches[0]!.body) throw Error("missing/duplicate canonical builder " + name);
+  const returns = matches[0]!.body!.statements.filter(ts.isReturnStatement);
+  if (returns.length !== 1 || !returns[0]!.expression) throw Error("missing canonical return " + name);
+  return returns[0]!.expression!.getText();
+}
+function expandCall(text: string, name: string, expectedArgs: string[], body: string): string {
+  const file = parsed(text),
+    matches: ts.CallExpression[] = [];
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === name)
+      matches.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(file);
+  if (matches.length !== 1) throw Error("missing/duplicate downward call " + name);
+  const call = matches[0]!;
+  if (
+    call.arguments.length !== expectedArgs.length ||
+    call.arguments.some((arg, i) => sourceHash(arg.getText()) !== sourceHash(expectedArgs[i]!))
+  )
+    throw Error("altered downward arguments " + name);
+  return text.slice(0, call.getStart()) + body + text.slice(call.end);
+}
+function removeImport(text: string, target: string, bindings: string[]): string {
+  const file = parsed(text);
+  const matches = file.statements.filter(
+    (node): node is ts.ImportDeclaration =>
+      ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier) && node.moduleSpecifier.text === target,
+  );
+  if (matches.length !== 1) throw Error("missing/duplicate canonical import " + target);
+  const node = matches[0]!,
+    clause = node.importClause;
+  if (
+    !clause ||
+    clause.isTypeOnly ||
+    clause.name ||
+    !clause.namedBindings ||
+    !ts.isNamedImports(clause.namedBindings) ||
+    node.attributes ||
+    JSON.stringify(
+      clause.namedBindings.elements.map((binding) => [
+        binding.name.text,
+        binding.propertyName?.text,
+        binding.isTypeOnly,
+      ]),
+    ) !== JSON.stringify(bindings.map((name) => [name, undefined, false]))
+  )
+    throw Error("altered canonical import " + target);
+  return text.slice(0, node.getStart()) + text.slice(node.end);
+}
+const sourceReceipts = {
+  any: "04071954b55d418ae7049b184c1b005e8fede0559ab0ad69f017ff08e087c635",
+  union: "7f8be351ea8004c7e86240336700fbd925c1632186011d7d94baf3854c59e0d8",
+  layouts: "e84e851859b521b4ed31afa86559a1427f32bc877da2c59335e001d6b7fc1281",
+  numbers: "ec5282195166408a0504c8cb75fe758723a3c0e85e1c848822bc12af1dc2e70d",
+} as const;
+// Additive only: the two original module hashes and two current delta hashes
+// above remain unchanged. Historical comment rows come from the exact 5118637
+// donors; new-owner comment rows come from the frozen rev1 canonical files.
+const commentReceipts = {
+  any: { count: 476, sha256: "e35e9db59375f54f74bc491a39aba1f0eede0224894a9f8824447fb923f63c68" },
+  union: { count: 595, sha256: "21581e0cb2aa1c7df12188a698c2b86c43075934e21d5eea64511d6e2bcad0f6" },
+  layouts: { count: 9, sha256: "34bb559fdbccc741ffb7d5523124f07522e084b8530ebbe35392c9ad44cdac7b" },
+  numbers: { count: 32, sha256: "a42a5c888b538b807f71341fc2b90fc433c6964f7bfbe10dcef2b52f8f4b7b57" },
+} as const;
+function verifyCommentReceipt(text: string, owner: keyof Sources): void {
+  const actual = completeCommentReceipt(text),
+    expected = commentReceipts[owner];
+  if (actual.count !== expected.count || actual.sha256 !== expected.sha256)
+    throw Error("complete comment receipt: " + owner);
+}
+function historicalSources(live: Sources): Pick<Sources, "any" | "union"> {
+  // Supplemental current delta pins include every new guard, signature, import
+  // and attached document. They do not replace either original donor receipt.
+  for (const owner of ["layouts", "numbers"] as const) {
+    if (!live[owner] || sourceHash(live[owner]) !== sourceReceipts[owner])
+      throw Error("canonical source receipt: " + owner);
+    verifyCommentReceipt(live[owner], owner);
+  }
+  let any = removeImport(live.any, "../runtime/wasmgc/values/primitive-layouts.js", [
+    "buildAnyValueType",
+    "buildUndefinedInitializer",
+  ]);
+  any = expandCall(any, "buildAnyValueType", [], returned(live.layouts, "buildAnyValueType"));
+  any = expandCall(
+    any,
+    "buildUndefinedInitializer",
+    ["anyTypeIdx"],
+    returned(live.layouts, "buildUndefinedInitializer"),
+  );
+  const singletonGuard = "if ((ctx.standalone || ctx.nativeStrings) && ctx.undefinedGlobalIdx === undefined) {";
+  any = replaceOnce(
+    any,
+    singletonGuard,
+    singletonGuard + "\nconst EQ_HEAP_TYPE = -19; // WasmGC `eq` abstract heap type",
+  );
+  let union = removeImport(live.union, "../../runtime/wasmgc/values/primitive-layouts.js", [
+    "buildBoxNumberType",
+    "buildBoxBooleanType",
+  ]);
+  union = removeImport(union, "../../runtime/wasmgc/values/number-bodies.js", [
+    "buildBoxNumberBody",
+    "buildBoxNumberLocals",
+    "buildUnboxNumberBody",
+    "buildUnboxNumberLocals",
+    "buildTypeofNumberBody",
+  ]);
+  for (const name of ["buildBoxNumberType", "buildBoxBooleanType"])
+    union = expandCall(union, name, [], returned(live.layouts, name));
+  for (const name of ["buildBoxNumberBody", "buildTypeofNumberBody"])
+    union = expandCall(union, name, ["boxNumStructIdx"], returned(live.numbers, name));
+  for (const [name, kind] of [
+    ["buildBoxNumberLocals", "i32"],
+    ["buildUnboxNumberLocals", "anyref"],
+  ]) {
+    const locals = replaceOnce(
+      returned(live.numbers, name!),
+      '{ kind: "' + kind + '" }',
+      '{ kind: "' + kind + '" } as ValType',
+    );
+    union = expandCall(union, name!, [], locals);
+  }
+  let unbox = returned(live.numbers, "buildUnboxNumberBody");
+  unbox = replaceOnce(
+    unbox,
+    'strings.kind === "native-string"',
+    "strToNumberIdx !== undefined && ctx.anyStrTypeIdx >= 0",
+  );
+  unbox = replaceOnce(unbox, "strings.anyStringTypeIdx", "ctx.anyStrTypeIdx");
+  unbox = replaceOnce(unbox, "strings.toNumber", "strToNumberIdx");
+  union = expandCall(
+    union,
+    "buildUnboxNumberBody",
+    [
+      "boxNumStructIdx",
+      "boxBoolStructIdx",
+      `strToNumberIdx !== undefined && ctx.anyStrTypeIdx >= 0
+    ? { kind: "native-string", anyStringTypeIdx: ctx.anyStrTypeIdx, toNumber: strToNumberIdx }
+    : { kind: "absent", evidence: "selected-primitive-only" }`,
+    ],
+    unbox,
+  );
+  return { any, union };
+}
+function verifySourceReceipts(live: Sources): void {
+  const historical = historicalSources(live);
+  for (const owner of ["any", "union"] as const) {
+    if (sourceHash(historical[owner]) !== sourceReceipts[owner]) throw Error("historical donor receipt: " + owner);
+    verifyCommentReceipt(historical[owner], owner);
+  }
+}
+
+describe("mandatory live native-value donor reconstruction", () => {
+  it("retains both complete donor modules, including nested bodies, docs and unrelated BigInt", () => {
+    verifySourceReceipts(liveSources());
+  });
+  it.each(["layouts", "numbers"] as const)("rejects missing canonical %s", (owner) => {
+    const live = liveSources();
+    verifySourceReceipts(live);
+    const changed = { ...live, [owner]: "" };
+    expect(() => verifySourceReceipts(changed)).toThrow();
+  });
+  it.each([
+    ["numbers", 'op: "i32.shl"', 'op: "i32.shr_s"'],
+    ["numbers", 'name: "$i31_temp"', 'name: "$lost"'],
+    ["numbers", "!Number.isInteger(strings.toNumber)", "~Number.isInteger(strings.toNumber)"],
+    ["numbers", "return [", "const ignored = 1; return ["],
+    ["layouts", "const EQ_HEAP_TYPE", "let EQ_HEAP_TYPE"],
+    ["layouts", 'name: "tag"', 'name: "lost"'],
+    ["layouts", "value: NaN", "value: 0"],
+    ["layouts", "tag = 1 (Undefined)", "tag = 1 (Null)"],
+    ["union", "ctx.nativeBoxNumberTypeIdx = boxNumStructIdx;", "ctx.nativeBoxNumberTypeIdx = boxBoolStructIdx;"],
+    ["union", 'kind: "i64", bigint: true', 'kind: "i64", bigint: false'],
+    ["union", "buildBoxNumberBody(boxNumStructIdx)", "buildBoxNumberBody(boxBoolStructIdx)"],
+    ["any", "ctx.undefinedGlobalIdx = globalIdx;", "ctx.undefinedGlobalIdx = globalIdx + 1;"],
+  ] as const)("rejects live %s mutation %s", (owner, before, after) => {
+    const live = liveSources();
+    verifySourceReceipts(live);
+    // Some literals recur in a complete donor. Change one actual occurrence;
+    // the original full-module receipt still covers every remaining occurrence.
+    if (!live[owner].includes(before)) throw Error("mutation did not find live input");
+    const changed = { ...live, [owner]: live[owner].replace(before, after) };
+    expect(() => verifySourceReceipts(changed)).toThrow();
+  });
+  it.each([
+    'import type { CodegenContext } from "../../../codegen/context/types.js";',
+    'import { addFuncType } from "../../../codegen/registry/types.js";',
+    'export * from "../../../codegen/index.js";',
+    'type Hidden = import("../../../codegen/context/types.js").CodegenContext;',
+  ])("rejects a forbidden upward edge: %s", (edge) => {
+    const live = liveSources();
+    verifySourceReceipts(live);
+    const changed = { ...live, layouts: live.layouts + "\n" + edge };
+    expect(() => verifySourceReceipts(changed)).toThrow();
+  });
+  it("rejects registration reordering rather than canonicalizing it away", () => {
+    const live = liveSources();
+    verifySourceReceipts(live);
+    const declaration = "ctx.nativeBoxNumberTypeIdx = boxNumStructIdx;";
+    const changed = {
+      ...live,
+      union: replaceOnce(
+        replaceOnce(live.union, declaration, ""),
+        "ctx.nativeBoxBooleanTypeIdx = boxBoolStructIdx;",
+        "ctx.nativeBoxBooleanTypeIdx = boxBoolStructIdx;\n" + declaration,
+      ),
+    };
+    expect(() => verifySourceReceipts(changed)).toThrow();
+  });
+});
+
+describe("legacy source callers of the same canonical native number bodies", () => {
+  it.each([
+    ["boolean true", "Number(new Boolean(true))", 1],
+    ["boolean false", "Number(new Boolean(false))", 0],
+    ["StringToNumber", '(new String("3e9") as any) - 0', 3e9],
+    ["StringToNumber exponent", '(new String(" 1.25e2 ") as any) - 0', 125],
+  ] as const)("executes the actual standalone %s path without host imports", async (_label, expression, expected) => {
+    const { compile } = await import("../src/index.js");
+    const result = await compile(`export function main(): number { return ${expression}; }`, {
+      target: "standalone",
+      skipSemanticDiagnostics: true,
+    });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.binary.length).toBeGreaterThan(0);
+    const module = await WebAssembly.compile(result.binary as BufferSource);
+    expect(WebAssembly.Module.imports(module)).toEqual([]);
+    const instance = await WebAssembly.instantiate(module, {});
+    expect((instance.exports.main as () => number)()).toBe(expected);
+  });
+});

--- a/tests/issue-3518-semantic-provider-boundary.test.ts
+++ b/tests/issue-3518-semantic-provider-boundary.test.ts
@@ -125,10 +125,22 @@ const stringErrorAdditions = [
   "src/backend/wasmgc/resources/native-string-literals.ts",
   "src/backend/wasmgc/resources/native-errors.ts",
 ];
-const groups = {
+const stringErrorGroups = {
   ...promiseGroups,
   "native-runtime": [...promiseGroups["native-runtime"], ...stringErrorAdditions.slice(0, 3)],
   "backend-wasmgc": [...promiseGroups["backend-wasmgc"], ...stringErrorAdditions.slice(3)],
+};
+const nativeValueAdditions = [
+  "src/ir/program/native-value-resources.ts",
+  "src/runtime/wasmgc/values/primitive-layouts.ts",
+  "src/runtime/wasmgc/values/number-bodies.ts",
+  "src/backend/wasmgc/resources/native-values.ts",
+];
+const groups = {
+  ...stringErrorGroups,
+  "ir-program": [...stringErrorGroups["ir-program"], nativeValueAdditions[0]!],
+  "native-runtime": [...stringErrorGroups["native-runtime"], ...nativeValueAdditions.slice(1, 3)],
+  "backend-wasmgc": [...stringErrorGroups["backend-wasmgc"], nativeValueAdditions[3]!],
 };
 const required = Object.values(groups).flat();
 const callableAdditions = ["src/ir/core/async-callables.ts", "src/ir/runtime/native-async-callables.ts"];
@@ -166,11 +178,19 @@ const additions = [
 const policy = () => JSON.parse(readFileSync(resolve(repository, "scripts/compiler-boundaries.json"), "utf8"));
 const digest = (value: unknown) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
 function assertNewActivations(history: unknown[]) {
-  expect(history.slice(0, 2)).toEqual(
-    (["native-runtime", "backend-wasmgc"] as const).map((layer) => ({
+  expect(history.slice(0, 3)).toEqual(
+    (["ir-program", "native-runtime", "backend-wasmgc"] as const).map((layer) => ({
       layer,
       entries: groups[layer],
       minModules: groups[layer].length,
+    })),
+  );
+  history = history.slice(3);
+  expect(history.slice(0, 2)).toEqual(
+    (["native-runtime", "backend-wasmgc"] as const).map((layer) => ({
+      layer,
+      entries: stringErrorGroups[layer],
+      minModules: stringErrorGroups[layer].length,
     })),
   );
   history = history.slice(2);
@@ -332,8 +352,8 @@ function fixture() {
 
 describe("semantic verification and provider ownership boundary", () => {
   it("pins the original 70 modules plus seven Promise/vector and five string/error owners without relaxing historical policy", () => {
-    expect(required).toHaveLength(82);
-    expect(new Set(required).size).toBe(82);
+    expect(required).toHaveLength(86);
+    expect(new Set(required).size).toBe(86);
     expect(callableAdditions).toHaveLength(2);
     expect(vectorAdditions).toHaveLength(2);
     expect(typeLayoutAdditions).toHaveLength(1);
@@ -356,6 +376,7 @@ describe("semantic verification and provider ownership boundary", () => {
             ...resolutionAdditions,
             ...promiseResourceAdditions,
             ...stringErrorAdditions,
+            ...nativeValueAdditions,
           ].includes(path),
       ),
     ).toHaveLength(56);
@@ -374,17 +395,18 @@ describe("semantic verification and provider ownership boundary", () => {
       ...resolutionAdditions,
       ...promiseResourceAdditions,
       ...stringErrorAdditions,
+      ...nativeValueAdditions,
     ])
       expect(required).toContain(path);
     const p = policy();
     assertNewActivations(p.activationHistory);
-    expect(p.activationHistory).toHaveLength(40);
-    expect(digest(p.activationHistory.slice(16))).toBe(
+    expect(p.activationHistory).toHaveLength(43);
+    expect(digest(p.activationHistory.slice(19))).toBe(
       "3437a59aacf39df9dffcafa8099ac9f47c0f43a7a0ecc423df4c1fe3e638f002",
     );
     expect(digest(p.allowedEdges)).toBe("efe7e7ed8dee1a009d2bef3ff36dba80df1a805cd3f5b7b472e62ec6dcff64c7");
     // Exact full activation history at b4c116639a, not a selected subset.
-    expect(digest(p.activationHistory.slice(22))).toBe(
+    expect(digest(p.activationHistory.slice(25))).toBe(
       "a6d07b900b0837832707ce083202ab6ffa40f0bbe6bfce25f3062270882b26da",
     );
     for (const [id, entries] of Object.entries(groups)) {
@@ -401,12 +423,12 @@ describe("semantic verification and provider ownership boundary", () => {
   it("loads the complete actual canonical type-and-value closure", () => {
     const r = fixture().run();
     expect(r.status, JSON.stringify(r.report.errors)).toBe(0);
-    expect(r.report.counts.total).toBe(82);
+    expect(r.report.counts.total).toBe(86);
     expect(r.report.errors).toEqual([]);
     for (const field of ["unknownEdges", "unresolvedEdges", "forbiddenEdges", "transitiveViolations"])
       expect(r.report[field]).toEqual([]);
-    expect(r.report.resolvedEdgeCount).toBe(298);
-    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 194, runtime: 104 });
+    expect(r.report.resolvedEdgeCount).toBe(313);
+    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 203, runtime: 110 });
   });
 
   it.each(["delete", "reorder", "layer", "entries", "minimum"] as const)(
@@ -438,6 +460,7 @@ describe("semantic verification and provider ownership boundary", () => {
     ...resolutionAdditions,
     ...promiseResourceAdditions,
     ...stringErrorAdditions,
+    ...nativeValueAdditions,
   ])("rejects deleting %s and its classification", (path) => {
     const f = fixture();
     rmSync(resolve(f.root, path));
@@ -462,6 +485,7 @@ describe("semantic verification and provider ownership boundary", () => {
     ...resolutionAdditions,
     ...promiseResourceAdditions,
     ...stringErrorAdditions,
+    ...nativeValueAdditions,
   ])("rejects an aliased frontend type dependency from %s", (path) => {
     const f = fixture();
     f.put("src/forbidden.ts", "export interface Hidden { value: number }");
@@ -491,6 +515,7 @@ describe("semantic verification and provider ownership boundary", () => {
       ...resolutionAdditions,
       ...promiseResourceAdditions,
       ...stringErrorAdditions,
+      ...nativeValueAdditions,
     ])(`reports ${field} from %s instead of treating it as closed`, (path) => {
       const f = fixture();
       f.append(path, source);


### PR DESCRIPTION
## Summary

Materialize canonical undefined and numeric values through the existing physical resource ledger. Preserve legacy callers, registration order and caches. Add a checked whole-program/current-projection entry and activate four canonical boundary owners.

Stacked on #5770; continues #3518 without closing it. Existing merge hold remains.

## Validation

- TS7 passed.
- 70/70 focused tests passed:60 resource/preservation and10 checked-entry controls.
- 205/205 boundary tests passed;86 modules,313 edges (203 type-only/110 runtime), no unknown/unresolved/forbidden dependencies.
- Preserved historical activation records, allowed edges and original donor receipt hashes. Fixed comment-mutation detection with additive complete comment receipts; retained earlier59/60 failure evidence.
- High final review approved the nine implementation/test files. Normal commit/push hooks passed, including18 numeric-local parity tests and issue integrity. Changed-root tests explicitly skipped:68 roots exceed20; not a passing receipt.

## Still required

Actual scanner/flattening/exponent/power producers, closure/argument-vector and object/callable integration, full Promise/frame/timer execution, fresh-process replay, IR-only cutover and direct retirement remain open. Primitive-only absence is bounded, not full migration completion. Signature/name checks do not certify a scanner.
