### PR TITLE
fix(wasmgc): authenticate native value resource completion

### DIFF
--- a/plan/agent-context/3518-native-values-completion-checkpoint-handoff-2026-09-09.md
+++ b/plan/agent-context/3518-native-values-completion-checkpoint-handoff-2026-09-09.md
@@ -1,0 +1,74 @@
+# Native values completion checkpoint
+
+This isolated checkpoint starts at published
+`33954266647300786ad06875688b33bbf1196d04` and supplies producer completion
+authentication, not full Promise/async materialization or retirement proof.
+
+## Scope and provenance
+
+The worker owns `src/backend/wasmgc/resources/native-values.ts` and
+`tests/issue-3518-native-value-resources.test.ts` under verified claim
+`3518:native-values-completion`, owner `ttraenkler/codex-native-values-completion`,
+write `37253-cfvi49ko`, claim commit `2cf23eb56f73ea809a4ee09498626da431f7fd0c`.
+Historical claims and frozen E2/B3/inliner work remain preserved.
+
+Parent explicitly handed off the following exact integration changes:
+
+- `src/wasm/physical/module-reservations.ts`: only the existing-map-based
+  `assertCompletedReservation` method; no new registry or allocator change.
+- `tests/issue-3518-reservation-completion-assertion.test.ts`: 15 ledger controls.
+- `src/backend/wasmgc/program/native-string-values.ts`: only the completion
+  accessor import, missing issued-plan guard, and numeric-branch call.
+- `tests/issue-3518-native-scanner-value-chain.test.ts`: completion observations,
+  exact returned-pack use, and four original/decoded × UTF storage cells.
+
+No E2 output requirements/options, shared flatten restructuring, concat emitter,
+generic callable admission, B3 wrappers, or mixed planner changes are included.
+The numeric source fixtures use APIs already present at the pinned base.
+
+The producer records success only after all four real fill calls. Completion
+requires its exact issued plan and retained dependencies, the existing ledger's
+actual function/global fill-map membership and snapshots, canonical type checks,
+and real scanner completion for native-string mode. It allocates, fills, exports
+and seals nothing. Missing/nonthrowing-omitted fills remain rejection controls;
+no recovery after a poisoned ledger is asserted.
+
+## Evidence and limits
+
+Parent's broader composed tree measured session `97495` exit0: 88/88 across
+native-value-resources and native-scanner-value-chain in 30.89 seconds; separate
+ledger controls 15/15; source TS7 session `7411` exit0. These are PARENT results,
+not proof that this extracted candidate passes. All earlier source receipts and
+original test controls are retained; no donor hash reseeding.
+
+Initial extraction left isolated validation pending. The subsequently granted
+serialized slot measured formatting exit0 (all six code/test files unchanged),
+source TS7 session `71740` exit0, three focused suites session `92480` exit0:
+103/103 in 29.03 seconds, and inventory session `34363` exit0 with `errors: []`,
+`architectureComplete: false`. Normal publication hooks follow these receipts.
+No new local Test262 or broad suite is requested. Publication must be a non-draft held PR
+targeting `codex/3518-number-format-consumer-20260909`, not main. Parent exact-head
+review remains mandatory before any merge; no hook/signing bypass is authorized.
+
+## Frozen extraction blob manifest
+
+Git blob identities before isolated validation:
+
+- `src/backend/wasmgc/resources/native-values.ts`: `4539bf5c77ab4d9fd41db188516f3a60dc0f291a`
+- `tests/issue-3518-native-value-resources.test.ts`: `16a022978a737030328f9d952dc9843750eb1d59`
+- `src/wasm/physical/module-reservations.ts`: `16ab305b019661a23b114e3c76ad5f6306de0d06`
+- `tests/issue-3518-reservation-completion-assertion.test.ts`: `9c22aae17c0dd4fb0afdd6f6ea68edbe2c7bf857`
+- `src/backend/wasmgc/program/native-string-values.ts`: `7797d7e73b932295167c8ebc142cc18bdf450cbe`
+- `tests/issue-3518-native-scanner-value-chain.test.ts`: `8214fdae22d18d67d287a34a7dc9337d505913fa`
+
+Scoped diff checking passed. An unscoped diff encountered the existing Git LFS
+shared temporary-directory permission denial; no filters/configuration were
+changed and no affected file was rewritten to work around it.
+
+Reproduction commands (existing pinned dependencies; sequential execution):
+
+```sh
+NODE_OPTIONS=--max-old-space-size=2048 GOMEMLIMIT=2GiB GOMAXPROCS=1 node node_modules/typescript7/lib/tsc.js --noEmit -p tsconfig.ts7.json
+NODE_OPTIONS=--max-old-space-size=2048 VITEST_FORK_MAX_OLD_SPACE_SIZE=2048 VITEST_MAX_FORKS=1 node node_modules/vitest/vitest.mjs run tests/issue-3518-native-value-resources.test.ts tests/issue-3518-native-scanner-value-chain.test.ts tests/issue-3518-reservation-completion-assertion.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+NODE_OPTIONS=--max-old-space-size=2048 node scripts/check-compiler-boundaries.mjs --mode inventory --json
+```

--- a/src/backend/wasmgc/program/native-string-values.ts
+++ b/src/backend/wasmgc/program/native-string-values.ts
@@ -56,6 +56,7 @@ import {
   declareNativeValueResources,
   reserveNativeValueResources,
   fillNativeValueResources,
+  requireCompletedNativeValues,
   type NativeValueReservations,
 } from "../resources/native-values.js";
 
@@ -385,8 +386,12 @@ export function requireCompletedNativeStringValues(
   if (!owner.filled) fail("incomplete native string value resources");
   requireCompletedNativeStringLiterals(tx, pack.strings);
   if (pack.number) {
+    if (!owner.input.valueRequirements) fail("number resources lost their issued value requirements");
     requireCompletedNativeStringFlatten(tx, pack.number.flatten, pack.strings);
     requireCompletedNativeStringNumber(tx, pack.number.scanner, owner.input.valueRequirements!, pack.strings);
+    requireCompletedNativeValues(tx, pack.number.values, owner.input.valueRequirements, {
+      strings: { kind: "native-string", stringPack: pack.strings, scanner: pack.number.scanner },
+    });
   }
   for (const row of owner.rows) tx.physicalIndex(row.reservation);
   return pack;

--- a/src/backend/wasmgc/resources/native-values.ts
+++ b/src/backend/wasmgc/resources/native-values.ts
@@ -135,6 +135,7 @@ interface Owner {
   readonly tx: PhysicalModuleReservations;
   readonly requirements: NativeValueResourcePlan;
   readonly dependency: NativeValueStringDependency;
+  filled: boolean;
 }
 const owners = new WeakMap<NativeValueReservations, Owner>();
 function fail(detail: string): never {
@@ -186,6 +187,7 @@ export function reserveNativeValueResources(
   owners.set(result, {
     tx,
     requirements,
+    filled: false,
     dependency:
       strings.kind === "absent"
         ? Object.freeze({ kind: "absent" })
@@ -244,4 +246,41 @@ export function fillNativeValueResources(
     body: buildUnboxNumberBody(boxedNumber.typeIndex, boxedBoolean.typeIndex, conversion),
   });
   tx.fillFunction(reservations.functions.isNumber, { locals: [], body: buildTypeofNumberBody(boxedNumber.typeIndex) });
+  owner.filled = true;
+}
+
+/** Authenticate successful producer completion without allocating, filling or sealing. */
+export function requireCompletedNativeValues(
+  tx: PhysicalModuleReservations,
+  pack: NativeValueReservations,
+  expectedRequirements: NativeValueResourcePlan,
+  expectedDependencies: NativeValueDependencies,
+): NativeValueReservations {
+  const owner = owners.get(pack);
+  if (!owner || owner.tx !== tx) fail("foreign native value reservations");
+  if (owner.requirements !== expectedRequirements) fail("substituted native value requirements");
+  assertNativeValueResourcePlan(expectedRequirements);
+  const strings = requireDependency(tx, expectedRequirements, expectedDependencies);
+  if (
+    strings.kind !== owner.dependency.kind ||
+    (strings.kind === "native-string" &&
+      (owner.dependency.kind !== "native-string" ||
+        strings.stringPack !== owner.dependency.stringPack ||
+        strings.scanner !== owner.dependency.scanner))
+  )
+    fail("substituted native string conversion dependency");
+  if (!owner.filled) fail("incomplete native value resources");
+  for (const [token, expected] of [
+    [pack.types.anyValue, buildAnyValueType()],
+    [pack.types.boxedNumber, buildBoxNumberType()],
+    [pack.types.boxedBoolean, buildBoxBooleanType()],
+  ] as const) {
+    if (tx.physicalIndex(token) !== token.typeIndex) fail("stale primitive layout coordinate");
+    same(token.object, expected, "altered primitive layout");
+  }
+  tx.assertCompletedReservation(pack.globals.undefined);
+  for (const token of Object.values(pack.functions)) tx.assertCompletedReservation(token);
+  if (strings.kind === "native-string")
+    requireCompletedNativeStringNumber(tx, strings.scanner, expectedRequirements, strings.stringPack);
+  return pack;
 }

--- a/src/wasm/physical/module-reservations.ts
+++ b/src/wasm/physical/module-reservations.ts
@@ -588,6 +588,18 @@ export class PhysicalModuleReservations {
     }
   }
 
+  /** Authenticate producer completion without sealing unrelated reservations. */
+  assertCompletedReservation(token: FunctionReservation | GlobalReservation): void {
+    if (this.#state !== "filling" && this.#state !== "sealed") this.#fail(`completion requested in ${this.#state}`);
+    this.#verifyLayout();
+    this.#owned(token);
+    if (token.kind === "function") {
+      if (!this.#filledFunctions.has(token)) this.#fail(`missing function fill ${token.key}`);
+    } else if (token.kind === "global") {
+      if (!this.#filledGlobals.has(token)) this.#fail(`missing global fill ${token.key}`);
+    } else this.#fail("completion requires a defined function or global");
+  }
+
   fillFunction(token: FunctionReservation, definition: { locals: LocalDef[]; body: Instr[] }): void {
     this.#require("filling");
     this.#owned(token);

--- a/tests/issue-3518-native-scanner-value-chain.test.ts
+++ b/tests/issue-3518-native-scanner-value-chain.test.ts
@@ -1,4 +1,16 @@
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
+import * as nativeValues from "../src/backend/wasmgc/resources/native-values.js";
+import { prepareWholeIrProgram } from "../src/ir/program-preparation.js";
+import { encodePreparedIrProgram, decodePreparedIrProgram } from "../src/ir/program-codec.js";
+import { sourceInput } from "./helpers/typed-program-fixtures.js";
+import { collectNativeStringValueDemands } from "../src/ir/program/native-string-value-demands.js";
+import { deriveNativeValueResourcePlan } from "../src/ir/program/native-value-resources.js";
+import {
+  planNativeStringValuePhysical,
+  reserveNativeStringValueResources,
+  fillNativeStringValueResources,
+  requireCompletedNativeStringValues,
+} from "../src/backend/wasmgc/program/native-string-values.js";
 import { createEmptyModule } from "../src/ir/types.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
@@ -9,6 +21,7 @@ import {
   reserveNativeStringLiteralResources,
   fillNativeStringLiteralResources,
   requireNativeStringLiteral,
+  reserveNativeStringLiteralTypes,
 } from "../src/backend/wasmgc/resources/native-string-literals.js";
 import {
   reserveNativeStringFlattenResources,
@@ -21,7 +34,91 @@ import {
 import {
   reserveNativeValueResources,
   fillNativeValueResources,
+  requireCompletedNativeValues,
 } from "../src/backend/wasmgc/resources/native-values.js";
+
+for (const replay of [false, true])
+  for (const utf8Storage of [false, true]) {
+    it(`aggregate consumes the completed value producer, replay=${replay}, UTF8=${utf8Storage}`, async () => {
+      const policy = {
+        backend: "wasmgc",
+        target: "standalone",
+        stringConst: { storage: "native" },
+        stringConcat: { concat: "native" },
+        numberBoundary: { box: "unsupported", unbox: "native" },
+      } as const;
+      const original = requireProgram(
+        prepareWholeIrProgram({
+          ...sourceInput({
+            "./entry.ts":
+              'export function parse(s: string): number { return +s; } export function literal(): string { return "42"; }',
+          }),
+          policy,
+          nativeStringValueProjection: "standalone-native",
+        }),
+      );
+      const program = replay ? decodePreparedIrProgram(encodePreparedIrProgram(original)) : original;
+      const projection = program.runtime[0]!,
+        demands = collectNativeStringValueDemands(program, projection);
+      const planned = planNativeStringValuePhysical(demands, { representation: "native-string", utf8Storage });
+      if (planned.kind !== "planned") throw new Error(JSON.stringify(planned));
+      const valueRequirements = deriveNativeValueResourcePlan(program, projection, "native-string");
+      const module = createEmptyModule(),
+        tx = new PhysicalModuleReservations(module);
+      const types = reserveNativeStringLiteralTypes(tx, planned.plan.key, utf8Storage);
+      const pack = reserveNativeStringValueResources(tx, { demands, plan: planned.plan, valueRequirements }, types);
+      if (!pack.number) throw new Error("genuine unbox source must select numeric resources");
+      const probe = tx.reserveFunction("completion:probe", "completionProbe", {
+        params: [],
+        results: [{ kind: "f64" }],
+      });
+      tx.freezeReservations();
+      fillNativeStringValueResources(tx, pack);
+      expect(requireCompletedNativeStringValues(tx, pack)).toBe(pack);
+      const sentinel = new Error("value producer completion omitted");
+      const spy = vi.spyOn(nativeValues, "requireCompletedNativeValues").mockImplementation(() => {
+        throw sentinel;
+      });
+      try {
+        let caught: unknown;
+        try {
+          requireCompletedNativeStringValues(tx, pack);
+        } catch (error) {
+          caught = error;
+        }
+        expect(caught).toBe(sentinel);
+        expect(spy).toHaveBeenCalledTimes(1);
+        const [actualTx, actualPack, actualRequirements, actualDependencies] = spy.mock.calls[0]!;
+        expect(actualTx).toBe(tx);
+        expect(actualPack).toBe(pack.number.values);
+        expect(actualRequirements).toBe(valueRequirements);
+        expect(actualDependencies.strings.kind).toBe("native-string");
+        if (actualDependencies.strings.kind !== "native-string") throw new Error("expected real scanner dependency");
+        expect(actualDependencies.strings.stringPack).toBe(pack.strings);
+        expect(actualDependencies.strings.scanner).toBe(pack.number.scanner);
+      } finally {
+        spy.mockRestore();
+      }
+      expect(requireCompletedNativeStringValues(tx, pack)).toBe(pack);
+      const demand = planned.plan.literalRequirements.literals.find((row) => row.value === "42");
+      if (!demand) throw new Error("source literal must survive preparation");
+      const literal = requireNativeStringLiteral(tx, pack.strings, "42", demand.encoding);
+      if (literal.kind !== "global") throw new Error("short source literal uses a real global");
+      tx.fillFunction(probe, {
+        locals: [],
+        body: [
+          { op: "global.get", index: tx.physicalIndex(literal.global) },
+          { op: "extern.convert_any" },
+          { op: "call", funcIdx: pack.number.values.functions.unboxNumber.handle },
+        ],
+      });
+      tx.defineExport("completion:export", "probe", probe);
+      tx.seal();
+      expect(requireCompletedNativeStringValues(tx, pack)).toBe(pack);
+      const { instance } = await WebAssembly.instantiate(emitBinary(module) as BufferSource, {});
+      expect((instance.exports.probe as () => number)()).toBe(42);
+    });
+  }
 
 it.each(["other-issued-plan", "cloned-plan", "other-string-pack", "cloned-scanner"] as const)(
   "rejects %s before native-value allocations after a genuine positive",
@@ -105,7 +202,9 @@ it("refuses an unfilled scanner and permits the same value reservation after can
   expect({ functions: module.functions, globals: module.globals }).toEqual(before);
   fillNativeStringNumberResources(tx, scanner);
   fillNativeValueResources(tx, values, deps);
+  expect(requireCompletedNativeValues(tx, values, plan, deps)).toBe(values);
   tx.seal();
+  expect(requireCompletedNativeValues(tx, values, plan, deps)).toBe(values);
   const compiled = new WebAssembly.Module(emitBinary(module) as BufferSource);
   expect(WebAssembly.Module.imports(compiled)).toEqual([]);
   expect(() => new WebAssembly.Instance(compiled, {})).not.toThrow();
@@ -166,6 +265,8 @@ it.each([false, true])("executes real literal, flatten, scanner and unbox produc
   fillNativeStringFlattenResources(tx, flatten);
   fillNativeStringNumberResources(tx, scanner);
   fillNativeValueResources(tx, values, deps);
+  const completed = requireCompletedNativeValues(tx, values, plan, deps);
+  expect(completed).toBe(values);
   probes.forEach((probe, i) => {
     const literal = requireNativeStringLiteral(tx, stringPack, cases[i]![0], encoding(cases[i]![0]));
     if (literal.kind !== "global") throw Error("expected real short literal global");
@@ -174,7 +275,7 @@ it.each([false, true])("executes real literal, flatten, scanner and unbox produc
       body: [
         { op: "global.get", index: tx.physicalIndex(literal.global) },
         { op: "extern.convert_any" },
-        { op: "call", funcIdx: values.functions.unboxNumber.handle },
+        { op: "call", funcIdx: completed.functions.unboxNumber.handle },
       ],
     });
     tx.defineExport(`export:${i}`, `probe${i}`, probe);

--- a/tests/issue-3518-native-value-resources.test.ts
+++ b/tests/issue-3518-native-value-resources.test.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { setImmediate } from "node:timers/promises";
 import ts from "typescript";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyModule } from "../src/ir/types.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { PhysicalModuleReservations } from "../src/wasm/physical/module-reservations.js";
@@ -20,11 +20,13 @@ import {
 import {
   reserveNativeValueResources,
   fillNativeValueResources,
+  requireCompletedNativeValues,
   type NativeValueDependencies,
 } from "../src/backend/wasmgc/resources/native-values.js";
 import { buildUnboxNumberBody } from "../src/runtime/wasmgc/values/number-bodies.js";
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await setImmediate();
 });
 const policy = { backend: "wasmgc", target: "standalone" } as const;
@@ -47,11 +49,10 @@ let cached: ReturnType<typeof prepare> | undefined;
 const actual = () => (cached ??= prepare());
 const absent = (): NativeValueDependencies => ({ strings: { kind: "absent" } });
 
-function reserve() {
+function reserve(plan = actual().plan) {
   const module = createEmptyModule(),
     tx = new PhysicalModuleReservations(module);
-  const dependencies = absent(),
-    plan = actual().plan;
+  const dependencies = absent();
   const pack = reserveNativeValueResources(tx, plan, dependencies);
   const f64 = { kind: "f64" } as const,
     i32 = { kind: "i32" } as const,
@@ -61,14 +62,16 @@ function reserve() {
   const boolean = tx.reserveFunction("control:boolean", "boolean", { params: [i32], results: [extern] });
   const undefinedValue = tx.reserveFunction("control:undefined", "undefinedValue", { params: [], results: [extern] });
   const tag = tx.reserveFunction("control:tag", "tag", { params: [], results: [i32] });
-  return { module, tx, dependencies, pack, roundtrip, small, boolean, undefinedValue, tag };
+  return { module, tx, dependencies, plan, pack, roundtrip, small, boolean, undefinedValue, tag };
 }
 
-function filled() {
-  const state = reserve();
-  const { tx, pack, dependencies, roundtrip, small, boolean, undefinedValue, tag } = state;
+function filled(plan = actual().plan) {
+  const state = reserve(plan);
+  const { tx, dependencies, roundtrip, small, boolean, undefinedValue, tag } = state;
   tx.freezeReservations();
-  fillNativeValueResources(tx, pack, dependencies);
+  fillNativeValueResources(tx, state.pack, dependencies);
+  const pack = requireCompletedNativeValues(tx, state.pack, plan, dependencies);
+  expect(pack).toBe(state.pack);
   tx.fillFunction(roundtrip, {
     locals: [],
     body: [
@@ -128,9 +131,10 @@ interface Exports {
   undefinedValue(): unknown;
   tag(): number;
 }
-function execute() {
-  const { module, tx } = filled();
+function execute(plan = actual().plan) {
+  const { module, tx, pack, dependencies } = filled(plan);
   const census = tx.seal();
+  expect(requireCompletedNativeValues(tx, pack, plan, dependencies)).toBe(pack);
   const binary = emitBinary(module);
   const compiled = new WebAssembly.Module(binary as BufferSource);
   expect(WebAssembly.Module.imports(compiled)).toEqual([]);
@@ -276,6 +280,146 @@ describe("native primitive resources: executed bodies, not signature-only admiss
     state.pack.globals.undefined.object.init[index] = { op: "i32.const", value: 42 };
     expect(() => state.tx.seal()).toThrow("altered");
   });
+});
+
+describe("native value producer completion authority", () => {
+  it("returns exact pack with a fresh containing dependency record without side effects", () => {
+    const state = filled();
+    const before = structuredClone(state.module);
+    const spies = [
+      vi.spyOn(state.tx, "reserveType"),
+      vi.spyOn(state.tx, "reserveFunction"),
+      vi.spyOn(state.tx, "reserveGlobal"),
+      vi.spyOn(state.tx, "internFunctionType"),
+      vi.spyOn(state.tx, "fillFunction"),
+      vi.spyOn(state.tx, "fillGlobal"),
+      vi.spyOn(state.tx, "defineExport"),
+      vi.spyOn(state.tx, "seal"),
+    ];
+    expect(requireCompletedNativeValues(state.tx, state.pack, state.plan, absent())).toBe(state.pack);
+    expect(state.tx.state).toBe("filling");
+    expect(state.module).toStrictEqual(before);
+    spies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+  it("executes decoded source-bound resources through completion before and after seal", () => {
+    const x = execute(prepare(true).plan).exports;
+    for (const value of [-1073741824, 1073741823, 70, 3e9, -0, 1.5, NaN, Infinity, -Infinity]) {
+      expect(Object.is(x.roundtrip(value), value)).toBe(true);
+      expect(x.isNumber(x.box(value))).toBe(1);
+    }
+    expect(x.tag()).toBe(1);
+    expect(x.unbox(x.undefinedValue())).toBeNaN();
+    expect(x.unbox(null)).toBe(0);
+    expect(x.unbox(x.boolean(1))).toBe(1);
+  });
+  it("rejects a distinct genuinely issued equal-visible plan", () => {
+    const state = filled();
+    expect(requireCompletedNativeValues(state.tx, state.pack, state.plan, state.dependencies)).toBe(state.pack);
+    const { program, projection } = actual();
+    const other = deriveNativeValueResourcePlan(program, projection, "primitive-only");
+    assertNativeValueResourcePlan(other);
+    expect(other).toEqual(state.plan);
+    expect(other).not.toBe(state.plan);
+    expect(() => requireCompletedNativeValues(state.tx, state.pack, other, state.dependencies)).toThrow(
+      "substituted native value requirements",
+    );
+  });
+  it("rejects foreign transactions and copied packs after a real completion", () => {
+    const state = filled();
+    expect(requireCompletedNativeValues(state.tx, state.pack, state.plan, state.dependencies)).toBe(state.pack);
+    expect(() =>
+      requireCompletedNativeValues(
+        new PhysicalModuleReservations(createEmptyModule()),
+        state.pack,
+        state.plan,
+        state.dependencies,
+      ),
+    ).toThrow("foreign");
+    expect(() => requireCompletedNativeValues(state.tx, { ...state.pack }, state.plan, state.dependencies)).toThrow(
+      "foreign",
+    );
+  });
+  it("rejects a genuine unfilled pack without marking it completed", () => {
+    const positive = filled();
+    expect(requireCompletedNativeValues(positive.tx, positive.pack, positive.plan, positive.dependencies)).toBe(
+      positive.pack,
+    );
+    const state = reserve();
+    state.tx.freezeReservations();
+    expect(() => requireCompletedNativeValues(state.tx, state.pack, state.plan, state.dependencies)).toThrow(
+      "incomplete native value resources",
+    );
+    expect(state.tx.state).toBe("filling");
+  });
+  for (const stopped of [0, 1, 2, 3])
+    it(`rejects real producer interrupted at fill ${stopped}`, () => {
+      const positive = filled();
+      expect(requireCompletedNativeValues(positive.tx, positive.pack, positive.plan, positive.dependencies)).toBe(
+        positive.pack,
+      );
+      const state = reserve();
+      state.tx.freezeReservations();
+      const sentinel = new Error("stop actual fill " + stopped);
+      const global = state.tx.fillGlobal.bind(state.tx),
+        fn = state.tx.fillFunction.bind(state.tx);
+      let calls = 0;
+      vi.spyOn(state.tx, "fillGlobal").mockImplementation((...args) => {
+        if (calls++ === stopped) throw sentinel;
+        return global(...args);
+      });
+      vi.spyOn(state.tx, "fillFunction").mockImplementation((...args) => {
+        if (calls++ === stopped) throw sentinel;
+        return fn(...args);
+      });
+      let caught: unknown;
+      try {
+        fillNativeValueResources(state.tx, state.pack, state.dependencies);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBe(sentinel);
+      expect(calls).toBe(stopped + 1);
+      expect(state.tx.state).toBe("filling");
+      expect(() => requireCompletedNativeValues(state.tx, state.pack, state.plan, state.dependencies)).toThrow(
+        "incomplete native value resources",
+      );
+    });
+  // Mandatory countermodels: returning from an intercepted ledger operation is
+  // not proof that its token entered the ledger's successful-fill map.
+  for (const omitted of [0, 1, 2, 3])
+    it(`rejects nonthrowing omission of fill ${omitted}`, () => {
+      const positive = filled();
+      expect(requireCompletedNativeValues(positive.tx, positive.pack, positive.plan, positive.dependencies)).toBe(
+        positive.pack,
+      );
+      const state = reserve();
+      state.tx.freezeReservations();
+      const global = state.tx.fillGlobal.bind(state.tx),
+        fn = state.tx.fillFunction.bind(state.tx);
+      let calls = 0;
+      vi.spyOn(state.tx, "fillGlobal").mockImplementation((...args) => {
+        if (calls++ === omitted) return;
+        return global(...args);
+      });
+      vi.spyOn(state.tx, "fillFunction").mockImplementation((...args) => {
+        if (calls++ === omitted) return;
+        return fn(...args);
+      });
+      fillNativeValueResources(state.tx, state.pack, state.dependencies);
+      expect(calls).toBe(4);
+      expect(() => requireCompletedNativeValues(state.tx, state.pack, state.plan, state.dependencies)).toThrow();
+    });
+  for (const mutation of ["body", "locals", "initializer", "type"] as const)
+    it(`rejects post-fill ${mutation} drift via completion accessor`, () => {
+      const state = filled();
+      expect(requireCompletedNativeValues(state.tx, state.pack, state.plan, state.dependencies)).toBe(state.pack);
+      if (mutation === "body") state.pack.functions.boxNumber.object.body.push({ op: "unreachable" });
+      if (mutation === "locals")
+        state.pack.functions.unboxNumber.object.locals.push({ name: "foreign", type: { kind: "i32" } });
+      if (mutation === "initializer") state.pack.globals.undefined.object.init[0] = { op: "i32.const", value: 42 };
+      if (mutation === "type") state.pack.types.boxedBoolean.object.name = "foreign";
+      expect(() => requireCompletedNativeValues(state.tx, state.pack, state.plan, state.dependencies)).toThrow();
+    });
 });
 
 // Fixed 5118637 donor receipts. Tests read mandatory LIVE files only. Whitespace

--- a/tests/issue-3518-reservation-completion-assertion.test.ts
+++ b/tests/issue-3518-reservation-completion-assertion.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { expect, it } from "vitest";
+import { createEmptyModule } from "../src/ir/types.js";
+import { PhysicalModuleReservations, type FunctionReservation } from "../src/wasm/physical/module-reservations.js";
+
+function setup() {
+  const module = createEmptyModule(),
+    tx = new PhysicalModuleReservations(module);
+  const fn = tx.reserveFunction("complete:fn", "completeFn", { params: [], results: [] });
+  const global = tx.reserveGlobal("complete:global", "completeGlobal", { kind: "i32" }, false);
+  return { module, tx, fn, global };
+}
+function filled() {
+  const value = setup();
+  value.tx.freezeReservations();
+  value.tx.fillFunction(value.fn, { locals: [], body: [] });
+  value.tx.fillGlobal(value.global, [{ op: "i32.const", value: 7 }]);
+  return value;
+}
+
+it("checks actual fills before and after seal without allocating or publishing", () => {
+  const { module, tx, fn, global } = filled();
+  for (const phase of ["filling", "sealed"] as const) {
+    if (phase === "sealed") tx.seal();
+    const before = structuredClone(module),
+      bodies = fn.object.body,
+      locals = fn.object.locals,
+      init = global.object.init;
+    expect(tx.assertCompletedReservation(fn)).toBeUndefined();
+    expect(tx.assertCompletedReservation(global)).toBeUndefined();
+    expect(tx.state).toBe(phase);
+    expect(module).toStrictEqual(before);
+    expect(fn.object.body).toBe(bodies);
+    expect(fn.object.locals).toBe(locals);
+    expect(global.object.init).toBe(init);
+  }
+});
+
+it("does not demand completion of an unrelated reserved function", () => {
+  const { tx, fn, global } = setup();
+  const pending = tx.reserveFunction("pending", "pending", { params: [], results: [] });
+  tx.freezeReservations();
+  tx.fillFunction(fn, { locals: [], body: [] });
+  tx.fillGlobal(global, [{ op: "i32.const", value: 7 }]);
+  expect(() => tx.assertCompletedReservation(fn)).not.toThrow();
+  expect(() => tx.assertCompletedReservation(global)).not.toThrow();
+  expect(tx.physicalIndex(pending)).toBeGreaterThanOrEqual(0);
+  expect(() => tx.assertCompletedReservation(pending)).toThrow("missing function fill pending");
+});
+
+it.each(["function", "global"] as const)("index existence is not %s completion", (kind) => {
+  const positive = filled();
+  expect(() =>
+    positive.tx.assertCompletedReservation(kind === "function" ? positive.fn : positive.global),
+  ).not.toThrow();
+  const { tx, fn, global } = setup();
+  tx.freezeReservations();
+  const token = kind === "function" ? fn : global;
+  expect(tx.physicalIndex(token)).toBeGreaterThanOrEqual(0);
+  expect(() => tx.assertCompletedReservation(token)).toThrow(`missing ${kind} fill ${token.key}`);
+  expect(tx.state).toBe("failed");
+});
+
+it.each(["function", "global"] as const)("rejects %s completion while reserving", (kind) => {
+  const { tx, fn, global } = setup();
+  expect(() => tx.assertCompletedReservation(kind === "function" ? fn : global)).toThrow(
+    "completion requested in reserving",
+  );
+});
+
+for (const kind of ["function", "global"] as const)
+  for (const mutation of ["copied", "foreign"] as const) {
+    it(`rejects ${mutation} ${kind} tokens after genuine completion`, () => {
+      const a = filled(),
+        token = kind === "function" ? a.fn : a.global;
+      expect(() => a.tx.assertCompletedReservation(token)).not.toThrow();
+      const b = filled(),
+        other = kind === "function" ? b.fn : b.global;
+      expect(() => a.tx.assertCompletedReservation(mutation === "copied" ? { ...token } : other)).toThrow(
+        "foreign or forged reservation token",
+      );
+    });
+  }
+
+it("rejects a genuine owned token of the wrong resource kind", () => {
+  const { tx, fn, global } = setup();
+  const type = tx.reserveType("not-a-fill", { kind: "struct", name: "NotAFill", fields: [] });
+  tx.freezeReservations();
+  tx.fillFunction(fn, { locals: [], body: [] });
+  tx.fillGlobal(global, [{ op: "i32.const", value: 7 }]);
+  expect(() => tx.assertCompletedReservation(fn)).not.toThrow();
+  expect(() => tx.assertCompletedReservation(type as unknown as FunctionReservation)).toThrow(
+    "completion requires a defined function or global",
+  );
+});
+
+it.each(["body", "locals", "initializer", "descriptor"] as const)("rejects altered completed %s", (mutation) => {
+  const { tx, fn, global } = filled();
+  tx.assertCompletedReservation(fn);
+  tx.assertCompletedReservation(global);
+  if (mutation === "body") fn.object.body = [...fn.object.body];
+  if (mutation === "locals") fn.object.locals = [...fn.object.locals];
+  if (mutation === "initializer") global.object.init = [...global.object.init];
+  if (mutation === "descriptor") global.object.mutable = true;
+  expect(() =>
+    tx.assertCompletedReservation(mutation === "initializer" || mutation === "descriptor" ? global : fn),
+  ).toThrow(/altered/);
+});


### PR DESCRIPTION
## Summary

- Authenticate native value completion against the exact issued plan, retained dependencies, canonical type snapshots and actual ledger function/global fill membership.
- Join the completed producer into the numeric string-value aggregate without E2 output/concat changes.
- Preserve primitive bodies/allocation order; cover omitted fills, mutations, foreign owners and genuine original/decoded execution.

Stacked on `codex/3518-number-format-consumer-20260909` at `33954266647300786ad06875688b33bbf1196d04` (PR #5798, “feat(ir): plan prepared formatter requirements and shared scratch”). **HOLD: parent exact-head review required. No merge/enqueue/auto-merge requested.**

## Validation

- Scoped formatting: passed, six code/test files unchanged.
- Source TS7: session 71740 exit0, 2 GiB/one Go worker.
- Three focused suites: session 92480 exit0, **103/103**, 29.03 seconds, one 2 GiB fork, no unhandled errors.
- Inventory: session 34363 exit0, zero errors; `architectureComplete: false`.
- Normal commit hooks: session 47144 exit0. Existing changed-root hook skipped its inherited 108-file population under its >20 rule; this is not additional test coverage.

Parent composed evidence was independently 88/88 plus ledger15/15 and source TS7; the isolated results above supersede the extraction's pending-validation status without claiming broader coverage. No full async materialization or retirement claim.

Durable scope, frozen blob manifest and reproduction commands: `plan/agent-context/3518-native-values-completion-checkpoint-handoff-2026-09-09.md`.
