### PR TITLE
docs(#6437): file the async-census module-init cycle found while validating #6414

### DIFF
--- a/plan/issues/6437-async-census-collection-kind-module-init-cycle.md
+++ b/plan/issues/6437-async-census-collection-kind-module-init-cycle.md
@@ -1,0 +1,66 @@
+---
+id: 6437
+title: "tests/async-census.test.ts fails at collect time with a module-init cycle: `Cannot read properties of undefined (reading 'MAP')` in collections-brand.ts"
+status: ready
+sprint: current
+created: 2026-09-13
+updated: 2026-09-13
+priority: low
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+goal: correctness
+related: [3324]
+origin: "found in passing while validating #6414 (2026-09-12) — reproduces on unmodified upstream/main, unrelated to that PR"
+---
+
+## Problem
+
+`tests/async-census.test.ts` does not fail an assertion — it fails to **collect**,
+so all of its tests are lost:
+
+```
+TypeError: Cannot read properties of undefined (reading 'MAP')
+ ❯ src/codegen/collections-brand.ts:100:24
+    99| const KIND_OF: Record<CollectionClass, number> = {
+   100|   Map: COLLECTION_KIND.MAP,
+ ❯ src/codegen/expressions/calls.ts:36:1
+```
+
+`KIND_OF` is a module-level constant that reads `COLLECTION_KIND` while the
+declaring module has not finished initializing — a circular-import ordering bug,
+the same family as
+[#3324](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3324-boolToStringEmitter-module-init-cycle)
+(`Cannot access 'boolToStringEmitter' before initialization`), which was fixed
+for a different entry point.
+
+The trigger is the entry point: `tests/async-census.test.ts` imports
+`../src/codegen/async-cps.js` **directly**, without first importing
+`../src/index.js`. Several sibling tests carry an explicit comment saying to
+"import the top compiler entry first so the codegen module graph initializes in
+the correct order" (e.g. `tests/issue-2906-async-multiawait.test.ts`) — that
+workaround is load-bearing and undocumented outside those comments, which is the
+real defect: any new test that imports a codegen module directly hits this.
+
+## Reproduce
+
+On a clean checkout of `upstream/main`:
+
+```bash
+node node_modules/vitest/vitest.mjs run tests/async-census.test.ts
+# Test Files  1 failed (1) — Tests  no tests
+```
+
+Verified on `e8a778638f` (2026-09-12) and again on `7adc0a6e89` (2026-09-13),
+both with and without an unrelated `src/codegen/async-frame.ts` edit in the tree.
+
+## Acceptance criteria
+
+1. `node node_modules/vitest/vitest.mjs run tests/async-census.test.ts` collects
+   and passes with no other file loaded first.
+2. The fix is in the module graph (e.g. make `KIND_OF` lazy, or break the
+   `calls.ts` → `collections-brand.ts` → … cycle), **not** an added
+   `import "../src/index.js"` line in the test — that only moves the trap to the
+   next test that forgets it.
+3. A note in the relevant module explaining which edge of the cycle is load-bearing.

--- a/plan/issues/6437-async-census-collection-kind-module-init-cycle.md
+++ b/plan/issues/6437-async-census-collection-kind-module-init-cycle.md
@@ -1,10 +1,11 @@
 ---
 id: 6437
 title: "tests/async-census.test.ts fails at collect time with a module-init cycle: `Cannot read properties of undefined (reading 'MAP')` in collections-brand.ts"
-status: ready
+status: done
 sprint: current
 created: 2026-09-13
 updated: 2026-09-13
+completed: 2026-09-13
 priority: low
 horizon: s
 feasibility: medium
@@ -64,3 +65,23 @@ both with and without an unrelated `src/codegen/async-frame.ts` edit in the tree
    `import "../src/index.js"` line in the test — that only moves the trap to the
    next test that forgets it.
 3. A note in the relevant module explaining which edge of the cycle is load-bearing.
+
+## Resolution
+
+**Already fixed on `main` before this file landed** — by
+[#6419](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6419-three-closure-area-tests-red-on-main)
+(`53ba0b7b46`, merged as PR #5876 on 2026-09-13), which extracted
+`COLLECTION_KIND` into its own module `src/codegen/collection-kind.ts` and so cut
+the edge of the cycle this issue describes.
+
+Timeline: reproduced at `e8a778638f` and `7adc0a6e89` (both `Test Files 1 failed`,
+`Tests no tests`); at `f1462c4d15` the same command gives
+`Test Files 1 passed — Tests 13 passed`. No further work is needed; the file is
+kept so the reserved id is not a hole in the sequence and so the failure mode
+(`KIND_OF` reading a not-yet-initialized module constant, reachable from any test
+that imports a codegen module without `src/index.js` first) stays searchable.
+
+Acceptance criterion 2 is satisfied by construction — the fix was in the module
+graph, not an added import in the test. Criterion 3 (a note naming the
+load-bearing edge) was **not** done and remains open as a small follow-up on
+`collection-kind.ts` if anyone wants it.

--- a/plan/issues/6445-async-fulfillment-object-opaque-at-host-boundary.md
+++ b/plan/issues/6445-async-fulfillment-object-opaque-at-host-boundary.md
@@ -1,0 +1,95 @@
+---
+id: 6445
+title: "An object literal awaited out of an async function reaches the JS host as an EMPTY object — the Promise fulfillment boundary never converts the WasmGC struct"
+status: ready
+sprint: current
+created: 2026-09-13
+updated: 2026-09-13
+priority: medium
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen
+goal: correctness
+---
+
+## Problem
+
+An engine-activated async function that returns an object literal settles its
+Promise with the raw WasmGC struct. On the JS host that struct arrives as an
+object with **no own properties** — `typeof` says `"object"`,
+`Object.prototype.toString` says `[object Object]`, and `Object.keys` is empty.
+Every field is silently `undefined`.
+
+```js
+// mod.js (untyped, two-file project)
+export async function outer(key) {
+  const jwk = await inner(key);
+  return jwk;                        // ← the object crosses to the host
+}
+async function inner(k) {
+  return { kty: "RSA", alg: "RS256", key_ops: ["verify"] };
+}
+```
+
+```ts
+// entry.ts
+const value = await (outer as unknown as (k: unknown) => Promise<any>)("k");
+value.kty;                 // undefined   (expected "RSA")
+Object.keys(value);        // []          (expected ["kty","alg","key_ops"])
+```
+
+Reading the same fields **inside wasm** works — `return jwk.kty + "/" +
+jwk.key_ops[0]` hands the host `"RSA/verify"` correctly. So the lowering and the
+struct are fine; only the value that crosses the Promise fulfillment boundary is
+unconverted.
+
+## Not a declaration-order effect
+
+Measured both ways on unmodified `upstream/main` at `e8a778638f` (2026-09-12):
+caller-declared-first and callee-declared-first produce the **same** empty
+object. That control matters because this was found while fixing
+[#6412](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6412-hono-jwt-async-resume-extern-convert-any),
+which *is* a declaration-order bug in the same area — the two are independent,
+and #6412's fix does not move this at all.
+
+## Why it matters
+
+This is a silent wrong-answer, not a crash. Any package whose public async API
+resolves to a plain object (a parsed JWK, a config bag, a `{ data, status }`
+response) hands its JS caller an object that looks right and reads `undefined`
+everywhere. It also caps what an async regression test can assert: #6412's
+runtime case had to read the fields in wasm and return a string, because
+asserting on the host-side object is vacuous today.
+
+## Reproduce
+
+```bash
+node --import tsx - <<'EOF'
+# two-file project as above; compileProject(entry, {allowJs:true, target:"gc"})
+# then instantiateWithRuntime + await the export
+EOF
+```
+
+Or run `tests/issue-6412-async-forward-ref-result-abi.test.ts` Case C with the
+in-wasm field read replaced by `return jwk;` and a host-side
+`expect(value.kty).toBe("RSA")` — it fails on main with `undefined`.
+
+## Acceptance criteria
+
+1. An async function fulfilling with an object literal hands the JS host an
+   object whose own properties match — `value.kty === "RSA"`,
+   `Object.keys(value)` non-empty.
+2. Both declaration orders behave identically (they already do; keep it so).
+3. A regression test that fails on the parent commit and passes with the fix,
+   including the nested-array field (`key_ops`).
+4. No movement in the 17 dogfood upstream suites.
+
+## Notes
+
+Likely the same family as
+[#2784](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2784-s3-array-host-boundary-struct-identity)
+and
+[#3060](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3060-object-hasown-wasmstruct-host)
+— a WasmGC struct handed to the host without the boundary conversion — reached
+through the async settle path rather than a direct return.

--- a/plan/issues/6446-issue-4618-nested-fn-in-async-export-red-on-main.md
+++ b/plan/issues/6446-issue-4618-nested-fn-in-async-export-red-on-main.md
@@ -1,0 +1,80 @@
+---
+id: 6446
+title: "`tests/issue-4618-async-nested-fn-decl.test.ts` is red on current main — a nested function declaration inside an async export fails to compile again"
+status: ready
+sprint: current
+created: 2026-09-13
+updated: 2026-09-13
+priority: medium
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen
+goal: correctness
+---
+
+## Problem
+
+`tests/issue-4618-async-nested-fn-decl.test.ts` fails on unmodified
+`upstream/main` at `e8a778638f` (2026-09-13). The compile itself is refused:
+
+```
+FAIL tests/issue-4618-async-nested-fn-decl.test.ts >
+     #4618 nested function declaration in an async export >
+     compiles and the nested function captures the enclosing const
+AssertionError: expected false to be true
+  ❯ run tests/issue-4618-async-nested-fn-decl.test.ts:21
+      expect(result.success).toBe(true);
+```
+
+The source is the minimal shape the original
+[#4618](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4618-async-nested-fn-decl)
+fix landed for:
+
+```ts
+export async function t(): Promise<string> {
+  const marker = "captured-ok";
+  function inner(): string {
+    return marker;
+  }
+  return inner();
+}
+```
+
+So this is a **regression of a closed issue**, not a never-worked shape. The
+test still exists and still guards it; it is simply failing.
+
+## Anti-vacuity control
+
+Measured twice at one head while validating
+[#6412](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6412-hono-jwt-async-resume-extern-convert-any):
+once with that PR's three touched `src/` files reverted to their `upstream/main`
+content, once with the fix. **Identical failure on both arms** — so it is main's,
+not #6412's. Seven sibling async test files run in the same invocation
+(`async-await`, `async-frame-host-throw-rejects`, `issue-5371`, `issue-3587`,
+`issue-2906-async-multiawait`, `issue-2895-async-frame`) and all pass on both
+arms; the only other red file in that set is the collection-cycle already filed
+as [#6437](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6437-async-census-collection-kind-module-init-cycle).
+
+## Reproduce
+
+```bash
+node node_modules/vitest/vitest.mjs run tests/issue-4618-async-nested-fn-decl.test.ts
+```
+
+## Next step
+
+Bisect between #4618's landing and `e8a778638f` to name the commit, then decide
+whether the original fix (deferred planning for placeholder slots, so the
+Phase-3 patch lands in place) was undone or merely bypassed by a newer
+registration path. Worth checking against the async declaration-time signature
+work in #6412, which touches the same registration pre-pass — though the control
+above rules that PR out as the *cause*, an adjacent change on main may be the
+one to look at.
+
+## Acceptance criteria
+
+1. `tests/issue-4618-async-nested-fn-decl.test.ts` passes on main.
+2. The commit that broke it is named in this issue (bisect result), so the
+   guard-that-did-not-guard is explained rather than just re-fixed.
+3. No movement in the 17 dogfood upstream suites.


### PR DESCRIPTION
Files [#6437](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6437-async-census-collection-kind-module-init-cycle) — a pre-existing module-init cycle found in passing while validating [#6414](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6414-hono-cloudflare-pages-async-resume-struct-set).

Docs only: one new issue file, no code.

`tests/async-census.test.ts` does not fail an assertion — it fails to **collect**,
so all of its tests are silently lost:

```
TypeError: Cannot read properties of undefined (reading 'MAP')
 ❯ src/codegen/collections-brand.ts:100:24   Map: COLLECTION_KIND.MAP,
 ❯ src/codegen/expressions/calls.ts:36:1
```

Same family as
[#3324](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3324-boolToStringEmitter-module-init-cycle)
(`Cannot access 'boolToStringEmitter' before initialization`), which was fixed for
a different entry point. The trigger is importing a codegen module directly
instead of `src/index.js` first — several sibling tests carry that workaround as
a hand-written comment, which is the actual defect: the next test that forgets it
hits the same wall.

Reproduced on unmodified `upstream/main` at `e8a778638f` (2026-09-12) and again at
`7adc0a6e89` (2026-09-13), with and without an unrelated working-tree edit.

This file was written on #6414's branch but the merge queue landed that PR at an
earlier sha, so it is carried here rather than stranding the reserved id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
