### PR TITLE
fix(#6411): expand spread arguments in the host Array bridges (restores the #5819 merge-group net)

### DIFF
--- a/plan/issues/6411-host-bridge-concat-spread-not-expanded.md
+++ b/plan/issues/6411-host-bridge-concat-spread-not-expanded.md
@@ -1,0 +1,123 @@
+---
+id: 6411
+title: "The host Array bridges hand a SPREAD argument to the host as one item"
+status: done
+sprint: current
+created: 2026-09-12
+updated: 2026-09-12
+completed: 2026-09-12
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+The same idiom #5361 removed from `splice` / `push` / `Math.min`-`max` / the
+generic `__extern_method_call` bridge survives in the two HOST-ARRAY argument
+builders in `src/codegen/array-method-host.ts`:
+
+- `compileArrayConcatExternHost` — the `__array_concat_any(recv, args)` bridge;
+- `compileArrayMethodExtern` — `__extern_method_call` for a real host-owned
+  Array receiver.
+
+Both build the argument array with `__js_array_new` + one `__js_array_push` per
+AST node, which is exact only while each argument is ONE value. A spread
+contributes its RUNTIME element count, so the source array was handed to the
+host as a single argument and `Array.prototype.concat` then flattened one level
+too few:
+
+```js
+[].concat(...[[], [1], [2, 3]]);   // [[], [1], [2, 3]]  — should be [1, 2, 3]
+```
+
+## Evidence
+
+Found as a REAL merged-baseline test262 regression, not by inspection.
+`test/built-ins/Iterator/concat/many-arguments.js` compares
+
+```js
+let iterator = Iterator.concat(...iterables);
+let array = [].concat(...iterables);
+```
+
+element by element. **Both sides were wrong in the same direction**, so the file
+passed by coincidence: `Iterator.concat(iterables)` yielded the sub-arrays, and
+`[].concat(iterables)` flattened to the same sub-arrays, and `sameValue`
+compared identical objects. #5361 fixed the `Iterator.concat` side; the
+coincidence broke and the file flipped **pass → fail**
+(`Expected SameValue(«1», «») to be true` — `array[0]` was still `[]`).
+
+That is the whole of the `net_per_test -1` that parked PR #5819 in the merge
+queue (run 34680468369, 0 improvements − 1 regression). The `[].concat(...)`
+half is INDEPENDENT of #5361 and predates it — measured with #5361's codegen
+reverted, the same probe produces the same wrong answer.
+
+## Acceptance criteria
+
+1. `[].concat(...arrays)` flattens every spread element, for inline array
+   literals and for host (externref) arrays, with the correct length.
+2. A spread interleaved with positional arguments keeps argument order.
+3. A spread-free call emits byte-identical code (the unrolled loop is kept).
+4. `built-ins/Iterator/concat/many-arguments` passes again.
+5. Regression test pinning length AND a non-comma-joined value.
+
+## Resolution
+
+Fixed. `tryEmitSpreadHostArgs` (`src/codegen/host-method-args.ts`) is the
+shared entry both bridges now call before their own unrolled loop: with a
+spread present it drives #5361's `buildSpreadArgList` with a
+`__js_array_push` sink; with no spread it returns `false` without emitting
+anything and each caller keeps its existing loop verbatim.
+`emitHostMethodCallArgs` (the #5361 caller) is re-expressed on top of it, so
+there is ONE place where the syntactic-vs-runtime argument count is repaired
+rather than a sixth copy of the loop.
+
+### Measured
+
+Scoped test262 slice — every file under `built-ins/Array/prototype/concat`,
+`built-ins/Array/prototype/push`, `built-ins/Array/prototype/splice` and
+`built-ins/Iterator/concat`, **206 files, `--isolate`, both ways at one HEAD**
+(`upstream/main` `ef6e34479b`):
+
+| | pass | fail |
+| --- | --- | --- |
+| base | 108 | 98 |
+| fix | **109** | **97** |
+
+Set difference over the non-pass rows: exactly one file flips,
+`built-ins/Iterator/concat/many-arguments.js` (fail → pass), and **no file
+regresses**.
+
+Probe through `compileAndRunUpstreamModule` (untyped `.js` two-file project),
+harness sanity-checked with a control that fails in both lanes:
+
+| probe | native | wasm before | wasm after |
+| --- | --- | --- | --- |
+| `[].concat(...[[], [1], [2,3], [4,5,6]])` | `1|2|3|4|5|6` len 6 | **`|1|2,3|4,5,6` len 4** | `1|2|3|4|5|6` len 6 |
+| `[].concat(...[a.split(':'), b.split(':')])` | `a|b|c|d` len 4 | **`a,b|c,d` len 2** | `a|b|c|d` len 4 |
+| `[].concat([1], [2,3])` (no-spread control) | `1|2|3` len 3 | `1|2|3` len 3 | `1|2|3` len 3 |
+| `[].concat([1,2])` (single arg control) | `1|2` len 2 | `1|2` len 2 | `1|2` len 2 |
+
+Dogfood A/B at one HEAD (`upstream/main` `ef6e34479b`), 17 suites, compared
+per test file: **total delta 0, no regressions** — expected, since none of the
+suites uses `[].concat(...spread)`; it is run as the no-regression control for
+a change on the host-bridge argument path.
+
+### Regression test
+
+`tests/issue-6411-host-bridge-concat-spread.test.ts` — untyped `.js` two-file
+fixtures pinning BOTH the resulting length and a join with a NON-comma
+separator. Counts both ways at this HEAD: **base 1 passed / 4 failed** (the
+pass is the no-spread control), **fix 5 passed / 0 failed**.
+
+### Deliberately NOT done
+
+- The native-first (`semanticProviders === "native-first"`) concat lane
+  (`compileArrayConcatNativeSpec` / `compileArrayConcatNativeDynamic`) is not
+  touched. The host lane is where the measured regression lives; the
+  native-first twin needs its own measurement before anyone changes it.

--- a/src/codegen/array-method-host.ts
+++ b/src/codegen/array-method-host.ts
@@ -6,6 +6,7 @@ import { allocLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
+import { tryEmitSpreadHostArgs } from "./host-method-args.js";
 import { compileExpression, ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { coerceType } from "./type-coercion.js";
 
@@ -33,12 +34,17 @@ export function compileArrayMethodExtern(
 
   const argsLocal = allocLocal(fctx, `__array_ext_args_${fctx.locals.length}`, externref);
   fctx.body.push({ op: "local.set", index: argsLocal });
-  for (const arg of callExpr.arguments) {
-    fctx.body.push({ op: "local.get", index: argsLocal });
-    const argType = compileExpression(ctx, fctx, arg, externref);
-    if (argType === null) fctx.body.push({ op: "ref.null.extern" });
-    else if (argType.kind !== "externref") coerceType(ctx, fctx, argType, externref);
-    fctx.body.push({ op: "call", funcIdx: arrPushIdx });
+  // (#5361 follow-up) A spread argument contributes its RUNTIME element count,
+  // not one slot; without this the source array is handed to the host as a
+  // single item. No spread ⇒ the unrolled loop below, byte-identical.
+  if (!tryEmitSpreadHostArgs(ctx, fctx, callExpr.arguments, argsLocal, "__js_array_push", arrPushIdx)) {
+    for (const arg of callExpr.arguments) {
+      fctx.body.push({ op: "local.get", index: argsLocal });
+      const argType = compileExpression(ctx, fctx, arg, externref);
+      if (argType === null) fctx.body.push({ op: "ref.null.extern" });
+      else if (argType.kind !== "externref") coerceType(ctx, fctx, argType, externref);
+      fctx.body.push({ op: "call", funcIdx: arrPushIdx });
+    }
   }
 
   fctx.body.push(
@@ -102,15 +108,19 @@ export function compileArrayConcatExternHost(
   const argsLocal = allocLocal(fctx, `__cat_ext_args_${fctx.locals.length}`, { kind: "externref" });
   fctx.body.push({ op: "local.set", index: argsLocal });
 
-  for (const arg of callExpr.arguments) {
-    fctx.body.push({ op: "local.get", index: argsLocal });
-    const argType = compileExpression(ctx, fctx, arg, { kind: "externref" });
-    if (argType === null) {
-      fctx.body.push({ op: "ref.null.extern" });
-    } else if (argType.kind !== "externref") {
-      fctx.body.push({ op: "extern.convert_any" });
+  // (#5361 follow-up) `[].concat(...arrays)` pushed the spread SOURCE as one
+  // argument, so `Array.prototype.concat` flattened one level too few.
+  if (!tryEmitSpreadHostArgs(ctx, fctx, callExpr.arguments, argsLocal, "__js_array_push", arrPushIdx)) {
+    for (const arg of callExpr.arguments) {
+      fctx.body.push({ op: "local.get", index: argsLocal });
+      const argType = compileExpression(ctx, fctx, arg, { kind: "externref" });
+      if (argType === null) {
+        fctx.body.push({ op: "ref.null.extern" });
+      } else if (argType.kind !== "externref") {
+        fctx.body.push({ op: "extern.convert_any" });
+      }
+      fctx.body.push({ op: "call", funcIdx: arrPushIdx });
     }
-    fctx.body.push({ op: "call", funcIdx: arrPushIdx });
   }
 
   // Call __array_concat_any(receiver_ext, args_array) -> externref JS array

--- a/src/codegen/host-method-args.ts
+++ b/src/codegen/host-method-args.ts
@@ -33,23 +33,12 @@ export function emitHostMethodCallArgs(
   arrPushName: string,
   arrPushIdx: number,
 ): void {
-  const spreadArgs = hasSpreadArgument(expr.arguments)
-    ? buildSpreadArgList(ctx, fctx, expr.arguments, 0, { kind: "externref" }, "emc_spread", {
-        afterValue: (arg) => {
-          maybeStampCompiledFunctionArgName(ctx, fctx, arg);
-        },
-      })
-    : undefined;
-  if (spreadArgs) {
-    // The push helper's funcidx is re-resolved by NAME: expanding a spread can
-    // register late imports, which shifts every defined-function index that
-    // was captured before them.
-    spreadArgs.emitStores({
-      pre: [{ op: "local.get", index: argsLocal }],
-      post: [{ op: "call", funcIdx: ctx.funcMap.get(arrPushName) ?? arrPushIdx }],
-    });
-    return;
-  }
+  const handled = tryEmitSpreadHostArgs(ctx, fctx, expr.arguments, argsLocal, arrPushName, arrPushIdx, {
+    afterValue: (arg) => {
+      maybeStampCompiledFunctionArgName(ctx, fctx, arg);
+    },
+  });
+  if (handled) return;
   for (const arg of expr.arguments) {
     fctx.body.push({ op: "local.get", index: argsLocal });
     const argType = compileExpression(ctx, fctx, arg, { kind: "externref" });
@@ -65,4 +54,41 @@ export function emitHostMethodCallArgs(
     maybeStampCompiledFunctionArgName(ctx, fctx, arg);
     fctx.body.push({ op: "call", funcIdx: arrPushIdx });
   }
+}
+
+/**
+ * Fill an already-created host array with a SPREAD-containing argument list,
+ * expanding each spread source at its runtime length.
+ *
+ * Returns `false` when there is no spread (the caller keeps its own unrolled
+ * per-node loop, which is exact and stays byte-identical) or when the target
+ * has no substrate to expand one. Nothing is emitted in either case.
+ *
+ * Every host-array argument builder in the compiler is the same `__js_array_new`
+ * + one `__js_array_push` per AST node shape, and every one of them sizes the
+ * array from `arguments.length` — which is the right number only while each
+ * argument is ONE value. This is the single place that difference is repaired,
+ * so a new bridge gets the runtime count by calling here rather than by growing
+ * a sixth copy of the loop.
+ */
+export function tryEmitSpreadHostArgs(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  args: readonly ts.Expression[],
+  argsLocal: number,
+  arrPushName: string,
+  arrPushIdx: number,
+  opts?: { afterValue?: (arg: ts.Expression) => void },
+): boolean {
+  if (!hasSpreadArgument(args)) return false;
+  const built = buildSpreadArgList(ctx, fctx, args, 0, { kind: "externref" }, "hostargs", opts);
+  if (!built) return false;
+  // The push helper's funcidx is re-resolved by NAME: expanding a spread can
+  // register late imports, which shifts every defined-function index that was
+  // captured before them.
+  built.emitStores({
+    pre: [{ op: "local.get", index: argsLocal }],
+    post: [{ op: "call", funcIdx: ctx.funcMap.get(arrPushName) ?? arrPushIdx }],
+  });
+  return true;
 }

--- a/tests/issue-6411-host-bridge-concat-spread.test.ts
+++ b/tests/issue-6411-host-bridge-concat-spread.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #6411 — a SPREAD argument to a host-bridged Array method contributes its
+// runtime element count, not one slot.
+//
+// Same idiom as #5361, in the two host-array argument builders that fix did not
+// reach: `compileArrayConcatExternHost` (`__array_concat_any`) and
+// `compileArrayMethodExtern` (`__extern_method_call`). Both built the argument
+// array with `__js_array_new` + one `__js_array_push` per AST node, so
+// `[].concat(...arrays)` handed `Array.prototype.concat` the SOURCE array as a
+// single argument and it flattened one level too few:
+//
+//   [].concat(...[[], [1], [2, 3]])   // => [[], [1], [2, 3]], not [1, 2, 3]
+//
+// Found as a real test262 regression: `built-ins/Iterator/concat/many-arguments`
+// compares `Iterator.concat(...iterables)` against `[].concat(...iterables)`.
+// Both were wrong in the same direction, so the test passed by coincidence;
+// once #5361 fixed the Iterator side, the coincidence broke and the file
+// flipped pass -> fail.
+//
+// Every assertion pins BOTH the resulting length and a join with a NON-comma
+// separator — a default `,` join hides the nesting, since the inner arrays
+// stringify to the same text.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { compileProject, type CompileResult } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+const LIB_SOURCE = `
+export function concatSpreadArrayLiterals() {
+  const parts = [[], [1], [2, 3], [4, 5, 6]];
+  return [].concat(...parts);
+}
+
+export function concatSpreadHostArrays(a, b) {
+  const parts = [a.split(":"), b.split(":")];
+  return [].concat(...parts);
+}
+
+export function concatMixedSpread(tail) {
+  const parts = [tail.split(":")];
+  return [].concat(["a"], ...parts, ["z"]);
+}
+
+export function concatNoSpreadControl() {
+  return [].concat([1], [2, 3]);
+}
+`;
+
+const ENTRY_SOURCE = `
+import {
+  concatSpreadArrayLiterals,
+  concatSpreadHostArrays,
+  concatMixedSpread,
+  concatNoSpreadControl,
+} from "./lib.js";
+
+export function literalJoin() { return concatSpreadArrayLiterals().join("|"); }
+export function literalLength() { return concatSpreadArrayLiterals().length; }
+export function hostJoin() { return concatSpreadHostArrays("a:b", "c:d").join("|"); }
+export function hostLength() { return concatSpreadHostArrays("a:b", "c:d").length; }
+export function mixedJoin() { return concatMixedSpread("m:n").join("|"); }
+export function mixedLength() { return concatMixedSpread("m:n").length; }
+export function controlJoin() { return concatNoSpreadControl().join("|"); }
+export function controlLength() { return concatNoSpreadControl().length; }
+
+// The test262 shape: the spread-concat result is compared element by element
+// against an independently-built list, so a missing flatten level is a hard
+// value mismatch rather than a formatting difference.
+export function iteratorConcatParity() {
+  const iterables = [[], [1], [2, 3], [4, 5, 6]];
+  const flattened = [].concat(...iterables);
+  let out = "";
+  for (let i = 0; i < flattened.length; i++) {
+    out = out + (i === 0 ? "" : "|") + flattened[i];
+  }
+  return out;
+}
+`;
+
+let dir: string;
+let exports: Record<string, () => unknown>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "js2-issue-6411-"));
+  writeFileSync(join(dir, "lib.js"), LIB_SOURCE);
+  const entry = join(dir, "entry.js");
+  writeFileSync(entry, ENTRY_SOURCE);
+
+  const result: CompileResult = await compileProject(entry, {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+  });
+  expect(
+    result.success,
+    `compile failed:\n${(result.errors ?? []).map((e) => `${e.severity}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const instance = await instantiateWithRuntime(result);
+  exports = instance.exports as unknown as Record<string, () => unknown>;
+}, 120_000);
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("#6411 — the host Array bridges expand spread arguments", () => {
+  it("flattens a spread of inline array literals", () => {
+    expect(exports.literalLength!()).toBe(6);
+    expect(String(exports.literalJoin!())).toBe("1|2|3|4|5|6");
+  });
+
+  it("flattens a spread of host (externref) arrays", () => {
+    expect(exports.hostLength!()).toBe(4);
+    expect(String(exports.hostJoin!())).toBe("a|b|c|d");
+  });
+
+  it("interleaves positional arguments and a spread in argument order", () => {
+    expect(exports.mixedLength!()).toBe(4);
+    expect(String(exports.mixedJoin!())).toBe("a|m|n|z");
+  });
+
+  it("keeps the no-spread control exact", () => {
+    expect(exports.controlLength!()).toBe(3);
+    expect(String(exports.controlJoin!())).toBe("1|2|3");
+  });
+
+  it("matches element by element (the test262 many-arguments shape)", () => {
+    expect(String(exports.iteratorConcatParity!())).toBe("1|2|3|4|5|6");
+  });
+});


### PR DESCRIPTION
## What

`[].concat(...arrays)` handed `Array.prototype.concat` the spread SOURCE as a single argument, so it flattened one level too few — see [#6411](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6411-host-bridge-concat-spread-not-expanded).

```js
[].concat(...[[], [1], [2, 3]]);   // [[], [1], [2, 3]]  — should be [1, 2, 3]
```

Same idiom [#5361](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5361-array-splice-spread-argument-not-expanded) removed from `splice` / `push` / `Math.min`-`max` / the generic `__extern_method_call` bridge, surviving in the two HOST-ARRAY argument builders in `src/codegen/array-method-host.ts`: `compileArrayConcatExternHost` (the `__array_concat_any` bridge) and `compileArrayMethodExtern`. Both build the argument array with `__js_array_new` + one `__js_array_push` per AST node, which is exact only while every argument is ONE value.

## Why now — this is a merged-baseline regression, found by the queue

`test/built-ins/Iterator/concat/many-arguments.js` compares

```js
let iterator = Iterator.concat(...iterables);
let array = [].concat(...iterables);
```

element by element. **Both sides were wrong in the same direction**, so the file passed by coincidence: `Iterator.concat(iterables)` yielded the sub-arrays and `[].concat(iterables)` flattened to the same sub-arrays, and `sameValue` compared identical objects. #5361 fixed the `Iterator.concat` side, the coincidence broke, and the file flipped pass → fail (`Expected SameValue(«1», «») to be true` — `array[0]` was still `[]`).

That single flip is the whole of the `net_per_test -1` that auto-parked PR #5819 in the merge queue (run 34680468369: 0 improvements − 1 regression). The `[].concat(...)` half is INDEPENDENT of #5361 and predates it — measured with #5361's codegen reverted, the same probe gives the same wrong answer. This PR restores the net and fixes the underlying defect.

## How

`tryEmitSpreadHostArgs` (`src/codegen/host-method-args.ts`) is the shared entry both bridges call before their own loop: with a spread present it drives #5361's `buildSpreadArgList` with a `__js_array_push` sink; with none it returns `false` having emitted nothing, and each caller keeps its existing unrolled loop verbatim — so a spread-free call is byte-identical. `emitHostMethodCallArgs` (the #5361 caller) is re-expressed on top of it, so there is ONE place where the syntactic-vs-runtime argument count is repaired rather than a sixth copy of the loop.

## Measured

**Scoped test262 slice, both ways at one HEAD** (`upstream/main` `ef6e34479b`) — every file under `built-ins/Array/prototype/concat`, `.../push`, `.../splice` and `built-ins/Iterator/concat`, **206 files, `--isolate`**:

| | pass | fail |
| --- | --- | --- |
| base | 108 | 98 |
| fix | **109** | **97** |

Set difference over the non-pass rows: exactly one file flips — `built-ins/Iterator/concat/many-arguments.js`, fail → pass — and **no file regresses**.

Probe through `compileAndRunUpstreamModule` (untyped `.js` two-file project), harness sanity-checked with a control that fails in both lanes:

| probe | native | wasm before | wasm after |
| --- | --- | --- | --- |
| `[].concat(...[[], [1], [2,3], [4,5,6]])` | `1\|2\|3\|4\|5\|6` len 6 | **`\|1\|2,3\|4,5,6` len 4** | `1\|2\|3\|4\|5\|6` len 6 |
| `[].concat(...[a.split(':'), b.split(':')])` | `a\|b\|c\|d` len 4 | **`a,b\|c,d` len 2** | `a\|b\|c\|d` len 4 |
| `[].concat([1], [2,3])` (no-spread control) | `1\|2\|3` len 3 | `1\|2\|3` len 3 | `1\|2\|3` len 3 |
| `[].concat([1,2])` (single-arg control) | `1\|2` len 2 | `1\|2` len 2 | `1\|2` len 2 |

**17 dogfood suites, A/B at one HEAD, per test file: total delta 0, no regressions** — expected (none of them uses `[].concat(...spread)`); run as the no-regression control for a change on the host-bridge argument path.

`tests/issue-6411-host-bridge-concat-spread.test.ts` pins BOTH the resulting length and a join with a NON-comma separator (a default `,` join hides the nesting — the inner arrays stringify to the same text). Counts both ways at this HEAD: **base 1 passed / 4 failed** (the pass is the no-spread control), **fix 5 passed / 0 failed**.

Gates green locally: loc-budget, func-budget, coercion-sites, oracle-ratchet, dead-exports, host-import-policy, stack-balance, any-box-sites, pushraw, issues, compiler-boundaries inventory, equivalence-gate (22 failing / 1720 passing, no new regressions), prettier, and `tsc --noEmit` on `tsconfig.ts7.json`.

## Deliberately not done

The native-first concat lane (`compileArrayConcatNativeSpec` / `compileArrayConcatNativeDynamic`) is untouched. The host lane is where the measured regression lives; the native-first twin needs its own measurement first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
