### PR TITLE
perf(checker): type-check only user files for semantic diagnostics

### DIFF
--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -309,6 +309,28 @@ function getLibSource(name: string): string | undefined {
 }
 
 /** Check if a file name is a known lib file */
+/**
+ * Semantic diagnostics for the USER's files only — never for the bundled
+ * `lib.*.d.ts` roots.
+ *
+ * `getUserSemanticDiagnostics(program)` with no argument type-checks every source
+ * file in the program, and the default-library files are ~440 of them. On a
+ * five-line input that is ~2.2 s of checker time against ~0.19 s for the user
+ * file alone (measured 2026-09-10, TypeScript 5.9, `lib.es2022.full` + DOM).
+ * The lib diagnostics were never surfaced anyway; every consumer filters by
+ * the user's file names. Files still get checked lazily whenever codegen asks
+ * the checker a type question, so type-directed lowering is unaffected — only
+ * the eager full-lib walk is skipped.
+ */
+export function getUserSemanticDiagnostics(program: ts.Program): ts.Diagnostic[] {
+  const out: ts.Diagnostic[] = [];
+  for (const sf of program.getSourceFiles()) {
+    if (program.isSourceFileDefaultLibrary(sf) || isKnownLibName(sf.fileName)) continue;
+    out.push(...program.getSemanticDiagnostics(sf));
+  }
+  return out;
+}
+
 export function isKnownLibName(name: string): boolean {
   return (
     name === DOM_LIB_NAME ||
@@ -1029,7 +1051,7 @@ export function analyzeSource(source: string, fileName = "input.ts", analyzeOpti
     const syn = dropEntryDecls(prog.getSyntacticDiagnostics());
     const sem = analyzeOptions?.skipSemanticDiagnostics
       ? ([] as readonly ts.Diagnostic[])
-      : dropEntryDecls(prog.getSemanticDiagnostics());
+      : dropEntryDecls(getUserSemanticDiagnostics(prog));
     return { prog, syn, sem };
   }
 
@@ -1160,7 +1182,7 @@ export function analyzeMultiSource(
   const syntacticDiagnostics = program.getSyntacticDiagnostics();
   const semanticDiagnostics = analyzeOptions?.skipSemanticDiagnostics
     ? ([] as ts.Diagnostic[])
-    : program.getSemanticDiagnostics();
+    : getUserSemanticDiagnostics(program);
   // #2815 — drop the benign "Cannot find name 'Deno'" on the natively-lowered
   // Deno stdio surface (this path injects no ambient `Deno` d.ts, unlike #2684).
   const diagnostics = filterRecognizedDenoStdioDiagnostics([...syntacticDiagnostics, ...semanticDiagnostics]);
@@ -1369,7 +1391,7 @@ export function analyzeFiles(entryPath: string, analyzeOptions?: AnalyzeOptions)
   const syntacticDiagnostics = program.getSyntacticDiagnostics();
   const semanticDiagnostics = analyzeOptions?.skipSemanticDiagnostics
     ? ([] as ts.Diagnostic[])
-    : program.getSemanticDiagnostics();
+    : getUserSemanticDiagnostics(program);
   // #2815 — drop the benign "Cannot find name 'Deno'" on the natively-lowered
   // Deno stdio surface (this path injects no ambient `Deno` d.ts, unlike #2684).
   const diagnostics = filterRecognizedDenoStdioDiagnostics([...syntacticDiagnostics, ...semanticDiagnostics]);

--- a/src/checker/language-service.ts
+++ b/src/checker/language-service.ts
@@ -1,7 +1,12 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { ts } from "../ts-api.js";
 import type { AnalyzeOptions, MultiTypedAST, TypedAST } from "./index.js";
-import { filterRecognizedDenoStdioDiagnostics, getLibSourceFile, isKnownLibName } from "./index.js";
+import {
+  filterRecognizedDenoStdioDiagnostics,
+  getLibSourceFile,
+  getUserSemanticDiagnostics,
+  isKnownLibName,
+} from "./index.js";
 import {
   buildBareSpecifierLookup,
   multiFileScriptKind,
@@ -436,7 +441,7 @@ export class IncrementalProjectLanguageService {
     const syntacticDiagnostics = program.getSyntacticDiagnostics();
     const semanticDiagnostics = analyzeOptions?.skipSemanticDiagnostics
       ? ([] as ts.Diagnostic[])
-      : program.getSemanticDiagnostics();
+      : getUserSemanticDiagnostics(program);
     const diagnostics = filterRecognizedDenoStdioDiagnostics([...syntacticDiagnostics, ...semanticDiagnostics]);
 
     return {


### PR DESCRIPTION
## What

`program.getSemanticDiagnostics()` with no argument type-checks every source file in the program, including the bundled `lib.*.d.ts` roots. Those lib diagnostics were never surfaced (every consumer filters by the user's files), but the eager full-lib walk was the single largest per-compile cost.

New helper `getUserSemanticDiagnostics(program)` in `src/checker/index.ts` checks only non-default-library files. It replaces the five bare calls in `src/checker/index.ts` and `src/checker/language-service.ts`.

## Measurements

`analyzeSource` on a 5-line class/closure/array sample, TypeScript 5.9:

| | base | this PR |
|---|---|---|
| cold (first compile in process) | 1074 ms | 484 ms |
| warm (subsequent compiles) | 444 ms | 8 ms |

The warm number is what pooled callers (test262 runner, language-service path) pay per file. Found with the [#3946](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3946-compile-phase-profiling) phase profiler plus `--cpu-prof`: `checkSourceElement` on lib interfaces was ~1.9 s of a 4.5 s CLI run.

## Safety

- Emitted binary is byte-identical on the sample (type-directed codegen still resolves lib types lazily via the checker; only the eager full-lib diagnostic walk is skipped).
- `node scripts/equivalence-gate.mjs`: 1720 passing, 22 known failures, no new regressions.
- lint, typecheck, LOC/func budget, coercion-sites, oracle-ratchet, dead-exports: all green.
- `tests/issue-1387-with-diagnostic.test.ts` and `tests/issue-700-test262-language-service.test.ts` fail identically on the base commit (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3vkrGUpsLbRXgNdPEQyra

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3vkrGUpsLbRXgNdPEQyra)_