### PR TITLE
fix(runtime): extract string output and handle UTF8 rope leaves

### DIFF
--- a/plan/agent-context/3518-native-string-output-extraction-handoff-2026-09-09.md
+++ b/plan/agent-context/3518-native-string-output-extraction-handoff-2026-09-09.md
@@ -1,0 +1,351 @@
+# Native string-output extraction E1 and UTF8-rope repair — publication handoff
+
+Worktree: `/private/tmp/js2-3518-native-string-output-extraction-20260909`
+Branch: `codex/3518-native-string-output-extraction-20260909`
+Exact published base: `721cd33a828c89cfc04c851b011f910b76a4d2c5`.
+
+## Current publication status
+
+All 14 implementation/proof files are frozen: eight production files, five
+tests and one proof CLI. The issue update, this handoff and the parent-authored
+inventory classification make the 17-file worker publication set.
+Original failed runs remain recorded below; later
+sections supersede their historical status, not their evidence.
+
+The original 84 E1, 75 repair and 61 flatten controls passed in session 97215;
+its eight argv-proof failures were repaired in the test harness only. The
+81-proof rerun passed in session 29311. TS7 session 78279 exited 0 with the
+unchanged production. Public comparison completed all four compiler children,
+eight compilations, 16 instances and 64 calls: candidate 32/32 correct,
+baseline 24/32 plus eight expected illegal casts. Disabled UTF8 bytes/WAT and
+outcomes are exact; enabled differences are retained. R2b comparison and six
+negative controls pass without a compiler rerun. The original controller's
+invented `warnings`-field assertion and exit 1 remain explicitly preserved.
+
+No implementation commit, push or PR has been made from this worker. Publication
+must use normal hooks and a non-draft held PR on `loopdive/js2`, after the parent
+grants the serialized slot. No merge/default-cutover/complete-async claim follows.
+
+Parent added and delegated inclusion of exactly two `files` records in
+`scripts/compiler-boundaries.json`: `src/runtime/wasmgc/values/string-concat-bodies.ts`
+and `src/runtime/wasmgc/values/stdout-bodies.ts`, each `state: clean` and
+`layer: native-runtime`. Removing just these two records reconstructs the
+entire base policy structurally. The exact parent-authored file SHA256 is
+`b7ce2750413e3f3257a6a535a691e58abff9857602739b4d76d0cbaceeb2ea55`.
+This is classification only: no allowed-edge, root, minimum, activation-history
+or negative-control expansion. Required-root activation remains parent-owned.
+The actual inventory check now passed in session 79242, exit 0, against the
+immutable base 721cd33a: 1,353 modules, zero errors, inventory valid and
+architecture incomplete. The source census contains two additional excluded
+nonmodule files; the two new owners were still untracked before staging.
+The report is `.tmp/e1-publication-inventory-r1.json`. This validates the
+classification, not expanded required-root coverage or closure certification.
+Existing caller regression suites and the full 64+2 three-arm scanner run remain
+unrun here after the shared repair. Normal publication hooks are also pending.
+
+## Historical R1 static status
+
+Status: five production files and two new test files frozen for High review and
+parent validation. No formatter, tests, typecheck, implementation commit or push
+has run. The normal claim helper completed session 28707, exit 0; remote record
+independently verified owner `ttraenkler/codex-native-string-output-extraction`,
+write ID `35913-cymplpk4`, introducing commit
+`ce9fa4ab3582286f4ed48be699f2ebc74be67b40`. Normal push, no bypass/config override;
+Thomas author and Codex GPT-6 Astra Low trailers verified. The existing corrected
+operational helper was reused read-only, with all guards unchanged. No new
+operational helper needs removal. Claim-only heavy slot was explicitly released.
+
+## Frozen executable interface
+
+- `buildStringConcatDefinition(layout, resources)`: explicit four layout type
+  indices, flatten function handle and already resolved empty-identity boolean;
+  returns six locals and the entire original binary-concat body.
+- `buildStringBatchedConcatDefinition(layout, arity, resources)`: explicit three
+  layout type indices, flatten/concat handles and one detached undefined-literal
+  instruction sequence per operand; returns three locals and the complete
+  fixed-arity body. Validates integer arity and exact dense literal population.
+- `buildStdoutAppendDefinition(resources)`: accumulator global and concat
+  function handles, zero locals.
+- `buildStdoutPrepareDefinition(resources)`: accumulator/readout globals, flat
+  type and flatten function handles, zero locals.
+- `buildStdoutCharDefinition(resources)`: readout global, flat/data type indices,
+  exactly one nullable flat-buffer local.
+
+All return fresh mutable instruction/local trees. Batched literal instructions
+are deep-detached per guard per invocation; no arbitrary callback, allocator,
+environment read, codegen import or helper lookup occurs in a pure builder.
+The records are low-level resolved physical dependencies, NOT admission
+credentials. Canonical Wasm model handle aliases retain the separate spaces.
+
+The old wrappers retain exact registration, availability/cache checks, helper
+names, signatures, global descriptors/initializers and publication order.
+The binary environment read stays after helper registration. The batched wrapper
+still calls `nativeStringLiteralInstrs(ctx, "undefined")` once per guard after
+registration and in operand order. Growth, owned-concat, comparison/slicing and
+`emitStandaloneStdoutAppendValue` are untouched.
+
+Actual existing callers remain at `src/codegen/string-ops.ts:1838`,
+`src/ir/integration.ts:7374`, `src/codegen/native-strings.ts:133` and the existing
+stdout registration/finalization calls in `src/codegen/index.ts` (5552, 6167,
+10720, 11544 at this base). No public caller was invented.
+
+## Donor evidence
+
+Exact originals were captured before source edits in
+`.tmp/string-output-donors-before.json`. The durable preservation test pins both
+original raw file SHA256s and complete parser token/comment receipt hashes; no
+historical git object is needed in shallow CI.
+
+Original raw file hashes:
+
+- `native-batched-concat.ts`: 52a1aaace8b89e85cb5862ad0ee7df86a2ccccd9e9664516bf747a4600bf7bb1
+- `native-strings-basics.ts`: d35ac41d78a1e12d3109d3001112fa6ef97e9548d1006e73241531f40c84865d
+- `native-strings.ts`: b29419deb584cc1e285a19f89a4ab7f3394215fb3d5fa7fe5c037b5be0c44173
+
+Measured original scopes (zero-based UTF-16 source positions, end exclusive):
+
+- ensureNativeBatchedConcat: 2085..7372, lines 42..195,
+  SHA256 0cb1d84114820b0d42f315b59107ff92d904f7a8c1775cee7d0b18d6b2562d5e.
+- First binary-concat block ONLY: 1875..7328, lines 36..174,
+  SHA256 a99f8646a2aa17581e0f845d7372afa61d76e50e488f9b37283e0e5558755017.
+- ensureStandaloneStdoutSink: 108041..110417, lines 2459..2519,
+  SHA256 3ad58ed16549c1c8c40f81c50e7a3ab04486039c61c9c67431c5b8c0b50e644c.
+- emitStdoutSinkExports: 113527..117236, lines 2578..2678,
+  SHA256 9538f088aeed7b3853cbc9328c448cc62551f62b9bcfe86b313b9b08b42be773.
+
+Read-only AST comparison reconstructed ALL THREE entire legacy files exactly at
+the token/comment level, not merely the moved expressions. It independently pins
+headers, dependencies, constant population, all forwarding calls and imports,
+then restores body/local construction at each original registration. This is
+static preservation, not Wasm execution. Parser diagnostics: 0 across seven
+owned files; scoped `git diff --check`: exit 0. Five builder spans are
+137/132/25/19/41 physical lines; none exceeds 300.
+
+## Authored, not yet executed
+
+Two suites contain a planned 84 cases: 60 body/adapter cases and 24 preservation
+cases (one genuine complete-file reconstruction plus 23 positive-first changes).
+
+The real-Wasm fixture has 24 recipes: twelve binary and twelve batch recipes
+(two lengths for each arity 3..8). Both empty-identity options are retained,
+with two fresh instances and two repeated calls per row: 192 planned recipe
+observations. It uses issued canonical literal and flatten packs, actual binary
+concat/batch functions, and actual stdout append/prepare/char bodies. It checks
+all UTF-16 code units, rope/flat selection, 63/64/65 boundaries, genuine rope and
+UTF-8 inputs, nonzero flat offsets, lone-surrogate data, repeated identity
+behavior, empty/null/bounds readout and four newline joins. Produced binaries,
+WAT, ordering and observations are retained under its own `.tmp/native-string-output-*`.
+
+The donor batch signature is nonnullable. A separate positive-first invalid
+module control demonstrates null injection is rejected; it is NOT reported as
+successful execution of the defensive undefined guard. That guard is still
+preserved by exact reconstruction and changed-guard controls. No nullable
+signature is fabricated to obtain a passing result.
+
+There is no new output materializer yet. These resource-backed body fixtures are
+not complete prepared-consumer, async-family, source-free replay, public default
+cutover, ABI30 or retirement proof.
+
+## Unrun commands, after parent grant
+
+This new tree has no node_modules link yet. Provision pinned existing dependencies
+using the repository's normal worktree workflow; no install/update. Do not alter
+global settings or bypass hooks.
+
+From the worktree, run sequentially:
+
+```sh
+NODE_OPTIONS=--max-old-space-size=2048 VITEST_FORK_MAX_OLD_SPACE_SIZE=2048 VITEST_MAX_FORKS=1 node node_modules/vitest/dist/cli.js run tests/issue-3518-native-string-output-bodies.test.ts tests/issue-3518-native-string-output-preservation.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose
+NODE_OPTIONS=--max-old-space-size=2048 node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json
+```
+
+Existing actual caller regression suites, still unrun and unchanged:
+`tests/native-batched-string-concat.test.ts`,
+`tests/native-string-empty-concat.test.ts`,
+`tests/native-strings-standalone.test.ts`.
+Public compiler byte/WAT pairing and no-demand comparison remain unmeasured.
+The existing three-arm no-demand instrument pins a different original/repair
+scope; it cannot be relabeled as this two-arm extraction comparison.
+
+Parent owns final inventory/boundary registration for the two new source owners,
+resource admission integration, High review and non-draft held PR publication.
+No allowances, baselines or boundary permissions were changed here.
+
+## Frozen source/test git blobs
+
+- `src/runtime/wasmgc/values/string-concat-bodies.ts`: `bc66046ee7dd0f26c9c0c7e355100b1640e9c288` (SHA256 `106451b45de1b08c7c7db79461f4c7d7bf8e92bae873845c6dde775fa00df8bd`).
+- `src/runtime/wasmgc/values/stdout-bodies.ts`: `a4ea0245059c27a7109f1fa6de34a1d023f34660` (SHA256 `77bb3e9a06cf1bce5ef57754094c0c5129bd0fb587ddee731ee82c7b2788b208`).
+- `src/codegen/native-batched-concat.ts`: `d3996b7b200d46051ae2ba77b759a09e084f48d5` (SHA256 `92c9f4b041c9598a1369f2cea630c07d7565f8030fe598f6e2d07cf191940eda`).
+- `src/codegen/native-strings-basics.ts`: `c13e7f52b41066fa0a6c934ced859ad3db393c82` (SHA256 `b5443c3f4d319ccfad825c7f4e174502b5915ea0bf933238172669afa940e618`).
+- `src/codegen/native-strings.ts`: `6d608fae95667011fa5c3eed500a7b52c7e9b926` (SHA256 `f29d91cbcf635e07d093d37e44568792d22e4112193d6c34a6675e8c5034dece`).
+- `tests/issue-3518-native-string-output-bodies.test.ts`: `684f79577b208cf85735ceb0c6c7798184e1dc37` (SHA256 `d98037d6096111ffcad0b4752729cd5d98809b658ac474d894a757bc33651ad6`).
+- `tests/issue-3518-native-string-output-preservation.test.ts`: `0fbb3b9adafd36a79400bbdc80a62af74cbd494c` (SHA256 `38612537dac57e0963e02e3a7d2ef3fb5d145015ced4d0a0b1e5e517b028bae0`).
+
+Machine-readable full receipt:
+`.tmp/native-string-output-extraction-frozen-r1.json`.
+
+## Executed R1 and unresolved UTF8 rope dependency (2026-09-09)
+
+The preceding static freeze remains historical evidence, not a test-pass claim.
+Vitest session 96230 exited 1: 56/84 passed (preservation 24/24; bodies 32/60),
+with all 28 failures retained in `.tmp/e1-validation-r1-vitest-96230.log`.
+TS7 session 55689 exited 0 without diagnostics. All seven frozen source/test
+hashes still match R1; no production or test repair has been made.
+
+The 28 failures each use the genuine mixed rope `ConsString(6, "rope-", "é")`,
+where the right leaf is an issued Utf8String. Binary-short, batch-short and
+batch-long first-pair paths all reach the unchanged copy-tree traversal. With
+empty identity enabled, `empty-rope` returns the original rope correctly and
+fails in subsequent readout. In both original failed binaries, reported PC3832
+is opcode `fb1603` starting at byte3831: casting the popped Utf8String to
+ConsString before reading its right field. No case or assertion was removed.
+The complete per-row attribution is `.tmp/e1-failure-attribution-r1.json`.
+
+### Independent original-donor / extracted execution
+
+An additional bounded A/B executes the exact original `emitStrFlattenHelpers`
+and `flattenConsBody` retained in the checked-in donor fixture, independently
+verified equal to `a6cc59a2cdfad5141d75faadf1530a9de63bebd7:src/codegen/native-strings-core.ts`.
+Its emitter registration is captured into actual issued string/flatten
+reservation tokens, validating every signature/name/handle. The candidate arm
+uses the actual `fillNativeStringFlattenResources` implementation. Neither arm
+substitutes a flatten algorithm or creates a fake provider.
+
+Sessions 49371 (donor) and 37951 (extracted) both exited 0 as recorders. Four
+cases per arm, two fresh instances and two calls per instance give 32 actual
+observations: UTF16-only rope and UTF8 root each pass 4/4 per arm; mixed-right
+and mixed-left UTF8 ropes each trap 4/4 per arm. This is 16 semantic successes
+and 16 retained semantic failures, not a green execution suite.
+The original and extracted copy-tree AND flatten bodies/locals are deeply
+identical. Full binary/WAT are not equal: only the decoder definition differs
+by the previously implemented offset-window correction (`b=0` becomes `b=off;
+end=off+byteLen`); its locals and all other body entries are identical. Raw
+bodies, bytes, WAT, imports/exports and every error stack are retained.
+
+### Actual public source reproduction, not a constructed short rope
+
+Baseline is an immutable `git archive` of published 721cd33a in the worker's
+own `.tmp/e1-public-base-tKGczA`, with all 1,353 source files individually
+verified against Git. Candidate is R1: the only five source differences are
+the three compatibility adapters and two new body owners. Every source hash
+is recorded before and after each arm. No baseline/peer checkout was edited.
+
+The actual public `compile` input has a nonconstant `join(a:string,b:string)`
+and an exported numeric probe choosing 64-character prefixes and `é`/`Ω`, then
+calling `join(a,b).charCodeAt(64)`. Both branches produce 65 code units; expected
+results are 233 and 937. No physical IR or string object is injected.
+Target is standalone, nativeStrings is true, optimize is false, and the two
+independent switches are experimentalIR and utf8Storage.
+
+Eight compilations across baseline/candidate and four switch combinations
+produced 16 real instances and 64 exported calls. All four pairs have exact
+binary, WAT, import/export order AND full outcome/error-stack equality.
+IR-off/storage-off, IR-off/storage-on and IR-on/storage-off pass all 8 calls
+per arm. IR-on/storage-on traps all 8 calls per arm: 48 public semantic passes
+and 16 retained public failures overall. With IR off, actual globals remain
+UTF16 even when storage is on, so those passing rows are controls, NOT UTF8
+leaf coverage. With IR and storage on, WAT shows actual Utf8String globals,
+`join` calling `__str_concat`, the >=64 ConsString construction, and readout
+calling `__str_flatten`. The public trap at 0x2ea2 is `fb1605`, the same
+ConsString cast in the copy-tree body inlined into flatten—not a new failure
+inferred from the shortened stack.
+
+Public recorder sessions: 25675/1228 (IR off), 81485/87469 (IR on), all exit 0.
+Exit 0 means complete measurement; acceptance remains false.
+Complete comparison and six report paths/hashes:
+`.tmp/e1-flatten-public-comparison-r1.json`.
+Harnesses: `.tmp/e1-flatten-donor-ab.mts` and `.tmp/e1-flatten-donor-ab-ir.mts`;
+the latter differs only in the explicit experimentalIR option. They retain
+the original log, all failed observations and exact instantiated bytes.
+
+### Required owner and next boundary
+
+This is an inherited shared flatten gap, independently reproduced both from
+the pre-extraction donor and through genuine public source on the E1 baseline.
+The semantic owner is `src/runtime/wasmgc/values/string-flatten-bodies.ts`:
+`buildStringCopyTreeDefinition` recognizes only NativeString leaves, with no
+decoder dependency, while its AnyString worklist admits Utf8String leaves.
+The root-only decoder branch in `buildStringFlattenDefinition` cannot handle
+UTF8 children reached during traversal.
+
+A separate High-approved repair must resolve the genuine optional decoder
+handle and thread it through BOTH callers: the issued fill in
+`src/backend/wasmgc/resources/native-string-flatten.ts` and legacy registration
+in `src/codegen/native-strings-core.ts`. It must preserve the declaration/type/
+function order copy-tree → optional decoder → flatten, avoid inferred sibling
+indices, and retain disabled-UTF8 behavior. Exact phase staging belongs to that
+owner/spec, not an E1 workaround. Do not preflatten/remove the mixed test leaf,
+change concat's >=64 behavior or install a dummy decoder. Existing donor
+receipts must retain their original hashes and identify any authorized delta.
+
+No shared-flatten source repair is authorized or claimed here. Heavy slot was
+released after 87469 terminated; no further heavy invocation is running.
+
+## Subsequent authorized shared repair: final bounded execution receipt
+
+This section records the later explicit High-contract repair authorization;
+the preceding R1 failures and scope statement remain historical evidence.
+The seven original E1 files and decoder remain byte-frozen. The three repaired
+production files are exactly the approved manifest
+`.tmp/e1-utf8-rope-repair-frozen-r1.json` (SHA256
+`c92715020c068c5bc417c74d36c36530dffd430659679c6192562c06002cd89e`).
+The sole subsequent proof-test change interchanges child argv positions;
+the guard, checker and all 81 controls remain retained.
+
+Validation history, without replacing failed runs:
+
+- Session 97215 exited 1: original E1 84/84, repair 75/75, existing flatten
+  61/61, proof 73/81; total 293/301. The eight proof failures were the
+  file-URL-as-filesystem-argv instrument error.
+- Session 78279: TS7 exit 0. Production has not changed since this check.
+- Session 29311: corrected proof invocation exit 0, 81/81; JSON SHA256
+  `9e9764212b5ff092d30aedbbfabe409326ac2d570548cee78c7bd09617ed07f7`
+  at `.tmp/e1-utf8-rope-validation-r2-proof.json`.
+
+The actual public pair reran the unchanged two probes and exact source/options
+described above. Baseline is still the 721cd33a archive (1,353 source files,
+every file checked against its Git blob). Candidate is that base plus the
+five E1 and three shared-repair production paths (1,355 source files).
+The complete changed-path census, all before/after source hashes and frozen
+file hashes are in `.tmp/e1-public-pair-r2-results/preflight.json`, SHA256
+`842b36e9aed719edf825effd3b9243e1faf57c3e3d49cf4bb841ff2286dd7c39`.
+Node executable, tsx implementation, esbuild executable/implementation and
+config content match; the child config path is explicitly bound to its arm.
+
+Session 28157 ran four sequential children: PIDs 29113, 29166, 29178, 29188.
+Every child exited 0, without signal or spawn error. All eight compilations,
+16 real instances and 64 calls completed. Candidate passes all 32 calls;
+baseline passes 24 and retains eight actual `RuntimeError: illegal cast`
+outcomes in IR-on/UTF8-on. Both UTF8-disabled pairs preserve exact binary,
+WAT, import/export ordering and outcomes. Both enabled pairs have explicit
+raw differences; byte parity with the broken enabled baseline is NOT claimed.
+Passing IR-off/storage-on still does not prove UTF8-leaf coverage.
+
+The controller subsequently exited 1 because its validator invented a
+required `warnings` field. The actual `CompileResult` exposes `errors`, not
+`warnings`. Its original script and failure report are unchanged. The separate
+comparison-only amendment requires the actually absent field, independently
+revalidates all launch/terminal/source/runtime/row identities, and rereads the
+same full artifacts without another compiler invocation. It exits 0; all six
+negative controls reject (missing row, foreign root, wrong value, substituted
+instantiated bytes, nonzero terminal, missing runtime).
+
+Final report: `.tmp/e1-public-pair-r2-results/comparison-r2b.json`, SHA256
+`55f87e2bac3473d7f66c33017451f6e87500cbb1998f52c450c5e16618e71913`.
+Each arm's full bytes, instantiated bytes, WAT, order, values and raw stacks
+remain in its referenced JSON, alongside separate launch/terminal receipts.
+The amended comparator is `.tmp/e1-public-pair-r2b-compare.mjs`, SHA256
+`52ade7773abf90e16892a3e4297f07137c2431c861ea986c61fda59aa76a9fa1`.
+
+Recorded comparison-only invocation from this frozen worker:
+`NODE_OPTIONS=--max-old-space-size=2048 node .tmp/e1-public-pair-r2b-compare.mjs .tmp/e1-public-pair-r2-results`
+on the existing receipts; it intentionally refuses to overwrite its existing
+output. The original execution controller and both probe hashes are retained
+in preflight. Any new compiler run requires a new output directory and the
+parent's serialized slot; no rerun is authorized by this handoff.
+
+The heavy slot was explicitly released after all four children terminated.
+No production, donor, original probe or prior failed receipt changed during
+this validation. The full 64+2 scanner three-arm CLI has not been rerun after
+the shared repair; its 81 proof controls are not that compiler population.
+Complete native output/async acceptance and retirement remain separate.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -6787,3 +6787,105 @@ agent-context/3518-native-async-resource-declarations-spec-2026-09-09.md;
 the frame API and object-access donor map are also preserved for the next lanes.
 This composition does not remove the async acceptance refusal or establish
 native async execution, public default cutover or retirement.
+
+### Native string-output executable extraction E1 — static draft (2026-09-09)
+
+The separately claimed Lane E prerequisite is implemented against published
+721cd33a828c89cfc04c851b011f910b76a4d2c5: complete binary concat, fixed-arity
+concat, stdout append, prepare and character readout bodies/locals now have
+pure runtime owners with live compatibility adapters. Registration, literal
+production and publication remain in their original order. Owned concat,
+growth, console coercion and all consumer/resource admission code are unchanged.
+
+Read-only inverse reconstruction matches all three complete historical donor
+files, with original hash receipts retained. Two new suites author 84 cases,
+including 24 real-Wasm recipes under both empty-identity choices; these tests,
+typecheck, formatting and normal publication hooks have NOT run in this draft.
+High review and serialized validation are required before publication.
+
+See agent-context/3518-native-string-output-extraction-handoff-2026-09-09.md
+for exact scope, interfaces, frozen source hashes and unrun commands. Native
+output resource admission and full-family consumer execution remain the next
+checkpoint; this extraction does not satisfy those acceptance conditions.
+
+### E1 validation exposes inherited UTF8 rope traversal failure (2026-09-09)
+
+The unchanged E1 R1 source/test freeze was measured: 56/84 focused cases pass,
+28 mixed-UTF8-rope cases fail; all 24 complete-donor preservation controls pass,
+and TS7 exits zero. Failures are retained, not waived or relabeled as successful
+native output acceptance.
+
+Independent original-donor versus canonical-resource execution gives 32 calls:
+UTF16 ropes and UTF8 roots succeed, while UTF8-left/right rope leaves trap on
+both arms (16 successes, 16 failures). Original and extracted copy-tree/flatten
+bodies and locals are exactly equal. Full binaries retain the separate prior
+UTF8 decoder offset correction as an explicit difference.
+
+Actual public source independently reproduces the defect: a runtime-selected
+65-code-unit concat followed by charCodeAt, compiled on exact 721cd33a versus
+frozen E1, with IR and UTF8-storage switches independently off/on. Eight
+compilations, 16 instances and 64 calls give 48 successes and 16 failures. All
+four baseline/candidate pairs have exact bytes/WAT/import/export/outcome parity.
+Only IR-on/storage-on produces real UTF8 leaves and traps; storage-on alone
+on the legacy source route still materializes UTF16 globals and is not UTF8
+coverage. The public trap is the copy-tree ConsString cast inlined into flatten.
+
+Required repair owner is the shared string-flatten runtime and its two actual
+legacy/resource callers, outside E1's five production paths. Copy-tree needs
+an actual decoder dependency for UTF8 leaves while preserving declaration and
+registration order. No such repair, case removal or production scope expansion
+has occurred. See the executed-evidence section of
+agent-context/3518-native-string-output-extraction-handoff-2026-09-09.md for
+exact sessions, donor lineage, artifacts, remaining limitations and owner join.
+
+### E1 extraction plus authorized UTF8-rope repair — publication preparation (2026-09-09)
+
+The later High contract explicitly authorized the shared copy-tree repair and
+its two real callers. Copy-tree receives the actual enabled/disabled decoder
+selection, classifies UTF8 leaves before the original descent, and retains all
+seven locals. Legacy registration captures and fills the same pending function
+object in the original order; issued resource fill passes the genuine decoder.
+The original seven E1 files and complete UTF8 decoder bytes remain unchanged.
+Two exact checked inverses reconstruct the original copy-tree and legacy adapter
+without reseeding historical scanner/decoder or whole-donor receipts.
+
+Session 97215 retained 293/301: E1 84/84, repair 75/75, flatten 61/61 and proof
+73/81. All eight remaining failures were child argv path errors. Their test-only
+correction then passed all 81/81 in session 29311; no guard was weakened.
+TS7 session 78279 exited zero with this unchanged production.
+
+Actual public compilation compared exact 721cd33a against the frozen eight-path
+production delta. All four compiler children exited zero: eight compilations,
+16 real instances and 64 calls. Candidate passes 32/32. Baseline retains its
+eight IR-on/UTF8-on illegal casts and passes the other 24/32. Both disabled-UTF8
+pairs preserve exact bytes/WAT/import/export ordering/outcomes; both enabled
+pairs retain explicit differences rather than pretending repair is parity.
+
+The public controller exited one only after compilation, because its validator
+invented a required `warnings` array; the real public CompileResult has `errors`,
+not a warnings field. Original script and failure report remain. A separate
+comparison-only correction reread the exact receipts without another compiler
+run and exited zero, with six independently rejecting corruption controls.
+The final report SHA256 is
+`55f87e2bac3473d7f66c33017451f6e87500cbb1998f52c450c5e16618e71913`;
+full artifact, provenance and terminal paths are in the E1 publication handoff.
+
+The heavy slot is released. Normal commit/push gates and parent-owned inventory
+registration for the two new body modules remain pending. The full scanner
+three-arm compiler run and existing caller regression suites have not been
+rerun here after this repair. This prepares a non-draft held checkpoint; it
+does not claim native output resource admission, complete async execution,
+public IR-only default, ABI30 acceptance or retirement.
+
+Subsequent bounded metadata handoff: parent added exactly two `files` records
+for the new concat/stdout body owners, both clean/native-runtime, and delegated
+their inclusion as the seventeenth checkpoint file. The complete policy is
+otherwise structurally unchanged: no allowed edges, required roots, minima,
+history or negative-control expansion. Actual inventory validation remains
+unrun pending the serialized slot; classification is not activation evidence.
+
+Actual publication inventory subsequently passed in session 79242, exit zero:
+1,353 modules, zero errors, inventory valid and architecture incomplete against
+the immutable 721cd33a base. The two new owners were counted as untracked prior
+to staging. This is classification validation, not expanded root coverage or
+complete-graph/retirement evidence; normal publication hooks remain next.

--- a/scripts/compiler-boundaries.json
+++ b/scripts/compiler-boundaries.json
@@ -1307,6 +1307,16 @@
   ],
   "files": [
     {
+      "path": "src/runtime/wasmgc/values/string-concat-bodies.ts",
+      "state": "clean",
+      "layer": "native-runtime"
+    },
+    {
+      "path": "src/runtime/wasmgc/values/stdout-bodies.ts",
+      "state": "clean",
+      "layer": "native-runtime"
+    },
+    {
       "path": "src/runtime/wasmgc/values/closure-layouts.ts",
       "state": "clean",
       "layer": "native-runtime"

--- a/scripts/verify-native-scanner-source-preservation.mjs
+++ b/scripts/verify-native-scanner-source-preservation.mjs
@@ -186,23 +186,174 @@ export function projectDecoder(source, url, expectedUrl, sha) {
   if (sha(text) !== pin.outputHash) throw Error("decoder projection output hash differs");
   return { text, evidence: { url, ...pin } };
 }
+export function projectCopyTreeUtf8(source, url, expectedUrl, sha) {
+  // Fixed reviewed semantic-delta inverse; the output is the original full-file receipt.
+  const pin = {
+    inputHash: "012223f8fe1feeee7c175f9e09e0c5461234bf47ba3998aa5f9dbfa51cc5c639",
+    outputHash: "f40b6b18f92c8bbba588efc72bd075a1e93c2cfe3fbe4939f3019fe6825a5bdf",
+    deltas: [
+      {
+        start: 4672,
+        text: '  utf8Decoder: StringFlattenResources["utf8Decoder"],\n',
+        replacement: "",
+      },
+      {
+        start: 4769,
+        text: '  const utf8Indices = utf8Decoder.kind === "present" ? [layout.utf8StrTypeIdx, layout.utf8StrDataTypeIdx] : [];\n  for (const index of utf8Indices)\n    if (!Number.isSafeInteger(index) || index < 0)\n      throw new Error("native string copy tree: decoder requires UTF8 layout");\n',
+        replacement: "",
+      },
+      {
+        start: 9282,
+        text: '                    // Normalize UTF8 at every descent, including popped right children.\n                    ...(utf8Decoder.kind === "present"\n                      ? ([\n                          { op: "local.get", index: CUR },\n                          { op: "ref.as_non_null" },\n                          { op: "ref.test", typeIdx: layout.utf8StrTypeIdx },\n                          {\n                            op: "if",\n                            blockType: { kind: "empty" },\n                            then: [\n                              { op: "local.get", index: CUR },\n                              { op: "ref.as_non_null" },\n                              { op: "ref.cast", typeIdx: layout.utf8StrTypeIdx },\n                              { op: "call", funcIdx: utf8Decoder.handle },\n                              { op: "local.set", index: CUR },\n                            ],\n                          },\n                        ] satisfies Instr[])\n                      : []),\n',
+        replacement: "",
+      },
+    ],
+    region: {
+      name: "buildStringCopyTreeDefinition",
+      start: 4566,
+      header:
+        'export function buildStringCopyTreeDefinition(\n  layout: NativeStringLayout,\n  worklistTypeIndex: number,\n  utf8Decoder: StringFlattenResources["utf8Decoder"],\n): { locals: LocalDef[]; body: Instr[] } {\n',
+    },
+  };
+  if (url !== expectedUrl || !expectedUrl.endsWith("/src/runtime/wasmgc/values/string-flatten-bodies.ts"))
+    throw Error("wrong copy-tree projection target/root");
+  if (sha(source) !== pin.inputHash) throw Error("copy-tree projection input hash differs");
+  if (
+    source.indexOf(pin.region.header) !== pin.region.start ||
+    source.lastIndexOf(pin.region.header) !== pin.region.start
+  )
+    throw Error("changed copy-tree region/header");
+  for (const d of pin.deltas)
+    if (source.indexOf(d.text) !== d.start || source.lastIndexOf(d.text) !== d.start)
+      throw Error("missing/duplicate/misplaced copy-tree delta");
+  let text = source;
+  for (const d of [...pin.deltas].sort((a, b) => b.start - a.start))
+    text = text.slice(0, d.start) + d.replacement + text.slice(d.start + d.text.length);
+  if (sha(text) !== pin.outputHash) throw Error("copy-tree projection output hash differs");
+  return { text, evidence: { url, ...pin } };
+}
+
+export function projectFlattenAdapterStaging(source, url, expectedUrl, sha) {
+  // Fixed reviewed semantic-delta inverse; the output is the original full-file receipt.
+  const pin = {
+    inputHash: "45407b5fd4be2c0d1a6912b23db8b34510f6accdee0ced9a4bcee92d376a40d1",
+    outputHash: "00668dc5edcba527d6c8d2bc5638a909f55a5894115d4c30aa1f7b03a50cc9d2",
+    deltas: [
+      {
+        start: 1096,
+        text: 'import type { WasmFunction } from "../wasm/model/module-records.js";\n',
+        replacement: "",
+      },
+      {
+        start: 1239,
+        text: "  type StringFlattenResources,\n",
+        replacement: "",
+      },
+      {
+        start: 2438,
+        text: '  let copyTreeFunction: WasmFunction;\n  let copyTreeWorklistType: number;\n  let utf8Decoder: StringFlattenResources["utf8Decoder"] = { kind: "absent" };\n',
+        replacement: "",
+      },
+      {
+        start: 4533,
+        text: '    // Reserve the actual function object in its historical slot. It is pending,\n    // not executable, until the optional decoder has been registered below.\n    copyTreeWorklistType = wlArrTypeIdx;\n    copyTreeFunction = {\n      name: "__str_copy_tree",\n      typeIdx,\n      locals: [],\n      body: [],\n      exported: false,\n    };\n    pushDefinedFunc(ctx, funcIdx, copyTreeFunction);',
+        replacement:
+          '    const definition = buildStringCopyTreeDefinition(ctx, wlArrTypeIdx);\n\n    pushDefinedFunc(ctx, funcIdx, {\n      name: "__str_copy_tree",\n      typeIdx,\n      locals: definition.locals,\n      body: definition.body,\n      exported: false,\n    });',
+      },
+      {
+        start: 6133,
+        text: '    utf8Decoder = { kind: "present", handle: funcIdx };\n',
+        replacement: "",
+      },
+      {
+        start: 6194,
+        text: "  // Fill the same pushed object once, using only the decoder minted above.\n  // A decoder construction failure propagates before any completion is claimed.\n  const copyTreeDefinition = buildStringCopyTreeDefinition(ctx, copyTreeWorklistType, utf8Decoder);\n  copyTreeFunction.locals = copyTreeDefinition.locals;\n  copyTreeFunction.body = copyTreeDefinition.body;\n\n",
+        replacement: "",
+      },
+      {
+        start: 7566,
+        text: '    const copyTreeIdx = ctx.nativeStrHelpers.get("__str_copy_tree")!;\n',
+        replacement:
+          '    const copyTreeIdx = ctx.nativeStrHelpers.get("__str_copy_tree")!;\n    // #1588 PR-B part 2: present iff --utf8-storage is on.\n    const utf8ToFlatIdx = ctx.nativeStrHelpers.get("__str_utf8_to_flat");\n',
+      },
+      {
+        start: 8041,
+        text: "      utf8Decoder,\n",
+        replacement:
+          '      utf8Decoder:\n        ctx.utf8Storage && ctx.utf8StrTypeIdx >= 0 && utf8ToFlatIdx !== undefined\n          ? { kind: "present", handle: utf8ToFlatIdx }\n          : { kind: "absent" },\n',
+      },
+    ],
+    region: {
+      name: "emitStrFlattenHelpers",
+      start: 2250,
+      header: "export function emitStrFlattenHelpers(shared: NativeStrShared): void {\n",
+    },
+  };
+  if (url !== expectedUrl || !expectedUrl.endsWith("/src/codegen/native-strings-core.ts"))
+    throw Error("wrong flatten adapter projection target/root");
+  if (sha(source) !== pin.inputHash) throw Error("flatten adapter projection input hash differs");
+  if (
+    source.indexOf(pin.region.header) !== pin.region.start ||
+    source.lastIndexOf(pin.region.header) !== pin.region.start
+  )
+    throw Error("changed flatten adapter region/header");
+  for (const d of pin.deltas)
+    if (source.indexOf(d.text) !== d.start || source.lastIndexOf(d.text) !== d.start)
+      throw Error("missing/duplicate/misplaced flatten adapter delta");
+  let text = source;
+  for (const d of [...pin.deltas].sort((a, b) => b.start - a.start))
+    text = text.slice(0, d.start) + d.replacement + text.slice(d.start + d.text.length);
+  if (sha(text) !== pin.outputHash) throw Error("flatten adapter projection output hash differs");
+  return { text, evidence: { url, ...pin } };
+}
+
+export function scannerProjectionTargets(root) {
+  return Object.fromEntries(
+    [
+      ["src/runtime/wasmgc/values/string-number-bodies.ts", "scanner"],
+      ["src/runtime/wasmgc/values/string-utf8-decode-bodies.ts", "decoder"],
+      ["src/runtime/wasmgc/values/string-flatten-bodies.ts", "copyTree"],
+      ["src/codegen/native-strings-core.ts", "adapter"],
+    ].map(([path, kind]) => [pathToFileURL(join(root, path)).href, kind]),
+  );
+}
+// Exact URL membership is the sole authorization. Suffix comparison below can
+// only deny alternate roots/routes/query instances, never authorize a load.
+export function scannerProjectionTarget(url, targets) {
+  if (Object.hasOwn(targets, url)) return targets[url];
+  const parsed = new URL(url);
+  for (const expected of Object.keys(targets)) {
+    const path = new URL(expected).pathname;
+    const relative = path.slice(path.lastIndexOf("/src/"));
+    if (parsed.pathname.endsWith(relative)) throw Error("wrong projection target/root " + url);
+  }
+  return null;
+}
+export function requireScannerBaselineSource(rows) {
+  // Independently checked against every blob in the fixed a6cc source tree.
+  assert.equal(rows.length, 1337, "baseline source population differs");
+  assert.equal(
+    sha(JSON.stringify(rows)),
+    "5dbae41d235c490b58f107fcc70ef54dc353544be3bccd63d92b5be706429df5",
+    "baseline source census differs",
+  );
+}
 const loaderSource = String.raw`
 import { createHash } from "node:crypto";
 let state, transformations=0, loads=0, perTarget={}, evidence=[];
 const sha=s=>createHash("sha256").update(s).digest("hex");
 export function initialize(data){state=data;state.port.on("message",message=>{if(message==="receipt")state.port.postMessage({transformations,loads,perTarget,evidence});});state.port.unref();}
 export async function load(url,context,next){
-  const decoder=url.includes("/src/runtime/wasmgc/values/string-utf8-decode-bodies.");
-  const expected=decoder?state.decoderUrl:state.expectedUrl;
-  if((decoder||url.includes("/src/runtime/wasmgc/values/string-number-bodies."))&&url!==expected)throw Error("wrong projection target/root");
+  const kind=SELECT_TARGET(url,state.targets);
   const result=await next(url,context);
-  if(url!==state.expectedUrl&&url!==state.decoderUrl)return result;
+  if(kind===null)return result;
   loads++;
   perTarget[url]=(perTarget[url]??0)+1;
   if(perTarget[url]!==1)throw Error("duplicate canonical load/transformation");
   const source=typeof result.source==="string"?result.source:Buffer.from(result.source).toString("utf8");
   if(state.arm!=="projection")return result;
-  const projected=decoder?PROJECT_DECODER(source,url,state.decoderUrl,sha):PROJECT_SCANNER(source,url,state.expectedUrl,sha);
+  const projectors={scanner:PROJECT_SCANNER,decoder:PROJECT_DECODER,copyTree:PROJECT_COPY_TREE,adapter:PROJECT_ADAPTER};
+  const projected=projectors[kind](source,url,url,sha);
   transformations++;evidence.push(projected.evidence);
   return {...result,source:projected.text};
 }
@@ -217,7 +368,7 @@ import { execFileSync } from "node:child_process";
 import { register } from "node:module";
 import { MessageChannel } from "node:worker_threads";
 const [rootArgument, arm, loaderArgument, harnessUrl, identityArgument] = process.argv.slice(1), root = realpathSync(rootArgument);
-const {scannerRuntimeIdentity} = await import(harnessUrl);
+const {scannerRuntimeIdentity,scannerProjectionTargets,requireScannerBaselineSource,requireTargetLoads,requireTransformCount} = await import(harnessUrl);
 const expectedIdentity=JSON.parse(Buffer.from(identityArgument,"base64").toString("utf8"));
 const runtimeBefore=scannerRuntimeIdentity(root,process.env,expectedIdentity);
 const sha = value => createHash("sha256").update(value).digest("hex");
@@ -236,13 +387,13 @@ if(arm==="baseline"){
 }
 function snapshot(){const rows=[];function walk(dir){for(const entry of readdirSync(join(root,dir),{withFileTypes:true}).sort((a,b)=>a.name.localeCompare(b.name))){const path=dir+"/"+entry.name;if(entry.isDirectory())walk(path);else{assert(entry.isFile(),"unexpected source symlink "+path);rows.push([path,sha(readFileSync(join(root,path)))]);}}}walk("src");assert(rows.length>1000);return rows;}
 const sourceBefore=snapshot(),urls=[];
+if(arm==="baseline")requireScannerBaselineSource(sourceBefore);
 // Register the raw-source hook FIRST. The identical tsx loader in every arm
 // then calls through it before performing its normal TypeScript transform.
 const loaderText=Buffer.from(loaderArgument,"base64").toString("utf8");
 const {port1,port2}=new MessageChannel();port1.unref();
-const expectedUrl=pathToFileURL(join(root,"src/runtime/wasmgc/values/string-number-bodies.ts")).href;
-const decoderUrl=pathToFileURL(join(root,"src/runtime/wasmgc/values/string-utf8-decode-bodies.ts")).href;
-register("data:text/javascript;base64,"+Buffer.from(loaderText).toString("base64"),{parentURL:import.meta.url,data:{root,arm,expectedUrl,decoderUrl,port:port2},transferList:[port2]});
+const targets=scannerProjectionTargets(root);
+register("data:text/javascript;base64,"+Buffer.from(loaderText).toString("base64"),{parentURL:import.meta.url,data:{root,arm,targets,port:port2},transferList:[port2]});
 const {register:registerTsx}=await import(pathToFileURL(runtimeBefore.paths.tsxEntry).href);
 registerTsx({tsconfig:join(root,"tsconfig.json")});
 const runtimeLoader={...runtimeBefore,content:{...runtimeBefore.content,loaderHash:sha(loaderText)}};
@@ -352,9 +503,10 @@ for(const fixture of [...fixtures,...malformed]){
 assert.deepEqual(snapshot(),sourceBefore,"compiler source changed during arm");
 scannerRuntimeIdentity(root,process.env,runtimeBefore);
 port1.ref();const projection=await awaitStep(new Promise(resolve=>{port1.once("message",resolve);port1.postMessage("receipt");}),{phase:"loader-receipt"});port1.close();
-assert.equal(projection.transformations,arm==="projection"?2:0,"missing/duplicate transformation");
-assert.equal(projection.loads,arm==="baseline"?0:2,"missing/duplicate scanner load");
-console.log("SCANNER_RECEIPT="+JSON.stringify({schema:"native-scanner-public-source-pair-v4",arm,root,head,urls,runtimeLoader,projection,sourceFiles:sourceBefore,fixturePins:pins,fixtures:fixtures.map(f=>({...f,expected:encode(f.expected)})),semanticFixtures:malformed.map(f=>({id:f.id,source:f.source,options:f.options})),rows,physicalAcceptanceCertified:false}));
+requireTransformCount(projection.transformations,arm);
+requireTargetLoads(projection.perTarget,root,arm);
+assert.equal(projection.loads,arm==="baseline"?1:4,"missing/duplicate scanner load");
+console.log("SCANNER_RECEIPT="+JSON.stringify({schema:"native-scanner-public-source-pair-v5",arm,root,head,urls,runtimeLoader,projection,sourceFiles:sourceBefore,fixturePins:pins,fixtures:fixtures.map(f=>({...f,expected:encode(f.expected)})),semanticFixtures:malformed.map(f=>({id:f.id,source:f.source,options:f.options})),rows,physicalAcceptanceCertified:false}));
 `;
 const expectedIds = [
   ...Array.from({ length: 17 }, (_, i) => "3570:" + i),
@@ -371,25 +523,26 @@ export function requirePopulation(ids) {
   if (JSON.stringify(ids) !== JSON.stringify(expectedIds)) throw Error("missing/duplicate/reordered source row");
 }
 export function requireTransformCount(count, arm) {
-  if (count !== (arm === "projection" ? 2 : 0)) throw Error("missing/duplicate/unexpected transformation");
+  if (!["baseline", "candidate", "projection"].includes(arm) || count !== (arm === "projection" ? 4 : 0))
+    throw Error("missing/duplicate/unexpected transformation");
 }
 export function requireTargetLoads(actual, root, arm) {
-  const expected =
-    arm === "baseline"
-      ? {}
-      : Object.fromEntries(
-          ["string-number-bodies.ts", "string-utf8-decode-bodies.ts"].map((name) => [
-            pathToFileURL(join(root, "src/runtime/wasmgc/values", name)).href,
-            1,
-          ]),
-        );
+  assert(["baseline", "candidate", "projection"].includes(arm), "unknown scanner arm");
+  const expected = Object.fromEntries(
+    Object.entries(scannerProjectionTargets(root))
+      .filter(([, kind]) => arm !== "baseline" || kind === "adapter")
+      .map(([url]) => [url, 1]),
+  );
   if (JSON.stringify(Object.entries(actual).sort()) !== JSON.stringify(Object.entries(expected).sort()))
     throw Error("missing/duplicate/foreign target load");
 }
 async function runArm(root, arm, directory) {
   const loader = loaderSource
     .replace("PROJECT_SCANNER", `(${projectScanner.toString()})`)
-    .replace("PROJECT_DECODER", `(${projectDecoder.toString()})`);
+    .replace("PROJECT_DECODER", `(${projectDecoder.toString()})`)
+    .replace("PROJECT_COPY_TREE", `(${projectCopyTreeUtf8.toString()})`)
+    .replace("PROJECT_ADAPTER", `(${projectFlattenAdapterStaging.toString()})`)
+    .replace("SELECT_TARGET", `(${scannerProjectionTarget.toString()})`);
   const env = scannerChildEnvironment(root);
   const runtimeBefore = scannerRuntimeIdentity(root, env);
   const child = spawn(
@@ -437,7 +590,7 @@ async function runArm(root, arm, directory) {
   scannerRuntimeIdentity(root, env, runtimeBefore);
   const receipt = JSON.parse(receipts[0].slice("SCANNER_RECEIPT=".length));
   writeFileSync(join(directory, arm + ".json"), JSON.stringify(receipt, null, 2));
-  assert.equal(receipt.schema, "native-scanner-public-source-pair-v4");
+  assert.equal(receipt.schema, "native-scanner-public-source-pair-v5");
   assert.equal(receipt.root, root);
   assert.equal(receipt.arm, arm);
   assert.deepEqual(
@@ -450,23 +603,23 @@ async function runArm(root, arm, directory) {
   assert.equal(receipt.semanticFixtures.length, 2);
   requireTransformCount(receipt.projection.transformations, arm);
   requireTargetLoads(receipt.projection.perTarget, root, arm);
-  assert.equal(receipt.projection.loads, arm === "baseline" ? 0 : 2);
+  assert.equal(receipt.projection.loads, arm === "baseline" ? 1 : 4);
+  if (arm === "baseline") requireScannerBaselineSource(receipt.sourceFiles);
   if (arm === "projection") {
-    const path = join(root, "src/runtime/wasmgc/values/string-number-bodies.ts"),
-      url = pathToFileURL(path).href;
-    const projected = projectScanner(readFileSync(path, "utf8"), url, url, (s) =>
-      createHash("sha256").update(s).digest("hex"),
-    );
-    const decoderPath = join(root, "src/runtime/wasmgc/values/string-utf8-decode-bodies.ts"),
-      decoderUrl = pathToFileURL(decoderPath).href;
-    const decoded = projectDecoder(readFileSync(decoderPath, "utf8"), decoderUrl, decoderUrl, (s) =>
-      createHash("sha256").update(s).digest("hex"),
+    const projectors = {
+      scanner: projectScanner,
+      decoder: projectDecoder,
+      copyTree: projectCopyTreeUtf8,
+      adapter: projectFlattenAdapterStaging,
+    };
+    const expectedEvidence = Object.entries(scannerProjectionTargets(root)).map(
+      ([url, kind]) => projectors[kind](readFileSync(new URL(url), "utf8"), url, url, sha).evidence,
     );
     assert.deepEqual(
       [...receipt.projection.evidence].sort((a, b) => a.url.localeCompare(b.url)),
-      [projected.evidence, decoded.evidence].sort((a, b) => a.url.localeCompare(b.url)),
+      expectedEvidence.sort((a, b) => a.url.localeCompare(b.url)),
     );
-    assert.equal(receipt.projection.evidence.length, 2);
+    assert.equal(receipt.projection.evidence.length, 4);
   } else assert.deepEqual(receipt.projection.evidence, []);
   return receipt;
 }

--- a/src/backend/wasmgc/resources/native-string-flatten.ts
+++ b/src/backend/wasmgc/resources/native-string-flatten.ts
@@ -151,7 +151,11 @@ export function fillNativeStringFlattenResources(
   if (owner.filled) fail("duplicate fill");
   requireCompletedNativeStringLiterals(tx, owner.stringPack);
   const layout = pack.stringPack.layout;
-  const copy = buildStringCopyTreeDefinition(layout, pack.worklist.typeIndex);
+  const copy = buildStringCopyTreeDefinition(
+    layout,
+    pack.worklist.typeIndex,
+    pack.utf8Decoder ? { kind: "present", handle: pack.utf8Decoder.handle } : { kind: "absent" },
+  );
   const decoder = pack.utf8Decoder ? buildStringUtf8ToFlatDefinition(layout) : null;
   const flat = buildStringFlattenDefinition(layout, {
     copyTree: pack.copyTree.handle,

--- a/src/codegen/native-batched-concat.ts
+++ b/src/codegen/native-batched-concat.ts
@@ -10,6 +10,7 @@
  * operand.
  */
 import type { Instr, ValType } from "../ir/types.js";
+import { buildStringBatchedConcatDefinition } from "../runtime/wasmgc/values/string-concat-bodies.js";
 import { ts } from "../ts-api.js";
 import { isStringType } from "../checker/type-mapper.js";
 import type { CodegenContext } from "./context/types.js";
@@ -24,7 +25,6 @@ import { STRING_CONCAT_MANY_NATIVE_ARITY } from "../ir/runtime-manifest.js";
 // authority and both readers derive from it.
 const MIN_BATCHED_CONCAT_ARITY = STRING_CONCAT_MANY_NATIVE_ARITY.min;
 const MAX_BATCHED_CONCAT_ARITY = STRING_CONCAT_MANY_NATIVE_ARITY.max;
-const FLAT_CONCAT_LIMIT = 64;
 
 /** Flatten only `+` subtrees whose TypeScript result is already a string. */
 export function collectConcatOperands(ctx: CodegenContext, expression: ts.Expression): ts.Expression[] {
@@ -70,125 +70,19 @@ export function ensureNativeBatchedConcat(ctx: CodegenContext, arity: number): n
   const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeStrHelpers.set(helperName, funcIdx);
 
-  // Params: operand0..operandN-1.
-  // Locals: totalLen(N), output(N+1), offset(N+2).
-  const totalLenLocal = arity;
-  const outputLocal = arity + 1;
-  const offsetLocal = arity + 2;
-  const body: Instr[] = [];
-  // (#4394) Null-carrier ToString guard. A statically-string-typed operand can
-  // carry the null $AnyString sentinel at runtime — the JS `undefined` of a
-  // missing property/param that flowed through a string-typed slot (the #3548
-  // carrier convention; e.g. `expectedErrorConstructor.name` in the test262
-  // asyncHelpers, JSDoc-typed `string`). The length sum below would trap on it
-  // ("dereferencing a null pointer in __str_concat_N"). §7.1.17 ToString of
-  // that carrier is "undefined", so substitute exactly that — never the empty
-  // string, which would silently corrupt the concatenation.
-  for (let index = 0; index < arity; index++) {
-    body.push(
-      { op: "local.get", index },
-      { op: "ref.is_null" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [...nativeStringLiteralInstrs(ctx, "undefined"), { op: "local.set", index }],
-      },
-    );
-  }
-  body.push({ op: "i32.const", value: 0 });
-  for (let index = 0; index < arity; index++) {
-    body.push({ op: "local.get", index }, { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 }, { op: "i32.add" });
-  }
-  body.push(
-    { op: "local.tee", index: totalLenLocal },
-    { op: "i32.const", value: FLAT_CONCAT_LIMIT },
-    { op: "i32.lt_u" },
-  );
-
-  const flatArm: Instr[] = [];
-  for (let index = 0; index < arity; index++) {
-    flatArm.push(
-      { op: "local.get", index },
-      { op: "ref.test", typeIdx: strTypeIdx },
-      { op: "i32.eqz" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          { op: "local.get", index },
-          { op: "call", funcIdx: flattenIdx },
-          { op: "local.set", index },
-        ],
-      },
-    );
-  }
-  flatArm.push(
-    { op: "local.get", index: totalLenLocal },
-    { op: "array.new_default", typeIdx: strDataTypeIdx },
-    { op: "local.set", index: outputLocal },
-    { op: "i32.const", value: 0 },
-    { op: "local.set", index: offsetLocal },
-  );
-  for (let index = 0; index < arity; index++) {
-    flatArm.push(
-      { op: "local.get", index: outputLocal },
-      { op: "ref.as_non_null" },
-      { op: "local.get", index: offsetLocal },
-      { op: "local.get", index },
-      { op: "ref.cast", typeIdx: strTypeIdx },
-      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 },
-      { op: "local.get", index },
-      { op: "ref.cast", typeIdx: strTypeIdx },
-      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 },
-      { op: "local.get", index },
-      { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
-      { op: "array.copy", dstTypeIdx: strDataTypeIdx, srcTypeIdx: strDataTypeIdx },
-    );
-    if (index + 1 < arity) {
-      flatArm.push(
-        { op: "local.get", index: offsetLocal },
-        { op: "local.get", index },
-        { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
-        { op: "i32.add" },
-        { op: "local.set", index: offsetLocal },
-      );
-    }
-  }
-  flatArm.push(
-    { op: "local.get", index: totalLenLocal },
-    { op: "i32.const", value: 0 },
-    { op: "local.get", index: outputLocal },
-    { op: "ref.as_non_null" },
-    { op: "struct.new", typeIdx: strTypeIdx },
-  );
-
-  // Preserve the exact existing left-associated concat/rope behaviour for
-  // longer results. Only the short-string allocation path changes.
-  const pairwiseArm: Instr[] = [
-    { op: "local.get", index: 0 },
-    { op: "local.get", index: 1 },
-    { op: "call", funcIdx: concatIdx },
-  ];
-  for (let index = 2; index < arity; index++) {
-    pairwiseArm.push({ op: "local.get", index }, { op: "call", funcIdx: concatIdx });
-  }
-
-  body.push({
-    op: "if",
-    blockType: { kind: "val", type: strRef },
-    then: flatArm,
-    else: pairwiseArm,
+  // Preserve each null guard's literal production after registration, in operand order.
+  const undefinedLiterals: Instr[][] = [];
+  for (let index = 0; index < arity; index++) undefinedLiterals.push(nativeStringLiteralInstrs(ctx, "undefined"));
+  const definition = buildStringBatchedConcatDefinition({ strTypeIdx, strDataTypeIdx, anyStrTypeIdx }, arity, {
+    flattenIdx,
+    concatIdx,
+    undefinedLiterals,
   });
-
   pushDefinedFunc(ctx, funcIdx, {
     name: helperName,
     typeIdx,
-    locals: [
-      { name: "totalLen", type: { kind: "i32" } },
-      { name: "output", type: { kind: "ref_null", typeIdx: strDataTypeIdx } },
-      { name: "offset", type: { kind: "i32" } },
-    ],
-    body,
+    locals: definition.locals,
+    body: definition.body,
     exported: false,
   });
   return funcIdx;

--- a/src/codegen/native-strings-basics.ts
+++ b/src/codegen/native-strings-basics.ts
@@ -18,6 +18,7 @@
  * to the pre-split inline blocks (verified via `prove-emit-identity`).
  */
 import type { Instr } from "../ir/types.js";
+import { buildStringConcatDefinition } from "../runtime/wasmgc/values/string-concat-bodies.js";
 import { addFuncType } from "./registry/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { lazyStrFlattenEnabled, relocatedFlattenPreamble } from "./lazy-str-flatten.js";
@@ -39,136 +40,15 @@ export function emitStrConcatHelpers(shared: NativeStrShared): void {
     const funcIdx = mintDefinedFunc(ctx);
     ctx.nativeStrHelpers.set("__str_concat", funcIdx);
 
-    // params: a(0), b(1)
-    // locals: lenA(2), lenB(3), newLen(4), newArr(5), flatA(6), flatB(7)
-    const body: Instr[] = [
-      // lenA = a.len (field 0 of AnyString)
-      { op: "local.get", index: 0 },
-      { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
-      { op: "local.set", index: 2 }, // lenA
-
-      // lenB = b.len (field 0 of AnyString)
-      { op: "local.get", index: 1 },
-      { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
-      { op: "local.set", index: 3 }, // lenB
-
-      // Empty strings are the identity element for concatenation. Returning
-      // the other immutable string directly avoids allocating and copying a
-      // fresh flat string for common accumulator shapes such as
-      // `let out = ""; out += value`. Keep a compile-time kill switch so the
-      // optimization can be measured against the identical compiler tree.
-      ...(process.env.JS2WASM_STR_CONCAT_EMPTY_IDENTITY === "0"
-        ? []
-        : [
-            { op: "local.get" as const, index: 2 },
-            { op: "i32.eqz" as const },
-            {
-              op: "if" as const,
-              blockType: { kind: "empty" as const },
-              then: [{ op: "local.get" as const, index: 1 }, { op: "return" as const }],
-            },
-            { op: "local.get" as const, index: 3 },
-            { op: "i32.eqz" as const },
-            {
-              op: "if" as const,
-              blockType: { kind: "empty" as const },
-              then: [{ op: "local.get" as const, index: 0 }, { op: "return" as const }],
-            },
-          ]),
-
-      // newLen = lenA + lenB
-      { op: "local.get", index: 2 },
-      { op: "local.get", index: 3 },
-      { op: "i32.add" },
-      { op: "local.set", index: 4 }, // newLen
-
-      // if newLen >= 64, create ConsString (O(1) rope node)
-      { op: "local.get", index: 4 },
-      { op: "i32.const", value: 64 },
-      { op: "i32.ge_u" },
-      {
-        op: "if",
-        blockType: { kind: "val", type: strRef },
-        then: [
-          // struct.new $ConsString(newLen, a, b)
-          { op: "local.get", index: 4 }, // len = newLen
-          { op: "local.get", index: 0 }, // left = a
-          { op: "local.get", index: 1 }, // right = b
-          { op: "struct.new", typeIdx: consStrTypeIdx },
-        ],
-        else: [
-          // Short string: flatten both sides and copy
-          // flatA = flatten(a)
-          { op: "local.get", index: 0 },
-          { op: "call", funcIdx: flattenIdx },
-          { op: "local.set", index: 6 },
-
-          // flatB = flatten(b)
-          { op: "local.get", index: 1 },
-          { op: "call", funcIdx: flattenIdx },
-          { op: "local.set", index: 7 },
-
-          // newArr = array.new_default(newLen)
-          { op: "local.get", index: 4 },
-          { op: "array.new_default", typeIdx: strDataTypeIdx },
-          { op: "local.set", index: 5 },
-
-          // array.copy(newArr, 0, flatA.data, flatA.off, lenA)
-          { op: "local.get", index: 5 }, // dst
-          { op: "ref.as_non_null" },
-          { op: "i32.const", value: 0 }, // dstOffset
-          { op: "local.get", index: 6 }, // flatA
-          { op: "ref.as_non_null" },
-          { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // flatA.data
-          { op: "local.get", index: 6 }, // flatA
-          { op: "ref.as_non_null" },
-          { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // flatA.off
-          { op: "local.get", index: 2 }, // lenA
-          {
-            op: "array.copy",
-            dstTypeIdx: strDataTypeIdx,
-            srcTypeIdx: strDataTypeIdx,
-          },
-
-          // array.copy(newArr, lenA, flatB.data, flatB.off, lenB)
-          { op: "local.get", index: 5 }, // dst
-          { op: "ref.as_non_null" },
-          { op: "local.get", index: 2 }, // dstOffset = lenA
-          { op: "local.get", index: 7 }, // flatB
-          { op: "ref.as_non_null" },
-          { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // flatB.data
-          { op: "local.get", index: 7 }, // flatB
-          { op: "ref.as_non_null" },
-          { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // flatB.off
-          { op: "local.get", index: 3 }, // lenB
-          {
-            op: "array.copy",
-            dstTypeIdx: strDataTypeIdx,
-            srcTypeIdx: strDataTypeIdx,
-          },
-
-          // result = struct.new $NativeString(newLen, 0, newArr)
-          { op: "local.get", index: 4 }, // len = newLen
-          { op: "i32.const", value: 0 }, // off = 0
-          { op: "local.get", index: 5 }, // data = newArr
-          { op: "ref.as_non_null" },
-          { op: "struct.new", typeIdx: strTypeIdx },
-        ],
-      },
-    ];
-
+    const definition = buildStringConcatDefinition(
+      { strTypeIdx, strDataTypeIdx, anyStrTypeIdx, consStrTypeIdx },
+      { flattenIdx, emptyIdentity: process.env.JS2WASM_STR_CONCAT_EMPTY_IDENTITY !== "0" },
+    );
     pushDefinedFunc(ctx, funcIdx, {
       name: "__str_concat",
       typeIdx,
-      locals: [
-        { name: "lenA", type: { kind: "i32" } },
-        { name: "lenB", type: { kind: "i32" } },
-        { name: "newLen", type: { kind: "i32" } },
-        { name: "newArr", type: { kind: "ref_null", typeIdx: strDataTypeIdx } },
-        { name: "flatA", type: { kind: "ref_null", typeIdx: strTypeIdx } },
-        { name: "flatB", type: { kind: "ref_null", typeIdx: strTypeIdx } },
-      ],
-      body,
+      locals: definition.locals,
+      body: definition.body,
       exported: false,
     });
   }

--- a/src/codegen/native-strings-core.ts
+++ b/src/codegen/native-strings-core.ts
@@ -18,9 +18,11 @@
  * to the pre-split inline blocks (verified via `prove-emit-identity`).
  */
 import type { Instr, ValType } from "../ir/types.js";
+import type { WasmFunction } from "../wasm/model/module-records.js";
 import {
   buildStringCopyTreeDefinition,
   buildStringFlattenDefinition,
+  type StringFlattenResources,
 } from "../runtime/wasmgc/values/string-flatten-bodies.js";
 import { buildStringUtf8ToFlatDefinition } from "../runtime/wasmgc/values/string-utf8-decode-bodies.js";
 import { flushLateImportShifts } from "./expressions/late-imports.js";
@@ -42,6 +44,9 @@ import type { NativeStrShared } from "./native-strings-shared.js";
  */
 export function emitStrFlattenHelpers(shared: NativeStrShared): void {
   const { ctx, strTypeIdx, strDataTypeIdx, anyStrTypeIdx, consStrTypeIdx, strRef, flatStrRef, strDataRef } = shared;
+  let copyTreeFunction: WasmFunction;
+  let copyTreeWorklistType: number;
+  let utf8Decoder: StringFlattenResources["utf8Decoder"] = { kind: "absent" };
 
   // --- $__str_copy_tree(node: ref $AnyString, buf: ref $__str_data, pos: i32) -> i32 ---
   // Iteratively copies rope tree into a flat buffer. Returns next write position.
@@ -78,15 +83,17 @@ export function emitStrFlattenHelpers(shared: NativeStrShared): void {
     //   wlTop(8): i32 — number of items currently on the worklist
     //   newWl(9): ref_null $AnyString_arr — scratch slot for grow-on-push reallocation (#1184)
 
-    const definition = buildStringCopyTreeDefinition(ctx, wlArrTypeIdx);
-
-    pushDefinedFunc(ctx, funcIdx, {
+    // Reserve the actual function object in its historical slot. It is pending,
+    // not executable, until the optional decoder has been registered below.
+    copyTreeWorklistType = wlArrTypeIdx;
+    copyTreeFunction = {
       name: "__str_copy_tree",
       typeIdx,
-      locals: definition.locals,
-      body: definition.body,
+      locals: [],
+      body: [],
       exported: false,
-    });
+    };
+    pushDefinedFunc(ctx, funcIdx, copyTreeFunction);
   }
 
   // #1588 PR-B part 2: $__str_utf8_to_flat(u: ref $Utf8String) -> ref $NativeString
@@ -111,7 +118,14 @@ export function emitStrFlattenHelpers(shared: NativeStrShared): void {
       body: definition.body,
       exported: false,
     });
+    utf8Decoder = { kind: "present", handle: funcIdx };
   }
+
+  // Fill the same pushed object once, using only the decoder minted above.
+  // A decoder construction failure propagates before any completion is claimed.
+  const copyTreeDefinition = buildStringCopyTreeDefinition(ctx, copyTreeWorklistType, utf8Decoder);
+  copyTreeFunction.locals = copyTreeDefinition.locals;
+  copyTreeFunction.body = copyTreeDefinition.body;
 
   // --- $__str_flatten(s: ref $AnyString) -> ref $NativeString ---
   // If s is already a FlatString, returns it. Otherwise flattens the rope tree.
@@ -131,8 +145,6 @@ export function emitStrFlattenHelpers(shared: NativeStrShared): void {
     ctx.funcMap.set("__str_flatten", funcIdx);
 
     const copyTreeIdx = ctx.nativeStrHelpers.get("__str_copy_tree")!;
-    // #1588 PR-B part 2: present iff --utf8-storage is on.
-    const utf8ToFlatIdx = ctx.nativeStrHelpers.get("__str_utf8_to_flat");
 
     // params: s(0)
     // locals: len(1), buf(2)
@@ -142,10 +154,7 @@ export function emitStrFlattenHelpers(shared: NativeStrShared): void {
     const definition = buildStringFlattenDefinition(ctx, {
       copyTree: copyTreeIdx,
       emptyLiteralGlobalIndex: emptyInstrs[0].index,
-      utf8Decoder:
-        ctx.utf8Storage && ctx.utf8StrTypeIdx >= 0 && utf8ToFlatIdx !== undefined
-          ? { kind: "present", handle: utf8ToFlatIdx }
-          : { kind: "absent" },
+      utf8Decoder,
     });
 
     pushDefinedFunc(ctx, funcIdx, {

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -6,6 +6,11 @@
  * Extracted from codegen/index.ts (#1013).
  */
 import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import {
+  buildStdoutAppendDefinition,
+  buildStdoutPrepareDefinition,
+  buildStdoutCharDefinition,
+} from "../runtime/wasmgc/values/stdout-bodies.js";
 import { ensureAnyValueType } from "./any-helpers.js";
 import { getArgumentsVecTypeIdx } from "./arguments-carrier-brand.js";
 import { ensureDateAnyToStringHelper } from "./date-any-to-string.js"; // (#4491 T4-B)
@@ -2487,33 +2492,13 @@ export function ensureStandaloneStdoutSink(ctx: CodegenContext): void {
   //   acc = __str_concat(acc, s);   // rope append, O(1) for long strings
   const typeIdx = addFuncType(ctx, [{ kind: "ref_null", typeIdx: anyStrTypeIdx }], [], "$stdout_append_type");
   const funcIdx = mintDefinedFunc(ctx);
-  const body: Instr[] = [
-    // if s is null → nothing to append
-    { op: "local.get", index: 0 },
-    { op: "ref.is_null" },
-    { op: "if", blockType: { kind: "empty" }, then: [{ op: "return" }] },
-    // if acc is null → acc = s (first line), done
-    { op: "global.get", index: accGlobalIdx },
-    { op: "ref.is_null" },
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [{ op: "local.get", index: 0 }, { op: "global.set", index: accGlobalIdx }, { op: "return" }],
-    },
-    // acc = __str_concat(acc, s) — both non-null here
-    { op: "global.get", index: accGlobalIdx },
-    { op: "ref.as_non_null" },
-    { op: "local.get", index: 0 },
-    { op: "ref.as_non_null" },
-    { op: "call", funcIdx: concatIdx },
-    { op: "global.set", index: accGlobalIdx },
-  ];
+  const definition = buildStdoutAppendDefinition({ accGlobalIdx, concatIdx });
   ctx.funcMap.set("__stdout_append", funcIdx);
   pushDefinedFunc(ctx, funcIdx, {
     name: "__stdout_append",
     typeIdx,
-    locals: [],
-    body,
+    locals: definition.locals,
+    body: definition.body,
     exported: false,
   } as WasmFunction);
 }
@@ -2601,27 +2586,13 @@ export function emitStdoutSinkExports(ctx: CodegenContext): void {
   {
     const typeIdx = addFuncType(ctx, [], [{ kind: "i32" }], "$stdout_prepare_type");
     const funcIdx = mintDefinedFunc(ctx);
-    const body: Instr[] = [
-      { op: "global.get", index: accGlobalIdx },
-      { op: "ref.is_null" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
-      },
-      { op: "global.get", index: accGlobalIdx },
-      { op: "ref.as_non_null" },
-      { op: "call", funcIdx: flattenIdx },
-      { op: "global.set", index: flatGlobalIdx },
-      { op: "global.get", index: flatGlobalIdx },
-      { op: "struct.get", typeIdx: flatTypeIdx, fieldIdx: 0 }, // len
-    ];
+    const definition = buildStdoutPrepareDefinition({ accGlobalIdx, flatGlobalIdx, flatTypeIdx, flattenIdx });
     ctx.funcMap.set("__stdout_prepare", funcIdx);
     pushDefinedFunc(ctx, funcIdx, {
       name: "__stdout_prepare",
       typeIdx,
-      locals: [],
-      body,
+      locals: definition.locals,
+      body: definition.body,
       exported: true,
     } as WasmFunction);
     mod.exports.push({ name: "__stdout_prepare", desc: { kind: "func", index: funcIdx } });
@@ -2631,46 +2602,13 @@ export function emitStdoutSinkExports(ctx: CodegenContext): void {
   {
     const typeIdx = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "i32" }], "$stdout_char_type");
     const funcIdx = mintDefinedFunc(ctx);
-    const L_I = 0;
-    const L_BUF = 1;
-    const body: Instr[] = [
-      { op: "global.get", index: flatGlobalIdx },
-      { op: "local.tee", index: L_BUF },
-      { op: "ref.is_null" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
-      },
-      // i < 0 || i >= len → 0
-      { op: "local.get", index: L_I },
-      { op: "i32.const", value: 0 },
-      { op: "i32.lt_s" },
-      { op: "local.get", index: L_I },
-      { op: "local.get", index: L_BUF },
-      { op: "struct.get", typeIdx: flatTypeIdx, fieldIdx: 0 }, // len
-      { op: "i32.ge_s" },
-      { op: "i32.or" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
-      },
-      // data[off + i]
-      { op: "local.get", index: L_BUF },
-      { op: "struct.get", typeIdx: flatTypeIdx, fieldIdx: 2 }, // data
-      { op: "local.get", index: L_BUF },
-      { op: "struct.get", typeIdx: flatTypeIdx, fieldIdx: 1 }, // off
-      { op: "local.get", index: L_I },
-      { op: "i32.add" },
-      { op: "array.get_u", typeIdx: dataTypeIdx },
-    ];
+    const definition = buildStdoutCharDefinition({ flatGlobalIdx, flatTypeIdx, dataTypeIdx });
     ctx.funcMap.set("__stdout_char", funcIdx);
     pushDefinedFunc(ctx, funcIdx, {
       name: "__stdout_char",
       typeIdx,
-      locals: [{ name: "buf", type: { kind: "ref_null", typeIdx: flatTypeIdx } }],
-      body,
+      locals: definition.locals,
+      body: definition.body,
       exported: true,
     } as WasmFunction);
     mod.exports.push({ name: "__stdout_char", desc: { kind: "func", index: funcIdx } });

--- a/src/runtime/wasmgc/values/stdout-bodies.ts
+++ b/src/runtime/wasmgc/values/stdout-bodies.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { FuncHandle, GlobalHandle, Instr, LocalDef, TypeHandle } from "../../../wasm/model/instructions.js";
+
+/** Resolved physical dependencies; these records do not grant admission. */
+export interface StdoutAppendResources {
+  readonly accGlobalIdx: GlobalHandle;
+  readonly concatIdx: FuncHandle;
+}
+export interface StdoutPrepareResources {
+  readonly accGlobalIdx: GlobalHandle;
+  readonly flatGlobalIdx: GlobalHandle;
+  readonly flatTypeIdx: TypeHandle;
+  readonly flattenIdx: FuncHandle;
+}
+export interface StdoutCharResources {
+  readonly flatGlobalIdx: GlobalHandle;
+  readonly flatTypeIdx: TypeHandle;
+  readonly dataTypeIdx: TypeHandle;
+}
+
+export function buildStdoutAppendDefinition(resources: StdoutAppendResources): { locals: LocalDef[]; body: Instr[] } {
+  const { accGlobalIdx, concatIdx } = resources;
+  const body: Instr[] = [
+    // if s is null → nothing to append
+    { op: "local.get", index: 0 },
+    { op: "ref.is_null" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "return" }] },
+    // if acc is null → acc = s (first line), done
+    { op: "global.get", index: accGlobalIdx },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: 0 }, { op: "global.set", index: accGlobalIdx }, { op: "return" }],
+    },
+    // acc = __str_concat(acc, s) — both non-null here
+    { op: "global.get", index: accGlobalIdx },
+    { op: "ref.as_non_null" },
+    { op: "local.get", index: 0 },
+    { op: "ref.as_non_null" },
+    { op: "call", funcIdx: concatIdx },
+    { op: "global.set", index: accGlobalIdx },
+  ];
+  return { locals: [], body };
+}
+
+export function buildStdoutPrepareDefinition(resources: StdoutPrepareResources): { locals: LocalDef[]; body: Instr[] } {
+  const { accGlobalIdx, flatGlobalIdx, flatTypeIdx, flattenIdx } = resources;
+  const body: Instr[] = [
+    { op: "global.get", index: accGlobalIdx },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+    },
+    { op: "global.get", index: accGlobalIdx },
+    { op: "ref.as_non_null" },
+    { op: "call", funcIdx: flattenIdx },
+    { op: "global.set", index: flatGlobalIdx },
+    { op: "global.get", index: flatGlobalIdx },
+    { op: "struct.get", typeIdx: flatTypeIdx, fieldIdx: 0 }, // len
+  ];
+  return { locals: [], body };
+}
+
+export function buildStdoutCharDefinition(resources: StdoutCharResources): { locals: LocalDef[]; body: Instr[] } {
+  const { flatGlobalIdx, flatTypeIdx, dataTypeIdx } = resources;
+  const L_I = 0;
+  const L_BUF = 1;
+  const body: Instr[] = [
+    { op: "global.get", index: flatGlobalIdx },
+    { op: "local.tee", index: L_BUF },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+    },
+    // i < 0 || i >= len → 0
+    { op: "local.get", index: L_I },
+    { op: "i32.const", value: 0 },
+    { op: "i32.lt_s" },
+    { op: "local.get", index: L_I },
+    { op: "local.get", index: L_BUF },
+    { op: "struct.get", typeIdx: flatTypeIdx, fieldIdx: 0 }, // len
+    { op: "i32.ge_s" },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+    },
+    // data[off + i]
+    { op: "local.get", index: L_BUF },
+    { op: "struct.get", typeIdx: flatTypeIdx, fieldIdx: 2 }, // data
+    { op: "local.get", index: L_BUF },
+    { op: "struct.get", typeIdx: flatTypeIdx, fieldIdx: 1 }, // off
+    { op: "local.get", index: L_I },
+    { op: "i32.add" },
+    { op: "array.get_u", typeIdx: dataTypeIdx },
+  ];
+  return {
+    locals: [{ name: "buf", type: { kind: "ref_null", typeIdx: flatTypeIdx } }],
+    body,
+  };
+}

--- a/src/runtime/wasmgc/values/string-concat-bodies.ts
+++ b/src/runtime/wasmgc/values/string-concat-bodies.ts
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { FuncHandle, Instr, LocalDef, TypeHandle, ValType } from "../../../wasm/model/instructions.js";
+
+/** Already resolved index spaces, not resource-admission authority. */
+export interface StringConcatLayout {
+  readonly strTypeIdx: TypeHandle;
+  readonly strDataTypeIdx: TypeHandle;
+  readonly anyStrTypeIdx: TypeHandle;
+  readonly consStrTypeIdx: TypeHandle;
+}
+
+export interface StringConcatResources {
+  readonly flattenIdx: FuncHandle;
+  readonly emptyIdentity: boolean;
+}
+
+export interface StringBatchedConcatResources {
+  readonly flattenIdx: FuncHandle;
+  readonly concatIdx: FuncHandle;
+  /** One independently produced literal sequence per original null guard. */
+  readonly undefinedLiterals: readonly (readonly Instr[])[];
+}
+
+const FLAT_CONCAT_LIMIT = 64;
+
+/** Complete binary concat body; registration and the environment switch stay with the caller. */
+export function buildStringConcatDefinition(
+  layout: StringConcatLayout,
+  resources: StringConcatResources,
+): { locals: LocalDef[]; body: Instr[] } {
+  const { strTypeIdx, strDataTypeIdx, anyStrTypeIdx, consStrTypeIdx } = layout;
+  const { flattenIdx, emptyIdentity } = resources;
+  const strRef: ValType = { kind: "ref", typeIdx: anyStrTypeIdx };
+  // params: a(0), b(1)
+  // locals: lenA(2), lenB(3), newLen(4), newArr(5), flatA(6), flatB(7)
+  const body: Instr[] = [
+    // lenA = a.len (field 0 of AnyString)
+    { op: "local.get", index: 0 },
+    { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: 2 }, // lenA
+
+    // lenB = b.len (field 0 of AnyString)
+    { op: "local.get", index: 1 },
+    { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: 3 }, // lenB
+
+    // Empty strings are the identity element for concatenation. Returning
+    // the other immutable string directly avoids allocating and copying a
+    // fresh flat string for common accumulator shapes such as
+    // `let out = ""; out += value`. Keep a compile-time kill switch so the
+    // optimization can be measured against the identical compiler tree.
+    ...(!emptyIdentity
+      ? []
+      : [
+          { op: "local.get" as const, index: 2 },
+          { op: "i32.eqz" as const },
+          {
+            op: "if" as const,
+            blockType: { kind: "empty" as const },
+            then: [{ op: "local.get" as const, index: 1 }, { op: "return" as const }],
+          },
+          { op: "local.get" as const, index: 3 },
+          { op: "i32.eqz" as const },
+          {
+            op: "if" as const,
+            blockType: { kind: "empty" as const },
+            then: [{ op: "local.get" as const, index: 0 }, { op: "return" as const }],
+          },
+        ]),
+
+    // newLen = lenA + lenB
+    { op: "local.get", index: 2 },
+    { op: "local.get", index: 3 },
+    { op: "i32.add" },
+    { op: "local.set", index: 4 }, // newLen
+
+    // if newLen >= 64, create ConsString (O(1) rope node)
+    { op: "local.get", index: 4 },
+    { op: "i32.const", value: 64 },
+    { op: "i32.ge_u" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: strRef },
+      then: [
+        // struct.new $ConsString(newLen, a, b)
+        { op: "local.get", index: 4 }, // len = newLen
+        { op: "local.get", index: 0 }, // left = a
+        { op: "local.get", index: 1 }, // right = b
+        { op: "struct.new", typeIdx: consStrTypeIdx },
+      ],
+      else: [
+        // Short string: flatten both sides and copy
+        // flatA = flatten(a)
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: flattenIdx },
+        { op: "local.set", index: 6 },
+
+        // flatB = flatten(b)
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: flattenIdx },
+        { op: "local.set", index: 7 },
+
+        // newArr = array.new_default(newLen)
+        { op: "local.get", index: 4 },
+        { op: "array.new_default", typeIdx: strDataTypeIdx },
+        { op: "local.set", index: 5 },
+
+        // array.copy(newArr, 0, flatA.data, flatA.off, lenA)
+        { op: "local.get", index: 5 }, // dst
+        { op: "ref.as_non_null" },
+        { op: "i32.const", value: 0 }, // dstOffset
+        { op: "local.get", index: 6 }, // flatA
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // flatA.data
+        { op: "local.get", index: 6 }, // flatA
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // flatA.off
+        { op: "local.get", index: 2 }, // lenA
+        {
+          op: "array.copy",
+          dstTypeIdx: strDataTypeIdx,
+          srcTypeIdx: strDataTypeIdx,
+        },
+
+        // array.copy(newArr, lenA, flatB.data, flatB.off, lenB)
+        { op: "local.get", index: 5 }, // dst
+        { op: "ref.as_non_null" },
+        { op: "local.get", index: 2 }, // dstOffset = lenA
+        { op: "local.get", index: 7 }, // flatB
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // flatB.data
+        { op: "local.get", index: 7 }, // flatB
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // flatB.off
+        { op: "local.get", index: 3 }, // lenB
+        {
+          op: "array.copy",
+          dstTypeIdx: strDataTypeIdx,
+          srcTypeIdx: strDataTypeIdx,
+        },
+
+        // result = struct.new $NativeString(newLen, 0, newArr)
+        { op: "local.get", index: 4 }, // len = newLen
+        { op: "i32.const", value: 0 }, // off = 0
+        { op: "local.get", index: 5 }, // data = newArr
+        { op: "ref.as_non_null" },
+        { op: "struct.new", typeIdx: strTypeIdx },
+      ],
+    },
+  ];
+
+  return {
+    locals: [
+      { name: "lenA", type: { kind: "i32" } },
+      { name: "lenB", type: { kind: "i32" } },
+      { name: "newLen", type: { kind: "i32" } },
+      { name: "newArr", type: { kind: "ref_null", typeIdx: strDataTypeIdx } },
+      { name: "flatA", type: { kind: "ref_null", typeIdx: strTypeIdx } },
+      { name: "flatB", type: { kind: "ref_null", typeIdx: strTypeIdx } },
+    ],
+    body,
+  };
+}
+
+/** Complete fixed-arity concat body with detached literal dependencies. */
+export function buildStringBatchedConcatDefinition(
+  layout: Pick<StringConcatLayout, "strTypeIdx" | "strDataTypeIdx" | "anyStrTypeIdx">,
+  arity: number,
+  resources: StringBatchedConcatResources,
+): { locals: LocalDef[]; body: Instr[] } {
+  if (!Number.isInteger(arity) || arity < 2 || resources.undefinedLiterals.length !== arity)
+    throw new Error("native batched concat: literal population must match arity");
+  for (let index = 0; index < arity; index++)
+    if (!Array.isArray(resources.undefinedLiterals[index]))
+      throw new Error("native batched concat: missing literal sequence");
+  const { strTypeIdx, strDataTypeIdx, anyStrTypeIdx } = layout;
+  const { flattenIdx, concatIdx } = resources;
+  const strRef: ValType = { kind: "ref", typeIdx: anyStrTypeIdx };
+  // Params: operand0..operandN-1.
+  // Locals: totalLen(N), output(N+1), offset(N+2).
+  const totalLenLocal = arity;
+  const outputLocal = arity + 1;
+  const offsetLocal = arity + 2;
+  const body: Instr[] = [];
+  // (#4394) Null-carrier ToString guard. A statically-string-typed operand can
+  // carry the null $AnyString sentinel at runtime — the JS `undefined` of a
+  // missing property/param that flowed through a string-typed slot (the #3548
+  // carrier convention; e.g. `expectedErrorConstructor.name` in the test262
+  // asyncHelpers, JSDoc-typed `string`). The length sum below would trap on it
+  // ("dereferencing a null pointer in __str_concat_N"). §7.1.17 ToString of
+  // that carrier is "undefined", so substitute exactly that — never the empty
+  // string, which would silently corrupt the concatenation.
+  for (let index = 0; index < arity; index++) {
+    body.push(
+      { op: "local.get", index },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [...structuredClone(resources.undefinedLiterals[index]!), { op: "local.set", index }],
+      },
+    );
+  }
+  body.push({ op: "i32.const", value: 0 });
+  for (let index = 0; index < arity; index++) {
+    body.push({ op: "local.get", index }, { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 }, { op: "i32.add" });
+  }
+  body.push(
+    { op: "local.tee", index: totalLenLocal },
+    { op: "i32.const", value: FLAT_CONCAT_LIMIT },
+    { op: "i32.lt_u" },
+  );
+
+  const flatArm: Instr[] = [];
+  for (let index = 0; index < arity; index++) {
+    flatArm.push(
+      { op: "local.get", index },
+      { op: "ref.test", typeIdx: strTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index },
+          { op: "call", funcIdx: flattenIdx },
+          { op: "local.set", index },
+        ],
+      },
+    );
+  }
+  flatArm.push(
+    { op: "local.get", index: totalLenLocal },
+    { op: "array.new_default", typeIdx: strDataTypeIdx },
+    { op: "local.set", index: outputLocal },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: offsetLocal },
+  );
+  for (let index = 0; index < arity; index++) {
+    flatArm.push(
+      { op: "local.get", index: outputLocal },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: offsetLocal },
+      { op: "local.get", index },
+      { op: "ref.cast", typeIdx: strTypeIdx },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 },
+      { op: "local.get", index },
+      { op: "ref.cast", typeIdx: strTypeIdx },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 },
+      { op: "local.get", index },
+      { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
+      { op: "array.copy", dstTypeIdx: strDataTypeIdx, srcTypeIdx: strDataTypeIdx },
+    );
+    if (index + 1 < arity) {
+      flatArm.push(
+        { op: "local.get", index: offsetLocal },
+        { op: "local.get", index },
+        { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
+        { op: "i32.add" },
+        { op: "local.set", index: offsetLocal },
+      );
+    }
+  }
+  flatArm.push(
+    { op: "local.get", index: totalLenLocal },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: outputLocal },
+    { op: "ref.as_non_null" },
+    { op: "struct.new", typeIdx: strTypeIdx },
+  );
+
+  // Preserve the exact existing left-associated concat/rope behaviour for
+  // longer results. Only the short-string allocation path changes.
+  const pairwiseArm: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: concatIdx },
+  ];
+  for (let index = 2; index < arity; index++) {
+    pairwiseArm.push({ op: "local.get", index }, { op: "call", funcIdx: concatIdx });
+  }
+
+  body.push({
+    op: "if",
+    blockType: { kind: "val", type: strRef },
+    then: flatArm,
+    else: pairwiseArm,
+  });
+
+  return {
+    locals: [
+      { name: "totalLen", type: { kind: "i32" } },
+      { name: "output", type: { kind: "ref_null", typeIdx: strDataTypeIdx } },
+      { name: "offset", type: { kind: "i32" } },
+    ],
+    body,
+  };
+}

--- a/src/runtime/wasmgc/values/string-flatten-bodies.ts
+++ b/src/runtime/wasmgc/values/string-flatten-bodies.ts
@@ -116,7 +116,12 @@ function flattenConsBody(
 export function buildStringCopyTreeDefinition(
   layout: NativeStringLayout,
   worklistTypeIndex: number,
+  utf8Decoder: StringFlattenResources["utf8Decoder"],
 ): { locals: LocalDef[]; body: Instr[] } {
+  const utf8Indices = utf8Decoder.kind === "present" ? [layout.utf8StrTypeIdx, layout.utf8StrDataTypeIdx] : [];
+  for (const index of utf8Indices)
+    if (!Number.isSafeInteger(index) || index < 0)
+      throw new Error("native string copy tree: decoder requires UTF8 layout");
   const { nativeStrTypeIdx: strTypeIdx, nativeStrDataTypeIdx: strDataTypeIdx, anyStrTypeIdx, consStrTypeIdx } = layout;
   const wlArrTypeIdx = worklistTypeIndex;
   const wlArrRefNull: ValType = { kind: "ref_null", typeIdx: wlArrTypeIdx };
@@ -225,6 +230,25 @@ export function buildStringCopyTreeDefinition(
                   op: "loop",
                   blockType: { kind: "empty" },
                   body: [
+                    // Normalize UTF8 at every descent, including popped right children.
+                    ...(utf8Decoder.kind === "present"
+                      ? ([
+                          { op: "local.get", index: CUR },
+                          { op: "ref.as_non_null" },
+                          { op: "ref.test", typeIdx: layout.utf8StrTypeIdx },
+                          {
+                            op: "if",
+                            blockType: { kind: "empty" },
+                            then: [
+                              { op: "local.get", index: CUR },
+                              { op: "ref.as_non_null" },
+                              { op: "ref.cast", typeIdx: layout.utf8StrTypeIdx },
+                              { op: "call", funcIdx: utf8Decoder.handle },
+                              { op: "local.set", index: CUR },
+                            ],
+                          },
+                        ] satisfies Instr[])
+                      : []),
                     // if cur is FlatString: br to end of inner block (depth 1)
                     { op: "local.get", index: CUR },
                     { op: "ref.as_non_null" },

--- a/tests/issue-3518-native-scanner-source-preservation.test.ts
+++ b/tests/issue-3518-native-scanner-source-preservation.test.ts
@@ -6,9 +6,14 @@ import { createHash } from "node:crypto";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { realpathSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import {
   projectScanner,
   projectDecoder,
+  projectCopyTreeUtf8,
+  projectFlattenAdapterStaging,
+  scannerProjectionTargets,
+  scannerProjectionTarget,
   requireTerminal,
   requirePopulation,
   requireTransformCount,
@@ -78,9 +83,9 @@ describe("positive-first semantic projection and recorder admission", () => {
       expect(changed).not.toBe(source);
       expect(() => projectScanner(changed, url, url, sha)).toThrow("projection input hash differs");
     });
-  for (const count of [0, 1, 3])
+  for (const count of [0, 1, 2, 3, 5])
     it(`rejects projection transformation count ${count}`, () => {
-      requireTransformCount(2, "projection");
+      requireTransformCount(4, "projection");
       expect(() => requireTransformCount(count, "projection")).toThrow("missing/duplicate/unexpected transformation");
     });
   it("rejects any transform in the untouched candidate", () => {
@@ -161,9 +166,7 @@ describe("second exact root-bound decoder projection", () => {
   for (const kind of ["missing", "duplicate", "foreign"] as const)
     it("rejects per-target " + kind + " even with a plausible aggregate", () => {
       const root = "/candidate";
-      const keys = ["string-number-bodies.ts", "string-utf8-decode-bodies.ts"].map(
-        (name) => pathToFileURL(join(root, "src/runtime/wasmgc/values", name)).href,
-      );
+      const keys = Object.keys(scannerProjectionTargets(root));
       const counts = Object.fromEntries(keys.map((key) => [key, 1]));
       requireTargetLoads(counts, root, "projection");
       if (kind === "missing") delete counts[keys[1]!];
@@ -174,6 +177,185 @@ describe("second exact root-bound decoder projection", () => {
       }
       expect(() => requireTargetLoads(counts, root, "projection")).toThrow("missing/duplicate/foreign target load");
     });
+});
+
+describe("two exact UTF8-rope repair inverses", () => {
+  const sha = (s: string) => createHash("sha256").update(s).digest("hex");
+  const specs = [
+    {
+      path: "src/runtime/wasmgc/values/string-flatten-bodies.ts",
+      project: projectCopyTreeUtf8,
+      original: "f40b6b18f92c8bbba588efc72bd075a1e93c2cfe3fbe4939f3019fe6825a5bdf",
+    },
+    {
+      path: "src/codegen/native-strings-core.ts",
+      project: projectFlattenAdapterStaging,
+      original: "00668dc5edcba527d6c8d2bc5638a909f55a5894115d4c30aa1f7b03a50cc9d2",
+    },
+  ];
+  function genuine(spec: (typeof specs)[number]) {
+    const url = pathToFileURL(join(checkoutRoot, spec.path)).href;
+    const source = readFileSync(new URL(url), "utf8");
+    const result = spec.project(source, url, url, sha);
+    expect(sha(result.text)).toBe(spec.original);
+    expect(result.evidence.inputHash).toBe(sha(source));
+    expect(result.evidence.deltas.length).toBeGreaterThan(0);
+    return { url, source, result };
+  }
+  for (const spec of specs) {
+    it("restores complete original " + spec.path, () => {
+      genuine(spec);
+    });
+    for (const variant of ["?duplicate=1", "#duplicate", "foreign-root"] as const)
+      it("rejects " + spec.path + " " + variant, () => {
+        const { url, source } = genuine(spec);
+        const changed = variant === "foreign-root" ? url.replace("/src/", "/foreign/src/") : url + variant;
+        expect(() => spec.project(source, changed, url, sha)).toThrow("projection target/root");
+      });
+    for (const mutation of ["missing", "duplicate", "misplaced", "unrelated", "header"] as const)
+      it("rejects " + spec.path + " " + mutation, () => {
+        const { url, source, result } = genuine(spec);
+        const span = result.evidence.deltas[0]!.text;
+        const changed =
+          mutation === "missing"
+            ? source.replace(span, "")
+            : mutation === "duplicate"
+              ? source.replace(span, span + span)
+              : mutation === "misplaced"
+                ? source.replace(span, "") + span
+                : mutation === "header"
+                  ? source.replace("export function ", "export async function ")
+                  : source.replace("Copyright (c) 2026", "Copyright (c) 2025");
+        expect(changed).not.toBe(source);
+        expect(() => spec.project(changed, url, url, sha)).toThrow("projection input hash differs");
+      });
+  }
+  for (const [name, from, to] of [
+    ["decoder handle", "funcIdx: utf8Decoder.handle", "funcIdx: worklistTypeIndex"],
+    ["decoder type", 'op: "ref.cast", typeIdx: layout.utf8StrTypeIdx', 'op: "ref.cast", typeIdx: consStrTypeIdx'],
+    ["local", 'op: "local.set", index: CUR', 'op: "local.set", index: FLAT'],
+    [
+      "pop path",
+      'op: "array.get", typeIdx: wlArrTypeIdx },\n            { op: "local.set", index: CUR',
+      'op: "array.get", typeIdx: wlArrTypeIdx },\n            { op: "local.set", index: FLAT',
+    ],
+    ["return", "    body,\n  };", "    body: [],\n  };"],
+  ])
+    it("rejects copy-tree " + name + " after real inverse", () => {
+      const spec = specs[0]!,
+        { source, url } = genuine(spec);
+      // Every countermodel must actually change its independently selected operand.
+      const changed = source.replace(from!, to!);
+      expect(changed).not.toBe(source);
+      expect(() => spec.project(changed, url, url, sha)).toThrow("projection input hash differs");
+    });
+  for (const move of ["after-cons-cast", "root-only"] as const)
+    it("rejects normalization " + move, () => {
+      const spec = specs[0]!,
+        { source, url, result } = genuine(spec);
+      const span = result.evidence.deltas[2]!.text;
+      const without = source.replace(span, "");
+      const anchor =
+        move === "root-only"
+          ? "  const body: Instr[] = [\n"
+          : '                    { op: "ref.cast", typeIdx: consStrTypeIdx },\n';
+      expect(without).toContain(anchor);
+      const changed = without.replace(anchor, anchor + span);
+      expect(() => spec.project(changed, url, url, sha)).toThrow("projection input hash differs");
+    });
+  for (const [name, from, to] of [
+    [
+      "replace reserved object",
+      "copyTreeFunction.locals = copyTreeDefinition.locals;",
+      "copyTreeFunction = { ...copyTreeFunction, locals: copyTreeDefinition.locals };",
+    ],
+    ["missing body fill", "  copyTreeFunction.body = copyTreeDefinition.body;\n", ""],
+    [
+      "extra push",
+      "    pushDefinedFunc(ctx, funcIdx, copyTreeFunction);",
+      "    pushDefinedFunc(ctx, funcIdx, copyTreeFunction);\n    pushDefinedFunc(ctx, funcIdx, copyTreeFunction);",
+    ],
+    [
+      "stale decoder",
+      'utf8Decoder = { kind: "present", handle: funcIdx };',
+      'utf8Decoder = { kind: "present", handle: ctx.nativeStrHelpers.get("__str_copy_tree")! };',
+    ],
+    [
+      "registration order",
+      '    ctx.nativeStrHelpers.set("__str_utf8_to_flat", funcIdx);',
+      '    ctx.funcMap.set("__str_utf8_to_flat", funcIdx);',
+    ],
+    ["unrelated late import", 'ctx.funcMap.set("__str_flatten", funcIdx);', 'ctx.funcMap.set("__str_flatten", 0);'],
+  ])
+    it("rejects adapter " + name, () => {
+      const spec = specs[1]!,
+        { source, url } = genuine(spec);
+      const changed = source.replace(from!, to!);
+      expect(changed).not.toBe(source);
+      expect(() => spec.project(changed, url, url, sha)).toThrow("projection input hash differs");
+    });
+});
+
+describe("four exact loader coordinates, with historical legacy-only baseline", () => {
+  const targets = scannerProjectionTargets(checkoutRoot);
+  it("requires all four candidate roots and exactly the historical adapter at baseline", () => {
+    expect(Object.keys(targets)).toHaveLength(4);
+    requireTargetLoads(Object.fromEntries(Object.keys(targets).map((url) => [url, 1])), checkoutRoot, "candidate");
+    const adapter = pathToFileURL(join(checkoutRoot, "src/codegen/native-strings-core.ts")).href;
+    requireTargetLoads({ [adapter]: 1 }, checkoutRoot, "baseline");
+    expect(() => requireTargetLoads({}, checkoutRoot, "baseline")).toThrow("missing/duplicate/foreign target load");
+    expect(() => requireTargetLoads({ [adapter]: 2 }, checkoutRoot, "baseline")).toThrow(
+      "missing/duplicate/foreign target load",
+    );
+    for (const [url, kind] of Object.entries(targets)) expect(scannerProjectionTarget(url, targets)).toBe(kind);
+  });
+  for (const [url, kind] of Object.entries(targets))
+    for (const suffix of ["?duplicate=1", "#duplicate"])
+      it("actually denies " + kind + suffix + " before loading, without a probe sentinel", () => {
+        const script = String.raw`
+        import assert from "node:assert/strict";
+        import { registerHooks } from "node:module";
+        const [root, harness, rejected] = process.argv.slice(1);
+        const { scannerProjectionTargets, scannerProjectionTarget } = await import(harness);
+        const targets = scannerProjectionTargets(root), denied = [], loaded = [];
+        registerHooks({
+          resolve(specifier, context, next) {
+            const result = next(specifier, context);
+            try { scannerProjectionTarget(result.url, targets); }
+            catch (error) { denied.push({ url: result.url, message: error.message }); throw error; }
+            return result;
+          },
+          load(url, context, next) { loaded.push(url); return next(url, context); }
+        });
+        const positive = await import("data:text/javascript,export default 42");
+        assert.equal(positive.default, 42);
+        let caught;
+        try { await import(rejected); } catch (error) { caught = error; }
+        assert(caught);
+        assert.equal(caught.message, "wrong projection target/root " + rejected);
+        assert.deepEqual(denied, [{ url: rejected, message: caught.message }]);
+        assert(!loaded.includes(rejected));
+        console.log(JSON.stringify({ positive: 42, denied, loaded }));
+      `;
+        const child = spawnSync(
+          process.execPath,
+          [
+            "--input-type=module",
+            "-e",
+            script,
+            checkoutRoot,
+            new URL("../scripts/verify-native-scanner-source-preservation.mjs", import.meta.url).href,
+            url + suffix,
+          ],
+          { encoding: "utf8", env: { ...process.env, NODE_OPTIONS: "--max-old-space-size=2048" } },
+        );
+        expect(child.error).toBeUndefined();
+        expect(child.status, child.stderr).toBe(0);
+        const report = JSON.parse(child.stdout.trim());
+        expect(report.positive).toBe(42);
+        expect(report.denied).toEqual([{ url: url + suffix, message: "wrong projection target/root " + url + suffix }]);
+        expect(report.loaded).not.toContain(url + suffix);
+      });
 });
 
 describe("native scanner effective runtime authentication", () => {

--- a/tests/issue-3518-native-string-flatten-resources.test.ts
+++ b/tests/issue-3518-native-string-flatten-resources.test.ts
@@ -6,7 +6,11 @@ import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
-import { projectDecoder } from "../scripts/verify-native-scanner-source-preservation.mjs";
+import {
+  projectDecoder,
+  projectCopyTreeUtf8,
+  projectFlattenAdapterStaging,
+} from "../scripts/verify-native-scanner-source-preservation.mjs";
 import { nativeStringFlattenDonor } from "./fixtures/issue-3518-native-string-flatten-donor.js";
 import { createEmptyModule } from "../src/ir/types.js";
 import type { Instr } from "../src/wasm/model/instructions.js";
@@ -25,6 +29,10 @@ import {
 } from "../src/backend/wasmgc/resources/native-string-flatten.js";
 
 const read = (path: string) => readFileSync(new URL("../" + path, import.meta.url), "utf8");
+function projectedFlattenSource(path: string, project: typeof projectCopyTreeUtf8): string {
+  const url = new URL("../" + path, import.meta.url).href;
+  return project(read(path), url, url, (s: string) => createHash("sha256").update(s).digest("hex")).text;
+}
 const parse = (text: string) => ts.createSourceFile("receipt.ts", text, ts.ScriptTarget.Latest, true);
 function functionNode(sf: ts.SourceFile, name: string): ts.FunctionDeclaration {
   const fn = sf.statements.find(
@@ -304,7 +312,14 @@ describe("mandatory live flatten donor reconstruction", () => {
   const adapterPath = "src/codegen/native-strings-core.ts",
     flattenPath = "src/runtime/wasmgc/values/string-flatten-bodies.ts",
     decoderPath = "src/runtime/wasmgc/values/string-utf8-decode-bodies.ts";
-  const current = () => [read(adapterPath), read(flattenPath), read(decoderPath)] as const;
+  // First authenticate and invert only the two approved semantic/staging deltas.
+  // The original donor, wrapper/header, token and comment controls below remain unchanged.
+  const current = () =>
+    [
+      projectedFlattenSource(adapterPath, projectFlattenAdapterStaging),
+      projectedFlattenSource(flattenPath, projectCopyTreeUtf8),
+      read(decoderPath),
+    ] as const;
   const verify = (rows: readonly [string, string, string]) =>
     expect(receipt(reconstruct(...rows))).toBe(receipt(nativeStringFlattenDonor));
   it("retains all three donor functions, nested bodies, locals, comments and registration order", () => {
@@ -805,8 +820,8 @@ describe("exact approved decoder offset delta", () => {
       expect(
         receipt(
           reconstruct(
-            read("src/codegen/native-strings-core.ts"),
-            read("src/runtime/wasmgc/values/string-flatten-bodies.ts"),
+            projectedFlattenSource("src/codegen/native-strings-core.ts", projectFlattenAdapterStaging),
+            projectedFlattenSource("src/runtime/wasmgc/values/string-flatten-bodies.ts", projectCopyTreeUtf8),
             source,
           ),
         ),

--- a/tests/issue-3518-native-string-output-bodies.test.ts
+++ b/tests/issue-3518-native-string-output-bodies.test.ts
@@ -1,0 +1,494 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createEmptyModule } from "../src/ir/types.js";
+import type { Instr, ValType } from "../src/wasm/model/instructions.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { emitWat } from "../src/emit/wat.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import {
+  reserveNativeStringLiteralResources,
+  fillNativeStringLiteralResources,
+  requireNativeStringLiteral,
+} from "../src/backend/wasmgc/resources/native-string-literals.js";
+import {
+  reserveNativeStringFlattenResources,
+  fillNativeStringFlattenResources,
+  requireCompletedNativeStringFlatten,
+} from "../src/backend/wasmgc/resources/native-string-flatten.js";
+import {
+  buildStringConcatDefinition,
+  buildStringBatchedConcatDefinition,
+  type StringConcatLayout,
+} from "../src/runtime/wasmgc/values/string-concat-bodies.js";
+import {
+  buildStdoutAppendDefinition,
+  buildStdoutPrepareDefinition,
+  buildStdoutCharDefinition,
+} from "../src/runtime/wasmgc/values/stdout-bodies.js";
+import { STRING_CONCAT_MANY_NATIVE_ARITY } from "../src/ir/runtime/contracts/manifest.js";
+import { ensureNativeBatchedConcat } from "../src/codegen/native-batched-concat.js";
+import type { CodegenContext } from "../src/codegen/context/types.js";
+
+type Leaf = { text: string; encoding: "wtf16" | "utf8-guaranteed"; backing?: string; offset?: number };
+type Operand = Leaf | { text: string; rope: readonly [Leaf, Leaf] };
+const flat = (text: string): Leaf => ({ text, encoding: "wtf16" });
+const utf8 = (text: string): Leaf => ({ text, encoding: "utf8-guaranteed" });
+const empty = flat("");
+const window: Leaf = { text: "Aé€😀", encoding: "wtf16", backing: "!?Aé€😀&Ω", offset: 2 };
+const rope: Operand = { text: "rope-é", rope: [flat("rope-"), utf8("é")] };
+const lines = ["seq: 6", "par: 6", "elapsed: 0", "undefined"];
+type Recipe = { name: string; operands: readonly Operand[]; expected: string; binary: boolean };
+const binaryRecipes: Recipe[] = [
+  { name: "empty-both", operands: [empty, empty], expected: "", binary: true },
+  { name: "empty-left", operands: [empty, flat("right")], expected: "right", binary: true },
+  { name: "empty-right", operands: [flat("left"), empty], expected: "left", binary: true },
+  { name: "short", operands: [flat("ab"), flat("cd")], expected: "abcd", binary: true },
+  ...[63, 64, 65].map(
+    (n): Recipe => ({
+      name: "threshold-" + n,
+      operands: [flat("a".repeat(31)), flat("b".repeat(n - 31))],
+      expected: "a".repeat(31) + "b".repeat(n - 31),
+      binary: true,
+    }),
+  ),
+  { name: "utf16-window", operands: [window, flat("!")], expected: "Aé€😀!", binary: true },
+  { name: "utf8-unicode", operands: [utf8("Aé€😀"), utf8("Ω")], expected: "Aé€😀Ω", binary: true },
+  { name: "mixed-encoding", operands: [utf8("é"), flat("\ud800")], expected: "é\ud800", binary: true },
+  { name: "rope-input", operands: [rope, window], expected: "rope-éAé€😀", binary: true },
+  { name: "empty-rope", operands: [empty, rope], expected: "rope-é", binary: true },
+];
+const arities = [3, 4, 5, 6, 7, 8] as const;
+const batchRecipes: Recipe[] = arities.flatMap((arity) =>
+  [false, true].map((long): Recipe => {
+    const operands: Operand[] = [window, rope, utf8(long ? "€".repeat(65) : "€")];
+    for (let i = 3; i < arity; i++) operands.push(flat(String(i)));
+    return {
+      name: "batch-" + arity + (long ? "-rope" : "-flat"),
+      operands,
+      expected: operands.map((x) => x.text).join(""),
+      binary: false,
+    };
+  }),
+);
+const recipes = [...binaryRecipes, ...batchRecipes];
+const leaves = (operand: Operand): readonly Leaf[] => ("rope" in operand ? operand.rope : [operand]);
+const units = (text: string) => Array.from({ length: text.length }, (_, i) => text.charCodeAt(i));
+const digest = (bytes: Uint8Array) => createHash("sha256").update(bytes).digest("hex");
+
+function issuedModule(emptyIdentity: boolean) {
+  const module = createEmptyModule(),
+    tx = new PhysicalModuleReservations(module);
+  const literalRows = [
+    empty,
+    flat("undefined"),
+    window,
+    flat("\n"),
+    ...lines.map(flat),
+    flat("identity"),
+    ...recipes.flatMap((r) => r.operands.flatMap(leaves)),
+  ];
+  const strings = reserveNativeStringLiteralResources(tx, {
+    key: "output:strings",
+    utf8Storage: true,
+    literals: literalRows.map((row) => ({ value: row.backing ?? row.text, encoding: row.encoding })),
+  });
+  const flatten = reserveNativeStringFlattenResources(tx, "output:flatten", strings);
+  const l = strings.layout;
+  const layout: StringConcatLayout = {
+    strTypeIdx: l.nativeStrTypeIdx,
+    strDataTypeIdx: l.nativeStrDataTypeIdx,
+    anyStrTypeIdx: l.anyStrTypeIdx,
+    consStrTypeIdx: l.consStrTypeIdx,
+  };
+  const strRef: ValType = { kind: "ref", typeIdx: layout.anyStrTypeIdx };
+  const concat = tx.reserveFunction("output:concat", "__str_concat", { params: [strRef, strRef], results: [strRef] });
+  const batches = arities.map((arity) =>
+    tx.reserveFunction("output:batch:" + arity, "__str_concat_" + arity, {
+      params: Array.from({ length: arity }, () => ({ ...strRef })),
+      results: [{ ...strRef }],
+    }),
+  );
+  const accumulator = tx.reserveGlobal(
+    "output:acc",
+    "__stdout_acc",
+    { kind: "ref_null", typeIdx: layout.anyStrTypeIdx },
+    true,
+  );
+  const buffer = tx.reserveGlobal(
+    "output:flat",
+    "__stdout_flat",
+    { kind: "ref_null", typeIdx: layout.strTypeIdx },
+    true,
+  );
+  const append = tx.reserveFunction("output:append", "__stdout_append", {
+    params: [{ kind: "ref_null", typeIdx: layout.anyStrTypeIdx }],
+    results: [],
+  });
+  const prepare = tx.reserveFunction("output:prepare", "__stdout_prepare", { params: [], results: [{ kind: "i32" }] });
+  const char = tx.reserveFunction("output:char", "__stdout_char", {
+    params: [{ kind: "i32" }],
+    results: [{ kind: "i32" }],
+  });
+  const probes = recipes.map((row) =>
+    tx.reserveFunction("output:probe:" + row.name, row.name, {
+      params: [],
+      results: Array.from({ length: 2 + row.expected.length }, () => ({ kind: "i32" as const })),
+    }),
+  );
+  const identity = tx.reserveFunction("output:identity", "empty_identity", { params: [], results: [{ kind: "i32" }] });
+  const appends = [flat(""), window, ...lines.map(flat)].map((_, i) =>
+    tx.reserveFunction("output:append-probe:" + i, "append_" + i, { params: [], results: [] }),
+  );
+  tx.freezeReservations();
+  fillNativeStringLiteralResources(tx, strings);
+  fillNativeStringFlattenResources(tx, flatten);
+  expect(requireCompletedNativeStringFlatten(tx, flatten, strings)).toBe(flatten);
+  function literal(row: Leaf): Instr[] {
+    const binding = requireNativeStringLiteral(tx, strings, row.backing ?? row.text, row.encoding);
+    if (binding.kind !== "global") throw Error("bounded output literal must be a genuine issued global");
+    const load: Instr[] = [{ op: "global.get", index: tx.physicalIndex(binding.global) }];
+    if (row.offset === undefined) return load;
+    if (row.encoding !== "wtf16") throw Error("this fixture's explicit subview is UTF-16");
+    return [
+      { op: "i32.const", value: row.text.length },
+      { op: "i32.const", value: row.offset },
+      ...load,
+      { op: "struct.get", typeIdx: layout.strTypeIdx, fieldIdx: 2 },
+      { op: "struct.new", typeIdx: layout.strTypeIdx },
+    ];
+  }
+  function operand(row: Operand): Instr[] {
+    if (!("rope" in row)) return literal(row);
+    return [
+      { op: "i32.const", value: row.text.length },
+      ...literal(row.rope[0]),
+      ...literal(row.rope[1]),
+      { op: "struct.new", typeIdx: layout.consStrTypeIdx },
+    ];
+  }
+  tx.fillFunction(concat, buildStringConcatDefinition(layout, { flattenIdx: flatten.flatten.handle, emptyIdentity }));
+  arities.forEach((arity, i) =>
+    tx.fillFunction(
+      batches[i]!,
+      buildStringBatchedConcatDefinition(layout, arity, {
+        flattenIdx: flatten.flatten.handle,
+        concatIdx: concat.handle,
+        undefinedLiterals: Array.from({ length: arity }, () => literal(flat("undefined"))),
+      }),
+    ),
+  );
+  tx.fillGlobal(accumulator, [{ op: "ref.null", typeIdx: layout.anyStrTypeIdx }]);
+  tx.fillGlobal(buffer, [{ op: "ref.null", typeIdx: layout.strTypeIdx }]);
+  tx.fillFunction(
+    append,
+    buildStdoutAppendDefinition({ accGlobalIdx: tx.physicalIndex(accumulator), concatIdx: concat.handle }),
+  );
+  tx.fillFunction(
+    prepare,
+    buildStdoutPrepareDefinition({
+      accGlobalIdx: tx.physicalIndex(accumulator),
+      flatGlobalIdx: tx.physicalIndex(buffer),
+      flatTypeIdx: layout.strTypeIdx,
+      flattenIdx: flatten.flatten.handle,
+    }),
+  );
+  tx.fillFunction(
+    char,
+    buildStdoutCharDefinition({
+      flatGlobalIdx: tx.physicalIndex(buffer),
+      flatTypeIdx: layout.strTypeIdx,
+      dataTypeIdx: layout.strDataTypeIdx,
+    }),
+  );
+  recipes.forEach((row, i) => {
+    const target = row.binary ? concat : batches[arities.indexOf(row.operands.length as (typeof arities)[number])]!;
+    if (!target) throw Error("missing exact batch target");
+    tx.fillFunction(probes[i]!, {
+      locals: [
+        { name: "result", type: { kind: "ref_null", typeIdx: layout.anyStrTypeIdx } },
+        { name: "flat", type: { kind: "ref_null", typeIdx: layout.strTypeIdx } },
+      ],
+      body: [
+        ...row.operands.flatMap(operand),
+        { op: "call", funcIdx: target.handle },
+        { op: "local.set", index: 0 },
+        { op: "local.get", index: 0 },
+        { op: "ref.test", typeIdx: layout.consStrTypeIdx },
+        { op: "local.get", index: 0 },
+        { op: "ref.as_non_null" },
+        { op: "call", funcIdx: flatten.flatten.handle },
+        { op: "local.set", index: 1 },
+        { op: "local.get", index: 1 },
+        { op: "struct.get", typeIdx: layout.strTypeIdx, fieldIdx: 0 },
+        ...units(row.expected).flatMap((_, index): Instr[] => [
+          { op: "local.get", index: 1 },
+          { op: "struct.get", typeIdx: layout.strTypeIdx, fieldIdx: 2 },
+          { op: "local.get", index: 1 },
+          { op: "struct.get", typeIdx: layout.strTypeIdx, fieldIdx: 1 },
+          { op: "i32.const", value: index },
+          { op: "i32.add" },
+          { op: "array.get_u", typeIdx: layout.strDataTypeIdx },
+        ]),
+      ],
+    });
+    tx.defineExport("export:" + row.name, row.name, probes[i]!);
+  });
+  tx.fillFunction(identity, {
+    locals: [],
+    body: [
+      ...literal(empty),
+      ...literal(flat("identity")),
+      { op: "call", funcIdx: concat.handle },
+      ...literal(flat("identity")),
+      { op: "ref.eq" },
+    ],
+  });
+  appends.forEach((token, i) =>
+    tx.fillFunction(token, {
+      locals: [],
+      body:
+        i === 0
+          ? [
+              { op: "ref.null", typeIdx: layout.anyStrTypeIdx },
+              { op: "call", funcIdx: append.handle },
+            ]
+          : i === 1
+            ? [...literal(window), { op: "call", funcIdx: append.handle }]
+            : [
+                ...literal(flat(lines[i - 2]!)),
+                ...literal(flat("\n")),
+                { op: "call", funcIdx: concat.handle },
+                { op: "call", funcIdx: append.handle },
+              ],
+    }),
+  );
+  for (const token of [prepare, char, identity, ...appends])
+    tx.defineExport("export:" + token.object.name, token.object.name, token);
+  expect(requireCompletedNativeStringFlatten(tx, flatten, strings)).toBe(flatten);
+  const census = tx.seal();
+  return { module, layout, census, concat, batches, probes, prepare, char };
+}
+
+function compileFixture(emptyIdentity: boolean) {
+  const state = issuedModule(emptyIdentity);
+  const binary = Uint8Array.from(emitBinary(state.module));
+  const compiled = new WebAssembly.Module(binary);
+  const imports = WebAssembly.Module.imports(compiled),
+    exports = WebAssembly.Module.exports(compiled);
+  expect(imports).toEqual([]);
+  expect(exports.map((e) => e.name)).toEqual([
+    ...recipes.map((r) => r.name),
+    "__stdout_prepare",
+    "__stdout_char",
+    "empty_identity",
+    ...Array.from({ length: 6 }, (_, i) => "append_" + i),
+  ]);
+  const artifact = {
+    scope: "canonical output bodies + genuine issued literal/flatten resources; not prepared consumer admission",
+    emptyIdentity,
+    recipes,
+    node: process.version,
+    versions: process.versions,
+    binary: Buffer.from(binary).toString("base64"),
+    instantiatedBinary: Buffer.from(binary).toString("base64"),
+    binarySha256: digest(binary),
+    wat: emitWat(state.module),
+    imports,
+    exports,
+    census: state.census,
+    functionOrder: state.module.functions.map((f) => f.name),
+  };
+  const parent = resolve(import.meta.dirname, "..", ".tmp");
+  mkdirSync(parent, { recursive: true });
+  const directory = mkdtempSync(resolve(parent, "native-string-output-"));
+  writeFileSync(resolve(directory, "artifact.json"), JSON.stringify(artifact, null, 2));
+  return { ...state, compiled, artifact, directory };
+}
+const fixtures = new Map<boolean, { value: ReturnType<typeof compileFixture> } | { error: unknown }>();
+function fixture(emptyIdentity: boolean) {
+  let entry = fixtures.get(emptyIdentity);
+  if (!entry) {
+    try {
+      entry = { value: compileFixture(emptyIdentity) };
+    } catch (error) {
+      entry = { error };
+    }
+    fixtures.set(emptyIdentity, entry);
+  }
+  if ("error" in entry) throw entry.error;
+  return entry.value;
+}
+function call(exports: WebAssembly.Exports, name: string, ...args: number[]) {
+  const fn = exports[name];
+  if (typeof fn !== "function") throw Error("missing actual export " + name);
+  return fn(...args);
+}
+function readStdout(exports: WebAssembly.Exports): string {
+  const length = call(exports, "__stdout_prepare");
+  if (!Number.isSafeInteger(length) || length < 0) throw Error("invalid stdout length");
+  return Array.from({ length }, (_, i) => String.fromCharCode(call(exports, "__stdout_char", i))).join("");
+}
+function expectedRope(row: Recipe, emptyIdentity: boolean) {
+  if (emptyIdentity && row.binary) {
+    if (!row.operands[0]!.text.length) return Number("rope" in row.operands[1]!);
+    if (!row.operands[1]!.text.length) return Number("rope" in row.operands[0]!);
+  }
+  return Number(row.expected.length >= 64);
+}
+
+describe("real canonical string-output execution", () => {
+  it("pins the complete supported arity and recipe denominator", () => {
+    expect(STRING_CONCAT_MANY_NATIVE_ARITY).toEqual({ min: 3, max: 8 });
+    expect(binaryRecipes).toHaveLength(12);
+    expect(batchRecipes).toHaveLength(12);
+    expect(new Set(recipes.map((r) => r.name)).size).toBe(24);
+    expect(units(window.text)).toEqual([65, 233, 8364, 55357, 56832]);
+  });
+  for (const emptyIdentity of [false, true]) {
+    it.each(recipes)("executes $name with empty identity " + emptyIdentity, (row) => {
+      const f = fixture(emptyIdentity),
+        observations = [];
+      expect(f.artifact.binary).toBe(f.artifact.instantiatedBinary);
+      for (let instance = 0; instance < 2; instance++) {
+        const exports = new WebAssembly.Instance(f.compiled, {}).exports;
+        for (let repetition = 0; repetition < 2; repetition++) {
+          const value = call(exports, row.name);
+          observations.push({ instance, repetition, name: row.name, value });
+          expect(value).toEqual([expectedRope(row, emptyIdentity), row.expected.length, ...units(row.expected)]);
+        }
+      }
+      expect(observations).toHaveLength(4);
+      writeFileSync(resolve(f.directory, row.name + ".json"), JSON.stringify(observations, null, 2));
+    });
+    it("executes real empty-identity choice " + emptyIdentity, () => {
+      const f = fixture(emptyIdentity);
+      for (let instance = 0; instance < 2; instance++) {
+        const exports = new WebAssembly.Instance(f.compiled, {}).exports;
+        expect(call(exports, "empty_identity")).toBe(Number(emptyIdentity));
+        expect(call(exports, "empty_identity")).toBe(Number(emptyIdentity));
+      }
+    });
+    it("reads real stdout null/bounds/offset/four-newline joins " + emptyIdentity, () => {
+      const f = fixture(emptyIdentity),
+        observations = [];
+      for (let instance = 0; instance < 2; instance++) {
+        const exports = new WebAssembly.Instance(f.compiled, {}).exports;
+        expect(call(exports, "__stdout_char", 0)).toBe(0); // null prepared buffer
+        expect(readStdout(exports)).toBe("");
+        call(exports, "append_0"); // genuine nullable append signature
+        expect(readStdout(exports)).toBe("");
+        call(exports, "append_1"); // first assignment keeps the nonzero flat offset
+        expect(readStdout(exports)).toBe(window.text);
+        let expected = window.text;
+        for (let repetition = 0; repetition < 2; repetition++) {
+          for (let line = 0; line < 4; line++) call(exports, "append_" + (line + 2));
+          expected += lines.join("\n") + "\n";
+          call(exports, "append_0");
+          const value = readStdout(exports);
+          observations.push({ instance, repetition, value });
+          expect(value).toBe(expected);
+          expect(readStdout(exports)).toBe(expected);
+          for (const index of [-1, -2147483648, expected.length, expected.length + 1])
+            expect(call(exports, "__stdout_char", index)).toBe(0);
+        }
+      }
+      writeFileSync(resolve(f.directory, "stdout.json"), JSON.stringify(observations, null, 2));
+    });
+  }
+  it("keeps real nonnullable batch input signatures; null injection is not a successful guard execution", () => {
+    const f = fixture(true),
+      mutant = structuredClone(f.module);
+    const target = f.batches[0]!;
+    const type = f.module.types[target.object.typeIdx]!;
+    if (type.kind !== "func") throw Error("batch signature unavailable");
+    expect(type.params).toEqual(Array.from({ length: 3 }, () => ({ kind: "ref", typeIdx: f.layout.anyStrTypeIdx })));
+    const probe = mutant.functions[f.module.functions.indexOf(f.probes[0]!.object)]!;
+    probe.body = [
+      { op: "ref.null", typeIdx: f.layout.anyStrTypeIdx },
+      { op: "ref.null", typeIdx: f.layout.anyStrTypeIdx },
+      { op: "ref.null", typeIdx: f.layout.anyStrTypeIdx },
+      { op: "call", funcIdx: target.handle },
+      { op: "drop" },
+      { op: "i32.const", value: 0 },
+      { op: "i32.const", value: 0 },
+    ];
+    expect(() => new WebAssembly.Module(Uint8Array.from(emitBinary(mutant)))).toThrow(WebAssembly.CompileError);
+  });
+});
+
+describe("builder detachment and legacy bounded registration", () => {
+  const layout: StringConcatLayout = { strTypeIdx: 2, strDataTypeIdx: 0, anyStrTypeIdx: 1, consStrTypeIdx: 3 };
+  const literal = (): Instr[] => [
+    { op: "block", blockType: { kind: "empty" }, body: [{ op: "global.get", index: 9 }] },
+  ];
+  it("detaches all five definitions across calls, including nested literal dependencies", () => {
+    const dependencies = Array.from({ length: 3 }, literal);
+    const builders = [
+      () => buildStringConcatDefinition(layout, { flattenIdx: 10, emptyIdentity: true }),
+      () =>
+        buildStringBatchedConcatDefinition(layout, 3, {
+          flattenIdx: 10,
+          concatIdx: 11,
+          undefinedLiterals: dependencies,
+        }),
+      () => buildStdoutAppendDefinition({ accGlobalIdx: 12, concatIdx: 11 }),
+      () => buildStdoutPrepareDefinition({ accGlobalIdx: 12, flatGlobalIdx: 13, flatTypeIdx: 2, flattenIdx: 10 }),
+      () => buildStdoutCharDefinition({ flatGlobalIdx: 13, flatTypeIdx: 2, dataTypeIdx: 0 }),
+    ];
+    const collect = (root: unknown) => {
+      const objects = new Set<object>();
+      const visit = (value: unknown) => {
+        if (!value || typeof value !== "object" || objects.has(value)) return;
+        objects.add(value);
+        for (const entry of Object.values(value)) visit(entry);
+      };
+      visit(root);
+      return objects;
+    };
+    for (const build of builders) {
+      const a = build(),
+        b = build();
+      expect(a).toEqual(b);
+      const owned = collect(a),
+        others = collect([b, dependencies]);
+      expect([...owned].filter((x) => others.has(x))).toEqual([]);
+      a.body.length = 0;
+      expect(b.body.length).toBeGreaterThan(0);
+    }
+    expect(builders.map((build) => build().locals.length)).toEqual([6, 3, 0, 0, 1]);
+  });
+  it.each(["missing", "extra", "hole"] as const)("rejects %s literal population", (kind) => {
+    const make = () => ({ flattenIdx: 10, concatIdx: 11, undefinedLiterals: Array.from({ length: 3 }, literal) });
+    expect(buildStringBatchedConcatDefinition(layout, 3, make()).body.length).toBeGreaterThan(0);
+    const deps = make();
+    if (kind === "missing") deps.undefinedLiterals.pop();
+    if (kind === "extra") deps.undefinedLiterals.push(literal());
+    if (kind === "hole") {
+      Reflect.deleteProperty(deps.undefinedLiterals, 1);
+      expect(Object.hasOwn(deps.undefinedLiterals, 1)).toBe(false);
+    }
+    expect(() => buildStringBatchedConcatDefinition(layout, 3, deps)).toThrow();
+  });
+  it("retains out-of-range refusal before touching the legacy context", () => {
+    const ctx = new Proxy({} as CodegenContext, {
+      get() {
+        throw Error("out-of-range helper touched context");
+      },
+    });
+    for (const arity of [0, 1, 2, 9, 16]) expect(ensureNativeBatchedConcat(ctx, arity)).toBeUndefined();
+  });
+  it("retains each already registered arity without allocating or reading layouts", () => {
+    const helpers = new Map(arities.map((arity) => ["__str_concat_" + arity, 100 + arity]));
+    const ctx = new Proxy({} as CodegenContext, {
+      get(_target, key) {
+        if (key === "nativeStrHelpers") return helpers;
+        throw Error("cached helper touched " + String(key));
+      },
+    });
+    for (const arity of arities) expect(ensureNativeBatchedConcat(ctx, arity)).toBe(100 + arity);
+  });
+});

--- a/tests/issue-3518-native-string-output-preservation.test.ts
+++ b/tests/issue-3518-native-string-output-preservation.test.ts
@@ -1,0 +1,394 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const concatPath = "src/runtime/wasmgc/values/string-concat-bodies.ts";
+const stdoutPath = "src/runtime/wasmgc/values/stdout-bodies.ts";
+const batchPath = "src/codegen/native-batched-concat.ts";
+const basicsPath = "src/codegen/native-strings-basics.ts";
+const legacyStdoutPath = "src/codegen/native-strings.ts";
+const paths = [concatPath, stdoutPath, batchPath, basicsPath, legacyStdoutPath];
+const read = () => Object.fromEntries(paths.map((p) => [p, readFileSync(new URL("../" + p, import.meta.url), "utf8")]));
+const parse = (s: string) => ts.createSourceFile("receipt.ts", s, ts.ScriptTarget.Latest, true);
+const sha = (s: string) => createHash("sha256").update(s).digest("hex");
+// Pinned from the complete files at 721cd33a828c89cfc04c851b011f910b76a4d2c5.
+// No git executable or historical object availability is needed in CI.
+const originals = {
+  [batchPath]: {
+    raw: "52a1aaace8b89e85cb5862ad0ee7df86a2ccccd9e9664516bf747a4600bf7bb1",
+    receipt: "2a6f1a7dfff5a3d5a0da680469c540752094e821f46fa55e15d48f6917e8d3d0",
+  },
+  [basicsPath]: {
+    raw: "d35ac41d78a1e12d3109d3001112fa6ef97e9548d1006e73241531f40c84865d",
+    receipt: "46d125901e67458657d6510eff8b3da75a309372a458cefdc96b63a078bff5bb",
+  },
+  [legacyStdoutPath]: {
+    raw: "b29419deb584cc1e285a19f89a4ab7f3394215fb3d5fa7fe5c037b5be0c44173",
+    receipt: "e1f7d82020519c76ec2542dac9c6c0e387fb3be4f4ff4885d1f08d2b89ddca20",
+  },
+};
+// Preserve every parser-owned token and every comment. Only formatting,
+// optional commas and statement semicolons are ignored.
+function receipt(text: string): string {
+  const sf = parse(text),
+    tokens: string[] = [],
+    comments = new Map<number, string>();
+  const visit = (node: ts.Node) => {
+    for (const pos of [node.pos, node.end, node.getFullStart()])
+      for (const range of [
+        ...(ts.getLeadingCommentRanges(text, pos) ?? []),
+        ...(ts.getTrailingCommentRanges(text, pos) ?? []),
+      ])
+        comments.set(range.pos, text.slice(range.pos, range.end));
+    const children = node.getChildren(sf);
+    if (
+      !children.length &&
+      node.kind !== ts.SyntaxKind.EndOfFileToken &&
+      ![ts.SyntaxKind.CommaToken, ts.SyntaxKind.SemicolonToken].includes(node.kind)
+    )
+      tokens.push(node.getText(sf));
+    else children.forEach(visit);
+  };
+  visit(sf);
+  return JSON.stringify({ tokens, comments: [...comments.values()].sort() });
+}
+function exact(actual: string, expected: string): void {
+  if (receipt(actual) !== receipt(expected)) throw Error("changed canonical header, dependency or forwarding contract");
+}
+function fn(sf: ts.SourceFile, name: string): ts.FunctionDeclaration & { body: ts.Block } {
+  const found = sf.statements.filter(
+    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === name,
+  );
+  if (found.length !== 1 || !found[0]!.body) throw Error("missing/duplicate function " + name);
+  return found[0] as ts.FunctionDeclaration & { body: ts.Block };
+}
+function prop(object: ts.ObjectLiteralExpression, name: string): ts.PropertyAssignment {
+  const found = object.properties.filter((p) => p.name?.getText() === name);
+  const selected = found[0];
+  if (found.length !== 1 || !selected || !ts.isPropertyAssignment(selected))
+    throw Error("missing/duplicate property " + name);
+  return selected;
+}
+function parts(sf: ts.SourceFile, name: string, header: string, prefix: string, prefixCount: number) {
+  const f = fn(sf, name),
+    statements = f.body.statements;
+  exact(sf.text.slice(f.getStart(sf), f.body.getStart(sf)), header);
+  exact(
+    statements
+      .slice(0, prefixCount)
+      .map((s) => s.getText(sf))
+      .join("\n"),
+    prefix,
+  );
+  const ret = statements.at(-1);
+  if (!ret || !ts.isReturnStatement(ret) || !ret.expression || !ts.isObjectLiteralExpression(ret.expression))
+    throw Error("missing canonical definition return");
+  exact(ret.expression.properties.map((p) => p.name?.getText(sf)).join(","), "locals,body");
+  const body = ret.expression.properties[1];
+  if (!body || !ts.isShorthandPropertyAssignment(body) || body.name.text !== "body")
+    throw Error("changed returned body");
+  const locals = prop(ret.expression, "locals").initializer;
+  if (!ts.isArrayLiteralExpression(locals)) throw Error("locals not explicit");
+  if (statements.length <= prefixCount + 1) throw Error("empty canonical construction");
+  return {
+    construction: sf.text.slice(statements[prefixCount]!.getFullStart(), statements.at(-2)!.end),
+    locals: locals.getText(sf),
+  };
+}
+function canonical(files: Record<string, string>) {
+  const c = parse(files[concatPath]!),
+    s = parse(files[stdoutPath]!);
+  const allowed = ["../../../wasm/model/instructions.js"];
+  for (const [sf, count] of [
+    [c, 2],
+    [s, 3],
+  ] as const) {
+    if (sf.statements.filter(ts.isFunctionDeclaration).length !== count) throw Error("changed executable population");
+    if (
+      sf.statements.filter(ts.isImportDeclaration).length !== 1 ||
+      sf.statements.filter(ts.isVariableStatement).length !== (sf === c ? 1 : 0)
+    )
+      throw Error("changed import/initializer population");
+    for (const statement of sf.statements) {
+      if (ts.isImportDeclaration(statement)) {
+        if (
+          !statement.importClause?.isTypeOnly ||
+          !ts.isStringLiteral(statement.moduleSpecifier) ||
+          !allowed.includes(statement.moduleSpecifier.text)
+        )
+          throw Error("forbidden executable dependency");
+        exact(
+          statement.getText(sf),
+          sf === c
+            ? 'import type { FuncHandle, Instr, LocalDef, TypeHandle, ValType } from "../../../wasm/model/instructions.js";'
+            : 'import type { FuncHandle, GlobalHandle, Instr, LocalDef, TypeHandle } from "../../../wasm/model/instructions.js";',
+        );
+      } else if (ts.isVariableStatement(statement)) {
+        if (sf !== c) throw Error("unexpected initializer");
+        exact(statement.getText(sf), "const FLAT_CONCAT_LIMIT = 64;");
+      } else if (!ts.isInterfaceDeclaration(statement) && !ts.isFunctionDeclaration(statement))
+        throw Error("unexpected top-level execution");
+    }
+  }
+  return [
+    parts(
+      c,
+      "buildStringConcatDefinition",
+      "export function buildStringConcatDefinition(layout: StringConcatLayout, resources: StringConcatResources): { locals: LocalDef[]; body: Instr[] }",
+      'const { strTypeIdx, strDataTypeIdx, anyStrTypeIdx, consStrTypeIdx } = layout; const { flattenIdx, emptyIdentity } = resources; const strRef: ValType = { kind: "ref", typeIdx: anyStrTypeIdx };',
+      3,
+    ),
+    parts(
+      c,
+      "buildStringBatchedConcatDefinition",
+      'export function buildStringBatchedConcatDefinition(layout: Pick<StringConcatLayout, "strTypeIdx" | "strDataTypeIdx" | "anyStrTypeIdx">, arity: number, resources: StringBatchedConcatResources): { locals: LocalDef[]; body: Instr[] }',
+      'if (!Number.isInteger(arity) || arity < 2 || resources.undefinedLiterals.length !== arity) throw new Error("native batched concat: literal population must match arity"); for (let index = 0; index < arity; index++) if (!Array.isArray(resources.undefinedLiterals[index])) throw new Error("native batched concat: missing literal sequence"); const { strTypeIdx, strDataTypeIdx, anyStrTypeIdx } = layout; const { flattenIdx, concatIdx } = resources; const strRef: ValType = { kind: "ref", typeIdx: anyStrTypeIdx };',
+      5,
+    ),
+    parts(
+      s,
+      "buildStdoutAppendDefinition",
+      "export function buildStdoutAppendDefinition(resources: StdoutAppendResources): { locals: LocalDef[]; body: Instr[] }",
+      "const { accGlobalIdx, concatIdx } = resources;",
+      1,
+    ),
+    parts(
+      s,
+      "buildStdoutPrepareDefinition",
+      "export function buildStdoutPrepareDefinition(resources: StdoutPrepareResources): { locals: LocalDef[]; body: Instr[] }",
+      "const { accGlobalIdx, flatGlobalIdx, flatTypeIdx, flattenIdx } = resources;",
+      1,
+    ),
+    parts(
+      s,
+      "buildStdoutCharDefinition",
+      "export function buildStdoutCharDefinition(resources: StdoutCharResources): { locals: LocalDef[]; body: Instr[] }",
+      "const { flatGlobalIdx, flatTypeIdx, dataTypeIdx } = resources;",
+      1,
+    ),
+  ];
+}
+type Edit = { start: number; end: number; text: string };
+function restoreAdapter(text: string, names: readonly string[], definitions: ReturnType<typeof canonical>) {
+  const sf = parse(text),
+    edits: Edit[] = [];
+  const imports = sf.statements
+    .filter(ts.isImportDeclaration)
+    .filter(
+      (s) =>
+        ts.isStringLiteral(s.moduleSpecifier) &&
+        /\/(string-concat-bodies|stdout-bodies)\.js$/.test(s.moduleSpecifier.text),
+    );
+  if (imports.length !== 1) throw Error("missing/duplicate forwarding import");
+  const imp = imports[0]!;
+  if (
+    imp.importClause?.isTypeOnly ||
+    !imp.importClause?.namedBindings ||
+    !ts.isNamedImports(imp.importClause.namedBindings)
+  )
+    throw Error("non-value import");
+  const imported = imp.importClause.namedBindings.elements;
+  if (
+    imported.some((s) => s.isTypeOnly || s.propertyName) ||
+    imported.map((s) => s.name.text).join(",") !== names.join(",")
+  )
+    throw Error("changed imported binding");
+  edits.push({ start: imp.getFullStart(), end: imp.end, text: "" });
+  let used = 0;
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && names.includes(node.expression.getText(sf))) {
+      const name = node.expression.getText(sf),
+        position = names.indexOf(name);
+      const d = definitions[position]!;
+      const declaration = node.parent;
+      if (
+        !ts.isVariableDeclaration(declaration) ||
+        declaration.name.getText(sf) !== "definition" ||
+        !ts.isVariableDeclarationList(declaration.parent) ||
+        !ts.isVariableStatement(declaration.parent.parent)
+      )
+        throw Error("changed adapter definition");
+      const statement = declaration.parent.parent;
+      const container = statement.parent;
+      if (!ts.isBlock(container)) throw Error("unexpected registration container");
+      let start = statement.getFullStart(),
+        restored = d.construction;
+      const argumentsByName: Record<string, string> = {
+        buildStringConcatDefinition:
+          '{ strTypeIdx, strDataTypeIdx, anyStrTypeIdx, consStrTypeIdx }, { flattenIdx, emptyIdentity: process.env.JS2WASM_STR_CONCAT_EMPTY_IDENTITY !== "0" }',
+        buildStringBatchedConcatDefinition:
+          "{ strTypeIdx, strDataTypeIdx, anyStrTypeIdx }, arity, { flattenIdx, concatIdx, undefinedLiterals }",
+        buildStdoutAppendDefinition: "{ accGlobalIdx, concatIdx }",
+        buildStdoutPrepareDefinition: "{ accGlobalIdx, flatGlobalIdx, flatTypeIdx, flattenIdx }",
+        buildStdoutCharDefinition: "{ flatGlobalIdx, flatTypeIdx, dataTypeIdx }",
+      };
+      exact(node.arguments.map((a) => a.getText(sf)).join(","), argumentsByName[name]!);
+      if (name === "buildStringConcatDefinition") {
+        if (restored.split("!emptyIdentity").length !== 2) throw Error("changed empty switch");
+        restored = restored.replace("!emptyIdentity", 'process.env.JS2WASM_STR_CONCAT_EMPTY_IDENTITY === "0"');
+      }
+      if (name === "buildStringBatchedConcatDefinition") {
+        const index = container.statements.indexOf(statement),
+          first = container.statements[index - 2]!,
+          second = container.statements[index - 1]!;
+        exact(first.getText(sf), "const undefinedLiterals: Instr[][] = [];");
+        exact(
+          second.getText(sf),
+          'for (let index = 0; index < arity; index++) undefinedLiterals.push(nativeStringLiteralInstrs(ctx, "undefined"));',
+        );
+        start = first.getFullStart();
+        if (restored.split("structuredClone(resources.undefinedLiterals[index]!)").length !== 2)
+          throw Error("changed detached literal read");
+        restored = restored.replace(
+          "structuredClone(resources.undefinedLiterals[index]!)",
+          'nativeStringLiteralInstrs(ctx, "undefined")',
+        );
+      }
+      edits.push({ start, end: statement.end, text: restored });
+      const pushes = container.statements
+        .filter(ts.isExpressionStatement)
+        .map((s) => s.expression)
+        .filter(
+          (e): e is ts.CallExpression => ts.isCallExpression(e) && e.expression.getText(sf) === "pushDefinedFunc",
+        );
+      if (pushes.length !== 1) throw Error("changed registration population");
+      let record = pushes[0]!.arguments[2]!;
+      if (ts.isAsExpression(record)) record = record.expression;
+      if (!ts.isObjectLiteralExpression(record)) throw Error("missing registration record");
+      for (const key of ["locals", "body"]) {
+        const p = prop(record, key);
+        exact(p.initializer.getText(sf), "definition." + key);
+        edits.push({ start: p.getStart(sf), end: p.end, text: key === "body" ? "body" : "locals: " + d.locals });
+      }
+      used++;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  if (used !== names.length) throw Error("changed forwarding call population");
+  for (const e of edits.sort((a, b) => b.start - a.start)) text = text.slice(0, e.start) + e.text + text.slice(e.end);
+  if (names.includes("buildStringBatchedConcatDefinition")) {
+    const marker = "const MAX_BATCHED_CONCAT_ARITY = STRING_CONCAT_MANY_NATIVE_ARITY.max;";
+    if (text.split(marker).length !== 2) throw Error("changed original arity authority");
+    text = text.replace(marker, marker + "\nconst FLAT_CONCAT_LIMIT = 64;");
+  }
+  return text;
+}
+function verify(files: Record<string, string>) {
+  const d = canonical(files);
+  const reconstructed = {
+    [basicsPath]: restoreAdapter(files[basicsPath]!, ["buildStringConcatDefinition"], [d[0]!]),
+    [batchPath]: restoreAdapter(files[batchPath]!, ["buildStringBatchedConcatDefinition"], [d[1]!]),
+    [legacyStdoutPath]: restoreAdapter(
+      files[legacyStdoutPath]!,
+      ["buildStdoutAppendDefinition", "buildStdoutPrepareDefinition", "buildStdoutCharDefinition"],
+      d.slice(2),
+    ),
+  };
+  for (const [p, text] of Object.entries(reconstructed))
+    if (sha(receipt(text)) !== originals[p]!.receipt) throw Error("donor preservation mismatch: " + p);
+  return reconstructed;
+}
+
+describe("native string output complete donor reconstruction", () => {
+  it("reconstructs all three entire legacy files, including untouched helpers and registration order", () => {
+    const result = verify(read());
+    expect(Object.keys(result)).toHaveLength(3);
+    expect(Object.values(originals).every((r) => r.raw.length === 64 && r.receipt.length === 64)).toBe(true);
+  });
+  const mutations: [string, string, string, string][] = [
+    ["unsigned concat threshold", concatPath, '{ op: "i32.const", value: 64 }', '{ op: "i32.const", value: 65 }'],
+    [
+      "rope operand order",
+      concatPath,
+      '{ op: "local.get", index: 0 }, // left = a',
+      '{ op: "local.get", index: 1 }, // left = a',
+    ],
+    [
+      "flat copy offset",
+      concatPath,
+      '{ op: "local.get", index: 2 }, // dstOffset = lenA',
+      '{ op: "i32.const", value: 0 }, // dstOffset = lenA',
+    ],
+    [
+      "scratch nullability",
+      concatPath,
+      'name: "newArr", type: { kind: "ref_null"',
+      'name: "newArr", type: { kind: "ref"',
+    ],
+    ["construction refinement", concatPath, '{ op: "ref.as_non_null" },', '{ op: "nop" },'],
+    ["empty-identity switch", basicsPath, 'EMPTY_IDENTITY !== "0"', 'EMPTY_IDENTITY === "0"'],
+    ["undefined guard", concatPath, "then: [...structuredClone(resources.undefinedLiterals[index]!),", "then: ["],
+    [
+      "literal creation ordering",
+      batchPath,
+      'undefinedLiterals.push(nativeStringLiteralInstrs(ctx, "undefined"))',
+      'undefinedLiterals.unshift(nativeStringLiteralInstrs(ctx, "undefined"))',
+    ],
+    ["null append branch", stdoutPath, 'then: [{ op: "return" }]', 'then: [{ op: "nop" }]'],
+    [
+      "accumulator target",
+      stdoutPath,
+      '{ op: "global.set", index: accGlobalIdx }',
+      '{ op: "global.set", index: accGlobalIdx + 1 }',
+    ],
+    ["signed lower bound", stdoutPath, '{ op: "i32.lt_s" }', '{ op: "i32.lt_u" }'],
+    ["upper bound", stdoutPath, '{ op: "i32.ge_s" }', '{ op: "i32.gt_s" }'],
+    ["read offset", stdoutPath, "fieldIdx: 1 }, // off", "fieldIdx: 0 }, // off"],
+    [
+      "unsigned code unit",
+      stdoutPath,
+      '{ op: "array.get_u", typeIdx: dataTypeIdx }',
+      '{ op: "array.get_s", typeIdx: dataTypeIdx }',
+    ],
+    [
+      "async builder header",
+      concatPath,
+      "export function buildStringConcatDefinition(",
+      "export async function buildStringConcatDefinition(",
+    ],
+    [
+      "generator builder header",
+      concatPath,
+      "export function buildStringConcatDefinition(",
+      "export function* buildStringConcatDefinition(",
+    ],
+    [
+      "extra execution",
+      stdoutPath,
+      "const { accGlobalIdx, concatIdx } = resources;",
+      'const { accGlobalIdx, concatIdx } = resources; throw Error("extra");',
+    ],
+    [
+      "type-only adapter",
+      basicsPath,
+      "import { buildStringConcatDefinition }",
+      "import type { buildStringConcatDefinition }",
+    ],
+    [
+      "aliased adapter",
+      basicsPath,
+      "import { buildStringConcatDefinition }",
+      "import { foreign as buildStringConcatDefinition }",
+    ],
+    ["untouched growth donor", basicsPath, "value: 16", "value: 17"],
+    ["stdout publication name", legacyStdoutPath, 'name: "__stdout_prepare", desc:', 'name: "foreign", desc:'],
+    ["missing batch constant", concatPath, "const FLAT_CONCAT_LIMIT = 64;", ""],
+    [
+      "rebound global index type",
+      stdoutPath,
+      "FuncHandle, GlobalHandle, Instr",
+      "FuncHandle, TypeHandle as GlobalHandle, Instr",
+    ],
+  ];
+  it.each(mutations)("rejects positive-first %s mutation", (_name, path, before, after) => {
+    const files = read();
+    verify(files);
+    expect(files[path]).toContain(before);
+    files[path] = files[path]!.replace(before, after);
+    expect(() => verify(files)).toThrow();
+  });
+});

--- a/tests/issue-3518-native-string-utf8-rope.test.ts
+++ b/tests/issue-3518-native-string-utf8-rope.test.ts
@@ -1,0 +1,574 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createEmptyModule } from "../src/ir/types.js";
+import type { Instr, ValType } from "../src/wasm/model/instructions.js";
+import type { WasmFunction } from "../src/wasm/model/module-records.js";
+import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
+import {
+  reserveNativeStringLiteralResources,
+  fillNativeStringLiteralResources,
+  requireNativeStringLiteral,
+} from "../src/backend/wasmgc/resources/native-string-literals.js";
+import {
+  reserveNativeStringFlattenResources,
+  fillNativeStringFlattenResources,
+  requireCompletedNativeStringFlatten,
+} from "../src/backend/wasmgc/resources/native-string-flatten.js";
+import {
+  buildStringCopyTreeDefinition,
+  buildStringFlattenDefinition,
+} from "../src/runtime/wasmgc/values/string-flatten-bodies.js";
+import { buildStringUtf8ToFlatDefinition } from "../src/runtime/wasmgc/values/string-utf8-decode-bodies.js";
+import {
+  projectCopyTreeUtf8,
+  projectFlattenAdapterStaging,
+} from "../scripts/verify-native-scanner-source-preservation.mjs";
+import { emitBinary } from "../src/emit/binary.js";
+import { emitWat } from "../src/emit/wat.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { makeNativeStrShared } from "../src/codegen/native-strings-shared.js";
+import { addFuncType, getOrRegisterArrayType } from "../src/codegen/registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
+import { nativeStringLiteralInstrs } from "../src/codegen/native-strings.js";
+import { compile } from "../src/index.js";
+
+const sha = (s: string | Uint8Array) => createHash("sha256").update(s).digest("hex");
+const units = (s: string) => Array.from({ length: s.length }, (_, i) => s.charCodeAt(i));
+const read = (path: string) => readFileSync(new URL("../" + path, import.meta.url), "utf8");
+const decoderPath = "src/runtime/wasmgc/values/string-utf8-decode-bodies.ts";
+type Leaf = { kind: "flat" | "utf8" | "hashed"; text: string; prefix?: string; suffix?: string };
+type Tree = Leaf | { kind: "cons"; left: Tree; right: Tree };
+const flat = (text: string): Leaf => ({ kind: "flat", text });
+const utf8 = (text: string, prefix = "", suffix = ""): Leaf => ({ kind: "utf8", text, prefix, suffix });
+const cons = (left: Tree, right: Tree): Tree => ({ kind: "cons", left, right });
+const textOf = (tree: Tree): string => (tree.kind === "cons" ? textOf(tree.left) + textOf(tree.right) : tree.text);
+const leafs = (tree: Tree): Leaf[] => (tree.kind === "cons" ? [...leafs(tree.left), ...leafs(tree.right)] : [tree]);
+let deep: Tree = utf8("€");
+for (let i = 0; i < 40; i++) deep = cons(deep, i % 2 ? flat("x") : utf8("é"));
+const recipes: { name: string; tree: Tree }[] = [
+  { name: "direct-utf8", tree: utf8("Aé€😀") },
+  { name: "direct-window", tree: utf8("é€😀", "é😀|", "&Ω") },
+  { name: "root-flat", tree: flat("A\uD800Z") },
+  { name: "root-hashed", tree: { kind: "hashed", text: "hashed" } },
+  { name: "left-utf8", tree: cons(utf8("é"), flat("right")) },
+  { name: "right-utf8", tree: cons(flat("left"), utf8("€")) },
+  { name: "both-utf8", tree: cons(utf8("é"), utf8("😀")) },
+  { name: "mixed-window", tree: cons(utf8("é€😀", "é😀|", "&Ω"), flat("\uD800!")) },
+  { name: "balanced", tree: cons(cons(utf8("é"), flat("A")), cons(utf8("😀"), utf8("€"))) },
+  { name: "deep-worklist-40", tree: deep },
+  { name: "empty-left", tree: cons(utf8(""), utf8("é")) },
+  { name: "empty-right", tree: cons(utf8("é"), utf8("")) },
+  { name: "empty-window", tree: cons(utf8("", "é😀|", "&Ω"), flat("Z")) },
+  { name: "all-empty", tree: cons(utf8(""), flat("")) },
+  { name: "direct-empty", tree: utf8("", "é😀|", "&Ω") },
+];
+function storage(leaf: Leaf) {
+  return {
+    value: (leaf.prefix ?? "") + leaf.text + (leaf.suffix ?? ""),
+    encoding: leaf.kind === "utf8" ? ("utf8-guaranteed" as const) : ("wtf16" as const),
+  };
+}
+function reserve(importCount = 0, utf8Storage = true) {
+  const module = createEmptyModule(),
+    tx = new PhysicalModuleReservations(module);
+  for (let i = 0; i < importCount; i++)
+    tx.reserveFunctionImport("offset:" + i, "offset", "f" + i, { params: [], results: [] });
+  const strings = reserveNativeStringLiteralResources(tx, {
+    key: "rope:strings",
+    utf8Storage,
+    literals: [
+      { value: "", encoding: "wtf16" },
+      ...recipes
+        .flatMap((r) => leafs(r.tree))
+        .filter((l) => utf8Storage || l.kind !== "utf8")
+        .map(storage),
+    ],
+  });
+  const pack = reserveNativeStringFlattenResources(tx, "rope:flatten", strings);
+  return { module, tx, strings, pack };
+}
+type State = ReturnType<typeof reserve>;
+function construct(tree: Tree, state: State): Instr[] {
+  const l = state.strings.layout;
+  if (tree.kind === "cons")
+    return [
+      { op: "i32.const", value: textOf(tree).length },
+      ...construct(tree.left, state),
+      ...construct(tree.right, state),
+      { op: "struct.new", typeIdx: l.consStrTypeIdx },
+    ];
+  const { value, encoding } = storage(tree);
+  const literal = requireNativeStringLiteral(state.tx, state.strings, value, encoding);
+  if (literal.kind !== "global") throw Error("issued test literal must be global");
+  const load: Instr = { op: "global.get", index: state.tx.physicalIndex(literal.global) };
+  if (tree.kind === "utf8")
+    return [
+      { op: "i32.const", value: tree.text.length },
+      { op: "i32.const", value: new TextEncoder().encode(tree.text).length },
+      { op: "i32.const", value: new TextEncoder().encode(tree.prefix ?? "").length },
+      load,
+      { op: "struct.get", typeIdx: l.utf8StrTypeIdx, fieldIdx: 3 },
+      { op: "struct.new", typeIdx: l.utf8StrTypeIdx },
+    ];
+  if (tree.kind === "hashed")
+    return [
+      { op: "i32.const", value: tree.text.length },
+      { op: "i32.const", value: 0 },
+      load,
+      { op: "struct.get", typeIdx: l.nativeStrTypeIdx, fieldIdx: 2 },
+      { op: "i32.const", value: 123 },
+      { op: "i32.const", value: 0 },
+      { op: "ref.null.eq" },
+      { op: "ref.null.eq" },
+      { op: "ref.null.eq" },
+      { op: "struct.new", typeIdx: l.hashedStrTypeIdx },
+    ];
+  return [load];
+}
+function probeDefinition(tree: Tree, mode: "copy" | "flatten", state: State) {
+  const l = state.strings.layout,
+    n = textOf(tree).length;
+  const locals = [
+    { name: "root", type: { kind: "ref_null", typeIdx: l.anyStrTypeIdx } as ValType },
+    { name: "flat", type: { kind: "ref_null", typeIdx: l.nativeStrTypeIdx } as ValType },
+    { name: "buffer", type: { kind: "ref_null", typeIdx: l.nativeStrDataTypeIdx } as ValType },
+    { name: "position", type: { kind: "i32" } as ValType },
+  ];
+  const getFlat: Instr[] = [{ op: "local.get", index: 1 }, { op: "ref.as_non_null" }];
+  const body: Instr[] = [...construct(tree, state), { op: "local.set", index: 0 }];
+  if (mode === "copy") {
+    body.push(
+      ...Array.from({ length: n + 4 }, (_, i): Instr => ({ op: "i32.const", value: i < 2 ? 0x1234 : 0x5678 })),
+      { op: "array.new_fixed", typeIdx: l.nativeStrDataTypeIdx, length: n + 4 },
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 0 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 2 },
+      { op: "ref.as_non_null" },
+      { op: "i32.const", value: 2 },
+      { op: "call", funcIdx: state.pack.copyTree.handle },
+      { op: "local.set", index: 3 },
+      { op: "local.get", index: 3 },
+      { op: "local.get", index: 2 },
+      { op: "ref.as_non_null" },
+      { op: "array.len" },
+    );
+    for (let i = 0; i < n + 4; i++)
+      body.push(
+        { op: "local.get", index: 2 },
+        { op: "ref.as_non_null" },
+        { op: "i32.const", value: i },
+        { op: "array.get_u", typeIdx: l.nativeStrDataTypeIdx },
+      );
+  } else {
+    body.push(
+      { op: "local.get", index: 0 },
+      { op: "ref.as_non_null" },
+      { op: "call", funcIdx: state.pack.flatten.handle },
+      { op: "local.set", index: 1 },
+      ...getFlat,
+      { op: "struct.get", typeIdx: l.nativeStrTypeIdx, fieldIdx: 0 },
+      ...getFlat,
+      { op: "struct.get", typeIdx: l.nativeStrTypeIdx, fieldIdx: 1 },
+      { op: "local.get", index: 0 },
+      { op: "ref.as_non_null" },
+      { op: "call", funcIdx: state.pack.flatten.handle },
+      ...getFlat,
+      { op: "ref.eq" },
+    );
+    for (let i = 0; i < n; i++)
+      body.push(
+        ...getFlat,
+        { op: "struct.get", typeIdx: l.nativeStrTypeIdx, fieldIdx: 2 },
+        { op: "i32.const", value: i },
+        { op: "array.get_u", typeIdx: l.nativeStrDataTypeIdx },
+      );
+  }
+  return { locals, body };
+}
+function buildModule(importCount: number) {
+  expect(sha(read(decoderPath))).toBe("119976d2b5c593dc05b22ed82df454537d3b0bed9395e9ae47ef7dbac64bb748");
+  const state = reserve(importCount),
+    { module, tx, strings, pack } = state;
+  const entries = recipes.flatMap((recipe) =>
+    (["copy", "flatten"] as const).map((mode) => ({
+      ...recipe,
+      mode,
+      name: recipe.name + ":" + mode,
+      token: tx.reserveFunction(recipe.name + ":" + mode, recipe.name + ":" + mode, {
+        params: [],
+        results: Array.from({ length: textOf(recipe.tree).length + (mode === "copy" ? 6 : 3) }, () => ({
+          kind: "i32" as const,
+        })),
+      }),
+    })),
+  );
+  expect(module.functions.slice(0, 3).map((f) => f.name)).toEqual([
+    "__str_copy_tree",
+    "__str_utf8_to_flat",
+    "__str_flatten",
+  ]);
+  tx.freezeReservations();
+  fillNativeStringLiteralResources(tx, strings);
+  fillNativeStringFlattenResources(tx, pack);
+  expect(requireCompletedNativeStringFlatten(tx, pack, strings)).toBe(pack);
+  expect(pack.copyTree.object.locals).toHaveLength(7);
+  expect(tx.physicalIndex(pack.copyTree)).toBe(importCount);
+  expect(tx.physicalIndex(pack.utf8Decoder!)).toBe(importCount + 1);
+  expect(tx.physicalIndex(pack.flatten)).toBe(importCount + 2);
+  const canonical = buildStringCopyTreeDefinition(strings.layout, pack.worklist.typeIndex, {
+    kind: "present",
+    handle: pack.utf8Decoder!.handle,
+  });
+  expect(pack.copyTree.object.body).toEqual(canonical.body);
+  expect(pack.copyTree.object.locals).toEqual(canonical.locals);
+  for (const entry of entries) {
+    tx.fillFunction(entry.token, probeDefinition(entry.tree, entry.mode, state));
+    tx.defineExport("export:" + entry.name, entry.name, entry.token);
+  }
+  const census = tx.seal(),
+    binary = Uint8Array.from(emitBinary(module)),
+    wat = emitWat(module);
+  const compiled = new WebAssembly.Module(binary);
+  expect(WebAssembly.Module.imports(compiled)).toEqual(
+    Array.from({ length: importCount }, (_, i) => ({ module: "offset", name: "f" + i, kind: "function" })),
+  );
+  return { entries, compiled, binary: Buffer.from(binary).toString("base64"), wat, census };
+}
+function evidenceDirectory() {
+  const parent = resolve(".tmp");
+  mkdirSync(parent, { recursive: true });
+  return mkdtempSync(resolve(parent, "utf8-rope-repair-"));
+}
+const execution = new Map<number, ReturnType<typeof buildModule> | Error>();
+function moduleOnce(importCount: number) {
+  if (!execution.has(importCount)) {
+    try {
+      execution.set(importCount, buildModule(importCount));
+    } catch (error) {
+      execution.set(
+        importCount,
+        error instanceof Error ? error : new Error("fixture construction failed", { cause: error }),
+      );
+    }
+  }
+  const cached = execution.get(importCount)!;
+  if (cached instanceof Error) throw cached;
+  return cached;
+}
+describe("genuine issued UTF8 rope copy-tree and flatten execution", () => {
+  for (const importCount of [0, 3])
+    for (const recipe of recipes)
+      for (const mode of ["copy", "flatten"] as const)
+        it(importCount + " imports: " + recipe.name + ":" + mode, () => {
+          const fixture = moduleOnce(importCount),
+            name = recipe.name + ":" + mode,
+            data = units(textOf(recipe.tree));
+          const expected =
+            mode === "copy"
+              ? [data.length + 2, data.length + 4, 0x1234, 0x1234, ...data, 0x5678, 0x5678]
+              : [data.length, 0, recipe.tree.kind === "utf8" ? 0 : 1, ...data];
+          const observations = [];
+          for (let instance = 0; instance < 2; instance++) {
+            const wasm = new WebAssembly.Instance(fixture.compiled, { offset: { f0() {}, f1() {}, f2() {} } });
+            const fn = wasm.exports[name] as () => number[];
+            for (let repeat = 0; repeat < 2; repeat++) {
+              try {
+                observations.push({ instance, repeat, value: fn() });
+              } catch (error) {
+                observations.push({
+                  instance,
+                  repeat,
+                  error:
+                    error instanceof Error
+                      ? { name: error.name, message: error.message, stack: error.stack }
+                      : { thrown: String(error) },
+                });
+              }
+            }
+          }
+          const directory = evidenceDirectory();
+          writeFileSync(
+            resolve(directory, "receipt.json"),
+            JSON.stringify(
+              {
+                name,
+                importCount,
+                binary: fixture.binary,
+                instantiatedBinary: fixture.binary,
+                wat: fixture.wat,
+                census: fixture.census,
+                expected,
+                observations,
+              },
+              null,
+              2,
+            ),
+          );
+          for (const observation of observations) expect(observation, directory).toMatchObject({ value: expected });
+        });
+});
+
+// Execute exact selected function source with instrumented real dependency calls;
+// the actual real pushDefinedFunc retains the very object observed by the probe.
+function evaluate(source: string, names: string[], dependencies: Record<string, unknown>) {
+  const sf = ts.createSourceFile("actual.ts", source, ts.ScriptTarget.Latest, true);
+  const functions = sf.statements.filter(ts.isFunctionDeclaration).filter((n) => names.includes(n.name?.text ?? ""));
+  expect(functions.map((n) => n.name!.text).sort()).toEqual([...names].sort());
+  const js = ts.transpileModule(functions.map((n) => n.getText(sf)).join("\n"), {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+  const exports: Record<string, Function> = {};
+  new Function("exports", ...Object.keys(dependencies), js)(exports, ...Object.values(dependencies));
+  return exports;
+}
+function legacy(utf8Storage: boolean, options: { stale?: boolean; throwDecoder?: unknown } = {}) {
+  const ctx = createCodegenContext(createEmptyModule(), ts.createProgram([], { noLib: true }).getTypeChecker(), {
+    standalone: true,
+    nativeStrings: true,
+    utf8Storage,
+  });
+  const shared = makeNativeStrShared(
+    ctx,
+    ctx.nativeStrTypeIdx,
+    ctx.nativeStrDataTypeIdx,
+    ctx.anyStrTypeIdx,
+    ctx.consStrTypeIdx,
+  );
+  const events: string[] = [],
+    captured: WasmFunction[] = [];
+  const pending: { name: string; body: number; locals: number }[] = [];
+  if (options.stale) {
+    const handle = mintDefinedFunc(ctx),
+      typeIdx = addFuncType(ctx, [], []);
+    pushDefinedFunc(ctx, handle, { name: "stale-decoder", typeIdx, locals: [], body: [], exported: false });
+    ctx.nativeStrHelpers.set("__str_utf8_to_flat", handle);
+  }
+  const set = ctx.nativeStrHelpers.set.bind(ctx.nativeStrHelpers);
+  ctx.nativeStrHelpers.set = (name, value) => {
+    events.push("map:" + name);
+    return set(name, value);
+  };
+  const funcSet = ctx.funcMap.set.bind(ctx.funcMap);
+  ctx.funcMap.set = (name, value) => {
+    events.push("funcMap:" + name);
+    return funcSet(name, value);
+  };
+  const selections: unknown[] = [],
+    worklists: number[] = [];
+  const dependencies = {
+    addFuncType: (...args: Parameters<typeof addFuncType>) => {
+      events.push("type");
+      return addFuncType(...args);
+    },
+    getOrRegisterArrayType: (...args: Parameters<typeof getOrRegisterArrayType>) => {
+      events.push("worklist");
+      return getOrRegisterArrayType(...args);
+    },
+    mintDefinedFunc: (...args: Parameters<typeof mintDefinedFunc>) => {
+      events.push("mint");
+      return mintDefinedFunc(...args);
+    },
+    pushDefinedFunc: (context: typeof ctx, handle: number, fn: WasmFunction) => {
+      events.push("push:" + fn.name);
+      captured.push(fn);
+      pending.push({ name: fn.name!, body: fn.body.length, locals: fn.locals.length });
+      pushDefinedFunc(context, handle, fn);
+      expect(ctx.mod.functions.at(-1)).toBe(fn);
+    },
+    nativeStringLiteralInstrs: (...args: Parameters<typeof nativeStringLiteralInstrs>) => {
+      events.push("empty");
+      return nativeStringLiteralInstrs(...args);
+    },
+    buildStringCopyTreeDefinition: (...args: Parameters<typeof buildStringCopyTreeDefinition>) => {
+      events.push("build:copy");
+      selections.push(args[2]);
+      worklists.push(args[1]);
+      return buildStringCopyTreeDefinition(...args);
+    },
+    buildStringUtf8ToFlatDefinition: (...args: Parameters<typeof buildStringUtf8ToFlatDefinition>) => {
+      events.push("build:decoder");
+      if (Object.hasOwn(options, "throwDecoder")) throw options.throwDecoder;
+      return buildStringUtf8ToFlatDefinition(...args);
+    },
+    buildStringFlattenDefinition: (...args: Parameters<typeof buildStringFlattenDefinition>) => {
+      events.push("build:flatten");
+      selections.push(args[1].utf8Decoder);
+      return buildStringFlattenDefinition(...args);
+    },
+  };
+  const source = read("src/codegen/native-strings-core.ts");
+  const url = new URL("../src/codegen/native-strings-core.ts", import.meta.url).href;
+  projectFlattenAdapterStaging(source, url, url, sha);
+  const entry = evaluate(source, ["emitStrFlattenHelpers"], dependencies).emitStrFlattenHelpers!;
+  let error: unknown;
+  try {
+    entry(shared);
+  } catch (caught) {
+    error = caught;
+  }
+  return { ctx, events, captured, pending, selections, worklists, error };
+}
+describe("legacy ordered pending-object registration, no provisional executable body", () => {
+  for (const enabled of [false, true])
+    it("preserves actual registration/fill ordering " + enabled, () => {
+      const r = legacy(enabled);
+      expect(r.error).toBeUndefined();
+      expect(r.events).toEqual([
+        "worklist",
+        "type",
+        "mint",
+        "map:__str_copy_tree",
+        "push:__str_copy_tree",
+        ...(enabled ? ["type", "mint", "map:__str_utf8_to_flat", "build:decoder", "push:__str_utf8_to_flat"] : []),
+        "build:copy",
+        "type",
+        "mint",
+        "map:__str_flatten",
+        "funcMap:__str_flatten",
+        "empty",
+        "build:flatten",
+        "push:__str_flatten",
+      ]);
+      expect(r.pending[0]).toEqual({ name: "__str_copy_tree", body: 0, locals: 0 });
+      expect(r.captured[0]).toBe(r.ctx.mod.functions[0]);
+      expect(r.captured[0]!.body.length).toBeGreaterThan(0);
+      expect(r.captured[0]!.locals).toHaveLength(7);
+      expect(r.selections).toHaveLength(2);
+      expect(r.selections[0]).toBe(r.selections[1]);
+      expect(r.selections[0]).toEqual(
+        enabled ? { kind: "present", handle: r.ctx.nativeStrHelpers.get("__str_utf8_to_flat") } : { kind: "absent" },
+      );
+    });
+  it("does not reuse a stale decoder map entry in disabled mode", () => {
+    const r = legacy(false, { stale: true });
+    expect(r.error).toBeUndefined();
+    expect(r.ctx.nativeStrHelpers.has("__str_utf8_to_flat")).toBe(true);
+    expect(r.selections).toEqual([{ kind: "absent" }, { kind: "absent" }]);
+    expect(r.events).not.toContain("build:decoder");
+  });
+  it("propagates the exact decoder construction error and leaves the pushed copy object pending", () => {
+    expect(legacy(true).error).toBeUndefined();
+    const sentinel = new Error("decoder construction sentinel");
+    const r = legacy(true, { throwDecoder: sentinel });
+    expect(r.error).toBe(sentinel);
+    expect(r.events).toEqual([
+      "worklist",
+      "type",
+      "mint",
+      "map:__str_copy_tree",
+      "push:__str_copy_tree",
+      "type",
+      "mint",
+      "map:__str_utf8_to_flat",
+      "build:decoder",
+    ]);
+    expect(r.ctx.mod.functions).toHaveLength(1);
+    expect(r.ctx.mod.functions[0]).toBe(r.captured[0]);
+    expect(r.captured[0]!.body).toEqual([]);
+    expect(r.captured[0]!.locals).toEqual([]);
+    expect(r.selections).toEqual([]);
+  });
+  it("disabled copy body and all seven locals equal the complete original checked source", () => {
+    const r = legacy(false);
+    expect(r.error).toBeUndefined();
+    const path = "src/runtime/wasmgc/values/string-flatten-bodies.ts";
+    const url = new URL("../" + path, import.meta.url).href;
+    const original = projectCopyTreeUtf8(read(path), url, url, sha).text;
+    const build = evaluate(original, ["buildStringCopyTreeDefinition"], {}).buildStringCopyTreeDefinition!;
+    const expected = build(r.ctx, r.worklists[0]);
+    expect(r.captured[0]!.body).toEqual(expected.body);
+    expect(r.captured[0]!.locals).toEqual(expected.locals);
+  });
+  for (const field of ["utf8StrTypeIdx", "utf8StrDataTypeIdx"] as const)
+    for (const invalid of [-1, NaN, 1.5])
+      it("rejects present decoder with invalid " + field + "=" + invalid, () => {
+        const state = reserve(),
+          { pack, strings } = state;
+        const binding = { kind: "present" as const, handle: pack.utf8Decoder!.handle };
+        expect(buildStringCopyTreeDefinition(strings.layout, pack.worklist.typeIndex, binding).locals).toHaveLength(7);
+        expect(() =>
+          buildStringCopyTreeDefinition({ ...strings.layout, [field]: invalid }, pack.worklist.typeIndex, binding),
+        ).toThrow("decoder requires UTF8 layout");
+      });
+});
+
+describe("actual public long concat uses the repaired shared flatten path", () => {
+  for (const experimentalIR of [false, true])
+    for (const utf8Storage of [false, true])
+      it(
+        "IR=" + experimentalIR + " UTF8=" + utf8Storage,
+        async () => {
+          const source =
+            "function join(a: string, b: string): string { return a + b; }\n" +
+            'export function probe(flag: number): number { const a = flag ? "' +
+            "x".repeat(64) +
+            '" : "' +
+            "y".repeat(64) +
+            '"; const b = flag ? "é" : "Ω"; return join(a, b).charCodeAt(64); }';
+          expect(sha(source)).toBe("81efa68899db0020c346843ecac041348e573af3079605e2a3c1ab7c3f953e03");
+          const options = {
+            fileName: "e1-long-concat.ts",
+            target: "standalone" as const,
+            nativeStrings: true,
+            utf8Storage,
+            experimentalIR,
+            optimize: false,
+            emitWat: true,
+          };
+          const result = await compile(source, options);
+          expect(result.success, JSON.stringify(result.errors)).toBe(true);
+          if (!result.binary || !result.wat) throw Error("missing public compiler artifacts");
+          const binary = Uint8Array.from(result.binary),
+            compiled = new WebAssembly.Module(binary);
+          expect(WebAssembly.Module.imports(compiled)).toEqual([]);
+          const observations = [];
+          for (let instance = 0; instance < 2; instance++) {
+            const wasm = new WebAssembly.Instance(compiled, {});
+            const run = wasm.exports.probe as (flag: number) => number;
+            for (let repeat = 0; repeat < 2; repeat++)
+              for (const argument of [1, 0]) {
+                const expected = argument ? 233 : 937;
+                try {
+                  observations.push({ instance, repeat, argument, value: run(argument), expected });
+                } catch (error) {
+                  observations.push({
+                    instance,
+                    repeat,
+                    argument,
+                    expected,
+                    error:
+                      error instanceof Error
+                        ? { name: error.name, message: error.message, stack: error.stack }
+                        : { thrown: String(error) },
+                  });
+                }
+              }
+          }
+          writeFileSync(
+            resolve(evidenceDirectory(), "public.json"),
+            JSON.stringify(
+              {
+                source,
+                options,
+                binary: Buffer.from(binary).toString("base64"),
+                instantiatedBinary: Buffer.from(binary).toString("base64"),
+                wat: result.wat,
+                imports: WebAssembly.Module.imports(compiled),
+                exports: WebAssembly.Module.exports(compiled),
+                observations,
+                enabledByteParityClaimed: false,
+              },
+              null,
+              2,
+            ),
+          );
+          for (const observation of observations) expect(observation).toMatchObject({ value: observation.expected });
+        },
+        120000,
+      );
+});


### PR DESCRIPTION
Extract binary/batched concat and stdout bodies into runtime owners while preserving the live adapters. Repair UTF8 rope traversal so every leaf, including popped right children, receives the actual decoder dependency.

## Current-main validation (2026-09-14)

Refreshed against main `987ed50ca832a56701246d926688878754881f97`. All fourteen published source/test/proof files remain byte-identical; metadata retains both issue histories and main's full policy plus the two original runtime classifications.

- 724/724 tests across eleven complete extraction, preservation, UTF8, resource, caller and boundary suites; zero skips or input drift.
- Previously pending full scanner comparison now passes: pinned `a6cc59a2cdfad5141d75faadf1530a9de63bebd7` baseline, actual candidate and preservation projection each execute 66 rows / 132 calls (64 original scenarios + two malformed-number probes), with zero comparison differences. Byte/WAT/order/value parity concerns baseline versus projection; actual candidate has separate semantic expectations.
- TS7 and all seven source gates pass. Inventory, kind, dialect, JsTag, layering, pushRaw and fallback checks pass. An initial fallback launcher socket-path error is retained; the same checker passes via direct `node --import tsx` invocation.
- Independently verified pinned corpus: 53,933 raw blobs, exact path sets, clean own checkout, no shared objects.

## Historical publication evidence (preserved)

- Original failed evidence retained: E1 56/84, then combined 293/301 with eight
  child-argv proof errors. No failing row was removed.
- E1 84/84, repair 75/75 and flatten 61/61 passed; corrected argv suite 81/81.
- Parent recovery reran the two post-format E1 suites against committed
  03d0615e34da8629971659d8c5937b8483f57643: session 52680 exited zero,
  84/84 passed in 15.23 seconds. The previous process handle was unavailable;
  its complete 84/84 report remains retained, not substituted or overwritten.
- TS7 exited 0 with unchanged production. Parent normal push session 48796
  exited zero, including typecheck, lint, formatting, ratchets, issue integrity
  and 18/18 numeric-parity tests.
- Actual inventory validation exited 0: 1,353 modules, zero errors, inventory
  valid; architecture remains incomplete. Required-root coverage is not expanded.
- Four public compiler children exited 0: 8 compilations, 16 instances, 64 calls.
  Candidate 32/32 correct; baseline 24/32 plus eight expected illegal casts.
- Both UTF8-disabled pairs retain exact bytes/WAT/ordering/outcomes. Enabled
  differences remain explicit. The comparison-only correction and six corruption
  controls passed without recompilation.
- The original controller exit 1 is retained: it invented a required warnings
  field absent from the actual CompileResult. This was a comparator error, not
  a compiler failure or a waived semantic result.

Full scope, hashes, exact terminal receipts and limitations:
`plan/agent-context/3518-native-string-output-extraction-handoff-2026-09-09.md`.

## Delivery scope

The earlier caller/scanner validation gap is now measured above. Protected queue admission and verified main delivery remain pending. The two new classifications do not expand activation roots, minima, edges, history or negative controls. Complete output/async execution, public IR-only default and frontend retirement remain unfinished.

Refs plan issue3518 — IR-only default and direct front-end retirement.
