### PR TITLE
chore(issues): migrate GitHub 5807 and guard local issue tracking

### DIFF
--- a/.claude/hooks/block-github-issue-create.py
+++ b/.claude/hooks/block-github-issue-create.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""PreToolUse guard for local issue tracking; scope/limits: plan issue 6448.
+
+This recognizes literal commands, not arbitrary shell/program evaluation.
+It never runs the inspected command or makes a network request.
+"""
+
+import json
+import os
+import re
+import sys
+from urllib.parse import urlsplit
+
+
+REPOS = {"loopdive/js2", "loopdive/js2wasm"}
+REASON = "GitHub issue creation is disabled for loopdive/js2 (alias js2wasm). Allocate a local plan/issues/ issue with scripts/claim-issue.mjs --allocate instead. PR creation and existing issue access remain allowed."
+
+
+def protected(value):
+    value = str(value).lower().rstrip("/")
+    value = re.sub(r"^(https?://)?(api\.)?github\.com/", "", value)
+    return value.removesuffix(".git") in REPOS
+
+
+def commands(source):
+    """Split literal shell words without treating quoted prose as commands.
+
+    Quotes/backslashes, separators and here-document data are recognized.
+    Expansion, substitutions, aliases and sourced programs are not evaluated.
+    """
+    words, word, pending = [], [], []
+    active = False
+    quote = None
+    i = 0
+    while i < len(source):
+        c = source[i]
+        if quote:
+            if c == quote:
+                quote = None
+            elif c == "\\" and quote == '"' and i + 1 < len(source) and source[i + 1] in '$`"\\\n':
+                i += 1
+                if source[i] != "\n":
+                    word.append(source[i])
+            else:
+                word.append(c)
+        elif c in "'\"":
+            active, quote = True, c
+        elif c == "\\" and i + 1 < len(source):
+            i += 1
+            if source[i] != "\n":
+                active = True
+                word.append(source[i])
+        elif c == "#" and not active:
+            end = source.find("\n", i)
+            i = len(source) if end < 0 else end
+            continue
+        elif c.isspace() or c in ";&|()<>":
+            if active:
+                words.append("".join(word))
+                word, active = [], False
+            if c == "<" and source[i:i + 2] == "<<" and source[i:i + 3] != "<<<":
+                match = re.match(r"<<(-?)\s*(['\"]?)([\w-]+)\2", source[i:])
+                if not match:
+                    raise ValueError("unrecognized here-document delimiter")
+                pending.append((match[3], bool(match[1])))
+                i += len(match[0])
+                continue
+            if c in ";&|()\n":
+                if words:
+                    yield words
+                    words = []
+                if c == "\n":
+                    for delimiter, strip_tabs in pending:
+                        while True:
+                            start = i + 1
+                            end = source.find("\n", start)
+                            if end < 0:
+                                end = len(source)
+                            line = source[start:end]
+                            i = end
+                            if (line.lstrip("\t") if strip_tabs else line) == delimiter:
+                                break
+                            if end == len(source):
+                                raise ValueError("unterminated here-document")
+                    pending = []
+        else:
+            active = True
+            word.append(c)
+        i += 1
+    if quote or pending:
+        raise ValueError("unterminated shell quote or here-document")
+    if active:
+        words.append("".join(word))
+    if words:
+        yield words
+
+
+def option(args, *names):
+    for i, arg in enumerate(args):
+        for name in names:
+            if arg == name and i + 1 < len(args):
+                return args[i + 1]
+            if arg.startswith(name + "="):
+                return arg[len(name) + 1:]
+            if len(name) == 2 and arg.startswith(name) and len(arg) > 2:
+                return arg[2:]
+    return None
+
+
+def rest_create(endpoint, method):
+    if method.upper() != "POST":
+        return False
+    if endpoint.startswith("https://"):
+        url = urlsplit(endpoint)
+        if url.netloc.lower() != "api.github.com":
+            return False
+        endpoint = url.path
+    endpoint = endpoint.split("?", 1)[0].strip("/")
+    return re.fullmatch(r"repos/loopdive/(js2|js2wasm)/issues", endpoint, re.I) is not None
+
+
+def api_create(args, curl=False):
+    explicit = option(args, "--request", "-X", "--method")
+    data_flags = ("--data", "--data-raw", "--data-binary", "--json", "-d") if curl else ("--field", "--raw-field", "--input", "-f", "-F")
+    has_data = any(option(args, flag) is not None for flag in data_flags)
+    method = explicit or ("POST" if has_data else "GET")
+    if curl and ("--get" in args or "-G" in args) and not explicit:
+        method = "GET"
+    if any(rest_create(arg, method) for arg in args):
+        return True
+    # Opaque GraphQL repository IDs/payload files cannot establish an unrelated
+    # repository here. Visible createIssue mutations fail closed in this project.
+    graphql = "graphql" in args or any(arg.startswith("https://api.github.com/graphql") for arg in args)
+    return graphql and any(re.search(r"\bcreateIssue\s*\(", arg) for arg in args)
+
+
+def shell_create(source, default_repo="loopdive/js2", depth=0):
+    if depth > 8:
+        raise ValueError("shell wrapper nesting exceeds inspection bound")
+    for words in commands(source):
+        repo = default_repo
+        while words and (words[0] in ("env", "command", "exec") or re.match(r"^[A-Za-z_][A-Za-z_0-9]*=", words[0])):
+            first = words.pop(0)
+            if first.startswith("GH_REPO="):
+                repo = first[8:]
+        if not words:
+            continue
+        executable = os.path.basename(words[0])
+        args = words[1:]
+        if executable in ("sh", "bash", "zsh"):
+            for i, arg in enumerate(args[:-1]):
+                if re.fullmatch(r"-[a-z]*c[a-z]*", arg) and shell_create(args[i + 1], repo, depth + 1):
+                    return True
+        if executable == "curl" and api_create(args, curl=True):
+            return True
+        if executable != "gh":
+            continue
+        target = option(args, "--repo", "-R") or repo
+        # gh accepts its repository selector before or after the subcommand.
+        command = list(args)
+        while command and command[0].startswith("-"):
+            arg = command.pop(0)
+            if arg in ("-R", "--repo") and command:
+                command.pop(0)
+            elif arg not in ("--",) and not arg.startswith(("-R", "--repo=")):
+                break
+        if command[:2] == ["issue", "create"] and protected(target):
+            return True
+        if command[:1] == ["api"] and api_create(command[1:]):
+            return True
+    return False
+
+
+def denied(event):
+    name = event.get("tool_name", "")
+    data = event.get("tool_input", {})
+    if not isinstance(name, str):
+        raise ValueError("tool_name must be a string")
+    if not isinstance(data, dict):
+        raise ValueError("tool_input must be an object")
+    if name in ("Bash", "exec_command", "shell_command", "functions.exec_command"):
+        source = data.get("command", data.get("cmd", ""))
+        if not isinstance(source, str):
+            raise ValueError("shell command must be a string")
+        return shell_create(source, os.environ.get("GH_REPO", "loopdive/js2"))
+    if "github" not in name.lower():
+        return False
+    target = data.get("repository_full_name", data.get("repo_full_name", data.get("repository", "")))
+    if not target and data.get("owner") and data.get("repo"):
+        target = f"{data['owner']}/{data['repo']}"
+    if not isinstance(target, str):
+        raise ValueError("repository name must be a string")
+    create = re.search(r"(?:create_issue|issue_create)$", name) or (name.endswith("issue_write") and data.get("method") == "create")
+    if create:
+        return not target or protected(target)
+    if rest_create(str(data.get("endpoint", data.get("url", ""))), str(data.get("method", "GET"))):
+        return True
+    return bool(re.search(r"\bcreateIssue\s*\(", str(data.get("query", ""))))
+
+
+if __name__ == "__main__":
+    try:
+        event = json.load(sys.stdin)
+        if not isinstance(event, dict):
+            raise ValueError("hook input must be an object")
+        block = denied(event)
+        reason = REASON
+    except (ValueError, TypeError) as error:
+        block, reason = True, f"Issue-creation guard could not inspect this call: {error}"
+    if block:
+        print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}))
+        print(reason, file=sys.stderr)
+        sys.exit(2)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -208,6 +208,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Bash|exec_command|shell_command|mcp__.*github.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/block-github-issue-create.py\"",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -10,6 +10,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash|exec_command|shell_command|mcp__.*github.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/block-github-issue-create.py\"",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/plan/issues/6448-bigint-typedarray-regression-investigation.md
+++ b/plan/issues/6448-bigint-typedarray-regression-investigation.md
@@ -1,0 +1,184 @@
+---
+id: 6448
+title: "Investigate landed BigInt TypedArray regressions (migrated GitHub 5807)"
+status: ready
+sprint: current
+created: 2026-09-09
+updated: 2026-09-13
+priority: high
+horizon: now
+feasibility: medium
+reasoning_effort: max
+task_type: bug
+area: runtime
+goal: correctness
+assignee: "ttraenkler/codex-5807-migration"
+---
+
+# Investigate landed BigInt TypedArray regressions
+
+## Corrected status
+
+The regression investigation remains unresolved. GitHub #5751 had already merged
+as `efa0908e09998c73da592fba32708c7ecca8d6e5`; the original title's
+unmerged-landing premise was corrected by the final comment. The authoritative
+CI report still contains two regressions. Retrieved JSONL rows omit `wasm_sha`,
+so the comparator's hash-change label is not independent evidence of unequal
+Wasm bytes. The bounded macOS 3/3 paired runs and six identical same-variant
+binary pairs do not clear the original Linux/four-worker failure. No causal
+fix, flakiness claim, or gate waiver follows from this migration.
+
+This allocated issue is the canonical destination for the original body and
+three comments from [GitHub #5807](https://github.com/loopdive/js2/issues/5807).
+The separately [held #5798 branch](https://github.com/loopdive/js2/pull/5798/files)
+includes the older local issue `5807-bigint-typedarray-landing-regressions.md` and later diagnostic
+artifacts; this migration preserves that owner's work and does not adopt or
+reinterpret its additional evidence. Issue numbers in the historical record
+below refer to GitHub unless explicitly described as local plan issues.
+
+## Implementation Plan — tracking migration and creation guard
+
+1. Preserve the exact GitHub title/body and all three comments below, including
+   their URLs and timestamps. Keep this issue open for the underlying diagnosis.
+2. Add one dependency-free `.claude/hooks/block-github-issue-create.py` decision
+   hook and register it in the existing `.claude/settings.json` and
+   `.codex/hooks.json` PreToolUse lists. Preserve every unrelated hook.
+3. Test literal `gh issue create`, issue-creation REST and GraphQL commands and
+   structured GitHub tool calls for `loopdive/js2` and its verified `js2wasm`
+   alias. Block before execution; allow PR creation, normal issue reads/closure,
+   other explicitly named repositories and quoted documentation. Test command
+   token boundaries, malformed input, and the actual registered hook commands
+   with local stubs; never send a real create-issue request.
+4. Document the precise supported routes and limits of local hook enforcement.
+   Project trust/activation is required; do not modify global trust or pretend
+   that registration proves this current desktop session runs the hook.
+5. Run the focused root test file and normal quality/commit/push hooks. Publish
+   the signed migration/guard on one ready PR, verify the remote plan file,
+   then close GitHub #5807 as migrated with that durable link. Closure does not
+   mark the compiler defect fixed.
+
+Owned files: this issue, the one new hook, the two existing hook registrations,
+and `tests/issue-6448-github-issue-creation-guard.test.ts`. No compiler, fixture,
+collection-brand, boundary-policy, or integration source changes are included.
+
+## Guard enforcement and limits
+
+The guard is registered as a `PreToolUse` command in both repository hook
+configurations. It recognizes literal `gh issue create` (including repository
+selectors, basic `env`/`command` wrappers and `sh`/`bash`/`zsh -c`), `gh api`
+POSTs to the issue collection (including the implicit POST from fields/input),
+explicit curl REST POSTs, visible GraphQL `createIssue` calls, and structured
+GitHub `create_issue`/`issue_write` inputs. Both names `loopdive/js2` and
+`loopdive/js2wasm` resolve to repository ID `1218952664` in the migration read.
+Unqualified creation defaults to this repository; an explicit different
+repository or `GH_REPO` is allowed. Visible GraphQL creation with an opaque
+repository ID is refused because the guard cannot prove a different target.
+Malformed hook input or unsupported quote/here-document syntax fails closed.
+
+A supported hook host consumes the deny decision/exit 2 before dispatch. The
+focused test executes each registered command and demonstrates that a denied
+call never reaches a local `gh` stub, while an allowed PR call reaches it. This
+is protocol/decision testing, not proof of current desktop activation.
+[Codex's documented hook contract](https://learn.chatgpt.com/docs/hooks) supports
+project `.codex/hooks.json`, shell/unified-exec calls under `Bash`, and MCP names;
+project trust and hook activation are prerequisites. The current session's
+trusted legacy entries do not establish trust or execution of this new entry.
+[Claude Code's hook contract](https://code.claude.com/docs/en/hooks) supports the
+repository settings registration and the same deny response. No global trust,
+account permission, or GitHub repository feature is changed.
+
+This is a local accidental-creation guard, not a GitHub-side security boundary.
+It does not interpret arbitrary programs, aliases, computed/expanded commands,
+backticks, shell substitutions, `eval`, sourced scripts, or opaque GraphQL
+payload files/stdin. It does not inspect later interactive `write_stdin` input,
+browser actions, or tools the host does not deliver to PreToolUse. Here-document
+bodies are treated as data, not evaluated as shell expansions. Other HTTP
+clients and custom API wrappers require additional adapters. The existing
+unrelated hook entries are preserved. PR creation, existing issue reads,
+comments/closure, and quoted shell documentation remain available.
+
+## Migration implementation evidence
+
+Local ID 6448 was atomically allocated and claimed for
+`ttraenkler/codex-5807-migration` on `origin/issue-assignments` with a successful
+open-PR collision scan, starting from main
+`6aac84c0b6ef418bbfa6a97cceca25960db7a3f6` in an isolated worktree. The 38-open-PR
+file snapshot contained no overlapping hook/configuration writer. This slice
+implements only the tracking migration and guard; the underlying compiler
+investigation retains `status: ready`.
+
+The first focused run passed **44/44** controls with one Node 24 worker and
+4 GB limits, including all command allow/deny rows, malformed input, structured
+GitHub calls and both registered hook commands. Tests use only local stubs;
+there were zero real GitHub issue-creation attempts. Raw original issue/comment
+API snapshots and the focused log/JSON report are preserved in the isolated
+worktree's `.tmp/5807-migration/`. The historical text below is copied exactly
+from the body and three-comment snapshot; corrections appear above it rather
+than rewriting the originals.
+
+## Original GitHub record (verbatim historical text)
+
+Source: https://github.com/loopdive/js2/issues/5807
+
+Original title: fix(ir): bisect two BigInt TypedArray regressions blocking #5751 landing
+
+Author: `ttraenkler`; created `2026-09-09T16:32:21Z`; last updated `2026-09-09T18:52:56Z`.
+
+State at migration snapshot: `open`; comments: `3`.
+
+### Original body
+
+```text
+Queue-drain landing blocker; new migration scope remains paused.
+
+Actual merge-group Test262 run https://github.com/loopdive/js2/actions/runs/34374533493 failed regression job 102551653768 on candidate efa0908e09998c73da592fba32708c7ecca8d6e5 (PR #5751 head 1330f172f78ed794915ffabeacbf2c39cf5bea07). The gate compared 48,735 baseline and candidate rows: 38,384 to 38,382 passes, two regressions, zero improvements; both regression Wasm hashes changed. Compile timeouts stayed 16 to 16 and no quarantine transitions were excluded.
+
+Affected paths:
+- test/built-ins/TypedArray/prototype/set/BigInt/array-arg-src-values-are-not-cached.js: pass to fail, RangeError offset out of bounds.
+- test/built-ins/TypedArrayConstructors/ctors-bigint/object-arg/new-instance-extensibility.js: pass to fail, cannot marshal opaque compiled value to host BigInt64Array constructor.
+
+The out-of-bounds category grew 11 to 12. These paths also appear in unresolved historical N1 evidence; repetition does not establish flakiness or authorize a waiver. The current baseline is content-current. PR #5751 is held and the queue is empty; cumulative #5798 must not land over this failure.
+
+Implementation/diagnosis plan:
+1. Preserve exact donor/candidate JSONL rows, hashes, shard logs and process/retry provenance from the actual run.
+2. Reproduce through the CI CompilerPool/worker path against clean known-good donor and exact candidate, with the same corpus, options, runtime and a known-good control. Local helper error classifications are not interchangeable with CI.
+3. Bisect and trace the source-to-Wasm/host-marshalling difference; have an independent agent review the minimal blocker fix.
+4. Add focused regression coverage and verify the original failure conditions, then push the fix to the existing landing PR. No gate, quarantine, baseline or test weakening.
+5. Re-run genuine protected-queue conformance only after cause/fix evidence; refresh #5798 and affected dependents after actual main delivery.
+
+Parent owns integration and public updates. Parallel agents own evidence collection and independent cause analysis. No fix or completion is claimed.
+```
+
+### Comment 5605367333
+
+Source: https://github.com/loopdive/js2/issues/5807#issuecomment-5605367333
+
+Author: `ttraenkler`; created `2026-09-09T16:38:01Z`; updated `2026-09-09T16:38:01Z`.
+
+```text
+Evidence refinement: the comparator labels both rows as Wasm-hash changes, but the retrieved authoritative baseline and candidate JSONL rows contain no wasm_sha fields. Therefore actual byte/hash inequality is not independently established; do not treat that comparator label as an artifact hash comparison. Both exact rows do establish baseline pass and candidate fail under oracle 13, honest lane, semantic providers auto, official standard scope and strict both. Both candidate import lists omit baseline env::__extern_set_strict; this is a diagnostic observation, not a proven cause. Exact failed candidate and passing donor worktrees are now available for paired CI-path reproduction. The simple run-test262-paths helper uses runTest262File and is not the CI CompilerPool classifier; that proposed shortcut has been rejected.
+```
+
+### Comment 5605517261
+
+Source: https://github.com/loopdive/js2/issues/5807#issuecomment-5605517261
+
+Author: `ttraenkler`; created `2026-09-09T16:49:58Z`; updated `2026-09-09T16:49:58Z`.
+
+```text
+Paired diagnostic update: exact donor 129e3efd4530ae1be56dbf5fdea54ddbbd87443e and failed merge candidate efa0908e09998c73da592fba32708c7ecca8d6e5 each passed 3/3 selected rows through the existing dynamic-chunk/shared CompilerPool CI path on Node 25.9.0, honest gc lane, providers auto. Both shard receipts record exactly three registered/settled canonical rows. The third row, non-BigInt constructor object-argument extensibility, is independently PASS/PASS in both original CI artifacts. Local runs used macOS ARM64 and one worker, not Linux x64/four-worker shard history, so this does not clear the original failure.
+
+A separate fresh-per-row artifact diagnostic produced six primary/strict variants in each root; parent independently compared every emitted Wasm file and found all six same-variant binary pairs byte-identical, with six passes in each root. That older capture driver has limited admission hardening, so this is bounded diagnostic evidence, not a replacement for the authoritative CI gate. Source-to-runtime worker history/environment remains to investigate; no source fix or flakiness claim is established.
+
+The shared CI caller replaces the primary result with the strict-rerun result after a primary pass. Thus passing-row imports and primary-failure imports can describe different variants; the missing strict-set import is not by itself causal evidence.
+```
+
+### Comment 5607080067
+
+Source: https://github.com/loopdive/js2/issues/5807#issuecomment-5607080067
+
+Author: `ttraenkler`; created `2026-09-09T18:52:55Z`; updated `2026-09-09T18:52:55Z`.
+
+```text
+Landing-state correction: #5751 merged at 2026-09-09T16:31:32Z as efa0908e09998c73da592fba32708c7ecca8d6e5. Its exact head and merge commit are verified ancestors of main96c4970002. Actual Test262 run34374533493 still reports failure; no causal fix or regression clearance has been established. This issue therefore concerns landed code, not an unmerged PR. The cumulative #5798 remains held while the evidence is reconciled and remaining composed validation runs. No bypass or flakiness claim is authorized by the merge itself.
+```

--- a/tests/issue-6448-github-issue-creation-guard.test.ts
+++ b/tests/issue-6448-github-issue-creation-guard.test.ts
@@ -1,0 +1,153 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+const root = resolve(__dirname, "..");
+const hook = join(root, ".claude/hooks/block-github-issue-create.py");
+const scratch = mkdtempSync(join(tmpdir(), "js2-6448-guard-"));
+afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+function inspect(toolName: string, toolInput: unknown) {
+  return spawnSync("python3", [hook], {
+    cwd: root,
+    input: JSON.stringify({ hook_event_name: "PreToolUse", cwd: root, tool_name: toolName, tool_input: toolInput }),
+    encoding: "utf8",
+    env: { ...process.env, GH_REPO: "loopdive/js2" },
+  });
+}
+
+describe("local-only issue creation policy", () => {
+  it.each([
+    "gh issue create --title regression",
+    "gh issue create -R loopdive/js2 --title regression",
+    "gh -Rloopdive/js2wasm issue create --title regression",
+    "gh --repo='https://github.com/loopdive/js2' issue create",
+    "gh issue create --repo LOOPDIVE/JS2",
+    "env GH_REPO=loopdive/js2wasm command gh issue create",
+    "gh issue view 5807; gh issue create -R loopdive/js2",
+    "echo allowed && /opt/homebrew/bin/gh issue create -R loopdive/js2",
+    "gh issue \\\ncreate --repo loopdive/js2",
+    "bash -lc 'gh issue create --repo loopdive/js2'",
+    "gh api -X POST repos/loopdive/js2/issues -f title=regression",
+    "gh api repos/loopdive/js2wasm/issues --raw-field title=regression",
+    "gh api --method=POST /repos/loopdive/js2/issues",
+    "gh api /repos/loopdive/js2/issues --input payload.json",
+    'gh api graphql -f \'query=mutation {createIssue(input:{repositoryId:"opaque",title:"regression"}){issue{id}}}\'',
+    "curl -XPOST https://api.github.com/repos/loopdive/js2/issues",
+    "curl --json @payload.json https://api.github.com/repos/loopdive/js2wasm/issues",
+    'curl --data \'{"query":"mutation {createIssue(input:{repositoryId: \\"opaque\\"}){issue{id}}}"}\' https://api.github.com/graphql',
+  ])("denies a real creation command: %s", (command) => {
+    const result = inspect("Bash", { command });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(2);
+    expect(JSON.parse(result.stdout).hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+    });
+    expect(result.stderr).toContain("plan/issues/");
+  });
+
+  it.each([
+    "gh pr create --repo loopdive/js2 --title regression --body-file pr.md",
+    "gh issue view 5807 --repo loopdive/js2 --comments",
+    "gh issue close 5807 --repo loopdive/js2 --reason 'not planned' --comment 'Tracking migrated.'",
+    "gh issue list --repo loopdive/js2wasm",
+    "gh api repos/loopdive/js2/issues",
+    "gh api repos/loopdive/js2/issues -X GET -f state=open",
+    "gh api repos/loopdive/js2/issues/5807 -X PATCH -f state=closed",
+    "gh api repos/loopdive/js2/issues/5807/comments -f body=migrated",
+    "gh api repos/loopdive/js2/pulls -f title=regression",
+    "gh issue create --repo unrelated/project --title regression",
+    "GH_REPO=unrelated/project gh issue create",
+    "gh api repos/unrelated/project/issues -f title=regression",
+    "curl --get --data state=open https://api.github.com/repos/loopdive/js2/issues",
+    "curl --data '{}' https://example.invalid/repos/loopdive/js2/issues",
+    "printf '%s\\n' 'gh issue create --repo loopdive/js2'",
+    "echo ';' gh issue create --repo loopdive/js2",
+    "git commit -m 'Document gh issue create; keep PR creation available'",
+    "cat <<'DOC' > documentation.md\ngh issue create --repo loopdive/js2\nDOC\ngh issue view 5807",
+    "# gh issue create\ngh issue view 5807",
+    'gh api graphql -f \'query={repository(owner:"loopdive",name:"js2"){issues(first:1){totalCount}}}\'',
+  ])("allows an unrelated action or quoted documentation: %s", (command) => {
+    const result = inspect("Bash", { command });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+
+  it("inspects unified exec's cmd field and shell nesting", () => {
+    expect(inspect("exec_command", { cmd: "zsh -c 'gh issue create'" }).status).toBe(2);
+    expect(inspect("exec_command", { cmd: "gh issue view 5807" }).status).toBe(0);
+  });
+
+  it("does not interpret Edit/Write documentation as an invocation", () => {
+    expect(inspect("Write", { content: "gh issue create", file_path: "README.md" }).status).toBe(0);
+  });
+
+  it("checks structured connector and GitHub MCP creation routes", () => {
+    for (const data of [
+      { repository_full_name: "loopdive/js2" },
+      { repo_full_name: "loopdive/js2wasm" },
+      { owner: "loopdive", repo: "js2" },
+    ]) {
+      expect(inspect("mcp__codex_apps__github_create_issue", data).status).toBe(2);
+    }
+    expect(inspect("mcp__github__issue_write", { method: "create", owner: "loopdive", repo: "js2" }).status).toBe(2);
+    expect(inspect("mcp__github__issue_write", { method: "update", owner: "loopdive", repo: "js2" }).status).toBe(0);
+    expect(inspect("mcp__github__create_issue", { owner: "another", repo: "project" }).status).toBe(0);
+    expect(inspect("mcp__github__create_pull_request", { owner: "loopdive", repo: "js2" }).status).toBe(0);
+    expect(inspect("mcp__github__get_issue", { owner: "loopdive", repo: "js2" }).status).toBe(0);
+  });
+
+  it("fails closed on missing creation targets and malformed hook input", () => {
+    expect(inspect("mcp__github__create_issue", { title: "unknown repository" }).status).toBe(2);
+    expect(inspect("Bash", { command: "gh issue create 'unterminated" }).status).toBe(2);
+    expect(inspect("Bash", { command: ["gh", "issue", "create"] }).status).toBe(2);
+    expect(inspect("mcp__github__create_issue", { repository: { name: "uninspectable" } }).status).toBe(2);
+    const malformed = spawnSync("python3", [hook], { input: "{", encoding: "utf8" });
+    expect(malformed.status).toBe(2);
+    expect(malformed.stderr).toContain("could not inspect");
+  });
+
+  it.each([".claude/settings.json", ".codex/hooks.json"])(
+    "runs the registered %s hook before a local gh stub",
+    (config) => {
+      const entries = JSON.parse(readFileSync(join(root, config), "utf8")).hooks.PreToolUse;
+      const guards = entries.filter((entry: { hooks: { command: string }[] }) =>
+        entry.hooks.some((handler) => handler.command.includes("block-github-issue-create.py")),
+      );
+      expect(guards).toHaveLength(1);
+      const entry = guards[0];
+      expect(new RegExp(entry.matcher).test("Bash")).toBe(true);
+      expect(new RegExp(entry.matcher).test("mcp__codex_apps__github_create_issue")).toBe(true);
+      const marker = join(scratch, config.includes("codex") ? "codex-marker" : "claude-marker");
+      const stub = join(scratch, "gh");
+      writeFileSync(stub, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$GUARD_TEST_MARKER"\n', { mode: 0o700 });
+      const env = {
+        ...process.env,
+        GH_REPO: "loopdive/js2",
+        PATH: `${scratch}:${process.env.PATH}`,
+        GUARD_TEST_MARKER: marker,
+      };
+      for (const [command, denied] of [
+        ["gh issue create", true],
+        ["gh pr create", false],
+      ] as const) {
+        const result = spawnSync("/bin/sh", ["-c", entry.hooks[0].command], {
+          cwd: root,
+          env,
+          input: JSON.stringify({ tool_name: "Bash", tool_input: { command } }),
+          encoding: "utf8",
+        });
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(denied ? 2 : 0);
+        // This models the documented hook protocol, not a live desktop invocation.
+        if (result.status === 0) expect(spawnSync("/bin/sh", ["-c", command], { env }).status).toBe(0);
+        expect(existsSync(marker)).toBe(!denied);
+      }
+      expect(readFileSync(marker, "utf8")).toBe("pr create\n");
+    },
+  );
+});


### PR DESCRIPTION
Migrate GitHub #5807 into allocated local issue #6448 while keeping the landed BigInt TypedArray regression investigation unresolved. The plan preserves the full original body and all three comments, leads with the corrected landing/hash-evidence status, and links the held historical #5798 record without changing it.

Add a repository PreToolUse guard in Claude Code and Codex for recognized `gh issue create`, issue-creation REST/GraphQL calls and structured GitHub tool calls. PR creation, issue reads/closure and quoted documentation remain allowed. The guard requires a supported, activated/trusted hook host; it is not a GitHub-side control or an interpreter for arbitrary scripts and opaque payloads. Precise inspection limits are recorded in the plan.

Validation: 44 focused controls and all 44 normal commit-hook controls, including the actual registered hook command strings and local deny-before-execution stubs. Normal push hooks passed typecheck, lint, formatting, issue integrity and all 18 existing numeric-local regressions. Canonical issue-ID/main/open-PR checks and an explicit nonempty coercion census also passed. No real issue-creation request and no compiler-source edit.

Closing the old GitHub tracking location as migrated is a separate explicit user-authorized action after this canonical plan is published; this PR does not claim a compiler fix.
