### PR TITLE
fix(#5368): dogfood-validation gates a module surface, not one declared entry

### DIFF
--- a/plan/issues/5368-dogfood-validation-gate-declared-entry-only.md
+++ b/plan/issues/5368-dogfood-validation-gate-declared-entry-only.md
@@ -1,10 +1,11 @@
 ---
 id: 5368
 title: "`check:dogfood-validation` compiles only each package's declared entry module — a subpath that emits invalid Wasm (`hono/dist/utils/color.js`, #5339) passes the gate green"
-status: ready
+status: done
 sprint: current
 created: 2026-09-06
-updated: 2026-09-06
+updated: 2026-09-12
+completed: 2026-09-12
 priority: high
 horizon: s
 feasibility: easy
@@ -66,3 +67,92 @@ four agents had already misread the null `wasmError`.
 
 Model: **opus** (small CI change; opus rather than sonnet because the
 mandatory step-0 base recipe on this box has stalled two sonnet agents).
+
+## Resolution
+
+**Mechanism.** `scripts/check-dogfood-validation.mjs` now compiles a module
+SURFACE per package instead of one declared entry. `tests/dogfood/dogfood-surface-modules.mjs`
+enumerates it; `tests/dogfood/dogfood-surface-probe.mjs` compiles a chunk of it
+in one child process (one process per chunk, not per module — loading the
+compiler is ~1.5 s and the surface has 20x the modules). Both phases now share
+ONE worker pool, so the short subpath chunks fill the gaps between the six long
+entry probes rather than forming a tail.
+
+Two surfaces:
+
+- **`suite` (gated, default)** — the declared entry plus every published module
+  the dogfood upstream suites admit. Derived from the committed suite pins, so
+  the gate needs no upstream clone and no generated tree. Only hono's suite
+  rewrites its tests' imports onto the published `dist/` tree; the other suites
+  (redux, jest, styled-components, moment, react) compile the upstream
+  repository's sources, so their admitted set is legitimately the entry alone.
+  That mapping is one declarative table entry per package, not new logic.
+- **`--surface exports` (survey, not gated)** — every file the package's
+  `exports` map resolves to. Deliberately not gated: see the residuals.
+
+A module that does not codegen at all is counted and printed but never failed
+on — it makes the implication vacuous, which is #5332's business, not this
+gate's. A chunk that dies mid-way is an infrastructure failure (exit 3), not a
+silent pass over the modules it never reached.
+
+**Counts both ways (AC 1).** Same gate, same command, two trees:
+
+| tree | verdict | subpath surface | exit |
+| --- | --- | --- | --- |
+| `34720daf53` (#5676's parent) | **RED** | 20 modules — 19 valid, **1 invalid** | 1 |
+| `cf82f78d6d` (main, 2026-09-12) | **GREEN** | 20 modules — 20 valid | 0 |
+
+The single invalid module on the parent is exactly #5339:
+
+```
+::error::[dogfood-validation] hono module dist/helper/dev/index.js compiled 36,213 bytes
+that do NOT validate: WebAssembly.Module(): Compiling function #36:"getColorEnabledAsync"
+failed: type error in return[0] (expected i32, got externref) @+11543
+```
+
+Package, module path, verbatim engine error — AC 4.
+
+**Wall clock (AC 3).** Measured back-to-back on the same loaded box, same
+concurrency 4:
+
+| run | wall | vs base |
+| --- | --- | --- |
+| entry-only gate (`HEAD:scripts/check-dogfood-validation.mjs`) | 44.5 s | 1.00x |
+| widened gate, run 1 | 71.8 s | 1.61x |
+| widened gate, run 2 | 65.0 s | 1.46x |
+
+Inside the ≤ 2x budget. The added *work* is small — the 20 hono modules cost
+~12 s of CPU serially — so most of the delta is scheduling contention from four
+more concurrent children on a shared box; a quiet runner should see less.
+
+**Anti-vacuity control.** `tests/dogfood/dogfood-surface-modules.test.ts` pins
+the SET, because an enumeration that quietly collapsed back to the declared
+entry would restore the exact blind spot and still exit 0. Disabling the suite
+mapping fails 3 of its 6 tests.
+
+## Residuals
+
+- **The `exports` surface is NOT gated, and it is not clean on main.** Running
+  `--surface exports` over hono's 74 published modules on `cf82f78d6d` finds
+  **7 invalid modules** — three distinct codegen bugs, now filed as #6412
+  (`extern.convert_any` given an already-external ref in
+  `__async_resume_fimportPublicKey`: `utils/jwt`, `middleware/jwk`,
+  `middleware/jwt`), #6413 (closure fallthrough typed `i32`, producing
+  `externref`: `jsx/dom/client`, `jsx/dom/jsx-runtime`,
+  `jsx/dom/jsx-dev-runtime`) and #6414 (`struct.set` of an `externref` into an
+  `i32` frame slot: `adapter/cloudflare-pages`). They are recorded in
+  `KNOWN_INVALID_MODULES` so the survey is reproducible; on the default surface
+  that list waives nothing. Widening the gate to `exports` means emptying it
+  first.
+- **Cost is the other reason `exports` is not gated**: hono's 74 modules cost
+  **151 s of CPU** on their own, which does not fit the `quality` budget at any
+  plausible concurrency. Four more hono modules fail to codegen outright
+  (`helper/streaming`, `middleware/combine`, `middleware/timing`,
+  `validator/index` — all the #3587 "async shape not supported" class).
+- **Compiling the whole exports surface as ONE union barrel does not work** and
+  should not be retried: it took 178 s and then failed to codegen at all, which
+  makes the implication vacuous for the entire package. Per-module compiles are
+  what keep a single bad module from blinding the rest.
+- Only hono contributes suite subpath modules today. The mechanism generalises
+  — a new package is one table entry — but the coverage it buys right now is
+  hono's 20 modules.

--- a/plan/issues/6412-hono-jwt-async-resume-extern-convert-any.md
+++ b/plan/issues/6412-hono-jwt-async-resume-extern-convert-any.md
@@ -1,0 +1,52 @@
+---
+id: 6412
+title: "hono's JWT subpaths emit an invalid module — `extern.convert_any[0] expected type anyref, found call of type externref` in `__async_resume_fimportPublicKey`"
+status: ready
+sprint: current
+created: 2026-09-12
+updated: 2026-09-12
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+goal: correctness
+---
+
+## Problem
+
+Three hono subpath modules compile successfully and then fail
+`WebAssembly.compile`:
+
+| module | engine message |
+| --- | --- |
+| `dist/utils/jwt/index.js` | `Compiling function #212:"__async_resume_fimportPublicKey" failed: extern.convert_any[0] expected type anyref, found call of type externref @+56513` |
+| `dist/middleware/jwk/index.js` | `Compiling function #426:"__async_resume_fimportPublicKey" failed: extern.convert_any[0] expected type anyref, found call of type externref @+187403` |
+| `dist/middleware/jwt/index.js` | `Compiling function #425:"__async_resume_fimportPublicKey" failed: extern.convert_any[0] expected type anyref, found call of type externref @+183035` |
+
+All three are the same defect reached through three entry points: the async
+resume continuation for `importPublicKey` feeds an `extern.convert_any` with a
+value the call already produced as `externref`. `extern.convert_any` takes
+`anyref` — converting an `externref` that is already external is the type
+error. The coercion is emitted in the resume path, not the straight-line one,
+which is why it survives the ordinary async lowering tests.
+
+Found by the `--surface exports` survey added in
+[#5368](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5368-dogfood-validation-gate-declared-entry-only)
+on `cf82f78d6d` (2026-09-12). Recorded in `KNOWN_INVALID_MODULES` in
+`scripts/check-dogfood-validation.mjs`; deleting those three rows is the
+acceptance test.
+
+## Reproduce
+
+```bash
+node --import tsx tests/dogfood/dogfood-surface-probe.mjs \
+  --package hono --modules dist/utils/jwt/index.js
+```
+
+## Acceptance criteria
+
+1. All three modules compile to binaries that pass `validateEmittedBinary`.
+2. Their three rows are deleted from `KNOWN_INVALID_MODULES`.
+3. A regression test that fails on the parent commit and passes with the fix.

--- a/plan/issues/6413-hono-jsx-dom-closure-fallthru-externref.md
+++ b/plan/issues/6413-hono-jsx-dom-closure-fallthru-externref.md
@@ -1,0 +1,55 @@
+---
+id: 6413
+title: "hono's `jsx/dom` subpaths emit an invalid module — closure falls through with `externref` where `i32` is expected"
+status: ready
+sprint: current
+created: 2026-09-12
+updated: 2026-09-12
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+goal: correctness
+---
+
+## Problem
+
+Three hono subpath modules compile successfully and then fail
+`WebAssembly.compile` with the same fallthrough type mismatch:
+
+| module | engine message |
+| --- | --- |
+| `dist/jsx/dom/client.js` | `Compiling function #195:"__closure_64" failed: type error in fallthru[0] (expected i32, got externref) @+110178` |
+| `dist/jsx/dom/jsx-runtime.js` | `Compiling function #157:"__closure_35" failed: type error in fallthru[0] (expected i32, got externref) @+80404` |
+| `dist/jsx/dom/jsx-dev-runtime.js` | `Compiling function #157:"__closure_35" failed: type error in fallthru[0] (expected i32, got externref) @+80363` |
+
+A generated closure is declared to return `i32` but its body falls off the end
+leaving an `externref` on the stack — the declared result type and the value
+the last expression actually produces disagree. The shape is adjacent to
+[#5339](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5339-hono-dev-index-whole-module)
+(`type error in return[0] (expected i32, got externref)`), which was an
+inlined-IIFE `return` inside a `catch` clause left as a Wasm `return`; here it
+is the implicit fallthrough rather than an explicit return, so the #5676 fix
+does not cover it. Whether the two share a root cause is unverified.
+
+Found by the `--surface exports` survey added in
+[#5368](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5368-dogfood-validation-gate-declared-entry-only)
+on `cf82f78d6d` (2026-09-12). `dist/jsx/dom/index.js`, `css.js` and `server.js`
+compile and validate, so the defect is in what `client.js` / the runtimes reach,
+not in the jsx/dom core.
+
+## Reproduce
+
+```bash
+node --import tsx tests/dogfood/dogfood-surface-probe.mjs \
+  --package hono --modules dist/jsx/dom/jsx-runtime.js
+```
+
+## Acceptance criteria
+
+1. All three modules compile to binaries that pass `validateEmittedBinary`.
+2. Their three rows are deleted from `KNOWN_INVALID_MODULES` in
+   `scripts/check-dogfood-validation.mjs`.
+3. A regression test that fails on the parent commit and passes with the fix.

--- a/plan/issues/6414-hono-cloudflare-pages-async-resume-struct-set.md
+++ b/plan/issues/6414-hono-cloudflare-pages-async-resume-struct-set.md
@@ -1,0 +1,56 @@
+---
+id: 6414
+title: "hono's `adapter/cloudflare-pages` emits an invalid module — `struct.set[1] expected type i32, found local.get of type externref` in an async resume"
+status: ready
+sprint: current
+created: 2026-09-12
+updated: 2026-09-12
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+goal: correctness
+---
+
+## Problem
+
+`hono/dist/adapter/cloudflare-pages/index.js` compiles successfully and then
+fails `WebAssembly.compile`:
+
+```
+Compiling function #318:"__async_resume_fanon_467" failed:
+  struct.set[1] expected type i32, found local.get of type externref @+117395
+```
+
+An async resume continuation stores a spilled local back into its frame struct
+with the wrong representation: the frame field was laid out as `i32` but the
+value being written is `externref`. The other hono adapters
+(`aws-lambda`, `bun`, `cloudflare-workers`, `deno`, `lambda-edge`, `netlify`,
+`service-worker`, `vercel`) all compile and validate, so the disagreement is
+specific to what this module's captured anonymous async function spills.
+
+Likely related to
+[#6412](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6412-hono-jwt-async-resume-extern-convert-any)
+— both are `__async_resume_*` frames mixing `i32` and `externref` for one slot
+— but they fail at different instructions and this has not been verified as one
+root cause.
+
+Found by the `--surface exports` survey added in
+[#5368](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5368-dogfood-validation-gate-declared-entry-only)
+on `cf82f78d6d` (2026-09-12).
+
+## Reproduce
+
+```bash
+node --import tsx tests/dogfood/dogfood-surface-probe.mjs \
+  --package hono --modules dist/adapter/cloudflare-pages/index.js
+```
+
+## Acceptance criteria
+
+1. The module compiles to a binary that passes `validateEmittedBinary`.
+2. Its row is deleted from `KNOWN_INVALID_MODULES` in
+   `scripts/check-dogfood-validation.mjs`.
+3. A regression test that fails on the parent commit and passes with the fix.

--- a/scripts/check-dogfood-validation.mjs
+++ b/scripts/check-dogfood-validation.mjs
@@ -44,6 +44,22 @@
 // such a baseline would be noisy. The per-package compile status IS printed on
 // every run so the regression is at least visible in the log.
 //
+// THE MODULE SURFACE (#5368). Until 2026-09-12 this gate compiled exactly one
+// module per package — `<pkg>/<declared entry>`. A module a dogfood SUITE
+// admits through a subpath was never compiled here, so the invariant held
+// green over a package whose subpath emitted a module no engine would load.
+// #5339 is the measured miss: hono's `dist/helper/dev/index.js` pulls in
+// `dist/utils/color.js`, whose `getColorEnabledAsync` emitted `type error in
+// return[0] (expected i32, got externref)`. Re-measured on #5676's parent
+// (`34720daf53`), that module is INVALID and the other 19 hono suite modules
+// are clean — the widened gate is red there and green on main.
+//
+// The gated surface is `suite`: the declared entry PLUS every published module
+// the dogfood upstream suites admit (tests/dogfood/dogfood-surface-modules.mjs
+// derives it from the committed suite pins, so no upstream clone and no
+// generated tree is needed). A wider `--surface exports` walks the whole
+// `exports` map; it is a SURVEY, not a gate — see KNOWN_INVALID_MODULES.
+//
 // MACHINERY. All reused: `runNpmCompatCatalogHarness` (tests/dogfood/
 // npm-compat-catalog-harness.mjs) compiles the pinned tarball's declared entry
 // module via `tests/helpers/compile-project-probe.ts` in a child process with
@@ -60,8 +76,10 @@
 //   node scripts/check-dogfood-validation.mjs --json
 //   node scripts/check-dogfood-validation.mjs --only moment,lit
 //   node scripts/check-dogfood-validation.mjs --concurrency 1
+//   node scripts/check-dogfood-validation.mjs --surface exports   # survey, wider
+//   node scripts/check-dogfood-validation.mjs --list-modules      # print the surface
 //
-// Exit 0 = every gated package upheld the invariant. Exit 1 = a gated package
+// Exit 0 = every gated module upheld the invariant. Exit 1 = a gated module
 // compiled to a binary that does not validate (or blew its compile budget).
 // Exit 2 = usage. Exit 3 = infrastructure failure; nothing was measured.
 
@@ -73,6 +91,9 @@ import { performance } from "node:perf_hooks";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const HARNESS = join(REPO_ROOT, "tests", "dogfood", "npm-compat-catalog-harness.mjs");
+const SURFACE_PROBE = join(REPO_ROOT, "tests", "dogfood", "dogfood-surface-probe.mjs");
+/** Per-module deadline used to size each chunk's wall budget. */
+const MODULE_TIMEOUT_MS = 120_000;
 
 /**
  * The gated set: pinned npm-compat catalog packages that BOTH compile and
@@ -104,6 +125,54 @@ const GATED = [
  * gate stays a clean invariant; fixing one means moving it into `GATED`.
  */
 const KNOWN_INVALID = [{ name: "lit", issue: 3977, detail: 'local.set[0] in "y_createRenderRoot"' }];
+
+/**
+ * Individual SUBPATH modules that compile but do not validate on main today,
+ * all found by this gate's own `--surface exports` survey on 2026-09-12
+ * (`cf82f78d6d`). None of them is in the gated `suite` surface, so on the
+ * default surface this list waives nothing — it is what stops the wider survey
+ * from reading as an undifferentiated pile of red, and it is the list a future
+ * widening of the gated surface has to empty first. Fixing one deletes its row.
+ *
+ * Three distinct codegen bugs, seven modules: #6412 (`extern.convert_any`
+ * expecting anyref where an async resume produced externref), #6413 (a closure
+ * falling through with externref where i32 is expected), #6414 (a `struct.set`
+ * expecting i32 and given externref in an async resume).
+ */
+const KNOWN_INVALID_MODULES = [
+  {
+    name: "hono",
+    module: "dist/utils/jwt/index.js",
+    issue: 6412,
+    detail: 'extern.convert_any in "__async_resume_fimportPublicKey"',
+  },
+  {
+    name: "hono",
+    module: "dist/middleware/jwk/index.js",
+    issue: 6412,
+    detail: "same __async_resume_fimportPublicKey shape",
+  },
+  {
+    name: "hono",
+    module: "dist/middleware/jwt/index.js",
+    issue: 6412,
+    detail: "same __async_resume_fimportPublicKey shape",
+  },
+  {
+    name: "hono",
+    module: "dist/jsx/dom/client.js",
+    issue: 6413,
+    detail: 'fallthru[0] expected i32, got externref in "__closure_64"',
+  },
+  { name: "hono", module: "dist/jsx/dom/jsx-runtime.js", issue: 6413, detail: "same __closure_35 fallthru shape" },
+  { name: "hono", module: "dist/jsx/dom/jsx-dev-runtime.js", issue: 6413, detail: "same __closure_35 fallthru shape" },
+  {
+    name: "hono",
+    module: "dist/adapter/cloudflare-pages/index.js",
+    issue: 6414,
+    detail: 'struct.set[1] expected i32, got externref in "__async_resume_fanon_467"',
+  },
+];
 
 function usage(message) {
   process.stderr.write(
@@ -159,18 +228,6 @@ function probePackage(name) {
   });
 }
 
-async function probeAll(names, concurrency) {
-  const queue = [...names];
-  const results = new Map();
-  const workers = Array.from({ length: Math.max(1, Math.min(concurrency, queue.length)) }, async () => {
-    for (let next = queue.shift(); next !== undefined; next = queue.shift()) {
-      results.set(next, await probePackage(next));
-    }
-  });
-  await Promise.all(workers);
-  return names.map((name) => results.get(name));
-}
-
 /** Classify one probe outcome. Only `invalid` and `budget` fail the gate. */
 function classify(outcome) {
   if (outcome.infrastructure) return { verdict: "infrastructure", detail: outcome.infrastructure };
@@ -203,10 +260,90 @@ function describe(outcome, classified) {
   };
 }
 
+/**
+ * Compile one CHUNK of one package's subpath modules in a single child.
+ * One process per chunk, not per module: loading the compiler costs ~1.5 s and
+ * the widened surface has ~20x the modules the entry-only gate had.
+ */
+function probeModuleChunk(name, modules) {
+  return new Promise((resolve) => {
+    const started = performance.now();
+    const child = spawn(
+      process.execPath,
+      [
+        "--max-old-space-size=2048",
+        "--import",
+        "tsx",
+        SURFACE_PROBE,
+        "--package",
+        name,
+        "--modules",
+        modules.join(","),
+      ],
+      { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    // Sized off the chunk, not off one module: a chunk that hangs must still
+    // be killed, but a slow-but-honest chunk must not be.
+    const timer = setTimeout(() => child.kill("SIGTERM"), MODULE_TIMEOUT_MS * modules.length);
+    const settle = (rows, infrastructure) => {
+      clearTimeout(timer);
+      resolve({ name, modules, rows, infrastructure, wallMs: Math.round(performance.now() - started) });
+    };
+    child.on("error", (error) => settle([], `surface probe could not start: ${error.message}`));
+    child.on("exit", (code, signal) => {
+      const rows = [];
+      for (const line of stdout.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        try {
+          rows.push(JSON.parse(line));
+        } catch {
+          // A non-JSON line is compiler chatter, not a verdict.
+        }
+      }
+      if (rows.some((row) => row.fatal)) {
+        settle([], `surface probe reported fatal: ${rows.find((row) => row.fatal).fatal}`);
+        return;
+      }
+      // A chunk that dies mid-way (OOM, crash) leaves its remaining modules
+      // unmeasured. Scoring only what survived would read as "all clear".
+      if (rows.length !== modules.length) {
+        const detail = stderr.trim() || `exited ${signal ?? `with code ${code}`}`;
+        settle(
+          rows,
+          `surface probe returned ${rows.length}/${modules.length} module verdicts ` +
+            `(stopped at ${modules[rows.length] ?? "?"}): ${detail.slice(0, 400)}`,
+        );
+        return;
+      }
+      settle(rows, null);
+    });
+  });
+}
+
+/** Split a package's modules into at most `parts` chunks, order preserved. */
+function chunk(modules, parts) {
+  const size = Math.max(1, Math.ceil(modules.length / Math.max(1, parts)));
+  const chunks = [];
+  for (let index = 0; index < modules.length; index += size) chunks.push(modules.slice(index, index + size));
+  return chunks;
+}
+
 const argv = process.argv.slice(2);
 const jsonOnly = argv.includes("--json");
 const survey = argv.includes("--survey");
 const only = readFlag(argv, "--only");
+const surface = readFlag(argv, "--surface") ?? "suite";
+if (!["suite", "exports"].includes(surface)) usage(`--surface expects one of suite, exports`);
 const concurrencyFlag = readFlag(argv, "--concurrency") ?? process.env.DOGFOOD_VALIDATION_CONCURRENCY;
 const concurrency = concurrencyFlag ? Number(concurrencyFlag) : Math.max(1, Math.min(4, availableParallelism() - 1));
 if (!Number.isInteger(concurrency) || concurrency < 1) usage(`--concurrency expects a positive integer`);
@@ -232,6 +369,38 @@ if (argv.includes("--list")) {
   process.exit(0);
 }
 
+// The subpath surface: the declared entry is already covered by the per-package
+// harness above, so it is dropped here rather than compiled twice.
+const { dogfoodSurfaceModules } = await import("../tests/dogfood/dogfood-surface-modules.mjs");
+const moduleJobs = [];
+const surfaceByPackage = new Map();
+for (const name of names) {
+  let enumerated;
+  try {
+    enumerated = dogfoodSurfaceModules(name, { surface });
+  } catch (error) {
+    // Enumeration is filesystem work over an extracted tarball; a package that
+    // cannot even be enumerated is reported by its entry probe below.
+    surfaceByPackage.set(name, { modules: [], error: error instanceof Error ? error.message : String(error) });
+    continue;
+  }
+  const subpaths = enumerated.modules.filter((entry) => entry.origin !== "entry").map((entry) => entry.path);
+  surfaceByPackage.set(name, { modules: subpaths, error: null });
+  for (const part of chunk(subpaths, concurrency)) moduleJobs.push({ name, modules: part });
+}
+
+if (argv.includes("--list-modules")) {
+  for (const name of names) {
+    const entry = surfaceByPackage.get(name);
+    if (entry.error) {
+      process.stdout.write(`${name}\t(enumeration failed: ${entry.error})\n`);
+      continue;
+    }
+    for (const modulePath of entry.modules) process.stdout.write(`${name}\t${modulePath}\n`);
+  }
+  process.exit(0);
+}
+
 const log = jsonOnly ? () => {} : (...values) => console.log(...values);
 const started = performance.now();
 log(
@@ -239,8 +408,35 @@ log(
     `asserting compile.success ⇒ the emitted binary validates`,
 );
 
-const outcomes = await probeAll(names, concurrency);
+// ONE pool over both kinds of work. The entry probes are a handful of long
+// jobs and the subpath chunks are many short ones; splitting the pool in two
+// leaves whichever half finishes first idle while the other is still the
+// critical path. Entry probes are queued first because they are the longest.
+const queue = [
+  ...names.map((name) => ({ kind: "entry", name })),
+  ...moduleJobs.map((job) => ({ kind: "chunk", ...job })),
+];
+const entryResults = new Map();
+const chunkResults = [];
+await Promise.all(
+  Array.from({ length: Math.max(1, Math.min(concurrency, queue.length)) }, async () => {
+    for (let job = queue.shift(); job !== undefined; job = queue.shift()) {
+      if (job.kind === "entry") entryResults.set(job.name, await probePackage(job.name));
+      else chunkResults.push(await probeModuleChunk(job.name, job.modules));
+    }
+  }),
+);
+const outcomes = names.map((name) => entryResults.get(name));
 const rows = outcomes.map((outcome) => describe(outcome, classify(outcome)));
+const moduleRows = chunkResults
+  .flatMap((result) => result.rows)
+  .sort((a, b) => a.package.localeCompare(b.package) || a.module.localeCompare(b.module));
+const moduleInfrastructure = chunkResults.filter((result) => result.infrastructure);
+const waived = new Set(KNOWN_INVALID_MODULES.map((entry) => `${entry.name} ${entry.module}`));
+const invalidModules = moduleRows.filter(
+  (row) => row.verdict === "invalid" && !waived.has(`${row.package} ${row.module}`),
+);
+const waivedHits = moduleRows.filter((row) => row.verdict === "invalid" && waived.has(`${row.package} ${row.module}`));
 const wallMs = Math.round(performance.now() - started);
 
 const MARK = {
@@ -262,6 +458,21 @@ if (!survey && !only) {
   }
 }
 
+const moduleCounts = { valid: 0, invalid: 0, "compile-failed": 0 };
+for (const row of moduleRows) moduleCounts[row.verdict] = (moduleCounts[row.verdict] ?? 0) + 1;
+log(
+  `  ${surface === "exports" ? "exports-map" : "suite"} subpath surface: ${moduleRows.length} module(s) — ` +
+    `${moduleCounts.valid} valid, ${moduleCounts.invalid} invalid, ${moduleCounts["compile-failed"]} did not codegen ` +
+    `(a module that does not codegen makes the implication vacuous; it is counted, never failed on)`,
+);
+for (const row of moduleRows) {
+  if (row.verdict === "valid") continue;
+  log(
+    `  ${row.verdict === "invalid" ? (waived.has(`${row.package} ${row.module}`) ? "(waived)" : "INVALID ") : "no-build"} ` +
+      `${`${row.package}/${row.module}`.padEnd(46)} ${String(row.detail).split("\n")[0].slice(0, 110)}`,
+  );
+}
+
 const invalid = rows.filter((row) => row.verdict === "invalid");
 const budget = rows.filter((row) => row.verdict === "budget");
 const infrastructure = rows.filter((row) => row.verdict === "infrastructure");
@@ -273,7 +484,11 @@ const vacuous = !survey && !only && compiled.length === 0;
 
 if (jsonOnly) {
   process.stdout.write(
-    `${JSON.stringify({ gated: !survey && !only, concurrency, wallMs, vacuous, packages: rows }, null, 2)}\n`,
+    `${JSON.stringify(
+      { gated: !survey && !only, surface, concurrency, wallMs, vacuous, packages: rows, modules: moduleRows },
+      null,
+      2,
+    )}\n`,
   );
 }
 
@@ -294,24 +509,37 @@ if (survey) {
   process.exit(0);
 }
 
-if (infrastructure.length > 0) {
+if (infrastructure.length > 0 || moduleInfrastructure.length > 0) {
   for (const row of infrastructure) console.error(`::error::[dogfood-validation] ${row.name}: ${row.detail}`);
+  for (const result of moduleInfrastructure) {
+    console.error(`::error::[dogfood-validation] ${result.name} subpath chunk: ${result.infrastructure}`);
+  }
   console.error(`[dogfood-validation] FAILED — the harness did not produce a verdict; nothing was measured.`);
   process.exit(3);
 }
 
-if (invalid.length > 0 || budget.length > 0) {
+if (invalid.length > 0 || budget.length > 0 || invalidModules.length > 0) {
   for (const row of [...invalid, ...budget]) {
     console.error(
       `::error::[dogfood-validation] ${row.name}@${row.version ?? "?"} (${row.entryModule ?? "?"}) ` +
         `${row.verdict === "budget" ? "blew its compile budget" : `compiled ${row.binaryBytes.toLocaleString("en-US")} bytes that do NOT validate`}: ${row.detail}`,
     );
   }
+  // Package, module path, and the engine's own words — a validation failure is
+  // only actionable if you can see WHICH function the engine rejected.
+  for (const row of invalidModules) {
+    console.error(
+      `::error::[dogfood-validation] ${row.package} module ${row.module} ` +
+        `compiled ${row.binaryBytes.toLocaleString("en-US")} bytes that do NOT validate: ${row.detail}`,
+    );
+  }
+  const total = invalid.length + invalidModules.length;
   console.error(
-    `\n[dogfood-validation] FAILED — the compiler emitted ${invalid.length} module(s) that WebAssembly refuses to load.\n` +
+    `\n[dogfood-validation] FAILED — the compiler emitted ${total} module(s) that WebAssembly refuses to load.\n` +
       `A module that codegens but does not validate is always a compiler bug: fix the codegen, do not\n` +
-      `adjust this gate. Reproduce one package locally with:\n` +
-      `  node --import tsx tests/dogfood/npm-compat-catalog-harness.mjs --package <name>\n`,
+      `adjust this gate. Reproduce locally with:\n` +
+      `  node --import tsx tests/dogfood/npm-compat-catalog-harness.mjs --package <name>          # declared entry\n` +
+      `  node --import tsx tests/dogfood/dogfood-surface-probe.mjs --package <name> --modules <p> # one subpath\n`,
   );
   process.exit(1);
 }
@@ -324,6 +552,14 @@ if (vacuous) {
   process.exit(1);
 }
 
+if (waivedHits.length > 0) {
+  for (const row of waivedHits) {
+    const waiver = KNOWN_INVALID_MODULES.find((entry) => entry.name === row.package && entry.module === row.module);
+    log(`  (waived) ${row.package}/${row.module} — known-invalid, tracked by #${waiver.issue}`);
+  }
+}
+
 log(
-  `[dogfood-validation] ok — ${compiled.length}/${rows.length} gated packages compiled, ${compiled.length}/${compiled.length} validated.`,
+  `[dogfood-validation] ok — ${compiled.length}/${rows.length} gated packages compiled, ${compiled.length}/${compiled.length} validated; ` +
+    `${moduleCounts.valid + moduleCounts.invalid}/${moduleRows.length} subpath modules compiled, ${moduleCounts.valid} validated.`,
 );

--- a/tests/dogfood/dogfood-surface-modules.mjs
+++ b/tests/dogfood/dogfood-surface-modules.mjs
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5368 — enumerate the modules a dogfood package actually presents to the
+// compiler, not just its declared entry.
+//
+// WHY. `scripts/check-dogfood-validation.mjs` (#5336) asserts
+// `compile.success ⇒ the emitted binary validates`, but it only ever compiled
+// `<pkg>/<declared entry>`. A module the dogfood SUITES admit through a
+// subpath was never compiled by the gate, so #5339 — hono's
+// `dist/helper/dev/index.js`, whose `utils/color.js` dependency emitted
+// `getColorEnabledAsync` with `type error in return[0] (expected i32, got
+// externref)` — was live on main with the gate green. It surfaced only as a
+// whole-file `0/8` in the hono upstream suite.
+//
+// THE TWO SURFACES.
+//
+//   "suite"    the modules the dogfood upstream suites admit. This is the
+//              gated surface: it is what the suites already compile, so a
+//              module in it that does not validate is a bug the project has
+//              already committed to caring about.
+//
+//   "exports"  every distinct file the package's `exports` map resolves to.
+//              A strictly wider survey surface, NOT gated — see the
+//              `--surface exports` note in the gate script. Enumerating it is
+//              cheap; compiling it is not, and on main today it is not clean.
+//
+// SUITE ENUMERATION, AND WHY IT IS DECLARATIVE. The suites do not share one
+// src→dist convention. Most of them (redux, jest, styled-components, moment,
+// react) compile the UPSTREAM REPOSITORY's sources against the package, so the
+// only published module they admit is the declared entry. hono is the
+// exception: `tests/dogfood/hono-upstream-suite.mjs` rewrites each selected
+// test's relative imports onto the published `dist/` tree, so every selected
+// `src/<rest>.test.ts` admits `dist/<rest>.js` (or `dist/<rest>/index.js`).
+// That mapping is stated here as DATA keyed by package, derived from the
+// committed suite pin — so the gate needs no upstream clone and no generated
+// tree, and adding a package is one table entry rather than new logic.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { npmCompatCatalogEntry, setupNpmCompatCatalogPackage } from "./npm-compat-catalog.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Packages whose upstream suite admits published subpath modules, and how its
+ * selected test paths map onto them. `pin` is the committed suite pin, so this
+ * enumeration is reproducible from the repository alone.
+ */
+const SUITE_SUBPATH_MAPS = {
+  hono: {
+    pin: "hono-upstream-suite-pin.json",
+    sourcePrefix: "src/",
+    distPrefix: "dist/",
+    note: "hono-upstream-suite.mjs rewrites each selected test's relative imports onto package/dist",
+  },
+};
+
+/** Conditions to resolve an `exports` entry with, most specific first. */
+const EXPORT_CONDITIONS = ["import", "module", "default", "node", "require"];
+
+function resolveCondition(value) {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return null;
+  for (const condition of EXPORT_CONDITIONS) {
+    if (!(condition in value)) continue;
+    const resolved = resolveCondition(value[condition]);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+function normalize(relativePath) {
+  return relativePath.replace(/^\.\//, "").replace(/\\/g, "/");
+}
+
+/** Modules the package's `exports` map resolves to, as package-root-relative paths. */
+function exportsMapModules(packageRoot, manifest) {
+  const map = manifest.exports;
+  if (!map || typeof map !== "object") return [];
+  const found = new Set();
+  for (const [subpath, value] of Object.entries(map)) {
+    // A `*` pattern needs a directory walk to expand and a `.json` subpath is
+    // not a module; neither belongs in a compile surface.
+    if (subpath.includes("*") || subpath.endsWith(".json")) continue;
+    const target = resolveCondition(value);
+    if (!target || !/\.(?:js|mjs|cjs)$/.test(target)) continue;
+    const normalized = normalize(target);
+    if (existsSync(join(packageRoot, normalized))) found.add(normalized);
+  }
+  return [...found];
+}
+
+/** Published modules the package's upstream dogfood suite admits. */
+function suiteSubpathModules(name, packageRoot) {
+  const map = SUITE_SUBPATH_MAPS[name];
+  if (!map) return [];
+  let pin;
+  try {
+    pin = JSON.parse(readFileSync(join(HERE, map.pin), "utf-8"));
+  } catch {
+    return [];
+  }
+  const found = new Set();
+  for (const testPath of pin.selectedFiles ?? []) {
+    if (!testPath.startsWith(map.sourcePrefix)) continue;
+    const rest = testPath.slice(map.sourcePrefix.length).replace(/\.test\.tsx?$/, "");
+    if (rest === testPath) continue;
+    for (const candidate of [`${map.distPrefix}${rest}.js`, `${map.distPrefix}${rest}/index.js`]) {
+      if (!existsSync(join(packageRoot, candidate))) continue;
+      found.add(candidate);
+      break;
+    }
+  }
+  return [...found];
+}
+
+/**
+ * Enumerate the compile surface of one npm-compat catalog package.
+ *
+ * @param {string} name catalog package name
+ * @param {{ surface?: "suite" | "exports" }} options
+ * @returns {{ name: string, version: string, packageRoot: string, entryModule: string,
+ *            modules: Array<{ path: string, origin: "entry" | "suite" | "exports" }> }}
+ */
+export function dogfoodSurfaceModules(name, { surface = "suite" } = {}) {
+  const pin = npmCompatCatalogEntry(name);
+  const setup = setupNpmCompatCatalogPackage(name);
+  // Every catalog pin's `entryModule` is `package/<something>`; the tarball's
+  // own root is that first segment, and every path below is relative to it.
+  const packageRootName = pin.entryModule.split("/")[0];
+  const packageRoot = join(setup.root, packageRootName);
+  const entryModule = pin.entryModule.slice(packageRootName.length + 1);
+
+  const origins = new Map();
+  const add = (path, origin) => {
+    if (!origins.has(path)) origins.set(path, origin);
+  };
+  if (setup.entryExists) add(entryModule, "entry");
+
+  let manifest = {};
+  try {
+    manifest = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf-8"));
+  } catch {
+    // A tarball without a readable manifest still has its declared entry; the
+    // wider surfaces simply contribute nothing.
+  }
+
+  for (const path of suiteSubpathModules(name, packageRoot)) add(path, "suite");
+  if (surface === "exports") {
+    for (const path of exportsMapModules(packageRoot, manifest)) add(path, "exports");
+  }
+
+  return {
+    name,
+    version: setup.version,
+    packageRoot,
+    entryModule,
+    // Sorted so the gate's output and its failure ordering are deterministic.
+    modules: [...origins].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)).map(([path, origin]) => ({ path, origin })),
+  };
+}
+
+export const DOGFOOD_SURFACES = Object.freeze(["suite", "exports"]);
+export const DOGFOOD_SUITE_SUBPATH_PACKAGES = Object.freeze(Object.keys(SUITE_SUBPATH_MAPS));

--- a/tests/dogfood/dogfood-surface-modules.test.ts
+++ b/tests/dogfood/dogfood-surface-modules.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5368 — the enumeration behind the widened `check:dogfood-validation` gate.
+//
+// The gate itself is a wall-clock-expensive compile; what is cheap and worth
+// pinning is the SET it compiles. Every assertion here exists because its
+// failure mode is silent: an enumeration that quietly collapses back to the
+// declared entry restores exactly the blind spot #5339 fell into, and the gate
+// would still exit 0.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { dogfoodSurfaceModules } from "./dogfood-surface-modules.mjs";
+
+describe("dogfood surface enumeration (#5368)", () => {
+  it("puts hono's #5339 module in the gated suite surface", () => {
+    const surface = dogfoodSurfaceModules("hono");
+    const paths = surface.modules.map((entry) => entry.path);
+    // The measured miss: `dist/helper/dev/index.js` imports `dist/utils/color.js`,
+    // whose `getColorEnabledAsync` emitted `type error in return[0] (expected
+    // i32, got externref)` on #5676's parent while this gate was green.
+    expect(paths).toContain("dist/helper/dev/index.js");
+    expect(surface.modules.find((entry) => entry.path === "dist/helper/dev/index.js")?.origin).toBe("suite");
+  });
+
+  it("is not vacuous — the suite surface is much wider than the declared entry", () => {
+    const surface = dogfoodSurfaceModules("hono");
+    const entries = surface.modules.filter((entry) => entry.origin === "entry");
+    expect(entries.map((entry) => entry.path)).toEqual(["dist/index.js"]);
+    // 20 selected upstream test files, each admitting one published module. An
+    // enumeration that regressed to "entry only" would pass every other
+    // assertion in this file and gate nothing.
+    expect(surface.modules.length).toBe(21);
+  });
+
+  it("enumerates only modules that exist in the pinned tarball", () => {
+    for (const name of ["hono", "redux", "react", "jest", "moment", "styled-components"]) {
+      const surface = dogfoodSurfaceModules(name, { surface: "exports" });
+      expect(surface.modules.length).toBeGreaterThan(0);
+      for (const entry of surface.modules) {
+        expect(existsSync(join(surface.packageRoot, entry.path)), `${name}/${entry.path}`).toBe(true);
+      }
+    }
+  });
+
+  it("orders deterministically and never repeats a module", () => {
+    const surface = dogfoodSurfaceModules("hono", { surface: "exports" });
+    const paths = surface.modules.map((entry) => entry.path);
+    expect(paths).toEqual([...paths].sort());
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it("reaches modules the exports map does not publish, and vice versa", () => {
+    const suite = dogfoodSurfaceModules("hono").modules;
+    const wide = dogfoodSurfaceModules("hono", { surface: "exports" }).modules;
+    // Neither surface contains the other. hono's `dist/utils/*.js` is internal
+    // — no `exports` subpath resolves to it — yet the suite compiles it, which
+    // is why the GATED surface is the suite one. Conversely the exports map
+    // publishes ~60 middleware/adapter modules no selected test touches.
+    const wideOrigins = new Map(wide.map((entry) => [entry.path, entry.origin]));
+    expect(wideOrigins.get("dist/utils/url.js")).toBe("suite");
+    expect(wide.filter((entry) => entry.origin === "exports").length).toBeGreaterThan(50);
+    expect(wide.length).toBeGreaterThan(suite.length);
+  });
+
+  it("falls back to the declared entry for packages whose suite compiles upstream sources", () => {
+    // redux/jest/styled-components/moment suites compile the upstream REPO, not
+    // published subpaths, so they legitimately contribute no `suite` modules.
+    for (const name of ["redux", "moment", "styled-components"]) {
+      const origins = new Set(dogfoodSurfaceModules(name).modules.map((entry) => entry.origin));
+      expect([...origins]).toEqual(["entry"]);
+    }
+  });
+});

--- a/tests/dogfood/dogfood-surface-probe.mjs
+++ b/tests/dogfood/dogfood-surface-probe.mjs
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5368 — compile a LIST of one package's modules in a single child process
+// and emit one JSON verdict line per module.
+//
+// The list lives in one process on purpose: `src/index.js` plus the TypeScript
+// program setup is ~1.5 s of fixed cost, and the widened surface has ~20x more
+// modules than the old one-entry-per-process shape. Paying that once per chunk
+// rather than once per module is what keeps the gate inside its budget.
+//
+// Isolation is still real — the parent spawns these and kills a chunk that
+// blows its deadline — but a compile that hard-crashes the process takes its
+// chunk-mates' verdicts with it. The parent treats a chunk that stops early as
+// an infrastructure failure rather than silently scoring the missing modules.
+//
+// USAGE (not a user-facing tool; the gate spawns it)
+//   node --import tsx dogfood-surface-probe.mjs --package <name> --modules a.js,b.js
+
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+
+import { compileProject, validateEmittedBinary } from "../../src/index.js";
+import { dogfoodSurfaceModules } from "./dogfood-surface-modules.mjs";
+
+function optionValue(name) {
+  const index = process.argv.indexOf(name);
+  return index < 0 ? null : (process.argv[index + 1] ?? null);
+}
+
+const name = optionValue("--package");
+const modulesArgument = optionValue("--modules");
+if (!name || !modulesArgument) {
+  process.stdout.write(`${JSON.stringify({ fatal: "usage: --package <name> --modules <a.js,b.js>" })}\n`);
+  process.exit(2);
+}
+
+// Only the resolved package root is needed here — the parent already decided
+// WHICH modules this chunk compiles.
+const surface = dogfoodSurfaceModules(name);
+const compileOptions = {
+  allowJs: true,
+  skipSemanticDiagnostics: true,
+  target: "gc",
+  platform: "node",
+};
+
+for (const modulePath of modulesArgument.split(",").filter(Boolean)) {
+  const started = performance.now();
+  let verdict = "invalid";
+  let detail = null;
+  let binaryBytes = 0;
+  try {
+    const result = await compileProject(join(surface.packageRoot, modulePath), compileOptions);
+    if (!result.success) {
+      // A module that does not codegen at all makes the implication vacuous.
+      // That is a different gate's business (#5332); count it, never fail on it.
+      verdict = "compile-failed";
+      detail = result.errors[0]?.message ?? "compile did not emit a binary";
+    } else {
+      binaryBytes = result.binary.byteLength;
+      const validation = validateEmittedBinary(result.binary);
+      verdict = validation.valid ? "valid" : "invalid";
+      detail = validation.valid ? null : (validation.detail ?? "emitted binary failed WebAssembly validation");
+    }
+  } catch (error) {
+    // A throw out of compileProject is a compiler crash, not an invalid
+    // binary; it says nothing about the implication under test.
+    verdict = "compile-failed";
+    detail = `compileProject threw: ${error instanceof Error ? error.message : String(error)}`;
+  }
+  process.stdout.write(
+    `${JSON.stringify({
+      package: name,
+      module: modulePath,
+      verdict,
+      detail,
+      binaryBytes,
+      compileMs: Math.round(performance.now() - started),
+    })}\n`,
+  );
+}


### PR DESCRIPTION
Closes [#5368](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5368-dogfood-validation-gate-declared-entry-only).

## The hole

`check:dogfood-validation` (required inside `quality`) asserts
`compile.success ⇒ the emitted binary validates` — but it compiled exactly one
module per package, the declared entry. Every module a dogfood suite admits
through a subpath was invisible to it. That is how
[#5339](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5339-hono-dev-index-whole-module)
stayed live on main with the gate green: hono's `dist/helper/dev/index.js`
pulls in `dist/utils/color.js`, whose `getColorEnabledAsync` emitted
`type error in return[0] (expected i32, got externref)`.

## Mechanism

- `tests/dogfood/dogfood-surface-modules.mjs` enumerates a package's compile
  surface from the **committed suite pins** — no upstream clone, no generated
  tree. Only hono's suite rewrites its tests' imports onto the published
  `dist/` tree; redux/jest/styled-components/moment/react suites compile the
  upstream repository's sources, so their admitted set is legitimately the
  entry alone. The mapping is one declarative table entry per package.
- `tests/dogfood/dogfood-surface-probe.mjs` compiles a **chunk** of that
  surface in one child process — one process per chunk, not per module,
  because loading the compiler costs ~1.5 s and the surface has 20x the
  modules the entry-only gate had.
- Both phases now share **one** worker pool, so the short subpath chunks fill
  the gaps between the six long entry probes instead of forming a tail.
- A module that does not codegen at all is counted and printed but never
  failed on — that makes the implication vacuous, which is #5332's business. A
  chunk that dies mid-way is an infrastructure failure (exit 3), never a silent
  pass over the modules it never reached.
- Two surfaces: `suite` (gated, default) and `--surface exports` (survey).
  `--list-modules` prints either without running anything.

## Evidence — same command, two trees

| tree | subpath surface | verdict | exit |
| --- | --- | --- | --- |
| `34720daf53` — #5676's parent | 20 modules, 19 valid, **1 invalid** | **RED** | 1 |
| `cf82f78d6d` — main, 2026-09-12 | 20 modules, 20 valid | **GREEN** | 0 |

The one invalid module on the parent is exactly #5339, and the message names
package, module path and the engine's verbatim words:

```
::error::[dogfood-validation] hono module dist/helper/dev/index.js compiled 36,213 bytes
that do NOT validate: WebAssembly.Module(): Compiling function #36:"getColorEnabledAsync"
failed: type error in return[0] (expected i32, got externref) @+11543
```

## Wall clock

Back-to-back on the same (loaded, shared) box, concurrency 4:

| run | wall | vs base |
| --- | --- | --- |
| entry-only gate | 44.5 s | 1.00x |
| widened, run 1 | 71.8 s | 1.61x |
| widened, run 2 | 65.0 s | 1.46x |

Inside the ≤ 2x budget. The added *work* is ~12 s of CPU (hono's 20 modules
serially); most of the delta is contention from four more concurrent children.

## What the survey found — three new bugs, not fixed here

`--surface exports` over hono's 74 published modules on main finds **7 invalid
modules**, three distinct codegen defects:

- [#6412](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6412-hono-jwt-async-resume-extern-convert-any) — `extern.convert_any` given an already-external ref in `__async_resume_fimportPublicKey` (`utils/jwt`, `middleware/jwk`, `middleware/jwt`)
- [#6413](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6413-hono-jsx-dom-closure-fallthru-externref) — closure declared `i32` falling through with `externref` (`jsx/dom/client`, `jsx/dom/jsx-runtime`, `jsx/dom/jsx-dev-runtime`)
- [#6414](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6414-hono-cloudflare-pages-async-resume-struct-set) — `struct.set` of an `externref` into an `i32` frame slot (`adapter/cloudflare-pages`)

They are recorded in `KNOWN_INVALID_MODULES`; on the default surface that list
waives nothing. Gating the exports surface means emptying it first — and also
costs 151 s of CPU for hono alone, which does not fit the `quality` budget.

Compiling the whole exports surface as **one union barrel** was tried and does
not work: 178 s and then a hard codegen failure, which makes the implication
vacuous for the entire package. Per-module compiles are what stop one bad
module from blinding the rest.

## Test

`tests/dogfood/dogfood-surface-modules.test.ts` pins the SET, because an
enumeration that quietly collapsed back to the declared entry would restore the
exact blind spot and still exit 0. Anti-vacuity control: disabling the suite
mapping fails 3 of its 6 tests.

`.github/workflows/**` untouched — the gate is already wired into `quality`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
