### PR TITLE
feat(ir): reserve authenticated native closure resources

### DIFF
--- a/plan/agent-context/3518-native-closure-integration-2026-09-08.md
+++ b/plan/agent-context/3518-native-closure-integration-2026-09-08.md
@@ -75,3 +75,17 @@ with the unchanged production's76 passing runtime controls (8 explicit skips)
 and221 passing boundary controls, this checkpoint is ready for normal
 publication checks. This is extraction/preservation evidence, not public
 IR-only cutover or direct-codegen retirement evidence.
+
+Publication correction: normal commit formatting changed only fixture JSON
+whitespace, from raw SHA25616d1ea63f62d793aac80739472e7ff551b73b826af38175de8081370578e1f87
+to be6904328b9bb25981ca9ae109c3526d86931832eeb433bce66af41f99b96575.
+Parsed JSON equality with the frozen original was verified, but that alone
+did not update the test's exact transport hash. Post-publication baseline
+run96621 exposed the mismatch at collection (Promise24 passed, closure suite
+failed before collecting tests). Update only the fixed transport hash;
+all embedded original donor text, hashes, populations and inverse checks
+remain unchanged. Focused rerun and normal publication checks follow.
+
+Rerun67996 exited0:86/86 passed (62 closure and24 Promise),14.88s.
+This restores the exact published-fixture test baseline without changing
+production or the embedded historical donor records.

--- a/plan/agent-context/3518-native-closure-integration-2026-09-08.md
+++ b/plan/agent-context/3518-native-closure-integration-2026-09-08.md
@@ -1,0 +1,77 @@
+# Native closure integration
+
+Parent checkout based on e3beb06321582908aba303fbcdf236d4c7a468c2 (#5776),
+including the real reservation-phase type ownership API. Euclid's frozen
+seven-file population was copied only after SHA256 verification and verifying
+each existing destination matched HEAD. Worker checkout remains untouched.
+
+The resource owner reserves the actual first signature wrapper as the open
+root, uses root-self lifted signatures, retains ordered cache/metadata request
+observations, and authenticates all external types before allocation. No
+Promise capture/trampoline/function fill ownership is added. Parent owns the
+future join with the existing native Promise pack; do not duplicate captures.
+
+Composed TS7 session69733 exited0. Focused resource tests and the four source
+control files required by the High spec are being executed next; no runtime
+success or review approval is inferred from the typecheck. Boundary activation
+and independent review remain pending. This is not full-family closure/object
+materialization, dispatcher execution, public IR-only cutover or retirement.
+
+Composed five-file test run89612 exited1:71 passed,2 failed,8 skipped of81
+collected,24.92s. All four existing source suites passed; skips remain skips.
+Both independent-donor order permutations fail on metadata minimum arity:
+native metadata reports0, actual legacy metadata reports1. No expectation
+changed. Euclid owns diagnosis and a scoped worker repair against the actual
+legacy observer behavior; parent will integrate a frozen revision afterward.
+
+Integrated R2 only after matching original destination hashes and new source
+hashes: backend892b895457a1909c76d15810cf5b7bb1b326be80c07ba5352ebfd16d94bec325,
+test6fe212d1e405d260de866213cef7275cc3eaa9c6dc27837fef7db6f7735248c7.
+The other five frozen files and historical fixture are unchanged. Legacy
+minimum observer snapshots existing records on first observation, then adds
+only the current wrapper; R1 incorrectly rescanned all later metadata copies.
+R2 restores the lazy snapshot timing, preserves the original comparisons,
+and adds three timing controls. Independent review and rerun are pending.
+
+Composed R2 rerun99469 exited0:76 passed,8 skipped of84 collected,25.52s,
+across the focused closure suite and all four required source control suites.
+The two formerly failing donor-order comparisons now pass without changing
+their expectations. Skipped controls are not counted as passing. Independent
+review, boundary activation, R2 typecheck and Promise producer join remain.
+
+High approved R2 production, but found the preservation inverse does not
+cover all three live canonical factory bodies: it substitutes fixture bodies
+after checking adapters. Euclid owns a test-only R3 repair reconstructing
+those full live declarations with enumerated substitutions, fixed original
+hashes, suffix population checks and positive-first extra-statement/missing
+factory/changed-field mutations. No production rewrite is requested.
+
+Parent boundary policy activates the two closure owners. Historical records
+and allowed edges match HEAD exactly. Targeted measurements show90 modules,
+325 imports (210 type-only,115 runtime), with no forbidden/unresolved/unknown
+edges. Count assertions now pin those observations; full221-control suite
+is running, not yet a claimed pass. These counts exclude scanner additions
+because this isolated checkpoint is stacked directly on argument-vector PR5776.
+
+Full closure boundary run36906 subsequently exited0:221/221 passed,141.13s.
+This closes the boundary validation item only; R3 live-factory preservation
+proof, final composed typecheck and publication remain pending.
+
+R2 composed typecheck95684 exited0 after boundary integration. Production
+and boundary checks are current; the R3 test-only live-factory preservation
+repair remains the next prerequisite before this checkpoint's publication.
+
+Integrated R3 test-only SHA256
+3151af4e00584792aaf261cb31f143747f66a36554e0a8c77ab06d60231f19f5
+after validating both destination R2 and source R3 hashes. Complete live
+factory reconstruction, suffix population/order checks and20 positive-first
+mutants added; production and fixed donor fixture unchanged. Focused R3
+run57482 exited0:62/62 passed,1.75s. Independent closure-proof review pending.
+
+Final High review closed the R3 preservation finding: complete live factory
+inverse, exact six-declaration suffix and all20 positive-first mutants are
+approved at the hash above. Final composed TS7 session3186 exited0. Together
+with the unchanged production's76 passing runtime controls (8 explicit skips)
+and221 passing boundary controls, this checkpoint is ready for normal
+publication checks. This is extraction/preservation evidence, not public
+IR-only cutover or direct-codegen retirement evidence.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6511,3 +6511,24 @@ negative matches the ledger's content contract and proves rejection before
 either function fills. No production semantics or identity gates were relaxed.
 The focused runtime,213 boundary tests and composed TS7 now pass; publication
 checks remain next. Full migration acceptance above remains open.
+
+### Native closure resource checkpoint — 2026-09-09
+
+The closure checkpoint is stacked on argument-vector PR #5776. Canonical
+closure layouts retain real legacy callers; the transaction-owned native
+closure pack reserves wrapper roots, signatures and builtin metadata in
+legacy order. The repaired minimum-arity observer preserves lazy snapshot
+timing rather than rescanning later metadata copies.
+
+High review approved production and the R3 complete-live-factory inverse.
+Validation: focused R3 62/62; composed runtime controls 76 passed and8 skipped;
+boundary policy 221/221; final composed TS7 exited0. Original donor hashes,
+complete factory population and20 positive-first mutation controls stay
+pinned. See agent-context/3518-native-closure-integration-2026-09-08.md for
+revision hashes and failure/repair provenance.
+
+Next: join native Promise consumers to the owned closure producer pack;
+do not duplicate Promise capture ownership. Full object/callable dispatch,
+whole-family execution, replay, public IR-only cutover and strict static
+closure/direct-codegen retirement remain open. This checkpoint does not
+claim those acceptance conditions.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -190,9 +190,10 @@
         "src/backend/wasmgc/resources/native-string-literals.ts",
         "src/backend/wasmgc/resources/native-errors.ts",
         "src/backend/wasmgc/resources/native-values.ts",
-        "src/backend/wasmgc/resources/native-argument-vectors.ts"
+        "src/backend/wasmgc/resources/native-argument-vectors.ts",
+        "src/backend/wasmgc/resources/native-closures.ts"
       ],
-      "minModules": 6
+      "minModules": 7
     },
     {
       "id": "native-runtime",
@@ -214,9 +215,10 @@
         "src/runtime/wasmgc/values/error-bodies.ts",
         "src/runtime/wasmgc/values/primitive-layouts.ts",
         "src/runtime/wasmgc/values/number-bodies.ts",
-        "src/runtime/wasmgc/values/argument-vector-bodies.ts"
+        "src/runtime/wasmgc/values/argument-vector-bodies.ts",
+        "src/runtime/wasmgc/values/closure-layouts.ts"
       ],
-      "minModules": 15
+      "minModules": 16
     },
     {
       "id": "standalone-platform",
@@ -455,6 +457,41 @@
     }
   ],
   "activationHistory": [
+    {
+      "layer": "native-runtime",
+      "entries": [
+        "src/runtime/wasmgc/async/microtask-queue-bodies.ts",
+        "src/runtime/wasmgc/promise/settlement-bodies.ts",
+        "src/runtime/wasmgc/async/frame-engine.ts",
+        "src/runtime/wasmgc/async/native-await.ts",
+        "src/runtime/wasmgc/promise/delay-bodies.ts",
+        "src/runtime/wasmgc/promise/combinator-bodies.ts",
+        "src/runtime/wasmgc/values/vector-grow-store.ts",
+        "src/runtime/wasmgc/promise/resolution-bodies.ts",
+        "src/runtime/wasmgc/promise/thenable-bodies.ts",
+        "src/runtime/wasmgc/values/string-layouts.ts",
+        "src/runtime/wasmgc/values/string-literal-bodies.ts",
+        "src/runtime/wasmgc/values/error-bodies.ts",
+        "src/runtime/wasmgc/values/primitive-layouts.ts",
+        "src/runtime/wasmgc/values/number-bodies.ts",
+        "src/runtime/wasmgc/values/argument-vector-bodies.ts",
+        "src/runtime/wasmgc/values/closure-layouts.ts"
+      ],
+      "minModules": 16
+    },
+    {
+      "layer": "backend-wasmgc",
+      "entries": [
+        "src/backend/wasmgc/resources/native-vectors.ts",
+        "src/backend/wasmgc/resources/native-promises.ts",
+        "src/backend/wasmgc/resources/native-string-literals.ts",
+        "src/backend/wasmgc/resources/native-errors.ts",
+        "src/backend/wasmgc/resources/native-values.ts",
+        "src/backend/wasmgc/resources/native-argument-vectors.ts",
+        "src/backend/wasmgc/resources/native-closures.ts"
+      ],
+      "minModules": 7
+    },
     {
       "layer": "native-runtime",
       "entries": [
@@ -1077,6 +1114,16 @@
     }
   ],
   "files": [
+    {
+      "path": "src/runtime/wasmgc/values/closure-layouts.ts",
+      "state": "clean",
+      "layer": "native-runtime"
+    },
+    {
+      "path": "src/backend/wasmgc/resources/native-closures.ts",
+      "state": "clean",
+      "layer": "backend-wasmgc"
+    },
     { "path": "src/runtime/wasmgc/values/argument-vector-bodies.ts", "state": "clean", "layer": "native-runtime" },
     { "path": "src/backend/wasmgc/resources/native-argument-vectors.ts", "state": "clean", "layer": "backend-wasmgc" },
     { "path": "src/ir/program/native-value-resources.ts", "state": "clean", "layer": "ir-program" },

--- a/src/backend/wasmgc/resources/native-closures.ts
+++ b/src/backend/wasmgc/resources/native-closures.ts
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { ValType } from "../../../wasm/model/instructions.js";
+import type { PhysicalModuleReservations, TypeReservation } from "../../../wasm/physical/module-reservations.js";
+import { preparedIrDataMismatch } from "../../../ir/program/data.js";
+import {
+  createSignatureWrapperType,
+  createBuiltinFunctionMetadataType,
+  type ClosureAllocationMode,
+} from "../../../runtime/wasmgc/values/closure-layouts.js";
+
+export interface NativeClosureSignatureRequest {
+  readonly kind: "signature";
+  readonly id: string;
+  readonly params: readonly ValType[];
+  readonly results: readonly ValType[];
+  readonly allocationMode: ClosureAllocationMode;
+  readonly minimumArgumentCount?: number;
+}
+export interface NativeClosureMetadataRequest {
+  readonly kind: "metadata";
+  readonly id: string;
+  readonly signatureId: string;
+  readonly key: string;
+  readonly name: string;
+  readonly length: number;
+}
+export interface NativeClosureRequirements {
+  readonly key: string;
+  readonly startingClosureCounter: number;
+  /** Ordered, including interleaved metadata and later signature cache hits. */
+  readonly requests: readonly (NativeClosureSignatureRequest | NativeClosureMetadataRequest)[];
+  /** Exact same-ledger prerequisites for every concrete user parameter/result. */
+  readonly referenceTypes: readonly TypeReservation[];
+}
+export interface NativeClosureInfo {
+  readonly structTypeIdx: number;
+  readonly funcTypeIdx: number;
+  readonly returnType: ValType | null;
+  readonly paramTypes: readonly ValType[];
+  readonly minimumArgumentCount: number | undefined;
+  readonly hostOneShotOnly?: boolean;
+}
+export interface NativeClosureWrapperBinding {
+  readonly type: TypeReservation;
+  readonly liftedFuncTypeIndex: number;
+  readonly liftedSelfTypeIndex: number;
+  readonly info: NativeClosureInfo;
+}
+export interface NativeClosureMetadataBinding {
+  readonly type: TypeReservation;
+  readonly signature: NativeClosureWrapperBinding;
+  readonly info: NativeClosureInfo;
+  readonly metadata: { readonly key: string; readonly name: string; readonly length: number; readonly id: number };
+}
+export type NativeClosureRegistration =
+  | { readonly kind: "counter"; readonly value: number }
+  | { readonly kind: "type" | "root"; readonly type: TypeReservation }
+  | { readonly kind: "signature"; readonly typeIndex: number; readonly selfTypeIndex: number }
+  | { readonly kind: "closure-info"; readonly info: NativeClosureInfo }
+  | { readonly kind: "wrapper-cache"; readonly key: string; readonly binding: NativeClosureWrapperBinding }
+  | { readonly kind: "metadata"; readonly binding: NativeClosureMetadataBinding }
+  | { readonly kind: "metadata-cache"; readonly key: string; readonly type: TypeReservation };
+export interface NativeClosureReservations {
+  readonly root: TypeReservation;
+  /** One row per request; cache hits retain the SAME binding object. */
+  readonly signatures: readonly { readonly id: string; readonly binding: NativeClosureWrapperBinding }[];
+  readonly metadata: readonly { readonly id: string; readonly binding: NativeClosureMetadataBinding }[];
+  readonly resultingClosureCounter: number;
+  readonly registrations: readonly NativeClosureRegistration[];
+}
+type MutableInfo = { -readonly [K in keyof NativeClosureInfo]: NativeClosureInfo[K] };
+const owners = new WeakMap<
+  NativeClosureReservations,
+  {
+    tx: PhysicalModuleReservations;
+    requirements: NativeClosureRequirements;
+    snapshot: unknown;
+    external: readonly TypeReservation[];
+  }
+>();
+function fail(detail: string): never {
+  throw new Error(`native closures: ${detail}`);
+}
+function same(actual: unknown, expected: unknown, detail: string): void {
+  if (preparedIrDataMismatch(actual, expected) !== undefined) fail(detail);
+}
+function signatureKey(request: NativeClosureSignatureRequest): string {
+  const key = (types: readonly ValType[]) =>
+    types.map((type) => type.kind + ("typeIdx" in type ? type.typeIdx : "")).join(",");
+  return `${key(request.params)}->${key(request.results)}`;
+}
+function requestData(requirements: NativeClosureRequirements) {
+  return {
+    key: requirements.key,
+    startingClosureCounter: requirements.startingClosureCounter,
+    requests: requirements.requests,
+  };
+}
+function validateRequests(tx: PhysicalModuleReservations, requirements: NativeClosureRequirements): void {
+  if (
+    tx.state !== "reserving" ||
+    !requirements.key ||
+    !Number.isSafeInteger(requirements.startingClosureCounter) ||
+    requirements.startingClosureCounter < 0
+  )
+    fail("invalid reservation phase/key/counter");
+  const external = new Map<number, TypeReservation>();
+  for (const token of requirements.referenceTypes) {
+    tx.assertTypeReservation(token);
+    if (external.has(token.typeIndex)) fail("duplicate external type prerequisite");
+    external.set(token.typeIndex, token);
+  }
+  const used = new Set<number>();
+  const ids = new Set<string>();
+  const signatures = new Map<string, NativeClosureSignatureRequest>();
+  const cache = new Map<string, NativeClosureSignatureRequest>();
+  const metadata = new Map<
+    string,
+    { request: NativeClosureMetadataRequest; signature: NativeClosureSignatureRequest }
+  >();
+  for (const request of requirements.requests) {
+    if (!request.id || ids.has(request.id)) fail("missing or duplicate request identity");
+    ids.add(request.id);
+    if (request.kind === "signature") {
+      if (!["support", "ordinary", "host-one-shot"].includes(request.allocationMode)) fail("invalid allocation mode");
+      if (
+        request.minimumArgumentCount !== undefined &&
+        (!Number.isInteger(request.minimumArgumentCount) ||
+          request.minimumArgumentCount < 0 ||
+          request.minimumArgumentCount > request.params.length)
+      )
+        fail("invalid observed minimum arity");
+      for (const type of [...request.params, ...request.results]) {
+        if (["i8", "i16"].includes(type.kind)) fail("packed storage is not a function value type");
+        if (type.kind === "ref" || type.kind === "ref_null") {
+          if (!external.has(type.typeIdx)) fail("missing concrete reference type prerequisite");
+          used.add(type.typeIdx);
+        }
+      }
+      const key = signatureKey(request),
+        cached = cache.get(key);
+      if (cached)
+        same(
+          { params: request.params, results: request.results },
+          { params: cached.params, results: cached.results },
+          "signature cache collision loses physical metadata",
+        );
+      else cache.set(key, request);
+      signatures.set(request.id, request);
+    } else if (request.kind === "metadata") {
+      const signature = signatures.get(request.signatureId);
+      if (!signature) fail("metadata must refer to an earlier genuine signature request");
+      if (!request.key || typeof request.name !== "string" || !Number.isInteger(request.length) || request.length < 0)
+        fail("invalid metadata identity/name/length");
+      if (request.key === "promise:settle")
+        same(
+          { params: signature.params, results: signature.results, name: request.name, length: request.length },
+          { params: [{ kind: "externref" }], results: [], name: "", length: 1 },
+          "noncanonical promise:settle request",
+        );
+      const cached = metadata.get(request.key);
+      if (cached)
+        same(
+          { signature: signatureKey(signature), name: request.name, length: request.length },
+          { signature: signatureKey(cached.signature), name: cached.request.name, length: cached.request.length },
+          "contradictory metadata cache request",
+        );
+      else metadata.set(request.key, { request, signature });
+    } else fail("unknown closure request kind");
+  }
+  if (!signatures.size) fail("missing first signature/root");
+  if (used.size !== external.size) fail("unused concrete reference prerequisite");
+  if (!Number.isSafeInteger(requirements.startingClosureCounter + cache.size)) fail("closure counter overflow");
+}
+
+/** No trampoline/body/fill API: these are actual type and lifted-signature resources. */
+export function reserveNativeClosureResources(
+  tx: PhysicalModuleReservations,
+  requirements: NativeClosureRequirements,
+): NativeClosureReservations {
+  validateRequests(tx, requirements); // Entire population and all foreign tokens checked BEFORE allocation.
+  const snapshot = structuredClone(requestData(requirements));
+  const cache = new Map<string, NativeClosureWrapperBinding>();
+  const byId = new Map<string, NativeClosureWrapperBinding>();
+  const metaCache = new Map<string, NativeClosureMetadataBinding>();
+  const signatures: { id: string; binding: NativeClosureWrapperBinding }[] = [];
+  const metadata: { id: string; binding: NativeClosureMetadataBinding }[] = [];
+  const registrations: NativeClosureRegistration[] = [];
+  // These are the issued records only, not another public population authority.
+  const infos: MutableInfo[] = [];
+  const minima = new Map<number, number>();
+  // The legacy observer indexes existing records ONCE on its first observation.
+  // Later observations add the current wrapper, not every subsequently-created
+  // metadata copy. Keep this separate from the full issued-record population.
+  let minimumObserverInfos: Set<MutableInfo> | undefined;
+  let root: TypeReservation | undefined;
+  let counter = requirements.startingClosureCounter;
+  // The first wrapper's returned index establishes the append frontier. Each
+  // subsequent ledger operation either appends here or interns an older type.
+  // No external allocator/callback runs inside this synchronous reservation.
+  let nextTypeIndex = -1;
+  for (const request of requirements.requests) {
+    if (request.kind === "signature") {
+      const key = signatureKey(request);
+      let binding = cache.get(key);
+      if (!binding) {
+        const name = `__fn_wrap_${counter++}`;
+        registrations.push({ kind: "counter", value: counter });
+        const type = tx.reserveType(
+          `${requirements.key}:wrapper:${request.id}`,
+          createSignatureWrapperType(`${name}_struct`, root?.typeIndex ?? -1),
+        );
+        registrations.push({ kind: "type", type });
+        if (!root) {
+          root = type;
+          registrations.push({ kind: "root", type });
+        }
+        const params = request.params.map((type) => Object.freeze({ ...type }));
+        const results = request.results.map((type) => Object.freeze({ ...type }));
+        const liftedFuncTypeIndex = tx.internFunctionType(
+          [{ kind: "ref", typeIdx: root.typeIndex }, ...params],
+          results,
+          `${name}_type`,
+        );
+        nextTypeIndex = Math.max(type.typeIndex, liftedFuncTypeIndex) + 1;
+        registrations.push({ kind: "signature", typeIndex: liftedFuncTypeIndex, selfTypeIndex: root.typeIndex });
+        const info: MutableInfo = {
+          structTypeIdx: type.typeIndex,
+          funcTypeIdx: liftedFuncTypeIndex,
+          returnType: results[0] ?? null,
+          paramTypes: Object.freeze(params),
+          minimumArgumentCount: undefined,
+        };
+        infos.push(info);
+        binding = { type, liftedFuncTypeIndex, liftedSelfTypeIndex: root.typeIndex, info };
+        // Observe flags/minimum before publication, matching the legacy adapters.
+        observe(binding, request);
+        registrations.push({ kind: "closure-info", info });
+        cache.set(key, binding);
+        registrations.push({ kind: "wrapper-cache", key, binding });
+      } else observe(binding, request);
+      byId.set(request.id, binding);
+      signatures.push(Object.freeze({ id: request.id, binding }));
+    } else {
+      let binding = metaCache.get(request.key);
+      if (!binding) {
+        const signature = byId.get(request.signatureId)!;
+        // Preserve the donor's index-bearing name without allocating a dummy
+        // type or mutating a descriptor already authenticated by the ledger.
+        const typeIndex = nextTypeIndex;
+        const type = tx.reserveType(
+          `${requirements.key}:metadata:${request.id}`,
+          createBuiltinFunctionMetadataType(typeIndex, signature.type.typeIndex),
+        );
+        if (type.typeIndex !== typeIndex) fail("unexpected metadata type coordinate");
+        nextTypeIndex = type.typeIndex + 1;
+        registrations.push({ kind: "type", type });
+        const info: MutableInfo = { ...signature.info, structTypeIdx: type.typeIndex };
+        infos.push(info);
+        registrations.push({ kind: "closure-info", info });
+        binding = {
+          type,
+          signature,
+          info,
+          metadata: Object.freeze({ key: request.key, name: request.name, length: request.length, id: type.typeIndex }),
+        };
+        registrations.push({ kind: "metadata", binding });
+        metaCache.set(request.key, binding);
+        registrations.push({ kind: "metadata-cache", key: request.key, type });
+      }
+      metadata.push(Object.freeze({ id: request.id, binding }));
+    }
+  }
+  function observe(binding: NativeClosureWrapperBinding, request: NativeClosureSignatureRequest): void {
+    const info = binding.info as MutableInfo;
+    if (request.minimumArgumentCount !== undefined) {
+      const minimum = Math.min(minima.get(info.funcTypeIdx) ?? info.paramTypes.length, request.minimumArgumentCount);
+      minima.set(info.funcTypeIdx, minimum);
+      // Match ensureLiveClosureInfoIndex's lazy snapshot plus explicit wrapper
+      // indexing. Metadata copied after that snapshot retains its copied minimum;
+      // metadata already present at the first observation is synchronized.
+      // There are no wrapper-record replacements in this pack. The legacy
+      // constructible/cache/closureMap records remain with their current owner.
+      minimumObserverInfos ??= new Set(infos);
+      minimumObserverInfos.add(info);
+      for (const record of minimumObserverInfos)
+        if (record.funcTypeIdx === info.funcTypeIdx)
+          record.minimumArgumentCount = Math.min(record.minimumArgumentCount ?? record.paramTypes.length, minimum);
+    }
+    if (request.allocationMode === "ordinary") info.hostOneShotOnly = false;
+    else if (request.allocationMode === "host-one-shot" && info.hostOneShotOnly === undefined)
+      info.hostOneShotOnly = true;
+  }
+  for (const info of infos) Object.freeze(info);
+  for (const binding of cache.values()) Object.freeze(binding);
+  for (const binding of metaCache.values()) Object.freeze(binding);
+  const pack = Object.freeze({
+    root: root!,
+    signatures: Object.freeze(signatures),
+    metadata: Object.freeze(metadata),
+    resultingClosureCounter: counter,
+    registrations: Object.freeze(registrations.map((record) => Object.freeze(record))),
+  });
+  owners.set(pack, { tx, requirements, snapshot, external: Object.freeze([...requirements.referenceTypes]) });
+  return pack;
+}
+
+/** Authenticate the exact issued pack at reserve time or after the shared freeze. */
+export function requireNativeClosureReservations(
+  tx: PhysicalModuleReservations,
+  pack: NativeClosureReservations,
+): NativeClosureReservations {
+  const owner = owners.get(pack);
+  if (!owner || owner.tx !== tx) fail("foreign or copied closure pack");
+  same(requestData(owner.requirements), owner.snapshot, "stale closure request sequence");
+  if (
+    owner.requirements.referenceTypes.length !== owner.external.length ||
+    owner.external.some((token, index) => token !== owner.requirements.referenceTypes[index])
+  )
+    fail("stale external type tokens");
+  const tokens = new Set([
+    ...owner.external,
+    pack.root,
+    ...pack.signatures.map((row) => row.binding.type),
+    ...pack.metadata.map((row) => row.binding.type),
+  ]);
+  for (const token of tokens) {
+    if (tx.state === "reserving") tx.assertTypeReservation(token);
+    else if (tx.physicalIndex(token) !== token.typeIndex) fail("closure type coordinate mismatch");
+  }
+  return pack;
+}

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -40,12 +40,11 @@
  */
 import type { Instr, ValType } from "../ir/types.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
+import { getOrCreateFuncRefWrapperTypes } from "./closures/funcref-wrapper-types.js";
 import {
-  closureArityField,
-  closureBagField,
-  closureBagInitInstr,
-  getOrCreateFuncRefWrapperTypes,
-} from "./closures/funcref-wrapper-types.js";
+  createBuiltinFunctionMetadataType,
+  buildBuiltinClosureValueInstrs,
+} from "../runtime/wasmgc/values/closure-layouts.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 
 /**
@@ -54,8 +53,7 @@ import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
  * a `$bag` slot at index 2 and these two shifted with it.
  * Layout: `[func, $arity, $bag, bfnstate, bfnid]`.
  */
-export const BFN_STATE_FIELD_IDX = 3;
-export const BFN_ID_FIELD_IDX = 4;
+export { BFN_STATE_FIELD_IDX, BFN_ID_FIELD_IDX } from "../runtime/wasmgc/values/closure-layouts.js";
 
 /**
  * Spec `{name, length}` for the builtin STATIC method closures wired in
@@ -271,23 +269,7 @@ export function ensureBuiltinFnMetaType(
   if (existing !== undefined) return existing;
 
   const typeIdx = ctx.mod.types.length;
-  ctx.mod.types.push({
-    kind: "struct",
-    name: `__builtinfn_meta_${typeIdx}_struct`,
-    fields: [
-      // Field 0 must mirror the supertype exactly (same type + mutability) —
-      // as must the #3673 $arity slot at index 1.
-      { name: "func", type: { kind: "funcref" as const }, mutable: false },
-      closureArityField(),
-      closureBagField(),
-      // Deleted-bits mask: bit 0 = "name" deleted, bit 1 = "length" deleted.
-      { name: "bfnstate", type: { kind: "i32" as const }, mutable: true },
-      // Stable per-module metadata identity. Structurally-equivalent meta
-      // subtypes cannot be distinguished by ref.test alone.
-      { name: "bfnid", type: { kind: "i32" as const }, mutable: false },
-    ],
-    superTypeIdx: baseStructTypeIdx,
-  });
+  ctx.mod.types.push(createBuiltinFunctionMetadataType(typeIdx, baseStructTypeIdx));
 
   ctx.closureInfoByTypeIdx.set(typeIdx, { ...baseClosureInfo, structTypeIdx: typeIdx });
   if (!ctx.builtinFnMetaByTypeIdx) ctx.builtinFnMetaByTypeIdx = new Map();
@@ -308,7 +290,7 @@ export function pushBuiltinFnClosureValueInstrs(
   closure: { type: { kind: "ref"; typeIdx: number }; funcIdx: number },
 ): Instr[] {
   const isMeta = ctx.builtinFnMetaByTypeIdx?.has(closure.type.typeIdx) ?? false;
-  const instrs: Instr[] = [{ op: "ref.func", funcIdx: closure.funcIdx }];
+
   // (#3673) $arity field 1 — the builtin's spec `length` when meta-typed,
   // else the registered closure signature's param count.
   // Receiver-aware variadic native-proto values are the one exception: their
@@ -323,13 +305,7 @@ export function pushBuiltinFnClosureValueInstrs(
       : isMeta
         ? (ctx.builtinFnMetaByTypeIdx?.get(closure.type.typeIdx)?.length ?? 0)
         : (closureInfo?.paramTypes.length ?? 0);
-  instrs.push({ op: "i32.const", value: arity });
-  instrs.push(closureBagInitInstr()); // (#4241) $bag field 2
-  if (isMeta) {
-    instrs.push({ op: "i32.const", value: 0 }, { op: "i32.const", value: closure.type.typeIdx });
-  }
-  instrs.push({ op: "struct.new", typeIdx: closure.type.typeIdx });
-  return instrs;
+  return buildBuiltinClosureValueInstrs(closure.type.typeIdx, closure.funcIdx, arity, isMeta);
 }
 
 /**

--- a/src/codegen/closures/closure-header-layout.ts
+++ b/src/codegen/closures/closure-header-layout.ts
@@ -1,115 +1,16 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
-/**
- * (#4241) The closure-struct HEADER layout — the single source of truth for the
- * fields every struct in the funcref-wrapper root hierarchy carries before its
- * captures, and for the predicate that recognises that header.
- *
- * ## Why this is its own module
- * The layout used to be stated in TWO places that could not see each other: the
- * mint-site constants in `funcref-wrapper-types.ts`, and a hand-written
- * `type.fields.length === 2 && fields[0] is funcref && fields[1] is i32`
- * validator inside `program-abi-type-planning.ts`'s IR closure-support check.
- * Adding the `$bag` slot satisfied the constants and silently violated the
- * validator, which does not warn — it THROWS, so all five async functions in
- * `website/playground/examples/js/async.ts` failed IR-first with
- * "non-canonical physical wrapper root" and the `check:ir-only` readiness gate
- * exited 1. Nothing in the type system connected the two statements.
- *
- * `funcref-wrapper-types.ts` cannot host the predicate, because it imports the
- * codegen barrel (`../index.js`) and `program-abi-type-planning.ts` is reachable
- * from that barrel — importing it there would close an initialization cycle
- * around `const` exports. So this module is a LEAF, importing only TYPES, for
- * the same reason and in the same shape as `closure-classifier.ts`: one
- * definition, many consumers, never two divergent copies.
- *
- * ## The layout
- * ```
- *   0  func    funcref     the lifted function reference
- *   1  $arity  i32         (#3673) declared user formal count
- *   2  $bag    externref   (#4241) carrier-intrinsic expando bag, mutable,
- *                          null until the carrier grows its first property
- *   3+ captures / TDZ flag cells / __constructible / subtype-specific fields
- * ```
- * Every capture read/write and TDZ-slot index derives from
- * {@link CLOSURE_CAPTURE_FIELD_BASE}, never a bare literal — and now so does
- * every VALIDATOR of the header.
- */
-import type { FieldDef, Instr, ValType } from "../../ir/types.js";
 
-/** Field 0 — the lifted function reference. */
-export const CLOSURE_FUNC_FIELD_IDX = 0;
-/** Field 1 — (#3673) the closure's declared user formal count. */
-export const CLOSURE_ARITY_FIELD_IDX = 1;
-/** Field 2 — (#4241) the carrier-intrinsic expando-bag slot. */
-export const CLOSURE_BAG_FIELD_IDX = 2;
-/** First capture field. Also the header's field COUNT, by construction. */
-export const CLOSURE_CAPTURE_FIELD_BASE = 3;
-
-/** The `$arity` field definition — shared by every closure-struct mint site. */
-export function closureArityField(): { name: string; type: ValType; mutable: false } {
-  return { name: "$arity", type: { kind: "i32" }, mutable: false };
-}
-
-/**
- * The `$bag` field definition — shared by every closure-struct mint site.
- * MUTABLE, so a WasmGC subtype must redeclare it with the identical type and
- * mutability (field types are invariant for mutable fields); using this one
- * factory everywhere is what guarantees that. The `$` prefix keeps it out of
- * name enumeration and getter emission, matching `$arity` and `$shape`.
- */
-/**
- * (#4241) The field NAME of the carrier-intrinsic expando bag. Exported so
- * every consumer resolves the slot by NAME rather than by index — the slot does
- * not stay last (`property-access-dispatch.ts` appends fields to already-
- * registered structs) and it sits at different indices in different carrier
- * families (index 2 in the closure header, appended in an instance carrier).
- */
-export const INSTANCE_BAG_FIELD = "$bag";
-
-export function closureBagField(): { name: string; type: ValType; mutable: true } {
-  return { name: "$bag", type: { kind: "externref" }, mutable: true };
-}
-
-/**
- * The `struct.new` operand for a freshly-minted closure's `$bag` slot. Sits
- * between the `$arity` i32 and the first capture at EVERY closure allocation
- * site — a missed site is a loud `struct.new` arity/type validation failure,
- * never a silent wrong answer.
- */
-export function closureBagInitInstr(): Instr {
-  return { op: "ref.null.extern" };
-}
-
-/**
- * Does `fields` START with the canonical closure header? True for a bare
- * wrapper root and for any subtype that correctly redeclares the header before
- * its own fields.
- *
- * Checked by KIND rather than by identity with the factories above, because the
- * consumers that ask this question are validating types the allocator already
- * built and canonicalized — a structural question, not a provenance one.
- */
-export function hasClosureHeaderPrefix(fields: readonly (FieldDef | undefined)[]): boolean {
-  return (
-    fields.length >= CLOSURE_CAPTURE_FIELD_BASE &&
-    fields[CLOSURE_FUNC_FIELD_IDX]?.type.kind === "funcref" &&
-    fields[CLOSURE_ARITY_FIELD_IDX]?.type.kind === "i32" &&
-    fields[CLOSURE_BAG_FIELD_IDX]?.type.kind === "externref"
-  );
-}
-
-/**
- * Is `fields` EXACTLY the canonical header and nothing else — i.e. a bare
- * wrapper root / signature wrapper with no captures?
- */
-export function isCanonicalClosureHeader(fields: readonly (FieldDef | undefined)[]): boolean {
-  return fields.length === CLOSURE_CAPTURE_FIELD_BASE && hasClosureHeaderPrefix(fields);
-}
-
-/**
- * The field count a captured subtype must have for `captureCount` captures:
- * the header plus one field per capture.
- */
-export function closureSubtypeFieldCount(captureCount: number): number {
-  return CLOSURE_CAPTURE_FIELD_BASE + captureCount;
-}
+// Compatibility facade; canonical layout, documentation and predicates live below.
+export {
+  CLOSURE_FUNC_FIELD_IDX,
+  CLOSURE_ARITY_FIELD_IDX,
+  CLOSURE_BAG_FIELD_IDX,
+  CLOSURE_CAPTURE_FIELD_BASE,
+  INSTANCE_BAG_FIELD,
+  closureArityField,
+  closureBagField,
+  closureBagInitInstr,
+  hasClosureHeaderPrefix,
+  isCanonicalClosureHeader,
+  closureSubtypeFieldCount,
+} from "../../runtime/wasmgc/values/closure-layouts.js";

--- a/src/codegen/closures/funcref-wrapper-types.ts
+++ b/src/codegen/closures/funcref-wrapper-types.ts
@@ -15,7 +15,8 @@ import { funcSignatureOf } from "../func-space.js"; // (#1916 S2 read chokepoint
 import { addFuncType } from "../registry/types.js";
 import { closureArityField, closureBagField } from "./closure-header-layout.js";
 
-export type ClosureAllocationMode = "support" | "ordinary" | "host-one-shot";
+import { createSignatureWrapperType, type ClosureAllocationMode } from "../../runtime/wasmgc/values/closure-layouts.js";
+export type { ClosureAllocationMode } from "../../runtime/wasmgc/values/closure-layouts.js";
 
 function observeAllocation(info: ClosureInfo, mode: ClosureAllocationMode): void {
   if (mode === "ordinary") info.hostOneShotOnly = false;
@@ -104,19 +105,10 @@ export function getOrCreateFuncRefWrapperTypes(
   // Mark as non-final (superTypeIdx = -1) so closures with captures can be
   // subtypes of this wrapper struct, enabling ref.cast to succeed at call sites.
   const closureName = `__fn_wrap_${ctx.closureCounter++}`;
-  const structFields = [
-    { name: "func", type: { kind: "funcref" as const }, mutable: false },
-    closureArityField(),
-    closureBagField(),
-  ];
+
   const structTypeIdx = ctx.mod.types.length;
   const rootWrapperTypeIdx = (ctx as unknown as { __funcRefWrapperRootTypeIdx?: number }).__funcRefWrapperRootTypeIdx;
-  ctx.mod.types.push({
-    kind: "struct",
-    name: `${closureName}_struct`,
-    fields: structFields,
-    superTypeIdx: rootWrapperTypeIdx ?? -1, // first wrapper is the root; later signatures subtype it
-  });
+  ctx.mod.types.push(createSignatureWrapperType(`${closureName}_struct`, rootWrapperTypeIdx ?? -1));
   const liftedSelfTypeIdx = rootWrapperTypeIdx ?? structTypeIdx;
   if (rootWrapperTypeIdx === undefined) {
     (ctx as unknown as { __funcRefWrapperRootTypeIdx?: number }).__funcRefWrapperRootTypeIdx = structTypeIdx;

--- a/src/runtime/wasmgc/values/closure-layouts.ts
+++ b/src/runtime/wasmgc/values/closure-layouts.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4241) The closure-struct HEADER layout — the single source of truth for the
+ * fields every struct in the funcref-wrapper root hierarchy carries before its
+ * captures, and for the predicate that recognises that header.
+ *
+ * ## Why this is its own module
+ * The layout used to be stated in TWO places that could not see each other: the
+ * mint-site constants in `funcref-wrapper-types.ts`, and a hand-written
+ * `type.fields.length === 2 && fields[0] is funcref && fields[1] is i32`
+ * validator inside `program-abi-type-planning.ts`'s IR closure-support check.
+ * Adding the `$bag` slot satisfied the constants and silently violated the
+ * validator, which does not warn — it THROWS, so all five async functions in
+ * `website/playground/examples/js/async.ts` failed IR-first with
+ * "non-canonical physical wrapper root" and the `check:ir-only` readiness gate
+ * exited 1. Nothing in the type system connected the two statements.
+ *
+ * `funcref-wrapper-types.ts` cannot host the predicate, because it imports the
+ * codegen barrel (`../index.js`) and `program-abi-type-planning.ts` is reachable
+ * from that barrel — importing it there would close an initialization cycle
+ * around `const` exports. So this module is a LEAF, importing only TYPES, for
+ * the same reason and in the same shape as `closure-classifier.ts`: one
+ * definition, many consumers, never two divergent copies.
+ *
+ * ## The layout
+ * ```
+ *   0  func    funcref     the lifted function reference
+ *   1  $arity  i32         (#3673) declared user formal count
+ *   2  $bag    externref   (#4241) carrier-intrinsic expando bag, mutable,
+ *                          null until the carrier grows its first property
+ *   3+ captures / TDZ flag cells / __constructible / subtype-specific fields
+ * ```
+ * Every capture read/write and TDZ-slot index derives from
+ * {@link CLOSURE_CAPTURE_FIELD_BASE}, never a bare literal — and now so does
+ * every VALIDATOR of the header.
+ */
+import type { Instr, ValType, FuncHandle } from "../../../wasm/model/instructions.js";
+import type { FieldDef, StructTypeDef } from "../../../wasm/model/module-records.js";
+
+/** Field 0 — the lifted function reference. */
+export const CLOSURE_FUNC_FIELD_IDX = 0;
+/** Field 1 — (#3673) the closure's declared user formal count. */
+export const CLOSURE_ARITY_FIELD_IDX = 1;
+/** Field 2 — (#4241) the carrier-intrinsic expando-bag slot. */
+export const CLOSURE_BAG_FIELD_IDX = 2;
+/** First capture field. Also the header's field COUNT, by construction. */
+export const CLOSURE_CAPTURE_FIELD_BASE = 3;
+
+/** The `$arity` field definition — shared by every closure-struct mint site. */
+export function closureArityField(): { name: string; type: ValType; mutable: false } {
+  return { name: "$arity", type: { kind: "i32" }, mutable: false };
+}
+
+/**
+ * The `$bag` field definition — shared by every closure-struct mint site.
+ * MUTABLE, so a WasmGC subtype must redeclare it with the identical type and
+ * mutability (field types are invariant for mutable fields); using this one
+ * factory everywhere is what guarantees that. The `$` prefix keeps it out of
+ * name enumeration and getter emission, matching `$arity` and `$shape`.
+ */
+/**
+ * (#4241) The field NAME of the carrier-intrinsic expando bag. Exported so
+ * every consumer resolves the slot by NAME rather than by index — the slot does
+ * not stay last (`property-access-dispatch.ts` appends fields to already-
+ * registered structs) and it sits at different indices in different carrier
+ * families (index 2 in the closure header, appended in an instance carrier).
+ */
+export const INSTANCE_BAG_FIELD = "$bag";
+
+export function closureBagField(): { name: string; type: ValType; mutable: true } {
+  return { name: "$bag", type: { kind: "externref" }, mutable: true };
+}
+
+/**
+ * The `struct.new` operand for a freshly-minted closure's `$bag` slot. Sits
+ * between the `$arity` i32 and the first capture at EVERY closure allocation
+ * site — a missed site is a loud `struct.new` arity/type validation failure,
+ * never a silent wrong answer.
+ */
+export function closureBagInitInstr(): Instr {
+  return { op: "ref.null.extern" };
+}
+
+/**
+ * Does `fields` START with the canonical closure header? True for a bare
+ * wrapper root and for any subtype that correctly redeclares the header before
+ * its own fields.
+ *
+ * Checked by KIND rather than by identity with the factories above, because the
+ * consumers that ask this question are validating types the allocator already
+ * built and canonicalized — a structural question, not a provenance one.
+ */
+export function hasClosureHeaderPrefix(fields: readonly (FieldDef | undefined)[]): boolean {
+  return (
+    fields.length >= CLOSURE_CAPTURE_FIELD_BASE &&
+    fields[CLOSURE_FUNC_FIELD_IDX]?.type.kind === "funcref" &&
+    fields[CLOSURE_ARITY_FIELD_IDX]?.type.kind === "i32" &&
+    fields[CLOSURE_BAG_FIELD_IDX]?.type.kind === "externref"
+  );
+}
+
+/**
+ * Is `fields` EXACTLY the canonical header and nothing else — i.e. a bare
+ * wrapper root / signature wrapper with no captures?
+ */
+export function isCanonicalClosureHeader(fields: readonly (FieldDef | undefined)[]): boolean {
+  return fields.length === CLOSURE_CAPTURE_FIELD_BASE && hasClosureHeaderPrefix(fields);
+}
+
+/**
+ * The field count a captured subtype must have for `captureCount` captures:
+ * the header plus one field per capture.
+ */
+export function closureSubtypeFieldCount(captureCount: number): number {
+  return CLOSURE_CAPTURE_FIELD_BASE + captureCount;
+}
+
+export type ClosureAllocationMode = "support" | "ordinary" | "host-one-shot";
+
+export const BFN_STATE_FIELD_IDX = 3;
+export const BFN_ID_FIELD_IDX = 4;
+
+export function createSignatureWrapperType(name: string, superTypeIdx: number): StructTypeDef {
+  const fields = [
+    { name: "func", type: { kind: "funcref" as const }, mutable: false },
+    closureArityField(),
+    closureBagField(),
+  ];
+  return { kind: "struct", name, fields, superTypeIdx };
+}
+
+export function createBuiltinFunctionMetadataType(typeIndex: number, signatureWrapperTypeIndex: number): StructTypeDef {
+  return {
+    kind: "struct",
+    name: `__builtinfn_meta_${typeIndex}_struct`,
+    fields: [
+      // Field 0 must mirror the supertype exactly (same type + mutability) —
+      // as must the #3673 $arity slot at index 1.
+      { name: "func", type: { kind: "funcref" as const }, mutable: false },
+      closureArityField(),
+      closureBagField(),
+      // Deleted-bits mask: bit 0 = "name" deleted, bit 1 = "length" deleted.
+      { name: "bfnstate", type: { kind: "i32" as const }, mutable: true },
+      // Stable per-module metadata identity. Structurally-equivalent meta
+      // subtypes cannot be distinguished by ref.test alone.
+      { name: "bfnid", type: { kind: "i32" as const }, mutable: false },
+    ],
+    superTypeIdx: signatureWrapperTypeIndex,
+  };
+}
+
+export function buildBuiltinClosureValueInstrs(
+  typeIndex: number,
+  functionHandle: FuncHandle,
+  arity: number,
+  isMetadata: boolean,
+): Instr[] {
+  const instrs: Instr[] = [{ op: "ref.func", funcIdx: functionHandle }];
+  instrs.push({ op: "i32.const", value: arity });
+  instrs.push(closureBagInitInstr()); // (#4241) $bag field 2
+  if (isMetadata) {
+    instrs.push({ op: "i32.const", value: 0 }, { op: "i32.const", value: typeIndex });
+  }
+  instrs.push({ op: "struct.new", typeIdx: typeIndex });
+  return instrs;
+}

--- a/tests/fixtures/issue-3518-native-closure-donors.json
+++ b/tests/fixtures/issue-3518-native-closure-donors.json
@@ -1,0 +1,329 @@
+{
+  "schemaVersion": 1,
+  "base": "bfe31c8bd96d748e867562e3e9b78343b72d1877",
+  "sources": [
+    {
+      "path": "src/codegen/closures/closure-header-layout.ts",
+      "text": "// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.\n/**\n * (#4241) The closure-struct HEADER layout — the single source of truth for the\n * fields every struct in the funcref-wrapper root hierarchy carries before its\n * captures, and for the predicate that recognises that header.\n *\n * ## Why this is its own module\n * The layout used to be stated in TWO places that could not see each other: the\n * mint-site constants in `funcref-wrapper-types.ts`, and a hand-written\n * `type.fields.length === 2 && fields[0] is funcref && fields[1] is i32`\n * validator inside `program-abi-type-planning.ts`'s IR closure-support check.\n * Adding the `$bag` slot satisfied the constants and silently violated the\n * validator, which does not warn — it THROWS, so all five async functions in\n * `website/playground/examples/js/async.ts` failed IR-first with\n * \"non-canonical physical wrapper root\" and the `check:ir-only` readiness gate\n * exited 1. Nothing in the type system connected the two statements.\n *\n * `funcref-wrapper-types.ts` cannot host the predicate, because it imports the\n * codegen barrel (`../index.js`) and `program-abi-type-planning.ts` is reachable\n * from that barrel — importing it there would close an initialization cycle\n * around `const` exports. So this module is a LEAF, importing only TYPES, for\n * the same reason and in the same shape as `closure-classifier.ts`: one\n * definition, many consumers, never two divergent copies.\n *\n * ## The layout\n * ```\n *   0  func    funcref     the lifted function reference\n *   1  $arity  i32         (#3673) declared user formal count\n *   2  $bag    externref   (#4241) carrier-intrinsic expando bag, mutable,\n *                          null until the carrier grows its first property\n *   3+ captures / TDZ flag cells / __constructible / subtype-specific fields\n * ```\n * Every capture read/write and TDZ-slot index derives from\n * {@link CLOSURE_CAPTURE_FIELD_BASE}, never a bare literal — and now so does\n * every VALIDATOR of the header.\n */\nimport type { FieldDef, Instr, ValType } from \"../../ir/types.js\";\n\n/** Field 0 — the lifted function reference. */\nexport const CLOSURE_FUNC_FIELD_IDX = 0;\n/** Field 1 — (#3673) the closure's declared user formal count. */\nexport const CLOSURE_ARITY_FIELD_IDX = 1;\n/** Field 2 — (#4241) the carrier-intrinsic expando-bag slot. */\nexport const CLOSURE_BAG_FIELD_IDX = 2;\n/** First capture field. Also the header's field COUNT, by construction. */\nexport const CLOSURE_CAPTURE_FIELD_BASE = 3;\n\n/** The `$arity` field definition — shared by every closure-struct mint site. */\nexport function closureArityField(): { name: string; type: ValType; mutable: false } {\n  return { name: \"$arity\", type: { kind: \"i32\" }, mutable: false };\n}\n\n/**\n * The `$bag` field definition — shared by every closure-struct mint site.\n * MUTABLE, so a WasmGC subtype must redeclare it with the identical type and\n * mutability (field types are invariant for mutable fields); using this one\n * factory everywhere is what guarantees that. The `$` prefix keeps it out of\n * name enumeration and getter emission, matching `$arity` and `$shape`.\n */\n/**\n * (#4241) The field NAME of the carrier-intrinsic expando bag. Exported so\n * every consumer resolves the slot by NAME rather than by index — the slot does\n * not stay last (`property-access-dispatch.ts` appends fields to already-\n * registered structs) and it sits at different indices in different carrier\n * families (index 2 in the closure header, appended in an instance carrier).\n */\nexport const INSTANCE_BAG_FIELD = \"$bag\";\n\nexport function closureBagField(): { name: string; type: ValType; mutable: true } {\n  return { name: \"$bag\", type: { kind: \"externref\" }, mutable: true };\n}\n\n/**\n * The `struct.new` operand for a freshly-minted closure's `$bag` slot. Sits\n * between the `$arity` i32 and the first capture at EVERY closure allocation\n * site — a missed site is a loud `struct.new` arity/type validation failure,\n * never a silent wrong answer.\n */\nexport function closureBagInitInstr(): Instr {\n  return { op: \"ref.null.extern\" };\n}\n\n/**\n * Does `fields` START with the canonical closure header? True for a bare\n * wrapper root and for any subtype that correctly redeclares the header before\n * its own fields.\n *\n * Checked by KIND rather than by identity with the factories above, because the\n * consumers that ask this question are validating types the allocator already\n * built and canonicalized — a structural question, not a provenance one.\n */\nexport function hasClosureHeaderPrefix(fields: readonly (FieldDef | undefined)[]): boolean {\n  return (\n    fields.length >= CLOSURE_CAPTURE_FIELD_BASE &&\n    fields[CLOSURE_FUNC_FIELD_IDX]?.type.kind === \"funcref\" &&\n    fields[CLOSURE_ARITY_FIELD_IDX]?.type.kind === \"i32\" &&\n    fields[CLOSURE_BAG_FIELD_IDX]?.type.kind === \"externref\"\n  );\n}\n\n/**\n * Is `fields` EXACTLY the canonical header and nothing else — i.e. a bare\n * wrapper root / signature wrapper with no captures?\n */\nexport function isCanonicalClosureHeader(fields: readonly (FieldDef | undefined)[]): boolean {\n  return fields.length === CLOSURE_CAPTURE_FIELD_BASE && hasClosureHeaderPrefix(fields);\n}\n\n/**\n * The field count a captured subtype must have for `captureCount` captures:\n * the header plus one field per capture.\n */\nexport function closureSubtypeFieldCount(captureCount: number): number {\n  return CLOSURE_CAPTURE_FIELD_BASE + captureCount;\n}\n",
+      "sha256": "8b6b7d016ff5c240609b0d63569bd2544bd934fb0850d87aff1efce67824d9b6",
+      "edits": [
+        {
+          "oldStart": 2,
+          "oldCount": 36,
+          "newStart": 1,
+          "newCount": 0,
+          "old": [
+            "/**",
+            " * (#4241) The closure-struct HEADER layout — the single source of truth for the",
+            " * fields every struct in the funcref-wrapper root hierarchy carries before its",
+            " * captures, and for the predicate that recognises that header.",
+            " *",
+            " * ## Why this is its own module",
+            " * The layout used to be stated in TWO places that could not see each other: the",
+            " * mint-site constants in `funcref-wrapper-types.ts`, and a hand-written",
+            " * `type.fields.length === 2 && fields[0] is funcref && fields[1] is i32`",
+            " * validator inside `program-abi-type-planning.ts`'s IR closure-support check.",
+            " * Adding the `$bag` slot satisfied the constants and silently violated the",
+            " * validator, which does not warn — it THROWS, so all five async functions in",
+            " * `website/playground/examples/js/async.ts` failed IR-first with",
+            " * \"non-canonical physical wrapper root\" and the `check:ir-only` readiness gate",
+            " * exited 1. Nothing in the type system connected the two statements.",
+            " *",
+            " * `funcref-wrapper-types.ts` cannot host the predicate, because it imports the",
+            " * codegen barrel (`../index.js`) and `program-abi-type-planning.ts` is reachable",
+            " * from that barrel — importing it there would close an initialization cycle",
+            " * around `const` exports. So this module is a LEAF, importing only TYPES, for",
+            " * the same reason and in the same shape as `closure-classifier.ts`: one",
+            " * definition, many consumers, never two divergent copies.",
+            " *",
+            " * ## The layout",
+            " * ```",
+            " *   0  func    funcref     the lifted function reference",
+            " *   1  $arity  i32         (#3673) declared user formal count",
+            " *   2  $bag    externref   (#4241) carrier-intrinsic expando bag, mutable,",
+            " *                          null until the carrier grows its first property",
+            " *   3+ captures / TDZ flag cells / __constructible / subtype-specific fields",
+            " * ```",
+            " * Every capture read/write and TDZ-slot index derives from",
+            " * {@link CLOSURE_CAPTURE_FIELD_BASE}, never a bare literal — and now so does",
+            " * every VALIDATOR of the header.",
+            " */",
+            "import type { FieldDef, Instr, ValType } from \"../../ir/types.js\";"
+          ],
+          "replacement": []
+        },
+        {
+          "oldStart": 39,
+          "oldCount": 77,
+          "newStart": 3,
+          "newCount": 14,
+          "old": [
+            "/** Field 0 — the lifted function reference. */",
+            "export const CLOSURE_FUNC_FIELD_IDX = 0;",
+            "/** Field 1 — (#3673) the closure's declared user formal count. */",
+            "export const CLOSURE_ARITY_FIELD_IDX = 1;",
+            "/** Field 2 — (#4241) the carrier-intrinsic expando-bag slot. */",
+            "export const CLOSURE_BAG_FIELD_IDX = 2;",
+            "/** First capture field. Also the header's field COUNT, by construction. */",
+            "export const CLOSURE_CAPTURE_FIELD_BASE = 3;",
+            "",
+            "/** The `$arity` field definition — shared by every closure-struct mint site. */",
+            "export function closureArityField(): { name: string; type: ValType; mutable: false } {",
+            "  return { name: \"$arity\", type: { kind: \"i32\" }, mutable: false };",
+            "}",
+            "",
+            "/**",
+            " * The `$bag` field definition — shared by every closure-struct mint site.",
+            " * MUTABLE, so a WasmGC subtype must redeclare it with the identical type and",
+            " * mutability (field types are invariant for mutable fields); using this one",
+            " * factory everywhere is what guarantees that. The `$` prefix keeps it out of",
+            " * name enumeration and getter emission, matching `$arity` and `$shape`.",
+            " */",
+            "/**",
+            " * (#4241) The field NAME of the carrier-intrinsic expando bag. Exported so",
+            " * every consumer resolves the slot by NAME rather than by index — the slot does",
+            " * not stay last (`property-access-dispatch.ts` appends fields to already-",
+            " * registered structs) and it sits at different indices in different carrier",
+            " * families (index 2 in the closure header, appended in an instance carrier).",
+            " */",
+            "export const INSTANCE_BAG_FIELD = \"$bag\";",
+            "",
+            "export function closureBagField(): { name: string; type: ValType; mutable: true } {",
+            "  return { name: \"$bag\", type: { kind: \"externref\" }, mutable: true };",
+            "}",
+            "",
+            "/**",
+            " * The `struct.new` operand for a freshly-minted closure's `$bag` slot. Sits",
+            " * between the `$arity` i32 and the first capture at EVERY closure allocation",
+            " * site — a missed site is a loud `struct.new` arity/type validation failure,",
+            " * never a silent wrong answer.",
+            " */",
+            "export function closureBagInitInstr(): Instr {",
+            "  return { op: \"ref.null.extern\" };",
+            "}",
+            "",
+            "/**",
+            " * Does `fields` START with the canonical closure header? True for a bare",
+            " * wrapper root and for any subtype that correctly redeclares the header before",
+            " * its own fields.",
+            " *",
+            " * Checked by KIND rather than by identity with the factories above, because the",
+            " * consumers that ask this question are validating types the allocator already",
+            " * built and canonicalized — a structural question, not a provenance one.",
+            " */",
+            "export function hasClosureHeaderPrefix(fields: readonly (FieldDef | undefined)[]): boolean {",
+            "  return (",
+            "    fields.length >= CLOSURE_CAPTURE_FIELD_BASE &&",
+            "    fields[CLOSURE_FUNC_FIELD_IDX]?.type.kind === \"funcref\" &&",
+            "    fields[CLOSURE_ARITY_FIELD_IDX]?.type.kind === \"i32\" &&",
+            "    fields[CLOSURE_BAG_FIELD_IDX]?.type.kind === \"externref\"",
+            "  );",
+            "}",
+            "",
+            "/**",
+            " * Is `fields` EXACTLY the canonical header and nothing else — i.e. a bare",
+            " * wrapper root / signature wrapper with no captures?",
+            " */",
+            "export function isCanonicalClosureHeader(fields: readonly (FieldDef | undefined)[]): boolean {",
+            "  return fields.length === CLOSURE_CAPTURE_FIELD_BASE && hasClosureHeaderPrefix(fields);",
+            "}",
+            "",
+            "/**",
+            " * The field count a captured subtype must have for `captureCount` captures:",
+            " * the header plus one field per capture.",
+            " */",
+            "export function closureSubtypeFieldCount(captureCount: number): number {",
+            "  return CLOSURE_CAPTURE_FIELD_BASE + captureCount;",
+            "}"
+          ],
+          "replacement": [
+            "// Compatibility facade; canonical layout, documentation and predicates live below.",
+            "export {",
+            "  CLOSURE_FUNC_FIELD_IDX,",
+            "  CLOSURE_ARITY_FIELD_IDX,",
+            "  CLOSURE_BAG_FIELD_IDX,",
+            "  CLOSURE_CAPTURE_FIELD_BASE,",
+            "  INSTANCE_BAG_FIELD,",
+            "  closureArityField,",
+            "  closureBagField,",
+            "  closureBagInitInstr,",
+            "  hasClosureHeaderPrefix,",
+            "  isCanonicalClosureHeader,",
+            "  closureSubtypeFieldCount,",
+            "} from \"../../runtime/wasmgc/values/closure-layouts.js\";"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "src/codegen/closures/funcref-wrapper-types.ts",
+      "text": "// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.\n/**\n * Funcref-wrapper struct / func-type registry for js2wasm closures.\n *\n * Extracted verbatim from `closures.ts` (issue #3270) — the small, foundational\n * wrapper-struct / lifted-func-type registry that the method-trampoline and\n * funcref-as-closure subsystems both build on. Isolates the isorecursive\n * root-wrapper canonicalization logic (#2873) in one place.\n */\n\nimport type { ClosureInfo, CodegenContext } from \"../context/types.js\";\nimport type { ValType } from \"../../ir/types.js\";\nimport { ts } from \"../../ts-api.js\";\nimport { funcSignatureOf } from \"../func-space.js\"; // (#1916 S2 read chokepoint)\nimport { addFuncType } from \"../registry/types.js\";\nimport { closureArityField, closureBagField } from \"./closure-header-layout.js\";\n\nexport type ClosureAllocationMode = \"support\" | \"ordinary\" | \"host-one-shot\";\n\nfunction observeAllocation(info: ClosureInfo, mode: ClosureAllocationMode): void {\n  if (mode === \"ordinary\") info.hostOneShotOnly = false;\n  else if (mode === \"host-one-shot\" && info.hostOneShotOnly === undefined) info.hostOneShotOnly = true;\n}\n\n/**\n * (#3673/#4241) Closure representation constants and header field factories.\n *\n * These now live in the LEAF module `closure-header-layout.ts` and are\n * re-exported here so the ~10 existing importers are unaffected. The move was\n * forced by a real failure: this module formerly imported the codegen barrel\n * (`../index.js`), and `program-abi-type-planning.ts` — which VALIDATES the\n * header on the IR path — was reachable from that barrel, so it could not import\n * the constants without closing an initialization cycle. It therefore carried\n * its own hand-written copy of the layout (`fields.length === 2 && funcref &&\n * i32`), which the `$bag` insertion silently invalidated. A leaf that both\n * sides can import is the fix; see that module's header for the full story.\n *\n * Capture fields start at CLOSURE_CAPTURE_FIELD_BASE — every capture\n * read/write, TDZ-slot index AND header validator derives from these\n * constants, never a bare literal.\n */\nexport {\n  CLOSURE_ARITY_FIELD_IDX,\n  CLOSURE_BAG_FIELD_IDX,\n  CLOSURE_CAPTURE_FIELD_BASE,\n  CLOSURE_FUNC_FIELD_IDX,\n  closureArityField,\n  closureBagField,\n  closureBagInitInstr,\n  closureSubtypeFieldCount,\n  hasClosureHeaderPrefix,\n  isCanonicalClosureHeader,\n} from \"./closure-header-layout.js\";\n\n/**\n * Look up a function's parameter and result types from its index.\n */\nexport function getFuncSignature(\n  ctx: CodegenContext,\n  funcIdx: number,\n): { params: ValType[]; results: ValType[] } | null {\n  // #1916 S2 — funcSignatureOf is the positional-read chokepoint (func-space.ts).\n  const sig = funcSignatureOf(ctx, funcIdx);\n  return sig ? { params: sig.params, results: sig.results } : null;\n}\n\n/**\n * Get or create the closure struct type and lifted func type for wrapping\n * plain functions with a given signature. Struct type and func type are shared\n * across all functions with the same signature, but each function gets its own\n * trampoline.\n */\nexport function getOrCreateFuncRefWrapperTypes(\n  ctx: CodegenContext,\n  userParams: ValType[],\n  resultTypes: ValType[],\n  allocationMode: ClosureAllocationMode = \"ordinary\",\n): {\n  structTypeIdx: number;\n  liftedFuncTypeIdx: number;\n  liftedSelfTypeIdx: number;\n  closureInfo: ClosureInfo;\n} | null {\n  // Build cache key from param types and result types\n  const sigKey = `${userParams.map((p) => p.kind + ((p as any).typeIdx ?? \"\")).join(\",\")}->${resultTypes.map((r) => r.kind + ((r as any).typeIdx ?? \"\")).join(\",\")}`;\n\n  const cached = ctx.funcRefWrapperCache.get(sigKey);\n  if (cached) {\n    const observedMinimum = ctx.closureMinimumArgumentCountByFuncTypeIdx.get(cached.funcTypeIdx);\n    if (observedMinimum !== undefined) {\n      const current = cached.minimumArgumentCount ?? cached.paramTypes.length;\n      cached.minimumArgumentCount = Math.min(current, observedMinimum);\n    }\n    observeAllocation(cached, allocationMode);\n    return {\n      structTypeIdx: cached.structTypeIdx,\n      liftedFuncTypeIdx: cached.funcTypeIdx,\n      liftedSelfTypeIdx: getFuncRefWrapperRootTypeIdx(ctx) ?? cached.structTypeIdx,\n      closureInfo: cached,\n    };\n  }\n\n  // Create the closure struct type: just (field $func funcref), no captures.\n  // Mark as non-final (superTypeIdx = -1) so closures with captures can be\n  // subtypes of this wrapper struct, enabling ref.cast to succeed at call sites.\n  const closureName = `__fn_wrap_${ctx.closureCounter++}`;\n  const structFields = [\n    { name: \"func\", type: { kind: \"funcref\" as const }, mutable: false },\n    closureArityField(),\n    closureBagField(),\n  ];\n  const structTypeIdx = ctx.mod.types.length;\n  const rootWrapperTypeIdx = (ctx as unknown as { __funcRefWrapperRootTypeIdx?: number }).__funcRefWrapperRootTypeIdx;\n  ctx.mod.types.push({\n    kind: \"struct\",\n    name: `${closureName}_struct`,\n    fields: structFields,\n    superTypeIdx: rootWrapperTypeIdx ?? -1, // first wrapper is the root; later signatures subtype it\n  });\n  const liftedSelfTypeIdx = rootWrapperTypeIdx ?? structTypeIdx;\n  if (rootWrapperTypeIdx === undefined) {\n    (ctx as unknown as { __funcRefWrapperRootTypeIdx?: number }).__funcRefWrapperRootTypeIdx = structTypeIdx;\n  }\n\n  // Cross-module callable ABI: every lifted funcref takes the structurally\n  // canonical ROOT as `self`, never the per-signature allocation wrapper.\n  // Wrapper creation order is module-local, so embedding the latter here\n  // makes identical source signatures disagree across separately compiled\n  // modules. Captured bodies recover their environment with a root→subtype\n  // cast; the user-visible params/results still identify the funcref exactly.\n  const liftedParams: ValType[] = [{ kind: \"ref\", typeIdx: liftedSelfTypeIdx }, ...userParams];\n  const liftedFuncTypeIdx = addFuncType(ctx, liftedParams, resultTypes, `${closureName}_type`);\n\n  const closureInfo: ClosureInfo = {\n    structTypeIdx,\n    funcTypeIdx: liftedFuncTypeIdx,\n    returnType: resultTypes.length > 0 ? resultTypes[0]! : null,\n    paramTypes: userParams,\n    minimumArgumentCount: ctx.closureMinimumArgumentCountByFuncTypeIdx.get(liftedFuncTypeIdx),\n  };\n  observeAllocation(closureInfo, allocationMode);\n  ctx.closureInfoByTypeIdx.set(structTypeIdx, closureInfo);\n  ctx.funcRefWrapperCache.set(sigKey, closureInfo);\n\n  return { structTypeIdx, liftedFuncTypeIdx, liftedSelfTypeIdx, closureInfo };\n}\n\n/**\n * #3371 — Return a nominally-distinct subtype for an ordinary function value.\n *\n * Arrow functions and method closures deliberately keep using the signature\n * wrapper above.  Ordinary function declarations/expressions add one immutable\n * marker field, making their runtime type distinguishable for IsConstructor\n * without changing field 0 or the shared lifted-call ABI.  The subtype still\n * casts to the base wrapper at every existing call site.\n */\nexport function getOrCreateConstructibleFuncRefWrapperTypes(\n  ctx: CodegenContext,\n  userParams: ValType[],\n  resultTypes: ValType[],\n): {\n  structTypeIdx: number;\n  liftedFuncTypeIdx: number;\n  liftedSelfTypeIdx: number;\n  closureInfo: ClosureInfo;\n} | null {\n  const sigKey = `${userParams.map((p) => p.kind + ((p as any).typeIdx ?? \"\")).join(\",\")}->${resultTypes.map((r) => r.kind + ((r as any).typeIdx ?? \"\")).join(\",\")}`;\n  const cached = ctx.constructibleFuncRefWrapperCache.get(sigKey);\n  if (cached) {\n    return {\n      structTypeIdx: cached.structTypeIdx,\n      liftedFuncTypeIdx: cached.funcTypeIdx,\n      liftedSelfTypeIdx: getFuncRefWrapperRootTypeIdx(ctx) ?? cached.structTypeIdx,\n      closureInfo: cached,\n    };\n  }\n\n  const base = getOrCreateFuncRefWrapperTypes(ctx, userParams, resultTypes);\n  if (!base) return null;\n  const structTypeIdx = ctx.mod.types.length;\n  ctx.mod.types.push({\n    kind: \"struct\",\n    name: `__constructible_fn_wrap_${ctx.closureCounter++}_struct`,\n    fields: [\n      { name: \"func\", type: { kind: \"funcref\" as const }, mutable: false },\n      closureArityField(),\n      closureBagField(),\n      { name: \"__constructible\", type: { kind: \"i32\" as const }, mutable: false },\n    ],\n    superTypeIdx: base.structTypeIdx,\n  });\n  const closureInfo: ClosureInfo = {\n    structTypeIdx,\n    funcTypeIdx: base.liftedFuncTypeIdx,\n    returnType: resultTypes.length > 0 ? resultTypes[0]! : null,\n    paramTypes: userParams,\n    minimumArgumentCount:\n      ctx.closureMinimumArgumentCountByFuncTypeIdx.get(base.liftedFuncTypeIdx) ?? base.closureInfo.minimumArgumentCount,\n  };\n  ctx.closureInfoByTypeIdx.set(structTypeIdx, closureInfo);\n  ctx.constructibleFuncRefWrapperCache.set(sigKey, closureInfo);\n  ctx.constructibleClosureTypeIdxs.add(structTypeIdx);\n  return {\n    structTypeIdx,\n    liftedFuncTypeIdx: base.liftedFuncTypeIdx,\n    liftedSelfTypeIdx: base.liftedSelfTypeIdx,\n    closureInfo,\n  };\n}\n\n/**\n * Is `structTypeIdx` one of the SHARED per-signature wrappers (plain or\n * constructible)? Their records in `closureInfoByTypeIdx` describe every\n * captureless allocation of the signature at once, so a `hasRestParam` flag on\n * them cannot single out any one function (#5334).\n */\nexport function isSharedSignatureWrapperStruct(ctx: CodegenContext, structTypeIdx: number): boolean {\n  for (const cache of [ctx.funcRefWrapperCache, ctx.constructibleFuncRefWrapperCache]) {\n    for (const info of cache.values()) if (info.structTypeIdx === structTypeIdx) return true;\n  }\n  return false;\n}\n\n/**\n * (#4616) Get-or-create the rest-marker subtype of a funcref-wrapper struct:\n * the base wrapper's fields plus one immutable f64 marker. The f64 (vs the\n * constructible subtype's i32 marker) keeps the canonical shape distinct, so\n * `ref.test` can discriminate rest-param singleton closures at dispatch time.\n */\nexport function ensureRestFnWrapSubtype(ctx: CodegenContext, baseStructTypeIdx: number): number {\n  const holder = ctx as unknown as { __restFnWrapSubtypeByBase?: Map<number, number> };\n  const cache = (holder.__restFnWrapSubtypeByBase ??= new Map());\n  const hit = cache.get(baseStructTypeIdx);\n  if (hit !== undefined) return hit;\n  const baseDef = ctx.mod.types[baseStructTypeIdx];\n  const baseFields = baseDef?.kind === \"struct\" ? baseDef.fields : [];\n  const idx = ctx.mod.types.length;\n  ctx.mod.types.push({\n    kind: \"struct\",\n    name: `__rest_fn_wrap_${ctx.closureCounter++}_struct`,\n    fields: [...baseFields, { name: \"__rest_marker\", type: { kind: \"f64\" as const }, mutable: false }],\n    superTypeIdx: baseStructTypeIdx,\n  });\n  cache.set(baseStructTypeIdx, idx);\n  return idx;\n}\n\n/**\n * (#5334) Pre-register the rest-marker allocation subtypes a rest DECLARATION's\n * cached singleton (`ensureFuncClosureSingleton`) will allocate, so a call site\n * compiled BEFORE the declaration's first value read — in an earlier source\n * file, say — already knows the struct whose `ref.test` proves the rest\n * reading. The singleton keys the marker on the wrapper it was asked for, and\n * its callers do not all agree on constructibility (#4491 T12), so both bases\n * are registered for an ordinary (constructible) declaration. Async and\n * generator declarations are left alone: their singleton wraps a different\n * result. Types only: no trampoline, no global, no function index moves.\n */\nexport function registerRestDeclarationWrapperShapes(\n  ctx: CodegenContext,\n  declaration: ts.FunctionDeclaration,\n  userParams: ValType[],\n  resultTypes: ValType[],\n): void {\n  if (\n    userParams.length === 0 ||\n    declaration.asteriskToken !== undefined ||\n    (declaration.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) ?? false) ||\n    !declaration.parameters.some((parameter) => parameter.dotDotDotToken !== undefined)\n  ) {\n    return;\n  }\n  const plain = getOrCreateFuncRefWrapperTypes(ctx, userParams, resultTypes, \"support\");\n  if (!plain) return;\n  const bases = [plain.structTypeIdx];\n  const marked = getOrCreateConstructibleFuncRefWrapperTypes(ctx, userParams, resultTypes);\n  if (marked) bases.push(marked.structTypeIdx);\n  for (const base of bases) {\n    const restIdx = ensureRestFnWrapSubtype(ctx, base);\n    if (!ctx.closureInfoByTypeIdx.has(restIdx)) {\n      ctx.closureInfoByTypeIdx.set(restIdx, {\n        structTypeIdx: restIdx,\n        funcTypeIdx: plain.liftedFuncTypeIdx,\n        returnType: resultTypes.length > 0 ? resultTypes[0]! : null,\n        paramTypes: userParams,\n        hasRestParam: true,\n      });\n    }\n    if (base !== plain.structTypeIdx) ctx.constructibleClosureTypeIdxs.add(restIdx);\n  }\n}\n\n/**\n * (#2873 park fix) The ROOT funcref-wrapper struct type — the FIRST wrapper\n * `getOrCreateFuncRefWrapperTypes` created in this module. Every later\n * per-signature wrapper struct is a direct subtype of it. It is also the\n * canonical lifted-function `self` type for EVERY signature, so function type\n * identity does not depend on which signature created the root locally. The\n * finalization pass explicitly keeps this root open even in a minimal module\n * with no child wrapper: WasmGC canonical identity includes finality, so an\n * opportunistically-final root would not match another module's open root.\n * The root is therefore the ONLY wrapper type a `ref.test`/`ref.cast` is\n * guaranteed to accept for a closure value of ANY shared signature wrapper.\n *\n * Why callers need it: wrapper structs are all layout-identical\n * `(struct (field funcref))`, but WasmGC isorecursive canonicalization keys on\n * (fields, supertype, finality) — a direct `$root` subtype does NOT canonicalize\n * with the root or with another sibling. A call site that casts a\n * closure value to the wrapper of its *declared* signature therefore nulls out\n * whenever the value was allocated under a different signature's wrapper\n * (e.g. an activated async closure: its wrapper is minted for the REWRITTEN\n * `... -> externref` Promise signature, while an `fn: () => void` param casts\n * to the void wrapper) — unless creation ORDER happened to make the declared\n * wrapper the root. Cast/read/pass `self` through the root instead and\n * discriminate only on the funcref's exact type (which encodes the true\n * signature).\n */\nexport function getFuncRefWrapperRootTypeIdx(ctx: CodegenContext): number | undefined {\n  return (ctx as unknown as { __funcRefWrapperRootTypeIdx?: number }).__funcRefWrapperRootTypeIdx;\n}\n\n/**\n * Return the concrete struct type used by a closure funcref's leading `self`\n * parameter. Shared wrapper funcs return the canonical root; private/named\n * function-expression funcs return their concrete nullable struct. Dispatch\n * sites use this distinction to avoid foreign per-signature wrapper casts\n * without breaking private closure types.\n */\nexport function getClosureFuncSelfTypeIdx(ctx: CodegenContext, funcTypeIdx: number): number | undefined {\n  const type = ctx.mod.types[funcTypeIdx];\n  if (!type || type.kind !== \"func\") return undefined;\n  const self = type.params[0];\n  return self && (self.kind === \"ref\" || self.kind === \"ref_null\") ? self.typeIdx : undefined;\n}\n",
+      "sha256": "8631bfc6e6ec1e21f62a3effa1d02f0a89f27e51dd60aa6e15d6889969de5e64",
+      "edits": [
+        {
+          "oldStart": 18,
+          "oldCount": 1,
+          "newStart": 18,
+          "newCount": 2,
+          "old": ["export type ClosureAllocationMode = \"support\" | \"ordinary\" | \"host-one-shot\";"],
+          "replacement": [
+            "import { createSignatureWrapperType, type ClosureAllocationMode } from \"../../runtime/wasmgc/values/closure-layouts.js\";",
+            "export type { ClosureAllocationMode } from \"../../runtime/wasmgc/values/closure-layouts.js\";"
+          ]
+        },
+        {
+          "oldStart": 107,
+          "oldCount": 5,
+          "newStart": 108,
+          "newCount": 1,
+          "old": [
+            "  const structFields = [",
+            "    { name: \"func\", type: { kind: \"funcref\" as const }, mutable: false },",
+            "    closureArityField(),",
+            "    closureBagField(),",
+            "  ];"
+          ],
+          "replacement": [""]
+        },
+        {
+          "oldStart": 114,
+          "oldCount": 6,
+          "newStart": 111,
+          "newCount": 1,
+          "old": [
+            "  ctx.mod.types.push({",
+            "    kind: \"struct\",",
+            "    name: `${closureName}_struct`,",
+            "    fields: structFields,",
+            "    superTypeIdx: rootWrapperTypeIdx ?? -1, // first wrapper is the root; later signatures subtype it",
+            "  });"
+          ],
+          "replacement": [
+            "  ctx.mod.types.push(createSignatureWrapperType(`${closureName}_struct`, rootWrapperTypeIdx ?? -1));"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "src/codegen/builtin-fn-meta.ts",
+      "text": "// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.\n/**\n * (#2896) Standalone native function-object metadata.\n *\n * A builtin function value under `--target standalone` is a closure wrapper\n * struct (`getOrCreateFuncRefWrapperTypes`); it carries no `name`/`length`, so\n * every REFLECTIVE read (`Object.getOwnPropertyDescriptor(fn, \"name\")`,\n * `fn[key]` with a runtime key, `hasOwnProperty`, `getOwnPropertyNames`) sees\n * nothing — which fails test262's `propertyHelper.js verifyProperty` for every\n * builtin `name.js` / `length.js` / `prop-desc.js` even where a compile-time\n * direct-access meta fold exists (the helper's receiver/key are runtime params).\n *\n * ## Mechanism — per-(builtin, member) meta SUBTYPE, constant metadata per type\n *\n * For each distinct builtin function we materialize, register a UNIQUE struct\n * subtype of its signature wrapper:\n *\n *   `$__builtinfn_<n> {\n *      funcref func;\n *      (mut i32) bfnstate;\n *      i32 bfnid;\n *    } <: $__fn_wrap_<sig>`\n *\n * - Being a SUBTYPE of the signature wrapper keeps every existing call path\n *   working untouched (static closure calls, reflective `.call`, any-typed\n *   callback dispatch — they cast to the sig wrapper / root, and a subtype\n *   passes).\n * - The metadata itself ({name, length}) is statically known per (builtin,\n *   member), so it lives in `ctx.builtinFnMetaByTypeIdx` keyed by the meta type\n *   index. WasmGC structurally canonicalizes the otherwise-identical meta\n *   subtypes, so `ref.test <metaType>` is not an identity discriminator. The\n *   immutable `bfnid` field anchors each instance to its exact metadata entry;\n *   reflective natives require both the family `ref.test` and matching id.\n * - `bfnstate` is the one piece of per-INSTANCE state: a deleted-bits mask\n *   (bit 0 = `name` deleted, bit 1 = `length` deleted). `verifyProperty`'s\n *   `isConfigurable` arm `delete`s the property and then requires\n *   `hasOwnProperty` to report false, so delete must genuinely work.\n *   `struct.new` sites therefore push an extra `i32.const 0`\n *   (`pushBuiltinFnClosureValueInstrs` below).\n */\nimport type { Instr, ValType } from \"../ir/types.js\";\nimport type { ClosureInfo, CodegenContext, FunctionContext } from \"./context/types.js\";\nimport {\n  closureArityField,\n  closureBagField,\n  closureBagInitInstr,\n  getOrCreateFuncRefWrapperTypes,\n} from \"./closures/funcref-wrapper-types.js\";\nimport { mintDefinedFunc, pushDefinedFunc } from \"./func-space.js\";\n\n/**\n * (#4241) Field indices of the meta-typed closure subtype, derived from the\n * shared closure header rather than spelled as bare literals — the header grew\n * a `$bag` slot at index 2 and these two shifted with it.\n * Layout: `[func, $arity, $bag, bfnstate, bfnid]`.\n */\nexport const BFN_STATE_FIELD_IDX = 3;\nexport const BFN_ID_FIELD_IDX = 4;\n\n/**\n * Spec `{name, length}` for the builtin STATIC method closures wired in\n * `ensureStandaloneBuiltinStaticMethodClosure` (property-access.ts). Keep in\n * sync with its `switch (key)`. Also consumed by the direct-access\n * `.name`/`.length` meta fold so the constant fold and the runtime descriptor\n * agree.\n */\nexport const STANDALONE_STATIC_METHOD_META: Record<string, { name: string; length: number }> = {\n  \"Array.isArray\": { name: \"isArray\", length: 1 },\n  \"Object.assign\": { name: \"assign\", length: 2 },\n  \"Object.keys\": { name: \"keys\", length: 1 },\n  \"Object.getOwnPropertyDescriptor\": { name: \"getOwnPropertyDescriptor\", length: 2 },\n  // (#2933) Fixed-arity Reflect.* namespace static-method value reads. Spec\n  // `length` per §28.1 (receiver arg is optional and not counted).\n  \"Reflect.get\": { name: \"get\", length: 2 },\n  \"Reflect.has\": { name: \"has\", length: 2 },\n  \"Reflect.set\": { name: \"set\", length: 3 },\n  \"Reflect.ownKeys\": { name: \"ownKeys\", length: 1 },\n  \"Reflect.getOwnPropertyDescriptor\": { name: \"getOwnPropertyDescriptor\", length: 2 },\n  \"Reflect.defineProperty\": { name: \"defineProperty\", length: 3 },\n  // (#2933) JSON.stringify as a VALUE — the fixed 1-arg compact form. The value\n  // closure serialises via the native `__json_stringify_root` (host-free), the\n  // SAME entry the direct `JSON.stringify(o)` call path uses. Spec `.length` is\n  // 3 (value, replacer, space); the host-free closure supports only the leading\n  // value arg (replacer/space out of scope, matching the standalone call-path\n  // narrowing), but `.length` reports the spec arity.\n  \"JSON.stringify\": { name: \"stringify\", length: 3 },\n  \"Symbol.for\": { name: \"for\", length: 1 },\n  \"Symbol.keyFor\": { name: \"keyFor\", length: 1 },\n  \"Promise.resolve\": { name: \"resolve\", length: 1 },\n  \"Promise.reject\": { name: \"reject\", length: 1 },\n  // (#2933) Math.max/Math.min as VALUES — genuinely VARIADIC; reified with the\n  // canonical variadic closure convention (one `$vec_externref` args param, see\n  // `ctx.variadicBuiltinClosure`). Spec `.length` is 2 for both (§21.3.2.24/.25).\n  \"Math.max\": { name: \"max\", length: 2 },\n  \"Math.min\": { name: \"min\", length: 2 },\n  // (#2963 Tier 2a) Number.is* fixed 1-arg predicates as VALUES. `.name` === the\n  // property key (§10.2.9); `.length` 1 (§21.1.2.x). These agree byte-for-byte\n  // with the generic `BUILTIN_STATIC_METHOD_ARITY` fallback, listed explicitly\n  // per the file-header sync rule for newly-wired closures.\n  \"Number.isInteger\": { name: \"isInteger\", length: 1 },\n  \"Number.isFinite\": { name: \"isFinite\", length: 1 },\n  \"Number.isNaN\": { name: \"isNaN\", length: 1 },\n  \"Number.isSafeInteger\": { name: \"isSafeInteger\", length: 1 },\n  // (#2963 Tier 2b) Object.is fixed 2-arg SameValue as a VALUE (§20.1.2.13).\n  \"Object.is\": { name: \"is\", length: 2 },\n};\n\n/**\n * (#2896) Spec arity of every standard builtin STATIC method (own\n * function-valued data properties of the global constructors/namespaces), for\n * the direct-access `<Builtin>.<method>.length` / `.name` meta fold. `.name`\n * equals the property key for all of these (§10.2.9); `.length` values are the\n * ECMA-262 declared arities (generated from a conforming host — V8/Node — and\n * spot-checked against the spec). This is a compile-time COMPANION of the\n * runtime metadata substrate above: the fold answers direct syntactic reads\n * (no closure materialization, so it also covers methods whose value-read is\n * not yet wired host-free); the meta subtypes answer reflective/runtime reads\n * for the wired closures.\n *\n * (#3181) The whole table AND every inner record are NULL-PROTOTYPED via\n * `nullProtoDeep`. A plain object literal inherits `Object.prototype`, so an\n * inner lookup of an `Object.prototype` method name (`toString`/`valueOf`/\n * `hasOwnProperty`/`constructor`…) returned the INHERITED FUNCTION rather than\n * `undefined` — making the fold at property-access.ts:1126 treat e.g.\n * `Number.toString.length` as \"found\" and emit the `Function` as an f64 → NaN.\n * With null prototypes, only the explicitly-listed static methods match; every\n * other name resolves `undefined` and routes through the normal path.\n */\nconst nullProtoDeep = (rec: Record<string, Record<string, number>>): Record<string, Record<string, number>> => {\n  const out: Record<string, Record<string, number>> = Object.create(null);\n  for (const key of Object.keys(rec)) {\n    out[key] = Object.assign(Object.create(null) as Record<string, number>, rec[key]);\n  }\n  return out;\n};\n\nexport const BUILTIN_STATIC_METHOD_ARITY: Record<string, Record<string, number>> = nullProtoDeep({\n  Array: { isArray: 1, from: 1, fromAsync: 1, of: 0 },\n  ArrayBuffer: { isView: 1 },\n  BigInt: { asUintN: 2, asIntN: 2 },\n  Date: { now: 0, parse: 1, UTC: 7 },\n  Error: { isError: 1 },\n  Map: { groupBy: 2 },\n  Number: { isFinite: 1, isInteger: 1, isNaN: 1, isSafeInteger: 1, parseFloat: 1, parseInt: 2 },\n  Object: {\n    assign: 2,\n    getOwnPropertyDescriptor: 2,\n    getOwnPropertyDescriptors: 1,\n    getOwnPropertyNames: 1,\n    getOwnPropertySymbols: 1,\n    hasOwn: 2,\n    is: 2,\n    preventExtensions: 1,\n    seal: 1,\n    create: 2,\n    defineProperties: 2,\n    defineProperty: 3,\n    freeze: 1,\n    getPrototypeOf: 1,\n    setPrototypeOf: 2,\n    isExtensible: 1,\n    isFrozen: 1,\n    isSealed: 1,\n    keys: 1,\n    entries: 1,\n    fromEntries: 1,\n    values: 1,\n    groupBy: 2,\n  },\n  Promise: { all: 1, allSettled: 1, any: 1, race: 1, resolve: 1, reject: 1, withResolvers: 0, try: 1 },\n  Proxy: { revocable: 2 },\n  Reflect: {\n    defineProperty: 3,\n    deleteProperty: 2,\n    apply: 3,\n    construct: 2,\n    get: 2,\n    getOwnPropertyDescriptor: 2,\n    getPrototypeOf: 1,\n    has: 2,\n    isExtensible: 1,\n    ownKeys: 1,\n    preventExtensions: 1,\n    set: 3,\n    setPrototypeOf: 2,\n  },\n  RegExp: { escape: 1 },\n  String: { fromCharCode: 1, fromCodePoint: 1, raw: 1 },\n  Symbol: { for: 1, keyFor: 1 },\n  Math: {\n    abs: 1,\n    acos: 1,\n    acosh: 1,\n    asin: 1,\n    asinh: 1,\n    atan: 1,\n    atanh: 1,\n    atan2: 2,\n    ceil: 1,\n    cbrt: 1,\n    expm1: 1,\n    clz32: 1,\n    cos: 1,\n    cosh: 1,\n    exp: 1,\n    floor: 1,\n    fround: 1,\n    hypot: 2,\n    imul: 2,\n    log: 1,\n    log1p: 1,\n    log2: 1,\n    log10: 1,\n    max: 2,\n    min: 2,\n    pow: 2,\n    random: 0,\n    round: 1,\n    sign: 1,\n    sin: 1,\n    sinh: 1,\n    sqrt: 1,\n    tan: 1,\n    tanh: 1,\n    trunc: 1,\n    f16round: 1,\n  },\n  JSON: { parse: 2, stringify: 3, rawJSON: 1, isRawJSON: 1 },\n  Atomics: {\n    load: 2,\n    store: 3,\n    add: 3,\n    sub: 3,\n    and: 3,\n    or: 3,\n    xor: 3,\n    exchange: 3,\n    compareExchange: 4,\n    isLockFree: 1,\n    wait: 4,\n    waitAsync: 4,\n    notify: 3,\n    pause: 0,\n  },\n  Iterator: { from: 1 },\n  Uint8Array: { fromBase64: 1, fromHex: 1 },\n});\n\n/**\n * Register (idempotently, keyed by `cacheKey`) the unique metadata-carrying\n * struct subtype for one builtin function closure and return its type index.\n *\n * - `baseStructTypeIdx` — the signature wrapper struct (the supertype).\n * - `baseClosureInfo` — the signature wrapper's ClosureInfo; a copy with\n *   `structTypeIdx` re-pointed at the meta type is registered in\n *   `ctx.closureInfoByTypeIdx` so the static closure-call path and the\n *   reflective `.call` recovery resolve the meta-typed value exactly like the\n *   base wrapper (the lifted func type takes `(ref $sigWrapper)` self — a meta\n *   instance passes as a subtype).\n */\nexport function ensureBuiltinFnMetaType(\n  ctx: CodegenContext,\n  baseStructTypeIdx: number,\n  baseClosureInfo: ClosureInfo,\n  cacheKey: string,\n  name: string,\n  length: number,\n): number {\n  if (!ctx.builtinFnMetaTypeByKey) ctx.builtinFnMetaTypeByKey = new Map();\n  const existing = ctx.builtinFnMetaTypeByKey.get(cacheKey);\n  if (existing !== undefined) return existing;\n\n  const typeIdx = ctx.mod.types.length;\n  ctx.mod.types.push({\n    kind: \"struct\",\n    name: `__builtinfn_meta_${typeIdx}_struct`,\n    fields: [\n      // Field 0 must mirror the supertype exactly (same type + mutability) —\n      // as must the #3673 $arity slot at index 1.\n      { name: \"func\", type: { kind: \"funcref\" as const }, mutable: false },\n      closureArityField(),\n      closureBagField(),\n      // Deleted-bits mask: bit 0 = \"name\" deleted, bit 1 = \"length\" deleted.\n      { name: \"bfnstate\", type: { kind: \"i32\" as const }, mutable: true },\n      // Stable per-module metadata identity. Structurally-equivalent meta\n      // subtypes cannot be distinguished by ref.test alone.\n      { name: \"bfnid\", type: { kind: \"i32\" as const }, mutable: false },\n    ],\n    superTypeIdx: baseStructTypeIdx,\n  });\n\n  ctx.closureInfoByTypeIdx.set(typeIdx, { ...baseClosureInfo, structTypeIdx: typeIdx });\n  if (!ctx.builtinFnMetaByTypeIdx) ctx.builtinFnMetaByTypeIdx = new Map();\n  ctx.builtinFnMetaByTypeIdx.set(typeIdx, { name, length });\n  ctx.builtinFnMetaTypeByKey.set(cacheKey, typeIdx);\n  return typeIdx;\n}\n\n/**\n * The instruction sequence that materializes a builtin closure VALUE from a\n * factory result. A meta-typed closure struct has the extra `(mut i32)\n * bfnstate` + `bfnid` fields, so its `struct.new` needs two more operands than\n * the plain `ref.func` + `struct.new` sequence; non-meta types keep the old\n * shape.\n */\nexport function pushBuiltinFnClosureValueInstrs(\n  ctx: CodegenContext,\n  closure: { type: { kind: \"ref\"; typeIdx: number }; funcIdx: number },\n): Instr[] {\n  const isMeta = ctx.builtinFnMetaByTypeIdx?.has(closure.type.typeIdx) ?? false;\n  const instrs: Instr[] = [{ op: \"ref.func\", funcIdx: closure.funcIdx }];\n  // (#3673) $arity field 1 — the builtin's spec `length` when meta-typed,\n  // else the registered closure signature's param count.\n  // Receiver-aware variadic native-proto values are the one exception: their\n  // internal lifted signature is `(self, thisValue, argsVec)`, while the\n  // in-Wasm `__apply_closure` selector must see zero positional arguments and\n  // leave the exact vector length to the method dispatcher. Their reflective\n  // JavaScript `.length` still comes from `nativeClosureMeta` / bfn metadata.\n  const closureInfo = ctx.closureInfoByTypeIdx.get(closure.type.typeIdx);\n  const arity =\n    closureInfo?.nativeProtoVariadic === true\n      ? 0\n      : isMeta\n        ? (ctx.builtinFnMetaByTypeIdx?.get(closure.type.typeIdx)?.length ?? 0)\n        : (closureInfo?.paramTypes.length ?? 0);\n  instrs.push({ op: \"i32.const\", value: arity });\n  instrs.push(closureBagInitInstr()); // (#4241) $bag field 2\n  if (isMeta) {\n    instrs.push({ op: \"i32.const\", value: 0 }, { op: \"i32.const\", value: closure.type.typeIdx });\n  }\n  instrs.push({ op: \"struct.new\", typeIdx: closure.type.typeIdx });\n  return instrs;\n}\n\n/**\n * (#2963) IDENTITY-STABLE reified builtin-function value. Instead of a fresh\n * `struct.new` per read (which gives `Promise.resolve !== Promise.resolve` —\n * two distinct closure instances), materialize the closure struct into a\n * MODULE-LEVEL SINGLETON: one `(ref null <structType>)` mutable global per\n * (builtin, member), lazily initialized on first read, so every read of the\n * same builtin value yields the SAME ref.\n *\n * Why a lazy null-guard in the FUNCTION BODY rather than a global const-init:\n * the singleton's `struct.new` takes a `ref.func <closureFuncIdx>` operand, and\n * `closureFuncIdx` is a DEFINED-function index that shifts whenever a late\n * import is added (`addUnionImports` / `shiftLateImportIndices` / the\n * string-import shifter). Those shifters walk function bodies + nested\n * `.then`/`.body`/`.else` arrays (verified) but do NOT walk\n * `ctx.mod.globals[].init`, so a `ref.func` embedded in a const-init would go\n * stale and reference the wrong function. Emitting the materialization inside\n * an `if (ref.is_null) { … }` guard in `fctx.body` keeps the `ref.func` in a\n * shift-covered array — the same discipline as every other funcidx bake site.\n *\n * The mutable `bfnstate` (delete-bits) field being shared across all reads is\n * spec-correct: a builtin method is ONE function object, so `delete fn.name`\n * seen through any reference mutates the same object (test262 `verifyProperty`\n * `isConfigurable` arm).\n *\n * Stack: `[] → [(ref <structType>)]` (non-null, exactly what\n * `pushBuiltinFnClosureValueInstrs` produced, so callers' result type is\n * unchanged).\n */\nexport function pushBuiltinFnSingletonValueInstrs(\n  ctx: CodegenContext,\n  closure: { type: { kind: \"ref\"; typeIdx: number }; funcIdx: number },\n): Instr[] {\n  const typeIdx = closure.type.typeIdx;\n  if (!ctx.builtinFnSingletonGlobalByTypeIdx) ctx.builtinFnSingletonGlobalByTypeIdx = new Map();\n  let globalIdx = ctx.builtinFnSingletonGlobalByTypeIdx.get(typeIdx);\n  if (globalIdx === undefined) {\n    globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;\n    ctx.mod.globals.push({\n      name: `__builtinfn_singleton_${typeIdx}`,\n      // (ref null <structType>) — starts null, set once on first read.\n      type: { kind: \"ref_null\", typeIdx },\n      mutable: true,\n      init: [{ op: \"ref.null\", typeIdx }],\n    });\n    ctx.builtinFnSingletonGlobalByTypeIdx.set(typeIdx, globalIdx);\n  }\n\n  return [\n    { op: \"global.get\", index: globalIdx },\n    { op: \"ref.is_null\" },\n    {\n      op: \"if\",\n      blockType: { kind: \"empty\" },\n      then: [...pushBuiltinFnClosureValueInstrs(ctx, closure), { op: \"global.set\", index: globalIdx }],\n    },\n    { op: \"global.get\", index: globalIdx },\n    { op: \"ref.as_non_null\" },\n  ];\n}\n\n/**\n * (#2984 / #5197) Canonical per-constructor `get [Symbol.species]` closure.\n *\n * Keep this builder beside the builtin-function metadata substrate rather than\n * in `builtin-static-gopd.ts`: both compile-time descriptor synthesis and the\n * reified constructor carrier need the exact same identity-stable accessor,\n * while the latter is imported by `builtin-static-globals.ts`.  Depending on\n * the higher-level property-access module here would close that initialization\n * cycle.\n *\n * The getter's first user parameter is the original receiver (`this`).  Its\n * unique metadata subtype makes the singleton's reflective `.name`/`.length`\n * surface spec-correct and registering that subtype as receiver-aware keeps a\n * reflective `.call(value)` from dropping the receiver.\n */\nexport function ensureStandaloneSpeciesGetterClosure(\n  ctx: CodegenContext,\n  builtinName: string,\n): { type: { kind: \"ref\"; typeIdx: number }; funcIdx: number } | null {\n  const userParams: ValType[] = [{ kind: \"externref\" }];\n  const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, userParams, [{ kind: \"externref\" }]);\n  if (!wrapperTypes) return null;\n\n  const funcName = `__builtin_species_get_${builtinName}`;\n  let funcIdx = ctx.funcMap.get(funcName);\n  if (funcIdx === undefined) {\n    const selfType: ValType = { kind: \"ref\", typeIdx: wrapperTypes.liftedSelfTypeIdx };\n    const closureFctx: FunctionContext = {\n      name: funcName,\n      params: [{ name: \"__self\", type: selfType }, ...userParams.map((type, i) => ({ name: `arg${i}`, type }))],\n      locals: [],\n      localMap: new Map(),\n      returnType: { kind: \"externref\" },\n      body: [{ op: \"local.get\", index: 1 }],\n      blockDepth: 0,\n      breakStack: [],\n      continueStack: [],\n      labelMap: new Map(),\n      savedBodies: [],\n    };\n    for (let i = 0; i < closureFctx.params.length; i++) {\n      closureFctx.localMap.set(closureFctx.params[i]!.name, i);\n    }\n    funcIdx = mintDefinedFunc(ctx);\n    pushDefinedFunc(ctx, funcIdx, {\n      name: funcName,\n      typeIdx: wrapperTypes.liftedFuncTypeIdx,\n      locals: closureFctx.locals,\n      body: closureFctx.body,\n      exported: false,\n    });\n    ctx.funcMap.set(funcName, funcIdx);\n    if (!ctx.nativeClosureMeta) ctx.nativeClosureMeta = new Map();\n    ctx.nativeClosureMeta.set(funcIdx, { name: \"get [Symbol.species]\", length: 0 });\n  }\n\n  const metaTypeIdx = ensureBuiltinFnMetaType(\n    ctx,\n    wrapperTypes.structTypeIdx,\n    wrapperTypes.closureInfo,\n    `species:${builtinName}`,\n    \"get [Symbol.species]\",\n    0,\n  );\n  if (!ctx.nativeProtoReceiverClosureStructTypes) ctx.nativeProtoReceiverClosureStructTypes = new Set();\n  ctx.nativeProtoReceiverClosureStructTypes.add(metaTypeIdx);\n  return { type: { kind: \"ref\", typeIdx: metaTypeIdx }, funcIdx };\n}\n",
+      "sha256": "f6da70eacab0e9ba87469f827f309372e3b853ce92e522c7172a5ba47fcdd284",
+      "edits": [
+        {
+          "oldStart": 42,
+          "oldCount": 0,
+          "newStart": 43,
+          "newCount": 1,
+          "old": [],
+          "replacement": ["import { getOrCreateFuncRefWrapperTypes } from \"./closures/funcref-wrapper-types.js\";"]
+        },
+        {
+          "oldStart": 44,
+          "oldCount": 5,
+          "newStart": 45,
+          "newCount": 3,
+          "old": [
+            "  closureArityField,",
+            "  closureBagField,",
+            "  closureBagInitInstr,",
+            "  getOrCreateFuncRefWrapperTypes,",
+            "} from \"./closures/funcref-wrapper-types.js\";"
+          ],
+          "replacement": [
+            "  createBuiltinFunctionMetadataType,",
+            "  buildBuiltinClosureValueInstrs,",
+            "} from \"../runtime/wasmgc/values/closure-layouts.js\";"
+          ]
+        },
+        {
+          "oldStart": 57,
+          "oldCount": 2,
+          "newStart": 56,
+          "newCount": 1,
+          "old": ["export const BFN_STATE_FIELD_IDX = 3;", "export const BFN_ID_FIELD_IDX = 4;"],
+          "replacement": [
+            "export { BFN_STATE_FIELD_IDX, BFN_ID_FIELD_IDX } from \"../runtime/wasmgc/values/closure-layouts.js\";"
+          ]
+        },
+        {
+          "oldStart": 274,
+          "oldCount": 17,
+          "newStart": 272,
+          "newCount": 1,
+          "old": [
+            "  ctx.mod.types.push({",
+            "    kind: \"struct\",",
+            "    name: `__builtinfn_meta_${typeIdx}_struct`,",
+            "    fields: [",
+            "      // Field 0 must mirror the supertype exactly (same type + mutability) —",
+            "      // as must the #3673 $arity slot at index 1.",
+            "      { name: \"func\", type: { kind: \"funcref\" as const }, mutable: false },",
+            "      closureArityField(),",
+            "      closureBagField(),",
+            "      // Deleted-bits mask: bit 0 = \"name\" deleted, bit 1 = \"length\" deleted.",
+            "      { name: \"bfnstate\", type: { kind: \"i32\" as const }, mutable: true },",
+            "      // Stable per-module metadata identity. Structurally-equivalent meta",
+            "      // subtypes cannot be distinguished by ref.test alone.",
+            "      { name: \"bfnid\", type: { kind: \"i32\" as const }, mutable: false },",
+            "    ],",
+            "    superTypeIdx: baseStructTypeIdx,",
+            "  });"
+          ],
+          "replacement": ["  ctx.mod.types.push(createBuiltinFunctionMetadataType(typeIdx, baseStructTypeIdx));"]
+        },
+        {
+          "oldStart": 311,
+          "oldCount": 1,
+          "newStart": 293,
+          "newCount": 1,
+          "old": ["  const instrs: Instr[] = [{ op: \"ref.func\", funcIdx: closure.funcIdx }];"],
+          "replacement": [""]
+        },
+        {
+          "oldStart": 326,
+          "oldCount": 7,
+          "newStart": 308,
+          "newCount": 1,
+          "old": [
+            "  instrs.push({ op: \"i32.const\", value: arity });",
+            "  instrs.push(closureBagInitInstr()); // (#4241) $bag field 2",
+            "  if (isMeta) {",
+            "    instrs.push({ op: \"i32.const\", value: 0 }, { op: \"i32.const\", value: closure.type.typeIdx });",
+            "  }",
+            "  instrs.push({ op: \"struct.new\", typeIdx: closure.type.typeIdx });",
+            "  return instrs;"
+          ],
+          "replacement": [
+            "  return buildBuiltinClosureValueInstrs(closure.type.typeIdx, closure.funcIdx, arity, isMeta);"
+          ]
+        }
+      ]
+    }
+  ],
+  "controls": [
+    {
+      "path": "tests/issue-4241-carrier-bag-slot.test.ts",
+      "sha256": "1309453f41ab1a113711674e90b2a843d01020c6559c9d14abed6585b6b29f2a"
+    },
+    {
+      "path": "tests/issue-2896.test.ts",
+      "sha256": "5c969b35d434de80a322806f4eb04fc708236e0fa8eff2cae9f4f58ff133a8f3"
+    },
+    {
+      "path": "tests/issue-2963-builtin-reification.test.ts",
+      "sha256": "a7fce30adaf18ac87b27e7e0f83a0672cc8ec7cfc1debca3713d234829f271e0"
+    },
+    {
+      "path": "tests/issue-5197-promise-generic-capability.test.ts",
+      "sha256": "4b6b63661b08939b27540ac20f9d2a265c2895aade14d95ba3ce1895a635728e"
+    }
+  ],
+  "minimumObserver": {
+    "path": "src/codegen/expressions/calls.ts",
+    "sourceSha256": "95600315f74c874d203444ce3274ce805d2e59bfd03e900db48192486b931889",
+    "start": 179095,
+    "end": 181752,
+    "text": "  let liveClosureInfosByFuncTypeIdx: Map<number, Set<ClosureInfo>> | undefined;\n  const indexLiveClosureInfo = (info: ClosureInfo): void => {\n    const index = (liveClosureInfosByFuncTypeIdx ??= new Map());\n    const records = index.get(info.funcTypeIdx) ?? new Set<ClosureInfo>();\n    records.add(info);\n    index.set(info.funcTypeIdx, records);\n  };\n  const ensureLiveClosureInfoIndex = (): void => {\n    if (liveClosureInfosByFuncTypeIdx !== undefined) return;\n    liveClosureInfosByFuncTypeIdx = new Map();\n    for (const records of [\n      ctx.funcRefWrapperCache.values(),\n      ctx.constructibleFuncRefWrapperCache.values(),\n      ctx.closureInfoByTypeIdx.values(),\n      ctx.closureMap.values(),\n    ]) {\n      for (const info of records) indexLiveClosureInfo(info);\n    }\n  };\n  const observeMinimumArgumentCount = (\n    wrapper: NonNullable<ReturnType<typeof getOrCreateFuncRefWrapperTypes>>,\n    minimumArgumentCount: number,\n  ): void => {\n    // A captureless arrow/function-expression can allocate the shared base\n    // wrapper and then replace `closureInfoByTypeIdx[base]` with its own\n    // ClosureInfo object.  The signature cache deliberately keeps the original\n    // object, so updating only `wrapper.closureInfo` leaves the dispatcher with\n    // a stale minimum and it rejects an optional-parameter declaration invoked\n    // through a narrower public callback type.  Minimum arity is ABI metadata:\n    // persist the minimum by exact lifted func type and synchronize every live\n    // record, including allocation subtypes and both wrapper caches. The\n    // persistent index is authoritative for dispatchers compiled after a later\n    // record replacement; no other signature is widened.\n    const funcTypeIdx = wrapper.closureInfo.funcTypeIdx;\n    const recordedMinimum = ctx.closureMinimumArgumentCountByFuncTypeIdx.get(funcTypeIdx);\n    const effectiveMinimum = Math.min(recordedMinimum ?? wrapper.closureInfo.paramTypes.length, minimumArgumentCount);\n    ctx.closureMinimumArgumentCountByFuncTypeIdx.set(funcTypeIdx, effectiveMinimum);\n\n    ensureLiveClosureInfoIndex();\n    // A wrapper may have been created by an earlier declaration in this same\n    // registration pass, after the lazy index snapshot above.\n    indexLiveClosureInfo(wrapper.closureInfo);\n    const mapped = ctx.closureInfoByTypeIdx.get(wrapper.closureInfo.structTypeIdx);\n    if (mapped) indexLiveClosureInfo(mapped);\n    for (const info of liveClosureInfosByFuncTypeIdx!.get(funcTypeIdx) ?? []) {\n      const current = info.minimumArgumentCount ?? info.paramTypes.length;\n      info.minimumArgumentCount = Math.min(current, effectiveMinimum);\n    }\n  };\n",
+    "sha256": "058e1607a5fd545c1ec26511d6545ebe4ce045b1e4f5bf8136beba9418376ef7"
+  }
+}

--- a/tests/issue-3518-native-closure-resources.test.ts
+++ b/tests/issue-3518-native-closure-resources.test.ts
@@ -1,0 +1,893 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import ts from "typescript";
+import { createEmptyModule, type Instr, type ValType } from "../src/ir/types.js";
+import { internFunctionType } from "../src/wasm/physical/function-types.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import * as funcSpace from "../src/codegen/func-space.js";
+import * as canonical from "../src/runtime/wasmgc/values/closure-layouts.js";
+import {
+  reserveNativeClosureResources,
+  requireNativeClosureReservations,
+  type NativeClosureRequirements,
+  type NativeClosureSignatureRequest,
+  type NativeClosureMetadataRequest,
+} from "../src/backend/wasmgc/resources/native-closures.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { emitWat } from "../src/emit/wat.js";
+
+const base = "bfe31c8bd96d748e867562e3e9b78343b72d1877";
+const fixtureHash = "16d1ea63f62d793aac80739472e7ff551b73b826af38175de8081370578e1f87";
+const hash = (text: string) => createHash("sha256").update(text).digest("hex");
+const read = (path: string) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+interface Donor {
+  path: string;
+  text: string;
+  sha256: string;
+  edits: {
+    oldStart: number;
+    oldCount: number;
+    newStart: number;
+    newCount: number;
+    old: string[];
+    replacement: string[];
+  }[];
+}
+interface Fixture {
+  schemaVersion: number;
+  base: string;
+  sources: Donor[];
+  controls: { path: string; sha256: string }[];
+  minimumObserver: { path: string; sourceSha256: string; start: number; end: number; text: string; sha256: string };
+}
+function authenticate(text: string): Fixture {
+  if (hash(text) !== fixtureHash) throw new Error("closure fixture digest mismatch");
+  const result = JSON.parse(text) as Fixture;
+  if (result.schemaVersion !== 1 || result.base !== base || result.sources.length !== 3 || result.controls.length !== 4)
+    throw new Error("closure donor population mismatch");
+  for (const source of result.sources)
+    if (hash(source.text) !== source.sha256) throw new Error("closure donor source receipt mismatch");
+  const observer = result.minimumObserver;
+  if (hash(observer.text) !== observer.sha256 || observer.end - observer.start !== observer.text.length)
+    throw new Error("minimum observer span mismatch");
+  return result;
+}
+// Independent exact-base originals and enumerated extraction edits; no runtime Git/fallback.
+const fixtureText = read("tests/fixtures/issue-3518-native-closure-donors.json");
+const fixture = authenticate(fixtureText);
+const [headerDonor, wrapperDonor, metadataDonor] = fixture.sources as [Donor, Donor, Donor];
+function inverse(source: string, donor: Donor): string {
+  const lines = source.split("\n");
+  for (const edit of [...donor.edits].reverse()) {
+    const start = edit.newCount === 0 ? edit.newStart : edit.newStart - 1;
+    if (JSON.stringify(lines.slice(start, start + edit.newCount)) !== JSON.stringify(edit.replacement))
+      throw new Error("unapproved extraction/import span");
+    lines.splice(start, edit.newCount, ...edit.old);
+  }
+  return lines.join("\n");
+}
+function requireDonor(source: string, donor: Donor): void {
+  if (hash(inverse(source, donor)) !== donor.sha256) throw new Error("full donor reconstruction mismatch");
+}
+function replaceOnce(source: string, before: string, after: string): string {
+  const at = source.indexOf(before);
+  if (at < 0 || source.indexOf(before, at + before.length) >= 0) throw new Error("missing/ambiguous mutation target");
+  return source.slice(0, at) + after + source.slice(at + before.length);
+}
+
+const factoryHeaders = [
+  "export function createSignatureWrapperType(name: string, superTypeIdx: number): StructTypeDef {",
+  "export function createBuiltinFunctionMetadataType(typeIndex: number, signatureWrapperTypeIndex: number): StructTypeDef {",
+  `export function buildBuiltinClosureValueInstrs(
+  typeIndex: number,
+  functionHandle: FuncHandle,
+  arity: number,
+  isMetadata: boolean,
+): Instr[] {`,
+] as const;
+const allocationModeDeclaration = 'export type ClosureAllocationMode = "support" | "ordinary" | "host-one-shot";';
+function completeFactories(source: string): { declarations: string[]; bodies: string[] } {
+  const start = source.indexOf(allocationModeDeclaration);
+  if (start < 0) throw new Error("missing canonical suffix population");
+  const suffix = source.slice(start);
+  const parsed = ts.createSourceFile("closure-factory-receipt.ts", suffix, ts.ScriptTarget.Latest, true);
+  const statements = [...parsed.statements];
+  if (
+    statements.length !== 6 ||
+    !ts.isTypeAliasDeclaration(statements[0]!) ||
+    !ts.isVariableStatement(statements[1]!) ||
+    !ts.isVariableStatement(statements[2]!) ||
+    !statements.slice(3).every(ts.isFunctionDeclaration)
+  ) {
+    throw new Error("canonical suffix must contain mode, two constants, and three complete factories");
+  }
+  const declarations = statements.slice(3).map((statement) => statement.getText(parsed));
+  const bodies = declarations.map((declaration, index) => {
+    const header = factoryHeaders[index]!;
+    if (!declaration.startsWith(header + "\n") || !declaration.endsWith("\n}")) {
+      throw new Error("unapproved complete factory header/return shape");
+    }
+    // Retain EVERY body character, not selected statements or just the returned
+    // initializer. Extra executable code and early returns survive reconstruction.
+    return declaration.slice(header.length + 1, -2);
+  });
+  const expectedSuffix = [
+    allocationModeDeclaration,
+    "",
+    "export const BFN_STATE_FIELD_IDX = 3;",
+    "export const BFN_ID_FIELD_IDX = 4;",
+    "",
+    declarations[0],
+    "",
+    declarations[1],
+    "",
+    declarations[2],
+    "",
+  ].join("\n");
+  if (suffix !== expectedSuffix) throw new Error("canonical suffix population/order/trivia mismatch");
+  return { declarations, bodies };
+}
+function originalSpan(source: string, startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker),
+    end = source.indexOf(endMarker, start + startMarker.length);
+  if (start < 0 || end < start) throw new Error("missing authenticated original factory span");
+  return source.slice(start, end);
+}
+
+/**
+ * Invert complete LIVE declarations using only the named extraction substitutions.
+ * Original bodies are comparison targets, never the source of reconstructed code.
+ * Existing whole-file hashes authenticate the resulting spans plus retained code.
+ */
+function requireCanonicalFactoryReceipts(source: string): void {
+  const { bodies } = completeFactories(source);
+  let wrapperBody = replaceOnce(bodies[0]!, "  const fields = [", "  const structFields = [");
+  // The factory's parameterized return is expanded to the original append shape;
+  // these two retained index declarations stay at their original caller position.
+  wrapperBody = replaceOnce(
+    wrapperBody,
+    '  return { kind: "struct", name, fields, superTypeIdx };',
+    `  const structTypeIdx = ctx.mod.types.length;
+  const rootWrapperTypeIdx = (ctx as unknown as { __funcRefWrapperRootTypeIdx?: number }).__funcRefWrapperRootTypeIdx;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: \`\${closureName}_struct\`,
+    fields: structFields,
+    superTypeIdx: rootWrapperTypeIdx ?? -1, // first wrapper is the root; later signatures subtype it
+  });`,
+  );
+  const wrapperSpan = originalSpan(wrapperDonor.text, "  const structFields = [", "  const liftedSelfTypeIdx =");
+  let reconstructedWrapper = inverse(read(wrapperDonor.path), wrapperDonor);
+  reconstructedWrapper = replaceOnce(reconstructedWrapper, wrapperSpan, wrapperBody + "\n");
+
+  let metadataBody = replaceOnce(bodies[1]!, "  return {", "  ctx.mod.types.push({");
+  metadataBody = replaceOnce(metadataBody, "\n  };", "\n  });");
+  metadataBody = metadataBody
+    .replace(/\btypeIndex\b/g, "typeIdx")
+    .replace(/\bsignatureWrapperTypeIndex\b/g, "baseStructTypeIdx");
+  const metadataFunction = metadataDonor.text.slice(
+    metadataDonor.text.indexOf("export function ensureBuiltinFnMetaType("),
+  );
+  const metadataSpan = originalSpan(metadataFunction, "  ctx.mod.types.push({", "\n\n  ctx.closureInfoByTypeIdx.set");
+  let reconstructedMetadata = inverse(read(metadataDonor.path), metadataDonor);
+  reconstructedMetadata = replaceOnce(reconstructedMetadata, metadataSpan, metadataBody);
+
+  const valueBody = bodies[2]!
+    .replace(/\bfunctionHandle\b/g, "closure.funcIdx")
+    .replace(/\btypeIndex\b/g, "closure.type.typeIdx")
+    .replace(/\bisMetadata\b/g, "isMeta");
+  const firstNewline = valueBody.indexOf("\n");
+  if (firstNewline < 0) throw new Error("missing complete value initializer/body");
+  const initial = valueBody.slice(0, firstNewline),
+    tail = valueBody.slice(firstNewline + 1);
+  const originalInitial = '  const instrs: Instr[] = [{ op: "ref.func", funcIdx: closure.funcIdx }];';
+  const valueFunction = metadataDonor.text.slice(
+    metadataDonor.text.indexOf("export function pushBuiltinFnClosureValueInstrs("),
+  );
+  const originalTail = originalSpan(valueFunction, '  instrs.push({ op: "i32.const", value: arity });', "\n}");
+  reconstructedMetadata = replaceOnce(reconstructedMetadata, originalInitial, initial);
+  reconstructedMetadata = replaceOnce(reconstructedMetadata, originalTail, tail);
+  if (hash(reconstructedWrapper) !== wrapperDonor.sha256 || hash(reconstructedMetadata) !== metadataDonor.sha256) {
+    throw new Error("complete live factory donor receipt mismatch");
+  }
+}
+
+function evaluate(source: string, dependencies: Record<string, unknown> = {}): Record<string, any> {
+  const output = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+  const exports: Record<string, any> = {};
+  new Function("exports", "require", output)(exports, (name: string) => {
+    if (!(name in dependencies)) throw new Error(`unexpected closure donor import ${name}`);
+    return dependencies[name];
+  });
+  return exports;
+}
+function modules(live: boolean, producers: Record<string, unknown> = canonical, wrapperSource?: string) {
+  const header = live
+    ? evaluate(read(headerDonor.path), { "../../runtime/wasmgc/values/closure-layouts.js": producers })
+    : evaluate(headerDonor.text);
+  const registry = {
+    addFuncType: (ctx: any, params: ValType[], results: ValType[], name?: string) =>
+      internFunctionType(ctx.mod.types, ctx.funcTypeCache, params, results, name),
+  };
+  const wrapper = evaluate(wrapperSource ?? (live ? read(wrapperDonor.path) : wrapperDonor.text), {
+    "../../ts-api.js": { ts },
+    "../func-space.js": funcSpace,
+    "../registry/types.js": registry,
+    "./closure-header-layout.js": header,
+    "../../runtime/wasmgc/values/closure-layouts.js": producers,
+  });
+  const metadata = evaluate(live ? read(metadataDonor.path) : metadataDonor.text, {
+    "./closures/funcref-wrapper-types.js": wrapper,
+    "./func-space.js": funcSpace,
+    "../runtime/wasmgc/values/closure-layouts.js": producers,
+  });
+  return { header, wrapper, metadata };
+}
+const signature = (
+  id: string,
+  params: ValType[] = [{ kind: "externref" }],
+  results: ValType[] = [],
+  allocationMode: canonical.ClosureAllocationMode = "ordinary",
+  minimumArgumentCount?: number,
+): NativeClosureSignatureRequest => ({
+  kind: "signature",
+  id,
+  params,
+  results,
+  allocationMode,
+  ...(minimumArgumentCount === undefined ? {} : { minimumArgumentCount }),
+});
+const metadata = (
+  id: string,
+  signatureId: string,
+  key = "promise:settle",
+  name = "",
+  length = 1,
+): NativeClosureMetadataRequest => ({ kind: "metadata", id, signatureId, key, name, length });
+function requirements(
+  requests: NativeClosureRequirements["requests"] = [signature("settle"), metadata("settle-meta", "settle")],
+): NativeClosureRequirements {
+  return { key: "module:closures", startingClosureCounter: 7, requests, referenceTypes: [] };
+}
+function reserve(input = requirements()) {
+  const module = createEmptyModule(),
+    tx = new PhysicalModuleReservations(module);
+  const pack = reserveNativeClosureResources(tx, input);
+  return { module, tx, pack };
+}
+function legacy(
+  input: NativeClosureRequirements,
+  live: boolean,
+  producers: Record<string, unknown> = canonical,
+  wrapperSource?: string,
+) {
+  const api = modules(live, producers, wrapperSource);
+  const ctx: any = {
+    mod: createEmptyModule(),
+    closureCounter: input.startingClosureCounter,
+    funcTypeCache: new Map(),
+    closureInfoByTypeIdx: new Map(),
+    closureMinimumArgumentCountByFuncTypeIdx: new Map(),
+    funcRefWrapperCache: new Map(),
+    constructibleFuncRefWrapperCache: new Map(),
+    closureMap: new Map(),
+    constructibleClosureTypeIdxs: new Set(),
+    funcMap: new Map(),
+    numImportFuncs: 0,
+    numImportGlobals: 0,
+  };
+  // Genuine synchronization helper, including copied records in closureMap.
+  const observer = evaluate(
+    `export function make(ctx: any) { ${fixture.minimumObserver.text}\nreturn observeMinimumArgumentCount; }`,
+  ).make(ctx);
+  const signatures = new Map<string, any>(),
+    metas = new Map<string, number>();
+  for (const request of input.requests) {
+    if (request.kind === "signature") {
+      const row = api.wrapper.getOrCreateFuncRefWrapperTypes(
+        ctx,
+        [...request.params],
+        [...request.results],
+        request.allocationMode,
+      );
+      if (request.minimumArgumentCount !== undefined) observer(row, request.minimumArgumentCount);
+      signatures.set(request.id, row);
+    } else {
+      const row = signatures.get(request.signatureId);
+      metas.set(
+        request.id,
+        api.metadata.ensureBuiltinFnMetaType(
+          ctx,
+          row.structTypeIdx,
+          row.closureInfo,
+          request.key,
+          request.name,
+          request.length,
+        ),
+      );
+    }
+  }
+  return { ctx, api, signatures, metas, observer };
+}
+
+describe("native closure identities and settlement metadata", () => {
+  it("reconstructs all original factory/body spans from complete live canonical declarations", () => {
+    requireCanonicalFactoryReceipts(read("src/runtime/wasmgc/values/closure-layouts.ts"));
+  });
+  for (const index of [0, 1, 2]) {
+    for (const mutation of ["extra-executable", "early-return", "missing-factory", "renamed-factory"] as const) {
+      it(`rejects complete canonical factory ${index} ${mutation} after a genuine positive`, () => {
+        const source = read("src/runtime/wasmgc/values/closure-layouts.ts");
+        requireCanonicalFactoryReceipts(source);
+        const { declarations, bodies } = completeFactories(source);
+        const declaration = declarations[index]!,
+          body = bodies[index]!;
+        const changed =
+          mutation === "extra-executable"
+            ? factoryHeaders[index] + "\n" + body + "\n  void 0;\n}"
+            : mutation === "early-return"
+              ? factoryHeaders[index] + "\n  return undefined as never;\n" + body + "\n}"
+              : mutation === "missing-factory"
+                ? ""
+                : declaration.replace("export function ", "export function renamed_");
+        const mutant = replaceOnce(source, declaration, changed);
+        expect(mutant).not.toBe(source);
+        expect(() => requireCanonicalFactoryReceipts(mutant)).toThrow(/factory|factories|suffix|mutation target/);
+      });
+    }
+  }
+  for (const mutation of [
+    "wrapper-construction-order",
+    "value-construction-order",
+    "field-mutability",
+    "metadata-id",
+  ] as const) {
+    it(`rejects live canonical ${mutation} through fixed donor receipts`, () => {
+      const source = read("src/runtime/wasmgc/values/closure-layouts.ts");
+      requireCanonicalFactoryReceipts(source);
+      const { declarations, bodies } = completeFactories(source);
+      const index = mutation === "wrapper-construction-order" ? 0 : mutation === "field-mutability" ? 1 : 2;
+      let changedBody = bodies[index]!;
+      if (mutation === "wrapper-construction-order") {
+        const returned = '  return { kind: "struct", name, fields, superTypeIdx };';
+        changedBody = returned + "\n" + replaceOnce(changedBody, "\n" + returned, "");
+      } else if (mutation === "value-construction-order") {
+        changedBody = replaceOnce(
+          changedBody,
+          '  instrs.push({ op: "i32.const", value: arity });\n  instrs.push(closureBagInitInstr()); // (#4241) $bag field 2',
+          '  instrs.push(closureBagInitInstr()); // (#4241) $bag field 2\n  instrs.push({ op: "i32.const", value: arity });',
+        );
+      } else if (mutation === "field-mutability") {
+        changedBody = replaceOnce(
+          changedBody,
+          '{ name: "bfnstate", type: { kind: "i32" as const }, mutable: true }',
+          '{ name: "bfnstate", type: { kind: "i32" as const }, mutable: false }',
+        );
+      } else
+        changedBody = replaceOnce(
+          changedBody,
+          '{ op: "i32.const", value: typeIndex }',
+          '{ op: "i32.const", value: typeIndex + 1 }',
+        );
+      const mutant = replaceOnce(source, declarations[index]!, factoryHeaders[index] + "\n" + changedBody + "\n}");
+      expect(mutant).not.toBe(source);
+      expect(() => requireCanonicalFactoryReceipts(mutant)).toThrow(/factory donor receipt mismatch/);
+    });
+  }
+  for (const mutation of ["mode", "constant", "factory-order", "extra-declaration"] as const) {
+    it(`pins the complete canonical suffix population against ${mutation}`, () => {
+      const source = read("src/runtime/wasmgc/values/closure-layouts.ts");
+      requireCanonicalFactoryReceipts(source);
+      const { declarations } = completeFactories(source);
+      let mutant: string;
+      if (mutation === "mode")
+        mutant = replaceOnce(
+          source,
+          allocationModeDeclaration,
+          allocationModeDeclaration.replace('"support"', '"unsupported"'),
+        );
+      else if (mutation === "constant")
+        mutant = replaceOnce(source, "export const BFN_ID_FIELD_IDX = 4;", "export const BFN_ID_FIELD_IDX = 5;");
+      else if (mutation === "extra-declaration") mutant = source + "export const extraFactoryState = 0;\n";
+      else
+        mutant = replaceOnce(
+          source,
+          declarations[0]! + "\n\n" + declarations[1]!,
+          declarations[1]! + "\n\n" + declarations[0]!,
+        );
+      expect(mutant).not.toBe(source);
+      expect(() => requireCanonicalFactoryReceipts(mutant)).toThrow(/suffix|factory header/);
+    });
+  }
+
+  it("authenticates fixed originals and rejects altered receipts", () => {
+    expect(fixture.sources.map((source) => source.path)).toEqual([
+      "src/codegen/closures/closure-header-layout.ts",
+      "src/codegen/closures/funcref-wrapper-types.ts",
+      "src/codegen/builtin-fn-meta.ts",
+    ]);
+    expect(() => authenticate(fixtureText.replace('"schemaVersion": 1', '"schemaVersion": 2'))).toThrow(/digest/);
+  });
+  for (const donor of fixture.sources) {
+    it(`inverse reconstructs ALL of ${donor.path}`, () => {
+      requireDonor(read(donor.path), donor);
+    });
+    for (const mutation of ["missing", "renamed"] as const) {
+      it(`rejects ${mutation} canonical imports/forwards in ${donor.path}`, () => {
+        const source = read(donor.path);
+        requireDonor(source, donor);
+        const first = source.indexOf("runtime/wasmgc/values/closure-layouts.js");
+        if (first < 0) throw new Error("missing canonical import control");
+        const mutant =
+          source.slice(0, first) +
+          (mutation === "missing" ? "" : "runtime/wasmgc/values/renamed.js") +
+          source.slice(first + "runtime/wasmgc/values/closure-layouts.js".length);
+        expect(() => requireDonor(mutant, donor)).toThrow(/extraction|reconstruction/);
+      });
+    }
+  }
+  it("preserves all moved header documentation, predicates and eleven forwards", () => {
+    const source = read("src/runtime/wasmgc/values/closure-layouts.ts");
+    const end = source.indexOf("\nexport type ClosureAllocationMode =");
+    if (end < 0) throw new Error("missing header boundary");
+    const reconstructed = source.slice(0, end).trimEnd() + "\n";
+    const restored = reconstructed.replace(
+      'import type { Instr, ValType, FuncHandle } from "../../../wasm/model/instructions.js";\nimport type { FieldDef, StructTypeDef } from "../../../wasm/model/module-records.js";',
+      'import type { FieldDef, Instr, ValType } from "../../ir/types.js";',
+    );
+    expect(hash(restored)).toBe(headerDonor.sha256);
+    const old = modules(false).header,
+      live = modules(true).header;
+    expect(Object.keys(live).sort()).toEqual(Object.keys(old).sort());
+    expect(Object.keys(live)).toHaveLength(11);
+    const fields = canonical.createSignatureWrapperType("root", -1).fields;
+    for (const probe of [[], fields, [...fields, fields[0]], [{ ...fields[0]!, mutable: true }, ...fields.slice(1)]]) {
+      expect(live.hasClosureHeaderPrefix(probe)).toBe(old.hasClosureHeaderPrefix(probe));
+      expect(live.isCanonicalClosureHeader(probe)).toBe(old.isCanonicalClosureHeader(probe));
+    }
+  });
+  it("retains original source controls and the full minimum-arity authority", () => {
+    for (const control of fixture.controls) expect(hash(read(control.path))).toBe(control.sha256);
+    expect(hash(read(fixture.minimumObserver.path))).toBe(fixture.minimumObserver.sourceSha256);
+  });
+  it("rejects retained catalog changes and publication reorder", () => {
+    const source = read(metadataDonor.path);
+    requireDonor(source, metadataDonor);
+    const changed = replaceOnce(
+      source,
+      '"Array.isArray": { name: "isArray", length: 1 }',
+      '"Array.isArray": { name: "isArray", length: 2 }',
+    );
+    const before =
+      "  ctx.builtinFnMetaByTypeIdx.set(typeIdx, { name, length });\n  ctx.builtinFnMetaTypeByKey.set(cacheKey, typeIdx);";
+    const reordered = replaceOnce(
+      source,
+      before,
+      "  ctx.builtinFnMetaTypeByKey.set(cacheKey, typeIdx);\n  ctx.builtinFnMetaByTypeIdx.set(typeIdx, { name, length });",
+    );
+    expect(() => requireDonor(changed, metadataDonor)).toThrow(/reconstruction/);
+    expect(() => requireDonor(reordered, metadataDonor)).toThrow(/reconstruction/);
+  });
+
+  for (const first of ["settle", "numeric"] as const) {
+    it(`matches independent donors and actual legacy callers with ${first} first`, () => {
+      const settle = signature("settle", [{ kind: "externref" }], [], "host-one-shot", 1);
+      const numeric = signature("numeric", [{ kind: "f64" }], [{ kind: "f64" }], "support");
+      const input = requirements([
+        ...(first === "settle" ? [settle, numeric] : [numeric, settle]),
+        metadata("meta", "settle"),
+        signature("hit", [{ kind: "externref" }], [], "ordinary", 0),
+        metadata("again", "hit"),
+        metadata("distinct", "hit", "builtin:other", "other", 1),
+      ]);
+      const old = legacy(input, false),
+        live = legacy(input, true),
+        { module, tx, pack } = reserve(input);
+      requireNativeClosureReservations(tx, pack);
+      expect(live.ctx.mod).toEqual(old.ctx.mod);
+      expect(module.types).toEqual(old.ctx.mod.types);
+      expect(pack.resultingClosureCounter).toBe(old.ctx.closureCounter);
+      for (const row of pack.signatures) expect(row.binding.info).toEqual(old.signatures.get(row.id).closureInfo);
+      for (const row of pack.metadata) {
+        expect(row.binding.type.typeIndex).toBe(old.metas.get(row.id));
+        expect(row.binding.info).toEqual(old.ctx.closureInfoByTypeIdx.get(row.binding.type.typeIndex));
+      }
+      expect(pack.signatures[2]!.binding).toBe(pack.signatures.find((row) => row.id === "settle")!.binding);
+      expect(pack.metadata[0]!.binding).toBe(pack.metadata[1]!.binding);
+      expect(pack.metadata[0]!.binding.metadata.id).not.toBe(pack.metadata[2]!.binding.metadata.id);
+      expect(pack.registrations.filter((record) => record.kind === "root")).toHaveLength(1);
+      expect(pack.registrations.filter((record) => record.kind === "closure-info")).toHaveLength(4);
+      expect(pack.registrations.map((record) => record.kind)).toEqual([
+        "counter",
+        "type",
+        "root",
+        "signature",
+        "closure-info",
+        "wrapper-cache",
+        "counter",
+        "type",
+        "signature",
+        "closure-info",
+        "wrapper-cache",
+        "type",
+        "closure-info",
+        "metadata",
+        "metadata-cache",
+        "type",
+        "closure-info",
+        "metadata",
+        "metadata-cache",
+      ]);
+      expect(
+        pack.metadata.every(
+          (row) => row.binding.type.object.kind === "struct" && row.binding.type.object.fields.length === 5,
+        ),
+      ).toBe(true);
+      expect(module.functions).toEqual([]);
+      expect(module.globals).toEqual([]);
+      tx.freezeReservations();
+      requireNativeClosureReservations(tx, pack);
+      tx.seal();
+      expect(emitBinary(module)).toEqual(emitBinary(old.ctx.mod));
+      expect(emitWat(module)).toBe(emitWat(old.ctx.mod));
+      expect(emitBinary(live.ctx.mod)).toEqual(emitBinary(old.ctx.mod));
+    });
+  }
+  for (const modes of [
+    ["support", "support"],
+    ["host-one-shot", "support"],
+    ["host-one-shot", "ordinary"],
+    ["ordinary", "host-one-shot"],
+  ] as const) {
+    it(`preserves allocation observations ${modes.join(" then ")}`, () => {
+      const input = requirements([
+        signature("a", undefined, undefined, modes[0], 1),
+        signature("b", undefined, undefined, modes[1], 0),
+      ]);
+      const { pack } = reserve(input),
+        old = legacy(input, false);
+      expect(pack.signatures[0]!.binding).toBe(pack.signatures[1]!.binding);
+      expect(pack.signatures[1]!.binding.info).toEqual(old.signatures.get("b").closureInfo);
+      expect(pack.resultingClosureCounter).toBe(8);
+    });
+  }
+  for (const timing of ["before-first", "after-first", "after-other-signature"] as const) {
+    it(`preserves metadata-copy minima ${timing} observation without rescanning late copies`, () => {
+      const initial: NativeClosureRequirements["requests"] =
+        timing === "after-other-signature"
+          ? [signature("other", [{ kind: "f64" }], [{ kind: "f64" }], "support", 1), signature("settle")]
+          : [signature("settle", [{ kind: "externref" }], [], "ordinary", timing === "after-first" ? 1 : undefined)];
+      const input = requirements([
+        ...initial,
+        metadata("copied", "settle"),
+        signature("lower", [{ kind: "externref" }], [], "ordinary", 0),
+        metadata("reused", "lower"),
+        metadata("fresh", "lower", "builtin:fresh", "fresh", 1),
+      ]);
+      const original = legacy(input, false),
+        live = legacy(input, true);
+      const expected = timing === "before-first" ? 0 : timing === "after-first" ? 1 : undefined;
+      const originalCopied = original.ctx.closureInfoByTypeIdx.get(original.metas.get("copied"));
+      expect(originalCopied.minimumArgumentCount).toBe(expected);
+      expect(live.ctx.closureInfoByTypeIdx.get(live.metas.get("copied"))).toEqual(originalCopied);
+      const { pack } = reserve(input);
+      const copied = pack.metadata.find((row) => row.id === "copied")!.binding;
+      const reused = pack.metadata.find((row) => row.id === "reused")!.binding;
+      const fresh = pack.metadata.find((row) => row.id === "fresh")!.binding;
+      expect(copied).toBe(reused);
+      expect(copied.info).toEqual(originalCopied);
+      expect(copied.info.minimumArgumentCount).toBe(expected);
+      expect(copied.signature.info.minimumArgumentCount).toBe(0);
+      expect(fresh.info.minimumArgumentCount).toBe(0);
+      for (const row of pack.metadata)
+        expect(row.binding.info).toEqual(original.ctx.closureInfoByTypeIdx.get(original.metas.get(row.id)));
+    });
+  }
+
+  it("retains actual minimum synchronization across copied closureMap and both caches", () => {
+    const input = requirements([signature("first")]);
+    for (const live of [false, true]) {
+      const result = legacy(input, live),
+        row = result.signatures.get("first");
+      const copies = [1, 2, 3].map((id) => ({ ...row.closureInfo, structTypeIdx: 100 + id }));
+      result.ctx.closureMap.set("capture", copies[0]);
+      result.ctx.constructibleFuncRefWrapperCache.set("constructible", copies[1]);
+      result.ctx.closureInfoByTypeIdx.set(103, copies[2]);
+      result.observer(row, 0);
+      expect(copies.map((record) => record.minimumArgumentCount)).toEqual([0, 0, 0]);
+    }
+  });
+
+  it("retains live arity selection and nested singleton initializer bodies", () => {
+    for (const isMetadata of [false, true])
+      for (const variadic of [false, true]) {
+        const input = requirements(isMetadata ? [signature("s"), metadata("m", "s")] : [signature("s")]);
+        const old = legacy(input, false),
+          live = legacy(input, true);
+        const index = isMetadata ? old.metas.get("m")! : old.signatures.get("s").structTypeIdx;
+        for (const result of [old, live]) result.ctx.closureInfoByTypeIdx.get(index).nativeProtoVariadic = variadic;
+        const closure = { type: { kind: "ref", typeIdx: index }, funcIdx: 42 };
+        expect(live.api.metadata.pushBuiltinFnClosureValueInstrs(live.ctx, closure)).toEqual(
+          old.api.metadata.pushBuiltinFnClosureValueInstrs(old.ctx, closure),
+        );
+        expect(live.api.metadata.pushBuiltinFnSingletonValueInstrs(live.ctx, closure)).toEqual(
+          old.api.metadata.pushBuiltinFnSingletonValueInstrs(old.ctx, closure),
+        );
+        expect(live.ctx.mod.globals).toEqual(old.ctx.mod.globals);
+        expect(live.ctx.builtinFnSingletonGlobalByTypeIdx).toEqual(old.ctx.builtinFnSingletonGlobalByTypeIdx);
+        expect(live.api.metadata.BFN_STATE_FIELD_IDX).toBe(3);
+        expect(live.api.metadata.BFN_ID_FIELD_IDX).toBe(4);
+      }
+  });
+  it("authenticates external ref/null-ref types and preserves their exact indices", () => {
+    const module = createEmptyModule(),
+      tx = new PhysicalModuleReservations(module);
+    const external = tx.reserveType("external", { kind: "struct", name: "external", fields: [] });
+    const input = {
+      ...requirements([
+        signature(
+          "typed",
+          [{ kind: "ref", typeIdx: external.typeIndex }],
+          [{ kind: "ref_null", typeIdx: external.typeIndex }],
+        ),
+      ]),
+      referenceTypes: [external],
+    };
+    const pack = reserveNativeClosureResources(tx, input);
+    expect(pack.root.typeIndex).toBe(1);
+    requireNativeClosureReservations(tx, pack);
+    tx.freezeReservations();
+    requireNativeClosureReservations(tx, pack);
+    tx.seal();
+  });
+  for (const provenance of ["foreign", "copied"] as const) {
+    it(`rejects ${provenance} matching-index type before allocation`, () => {
+      const module = createEmptyModule(),
+        tx = new PhysicalModuleReservations(module);
+      const other = new PhysicalModuleReservations(createEmptyModule());
+      const local = tx.reserveType("external", { kind: "struct", name: "external", fields: [] });
+      const foreign = other.reserveType("external", { kind: "struct", name: "external", fields: [] });
+      const token = provenance === "foreign" ? foreign : { ...local };
+      expect(token.typeIndex).toBe(local.typeIndex);
+      const before = structuredClone(module);
+      const input = { ...requirements([signature("typed", [{ kind: "ref", typeIdx: 0 }])]), referenceTypes: [token] };
+      expect(() => reserveNativeClosureResources(tx, input)).toThrow(/foreign|forged/);
+      expect(module).toEqual(before);
+      expect(module.funcOrdinalToPosition).toEqual([]);
+    });
+  }
+  it("rejects copied/foreign packs and changed request sequences", () => {
+    const input = requirements(),
+      a = reserve(input),
+      b = reserve();
+    expect(() => requireNativeClosureReservations(a.tx, { ...a.pack })).toThrow(/copied/);
+    expect(() => requireNativeClosureReservations(a.tx, b.pack)).toThrow(/foreign/);
+    (input.requests[0] as { allocationMode: string }).allocationMode = "support";
+    expect(() => requireNativeClosureReservations(a.tx, a.pack)).toThrow(/stale/);
+  });
+  it("rejects stale field content and missing references before reservation changes", () => {
+    const module = createEmptyModule(),
+      tx = new PhysicalModuleReservations(module);
+    const external = tx.reserveType("external", canonical.createSignatureWrapperType("external", -1));
+    if (external.object.kind !== "struct") throw new Error("expected struct");
+    external.object.fields[2]!.mutable = false;
+    const before = structuredClone(module);
+    expect(() =>
+      reserveNativeClosureResources(tx, {
+        ...requirements([signature("typed", [{ kind: "ref", typeIdx: 0 }])]),
+        referenceTypes: [external],
+      }),
+    ).toThrow(/altered/);
+    expect(module).toEqual(before);
+    const clean = createEmptyModule(),
+      fresh = new PhysicalModuleReservations(clean);
+    expect(() =>
+      reserveNativeClosureResources(fresh, requirements([signature("missing", [{ kind: "ref", typeIdx: 9 }])])),
+    ).toThrow(/missing concrete/);
+    expect(clean.types).toEqual([]);
+  });
+  for (const requests of [
+    [],
+    [metadata("forward", "missing")],
+    [signature("a"), signature("a")],
+    [signature("a"), metadata("bad", "a", "promise:settle", "wrong")],
+  ] as NativeClosureRequirements["requests"][]) {
+    it(`rejects invalid request population ${JSON.stringify(requests)}`, () => {
+      const module = createEmptyModule(),
+        tx = new PhysicalModuleReservations(module);
+      expect(() => reserveNativeClosureResources(tx, requirements(requests))).toThrow();
+      expect(module.types).toEqual([]);
+      expect(module.functions).toEqual([]);
+    });
+  }
+
+  for (const mutant of ["bag-mutability", "field-order", "metadata-id"] as const) {
+    it(`independent legacy control rejects canonical ${mutant}`, () => {
+      const input = requirements(),
+        old = legacy(input, false),
+        live = legacy(input, true);
+      expect(live.ctx.mod).toEqual(old.ctx.mod);
+      const replacements: Record<string, unknown> = { ...canonical };
+      if (mutant !== "metadata-id")
+        replacements.createBuiltinFunctionMetadataType = (index: number, parent: number) => {
+          const type = canonical.createBuiltinFunctionMetadataType(index, parent);
+          if (mutant === "bag-mutability") type.fields[2]!.mutable = false;
+          else [type.fields[3], type.fields[4]] = [type.fields[4]!, type.fields[3]!];
+          return type;
+        };
+      else
+        replacements.buildBuiltinClosureValueInstrs = (index: number, handle: number, arity: number, meta: boolean) => {
+          const body = canonical.buildBuiltinClosureValueInstrs(index, handle, arity, meta);
+          if (meta) body[4] = { op: "i32.const", value: index + 1 };
+          return body;
+        };
+      const changed = legacy(input, true, replacements);
+      if (mutant === "metadata-id") {
+        const index = live.metas.get("settle-meta")!,
+          closure = { type: { kind: "ref", typeIdx: index }, funcIdx: 42 };
+        const positive = live.api.metadata.pushBuiltinFnClosureValueInstrs(live.ctx, closure);
+        const expected = old.api.metadata.pushBuiltinFnClosureValueInstrs(old.ctx, closure);
+        expect(positive).toEqual(expected);
+        const body = changed.api.metadata.pushBuiltinFnClosureValueInstrs(changed.ctx, closure);
+        expect(() => expect(body).toEqual(expected)).toThrow();
+      } else expect(() => expect(changed.ctx.mod).toEqual(old.ctx.mod)).toThrow();
+    });
+  }
+  for (const mutant of ["root-self", "duplicate-root", "cache-update", "publication"] as const) {
+    it(`rejects live wrapper ${mutant} after a genuine positive`, () => {
+      const input = requirements([
+        signature("first", [], []),
+        signature("settle", undefined, undefined, "host-one-shot"),
+        signature("hit", undefined, undefined, "ordinary"),
+      ]);
+      const source = read(wrapperDonor.path),
+        old = legacy(input, false),
+        live = legacy(input, true);
+      expect(live.ctx.mod).toEqual(old.ctx.mod);
+      let altered: string;
+      if (mutant === "root-self")
+        altered = replaceOnce(
+          source,
+          'const liftedParams: ValType[] = [{ kind: "ref", typeIdx: liftedSelfTypeIdx }, ...userParams];',
+          'const liftedParams: ValType[] = [{ kind: "ref", typeIdx: structTypeIdx }, ...userParams];',
+        );
+      else if (mutant === "duplicate-root")
+        altered = replaceOnce(
+          source,
+          "createSignatureWrapperType(`${closureName}_struct`, rootWrapperTypeIdx ?? -1)",
+          "createSignatureWrapperType(`${closureName}_struct`, -1)",
+        );
+      else if (mutant === "cache-update")
+        altered = replaceOnce(
+          source,
+          "    observeAllocation(cached, allocationMode);",
+          "    // mutant drops cache-hit allocation observation",
+        );
+      else
+        altered = replaceOnce(
+          source,
+          "  ctx.closureInfoByTypeIdx.set(structTypeIdx, closureInfo);\n  ctx.funcRefWrapperCache.set(sigKey, closureInfo);",
+          "  ctx.funcRefWrapperCache.set(sigKey, closureInfo);\n  ctx.closureInfoByTypeIdx.set(structTypeIdx, closureInfo);",
+        );
+      const changed = legacy(input, true, canonical, altered);
+      if (mutant === "cache-update")
+        expect(() =>
+          expect(changed.signatures.get("hit").closureInfo).toEqual(old.signatures.get("hit").closureInfo),
+        ).toThrow();
+      else if (mutant !== "publication") expect(() => expect(changed.ctx.mod).toEqual(old.ctx.mod)).toThrow();
+      expect(() => requireDonor(altered, wrapperDonor)).toThrow(/extraction|reconstruction/);
+    });
+  }
+
+  it("executes generated metadata values through actual typed functions and independently reads all fields", () => {
+    const input = requirements([
+      signature("identity", [{ kind: "externref" }], [{ kind: "externref" }]),
+      metadata("identity-meta", "identity", "builtin:identity", "identity", 1),
+      signature("settle"),
+      metadata("settle-meta", "settle"),
+    ]);
+    const { module, tx, pack } = reserve(input);
+    const identity = pack.signatures[0]!.binding,
+      settle = pack.signatures[1]!.binding;
+    const target = tx.reserveFunction("target:identity", "identity", {
+      params: [{ kind: "ref", typeIdx: pack.root.typeIndex }, { kind: "externref" }],
+      results: [{ kind: "externref" }],
+    });
+    const settleTarget = tx.reserveFunction("target:settle", "settle", {
+      params: [{ kind: "ref", typeIdx: pack.root.typeIndex }, { kind: "externref" }],
+      results: [],
+    });
+    expect(target.object.typeIdx).toBe(identity.liftedFuncTypeIndex);
+    expect(settleTarget.object.typeIdx).toBe(settle.liftedFuncTypeIndex);
+    const factories = pack.metadata.map((row, index) =>
+      tx.reserveFunction(`factory:${index}`, `make${index}`, { params: [], results: [{ kind: "externref" }] }),
+    );
+    const invoke = tx.reserveFunction("invoke", "invoke", {
+      params: [{ kind: "externref" }, { kind: "externref" }],
+      results: [{ kind: "externref" }],
+    });
+    const reads = pack.metadata.flatMap((row, index) =>
+      [1, 2, 3, 4].map((field) => ({
+        row,
+        index,
+        field,
+        fn: tx.reserveFunction(`read:${index}:${field}`, `read${index}_${field}`, {
+          params: [{ kind: "externref" }],
+          results: [{ kind: "i32" }],
+        }),
+      })),
+    );
+    tx.freezeReservations();
+    requireNativeClosureReservations(tx, pack);
+    tx.fillFunction(target, { locals: [], body: [{ op: "local.get", index: 1 }] });
+    tx.fillFunction(settleTarget, { locals: [], body: [] });
+    tx.declareFunctionReference(target);
+    tx.declareFunctionReference(settleTarget);
+    for (let i = 0; i < factories.length; i++) {
+      const row = pack.metadata[i]!.binding;
+      tx.fillFunction(factories[i]!, {
+        locals: [],
+        body: [
+          ...canonical.buildBuiltinClosureValueInstrs(
+            row.type.typeIndex,
+            i === 0 ? target.handle : settleTarget.handle,
+            row.metadata.length,
+            true,
+          ),
+          { op: "extern.convert_any" },
+        ],
+      });
+      tx.defineExport(`export:make${i}`, `make${i}`, factories[i]!);
+    }
+    const self = (): Instr[] => [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: pack.root.typeIndex },
+    ];
+    tx.fillFunction(invoke, {
+      locals: [],
+      body: [
+        ...self(),
+        { op: "local.get", index: 1 },
+        ...self(),
+        { op: "struct.get", typeIdx: pack.root.typeIndex, fieldIdx: 0 },
+        { op: "ref.cast", typeIdx: identity.liftedFuncTypeIndex },
+        { op: "call_ref", typeIdx: identity.liftedFuncTypeIndex },
+      ],
+    });
+    tx.defineExport("export:invoke", "invoke", invoke);
+    for (const { row, index, field, fn } of reads) {
+      const body: Instr[] = [
+        { op: "local.get", index: 0 },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: row.binding.type.typeIndex },
+        { op: "struct.get", typeIdx: row.binding.type.typeIndex, fieldIdx: field },
+      ];
+      if (field === 2) body.push({ op: "ref.is_null" });
+      tx.fillFunction(fn, { locals: [], body });
+      tx.defineExport(`export:read${index}_${field}`, `read${index}_${field}`, fn);
+    }
+    tx.seal();
+    const binary = emitBinary(module);
+    expect(WebAssembly.validate(binary)).toBe(true);
+    const api = new WebAssembly.Instance(new WebAssembly.Module(binary)).exports as Record<
+      string,
+      (...args: any[]) => any
+    >;
+    const value = api.make0!(),
+      payload = { identity: 17 };
+    expect(api.invoke!(value, payload)).toBe(payload);
+    for (let index = 0; index < 2; index++) {
+      const closure = api[`make${index}`]!();
+      expect(api[`read${index}_1`]!(closure)).toBe(1);
+      expect(api[`read${index}_2`]!(closure)).toBe(1);
+      expect(api[`read${index}_3`]!(closure)).toBe(0);
+      expect(api[`read${index}_4`]!(closure)).toBe(pack.metadata[index]!.binding.metadata.id);
+    }
+  });
+});

--- a/tests/issue-3518-native-closure-resources.test.ts
+++ b/tests/issue-3518-native-closure-resources.test.ts
@@ -20,7 +20,9 @@ import { emitBinary } from "../src/emit/binary.js";
 import { emitWat } from "../src/emit/wat.js";
 
 const base = "bfe31c8bd96d748e867562e3e9b78343b72d1877";
-const fixtureHash = "16d1ea63f62d793aac80739472e7ff551b73b826af38175de8081370578e1f87";
+// Prettier changed only the fixture's JSON whitespace at publication. All
+// embedded donor text/hashes remain unchanged; pin the formatted transport.
+const fixtureHash = "be6904328b9bb25981ca9ae109c3526d86931832eeb433bce66af41f99b96575";
 const hash = (text: string) => createHash("sha256").update(text).digest("hex");
 const read = (path: string) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
 interface Donor {

--- a/tests/issue-3518-semantic-provider-boundary.test.ts
+++ b/tests/issue-3518-semantic-provider-boundary.test.ts
@@ -146,10 +146,19 @@ const argumentVectorAdditions = [
   "src/runtime/wasmgc/values/argument-vector-bodies.ts",
   "src/backend/wasmgc/resources/native-argument-vectors.ts",
 ];
-const groups = {
+const argumentVectorGroups = {
   ...nativeValueGroups,
   "native-runtime": [...nativeValueGroups["native-runtime"], argumentVectorAdditions[0]!],
   "backend-wasmgc": [...nativeValueGroups["backend-wasmgc"], argumentVectorAdditions[1]!],
+};
+const closureAdditions = [
+  "src/runtime/wasmgc/values/closure-layouts.ts",
+  "src/backend/wasmgc/resources/native-closures.ts",
+];
+const groups = {
+  ...argumentVectorGroups,
+  "native-runtime": [...argumentVectorGroups["native-runtime"], closureAdditions[0]!],
+  "backend-wasmgc": [...argumentVectorGroups["backend-wasmgc"], closureAdditions[1]!],
 };
 const required = Object.values(groups).flat();
 const callableAdditions = ["src/ir/core/async-callables.ts", "src/ir/runtime/native-async-callables.ts"];
@@ -192,6 +201,14 @@ function assertNewActivations(history: unknown[]) {
       layer,
       entries: groups[layer],
       minModules: groups[layer].length,
+    })),
+  );
+  history = history.slice(2);
+  expect(history.slice(0, 2)).toEqual(
+    (["native-runtime", "backend-wasmgc"] as const).map((layer) => ({
+      layer,
+      entries: argumentVectorGroups[layer],
+      minModules: argumentVectorGroups[layer].length,
     })),
   );
   history = history.slice(2);
@@ -369,8 +386,8 @@ function fixture() {
 
 describe("semantic verification and provider ownership boundary", () => {
   it("pins the original 70 modules plus seven Promise/vector and five string/error owners without relaxing historical policy", () => {
-    expect(required).toHaveLength(88);
-    expect(new Set(required).size).toBe(88);
+    expect(required).toHaveLength(90);
+    expect(new Set(required).size).toBe(90);
     expect(callableAdditions).toHaveLength(2);
     expect(vectorAdditions).toHaveLength(2);
     expect(typeLayoutAdditions).toHaveLength(1);
@@ -395,6 +412,7 @@ describe("semantic verification and provider ownership boundary", () => {
             ...stringErrorAdditions,
             ...nativeValueAdditions,
             ...argumentVectorAdditions,
+            ...closureAdditions,
           ].includes(path),
       ),
     ).toHaveLength(56);
@@ -415,17 +433,18 @@ describe("semantic verification and provider ownership boundary", () => {
       ...stringErrorAdditions,
       ...nativeValueAdditions,
       ...argumentVectorAdditions,
+      ...closureAdditions,
     ])
       expect(required).toContain(path);
     const p = policy();
     assertNewActivations(p.activationHistory);
-    expect(p.activationHistory).toHaveLength(45);
-    expect(digest(p.activationHistory.slice(21))).toBe(
+    expect(p.activationHistory).toHaveLength(47);
+    expect(digest(p.activationHistory.slice(23))).toBe(
       "3437a59aacf39df9dffcafa8099ac9f47c0f43a7a0ecc423df4c1fe3e638f002",
     );
     expect(digest(p.allowedEdges)).toBe("efe7e7ed8dee1a009d2bef3ff36dba80df1a805cd3f5b7b472e62ec6dcff64c7");
     // Exact full activation history at b4c116639a, not a selected subset.
-    expect(digest(p.activationHistory.slice(27))).toBe(
+    expect(digest(p.activationHistory.slice(29))).toBe(
       "a6d07b900b0837832707ce083202ab6ffa40f0bbe6bfce25f3062270882b26da",
     );
     for (const [id, entries] of Object.entries(groups)) {
@@ -442,12 +461,12 @@ describe("semantic verification and provider ownership boundary", () => {
   it("loads the complete actual canonical type-and-value closure", () => {
     const r = fixture().run();
     expect(r.status, JSON.stringify(r.report.errors)).toBe(0);
-    expect(r.report.counts.total).toBe(88);
+    expect(r.report.counts.total).toBe(90);
     expect(r.report.errors).toEqual([]);
     for (const field of ["unknownEdges", "unresolvedEdges", "forbiddenEdges", "transitiveViolations"])
       expect(r.report[field]).toEqual([]);
-    expect(r.report.resolvedEdgeCount).toBe(319);
-    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 206, runtime: 113 });
+    expect(r.report.resolvedEdgeCount).toBe(325);
+    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 210, runtime: 115 });
   });
 
   it.each(["delete", "reorder", "layer", "entries", "minimum"] as const)(
@@ -481,6 +500,7 @@ describe("semantic verification and provider ownership boundary", () => {
     ...stringErrorAdditions,
     ...nativeValueAdditions,
     ...argumentVectorAdditions,
+    ...closureAdditions,
   ])("rejects deleting %s and its classification", (path) => {
     const f = fixture();
     rmSync(resolve(f.root, path));
@@ -507,6 +527,7 @@ describe("semantic verification and provider ownership boundary", () => {
     ...stringErrorAdditions,
     ...nativeValueAdditions,
     ...argumentVectorAdditions,
+    ...closureAdditions,
   ])("rejects an aliased frontend type dependency from %s", (path) => {
     const f = fixture();
     f.put("src/forbidden.ts", "export interface Hidden { value: number }");
@@ -538,6 +559,7 @@ describe("semantic verification and provider ownership boundary", () => {
       ...stringErrorAdditions,
       ...nativeValueAdditions,
       ...argumentVectorAdditions,
+      ...closureAdditions,
     ])(`reports ${field} from %s instead of treating it as closed`, (path) => {
       const f = fixture();
       f.append(path, source);


### PR DESCRIPTION
## Summary

Stacked on #5776. Extract canonical closure layouts while retaining live
legacy callers, and reserve authenticated native wrapper/signature/metadata
resources through the transaction ledger. Preserve declaration order and
legacy lazy minimum-arity observation.

Add complete live donor reconstruction, positive-first mutation controls,
bounded compiler ownership checks, and implementation handoff in the
IR migration issue. This checkpoint does not complete direct-codegen
retirement or public IR-only cutover; the Promise producer join remains next.

## Validation

- Astra High approved production and the repaired complete factory inverse.
- Focused closure R3: 62/62 passed.
- Composed runtime controls: 76 passed, 8 explicitly skipped.
- Compiler ownership boundaries: 221/221 passed.
- Final composed TypeScript check passed.
- Normal commit hooks passed; changed-root gate explicitly skipped its
  72-file population above its 20-file limit, not counted as a test pass.
- Commit formatting changed donor JSON whitespace only; parsed JSON equality
  against the frozen donor was verified. Published fixture SHA256:
  `be6904328b9bb25981ca9ae109c3526d86931832eeb433bce66af41f99b96575`.

Related to #3518; do not close the migration issue for this extraction.
