### PR TITLE
fix(#5341): `.call` keeps its receiver at any arity, not just an exact one

### DIFF
--- a/plan/issues/5341-axios-residual-buckets.md
+++ b/plan/issues/5341-axios-residual-buckets.md
@@ -1,10 +1,11 @@
 ---
 id: 5341
 title: "axios residual: 31 failures across nine files after the three landed blockers — prioritised by bucket"
-status: ready
+status: done
 sprint: current
 created: 2026-09-05
-updated: 2026-09-05
+updated: 2026-09-12
+completed: 2026-09-12
 priority: high
 horizon: m
 feasibility: medium
@@ -90,3 +91,88 @@ Notes that narrow the work:
 
 Model: **opus**. Nine small buckets need triage judgement to find the shared
 cause rather than nine local patches.
+
+
+## Resolution
+
+**Mechanism — `.call`/`.apply`/`bind` DROPPED the receiver at any arity but an
+exact one.** The receiver-correct trampoline (#3796) is reached only through
+`resolveNamedThisCallTarget` (`src/codegen/named-this-call.ts`), whose
+admission gate required
+`userArguments.length === declaration.parameters.length`. Every other arity
+fell through to the ordinary `.call` lowering in
+`src/codegen/expressions/calls.ts`, which evaluates `thisArg` and then
+literally `drop`s it. That is a silent wrong answer, not a refusal: the callee
+read the AMBIENT receiver.
+
+axios `lib/core/transformData.js` is exactly that shape —
+
+```js
+export default function transformData(fns, response) {
+  const config = this || defaults;      // `this` was lost …
+  const context = response || config;
+  let data = context.data;              // … so this read `defaults.data`
+  utils.forEach(fns, function transform(fn) { data = fn.call(config, data, …); });
+  return data;
+}
+```
+
+called as `transformData.call({ data: '' }, fns)` — one argument into two
+formals. `data` started as `undefined` instead of `''`, so three appending
+transformers produced `'undefinedfoo'` instead of `'foo'`, and every
+`transformResponse` case that reads its body out of `this` answered
+`undefined`.
+
+Reduced to a two-file untyped `.js` fixture, the whole defect is arity:
+
+| call (callee declares 2 formals, reads `this`)  | native      | wasm before      | wasm after |
+| ----------------------------------------------- | ----------- | ---------------- | ---------- |
+| `f.call(t, 1, 2)`                               | `T\|1\|2`   | `T\|1\|2`        | `T\|1\|2`  |
+| `f.call(t, 1)`                                  | `T\|1\|und` | `NO-THIS\|1\|und` | `T\|1\|und` |
+| `f.call(t, 1, 2, 3)`                            | `T\|1\|2`   | `NO-THIS\|1\|2`  | `T\|1\|2`  |
+| `f.apply(t, [1])`                               | `T\|1\|und` | `NO-THIS\|1\|und` | `T\|1\|und` |
+| `f.bind(t)(1)`                                  | `T\|1\|und` | `NO-THIS\|1\|und` | `T\|1\|und` |
+
+**Fix.** The arity clause is removed from the admission gate. It is sound to
+admit every arity because the operand stack the caller builds is ALWAYS
+`paramTypes.length` wide: under-application pads (optional-param sentinels,
+then `pushDefaultValue`), over-application either marshals the overflow
+through the extras-argv global or compiles-and-drops it, and a rest
+declaration packs its trailing arguments into the single vec parameter. The
+trampoline's signature is `[externref this, ...targetParams]`, so that stack
+fits it unchanged; the only thing admission changes is that the receiver is
+INSTALLED instead of discarded. One file, one clause.
+
+**Counts.** axios `202/231 → 208/231` at one HEAD (`upstream/main`
+`cf82f78d6d`). Six flips, all `failed → passed`, no regressions in the suite:
+
+| file                             | before | after |
+| -------------------------------- | ------ | ----- |
+| `core/transformData.test.js`     | 2/4    | 4/4   |
+| `transformResponse.test.js`      | 1/6    | 5/6   |
+
+**Regression test.** `tests/issue-5341-under-applied-call-receiver.test.ts` —
+15 cases on untyped `.js` two-file fixtures: 11 fail on the parent and pass
+with the fix; 4 controls pass both ways; plus an anti-vacuity control that
+proves the harness can still see an absent receiver.
+
+**Also refreshed:** `tests/issue-3796-named-this-call.test.ts` was RED on
+`upstream/main` before this change, for two reasons unrelated to it — it
+asserted `catch_all`/`rethrow 0` in a standalone module that has emitted
+`try_table` since standardized EH (#4620) landed, and it asserted
+`$__named_this_call_readsThis_` is absent when #3983 legitimately emits it for
+the `.apply` site. Both assertions were refreshed to the behaviour that
+actually holds; its over-arity negative moved to a positive per this change,
+with the runtime answer unchanged at `2116`.
+
+## Residuals (deliberately not taken here)
+
+- **`arguments.length` is still the FORMAL count inside an under-applied
+  target** — `f.call({}, 1)` into `function f(a, b)` reports `2`. Independent
+  of the receiver, reads identically before and after this fix. Filed as
+  **#6416**.
+- **The other 23 axios failures** — `buildURL` (6), the `instance mismatch`
+  cluster (4, → #5347), the `validator returned 1` cluster (3), `isX` (3),
+  `isNativeError` (2), `composeSignals` (1), and `platform` (2, a
+  `randomFillSync` host-shim gap that is not a compiler bug). Re-measured
+  after this fix and filed as **#6417**.

--- a/plan/issues/6416-arguments-length-under-applied-call.md
+++ b/plan/issues/6416-arguments-length-under-applied-call.md
@@ -1,0 +1,68 @@
+---
+id: 6416
+title: "`arguments.length` inside an under-applied `.call`/`.apply` target reports the FORMAL count, not the supplied one"
+status: ready
+sprint: current
+created: 2026-09-12
+updated: 2026-09-12
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+A named function invoked reflectively with fewer arguments than it declares
+sees `arguments.length` equal to its FORMAL count, not the count the call site
+actually supplied.
+
+```js
+function f(a, b) { return arguments.length; }
+f.call({}, 1);   // native 1 · wasm 2
+```
+
+Found while fixing [#5341](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5341-axios-residual-buckets)
+(the under-applied `.call` receiver drop). It is a **separate, pre-existing**
+mechanism: it reads identically before and after that fix, and it is
+independent of the receiver — the receiver is now correct while
+`arguments.length` is still wrong.
+
+Measured 2026-09-12 on `upstream/main` `cf82f78d6d`, probe via
+`compileAndRunUpstreamModule`, two-file untyped `.js` fixture:
+
+| call                                 | native  | wasm (before #5341) | wasm (after #5341) |
+| ------------------------------------ | ------- | ------------------- | ------------------ |
+| `withArguments.call({t:'T'}, 1)`     | `T\|1`  | `NO-THIS\|2`        | `T\|2`             |
+
+with `function withArguments(a, b) { return (this ? this.t : 'NO-THIS') + '|' + arguments.length; }`.
+
+## Where to look
+
+`maybeSetArgcForKnownCall` (`src/codegen/statements/nested-declarations.ts`
+~L3760) does push `i32.const min(actualArgCount, paramCount)` into the
+`__argc` global at the `.call` site — so the value written appears to be
+right (1). The reader side is what to check: whatever computes
+`arguments.length` for a plain named FunctionDeclaration is falling back to
+the formal count rather than honouring the global. Candidates: the argc
+global is reset to `-1` before the callee reads it, or the `arguments`
+materialisation for a non-closure target never consults it.
+
+Note that the `.call` path now goes through the `#3796` named-`this`
+trampoline for these arities. The trampoline does not touch `__argc` — it
+only saves/installs/restores `__current_this` — so it is not the cause, but
+confirm that on the emitted WAT rather than assuming it.
+
+## Acceptance criteria
+
+1. `f.call(t, 1)` into `function f(a, b)` answers `arguments.length === 1`,
+   and `arguments[1] === undefined`.
+2. The same for `.apply(t, [1])` and for an immediately-invoked
+   `f.bind(t)(1)`.
+3. Over-application is unchanged (the extras-argv ABI already carries it).
+4. Regression test with untyped `.js` two-file fixtures, failing on the
+   parent and passing with the fix, plus an anti-vacuity control.
+5. A/B over the 17 dogfood suites — no regression.

--- a/plan/issues/6417-axios-residual-round-2.md
+++ b/plan/issues/6417-axios-residual-round-2.md
@@ -1,0 +1,85 @@
+---
+id: 6417
+title: "axios residual round 2: 23 failures across eight files after the under-applied `.call` receiver fix"
+status: ready
+sprint: current
+created: 2026-09-12
+updated: 2026-09-12
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+axios is **208/231** on `upstream/main` `cf82f78d6d` + the
+[#5341](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5341-axios-residual-buckets)
+receiver fix (202 before it). The six tests that moved were the whole
+`transformData`/`transformResponse` bucket. What is left is what #5341
+explicitly did not take, re-measured after it, plus one bucket that #5341's
+own evidence mis-attributed.
+
+## Evidence (2026-09-12, `tests/dogfood/report/axios-upstream-suite.json`)
+
+```
+ 3  TypeError: Cannot access property on null or undefined   buildURL.test.js
+ 3  assertion 1 toEqual mismatch                             isX.test.js
+ 2  assertion 1 instance mismatch                            validator.test.js   (0/2)
+ 2  validation function expected "true". Received 1          fromDataURI.test.js
+ 2  randomFillSync is not a function                         platform.test.js    ← host shim gap
+ 1  Function.prototype.bind called on incompatible undefined buildURL.test.js
+ 1  assertion 1 toEqual mismatch                             buildURL.test.js
+ 1  assertion 1 toBe: string:undefined != string:function    buildURL.test.js
+ 1  assertion 1 instance mismatch                            AxiosError.test.js
+ 1  assertion 2 instance mismatch                            settle.test.js
+ 1  assertion 1 toBe: object:null != boolean:true            AxiosError.test.js
+ 1  assertion 1 expected contained value                     AxiosError.test.js
+ 1  assertion 1 toBe: object != object                       AxiosError.test.js
+ 1  assertion 1 toBe: object:null != boolean:true            canceledError.test.js
+ 1  RuntimeError: dereferencing a null pointer               composeSignals.test.js
+ 1  validation function expected "true". Received 1          transformResponse.test.js
+```
+
+Ordered by what a single mechanism would buy:
+
+1. **`buildURL` (6)** — the biggest single file. Three shapes, probably one
+   cause: `AxiosURLSearchParams` construction/`toString(_encode)` returning
+   nullish. Note `should be exported as a named export` reports the module's
+   own `buildURL` binding as `string:undefined` where `function` is expected,
+   which points at the module-shape side rather than the body.
+2. **The `instance mismatch` cluster (4)** — `validator` ×2, `AxiosError` ×1,
+   `settle` ×1. `instanceof` against a class that crossed the host boundary;
+   same family as #5325's residual and #5347. **Check #5347 first and fix it
+   there once** rather than locally here.
+3. **`The validation function is expected to return "true". Received 1` (3)** —
+   `fromDataURI` ×2, `transformResponse` ×1. Node's `assert.throws(fn,
+   validator)` requires the validator to return literally `true`; a compiled
+   validator returning a boolean answers `1` to the host caller. If that is a
+   boolean→number boxing at the function-RETURN host boundary it is one
+   narrow mechanism worth taking on its own — verify before assuming, the
+   validators also contain an `instanceof` that may be failing for reason 2.
+4. **`isX` (3)** — `ArrayBuffer`, `ArrayBufferView`, `Date` type predicates.
+5. **`util.types.isNativeError` answers `null` (2)** — `AxiosError` and
+   `canceledError` both assert a compiled Error subclass is recognised as a
+   native error by Node; the host call answers `null`.
+6. **`composeSignals` (1)** — the one remaining trap in axios. `AbortSignal`
+   composition through `addEventListener` callbacks; capture-cell family
+   (#5320/#5323).
+7. **`platform` (2) is NOT a compiler bug.** `randomFillSync` is a Node
+   `crypto` builtin the host shim does not expose. Record, do not fix.
+
+So the compiler-addressable ceiling here is **229/231**, and the realistic
+next step is 1 + 2 (10 tests).
+
+## Acceptance criteria
+
+1. axios ≥ 214/231, or an equivalent gain if a target bucket turns out to be
+   non-compiler.
+2. One PR per independent cause; a cause shared with #5347 lands there.
+3. Regression tests with untyped `.js` two-file fixtures, failing on the
+   parent, with an anti-vacuity control.
+4. A/B at one HEAD over the 17 dogfood suites, per test file.

--- a/src/codegen/named-this-call.ts
+++ b/src/codegen/named-this-call.ts
@@ -423,14 +423,34 @@ export function resolveNamedThisCallTarget(
   userArguments: readonly ts.Expression[],
 ): NamedThisCallTarget | undefined {
   const declaration = resolveDeclaration(ctx, callee);
-  const restIndex = declaration?.parameters.findIndex((parameter) => parameter.dotDotDotToken !== undefined) ?? -1;
-  // Rest arguments are packed into the declaration's single vec parameter by
-  // the ordinary `.call` lowering before it invokes this trampoline. Their
-  // source count therefore does not need to equal the Wasm parameter count;
-  // only every non-rest prefix parameter must be present.
-  const arityAdmitted =
-    declaration !== undefined &&
-    (restIndex >= 0 ? userArguments.length >= restIndex : userArguments.length === declaration.parameters.length);
+  // (#5341) ARITY NO LONGER GATES ADMISSION. It used to demand an exact match
+  // (`userArguments.length === declaration.parameters.length`, or `>= restIndex`
+  // for a rest declaration), and everything else fell through to the ordinary
+  // `.call` lowering — which evaluates `thisArg` and DROPS it. That is a silent
+  // wrong answer, not a refusal: axios' `transformData.call({ data: '' }, fns)`
+  // passes one argument into two formals, so `const config = this || defaults`
+  // read the ambient receiver and `context.data` answered `undefined` —
+  // `'undefinedfoo'` instead of `'foo'` (five more of the same shape in
+  // `transformResponse`).
+  //
+  // Admitting every arity is sound because the operand stack the caller builds
+  // is ALWAYS `paramTypes.length` wide, whatever the source argument count:
+  //   - under-application pads — optional-param sentinels first, then
+  //     `pushDefaultValue` for the remaining formals;
+  //   - over-application either marshals the overflow through the extras-argv
+  //     global (`emitSetExtrasArgv`, which pushes no operand) or compiles and
+  //     drops it;
+  //   - a rest declaration packs its trailing arguments into the single vec
+  //     parameter before the call.
+  // The trampoline's signature is exactly `[externref this, ...targetParams]`,
+  // so that stack fits it unchanged. The only thing admission changes is that
+  // the receiver is INSTALLED instead of discarded.
+  //
+  // Not fixed here, and still a residual: `arguments.length` inside an
+  // under-applied `.call` target reports the FORMAL count, not the supplied
+  // one. That is the argc-global protocol, independent of the receiver, and it
+  // reads the same before and after this change.
+
   // (#4203) Strictness of the TARGET, not of the call site: §10.4.3 keys the
   // receiver's treatment on the callee's own code. Only a strict target can
   // observe explicit-null differently from absent, so only a strict target
@@ -443,7 +463,6 @@ export function resolveNamedThisCallTarget(
     !declaration?.body ||
     ctx.liveFuncBindingGlobals?.has(callee.text) === true ||
     !declarationOwnsHandle(ctx, declaration, targetFuncIdx) ||
-    !arityAdmitted ||
     userArguments.some((argument) => ts.isSpreadElement(argument)) ||
     (declaration.parameters[0] &&
       ts.isIdentifier(declaration.parameters[0].name) &&

--- a/tests/issue-3796-named-this-call.test.ts
+++ b/tests/issue-3796-named-this-call.test.ts
@@ -90,8 +90,14 @@ describe("#3796 receiver-correct stable named FunctionDeclaration.call", () => {
 
     expect((instance.exports.run as () => number)()).toBe(42);
     expect(result.wat).toContain("$__named_this_call_throwFromReceiver_");
-    expect(result.wat).toContain("catch_all");
-    expect(result.wat).toContain("rethrow 0");
+    // The standalone/WASI lane lowers the trampoline's restore-and-rethrow
+    // through STANDARDIZED exception handling (#4620), so the shape is a
+    // `try_table` with an explicit `catch` + `throw`, not the legacy
+    // `try`/`catch_all`/`rethrow 0`. Those two literals have not been in this
+    // module since standardized EH landed; asserting them made this case red
+    // on main independently of what it is testing (noticed while fixing
+    // #5341). Assert the shape that actually carries the restore.
+    expect(result.wat).toContain("try_table");
   });
 
   it("executes Acorn's finishNodeAt locations/ranges wrapper shape", async () => {
@@ -122,7 +128,7 @@ describe("#3796 receiver-correct stable named FunctionDeclaration.call", () => {
     expect(result.wat).toContain("$__named_this_call_wrapper_");
   });
 
-  it("keeps unstable identity, over-arity, and unsupported call shapes off the trampoline", async () => {
+  it("keeps unstable identity and unsupported call shapes off the trampoline", async () => {
     const source = `
       function readsThis(value) { return this.value + value; }
       function ignoresThis(value) { return value; }
@@ -175,13 +181,22 @@ describe("#3796 receiver-correct stable named FunctionDeclaration.call", () => {
     `;
     const { result, instance } = await compileStandalone(source, "issue-3796-negatives.mjs");
 
-    expect(result.wat).not.toContain("$__named_this_call_readsThis_");
+    // `readsThis` IS on the trampoline — not from `nullReceiver` (a provably
+    // null receiver still keeps the legacy lowering) but from `applyReceiver`,
+    // which #3983 routes onto the receiver-correct `.call` path. That has been
+    // true since #3983; the stale `not.toContain` here made this case red on
+    // main (noticed while fixing #5341). Assert the answers instead.
+    expect((instance.exports.applyReceiver as () => number)()).toBe(3);
     expect(result.wat).not.toContain("$__named_this_call_ignoresThis_");
     expect(result.wat).not.toContain("$__named_this_call_closure_");
     expect(result.wat).not.toContain("$__named_this_call_mutableTarget_");
     expect(result.wat).not.toContain("$__named_this_call_nestedTarget_");
     expect(result.wat).not.toContain("$__named_this_call_shadowedTarget_");
-    expect(result.wat).not.toContain("$__named_this_call_overArityTarget_");
+    // (#5341) Over-arity is no longer a refusal: the caller drops or marshals
+    // the overflow before the call, so the trampoline's operand stack is the
+    // same either way and the receiver is now installed rather than discarded.
+    // The answer below is unchanged — it never read `this` on this path.
+    expect(result.wat).toContain("$__named_this_call_overArityTarget_");
     expect((instance.exports.reassignedBeforeWrite as () => number)()).toBe(42);
     expect((instance.exports.nestedDeclaration as () => number)()).toBe(42);
     expect((instance.exports.sameNameShadow as () => number)()).toBe(42);

--- a/tests/issue-5341-under-applied-call-receiver.test.ts
+++ b/tests/issue-5341-under-applied-call-receiver.test.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #5341 — `fn.call(thisArg, …)` DROPPED the receiver whenever the supplied
+// argument count did not exactly equal the callee's formal count.
+//
+// The receiver-correct trampoline (#3796) is only reached through
+// `resolveNamedThisCallTarget`, whose admission gate demanded
+// `userArguments.length === declaration.parameters.length`. Every other arity
+// fell through to the ordinary `.call` lowering, which evaluates `thisArg` and
+// then literally `drop`s it — a silent wrong answer, not a refusal. The callee
+// therefore read the AMBIENT receiver.
+//
+//     function f(fns, response) { const c = this || defaults; … }
+//     f.call({ data: '' }, fns)          // 1 argument, 2 formals → this lost
+//
+// That is axios' `lib/core/transformData.js` verbatim. `const config = this ||
+// defaults` picked up `defaults`, `context.data` answered `undefined`, and the
+// transformer chain produced `'undefinedfoo'` instead of `'foo'` — six axios
+// unit tests across `core/transformData` and `transformResponse`.
+//
+// The fixtures are plain untyped `.js`, matching how the upstream npm suites
+// feed package code in: a typed fixture routes the call through a different
+// lowering and proves nothing here. Cases marked (was ✗) answered wrongly on
+// the parent commit; the controls passed there and must keep passing.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { compileProject } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+const ENTRY = `import { run } from "./mod.js";\nexport function test(): string { return String((run as unknown as () => unknown)()); }`;
+
+async function runModule(moduleSource: string): Promise<string> {
+  const root = mkdtempSync(join(tmpdir(), "js2-5341-"));
+  roots.push(root);
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, "mod.js"), moduleSource);
+  writeFileSync(join(root, "entry.ts"), ENTRY);
+  const result = await compileProject(join(root, "entry.ts"), {
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "gc",
+    platform: "node",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const instance = await instantiateWithRuntime(result);
+  return String((instance.exports as Record<string, () => unknown>).test());
+}
+
+/** [name, module source, expected]. */
+const cases: Array<[string, string, string]> = [
+  // ── the reported repro: axios transformData, reduced ────────────────────────
+  [
+    "axios transformData shape: 1 argument into 2 formals (was ✗: 'undefinedfoo')",
+    `const defaults = { data: 'DEFAULTS' };
+function transformData(fns, response) {
+  const config = this || defaults;
+  const context = response || config;
+  let data = context.data;
+  fns.forEach(function transform(fn) { data = fn.call(config, data); });
+  return data;
+}
+export function run() {
+  return transformData.call({ data: '' }, [(v) => v + 'f', (v) => v + 'o', (v) => v + 'o']);
+}`,
+    "foo",
+  ],
+  [
+    "one argument short (was ✗: NO-THIS)",
+    `function f(a, b) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + String(b); }
+export function run() { return f.call({ t: 'T' }, 1); }`,
+    "T|1|undefined",
+  ],
+  [
+    "no arguments at all into one formal (was ✗: NO-THIS)",
+    `function f(a) { return (this ? this.t : 'NO-THIS') + '|' + String(a); }
+export function run() { return f.call({ t: 'T' }); }`,
+    "T|undefined",
+  ],
+  [
+    "under-applied .apply (was ✗: NO-THIS)",
+    `function f(a, b) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + String(b); }
+export function run() { return f.apply({ t: 'T' }, [1]); }`,
+    "T|1|undefined",
+  ],
+  [
+    "bare .apply(thisArg) with no argv (was ✗: NO-THIS)",
+    `function f(a, b) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + String(b); }
+export function run() { return f.apply({ t: 'T' }); }`,
+    "T|undefined|undefined",
+  ],
+  [
+    "immediately-invoked under-applied bind (was ✗: NO-THIS)",
+    `function f(a, b) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + String(b); }
+export function run() { return f.bind({ t: 'T' })(1); }`,
+    "T|1|undefined",
+  ],
+  [
+    "over-applied .call (was ✗: NO-THIS)",
+    `function f(a, b) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + String(b); }
+export function run() { return f.call({ t: 'T' }, 1, 2, 3); }`,
+    "T|1|2",
+  ],
+  [
+    "rest declaration, nothing supplied for the leading formal (was ✗: NO-THIS)",
+    `function f(a, ...more) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + more.length; }
+export function run() { return f.call({ t: 'T' }); }`,
+    "T|undefined|0",
+  ],
+  // ── controls: green on the parent, must stay green ──────────────────────────
+  [
+    "control: exact arity",
+    `function f(a, b) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + String(b); }
+export function run() { return f.call({ t: 'T' }, 1, 2); }`,
+    "T|1|2",
+  ],
+  [
+    "control: rest declaration at exact-or-more arity",
+    `function f(a, ...more) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + more.length; }
+export function run() { return f.call({ t: 'T' }, 1, 2, 3); }`,
+    "T|1|2",
+  ],
+  [
+    "control: callee that ignores `this` still just gets padded arguments",
+    `function f(a, b) { return String(a) + '|' + String(b); }
+export function run() { return f.call({ t: 'T' }, 1); }`,
+    "1|undefined",
+  ],
+  [
+    "control: under-applied call with an absent receiver is unchanged",
+    `function f(a, b) { return (this ? this.t : 'NO-THIS') + '|' + String(a) + '|' + String(b); }
+export function run() { return f(1); }`,
+    "NO-THIS|1|undefined",
+  ],
+  [
+    "control: the receiver is restored after the under-applied call returns",
+    `function inner(a, b) { return (this ? this.t : 'NO-THIS') + String(a) + String(b); }
+function outer() { const got = inner.call({ t: 'I' }, 1); return got + '/' + (this ? this.t : 'NO-THIS'); }
+export function run() { return outer.call({ t: 'O' }); }`,
+    "I1undefined/O",
+  ],
+  [
+    "control: the receiver is restored when the under-applied call throws",
+    `function boom(a, b) { if (this.fail) throw new Error('x'); return String(a) + String(b); }
+function outer() {
+  try { boom.call({ fail: true }, 1); } catch (e) { return 'caught/' + (this ? this.t : 'NO-THIS'); }
+  return 'no-throw';
+}
+export function run() { return outer.call({ t: 'O' }); }`,
+    "caught/O",
+  ],
+];
+
+describe("#5341 under- and over-applied `.call` keeps its receiver", () => {
+  for (const [name, source, expected] of cases) {
+    it(name, async () => {
+      await expect(runModule(source)).resolves.toBe(expected);
+    });
+  }
+
+  // Anti-vacuity: the harness must be able to SEE a wrong receiver. If the
+  // fixture shape silently stopped exercising `.call` at all, this case would
+  // pass by accident along with everything above.
+  it("anti-vacuity control: a genuinely absent receiver still reads as absent", async () => {
+    await expect(
+      runModule(
+        `function f(a, b) { return (this ? this.t : 'NO-THIS') + '|' + String(a); }
+export function run() { const g = f; return g(1) + '#' + f.call({ t: 'T' }, 1); }`,
+      ),
+    ).resolves.toBe("NO-THIS|1#T|1");
+  });
+});


### PR DESCRIPTION
Closes [#5341](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5341-axios-residual-buckets).

## Mechanism

`fn.call(thisArg, …)` **dropped the receiver at every arity but an exact one.**

The receiver-correct trampoline ([#3796](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3796-named-this-call)) is reached only through
`resolveNamedThisCallTarget` in `src/codegen/named-this-call.ts`, whose
admission gate demanded `userArguments.length === declaration.parameters.length`.
Everything else fell through to the ordinary `.call` lowering in
`src/codegen/expressions/calls.ts`, which evaluates `thisArg` and then literally
`drop`s it. That is a silent wrong answer, not a refusal — the callee read the
**ambient** receiver.

axios `lib/core/transformData.js` is exactly that shape:

```js
export default function transformData(fns, response) {
  const config = this || defaults;   // `this` was lost → config = defaults
  const context = response || config;
  let data = context.data;           // → undefined instead of ''
  utils.forEach(fns, function transform(fn) { data = fn.call(config, data, …); });
  return data;
}
```

called as `transformData.call({ data: '' }, fns)` — one argument into two
formals. Three appending transformers then produced `'undefinedfoo'` instead of
`'foo'`, and every `transformResponse` case that reads its body out of `this`
answered `undefined`.

Reduced to a two-file untyped `.js` fixture, the whole defect is arity
(callee declares 2 formals and reads `this`):

| call | native | wasm before | wasm after |
| --- | --- | --- | --- |
| `f.call(t, 1, 2)` | `T\|1\|2` | `T\|1\|2` | `T\|1\|2` |
| `f.call(t, 1)` | `T\|1\|undefined` | `NO-THIS\|1\|undefined` | `T\|1\|undefined` |
| `f.call(t, 1, 2, 3)` | `T\|1\|2` | `NO-THIS\|1\|2` | `T\|1\|2` |
| `f.apply(t, [1])` | `T\|1\|undefined` | `NO-THIS\|1\|undefined` | `T\|1\|undefined` |
| `f.bind(t)(1)` | `T\|1\|undefined` | `NO-THIS\|1\|undefined` | `T\|1\|undefined` |

## Fix

The arity clause is removed from the admission gate — one file, one clause.

It is sound to admit every arity because the operand stack the caller builds is
**always `paramTypes.length` wide**, whatever the source argument count:

- under-application pads — optional-param sentinels first, then `pushDefaultValue`;
- over-application either marshals the overflow through the extras-argv global
  (`emitSetExtrasArgv`, which pushes no operand) or compiles and drops it;
- a rest declaration packs its trailing arguments into the single vec parameter.

The trampoline's signature is exactly `[externref this, ...targetParams]`, so
that stack fits it unchanged. Admission only decides whether the receiver is
**installed** or **discarded**.

## Counts

axios **202/231 → 208/231** at one HEAD (`upstream/main` `cf82f78d6d`). Six
flips, all `failed → passed`, nothing else in the suite moved:

| file | before | after |
| --- | --- | --- |
| `tests/unit/core/transformData.test.js` | 2/4 | 4/4 |
| `tests/unit/transformResponse.test.js` | 1/6 | 5/6 |

## Tests

`tests/issue-5341-under-applied-call-receiver.test.ts` — 15 cases on untyped
`.js` two-file fixtures. **11 fail on the parent commit and pass with the fix**;
4 controls pass both ways (exact arity, rest at exact-or-more arity, a callee
that ignores `this`, an under-applied call with no receiver at all), plus an
anti-vacuity control that proves the harness can still observe an absent
receiver.

**`tests/issue-3796-named-this-call.test.ts` was already RED on
`upstream/main`**, for two reasons unrelated to this change, and is refreshed
here:

- it asserted `catch_all` / `rethrow 0` in a **standalone** module, which has
  lowered the trampoline's restore-and-rethrow through standardized EH
  (`try_table` + `catch` + `throw`) since #4620;
- it asserted `$__named_this_call_readsThis_` is absent when #3983 legitimately
  emits it for the `.apply` site in the same fixture.

Its over-arity negative moved to a positive per this change; the runtime answer
it guards is unchanged at `2116`.

## Residuals

- [**#6416**](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6416-arguments-length-under-applied-call) — `arguments.length` inside an under-applied target still reports
  the FORMAL count (`f.call({}, 1)` into `function f(a, b)` answers `2`).
  Independent of the receiver; reads identically before and after this fix.
- [**#6417**](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6417-axios-residual-round-2) — the other 23 axios failures, re-measured after this fix:
  `buildURL` (6), the `instance mismatch` cluster (4, belongs to [#5347](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5347-redux-getprototypeof-compiled-class-instance)), the
  "validator returned 1" cluster (3), `isX` (3), `isNativeError` (2),
  `composeSignals` (1), and `platform` (2 — a `randomFillSync` host-shim gap
  that is not a compiler bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
