### PR TITLE
feat(ir): authenticate completed native string dependencies

### DIFF
--- a/plan/agent-context/3518-native-scanner-high-plan-2026-09-08.md
+++ b/plan/agent-context/3518-native-scanner-high-plan-2026-09-08.md
@@ -1,0 +1,201 @@
+## Frozen Low dispatch: genuine native scanner
+
+Implement **string pack → flatten/copy/optional UTF-8 decode → StringToNumber/power table → native-value unboxing**.
+
+Start from the published native-value checkpoint once parent supplies its commit SHA. The inspected scanner/flatten donors remain byte-identical to `5118637e0e9b34291465230428447e511958faa1`. Reconcile those exact donors before writing.
+
+Euclid’s closure/ObjVec census is the subsequent connected checkpoint; it is not folded into these write sets.
+
+### 1. Disjoint ownership
+
+**Low A — flatten implementation**
+
+Existing production:
+
+- `src/codegen/native-strings-core.ts`
+
+New production:
+
+- `src/runtime/wasmgc/values/string-flatten-bodies.ts`
+- `src/runtime/wasmgc/values/string-utf8-decode-bodies.ts`
+- `src/backend/wasmgc/resources/native-string-flatten.ts`
+
+Tests:
+
+- `tests/issue-3518-native-string-flatten-resources.test.ts`
+- `tests/fixtures/issue-3518-native-string-flatten-donor.ts`
+
+Extract the exact copy-tree, optional UTF-8 decoder, flatten and cons-memoization bodies/locals. Retain the legacy registration adapter and unchanged `emitStrToUtf8Helper`.
+
+**Low B — scanner implementation**
+
+Existing production:
+
+- `src/codegen/parse-number-native.ts`
+
+New production:
+
+- `src/runtime/wasmgc/values/string-number-grammar.ts`
+- `src/runtime/wasmgc/values/decimal-scale-bodies.ts`
+- `src/runtime/wasmgc/values/string-number-bodies.ts`
+- `src/backend/wasmgc/resources/native-string-number.ts`
+
+Tests:
+
+- `tests/issue-3518-native-string-number-resources.test.ts`
+- `tests/fixtures/issue-3518-native-string-number-donor.ts`
+
+Move StringToNumber’s executable body/locals and shared grammar/scaling helpers. Keep parseFloat/parseInt orchestration, caches, registration and module-init delegate authority in the legacy adapter. Shared algorithms must have one canonical implementation.
+
+**Parent integration**
+
+- `src/backend/wasmgc/resources/native-string-literals.ts`
+- `src/backend/wasmgc/resources/native-values.ts`
+- Existing native-value resource tests.
+- Checked physical-plan/consumer joins.
+- Boundary activation, historical receipts and root-bound source comparisons.
+
+No changes to Promise settlement, closures, ObjVec, host/linear implementation, ABI obligations or policy allowed edges.
+
+### 2. Frozen pure interfaces
+
+These are proposed exports, not existing APIs.
+
+Flatten builders:
+
+- `buildStringCopyTreeDefinition(layout, worklistTypeIndex)`
+- `buildStringUtf8ToFlatDefinition(layout)`
+- `buildStringFlattenDefinition(layout, resources)`
+
+Return `{ locals: LocalDef[], body: Instr[] }`. Reuse canonical `NativeStringLayout`.
+
+Flatten resources contain only:
+
+- `copyTree: FuncHandle`
+- `emptyLiteralGlobalIndex: number`
+- Explicit absent/present UTF-8 decoder handle
+
+Scanner builders:
+
+- `buildStringToNumberPrelude(layout, flattenHandle): Instr[]`
+- `buildStringToNumberResult(powerResources): Instr[]`
+- `buildStringToNumberLocals(layout): LocalDef[]`
+- Power-array descriptor and initializer builders.
+
+`powerResources` contains exactly `arrayTypeIndex` and `globalIndex`.
+
+The prelude ends after exponent scanning and full-match rejection. The result builder performs decimal scaling and returns the result. This separation preserves the legacy adapter’s original lazy power-table creation point without passing an allocating callback into canonical code.
+
+Grammar ownership includes the existing 33 `C_*` constants and whitespace, digit, radix, exact-Infinity and exponent builders. Scaling owns `POW10_TABLE_MAX`, decimal scaling and the beyond-table tail.
+
+Canonical modules import only approved downward runtime/model dependencies—no context types, legacy facades or arbitrary emission callbacks.
+
+### 3. Frozen resource interfaces
+
+Flatten owner:
+
+- `reserveNativeStringFlattenResources(tx, key, stringPack)`
+- `fillNativeStringFlattenResources(tx, pack)`
+- `requireCompletedNativeStringFlatten(tx, pack, expectedStringPack)`
+
+Reservations contain the exact string pack, worklist type, copy-tree/flatten functions and optional decoder.
+
+Scanner owner:
+
+- `reserveNativeStringNumberResources(tx, nativeValuePlan, flattenPack)`
+- `fillNativeStringNumberResources(tx, pack)`
+- `requireCompletedNativeStringNumber(tx, pack, expectedStringPack)`
+
+Reservations contain the power-array type/global and actual StringToNumber function. Private ownership retains the issued plan, exact flatten/string packs and transaction.
+
+Use `PhysicalModuleReservations` exclusively. No new allocator or completion ledger.
+
+Completion requires:
+
+1. An actually issued pack.
+2. Exact transaction and dependency identity.
+3. Successful canonical fill of every required resource.
+4. Current ledger validation of all captured tokens and completed contents.
+
+A correctly named constant-return function, matching signature, copied body, nonempty body or structurally fabricated pack must fail authentication. Partial fill cannot issue completion.
+
+Parent replaces native-values’ raw `{ anyString, toNumber }` dependency with the owned scanner pack. Primitive-only absence remains unchanged and cannot substitute for native-string selection.
+
+### 4. String identity and reservation order
+
+Extend the existing string owner narrowly to attest completed resources through its existing ownership record.
+
+Flatten requires the genuine **UTF-16 `""` demand**, matching the donor’s unannotated literal materialization. Do not select merely the first equal text if both UTF-8 and UTF-16 empty literals exist; retain the interning/encoding identity in the lookup. No fabricated global-zero fallback.
+
+One transaction:
+
+1. Reserve string layouts and complete ordered literal demands.
+2. Reserve one nullable-AnyString worklist array.
+3. Reserve copy-tree, optional decoder, then flatten.
+4. Reserve scanner signature/function, then power-array type/global.
+5. Reserve dependent native-value functions and remaining selected resources.
+6. Freeze once.
+7. Fill strings, flatten resources, power/scanner, then native values.
+8. Publish final indices and seal.
+
+The worklist type must be reusable by later canonical string providers. Legacy code retains its existing array interner; do not duplicate that identity within either compilation path.
+
+Calls use stable handles. Global/publication coordinates use final physical indices. Stable handles never become `ProgramAbiMap` final indices.
+
+### 5. Required preservation
+
+Retain:
+
+- Legacy broad string-helper initialization order, import-shift reconciliation and suppressed-vector-usage scope.
+- Copy-tree → decoder → flatten registration order.
+- Flatten’s `nativeStrHelpers` and authoritative `funcMap` registrations.
+- Empty-string interning at its original body-construction point.
+- Scanner registration before body construction.
+- parseFloat → parseInt → StringToNumber selection order.
+- Lazy power caches, imported-global offset and push/trace failure ordering.
+- All scanner locals, including i64 mantissa and retained unused `fracScale`.
+- Flat offsets, worklist capacity16/doubling/copy order and memoization writes.
+- Hashed-string cache fields and selected UTF-8 decoding.
+
+The power table remains exactly **309 entries**, `Number(\`1e${k}\`)` for `k=0…308`, with unchanged immutable descriptors and scaling order. Do not substitute `Math.pow`, another parser, generic vector growth or a host conversion.
+
+Receipt reconstruction retains all **13 scanner-module functions, three flatten-module functions, 34 constants**, nested bodies, locals, documentation and registration statements. Preserve existing hashes/denominators through checked live reconstruction; no runtime Git fallback or baseline reseeding.
+
+### 6. Acceptance required before checkpoint completion
+
+**Authentication negatives**
+
+Genuine-positive first, then:
+
+- Foreign transaction/string pack; cloned or substituted producer.
+- Missing scanner, decoder, power or literal fill.
+- Correctly named/signature-compatible constant-return scanner.
+- Changed completed body, locals, power entry/count/mutability or empty literal.
+- Reordered/substituted resources.
+- Deleted canonical roots and forbidden type/value facade imports.
+
+**Execution**
+
+Execute actual owned flatten → scanner → unbox resources, covering:
+
+- `3e9`, negative zero, NaN-producing text, infinities.
+- Whitespace, decimal exponents and unsigned radix strings.
+- Signed radix rejection.
+- Nonzero flat offsets.
+- Deep ropes exceeding16 pending children and repeated memoized flattening.
+- Selected UTF-8 decoding.
+- Power-table boundary and beyond-308 behavior.
+
+Reuse real source fixtures from `issue-3570`, `issue-2654`, `issue-1184` and native-string suites. Record complete bytes/WAT/resource order and repeated outcomes in explicit-root baseline/candidate children. Add fresh-process canonical execution with legacy/frontend imports forbidden.
+
+Keep separate verdicts for legacy preservation, canonical producer execution and whole-program execution.
+
+The donor’s malformed-exponent handling and precision limitations require explicit semantic controls. Source inspection indicates a possible existing `"1e"`/`"1e+"` acceptance defect; it was not executed here. Preserve any baseline failure rather than treating equal wrong results as correctness.
+
+### 7. Dispatch boundary
+
+Both Low lanes can begin after parent publishes these interfaces and verifies ownership. Parent integrates their authenticated dependency chain after freeze.
+
+This supplies the real scanner required by native values; it does not finish Promise/frame fill, closure application, object classification, formatting/concat/output or full-family physical execution. The original **16-owner/33-call** population, public IR-only cutover, strict closure and unresolved ABI30 witness remain intact.
+
+No further research, edits or tests were performed for this freeze.

--- a/plan/agent-context/3518-native-scanner-integration-2026-09-08.md
+++ b/plan/agent-context/3518-native-scanner-integration-2026-09-08.md
@@ -1,0 +1,34 @@
+# Native scanner integration
+
+Base: a6cc59a2cdfad5141d75faadf1530a9de63bebd7 (PR #5774).
+Parent owns string-literal authentication and subsequent scanner/native-value
+joins. Hilbert owns flattening, Maxwell owns StringToNumber, Euclid owns the
+disjoint ObjVec slice. No full scanner implementation is present here yet.
+
+Added explicit encoding lookup through the existing literal interning keys,
+preserving the old text-only API. UTF16 empty lookup must request `wtf16`;
+UTF8 test demands use the actual `utf8-guaranteed` contract. Completion
+requires an issued owner, exact ledger, successful fill and current physical
+ledger validation of all owned types, globals and literal functions.
+
+Initial test setup failed on a nonexistent createEmptyModule export; corrected
+to its actual existing ir/types owner. Next run passed4/5 and exposed invalid
+test encoding `utf8`; corrected to the real StringEncoding vocabulary. Final
+focused5/5 passed. Composed session96731 exited0: TS7 and34/34 tests
+(5 completion controls plus29 unchanged string/error cases),10.10s.
+No failures were interpreted as implementation success.
+
+High confirmed separate flatten reservation-phase and completion accessors.
+Before freeze, authenticate issued owner/transaction/string pack/exact empty
+binding without physicalIndex or fill requirements. After freeze, require
+canonical fills and current ledger validation. Shared private ownership checks
+must prevent the two accessors drifting. No new global completion ledger.
+
+Parent authentication diff still requires independent review. Scanner,
+flattening, prepared replay and full-family execution are not certified by
+these34 tests. Existing cutover/retirement obligations remain unchanged.
+
+High independently approved source blob eae06050f2c2f31afc90819bb44836180cb3b2b0
+and test blob c158bf5bd8e6616630fabbe8c4e03cb42b40a0ff with no concrete findings.
+Approval covers string authentication only. Publication awaits the serialized
+normal-hook slot; no scanner/full-family completion is inferred.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6453,3 +6453,24 @@ fresh-process replay, cutover, strict closure and retirement remain open.
 
 Expanded boundary suite86860 subsequently exited0:205/205 passed in132.76s.
 The full High native-value implementation plan is included in agent-context.
+
+## Native scanner dependency authentication — 2026-09-08
+
+On #5774, parent added encoding-specific literal lookup through existing
+interning identities and completed-string attestation through the existing
+physical ledger. This lets flattening require the genuine UTF16 empty global
+even when an equal UTF8 literal was demanded first. Old text-only lookup is
+unchanged. Forged/foreign owners, incomplete fills and changed completed
+global/function contents are rejected by the new completion accessor.
+
+TS7 and34/34 focused tests passed in96731 (5 new completion controls and29
+unchanged literal/error cases). Independent review and publication pending.
+The full frozen scanner implementation plan is included in agent-context.
+Hilbert owns flatten/copy/optionalUTF8decode; Maxwell owns StringToNumber and
+grammar/power resources. Parent owns string authentication and the subsequent
+owned-scanner dependency in native values. Euclid owns disjoint ObjVec work.
+
+Reservation-phase producer authentication is separate from completed-fill
+attestation: reserve-all-before-freeze cannot require completed dependencies.
+Neither accessor establishes whole-program execution. Actual scanner,
+flattening, resource-chain execution, replay and retirement remain open.

--- a/src/backend/wasmgc/resources/native-string-literals.ts
+++ b/src/backend/wasmgc/resources/native-string-literals.ts
@@ -50,6 +50,8 @@ export interface NativeStringLiteralReservations {
 }
 interface LiteralOwner {
   readonly tx: PhysicalModuleReservations;
+  readonly utf8Storage: boolean;
+  readonly bindings: ReadonlyMap<string, NativeStringLiteralBinding>;
   readonly globals: readonly { readonly token: GlobalReservation; readonly init: Instr[] }[];
   readonly functions: readonly {
     readonly token: FunctionReservation;
@@ -128,7 +130,7 @@ export function reserveNativeStringLiteralResources(
   };
   const literals = requirements.literals.map(({ value, encoding }) => literal(value, encoding));
   const pack = Object.freeze({ layout, types: Object.freeze(types), literals: Object.freeze(literals) });
-  owners.set(pack, { tx, globals, functions, filled: false });
+  owners.set(pack, { tx, utf8Storage: requirements.utf8Storage, bindings: cache, globals, functions, filled: false });
   return pack;
 }
 
@@ -137,15 +139,34 @@ export function requireNativeStringLiteral(
   tx: PhysicalModuleReservations,
   pack: NativeStringLiteralReservations,
   text: string,
+  encoding?: StringEncoding,
 ): NativeStringLiteralBinding {
   const owner = owners.get(pack);
   if (!owner || owner.tx !== tx) throw new Error("native strings: foreign or forged resource owner");
   if (tx.state !== "reserving") {
     for (const token of pack.types) tx.physicalIndex(token);
   }
-  const binding = pack.literals.find((row) => row.text === text);
+  const selected =
+    encoding === undefined
+      ? undefined
+      : owner.bindings.get(planNativeStringLiteral(pack.layout, owner.utf8Storage, text, encoding).key);
+  const binding = pack.literals.find((row) => (encoding === undefined ? row.text === text : row === selected));
   if (!binding) throw new Error(`native strings: missing literal ${JSON.stringify(text)}`);
   return binding;
+}
+
+/** Attest actual canonical fills through this owner's existing ledger, not a body-name heuristic. */
+export function requireCompletedNativeStringLiterals(
+  tx: PhysicalModuleReservations,
+  pack: NativeStringLiteralReservations,
+): NativeStringLiteralReservations {
+  const owner = owners.get(pack);
+  if (!owner || owner.tx !== tx) throw new Error("native strings: foreign or forged resource owner");
+  if (!owner.filled) throw new Error("native strings: incomplete literal resources");
+  for (const token of pack.types) tx.physicalIndex(token);
+  for (const row of owner.globals) tx.physicalIndex(row.token);
+  for (const row of owner.functions) tx.physicalIndex(row.token);
+  return pack;
 }
 
 export function fillNativeStringLiteralResources(

--- a/tests/issue-3518-native-string-completion.test.ts
+++ b/tests/issue-3518-native-string-completion.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { createEmptyModule } from "../src/ir/types.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import {
+  reserveNativeStringLiteralResources,
+  fillNativeStringLiteralResources,
+  requireNativeStringLiteral,
+  requireCompletedNativeStringLiterals,
+} from "../src/backend/wasmgc/resources/native-string-literals.js";
+
+function fixture(oversized = false) {
+  const tx = new PhysicalModuleReservations(createEmptyModule());
+  const pack = reserveNativeStringLiteralResources(tx, {
+    key: "completion",
+    utf8Storage: true,
+    literals: [
+      { value: "", encoding: "utf8-guaranteed" },
+      { value: "", encoding: "wtf16" },
+      ...(oversized ? [{ value: "x".repeat(20001), encoding: "wtf16" as const }] : []),
+    ],
+  });
+  return { tx, pack };
+}
+
+describe("native string producer completion", () => {
+  it("selects UTF16 empty identity even when UTF8 is demanded first", () => {
+    const { tx, pack } = fixture();
+    const utf8 = requireNativeStringLiteral(tx, pack, "", "utf8-guaranteed");
+    const utf16 = requireNativeStringLiteral(tx, pack, "", "wtf16");
+    expect(utf8).not.toBe(utf16);
+    expect(utf16).toBe(pack.literals[1]);
+    expect(requireNativeStringLiteral(tx, pack, "")).toBe(utf8);
+    tx.freezeReservations();
+    fillNativeStringLiteralResources(tx, pack);
+    expect(requireCompletedNativeStringLiterals(tx, pack)).toBe(pack);
+  });
+  it("rejects unfilled resources before accepting their genuine fill", () => {
+    const { tx, pack } = fixture();
+    expect(() => requireCompletedNativeStringLiterals(tx, pack)).toThrow("incomplete");
+    tx.freezeReservations();
+    expect(() => requireCompletedNativeStringLiterals(tx, pack)).toThrow("incomplete");
+    fillNativeStringLiteralResources(tx, pack);
+    expect(requireCompletedNativeStringLiterals(tx, pack)).toBe(pack);
+  });
+  it("rejects copied owners and foreign ledgers after a genuine positive", () => {
+    const { tx, pack } = fixture();
+    tx.freezeReservations();
+    fillNativeStringLiteralResources(tx, pack);
+    expect(requireCompletedNativeStringLiterals(tx, pack)).toBe(pack);
+    expect(() => requireCompletedNativeStringLiterals(tx, { ...pack })).toThrow("forged");
+    expect(() => requireCompletedNativeStringLiterals(fixture().tx, pack)).toThrow("foreign");
+  });
+  it("rejects altered completed globals", () => {
+    const { tx, pack } = fixture();
+    tx.freezeReservations();
+    fillNativeStringLiteralResources(tx, pack);
+    expect(requireCompletedNativeStringLiterals(tx, pack)).toBe(pack);
+    const binding = requireNativeStringLiteral(tx, pack, "", "wtf16");
+    if (binding.kind !== "global") throw Error("expected actual empty global");
+    binding.global.object.init = [];
+    expect(() => requireCompletedNativeStringLiterals(tx, pack)).toThrow("altered completed global");
+  });
+  it("rejects altered oversized literal bodies", () => {
+    const { tx, pack } = fixture(true);
+    tx.freezeReservations();
+    fillNativeStringLiteralResources(tx, pack);
+    expect(requireCompletedNativeStringLiterals(tx, pack)).toBe(pack);
+    const binding = pack.literals[2]!;
+    if (binding.kind !== "callable") throw Error("expected actual oversized helper");
+    binding.function.object.body = [];
+    expect(() => requireCompletedNativeStringLiterals(tx, pack)).toThrow("altered completed function");
+  });
+});


### PR DESCRIPTION
## Summary

Authenticate completed native string resources through their existing owner and physical ledger. Add encoding-specific literal lookup so scanner flattening can require the actual UTF16 empty literal without selecting an equal UTF8 demand.

Stacked on #5774; continues #3518. No auto-merge or hold removal.

## Validation

TS7 and34/34 focused tests passed:5 new completion/identity tests and29 unchanged string/error preservation cases. Includes foreign/copied owners, incomplete fills and altered completed globals/functions. High independently approved both source/test blobs. Normal commit/push checks passed, including18 numeric-local parity tests and issue integrity. Changed-root tests explicitly skipped69 roots (>20); not a passing test receipt.

## Scope

Includes the frozen High scanner implementation plan and issue handoff. This is dependency authentication, not completed scanner or whole-program execution. Flattening, scanner, owned native-value join, closure/object integration and retirement remain required.
