### PR TITLE
feat(ir): transport canonical formatter support through prepared programs

### DIFF
--- a/plan/agent-context/3518-formatter-d1-high-contract-2026-09-09.md
+++ b/plan/agent-context/3518-formatter-d1-high-contract-2026-09-09.md
@@ -1,0 +1,318 @@
+# Frozen D1 contract: index-free radix IR and typed support transport
+
+Status: High implementation specification, not claim acquisition, implementation, execution evidence, D2 acceptance or retirement proof. Written only in this High-owned scratch directory. Parent may publish and assign the named scopes after its live claim checks.
+
+## 1. Evidence and decisions
+
+Inspected production in `/private/tmp/js2-3518-native-async-integration-20260909`, observed HEAD `721cd33a828c89cfc04c851b011f910b76a4d2c5`. Independently hashed all **28** donor/evidence files in the published Maxwell census: all match its recorded bytes. Census JSON parsed-content SHA256, using `JSON.stringify(JSON.parse(text))`, is `f26c233a20bc2d1beaf0f24c06691c00b5d452022554e74d07c4778dc1ade3c0`; its formatting is not source authority. The accompanying Markdown and JSON are `plan/agent-context/3518-formatter-d1-transport-census-2026-09-09.{md,json}`. Their 17 selected-declaration receipts remain the original receipts, not a new denominator.
+
+Freeze two distinct contracts:
+
+1. **R: a nominal, index-free support-reference leaf in semantic IR.** It carries an existing structural support type reference and explicit nullability, not a physical index or formatter catalog. This is the minimal faithful representation of the radix scratch value. It is not a JavaScript vector, string, externref, anonymous object, or `val` with a fabricated index.
+2. **T: an optional, explicitly typed compiler runtime-support batch in the program handoff.** It contains the actual fully built radix IR, its closed declarations and provenance; it is jointly captured with the original allocation registry. It is not an unknown payload, slotless support intent, extra ordinary source body, or backend compilation callback.
+
+R must be usable by the genuine frontend builder before T can execute. T is a real source-to-prepared-program implementation: the existing legacy builder calls the extracted kernel, and `prepareWholeIrProgram` supplies the support batch before its single typed transaction. D1 does **not** make a formatter physical implementation exist. D2 must still declare/fill the five kernels, radix body, thunk and full formatter dependencies and wire real consumer emission. No async guard is removed in D1.
+
+This design fits the approved semantic-core/program/backend separation; it requires parent approval of this new API and scoped claims, not a new host/linear or general opaque-IR feature decision.
+
+## 2. Non-negotiable donor facts
+
+`src/stdlib/number-format.ts:51–110` contains the original `TOSTRING_RADIX_SOURCE`, 1,618 UTF8 bytes, SHA256 `7b13099fbed0a87079f92e9bddbf75959065ed28daf66d5ad344e0b240037dc6`. Its declaration receipt is `6664ed185bf6117a93ef311eefdb941b38a3feb8b8ef3ef5ef208c0dedbbb664`; `numToStringRadixDef:116–131` is `3917470d4016fb92105cdb72babb4ebe627ddc83f6addd19dbc553b49cbb99cb`. Keep source and definition bodies unchanged. Import/type-owner changes are separately checked inverse edits, not permission to reseed these hashes.
+
+One original function, `__sh_num_toString_radix(value:number, radix:number):string`. Exactly sixteen **source** calls: Math.floor four, trap one, new one, set seven, get two, fin one. Four source literal occurrences, ordered `NaN`, `Infinity`, `-Infinity`, `0`. Math.floor remains the actual existing intrinsic lowering, not a sixth support kernel. Do not claim these source counts are post-pass or executed call counts.
+
+Let B be the nullable reference to the selected string pack's mutable packed-i16 data array. The five declarations, in `calleeTypes` order, are:
+
+- new: `(f64) -> B`;
+- get: `(B,f64) -> f64`, with unsigned packed reads;
+- set: `(B,f64,f64) -> void`;
+- fin: `(B,f64) -> string`, a tight prefix copy at offset zero;
+- trap: `() -> void`, implemented by `unreachable` later.
+
+Legacy physical order is **new/get/set/trap/fin**, then radix body, then thunk. Preserve this separately from the logical declaration order. `number-format-selfhost.ts:54–148` owns the five bodies today. `emitSelfHostedToStringRadix:157–171` creates the current context-indexed B. Preserve its physical donor unchanged in D1. Its thunk is `(f64,f64)->externref`: argument0, argument1, call body, extern.convert_any.
+
+Preserve nonfinite tests, radix floor, negative zero, MAX_SAFE_INTEGER refusal, integer digit/reversal order, fractional loop and its 100-digit bound. Existing fractional non-V8-shortest behavior stays explicit. Radix is not Ryū, fixed/exponential/precision, full native ToString, or the full async formatter.
+
+## 3. R: exact semantic reference interface
+
+Add this named interface/constructor to `src/ir/core/types.ts` and add the interface to its existing `IrType` union:
+
+```ts
+export interface IrSupportRefType {
+  readonly kind: "support-ref";
+  readonly ref: IrTypeRef & {
+    readonly binding: Extract<IrTypeBinding, { readonly kind: "support" }>;
+  };
+  readonly nullable: boolean;
+}
+
+export function irSupportRef(ref: IrTypeRef, nullable: boolean): IrSupportRefType;
+```
+
+The constructor validates an actual `kind: type` reference, support binding, nonempty type-domain binding ID, and a boolean nullability. Reuse the core `requireBindingId` primitive; do not import mixed `ir/abi-bindings.ts` into core. Program ownership is validated later; the constructor's brand/prefix check is not ownership proof.
+
+No `val`, `typeIdx`, packed layout, runtime feature, provider, source object, callback or physical token is in this leaf. Formatter-specific storage/role restrictions live in the program contract below. Both nullabilities exist for faithful type operations, but **D1 admits B only with `nullable:true`**, exactly as the donor. No signature narrowing because new happens to construct a nonnull value.
+
+Equality uses support binding identity plus nullability, never `ref.name`. The semantic type key must be unambiguous and index-free: a length-delimited support binding ID and explicit nullability. `preparedIrTypeKey` must normalize this new arm consistently instead of reintroducing the display name through `preparedIrDataKey`; all old type keys remain byte-for-byte unchanged. Do not parse the encoded ID into guessed owner/role components: rederive canonical refs from the separately recorded owner and role.
+
+There is one necessary factory-owner correction: `irSupportTypeRef` and its `typeRef` helper currently live in mixed `src/ir/abi-bindings.ts`, which imports the old nodes facade. Move **those two existing function bodies** unchanged to new `src/ir/core/type-references.ts`, with canonical core types, core binding-key primitives and foundation identity imports. Preserve `irSupportTypeRef`'s old exported identity by import/reexport; all other old ABI factories call the same moved `typeRef` helper. Do not copy a second implementation into the program factory or import mixed ABI bindings into clean program/core code. Existing `irSupportFuncRef` already has a canonical core owner. This is a bounded R prerequisite, not a migration of the whole ABI module.
+
+`asVal(supportRef)` returns null. At `lowerIrTypeToValType` in `src/ir/lower.ts:4319`, use the existing `resolver.resolveType(ref)` and only then create `{kind: nullable ? "ref_null" : "ref", typeIdx: actualResolvedIndex}`. Missing/unowned/incompatible type resolution remains a failure. No second resolver API, allocator, placeholder index or index-bearing source-build type.
+
+Do not inherit generic reference-shaped leniency. Current `verify.ts:556`, branch checks around 1530, `checkDeclaredCarrier:2178`, and declared-call result checks around 2250 collapse non-val types to null/unknown. For this new arm, explicitly check full identity/nullability on returns, branch arguments and declared call arguments/results; reject support-ref slot flows as specified below. Where a support-ref participates, an absent type/declaration is not evidence of compatibility. Preserve historical conservative checks for all existing arms. D1 permits only exact identity/nullability flows; no support-ref boxing, numeric conversion, object/vector methods, unions or arbitrary reference promotion.
+
+**Actual API limits, frozen amendment:** `verifyIrBackendLegality` receives a backend, not a target. R rejects support-ref on non-WasmGC backends using that existing API; it cannot certify standalone selection. T must separately check the actual selected runtime policy is `backend:"wasmgc", target:"standalone"` before support admission, and recheck selected projection policy at replay/acceptance. No new legality flag or target argument is authorized. `IrSlotDef` in `core/nodes.ts:1775–1779` stores only physical `ValType`. R therefore rejects support-ref `slot.read`/`slot.write` or producer slot promotion; it must not extend the slot union, invent a physical index, cast the semantic reference into a slot descriptor, or silently erase its identity. The genuine unchanged radix source uses a const scratch binding expected to remain SSA. R+F must prove that actual build succeeds; if it requires a scratch slot, report a concrete blocker for a separately reviewed slot contract rather than bypassing this limit. Scalar loop slots and existing SSA-local physical allocation remain unchanged.
+
+### Exact R owner map
+
+The R worker owns these existing paths, restricted to the new arm and its rejection/identity behavior:
+
+- `src/ir/core/types.ts`: union, constructor, equality.
+- `src/ir/core/type-references.ts` (new) and `src/ir/abi-bindings.ts`: exact two-body canonical factory relocation and compatibility forwarding above; retain all other ABI declarations, private-helper order and behavior.
+- `src/ir/type-key.ts`: explicit leaf before the current boxed fallthrough.
+- `src/ir/from-ast.ts`: preserve supplied callee/local support types; explicit nullability; reject unsupported coercion. No new JavaScript source syntax or checker-name heuristic.
+- `src/ir/lower.ts`: symbolic resolution as above.
+- `src/ir/verify.ts`: support-ref-only strict joins; no waiver of existing rules.
+- `src/ir/physical-ref-support.ts`: preserve the leaf; never pass it through the legacy physical-index attachment callback.
+- `src/ir/prepared-callable-boundary.ts`, `src/ir/prepared-closure-support.ts`: explicit leaf in existing recursive type traversals; no new closure admission.
+- `src/ir/passes/monomorphize.ts`: its separate private key gains the same identity rule; existing keys unchanged.
+- `src/ir/vec-layout.ts`, `src/ir/string-carrier.ts`: their exhaustive mapType switches must return the same support leaf, not uninitialized `mapped` or a new carrier.
+- `src/ir/backend/legality.ts`: reject the new surface for non-WasmGC backends through the existing backend-only API; T owns the separate explicit standalone-policy check. No new flags/signature expansion.
+- `src/ir/fnctor-abi.ts`: concrete post-freeze scope amendment for the TS2366 exhaustive-switch failure at `validateTypeGraph` (line 76 in the inspected source). Add only an explicit `support-ref` rejection returning an explanatory diagnostic. This is not `irTypeAbiKey`; no key construction, fnctor admission, resolver or ABI contract change is authorized. Preserve all existing-arm behavior.
+- `src/ir/analysis/linear-memory-plan.ts`: explicit unsupported case in its exhaustive type-key path only. This is a fail-closed compatibility update, not new linear implementation.
+
+R does **not** own `program-abi-contracts.ts` or `prepared-component-dependencies.ts`; T owns their coordinated changes below. It does not change `ir/nodes.ts`'s old forwarding identities. The initial read-only fnctor inspection was not a whole-project typecheck; the subsequently reported concrete diagnostic authorizes only the rejection case above. Inline-small and linear-integration are not additional write targets. Any further concrete exhaustive switch diagnostic requires an exact parent scope amendment, not open-ended ownership.
+
+New R test: `tests/issue-3518-symbolic-support-ref.test.ts`. Required controls: same ID/different display name, foreign ID, nullability, wrong binding domain, physical fields absent, missing declaration/resolver, same-key clone versus actual program ownership, unconditional support-ref slot-flow rejection, branch/call/return mismatches, and real original radix lowering through the source kernel with scratch remaining SSA. Reject non-WasmGC at R; test host-gc/WASI/linear policy refusal separately at T without adding legality flags. Exercise two genuine physical type layouts with different preceding reservations to prove resolution is index-independent. That physical lowering control is not prepared-program execution or D2 completion.
+
+## 4. Source kernel and real production trigger
+
+New frontend files (one F worker):
+
+- `src/frontend/builtins/contracts.ts`: relocate the existing `SelfHostedFuncDef` interface/docs unchanged, using canonical IR types. It is frontend data, not a new backend or runtime catalog.
+- `src/frontend/builtins/build-ir.ts`: own the existing parse/lower/verify/hygiene kernel, not memoization, physical lowering or context access.
+- `src/frontend/builtins/prepare-number-format.ts`: the one genuine D1 producer using the original definition and the source preparation's allocation registry.
+
+Existing F writes: `src/codegen/stdlib-selfhost.ts` and `src/stdlib/number-format.ts`. No `number-format-selfhost.ts` or `number-format-native.ts` body edits. Move the interface/imports and call the extracted kernel from the existing `buildSelfHostedIr`; retain its export, error text, memo checks/fingerprint/template/materialization, native-string resolver adapter and all old physical callers. Radix remains non-memoized. A program-qualified support-ref is not eligible for a process-global memo merely because it lacks an index.
+
+Freeze the new frontend kernel API (all names here are proposed exports, not claims of existing APIs):
+
+```ts
+export interface SelfHostedIrBuildInput {
+  readonly definition: SelfHostedFuncDef;
+  readonly ownerUnitId: IrUnitId;
+  readonly callees: ReadonlyMap<string, IrDirectCallTarget>;
+  readonly resolver?: IrFromAstResolver; // legacy typed resolver, never CodegenContext
+  readonly allocRegistry?: AllocSiteRegistry;
+}
+export function buildSelfHostedIrBody(input: SelfHostedIrBuildInput): IrFunction;
+
+export function prepareNumberFormatRuntimeSupport(
+  source: IrProgramSourcePreparation,
+  policy: RuntimeManifestPolicy,
+): IrRuntimeSupport | undefined;
+```
+
+Use actual existing `IrDirectCallTarget`, `IrFromAstResolver`, `AllocSiteRegistry` types; the new kernel cannot import a codegen module. The compatibility wrapper supplies its existing exact direct refs and resolver. D1 supplies the closed five support targets, an actual shared registry and no context-bearing resolver. Do not derive targets from names/prefixes in the kernel. Allocation remains optional solely for unchanged historical callers, mandatory for the D1 producer.
+
+Sequence remains parse exact `stdlib/${name}.ts` -> matching declaration/arity -> existing direct-call-plan builder -> `lowerFunctionAstToIr` -> reject lifted -> verify -> at most ten `constantFold/deadCode/simplifyCFG` iterations -> verify. Pass the exact supplied registry through existing `AstToIrOptions.allocRegistry`. Add declared signatures for strict support-ref validation without altering old diagnostic ordering or introducing a second build. Do not materialize an identity-free template for D1 and then lose its allocation owner; the D1 result retains the same owner used while minting allocations. The legacy wrapper retains its old template reconstruction behavior.
+
+For this checkpoint the closed trigger is an actual canonical native-async number-to-string reference: `irNativeAsyncCallableDeclaration(ref)?.feature === "async.native.number-to-string"`, **plus** selected `wasmgc:standalone` native policy/provider demand. This uses the existing six-declaration catalog, not spelling `__ir_number_toString_native`, operand guesses, a helper export or host `js.number.box`. Scan every executable source buffer, including existing semantic async states, by canonical traversal. Revalidate against every transformed/final primary body before finalization. Do not let removing both support data and its own claimed demand vector disable the independent primary-body scan.
+
+Other formatter demand families are explicit follow-on D2/producer work, not silently authorized by this trigger. New demand discovered only after passes must produce an explicit missing-support failure, not backend parsing, a lazy callback or a second full typed transaction. This trigger is sufficient to build radix support for the existing original native-family main; it does not certify that the rest of that formatter or async consumer can execute.
+
+New F test: `tests/issue-3518-number-format-source-support.test.ts`. Reuse the actual original source and real frontend builder; preserve all original source/declaration receipts and existing memo/string/math tests. Add positive-first source/template/callee/owner/alloc-registry mutations. Verify source facts separately from the actual post-pass IR census. No manufactured caller, altered template or unconditional Math resolver.
+
+## 5. T: frozen typed transport data
+
+New pure program modules are `src/ir/program/runtime-support.ts` and `src/ir/program/formatter-support.ts`. They may import canonical core/foundation/program and existing canonical semantic catalog/analysis dependencies allowed by the approved layer, never TypeScript, frontend, stdlib source, codegen, backend resources or physical tokens. Keep declaration data separate from the frontend implementation. Do not widen boundary policy to make a mixed import pass.
+
+Use the following exact public data names/shape. `IrFunction` means canonical semantic core function, not a prepared async extension; `IrFuncRef`, `IrTypeRef`, IDs and allocation IDs are existing canonical types.
+
+```ts
+export type IrFormatterKernelRole = "new" | "get" | "set" | "fin" | "trap";
+
+export interface IrRuntimeSupportCallable {
+  readonly ref: IrFuncRef; // validator requires a support binding
+  readonly params: readonly IrType[];
+  readonly results: readonly IrType[];
+}
+
+export interface IrRuntimeSupportCallOccurrence {
+  readonly path: readonly (string | number)[];
+  readonly target: IrFuncRef;
+}
+
+export interface IrRuntimeSupportLiteralOccurrence {
+  readonly path: readonly (string | number)[];
+  readonly value: string;
+  readonly alloc: AllocSiteId;
+}
+
+export interface IrNumberFormatRadixSupport {
+  readonly kind: "number-format-radix-v1";
+  readonly sourceId: IrSourceId;
+  readonly demandOwners: readonly IrUnitId[];
+  readonly source: {
+    readonly definition: "numToStringRadixDef";
+    readonly functionName: "__sh_num_toString_radix";
+    readonly utf8Bytes: 1618;
+    readonly sha256: "7b13099fbed0a87079f92e9bddbf75959065ed28daf66d5ad344e0b240037dc6";
+  };
+  readonly scratch: {
+    readonly type: IrSupportRefType;
+    readonly storage: { readonly kind: "array"; readonly element: "i16"; readonly mutable: true };
+    readonly stringDataRole: readonly ["string-type", "data"];
+  };
+  readonly kernels: readonly [
+    IrRuntimeSupportCallable & { readonly role: "new" },
+    IrRuntimeSupportCallable & { readonly role: "get" },
+    IrRuntimeSupportCallable & { readonly role: "set" },
+    IrRuntimeSupportCallable & { readonly role: "fin" },
+    IrRuntimeSupportCallable & { readonly role: "trap" },
+  ];
+  readonly implementation: {
+    readonly declaration: IrRuntimeSupportCallable;
+    readonly body: IrFunction;
+  };
+  readonly calls: readonly IrRuntimeSupportCallOccurrence[];
+  readonly literals: readonly IrRuntimeSupportLiteralOccurrence[];
+}
+
+export interface IrRuntimeSupport {
+  readonly schema: "ir-runtime-support-v1";
+  readonly batches: readonly IrNumberFormatRadixSupport[];
+}
+```
+
+For D1 require exactly one batch when demanded; otherwise omit `runtimeSupport` entirely. Empty arrays, own-property undefined and unknown batch kinds are not alternate no-demand spellings. Keep outer prepared/codec versions unchanged; the optional field has its own closed version and old/no-demand serialization stays exact. Broader support families require additive reviewed discriminants, not `unknown`/`any` payloads.
+
+The `calls` and `literals` are **post-kernel-hygiene occurrence receipts**, regenerated and exactly compared against the actual body. Paths are own-property paths through the canonical body/instruction-buffer structure, including array ordinals; not instruction names, allocation-name matches or arbitrary substring searches. Enumerate DAG occurrences per executable position, not globally deduplicated objects. The source facts of section 2 remain an independent producer preservation obligation; do not force sixteen surviving IR calls or fabricate four live literals after transformations.
+
+Do not duplicate allocation metadata in a normalized second schema. Each literal receipt points into the **single complete program allocation snapshot**, which also contains the fin string-result allocation and all original source sites, live/aliased/retired state and metadata. Existing capture preserves unknown native payloads; existing final validator restrictions remain restrictions. No new namespace filtering, metadata dropping or relaxation of validation is permitted.
+
+`formatter-support.ts` owns a single closed factory/validator for this schema:
+
+```ts
+export function numberFormatRadixSupportDeclarations(sourceId: IrSourceId): {
+  readonly ownerUnitId: IrUnitId;
+  readonly scratch: IrNumberFormatRadixSupport["scratch"];
+  readonly kernels: IrNumberFormatRadixSupport["kernels"];
+  readonly implementation: IrRuntimeSupportCallable;
+};
+```
+
+No stored source text or TS parser belongs here. This factory is the one semantic kernel-signature authority consumed by both frontend production and independent program validation. The actual physical bodies remain D2's donor-backed responsibility. A source hash is provenance/currentness evidence under the internal compiler-data contract, not cryptographic proof against an attacker who rewrites arbitrary IR and receipts together.
+
+`runtime-support.ts` supplies `assertIrRuntimeSupport(input, support)` and `irRuntimeSupportFunctions(support)`. `input` is the narrow structural projection `{inventory, ir, derivedUnits, allocations}` from the existing typed/prepared contracts, not a legacy context; `support` is `IrRuntimeSupport | undefined`. The assertion independently derives demand owners from primary IR and validates exact support population, source anchor, refs, body/type/declaration joins, complete instruction/call/literal/allocation census and prohibited D1 attachments. The function accessor returns actual support bodies in batch order, never an artificial source module. Keep this accessor honest: it is an additional population, not a replacement for primary/async traversal.
+
+Keep this pure assertion's implementation structural: canonical traversal, closed declaration comparison, snapshot membership and provenance. It must not import mixed `verify.ts`, `program-validation.ts`, `type-key.ts`, `abi-bindings.ts`, the registry facade, or source-middleend helpers. General SSA/dominance verification and live allocation analyses remain calls in their **existing mixed T orchestration owners**, using this explicit support vector. Use the moved canonical type-ref factory and existing core callable factory. This preserves the distinction between clean data/structural validation and still-unmigrated full preparation implementation.
+
+### Identity rules
+
+Anchor the batch at the one actual inventory source with `kind:"entry"`, as existing `preparedIrRuntimeAbiAnchor` does. Demand owners are distinct real source/derived owner IDs in canonical body order; resolve them through existing source/derived ancestry, not encoded-ID parsing. Recompute the vector after async transformation/optimization; the original source ownership still resolves through that ancestry.
+
+Factory roles, all ordinal zero, are frozen:
+
+- body unit ID: `createDerivedIrUnitId({parentId: sourceId, role: "runtime-support:number-format-radix", ordinal: 0})`;
+- scratch ref: `irSupportTypeRef(sourceId, "number-format-radix:scratch", "__nfd_buffer")`;
+- kernel refs: `irSupportFuncRef(sourceId, "number-format-radix:" + role, exactDonorName)` for the five closed roles;
+- body callable ref: `irSupportFuncRef(sourceId, "number-format-radix:body", "__sh_num_toString_radix")`.
+
+The body unit ID is validated by this **support** contract. It is not inserted in ordinary `inventory`, `derivedUnits`, `units`, startup, or `ir.functions`; do not use `irUnitFuncRef`/unit-callable ID for its ABI entry. No `@compiler/stdlib-selfhost` fake source or terminal. Global/class/closure/async/generator attachments on this D1 body are rejected. Source five-owner and transformed sixteen-function/thirty-three-call counts retain their original scopes; report support body/kernel/source-occurrence counts separately.
+
+**Exact identity amendment, confirmed after the initial freeze:** `src/shared/contracts/ir-identity.ts:27–32` currently has a closed `IrSyntheticUnitRole` union and does not include this body role. T owns one additional foundation edit: append the single literal `"runtime-support:number-format-radix"`. Do not cast it, reuse a false `stdlib-selfhost` role, or widen to `runtime-support:${string}`/`string`. `CreateDerivedIrUnitIdInput.parentId` already accepts `IrSourceId`; no input-domain change is needed. `src/shared/contracts/identity-values.ts:15–17` already encodes the role and validates its ordinal; its implementation is unchanged and it has no runtime role-enumeration guard to extend. This new literal identifies a support body, not permission to insert it into ordinary derived/source population. T's support validator must reject such contamination, including a matching counterfeit ordinary derived record.
+
+The storage role is the actual `declareNativeStringLiteralTypes` role `["string-type","data"]`, whose canonical recipe uses `createStringDataType()`. D2 must reconcile it with the actual selected issued string pack and complete declaration, not construct another same-shaped but independently required type. Select one canonical ABI required root, or an explicitly compatible alias to an existing root, before reservations. Two required entries later interned onto one token are not a valid alias proof. D1 does not import the backend recipe into pure program validation.
+
+## 6. T transaction, allocations, ABI and codec integration
+
+The following are the **eleven existing T paths**, now explicitly released by P for these changes in a separate worktree:
+
+1. `src/ir/program/input-contracts.ts`: add optional `readonly runtimeSupport?: IrRuntimeSupport`.
+2. `src/ir/program/prepared-contracts.ts`: same optional finalized typed field; keep candidate and prepared schemas distinct.
+3. `src/ir/program/input.ts`: add the optional allowed key, dense/exact shape checks, and joint copy/restore. No supplied prepared async attachments inside support functions.
+4. `src/ir/program-preparation.ts`: after successful real source preparation and before capture, call the new frontend producer exactly once. Enforce explicit standalone-WasmGC policy before admitting its batch; backend-only legality is insufficient. Then capture, resolve controls, enter the existing single typed transaction/finally counter path, and observe only a successful prepared result. Preserve existing policy failures and original thrown-error identity; do not wrap unrelated errors or double count failed preparation.
+5. `src/ir/program-prepare-ir.ts`: carry support through each object reconstruction and the **same semantic freeze before runtime attachment authentication**. Validate explicit standalone-WasmGC policies and initial/final primary-demand joins even when the caller directly supplies typed input, bypassing the historical wrapper. Keep support bodies on their inherited self-host CF/DCE/CFG pipeline; do not silently feed them through ordinary source inlining/GVN or add fake source units. Run the required final allocation analyses for their real string sites with resolved existing controls, then freeze them jointly. Existing source GVN counters/failure/finally behavior remains unchanged.
+6. `src/ir/program-abi-contracts.ts`: accept the optional batch, normalize new support-ref keys (including the recursive support-ref case of `preparedIrDataKey`) and add exact support type/callable entries, including support `sourceId` ownership. All old-arm keys remain unchanged. No changes to the ABI class or generic catalog.
+7. `src/ir/program-validation.ts`: independently validate support population and each function using the full declared-signature table. Reuse body call/global/provenance validation over the separate support vector, with its own exact callable owner rather than a unit-callable lookup. Do not put support bodies into the primary `functions` map used for startup/population. Primary validation remains unchanged in scope.
+8. `src/ir/program-allocations.ts`: additional support-body traversal and metadata analysis, preserving every original primary and async-state traversal, snapshot size/state/alias/namespace checks and source references.
+9. `src/ir/program-codec.ts`: shape-check and explicitly include support in `reauthenticatePreparedIrProgram`'s reconstructed result (currently lines 432–445), then complete validation. No TS rebuilding on decode, no opaque field silently retained only by generic JSON encoding. Re-encode exact canonical bytes and retain all current special-value/alias rules.
+10. `src/ir/prepared-component-dependencies.ts`: record support type references and the complete separate support-body dependencies. Preserve old raw-ref handling and existing callable/type dependency failures. This is the shared R/T join owned solely by T.
+11. `src/ir/program-source.ts`: only `captureTypedIrProgramInput(source, runtimeSupport?)` and its explicit projection change. Include the batch in the existing `allocations.capturePreparationData(...)` graph. Do not append an independently cloned batch or change source lowering/options here.
+
+`program/data.ts`, the registry's capture/restore implementation, `program-population.ts`, startup, async schema/attachment/codec authority, canonical ABI class and global runtime declaration catalogs are not new write targets. No new prepared-closure or P schema-v2 transport is adopted. Any genuine newly discovered requirement must be named for parent scope reconciliation before editing it.
+
+The single-literal edit in `src/shared/contracts/ir-identity.ts` is an explicit **additional T-owned path outside the eleven released P paths**, requested and approved for this contract; it is not a wider P release or an R/F ownership transfer. Add to existing `tests/issue-3521-pure-identity-values.test.ts` an actual canonical source-parent/new-role/ordinal-zero output assertion while retaining both old controls and public re-export identity. Add a compiler-checked closed-role control (new literal accepted, misspelled sibling/general runtime-support string rejected without a cast) and source-free support replay/foreign-role negatives in T's tests. No new global runtime role validator or identity factory is required.
+
+Allocation sequence: source lowering first; support lowering against that same live registry next; one joint capture/restore; inherited support hygiene already complete; final source/support analysis; one semantic freeze/snapshot; runtime attachment producer authenticates final existing primary identities. No authenticated attached object is cloned afterward. Actual static producer accounting is four literal sites plus fin's string-result allocation; post-pass registry state must explain any retirement/alias. `__nfd_new`'s internal Wasm allocation is not a fake semantic object/JS-vector site: `AllocKind` excludes black-box builtin internals.
+
+ABI order: keep all old non-runtime entries in their original relative order. Insert D1 support entries **before the canonical runtime tail** in this fixed order: scratch type, new/get/set/fin/trap kernel callables, body callable. Their source-order/declaration-order slots use the same existing counter/entry anchor. This adds seven typed entries, not seven source units. Update complete runtime-order reconstruction accordingly: `validateRuntimeCallables` currently calculates its tail start by counting all non-runtime entries at the anchor. Appending support after the tail but leaving that calculation unchanged is wrong. The canonical runtime formatter entry keeps its existing owner-free declaration; do not add support source ownership to it. All no-demand entry vectors remain exact.
+
+Prepared support type/callable entries use real required type/function slots, except an explicitly validated compatible alias selected by the later physical plan; never `kind:support` slotless intents as executable authority. Keys/signatures come from the one semantic factory, not body usage guesses. Supplemental physical kernel/thunk/local-type recipes are D2 and must reconcile to these entries before the same ABI plan seals and the same module ledger reserves/freezes/fills.
+
+### Exact type-ownership and dependency-caller amendment
+
+`ProgramAbiIntent`'s type arm is exactly `{kind:"type", shapeKey}`; do not add `sourceId` or edit `src/ir/program/abi.ts`. The six callable intents use their existing `sourceId` field. Scratch type ownership is a program-validation proof: derive the actual entry-source anchor independently, rebuild its canonical formatter declarations, and compare the scratch binding ID, structural reference key, complete semantic type/nullability/shape key, required type slot and exact support-group order. Validate the seven support entries before the runtime tail. A matching shape or numeric source order alone is insufficient; foreign binding/source substitution, alias/slotless replacement and reordered entries must fail. The generic ABI class is not claimed to independently authenticate type-source ownership.
+
+The two current production calls to `derivePreparedComponentDependencies` are in `prepared-component-sealing.ts` (624 in the inspected tree) and `compiler-timer-shim-preparation.ts` (367). They are legacy source-terminal/physical-readiness paths, not T's whole-program transaction. Do not expand those callers or append support bodies to their module/terminal populations. Logical strings in D1 do not yet satisfy that collector's physical carrier requirements.
+
+Within the already T-owned `src/ir/prepared-component-dependencies.ts`, keep the explicit support-ref arm for existing component callers and add a separate proposed export:
+
+```ts
+export function assertPreparedIrRuntimeSupportDependencies(
+  input: Pick<PreparedIrProgram, "inventory" | "runtimeSupport" | "abi">,
+): void;
+```
+
+This assertion traverses actual separate support bodies and their declared signatures, not only stored occurrence receipts. Reconcile every explicit symbolic type/callable reference with the validated ABI, including parameter/result types, block argument types, nested instructions and their type/reference fields. Reject unsupported dependency-bearing forms rather than ignoring them. Use the canonical formatter factory, not a second signature catalog. Keep semantic string/allocation requirements distinct from unfulfilled D2 physical carrier/materializer readiness; existing structural support, allocation and full SSA checks remain mandatory. No fake terminal, physical index or all-clear physical component report is produced.
+
+The only new production caller is already T-owned `src/ir/program-validation.ts`: call this assertion after structural support and exact support ABI-entry reconciliation. `prepareTypedIrProgram`, codec reauthentication and backend admission already call `assertPreparedIrProgram`, so they reach the same check. No existing production path outside T's eleven requires a caller edit. Keep old component input/report shapes and no-support verdicts unchanged. Add the genuine-radix positive and missing/foreign type or callable, wrong shape/nullability/order, nested-reference and codec mutation controls in the already owned runtime-support transport/codec tests. A local static import/export projection of the current dependency module found 15 runtime modules, no listed frontend/codegen/from-ast path and no unresolved static specifier; this is not universal closure or an executed source-free test.
+
+## 7. Ownership, ordering and real parallel work
+
+Read and verified P's actual `.tmp/3527-p-handoff.md` first section on 2026-09-09. It explicitly releases the above eleven current paths **after this High freeze, in another worktree**, for typed support, once-only frontend production, joint allocation capture, existing ABI and codec validation. Paused P HEAD is `6037ac8bcf07be4f71839cea33cf8c90ecc87f94`; its twelve source drafts remain untouched. This is a scoped release, not absence of file overlap or permission to overwrite old P schema-v2 work. Other live claims still require parent checking.
+
+Do not touch the current Hilbert declaration lane's seven production files: native-resource-declaration-types, native-resource-declarations, closure-layouts, argument-vector-bodies, native-closures, native-argument-vectors, native-promises; or its five tests. D1 scratch storage records are semantic contracts, not an excuse to alter that physical recipe lane. No C consumer/physical-plan implementation is included here.
+
+Dispatch order:
+
+1. R and F can work in disjoint isolated trees after parent claim checks. F may extract/verify the genuine legacy build kernel and preserve all existing callers while R lands the new leaf; no fake replacement type for pending R. Their joined original-radix positive is mandatory before declaring R usable.
+2. T's owner can implement the two pure contract modules, schema/codec controls and source-free harness against these exact interfaces concurrently; its released eleven-file production integration consumes R+F only after their frozen hashes. F does not edit the eleven T paths. T alone integrates the real wrapper trigger, ABI insertion and dependency join.
+3. Parent composes the frozen sources, exact original receipts and mandatory actual roots; runs scoped type checks and preservation suites, then fresh-process original/decoded preparation. Publish a bounded D1 checkpoint with explicit D2 physical refusal if that is still the actual next boundary. Do not label it full formatter acceptance.
+4. D2 physically reserves/fills donor-backed scratch kernels/body/thunk and the remaining formatter resources through the existing one ABI/ledger; parent wires real consumer dispatch and tests full formatter/native family. No new unused helper checkpoint should stand in for this dependent execution obligation.
+
+## 8. Tests and preservation contract
+
+T owns new tests:
+
+- `tests/issue-3518-runtime-support-transport.test.ts` — real whole-source original family plus no-demand controls; separate source/support populations, canonical refs/signatures/ABI order, global/startup/source-owner preservation.
+- `tests/issue-3518-runtime-support-codec.test.ts` — actual encode/decode/re-encode, body/callee/literal/allocation identity and values, canonical reconstruction failures.
+- `tests/helpers/runtime-support-source-free.mjs` and `tests/issue-3518-runtime-support-source-free.test.ts` — nonempty prepared/decoded support input, guarded fresh process, no TypeScript/ts-api/frontend/from-ast/stdlib/codegen loads; real complete validator. Not an emission claim while D2 is missing.
+
+Parent-owned additive gate/receipt work is limited to the existing compiler-boundary policy/test and existing preservation ledgers actually affected by R/F/T. Keep all original active roots/history, allowed edges, N1 six/full-cut, core ten/full-cut, twelve execution witnesses and strict unknowns unchanged. New canonical modules must be mandatory, with deletion/import-type/type-query/barrel/runtime forbidden-edge negatives; classify mixed existing wrappers as existing debt. New exported function preservation needs real frontend/typed-program call paths, not class visitation or test-only fake callers. No baseline budget edits/growth credit. If a historical receipt touches changed bodies, use a checked exact relocation/inverse delta and retain the original hash/order/count rather than replacing it with a new snapshot.
+
+Mandatory positive-first negative controls, across R/F/T:
+
+- Exact genuine template/definition first, then altered source/callee order/signature/name/target/missing trap; all five declared roles and all sixteen source call occurrences remain counted independently.
+- Wrong source anchor, foreign support ID, absent/reordered/duplicate kernel, wrong B nullability, width/mutability/string-data role, changed fin return, unknown callable, fabricated raw-index type, injected async/global/closure attachment.
+- Real support body and complete source demand first; deletion of batch, deletion of both batch and its own demand receipt, or equal visible foreign owner still fails independent primary-demand reconciliation.
+- Call target/result/argument, branch/slot/return mismatch; removed literal, changed literal value, missing/shared-foreign allocation, stale alias/retired/live metadata or extra unsupported namespace retains exact existing error behavior. Joint capture preserves actual aliases/unknown values before final admission; never silently filter them.
+- Codec payload mutated at each support field; canonical bytes and no-demand roundtrip unchanged; no TS parsing/compile retry during replay. Symbolic scratch IDs survive changed physical reservation offsets without hidden index rewriting.
+- One build/transaction/observer and original error identity, including failure; no new ambient option reads or double GVN accounting. Support hygiene order remains the donor order.
+
+Use the actual `tests/issue-3305.test.ts` inputs as historical formatter controls, but not its permissive dummy-import construction for standalone execution acceptance. D2 must execute the actual prepared radix/full formatter on original and decoded programs, repeated instances, exact values/traps/binaries/WAT/resource order and empty UTF16 resource behavior; UTF8 policy is not inferred from the four ASCII literals. Preserve inherited fractional differences separately. Full original async-family acceptance still requires real timers70/3e9, sequential/reverse Promise.all/rejection, formatted output, void/undefined, complete selected-state/spill traversal and authentic native value/object/closure dependencies.
+
+## 9. Remaining limits
+
+### Bounded existing native-family fixture amendment
+
+T may add `tests/helpers/native-family-runtime-support.ts` with the explicit helper `captureNativeFamilyRuntimeSupport(source: IrProgramSourcePreparation, policy: RuntimeManifestPolicy): TypedIrProgramInput`. It calls the real `prepareNumberFormatRuntimeSupport(source, policy)` exactly once, requires the one demanded batch, and then calls `captureTypedIrProgramInput(source, support)` once on that same source/registry. No policy defaults, repair-on-replay, hand-built IR, name-based demand, global memoization or independent support clone. The helper runs only on the frontend side of transport.
+
+The source-grounded existing test write map is exactly: `tests/issue-3518-native-promise-resources.test.ts` (its full-family prepare helper); `tests/issue-3518-native-vector-resources.test.ts` (its full-family prepare helper); and `tests/issue-3518-native-family-source-contract.test.ts` (the typed original/decoded native-policy matrices and fresh-process packet construction). Keep source-only capture/identity controls source-only. Deliberately omitted-native-policy tests must start from a valid support-bearing packet produced with an explicit native policy, then pass the unchanged deficient options to typed preparation; preserve the exact existing located policy refusal. Do not substitute a missing-support failure for it. Preserve both source variants, GVN modes, replay forms, primary 5/22 and transformed 16/33 populations and every allocation; report support separately.
+
+Do not change generic `tests/helpers/typed-program-fixtures.ts`, delay-only callable replay/certified-delay fixtures, ordinary string-number fixtures, or public/historical compiler fixtures merely to populate support. Those inspected paths do not carry the formatter demand. Do not load the new frontend helper inside a source-free child; serialize its complete result first and retain the existing child import guard unchanged. Existing T transport/codec tests retain their direct genuine producer route and positive-first missing-batch/deleted-demand controls. Add a genuine raw family source/capture without support as an explicit missing-support negative; never make absence a compatibility success. New dependencies exposed after valid capture remain failures, not permission to prune support allocations or alter resource expectations.
+
+No tests, compiler runs or physical executions were performed for this specification. The exact source and declaration hashes were read/compared; static type-consumer inspection is not universal checker/graph closure. Additional concrete exhaustive switch failures require named ownership changes. Codec internal-IR validation is not authentication against deliberately fabricated hostile live JavaScript objects. No provider authorization is inferred from a name or source hash.
+
+D1 closes two actual source/transport blockers while preserving separate source and support authorities. It does not complete D2/Ryū, full formatter physical resources, native async materialization/public default cutover, host/linear migration, the ABI30 missing planningSealed public witness, or direct-codegen retirement. Existing unknown-closure failures and holds remain.

--- a/plan/agent-context/3518-runtime-support-transport-progress-2026-09-09.md
+++ b/plan/agent-context/3518-runtime-support-transport-progress-2026-09-09.md
@@ -1,0 +1,43 @@
+# Formatter runtime-support transport integration
+
+Status: uncommitted integration in `codex/3518-runtime-support-transport-20260909`, based on `721cd33a828c89cfc04c851b011f910b76a4d2c5`. Not full formatter execution, async materialization, ABI30 completion, public cutover, or retirement.
+
+Composed the frozen R/F implementation from `/private/tmp/js2-3518-symbolic-support-ref-20260909/.tmp/symbolic-support-ref-r2-validation.json`. All 26 recorded R/F/T dependency hashes matched after composition. The R/F worker's final run was 30/30 and TS7 exited zero; those results cover the real radix SSA build and source producer, not this whole transport integration.
+
+T now builds support once before joint capture, retains it through the existing semantic freeze and codec reconstruction, independently reconciles primary demand, validates the separate body and allocation population, and adds seven required ABI entries before the runtime tail. The support body never enters ordinary inventory, derived units, startup, or primary functions. Missing support is a failure even when its own demand receipt is removed.
+
+Parent validation receipts, all terminal:
+
+- `37713`, exit 0: 16/16 across transport (7), codec (4), guarded fresh-process replay (2), and identity (3), 22.80 seconds.
+- `68757`, exit 0: TS7 with `--noEmit -p tsconfig.ts7.json`.
+- `90298`, exit 0: 109/109 across native-family source contract (45), Promise resources (33), and vector resources (31), 40.52 seconds. Original policy-refusal diagnostics and primary 5/22 -> 16/33 populations remain tested.
+
+Heavy commands used one Vitest fork and 2 GiB limits; TS7 used GOMEMLIMIT=2GiB and GOMAXPROCS=1. No heavy process remains from these parent invocations.
+
+The subsequent High amendment added no ABI schema or legacy caller changes. `assertPreparedIrRuntimeSupportDependencies` now traverses actual support body/signature fields from the existing complete program validator, rejects unsupported and physical reference forms, and reconciles canonical dependencies against required ABI declarations. Session `7107` exited 0: 17/17 across transport (11), codec (4), and source-free replay (2), 24.13 seconds. Four new controls independently remove type/callable declarations or introduce a nested foreign reference/physical index while retaining original occurrence receipts. The preceding dependency-join smoke session `40669` passed 9/9 on the earlier test population; it does not cover those four added controls.
+
+TS7 sessions `99588` and `59936` exited 1 on binding-union narrowing. The final fix uses an explicit local binding and terminating guard, then captures its ID before the callback. Session `4660` exited 0. The canonical core/program modules are now mandatory in the boundary policy with additive history and unchanged allowed edges; classification of the newly extracted frontend wrappers still needs its reviewed disposition and executed boundary verification.
+
+The dependency review found that canonical callable membership alone did not authorize a literal materializer field. D1 now rejects any own storage/materializer attachment on support literals. A genuine literal mutated with the canonical `new` kernel is rejected through both complete program validation and codec reauthentication. Additional real-packet controls cover foreign anchors, kernel order/duplicates, nullability, storage width, missing literal receipts and retired allocations.
+
+After formatting all 47 source/test paths (`18508`, exit 0), session `69266` exited 0: **167/167 across nine suites**, 64.72 seconds. This combines R20, F10, transport18, codec5, source-free2, identity3, native-family45, Promise33 and vector31 on the formatted implementation. The earlier expanded transport run `15405` passed 25/25 before that formatting.
+
+Boundary activation required a measured correction: the checker enforces every file assigned to an active layer, irrespective of its unmigrated state. Contracts-only frontend activation therefore exposed pre-existing dependencies in 17 of the 20 existing frontend debt files. High approved changing exactly those 17 layer labels to mixed-needs-split with destination frontend-ts, retaining all unmigrated states and existing owner/next-boundary text. Divergence-classifier, node-capability-map and ts-api remain unchanged. All previous active history and allowed edges remain intact. Inventory audit `43404` exited 0 with zero errors and **architectureComplete:false**. Earlier failing audit `75317` is retained as the activation diagnosis, not ignored. Targeted boundary run `18519` passed 17 with 42 explicitly filter-skipped; the subsequent complete boundary suite is not yet recorded here.
+
+Complete boundary retry `5497` passed 64/64 in 31.19 seconds. The first complete run `6867` had 60/64 because four newly added fixtures omitted their contracts-only root and mixed-debt owner metadata; diagnostic run `21108` confirmed those setup errors, and focused retry `79871` passed 4/4 before the complete rerun. No detector implementation or allowed edge was changed to resolve these fixture failures.
+
+Preservation gate `12667` exited 0 under the explicitly approved preservation-only contract: 12/12 core-node executed callers, 10/10 core-type full/cut references, and 6/6 moved source witnesses in both views. The strict graph remains OPEN on the original nonliteral imports in optimize.ts and platform-capability-adapter.ts; retirement/deletion is NOT certified. Final post-format TS7 `80148` exited 0.
+
+Older builtin run `67058` exited 0: 19/19 across five suites in 20.84 seconds, including generalized self-hosting, host/standalone timsort, cache identity, and the original standalone/WASI radix cases. These are preservation controls, not execution of the new prepared D2 formatter.
+
+Final Astra High static review approved the non-draft D1 semantic-support checkpoint, including the exact 17 debt classifications, unchanged prior history/allowed edges, and complete-validator materializer rejection. Reviewed source/test manifest SHA-256: `d989f81cb02d9dd1ea1d47879a076d8daf7bf17419fb93825c9fa1ace4fbe628`; policy SHA-256: `f3b8b58050c85d9018cd135e3d4a4b6dbb09c2b1fed0f286c91fb1fa4602e42d`. The earlier pending-classification and pending-boundary notes above describe intermediate states; the subsequent review and 64/64 receipt supersede them.
+
+Still required before publication: normal commit/push hooks and a non-draft PR on loopdive/js2. D2 physical formatter emission remains required afterward.
+
+Normal commit attempt `96236` exited 1 on Biome `noVoidTypeReturn` in the dependency visitor. Replaced `return invalid(...)` with a block that calls the same throwing helper then returns without a value. No validation policy changed. Post-amendment TS7 `13215` exited 0; normal hooks must still pass on retry.
+
+Normal commit retry `65612` passed formatting, lint and the file-size budget but exited 1 at the function-size budget: `verifyInstrTypeRules` measured 317 lines and `lowerVarDecl` 305, both above 300. Applied the implementation subagent's helper extraction (`0172f51be673f10eff4add10f365897b000cc9e22f8618c4a7972a457f9e2f92` patch SHA-256): `checkSupportRefFlow` preserves the instruction guard order and diagnostics; `resolveMutableLocalRepresentation` preserves widening, rejection and resolver behavior. No budget allowance or gate changed. Post-refactor review, tests and hook retry remain required.
+
+Post-refactor function-budget run `93371` exited 0. Scoped verification `96167` exited 0: **55/55 in five suites**, 32.62 seconds, covering symbolic support references (20), genuine source support (10), transport (18), codec (5), and fresh-process source-free replay (2), with no skips. These runs supersede the corresponding pending checks above; final TS7, amendment review and normal hooks remain pending at this writing.
+
+Final post-refactor TS7 `51116` exited 0. Astra High approved the applied helper extraction and lint guard as semantically equivalent, retaining D1 publication approval. Verified SHA-256: verify.ts `fd73abfc7adb62789a1a794ace44f007baa53a141e946a98ebaeb20f23adfd0a`; from-ast.ts `d887bbd1dc61d68fdefedd665ce2eb409af28d0336f03960cdd30d058f1392d3`; dependency validator `0ea7a1b7d7ce5bf0a035d8b3a4c9c5a65aabd841ddd3c7a7c10bf82b11c9b8a7`. Normal commit/push hooks and publication are the remaining D1 handoff steps.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6787,3 +6787,33 @@ agent-context/3518-native-async-resource-declarations-spec-2026-09-09.md;
 the frame API and object-access donor map are also preserved for the next lanes.
 This composition does not remove the async acceptance refusal or establish
 native async execution, public default cutover or retirement.
+
+### Formatter semantic support transport checkpoint (2026-09-09)
+
+The formatter prerequisite now builds the unchanged radix source into real,
+index-free IR using the source program's allocation registry. A separate typed
+support batch survives preparation, ABI registration, validation and codec
+replay without being inserted into ordinary source populations. The original
+legacy self-hosted builder calls the same extracted frontend kernel.
+
+After composition and formatting, parent run 69266 passed 167/167 across nine
+source/transport/resource suites. Full boundary run 5497 passed 64/64; inventory
+run 43404 reported zero errors and architectureComplete:false. Source-free
+replay and its deliberately forbidden frontend-import control both passed.
+The reviewed materializer-use-site hole is fixed with complete validator and
+codec rejection tests using an actual canonical kernel reference.
+
+The four clean module activations retain all earlier active history and allowed
+edges. Exactly 17 already-unmigrated frontend files now carry mixed-needs-split
+layer labels with their frontend destination; three other existing frontend
+debt classifications remain unchanged. This is explicit migration debt, not
+whole-frontend closure. See agent-context/3518-formatter-d1-high-contract-2026-09-09.md
+and agent-context/3518-runtime-support-transport-progress-2026-09-09.md.
+
+Final preservation gate passed its 12 executed callers, 10 core-type references
+and six moved-function witnesses under the approved preservation-only contract;
+the two known dynamic imports still prevent strict closure. Post-format TS7
+passed, and the older self-hosted builtin suites passed 19/19. Normal publication
+checks remain in progress.
+Physical radix kernels, full formatter materialization, native async execution,
+public default cutover, ABI30 and direct-codegen retirement remain open.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -65,10 +65,10 @@
     },
     {
       "id": "frontend-ts",
-      "status": "planned",
-      "roots": ["src/frontend/ts"],
+      "status": "active",
+      "roots": ["src/frontend/builtins/contracts.ts"],
       "required": true,
-      "entries": ["src/frontend/ts/index.ts"],
+      "entries": ["src/frontend/builtins/contracts.ts"],
       "minModules": 1
     },
     {
@@ -93,9 +93,10 @@
         "src/ir/core/intrinsics.ts",
         "src/ir/core/callable-bindings.ts",
         "src/ir/core/async-callables.ts",
-        "src/ir/core/vector-runtime.ts"
+        "src/ir/core/vector-runtime.ts",
+        "src/ir/core/type-references.ts"
       ],
-      "minModules": 17
+      "minModules": 18
     },
     {
       "id": "ir-analysis",
@@ -167,9 +168,11 @@
         "src/ir/program/native-vector-resources.ts",
         "src/ir/program/native-promise-resources.ts",
         "src/ir/program/native-value-resources.ts",
-        "src/ir/program/native-string-value-demands.ts"
+        "src/ir/program/native-string-value-demands.ts",
+        "src/ir/program/runtime-support.ts",
+        "src/ir/program/formatter-support.ts"
       ],
-      "minModules": 16
+      "minModules": 18
     },
     {
       "id": "runtime-contracts",
@@ -472,6 +475,21 @@
     }
   ],
   "activationHistory": [
+    {
+      "layer": "frontend-ts",
+      "entries": ["src/frontend/builtins/contracts.ts"],
+      "minModules": 1
+    },
+    {
+      "layer": "ir-core",
+      "entries": ["src/ir/core/type-references.ts"],
+      "minModules": 1
+    },
+    {
+      "layer": "ir-program",
+      "entries": ["src/ir/program/runtime-support.ts", "src/ir/program/formatter-support.ts"],
+      "minModules": 2
+    },
     {
       "layer": "native-runtime",
       "entries": [
@@ -1307,6 +1325,27 @@
   ],
   "files": [
     {
+      "path": "src/frontend/builtins/contracts.ts",
+      "state": "clean",
+      "layer": "frontend-ts"
+    },
+    {
+      "path": "src/frontend/builtins/build-ir.ts",
+      "state": "unmigrated",
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate the existing mixed from-ast, direct-call planning, verifier and hygiene dependencies. The broader src/frontend/ts/index.ts boundary remains unfulfilled; contracts-only activation does not certify this implementation."
+    },
+    {
+      "path": "src/frontend/builtins/prepare-number-format.ts",
+      "state": "unmigrated",
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate the existing mixed source-preparation type and stdlib template dependencies from the canonical typed support producer. The broader src/frontend/ts/index.ts boundary remains unfulfilled."
+    },
+    {
       "path": "src/runtime/wasmgc/values/closure-layouts.ts",
       "state": "clean",
       "layer": "native-runtime"
@@ -1383,6 +1422,16 @@
     },
     {
       "path": "src/ir/program/native-string-value-demands.ts",
+      "state": "clean",
+      "layer": "ir-program"
+    },
+    {
+      "path": "src/ir/program/runtime-support.ts",
+      "state": "clean",
+      "layer": "ir-program"
+    },
+    {
+      "path": "src/ir/program/formatter-support.ts",
       "state": "clean",
       "layer": "ir-program"
     },
@@ -1717,6 +1766,11 @@
       "layer": "ir-core"
     },
     {
+      "path": "src/ir/core/type-references.ts",
+      "state": "clean",
+      "layer": "ir-core"
+    },
+    {
       "path": "src/ir/core/fnctor-shapes.ts",
       "state": "clean",
       "layer": "ir-core"
@@ -1779,12 +1833,18 @@
     {
       "path": "src/checker/binder.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/builtin-shadow.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/divergence-classifier.ts",
@@ -1794,32 +1854,50 @@
     {
       "path": "src/checker/dts-entrypoint-seeds.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/index.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/inhouse-globals.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/inhouse-oracle.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/language-service.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/multi-file-paths.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/node-capability-map.ts",
@@ -1829,32 +1907,50 @@
     {
       "path": "src/checker/oracle-backend.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/oracle-declaration-snapshot.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/oracle.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/ts5-trace.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/type-mapper.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/checker/usage-inference.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts"
+      "layer": "mixed-needs-split",
+      "destination": "frontend-ts",
+      "owner": "3518-coordinator",
+      "nextBoundary": "Separate existing TS-wrapper, module-resolution and mixed identity/type/planning dependencies before frontend closure. This file was already unmigrated before the contracts-only frontend activation; no source behavior changed."
     },
     {
       "path": "src/cjs-rewrite.ts",
@@ -10307,9 +10403,10 @@
     {
       "path": "src/ir/planning-sites.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts",
+      "layer": "mixed-needs-split",
       "owner": "3518-coordinator",
-      "nextBoundary": "Source-bound AST identity validation shared with the legacy overlay; not a pure IR contract or physical runtime owner. Relocate under frontend/ts with its planning identity dependencies before frontend retirement."
+      "nextBoundary": "Source-bound AST identity validation shared with the legacy overlay; not a pure IR contract or physical runtime owner. Relocate under frontend/ts with its planning identity dependencies before frontend retirement.",
+      "destination": "frontend-ts"
     },
     {
       "path": "src/ir/planning-identity.ts",
@@ -10522,16 +10619,18 @@
     {
       "path": "src/ir/program-logical-types.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts",
+      "layer": "mixed-needs-split",
       "owner": "3518-coordinator",
-      "nextBoundary": "Checker-bound logical vector facts for original source nodes; relocate under frontend/ts with source preparation before retirement. No physical type authority or pure IR closure claim."
+      "nextBoundary": "Checker-bound logical vector facts for original source nodes; relocate under frontend/ts with source preparation before retirement. No physical type authority or pure IR closure claim.",
+      "destination": "frontend-ts"
     },
     {
       "path": "src/ir/program-native-async-source.ts",
       "state": "unmigrated",
-      "layer": "frontend-ts",
+      "layer": "mixed-needs-split",
       "owner": "3518-coordinator",
-      "nextBoundary": "Original-AST native async family certification and logical lowering plans; relocate under frontend/ts with planning identity before retirement. Keep runtime declarations and physical providers separate."
+      "nextBoundary": "Original-AST native async family certification and logical lowering plans; relocate under frontend/ts with planning identity before retirement. Keep runtime declarations and physical providers separate.",
+      "destination": "frontend-ts"
     },
     {
       "path": "src/ir/program-observation.ts",

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -61,9 +61,9 @@
  * tail statement in the IR subset (`lowerTail`).
  */
 
-import { ts } from "../ts-api.js";
-import { lowerFunctionAstToIr, type IrFromAstResolver } from "../ir/from-ast.js";
-import { collectIrDirectCallLoweringPlans, type IrDirectCallTarget } from "../ir/ast-lowering-plans.js";
+import type { IrFromAstResolver } from "../ir/from-ast.js";
+import { buildSelfHostedIrBody } from "../frontend/builtins/build-ir.js";
+import type { SelfHostedFuncDef } from "../frontend/builtins/contracts.js";
 import { irIntrinsicFuncRef, irRuntimeFuncRef } from "../ir/callable-bindings.js";
 import { irVal, type IrFunction, type IrType } from "../ir/nodes.js";
 import { IR_VEC_ELEM_SET_PREFIX, parseIrVectorRuntimeElement } from "../ir/vector-runtime.js";
@@ -87,10 +87,6 @@ import { createDerivedIrUnitId, createIrSourceId, type IrSyntheticUnitRole, type
 import type { Instr, ValType } from "../ir/types.js";
 import { ensureNativeCharCodeAtHelper, NATIVE_CHARCODEAT_FN } from "./char-code-at-helpers.js";
 import { ensureVecElemSet, ensureVecElemSetForElement, VEC_ELEM_SET_PREFIX } from "./vec-elem-set.js";
-import { constantFold } from "../ir/passes/constant-fold.js";
-import { deadCode } from "../ir/passes/dead-code.js";
-import { simplifyCFG } from "../ir/passes/simplify-cfg.js";
-import { verifyIrFunction } from "../ir/verify.js";
 import { lowerIrFunctionToWasm, type IrLowerResolver } from "../ir/lower.js";
 import type { StdlibMathBuiltin } from "../stdlib/math.js";
 import type { CodegenContext } from "./context/types.js";
@@ -108,59 +104,7 @@ function selfHostedCalleeRef(name: string) {
     : irRuntimeFuncRef(name);
 }
 
-/**
- * #3161 — a self-hosted builtin with an explicit typed signature. The
- * generalized shape behind the `StdlibMathBuiltin` pilot descriptor:
- * positional param types + a typed callee map instead of the pilot's
- * implicit "everything is unary f64".
- *
- * `paramTypes` is positional and override-authoritative: a param whose
- * type has no TS-primitive spelling (externref, `ref_null { typeIdx }`)
- * should be annotated `unknown` in `source` — from-ast's `resolveIrType`
- * defers non-primitive annotations to the override, and REJECTS a
- * primitive annotation that disagrees with it (typo guard).
- * `returnType: null` means void (zero Wasm results; bare `return;` /
- * fall-through tails, statement-position calls only — #1228 / #2856 C4).
- */
-export interface SelfHostedFuncDef {
-  /** funcMap registration name — also the function's name in `source`. */
-  readonly name: string;
-  /** Ordinary TS source, IR-claimable subset. */
-  readonly source: string;
-  /** Positional param IrTypes (may carry ctx-bound typeIdx refs). */
-  readonly paramTypes: readonly IrType[];
-  /** Return IrType; null == void. */
-  readonly returnType: IrType | null;
-  /** Typed signatures for every direct callee in `source`. */
-  readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
-  /**
-   * Optional process-lifetime memo key. Set ONLY for a CONTEXT-FREE def —
-   * one whose `paramTypes` / `returnType` / callee sigs carry no ctx-bound
-   * `{ typeIdx }` ref (all abstract scalars / string / externref). The
-   * memoized `IrFunction` is shared across every compilation, so a def with
-   * a ctx-relative type must NOT set this (its typeIdx would leak across
-   * contexts). The math family (all `(f64) -> f64`) sets it (keyed by
-   * builtin name); the generalized families (raw-array/typeIdx params)
-   * leave it unset and rebuild per emission — bounded to once per
-   * compilation by `emitSelfHostedFunc`'s funcMap early-return.
-   */
-  readonly memoKey?: string;
-  /**
-   * (#3256 Tier-1) Opt-in from-ast dialect for the STRING family: installs a
-   * context-free native-strings `stringMethodPlan` resolver at BUILD time so
-   * the source may use string method syntax (`s.charCodeAt(i)`,
-   * `s.substring(a, b)`) and string-typed params/locals. When emitted through
-   * `emitSelfHostedFunc`, the build resolver ALSO carries the live ctx's
-   * `resolveString()` (mutated string `let`s bind as slots whose Wasm-local
-   * type is the ctx-bound `(ref $AnyString)`), so dialect defs must NOT set
-   * `memoKey` — the baked slot typeIdx is only meaningful in the registering
-   * CodegenContext. Families that don't set this build exactly as before (no
-   * resolver — any accidental string-method use remains a loud error), which
-   * keeps the math/timsort/object defs byte-inert by construction.
-   */
-  readonly dialect?: "native-strings";
-}
-
+export type { SelfHostedFuncDef } from "../frontend/builtins/contracts.js";
 /**
  * (#3256) The native-mode string-method decision table the stdlib string
  * sources are allowed to use. Deliberately a SUBSET of integration.ts's
@@ -299,6 +243,9 @@ function irTypeContainsContextIndex(type: IrType, seen = new Set<object>()): boo
       return type.members.some((member) => irTypeContainsContextIndex(member, seen));
     case "boxed":
       return irTypeContainsContextIndex(type.inner, seen);
+    case "support-ref":
+      // Program-qualified support references must never enter the process cache.
+      return true;
     case "fnctor":
       // Fnctor shapes are nominal, backend-neutral leaves here. Their
       // reserved layout and constructor target are symbolic bindings rather
@@ -373,74 +320,14 @@ export function buildSelfHostedIr(def: SelfHostedFuncDef, unitId: IrUnitId, from
       return materializeSelfHostedIr(cached.template, unitId);
     }
   }
-  const sourceFile = ts.createSourceFile(
-    `stdlib/${def.name}.ts`,
-    def.source,
-    ts.ScriptTarget.Latest,
-    /* setParentNodes */ true,
-    ts.ScriptKind.TS,
-  );
-  const fnDecl = sourceFile.statements.find(
-    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === def.name,
-  );
-  if (!fnDecl) {
-    throw new Error(`stdlib-selfhost: source for ${def.name} has no matching function declaration`);
-  }
-  if (fnDecl.parameters.length !== def.paramTypes.length) {
-    throw new Error(
-      `stdlib-selfhost: ${def.name} declares ${fnDecl.parameters.length} params but paramTypes has ${def.paramTypes.length}`,
-    );
-  }
-
-  const { main, lifted } = lowerFunctionAstToIr(fnDecl, {
+  const ir = buildSelfHostedIrBody({
+    definition: def,
     ownerUnitId: unitId,
-    funcName: def.name,
-    exported: false,
-    calleeTypes: def.calleeTypes,
-    directCalls: collectIrDirectCallLoweringPlans(
-      fnDecl,
-      unitId,
-      new Map<string, IrDirectCallTarget>(
-        [...def.calleeTypes].map(([name, signature]) => [
-          name,
-          {
-            target: selfHostedCalleeRef(name),
-            signature,
-          },
-        ]),
-      ),
+    callees: new Map(
+      [...def.calleeTypes].map(([name, signature]) => [name, { target: selfHostedCalleeRef(name), signature }]),
     ),
-    paramTypeOverrides: def.paramTypes,
-    returnTypeOverride: def.returnType,
-    // (#3256) string-family dialect: the caller-supplied ctx-bound resolver
-    // (emitSelfHostedFunc), or the context-free plan table for resolver-less
-    // unit builds; absent for every other family (see the field doc).
     resolver: fromAst ?? (def.dialect === "native-strings" ? NATIVE_STRINGS_FROMAST_RESOLVER : undefined),
   });
-  if (lifted.length > 0) {
-    throw new Error(`stdlib-selfhost: ${def.name} unexpectedly produced ${lifted.length} lifted functions`);
-  }
-
-  const buildErrors = verifyIrFunction(main);
-  if (buildErrors.length > 0) {
-    throw new Error(`stdlib-selfhost: IR verify failed for ${def.name}: ${buildErrors[0]!.message}`);
-  }
-
-  // Same hygiene pipeline integration.ts runs (constantFold → deadCode →
-  // simplifyCFG to fixpoint; each pass returns the same reference when it
-  // makes no change).
-  let ir = main;
-  for (let iter = 0; iter < 10; iter++) {
-    const next = simplifyCFG(deadCode(constantFold(ir)));
-    if (next === ir) break;
-    ir = next;
-  }
-
-  const postErrors = verifyIrFunction(ir);
-  if (postErrors.length > 0) {
-    throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${def.name}: ${postErrors[0]!.message}`);
-  }
-
   const template = selfHostedTemplate(ir);
   if (def.memoKey !== undefined) irCache.set(def.memoKey, { fingerprint: fingerprint!, template });
   return materializeSelfHostedIr(template, unitId);

--- a/src/frontend/builtins/build-ir.ts
+++ b/src/frontend/builtins/build-ir.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts } from "../../ts-api.js";
+import { lowerFunctionAstToIr, type IrFromAstResolver } from "../../ir/from-ast.js";
+import { collectIrDirectCallLoweringPlans, type IrDirectCallTarget } from "../../ir/ast-lowering-plans.js";
+import type { AllocSiteRegistry } from "../../ir/alloc-registry.js";
+import type { IrFunction } from "../../ir/core/nodes.js";
+import { irTypeEquals } from "../../ir/core/types.js";
+import type { IrUnitId } from "../../shared/contracts/ir-identity.js";
+import { irBindingKey } from "../../ir/declared-types.js";
+import { constantFold } from "../../ir/passes/constant-fold.js";
+import { deadCode } from "../../ir/passes/dead-code.js";
+import { simplifyCFG } from "../../ir/passes/simplify-cfg.js";
+import { verifyIrFunction } from "../../ir/verify.js";
+import type { SelfHostedFuncDef } from "./contracts.js";
+
+export interface SelfHostedIrBuildInput {
+  readonly definition: SelfHostedFuncDef;
+  readonly ownerUnitId: IrUnitId;
+  readonly callees: ReadonlyMap<string, IrDirectCallTarget>;
+  readonly resolver?: IrFromAstResolver;
+  readonly allocRegistry?: AllocSiteRegistry;
+}
+
+/** Canonical parse/lower/verify/hygiene kernel; no cache or physical context. */
+export function buildSelfHostedIrBody(input: SelfHostedIrBuildInput): IrFunction {
+  const def = input.definition;
+  const unitId = input.ownerUnitId;
+  const sourceFile = ts.createSourceFile(
+    `stdlib/${def.name}.ts`,
+    def.source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+  const fnDecl = sourceFile.statements.find(
+    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === def.name,
+  );
+  if (!fnDecl) {
+    throw new Error(`stdlib-selfhost: source for ${def.name} has no matching function declaration`);
+  }
+  if (fnDecl.parameters.length !== def.paramTypes.length) {
+    throw new Error(
+      `stdlib-selfhost: ${def.name} declares ${fnDecl.parameters.length} params but paramTypes has ${def.paramTypes.length}`,
+    );
+  }
+
+  const supplied = [...input.callees];
+  const expected = [...def.calleeTypes];
+  if (
+    supplied.length !== expected.length ||
+    expected.some(([name, signature], index) => {
+      const entry = supplied[index];
+      return (
+        entry === undefined ||
+        entry[0] !== name ||
+        entry[1].signature.params.length !== signature.params.length ||
+        signature.params.some((type, ordinal) => !irTypeEquals(type, entry[1].signature.params[ordinal]!)) ||
+        (signature.returnType === null
+          ? entry[1].signature.returnType !== null
+          : entry[1].signature.returnType === null ||
+            !irTypeEquals(signature.returnType, entry[1].signature.returnType))
+      );
+    })
+  )
+    throw new Error(`stdlib-selfhost: callee declarations disagree for ${def.name}`);
+
+  const { main, lifted } = lowerFunctionAstToIr(fnDecl, {
+    ownerUnitId: unitId,
+    funcName: def.name,
+    exported: false,
+    calleeTypes: def.calleeTypes,
+    directCalls: collectIrDirectCallLoweringPlans(fnDecl, unitId, input.callees),
+    paramTypeOverrides: def.paramTypes,
+    returnTypeOverride: def.returnType,
+    resolver: input.resolver,
+    allocRegistry: input.allocRegistry,
+  });
+  if (lifted.length > 0) {
+    throw new Error(`stdlib-selfhost: ${def.name} unexpectedly produced ${lifted.length} lifted functions`);
+  }
+
+  const declarations = {
+    declaredSignatures: new Map(
+      [...input.callees.values()].map(({ target, signature }) => {
+        const key = irBindingKey(target.binding);
+        if (key === null) throw new Error(`stdlib-selfhost: invalid callee binding for ${def.name}`);
+        return [key, { params: signature.params, result: signature.returnType }] as const;
+      }),
+    ),
+  };
+  const buildErrors = verifyIrFunction(main, undefined, declarations);
+  if (buildErrors.length > 0) {
+    throw new Error(`stdlib-selfhost: IR verify failed for ${def.name}: ${buildErrors[0]!.message}`);
+  }
+
+  // Same hygiene pipeline integration.ts runs (constantFold → deadCode →
+  // simplifyCFG to fixpoint; each pass returns the same reference when it
+  // makes no change).
+  let ir = main;
+  for (let iter = 0; iter < 10; iter++) {
+    const next = simplifyCFG(deadCode(constantFold(ir)));
+    if (next === ir) break;
+    ir = next;
+  }
+
+  const postErrors = verifyIrFunction(ir, undefined, declarations);
+  if (postErrors.length > 0) {
+    throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${def.name}: ${postErrors[0]!.message}`);
+  }
+
+  return ir;
+}

--- a/src/frontend/builtins/contracts.ts
+++ b/src/frontend/builtins/contracts.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import type { IrType } from "../../ir/core/types.js";
+
+/**
+ * #3161 — a self-hosted builtin with an explicit typed signature. The
+ * generalized shape behind the `StdlibMathBuiltin` pilot descriptor:
+ * positional param types + a typed callee map instead of the pilot's
+ * implicit "everything is unary f64".
+ *
+ * `paramTypes` is positional and override-authoritative: a param whose
+ * type has no TS-primitive spelling (externref, `ref_null { typeIdx }`)
+ * should be annotated `unknown` in `source` — from-ast's `resolveIrType`
+ * defers non-primitive annotations to the override, and REJECTS a
+ * primitive annotation that disagrees with it (typo guard).
+ * `returnType: null` means void (zero Wasm results; bare `return;` /
+ * fall-through tails, statement-position calls only — #1228 / #2856 C4).
+ */
+export interface SelfHostedFuncDef {
+  /** funcMap registration name — also the function's name in `source`. */
+  readonly name: string;
+  /** Ordinary TS source, IR-claimable subset. */
+  readonly source: string;
+  /** Positional param IrTypes (may carry ctx-bound typeIdx refs). */
+  readonly paramTypes: readonly IrType[];
+  /** Return IrType; null == void. */
+  readonly returnType: IrType | null;
+  /** Typed signatures for every direct callee in `source`. */
+  readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+  /**
+   * Optional process-lifetime memo key. Set ONLY for a CONTEXT-FREE def —
+   * one whose `paramTypes` / `returnType` / callee sigs carry no ctx-bound
+   * `{ typeIdx }` ref (all abstract scalars / string / externref). The
+   * memoized `IrFunction` is shared across every compilation, so a def with
+   * a ctx-relative type must NOT set this (its typeIdx would leak across
+   * contexts). The math family (all `(f64) -> f64`) sets it (keyed by
+   * builtin name); the generalized families (raw-array/typeIdx params)
+   * leave it unset and rebuild per emission — bounded to once per
+   * compilation by `emitSelfHostedFunc`'s funcMap early-return.
+   */
+  readonly memoKey?: string;
+  /**
+   * (#3256 Tier-1) Opt-in from-ast dialect for the STRING family: installs a
+   * context-free native-strings `stringMethodPlan` resolver at BUILD time so
+   * the source may use string method syntax (`s.charCodeAt(i)`,
+   * `s.substring(a, b)`) and string-typed params/locals. When emitted through
+   * `emitSelfHostedFunc`, the build resolver ALSO carries the live ctx's
+   * `resolveString()` (mutated string `let`s bind as slots whose Wasm-local
+   * type is the ctx-bound `(ref $AnyString)`), so dialect defs must NOT set
+   * `memoKey` — the baked slot typeIdx is only meaningful in the registering
+   * CodegenContext. Families that don't set this build exactly as before (no
+   * resolver — any accidental string-method use remains a loud error), which
+   * keeps the math/timsort/object defs byte-inert by construction.
+   */
+  readonly dialect?: "native-strings";
+}

--- a/src/frontend/builtins/prepare-number-format.ts
+++ b/src/frontend/builtins/prepare-number-format.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import type { IrProgramSourcePreparation } from "../../ir/program-source.js";
+import type { RuntimeManifestPolicy } from "../../runtime/contracts/provider-policy.js";
+import { RuntimeManifestBuilder } from "../../ir/runtime/manifest.js";
+import { nativeAsyncProviderMismatch } from "../../ir/runtime/native-async-callables.js";
+import { numberFormatRadixSupportDeclarations } from "../../ir/program/formatter-support.js";
+import {
+  irNumberFormatDemandOwners,
+  irRuntimeSupportOccurrences,
+  type IrRuntimeSupport,
+} from "../../ir/program/runtime-support.js";
+import { numToStringRadixDef } from "../../stdlib/number-format.js";
+import { buildSelfHostedIrBody } from "./build-ir.js";
+
+/** Build the genuine radix body once, against the source preparation's allocation owner. */
+export function prepareNumberFormatRuntimeSupport(
+  source: IrProgramSourcePreparation,
+  policy: RuntimeManifestPolicy,
+): IrRuntimeSupport | undefined {
+  const demandOwners = irNumberFormatDemandOwners(source.ir.functions);
+  if (demandOwners.length === 0) return undefined;
+  if (policy.backend !== "wasmgc" || policy.target !== "standalone")
+    throw new Error("number-format support requires wasmgc:standalone native policy");
+  // Select the actual canonical provider before building or allocating support.
+  const manifest = new RuntimeManifestBuilder(policy);
+  manifest.requestFeature("async.native.number-to-string");
+  manifest.freeze();
+  const provider = manifest.resolveProvider("async.native.number-to-string");
+  const mismatch = nativeAsyncProviderMismatch(provider);
+  if (mismatch !== undefined) throw new Error(mismatch);
+  const entries = source.inventory.sources.filter((entry) => entry.kind === "entry");
+  if (entries.length !== 1) throw new Error("number-format support requires one entry source anchor");
+  const sourceId = entries[0]!.id;
+  if (source.allocations === undefined)
+    throw new Error("number-format support requires the source allocation registry");
+  const declarations = numberFormatRadixSupportDeclarations(sourceId);
+  const definition = numToStringRadixDef(declarations.scratch.type);
+  const body = buildSelfHostedIrBody({
+    definition,
+    ownerUnitId: declarations.ownerUnitId,
+    callees: new Map(
+      declarations.kernels.map((kernel) => [
+        kernel.ref.name,
+        {
+          target: kernel.ref,
+          signature: { params: kernel.params, returnType: kernel.results[0] ?? null },
+        },
+      ]),
+    ),
+    allocRegistry: source.allocations,
+  });
+  const occurrences = irRuntimeSupportOccurrences(body);
+  return {
+    schema: "ir-runtime-support-v1",
+    batches: [
+      {
+        kind: "number-format-radix-v1",
+        sourceId,
+        demandOwners,
+        source: {
+          definition: "numToStringRadixDef",
+          functionName: "__sh_num_toString_radix",
+          utf8Bytes: 1618,
+          sha256: "7b13099fbed0a87079f92e9bddbf75959065ed28daf66d5ad344e0b240037dc6",
+        },
+        scratch: declarations.scratch,
+        kernels: declarations.kernels,
+        implementation: { declaration: declarations.implementation, body },
+        calls: occurrences.calls,
+        literals: occurrences.literals,
+      },
+    ],
+  };
+}

--- a/src/ir/abi-bindings.ts
+++ b/src/ir/abi-bindings.ts
@@ -10,6 +10,8 @@ import {
 import { createIrBindingId } from "./identity-values.js";
 import type { IrBindingId, IrClassId, IrSourceId, IrUnitId } from "./identity.js";
 import type { IrGlobalBinding, IrGlobalRef, IrTypeBinding, IrTypeRef } from "./nodes.js";
+import { typeRef, irSupportTypeRef } from "./core/type-references.js";
+export { irSupportTypeRef } from "./core/type-references.js";
 
 type IrBindingOwnerId = IrSourceId | IrUnitId | IrClassId;
 
@@ -29,15 +31,6 @@ function globalRef(name: string, binding: IrGlobalBinding): IrGlobalRef {
   return Object.freeze({
     kind: "global",
     name: requireNonEmpty(name, "global compatibility name"),
-    binding: Object.freeze(binding),
-  });
-}
-
-function typeRef(name: string, binding: IrTypeBinding): IrTypeRef {
-  requireBindingId(binding.bindingId, "type bindingId", binding.kind === "class" ? "class" : "type");
-  return Object.freeze({
-    kind: "type",
-    name: requireNonEmpty(name, "type compatibility name"),
     binding: Object.freeze(binding),
   });
 }
@@ -310,25 +303,6 @@ export function irRuntimeTypeRef(
       ownerId: requireNonEmpty(ownerId, "runtime type owner identity") as IrBindingOwnerId,
       domain: "type",
       role: `runtime:${checkedSymbol}`,
-      ordinal,
-    }),
-  });
-}
-
-/** Reference one compiler support type intention. */
-export function irSupportTypeRef(
-  ownerId: IrBindingOwnerId,
-  role: string,
-  adapterName: string,
-  ordinal?: number,
-): IrTypeRef {
-  const checkedRole = requireNonEmpty(role, "support type role");
-  return typeRef(adapterName, {
-    kind: "support",
-    bindingId: createIrBindingId({
-      ownerId: requireNonEmpty(ownerId, "support type owner identity") as IrBindingOwnerId,
-      domain: "type",
-      role: checkedRole,
       ordinal,
     }),
   });

--- a/src/ir/analysis/linear-memory-plan.ts
+++ b/src/ir/analysis/linear-memory-plan.ts
@@ -1336,6 +1336,8 @@ function collectGlobalStorage(
 
 function linearIrTypeKey(type: IrType): string {
   switch (type.kind) {
+    case "support-ref":
+      throw new Error("linear-memory plan does not support compiler support references");
     case "val":
       return `scalar:${linearStorageForIrType(type)}`;
     case "string":

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -483,6 +483,10 @@ function porfforBinopLegal(op: IrBinop): boolean {
 }
 
 function backendTypeError(backend: IrBackendKind, type: IrType, fnctorResolved = false): string | null {
+  // This backend-only checker cannot confer target/program support ownership.
+  // The complete program admission separately requires standalone support.
+  if (type.kind === "support-ref")
+    return backend === "wasmgc" ? null : `${backend} backend does not support support-ref types`;
   if (type.kind === "fnctor" && !fnctorResolved) {
     return `${backend} backend does not support nominal fnctor types until an explicit ABI resolver is installed`;
   }

--- a/src/ir/core/type-references.ts
+++ b/src/ir/core/type-references.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { requireBindingId, requireNonEmpty } from "./binding-key-primitives.js";
+import { createIrBindingId } from "../../shared/contracts/identity-values.js";
+import type { IrClassId, IrSourceId, IrUnitId } from "../../shared/contracts/ir-identity.js";
+import type { IrTypeBinding, IrTypeRef } from "./types.js";
+
+type IrBindingOwnerId = IrSourceId | IrUnitId | IrClassId;
+
+export function typeRef(name: string, binding: IrTypeBinding): IrTypeRef {
+  requireBindingId(binding.bindingId, "type bindingId", binding.kind === "class" ? "class" : "type");
+  return Object.freeze({
+    kind: "type",
+    name: requireNonEmpty(name, "type compatibility name"),
+    binding: Object.freeze(binding),
+  });
+}
+
+/** Reference one compiler support type intention. */
+export function irSupportTypeRef(
+  ownerId: IrBindingOwnerId,
+  role: string,
+  adapterName: string,
+  ordinal?: number,
+): IrTypeRef {
+  const checkedRole = requireNonEmpty(role, "support type role");
+  return typeRef(adapterName, {
+    kind: "support",
+    bindingId: createIrBindingId({
+      ownerId: requireNonEmpty(ownerId, "support type owner identity") as IrBindingOwnerId,
+      domain: "type",
+      role: checkedRole,
+      ordinal,
+    }),
+  });
+}

--- a/src/ir/core/types.ts
+++ b/src/ir/core/types.ts
@@ -5,6 +5,7 @@ import type { ValType } from "../../wasm/model/instructions.js";
 import type { IrFnctorShape } from "./fnctor-shapes.js";
 import type { IrFuncRef } from "./value-references.js";
 import { type TagId, tagRefinementEquals } from "./tag-refinement.js";
+import { requireBindingId } from "./binding-key-primitives.js";
 
 // ---------------------------------------------------------------------------
 // Symbolic references
@@ -38,6 +39,23 @@ export interface IrTypeRef {
   /** Compatibility/debug label; never the semantic lookup key. */
   readonly name: string;
   readonly binding: IrTypeBinding;
+}
+
+/** Nominal compiler-support storage; physical ownership is resolved later. */
+export interface IrSupportRefType {
+  readonly kind: "support-ref";
+  readonly ref: IrTypeRef & {
+    readonly binding: Extract<IrTypeBinding, { readonly kind: "support" }>;
+  };
+  readonly nullable: boolean;
+}
+
+export function irSupportRef(ref: IrTypeRef, nullable: boolean): IrSupportRefType {
+  if (!ref || ref.kind !== "type" || ref.binding?.kind !== "support")
+    throw new TypeError("support-ref requires a support type reference");
+  requireBindingId(ref.binding.bindingId, "support-ref bindingId", "type");
+  if (typeof nullable !== "boolean") throw new TypeError("support-ref nullability must be boolean");
+  return { kind: "support-ref", ref: ref as IrSupportRefType["ref"], nullable };
 }
 
 /**
@@ -263,6 +281,7 @@ export interface IrClassShape {
 }
 
 export type IrType =
+  | IrSupportRefType
   // The optional `signed` flag (#1126 Stage 1) is a *value-domain* fact, not
   // a Wasm-storage fact: both `int32` and `uint32` lower to the same Wasm
   // `i32` storage but are distinguished at op-selection time (`i32.shr_s`
@@ -451,6 +470,8 @@ export function irDynamic(tag?: TagId): IrType {
  */
 export function irTypeEquals(a: IrType, b: IrType): boolean {
   if (a.kind !== b.kind) return false;
+  if (a.kind === "support-ref" && b.kind === "support-ref")
+    return a.ref.binding.bindingId === b.ref.binding.bindingId && a.nullable === b.nullable;
   if (a.kind === "val" && b.kind === "val") {
     if (!valTypeEquals(a.val, b.val)) return false;
     // #1126 Stage 1 — `signed` is a domain fact, not a Wasm-storage fact.

--- a/src/ir/fnctor-abi.ts
+++ b/src/ir/fnctor-abi.ts
@@ -74,6 +74,7 @@ function validateCaptures(captures: readonly IrFnctorCapture[]): string | null {
 }
 
 function validateTypeGraph(type: IrType, activeTypes: Set<object>, activeShapes: Set<object>): string | null {
+  if (type.kind === "support-ref") return "fnctor shapes do not admit symbolic support references";
   if (type.kind === "val" || type.kind === "string" || type.kind === "dynamic" || type.kind === "extern") return null;
   if (activeTypes.has(type)) return "fnctor shape contains a recursive IR type graph";
   activeTypes.add(type);

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -3420,6 +3420,20 @@ function validateVectorInitializer(
   }
 }
 
+function resolveMutableLocalRepresentation(
+  inferred: IrType,
+  widenDynamic: boolean,
+  cx: LowerCtx,
+): IrSlotRepresentation | null {
+  const logicalType = inferred.kind === "dynamic" && widenDynamic ? irDynamic() : inferred;
+  if (logicalType.kind === "support-ref")
+    demoteToLegacy(
+      "operand-coercion-unsupported",
+      `ir/from-ast: support-ref cannot use a physical mutable slot (${cx.funcName})`,
+    );
+  return resolveIrSlotRepresentation(logicalType, cx.resolver, cx.funcName);
+}
+
 function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
   const isConst = !!(stmt.declarationList.flags & ts.NodeFlags.Const);
   for (const d of stmt.declarationList.declarations) {
@@ -3691,8 +3705,7 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
     // Logical string, dynamic, and vector values use resolver-selected
     // backend storage while identifier reads retain their logical IR type.
     if (!isConst && cx.mutatedLets.has(name)) {
-      const logicalType = inferred.kind === "dynamic" && widenDynamic ? irDynamic() : inferred;
-      const representation = resolveIrSlotRepresentation(logicalType, cx.resolver, cx.funcName);
+      const representation = resolveMutableLocalRepresentation(inferred, widenDynamic, cx);
       if (representation) {
         const slotIndex = cx.builder.declareSlot(name, representation.storageType);
         cx.builder.emitSlotWrite(slotIndex, value);
@@ -3971,6 +3984,7 @@ function coerceIrNumeric(value: IrValueId, target: IrType, cx: LowerCtx): IrValu
 
 /** Short debug string for IrType, used in error messages. */
 function describeIrType(t: IrType): string {
+  if (t.kind === "support-ref") return `support-ref<${t.ref.binding.bindingId}>${t.nullable ? "?" : ""}`;
   if (t.kind === "val") return t.val.kind;
   if (t.kind === "string") return "string";
   if (t.kind === "vec") return `vec<${describeIrType(t.elementType)}>${t.nullable ? "?" : ""}`;
@@ -5275,6 +5289,8 @@ function staticTypeOfFor(t: IrType): string | null {
  */
 function isIrTypeNullable(t: IrType): boolean {
   switch (t.kind) {
+    case "support-ref":
+      return t.nullable;
     case "object":
     case "class":
     case "string":
@@ -9897,6 +9913,11 @@ function lowerYield(expr: ts.YieldExpression, cx: LowerCtx): void {
  */
 function coerceReturnValue(value: IrValueId, cx: LowerCtx, sourceExpression?: ts.Expression): IrValueId {
   const declared = cx.returnType;
+  const supportActual = cx.builder.typeOf(value);
+  if (declared?.kind === "support-ref" || supportActual.kind === "support-ref") {
+    if (declared && irTypeEquals(supportActual, declared)) return value;
+    demoteToLegacy("operand-coercion-unsupported", `ir/from-ast: incompatible support-ref return in ${cx.funcName}`);
+  }
   if (declared?.kind === "callable") {
     const actual = cx.builder.typeOf(value);
     if (actual.kind === "callable" && closureSignatureEquals(actual.signature, declared.signature)) return value;

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -4317,6 +4317,12 @@ function memberValType(t: IrType, funcName: string): ValType {
 }
 
 export function lowerIrTypeToValType(t: IrType, resolver: IrLowerResolver, funcName: string): ValType {
+  if (t.kind === "support-ref") {
+    const typeIdx = resolver.resolveType(t.ref);
+    if (!Number.isSafeInteger(typeIdx) || typeIdx < 0)
+      throw new Error(`ir/lower: resolver cannot lower support-ref (${funcName})`);
+    return { kind: t.nullable ? "ref_null" : "ref", typeIdx };
+  }
   if (t.kind === "val") {
     if (!t.typeRef) return t.val;
     if (t.val.kind !== "ref" && t.val.kind !== "ref_null") {
@@ -4448,6 +4454,7 @@ function describeShape(shape: IrObjectShape): string {
 }
 
 function describeIrTypeShallow(t: IrType): string {
+  if (t.kind === "support-ref") return `support-ref<${t.ref.binding.bindingId}>${t.nullable ? "?" : ""}`;
   if (t.kind === "val") return t.val.kind;
   if (t.kind === "string") return "string";
   if (t.kind === "vec") return `vec<${describeIrTypeShallow(t.elementType)}>${t.nullable ? "?" : ""}`;

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -506,6 +506,8 @@ function tupleKey(types: readonly IrType[]): string {
 }
 
 function irTypeKey(t: IrType): string {
+  if (t.kind === "support-ref")
+    return `support-ref|${t.ref.binding.bindingId.length}:${t.ref.binding.bindingId}|nullable:${t.nullable ? 1 : 0}`;
   if (t.kind === "val") return `v:${valTypeKey(t.val)}`;
   if (t.kind === "string") return "s";
   if (t.kind === "vec") return `vec:${irTypeKey(t.elementType)}${t.nullable ? "?" : ""}`;

--- a/src/ir/physical-ref-support.ts
+++ b/src/ir/physical-ref-support.ts
@@ -56,6 +56,7 @@ export function attachIrPhysicalRefTypeRefs(
   const nestedTypes = (type: IrType): readonly IrType[] => {
     switch (type.kind) {
       case "val":
+      case "support-ref":
       case "string":
       case "class":
       case "extern":
@@ -201,6 +202,7 @@ export function attachIrPhysicalRefTypeRefs(
       case "string":
       case "extern":
       case "fnctor":
+      case "support-ref":
       case "dynamic":
         mapped = type;
         break;

--- a/src/ir/prepared-callable-boundary.ts
+++ b/src/ir/prepared-callable-boundary.ts
@@ -281,6 +281,7 @@ function collectCallableTypes(type: IrType, out: Set<IrType>): void {
       for (const member of type.members) collectCallableTypes(member, out);
       return;
     case "val":
+    case "support-ref":
     case "string":
     case "class":
     case "extern":

--- a/src/ir/prepared-closure-support.ts
+++ b/src/ir/prepared-closure-support.ts
@@ -302,6 +302,7 @@ export function prepareDependencyCompleteClosureSupport(
         for (const member of type.members) collectObjectSupport(member);
         return;
       case "val":
+      case "support-ref":
       case "string":
       case "class":
       case "extern":

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -40,7 +40,101 @@ import {
   type PreparedDynamicInstructionSupportEvidence,
 } from "./prepared-instruction-support.js";
 import type { PreparedComponentAbiEntry, PreparedComponentAbiLookup } from "./program/abi-lookup.js";
+import type { PreparedIrProgram } from "./program/prepared-contracts.js";
+import { PreparedIrProgramInvariantError } from "./program/errors.js";
+import { numberFormatRadixSupportDeclarations } from "./program/formatter-support.js";
+import { irTypeEquals } from "./core/types.js";
 export type { PreparedComponentAbiEntry, PreparedComponentAbiLookup } from "./program/abi-lookup.js";
+
+/** Semantic dependency proof for separate support bodies, not physical readiness. */
+export function assertPreparedIrRuntimeSupportDependencies(
+  input: Pick<PreparedIrProgram, "inventory" | "runtimeSupport" | "abi">,
+): void {
+  const invalid = (detail: string): never => {
+    throw new PreparedIrProgramInvariantError("invalid-prepared-data", `runtime support dependencies: ${detail}`);
+  };
+  for (const batch of input.runtimeSupport?.batches ?? []) {
+    const anchors = input.inventory.sources.filter((source) => source.kind === "entry");
+    if (anchors.length !== 1 || anchors[0]!.id !== batch.sourceId) invalid("foreign source anchor");
+    const canonical = numberFormatRadixSupportDeclarations(batch.sourceId);
+    const callables = [...canonical.kernels, canonical.implementation];
+    const active = new Set<object>();
+    const visit = (value: unknown): void => {
+      if (value === null || typeof value !== "object") return;
+      if (active.has(value)) invalid("cyclic support dependency graph");
+      const record = value as Record<string, unknown>;
+      if (record.kind === "string.const" && (Object.hasOwn(record, "storage") || Object.hasOwn(record, "materializer")))
+        invalid("D1 support literals cannot carry physical storage or materializer attachments");
+      if (Object.hasOwn(record, "typeIdx")) invalid("physical type index in semantic support");
+      if (
+        [
+          "global",
+          "class",
+          "object",
+          "vec",
+          "closure",
+          "callable",
+          "boxed",
+          "union",
+          "fnctor",
+          "extern",
+          "dynamic",
+          "ref",
+          "ref_null",
+        ].includes(String(record.kind))
+      )
+        invalid(`unsupported dependency-bearing form ${String(record.kind)}`);
+      if (record.kind === "support-ref") {
+        const type = value as Extract<IrType, { kind: "support-ref" }>;
+        if (!type.ref || type.ref.binding?.kind !== "support" || !irTypeEquals(type, canonical.scratch.type))
+          invalid("foreign or incompatible symbolic scratch type");
+      }
+      if (record.kind === "type" || record.kind === "func") {
+        const ref = value as IrTypeRef | IrFuncRef;
+        const binding = ref.binding;
+        if (binding?.kind !== "support") {
+          invalid("support body references a non-support declaration");
+          return;
+        }
+        const bindingId = binding.bindingId;
+        const key = ref.kind === "type" ? irTypeBindingKey(ref.binding) : irCallableBindingKey(ref.binding);
+        const allowed =
+          ref.kind === "type"
+            ? key === irTypeBindingKey(canonical.scratch.type.ref.binding)
+            : callables.some((callee) => key === irCallableBindingKey(callee.ref.binding));
+        if (!allowed) invalid("foreign symbolic dependency");
+        const matches = input.abi.entries.filter((entry) => entry.plan.id === bindingId);
+        if (matches.length !== 1) invalid("missing or duplicate symbolic dependency");
+        const entry = matches[0]!;
+        if (
+          entry.plan.structuralReferenceKey !== key ||
+          entry.plan.slotPolicy !== "required" ||
+          entry.plan.slotSpace !== (ref.kind === "type" ? "type" : "function") ||
+          entry.contract.kind !== (ref.kind === "type" ? "type" : "callable")
+        )
+          invalid("symbolic dependency lacks its required ABI declaration");
+      }
+      active.add(value);
+      try {
+        if (Array.isArray(value)) {
+          for (let index = 0; index < value.length; index++) {
+            if (!Object.hasOwn(value, index)) invalid("sparse support dependency graph");
+            visit(value[index]);
+          }
+        } else {
+          for (const nested of Object.values(record)) visit(nested);
+        }
+      } finally {
+        active.delete(value);
+      }
+    };
+    // Traverse actual fields, including block arguments, nested instructions,
+    // slots and explicit ref/type positions. Occurrence receipts are not used.
+    visit(batch.scratch.type);
+    visit(batch.kernels);
+    visit(batch.implementation);
+  }
+}
 
 export type {
   PreparedClassAccessorWritebackEvidence,
@@ -332,6 +426,15 @@ function recordImplicitTypeRequirement(
     });
   };
   switch (type.kind) {
+    case "support-ref":
+      recordSupportTypeReference(
+        evidence,
+        type.ref,
+        abi,
+        ownership,
+        "IR symbolic support reference must use a compiler-support Program ABI type ref",
+      );
+      return;
     case "val":
       if (type.val.kind === "ref" || type.val.kind === "ref_null") {
         if (!type.typeRef) {

--- a/src/ir/program-abi-contracts.ts
+++ b/src/ir/program-abi-contracts.ts
@@ -5,7 +5,7 @@ import { preparedIrProgramCallableResults } from "./program-callable-contract.js
 import type { IrBindingId, IrSourceId, IrUnitId } from "../shared/contracts/ir-identity.js";
 import type { IrUnitInventory } from "../shared/contracts/ir-unit-inventory.js";
 import { irCallableBindingKey, irUnitCallableBindingId, irUnitFuncRef } from "./callable-bindings.js";
-import { irGlobalBindingKey } from "./abi-bindings.js";
+import { irGlobalBindingKey, irTypeBindingKey } from "./abi-bindings.js";
 import type { PreparedIrModule as IrModule } from "./runtime/contracts/prepared.js";
 import type { IrClassShape, IrType } from "./core/types.js";
 import type { IrGlobalRef } from "./core/value-references.js";
@@ -19,6 +19,8 @@ import type { TypedIrProgramGlobal } from "./program/input-contracts.js";
 import type { IrProgramCallableBindingRecord } from "./program/callable-bindings.js";
 import type { IrRuntimeCallableDeclaration } from "./runtime-callable-declarations.js";
 import { irRuntimeCallableHasNoSlot } from "./runtime/native-async-callables.js";
+import type { IrRuntimeSupport } from "./program/runtime-support.js";
+import { numberFormatRadixSupportDeclarations } from "./program/formatter-support.js";
 import {
   assertPreparedIrRuntimeCallableDeclaration,
   preparedIrRuntimeAbiAnchor,
@@ -27,6 +29,7 @@ import {
 
 /** Semantic signature key; backend layout indices are deliberately not encoded here. */
 export function preparedIrTypeKey(type: IrType): string {
+  if (type.kind === "support-ref") return irTypeKey(type);
   return `${irTypeKey(type)}:${preparedIrDataKey(type)}`;
 }
 
@@ -36,6 +39,11 @@ export function preparedIrDataKey(data: unknown): string {
   const canonical = (value: unknown): unknown => {
     if (value === null || typeof value !== "object") return value;
     const typed = value as Partial<IrType>;
+    if (typed.kind === "support-ref") {
+      if (!typed.ref || typeof typed.nullable !== "boolean" || typed.ref.binding.kind !== "support")
+        throw new PreparedIrProgramInvariantError("invalid-prepared-data", "support type lacks its declared identity");
+      return { kind: "support-ref", key: preparedIrTypeKey(typed as IrType) };
+    }
     if (typed.kind === "class") {
       if (!typed.shape || typeof typed.shape.classId !== "string")
         throw new PreparedIrProgramInvariantError("invalid-prepared-data", "class type lacks its declared identity");
@@ -89,6 +97,7 @@ export interface PrepareIrProgramAbiInput {
   readonly globals: readonly TypedIrProgramGlobal[];
   readonly startup: readonly IrModuleInitPlan[];
   readonly callables: readonly IrProgramCallableBindingRecord[];
+  readonly runtimeSupport?: IrRuntimeSupport;
 }
 
 /** Produce semantic contracts from declared bodies/storage, never from a call's guessed usage. */
@@ -221,6 +230,45 @@ export function prepareIrProgramAbiEntries(
           intent: { kind: "export", externalName, targetId },
         },
         contract: { kind: "export", externalName, targetId },
+      });
+    }
+  }
+  // These are real type/function declarations, never ordinary source units or
+  // slotless runtime intents. Keep the canonical runtime tail after this vector.
+  for (const batch of input.runtimeSupport?.batches ?? []) {
+    const declaration = numberFormatRadixSupportDeclarations(batch.sourceId);
+    const type = declaration.scratch.type;
+    entries.push({
+      plan: {
+        id: type.ref.binding.bindingId,
+        order: order(batch.sourceId),
+        displayName: type.ref.name,
+        structuralReferenceKey: irTypeBindingKey(type.ref.binding),
+        slotPolicy: "required",
+        slotSpace: "type",
+        intent: { kind: "type", shapeKey: preparedIrTypeKey(type) },
+      },
+      contract: { kind: "type", ref: type.ref, type },
+    });
+    for (const callable of [...declaration.kernels, declaration.implementation]) {
+      if (callable.ref.binding.kind !== "support")
+        throw new PreparedIrProgramInvariantError("invalid-prepared-data", "formatter callable lacks support binding");
+      entries.push({
+        plan: {
+          id: callable.ref.binding.bindingId,
+          order: order(batch.sourceId),
+          displayName: callable.ref.name,
+          structuralReferenceKey: irCallableBindingKey(callable.ref.binding),
+          slotPolicy: "required",
+          slotSpace: "function",
+          intent: {
+            kind: "callable",
+            origin: "support",
+            sourceId: batch.sourceId,
+            signature: preparedIrCallableSignature(callable.params, callable.results),
+          },
+        },
+        contract: { kind: "callable", ref: callable.ref, params: callable.params, results: callable.results },
       });
     }
   }

--- a/src/ir/program-allocations.ts
+++ b/src/ir/program-allocations.ts
@@ -8,9 +8,29 @@ import { asAllocSiteId, forEachInstrDeep, type IrFunction } from "./nodes.js";
 import { preparedIrDataKey, preparedIrTypeKey } from "./program-abi-contracts.js";
 import { PreparedIrProgramInvariantError, type PreparedIrProgram } from "./program.js";
 import { assertFinalAllocProvenance } from "./verify-alloc.js";
+import { irRuntimeSupportFunctions, type IrRuntimeSupport } from "./program/runtime-support.js";
+import type { IrPreparationControls } from "./program/controls.js";
+
+/** Support has already received its inherited self-host hygiene, not source GVN. */
+export function analyzeIrRuntimeSupportAllocations(
+  support: IrRuntimeSupport | undefined,
+  allocations: AllocSiteRegistry,
+  controls: IrPreparationControls,
+): void {
+  for (const fn of irRuntimeSupportFunctions(support)) {
+    assertFinalAllocProvenance(fn, allocations);
+    analyzeEncoding(fn, allocations);
+    if (controls.ownership || controls.escape) {
+      const ownership = analyzeOwnership(fn, allocations);
+      if (controls.escape) analyzeEscape(fn, allocations, ownership);
+    }
+  }
+}
 
 /** Reconstruct the existing registry's read authority, then verify every final artifact. */
-export function assertPreparedIrProgramAllocations(program: Pick<PreparedIrProgram, "allocations" | "ir">): void {
+export function assertPreparedIrProgramAllocations(
+  program: Pick<PreparedIrProgram, "allocations" | "ir" | "runtimeSupport">,
+): void {
   const snapshot = program.allocations;
   const invalid = (detail: string): never => {
     throw new PreparedIrProgramInvariantError("invalid-prepared-data", `program allocations: ${detail}`);
@@ -82,7 +102,7 @@ export function assertPreparedIrProgramAllocations(program: Pick<PreparedIrProgr
       if (requestedNamespaces.has(ALLOC_NAMESPACES.escape)) analyzeEscape(fn, registry, ownership);
     }
   };
-  for (const fn of program.ir.functions) {
+  for (const fn of [...program.ir.functions, ...irRuntimeSupportFunctions(program.runtimeSupport)]) {
     analyze(fn);
     // State buffers are executable semantic bodies too. The existing provenance
     // verifier accepts a function carrier, so reuse it over each exact buffer.

--- a/src/ir/program-codec.ts
+++ b/src/ir/program-codec.ts
@@ -438,6 +438,7 @@ export function reauthenticatePreparedIrProgram(persisted: PreparedIrProgram): P
     derivedUnits: persisted.derivedUnits,
     startup: persisted.startup,
     allocations: persisted.allocations,
+    ...(persisted.runtimeSupport === undefined ? {} : { runtimeSupport: persisted.runtimeSupport }),
     runtime: Object.freeze(runtime),
     reconciliation: persisted.reconciliation,
     sealed: persisted.sealed,
@@ -504,6 +505,19 @@ export function assertPreparedIrProgramShape(value: unknown): asserts value is P
     return invalid(`program.reconciliation must be "complete", got ${String(program.reconciliation)}`);
   }
   if (program.sealed !== true) return invalid("program.sealed must be true");
+  if (Object.hasOwn(program, "runtimeSupport")) {
+    const support = requireRecord(program.runtimeSupport, "program.runtimeSupport");
+    if (support.schema !== "ir-runtime-support-v1") return invalid("unsupported runtime support schema");
+    const batches = requireArray(support.batches, "program.runtimeSupport.batches");
+    if (batches.length !== 1) return invalid("runtime support must contain exactly one radix batch");
+    const batch = requireRecord(batches[0], "program.runtimeSupport.batches[0]");
+    if (batch.kind !== "number-format-radix-v1") return invalid("unsupported runtime support batch");
+    const implementation = requireRecord(batch.implementation, "runtime support implementation");
+    const body = requireRecord(implementation.body, "runtime support body");
+    requireArray(body.blocks, "runtime support body.blocks");
+    requireArray(body.params, "runtime support body.params");
+    requireArray(body.resultTypes, "runtime support body.resultTypes");
+  }
 
   const inventory = requireRecord(program.inventory, "program.inventory");
   const sources = requireArray(inventory.sources, "program.inventory.sources");

--- a/src/ir/program-preparation.ts
+++ b/src/ir/program-preparation.ts
@@ -10,6 +10,7 @@ import { PreparedIrProgramInvariantError } from "./program/errors.js";
 import type { IrProgramPreparationResult } from "./program/prepared-contracts.js";
 import { observePreparedIrProgram } from "./program-observation.js";
 import type { RuntimeManifestPolicy } from "./runtime-manifest.js";
+import { prepareNumberFormatRuntimeSupport } from "../frontend/builtins/prepare-number-format.js";
 
 export interface IrWholeProgramPreparationInput extends IrProgramSourceInput {
   /** Internal resolved projection requests; all consume the same semantic module. */
@@ -55,7 +56,16 @@ export function prepareWholeIrProgram(input: IrWholeProgramPreparationInput): Ir
     );
   const source = prepareIrProgramSources(input);
   if (source.kind !== "prepared") return source;
-  const typed = captureTypedIrProgramInput(source);
+  const runtimeSupport = prepareNumberFormatRuntimeSupport(source, input.policy);
+  if (
+    runtimeSupport !== undefined &&
+    policies.some((policy) => policy.backend !== "wasmgc" || policy.target !== "standalone")
+  )
+    throw new PreparedIrProgramInvariantError(
+      "invalid-prepared-data",
+      "formatter runtime support cannot request a runtime projection outside wasmgc:standalone",
+    );
+  const typed = captureTypedIrProgramInput(source, runtimeSupport);
   const controls = resolveIrPreparationControlsFromEnv();
   const counters = createGvnCounters();
   let result: IrProgramPreparationResult;

--- a/src/ir/program-prepare-ir.ts
+++ b/src/ir/program-prepare-ir.ts
@@ -10,6 +10,8 @@ import { prepareIrProgramRuntimeCallables } from "./program-runtime-abi.js";
 import { prepareWholeProgramAsyncFunctions, prepareWholeProgramRuntimeManifest } from "./runtime-program-producers.js";
 import { irProgramRuntimeDemands } from "./program-runtime-demands.js";
 import { assertPreparedIrProgram } from "./program-validation.js";
+import { assertIrRuntimeSupport, irNumberFormatDemandOwners } from "./program/runtime-support.js";
+import { analyzeIrRuntimeSupportAllocations } from "./program-allocations.js";
 import { freezePreparedIrValue, freezePreparedIrRuntimeValue, preparedIrReadonlyMap } from "./program/data.js";
 import { PreparedIrProgramInvariantError } from "./program/errors.js";
 import type {
@@ -53,6 +55,17 @@ export function prepareTypedIrProgram(
   const resolved = ownTypedIrProgramOptions(options);
   const { input: source, allocations } = ownTypedIrProgramInput(input);
   assertPreparedIrProgramPopulation(source);
+  assertIrRuntimeSupport(source, source.runtimeSupport);
+  if (
+    source.runtimeSupport !== undefined &&
+    [resolved.policy, ...resolved.runtimePolicies].some(
+      (policy) => policy.backend !== "wasmgc" || policy.target !== "standalone",
+    )
+  )
+    throw new PreparedIrProgramInvariantError(
+      "invalid-prepared-data",
+      "formatter runtime support requires wasmgc:standalone for every selected policy",
+    );
   const initialRuntime = prepareIrProgramRuntimeCallables(source);
   if (initialRuntime.kind !== "prepared") return initialRuntime;
   const initialEntries = prepareIrProgramAbiEntries(source, initialRuntime.declarations);
@@ -80,6 +93,15 @@ export function prepareTypedIrProgram(
     counters,
   );
   const finalSource = { ...source, ...optimized };
+  if (finalSource.runtimeSupport !== undefined) {
+    const demandOwners = irNumberFormatDemandOwners(finalSource.ir.functions);
+    finalSource.runtimeSupport = {
+      ...finalSource.runtimeSupport,
+      batches: finalSource.runtimeSupport.batches.map((batch) => ({ ...batch, demandOwners })),
+    };
+  }
+  assertIrRuntimeSupport({ ...finalSource, allocations: allocations.snapshot() }, finalSource.runtimeSupport);
+  analyzeIrRuntimeSupportAllocations(finalSource.runtimeSupport, allocations, resolved.controls);
   const finalRuntime = prepareIrProgramRuntimeCallables(finalSource);
   if (finalRuntime.kind !== "prepared") return finalRuntime;
   const entries = prepareIrProgramAbiEntries(finalSource, finalRuntime.declarations);
@@ -90,8 +112,12 @@ export function prepareTypedIrProgram(
     ...optimized,
     abi: { entries },
     startup: source.startup,
+    ...(finalSource.runtimeSupport === undefined ? {} : { runtimeSupport: finalSource.runtimeSupport }),
     allocations: allocations.snapshot(),
-  }) as Pick<PreparedIrProgram, "inventory" | "ir" | "derivedUnits" | "abi" | "startup" | "allocations">;
+  }) as Pick<
+    PreparedIrProgram,
+    "inventory" | "ir" | "derivedUnits" | "abi" | "startup" | "allocations" | "runtimeSupport"
+  >;
   const runtime: PreparedIrProgramRuntimeProjection[] = [];
   const demands = new Map(semantic.ir.functions.map((fn) => [fn.unitId, irProgramRuntimeDemands(fn)]));
   for (const policy of resolved.runtimePolicies) {

--- a/src/ir/program-source.ts
+++ b/src/ir/program-source.ts
@@ -84,7 +84,10 @@ function sourceDataField<T extends object, K extends keyof T>(object: T, key: K)
 }
 
 /** Explicit frontend projection; capture all semantic fields jointly with allocations. */
-export function captureTypedIrProgramInput(source: IrProgramSourcePreparation): TypedIrProgramInput {
+export function captureTypedIrProgramInput(
+  source: IrProgramSourcePreparation,
+  runtimeSupport?: TypedIrProgramInput["runtimeSupport"],
+): TypedIrProgramInput {
   const allocations = sourceDataField(source, "allocations");
   const inventory = sourceDataField(source, "inventory");
   const ir = sourceDataField(source, "ir");
@@ -122,7 +125,15 @@ export function captureTypedIrProgramInput(source: IrProgramSourcePreparation): 
       },
     });
   }
-  const captured = allocations.capturePreparationData({ inventory, ir, derivedUnits, startup, callables, globals });
+  const captured = allocations.capturePreparationData({
+    inventory,
+    ir,
+    derivedUnits,
+    startup,
+    callables,
+    globals,
+    ...(runtimeSupport === undefined ? {} : { runtimeSupport }),
+  });
   return {
     inventory: captured.data.inventory,
     ir: captured.data.ir,
@@ -131,6 +142,7 @@ export function captureTypedIrProgramInput(source: IrProgramSourcePreparation): 
     callables: captured.data.callables,
     globals: captured.data.globals,
     allocations: captured.allocations,
+    ...(captured.data.runtimeSupport === undefined ? {} : { runtimeSupport: captured.data.runtimeSupport }),
   };
 }
 

--- a/src/ir/program-validation.ts
+++ b/src/ir/program-validation.ts
@@ -25,6 +25,9 @@ import {
 import { verifyIrFunction, type IrVerificationOptions } from "./verify.js";
 import { assertPreparedIrClassLayouts } from "./program-class-layouts.js";
 import { assertPreparedIrProgramAllocations } from "./program-allocations.js";
+import { assertIrRuntimeSupport } from "./program/runtime-support.js";
+import { numberFormatRadixSupportDeclarations } from "./program/formatter-support.js";
+import { assertPreparedIrRuntimeSupportDependencies } from "./prepared-component-dependencies.js";
 import { irRuntimeCallableHasNoSlot } from "./runtime/native-async-callables.js";
 import {
   assertPreparedIrRuntimeProjection,
@@ -184,6 +187,9 @@ export function assertPreparedIrProgram(program: PreparedIrProgram, options?: Ir
   if (program.schema !== "prepared-ir-program-v1" || program.reconciliation !== "complete" || program.sealed !== true)
     invalid("program is not a complete prepared program");
   assertPreparedIrProgramPopulation(program);
+  if (Object.hasOwn(program, "runtimeSupport") && program.runtimeSupport === undefined)
+    invalid("runtime support must be absent rather than own-property undefined");
+  assertIrRuntimeSupport(program, program.runtimeSupport);
   assertPreparedIrSemanticRuntimeSeparation(program);
   assertPreparedIrProgramAllocations(program);
   assertPreparedIrClassLayouts(program);
@@ -203,7 +209,70 @@ export function assertPreparedIrProgram(program: PreparedIrProgram, options?: Ir
   }
   const entries = new Map(program.abi.entries.map((entry) => [entry.plan.id, entry]));
   if (entries.size !== program.abi.entries.length) invalid("program ABI duplicates a binding");
+  for (const batch of program.runtimeSupport?.batches ?? []) {
+    const canonical = numberFormatRadixSupportDeclarations(batch.sourceId);
+    const refs = [
+      canonical.scratch.type.ref,
+      ...canonical.kernels.map((kernel) => kernel.ref),
+      canonical.implementation.ref,
+    ];
+    const ids = refs.map((ref) => {
+      if (ref.binding.kind !== "support") return invalid("formatter declaration is not support-owned");
+      return ref.binding.bindingId;
+    });
+    const first = program.abi.entries.findIndex((entry) => entry.plan.id === ids[0]);
+    if (first < 0) invalid("formatter ABI omits scratch type");
+    const anchor = preparedIrRuntimeAbiAnchor(program.inventory);
+    const firstOrder = program.abi.entries
+      .slice(0, first)
+      .filter((entry) => entry.plan.order.sourceOrder === anchor.order).length;
+    for (const [index, id] of ids.entries()) {
+      const entry = program.abi.entries[first + index];
+      if (
+        !entry ||
+        entry.plan.id !== id ||
+        entry.plan.slotPolicy !== "required" ||
+        entry.plan.slotSpace !== (index === 0 ? "type" : "function") ||
+        entry.plan.order.sourceOrder !== anchor.order ||
+        entry.plan.order.declarationOrder !== firstOrder + index
+      )
+        invalid("formatter ABI lacks its exact ordered required declarations");
+      if (index === 0) {
+        if (
+          preparedIrDataMismatch(entry.contract, {
+            kind: "type",
+            ref: canonical.scratch.type.ref,
+            type: canonical.scratch.type,
+          }) !== undefined
+        )
+          invalid("formatter ABI scratch contract differs from canonical declaration");
+      } else {
+        const callable = [...canonical.kernels, canonical.implementation][index - 1]!;
+        if (
+          entry.plan.intent.kind !== "callable" ||
+          entry.plan.intent.origin !== "support" ||
+          entry.plan.intent.sourceId !== batch.sourceId ||
+          preparedIrDataMismatch(entry.contract, {
+            kind: "callable",
+            ref: callable.ref,
+            params: callable.params,
+            results: callable.results,
+          }) !== undefined
+        )
+          invalid("formatter ABI callable differs from canonical source-owned declaration");
+      }
+    }
+    const isRuntime = (entry: PreparedIrAbiEntry): boolean =>
+      entry.contract.kind === "callable" &&
+      (entry.contract.ref.binding.kind === "runtime" || entry.contract.ref.binding.kind === "intrinsic");
+    if (
+      program.abi.entries.slice(0, first).some(isRuntime) ||
+      program.abi.entries.slice(first + ids.length).some((entry) => !isRuntime(entry))
+    )
+      invalid("formatter ABI must follow ordinary entries and precede the runtime tail");
+  }
   validateRuntimeCallables(program);
+  assertPreparedIrRuntimeSupportDependencies(program);
   const authority = new ProgramAbiMap(program.inventory, program.derivedUnits);
   for (const entry of program.abi.entries) {
     validateEntry(entry, entries);
@@ -232,8 +301,14 @@ export function assertPreparedIrProgram(program: PreparedIrProgram, options?: Ir
       declaredGlobals.set(irBindingKey(entry.contract.ref.binding)!, entry.contract.type);
     }
   }
-  for (const fn of functions.values()) {
-    const own = entries.get(irUnitCallableBindingId(fn.unitId));
+  const bodies = [
+    ...[...functions.values()].map((fn) => ({ fn, own: entries.get(irUnitCallableBindingId(fn.unitId)) })),
+    ...(program.runtimeSupport?.batches ?? []).map((batch) => ({
+      fn: batch.implementation.body,
+      own: calls.get(irCallableBindingKey(batch.implementation.declaration.ref.binding)),
+    })),
+  ];
+  for (const { fn, own } of bodies) {
     if (
       own?.contract.kind !== "callable" ||
       !sameSignature(
@@ -292,6 +367,8 @@ export function assertPreparedIrProgram(program: PreparedIrProgram, options?: Ir
   if (program.runtime.length === 0) invalid("program lacks an explicit runtime projection");
   const projections = new Set<string>();
   for (const projection of program.runtime) {
+    if (program.runtimeSupport !== undefined && (projection.backend !== "wasmgc" || projection.target !== "standalone"))
+      invalid("formatter runtime support requires a wasmgc:standalone projection");
     const key = `${projection.backend}:${projection.target}`;
     if (projections.has(key)) invalid(`program duplicates runtime projection ${key}`);
     projections.add(key);

--- a/src/ir/program/formatter-support.ts
+++ b/src/ir/program/formatter-support.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createDerivedIrUnitId } from "../../shared/contracts/identity-values.js";
+import type { IrSourceId, IrUnitId } from "../../shared/contracts/ir-identity.js";
+import { irSupportFuncRef } from "../core/callable-bindings.js";
+import { irSupportTypeRef } from "../core/type-references.js";
+import { irSupportRef, type IrType } from "../core/types.js";
+import { freezePreparedIrValue } from "./data.js";
+import type { IrFormatterKernelRole, IrNumberFormatRadixSupport, IrRuntimeSupportCallable } from "./runtime-support.js";
+
+const F64: IrType = Object.freeze({ kind: "val", val: Object.freeze({ kind: "f64" }) });
+const STRING: IrType = Object.freeze({ kind: "string" });
+
+/** One signature authority shared by the frontend producer and program validation. */
+export function numberFormatRadixSupportDeclarations(sourceId: IrSourceId): {
+  readonly ownerUnitId: IrUnitId;
+  readonly scratch: IrNumberFormatRadixSupport["scratch"];
+  readonly kernels: IrNumberFormatRadixSupport["kernels"];
+  readonly implementation: IrRuntimeSupportCallable;
+} {
+  const scratch = {
+    type: irSupportRef(irSupportTypeRef(sourceId, "number-format-radix:scratch", "__nfd_buffer"), true),
+    storage: { kind: "array" as const, element: "i16" as const, mutable: true as const },
+    stringDataRole: ["string-type", "data"] as const,
+  };
+  const kernel = <R extends IrFormatterKernelRole>(
+    role: R,
+    name: string,
+    params: readonly IrType[],
+    results: readonly IrType[],
+  ): IrRuntimeSupportCallable & { readonly role: R } => ({
+    role,
+    ref: irSupportFuncRef(sourceId, "number-format-radix:" + role, name),
+    params,
+    results,
+  });
+  const declarations = {
+    ownerUnitId: createDerivedIrUnitId({
+      parentId: sourceId,
+      role: "runtime-support:number-format-radix",
+      ordinal: 0,
+    }),
+    scratch,
+    kernels: [
+      kernel("new", "__nfd_new", [F64], [scratch.type]),
+      kernel("get", "__nfd_get", [scratch.type, F64], [F64]),
+      kernel("set", "__nfd_set", [scratch.type, F64, F64], []),
+      kernel("fin", "__nfd_fin", [scratch.type, F64], [STRING]),
+      kernel("trap", "__num_fmt_trap", [], []),
+    ] as const,
+    implementation: {
+      ref: irSupportFuncRef(sourceId, "number-format-radix:body", "__sh_num_toString_radix"),
+      params: [F64, F64],
+      results: [STRING],
+    },
+  };
+  return freezePreparedIrValue(declarations) as typeof declarations;
+}

--- a/src/ir/program/input-contracts.ts
+++ b/src/ir/program/input-contracts.ts
@@ -11,6 +11,7 @@ import type { ProgramAbiDerivedUnitRecord } from "./abi.js";
 import type { IrProgramCallableBindingRecord } from "./callable-bindings.js";
 import type { IrPreparationControls } from "./controls.js";
 import type { RuntimeManifestPolicy } from "../../runtime/contracts/provider-policy.js";
+import type { IrRuntimeSupport } from "./runtime-support.js";
 
 /** Only semantic storage facts cross the frontend boundary, never declarations. */
 export interface TypedIrProgramGlobal {
@@ -39,6 +40,7 @@ export interface TypedIrProgramInput {
   readonly callables: readonly IrProgramCallableBindingRecord[];
   readonly globals: readonly TypedIrProgramGlobal[];
   readonly allocations: AllocRegistrySnapshot;
+  readonly runtimeSupport?: IrRuntimeSupport;
 }
 
 export interface TypedIrProgramOptions {

--- a/src/ir/program/input.ts
+++ b/src/ir/program/input.ts
@@ -4,6 +4,7 @@ import { AllocSiteRegistry, copyIrPreparationData } from "../analysis/alloc-regi
 import { preparedIrDataMismatch } from "./data.js";
 import { PreparedIrProgramInvariantError } from "./errors.js";
 import type { TypedIrProgramInput, TypedIrProgramOptions } from "./input-contracts.js";
+import { assertIrRuntimeSupport } from "./runtime-support.js";
 
 function invalid(detail: string): never {
   throw new PreparedIrProgramInvariantError("invalid-prepared-data", detail);
@@ -76,7 +77,11 @@ export function ownTypedIrProgramInput(input: TypedIrProgramInput): {
 } {
   // Inspect descriptors before reading any caller-supplied field. No getters run.
   const captured = copyIrPreparationData(input);
-  fields(captured, ["inventory", "ir", "derivedUnits", "startup", "callables", "globals", "allocations"]);
+  fields(
+    captured,
+    ["inventory", "ir", "derivedUnits", "startup", "callables", "globals", "allocations"],
+    ["runtimeSupport"],
+  );
   fields(captured.inventory, ["sources", "classes", "allUnits", "terminalUnits"]);
   for (const values of [
     captured.inventory.sources,
@@ -103,6 +108,10 @@ export function ownTypedIrProgramInput(input: TypedIrProgramInput): {
       invalid("typed global lacks source/storage ownership");
   }
   assertGlobalStorage(captured);
+  if (Object.hasOwn(captured, "runtimeSupport")) {
+    if (captured.runtimeSupport === undefined) invalid("typed input must omit absent runtime support");
+    assertIrRuntimeSupport(captured, captured.runtimeSupport);
+  }
   // Joint restoration retains sharing between IR, sites, and metadata values.
   const restored = AllocSiteRegistry.restorePreparationData(captured.allocations, captured);
   return { input: restored.data, allocations: restored.allocations };

--- a/src/ir/program/prepared-contracts.ts
+++ b/src/ir/program/prepared-contracts.ts
@@ -12,6 +12,7 @@ import type { AllocRegistrySnapshot } from "../analysis/contracts/allocations.js
 import type { ProgramAbiDerivedUnitRecord, ProgramAbiPlanEntry } from "./abi.js";
 import type { PreparedComponentAbiLookup } from "./abi-lookup.js";
 import type { IrModuleInitPlan } from "./startup.js";
+import type { IrRuntimeSupport } from "./runtime-support.js";
 
 /** Semantic contracts enrich the existing ABI entries; there is no second binding authority. */
 export type PreparedIrAbiContract =
@@ -81,6 +82,7 @@ export interface PreparedIrProgram {
   /** Includes empty sources and preserves semantic module evaluation order. */
   readonly startup: readonly IrModuleInitPlan[];
   readonly allocations: AllocRegistrySnapshot;
+  readonly runtimeSupport?: IrRuntimeSupport;
   readonly runtime: readonly PreparedIrProgramRuntimeProjection[];
   readonly reconciliation: "complete";
   readonly sealed: true;

--- a/src/ir/program/runtime-support.ts
+++ b/src/ir/program/runtime-support.ts
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { forEachNestedBuffer, type AllocSiteId, type IrFunction, type IrInstr } from "../core/nodes.js";
+import type { IrSupportRefType, IrType } from "../core/types.js";
+import type { IrFuncRef } from "../core/value-references.js";
+import type { IrSourceId, IrUnitId } from "../../shared/contracts/ir-identity.js";
+import { irNativeAsyncCallableDeclaration } from "../runtime/native-async-callables.js";
+import { PreparedIrProgramInvariantError } from "./errors.js";
+import { preparedIrDataMismatch } from "./data.js";
+import { irCallableBindingKey } from "../core/callable-bindings.js";
+import { numberFormatRadixSupportDeclarations } from "./formatter-support.js";
+import type { TypedIrProgramInput } from "./input-contracts.js";
+
+export type IrFormatterKernelRole = "new" | "get" | "set" | "fin" | "trap";
+
+/** A compiler support declaration, distinct from an ordinary source callable. */
+export interface IrRuntimeSupportCallable {
+  readonly ref: IrFuncRef;
+  readonly params: readonly IrType[];
+  readonly results: readonly IrType[];
+}
+
+export interface IrRuntimeSupportCallOccurrence {
+  readonly path: readonly (string | number)[];
+  readonly target: IrFuncRef;
+}
+
+export interface IrRuntimeSupportLiteralOccurrence {
+  readonly path: readonly (string | number)[];
+  readonly value: string;
+  readonly alloc: AllocSiteId;
+}
+
+/** Fully built semantic IR, never source text or a deferred compiler callback. */
+export interface IrNumberFormatRadixSupport {
+  readonly kind: "number-format-radix-v1";
+  readonly sourceId: IrSourceId;
+  readonly demandOwners: readonly IrUnitId[];
+  readonly source: {
+    readonly definition: "numToStringRadixDef";
+    readonly functionName: "__sh_num_toString_radix";
+    readonly utf8Bytes: 1618;
+    readonly sha256: "7b13099fbed0a87079f92e9bddbf75959065ed28daf66d5ad344e0b240037dc6";
+  };
+  readonly scratch: {
+    readonly type: IrSupportRefType;
+    readonly storage: { readonly kind: "array"; readonly element: "i16"; readonly mutable: true };
+    readonly stringDataRole: readonly ["string-type", "data"];
+  };
+  readonly kernels: readonly [
+    IrRuntimeSupportCallable & { readonly role: "new" },
+    IrRuntimeSupportCallable & { readonly role: "get" },
+    IrRuntimeSupportCallable & { readonly role: "set" },
+    IrRuntimeSupportCallable & { readonly role: "fin" },
+    IrRuntimeSupportCallable & { readonly role: "trap" },
+  ];
+  readonly implementation: {
+    readonly declaration: IrRuntimeSupportCallable;
+    readonly body: IrFunction;
+  };
+  /** Post-hygiene occurrences; source call counts are a separate proof. */
+  readonly calls: readonly IrRuntimeSupportCallOccurrence[];
+  readonly literals: readonly IrRuntimeSupportLiteralOccurrence[];
+}
+
+export interface IrRuntimeSupport {
+  readonly schema: "ir-runtime-support-v1";
+  readonly batches: readonly IrNumberFormatRadixSupport[];
+}
+
+function invalidSupport(detail: string): never {
+  throw new PreparedIrProgramInvariantError("invalid-prepared-data", `runtime support: ${detail}`);
+}
+
+function sameSupport(actual: unknown, expected: unknown, detail: string): void {
+  if (preparedIrDataMismatch(actual, expected) !== undefined) invalidSupport(detail);
+}
+
+type SupportPath = readonly (string | number)[];
+
+/** Paths only: the canonical walker below remains the buffer-population authority. */
+function childPaths(instr: IrInstr): readonly SupportPath[] {
+  switch (instr.kind) {
+    case "if":
+    case "if.stmt":
+      return [["then"], ["else"]];
+    case "forof.vec":
+    case "forof.iter":
+    case "forof.string":
+    case "labeled.block":
+      return [["body"]];
+    case "while.loop":
+      return [["cond"], ["body"]];
+    case "for.loop":
+      return [["cond"], ["body"], ["update"]];
+    case "try":
+      return [
+        ["body"],
+        ...(instr.catchClause ? [["catchClause", "body"]] : []),
+        ...(instr.finallyBody ? [["finallyBody"]] : []),
+      ];
+    case "switch":
+      return instr.bodies.map((_, index) => ["bodies", index]);
+    default:
+      return [];
+  }
+}
+
+function walkSupportBody(body: IrFunction, visit: (instr: IrInstr, path: SupportPath) => void): void {
+  const active = new Set<readonly IrInstr[]>();
+  const walk = (buffer: readonly IrInstr[], prefix: SupportPath): void => {
+    if (!Array.isArray(buffer) || active.has(buffer)) invalidSupport("missing or cyclic support buffer");
+    active.add(buffer);
+    for (let index = 0; index < buffer.length; index++) {
+      const instr = buffer[index];
+      if (!Object.hasOwn(buffer, index) || !instr) invalidSupport("sparse support buffer");
+      const path = [...prefix, index];
+      visit(instr, path);
+      const paths = childPaths(instr);
+      let ordinal = 0;
+      forEachNestedBuffer(instr, (child) => {
+        const relative = paths[ordinal++];
+        if (!relative) invalidSupport("unmapped canonical child buffer");
+        let target: unknown = instr;
+        for (const key of relative) {
+          if (!target || typeof target !== "object" || !Object.hasOwn(target, key))
+            invalidSupport("missing child-buffer path");
+          target = (target as Record<string | number, unknown>)[key];
+        }
+        if (target !== child) invalidSupport("child-buffer path disagrees with canonical traversal");
+        walk(child, [...path, ...relative]);
+      });
+      if (ordinal !== paths.length) invalidSupport("extra child-buffer path");
+    }
+    active.delete(buffer);
+  };
+  if (!Array.isArray(body.blocks) || body.blocks.length === 0) invalidSupport("missing support entry block");
+  for (let index = 0; index < body.blocks.length; index++) {
+    if (!Object.hasOwn(body.blocks, index) || !body.blocks[index]) invalidSupport("sparse support blocks");
+    walk(body.blocks[index]!.instrs, ["blocks", index, "instrs"]);
+  }
+}
+
+/** Recount executable positions, including aliased sibling buffers separately. */
+export function irRuntimeSupportOccurrences(body: IrFunction): {
+  readonly calls: readonly IrRuntimeSupportCallOccurrence[];
+  readonly literals: readonly IrRuntimeSupportLiteralOccurrence[];
+} {
+  const calls: IrRuntimeSupportCallOccurrence[] = [];
+  const literals: IrRuntimeSupportLiteralOccurrence[] = [];
+  walkSupportBody(body, (instr, path) => {
+    if (instr.kind === "call") calls.push({ path, target: instr.target });
+    if (instr.kind === "string.const") {
+      if (instr.alloc === undefined) invalidSupport("support literal has no allocation identity");
+      literals.push({ path, value: instr.value, alloc: instr.alloc });
+    }
+  });
+  return { calls, literals };
+}
+
+function exactSupportKeys(value: unknown, keys: readonly string[], label: string): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) invalidSupport(`invalid ${label}`);
+  sameSupport(Object.keys(value).sort(), [...keys].sort(), `${label} field population`);
+}
+
+/** Structural support checks; full SSA and allocation analyses stay in program validation. */
+export function assertIrRuntimeSupport(
+  input: Pick<TypedIrProgramInput, "inventory" | "ir" | "derivedUnits" | "allocations">,
+  support: IrRuntimeSupport | undefined,
+): void {
+  const demanded = irNumberFormatDemandOwners(input.ir.functions);
+  if (demanded.length === 0) {
+    if (support !== undefined) invalidSupport("support supplied without primary demand");
+    return;
+  }
+  if (!support) invalidSupport("missing demanded formatter support");
+  exactSupportKeys(support, ["schema", "batches"], "support");
+  if (support.schema !== "ir-runtime-support-v1" || !Array.isArray(support.batches) || support.batches.length !== 1)
+    invalidSupport("invalid support schema or batch population");
+  const batch = support.batches[0];
+  exactSupportKeys(
+    batch,
+    ["kind", "sourceId", "demandOwners", "source", "scratch", "kernels", "implementation", "calls", "literals"],
+    "radix batch",
+  );
+  const entries = input.inventory.sources.filter((source) => source.kind === "entry");
+  if (entries.length !== 1 || !batch || batch.sourceId !== entries[0]!.id || batch.kind !== "number-format-radix-v1")
+    invalidSupport("invalid radix source anchor");
+  sameSupport(batch.demandOwners, demanded, "stale primary demand owners");
+  for (const owner of demanded) {
+    const records = [...input.inventory.allUnits, ...input.derivedUnits].filter((record) => record.id === owner);
+    if (records.length !== 1 || !input.inventory.sources.some((source) => source.id === records[0]!.sourceId))
+      invalidSupport("formatter demand has no exact source owner");
+  }
+  sameSupport(
+    batch.source,
+    {
+      definition: "numToStringRadixDef",
+      functionName: "__sh_num_toString_radix",
+      utf8Bytes: 1618,
+      sha256: "7b13099fbed0a87079f92e9bddbf75959065ed28daf66d5ad344e0b240037dc6",
+    },
+    "changed radix source provenance",
+  );
+  const declared = numberFormatRadixSupportDeclarations(batch.sourceId);
+  sameSupport(batch.scratch, declared.scratch, "changed scratch contract");
+  sameSupport(batch.kernels, declared.kernels, "changed kernel declarations");
+  exactSupportKeys(batch.implementation, ["declaration", "body"], "radix implementation");
+  sameSupport(batch.implementation.declaration, declared.implementation, "changed radix declaration");
+  const body = batch.implementation.body;
+  if (
+    [...input.inventory.allUnits, ...input.derivedUnits].some((unit) => unit.id === declared.ownerUnitId) ||
+    input.ir.functions.some((fn) => fn.unitId === declared.ownerUnitId)
+  )
+    invalidSupport("support body contaminates the ordinary source population");
+  if (!body || body.unitId !== declared.ownerUnitId || body.name !== declared.implementation.ref.name || body.exported)
+    invalidSupport("foreign support body identity");
+  if (
+    (body.funcKind !== undefined && body.funcKind !== "regular") ||
+    ["closureSubtype", "asyncPlan", "asyncRuntime", "generatorBufferSlot"].some((key) => Object.hasOwn(body, key))
+  )
+    invalidSupport("unsupported radix attachment");
+  sameSupport(
+    body.params.map((param: IrFunction["params"][number]) => param.type),
+    declared.implementation.params,
+    "changed radix parameters",
+  );
+  sameSupport(body.resultTypes, declared.implementation.results, "changed radix results");
+  const occurrences = irRuntimeSupportOccurrences(body);
+  sameSupport(batch.calls, occurrences.calls, "stale support call occurrences");
+  sameSupport(batch.literals, occurrences.literals, "stale support literal occurrences");
+  const kernels = new Map(declared.kernels.map((kernel) => [irCallableBindingKey(kernel.ref.binding), kernel]));
+  walkSupportBody(body, (instr) => {
+    if (instr.kind === "call") {
+      const callee = kernels.get(irCallableBindingKey(instr.target.binding));
+      if (!callee) invalidSupport("undeclared support callable");
+      sameSupport(instr.target, callee.ref, "changed support callable reference");
+      if (instr.args.length !== callee.params.length) invalidSupport("support call argument count");
+      sameSupport(instr.resultType, callee.results[0] ?? null, "support call result contract");
+      if (callee.role === "fin" && instr.alloc === undefined) invalidSupport("fin result has no string allocation");
+    }
+    if (
+      instr.kind.startsWith("global.") ||
+      instr.kind.startsWith("closure.") ||
+      instr.kind.startsWith("class.") ||
+      instr.kind.startsWith("extern.") ||
+      instr.kind === "raw.wasm" ||
+      instr.kind === "await"
+    )
+      invalidSupport("undeclared support dependency");
+    if (instr.alloc !== undefined) {
+      let id: number = instr.alloc;
+      const visited = new Set<number>();
+      for (;;) {
+        if (!Number.isSafeInteger(id) || id < 0 || id >= input.allocations.size || visited.has(id))
+          invalidSupport("missing or cyclic support allocation");
+        visited.add(id);
+        const entry = input.allocations.entries[id];
+        if (!entry || entry.state === "retired") invalidSupport("support allocation is not live");
+        if (entry.state === "aliased") {
+          id = entry.to;
+          continue;
+        }
+        if (entry.site.id !== id || entry.site.kind !== "string") invalidSupport("foreign support allocation kind");
+        sameSupport(entry.site.type, { kind: "string" }, "support allocation type");
+        break;
+      }
+    }
+  });
+}
+
+/**
+ * Recollect demand from primary executable bodies, independently of a batch's
+ * own demand receipt. This is a demand census, not selected-provider authority.
+ * Source preparation and final validation use the same traversal on their own
+ * current bodies; support functions never manufacture primary demand owners.
+ */
+export function irNumberFormatDemandOwners(functions: readonly IrFunction[]): readonly IrUnitId[] {
+  const owners: IrUnitId[] = [];
+  const seen = new Set<IrUnitId>();
+  const active = new Set<readonly IrInstr[]>();
+  const dense = <T>(items: readonly T[], label: string, visit: (item: T) => void): void => {
+    if (!Array.isArray(items)) invalidSupport(`missing ${label}`);
+    for (let index = 0; index < items.length; index++) {
+      if (!Object.hasOwn(items, index) || items[index] === undefined) invalidSupport(`sparse ${label}`);
+      visit(items[index]!);
+    }
+  };
+  dense(functions, "primary functions", (fn) => {
+    if (!fn || !fn.unitId || seen.has(fn.unitId)) invalidSupport("missing or duplicate primary owner");
+    seen.add(fn.unitId);
+    let demanded = false;
+    const visit = (buffer: readonly IrInstr[]): void => {
+      if (active.has(buffer)) invalidSupport("cyclic executable buffer");
+      active.add(buffer);
+      dense(buffer, "executable instructions", (instr) => {
+        if (!instr) invalidSupport("missing executable instruction");
+        const ref = instr.kind === "call" ? instr.target : instr.kind === "closure.new" ? instr.liftedFunc : undefined;
+        if (ref && irNativeAsyncCallableDeclaration(ref)?.feature === "async.native.number-to-string") {
+          if (instr.kind !== "call") invalidSupport("formatter support requires a direct canonical call");
+          demanded = true;
+        }
+        // Never stop after the first hit: malformed later buffers still fail.
+        forEachNestedBuffer(instr, visit);
+      });
+      active.delete(buffer);
+    };
+    dense(fn.blocks, "primary blocks", (block) => visit(block.instrs));
+    if (fn.asyncPlan) dense(fn.asyncPlan.states, "semantic async states", (state) => visit(state.body));
+    if (demanded) owners.push(fn.unitId);
+  });
+  return Object.freeze(owners);
+}
+
+/** Additional bodies only; never substitutes for the primary program population. */
+export function irRuntimeSupportFunctions(support: IrRuntimeSupport | undefined): readonly IrFunction[] {
+  return support === undefined ? [] : support.batches.map((batch) => batch.implementation.body);
+}

--- a/src/ir/string-carrier.ts
+++ b/src/ir/string-carrier.ts
@@ -65,6 +65,7 @@ export function attachIrStringCarrier(fn: IrFunction, carrierRef: IrTypeRef): Ir
   };
 
   function mapType(type: IrType): IrType {
+    if (type.kind === "support-ref") return type;
     const cached = typeMemo.get(type);
     if (cached) return cached;
     let mapped: IrType;

--- a/src/ir/type-key.ts
+++ b/src/ir/type-key.ts
@@ -18,6 +18,8 @@ export function irTypeKey(type: IrType): string {
       return current.val.kind;
     }
     if (current.kind === "string") return "string";
+    if (current.kind === "support-ref")
+      return `support-ref|${current.ref.binding.bindingId.length}:${current.ref.binding.bindingId}|nullable:${current.nullable ? 1 : 0}`;
     if (active.has(current)) throw new Error("IR type key cannot encode a recursive anonymous layout");
     active.add(current);
     try {

--- a/src/ir/vec-layout.ts
+++ b/src/ir/vec-layout.ts
@@ -79,6 +79,7 @@ export function attachIrVecLayouts(
   };
 
   function mapType(type: IrType): IrType {
+    if (type.kind === "support-ref") return type;
     const cached = typeMemo.get(type);
     if (cached) return cached;
     let mapped: IrType;
@@ -262,6 +263,7 @@ export function attachIrVecLayouts(
       case "class":
       case "extern":
       case "dynamic":
+      case "support-ref":
         return;
     }
   };

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -22,6 +22,7 @@
 
 import type { IrBlock, IrFunction, IrInstr, IrLabelId, IrModuleDeclarations, IrType, IrValueId } from "./nodes.js";
 import { asVal, forEachInstrDeep, forEachNestedBuffer, irTypeEquals } from "./nodes.js";
+import { irSupportRef } from "./core/types.js";
 // #4605 — the module-level declared-type tables and the rules that read them.
 // `verifyIrFunction` stays standalone: the tables arrive as an optional
 // parameter, and their absence is always a conservative skip.
@@ -371,6 +372,30 @@ export function verifyIrFunction(
   options?: IrVerificationOptions,
 ): IrVerifyError[] {
   const errors: IrVerifyError[] = [];
+  const checkSupportType = (type: IrType | null | undefined): void => {
+    if (type?.kind !== "support-ref") return;
+    try {
+      irSupportRef(type.ref, type.nullable);
+      if (Object.hasOwn(type, "val") || Object.hasOwn(type, "typeIdx") || Object.hasOwn(type, "layout"))
+        throw new TypeError("support-ref cannot carry physical fields");
+    } catch (error) {
+      errors.push({
+        message: `invalid support-ref type: ${error instanceof Error ? error.message : String(error)}`,
+        func: func.name,
+      });
+    }
+  };
+  for (const param of func.params) checkSupportType(param.type);
+  for (const type of func.resultTypes) checkSupportType(type);
+  for (const block of func.blocks) {
+    for (const type of block.blockArgTypes) checkSupportType(type);
+    for (const root of block.instrs)
+      forEachInstrDeep(root, (instr) => {
+        checkSupportType(instr.resultType);
+        if (instr.kind === "const" && instr.value.kind === "null") checkSupportType(instr.value.ty);
+      });
+  }
+  if (errors.length) return errors;
   const defs = new Set<IrValueId>();
 
   if (func.asyncPlan) {
@@ -551,6 +576,7 @@ export function verifyIrFunction(
  * an unambiguous mismatch.
  */
 function returnTypeAssignable(actual: IrType, declared: IrType): boolean {
+  if (actual.kind === "support-ref" || declared.kind === "support-ref") return irTypeEquals(actual, declared);
   // Fnctor values are nominal source-qualified instances, never arbitrary
   // reference-shaped carriers. An exact shape match is required in either
   // return direction; there is no implicit fnctor↔object/class conversion.
@@ -1539,6 +1565,18 @@ function checkBranchArgTypes(
 ): void {
   const target = func.blocks[toIdx];
   if (!target) return; // arity check already reported the bad target
+  for (let i = 0; i < args.length; i++) {
+    const actual = typeOf.get(args[i]!),
+      declared = target.blockArgTypes[i];
+    if (actual?.kind === "support-ref" || declared?.kind === "support-ref") {
+      if (!actual || !declared || !irTypeEquals(actual, declared))
+        errors.push({
+          message: `branch arg ${i} support-ref identity/nullability mismatch`,
+          func: func.name,
+          block: from.id as number,
+        });
+    }
+  }
   const n = Math.min(args.length, target.blockArgTypes.length);
   for (let i = 0; i < n; i++) {
     const declared = target.blockArgTypes[i];
@@ -2095,6 +2133,14 @@ function checkArmsAgainstResult(
   blockId: number,
   ctx: RoadmapRuleCtx,
 ): void {
+  if (resultType?.kind === "support-ref" || arms.some(([, value]) => ctx.typeOf.get(value)?.kind === "support-ref")) {
+    for (const [label, value] of arms) {
+      const actual = ctx.typeOf.get(value);
+      if (!actual || !resultType || !irTypeEquals(actual, resultType))
+        roadmapError(ctx, blockId, `${kind} ${label} support-ref identity/nullability mismatch`);
+    }
+    return;
+  }
   const want = resultType ? (asVal(resultType)?.kind ?? null) : null;
   if (want === null) return;
   for (const [label, v] of arms) {
@@ -2183,6 +2229,12 @@ function checkDeclaredCarrier(
   ctx: RoadmapRuleCtx,
   suffix = "",
 ): void {
+  const actual = ctx.typeOf.get(value);
+  if (declared?.kind === "support-ref" || actual?.kind === "support-ref") {
+    if (!actual || !declared || !irTypeEquals(actual, declared))
+      roadmapError(ctx, blockId, `${label} support-ref identity/nullability mismatch${suffix}`);
+    return;
+  }
   const want = asVal(declared)?.kind ?? null;
   const got = valKindOf(ctx.typeOf, value);
   if (want !== null && got !== null && got !== want) {
@@ -2258,6 +2310,32 @@ function checkSymbolicRefCoherence(instr: RoadmapSymbolicInstr, blockId: number,
   if (instr.kind === "call") {
     const resultKind = instr.resultType ? (asVal(instr.resultType)?.kind ?? null) : null;
     const signature = ctx.declarations?.declaredSignatures?.get(key);
+    const carriesSupport =
+      instr.resultType?.kind === "support-ref" ||
+      instr.args.some((value) => ctx.typeOf.get(value)?.kind === "support-ref") ||
+      signature?.result?.kind === "support-ref" ||
+      signature?.params.some((type) => type.kind === "support-ref");
+    if (carriesSupport) {
+      if (!signature) roadmapError(ctx, blockId, `call ${instr.target.name} support-ref requires a declared signature`);
+      else {
+        if (signature.params.length !== instr.args.length)
+          roadmapError(ctx, blockId, `call ${instr.target.name} support-ref declaration arity mismatch`);
+        for (let i = 0; i < instr.args.length; i++) {
+          const actual = ctx.typeOf.get(instr.args[i]!),
+            expected = signature.params[i];
+          if (actual?.kind === "support-ref" || expected?.kind === "support-ref")
+            if (!actual || !expected || !irTypeEquals(actual, expected))
+              roadmapError(
+                ctx,
+                blockId,
+                `call ${instr.target.name} arg ${i} support-ref identity/nullability mismatch`,
+              );
+        }
+        if (instr.resultType?.kind === "support-ref" || signature.result?.kind === "support-ref")
+          if (!instr.resultType || !signature.result || !irTypeEquals(instr.resultType, signature.result))
+            roadmapError(ctx, blockId, `call ${instr.target.name} result support-ref identity/nullability mismatch`);
+      }
+    }
     if (signature !== undefined) {
       const want = signature.result ? (asVal(signature.result)?.kind ?? null) : null;
       const args = instr.args.length;
@@ -2429,6 +2507,28 @@ function collectIrDefinitions(func: IrFunction): ReadonlyMap<IrValueId, IrInstr>
   return definitions;
 }
 
+function checkSupportRefFlow(instr: IrInstr, blockId: number, ctx: RoadmapRuleCtx): void {
+  const supportOperand = collectUses(instr).some((value) => ctx.typeOf.get(value)?.kind === "support-ref");
+  const supportResult = instr.resultType?.kind === "support-ref";
+  if (supportOperand || supportResult) {
+    const permitted =
+      instr.kind === "call" ||
+      instr.kind === "if" ||
+      instr.kind === "select" ||
+      instr.kind === "early.return" ||
+      (instr.kind === "unary" && instr.op === "ref.is_null" && !supportResult) ||
+      (instr.kind === "const" &&
+        instr.value.kind === "null" &&
+        instr.resultType?.kind === "support-ref" &&
+        instr.resultType.nullable &&
+        irTypeEquals(instr.value.ty, instr.resultType));
+    if (!permitted) roadmapError(ctx, blockId, `${instr.kind} does not support support-ref flow`);
+    const condition = instr.kind === "if" ? instr.cond : instr.kind === "select" ? instr.condition : undefined;
+    if (condition !== undefined && ctx.typeOf.get(condition)?.kind === "support-ref")
+      roadmapError(ctx, blockId, `${instr.kind} condition cannot be support-ref`);
+  }
+}
+
 function verifyInstrTypeRules(
   func: IrFunction,
   typeOf: ReadonlyMap<IrValueId, IrType>,
@@ -2464,6 +2564,7 @@ function verifyInstrTypeRules(
   };
 
   const checkInstr = (instr: IrInstr, blockId: number): void => {
+    checkSupportRefFlow(instr, blockId, roadmap);
     if (checkRoadmapRule(instr, blockId, roadmap)) return;
     switch (instr.kind) {
       case "intrinsic": {

--- a/src/shared/contracts/ir-identity.ts
+++ b/src/shared/contracts/ir-identity.ts
@@ -27,6 +27,7 @@ export interface IrFunctionIdentity {
 export type IrSyntheticUnitRole =
   | `compiler-unit:${CompilerSourceProducer}:${string}`
   | `stdlib-selfhost:${string}`
+  | "runtime-support:number-format-radix"
   | "ir-async-state"
   | "lifted-closure"
   | "monomorphization-clone";

--- a/src/stdlib/number-format.ts
+++ b/src/stdlib/number-format.ts
@@ -31,8 +31,8 @@
  * carry the ctx-bound `$__str_data` typeIdx (the #3161 typed-def rule).
  */
 
-import type { SelfHostedFuncDef } from "../codegen/stdlib-selfhost.js";
-import { irVal, type IrType } from "../ir/nodes.js";
+import type { SelfHostedFuncDef } from "../frontend/builtins/contracts.js";
+import { irVal, type IrType } from "../ir/core/types.js";
 
 const F64: IrType = irVal({ kind: "f64" });
 const STR: IrType = { kind: "string" };

--- a/tests/helpers/native-family-runtime-support.ts
+++ b/tests/helpers/native-family-runtime-support.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { captureTypedIrProgramInput, type IrProgramSourcePreparation } from "../../src/ir/program-source.js";
+import { prepareNumberFormatRuntimeSupport } from "../../src/frontend/builtins/prepare-number-format.js";
+import type { RuntimeManifestPolicy } from "../../src/ir/runtime-manifest.js";
+import type { TypedIrProgramInput } from "../../src/ir/program/input-contracts.js";
+
+/** Frontend-side fixture capture; never imported by a source-free replay child. */
+export function captureNativeFamilyRuntimeSupport(
+  source: IrProgramSourcePreparation,
+  policy: RuntimeManifestPolicy,
+): TypedIrProgramInput {
+  const support = prepareNumberFormatRuntimeSupport(source, policy);
+  if (support?.batches.length !== 1) throw new Error("native family fixture requires one real formatter support batch");
+  return captureTypedIrProgramInput(source, support);
+}

--- a/tests/helpers/runtime-support-source-free.mjs
+++ b/tests/helpers/runtime-support-source-free.mjs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { register } from "node:module";
+import { readFileSync } from "node:fs";
+
+const [packetFile, censusFile, mode = "replay"] = process.argv.slice(2);
+if (!packetFile || !censusFile || !["replay", "probe"].includes(mode))
+  throw new Error("invalid runtime-support replay arguments");
+const patterns = [
+  /\/src\/(checker|frontend|codegen|codegen-linear|stdlib)\//,
+  /\/src\/(ts-api|compiler|index)\.[cm]?[jt]s$/,
+  /\/src\/ir\/(from-ast|async-from-ast|async-prepare|identity|program-source|program-preparation|program-middleend)\.[cm]?[jt]s$/,
+  /\/node_modules\/(typescript|typescript7)\//,
+];
+const loader = `data:text/javascript,${encodeURIComponent(`
+  import { appendFileSync } from "node:fs";
+  import { fileURLToPath } from "node:url";
+  let data;
+  export function initialize(value) { data = value; }
+  function inspect(url, parent) {
+    const path = url.startsWith("file:") ? fileURLToPath(url) : url;
+    const denied = data.patterns.some(pattern => new RegExp(pattern).test(path));
+    appendFileSync(data.file, JSON.stringify({url, parent:parent??null, denied}) + "\\n");
+    if (denied) throw new Error("forbidden runtime-support replay load: " + url);
+  }
+  export async function resolve(specifier, context, next) {
+    if (specifier.startsWith("file:") || ((specifier.startsWith("./") || specifier.startsWith("../")) && context.parentURL?.startsWith("file:")))
+      inspect(new URL(specifier, context.parentURL).href, context.parentURL);
+    const result = await next(specifier, context);
+    inspect(result.url, context.parentURL);
+    return result;
+  }
+`)}`;
+register(loader, {
+  parentURL: import.meta.url,
+  data: { file: censusFile, patterns: patterns.map((pattern) => pattern.source) },
+});
+
+const report = { ok: false, decoded: false, batches: 0, calls: 0, literals: 0, error: null };
+try {
+  const { decodePreparedIrProgram, encodePreparedIrProgram } = await import("../../src/ir/program-codec.ts");
+  const { assertIrRuntimeSupport } = await import("../../src/ir/program/runtime-support.ts");
+  const text = readFileSync(packetFile, "utf8");
+  const program = decodePreparedIrProgram(text);
+  assertIrRuntimeSupport(program, program.runtimeSupport);
+  if (encodePreparedIrProgram(program) !== text) throw new Error("canonical support bytes changed");
+  report.batches = program.runtimeSupport?.batches.length ?? 0;
+  for (const batch of program.runtimeSupport?.batches ?? []) {
+    report.calls += batch.calls.length;
+    report.literals += batch.literals.length;
+  }
+  if (report.batches !== 1 || report.calls === 0 || report.literals === 0)
+    throw new Error("empty support replay is not evidence");
+  report.decoded = true;
+  if (mode === "probe") await import("../../src/ir/from-ast.ts");
+  report.ok = true;
+} catch (error) {
+  report.error = error instanceof Error ? error.message : String(error);
+  process.exitCode = 1;
+}
+process.stdout.write(JSON.stringify(report) + "\n");

--- a/tests/issue-3518-compiler-boundaries.test.ts
+++ b/tests/issue-3518-compiler-boundaries.test.ts
@@ -102,6 +102,176 @@ afterEach(() => {
 const codes = (result: ReturnType<ReturnType<typeof fixture>["run"]>) =>
   result.report.errors.map((error: { code: string }) => error.code);
 
+it("records exactly the existing frontend debt affected by contracts-only activation", () => {
+  const policy = JSON.parse(readFileSync(resolve(repository, "scripts/compiler-boundaries.json"), "utf8"));
+  const changed = [
+    ...[
+      "binder",
+      "builtin-shadow",
+      "dts-entrypoint-seeds",
+      "index",
+      "inhouse-globals",
+      "inhouse-oracle",
+      "language-service",
+      "multi-file-paths",
+      "oracle-backend",
+      "oracle-declaration-snapshot",
+      "oracle",
+      "ts5-trace",
+      "type-mapper",
+      "usage-inference",
+    ].map((name) => `src/checker/${name}.ts`),
+    "src/ir/planning-sites.ts",
+    "src/ir/program-logical-types.ts",
+    "src/ir/program-native-async-source.ts",
+  ];
+  expect(changed).toHaveLength(17);
+  for (const path of changed)
+    expect(policy.files.find((row: { path: string }) => row.path === path)).toMatchObject({
+      state: "unmigrated",
+      layer: "mixed-needs-split",
+      destination: "frontend-ts",
+      owner: "3518-coordinator",
+    });
+  for (const path of ["src/checker/divergence-classifier.ts", "src/checker/node-capability-map.ts", "src/ts-api.ts"])
+    expect(policy.files.find((row: { path: string }) => row.path === path)).toEqual({
+      path,
+      state: "unmigrated",
+      layer: "frontend-ts",
+    });
+  expect(policy.layers.find((row: { id: string }) => row.id === "frontend-ts")).toEqual({
+    id: "frontend-ts",
+    status: "active",
+    roots: ["src/frontend/builtins/contracts.ts"],
+    required: true,
+    entries: ["src/frontend/builtins/contracts.ts"],
+    minModules: 1,
+  });
+});
+
+for (const debtLayer of ["frontend-ts", "mixed-needs-split"]) {
+  it.each(["type", "value"])(`formatter contracts cannot import ${debtLayer} debt via %s`, (form) => {
+    const f = fixture();
+    const path = "src/frontend/builtins/contracts.ts";
+    f.put(path, "export type Contract = number;");
+    f.policy.files.push({ path, state: "clean", layer: "frontend-ts" });
+    const debt = f.policy.files.find((row: { path: string }) => row.path === "src/frontend/parser.ts");
+    debt.state = "unmigrated";
+    debt.layer = debtLayer;
+    f.put(debt.path, "export type Parsed = number; export const parsed = 1;");
+    // Remove the old fixture's clean-entry obligation, not a production rule.
+    const front = f.policy.layers.find((row: { id: string }) => row.id === "frontend-ts");
+    front.entries = [path];
+    front.roots = [path];
+    if (debtLayer === "mixed-needs-split") {
+      debt.owner = "fixture-owner";
+      debt.destination = "frontend-ts";
+      debt.nextBoundary = "Separate this fixture's explicit migration debt before frontend admission.";
+      f.policy.layers.push({
+        id: debtLayer,
+        status: "planned",
+        roots: [debt.path],
+        required: true,
+        entries: [debt.path],
+        minModules: 1,
+      });
+      f.policy.allowedEdges[debtLayer] = [];
+    }
+    const baseline = f.run("inventory");
+    expect(baseline.exit, JSON.stringify(baseline.report)).toBe(0);
+    f.put(
+      path,
+      form === "type" ? 'export type { Parsed } from "../parser.js";' : 'export { parsed } from "../parser.js";',
+    );
+    const result = f.run("inventory");
+    expect(result.exit).toBe(1);
+    expect(codes(result)).toContain("forbidden-clean-edge");
+  });
+}
+
+it("keeps formatter support contracts and the canonical type factory mandatory", () => {
+  const policy = JSON.parse(readFileSync(resolve(repository, "scripts/compiler-boundaries.json"), "utf8"));
+  for (const [layerId, paths] of [
+    ["ir-core", ["src/ir/core/type-references.ts"]],
+    ["ir-program", ["src/ir/program/runtime-support.ts", "src/ir/program/formatter-support.ts"]],
+  ] as const) {
+    const layer = policy.layers.find((item: { id: string }) => item.id === layerId);
+    expect(layer).toMatchObject({ status: "active", required: true });
+    expect(layer.entries).toEqual(expect.arrayContaining(paths));
+    expect(layer.minModules).toBeGreaterThanOrEqual(18);
+    for (const path of paths) {
+      expect(policy.files.find((item: { path: string }) => item.path === path)).toEqual({
+        path,
+        state: "clean",
+        layer: layerId,
+      });
+      expect(
+        policy.activationHistory.some(
+          (entry: { layer: string; entries: string[] }) => entry.layer === layerId && entry.entries.includes(path),
+        ),
+      ).toBe(true);
+      expect(readFileSync(resolve(repository, path), "utf8").length).toBeGreaterThan(0);
+    }
+  }
+  expect(policy.allowedEdges["ir-core"]).toEqual(["ir-core", "foundation", "wasm-model"]);
+  expect(policy.allowedEdges["ir-program"]).not.toContain("frontend-ts");
+  expect(policy.allowedEdges["ir-program"]).not.toContain("mixed-needs-split");
+});
+
+for (const [layerId, path] of [
+  ["frontend-ts", "src/frontend/builtins/contracts.ts"],
+  ["ir-core", "src/ir/core/type-references.ts"],
+  ["ir-program", "src/ir/program/runtime-support.ts"],
+  ["ir-program", "src/ir/program/formatter-support.ts"],
+] as const) {
+  it.each(["delete", "demote", "type-import", "value-import"] as const)(
+    `formatter boundary ${path} rejects %s after its positive control`,
+    (mutation) => {
+      const f = fixture();
+      const source = "export type Contract = number; export const present = 1;";
+      f.put(path, source);
+      f.policy.files.push({ path, state: "clean", layer: layerId });
+      const existing = f.policy.layers.find((layer: { id: string }) => layer.id === layerId);
+      if (existing) {
+        existing.entries.push(path);
+        existing.minModules++;
+      } else {
+        f.policy.layers.push({
+          id: layerId,
+          status: "active",
+          roots: [path],
+          required: true,
+          entries: [path],
+          minModules: 1,
+        });
+        f.policy.allowedEdges[layerId] = [layerId, "foundation"];
+      }
+      f.policy.activationHistory.push({ layer: layerId, entries: [path], minModules: 1 });
+      f.put("src/legacy.ts", "export type Legacy = number; export const legacy = 1;");
+      f.policy.layers.push({
+        id: "legacy-wasmgc",
+        status: "active",
+        roots: ["src/legacy.ts"],
+        required: true,
+        entries: ["src/legacy.ts"],
+        minModules: 1,
+      });
+      f.policy.allowedEdges["legacy-wasmgc"] = ["legacy-wasmgc"];
+      f.policy.files.push({ path: "src/legacy.ts", state: "clean", layer: "legacy-wasmgc" });
+      expect(f.run().exit).toBe(0);
+      if (mutation === "delete") rmSync(resolve(f.root, path));
+      if (mutation === "demote")
+        f.policy.files.find((file: { path: string }) => file.path === path).state = "unmigrated";
+      if (mutation === "type-import")
+        f.put(path, source + '\nimport type { Legacy } from "../../legacy.js"; export type Hidden = Legacy;');
+      if (mutation === "value-import") f.put(path, source + '\nexport { legacy } from "../../legacy.js";');
+      const result = f.run();
+      expect(result.exit).not.toBe(0);
+      if (mutation.endsWith("import")) expect(codes(result)).toContain("forbidden-clean-edge");
+    },
+  );
+}
+
 // Synthetic history exists only in temporary fixture repositories. Writing Git
 // objects avoids requiring signing credentials or executing project commit hooks
 // to model the historical policies that the detector must read.

--- a/tests/issue-3518-native-family-source-contract.test.ts
+++ b/tests/issue-3518-native-family-source-contract.test.ts
@@ -23,6 +23,7 @@ import * as runtimeCallables from "../src/ir/program-runtime-abi.js";
 import { irRuntimeCallableDeclaration } from "../src/ir/runtime/callable-declarations.js";
 import { sourceInput, typedOptions } from "./helpers/typed-program-fixtures.js";
 import { encodeTypedPacket, decodeTypedPacket } from "./helpers/typed-program-transport.mjs";
+import { captureNativeFamilyRuntimeSupport } from "./helpers/native-family-runtime-support.js";
 
 const ORIGINAL = readFileSync(new URL("../website/playground/examples/js/async.ts", import.meta.url), "utf8");
 const RUNTIME = ORIGINAL.replace("async function fetchUser", "export async function fetchUser")
@@ -280,7 +281,7 @@ describe("complete native family logical source preparation", () => {
       for (const replay of [false, true])
         it(`${variant} GVN=${gvnMode} decoded=${replay}: rejects omitted native string policy`, () => {
           const source = requireSource(prepareIrProgramSources(request(text)));
-          const original = captureTypedIrProgramInput(source);
+          const original = captureNativeFamilyRuntimeSupport(source, nativePolicy);
           const encoded = encodeTypedPacket(original);
           const decoded = decodeTypedPacket(encoded);
           expect(encodeTypedPacket(decoded)).toBe(encoded);
@@ -330,7 +331,7 @@ describe("complete native family logical source preparation", () => {
       for (const replay of [false, true])
         it(`${variant} GVN=${gvnMode} decoded=${replay}: prepares the entire native family`, () => {
           const source = requireSource(prepareIrProgramSources(request(text)));
-          const original = captureTypedIrProgramInput(source);
+          const original = captureNativeFamilyRuntimeSupport(source, nativePolicy);
           const encoded = encodeTypedPacket(original);
           const scans: ReturnType<typeof callCensus>[] = [];
           const collect = runtimeCallables.prepareIrProgramRuntimeCallables;
@@ -399,7 +400,7 @@ describe("complete native family logical source preparation", () => {
     { label: "explicit native policy", options: nativeOptions, expectedKind: "prepared" },
   ])("replays the complete source-free packet with $label in a fresh process", ({ options, expectedKind }) => {
     const source = requireSource(prepareIrProgramSources(request()));
-    const packet = captureTypedIrProgramInput(source);
+    const packet = captureNativeFamilyRuntimeSupport(source, nativePolicy);
     mkdirSync(resolve(".tmp"), { recursive: true });
     const directory = mkdtempSync(resolve(".tmp/native-family-source-free-"));
     const packetFile = resolve(directory, "packet.json");

--- a/tests/issue-3518-native-promise-resources.test.ts
+++ b/tests/issue-3518-native-promise-resources.test.ts
@@ -4,7 +4,8 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { createEmptyModule } from "../src/ir/types.js";
 import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
-import { prepareIrProgramSources, captureTypedIrProgramInput } from "../src/ir/program-source.js";
+import { prepareIrProgramSources } from "../src/ir/program-source.js";
+import { captureNativeFamilyRuntimeSupport } from "./helpers/native-family-runtime-support.js";
 import { prepareTypedIrProgram } from "../src/ir/program-prepare-ir.js";
 import { sourceInput, typedOptions, requireProgram } from "./helpers/typed-program-fixtures.js";
 import { encodeTypedPacket, decodeTypedPacket } from "./helpers/typed-program-transport.mjs";
@@ -46,7 +47,7 @@ function prepare(gvnMode: "off" | "on" = "off", replay = false) {
     asyncFamilyProjection: "standalone-native",
   });
   if (source.kind !== "prepared") throw new Error(source.detail);
-  const packet = captureTypedIrProgramInput(source);
+  const packet = captureNativeFamilyRuntimeSupport(source, policy);
   const input = replay ? decodeTypedPacket(encodeTypedPacket(packet)) : packet;
   const program = requireProgram(
     prepareTypedIrProgram(input, {

--- a/tests/issue-3518-native-vector-resources.test.ts
+++ b/tests/issue-3518-native-vector-resources.test.ts
@@ -5,7 +5,8 @@ import { describe, expect, it } from "vitest";
 import { createEmptyModule, type Instr, type ValType } from "../src/ir/types.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
-import { prepareIrProgramSources, captureTypedIrProgramInput } from "../src/ir/program-source.js";
+import { prepareIrProgramSources } from "../src/ir/program-source.js";
+import { captureNativeFamilyRuntimeSupport } from "./helpers/native-family-runtime-support.js";
 import { prepareTypedIrProgram } from "../src/ir/program-prepare-ir.js";
 import { encodePreparedIrProgram, decodePreparedIrProgram } from "../src/ir/program-codec.js";
 import { forEachInstrDeep, type IrFunction } from "../src/ir/core/nodes.js";
@@ -63,7 +64,7 @@ function prepare(gvnMode: "off" | "on", replay: boolean) {
   });
   if (source.kind !== "prepared") throw new Error(source.detail);
   expect(census(source.ir.functions)).toEqual({ owners: 5, calls: 22 });
-  const packet = captureTypedIrProgramInput(source);
+  const packet = captureNativeFamilyRuntimeSupport(source, policy);
   const input = replay ? decodeTypedPacket(encodeTypedPacket(packet)) : packet;
   expect(input.allocations).toEqual(packet.allocations);
   const program = requireProgram(

--- a/tests/issue-3518-number-format-source-support.test.ts
+++ b/tests/issue-3518-number-format-source-support.test.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ts } from "../src/ts-api.js";
+import { buildSelfHostedIrBody } from "../src/frontend/builtins/build-ir.js";
+import { prepareNumberFormatRuntimeSupport } from "../src/frontend/builtins/prepare-number-format.js";
+import { numToStringRadixDef } from "../src/stdlib/number-format.js";
+import { numberFormatRadixSupportDeclarations } from "../src/ir/program/formatter-support.js";
+import {
+  assertIrRuntimeSupport,
+  irRuntimeSupportOccurrences,
+  irNumberFormatDemandOwners,
+} from "../src/ir/program/runtime-support.js";
+import { prepareIrProgramSources } from "../src/ir/program-source.js";
+import { AllocSiteRegistry } from "../src/ir/alloc-registry.js";
+import { createIrSourceId } from "../src/ir/identity.js";
+import { sourceInput } from "./helpers/typed-program-fixtures.js";
+
+const ORIGINAL = readFileSync(new URL("../website/playground/examples/js/async.ts", import.meta.url), "utf8");
+const policy = { backend: "wasmgc", target: "standalone", stringConst: { storage: "native" } } as const;
+const hash = (text: string) => createHash("sha256").update(text).digest("hex");
+
+function source() {
+  const result = prepareIrProgramSources({
+    ...sourceInput({ "./entry.ts": ORIGINAL }),
+    policy,
+    promiseDelayProjection: "standalone-native",
+    asyncFamilyProjection: "standalone-native",
+  });
+  if (result.kind !== "prepared") throw new Error(result.detail);
+  return result;
+}
+
+function kernel() {
+  const declarations = numberFormatRadixSupportDeclarations(
+    createIrSourceId({
+      sourceKey: "./entry.ts",
+      kind: "entry",
+      order: 0,
+    }),
+  );
+  const definition = numToStringRadixDef(declarations.scratch.type);
+  const input = {
+    definition,
+    ownerUnitId: declarations.ownerUnitId,
+    callees: new Map(
+      declarations.kernels.map((entry) => [
+        entry.ref.name,
+        { target: entry.ref, signature: { params: entry.params, returnType: entry.results[0] ?? null } },
+      ]),
+    ),
+    allocRegistry: new AllocSiteRegistry(),
+  };
+  return { declarations, input };
+}
+
+describe("genuine radix source kernel", () => {
+  it("pins the original source bytes and independent source occurrence order", () => {
+    const { input } = kernel();
+    expect(Buffer.byteLength(input.definition.source)).toBe(1618);
+    expect(hash(input.definition.source)).toBe("7b13099fbed0a87079f92e9bddbf75959065ed28daf66d5ad344e0b240037dc6");
+    const ast = ts.createSourceFile("radix.ts", input.definition.source, ts.ScriptTarget.Latest, true);
+    const calls: string[] = [];
+    const literals: string[] = [];
+    const walk = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) calls.push(node.expression.getText(ast));
+      if (ts.isStringLiteral(node)) literals.push(node.text);
+      ts.forEachChild(node, walk);
+    };
+    walk(ast);
+    expect(calls).toHaveLength(16);
+    expect(calls.filter((name) => name === "Math.floor")).toHaveLength(4);
+    expect(calls.filter((name) => name === "__nfd_set")).toHaveLength(7);
+    expect(calls.filter((name) => name === "__nfd_get")).toHaveLength(2);
+    for (const name of ["__nfd_new", "__nfd_fin", "__num_fmt_trap"])
+      expect(calls.filter((actual) => actual === name)).toHaveLength(1);
+    expect(literals).toEqual(["NaN", "Infinity", "-Infinity", "0"]);
+    expect([...input.definition.calleeTypes.keys()]).toEqual([
+      "__nfd_new",
+      "__nfd_get",
+      "__nfd_set",
+      "__nfd_fin",
+      "__num_fmt_trap",
+    ]);
+    expect(input.definition.memoKey).toBeUndefined();
+  });
+
+  it("retains the build owner and shared registry through actual hygiene", () => {
+    const { input } = kernel();
+    const body = buildSelfHostedIrBody(input);
+    expect(body.unitId).toBe(input.ownerUnitId);
+    const receipts = irRuntimeSupportOccurrences(body);
+    expect(receipts.calls.length).toBeGreaterThan(0);
+    expect(receipts.literals.length).toBeGreaterThan(0);
+    const captured = input.allocRegistry.capturePreparationData({ body, receipts });
+    expect(captured.data.body.unitId).toBe(body.unitId);
+    expect(captured.data.receipts).toEqual(receipts);
+    for (const occurrence of receipts.calls) {
+      let actual: unknown = body;
+      for (const key of occurrence.path) actual = (actual as Record<string | number, unknown>)[key];
+      expect(actual).toMatchObject({ kind: "call", target: occurrence.target });
+    }
+  });
+
+  it.each(["name", "arity", "trap", "order", "signature"] as const)(
+    "rejects %s corruption after a genuine build",
+    (mutation) => {
+      const { input } = kernel();
+      expect(buildSelfHostedIrBody(input).unitId).toBe(input.ownerUnitId);
+      if (mutation === "name")
+        expect(() => buildSelfHostedIrBody({ ...input, definition: { ...input.definition, name: "missing" } })).toThrow(
+          /matching function/,
+        );
+      else if (mutation === "arity")
+        expect(() => buildSelfHostedIrBody({ ...input, definition: { ...input.definition, paramTypes: [] } })).toThrow(
+          /paramTypes/,
+        );
+      else {
+        const callees = new Map(input.callees);
+        if (mutation === "trap") callees.delete("__num_fmt_trap");
+        if (mutation === "signature") {
+          const entry = callees.get("__nfd_new")!;
+          callees.set("__nfd_new", { ...entry, signature: { ...entry.signature, params: [] } });
+        }
+        const altered = mutation === "order" ? new Map([...callees].reverse()) : callees;
+        expect(() => buildSelfHostedIrBody({ ...input, callees: altered })).toThrow(/callee declarations/);
+      }
+    },
+  );
+});
+
+describe("real native family support producer", () => {
+  it("builds separate support without manufacturing primary source units", () => {
+    const prepared = source();
+    const functions = prepared.ir.functions;
+    const inventory = prepared.inventory;
+    const support = prepareNumberFormatRuntimeSupport(prepared, policy);
+    expect(support?.batches).toHaveLength(1);
+    const batch = support!.batches[0]!;
+    expect(batch.demandOwners).toEqual(irNumberFormatDemandOwners(functions));
+    expect(batch.demandOwners.length).toBeGreaterThan(0);
+    expect(irRuntimeSupportOccurrences(batch.implementation.body)).toEqual({
+      calls: batch.calls,
+      literals: batch.literals,
+    });
+    expect(prepared.ir.functions).toBe(functions);
+    expect(prepared.inventory).toBe(inventory);
+    expect(functions.includes(batch.implementation.body)).toBe(false);
+    expect(() => prepareNumberFormatRuntimeSupport(prepared, { backend: "wasmgc", target: "host" })).toThrow();
+  });
+
+  it("omits support for genuine no-demand source", () => {
+    const prepared = prepareIrProgramSources(sourceInput());
+    if (prepared.kind !== "prepared") throw new Error(prepared.detail);
+    expect(prepareNumberFormatRuntimeSupport(prepared, policy)).toBeUndefined();
+  });
+
+  it("rejects changed source, owner, target and allocation evidence after genuine joint capture", () => {
+    const prepared = source();
+    const support = prepareNumberFormatRuntimeSupport(prepared, policy)!;
+    const captured = prepared.allocations.capturePreparationData({
+      inventory: prepared.inventory,
+      ir: prepared.ir,
+      derivedUnits: prepared.derivedUnits,
+      support,
+    });
+    const input = { ...captured.data, allocations: captured.allocations };
+    const original = captured.data.support;
+    expect(() => assertIrRuntimeSupport(input, original)).not.toThrow();
+    const batch = original.batches[0]!;
+    const foreign = numberFormatRadixSupportDeclarations(
+      createIrSourceId({
+        kind: "entry",
+        order: 1,
+        sourceKey: "./foreign.ts",
+      }),
+    );
+    const mutations = [
+      { ...batch, source: { ...batch.source, utf8Bytes: 1617 as 1618 } },
+      {
+        ...batch,
+        implementation: {
+          ...batch.implementation,
+          body: { ...batch.implementation.body, unitId: foreign.ownerUnitId },
+        },
+      },
+      { ...batch, implementation: { ...batch.implementation, declaration: foreign.implementation } },
+      { ...batch, literals: [] },
+    ];
+    for (const altered of mutations)
+      expect(() => assertIrRuntimeSupport(input, { ...original, batches: [altered] })).toThrow();
+    const empty = new AllocSiteRegistry().captureSnapshot();
+    expect(() => assertIrRuntimeSupport({ ...input, allocations: empty }, original)).toThrow();
+    expect(() => assertIrRuntimeSupport(input, undefined)).toThrow();
+  });
+});

--- a/tests/issue-3518-runtime-support-codec.test.ts
+++ b/tests/issue-3518-runtime-support-codec.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { prepareWholeIrProgram } from "../src/ir/program-preparation.js";
+import {
+  encodePreparedIrProgram,
+  decodePreparedIrProgram,
+  reauthenticatePreparedIrProgram,
+} from "../src/ir/program-codec.js";
+import { assertIrRuntimeSupport, irRuntimeSupportOccurrences } from "../src/ir/program/runtime-support.js";
+import { assertPreparedIrProgram } from "../src/ir/program-validation.js";
+import { sourceInput, requireProgram } from "./helpers/typed-program-fixtures.js";
+
+function actual() {
+  const text = readFileSync(new URL("../website/playground/examples/js/async.ts", import.meta.url), "utf8");
+  return requireProgram(
+    prepareWholeIrProgram({
+      ...sourceInput({ "./entry.ts": text }),
+      policy: {
+        backend: "wasmgc",
+        target: "standalone",
+        stringConst: { storage: "native" },
+        stringConcat: { concat: "native" },
+      },
+      promiseDelayProjection: "standalone-native",
+      asyncFamilyProjection: "standalone-native",
+    }),
+  );
+}
+
+describe("formatter support in the actual prepared-program codec", () => {
+  it("round-trips a nonempty built body and re-encodes exact canonical bytes", () => {
+    const original = actual();
+    expect(original.runtimeSupport?.batches).toHaveLength(1);
+    const encoded = encodePreparedIrProgram(original);
+    const decoded = decodePreparedIrProgram(encoded);
+    expect(encodePreparedIrProgram(decoded)).toBe(encoded);
+    expect(decoded.runtimeSupport).toEqual(original.runtimeSupport);
+    assertIrRuntimeSupport(decoded, decoded.runtimeSupport);
+    const batch = decoded.runtimeSupport!.batches[0]!;
+    expect(irRuntimeSupportOccurrences(batch.implementation.body)).toEqual({
+      calls: batch.calls,
+      literals: batch.literals,
+    });
+    expect(batch.calls.length).toBeGreaterThan(0);
+    expect(batch.literals.length).toBeGreaterThan(0);
+    for (const literal of batch.literals) {
+      expect(decoded.allocations.entries[literal.alloc]).toEqual(original.allocations.entries[literal.alloc]);
+    }
+  });
+
+  it("refuses stripped support even when its own demand vector vanishes", () => {
+    const original = actual();
+    expect(original.runtimeSupport!.batches[0]!.demandOwners.length).toBeGreaterThan(0);
+    const { runtimeSupport: _removed, ...stripped } = original;
+    expect(() => reauthenticatePreparedIrProgram(stripped)).toThrow(/missing demanded formatter support/);
+  });
+
+  it("refuses changed literal occurrence receipts on real otherwise intact input", () => {
+    const original = actual();
+    const support = original.runtimeSupport!;
+    const batch = support.batches[0]!;
+    expect(batch.literals.length).toBeGreaterThan(0);
+    const mutated = {
+      ...original,
+      runtimeSupport: {
+        ...support,
+        batches: [
+          {
+            ...batch,
+            literals: batch.literals.map((literal, index) => (index === 0 ? { ...literal, value: "forged" } : literal)),
+          },
+        ],
+      },
+    };
+    expect(() => reauthenticatePreparedIrProgram(mutated)).toThrow(/stale support literal occurrences/);
+  });
+
+  it("rejects own-property undefined rather than silently dropping it in reconstruction", () => {
+    const original = actual();
+    expect(() => reauthenticatePreparedIrProgram({ ...original, runtimeSupport: undefined })).toThrow();
+  });
+
+  it("rejects a canonical kernel used as a literal materializer", () => {
+    const original = actual();
+    // Positive first through the complete replay validator, not a fabricated ABI.
+    expect(reauthenticatePreparedIrProgram(original).runtimeSupport?.batches).toHaveLength(1);
+    const support = original.runtimeSupport!,
+      batch = support.batches[0]!;
+    const body = structuredClone(batch.implementation.body);
+    const occurrence = batch.literals[0]!;
+    expect(occurrence).toBeDefined();
+    let instruction: unknown = body;
+    for (const key of occurrence.path) instruction = (instruction as Record<string | number, unknown>)[key];
+    expect(instruction).toMatchObject({ kind: "string.const", value: occurrence.value });
+    // The reference is real and present in the ABI, but invalid for this field.
+    Reflect.set(instruction as object, "materializer", batch.kernels[0].ref);
+    const changed = {
+      ...original,
+      runtimeSupport: { ...support, batches: [{ ...batch, implementation: { ...batch.implementation, body } }] },
+    };
+    expect(() => assertPreparedIrProgram(changed)).toThrow(
+      /support literals cannot carry physical storage or materializer attachments/,
+    );
+    expect(() => reauthenticatePreparedIrProgram(changed)).toThrow(
+      /support literals cannot carry physical storage or materializer attachments/,
+    );
+  });
+});

--- a/tests/issue-3518-runtime-support-source-free.test.ts
+++ b/tests/issue-3518-runtime-support-source-free.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { prepareWholeIrProgram } from "../src/ir/program-preparation.js";
+import { encodePreparedIrProgram } from "../src/ir/program-codec.js";
+import { sourceInput, requireProgram } from "./helpers/typed-program-fixtures.js";
+
+describe("nonempty runtime support replays without source compiler loads", () => {
+  it.each(["replay", "probe"] as const)(
+    "fresh process: %s",
+    (mode) => {
+      const source = readFileSync(new URL("../website/playground/examples/js/async.ts", import.meta.url), "utf8");
+      const program = requireProgram(
+        prepareWholeIrProgram({
+          ...sourceInput({ "./entry.ts": source }),
+          policy: {
+            backend: "wasmgc",
+            target: "standalone",
+            stringConst: { storage: "native" },
+            stringConcat: { concat: "native" },
+          },
+          promiseDelayProjection: "standalone-native",
+          asyncFamilyProjection: "standalone-native",
+        }),
+      );
+      expect(program.runtimeSupport?.batches).toHaveLength(1);
+      const directory = mkdtempSync(join(tmpdir(), "js2-runtime-support-replay-"));
+      const packet = join(directory, "program.json"),
+        census = join(directory, "loads.jsonl");
+      writeFileSync(packet, encodePreparedIrProgram(program));
+      const child = spawnSync(
+        process.execPath,
+        ["--import", "tsx", "tests/helpers/runtime-support-source-free.mjs", packet, census, mode],
+        {
+          cwd: resolve(import.meta.dirname, ".."),
+          encoding: "utf8",
+          timeout: 60000,
+          maxBuffer: 4 * 1024 * 1024,
+        },
+      );
+      expect(child.error, child.stderr).toBeUndefined();
+      expect(child.signal, child.stderr).toBeNull();
+      const report = JSON.parse(child.stdout.trim());
+      expect(report.decoded, JSON.stringify(report)).toBe(true);
+      expect(report.batches).toBe(1);
+      expect(report.calls).toBeGreaterThan(0);
+      expect(report.literals).toBeGreaterThan(0);
+      const rows = readFileSync(census, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.some((row) => row.url.includes("/src/ir/program-validation."))).toBe(true);
+      if (mode === "replay") {
+        expect(child.status, JSON.stringify(report)).toBe(0);
+        expect(report.ok).toBe(true);
+        expect(rows.filter((row) => row.denied)).toEqual([]);
+      } else {
+        expect(child.status).toBe(1);
+        expect(report.ok).toBe(false);
+        expect(report.error).toMatch(/forbidden runtime-support replay load/);
+        expect(rows.some((row) => row.denied && row.url.includes("/src/ir/from-ast."))).toBe(true);
+      }
+      // Preserve the exact packet and load census for failure attribution.
+    },
+    90000,
+  );
+});

--- a/tests/issue-3518-runtime-support-transport.test.ts
+++ b/tests/issue-3518-runtime-support-transport.test.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { prepareIrProgramSources, captureTypedIrProgramInput } from "../src/ir/program-source.js";
+import { prepareNumberFormatRuntimeSupport } from "../src/frontend/builtins/prepare-number-format.js";
+import { prepareWholeIrProgram } from "../src/ir/program-preparation.js";
+import { prepareTypedIrProgram } from "../src/ir/program-prepare-ir.js";
+import {
+  assertIrRuntimeSupport,
+  irNumberFormatDemandOwners,
+  irRuntimeSupportFunctions,
+} from "../src/ir/program/runtime-support.js";
+import { numberFormatRadixSupportDeclarations } from "../src/ir/program/formatter-support.js";
+import { preparedIrTypeKey, preparedIrDataKey } from "../src/ir/program-abi-contracts.js";
+import { assertPreparedIrRuntimeSupportDependencies } from "../src/ir/prepared-component-dependencies.js";
+import { irSupportTypeRef } from "../src/ir/core/type-references.js";
+import { sourceInput, typedOptions, requireProgram } from "./helpers/typed-program-fixtures.js";
+
+const policy = {
+  backend: "wasmgc",
+  target: "standalone",
+  stringConst: { storage: "native" },
+  stringConcat: { concat: "native" },
+} as const;
+const original = readFileSync(new URL("../website/playground/examples/js/async.ts", import.meta.url), "utf8");
+const request = () => ({
+  ...sourceInput({ "./entry.ts": original }),
+  policy,
+  promiseDelayProjection: "standalone-native" as const,
+  asyncFamilyProjection: "standalone-native" as const,
+});
+const options = { ...typedOptions, policy, runtimePolicies: [policy] };
+
+function packet() {
+  const source = prepareIrProgramSources(request());
+  if (source.kind !== "prepared") throw new Error(source.detail);
+  const support = prepareNumberFormatRuntimeSupport(source, policy);
+  expect(support?.batches).toHaveLength(1);
+  const input = captureTypedIrProgramInput(source, support);
+  assertIrRuntimeSupport(input, input.runtimeSupport);
+  return input;
+}
+
+describe("real source-to-program formatter support transport", () => {
+  it("keeps the actual support body separate from source and startup populations", () => {
+    const input = packet();
+    const support = input.runtimeSupport!;
+    const batch = support.batches[0]!;
+    expect(input.ir.functions).toHaveLength(5);
+    expect(irNumberFormatDemandOwners(input.ir.functions)).toEqual(batch.demandOwners);
+    expect(batch.demandOwners.length).toBeGreaterThan(0);
+    expect(irRuntimeSupportFunctions(support)).toEqual([batch.implementation.body]);
+    expect(input.ir.functions.some((fn) => fn.unitId === batch.implementation.body.unitId)).toBe(false);
+    expect(input.derivedUnits.some((unit) => unit.id === batch.implementation.body.unitId)).toBe(false);
+    expect(input.startup.some((plan) => plan.unitId === batch.implementation.body.unitId)).toBe(false);
+    expect(batch.kernels.map((kernel) => kernel.role)).toEqual(["new", "get", "set", "fin", "trap"]);
+    expect(batch.calls.length).toBeGreaterThan(0);
+    expect(batch.literals.length).toBeGreaterThan(0);
+    for (const literal of batch.literals) expect(input.allocations.entries[literal.alloc]?.state).toBe("live");
+  });
+
+  it("independently rejects deletion of the batch together with its claimed demand owners", () => {
+    const input = packet();
+    const { runtimeSupport: removed, ...missing } = input;
+    expect(removed!.batches[0]!.demandOwners.length).toBeGreaterThan(0);
+    expect(() => prepareTypedIrProgram(missing, options)).toThrow(/missing demanded formatter support/);
+    expect(() =>
+      prepareTypedIrProgram({ ...input, runtimeSupport: { schema: "ir-runtime-support-v1", batches: [] } }, options),
+    ).toThrow();
+  });
+
+  it("rejects stale primary-owner receipts before recomputing transformed owners", () => {
+    const input = packet();
+    const support = input.runtimeSupport!;
+    const changed = { ...support, batches: support.batches.map((batch) => ({ ...batch, demandOwners: [] })) };
+    expect(() => prepareTypedIrProgram({ ...input, runtimeSupport: changed }, options)).toThrow(
+      /stale primary demand owners/,
+    );
+  });
+
+  it.each(["source", "kernel-order", "kernel-duplicate", "nullability", "storage-width", "literal-receipt"] as const)(
+    "refuses altered support declarations after genuine source capture: %s",
+    (mutation) => {
+      const input = packet();
+      const support = structuredClone(input.runtimeSupport!);
+      const batch = support.batches[0]!;
+      if (mutation === "source") Reflect.set(batch, "sourceId", batch.sourceId + ":foreign");
+      if (mutation === "kernel-order") Reflect.set(batch, "kernels", [...batch.kernels].reverse());
+      if (mutation === "kernel-duplicate")
+        Reflect.set(batch, "kernels", [batch.kernels[0], batch.kernels[0], ...batch.kernels.slice(2)]);
+      if (mutation === "nullability") Reflect.set(batch.scratch.type, "nullable", false);
+      if (mutation === "storage-width") Reflect.set(batch.scratch.storage, "element", "i8");
+      if (mutation === "literal-receipt") Reflect.set(batch, "literals", batch.literals.slice(1));
+      expect(() => prepareTypedIrProgram({ ...input, runtimeSupport: support }, options)).toThrow();
+    },
+  );
+
+  it("refuses a retired allocation still referenced by the real support body", () => {
+    const input = packet();
+    const id = input.runtimeSupport!.batches[0]!.literals[0]!.alloc;
+    expect(input.allocations.entries[id]?.state).toBe("live");
+    const allocations = {
+      ...input.allocations,
+      entries: input.allocations.entries.map((entry, index) => (index === id ? { state: "retired" as const } : entry)),
+    };
+    expect(() => assertIrRuntimeSupport({ ...input, allocations }, input.runtimeSupport)).toThrow(
+      /support allocation is not live/,
+    );
+  });
+
+  it.each(["off", "on"] as const)("carries real support through final preparation with GVN %s", (gvnMode) => {
+    const input = packet();
+    const program = requireProgram(
+      prepareTypedIrProgram(input, {
+        ...options,
+        controls: { ...options.controls, gvnMode },
+      }),
+    );
+    expect(program.ir.functions).toHaveLength(16);
+    expect(program.runtimeSupport?.batches).toHaveLength(1);
+    assertIrRuntimeSupport(program, program.runtimeSupport);
+    expect(Object.isFrozen(program.runtimeSupport)).toBe(true);
+    expect(Object.isFrozen(program.runtimeSupport!.batches[0]!.implementation.body)).toBe(true);
+  });
+
+  it("normalizes support identity without display-name dependence", () => {
+    const input = packet();
+    const type = numberFormatRadixSupportDeclarations(input.runtimeSupport!.batches[0]!.sourceId).scratch.type;
+    const renamed = { ...type, ref: { ...type.ref, name: "diagnostic-only" } };
+    expect(preparedIrTypeKey(renamed)).toBe(preparedIrTypeKey(type));
+    expect(preparedIrDataKey({ nested: [renamed] })).toBe(preparedIrDataKey({ nested: [type] }));
+    expect(preparedIrTypeKey({ ...type, nullable: false })).not.toBe(preparedIrTypeKey(type));
+  });
+
+  it("preserves absence for genuine no-demand source", () => {
+    const program = requireProgram(
+      prepareWholeIrProgram({
+        ...sourceInput({ "./entry.ts": "export function main(): number { return 42; }" }),
+        policy,
+      }),
+    );
+    expect(Object.hasOwn(program, "runtimeSupport")).toBe(false);
+    expect(irRuntimeSupportFunctions(program.runtimeSupport)).toEqual([]);
+  });
+
+  it.each(["missing-type", "missing-callable", "nested-reference", "physical-index"] as const)(
+    "checks actual support dependency fields: %s",
+    (mutation) => {
+      const program = requireProgram(prepareTypedIrProgram(packet(), options));
+      assertPreparedIrRuntimeSupportDependencies(program);
+      const support = program.runtimeSupport!;
+      const batch = support.batches[0]!;
+      if (mutation === "missing-type" || mutation === "missing-callable") {
+        const ref = mutation === "missing-type" ? batch.scratch.type.ref : batch.kernels[0].ref;
+        if (ref.binding.kind !== "support") throw new Error("positive fixture lacks support binding");
+        const id = ref.binding.bindingId;
+        const entries = program.abi.entries.filter((entry) => entry.plan.id !== id);
+        expect(entries).toHaveLength(program.abi.entries.length - 1);
+        expect(() => assertPreparedIrRuntimeSupportDependencies({ ...program, abi: { entries } })).toThrow(
+          /missing or duplicate symbolic dependency/,
+        );
+      } else {
+        const foreign = irSupportTypeRef(batch.sourceId, "foreign", "foreign");
+        const body = batch.implementation.body;
+        const resultType =
+          mutation === "nested-reference"
+            ? { kind: "string" as const, carrierRef: foreign }
+            : { kind: "string" as const, typeIdx: 0 };
+        // Retain the original occurrence receipts: this assertion must inspect
+        // the body/signature graph independently of those unchanged receipts.
+        const changed = {
+          ...batch,
+          implementation: { ...batch.implementation, body: { ...body, resultTypes: [resultType] } },
+        };
+        expect(() =>
+          assertPreparedIrRuntimeSupportDependencies({
+            ...program,
+            runtimeSupport: { ...support, batches: [changed] },
+          }),
+        ).toThrow(mutation === "nested-reference" ? /foreign symbolic dependency/ : /physical type index/);
+      }
+    },
+  );
+});

--- a/tests/issue-3518-symbolic-support-ref.test.ts
+++ b/tests/issue-3518-symbolic-support-ref.test.ts
@@ -1,0 +1,358 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { irSupportRef, irTypeEquals, asVal, irVal, type IrType } from "../src/ir/core/types.js";
+import { irSupportTypeRef } from "../src/ir/core/type-references.js";
+import { irSupportTypeRef as compatibilityFactory } from "../src/ir/abi-bindings.js";
+import { irSupportFuncRef } from "../src/ir/core/callable-bindings.js";
+import {
+  asBlockId,
+  asValueId,
+  forEachInstrDeep,
+  type IrFunction,
+  type IrInstr,
+  type IrModuleDeclarations,
+} from "../src/ir/core/nodes.js";
+import { irTypeKey } from "../src/ir/type-key.js";
+import { verifyIrFunction } from "../src/ir/verify.js";
+import { irBindingKey } from "../src/ir/declared-types.js";
+import { lowerIrTypeToValType, type IrLowerResolver } from "../src/ir/lower.js";
+import { attachIrPhysicalRefTypeRefs } from "../src/ir/physical-ref-support.js";
+import { attachIrStringCarrier } from "../src/ir/string-carrier.js";
+import { attachIrVecLayouts } from "../src/ir/vec-layout.js";
+import { verifyIrBackendLegality } from "../src/ir/backend/legality.js";
+import { buildIrUnitInventory, createIrSourceId, createIrUnitId } from "../src/ir/identity.js";
+import { createDerivedIrUnitId } from "../src/shared/contracts/identity-values.js";
+import { ProgramAbiMap } from "../src/ir/program/abi.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import { createStringDataType } from "../src/runtime/wasmgc/values/string-layouts.js";
+import { AllocSiteRegistry } from "../src/ir/analysis/alloc-registry.js";
+import { numToStringRadixDef } from "../src/stdlib/number-format.js";
+// Mandatory joined R+F test. No fallback/skip when the source kernel is absent
+// from an uncomposed R checkout; validation must use the composed production.
+import { buildSelfHostedIrBody } from "../src/frontend/builtins/build-ir.js";
+import type { IrDirectCallTarget } from "../src/ir/ast-lowering-plans.js";
+
+const sourceId = createIrSourceId({ kind: "entry", order: 0, sourceKey: "symbolic-support-ref.ts" });
+const unitId = createIrUnitId({ sourceId, lexicalOwnerId: null, kind: "top-level-function", ordinal: 0 });
+const ref = irSupportTypeRef(sourceId, "scratch", "buffer"),
+  B = irSupportRef(ref, true);
+const foreign = irSupportRef(irSupportTypeRef(sourceId, "foreign", "buffer"), true);
+const F64 = irVal({ kind: "f64" });
+const target = irSupportFuncRef(sourceId, "identity", "identity");
+const declarations: IrModuleDeclarations = {
+  declaredSignatures: new Map([[irBindingKey(target.binding)!, { params: [B], result: B }]]),
+};
+function forward(): IrFunction {
+  return {
+    unitId,
+    name: "forward",
+    params: [{ value: asValueId(0), name: "input", type: B }],
+    resultTypes: [B],
+    exported: false,
+    valueCount: 2,
+    blocks: [
+      {
+        id: asBlockId(0),
+        blockArgs: [],
+        blockArgTypes: [],
+        instrs: [{ kind: "call", target, args: [asValueId(0)], result: asValueId(1), resultType: B }],
+        terminator: { kind: "return", values: [asValueId(1)] },
+      },
+    ],
+  };
+}
+const verify = (fn: IrFunction, table: IrModuleDeclarations | undefined = declarations) =>
+  verifyIrFunction(fn, undefined, table).map((error) => error.message);
+const read = (path: string) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+const hash = (text: string) => createHash("sha256").update(text).digest("hex");
+function replaceOnce(source: string, before: string, after: string): string {
+  const at = source.indexOf(before);
+  if (at < 0 || source.indexOf(before, at + before.length) >= 0) throw new Error("missing/duplicate relocation span");
+  return source.slice(0, at) + after + source.slice(at + before.length);
+}
+function requireFactoryRelocation(canonical: string, facade: string): void {
+  const parsed = ts.createSourceFile("type-references.ts", canonical, ts.ScriptTarget.Latest, true);
+  const functions = parsed.statements.filter(ts.isFunctionDeclaration);
+  expect(functions.map((fn) => fn.name?.text)).toEqual(["typeRef", "irSupportTypeRef"]);
+  const helper = functions[0]!.getText(parsed),
+    factory = functions[1]!.getText(parsed);
+  const prefix = `// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { requireBindingId, requireNonEmpty } from "./binding-key-primitives.js";
+import { createIrBindingId } from "../../shared/contracts/identity-values.js";
+import type { IrClassId, IrSourceId, IrUnitId } from "../../shared/contracts/ir-identity.js";
+import type { IrTypeBinding, IrTypeRef } from "./types.js";
+
+type IrBindingOwnerId = IrSourceId | IrUnitId | IrClassId;
+
+`;
+  expect(canonical).toBe(
+    prefix + helper + "\n\n/** Reference one compiler support type intention. */\n" + factory + "\n",
+  );
+  let inverse = replaceOnce(
+    facade,
+    'import type { IrGlobalBinding, IrGlobalRef, IrTypeBinding, IrTypeRef } from "./nodes.js";\nimport { typeRef, irSupportTypeRef } from "./core/type-references.js";\nexport { irSupportTypeRef } from "./core/type-references.js";',
+    'import type { IrGlobalBinding, IrGlobalRef, IrTypeBinding, IrTypeRef } from "./nodes.js";',
+  );
+  inverse = replaceOnce(
+    inverse,
+    "/** Exact source-owned value-storage ID for one top-level declaration ordinal. */",
+    replaceOnce(helper, "export function typeRef", "function typeRef") +
+      "\n\n/** Exact source-owned value-storage ID for one top-level declaration ordinal. */",
+  );
+  inverse = replaceOnce(
+    inverse,
+    "/** Exact reserved layout type identity for one nominal-fnctor constructor. */",
+    "/** Reference one compiler support type intention. */\n" +
+      factory +
+      "\n\n/** Exact reserved layout type identity for one nominal-fnctor constructor. */",
+  );
+  expect(hash(inverse)).toBe("9324caf316c596019beab1007c7e602263ae2955328a0f336b1ab38246bb09fc");
+}
+
+describe("nominal index-free support references", () => {
+  it("retains the exact old factory identity and complete two-body relocation receipt", () => {
+    expect(compatibilityFactory).toBe(irSupportTypeRef);
+    requireFactoryRelocation(read("src/ir/core/type-references.ts"), read("src/ir/abi-bindings.ts"));
+  });
+  it.each(["body", "extra", "route", "export"] as const)(
+    "rejects a %s relocation mutation after the original positive",
+    (kind) => {
+      const canonical = read("src/ir/core/type-references.ts"),
+        facade = read("src/ir/abi-bindings.ts");
+      requireFactoryRelocation(canonical, facade);
+      const changed =
+        kind === "body"
+          ? replaceOnce(canonical, "    role: checkedRole,", "    role: role,")
+          : kind === "extra"
+            ? canonical + "void 0;\n"
+            : kind === "route"
+              ? replaceOnce(canonical, 'from "./types.js"', 'from "../nodes.js"')
+              : replaceOnce(canonical, "export function typeRef", "function typeRef");
+      expect(() => requireFactoryRelocation(changed, facade)).toThrow();
+    },
+  );
+  it("keys identity and nullability, never the compatibility name or physical fields", () => {
+    const renamed = irSupportRef({ ...ref, name: "different" }, true);
+    expect(irTypeEquals(B, renamed)).toBe(true);
+    expect(irTypeKey(B)).toBe(irTypeKey(renamed));
+    expect(irTypeKey(B)).toBe(`support-ref|${ref.binding.bindingId.length}:${ref.binding.bindingId}|nullable:1`);
+    expect(irTypeEquals(B, foreign)).toBe(false);
+    expect(irTypeEquals(B, irSupportRef(ref, false))).toBe(false);
+    expect(asVal(B)).toBeNull();
+    expect(Reflect.ownKeys(B)).toEqual(["kind", "ref", "nullable"]);
+    for (const field of ["val", "typeIdx", "layout", "provider"]) expect(Object.hasOwn(B, field)).toBe(false);
+    expect(irTypeKey(F64)).toBe("f64");
+  });
+  it.each(["kind", "binding", "domain", "empty", "nullable"] as const)("rejects invalid constructor %s", (kind) => {
+    expect(irSupportRef(ref, true)).toEqual(B);
+    const bad = structuredClone(ref);
+    if (kind === "kind") Object.assign(bad, { kind: "global" });
+    if (kind === "binding") Object.assign(bad.binding, { kind: "source" });
+    if (kind === "domain") Object.assign(bad.binding, { bindingId: "ir-binding:v1:global:foreign" });
+    if (kind === "empty") Object.assign(bad.binding, { bindingId: "" });
+    expect(() => irSupportRef(bad, kind === "nullable" ? undefined! : true)).toThrow();
+  });
+  it.each(["argument", "result", "return", "nullability", "missing-declaration"] as const)(
+    "checks exact %s flow",
+    (kind) => {
+      expect(verify(forward())).toEqual([]);
+      const fn = forward();
+      if (kind === "argument") Object.assign(fn.params[0]!, { type: foreign });
+      if (kind === "result") Object.assign(fn.blocks[0]!.instrs[0]!, { resultType: foreign });
+      if (kind === "return") Object.assign(fn, { resultTypes: [foreign] });
+      if (kind === "nullability") Object.assign(fn.params[0]!, { type: irSupportRef(ref, false) });
+      const errors = kind === "missing-declaration" ? verifyIrFunction(fn).map((error) => error.message) : verify(fn);
+      expect(errors.some((message) => message.includes("support-ref"))).toBe(true);
+    },
+  );
+  it("checks branch identities and rejects physical slot storage", () => {
+    const fn = forward();
+    Object.assign(fn.blocks[0]!, {
+      terminator: { kind: "br", branch: { target: asBlockId(1), args: [asValueId(1)] } },
+    });
+    (fn.blocks as unknown[]).push({
+      id: asBlockId(1),
+      blockArgs: [asValueId(2)],
+      blockArgTypes: [B],
+      instrs: [],
+      terminator: { kind: "return", values: [asValueId(2)] },
+    });
+    Object.assign(fn, { valueCount: 3 });
+    expect(verify(fn)).toEqual([]);
+    Object.assign(fn.blocks[1]!, { blockArgTypes: [foreign] });
+    expect(verify(fn)).toContain("branch arg 0 support-ref identity/nullability mismatch");
+    const slot = forward();
+    expect(verify(slot)).toEqual([]);
+    Object.assign(slot, { slots: [{ index: 0, name: "slot", type: { kind: "externref" } }] });
+    (slot.blocks[0]!.instrs as IrInstr[]).push({
+      kind: "slot.write",
+      slotIndex: 0,
+      value: asValueId(1),
+      result: null,
+      resultType: null,
+    });
+    expect(verify(slot)).toContain("slot.write does not support support-ref flow");
+    const readSlot = forward();
+    expect(verify(readSlot)).toEqual([]);
+    Object.assign(readSlot, { slots: [{ index: 0, name: "slot", type: { kind: "externref" } }] });
+    Object.assign(readSlot.blocks[0]!.instrs[0]!, { kind: "slot.read", slotIndex: 0 });
+    expect(verify(readSlot)).toContain("slot.read does not support support-ref flow");
+  });
+  it("preserves the leaf without calling a physical attachment allocator", () => {
+    const fn = forward();
+    expect(
+      attachIrPhysicalRefTypeRefs(fn, () => {
+        throw new Error("must not resolve support-ref as raw physical ref");
+      }),
+    ).toBe(fn);
+    expect(attachIrStringCarrier(fn, ref).function.params[0]!.type).toBe(B);
+    expect(
+      attachIrVecLayouts(fn, () => {
+        throw new Error("must not allocate a vector");
+      }).function.params[0]!.type,
+    ).toBe(B);
+    expect(verifyIrBackendLegality(fn, "wasmgc")).toEqual([]);
+    for (const backend of ["linear", "bytecode", "porffor"] as const)
+      expect(verifyIrBackendLegality(fn, backend).some((error) => error.message.includes("support-ref"))).toBe(true);
+  });
+  it("resolves through two real ABI/ledger layouts without index-bearing source types", () => {
+    const source = ts.createSourceFile(
+      "/r/entry.ts",
+      "export function run(): number { return 42; }",
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const inventory = buildIrUnitInventory([source], { entrySource: source });
+    const ownedRef = irSupportTypeRef(inventory.sources[0]!.id, "scratch", "buffer"),
+      type = irSupportRef(ownedRef, true);
+    const indices = [0, 3].map((padding) => {
+      const abi = new ProgramAbiMap(inventory),
+        module = createEmptyModule(),
+        tx = new PhysicalModuleReservations(module);
+      abi.plan({
+        id: ownedRef.binding.bindingId,
+        displayName: "buffer",
+        order: { sourceOrder: 0, declarationOrder: 0 },
+        slotPolicy: "required",
+        slotSpace: "type",
+        intent: { kind: "type", shapeKey: irTypeKey(type) },
+      });
+      abi.sealPlan();
+      for (let i = 0; i < padding; i++)
+        tx.reserveType(`preceding:${i}`, { kind: "struct", name: `preceding${i}`, fields: [] });
+      const token = tx.reserveType(ownedRef.binding.bindingId, createStringDataType());
+      tx.freezeReservations();
+      abi.bindFinalIndex(ownedRef.binding.bindingId, { space: "type", index: tx.physicalIndex(token) });
+      abi.finishBinding();
+      const resolver: IrLowerResolver = {
+        resolveFunc: () => {
+          throw new Error("unexpected callable");
+        },
+        resolveGlobal: () => {
+          throw new Error("unexpected global");
+        },
+        internFuncType: () => {
+          throw new Error("unexpected signature");
+        },
+        resolveType: (reference) => {
+          const result = abi.resolveFinalIndex(reference.binding.bindingId);
+          if (result?.space !== "type") throw new Error("missing owned type");
+          return result.index;
+        },
+      };
+      expect(lowerIrTypeToValType(type, resolver, "test")).toEqual({ kind: "ref_null", typeIdx: token.typeIndex });
+      expect(lowerIrTypeToValType(irSupportRef(structuredClone(ownedRef), false), resolver, "test")).toEqual({
+        kind: "ref",
+        typeIdx: token.typeIndex,
+      });
+      expect(() => lowerIrTypeToValType(foreign, resolver, "test")).toThrow();
+      expect(() => lowerIrTypeToValType(type, { ...resolver, resolveType: undefined! }, "test")).toThrow();
+      // A rejected token permanently fails the ledger: corrupt only after all
+      // positive witnesses, never reuse that failed transaction for admission.
+      expect(() => tx.physicalIndex({ ...token })).toThrow();
+      return token.typeIndex;
+    });
+    expect(indices).toEqual([0, 3]);
+    expect(Object.hasOwn(type, "typeIdx")).toBe(false);
+  });
+  it("lowers the unchanged original radix through the genuine frontend kernel (mandatory R+F join)", () => {
+    const radixType = irSupportRef(irSupportTypeRef(sourceId, "number-format-radix:scratch", "__nfd_buffer"), true);
+    const definition = numToStringRadixDef(radixType),
+      allocRegistry = new AllocSiteRegistry();
+    expect(Buffer.byteLength(definition.source, "utf8")).toBe(1618);
+    expect(hash(definition.source)).toBe("7b13099fbed0a87079f92e9bddbf75959065ed28daf66d5ad344e0b240037dc6");
+    const parsed = ts.createSourceFile("radix.ts", definition.source, ts.ScriptTarget.Latest, true);
+    const sourceCalls: string[] = [],
+      sourceLiterals: string[] = [];
+    const collect = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) sourceCalls.push(node.expression.getText(parsed));
+      if (ts.isStringLiteral(node)) sourceLiterals.push(node.text);
+      ts.forEachChild(node, collect);
+    };
+    collect(parsed);
+    expect(sourceCalls).toHaveLength(16);
+    expect(
+      sourceCalls.reduce<Record<string, number>>((counts, name) => {
+        counts[name] = (counts[name] ?? 0) + 1;
+        return counts;
+      }, {}),
+    ).toEqual({ "Math.floor": 4, __num_fmt_trap: 1, __nfd_new: 1, __nfd_set: 7, __nfd_get: 2, __nfd_fin: 1 });
+    expect(sourceLiterals).toEqual(["NaN", "Infinity", "-Infinity", "0"]);
+    const callees = new Map<string, IrDirectCallTarget>();
+    const roles = ["new", "get", "set", "fin", "trap"] as const;
+    [...definition.calleeTypes].forEach(([name, signature], index) =>
+      callees.set(name, {
+        target: irSupportFuncRef(sourceId, "number-format-radix:" + roles[index]!, name),
+        signature,
+      }),
+    );
+    expect([...callees.keys()]).toEqual(["__nfd_new", "__nfd_get", "__nfd_set", "__nfd_fin", "__num_fmt_trap"]);
+    const ownerUnitId = createDerivedIrUnitId({
+      parentId: sourceId,
+      role: "runtime-support:number-format-radix",
+      ordinal: 0,
+    });
+    const body = buildSelfHostedIrBody({ definition, ownerUnitId, callees, allocRegistry });
+    expect(body.unitId).toBe(ownerUnitId);
+    const table: IrModuleDeclarations = {
+      declaredSignatures: new Map(
+        [...callees.values()].map(({ target, signature }) => [
+          irBindingKey(target.binding)!,
+          { params: signature.params, result: signature.returnType },
+        ]),
+      ),
+    };
+    expect(verifyIrFunction(body, undefined, table)).toEqual([]);
+    const supportResults: IrType[] = [],
+      calls: string[] = [];
+    for (const block of body.blocks)
+      for (const instr of block.instrs)
+        forEachInstrDeep(instr, (nested) => {
+          if (nested.resultType?.kind === "support-ref") supportResults.push(nested.resultType);
+          if (nested.kind === "call") calls.push(nested.target.name);
+        });
+    expect(supportResults.length).toBeGreaterThan(0);
+    expect(supportResults.every((type) => irTypeEquals(type, radixType))).toBe(true);
+    const scratchValues = new Set<number>();
+    for (const block of body.blocks)
+      for (const instr of block.instrs)
+        forEachInstrDeep(instr, (nested) => {
+          if (nested.result !== null && nested.resultType?.kind === "support-ref") scratchValues.add(nested.result);
+        });
+    for (const block of body.blocks)
+      for (const instr of block.instrs)
+        forEachInstrDeep(instr, (nested) => {
+          if (nested.kind === "slot.write") expect(scratchValues.has(nested.value)).toBe(false);
+          if (nested.kind === "slot.read") expect(nested.resultType?.kind).not.toBe("support-ref");
+        });
+    expect(calls).toContain("__nfd_new");
+    expect(calls).toContain("__nfd_fin");
+    // This is source lowering and verification, not prepared-program/D2 execution.
+  });
+});

--- a/tests/issue-3521-pure-identity-values.test.ts
+++ b/tests/issue-3521-pure-identity-values.test.ts
@@ -5,6 +5,20 @@ import * as frontend from "../src/ir/identity.js";
 import * as data from "../src/ir/identity-values.js";
 
 describe("source-free canonical identity factories", () => {
+  it("gives the closed formatter support role a real source-parent identity", () => {
+    const parentId = frontend.createIrSourceId({ kind: "entry", order: 0, sourceKey: "formatter/source.ts" });
+    const role: frontend.CreateDerivedIrUnitIdInput["role"] = "runtime-support:number-format-radix";
+    expect(data.createDerivedIrUnitId({ parentId, role, ordinal: 0 })).toBe(
+      `ir-unit:v1:derived:${encodeURIComponent(parentId)}:runtime-support%3Anumber-format-radix:0000000000000000`,
+    );
+    // @ts-expect-error The role is closed, not a family-wide support escape hatch.
+    const misspelled: frontend.CreateDerivedIrUnitIdInput["role"] = "runtime-support:number-format-radiks";
+    // @ts-expect-error An arbitrary support role requires its own reviewed contract.
+    const general: frontend.CreateDerivedIrUnitIdInput["role"] = "runtime-support:other";
+    expect(misspelled).not.toBe(role);
+    expect(general).not.toBe(role);
+  });
+
   it("retains identical public re-exports and canonical escaped output", () => {
     expect(frontend.createIrBindingId).toBe(data.createIrBindingId);
     expect(frontend.createDerivedIrUnitId).toBe(data.createDerivedIrUnitId);


### PR DESCRIPTION
Build canonical radix support once through the shared frontend kernel and preserve its separate IR population, symbolic references, ABI declarations and allocation provenance through validation and source-free codec replay.

This refresh retains the published formatter implementation while incorporating delivered main through `35858c851f6dba219a5ab2f9a31cedb511cb38d0`. Main's lowering facade stays intact; the seven support-reference lines move into its canonical implementation. Boundary policy preserves all main history and allowed edges, with the formatter's three activation records and four canonical modules covered explicitly.

Validation on the refreshed composition: 276/276 formatter, native-resource, compiler-boundary and older builtin checks; 336/336 semantic-provider boundary checks after correcting its stale copied module set and history offsets. The original 37 fixture failures are preserved. All historical digests and negative controls remain; 31 formatter controls are added. Independent review found no source regressions or policy relaxation.

Seven source checks pass, including TS7, budgets, coercion, oracle, moved-caller preservation and report consistency. Test262's independent checkout matches all 53,933 pinned raw files. Normal signed hooks run without bypass; the first merge's changed-root hook self-skipped 99 inherited changed test files, so that skip is not counted as test execution. The final normal commit hook passed 579/579 tests across 11 suites, with no input drift. Fresh main `867e0af1745dce693cadb34d8093fc9f9b732053` adds only the unrelated issue-3451 plan; the protected queue must verify its exact composition with this tested head. Protected head and merge-group checks remain required.

This is a semantic-support checkpoint. Physical formatter emission, full native async execution, public cutover, ABI30 and direct-codegen retirement remain open. The original dynamic-import gaps remain unresolved in strict retirement evidence.

Implementation contract and original evidence: `plan/agent-context/3518-formatter-d1-high-contract-2026-09-09.md` and `plan/agent-context/3518-runtime-support-transport-progress-2026-09-09.md`. Current refresh evidence is recorded in `plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md`.

The first published-head quality run exposed an unclassified named IrType payload. The scoped repair requires canonical declaration, exact discriminant, direct IrType membership and absence from instruction unions; unknown types and instruction promotion still fail. All 85 instruction verdicts and the entire baseline remain unchanged. Focused tests pass 58/58; final repair-commit hooks pass 637/637 across 13 suites. Original failures are retained. The prior head independently passed 579/579 changed tests in CI; the repaired head requires fresh protected checks.

Fresh main `7c415913417c70cd3abfbf5cc71b227537fcb135` adds only 16 generated benchmark artifacts after the previously verified documentation-only update. No compiler, tests, policy or budget changes occur in either advance. Queue verification must cover the exact merged tree, including these main artifacts.
