### PR TITLE
fix(ir): refine vector backing scratch before construction

### DIFF
--- a/plan/agent-context/3518-vector-data-nonnull-2026-09-09.md
+++ b/plan/agent-context/3518-vector-data-nonnull-2026-09-09.md
@@ -1,0 +1,61 @@
+# Vector constructor scratch nullability repair
+
+Isolated worktree: /private/tmp/js2-3518-vector-data-nonnull-20260909.
+Branch: codex/3518-vector-data-nonnull-20260909.
+Exact base: 5404151bfc1b49d6cffed4a87a8985c51bd3dd93, the published native
+resource declaration checkpoint. Authoritative upstream claim
+3518:vector-data-nonnull verified for ttraenkler/codex-vector-data-nonnull;
+claim terminal 1103 exited 0. The first sandboxed attempt exited 6 because DNS
+was unavailable and wrote nothing. Approved network retry verified the claim.
+
+## Production change
+
+One instruction in WasmGcEmitter.emitVecNewFixed: ref.as_non_null immediately
+after reloading the backing-array scratch local and before struct.new. Both
+successful branches store a newly allocated array before the reload. Preserve
+the nullable/defaultable scratch, non-null carrier data field, allocation order,
+ABI, and unsupported nonempty-spare-capacity refusal. No lower.ts, source
+admission, producer-original, consumer, baseline, or allowance changes.
+
+The production hunk is independently applicable to the historical
+2ccdcffd baseline and composed consumer; no commit has been made yet.
+
+## Regression proof and limits
+
+Dedicated test: tests/issue-3518-vector-construction-nullability.test.ts.
+Five AST-to-IR component rows use explicit type overrides and a physical-fixture
+resolver through analyzeSource -> lowerFunctionAstToIr ->
+lowerIrFunctionToWasm -> WasmGcEmitter -> emitted binary validation and execution:
+numeric and externref populated/empty fixed arrays, plus numeric counted-push
+source whose empty constructor reserves spare capacity. The latter returns
+after filling its three reserved slots; its constructor IR retains length zero.
+
+The sixth construction case is explicitly IR-lowerer-only: externref empty
+spare capacity. The current counted-push source proof admits numeric/boolean
+values, not externref values. This case uses the canonical IR builder and real
+lowerer, not a patched positive instruction stream. High approved the exact
+production/test diff and this bounded proof split: five AST-to-IR component
+rows with explicit type overrides/physical-fixture resolver, one IR-builder
+row, and one refusal control. This is not whole-source admission or full
+consumer execution. Parent owns the separate three-arm whole-consumer comparison.
+
+Read-only Wasm probes inspect returned length, capacity and elements, including
+3e9 numeric transport and externref identity/default nulls. Every positive
+binary is validated and executed without a body patch. Only an isolated cloned
+countermodel removes exactly one reload refinement; validation and compilation
+must then reject it. A seventh test retains the unsupported capacity refusal.
+
+## Validation receipts
+
+- 72033: exit 0, initial six construction cases, 6/6, 10.59 seconds.
+- 35986: exit 0, full unfiltered TS7 on this isolated tree.
+- 20787: exit 0, 31/31 across the final seven-case suite plus existing
+  ir-vec-new-fixed and ir-vec-two-backend suites, 15.70 seconds.
+
+All validation is serialized. NODE_OPTIONS=--max-old-space-size=2048,
+VITEST_FORK_MAX_OLD_SPACE_SIZE=2048, GOMEMLIMIT=2GiB, GOMAXPROCS=1;
+Vitest uses --pool=forks --poolOptions.forks.singleFork=true
+--no-file-parallelism. Existing node_modules is linked, not installed.
+High final diff review approved emitter caba0379 and test 4f51e96a. Parent
+authorized normal commit/push and a non-draft held PR stacked on the native
+resource declaration checkpoint. Hook/publication results follow separately.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6571,3 +6571,17 @@ The clean producer checkpoint now also passes 250/250 full boundary controls
 and unfiltered TS7 (session 54286 exit 0). Full caller revalidation passed
 322/322 across eight suites (session 46568 exit 0). Checkpoint validation is
 complete; this is not a migration-completion claim.
+
+### Isolated vector construction nullability repair (2026-09-09)
+
+Claim 3518:vector-data-nonnull owns a one-instruction WasmGC emitter fix at
+published base 5404151bfc. A nullable/defaultable backing-array scratch reload
+now receives ref.as_non_null before the carrier's non-null data field is
+constructed. Layout, allocation order and unsupported-capacity refusal remain
+unchanged. Full TS7 exits 0; the final combined regression run passes 31/31
+across three suites, including all seven new controls. High approved the proof
+split: five AST-to-IR component rows with explicit type overrides and a
+physical-fixture resolver, one IR-builder externref spare-capacity row, and
+one refusal control. This is not whole-source admission or consumer execution.
+See agent-context/3518-vector-data-nonnull-2026-09-09.md for exact receipts and
+the separate historical-baseline/common-fix application requirement.

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -177,6 +177,7 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     out.push({ op: "local.set", index: dataScratchLocal });
     out.push({ op: "i32.const", value: count });
     out.push({ op: "local.get", index: dataScratchLocal });
+    out.push({ op: "ref.as_non_null" });
     out.push({ op: "struct.new", typeIdx: layout.vecStructTypeIdx });
   }
 

--- a/tests/issue-3518-vector-construction-nullability.test.ts
+++ b/tests/issue-3518-vector-construction-nullability.test.ts
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import ts from "typescript";
+import { expect, it } from "vitest";
+import { analyzeSource } from "../src/checker/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+import { WasmGcEmitter } from "../src/ir/backend/wasmgc-emitter.js";
+import { IrFunctionBuilder } from "../src/ir/builder.js";
+import { irVal, irVec } from "../src/ir/core/types.js";
+import { forEachInstrDeep, type IrFunction } from "../src/ir/core/nodes.js";
+import { createEmptyModule, type Instr, type ValType } from "../src/ir/types.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import {
+  createVectorBaseType,
+  createVectorBackingArrayType,
+  createVectorCarrierType,
+} from "../src/runtime/wasmgc/values/vector-grow-store.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("vector-construction-nullability");
+type Arm = "populated" | "empty" | "spare";
+it("preserves the unsupported populated spare-capacity refusal", () => {
+  const f = fixture({ kind: "f64" });
+  const out: Instr[] = [];
+  expect(() => new WasmGcEmitter().emitVecNewFixed(f.layout, 2, 3, 0, out)).toThrow(
+    "vec capacity 3 unsupported for logical length 2",
+  );
+  expect(out).toStrictEqual([]);
+});
+function fixture(element: ValType) {
+  const module = createEmptyModule();
+  const tx = new PhysicalModuleReservations(module);
+  const base = tx.reserveType("base", createVectorBaseType());
+  const array = tx.reserveType("array", createVectorBackingArrayType("data", element));
+  const carrier = tx.reserveType(
+    "carrier",
+    createVectorCarrierType({ name: "vec", baseTypeIndex: base.typeIndex, arrayTypeIndex: array.typeIndex }),
+  );
+  const layout = {
+    vecStructTypeIdx: carrier.typeIndex,
+    arrayTypeIdx: array.typeIndex,
+    lengthFieldIdx: 0,
+    dataFieldIdx: 1,
+    elementValType: element,
+  };
+  const resolver: IrLowerResolver = {
+    resolveFunc: () => {
+      throw new Error("unexpected source call; no fallback");
+    },
+    resolveGlobal: () => {
+      throw new Error("unexpected source global");
+    },
+    resolveType: () => {
+      throw new Error("unexpected type reference");
+    },
+    resolveVec: () => layout,
+    resolveVecForElement: () => layout,
+    internFuncType: (signature) => tx.internFunctionType(signature.params, signature.results),
+  };
+  return { module, tx, array, carrier, layout, resolver };
+}
+function sourceIr(f: ReturnType<typeof fixture>, element: ValType, arm: Arm) {
+  const scalar = element.kind === "f64" ? "number" : "any";
+  const source =
+    arm === "spare"
+      ? "export function make(x: number): number[] { const a: number[] = []; for (let i = 0; i < 3; i++) { a.push(x); } return a; }"
+      : `export function make(x: ${scalar}): ${scalar}[] { return ${arm === "populated" ? "[x, x]" : "[]"}; }`;
+  const ast = analyzeSource(source);
+  const declaration = ast.sourceFile.statements.find(ts.isFunctionDeclaration)!;
+  return lowerFunctionAstToIr(declaration, {
+    ownerUnitId: identities.next("make").unitId,
+    exported: true,
+    ...(arm === "spare" ? { checker: ast.checker } : {}),
+    paramTypeOverrides: [irVal(element)],
+    returnTypeOverride: irVec(irVal(element), false),
+    resolver: { resolveVec: () => f.layout, resolveVecForElement: () => f.layout },
+  }).main;
+}
+function inspectConstruction(ir: IrFunction, count: number, capacity: number) {
+  const constructions: unknown[] = [];
+  for (const block of ir.blocks)
+    for (const root of block.instrs)
+      forEachInstrDeep(root, (instruction) => {
+        if (instruction.kind === "vec.new_fixed")
+          constructions.push({ count: instruction.elements.length, capacity: instruction.capacity });
+      });
+  expect(constructions).toStrictEqual([{ count, capacity }]);
+}
+function executable(f: ReturnType<typeof fixture>, ir: IrFunction, element: ValType) {
+  const lowered = lowerIrFunctionToWasm(ir, f.resolver, new WasmGcEmitter(f.resolver)).func;
+  const make = f.tx.reserveFunction("make", "make", {
+    params: [element],
+    results: [{ kind: "ref", typeIdx: f.carrier.typeIndex }],
+  });
+  const ref: ValType = { kind: "ref", typeIdx: f.carrier.typeIndex };
+  const length = f.tx.reserveFunction("length", "length", { params: [ref], results: [{ kind: "i32" }] });
+  const capacity = f.tx.reserveFunction("capacity", "capacity", { params: [ref], results: [{ kind: "i32" }] });
+  const get = f.tx.reserveFunction("get", "get", { params: [ref, { kind: "i32" }], results: [element] });
+  f.tx.freezeReservations();
+  f.tx.fillFunction(make, { locals: lowered.locals, body: lowered.body });
+  // Read-only probes observe the returned carrier; they never construct or patch it.
+  f.tx.fillFunction(length, {
+    locals: [],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: f.carrier.typeIndex, fieldIdx: 0 },
+    ],
+  });
+  const data: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "struct.get", typeIdx: f.carrier.typeIndex, fieldIdx: 1 },
+  ];
+  f.tx.fillFunction(capacity, { locals: [], body: [...data, { op: "array.len" }] });
+  f.tx.fillFunction(get, {
+    locals: [],
+    body: [...data, { op: "local.get", index: 1 }, { op: "array.get", typeIdx: f.array.typeIndex }],
+  });
+  for (const token of [make, length, capacity, get]) f.tx.defineExport("export:" + token.key, token.key, token);
+  f.tx.seal();
+  const scratch = make.object.locals.filter((local) => local.name.startsWith("$vec_data_"));
+  expect(scratch).toHaveLength(1);
+  expect(scratch[0]!.type).toStrictEqual({ kind: "ref_null", typeIdx: f.array.typeIndex });
+  if (f.carrier.object.kind !== "struct") throw new Error("expected carrier");
+  expect(f.carrier.object.fields[1]!.type).toStrictEqual({ kind: "ref", typeIdx: f.array.typeIndex });
+  const binary = emitBinary(f.module);
+  expect(WebAssembly.validate(binary as BufferSource)).toBe(true);
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(binary as BufferSource));
+  const exports = instance.exports as unknown as {
+    make(x: unknown): unknown;
+    length(v: unknown): number;
+    capacity(v: unknown): number;
+    get(v: unknown, i: number): unknown;
+  };
+  return { exports, make };
+}
+function removeSingleRefinement(body: Instr[]): number {
+  let removed = 0;
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (let i = 1; i + 1 < value.length; i++) {
+        if (
+          value[i]?.op === "ref.as_non_null" &&
+          value[i - 1]?.op === "local.get" &&
+          value[i + 1]?.op === "struct.new"
+        ) {
+          value.splice(i, 1);
+          removed++;
+        }
+      }
+      value.forEach(visit);
+    } else if (value && typeof value === "object") Object.values(value).forEach(visit);
+  };
+  visit(body);
+  return removed;
+}
+for (const kind of ["f64", "externref"] as const)
+  for (const arm of ["populated", "empty", "spare"] as const) {
+    it(`${kind} ${arm}: real lowerer bytes execute; removing only the refinement is invalid`, () => {
+      const element: ValType = { kind };
+      const f = fixture(element);
+      let ir: IrFunction;
+      if (kind === "externref" && arm === "spare") {
+        // Source counted-push admission is numeric-only. This is explicitly an IR-lowerer
+        // control, not a claim that the frontend admits externref spare-capacity source.
+        const builder = new IrFunctionBuilder(identities.next("make"), [irVec(irVal(element), false)], true);
+        builder.addParam("x", irVal(element));
+        builder.openBlock();
+        const vector = builder.emitVecNewFixed([], irVal(element), irVec(irVal(element), false), 3);
+        builder.terminate({ kind: "return", values: [vector] });
+        ir = builder.finish();
+      } else ir = sourceIr(f, element, arm);
+      inspectConstruction(ir, arm === "populated" ? 2 : 0, arm === "populated" ? 2 : arm === "spare" ? 3 : 0);
+      const { exports, make } = executable(f, ir, element);
+      const input = kind === "f64" ? 3e9 : { retained: "identity" };
+      const result = exports.make(input);
+      const length = arm === "populated" ? 2 : arm === "spare" && kind === "f64" ? 3 : 0;
+      expect(exports.length(result)).toBe(length);
+      expect(exports.capacity(result)).toBe(arm === "spare" ? 3 : length);
+      for (let i = 0; i < length; i++) expect(exports.get(result, i) === input).toBe(true);
+      if (arm === "spare" && kind === "externref")
+        for (let i = 0; i < 3; i++) expect(exports.get(result, i)).toBe(null);
+      const mutant = structuredClone(f.module);
+      const functionIndex = f.module.functions.indexOf(make.object);
+      expect(removeSingleRefinement(mutant.functions[functionIndex]!.body)).toBe(1);
+      const invalid = emitBinary(mutant);
+      expect(WebAssembly.validate(invalid as BufferSource)).toBe(false);
+      expect(() => new WebAssembly.Module(invalid as BufferSource)).toThrow(WebAssembly.CompileError);
+    });
+  }


### PR DESCRIPTION
## Summary

Stacked on #5789. Held for parent integration and the separate three-arm consumer comparison; do not enqueue yet.

Add exactly one ref.as_non_null after reloading the defaultable nullable backing-array scratch and before constructing the non-null vector data field. Preserve layout ABI, allocation order, and unsupported capacity refusal.

## Evidence

- Full isolated TS7: terminal 35986, exit 0.
- Focused regression suites: terminal 20787, 31/31 across three files, exit 0.
- New proof population: five AST-to-IR component rows with explicit type overrides and physical-fixture resolver, one IR-builder externref spare-capacity row, one refusal control. Not whole-source admission or consumer execution.
- Each construction validates and executes unpatched emitted bytes; an isolated countermodel removing exactly one refinement is rejected.
- Normal commit hooks: terminal 4235, exit 0. Changed-root gate explicitly skipped 78 files; this is not a test pass.
- Normal push hooks: terminal 72861, exit 0; typecheck, lint, formatting, ratchets, integrity and 18/18 numeric-local parity passed.

High approved emitter caba0379 and test 4f51e96a; both hashes remain unchanged after hooks. Production hunk is separable for applying the common fix to historical baseline 2ccdcffd and the composed consumer. No baseline, source-admission, frozen producer or parent consumer edits.

Tracks #3518; does not close migration or public-cutover requirements.