### PR TITLE
feat(ir): authenticate Promise closure producer dependencies

### DIFF
--- a/plan/agent-context/3518-native-promise-closure-join-high-plan-2026-09-09.md
+++ b/plan/agent-context/3518-native-promise-closure-join-high-plan-2026-09-09.md
@@ -1,0 +1,43 @@
+# Native Promise / closure producer join — frozen High specification
+
+Base: 794ba37c84169944bec1d39ee9c218b96efe0940 (PR #5778).
+Implementation owner: Euclid. Parent owns boundary census and publication.
+
+Exactly two implementation paths:
+
+- src/backend/wasmgc/resources/native-promises.ts
+- tests/issue-3518-native-promise-resources.test.ts
+
+Replace independent raw closureRoot/settleMetadata dependencies with
+`closures: NativeClosureReservations` and `settleMetadataRequestId: string`.
+
+Authenticate the exact issued pack and same transaction using the existing
+requireNativeClosureReservations before any Promise allocation. Select
+exactly one metadata row by request ID. Require key promise:settle, name "",
+public length1, metadata ID equal to metadata type index, genuine signature
+binding membership, exact externref-to-empty signature, and lifted canonical
+root identity. Do not require minimumArgumentCount1 or equal lazy-observer
+snapshots. Preserve first-signature root selection and legitimate repeated
+requests selecting the same cached binding.
+
+Retain exact pack, selected binding and copied request ID in the existing
+Promise owner. Reauthenticate before fills/body construction and derive root
+and metadata operands from that retained selection. Remove local duplicate
+closure-field schema. Keep Promise-owned capture subtype, copied five
+metadata fields plus capture field5, fourteen functions, six globals,
+reservation/fill order and resolve-to-resolveValue routing unchanged.
+
+No new registry, allocator, public selector, raw-token fallback, closure
+producer/body changes, or external P/C changes are authorized in this slice.
+
+Preserve all24 existing tests and actual16-owner/33-call preparation/replay
+axes. Add positive-first genuine-pack, alternate-first-signature, repeated
+binding and lazy-arity controls. Copied/foreign/stale/wrong-request negatives
+must leave preallocation populations unchanged. Test fill reauthentication
+against the genuine missing-dependency frontier, not fabricated complete
+dependencies. Replace fake root/metadata fixture allocations with genuine
+ordered closure producer requests; do not keep both allocations.
+
+Full fill, complete carrier inventory, native-family execution, public
+cutover and ABI30's unresolved planningSealed witness remain open. This
+producer join does not establish those acceptance conditions.

--- a/plan/agent-context/3518-native-promise-closure-join-integration-2026-09-09.md
+++ b/plan/agent-context/3518-native-promise-closure-join-integration-2026-09-09.md
@@ -1,0 +1,58 @@
+# Native Promise / closure producer join — integration
+
+Euclid implemented exactly the two files authorized by the frozen High plan.
+Claim3518:native-promise-closure-join is verified on upstream issue-assignments;
+owner ttraenkler/codex-native-promise-closure-join. Original implementation base
+794ba37c84169944bec1d39ee9c218b96efe0940 was fast-forwarded by parent to
+27d15c6f1adef787bb119538ced6e722a2cd29aa, the tested #5778 transport-hash
+correction. Both implementation hashes remained unchanged across that update.
+
+Frozen formatted SHA256:
+
+- native-promises.ts: d2ca89b448f2f98561b96eacd9b9ab3592895c29bf7b34e6001fa6ad2f6e6251
+- native-promise-resources.test.ts: ff7ccc88c22324bdd160329ec3baff66f9f3d687fea0086b76e1f8d7c9dd94bf
+
+Parent read the complete two-file diff. Real closure pack authentication and
+selected metadata replace independent raw type handles; the selection is
+retained and reauthenticated before fills. The existing Promise capture,
+fourteen functions, six globals and resolution routing remain owned here.
+No complete missing fill dependencies are fabricated by the tests.
+
+Composed run76979 exited0:95/95 passed (33 Promise,62 closure),17.10s.
+This retains all24 prior Promise cases and adds9 genuine producer controls.
+Final composed TS7, boundary census adjustments and independent review are
+pending. Full runtime fill/execution, carrier inventory, public cutover and
+direct-codegen retirement remain outside this checkpoint's evidence.
+
+R1 composed TS7 session64994 exited0. High found two scoped repairs despite
+95/95 tests passing: copy inherited metadata field descriptors rather than
+sharing their objects, matching the legacy donor; replace JSON-only mutation
+assertions with lossless snapshots, retained identities and next-reservation
+ordinal comparisons. Euclid owns those two-file repairs after the typecheck
+finished. All other bounded join requirements were reviewed as acceptable;
+publication remains pending repair and revalidation.
+
+Euclid R2 is formatted and frozen: producer6671c46397b40b736a5a1889b47a4954b7dc46060093d51024e1df3c93730dd4,
+testcd80e12601f0650ead49534c47e57b273df02c3df371a6caebea59d80636ef0b.
+Parent inspected the full diff. Inherited field descriptors are shallow
+copied as in the donor, while field type identities are retained. Rejection
+controls use structuredClone/toStrictEqual, retained object/Map identities,
+and pristine-twin future type/function/signature reservation comparisons.
+All24+9 cases remain. Independent R2 review and runtime rerun are pending.
+
+Boundary measurement47916/68507 identifies exactly326 edges:210 type-only
+and116 runtime across the unchanged90 modules. No unknown, unresolved,
+forbidden or transitive violations were observed. The existing assertion
+was325/210/115; update only these measured import-count assertions for the
+new Promise-to-closure producer edge. Policy, allowed edges and activation
+history are unchanged. Full221-control boundary rerun remains required.
+
+High closed both R2 findings at the frozen hashes above. Composed R2
+run85235 exited0:95/95 passed,15.51s. Full boundary run35032 exited0:
+221/221 passed,141.33s. The unchanged90-module population now has exactly
+326 edges (210 type-only,116 runtime). No policy/activation/allowlist edit
+was needed. Final post-R2 composed TS7 and normal publication hooks remain.
+
+Final R2 composed TS7 session69386 exited0. Independent review,95 focused
+controls and221 boundary controls are current for the formatted source.
+Proceed with normal commit/push checks and a non-draft PR stacked on #5778.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6532,3 +6532,27 @@ do not duplicate Promise capture ownership. Full object/callable dispatch,
 whole-family execution, replay, public IR-only cutover and strict static
 closure/direct-codegen retirement remain open. This checkpoint does not
 claim those acceptance conditions.
+
+### Native Promise / closure producer join — 2026-09-09
+
+High approved the implementation specification in
+agent-context/3518-native-promise-closure-join-high-plan-2026-09-09.md.
+Euclid owns exactly native-promises.ts and its existing resource test,
+based on closure PR #5778. Replace independent raw root/metadata tokens
+with the issued closure pack and metadata request ID. Authenticate before
+allocations and again before fills, preserving genuine cache aliases,
+lazy-arity semantics and existing Promise capture/runtime ownership.
+Parent owns boundary updates, integration checks and non-draft publication.
+
+This is a producer-provenance join, not complete Promise execution. Full
+carrier inventory, callable dispatch, fill dependencies, native-family
+execution, public cutover and the ABI30 planningSealed witness remain open.
+
+The bounded join is implemented and independently approved after two R2
+repairs: inherited metadata field descriptors are copied as in the donor;
+rejection proofs preserve lossless data, object identities and future
+reservation ordinals. Composed Promise/closure95/95 tests and221/221
+boundary controls pass. The single new runtime import links the existing
+Promise and closure owners; no boundary permissions were relaxed. Final
+post-repair typecheck and normal publication checks remain next. See
+agent-context/3518-native-promise-closure-join-integration-2026-09-09.md.

--- a/src/backend/wasmgc/resources/native-promises.ts
+++ b/src/backend/wasmgc/resources/native-promises.ts
@@ -16,6 +16,11 @@ import { preparedIrDataMismatch, freezePreparedIrValue } from "../../../ir/progr
 import type { NativePromiseResourcePlan, NativePromiseOwner } from "../../../ir/program/native-promise-resources.js";
 import { resolveNativeVectorForElement, type NativeVectorTypeReservations } from "./native-vectors.js";
 import {
+  requireNativeClosureReservations,
+  type NativeClosureReservations,
+  type NativeClosureMetadataBinding,
+} from "./native-closures.js";
+import {
   buildGrowLocals,
   buildGrowBody,
   buildEnqueueBody,
@@ -54,8 +59,8 @@ export interface NativePromiseReservationDependencies {
   readonly vectors: NativeVectorTypeReservations;
   readonly exceptionTag: Tag;
   /** Actual canonical closure root and builtin metadata reservation from the value materializer. */
-  readonly closureRoot: TypeReservation;
-  readonly settleMetadata: TypeReservation;
+  readonly closures: NativeClosureReservations;
+  readonly settleMetadataRequestId: string;
 }
 export interface NativePromiseReservations {
   readonly types: {
@@ -154,6 +159,7 @@ const owners = new WeakMap<
     tx: PhysicalModuleReservations;
     plan: NativePromiseResourcePlan;
     dependencies: NativePromiseReservationDependencies;
+    settleMetadata: NativeClosureMetadataBinding;
     snapshots: readonly { token: TypeReservation; descriptor: TypeDef }[];
     filled: boolean;
   }
@@ -168,11 +174,22 @@ function structFields(token: TypeReservation) {
   if (token.object.kind !== "struct") fail("expected concrete struct reservation");
   return token.object.fields;
 }
-const closureFields = () => [
-  { name: "func", type: { kind: "funcref" } as ValType, mutable: false },
-  { name: "$arity", type: I32, mutable: false },
-  { name: "$bag", type: EXTERN, mutable: true },
-];
+function requireSettleMetadata(tx: PhysicalModuleReservations, dependencies: NativePromiseReservationDependencies) {
+  const closures = requireNativeClosureReservations(tx, dependencies.closures);
+  const rows = closures.metadata.filter((row) => row.id === dependencies.settleMetadataRequestId);
+  if (rows.length !== 1) fail("missing or ambiguous settle metadata request");
+  const binding = rows[0]!.binding;
+  same(
+    binding.metadata,
+    { key: "promise:settle", name: "", length: 1, id: binding.type.typeIndex },
+    "invalid settle metadata",
+  );
+  if (!closures.signatures.some((row) => row.binding === binding.signature)) fail("foreign settle signature binding");
+  same(binding.signature.info.paramTypes, [EXTERN], "invalid settle parameters");
+  same(binding.signature.info.returnType, null, "invalid settle result");
+  if (binding.signature.liftedSelfTypeIndex !== closures.root.typeIndex) fail("invalid settle closure root");
+  return binding;
+}
 
 /** Reserve only: empty bodies are ledger obligations, never accepted fallback implementations. */
 export function reserveNativePromiseResources(
@@ -181,6 +198,8 @@ export function reserveNativePromiseResources(
   dependencies: NativePromiseReservationDependencies,
 ): NativePromiseReservations {
   if (!plan.required || !plan.anchor) fail("missing required native Promise plan");
+  const settleMetadata = requireSettleMetadata(tx, dependencies);
+  const closureRoot = dependencies.closures.root;
   const layout = resolveNativeVectorForElement(dependencies.vectors, EXTERN);
   const argumentArray = dependencies.vectors.layouts.find((row) => row.element === "externref")?.array;
   if (!layout || !argumentArray || argumentArray.typeIndex !== layout.arrayTypeIdx)
@@ -190,13 +209,7 @@ export function reserveNativePromiseResources(
     { kind: "array", name: "__arr_externref", element: EXTERN, mutable: true },
     "shared array descriptor mismatch",
   );
-  same(structFields(dependencies.closureRoot), closureFields(), "noncanonical closure root");
-  const metadataFields = [
-    ...closureFields(),
-    { name: "bfnstate", type: I32, mutable: true },
-    { name: "bfnid", type: I32, mutable: false },
-  ];
-  same(structFields(dependencies.settleMetadata), metadataFields, "noncanonical settle metadata fields");
+  const metadataFields = structFields(settleMetadata.type);
   // The actual metadata subtype may sit below a signature wrapper; ancestry is checked by the ledger.
   const key = (role: string) => `physical:promise:${JSON.stringify(plan.anchor)}:${role}`;
   const functionsType = tx.reserveType(key("queue:function-array"), {
@@ -282,11 +295,14 @@ export function reserveNativePromiseResources(
   const settleCapture = tx.reserveType(key("settle-capture"), {
     kind: "struct",
     name: "$__promise_settle_cap",
-    superTypeIdx: dependencies.settleMetadata.typeIndex,
-    fields: [...metadataFields, { name: "cap_promise", type: promiseRef, mutable: false }],
+    superTypeIdx: settleMetadata.type.typeIndex,
+    fields: [
+      ...metadataFields.map((field) => ({ ...field })),
+      { name: "cap_promise", type: promiseRef, mutable: false },
+    ],
   });
   const trampoline = {
-    params: [{ kind: "ref", typeIdx: dependencies.closureRoot.typeIndex } as ValType, EXTERN],
+    params: [{ kind: "ref", typeIdx: closureRoot.typeIndex } as ValType, EXTERN],
     results: [],
   };
   const resolveClosure = reserve("resolve-closure", "__promise_resolve_cl", trampoline);
@@ -337,13 +353,14 @@ export function reserveNativePromiseResources(
     callback,
     captures,
     settleCapture,
-    dependencies.closureRoot,
-    dependencies.settleMetadata,
+    closureRoot,
+    settleMetadata.type,
   ].map((token) => ({ token, descriptor: freezePreparedIrValue(token.object) as TypeDef }));
   owners.set(result, {
     tx,
     plan: freezePreparedIrValue(plan) as NativePromiseResourcePlan,
     dependencies: Object.freeze({ ...dependencies }),
+    settleMetadata,
     snapshots,
     filled: false,
   });
@@ -378,6 +395,7 @@ export function fillNativePromiseResources(
   const owner = owners.get(pack);
   if (!owner || owner.tx !== tx) fail("foreign Promise pack");
   if (owner.filled) fail("duplicate Promise pack fill");
+  if (requireSettleMetadata(tx, owner.dependencies) !== owner.settleMetadata) fail("changed settle metadata binding");
   if (!dependencies?.inventory || !dependencies.values || !dependencies.resolution)
     fail("complete native dependencies are missing");
   same(dependencies.inventory.owners, owner.plan.owners, "classification owner population differs");
@@ -475,7 +493,7 @@ export function fillNativePromiseResources(
       fields.push({ typeIdx: index, fieldIdx: row.fieldIndex });
     }
   }
-  if (!seenTypes.has(owner.dependencies.closureRoot)) fail("closure root absent from finalized inventory");
+  if (!seenTypes.has(owner.dependencies.closures.root)) fail("closure root absent from finalized inventory");
   const av = inventory.anyValue;
   const avFields = structFields(av.type);
   if (av.tag !== 0 || av.ref !== 3 || av.extern !== 4) fail("invalid AnyValue peel descriptor");
@@ -546,7 +564,7 @@ export function fillNativePromiseResources(
   const queue = promiseQueueReservations(tx, pack);
   const cap = {
     capTypeIdx: t.settleCapture.typeIndex,
-    capMetaTypeIdx: owner.dependencies.settleMetadata.typeIndex,
+    capMetaTypeIdx: owner.settleMetadata.type.typeIndex,
     capPromiseFieldIdx: 5,
   };
   const target = { wasi: false, standalone: true };
@@ -579,7 +597,7 @@ export function fillNativePromiseResources(
     bagHasIdx: bagHas,
     externGetIdx: externGet,
     typeofFunctionIdx: typeofFunction,
-    callableRootTypeIdx: owner.dependencies.closureRoot.typeIndex,
+    callableRootTypeIdx: owner.dependencies.closures.root.typeIndex,
   });
   const thenableInventory: PromiseThenableInventory = {
     finalized: true,

--- a/tests/issue-3518-native-promise-resources.test.ts
+++ b/tests/issue-3518-native-promise-resources.test.ts
@@ -13,6 +13,10 @@ import { planNativePromiseResources } from "../src/ir/program-physical-plan.js";
 import { deriveNativeVectorResourcePlan } from "../src/ir/program/native-vector-resources.js";
 import { reserveNativeVectorTypes } from "../src/backend/wasmgc/resources/native-vectors.js";
 import {
+  reserveNativeClosureResources,
+  type NativeClosureRequirements,
+} from "../src/backend/wasmgc/resources/native-closures.js";
+import {
   reserveNativePromiseResources,
   fillNativePromiseResources,
   type NativePromiseFillDependencies,
@@ -74,7 +78,13 @@ let cached: ReturnType<typeof prepare> | undefined;
 const actual = () => (cached ??= prepare());
 
 /** Type-only kernel harness. No fabricated native value/classifier/function dependency. */
-function reserve() {
+function closureRequests(): NativeClosureRequirements["requests"] {
+  return [
+    { kind: "signature", id: "settle", params: [{ kind: "externref" }], results: [], allocationMode: "ordinary" },
+    { kind: "metadata", id: "settle-meta", signatureId: "settle", key: "promise:settle", name: "", length: 1 },
+  ];
+}
+function prerequisites(requests = closureRequests(), settleMetadataRequestId = "settle-meta") {
   const { plan, vectorPlan } = actual();
   const module = createEmptyModule(),
     tx = new PhysicalModuleReservations(module);
@@ -84,30 +94,62 @@ function reserve() {
     { kind: "defined", name: "__exn" },
   );
   const vectors = reserveNativeVectorTypes(tx, vectorPlan);
-  const fields = [
-    { name: "func", type: { kind: "funcref" } as const, mutable: false },
-    { name: "$arity", type: { kind: "i32" } as const, mutable: false },
-    { name: "$bag", type: { kind: "externref" } as const, mutable: true },
-  ];
-  const closureRoot = tx.reserveType("kernel:closure-root", {
-    kind: "struct",
-    name: "kernel-root",
-    superTypeIdx: -1,
-    fields,
-  });
-  const settleMetadata = tx.reserveType("kernel:metadata", {
-    kind: "struct",
-    name: "kernel-metadata",
-    superTypeIdx: closureRoot.typeIndex,
-    fields: [
-      ...fields,
-      { name: "bfnstate", type: { kind: "i32" }, mutable: true },
-      { name: "bfnid", type: { kind: "i32" }, mutable: false },
-    ],
-  });
-  const dependencies = { vectors, exceptionTag: tag, closureRoot, settleMetadata };
-  const pack = reserveNativePromiseResources(tx, plan, dependencies);
-  return { module, tx, pack, dependencies, plan };
+  const closureRequirements: NativeClosureRequirements = {
+    key: "kernel:closures",
+    startingClosureCounter: 0,
+    requests,
+    referenceTypes: [],
+  };
+  const closures = reserveNativeClosureResources(tx, closureRequirements);
+  const dependencies = { vectors, exceptionTag: tag, closures, settleMetadataRequestId };
+  return { module, tx, dependencies, plan, closureRequirements };
+}
+function reserve(requests = closureRequests(), settleMetadataRequestId = "settle-meta") {
+  const input = prerequisites(requests, settleMetadataRequestId);
+  const pack = reserveNativePromiseResources(input.tx, input.plan, input.dependencies);
+  return { ...input, pack };
+}
+
+/** Preserve undefined, sparse arrays, maps and numeric values as well as every object identity. */
+function unchangedModule(module: ReturnType<typeof createEmptyModule>) {
+  const snapshot = structuredClone(module);
+  const checks: (() => void)[] = [];
+  const seen = new Set<object>();
+  function retain(value: unknown) {
+    if (value === null || typeof value !== "object" || seen.has(value)) return;
+    seen.add(value);
+    for (const key of Reflect.ownKeys(value)) {
+      const member = Reflect.get(value, key);
+      checks.push(() => expect(Reflect.get(value, key)).toBe(member));
+      retain(member);
+    }
+    if (value instanceof Map) {
+      const entries = [...value];
+      checks.push(() => {
+        const current = [...value];
+        expect(current).toHaveLength(entries.length);
+        entries.forEach(([key, member], i) => {
+          expect(current[i]![0]).toBe(key);
+          expect(current[i]![1]).toBe(member);
+        });
+      });
+      entries.forEach(([key, member]) => {
+        retain(key);
+        retain(member);
+      });
+    }
+  }
+  retain(module);
+  return () => {
+    expect(module).toStrictEqual(snapshot);
+    checks.forEach((check) => check());
+  };
+}
+
+function futureReservationProbe(tx: PhysicalModuleReservations) {
+  const type = tx.reserveType("join:future-type", { kind: "struct", name: "join-future", fields: [] });
+  const fn = tx.reserveFunction("join:future-function", "join-future", { params: [], results: [] });
+  return { typeIndex: type.typeIndex, handle: fn.handle, functionTypeIndex: fn.object.typeIdx };
 }
 
 describe("native Promise resource requirements, not whole-family materialization", () => {
@@ -238,6 +280,128 @@ describe("native Promise resource requirements, not whole-family materialization
 });
 
 describe("reservation-only Promise pack controls; missing native dependencies remain a gap", () => {
+  it("joins genuine metadata while preserving an alternate first-signature root", () => {
+    const a = reserve();
+    expect(a.dependencies.closures.root).toBe(a.dependencies.closures.signatures[0]!.binding.type);
+    const b = reserve([
+      {
+        kind: "signature",
+        id: "numeric",
+        params: [{ kind: "f64" }],
+        results: [{ kind: "f64" }],
+        allocationMode: "ordinary",
+      },
+      ...closureRequests(),
+    ]);
+    const { closures } = b.dependencies;
+    const producer = closures.metadata[0]!.binding.type.object;
+    const capture = b.pack.types.settleCapture.object;
+    if (producer.kind !== "struct" || capture.kind !== "struct") throw new Error("expected genuine struct types");
+    expect(producer.fields).toHaveLength(5);
+    expect(capture.fields.slice(0, 5)).toStrictEqual(producer.fields);
+    producer.fields.forEach((field, index) => {
+      expect(capture.fields[index]).not.toBe(field);
+      expect(capture.fields[index]!.type).toBe(field.type);
+    });
+    expect(closures.root).toBe(closures.signatures[0]!.binding.type);
+    expect(closures.metadata[0]!.binding.signature.type).not.toBe(closures.root);
+    expect(b.pack.types.settleCapture.object).toMatchObject({
+      superTypeIdx: closures.metadata[0]!.binding.type.typeIndex,
+      fields: [
+        ...(closures.metadata[0]!.binding.type.object as { fields: unknown[] }).fields,
+        { name: "cap_promise", type: { kind: "ref", typeIdx: b.pack.types.promise.typeIndex }, mutable: false },
+      ],
+    });
+    expect(b.module.types[b.pack.functions.resolveClosure.object.typeIdx]).toMatchObject({
+      params: [{ kind: "ref", typeIdx: closures.root.typeIndex }, { kind: "externref" }],
+      results: [],
+    });
+  });
+  it("accepts repeated metadata requests selecting the same cached binding and copies the request ID", () => {
+    const a = reserve();
+    expect(a.dependencies.closures.metadata).toHaveLength(1);
+    const b = reserve(
+      [
+        ...closureRequests(),
+        { kind: "metadata", id: "again", signatureId: "settle", key: "promise:settle", name: "", length: 1 },
+      ],
+      "again",
+    );
+    const rows = b.dependencies.closures.metadata;
+    expect(rows[0]!.binding).toBe(rows[1]!.binding);
+    b.dependencies.settleMetadataRequestId = "not-the-retained-id";
+    b.tx.freezeReservations();
+    expect(() => fillNativePromiseResources(b.tx, b.pack, undefined!)).toThrow(
+      "complete native dependencies are missing",
+    );
+  });
+  it("accepts undefined and lowered lazy arity without equating metadata snapshots", () => {
+    const a = reserve();
+    expect(a.dependencies.closures.metadata[0]!.binding.info.minimumArgumentCount).toBeUndefined();
+    const requests = closureRequests().map((request) =>
+      request.kind === "signature" ? { ...request, minimumArgumentCount: 1 } : request,
+    );
+    const b = reserve([
+      ...requests,
+      {
+        kind: "signature",
+        id: "later",
+        params: [{ kind: "externref" }],
+        results: [],
+        allocationMode: "ordinary",
+        minimumArgumentCount: 0,
+      },
+    ]);
+    expect(b.dependencies.closures.signatures[0]!.binding.info.minimumArgumentCount).toBe(0);
+    expect(b.dependencies.closures.metadata[0]!.binding.info.minimumArgumentCount).toBe(1);
+  });
+  for (const mutation of ["copied", "foreign", "stale", "missing-request", "wrong-request"] as const)
+    it(`rejects ${mutation} closure selection before allocating any Promise resources`, () => {
+      const positive = reserve();
+      expect(Object.keys(positive.pack.functions)).toHaveLength(14);
+      const requests: NativeClosureRequirements["requests"] = [
+        ...closureRequests(),
+        { kind: "metadata", id: "other", signatureId: "settle", key: "other", name: "other", length: 1 },
+      ];
+      const input = prerequisites(requests);
+      const control = prerequisites(structuredClone(requests));
+      const { tx, module, dependencies, plan, closureRequirements } = input;
+      if (mutation === "copied") dependencies.closures = { ...dependencies.closures };
+      if (mutation === "foreign") dependencies.closures = prerequisites().dependencies.closures;
+      if (mutation === "stale") (closureRequirements as { startingClosureCounter: number }).startingClosureCounter++;
+      if (mutation === "missing-request") dependencies.settleMetadataRequestId = "absent";
+      if (mutation === "wrong-request") dependencies.settleMetadataRequestId = "other";
+      const assertUnchanged = unchangedModule(module);
+      const error =
+        mutation === "copied" || mutation === "foreign"
+          ? "foreign or copied closure pack"
+          : mutation === "stale"
+            ? "stale closure request sequence"
+            : mutation === "missing-request"
+              ? "missing or ambiguous settle metadata request"
+              : "invalid settle metadata";
+      expect(() => reserveNativePromiseResources(tx, plan, dependencies)).toThrow(error);
+      assertUnchanged();
+      expect(tx.state).toBe("reserving");
+      // A pristine twin exposes consumed allocator ordinals even if an implementation
+      // restored the visible arrays before rejecting the bad dependency.
+      expect(futureReservationProbe(tx)).toStrictEqual(futureReservationProbe(control.tx));
+      expect(module.funcOrdinalToPosition).toStrictEqual(control.module.funcOrdinalToPosition);
+    });
+  it("reauthenticates the retained producer before the genuine missing-dependency fill frontier", () => {
+    const input = reserve();
+    input.tx.freezeReservations();
+    expect(() => fillNativePromiseResources(input.tx, input.pack, undefined!)).toThrow(
+      "complete native dependencies are missing",
+    );
+    const assertUnchanged = unchangedModule(input.module);
+    (input.closureRequirements as { startingClosureCounter: number }).startingClosureCounter++;
+    expect(() => fillNativePromiseResources(input.tx, input.pack, undefined!)).toThrow(
+      "stale closure request sequence",
+    );
+    assertUnchanged();
+    expect(input.tx.state).toBe("filling");
+  });
   it("reuses the exact vector array and preserves queue order and lazy storage obligations", () => {
     const { module, pack, dependencies, tx } = reserve();
     expect(pack.types.arguments).toBe(dependencies.vectors.layouts.find((row) => row.element === "externref")!.array);

--- a/tests/issue-3518-semantic-provider-boundary.test.ts
+++ b/tests/issue-3518-semantic-provider-boundary.test.ts
@@ -465,8 +465,8 @@ describe("semantic verification and provider ownership boundary", () => {
     expect(r.report.errors).toEqual([]);
     for (const field of ["unknownEdges", "unresolvedEdges", "forbiddenEdges", "transitiveViolations"])
       expect(r.report[field]).toEqual([]);
-    expect(r.report.resolvedEdgeCount).toBe(325);
-    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 210, runtime: 115 });
+    expect(r.report.resolvedEdgeCount).toBe(326);
+    expect(r.report.counts.resolvedEdgesByType).toEqual({ typeOnly: 210, runtime: 116 });
   });
 
   it.each(["delete", "reorder", "layer", "entries", "minimum"] as const)(


### PR DESCRIPTION
## Summary

Stacked on #5778. Replace independent Promise closure-root/metadata handles
with an authenticated issued closure pack and explicit metadata request ID.
Authenticate before allocations and again before fills while preserving
cache aliases, lazy arity behavior and first-signature root selection.

Keep Promise-owned captures, fourteen functions, six globals and resolution
routing unchanged. Copy inherited metadata fields as in the original donor.
Record the implementation plan and handoff in the migration issue.

## Validation

- Astra High approved the bounded join and both R2 repairs.
- Final composed TypeScript check passed.
- 95/95 combined Promise and closure controls passed.
- 221/221 compiler boundary controls passed: unchanged90 modules,
  326 edges (210 type-only,116 runtime). No permissions relaxed.
- Negative controls preserve lossless snapshots, object identities and
  future reservation ordinals against pristine controls.

This does not complete Promise fill/execution, public IR-only cutover or
direct-codegen retirement. Full carrier inventory and ABI30's planningSealed
witness remain open. Related to #3518; do not close the migration issue.
