### PR TITLE
refactor(ir): declare native async resources before reservation

### DIFF
--- a/plan/agent-context/3518-native-async-resource-declarations-implementation-2026-09-09.md
+++ b/plan/agent-context/3518-native-async-resource-declarations-implementation-2026-09-09.md
@@ -1,0 +1,59 @@
+# Shared native async declarations — implementation handoff
+
+Base: a024d9c048b620bef2c4a95f89f09f23de44c938.
+Branch: codex/3518-native-async-resource-declarations-20260909.
+Worktree: /private/tmp/js2-3518-native-async-resource-declarations-20260909.
+Claim: 3518:native-async-resource-declarations, owner ttraenkler/codex-native-async-resource-declarations. Canonical claim35098 exit0; independent upstream verification69730 confirmed the same owner. No implementation commit or push.
+
+## Scope and interfaces
+
+The frozen contract's seven production and five test files only, plus this owned handoff. No ledger, ABI catalog, consumer, physical-plan, canonical body algorithm, boundary inventory, or peer worktree edits.
+
+All three existing reserve functions accept an optional expected declaration plan. Pure plans use resource keys, never guessed indices. Closure requirements instantiate actual authenticated type prerequisites; the live observer/cache loop consumes a checked recipe cursor. Argument vectors retain fresh/adopted array ordering and real fills. Promise retains 25 owned declarations, 26 operations, the actual borrowed argument array, and fresh inherited field records retaining metadata type identities.
+
+Inventory accessors require the exact supplied plan and issued pack through existing private owners. They return declaration-order owned reservations, excluding external/adopted dependencies and keeping alias mappings separate. They do not attest successful body completion or whole-program/provider authorization.
+
+Shared executor preserves declaration-list-as-lookup semantics; reservation steps determine execution order. Unnamed interning keeps exactly two arguments; named interning passes three. Signature observations capture the one actual operation's result. Self-indexed metadata is exclusively supported by the closure cursor's existing checked append frontier: generic execution refuses that shape before any allocation.
+
+## Borrowed exception-tag limitation
+
+The ledger exposes only reserve-phase assertTypeReservation. It does not expose a tag assertion, and physicalIndex rejects reserving. Promise retains the original tag association, rejects later substitution, and authenticates its actual ledger token after freeze. Parent remains responsible for genuine preallocation tag issuance. Existing fill still validates the tag descriptor/signature. Tests distinguish association currentness from initially foreign/copied tag provenance after freeze. No new ledger API or claimed reserve-phase tag authentication.
+
+## Validation receipts
+
+- First focused run97518: exit1,186/190 tests, five suites,18.49s. Three closure inverse mutation-target/attribution failures and one two-versus-three-argument unnamed interning failure. Retained, not relabeled as success.
+- First TS710756: exit1. Owned closure/Promise declaration typing errors from scalar constructors annotated with broad ValType. Repaired by precise scalar annotations; exact donor-header inverse retained.
+- Repaired focused run77955: exit0,194/194 tests, five suites,21.20s. Four added controls retain late physical rejection, actual signature mutation, inherited metadata type identity, and source-plan staleness.
+- Repaired TS743844: exit0. Exclusive heavy slot released after this terminal result; no worker heavy process remains.
+
+No original donor hash was changed. Original live controls remain individually present. Argument-vector factoring pins the complete pre-factoring canonical source hash 5be0cba6648fd0c6eee5ff66fdca78c318b6f1d28b7c2901b0a171930a3bd166 in addition to unchanged historical extraction receipts. Closure proof reconstructs complete live shape implementations and precise numeric delegates, with live mutation controls.
+
+## Frozen R2 source/test SHA256
+
+```text
+ff7714e126ef320ff5ae8b26b3b135aaee65dc29d3dc92c4642ff016ff03e173  src/runtime/wasmgc/values/native-resource-declaration-types.ts
+29fbb5476909236863201bc15f04f56ade29fbc50c47705eed3a74a426b06bfa  src/backend/wasmgc/resources/native-resource-declarations.ts
+0f9e1fe72f60e7f24577bf12ef194629e0b77815339f335c37df5784950a5543  src/runtime/wasmgc/values/closure-layouts.ts
+19b9f7e8e265df20997f8c3e40cd0bdf37d5723419575cd87536d8f7a5de1118  src/runtime/wasmgc/values/argument-vector-bodies.ts
+e76ff3a42cb04f1b60e3320f019e15af640f857c2fc1d8d80eb5a77d328c1830  src/backend/wasmgc/resources/native-closures.ts
+c39011af32edb14dd0db42aebaa0a62e9fe2957b333d2606696004ff73f0c07c  src/backend/wasmgc/resources/native-argument-vectors.ts
+6ed23305d64b18890910954afaee436af0944371da6c0c8c7799250ec2fc15c7  src/backend/wasmgc/resources/native-promises.ts
+1c7c617be4aa989db2c48ee936fabbc0d987568433c765a4aa6555b1079a6def  tests/issue-3518-native-async-resource-declarations.test.ts
+6d0aca37aed5dc85ff393b2155c2768df9bb1e9c98c6279918727add06e84621  tests/issue-3518-native-resource-declarations.test.ts
+e8d33e1797d0829acfa172b8ebd86eb7742e9a253c840dc82eca020a300b76ba  tests/issue-3518-native-closure-resources.test.ts
+f9d44c89ac8490abcc1bcc8fef26616b7955384bd2715663fa129183fe06634b  tests/issue-3518-native-argument-vector-resources.test.ts
+b93ca6a413e0e8af4c222442ea8ec61e65a21642a2a7b80cebea813a57c18d18  tests/issue-3518-native-promise-resources.test.ts
+```
+
+## Exact bounded commands
+
+Run from the worktree above, serially:
+
+```sh
+NODE_OPTIONS=--max-old-space-size=2048 VITEST_FORK_MAX_OLD_SPACE_SIZE=2048 VITEST_MAX_FORKS=1 node node_modules/vitest/dist/cli.js run tests/issue-3518-native-async-resource-declarations.test.ts tests/issue-3518-native-resource-declarations.test.ts tests/issue-3518-native-closure-resources.test.ts tests/issue-3518-native-argument-vector-resources.test.ts tests/issue-3518-native-promise-resources.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot
+NODE_OPTIONS=--max-old-space-size=2048 GOMEMLIMIT=2GiB GOMAXPROCS=1 node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json
+```
+
+High reviewed all twelve frozen R2 hashes and approved the scoped declaration/reservation checkpoint. The review verified operation order, cache observations, metadata type identities, adopted arrays, exact plan association and historical inverses. It does not cover full async fill/execution, aggregate integration or retirement.
+
+Unrun at this handoff: broad suites, boundary activation, full async/frame consumer execution, normal implementation commit/push hooks. Parent is publishing after High approval. This lane does not claim native Promise full materialization from deliberately incomplete dependency fixtures.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6787,3 +6787,19 @@ agent-context/3518-native-async-resource-declarations-spec-2026-09-09.md;
 the frame API and object-access donor map are also preserved for the next lanes.
 This composition does not remove the async acceptance refusal or establish
 native async execution, public default cutover or retirement.
+
+### Native async producer declarations (2026-09-09)
+
+The existing closure, argument-vector and Promise reservation callers now consume
+pure symbolic declaration plans before allocating. Issued inventories preserve
+ownership, request/cache ordering, adopted arrays and inherited metadata type
+identity. Promise still owns 25 declarations across 26 ordered operations.
+The declaration checkpoint passes 194/194 focused tests (77955, exit zero) and
+unfiltered TS7 (43844, exit zero). High approved the twelve frozen source/test
+files; earlier failing runs remain in the implementation handoff.
+
+Borrowed tag association is checked while reserving; actual tag provenance is
+authenticated only after freeze using the existing ledger. This limitation is
+explicit, not a claim of preallocation tag authentication. The full async
+consumer, staged cross-producer closure scheduling, complete runtime fills,
+public cutover and retirement remain unfinished.

--- a/src/backend/wasmgc/resources/native-argument-vectors.ts
+++ b/src/backend/wasmgc/resources/native-argument-vectors.ts
@@ -10,11 +10,105 @@ import { createVectorBaseType } from "../../../runtime/wasmgc/values/vector-grow
 import {
   createArgumentVectorArrayType,
   createArgumentVectorType,
+  createArgumentVectorShape,
   buildArgumentVectorNewBody,
   buildArgumentVectorPushLocals,
   buildArgumentVectorPushBody,
   type ArgumentVectorLayout,
 } from "../../../runtime/wasmgc/values/argument-vector-bodies.js";
+import type {
+  NativeResourceRecipe,
+  NativeStringValueDeclaration,
+} from "../../../runtime/wasmgc/values/native-resource-declaration-types.js";
+import {
+  freezeNativeResourceRecipe,
+  preflightNativeResourceRecipe,
+  executeNativeResourceRecipe,
+  requireNativeDeclaredReservation,
+  nativeScalarTypeDeclaration,
+  type NativeDeclaredReservation,
+} from "./native-resource-declarations.js";
+
+export interface NativeArgumentVectorDeclarationDependencies {
+  readonly vectorBaseKey: string;
+  readonly earlyArgumentArrayKey?: string;
+}
+export interface NativeArgumentVectorDeclarationPlan extends NativeResourceRecipe {
+  readonly key: string;
+  readonly dependencies: NativeArgumentVectorDeclarationDependencies;
+  readonly arrayKey: string;
+  readonly carrierKey: string;
+  readonly newVectorKey: string;
+  readonly pushKey: string;
+}
+export function declareNativeArgumentVectorResources(
+  requirements: { readonly key: string },
+  dependencies: NativeArgumentVectorDeclarationDependencies,
+): NativeArgumentVectorDeclarationPlan {
+  if (
+    !requirements.key ||
+    !dependencies.vectorBaseKey ||
+    (Object.hasOwn(dependencies, "earlyArgumentArrayKey") && !dependencies.earlyArgumentArrayKey)
+  )
+    fail("invalid declaration dependencies");
+  const key = (role: string) => `${requirements.key}:${role}`;
+  const arrayKey = dependencies.earlyArgumentArrayKey ?? key("array"),
+    carrierKey = key("carrier"),
+    newVectorKey = key("new"),
+    pushKey = key("push");
+  const declarations: NativeStringValueDeclaration[] = [];
+  if (!dependencies.earlyArgumentArrayKey)
+    declarations.push({
+      key: arrayKey,
+      role: ["argument-vector", "array"],
+      space: "type",
+      shape: nativeScalarTypeDeclaration(createArgumentVectorArrayType()),
+    });
+  declarations.push(
+    {
+      key: carrierKey,
+      role: ["argument-vector", "carrier"],
+      space: "type",
+      shape: createArgumentVectorShape(
+        { kind: "ref", typeKey: arrayKey },
+        { kind: "resource", typeKey: dependencies.vectorBaseKey },
+      ),
+    },
+    {
+      key: newVectorKey,
+      role: ["argument-vector", "new"],
+      space: "function",
+      name: "__objvec_new",
+      signature: { params: [], results: [{ kind: "externref" }] },
+    },
+    {
+      key: pushKey,
+      role: ["argument-vector", "push"],
+      space: "function",
+      name: "__objvec_push",
+      signature: { params: [{ kind: "externref" }, { kind: "externref" }], results: [] },
+    },
+  );
+  const plan = {
+    key: requirements.key,
+    dependencies,
+    arrayKey,
+    carrierKey,
+    newVectorKey,
+    pushKey,
+    declarations,
+    reservationSteps: declarations.map((row) => ({
+      phase: "resources" as const,
+      kind: "reserve" as const,
+      resourceKey: row.key,
+    })),
+  };
+  preflightNativeResourceRecipe(plan, [
+    dependencies.vectorBaseKey,
+    ...(dependencies.earlyArgumentArrayKey ? [dependencies.earlyArgumentArrayKey] : []),
+  ]);
+  return freezeNativeResourceRecipe(plan);
+}
 
 export interface NativeArgumentVectorDependencies {
   readonly vectorBase: TypeReservation;
@@ -32,7 +126,17 @@ export interface NativeArgumentVectorReservations {
 }
 
 // Provenance only. The transaction remains the sole allocator/completion authority.
-const owners = new WeakMap<NativeArgumentVectorReservations, { tx: PhysicalModuleReservations; filled: boolean }>();
+const owners = new WeakMap<
+  NativeArgumentVectorReservations,
+  {
+    tx: PhysicalModuleReservations;
+    filled: boolean;
+    plan: NativeArgumentVectorDeclarationPlan;
+    requirements: { readonly key: string };
+    dependencies: NativeArgumentVectorDependencies;
+    records: ReadonlyMap<string, NativeDeclaredReservation>;
+  }
+>();
 
 function fail(detail: string): never {
   throw new Error(`native argument vectors: ${detail}`);
@@ -60,6 +164,7 @@ export function reserveNativeArgumentVectorResources(
   tx: PhysicalModuleReservations,
   requirements: { readonly key: string },
   dependencies: NativeArgumentVectorDependencies,
+  expectedPlan?: NativeArgumentVectorDeclarationPlan,
 ): NativeArgumentVectorReservations {
   if (tx.state !== "reserving" || !requirements.key) fail("invalid reservation phase/key");
   tx.assertTypeReservation(dependencies.vectorBase);
@@ -72,21 +177,21 @@ export function reserveNativeArgumentVectorResources(
       "noncanonical early argument backing",
     );
   }
-  const key = (role: string) => `${requirements.key}:${role}`;
-  const array = dependencies.earlyArgumentArray ?? tx.reserveType(key("array"), createArgumentVectorArrayType());
-  const carrier = tx.reserveType(
-    key("carrier"),
-    createArgumentVectorType(dependencies.vectorBase.typeIndex, array.typeIndex),
-  );
-  // Preserve the donor's new-before-push function signature/registration order.
-  const newVector = tx.reserveFunction(key("new"), "__objvec_new", {
-    params: [],
-    results: [{ kind: "externref" }],
+  const derived = declareNativeArgumentVectorResources(requirements, {
+    vectorBaseKey: dependencies.vectorBase.key,
+    ...(dependencies.earlyArgumentArray ? { earlyArgumentArrayKey: dependencies.earlyArgumentArray.key } : {}),
   });
-  const push = tx.reserveFunction(key("push"), "__objvec_push", {
-    params: [{ kind: "externref" }, { kind: "externref" }],
-    results: [],
-  });
+  if (expectedPlan) same(derived, expectedPlan, "substituted argument-vector declaration plan");
+  const plan = expectedPlan ?? derived;
+  const prerequisites = [
+    dependencies.vectorBase,
+    ...(dependencies.earlyArgumentArray ? [dependencies.earlyArgumentArray] : []),
+  ];
+  const records = executeNativeResourceRecipe(tx, plan, new Map(prerequisites.map((token) => [token.key, token])));
+  const array = dependencies.earlyArgumentArray ?? requireNativeDeclaredReservation(records, plan.arrayKey, "type");
+  const carrier = requireNativeDeclaredReservation(records, plan.carrierKey, "type");
+  const newVector = requireNativeDeclaredReservation(records, plan.newVectorKey, "function");
+  const push = requireNativeDeclaredReservation(records, plan.pushKey, "function");
   const pack = Object.freeze({
     vectorBase: dependencies.vectorBase,
     array,
@@ -95,8 +200,44 @@ export function reserveNativeArgumentVectorResources(
     newVector,
     push,
   });
-  owners.set(pack, { tx, filled: false });
+  owners.set(pack, { tx, filled: false, plan, requirements, dependencies, records });
   return pack;
+}
+
+export function nativeArgumentVectorReservationInventory(
+  tx: PhysicalModuleReservations,
+  pack: NativeArgumentVectorReservations,
+  expectedPlan: NativeArgumentVectorDeclarationPlan,
+): readonly NativeDeclaredReservation[] {
+  const owner = owners.get(pack);
+  if (!owner || owner.tx !== tx || owner.plan !== expectedPlan)
+    fail("foreign or substituted argument-vector declaration plan");
+  if (
+    owner.dependencies.vectorBase !== pack.vectorBase ||
+    (owner.dependencies.earlyArgumentArray && owner.dependencies.earlyArgumentArray !== pack.array)
+  )
+    fail("stale argument-vector dependency");
+  same(
+    declareNativeArgumentVectorResources(owner.requirements, {
+      vectorBaseKey: pack.vectorBase.key,
+      ...(owner.dependencies.earlyArgumentArray ? { earlyArgumentArrayKey: pack.array.key } : {}),
+    }),
+    expectedPlan,
+    "stale argument-vector requirements",
+  );
+  for (const type of [pack.vectorBase, pack.array, pack.carrier]) {
+    if (tx.state === "reserving") tx.assertTypeReservation(type);
+    else tx.physicalIndex(type);
+  }
+  validateLayouts(pack);
+  return Object.freeze(
+    expectedPlan.declarations.map((row) => {
+      const token = owner.records.get(row.key);
+      if (!token) fail("missing argument-vector reservation");
+      if (tx.state !== "reserving") tx.physicalIndex(token);
+      return token;
+    }),
+  );
 }
 
 /** Fill both actual implementations; never freeze, seal, allocate, or publish here. */

--- a/src/backend/wasmgc/resources/native-closures.ts
+++ b/src/backend/wasmgc/resources/native-closures.ts
@@ -4,10 +4,25 @@ import type { ValType } from "../../../wasm/model/instructions.js";
 import type { PhysicalModuleReservations, TypeReservation } from "../../../wasm/physical/module-reservations.js";
 import { preparedIrDataMismatch } from "../../../ir/program/data.js";
 import {
-  createSignatureWrapperType,
-  createBuiltinFunctionMetadataType,
+  createSignatureWrapperShape,
+  createBuiltinFunctionMetadataShape,
   type ClosureAllocationMode,
 } from "../../../runtime/wasmgc/values/closure-layouts.js";
+import type {
+  NativeDeclaredValType,
+  NativeResourceRecipe,
+  NativeStringValueDeclaration,
+  NativeStringValueReservationStep,
+} from "../../../runtime/wasmgc/values/native-resource-declaration-types.js";
+import {
+  freezeNativeResourceRecipe,
+  preflightNativeResourceRecipe,
+  instantiateNativeDeclaredValType,
+  instantiateNativeDeclaredType,
+  instantiateNativeDeclaredSignature,
+  type NativeDeclaredTypeTokens,
+  type NativeDeclaredReservation,
+} from "./native-resource-declarations.js";
 
 export interface NativeClosureSignatureRequest {
   readonly kind: "signature";
@@ -32,6 +47,227 @@ export interface NativeClosureRequirements {
   readonly requests: readonly (NativeClosureSignatureRequest | NativeClosureMetadataRequest)[];
   /** Exact same-ledger prerequisites for every concrete user parameter/result. */
   readonly referenceTypes: readonly TypeReservation[];
+}
+export type NativeClosureDeclaredSignatureRequest = Omit<NativeClosureSignatureRequest, "params" | "results"> & {
+  readonly params: readonly NativeDeclaredValType[];
+  readonly results: readonly NativeDeclaredValType[];
+};
+export interface NativeClosureDeclarationRequirements {
+  readonly key: string;
+  readonly startingClosureCounter: number;
+  readonly requests: readonly (NativeClosureDeclaredSignatureRequest | NativeClosureMetadataRequest)[];
+  readonly referenceTypeKeys: readonly string[];
+}
+export interface NativeClosureDeclarationPlan extends NativeResourceRecipe {
+  readonly requirements: NativeClosureDeclarationRequirements;
+  readonly rootKey: string;
+  readonly signatures: readonly {
+    readonly requestId: string;
+    readonly wrapperKey: string;
+    readonly liftedSignatureKey: string;
+  }[];
+  readonly metadata: readonly {
+    readonly requestId: string;
+    readonly signatureRequestId: string;
+    readonly typeKey: string;
+  }[];
+  readonly resultingClosureCounter: number;
+}
+
+export function declareNativeClosureResources(
+  requirements: NativeClosureDeclarationRequirements,
+): NativeClosureDeclarationPlan {
+  if (
+    !requirements.key ||
+    !Number.isSafeInteger(requirements.startingClosureCounter) ||
+    requirements.startingClosureCounter < 0
+  )
+    fail("invalid declaration key/counter");
+  const declarations: NativeStringValueDeclaration[] = [],
+    reservationSteps: NativeStringValueReservationStep[] = [];
+  const signatures: { requestId: string; wrapperKey: string; liftedSignatureKey: string }[] = [];
+  const metadata: { requestId: string; signatureRequestId: string; typeKey: string }[] = [];
+  const external = new Set(requirements.referenceTypeKeys),
+    used = new Set<string>(),
+    ids = new Set<string>();
+  if (external.size !== requirements.referenceTypeKeys.length || [...external].some((key) => !key))
+    fail("invalid declaration prerequisites");
+  const cache = new Map<string, { wrapperKey: string; liftedSignatureKey: string }>();
+  const cacheRequests = new Map<string, NativeClosureDeclaredSignatureRequest>();
+  const byId = new Map<
+    string,
+    { request: NativeClosureDeclaredSignatureRequest; cacheKey: string; wrapperKey: string }
+  >();
+  const metaCache = new Map<string, { request: NativeClosureMetadataRequest; signatureKey: string; typeKey: string }>();
+  let counter = requirements.startingClosureCounter,
+    rootKey = "";
+  const add = (row: NativeStringValueDeclaration) => {
+    declarations.push(row);
+    reservationSteps.push({ phase: "resources", kind: "reserve", resourceKey: row.key });
+  };
+  for (const request of requirements.requests) {
+    if (!request || !request.id || ids.has(request.id)) fail("missing or duplicate request identity");
+    ids.add(request.id);
+    if (request.kind === "signature") {
+      if (!["support", "ordinary", "host-one-shot"].includes(request.allocationMode)) fail("invalid allocation mode");
+      if (
+        request.minimumArgumentCount !== undefined &&
+        (!Number.isInteger(request.minimumArgumentCount) ||
+          request.minimumArgumentCount < 0 ||
+          request.minimumArgumentCount > request.params.length)
+      )
+        fail("invalid observed minimum arity");
+      for (const type of [...request.params, ...request.results]) {
+        if (["i8", "i16"].includes(type.kind)) fail("packed storage is not a function value type");
+        if ("typeIdx" in type) fail("numeric reference in declaration");
+        if (type.kind === "ref" || type.kind === "ref_null") {
+          if (!external.has(type.typeKey)) fail("missing concrete reference type prerequisite");
+          used.add(type.typeKey);
+        }
+      }
+      const valueKey = (type: NativeDeclaredValType) =>
+        type.kind === "ref" || type.kind === "ref_null" ? [type.kind, type.typeKey] : [type.kind];
+      const cacheKey = JSON.stringify([request.params.map(valueKey), request.results.map(valueKey)]);
+      let binding = cache.get(cacheKey);
+      const cachedRequest = cacheRequests.get(cacheKey);
+      if (cachedRequest)
+        same(
+          { params: request.params, results: request.results },
+          { params: cachedRequest.params, results: cachedRequest.results },
+          "signature cache collision loses physical metadata",
+        );
+      if (!binding) {
+        const name = `__fn_wrap_${counter++}`,
+          wrapperKey = `${requirements.key}:wrapper:${request.id}`,
+          liftedSignatureKey = `${requirements.key}:lifted:${request.id}`;
+        add({
+          key: wrapperKey,
+          role: ["closure-wrapper", request.id],
+          space: "type",
+          shape: createSignatureWrapperShape(
+            name + "_struct",
+            rootKey ? { kind: "resource", typeKey: rootKey } : { kind: "root" },
+          ),
+        });
+        rootKey ||= wrapperKey;
+        reservationSteps.push({
+          phase: "resources",
+          kind: "intern-signature",
+          key: liftedSignatureKey,
+          name: name + "_type",
+          signature: { params: [{ kind: "ref", typeKey: rootKey }, ...request.params], results: request.results },
+        });
+        binding = { wrapperKey, liftedSignatureKey };
+        cache.set(cacheKey, binding);
+        cacheRequests.set(cacheKey, request);
+      }
+      signatures.push({ requestId: request.id, ...binding });
+      byId.set(request.id, { request, cacheKey, wrapperKey: binding.wrapperKey });
+    } else if (request.kind === "metadata") {
+      const signature = byId.get(request.signatureId);
+      if (!signature) fail("metadata must refer to an earlier genuine signature request");
+      if (!request.key || typeof request.name !== "string" || !Number.isInteger(request.length) || request.length < 0)
+        fail("invalid metadata identity/name/length");
+      if (request.key === "promise:settle")
+        same(
+          {
+            params: signature.request.params,
+            results: signature.request.results,
+            name: request.name,
+            length: request.length,
+          },
+          { params: [{ kind: "externref" }], results: [], name: "", length: 1 },
+          "noncanonical promise:settle request",
+        );
+      let binding = metaCache.get(request.key);
+      if (binding)
+        same(
+          { signature: signature.cacheKey, name: request.name, length: request.length },
+          { signature: binding.signatureKey, name: binding.request.name, length: binding.request.length },
+          "contradictory metadata cache request",
+        );
+      else {
+        const typeKey = `${requirements.key}:metadata:${request.id}`;
+        add({
+          key: typeKey,
+          role: ["closure-metadata", request.id],
+          space: "type",
+          shape: createBuiltinFunctionMetadataShape(
+            { kind: "builtin-function-metadata-index", typeKey },
+            { kind: "resource", typeKey: signature.wrapperKey },
+          ),
+        });
+        binding = { request, signatureKey: signature.cacheKey, typeKey };
+        metaCache.set(request.key, binding);
+      }
+      metadata.push({ requestId: request.id, signatureRequestId: request.signatureId, typeKey: binding.typeKey });
+    } else fail("unknown closure request kind");
+  }
+  if (!rootKey) fail("missing first signature/root");
+  if (used.size !== external.size) fail("unused concrete reference prerequisite");
+  if (!Number.isSafeInteger(counter)) fail("closure counter overflow");
+  const plan = {
+    requirements,
+    rootKey,
+    signatures,
+    metadata,
+    resultingClosureCounter: counter,
+    declarations,
+    reservationSteps,
+  };
+  preflightNativeResourceRecipe(plan, requirements.referenceTypeKeys);
+  return freezeNativeResourceRecipe(plan);
+}
+
+export function instantiateNativeClosureRequirements(
+  tx: PhysicalModuleReservations,
+  plan: NativeClosureDeclarationPlan,
+  types: NativeDeclaredTypeTokens,
+): NativeClosureRequirements {
+  same(plan, declareNativeClosureResources(plan.requirements), "substituted closure declaration plan");
+  if (types.size !== plan.requirements.referenceTypeKeys.length) fail("extra declaration prerequisite");
+  const referenceTypes = plan.requirements.referenceTypeKeys.map((key) => {
+    const token = types.get(key);
+    if (!token || token.key !== key) fail("missing concrete reference type prerequisite");
+    tx.assertTypeReservation(token);
+    return token;
+  });
+  const requests = plan.requirements.requests.map((request) =>
+    request.kind === "metadata"
+      ? request
+      : {
+          ...request,
+          params: request.params.map((type) => instantiateNativeDeclaredValType(tx, type, types)),
+          results: request.results.map((type) => instantiateNativeDeclaredValType(tx, type, types)),
+        },
+  );
+  const result = {
+    key: plan.requirements.key,
+    startingClosureCounter: plan.requirements.startingClosureCounter,
+    requests,
+    referenceTypes,
+  };
+  validateRequests(tx, result);
+  return result;
+}
+
+function symbolicRequirements(requirements: NativeClosureRequirements): NativeClosureDeclarationRequirements {
+  const value = (type: ValType): NativeDeclaredValType => {
+    if (type.kind !== "ref" && type.kind !== "ref_null") return { ...type };
+    const token = requirements.referenceTypes.find((row) => row.typeIndex === type.typeIdx);
+    if (!token) fail("missing concrete reference type prerequisite");
+    return { kind: type.kind, typeKey: token.key };
+  };
+  return {
+    key: requirements.key,
+    startingClosureCounter: requirements.startingClosureCounter,
+    requests: requirements.requests.map((request) =>
+      request.kind === "metadata"
+        ? request
+        : { ...request, params: request.params.map(value), results: request.results.map(value) },
+    ),
+    referenceTypeKeys: requirements.referenceTypes.map((token) => token.key),
+  };
 }
 export interface NativeClosureInfo {
   readonly structTypeIdx: number;
@@ -77,6 +313,7 @@ const owners = new WeakMap<
     requirements: NativeClosureRequirements;
     snapshot: unknown;
     external: readonly TypeReservation[];
+    plan: NativeClosureDeclarationPlan;
   }
 >();
 function fail(detail: string): never {
@@ -178,8 +415,26 @@ function validateRequests(tx: PhysicalModuleReservations, requirements: NativeCl
 export function reserveNativeClosureResources(
   tx: PhysicalModuleReservations,
   requirements: NativeClosureRequirements,
+  expectedPlan?: NativeClosureDeclarationPlan,
 ): NativeClosureReservations {
   validateRequests(tx, requirements); // Entire population and all foreign tokens checked BEFORE allocation.
+  const derivedPlan = declareNativeClosureResources(symbolicRequirements(requirements));
+  if (expectedPlan) same(derivedPlan, expectedPlan, "substituted closure declaration plan");
+  const plan = expectedPlan ?? derivedPlan;
+  const types = new Map(requirements.referenceTypes.map((token) => [token.key, token]));
+  let cursor = 0;
+  const reserve = (key: string, self?: number): TypeReservation => {
+    const step = plan.reservationSteps[cursor++];
+    if (step?.kind !== "reserve" || step.resourceKey !== key) fail("closure recipe operation mismatch");
+    const row = plan.declarations.find((entry) => entry.key === key);
+    if (row?.space !== "type") fail("missing closure type declaration");
+    const token = tx.reserveType(
+      key,
+      instantiateNativeDeclaredType(tx, row.shape, types, self === undefined ? undefined : { key, typeIndex: self }),
+    );
+    types.set(key, token);
+    return token;
+  };
   const snapshot = structuredClone(requestData(requirements));
   const cache = new Map<string, NativeClosureWrapperBinding>();
   const byId = new Map<string, NativeClosureWrapperBinding>();
@@ -207,10 +462,7 @@ export function reserveNativeClosureResources(
       if (!binding) {
         const name = `__fn_wrap_${counter++}`;
         registrations.push({ kind: "counter", value: counter });
-        const type = tx.reserveType(
-          `${requirements.key}:wrapper:${request.id}`,
-          createSignatureWrapperType(`${name}_struct`, root?.typeIndex ?? -1),
-        );
+        const type = reserve(`${requirements.key}:wrapper:${request.id}`);
         registrations.push({ kind: "type", type });
         if (!root) {
           root = type;
@@ -218,11 +470,16 @@ export function reserveNativeClosureResources(
         }
         const params = request.params.map((type) => Object.freeze({ ...type }));
         const results = request.results.map((type) => Object.freeze({ ...type }));
-        const liftedFuncTypeIndex = tx.internFunctionType(
-          [{ kind: "ref", typeIdx: root.typeIndex }, ...params],
-          results,
-          `${name}_type`,
+        const step = plan.reservationSteps[cursor++];
+        if (step?.kind !== "intern-signature" || step.name !== `${name}_type`)
+          fail("closure signature operation mismatch");
+        const signature = instantiateNativeDeclaredSignature(tx, step.signature, types);
+        same(
+          signature,
+          { params: [{ kind: "ref", typeIdx: root.typeIndex }, ...params], results },
+          "closure lifted signature mismatch",
         );
+        const liftedFuncTypeIndex = tx.internFunctionType(signature.params, signature.results, step.name);
         nextTypeIndex = Math.max(type.typeIndex, liftedFuncTypeIndex) + 1;
         registrations.push({ kind: "signature", typeIndex: liftedFuncTypeIndex, selfTypeIndex: root.typeIndex });
         const info: MutableInfo = {
@@ -249,10 +506,7 @@ export function reserveNativeClosureResources(
         // Preserve the donor's index-bearing name without allocating a dummy
         // type or mutating a descriptor already authenticated by the ledger.
         const typeIndex = nextTypeIndex;
-        const type = tx.reserveType(
-          `${requirements.key}:metadata:${request.id}`,
-          createBuiltinFunctionMetadataType(typeIndex, signature.type.typeIndex),
-        );
+        const type = reserve(`${requirements.key}:metadata:${request.id}`, typeIndex);
         if (type.typeIndex !== typeIndex) fail("unexpected metadata type coordinate");
         nextTypeIndex = type.typeIndex + 1;
         registrations.push({ kind: "type", type });
@@ -293,6 +547,8 @@ export function reserveNativeClosureResources(
       info.hostOneShotOnly = true;
   }
   for (const info of infos) Object.freeze(info);
+  if (cursor !== plan.reservationSteps.length || counter !== plan.resultingClosureCounter)
+    fail("unconsumed closure recipe operations");
   for (const binding of cache.values()) Object.freeze(binding);
   for (const binding of metaCache.values()) Object.freeze(binding);
   const pack = Object.freeze({
@@ -302,7 +558,7 @@ export function reserveNativeClosureResources(
     resultingClosureCounter: counter,
     registrations: Object.freeze(registrations.map((record) => Object.freeze(record))),
   });
-  owners.set(pack, { tx, requirements, snapshot, external: Object.freeze([...requirements.referenceTypes]) });
+  owners.set(pack, { tx, requirements, snapshot, external: Object.freeze([...requirements.referenceTypes]), plan });
   return pack;
 }
 
@@ -314,6 +570,11 @@ export function requireNativeClosureReservations(
   const owner = owners.get(pack);
   if (!owner || owner.tx !== tx) fail("foreign or copied closure pack");
   same(requestData(owner.requirements), owner.snapshot, "stale closure request sequence");
+  same(
+    declareNativeClosureResources(symbolicRequirements(owner.requirements)),
+    owner.plan,
+    "stale closure declaration plan",
+  );
   if (
     owner.requirements.referenceTypes.length !== owner.external.length ||
     owner.external.some((token, index) => token !== owner.requirements.referenceTypes[index])
@@ -330,4 +591,26 @@ export function requireNativeClosureReservations(
     else if (tx.physicalIndex(token) !== token.typeIndex) fail("closure type coordinate mismatch");
   }
   return pack;
+}
+
+export function nativeClosureReservationInventory(
+  tx: PhysicalModuleReservations,
+  pack: NativeClosureReservations,
+  expectedPlan: NativeClosureDeclarationPlan,
+): readonly NativeDeclaredReservation[] {
+  const owner = owners.get(pack);
+  if (!owner || owner.plan !== expectedPlan) fail("foreign or substituted closure declaration plan");
+  requireNativeClosureReservations(tx, pack);
+  const tokens = new Map(
+    [...pack.signatures.map((row) => row.binding.type), ...pack.metadata.map((row) => row.binding.type)].map(
+      (token) => [token.key, token],
+    ),
+  );
+  return Object.freeze(
+    expectedPlan.declarations.map((row) => {
+      const token = tokens.get(row.key);
+      if (!token) fail("missing owned closure declaration");
+      return token;
+    }),
+  );
 }

--- a/src/backend/wasmgc/resources/native-promises.ts
+++ b/src/backend/wasmgc/resources/native-promises.ts
@@ -10,9 +10,26 @@ import type {
   FunctionReservation,
   TagReservation,
   TagImportReservation,
-  PhysicalFunctionSignature,
 } from "../../../wasm/physical/module-reservations.js";
 import { preparedIrDataMismatch, freezePreparedIrValue } from "../../../ir/program/data.js";
+import { createBuiltinFunctionMetadataShape } from "../../../runtime/wasmgc/values/closure-layouts.js";
+import type {
+  NativeResourceRecipe,
+  NativeDeclaredType,
+  NativeDeclaredSignature,
+  NativeDeclaredValType,
+  NativeStringValueDeclaration,
+  NativeStringValueReservationStep,
+} from "../../../runtime/wasmgc/values/native-resource-declaration-types.js";
+import {
+  freezeNativeResourceRecipe,
+  preflightNativeResourceRecipe,
+  instantiateNativeDeclaredType,
+  instantiateNativeDeclaredValType,
+  instantiateNativeDeclaredSignature,
+  requireNativeDeclaredReservation,
+  type NativeDeclaredReservation,
+} from "./native-resource-declarations.js";
 import type { NativePromiseResourcePlan, NativePromiseOwner } from "../../../ir/program/native-promise-resources.js";
 import { resolveNativeVectorForElement, type NativeVectorTypeReservations } from "./native-vectors.js";
 import {
@@ -51,10 +68,129 @@ import {
 } from "../../../runtime/wasmgc/promise/thenable-bodies.js";
 
 type Tag = TagReservation | TagImportReservation;
-const EXTERN: ValType = { kind: "externref" },
-  I32: ValType = { kind: "i32" },
-  F64: ValType = { kind: "f64" };
+const EXTERN = { kind: "externref" } as const,
+  I32 = { kind: "i32" } as const,
+  F64 = { kind: "f64" } as const;
 const callbackSignature = { params: [EXTERN, EXTERN], results: [EXTERN] };
+export interface NativePromiseDeclarationDependencies {
+  readonly argumentArrayKey: string;
+  readonly closureRootKey: string;
+  readonly settleMetadataKey: string;
+}
+export interface NativePromiseDeclarationPlan extends NativeResourceRecipe {
+  readonly dependencies: NativePromiseDeclarationDependencies;
+  readonly callbackSignatureKey: string;
+}
+function promiseKey(plan: NativePromiseResourcePlan, role: string): string {
+  return `physical:promise:${JSON.stringify(plan.anchor)}:${role}`;
+}
+function promiseFunctionKey(plan: NativePromiseResourcePlan, role: string, name: string): string {
+  const bindings = plan.callableBindings.filter(
+    (entry) =>
+      entry.contract.kind === "callable" &&
+      (entry.contract.ref.binding.kind === "runtime" || entry.contract.ref.binding.kind === "intrinsic") &&
+      entry.contract.ref.binding.symbol === name,
+  );
+  if (bindings.length > 1) fail("duplicate canonical helper binding");
+  return bindings[0]?.plan.id ?? promiseKey(plan, role);
+}
+export function declareNativePromiseResources(
+  plan: NativePromiseResourcePlan,
+  dependencies: NativePromiseDeclarationDependencies,
+): NativePromiseDeclarationPlan {
+  if (!plan.required || !plan.anchor) fail("missing required native Promise plan");
+  const key = (role: string) => promiseKey(plan, role);
+  const declarations: NativeStringValueDeclaration[] = [],
+    reservationSteps: NativeStringValueReservationStep[] = [];
+  const add = (row: NativeStringValueDeclaration) => {
+    declarations.push(row);
+    reservationSteps.push({ phase: "resources", kind: "reserve", resourceKey: row.key });
+  };
+  const type = (role: string, shape: NativeDeclaredType) =>
+    add({ key: key(role), role: ["promise", role], space: "type", shape });
+  const global = (role: string, name: string, valueType: NativeDeclaredValType) =>
+    add({ key: key(role), role: ["promise", role], space: "global", name, valueType, mutable: true });
+  const fn = (role: string, name: string, signature: NativeDeclaredSignature) =>
+    add({ key: promiseFunctionKey(plan, role, name), role: ["promise", role], space: "function", name, signature });
+  type("queue:function-array", { kind: "array", name: "__arr_mt_func", element: { kind: "funcref" }, mutable: true });
+  const callbackSignatureKey = key("queue:callback-signature");
+  reservationSteps.push({
+    phase: "resources",
+    kind: "intern-signature",
+    key: callbackSignatureKey,
+    name: "$__mt_func_type",
+    signature: callbackSignature,
+  });
+  global("queue:head", "__mt_head", I32);
+  global("queue:tail", "__mt_tail", I32);
+  global("queue:capacity", "__mt_cap", I32);
+  global("queue:functions", "__mt_funcs", { kind: "ref_null", typeKey: key("queue:function-array") });
+  global("queue:captures", "__mt_caps", { kind: "ref_null", typeKey: dependencies.argumentArrayKey });
+  global("queue:arguments", "__mt_args", { kind: "ref_null", typeKey: dependencies.argumentArrayKey });
+  fn("queue:grow", "__microtask_grow", { params: [I32], results: [] });
+  fn("queue:enqueue", "__microtask_enqueue", { params: [{ kind: "funcref" }, EXTERN, EXTERN], results: [] });
+  fn("queue:drain", "__drain_microtasks", { params: [], results: [] });
+  type("carrier", {
+    kind: "struct",
+    name: "$Promise",
+    fields: [
+      { name: "state", type: I32, mutable: true },
+      { name: "value", type: EXTERN, mutable: true },
+      { name: "callbacks", type: EXTERN, mutable: true },
+      { name: "$bag", type: EXTERN, mutable: true },
+    ],
+  });
+  type("callback", {
+    kind: "struct",
+    name: "$PromiseCallback",
+    fields: [
+      { name: "onFulfilledFn", type: { kind: "funcref" }, mutable: false },
+      { name: "onFulfilledCaps", type: EXTERN, mutable: false },
+      { name: "onRejectedFn", type: { kind: "funcref" }, mutable: false },
+      { name: "onRejectedCaps", type: EXTERN, mutable: false },
+      { name: "next", type: EXTERN, mutable: false },
+    ],
+  });
+  const promiseRef: NativeDeclaredValType = { kind: "ref", typeKey: key("carrier") };
+  type("captures", {
+    kind: "struct",
+    name: "$__then_caps",
+    fields: [
+      { name: "callback", type: EXTERN, mutable: false },
+      { name: "chained", type: promiseRef, mutable: false },
+    ],
+  });
+  const settle = { params: [promiseRef, EXTERN], results: [EXTERN] };
+  fn("fulfill", "__promise_fulfill", settle);
+  fn("reject", "__promise_reject", settle);
+  fn("identity-fulfill", "__then_identity_fulfill", callbackSignature);
+  fn("identity-reject", "__then_identity_reject", callbackSignature);
+  fn("resolve-value", "__promise_resolve_value", settle);
+  const metadata = createBuiltinFunctionMetadataShape("", {
+    kind: "resource" as const,
+    typeKey: dependencies.settleMetadataKey,
+  });
+  type("settle-capture", {
+    kind: "struct",
+    name: "$__promise_settle_cap",
+    parent: metadata.parent,
+    fields: [...metadata.fields, { name: "cap_promise", type: promiseRef, mutable: false }],
+  });
+  const trampoline = { params: [{ kind: "ref" as const, typeKey: dependencies.closureRootKey }, EXTERN], results: [] };
+  fn("resolve-closure", "__promise_resolve_cl", trampoline);
+  fn("reject-closure", "__promise_reject_cl", trampoline);
+  fn("peel", "__promise_peel_value", { params: [EXTERN], results: [EXTERN] });
+  fn("classifier", "__promise_has_callable_then", { params: [EXTERN], results: [I32] });
+  fn("lookup-then", "__promise_lookup_then", { params: [EXTERN], results: [I32, EXTERN] });
+  fn("thenable-job", "__promise_thenable_job", callbackSignature);
+  const result = { dependencies, callbackSignatureKey, declarations, reservationSteps };
+  preflightNativeResourceRecipe(result, [
+    dependencies.argumentArrayKey,
+    dependencies.closureRootKey,
+    dependencies.settleMetadataKey,
+  ]);
+  return freezeNativeResourceRecipe(result);
+}
 export interface NativePromiseReservationDependencies {
   readonly vectors: NativeVectorTypeReservations;
   readonly exceptionTag: Tag;
@@ -159,9 +295,13 @@ const owners = new WeakMap<
     tx: PhysicalModuleReservations;
     plan: NativePromiseResourcePlan;
     dependencies: NativePromiseReservationDependencies;
+    sourceDependencies: NativePromiseReservationDependencies;
     settleMetadata: NativeClosureMetadataBinding;
     snapshots: readonly { token: TypeReservation; descriptor: TypeDef }[];
     filled: boolean;
+    declarationPlan: NativePromiseDeclarationPlan;
+    sourcePlan: NativePromiseResourcePlan;
+    records: ReadonlyMap<string, NativeDeclaredReservation>;
   }
 >();
 function fail(detail: string): never {
@@ -196,6 +336,7 @@ export function reserveNativePromiseResources(
   tx: PhysicalModuleReservations,
   plan: NativePromiseResourcePlan,
   dependencies: NativePromiseReservationDependencies,
+  expectedPlan?: NativePromiseDeclarationPlan,
 ): NativePromiseReservations {
   if (!plan.required || !plan.anchor) fail("missing required native Promise plan");
   const settleMetadata = requireSettleMetadata(tx, dependencies);
@@ -209,108 +350,82 @@ export function reserveNativePromiseResources(
     { kind: "array", name: "__arr_externref", element: EXTERN, mutable: true },
     "shared array descriptor mismatch",
   );
+  tx.assertTypeReservation(argumentArray);
   const metadataFields = structFields(settleMetadata.type);
-  // The actual metadata subtype may sit below a signature wrapper; ancestry is checked by the ledger.
-  const key = (role: string) => `physical:promise:${JSON.stringify(plan.anchor)}:${role}`;
-  const functionsType = tx.reserveType(key("queue:function-array"), {
-    kind: "array",
-    name: "__arr_mt_func",
-    element: { kind: "funcref" },
-    mutable: true,
+  const declaration = declareNativePromiseResources(plan, {
+    argumentArrayKey: argumentArray.key,
+    closureRootKey: closureRoot.key,
+    settleMetadataKey: settleMetadata.type.key,
   });
-  const callbackType = tx.internFunctionType(callbackSignature.params, callbackSignature.results, "$__mt_func_type");
-  const head = tx.reserveGlobal(key("queue:head"), "__mt_head", I32, true);
-  const tail = tx.reserveGlobal(key("queue:tail"), "__mt_tail", I32, true);
-  const capacity = tx.reserveGlobal(key("queue:capacity"), "__mt_cap", I32, true);
-  const functionsGlobal = tx.reserveGlobal(
-    key("queue:functions"),
-    "__mt_funcs",
-    { kind: "ref_null", typeIdx: functionsType.typeIndex },
-    true,
-  );
-  const capturesGlobal = tx.reserveGlobal(
-    key("queue:captures"),
-    "__mt_caps",
-    { kind: "ref_null", typeIdx: argumentArray.typeIndex },
-    true,
-  );
-  const argumentsGlobal = tx.reserveGlobal(
-    key("queue:arguments"),
-    "__mt_args",
-    { kind: "ref_null", typeIdx: argumentArray.typeIndex },
-    true,
-  );
-  const reserve = (role: string, name: string, signature: PhysicalFunctionSignature) => {
-    const bindings = plan.callableBindings.filter(
-      (entry) =>
-        entry.contract.kind === "callable" &&
-        (entry.contract.ref.binding.kind === "runtime" || entry.contract.ref.binding.kind === "intrinsic") &&
-        entry.contract.ref.binding.symbol === name,
-    );
-    if (bindings.length > 1) fail("duplicate canonical helper binding");
-    return tx.reserveFunction(bindings[0]?.plan.id ?? key(role), name, signature);
+  if (expectedPlan) same(declaration, expectedPlan, "substituted Promise declaration plan");
+  const declarationPlan = expectedPlan ?? declaration;
+  const key = (role: string) => promiseKey(plan, role);
+  const types = new Map([argumentArray, closureRoot, settleMetadata.type].map((token) => [token.key, token]));
+  const records = new Map<string, NativeDeclaredReservation>();
+  let callbackType: number | undefined;
+  for (const step of declarationPlan.reservationSteps) {
+    if (step.kind === "intern-signature") {
+      const signature = instantiateNativeDeclaredSignature(tx, step.signature, types);
+      callbackType = tx.internFunctionType(signature.params, signature.results, step.name);
+      continue;
+    }
+    const row = declarationPlan.declarations.find((entry) => entry.key === step.resourceKey)!;
+    let token: NativeDeclaredReservation;
+    if (row.space === "type") {
+      let descriptor = instantiateNativeDeclaredType(tx, row.shape, types);
+      if (row.key === key("settle-capture")) {
+        if (descriptor.kind !== "struct") fail("invalid settle-capture declaration");
+        same(metadataFields, descriptor.fields.slice(0, 5), "altered inherited metadata fields");
+        descriptor = {
+          ...descriptor,
+          fields: [...metadataFields.map((field) => ({ ...field })), descriptor.fields[5]!],
+        };
+      }
+      token = tx.reserveType(row.key, descriptor);
+      types.set(row.key, token);
+    } else if (row.space === "global") {
+      token = tx.reserveGlobal(
+        row.key,
+        row.name,
+        instantiateNativeDeclaredValType(tx, row.valueType, types),
+        row.mutable,
+      );
+    } else token = tx.reserveFunction(row.key, row.name, instantiateNativeDeclaredSignature(tx, row.signature, types));
+    records.set(row.key, token);
+  }
+  if (callbackType === undefined) fail("missing actual callback signature observation");
+  const type = (role: string) => requireNativeDeclaredReservation(records, key(role), "type");
+  const global = (role: string) => requireNativeDeclaredReservation(records, key(role), "global");
+  const fn = (role: string) => {
+    const declaration = declarationPlan.declarations.find((row) => row.role[1] === role && row.space === "function");
+    if (!declaration) fail("missing Promise function declaration");
+    return requireNativeDeclaredReservation(records, declaration.key, "function");
   };
-  const grow = reserve("queue:grow", "__microtask_grow", { params: [I32], results: [] });
-  const enqueue = reserve("queue:enqueue", "__microtask_enqueue", {
-    params: [{ kind: "funcref" }, EXTERN, EXTERN],
-    results: [],
-  });
-  const drain = reserve("queue:drain", "__drain_microtasks", { params: [], results: [] });
-  const promise = tx.reserveType(key("carrier"), {
-    kind: "struct",
-    name: "$Promise",
-    fields: [
-      { name: "state", type: I32, mutable: true },
-      { name: "value", type: EXTERN, mutable: true },
-      { name: "callbacks", type: EXTERN, mutable: true },
-      { name: "$bag", type: EXTERN, mutable: true },
-    ],
-  });
-  const callback = tx.reserveType(key("callback"), {
-    kind: "struct",
-    name: "$PromiseCallback",
-    fields: [
-      { name: "onFulfilledFn", type: { kind: "funcref" }, mutable: false },
-      { name: "onFulfilledCaps", type: EXTERN, mutable: false },
-      { name: "onRejectedFn", type: { kind: "funcref" }, mutable: false },
-      { name: "onRejectedCaps", type: EXTERN, mutable: false },
-      { name: "next", type: EXTERN, mutable: false },
-    ],
-  });
-  const promiseRef: ValType = { kind: "ref", typeIdx: promise.typeIndex };
-  const captures = tx.reserveType(key("captures"), {
-    kind: "struct",
-    name: "$__then_caps",
-    fields: [
-      { name: "callback", type: EXTERN, mutable: false },
-      { name: "chained", type: promiseRef, mutable: false },
-    ],
-  });
-  const settle = { params: [promiseRef, EXTERN], results: [EXTERN] };
-  const fulfill = reserve("fulfill", "__promise_fulfill", settle);
-  const reject = reserve("reject", "__promise_reject", settle);
-  const identityFulfill = reserve("identity-fulfill", "__then_identity_fulfill", callbackSignature);
-  const identityReject = reserve("identity-reject", "__then_identity_reject", callbackSignature);
-  const resolveValue = reserve("resolve-value", "__promise_resolve_value", settle);
-  const settleCapture = tx.reserveType(key("settle-capture"), {
-    kind: "struct",
-    name: "$__promise_settle_cap",
-    superTypeIdx: settleMetadata.type.typeIndex,
-    fields: [
-      ...metadataFields.map((field) => ({ ...field })),
-      { name: "cap_promise", type: promiseRef, mutable: false },
-    ],
-  });
-  const trampoline = {
-    params: [{ kind: "ref", typeIdx: closureRoot.typeIndex } as ValType, EXTERN],
-    results: [],
-  };
-  const resolveClosure = reserve("resolve-closure", "__promise_resolve_cl", trampoline);
-  const rejectClosure = reserve("reject-closure", "__promise_reject_cl", trampoline);
-  const peel = reserve("peel", "__promise_peel_value", { params: [EXTERN], results: [EXTERN] });
-  const classifier = reserve("classifier", "__promise_has_callable_then", { params: [EXTERN], results: [I32] });
-  const lookupThen = reserve("lookup-then", "__promise_lookup_then", { params: [EXTERN], results: [I32, EXTERN] });
-  const thenableJob = reserve("thenable-job", "__promise_thenable_job", callbackSignature);
+  const functionsType = type("queue:function-array"),
+    promise = type("carrier"),
+    callback = type("callback"),
+    captures = type("captures"),
+    settleCapture = type("settle-capture");
+  const head = global("queue:head"),
+    tail = global("queue:tail"),
+    capacity = global("queue:capacity"),
+    functionsGlobal = global("queue:functions"),
+    capturesGlobal = global("queue:captures"),
+    argumentsGlobal = global("queue:arguments");
+  const grow = fn("queue:grow"),
+    enqueue = fn("queue:enqueue"),
+    drain = fn("queue:drain"),
+    fulfill = fn("fulfill"),
+    reject = fn("reject"),
+    identityFulfill = fn("identity-fulfill"),
+    identityReject = fn("identity-reject"),
+    resolveValue = fn("resolve-value"),
+    resolveClosure = fn("resolve-closure"),
+    rejectClosure = fn("reject-closure"),
+    peel = fn("peel"),
+    classifier = fn("classifier"),
+    lookupThen = fn("lookup-then"),
+    thenableJob = fn("thenable-job");
   const result: NativePromiseReservations = Object.freeze({
     types: Object.freeze({
       arguments: argumentArray,
@@ -360,9 +475,13 @@ export function reserveNativePromiseResources(
     tx,
     plan: freezePreparedIrValue(plan) as NativePromiseResourcePlan,
     dependencies: Object.freeze({ ...dependencies }),
+    sourceDependencies: dependencies,
     settleMetadata,
     snapshots,
     filled: false,
+    declarationPlan,
+    sourcePlan: plan,
+    records,
   });
   return result;
 }
@@ -384,6 +503,61 @@ function promiseQueueReservations(
     grow: { kind: "function", index: pack.functions.grow.handle },
     initialCapacity: 8192,
   };
+}
+
+export function nativePromiseReservationInventory(
+  tx: PhysicalModuleReservations,
+  pack: NativePromiseReservations,
+  expectedPlan: NativePromiseDeclarationPlan,
+): readonly NativeDeclaredReservation[] {
+  const owner = owners.get(pack);
+  if (!owner || owner.tx !== tx || owner.declarationPlan !== expectedPlan)
+    fail("foreign or substituted Promise declaration plan");
+  same(owner.sourcePlan, owner.plan, "stale Promise requirements");
+  if (owner.sourceDependencies.exceptionTag !== owner.dependencies.exceptionTag)
+    fail("changed borrowed exception tag association");
+  if (
+    owner.sourceDependencies.vectors !== owner.dependencies.vectors ||
+    owner.sourceDependencies.closures !== owner.dependencies.closures ||
+    owner.sourceDependencies.settleMetadataRequestId !== owner.dependencies.settleMetadataRequestId
+  )
+    fail("changed Promise dependency association");
+  // No reserve-phase tag assertion exists in the ledger. The parent issues
+  // this borrowed prerequisite; exact association is retained here, with
+  // ledger provenance authenticated once final coordinates are available.
+  if (tx.state !== "reserving") tx.physicalIndex(owner.dependencies.exceptionTag);
+  if (requireSettleMetadata(tx, owner.dependencies) !== owner.settleMetadata) fail("changed settle metadata binding");
+  const argumentArray = owner.dependencies.vectors.layouts.find((row) => row.element === "externref")?.array;
+  if (!argumentArray || argumentArray !== pack.types.arguments) fail("changed shared argument array");
+  resolveNativeVectorForElement(owner.dependencies.vectors, EXTERN);
+  same(
+    declareNativePromiseResources(owner.sourcePlan, {
+      argumentArrayKey: argumentArray.key,
+      closureRootKey: owner.dependencies.closures.root.key,
+      settleMetadataKey: owner.settleMetadata.type.key,
+    }),
+    expectedPlan,
+    "stale Promise declaration plan",
+  );
+  for (const { token, descriptor } of owner.snapshots) {
+    if (tx.state === "reserving") tx.assertTypeReservation(token);
+    else tx.physicalIndex(token);
+    same(token.object, descriptor, "changed Promise type descriptor");
+  }
+  const fields = structFields(pack.types.settleCapture),
+    metadata = structFields(owner.settleMetadata.type);
+  for (let index = 0; index < metadata.length; index++) {
+    if (fields[index] === metadata[index] || fields[index]?.type !== metadata[index]!.type)
+      fail("lost inherited metadata field/type identity");
+  }
+  return Object.freeze(
+    expectedPlan.declarations.map((row) => {
+      const token = owner.records.get(row.key);
+      if (!token) fail("missing Promise reservation");
+      if (tx.state !== "reserving") tx.physicalIndex(token);
+      return token;
+    }),
+  );
 }
 
 /** No fallback: resolution/classification/value dependencies must all be real same-ledger reservations. */

--- a/src/backend/wasmgc/resources/native-resource-declarations.ts
+++ b/src/backend/wasmgc/resources/native-resource-declarations.ts
@@ -14,6 +14,7 @@ import type {
   NativeDeclaredSignature,
   NativeStringValueDeclaration,
   NativeResourceRecipe,
+  NativeDeclaredName,
 } from "../../../runtime/wasmgc/values/native-resource-declaration-types.js";
 import { freezePreparedIrValue, preparedIrDataMismatch } from "../../../ir/program/data.js";
 
@@ -80,11 +81,20 @@ export function instantiateNativeDeclaredType(
   tx: PhysicalModuleReservations,
   shape: NativeDeclaredType,
   types: NativeDeclaredTypeTokens,
+  self?: { readonly key: string; readonly typeIndex: number },
 ): TypeDef {
+  const name = (value: NativeDeclaredName): string => {
+    if (typeof value === "string") return value;
+    if (value.kind === "array-ref-index") return `__arr_ref_${typeIndex(tx, types, value.typeKey)}`;
+    if (value.kind !== "builtin-function-metadata-index") fail("invalid indexed name");
+    const index = self?.key === value.typeKey ? self.typeIndex : typeIndex(tx, types, value.typeKey);
+    if (!Number.isSafeInteger(index) || index < 0) fail("invalid self coordinate");
+    return `__builtinfn_meta_${index}_struct`;
+  };
   if (shape.kind === "array")
     return {
       kind: "array",
-      name: typeof shape.name === "string" ? shape.name : `__arr_ref_${typeIndex(tx, types, shape.name.typeKey)}`,
+      name: name(shape.name),
       element: instantiateNativeDeclaredValType(tx, shape.element, types),
       mutable: shape.mutable,
     };
@@ -92,6 +102,7 @@ export function instantiateNativeDeclaredType(
   const { parent, fields, ...rest } = shape;
   return {
     ...rest,
+    name: name(shape.name),
     fields: fields.map((field) => ({ ...field, type: instantiateNativeDeclaredValType(tx, field.type, types) })),
     ...(Object.hasOwn(shape, "parent")
       ? {
@@ -122,17 +133,16 @@ export function nativeScalarTypeDeclaration(definition: TypeDef): NativeDeclared
   };
 }
 
-/** Preflight the entire recipe without allocation, then execute its exact interleaving. */
-export function executeNativeResourceRecipe(
-  tx: PhysicalModuleReservations,
+/** Validate the complete symbolic operation population without a module or ledger. */
+export function preflightNativeResourceRecipe(
   recipe: NativeResourceRecipe,
-  prerequisites: NativeDeclaredTypeTokens = new Map(),
-): ReadonlyMap<string, NativeDeclaredReservation> {
-  const types = new Map(prerequisites);
-  for (const [key, token] of types) {
-    if (token.key !== key) fail("substituted prerequisite key");
-    tx.assertTypeReservation(token);
-  }
+  prerequisiteKeys: readonly string[] = [],
+): void {
+  const types = new Set<string>();
+  dense(prerequisiteKeys, "prerequisites", (key) => {
+    if (typeof key !== "string" || !key || types.has(key)) fail("invalid prerequisite key");
+    types.add(key);
+  });
   const declarations = new Map<string, NativeStringValueDeclaration>();
   dense(recipe.declarations, "declarations", (row) => {
     if (!row.key || declarations.has(row.key) || types.has(row.key)) fail("duplicate declaration key");
@@ -142,7 +152,7 @@ export function executeNativeResourceRecipe(
     });
     declarations.set(row.key, row);
   });
-  const available = new Set(types.keys()),
+  const available = new Set(types),
     reserved = new Set<string>();
   const ref = (value: NativeDeclaredValType) => {
     if (!value || typeof value !== "object") fail("invalid value type");
@@ -156,11 +166,24 @@ export function executeNativeResourceRecipe(
     dense(sig.results, "signature results", ref);
   };
   let resourcePhase = false;
+  const signatureKeys = new Set<string>();
   dense(recipe.reservationSteps, "reservation steps", (step) => {
     if (step.phase !== "string-types" && step.phase !== "resources") fail("invalid reservation phase");
     if (step.phase === "resources") resourcePhase = true;
     else if (resourcePhase) fail("reordered string type phase");
     if (step.kind === "intern-signature") {
+      if (Object.hasOwn(step, "key")) {
+        if (
+          typeof step.key !== "string" ||
+          !step.key ||
+          signatureKeys.has(step.key) ||
+          declarations.has(step.key) ||
+          types.has(step.key)
+        )
+          fail("invalid signature observation key");
+        signatureKeys.add(step.key);
+      }
+      if (Object.hasOwn(step, "name") && typeof step.name !== "string") fail("invalid signature name");
       signature(step.signature);
       return;
     }
@@ -177,6 +200,11 @@ export function executeNativeResourceRecipe(
         )
           fail("invalid symbolic array name");
       } else if (shape.kind === "struct") {
+        if (
+          typeof shape.name !== "string" &&
+          (shape.name?.kind !== "builtin-function-metadata-index" || shape.name.typeKey !== row.key)
+        )
+          fail("invalid symbolic struct name");
         dense(shape.fields, "struct fields", (field) => ref(field.type));
         if (
           Object.hasOwn(shape, "parent") &&
@@ -192,11 +220,40 @@ export function executeNativeResourceRecipe(
     reserved.add(row.key);
   });
   if (reserved.size !== declarations.size) fail("declaration missing reserve step");
+}
+
+/** Both public execution APIs share these exact reservation/interner operations. */
+export function executeNativeResourceRecipeWithSignatures(
+  tx: PhysicalModuleReservations,
+  recipe: NativeResourceRecipe,
+  prerequisites: NativeDeclaredTypeTokens = new Map(),
+): {
+  readonly reservations: ReadonlyMap<string, NativeDeclaredReservation>;
+  readonly signatures: ReadonlyMap<string, number>;
+} {
+  preflightNativeResourceRecipe(recipe, [...prerequisites.keys()]);
+  // Only the closure producer has an authenticated append frontier for its
+  // self-named metadata subtype. Refuse before executing any generic step.
+  for (const row of recipe.declarations) {
+    if (row.space === "type" && row.shape.kind === "struct" && typeof row.shape.name !== "string")
+      fail("self-indexed metadata requires the closure reservation cursor");
+  }
+  const types = new Map(prerequisites);
+  for (const [key, token] of types) {
+    if (token.key !== key) fail("substituted prerequisite key");
+    tx.assertTypeReservation(token);
+  }
+  const declarations = new Map(recipe.declarations.map((row) => [row.key, row]));
+  const signatures = new Map<string, number>();
   const result = new Map<string, NativeDeclaredReservation>();
   for (const step of recipe.reservationSteps) {
     if (step.kind === "intern-signature") {
       const sig = instantiateNativeDeclaredSignature(tx, step.signature, types);
-      tx.internFunctionType(sig.params, sig.results);
+      const index =
+        step.name === undefined
+          ? tx.internFunctionType(sig.params, sig.results)
+          : tx.internFunctionType(sig.params, sig.results, step.name);
+      if (step.key !== undefined) signatures.set(step.key, index);
       continue;
     }
     const row = declarations.get(step.resourceKey)!;
@@ -214,7 +271,15 @@ export function executeNativeResourceRecipe(
     else token = tx.reserveFunction(row.key, row.name, instantiateNativeDeclaredSignature(tx, row.signature, types));
     result.set(row.key, token);
   }
-  return result;
+  return { reservations: result, signatures };
+}
+
+export function executeNativeResourceRecipe(
+  tx: PhysicalModuleReservations,
+  recipe: NativeResourceRecipe,
+  prerequisites: NativeDeclaredTypeTokens = new Map(),
+): ReadonlyMap<string, NativeDeclaredReservation> {
+  return executeNativeResourceRecipeWithSignatures(tx, recipe, prerequisites).reservations;
 }
 
 export function requireNativeDeclaredReservation<K extends NativeDeclaredReservation["kind"]>(

--- a/src/runtime/wasmgc/values/argument-vector-bodies.ts
+++ b/src/runtime/wasmgc/values/argument-vector-bodies.ts
@@ -19,13 +19,21 @@ export function createArgumentVectorArrayType(): ArrayTypeDef {
 }
 
 export function createArgumentVectorType(objVecBaseTypeIdx: number, objVecArrTypeIdx: number): StructTypeDef {
+  const { parent, ...shape } = createArgumentVectorShape(
+    { kind: "ref" as const, typeIdx: objVecArrTypeIdx },
+    objVecBaseTypeIdx,
+  );
+  return { kind: shape.kind, name: shape.name, superTypeIdx: parent, fields: shape.fields };
+}
+
+export function createArgumentVectorShape<D, P>(data: D, parent: P) {
   return {
-    kind: "struct",
+    kind: "struct" as const,
     name: "$ObjVec",
-    superTypeIdx: objVecBaseTypeIdx,
+    parent,
     fields: [
-      { name: "length", type: { kind: "i32" }, mutable: true },
-      { name: "data", type: { kind: "ref", typeIdx: objVecArrTypeIdx }, mutable: true },
+      { name: "length", type: { kind: "i32" as const }, mutable: true },
+      { name: "data", type: data, mutable: true },
     ],
   };
 }

--- a/src/runtime/wasmgc/values/closure-layouts.ts
+++ b/src/runtime/wasmgc/values/closure-layouts.ts
@@ -34,7 +34,7 @@
  * {@link CLOSURE_CAPTURE_FIELD_BASE}, never a bare literal — and now so does
  * every VALIDATOR of the header.
  */
-import type { Instr, ValType, FuncHandle } from "../../../wasm/model/instructions.js";
+import type { Instr, FuncHandle } from "../../../wasm/model/instructions.js";
 import type { FieldDef, StructTypeDef } from "../../../wasm/model/module-records.js";
 
 /** Field 0 — the lifted function reference. */
@@ -47,7 +47,7 @@ export const CLOSURE_BAG_FIELD_IDX = 2;
 export const CLOSURE_CAPTURE_FIELD_BASE = 3;
 
 /** The `$arity` field definition — shared by every closure-struct mint site. */
-export function closureArityField(): { name: string; type: ValType; mutable: false } {
+export function closureArityField(): { name: string; type: { kind: "i32" }; mutable: false } {
   return { name: "$arity", type: { kind: "i32" }, mutable: false };
 }
 
@@ -67,7 +67,7 @@ export function closureArityField(): { name: string; type: ValType; mutable: fal
  */
 export const INSTANCE_BAG_FIELD = "$bag";
 
-export function closureBagField(): { name: string; type: ValType; mutable: true } {
+export function closureBagField(): { name: string; type: { kind: "externref" }; mutable: true } {
   return { name: "$bag", type: { kind: "externref" }, mutable: true };
 }
 
@@ -121,18 +121,31 @@ export const BFN_STATE_FIELD_IDX = 3;
 export const BFN_ID_FIELD_IDX = 4;
 
 export function createSignatureWrapperType(name: string, superTypeIdx: number): StructTypeDef {
+  const { parent, ...shape } = createSignatureWrapperShape(name, superTypeIdx);
+  return { ...shape, superTypeIdx: parent };
+}
+
+export function createSignatureWrapperShape<P>(name: string, parent: P) {
   const fields = [
     { name: "func", type: { kind: "funcref" as const }, mutable: false },
     closureArityField(),
     closureBagField(),
   ];
-  return { kind: "struct", name, fields, superTypeIdx };
+  return { kind: "struct" as const, name, fields, parent };
 }
 
 export function createBuiltinFunctionMetadataType(typeIndex: number, signatureWrapperTypeIndex: number): StructTypeDef {
+  const { parent, ...shape } = createBuiltinFunctionMetadataShape(
+    `__builtinfn_meta_${typeIndex}_struct`,
+    signatureWrapperTypeIndex,
+  );
+  return { ...shape, superTypeIdx: parent };
+}
+
+export function createBuiltinFunctionMetadataShape<N, P>(name: N, parent: P) {
   return {
-    kind: "struct",
-    name: `__builtinfn_meta_${typeIndex}_struct`,
+    kind: "struct" as const,
+    name,
     fields: [
       // Field 0 must mirror the supertype exactly (same type + mutability) —
       // as must the #3673 $arity slot at index 1.
@@ -145,7 +158,7 @@ export function createBuiltinFunctionMetadataType(typeIndex: number, signatureWr
       // subtypes cannot be distinguished by ref.test alone.
       { name: "bfnid", type: { kind: "i32" as const }, mutable: false },
     ],
-    superTypeIdx: signatureWrapperTypeIndex,
+    parent,
   };
 }
 

--- a/src/runtime/wasmgc/values/native-resource-declaration-types.ts
+++ b/src/runtime/wasmgc/values/native-resource-declaration-types.ts
@@ -9,11 +9,13 @@ export interface NativeDeclaredSignature {
   readonly params: readonly NativeDeclaredValType[];
   readonly results: readonly NativeDeclaredValType[];
 }
-export type NativeDeclaredName = string | { readonly kind: "array-ref-index"; readonly typeKey: string };
+export type NativeDeclaredName =
+  | string
+  | { readonly kind: "array-ref-index" | "builtin-function-metadata-index"; readonly typeKey: string };
 export type NativeDeclaredType =
   | {
       readonly kind: "struct";
-      readonly name: string;
+      readonly name: NativeDeclaredName;
       readonly fields: readonly (Omit<FieldDef, "type"> & { readonly type: NativeDeclaredValType })[];
       readonly parent?: { readonly kind: "root" } | { readonly kind: "resource"; readonly typeKey: string };
       readonly final?: boolean;
@@ -36,7 +38,12 @@ export type NativeStringValueDeclaration = { readonly key: string; readonly role
 );
 export type NativeStringValueReservationStep = { readonly phase: "string-types" | "resources" } & (
   | { readonly kind: "reserve"; readonly resourceKey: string }
-  | { readonly kind: "intern-signature"; readonly signature: NativeDeclaredSignature }
+  | {
+      readonly kind: "intern-signature";
+      readonly signature: NativeDeclaredSignature;
+      readonly key?: string;
+      readonly name?: string;
+    }
 );
 export interface NativeResourceRecipe {
   readonly declarations: readonly NativeStringValueDeclaration[];

--- a/tests/issue-3518-native-argument-vector-resources.test.ts
+++ b/tests/issue-3518-native-argument-vector-resources.test.ts
@@ -18,6 +18,8 @@ import {
 } from "../src/runtime/wasmgc/values/vector-grow-store.js";
 import * as bodies from "../src/runtime/wasmgc/values/argument-vector-bodies.js";
 import {
+  declareNativeArgumentVectorResources,
+  nativeArgumentVectorReservationInventory,
   reserveNativeArgumentVectorResources,
   fillNativeArgumentVectorResources,
 } from "../src/backend/wasmgc/resources/native-argument-vectors.js";
@@ -208,13 +210,59 @@ function legacy(original: boolean, early: boolean, baseFirst: boolean) {
   const result = run(ctx);
   return { ctx, result };
 }
-function reserve(early = false) {
+function reserve(early = false, explicit = true) {
   const module = createEmptyModule();
   const tx = new PhysicalModuleReservations(module);
   const vectorBase = tx.reserveType("shared:base", createVectorBaseType());
   const earlyArgumentArray = early ? tx.reserveType("early:argv", bodies.createArgumentVectorArrayType()) : undefined;
-  const pack = reserveNativeArgumentVectorResources(tx, { key: "argv" }, { vectorBase, earlyArgumentArray });
-  return { module, tx, pack };
+  const declaration = declareNativeArgumentVectorResources(
+    { key: "argv" },
+    { vectorBaseKey: vectorBase.key, ...(earlyArgumentArray ? { earlyArgumentArrayKey: earlyArgumentArray.key } : {}) },
+  );
+  const pack = reserveNativeArgumentVectorResources(
+    tx,
+    { key: "argv" },
+    { vectorBase, earlyArgumentArray },
+    explicit ? declaration : undefined,
+  );
+  return { module, tx, pack, declaration };
+}
+
+const canonicalBodySource = () =>
+  readFileSync(new URL("../src/runtime/wasmgc/values/argument-vector-bodies.ts", import.meta.url), "utf8");
+function requireFactoredArgumentVectorReceipt(source: string): void {
+  const parsed = ts.createSourceFile("argument-vector-factories.ts", source, ts.ScriptTarget.Latest, true);
+  const declarations = parsed.statements.filter(ts.isFunctionDeclaration);
+  const named = (name: string) => {
+    const matches = declarations.filter((row) => row.name?.text === name);
+    if (matches.length !== 1) throw new Error("missing/duplicate argument-vector factory");
+    return matches[0]!.getText(parsed);
+  };
+  const delegate = named("createArgumentVectorType"),
+    shape = named("createArgumentVectorShape");
+  const header =
+    "export function createArgumentVectorType(objVecBaseTypeIdx: number, objVecArrTypeIdx: number): StructTypeDef {";
+  const expected = `${header}
+  const { parent, ...shape } = createArgumentVectorShape(
+    { kind: "ref" as const, typeIdx: objVecArrTypeIdx },
+    objVecBaseTypeIdx,
+  );
+  return { kind: shape.kind, name: shape.name, superTypeIdx: parent, fields: shape.fields };
+}`;
+  if (delegate !== expected) throw new Error("changed argument-vector delegate");
+  let original = replaceExactlyOnce(
+    shape,
+    "export function createArgumentVectorShape<D, P>(data: D, parent: P) {",
+    header,
+  );
+  original = replaceExactlyOnce(original, 'kind: "struct" as const,', 'kind: "struct",');
+  original = replaceExactlyOnce(original, "    parent,", "    superTypeIdx: objVecBaseTypeIdx,");
+  original = replaceExactlyOnce(original, 'type: { kind: "i32" as const }', 'type: { kind: "i32" }');
+  original = replaceExactlyOnce(original, "type: data,", 'type: { kind: "ref", typeIdx: objVecArrTypeIdx },');
+  const inverse = replaceExactlyOnce(source, delegate + "\n\n" + shape, original);
+  // Exact pre-factoring file at a024d9c048; prior extraction donors unchanged.
+  if (sha256(inverse) !== "5be0cba6648fd0c6eee5ff66fdca78c318b6f1d28b7c2901b0a171930a3bd166")
+    throw new Error("complete argument-vector factory inverse mismatch");
 }
 type Api = {
   newVector(): unknown;
@@ -268,6 +316,41 @@ function instantiate() {
 }
 
 describe("native argument-vector resources", () => {
+  it("inverts only the shared factory factoring against the complete unchanged donor", () => {
+    requireFactoredArgumentVectorReceipt(canonicalBodySource());
+  });
+  for (const [before, after] of [
+    ["type: data,", 'type: { kind: "externref" },'],
+    ["    parent,", "    parent: undefined,"],
+    ["export function createArgumentVectorShape<D, P>", "export async function createArgumentVectorShape<D, P>"],
+    ['  return {\n    kind: "struct" as const,', '  void 0;\n  return {\n    kind: "struct" as const,'],
+  ])
+    it(`rejects live argument-vector factory mutation ${before}`, () => {
+      const source = canonicalBodySource();
+      requireFactoredArgumentVectorReceipt(source);
+      expect(() => requireFactoredArgumentVectorReceipt(replaceExactlyOnce(source, before!, after!))).toThrow();
+    });
+  it.each([false, true])("preserves implicit/explicit recipe bodies and inventory, adopted=%s", (early) => {
+    const explicit = reserve(early),
+      implicit = reserve(early, false);
+    expect(explicit.module).toStrictEqual(implicit.module);
+    const rows = nativeArgumentVectorReservationInventory(explicit.tx, explicit.pack, explicit.declaration);
+    expect(rows.map((row) => row.key)).toEqual(explicit.declaration.declarations.map((row) => row.key));
+    expect(rows).toHaveLength(early ? 3 : 4);
+    if (early) expect(rows).not.toContain(explicit.pack.array);
+    explicit.tx.freezeReservations();
+    implicit.tx.freezeReservations();
+    fillNativeArgumentVectorResources(explicit.tx, explicit.pack);
+    fillNativeArgumentVectorResources(implicit.tx, implicit.pack);
+    expect(explicit.module).toStrictEqual(implicit.module);
+    expect(nativeArgumentVectorReservationInventory(explicit.tx, explicit.pack, explicit.declaration)).toEqual(rows);
+    expect(() =>
+      nativeArgumentVectorReservationInventory(explicit.tx, { ...explicit.pack }, explicit.declaration),
+    ).toThrow();
+    expect(() =>
+      nativeArgumentVectorReservationInventory(explicit.tx, explicit.pack, structuredClone(explicit.declaration)),
+    ).toThrow();
+  });
   for (const file of ["object", "linear"] as const) {
     const source = file === "object" ? liveObject : liveLinear;
     const canonicalImport = file === "object" ? canonicalObjectImport : canonicalLinearImport;

--- a/tests/issue-3518-native-async-resource-declarations.test.ts
+++ b/tests/issue-3518-native-async-resource-declarations.test.ts
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import { createEmptyModule } from "../src/ir/types.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import { createVectorBaseType } from "../src/runtime/wasmgc/values/vector-grow-store.js";
+import { createArgumentVectorArrayType } from "../src/runtime/wasmgc/values/argument-vector-bodies.js";
+import {
+  declareNativeClosureResources,
+  instantiateNativeClosureRequirements,
+  reserveNativeClosureResources,
+  nativeClosureReservationInventory,
+  type NativeClosureDeclarationRequirements,
+} from "../src/backend/wasmgc/resources/native-closures.js";
+import {
+  declareNativeArgumentVectorResources,
+  reserveNativeArgumentVectorResources,
+  nativeArgumentVectorReservationInventory,
+} from "../src/backend/wasmgc/resources/native-argument-vectors.js";
+import { preflightNativeResourceRecipe } from "../src/backend/wasmgc/resources/native-resource-declarations.js";
+
+const requirements = (): NativeClosureDeclarationRequirements => ({
+  key: "async:closures",
+  startingClosureCounter: 3,
+  referenceTypeKeys: ["external:object"],
+  requests: [
+    {
+      kind: "signature",
+      id: "ref",
+      params: [{ kind: "ref_null", typeKey: "external:object" }],
+      results: [],
+      allocationMode: "ordinary",
+      minimumArgumentCount: 1,
+    },
+    { kind: "metadata", id: "meta", signatureId: "ref", key: "reference", name: "reference", length: 1 },
+    {
+      kind: "signature",
+      id: "ref-alias",
+      params: [{ typeKey: "external:object", kind: "ref_null" }],
+      results: [],
+      allocationMode: "support",
+      minimumArgumentCount: 0,
+    },
+    { kind: "metadata", id: "meta-alias", signatureId: "ref-alias", key: "reference", name: "reference", length: 1 },
+    { kind: "signature", id: "settle", params: [{ kind: "externref" }], results: [], allocationMode: "ordinary" },
+    { kind: "metadata", id: "settle-meta", signatureId: "settle", key: "promise:settle", name: "", length: 1 },
+  ],
+});
+function fixture() {
+  const module = createEmptyModule(),
+    tx = new PhysicalModuleReservations(module);
+  const external = tx.reserveType("external:object", { kind: "struct", name: "external", fields: [] });
+  return { module, tx, external, types: new Map([[external.key, external]]) };
+}
+function closure() {
+  const plan = declareNativeClosureResources(requirements()),
+    input = fixture();
+  const physical = instantiateNativeClosureRequirements(input.tx, plan, input.types);
+  const pack = reserveNativeClosureResources(input.tx, physical, plan);
+  return { ...input, physical, plan, pack };
+}
+
+describe("shared async declarations on existing reservation producers", () => {
+  it("rejects late malformed physical requests before consuming reservation ordinals", () => {
+    const positive = closure();
+    expect(nativeClosureReservationInventory(positive.tx, positive.pack, positive.plan)).toHaveLength(4);
+    const a = fixture(),
+      plan = declareNativeClosureResources(requirements());
+    const physical = instantiateNativeClosureRequirements(a.tx, plan, a.types);
+    const requests = structuredClone(physical.requests);
+    Object.assign(requests[5]!, { signatureId: "unknown" });
+    const before = structuredClone(a.module);
+    expect(() => reserveNativeClosureResources(a.tx, { ...physical, requests }, plan)).toThrow(
+      "metadata must refer to an earlier genuine signature request",
+    );
+    expect(a.module).toStrictEqual(before);
+    const twin = fixture();
+    const probe = (tx: PhysicalModuleReservations) =>
+      tx.reserveType("probe", { kind: "struct", name: "probe", fields: [] }).typeIndex;
+    expect(probe(a.tx)).toBe(probe(twin.tx));
+  });
+  it("rejects changed actual lifted signatures, not only recorded intentions", () => {
+    const a = closure();
+    expect(nativeClosureReservationInventory(a.tx, a.pack, a.plan)).toHaveLength(4);
+    const signature = a.module.types[a.pack.signatures[0]!.binding.liftedFuncTypeIndex];
+    if (signature?.kind !== "func") throw new Error("fixture actual lifted signature");
+    signature.params.push({ kind: "i32" });
+    expect(() => nativeClosureReservationInventory(a.tx, a.pack, a.plan)).toThrow();
+  });
+  it("derives symbolic identities, aliases, indexed metadata names and all interning operations without a ledger", () => {
+    const plan = declareNativeClosureResources(requirements());
+    expect(plan.declarations.map((row) => row.key)).toEqual([
+      "async:closures:wrapper:ref",
+      "async:closures:metadata:meta",
+      "async:closures:wrapper:settle",
+      "async:closures:metadata:settle-meta",
+    ]);
+    expect(plan.reservationSteps.map((step) => step.kind)).toEqual([
+      "reserve",
+      "intern-signature",
+      "reserve",
+      "reserve",
+      "intern-signature",
+      "reserve",
+    ]);
+    expect(plan.signatures).toHaveLength(3);
+    expect(plan.metadata).toHaveLength(3);
+    expect(plan.signatures[0]!.wrapperKey).toBe(plan.signatures[1]!.wrapperKey);
+    expect(plan.metadata[0]!.typeKey).toBe(plan.metadata[1]!.typeKey);
+    expect(plan.resultingClosureCounter).toBe(5);
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(() => preflightNativeResourceRecipe(plan, ["external:object"])).not.toThrow();
+  });
+
+  it("preserves the concrete prerequisite and exact alias bindings through reserve/freeze", () => {
+    const a = closure();
+    expect(a.physical.referenceTypes[0]).toBe(a.external);
+    expect(a.pack.signatures[0]!.binding).toBe(a.pack.signatures[1]!.binding);
+    expect(a.pack.metadata[0]!.binding).toBe(a.pack.metadata[1]!.binding);
+    const rows = nativeClosureReservationInventory(a.tx, a.pack, a.plan);
+    expect(rows).toHaveLength(4);
+    expect(rows).not.toContain(a.external);
+    a.pack.metadata.forEach(({ binding }) =>
+      expect(binding.type.object.name).toBe(`__builtinfn_meta_${binding.type.typeIndex}_struct`),
+    );
+    a.tx.freezeReservations();
+    expect(nativeClosureReservationInventory(a.tx, a.pack, a.plan)).toEqual(rows);
+    expect(a.pack.signatures[0]!.binding.info.minimumArgumentCount).toBe(0);
+    expect(a.pack.metadata[0]!.binding.metadata.length).toBe(1);
+  });
+
+  it.each(["numeric", "missing", "extra", "late", "metadata-signature", "metadata-length"] as const)(
+    "rejects %s symbolic input before module construction",
+    (mutation) => {
+      expect(declareNativeClosureResources(requirements()).declarations).toHaveLength(4);
+      const bad = structuredClone(requirements());
+      const first = bad.requests[0]!;
+      if (first.kind !== "signature") throw new Error("fixture signature");
+      if (mutation === "numeric") Object.assign(first.params[0]!, { typeIdx: 0 });
+      if (mutation === "missing") Object.assign(bad, { referenceTypeKeys: [] });
+      if (mutation === "extra") Object.assign(bad, { referenceTypeKeys: ["external:object", "unused"] });
+      if (mutation === "late") Object.assign(bad.requests[5]!, { signatureId: "missing" });
+      if (mutation === "metadata-signature") Object.assign(bad.requests[5]!, { signatureId: "ref" });
+      if (mutation === "metadata-length") Object.assign(bad.requests[5]!, { length: 0 });
+      expect(() => declareNativeClosureResources(bad)).toThrow();
+    },
+  );
+
+  it.each(["copy", "foreign", "missing", "extra"] as const)(
+    "rejects %s prerequisite tokens before any dependent population changes",
+    (mutation) => {
+      const plan = declareNativeClosureResources(requirements()),
+        good = fixture();
+      expect(instantiateNativeClosureRequirements(good.tx, plan, good.types).referenceTypes).toEqual([good.external]);
+      const a = fixture(),
+        types = new Map(a.types),
+        before = structuredClone(a.module);
+      if (mutation === "copy") types.set(a.external.key, { ...a.external });
+      if (mutation === "foreign") types.set(a.external.key, fixture().external);
+      if (mutation === "missing") types.clear();
+      if (mutation === "extra") types.set("extra", a.external);
+      expect(() => instantiateNativeClosureRequirements(a.tx, plan, types)).toThrow();
+      expect(a.module).toStrictEqual(before);
+    },
+  );
+
+  it.each(["declarations", "steps", "requests", "indexed-name", "signature-name", "delete"] as const)(
+    "rejects substituted %s before the closure cursor allocates",
+    (mutation) => {
+      const positive = closure();
+      expect(nativeClosureReservationInventory(positive.tx, positive.pack, positive.plan)).toHaveLength(4);
+      const a = fixture(),
+        plan = declareNativeClosureResources(requirements());
+      const physical = instantiateNativeClosureRequirements(a.tx, plan, a.types),
+        bad = structuredClone(plan);
+      if (mutation === "declarations") (bad.declarations as unknown[]).reverse();
+      if (mutation === "steps") (bad.reservationSteps as unknown[]).reverse();
+      if (mutation === "requests") (bad.requirements.requests as unknown[]).reverse();
+      if (mutation === "delete") (bad.declarations as unknown[]).pop();
+      if (mutation === "signature-name") Object.assign(bad.reservationSteps[1]!, { name: "changed" });
+      if (mutation === "indexed-name") {
+        const row = bad.declarations[1]!;
+        if (row.space !== "type") throw new Error("fixture type");
+        Object.assign(row.shape, { name: { kind: "array-ref-index", typeKey: bad.rootKey } });
+      }
+      const before = structuredClone(a.module);
+      expect(() => reserveNativeClosureResources(a.tx, physical, bad)).toThrow("substituted closure declaration plan");
+      expect(a.module).toStrictEqual(before);
+    },
+  );
+
+  it.each([false, true])("requires the exact declaration association and adopted array identity, early=%s", (early) => {
+    const module = createEmptyModule(),
+      tx = new PhysicalModuleReservations(module);
+    const vectorBase = tx.reserveType("base", createVectorBaseType());
+    const earlyArgumentArray = early ? tx.reserveType("early", createArgumentVectorArrayType()) : undefined;
+    const plan = declareNativeArgumentVectorResources(
+      { key: "argv" },
+      {
+        vectorBaseKey: vectorBase.key,
+        ...(earlyArgumentArray ? { earlyArgumentArrayKey: earlyArgumentArray.key } : {}),
+      },
+    );
+    const deps = { vectorBase, earlyArgumentArray },
+      pack = reserveNativeArgumentVectorResources(tx, { key: "argv" }, deps, plan);
+    const inventory = nativeArgumentVectorReservationInventory(tx, pack, plan);
+    expect(inventory.map((row) => row.key)).toEqual(
+      early ? ["argv:carrier", "argv:new", "argv:push"] : ["argv:array", "argv:carrier", "argv:new", "argv:push"],
+    );
+    if (early) expect(pack.array).toBe(earlyArgumentArray);
+    expect(() => nativeArgumentVectorReservationInventory(tx, pack, structuredClone(plan))).toThrow();
+    expect(() => nativeArgumentVectorReservationInventory(tx, { ...pack }, plan)).toThrow();
+    Object.assign(deps, { vectorBase: { ...vectorBase } });
+    expect(() => nativeArgumentVectorReservationInventory(tx, pack, plan)).toThrow();
+  });
+});

--- a/tests/issue-3518-native-closure-resources.test.ts
+++ b/tests/issue-3518-native-closure-resources.test.ts
@@ -11,6 +11,9 @@ import * as funcSpace from "../src/codegen/func-space.js";
 import * as canonical from "../src/runtime/wasmgc/values/closure-layouts.js";
 import {
   reserveNativeClosureResources,
+  declareNativeClosureResources,
+  instantiateNativeClosureRequirements,
+  nativeClosureReservationInventory,
   requireNativeClosureReservations,
   type NativeClosureRequirements,
   type NativeClosureSignatureRequest,
@@ -92,6 +95,56 @@ const factoryHeaders = [
 ] as const;
 const allocationModeDeclaration = 'export type ClosureAllocationMode = "support" | "ordinary" | "host-one-shot";';
 function completeFactories(source: string): { declarations: string[]; bodies: string[] } {
+  const parsed = ts.createSourceFile("live-shapes.ts", source, ts.ScriptTarget.Latest, true);
+  const functions = parsed.statements.filter(ts.isFunctionDeclaration);
+  const declaration = (name: string) => {
+    const matches = functions.filter((fn) => fn.name?.text === name);
+    if (matches.length !== 1) throw new Error("missing/duplicate shape factory");
+    return matches[0]!.getText(parsed);
+  };
+  const wrapper = declaration("createSignatureWrapperType"),
+    metadata = declaration("createBuiltinFunctionMetadataType");
+  const wrapperShape = declaration("createSignatureWrapperShape"),
+    metadataShape = declaration("createBuiltinFunctionMetadataShape");
+  const wrapperDelegate = `${factoryHeaders[0]}
+  const { parent, ...shape } = createSignatureWrapperShape(name, superTypeIdx);
+  return { ...shape, superTypeIdx: parent };
+}`;
+  const metadataDelegate = `${factoryHeaders[1]}
+  const { parent, ...shape } = createBuiltinFunctionMetadataShape(
+    \`__builtinfn_meta_\${typeIndex}_struct\`,
+    signatureWrapperTypeIndex,
+  );
+  return { ...shape, superTypeIdx: parent };
+}`;
+  if (wrapper !== wrapperDelegate || metadata !== metadataDelegate)
+    throw new Error("changed numeric factory delegation");
+  let originalWrapper = replaceOnce(
+    wrapperShape,
+    "export function createSignatureWrapperShape<P>(name: string, parent: P) {",
+    factoryHeaders[0],
+  );
+  originalWrapper = replaceOnce(
+    originalWrapper,
+    'return { kind: "struct" as const, name, fields, parent };',
+    'return { kind: "struct", name, fields, superTypeIdx };',
+  );
+  let originalMetadata = replaceOnce(
+    metadataShape,
+    "export function createBuiltinFunctionMetadataShape<N, P>(name: N, parent: P) {",
+    factoryHeaders[1],
+  );
+  originalMetadata = replaceOnce(originalMetadata, 'kind: "struct" as const,', 'kind: "struct",');
+  originalMetadata = replaceOnce(originalMetadata, "    name,", "    name: `__builtinfn_meta_${typeIndex}_struct`,");
+  originalMetadata = replaceOnce(originalMetadata, "    parent,", "    superTypeIdx: signatureWrapperTypeIndex,");
+  let reconstructed = replaceOnce(source, wrapper + "\n\n" + wrapperShape, originalWrapper);
+  reconstructed = replaceOnce(reconstructed, metadata + "\n\n" + metadataShape, originalMetadata);
+  const complete = completeOriginalFactories(reconstructed);
+  // Existing mutation controls still mutate the LIVE numeric delegates; the
+  // bodies passed to the original donor inverse come from the live shapes.
+  return { declarations: [wrapper, metadata, declaration("buildBuiltinClosureValueInstrs")], bodies: complete.bodies };
+}
+function completeOriginalFactories(source: string): { declarations: string[]; bodies: string[] } {
   const start = source.indexOf(allocationModeDeclaration);
   if (start < 0) throw new Error("missing canonical suffix population");
   const suffix = source.slice(start);
@@ -318,6 +371,54 @@ function legacy(
 }
 
 describe("native closure identities and settlement metadata", () => {
+  for (const [before, after] of [
+    ["export function createSignatureWrapperShape<P>", "export async function createSignatureWrapperShape<P>"],
+    [
+      '  return { kind: "struct" as const, name, fields, parent };',
+      '  void 0;\n  return { kind: "struct" as const, name, fields, parent };',
+    ],
+    ["    parent,", "    parent: undefined,"],
+    [
+      '      { name: "bfnstate", type: { kind: "i32" as const }, mutable: true },',
+      '      { name: "bfnstate", type: { kind: "i32" as const }, mutable: false },',
+    ],
+  ])
+    it(`rejects live shape factoring mutation ${before}`, () => {
+      const source = read("src/runtime/wasmgc/values/closure-layouts.ts");
+      requireCanonicalFactoryReceipts(source);
+      expect(() => requireCanonicalFactoryReceipts(replaceOnce(source, before!, after!))).toThrow();
+    });
+  it("feeds a pure declaration to the live observer loop without changing donor descriptors or aliases", () => {
+    const input = requirements([
+      signature("first", [{ kind: "externref" }], [], "ordinary", 1),
+      metadata("meta", "first"),
+      signature("alias", [{ kind: "externref" }], [], "support", 0),
+      metadata("meta-alias", "alias"),
+    ]);
+    const plan = declareNativeClosureResources({
+      key: input.key,
+      startingClosureCounter: input.startingClosureCounter,
+      requests: input.requests as Parameters<typeof declareNativeClosureResources>[0]["requests"],
+      referenceTypeKeys: [],
+    });
+    const module = createEmptyModule(),
+      tx = new PhysicalModuleReservations(module);
+    const physical = instantiateNativeClosureRequirements(tx, plan, new Map());
+    const pack = reserveNativeClosureResources(tx, physical, plan);
+    const original = legacy(input, false);
+    expect(module.types).toStrictEqual(original.ctx.mod.types);
+    expect(pack.signatures[0]!.binding).toBe(pack.signatures[1]!.binding);
+    expect(pack.metadata[0]!.binding).toBe(pack.metadata[1]!.binding);
+    expect(pack.metadata[0]!.binding.metadata.length).toBe(1);
+    expect(pack.signatures[0]!.binding.info.minimumArgumentCount).toBe(0);
+    const rows = nativeClosureReservationInventory(tx, pack, plan);
+    expect(rows.map((row) => row.key)).toEqual(plan.declarations.map((row) => row.key));
+    expect(rows).toHaveLength(2);
+    tx.freezeReservations();
+    expect(nativeClosureReservationInventory(tx, pack, plan)).toEqual(rows);
+    expect(() => nativeClosureReservationInventory(tx, pack, structuredClone(plan))).toThrow();
+    expect(() => nativeClosureReservationInventory(tx, { ...pack }, plan)).toThrow();
+  });
   it("reconstructs all original factory/body spans from complete live canonical declarations", () => {
     requireCanonicalFactoryReceipts(read("src/runtime/wasmgc/values/closure-layouts.ts"));
   });
@@ -376,7 +477,18 @@ describe("native closure identities and settlement metadata", () => {
           '{ op: "i32.const", value: typeIndex }',
           '{ op: "i32.const", value: typeIndex + 1 }',
         );
-      const mutant = replaceOnce(source, declarations[index]!, factoryHeaders[index] + "\n" + changedBody + "\n}");
+      let mutant: string;
+      if (mutation === "wrapper-construction-order") {
+        const returned = '  return { kind: "struct" as const, name, fields, parent };';
+        const header = "export function createSignatureWrapperShape<P>(name: string, parent: P) {";
+        mutant = replaceOnce(replaceOnce(source, "\n" + returned, ""), header, header + "\n" + returned);
+      } else if (mutation === "field-mutability") {
+        mutant = replaceOnce(
+          source,
+          '{ name: "bfnstate", type: { kind: "i32" as const }, mutable: true }',
+          '{ name: "bfnstate", type: { kind: "i32" as const }, mutable: false }',
+        );
+      } else mutant = replaceOnce(source, declarations[index]!, factoryHeaders[index] + "\n" + changedBody + "\n}");
       expect(mutant).not.toBe(source);
       expect(() => requireCanonicalFactoryReceipts(mutant)).toThrow(/factory donor receipt mismatch/);
     });
@@ -396,12 +508,14 @@ describe("native closure identities and settlement metadata", () => {
       else if (mutation === "constant")
         mutant = replaceOnce(source, "export const BFN_ID_FIELD_IDX = 4;", "export const BFN_ID_FIELD_IDX = 5;");
       else if (mutation === "extra-declaration") mutant = source + "export const extraFactoryState = 0;\n";
-      else
-        mutant = replaceOnce(
-          source,
-          declarations[0]! + "\n\n" + declarations[1]!,
-          declarations[1]! + "\n\n" + declarations[0]!,
-        );
+      else {
+        const firstStart = source.indexOf(declarations[0]!),
+          secondStart = source.indexOf(declarations[1]!),
+          thirdStart = source.indexOf(declarations[2]!);
+        const first = source.slice(firstStart, secondStart),
+          second = source.slice(secondStart, thirdStart);
+        mutant = replaceOnce(source, first + second, second + first);
+      }
       expect(mutant).not.toBe(source);
       expect(() => requireCanonicalFactoryReceipts(mutant)).toThrow(/suffix|factory header/);
     });
@@ -437,9 +551,21 @@ describe("native closure identities and settlement metadata", () => {
     const source = read("src/runtime/wasmgc/values/closure-layouts.ts");
     const end = source.indexOf("\nexport type ClosureAllocationMode =");
     if (end < 0) throw new Error("missing header boundary");
-    const reconstructed = source.slice(0, end).trimEnd() + "\n";
+    let reconstructed = source.slice(0, end).trimEnd() + "\n";
+    // Only accurate scalar return annotations changed in the retained header;
+    // invert those exact signatures, preserving every implementation character.
+    reconstructed = replaceOnce(
+      reconstructed,
+      'export function closureArityField(): { name: string; type: { kind: "i32" }; mutable: false } {',
+      "export function closureArityField(): { name: string; type: ValType; mutable: false } {",
+    );
+    reconstructed = replaceOnce(
+      reconstructed,
+      'export function closureBagField(): { name: string; type: { kind: "externref" }; mutable: true } {',
+      "export function closureBagField(): { name: string; type: ValType; mutable: true } {",
+    );
     const restored = reconstructed.replace(
-      'import type { Instr, ValType, FuncHandle } from "../../../wasm/model/instructions.js";\nimport type { FieldDef, StructTypeDef } from "../../../wasm/model/module-records.js";',
+      'import type { Instr, FuncHandle } from "../../../wasm/model/instructions.js";\nimport type { FieldDef, StructTypeDef } from "../../../wasm/model/module-records.js";',
       'import type { FieldDef, Instr, ValType } from "../../ir/types.js";',
     );
     expect(hash(restored)).toBe(headerDonor.sha256);

--- a/tests/issue-3518-native-promise-resources.test.ts
+++ b/tests/issue-3518-native-promise-resources.test.ts
@@ -18,6 +18,8 @@ import {
 } from "../src/backend/wasmgc/resources/native-closures.js";
 import {
   reserveNativePromiseResources,
+  declareNativePromiseResources,
+  nativePromiseReservationInventory,
   fillNativePromiseResources,
   type NativePromiseFillDependencies,
 } from "../src/backend/wasmgc/resources/native-promises.js";
@@ -106,8 +108,20 @@ function prerequisites(requests = closureRequests(), settleMetadataRequestId = "
 }
 function reserve(requests = closureRequests(), settleMetadataRequestId = "settle-meta") {
   const input = prerequisites(requests, settleMetadataRequestId);
-  const pack = reserveNativePromiseResources(input.tx, input.plan, input.dependencies);
-  return { ...input, pack };
+  const declaration = declarationFor(input);
+  const pack = reserveNativePromiseResources(input.tx, input.plan, input.dependencies, declaration);
+  return { ...input, pack, declaration };
+}
+function declarationFor(input: ReturnType<typeof prerequisites>) {
+  const metadata = input.dependencies.closures.metadata.find(
+    (row) => row.id === input.dependencies.settleMetadataRequestId,
+  );
+  if (!metadata) throw new Error("test requires genuine settlement metadata");
+  return declareNativePromiseResources(input.plan, {
+    argumentArrayKey: input.dependencies.vectors.layouts.find((row) => row.element === "externref")!.array.key,
+    closureRootKey: input.dependencies.closures.root.key,
+    settleMetadataKey: metadata.binding.type.key,
+  });
 }
 
 /** Preserve undefined, sparse arrays, maps and numeric values as well as every object identity. */
@@ -153,6 +167,135 @@ function futureReservationProbe(tx: PhysicalModuleReservations) {
 }
 
 describe("native Promise resource requirements, not whole-family materialization", () => {
+  it("rejects structural clones that lose the retained metadata field type identity", () => {
+    const a = reserve();
+    expect(nativePromiseReservationInventory(a.tx, a.pack, a.declaration)).toHaveLength(25);
+    const capture = a.pack.types.settleCapture.object;
+    if (capture.kind !== "struct") throw new Error("fixture capture struct");
+    capture.fields[0]!.type = { ...capture.fields[0]!.type };
+    expect(() => nativePromiseReservationInventory(a.tx, a.pack, a.declaration)).toThrow(
+      "lost inherited metadata field/type identity",
+    );
+  });
+  it("rejects stale original plan data after a genuine reservation", () => {
+    const a = prerequisites(),
+      mutable = structuredClone(a.plan);
+    const declaration = declareNativePromiseResources(mutable, declarationFor(a).dependencies);
+    const pack = reserveNativePromiseResources(a.tx, mutable, a.dependencies, declaration);
+    expect(nativePromiseReservationInventory(a.tx, pack, declaration)).toHaveLength(25);
+    Object.assign(mutable, { anchor: "changed" });
+    expect(() => nativePromiseReservationInventory(a.tx, pack, declaration)).toThrow("stale Promise requirements");
+  });
+  it("declares the exact 25 resources and 26 operations before any ledger exists", () => {
+    const declaration = declareNativePromiseResources(actual().plan, {
+      argumentArrayKey: "external:argv",
+      closureRootKey: "external:root",
+      settleMetadataKey: "external:meta",
+    });
+    expect(declaration.declarations).toHaveLength(25);
+    expect(declaration.reservationSteps).toHaveLength(26);
+    expect(declaration.declarations.map((row) => row.role[1])).toEqual([
+      "queue:function-array",
+      "queue:head",
+      "queue:tail",
+      "queue:capacity",
+      "queue:functions",
+      "queue:captures",
+      "queue:arguments",
+      "queue:grow",
+      "queue:enqueue",
+      "queue:drain",
+      "carrier",
+      "callback",
+      "captures",
+      "fulfill",
+      "reject",
+      "identity-fulfill",
+      "identity-reject",
+      "resolve-value",
+      "settle-capture",
+      "resolve-closure",
+      "reject-closure",
+      "peel",
+      "classifier",
+      "lookup-then",
+      "thenable-job",
+    ]);
+    expect(declaration.declarations.filter((row) => row.space === "type")).toHaveLength(5);
+    expect(declaration.declarations.filter((row) => row.space === "global")).toHaveLength(6);
+    expect(declaration.declarations.filter((row) => row.space === "function")).toHaveLength(14);
+    expect(declaration.reservationSteps[1]).toMatchObject({
+      kind: "intern-signature",
+      key: declaration.callbackSignatureKey,
+      name: "$__mt_func_type",
+    });
+  });
+  it("reconciles explicit declarations with the live implicit path and retains metadata type identities", () => {
+    const a = reserve(),
+      b = prerequisites();
+    reserveNativePromiseResources(b.tx, b.plan, b.dependencies);
+    expect(a.module).toStrictEqual(b.module);
+    const rows = nativePromiseReservationInventory(a.tx, a.pack, a.declaration);
+    expect(rows.map((row) => row.key)).toEqual(a.declaration.declarations.map((row) => row.key));
+    expect(rows).toHaveLength(25);
+    expect(rows).not.toContain(a.pack.types.arguments);
+    const capture = a.pack.types.settleCapture.object,
+      meta = a.dependencies.closures.metadata[0]!.binding.type.object;
+    if (capture.kind !== "struct" || meta.kind !== "struct") throw new Error("expected actual structs");
+    expect(capture.fields).toHaveLength(6);
+    meta.fields.forEach((field, index) => {
+      expect(capture.fields[index]).not.toBe(field);
+      expect(capture.fields[index]!.type).toBe(field.type);
+    });
+    a.tx.freezeReservations();
+    expect(nativePromiseReservationInventory(a.tx, a.pack, a.declaration)).toEqual(rows);
+    expect(() => nativePromiseReservationInventory(a.tx, { ...a.pack }, a.declaration)).toThrow();
+    expect(() => nativePromiseReservationInventory(a.tx, a.pack, structuredClone(a.declaration))).toThrow();
+    expect(() => fillNativePromiseResources(a.tx, a.pack, undefined!)).toThrow(
+      "complete native dependencies are missing",
+    );
+  });
+  it.each(["foreign", "copy"] as const)(
+    "rejects %s borrowed-tag substitution without claiming reserve-phase provenance",
+    (kind) => {
+      const a = reserve();
+      expect(nativePromiseReservationInventory(a.tx, a.pack, a.declaration)).toHaveLength(25);
+      const replacement =
+        kind === "foreign" ? prerequisites().dependencies.exceptionTag : { ...a.dependencies.exceptionTag };
+      Object.assign(a.dependencies, { exceptionTag: replacement });
+      expect(() => nativePromiseReservationInventory(a.tx, a.pack, a.declaration)).toThrow(
+        "changed borrowed exception tag association",
+      );
+    },
+  );
+  it.each(["foreign", "copy"] as const)("authenticates an initially %s borrowed tag only after freeze", (kind) => {
+    const positive = reserve();
+    positive.tx.freezeReservations();
+    expect(nativePromiseReservationInventory(positive.tx, positive.pack, positive.declaration)).toHaveLength(25);
+    const a = prerequisites();
+    Object.assign(a.dependencies, {
+      exceptionTag: kind === "foreign" ? prerequisites().dependencies.exceptionTag : { ...a.dependencies.exceptionTag },
+    });
+    const declaration = declarationFor(a),
+      pack = reserveNativePromiseResources(a.tx, a.plan, a.dependencies, declaration);
+    // Current association is known here; tag provenance is NOT yet attested.
+    expect(nativePromiseReservationInventory(a.tx, pack, declaration)).toHaveLength(25);
+    a.tx.freezeReservations();
+    expect(() => nativePromiseReservationInventory(a.tx, pack, declaration)).toThrow();
+  });
+  it.each(["type", "global", "function"] as const)("rejects a deleted %s declaration before allocating", (space) => {
+    const positive = reserve();
+    expect(nativePromiseReservationInventory(positive.tx, positive.pack, positive.declaration)).toHaveLength(25);
+    const a = prerequisites(),
+      declaration = structuredClone(declarationFor(a));
+    const index = declaration.declarations.findIndex((row) => row.space === space);
+    (declaration.declarations as unknown[]).splice(index, 1);
+    const unchanged = unchangedModule(a.module);
+    expect(() => reserveNativePromiseResources(a.tx, a.plan, a.dependencies, declaration)).toThrow(
+      "substituted Promise declaration plan",
+    );
+    unchanged();
+  });
   it("rejects an unsealed program after accepting the genuine complete program", () => {
     const { program, plan } = actual();
     const projection = program.runtime[0]!;

--- a/tests/issue-3518-native-resource-declarations.test.ts
+++ b/tests/issue-3518-native-resource-declarations.test.ts
@@ -27,6 +27,8 @@ import {
 } from "../src/backend/wasmgc/resources/native-values.js";
 import {
   executeNativeResourceRecipe,
+  executeNativeResourceRecipeWithSignatures,
+  preflightNativeResourceRecipe,
   instantiateNativeDeclaredType,
   instantiateNativeDeclaredValType,
   compareNativeResourceDeclarationShape,
@@ -49,6 +51,65 @@ function fixture() {
   const module = createEmptyModule();
   return { module, tx: new PhysicalModuleReservations(module) };
 }
+
+it("retains step order independently of declaration-list order and captures named interning once", () => {
+  const recipe: NativeResourceRecipe = {
+    declarations: [
+      { key: "second", role: ["second"], space: "type", shape: { kind: "struct", name: "second", fields: [] } },
+      { key: "first", role: ["first"], space: "type", shape: { kind: "struct", name: "first", fields: [] } },
+    ],
+    reservationSteps: [
+      { phase: "resources", kind: "reserve", resourceKey: "first" },
+      {
+        phase: "resources",
+        kind: "intern-signature",
+        key: "observed",
+        name: "callback",
+        signature: { params: [], results: [] },
+      },
+      { phase: "resources", kind: "reserve", resourceKey: "second" },
+    ],
+  };
+  preflightNativeResourceRecipe(recipe, []);
+  const old = fixture(),
+    current = fixture();
+  const intern = vi.spyOn(current.tx, "internFunctionType");
+  const oldRows = executeNativeResourceRecipe(old.tx, recipe);
+  const result = executeNativeResourceRecipeWithSignatures(current.tx, recipe);
+  expect([...result.reservations.keys()]).toEqual(["first", "second"]);
+  expect([...oldRows.keys()]).toEqual([...result.reservations.keys()]);
+  expect(current.module).toStrictEqual(old.module);
+  expect(intern).toHaveBeenCalledTimes(1);
+  expect(result.signatures.get("observed")).toBe(1);
+  expect(current.module.types[1]).toMatchObject({ kind: "func", name: "callback" });
+});
+
+it("refuses self-index metadata in the generic executor before its first reservation", () => {
+  const recipe: NativeResourceRecipe = {
+    declarations: [
+      { key: "first", role: ["first"], space: "type", shape: { kind: "struct", name: "first", fields: [] } },
+      {
+        key: "meta",
+        role: ["meta"],
+        space: "type",
+        shape: {
+          kind: "struct",
+          name: { kind: "builtin-function-metadata-index", typeKey: "meta" },
+          fields: [],
+          parent: { kind: "resource", typeKey: "first" },
+        },
+      },
+    ],
+    reservationSteps: ["first", "meta"].map((resourceKey) => ({ phase: "resources", kind: "reserve", resourceKey })),
+  };
+  expect(() => preflightNativeResourceRecipe(recipe, [])).not.toThrow();
+  const { tx, module } = fixture(),
+    before = structuredClone(module);
+  expect(() => executeNativeResourceRecipeWithSignatures(tx, recipe)).toThrow(
+    "self-indexed metadata requires the closure reservation cursor",
+  );
+  expect(module).toStrictEqual(before);
+});
 
 it.each(["params", "results", "fields", "roles"] as const)(
   "rejects late sparse %s without consuming keys or hidden ordinals",


### PR DESCRIPTION
Native async resource producers now declare closure, argument-vector and Promise requirements as pure plans before reservation. Existing authenticated producers consume those plans while preserving allocation order, signature observations, metadata identities and adopted arrays. Exact-plan inventory checks reject stale or substituted reservations.

Refreshed dependency-first onto main, preserving the delivered early-error fix and its regression tests. The boundary census accounts for seven source-verified imports; allowed edges, historical receipts and negative controls are unchanged. This is a declaration/reservation checkpoint, not a claim of complete async materialization or IR-only retirement.

Validation: 351/351 production and early-error regression tests on the refreshed composition, plus 305/305 boundary tests with unchanged boundary inputs (656 tests across nine files). Original 586/633 subprocess-error and 632/633 stale-census results are preserved in the local issue history. The boundary correction passed using an isolated temporary directory with the original assertions and 30-second child-process timeout.

All seven exact-base source gates pass: TS7, LOC/function budgets, coercion, oracle, moved-reference preservation/dead exports, and conformance synchronization.
