### PR TITLE
docs(issues): file #6424 (worker uncaughtException still zeroes a file) and #6425 (hono TextEncoder)

### DIFF
--- a/plan/issues/6424-worker-uncaught-exception-still-zeroes-file.md
+++ b/plan/issues/6424-worker-uncaught-exception-still-zeroes-file.md
@@ -1,0 +1,72 @@
+---
+id: 6424
+title: "An uncaught exception in the dogfood Wasm worker still zeroes the whole test file — the other half of #5369"
+status: ready
+sprint: current
+created: 2026-09-12
+updated: 2026-09-12
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: infra
+area: testing
+goal: correctness
+---
+
+## Problem
+
+[#5369](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5369-unhandled-host-rejection-zeroes-test-module)
+removed the whole-file cliff for one failure mode — an unobserved host-promise
+**rejection** — by installing a sink in
+`tests/dogfood/upstream-suite-compile-worker.mjs` and attributing each reason
+to the test that was running.
+
+The sibling mode is untouched. A host **throw** from outside any awaited test
+body — a `setTimeout` callback, a stream `error` event, a scheduler handle the
+guest left behind — is an `uncaughtException`, and the worker still has no
+listener for it. Node kills the worker, the parent finds no JSON on stdout,
+`wasm: null`, and `summarizeUpstreamRuns` records every test of that file as
+failed with `wasmError: null`. Exactly the shape #5369 describes, reached by a
+different door.
+
+That door is known to be walked through: `installNativeLateErrorBoundary` in
+`tests/dogfood/upstream-suite-runner.mjs` exists *because* hono's
+`concurrent.js` threw "interval violated" from a `setTimeout` ~2 minutes into
+an npm-compat refresh (run 32623956233) and killed the driver. That boundary
+covers the **native** lane only; the Wasm worker has no equivalent.
+
+## Why #5369 deliberately did not do it
+
+Recorded so this is a decision and not an oversight. Swallowing an
+`uncaughtException` in the worker is not symmetric with swallowing a rejection:
+
+- An uncaught exception in the worker is more often a **harness** bug (a
+  compiler crash, a bad import object) than guest behaviour, and today it fails
+  fast with a readable message in `compile.errors[0]`.
+- Recording and continuing risks turning that fast failure into a **180 s
+  worker timeout**, because the worker may never reach its `emit`.
+
+So the fix needs a rule that distinguishes "the guest's stray timer threw,
+keep going" from "the harness is broken, report and die" — probably: attribute
+and continue only while the sequential test loop is running, and stay fatal
+before the first test and after the last.
+
+## Acceptance criteria
+
+1. An `uncaughtException` raised while test N runs is attributed to test N (its
+   `wasmError` carries the message) and the remaining tests of the file still
+   run.
+2. An `uncaughtException` outside the test loop (compile, instantiation,
+   module init, emit) stays fatal and keeps today's `compile.errors` message —
+   no silent 180 s timeout.
+3. Regression fixture in the shape of `tests/dogfood/unhandled-host-rejection.test.ts`:
+   a 3-test module whose test 1 schedules a throwing host timer must read 2/3
+   with the message on test 1 (today 0/3, `wasmError: null`).
+4. A/B over all 17 upstream suites at one HEAD: no count changes.
+
+## Notes
+
+`tests/dogfood/upstream-unhandled-rejections.mjs` already has the sink and
+`attributeRejections` shape to reuse; this is mostly a second listener plus the
+in-loop/out-of-loop rule.

--- a/plan/issues/6425-hono-crypto-textencoder-not-a-constructor.md
+++ b/plan/issues/6425-hono-crypto-textencoder-not-a-constructor.md
@@ -1,0 +1,70 @@
+---
+id: 6425
+title: "hono crypto: `new TextEncoder()` in compiled code answers `TextEncoder is not a constructor` — the whole of src/utils/crypto.test.ts (4 tests)"
+status: ready
+sprint: current
+created: 2026-09-12
+updated: 2026-09-12
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: runtime
+goal: correctness
+---
+
+## Problem
+
+hono's `src/utils/crypto.test.ts` reads **0/4** in the Wasm lane, 4/4 native.
+Three of the four carry the same host-boundary failure:
+
+```
+sha256                                              TextEncoder is not a constructor
+sha1                                                TextEncoder is not a constructor
+Should not be the same values - compare difference  unhandled rejection: TypeError: TextEncoder is not a constructor;
+                                                                        TypeError: TextEncoder is not a constructor
+Should create hash for Buffer                       update is not a function
+```
+
+`TextEncoder` **is** supplied to the worker: `getWebHostConstructors()`
+(`src/runtime/web-host-constructors.ts`) forwards it whenever
+`typeof globalThis.TextEncoder === "function"`, which holds on every Node the
+harness runs on. So the binding reaches the import object and the compiled
+`new TextEncoder()` still does not construct — the defect is on the
+compiled-code side of the extern-constructor boundary, not in the dependency
+map.
+
+It has been visible but unowned: #5338 named it "adjacent, do not chase" and
+closed without filing it.
+
+## Why it is filed now
+
+The third test used to read **passed**. It compares two values that are
+unawaited Promises (the
+[#5371](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5371-await-hands-back-the-promise)
+family), so the comparison was trivially satisfied while two `TextEncoder`
+rejections were dropped on the floor unobserved.
+[#5369](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5369-unhandled-host-rejection-zeroes-test-module)
+now attributes those rejections to the test that leaked them, so the file reads
+0/4 honestly instead of 1/4. hono's headline moved 258/324 → 257/324 for that
+reason alone — an accuracy correction, and the reason this defect now has a
+number.
+
+## Acceptance criteria
+
+1. `new TextEncoder()` in compiled JS-host-lane code constructs a real host
+   `TextEncoder`, and `.encode()` on it returns something the host accepts.
+2. hono `src/utils/crypto.test.ts` reads at least 3/4 (the fourth,
+   `update is not a function`, is a separate Buffer-surface gap — diagnose but
+   do not bundle).
+3. A regression test in `tests/` that constructs a `TextEncoder` from compiled
+   code and round-trips a string, independent of hono.
+4. A/B over the 17 upstream suites at one HEAD: hono up, nothing else down.
+
+## Notes
+
+Start by checking how the extern constructor is resolved for the web lane's
+forwarded constructors versus the `node:` namespace ones — hono's other
+`TextEncoder` uses may go through a different path, since only this file
+reports the failure.


### PR DESCRIPTION
Two issue files, both surfaced while fixing [#5369](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5369-unhandled-host-rejection-zeroes-test-module) (PR #5843). Docs-only — no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` change.

**[#6424](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6424-worker-uncaught-exception-still-zeroes-file)** — the dogfood Wasm worker still has no `uncaughtException` listener, so a host throw from a stray timer zeroes the whole test file exactly the way an unobserved rejection used to. #5369 fixed the rejection half; the issue records *why* the other half was left alone (an uncaught exception in the worker is usually a harness bug, and recording-and-continuing risks turning a fast readable failure into a 180 s worker timeout) and the in-loop / out-of-loop rule a fix needs to distinguish the two.

**[#6425](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6425-hono-crypto-textencoder-not-a-constructor)** — hono `src/utils/crypto.test.ts` reads 0/4 in the Wasm lane on `TextEncoder is not a constructor`, even though `getWebHostConstructors()` does forward the binding, so the defect is on the compiled side of the extern-constructor boundary. [#5338](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5338-hono-ipaddr-null-string-split) called it "adjacent, do not chase" and closed without filing it. Filed now because #5369 exposed its fourth casualty: that test was reading `passed` only because it compared two unawaited Promises while dropping two `TextEncoder` rejections on the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
