### PR TITLE
docs(#5341): record the 17-suite A/B for the under-applied `.call` receiver fix

### DIFF
--- a/plan/issues/5341-axios-residual-buckets.md
+++ b/plan/issues/5341-axios-residual-buckets.md
@@ -165,6 +165,46 @@ the `.apply` site. Both assertions were refreshed to the behaviour that
 actually holds; its over-arity negative moved to a positive per this change,
 with the runtime answer unchanged at `2116`.
 
+## A/B — 17 dogfood upstream suites, one HEAD (`upstream/main` `cf82f78d6d`)
+
+Base = the same tree with the one changed clause reverted (file-copy A/B, no
+stashing). Both variants were measured back to back on the same box, per test
+file.
+
+| suite             |        base |         fix | delta  |
+| ----------------- | ----------- | ----------- | ------ |
+| webpack           | 16/16       | 16/16       | 0      |
+| three             | 17/18       | 17/18       | 0      |
+| clsx              | 32/32       | 32/32       | 0      |
+| cookie            | 63740/63740 | 63740/63740 | 0      |
+| lodash            | 59/62       | 59/62       | 0      |
+| redux             | 67/82       | 67/82       | 0      |
+| **axios**         | **202/231** | **208/231** | **+6** |
+| stylelint         | 108/108     | 108/108     | 0      |
+| tailwindcss       | 13/13       | 13/13       | 0      |
+| jsdom             | 6/6         | 6/6         | 0      |
+| styled-components | 9/9         | 9/9         | 0      |
+| uuid              | 75/75       | 75/75       | 0      |
+| marked            | 16/30       | 16/30       | 0      |
+| moment            | 10/10       | 10/10       | 0      |
+| prettier          | 105/151     | 105/151     | 0      |
+| jest              | 335/356     | 335/356     | 0      |
+| hono              | 258/324     | 258/324     | 0      |
+
+Per-file movers — **every status change across all 17 suites**, all
+`failed → passed`:
+
+| suite | file                                    | test                                   |
+| ----- | --------------------------------------- | -------------------------------------- |
+| axios | `tests/unit/transformResponse.test.js`  | parses json                            |
+| axios | `tests/unit/transformResponse.test.js`  | ignores XML                            |
+| axios | `tests/unit/transformResponse.test.js`  | does not parse the empty string        |
+| axios | `tests/unit/transformResponse.test.js`  | does not parse undefined               |
+| axios | `tests/unit/core/transformData.test.js` | supports an array of transformers      |
+| axios | `tests/unit/core/transformData.test.js` | passes headers through to transformers |
+
+Nothing else in any suite changed status in either direction.
+
 ## Residuals (deliberately not taken here)
 
 - **`arguments.length` is still the FORMAL count inside an under-applied


### PR DESCRIPTION
Docs-only. Records the A/B evidence for [#5341](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5341-axios-residual-buckets), whose implementation landed in #5836 while the measurement was still running.

Touches one file: `plan/issues/5341-axios-residual-buckets.md`.

Base = the same tree with the one changed clause (`resolveNamedThisCallTarget`'s
arity gate) reverted, file-copy A/B. Both variants measured back to back on the
same box, at one HEAD (`upstream/main` `cf82f78d6d`), per test file.

| suite             |        base |         fix | delta  |
| ----------------- | ----------- | ----------- | ------ |
| webpack           | 16/16       | 16/16       | 0      |
| three             | 17/18       | 17/18       | 0      |
| clsx              | 32/32       | 32/32       | 0      |
| cookie            | 63740/63740 | 63740/63740 | 0      |
| lodash            | 59/62       | 59/62       | 0      |
| redux             | 67/82       | 67/82       | 0      |
| **axios**         | **202/231** | **208/231** | **+6** |
| stylelint         | 108/108     | 108/108     | 0      |
| tailwindcss       | 13/13       | 13/13       | 0      |
| jsdom             | 6/6         | 6/6         | 0      |
| styled-components | 9/9         | 9/9         | 0      |
| uuid              | 75/75       | 75/75       | 0      |
| marked            | 16/30       | 16/30       | 0      |
| moment            | 10/10       | 10/10       | 0      |
| prettier          | 105/151     | 105/151     | 0      |
| jest              | 335/356     | 335/356     | 0      |
| hono              | 258/324     | 258/324     | 0      |

Every status change across all 17 suites, all `failed → passed`:
axios `tests/unit/core/transformData.test.js` (supports an array of
transformers; passes headers through to transformers) and
`tests/unit/transformResponse.test.js` (parses json; ignores XML; does not
parse the empty string; does not parse undefined). Nothing else changed status
in either direction.

I first pushed this onto the then-open docs PR #5844 per the single-open-docs-PR
rule, but that PR merged ~90 seconds before my push landed, so the commit
stayed on the branch and never reached `main`. No non-draft docs PR is open now,
hence this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
