### PR TITLE
feat(ir): split authenticated native string type reservations

### DIFF
--- a/plan/agent-context/3518-native-string-types-split-2026-09-09.md
+++ b/plan/agent-context/3518-native-string-types-split-2026-09-09.md
@@ -1,0 +1,60 @@
+# Native string type reservation checkpoint
+
+Base: cf0026db2e926bf45c57204f6324fbae5fb168f7, scanner PR #5781.
+Branch: codex/3518-native-string-types-split-20260909.
+Verified upstream claim: 3518:native-string-types-split,
+ttraenkler/codex-native-string-types-split.
+
+## Implementation and purpose
+
+Prepared-program emission must reserve typed imports before defined literal
+globals and materializers. The split exposes an authenticated types-only pack
+while retaining the old combined resource API and canonical allocation order.
+One literal pack consumes a type pack, including empty requests. Dense input
+validation precedes type allocation; complete canonical literal planning
+precedes literal allocation. Failed supplied-pack preflight permits retry;
+allocation failure does not promise rollback or another consumption.
+
+Lookup, inventory, fill and completion authenticate the retained exact issued
+type pack. The seven-line PhysicalModuleReservations.assertTypeReservation
+addition is identical to sibling argument-vector commit
+e3beb06321582908aba303fbcdf236d4c7a468c2 (PR #5776). Its #require call invokes
+#verifyLayout; descriptor integrity is not delegated to a second authority.
+
+The frozen inventory exposes exact ordered request bindings, all globals and
+materializer functions, including private chunk globals and repeated chunk
+references. Tokens are not cloned. Inventory is not a completion receipt.
+
+## Validation and frozen revision
+
+Initial core: TS7 exit 0; 41/41 focused controls passed. High then required
+consume-once, full preflight, complete inventory and reauthentication controls.
+Revised implementation: TS7 session 27896 exit 0; focused session 52306 exit 0,
+54/54 tests across the split, existing string/Error resources and completion
+suites. Runs were sequential, 2 GiB, one fork, no file parallelism.
+
+Frozen SHA-256:
+
+- native-string-literals.ts: 0150e77fca27c9503aa17ecf09d6e1596526d17b7dc59391cfcbfd16c1f45c49
+- issue-3518-native-string-types-split.test.ts: 436f59d85c8a2a44f4d41f70780eff836a34697159a9a060d0a55dcc0387784a
+- module-reservations.ts: 462143fec6e6b9c62bb86b869a6c806cf48768c05461fbb37e9056579746bbae
+
+Final High and parent review found no blockers at these exact hashes. Existing
+caller regressions passed 188/188 (61 flatten, 120 scanner, 7 value-chain),
+session 51901 exit 0 in 55.79 seconds with one fork and a 2 GiB bound.
+No external-root CLI was run for this split. Do not interpret these denominators as
+coverage of actual prepared-consumer execution or public compilation cutover.
+
+The first commit hook rejected the test's delete operator. Replacing it with
+Reflect.deleteProperty preserves the actual array hole (now explicitly asserted).
+The affected file passed 20/20 again, session 17996 exit 0; production and ledger
+hashes remain unchanged. The test hash above is the corrected publication hash.
+
+## Next production integration
+
+Source admission and pure demand planning feed the same physical consumer,
+with one reservation/freeze/fill transaction and one authoritative ABI map.
+C and P explicitly released additive native integration in separate worktrees;
+their paused async drafts remain preserved and excluded. Native execution
+through the prepared consumer, public default cutover, complete native families,
+strict closure and direct retirement remain required, unproven work.

--- a/plan/agent-context/3518-native-string-value-full-contract-2026-09-09.md
+++ b/plan/agent-context/3518-native-string-value-full-contract-2026-09-09.md
@@ -1,0 +1,468 @@
+# Frozen source/demand/resource/consumer contract
+
+Grounding: scanner source `cf0026db2e926bf45c57204f6324fbae5fb168f7` and published contract `31e4e232eb16804afc1577055d33d1c6530c0e22`.
+
+## 1. Independent pure-demand writer
+
+Exclusive proposed files:
+
+- `src/ir/program/native-string-value-demands.ts`
+- `tests/issue-3518-native-string-value-demands.test.ts`
+
+No existing source edits, resource allocation, ABI mutation, provider selection, source/checker access or new acceptance authority.
+
+Use canonical types from `core/nodes`, `core/async-plan`, `runtime/contracts/prepared`, `analysis/contracts/allocations`, `shared/contracts/ir-identity`, and `program/prepared-contracts`. Do not import their historical facades.
+
+### Exact exports
+
+```ts
+export type NativeStringValuePresence<T> =
+  | { readonly present: false }
+  | { readonly present: true; readonly value: T };
+
+export type NativeStringValueView = "program" | "projection";
+
+export type NativeStringValueBufferRoot =
+  | {
+      readonly kind: "block";
+      readonly index: number;
+      readonly id: IrBlockId;
+    }
+  | {
+      readonly kind: "async-plan";
+      readonly index: number;
+      readonly id: IrAsyncStateId;
+    }
+  | {
+      readonly kind: "async-runtime";
+      readonly index: number;
+      readonly id: IrAsyncStateId;
+    };
+
+export interface NativeStringValueBuffer {
+  readonly ownerUnitId: IrUnitId;
+  readonly view: NativeStringValueView;
+  readonly root: NativeStringValueBufferRoot;
+
+  /** Nested-buffer coordinates, in canonical child-buffer order. */
+  readonly path: readonly {
+    readonly instructionIndex: number;
+    readonly childBufferIndex: number;
+  }[];
+
+  readonly instructions: readonly IrInstr[];
+}
+
+export interface NativeStringValueOccurrence {
+  /** Index into NativeStringValueDemands.buffers. */
+  readonly bufferIndex: number;
+  readonly instructionIndex: number;
+  readonly instruction: IrInstr;
+}
+
+export interface NativeStringValueAllocationEvidence {
+  readonly allocation:
+    NativeStringValuePresence<AllocSiteId | undefined>;
+
+  /** Null only when no allocation identity was supplied. */
+  readonly canonicalAllocation: AllocSiteId | null;
+
+  readonly metadataRow:
+    NativeStringValuePresence<AllocRegistryMetadataSnapshot>;
+
+  /** Existing unknown metadata payload, not an erased encoding schema. */
+  readonly encoding: NativeStringValuePresence<unknown>;
+}
+
+export type NativeStringValueLiteralDemand =
+  | {
+      readonly kind: "string.const";
+      readonly occurrence: number;
+      readonly instruction: IrInstrStringConst;
+      readonly allocation: NativeStringValueAllocationEvidence;
+    }
+  | {
+      readonly kind: "extern.regex";
+      readonly occurrence: number;
+      readonly part: "pattern" | "flags";
+      readonly value: string;
+    };
+
+export interface NativeStringValueIntrinsicDemand {
+  readonly occurrence: number;
+  readonly instruction: IrInstrIntrinsic;
+}
+
+export interface NativeStringValueDemands {
+  /** Borrowed exact prepared objects; these are not acceptance tokens. */
+  readonly program: PreparedIrProgram;
+  readonly projection: PreparedIrProgramRuntimeProjection;
+
+  readonly owners: readonly {
+    readonly unitId: IrUnitId;
+    readonly programFunction: PreparedIrFunction;
+    readonly projectedFunction: PreparedIrFunction;
+  }[];
+
+  /** Preserve the complete snapshot, including unused namespaces/rows. */
+  readonly allocations: AllocRegistrySnapshot;
+
+  readonly buffers: readonly NativeStringValueBuffer[];
+  readonly occurrences: readonly NativeStringValueOccurrence[];
+  readonly literals: readonly NativeStringValueLiteralDemand[];
+  readonly intrinsics: readonly NativeStringValueIntrinsicDemand[];
+}
+
+export function collectNativeStringValueDemands(
+  program: PreparedIrProgram,
+  projection: PreparedIrProgramRuntimeProjection,
+): NativeStringValueDemands;
+```
+
+### Collection rules
+
+- Require the selected projection to belong to this program and consistently identify standalone WasmGC.
+- Require complete, unique, identically ordered owner IDs in `program.ir.functions` and `projection.prepared.functions`. Include derived owners; do not substitute exports, declarations or source-terminal subsets.
+- For each owner, visit the **program view then projection view**. Within each view: blocks, semantic async states, prepared async-runtime states, each in existing array order.
+- Retain empty buffers. Traverse nested buffers through canonical `forEachNestedBuffer`, preserving its order. Number occurrences by preorder.
+- Do not deduplicate shared instruction, buffer, function or state objects across occurrences/views.
+- Collect **every instruction** into `occurrences`, every intrinsic into `intrinsics`, and string literals into `literals`. This is not a supported-instruction whitelist.
+- Preserve complete function objects so signatures, slots, spills, resume types, declarations and attachment schemas remain available to subsequent planning.
+- Record regex pattern/flags because the lowerer emits them through `emitStringConst`. Their collection **does not admit regex materialization**.
+
+For allocation evidence, reuse canonical registry restoration/resolution without mutating the input. Obtain the canonical live allocation ID, then retain the corresponding **original snapshot row** and raw encoding payload. Unknown/retired/broken allocation references on a live literal are invariant failures, not “no encoding.”
+
+Distinguish:
+
+- absent `alloc` from present `alloc: undefined`;
+- absent metadata row from an empty row;
+- absent encoding namespace from a written `undefined`;
+- aliased identity from its canonical identity.
+
+Do not validate or discard unknown encoding payloads prematurely: the later representation planner decides whether that namespace is consumed. Preserve all other unknown metadata unchanged.
+
+Freeze newly created containers only; do not clone or re-freeze borrowed prepared objects. Full program/attachment authentication remains mandatory in the coordinator’s checked acceptance path. This collector’s local checks are not a substitute.
+
+### Required tests
+
+Use genuine source-produced preparation and decoded replay for positive population tests. Add focused data controls for:
+
+- complete owner order, missing/duplicate owner and foreign projection;
+- nested sibling ordering, shared-object occurrences and empty buffers;
+- both async-plan and runtime-state coverage;
+- alias-resolved encoding and all presence distinctions;
+- unknown metadata retention without JSON normalization;
+- original `site`, allocation, storage and materializer identities;
+- regex pattern/flags recorded but not certified supported;
+- no mutation of the input graph.
+
+The producer may be independently tested now. Its production caller is the forthcoming `planPhysicalSetup` integration; tests alone do not establish that integration.
+
+## 2. Source-admission writer
+
+The requested from-ast-only start was sound. With the subsequently relayed P release, Maxwell may additionally wire the two permitted source/preparation files—without importing P’s async-ABI changes.
+
+### Frozen lowering property
+
+```ts
+// AstToIrOptions
+readonly stringNumericCoercion?: "number-boundary";
+
+// LowerCtx
+readonly stringNumericCoercion?:
+  AstToIrOptions["stringNumericCoercion"];
+```
+
+Forward it in exactly these explicit context constructions:
+
+- ordinary `lowerFunctionAstToIr`: `options.stringNumericCoercion`;
+- `liftNestedFunction`: `cx.stringNumericCoercion`;
+- `liftClosureBody`: `cx.stringNumericCoercion`.
+
+Contexts created with `...cx` inherit it.
+
+In `emitUnaryToNumber`, change only the statically string-typed arm when selected:
+
+```ts
+return cx.builder.emitIntrinsic("js.number.unbox", [
+  coerceIrValueToExternref(cx.builder, rand),
+]);
+```
+
+Keep the existing box-plus-`dyn.to_number` arm when omitted. Preserve boolean, numeric, object/ToPrimitive and unsupported branches. Operand evaluation happens once before conversion; unary minus retains its existing subsequent negation.
+
+### Whole-source selection
+
+```ts
+// IrProgramSourceInput
+readonly nativeStringValueProjection?: "standalone-native";
+```
+
+The whole-source wrapper validates the explicit selection against `input.policy` and the actual resolved runtime-policy list. All requested projections must be standalone WasmGC. Do not infer this option from target, fast mode or provider availability.
+
+`program-source` forwards `"number-boundary"` only for that explicit selection. The option is frontend configuration, not a new serialized IR field or provider authorization.
+
+Writer scope:
+
+- `src/ir/from-ast.ts`
+- `src/ir/program-source.ts`
+- `src/ir/program-preparation.ts`
+- `tests/issue-3518-native-string-number-source-admission.test.ts`
+
+Tests must inspect ordinary, nested-function and lifted-closure artifacts; selected string conversion uses the intrinsic without boxing/dynamic conversion, while omission retains the historical route. Include once-only operand effects, negative operands/types, unary minus, and no rewriting of a shadowed `Number` call. Lifted-artifact tests do not imply closure physical execution.
+
+## 3. Representation/resource interface
+
+This lane follows Euclid’s split and consumes the demand API above.
+
+Proposed files:
+
+- `src/runtime/wasmgc/values/string-literal-bodies.ts`
+- `src/backend/wasmgc/program/native-string-values.ts`
+- `tests/issue-3518-native-string-value-planning.test.ts`
+- `tests/issue-3518-native-string-value-materialization.test.ts`
+
+### Representation selection
+
+Extract layout-independent selection from the existing literal planner—not a second implementation:
+
+```ts
+export type NativeStringLiteralSelection =
+  | {
+      readonly kind: "global";
+      readonly key: string;
+      readonly encoding: "utf8" | "wtf16";
+    }
+  | {
+      readonly kind: "callable";
+      readonly key: string;
+      readonly chunks: readonly string[];
+    };
+
+export function selectNativeStringLiteral(
+  utf8Storage: boolean,
+  utf8Available: boolean,
+  value: string,
+  encoding?: StringEncoding,
+): NativeStringLiteralSelection;
+```
+
+`planNativeStringLiteral` consumes this selection and constructs its existing actual initializer/layout references. Preserve its canonical keys and thresholds:
+
+- UTF-8 bytes versus UTF-16 code units are different limits.
+- `é.repeat(5001)` can be a UTF-16 global, not a materializer.
+- Preserve lone-surrogate behavior.
+- Preserve explicitly UTF-16 empty storage separately from ASCII empty storage.
+- Oversized chunk selection remains explicitly UTF-16.
+
+The new planner validates consumed encoding metadata against canonical `IrStringEncoding`; it must not silently reinterpret invalid consumed evidence. Existing storage/materializer references must agree with selection or produce a located contradiction—never be overwritten.
+
+### Materialization exports
+
+```ts
+export interface NativeStringValueOptions {
+  readonly representation: "native-string";
+  readonly utf8Storage: boolean;
+}
+
+export interface NativeStringValuePhysicalPlan {
+  readonly key: string;
+  readonly mode: "literals" | "number-boundary";
+  readonly literalRequirements: NativeStringLiteralRequirements;
+
+  /** Only executable projection demands receive physical bindings. */
+  readonly literalUses: readonly {
+    readonly demandIndex: number;
+    readonly cacheKey: string;
+  }[];
+}
+
+export type NativeStringValuePlanningOutcome =
+  | { readonly kind: "none" }
+  | {
+      readonly kind: "planned";
+      readonly plan: NativeStringValuePhysicalPlan;
+    }
+  | PreparedIrProgramFailure;
+
+export function planNativeStringValuePhysical(
+  demands: NativeStringValueDemands,
+  options: NativeStringValueOptions,
+): NativeStringValuePlanningOutcome;
+
+export interface NativeStringValueReservationInput {
+  readonly demands: NativeStringValueDemands;
+  readonly plan: NativeStringValuePhysicalPlan;
+  /** Required exactly for number-boundary mode. Never cloned. */
+  readonly valueRequirements?: NativeValueResourcePlan;
+}
+
+export type NativeStringValueResourceRow =
+  | {
+      readonly key: string;
+      readonly space: "type";
+      readonly reservation: TypeReservation;
+    }
+  | {
+      readonly key: string;
+      readonly space: "global";
+      readonly reservation: GlobalReservation;
+    }
+  | {
+      readonly key: string;
+      readonly space: "function";
+      readonly reservation: FunctionReservation;
+    };
+
+export interface NativeStringValueReservations {
+  readonly strings: NativeStringLiteralReservations;
+  readonly number?: {
+    readonly flatten: NativeStringFlattenReservations;
+    readonly scanner: NativeStringNumberReservations;
+    readonly values: NativeValueReservations;
+  };
+}
+
+export function reserveNativeStringValueResources(
+  tx: PhysicalModuleReservations,
+  input: NativeStringValueReservationInput,
+  types: NativeStringLiteralTypeReservations,
+): NativeStringValueReservations;
+
+export function fillNativeStringValueResources(
+  tx: PhysicalModuleReservations,
+  pack: NativeStringValueReservations,
+): void;
+
+export function requireCompletedNativeStringValues(
+  tx: PhysicalModuleReservations,
+  pack: NativeStringValueReservations,
+): NativeStringValueReservations;
+
+export function nativeStringValueReservationInventory(
+  tx: PhysicalModuleReservations,
+  pack: NativeStringValueReservations,
+): readonly NativeStringValueResourceRow[];
+
+export function emitPreparedNativeStringLiteral(
+  tx: PhysicalModuleReservations,
+  pack: NativeStringValueReservations,
+  ownerUnitId: IrUnitId,
+  value: string,
+  alloc?: AllocSiteId,
+  storage?: IrGlobalRef,
+  materializer?: IrFuncRef,
+): readonly Instr[];
+```
+
+Private resource provenance captures the exact input/issued packs. It supplements—not replaces—the existing ledger. Recompute/check the descriptive selection before reservation; never accept a mismatching demand/plan pair.
+
+`literals` mode needs only strings. `number-boundary` mode requires the genuine flatten→scanner→values chain and adds flatten’s explicit UTF-16 empty demand. No-demand programs take the existing path unchanged.
+
+The inventory uses Euclid’s complete internal literal census plus actual flatten/scanner/value tokens. Do not derive ownership from names, requested literals or counts. Interned signature types remain ledger-owned; do not reserve duplicates merely to manufacture ABI rows.
+
+The literal emitter matches the closed owner/value/allocation/reference tuple against planned projection demands. Ambiguous tuples requiring different physical bindings fail during planning. Preserve occurrence evidence even when identical uses share storage. Regex, `.length` and other string operations remain unsupported unless their own complete provider/resource joins are implemented.
+
+## 4. Issued-plan and ABI joins
+
+### One necessary coordinator-owned authority extension
+
+In existing `src/ir/program/native-value-resources.ts`:
+
+```ts
+export function assertNativeValueResourcePlanFor(
+  plan: NativeValueResourcePlan,
+  program: PreparedIrProgram,
+  projection: PreparedIrProgramRuntimeProjection,
+  strings: NativeValueStringRepresentation,
+): void;
+```
+
+Use the **existing** private `sources` map: require exact program/projection/representation association, then existing currentness validation. No second registry.
+
+This prevents substituting another valid issued plan merely because its anchor and visible fields match. Scanner reservation and completion continue receiving the exact same issued plan and string pack.
+
+### Supplemental ABI identity
+
+Coordinator-owned `program-physical-plan.ts` constructs binding records using existing reference/identity factories:
+
+```ts
+export interface NativeStringValueAbiBinding {
+  readonly resourceKey: string;
+  readonly entry: ProgramAbiPlanEntry;
+  readonly reference: IrFuncRef | IrGlobalRef | IrTypeRef;
+}
+```
+
+Rules:
+
+- Anchor to the canonical entry-source identity, never a display name or parsed encoded ID.
+- Internal support roles use a versioned structural tuple, for example  
+  `native-string-values:v1:` + `JSON.stringify(["literal-global", cacheKey])`.
+- Use existing support-global, support-callable and source-type reference factories. Do not import their mixed facade into the clean backend module; the coordinator owns this binding construction.
+- Reuse an existing compatible semantic binding and its alias structure. Reject contradictory required bindings rather than manufacturing aliases or assigning two incompatible owners.
+- For actual native `js.number.unbox`, use the provider’s canonical runtime reference and existing `preparedIrRuntimeCallableBindingId` derivation. Authenticate its selected provider, exact signature and actual intrinsic demand.
+- Presence of `__box_number` does **not** authorize `js.number.box`. Native unbox and `generator.number-box` remain distinct contracts.
+- Internal pack helpers receive support ownership, not fabricated source callers.
+- Preserve every existing ABI entry and order. Append supplemental entries using explicit entry-source declaration ordinals after existing entries; never derive IDs/orders from eventual indices.
+- Plan and bind everything through the **same `ProgramAbiMap`**. Bind actual ledger indices after freeze, not stable function handles.
+
+Internal physical reference signatures may use resource keys until reservation. They are acceptance-side planning data, not a new serialized prepared-program schema or replacement for P’s preserved ABI work.
+
+## 5. Consumer integration and lifecycle
+
+The native-only C release covers this work in a separate integration tree:
+
+- `src/ir/program-physical-plan.ts`
+- `src/ir/program-consumer.ts`
+- the issued-plan guard above;
+- `tests/issue-3518-native-string-value-consumer.test.ts`
+- `tests/helpers/native-string-value-consumer-replay.mjs`
+- parent-owned boundary activation/controls.
+
+Keep the existing acceptance authority. Its private record retains:
+
+- copied descriptive physical setup;
+- exact demands/program/projection;
+- the **uncloned issued** native-value plan when needed.
+
+Do not put that issued object through `freezePreparedIrValue`.
+
+Reservation order in the existing single transaction:
+
+1. Existing exception/vector prerequisites, then native string types.
+2. Existing imports, using the reserved string type where a logical string signature requires it.
+3. Literal resources.
+4. Flatten, scanner, values when required.
+5. Remaining program globals/functions, vector helper and startup.
+6. One freeze; final ABI binding.
+7. Canonical fills in dependency order, then program lowering and existing publication/seal.
+
+Preserve the old no-demand path exactly.
+
+Extend signature conversion for logical string carriers. Add real `resolveString` and the closed-plan literal emitter to each owner’s resolver. Resolve provider calls through the actual owned function map. Extend exact emitted-function ownership to every authenticated internal materializer/helper object.
+
+Do not add `CodegenContext`, frontend callbacks, partial dynamic-lowering objects or blanket callable exemptions. Acceptance must still reject unsupported instructions/resources before emission. Existing single-use and observer-failure ordering remain unchanged.
+
+## 6. Connected acceptance—not another resource-only checkpoint
+
+Required executable source:
+
+```ts
+function parse(s: string): number {
+  return +s;
+}
+export function run(): number {
+  return parse(" 42 ");
+}
+```
+
+Prove preparation→acceptance→`program-consumer` execution reaches the owned unbox/scanner chain. A manually assembled resource module is insufficient.
+
+Matrix: original/decoded preparation, GVN off/on, both UTF modes, repeated fresh instances and execution, source aliases/startup ordering, oversized literals, separate empty encodings and malformed exponent semantics. Reuse the existing module-completion replay pattern.
+
+Add positive-first failures for foreign/copied/wrong-source issued plans, mismatched string/scanner packs, contradictory existing references, altered encoding evidence, missing canonical provider, missing fill, missing internal chunks, extra function ownership and post-acceptance changes. Preserve source-free loader guards and all existing historical/evidence denominators.
+
+Existing synchronous no-demand bytes/WAT/order remain exact. New supported cases retain their old refusal as baseline evidence; do not call that historical byte parity.
+
+Public compiler default routing, complete async-family materialization, broader string/dynamic operations, strict closure/direct retirement and ABI30’s unresolved getter witness remain open. The scoped P/C releases do not authorize changing those contracts.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6536,3 +6536,14 @@ compiler still calls direct generateModule/generateMultiModule, and the
 prepared-program emitter has not yet wired these string/value producers.
 See agent-context/3518-native-string-consumer-census-2026-09-09.md for the
 next required production integration boundary and ownership coordination.
+
+### Native string type reservation for real consumer integration
+
+The independent type-split draft now preserves a types-first import window,
+authenticates single-use literal ownership and exposes a complete private-chunk
+inventory. Revised TS7 and 54/54 focused tests pass; final review has no blockers
+and 188/188 existing flatten/scanner/value caller regressions pass. Exact provenance and
+limitations are recorded in
+agent-context/3518-native-string-types-split-2026-09-09.md. This is a prerequisite
+for actual prepared-consumer wiring, not evidence that the public direct path
+has been replaced. Paused P/C async drafts remain untouched.

--- a/src/backend/wasmgc/resources/native-string-literals.ts
+++ b/src/backend/wasmgc/resources/native-string-literals.ts
@@ -48,13 +48,45 @@ export interface NativeStringLiteralReservations {
   /** One binding per ordered demand, including repeated demands. */
   readonly literals: readonly NativeStringLiteralBinding[];
 }
+export interface NativeStringLiteralTypeReservations {
+  readonly key: string;
+  readonly utf8Storage: boolean;
+  readonly layout: NativeStringLayout;
+  readonly types: readonly TypeReservation[];
+}
+export interface NativeStringLiteralReservationInventory {
+  readonly typePack: NativeStringLiteralTypeReservations;
+  readonly requests: readonly { readonly cacheKey: string; readonly binding: NativeStringLiteralBinding }[];
+  readonly globals: readonly { readonly cacheKey: string; readonly global: GlobalReservation }[];
+  readonly functions: readonly {
+    readonly cacheKey: string;
+    readonly function: FunctionReservation;
+    readonly chunkGlobals: readonly GlobalReservation[];
+  }[];
+}
+const typeOwners = new WeakMap<
+  NativeStringLiteralTypeReservations,
+  { tx: PhysicalModuleReservations; consumed: boolean }
+>();
+function authenticateTypes(tx: PhysicalModuleReservations, pack: NativeStringLiteralTypeReservations) {
+  const owner = typeOwners.get(pack);
+  if (!owner || owner.tx !== tx) throw new Error("native strings: foreign or forged type owner");
+  for (const token of pack.types) {
+    if (tx.state === "reserving") tx.assertTypeReservation(token);
+    else tx.physicalIndex(token);
+  }
+  return owner;
+}
 interface LiteralOwner {
   readonly tx: PhysicalModuleReservations;
+  readonly typePack: NativeStringLiteralTypeReservations;
+  readonly inventory: NativeStringLiteralReservationInventory;
   readonly utf8Storage: boolean;
   readonly bindings: ReadonlyMap<string, NativeStringLiteralBinding>;
-  readonly globals: readonly { readonly token: GlobalReservation; readonly init: Instr[] }[];
+  readonly globals: readonly { readonly cacheKey: string; readonly token: GlobalReservation; readonly init: Instr[] }[];
   readonly functions: readonly {
     readonly token: FunctionReservation;
+    readonly cacheKey: string;
     readonly chunks: readonly string[];
     readonly globals: readonly GlobalReservation[];
   }[];
@@ -62,13 +94,15 @@ interface LiteralOwner {
 }
 const owners = new WeakMap<NativeStringLiteralReservations, LiteralOwner>();
 
-/** Canonical type family and actual literal demands, reserved without publishing indices. */
-export function reserveNativeStringLiteralResources(
+/** Reserve only the canonical type family, leaving the import window open. */
+export function reserveNativeStringLiteralTypes(
   tx: PhysicalModuleReservations,
-  requirements: NativeStringLiteralRequirements,
-): NativeStringLiteralReservations {
-  if (!requirements.key || tx.state !== "reserving") throw new Error("native strings: invalid reservation phase/key");
-  const key = (role: string) => `${requirements.key}:${role}`;
+  resourceKey: string,
+  utf8Storage: boolean,
+): NativeStringLiteralTypeReservations {
+  if (typeof resourceKey !== "string" || !resourceKey || typeof utf8Storage !== "boolean" || tx.state !== "reserving")
+    throw new Error("native strings: invalid reservation phase/key/config");
+  const key = (role: string) => `${resourceKey}:${role}`;
   const types: TypeReservation[] = [];
   const reserve = (role: string, descriptor: Parameters<PhysicalModuleReservations["reserveType"]>[1]) => {
     const token = tx.reserveType(key(role), descriptor);
@@ -89,17 +123,72 @@ export function reserveNativeStringLiteralResources(
   layout.nativeStrTypeIdx = reserve("flat", createNativeStringType(layout));
   layout.consStrTypeIdx = reserve("cons", createConsStringType(layout));
   layout.hashedStrTypeIdx = reserve("hashed", createHashedStringType(layout));
-  if (requirements.utf8Storage) {
+  if (utf8Storage) {
     layout.utf8StrDataTypeIdx = reserve("utf8-data", createUtf8StringDataType());
     layout.utf8StrTypeIdx = reserve("utf8", createUtf8StringType(layout));
   }
   Object.freeze(layout);
-  const globals: { token: GlobalReservation; init: Instr[] }[] = [];
-  const functions: { token: FunctionReservation; chunks: readonly string[]; globals: readonly GlobalReservation[] }[] =
-    [];
+  const pack = Object.freeze({ key: resourceKey, utf8Storage, layout, types: Object.freeze(types) });
+  typeOwners.set(pack, { tx, consumed: false });
+  return pack;
+}
+
+/** Combined compatibility API, or literal demands using this producer's exact type pack. */
+export function reserveNativeStringLiteralResources(
+  tx: PhysicalModuleReservations,
+  requirements: NativeStringLiteralRequirements,
+  suppliedTypes?: NativeStringLiteralTypeReservations,
+): NativeStringLiteralReservations {
+  if (
+    !requirements ||
+    typeof requirements.key !== "string" ||
+    !requirements.key ||
+    typeof requirements.utf8Storage !== "boolean" ||
+    tx.state !== "reserving" ||
+    !Array.isArray(requirements.literals)
+  )
+    throw new Error("native strings: invalid reservation phase/key/config/demands");
+  // Copy dense, validated demands before any type allocation. Encoding evidence is
+  // checked by the canonical planner below, after authenticating the type pack.
+  const demands: { value: string; encoding?: StringEncoding }[] = [];
+  for (let i = 0; i < requirements.literals.length; i++) {
+    const row = requirements.literals[i];
+    if (
+      !Object.hasOwn(requirements.literals, i) ||
+      !row ||
+      typeof row.value !== "string" ||
+      (row.encoding !== undefined &&
+        row.encoding !== "ascii" &&
+        row.encoding !== "utf8-guaranteed" &&
+        row.encoding !== "wtf16")
+    )
+      throw new Error("native strings: invalid literal demand");
+    demands.push({ value: row.value, encoding: row.encoding });
+  }
+  const typePack = suppliedTypes ?? reserveNativeStringLiteralTypes(tx, requirements.key, requirements.utf8Storage);
+  const typeOwner = authenticateTypes(tx, typePack);
+  if (typePack.key !== requirements.key || typePack.utf8Storage !== requirements.utf8Storage)
+    throw new Error("native strings: type key/config mismatch");
+  if (typeOwner.consumed) throw new Error("native strings: type pack already consumed");
+  const { layout, types } = typePack;
+  const plans = demands.map(({ value, encoding }) =>
+    planNativeStringLiteral(layout, typePack.utf8Storage, value, encoding),
+  );
+  const key = (role: string) => `${requirements.key}:${role}`;
+  const globals: { cacheKey: string; token: GlobalReservation; init: Instr[] }[] = [];
+  const functions: {
+    cacheKey: string;
+    token: FunctionReservation;
+    chunks: readonly string[];
+    globals: readonly GlobalReservation[];
+  }[] = [];
   const cache = new Map<string, NativeStringLiteralBinding>();
-  const literal = (value: string, encoding?: StringEncoding): NativeStringLiteralBinding => {
-    const plan = planNativeStringLiteral(layout, requirements.utf8Storage, value, encoding);
+  const literal = (
+    value: string,
+    encoding?: StringEncoding,
+    planned?: ReturnType<typeof planNativeStringLiteral>,
+  ): NativeStringLiteralBinding => {
+    const plan = planned ?? planNativeStringLiteral(layout, typePack.utf8Storage, value, encoding);
     const existing = cache.get(plan.key);
     if (existing) return existing;
     let binding: NativeStringLiteralBinding;
@@ -110,7 +199,7 @@ export function reserveNativeStringLiteralResources(
         { kind: "ref", typeIdx: plan.refTypeIdx },
         false,
       );
-      globals.push({ token, init: plan.init });
+      globals.push({ cacheKey: plan.key, token, init: plan.init });
       binding = Object.freeze({ kind: "global", text: value, global: token, representation: "gc" });
     } else {
       const leaves = plan.chunks.map((chunk) => {
@@ -122,16 +211,52 @@ export function reserveNativeStringLiteralResources(
         params: [],
         results: [{ kind: "ref", typeIdx: layout.anyStrTypeIdx }],
       });
-      functions.push({ token, chunks: plan.chunks, globals: leaves });
+      functions.push({ cacheKey: plan.key, token, chunks: plan.chunks, globals: leaves });
       binding = Object.freeze({ kind: "callable", text: value, function: token, representation: "gc" });
     }
     cache.set(plan.key, binding);
     return binding;
   };
-  const literals = requirements.literals.map(({ value, encoding }) => literal(value, encoding));
+  // Allocation failures consume this pack; there is no rollback contract.
+  typeOwner.consumed = true;
+  const literals = demands.map(({ value, encoding }, i) => literal(value, encoding, plans[i]));
   const pack = Object.freeze({ layout, types: Object.freeze(types), literals: Object.freeze(literals) });
-  owners.set(pack, { tx, utf8Storage: requirements.utf8Storage, bindings: cache, globals, functions, filled: false });
+  const inventory = Object.freeze({
+    typePack,
+    requests: Object.freeze(literals.map((binding, i) => Object.freeze({ cacheKey: plans[i]!.key, binding }))),
+    globals: Object.freeze(globals.map((row) => Object.freeze({ cacheKey: row.cacheKey, global: row.token }))),
+    functions: Object.freeze(
+      functions.map((row) =>
+        Object.freeze({ cacheKey: row.cacheKey, function: row.token, chunkGlobals: Object.freeze([...row.globals]) }),
+      ),
+    ),
+  });
+  owners.set(pack, {
+    tx,
+    typePack,
+    inventory,
+    utf8Storage: typePack.utf8Storage,
+    bindings: cache,
+    globals,
+    functions,
+    filled: false,
+  });
   return pack;
+}
+
+function authenticateLiteralOwner(tx: PhysicalModuleReservations, pack: NativeStringLiteralReservations) {
+  const owner = owners.get(pack);
+  if (!owner || owner.tx !== tx) throw new Error("native strings: foreign or forged resource owner");
+  authenticateTypes(tx, owner.typePack);
+  return owner;
+}
+
+/** Reservation census includes private chunks; it does not attest completion. */
+export function nativeStringLiteralReservationInventory(
+  tx: PhysicalModuleReservations,
+  pack: NativeStringLiteralReservations,
+): NativeStringLiteralReservationInventory {
+  return authenticateLiteralOwner(tx, pack).inventory;
 }
 
 /** Authenticate the actual owner and ledger descriptors before exposing a literal dependency. */
@@ -141,11 +266,7 @@ export function requireNativeStringLiteral(
   text: string,
   encoding?: StringEncoding,
 ): NativeStringLiteralBinding {
-  const owner = owners.get(pack);
-  if (!owner || owner.tx !== tx) throw new Error("native strings: foreign or forged resource owner");
-  if (tx.state !== "reserving") {
-    for (const token of pack.types) tx.physicalIndex(token);
-  }
+  const owner = authenticateLiteralOwner(tx, pack);
   const selected =
     encoding === undefined
       ? undefined
@@ -160,8 +281,7 @@ export function requireCompletedNativeStringLiterals(
   tx: PhysicalModuleReservations,
   pack: NativeStringLiteralReservations,
 ): NativeStringLiteralReservations {
-  const owner = owners.get(pack);
-  if (!owner || owner.tx !== tx) throw new Error("native strings: foreign or forged resource owner");
+  const owner = authenticateLiteralOwner(tx, pack);
   if (!owner.filled) throw new Error("native strings: incomplete literal resources");
   for (const token of pack.types) tx.physicalIndex(token);
   for (const row of owner.globals) tx.physicalIndex(row.token);
@@ -173,8 +293,7 @@ export function fillNativeStringLiteralResources(
   tx: PhysicalModuleReservations,
   pack: NativeStringLiteralReservations,
 ): void {
-  const owner = owners.get(pack);
-  if (!owner || owner.tx !== tx) throw new Error("native strings: foreign or forged resource owner");
+  const owner = authenticateLiteralOwner(tx, pack);
   if (owner.filled) throw new Error("native strings: duplicate fill");
   for (const token of pack.types) tx.physicalIndex(token);
   for (const row of owner.globals) tx.fillGlobal(row.token, row.init);

--- a/src/wasm/physical/module-reservations.ts
+++ b/src/wasm/physical/module-reservations.ts
@@ -422,6 +422,13 @@ export class PhysicalModuleReservations {
     return this.#register({ kind: "type", key, object: definition, typeIndex }, typeIndex);
   }
 
+  /** Authenticate a prerequisite before allocating dependents; exposes no final index. */
+  assertTypeReservation(token: TypeReservation): void {
+    this.#require("reserving");
+    this.#owned(token);
+    if (token.kind !== "type") this.#fail("expected type reservation token");
+  }
+
   /** Reserve the emitter-affecting descriptor before freeze, including future members. */
   reserveCanonicalRuntimeRecGroup(
     key: PhysicalResourceKey,

--- a/tests/issue-3518-native-string-types-split.test.ts
+++ b/tests/issue-3518-native-string-types-split.test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it, vi } from "vitest";
+import { createEmptyModule } from "../src/ir/types.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import {
+  reserveNativeStringLiteralTypes,
+  reserveNativeStringLiteralResources,
+  fillNativeStringLiteralResources,
+  requireCompletedNativeStringLiterals,
+  requireNativeStringLiteral,
+  nativeStringLiteralReservationInventory,
+  type NativeStringLiteralRequirements,
+} from "../src/backend/wasmgc/resources/native-string-literals.js";
+
+function fixture() {
+  const module = createEmptyModule();
+  return { module, tx: new PhysicalModuleReservations(module) };
+}
+function demands(utf8Storage: boolean) {
+  return {
+    key: "strings",
+    utf8Storage,
+    literals: [
+      { value: "then" },
+      { value: "then" },
+      { value: "", encoding: "utf8-guaranteed" as const },
+      { value: "", encoding: "wtf16" as const },
+      { value: "x".repeat(9999) + "😀end" },
+    ],
+  };
+}
+function probe(tx: PhysicalModuleReservations) {
+  const type = tx.reserveType("probe:type", { kind: "struct", name: "probe", fields: [] });
+  const fn = tx.reserveFunction("probe:fn", "probe", { params: [], results: [] });
+  return { index: type.typeIndex, handle: fn.handle, signature: fn.object.typeIdx };
+}
+
+describe("native string types-only core split", () => {
+  for (const empty of [false, true])
+    it(`consumes the type pack exactly once, empty=${empty}`, () => {
+      const { tx, module } = fixture();
+      const types = reserveNativeStringLiteralTypes(tx, "strings", false);
+      const req = { ...demands(false), literals: empty ? [] : [{ value: "then" }] };
+      const pack = reserveNativeStringLiteralResources(tx, req, types);
+      expect(nativeStringLiteralReservationInventory(tx, pack).typePack).toBe(types);
+      const before = structuredClone(module);
+      expect(() => reserveNativeStringLiteralResources(tx, req, types)).toThrow("already consumed");
+      expect(module).toStrictEqual(before);
+    });
+
+  for (const bad of ["value", "encoding", "hole", "surrogate"] as const)
+    it(`preflights every late ${bad} demand and permits supplied-pack retry`, () => {
+      const { tx, module } = fixture();
+      const types = reserveNativeStringLiteralTypes(tx, "strings", true);
+      const rows: unknown[] = [{ value: "valid" }, { value: "later" }];
+      if (bad === "value") rows[1] = { value: 7 };
+      if (bad === "encoding") rows[1] = { value: "later", encoding: "unknown" };
+      if (bad === "hole") {
+        Reflect.deleteProperty(rows, 1);
+        expect(Object.hasOwn(rows, 1)).toBe(false);
+      }
+      if (bad === "surrogate") rows[1] = { value: "\ud800", encoding: "utf8-guaranteed" };
+      const req = { key: "strings", utf8Storage: true, literals: rows } as NativeStringLiteralRequirements;
+      const before = structuredClone(module);
+      expect(() => reserveNativeStringLiteralResources(tx, req, types)).toThrow(
+        bad === "surrogate" ? /surrogate/ : /invalid literal/,
+      );
+      expect(module).toStrictEqual(before);
+      const pack = reserveNativeStringLiteralResources(tx, { ...req, literals: [{ value: "valid" }] }, types);
+      expect(requireNativeStringLiteral(tx, pack, "valid")).toBe(pack.literals[0]);
+      if (bad !== "surrogate") {
+        const combined = fixture();
+        expect(() => reserveNativeStringLiteralResources(combined.tx, req)).toThrow(/invalid literal/);
+        expect(combined.module.types).toHaveLength(0);
+      }
+    });
+
+  it("consumes on allocation failure without promising rollback", () => {
+    const { tx } = fixture();
+    const types = reserveNativeStringLiteralTypes(tx, "strings", false);
+    const allocation = vi.spyOn(tx, "reserveGlobal").mockImplementationOnce(() => {
+      throw new Error("injected allocation failure");
+    });
+    expect(() => reserveNativeStringLiteralResources(tx, demands(false), types)).toThrow("injected allocation failure");
+    allocation.mockRestore();
+    expect(() => reserveNativeStringLiteralResources(tx, { ...demands(false), literals: [] }, types)).toThrow(
+      /consumed/,
+    );
+  });
+
+  it("enumerates all private chunks in allocation order, retaining repeated tokens", () => {
+    const { tx, module } = fixture();
+    const value = "x".repeat(20001);
+    const pack = reserveNativeStringLiteralResources(tx, {
+      key: "strings",
+      utf8Storage: false,
+      literals: [{ value }, { value }],
+    });
+    const census = nativeStringLiteralReservationInventory(tx, pack);
+    expect(census.requests).toHaveLength(2);
+    expect(census.requests[0]!.binding).toBe(census.requests[1]!.binding);
+    expect(census.requests[0]!.cacheKey).toBe(`__strlit_materialize:u16:${value}`);
+    expect(census.globals.map((row) => row.cacheKey)).toStrictEqual([`u16:${"x".repeat(10000)}`, "u16:x"]);
+    expect(census.globals.map((row) => row.global.object)).toStrictEqual(module.globals);
+    expect(census.functions).toHaveLength(1);
+    expect(census.functions[0]!.function.object).toBe(module.functions[0]);
+    expect(census.functions[0]!.chunkGlobals).toStrictEqual([
+      census.globals[0]!.global,
+      census.globals[0]!.global,
+      census.globals[1]!.global,
+    ]);
+    expect(census.functions[0]!.chunkGlobals[0]).toBe(census.functions[0]!.chunkGlobals[1]);
+    for (const container of [
+      census,
+      census.requests,
+      ...census.requests,
+      census.globals,
+      ...census.globals,
+      census.functions,
+      ...census.functions,
+      census.functions[0]!.chunkGlobals,
+    ])
+      expect(Object.isFrozen(container)).toBe(true);
+    expect(() => requireCompletedNativeStringLiterals(tx, pack)).toThrow(/incomplete/);
+    tx.freezeReservations();
+    fillNativeStringLiteralResources(tx, pack);
+    expect(requireCompletedNativeStringLiterals(tx, pack)).toBe(pack);
+  });
+
+  for (const phase of ["reserve", "lookup", "inventory", "fill", "completion"] as const)
+    it(`reauthenticates actual descriptor contents at ${phase}`, () => {
+      const positive = fixture();
+      const good = reserveNativeStringLiteralResources(positive.tx, demands(false));
+      expect(requireNativeStringLiteral(positive.tx, good, "then")).toBe(good.literals[0]);
+      expect(nativeStringLiteralReservationInventory(positive.tx, good).requests).toHaveLength(5);
+      positive.tx.freezeReservations();
+      fillNativeStringLiteralResources(positive.tx, good);
+      expect(requireCompletedNativeStringLiterals(positive.tx, good)).toBe(good);
+      const { tx, module } = fixture();
+      const types = reserveNativeStringLiteralTypes(tx, "strings", false);
+      const pack = phase === "reserve" ? undefined : reserveNativeStringLiteralResources(tx, demands(false), types);
+      if (phase === "fill" || phase === "completion") tx.freezeReservations();
+      if (phase === "completion") fillNativeStringLiteralResources(tx, pack!);
+      const descriptor = types.types[0]!.object;
+      if (descriptor.kind !== "array") throw new Error("expected string data array");
+      descriptor.mutable = false;
+      const before = structuredClone(module);
+      expect(() => {
+        if (phase === "reserve") reserveNativeStringLiteralResources(tx, demands(false), types);
+        if (phase === "lookup") requireNativeStringLiteral(tx, pack!, "then");
+        if (phase === "inventory") nativeStringLiteralReservationInventory(tx, pack!);
+        if (phase === "fill") fillNativeStringLiteralResources(tx, pack!);
+        if (phase === "completion") requireCompletedNativeStringLiterals(tx, pack!);
+      }).toThrow(/altered/);
+      expect(module).toStrictEqual(before);
+    });
+  for (const utf8 of [false, true])
+    it(`preserves combined allocation and fill order, utf8=${utf8}`, () => {
+      const a = fixture(),
+        b = fixture();
+      const combined = reserveNativeStringLiteralResources(a.tx, demands(utf8));
+      const types = reserveNativeStringLiteralTypes(b.tx, "strings", utf8);
+      expect(Object.isFrozen(types)).toBe(true);
+      expect(Object.isFrozen(types.layout)).toBe(true);
+      expect(Object.isFrozen(types.types)).toBe(true);
+      expect(types.types).toHaveLength(utf8 ? 7 : 5);
+      expect(b.module.globals).toHaveLength(0);
+      expect(b.module.functions).toHaveLength(0);
+      const split = reserveNativeStringLiteralResources(b.tx, demands(utf8), types);
+      expect(split.types).toBe(types.types);
+      expect(split.layout).toBe(types.layout);
+      expect(split.literals[0]).toBe(split.literals[1]);
+      expect(b.module).toStrictEqual(a.module);
+      a.tx.freezeReservations();
+      b.tx.freezeReservations();
+      fillNativeStringLiteralResources(a.tx, combined);
+      fillNativeStringLiteralResources(b.tx, split);
+      expect(requireCompletedNativeStringLiterals(b.tx, split)).toBe(split);
+      expect(b.module).toStrictEqual(a.module);
+    });
+
+  it("permits function and global imports between types and literals", () => {
+    const { module, tx } = fixture();
+    const types = reserveNativeStringLiteralTypes(tx, "strings", false);
+    tx.reserveFunctionImport("host:fn", "host", "fn", { params: [], results: [] });
+    const imported = tx.reserveGlobalImport("host:global", "host", "global", { kind: "i32" }, false);
+    const pack = reserveNativeStringLiteralResources(tx, demands(false), types);
+    expect(module.imports).toHaveLength(2);
+    tx.freezeReservations();
+    fillNativeStringLiteralResources(tx, pack);
+    expect(tx.physicalIndex(imported)).toBe(0);
+    const first = pack.literals[0]!;
+    if (first.kind !== "global") throw new Error("expected literal global");
+    expect(tx.physicalIndex(first.global)).toBe(1);
+    expect(requireCompletedNativeStringLiterals(tx, pack)).toBe(pack);
+  });
+
+  for (const mutation of ["copied", "foreign", "key", "config"] as const)
+    it(`rejects ${mutation} supplied types before literal allocations`, () => {
+      const positive = fixture();
+      const genuine = reserveNativeStringLiteralTypes(positive.tx, "strings", false);
+      expect(reserveNativeStringLiteralResources(positive.tx, demands(false), genuine).types).toBe(genuine.types);
+      const a = fixture(),
+        control = fixture();
+      const types = reserveNativeStringLiteralTypes(a.tx, "strings", false);
+      reserveNativeStringLiteralTypes(control.tx, "strings", false);
+      const supplied = mutation === "copied" ? { ...types } : mutation === "foreign" ? genuine : types;
+      const requirements = {
+        ...demands(false),
+        ...(mutation === "key" ? { key: "other" } : {}),
+        ...(mutation === "config" ? { utf8Storage: true } : {}),
+      };
+      const before = structuredClone(a.module);
+      const records = [...a.module.types];
+      expect(() => reserveNativeStringLiteralResources(a.tx, requirements, supplied)).toThrow(
+        mutation === "copied" || mutation === "foreign" ? "foreign or forged type owner" : "type key/config mismatch",
+      );
+      expect(a.module).toStrictEqual(before);
+      records.forEach((record, index) => expect(a.module.types[index]).toBe(record));
+      expect(probe(a.tx)).toStrictEqual(probe(control.tx));
+      expect(a.module.funcOrdinalToPosition).toStrictEqual(control.module.funcOrdinalToPosition);
+    });
+});


### PR DESCRIPTION
## Summary

Split native string type reservation from literal allocation so the prepared
consumer can reserve typed imports before defined resources. Preserve the
combined API, enforce issued single-use ownership, preflight all demands, and
expose the complete authenticated literal/chunk inventory.

Stacked on #5781. The canonical seven-line ledger assertion is identical to
the sibling #5776 implementation. Includes the frozen full source/demand/
materialization/consumer contract and an implementation handoff for #3518.

## Validation

- TS7 passed.
- 54/54 focused resource tests passed.
- 188/188 existing callers passed: 61 flatten, 120 scanner, 7 value-chain.
- 20/20 split tests passed again after the test-only array-hole lint repair.
- High and parent review found no blocking issues.

This is a prerequisite for prepared-consumer wiring, not proof of public IR
cutover or direct-codegen retirement. Existing regression and dependency holds
remain in force; stacked CI is not main-branch acceptance evidence.
