### PR TITLE
fix(regexp): preserve standalone sticky match cursor

### DIFF
--- a/plan/issues/5198-es2015-standalone-regexp-r2.md
+++ b/plan/issues/5198-es2015-standalone-regexp-r2.md
@@ -4,7 +4,7 @@ title: "ES2015 standalone regexp — r2 residual pass"
 status: in-progress
 sprint: current
 created: 2026-08-29
-updated: 2026-09-12
+updated: 2026-09-13
 priority: high
 horizon: m
 feasibility: hard
@@ -17,6 +17,7 @@ pr: 5296
 loc-budget-allow:
   - src/codegen/regexp-standalone.ts
   - src/codegen/native-regex.ts
+  - src/codegen/string-proto-match-search.ts
   - src/codegen/context/types.ts
   - src/codegen/type-coercion.ts
 func-budget-allow:
@@ -24,6 +25,7 @@ func-budget-allow:
   - src/codegen/native-regex.ts::ensureRegexReplace
   - src/codegen/native-regex.ts::ensureRegexMatchAll
   - src/codegen/regexp-standalone.ts::emitStandaloneRegExpMatchCore
+  - src/codegen/string-proto-match-search.ts::emitMatchResult
   - src/codegen/regexp-standalone.ts::emitStandaloneRegExpReplaceCore
   - src/codegen/type-coercion.ts::coerceType
 ---
@@ -587,6 +589,125 @@ tests: the static/backend-created `@@replace` code is now landed in main, while
 the two standalone `RegExp.prototype.exec` lastIndex-access residuals and the
 separate three-row `@@match` cursor extension remain deferred. This is not a
 claim of complete RegExp-prototype or whole-suite conformance.
+
+## 2026-09-13 continuation plan — exact exec and `@@match` cursor residuals
+
+The implementation branch starts at exact upstream `main`
+`e0023dbbe6c37e15c1f56ed0c8bc8d15d0afbac3`. The coordinator's freshly
+maintained ES2015 selection has 11,704 rows (`10,255` pass / `1,449` non-pass;
+filter hash prefix `90d5e85a`), but this five-row plan is deliberately a
+bounded conformance fix, not a whole-edition claim.
+
+Fresh standalone evidence from that maintained JSONL identifies these exact
+owned failures; host is the paired passing control for each:
+
+1. `built-ins/RegExp/prototype/exec/failure-lastindex-access.js` — ordinary
+   `Get(lastIndex)` invokes `valueOf`, but a later ordinary `lastIndex` read
+   loses the assigned object's identity.
+2. `built-ins/RegExp/prototype/exec/success-lastindex-access.js` — the same
+   raw-slot identity loss after a successful non-global exec.
+3. `built-ins/RegExp/prototype/Symbol.match/g-init-lastindex-err.js` — global
+   `@@match` bypasses the descriptor-aware initial `Set(lastIndex, 0, true)`.
+4. `built-ins/RegExp/prototype/Symbol.match/builtin-failure-g-set-lastindex-err.js`
+   — the same missing global Set makes a required TypeError disappear.
+5. `built-ins/RegExp/prototype/Symbol.match/y-fail-global-return.js` — the
+   global match walker scans past a sticky gap and returns three matches where
+   the mandated sticky cursor loop returns two.
+
+An initial candidate tried to reuse `ctx.nonWritableExternKeys` for rows 3–4.
+That metadata is compile-time rather than branch-aware: the bounded exported
+`optionalWrite(flag)` probe passed on exact e002 as `false → 2, true → 2`, but
+the candidate threw a `WebAssembly.Exception` for both values. An uncalled
+later descriptor function alone did not throw, but the runtime-branch control
+proved the static guard unsound. The rejected A/B is retained in the local
+evidence log; do not ship or extend that guard.
+
+The delivery is therefore intentionally split into three independently
+reviewable PRs. The current PR claims only row 5, the sticky/global `@@match`
+cursor. A later descriptor PR must solve rows 3–4 with runtime, branch-aware
+property state. A third PR, from a fresh worktree after this one is published,
+owns only rows 1–2 and must prove original-reference identity through aliases,
+numeric overwrites, `exec` writeback, mutation in both directions, and
+rebinding.
+
+The current sticky-only delivery is limited to the native match-all loop and
+its two callers:
+
+1. Thread the statically known sticky bit into `__regex_match_all` so every
+   iteration uses an anchored native search for `/gy`; the first gap terminates
+   the loop. Keep the normal global scan and existing empty-match progression
+   unchanged. The shared helper's dynamic `String.prototype.match` caller must
+   pass its runtime sticky bit through the same ABI.
+2. Add one narrowly named cursor pin for row 5 in both host and standalone
+   lanes. Keep that pin small enough for the repository's default 512 MiB
+   single-fork issue gate; validate ten established `@@match` passing controls
+   through the maintained fresh-isolated runner manifest instead of retaining
+   full-harness compilations in one fork. Add a borrowed
+   `String.prototype.match.call` `/gy/` versus `/g/` pair so the second
+   `__regex_match_all` caller is exercised with runtime, rather than static,
+   flags.
+
+The sticky-only PR is acceptable only if row 5 passes in both lanes, the
+shared-helper controls pass, and rows 1–4 remain explicitly recorded as
+non-claimed residuals. It does not close #5198 or infer a whole
+RegExp-prototype/edition gain from this bounded cohort.
+
+### Sticky-only evidence at the e002 dispatch baseline
+
+The completed candidate keeps its evidence deliberately small and exact:
+
+- `y-fail-global-return.js` passes `1/1` through a fresh isolated host runner
+  and `1/1` through a fresh isolated standalone runner, with zero standalone
+  host imports.
+- Ten established `@@match` controls pass `10/10` in each fresh isolated lane.
+  The checked-in three-test issue gate (the claimed row in both lanes plus the
+  borrowed dynamic caller) passes `3/3` under the default 512 MiB single-fork
+  configuration. A larger 27-test one-fork aggregation exhausted that heap and
+  is not claimed as a passing result.
+- The dynamic caller has structural WAT evidence: its runtime `RE_FLAG_Y` mask
+  is read from the RegExp flags and supplied to the native match-all loop. Its
+  standalone runtime controls return `2` for `/a/gy/.match("aaba")` and `3`
+  for `/a/g/.match("aaba")`, so the second changed caller is not merely a
+  static-pattern proof.
+- Formatting, LOC/function budgets, oracle/coercion ratchets, issue integrity,
+  and compiler-boundary inventory all pass locally. The 238-row ES2015
+  RegExp-prototype intersection remains an authoritative-CI reconciliation,
+  not a completed local cohort claim.
+
+The candidate must still complete the normal pre-push hooks and CI at its PR
+head. These baseline results are provenance, not a claim that the current
+upstream integration or all #5198 residuals are solved.
+
+### Deferred descriptor boundary
+
+The rejected static guard does not make rows 3–4 safe to defer by adding a
+branch test only around `@@match`. The later runtime-state implementation must
+audit every reader and mutator that uses the existing
+`standaloneRegExpLastIndexSetGuardInstrs` / `emitRegExpLastIndexWriteGuard`,
+including the `exec` and `@@replace` consumers. The `optionalWrite(false)` /
+`optionalWrite(true)` branch probe remains a shared acceptance control: only
+the executed non-writable branch may throw.
+
+The deferred identity delivery starts with the existing WAT proof: raw
+assignment places the original closed-struct reference into the RegExp slot in
+`__module_init_chunk_0`, while a later generic struct-to-`$Object` conversion
+in `__module_init_chunk_1` materializes a copy. It must preserve that original
+reference across the specific escaped binding boundary rather than cache a
+value-copy object. No type-wide marker, raw-present-gated cache, or
+shared-source-spelling policy is acceptable: aliases and already-observed
+references must remain stable after a numeric overwrite or `exec` writeback.
+
+For each delivery, run its exact rows and controls through fresh isolated host
+and standalone `run-test262-paths.mts` invocations. The exact ES2015
+`built-ins/RegExp/prototype/**` corpus is the 238-row intersection of the same
+maintained JSONL and the checked-in `ES2015` edition map (baseline: `127 pass /
+102 fail / 9 compile_error`). Under shared-worker load, publish a ready
+sticky-only PR after its bounded proof and local quality gates, then reconcile
+that fixed corpus through authoritative CI at the PR head; record every status
+transition and allow no host or previously-passing loss. The standalone result
+must have zero host imports, compile errors, timeouts, and skips for the
+claimed cohort. Full TypeScript, formatting, ratchet, issue-integrity, and
+repository-hook evidence remains required before publication.
 
 ## Acceptance criteria
 

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -3086,7 +3086,7 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
 
 /**
  * Emit `__regex_match_all(prog, classTable, nGroups, strData, strOff, strLen,
- * subject) -> ref null $__regexp_match_vec` (#1913).
+ * subject, nScratch, sticky) -> ref null $__regexp_match_vec` (#1913).
  *
  * `String.prototype.match` with a GLOBAL regex (§22.2.6.8 step 6): collect
  * every match's [0] substring, advancing past empty matches per
@@ -3128,6 +3128,7 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
       { kind: "i32" }, // strLen
       strRef, // subject (flattened)
       { kind: "i32" }, // nScratch (#1959 — PROGRESS guard slots)
+      { kind: "i32" }, // sticky — anchor every search for a /gy/ walk
     ],
     [{ kind: "ref_null", typeIdx: matchVecTypeIdx }],
   );
@@ -3142,18 +3143,19 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
     SOFF = 4,
     SLEN = 5,
     SUBJ = 6,
-    NSCRATCH = 7;
+    NSCRATCH = 7,
+    STICKY = 8;
   // locals
-  const NSLOTS = 8;
-  const CAPS = 9;
-  const POS = 10;
-  const RARR = 11;
-  const RLEN = 12;
-  const RCAP = 13;
-  const NEWARR = 14;
-  const MSTART = 15;
-  const MEND = 16;
-  const FIRSTMS = 17;
+  const NSLOTS = 9;
+  const CAPS = 10;
+  const POS = 11;
+  const RARR = 12;
+  const RLEN = 13;
+  const RCAP = 14;
+  const NEWARR = 15;
+  const MSTART = 16;
+  const MEND = 17;
+  const FIRSTMS = 18;
 
   const body: Instr[] = [
     // nSlots = 2 * nGroups + nScratch (#1959 scratch slots ride in caps)
@@ -3198,7 +3200,7 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
             { op: "local.get", index: SOFF },
             { op: "local.get", index: SLEN },
             { op: "local.get", index: POS },
-            { op: "i32.const", value: 0 },
+            { op: "local.get", index: STICKY },
             { op: "local.get", index: CAPS },
             { op: "call", funcIdx: searchIdx },
             { op: "i32.eqz" },

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -3995,8 +3995,9 @@ function staticRegExpFlags(
  * `String.prototype.match(regexp)` in standalone mode (#1539 Phase 2b).
  *
  * Non-global static RegExp arguments share the same result shape as `.exec`.
- * Global `match` returns an all-matches array and sticky/global lastIndex
- * details are intentionally left to the next capture-array slice.
+ * Global `match` returns an all-matches array and threads a static sticky bit
+ * through the shared cursor loop. Dynamic flags still fall through to the
+ * refusal path.
  * (#4016) Plain-`ToString` search values are handled in `string-search-value.ts`.
  */
 export function tryCompileStandaloneStringMatch(
@@ -4077,7 +4078,8 @@ function emitStandaloneRegExpMatchCore(
     const subjLocal = allocLocal(fctx, `__re_gm_subj_${fctx.locals.length}`, { kind: "ref", typeIdx: strTypeIdx });
     fctx.body.push({ op: "local.set", index: subjLocal });
 
-    // __regex_match_all(prog, classTable, nGroups, subjData, subjOff, subjLen, subject)
+    // __regex_match_all(prog, classTable, nGroups, subjData, subjOff, subjLen,
+    // subject, nScratch, sticky)
     fctx.body.push({ op: "local.get", index: regexpLocal });
     fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_PROG });
     fctx.body.push({ op: "local.get", index: regexpLocal });
@@ -4091,9 +4093,10 @@ function emitStandaloneRegExpMatchCore(
     fctx.body.push({ op: "local.get", index: subjLocal });
     fctx.body.push({ op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }); // len
     fctx.body.push({ op: "local.get", index: subjLocal });
-    // nScratch (#1959) — PROGRESS empty-loop guard slots, last arg.
+    // nScratch (#1959) — PROGRESS empty-loop guard slots; sticky follows.
     fctx.body.push({ op: "local.get", index: regexpLocal });
     fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSCRATCH });
+    fctx.body.push({ op: "i32.const", value: flags.includes("y") ? 1 : 0 });
     fctx.body.push({ op: "call", funcIdx: matchAllIdx });
     // lastIndex = 0 (net effect of the spec's exec loop on a global regex).
     fctx.body.push({ op: "local.get", index: regexpLocal });

--- a/src/codegen/string-proto-match-search.ts
+++ b/src/codegen/string-proto-match-search.ts
@@ -100,7 +100,7 @@ import {
 } from "./native-strings.js";
 import { ensureRegexMatchAll, ensureRegexMatchVecType, regexI32ArrayType } from "./native-regex.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
-import { RE_FLAG_G } from "./regex/bytecode.js";
+import { RE_FLAG_G, RE_FLAG_Y } from "./regex/bytecode.js";
 import {
   RE_FIELD_CLASS_TABLE,
   RE_FIELD_FLAGS,
@@ -375,6 +375,14 @@ function emitMatchResult(
     { op: "local.get", index: subjLocal },
     { op: "local.get", index: regexpLocal },
     { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSCRATCH },
+    // The shared match-all helper also serves dynamic String.prototype.match;
+    // preserve a runtime `/gy/` receiver's anchored cursor walk.
+    { op: "local.get", index: regexpLocal },
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_FLAGS },
+    { op: "i32.const", value: RE_FLAG_Y },
+    { op: "i32.and" },
+    { op: "i32.const", value: 0 },
+    { op: "i32.ne" },
     { op: "call", funcIdx: matchAllIdx },
     { op: "local.set", index: allLocal },
     // lastIndex = 0 — the net effect of the spec's exec loop on a global regex.

--- a/tests/issue-5198-es2015-regexp-match-cursor.test.ts
+++ b/tests/issue-5198-es2015-regexp-match-cursor.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #5198 continuation — static and dynamic RegExp @@match sticky cursor.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+
+type Lane = "host" | "standalone";
+
+const TEST262_ROOT = fileURLToPath(new URL("../test262/", import.meta.url));
+
+const CURSOR_ROWS = ["built-ins/RegExp/prototype/Symbol.match/y-fail-global-return.js"] as const;
+
+type Test262Row = (typeof CURSOR_ROWS)[number];
+
+const TEST262_AVAILABLE =
+  process.env.JS2_TEST262_AVAILABLE !== "0" &&
+  existsSync(join(TEST262_ROOT, "harness", "assert.js")) &&
+  CURSOR_ROWS.every((relativePath) => existsSync(join(TEST262_ROOT, "test", relativePath)));
+const itWithTest262 = TEST262_AVAILABLE ? it : it.skip;
+
+async function runMatchRow(relativePath: Test262Row, lane: Lane) {
+  try {
+    return await runTest262File(
+      join(TEST262_ROOT, "test", relativePath),
+      "issue-5198-match-cursor",
+      180_000,
+      lane === "standalone" ? lane : undefined,
+    );
+  } finally {
+    restoreHostBuiltins();
+  }
+}
+
+async function runStandaloneStickyControl(): Promise<number> {
+  const result = await compile(
+    `
+      function invoke(receiver: any, regexp: any): any {
+        return String.prototype.match.call(receiver, regexp);
+      }
+      export function test(): number {
+        // Runtime flags must reach the shared native match-all caller, rather
+        // than the compile-time static /g fast path.
+        const sticky: any = /a/gy;
+        const stickyMatches = invoke("aaba", sticky);
+        if (stickyMatches === null || stickyMatches.length !== 2) return 1;
+
+        const global: any = /a/g;
+        const globalMatches = invoke("aaba", global);
+        if (globalMatches === null || globalMatches.length !== 3) return 2;
+
+        return 0;
+      }
+    `,
+    {
+      fileName: "issue-5198-dynamic-match-sticky-control.ts",
+      target: "standalone",
+    },
+  );
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports).toHaveLength(0);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#5198 static RegExp @@match sticky cursor", () => {
+  for (const lane of ["host", "standalone"] as const) {
+    for (const relativePath of CURSOR_ROWS) {
+      itWithTest262(`${lane}: cursor row ${relativePath}`, { timeout: 200_000 }, async () => {
+        const result = await runMatchRow(relativePath, lane);
+        expect(`${result.status}: ${result.error ?? ""}`, `${lane} ${relativePath}`).toBe("pass: ");
+      });
+    }
+  }
+
+  it("preserves dynamic sticky dispatch through borrowed String.prototype.match", async () => {
+    expect(await runStandaloneStickyControl()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

- Carry the sticky bit through the native global `@@match` walker, so a `/gy/`
  walk stops at its first gap rather than scanning ahead.
- Pass that bit from both the static standalone path and the runtime
  `String.prototype.match` shared helper.
- Add a small permanent host/standalone Test262 pin and a dynamic borrowed
  `String.prototype.match.call` `/gy/` versus `/g/` control.
- Deliberately leave the two `lastIndex` descriptor rows and two escaped raw
  identity rows as separate #5198 residual slices.

## Validation

- `pnpm exec vitest run tests/issue-5198-es2015-regexp-match-cursor.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot` — 3/3 passed under the default 512 MiB single-fork configuration.
- Fresh isolated `run-test262-paths.mts` runs — claimed row 1/1 host and 1/1 standalone; ten established `@@match` controls 10/10 in each lane.
- Dynamic standalone control returns 2 for `/a/gy/` and 3 for `/a/g/` on `"aaba"`; emitted WAT reads the runtime sticky flag and carries it into the native match-all loop.
- Formatting, LOC/function budgets, oracle/coercion ratchets, issue integrity, and compiler-boundary inventory passed locally. Normal pre-push hooks and authoritative CI remain the integration proof; the 238-row ES2015 RegExp-prototype cohort is not claimed as locally complete.

## CLA

- [x] I have read and agree to the CLA
