### PR TITLE
fix(#6426): an object-rest source keeps its values across a linked package

### DIFF
--- a/plan/issues/6426-object-assign-option-bag-across-linked-package.md
+++ b/plan/issues/6426-object-assign-option-bag-across-linked-package.md
@@ -1,10 +1,11 @@
 ---
 id: 6426
 title: "`Object.assign(this, options)` in a base class drops the value when the class lives in a separately-linked package"
-status: ready
+status: done
 sprint: current
 created: 2026-09-12
-updated: 2026-09-12
+updated: 2026-09-13
+completed: 2026-09-13
 priority: medium
 horizon: m
 feasibility: medium
@@ -97,3 +98,73 @@ Then delete `LINKED_RESIDUALS` in `tests/issue-5366-nullish-join-carrier.test.ts
 ## Dispatch
 
 **Model: opus.** The defect is located to four one-line sites in `src/runtime.ts` with a known template (#5225), but the work needs a correct three-lane linked-package fixture (the fallback-to-bundled trap above) and a per-file dogfood A/B read honestly — medium, not mechanical.
+
+## Resolution
+
+**Fixed 2026-09-13** in `src/runtime.ts` (host runtime only, no codegen change),
+PR on `issue-6426`. The plan's diagnosis was right and its four sites were the
+right four; the probe confirmed it before any edit and added one row it did not
+predict.
+
+**Mechanism.** Four host helpers read a WasmGC struct in two steps: field NAMES
+from `_getStructFieldNames`, then each VALUE from `exports["__sget_<key>"]`.
+Since #5225 the name step routes through `_decoderExportsFor`, so it answers
+with the struct OWNER's decoder — but the value step still used the READER's
+own exports. A `__sget_<key>` getter is module-global by field NAME and does not
+trap on a foreign struct type: it `ref.test`-misses and returns its miss default.
+So when a consumer mints an options bag and a linked provider does
+`const { strict, ...rest } = options; Object.assign(this, rest)`, every key
+survives and every value is lost — `null` for references, `0` for numbers.
+`typeof null === "object"` is the whole reason the issue's function row looked
+like a different defect from its object row; both are the same lost value.
+
+The fix is one line at each of the four sites — `_decoderExportsFor(obj,
+callbackState?.getExports())`, exactly the L12569 template — in
+`__extern_rest_object`, `__object_values`, `__object_entries` and the tuple arm
+of `__extern_slice`. `__object_keys` is names-only and was already correct;
+nothing on the write side moved. The diff is 4 changed lines and **zero net
+lines**: `src/runtime.ts` sits exactly at the #4401 ceiling (19735), so the
+mechanism is written up here and in the test header rather than inline, and the
+sites carry the repo's existing `// (#5225/#6426)` marker.
+
+**Probe (`.tmp/6426-repro.mts`, `linkPlan.mode === "separate"`), base → fix.**
+6 of 9 rows wrong on base, 0 after; the 3 controls never moved.
+
+| row | base | fix | node |
+| --- | --- | --- | --- |
+| `restObj` (object through `...rest`) | `"null"` | `"R"` | `"R"` |
+| `restFn` (function through `...rest`) | `"object"` | `"function"` | `"function"` |
+| `restNum` (number through `...rest`) | `"0"` | `"7"` | `"7"` |
+| `restKeys` (`Object.keys(rest)` + `rest.router`) | `"router\|no"` | `"router\|has"` | `"router\|has"` |
+| `Object.values` of a consumer struct in the provider | `"undefined,undefined"` | `"number,string"` | `"number,string"` |
+| `Object.entries` of same | `"a:undefined,b:undefined"` | `"a:number,b:string"` | `"a:number,b:string"` |
+| control: direct `Object.assign(this, options)` | `"R"` | `"R"` | `"R"` |
+| control: `{ ...options }` spread source | `"R"` | `"R"` | `"R"` |
+| control: `this.router = options.router` | `"R"` | `"R"` | `"R"` |
+
+The number row (`0`, not `undefined`) is the sharpest confirmation of the
+mechanism: that is a `ref.test`-miss default, not a missing key.
+
+**Regression test** `tests/issue-6426-linked-object-rest-source.test.ts`, 12 rows
+x 3 lanes, one shared `EXPECTED` table:
+
+- parent: single 0 wrong / one-unit multi 0 / separately-linked **6** = 6
+- fix: 0 / 0 / 0 = 0
+
+The 6 are `restObj`, `restFn`, `restNum`, `restKeys`, `restValues`,
+`restEntries`. The other 6 rows are anti-vacuity controls that already passed on
+the parent (direct assign, spread source, plain field store, `Object.keys`,
+rest-with-an-excluded-key, empty bag), and the linked lane additionally asserts
+that all 6 regressed rows are actually present in that module's exports.
+
+**Acceptance 2** — `LINKED_RESIDUALS` is deleted from
+`tests/issue-5366-nullish-join-carrier.test.ts` and its linked lane now asserts
+the shared `EXPECTED` table; all three lanes of that file pass.
+
+**Dogfood A/B** — base vs fix at one HEAD over all 17 upstream suites, results
+in the PR body. Flat, as the plan predicted: these suites compile the package's
+own source as the root unit, so the consumer→provider rest seam never fires.
+
+**Residual.** `tests/issue-2131.test.ts` fails 6/7 on `upstream/main`
+`3e92241ecc` and fails identically with this change — pre-existing, untouched,
+not this issue's.

--- a/plan/issues/6451-jshost-struct-enumeration-returns-empty-in-2131-harness.md
+++ b/plan/issues/6451-jshost-struct-enumeration-returns-empty-in-2131-harness.md
@@ -1,0 +1,80 @@
+---
+id: 6451
+title: "JS-host `Object.keys`/`values`/`entries`/`for-in` return nothing in the #2131 harness — 6 of 7 rows regressed on main"
+status: ready
+sprint: current
+created: 2026-09-13
+updated: 2026-09-13
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+`tests/issue-2131.test.ts` passes **1 of 7** on `upstream/main` `3e92241ecc`.
+The six JS-host rows do not merely mis-*order* keys — the enumeration comes back
+**empty**:
+
+| row | expected | actual on main |
+| --- | --- | --- |
+| `Object.keys` puts array-index keys first, ascending | `1,2,b,a` | `""` |
+| `for-in` visits keys in the same order | `1,2,b,a,` | `""` |
+| `Object.values` follows the spec key order | `4,2,1,3` | `""` |
+| `Object.entries` follows the spec key order | `12ba` | `NaN` |
+| pure string-key objects keep insertion order | `b,a,c` | `""` |
+| non-canonical numeric-looking keys are NOT reordered | `b,01,a` | `""` |
+| standalone keeps integer-key-first order (#3155) | — | ✓ passes |
+
+Only the **standalone** row survives, which localises this to the **JS-host**
+enumeration path, not to `_orderOwnKeysSpec` or the standalone twin.
+
+Measured 2026-09-13 while landing
+[#6426](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6426-object-assign-option-bag-across-linked-package):
+identical counts with #6426's change applied and with it reverted, so it is
+neither caused nor masked by that fix.
+
+[#2131](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2131-jshost-enum-order-ignores-integer-key-ascending)
+is `done` and its Resolution records `7/7`, so this is an untracked regression
+some later change introduced.
+
+## Why it is not already obvious
+
+Every dogfood suite is green on the same HEAD and several of them (redux's
+`finalReducers[key]`, React's dynamically assembled props — see the #4298 note
+in `src/runtime.ts`) depend on exactly this round trip. So either
+
+- the regression is specific to how **this test's harness** drives the runtime
+  (it calls `buildImports` from `src/runtime.js` directly rather than going
+  through `compile`'s own import object), which would make it a stale-harness
+  defect rather than a compiler one, **or**
+- the dogfood suites never exercise the shape this test uses.
+
+Deciding which of those is true is the first job, because they have opposite
+consequences: the first is a test-only fix, the second is a real user-visible
+enumeration hole that nothing else in the corpus covers.
+
+## Acceptance criteria
+
+1. Name which of the two explanations above is correct, with a probe that
+   distinguishes them (same source compiled through `compile` end-to-end vs
+   through the test's `buildImports` harness).
+2. If the compiler is at fault: the six rows answer as node does, and a dogfood
+   A/B over the 17 suites is reported.
+3. If the harness is at fault: the harness is repaired so the rows exercise the
+   real import object, and the test is green — a test that cannot fail for the
+   right reason is worse than no test.
+4. Bisect to the commit that moved it, and record that sha here either way.
+
+## Notes
+
+- `tests/issue-2131.test.ts:88` is the last of the six; `:35`, `:47`, `:57`,
+  `:68`, `:78` are the others.
+- `Object.entries` answering `NaN` rather than `""` is the sharpest clue: that
+  row builds a string by concatenation over the entries, so an empty entry list
+  plus a numeric seed produces `NaN`. Consistent with "the list is empty",
+  inconsistent with "the list is mis-ordered".

--- a/plan/issues/6452-mixed-decoder-audit-remaining-sget-read-sites.md
+++ b/plan/issues/6452-mixed-decoder-audit-remaining-sget-read-sites.md
@@ -1,0 +1,104 @@
+---
+id: 6452
+title: "Mixed-decoder audit: 27 more host helpers read `__sget_` with the READER's exports"
+status: ready
+sprint: current
+created: 2026-09-13
+updated: 2026-09-13
+priority: medium
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+## Problem
+
+Three issues have now fixed the same one-line defect at different sites:
+[#5225](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5225-consumer-minted-struct-opaque-in-linked-provider)
+(`__extern_get` and one more),
+[#5365](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5365-compiled-closure-length-reads-vec-getter-miss)
+(closure `.length` ahead of the probe), and
+[#6426](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6426-object-assign-option-bag-across-linked-package)
+(`__extern_rest_object`, `__object_values`, `__object_entries`, the
+`__extern_slice` tuple arm).
+
+The shape is always identical. A host helper binds
+
+```ts
+const exports = callbackState?.getExports();   // the READER's exports
+```
+
+and then reads a struct field through `exports["__sget_<key>"]`. A `__sget_`
+getter is module-global by field **name** and does **not** trap on a struct type
+it does not own: it `ref.test`-misses and returns that getter's default — `null`
+for references, `0` for numbers. So across a linked package boundary the read
+silently yields a wrong value instead of failing. `_decoderExportsFor(obj,
+callbackState?.getExports())` is the fix, and it has been applied one site at a
+time, each time after a user-visible bug was reported.
+
+**A mechanical scan of `src/runtime.ts` at `3e92241ecc` finds 27 more sites with
+that exact shape** (`const <x> = callbackState?.getExports();` followed within 45
+lines by a `__sget_` read, with no `_decoderExportsFor`):
+
+| import | lines |
+| --- | --- |
+| `__iterator_next` | 17359, 17365, 17371, 17380, 17388 |
+| `__extern_length` | 12890\*, 12929 |
+| `__defineProperties` | 14229\*, 14272 |
+| `__for_in_has` | 16616, 16638 |
+| `__gen_result_value` / `_f64` / `_done` | 17191, 17198, 17207 |
+| `__extern_get_idx`, `__extern_has_idx` | 12978, 13050 |
+| `__make_iterable`\*, `__array_values`, `__array_concat_any` | 17483, 17619, 17637 |
+| `__async_iterator`, `__iterator_return` | 17314, 17424 |
+| `preventExtensions` | 9833 |
+| unnamed helpers | 3454, 5513, 5527, 5641\*, 5678 |
+
+\* = also reads the field **names** (`_getStructFieldNames` /
+`__struct_field_names`) from the same reader exports, which is the strictly worse
+variant: names and values then disagree about which module owns the struct.
+
+## Why this is worth doing as one pass
+
+Three separate user-visible bugs have now been paid for one site at a time, and
+the remaining list includes the iterator protocol and `for-in` — paths that a
+linked package hits constantly. The per-site cost is one line; the cost of
+finding each one the current way is a reported bug plus a reduction.
+
+**But it is explicitly NOT a blind sed.** Some of these sites may be reached only
+with structs the reader does own, in which case `_decoderExportsFor` is a no-op
+and the change is noise; others may pass `exports` on to a helper that already
+applies the decoder. Each site needs its own two-module probe before it is
+touched.
+
+## Acceptance criteria
+
+1. Every one of the 27 sites is classified: **fix** (a linked-lane probe shows a
+   wrong value), **already-covered** (the decoder is applied downstream), or
+   **unreachable-cross-module** (with the argument for why).
+2. Each `fix` site gets a row in one regression test built on the
+   `tests/issue-6426-linked-object-rest-source.test.ts` three-lane pattern
+   (single / one-unit multi / `compileProject` separate, one shared `EXPECTED`
+   table, `linkPlan.mode === "separate"` asserted).
+3. A lint or gate that makes the next instance fail at author time rather than at
+   bug-report time — the recurring-defect part of this issue, and the part that
+   stops a fourth round.
+4. `src/runtime.ts` is **at** the #4401 ceiling (19735 lines), so the pass must
+   be line-neutral or move the helpers into `src/runtime/<module>.ts`.
+5. A/B over the 17 dogfood suites, per test file.
+
+## Reproduction of the scan
+
+```bash
+python3 - <<'PY'
+import io, re
+lines = io.open("src/runtime.ts", encoding="utf-8").read().split("\n")
+for i, l in enumerate(lines):
+    if re.search(r"const \w+ = callbackState\?\.getExports\(\);", l) and "_decoderExportsFor" not in l:
+        w = "\n".join(lines[i:i+45])
+        if "__sget_" in w:
+            print(i+1, "names_too=" + str("_getStructFieldNames" in w or "__struct_field_names" in w))
+PY
+```

--- a/plan/issues/6454-merge-queue-test262-shards-die-before-afterall.md
+++ b/plan/issues/6454-merge-queue-test262-shards-die-before-afterall.md
@@ -1,0 +1,83 @@
+---
+id: 6454
+title: "Merge queue is wedged: every `merge_group` test262 shard dies before `afterAll`, so no PR can land"
+status: ready
+sprint: current
+created: 2026-09-13
+updated: 2026-09-13
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ci
+goal: correctness
+---
+
+## Problem
+
+Every `merge_group` re-validation on 2026-09-13 fails `Test262 Sharded`, so
+`auto-park` `hold`-labels the PR and **nothing merges**. This is not one PR's
+regression — it is the whole queue.
+
+Observed on three consecutive, unrelated PRs:
+
+| PR | merge_group run | `Test262 Sharded` |
+| --- | --- | --- |
+| #5885 | 34739…544 (05:11Z), 05:15Z | failure |
+| #5889 | 34739544544 (05:08Z) | failure |
+| #5890 | 34739996390 (05:19Z), 05:22Z | failure |
+
+**90 of 100 jobs fail, all with the same two lines:**
+
+```
+##[error]Test262 shard did not reach afterAll; refusing partial JSONL evidence
+##[error]Process completed with exit code 2.
+```
+
+The shape says infra, not conformance:
+
+- The vitest invocation lasts **~10 seconds** (05:21:11.85 → 05:21:21.61 on
+  `test262 standalone shard 1/50`). A real shard is minutes.
+- The **blob report is written** and vitest's exit code is accepted by the
+  wrapper — so vitest ran and returned cleanly; it simply produced no
+  `…​.shard-*.complete.json` completion marker, which is what the guard checks.
+- Everything upstream of it is healthy in the log: the compiler and runtime
+  bundles build (`18.0mb` / `17.8mb`, ~400 ms each), and the Temporal provider
+  artifact downloads with a matching SHA256.
+- Both the **js-host** and the **standalone** matrices fail, which rules out
+  anything target-specific.
+
+So the guard is doing its job — refusing partial evidence — and **no test262
+verdict was ever produced.** Every `hold` it produced today is therefore
+evidence-free: the park comments' own footer names exactly this case ("If it is
+a setup/infra step rather than a verdict step, the verdict never ran and this
+park may be spurious").
+
+## Why this matters more than a normal red gate
+
+`auto-enqueue` skips a `hold`-labelled PR, so each parked PR **strands** until a
+human clears it — and clearing it just sends the PR back through the same
+failing group. Work is accumulating behind a gate that is not measuring
+anything.
+
+## Acceptance criteria
+
+1. Name the change that made `tests/test262-chunk-dynamic.test.ts` return in
+   ~10 s without reaching `afterAll`, and when it landed (bisect over main
+   between the last green `merge_group` and 2026-09-13 05:08Z).
+2. The shard either runs to completion or fails with a message that says *why*
+   collection produced nothing — a ten-second silent no-op that trips a
+   downstream evidence guard is the expensive part of this incident.
+3. Every PR parked by this outage is re-admitted once the queue is green, and
+   each one's `hold` is removed only after confirming its own group passed.
+4. Consider whether the completion-marker guard should distinguish "shard
+   crashed" from "shard collected zero tests" — they need different responses,
+   and today they produce the same message.
+
+## Evidence
+
+- Failing job log: <https://github.com/loopdive/js2/actions/runs/34739996390/job/103678140919>
+- Same signature on an unrelated PR: <https://github.com/loopdive/js2/actions/runs/34739544544> (job 103676937051)
+- Enumerate more:
+  `gh api 'repos/loopdive/js2/actions/runs?event=merge_group&per_page=20' --jq '.workflow_runs[] | "\(.created_at) \(.conclusion) \(.name) \(.head_branch)"'`

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13814,7 +13814,7 @@ assert._isSameValue = isSameValue;
           // ES §20.1.2.22 Object.values → ToObject (§7.1.18) throws on null/undefined.
           if (obj == null) throw new TypeError(`Cannot convert ${obj === null ? "null" : "undefined"} to object`);
           if (_isWasmStruct(obj)) {
-            const exports = callbackState?.getExports();
+            const exports = _decoderExportsFor(obj, callbackState?.getExports()); // (#5225/#6426)
             const fieldNames = _getStructFieldNames(obj, exports);
             if (fieldNames) {
               const descs = _wasmPropDescs.get(obj);
@@ -13839,7 +13839,7 @@ assert._isSameValue = isSameValue;
           // ES §20.1.2.5 Object.entries → ToObject (§7.1.18) throws on null/undefined.
           if (obj == null) throw new TypeError(`Cannot convert ${obj === null ? "null" : "undefined"} to object`);
           if (_isWasmStruct(obj)) {
-            const exports = callbackState?.getExports();
+            const exports = _decoderExportsFor(obj, callbackState?.getExports()); // (#5225/#6426)
             const fieldNames = _getStructFieldNames(obj, exports);
             if (fieldNames) {
               const descs = _wasmPropDescs.get(obj);
@@ -13868,7 +13868,7 @@ assert._isSameValue = isSameValue;
           if (typeof arr === "string") return Array.from(arr).slice(start);
           // Handle WasmGC structs (tuples) — extract fields from index onwards
           if (_isWasmStruct(arr)) {
-            const exports = callbackState?.getExports();
+            const exports = _decoderExportsFor(arr, callbackState?.getExports()); // (#5225/#6426)
             const fieldNames = _getStructFieldNames(arr, exports);
             if (fieldNames && exports) {
               const result: any[] = [];
@@ -13905,7 +13905,7 @@ assert._isSameValue = isSameValue;
           };
           // For WasmGC structs, use exported getters to read fields
           if (_isWasmStruct(obj)) {
-            const exports = callbackState?.getExports();
+            const exports = _decoderExportsFor(obj, callbackState?.getExports()); // (#5225/#6426)
             const fieldNames = _getStructFieldNames(obj, exports);
             if (fieldNames) {
               for (const key of fieldNames) {

--- a/tests/issue-5366-nullish-join-carrier.test.ts
+++ b/tests/issue-5366-nullish-join-carrier.test.ts
@@ -22,9 +22,10 @@
 // Parent's wrong rows are optionRouter "null", optionRouterIdentity
 // "different", optionRouterThroughField "null" in every lane, plus
 // nullishShortCircuits "THREW: dereferencing a null pointer" in the two
-// single-unit lanes. The 2 that remain are the linked lane's baseObjectAssign /
-// otherOptionKey, wrong identically on BOTH sides and pinned in
-// LINKED_RESIDUALS below. Every other row is an anti-vacuity control that
+// single-unit lanes. The 2 that remained were the linked lane's
+// baseObjectAssign / otherOptionKey — a separate cross-module defect, closed as
+// #6426 (2026-09-13), so all three lanes now assert the same table.
+// Every other row is an anti-vacuity control that
 // already passed on the parent: the default arm, a same-class option, a
 // post-construction store, and the primitive-default `??` shapes.
 
@@ -163,21 +164,14 @@ const REGRESSED_ROWS = [
   "nullishShortCircuits",
 ] as const;
 
-/**
- * Two rows that are wrong in the separately-linked lane on BOTH sides of this
- * fix, asserted at the value the compiler actually produces (measured
- * 2026-09-12, parent and fix identical). Neither contains a `??`:
- * `baseObjectAssign` is `Object.assign(this, {...rest})` in the base class, and
- * `otherOptionKey` reads a FUNCTION copied by that same `Object.assign` and
- * gets `"object"`. So the option-bag copy loses the value's identity across a
- * separately-linked package boundary — a different defect, tracked as #6426.
- * Asserting them here makes that claim testable: if #6426 lands, this override
- * fails and is deleted; if this fix ever starts moving them, it fails first.
- */
-const LINKED_RESIDUALS: Record<string, unknown> = {
-  baseObjectAssign: "null", // node: "RegExpRouter"
-  otherOptionKey: "object", // node: "function"
-};
+// The two rows that used to be pinned here as LINKED_RESIDUALS —
+// `baseObjectAssign` "null" and `otherOptionKey` "object" — were the
+// separately-linked lane's residual after this fix, and were NOT a `??` defect:
+// the base class's `const { strict, ...rest } = options; Object.assign(this,
+// rest)` lost every value of a consumer-minted options bag because the host
+// rest helper read `__sget_<key>` from the READER's exports instead of the
+// struct owner's. Fixed as #6426 (2026-09-13); the linked lane now asserts the
+// shared EXPECTED table like the other two.
 
 function readAll(exports: Record<string, unknown>): Record<string, unknown> {
   const observed: Record<string, unknown> = {};
@@ -251,9 +245,6 @@ describe("#5366 — `??` joins on a carrier that holds both arms", () => {
     expect(result.linkPlan?.mode).toBe("separate");
 
     const { instance } = await instantiateLinkedProject(result);
-    expect(readAll(instance.exports as unknown as Record<string, unknown>)).toEqual({
-      ...EXPECTED,
-      ...LINKED_RESIDUALS,
-    });
+    expect(readAll(instance.exports as unknown as Record<string, unknown>)).toEqual(EXPECTED);
   });
 });

--- a/tests/issue-6426-linked-object-rest-source.test.ts
+++ b/tests/issue-6426-linked-object-rest-source.test.ts
@@ -1,0 +1,219 @@
+// #6426 — an object-REST source loses every value across a separately-linked
+// package boundary.
+//
+// MECHANISM. The host helper `__extern_rest_object` (and its `Object.values` /
+// `Object.entries` / tuple-slice siblings) read a WasmGC struct in two steps:
+// `_getStructFieldNames` for the key list, then `exports["__sget_<key>"]` for
+// each value. Since #5225 the NAME step routes through `_decoderExportsFor`, so
+// it answers with the struct OWNER's decoder — but the VALUE step still used
+// the READER's own exports. When a consumer mints the options bag and a linked
+// provider does `const { strict, ...rest } = options`, the provider's
+// same-named `__sget_` getter `ref.test`-misses the consumer's struct type and
+// returns its miss default instead of trapping: every key survives, every value
+// comes back `null` (references) or `0` (numbers). `typeof null === "object"`
+// is why a copied FUNCTION looked like a different defect from a copied object;
+// it is one lost value in both rows.
+//
+// The fix is `_decoderExportsFor` on the value read too, at the four sites with
+// this exact names-then-values shape.
+//
+// Counts, measured 2026-09-13 at one HEAD, 12 rows x 3 lanes:
+//   parent  single 0 wrong / multi 0 / linked 6 = 6
+//   fix     single 0 wrong / multi 0 / linked 0 = 0
+// The 6 are restObj / restFn / restNum / restKeys / restValues / restEntries.
+// Everything else is an anti-vacuity control that already passed on the parent:
+// a direct `Object.assign(this, options)`, a `{ ...options }` spread source, a
+// plain `this.x = options.x`, `Object.keys` (names-only, never broken) and the
+// two single-unit lanes of every row.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { compile, compileMulti, compileProject, instantiateLinkedProject } from "../src/index.js";
+
+/**
+ * The provider half — deliberately untyped `.js` and CLASSES ONLY. A provider
+ * that exports untyped *functions* makes the linker fall back to a `bundled`
+ * plan (inferred/`any` package signatures), which would silently run the
+ * single-unit lane a third time; the `linkPlan.mode === "separate"` assertion
+ * below is the guard, and class exports are what keeps it true.
+ */
+const LIB_SOURCE = `
+export class R {
+  constructor() { this.name = "R"; }
+}
+/** THE BUG: the option bag reaches the ctor through an object-rest binding. */
+export class RestSrc {
+  router;
+  getPath;
+  n;
+  constructor(options = {}) {
+    const { strict, ...rest } = options;
+    Object.assign(this, rest);
+  }
+}
+/** Same rest binding, read directly instead of copied — key vs value split. */
+export class RestProbe {
+  keys;
+  val;
+  constructor(options = {}) {
+    const { strict, ...rest } = options;
+    this.keys = Object.keys(rest).join("|");
+    this.val = rest.router ? "has" : "no";
+  }
+}
+/** CONTROL: no rest binding, the bag is assigned as it arrived. */
+export class DirectSrc {
+  router;
+  constructor(options = {}) { Object.assign(this, options); }
+}
+/** CONTROL: a spread copy as the assign source. */
+export class SpreadSrc {
+  router;
+  constructor(options = {}) { Object.assign(this, { ...options }); }
+}
+/** CONTROL: a plain field store off the bag. */
+export class FieldSrc {
+  router;
+  constructor(options = {}) { this.router = options.router; }
+}
+/** Object.values of a consumer-minted struct, read inside the provider. */
+export class ValuesProbe {
+  types;
+  constructor(options = {}) { this.types = Object.values(options).map((v) => typeof v).join(","); }
+}
+/** Object.entries of a consumer-minted struct, read inside the provider. */
+export class EntriesProbe {
+  pairs;
+  constructor(options = {}) { this.pairs = Object.entries(options).map(([k, v]) => k + ":" + typeof v).join(","); }
+}
+/** Object.keys — names only, correct before the fix; pins that half in place. */
+export class KeysProbe {
+  keys;
+  constructor(options = {}) { this.keys = Object.keys(options).join(","); }
+}
+`;
+
+const PROBES = `
+const nm = (v) => (v === null || v === undefined ? String(v) : String(v.name));
+
+// --- THE BUG -------------------------------------------------------------
+export function restObj() { return nm(new RestSrc({ router: new R() }).router); }
+export function restFn() { return typeof new RestSrc({ getPath: (x) => x }).getPath; }
+export function restNum() { return String(new RestSrc({ n: 7 }).n); }
+export function restKeys() { const p = new RestProbe({ router: new R() }); return p.keys + "|" + p.val; }
+export function restValues() { return new ValuesProbe({ a: 1, b: "s" }).types; }
+export function restEntries() { return new EntriesProbe({ a: 1, b: "s" }).pairs; }
+
+// --- CONTROLS (already correct on the parent) -----------------------------
+export function directObj() { return nm(new DirectSrc({ router: new R() }).router); }
+export function spreadObj() { return nm(new SpreadSrc({ router: new R() }).router); }
+export function fieldObj() { return nm(new FieldSrc({ router: new R() }).router); }
+export function keysOnly() { return new KeysProbe({ a: 1, b: "s" }).keys; }
+export function restExcludes() { const p = new RestProbe({ strict: 1, router: new R() }); return p.keys; }
+export function restEmpty() { return new RestProbe({}).keys + "|" + new RestProbe({}).val; }
+`;
+
+/** Node's answers. Shared by all three lanes — that is the point. */
+const EXPECTED: Record<string, unknown> = {
+  restObj: "R",
+  restFn: "function",
+  restNum: "7",
+  restKeys: "router|has",
+  restValues: "number,string",
+  restEntries: "a:number,b:string",
+  directObj: "R",
+  spreadObj: "R",
+  fieldObj: "R",
+  keysOnly: "a,b",
+  restExcludes: "router",
+  restEmpty: "|no",
+};
+
+/** The rows that are wrong on the parent, in the linked lane only. */
+const REGRESSED_ROWS = ["restObj", "restFn", "restNum", "restKeys", "restValues", "restEntries"];
+
+function readAll(exports: Record<string, unknown>): Record<string, unknown> {
+  const observed: Record<string, unknown> = {};
+  for (const name of Object.keys(EXPECTED)) {
+    try {
+      observed[name] = (exports[name] as (() => unknown) | undefined)?.();
+    } catch (error) {
+      observed[name] = `THREW: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  }
+  return observed;
+}
+
+async function instantiateSingle(result: unknown): Promise<Record<string, unknown>> {
+  const r = result as {
+    binary: BufferSource;
+    importObject: WebAssembly.Imports & { __setInstance?: (i: WebAssembly.Instance) => void };
+  };
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  r.importObject.__setInstance?.(instance);
+  (instance.exports as { __module_init?: () => void }).__module_init?.();
+  return instance.exports as unknown as Record<string, unknown>;
+}
+
+describe("#6426 — an object-rest source keeps its values across a package boundary", () => {
+  it("single module", { timeout: 300_000 }, async () => {
+    const result = await compile(`${LIB_SOURCE}\n${PROBES}`, {
+      allowJs: true,
+      skipSemanticDiagnostics: true,
+    } as never);
+    const observed = readAll(await instantiateSingle(result));
+    expect(observed).toEqual(EXPECTED);
+  });
+
+  it("two untyped .js modules in one compilation unit", { timeout: 300_000 }, async () => {
+    const entry = "/main.js";
+    const result = await compileMulti(
+      {
+        "/lib.js": LIB_SOURCE,
+        [entry]: `import { R, RestSrc, RestProbe, DirectSrc, SpreadSrc, FieldSrc, ValuesProbe, EntriesProbe, KeysProbe } from "./lib";\n${PROBES}`,
+      },
+      entry,
+      { allowJs: true, skipSemanticDiagnostics: true },
+    );
+    expect(result.success).toBe(true);
+    expect(result.linkedModules ?? []).toHaveLength(0);
+    expect(readAll(await instantiateSingle(result))).toEqual(EXPECTED);
+  });
+
+  it("library in a separately linked package", { timeout: 300_000 }, async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-6426-"));
+    const packageRoot = join(root, "node_modules", "bag6426");
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      JSON.stringify({ name: "bag6426", version: "0.0.0", main: "index.js" }),
+    );
+    writeFileSync(join(packageRoot, "index.js"), LIB_SOURCE);
+    const entry = join(root, "main.js");
+    writeFileSync(
+      entry,
+      `import { R, RestSrc, RestProbe, DirectSrc, SpreadSrc, FieldSrc, ValuesProbe, EntriesProbe, KeysProbe } from "bag6426";\n${PROBES}`,
+    );
+
+    const result = await compileProject(entry, {
+      allowJs: true,
+      skipSemanticDiagnostics: true,
+      packageCacheDir: join(root, "providers"),
+    });
+    expect(result.success).toBe(true);
+    // Load-bearing: a `bundled` plan would inline the package and silently
+    // test the single-module lane a third time.
+    expect(result.linkPlan?.mode).toBe("separate");
+
+    const { instance } = await instantiateLinkedProject(result);
+    const observed = readAll(instance.exports as unknown as Record<string, unknown>);
+    // Anti-vacuity: the six rows the fix is about must actually be exercised
+    // in THIS lane, not silently absent from the linked module's exports.
+    for (const row of REGRESSED_ROWS) expect(Object.keys(observed)).toContain(row);
+    expect(observed).toEqual(EXPECTED);
+  });
+});


### PR DESCRIPTION
Closes [#6426](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6426-object-assign-option-bag-across-linked-package).

## Mechanism

Four host helpers in `src/runtime.ts` read a WasmGC struct in two steps: field
**names** from `_getStructFieldNames`, then each **value** from
`exports["__sget_<key>"]`. Since
[#5225](https://js2wasm.loopdive.com/dashboard/issue.html?slug=5225-consumer-minted-struct-opaque-in-linked-provider)
the name step routes through `_decoderExportsFor`, so it answers with the struct
**owner's** decoder — but the value step still used the **reader's** own exports.

A `__sget_<key>` getter is module-global by field *name* and does **not** trap on
a foreign struct type: it `ref.test`-misses and returns that getter's default. So
when a consumer mints an options bag and a separately-linked provider does

```js
const { strict, ...rest } = options;
Object.assign(this, rest);
```

every key survives and every value is lost — `null` for references, `0` for
numbers. `typeof null === "object"` is the whole reason the issue's copied-*function*
row looked like a different defect from its copied-*object* row; both are the same
lost value.

The fix is `_decoderExportsFor` on the value read too, at the four sites with that
names-then-values shape: `__extern_rest_object`, `__object_values`,
`__object_entries`, and the tuple arm of `__extern_slice`. `__object_keys` is
names-only and was already correct; no write path moved.

**No codegen change.** `src/codegen/statements/destructuring.ts` already routes
rest patterns to the externref path correctly, and the standalone twin
(`__extern_rest_object` in `src/codegen/destructuring-params.ts`) never runs
`runtime.ts` — so the standalone floor/net is untouched.

**4 changed lines, zero net lines.** `src/runtime.ts` sits exactly at the #4401
ceiling (19735), so the write-up lives here and in the test header rather than
inline, and the sites carry the repo's existing `// (#5225/#6426)` marker. No
budget allowance needed.

## Probe, base → fix

`.tmp/6426-repro.mts`, `linkPlan.mode === "separate"`. 6 of 9 rows wrong on base,
0 after; the 3 controls never moved.

| row | base | fix | node |
| --- | --- | --- | --- |
| `restObj` — object through `...rest` | `"null"` | `"R"` | `"R"` |
| `restFn` — function through `...rest` | `"object"` | `"function"` | `"function"` |
| `restNum` — number through `...rest` | `"0"` | `"7"` | `"7"` |
| `restKeys` — `Object.keys(rest)` + `rest.router` | `router\|no` | `router\|has` | `router\|has` |
| `Object.values` of a consumer struct, in the provider | `"undefined,undefined"` | `"number,string"` | `"number,string"` |
| `Object.entries` of the same | `"a:undefined,b:undefined"` | `"a:number,b:string"` | `"a:number,b:string"` |
| control — direct `Object.assign(this, options)` | `"R"` | `"R"` | `"R"` |
| control — `{ ...options }` spread source | `"R"` | `"R"` | `"R"` |
| control — `this.router = options.router` | `"R"` | `"R"` | `"R"` |

The number row coming back `0` rather than `undefined` is the sharpest
confirmation of the mechanism: that is a `ref.test`-miss default, not a missing key.

## Regression test

`tests/issue-6426-linked-object-rest-source.test.ts` — 12 rows × 3 lanes (single
`compile`, `compileMulti` one unit, `compileProject` separate), one shared
`EXPECTED` table.

| lane | parent wrong | fix wrong |
| --- | --- | --- |
| single module | 0 | 0 |
| two modules, one unit | 0 | 0 |
| separately-linked package | **6** | **0** |

The 6 are `restObj`, `restFn`, `restNum`, `restKeys`, `restValues`, `restEntries`.
The other 6 rows are anti-vacuity controls that already passed on the parent
(direct assign, spread source, plain field store, `Object.keys`, rest with an
excluded key, empty bag), and the linked lane additionally asserts that all 6
regressed rows are actually present in that module's exports. The fixture's
provider exports **classes only** on purpose: a provider exporting untyped
*functions* falls back to a `bundled` plan, which would silently run the
single-unit lane a third time — hence the `linkPlan.mode === "separate"` assertion.

## Acceptance 2

`LINKED_RESIDUALS` is deleted from `tests/issue-5366-nullish-join-carrier.test.ts`
and its separately-linked lane now asserts the shared `EXPECTED` table. All three
lanes of that file pass.


## Dogfood A/B — all 17 suites, flat

Base vs fix at one HEAD (`upstream/main` `3e92241ecc` ± the 4-line change), one suite at a time, per test file. **Every suite flat; zero per-file movers.**

| suite | base | fix | | suite | base | fix |
| --- | --- | --- | --- | --- | --- | --- |
| webpack | 16/16 | 16/16 | | styled-components | 9/9 | 9/9 |
| three | 17/18 | 17/18 | | uuid | 75/75 | 75/75 |
| clsx | 32/32 | 32/32 | | marked | 16/30 | 16/30 |
| cookie | 63740/63740 | 63740/63740 | | moment | 10/10 | 10/10 |
| lodash | 59/62 | 59/62 | | prettier | 108/151 | 108/151 |
| redux | 67/82 | 67/82 | | jest | 335/356 | 335/356 |
| axios | 208/231 | 208/231 | | hono | 261/324 | 261/324 |
| stylelint | 108/108 | 108/108 | | | | |
| tailwindcss | 13/13 | 13/13 | | | | |
| jsdom | 6/6 | 6/6 | | | | |

All 34 runs exited 0. Beyond the headlines, **every per-file `N/M Wasm` fraction is identical between the two lanes across all 17 suites** — so this is flat at file granularity, not just in the totals.

That is the predicted result: these suites compile the package's **own** source as the root unit, so the consumer→provider rest seam this fixes never fires.

**Two suites read differently from the dispatch brief's anchors, and neither is this change:** prettier **108** vs the brief's 107, and hono **261** vs 259. Both read identically on *my own base lane*, so they are main-side drift between 2026-09-12 and today, measured rather than assumed.

**One measurement was discarded and re-run.** My first hono fix-lane run overlapped the lane swap — my waiter counted log files, which are created when a suite *starts*, so the base lane began while hono was still going and `src/runtime.ts` changed underneath it. That number was thrown away and hono re-run cleanly on the fix runtime; the 261/324 above is the clean run. The other 16 suites were unaffected (they had completed), and pass counts here are deterministic.

## Gates

`check-loc-budget` · `check-func-budget` · `check-coercion-sites` · `check:oracle-ratchet` · `check:dead-exports` · `check:dogfood-validation` · `check:host-import-policy` — all green, re-run after merging current `main`. ts7 `--noEmit` clean. Biome clean on the changed files.

`check:compiler-boundaries` reports `inventory-valid-architecture-incomplete` — **identically on `upstream/main` with this change reverted**, so it is pre-existing (`inventoryValid: true`, `errors: []`, and this PR adds no module).

## Residuals

- **`tests/issue-2131.test.ts` fails 6/7 on `upstream/main`**, identically with this change applied and reverted. Not caused or masked by it; filed as [#6451](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6451-jshost-struct-enumeration-returns-empty-in-2131-harness). The six JS-host rows return an *empty* enumeration rather than a mis-ordered one, and only the standalone row survives.
- **27 more host helpers share this exact defect shape** — bind the reader's exports, then read `__sget_<key>`. #5225, #5365 and now #6426 have each fixed a subset one bug report at a time. Filed as [#6452](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6452-mixed-decoder-audit-remaining-sget-read-sites) with the scan, a per-site classification requirement (deliberately not a blind sed), and a gate so there is no fourth round.
- **The merge-queue outage that parked this PR**: [#6454](https://js2wasm.loopdive.com/dashboard/issue.html?slug=6454-merge-queue-test262-shards-die-before-afterall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
